### PR TITLE
repl: inline ghost-text suggestions for symbol autocomplete

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6797,6 +6797,7 @@ extern "C" JSC::EncodedJSValue Bun__REPL__getCompletions(
         ? WTF::String::fromUTF8(std::span { prefixPtr, prefixLen })
         : WTF::String();
 
+    // getPropertyNames already walks (and dedups) the prototype chain, throwing past maximumPrototypeChainDepth.
     JSC::JSObject* object = target.getObject();
     JSC::PropertyNameArrayBuilder propertyNames(vm, JSC::PropertyNameMode::Strings, JSC::PrivateSymbolMode::Exclude);
     object->getPropertyNames(globalObject, propertyNames, DontEnumPropertiesMode::Include);
@@ -6815,32 +6816,6 @@ extern "C" JSC::EncodedJSValue Bun__REPL__getCompletions(
             if (scope.exception()) [[unlikely]]
                 return clearAndEncode(JSC::jsUndefined());
         }
-    }
-
-    // Also check the prototype chain
-    JSC::JSValue proto = object->getPrototype(globalObject);
-    if (scope.exception()) [[unlikely]]
-        return clearAndEncode(completions);
-
-    while (proto && proto.isObject()) {
-        JSC::JSObject* protoObj = proto.getObject();
-        JSC::PropertyNameArrayBuilder protoNames(vm, JSC::PropertyNameMode::Strings, JSC::PrivateSymbolMode::Exclude);
-        protoObj->getPropertyNames(globalObject, protoNames, DontEnumPropertiesMode::Include);
-        if (scope.exception()) [[unlikely]]
-            return clearAndEncode(completions);
-
-        for (const auto& propertyName : protoNames) {
-            WTF::String name = propertyName.string();
-            if (prefix.isEmpty() || name.startsWith(prefix)) {
-                completions->putDirectIndex(globalObject, completionIndex++, JSC::jsString(vm, name));
-                if (scope.exception()) [[unlikely]]
-                    return clearAndEncode(completions);
-            }
-        }
-
-        proto = protoObj->getPrototype(globalObject);
-        if (scope.exception()) [[unlikely]]
-            return clearAndEncode(completions);
     }
 
     return JSC::JSValue::encode(completions);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6821,6 +6821,31 @@ extern "C" JSC::EncodedJSValue Bun__REPL__getCompletions(
     return JSC::JSValue::encode(completions);
 }
 
+// One `object.name` step of a completion chain, with ordinary property semantics (whole prototype
+// chain, getters run). `name` is UTF-8. A missing property or a throwing getter yields undefined.
+extern "C" JSC::EncodedJSValue Bun__REPL__getProperty(
+    JSC::JSGlobalObject* globalObject,
+    JSC::EncodedJSValue objectValue,
+    const unsigned char* namePtr,
+    size_t nameLen)
+{
+    auto& vm = JSC::getVM(globalObject);
+    // As in Bun__REPL__getCompletions: the Rust caller has no exception scope.
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+
+    JSC::JSObject* object = JSC::JSValue::decode(objectValue).getObject();
+    WTF::String name = WTF::String::fromUTF8(std::span { namePtr, nameLen });
+    if (!object || name.isNull())
+        return JSC::JSValue::encode(JSC::jsUndefined());
+
+    JSC::JSValue result = object->getIfPropertyExists(globalObject, JSC::Identifier::fromString(vm, name));
+    if (scope.exception()) [[unlikely]] {
+        scope.clearException();
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+    return JSC::JSValue::encode(result ? result : JSC::jsUndefined());
+}
+
 // Format a value for REPL output using util.inspect style
 extern "C" JSC::EncodedJSValue Bun__REPL__formatValue(
     JSC::JSGlobalObject* globalObject,

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6774,9 +6774,7 @@ extern "C" JSC::EncodedJSValue Bun__REPL__getCompletions(
     size_t prefixLen)
 {
     auto& vm = JSC::getVM(globalObject);
-    // This is an FFI boundary called from Rust (repl.rs) without JSError
-    // propagation, so use a top-level scope and swallow any exception locally
-    // rather than letting it escape to a caller that has no scope to check it.
+    // The Rust caller (repl.rs) has no exception scope, so nothing may escape.
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto clearAndEncode = [&](JSC::JSValue v) {
         scope.clearException();

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6774,7 +6774,14 @@ extern "C" JSC::EncodedJSValue Bun__REPL__getCompletions(
     size_t prefixLen)
 {
     auto& vm = JSC::getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
+    // This is an FFI boundary called from Rust (repl.rs) without JSError
+    // propagation, so use a top-level scope and swallow any exception locally
+    // rather than letting it escape to a caller that has no scope to check it.
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto clearAndEncode = [&](JSC::JSValue v) {
+        scope.clearException();
+        return JSC::JSValue::encode(v);
+    };
 
     JSC::JSValue target = JSC::JSValue::decode(targetValue);
     if (!target || target.isUndefined() || target.isNull()) {
@@ -6783,7 +6790,8 @@ extern "C" JSC::EncodedJSValue Bun__REPL__getCompletions(
 
     if (!target.isObject()) {
         JSObject* boxed = target.toObject(globalObject);
-        RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(JSC::jsUndefined()));
+        if (scope.exception()) [[unlikely]]
+            return clearAndEncode(JSC::jsUndefined());
         target = boxed;
     }
 
@@ -6794,40 +6802,47 @@ extern "C" JSC::EncodedJSValue Bun__REPL__getCompletions(
     JSC::JSObject* object = target.getObject();
     JSC::PropertyNameArrayBuilder propertyNames(vm, JSC::PropertyNameMode::Strings, JSC::PrivateSymbolMode::Exclude);
     object->getPropertyNames(globalObject, propertyNames, DontEnumPropertiesMode::Include);
-    RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(JSC::jsUndefined()));
+    if (scope.exception()) [[unlikely]]
+        return clearAndEncode(JSC::jsUndefined());
 
     JSC::JSArray* completions = JSC::constructEmptyArray(globalObject, nullptr, 0);
-    RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(JSC::jsUndefined()));
+    if (scope.exception()) [[unlikely]]
+        return clearAndEncode(JSC::jsUndefined());
 
     unsigned completionIndex = 0;
     for (const auto& propertyName : propertyNames) {
         WTF::String name = propertyName.string();
         if (prefix.isEmpty() || name.startsWith(prefix)) {
             completions->putDirectIndex(globalObject, completionIndex++, JSC::jsString(vm, name));
-            RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(JSC::jsUndefined()));
+            if (scope.exception()) [[unlikely]]
+                return clearAndEncode(JSC::jsUndefined());
         }
     }
 
     // Also check the prototype chain
     JSC::JSValue proto = object->getPrototype(globalObject);
-    RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(completions));
+    if (scope.exception()) [[unlikely]]
+        return clearAndEncode(completions);
 
     while (proto && proto.isObject()) {
         JSC::JSObject* protoObj = proto.getObject();
         JSC::PropertyNameArrayBuilder protoNames(vm, JSC::PropertyNameMode::Strings, JSC::PrivateSymbolMode::Exclude);
         protoObj->getPropertyNames(globalObject, protoNames, DontEnumPropertiesMode::Include);
-        RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(completions));
+        if (scope.exception()) [[unlikely]]
+            return clearAndEncode(completions);
 
         for (const auto& propertyName : protoNames) {
             WTF::String name = propertyName.string();
             if (prefix.isEmpty() || name.startsWith(prefix)) {
                 completions->putDirectIndex(globalObject, completionIndex++, JSC::jsString(vm, name));
-                RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(completions));
+                if (scope.exception()) [[unlikely]]
+                    return clearAndEncode(completions);
             }
         }
 
         proto = protoObj->getPrototype(globalObject);
-        RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(completions));
+        if (scope.exception()) [[unlikely]]
+            return clearAndEncode(completions);
     }
 
     return JSC::JSValue::encode(completions);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6821,10 +6821,10 @@ extern "C" JSC::EncodedJSValue Bun__REPL__getCompletions(
     return JSC::JSValue::encode(completions);
 }
 
-// One `object.name` step of a completion chain: ordinary property semantics (prototype chain, getters run), UTF-8 name; a miss or a throwing getter yields undefined.
+// One `base.name` step of a completion chain: ordinary property semantics (primitives boxed, prototype chain, getters run), UTF-8 name; a miss or a throwing getter yields undefined.
 extern "C" JSC::EncodedJSValue Bun__REPL__getProperty(
     JSC::JSGlobalObject* globalObject,
-    JSC::EncodedJSValue objectValue,
+    JSC::EncodedJSValue baseValue,
     const unsigned char* namePtr,
     size_t nameLen)
 {
@@ -6832,10 +6832,16 @@ extern "C" JSC::EncodedJSValue Bun__REPL__getProperty(
     // As in Bun__REPL__getCompletions: the Rust caller has no exception scope.
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
-    JSC::JSObject* object = JSC::JSValue::decode(objectValue).getObject();
+    JSC::JSValue base = JSC::JSValue::decode(baseValue);
     WTF::String name = WTF::String::fromUTF8(std::span { namePtr, nameLen });
-    if (!object || name.isNull())
+    if (!base || base.isUndefinedOrNull() || name.isNull())
         return JSC::JSValue::encode(JSC::jsUndefined());
+
+    JSC::JSObject* object = base.toObject(globalObject);
+    if (scope.exception()) [[unlikely]] {
+        scope.clearException();
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
 
     JSC::JSValue result = object->getIfPropertyExists(globalObject, JSC::Identifier::fromString(vm, name));
     if (scope.exception()) [[unlikely]] {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6821,8 +6821,7 @@ extern "C" JSC::EncodedJSValue Bun__REPL__getCompletions(
     return JSC::JSValue::encode(completions);
 }
 
-// One `object.name` step of a completion chain, with ordinary property semantics (whole prototype
-// chain, getters run). `name` is UTF-8. A missing property or a throwing getter yields undefined.
+// One `object.name` step of a completion chain: ordinary property semantics (prototype chain, getters run), UTF-8 name; a miss or a throwing getter yields undefined.
 extern "C" JSC::EncodedJSValue Bun__REPL__getProperty(
     JSC::JSGlobalObject* globalObject,
     JSC::EncodedJSValue objectValue,

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -167,7 +167,7 @@ CPP_DECL void JSC__JSFunction__optimizeSoon(JSC::EncodedJSValue JSValue0);
 
 CPP_DECL JSC::EncodedJSValue Bun__REPL__evaluate(JSC::JSGlobalObject* globalObject, const unsigned char* sourcePtr, size_t sourceLen, const unsigned char* filenamePtr, size_t filenameLen, JSC::EncodedJSValue* exception);
 CPP_DECL JSC::EncodedJSValue Bun__REPL__getCompletions(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue targetValue, const unsigned char* prefixPtr, size_t prefixLen);
-CPP_DECL JSC::EncodedJSValue Bun__REPL__getProperty(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue objectValue, const unsigned char* namePtr, size_t nameLen);
+CPP_DECL JSC::EncodedJSValue Bun__REPL__getProperty(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue baseValue, const unsigned char* namePtr, size_t nameLen);
 CPP_DECL JSC::EncodedJSValue Bun__REPL__formatValue(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue valueEncoded, int32_t depth, bool colors);
 
 #pragma mark - JSC::JSGlobalObject

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -167,6 +167,7 @@ CPP_DECL void JSC__JSFunction__optimizeSoon(JSC::EncodedJSValue JSValue0);
 
 CPP_DECL JSC::EncodedJSValue Bun__REPL__evaluate(JSC::JSGlobalObject* globalObject, const unsigned char* sourcePtr, size_t sourceLen, const unsigned char* filenamePtr, size_t filenameLen, JSC::EncodedJSValue* exception);
 CPP_DECL JSC::EncodedJSValue Bun__REPL__getCompletions(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue targetValue, const unsigned char* prefixPtr, size_t prefixLen);
+CPP_DECL JSC::EncodedJSValue Bun__REPL__getProperty(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue objectValue, const unsigned char* namePtr, size_t nameLen);
 CPP_DECL JSC::EncodedJSValue Bun__REPL__formatValue(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue valueEncoded, int32_t depth, bool colors);
 
 #pragma mark - JSC::JSGlobalObject

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -1304,7 +1304,11 @@ impl<'a> Repl<'a> {
         }
 
         let mut current = global.to_js_value();
-        for part in strings::split(expr, b".") {
+        for (index, part) in strings::split(expr, b".").enumerate() {
+            // Top-level `this` evaluates to globalThis in the REPL, which is where the walk starts.
+            if index == 0 && part == b"this" {
+                continue;
+            }
             if !identifier::is_identifier(part) || !current.is_object() {
                 return JSValue::UNDEFINED;
             }
@@ -2810,8 +2814,11 @@ fn parse_completion_context(line: &[u8], cursor: usize) -> Option<CompletionCont
     let prefix_start = i;
     let prefix = &line[prefix_start..cursor];
 
-    // `..` before the word is the tail of a spread (`[...args`), not member access.
-    if i == 0 || line[i - 1] != b'.' || (i >= 2 && line[i - 2] == b'.') {
+    // A `..` ending at `end` is the tail of a spread (`[...args`, `[...a.b`), not member access.
+    let member_dot_ends_at =
+        |end: usize| end >= 1 && line[end - 1] == b'.' && (end < 2 || line[end - 2] != b'.');
+
+    if !member_dot_ends_at(i) {
         return Some(CompletionContext {
             object_expr: b"",
             prefix,
@@ -2829,7 +2836,7 @@ fn parse_completion_context(line: &[u8], cursor: usize) -> Option<CompletionCont
         if i == ident_end {
             return None;
         }
-        if i == 0 || line[i - 1] != b'.' {
+        if !member_dot_ends_at(i) {
             break;
         }
         i -= 1;

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -54,6 +54,13 @@ unsafe extern "C" {
         prefixPtr: *const u8,
         prefixLen: usize,
     ) -> JSValue;
+
+    fn Bun__REPL__getProperty(
+        globalObject: *const JSGlobalObject,
+        objectValue: JSValue,
+        namePtr: *const u8,
+        nameLen: usize,
+    ) -> JSValue;
 }
 
 // ============================================================================
@@ -1301,14 +1308,9 @@ impl<'a> Repl<'a> {
             if !identifier::is_identifier(part) || !current.is_object() {
                 return JSValue::UNDEFINED;
             }
-            match current.get(global, part) {
-                Ok(Some(next)) => current = next,
-                Ok(None) => return JSValue::UNDEFINED,
-                Err(_) => {
-                    global.clear_exception();
-                    return JSValue::UNDEFINED;
-                }
-            }
+            // SAFETY: `global` is a live opaque `JSGlobalObject` handle; `part` borrows
+            // from `expr`, which outlives the call.
+            current = unsafe { Bun__REPL__getProperty(global, current, part.as_ptr(), part.len()) };
         }
         current
     }
@@ -1334,7 +1336,7 @@ impl<'a> Repl<'a> {
         let Some(ctx) = parse_completion_context(&line, self.line_editor.cursor) else {
             return;
         };
-        if ctx.prefix.is_empty() && ctx.object_expr.is_empty() {
+        if (ctx.prefix.is_empty() && ctx.object_expr.is_empty()) || ends_inside_string(&line) {
             return;
         }
 
@@ -2772,6 +2774,26 @@ const JS_KEYWORDS: &[&[u8]] = &[
     b"yield",
 ];
 
+/// Words inside a `'…'`, `"…"` or backtick literal are not identifiers, so hinting there is noise.
+fn ends_inside_string(line: &[u8]) -> bool {
+    let mut quote = 0u8;
+    let mut escaped = false;
+    for &c in line {
+        if escaped {
+            escaped = false;
+        } else if c == b'\\' {
+            escaped = true;
+        } else if quote != 0 {
+            if c == quote {
+                quote = 0;
+            }
+        } else if matches!(c, b'"' | b'\'' | b'`') {
+            quote = c;
+        }
+    }
+    quote != 0
+}
+
 /// `console.lo|` → `object_expr = "console"`, `prefix = "lo"`; empty `object_expr` = globalThis.
 struct CompletionContext<'a> {
     object_expr: &'a [u8],
@@ -2788,7 +2810,8 @@ fn parse_completion_context(line: &[u8], cursor: usize) -> Option<CompletionCont
     let prefix_start = i;
     let prefix = &line[prefix_start..cursor];
 
-    if i == 0 || line[i - 1] != b'.' {
+    // `..` before the word is the tail of a spread (`[...args`), not member access.
+    if i == 0 || line[i - 1] != b'.' || (i >= 2 && line[i - 2] == b'.') {
         return Some(CompletionContext {
             object_expr: b"",
             prefix,

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -849,9 +849,7 @@ pub(super) struct Repl<'a> {
     history: History,
     multiline_buffer: Vec<u8>,
     editor_buffer: Vec<u8>,
-    /// Ghost text shown dimmed after the cursor (the *remainder* to append,
-    /// not the full word). Empty when no suggestion is available. Only
-    /// rendered when the cursor is at end-of-line and colors are enabled.
+    /// Remainder of the current inline completion (not the full word); empty when none.
     suggestion: Vec<u8>,
 
     // State
@@ -1254,11 +1252,7 @@ impl<'a> Repl<'a> {
             self.write(line);
         }
 
-        // Write the inline ghost suggestion after the typed text. Only shown
-        // when the cursor is at end-of-line so it visually continues the
-        // input. Width-fit is enforced in update_suggestion(), so anything
-        // stored here is guaranteed to render on the current row — keeping
-        // render/accept in sync.
+        // Ghost text; update_suggestion() already guarantees it fits on this row.
         if !self.suggestion.is_empty()
             && self.use_colors
             && self.line_editor.cursor == self.line_editor.buffer.len()
@@ -1293,11 +1287,8 @@ impl<'a> Repl<'a> {
     // Inline Suggestions (ghost text)
     // ========================================================================
 
-    /// Resolve a dotted identifier chain like `process.env` starting from
-    /// globalThis by walking own/prototype properties. Returns `UNDEFINED`
-    /// on any failure. Deliberately avoids the REPL evaluator so `_`/`_error`
-    /// are untouched; getters on the chain may still run (matching Node's
-    /// REPL).
+    /// Walk `a.b.c` from globalThis via property gets (not the evaluator, so `_` is
+    /// untouched). `UNDEFINED` on any failure.
     fn resolve_object_expr(&self, expr: &[u8]) -> JSValue {
         let Some(global) = self.global else {
             return JSValue::UNDEFINED;
@@ -1326,8 +1317,6 @@ impl<'a> Repl<'a> {
         current
     }
 
-    /// Recompute the inline ghost suggestion for the current editor state.
-    /// Stores only the remainder (text to append) in `self.suggestion`.
     fn update_suggestion(&mut self) {
         self.suggestion.clear();
 
@@ -1338,8 +1327,6 @@ impl<'a> Repl<'a> {
             return;
         }
 
-        // Only suggest when the cursor is at end-of-line; mid-line ghost text
-        // is confusing to render correctly.
         let line: Vec<u8> = self.line_editor.get_line().to_vec();
         if self.line_editor.cursor != line.len() {
             return;
@@ -1365,9 +1352,8 @@ impl<'a> Repl<'a> {
             }
         }
 
-        // SAFETY: `global` is a live opaque handle; `ctx.prefix` is valid for
-        // the duration of the call. The C++ side uses a TopExceptionScope and
-        // clears any exception before returning, so nothing escapes here.
+        // SAFETY: `global` is a live opaque `JSGlobalObject` handle; the prefix ptr/len
+        // pair is valid for the duration of the call.
         let completions = unsafe {
             Bun__REPL__getCompletions(global, target, ctx.prefix.as_ptr(), ctx.prefix.len())
         };
@@ -1405,10 +1391,9 @@ impl<'a> Repl<'a> {
                     continue;
                 }
                 if !is_dot_accessible(name) {
-                    continue; // skip keys that can't follow `.`
+                    continue;
                 }
                 if ctx.prefix.is_empty() {
-                    // `obj.` with no prefix: just offer the first reasonable key.
                     self.suggestion.clear();
                     self.suggestion.extend_from_slice(name);
                     break;
@@ -1421,7 +1406,6 @@ impl<'a> Repl<'a> {
             }
         }
 
-        // Fallback: suggest a JS keyword in global context.
         if self.suggestion.is_empty() && ctx.object_expr.is_empty() && !ctx.prefix.is_empty() {
             for &kw in JS_KEYWORDS {
                 if kw.len() > ctx.prefix.len() && kw.starts_with(ctx.prefix) && kw.len() < best_len
@@ -1433,13 +1417,8 @@ impl<'a> Repl<'a> {
             }
         }
 
-        // Drop the suggestion if rendering it would wrap past the terminal
-        // width — wrapping would make refresh_line()'s `\r`+CUF cursor restore
-        // land on the wrong row. Enforcing it here (not just at render time)
-        // keeps acceptance in sync: Tab/Right/End can never apply a
-        // suggestion the user didn't see. The line's display width can differ
-        // from its byte length (multi-byte/wide chars); the suggestion itself
-        // is always ASCII so its byte length is its width.
+        // A wrapped ghost would put refresh_line()'s cursor restore on the wrong row;
+        // dropping it here (not at render) also keeps accept in sync with what's shown.
         if !self.suggestion.is_empty() {
             let line_width = strings::visible::width::exclude_ansi_colors::utf8(&line);
             if self.get_prompt_length() + line_width + self.suggestion.len()
@@ -1450,18 +1429,23 @@ impl<'a> Repl<'a> {
         }
     }
 
-    /// Insert the current suggestion into the line buffer. Returns true if a
-    /// suggestion was accepted.
     fn accept_suggestion(&mut self) -> bool {
         if self.suggestion.is_empty() {
             return false;
         }
         let sugg = core::mem::take(&mut self.suggestion);
         let ok = self.line_editor.insert_slice(&sugg).is_ok();
-        // Keep the Vec's capacity for reuse.
         self.suggestion = sugg;
         self.suggestion.clear();
         ok
+    }
+
+    /// Clear the suggestion and wipe any ghost text already drawn past the cursor.
+    fn erase_suggestion(&mut self) {
+        if !self.suggestion.is_empty() {
+            self.write(Cursor::CLEAR_TO_END.as_bytes());
+            self.suggestion.clear();
+        }
     }
 
     fn write_highlighted(&self, text: &[u8]) {
@@ -2293,16 +2277,12 @@ impl<'a> Repl<'a> {
                     self.refresh_line();
                 }
                 Key::CtrlF | Key::ArrowRight => {
-                    // At end-of-line with a visible suggestion, Right accepts
-                    // it (fish/node-style). Otherwise it moves the cursor.
-                    if self.line_editor.cursor == self.line_editor.buffer.len()
-                        && self.accept_suggestion()
+                    if self.line_editor.cursor != self.line_editor.buffer.len()
+                        || !self.accept_suggestion()
                     {
-                        self.update_suggestion();
-                    } else {
                         self.line_editor.move_right();
-                        self.update_suggestion();
                     }
+                    self.update_suggestion();
                     self.refresh_line();
                 }
                 Key::AltB | Key::AltLeft => {
@@ -2403,12 +2383,7 @@ impl<'a> Repl<'a> {
     }
 
     fn handle_enter(&mut self) -> Result<(), crate::Error> {
-        // Erase any rendered ghost text past the cursor so the submitted
-        // line shows only what was actually typed.
-        if !self.suggestion.is_empty() {
-            self.write(Cursor::CLEAR_TO_END.as_bytes());
-        }
-        self.suggestion.clear();
+        self.erase_suggestion();
         self.print(format_args!("\n"));
 
         // Note: reshaped for borrowck — copy line out so we can call &mut self methods
@@ -2514,10 +2489,7 @@ impl<'a> Repl<'a> {
     }
 
     fn handle_ctrl_c(&mut self) {
-        if !self.suggestion.is_empty() {
-            self.write(Cursor::CLEAR_TO_END.as_bytes());
-        }
-        self.suggestion.clear();
+        self.erase_suggestion();
         match self.input_mode {
             InputMode::Editor => {
                 self.print(format_args!(
@@ -2557,7 +2529,6 @@ impl<'a> Repl<'a> {
     }
 
     fn handle_tab(&mut self) {
-        // If a ghost suggestion is showing, Tab accepts it.
         if !self.suggestion.is_empty() && self.line_editor.cursor == self.line_editor.buffer.len() {
             self.accept_suggestion();
             self.update_suggestion();
@@ -2608,18 +2579,12 @@ impl<'a> Repl<'a> {
 
         let cursor = self.line_editor.cursor;
 
-        // Don't complete when the cursor is in the middle of an identifier —
-        // replacing only the left half would duplicate the right half (e.g.
-        // `con|sole` + Tab -> `consolesole`). Do nothing rather than insert
-        // whitespace here: every other indent-fallback in this function runs
-        // with the cursor at/after a token boundary, but this branch is by
-        // definition inside one, and injecting spaces would split it.
+        // Mid-identifier (`con|sole`): completing would duplicate the suffix.
         if cursor < line.len() && is_ident_part(line[cursor]) {
             self.refresh_line();
             return;
         }
 
-        // Parse the completion context at the cursor (handles `obj.prop` chains).
         let ctx = parse_completion_context(&line, cursor);
         let word_start = ctx.prefix_start;
         let prefix = ctx.prefix;
@@ -2628,7 +2593,6 @@ impl<'a> Repl<'a> {
         if !ctx.object_expr.is_empty() {
             target = self.resolve_object_expr(ctx.object_expr);
             if target.is_undefined_or_null() {
-                // Couldn't resolve the object; just indent.
                 let _ = self.line_editor.insert(b' ');
                 let _ = self.line_editor.insert(b' ');
                 self.refresh_line();
@@ -2636,7 +2600,6 @@ impl<'a> Repl<'a> {
             }
         }
 
-        // Get completions from the target (or global object if target is undefined).
         // SAFETY: `global` is a live opaque `JSGlobalObject` handle; `prefix` ptr/len
         // are valid for the duration of the call.
         let completions =
@@ -2682,11 +2645,7 @@ impl<'a> Repl<'a> {
                     }
                 };
                 let completion = slice.slice();
-                // Only insert if the result is a valid dot-access identifier;
-                // e.g. a sole `"foo-bar"` key would otherwise produce
-                // `obj.foo-bar` which parses as subtraction.
                 if is_dot_accessible(completion) {
-                    // Replace the prefix with the completion
                     while self.line_editor.cursor > word_start {
                         self.line_editor.backspace();
                     }
@@ -2778,9 +2737,6 @@ fn is_ident_start(c: u8) -> bool {
     c.is_ascii_alphabetic() || c == b'_' || c == b'$'
 }
 
-/// True if `name` is safe to insert after a `.` — i.e. a plain ASCII
-/// identifier. Rejects keys like `"foo-bar"` or `"a b"` whose first byte
-/// passes `is_ident_start` but which would not parse as dot-access.
 fn is_dot_accessible(name: &[u8]) -> bool {
     match name.first() {
         Some(&c) if is_ident_start(c) => name[1..].iter().all(|&c| is_ident_part(c)),
@@ -2788,8 +2744,7 @@ fn is_dot_accessible(name: &[u8]) -> bool {
     }
 }
 
-/// Common JS keywords offered as fallback suggestions in global context when
-/// no matching global property exists (e.g. `fun` -> `function`).
+/// Fallback suggestions when no global matches the prefix.
 const JS_KEYWORDS: &[&[u8]] = &[
     b"async",
     b"await",
@@ -2830,19 +2785,16 @@ const JS_KEYWORDS: &[&[u8]] = &[
     b"yield",
 ];
 
+/// For `console.lo|`: `object_expr = "console"`, `prefix = "lo"`. An empty
+/// `object_expr` means complete against globalThis.
 struct CompletionContext<'a> {
-    /// Dotted object expression before the final `.`, e.g. `b"console"` for
-    /// input `console.lo|`. Empty means complete against globalThis.
     object_expr: &'a [u8],
-    /// Trailing identifier fragment being typed, e.g. `b"lo"` for `console.lo|`.
     prefix: &'a [u8],
-    /// Byte offset in `line` where `prefix` begins.
     prefix_start: usize,
 }
 
-/// Parse backward from `cursor` to determine what is being completed.
-/// Only recognises simple `ident(.ident)*` chains; anything fancier (calls,
-/// indexing, optional chaining) falls back to completing `prefix` on global.
+/// Only recognises `ident(.ident)*` before the cursor; anything else (calls,
+/// indexing, `?.`) degrades to global completion of the bare prefix.
 fn parse_completion_context(line: &[u8], cursor: usize) -> CompletionContext<'_> {
     let mut i = cursor;
     while i > 0 && is_ident_part(line[i - 1]) {
@@ -2867,8 +2819,7 @@ fn parse_completion_context(line: &[u8], cursor: usize) -> CompletionContext<'_>
             i -= 1;
         }
         if i == ident_end {
-            // No identifier before the dot (e.g. `(expr).foo`) — can't safely
-            // resolve, so treat as global completion of the bare prefix.
+            // e.g. `(expr).foo`
             return CompletionContext {
                 object_expr: b"",
                 prefix,

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -57,7 +57,7 @@ unsafe extern "C" {
 
     fn Bun__REPL__getProperty(
         globalObject: *const JSGlobalObject,
-        objectValue: JSValue,
+        baseValue: JSValue,
         namePtr: *const u8,
         nameLen: usize,
     ) -> JSValue;
@@ -1309,7 +1309,7 @@ impl<'a> Repl<'a> {
             if index == 0 && part == b"this" {
                 continue;
             }
-            if !identifier::is_identifier(part) || !current.is_object() {
+            if !identifier::is_identifier(part) || current.is_undefined_or_null() {
                 return JSValue::UNDEFINED;
             }
             // SAFETY: `global` is a live opaque `JSGlobalObject` handle; `part` borrows
@@ -2585,6 +2585,10 @@ impl<'a> Repl<'a> {
         };
 
         let cursor = self.line_editor.cursor;
+        if ends_inside_string(&line[..cursor]) {
+            self.insert_tab_spaces();
+            return;
+        }
 
         // Mid-identifier (`con|sole`): completing would duplicate the suffix.
         if cursor < line.len() && is_word_byte(line[cursor]) {
@@ -2778,7 +2782,7 @@ const JS_KEYWORDS: &[&[u8]] = &[
     b"yield",
 ];
 
-/// Words inside a `'…'`, `"…"` or backtick literal are not identifiers, so hinting there is noise.
+/// Words inside a `'…'`, `"…"` or backtick literal are not identifiers, so completing them is noise.
 fn ends_inside_string(line: &[u8]) -> bool {
     let mut quote = 0u8;
     let mut escaped = false;

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -1340,7 +1340,7 @@ impl<'a> Repl<'a> {
         let Some(ctx) = parse_completion_context(&line, self.line_editor.cursor) else {
             return;
         };
-        if (ctx.prefix.is_empty() && ctx.object_expr.is_empty()) || ends_inside_string(&line) {
+        if (ctx.prefix.is_empty() && ctx.object_expr.is_empty()) || ends_inside_string(&[&line]) {
             return;
         }
 
@@ -2585,7 +2585,13 @@ impl<'a> Repl<'a> {
         };
 
         let cursor = self.line_editor.cursor;
-        if ends_inside_string(&line[..cursor]) {
+        // A template literal may have been opened on an earlier line of this input.
+        let earlier_lines: &[u8] = match self.input_mode {
+            InputMode::Normal => b"",
+            InputMode::Multiline => &self.multiline_buffer,
+            InputMode::Editor => &self.editor_buffer,
+        };
+        if ends_inside_string(&[earlier_lines, &line[..cursor]]) {
             self.insert_tab_spaces();
             return;
         }
@@ -2782,21 +2788,47 @@ const JS_KEYWORDS: &[&[u8]] = &[
     b"yield",
 ];
 
-/// Words inside a `'…'`, `"…"` or backtick literal are not identifiers, so completing them is noise.
-fn ends_inside_string(line: &[u8]) -> bool {
+/// Text ends inside string/template content, where completing is noise; `${…}` holes hold code.
+fn ends_inside_string(parts: &[&[u8]]) -> bool {
     let mut quote = 0u8;
-    let mut escaped = false;
-    for &c in line {
-        if escaped {
-            escaped = false;
-        } else if c == b'\\' {
-            escaped = true;
-        } else if quote != 0 {
-            if c == quote {
-                quote = 0;
+    // Unclosed-brace count of each `${` hole being scanned, innermost last.
+    let mut holes: Vec<u32> = Vec::new();
+    for part in parts {
+        let mut i = 0;
+        while i < part.len() {
+            let c = part[i];
+            i += 1;
+            if quote != 0 {
+                match c {
+                    b'\\' => i += 1,
+                    b'$' if quote == b'`' && part.get(i) == Some(&b'{') => {
+                        i += 1;
+                        holes.push(1);
+                        quote = 0;
+                    }
+                    _ if c == quote => quote = 0,
+                    _ => {}
+                }
+            } else {
+                match c {
+                    b'"' | b'\'' | b'`' => quote = c,
+                    b'{' => {
+                        if let Some(depth) = holes.last_mut() {
+                            *depth += 1;
+                        }
+                    }
+                    b'}' => {
+                        if let Some(depth) = holes.last_mut() {
+                            *depth -= 1;
+                            if *depth == 0 {
+                                holes.pop();
+                                quote = b'`';
+                            }
+                        }
+                    }
+                    _ => {}
+                }
             }
-        } else if matches!(c, b'"' | b'\'' | b'`') {
-            quote = c;
         }
     }
     quote != 0

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -74,6 +74,7 @@ struct Cursor;
 impl Cursor {
     const HOME: &'static str = concat!("\x1b", "[", "H");
     const CLEAR_LINE: &'static str = concat!("\x1b", "[", "2K");
+    const CLEAR_TO_END: &'static str = concat!("\x1b", "[", "0K");
     const CLEAR_SCREEN: &'static str = concat!("\x1b", "[", "2J");
     const CLEAR_SCROLLBACK: &'static str = concat!("\x1b", "[", "3J");
 }
@@ -656,7 +657,12 @@ fn cmd_help(repl: &mut Repl, _: &[u8]) -> ReplResult {
         Color::RESET
     ));
     repl.print(format_args!(
-        "  {}Tab{}          Auto-complete\n",
+        "  {}Tab{}          Auto-complete / accept suggestion\n",
+        Color::CYAN,
+        Color::RESET
+    ));
+    repl.print(format_args!(
+        "  {}Right/End{}    Accept inline suggestion\n",
         Color::CYAN,
         Color::RESET
     ));
@@ -797,6 +803,7 @@ fn cmd_editor(repl: &mut Repl, _: &[u8]) -> ReplResult {
 fn cmd_break(repl: &mut Repl, _: &[u8]) -> ReplResult {
     repl.line_editor.clear();
     repl.multiline_buffer.clear();
+    repl.suggestion.clear();
     repl.input_mode = InputMode::Normal;
     ReplResult::SkipEval
 }
@@ -842,6 +849,10 @@ pub(super) struct Repl<'a> {
     history: History,
     multiline_buffer: Vec<u8>,
     editor_buffer: Vec<u8>,
+    /// Ghost text shown dimmed after the cursor (the *remainder* to append,
+    /// not the full word). Empty when no suggestion is available. Only
+    /// rendered when the cursor is at end-of-line and colors are enabled.
+    suggestion: Vec<u8>,
 
     // State
     input_mode: InputMode,
@@ -882,6 +893,7 @@ impl<'a> Repl<'a> {
             history: History::init(),
             multiline_buffer: Vec::new(),
             editor_buffer: Vec::new(),
+            suggestion: Vec::new(),
             input_mode: InputMode::Normal,
             running: false,
             is_tty: false,
@@ -1242,6 +1254,20 @@ impl<'a> Repl<'a> {
             self.write(line);
         }
 
+        // Write the inline ghost suggestion after the typed text. Only shown
+        // when the cursor is at end-of-line so it visually continues the
+        // input. Width-fit is enforced in update_suggestion(), so anything
+        // stored here is guaranteed to render on the current row — keeping
+        // render/accept in sync.
+        if !self.suggestion.is_empty()
+            && self.use_colors
+            && self.line_editor.cursor == self.line_editor.buffer.len()
+        {
+            self.write(Color::DIM.as_bytes());
+            self.write(&self.suggestion);
+            self.write(Color::RESET.as_bytes());
+        }
+
         // Position cursor. The cursor is a byte offset, but the terminal column
         // is the display width of the text before it, so multi-byte UTF-8 and
         // wide (e.g. CJK) characters advance the column correctly.
@@ -1261,6 +1287,181 @@ impl<'a> Repl<'a> {
         }
 
         Output::flush();
+    }
+
+    // ========================================================================
+    // Inline Suggestions (ghost text)
+    // ========================================================================
+
+    /// Resolve a dotted identifier chain like `process.env` starting from
+    /// globalThis by walking own/prototype properties. Returns `UNDEFINED`
+    /// on any failure. Deliberately avoids the REPL evaluator so `_`/`_error`
+    /// are untouched; getters on the chain may still run (matching Node's
+    /// REPL).
+    fn resolve_object_expr(&self, expr: &[u8]) -> JSValue {
+        let Some(global) = self.global else {
+            return JSValue::UNDEFINED;
+        };
+        if expr.is_empty() {
+            return JSValue::UNDEFINED;
+        }
+
+        let mut current = global.to_js_value();
+        for part in strings::split(expr, b".") {
+            if part.is_empty() || !is_ident_start(part[0]) {
+                return JSValue::UNDEFINED;
+            }
+            if !current.is_object() {
+                return JSValue::UNDEFINED;
+            }
+            match current.get(global, part) {
+                Ok(Some(next)) => current = next,
+                Ok(None) => return JSValue::UNDEFINED,
+                Err(_) => {
+                    global.clear_exception();
+                    return JSValue::UNDEFINED;
+                }
+            }
+        }
+        current
+    }
+
+    /// Recompute the inline ghost suggestion for the current editor state.
+    /// Stores only the remainder (text to append) in `self.suggestion`.
+    fn update_suggestion(&mut self) {
+        self.suggestion.clear();
+
+        if !self.is_tty || !self.use_colors {
+            return;
+        }
+        if self.input_mode != InputMode::Normal {
+            return;
+        }
+
+        // Only suggest when the cursor is at end-of-line; mid-line ghost text
+        // is confusing to render correctly.
+        let line: Vec<u8> = self.line_editor.get_line().to_vec();
+        if self.line_editor.cursor != line.len() {
+            return;
+        }
+        if line.is_empty() || line[0] == b'.' {
+            return; // skip REPL dot-commands
+        }
+
+        let ctx = parse_completion_context(&line, self.line_editor.cursor);
+        if ctx.prefix.is_empty() && ctx.object_expr.is_empty() {
+            return;
+        }
+
+        let Some(global) = self.global else {
+            return;
+        };
+
+        let mut target = JSValue::UNDEFINED;
+        if !ctx.object_expr.is_empty() {
+            target = self.resolve_object_expr(ctx.object_expr);
+            if target.is_undefined_or_null() {
+                return;
+            }
+        }
+
+        // SAFETY: `global` is a live opaque handle; `ctx.prefix` is valid for
+        // the duration of the call. The C++ side uses a TopExceptionScope and
+        // clears any exception before returning, so nothing escapes here.
+        let completions = unsafe {
+            Bun__REPL__getCompletions(global, target, ctx.prefix.as_ptr(), ctx.prefix.len())
+        };
+
+        let mut best_len: usize = usize::MAX;
+
+        if !completions.is_undefined_or_null() && completions.is_array() {
+            let len: u32 = match completions.get_length(global) {
+                Ok(n) => n as u32,
+                Err(_) => {
+                    global.clear_exception();
+                    0
+                }
+            };
+            for idx in 0..len {
+                let item = match completions.get_index(global, idx) {
+                    Ok(v) => v,
+                    Err(_) => {
+                        global.clear_exception();
+                        continue;
+                    }
+                };
+                if !item.is_string() {
+                    continue;
+                }
+                let slice = match item.to_slice(global) {
+                    Ok(s) => s,
+                    Err(_) => {
+                        global.clear_exception();
+                        continue;
+                    }
+                };
+                let name = slice.slice();
+                if name.len() <= ctx.prefix.len() {
+                    continue;
+                }
+                if !is_dot_accessible(name) {
+                    continue; // skip keys that can't follow `.`
+                }
+                if ctx.prefix.is_empty() {
+                    // `obj.` with no prefix: just offer the first reasonable key.
+                    self.suggestion.clear();
+                    self.suggestion.extend_from_slice(name);
+                    break;
+                }
+                if name.len() < best_len {
+                    best_len = name.len();
+                    self.suggestion.clear();
+                    self.suggestion.extend_from_slice(&name[ctx.prefix.len()..]);
+                }
+            }
+        }
+
+        // Fallback: suggest a JS keyword in global context.
+        if self.suggestion.is_empty() && ctx.object_expr.is_empty() && !ctx.prefix.is_empty() {
+            for &kw in JS_KEYWORDS {
+                if kw.len() > ctx.prefix.len() && kw.starts_with(ctx.prefix) && kw.len() < best_len
+                {
+                    best_len = kw.len();
+                    self.suggestion.clear();
+                    self.suggestion.extend_from_slice(&kw[ctx.prefix.len()..]);
+                }
+            }
+        }
+
+        // Drop the suggestion if rendering it would wrap past the terminal
+        // width — wrapping would make refresh_line()'s `\r`+CUF cursor restore
+        // land on the wrong row. Enforcing it here (not just at render time)
+        // keeps acceptance in sync: Tab/Right/End can never apply a
+        // suggestion the user didn't see. The line's display width can differ
+        // from its byte length (multi-byte/wide chars); the suggestion itself
+        // is always ASCII so its byte length is its width.
+        if !self.suggestion.is_empty() {
+            let line_width = strings::visible::width::exclude_ansi_colors::utf8(&line);
+            if self.get_prompt_length() + line_width + self.suggestion.len()
+                >= self.terminal_width as usize
+            {
+                self.suggestion.clear();
+            }
+        }
+    }
+
+    /// Insert the current suggestion into the line buffer. Returns true if a
+    /// suggestion was accepted.
+    fn accept_suggestion(&mut self) -> bool {
+        if self.suggestion.is_empty() {
+            return false;
+        }
+        let sugg = core::mem::take(&mut self.suggestion);
+        let ok = self.line_editor.insert_slice(&sugg).is_ok();
+        // Keep the Vec's capacity for reuse.
+        self.suggestion = sugg;
+        self.suggestion.clear();
+        ok
     }
 
     fn write_highlighted(&self, text: &[u8]) {
@@ -2065,6 +2266,7 @@ impl<'a> Repl<'a> {
                     }
                     _ => {
                         self.line_editor.delete_char();
+                        self.update_suggestion();
                         self.refresh_line();
                     }
                 },
@@ -2075,54 +2277,77 @@ impl<'a> Repl<'a> {
                 }
                 Key::CtrlA => {
                     self.line_editor.move_to_start();
+                    self.suggestion.clear();
                     self.refresh_line();
                 }
                 Key::CtrlE => {
-                    self.line_editor.move_to_end();
+                    if !self.accept_suggestion() {
+                        self.line_editor.move_to_end();
+                    }
+                    self.update_suggestion();
                     self.refresh_line();
                 }
                 Key::CtrlB | Key::ArrowLeft => {
                     self.line_editor.move_left();
+                    self.suggestion.clear();
                     self.refresh_line();
                 }
                 Key::CtrlF | Key::ArrowRight => {
-                    self.line_editor.move_right();
+                    // At end-of-line with a visible suggestion, Right accepts
+                    // it (fish/node-style). Otherwise it moves the cursor.
+                    if self.line_editor.cursor == self.line_editor.buffer.len()
+                        && self.accept_suggestion()
+                    {
+                        self.update_suggestion();
+                    } else {
+                        self.line_editor.move_right();
+                        self.update_suggestion();
+                    }
                     self.refresh_line();
                 }
                 Key::AltB | Key::AltLeft => {
                     self.line_editor.move_word_left();
+                    self.suggestion.clear();
                     self.refresh_line();
                 }
                 Key::AltF | Key::AltRight => {
                     self.line_editor.move_word_right();
+                    self.update_suggestion();
                     self.refresh_line();
                 }
                 Key::CtrlU => {
                     self.line_editor.delete_to_start();
+                    self.update_suggestion();
                     self.refresh_line();
                 }
                 Key::CtrlK => {
                     self.line_editor.delete_to_end();
+                    self.update_suggestion();
                     self.refresh_line();
                 }
                 Key::CtrlW | Key::AltBackspace => {
                     self.line_editor.backspace_word();
+                    self.update_suggestion();
                     self.refresh_line();
                 }
                 Key::AltD => {
                     self.line_editor.delete_word();
+                    self.update_suggestion();
                     self.refresh_line();
                 }
                 Key::CtrlT => {
                     self.line_editor.swap();
+                    self.update_suggestion();
                     self.refresh_line();
                 }
                 Key::Backspace => {
                     self.line_editor.backspace();
+                    self.update_suggestion();
                     self.refresh_line();
                 }
                 Key::Delete => {
                     self.line_editor.delete_char();
+                    self.update_suggestion();
                     self.refresh_line();
                 }
                 Key::ArrowUp | Key::CtrlP => {
@@ -2131,6 +2356,7 @@ impl<'a> Repl<'a> {
                     if let Some(prev_line) = self.history.prev(&cur) {
                         let prev_line = prev_line.to_vec();
                         let _ = self.line_editor.set(&prev_line);
+                        self.suggestion.clear();
                         self.refresh_line();
                     }
                 }
@@ -2141,23 +2367,30 @@ impl<'a> Repl<'a> {
                     } else {
                         self.line_editor.clear();
                     }
+                    self.suggestion.clear();
                     self.refresh_line();
                 }
                 Key::Tab => self.handle_tab(),
                 Key::Home => {
                     self.line_editor.move_to_start();
+                    self.suggestion.clear();
                     self.refresh_line();
                 }
                 Key::End => {
-                    self.line_editor.move_to_end();
+                    if !self.accept_suggestion() {
+                        self.line_editor.move_to_end();
+                    }
+                    self.update_suggestion();
                     self.refresh_line();
                 }
                 Key::Char(c) => {
                     let _ = self.line_editor.insert(c);
+                    self.update_suggestion();
                     self.refresh_line();
                 }
                 Key::Text(bytes, len) => {
                     let _ = self.line_editor.insert_slice(&bytes[..len]);
+                    self.update_suggestion();
                     self.refresh_line();
                 }
                 _ => {}
@@ -2170,6 +2403,12 @@ impl<'a> Repl<'a> {
     }
 
     fn handle_enter(&mut self) -> Result<(), crate::Error> {
+        // Erase any rendered ghost text past the cursor so the submitted
+        // line shows only what was actually typed.
+        if !self.suggestion.is_empty() {
+            self.write(Cursor::CLEAR_TO_END.as_bytes());
+        }
+        self.suggestion.clear();
         self.print(format_args!("\n"));
 
         // Note: reshaped for borrowck — copy line out so we can call &mut self methods
@@ -2275,6 +2514,10 @@ impl<'a> Repl<'a> {
     }
 
     fn handle_ctrl_c(&mut self) {
+        if !self.suggestion.is_empty() {
+            self.write(Cursor::CLEAR_TO_END.as_bytes());
+        }
+        self.suggestion.clear();
         match self.input_mode {
             InputMode::Editor => {
                 self.print(format_args!(
@@ -2314,6 +2557,14 @@ impl<'a> Repl<'a> {
     }
 
     fn handle_tab(&mut self) {
+        // If a ghost suggestion is showing, Tab accepts it.
+        if !self.suggestion.is_empty() && self.line_editor.cursor == self.line_editor.buffer.len() {
+            self.accept_suggestion();
+            self.update_suggestion();
+            self.refresh_line();
+            return;
+        }
+
         // Note: reshaped for borrowck — copy line out
         let line: Vec<u8> = self.line_editor.get_line().to_vec();
 
@@ -2355,24 +2606,41 @@ impl<'a> Repl<'a> {
             return;
         };
 
-        // Find the word being completed
-        let mut word_start: usize = line.len();
-        while word_start > 0 {
-            let c = line[word_start - 1];
-            if !c.is_ascii_alphanumeric() && c != b'_' && c != b'$' {
-                break;
-            }
-            word_start -= 1;
+        let cursor = self.line_editor.cursor;
+
+        // Don't complete when the cursor is in the middle of an identifier —
+        // replacing only the left half would duplicate the right half (e.g.
+        // `con|sole` + Tab -> `consolesole`). Do nothing rather than insert
+        // whitespace here: every other indent-fallback in this function runs
+        // with the cursor at/after a token boundary, but this branch is by
+        // definition inside one, and injecting spaces would split it.
+        if cursor < line.len() && is_ident_part(line[cursor]) {
+            self.refresh_line();
+            return;
         }
 
-        let prefix = &line[word_start..];
+        // Parse the completion context at the cursor (handles `obj.prop` chains).
+        let ctx = parse_completion_context(&line, cursor);
+        let word_start = ctx.prefix_start;
+        let prefix = ctx.prefix;
 
-        // Get completions from global object
+        let mut target = JSValue::UNDEFINED;
+        if !ctx.object_expr.is_empty() {
+            target = self.resolve_object_expr(ctx.object_expr);
+            if target.is_undefined_or_null() {
+                // Couldn't resolve the object; just indent.
+                let _ = self.line_editor.insert(b' ');
+                let _ = self.line_editor.insert(b' ');
+                self.refresh_line();
+                return;
+            }
+        }
+
+        // Get completions from the target (or global object if target is undefined).
         // SAFETY: `global` is a live opaque `JSGlobalObject` handle; `prefix` ptr/len
         // are valid for the duration of the call.
-        let completions = unsafe {
-            Bun__REPL__getCompletions(global, JSValue::UNDEFINED, prefix.as_ptr(), prefix.len())
-        };
+        let completions =
+            unsafe { Bun__REPL__getCompletions(global, target, prefix.as_ptr(), prefix.len()) };
 
         if completions.is_undefined() || !completions.is_array() {
             let _ = self.line_editor.insert(b' ');
@@ -2414,11 +2682,16 @@ impl<'a> Repl<'a> {
                     }
                 };
                 let completion = slice.slice();
-                // Replace the prefix with the completion
-                while self.line_editor.cursor > word_start {
-                    self.line_editor.backspace();
+                // Only insert if the result is a valid dot-access identifier;
+                // e.g. a sole `"foo-bar"` key would otherwise produce
+                // `obj.foo-bar` which parses as subtraction.
+                if is_dot_accessible(completion) {
+                    // Replace the prefix with the completion
+                    while self.line_editor.cursor > word_start {
+                        self.line_editor.backspace();
+                    }
+                    let _ = self.line_editor.insert_slice(completion);
                 }
-                let _ = self.line_editor.insert_slice(completion);
                 self.refresh_line();
             }
         } else if len <= 50 {
@@ -2488,6 +2761,130 @@ extern "C" fn sigint_handler(_: c_int) {
         // `vm` was a valid `*mut jsc::VM` when stored (JS thread is
         // blocked in wait while the handler runs, so it stays valid).
         jsc::VM::opaque_ref(vm).set_execution_forbidden(true);
+    }
+}
+
+// ============================================================================
+// Inline Suggestions (ghost text)
+// ============================================================================
+
+#[inline]
+fn is_ident_part(c: u8) -> bool {
+    c.is_ascii_alphanumeric() || c == b'_' || c == b'$'
+}
+
+#[inline]
+fn is_ident_start(c: u8) -> bool {
+    c.is_ascii_alphabetic() || c == b'_' || c == b'$'
+}
+
+/// True if `name` is safe to insert after a `.` — i.e. a plain ASCII
+/// identifier. Rejects keys like `"foo-bar"` or `"a b"` whose first byte
+/// passes `is_ident_start` but which would not parse as dot-access.
+fn is_dot_accessible(name: &[u8]) -> bool {
+    match name.first() {
+        Some(&c) if is_ident_start(c) => name[1..].iter().all(|&c| is_ident_part(c)),
+        _ => false,
+    }
+}
+
+/// Common JS keywords offered as fallback suggestions in global context when
+/// no matching global property exists (e.g. `fun` -> `function`).
+const JS_KEYWORDS: &[&[u8]] = &[
+    b"async",
+    b"await",
+    b"break",
+    b"case",
+    b"catch",
+    b"class",
+    b"const",
+    b"continue",
+    b"debugger",
+    b"default",
+    b"delete",
+    b"else",
+    b"export",
+    b"extends",
+    b"false",
+    b"finally",
+    b"for",
+    b"function",
+    b"import",
+    b"instanceof",
+    b"let",
+    b"new",
+    b"null",
+    b"return",
+    b"static",
+    b"super",
+    b"switch",
+    b"this",
+    b"throw",
+    b"true",
+    b"try",
+    b"typeof",
+    b"undefined",
+    b"var",
+    b"void",
+    b"while",
+    b"yield",
+];
+
+struct CompletionContext<'a> {
+    /// Dotted object expression before the final `.`, e.g. `b"console"` for
+    /// input `console.lo|`. Empty means complete against globalThis.
+    object_expr: &'a [u8],
+    /// Trailing identifier fragment being typed, e.g. `b"lo"` for `console.lo|`.
+    prefix: &'a [u8],
+    /// Byte offset in `line` where `prefix` begins.
+    prefix_start: usize,
+}
+
+/// Parse backward from `cursor` to determine what is being completed.
+/// Only recognises simple `ident(.ident)*` chains; anything fancier (calls,
+/// indexing, optional chaining) falls back to completing `prefix` on global.
+fn parse_completion_context(line: &[u8], cursor: usize) -> CompletionContext<'_> {
+    let mut i = cursor;
+    while i > 0 && is_ident_part(line[i - 1]) {
+        i -= 1;
+    }
+    let prefix_start = i;
+    let prefix = &line[prefix_start..cursor];
+
+    if i == 0 || line[i - 1] != b'.' {
+        return CompletionContext {
+            object_expr: b"",
+            prefix,
+            prefix_start,
+        };
+    }
+    i -= 1; // skip the `.`
+    let chain_end = i;
+
+    loop {
+        let ident_end = i;
+        while i > 0 && is_ident_part(line[i - 1]) {
+            i -= 1;
+        }
+        if i == ident_end {
+            // No identifier before the dot (e.g. `(expr).foo`) — can't safely
+            // resolve, so treat as global completion of the bare prefix.
+            return CompletionContext {
+                object_expr: b"",
+                prefix,
+                prefix_start,
+            };
+        }
+        if i == 0 || line[i - 1] != b'.' {
+            break;
+        }
+        i -= 1;
+    }
+
+    CompletionContext {
+        object_expr: &line[i..chain_end],
+        prefix,
+        prefix_start,
     }
 }
 

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -22,7 +22,7 @@ use bun_collections::VecExt;
 use bun_core::strings;
 #[cfg(unix)]
 use bun_core::tty;
-use bun_core::{Environment, Output, env_var, fmt};
+use bun_core::{Environment, Output, env_var, fmt, identifier};
 use bun_jsc::js_promise::Status as PromiseStatus;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{self as jsc, JSGlobalObject, JSValue, JsResult, ProtectedJSValue};
@@ -1287,8 +1287,7 @@ impl<'a> Repl<'a> {
     // Inline Suggestions (ghost text)
     // ========================================================================
 
-    /// Walk `a.b.c` from globalThis via property gets (not the evaluator, so `_` is
-    /// untouched). `UNDEFINED` on any failure.
+    /// Walks `a.b.c` via property gets, not the evaluator (so `_` is untouched).
     fn resolve_object_expr(&self, expr: &[u8]) -> JSValue {
         let Some(global) = self.global else {
             return JSValue::UNDEFINED;
@@ -1299,10 +1298,7 @@ impl<'a> Repl<'a> {
 
         let mut current = global.to_js_value();
         for part in strings::split(expr, b".") {
-            if part.is_empty() || !is_ident_start(part[0]) {
-                return JSValue::UNDEFINED;
-            }
-            if !current.is_object() {
+            if !identifier::is_identifier(part) || !current.is_object() {
                 return JSValue::UNDEFINED;
             }
             match current.get(global, part) {
@@ -1335,7 +1331,9 @@ impl<'a> Repl<'a> {
             return; // skip REPL dot-commands
         }
 
-        let ctx = parse_completion_context(&line, self.line_editor.cursor);
+        let Some(ctx) = parse_completion_context(&line, self.line_editor.cursor) else {
+            return;
+        };
         if ctx.prefix.is_empty() && ctx.object_expr.is_empty() {
             return;
         }
@@ -1387,21 +1385,20 @@ impl<'a> Repl<'a> {
                     }
                 };
                 let name = slice.slice();
-                if name.len() <= ctx.prefix.len() {
+                let Some(rest) = name.strip_prefix(ctx.prefix) else {
                     continue;
-                }
-                if !is_dot_accessible(name) {
+                };
+                // Skips keys like `"foo-bar"` or `"0"`, which can't follow a `.`.
+                if rest.is_empty() || !identifier::is_identifier(name) {
                     continue;
-                }
-                if ctx.prefix.is_empty() {
-                    self.suggestion.clear();
-                    self.suggestion.extend_from_slice(name);
-                    break;
                 }
                 if name.len() < best_len {
                     best_len = name.len();
                     self.suggestion.clear();
-                    self.suggestion.extend_from_slice(&name[ctx.prefix.len()..]);
+                    self.suggestion.extend_from_slice(rest);
+                    if ctx.prefix.is_empty() {
+                        break;
+                    }
                 }
             }
         }
@@ -1417,11 +1414,12 @@ impl<'a> Repl<'a> {
             }
         }
 
-        // A wrapped ghost would put refresh_line()'s cursor restore on the wrong row;
-        // dropping it here (not at render) also keeps accept in sync with what's shown.
+        // Dropped here, not at render, so accept can never apply more than was drawn.
         if !self.suggestion.is_empty() {
             let line_width = strings::visible::width::exclude_ansi_colors::utf8(&line);
-            if self.get_prompt_length() + line_width + self.suggestion.len()
+            let suggestion_width =
+                strings::visible::width::exclude_ansi_colors::utf8(&self.suggestion);
+            if self.get_prompt_length() + line_width + suggestion_width
                 >= self.terminal_width as usize
             {
                 self.suggestion.clear();
@@ -2528,6 +2526,12 @@ impl<'a> Repl<'a> {
         self.refresh_line();
     }
 
+    /// Tab with nothing to complete indents instead.
+    fn insert_tab_spaces(&mut self) {
+        let _ = self.line_editor.insert_slice(b"  ");
+        self.refresh_line();
+    }
+
     fn handle_tab(&mut self) {
         if !self.suggestion.is_empty() && self.line_editor.cursor == self.line_editor.buffer.len() {
             self.accept_suggestion();
@@ -2570,22 +2574,22 @@ impl<'a> Repl<'a> {
 
         // Property completion using JSC
         let Some(global) = self.global else {
-            // No VM, just insert spaces
-            let _ = self.line_editor.insert(b' ');
-            let _ = self.line_editor.insert(b' ');
-            self.refresh_line();
+            self.insert_tab_spaces();
             return;
         };
 
         let cursor = self.line_editor.cursor;
 
         // Mid-identifier (`con|sole`): completing would duplicate the suffix.
-        if cursor < line.len() && is_ident_part(line[cursor]) {
+        if cursor < line.len() && is_word_byte(line[cursor]) {
             self.refresh_line();
             return;
         }
 
-        let ctx = parse_completion_context(&line, cursor);
+        let Some(ctx) = parse_completion_context(&line, cursor) else {
+            self.insert_tab_spaces();
+            return;
+        };
         let word_start = ctx.prefix_start;
         let prefix = ctx.prefix;
 
@@ -2593,9 +2597,7 @@ impl<'a> Repl<'a> {
         if !ctx.object_expr.is_empty() {
             target = self.resolve_object_expr(ctx.object_expr);
             if target.is_undefined_or_null() {
-                let _ = self.line_editor.insert(b' ');
-                let _ = self.line_editor.insert(b' ');
-                self.refresh_line();
+                self.insert_tab_spaces();
                 return;
             }
         }
@@ -2606,9 +2608,7 @@ impl<'a> Repl<'a> {
             unsafe { Bun__REPL__getCompletions(global, target, prefix.as_ptr(), prefix.len()) };
 
         if completions.is_undefined() || !completions.is_array() {
-            let _ = self.line_editor.insert(b' ');
-            let _ = self.line_editor.insert(b' ');
-            self.refresh_line();
+            self.insert_tab_spaces();
             return;
         }
 
@@ -2621,9 +2621,7 @@ impl<'a> Repl<'a> {
             }
         };
         if len == 0 {
-            let _ = self.line_editor.insert(b' ');
-            let _ = self.line_editor.insert(b' ');
-            self.refresh_line();
+            self.insert_tab_spaces();
             return;
         }
 
@@ -2645,7 +2643,7 @@ impl<'a> Repl<'a> {
                     }
                 };
                 let completion = slice.slice();
-                if is_dot_accessible(completion) {
+                if identifier::is_identifier(completion) {
                     while self.line_editor.cursor > word_start {
                         self.line_editor.backspace();
                     }
@@ -2727,21 +2725,10 @@ extern "C" fn sigint_handler(_: c_int) {
 // Inline Suggestions (ghost text)
 // ============================================================================
 
+/// Word bytes for the prefix/chain scan; non-ASCII is taken wholesale (a junk prefix matches nothing).
 #[inline]
-fn is_ident_part(c: u8) -> bool {
-    c.is_ascii_alphanumeric() || c == b'_' || c == b'$'
-}
-
-#[inline]
-fn is_ident_start(c: u8) -> bool {
-    c.is_ascii_alphabetic() || c == b'_' || c == b'$'
-}
-
-fn is_dot_accessible(name: &[u8]) -> bool {
-    match name.first() {
-        Some(&c) if is_ident_start(c) => name[1..].iter().all(|&c| is_ident_part(c)),
-        _ => false,
-    }
+fn is_word_byte(c: u8) -> bool {
+    c.is_ascii_alphanumeric() || c == b'_' || c == b'$' || c >= 0x80
 }
 
 /// Fallback suggestions when no global matches the prefix.
@@ -2785,46 +2772,39 @@ const JS_KEYWORDS: &[&[u8]] = &[
     b"yield",
 ];
 
-/// For `console.lo|`: `object_expr = "console"`, `prefix = "lo"`. An empty
-/// `object_expr` means complete against globalThis.
+/// `console.lo|` → `object_expr = "console"`, `prefix = "lo"`; empty `object_expr` = globalThis.
 struct CompletionContext<'a> {
     object_expr: &'a [u8],
     prefix: &'a [u8],
     prefix_start: usize,
 }
 
-/// Only recognises `ident(.ident)*` before the cursor; anything else (calls,
-/// indexing, `?.`) degrades to global completion of the bare prefix.
-fn parse_completion_context(line: &[u8], cursor: usize) -> CompletionContext<'_> {
+/// `None` for e.g. `foo().th|`: a property name follows the `.`, so globals/keywords don't apply.
+fn parse_completion_context(line: &[u8], cursor: usize) -> Option<CompletionContext<'_>> {
     let mut i = cursor;
-    while i > 0 && is_ident_part(line[i - 1]) {
+    while i > 0 && is_word_byte(line[i - 1]) {
         i -= 1;
     }
     let prefix_start = i;
     let prefix = &line[prefix_start..cursor];
 
     if i == 0 || line[i - 1] != b'.' {
-        return CompletionContext {
+        return Some(CompletionContext {
             object_expr: b"",
             prefix,
             prefix_start,
-        };
+        });
     }
     i -= 1; // skip the `.`
     let chain_end = i;
 
     loop {
         let ident_end = i;
-        while i > 0 && is_ident_part(line[i - 1]) {
+        while i > 0 && is_word_byte(line[i - 1]) {
             i -= 1;
         }
         if i == ident_end {
-            // e.g. `(expr).foo`
-            return CompletionContext {
-                object_expr: b"",
-                prefix,
-                prefix_start,
-            };
+            return None;
         }
         if i == 0 || line[i - 1] != b'.' {
             break;
@@ -2832,11 +2812,11 @@ fn parse_completion_context(line: &[u8], cursor: usize) -> CompletionContext<'_>
         i -= 1;
     }
 
-    CompletionContext {
+    Some(CompletionContext {
         object_expr: &line[i..chain_end],
         prefix,
         prefix_start,
-    }
+    })
 }
 
 fn is_incomplete_code(code: &[u8]) -> bool {

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -46,6 +46,7 @@ async function withTerminalRepl(
     waitFor: (pattern: string | RegExp, timeoutMs?: number) => Promise<string>;
     allOutput: () => string;
   }) => Promise<void>,
+  options: { env?: Record<string, string | undefined> } = {},
 ) {
   const received: string[] = [];
   let cursor = 0;
@@ -70,6 +71,7 @@ async function withTerminalRepl(
     env: {
       ...bunEnv,
       TERM: "xterm-256color",
+      ...options.env,
     },
   });
 
@@ -1053,6 +1055,146 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
       await waitFor(".he");
       send("\t"); // Tab — should complete to .help (only match)
       await waitFor(".help");
+    });
+  });
+
+  describe("inline suggestions", () => {
+    // Ghost text is rendered as: ESC[2m<remainder>ESC[0m after the typed text.
+    // The feature requires colors, so override bunEnv's NO_COLOR for these.
+    const DIM = "\x1b[2m";
+    const colorEnv = { NO_COLOR: undefined, FORCE_COLOR: "1" };
+
+    test("suggests global completion while typing", async () => {
+      await withTerminalRepl(
+        async ({ send, waitFor }) => {
+          // "cons" should suggest "ole" (-> console). There are longer globals
+          // like `constructor` on the prototype chain, but the REPL picks the
+          // shortest match.
+          send("cons");
+          await waitFor(`${DIM}ole`);
+        },
+        { env: colorEnv },
+      );
+    });
+
+    test("right arrow accepts the suggestion", async () => {
+      await withTerminalRepl(
+        async ({ send, waitFor }) => {
+          send("JSO");
+          await waitFor(`${DIM}N`);
+          send("\x1b[C"); // Right arrow — accepts the ghost text
+          // After acceptance the input is `JSON`; extend it and evaluate.
+          // The result "81" never appears in the echoed input, so this only
+          // matches once the expression actually evaluates — proving the
+          // ghost was accepted (otherwise `JSO.stringify` → ReferenceError).
+          send(".stringify(9*9)\n");
+          await waitFor('"81"');
+        },
+        { env: colorEnv },
+      );
+    });
+
+    test("suggests property completion after a dot", async () => {
+      await withTerminalRepl(
+        async ({ send, waitFor }) => {
+          // Build up `console.` by accepting the global suggestion first.
+          send("cons");
+          await waitFor(`${DIM}ole`);
+          send("\x1b[C"); // accept -> "console"
+          send(".l");
+          // console.l -> "log" is the shortest property starting with "l"
+          await waitFor(`${DIM}og`);
+        },
+        { env: colorEnv },
+      );
+    });
+
+    test("tab accepts the visible suggestion", async () => {
+      await withTerminalRepl(
+        async ({ send, waitFor }) => {
+          send("JSON.str");
+          await waitFor(`${DIM}ingify`, 10000);
+          send("\t"); // Tab accepts the ghost suggestion -> `JSON.stringify`
+          // Result "81" cannot occur in the echoed input, so it only matches
+          // if Tab really completed to `stringify` and the call succeeded.
+          send("(9*9)\n");
+          await waitFor('"81"');
+        },
+        { env: colorEnv },
+      );
+    }, 15000);
+
+    test("end key accepts the suggestion", async () => {
+      await withTerminalRepl(
+        async ({ send, waitFor }) => {
+          send("Mat");
+          await waitFor(`${DIM}h`);
+          send("\x1b[F"); // End — accepts suggestion -> "Math"
+          // Result 63 cannot occur in the echoed input; if End didn't accept,
+          // `Mat.max(...)` would throw instead of producing it.
+          send(".max(4,7)*9\n");
+          await waitFor("63");
+        },
+        { env: colorEnv },
+      );
+    });
+
+    test("suggests first property when prefix is empty after dot", async () => {
+      await withTerminalRepl(
+        async ({ send, waitFor }) => {
+          // Define an object with a single distinctive property so the
+          // suggestion is deterministic regardless of prototype ordering.
+          send("globalThis.__sgObj = Object.create(null); __sgObj.onlyProp = 1\n");
+          await waitFor("1");
+          send("__sgObj.");
+          await waitFor(`${DIM}onlyProp`);
+        },
+        { env: colorEnv },
+      );
+    });
+
+    test("falls back to JS keywords when no global matches", async () => {
+      await withTerminalRepl(
+        async ({ send, waitFor }) => {
+          // No global starts with "instan", but the keyword `instanceof` does.
+          send("x instan");
+          await waitFor(`${DIM}ceof`);
+        },
+        { env: colorEnv },
+      );
+    });
+
+    test("tab completes properties on an object (no ghost)", async () => {
+      // Tab completion now resolves `obj.prefix` chains even when ghost text
+      // is disabled (NO_COLOR) — verifies parseCompletionContext + resolve.
+      await withTerminalRepl(async ({ send, waitFor }) => {
+        // Store the marker as two halves so it never appears in the echoed
+        // input; it only shows up once the completed property is evaluated.
+        send("globalThis.__tcObj = { uniqueLongName: 'tcMAR' + 'KER' }; 0\n");
+        await waitFor(/\b0\b/);
+        send("__tcObj.uni");
+        send("\t");
+        // After tab, the full property should be in the input; evaluate it.
+        send("\n");
+        await waitFor("tcMARKER");
+      });
+    });
+
+    test("suggestion is not evaluated on enter", async () => {
+      await withTerminalRepl(
+        async ({ send, waitFor }) => {
+          send("globalThis.zzGhostMarker = 1\n");
+          await waitFor("1");
+          // Type a prefix that triggers a suggestion but don't accept it.
+          send("zz");
+          await waitFor(`${DIM}GhostMarker`);
+          // Hit Enter without accepting — the ghost text must not be part of
+          // the evaluated input, so `zz` alone is a ReferenceError.
+          send("\n");
+          await waitFor(/ReferenceError|not defined/);
+        },
+        { env: colorEnv },
+      );
     });
   });
 

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1275,6 +1275,47 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
       });
     });
 
+    test("suggests inside a template hole but not in the template text around it", async () => {
+      await withTerminalRepl(
+        async ({ send, waitFor }) => {
+          send("`${JSO");
+          await waitFor(`${DIM}N`);
+          // Back in template text after the `}`: "st" must get no ghost, or the
+          // right arrow would accept it. `${JSON}` stringifies to the 13-char
+          // "[object JSON]", plus " st", so the length is 16.
+          send("N} st\x1b[C`.length === 16\n");
+          await waitFor("true");
+        },
+        { env: colorEnv },
+      );
+    });
+
+    test("tab on a continuation line of a template literal indents", async () => {
+      await withTerminalRepl(async ({ send, waitFor }) => {
+        send("globalThis.__tpl = `\n");
+        await waitFor("...");
+        // The backtick was opened on the previous line. Without that context
+        // Tab would complete `JSON.pars` to `parse` inside the template.
+        send("JSON.pars\t`\n");
+        await waitFor(/\u276f|> /);
+        // "\n" + "JSON.pars" + two spaces.
+        send("__tpl.length\n");
+        await waitFor(/\b12\b/);
+      });
+    });
+
+    test("tab on a continuation line outside a string still completes", async () => {
+      await withTerminalRepl(async ({ send, waitFor }) => {
+        send("function __cont() {\n");
+        await waitFor("...");
+        send("return JSON.pars\t\n");
+        send("}\n");
+        await waitFor(/\u276f|> /);
+        send("__cont() === JSON.parse\n");
+        await waitFor("true");
+      });
+    });
+
     test("completion on a Proxy with a misbehaving getPrototypeOf trap does not hang", async () => {
       await withTerminalRepl(
         async ({ send, waitFor }) => {

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1187,13 +1187,55 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
           // Both keys start with "caf" and have the same byte length, and `caf→`
           // comes first; only `cafés` can follow a `.`, so the ghost must be its
           // remainder.
-          send('globalThis.__u = { "caf\\u2192": 1, "caf\\u00e9s": 2 }; "u" + "Ready"\n');
+          send(
+            'globalThis.__u = { "caf\\u2192": 1, "caf\\u00e9s": 2 }; globalThis["caf\\u00e9"] = { latte: 1 }; "u" + "Ready"\n',
+          );
           await waitFor("uReady");
           send("__u.caf");
           await waitFor(`${DIM}és`);
           // The typed prefix itself may contain non-ASCII characters.
           send("é");
           await waitFor(`${DIM}s`);
+          // So may the object being completed: the chain segment is looked up as
+          // UTF-8, not byte-per-character.
+          send("\x15café.");
+          await waitFor(`${DIM}latte`);
+        },
+        { env: colorEnv },
+      );
+    });
+
+    test("resolves chain segments inherited from Object.prototype", async () => {
+      await withTerminalRepl(
+        async ({ send, waitFor }) => {
+          // `constructor` comes from Object.prototype; it must resolve to `Object`
+          // like a real property access would, not stop at the object's own keys.
+          send('globalThis.__plain = {}; "plain" + "Ready"\n');
+          await waitFor("plainReady");
+          send("__plain.constructor.getOwnPropertyNa");
+          await waitFor(`${DIM}mes`);
+        },
+        { env: colorEnv },
+      );
+    });
+
+    test("spread dots do not turn the word into a property access", async () => {
+      await withTerminalRepl(
+        async ({ send, waitFor }) => {
+          send("[...cons");
+          await waitFor(`${DIM}ole`);
+        },
+        { env: colorEnv },
+      );
+    });
+
+    test("no suggestions inside a string literal", async () => {
+      await withTerminalRepl(
+        async ({ send, waitFor }) => {
+          // `st` would otherwise match globals such as `structuredClone`, and the
+          // right arrow would accept that ghost, changing the evaluated string.
+          send('"st\x1b[C" + "x"\n');
+          await waitFor('"stx"');
         },
         { env: colorEnv },
       );

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1224,6 +1224,19 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
         async ({ send, waitFor }) => {
           send("[...cons");
           await waitFor(`${DIM}ole`);
+          // Nor do they swallow the chain that follows them.
+          send("\x15[...console.l");
+          await waitFor(`${DIM}og`);
+        },
+        { env: colorEnv },
+      );
+    });
+
+    test("a chain starting with `this` completes against the global object", async () => {
+      await withTerminalRepl(
+        async ({ send, waitFor }) => {
+          send("this.cons");
+          await waitFor(`${DIM}ole`);
         },
         { env: colorEnv },
       );

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1219,6 +1219,18 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
       );
     });
 
+    test("resolves chains through primitive values", async () => {
+      await withTerminalRepl(
+        async ({ send, waitFor }) => {
+          // `process.version` is a string and `.length` a number; both get boxed
+          // the way a real property access would, ending on Number.prototype.
+          send("process.version.length.toF");
+          await waitFor(`${DIM}ixed`);
+        },
+        { env: colorEnv },
+      );
+    });
+
     test("spread dots do not turn the word into a property access", async () => {
       await withTerminalRepl(
         async ({ send, waitFor }) => {
@@ -1252,6 +1264,15 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
         },
         { env: colorEnv },
       );
+    });
+
+    test("tab inside a string literal indents instead of completing", async () => {
+      await withTerminalRepl(async ({ send, waitFor }) => {
+        // `JSON.pars` has exactly one completion, which Tab would otherwise splice
+        // into the string; indenting adds two spaces, so the length is 9 + 2.
+        send('("JSON.pars\t").length\n');
+        await waitFor(/\b11\b/);
+      });
     });
 
     test("completion on a Proxy with a misbehaving getPrototypeOf trap does not hang", async () => {

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -108,8 +108,10 @@ async function withTerminalRepl(
 
   await fn({ terminal, proc, send, waitFor, allOutput });
 
-  // Clean exit
-  send(".exit\n");
+  // Clean exit. Ctrl+U first discards whatever the test left on the line, so
+  // `.exit` is not appended to it (which would leave the REPL running until
+  // the kill below).
+  send("\x15.exit\n");
   await Promise.race([proc.exited, Bun.sleep(2000)]);
   if (!proc.killed) proc.kill();
 }
@@ -1082,11 +1084,11 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
         async ({ send, waitFor }) => {
           send("JSO");
           await waitFor(`${DIM}N`);
-          send("\x1b[C"); // Right arrow — accepts the ghost text
+          send("\x1b[C"); // Right arrow accepts the ghost text
           // After acceptance the input is `JSON`; extend it and evaluate.
           // The result "81" never appears in the echoed input, so this only
-          // matches once the expression actually evaluates — proving the
-          // ghost was accepted (otherwise `JSO.stringify` → ReferenceError).
+          // matches once the expression actually evaluates, proving the ghost
+          // was accepted (otherwise `JSO.stringify` is a ReferenceError).
           send(".stringify(9*9)\n");
           await waitFor('"81"');
         },
@@ -1129,7 +1131,7 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
         async ({ send, waitFor }) => {
           send("Mat");
           await waitFor(`${DIM}h`);
-          send("\x1b[F"); // End — accepts suggestion -> "Math"
+          send("\x1b[F"); // End accepts the suggestion -> "Math"
           // Result 63 cannot occur in the echoed input; if End didn't accept,
           // `Mat.max(...)` would throw instead of producing it.
           send(".max(4,7)*9\n");
@@ -1164,9 +1166,61 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
       );
     });
 
+    test("no global or keyword suggestion for a property of an unresolvable expression", async () => {
+      await withTerminalRepl(
+        async ({ send, waitFor }) => {
+          send('globalThis.__o = () => ({ th: "no" + "Ghost", this: "had" + "Ghost" }); "o" + "Ready"\n');
+          await waitFor("oReady");
+          // `.th` names a property of the call result, so the keyword fallback
+          // (`this`) must not kick in. Right arrow would accept such a ghost,
+          // turning the line into `__o().this`.
+          send("__o().th\x1b[C\n");
+          await waitFor("noGhost");
+        },
+        { env: colorEnv },
+      );
+    });
+
+    test("suggests non-ASCII property names that are valid identifiers", async () => {
+      await withTerminalRepl(
+        async ({ send, waitFor }) => {
+          // Both keys start with "caf" and have the same byte length, and `caf→`
+          // comes first; only `cafés` can follow a `.`, so the ghost must be its
+          // remainder.
+          send('globalThis.__u = { "caf\\u2192": 1, "caf\\u00e9s": 2 }; "u" + "Ready"\n');
+          await waitFor("uReady");
+          send("__u.caf");
+          await waitFor(`${DIM}és`);
+          // The typed prefix itself may contain non-ASCII characters.
+          send("é");
+          await waitFor(`${DIM}s`);
+        },
+        { env: colorEnv },
+      );
+    });
+
+    test("completion on a Proxy with a misbehaving getPrototypeOf trap does not hang", async () => {
+      await withTerminalRepl(
+        async ({ send, waitFor }) => {
+          // The trap alternates between ending the chain and pointing back at
+          // the proxy, so any completer that walks the chain itself never finishes.
+          send(
+            'globalThis.__flipN = 0; globalThis.__flip = new Proxy({}, { getPrototypeOf: () => (__flipN++ % 2 ? __flip : null) }); "flip" + "Ready"\n',
+          );
+          await waitFor("flipReady");
+          // Typing the `.` computes completions for `__flip`; Ctrl+C then
+          // discards the line and the REPL must still evaluate the next one.
+          send("__flip.\x03");
+          send('"still" + "Alive"\n');
+          await waitFor("stillAlive");
+        },
+        { env: colorEnv },
+      );
+    });
+
     test("tab completes properties on an object (no ghost)", async () => {
-      // Tab completion now resolves `obj.prefix` chains even when ghost text
-      // is disabled (NO_COLOR) — verifies parseCompletionContext + resolve.
+      // Tab completion resolves `obj.prefix` chains even when ghost text is
+      // disabled (NO_COLOR), so this covers parse_completion_context + resolve.
       await withTerminalRepl(async ({ send, waitFor }) => {
         // Store the marker as two halves so it never appears in the echoed
         // input; it only shows up once the completed property is evaluated.
@@ -1188,7 +1242,7 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
           // Type a prefix that triggers a suggestion but don't accept it.
           send("zz");
           await waitFor(`${DIM}GhostMarker`);
-          // Hit Enter without accepting — the ghost text must not be part of
+          // Hit Enter without accepting: the ghost text must not be part of
           // the evaluated input, so `zz` alone is a ReferenceError.
           send("\n");
           await waitFor(/ReferenceError|not defined/);


### PR DESCRIPTION
### Problem
- `bun repl` only offers completions on Tab, and only for globals. There is no inline hint while typing, and `obj.<Tab>` cannot complete properties.

### Fix
Inline, fish/IntelliSense-style hints in `bun repl`: as you type, the remainder of the best matching symbol is drawn dimmed after the cursor; Right, End, Ctrl+E, Ctrl+F or Tab accept it.

![bun repl showing dimmed inline completion hints being accepted with the right arrow, End and Tab](https://raw.githubusercontent.com/robobun/bun/c3d93bcd32f797065587054beaff2c93068613f0/repl-ghost-text.gif)

```
❯ cons·ole            "ole" is dimmed
❯ console.l·og        properties of a resolved `a.b.c` chain
❯ JSON.·parse         first property after a bare dot
❯ x instan·ceof       keyword fallback when no global matches
```

`src/runtime/cli/repl.rs`
- `parse_completion_context` splits the text before the cursor into an optional `ident(.ident)*` chain and the word being typed. When the word follows a `.` that is not preceded by such a chain (`p.then(x).th|`) it returns `None` and nothing is suggested, since globals and keywords are never valid there (an earlier revision suggested `tls` for `foo().t` and `this` for `foo().th`). The `..` of a spread (`[...args`, `[...a.b`) is not treated as member access, and a chain may start with `this`, which the REPL evaluates as globalThis. Nothing is suggested inside string or template text (Tab just indents there, also when the template was opened on an earlier line of the same input); the `${…}` holes of a template count as code.
- `resolve_object_expr` walks the chain from `globalThis` one property at a time through the new `Bun__REPL__getProperty` binding: the segment is decoded as UTF-8 and looked up with ordinary semantics (the base is boxed with `toObject`, then `JSObject::getIfPropertyExists`, so inherited properties such as `o.constructor` and chains through primitives such as `s.length.toF` resolve). This deliberately runs getters, as node's completion preview does; a throwing getter or a missing property just ends the chain. The REPL evaluator is not involved, so `_` / `_error` are untouched.
- `update_suggestion` calls the existing `Bun__REPL__getCompletions`, keeps candidates that are IdentifierNames (`bun_core::identifier::is_identifier`, the check the printer uses for `a.b` vs `a["b"]`, so `café` qualifies and `"foo-bar"` / `"0"` do not), takes the shortest (first, for an empty prefix), and stores only the remainder. A remainder that would wrap past the terminal width is dropped at this point, so what can be accepted is always exactly what was drawn.
- `refresh_line` draws the remainder as `ESC[2m…ESC[0m` when the cursor is at end of line; Enter and Ctrl+C clear to end of line first so the ghost never ends up in the submitted line. Every editing key recomputes or clears the suggestion.
- Tab: accepts a visible ghost; otherwise the existing completion UI now also works on `obj.prefix` chains, does nothing mid-identifier (`con|sole` used to become `consolesole`), and inserts spaces through one `insert_tab_spaces` helper on every "nothing to complete" path.
- Only computed in interactive TTY sessions with colors enabled, and only on the first line of an input (continuation lines and `.editor` mode get no hints); piped and `NO_COLOR` sessions are unchanged apart from the Tab improvements. Per keystroke this costs one property enumeration of the target (enumerating the `globalThis` chain measures at roughly 20 µs in a release build).

`src/jsc/bindings/bindings.cpp`
- `Bun__REPL__getProperty` (new, see above): a top exception scope, UTF-8 name, base boxed like `getCompletions` already did for its target, undefined on miss or throw.
- `Bun__REPL__getCompletions` uses `DECLARE_TOP_EXCEPTION_SCOPE` and clears exceptions itself: the Rust caller has no exception scope, and the old throw scope tripped `validateExceptionChecks` on the ASAN lane once this was called per keystroke.
- Dropped the manual prototype walk. `JSObject::getPropertyNames` already covers the chain (deduplicated, depth-capped), so the walk only listed inherited names once per level (on main `is` + Tab shows `isPrototypeOf` twice) and spun forever on a Proxy whose `getPrototypeOf` trap changes its answer, which now matters because user objects reach this function on every keystroke.

Verification
- `test/js/bun/repl/repl.test.ts`, `inline suggestions`: 21 PTY tests (global / property / keyword / empty-prefix hints, acceptance via Right, End and Tab, no hint after a non-chain dot or inside a string, Tab inside a string and on continuation lines, template holes, spread, `this.`, chains through primitives, non-ASCII names, prefixes and chain segments, segments inherited from `Object.prototype`, the misbehaving Proxy, chain Tab completion without colors, ghost text not evaluated on Enter). All of them time out on the released bun; each test added in the last two rounds was also run against the revision it fixes and fails there.
- Whole file: 169 pass. `withTerminalRepl` now sends Ctrl+U before `.exit`, so tests that leave text on the prompt exit immediately instead of waiting for the 2 s kill.
- Source lints, `cargo fmt`, clang-format and prettier clean. Throwing getters, missing segments and non-ASCII segments were also exercised under `BUN_JSC_validateExceptionChecks=1`.

### Background
- Ghost text: the suggestion is not part of the line buffer. `Repl.suggestion` holds just the remainder; it is redrawn on every refresh and only becomes input when an accept key copies it into the `LineEditor`.
- `Bun__REPL__getCompletions` predates this PR: given an object (or `undefined` for `globalThis`) and a prefix it returns a JS array of matching property names. Both the new hint path and Tab go through it.
- JSC 8-bit strings are Latin-1, and the general-purpose `JSValue::get` builds its key that way (it also uses Bun's prototype-pollution-mitigating lookup, which stops at `Object.prototype`). User-typed chain segments are UTF-8 and need real property semantics, hence the dedicated binding.
- IdentifierName is the grammar for what may follow a `.`; it allows Unicode ID_Start / ID_Continue characters and reserved words, which is why the filter is the identifier check rather than an ASCII scan.
- The line editor runs in raw mode while typing (SIGINT is only enabled while awaiting a promise), so a completer that does not return blocks the REPL; hence the Proxy test.

<details>
<summary>History</summary>

Originally written against the Zig REPL; after #30412 moved the REPL to `src/runtime/cli/repl.rs` the feature was re-ported there and the `.zig` file is untouched. Later rounds switched the C++ side to a top exception scope (ASAN lane), made the acceptance tests assert on evaluated results rather than echoed input, then stopped suggesting globals/keywords after a non-chain dot, moved the candidate filter to `identifier::is_identifier`, and removed the prototype walk; the latest round replaced `JSValue::get` in the chain walk with `Bun__REPL__getProperty`, fixed the spread cases, made `this.` chains and chains through primitives work, and stopped completing inside strings (later refined so template holes and continuation lines are handled).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 23 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/repl/repl.test.ts

<!-- robobun:evidence:end -->





