### PR TITLE
test: add regression guard for hot-reload + Bun.build (#30436)

### DIFF
--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -766,3 +766,89 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
   },
   longTimeout,
 );
+
+// https://github.com/oven-sh/bun/issues/30436
+// Before the fix landed in #30412, `Bun.build({entrypoints:['missing.ts']})`
+// called from a `--hot` entry permanently disabled reload. `bustDirCacheFromSpecifier`
+// dropped the directory entries map; the rebuilt Entry had empty abs_path;
+// the dir-watch hash match silently missed on every subsequent atomic-rename
+// save (sed -i, vim, VS Code with atomic save, etc.). This guards against
+// the regression — the test reaches ≥ 3 reloads only if the dir-watch path
+// correctly re-triggers reload for the main entrypoint after the bust.
+it(
+  "Bun.build() with a failing entrypoint does not disable --hot reload",
+  async () => {
+    const root = hotRunnerRoot;
+    const rootTmp = root + ".tmp";
+    // Bun.build is awaited BEFORE the "Reloaded:" log so the parent
+    // directory-cache bust happens before the test triggers its first
+    // rename — without this ordering the rename can race Bun.build's
+    // completion and land on the still-populated cache, masking the bug.
+    const src = `
+globalThis.n = (globalThis.n ?? 0) + 1;
+if (!globalThis.done) {
+  globalThis.done = true;
+  try { await Bun.build({ entrypoints: ["nonexistent-entrypoint.ts"] }); } catch {}
+}
+console.log(\`[#!root] Reloaded: \${globalThis.n}\`);
+`;
+    writeFileSync(root, src);
+
+    try {
+      var runner = spawn({
+        cmd: [bunExe(), "--hot", "run", root],
+        env: bunEnv,
+        cwd,
+        stdout: "pipe",
+        stderr: "inherit",
+        stdin: "ignore",
+      });
+
+      var reloadCounter = 0;
+
+      // rm-then-rename into place matches what vim/sed/atomic-save editors
+      // do; `renameSync(tmp, root)` over an in-use script fails with EPERM
+      // on Windows, so rm first.
+      async function onReload() {
+        writeFileSync(rootTmp, src);
+        rmSync(root);
+        renameSync(rootTmp, root);
+      }
+
+      var str = "";
+      for await (const chunk of runner.stdout) {
+        str += new TextDecoder().decode(chunk);
+        var any = false;
+        if (!/\[#!root\].*[0-9]\n/g.test(str)) continue;
+
+        for (let line of str.split("\n")) {
+          if (!line.includes("[#!root]")) continue;
+          reloadCounter++;
+          str = "";
+
+          if (reloadCounter === 3) {
+            runner.unref();
+            runner.kill();
+            break;
+          }
+
+          expect(line).toContain(`[#!root] Reloaded: ${reloadCounter}`);
+          any = true;
+        }
+
+        if (any) await onReload();
+      }
+
+      expect(reloadCounter).toBeGreaterThanOrEqual(3);
+    } finally {
+      // @ts-ignore
+      runner?.unref?.();
+      // @ts-ignore
+      runner?.kill?.(9);
+    }
+  },
+  // Finite timeout — a regression silently stalls the reload pipeline, so
+  // the stdout for-await never completes. Let the test runner abort on its
+  // own instead of running up against the file-level (Infinity) wall.
+  isDebug ? 30_000 : 10_000,
+);


### PR DESCRIPTION
Closes #30436.

## Background

The original repro from #30436:

```ts
// app.ts
globalThis.n = (globalThis.n ?? 0) + 1;
console.log(\`n=${globalThis.n}\`);
if (!globalThis.done) {
  globalThis.done = true;
  try { await Bun.build({ entrypoints: ['nonexistent.ts'] }); } catch {}
}
```

```sh
bun --hot app.ts &
sleep 1 && sed -i 's/hi/bye/' app.ts   # no reload fires
```

Root cause (original): `Bun.build`'s `ModuleNotFound` path calls `bustDirCacheFromSpecifier`, which drops the entire `FileSystem.instance.fs.entries` for the parent directory. The rebuilt `Entry` has an empty lazy `abs_path`, so the `--hot` dir-watch hash match in `hot_reloader.zig`'s `onFileUpdate` always misses on subsequent atomic-rename saves (`sed -i`, vim, VS Code with atomic save). `current_task.count` stays 0, `Task.enqueue` early-returns, reload is silently dead.

## What this PR does now

The underlying bug was fixed by #30412 (Rust rewrite) as a side-effect of a related watcher-event handler repair — the atomic-rename recovery block at `onFileUpdate` that re-triggers reload for the main entrypoint when its basename appears in a directory event's `affected` list.

So the source fix this PR originally carried is no longer needed. This PR now narrows to the regression test alone.

## Test

`test/cli/hot/hot.test.ts` — new `Bun.build() with a failing entrypoint does not disable --hot reload`:

- Writes a `--hot` entry that awaits `Bun.build({ entrypoints: ['nonexistent-entrypoint.ts'] })` BEFORE logging its `Reloaded: N` marker, so the cache bust completes before the test triggers its first rename.
- Drives three `rmSync(root); renameSync(tmp, root)` saves (rm-then-rename mirrors the existing `should hot reload when a file is renamed() into place` test and works cross-platform — renameSync-over-target fails with EPERM on Windows when bun still holds the entry file's handle).
- Asserts `reloadCounter >= 3`.

Without the watcher-event handler fix (verified locally by temporarily reverting the atomic-rename recovery block in `hot_reloader.zig` lines 524-555), the test hangs waiting for reload and the finite timeout (30s debug / 10s release) fails it. With the fix, passes in ~20ms release / ~1s debug.

Previous iterations of this PR also carried test-deflake commits for `should not hot reload when a random file is written` and the sourcemap race — both of which were independently deflaked in #30412, so this rebased version drops them.