### PR TITLE
resolve: own specifier/referrer UTF-8 across auto-install re-entrancy

### DIFF
--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -1905,10 +1905,16 @@ pub fn resolveMaybeNeedsTrailingSlash(
 
     var result = ResolveFunctionResult{ .path = "", .result = null };
     const jsc_vm = global.bunVM();
-    const specifier_utf8 = specifier.toUTF8(bun.default_allocator);
+    // `_resolve` below can reach the auto-install path whose `sleepUntil`
+    // pumps the JS event loop; arbitrary JS may run (timers, GC) while this
+    // frame is on the stack. Own the UTF-8 bytes instead of borrowing the
+    // WTF::StringImpl's inline buffer so a re-entrant deref/free doesn't
+    // leave `specifier_utf8`/`source_utf8` dangling when we read them again
+    // to build the ResolveMessage.
+    const specifier_utf8 = specifier.toUTF8Owned(bun.default_allocator);
     defer specifier_utf8.deinit();
 
-    const source_utf8 = source.toUTF8(bun.default_allocator);
+    const source_utf8 = source.toUTF8Owned(bun.default_allocator);
     defer source_utf8.deinit();
     if (jsc_vm.plugin_runner) |plugin_runner| {
         if (PluginRunner.couldBePlugin(specifier_utf8.slice())) {

--- a/test/js/bun/resolve/resolve-autoinstall-invalid-name.test.ts
+++ b/test/js/bun/resolve/resolve-autoinstall-invalid-name.test.ts
@@ -55,6 +55,56 @@ test("resolver does not attempt auto-install for invalid npm package names", asy
   expect(exitCode).toBe(0);
 });
 
+// Auto-install's `sleepUntil` pumps the full JS event loop while the resolver
+// is on the stack holding slices that borrow from the referrer's
+// WTF::StringImpl. If pending JS (timers/GC) runs during that window, those
+// borrowed bytes must not be invalidated before the resolver reads them again
+// to build the ResolveMessage.
+test("resolver survives event-loop re-entrancy during auto-install", async () => {
+  await using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response("{}", { status: 404, headers: { "content-type": "application/json" } });
+    },
+  });
+
+  using dir = tempDir("resolve-autoinstall-reentrant", {
+    "index.js": `
+      let uncaught = 0;
+      process.on("uncaughtException", () => { uncaught++; });
+      let caught = 0;
+      for (let i = 0; i < 10; i++) {
+        setImmediate(() => { Bun.gc(true); throw new Error("from-immediate"); });
+        try {
+          require("pkg-does-not-exist-" + i);
+        } catch (e) {
+          if (typeof e.referrer !== "string" || !e.referrer.endsWith("index.js"))
+            throw new Error("bad referrer: " + e.referrer);
+          caught++;
+        }
+      }
+      setImmediate(() => console.log("caught=" + caught + " uncaught=" + uncaught));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--install=force", "index.js"],
+    env: {
+      ...bunEnv,
+      BUN_CONFIG_REGISTRY: server.url.href,
+      NPM_CONFIG_REGISTRY: server.url.href,
+    },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("caught=10 uncaught=10");
+  expect(exitCode).toBe(0);
+});
+
 test("resolver still attempts auto-install for valid npm package names", async () => {
   let requests = 0;
   await using server = Bun.serve({

--- a/test/js/bun/resolve/resolve-autoinstall-invalid-name.test.ts
+++ b/test/js/bun/resolve/resolve-autoinstall-invalid-name.test.ts
@@ -61,9 +61,11 @@ test("resolver does not attempt auto-install for invalid npm package names", asy
 // borrowed bytes must not be invalidated before the resolver reads them again
 // to build the ResolveMessage.
 test("resolver survives event-loop re-entrancy during auto-install", async () => {
+  let requests = 0;
   await using server = Bun.serve({
     port: 0,
     fetch() {
+      requests++;
       return new Response("{}", { status: 404, headers: { "content-type": "application/json" } });
     },
   });
@@ -102,6 +104,7 @@ test("resolver survives event-loop re-entrancy during auto-install", async () =>
   const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toContain("caught=10 uncaught=10");
+  expect(requests).toBeGreaterThan(0);
   expect(exitCode).toBe(0);
 });
 


### PR DESCRIPTION
## What does this PR do?

`resolveMaybeNeedsTrailingSlash` converts the specifier/referrer `bun.String`s to UTF-8 via `toUTF8()`, which for an all-ASCII `WTFStringImpl` returns a slice that borrows the StringImpl's inline Latin-1 buffer (pinned by a ref). Those slices are read again **after** `_resolve()` returns — to format the `ResolveMessage` error and to clone the referrer into it.

`_resolve()` → `resolveAndAutoInstall()` → `enqueueDependencyToRoot()` reaches `sleepUntil()`, which for the `.js` event loop runs `tick()`/`autoTick()` in a loop. Arbitrary JS executes while this frame is parked: pending `setImmediate` callbacks fire, GC runs, the uncaught-exception handler formats stack traces.

Fuzzilli found a flaky ASAN `use-after-poison` inside `functionImportMeta__resolveSyncPrivate` where a 26-byte memmove (the length of the referrer path `/tmp/bun-fuzzilli-reprl.js`) read from mimalloc-poisoned memory after many REPRL iterations of:

```js
setImmediate(SharedArrayBuffer);          // throws when the event loop ticks
try { this.require("tHex"); } catch {}    // triggers auto-install → sleepUntil
Bun.gc(true);
```

The crash was not deterministically reproducible (network-timing dependent, requires many REPRL iterations to accumulate state), but the hazard is concrete: the borrowed slice's backing must survive arbitrary re-entrant JS.

Switch to `toUTF8Owned()` so the bytes live in a fresh `bun.default_allocator` allocation that is independent of whatever the re-entrant JS does to the backing `StringImpl`. This is two small allocations per `require()`/`import.meta.resolveSync()` — acceptable for a path that is about to do filesystem lookups or an HTTP round-trip anyway.

## How did you verify your code works?

- The crash repro (wrapped in the REPRL-equivalent indirect-eval harness) runs cleanly on the debug+ASAN build.
- `bun bd test test/js/bun/resolve/resolve.test.ts` — all 37 existing resolve tests pass.
- `bun bd test test/js/bun/resolve/resolve-error.test.ts` — all 15 existing ResolveMessage tests pass.
- `bun bd test test/js/bun/resolve/import-meta.test.js` — all 32 existing import.meta tests pass.
- New test in `resolve-autoinstall-invalid-name.test.ts` queues throwing `setImmediate` + `Bun.gc(true)` callbacks before each failing `require()` under `--install=force` against a local 404 registry, and asserts every resulting `ResolveMessage.referrer` is still the module's own path after the event loop was pumped mid-resolve.