### PR TITLE
Bun.Transpiler: fix use-after-free in async transform() error messages

### DIFF
--- a/src/runtime/api/JSTranspiler.zig
+++ b/src/runtime/api/JSTranspiler.zig
@@ -504,6 +504,10 @@ pub const TransformTask = struct {
         this.transpiler.setLog(&this.log);
         this.log.msgs.allocator = bun.default_allocator;
 
+        defer for (this.log.msgs.items) |*msg| {
+            msg.* = bun.handleOom(msg.clone(bun.default_allocator));
+        };
+
         const jsx = if (this.tsconfig != null)
             this.tsconfig.?.mergeJSX(this.transpiler.options.jsx)
         else

--- a/test/js/bun/transpiler/transpiler-async-error-uaf.test.ts
+++ b/test/js/bun/transpiler/transpiler-async-error-uaf.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test";
+
+test("async transform() parse errors do not read freed arena memory", async () => {
+  const transpiler = new Bun.Transpiler();
+  const promises: Promise<unknown>[] = [];
+  for (let i = 0; i < 200; i++) {
+    promises.push(transpiler.transform("\x00\x01\x02").catch(e => e));
+    Bun.gc(true);
+  }
+  const results = await Promise.all(promises);
+  for (const result of results) {
+    expect((result as { message: string }).message).toBe("Unexpected \x00");
+  }
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a use-after-free in `Bun.Transpiler.prototype.transform()` (the async variant) when the input fails to parse.

`TransformTask.run()` executes on a worker thread and uses a thread-local `MimallocArena` for parsing. The lexer allocates error message text (e.g. `"Unexpected \x00"`) from this arena via `std.fmt.allocPrint(self.allocator, ...)`. The arena is destroyed when `run()` returns, but the log messages that reference that text are read later on the main thread in `then()` → `log.toJS()` → `Msg.clone()`, which `memcpy`s from the freed arena.

Under ASAN this shows up as `use-after-poison`; in release builds it reads stale/garbage bytes and can manifest as other signals depending on what reuses the arena pages.

Fix: before `run()` returns (and before `arena.deinit()` runs), deep-clone each log message into `bun.default_allocator` so the text, location, and notes all outlive the arena. `Msg.clone()` already deep-clones `data.text`, `location.file`, `location.line_text`, and each note's `Data` via `bun.clone`.

## How did you verify your code works?

Minimal repro that crashes the ASAN build before this change and passes after:

```js
const t = new Bun.Transpiler();
for (let i = 0; i < 200; i++) {
  t.transform("\x00\x01\x02").catch(() => {});
  Bun.gc(true);
}
```

Added as `test/js/bun/transpiler/transpiler-async-error-uaf.test.ts`, which also asserts the error message content is preserved correctly. All existing `test/js/bun/transpiler/` tests pass.

Found by Fuzzilli (fingerprint `11673762e644e33d`).