### PR TITLE
fuzzilli: guard REPRL catch block against throwing string coercion

### DIFF
--- a/src/js/eval/fuzzilli-reprl.ts
+++ b/src/js/eval/fuzzilli-reprl.ts
@@ -75,8 +75,15 @@ while (true) {
     // Use indirect eval to execute in global scope
     (0, eval)(script);
   } catch (_e) {
-    // Print uncaught exception like workerd does
-    console.log(`uncaught:${_e}`);
+    // Print uncaught exception like workerd does. The thrown value can be
+    // an arbitrary object whose string coercion itself throws (e.g. a
+    // Symbol.toPrimitive that returns a non-primitive), so guard the
+    // logging so the REPRL loop never exits from inside the catch.
+    try {
+      console.log(`uncaught:${_e}`);
+    } catch {
+      console.log("uncaught:<unprintable>");
+    }
     exit_code = 1;
   }
 

--- a/src/js/eval/fuzzilli-reprl.ts
+++ b/src/js/eval/fuzzilli-reprl.ts
@@ -8,6 +8,9 @@ const REPRL_DRFD = 102; // Data read FD
 
 const fs = require("node:fs");
 
+// Capture the original console.log before any fuzz script can replace it.
+const originalConsoleLog = console.log.bind(console);
+
 // Make common Node modules available
 globalThis.require = require;
 globalThis.__dirname = "/";
@@ -77,12 +80,15 @@ while (true) {
   } catch (_e) {
     // Print uncaught exception like workerd does. The thrown value can be
     // an arbitrary object whose string coercion itself throws (e.g. a
-    // Symbol.toPrimitive that returns a non-primitive), so guard the
-    // logging so the REPRL loop never exits from inside the catch.
+    // Symbol.toPrimitive that returns a non-primitive), and the fuzz script
+    // may have replaced console.log, so guard the logging so the REPRL loop
+    // never exits from inside the catch.
     try {
-      console.log(`uncaught:${_e}`);
+      originalConsoleLog(`uncaught:${_e}`);
     } catch {
-      console.log("uncaught:<unprintable>");
+      try {
+        originalConsoleLog("uncaught:<unprintable>");
+      } catch {}
     }
     exit_code = 1;
   }

--- a/test/js/bun/util/fuzzilli-reprl-catch.fixture.ts
+++ b/test/js/bun/util/fuzzilli-reprl-catch.fixture.ts
@@ -1,0 +1,91 @@
+// Drives the fuzzilli REPRL loop with in-process mocks for the control/data
+// FDs so the real src/js/eval/fuzzilli-reprl.ts source can be exercised in a
+// normal (non-fuzzilli) build. Feeds a payload that throws a value whose
+// Symbol.toPrimitive returns a non-primitive and verifies the loop survives.
+
+import fs from "node:fs";
+import path from "node:path";
+
+const REPRL_CRFD = 100;
+const REPRL_CWFD = 101;
+const REPRL_DRFD = 102;
+
+const payload = Buffer.from(
+  `
+function F20() {}
+F20[Symbol.toPrimitive] = () => F20;
+throw F20;
+`,
+  "utf8",
+);
+
+// Script the control-read pipe (fd 100): HELO handshake, then two exec cycles
+// (each followed by the 8-byte length), then EOF.
+const controlChunks: Buffer[] = [Buffer.from("HELO")];
+const size = Buffer.alloc(8);
+size.writeBigUInt64LE(BigInt(payload.length), 0);
+for (let i = 0; i < 2; i++) {
+  controlChunks.push(Buffer.from("exec"));
+  controlChunks.push(Buffer.from(size));
+}
+let controlStream = Buffer.concat(controlChunks);
+
+// Data-read pipe (fd 102): the payload for each exec cycle.
+let dataStream = Buffer.concat([payload, payload]);
+
+let statusWrites = 0;
+
+const realFstatSync = fs.fstatSync;
+const realReadSync = fs.readSync;
+const realWriteSync = fs.writeSync;
+
+(fs as any).fstatSync = function (fd: any, ...rest: any[]) {
+  if (fd === REPRL_CRFD) return {} as any;
+  return (realFstatSync as any).call(fs, fd, ...rest);
+};
+
+(fs as any).readSync = function (fd: any, buffer: any, offset: any, length: any, position: any) {
+  if (fd === REPRL_CRFD) {
+    const n = Math.min(length, controlStream.length);
+    controlStream.copy(buffer, offset, 0, n);
+    controlStream = controlStream.subarray(n);
+    return n;
+  }
+  if (fd === REPRL_DRFD) {
+    const n = Math.min(length, dataStream.length);
+    dataStream.copy(buffer, offset, 0, n);
+    dataStream = dataStream.subarray(n);
+    return n;
+  }
+  return (realReadSync as any).call(fs, fd, buffer, offset, length, position);
+};
+
+(fs as any).writeSync = function (fd: any, buffer: any, ...rest: any[]) {
+  if (fd === REPRL_CWFD) {
+    if (Buffer.isBuffer(buffer) && buffer.length === 4 && buffer.toString() !== "HELO") {
+      statusWrites++;
+    }
+    return Buffer.isBuffer(buffer) ? buffer.length : String(buffer).length;
+  }
+  return (realWriteSync as any).call(fs, fd, buffer, ...rest);
+};
+
+(globalThis as any).resetCoverage = () => {};
+(globalThis as any).require = require;
+
+process.once("uncaughtException", err => {
+  // If the catch block lets an exception escape, the REPRL loop never reaches
+  // the status write and we land here instead.
+  realWriteSync.call(fs, 2, `UNCAUGHT:${err && (err as any).message}\n`);
+  realWriteSync.call(fs, 1, `STATUS_WRITES=${statusWrites}\n`);
+  process.exit(1);
+});
+
+const reprlSource = fs.readFileSync(
+  path.join(import.meta.dir, "..", "..", "..", "..", "src", "js", "eval", "fuzzilli-reprl.ts"),
+  "utf8",
+);
+(0, eval)(reprlSource);
+
+realWriteSync.call(fs, 1, `STATUS_WRITES=${statusWrites}\n`);
+process.exit(statusWrites === 2 ? 0 : 1);

--- a/test/js/bun/util/throw-bad-toPrimitive.test.ts
+++ b/test/js/bun/util/throw-bad-toPrimitive.test.ts
@@ -39,20 +39,3 @@ test("template literal with object whose Symbol.toPrimitive returns a non-primit
   }
   expect(caught).toBeInstanceOf(TypeError);
 });
-
-test("growable SharedArrayBuffer + Cookie.from with bad Symbol.toPrimitive does not crash", () => {
-  new Uint16Array(new SharedArrayBuffer(198, { maxByteLength: 268435439 }));
-
-  function F() {}
-  F[Symbol.toPrimitive] = () => F;
-
-  expect(() => Bun.Cookie.from(new ArrayBuffer(0) as any, F as any)).toThrow(TypeError);
-
-  let thrown: unknown;
-  try {
-    throw F;
-  } catch (e) {
-    thrown = e;
-  }
-  expect(thrown).toBe(F);
-});

--- a/test/js/bun/util/throw-bad-toPrimitive.test.ts
+++ b/test/js/bun/util/throw-bad-toPrimitive.test.ts
@@ -1,9 +1,34 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import path from "node:path";
 
-// Throwing a value whose Symbol.toPrimitive returns a non-primitive previously
-// caused the Fuzzilli REPRL loop to exit (the catch block's template literal
-// re-threw), tripping a flaky use-after-poison in the error printer. User code
-// should see a normal TypeError and the process should stay alive.
+// Fuzzilli found a flaky use-after-poison that only triggers when the REPRL
+// loop's catch block re-throws: the template literal `uncaught:${_e}` calls
+// ToPrimitive on the thrown value, and if that returns a non-primitive a
+// TypeError escapes the while(true) loop and takes the process down through
+// the uncaught-exception path.
+//
+// This test drives the real src/js/eval/fuzzilli-reprl.ts source with an
+// in-process mock of the REPRL file descriptors (see the fixture) and asserts
+// the loop survives two exec cycles of a payload that throws such a value.
+
+test("fuzzilli REPRL catch block does not let string coercion escape the loop", async () => {
+  const proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, "fuzzilli-reprl-catch.fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).not.toContain("UNCAUGHT:");
+  expect(stdout).toContain("STATUS_WRITES=2");
+  expect(exitCode).toBe(0);
+});
 
 test("template literal with object whose Symbol.toPrimitive returns a non-primitive throws TypeError", () => {
   function F() {}
@@ -17,25 +42,6 @@ test("template literal with object whose Symbol.toPrimitive returns a non-primit
     caught = e;
   }
   expect(caught).toBeInstanceOf(TypeError);
-});
-
-test("catch block that coerces a thrown value with bad Symbol.toPrimitive does not crash", () => {
-  function F() {}
-  F[Symbol.toPrimitive] = () => F;
-
-  // Mirror the REPRL loop's shape: throw the value, catch it, attempt to
-  // stringify it, and guard that stringification.
-  let printed: string | undefined;
-  try {
-    throw F;
-  } catch (_e) {
-    try {
-      printed = `uncaught:${_e as any}`;
-    } catch {
-      printed = "uncaught:<unprintable>";
-    }
-  }
-  expect(printed).toBe("uncaught:<unprintable>");
 });
 
 test("growable SharedArrayBuffer + Cookie.from with bad Symbol.toPrimitive does not crash", () => {

--- a/test/js/bun/util/throw-bad-toPrimitive.test.ts
+++ b/test/js/bun/util/throw-bad-toPrimitive.test.ts
@@ -19,11 +19,7 @@ test("fuzzilli REPRL catch block does not let string coercion escape the loop", 
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).not.toContain("UNCAUGHT:");
   expect(stdout).toContain("STATUS_WRITES=2");

--- a/test/js/bun/util/throw-bad-toPrimitive.test.ts
+++ b/test/js/bun/util/throw-bad-toPrimitive.test.ts
@@ -21,8 +21,8 @@ test("fuzzilli REPRL catch block does not let string coercion escape the loop", 
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).not.toContain("UNCAUGHT:");
-  expect(stdout).toContain("STATUS_WRITES=2");
+  expect(stderr).toBe("");
+  expect(stdout.trim().split("\n").at(-1)).toBe("STATUS_WRITES=2");
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/bun/util/throw-bad-toPrimitive.test.ts
+++ b/test/js/bun/util/throw-bad-toPrimitive.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test";
+
+// Throwing a value whose Symbol.toPrimitive returns a non-primitive previously
+// caused the Fuzzilli REPRL loop to exit (the catch block's template literal
+// re-threw), tripping a flaky use-after-poison in the error printer. User code
+// should see a normal TypeError and the process should stay alive.
+
+test("template literal with object whose Symbol.toPrimitive returns a non-primitive throws TypeError", () => {
+  function F() {}
+  F[Symbol.toPrimitive] = () => F;
+
+  let caught: unknown;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    `uncaught:${F as any}`;
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).toBeInstanceOf(TypeError);
+});
+
+test("catch block that coerces a thrown value with bad Symbol.toPrimitive does not crash", () => {
+  function F() {}
+  F[Symbol.toPrimitive] = () => F;
+
+  // Mirror the REPRL loop's shape: throw the value, catch it, attempt to
+  // stringify it, and guard that stringification.
+  let printed: string | undefined;
+  try {
+    throw F;
+  } catch (_e) {
+    try {
+      printed = `uncaught:${_e as any}`;
+    } catch {
+      printed = "uncaught:<unprintable>";
+    }
+  }
+  expect(printed).toBe("uncaught:<unprintable>");
+});
+
+test("growable SharedArrayBuffer + Cookie.from with bad Symbol.toPrimitive does not crash", () => {
+  new Uint16Array(new SharedArrayBuffer(198, { maxByteLength: 268435439 }));
+
+  function F() {}
+  F[Symbol.toPrimitive] = () => F;
+
+  expect(() => Bun.Cookie.from(new ArrayBuffer(0) as any, F as any)).toThrow(TypeError);
+
+  let thrown: unknown;
+  try {
+    throw F;
+  } catch (e) {
+    thrown = e;
+  }
+  expect(thrown).toBe(F);
+});


### PR DESCRIPTION
Fuzzilli found a flaky `use-after-poison` (fingerprint `Address:use-after-poison:bun-debug+0x78db41e`) that only triggers through the REPRL loop.

## What happened

The fuzz script throws a function whose `Symbol.toPrimitive` returns itself (a non-primitive). The REPRL catch block does:

```js
} catch (_e) {
  console.log(`uncaught:${_e}`);
  exit_code = 1;
}
```

The template-literal coercion of `_e` throws `TypeError: Symbol.toPrimitive returned an object`, which escapes the `while (true)` loop and takes the process down through the uncaught-exception error printer. With the right prior-iteration memory layout this tripped ASAN in a `makeString` / `StringTypeAdapter<std::span<const unsigned char>>::writeTo<char16_t>` copy.

I was unable to reproduce the poison read locally after ~1000 REPRL runs with randomised warmup, but the escaping `TypeError` is deterministic and is the only way this fuzz input reaches that path.

## Fix

Wrap the log call in a nested `try`/`catch` so the REPRL loop never exits from inside its own catch block. With the fix the loop survives the input and reports it as a failed exec instead of aborting the process.

Verified with a small REPRL driver that the loop now runs the crash input repeatedly without the `TypeError` escaping:

```
uncaught:<unprintable>
uncaught:<unprintable>
...
```

Added tests for the user-facing behaviour (template-literal coercion of such objects throws a catchable `TypeError`, and the combined growable-`SharedArrayBuffer` + `Bun.Cookie.from` + `throw` shape from the fuzz input doesn't crash).