### PR TITLE
resolver: reject import paths longer than MAX_PATH_BYTES

### DIFF
--- a/src/bundler/transpiler.zig
+++ b/src/bundler/transpiler.zig
@@ -133,6 +133,10 @@ pub const Transpiler = struct {
 
             // Bust directory cache and try again
             const buster_name = name: {
+                // A path this long cannot have a cached directory entry and
+                // would overflow `cache_bust_buf` during normalization below.
+                if (entry_point.len > bun.MAX_PATH_BYTES) break :name "";
+
                 if (std.fs.path.isAbsolute(entry_point)) {
                     if (std.fs.path.dirname(entry_point)) |dir| {
                         // Normalized with trailing slash

--- a/src/bundler/transpiler.zig
+++ b/src/bundler/transpiler.zig
@@ -132,13 +132,10 @@ pub const Transpiler = struct {
             var cache_bust_buf: bun.PathBuffer = undefined;
 
             // Bust directory cache and try again
-            const buster_name = name: {
-                // A path this long cannot have a cached directory entry and
-                // would overflow `cache_bust_buf` during normalization below.
-                if (entry_point.len > bun.MAX_PATH_BYTES) break :name "";
-
+            const buster_name: string = name: {
                 if (std.fs.path.isAbsolute(entry_point)) {
                     if (std.fs.path.dirname(entry_point)) |dir| {
+                        if (dir.len > cache_bust_buf.len) break :name "";
                         // Normalized with trailing slash
                         break :name bun.strings.normalizeSlashesOnly(&cache_bust_buf, dir, std.fs.path.sep);
                     }
@@ -149,12 +146,15 @@ pub const Transpiler = struct {
                     bun.pathLiteral(".."),
                 };
 
-                break :name bun.path.joinAbsStringBufZ(
+                // `entry_point` is user-controlled and may be long enough that
+                // the unnormalized join overflows `cache_bust_buf`; the checked
+                // variant uses a heap scratch for normalization when needed.
+                break :name bun.path.joinAbsStringBufChecked(
                     transpiler.fs.top_level_dir,
                     &cache_bust_buf,
                     &parts,
                     .auto,
-                );
+                ) orelse "";
             };
 
             // Only re-query if we previously had something cached.

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -3955,6 +3955,7 @@ pub const Resolver = struct {
 
     fn loadExtension(r: *ThisResolver, base: string, path: string, ext: string, entries: *Fs.FileSystem.DirEntry) ?LoadResult {
         const rfs: *Fs.FileSystem.RealFS = &r.fs.fs;
+        if (path.len + ext.len > bufs(.load_as_file).len) return null;
         const buffer = bufs(.load_as_file)[0 .. path.len + ext.len];
         bun.copy(u8, buffer[path.len..], ext);
         const file_name = buffer[path.len - base.len .. buffer.len];

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -851,9 +851,9 @@ pub const Resolver = struct {
 
                     return .{ .not_found = {} };
                 } else if (bun.StandaloneModuleGraph.isBunStandaloneFilePath(source_dir)) {
-                    if (import_path.len > 2 and isDotSlash(import_path[0..2])) {
+                    if (import_path.len > 2 and isDotSlash(import_path[0..2])) graph_lookup: {
                         const buf = bufs(.import_path_for_standalone_module_graph);
-                        const joined = bun.path.joinAbsStringBuf(source_dir, buf, &.{import_path}, .loose);
+                        const joined = bun.path.joinAbsStringBufChecked(source_dir, buf, &.{import_path}, .loose) orelse break :graph_lookup;
 
                         // Support relative paths in the graph
                         if (graph.findAssumeStandalonePath(joined)) |file| {

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -911,8 +911,10 @@ pub const Resolver = struct {
         errdefer (r.flushDebugLogs(.fail) catch {});
 
         // A path with a null byte cannot exist on the filesystem. Continuing
-        // anyways would cause assertion failures.
-        if (bun.strings.containsChar(import_path, 0)) {
+        // anyways would cause assertion failures. Likewise, a path longer
+        // than MAX_PATH_BYTES cannot name a real file and would overflow the
+        // threadlocal path buffers used below.
+        if (import_path.len > bun.MAX_PATH_BYTES or bun.strings.containsChar(import_path, 0)) {
             r.flushDebugLogs(.fail) catch {};
             return .{ .not_found = {} };
         }

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -181,4 +181,39 @@ describe.concurrent("long import path overflow", () => {
     // Walk-up loop indexed into a fixed [256]DirEntryResolveQueueItem
     await run(String(dir), `\`/\${"a/".repeat(300)}x\``);
   });
+
+  // Specifiers where the *import path itself* is longer than MAX_PATH_BYTES.
+  // These previously overflowed threadlocal PathBuffers in loadAsFile and in
+  // the entry-point cache-bust retry in Transpiler.resolveEntryPoint.
+  const huge = `Buffer.alloc(${len * 2}, "a").toString()`;
+
+  it("Bun.resolveSync with specifier longer than PATH_MAX", async () => {
+    using dir = makeDir();
+    await run(String(dir), huge);
+  });
+
+  for (const [label, prefix] of [
+    ["bare", ""],
+    ["relative", "./"],
+    ["absolute", "/"],
+  ] as const) {
+    it(`Bun.build entrypoint longer than PATH_MAX (${label})`, async () => {
+      using dir = makeDir();
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const r = await Bun.build({ entrypoints: [${JSON.stringify(prefix)} + ${huge}], throw: false }); if (r.success) throw new Error("should have failed"); console.log("ok");`,
+        ],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("panic");
+      expect(stdout.trim()).toBe("ok");
+      expect(exitCode).toBe(0);
+    });
+  }
 });

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -187,7 +187,7 @@ describe.concurrent("long import path overflow", () => {
   // the entry-point cache-bust retry in Transpiler.resolveEntryPoint.
   const huge = `Buffer.alloc(${len * 2}, "a").toString()`;
 
-  it("Bun.resolveSync with specifier longer than PATH_MAX", async () => {
+  it("dynamic import with specifier longer than PATH_MAX", async () => {
     using dir = makeDir();
     await run(String(dir), huge);
   });
@@ -211,7 +211,7 @@ describe.concurrent("long import path overflow", () => {
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).not.toContain("panic");
+      expect(stderr).toBe("");
       expect(stdout.trim()).toBe("ok");
       expect(exitCode).toBe(0);
     });


### PR DESCRIPTION
Found by Fuzzilli. Fingerprint: `panic:index out of bounds: index 6851, len 4095`

### What
Passing an entrypoint/import specifier longer than `MAX_PATH_BYTES` to `Bun.build` (or the resolver) panicked with `index out of bounds` when the path was copied into fixed-size threadlocal `bun.PathBuffer` arrays — specifically in `loadAsFile` (`bufs(.load_as_file)`) and in the entry-point cache-bust retry in `Transpiler.resolveEntryPoint` when joining into `cache_bust_buf`.

Repro:
```js
await Bun.build({ entrypoints: [Buffer.alloc(8000, "a").toString()] });
```

### Fix
- In `resolveAndAutoInstall`, return `.not_found` when `import_path.len > bun.MAX_PATH_BYTES`, alongside the existing null-byte check. This runs *after* data URLs, http(s) URLs, and external patterns are handled, so long non-filesystem specifiers are unaffected.
- In `Transpiler.resolveEntryPoint`, skip the directory-cache-bust retry when the entry point is longer than `MAX_PATH_BYTES` (nothing to bust, and the join into `cache_bust_buf` would overflow).

Added tests to the existing `long import path overflow` block in `test/js/bun/resolve/resolve-error.test.ts` covering bare/relative/absolute oversized entrypoints and `Bun.resolveSync`.