### PR TITLE
perf(serve): O(n) Bun.serve({ routes }) registration

### DIFF
--- a/bench/snippets/serve-routes.mjs
+++ b/bench/snippets/serve-routes.mjs
@@ -1,0 +1,44 @@
+// Measures the cost of `Bun.serve({ routes })` as a function of how many routes
+// are registered. Run with a release build, e.g.:
+//
+//   bun-release bench/snippets/serve-routes.mjs
+//   bun-release bench/snippets/serve-routes.mjs 1000 5000 10000 20000 40000 100000
+//
+// Each route count is timed a few times and the fastest run is reported.
+
+const counts = process.argv.slice(2).map(Number).filter(n => Number.isFinite(n) && n > 0);
+const ROUTE_COUNTS = counts.length ? counts : [1_000, 5_000, 10_000, 20_000, 40_000, 100_000];
+const REPEAT = 5;
+
+function makeRoutes(total) {
+  const routes = Object.create(null);
+  const handler = { GET: () => new Response("ok") };
+  for (let i = 0; i < total; i++) {
+    routes[`/${i}`] = handler;
+  }
+  return routes;
+}
+
+function timeServe(routes) {
+  const t = performance.now();
+  const server = Bun.serve({ port: 0, routes });
+  const elapsed = performance.now() - t;
+  server.stop(true);
+  return elapsed;
+}
+
+const rows = [];
+for (const total of ROUTE_COUNTS) {
+  const routes = makeRoutes(total);
+  // Warmup once, then take the best of REPEAT.
+  timeServe(routes);
+  let best = Infinity;
+  for (let i = 0; i < REPEAT; i++) {
+    best = Math.min(best, timeServe(routes));
+  }
+  rows.push({ routes: total, ms: best });
+  console.log(`${total.toLocaleString().padStart(9)} routes  ->  ${best.toFixed(2).padStart(10)} ms`);
+}
+
+// Machine-readable line for tooling.
+console.log("\nJSON: " + JSON.stringify(rows));

--- a/packages/bun-uws/src/HttpRouter.h
+++ b/packages/bun-uws/src/HttpRouter.h
@@ -19,6 +19,8 @@
 #define UWS_HTTPROUTER_HPP
 
 #include <map>
+#include <unordered_map>
+#include <array>
 #include <vector>
 #include <cstring>
 #include <string_view>
@@ -53,14 +55,69 @@ private:
     std::string_view urlSegmentVector[MAX_URL_SEGMENTS] = {};
     int urlSegmentTop = -1;
 
+    /* Once a node reaches this many children, getNode()/findHandler() build a hash
+     * index over them so route registration stays linear instead of quadratic when
+     * many routes share a parent (e.g. thousands of top-level or same-prefix routes). */
+    static constexpr size_t CHILD_INDEX_THRESHOLD = 16;
+
     /* The matching tree */
     struct Node {
         std::string name = {};
         std::vector<std::unique_ptr<Node>> children = {};
         std::vector<uint32_t> handlers = {};
         bool isHighPriority = false;
+        /* Lazily built once `children` reaches CHILD_INDEX_THRESHOLD. Maps a child's
+         * name to {normal-priority child, high-priority child} (either may be null).
+         * Kept in sync with `children`; reordering `children` does not invalidate it. */
+        std::unique_ptr<std::unordered_map<std::string, std::array<Node *, 2>>> childIndex;
 
-        explicit constexpr Node(std::string name) noexcept : name(std::move(name)) {}
+        explicit Node(std::string name) noexcept : name(std::move(name)) {}
+
+        Node *findChild(std::string_view childName, bool isHighPriority) const {
+            if (childIndex) {
+                auto it = childIndex->find(std::string(childName));
+                return it != childIndex->end() ? it->second[isHighPriority] : nullptr;
+            }
+            for (const std::unique_ptr<Node> &child : children) {
+                if (child->name == childName && child->isHighPriority == isHighPriority) {
+                    return child.get();
+                }
+            }
+            return nullptr;
+        }
+
+        /* Call after `child` has been inserted into `children`. */
+        void registerChild(Node *child) {
+            if (!childIndex) {
+                if (children.size() < CHILD_INDEX_THRESHOLD) {
+                    return;
+                }
+                childIndex = std::make_unique<std::unordered_map<std::string, std::array<Node *, 2>>>();
+                childIndex->reserve(children.size());
+                for (const std::unique_ptr<Node> &existing : children) {
+                    (*childIndex)[existing->name][existing->isHighPriority] = existing.get();
+                }
+                return;
+            }
+            (*childIndex)[child->name][child->isHighPriority] = child;
+        }
+
+        /* Call before `child` is erased from `children`. */
+        void unregisterChild(Node *child) {
+            if (!childIndex) {
+                return;
+            }
+            auto it = childIndex->find(child->name);
+            if (it == childIndex->end()) {
+                return;
+            }
+            if (it->second[child->isHighPriority] == child) {
+                it->second[child->isHighPriority] = nullptr;
+            }
+            if (!it->second[0] && !it->second[1]) {
+                childIndex->erase(it);
+            }
+        }
     } root {"rootNode"};
 
     /* Sort wildcards after alphanum */
@@ -79,22 +136,23 @@ private:
 
     /* Advance from parent to child, adding child if necessary */
     Node *getNode(Node *parent, std::string_view child, bool isHighPriority) {
-        for (const std::unique_ptr<Node> &node : parent->children) {
-            if (node->name == child && node->isHighPriority == isHighPriority) {
-                return node.get();
-            }
+        if (Node *existing = parent->findChild(child, isHighPriority)) {
+            return existing;
         }
 
         /* Insert sorted, but keep order if parent is root (we sort methods by priority elsewhere) */
         auto newNode = std::make_unique<Node>(std::string(child));
         newNode->isHighPriority = isHighPriority;
+        Node *newNodePtr = newNode.get();
         auto iter = std::upper_bound(parent->children.begin(), parent->children.end(), newNode, [parent, this](auto &a, auto &b) {
             if (a->isHighPriority != b->isHighPriority) {
                 return a->isHighPriority;
             }
             return !b->name.empty() && (parent != &root) && (lexicalOrder(b->name) < lexicalOrder(a->name));
         });
-        return parent->children.emplace(iter, std::move(newNode))->get();
+        parent->children.emplace(iter, std::move(newNode));
+        parent->registerChild(newNodePtr);
+        return newNodePtr;
     }
 
     /* Basically a pre-allocated stack */
@@ -213,14 +271,9 @@ private:
                 Node *n = node.get();
                 for (int i = 0; !getUrlSegment(i).second; i++) {
                     /* Go to next segment or quit */
-                    std::string segment(getUrlSegment(i).first);
-                    Node *next = nullptr;
-                    for (const std::unique_ptr<Node> &child : n->children) {
-                        if (((segment.starts_with(':') && child->name.starts_with(':')) || child->name == segment) && child->isHighPriority == (priority == HIGH_PRIORITY)) {
-                            next = child.get();
-                            break;
-                        }
-                    }
+                    std::string_view segment = getUrlSegment(i).first;
+                    /* add() strips parameter segments down to ":", so look that up directly */
+                    Node *next = n->findChild(segment.starts_with(':') ? std::string_view(":") : segment, priority == HIGH_PRIORITY);
                     if (!next) {
                         return UINT32_MAX;
                     }
@@ -345,6 +398,7 @@ public:
 
             /* If we have no children and no handlers, remove us from the parent->children list */
             if (!node->handlers.size() && !node->children.size()) {
+                parent->unregisterChild(node);
                 parent->children.erase(std::find_if(parent->children.begin(), parent->children.end(), [node](const std::unique_ptr<Node> &a) {
                     return a.get() == node;
                 }));

--- a/src/jsc/bindings/ServerRouteList.cpp
+++ b/src/jsc/bindings/ServerRouteList.cpp
@@ -100,7 +100,7 @@ private:
         : Base(vm, structure)
         , m_routes(callbacks.size())
         , m_paramsObjectStructures(paths.size())
-        , m_pathIdentifierRanges(paths.size() * 2)
+        , m_pathIdentifierRanges(paths.size())
     {
         ASSERT(callbacks.size() == paths.size());
     }

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -717,3 +717,86 @@ it("route precedence for mix of method-specific routes and any routes", async ()
     "POST /test/ANY/POST",
   );
 });
+
+// Once a router node has enough direct children, uWS builds a hash index over
+// them so registration stays O(n). This exercises that index end-to-end:
+// building it, matching static + parameterised siblings through it, and
+// maintaining it across reload() (which removes handlers and culls nodes).
+describe("many sibling routes", () => {
+  const N = 256;
+
+  function buildRoutes(prefix: string) {
+    const routes: Record<string, (req: any) => Response> = {};
+    // top-level siblings
+    for (let i = 0; i < N; i++) {
+      const body = `${prefix}top-${i}`;
+      routes[`/r${i}`] = () => new Response(body);
+    }
+    // nested siblings under a shared parent
+    for (let i = 0; i < N; i++) {
+      const body = `${prefix}nested-${i}`;
+      routes[`/api/r${i}`] = () => new Response(body);
+    }
+    // parameterised + wildcard siblings sitting next to the static ones
+    routes["/api/:id"] = req => new Response(`${prefix}param-${req.params.id}`);
+    routes["/api/:id/sub"] = req => new Response(`${prefix}paramsub-${req.params.id}`);
+    routes["/api/*"] = () => new Response(`${prefix}wild`);
+    return routes;
+  }
+
+  async function check(server: Server, prefix: string) {
+    // spot-check across the range so we cover first/last/middle insertions
+    for (const i of [0, 1, 15, 16, 17, N >> 1, N - 2, N - 1]) {
+      expect(await fetch(new URL(`/r${i}`, server.url)).then(r => r.text())).toBe(`${prefix}top-${i}`);
+      expect(await fetch(new URL(`/api/r${i}`, server.url)).then(r => r.text())).toBe(`${prefix}nested-${i}`);
+    }
+    // parameter route must still win over nothing and lose to exact match
+    expect(await fetch(new URL(`/api/r0`, server.url)).then(r => r.text())).toBe(`${prefix}nested-0`);
+    expect(await fetch(new URL(`/api/xyz`, server.url)).then(r => r.text())).toBe(`${prefix}param-xyz`);
+    expect(await fetch(new URL(`/api/xyz/sub`, server.url)).then(r => r.text())).toBe(`${prefix}paramsub-xyz`);
+    expect(await fetch(new URL(`/api/xyz/deep/er`, server.url)).then(r => r.text())).toBe(`${prefix}wild`);
+    expect(await fetch(new URL(`/unmatched`, server.url)).then(r => r.text())).toBe("fallback");
+  }
+
+  it("matches static, param and wildcard routes alongside many siblings", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: buildRoutes("a-"),
+      fetch: () => new Response("fallback"),
+    });
+    await check(server, "a-");
+  });
+
+  it("survives reload() replacing every route", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: buildRoutes("a-"),
+      fetch: () => new Response("fallback"),
+    });
+    await check(server, "a-");
+
+    // Replace every handler: exercises findHandler()/remove()/cullNode() on
+    // a node whose child index is populated, then re-registers through it.
+    server.reload({
+      routes: buildRoutes("b-"),
+      fetch: () => new Response("fallback"),
+    });
+    await check(server, "b-");
+
+    // Drop the nested siblings entirely so /api/:id must match what used to
+    // be exact hits, after their nodes were culled from the index.
+    const sparse: Record<string, (req: any) => Response> = {};
+    for (let i = 0; i < N; i++) {
+      const body = `c-top-${i}`;
+      sparse[`/r${i}`] = () => new Response(body);
+    }
+    sparse["/api/:id"] = req => new Response(`c-param-${req.params.id}`);
+    server.reload({ routes: sparse, fetch: () => new Response("fallback") });
+
+    expect(await fetch(new URL(`/r0`, server.url)).then(r => r.text())).toBe("c-top-0");
+    expect(await fetch(new URL(`/r${N - 1}`, server.url)).then(r => r.text())).toBe(`c-top-${N - 1}`);
+    expect(await fetch(new URL(`/api/r0`, server.url)).then(r => r.text())).toBe("c-param-r0");
+    expect(await fetch(new URL(`/api/r${N - 1}`, server.url)).then(r => r.text())).toBe(`c-param-r${N - 1}`);
+    expect(await fetch(new URL(`/unmatched`, server.url)).then(r => r.text())).toBe("fallback");
+  });
+});


### PR DESCRIPTION
## Summary

`Bun.serve({ routes })` startup grows as **O(n²)** with the route count when many routes share a parent path segment — thousands of `/api/<x>`-style routes, or many top-level routes, which is the common case. On a release build, 100k routes take ~17.6s and 40k take ~2.4s.

**Root cause:** in `packages/bun-uws/src/HttpRouter.h`, the trie-node lookup linear-scanned a parent's `children` vector for every route added — once in `getNode()`, and again in `findHandler()` (called from `remove()` at the top of every `add()`). A parent that ends up with N children means each insert is O(N) → O(N²) overall.

**Fix:** each node lazily builds a hash index over its children once it reaches 16 children; `getNode()`/`findHandler()` then do O(1) lookups. Request matching is unchanged — it still walks the ordered `children` vector, so exact-match / `:param` / wildcard precedence is identical. The index is only allocated for nodes with many children, so typical apps pay nothing extra.

Also fixes a small over-allocation in `ServerRouteList`: `m_pathIdentifierRanges` was sized `paths.size() * 2` but only `paths.size()` entries are ever written.

### Numbers

`Bun.serve({ routes })` startup, release build, best of 5 — `bench/snippets/serve-routes.mjs`:

| routes | before | after |
|---:|---:|---:|
| 1,000 | 3.9 ms | 0.7 ms |
| 5,000 | 42.0 ms | 3.1 ms |
| 10,000 | 168.3 ms | 5.9 ms |
| 20,000 | 513.8 ms | 11.4 ms |
| 40,000 | 2,376.8 ms | 22.9 ms |
| 100,000 | **17,588.9 ms** | **61.9 ms** |
| 200,000 | — | 121.5 ms |
| 500,000 | — | 345.3 ms |
| 1,000,000 | — | 760.1 ms |

Before is textbook O(n²) (10× the routes ≈ 100× the time); after is linear.

## Test plan

- [ ] `bun test test/js/bun/http/bun-serve-routes.test.ts` passes
- [ ] `:param` routes still resolve (`/u/:id`, `/x/:a/:b`) and non-matching paths 404
- [ ] `bun bench/snippets/serve-routes.mjs` shows linear scaling
- [ ] CI green