### PR TITLE
Fix crash when using Reflect.construct on mock functions

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -86,6 +86,7 @@ inline To tryJSDynamicCast(JSC::WriteBarrier<WriteBarrierT>& from)
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionCall);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionConstruct);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetter_mockGetLastCall);
@@ -462,7 +463,7 @@ public:
     }
 
     JSMockFunction(JSC::VM& vm, JSC::Structure* structure, CallbackKind wrapKind)
-        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
+        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionConstruct)
     {
         initMock();
     }
@@ -979,6 +980,30 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
 
     setReturnValue(createMockResult(vm, globalObject, "return"_s, jsUndefined()));
     return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    EncodedJSValue encodedResult = jsMockFunctionCall(lexicalGlobalObject, callframe);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    JSValue result = JSValue::decode(encodedResult);
+    if (result.isObject()) [[likely]]
+        return encodedResult;
+
+    JSValue newTarget = callframe->newTarget();
+    JSObject* newTargetObject = newTarget.getObject();
+    if (!newTargetObject) [[unlikely]]
+        return JSValue::encode(constructEmptyObject(lexicalGlobalObject));
+
+    JSGlobalObject* functionGlobalObject = getFunctionRealm(lexicalGlobalObject, newTargetObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    Structure* objectStructure = InternalFunction::createSubclassStructure(lexicalGlobalObject, newTargetObject, functionGlobalObject->objectStructureForObjectConstructor());
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(constructEmptyObject(vm, objectStructure));
 }
 
 void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1053,14 +1053,17 @@ describe("construct", () => {
     expect(typeof result === "object" || typeof result === "function").toBe(true);
   });
 
-  test("Reflect.construct on spyOn of non-function value does not crash", () => {
-    const arr = [-62400, 1355854322, -7];
-    const spy = spyOn(arr, 1);
-    const result = Reflect.construct(spy, []);
-    expect(typeof result).toBe("object");
-    expect(result).not.toBeNull();
-    spy.mockRestore();
-  });
+  if (isBun) {
+    // Jest/Vitest don't allow spying on non-function properties
+    test("Reflect.construct on spyOn of non-function value does not crash", () => {
+      const arr = [-62400, 1355854322, -7];
+      const spy = spyOn(arr, 1);
+      const result = Reflect.construct(spy, []);
+      expect(typeof result).toBe("object");
+      expect(result).not.toBeNull();
+      spy.mockRestore();
+    });
+  }
 
   test("Reflect.construct respects newTarget prototype", () => {
     const fn = jest.fn();

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1015,3 +1015,64 @@ describe("spyOn", () => {
 
   // spyOn does not work with getters/setters yet.
 });
+
+describe("construct", () => {
+  test("Reflect.construct on empty mock returns an object", () => {
+    const fn = jest.fn();
+    const result = Reflect.construct(fn, []);
+    expect(typeof result).toBe("object");
+    expect(result).not.toBeNull();
+  });
+
+  test("Reflect.construct on mockReturnValue with primitive returns an object", () => {
+    const fn = jest.fn().mockReturnValue(42);
+    const result = Reflect.construct(fn, []);
+    expect(typeof result).toBe("object");
+    expect(result).not.toBeNull();
+    expect(fn()).toBe(42);
+  });
+
+  test("Reflect.construct with implementation returning primitive returns an object", () => {
+    const fn = jest.fn(() => 99);
+    const result = Reflect.construct(fn, []);
+    expect(typeof result).toBe("object");
+    expect(result).not.toBeNull();
+  });
+
+  test("Reflect.construct with implementation returning object preserves the object", () => {
+    const obj = { marker: true };
+    const fn = jest.fn(() => obj);
+    const result = Reflect.construct(fn, []);
+    expect(result).toBe(obj);
+  });
+
+  test("Reflect.construct on mockReturnThis does not crash", () => {
+    const fn = jest.fn().mockReturnThis();
+    const result = Reflect.construct(fn, []);
+    expect(result == null).toBe(false);
+    expect(typeof result === "object" || typeof result === "function").toBe(true);
+  });
+
+  test("Reflect.construct on spyOn of non-function value does not crash", () => {
+    const arr = [-62400, 1355854322, -7];
+    const spy = spyOn(arr, 1);
+    const result = Reflect.construct(spy, []);
+    expect(typeof result).toBe("object");
+    expect(result).not.toBeNull();
+    spy.mockRestore();
+  });
+
+  test("Reflect.construct respects newTarget prototype", () => {
+    const fn = jest.fn();
+    class Target {}
+    const result = Reflect.construct(fn, [], Target);
+    expect(Object.getPrototypeOf(result)).toBe(Target.prototype);
+  });
+
+  test("new on empty mock returns an object", () => {
+    const fn = jest.fn();
+    const result = new fn();
+    expect(typeof result).toBe("object");
+    expect(result).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes an `ASSERTION FAILED: isCell()` crash (SIGABRT in debug, undefined behavior in release) when calling `Reflect.construct` on a `jest.fn()` / `mock()` / `spyOn()` function whose implementation returns a primitive.

### Root cause

`JSMockFunction` registered `jsMockFunctionCall` as **both** its call and construct handler:

```cpp
Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
```

`jsMockFunctionCall` returns whatever the mock implementation produces — `undefined` for an empty `mock()`, a number for `mockReturnValue(42)`, the spied value for `spyOn(arr, 1)`, etc.

Native `[[Construct]]` handlers are required to return an object. `JSC::Interpreter::executeConstruct` unconditionally does `asObject(JSValue::decode(result))` on the return value, which asserts `isCell()` and crashes when given a primitive.

### Minimal reproduction

```js
const { mock } = Bun.jest("");
Reflect.construct(mock(), []); // ASSERTION FAILED: isCell()
```

### Fix

Add a dedicated `jsMockFunctionConstruct` entry point. It delegates to `jsMockFunctionCall`, and if the result is not an object it returns a freshly created object derived from `newTarget` (via `InternalFunction::createSubclassStructure`). This matches standard `[[Construct]]` semantics where a primitive return from a constructor is replaced with the newly-created `this`.

Note: `CallFrame::newTarget()` is an alias for `thisValue()`, so it is not usable to distinguish call from construct within a single shared handler — a separate entry point is required.

## How did you verify your code works?

- Original Fuzzilli crash script now exits cleanly.
- Added regression tests in `test/js/bun/test/mock-fn.test.js` covering `Reflect.construct` and `new` on empty mocks, `mockReturnValue`, `mockReturnThis`, implementations returning primitives/objects, `spyOn` of a non-function value, and `newTarget` prototype handling.
- All existing mock/spy tests continue to pass (`mock-fn.test.js`, `spyMatchers.test.ts`, `mock-disposable.test.ts`, `issue-1825-jest-mock-functions.test.ts`).

Fuzzer fingerprint: `da4ad3f1149e9251`