### PR TITLE
webview: put Chrome in its own process group so closeAll() reaps helpers

### DIFF
--- a/src/runtime/webview/ChromeProcess.zig
+++ b/src/runtime/webview/ChromeProcess.zig
@@ -24,13 +24,27 @@ process: *bun.spawn.Process,
 var instance: ?*ChromeProcess = null;
 
 /// Called from WebView.closeAll() and dispatchOnExit. Chrome spawns its own
-/// renderer/gpu/utility children (the "process model" zygote tree) — tracked
-/// by Chrome's own ProcessSingleton, they exit when the browser process
-/// dies. SIGKILL here takes the browser process, the zygote tree follows.
-/// The C++ side doesn't touch JS state; EVFILT_PROC → Bun__Chrome__died →
-/// rejectAllAndMarkDead handles promise rejection on the next loop tick.
+/// renderer/gpu/utility/crashpad children; only zygote-forked renderers get
+/// PR_SET_PDEATHSIG from the browser (base/process/launch_posix.cc's
+/// `kill_on_parent_death` is opt-in and most helpers skip it). Signalling
+/// the browser pid alone leaves GPU/network/utility/crashpad reparented to
+/// PID 1 on Linux — in a container where PID 1 isn't a real init, they
+/// accumulate forever (#30475).
+///
+/// Spawn sets `new_process_group = true`, so the browser is the leader of
+/// its own pgroup (pgid == pid) and every helper inherits that pgid.
+/// `kill(-pid, SIGKILL)` on POSIX takes the whole tree down atomically;
+/// the browser's own exit path still runs and EVFILT_PROC → Bun__Chrome__died
+/// → rejectAllAndMarkDead handles promise rejection on the next loop tick.
 pub export fn Bun__Chrome__kill() void {
-    if (instance) |i| {
+    const i = instance orelse return;
+    if (comptime bun.Environment.isPosix) {
+        // kill(-pgid, sig) signals every process in the group. Chrome is
+        // the group leader because of the setpgid(0, 0) done in the child
+        // before exec (SpawnOptions.new_process_group). ESRCH — the group
+        // is already gone — is a no-op, same as the single-pid path.
+        _ = std.c.kill(-i.process.pid, std.posix.SIG.KILL);
+    } else {
         _ = i.process.kill(9);
     }
 }
@@ -329,6 +343,13 @@ fn spawn(vm: *jsc.VirtualMachine, userDataDir: ?[*:0]const u8, explicitPath: ?[*
         // the same socket at both positions.
         .extra_fds = &.{ .{ .pipe = fds[1] }, .{ .pipe = fds[1] } },
         .argv0 = chrome.ptr,
+        // setpgid(0, 0) in the child so Chrome leads its own process
+        // group. Bun__Chrome__kill then does kill(-pid, SIGKILL) to reap
+        // GPU/network/utility/crashpad helpers along with the browser
+        // (they only get PR_SET_PDEATHSIG from the browser for zygote-
+        // forked renderers; everything else would reparent to PID 1 on
+        // Linux otherwise — see #30475).
+        .new_process_group = true,
     };
 
     var spawned = try (try bun.spawn.spawnProcess(

--- a/src/runtime/webview/ChromeProcess.zig
+++ b/src/runtime/webview/ChromeProcess.zig
@@ -83,6 +83,18 @@ pub export fn Bun__Chrome__ensure(
 
 pub fn onProcessExit(this: *ChromeProcess, _: *bun.spawn.Process, status: bun.spawn.Status, _: *const bun.spawn.Rusage) void {
     log("chrome exited: {f}", .{status});
+    // Browser-crash path: segfault, OOM, external SIGKILL. Bun__Chrome__kill
+    // only runs from closeAll() / dispatchOnExit — a straight-up browser
+    // crash never goes through it, so without a pgroup-kill here the
+    // helpers lose their parent-death coupling and reparent to PID 1 (same
+    // #30475 leak, different trigger). Same setpgid(0, 0) at spawn makes
+    // the browser the pgroup leader; signalling -pid reaches every helper
+    // that inherited that pgid. ESRCH is harmless if no helper survived
+    // the browser's own death. Must happen BEFORE deref/destroy — after
+    // destroy `this` is freed and the pid is gone.
+    if (comptime bun.Environment.isPosix) {
+        _ = std.c.kill(-this.process.pid, std.posix.SIG.KILL);
+    }
     const signo: i32 = if (status.signalCode()) |sig| @intFromEnum(sig) else 0;
     Bun__Chrome__died(signo);
     this.process.deref();

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isCI, isMacOS, isMacOSVersionAtLeast } from "harness";
+import { bunEnv, bunExe, isCI, isMacOS, isMacOSVersionAtLeast, isPosix, tempDir } from "harness";
 
 // Chrome backend works on any platform with Chrome/Chromium installed.
 // Mark tests todo if no Chrome found (CI may not have it). Mirrors
@@ -506,6 +506,76 @@ test("WebView.closeAll is a static function", () => {
   expect(typeof Bun.WebView.closeAll).toBe("function");
   // No-op when no subprocesses are alive — verifies the idempotent fast path.
   Bun.WebView.closeAll();
+});
+
+// #30475 — closeAll() must reach the browser's helpers (renderer, GPU,
+// network, utility, crashpad) and not just the main browser pid. Real
+// Chrome doesn't opt in to PR_SET_PDEATHSIG on most of its helpers, so
+// they'd reparent to PID 1 when the browser-only SIGKILL runs. This uses
+// a stand-in "fake chrome" shell script that forks two children then
+// blocks on fd 3 (where Bun's socketpair lands); the three pids stand in
+// for the browser + two helpers. With the fix (setpgid in the child,
+// kill(-pid, SIGKILL) on teardown) all three die together; without it,
+// only the shell dies and the sleep children leak.
+test.skipIf(!isPosix)("chrome: closeAll() reaps the whole process group (#30475)", async () => {
+  using dir = tempDir("chrome-closeall-pgid", {
+    // /bin/sh `&` job-control still inherits pgid, so the sleeps land in
+    // the same group as the shell. `exec cat <&3` replaces the shell with
+    // cat (same pid, so the browser "pid" the test sees is stable) and
+    // parks on the socketpair fd Bun dup2'd into position 3.
+    "fake-chrome.sh":
+      "#!/bin/sh\n" +
+      'sleep 3600 &\nC1=$!\n' +
+      'sleep 3600 &\nC2=$!\n' +
+      'printf "%d %d %d" "$$" "$C1" "$C2" > "$PID_OUT"\n' +
+      "exec cat <&3 >/dev/null\n",
+    "driver.ts":
+      'import { chmodSync, existsSync, readFileSync } from "node:fs";\n' +
+      'chmodSync("./fake-chrome.sh", 0o755);\n' +
+      "const view = new Bun.WebView({\n" +
+      '  backend: { type: "chrome", path: "./fake-chrome.sh", url: false },\n' +
+      "  width: 100, height: 100,\n" +
+      "});\n" +
+      // fake-chrome writes its pid-trio asynchronously from exec; poll.
+      "const deadline0 = Date.now() + 5000;\n" +
+      'while (Date.now() < deadline0 && !existsSync("pids.txt")) await Bun.sleep(10);\n' +
+      'const pids = readFileSync("pids.txt", "utf8").trim().split(" ").map(Number);\n' +
+      'if (pids.length !== 3 || pids.some(p => !p)) throw new Error("bad pids: " + JSON.stringify(pids));\n' +
+      "const isAlive = (p) => { try { process.kill(p, 0); return true; } catch { return false; } };\n" +
+      // Prove all three are alive first — otherwise a vacuously empty
+      // survivor list would "pass" even if the test is broken.
+      'const beforeDead = pids.filter(p => !isAlive(p));\n' +
+      'if (beforeDead.length) throw new Error("dead before closeAll: " + JSON.stringify(beforeDead));\n' +
+      "Bun.WebView.closeAll();\n" +
+      // Poll for every pid to be gone. kill(-pgid, SIGKILL) is delivered
+      // synchronously from closeAll(), but wait() to reap the zombies
+      // runs on the event loop tick after; kill(pid, 0) returns ESRCH
+      // as soon as the task is killed, independent of reaping.
+      "const deadline = Date.now() + 5000;\n" +
+      "while (Date.now() < deadline && pids.some(isAlive)) await Bun.sleep(25);\n" +
+      "const survivors = pids.filter(isAlive);\n" +
+      // Diagnostic: if anything survives, reap from the test so the sleep
+      // doesn't keep the container dirty for the rest of the run.
+      "for (const p of survivors) { try { process.kill(p, 9); } catch {} }\n" +
+      "console.log(JSON.stringify(survivors));\n",
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "driver.ts"],
+    env: { ...bunEnv, PID_OUT: `${dir}/pids.txt` },
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  // Zero survivors: browser + both "helpers" died together. With the bug
+  // the two sleeps survive (reparented to PID 1); with the fix they're
+  // reaped via kill(-pgid, SIGKILL).
+  if (exitCode !== 0) console.error(stderr);
+  expect(stdout.trim()).toBe("[]");
+  expect(exitCode).toBe(0);
 });
 
 it("chrome: closeAll() kills the subprocess and pending promises reject", async () => {

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -525,8 +525,8 @@ test.skipIf(!isPosix)("chrome: closeAll() reaps the whole process group (#30475)
     // parks on the socketpair fd Bun dup2'd into position 3.
     "fake-chrome.sh":
       "#!/bin/sh\n" +
-      'sleep 3600 &\nC1=$!\n' +
-      'sleep 3600 &\nC2=$!\n' +
+      "sleep 3600 &\nC1=$!\n" +
+      "sleep 3600 &\nC2=$!\n" +
       'printf "%d %d %d" "$$" "$C1" "$C2" > "$PID_OUT"\n' +
       "exec cat <&3 >/dev/null\n",
     "driver.ts":
@@ -544,7 +544,7 @@ test.skipIf(!isPosix)("chrome: closeAll() reaps the whole process group (#30475)
       "const isAlive = (p) => { try { process.kill(p, 0); return true; } catch { return false; } };\n" +
       // Prove all three are alive first — otherwise a vacuously empty
       // survivor list would "pass" even if the test is broken.
-      'const beforeDead = pids.filter(p => !isAlive(p));\n' +
+      "const beforeDead = pids.filter(p => !isAlive(p));\n" +
       'if (beforeDead.length) throw new Error("dead before closeAll: " + JSON.stringify(beforeDead));\n' +
       "Bun.WebView.closeAll();\n" +
       // Poll for every pid to be gone. kill(-pgid, SIGKILL) is delivered
@@ -565,11 +565,7 @@ test.skipIf(!isPosix)("chrome: closeAll() reaps the whole process group (#30475)
     cwd: String(dir),
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   // Zero survivors: browser + both "helpers" died together. With the bug
   // the two sleeps survive (reparented to PID 1); with the fix they're
   // reaped via kill(-pgid, SIGKILL).

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -511,53 +511,91 @@ test("WebView.closeAll is a static function", () => {
 // #30475 — closeAll() must reach the browser's helpers (renderer, GPU,
 // network, utility, crashpad) and not just the main browser pid. Real
 // Chrome doesn't opt in to PR_SET_PDEATHSIG on most of its helpers, so
-// they'd reparent to PID 1 when the browser-only SIGKILL runs. This uses
-// a stand-in "fake chrome" shell script that forks two children then
-// blocks on fd 3 (where Bun's socketpair lands); the three pids stand in
-// for the browser + two helpers. With the fix (setpgid in the child,
-// kill(-pid, SIGKILL) on teardown) all three die together; without it,
-// only the shell dies and the sleep children leak.
+// they'd reparent to PID 1 when the browser-only SIGKILL runs. Two
+// tests share the same fake-chrome fixture (a shell script that forks
+// two `sleep` children standing in for helpers, then parks on fd 3):
+//   1. closeAll() path — the explicit teardown from user code.
+//   2. browser-crash path — Chrome exits on its own (onProcessExit).
+// With the fix both paths kill(-pgid, SIGKILL); without either one,
+// the two sleeps leak.
+
+// A "dead" pid has two phases: task killed (kill(pid, 0) → 0, zombie
+// remains in the process table) then reaped (kill(pid, 0) → ESRCH).
+// Test a container that doesn't reap PID-1-adopted zombies (test runs
+// under bun, not an init) — so treat state 'Z' as dead on Linux.
+// macOS: no /proc. launchd reaps orphans eventually; kill(pid, 0) is
+// the only signal we have. Same helper is used by both tests below.
+const isDeadHelper = [
+  "import { readFileSync } from 'node:fs';",
+  "const isReapedOrZombie = (p) => {",
+  "  try { process.kill(p, 0); }",
+  "  catch { return true; }", // ESRCH — reaped (or never existed)
+  "  if (process.platform !== 'linux') return false;",
+  // /proc/<pid>/stat line: "<pid> (<comm>) <state> ..." — `comm` may
+  // contain spaces or parens; scan from the LAST ')' to skip it safely.
+  "  try {",
+  "    const s = readFileSync('/proc/' + p + '/stat', 'utf8');",
+  "    const i = s.lastIndexOf(')');",
+  "    return i > 0 && s[i + 2] === 'Z';",
+  "  } catch { return true; }", // /proc entry gone → reaped
+  "};",
+].join("\n");
+
+const fakeChrome =
+  "#!/bin/sh\n" +
+  "sleep 3600 &\nC1=$!\n" +
+  "sleep 3600 &\nC2=$!\n" +
+  'printf "%d %d %d" "$$" "$C1" "$C2" > "$PID_OUT"\n' +
+  // $TRIGGER: empty = park forever (closeAll path). non-empty = poll
+  // for the trigger file, then SIGKILL ourselves to simulate a browser
+  // crash (onProcessExit path). `exec cat <&3` so the main pid keeps
+  // stdin-reading from Bun's socketpair in the park-forever case.
+  'if [ -n "$TRIGGER" ]; then\n' +
+  '  while [ ! -e "$TRIGGER" ]; do sleep 0.05; done\n' +
+  "  kill -9 $$\n" +
+  "else\n" +
+  "  exec cat <&3 >/dev/null\n" +
+  "fi\n";
+
+function driver({ triggerCrash }: { triggerCrash: boolean }): string {
+  return [
+    "import { chmodSync, existsSync, readFileSync, writeFileSync } from 'node:fs';",
+    isDeadHelper,
+    "chmodSync('./fake-chrome.sh', 0o755);",
+    "const view = new Bun.WebView({",
+    "  backend: { type: 'chrome', path: './fake-chrome.sh', url: false },",
+    "  width: 100, height: 100,",
+    "});",
+    // pid-trio is written after the shell forks; poll.
+    "const pidsDeadline = Date.now() + 5000;",
+    "while (Date.now() < pidsDeadline && !existsSync('pids.txt')) await Bun.sleep(10);",
+    "const pids = readFileSync('pids.txt', 'utf8').trim().split(' ').map(Number);",
+    "if (pids.length !== 3 || pids.some(p => !p)) throw new Error('bad pids: ' + JSON.stringify(pids));",
+    // Sanity: every pid must be alive right now. A vacuously empty
+    // survivor list at the end would "pass" even if the fixture broke.
+    "const beforeDead = pids.filter(isReapedOrZombie);",
+    "if (beforeDead.length) throw new Error('dead before trigger: ' + JSON.stringify(beforeDead));",
+    triggerCrash
+      ? // Trigger the browser-crash path: fake-chrome SIGKILLs itself,
+        // Bun's EVFILT_PROC → onProcessExit fires (which must then
+        // kill(-pgid, SIGKILL) to reach the sleep helpers).
+        "writeFileSync('go', '1');"
+      : // Trigger the closeAll path.
+        "Bun.WebView.closeAll();",
+    "const deadline = Date.now() + 5000;",
+    "while (Date.now() < deadline && !pids.every(isReapedOrZombie)) await Bun.sleep(25);",
+    "const survivors = pids.filter(p => !isReapedOrZombie(p));",
+    // Cleanup: anything that survived shouldn't be our problem to
+    // inherit, so reap.
+    "for (const p of survivors) { try { process.kill(p, 9); } catch {} }",
+    "console.log(JSON.stringify(survivors));",
+  ].join("\n");
+}
+
 test.skipIf(!isPosix)("chrome: closeAll() reaps the whole process group (#30475)", async () => {
   using dir = tempDir("chrome-closeall-pgid", {
-    // /bin/sh `&` job-control still inherits pgid, so the sleeps land in
-    // the same group as the shell. `exec cat <&3` replaces the shell with
-    // cat (same pid, so the browser "pid" the test sees is stable) and
-    // parks on the socketpair fd Bun dup2'd into position 3.
-    "fake-chrome.sh":
-      "#!/bin/sh\n" +
-      "sleep 3600 &\nC1=$!\n" +
-      "sleep 3600 &\nC2=$!\n" +
-      'printf "%d %d %d" "$$" "$C1" "$C2" > "$PID_OUT"\n' +
-      "exec cat <&3 >/dev/null\n",
-    "driver.ts":
-      'import { chmodSync, existsSync, readFileSync } from "node:fs";\n' +
-      'chmodSync("./fake-chrome.sh", 0o755);\n' +
-      "const view = new Bun.WebView({\n" +
-      '  backend: { type: "chrome", path: "./fake-chrome.sh", url: false },\n' +
-      "  width: 100, height: 100,\n" +
-      "});\n" +
-      // fake-chrome writes its pid-trio asynchronously from exec; poll.
-      "const deadline0 = Date.now() + 5000;\n" +
-      'while (Date.now() < deadline0 && !existsSync("pids.txt")) await Bun.sleep(10);\n' +
-      'const pids = readFileSync("pids.txt", "utf8").trim().split(" ").map(Number);\n' +
-      'if (pids.length !== 3 || pids.some(p => !p)) throw new Error("bad pids: " + JSON.stringify(pids));\n' +
-      "const isAlive = (p) => { try { process.kill(p, 0); return true; } catch { return false; } };\n" +
-      // Prove all three are alive first — otherwise a vacuously empty
-      // survivor list would "pass" even if the test is broken.
-      "const beforeDead = pids.filter(p => !isAlive(p));\n" +
-      'if (beforeDead.length) throw new Error("dead before closeAll: " + JSON.stringify(beforeDead));\n' +
-      "Bun.WebView.closeAll();\n" +
-      // Poll for every pid to be gone. kill(-pgid, SIGKILL) is delivered
-      // synchronously from closeAll(), but wait() to reap the zombies
-      // runs on the event loop tick after; kill(pid, 0) returns ESRCH
-      // as soon as the task is killed, independent of reaping.
-      "const deadline = Date.now() + 5000;\n" +
-      "while (Date.now() < deadline && pids.some(isAlive)) await Bun.sleep(25);\n" +
-      "const survivors = pids.filter(isAlive);\n" +
-      // Diagnostic: if anything survives, reap from the test so the sleep
-      // doesn't keep the container dirty for the rest of the run.
-      "for (const p of survivors) { try { process.kill(p, 9); } catch {} }\n" +
-      "console.log(JSON.stringify(survivors));\n",
+    "fake-chrome.sh": fakeChrome,
+    "driver.ts": driver({ triggerCrash: false }),
   });
   await using proc = Bun.spawn({
     cmd: [bunExe(), "driver.ts"],
@@ -566,9 +604,29 @@ test.skipIf(!isPosix)("chrome: closeAll() reaps the whole process group (#30475)
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  // Zero survivors: browser + both "helpers" died together. With the bug
-  // the two sleeps survive (reparented to PID 1); with the fix they're
-  // reaped via kill(-pgid, SIGKILL).
+  if (exitCode !== 0) console.error(stderr);
+  // Zero survivors: browser + both helpers died together via kill(-pgid).
+  // Without the fix the two sleep children survive the browser-only kill.
+  expect(stdout.trim()).toBe("[]");
+  expect(exitCode).toBe(0);
+});
+
+test.skipIf(!isPosix)("chrome: onProcessExit reaps helpers when the browser crashes (#30475)", async () => {
+  // Same fixture, but the "browser" SIGKILLs itself — simulates a
+  // segfault / OOM / external kill. Bun__Chrome__kill isn't called in
+  // this path; onProcessExit must do the pgroup-kill itself or the
+  // helpers leak to PID 1 just like the closeAll path before the fix.
+  using dir = tempDir("chrome-crash-pgid", {
+    "fake-chrome.sh": fakeChrome,
+    "driver.ts": driver({ triggerCrash: true }),
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "driver.ts"],
+    env: { ...bunEnv, PID_OUT: `${dir}/pids.txt`, TRIGGER: `${dir}/go` },
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   if (exitCode !== 0) console.error(stderr);
   expect(stdout.trim()).toBe("[]");
   expect(exitCode).toBe(0);

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -525,8 +525,10 @@ test("WebView.closeAll is a static function", () => {
 // under bun, not an init) — so treat state 'Z' as dead on Linux.
 // macOS: no /proc. launchd reaps orphans eventually; kill(pid, 0) is
 // the only signal we have. Same helper is used by both tests below.
+// `readFileSync` comes from the driver's outer import (spec says you
+// can't bind the same name twice from one module), so this helper
+// only declares the function.
 const isDeadHelper = [
-  "import { readFileSync } from 'node:fs';",
   "const isReapedOrZombie = (p) => {",
   "  try { process.kill(p, 0); }",
   "  catch { return true; }", // ESRCH — reaped (or never existed)
@@ -559,18 +561,30 @@ const fakeChrome =
 
 function driver({ triggerCrash }: { triggerCrash: boolean }): string {
   return [
-    "import { chmodSync, existsSync, readFileSync, writeFileSync } from 'node:fs';",
+    "import { chmodSync, readFileSync, writeFileSync } from 'node:fs';",
     isDeadHelper,
     "chmodSync('./fake-chrome.sh', 0o755);",
     "const view = new Bun.WebView({",
     "  backend: { type: 'chrome', path: './fake-chrome.sh', url: false },",
     "  width: 100, height: 100,",
     "});",
-    // pid-trio is written after the shell forks; poll.
+    // Poll for the pid-trio. Shell `> $PID_OUT` O_CREAT|O_TRUNCs the
+    // file BEFORE printf writes — a plain existsSync() can see it
+    // empty. Read the content on every tick and bail only when we
+    // actually have three numeric pids.
     "const pidsDeadline = Date.now() + 5000;",
-    "while (Date.now() < pidsDeadline && !existsSync('pids.txt')) await Bun.sleep(10);",
-    "const pids = readFileSync('pids.txt', 'utf8').trim().split(' ').map(Number);",
-    "if (pids.length !== 3 || pids.some(p => !p)) throw new Error('bad pids: ' + JSON.stringify(pids));",
+    "let pids = [];",
+    "while (Date.now() < pidsDeadline) {",
+    "  try {",
+    "    const parsed = readFileSync('pids.txt', 'utf8').trim().split(' ').map(Number);",
+    "    if (parsed.length === 3 && parsed.every(p => Number.isFinite(p) && p > 0)) {",
+    "      pids = parsed;",
+    "      break;",
+    "    }",
+    "  } catch {}", // ENOENT while the shell still hasn't opened the redirect
+    "  await Bun.sleep(10);",
+    "}",
+    "if (pids.length !== 3) throw new Error('timed out waiting for pids');",
     // Sanity: every pid must be alive right now. A vacuously empty
     // survivor list at the end would "pass" even if the fixture broke.
     "const beforeDead = pids.filter(isReapedOrZombie);",


### PR DESCRIPTION
## Repro

```ts
// leak.ts — bun leak.ts
for (let i = 0; i < 5; i++) {
  const view = new Bun.WebView({
    backend: { type: 'chrome', path: '/usr/bin/chromium', url: false,
               argv: ['--no-sandbox', '--disable-gpu', '--headless'] },
    width: 200, height: 200,
  });
  await view.navigate('file:///tmp/x.html');
  await view.screenshot({ format: 'png' });
  await view.close();
  Bun.WebView.closeAll();
}
console.log(Bun.spawnSync(['ps','-e','-o','pid,ppid,comm']).stdout.toString());
```

After 5 iterations `ps` showed 10-15 `chromium` + several `chrome_crashpad` processes with `PPID=1`.

## Cause

`ChromeProcess.zig` spawned Chrome without `new_process_group`, and `Bun__Chrome__kill` did `process.kill(9)` on the browser pid only. Chrome's GPU / network / utility / crashpad helpers are direct browser children, and Chromium's `kill_on_parent_death` (PR_SET_PDEATHSIG) is opt-in per-helper — most non-renderer processes skip it ([`base/process/launch_posix.cc`](https://chromium.googlesource.com/chromium/src/+/HEAD/base/process/launch_posix.cc)). On Linux they reparent to PID 1 and never exit.

## Fix

- Spawn with `new_process_group = true` — Chrome does `setpgid(0, 0)` before exec, helpers inherit the pgid.
- `Bun__Chrome__kill` signals the whole group via `kill(-pid, SIGKILL)` on POSIX (Chrome is its own pgroup leader, so pgid == pid). Windows path unchanged.

Same pattern puppeteer / playwright / chrome-launcher use.

## Verification

New test `chrome: closeAll() reaps the whole process group (#30475)` uses a stand-in fake-chrome shell script (so it runs on any POSIX CI lane, not just one with Chrome installed). Fixture forks two `sleep` children that stand in for the helpers, blocks on fd 3 where Bun dup2'd its socketpair. `closeAll()` then either kills all three (fix) or only the shell (bug).

Fails without the ChromeProcess.zig changes; passes with them.

Closes #30475