### PR TITLE
runtime: react to OS memory-pressure signals (opt-in)

### DIFF
--- a/src/aio/MemoryPressureWatcher.zig
+++ b/src/aio/MemoryPressureWatcher.zig
@@ -346,11 +346,17 @@ const Linux = struct {
     /// Dedicated thread. PSI fires POLLPRI which `Async.FilePoll` doesn't yet
     /// expose, so block in poll() here and post a `ConcurrentTask` to the JS
     /// thread when it does — same off-thread→enqueue shape as macOS/Windows.
+    ///
+    /// On Linux, closing an fd from another thread does NOT wake a poll()
+    /// already blocked on it: poll holds its own `struct file` reference via
+    /// fdget(), so close() just decrements f_count without reaching
+    /// release(). Use a finite timeout so `shutdown` is checked periodically
+    /// instead of relying on cross-thread close-as-wakeup.
     fn run(s: *State) void {
         bun.Output.Source.configureNamedThread("MemoryPressure");
         var fds = [1]std.posix.pollfd{.{ .fd = s.fd.cast(), .events = std.posix.POLL.PRI, .revents = 0 }};
         while (!s.shutdown.load(.monotonic)) {
-            const n = std.posix.poll(&fds, -1) catch break;
+            const n = std.posix.poll(&fds, 200) catch break;
             if (s.shutdown.load(.monotonic)) break;
             if (n == 0) continue;
             if (fds[0].revents & (std.posix.POLL.ERR | std.posix.POLL.HUP | std.posix.POLL.NVAL) != 0) break;
@@ -378,9 +384,11 @@ const Linux = struct {
         const s = state orelse return;
         state = null;
         s.shutdown.store(true, .monotonic);
-        // Wake the blocked poll() with POLLERR/POLLNVAL.
-        s.fd.close();
+        // run()'s 200 ms poll timeout picks up the shutdown flag; join first
+        // and only then close the fd, so a concurrent fd-table reuse can't
+        // make the watcher poll() an unrelated file.
         s.thread.join();
+        s.fd.close();
         bun.destroy(s);
     }
 };

--- a/src/aio/MemoryPressureWatcher.zig
+++ b/src/aio/MemoryPressureWatcher.zig
@@ -222,6 +222,13 @@ const Darwin = struct {
         vm: *jsc.VirtualMachine,
         /// Set on the dispatch thread, consumed on the JS thread.
         pending_critical: std.atomic.Value(bool) = .init(true),
+        /// Set in uninstall() before dispatch_source_cancel() so an in-flight
+        /// onPressureDispatch skips enqueueTaskConcurrent — VirtualMachine
+        /// .deinit() proceeds past uninstall() to has_terminated=true, and a
+        /// post-terminate enqueue panics under allow_assert. Brings Darwin in
+        /// line with Linux/Windows whose uninstall() blocks until the
+        /// off-thread callback drains.
+        shutting_down: std.atomic.Value(bool) = .init(false),
     };
 
     fn install(vm: *jsc.VirtualMachine) void {
@@ -249,6 +256,7 @@ const Darwin = struct {
     /// *transitions*, so no holdoff is needed — one task per transition.
     fn onPressureDispatch(ctx: ?*anyopaque) callconv(.c) void {
         const s: *State = @ptrCast(@alignCast(ctx.?));
+        if (s.shutting_down.load(.acquire)) return;
         const data = dispatch_source_get_data(s.source);
         const critical = (data & (DISPATCH_MEMORYPRESSURE_CRITICAL | DISPATCH_MEMORYPRESSURE_PROC_LIMIT_CRITICAL)) != 0;
         s.pending_critical.store(critical, .monotonic);
@@ -264,6 +272,7 @@ const Darwin = struct {
     fn uninstall() void {
         const s = state orelse return;
         state = null;
+        s.shutting_down.store(true, .release);
         // Async — release+destroy happen in onCancelled once any in-flight
         // event handler has drained.
         dispatch_source_cancel(s.source);

--- a/src/aio/MemoryPressureWatcher.zig
+++ b/src/aio/MemoryPressureWatcher.zig
@@ -1,0 +1,369 @@
+//! Reacts to OS low-memory signals by shrinking the JSC heap and returning
+//! mimalloc free segments to the OS. One per process, hooked into the
+//! main-thread VM's event loop, never keeps the loop alive.
+//!
+//! Off by default — opt in with
+//! `BUN_FEATURE_FLAG_EXPERIMENTAL_MEMORY_PRESSURE_HANDLER=1` so downstreams can
+//! A/B the change before it becomes default-on.
+//!
+//! Detection front-ends:
+//! - Windows: `CreateMemoryResourceNotification(LowMemoryResourceNotification)`
+//!   waited on via `RegisterWaitForSingleObject` (NT threadpool); the callback
+//!   `uv_async_send`s the JS thread. Mirrors WebKit PR 63320.
+//! - macOS: `dispatch_source_create(DISPATCH_SOURCE_TYPE_MEMORYPRESSURE, …)` on
+//!   a global concurrent queue; the handler enqueues a `ConcurrentTask`.
+//!   Mirrors `MemoryPressureHandlerCocoa.mm`.
+//! - Linux: a PSI trigger (`/proc/pressure/memory`, `POLLPRI`) blocked on by a
+//!   dedicated thread which enqueues a `ConcurrentTask`. PSI signals via
+//!   POLLPRI which `Async.FilePoll` doesn't yet expose, hence the thread.
+//!
+//! All three converge on `respond()` running on the JS thread.
+//!
+//! `WTF::MemoryPressureHandler` was considered but not used: in Bun's JSCOnly
+//! WebKit build it is a no-op stub on macOS, has no OS hook on Linux, polls
+//! every 60 s on Windows, and `releaseMemory()` does nothing without a
+//! Bun-supplied `lowMemoryHandler` anyway — see `PlatformJSCOnly.cmake`.
+
+const log = bun.Output.scoped(.MemoryPressure, .visible);
+
+/// At most one `respond()` per holdoff window on platforms whose signal stays
+/// asserted while pressure persists (Windows level-triggered handle, Linux PSI
+/// re-firing each measurement window). macOS only fires on state transitions
+/// so it doesn't need this.
+const holdoff_ms: u64 = 30_000;
+
+var installed = std.atomic.Value(bool).init(false);
+
+/// Called from `VirtualMachine.init` once the main-thread VM and its event
+/// loop exist. Single-shot; later VMs (workers) skip via `is_main_thread`.
+pub fn installOnEventLoop(vm: *jsc.VirtualMachine) void {
+    if (!bun.feature_flag.BUN_FEATURE_FLAG_EXPERIMENTAL_MEMORY_PRESSURE_HANDLER.get()) return;
+    if (installed.swap(true, .monotonic)) return;
+
+    Backend.install(vm);
+}
+
+/// Called from `VirtualMachine.deinit` for the main-thread VM. Best-effort:
+/// process exit will reclaim everything anyway, but this lets the JS-thread
+/// `respond()` race against shutdown cleanly.
+pub fn uninstall() void {
+    if (!installed.swap(false, .monotonic)) return;
+    Backend.uninstall();
+}
+
+/// Test seam — runs the JS-thread response path directly. Debug builds only.
+/// Returns the post-increment `analytics.Features.memory_pressure` count.
+pub fn simulate(vm: *jsc.VirtualMachine) usize {
+    if (comptime !Environment.isDebug) return 0;
+    respond(vm, true);
+    return bun.analytics.Features.memory_pressure;
+}
+
+/// The platform-agnostic response. Always runs on the JS thread that owns
+/// `vm`, so it's safe to touch the JSC heap directly.
+fn respond(vm: *jsc.VirtualMachine, critical: bool) void {
+    log("memory pressure ({s}); shrinking footprint", .{if (critical) "critical" else "warning"});
+    bun.analytics.Features.memory_pressure += 1;
+    // Synchronous full collection now — reclaims unreachable JS objects
+    // immediately, regardless of whether we're inside an entryScope.
+    _ = vm.global.vm().runGC(true);
+    // Deferred deeper cleanup: shrinkFootprintWhenIdle() runs `deleteAllCode`
+    // (drops JIT'd code) + another sync full GC + releaseFastMallocFreeMemory
+    // via VM::whenIdle, i.e. immediately if no JS is on the stack, otherwise
+    // when the current entryScope pops.
+    vm.global.vm().shrinkFootprint();
+    // Return mimalloc free segments to the OS.
+    bun.Global.mimalloc_cleanup(critical);
+}
+
+const Backend = if (Environment.isWindows)
+    Windows
+else if (Environment.isMac)
+    Darwin
+else if (Environment.isLinux)
+    Linux
+else
+    Noop;
+
+const Noop = struct {
+    fn install(_: *jsc.VirtualMachine) void {}
+    fn uninstall() void {}
+};
+
+// ───────────────────────────────────── Windows ──────────────────────────────
+
+const Windows = struct {
+    var state: ?*State = null;
+
+    const State = struct {
+        notification: w32.HANDLE,
+        wait: ?w32.HANDLE = null,
+        wake: libuv.uv_async_t,
+        rearm: libuv.Timer,
+        vm: *jsc.VirtualMachine,
+    };
+
+    fn install(vm: *jsc.VirtualMachine) void {
+        const notification = win_externs.CreateMemoryResourceNotification(.LowMemoryResourceNotification) orelse {
+            log("CreateMemoryResourceNotification failed (err={d})", .{@intFromEnum(w32.GetLastError())});
+            return;
+        };
+
+        const s = bun.new(State, .{
+            .notification = notification,
+            .wake = undefined,
+            .rearm = undefined,
+            .vm = vm,
+        });
+        state = s;
+
+        s.wake.init(vm.uvLoop(), onWake);
+        s.wake.unref();
+        s.wake.setData(s);
+        s.rearm.init(vm.uvLoop());
+        s.rearm.unref();
+        s.rearm.data = s;
+
+        if (!arm(s)) {
+            // Best-effort: leave the libuv handles up but never armed.
+            log("RegisterWaitForSingleObject failed (err={d}); watcher disabled", .{@intFromEnum(w32.GetLastError())});
+            return;
+        }
+        log("installed (RegisterWaitForSingleObject)", .{});
+    }
+
+    fn arm(s: *State) bool {
+        var wait: w32.HANDLE = undefined;
+        const ok = win_externs.RegisterWaitForSingleObject(
+            &wait,
+            s.notification,
+            onLowMemoryThreadpool,
+            s,
+            w32.INFINITE,
+            win_externs.WT_EXECUTEINWAITTHREAD | win_externs.WT_EXECUTEONLYONCE,
+        );
+        if (ok == 0) return false;
+        s.wait = wait;
+        return true;
+    }
+
+    /// NT threadpool thread. The notification handle is *level*-triggered: it
+    /// stays signalled while memory remains low, so we registered ONLYONCE and
+    /// re-arm from the JS thread after the holdoff.
+    fn onLowMemoryThreadpool(ctx: ?*anyopaque, _: w32.BOOLEAN) callconv(.winapi) void {
+        const s: *State = @ptrCast(@alignCast(ctx.?));
+        var is_low: w32.BOOL = 0;
+        // Spurious wake — re-arm happens from the JS side regardless.
+        if (win_externs.QueryMemoryResourceNotification(s.notification, &is_low) != 0 and is_low == 0) return;
+        s.wake.send();
+    }
+
+    /// JS thread.
+    fn onWake(handle: [*c]libuv.uv_async_t) callconv(.c) void {
+        const s: *State = @ptrCast(@alignCast(handle.*.data.?));
+        // The ONLYONCE wait has self-completed; drop the stale handle now so
+        // uninstall() during the holdoff doesn't try to UnregisterWaitEx it.
+        s.wait = null;
+        respond(s.vm, true);
+        s.rearm.start(holdoff_ms, 0, onRearm);
+        s.rearm.unref();
+    }
+
+    /// JS thread.
+    fn onRearm(handle: *libuv.Timer) callconv(.c) void {
+        const s: *State = @ptrCast(@alignCast(handle.data.?));
+        if (state == null) return; // uninstall() raced
+        if (!arm(s)) {
+            log("RegisterWaitForSingleObject re-arm failed (err={d}); watcher disabled", .{@intFromEnum(w32.GetLastError())});
+        }
+    }
+
+    fn uninstall() void {
+        const s = state orelse return;
+        state = null;
+        if (s.wait) |w| {
+            // INVALID_HANDLE_VALUE waits for any in-flight callback to drain.
+            _ = win_externs.UnregisterWaitEx(w, w32.INVALID_HANDLE_VALUE);
+        }
+        _ = win_externs.CloseHandle(s.notification);
+        s.rearm.stop();
+        libuv.uv_close(@ptrCast(&s.rearm), null);
+        libuv.uv_close(@ptrCast(&s.wake), onClosed);
+    }
+
+    fn onClosed(handle: *anyopaque) callconv(.c) void {
+        const h: *libuv.Handle = @ptrCast(@alignCast(handle));
+        const s: *State = @ptrCast(@alignCast(h.data.?));
+        bun.destroy(s);
+    }
+};
+
+// ───────────────────────────────────── Darwin ───────────────────────────────
+
+const Darwin = struct {
+    var state: ?*State = null;
+
+    const State = struct {
+        source: *anyopaque,
+        vm: *jsc.VirtualMachine,
+        /// Set on the dispatch thread, consumed on the JS thread.
+        pending_critical: std.atomic.Value(bool) = .init(true),
+    };
+
+    fn install(vm: *jsc.VirtualMachine) void {
+        const mask = DISPATCH_MEMORYPRESSURE_WARN | DISPATCH_MEMORYPRESSURE_CRITICAL |
+            DISPATCH_MEMORYPRESSURE_PROC_LIMIT_WARN | DISPATCH_MEMORYPRESSURE_PROC_LIMIT_CRITICAL;
+        const queue = dispatch_get_global_queue(QOS_CLASS_UTILITY, 0);
+        const source = dispatch_source_create(&_dispatch_source_type_memorypressure, 0, mask, queue) orelse {
+            log("dispatch_source_create(DISPATCH_SOURCE_TYPE_MEMORYPRESSURE) failed", .{});
+            return;
+        };
+        const s = bun.new(State, .{ .source = source, .vm = vm });
+        state = s;
+        dispatch_set_context(source, s);
+        dispatch_source_set_event_handler_f(source, onPressureDispatch);
+        dispatch_resume(source);
+        log("installed (DISPATCH_SOURCE_TYPE_MEMORYPRESSURE)", .{});
+    }
+
+    /// libdispatch worker thread. The kernel only fires on state
+    /// *transitions*, so no holdoff is needed — one task per transition.
+    fn onPressureDispatch(ctx: ?*anyopaque) callconv(.c) void {
+        const s: *State = @ptrCast(@alignCast(ctx.?));
+        const data = dispatch_source_get_data(s.source);
+        const critical = (data & (DISPATCH_MEMORYPRESSURE_CRITICAL | DISPATCH_MEMORYPRESSURE_PROC_LIMIT_CRITICAL)) != 0;
+        s.pending_critical.store(critical, .monotonic);
+        s.vm.enqueueTaskConcurrent(jsc.ConcurrentTask.fromCallback(s, onJSThread));
+    }
+
+    /// JS thread.
+    fn onJSThread(s: *State) void {
+        if (state == null) return; // uninstall() raced
+        respond(s.vm, s.pending_critical.load(.monotonic));
+    }
+
+    fn uninstall() void {
+        const s = state orelse return;
+        state = null;
+        dispatch_source_cancel(s.source);
+        dispatch_release(s.source);
+        bun.destroy(s);
+    }
+
+    extern "c" const _dispatch_source_type_memorypressure: anyopaque;
+    extern "c" fn dispatch_source_create(type: *const anyopaque, handle: usize, mask: c_ulong, queue: ?*anyopaque) ?*anyopaque;
+    extern "c" fn dispatch_source_set_event_handler_f(source: *anyopaque, handler: *const fn (?*anyopaque) callconv(.c) void) void;
+    extern "c" fn dispatch_set_context(object: *anyopaque, context: ?*anyopaque) void;
+    extern "c" fn dispatch_source_get_data(source: *anyopaque) c_ulong;
+    extern "c" fn dispatch_get_global_queue(identifier: c_long, flags: c_ulong) *anyopaque;
+    extern "c" fn dispatch_resume(object: *anyopaque) void;
+    extern "c" fn dispatch_source_cancel(source: *anyopaque) void;
+    extern "c" fn dispatch_release(object: *anyopaque) void;
+    const DISPATCH_MEMORYPRESSURE_WARN: c_ulong = 0x02;
+    const DISPATCH_MEMORYPRESSURE_CRITICAL: c_ulong = 0x04;
+    const DISPATCH_MEMORYPRESSURE_PROC_LIMIT_WARN: c_ulong = 0x10;
+    const DISPATCH_MEMORYPRESSURE_PROC_LIMIT_CRITICAL: c_ulong = 0x20;
+    const QOS_CLASS_UTILITY: c_long = 0x11;
+};
+
+// ───────────────────────────────────── Linux ────────────────────────────────
+
+const Linux = struct {
+    var state: ?*State = null;
+
+    /// ≥150 ms some-stall in any 1 s window. "some" rather than "full" so we
+    /// react before the whole process is blocked on reclaim.
+    const trigger = "some 150000 1000000\n";
+
+    const State = struct {
+        fd: bun.FD,
+        thread: std.Thread,
+        vm: *jsc.VirtualMachine,
+        shutdown: std.atomic.Value(bool) = .init(false),
+    };
+
+    fn install(vm: *jsc.VirtualMachine) void {
+        // PSI triggers need O_RDWR | O_NONBLOCK and signal via POLLPRI.
+        const fd = switch (bun.sys.open("/proc/pressure/memory", bun.O.RDWR | bun.O.NONBLOCK | bun.O.CLOEXEC, 0)) {
+            .result => |fd| fd,
+            .err => |err| {
+                // ENOENT (no PSI), EACCES (some hardened kernels gate
+                // unprivileged triggers), …: best-effort, just skip.
+                log("PSI unavailable (open /proc/pressure/memory: {s}); watcher disabled", .{@tagName(err.getErrno())});
+                return;
+            },
+        };
+        switch (bun.sys.write(fd, trigger)) {
+            .result => {},
+            .err => |err| {
+                // EOPNOTSUPP (psi=0 cmdline), EBUSY, …
+                log("PSI unavailable (write trigger: {s}); watcher disabled", .{@tagName(err.getErrno())});
+                fd.close();
+                return;
+            },
+        }
+
+        const s = bun.new(State, .{ .fd = fd, .thread = undefined, .vm = vm });
+        state = s;
+        s.thread = std.Thread.spawn(.{ .stack_size = 64 * 1024 }, run, .{s}) catch {
+            log("PSI watcher thread spawn failed; watcher disabled", .{});
+            fd.close();
+            bun.destroy(s);
+            state = null;
+            return;
+        };
+        log("installed (/proc/pressure/memory PSI)", .{});
+    }
+
+    /// Dedicated thread. PSI fires POLLPRI which `Async.FilePoll` doesn't yet
+    /// expose, so block in poll() here and post a `ConcurrentTask` to the JS
+    /// thread when it does — same off-thread→enqueue shape as macOS/Windows.
+    fn run(s: *State) void {
+        bun.Output.Source.configureNamedThread("MemoryPressure");
+        var fds = [1]std.posix.pollfd{.{ .fd = s.fd.cast(), .events = std.posix.POLL.PRI, .revents = 0 }};
+        while (!s.shutdown.load(.monotonic)) {
+            const n = std.posix.poll(&fds, -1) catch break;
+            if (s.shutdown.load(.monotonic)) break;
+            if (n == 0) continue;
+            if (fds[0].revents & (std.posix.POLL.ERR | std.posix.POLL.HUP | std.posix.POLL.NVAL) != 0) break;
+            if (fds[0].revents & std.posix.POLL.PRI == 0) continue;
+
+            s.vm.enqueueTaskConcurrent(jsc.ConcurrentTask.fromCallback(s, onJSThread));
+
+            // PSI re-fires every measurement window while the stall persists;
+            // throttle so we don't sync-GC in a tight loop. Sleep in slices so
+            // shutdown is reasonably prompt.
+            var slept: u64 = 0;
+            while (slept < holdoff_ms and !s.shutdown.load(.monotonic)) : (slept += 200) {
+                std.Thread.sleep(200 * std.time.ns_per_ms);
+            }
+        }
+    }
+
+    /// JS thread.
+    fn onJSThread(s: *State) void {
+        if (state == null) return; // uninstall() raced
+        respond(s.vm, true);
+    }
+
+    fn uninstall() void {
+        const s = state orelse return;
+        state = null;
+        s.shutdown.store(true, .monotonic);
+        // Wake the blocked poll() with POLLERR/POLLNVAL.
+        s.fd.close();
+        s.thread.join();
+        bun.destroy(s);
+    }
+};
+
+const std = @import("std");
+
+const bun = @import("bun");
+const Environment = bun.Environment;
+
+const jsc = bun.jsc;
+
+const w32 = if (Environment.isWindows) std.os.windows else struct {};
+const libuv = if (Environment.isWindows) bun.windows.libuv else struct {};
+const win_externs = if (Environment.isWindows) @import("../windows_sys/externs.zig") else struct {};

--- a/src/aio/MemoryPressureWatcher.zig
+++ b/src/aio/MemoryPressureWatcher.zig
@@ -357,13 +357,12 @@ const Linux = struct {
     }
 };
 
+const w32 = if (Environment.isWindows) std.os.windows else struct {};
+const libuv = if (Environment.isWindows) bun.windows.libuv else struct {};
+const win_externs = if (Environment.isWindows) @import("../windows_sys/externs.zig") else struct {};
+
 const std = @import("std");
 
 const bun = @import("bun");
 const Environment = bun.Environment;
-
 const jsc = bun.jsc;
-
-const w32 = if (Environment.isWindows) std.os.windows else struct {};
-const libuv = if (Environment.isWindows) bun.windows.libuv else struct {};
-const win_externs = if (Environment.isWindows) @import("../windows_sys/externs.zig") else struct {};

--- a/src/aio/MemoryPressureWatcher.zig
+++ b/src/aio/MemoryPressureWatcher.zig
@@ -59,6 +59,15 @@ pub fn simulate(vm: *jsc.VirtualMachine) usize {
     return bun.analytics.Features.memory_pressure;
 }
 
+/// Test seam — see `Darwin.testUninstallBarrier`. Returns `true` iff
+/// `uninstall()` blocked until an in-flight libdispatch event handler
+/// finished (the property a barrier in `uninstall()` would guarantee).
+/// Debug + macOS only; trivially `true` elsewhere.
+pub fn testUninstallBarrier(vm: *jsc.VirtualMachine) bool {
+    if (comptime !(Environment.isDebug and Environment.isMac)) return true;
+    return Darwin.testUninstallBarrier(vm);
+}
+
 /// The platform-agnostic response. Always runs on the JS thread that owns
 /// `vm`, so it's safe to touch the JSC heap directly.
 fn respond(vm: *jsc.VirtualMachine, critical: bool) void {
@@ -217,26 +226,56 @@ const Windows = struct {
 const Darwin = struct {
     var state: ?*State = null;
 
+    /// Debug-only instrumentation for `testUninstallBarrier()` — lets the
+    /// test deterministically park a libdispatch-invoked event handler in
+    /// the post-`shutting_down`-check / pre-`enqueueTaskConcurrent` window
+    /// while `uninstall()` runs, then observe whether the handler completed
+    /// before `uninstall()` returned.
+    const TestHooks = if (Environment.isDebug) struct {
+        /// Set by `onPressureDispatch` once it's past `shutting_down` and
+        /// about to enqueue. The test waits on this before calling uninstall.
+        in_handler: std.Thread.ResetEvent = .{},
+        /// `onPressureDispatch` waits on this before the enqueue. Released
+        /// by the test's helper thread once `uninstall()` is past
+        /// `dispatch_source_cancel()` (via `after_cancel`).
+        proceed: std.Thread.ResetEvent = .{},
+        /// Set inside `uninstall()` immediately after the async
+        /// `dispatch_source_cancel()` call — i.e., right at the start of the
+        /// would-be race window. The helper thread waits on this so it
+        /// releases the worker only once `uninstall()` is in progress.
+        after_cancel: std.Thread.ResetEvent = .{},
+        /// Set by `onPressureDispatch` after the enqueue completes. The test
+        /// snapshots `isSet()` immediately after `uninstall()` returns (RED
+        /// ⇒ false: uninstall returned while the worker was still parked;
+        /// GREEN ⇒ true: uninstall blocked until the worker — and therefore
+        /// the cancel handler — finished), then `wait()`s on it so the
+        /// stack-allocated `hooks` outlives the worker even in RED.
+        handler_done: std.Thread.ResetEvent = .{},
+    } else void;
+
     const State = struct {
         source: *anyopaque,
         vm: *jsc.VirtualMachine,
         /// Set on the dispatch thread, consumed on the JS thread.
         pending_critical: std.atomic.Value(bool) = .init(true),
-        /// Set in uninstall() before dispatch_source_cancel() so an in-flight
-        /// onPressureDispatch skips enqueueTaskConcurrent — VirtualMachine
-        /// .deinit() proceeds past uninstall() to has_terminated=true, and a
-        /// post-terminate enqueue panics under allow_assert. Brings Darwin in
-        /// line with Linux/Windows whose uninstall() blocks until the
-        /// off-thread callback drains.
+        /// Fast-path bail for an in-flight `onPressureDispatch` during
+        /// shutdown. NOT load-bearing for safety — see `testUninstallBarrier`
+        /// for the TOCTOU (handler can pass this check before it's set).
         shutting_down: std.atomic.Value(bool) = .init(false),
+        test_hooks: if (Environment.isDebug) ?*TestHooks else void =
+            if (Environment.isDebug) null else {},
     };
 
     fn install(vm: *jsc.VirtualMachine) void {
         const mask = DISPATCH_MEMORYPRESSURE_WARN | DISPATCH_MEMORYPRESSURE_CRITICAL |
             DISPATCH_MEMORYPRESSURE_PROC_LIMIT_WARN | DISPATCH_MEMORYPRESSURE_PROC_LIMIT_CRITICAL;
+        installSource(vm, &_dispatch_source_type_memorypressure, mask, "DISPATCH_SOURCE_TYPE_MEMORYPRESSURE");
+    }
+
+    fn installSource(vm: *jsc.VirtualMachine, source_type: *const anyopaque, mask: c_ulong, name: []const u8) void {
         const queue = dispatch_get_global_queue(QOS_CLASS_UTILITY, 0);
-        const source = dispatch_source_create(&_dispatch_source_type_memorypressure, 0, mask, queue) orelse {
-            log("dispatch_source_create(DISPATCH_SOURCE_TYPE_MEMORYPRESSURE) failed", .{});
+        const source = dispatch_source_create(source_type, 0, mask, queue) orelse {
+            log("dispatch_source_create({s}) failed", .{name});
             return;
         };
         const s = bun.new(State, .{ .source = source, .vm = vm });
@@ -246,10 +285,10 @@ const Darwin = struct {
         // dispatch_source_cancel() is async and doesn't interrupt an
         // in-flight event handler; libdispatch guarantees the cancel handler
         // runs only after the last event handler has returned, so do the
-        // release+destroy there to avoid a UAF on uninstall.
+        // release+destroy there to avoid a UAF.
         dispatch_source_set_cancel_handler_f(source, onCancelled);
         dispatch_resume(source);
-        log("installed (DISPATCH_SOURCE_TYPE_MEMORYPRESSURE)", .{});
+        log("installed ({s})", .{name});
     }
 
     /// libdispatch worker thread. The kernel only fires on state
@@ -257,10 +296,17 @@ const Darwin = struct {
     fn onPressureDispatch(ctx: ?*anyopaque) callconv(.c) void {
         const s: *State = @ptrCast(@alignCast(ctx.?));
         if (s.shutting_down.load(.acquire)) return;
+        if (comptime Environment.isDebug) if (s.test_hooks) |th| {
+            // Park in the race window so testUninstallBarrier() can run
+            // uninstall() while we're between the check and the enqueue.
+            th.in_handler.set();
+            th.proceed.wait();
+        };
         const data = dispatch_source_get_data(s.source);
         const critical = (data & (DISPATCH_MEMORYPRESSURE_CRITICAL | DISPATCH_MEMORYPRESSURE_PROC_LIMIT_CRITICAL)) != 0;
         s.pending_critical.store(critical, .monotonic);
         s.vm.enqueueTaskConcurrent(jsc.ConcurrentTask.fromCallback(s, onJSThread));
+        if (comptime Environment.isDebug) if (s.test_hooks) |th| th.handler_done.set();
     }
 
     /// JS thread.
@@ -273,12 +319,21 @@ const Darwin = struct {
         const s = state orelse return;
         state = null;
         s.shutting_down.store(true, .release);
-        // Async — release+destroy happen in onCancelled once any in-flight
-        // event handler has drained.
         dispatch_source_cancel(s.source);
+        if (comptime Environment.isDebug) if (s.test_hooks) |th| th.after_cancel.set();
+        // RACE: dispatch_source_cancel() is async and does NOT wait for an
+        // in-flight event handler, so onPressureDispatch may be between its
+        // shutting_down.load() and enqueueTaskConcurrent() while we return
+        // and VirtualMachine.deinit() proceeds to has_terminated=true (which
+        // makes that enqueue panic under allow_assert). State cleanup is
+        // deferred to onCancelled, which libdispatch guarantees runs after
+        // the last event handler — so State is safe; the enqueue is not.
+        // Demonstrated by testUninstallBarrier(); barrier added in the
+        // following commit. Linux (thread.join) and Windows
+        // (UnregisterWaitEx INVALID_HANDLE_VALUE) already block here.
     }
 
-    /// libdispatch worker thread. Runs after the last onPressureDispatch
+    /// libdispatch worker thread. Runs after the last `onPressureDispatch`
     /// has returned, so State is no longer touched concurrently.
     fn onCancelled(ctx: ?*anyopaque) callconv(.c) void {
         const s: *State = @ptrCast(@alignCast(ctx.?));
@@ -286,10 +341,73 @@ const Darwin = struct {
         bun.destroy(s);
     }
 
+    /// Debug-only red/green seam for the `uninstall()` barrier.
+    ///
+    /// Installs a `DISPATCH_SOURCE_TYPE_DATA_ADD` source (fireable on demand
+    /// via `dispatch_source_merge_data`) through the SAME `installSource` /
+    /// `onPressureDispatch` / `onCancelled` / `uninstall` path the real
+    /// MEMORYPRESSURE source uses, fires it once, parks the libdispatch
+    /// worker in the race window, then calls `uninstall()` and snapshots
+    /// `handler_done` immediately after it returns.
+    ///
+    /// Returns `true` iff the handler had completed before `uninstall()`
+    /// returned. With the current non-blocking `uninstall()` this is
+    /// deterministically `false`: `uninstall()` falls through right after
+    /// `after_cancel.set()` while the worker is still parked, the helper
+    /// thread hasn't released `proceed` yet (it waits on `after_cancel`),
+    /// so when we read `handler_done.isSet()` the worker hasn't reached the
+    /// enqueue. After capturing the verdict the seam waits on `handler_done`
+    /// so the stack-allocated `hooks` outlives the worker, then joins the
+    /// helper. The enqueued ConcurrentTask is harmless: when it later runs
+    /// `onJSThread(s)` on the event loop the first line is
+    /// `if (state == null) return;`, which bails before any `s` deref.
+    pub fn testUninstallBarrier(vm: *jsc.VirtualMachine) bool {
+        if (comptime !Environment.isDebug) return true;
+        bun.assert(state == null); // don't clobber a real install
+
+        var hooks: TestHooks = .{};
+        installSource(vm, &_dispatch_source_type_data_add, 0, "DISPATCH_SOURCE_TYPE_DATA_ADD (test)");
+        const s = state orelse return true; // installSource failed; nothing to test
+        s.test_hooks = &hooks;
+
+        // Fire the source so libdispatch invokes onPressureDispatch on a
+        // worker (NOT a direct call — the cancel-handler ordering guarantee
+        // only applies to libdispatch-managed invocations).
+        dispatch_source_merge_data(s.source, 1);
+        hooks.in_handler.wait();
+
+        // Helper thread releases the worker only once uninstall() is past
+        // dispatch_source_cancel() — i.e., inside what would be the race
+        // window if uninstall() didn't block.
+        const helper = std.Thread.spawn(.{}, struct {
+            fn run(th: *TestHooks) void {
+                th.after_cancel.wait();
+                th.proceed.set();
+            }
+        }.run, .{&hooks}) catch {
+            // Can't spawn — unblock the worker and tear down so we don't
+            // hang; report inconclusive-as-pass (best effort for a debug seam).
+            hooks.proceed.set();
+            Darwin.uninstall();
+            hooks.handler_done.wait();
+            return true;
+        };
+
+        Darwin.uninstall();
+        const blocked = hooks.handler_done.isSet();
+        // Drain so `hooks` outlives the worker even when uninstall() didn't
+        // block (RED). onCancelled then frees `s` once the worker returns.
+        hooks.handler_done.wait();
+        helper.join();
+        return blocked;
+    }
+
     extern "c" const _dispatch_source_type_memorypressure: anyopaque;
+    extern "c" const _dispatch_source_type_data_add: anyopaque;
     extern "c" fn dispatch_source_create(type: *const anyopaque, handle: usize, mask: c_ulong, queue: ?*anyopaque) ?*anyopaque;
     extern "c" fn dispatch_source_set_event_handler_f(source: *anyopaque, handler: *const fn (?*anyopaque) callconv(.c) void) void;
     extern "c" fn dispatch_source_set_cancel_handler_f(source: *anyopaque, handler: *const fn (?*anyopaque) callconv(.c) void) void;
+    extern "c" fn dispatch_source_merge_data(source: *anyopaque, value: c_ulong) void;
     extern "c" fn dispatch_set_context(object: *anyopaque, context: ?*anyopaque) void;
     extern "c" fn dispatch_source_get_data(source: *anyopaque) c_ulong;
     extern "c" fn dispatch_get_global_queue(identifier: c_long, flags: c_ulong) *anyopaque;

--- a/src/aio/MemoryPressureWatcher.zig
+++ b/src/aio/MemoryPressureWatcher.zig
@@ -255,12 +255,19 @@ const Darwin = struct {
 
     const State = struct {
         source: *anyopaque,
+        /// Signalled by the cancel handler once the last in-flight event
+        /// handler has returned. `uninstall()` blocks on this so it doesn't
+        /// return to `VirtualMachine.deinit()` until no off-thread enqueue
+        /// can happen — same guarantee as Linux's `thread.join()` and
+        /// Windows's `UnregisterWaitEx(..., INVALID_HANDLE_VALUE)`.
+        drained: *anyopaque,
         vm: *jsc.VirtualMachine,
         /// Set on the dispatch thread, consumed on the JS thread.
         pending_critical: std.atomic.Value(bool) = .init(true),
         /// Fast-path bail for an in-flight `onPressureDispatch` during
-        /// shutdown. NOT load-bearing for safety — see `testUninstallBarrier`
-        /// for the TOCTOU (handler can pass this check before it's set).
+        /// shutdown. Not load-bearing for safety — `drained` is what makes
+        /// `uninstall()` block until the handler finishes; this just avoids
+        /// an unnecessary enqueue when the handler hasn't started yet.
         shutting_down: std.atomic.Value(bool) = .init(false),
         test_hooks: if (Environment.isDebug) ?*TestHooks else void =
             if (Environment.isDebug) null else {},
@@ -278,14 +285,18 @@ const Darwin = struct {
             log("dispatch_source_create({s}) failed", .{name});
             return;
         };
-        const s = bun.new(State, .{ .source = source, .vm = vm });
+        const drained = dispatch_semaphore_create(0) orelse {
+            log("dispatch_semaphore_create failed", .{});
+            dispatch_release(source);
+            return;
+        };
+        const s = bun.new(State, .{ .source = source, .drained = drained, .vm = vm });
         state = s;
         dispatch_set_context(source, s);
         dispatch_source_set_event_handler_f(source, onPressureDispatch);
-        // dispatch_source_cancel() is async and doesn't interrupt an
-        // in-flight event handler; libdispatch guarantees the cancel handler
-        // runs only after the last event handler has returned, so do the
-        // release+destroy there to avoid a UAF.
+        // libdispatch guarantees the cancel handler runs only after the last
+        // event handler has returned. onCancelled signals `drained`;
+        // uninstall() waits on it before releasing/destroying.
         dispatch_source_set_cancel_handler_f(source, onCancelled);
         dispatch_resume(source);
         log("installed ({s})", .{name});
@@ -321,24 +332,28 @@ const Darwin = struct {
         s.shutting_down.store(true, .release);
         dispatch_source_cancel(s.source);
         if (comptime Environment.isDebug) if (s.test_hooks) |th| th.after_cancel.set();
-        // RACE: dispatch_source_cancel() is async and does NOT wait for an
-        // in-flight event handler, so onPressureDispatch may be between its
-        // shutting_down.load() and enqueueTaskConcurrent() while we return
-        // and VirtualMachine.deinit() proceeds to has_terminated=true (which
-        // makes that enqueue panic under allow_assert). State cleanup is
-        // deferred to onCancelled, which libdispatch guarantees runs after
-        // the last event handler — so State is safe; the enqueue is not.
-        // Demonstrated by testUninstallBarrier(); barrier added in the
-        // following commit. Linux (thread.join) and Windows
-        // (UnregisterWaitEx INVALID_HANDLE_VALUE) already block here.
+        // dispatch_source_cancel() is async and does NOT wait for an
+        // in-flight event handler — without this barrier, onPressureDispatch
+        // could be between its shutting_down.load() and enqueueTaskConcurrent
+        // while VirtualMachine.deinit() proceeds past us to
+        // has_terminated=true (which makes that enqueue panic under
+        // allow_assert). libdispatch guarantees the cancel handler runs only
+        // after the last event handler returns, so blocking on `drained`
+        // here closes the race. No deadlock risk: we're on the JS thread,
+        // the cancel handler runs on a libdispatch worker for the global
+        // utility queue. Verified by testUninstallBarrier().
+        _ = dispatch_semaphore_wait(s.drained, DISPATCH_TIME_FOREVER);
+        dispatch_release(s.drained);
+        dispatch_release(s.source);
+        bun.destroy(s);
     }
 
     /// libdispatch worker thread. Runs after the last `onPressureDispatch`
-    /// has returned, so State is no longer touched concurrently.
+    /// has returned. Must not touch `s` after signalling — `uninstall()` may
+    /// destroy it the moment the wait unblocks.
     fn onCancelled(ctx: ?*anyopaque) callconv(.c) void {
         const s: *State = @ptrCast(@alignCast(ctx.?));
-        dispatch_release(s.source);
-        bun.destroy(s);
+        _ = dispatch_semaphore_signal(s.drained);
     }
 
     /// Debug-only red/green seam for the `uninstall()` barrier.
@@ -351,16 +366,17 @@ const Darwin = struct {
     /// `handler_done` immediately after it returns.
     ///
     /// Returns `true` iff the handler had completed before `uninstall()`
-    /// returned. With the current non-blocking `uninstall()` this is
-    /// deterministically `false`: `uninstall()` falls through right after
-    /// `after_cancel.set()` while the worker is still parked, the helper
-    /// thread hasn't released `proceed` yet (it waits on `after_cancel`),
-    /// so when we read `handler_done.isSet()` the worker hasn't reached the
-    /// enqueue. After capturing the verdict the seam waits on `handler_done`
-    /// so the stack-allocated `hooks` outlives the worker, then joins the
-    /// helper. The enqueued ConcurrentTask is harmless: when it later runs
-    /// `onJSThread(s)` on the event loop the first line is
-    /// `if (state == null) return;`, which bails before any `s` deref.
+    /// returned. Without `dispatch_semaphore_wait(s.drained)` in
+    /// `uninstall()` this is deterministically `false`: `uninstall()` falls
+    /// through right after `after_cancel.set()` while the worker is still
+    /// parked, the helper thread hasn't released `proceed` yet (it waits on
+    /// `after_cancel`), so when we read `handler_done.isSet()` the worker
+    /// hasn't reached the enqueue. After capturing the verdict the seam
+    /// waits on `handler_done` so the stack-allocated `hooks` outlives the
+    /// worker, then joins the helper. The enqueued ConcurrentTask is
+    /// harmless: when it later runs `onJSThread(s)` on the event loop the
+    /// first line is `if (state == null) return;`, which bails before any
+    /// `s` deref.
     pub fn testUninstallBarrier(vm: *jsc.VirtualMachine) bool {
         if (comptime !Environment.isDebug) return true;
         bun.assert(state == null); // don't clobber a real install
@@ -414,6 +430,10 @@ const Darwin = struct {
     extern "c" fn dispatch_resume(object: *anyopaque) void;
     extern "c" fn dispatch_source_cancel(source: *anyopaque) void;
     extern "c" fn dispatch_release(object: *anyopaque) void;
+    extern "c" fn dispatch_semaphore_create(value: c_long) ?*anyopaque;
+    extern "c" fn dispatch_semaphore_signal(sema: *anyopaque) c_long;
+    extern "c" fn dispatch_semaphore_wait(sema: *anyopaque, timeout: u64) c_long;
+    const DISPATCH_TIME_FOREVER: u64 = ~@as(u64, 0);
     const DISPATCH_MEMORYPRESSURE_WARN: c_ulong = 0x02;
     const DISPATCH_MEMORYPRESSURE_CRITICAL: c_ulong = 0x04;
     const DISPATCH_MEMORYPRESSURE_PROC_LIMIT_WARN: c_ulong = 0x10;

--- a/src/aio/MemoryPressureWatcher.zig
+++ b/src/aio/MemoryPressureWatcher.zig
@@ -101,6 +101,10 @@ const Windows = struct {
         wake: libuv.uv_async_t,
         rearm: libuv.Timer,
         vm: *jsc.VirtualMachine,
+        /// uv_close is async and close callbacks fire LIFO within a loop
+        /// tick, so destroying State from one handle's close cb while the
+        /// other's is still pending is a UAF. Count both closes down to 0.
+        closing: std.atomic.Value(u32) = .init(0),
     };
 
     fn install(vm: *jsc.VirtualMachine) void {
@@ -187,14 +191,15 @@ const Windows = struct {
         }
         _ = win_externs.CloseHandle(s.notification);
         s.rearm.stop();
-        libuv.uv_close(@ptrCast(&s.rearm), null);
+        s.closing.store(2, .monotonic);
+        libuv.uv_close(@ptrCast(&s.rearm), onClosed);
         libuv.uv_close(@ptrCast(&s.wake), onClosed);
     }
 
     fn onClosed(handle: *anyopaque) callconv(.c) void {
         const h: *libuv.Handle = @ptrCast(@alignCast(handle));
         const s: *State = @ptrCast(@alignCast(h.data.?));
-        bun.destroy(s);
+        if (s.closing.fetchSub(1, .acq_rel) == 1) bun.destroy(s);
     }
 };
 

--- a/src/aio/MemoryPressureWatcher.zig
+++ b/src/aio/MemoryPressureWatcher.zig
@@ -154,20 +154,29 @@ const Windows = struct {
     /// NT threadpool thread. The notification handle is *level*-triggered: it
     /// stays signalled while memory remains low, so we registered ONLYONCE and
     /// re-arm from the JS thread after the holdoff.
+    ///
+    /// We do NOT re-check QueryMemoryResourceNotification here: a TOCTOU
+    /// where pressure clears between signal and callback would otherwise
+    /// permanently disarm the watcher (the only re-arm path is via onWake).
+    /// A false-positive respond() once per 30 s holdoff is harmless.
     fn onLowMemoryThreadpool(ctx: ?*anyopaque, _: w32.BOOLEAN) callconv(.winapi) void {
         const s: *State = @ptrCast(@alignCast(ctx.?));
-        var is_low: w32.BOOL = 0;
-        // Spurious wake — re-arm happens from the JS side regardless.
-        if (win_externs.QueryMemoryResourceNotification(s.notification, &is_low) != 0 and is_low == 0) return;
         s.wake.send();
     }
 
     /// JS thread.
     fn onWake(handle: [*c]libuv.uv_async_t) callconv(.c) void {
         const s: *State = @ptrCast(@alignCast(handle.*.data.?));
-        // The ONLYONCE wait has self-completed; drop the stale handle now so
-        // uninstall() during the holdoff doesn't try to UnregisterWaitEx it.
-        s.wait = null;
+        // WT_EXECUTEONLYONCE only stops the callback re-firing; per MSDN the
+        // wait registration must still be UnregisterWaitEx'd to free the NT
+        // threadpool object. Safe to do here: we're on the JS thread (via
+        // uv_async), not inside the WAITORTIMERCALLBACK, so the "no blocking
+        // unregister from the callback" restriction doesn't apply. null
+        // CompletionEvent: the callback that posted us has already returned.
+        if (s.wait) |w| {
+            _ = win_externs.UnregisterWaitEx(w, null);
+            s.wait = null;
+        }
         respond(s.vm, true);
         s.rearm.start(holdoff_ms, 0, onRearm);
         s.rearm.unref();
@@ -227,6 +236,11 @@ const Darwin = struct {
         state = s;
         dispatch_set_context(source, s);
         dispatch_source_set_event_handler_f(source, onPressureDispatch);
+        // dispatch_source_cancel() is async and doesn't interrupt an
+        // in-flight event handler; libdispatch guarantees the cancel handler
+        // runs only after the last event handler has returned, so do the
+        // release+destroy there to avoid a UAF on uninstall.
+        dispatch_source_set_cancel_handler_f(source, onCancelled);
         dispatch_resume(source);
         log("installed (DISPATCH_SOURCE_TYPE_MEMORYPRESSURE)", .{});
     }
@@ -250,7 +264,15 @@ const Darwin = struct {
     fn uninstall() void {
         const s = state orelse return;
         state = null;
+        // Async — release+destroy happen in onCancelled once any in-flight
+        // event handler has drained.
         dispatch_source_cancel(s.source);
+    }
+
+    /// libdispatch worker thread. Runs after the last onPressureDispatch
+    /// has returned, so State is no longer touched concurrently.
+    fn onCancelled(ctx: ?*anyopaque) callconv(.c) void {
+        const s: *State = @ptrCast(@alignCast(ctx.?));
         dispatch_release(s.source);
         bun.destroy(s);
     }
@@ -258,6 +280,7 @@ const Darwin = struct {
     extern "c" const _dispatch_source_type_memorypressure: anyopaque;
     extern "c" fn dispatch_source_create(type: *const anyopaque, handle: usize, mask: c_ulong, queue: ?*anyopaque) ?*anyopaque;
     extern "c" fn dispatch_source_set_event_handler_f(source: *anyopaque, handler: *const fn (?*anyopaque) callconv(.c) void) void;
+    extern "c" fn dispatch_source_set_cancel_handler_f(source: *anyopaque, handler: *const fn (?*anyopaque) callconv(.c) void) void;
     extern "c" fn dispatch_set_context(object: *anyopaque, context: ?*anyopaque) void;
     extern "c" fn dispatch_source_get_data(source: *anyopaque) c_ulong;
     extern "c" fn dispatch_get_global_queue(identifier: c_long, flags: c_ulong) *anyopaque;

--- a/src/analytics/analytics.zig
+++ b/src/analytics/analytics.zig
@@ -63,6 +63,7 @@ pub const Features = struct {
     pub var isolated_bun_install: usize = 0;
     pub var hoisted_bun_install: usize = 0;
     pub var macros: usize = 0;
+    pub var memory_pressure: usize = 0;
     pub var no_avx2: usize = 0;
     pub var no_avx: usize = 0;
     pub var shell: usize = 0;

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -243,6 +243,7 @@ pub const md = @import("./md/root.zig");
 pub const Output = @import("./bun_core/output.zig");
 pub const Global = @import("./bun_core/Global.zig");
 pub const ParentDeathWatchdog = @import("./aio/ParentDeathWatchdog.zig");
+pub const MemoryPressureWatcher = @import("./aio/MemoryPressureWatcher.zig");
 
 pub const FD = @import("./sys/fd.zig").FD;
 pub const MovableIfWindowsFd = @import("./sys/fd.zig").MovableIfWindowsFd;

--- a/src/bun_core/env_var.zig
+++ b/src/bun_core/env_var.zig
@@ -181,6 +181,12 @@ pub const feature_flag = struct {
     pub const BUN_FEATURE_FLAG_DISABLE_IPV4 = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_IPV4", .{});
     pub const BUN_FEATURE_FLAG_DISABLE_IPV6 = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_IPV6", .{});
     pub const BUN_FEATURE_FLAG_DISABLE_MEMFD = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_MEMFD", .{});
+    /// React to OS low-memory signals (Windows LowMemoryResourceNotification,
+    /// macOS DISPATCH_SOURCE_TYPE_MEMORYPRESSURE, Linux PSI) by running a sync
+    /// GC, shrinking the JSC footprint, and forcing mi_collect. Default-off
+    /// while we gather data; flip to default-on (rename to ...DISABLE...) once
+    /// validated.
+    pub const BUN_FEATURE_FLAG_EXPERIMENTAL_MEMORY_PRESSURE_HANDLER = newFeatureFlag("BUN_FEATURE_FLAG_EXPERIMENTAL_MEMORY_PRESSURE_HANDLER", .{});
     /// The RedisClient supports auto-pipelining by default. This flag disables that behavior.
     pub const BUN_FEATURE_FLAG_DISABLE_REDIS_AUTO_PIPELINING = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_REDIS_AUTO_PIPELINING", .{});
     pub const BUN_FEATURE_FLAG_DISABLE_RWF_NONBLOCK = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_RWF_NONBLOCK", .{});

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -1189,6 +1189,7 @@ pub fn initWithModuleGraph(
     vm.jsc_vm = vm.global.vm();
     uws.Loop.get().internal_loop_data.jsc_vm = vm.jsc_vm;
     bun.ParentDeathWatchdog.installOnEventLoop(jsc.EventLoopHandle.init(vm));
+    if (opts.is_main_thread) bun.MemoryPressureWatcher.installOnEventLoop(vm);
 
     vm.configureDebugger(opts.debugger);
     vm.body_value_hive_allocator = Body.Value.HiveAllocator.init(bun.typedAllocator(jsc.WebCore.Body.Value));

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -1314,6 +1314,7 @@ pub fn init(opts: Options) !*VirtualMachine {
     vm.smol = opts.smol;
     vm.dns_result_order = opts.dns_result_order;
     if (opts.is_main_thread) bun.ParentDeathWatchdog.installOnEventLoop(jsc.EventLoopHandle.init(vm));
+    if (opts.is_main_thread) bun.MemoryPressureWatcher.installOnEventLoop(vm);
 
     if (opts.smol)
         is_smol_mode = opts.smol;
@@ -2107,6 +2108,7 @@ pub fn processFetchLog(globalThis: *JSGlobalObject, specifier: bun.String, refer
 }
 
 pub fn deinit(this: *VirtualMachine) void {
+    if (this.is_main_thread) bun.MemoryPressureWatcher.uninstall();
     this.auto_killer.deinit();
 
     if (source_code_printer) |print| {

--- a/src/runtime/api/UnsafeObject.zig
+++ b/src/runtime/api/UnsafeObject.zig
@@ -1,5 +1,5 @@
 pub fn create(globalThis: *jsc.JSGlobalObject) jsc.JSValue {
-    const object = JSValue.createEmptyObject(globalThis, 3);
+    const object = JSValue.createEmptyObject(globalThis, 4);
     const fields = comptime .{
         .gcAggressionLevel = gcAggressionLevel,
         .arrayBufferToString = arrayBufferToString,
@@ -10,6 +10,13 @@ pub fn create(globalThis: *jsc.JSGlobalObject) jsc.JSValue {
             globalThis,
             comptime ZigString.static(name),
             jsc.JSFunction.create(globalThis, name, @field(fields, name), 1, .{}),
+        );
+    }
+    if (comptime bun.Environment.isDebug) {
+        object.put(
+            globalThis,
+            comptime ZigString.static("simulateMemoryPressure"),
+            jsc.JSFunction.create(globalThis, "simulateMemoryPressure", simulateMemoryPressure, 0, .{}),
         );
     }
     return object;
@@ -65,6 +72,15 @@ fn dump_mimalloc(globalObject: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSErr
         dump_zone_malloc_stats();
     }
     return .js_undefined;
+}
+
+/// Debug-only test seam for `MemoryPressureWatcher`. Runs the same JS-thread
+/// `respond()` path the OS callback would, returns the post-increment
+/// `analytics.Features.memory_pressure` count.
+pub fn simulateMemoryPressure(globalThis: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+    if (comptime !bun.Environment.isDebug) return .js_undefined;
+    const count = bun.MemoryPressureWatcher.simulate(globalThis.bunVM());
+    return JSValue.jsNumber(@as(i64, @intCast(count)));
 }
 
 const bun = @import("bun");

--- a/src/runtime/api/UnsafeObject.zig
+++ b/src/runtime/api/UnsafeObject.zig
@@ -1,5 +1,5 @@
 pub fn create(globalThis: *jsc.JSGlobalObject) jsc.JSValue {
-    const object = JSValue.createEmptyObject(globalThis, 4);
+    const object = JSValue.createEmptyObject(globalThis, if (bun.Environment.isDebug) 5 else 3);
     const fields = comptime .{
         .gcAggressionLevel = gcAggressionLevel,
         .arrayBufferToString = arrayBufferToString,
@@ -17,6 +17,11 @@ pub fn create(globalThis: *jsc.JSGlobalObject) jsc.JSValue {
             globalThis,
             comptime ZigString.static("simulateMemoryPressure"),
             jsc.JSFunction.create(globalThis, "simulateMemoryPressure", simulateMemoryPressure, 0, .{}),
+        );
+        object.put(
+            globalThis,
+            comptime ZigString.static("testMemoryPressureUninstallBarrier"),
+            jsc.JSFunction.create(globalThis, "testMemoryPressureUninstallBarrier", testMemoryPressureUninstallBarrier, 0, .{}),
         );
     }
     return object;
@@ -81,6 +86,15 @@ pub fn simulateMemoryPressure(globalThis: *jsc.JSGlobalObject, _: *jsc.CallFrame
     if (comptime !bun.Environment.isDebug) return .js_undefined;
     const count = bun.MemoryPressureWatcher.simulate(globalThis.bunVM());
     return JSValue.jsNumber(@as(i64, @intCast(count)));
+}
+
+/// Debug-only red/green seam for the Darwin `uninstall()` barrier. See
+/// `MemoryPressureWatcher.Darwin.testUninstallBarrier` — returns `true` iff
+/// `uninstall()` blocked until an in-flight libdispatch event handler
+/// finished. Trivially `true` off macOS.
+pub fn testMemoryPressureUninstallBarrier(globalThis: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+    if (comptime !bun.Environment.isDebug) return .js_undefined;
+    return JSValue.jsBoolean(bun.MemoryPressureWatcher.testUninstallBarrier(globalThis.bunVM()));
 }
 
 const bun = @import("bun");

--- a/src/windows_sys/externs.zig
+++ b/src/windows_sys/externs.zig
@@ -161,7 +161,6 @@ pub const MEMORY_RESOURCE_NOTIFICATION_TYPE = enum(c_int) {
     HighMemoryResourceNotification = 1,
 };
 pub extern "kernel32" fn CreateMemoryResourceNotification(NotificationType: MEMORY_RESOURCE_NOTIFICATION_TYPE) callconv(.winapi) ?HANDLE;
-pub extern "kernel32" fn QueryMemoryResourceNotification(ResourceNotificationHandle: HANDLE, ResourceState: *BOOL) callconv(.winapi) BOOL;
 pub const WAITORTIMERCALLBACK = *const fn (lpParameter: ?*anyopaque, TimerOrWaitFired: BOOLEAN) callconv(.winapi) void;
 pub extern "kernel32" fn RegisterWaitForSingleObject(phNewWaitObject: *HANDLE, hObject: HANDLE, Callback: WAITORTIMERCALLBACK, Context: ?*anyopaque, dwMilliseconds: windows.ULONG, dwFlags: windows.ULONG) callconv(.winapi) BOOL;
 pub extern "kernel32" fn UnregisterWaitEx(WaitHandle: HANDLE, CompletionEvent: ?HANDLE) callconv(.winapi) BOOL;

--- a/src/windows_sys/externs.zig
+++ b/src/windows_sys/externs.zig
@@ -156,6 +156,18 @@ pub extern "kernel32" fn ClosePseudoConsole(hPC: HPCON) callconv(.winapi) void;
 
 pub extern "kernel32" fn CloseHandle(hObject: HANDLE) callconv(.winapi) BOOL;
 
+pub const MEMORY_RESOURCE_NOTIFICATION_TYPE = enum(c_int) {
+    LowMemoryResourceNotification = 0,
+    HighMemoryResourceNotification = 1,
+};
+pub extern "kernel32" fn CreateMemoryResourceNotification(NotificationType: MEMORY_RESOURCE_NOTIFICATION_TYPE) callconv(.winapi) ?HANDLE;
+pub extern "kernel32" fn QueryMemoryResourceNotification(ResourceNotificationHandle: HANDLE, ResourceState: *BOOL) callconv(.winapi) BOOL;
+pub const WAITORTIMERCALLBACK = *const fn (lpParameter: ?*anyopaque, TimerOrWaitFired: BOOLEAN) callconv(.winapi) void;
+pub extern "kernel32" fn RegisterWaitForSingleObject(phNewWaitObject: *HANDLE, hObject: HANDLE, Callback: WAITORTIMERCALLBACK, Context: ?*anyopaque, dwMilliseconds: windows.ULONG, dwFlags: windows.ULONG) callconv(.winapi) BOOL;
+pub extern "kernel32" fn UnregisterWaitEx(WaitHandle: HANDLE, CompletionEvent: ?HANDLE) callconv(.winapi) BOOL;
+pub const WT_EXECUTEONLYONCE: windows.ULONG = 0x00000008;
+pub const WT_EXECUTEINWAITTHREAD: windows.ULONG = 0x00000004;
+
 pub extern "kernel32" fn GetFinalPathNameByHandleW(hFile: HANDLE, lpszFilePath: [*]u16, cchFilePath: DWORD, dwFlags: DWORD) callconv(.winapi) DWORD;
 
 pub extern "kernel32" fn DeleteFileW(lpFileName: [*:0]const u16) callconv(.winapi) BOOL;

--- a/test/js/bun/util/memory-pressure.test.ts
+++ b/test/js/bun/util/memory-pressure.test.ts
@@ -101,4 +101,29 @@ describe.concurrent("MemoryPressureWatcher", () => {
     expect(debug).not.toContain("installed");
     expect(exitCode).toBe(0);
   });
+
+  // Red/green for the Darwin uninstall() barrier: dispatch_source_cancel()
+  // is async, so without a barrier in Darwin.uninstall() an in-flight
+  // onPressureDispatch can be between its shutting_down.load() and
+  // enqueueTaskConcurrent() while uninstall() returns and
+  // VirtualMachine.deinit() proceeds to has_terminated=true — which makes
+  // that enqueue panic under allow_assert. The seam installs a
+  // DISPATCH_SOURCE_TYPE_DATA_ADD source through the same install/handler/
+  // cancel/uninstall path, fires it via dispatch_source_merge_data, parks
+  // the libdispatch worker in the race window, runs uninstall(), and
+  // reports whether the worker had completed before uninstall() returned.
+  // RED ⇒ { blocked: false }, GREEN ⇒ { blocked: true }.
+  test.skipIf(!isDebug || !isMacOS)("Darwin.uninstall() blocks until in-flight event handler drains", async () => {
+    // Flag OFF so the real MEMORYPRESSURE source isn't installed; the seam
+    // does its own DATA_ADD install and asserts state == null on entry.
+    const env = { ...flagOn };
+    delete env.BUN_FEATURE_FLAG_EXPERIMENTAL_MEMORY_PRESSURE_HANDLER;
+    const { out, stderr, exitCode } = await run(
+      env,
+      `process.stdout.write(JSON.stringify({ blocked: Bun.unsafe.testMemoryPressureUninstallBarrier() }))`,
+    );
+    expect(stderr).not.toContain("error");
+    expect(JSON.parse(out.trim())).toEqual({ blocked: true });
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/util/memory-pressure.test.ts
+++ b/test/js/bun/util/memory-pressure.test.ts
@@ -52,13 +52,15 @@ describe("MemoryPressureWatcher", () => {
     // Heap-size deltas are too noisy to assert on (JSC keeps block capacity
     // around after a collection), so use a WeakRef as the deterministic signal
     // that runGC(true) ran: the referent must be gone afterwards.
+    //
+    // Per spec, deref() adds the target to [[KeptAlive]] until the end of the
+    // current synchronous job, so don't deref before the GC — only after.
     const code = /* js */ `
       function makeRef() { return new WeakRef({ sentinel: true }); }
       const ref = makeRef();
-      const aliveBefore = ref.deref() !== undefined;
       const counter = Bun.unsafe.simulateMemoryPressure();
       const aliveAfter = ref.deref() !== undefined;
-      process.stdout.write(JSON.stringify({ aliveBefore, aliveAfter, counter }));
+      process.stdout.write(JSON.stringify({ aliveAfter, counter }));
     `;
     const { out, debug, stderr, exitCode } = await run(flagOn, code);
     expect({ debug, stderr }).toEqual({
@@ -66,7 +68,6 @@ describe("MemoryPressureWatcher", () => {
       stderr: expect.not.stringContaining("error"),
     });
     expect(JSON.parse(out.trim())).toEqual({
-      aliveBefore: true,
       aliveAfter: false,
       counter: 1,
     });

--- a/test/js/bun/util/memory-pressure.test.ts
+++ b/test/js/bun/util/memory-pressure.test.ts
@@ -13,7 +13,7 @@
 //   Linux:   stress-ng --vm 1 --vm-bytes 90% -t 30
 //   Windows: Sysinternals testlimit -d, or a tight allocator loop in another process
 
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug, isLinux } from "harness";
 
 const flagOn = {

--- a/test/js/bun/util/memory-pressure.test.ts
+++ b/test/js/bun/util/memory-pressure.test.ts
@@ -46,7 +46,7 @@ async function run(env: Record<string, string | undefined>, code: string) {
   return { out, debug, stderr, exitCode };
 }
 
-describe("MemoryPressureWatcher", () => {
+describe.concurrent("MemoryPressureWatcher", () => {
   test.skipIf(!isDebug)("respond() runs a sync GC and bumps the analytics counter", async () => {
     // The simulate seam runs the same JS-thread respond() the OS callback would.
     // Heap-size deltas are too noisy to assert on (JSC keeps block capacity

--- a/test/js/bun/util/memory-pressure.test.ts
+++ b/test/js/bun/util/memory-pressure.test.ts
@@ -14,7 +14,7 @@
 //   Windows: Sysinternals testlimit -d, or a tight allocator loop in another process
 
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isLinux } from "harness";
+import { bunEnv, bunExe, isDebug, isLinux, isMacOS, isWindows } from "harness";
 
 const flagOn = {
   ...bunEnv,
@@ -85,8 +85,11 @@ describe("MemoryPressureWatcher", () => {
       // on most kernels, so containers commonly fall through to "unavailable".
       // Either outcome is fine; just prove the install path ran and reported one.
       expect(debug).toMatch(/installed \(.*PSI\)|PSI unavailable/);
-    } else {
+    } else if (isMacOS || isWindows) {
       expect(debug).toContain("installed");
+    } else {
+      // FreeBSD etc. → Noop backend, nothing installs.
+      expect(debug).toBe("");
     }
     expect(exitCode).toBe(0);
   });

--- a/test/js/bun/util/memory-pressure.test.ts
+++ b/test/js/bun/util/memory-pressure.test.ts
@@ -1,0 +1,100 @@
+// Verifies the OS memory-pressure watcher (src/aio/MemoryPressureWatcher.zig).
+//
+// Real OS pressure can't be triggered deterministically in CI, so:
+//   - the response path is exercised via the debug-only
+//     Bun.unsafe.simulateMemoryPressure() seam,
+//   - install/uninstall is smoke-tested via the BUN_DEBUG_MemoryPressure log,
+//   - and we assert the watcher never keeps the event loop alive.
+//
+// Manual end-to-end repro (run alongside
+// `BUN_DEBUG_MemoryPressure=1 BUN_FEATURE_FLAG_EXPERIMENTAL_MEMORY_PRESSURE_HANDLER=1 bun --watch script.js`
+// and watch for "memory pressure (critical); shrinking footprint" + an RSS drop):
+//   macOS:   sudo memory_pressure -S -l critical
+//   Linux:   stress-ng --vm 1 --vm-bytes 90% -t 30
+//   Windows: Sysinternals testlimit -d, or a tight allocator loop in another process
+
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe, isDebug, isLinux } from "harness";
+
+const flagOn = {
+  ...bunEnv,
+  BUN_FEATURE_FLAG_EXPERIMENTAL_MEMORY_PRESSURE_HANDLER: "1",
+  // Output.scoped logs go to stdout in debug builds; QUIET_LOGS hushes every
+  // other scope so we can grep for just [memorypressure] lines.
+  BUN_DEBUG_MemoryPressure: "1",
+  BUN_DEBUG_QUIET_LOGS: "1",
+};
+
+async function run(env: Record<string, string | undefined>, code: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // Output.scoped(.MemoryPressure) writes to stdout. Pull those lines out so
+  // tests can assert on them separately from the user script's own output.
+  const debug = stdout
+    .split("\n")
+    .filter(l => l.includes("[memorypressure]"))
+    .join("\n");
+  const out = stdout
+    .split("\n")
+    .filter(l => !l.includes("[memorypressure]"))
+    .join("\n");
+  return { out, debug, stderr, exitCode };
+}
+
+describe("MemoryPressureWatcher", () => {
+  test.skipIf(!isDebug)("respond() runs a sync GC and bumps the analytics counter", async () => {
+    // The simulate seam runs the same JS-thread respond() the OS callback would.
+    // Heap-size deltas are too noisy to assert on (JSC keeps block capacity
+    // around after a collection), so use a WeakRef as the deterministic signal
+    // that runGC(true) ran: the referent must be gone afterwards.
+    const code = /* js */ `
+      function makeRef() { return new WeakRef({ sentinel: true }); }
+      const ref = makeRef();
+      const aliveBefore = ref.deref() !== undefined;
+      const counter = Bun.unsafe.simulateMemoryPressure();
+      const aliveAfter = ref.deref() !== undefined;
+      process.stdout.write(JSON.stringify({ aliveBefore, aliveAfter, counter }));
+    `;
+    const { out, debug, stderr, exitCode } = await run(flagOn, code);
+    expect({ debug, stderr }).toEqual({
+      debug: expect.stringContaining("shrinking footprint"),
+      stderr: expect.not.stringContaining("error"),
+    });
+    expect(JSON.parse(out.trim())).toEqual({
+      aliveBefore: true,
+      aliveAfter: false,
+      counter: 1,
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test.skipIf(!isDebug)("installs when the flag is on, and does not keep the loop alive", async () => {
+    // exitCode === 0 here is the loop-keepalive guard: if the watcher's
+    // libuv handle / dispatch source / PSI thread accidentally ref'd the
+    // loop, this child would never exit and the assertion would fail on
+    // bun:test's default timeout instead.
+    const { debug, exitCode } = await run(flagOn, `await Bun.sleep(50)`);
+    if (isLinux) {
+      // System-wide PSI triggers (/proc/pressure/memory) need CAP_SYS_RESOURCE
+      // on most kernels, so containers commonly fall through to "unavailable".
+      // Either outcome is fine; just prove the install path ran and reported one.
+      expect(debug).toMatch(/installed \(.*PSI\)|PSI unavailable/);
+    } else {
+      expect(debug).toContain("installed");
+    }
+    expect(exitCode).toBe(0);
+  });
+
+  test.skipIf(!isDebug)("does not install when the feature flag is off (default)", async () => {
+    const flagOff = { ...flagOn };
+    delete flagOff.BUN_FEATURE_FLAG_EXPERIMENTAL_MEMORY_PRESSURE_HANDLER;
+    const { debug, exitCode } = await run(flagOff, `await Bun.sleep(50)`);
+    expect(debug).not.toContain("installed");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Adds a Bun-native memory-pressure watcher that, when the OS signals low memory, runs a sync JSC GC, schedules `shrinkFootprintWhenIdle()` (drops JIT code at the next safe point), forces `mi_collect(true)` to hand mimalloc free segments back to the OS, and bumps `analytics.Features.memory_pressure` so any later crash report carries `memory_pressure(N)`.

**Off by default** behind `BUN_FEATURE_FLAG_EXPERIMENTAL_MEMORY_PRESSURE_HANDLER=1` so it can be A/B'd before becoming default-on. No JS-visible hook.

#### Detection
| Platform | Mechanism | Cross-thread dispatch |
| --- | --- | --- |
| Windows | `CreateMemoryResourceNotification(LowMemoryResourceNotification)` + `RegisterWaitForSingleObject` (NT threadpool, `WT_EXECUTEONLYONCE`); 30 s `uv_timer` holdoff before re-arm since the handle is level-triggered. Same approach upstream WebKit recently took in `MemoryPressureHandlerWin`. | `uv_async_send` |
| macOS | `dispatch_source_create(DISPATCH_SOURCE_TYPE_MEMORYPRESSURE, …, WARN \| CRITICAL \| PROC_LIMIT_*)` on a global utility queue. Edge-triggered on transitions, no holdoff needed. | `enqueueTaskConcurrent` |
| Linux | PSI trigger on `/proc/pressure/memory` (`some 150000 1000000`), blocked on `POLLPRI` by a parked thread; 30 s holdoff between fires. Gracefully no-ops where the trigger write fails (no PSI / no `CAP_SYS_RESOURCE`). | `enqueueTaskConcurrent` |

All three converge on `respond()` running on the JS thread.

#### Why not `WTF::MemoryPressureHandler`?
In Bun's JSCOnly WebKit build (`PlatformJSCOnly.cmake`), `install()` is the empty `Generic` stub on Apple, sets a flag with no OS hook on Linux (it expects GTK/WPE's UIProcess to call `triggerMemoryPressureEvent` over IPC), and 60 s polling on Windows. And `releaseMemory()` is a no-op without `setLowMemoryHandler`, so we'd be supplying the same Bun-side cleanup either way.

### How did you verify your code works?

- `bun run zig:check-all` — 61/61 (all 16 OS/arch/profile combos)
- `bun bd test test/js/bun/util/memory-pressure.test.ts` — 3 pass / 0 fail (Linux)
- `USE_SYSTEM_BUN=1 bun test …` — 0 pass / 3 skip (no false positives)
- Manually confirmed the Linux install path runs and gracefully degrades without `CAP_SYS_RESOURCE` (PSI write → `EINVAL`, watcher logs `PSI unavailable` and skips).

Tests use the debug-only `Bun.unsafe.simulateMemoryPressure()` seam and a `WeakRef` to deterministically assert the sync GC ran (heap-size deltas were too noisy — JSC retains block capacity post-collection). Manual end-to-end repro instructions for each platform are in the test file's header comment.

macOS and Windows backends are compile-tested locally; CI runners on those platforms will exercise the install-smoke test.