### PR TITLE
Fix capacity under-allocation in ESMConditions.init with user conditions

### DIFF
--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1087,9 +1087,10 @@ pub const ESMConditions = struct {
         var require_condition_map = ConditionsMap.init(allocator);
         var style_condition_map = ConditionsMap.init(allocator);
 
-        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
+        const addons: usize = if (allow_addons) 1 else 0;
+        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + addons + conditions.len);
+        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + addons + conditions.len);
+        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + addons + conditions.len);
         try style_condition_map.ensureTotalCapacity(defaults.len + 2 + conditions.len);
 
         import_condition_map.putAssumeCapacity("import", {});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -649,6 +649,27 @@ describe("Bun.build", () => {
       expect(await html?.text()).toContain("<meta name='injected-by-plugin' content='true'>");
     },
   );
+
+  test.concurrent("many custom conditions does not crash", async () => {
+    const dir = tempDirWithFiles("bun-build-api-many-conditions", {
+      "entry.js": "export const x = 1;\n",
+    });
+    const conditions = Array.from({ length: 64 }, (_, i) => "cond" + i);
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const r = await Bun.build({ entrypoints: [${JSON.stringify(join(dir, "entry.js"))}], conditions: ${JSON.stringify(conditions)} }); if (!r.success) throw new AggregateError(r.logs); console.log("ok");`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("ok\n");
+    expect(exitCode).toBe(0);
+  });
 });
 
 test.concurrent("macro with nested object", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a debug assertion / heap overflow in `ESMConditions.init` when `Bun.build()` is called with custom `conditions`.

The capacity reservation used:

```zig
defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len
```

which in Zig parses as:

```zig
defaults.len + 2 + (if (allow_addons) 1 else (0 + conditions.len))
```

Since `allow_addons` defaults to `true`, `conditions.len` was never counted toward the reserved capacity, and the subsequent `putAssumeCapacity` calls overflowed the map once enough user conditions were supplied.

## How did you verify your code works?

Reproduced reliably with:

```js
await Bun.build({
  entrypoints: ["entry.js"],
  conditions: Array.from({ length: 64 }, (_, i) => "cond" + i),
});
```

Crashes before, passes after. Added a regression test in `test/bundler/bun-build-api.test.ts`.

Found by Fuzzilli (fingerprint `1a2e21437cb0aea9`).