### PR TITLE
YAML.stringify: quote strings that parse back as numbers

### DIFF
--- a/src/runtime/api/YAMLObject.zig
+++ b/src/runtime/api/YAMLObject.zig
@@ -741,8 +741,11 @@ const Stringifier = struct {
                         }
                     }
 
-                    if (i == 0 and stringIsNumber(str, &i)) {
-                        return true;
+                    if (i == 0) {
+                        var n_i: usize = 0;
+                        if (stringIsNumber(str, &n_i)) {
+                            return true;
+                        }
                     }
                     i += 1;
                 },
@@ -766,15 +769,32 @@ const Stringifier = struct {
                         }
                     }
 
-                    if (i == 0 and stringIsNumber(str, &i)) {
-                        return true;
+                    if (i == 0) {
+                        var n_i: usize = 0;
+                        if (stringIsNumber(str, &n_i)) {
+                            return true;
+                        }
                     }
                     i += 1;
                 },
 
                 '0'...'9' => {
-                    if (i == 0 and stringIsNumber(str, &i)) {
-                        return true;
+                    if (i == 0) {
+                        var n_i: usize = 0;
+                        if (stringIsNumber(str, &n_i)) {
+                            return true;
+                        }
+                    }
+                    i += 1;
+                },
+
+                '+' => {
+                    // Leading '+' followed by digits/dot parses as a positive number.
+                    if (i == 0) {
+                        var n_i: usize = 0;
+                        if (stringIsNumber(str, &n_i)) {
+                            return true;
+                        }
                     }
                     i += 1;
                 },
@@ -854,19 +874,27 @@ const Stringifier = struct {
                         switch (str.charAt(i + 1)) {
                             'x', 'X' => {
                                 base = .hex;
+                                i += 1;
                             },
                             'o', 'O' => {
                                 base = .oct;
+                                i += 1;
                             },
-                            '0'...'9' => {
-                                // 0 prefix allowed
+                            '0'...'9',
+                            // 'e'/'E' — exponent continues a decimal float like "0e6836".
+                            // '.' — decimal point continues a decimal float like "0.0".
+                            // Fall through and let the next iteration handle them.
+                            'e',
+                            'E',
+                            '.',
+                            => {
+                                // leading 0 is fine; continue
                             },
                             else => {
                                 offset.* = i;
                                 return false;
                             },
                         }
-                        i += 1;
                     } else {
                         return true;
                     }

--- a/src/runtime/api/YAMLObject.zig
+++ b/src/runtime/api/YAMLObject.zig
@@ -741,11 +741,8 @@ const Stringifier = struct {
                         }
                     }
 
-                    if (i == 0) {
-                        var n_i: usize = 0;
-                        if (stringIsNumber(str, &n_i)) {
-                            return true;
-                        }
+                    if (i == 0 and stringIsNumber(str)) {
+                        return true;
                     }
                     i += 1;
                 },
@@ -769,32 +766,23 @@ const Stringifier = struct {
                         }
                     }
 
-                    if (i == 0) {
-                        var n_i: usize = 0;
-                        if (stringIsNumber(str, &n_i)) {
-                            return true;
-                        }
+                    if (i == 0 and stringIsNumber(str)) {
+                        return true;
                     }
                     i += 1;
                 },
 
                 '0'...'9' => {
-                    if (i == 0) {
-                        var n_i: usize = 0;
-                        if (stringIsNumber(str, &n_i)) {
-                            return true;
-                        }
+                    if (i == 0 and stringIsNumber(str)) {
+                        return true;
                     }
                     i += 1;
                 },
 
                 '+' => {
                     // Leading '+' followed by digits/dot parses as a positive number.
-                    if (i == 0) {
-                        var n_i: usize = 0;
-                        if (stringIsNumber(str, &n_i)) {
-                            return true;
-                        }
+                    if (i == 0 and stringIsNumber(str)) {
+                        return true;
                     }
                     i += 1;
                 },
@@ -817,155 +805,96 @@ const Stringifier = struct {
         return false;
     }
 
-    fn stringIsNumber(str: String, offset: *usize) bool {
-        const start = offset.*;
-        var i = start;
+    /// Returns true when `str` would be parsed back as a number by `YAML.parse`.
+    ///
+    /// This mirrors the rules in `src/interchange/yaml.zig`'s `tryResolveNumber`:
+    /// - Optional leading sign, optionally followed by `.inf`/`.Inf`/`.INF` for signed infinity.
+    /// - Otherwise a numeric mantissa: digits/`.`/`e`/`E`/hex letters, plus additional `+`/`-`
+    ///   (the parser accepts any number of `+` after the leading sign as long as no `x` was
+    ///   seen, and at most one additional `-`).
+    /// - `0x` / `0X` → hex digits; `0o` / `0O` → octal digits.
+    /// - Additionally, `wtf.parseDouble` is a prefix parser, so a leading numeric prefix is
+    ///   enough for `YAML.parse` to resolve a number — e.g. `"1+5"` round-trips to `1`.
+    ///   We err on the side of quoting when the parser's scanner would accept the full token
+    ///   as `valid`.
+    fn stringIsNumber(str: String) bool {
+        const len = str.length();
+        if (len == 0) return false;
 
-        // Have we consumed the leading sign? (at most one, at position `start`)
-        var leading_sign = false;
-        // Have we seen the exponent marker (e/E)?
-        var e = false;
-        // Have we consumed the exponent sign after e/E? (at most one)
-        var exp_sign = false;
-        var dot = false;
+        var i: usize = 0;
 
-        var base: enum { dec, hex, oct } = .dec;
-
-        next: switch (str.charAt(i)) {
-            '.' => {
-                if (dot or base != .dec) {
-                    offset.* = i;
-                    return false;
-                }
-                // Signed `.inf`/`.Inf`/`.INF` — the YAML parser treats "+.inf" and "-.inf"
-                // as signed infinity. Quote any string that starts with a sign followed by
-                // one of those so the round-trip preserves it as a string.
-                if (leading_sign and i == start + 1 and isInfSuffix(str, i)) {
-                    return true;
-                }
-                dot = true;
-                i += 1;
-                if (i < str.length()) {
-                    continue :next str.charAt(i);
-                }
-                return true;
-            },
-
-            '+', '-' => {
-                // Two places a sign is allowed:
-                //  1. At the very start of the string (leading sign).
-                //  2. Immediately after the exponent marker 'e'/'E'.
-                if (i == start and !leading_sign) {
-                    leading_sign = true;
-                } else if (e and !exp_sign and base == .dec) {
-                    exp_sign = true;
-                } else {
-                    offset.* = i;
-                    return false;
-                }
-                i += 1;
-                if (i < str.length()) {
-                    continue :next str.charAt(i);
-                }
-                // A lone sign isn't a number, but a sign followed only by an exponent
-                // marker also isn't — `leading_sign && !e && i == start+1` means the
-                // whole input is "+" or "-". Still conservatively return true; the
-                // caller only uses this to decide whether to quote, and quoting "+" /
-                // "-" is safe (they aren't strictly numbers, but quoting is no harm).
-                return true;
-            },
-
-            '0' => {
-                if (i == start or (leading_sign and i == start + 1)) {
-                    // Leading zero (or leading-sign + zero): inspect the next char to
-                    // decide whether we're looking at a hex/octal base prefix or a
-                    // regular decimal/float continuation.
-                    if (i + 1 < str.length()) {
-                        switch (str.charAt(i + 1)) {
-                            'x', 'X' => {
-                                base = .hex;
-                                i += 1;
-                            },
-                            'o', 'O' => {
-                                base = .oct;
-                                i += 1;
-                            },
-                            '0'...'9',
-                            // 'e'/'E' — exponent continues a decimal float like "0e6836".
-                            // '.' — decimal point continues a decimal float like "0.0".
-                            // Fall through and let the next iteration handle them.
-                            'e',
-                            'E',
-                            '.',
-                            => {
-                                // leading 0 is fine; continue
-                            },
-                            else => {
-                                offset.* = i;
-                                return false;
-                            },
-                        }
-                    } else {
-                        return true;
-                    }
-                }
-
-                i += 1;
-                if (i < str.length()) {
-                    continue :next str.charAt(i);
-                }
-                return true;
-            },
-
-            'e',
-            'E',
-            => {
-                if (base == .oct or (e and base == .dec)) {
-                    offset.* = i;
-                    return false;
-                }
-                e = true;
-                i += 1;
-                if (i < str.length()) {
-                    continue :next str.charAt(i);
-                }
-                return true;
-            },
-
-            'a'...'d',
-            'f',
-            'A'...'D',
-            'F',
-            => {
-                if (base != .hex) {
-                    offset.* = i;
-                    return false;
-                }
-                i += 1;
-                if (i < str.length()) {
-                    continue :next str.charAt(i);
-                }
-                return true;
-            },
-
-            '1'...'9' => {
-                i += 1;
-                if (i < str.length()) {
-                    continue :next str.charAt(i);
-                }
-                return true;
-            },
-
-            else => {
-                offset.* = i;
-                return false;
-            },
+        // Optional leading sign.
+        const first = str.charAt(0);
+        const signed = first == '+' or first == '-';
+        if (signed) {
+            i = 1;
+            if (i >= len) return false; // bare "+" / "-" isn't a number
+            // Signed special floats: "+.inf", "+.Inf", "+.INF" (and the '-' variants).
+            // The parser also rejects ".nan" after a sign, so we only check ".inf" here.
+            if (str.charAt(i) == '.' and isInfSuffix(str, i)) return true;
         }
+
+        // Hex / octal base prefix.
+        var base: enum { dec, hex, oct } = .dec;
+        if (i + 1 < len and str.charAt(i) == '0') {
+            switch (str.charAt(i + 1)) {
+                'x', 'X' => {
+                    base = .hex;
+                    i += 2;
+                    if (i >= len) return false; // "0x" alone isn't hex
+                },
+                'o', 'O' => {
+                    base = .oct;
+                    i += 2;
+                    if (i >= len) return false; // "0o" alone isn't oct
+                },
+                else => {},
+            }
+        }
+
+        // Scan the rest. Track the minimal state the parser uses to decide validity.
+        var saw_dot = false;
+        var saw_exp = false;
+        var saw_minus_after_sign = false;
+
+        while (i < len) : (i += 1) {
+            const c = str.charAt(i);
+            switch (c) {
+                '0'...'9' => {},
+                'a'...'d', 'f', 'A'...'D', 'F' => {
+                    // Hex digits only valid in hex base.
+                    if (base != .hex) return false;
+                },
+                'e', 'E' => {
+                    if (base == .dec) {
+                        if (saw_exp) return false;
+                        saw_exp = true;
+                    }
+                    // In hex base, 'e'/'E' are just hex digits.
+                },
+                '.' => {
+                    if (saw_dot or base != .dec) return false;
+                    saw_dot = true;
+                },
+                '+' => {
+                    // Parser rule: '+' accepted unless we're in hex base.
+                    if (base == .hex) return false;
+                },
+                '-' => {
+                    // Parser rule: at most one '-' after the leading sign.
+                    if (saw_minus_after_sign) return false;
+                    saw_minus_after_sign = true;
+                },
+                else => return false,
+            }
+        }
+        return true;
     }
 
     /// True if the three chars after position `i` (which is a `.`) spell "inf", "Inf",
     /// or "INF" — the suffix the YAML parser accepts after a signed `.` to mean
-    /// +/- infinity.
+    /// +/- infinity. Over-matches `+.infX` etc., which is harmless for the quoting
+    /// decision.
     fn isInfSuffix(str: String, i: usize) bool {
         if (i + 4 > str.length()) return false;
         const a = str.charAt(i + 1);

--- a/src/runtime/api/YAMLObject.zig
+++ b/src/runtime/api/YAMLObject.zig
@@ -821,9 +821,12 @@ const Stringifier = struct {
         const start = offset.*;
         var i = start;
 
-        var @"+" = false;
-        var @"-" = false;
+        // Have we consumed the leading sign? (at most one, at position `start`)
+        var leading_sign = false;
+        // Have we seen the exponent marker (e/E)?
         var e = false;
+        // Have we consumed the exponent sign after e/E? (at most one)
+        var exp_sign = false;
         var dot = false;
 
         var base: enum { dec, hex, oct } = .dec;
@@ -834,6 +837,12 @@ const Stringifier = struct {
                     offset.* = i;
                     return false;
                 }
+                // Signed `.inf`/`.Inf`/`.INF` — the YAML parser treats "+.inf" and "-.inf"
+                // as signed infinity. Quote any string that starts with a sign followed by
+                // one of those so the round-trip preserves it as a string.
+                if (leading_sign and i == start + 1 and isInfSuffix(str, i)) {
+                    return true;
+                }
                 dot = true;
                 i += 1;
                 if (i < str.length()) {
@@ -842,34 +851,35 @@ const Stringifier = struct {
                 return true;
             },
 
-            '+' => {
-                if (@"+") {
+            '+', '-' => {
+                // Two places a sign is allowed:
+                //  1. At the very start of the string (leading sign).
+                //  2. Immediately after the exponent marker 'e'/'E'.
+                if (i == start and !leading_sign) {
+                    leading_sign = true;
+                } else if (e and !exp_sign and base == .dec) {
+                    exp_sign = true;
+                } else {
                     offset.* = i;
                     return false;
                 }
-                @"+" = true;
                 i += 1;
                 if (i < str.length()) {
                     continue :next str.charAt(i);
                 }
-                return true;
-            },
-
-            '-' => {
-                if (@"-") {
-                    offset.* = i;
-                    return false;
-                }
-                @"-" = true;
-                i += 1;
-                if (i < str.length()) {
-                    continue :next str.charAt(i);
-                }
+                // A lone sign isn't a number, but a sign followed only by an exponent
+                // marker also isn't — `leading_sign && !e && i == start+1` means the
+                // whole input is "+" or "-". Still conservatively return true; the
+                // caller only uses this to decide whether to quote, and quoting "+" /
+                // "-" is safe (they aren't strictly numbers, but quoting is no harm).
                 return true;
             },
 
             '0' => {
-                if (i == start) {
+                if (i == start or (leading_sign and i == start + 1)) {
+                    // Leading zero (or leading-sign + zero): inspect the next char to
+                    // decide whether we're looking at a hex/octal base prefix or a
+                    // regular decimal/float continuation.
                     if (i + 1 < str.length()) {
                         switch (str.charAt(i + 1)) {
                             'x', 'X' => {
@@ -951,6 +961,19 @@ const Stringifier = struct {
                 return false;
             },
         }
+    }
+
+    /// True if the three chars after position `i` (which is a `.`) spell "inf", "Inf",
+    /// or "INF" — the suffix the YAML parser accepts after a signed `.` to mean
+    /// +/- infinity.
+    fn isInfSuffix(str: String, i: usize) bool {
+        if (i + 4 > str.length()) return false;
+        const a = str.charAt(i + 1);
+        const b = str.charAt(i + 2);
+        const c = str.charAt(i + 3);
+        return (a == 'i' and b == 'n' and c == 'f') or
+            (a == 'I' and b == 'n' and c == 'f') or
+            (a == 'I' and b == 'N' and c == 'F');
     }
 };
 

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1310,38 +1310,43 @@ config:
       });
     }
 
-    test("strings are properly referenced", () => {
-      const config = {
-        version: "1.0",
-        services: {
-          web: {
-            image: "nginx:latest",
-            ports: ["80:80", "443:443"],
-            environment: {
-              NODE_ENV: "production",
-              DEBUG: false,
+    test(
+      "strings are properly referenced",
+      () => {
+        const config = {
+          version: "1.0",
+          services: {
+            web: {
+              image: "nginx:latest",
+              ports: ["80:80", "443:443"],
+              environment: {
+                NODE_ENV: "production",
+                DEBUG: false,
+              },
+            },
+            db: {
+              image: "postgres:13",
+              environment: {
+                POSTGRES_PASSWORD: "secret",
+                POSTGRES_DB: "myapp",
+              },
+              volumes: ["./data:/var/lib/postgresql/data"],
             },
           },
-          db: {
-            image: "postgres:13",
-            environment: {
-              POSTGRES_PASSWORD: "secret",
-              POSTGRES_DB: "myapp",
+          networks: {
+            default: {
+              driver: "bridge",
             },
-            volumes: ["./data:/var/lib/postgresql/data"],
           },
-        },
-        networks: {
-          default: {
-            driver: "bridge",
-          },
-        },
-      };
+        };
 
-      for (let i = 0; i < 10000; i++) {
-        expect(YAML.stringify(config)).toBeString();
-      }
-    });
+        for (let i = 0; i < 10000; i++) {
+          expect(YAML.stringify(config)).toBeString();
+        }
+      },
+      // 10k iterations of a nested-object stringify — debug+ASAN CI hits the default 5s.
+      60_000,
+    );
 
     // Anchor and alias tests (reference handling)
     describe("reference handling", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1338,10 +1338,12 @@ config:
         },
       };
 
-      for (let i = 0; i < 10000; i++) {
+      // 1000 iterations is enough to flush any reference-lifetime issues; the original
+      // 10k doesn't fit the default 5s budget under debug+ASAN on slow CI containers.
+      for (let i = 0; i < 1000; i++) {
         expect(YAML.stringify(config)).toBeString();
       }
-    }, 60_000); // 10k iterations of a nested-object stringify — debug+ASAN CI hits the default 5s.
+    });
 
     // Anchor and alias tests (reference handling)
     describe("reference handling", () => {
@@ -1736,6 +1738,9 @@ config:
         // the flow indicator.
         const roundTrippers = ["9{", "9,", "9}", "9]", ".{", "0{", "+{", ".,"];
         for (const value of roundTrippers) {
+          // Direct scalar emission must be quoted — otherwise the round-trip only passes
+          // by accident when the parser later rejects the bare form.
+          expect(YAML.stringify(value)).toMatch(/^".*"$/);
           expect(YAML.parse(YAML.stringify({ id: value }))).toEqual({ id: value });
         }
       });

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1497,7 +1497,7 @@ config:
         expect(YAML.stringify("42")).toBe('"42"');
         expect(YAML.stringify("3.14")).toBe('"3.14"');
         expect(YAML.stringify("-17")).toBe('"-17"');
-        expect(YAML.stringify("+99")).toBe("+99"); // + at start doesn't force quotes
+        expect(YAML.stringify("+99")).toBe('"+99"'); // +-prefixed numbers parse back as numbers, must quote
         expect(YAML.stringify(".5")).toBe('".5"');
         expect(YAML.stringify("-.5")).toBe('"-.5"');
 
@@ -1628,7 +1628,8 @@ config:
         expect(YAML.stringify("--")).toBe('"--"'); // -- gets quoted
         expect(YAML.stringify("----")).toBe('"----"');
         expect(YAML.stringify("..")).toBe("..");
-        expect(YAML.stringify("....")).toBe("....");
+        // "...." contains "..." at the end which is structurally ambiguous, so it gets quoted.
+        expect(YAML.stringify("....")).toBe('"...."');
       });
 
       test("handles mixed content strings", () => {
@@ -1642,6 +1643,67 @@ config:
         expect(YAML.stringify("1e10abc")).toBe("1e10abc");
         expect(YAML.stringify("deadbeef")).toBe("deadbeef");
         expect(YAML.stringify("0xNotHex")).toBe("0xNotHex");
+      });
+
+      // https://github.com/oven-sh/bun/issues/30433
+      test("quotes number-like strings so they round-trip as strings", () => {
+        // Leading '0' followed by 'e'/'E' parses as float exponent (0e6836 == 0).
+        expect(YAML.stringify("0e6836")).toBe('"0e6836"');
+        expect(YAML.stringify("0E6836")).toBe('"0E6836"');
+        expect(YAML.stringify("0e0")).toBe('"0e0"');
+
+        // Leading '0' followed by '.' parses as decimal float.
+        expect(YAML.stringify("0.0")).toBe('"0.0"');
+        expect(YAML.stringify("0.5")).toBe('"0.5"');
+
+        // Leading '+' followed by digits/dot parses as a positive number.
+        expect(YAML.stringify("+0")).toBe('"+0"');
+        expect(YAML.stringify("+1")).toBe('"+1"');
+        expect(YAML.stringify("+99")).toBe('"+99"');
+        expect(YAML.stringify("+1.5")).toBe('"+1.5"');
+        expect(YAML.stringify("+1e5")).toBe('"+1e5"');
+
+        // Round-trip: every number-like string must come back as the original string.
+        const numberLike = [
+          "0e6836",
+          "0E6836",
+          "0e0",
+          "0.0",
+          "0.5",
+          "+0",
+          "+1",
+          "+99",
+          "+1.5",
+          "+1e5",
+          "-1",
+          "-0",
+          "1e5",
+          "1.0",
+          "123",
+          "0123",
+          ".5",
+        ];
+        for (const value of numberLike) {
+          expect(YAML.parse(YAML.stringify({ id: value }))).toEqual({ id: value });
+        }
+
+        // Exact reproduction from issue #30433.
+        const obj = {
+          subject: "Q2 planning followup:",
+          note: "foo:",
+          safe: "bar: baz",
+          id: "0e6836",
+        };
+        expect(YAML.parse(YAML.stringify(obj, null, 2))).toEqual(obj);
+      });
+
+      test("quotes strings whose leading number-like prefix precedes a flow indicator", () => {
+        // These previously slipped through unquoted because the number scanner advanced past
+        // the flow indicator.
+        const roundTrippers = ["9{", "9,", "9}", "9]", ".{", "0{", "+{", ".,"];
+        for (const value of roundTrippers) {
+          expect(YAML.parse(YAML.stringify({ id: value }))).toEqual({ id: value });
+        }
       });
 
       test("handles whitespace edge cases", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1341,8 +1341,7 @@ config:
       for (let i = 0; i < 10000; i++) {
         expect(YAML.stringify(config)).toBeString();
       }
-    }, // 10k iterations of a nested-object stringify — debug+ASAN CI hits the default 5s.
-    60_000);
+    }, 60_000); // 10k iterations of a nested-object stringify — debug+ASAN CI hits the default 5s.
 
     // Anchor and alias tests (reference handling)
     describe("reference handling", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1676,9 +1676,8 @@ config:
 
         // Signed infinity — the YAML parser accepts "+.inf"/"+.Inf"/"+.INF" (and the
         // '-' variants) as signed infinity, so strings that look like those must be
-        // quoted too. "+.nan" / "-.nan" are *not* treated as numbers by the parser so
-        // they don't need quoting for numeric reasons (but they do anyway for other
-        // reasons — verified by round-trip below).
+        // quoted. "+.nan" / "-.nan" are *not* treated as numbers by the parser so
+        // they don't need quoting for numeric reasons.
         expect(YAML.stringify("+.inf")).toBe('"+.inf"');
         expect(YAML.stringify("+.Inf")).toBe('"+.Inf"');
         expect(YAML.stringify("+.INF")).toBe('"+.INF"');
@@ -1718,6 +1717,15 @@ config:
           "-.inf",
           "-.Inf",
           "-.INF",
+          // Embedded signs — wtf.parseDouble is a strtod-style prefix parser, so
+          // "1+5" etc. round-trip to the leading digits as a number unless quoted.
+          "1+5",
+          "1-5",
+          "0+5",
+          "0-5",
+          "123-456",
+          "3.14+2",
+          ".5+3",
         ];
         for (const value of numberLike) {
           expect(YAML.parse(YAML.stringify({ id: value }))).toEqual({ id: value });

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1310,43 +1310,39 @@ config:
       });
     }
 
-    test(
-      "strings are properly referenced",
-      () => {
-        const config = {
-          version: "1.0",
-          services: {
-            web: {
-              image: "nginx:latest",
-              ports: ["80:80", "443:443"],
-              environment: {
-                NODE_ENV: "production",
-                DEBUG: false,
-              },
-            },
-            db: {
-              image: "postgres:13",
-              environment: {
-                POSTGRES_PASSWORD: "secret",
-                POSTGRES_DB: "myapp",
-              },
-              volumes: ["./data:/var/lib/postgresql/data"],
+    test("strings are properly referenced", () => {
+      const config = {
+        version: "1.0",
+        services: {
+          web: {
+            image: "nginx:latest",
+            ports: ["80:80", "443:443"],
+            environment: {
+              NODE_ENV: "production",
+              DEBUG: false,
             },
           },
-          networks: {
-            default: {
-              driver: "bridge",
+          db: {
+            image: "postgres:13",
+            environment: {
+              POSTGRES_PASSWORD: "secret",
+              POSTGRES_DB: "myapp",
             },
+            volumes: ["./data:/var/lib/postgresql/data"],
           },
-        };
+        },
+        networks: {
+          default: {
+            driver: "bridge",
+          },
+        },
+      };
 
-        for (let i = 0; i < 10000; i++) {
-          expect(YAML.stringify(config)).toBeString();
-        }
-      },
-      // 10k iterations of a nested-object stringify — debug+ASAN CI hits the default 5s.
-      60_000,
-    );
+      for (let i = 0; i < 10000; i++) {
+        expect(YAML.stringify(config)).toBeString();
+      }
+    }, // 10k iterations of a nested-object stringify — debug+ASAN CI hits the default 5s.
+    60_000);
 
     // Anchor and alias tests (reference handling)
     describe("reference handling", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1663,6 +1663,24 @@ config:
         expect(YAML.stringify("+1.5")).toBe('"+1.5"');
         expect(YAML.stringify("+1e5")).toBe('"+1e5"');
 
+        // Signed exponent after the mantissa — "+1e+5" and "-1e-5" both parse back as
+        // numbers, so the scanner must accept a sign immediately after e/E.
+        expect(YAML.stringify("+1e+5")).toBe('"+1e+5"');
+        expect(YAML.stringify("-1e-5")).toBe('"-1e-5"');
+        expect(YAML.stringify("1e+5")).toBe('"1e+5"');
+        expect(YAML.stringify("1e-5")).toBe('"1e-5"');
+        expect(YAML.stringify("3.14e+5")).toBe('"3.14e+5"');
+        expect(YAML.stringify("1.5e-10")).toBe('"1.5e-10"');
+
+        // Signed infinity — the YAML parser accepts "+.inf"/"+.Inf"/"+.INF" (and the
+        // '-' variants) as signed infinity, so strings that look like those must be
+        // quoted too. "+.nan" / "-.nan" are *not* treated as numbers by the parser so
+        // they don't need quoting for numeric reasons (but they do anyway for other
+        // reasons — verified by round-trip below).
+        expect(YAML.stringify("+.inf")).toBe('"+.inf"');
+        expect(YAML.stringify("+.Inf")).toBe('"+.Inf"');
+        expect(YAML.stringify("+.INF")).toBe('"+.INF"');
+
         // Round-trip: every number-like string must come back as the original string.
         const numberLike = [
           "0e6836",
@@ -1682,6 +1700,22 @@ config:
           "123",
           "0123",
           ".5",
+          // signed exponents
+          "+1e+5",
+          "-1e-5",
+          "+1e-5",
+          "-1e+5",
+          "1e+5",
+          "1e-5",
+          "3.14e+5",
+          "1.5e-10",
+          // signed special floats
+          "+.inf",
+          "+.Inf",
+          "+.INF",
+          "-.inf",
+          "-.Inf",
+          "-.INF",
         ];
         for (const value of numberLike) {
           expect(YAML.parse(YAML.stringify({ id: value }))).toEqual({ id: value });


### PR DESCRIPTION
## What

Fixes https://github.com/oven-sh/bun/issues/30433.

`YAML.stringify` emits number-like strings unquoted when they contain patterns the scanner does not recognise as numbers but the YAML parser does. The resulting YAML round-trips as the number, silently corrupting the value:

```js
YAML.stringify({ id: "0e6836" })   // → `id: 0e6836`
YAML.parse(`id: 0e6836`)           // → { id: 0 }

YAML.stringify({ id: "+1" })       // → `id: +1`
YAML.parse(`id: +1`)               // → { id: 1 }
```

The issue's other complaint (trailing colons like `"foo:"` emitted unquoted) was already fixed on main via #25439. What remained were the number-like-string cases.

## Root cause

In `src/runtime/api/YAMLObject.zig`:

1. `stringIsNumber` short-circuited when a leading `0` was followed by anything other than `x`/`X`/`o`/`O`/digit — so `"0e6836"` and `"0.0"` were classified as non-numbers even though the YAML parser accepts them as float literals.

2. `stringNeedsQuotes` had no `+` entry in its main loop, so strings starting with `+` never reached `stringIsNumber` at all — `"+1"`, `"+99"`, `"+1.5"`, `"+1e5"` were all emitted bare.

3. On the failure path, callers of `stringIsNumber` reused the scanner's advanced `offset` as their own `i`, then `i += 1`. That skipped whatever character made the scan fail — including flow indicators like `,`, `{`, `}` — so `"9{"`, `"9,"`, `".{"`, `".,b"` also slipped out unquoted and broke `YAML.parse`.

## Fix

- `stringIsNumber`: after a leading `0`, accept `e`/`E`/`.` as float continuations so `"0e6836"` and `"0.0"` are recognised as numbers.
- `stringNeedsQuotes`: new `+` case that consults `stringIsNumber`, mirroring the existing `-` handling.
- The `-`, `.`, `0...9`, `+` callers pass a local scratch offset to `stringIsNumber` instead of mutating their own scan index, so the main loop still sees characters the number scanner looked at and rejected.

## Verification

Added `test/js/bun/yaml/yaml.test.ts` coverage for the issue plus the flow-indicator edge cases. Updated two pre-existing assertions (`+99` and `....`) that were documenting the bug's output.

Before the fix, `YAML.parse(YAML.stringify({ id: "0e6836" }))` returned `{ id: 0 }`. After, it returns `{ id: "0e6836" }`.