### PR TITLE
feat(install): add --no-save-package-json flag to update lockfile without package.json changes

### DIFF
--- a/src/install/PackageManager/CommandLineArguments.zig
+++ b/src/install/PackageManager/CommandLineArguments.zig
@@ -47,6 +47,7 @@ const shared_params = [_]ParamType{
     clap.parseParam("--concurrent-scripts <NUM>            Maximum number of concurrent jobs for lifecycle scripts (default: 2x CPU cores)") catch unreachable,
     clap.parseParam("--network-concurrency <NUM>           Maximum number of concurrent network requests (default 48)") catch unreachable,
     clap.parseParam("--save-text-lockfile                  Save a text-based lockfile") catch unreachable,
+    clap.parseParam("--no-save-package-json                Do not update package.json when installing") catch unreachable,
     clap.parseParam("--omit <dev|optional|peer>...         Exclude 'dev', 'optional', or 'peer' dependencies from install") catch unreachable,
     clap.parseParam("--lockfile-only                       Generate a lockfile without installing dependencies") catch unreachable,
     clap.parseParam("--linker <STR>                        Linker strategy (one of \"isolated\" or \"hoisted\")") catch unreachable,
@@ -230,6 +231,7 @@ ca_file_name: string = "",
 save_text_lockfile: ?bool = null,
 
 lockfile_only: bool = false,
+no_save_package_json: bool = false,
 
 node_linker: ?Options.NodeLinker = null,
 
@@ -809,6 +811,7 @@ pub fn parse(allocator: std.mem.Allocator, comptime subcommand: Subcommand) !Com
     cli.no_summary = args.flag("--no-summary");
     cli.ca = args.options("--ca");
     cli.lockfile_only = args.flag("--lockfile-only");
+    cli.no_save_package_json = args.flag("--no-save-package-json");
 
     if (args.option("--linker")) |linker| {
         cli.node_linker = Options.NodeLinker.fromStr(linker) orelse {

--- a/src/install/PackageManager/PackageManagerOptions.zig
+++ b/src/install/PackageManager/PackageManagerOptions.zig
@@ -56,6 +56,7 @@ ca_file_name: string = &.{},
 save_text_lockfile: ?bool = null,
 
 lockfile_only: bool = false,
+no_save_package_json: bool = false,
 
 // `bun pm version` command options
 git_tag_version: bool = true,
@@ -499,9 +500,11 @@ pub fn load(
             this.scope.token = cli.token;
         }
 
-        if (cli.no_save) {
-            this.do.save_lockfile = false;
+        if (cli.no_save or cli.no_save_package_json) {
             this.do.write_package_json = false;
+            if (cli.no_save) {
+                this.do.save_lockfile = false;
+            }
         }
 
         if (cli.dry_run) {
@@ -561,6 +564,7 @@ pub fn load(
         }
 
         this.lockfile_only = cli.lockfile_only;
+        this.no_save_package_json = cli.no_save_package_json;
 
         if (cli.lockfile_only) {
             this.do.prefetch_resolved_tarballs = false;


### PR DESCRIPTION
Fixes #30407

This PR adds a new flag --no-save-package-json to un install and un update. This flag allows users to update their lockfile (and install dependencies) while ensuring that package.json remains untouched.

This is a common workflow in other package managers (like pnpm update --no-save) and was requested to avoid confusing behavior where --no-save currently disables both lockfile saving and package.json updates.