### PR TITLE
process: handle exception in nextTick lazy property callback

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3913,6 +3913,8 @@ static JSValue constructMainModuleProperty(VM& vm, JSObject* processObject)
 
 JSValue Process::constructNextTickFn(JSC::VM& vm, Zig::GlobalObject* globalObject)
 {
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+
     JSNextTickQueue* nextTickQueueObject;
     if (!globalObject->m_nextTickQueue) {
         nextTickQueueObject = JSNextTickQueue::create(globalObject);
@@ -3930,6 +3932,11 @@ JSValue Process::constructNextTickFn(JSC::VM& vm, Zig::GlobalObject* globalObjec
     args.append(JSC::JSFunction::create(vm, globalObject, 1, String(), jsFunctionReportUncaughtException, ImplementationVisibility::Private));
 
     JSValue nextTickFunction = JSC::profiledCall(globalObject, ProfilingReason::API, initializer, JSC::getCallData(initializer), globalObject->globalThis(), args);
+    if (auto* exception = scope.exception()) {
+        (void)scope.tryClearException();
+        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        return jsUndefined();
+    }
     if (nextTickFunction && nextTickFunction.isObject()) {
         this->m_nextTickFunction.set(vm, this, nextTickFunction.getObject());
     }

--- a/test/js/node/process/process-nexttick-stack-overflow.test.ts
+++ b/test/js/node/process/process-nexttick-stack-overflow.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // When the stack is nearly exhausted, lazily initializing process.nextTick

--- a/test/js/node/process/process-nexttick-stack-overflow.test.ts
+++ b/test/js/node/process/process-nexttick-stack-overflow.test.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// When the stack is nearly exhausted, lazily initializing process.nextTick
+// runs JS that can throw a stack overflow. The lazy property callback must
+// not leave an exception pending (assertion in JSObject::get) or reify the
+// property as an internal Exception object.
+test("process.nextTick lazy init does not leak Exception object on stack overflow", async () => {
+  const src = `
+    const { writeFileSync } = require("fs");
+    let done = false;
+    function recurse() {
+      try { recurse(); } catch {}
+      if (done) return;
+      done = true;
+      try { process.nextTick(() => {}); } catch {}
+    }
+    recurse();
+    writeFileSync(1, "typeof=" + typeof process.nextTick + "\\n");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).not.toBe("typeof=object");
+  expect(["typeof=function", "typeof=undefined"]).toContain(stdout.trim());
+  expect(proc.signalCode).toBeNull();
+});


### PR DESCRIPTION
Fuzzilli found a crash at `JSObjectInlines.h:102`:

```
ASSERTION FAILED: !scope.exception() || vm.hasPendingTerminationException() || !hasProperty
JSValue JSC::JSObject::get(JSGlobalObject *, PropertyName) const
```

Repro:
```js
function recurse() {
  try { recurse(); } catch {}
  new Worker("x");
}
recurse();
```

### What happens

`process.nextTick` is a `PropertyCallback` in the static hash table. Its callback, `constructNextTickFn`, runs JS via `profiledCall` to set up the tick queue. When the stack is nearly exhausted this throws `RangeError: Maximum call stack size exceeded`, and `executeCall` returns the `Exception*` as a `JSValue`.

The callback then returned that value with the exception still pending. `reifyStaticProperty` stored it with `putDirect`, `getPropertySlot` reported `hasProperty=true`, and `JSObject::get` asserted because an exception was set for a found property. In release builds the assertion is compiled out, but `process.nextTick` ends up reified as an internal `Exception` cell (`typeof process.nextTick === "object"`), which later trips a different assertion in `JSCell::toStringSlowCase` when JS tries to call it.

`new Worker(...)` reaches this path via `process->emitOnNextTick` → `queueNextTick` → `process->get("nextTick")`.

### Fix

Match the existing pattern in `constructStdin`/`constructStdout`/`constructStderr`: catch the exception from `profiledCall`, report it via `reportUncaughtExceptionAtEventLoop`, and return `jsUndefined()` so the property reifies to a sane value and no exception leaks out of the `LazyPropertyCallback`.