### PR TITLE
Fix null deref in forEachProperty when Proxy getPrototype throws

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5369,10 +5369,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5444,7 +5444,10 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            iterating = proto ? proto.getObject() : nullptr;
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -453,6 +453,29 @@ const fixture = [
     ),
 ];
 
+describe("Proxy in prototype chain", () => {
+  it("inspecting an object whose prototype is a Proxy with a throwing getPrototypeOf trap does not crash", () => {
+    const obj = {};
+    const proto = Object.getPrototypeOf(obj);
+    Object.setPrototypeOf(
+      obj,
+      new Proxy(proto, {
+        getPrototypeOf() {
+          throw new Error("nope");
+        },
+      }),
+    );
+    expect(() => Bun.inspect(obj)).not.toThrow();
+  });
+
+  it("inspecting an object whose prototype is a Proxy wrapping a native prototype does not crash", () => {
+    const e = expect({});
+    const proto = Object.getPrototypeOf(e);
+    Object.setPrototypeOf(e, new Proxy(proto, {}));
+    expect(() => Bun.inspect(e)).not.toThrow();
+  });
+});
+
 describe("crash testing", () => {
   for (let input of fixture) {
     it(`inspecting "${input.toString().slice(0, 20).replaceAll("\n", "\\n")}" doesn't crash`, async () => {


### PR DESCRIPTION
Found by Fuzzilli. Fingerprint: `f363b9d446e2156f`

## What

`JSC__JSValue__forEachPropertyImpl` walks the prototype chain to enumerate properties for `Bun.inspect` / `console.log` formatting. At the end of each iteration it advances via:

```cpp
iterating = iterating->getPrototype(globalObject).getObject();
```

When `iterating` is a `ProxyObject`, `getPrototype()` can throw (via a `getPrototypeOf` trap) or return early due to an already-pending exception, returning an empty `JSValue`. An empty `JSValue` reports `isCell() == true` but `asCell() == nullptr`, so `.getObject()` dereferences a null pointer.

The fast path in the same function already guards against this (checking `if (JSValue proto = ...)` and clearing the exception). This applies the same guard to the slow path.

## Repro

```js
const obj = {};
Object.setPrototypeOf(obj, new Proxy(Object.getPrototypeOf(obj), {
  getPrototypeOf() { throw new Error("nope"); },
}));
console.log(obj); // segfault
```

Also reproduces with an empty Proxy handler wrapping a native prototype that has throwing accessors (e.g. `expect()` instances).