### PR TITLE
Fix crash in Bun.build with many `conditions`

### DIFF
--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1087,9 +1087,9 @@ pub const ESMConditions = struct {
         var require_condition_map = ConditionsMap.init(allocator);
         var style_condition_map = ConditionsMap.init(allocator);
 
-        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
+        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + @intFromBool(allow_addons) + conditions.len);
+        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + @intFromBool(allow_addons) + conditions.len);
+        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + @intFromBool(allow_addons) + conditions.len);
         try style_condition_map.ensureTotalCapacity(defaults.len + 2 + conditions.len);
 
         import_condition_map.putAssumeCapacity("import", {});

--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1572,9 +1572,9 @@ pub fn loadersFromTransformOptions(allocator: std.mem.Allocator, _loaders: ?api.
         bun.StringArrayHashMap(Loader),
         allocator,
         input_loaders.extensions.len +
-            if (target.isBun()) default_loader_ext_bun.len else 0 +
-                if (target == .browser) default_loader_ext_browser.len else 0 +
-                    default_loader_ext.len,
+            (if (target.isBun()) default_loader_ext_bun.len else 0) +
+            (if (target == .browser) default_loader_ext_browser.len else 0) +
+            default_loader_ext.len,
         input_loaders.extensions,
         loader_values,
     );

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -811,6 +811,19 @@ identity(mod23);
   expect(text).toContain(" globalThis.");
 });
 
+test.concurrent("conditions array with many entries does not crash", async () => {
+  const dir = tempDirWithFiles("bun-build-many-conditions", {
+    "entry.js": `export const a = 1;`,
+  });
+
+  const build = await Bun.build({
+    entrypoints: [join(dir, "entry.js")],
+    conditions: ["aa", "bb", "cc", "dd", "ee", "ff", "gg", "hh"],
+  });
+
+  expect(build.success).toBe(true);
+});
+
 describe.concurrent("sourcemap boolean values", () => {
   test("sourcemap: true should work (boolean)", async () => {
     const dir = tempDirWithFiles("sourcemap-true-boolean", {


### PR DESCRIPTION
`ESMConditions.init` computed hashmap capacity with:

```zig
defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len
```

which Zig parses as `if (allow_addons) 1 else (0 + conditions.len)`. When `allow_addons` is true (the default for `Bun.build`), `conditions.len` was dropped from the capacity request, so passing several custom conditions would overflow the preallocated map and hit the `putAssumeCapacity` assertion on the bundle thread.

Replaced the `if` expression with `@intFromBool(allow_addons)` so the sum is unambiguous.

### Repro
```js
await Bun.build({
  entrypoints: ["./entry.js"],
  conditions: ["aa", "bb", "cc", "dd", "ee", "ff", "gg", "hh"],
});
```

Found by Fuzzilli (fingerprint `f7b40b0e431d91d6`).