### PR TITLE
Fix capacity calculation in ESMConditions.init

### DIFF
--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1087,9 +1087,10 @@ pub const ESMConditions = struct {
         var require_condition_map = ConditionsMap.init(allocator);
         var style_condition_map = ConditionsMap.init(allocator);
 
-        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
+        const addon_count: usize = @intFromBool(allow_addons);
+        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + addon_count + conditions.len);
+        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + addon_count + conditions.len);
+        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + addon_count + conditions.len);
         try style_condition_map.ensureTotalCapacity(defaults.len + 2 + conditions.len);
 
         import_condition_map.putAssumeCapacity("import", {});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -649,6 +649,23 @@ describe("Bun.build", () => {
       expect(await html?.text()).toContain("<meta name='injected-by-plugin' content='true'>");
     },
   );
+
+  test("many conditions does not crash", async () => {
+    // The capacity reservation for export-condition maps used to drop
+    // `conditions.len` from the total when addons were allowed (the default),
+    // so enough user conditions would overflow a putAssumeCapacity and panic.
+    const dir = tempDirWithFiles("bun-build-api-many-conditions", {
+      "index.ts": "export const x = 1;\n",
+    });
+    const conditions: string[] = [];
+    for (let i = 0; i < 64; i++) conditions.push("cond" + i);
+    const result = await Bun.build({
+      entrypoints: [join(dir, "index.ts")],
+      target: "browser",
+      conditions,
+    });
+    expect(result.success).toBe(true);
+  });
 });
 
 test.concurrent("macro with nested object", async () => {


### PR DESCRIPTION
The expression

```zig
defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len
```

parses as

```zig
defaults.len + 2 + (if (allow_addons) 1 else (0 + conditions.len))
```

so when addons are allowed (the default) the user-provided `conditions` were never counted toward the reserved capacity of the export-condition maps. With enough entries in `conditions` the subsequent `putAssumeCapacity` calls overflow the reservation, panicking in debug builds and writing past the allocation in release builds.

### Repro

```js
const conditions = [];
for (let i = 0; i < 64; i++) conditions.push("cond" + i);
await Bun.build({ entrypoints: ["./index.ts"], target: "browser", conditions });
```

Found by Fuzzilli (fingerprint `ba9f621505dfdce8`).