### PR TITLE
tls: load intermediates and trusted-people from Windows system stores

### DIFF
--- a/packages/bun-usockets/src/crypto/root_certs_windows.cpp
+++ b/packages/bun-usockets/src/crypto/root_certs_windows.cpp
@@ -4,6 +4,7 @@
 #include <wincrypt.h>
 #include <vector>
 #include <cstring>
+#include <string_view>
 
 // Forward declaration to avoid including OpenSSL headers here
 // This prevents conflicts with Windows macros like X509_NAME
@@ -14,40 +15,139 @@ struct RawCertificate {
   std::vector<unsigned char> data;
 };
 
-// Helper function to load raw certificates from a Windows certificate store
-static void LoadRawCertsFromStore(std::vector<RawCertificate>& raw_certs, 
-                                  DWORD store_flags, 
-                                  const wchar_t* store_name) {
+// Returns true if the cert can be used for server authentication, based on
+// certificate properties. Mirrors Node.js's IsCertTrustedForServerAuth in
+// src/crypto/crypto_context.cc.
+//
+// While there are a variety of certificate properties that can affect how
+// trust is computed, the main property is CERT_ENHKEY_USAGE_PROP_ID, which
+// is intersected with the certificate's EKU extension (if present).
+// The intersection is documented in the Remarks section of
+// CertGetEnhancedKeyUsage, and is as follows:
+// - No EKU property, and no EKU extension = Trusted for all purposes
+// - Either an EKU property, or EKU extension, but not both = Trusted only
+//   for the listed purposes
+// - Both an EKU property and an EKU extension = Trusted for the set
+//   intersection of the listed purposes
+// CertGetEnhancedKeyUsage handles this logic, and if an empty set is
+// returned, the distinction between the first and third case can be
+// determined by GetLastError() returning CRYPT_E_NOT_FOUND.
+//
+// See:
+// https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certgetenhancedkeyusage
+//
+// If we run into any errors reading the certificate properties, we fail
+// closed.
+static bool IsCertTrustedForServerAuth(PCCERT_CONTEXT cert) {
+  DWORD usage_size = 0;
+
+  if (!CertGetEnhancedKeyUsage(cert, 0, nullptr, &usage_size)) {
+    return false;
+  }
+
+  std::vector<BYTE> usage_bytes(usage_size);
+  CERT_ENHKEY_USAGE* usage =
+      reinterpret_cast<CERT_ENHKEY_USAGE*>(usage_bytes.data());
+  if (!CertGetEnhancedKeyUsage(cert, 0, usage, &usage_size)) {
+    return false;
+  }
+
+  if (usage->cUsageIdentifier == 0) {
+    // check GetLastError
+    HRESULT error_code = GetLastError();
+
+    switch (error_code) {
+      case CRYPT_E_NOT_FOUND:
+        return true;
+      case S_OK:
+        return false;
+      default:
+        return false;
+    }
+  }
+
+  // SAFETY: `usage->rgpszUsageIdentifier` is an array of LPSTR (pointer to
+  // null-terminated string) of length `usage->cUsageIdentifier`.
+  for (DWORD i = 0; i < usage->cUsageIdentifier; ++i) {
+    std::string_view eku(usage->rgpszUsageIdentifier[i]);
+    if ((eku == szOID_PKIX_KP_SERVER_AUTH) ||
+        (eku == szOID_ANY_ENHANCED_KEY_USAGE)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// Helper function to load raw certificates from a Windows certificate store.
+// Mirrors Node.js's GatherCertsForLocation.
+static void GatherCertsForLocation(std::vector<RawCertificate>& raw_certs,
+                                   DWORD location,
+                                   const wchar_t* store_name) {
+  if (!(location == CERT_SYSTEM_STORE_LOCAL_MACHINE ||
+        location == CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY ||
+        location == CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE ||
+        location == CERT_SYSTEM_STORE_CURRENT_USER ||
+        location == CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY)) {
+    return;
+  }
+
+  DWORD flags =
+      location | CERT_STORE_OPEN_EXISTING_FLAG | CERT_STORE_READONLY_FLAG;
+
   HCERTSTORE cert_store = CertOpenStore(
     CERT_STORE_PROV_SYSTEM_W,
     0,
     0,
-    store_flags | CERT_STORE_READONLY_FLAG,
+    flags,
     store_name
   );
-  
+
   if (cert_store == NULL) {
     return;
   }
-  
+
   PCCERT_CONTEXT cert_context = NULL;
   while ((cert_context = CertEnumCertificatesInStore(cert_store, cert_context)) != NULL) {
+    if (!IsCertTrustedForServerAuth(cert_context)) {
+      continue;
+    }
     RawCertificate raw_cert;
-    raw_cert.data.assign(cert_context->pbCertEncoded, 
-                        cert_context->pbCertEncoded + cert_context->cbCertEncoded);
+    raw_cert.data.assign(cert_context->pbCertEncoded,
+                         cert_context->pbCertEncoded + cert_context->cbCertEncoded);
     raw_certs.push_back(std::move(raw_cert));
   }
-  
+
   CertCloseStore(cert_store, 0);
 }
 
-// Main function to load raw system certificates on Windows
-// Returns certificates as raw DER data to avoid OpenSSL header conflicts
+// Main function to load raw system certificates on Windows.
+// Returns certificates as raw DER data to avoid OpenSSL header conflicts.
+// Mirrors Node.js's ReadWindowsCertificates: loads roots, intermediates, and
+// trusted end-entity certs from the same set of system store locations so
+// that chain building succeeds even when servers omit intermediates.
 extern void us_load_system_certificates_windows_raw(
     std::vector<RawCertificate>& raw_certs) {
-  // Load only from ROOT by default
-  LoadRawCertsFromStore(raw_certs, CERT_SYSTEM_STORE_CURRENT_USER, L"ROOT");
-  LoadRawCertsFromStore(raw_certs, CERT_SYSTEM_STORE_LOCAL_MACHINE, L"ROOT");
+  // Grab the user-added roots.
+  GatherCertsForLocation(raw_certs, CERT_SYSTEM_STORE_LOCAL_MACHINE, L"ROOT");
+  GatherCertsForLocation(raw_certs, CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY, L"ROOT");
+  GatherCertsForLocation(raw_certs, CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE, L"ROOT");
+  GatherCertsForLocation(raw_certs, CERT_SYSTEM_STORE_CURRENT_USER, L"ROOT");
+  GatherCertsForLocation(raw_certs, CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY, L"ROOT");
+
+  // Grab the intermediate certs.
+  GatherCertsForLocation(raw_certs, CERT_SYSTEM_STORE_LOCAL_MACHINE, L"CA");
+  GatherCertsForLocation(raw_certs, CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY, L"CA");
+  GatherCertsForLocation(raw_certs, CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE, L"CA");
+  GatherCertsForLocation(raw_certs, CERT_SYSTEM_STORE_CURRENT_USER, L"CA");
+  GatherCertsForLocation(raw_certs, CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY, L"CA");
+
+  // Grab the user-added trusted server certs. Trusted end-entity certs are
+  // only allowed for server auth in the "local machine" store, but not in the
+  // "current user" store.
+  GatherCertsForLocation(raw_certs, CERT_SYSTEM_STORE_LOCAL_MACHINE, L"TrustedPeople");
+  GatherCertsForLocation(raw_certs, CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY, L"TrustedPeople");
+  GatherCertsForLocation(raw_certs, CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE, L"TrustedPeople");
 }
 
 #endif // _WIN32


### PR DESCRIPTION
### What does this PR do?

Brings `--use-system-ca` / `NODE_USE_SYSTEM_CA` on Windows to parity with Node.js's `ReadWindowsCertificates` (`src/crypto/crypto_context.cc`).

Before this change, `root_certs_windows.cpp` only enumerated the `ROOT` store for `CURRENT_USER` and `LOCAL_MACHINE` (2 `CertOpenStore` calls). Node opens 13: `ROOT`, `CA` (intermediates), and `TrustedPeople` across `LOCAL_MACHINE`, `CURRENT_USER`, and the group-policy / enterprise variants — and filters by EKU.

The most user-visible consequence of the old behavior: when a server is misconfigured and sends only the leaf cert without its intermediates (very common on intranets, the primary use case for `--use-system-ca`), Node can still build the chain from the intermediates Windows keeps in the `CA` store; Bun would fail with `unable to get local issuer certificate`.

Changes, all mirroring Node:

| | before | after |
|---|---|---|
| Store names | `ROOT` | `ROOT`, `CA`, `TrustedPeople` |
| Locations | `LOCAL_MACHINE`, `CURRENT_USER` | + `GROUP_POLICY`, `ENTERPRISE` variants |
| `CERT_STORE_OPEN_EXISTING_FLAG` | no | yes (don't create a missing store) |
| EKU server-auth filter (`CertGetEnhancedKeyUsage`) | no | yes (skip certs restricted to e.g. code-signing only) |

`IsCertTrustedForServerAuth` and `GatherCertsForLocation` are direct ports of the equivalents in Node's `crypto_context.cc`, adapted to Bun's raw-DER-blob layering (this TU is kept OpenSSL-free to avoid `wincrypt.h` / BoringSSL macro collisions; `root_certs.cpp` does the `d2i_X509` conversion).


### Related issues (context, not fixes)

The issue-finder bot flagged #17108, #28612, and #9365. None of them are closed by this PR because it only changes behavior when `--use-system-ca` / `NODE_USE_SYSTEM_CA=1` is set:

- #17108 asked for the base feature, which #22441 already shipped — this PR refines which Windows stores it reads.
- #28612 reports `unable to get local issuer certificate` with **no** `--use-system-ca` set (default bundled store, public CAs, TTY-startup race) — different layer.
- #9365 reproduces on WSL/Linux too and predates `--use-system-ca` — likely a server omitting intermediates with no system-store fallback at all.
