### PR TITLE
Fix use-after-free in Bun.Transpiler async transform() error messages

### DIFF
--- a/src/runtime/api/JSTranspiler.zig
+++ b/src/runtime/api/JSTranspiler.zig
@@ -500,9 +500,16 @@ pub const TransformTask = struct {
         var ast_scope = ast_memory_allocator.enter(allocator);
         defer ast_scope.exit();
 
+        // The parser allocates error message text using the transpiler's
+        // allocator (the arena above). Collect messages in a local log and
+        // deep-copy them into `this.log` before the arena is destroyed so
+        // `then()` on the JS thread does not read freed memory.
+        var local_log = logger.Log.init(allocator);
+        local_log.level = this.log.level;
+        defer bun.handleOom(local_log.appendToWithRecycled(&this.log, true));
+
         this.transpiler.setAllocator(allocator);
-        this.transpiler.setLog(&this.log);
-        this.log.msgs.allocator = bun.default_allocator;
+        this.transpiler.setLog(&local_log);
 
         const jsx = if (this.tsconfig != null)
             this.tsconfig.?.mergeJSX(this.transpiler.options.jsx)

--- a/test/js/bun/transpiler/transpiler-async-error-uaf.test.ts
+++ b/test/js/bun/transpiler/transpiler-async-error-uaf.test.ts
@@ -5,10 +5,12 @@ describe("Transpiler async transform() error lifetime", () => {
     const transpiler = new Bun.Transpiler();
     const promises: Promise<unknown>[] = [];
     for (let i = 0; i < 50; i++) {
-      promises.push(transpiler.transform("const x = @@@", "js").then(
-        () => null,
-        e => e,
-      ));
+      promises.push(
+        transpiler.transform("const x = @@@", "js").then(
+          () => null,
+          e => e,
+        ),
+      );
     }
     const results = await Promise.all(promises);
     for (const r of results) {

--- a/test/js/bun/transpiler/transpiler-async-error-uaf.test.ts
+++ b/test/js/bun/transpiler/transpiler-async-error-uaf.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+describe("Transpiler async transform() error lifetime", () => {
+  test.concurrent("concurrent async transform() parse errors do not read freed memory", async () => {
+    const transpiler = new Bun.Transpiler();
+    const promises: Promise<unknown>[] = [];
+    for (let i = 0; i < 50; i++) {
+      promises.push(transpiler.transform("const x = @@@", "js").then(
+        () => null,
+        e => e,
+      ));
+    }
+    const results = await Promise.all(promises);
+    for (const r of results) {
+      expect(r).toBeInstanceOf(BuildMessage);
+      const msg = r as BuildMessage;
+      expect(msg.message).toBe('Expected identifier but found "@"');
+      expect(msg.position).toEqual({
+        lineText: "const x = @@@",
+        file: "input.js",
+        namespace: "file",
+        line: 1,
+        column: 12,
+        length: 1,
+        offset: 11,
+      });
+    }
+  });
+
+  test.concurrent("async transform() rejects with a usable BuildMessage after arena is freed", async () => {
+    const transpiler = new Bun.Transpiler();
+    const err = await transpiler.transform("1 + ", "js").then(
+      () => null,
+      e => e,
+    );
+    expect(err).toBeInstanceOf(BuildMessage);
+    expect((err as BuildMessage).message).toBe("Unexpected end of file");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a use-after-free in `Bun.Transpiler#transform()` (the async variant) when parsing fails.

`TransformTask.run()` runs on a worker thread and uses a `MimallocArena` as the transpiler's allocator for parsing. Error message text produced by the parser is allocated from that arena. The arena is destroyed when `run()` returns. Later, `then()` runs on the JS thread and calls `log.toJS()` → `BuildMessage.create()` → `Msg.clone()` → `allocator.dupe(u8, text)`, which reads the freed arena memory.

Under ASAN this shows as `use-after-poison` in `Data.clone`; in release builds the rejection's `BuildMessage` contains garbage bytes instead of the real error message.

### Fix

Collect parse messages in a local arena-backed log and deep-copy them into the task's persistent log (backed by `bun.default_allocator`) via `appendToWithRecycled(..., true)` in a `defer` that runs before the arena is destroyed.

## How did you verify your code works?

Minimal repro (crashes under ASAN before, garbage message text in release before):

```js
const transpiler = new Bun.Transpiler();
const promises = [];
for (let i = 0; i < 50; i++) {
  promises.push(transpiler.transform("const x = @@@", "js").catch(e => e));
}
await Promise.all(promises);
```

Added a regression test in `test/js/bun/transpiler/transpiler-async-error-uaf.test.ts` that asserts the rejection is a `BuildMessage` with the correct `message` and `position`. The test fails on current `main` (receives garbage bytes like `"H)yôP)yôX)yô"`) and passes with this fix. Existing transpiler tests continue to pass.