### PR TITLE
resolver: return null for empty/non-absolute paths instead of panicking

### DIFF
--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -2717,8 +2717,8 @@ pub const Resolver = struct {
         // field can legitimately be empty (e.g. when the path has no
         // separator). Every caller already tolerates a null return or a
         // thrown error, so bail here rather than walking into the cache with
-        // an empty key — or on Windows ReleaseSafe, panicking at the
-        // `isAbsolute` assert below. https://github.com/oven-sh/bun/issues/30429
+        // an empty key or falling through to the `isAbsolute` check below.
+        // https://github.com/oven-sh/bun/issues/30429
         if (input_path.len == 0) return null;
 
         if (comptime Environment.isWindows) {

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -2712,6 +2712,15 @@ pub const Resolver = struct {
         // below when called with user-controlled absolute import paths.
         if (input_path.len > bun.MAX_PATH_BYTES) return null;
 
+        // An empty path has no DirInfo. Callers such as `finalizeResult` and
+        // module-loader tag detection pass `Path.name.dir` directly, and that
+        // field can legitimately be empty (e.g. when the path has no
+        // separator). Every caller already tolerates a null return or a
+        // thrown error, so bail here rather than walking into the cache with
+        // an empty key — or on Windows ReleaseSafe, panicking at the
+        // `isAbsolute` assert below. https://github.com/oven-sh/bun/issues/30429
+        if (input_path.len == 0) return null;
+
         if (comptime Environment.isWindows) {
             const win32_normalized_dir_info_cache_buf = bufs(.win32_normalized_dir_info_cache);
             input_path = r.fs.normalizeBuf(win32_normalized_dir_info_cache_buf, input_path);
@@ -2734,7 +2743,9 @@ pub const Resolver = struct {
             }
         }
 
-        bun.assertf(std.fs.path.isAbsolute(input_path), "cannot resolve DirInfo for non-absolute path: {s}", .{input_path});
+        // A non-absolute path likewise has no DirInfo — return null rather
+        // than panicking so callers can fall through to their error paths.
+        if (!std.fs.path.isAbsolute(input_path)) return null;
 
         const path_without_trailing_slash = strings.withoutTrailingSlashWindowsPath(input_path);
         assertValidCacheKey(path_without_trailing_slash);

--- a/test/regression/issue/30429.test.ts
+++ b/test/regression/issue/30429.test.ts
@@ -8,22 +8,39 @@
 // which is true for debug and Windows ReleaseSafe builds, so the
 // reproduction below panics on `bun bd` too.
 import { expect, test } from "bun:test";
-import { mkdirSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { mkdirSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 test("bare-specifier virtual CJS module does not panic on transpiler-cache hit", async () => {
-  const dir = tmpdirSync();
-  const cache = join(dir, ".cache");
-  mkdirSync(cache, { recursive: true });
-
   // A CJS file large enough that the transpiler cache stores it
   // (MINIMUM_CACHE_SIZE is 50 KiB). The content must match between the
   // primer run and the virtual module so that `RuntimeTranspilerCache.get`
   // (keyed by content hash) restores it.
-  const payload = "// " + "x".repeat(80 * 1024) + "\nmodule.exports = { ok: true };\n";
-  const primer = join(dir, "primer.cjs");
-  writeFileSync(primer, payload);
+  const payload = "// " + Buffer.alloc(80 * 1024, "x").toString() + "\nmodule.exports = { ok: true };\n";
+
+  using dir = tempDir("issue-30429", {
+    "primer.cjs": payload,
+    "fixture.ts": `
+      const { readFileSync } = require("fs");
+      const { join } = require("path");
+      const payload = readFileSync(join(__dirname, "primer.cjs"), "utf8");
+      Bun.plugin({
+        name: "virt30429",
+        setup(builder) {
+          builder.module("virtual30429.cjs", () => ({
+            contents: payload,
+            loader: "js",
+          }));
+        },
+      });
+      const mod = require("virtual30429.cjs");
+      console.log(typeof mod);
+    `,
+  });
+
+  const cache = join(dir + "", ".cache");
+  mkdirSync(cache, { recursive: true });
 
   const env = {
     ...bunEnv,
@@ -33,7 +50,7 @@ test("bare-specifier virtual CJS module does not panic on transpiler-cache hit",
 
   // Prime the cache by running the real file once.
   const primed = Bun.spawnSync({
-    cmd: [bunExe(), primer],
+    cmd: [bunExe(), join(dir + "", "primer.cjs")],
     env,
     stdin: "ignore",
   });
@@ -44,42 +61,17 @@ test("bare-specifier virtual CJS module does not panic on transpiler-cache hit",
   // `name.dir == ""`, so `readDirInfo("")` is called from the CJS tag
   // detection in `jsc/ModuleLoader.zig`. Before the fix,
   // `dirInfoCachedMaybeLog` panicked on the `isAbsolute` assertion.
-  const fixture = join(dir, "fixture.ts");
-  writeFileSync(
-    fixture,
-    `
-    const fs = require("fs");
-    const payload = fs.readFileSync(${JSON.stringify(primer)}, "utf8");
-    Bun.plugin({
-      name: "virt30429",
-      setup(builder) {
-        builder.module("virtual30429.cjs", () => ({
-          contents: payload,
-          loader: "js",
-        }));
-      },
-    });
-    const mod = require("virtual30429.cjs");
-    console.log(typeof mod);
-    `,
-  );
-
   const result = Bun.spawnSync({
-    cmd: [bunExe(), fixture],
+    cmd: [bunExe(), join(dir + "", "fixture.ts")],
     env,
     stdin: "ignore",
     timeout: 10_000,
   });
 
-  expect({
-    stderr: result.stderr.toString(),
-    stdout: result.stdout.toString().trim(),
-    exitCode: result.exitCode,
-    signalCode: result.signalCode,
-  }).toEqual({
-    stderr: "",
-    stdout: "object",
-    exitCode: 0,
-    signalCode: undefined,
-  });
+  // Assert stdout first so that diagnostics surface clearly when the
+  // subprocess exits non-zero. Don't pin stderr to an exact string —
+  // ASAN lanes emit sanitizer summaries there.
+  expect(result.stdout.toString().trim()).toBe("object");
+  expect(result.signalCode).toBeUndefined();
+  expect(result.exitCode).toBe(0);
 });

--- a/test/regression/issue/30429.test.ts
+++ b/test/regression/issue/30429.test.ts
@@ -1,0 +1,86 @@
+// https://github.com/oven-sh/bun/issues/30429
+//
+// Crash on Windows ReleaseSafe builds: "panic: Internal assertion failure:
+// cannot resolve DirInfo for non-absolute path:" — triggered when the
+// runtime-transpiler cache restores a CJS module whose `Fs.Path.name.dir`
+// is empty (i.e. the specifier has no path separator). Reporter hit it
+// with `bun eslint`. The assert is gated on `Environment.allow_assert`,
+// which is true for debug and Windows ReleaseSafe builds, so the
+// reproduction below panics on `bun bd` too.
+import { expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
+
+test("bare-specifier virtual CJS module does not panic on transpiler-cache hit", async () => {
+  const dir = tmpdirSync();
+  const cache = join(dir, ".cache");
+  mkdirSync(cache, { recursive: true });
+
+  // A CJS file large enough that the transpiler cache stores it
+  // (MINIMUM_CACHE_SIZE is 50 KiB). The content must match between the
+  // primer run and the virtual module so that `RuntimeTranspilerCache.get`
+  // (keyed by content hash) restores it.
+  const payload =
+    "// " + "x".repeat(80 * 1024) + "\nmodule.exports = { ok: true };\n";
+  const primer = join(dir, "primer.cjs");
+  writeFileSync(primer, payload);
+
+  const env = {
+    ...bunEnv,
+    BUN_RUNTIME_TRANSPILER_CACHE_PATH: cache,
+    BUN_DEBUG_ENABLE_RESTORE_FROM_TRANSPILER_CACHE: "1",
+  };
+
+  // Prime the cache by running the real file once.
+  const primed = Bun.spawnSync({
+    cmd: [bunExe(), primer],
+    env,
+    stdin: "ignore",
+  });
+  expect(primed.exitCode).toBe(0);
+
+  // Now require the same contents via a virtual module whose specifier has
+  // no path separator. `Fs.Path.init("virtual30429.cjs")` produces
+  // `name.dir == ""`, so `readDirInfo("")` is called from the CJS tag
+  // detection in `jsc/ModuleLoader.zig`. Before the fix,
+  // `dirInfoCachedMaybeLog` panicked on the `isAbsolute` assertion.
+  const fixture = join(dir, "fixture.ts");
+  writeFileSync(
+    fixture,
+    `
+    const fs = require("fs");
+    const payload = fs.readFileSync(${JSON.stringify(primer)}, "utf8");
+    Bun.plugin({
+      name: "virt30429",
+      setup(builder) {
+        builder.module("virtual30429.cjs", () => ({
+          contents: payload,
+          loader: "js",
+        }));
+      },
+    });
+    const mod = require("virtual30429.cjs");
+    console.log(typeof mod);
+    `,
+  );
+
+  const result = Bun.spawnSync({
+    cmd: [bunExe(), fixture],
+    env,
+    stdin: "ignore",
+    timeout: 10_000,
+  });
+
+  expect({
+    stderr: result.stderr.toString(),
+    stdout: result.stdout.toString().trim(),
+    exitCode: result.exitCode,
+    signalCode: result.signalCode,
+  }).toEqual({
+    stderr: "",
+    stdout: "object",
+    exitCode: 0,
+    signalCode: undefined,
+  });
+});

--- a/test/regression/issue/30429.test.ts
+++ b/test/regression/issue/30429.test.ts
@@ -9,8 +9,8 @@
 // reproduction below panics on `bun bd` too.
 import { expect, test } from "bun:test";
 import { mkdirSync, writeFileSync } from "fs";
-import { join } from "path";
 import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { join } from "path";
 
 test("bare-specifier virtual CJS module does not panic on transpiler-cache hit", async () => {
   const dir = tmpdirSync();
@@ -21,8 +21,7 @@ test("bare-specifier virtual CJS module does not panic on transpiler-cache hit",
   // (MINIMUM_CACHE_SIZE is 50 KiB). The content must match between the
   // primer run and the virtual module so that `RuntimeTranspilerCache.get`
   // (keyed by content hash) restores it.
-  const payload =
-    "// " + "x".repeat(80 * 1024) + "\nmodule.exports = { ok: true };\n";
+  const payload = "// " + "x".repeat(80 * 1024) + "\nmodule.exports = { ok: true };\n";
   const primer = join(dir, "primer.cjs");
   writeFileSync(primer, payload);
 


### PR DESCRIPTION
Fixes #30429

## Repro

Running `bun eslint <somefile.ts>` on Windows 1.3.13 crashed with:

```
panic(thread N): Internal assertion failure: cannot resolve DirInfo for non-absolute path: 
    src/bun.zig:3074  assertf
    src/resolver/resolver.zig:2670  dirInfoCachedMaybeLog
    src/resolver/resolver.zig:2619  readDirInfo
    src/bun.js/ModuleLoader.zig:452 transpileSourceCode
```

The path after the colon is **empty**. Reproduces on `bun bd` by
rigging a cache hit against a virtual module whose specifier has no
path separator — see the added test.

## Cause

`dirInfoCachedMaybeLog` asserts `std.fs.path.isAbsolute(input_path)`
then uses the path as a cache key and to walk parent directories. The
assert is gated on `Environment.allow_assert`, which is true for debug
and **Windows ReleaseSafe** (load-bearing since Bun 1.1, per
`scripts/build/zig.ts`). Linux release builds strip it, so the same
code path silently misbehaves there.

`jsc/ModuleLoader.zig:452` (the CJS tag-detection branch on a
transpiler-cache restore) passes `source.path.name.dir` directly.
`PathName.init` sets `dir = ""` whenever the input has no separator —
the exact shape the runtime can produce when the specifier comes from
a plugin `builder.module(name, ...)` call or any other bare source.
`Fs.Path.init("virtual30429.cjs").name.dir == ""`, and the content-keyed
`RuntimeTranspilerCache` will happily return a hit from a prior run of
the real file with the same bytes.

Two sibling call sites in `resolver.zig` (`finalizeResult` at line 1031,
the browser-field remap at line 1573) also pass `.name.dir` raw, each
already wrapped in `catch null orelse ...` — so they would panic too
if they ever saw a bare-dir path.

## Fix

Fix the callee once: in `dirInfoCachedMaybeLog`, return `null` for
empty or non-absolute paths before reaching the assert, instead of
strengthening the invariant and auditing every caller. All three
current callers already route `null` into their fallback paths.

## Verification

- `test/regression/issue/30429.test.ts` primes the runtime transpiler
  cache with a ≥50 KiB CJS file, then requires a virtual module whose
  specifier is `virtual30429.cjs` (no separator) with matching content
  so the cache restore path fires.
- Gate: `git stash` → `bun bd` → `bun bd test …/30429.test.ts`
  fails with the exact `cannot resolve DirInfo for non-absolute path:`
  panic; `git stash pop` → `bun bd` → passes.
- `test/cli/run/transpiler-cache.test.ts` (9 tests), the
  `test/js/bun/resolve/` suite (47 passing), and
  `test/js/bun/plugin/plugins.test.ts` (29 passing) still green.