### PR TITLE
bake: validate `app.bundlerOptions` values are objects

### DIFF
--- a/src/bake/bake.zig
+++ b/src/bake/bake.zig
@@ -68,14 +68,17 @@ pub const UserOptions = struct {
         }
 
         if (try config.getOptional(global, "bundlerOptions", JSValue)) |js_options| {
+            if (!js_options.isObject()) {
+                return global.throwInvalidArguments("'" ++ api_name ++ ".bundlerOptions' must be an object", .{});
+            }
             if (try js_options.getOptional(global, "server", JSValue)) |server_options| {
-                bundler_options.server = try BuildConfigSubset.fromJS(global, server_options);
+                bundler_options.server = try BuildConfigSubset.fromJS(global, server_options, "server");
             }
             if (try js_options.getOptional(global, "client", JSValue)) |client_options| {
-                bundler_options.client = try BuildConfigSubset.fromJS(global, client_options);
+                bundler_options.client = try BuildConfigSubset.fromJS(global, client_options, "client");
             }
             if (try js_options.getOptional(global, "ssr", JSValue)) |ssr_options| {
-                bundler_options.ssr = try BuildConfigSubset.fromJS(global, ssr_options);
+                bundler_options.ssr = try BuildConfigSubset.fromJS(global, ssr_options, "ssr");
             }
         }
 
@@ -202,8 +205,12 @@ const BuildConfigSubset = struct {
     minify_identifiers: ?bool = null,
     minify_whitespace: ?bool = null,
 
-    pub fn fromJS(global: *jsc.JSGlobalObject, js_options: JSValue) bun.JSError!BuildConfigSubset {
+    pub fn fromJS(global: *jsc.JSGlobalObject, js_options: JSValue, comptime name: []const u8) bun.JSError!BuildConfigSubset {
         var options = BuildConfigSubset{};
+
+        if (!js_options.isObject()) {
+            return global.throwInvalidArguments("'" ++ api_name ++ ".bundlerOptions." ++ name ++ "' must be an object", .{});
+        }
 
         if (try js_options.getOptional(global, "sourcemap", JSValue)) |val| brk: {
             if (try bun.schema.api.SourceMapMode.fromJS(global, val)) |sourcemap| {
@@ -215,11 +222,16 @@ const BuildConfigSubset = struct {
         }
 
         if (try js_options.getOptional(global, "minify", JSValue)) |minify_options| brk: {
-            if (minify_options.isBoolean() and minify_options.asBoolean()) {
-                options.minify_syntax = minify_options.asBoolean();
-                options.minify_identifiers = minify_options.asBoolean();
-                options.minify_whitespace = minify_options.asBoolean();
+            if (minify_options.isBoolean()) {
+                const value = minify_options.asBoolean();
+                options.minify_syntax = value;
+                options.minify_identifiers = value;
+                options.minify_whitespace = value;
                 break :brk;
+            }
+
+            if (!minify_options.isObject()) {
+                return global.throwInvalidArguments("'" ++ api_name ++ ".bundlerOptions." ++ name ++ ".minify' must be a boolean or an object", .{});
             }
 
             if (try minify_options.getBooleanLoose(global, "whitespace")) |value| {

--- a/test/bake/bundler-options-validation.test.ts
+++ b/test/bake/bundler-options-validation.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 describe("Bun.serve app.bundlerOptions validation", () => {
   test.each([42, "str", true, Symbol(), 1n])("throws when bundlerOptions is %p", value => {

--- a/test/bake/bundler-options-validation.test.ts
+++ b/test/bake/bundler-options-validation.test.ts
@@ -1,0 +1,41 @@
+import { test, expect, describe } from "bun:test";
+
+describe("Bun.serve app.bundlerOptions validation", () => {
+  test.each([42, "str", true, Symbol(), 1n])("throws when bundlerOptions is %p", value => {
+    expect(() =>
+      Bun.serve({
+        // @ts-expect-error
+        app: { bundlerOptions: value },
+      }),
+    ).toThrow("'app.bundlerOptions' must be an object");
+  });
+
+  describe.each(["server", "client", "ssr"] as const)("bundlerOptions.%s", key => {
+    test.each([42, "str", true, Symbol(), 1n])("throws when value is %p", value => {
+      expect(() =>
+        Bun.serve({
+          // @ts-expect-error
+          app: { bundlerOptions: { [key]: value } },
+        }),
+      ).toThrow(`'app.bundlerOptions.${key}' must be an object`);
+    });
+
+    test.each([42, "str", Symbol(), 1n])("throws when minify is %p", value => {
+      expect(() =>
+        Bun.serve({
+          // @ts-expect-error
+          app: { bundlerOptions: { [key]: { minify: value } } },
+        }),
+      ).toThrow(`'app.bundlerOptions.${key}.minify' must be a boolean or an object`);
+    });
+
+    test.each([true, false])("does not crash when minify is %p", value => {
+      expect(() =>
+        Bun.serve({
+          // @ts-expect-error
+          app: { bundlerOptions: { [key]: { minify: value } } },
+        }),
+      ).toThrow("'app' is missing 'framework'");
+    });
+  });
+});


### PR DESCRIPTION
Fuzzer found a debug assertion crash in `Bun.serve({ app: { bundlerOptions: ... } })`.

`JSValue.get` asserts that its target is an object, but `bake.UserOptions.fromJS` and `BuildConfigSubset.fromJS` were calling `.getOptional()` on user-provided values without validating them first. This crashed when:

- `app.bundlerOptions` was a primitive (number, string, boolean, symbol, bigint)
- `app.bundlerOptions.{server,client,ssr}` was a primitive
- `app.bundlerOptions.*.minify` was `false` or any non-boolean primitive (the previous check was `isBoolean() and asBoolean()`, so `false` fell through to the object path)

These now throw `InvalidArguments` errors instead.

Fingerprint: `86855f8bedcf582b`