### PR TITLE
chore: prevent auto-update actions from running on forks

### DIFF
--- a/.github/workflows/update-cares.yml
+++ b/.github/workflows/update-cares.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-update:
+    if: github.repository == 'oven-sh/bun'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/update-hdrhistogram.yml
+++ b/.github/workflows/update-hdrhistogram.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-update:
+    if: github.repository == 'oven-sh/bun'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/update-highway.yml
+++ b/.github/workflows/update-highway.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-update:
+    if: github.repository == 'oven-sh/bun'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/update-libarchive.yml
+++ b/.github/workflows/update-libarchive.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-update:
+    if: github.repository == 'oven-sh/bun'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/update-libdeflate.yml
+++ b/.github/workflows/update-libdeflate.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-update:
+    if: github.repository == 'oven-sh/bun'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/update-lolhtml.yml
+++ b/.github/workflows/update-lolhtml.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-update:
+    if: github.repository == 'oven-sh/bun'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/update-lshpack.yml
+++ b/.github/workflows/update-lshpack.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-update:
+    if: github.repository == 'oven-sh/bun'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/update-root-certs.yml
+++ b/.github/workflows/update-root-certs.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-and-update:
+    if: github.repository == 'oven-sh/bun'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/update-sqlite3.yml
+++ b/.github/workflows/update-sqlite3.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-update:
+    if: github.repository == 'oven-sh/bun'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/update-vendor.yml
+++ b/.github/workflows/update-vendor.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-update:
+    if: github.repository == 'oven-sh/bun'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/update-zstd.yml
+++ b/.github/workflows/update-zstd.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-update:
+    if: github.repository == 'oven-sh/bun'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
### What does this PR do?

Makes these actions only run on upstream Bun. I don't need PRs [like these](https://github.com/190n/bun/pulls?q=is%3Apr+is%3Aclosed) to be opened since I only keep my repo up for sending PRs back here, and Bun will merge those updates itself.

### How did you verify your code works?
