### PR TITLE
install: disable isolated global virtual store by default until no longer experimental

### DIFF
--- a/docs/pm/global-store.mdx
+++ b/docs/pm/global-store.mdx
@@ -11,30 +11,23 @@ The result: warm installs are roughly **7× faster** (one symlink per package in
 
 ## Enabling
 
-The global virtual store is **on by default** with the isolated linker on every platform. It is not used by the hoisted linker.
+The global virtual store is **off by default**. It only applies to the isolated linker; it is not used by the hoisted linker.
 
-```bash terminal icon="terminal"
-bun install --linker isolated
-```
-
-To make isolated the default for a project:
+To enable it for a project:
 
 ```toml title="bunfig.toml" icon="settings"
 [install]
 linker = "isolated"
+globalStore = true
 ```
 
-To opt out and fall back to per-project package copies:
-
-```toml title="bunfig.toml" icon="settings"
-[install]
-linker = "isolated"
-globalStore = false
-```
+Or per-invocation via the environment:
 
 ```bash terminal icon="terminal"
-BUN_INSTALL_GLOBAL_STORE=0 bun install --linker isolated
+BUN_INSTALL_GLOBAL_STORE=1 bun install --linker isolated
 ```
+
+To explicitly opt out (the default), set `globalStore = false` or `BUN_INSTALL_GLOBAL_STORE=0`.
 
 ## Why it's fast
 

--- a/docs/pm/isolated-installs.mdx
+++ b/docs/pm/isolated-installs.mdx
@@ -124,11 +124,11 @@ The directory name encodes both the package version and its peer dependency vers
 
 ### Global virtual store
 
-By default, store entries are materialized once into a [global virtual store](/pm/global-store) at `<cache>/links/` and `node_modules/.bun/<pkg>@<ver>` is a symlink into it. Warm installs after `rm -rf node_modules` only create one symlink per package instead of copying every package's files again, which is roughly **7× faster** on a typical mid-size project. See the [global store docs](/pm/global-store) for the full layout, benchmarks, and tradeoffs.
+When [`install.globalStore`](/runtime/bunfig#install-globalstore) is enabled, store entries are materialized once into a [global virtual store](/pm/global-store) at `<cache>/links/` and `node_modules/.bun/<pkg>@<ver>` is a symlink into it. Warm installs after `rm -rf node_modules` only create one symlink per package instead of copying every package's files again, which is roughly **7× faster** on a typical mid-size project. The global store is **off by default**; see the [global store docs](/pm/global-store) for how to enable it, the full layout, benchmarks, and tradeoffs.
 
 ### Backend strategies
 
-When an entry isn't eligible for the global store (or the global store is disabled), Bun materializes it under the project using one of:
+When the global store is disabled (the default) or an entry isn't eligible for it, Bun materializes the entry under the project using one of:
 
 - **Clonefile** (macOS) — Copy-on-write filesystem clones for maximum efficiency
 - **Hardlink** (Linux/Windows) — Hardlinks to save disk space

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -671,13 +671,13 @@ Valid values are:
 
 ### `install.globalStore`
 
-When using the `"isolated"` linker, share package installations across projects in a global virtual store at `<cache>/links/` and link `node_modules/.bun/<pkg>@<ver>` into it instead of materializing each package into the project. Makes warm installs after `rm -rf node_modules` an order of magnitude faster. Default `true`. Can also be set with the `BUN_INSTALL_GLOBAL_STORE` environment variable.
+When using the `"isolated"` linker, share package installations across projects in a global virtual store at `<cache>/links/` and link `node_modules/.bun/<pkg>@<ver>` into it instead of materializing each package into the project. Makes warm installs after `rm -rf node_modules` an order of magnitude faster. Default `false`. Can also be set with the `BUN_INSTALL_GLOBAL_STORE` environment variable.
 
 For complete documentation refer to [Package manager > Global virtual store](/pm/global-store).
 
 ```toml title="bunfig.toml" icon="settings"
 [install]
-globalStore = false
+globalStore = true
 ```
 
 ### `install.publicHoistPattern`

--- a/src/install/PackageManager/PackageManagerOptions.zig
+++ b/src/install/PackageManager/PackageManagerOptions.zig
@@ -726,8 +726,9 @@ pub const Enable = packed struct(u16) {
     /// Isolated linker only: materialize package entries once into a shared
     /// `<cache>/links/` directory and symlink `node_modules/.bun/<pkg>` into
     /// it, instead of clonefiling every package into every project on every
-    /// install. Set BUN_INSTALL_GLOBAL_STORE=0 to disable.
-    global_virtual_store: bool = true,
+    /// install. Off by default; set BUN_INSTALL_GLOBAL_STORE=1 or
+    /// `install.globalStore = true` in bunfig to enable.
+    global_virtual_store: bool = false,
     _: u6 = 0,
 };
 

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1376,8 +1376,69 @@ test("transitive peer deps are resolved when resolution is fully synchronous", a
 });
 
 describe("global virtual store", () => {
-  test("survives node_modules wipe", async () => {
+  // The global virtual store is off by default; tests that exercise it opt
+  // in via bunfig `install.globalStore = true`.
+  const gvsBunfigOpts = { linker: "isolated", globalStore: true } as const;
+
+  test("is disabled by default", async () => {
     const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-global-store-default-off",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+
+    // With the global store disabled (the default) the entry is a real
+    // directory under `node_modules/.bun/` (the pre-global-store layout).
+    const entry = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0");
+    expect(lstatSync(entry).isSymbolicLink()).toBe(false);
+    expect(lstatSync(entry).isDirectory()).toBe(true);
+    expect(existsSync(join(entry, "node_modules", "no-deps", "package.json"))).toBe(true);
+  });
+
+  test("can be enabled via BUN_INSTALL_GLOBAL_STORE=1", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-global-store-on-env",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+    );
+
+    await runBunInstall({ ...bunEnv, BUN_INSTALL_GLOBAL_STORE: "1" }, packageDir);
+
+    const entry = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0");
+    expect(lstatSync(entry).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(entry)).toMatch(/links[\/\\]no-deps@1\.0\.0-[0-9a-f]{16}$/);
+  });
+
+  test("can be enabled via bunfig install.globalStore", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-global-store-on-bunfig",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+
+    const entry = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0");
+    expect(lstatSync(entry).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(entry)).toMatch(/links[\/\\]no-deps@1\.0\.0-[0-9a-f]{16}$/);
+  });
+
+  test("survives node_modules wipe", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
 
     await write(
       packageJson,
@@ -1426,7 +1487,7 @@ describe("global virtual store", () => {
   });
 
   test("--force replaces a corrupted global-store entry", async () => {
-    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
 
     await write(
       packageJson,
@@ -1489,8 +1550,8 @@ describe("global virtual store", () => {
     expect(siblings.some(n => n.includes(".old-") || n.includes(".tmp-"))).toBe(false);
   });
 
-  test("can be disabled via BUN_INSTALL_GLOBAL_STORE=0", async () => {
-    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+  test("BUN_INSTALL_GLOBAL_STORE=0 overrides bunfig globalStore = true", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
 
     await write(
       packageJson,
@@ -1510,28 +1571,8 @@ describe("global virtual store", () => {
     expect(existsSync(join(entry, "node_modules", "no-deps", "package.json"))).toBe(true);
   });
 
-  test("can be disabled via bunfig install.globalStore", async () => {
-    const { packageJson, packageDir } = await registry.createTestDir({
-      bunfigOpts: { linker: "isolated", globalStore: false },
-    });
-
-    await write(
-      packageJson,
-      JSON.stringify({
-        name: "test-pkg-global-store-off-bunfig",
-        dependencies: { "no-deps": "1.0.0" },
-      }),
-    );
-
-    await runBunInstall(bunEnv, packageDir);
-
-    const entry = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0");
-    expect(lstatSync(entry).isSymbolicLink()).toBe(false);
-    expect(lstatSync(entry).isDirectory()).toBe(true);
-  });
-
   test("entry hash is deterministic across fresh installs", async () => {
-    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
 
     await write(
       packageJson,
@@ -1563,8 +1604,8 @@ describe("global virtual store", () => {
     // versions of one of its transitive deps must NOT share a global entry —
     // the dep symlink inside the entry would point at the wrong version for
     // one of them.
-    const a = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
-    const b = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const a = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
+    const b = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
 
     await write(
       a.packageJson,
@@ -1605,8 +1646,8 @@ describe("global virtual store", () => {
   });
 
   test("two projects with the same closure share one global entry", async () => {
-    const a = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
-    const b = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const a = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
+    const b = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
 
     for (const { packageJson } of [a, b]) {
       await write(
@@ -1634,7 +1675,7 @@ describe("global virtual store", () => {
     // dangling for any other project that shared the entry. The eligibility
     // check propagates: an entry that links to anything project-local is
     // itself project-local.
-    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
 
     await mkdir(join(packageDir, "packages", "ws-pkg"), { recursive: true });
     await write(
@@ -1663,7 +1704,7 @@ describe("global virtual store", () => {
   });
 
   test("packages with trusted lifecycle scripts stay project-local", async () => {
-    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
 
     await write(
       packageJson,
@@ -1699,15 +1740,15 @@ describe("global virtual store", () => {
     // Two `bun install` processes may race to create the same content-addressed
     // global entry; the loser sees EEXIST from clonefile/symlink/bin-link and
     // must treat it as success rather than failing the install.
-    const a = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
-    const b = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const a = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
+    const b = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
 
     // Both projects must share one cache for the race to be real; the harness
     // gives each test dir its own `.bun-cache/` by default.
     const sharedCache = join(a.packageDir, ".bun-cache");
     await write(
       join(b.packageDir, "bunfig.toml"),
-      `[install]\ncache = "${sharedCache.replaceAll("\\", "\\\\")}"\nregistry = "${registry.registryUrl()}"\nlinker = "isolated"\n`,
+      `[install]\ncache = "${sharedCache.replaceAll("\\", "\\\\")}"\nregistry = "${registry.registryUrl()}"\nlinker = "isolated"\nglobalStore = true\n`,
     );
 
     for (const { packageJson } of [a, b]) {
@@ -1760,7 +1801,7 @@ describe("global virtual store", () => {
     // `<entry>/` as the final step, so a published entry is always complete.
     // A crashed earlier install can leave a staging directory behind; the
     // warm-hit check must look at the final path only.
-    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
 
     await write(
       packageJson,
@@ -1796,7 +1837,7 @@ describe("global virtual store", () => {
     // resolver would then `ReadFile` a directory. Exercising an actual
     // `require()` through a transitive dep proves the chain resolves
     // end-to-end on every platform.
-    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
 
     await write(
       packageJson,
@@ -1841,7 +1882,7 @@ describe("global virtual store", () => {
     // the shared cache. On Windows the `.expect_missing` dep-symlink rewrite
     // then baked a project-absolute junction target into the shared entry,
     // which dangled after `rm -rf node_modules`.
-    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
 
     await write(
       packageJson,
@@ -1883,7 +1924,7 @@ describe("global virtual store", () => {
     // real directory. Re-running install with the global store enabled must
     // replace that directory with a symlink (not fail with EEXIST or leave the
     // stale tree behind).
-    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
 
     await write(
       packageJson,
@@ -1909,7 +1950,7 @@ describe("global virtual store", () => {
     // A subsequent `bun install` (e.g. to add another dep) before `--commit`
     // must not see that real directory as a stale pre-GVS layout and
     // `deleteTree` the user's in-progress edits.
-    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
 
     await write(
       packageJson,


### PR DESCRIPTION
## What

Flip the default for the isolated linker's global virtual store from **on** to **off**. It is now opt-in.

## Why

The global virtual store (`<cache>/links/`) shares package installs across projects by symlinking `node_modules/.bun/<pkg>@<ver>` into a machine-wide cache directory. While this makes warm installs much faster, it changes module-resolution realpaths in a way that can surprise tooling that doesn't follow symlinks, and breaks the phantom-dependency fallback through `node_modules/.bun/node_modules/`. Disabling it by default restores the more compatible per-project layout; users who want the speedup can opt in.

## How to enable

```toml
# bunfig.toml
[install]
linker = "isolated"
globalStore = true
```

or

```sh
BUN_INSTALL_GLOBAL_STORE=1 bun install --linker isolated
```

Both of these already existed; only the default changed.

## Changes

- `src/install/PackageManager/PackageManagerOptions.zig`: `Enable.global_virtual_store` now defaults to `false`.
- `test/cli/install/isolated-install.test.ts`: the `global virtual store` describe block now explicitly opts in via `{ linker: "isolated", globalStore: true }`. Added tests that it is disabled by default and can be enabled via env var / bunfig; replaced the old "can be disabled" tests with an env-overrides-bunfig check.
- `docs/pm/global-store.mdx`, `docs/runtime/bunfig.mdx`: document the new default and show opt-in examples.

## Verification

```
# without src/ change:
(fail) global virtual store > is disabled by default   # entry is a symlink

# with src/ change:
(pass) global virtual store > is disabled by default
# all 46 tests in isolated-install.test.ts pass
```