### PR TITLE
child_process: transfer extra stdio fd ownership to adopted net.Socket

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1229,7 +1229,9 @@ class ChildProcess extends EventEmitter {
               // adopts the fd into a uSockets poll and closes it on socket
               // close. A synchronous throw here (bad fd, OOM, etc.) means
               // nothing owns the fd, so close it before re-throwing.
-              try { require("node:fs").closeSync(fd); } catch {}
+              try {
+                require("node:fs").closeSync(fd);
+              } catch {}
               throw err;
             }
         }

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1214,9 +1214,24 @@ class ChildProcess extends EventEmitter {
         switch (io) {
           case "pipe":
             if (!NetModule) NetModule = require("node:net");
-            const fd = handle && handle.stdio[i];
-            if (!fd) return null;
-            return NetModule.connect({ fd });
+            // Transfer ownership of the fd from the Subprocess to the adopted
+            // net.Socket. Reading `handle.stdio[i]` would only hand back a
+            // borrowed fd number — the Subprocess's finalizer would still
+            // close it, racing the socket's own close and corrupting the next
+            // spawn's fd table (#30443).
+            if (!handle) return null;
+            const fd = handle.takeStdioFd(i - 3);
+            if (typeof fd !== "number" || fd < 0) return null;
+            try {
+              return NetModule.connect({ fd });
+            } catch (err) {
+              // Ownership has been transferred to us — net.connect normally
+              // adopts the fd into a uSockets poll and closes it on socket
+              // close. A synchronous throw here (bad fd, OOM, etc.) means
+              // nothing owns the fd, so close it before re-throwing.
+              try { require("node:fs").closeSync(fd); } catch {}
+              throw err;
+            }
         }
         return null;
     }

--- a/src/runtime/api/BunObject.classes.ts
+++ b/src/runtime/api/BunObject.classes.ts
@@ -121,6 +121,10 @@ export default [
       stdio: {
         getter: "getStdio",
       },
+      takeStdioFd: {
+        fn: "takeStdioFd",
+        length: 1,
+      },
       terminal: {
         getter: "getTerminal",
         cache: true,

--- a/src/runtime/api/bun/subprocess.zig
+++ b/src/runtime/api/bun/subprocess.zig
@@ -507,6 +507,40 @@ pub fn getStdio(this: *Subprocess, global: *JSGlobalObject) bun.JSError!JSValue 
     return array;
 }
 
+/// Transfers ownership of the extra pipe fd at `stdio_pipes[slot_index]` to
+/// the caller. Returns the fd number and marks the slot `.unavailable` so
+/// `finalizeStreams` won't double-close it. Used by `node:child_process` when
+/// it adopts the fd into a `net.Socket` via `net.connect({ fd })` — uSockets
+/// then owns the fd lifecycle. Returns `null` if the slot is out of range,
+/// already taken, or (on Windows) isn't an fd-style pipe.
+pub fn takeStdioFd(this: *Subprocess, globalThis: *JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    const slot_js = callframe.argumentsAsArray(1)[0];
+    const slot = try globalThis.validateIntegerRange(slot_js, i32, 0, .{ .min = 0, .field_name = "slot" });
+    const idx: usize = @intCast(slot);
+    if (idx >= this.stdio_pipes.items.len) return .null;
+
+    if (Environment.isWindows) {
+        // On Windows the extra pipes are uv pipes (not raw fds) — there is
+        // nothing to transfer out as a plain fd number. node:child_process
+        // only takes this path on POSIX.
+        return .null;
+    }
+
+    switch (this.stdio_pipes.items[idx]) {
+        .owned_fd => |fd| {
+            // Caller now owns the fd.
+            this.stdio_pipes.items[idx] = .unavailable;
+            return JSValue.jsNumber(fd.cast());
+        },
+        .unowned_fd => |fd| {
+            // Caller supplied this fd in the original stdio array and still
+            // owns it; just hand back the number.
+            return JSValue.jsNumber(fd.cast());
+        },
+        .unavailable => return .null,
+    }
+}
+
 pub const Source = union(enum) {
     blob: jsc.WebCore.Blob.Any,
     array_buffer: jsc.ArrayBuffer.Strong,

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -470,3 +470,45 @@ it("spawnSync(does-not-exist)", () => {
   expect(x.stdout).toEqual(null);
   expect(x.stderr).toEqual(null);
 });
+
+// #30443 — child_process.spawn() with a 4+ entry stdio array used to fail
+// with "connect ENOENT" after ~13 iterations because the extra pipe fd was
+// double-closed (Subprocess.finalizeStreams closed it, then the adopted
+// net.Socket closed it again). The fd was then reused by a new spawn's
+// extra pipe, and the net.Socket for the new one still had a stale poll
+// reference, so epoll_ctl(ADD) failed.
+it.skipIf(isWindows)("repeated spawn with 4+ stdio entries does not leak fds (#30443)", async () => {
+  // Pre-fix:
+  //   - debug+ASAN: fd double-close debugAssert panics at iteration ~14
+  //   - release:    epoll_ctl EBADF once fds start colliding around 44-50
+  // 60 iterations is enough to catch both modes; runs in ~2s under debug.
+  const N = 60;
+  let succeeded = 0;
+  let lastErr: string | null = null;
+  for (let i = 1; i <= N; i++) {
+    try {
+      // `true` is the smallest possible child — exits immediately.
+      const child = spawn("true", [], {
+        stdio: ["ignore", "pipe", "pipe", "pipe"],
+      });
+      // Eagerly touch the extra pipe — this is what forces #getBunSpawnIo
+      // to materialize the fd as a net.Socket, which is where the crash
+      // was triggered under Bun. Playwright (the real-world repro) hits
+      // this path via an immediate `child.pid` access.
+      const extra = child.stdio[3] as NodeJS.ReadableStream | null;
+      if (extra && "on" in extra) {
+        extra.on("data", () => {});
+        extra.on("error", () => {});
+      }
+      await new Promise<void>((resolve, reject) => {
+        child.on("error", reject);
+        child.on("exit", () => resolve());
+      });
+      succeeded++;
+    } catch (e: any) {
+      lastErr = e?.message ?? String(e);
+      break;
+    }
+  }
+  expect({ succeeded, lastErr }).toEqual({ succeeded: N, lastErr: null });
+});


### PR DESCRIPTION
## Repro

```js
import { spawn } from 'node:child_process';
for (let i = 1; i <= 50; i++) {
  const child = spawn('sleep', ['0.01'], {
    stdio: ['ignore', 'pipe', 'pipe', 'pipe'], // 4-entry stdio triggers it
  });
  if (child.stdio[3]) child.stdio[3].on('error', () => {});
  await new Promise(r => child.on('exit', r));
}
```

Pre-fix (Bun 1.3.14, Linux x64): fails at iteration 14 with `Failed to connect / errno -2 / ENOENT`. Real-world impact: Playwright's Chromium launcher passes `stdio: ['ignore', 'pipe', 'pipe', 'pipe', 'pipe']` and immediately reads `child.pid`, so after ~7-12 `launchPersistentContext` cycles the next launch crashes in `node:child_process:622 (#createStdioObject)`. The rejection is an unhandled promise rejection — per-call `try/catch` doesn't see it.

## Cause

On the extra-pipe path, `#getBunSpawnIo` for slot `i >= 3` called `NetModule.connect({ fd })` using the fd number returned by `handle.stdio[i]`. Both sides then closed the fd independently:

- `Subprocess.finalizeStreams` closed every `owned_fd` in `stdio_pipes` (`subprocess.zig:781`).
- The adopted `net.Socket` also closed it via `us_socket_close → bsd_close_socket` whenever the readable half hit EOF.

Whichever ran second got EBADF. Meanwhile the kernel recycled the fd number into the next `socketpair()` call, and when `us_socket_from_fd` on that new fd hit `epoll_ctl(ADD)`, things lined up for either an outright EBADF (release) or a debug fd-UAF panic during sweep. Threshold sits at iter 14-16 under debug+ASAN and 44-50 under release because that's roughly how many iterations it takes for fd numbers to collide.

## Fix

Add `Subprocess.takeStdioFd(slotIndex)` that returns the fd for an extra pipe **and** flips its `stdio_pipes` entry from `owned_fd` → `.unavailable`. This is the same pattern `js_bun_spawn_bindings.zig:840` already uses for the IPC slot once uSockets adopts it (`uws owns the fd now (owns_fd=1); neutralize the slot so finalizeStreams doesn't double-close`).

`#getBunSpawnIo` now calls `takeStdioFd(i - 3)` instead of reading `handle.stdio[i]`. The moment the fd is wrapped into a `net.Socket`, `finalizeStreams` stops tracking it and uSockets owns the close lifecycle.

Direct `Bun.spawn` callers still get `proc.stdio[i]` as a borrowed fd number — unchanged — and the Subprocess finalizer still closes those.

## Verification

```
# Before: fails at 16
USE_SYSTEM_BUN=1 bun /tmp/repro.mjs
# runtime=bun-1.3.14 ok=15 firstFail=16 lastErr=Failed to connect

# After
bun bd /tmp/repro.mjs
# runtime=bun-1.3.14 ok=50 firstFail=none lastErr=
```

Gate check with the new regression test (`test/js/node/child_process/child_process.test.ts`):

```
git stash push -- src/ && bun bd test test/js/node/child_process/child_process.test.ts -t 30443
# → debug+ASAN panics on fd-UAF at iteration ~14 (fail)

git stash pop && bun bd test test/js/node/child_process/child_process.test.ts -t 30443
# → 60 iterations pass in ~2s
```

Existing `test/js/bun/spawn/spawn.test.ts > close handling` (72 tests including "does not close caller-owned fds passed as extra stdio") still pass.

Fixes #30443