### PR TITLE
cli: sync PWD env var with --cwd chdir

### DIFF
--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -853,10 +853,12 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
         // Store the post-chdir physical path (mirrors process.chdir) so
         // process.cwd(), path.resolve, and the resolver agree on one form.
         let mut phys = PathBuffer::uninit();
-        match bun_core::getcwd(&mut phys) {
-            Ok(p) => Box::<[u8]>::from(p.as_bytes()),
-            Err(_) => Box::<[u8]>::from(out_z.as_bytes()),
-        }
+        let resolved = match bun_core::getcwd(&mut phys) {
+            Ok(p) => bun_core::ZBox::from_bytes(p.as_bytes()),
+            Err(_) => out_z,
+        };
+        set_pwd_env(&resolved);
+        Box::<[u8]>::from(resolved.as_bytes())
     } else if matches!(
         cmd,
         CommandTag::AutoCommand | CommandTag::RunCommand | CommandTag::RunAsNodeCommand
@@ -1713,6 +1715,65 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
     }
 
     Ok(opts)
+}
+
+/// Publish `cwd` as `PWD` after a successful `--cwd` chdir, like bash's `cd`.
+fn set_pwd_env(cwd: &bun_core::ZBox) {
+    #[cfg(windows)]
+    {
+        patch_windows_environ_snapshot(cwd.as_bytes());
+        let mut wbuf = bun_paths::WPathBuffer::uninit();
+        let wcwd = bun_paths::strings::to_w_path(wbuf.as_mut_slice(), cwd.as_bytes());
+        const PWD_W: [u16; 4] = [b'P' as u16, b'W' as u16, b'D' as u16, 0];
+        // SAFETY: PWD_W is NUL-terminated; to_w_path writes a NUL-terminated WStr.
+        unsafe {
+            let _ = bun_sys::windows::SetEnvironmentVariableW(PWD_W.as_ptr(), wcwd.as_ptr());
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        // SAFETY: literal is NUL-terminated; ZBox::as_ptr() points to NUL-terminated bytes.
+        unsafe {
+            let _ = libc::setenv(c"PWD".as_ptr(), cwd.as_ptr(), 1);
+        }
+    }
+}
+
+/// Rebuild the envp snapshot with `PWD=cwd`: `SetEnvironmentVariableW` does
+/// not update the WTF-8 snapshot that `DotEnv::load_process` reads.
+#[cfg(windows)]
+fn patch_windows_environ_snapshot(cwd: &[u8]) {
+    let mut entry: Vec<u8> = Vec::with_capacity(4 + cwd.len() + 1);
+    entry.extend_from_slice(b"PWD=");
+    entry.extend_from_slice(cwd);
+    entry.push(0);
+    let entry_ptr: *mut core::ffi::c_char = Box::leak(entry.into_boxed_slice()).as_mut_ptr().cast();
+
+    // SAFETY: single-threaded argv parse; no other thread reads `environ` yet.
+    let env = unsafe { bun_core::os::environ() };
+    let mut new: Vec<*mut core::ffi::c_char> = Vec::with_capacity(env.len() + 2);
+    let mut replaced = false;
+    for slot in env {
+        // SAFETY: entries are NUL-terminated by construction in convert_env_to_wtf8.
+        let bytes = unsafe { bun_core::ffi::cstr(*slot as *const _) }.to_bytes();
+        // Windows env keys are case-insensitive — match getenv_z_any_case.
+        let key_end = bun_core::strings::index_of_char_usize(bytes, b'=').unwrap_or(bytes.len());
+        if bun_core::strings::eql_case_insensitive_ascii_check_length(&bytes[..key_end], b"PWD") {
+            new.push(entry_ptr);
+            replaced = true;
+        } else {
+            new.push(*slot);
+        }
+    }
+    if !replaced {
+        new.push(entry_ptr);
+    }
+    new.push(core::ptr::null_mut());
+    let new = Box::leak(new.into_boxed_slice());
+    // SAFETY: single-threaded startup; `new` is live for the process lifetime.
+    unsafe {
+        bun_core::os::set_environ(new.as_mut_ptr(), new.len() - 1);
+    }
 }
 
 /// Cold path: `bun test` option-group parsing — timeout / coverage / reporter /

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -379,6 +379,113 @@ describe.concurrent("bun run", () => {
     });
   });
 
+  // https://github.com/oven-sh/bun/issues/30456
+  //
+  // The reported repro is `bun --cwd=frontend run lint`, so cover both the
+  // bare-entrypoint form (`bun --cwd=subdir test.js`) and the `run`
+  // subcommand form (`bun --cwd=subdir run test.js`) — each hits a different
+  // Arguments.parse branch.
+  //
+  // `PWD` is a POSIX shell convention — these tests exist for the tools that
+  // read it (vue-tsc via TypeScript's module resolution, shell scripts,
+  // subprocess children). On Windows the path / env conventions differ enough
+  // (case-insensitive keys, backslash vs forward-slash in `process.cwd()` vs
+  // the `.loose`-normalised path we store, `%CD%` as the native equivalent)
+  // that a strict equality test would produce false failures; skip there.
+  for (const withRun of [false, true]) {
+    const label = withRun ? "bun --cwd run" : "bun --cwd";
+    const buildCmd = (...extra: string[]) => [bunExe(), "--cwd=subdir", ...(withRun ? ["run"] : []), ...extra];
+
+    it.skipIf(isWindows)(`${label} updates process.env.PWD to match the new cwd`, async () => {
+      using dir = tempDir(`bun-run-cwd-pwd-${withRun ? "run" : "bare"}`, {
+        "subdir/test.js": `console.log(JSON.stringify({ pwd: process.env.PWD, cwd: process.cwd() }));`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: buildCmd("test.js"),
+        cwd: String(dir),
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...bunEnv,
+          // Set a known PWD so we detect when it's not overwritten — don't
+          // rely on the inherited parent PWD (Bun's test harness can leave
+          // it pointing at an unexpected directory on some platforms).
+          PWD: String(dir),
+        },
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      const { pwd, cwd } = JSON.parse(stdout);
+      // realpath-resolved subdir under the tempdir, since macOS tempdirs
+      // symlink through /private.
+      expect(cwd).toMatch(/subdir$/);
+      // PWD must match cwd — tools like vue-tsc / TypeScript's module
+      // resolution read PWD and use it as the resolution root.
+      expect(pwd).toBe(cwd);
+      expect(exitCode).toBe(0);
+    });
+
+    it.skipIf(isWindows)(`${label} PWD is inherited by spawned child processes`, async () => {
+      using dir = tempDir(`bun-run-cwd-pwd-child-${withRun ? "run" : "bare"}`, {
+        "subdir/test.js": `
+          import { spawnSync } from "child_process";
+          const out = spawnSync(process.execPath, ["-e", "console.log(process.env.PWD)"], {
+            env: process.env,
+            encoding: "utf8",
+          });
+          process.stdout.write(out.stdout);
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: buildCmd("test.js"),
+        cwd: String(dir),
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...bunEnv,
+          PWD: String(dir),
+        },
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toMatch(/subdir$/);
+      expect(exitCode).toBe(0);
+    });
+
+    // When PWD is absent from the inherited env (env -u PWD, cron, systemd,
+    // minimal Docker), --cwd still has to publish it through to process.env.
+    it.skipIf(isWindows)(`${label} adds PWD when parent had none`, async () => {
+      using dir = tempDir(`bun-run-cwd-pwd-unset-${withRun ? "run" : "bare"}`, {
+        "subdir/test.js": `console.log(process.env.PWD ?? "<unset>");`,
+      });
+
+      const { PWD, ...envNoPwd } = bunEnv;
+
+      await using proc = Bun.spawn({
+        cmd: buildCmd("test.js"),
+        cwd: String(dir),
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+        env: envNoPwd,
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toMatch(/subdir$/);
+      expect(exitCode).toBe(0);
+    });
+  }
+
   it("DCE annotations are respected", async () => {
     using dir = tempDir("test", {
       "index.ts": `


### PR DESCRIPTION
## Repro

```console
$ cd /tmp && bun --cwd=cwd-test -e 'console.log("PWD:", process.env.PWD); console.log("cwd:", process.cwd())'
PWD: /tmp
cwd: /tmp/cwd-test
```

`bun --cwd=<dir>` calls `chdir()` so `process.cwd()` reports the new
directory, but `process.env.PWD` still points at the parent. Any tool
(or child process) that reads `PWD` sees the wrong directory.

## Cause

`arguments::parse` (`src/runtime/cli/Arguments.rs`) only called
`bun_sys::chdir` — it never updated the `PWD` env var. `PWD` is
inherited from the parent shell and left unchanged.

For the reported scenario (`bun --cwd=frontend run lint` → `vue-tsc`),
TypeScript's `ts.sys` reads `process.env.PWD` as the resolution root
for relative module specifiers, so `./App.vue` resolves against the
project root instead of `frontend/`, and module resolution fails.

Bun's shell interpreter already updates `PWD` when it runs its own
builtin `cd`, so scripts that go through `bun run` → shell → children
*usually* recover. But the Bun process started by `--cwd` itself — and
any `bun --cwd=X -e ...` or `bun --cwd=X file.js` — sees the stale
`PWD`.

## Fix

After a successful `--cwd` chdir, write `PWD` to the new directory:

- **POSIX**: `setenv("PWD", cwd, 1)`. `bun_sys::environ()` reads libc's
  live `environ` pointer on every call, so `DotEnv::load_process`
  picks up the change — no further work needed. Matches `bash`'s
  builtin `cd` behaviour (only overwrite on success).
- **Windows**: `SetEnvironmentVariableW` *plus* a patch into
  `bun_core::os::environ()` — the WTF-8 snapshot
  `convert_env_to_wtf8` freezes at startup
  (`src/sys/windows/env.rs`). `SetEnvironmentVariableW` only mutates
  the Win32 env block, so without patching the snapshot
  `DotEnv::load_process` still sees the pre-chdir value. Replace
  the existing `PWD=` slot in place when present, or grow the
  envp slice by one and re-publish via `bun_core::os::set_environ`.

Only touched when `--cwd` is actually provided.

Intentionally excluded: the package-manager subcommands (`bun
install/add/remove/... --cwd`) parse `--cwd` separately
(`src/install/PackageManager/CommandLineArguments.rs`) and keep their
pre-existing behaviour. Impact there is lower — lifecycle scripts are
spawned with an explicit cwd, and scripts routed through Bun's shell
get `PWD` re-derived by the shell's own `cd`. Can be lifted to a shared
helper in a follow-up if wanted.

## Rebase note

When this PR was first opened the CLI argument parser lived in Zig
(`src/cli/Arguments.zig`); the port in #30412 moved the hot path to
Rust (`src/runtime/cli/Arguments.rs`) while leaving the Zig file as
dead code. After the rebase the fix was ported to Rust — this is why
the diff is now against `.rs` instead of `.zig`.

## Verification

`test/cli/install/bun-run.test.ts` — three cases × `withRun={false,true}`:

1. `--cwd` updates `process.env.PWD` to match `process.cwd()`
2. That `PWD` is inherited by spawned child processes
3. `--cwd` publishes `PWD` even when the parent env doesn't have one
   (`env -u PWD` / cron / systemd / minimal Docker)

```
USE_SYSTEM_BUN=1 bun test test/cli/install/bun-run.test.ts -t cwd  → 6 fail
bun bd         test test/cli/install/bun-run.test.ts -t cwd         → 7 pass
```

Skipped on Windows (`PWD` is a POSIX shell convention; the path-shape
`.loose`-normalised forward-slash vs `process.cwd()`'s backslashes
makes strict-equality tests noisy there) — the fix still runs, the
test just doesn't assert the cross-platform-dicey shape.

Fixes #30456

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 11 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-run.test.ts

<!-- robobun:evidence:end -->
