### PR TITLE
Fix double-free of path string on S3 error paths

### DIFF
--- a/src/runtime/webcore/S3Client.zig
+++ b/src/runtime/webcore/S3Client.zig
@@ -135,9 +135,11 @@ pub const S3Client = struct {
             }
             return globalThis.throwInvalidArguments("Expected a path", .{});
         };
-        errdefer path.deinit();
+        var path_consumed = false;
+        errdefer if (!path_consumed) path.deinit();
         const options = args.nextEat();
         var blob = Blob.new(try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer));
+        path_consumed = true;
         return blob.toJS(globalThis);
     }
 
@@ -151,10 +153,12 @@ pub const S3Client = struct {
             }
             return globalThis.throwInvalidArguments("Expected a path to presign", .{});
         };
-        errdefer path.deinit();
+        var path_consumed = false;
+        errdefer if (!path_consumed) path.deinit();
 
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
+        path_consumed = true;
         defer blob.detach();
         return S3File.getPresignUrlFrom(&blob, globalThis, options);
     }
@@ -169,9 +173,11 @@ pub const S3Client = struct {
             }
             return globalThis.throwInvalidArguments("Expected a path to check if it exists", .{});
         };
-        errdefer path.deinit();
+        var path_consumed = false;
+        errdefer if (!path_consumed) path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
+        path_consumed = true;
         defer blob.detach();
         return S3File.S3BlobStatTask.exists(globalThis, &blob);
     }
@@ -186,9 +192,11 @@ pub const S3Client = struct {
             }
             return globalThis.throwInvalidArguments("Expected a path to check the size of", .{});
         };
-        errdefer path.deinit();
+        var path_consumed = false;
+        errdefer if (!path_consumed) path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
+        path_consumed = true;
         defer blob.detach();
         return S3File.S3BlobStatTask.size(globalThis, &blob);
     }
@@ -203,9 +211,11 @@ pub const S3Client = struct {
             }
             return globalThis.throwInvalidArguments("Expected a path to check the stat of", .{});
         };
-        errdefer path.deinit();
+        var path_consumed = false;
+        errdefer if (!path_consumed) path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
+        path_consumed = true;
         defer blob.detach();
         return S3File.S3BlobStatTask.stat(globalThis, &blob);
     }
@@ -217,13 +227,15 @@ pub const S3Client = struct {
         const path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
             return globalThis.ERR(.MISSING_ARGS, "Expected a path to write to", .{}).throw();
         };
-        errdefer path.deinit();
+        var path_consumed = false;
+        errdefer if (!path_consumed) path.deinit();
         const data = args.nextEat() orelse {
             return globalThis.ERR(.MISSING_ARGS, "Expected a Blob-y thing to write", .{}).throw();
         };
 
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
+        path_consumed = true;
         defer blob.detach();
         var blob_internal: PathOrBlob = .{ .blob = blob };
         return Blob.writeFileInternal(globalThis, &blob_internal, data, .{
@@ -251,9 +263,11 @@ pub const S3Client = struct {
         const path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
             return globalThis.ERR(.MISSING_ARGS, "Expected a path to unlink", .{}).throw();
         };
-        errdefer path.deinit();
+        var path_consumed = false;
+        errdefer if (!path_consumed) path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
+        path_consumed = true;
         defer blob.detach();
         return blob.store.?.data.s3.unlink(blob.store.?, globalThis, options);
     }

--- a/src/runtime/webcore/S3File.zig
+++ b/src/runtime/webcore/S3File.zig
@@ -67,8 +67,9 @@ pub fn presign(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.J
 
     // accept a path or a blob
     var path_or_blob = try PathOrBlob.fromJSNoCopy(globalThis, &args);
+    var path_consumed = false;
     errdefer {
-        if (path_or_blob == .path) {
+        if (!path_consumed and path_or_blob == .path) {
             path_or_blob.path.deinit();
         }
     }
@@ -84,6 +85,7 @@ pub fn presign(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.J
             }
             const options = args.nextEat();
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_consumed = true;
             defer blob.deinit();
             return try getPresignUrlFrom(&blob, globalThis, options);
         },
@@ -98,8 +100,9 @@ pub fn unlink(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JS
 
     // accept a path or a blob
     var path_or_blob = try PathOrBlob.fromJSNoCopy(globalThis, &args);
+    var path_consumed = false;
     errdefer {
-        if (path_or_blob == .path) {
+        if (!path_consumed and path_or_blob == .path) {
             path_or_blob.path.deinit();
         }
     }
@@ -114,6 +117,7 @@ pub fn unlink(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JS
             }
             const options = args.nextEat();
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_consumed = true;
             defer blob.deinit();
             return try blob.store.?.data.s3.unlink(blob.store.?, globalThis, options);
         },
@@ -130,8 +134,9 @@ pub fn write(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSE
 
     // accept a path or a blob
     var path_or_blob = try PathOrBlob.fromJSNoCopy(globalThis, &args);
+    var path_consumed = false;
     errdefer {
-        if (path_or_blob == .path) {
+        if (!path_consumed and path_or_blob == .path) {
             path_or_blob.path.deinit();
         }
     }
@@ -151,6 +156,7 @@ pub fn write(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSE
                 return globalThis.throwInvalidArguments("Expected a S3 or path to upload", .{});
             }
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_consumed = true;
             defer blob.deinit();
 
             var blob_internal: PathOrBlob = .{ .blob = blob };
@@ -173,8 +179,9 @@ pub fn size(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSEr
 
     // accept a path or a blob
     var path_or_blob = try PathOrBlob.fromJSNoCopy(globalThis, &args);
+    var path_consumed = false;
     errdefer {
-        if (path_or_blob == .path) {
+        if (!path_consumed and path_or_blob == .path) {
             path_or_blob.path.deinit();
         }
     }
@@ -190,6 +197,7 @@ pub fn size(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSEr
                 return globalThis.throwInvalidArguments("Expected a S3 or path to get size", .{});
             }
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_consumed = true;
             defer blob.deinit();
 
             return S3BlobStatTask.size(globalThis, &blob);
@@ -206,8 +214,9 @@ pub fn exists(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JS
 
     // accept a path or a blob
     var path_or_blob = try PathOrBlob.fromJSNoCopy(globalThis, &args);
+    var path_consumed = false;
     errdefer {
-        if (path_or_blob == .path) {
+        if (!path_consumed and path_or_blob == .path) {
             path_or_blob.path.deinit();
         }
     }
@@ -223,6 +232,7 @@ pub fn exists(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JS
                 return globalThis.throwInvalidArguments("Expected a S3 or path to check if it exists", .{});
             }
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_consumed = true;
             defer blob.deinit();
 
             return S3BlobStatTask.exists(globalThis, &blob);
@@ -557,8 +567,9 @@ pub fn stat(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSEr
 
     // accept a path or a blob
     var path_or_blob = try PathOrBlob.fromJSNoCopy(globalThis, &args);
+    var path_consumed = false;
     errdefer {
-        if (path_or_blob == .path) {
+        if (!path_consumed and path_or_blob == .path) {
             path_or_blob.path.deinit();
         }
     }
@@ -574,6 +585,7 @@ pub fn stat(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSEr
                 return globalThis.throwInvalidArguments("Expected a S3 or path to get size", .{});
             }
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_consumed = true;
             defer blob.deinit();
 
             return S3BlobStatTask.stat(globalThis, &blob);

--- a/test/js/bun/s3/s3-error-path-cleanup.test.ts
+++ b/test/js/bun/s3/s3-error-path-cleanup.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+
+// When an S3 operation fails after the blob store is created (e.g. missing
+// credentials in signRequest), the path string's ownership has already been
+// transferred to the store via toThreadSafe(). The caller's errdefer must not
+// deinit it again or the underlying StringImpl gets double-freed.
+describe("S3 methods do not double-free path on error", () => {
+  const paths = ["abc", "foo/bar", "xyz" + Math.random().toString(36).slice(2)];
+
+  describe.each(paths)("path=%s", p => {
+    test("S3Client instance presign", () => {
+      expect(() => Bun.s3.presign(p)).toThrow();
+      expect(() => Bun.s3.presign(p, new SharedArrayBuffer(16))).toThrow();
+      expect(() => new Bun.S3Client({}).presign(p)).toThrow();
+    });
+
+    test("S3Client static presign", () => {
+      expect(() => Bun.S3Client.presign(p)).toThrow();
+    });
+
+    test("S3Client unlink", () => {
+      const a = Bun.s3.unlink(p);
+      const b = Bun.S3Client.unlink(p);
+      expect(a).rejects.toThrow();
+      expect(b).rejects.toThrow();
+    });
+
+    test("S3Client write", () => {
+      const a = Bun.s3.write(p, "x");
+      const b = Bun.S3Client.write(p, "x");
+      expect(a).rejects.toThrow();
+      expect(b).rejects.toThrow();
+    });
+  });
+
+  test("valid presign still works", () => {
+    const client = new Bun.S3Client({
+      accessKeyId: "a",
+      secretAccessKey: "b",
+      bucket: "c",
+      endpoint: "http://localhost",
+    });
+    expect(client.presign("abc")).toStartWith("http://localhost/c/abc?");
+  });
+
+  test("early failure before store creation still cleans up path", () => {
+    expect(() => Bun.s3.presign("abc", { accessKeyId: 123 })).toThrow();
+    expect(() => new Bun.S3Client({}).presign("abc", { accessKeyId: 123 })).toThrow();
+  });
+
+  test("repeated calls under GC", () => {
+    for (let i = 0; i < 50; i++) {
+      try {
+        Bun.s3.presign("k" + i);
+      } catch {}
+      try {
+        Bun.S3Client.presign("k" + i);
+      } catch {}
+    }
+    Bun.gc(true);
+  });
+});


### PR DESCRIPTION
## What

`Bun.s3.presign("abc")` (and the static `Bun.S3Client.presign`) crashed with `reached unreachable code` in debug builds when credentials are missing:

```
panic(main thread): reached unreachable code
  string.wtf.WTFStringImplStruct.deref (wtf.zig:92) — bun.assert(self.hasAtLeastOneRef())
  string.string.SliceWithUnderlyingString.deinit
  runtime.node.types.PathLike.deinit
  runtime.webcore.S3Client.S3Client.presign (S3Client.zig:154) — errdefer path.deinit()
```

## Why

`Blob.Store.initS3*` receives the `PathLike` **by value** and calls `path.toThreadSafe()` on its local copy. For a `.slice_with_underlying_string` path this replaces the underlying `WTFStringImpl*` with an isolated copy and releases the refs the caller was holding on the original impl — ownership is transferred to the store.

If a later step fails (e.g. `signRequest` → `MissingCredentials` in `getPresignUrlFrom`), the caller's `errdefer path.deinit()` fires and derefs the original impl again — a double-free. Static strings (`"path"`, `"name"`, `"type"`, …) masked this because their refcount never drops, so only "normal" path strings tripped the assertion.

## How

Add a `path_consumed` flag set immediately after the blob store is created. The `errdefer` now only deinits the path when the failure happened before ownership was transferred.

Applied to all affected methods on `S3Client` (instance + static) and the `S3File` static entrypoints (`presign`, `unlink`, `write`, `exists`, `size`, `stat`).

## Test

`test/js/bun/s3/s3-error-path-cleanup.test.ts` — panics on the unpatched build, passes after. Also covers the early-failure path (invalid option type before store creation) to ensure the path is still freed there, and a GC stress loop.

Found by Fuzzilli (fingerprint `1ebbda306723eeb6`).