### PR TITLE
bake: validate `app.bundlerOptions` and sub-options are objects

### DIFF
--- a/src/bake/bake.zig
+++ b/src/bake/bake.zig
@@ -68,14 +68,17 @@ pub const UserOptions = struct {
         }
 
         if (try config.getOptional(global, "bundlerOptions", JSValue)) |js_options| {
+            if (!js_options.isObject()) {
+                return global.throwInvalidArguments("'" ++ api_name ++ ".bundlerOptions' must be an object", .{});
+            }
             if (try js_options.getOptional(global, "server", JSValue)) |server_options| {
-                bundler_options.server = try BuildConfigSubset.fromJS(global, server_options);
+                bundler_options.server = try BuildConfigSubset.fromJS(global, server_options, "server");
             }
             if (try js_options.getOptional(global, "client", JSValue)) |client_options| {
-                bundler_options.client = try BuildConfigSubset.fromJS(global, client_options);
+                bundler_options.client = try BuildConfigSubset.fromJS(global, client_options, "client");
             }
             if (try js_options.getOptional(global, "ssr", JSValue)) |ssr_options| {
-                bundler_options.ssr = try BuildConfigSubset.fromJS(global, ssr_options);
+                bundler_options.ssr = try BuildConfigSubset.fromJS(global, ssr_options, "ssr");
             }
         }
 
@@ -202,8 +205,12 @@ const BuildConfigSubset = struct {
     minify_identifiers: ?bool = null,
     minify_whitespace: ?bool = null,
 
-    pub fn fromJS(global: *jsc.JSGlobalObject, js_options: JSValue) bun.JSError!BuildConfigSubset {
+    pub fn fromJS(global: *jsc.JSGlobalObject, js_options: JSValue, comptime property_name: []const u8) bun.JSError!BuildConfigSubset {
         var options = BuildConfigSubset{};
+
+        if (!js_options.isObject()) {
+            return global.throwInvalidArguments("'" ++ api_name ++ ".bundlerOptions." ++ property_name ++ "' must be an object", .{});
+        }
 
         if (try js_options.getOptional(global, "sourcemap", JSValue)) |val| brk: {
             if (try bun.schema.api.SourceMapMode.fromJS(global, val)) |sourcemap| {
@@ -215,11 +222,16 @@ const BuildConfigSubset = struct {
         }
 
         if (try js_options.getOptional(global, "minify", JSValue)) |minify_options| brk: {
-            if (minify_options.isBoolean() and minify_options.asBoolean()) {
-                options.minify_syntax = minify_options.asBoolean();
-                options.minify_identifiers = minify_options.asBoolean();
-                options.minify_whitespace = minify_options.asBoolean();
+            if (minify_options.isBoolean()) {
+                const value = minify_options.asBoolean();
+                options.minify_syntax = value;
+                options.minify_identifiers = value;
+                options.minify_whitespace = value;
                 break :brk;
+            }
+
+            if (!minify_options.isObject()) {
+                return global.throwInvalidArguments("'" ++ api_name ++ ".bundlerOptions." ++ property_name ++ ".minify' must be a boolean or an object", .{});
             }
 
             if (try minify_options.getBooleanLoose(global, "whitespace")) |value| {

--- a/test/bake/bundler-options-validation.test.ts
+++ b/test/bake/bundler-options-validation.test.ts
@@ -13,30 +13,6 @@ describe("Bun.serve app.bundlerOptions validation", () => {
     );
   });
 
-  test.each(["server", "client", "ssr"] as const)("throws when bundlerOptions.%s is not an object", key => {
-    expect(() => Bun.serve({ app: { bundlerOptions: { [key]: 2 } as any } } as any)).toThrow(
-      `'app.bundlerOptions.${key}' must be an object`,
-    );
-    expect(() => Bun.serve({ app: { bundlerOptions: { [key]: "x" } as any } } as any)).toThrow(
-      `'app.bundlerOptions.${key}' must be an object`,
-    );
-    expect(() => Bun.serve({ app: { bundlerOptions: { [key]: true } as any } } as any)).toThrow(
-      `'app.bundlerOptions.${key}' must be an object`,
-    );
-  });
-
-  test.each(["server", "client", "ssr"] as const)(
-    "throws when bundlerOptions.%s.minify is not a boolean or an object",
-    key => {
-      expect(() => Bun.serve({ app: { bundlerOptions: { [key]: { minify: 5 } } as any } } as any)).toThrow(
-        `'app.bundlerOptions.${key}.minify' must be a boolean or an object`,
-      );
-      expect(() => Bun.serve({ app: { bundlerOptions: { [key]: { minify: "yes" } } as any } } as any)).toThrow(
-        `'app.bundlerOptions.${key}.minify' must be a boolean or an object`,
-      );
-    },
-  );
-
   test("does not crash with self-referencing bundlerOptions and non-object sub-options", () => {
     const v2: any = {};
     v2.client = 2;
@@ -44,12 +20,35 @@ describe("Bun.serve app.bundlerOptions validation", () => {
     expect(() => Bun.serve({ app: v2 } as any)).toThrow("'app.bundlerOptions.client' must be an object");
   });
 
-  test.each(["server", "client", "ssr"] as const)("accepts minify: false without crashing for %s", key => {
-    expect(() => Bun.serve({ app: { bundlerOptions: { [key]: { minify: false } } as any } } as any)).toThrow(
-      "'app' is missing 'framework'",
-    );
-    expect(() => Bun.serve({ app: { bundlerOptions: { [key]: { minify: true } } as any } } as any)).toThrow(
-      "'app' is missing 'framework'",
-    );
+  describe.each(["server", "client", "ssr"] as const)("bundlerOptions.%s", key => {
+    test("throws when value is not an object", () => {
+      expect(() => Bun.serve({ app: { bundlerOptions: { [key]: 2 } as any } } as any)).toThrow(
+        `'app.bundlerOptions.${key}' must be an object`,
+      );
+      expect(() => Bun.serve({ app: { bundlerOptions: { [key]: "x" } as any } } as any)).toThrow(
+        `'app.bundlerOptions.${key}' must be an object`,
+      );
+      expect(() => Bun.serve({ app: { bundlerOptions: { [key]: true } as any } } as any)).toThrow(
+        `'app.bundlerOptions.${key}' must be an object`,
+      );
+    });
+
+    test("throws when minify is not a boolean or an object", () => {
+      expect(() => Bun.serve({ app: { bundlerOptions: { [key]: { minify: 5 } } as any } } as any)).toThrow(
+        `'app.bundlerOptions.${key}.minify' must be a boolean or an object`,
+      );
+      expect(() => Bun.serve({ app: { bundlerOptions: { [key]: { minify: "yes" } } as any } } as any)).toThrow(
+        `'app.bundlerOptions.${key}.minify' must be a boolean or an object`,
+      );
+    });
+
+    test("accepts boolean minify without crashing", () => {
+      expect(() => Bun.serve({ app: { bundlerOptions: { [key]: { minify: false } } as any } } as any)).toThrow(
+        "'app' is missing 'framework'",
+      );
+      expect(() => Bun.serve({ app: { bundlerOptions: { [key]: { minify: true } } as any } } as any)).toThrow(
+        "'app' is missing 'framework'",
+      );
+    });
   });
 });

--- a/test/bake/bundler-options-validation.test.ts
+++ b/test/bake/bundler-options-validation.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+
+describe("Bun.serve app.bundlerOptions validation", () => {
+  test("throws when bundlerOptions is not an object", () => {
+    expect(() => Bun.serve({ app: { bundlerOptions: 5 as any } } as any)).toThrow(
+      "'app.bundlerOptions' must be an object",
+    );
+    expect(() => Bun.serve({ app: { bundlerOptions: "hello" as any } } as any)).toThrow(
+      "'app.bundlerOptions' must be an object",
+    );
+    expect(() => Bun.serve({ app: { bundlerOptions: true as any } } as any)).toThrow(
+      "'app.bundlerOptions' must be an object",
+    );
+  });
+
+  test.each(["server", "client", "ssr"] as const)("throws when bundlerOptions.%s is not an object", key => {
+    expect(() => Bun.serve({ app: { bundlerOptions: { [key]: 2 } as any } } as any)).toThrow(
+      `'app.bundlerOptions.${key}' must be an object`,
+    );
+    expect(() => Bun.serve({ app: { bundlerOptions: { [key]: "x" } as any } } as any)).toThrow(
+      `'app.bundlerOptions.${key}' must be an object`,
+    );
+    expect(() => Bun.serve({ app: { bundlerOptions: { [key]: true } as any } } as any)).toThrow(
+      `'app.bundlerOptions.${key}' must be an object`,
+    );
+  });
+
+  test.each(["server", "client", "ssr"] as const)(
+    "throws when bundlerOptions.%s.minify is not a boolean or an object",
+    key => {
+      expect(() => Bun.serve({ app: { bundlerOptions: { [key]: { minify: 5 } } as any } } as any)).toThrow(
+        `'app.bundlerOptions.${key}.minify' must be a boolean or an object`,
+      );
+      expect(() => Bun.serve({ app: { bundlerOptions: { [key]: { minify: "yes" } } as any } } as any)).toThrow(
+        `'app.bundlerOptions.${key}.minify' must be a boolean or an object`,
+      );
+    },
+  );
+
+  test("does not crash with self-referencing bundlerOptions and non-object sub-options", () => {
+    const v2: any = {};
+    v2.client = 2;
+    v2.bundlerOptions = v2;
+    expect(() => Bun.serve({ app: v2 } as any)).toThrow("'app.bundlerOptions.client' must be an object");
+  });
+
+  test.each(["server", "client", "ssr"] as const)("accepts minify: false without crashing for %s", key => {
+    expect(() => Bun.serve({ app: { bundlerOptions: { [key]: { minify: false } } as any } } as any)).toThrow(
+      "'app' is missing 'framework'",
+    );
+    expect(() => Bun.serve({ app: { bundlerOptions: { [key]: { minify: true } } as any } } as any)).toThrow(
+      "'app' is missing 'framework'",
+    );
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a debug assertion crash in `Bun.serve({ app: ... })` when `app.bundlerOptions`, `app.bundlerOptions.{server,client,ssr}`, or their `.minify` option is a non-object primitive (number, string, boolean).

`JSValue.get()` asserts that its target is an object, but `BuildConfigSubset.fromJS` and `UserOptions.fromJS` called it on values obtained via `getOptional(..., JSValue)` without first checking they were objects.

Also fixes `minify: false` falling through to the object-property read path (which would then assert), since the previous check was `isBoolean() and asBoolean()`.

### Repro

```js
Bun.serve({ app: { bundlerOptions: { client: 2 } } });
// or
Bun.serve({ app: { bundlerOptions: 5 } });
// or
Bun.serve({ app: { bundlerOptions: { client: { minify: 5 } } } });
// or
Bun.serve({ app: { bundlerOptions: { client: { minify: false } } } });
```

Before: `panic(main thread): reached unreachable code` at `JSValue.get` → `bun.debugAssert(target.isObject())`.

After: throws `TypeError: 'app.bundlerOptions.client' must be an object` (etc).

## How did you verify your code works?

Added `test/bake/bundler-options-validation.test.ts` covering all three levels of non-object inputs plus the `minify: false` path.

Found by Fuzzilli (fingerprint `9aa9c17813ebf2b4`).