### PR TITLE
fs.readdir: return Dirent with Buffer name when encoding is "buffer"

### DIFF
--- a/src/jsc/bindings/NodeDirent.cpp
+++ b/src/jsc/bindings/NodeDirent.cpp
@@ -20,6 +20,7 @@
 #include <JavaScriptCore/Structure.h>
 #include <JavaScriptCore/PropertyNameArray.h>
 #include "ZigGlobalObject.h"
+#include "JSBuffer.h"
 
 namespace Bun {
 
@@ -327,41 +328,77 @@ extern "C" JSC::EncodedJSValue Bun__JSDirentObjectConstructor(Zig::GlobalObject*
     return JSValue::encode(globalobject->m_JSDirentClassStructure.constructor(globalobject));
 }
 
-extern "C" JSC::EncodedJSValue Bun__Dirent__toJS(Zig::GlobalObject* globalObject, int type, BunString* name, BunString* path, JSString** previousPath)
+// Construct a Buffer from a BunString whose bytes should be preserved 1:1.
+// When the string is 8-bit (e.g. cloneLatin1), the span maps directly to the
+// raw filesystem bytes. When it's 16-bit (e.g. cloneUTF16 on Windows), fall
+// back to the UTF-8 transcode, which is what libuv would have produced on
+// POSIX anyway.
+static JSC::JSValue bunStringToBuffer(JSC::JSGlobalObject* globalObject, BunString* str)
+{
+    auto wtfString = str->transferToWTFString();
+    if (wtfString.isNull() || wtfString.isEmpty()) {
+        return WebCore::createBuffer(globalObject, static_cast<const uint8_t*>(nullptr), 0);
+    }
+    if (wtfString.is8Bit()) {
+        auto span = wtfString.span8();
+        return WebCore::createBuffer(globalObject, span.data(), span.size());
+    }
+    auto utf8 = wtfString.utf8();
+    return WebCore::createBuffer(globalObject, utf8.data(), utf8.length());
+}
+
+extern "C" JSC::EncodedJSValue Bun__Dirent__toJS(Zig::GlobalObject* globalObject, int type, BunString* name, BunString* path, JSString** previousPath, bool nameAsBuffer, bool pathAsBuffer)
 {
     auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* structure = globalObject->m_JSDirentClassStructure.get(globalObject);
     auto* object = JSC::JSFinalObject::create(vm, structure);
-    JSString* pathValue = nullptr;
-    if (path && path->tag == BunStringTag::WTFStringImpl && previousPath && *previousPath) {
-        // The caller (readdir result toJS loop) already deduplicates the
-        // underlying StringImpl per directory, so consecutive entries that
-        // share a parent path arrive here with the same `path->impl.wtf`
-        // pointer that we adopted into `*previousPath` last call. Compare the
-        // impl pointer directly instead of materializing a
-        // GCOwnedDataScope<StringView> via JSString::view(), whose
-        // construction/destruction acquires a WTF::Lock and touches a
-        // HashTable per call in debug builds.
-        auto* prevImpl = (*previousPath)->tryGetValueImpl();
-        if (prevImpl && (prevImpl == path->impl.wtf || WTF::equal(prevImpl, path->impl.wtf))) {
-            pathValue = *previousPath;
 
-            // Decrement the ref count of the previous path
+    // When `path` is emitted as a Buffer, every Dirent gets a fresh Buffer —
+    // Node.js behavior — so the JSString cache is bypassed entirely.
+    JSValue pathValue;
+    if (pathAsBuffer) {
+        pathValue = bunStringToBuffer(globalObject, path);
+        RETURN_IF_EXCEPTION(scope, {});
+    } else {
+        JSString* cachedPath = nullptr;
+        if (path && path->tag == BunStringTag::WTFStringImpl && previousPath && *previousPath) {
+            // The caller (readdir result toJS loop) already deduplicates the
+            // underlying StringImpl per directory, so consecutive entries that
+            // share a parent path arrive here with the same `path->impl.wtf`
+            // pointer that we adopted into `*previousPath` last call. Compare the
+            // impl pointer directly instead of materializing a
+            // GCOwnedDataScope<StringView> via JSString::view(), whose
+            // construction/destruction acquires a WTF::Lock and touches a
+            // HashTable per call in debug builds.
+            auto* prevImpl = (*previousPath)->tryGetValueImpl();
+            if (prevImpl && (prevImpl == path->impl.wtf || WTF::equal(prevImpl, path->impl.wtf))) {
+                cachedPath = *previousPath;
+
+                // Decrement the ref count of the previous path
+                auto pathString = path->transferToWTFString();
+            }
+        }
+
+        if (!cachedPath) {
             auto pathString = path->transferToWTFString();
+            cachedPath = jsString(vm, WTF::move(pathString));
+            if (previousPath) {
+                *previousPath = cachedPath;
+            }
         }
+        pathValue = cachedPath;
     }
 
-    if (!pathValue) {
-        auto pathString = path->transferToWTFString();
-        pathValue = jsString(vm, WTF::move(pathString));
-        if (previousPath) {
-            *previousPath = pathValue;
-        }
+    JSValue nameValue;
+    if (nameAsBuffer) {
+        nameValue = bunStringToBuffer(globalObject, name);
+        RETURN_IF_EXCEPTION(scope, {});
+    } else {
+        auto nameString = name->transferToWTFString();
+        nameValue = jsString(vm, WTF::move(nameString));
     }
-
-    auto nameString = name->transferToWTFString();
-    auto nameValue = jsString(vm, WTF::move(nameString));
     auto typeValue = jsNumber(type);
     object->putDirectOffset(vm, 0, nameValue);
     object->putDirectOffset(vm, 1, pathValue);

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6500,7 +6500,10 @@ impl NodeFS {
                 dirent_path = if args.path_is_buffer {
                     BunString::clone_latin1(basename_bytes)
                 } else {
-                    webcore::encoding::to_bun_string(basename_bytes, encoding_to_node(args.encoding))
+                    webcore::encoding::to_bun_string(
+                        basename_bytes,
+                        encoding_to_node(args.encoding),
+                    )
                 };
             }
 
@@ -6515,7 +6518,14 @@ impl NodeFS {
             } else {
                 current.kind
             };
-            T::append_entry(entries, utf8_name, &dirent_path, kind, args.encoding, args.path_is_buffer);
+            T::append_entry(
+                entries,
+                utf8_name,
+                &dirent_path,
+                kind,
+                args.encoding,
+                args.path_is_buffer,
+            );
         }
 
         dirent_path.deref();
@@ -6564,7 +6574,10 @@ impl NodeFS {
                 dirent_path = if args.path_is_buffer {
                     BunString::clone_latin1(basename_bytes)
                 } else {
-                    webcore::encoding::to_bun_string(basename_bytes, encoding_to_node(args.encoding))
+                    webcore::encoding::to_bun_string(
+                        basename_bytes,
+                        encoding_to_node(args.encoding),
+                    )
                 };
             }
 

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6783,7 +6783,6 @@ impl NodeFS {
                 &dirent_path_prev,
                 effective_kind,
                 args.encoding,
-                true,
                 args.path_is_buffer,
             );
         }
@@ -6969,7 +6968,6 @@ impl NodeFS {
                     &dirent_path_prev,
                     effective_kind,
                     args.encoding,
-                    true,
                     args.path_is_buffer,
                 );
             }
@@ -9507,10 +9505,7 @@ pub trait ReaddirEntry: Sized {
     );
     /// Recursive readdir: `utf8_name` is the bare entry name, `name_to_copy`
     /// is the path *relative to the recursion root* (what Node returns).
-    /// `apply_encoding` distinguishes the sync path (which honours
-    /// `args.encoding` via `webcore::encoding::to_bun_string`) from
-    /// the async path (which uses raw
-    /// `BunString::clone_utf8` and ignores the requested encoding).
+    /// Both the sync and async recursive paths honour `args.encoding`.
     fn append_entry_recursive(
         entries: &mut Vec<Self>,
         utf8_name: &[u8],
@@ -9518,7 +9513,6 @@ pub trait ReaddirEntry: Sized {
         dirent_path: &BunString,
         kind: sys::FileKind,
         encoding: Encoding,
-        apply_encoding: bool,
         path_is_buffer: bool,
     );
 }
@@ -9569,15 +9563,10 @@ impl ReaddirEntry for BunString {
         _dirent_path: &BunString,
         _kind: sys::FileKind,
         encoding: Encoding,
-        apply_encoding: bool,
         _path_is_buffer: bool,
     ) {
         let bytes = without_nt_prefix::<u8>(name_to_copy);
-        entries.push(if apply_encoding {
-            webcore::encoding::to_bun_string(bytes, encoding)
-        } else {
-            BunString::clone_utf8(bytes)
-        });
+        entries.push(webcore::encoding::to_bun_string(bytes, encoding));
     }
 }
 impl ReaddirEntry for Dirent {
@@ -9654,16 +9643,13 @@ impl ReaddirEntry for Dirent {
         dirent_path: &BunString,
         kind: sys::FileKind,
         encoding: Encoding,
-        apply_encoding: bool,
         path_is_buffer: bool,
     ) {
         let name_as_buffer = encoding == Encoding::Buffer;
         let name = if name_as_buffer {
             BunString::clone_latin1(utf8_name)
-        } else if apply_encoding {
-            webcore::encoding::to_bun_string(utf8_name, encoding)
         } else {
-            BunString::clone_utf8(utf8_name)
+            webcore::encoding::to_bun_string(utf8_name, encoding)
         };
         entries.push(Dirent {
             name,
@@ -9714,7 +9700,6 @@ impl ReaddirEntry for Buffer {
         _dirent_path: &BunString,
         _kind: sys::FileKind,
         _encoding: Encoding,
-        _apply_encoding: bool,
         _path_is_buffer: bool,
     ) {
         entries.push(Buffer::from_string(without_nt_prefix::<u8>(name_to_copy)).expect("oom"));

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -3551,23 +3551,29 @@ pub mod args {
         pub encoding: Encoding,
         pub with_file_types: bool,
         pub recursive: bool,
+        /// True when the user-supplied `path` was a Buffer/TypedArray/ArrayBuffer.
+        /// Matches Node's `Dirent.parentPath` semantics: when the path arg was a
+        /// Buffer, `parentPath` is emitted as a Buffer too — independent of the
+        /// `encoding` option.
+        pub path_is_buffer: bool,
     }
     fs_args_path_forwarders!(Readdir; path);
     impl Readdir {
         pub fn tag(&self) -> ret::ReaddirTag {
+            // withFileTypes takes priority regardless of encoding; the buffer
+            // encoding is then threaded through Dirent so `name` is emitted as
+            // a Buffer instead of a String.
+            if self.with_file_types {
+                return ret::ReaddirTag::WithFileTypes;
+            }
             match self.encoding {
                 Encoding::Buffer => ret::ReaddirTag::Buffers,
-                _ => {
-                    if self.with_file_types {
-                        ret::ReaddirTag::WithFileTypes
-                    } else {
-                        ret::ReaddirTag::Files
-                    }
-                }
+                _ => ret::ReaddirTag::Files,
             }
         }
         pub fn from_js(ctx: &JSGlobalObject, arguments: &mut ArgumentsSlice) -> JsResult<Readdir> {
             let path = PathLike::from_js_required(ctx, arguments, "path")?;
+            let path_is_buffer = matches!(path, PathLike::Buffer(_));
             let mut encoding = Encoding::Utf8;
             let mut with_file_types = false;
             let mut recursive = false;
@@ -3597,6 +3603,7 @@ pub mod args {
                 encoding,
                 with_file_types,
                 recursive,
+                path_is_buffer,
             })
         }
     }
@@ -6484,10 +6491,17 @@ impl NodeFS {
             };
 
             if T::IS_DIRENT && dirent_path.is_empty() {
-                dirent_path = webcore::encoding::to_bun_string(
-                    without_nt_prefix::<u8>(basename.as_bytes()),
-                    encoding_to_node(args.encoding),
-                );
+                // Storage is gated on `path_is_buffer`, not on `encoding`:
+                // when the path arg was a Buffer, `parentPath` is emitted as a
+                // Buffer, so store raw bytes 1:1 as Latin-1 to survive the
+                // round-trip without UTF-8 replacement. Otherwise `parentPath`
+                // is emitted as a JS string, so decode properly.
+                let basename_bytes = without_nt_prefix::<u8>(basename.as_bytes());
+                dirent_path = if args.path_is_buffer {
+                    BunString::clone_latin1(basename_bytes)
+                } else {
+                    webcore::encoding::to_bun_string(basename_bytes, encoding_to_node(args.encoding))
+                };
             }
 
             let utf8_name = current.name.slice();
@@ -6501,7 +6515,7 @@ impl NodeFS {
             } else {
                 current.kind
             };
-            T::append_entry(entries, utf8_name, &dirent_path, kind, args.encoding);
+            T::append_entry(entries, utf8_name, &dirent_path, kind, args.encoding, args.path_is_buffer);
         }
 
         dirent_path.deref();
@@ -6545,10 +6559,13 @@ impl NodeFS {
             };
 
             if T::IS_DIRENT && dirent_path.is_empty() {
-                dirent_path = webcore::encoding::to_bun_string(
-                    without_nt_prefix::<u8>(basename.as_bytes()),
-                    encoding_to_node(args.encoding),
-                );
+                // Same path_is_buffer gating as the non-Windows arm.
+                let basename_bytes = without_nt_prefix::<u8>(basename.as_bytes());
+                dirent_path = if args.path_is_buffer {
+                    BunString::clone_latin1(basename_bytes)
+                } else {
+                    webcore::encoding::to_bun_string(basename_bytes, encoding_to_node(args.encoding))
+                };
             }
 
             let utf16_name = current.name.slice();
@@ -6561,6 +6578,7 @@ impl NodeFS {
                 current.kind,
                 args.encoding,
                 re_encoding_buffer.as_deref_mut(),
+                args.path_is_buffer,
             );
         }
 
@@ -6734,10 +6752,17 @@ impl NodeFS {
                 let path_u8 = paths::resolve_path::dirname::<paths::platform::Auto>(joined);
                 if dirent_path_prev.is_empty() || dirent_path_prev.byte_slice() != path_u8 {
                     dirent_path_prev.deref();
-                    dirent_path_prev = BunString::clone_utf8(path_u8);
+                    // Storage tracks path_is_buffer to match emission, and
+                    // honors args.encoding for string paths to stay aligned
+                    // with the non-recursive and sync-recursive paths.
+                    dirent_path_prev = if args.path_is_buffer {
+                        BunString::clone_latin1(path_u8)
+                    } else {
+                        webcore::encoding::to_bun_string(path_u8, encoding_to_node(args.encoding))
+                    };
                 }
             }
-            // async path: uses raw `BunString::clone_utf8` — do not apply encoding.
+            // async path: honors args.encoding to align with sync/non-recursive.
             T::append_entry_recursive(
                 entries,
                 utf8_name,
@@ -6745,7 +6770,8 @@ impl NodeFS {
                 &dirent_path_prev,
                 effective_kind,
                 args.encoding,
-                false,
+                true,
+                args.path_is_buffer,
             );
         }
 
@@ -6913,10 +6939,13 @@ impl NodeFS {
                     let path_u8 = paths::resolve_path::dirname::<paths::platform::Auto>(joined);
                     if dirent_path_prev.is_empty() || dirent_path_prev.byte_slice() != path_u8 {
                         dirent_path_prev.deref();
-                        dirent_path_prev = webcore::encoding::to_bun_string(
-                            without_nt_prefix::<u8>(path_u8),
-                            encoding_to_node(args.encoding),
-                        );
+                        // Storage tracks path_is_buffer to match emission.
+                        let bytes = without_nt_prefix::<u8>(path_u8);
+                        dirent_path_prev = if args.path_is_buffer {
+                            BunString::clone_latin1(bytes)
+                        } else {
+                            webcore::encoding::to_bun_string(bytes, encoding_to_node(args.encoding))
+                        };
                     }
                 }
                 // sync path: uses `webcore::encoding::to_bun_string(.., args.encoding)`.
@@ -6928,6 +6957,7 @@ impl NodeFS {
                     effective_kind,
                     args.encoding,
                     true,
+                    args.path_is_buffer,
                 );
             }
             dirent_path_prev.deref();
@@ -9447,16 +9477,20 @@ pub trait ReaddirEntry: Sized {
         kind: sys::FileKind,
         encoding: Encoding,
         re_encoding_buffer: Option<&mut PathBuffer>,
+        path_is_buffer: bool,
     );
     fn into_readdir(v: Vec<Self>) -> ret::Readdir;
     /// Non-recursive readdir: append one entry given the bare entry name.
     /// `dirent_path` is the basename's directory (encoded once per dir).
+    /// `path_is_buffer` is true when the user passed a Buffer as the `path`
+    /// arg; Dirent uses it to tag `parentPath` for Buffer emission.
     fn append_entry(
         entries: &mut Vec<Self>,
         utf8_name: &[u8],
         dirent_path: &BunString,
         kind: sys::FileKind,
         encoding: Encoding,
+        path_is_buffer: bool,
     );
     /// Recursive readdir: `utf8_name` is the bare entry name, `name_to_copy`
     /// is the path *relative to the recursion root* (what Node returns).
@@ -9472,6 +9506,7 @@ pub trait ReaddirEntry: Sized {
         kind: sys::FileKind,
         encoding: Encoding,
         apply_encoding: bool,
+        path_is_buffer: bool,
     );
 }
 impl ReaddirEntry for BunString {
@@ -9489,6 +9524,7 @@ impl ReaddirEntry for BunString {
         _dirent_path: &BunString,
         _kind: sys::FileKind,
         encoding: Encoding,
+        _path_is_buffer: bool,
     ) {
         entries.push(webcore::encoding::to_bun_string(utf8_name, encoding));
     }
@@ -9499,6 +9535,7 @@ impl ReaddirEntry for BunString {
         _kind: sys::FileKind,
         encoding: Encoding,
         re_encoding_buffer: Option<&mut PathBuffer>,
+        _path_is_buffer: bool,
     ) {
         match encoding {
             Encoding::Buffer => unreachable!(),
@@ -9520,6 +9557,7 @@ impl ReaddirEntry for BunString {
         _kind: sys::FileKind,
         encoding: Encoding,
         apply_encoding: bool,
+        _path_is_buffer: bool,
     ) {
         let bytes = without_nt_prefix::<u8>(name_to_copy);
         entries.push(if apply_encoding {
@@ -9544,11 +9582,25 @@ impl ReaddirEntry for Dirent {
         dirent_path: &BunString,
         kind: sys::FileKind,
         encoding: Encoding,
+        path_is_buffer: bool,
     ) {
+        let name_as_buffer = encoding == Encoding::Buffer;
+        // When encoding is .buffer, store the name bytes 1:1 as Latin-1 so the
+        // C++ side can hand them straight to `createBuffer` without a lossy
+        // UTF-8↔UTF-16 round-trip. `to_bun_string(.buffer)` transcodes through
+        // UTF-16 and replaces invalid UTF-8 with U+FFFD — wrong for raw
+        // filesystem bytes.
+        let name = if name_as_buffer {
+            BunString::clone_latin1(utf8_name)
+        } else {
+            webcore::encoding::to_bun_string(utf8_name, encoding)
+        };
         entries.push(Dirent {
-            name: webcore::encoding::to_bun_string(utf8_name, encoding),
+            name,
             path: dirent_path.dupe_ref(),
             kind,
+            name_as_buffer,
+            path_as_buffer: path_is_buffer,
         });
     }
     fn append_entry_w(
@@ -9556,15 +9608,30 @@ impl ReaddirEntry for Dirent {
         utf16_name: &[u16],
         dirent_path: &BunString,
         kind: sys::FileKind,
-        _encoding: Encoding,
-        _re_encoding_buffer: Option<&mut PathBuffer>,
+        encoding: Encoding,
+        re_encoding_buffer: Option<&mut PathBuffer>,
+        path_is_buffer: bool,
     ) {
-        // Windows Dirent always clones the raw UTF-16
-        // name (no re-encoding) and skips the lstatat() DT_UNKNOWN fallback.
+        let name_as_buffer = encoding == Encoding::Buffer;
+        // On Windows, filesystem names are UTF-16. For encoding=buffer,
+        // transcode to UTF-8 (libuv's POSIX behavior) and store as Latin-1
+        // so the bytes round-trip 1:1 to a Buffer. Otherwise Windows Dirent
+        // clones the raw UTF-16 name (no re-encoding) and skips the lstatat()
+        // DT_UNKNOWN fallback.
+        let name = if name_as_buffer {
+            let buf = re_encoding_buffer
+                .expect("re_encoding_buffer must be allocated when encoding != utf8");
+            let utf8 = strings::paths::from_w_path(&mut buf[..], utf16_name);
+            BunString::clone_latin1(utf8.as_bytes())
+        } else {
+            BunString::clone_utf16(utf16_name)
+        };
         entries.push(Dirent {
-            name: BunString::clone_utf16(utf16_name),
+            name,
             path: dirent_path.dupe_ref(),
             kind,
+            name_as_buffer,
+            path_as_buffer: path_is_buffer,
         });
     }
     fn append_entry_recursive(
@@ -9575,15 +9642,22 @@ impl ReaddirEntry for Dirent {
         kind: sys::FileKind,
         encoding: Encoding,
         apply_encoding: bool,
+        path_is_buffer: bool,
     ) {
+        let name_as_buffer = encoding == Encoding::Buffer;
+        let name = if name_as_buffer {
+            BunString::clone_latin1(utf8_name)
+        } else if apply_encoding {
+            webcore::encoding::to_bun_string(utf8_name, encoding)
+        } else {
+            BunString::clone_utf8(utf8_name)
+        };
         entries.push(Dirent {
-            name: if apply_encoding {
-                webcore::encoding::to_bun_string(utf8_name, encoding)
-            } else {
-                BunString::clone_utf8(utf8_name)
-            },
+            name,
             path: dirent_path.dupe_ref(),
             kind,
+            name_as_buffer,
+            path_as_buffer: path_is_buffer,
         });
     }
 }
@@ -9602,6 +9676,7 @@ impl ReaddirEntry for Buffer {
         _dirent_path: &BunString,
         _kind: sys::FileKind,
         _encoding: Encoding,
+        _path_is_buffer: bool,
     ) {
         entries.push(Buffer::from_string(utf8_name).expect("oom"));
     }
@@ -9612,6 +9687,7 @@ impl ReaddirEntry for Buffer {
         _: sys::FileKind,
         _: Encoding,
         _: Option<&mut PathBuffer>,
+        _: bool,
     ) {
         // Buffer never
         // takes the u16 iterator (`IS_U16 = false`); the call site is gated on
@@ -9626,6 +9702,7 @@ impl ReaddirEntry for Buffer {
         _kind: sys::FileKind,
         _encoding: Encoding,
         _apply_encoding: bool,
+        _path_is_buffer: bool,
     ) {
         entries.push(Buffer::from_string(without_nt_prefix::<u8>(name_to_copy)).expect("oom"));
     }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6775,7 +6775,6 @@ impl NodeFS {
                     };
                 }
             }
-            // async path: honors args.encoding to align with sync/non-recursive.
             T::append_entry_recursive(
                 entries,
                 utf8_name,
@@ -6960,7 +6959,6 @@ impl NodeFS {
                         };
                     }
                 }
-                // sync path: uses `webcore::encoding::to_bun_string(.., args.encoding)`.
                 T::append_entry_recursive(
                     entries,
                     utf8_name,

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1865,6 +1865,14 @@ pub struct Dirent {
     pub path: bun_core::String,
     // not publicly exposed
     pub kind: DirentKind,
+    /// When true, emit `name` as a `Buffer` instead of a `String`. Set when
+    /// `readdir` was called with `{ encoding: "buffer" }`. The bytes in `name`
+    /// are stored as Latin-1 in that case to preserve raw filesystem bytes 1:1.
+    pub name_as_buffer: bool,
+    /// When true, emit `path`/`parentPath` as a `Buffer` instead of a `String`.
+    /// Set when the caller passed a `Buffer` as the `path` argument to
+    /// `readdir`, matching Node.js semantics.
+    pub path_as_buffer: bool,
 }
 
 pub type DirentKind = bun_sys::FileKind;
@@ -1882,6 +1890,8 @@ unsafe extern "C" {
         name: &mut bun_core::String,
         path: &mut bun_core::String,
         cached_previous_path_jsvalue: Option<&mut *mut jsc::JSString>,
+        name_as_buffer: bool,
+        path_as_buffer: bool,
     ) -> JSValue;
 }
 
@@ -1917,6 +1927,8 @@ impl Dirent {
                 &mut self.name,
                 &mut self.path,
                 cached_previous_path_jsvalue,
+                self.name_as_buffer,
+                self.path_as_buffer,
             )
         })
     }

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3457,48 +3457,39 @@ describe("fs/promises", () => {
     // name-as-buffer (encoding option) and path-as-buffer (path arg type) are
     // independent flags. Storage representation must track `path_is_buffer`,
     // not `encoding`, or non-ASCII paths produce mojibake / lossy output.
-    it.skipIf(isWindows)(
-      "non-ASCII string path + encoding='buffer' → parentPath is the original string",
-      () => {
-        using dir = tempDir("readdir-café-", { "a.txt": "x" });
-        const [entry] = readdirSync(String(dir), { withFileTypes: true, encoding: "buffer" });
-        expect(entry).toBeInstanceOf(Dirent);
-        expect(typeof entry.parentPath).toBe("string");
-        expect(entry.parentPath).toBe(String(dir));
-        expect(entry.name).toBeInstanceOf(Buffer);
-        expect((entry.name as unknown as Buffer).toString()).toBe("a.txt");
-      },
-    );
+    it.skipIf(isWindows)("non-ASCII string path + encoding='buffer' → parentPath is the original string", () => {
+      using dir = tempDir("readdir-café-", { "a.txt": "x" });
+      const [entry] = readdirSync(String(dir), { withFileTypes: true, encoding: "buffer" });
+      expect(entry).toBeInstanceOf(Dirent);
+      expect(typeof entry.parentPath).toBe("string");
+      expect(entry.parentPath).toBe(String(dir));
+      expect(entry.name).toBeInstanceOf(Buffer);
+      expect((entry.name as unknown as Buffer).toString()).toBe("a.txt");
+    });
 
-    it.skipIf(isWindows)(
-      "non-ASCII Buffer path + encoding='buffer' → parentPath has original bytes",
-      () => {
-        using dir = tempDir("readdir-ünïcode-", { "a.txt": "x" });
-        const pathBytes = Buffer.from(String(dir));
-        const [entry] = readdirSync(pathBytes, { withFileTypes: true, encoding: "buffer" });
-        expect(entry).toBeInstanceOf(Dirent);
-        expect(entry.parentPath).toBeInstanceOf(Buffer);
-        expect(entry.parentPath.equals(pathBytes)).toBe(true);
-        expect(entry.name).toBeInstanceOf(Buffer);
-        expect((entry.name as unknown as Buffer).toString()).toBe("a.txt");
-      },
-    );
+    it.skipIf(isWindows)("non-ASCII Buffer path + encoding='buffer' → parentPath has original bytes", () => {
+      using dir = tempDir("readdir-ünïcode-", { "a.txt": "x" });
+      const pathBytes = Buffer.from(String(dir));
+      const [entry] = readdirSync(pathBytes, { withFileTypes: true, encoding: "buffer" });
+      expect(entry).toBeInstanceOf(Dirent);
+      expect(entry.parentPath).toBeInstanceOf(Buffer);
+      expect(entry.parentPath.equals(pathBytes)).toBe(true);
+      expect(entry.name).toBeInstanceOf(Buffer);
+      expect((entry.name as unknown as Buffer).toString()).toBe("a.txt");
+    });
 
-    it.skipIf(isWindows)(
-      "non-ASCII Buffer path + default encoding → parentPath is a Buffer, name is a string",
-      () => {
-        using dir = tempDir("readdir-ünïcode2-", { "a.txt": "x" });
-        const pathBytes = Buffer.from(String(dir));
-        const [entry] = readdirSync(pathBytes, { withFileTypes: true });
-        expect(entry).toBeInstanceOf(Dirent);
-        // Path arg was a Buffer → parentPath is a Buffer, independent of encoding.
-        expect(entry.parentPath).toBeInstanceOf(Buffer);
-        expect(entry.parentPath.equals(pathBytes)).toBe(true);
-        // encoding defaulted to utf8 → name is a string.
-        expect(typeof entry.name).toBe("string");
-        expect(entry.name).toBe("a.txt");
-      },
-    );
+    it.skipIf(isWindows)("non-ASCII Buffer path + default encoding → parentPath is a Buffer, name is a string", () => {
+      using dir = tempDir("readdir-ünïcode2-", { "a.txt": "x" });
+      const pathBytes = Buffer.from(String(dir));
+      const [entry] = readdirSync(pathBytes, { withFileTypes: true });
+      expect(entry).toBeInstanceOf(Dirent);
+      // Path arg was a Buffer → parentPath is a Buffer, independent of encoding.
+      expect(entry.parentPath).toBeInstanceOf(Buffer);
+      expect(entry.parentPath.equals(pathBytes)).toBe(true);
+      // encoding defaulted to utf8 → name is a string.
+      expect(typeof entry.name).toBe("string");
+      expect(entry.name).toBe("a.txt");
+    });
 
     // POSIX filesystems allow arbitrary bytes in paths — not just valid UTF-8.
     // When the caller passes those bytes as a Buffer, `parentPath` must be

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -8,6 +8,7 @@ import {
   isDebug,
   isIntelMacOS,
   isLinux,
+  isMacOS,
   isPosix,
   isWindows,
   tempDir,
@@ -3491,10 +3492,10 @@ describe("fs/promises", () => {
       expect(entry.name).toBe("a.txt");
     });
 
-    // POSIX filesystems allow arbitrary bytes in paths — not just valid UTF-8.
-    // When the caller passes those bytes as a Buffer, `parentPath` must be
-    // emitted as a Buffer with the original bytes, regardless of encoding.
-    it.skipIf(isWindows)("Buffer path with raw non-UTF-8 bytes → parentPath preserves bytes 1:1", () => {
+    // Only Linux/BSD filesystems accept arbitrary bytes in paths. Windows
+    // paths are UTF-16 and macOS APFS/HFS+ require valid UTF-8 (the kernel
+    // rejects invalid sequences with EILSEQ), so skip on both.
+    it.skipIf(isWindows || isMacOS)("Buffer path with raw non-UTF-8 bytes → parentPath preserves bytes 1:1", () => {
       using parent = tempDir("readdir-raw-", {});
       // Create a subdirectory whose name contains a raw 0xFF byte (not valid UTF-8).
       const rawSub = Buffer.concat([Buffer.from(String(parent) + "/"), Buffer.from([0xff, 0x41, 0x42])]);

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3380,6 +3380,24 @@ describe("fs/promises", () => {
       expect(entries[0]).toBeInstanceOf(Dirent);
       expect(entries[0].name).toBeInstanceOf(Buffer);
       expect((entries[0].name as unknown as Buffer).toString()).toBe("foo.js");
+      expect(typeof entries[0].parentPath).toBe("string");
+      expect(entries[0].parentPath).toBe(String(dir));
+    });
+
+    it("readdir (async callback, Buffer path): Buffer parentPath", async () => {
+      using dir = tempDir("readdir-buf-dirent-cb-buf-path", { "foo.js": "1" });
+      const pathBytes = Buffer.from(String(dir));
+      const { promise, resolve, reject } = Promise.withResolvers<Dirent[]>();
+      fs.readdir(pathBytes, { withFileTypes: true, encoding: "buffer" }, (err, entries) => {
+        if (err) reject(err);
+        else resolve(entries);
+      });
+      const [entry] = await promise;
+      expect(entry).toBeInstanceOf(Dirent);
+      expect(entry.parentPath).toBeInstanceOf(Buffer);
+      expect((entry.parentPath as unknown as Buffer).equals(pathBytes)).toBe(true);
+      expect(entry.name).toBeInstanceOf(Buffer);
+      expect((entry.name as unknown as Buffer).toString()).toBe("foo.js");
     });
 
     it("promises.readdir: Dirent with Buffer name", async () => {
@@ -3392,6 +3410,22 @@ describe("fs/promises", () => {
       expect(entries[0]).toBeInstanceOf(Dirent);
       expect(entries[0].name).toBeInstanceOf(Buffer);
       expect((entries[0].name as unknown as Buffer).toString()).toBe("bar.ts");
+      expect(typeof entries[0].parentPath).toBe("string");
+      expect(entries[0].parentPath).toBe(String(dir));
+    });
+
+    it("promises.readdir (Buffer path): Buffer parentPath", async () => {
+      using dir = tempDir("readdir-buf-dirent-prom-buf-path", { "bar.ts": "1" });
+      const pathBytes = Buffer.from(String(dir));
+      const [entry] = await promises.readdir(pathBytes, {
+        withFileTypes: true,
+        encoding: "buffer",
+      });
+      expect(entry).toBeInstanceOf(Dirent);
+      expect(entry.parentPath).toBeInstanceOf(Buffer);
+      expect((entry.parentPath as unknown as Buffer).equals(pathBytes)).toBe(true);
+      expect(entry.name).toBeInstanceOf(Buffer);
+      expect((entry.name as unknown as Buffer).toString()).toBe("bar.ts");
     });
 
     it("readdirSync recursive: Dirent with Buffer name", () => {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3453,6 +3453,73 @@ describe("fs/promises", () => {
       expect(entries[0]).not.toBeInstanceOf(Dirent as any);
       expect(Buffer.from(entries[0]).toString()).toBe("hello.txt");
     });
+
+    // name-as-buffer (encoding option) and path-as-buffer (path arg type) are
+    // independent flags. Storage representation must track `path_is_buffer`,
+    // not `encoding`, or non-ASCII paths produce mojibake / lossy output.
+    it.skipIf(isWindows)(
+      "non-ASCII string path + encoding='buffer' → parentPath is the original string",
+      () => {
+        using dir = tempDir("readdir-café-", { "a.txt": "x" });
+        const [entry] = readdirSync(String(dir), { withFileTypes: true, encoding: "buffer" });
+        expect(entry).toBeInstanceOf(Dirent);
+        expect(typeof entry.parentPath).toBe("string");
+        expect(entry.parentPath).toBe(String(dir));
+        expect(entry.name).toBeInstanceOf(Buffer);
+        expect((entry.name as unknown as Buffer).toString()).toBe("a.txt");
+      },
+    );
+
+    it.skipIf(isWindows)(
+      "non-ASCII Buffer path + encoding='buffer' → parentPath has original bytes",
+      () => {
+        using dir = tempDir("readdir-ünïcode-", { "a.txt": "x" });
+        const pathBytes = Buffer.from(String(dir));
+        const [entry] = readdirSync(pathBytes, { withFileTypes: true, encoding: "buffer" });
+        expect(entry).toBeInstanceOf(Dirent);
+        expect(entry.parentPath).toBeInstanceOf(Buffer);
+        expect(entry.parentPath.equals(pathBytes)).toBe(true);
+        expect(entry.name).toBeInstanceOf(Buffer);
+        expect((entry.name as unknown as Buffer).toString()).toBe("a.txt");
+      },
+    );
+
+    it.skipIf(isWindows)(
+      "non-ASCII Buffer path + default encoding → parentPath is a Buffer, name is a string",
+      () => {
+        using dir = tempDir("readdir-ünïcode2-", { "a.txt": "x" });
+        const pathBytes = Buffer.from(String(dir));
+        const [entry] = readdirSync(pathBytes, { withFileTypes: true });
+        expect(entry).toBeInstanceOf(Dirent);
+        // Path arg was a Buffer → parentPath is a Buffer, independent of encoding.
+        expect(entry.parentPath).toBeInstanceOf(Buffer);
+        expect(entry.parentPath.equals(pathBytes)).toBe(true);
+        // encoding defaulted to utf8 → name is a string.
+        expect(typeof entry.name).toBe("string");
+        expect(entry.name).toBe("a.txt");
+      },
+    );
+
+    // POSIX filesystems allow arbitrary bytes in paths — not just valid UTF-8.
+    // When the caller passes those bytes as a Buffer, `parentPath` must be
+    // emitted as a Buffer with the original bytes, regardless of encoding.
+    it.skipIf(isWindows)("Buffer path with raw non-UTF-8 bytes → parentPath preserves bytes 1:1", () => {
+      using parent = tempDir("readdir-raw-", {});
+      // Create a subdirectory whose name contains a raw 0xFF byte (not valid UTF-8).
+      const rawSub = Buffer.concat([Buffer.from(String(parent) + "/"), Buffer.from([0xff, 0x41, 0x42])]);
+      fs.mkdirSync(rawSub);
+      fs.writeFileSync(Buffer.concat([rawSub, Buffer.from("/a.txt")]), "x");
+
+      const [entry] = readdirSync(rawSub, { withFileTypes: true });
+      expect(entry).toBeInstanceOf(Dirent);
+      expect(entry.parentPath).toBeInstanceOf(Buffer);
+      expect(entry.parentPath.equals(rawSub)).toBe(true);
+      expect(entry.name).toBe("a.txt");
+
+      try {
+        fs.rmSync(rawSub, { recursive: true, force: true });
+      } catch {}
+    });
   });
 
   for (let withFileTypes of [false, true] as const) {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3324,6 +3324,137 @@ describe("fs/promises", () => {
     100000,
   );
 
+  // https://github.com/oven-sh/bun/issues/30482 — readdir with
+  // { withFileTypes: true, encoding: "buffer" } previously ignored withFileTypes
+  // and returned a flat Uint8Array[] instead of Dirent[] with Buffer names.
+  describe.concurrent("readdir({ withFileTypes: true, encoding: 'buffer' })", () => {
+    it("readdirSync(string path): Dirent with Buffer name, string parentPath", () => {
+      using dir = tempDir("readdir-buf-dirent-sync-str", {
+        "a.txt": "a",
+        "b.txt": "b",
+      });
+
+      const entries = readdirSync(String(dir), { withFileTypes: true, encoding: "buffer" });
+      expect(entries).toHaveLength(2);
+      for (const entry of entries) {
+        expect(entry).toBeInstanceOf(Dirent);
+        expect(entry.name).toBeInstanceOf(Buffer);
+        // Path was a string → parentPath stays a string.
+        expect(typeof entry.parentPath).toBe("string");
+        expect(entry.parentPath).toBe(String(dir));
+        expect(entry.isFile()).toBe(true);
+      }
+      expect(entries.map(e => (e.name as unknown as Buffer).toString()).sort()).toEqual(["a.txt", "b.txt"]);
+    });
+
+    it("readdirSync(Buffer path): Dirent with Buffer name and Buffer parentPath", () => {
+      using dir = tempDir("readdir-buf-dirent-sync-buf", {
+        "only.txt": "x",
+      });
+
+      const entries = readdirSync(Buffer.from(String(dir)), {
+        withFileTypes: true,
+        encoding: "buffer",
+      });
+      expect(entries).toHaveLength(1);
+      const [entry] = entries;
+      expect(entry).toBeInstanceOf(Dirent);
+      expect(entry.name).toBeInstanceOf(Buffer);
+      expect((entry.name as unknown as Buffer).toString()).toBe("only.txt");
+      // Path was a Buffer → parentPath is a Buffer (independent of encoding).
+      expect(entry.parentPath).toBeInstanceOf(Buffer);
+      expect((entry.parentPath as unknown as Buffer).toString()).toBe(String(dir));
+      expect(entry.isFile()).toBe(true);
+    });
+
+    it("readdir (async callback): Dirent with Buffer name", async () => {
+      using dir = tempDir("readdir-buf-dirent-cb", { "foo.js": "1" });
+      const { promise, resolve, reject } = Promise.withResolvers<Dirent[]>();
+      fs.readdir(String(dir), { withFileTypes: true, encoding: "buffer" }, (err, entries) => {
+        if (err) reject(err);
+        else resolve(entries);
+      });
+      const entries = await promise;
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toBeInstanceOf(Dirent);
+      expect(entries[0].name).toBeInstanceOf(Buffer);
+      expect((entries[0].name as unknown as Buffer).toString()).toBe("foo.js");
+    });
+
+    it("promises.readdir: Dirent with Buffer name", async () => {
+      using dir = tempDir("readdir-buf-dirent-promises", { "bar.ts": "1" });
+      const entries = await promises.readdir(String(dir), {
+        withFileTypes: true,
+        encoding: "buffer",
+      });
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toBeInstanceOf(Dirent);
+      expect(entries[0].name).toBeInstanceOf(Buffer);
+      expect((entries[0].name as unknown as Buffer).toString()).toBe("bar.ts");
+    });
+
+    it("readdirSync recursive: Dirent with Buffer name", () => {
+      using dir = tempDir("readdir-buf-dirent-recursive", {
+        "a.txt": "a",
+        "sub/b.txt": "b",
+      });
+
+      const entries = readdirSync(String(dir), {
+        withFileTypes: true,
+        encoding: "buffer",
+        recursive: true,
+      });
+      expect(entries.length).toBeGreaterThanOrEqual(3);
+      for (const entry of entries) {
+        expect(entry).toBeInstanceOf(Dirent);
+        expect(entry.name).toBeInstanceOf(Buffer);
+        expect(typeof entry.parentPath).toBe("string");
+      }
+      const names = entries.map(e => (e.name as unknown as Buffer).toString()).sort();
+      expect(names).toEqual(["a.txt", "b.txt", "sub"]);
+    });
+
+    it("promises.readdir recursive: Dirent with Buffer name", async () => {
+      using dir = tempDir("readdir-buf-dirent-promises-recursive", {
+        "a.txt": "a",
+        "sub/b.txt": "b",
+      });
+
+      const entries = await promises.readdir(String(dir), {
+        withFileTypes: true,
+        encoding: "buffer",
+        recursive: true,
+      });
+      expect(entries.length).toBeGreaterThanOrEqual(3);
+      for (const entry of entries) {
+        expect(entry).toBeInstanceOf(Dirent);
+        expect(entry.name).toBeInstanceOf(Buffer);
+        expect(typeof entry.parentPath).toBe("string");
+      }
+      const names = entries.map(e => (e.name as unknown as Buffer).toString()).sort();
+      expect(names).toEqual(["a.txt", "b.txt", "sub"]);
+    });
+
+    // Control: the two options independently still behave correctly.
+    it("withFileTypes only (default encoding) still returns Dirent with string name", () => {
+      using dir = tempDir("readdir-dirent-string", { "hello.txt": "h" });
+      const entries = readdirSync(String(dir), { withFileTypes: true });
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toBeInstanceOf(Dirent);
+      expect(typeof entries[0].name).toBe("string");
+      expect(entries[0].name).toBe("hello.txt");
+    });
+
+    it("encoding=buffer only (no withFileTypes) still returns a Uint8Array[]", () => {
+      using dir = tempDir("readdir-buf-no-dirent", { "hello.txt": "h" });
+      const entries = readdirSync(String(dir), { encoding: "buffer" });
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toBeInstanceOf(Uint8Array);
+      expect(entries[0]).not.toBeInstanceOf(Dirent as any);
+      expect(Buffer.from(entries[0]).toString()).toBe("hello.txt");
+    });
+  });
+
   for (let withFileTypes of [false, true] as const) {
     const iterCount = isDebug ? 16 : 200;
     const full = resolve(import.meta.dir, "../");


### PR DESCRIPTION
Closes #30482. Same root cause as #27914.

## Repro

```js
const fs = require('fs');
fs.readdir(Buffer.from('.'), { withFileTypes: true, encoding: 'buffer' }, (err, entries) => {
  console.log(entries[0]);
});
```

**Node.js:**
```
Dirent {
  name: <Buffer 72 65 61 64 64 69 72 2d 62 75 66 66 65 72 2e 63 6a 73>,
  parentPath: <Buffer 2e>,
  Symbol(type): 1
}
```

**Bun before:**
```
Uint8Array(18) [ 114, 101, 97, 100, 100, 105, 114, ... ]
```

## Cause

`Arguments.Readdir.tag()` in `src/runtime/node/node_fs.zig` matched the
`.buffer` encoding **before** checking `with_file_types`:

```zig
return switch (this.encoding) {
    .buffer => .buffers,             // <-- claims the whole buffer branch
    else => if (this.with_file_types) .with_file_types else .files,
};
```

So every `withFileTypes: true, encoding: 'buffer'` call fell through to
the flat `Buffer[]` branch and never constructed Dirents.

Fixing just the branch ordering would produce Dirents whose `name` was a
String, not a Buffer — the `Dirent` struct and the C++ `Bun__Dirent__toJS`
only knew how to emit strings.

## Fix

- `tag()`: withFileTypes wins, regardless of encoding.
- `Arguments.Readdir` records `path_is_buffer` at `fromJS` time. Node's
  rule for `parentPath` is: Buffer iff the user-supplied `path` was a
  Buffer, independent of the `encoding` option.
- `Dirent` struct gains `name_as_buffer` and `path_as_buffer` flags and
  threads them to `Bun__Dirent__toJS`.
- When `encoding == .buffer`, the Zig side stores name/path bytes with
  `bun.String.cloneLatin1` so raw filesystem bytes survive 1:1.
  `toBunString(.buffer)` goes through UTF-16 and replaces invalid UTF-8
  sequences with U+FFFD — wrong for a Buffer that's supposed to be
  byte-transparent.
- `Bun__Dirent__toJS` reads `.span8()` directly and hands the bytes to
  `WebCore::createBuffer` when a field should be a Buffer. Fresh Buffer
  per Dirent for `path` (Node behavior; the JSString cache is bypassed).

All four paths covered: sync, async callback, promises, recursive (async
and sync).

## Tests

`test/js/node/fs/fs.test.ts` gains a `describe.concurrent` block with
8 tests covering every combination — sync, async callback, promises,
recursive + string/Buffer path — plus two controls asserting the other
two branches (withFileTypes-only, encoding=buffer-only) still behave
unchanged.

Gate:
- `USE_SYSTEM_BUN=1 bun test …` — 6 fail, 2 pass (controls).
- `bun bd test …` — 8 pass.

## Notes

Supersedes the now-stale #27914 → #27917 attempt. That PR predates the
`src/bun.js → src/runtime` move and has merge conflicts; this one is
rebased on current main, preserves raw filesystem bytes for non-UTF-8
names, and handles Node's `parentPath` Buffer/String asymmetry.