### PR TITLE
test(http): drive emit-close-on-abort test with http.get + destroy

### DIFF
--- a/test/js/bun/test/parallel/test-http-should-emit-close-when-connection-is-aborted.ts
+++ b/test/js/bun/test/parallel/test-http-should-emit-close-when-connection-is-aborted.ts
@@ -3,19 +3,41 @@ import { once } from "node:events";
 import http from "node:http";
 const { expect } = createTest(import.meta.path);
 
+// What this test asserts: when the client tears down the connection
+// mid-request, the server's IncomingMessage emits "close" and `req.aborted`
+// is true.
+//
+// The original version drove the client side with `fetch()` + an
+// AbortController. On Windows that consistently timed out at
+// `await closeEvent.promise`: aborting a Bun fetch posts a shutdown to the
+// HTTP thread (`http_thread.scheduleShutdown`) which then closes the socket
+// asynchronously, and the server's `req` was never observing "close" before
+// the runner's timeout. The server-side behaviour under test doesn't care
+// *how* the client hangs up, so use `http.get()` + `clientReq.destroy()`
+// instead — that closes the underlying socket synchronously from the JS
+// thread on every platform, and the test no longer depends on fetch's
+// abort-to-socket-close path.
+
 await using server = http.createServer().listen(0);
 server.unref();
 await once(server, "listening");
-const controller = new AbortController();
-fetch(`http://localhost:${server.address().port}`, { signal: controller.signal })
-  .then(res => res.text())
-  .catch(() => {});
 
-const [req, res] = await once(server, "request");
-const closeEvent = Promise.withResolvers();
-req.once("close", () => {
-  closeEvent.resolve();
+const clientReq = http.get({
+  host: "127.0.0.1",
+  port: server.address().port,
+  // Don't let the client agent pool the socket — we want destroy() to
+  // actually close it.
+  agent: false,
 });
-controller.abort();
+clientReq.on("error", () => {});
+
+const [req] = await once(server, "request");
+// Not `once(req, "close")`: events.once() also attaches a temporary "error"
+// listener, and `_http_server.ts` #onClose only constructs the
+// ConnResetException when `req.listenerCount("error") > 0` — which would
+// then make once() reject instead of resolving on "close".
+const closeEvent = Promise.withResolvers();
+req.once("close", () => closeEvent.resolve());
+clientReq.destroy();
 await closeEvent.promise;
 expect(req.aborted).toBe(true);


### PR DESCRIPTION
### What does this PR do?

`test/js/bun/test/parallel/test-http-should-emit-close-when-connection-is-aborted.ts` has been timing out on every Windows CI runner on every recent build — e.g. [#52850 win 2019 x64](https://buildkite.com/bun/bun/builds/52850#019e087e-f72d-4b1e-93ea-9364289c4686), [#52850 win 2019 x64-baseline](https://buildkite.com/bun/bun/builds/52850#019e087e-f737-4b62-8549-0fa59218ba3c), [#52850 win 11 aarch64](https://buildkite.com/bun/bun/builds/52850#019e087e-f741-447f-9146-af66f88dace3), and the same three on #52846 / #52855 / #52861.

The test asserts that when the client tears down the connection mid-request, the server's `IncomingMessage` emits `"close"` and `req.aborted === true`. The previous version drove the client side with `fetch()` + an `AbortController`. Aborting a Bun fetch sets the `signals.aborted` atomic and posts a shutdown to the HTTP thread (`FetchTasklet.abortTask` → `http_thread.scheduleShutdown`), which then `socket.close(.failure)`s asynchronously on that thread; on Windows the server's `req` wasn't observing `"close"` before the runner's timeout, so the test hung at `await closeEvent.promise`.

The server-side behaviour under test doesn't care *how* the client hangs up. Switching the client to `http.get({ host: "127.0.0.1", agent: false })` + `clientReq.destroy()` closes the underlying socket synchronously from the JS thread on every platform, so the test no longer depends on fetch's abort-to-socket-close path. The `127.0.0.1` host also removes any `localhost` IPv4/IPv6 resolution variance.

Kept the original `Promise.withResolvers()` close-listener pattern rather than `once(req, "close")`: `events.once()` attaches a temporary `"error"` listener, which flips `_http_server.ts` `#onClose` into the `req.destroy(new ConnResetException(...))` branch and makes `once()` reject instead of resolve.

> If `fetch().abort()` not promptly closing the underlying socket on Windows is itself a bug, that's separate from what this test is checking and worth its own targeted coverage — happy to open a follow-up if a reviewer thinks so.

### How did you verify your code works?

15/15 consecutive passes with the debug build on Linux:
```
for i in $(seq 1 15); do bun-debug test/js/bun/test/parallel/test-http-should-emit-close-when-connection-is-aborted.ts >/dev/null 2>&1; echo "run $i: exit=$?"; done
```
all `exit=0`. Can't reproduce the original timeout locally (no Windows box); the change removes the cross-thread async dependency that's the only platform-variant step in the original sequence.