### PR TITLE
Validate `app.bundlerOptions` types in `Bun.serve`

### DIFF
--- a/src/bake/bake.zig
+++ b/src/bake/bake.zig
@@ -68,14 +68,17 @@ pub const UserOptions = struct {
         }
 
         if (try config.getOptional(global, "bundlerOptions", JSValue)) |js_options| {
+            if (!js_options.isObject()) {
+                return global.throwInvalidArguments("'" ++ api_name ++ ".bundlerOptions' must be an object", .{});
+            }
             if (try js_options.getOptional(global, "server", JSValue)) |server_options| {
-                bundler_options.server = try BuildConfigSubset.fromJS(global, server_options);
+                bundler_options.server = try BuildConfigSubset.fromJS(global, server_options, "server");
             }
             if (try js_options.getOptional(global, "client", JSValue)) |client_options| {
-                bundler_options.client = try BuildConfigSubset.fromJS(global, client_options);
+                bundler_options.client = try BuildConfigSubset.fromJS(global, client_options, "client");
             }
             if (try js_options.getOptional(global, "ssr", JSValue)) |ssr_options| {
-                bundler_options.ssr = try BuildConfigSubset.fromJS(global, ssr_options);
+                bundler_options.ssr = try BuildConfigSubset.fromJS(global, ssr_options, "ssr");
             }
         }
 
@@ -202,8 +205,12 @@ const BuildConfigSubset = struct {
     minify_identifiers: ?bool = null,
     minify_whitespace: ?bool = null,
 
-    pub fn fromJS(global: *jsc.JSGlobalObject, js_options: JSValue) bun.JSError!BuildConfigSubset {
+    pub fn fromJS(global: *jsc.JSGlobalObject, js_options: JSValue, comptime name: []const u8) bun.JSError!BuildConfigSubset {
         var options = BuildConfigSubset{};
+
+        if (!js_options.isObject()) {
+            return global.throwInvalidArguments("'" ++ api_name ++ ".bundlerOptions." ++ name ++ "' must be an object", .{});
+        }
 
         if (try js_options.getOptional(global, "sourcemap", JSValue)) |val| brk: {
             if (try bun.schema.api.SourceMapMode.fromJS(global, val)) |sourcemap| {
@@ -215,11 +222,15 @@ const BuildConfigSubset = struct {
         }
 
         if (try js_options.getOptional(global, "minify", JSValue)) |minify_options| brk: {
-            if (minify_options.isBoolean() and minify_options.asBoolean()) {
+            if (minify_options.isBoolean()) {
                 options.minify_syntax = minify_options.asBoolean();
                 options.minify_identifiers = minify_options.asBoolean();
                 options.minify_whitespace = minify_options.asBoolean();
                 break :brk;
+            }
+
+            if (!minify_options.isObject()) {
+                return global.throwInvalidArguments("'" ++ api_name ++ ".bundlerOptions." ++ name ++ ".minify' must be a boolean or an object", .{});
             }
 
             if (try minify_options.getBooleanLoose(global, "whitespace")) |value| {

--- a/test/bake/bundler-options-validation.test.ts
+++ b/test/bake/bundler-options-validation.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+
+describe("Bun.serve app.bundlerOptions validation", () => {
+  test("throws when bundlerOptions is not an object", () => {
+    expect(() =>
+      // @ts-expect-error
+      Bun.serve({ app: { bundlerOptions: 123 } }),
+    ).toThrow("'app.bundlerOptions' must be an object");
+  });
+
+  describe.each(["server", "client", "ssr"])("bundlerOptions.%s", key => {
+    test("throws when not an object", () => {
+      expect(() =>
+        // @ts-expect-error
+        Bun.serve({ app: { bundlerOptions: { [key]: 699 } } }),
+      ).toThrow(`'app.bundlerOptions.${key}' must be an object`);
+    });
+
+    test("throws when minify is not a boolean or object", () => {
+      expect(() =>
+        // @ts-expect-error
+        Bun.serve({ app: { bundlerOptions: { [key]: { minify: 5 } } } }),
+      ).toThrow(`'app.bundlerOptions.${key}.minify' must be a boolean or an object`);
+    });
+
+    test.each([true, false])("does not crash when minify is %p", minify => {
+      expect(() =>
+        // @ts-expect-error
+        Bun.serve({ app: { bundlerOptions: { [key]: { minify } } } }),
+      ).toThrow("'app' is missing 'framework'");
+    });
+  });
+});


### PR DESCRIPTION
`Bun.serve({ app: { bundlerOptions: ... } })` hit a debug assertion in `JSValue.get` when `bundlerOptions`, `bundlerOptions.{server,client,ssr}`, or their `minify` option were non-object primitives (e.g. a number). The code called `.getOptional()` on these values without checking they were objects first.

```js
Bun.serve({ app: { bundlerOptions: { ssr: 699 } } });
// panic: reached unreachable code (debugAssert target.isObject())
```

Now throws a `TypeError` with the offending property path instead. Also fixes `minify: false`, which previously fell through the boolean check and hit the same assertion.

Found by Fuzzilli. Fingerprint: `b2de5bfcd9b59c23`