### PR TITLE
http2: reclaim closed-stream entries from the session streams map

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -1273,17 +1273,24 @@ pub const H2FrameParser = struct {
         this.usedWindowSize +|= payloadSize;
         log("adjustWindowSize {} {} {} {}", .{ this.usedWindowSize, this.windowSize, this.isServer, payloadSize });
         if (this.usedWindowSize > this.windowSize) {
-            // we are receiving more data than we are allowed to
-            this.sendGoAway(0, .FLOW_CONTROL_ERROR, "Window size overflow", this.lastStreamID, true);
+            // we are receiving more data than we are allowed to.
+            // sendGoAway dispatches onError/onEnd to JS; if the JS handler
+            // destroys the session (which is typical), every stream — including
+            // the one passed in here — is removed via emitErrorToAllStreams →
+            // removeAllClosedStreams. Roll back usedWindowSize *before*
+            // dispatch and bail afterwards so we never touch `stream` again.
             this.usedWindowSize -= payloadSize;
+            this.sendGoAway(0, .FLOW_CONTROL_ERROR, "Window size overflow", this.lastStreamID, true);
+            return;
         }
 
         if (stream) |s| {
             s.usedWindowSize += payloadSize;
             if (s.usedWindowSize > s.windowSize) {
-                // we are receiving more data than we are allowed to
-                this.sendGoAway(s.id, .FLOW_CONTROL_ERROR, "Window size overflow", this.lastStreamID, true);
+                // Same UAF concern as above: roll back first, then dispatch.
+                const stream_id = s.id;
                 s.usedWindowSize -= payloadSize;
+                this.sendGoAway(stream_id, .FLOW_CONTROL_ERROR, "Window size overflow", this.lastStreamID, true);
             }
         }
     }
@@ -2122,8 +2129,13 @@ pub const H2FrameParser = struct {
 
         const end: usize = @min(@as(usize, @intCast(this.remainingLength)), data.len);
         var payload = data[0..end];
-        // window size considering the full frame.length received so far
+        // window size considering the full frame.length received so far.
+        // On a flow-control violation adjustWindowSize sends GOAWAY and the
+        // JS onError handler may synchronously destroy the session, removing
+        // every stream. Re-resolve afterwards and bail if the stream is gone.
+        const stream_id = stream.id;
         this.adjustWindowSize(stream, @truncate(payload.len));
+        stream = this.streams.get(stream_id) orelse return data.len;
         const previous_remaining_length: isize = this.remainingLength;
 
         this.remainingLength -= @intCast(end);
@@ -2197,10 +2209,13 @@ pub const H2FrameParser = struct {
         }
         if (this.remainingLength == 0) {
             this.currentFrame = null;
-            stream.padding = null;
+            // `dispatchWithExtra(.onStreamData, ...)` above may have re-entered
+            // JS and freed this stream (user destroy/abort inside an on("data")
+            // listener). Re-resolve before any further *Stream access.
             if (emitted) {
                 stream = this.streams.get(frame.streamIdentifier) orelse return end;
             }
+            stream.padding = null;
             if (frame.flags & @intFromEnum(DataFrameFlags.END_STREAM) != 0) {
                 const identifier = stream.getIdentifier();
                 identifier.ensureStillAlive();

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -3426,8 +3426,14 @@ pub const H2FrameParser = struct {
             return globalObject.throw("Invalid stream id", .{});
         }
 
+        // Pre-PR, a closed stream lingered in the map and this method
+        // silently returned `.false` via the canSendData/canReceiveData
+        // check below. Now that closed entries are reclaimed, mirror that
+        // behavior for a removed id so `stream.priority({...})` doesn't
+        // throw in the brief window between native removal and JS
+        // `_destroy` nulling `bunHTTP2Session`.
         var stream = this.streams.get(stream_id) orelse {
-            return globalObject.throw("Invalid stream id", .{});
+            return .false;
         };
 
         if (!stream.canSendData() and !stream.canReceiveData()) {
@@ -3578,22 +3584,30 @@ pub const H2FrameParser = struct {
 
         defer {
             if (!enqueued) {
+                // Dispatching the write callback re-enters JS. User code may
+                // synchronously abort the attached AbortSignal (→ SignalRef
+                // abortListener → abortStream → removeStreamByID) or destroy
+                // the session, either of which frees the *Stream. Re-resolve
+                // by id after dispatch and skip the close path if the stream
+                // is gone (abortStream already emitted the terminal event).
                 this.dispatchWriteCallback(callback);
                 var closed = false;
                 if (close) {
-                    if (stream.waitForTrailers) {
-                        this.dispatch(.onWantTrailers, stream.getIdentifier());
-                    } else {
-                        const identifier = stream.getIdentifier();
-                        identifier.ensureStillAlive();
-                        if (stream.state == .HALF_CLOSED_REMOTE) {
-                            stream.state = .CLOSED;
-                            stream.freeResources(this, false);
-                            closed = true;
+                    if (this.streams.get(stream_id)) |s| {
+                        if (s.waitForTrailers) {
+                            this.dispatch(.onWantTrailers, s.getIdentifier());
                         } else {
-                            stream.state = .HALF_CLOSED_LOCAL;
+                            const identifier = s.getIdentifier();
+                            identifier.ensureStillAlive();
+                            if (s.state == .HALF_CLOSED_REMOTE) {
+                                s.state = .CLOSED;
+                                s.freeResources(this, false);
+                                closed = true;
+                            } else if (s.state != .CLOSED) {
+                                s.state = .HALF_CLOSED_LOCAL;
+                            }
+                            this.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(@intFromEnum(s.state)));
                         }
-                        this.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(@intFromEnum(stream.state)));
                     }
                 }
                 if (closed) this.removeStreamByID(stream_id);

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -4692,10 +4692,9 @@ pub const H2FrameParser = struct {
                     if (parent <= 0 or parent > MAX_STREAM_ID) {
                         stream.state = .CLOSED;
                         stream.rstCode = @intFromEnum(ErrorCode.INTERNAL_ERROR);
-                        const bad_parent_id = stream.id;
                         this.dispatchWithExtra(.onStreamError, stream.getIdentifier(), jsc.JSValue.jsNumber(stream.rstCode));
-                        this.removeStreamByID(bad_parent_id);
-                        return jsc.JSValue.jsNumber(bad_parent_id);
+                        this.removeStreamByID(stream_id);
+                        return jsc.JSValue.jsNumber(stream_id);
                     }
                     stream.streamDependency = @intCast(parent);
                 } else {

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -3565,6 +3565,13 @@ pub const H2FrameParser = struct {
                 return globalObject.ERR(.INVALID_ARG_TYPE, "options.silent must be a boolean", .{}).throw();
             }
         }
+        // Any of the `options.get(...)` calls above can invoke a user
+        // getter / Proxy trap that synchronously aborts the stream's
+        // AbortSignal — SignalRef.abortListener runs inline → abortStream
+        // → removeStreamByID → bun.destroy(stream). Re-resolve before
+        // touching `stream.*` again so the subsequent writes/reads don't
+        // land on freed heap.
+        stream = this.streams.get(stream_id) orelse return .false;
         if (parent_id == stream.id) {
             this.sendGoAway(stream.id, ErrorCode.PROTOCOL_ERROR, "Stream with self dependency", this.lastStreamID, true);
             return .false;
@@ -4030,6 +4037,15 @@ pub const H2FrameParser = struct {
         log("trailers encoded_size {}", .{encoded_size});
 
         const writer = this.toWriter();
+
+        // The header-iteration loop above called `item.toJSString()` and
+        // `sensitive_arg.getTruthyPropertyValue(...)` on user-supplied
+        // values, either of which can invoke a Proxy trap / Symbol.toPrimitive
+        // that synchronously aborts the stream's AbortSignal →
+        // SignalRef.abortListener → abortStream → removeStreamByID →
+        // bun.destroy(stream). Re-resolve before any further `stream.*`
+        // access so the subsequent writes/reads don't land on freed heap.
+        stream = this.streams.get(stream_id) orelse return .js_undefined;
 
         // RFC 7540 Section 6.2 & 6.10: Check if we need CONTINUATION frames
         if (encoded_size <= actual_max_frame_size) {

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -4378,9 +4378,15 @@ pub const H2FrameParser = struct {
     }
 
     /// Sweep and free every stream entry whose state is CLOSED. Used by
-    /// session-teardown paths that mark all streams CLOSED mid-iteration —
-    /// removing in-place during a StreamResumableIterator walk could disturb
-    /// the iterator, so terminal paths batch the removal here.
+    /// `flushStreamQueue`'s defer to reclaim streams that `flushQueue`
+    /// transitioned to CLOSED but intentionally left in the map (see the
+    /// comment block there), and as a belt-and-suspenders leading/trailing
+    /// sweep around the `emitAbortToAllStreams` / `emitErrorToAllStreams`
+    /// walks to catch any pre-existing CLOSED entries that their loops
+    /// skip. `std.HashMap.fetchRemove` only tombstones the slot — it never
+    /// rehashes or shifts — so mid-iteration removal itself is safe; this
+    /// batching is a deferred cleanup for paths that deliberately defer
+    /// reclamation, not a workaround for iterator fragility.
     fn removeAllClosedStreams(this: *H2FrameParser) void {
         // Mirror removeStreamByID's server-side gate so we don't walk the
         // map + heap-allocate an O(N) id list on every flushStreamQueue for

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -1269,6 +1269,31 @@ pub const H2FrameParser = struct {
         }
     }
 
+    /// Unlink a stream from the map without freeing it. Used by the
+    /// endStream/abortStream path to prevent a re-entrant
+    /// `removeAllClosedStreams` sweep (triggered by a user
+    /// `session.destroy()` inside a write callback dispatched by
+    /// `freeResources` → `cleanQueue`) from freeing the stream before the
+    /// outer frame finishes its post-dispatch reads. Caller is responsible
+    /// for `destroyDetachedStream` once all accesses to the `*Stream`
+    /// complete.
+    fn detachStreamFromMap(this: *H2FrameParser, stream_id: u32) void {
+        if (this.isServer) return; // mirror removeStreamByID's server gate
+        _ = this.streams.fetchRemove(stream_id);
+        if (stream_id > this.max_removed_stream_id) {
+            this.max_removed_stream_id = stream_id;
+        }
+    }
+
+    /// Free a `*Stream` that was previously unlinked via
+    /// `detachStreamFromMap` and drained via `freeResources`. Server-side
+    /// streams are never detached, so this is a no-op on the server to
+    /// match `removeStreamByID`.
+    fn destroyDetachedStream(this: *H2FrameParser, stream: *Stream) void {
+        if (this.isServer) return;
+        bun.destroy(stream);
+    }
+
     const HeaderValue = lshpack.HPACK.DecodeResult;
 
     pub fn decode(this: *H2FrameParser, src_buffer: []const u8) !HeaderValue {
@@ -1387,10 +1412,18 @@ pub const H2FrameParser = struct {
         const stream_id = stream.id;
         const identifier = stream.getIdentifier();
         identifier.ensureStillAlive();
+        // Unlink from the map *before* freeResources runs. freeResources →
+        // cleanQueue dispatches queued DATA write callbacks back into JS;
+        // if that callback calls session.destroy() → emitErrorToAllStreams
+        // → removeAllClosedStreams() finds this already-.CLOSED stream in
+        // the map and bun.destroy()s it, leaving the outer freeResources
+        // reading this.signal on freed memory. Dropping it from the map
+        // first means the re-entrant sweep can't see it.
+        this.detachStreamFromMap(stream_id);
         stream.freeResources(this, false);
         this.dispatchWith2Extra(.onAborted, identifier, abortReason, jsc.JSValue.jsNumber(@intFromEnum(old_state)));
         _ = this.write(&buffer);
-        this.removeStreamByID(stream_id);
+        this.destroyDetachedStream(stream);
     }
 
     pub fn endStream(this: *H2FrameParser, stream: *Stream, rstCode: ErrorCode) void {
@@ -1419,15 +1452,21 @@ pub const H2FrameParser = struct {
         const stream_id = stream.id;
         const identifier = stream.getIdentifier();
         identifier.ensureStillAlive();
+        // Unlink before freeResources runs; see abortStream for the
+        // dispatch-re-entry UAF this avoids.
+        this.detachStreamFromMap(stream_id);
         stream.freeResources(this, false);
         if (rstCode == .NO_ERROR) {
-            this.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(@intFromEnum(stream.state)));
+            // stream.state is guaranteed .CLOSED here; no reason to
+            // re-read it from a pointer that outlived dispatchWriteCallback.
+            const closed_state_value = @intFromEnum(@as(@FieldType(Stream, "state"), .CLOSED));
+            this.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(closed_state_value));
         } else {
             this.dispatchWithExtra(.onStreamError, identifier, jsc.JSValue.jsNumber(@intFromEnum(rstCode)));
         }
 
         _ = this.write(&buffer);
-        this.removeStreamByID(stream_id);
+        this.destroyDetachedStream(stream);
     }
 
     pub fn sendGoAway(this: *H2FrameParser, streamIdentifier: u32, rstCode: ErrorCode, debug_data: []const u8, lastStreamID: u32, emitError: bool) void {

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -3421,10 +3421,10 @@ pub const H2FrameParser = struct {
         const stream = this.streams.get(stream_id) orelse {
             // Stream was removed after close — report a CLOSED state so
             // JS consumers get a consistent answer instead of a throw.
-            const closed_state_number: u8 = 7; // Stream.state enum value for CLOSED
+            const closed_state_value = @intFromEnum(@as(@FieldType(Stream, "state"), .CLOSED));
             var closed_state = jsc.JSValue.createEmptyObject(globalObject, 6);
             closed_state.put(globalObject, jsc.ZigString.static("localWindowSize"), jsc.JSValue.jsNumber(0));
-            closed_state.put(globalObject, jsc.ZigString.static("state"), jsc.JSValue.jsNumber(closed_state_number));
+            closed_state.put(globalObject, jsc.ZigString.static("state"), jsc.JSValue.jsNumber(closed_state_value));
             closed_state.put(globalObject, jsc.ZigString.static("localClose"), jsc.JSValue.jsNumber(1));
             closed_state.put(globalObject, jsc.ZigString.static("remoteClose"), jsc.JSValue.jsNumber(1));
             closed_state.put(globalObject, jsc.ZigString.static("sumDependencyWeight"), jsc.JSValue.jsNumber(0));

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -968,8 +968,9 @@ pub const H2FrameParser = struct {
                                                 client.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(@intFromEnum(stream.state)));
                                                 // Do not `removeStreamByID` here; we are inside a
                                                 // StreamResumableIterator walk in flushStreamQueue.
-                                                // The outer loop sweeps closed streams after each
-                                                // pass via removeAllClosedStreams.
+                                                // Closed streams are reclaimed via the
+                                                // `defer removeAllClosedStreams()` in flushStreamQueue
+                                                // itself, which runs once when that function returns.
                                             }
                                         }
                                     }
@@ -2256,8 +2257,13 @@ pub const H2FrameParser = struct {
     }
 
     pub fn handleGoAwayFrame(this: *H2FrameParser, frame: FrameHeader, data: []const u8, stream_: ?*Stream) usize {
+        _ = stream_;
         log("handleGoAwayFrame {} {s}", .{ frame.streamIdentifier, data });
-        if (stream_ != null) {
+        // RFC 7540 §6.8: GOAWAY MUST have streamIdentifier == 0. Check the
+        // wire field directly rather than `stream_ != null` — on the client
+        // side handleReceivedStreamID now returns null for stale nonzero
+        // ids, which would otherwise sneak an RFC-violating GOAWAY past us.
+        if (frame.streamIdentifier != 0) {
             this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "GoAway frame on stream", this.lastStreamID, true);
             return data.len;
         }
@@ -2420,7 +2426,12 @@ pub const H2FrameParser = struct {
     }
 
     pub fn handlePingFrame(this: *H2FrameParser, frame: FrameHeader, data: []const u8, stream_: ?*Stream) usize {
-        if (stream_ != null) {
+        _ = stream_;
+        // RFC 7540 §6.7: PING MUST have streamIdentifier == 0. Check the
+        // wire field directly rather than `stream_ != null` — on the client
+        // side handleReceivedStreamID now returns null for stale nonzero
+        // ids, which would otherwise sneak an RFC-violating PING past us.
+        if (frame.streamIdentifier != 0) {
             this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Ping frame on stream", this.lastStreamID, true);
             return data.len;
         }

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -675,10 +675,6 @@ pub const H2FrameParser = struct {
     outStandingPings: u64 = 0,
     maxSendHeaderBlockLength: u32 = 0,
     lastStreamID: u32 = 0,
-    /// Highest stream id we've removed from the map via removeStreamByID.
-    /// Used to distinguish stale (previously-open, now-reclaimed) stream ids
-    /// from brand-new ones we've simply never seen. Monotonic: only advances.
-    max_removed_stream_id: u32 = 0,
     isServer: bool = false,
     prefaceReceivedLen: u8 = 0,
     // we buffer requests until we get the first settings ACK
@@ -1258,9 +1254,6 @@ pub const H2FrameParser = struct {
         if (this.isServer) return;
         if (this.streams.fetchRemove(stream_id)) |kv| {
             const stream = kv.value;
-            if (stream_id > this.max_removed_stream_id) {
-                this.max_removed_stream_id = stream_id;
-            }
             // freeResources is idempotent; call again in case an earlier path
             // skipped it (e.g. request() error branches that set state = .CLOSED
             // without invoking freeResources).
@@ -1280,9 +1273,6 @@ pub const H2FrameParser = struct {
     fn detachStreamFromMap(this: *H2FrameParser, stream_id: u32) void {
         if (this.isServer) return; // mirror removeStreamByID's server gate
         _ = this.streams.fetchRemove(stream_id);
-        if (stream_id > this.max_removed_stream_id) {
-            this.max_removed_stream_id = stream_id;
-        }
     }
 
     /// Free a `*Stream` that was previously unlinked via
@@ -4344,6 +4334,11 @@ pub const H2FrameParser = struct {
     /// removing in-place during a StreamResumableIterator walk could disturb
     /// the iterator, so terminal paths batch the removal here.
     fn removeAllClosedStreams(this: *H2FrameParser) void {
+        // Mirror removeStreamByID's server-side gate so we don't walk the
+        // map + heap-allocate an O(N) id list on every flushStreamQueue for
+        // a long-lived server session (the sweep would no-op via
+        // removeStreamByID anyway).
+        if (this.isServer) return;
         // Collect ids to remove. Iteration is stable as long as nothing grows
         // the map; we only read keys here.
         var to_remove: std.ArrayListUnmanaged(u32) = .{};

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -1876,6 +1876,61 @@ pub const H2FrameParser = struct {
         end: usize,
     };
 
+    /// Drop exactly one frame's payload without dispatching it. Used when a
+    /// frame arrives for a stream we've already removed (RFC 7540 §5.1 permits
+    /// late frames during the brief window before the peer sees our
+    /// RST/END_STREAM). Advances `remainingLength` / clears `currentFrame` the
+    /// same way a normal `handleIncommingPayload` loop would, so the parser
+    /// moves past the frame and doesn't re-enter the null-stream branch
+    /// forever on subsequent reads. For DATA, the connection-level
+    /// flow-control window is charged so the peer's view of our receive window
+    /// stays consistent. For HEADERS/CONTINUATION the HPACK dynamic table is
+    /// advanced through the payload even though nothing is dispatched — HPACK
+    /// state is shared across streams, so skipping decode would desync the
+    /// table and corrupt every subsequent request on this session.
+    fn discardFramePayload(this: *H2FrameParser, frame: FrameHeader, data: []const u8) usize {
+        // DATA frames count against the connection-level receive window even
+        // when the stream is gone.
+        if (frame.type == @intFromEnum(FrameType.HTTP_FRAME_DATA)) {
+            const chunk_len: u32 = @intCast(@min(@as(usize, @intCast(this.remainingLength)), data.len));
+            this.adjustWindowSize(null, chunk_len);
+        }
+        if (handleIncommingPayload(this, data, frame.streamIdentifier)) |content| {
+            defer this.readBuffer.reset();
+            // For header block fragments, walk the decoder over the payload
+            // so the HPACK dynamic table stays in sync with the peer.
+            if (frame.type == @intFromEnum(FrameType.HTTP_FRAME_HEADERS) or
+                frame.type == @intFromEnum(FrameType.HTTP_FRAME_CONTINUATION))
+            {
+                var payload = content.data;
+                // HEADERS carries optional padding length + optional priority
+                // before the header block. CONTINUATION has no padding/priority.
+                if (frame.type == @intFromEnum(FrameType.HTTP_FRAME_HEADERS)) {
+                    var offset: usize = 0;
+                    if (frame.flags & @intFromEnum(HeadersFrameFlags.PADDED) != 0 and payload.len >= 1) {
+                        const padding: usize = payload[0];
+                        offset += 1;
+                        if (padding + offset > payload.len) return content.end; // malformed, give up
+                        payload = payload[offset .. payload.len - padding];
+                    } else {
+                        payload = payload[offset..];
+                    }
+                    if (frame.flags & @intFromEnum(HeadersFrameFlags.PRIORITY) != 0) {
+                        if (payload.len < 5) return content.end;
+                        payload = payload[5..];
+                    }
+                }
+                while (payload.len > 0) {
+                    const header = this.decode(payload) catch break;
+                    if (header.next == 0) break; // decoder didn't advance; bail
+                    payload = payload[header.next..];
+                }
+            }
+            return content.end;
+        }
+        return data.len;
+    }
+
     // Default handling for payload is buffering it
     // for data frames we use another strategy
     pub fn handleIncommingPayload(this: *H2FrameParser, data: []const u8, streamIdentifier: u32) ?Payload {
@@ -2038,13 +2093,16 @@ pub const H2FrameParser = struct {
             log("received data frame on stream that does not exist", .{});
             // id=0 is a protocol error (DATA frames require a stream). For a
             // nonzero id that isn't in the map, the stream was closed and
-            // removed; drop the frame silently (RFC 7540 Section 5.1 allows
-            // late frames during the brief window before the peer sees our
-            // RST/END_STREAM).
+            // removed; drop the frame silently (RFC 7540 §5.1 permits late
+            // frames during the brief window before the peer sees our
+            // RST/END_STREAM). In either case the payload still has to be
+            // drained so `remainingLength`/`currentFrame` advance past the
+            // frame — otherwise the parser loops on this header forever.
             if (frame.streamIdentifier == 0) {
                 this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Data frame on connection stream", this.lastStreamID, true);
+                return data.len;
             }
-            return data.len;
+            return this.discardFramePayload(frame, data);
         };
 
         const settings = this.remoteSettings orelse this.localSettings;
@@ -2282,10 +2340,12 @@ pub const H2FrameParser = struct {
         var stream = stream_ orelse {
             if (frame.streamIdentifier == 0) {
                 this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "RST_STREAM frame on connection stream", this.lastStreamID, true);
+                return data.len;
             }
             // Stale RST for an already-closed stream: the peer is acknowledging
-            // a close we already performed — nothing more to do.
-            return data.len;
+            // a close we already performed — drain the 4-byte payload so the
+            // parser moves past this frame.
+            return this.discardFramePayload(frame, data);
         };
 
         if (frame.length != 4) {
@@ -2352,9 +2412,11 @@ pub const H2FrameParser = struct {
         var stream = stream_ orelse {
             if (frame.streamIdentifier == 0) {
                 this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Priority frame on connection stream", this.lastStreamID, true);
+                return data.len;
             }
-            // Priority frames for already-closed streams are harmless; ignore.
-            return data.len;
+            // Priority frames for already-closed streams are harmless; drain
+            // the 5-byte payload and move on.
+            return this.discardFramePayload(frame, data);
         };
 
         if (frame.length != StreamPriority.byteSize) {
@@ -2393,10 +2455,14 @@ pub const H2FrameParser = struct {
         var stream = stream_ orelse {
             if (frame.streamIdentifier == 0) {
                 this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Continuation on connection stream", this.lastStreamID, true);
+                return data.len;
             }
             // CONTINUATION for an already-closed stream: nothing to attach
-            // headers to; drop quietly.
-            return data.len;
+            // headers to; drain the payload and move on. HPACK state is not
+            // advanced (decodeHeaderBlock isn't called), but stale
+            // continuations only follow HEADERS/CONTINUATION that were also
+            // dropped above, so there's no fragment to reassemble.
+            return this.discardFramePayload(frame, data);
         };
 
         if (!stream.isWaitingMoreHeaders) {
@@ -2442,9 +2508,12 @@ pub const H2FrameParser = struct {
         var stream = stream_ orelse {
             if (frame.streamIdentifier == 0) {
                 this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Headers frame on connection stream", this.lastStreamID, true);
+                return data.len;
             }
-            // Late HEADERS for an already-closed stream: drop quietly.
-            return data.len;
+            // Late HEADERS/trailers for an already-closed stream: drain the
+            // payload and keep the HPACK dynamic table in sync so subsequent
+            // streams on this session still decode correctly.
+            return this.discardFramePayload(frame, data);
         };
 
         const settings = this.remoteSettings orelse this.localSettings;

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -4324,10 +4324,21 @@ pub const H2FrameParser = struct {
                 const old_state = stream.state;
                 stream.state = .CLOSED;
                 stream.rstCode = @intFromEnum(ErrorCode.CANCEL);
+                const stream_id = stream.id;
                 const identifier = stream.getIdentifier();
                 identifier.ensureStillAlive();
+                // Detach before freeResources: freeResources → cleanQueue
+                // dispatches queued DATA write callbacks, and a user
+                // callback that calls session.destroy() would re-enter
+                // emitErrorToAllStreams whose leading
+                // removeAllClosedStreams() would see this CLOSED-in-map
+                // entry and free it, leaving the outer freeResources
+                // touching this.signal on freed heap. Mirror abortStream/
+                // endStream's detach-then-destroy pattern.
+                this.detachStreamFromMap(stream_id);
                 stream.freeResources(this, false);
                 this.dispatchWith2Extra(.onAborted, identifier, .js_undefined, jsc.JSValue.jsNumber(@intFromEnum(old_state)));
+                this.destroyDetachedStream(stream);
             }
         }
         this.removeAllClosedStreams();
@@ -4351,10 +4362,15 @@ pub const H2FrameParser = struct {
             if (stream.state != .CLOSED) {
                 stream.state = .CLOSED;
                 stream.rstCode = args_list.ptr[0].to(u32);
+                const stream_id = stream.id;
                 const identifier = stream.getIdentifier();
                 identifier.ensureStillAlive();
+                // Detach before freeResources — same re-entrancy hazard as
+                // emitAbortToAllStreams above.
+                this.detachStreamFromMap(stream_id);
                 stream.freeResources(this, false);
                 this.dispatchWithExtra(.onStreamError, identifier, args_list.ptr[0]);
+                this.destroyDetachedStream(stream);
             }
         }
         this.removeAllClosedStreams();
@@ -4582,7 +4598,7 @@ pub const H2FrameParser = struct {
         const encoded_data = encoded_headers.items;
         const encoded_size = encoded_data.len;
 
-        const stream = this.handleReceivedStreamID(stream_id) orelse {
+        var stream = this.handleReceivedStreamID(stream_id) orelse {
             return jsc.JSValue.jsNumber(-1);
         };
         if (!stream_ctx_arg.isEmptyOrUndefinedOrNull() and stream_ctx_arg.isObject()) {
@@ -4606,7 +4622,16 @@ pub const H2FrameParser = struct {
                 return jsc.JSValue.jsNumber(stream_id);
             }
 
+            // Every `options.get(globalObject, ...)` below can invoke a
+            // user getter / Proxy trap that synchronously calls
+            // `session.destroy()` → `emitErrorToAllStreams` →
+            // `removeAllClosedStreams()` → `bun.destroy(stream)`. Any
+            // subsequent `stream.*` access would then hit freed heap.
+            // Re-resolve from the map after each `options.get`, bail out
+            // if the stream was destroyed. Same pattern as
+            // setStreamPriority / sendTrailers.
             if (try options.get(globalObject, "paddingStrategy")) |padding_js| {
+                stream = this.streams.get(stream_id) orelse return jsc.JSValue.jsNumber(stream_id);
                 if (padding_js.isNumber()) {
                     stream.paddingStrategy = switch (padding_js.to(u32)) {
                         1 => .aligned,
@@ -4617,6 +4642,7 @@ pub const H2FrameParser = struct {
             }
 
             if (try options.get(globalObject, "waitForTrailers")) |trailes_js| {
+                stream = this.streams.get(stream_id) orelse return jsc.JSValue.jsNumber(stream_id);
                 if (trailes_js.isBoolean()) {
                     waitForTrailers = trailes_js.asBoolean();
                     stream.waitForTrailers = waitForTrailers;
@@ -4648,6 +4674,7 @@ pub const H2FrameParser = struct {
             if (try options.get(globalObject, "exclusive")) |exclusive_js| {
                 if (exclusive_js.isBoolean()) {
                     if (exclusive_js.asBoolean()) {
+                        stream = this.streams.get(stream_id) orelse return jsc.JSValue.jsNumber(stream_id);
                         exclusive = true;
                         stream.exclusive = true;
                         has_priority = true;
@@ -4659,6 +4686,7 @@ pub const H2FrameParser = struct {
 
             if (try options.get(globalObject, "parent")) |parent_js| {
                 if (parent_js.isNumber() or parent_js.isInt32()) {
+                    stream = this.streams.get(stream_id) orelse return jsc.JSValue.jsNumber(stream_id);
                     has_priority = true;
                     parent = parent_js.toInt32();
                     if (parent <= 0 or parent > MAX_STREAM_ID) {
@@ -4677,6 +4705,7 @@ pub const H2FrameParser = struct {
 
             if (try options.get(globalObject, "weight")) |weight_js| {
                 if (weight_js.isNumber() or weight_js.isInt32()) {
+                    stream = this.streams.get(stream_id) orelse return jsc.JSValue.jsNumber(stream_id);
                     has_priority = true;
                     weight = weight_js.toInt32();
                     if (weight < 1 or weight > std.math.maxInt(u8)) {
@@ -4703,6 +4732,7 @@ pub const H2FrameParser = struct {
             }
 
             if (try options.get(globalObject, "signal")) |signal_arg| {
+                stream = this.streams.get(stream_id) orelse return jsc.JSValue.jsNumber(stream_id);
                 if (signal_arg.as(jsc.WebCore.AbortSignal)) |signal_| {
                     if (signal_.aborted()) {
                         stream.state = .IDLE;
@@ -4714,6 +4744,12 @@ pub const H2FrameParser = struct {
                     return globalObject.throwInvalidArgumentTypeValue("options.signal", "AbortSignal", signal_arg);
                 }
             }
+
+            // Final re-resolve after the options block — covers the
+            // subsequent stream.* accesses (getSessionMemoryUsage gate,
+            // encoded_size check, frame writes). If a trailing options.get
+            // above wiped the stream out, bail.
+            stream = this.streams.get(stream_id) orelse return jsc.JSValue.jsNumber(stream_id);
         }
 
         // too much memory being use

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -675,6 +675,10 @@ pub const H2FrameParser = struct {
     outStandingPings: u64 = 0,
     maxSendHeaderBlockLength: u32 = 0,
     lastStreamID: u32 = 0,
+    /// Highest stream id we've removed from the map via removeStreamByID.
+    /// Used to distinguish stale (previously-open, now-reclaimed) stream ids
+    /// from brand-new ones we've simply never seen. Monotonic: only advances.
+    max_removed_stream_id: u32 = 0,
     isServer: bool = false,
     prefaceReceivedLen: u8 = 0,
     // we buffer requests until we get the first settings ACK
@@ -1240,8 +1244,22 @@ pub const H2FrameParser = struct {
     ///    could be disturbed by insertions (removal is safe; growth is not).
     /// No-op if the id is not in the map (defensive; normal paths always find it).
     fn removeStreamByID(this: *H2FrameParser, stream_id: u32) void {
+        // Server-side removal is disabled. Bun's own client emits child
+        // HEADERS ahead of the parent's HEADERS when a request() options
+        // getter re-enters (see node-http2-streams-rehash), so ids can
+        // arrive out of order on the wire and a brand-new id can land at
+        // or below our high-water mark. Without a reliable way to tell
+        // "stale removed stream" from "out-of-order new stream" on the
+        // server, the safer choice is to keep closed streams in the map
+        // as before. The #30415 leak is strictly client-side (AWS SDK
+        // pooled `http2.connect()` sessions); the server-side unbounded
+        // map growth was the pre-PR status quo.
+        if (this.isServer) return;
         if (this.streams.fetchRemove(stream_id)) |kv| {
             const stream = kv.value;
+            if (stream_id > this.max_removed_stream_id) {
+                this.max_removed_stream_id = stream_id;
+            }
             // freeResources is idempotent; call again in case an earlier path
             // skipped it (e.g. request() error branches that set state = .CLOSED
             // without invoking freeResources).
@@ -2738,24 +2756,17 @@ pub const H2FrameParser = struct {
             return stream;
         }
 
-        // Stale-stream detection applies only to the client side. Client
-        // stream ids are allocated monotonically via getNextStream() (and the
-        // even-id push-promise space is updated the same way), so any id
-        // <= lastStreamID that isn't in the map was closed and removed.
-        // RFC 7540 §5.1 permits late frames from the peer during the brief
-        // window before it sees our RST/END_STREAM. Signal to callers by
-        // returning null; frame handlers below distinguish "stream-level
-        // stale" from "connection-level (id=0)" using streamIdentifier.
+        // Stale stream on the client side: client ids are allocated
+        // monotonically via getNextStream(), so any id <= lastStreamID that
+        // isn't in the map was closed and removed (RFC 7540 §5.1 permits
+        // late frames from the peer before it sees our RST/END_STREAM).
+        // Frame handlers distinguish "stream-level stale" from
+        // "connection-level (id=0)" using streamIdentifier itself.
         //
-        // On the server, the peer chooses ids. A new id <= lastStreamID may
-        // be a stale removed stream OR an out-of-order stream from a
-        // misbehaving client. We can't distinguish without tracking every
-        // removed id, so keep the pre-PR "create a fresh stream" behavior
-        // and avoid rejecting out-of-order clients more strictly than before.
-        // The memory leak this PR targets (#30415) is client-side only
-        // (AWS SDK pooled `http2.connect()` sessions) — server-side map
-        // growth still bounds to the total lifetime request count, which is
-        // the prior behavior.
+        // Server-side removal is disabled in removeStreamByID (see comment
+        // there), so server-side closed streams stay in the map and this
+        // branch is unreachable from the server — a server-observed id
+        // that isn't in the map is genuinely new.
         if (!this.isServer and streamIdentifier <= this.lastStreamID) {
             return null;
         }

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -2738,17 +2738,31 @@ pub const H2FrameParser = struct {
             return stream;
         }
 
-        // Stale stream: an id at or below the high-water mark that isn't in the
-        // map was closed and removed. RFC 7540 Section 5.1 allows frames to
-        // arrive for a short window after the stream closes (peer hasn't
-        // processed our RST/END_STREAM yet). Signal to callers by returning
-        // null; frame handlers below distinguish "stream-level stale" from
-        // "connection-level (id=0)" using the streamIdentifier itself.
-        if (streamIdentifier <= this.lastStreamID) {
+        // Stale-stream detection applies only to the client side. Client
+        // stream ids are allocated monotonically via getNextStream() (and the
+        // even-id push-promise space is updated the same way), so any id
+        // <= lastStreamID that isn't in the map was closed and removed.
+        // RFC 7540 §5.1 permits late frames from the peer during the brief
+        // window before it sees our RST/END_STREAM. Signal to callers by
+        // returning null; frame handlers below distinguish "stream-level
+        // stale" from "connection-level (id=0)" using streamIdentifier.
+        //
+        // On the server, the peer chooses ids. A new id <= lastStreamID may
+        // be a stale removed stream OR an out-of-order stream from a
+        // misbehaving client. We can't distinguish without tracking every
+        // removed id, so keep the pre-PR "create a fresh stream" behavior
+        // and avoid rejecting out-of-order clients more strictly than before.
+        // The memory leak this PR targets (#30415) is client-side only
+        // (AWS SDK pooled `http2.connect()` sessions) — server-side map
+        // growth still bounds to the total lifetime request count, which is
+        // the prior behavior.
+        if (!this.isServer and streamIdentifier <= this.lastStreamID) {
             return null;
         }
 
-        this.lastStreamID = streamIdentifier;
+        if (streamIdentifier > this.lastStreamID) {
+            this.lastStreamID = streamIdentifier;
+        }
 
         // new stream open
         // Per RFC 7540 Section 6.5.1: The sender of SETTINGS can only rely on the

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -1983,9 +1983,16 @@ pub const H2FrameParser = struct {
             this.readBuffer.reset();
             if (stream) |s| {
                 s.remoteWindowSize += windowSizeIncrement.uint31;
-            } else {
+            } else if (frame.streamIdentifier == 0) {
+                // Connection-level WINDOW_UPDATE (RFC 7540 §6.9).
                 this.remoteWindowSize += windowSizeIncrement.uint31;
             }
+            // else: nonzero id with no matching stream — stale stream-level
+            // WINDOW_UPDATE for a close we've already reclaimed. RFC 7540
+            // §5.1 permits these in the brief window before the peer sees
+            // our RST/END_STREAM. Crediting this to `this.remoteWindowSize`
+            // would overshoot the peer's connection window and eventually
+            // trip GOAWAY(FLOW_CONTROL_ERROR) on long-lived pooled sessions.
             log("windowSizeIncrement stream {} value {}", .{ frame.streamIdentifier, windowSizeIncrement });
             return content.end;
         }
@@ -2458,10 +2465,10 @@ pub const H2FrameParser = struct {
                 return data.len;
             }
             // CONTINUATION for an already-closed stream: nothing to attach
-            // headers to; drain the payload and move on. HPACK state is not
-            // advanced (decodeHeaderBlock isn't called), but stale
-            // continuations only follow HEADERS/CONTINUATION that were also
-            // dropped above, so there's no fragment to reassemble.
+            // headers to. discardFramePayload walks the HPACK decoder over
+            // the fragment so the connection-scoped dynamic table stays in
+            // sync, then drains the payload so the parser moves past this
+            // frame.
             return this.discardFramePayload(frame, data);
         };
 

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -2442,13 +2442,21 @@ pub const H2FrameParser = struct {
             const stream_id = stream.id;
             const identifier = stream.getIdentifier();
             identifier.ensureStillAlive();
+            // Unlink before freeResources runs: freeResources → cleanQueue
+            // dispatches queued DATA write callbacks, and a user callback
+            // that calls session.destroy() would reach
+            // emitErrorToAllStreams → removeAllClosedStreams and free this
+            // stream out from under us. Mirror the endStream/abortStream
+            // detach-then-destroy pattern.
+            this.detachStreamFromMap(stream_id);
             stream.freeResources(this, false);
+            const closed_state_value = @intFromEnum(@as(@FieldType(Stream, "state"), .CLOSED));
             if (rst_code == @intFromEnum(ErrorCode.NO_ERROR)) {
-                this.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(@intFromEnum(stream.state)));
+                this.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(closed_state_value));
             } else {
                 this.dispatchWithExtra(.onStreamError, identifier, jsc.JSValue.jsNumber(rst_code));
             }
-            this.removeStreamByID(stream_id);
+            this.destroyDetachedStream(stream);
             return content.end;
         }
         return data.len;
@@ -3968,6 +3976,12 @@ pub const H2FrameParser = struct {
                         if (err == error.OutOfMemory) {
                             return globalObject.throw("Failed to allocate header buffer", .{});
                         }
+                        // `item.toJSString()` and `sensitive_arg.getTruthyPropertyValue()`
+                        // above (and in prior iterations) can invoke a user Proxy trap
+                        // / Symbol.toPrimitive that aborts the stream's AbortSignal →
+                        // SignalRef.abortListener → abortStream → bun.destroy(stream).
+                        // Re-resolve before touching `stream.*`.
+                        stream = this.streams.get(stream_id) orelse return .js_undefined;
                         stream.state = .CLOSED;
                         const identifier = stream.getIdentifier();
                         identifier.ensureStillAlive();
@@ -4009,6 +4023,8 @@ pub const H2FrameParser = struct {
                     if (err == error.OutOfMemory) {
                         return globalObject.throw("Failed to allocate header buffer", .{});
                     }
+                    // Same UAF concern as the sibling branch above.
+                    stream = this.streams.get(stream_id) orelse return .js_undefined;
                     stream.state = .CLOSED;
                     const identifier = stream.getIdentifier();
                     identifier.ensureStillAlive();

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -932,26 +932,41 @@ pub const H2FrameParser = struct {
                 if (this.dataFrameQueue.peekFront()) |frame| {
                     const no_backpressure = brk: {
                         var is_flow_control_limited = false;
+                        const stream_id_local = this.id;
                         defer {
                             if (!is_flow_control_limited) {
                                 // only call the callback + free the frame if we write to the socket the full frame
                                 var _frame = this.dataFrameQueue.dequeue().?;
                                 client.outboundQueueSize -= 1;
 
+                                // Dispatching the write callback re-enters JS.
+                                // User code may synchronously destroy or reset
+                                // this stream (stream.close → rstStream →
+                                // endStream → removeStreamByID), in which case
+                                // `this` is freed and the stream no longer
+                                // exists in `client.streams`. Look up by id
+                                // after dispatch rather than trusting `this`.
                                 if (_frame.callback.get()) |callback_value| client.dispatchWriteCallback(callback_value);
-                                if (this.dataFrameQueue.isEmpty()) {
-                                    if (_frame.end_stream) {
-                                        if (this.waitForTrailers) {
-                                            client.dispatch(.onWantTrailers, this.getIdentifier());
-                                        } else {
-                                            const identifier = this.getIdentifier();
-                                            identifier.ensureStillAlive();
-                                            if (this.state == .HALF_CLOSED_REMOTE) {
-                                                this.state = .CLOSED;
+                                if (client.streams.get(stream_id_local)) |stream| {
+                                    if (stream.dataFrameQueue.isEmpty()) {
+                                        if (_frame.end_stream) {
+                                            if (stream.waitForTrailers) {
+                                                client.dispatch(.onWantTrailers, stream.getIdentifier());
                                             } else {
-                                                this.state = .HALF_CLOSED_LOCAL;
+                                                const identifier = stream.getIdentifier();
+                                                identifier.ensureStillAlive();
+                                                if (stream.state == .HALF_CLOSED_REMOTE) {
+                                                    stream.state = .CLOSED;
+                                                    stream.freeResources(client, false);
+                                                } else if (stream.state != .CLOSED) {
+                                                    stream.state = .HALF_CLOSED_LOCAL;
+                                                }
+                                                client.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(@intFromEnum(stream.state)));
+                                                // Do not `removeStreamByID` here; we are inside a
+                                                // StreamResumableIterator walk in flushStreamQueue.
+                                                // The outer loop sweeps closed streams after each
+                                                // pass via removeAllClosedStreams.
                                             }
-                                            client.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(@intFromEnum(this.state)));
                                         }
                                     }
                                 }
@@ -1217,6 +1232,24 @@ pub const H2FrameParser = struct {
         }
     };
 
+    /// Remove a stream entry from the streams map and free its heap allocation.
+    /// Callers must ensure:
+    ///  - The stream's terminal JS dispatch (onStreamEnd/onStreamError/onAborted)
+    ///    has already run, so no further code here looks up the id.
+    ///  - We are NOT inside a `StreamResumableIterator` walk over `streams` that
+    ///    could be disturbed by insertions (removal is safe; growth is not).
+    /// No-op if the id is not in the map (defensive; normal paths always find it).
+    fn removeStreamByID(this: *H2FrameParser, stream_id: u32) void {
+        if (this.streams.fetchRemove(stream_id)) |kv| {
+            const stream = kv.value;
+            // freeResources is idempotent; call again in case an earlier path
+            // skipped it (e.g. request() error branches that set state = .CLOSED
+            // without invoking freeResources).
+            stream.freeResources(this, false);
+            bun.destroy(stream);
+        }
+    }
+
     const HeaderValue = lshpack.HPACK.DecodeResult;
 
     pub fn decode(this: *H2FrameParser, src_buffer: []const u8) !HeaderValue {
@@ -1325,11 +1358,13 @@ pub const H2FrameParser = struct {
         _ = writer.write(std.mem.asBytes(&value)) catch 0;
         const old_state = stream.state;
         stream.state = .CLOSED;
+        const stream_id = stream.id;
         const identifier = stream.getIdentifier();
         identifier.ensureStillAlive();
         stream.freeResources(this, false);
         this.dispatchWith2Extra(.onAborted, identifier, abortReason, jsc.JSValue.jsNumber(@intFromEnum(old_state)));
         _ = this.write(&buffer);
+        this.removeStreamByID(stream_id);
     }
 
     pub fn endStream(this: *H2FrameParser, stream: *Stream, rstCode: ErrorCode) void {
@@ -1355,6 +1390,7 @@ pub const H2FrameParser = struct {
         _ = writer.write(std.mem.asBytes(&value)) catch 0;
 
         stream.state = .CLOSED;
+        const stream_id = stream.id;
         const identifier = stream.getIdentifier();
         identifier.ensureStillAlive();
         stream.freeResources(this, false);
@@ -1365,6 +1401,7 @@ pub const H2FrameParser = struct {
         }
 
         _ = this.write(&buffer);
+        this.removeStreamByID(stream_id);
     }
 
     pub fn sendGoAway(this: *H2FrameParser, streamIdentifier: u32, rstCode: ErrorCode, debug_data: []const u8, lastStreamID: u32, emitError: bool) void {
@@ -1666,6 +1703,11 @@ pub const H2FrameParser = struct {
         log("flushStreamQueue {}", .{this.outboundQueueSize});
         var written: usize = 0;
         var something_was_flushed = true;
+
+        // Any streams that flushQueue transitioned to CLOSED are reclaimed
+        // here after the iterator walk completes, so mid-iteration removal
+        // can't disturb the StreamResumableIterator's position.
+        defer this.removeAllClosedStreams();
 
         // try to send as much as we can until we reach backpressure or until we can't flush anymore
         while (this.outboundQueueSize > 0 and something_was_flushed) {
@@ -1994,7 +2036,14 @@ pub const H2FrameParser = struct {
 
         var stream = stream_ orelse {
             log("received data frame on stream that does not exist", .{});
-            this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Data frame on connection stream", this.lastStreamID, true);
+            // id=0 is a protocol error (DATA frames require a stream). For a
+            // nonzero id that isn't in the map, the stream was closed and
+            // removed; drop the frame silently (RFC 7540 Section 5.1 allows
+            // late frames during the brief window before the peer sees our
+            // RST/END_STREAM).
+            if (frame.streamIdentifier == 0) {
+                this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Data frame on connection stream", this.lastStreamID, true);
+            }
             return data.len;
         };
 
@@ -2091,13 +2140,17 @@ pub const H2FrameParser = struct {
                 const identifier = stream.getIdentifier();
                 identifier.ensureStillAlive();
 
+                var closed = false;
                 if (stream.state == .HALF_CLOSED_LOCAL) {
                     stream.state = .CLOSED;
                     stream.freeResources(this, false);
+                    closed = true;
                 } else {
                     stream.state = .HALF_CLOSED_REMOTE;
                 }
+                const closed_id = stream.id;
                 this.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(@intFromEnum(stream.state)));
+                if (closed) this.removeStreamByID(closed_id);
             }
         }
 
@@ -2227,7 +2280,11 @@ pub const H2FrameParser = struct {
     pub fn handleRSTStreamFrame(this: *H2FrameParser, frame: FrameHeader, data: []const u8, stream_: ?*Stream) usize {
         log("handleRSTStreamFrame {s}", .{data});
         var stream = stream_ orelse {
-            this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "RST_STREAM frame on connection stream", this.lastStreamID, true);
+            if (frame.streamIdentifier == 0) {
+                this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "RST_STREAM frame on connection stream", this.lastStreamID, true);
+            }
+            // Stale RST for an already-closed stream: the peer is acknowledging
+            // a close we already performed — nothing more to do.
             return data.len;
         };
 
@@ -2247,6 +2304,7 @@ pub const H2FrameParser = struct {
             stream.rstCode = rst_code;
             this.readBuffer.reset();
             stream.state = .CLOSED;
+            const stream_id = stream.id;
             const identifier = stream.getIdentifier();
             identifier.ensureStillAlive();
             stream.freeResources(this, false);
@@ -2255,6 +2313,7 @@ pub const H2FrameParser = struct {
             } else {
                 this.dispatchWithExtra(.onStreamError, identifier, jsc.JSValue.jsNumber(rst_code));
             }
+            this.removeStreamByID(stream_id);
             return content.end;
         }
         return data.len;
@@ -2291,7 +2350,10 @@ pub const H2FrameParser = struct {
 
     pub fn handlePriorityFrame(this: *H2FrameParser, frame: FrameHeader, data: []const u8, stream_: ?*Stream) usize {
         var stream = stream_ orelse {
-            this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Priority frame on connection stream", this.lastStreamID, true);
+            if (frame.streamIdentifier == 0) {
+                this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Priority frame on connection stream", this.lastStreamID, true);
+            }
+            // Priority frames for already-closed streams are harmless; ignore.
             return data.len;
         };
 
@@ -2329,7 +2391,11 @@ pub const H2FrameParser = struct {
     pub fn handleContinuationFrame(this: *H2FrameParser, frame: FrameHeader, data: []const u8, stream_: ?*Stream) bun.JSError!usize {
         log("handleContinuationFrame", .{});
         var stream = stream_ orelse {
-            this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Continuation on connection stream", this.lastStreamID, true);
+            if (frame.streamIdentifier == 0) {
+                this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Continuation on connection stream", this.lastStreamID, true);
+            }
+            // CONTINUATION for an already-closed stream: nothing to attach
+            // headers to; drop quietly.
             return data.len;
         };
 
@@ -2349,14 +2415,18 @@ pub const H2FrameParser = struct {
                 if (frame.flags & @intFromEnum(HeadersFrameFlags.END_STREAM) != 0) {
                     const identifier = stream.getIdentifier();
                     identifier.ensureStillAlive();
+                    var closed = false;
                     if (stream.state == .HALF_CLOSED_REMOTE) {
                         // no more continuation headers we can call it closed
                         stream.state = .CLOSED;
                         stream.freeResources(this, false);
+                        closed = true;
                     } else {
                         stream.state = .HALF_CLOSED_LOCAL;
                     }
+                    const closed_id = stream.id;
                     this.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(@intFromEnum(stream.state)));
+                    if (closed) this.removeStreamByID(closed_id);
                 }
             }
 
@@ -2370,7 +2440,10 @@ pub const H2FrameParser = struct {
     pub fn handleHeadersFrame(this: *H2FrameParser, frame: FrameHeader, data: []const u8, stream_: ?*Stream) bun.JSError!usize {
         log("handleHeadersFrame {s}", .{if (this.isServer) "server" else "client"});
         var stream = stream_ orelse {
-            this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Headers frame on connection stream", this.lastStreamID, true);
+            if (frame.streamIdentifier == 0) {
+                this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Headers frame on connection stream", this.lastStreamID, true);
+            }
+            // Late HEADERS for an already-closed stream: drop quietly.
             return data.len;
         };
 
@@ -2430,6 +2503,7 @@ pub const H2FrameParser = struct {
                 const identifier = stream.getIdentifier();
                 identifier.ensureStillAlive();
 
+                var closed = false;
                 if (stream.isWaitingMoreHeaders) {
                     stream.state = .HALF_CLOSED_REMOTE;
                 } else {
@@ -2437,11 +2511,14 @@ pub const H2FrameParser = struct {
                     if (stream.state == .HALF_CLOSED_LOCAL) {
                         stream.state = .CLOSED;
                         stream.freeResources(this, false);
+                        closed = true;
                     } else {
                         stream.state = .HALF_CLOSED_REMOTE;
                     }
                 }
+                const closed_id = stream.id;
                 this.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(@intFromEnum(stream.state)));
+                if (closed) this.removeStreamByID(closed_id);
             }
             return content.end;
         }
@@ -2557,7 +2634,8 @@ pub const H2FrameParser = struct {
         return data.len;
     }
 
-    /// Returned *Stream is heap-allocated and stable for the lifetime of this H2FrameParser.
+    /// Returned *Stream is heap-allocated and stable until the stream closes
+    /// (see removeStreamByID) or until H2FrameParser deinit.
     fn handleReceivedStreamID(this: *H2FrameParser, streamIdentifier: u32) ?*Stream {
         // connection stream
         if (streamIdentifier == 0) {
@@ -2569,9 +2647,17 @@ pub const H2FrameParser = struct {
             return stream;
         }
 
-        if (streamIdentifier > this.lastStreamID) {
-            this.lastStreamID = streamIdentifier;
+        // Stale stream: an id at or below the high-water mark that isn't in the
+        // map was closed and removed. RFC 7540 Section 5.1 allows frames to
+        // arrive for a short window after the stream closes (peer hasn't
+        // processed our RST/END_STREAM yet). Signal to callers by returning
+        // null; frame handlers below distinguish "stream-level stale" from
+        // "connection-level (id=0)" using the streamIdentifier itself.
+        if (streamIdentifier <= this.lastStreamID) {
+            return null;
         }
+
+        this.lastStreamID = streamIdentifier;
 
         // new stream open
         // Per RFC 7540 Section 6.5.1: The sender of SETTINGS can only rely on the
@@ -2931,7 +3017,7 @@ pub const H2FrameParser = struct {
 
     pub fn getCurrentState(this: *H2FrameParser, globalObject: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!JSValue {
         jsc.markBinding(@src());
-        var result = JSValue.createEmptyObject(globalObject, 9);
+        var result = JSValue.createEmptyObject(globalObject, 10);
         result.put(globalObject, jsc.ZigString.static("effectiveLocalWindowSize"), jsc.JSValue.jsNumber(this.windowSize));
         result.put(globalObject, jsc.ZigString.static("effectiveRecvDataLength"), jsc.JSValue.jsNumber(this.windowSize - this.usedWindowSize));
         result.put(globalObject, jsc.ZigString.static("nextStreamID"), jsc.JSValue.jsNumber(this.getNextStreamID()));
@@ -2943,6 +3029,10 @@ pub const H2FrameParser = struct {
         result.put(globalObject, jsc.ZigString.static("deflateDynamicTableSize"), jsc.JSValue.jsNumber(this.localSettings.headerTableSize));
         result.put(globalObject, jsc.ZigString.static("inflateDynamicTableSize"), jsc.JSValue.jsNumber(this.localSettings.headerTableSize));
         result.put(globalObject, jsc.ZigString.static("outboundQueueSize"), jsc.JSValue.jsNumber(this.outboundQueueSize));
+        // Count of tracked streams still in the hashmap. Used by the
+        // regression test for oven-sh/bun#30415 to confirm closed streams
+        // are reclaimed instead of accumulating.
+        result.put(globalObject, jsc.ZigString.static("streamCount"), jsc.JSValue.jsNumber(this.streams.count()));
         return result;
     }
 
@@ -3169,8 +3259,9 @@ pub const H2FrameParser = struct {
             return globalObject.throw("Invalid stream id", .{});
         }
 
+        // Stream was already removed after close; treat as no-end-after-headers.
         const stream = this.streams.get(stream_id) orelse {
-            return globalObject.throw("Invalid stream id", .{});
+            return .false;
         };
 
         return jsc.JSValue.jsBoolean(stream.endAfterHeaders);
@@ -3193,8 +3284,9 @@ pub const H2FrameParser = struct {
             return globalObject.throw("Invalid stream id", .{});
         }
 
+        // Stream was already removed after close; not aborted (ended normally).
         const stream = this.streams.get(stream_id) orelse {
-            return globalObject.throw("Invalid stream id", .{});
+            return .false;
         };
 
         if (stream.signal) |signal_ref| {
@@ -3221,8 +3313,18 @@ pub const H2FrameParser = struct {
             return globalObject.throw("Invalid stream id", .{});
         }
 
-        var stream = this.streams.get(stream_id) orelse {
-            return globalObject.throw("Invalid stream id", .{});
+        const stream = this.streams.get(stream_id) orelse {
+            // Stream was removed after close — report a CLOSED state so
+            // JS consumers get a consistent answer instead of a throw.
+            const closed_state_number: u8 = 7; // Stream.state enum value for CLOSED
+            var closed_state = jsc.JSValue.createEmptyObject(globalObject, 6);
+            closed_state.put(globalObject, jsc.ZigString.static("localWindowSize"), jsc.JSValue.jsNumber(0));
+            closed_state.put(globalObject, jsc.ZigString.static("state"), jsc.JSValue.jsNumber(closed_state_number));
+            closed_state.put(globalObject, jsc.ZigString.static("localClose"), jsc.JSValue.jsNumber(1));
+            closed_state.put(globalObject, jsc.ZigString.static("remoteClose"), jsc.JSValue.jsNumber(1));
+            closed_state.put(globalObject, jsc.ZigString.static("sumDependencyWeight"), jsc.JSValue.jsNumber(0));
+            closed_state.put(globalObject, jsc.ZigString.static("weight"), jsc.JSValue.jsNumber(0));
+            return closed_state;
         };
         var state = jsc.JSValue.createEmptyObject(globalObject, 6);
 
@@ -3353,8 +3455,12 @@ pub const H2FrameParser = struct {
             return globalObject.throw("Invalid stream id", .{});
         }
 
+        // JS stream destroy schedules this via setImmediate after the stream
+        // already transitioned to CLOSED natively and was removed from the
+        // map. Treat a missing entry as a benign "already closed" signal
+        // rather than a programming error.
         const stream = this.streams.get(stream_id) orelse {
-            return globalObject.throw("Invalid stream id", .{});
+            return .false;
         };
         if (!error_arg.isNumber()) {
             return globalObject.throw("Invalid ErrorCode", .{});
@@ -3404,6 +3510,7 @@ pub const H2FrameParser = struct {
         defer {
             if (!enqueued) {
                 this.dispatchWriteCallback(callback);
+                var closed = false;
                 if (close) {
                     if (stream.waitForTrailers) {
                         this.dispatch(.onWantTrailers, stream.getIdentifier());
@@ -3413,12 +3520,14 @@ pub const H2FrameParser = struct {
                         if (stream.state == .HALF_CLOSED_REMOTE) {
                             stream.state = .CLOSED;
                             stream.freeResources(this, false);
+                            closed = true;
                         } else {
                             stream.state = .HALF_CLOSED_LOCAL;
                         }
                         this.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(@intFromEnum(stream.state)));
                     }
                 }
+                if (closed) this.removeStreamByID(stream_id);
             }
             this.deref();
         }
@@ -3508,8 +3617,9 @@ pub const H2FrameParser = struct {
             return globalObject.throw("Invalid stream id", .{});
         }
 
+        // Stream was already closed and removed — nothing to trail.
         var stream = this.streams.get(@intCast(stream_id)) orelse {
-            return globalObject.throw("Invalid stream id", .{});
+            return .js_undefined;
         };
 
         stream.waitForTrailers = false;
@@ -3583,8 +3693,9 @@ pub const H2FrameParser = struct {
             return globalObject.throw("Invalid stream id", .{});
         }
 
+        // Stream was already closed and removed — nothing to trail.
         var stream = this.streams.get(@intCast(stream_id)) orelse {
-            return globalObject.throw("Invalid stream id", .{});
+            return .js_undefined;
         };
 
         const headers_obj = headers_arg.getObject() orelse {
@@ -3692,6 +3803,7 @@ pub const H2FrameParser = struct {
                             jsc.JSValue.jsNumber(@intFromEnum(ErrorCode.FRAME_SIZE_ERROR)),
                         );
                         this.dispatchWithExtra(.onStreamError, identifier, jsc.JSValue.jsNumber(stream.rstCode));
+                        this.removeStreamByID(stream_id);
                         return .js_undefined;
                     };
                 }
@@ -3732,6 +3844,7 @@ pub const H2FrameParser = struct {
                         jsc.JSValue.jsNumber(@intFromEnum(ErrorCode.FRAME_SIZE_ERROR)),
                     );
                     this.dispatchWithExtra(.onStreamError, identifier, jsc.JSValue.jsNumber(stream.rstCode));
+                    this.removeStreamByID(stream_id);
                     return .js_undefined;
                 };
             }
@@ -3802,13 +3915,17 @@ pub const H2FrameParser = struct {
         }
         const identifier = stream.getIdentifier();
         identifier.ensureStillAlive();
+        var closed = false;
         if (stream.state == .HALF_CLOSED_REMOTE) {
             stream.state = .CLOSED;
             stream.freeResources(this, false);
+            closed = true;
         } else {
             stream.state = .HALF_CLOSED_LOCAL;
         }
+        const closed_id = stream.id;
         this.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(@intFromEnum(stream.state)));
+        if (closed) this.removeStreamByID(closed_id);
         return .js_undefined;
     }
 
@@ -3827,8 +3944,11 @@ pub const H2FrameParser = struct {
         }
         const close = close_arg.toBoolean();
 
+        // Stream was already closed and removed — deliver the pending write
+        // callback so the Duplex can settle, then no-op.
         var stream = this.streams.get(@intCast(stream_id)) orelse {
-            return globalObject.throw("Invalid stream id", .{});
+            this.dispatchWriteCallback(callback_arg);
+            return .false;
         };
         if (!stream.canSendData()) {
             this.dispatchWriteCallback(callback_arg);
@@ -3990,6 +4110,7 @@ pub const H2FrameParser = struct {
 
     pub fn emitAbortToAllStreams(this: *H2FrameParser, _: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!jsc.JSValue {
         jsc.markBinding(@src());
+        this.removeAllClosedStreams();
         var it = StreamResumableIterator.init(this);
         while (it.next()) |stream| {
 
@@ -4007,6 +4128,7 @@ pub const H2FrameParser = struct {
                 this.dispatchWith2Extra(.onAborted, identifier, .js_undefined, jsc.JSValue.jsNumber(@intFromEnum(old_state)));
             }
         }
+        this.removeAllClosedStreams();
         return .js_undefined;
     }
 
@@ -4018,6 +4140,7 @@ pub const H2FrameParser = struct {
             return globalObject.throw("Expected error argument", .{});
         }
 
+        this.removeAllClosedStreams();
         var it = StreamResumableIterator.init(this);
         while (it.next()) |stream| {
             // if (this.isServer) {
@@ -4032,7 +4155,26 @@ pub const H2FrameParser = struct {
                 this.dispatchWithExtra(.onStreamError, identifier, args_list.ptr[0]);
             }
         }
+        this.removeAllClosedStreams();
         return .js_undefined;
+    }
+
+    /// Sweep and free every stream entry whose state is CLOSED. Used by
+    /// session-teardown paths that mark all streams CLOSED mid-iteration —
+    /// removing in-place during a StreamResumableIterator walk could disturb
+    /// the iterator, so terminal paths batch the removal here.
+    fn removeAllClosedStreams(this: *H2FrameParser) void {
+        // Collect ids to remove. Iteration is stable as long as nothing grows
+        // the map; we only read keys here.
+        var to_remove: std.ArrayListUnmanaged(u32) = .{};
+        defer to_remove.deinit(this.allocator);
+        var it = this.streams.iterator();
+        while (it.next()) |entry| {
+            if (entry.value_ptr.*.state == .CLOSED) {
+                bun.handleOom(to_remove.append(this.allocator, entry.key_ptr.*));
+            }
+        }
+        for (to_remove.items) |id| this.removeStreamByID(id);
     }
 
     pub fn flushFromJS(this: *H2FrameParser, _: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!JSValue {
@@ -4186,6 +4328,7 @@ pub const H2FrameParser = struct {
                             stream.state = .CLOSED;
                             stream.rstCode = @intFromEnum(ErrorCode.COMPRESSION_ERROR);
                             this.dispatchWithExtra(.onStreamError, stream.getIdentifier(), jsc.JSValue.jsNumber(stream.rstCode));
+                            this.removeStreamByID(stream_id);
                             return .js_undefined;
                         };
                     }
@@ -4223,6 +4366,7 @@ pub const H2FrameParser = struct {
                         }
                         stream.rstCode = @intFromEnum(ErrorCode.COMPRESSION_ERROR);
                         this.dispatchWithExtra(.onStreamError, stream.getIdentifier(), jsc.JSValue.jsNumber(stream.rstCode));
+                        this.removeStreamByID(stream_id);
                         return jsc.JSValue.jsNumber(stream_id);
                     };
                 }
@@ -4251,6 +4395,7 @@ pub const H2FrameParser = struct {
                 stream.state = .CLOSED;
                 stream.rstCode = @intFromEnum(ErrorCode.INTERNAL_ERROR);
                 this.dispatchWithExtra(.onStreamError, stream.getIdentifier(), jsc.JSValue.jsNumber(stream.rstCode));
+                this.removeStreamByID(stream_id);
                 return jsc.JSValue.jsNumber(stream_id);
             }
 
@@ -4312,8 +4457,10 @@ pub const H2FrameParser = struct {
                     if (parent <= 0 or parent > MAX_STREAM_ID) {
                         stream.state = .CLOSED;
                         stream.rstCode = @intFromEnum(ErrorCode.INTERNAL_ERROR);
+                        const bad_parent_id = stream.id;
                         this.dispatchWithExtra(.onStreamError, stream.getIdentifier(), jsc.JSValue.jsNumber(stream.rstCode));
-                        return jsc.JSValue.jsNumber(stream.id);
+                        this.removeStreamByID(bad_parent_id);
+                        return jsc.JSValue.jsNumber(bad_parent_id);
                     }
                     stream.streamDependency = @intCast(parent);
                 } else {
@@ -4329,6 +4476,7 @@ pub const H2FrameParser = struct {
                         stream.state = .CLOSED;
                         stream.rstCode = @intFromEnum(ErrorCode.INTERNAL_ERROR);
                         this.dispatchWithExtra(.onStreamError, stream.getIdentifier(), jsc.JSValue.jsNumber(stream.rstCode));
+                        this.removeStreamByID(stream_id);
                         return jsc.JSValue.jsNumber(stream_id);
                     }
                     stream.weight = @intCast(weight);
@@ -4340,6 +4488,7 @@ pub const H2FrameParser = struct {
                     stream.state = .CLOSED;
                     stream.rstCode = @intFromEnum(ErrorCode.INTERNAL_ERROR);
                     this.dispatchWithExtra(.onStreamError, stream.getIdentifier(), jsc.JSValue.jsNumber(stream.rstCode));
+                    this.removeStreamByID(stream_id);
                     return jsc.JSValue.jsNumber(stream_id);
                 }
 
@@ -4370,6 +4519,7 @@ pub const H2FrameParser = struct {
                 const chunk = try this.handlers.binary_type.toJS("ENHANCE_YOUR_CALM", this.handlers.globalObject);
                 this.dispatchWith2Extra(.onError, jsc.JSValue.jsNumber(@intFromEnum(ErrorCode.ENHANCE_YOUR_CALM)), jsc.JSValue.jsNumber(this.lastStreamID), chunk);
             }
+            this.removeStreamByID(stream_id);
             return jsc.JSValue.jsNumber(stream_id);
         }
         var length: usize = encoded_size;
@@ -4393,6 +4543,7 @@ pub const H2FrameParser = struct {
             );
 
             this.dispatchWithExtra(.onStreamError, stream.getIdentifier(), jsc.JSValue.jsNumber(stream.rstCode));
+            this.removeStreamByID(stream_id);
             return jsc.JSValue.jsNumber(stream_id);
         }
 

--- a/test/regression/issue/30415.test.ts
+++ b/test/regression/issue/30415.test.ts
@@ -159,3 +159,84 @@ test("http2 write callback aborting the signal does not UAF the stream", async (
     exitCode: 0,
   });
 });
+
+// Same UAF class, different entry point. `stream.priority({...})` and
+// `stream.sendTrailers({...})` hand a user-controlled object straight to
+// native code, which reads `options.get("weight")` / `options.get("parent")`
+// etc. A property getter / Proxy trap on that object can synchronously
+// `AbortController.abort()`, which fires `SignalRef.abortListener` inline
+// → `abortStream` → `removeStreamByID` → `bun.destroy(stream)`. The native
+// code then continues reading and writing `stream.*` on the freed
+// allocation. Before the fix a release build would silently corrupt the
+// heap; an ASAN build crashes.
+test("http2 priority options getter aborting the signal does not UAF", async () => {
+  const script = /* js */ `
+    const http2 = require("node:http2");
+
+    const server = http2.createServer();
+    server.on("stream", stream => {
+      // Don't end immediately — keep the stream open long enough for the
+      // client to call priority() on it.
+      setImmediate(() => {
+        stream.respond({ ":status": 200 });
+        stream.end();
+      });
+    });
+
+    server.listen(0, "127.0.0.1", async () => {
+      const port = server.address().port;
+      const client = http2.connect("http://127.0.0.1:" + port);
+      client.on("error", () => {});
+      await new Promise(r => client.on("connect", r));
+
+      const ITERATIONS = 10;
+      for (let i = 0; i < ITERATIONS; i++) {
+        const ac = new AbortController();
+        await new Promise(resolve => {
+          const req = client.request(
+            { ":path": "/", ":method": "GET" },
+            { signal: ac.signal },
+          );
+          req.on("error", () => {});
+          req.on("close", resolve);
+          req.on("response", () => {
+            // Call priority() with an options object whose "weight" getter
+            // synchronously aborts the AbortSignal. The native
+            // setStreamPriority reads options.get("weight") first, then
+            // proceeds to write stream.streamDependency / stream.exclusive
+            // / stream.weight — on freed memory before this fix.
+            try {
+              req.priority({
+                get weight() {
+                  ac.abort();
+                  return 16;
+                },
+                parent: 3,
+                exclusive: false,
+                silent: false,
+              });
+            } catch {}
+          });
+          req.resume();
+          req.end();
+        });
+      }
+
+      for (let i = 0; i < 4; i++) await new Promise(r => setImmediate(r));
+      console.log("ok");
+      client.close(() => server.close(() => process.exit(0)));
+    });
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stderr, stdout: stdout.trim().split("\n").pop(), exitCode }).toMatchObject({
+    stdout: "ok",
+    exitCode: 0,
+  });
+});

--- a/test/regression/issue/30415.test.ts
+++ b/test/regression/issue/30415.test.ts
@@ -76,11 +76,7 @@ test("http2 session does not retain closed streams", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stderr, stdout: stdout.trim().split("\n").pop(), exitCode }).toEqual({
     stderr: "",
     stdout: expect.stringMatching(/^ok retained=\d+ lastId=\d+$/),

--- a/test/regression/issue/30415.test.ts
+++ b/test/regression/issue/30415.test.ts
@@ -1,0 +1,89 @@
+// https://github.com/oven-sh/bun/issues/30415
+//
+// Sustained `http2.connect()` session reuse (e.g. AWS SDK v3 Kinesis
+// GetRecords) leaked native RSS at ~380 MB/hour on Bun because
+// `H2FrameParser.streams` never dropped entries for closed streams —
+// every `session.request()` added a `*Stream` and only a full session
+// teardown freed them. Node reclaims stream state on close and stays flat.
+//
+// This test opens a real HTTP/2 loopback, runs many sequential requests
+// through a single session, then inspects `session.state.streamCount` —
+// the native count of tracked streams. Before the fix it grew linearly
+// with request count; after the fix it drops back to zero (or a tiny
+// transient count for the most recently closed stream).
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("http2 session does not retain closed streams", async () => {
+  const script = /* js */ `
+    const http2 = require("node:http2");
+
+    const server = http2.createServer();
+    server.on("stream", stream => {
+      stream.respond({ ":status": 200 });
+      stream.end();
+    });
+
+    server.listen(0, "127.0.0.1", () => {
+      const port = server.address().port;
+      const client = http2.connect("http://127.0.0.1:" + port);
+
+      client.on("connect", async () => {
+        const ITERATIONS = 50;
+        for (let i = 0; i < ITERATIONS; i++) {
+          await new Promise((resolve, reject) => {
+            const req = client.request({ ":path": "/", ":method": "GET" });
+            req.on("error", reject);
+            req.on("close", resolve);
+            req.resume();
+            req.end();
+          });
+        }
+        // Give the event loop a chance to settle any setImmediate(rstNextTick).
+        for (let i = 0; i < 4; i++) await new Promise(r => setImmediate(r));
+
+        const state = client.state;
+        const retained = state.streamCount;
+        const lastId = state.lastProcStreamID;
+        // lastProcStreamID grows by 2 per client-initiated request. Confirm
+        // we actually made it through all ITERATIONS (otherwise a low
+        // streamCount could be a false negative).
+        if (lastId < ITERATIONS * 2 - 1) {
+          console.error("only completed", lastId, "requests");
+          process.exit(1);
+        }
+        // Before the fix: retained grows with ITERATIONS. After the fix it
+        // should be 0 (or 1 if the last stream's setImmediate rstNextTick
+        // hasn't run yet), which stays stable regardless of ITERATIONS.
+        if (retained > 4) {
+          console.error("retained", retained, "closed streams after", ITERATIONS, "requests");
+          process.exit(2);
+        }
+        console.log("ok retained=" + retained + " lastId=" + lastId);
+        client.close(() => server.close(() => process.exit(0)));
+      });
+
+      client.on("error", err => {
+        console.error("client error:", err?.message || err);
+        process.exit(99);
+      });
+    });
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  expect({ stderr, stdout: stdout.trim().split("\n").pop(), exitCode }).toEqual({
+    stderr: "",
+    stdout: expect.stringMatching(/^ok retained=\d+ lastId=\d+$/),
+    exitCode: 0,
+  });
+});

--- a/test/regression/issue/30415.test.ts
+++ b/test/regression/issue/30415.test.ts
@@ -77,8 +77,11 @@ test("http2 session does not retain closed streams", async () => {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stderr, stdout: stdout.trim().split("\n").pop(), exitCode }).toEqual({
-    stderr: "",
+  // Don't pin stderr to "" — ASAN and other diagnostic builds may emit
+  // benign lines there. The test only cares about stdout + exit code; the
+  // stderr value is still included in the failure object so a real crash
+  // shows up in the diff.
+  expect({ stderr, stdout: stdout.trim().split("\n").pop(), exitCode }).toMatchObject({
     stdout: expect.stringMatching(/^ok retained=\d+ lastId=\d+$/),
     exitCode: 0,
   });

--- a/test/regression/issue/30415.test.ts
+++ b/test/regression/issue/30415.test.ts
@@ -14,7 +14,7 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-test("http2 session does not retain closed streams", async () => {
+test.concurrent("http2 session does not retain closed streams", async () => {
   const script = /* js */ `
     const http2 = require("node:http2");
 
@@ -95,7 +95,7 @@ test("http2 session does not retain closed streams", async () => {
 // `removeStreamByID` → `bun.destroy(stream)` — and the dereferences in the
 // defer become use-after-free. ASAN would trip here before the fix; release
 // builds would silently read reused heap memory.
-test("http2 write callback aborting the signal does not UAF the stream", async () => {
+test.concurrent("http2 write callback aborting the signal does not UAF the stream", async () => {
   const script = /* js */ `
     const http2 = require("node:http2");
 
@@ -169,7 +169,7 @@ test("http2 write callback aborting the signal does not UAF the stream", async (
 // code then continues reading and writing `stream.*` on the freed
 // allocation. Before the fix a release build would silently corrupt the
 // heap; an ASAN build crashes.
-test("http2 priority options getter aborting the signal does not UAF", async () => {
+test.concurrent("http2 priority options getter aborting the signal does not UAF", async () => {
   const script = /* js */ `
     const http2 = require("node:http2");
 

--- a/test/regression/issue/30415.test.ts
+++ b/test/regression/issue/30415.test.ts
@@ -86,3 +86,76 @@ test("http2 session does not retain closed streams", async () => {
     exitCode: 0,
   });
 });
+
+// Regression for the UAF that landed alongside the stream-reclamation fix:
+// `sendData`'s defer block dispatches the write callback before reading
+// `stream.state` / `stream.waitForTrailers` / `stream.getIdentifier()`. If
+// that write callback synchronously aborts the stream's AbortSignal, the
+// native listener runs inline — `SignalRef.abortListener` → `abortStream` →
+// `removeStreamByID` → `bun.destroy(stream)` — and the dereferences in the
+// defer become use-after-free. ASAN would trip here before the fix; release
+// builds would silently read reused heap memory.
+test("http2 write callback aborting the signal does not UAF the stream", async () => {
+  const script = /* js */ `
+    const http2 = require("node:http2");
+
+    const server = http2.createServer();
+    server.on("stream", stream => {
+      stream.respond({ ":status": 200 });
+      // Drain any body the client writes so the peer-level flow stays sane.
+      stream.on("data", () => {});
+      stream.on("end", () => stream.end());
+      stream.on("error", () => {});
+    });
+
+    server.listen(0, "127.0.0.1", async () => {
+      const port = server.address().port;
+      const client = http2.connect("http://127.0.0.1:" + port);
+      client.on("error", err => {
+        console.error("client error:", err?.message || err);
+        process.exit(99);
+      });
+      await new Promise(r => client.on("connect", r));
+
+      const ITERATIONS = 20;
+      for (let i = 0; i < ITERATIONS; i++) {
+        const ac = new AbortController();
+        await new Promise(resolve => {
+          const req = client.request(
+            { ":path": "/", ":method": "POST" },
+            { signal: ac.signal },
+          );
+          req.on("error", () => {});
+          req.on("close", resolve);
+          req.on("response", () => {});
+          req.resume();
+          // Writable 'finish' fires synchronously from inside the internal
+          // callback that _final passes to native.writeStream(..., close=true).
+          // sendData's defer dispatches that callback before reading the
+          // stream's state/waitForTrailers/identifier — aborting the attached
+          // AbortSignal here runs SignalRef.abortListener synchronously,
+          // which reaches abortStream → removeStreamByID → bun.destroy
+          // before the defer is done.
+          req.on("finish", () => ac.abort());
+          req.end("x");
+        });
+      }
+
+      for (let i = 0; i < 4; i++) await new Promise(r => setImmediate(r));
+      console.log("ok");
+      client.close(() => server.close(() => process.exit(0)));
+    });
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stderr, stdout: stdout.trim().split("\n").pop(), exitCode }).toMatchObject({
+    stdout: "ok",
+    exitCode: 0,
+  });
+});


### PR DESCRIPTION
Fixes #30415

## Reproduction

Sustained `http2.connect()` session reuse (the pattern `@smithy/node-http-handler` uses in AWS SDK v3, including `@aws-sdk/client-kinesis`) leaked native RSS at ~380 MB/hour on Bun. Node plateaued flat. I reproduced without AWS by pointing the SDK at a local HTTP/2 mock:

- 64 concurrent "shards" × ~60 requests/second on one pooled session
- Bun 1.3.13 / 1.3.14: RSS climbs 173 → 221 MB in 450s (~380 MB/hr)
- Node 24: pinned at 339–340 MB over 8 minutes / 360k requests
- Raw `fetch()` over the same H2 endpoint at double the rate: flat — the fetch-path H2 client isn't the culprit
- Raw `node:http2` client: reproduces — isolating the leak to this module

`Bun.gc(true)` reclaims most of it at the end, so the memory is retained (JS-reachable) rather than unfreed buffers, but natural GC doesn't keep up during steady-state load.

## Cause

`H2FrameParser.streams` (`bun.U32HashMap(*Stream)`) only dropped entries in `deinit()`. Every `session.request()` called `streams.put(id, Stream.new(...))`; normal stream closure (`END_STREAM`, `RST_STREAM`, `AbortSignal`, error paths) just set `state = .CLOSED` and called `freeResources` — the heap-allocated `Stream` and its map entry outlived every request until the whole session died. At ~150 bytes per closed stream, a long-lived pooled session bleeds memory proportional to total request count.

The parallel fetch-path client in `src/http/h2_client/ClientSession.zig` already has the right pattern (`removeStream(*Stream) → swapRemove + deinit`); this PR brings the same discipline to `src/runtime/api/bun/h2_frame_parser.zig`.

## Fix

- Add `removeStreamByID(id)` — `fetchRemove` the map entry, call `freeResources` (idempotent), `bun.destroy` the `Stream`. Call it at every `state = .CLOSED` transition **after** the terminal JS dispatch (`onStreamEnd`/`onStreamError`/`onAborted`) completes.
- For paths that walk the map via `StreamResumableIterator` (`flushStreamQueue`, `emitAbortToAllStreams`, `emitErrorToAllStreams`, other teardown loops) defer the reclaim to a post-iteration sweep — `removeAllClosedStreams` collects every slot whose `Stream` is `.CLOSED` and removes them. Removing mid-iteration would still be memory-safe (`std.HashMap.remove` tombstones), but a re-entrant dispatch could `bun.destroy` `this` under our feet while `flushQueue`'s defer is still reading `this.dataFrameQueue`.
- `flushQueue` rewrites its defer to re-resolve the stream by id after `dispatchWriteCallback` — the user's write callback can synchronously reset the stream (`stream.close → rstStream → endStream → removeStreamByID`), so trusting `this` across the callback was already a latent UAF that becomes observable once entries are reclaimed.
- `handleReceivedStreamID` returns null for an id ≤ `lastStreamID` that isn't in the map, instead of creating a fresh `Stream`. Without this, a stale frame arriving after we removed the entry would resurrect a ghost stream with default state. The affected frame handlers (`handleDataFrame`, `handleHeadersFrame`, `handleRSTStreamFrame`, `handleContinuationFrame`, `handlePriorityFrame`) only escalate to a connection-level GOAWAY when the frame itself is connection-scoped (`streamIdentifier == 0`); a late frame on a closed stream is dropped per RFC 7540 §5.1.
- JS-side destruction schedules `setImmediate(rstNextTick)` after we've already removed the native stream; `parser.rstStream` now silently returns `.false` instead of throwing `Invalid stream id`. `noTrailers`, `sendTrailers`, `writeStream`, `getStreamState`, `getEndAfterHeaders`, and `isStreamAborted` likewise degrade to no-ops / closed defaults for a removed id — the JS Duplex is mid-destroy by the time these fire.

## Verification

`test/regression/issue/30415.test.ts` makes 50 sequential requests on one `http2.connect()` session, then reads `client.state.streamCount` (a new field on `getCurrentState`'s output that exposes `parser.streams.count()`):

- Before the fix: `streamCount` grows to ~50. Test fails.
- After the fix: `streamCount` is 0 (or 1 if the last stream's `setImmediate(rstNextTick)` hasn't run). Test passes.

Passes the gate: `git stash push -- src/ && bun bd test test/regression/issue/30415.test.ts` fails without the fix, passes with it. All 241 Bun http2 tests in `test/js/node/http2/node-http2.test.js` still pass (the 4 pre-existing failures — 3 `node none` Node-ref tests and `http2 server with minimal maxSessionMemory handles multiple requests` — fail on `main` too in this container, unrelated to this PR).