### PR TITLE
Fix per-stream ANSI color detection when stdout/stderr differ

### DIFF
--- a/src/bun_core/output.zig
+++ b/src/bun_core/output.zig
@@ -395,17 +395,19 @@ pub const Source = struct {
                     stderr_descriptor_type = OutputStreamDescriptor.terminal;
                 }
 
-                var enable_color: ?bool = null;
                 if (isForceColor()) {
-                    enable_color = true;
+                    enable_ansi_colors_stdout = true;
+                    enable_ansi_colors_stderr = true;
                 } else if (isNoColor()) {
-                    enable_color = false;
-                } else if (isColorTerminal() and (is_stdout_tty or is_stderr_tty)) {
-                    enable_color = true;
+                    enable_ansi_colors_stdout = false;
+                    enable_ansi_colors_stderr = false;
+                } else {
+                    // Each stream gets color only when it is a tty itself.
+                    // The old code used a single flag for both, so a tty on
+                    // stderr would also enable colors on a piped stdout.
+                    enable_ansi_colors_stdout = is_stdout_tty;
+                    enable_ansi_colors_stderr = is_stderr_tty;
                 }
-
-                enable_ansi_colors_stdout = enable_color orelse is_stdout_tty;
-                enable_ansi_colors_stderr = enable_color orelse is_stderr_tty;
             }
 
             stdout_stream = stdout;

--- a/test/js/bun/console/console-no-color-pipe.test.ts
+++ b/test/js/bun/console/console-no-color-pipe.test.ts
@@ -1,0 +1,66 @@
+import { spawnSync } from "bun";
+import { describe, expect, it } from "bun:test";
+import { bunExe } from "harness";
+
+function cleanEnv(overrides: Record<string, string | undefined> = {}): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined) env[k] = v;
+  }
+  delete env.FORCE_COLOR;
+  delete env.NO_COLOR;
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v === undefined) delete env[k];
+    else env[k] = v;
+  }
+  return env;
+}
+
+describe("console.log with piped stdout", () => {
+  it("should not emit ANSI escape codes when stdout is piped", () => {
+    const { stdout, stderr } = spawnSync({
+      cmd: [bunExe(), import.meta.dir + "/console-no-color-pipe.ts"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: cleanEnv(),
+    });
+
+    const out = stdout.toString();
+    const err = stderr.toString();
+
+    // Neither piped stream should contain escape codes
+    expect(out).not.toContain("\x1b[");
+    expect(err).not.toContain("\x1b[");
+    // Verify actual data is present
+    expect(out).toContain("Map");
+    expect(err).toContain("Map");
+  });
+
+  it("should emit ANSI escape codes on both streams when FORCE_COLOR is set", () => {
+    const { stdout, stderr } = spawnSync({
+      cmd: [bunExe(), import.meta.dir + "/console-no-color-pipe.ts"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: cleanEnv({ FORCE_COLOR: "1" }),
+    });
+
+    const out = stdout.toString();
+    const err = stderr.toString();
+    expect(out).toContain("\x1b[");
+    expect(err).toContain("\x1b[");
+  });
+
+  it("should not emit ANSI escape codes when NO_COLOR is set", () => {
+    const { stdout, stderr } = spawnSync({
+      cmd: [bunExe(), import.meta.dir + "/console-no-color-pipe.ts"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: cleanEnv({ NO_COLOR: "1" }),
+    });
+
+    const out = stdout.toString();
+    const err = stderr.toString();
+    expect(out).not.toContain("\x1b[");
+    expect(err).not.toContain("\x1b[");
+  });
+});

--- a/test/js/bun/console/console-no-color-pipe.ts
+++ b/test/js/bun/console/console-no-color-pipe.ts
@@ -1,0 +1,4 @@
+// Fixture: logs structured data to both stdout and stderr.
+// When a stream is piped (not a tty), its output should contain no ANSI escape codes.
+console.log(new Map([["x", 1]]));
+console.error(new Map([["e", 2]]));


### PR DESCRIPTION
### What does this PR do?

The color-init path in `output.zig` used a single boolean for both streams: if `isColorTerminal()` was true and *either* stream was a tty, both got ANSI escapes enabled. This meant piping stdout while stderr remained a tty produced colored output on the piped stream.

Now each stream is evaluated independently: `enable_ansi_colors_stdout = is_stdout_tty`, `enable_ansi_colors_stderr = is_stderr_tty`. `FORCE_COLOR` and `NO_COLOR` still override both.

### How did you verify your code works?

Added `console-no-color-pipe.test.ts` which spawns bun with both streams piped and verifies no ANSI escapes appear, plus `FORCE_COLOR` and `NO_COLOR` override tests.

**Note on test coverage:** The test validates correct behavior when both streams are piped (both should be plain), but it cannot reproduce the exact original bug scenario (one tty + one pipe) because `spawnSync` pipes both. The Zig fix is the minimal correct change — the `isColorTerminal()` check was only needed as a gate for the shared flag, which no longer exists.