### PR TITLE
bundler: fix ESMConditions capacity with user-provided conditions

### DIFF
--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1087,9 +1087,10 @@ pub const ESMConditions = struct {
         var require_condition_map = ConditionsMap.init(allocator);
         var style_condition_map = ConditionsMap.init(allocator);
 
-        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
+        const extra: usize = if (allow_addons) 1 else 0;
+        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + extra + conditions.len);
+        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + extra + conditions.len);
+        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + extra + conditions.len);
         try style_condition_map.ensureTotalCapacity(defaults.len + 2 + conditions.len);
 
         import_condition_map.putAssumeCapacity("import", {});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -811,6 +811,24 @@ identity(mod23);
   expect(text).toContain(" globalThis.");
 });
 
+test("many custom conditions does not crash", async () => {
+  const dir = tempDirWithFiles("bun-build-many-conditions", {
+    "entry.js": `console.log(1);`,
+  });
+
+  for (const target of ["bun", "browser", "node"] as const) {
+    for (const n of [1, 4, 6, 8, 12, 20]) {
+      const conditions = Array.from({ length: n }, (_, i) => `cond${i}`);
+      const build = await Bun.build({
+        entrypoints: [join(dir, "entry.js")],
+        target,
+        conditions,
+      });
+      expect(build.success).toBe(true);
+    }
+  }
+});
+
 describe.concurrent("sourcemap boolean values", () => {
   test("sourcemap: true should work (boolean)", async () => {
     const dir = tempDirWithFiles("sourcemap-true-boolean", {


### PR DESCRIPTION
## What does this PR do?

`ESMConditions.init` computes how much capacity to reserve for each condition map before inserting with `putAssumeCapacity`. The expression used was:

```zig
defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len
```

which Zig parses as:

```zig
defaults.len + 2 + (if (allow_addons) 1 else (0 + conditions.len))
```

So when `allow_addons` is true (the default), the number of user-provided conditions was never counted towards the reserved capacity. With roughly 6+ custom conditions passed to `Bun.build({ conditions })` or `bun build --conditions`, the subsequent `putAssumeCapacity` calls exceed the allocation — tripping a debug assertion and writing past the buffer in release builds.

Fix by hoisting the conditional into a local so the addition is unambiguous.

## How did you verify your code works?

Added a regression test that builds with 1–20 custom conditions across `bun`, `browser`, and `node` targets. Before this change the test panics with `reached unreachable code` in `MultiArrayList.addOneAssumeCapacity`; after, it passes.

Fuzzer fingerprint: `2ca2ef9e67423f31`