### PR TITLE
Bun.mmap: throw on non-object options instead of asserting

### DIFF
--- a/src/runtime/api/BunObject.zig
+++ b/src/runtime/api/BunObject.zig
@@ -1216,33 +1216,37 @@ pub fn mmapFile(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.
     var map_size: ?usize = null;
 
     if (args.nextEat()) |opts| {
-        flags.TYPE = if ((try opts.getBooleanLoose(globalThis, "shared")) orelse true)
-            .SHARED
-        else
-            .PRIVATE;
+        if (opts.isObject()) {
+            flags.TYPE = if ((try opts.getBooleanLoose(globalThis, "shared")) orelse true)
+                .SHARED
+            else
+                .PRIVATE;
 
-        if (@hasField(std.c.MAP, "SYNC")) {
-            if ((try opts.getBooleanLoose(globalThis, "sync")) orelse false) {
-                flags.TYPE = .SHARED_VALIDATE;
-                flags.SYNC = true;
+            if (@hasField(std.c.MAP, "SYNC")) {
+                if ((try opts.getBooleanLoose(globalThis, "sync")) orelse false) {
+                    flags.TYPE = .SHARED_VALIDATE;
+                    flags.SYNC = true;
+                }
             }
-        }
 
-        if (try opts.get(globalThis, "size")) |value| {
-            const size_value = try value.coerceToInt64(globalThis);
-            if (size_value < 0) {
-                return globalThis.throwInvalidArguments("size must be a non-negative integer", .{});
+            if (try opts.get(globalThis, "size")) |value| {
+                const size_value = try value.coerceToInt64(globalThis);
+                if (size_value < 0) {
+                    return globalThis.throwInvalidArguments("size must be a non-negative integer", .{});
+                }
+                map_size = @intCast(size_value);
             }
-            map_size = @intCast(size_value);
-        }
 
-        if (try opts.get(globalThis, "offset")) |value| {
-            const offset_value = try value.coerceToInt64(globalThis);
-            if (offset_value < 0) {
-                return globalThis.throwInvalidArguments("offset must be a non-negative integer", .{});
+            if (try opts.get(globalThis, "offset")) |value| {
+                const offset_value = try value.coerceToInt64(globalThis);
+                if (offset_value < 0) {
+                    return globalThis.throwInvalidArguments("offset must be a non-negative integer", .{});
+                }
+                offset = @intCast(offset_value);
+                offset = std.mem.alignBackwardAnyAlign(usize, offset, std.heap.pageSize());
             }
-            offset = @intCast(offset_value);
-            offset = std.mem.alignBackwardAnyAlign(usize, offset, std.heap.pageSize());
+        } else if (!opts.isUndefinedOrNull()) {
+            return globalThis.throwInvalidArguments("Expected options to be an object", .{});
         }
     }
 

--- a/test/js/bun/util/mmap.test.js
+++ b/test/js/bun/util/mmap.test.js
@@ -77,6 +77,14 @@ describe.skipIf(isWindows)("Bun.mmap", async () => {
     expect(() => Bun.mmap(path, { size: -1 })).toThrow("size must be a non-negative integer");
   });
 
+  it("mmap rejects non-object options", () => {
+    expect(() => Bun.mmap(path, 256)).toThrow("Expected options to be an object");
+    expect(() => Bun.mmap(path, "foo")).toThrow("Expected options to be an object");
+    expect(() => Bun.mmap(path, true)).toThrow("Expected options to be an object");
+    expect(() => Bun.mmap(path, undefined)).not.toThrow();
+    expect(() => Bun.mmap(path, null)).not.toThrow();
+  });
+
   it("mmap handles non-number offset/size without crashing", () => {
     // These should not crash - non-number values coerce to 0 per JavaScript semantics
     // Previously these caused assertion failures (issue ENG-22413)


### PR DESCRIPTION
## What does this PR do?

`Bun.mmap(path, 256)` (or any non-object second argument) hit a debug assertion in `JSValue.get()` because the options value was passed straight to `getBooleanLoose` without first checking that it is an object.

Now non-object, non-nullish values throw `ERR_INVALID_ARG_TYPE`, and `undefined`/`null` are treated the same as omitting the options argument.

```
panic(main thread): reached unreachable code
bun.debugAssert
jsc.JSValue.JSValue.get                 src/jsc/JSValue.zig:1534
jsc.JSValue.JSValue.getBooleanLoose     src/jsc/JSValue.zig:1867
runtime.api.BunObject.mmapFile          src/runtime/api/BunObject.zig:1219
```

## How did you verify your code works?

Added a test to `test/js/bun/util/mmap.test.js` covering number/string/boolean (throw) and undefined/null (no throw).

Found by Fuzzilli (fingerprint `b1832bde6df73226`).