### PR TITLE
ModuleLoader: drop stale watchlist fd after atomic rename of entry

### DIFF
--- a/src/jsc/ModuleLoader.zig
+++ b/src/jsc/ModuleLoader.zig
@@ -100,10 +100,16 @@ pub fn cachedFdIsStale(path: *const Fs.Path, cached_fd: FD) bool {
     defer bun.path_buffer_pool.put(path_buf);
     const path_z = bun.path.z(path.text, path_buf);
 
+    // If stat(path) fails (file removed, permissions changed, network FS
+    // transient) the fd is equally untrustworthy: still open on the old
+    // inode, but we can no longer confirm it matches what a fresh open
+    // would see. Drop it and let the caller's path-based open surface the
+    // real error instead of silently returning pre-removal bytes.
     const on_disk = switch (bun.sys.stat(path_z)) {
         .result => |st| st,
-        .err => return false,
+        .err => return true,
     };
+    // fstat on an already-closed fd fails — treat that as stale too.
     const via_fd = switch (bun.sys.fstat(cached_fd)) {
         .result => |st| st,
         .err => return true,

--- a/src/jsc/ModuleLoader.zig
+++ b/src/jsc/ModuleLoader.zig
@@ -82,6 +82,35 @@ pub export fn Bun__getDefaultLoader(global: *JSGlobalObject, str: *const bun.Str
     return loader;
 }
 
+/// Returns true when the watchlist-cached fd for this path no longer points at
+/// the inode that currently lives at the path on disk. An atomic rename (sed
+/// -i, vim default save, prettier, VSCode default, etc.) replaces the inode at
+/// the path, but the old fd still references the now-unlinked original inode.
+/// Reading through the stale fd yields pre-edit bytes even though the new file
+/// is present on disk. See oven-sh/bun#30449.
+///
+/// Windows doesn't expose POSIX inodes the same way, and atomic-rename hot
+/// reload is already handled by the Windows watcher, so skip there.
+pub fn cachedFdIsStale(path: *const Fs.Path, cached_fd: FD) bool {
+    if (comptime Environment.isWindows) return false;
+    if (!path.isFile()) return false;
+    if (path.text.len == 0 or path.text.len >= bun.MAX_PATH_BYTES) return false;
+
+    const path_buf = bun.path_buffer_pool.get();
+    defer bun.path_buffer_pool.put(path_buf);
+    const path_z = bun.path.z(path.text, path_buf);
+
+    const on_disk = switch (bun.sys.stat(path_z)) {
+        .result => |st| st,
+        .err => return false,
+    };
+    const via_fd = switch (bun.sys.fstat(cached_fd)) {
+        .result => |st| st,
+        .err => return true,
+    };
+    return on_disk.ino != via_fd.ino or on_disk.dev != via_fd.dev;
+}
+
 pub fn transpileSourceCode(
     jsc_vm: *VirtualMachine,
     specifier: string,
@@ -173,6 +202,9 @@ pub fn transpileSourceCode(
             if (jsc_vm.bun_watcher.indexOf(hash)) |index| {
                 fd = jsc_vm.bun_watcher.watchlist().items(.fd)[index].unwrapValid();
                 package_json = jsc_vm.bun_watcher.watchlist().items(.package_json)[index];
+                if (fd) |cached_fd| {
+                    if (cachedFdIsStale(&path, cached_fd)) fd = null;
+                }
             }
 
             var cache = jsc.RuntimeTranspilerCache{

--- a/src/jsc/RuntimeTranspilerStore.zig
+++ b/src/jsc/RuntimeTranspilerStore.zig
@@ -349,6 +349,9 @@ pub const RuntimeTranspilerStore = struct {
                         // of calling `seekTo` on a bogus handle.
                         fd = if (watcher_fd.isValid() and watcher_fd.stdioTag() == null) watcher_fd else null;
                         package_json = vm.bun_watcher.watchlist().items(.package_json)[index];
+                        if (fd) |cached_fd| {
+                            if (ModuleLoader.cachedFdIsStale(&path, cached_fd)) fd = null;
+                        }
                     }
                 },
                 else => {},
@@ -624,6 +627,7 @@ pub const RuntimeTranspilerStore = struct {
 };
 
 const Fs = @import("../resolver/fs.zig");
+const ModuleLoader = @import("./ModuleLoader.zig");
 const analyze_transpiled_module = @import("../bundler/analyze_transpiled_module.zig");
 const node_fallbacks = @import("../resolver/node_fallbacks.zig");
 const std = @import("std");

--- a/src/watcher/Watcher.zig
+++ b/src/watcher/Watcher.zig
@@ -737,16 +737,6 @@ pub fn addFile(
             // On Linux, the file descriptor might be out of date.
             if (fd.isValid()) {
                 var fds = this.watchlist.items(.fd);
-                // The caller may have dropped its cached fd because the path
-                // changed inode (see `ModuleLoader.cachedFdIsStale`, #30449).
-                // The old fd still points at an unlinked inode nobody needs;
-                // closing it here avoids walking toward EMFILE every time an
-                // atomic-rename save forces a fresh open. Skip the close when
-                // the caller handed us the same fd (identity).
-                const old = fds[index];
-                if (old.isValid() and old.native() != fd.native()) {
-                    old.close();
-                }
                 fds[index] = fd;
             }
         }

--- a/src/watcher/Watcher.zig
+++ b/src/watcher/Watcher.zig
@@ -737,6 +737,16 @@ pub fn addFile(
             // On Linux, the file descriptor might be out of date.
             if (fd.isValid()) {
                 var fds = this.watchlist.items(.fd);
+                // The caller may have dropped its cached fd because the path
+                // changed inode (see `ModuleLoader.cachedFdIsStale`, #30449).
+                // The old fd still points at an unlinked inode nobody needs;
+                // closing it here avoids walking toward EMFILE every time an
+                // atomic-rename save forces a fresh open. Skip the close when
+                // the caller handed us the same fd (identity).
+                const old = fds[index];
+                if (old.isValid() and old.native() != fd.native()) {
+                    old.close();
+                }
                 fds[index] = fd;
             }
         }

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { beforeEach, expect, it } from "bun:test";
 import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isDebug, tmpdirSync, waitForFileToExist } from "harness";
+import { bunEnv, bunExe, isDebug, isLinux, tmpdirSync, waitForFileToExist } from "harness";
 import { join } from "path";
 
 const timeout = isDebug ? Infinity : 10_000;
@@ -487,6 +487,116 @@ it(
       runner?.unref?.();
       // @ts-ignore
       runner?.kill?.(9);
+    }
+  },
+  timeout,
+);
+
+// https://github.com/oven-sh/bun/issues/30449
+//
+// Under `--hot`, userland that calls
+//   delete require.cache[entry]; await import(entry);
+// after an atomic rename (sed -i / vim default save / prettier) used to
+// re-run top-level with stale bytes: the watchlist cached a file descriptor
+// pointing at the now-unlinked old inode, so the re-transpile read pre-edit
+// source. Assert the re-import returns the post-edit VALUE.
+//
+// The entry lives in a separate directory from the process cwd, so bun's
+// watcher only holds a file watch — without a parent-dir watch it cannot
+// observe the rename through the dir, which is what made the stale fd
+// matter in the first place.
+//
+// Linux-only: kqueue-backed platforms already evict the watchlist entry on
+// NOTE_RENAME (see `hot_reloader.zig`), so whether this repro hits the
+// stale-fd window is timing-dependent there. The fd-staleness check we rely
+// on applies on both, but the deterministic repro needs inotify.
+it.skipIf(!isLinux)(
+  "should re-import fresh source after atomic rename of entry (#30449)",
+  async () => {
+    const outerCwd = tmpdirSync();
+    const entryDir = tmpdirSync();
+    const root = join(entryDir, "entry.ts");
+    const stage = root + ".stage";
+    const sourceForValue = (value: string) => `
+import { watch } from "node:fs";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const ENTRY = fileURLToPath(import.meta.url);
+const r = createRequire(import.meta.url);
+
+export const VALUE = ${JSON.stringify(value)};
+
+console.write("INITIAL " + VALUE + "\\n");
+
+if (!(globalThis as any).__started) {
+  (globalThis as any).__started = true;
+  let busy = false;
+  watch(ENTRY, async () => {
+    if (busy) return;
+    busy = true;
+    try {
+      delete r.cache[ENTRY];
+      const m = await import(ENTRY);
+      console.write("IMPORTED " + (m as any).VALUE + "\\n");
+    } catch (e) {
+      console.write("FAIL " + (e as Error).message + "\\n");
+    } finally {
+      busy = false;
+    }
+  });
+}
+`;
+
+    writeFileSync(root, sourceForValue("V1"));
+    try {
+      var runner = spawn({
+        cmd: [bunExe(), "--hot", "run", root],
+        env: bunEnv,
+        cwd: outerCwd,
+        stdout: "pipe",
+        stderr: "inherit",
+        stdin: "ignore",
+      });
+
+      let stdout = "";
+      let sawInitial = false;
+      let sawImported = false;
+      for await (const chunk of runner.stdout) {
+        stdout += new TextDecoder().decode(chunk);
+
+        // Once we see the initial eval, trigger an atomic rename (what
+        // sed -i / vim default save / prettier do by default). Writing
+        // to a sibling and renaming over the entry replaces the inode,
+        // which is exactly what leaves the watchlist's cached fd
+        // pointing at the unlinked old inode.
+        if (!sawInitial && stdout.includes("INITIAL V1")) {
+          sawInitial = true;
+          writeFileSync(stage, sourceForValue("V2"));
+          renameSync(stage, root);
+        }
+
+        if (stdout.includes("IMPORTED ")) {
+          sawImported = true;
+          break;
+        }
+      }
+
+      runner.unref();
+      runner.kill();
+
+      // The critical assertion: the userland re-import returned the
+      // post-edit value, not the pre-edit one from the stale fd.
+      expect(sawImported).toBe(true);
+      expect(stdout).toContain("IMPORTED V2");
+      expect(stdout).not.toContain("IMPORTED V1");
+    } finally {
+      // @ts-ignore
+      runner?.unref?.();
+      // @ts-ignore
+      runner?.kill?.(9);
+      rmSync(root, { force: true });
+      rmSync(stage, { force: true });
     }
   },
   timeout,

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { beforeEach, expect, it } from "bun:test";
 import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isDebug, isLinux, tmpdirSync, waitForFileToExist } from "harness";
+import { bunEnv, bunExe, isDebug, isLinux, tempDir, tmpdirSync, waitForFileToExist } from "harness";
 import { join } from "path";
 
 const timeout = isDebug ? Infinity : 10_000;
@@ -513,10 +513,6 @@ it(
 it.skipIf(!isLinux)(
   "should re-import fresh source after atomic rename of entry (#30449)",
   async () => {
-    const outerCwd = tmpdirSync();
-    const entryDir = tmpdirSync();
-    const root = join(entryDir, "entry.ts");
-    const stage = root + ".stage";
     const sourceForValue = (value: string) => `
 import { watch } from "node:fs";
 import { createRequire } from "node:module";
@@ -547,57 +543,48 @@ if (!(globalThis as any).__started) {
   });
 }
 `;
+    using outerCwd = tempDir("hot-30449-cwd-", {});
+    using entryDir = tempDir("hot-30449-entry-", { "entry.ts": sourceForValue("V1") });
+    const root = join(String(entryDir), "entry.ts");
+    const stage = root + ".stage";
 
-    writeFileSync(root, sourceForValue("V1"));
-    try {
-      var runner = spawn({
-        cmd: [bunExe(), "--hot", "run", root],
-        env: bunEnv,
-        cwd: outerCwd,
-        stdout: "pipe",
-        stderr: "inherit",
-        stdin: "ignore",
-      });
+    await using runner = spawn({
+      cmd: [bunExe(), "--hot", "run", root],
+      env: bunEnv,
+      cwd: String(outerCwd),
+      stdout: "pipe",
+      stderr: "inherit",
+      stdin: "ignore",
+    });
 
-      let stdout = "";
-      let sawInitial = false;
-      let sawImported = false;
-      for await (const chunk of runner.stdout) {
-        stdout += new TextDecoder().decode(chunk);
+    let stdout = "";
+    let sawInitial = false;
+    let sawImported = false;
+    for await (const chunk of runner.stdout) {
+      stdout += new TextDecoder().decode(chunk);
 
-        // Once we see the initial eval, trigger an atomic rename (what
-        // sed -i / vim default save / prettier do by default). Writing
-        // to a sibling and renaming over the entry replaces the inode,
-        // which is exactly what leaves the watchlist's cached fd
-        // pointing at the unlinked old inode.
-        if (!sawInitial && stdout.includes("INITIAL V1")) {
-          sawInitial = true;
-          writeFileSync(stage, sourceForValue("V2"));
-          renameSync(stage, root);
-        }
-
-        if (stdout.includes("IMPORTED ")) {
-          sawImported = true;
-          break;
-        }
+      // Once we see the initial eval, trigger an atomic rename (what
+      // sed -i / vim default save / prettier do by default). Writing
+      // to a sibling and renaming over the entry replaces the inode,
+      // which is exactly what leaves the watchlist's cached fd
+      // pointing at the unlinked old inode.
+      if (!sawInitial && stdout.includes("INITIAL V1")) {
+        sawInitial = true;
+        writeFileSync(stage, sourceForValue("V2"));
+        renameSync(stage, root);
       }
 
-      runner.unref();
-      runner.kill();
-
-      // The critical assertion: the userland re-import returned the
-      // post-edit value, not the pre-edit one from the stale fd.
-      expect(sawImported).toBe(true);
-      expect(stdout).toContain("IMPORTED V2");
-      expect(stdout).not.toContain("IMPORTED V1");
-    } finally {
-      // @ts-ignore
-      runner?.unref?.();
-      // @ts-ignore
-      runner?.kill?.(9);
-      rmSync(root, { force: true });
-      rmSync(stage, { force: true });
+      if (stdout.includes("IMPORTED ")) {
+        sawImported = true;
+        break;
+      }
     }
+
+    // The critical assertion: the userland re-import returned the
+    // post-edit value, not the pre-edit one from the stale fd.
+    expect(sawImported).toBe(true);
+    expect(stdout).toContain("IMPORTED V2");
+    expect(stdout).not.toContain("IMPORTED V1");
   },
   timeout,
 );


### PR DESCRIPTION
Fixes #30449.

## Repro

```ts
// main.ts
import { watch } from 'node:fs';
import { createRequire } from 'node:module';
import { fileURLToPath } from 'node:url';

const ENTRY = fileURLToPath(import.meta.url);
const r = createRequire(import.meta.url);
export const VALUE = 'V1';
console.log('eval:', VALUE);

if (!globalThis.__started) {
  globalThis.__started = true;
  watch(ENTRY, async () => {
    delete r.cache[ENTRY];
    const m = await import(ENTRY);
    console.log('import:', m.VALUE);
  });
}
```

```console
$ cd /elsewhere && bun --hot /tmp/run/main.ts &
$ sed -i 's/V1/V2/' /tmp/run/main.ts
eval: V1
eval: V1           # bug: re-ran top-level with stale bytes
import: V1         # bug: userland await import returns pre-edit value
```

## Cause

When `--hot` / `--watch` is on, `ModuleLoader.transpileSourceCode` looks up the path in `bun_watcher.watchlist` and reuses the `fd` cached there to avoid re-opening on every re-transpile. An atomic rename (sed -i, vim default save, prettier, VSCode default) unlinks the old inode and installs a new one at the same path. The cached `fd` stays open on the now-unlinked inode (the kernel keeps it alive until the fd closes), so every read through it returns pre-edit bytes.

On kqueue platforms `hot_reloader.onFileUpdate` already evicts the watchlist entry on `NOTE_RENAME`, so a later transpile re-opens through the path. On Linux the same branch is `Environment.isKqueue`-gated: when the entry lives outside `top_level_dir` there's no parent-directory watch to spot the rename, and the file's own `IN_MOVE_SELF` reaches us but doesn't trigger eviction. The watchlist keeps the stale fd indefinitely.

The user's workaround in absolutejs is to run `delete require.cache[entry]; await import(entry)` from an `fs.watch` callback — needed because `Bun.build()` inside a `--hot` entry permanently disables `--hot`'s own reload (#30436). With the stale fd, that re-import returns V1 even though the file on disk is V2 and a plain `readFileSync(entry)` from inside the re-eval also sees V2.

## Fix

Validate the cached fd at the point of use. In `transpileSourceCode` and `RuntimeTranspilerStore` (the sync and async transpile paths), after pulling `fd` out of the watchlist, `stat(path)` + `fstat(fd)` and compare `(dev, ino)`. On mismatch, drop the cached fd; `readFileWithAllocator` then opens from the path and reads the current inode's bytes. Factored into `ModuleLoader.cachedFdIsStale` to share the shape between the two callers.

Two stats on a transpile-hit path are cheap and only run in dev-mode (the `indexOf(hash)` hit gate). The check is POSIX-only — `bun.Stat.dev`/`.ino` differ in shape on Windows, and atomic-rename reload there is already handled by the Windows watcher.

## Verification

`test/cli/hot/hot.test.ts` adds "should re-import fresh source after atomic rename of entry (#30449)": runs `bun --hot` with cwd outside the entry's directory (so the inotify parent-dir watch isn't registered — the deterministic-repro condition), writes to a staging file and renames over the entry, asserts the userland `await import(ENTRY)` returns the post-edit VALUE.

- `USE_SYSTEM_BUN=1 bun test test/cli/hot/hot.test.ts -t '#30449'`: 1 fail — `Expected to contain: "IMPORTED V2" / Received: "INITIAL V1\\nINITIAL V1\\nIMPORTED V1\\n"`
- `bun bd test test/cli/hot/hot.test.ts -t '#30449'`: 1 pass (5 runs, stable 1.7–2.2s)

The existing `should hot reload" tests (5 cases) still pass on the debug build, including `"when a file is renamed() into place"`.

The test is Linux-only (`it.skipIf(!isLinux)`). kqueue platforms already evict on rename via `hot_reloader.zig`, so whether the repro hits the stale-fd window is timing-dependent there; the fd-staleness check itself still applies on macOS as a safety net.