### PR TITLE
tls: implement `SecureContext.addCACert`

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -120,15 +120,19 @@ static int us_sni_ex_idx = -1;
 static int us_ctx_cache_ex_idx = -1;
 static int us_ssl_reneg_state_idx = -1;
 static int us_ssl_listener_ex_idx = -1;
-/* Set when a CTX carries user CAs: by `us_ssl_ctx_add_ca_pem` (node:tls
- * `SecureContext.addCACert`) and by the construction-time `options.ca` /
- * `ca_file_name` / `request_cert` branches of `us_ssl_ctx_build_raw`. The
- * client-attach paths — `us_internal_ssl_attach` here and Rust's `SSLWrapper`
- * (via `us_ctx_has_user_ca`) — read it to skip their per-SSL
+/* Set when a CTX carries an explicitly-managed trust store that the
+ * client-attach paths must not override. Producers and what each installs:
+ *   - `us_ssl_ctx_add_ca_pem` (node:tls `SecureContext.addCACert`): default
+ *     roots + the appended user CAs;
+ *   - `options.ca` / `ca_file_name` branches of `us_ssl_ctx_build_raw`: the
+ *     user CAs only (explicit `ca` replaces the default store, Node.js
+ *     semantics);
+ *   - `request_cert` branch of `us_ssl_ctx_build_raw`: default roots only.
+ * The client-attach paths — `us_internal_ssl_attach` here and Rust's
+ * `SSLWrapper` (via `us_ctx_has_user_ca`) — read it to skip their per-SSL
  * `SSL_set0_verify_cert_store(ssl, shared_default_roots)` override: when set,
- * the CTX's own store already carries the user CAs, and overriding would make
- * them invisible at handshake time. The pointer IS the value (NULL/!NULL),
- * so no free_func. */
+ * the CTX's own store is authoritative and overriding would make it invisible
+ * at handshake time. The pointer IS the value (NULL/!NULL), so no free_func. */
 static int us_ctx_user_ca_idx = -1;
 #ifdef _WIN32
 static INIT_ONCE us_ex_idx_once = INIT_ONCE_STATIC_INIT;
@@ -418,10 +422,11 @@ int us_ssl_ctx_add_ca_pem(SSL_CTX *ctx, const char *pem, size_t pem_len) {
   void *marked = SSL_CTX_get_ex_data(ctx, us_ctx_user_ca_idx);
   X509_STORE *store;
   if (marked) {
-    /* CTX already carries default roots + user CAs — set by a prior
-     * `addCACert` or by the `options.ca` / `ca_file_name` / `request_cert`
-     * branches of `us_ssl_ctx_build_raw`. Append to that store instead of
-     * swapping in a fresh one, which would drop the existing CAs. */
+    /* CTX already carries an explicitly-managed trust store — default roots +
+     * user CAs from a prior `addCACert`, user CAs only from the `options.ca` /
+     * `ca_file_name` branches of `us_ssl_ctx_build_raw`, or default roots only
+     * from its `request_cert` branch. Append to that store instead of swapping
+     * in a fresh one, which would drop whatever it already holds. */
     store = SSL_CTX_get_cert_store(ctx);
   } else {
     /* First user-CA installation on this CTX: swap in the default_ca_store

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -617,7 +617,12 @@ SSL_CTX *us_ssl_ctx_build_raw(struct us_bun_socket_context_options_t options,
     /* An explicit CA replaces the default trust store (Node.js semantics):
      * chains must validate exclusively against the supplied CAs. The SSL_CTX
      * already owns a fresh, empty X509_STORE from SSL_CTX_new(), so
-     * SSL_CTX_load_verify_locations below populates only the user's CAs. */
+     * SSL_CTX_load_verify_locations below populates only the user's CAs.
+     * Flip `us_ctx_user_ca_idx` so a later `us_ssl_ctx_add_ca_pem`
+     * (addCACert) appends to THIS user-CA store rather than swapping in the
+     * default roots, and so the per-socket client override in
+     * `us_internal_ssl_attach` preserves the user CAs. */
+    SSL_CTX_set_ex_data(ssl_context, us_ctx_user_ca_idx, (void *)(uintptr_t)1);
     STACK_OF(X509_NAME) *ca_list = SSL_load_client_CA_file(options.ca_file_name);
     if (ca_list == NULL) {
       *err = CREATE_BUN_SOCKET_ERROR_LOAD_CA_FILE;
@@ -638,7 +643,9 @@ SSL_CTX *us_ssl_ctx_build_raw(struct us_bun_socket_context_options_t options,
   } else if (options.ca && options.ca_count > 0) {
     /* As above: user CAs only, into the SSL_CTX's own initially-empty store —
      * otherwise a server doing mTLS with `ca: [internalCA]` would also accept
-     * any client certificate that chains to a public root. */
+     * any client certificate that chains to a public root. The marker makes
+     * a later addCACert append to this store (see ca_file_name branch). */
+    SSL_CTX_set_ex_data(ssl_context, us_ctx_user_ca_idx, (void *)(uintptr_t)1);
     X509_STORE *cert_store = SSL_CTX_get_cert_store(ssl_context);
     for (unsigned int i = 0; i < options.ca_count; i++) {
       if (!add_ca_cert_to_ctx_store(ssl_context, options.ca[i], cert_store)) {
@@ -654,6 +661,9 @@ SSL_CTX *us_ssl_ctx_build_raw(struct us_bun_socket_context_options_t options,
     }
   } else if (options.request_cert) {
     SSL_CTX_set_cert_store(ssl_context, us_get_default_ca_store());
+    /* See comment above the ca_file_name branch — `requestCert: true` also
+     * installs a populated trust store that a later addCACert must preserve. */
+    SSL_CTX_set_ex_data(ssl_context, us_ctx_user_ca_idx, (void *)(uintptr_t)1);
     SSL_CTX_set_verify(ssl_context,
         options.reject_unauthorized ? (SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT)
                                     : SSL_VERIFY_PEER,

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -120,12 +120,15 @@ static int us_sni_ex_idx = -1;
 static int us_ctx_cache_ex_idx = -1;
 static int us_ssl_reneg_state_idx = -1;
 static int us_ssl_listener_ex_idx = -1;
-/* `us_ssl_ctx_add_ca_pem` (node:tls `SecureContext.addCACert`) flips this
- * slot to !NULL. The client branch of `us_internal_ssl_attach` reads it to
- * skip its `SSL_set0_verify_cert_store(ssl, shared_default_roots)` override
- * — once user CAs were appended post-construction, the CTX's own store
- * carries them, and overriding would make the added CAs invisible at
- * handshake time. The pointer IS the value (NULL/!NULL), so no free_func. */
+/* Set when a CTX carries user CAs: by `us_ssl_ctx_add_ca_pem` (node:tls
+ * `SecureContext.addCACert`) and by the construction-time `options.ca` /
+ * `ca_file_name` / `request_cert` branches of `us_ssl_ctx_build_raw`. The
+ * client-attach paths — `us_internal_ssl_attach` here and Rust's `SSLWrapper`
+ * (via `us_ctx_has_user_ca`) — read it to skip their per-SSL
+ * `SSL_set0_verify_cert_store(ssl, shared_default_roots)` override: when set,
+ * the CTX's own store already carries the user CAs, and overriding would make
+ * them invisible at handshake time. The pointer IS the value (NULL/!NULL),
+ * so no free_func. */
 static int us_ctx_user_ca_idx = -1;
 #ifdef _WIN32
 static INIT_ONCE us_ex_idx_once = INIT_ONCE_STATIC_INIT;

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -415,13 +415,16 @@ int us_ssl_ctx_add_ca_pem(SSL_CTX *ctx, const char *pem, size_t pem_len) {
   void *marked = SSL_CTX_get_ex_data(ctx, us_ctx_user_ca_idx);
   X509_STORE *store;
   if (marked) {
-    /* Second+ addCACert on this CTX: reuse the store we installed last time. */
+    /* CTX already carries default roots + user CAs — set by a prior
+     * `addCACert` or by the `options.ca` / `ca_file_name` / `request_cert`
+     * branches of `us_ssl_ctx_build_raw`. Append to that store instead of
+     * swapping in a fresh one, which would drop the existing CAs. */
     store = SSL_CTX_get_cert_store(ctx);
   } else {
-    /* First call: install the default_ca_store so the added CA joins (not
-     * replaces) OS/baked-in trust anchors. The mark below is what tells the
-     * client attach path to keep this store instead of overriding it with
-     * the shared default roots. */
+    /* First user-CA installation on this CTX: swap in the default_ca_store
+     * so the added CA joins (not replaces) OS/baked-in trust anchors. The
+     * mark below is what tells the client attach path to keep this store
+     * instead of overriding it with the shared default roots. */
     store = us_get_default_ca_store();
     if (store == NULL) return 0;
     SSL_CTX_set_cert_store(ctx, store);

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -468,9 +468,11 @@ int us_ssl_ctx_add_ca_pem(SSL_CTX *ctx, const char *pem, size_t pem_len) {
   return added;
 }
 
-/* Exposed so `us_internal_ssl_attach`'s client branch can skip the
- * trust-store override when user CAs have been appended via addCACert. */
-static inline int us_ctx_has_user_ca(SSL_CTX *ctx) {
+/* Exposed for the C client-attach path (`us_internal_ssl_attach`) and for
+ * Zig's `SSLWrapper` (Duplex/UpgradedDuplex TLS) so both can skip their
+ * per-SSL trust-store override when user CAs have been installed on the
+ * CTX (either at construction or via addCACert). */
+int us_ctx_has_user_ca(SSL_CTX *ctx) {
   us_ex_idx_ensure();
   return SSL_CTX_get_ex_data(ctx, us_ctx_user_ca_idx) != NULL;
 }

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -19,6 +19,7 @@
 
 #include "internal/internal.h"
 #include "libusockets.h"
+#include <limits.h>
 #include <string.h>
 #include <stdatomic.h>
 #include <time.h>
@@ -373,6 +374,68 @@ static int add_ca_cert_to_ctx_store(SSL_CTX *ctx, const char *content, X509_STOR
 end:
   BIO_free(in);
   return count > 0;
+}
+
+/* Defined below; forward-declare so us_ssl_ctx_add_ca_pem can reference it. */
+static int us_verify_callback(int preverify_ok, X509_STORE_CTX *ctx);
+
+/* Post-construction variant of add_ca_cert_to_ctx_store for Node's
+ * `SecureContext.addCACert`. Node silently ignores empty/malformed input and
+ * duplicate CAs, and leaves the store untouched if the input has no valid
+ * PEM blocks — so there's no error return; we just count what stuck.
+ *
+ * If the CTX was built without `options.ca` its verify_mode is still
+ * SSL_VERIFY_NONE and its cert_store is the empty one SSL_CTX_new hands out.
+ * Mirror the `options.ca` path in us_ssl_ctx_build_raw: install the default
+ * trust store (OS roots + baked-in Bun roots) and flip verify_mode to
+ * SSL_VERIFY_PEER, so (a) the per-socket client override in
+ * us_internal_ssl_attach doesn't discard the CA, and (b) the CA we just
+ * added is actually consulted at handshake time. */
+int us_ssl_ctx_add_ca_pem(SSL_CTX *ctx, const char *pem, size_t pem_len) {
+  if (ctx == NULL || pem == NULL || pem_len == 0) return 0;
+  /* BoringSSL's BIO_new_mem_buf takes `ossl_ssize_t` (ptrdiff_t). Cap at
+   * INT_MAX, which is far beyond any real PEM blob. */
+  if (pem_len > (size_t)INT_MAX) return 0;
+
+  ERR_clear_error();
+
+  /* First call after a VERIFY_NONE build: upgrade to default_ca_store so the
+   * added CA joins (not replaces) the OS/baked-in trust anchors, and flip
+   * verify_mode so the client attach-time override preserves this store. */
+  X509_STORE *store = SSL_CTX_get_cert_store(ctx);
+  if (SSL_CTX_get_verify_mode(ctx) == SSL_VERIFY_NONE) {
+    X509_STORE *new_store = us_get_default_ca_store();
+    if (new_store != NULL) {
+      SSL_CTX_set_cert_store(ctx, new_store);
+      store = new_store;
+    }
+    SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, us_verify_callback);
+  }
+  if (store == NULL) return 0;
+
+  BIO *in = BIO_new_mem_buf(pem, (int)pem_len);
+  if (in == NULL) {
+    OPENSSL_PUT_ERROR(SSL, ERR_R_BUF_LIB);
+    return 0;
+  }
+
+  int added = 0;
+  X509 *x;
+  while ((x = PEM_read_bio_X509(in, NULL, SSL_CTX_get_default_passwd_cb(ctx),
+                                SSL_CTX_get_default_passwd_cb_userdata(ctx))) != NULL) {
+    if (X509_STORE_add_cert(store, x) == 1) {
+      added++;
+    }
+    /* Node behavior: swallow per-cert add failures so stray errors
+     * (X509_R_CERT_ALREADY_IN_HASH_TABLE for duplicates, anything else
+     * per-cert) don't blow up unrelated BoringSSL calls later. */
+    ERR_clear_error();
+    X509_free(x);
+  }
+  /* PEM_read_bio_X509 sets PEM_R_NO_START_LINE on EOF — normal termination. */
+  ERR_clear_error();
+  BIO_free(in);
+  return added;
 }
 
 static int us_ssl_ctx_use_certificate_chain(SSL_CTX *ctx, const char *content) {

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -477,9 +477,9 @@ int us_ssl_ctx_add_ca_pem(SSL_CTX *ctx, const char *pem, size_t pem_len) {
 }
 
 /* Exposed for the C client-attach path (`us_internal_ssl_attach`) and for
- * Zig's `SSLWrapper` (Duplex/UpgradedDuplex TLS) so both can skip their
- * per-SSL trust-store override when user CAs have been installed on the
- * CTX (either at construction or via addCACert). */
+ * Rust's `SSLWrapper` in `src/uws/lib.rs` (Duplex/UpgradedDuplex TLS) so both
+ * can skip their per-SSL trust-store override when user CAs have been
+ * installed on the CTX (either at construction or via addCACert). */
 int us_ctx_has_user_ca(SSL_CTX *ctx) {
   us_ex_idx_ensure();
   return SSL_CTX_get_ex_data(ctx, us_ctx_user_ca_idx) != NULL;

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -120,6 +120,13 @@ static int us_sni_ex_idx = -1;
 static int us_ctx_cache_ex_idx = -1;
 static int us_ssl_reneg_state_idx = -1;
 static int us_ssl_listener_ex_idx = -1;
+/* `us_ssl_ctx_add_ca_pem` (node:tls `SecureContext.addCACert`) flips this
+ * slot to !NULL. The client branch of `us_internal_ssl_attach` reads it to
+ * skip its `SSL_set0_verify_cert_store(ssl, shared_default_roots)` override
+ * — once user CAs were appended post-construction, the CTX's own store
+ * carries them, and overriding would make the added CAs invisible at
+ * handshake time. The pointer IS the value (NULL/!NULL), so no free_func. */
+static int us_ctx_user_ca_idx = -1;
 #ifdef _WIN32
 static INIT_ONCE us_ex_idx_once = INIT_ONCE_STATIC_INIT;
 #else
@@ -159,6 +166,7 @@ static void us_ex_idx_init(void) {
   us_ctx_cache_ex_idx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, bun_ssl_ctx_cache_on_free);
   us_ssl_reneg_state_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, us_ssl_reneg_state_free);
   us_ssl_listener_ex_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
+  us_ctx_user_ca_idx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
 }
 
 #ifdef _WIN32
@@ -376,21 +384,25 @@ end:
   return count > 0;
 }
 
-/* Defined below; forward-declare so us_ssl_ctx_add_ca_pem can reference it. */
-static int us_verify_callback(int preverify_ok, X509_STORE_CTX *ctx);
-
 /* Post-construction variant of add_ca_cert_to_ctx_store for Node's
  * `SecureContext.addCACert`. Node silently ignores empty/malformed input and
  * duplicate CAs, and leaves the store untouched if the input has no valid
  * PEM blocks — so there's no error return; we just count what stuck.
  *
- * If the CTX was built without `options.ca` its verify_mode is still
- * SSL_VERIFY_NONE and its cert_store is the empty one SSL_CTX_new hands out.
- * Mirror the `options.ca` path in us_ssl_ctx_build_raw: install the default
- * trust store (OS roots + baked-in Bun roots) and flip verify_mode to
- * SSL_VERIFY_PEER, so (a) the per-socket client override in
- * us_internal_ssl_attach doesn't discard the CA, and (b) the CA we just
- * added is actually consulted at handshake time. */
+ * Unlike the `options.ca` construction-time path, we do NOT flip CTX-level
+ * `verify_mode`. `SecureContext` is mode-neutral (the same object may back
+ * `tls.connect` and `tls.createServer`), and `SSL_VERIFY_PEER` on a server
+ * CTX makes BoringSSL send `CertificateRequest` even when the user never set
+ * `requestCert`. Node's `SecureContext::AddCACert` also leaves verify_mode
+ * alone.
+ *
+ * The trust store is still upgraded on the first call: a SecureContext built
+ * without `ca` has the empty default-paths store from `SSL_CTX_new`, so just
+ * appending would make a client trust ONLY the added CA, not the public web.
+ * We swap in `us_get_default_ca_store()` (OS roots + baked-in Bun roots), add
+ * the user CA on top, and flip `us_ctx_user_ca_idx` so the client branch of
+ * `us_internal_ssl_attach` knows to skip its per-socket trust-store override
+ * (the CTX's own store now carries the user CAs + default roots). */
 int us_ssl_ctx_add_ca_pem(SSL_CTX *ctx, const char *pem, size_t pem_len) {
   if (ctx == NULL || pem == NULL || pem_len == 0) return 0;
   /* BoringSSL's BIO_new_mem_buf takes `ossl_ssize_t` (ptrdiff_t). Cap at
@@ -399,17 +411,20 @@ int us_ssl_ctx_add_ca_pem(SSL_CTX *ctx, const char *pem, size_t pem_len) {
 
   ERR_clear_error();
 
-  /* First call after a VERIFY_NONE build: upgrade to default_ca_store so the
-   * added CA joins (not replaces) the OS/baked-in trust anchors, and flip
-   * verify_mode so the client attach-time override preserves this store. */
-  X509_STORE *store = SSL_CTX_get_cert_store(ctx);
-  if (SSL_CTX_get_verify_mode(ctx) == SSL_VERIFY_NONE) {
-    X509_STORE *new_store = us_get_default_ca_store();
-    if (new_store != NULL) {
-      SSL_CTX_set_cert_store(ctx, new_store);
-      store = new_store;
-    }
-    SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, us_verify_callback);
+  us_ex_idx_ensure();
+  void *marked = SSL_CTX_get_ex_data(ctx, us_ctx_user_ca_idx);
+  X509_STORE *store;
+  if (marked) {
+    /* Second+ addCACert on this CTX: reuse the store we installed last time. */
+    store = SSL_CTX_get_cert_store(ctx);
+  } else {
+    /* First call: install the default_ca_store so the added CA joins (not
+     * replaces) OS/baked-in trust anchors. The mark below is what tells the
+     * client attach path to keep this store instead of overriding it with
+     * the shared default roots. */
+    store = us_get_default_ca_store();
+    if (store == NULL) return 0;
+    SSL_CTX_set_cert_store(ctx, store);
   }
   if (store == NULL) return 0;
 
@@ -426,6 +441,13 @@ int us_ssl_ctx_add_ca_pem(SSL_CTX *ctx, const char *pem, size_t pem_len) {
     if (X509_STORE_add_cert(store, x) == 1) {
       added++;
     }
+    /* Mirror Node's `SecureContext::AddCACert` and Bun's own construction-
+     * time `add_ca_cert_to_ctx_store`: also surface the DN in the
+     * CertificateRequest's `certificate_authorities` list. Only meaningful
+     * for a server with `requestCert: true`; advisory for others. Returns 0
+     * on OOM (rare) — swallow like the rest. `add_client_CA` dups the subject
+     * name, so the `X509_free(x)` below still works. */
+    (void)SSL_CTX_add_client_CA(ctx, x);
     /* Node behavior: swallow per-cert add failures so stray errors
      * (X509_R_CERT_ALREADY_IN_HASH_TABLE for duplicates, anything else
      * per-cert) don't blow up unrelated BoringSSL calls later. */
@@ -435,7 +457,19 @@ int us_ssl_ctx_add_ca_pem(SSL_CTX *ctx, const char *pem, size_t pem_len) {
   /* PEM_read_bio_X509 sets PEM_R_NO_START_LINE on EOF — normal termination. */
   ERR_clear_error();
   BIO_free(in);
+
+  /* Mark the CTX so the client attach path preserves our trust store. */
+  if (!marked) {
+    SSL_CTX_set_ex_data(ctx, us_ctx_user_ca_idx, (void *)(uintptr_t)1);
+  }
   return added;
+}
+
+/* Exposed so `us_internal_ssl_attach`'s client branch can skip the
+ * trust-store override when user CAs have been appended via addCACert. */
+static inline int us_ctx_has_user_ca(SSL_CTX *ctx) {
+  us_ex_idx_ensure();
+  return SSL_CTX_get_ex_data(ctx, us_ctx_user_ca_idx) != NULL;
 }
 
 static int us_ssl_ctx_use_certificate_chain(SSL_CTX *ctx, const char *content) {
@@ -736,8 +770,14 @@ void us_internal_ssl_attach(struct us_socket_t *s, SSL_CTX *ctx,
      * never aborts here — JS reads verify_error and decides. */
     if (SSL_CTX_get_verify_mode(ctx) == SSL_VERIFY_NONE) {
       SSL_set_verify(ssl, SSL_VERIFY_PEER, us_verify_callback);
-      X509_STORE *roots = us_get_shared_default_ca_store();
-      if (roots) SSL_set0_verify_cert_store(ssl, roots);
+      /* ...unless `SecureContext.addCACert` already installed the default
+       * roots (and appended the user CAs) on the CTX itself. Overriding would
+       * throw away those added CAs. When the marker is set, the CTX's own
+       * store already has OS/baked-in roots + user CAs. */
+      if (!us_ctx_has_user_ca(ctx)) {
+        X509_STORE *roots = us_get_shared_default_ca_store();
+        if (roots) SSL_set0_verify_cert_store(ssl, roots);
+      }
     }
   } else {
     SSL_set_accept_state(ssl);

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -441,13 +441,17 @@ long us_ssl_ctx_live_count(void);
 
 /* Node's `SecureContext.addCACert`. Parses `pem` as one or more PEM-encoded
  * X.509 certificates and appends them to `ssl_ctx`'s verify store. On the
- * first call into a CTX whose verify_mode is still SSL_VERIFY_NONE (no `ca`
- * in options), swaps in us_get_default_ca_store() and flips verify_mode to
- * SSL_VERIFY_PEER so the per-socket client override in us_internal_ssl_attach
- * doesn't discard the added CA. Duplicates are silently ignored (Node
- * behavior). Returns the number of certificates added (0 if `pem` was empty
- * or contained no PEM blocks — not an error). Silently no-ops on NULL/0-len
- * input to mirror Node. */
+ * first call into a CTX that doesn't already carry user CAs (the `options.ca`
+ * / `options.ca_file_name` / `options.request_cert` build paths set the
+ * `us_ctx_user_ca_idx` marker at construction), swaps in
+ * us_get_default_ca_store() so the added CA joins the OS/baked-in trust
+ * anchors instead of replacing them, and flips the same marker so the
+ * per-socket client override in us_internal_ssl_attach doesn't discard the
+ * added CA. CTX verify_mode is NOT touched — that would make servers send
+ * CertificateRequest on every handshake. Duplicates are silently ignored
+ * (Node behavior). Returns the number of certificates added (0 if `pem` was
+ * empty or contained no PEM blocks — not an error). Silently no-ops on
+ * NULL/0-len input to mirror Node. */
 int us_ssl_ctx_add_ca_pem(struct ssl_ctx_st *ssl_ctx, const char *pem, size_t pem_len);
 
 /* Public interfaces for loops */

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -439,6 +439,17 @@ void us_internal_ssl_ctx_up_ref(struct ssl_ctx_st *ssl_ctx);
 void us_internal_ssl_ctx_unref(struct ssl_ctx_st *ssl_ctx);
 long us_ssl_ctx_live_count(void);
 
+/* Node's `SecureContext.addCACert`. Parses `pem` as one or more PEM-encoded
+ * X.509 certificates and appends them to `ssl_ctx`'s verify store. On the
+ * first call into a CTX whose verify_mode is still SSL_VERIFY_NONE (no `ca`
+ * in options), swaps in us_get_default_ca_store() and flips verify_mode to
+ * SSL_VERIFY_PEER so the per-socket client override in us_internal_ssl_attach
+ * doesn't discard the added CA. Duplicates are silently ignored (Node
+ * behavior). Returns the number of certificates added (0 if `pem` was empty
+ * or contained no PEM blocks — not an error). Silently no-ops on NULL/0-len
+ * input to mirror Node. */
+int us_ssl_ctx_add_ca_pem(struct ssl_ctx_st *ssl_ctx, const char *pem, size_t pem_len);
+
 /* Public interfaces for loops */
 
 /* Returns a new event loop with user data extension */

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -454,6 +454,14 @@ long us_ssl_ctx_live_count(void);
  * NULL/0-len input to mirror Node. */
 int us_ssl_ctx_add_ca_pem(struct ssl_ctx_st *ssl_ctx, const char *pem, size_t pem_len);
 
+/* 1 if this CTX already carries user CAs (installed at construction via
+ * `options.ca` / `ca_file_name` / `request_cert`, or appended by a later
+ * `us_ssl_ctx_add_ca_pem`); 0 otherwise. Client-attach paths read this to
+ * decide whether to override the per-SSL verify store with the shared
+ * default roots — they must NOT override when user CAs are on the CTX, or
+ * the added CAs become invisible at handshake time. */
+int us_ctx_has_user_ca(struct ssl_ctx_st *ssl_ctx);
+
 /* Public interfaces for loops */
 
 /* Returns a new event loop with user data extension */

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -51,6 +51,7 @@ const shellLex = $newZigFunction("shell.zig", "TestingAPIs.shellLex", 2);
 const shellParse = $newZigFunction("shell.zig", "TestingAPIs.shellParse", 2);
 
 export const sslCtxLiveCount = $newZigFunction("SecureContext.zig", "jsLiveCount", 0);
+export const secureContextVerifyMode = $newZigFunction("SecureContext.zig", "jsVerifyMode", 1);
 
 export const escapeRegExp = $newZigFunction("escapeRegExp.zig", "jsEscapeRegExp", 1);
 export const escapeRegExpForPackageNameMatching = $newZigFunction(

--- a/src/jsc/bindings/BunSecureContextCache.cpp
+++ b/src/jsc/bindings/BunSecureContextCache.cpp
@@ -24,3 +24,15 @@ extern "C" void Bun__SecureContextCache__set(Zig::GlobalObject* global, uint64_t
     JSObject* obj = JSValue::decode(value).getObject();
     if (obj) slot->set(key, obj);
 }
+
+// Called from Zig when a SecureContext mutates its SSL_CTX (e.g. addCACert):
+// the cache should no longer hand back the mutated cell for fresh
+// `createSecureContext(sameOptions)` calls, so drop the key. WeakGCMap takes
+// no position on whether the cell is still reachable — the original handle
+// keeps it alive via its JS ref.
+extern "C" void Bun__SecureContextCache__remove(Zig::GlobalObject* global, uint64_t key)
+{
+    auto& slot = global->m_secureContextCache;
+    if (!slot) return;
+    slot->remove(key);
+}

--- a/src/jsc/bindings/BunSecureContextCache.cpp
+++ b/src/jsc/bindings/BunSecureContextCache.cpp
@@ -25,11 +25,11 @@ extern "C" void Bun__SecureContextCache__set(Zig::GlobalObject* global, uint64_t
     if (obj) slot->set(key, obj);
 }
 
-// Called from Zig when a SecureContext mutates its SSL_CTX (e.g. addCACert):
-// the cache should no longer hand back the mutated cell for fresh
-// `createSecureContext(sameOptions)` calls, so drop the key. WeakGCMap takes
-// no position on whether the cell is still reachable — the original handle
-// keeps it alive via its JS ref.
+// Called from Rust (`SecureContext::add_ca_cert`) when a SecureContext mutates
+// its SSL_CTX (e.g. addCACert): the cache should no longer hand back the
+// mutated cell for fresh `createSecureContext(sameOptions)` calls, so drop the
+// key. WeakGCMap takes no position on whether the cell is still reachable — the
+// original handle keeps it alive via its JS ref.
 extern "C" void Bun__SecureContextCache__remove(Zig::GlobalObject* global, uint64_t key)
 {
     auto& slot = global->m_secureContextCache;

--- a/src/jsc/bindings/BunSecureContextCache.h
+++ b/src/jsc/bindings/BunSecureContextCache.h
@@ -25,6 +25,7 @@ public:
 
     JSC::JSObject* get(uint64_t key) { return m_map.get(key); }
     void set(uint64_t key, JSC::JSObject* value) { m_map.set(key, JSC::Weak<JSC::JSObject>(value)); }
+    void remove(uint64_t key) { m_map.remove(key); }
 
 private:
     JSC::WeakGCMap<uint64_t, JSC::JSObject, WTF::IntHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_map;

--- a/src/runtime/api/SecureContext.classes.ts
+++ b/src/runtime/api/SecureContext.classes.ts
@@ -13,12 +13,16 @@ export default [
       // old SHA-256/WeakRef cache that lived in `tls.ts`.
       intern: { fn: "intern", length: 1 },
     },
-    // No prototype surface — node:tls hands out the SecureContext object
-    // itself as `.context`. We deliberately do NOT expose the underlying
-    // SSL_CTX* to JS: a Number would lose precision above 2^53, and Node's
-    // `context._external` is a V8 External (opaque) used only by N-API
-    // addons that link OpenSSL directly, which Bun's BoringSSL build can't
-    // satisfy anyway.
-    proto: {},
+    // node:tls hands out the SecureContext object itself as `.context`. We
+    // deliberately do NOT expose the underlying SSL_CTX* to JS: a Number would
+    // lose precision above 2^53, and Node's `context._external` is a V8
+    // External (opaque) used only by N-API addons that link OpenSSL directly,
+    // which Bun's BoringSSL build can't satisfy anyway.
+    proto: {
+      // Append a PEM-encoded (possibly multi-cert) trust anchor to the
+      // context's verify store. Lenient like Node — bad input is silently
+      // ignored, duplicates are no-ops.
+      addCACert: { fn: "addCACert", length: 1 },
+    },
   }),
 ];

--- a/src/runtime/api/bun/SSLContextCache.rs
+++ b/src/runtime/api/bun/SSLContextCache.rs
@@ -189,6 +189,33 @@ impl SSLContextCache {
         Some(ctx)
     }
 
+    /// Drop `ctx` from the cache NOW (without freeing it). Used by
+    /// `SecureContext::add_ca_cert` after it mutates an SSL_CTX: the cache
+    /// memoises by input-config digest, so a mutated CTX is no longer the
+    /// canonical one for that digest and future `get_or_create` for the same
+    /// digest must build fresh. Clears `ex_data` so the later `SSL_CTX_free`
+    /// tombstone fires into a no-op instead of touching a destroyed Entry.
+    pub fn invalidate(&mut self, ctx: *mut boringssl::SSL_CTX, d: &Digest) {
+        let _guard = self.mutex.lock_guard();
+        if let Some(&entry) = self.map.get(d) {
+            // SAFETY: map values are live heap Entries; we hold the mutex.
+            if unsafe { (*entry).ctx } == ctx {
+                // SAFETY: ctx non-null (matched above); clearing the slot we set.
+                unsafe {
+                    boringssl::SSL_CTX_set_ex_data(
+                        ctx,
+                        c::us_ssl_ctx_cache_ex_idx(),
+                        ptr::null_mut(),
+                    )
+                };
+                self.map.swap_remove(d);
+                // SAFETY: entry was heap-allocated in get_or_create_digest and
+                // its ex_data back-pointer was just cleared above.
+                drop(unsafe { bun_core::heap::take(entry) });
+            }
+        }
+    }
+
     /// Reclaim tombstoned entries. Locked variant — callers hold `self.mutex`.
     fn compact_locked(&mut self) {
         let mut i: usize = 0;

--- a/src/runtime/api/bun/SSLContextCache.rs
+++ b/src/runtime/api/bun/SSLContextCache.rs
@@ -195,6 +195,11 @@ impl SSLContextCache {
     /// canonical one for that digest and future `get_or_create` for the same
     /// digest must build fresh. Clears `ex_data` so the later `SSL_CTX_free`
     /// tombstone fires into a no-op instead of touching a destroyed Entry.
+    // `ctx` is used only as a comparison key and forwarded by value to the
+    // C `SSL_CTX_set_ex_data` FFI — it is never dereferenced here (the `(*entry)`
+    // deref is of the map's heap Entry, not `ctx`), so not_unsafe_ptr_arg_deref
+    // is a false positive.
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn invalidate(&mut self, ctx: *mut boringssl::SSL_CTX, d: &Digest) {
         let _guard = self.mutex.lock_guard();
         if let Some(&entry) = self.map.get(d) {

--- a/src/runtime/api/bun/SSLContextCache.zig
+++ b/src/runtime/api/bun/SSLContextCache.zig
@@ -132,6 +132,24 @@ pub fn getOrCreateDigest(
     return ctx;
 }
 
+/// Drop `ctx` from the cache NOW (without freeing it). Used by
+/// `SecureContext.addCACert` and friends after they mutate an SSL_CTX: the
+/// cache memoises by input-config digest, so a mutated CTX is no longer the
+/// canonical one for that digest and future `getOrCreate` for the same
+/// digest must build fresh. Clears `ex_data` so the later `SSL_CTX_free`
+/// tombstone fires into a no-op instead of touching a destroyed Entry.
+pub fn invalidate(self: *SSLContextCache, ctx: *BoringSSL.SSL_CTX, d: Digest) void {
+    self.mutex.lock();
+    defer self.mutex.unlock();
+    if (self.map.get(d)) |entry| {
+        if (entry.ctx == ctx) {
+            _ = BoringSSL.SSL_CTX_set_ex_data(ctx, c.us_ssl_ctx_cache_ex_idx(), null);
+            _ = self.map.swapRemove(d);
+            bun.destroy(entry);
+        }
+    }
+}
+
 /// `CRYPTO_EX_free` for the cache slot. `ptr` is the `*Entry` we stashed via
 /// `SSL_CTX_set_ex_data` (null for CTXs that never went through the cache —
 /// e.g. `HTTPThread`'s, or build-fail paths). Runs synchronously inside

--- a/src/runtime/api/bun/SecureContext.rs
+++ b/src/runtime/api/bun/SecureContext.rs
@@ -278,8 +278,11 @@ impl SecureContext {
         // addCACert already evicted us; a subsequent createSecureContext with
         // the same digest may have installed a *different* cell. Mirror the
         // `entry.ctx == ctx` guard in `SSLContextCache::invalidate`.
-        let key =
-            u64::from_le_bytes(self.digest[0..8].try_into().expect("infallible: size matches"));
+        let key = u64::from_le_bytes(
+            self.digest[0..8]
+                .try_into()
+                .expect("infallible: size matches"),
+        );
         if cpp::Bun__SecureContextCache__get(global, key) == callframe.this() {
             cpp::Bun__SecureContextCache__remove(global, key);
         }

--- a/src/runtime/api/bun/SecureContext.rs
+++ b/src/runtime/api/bun/SecureContext.rs
@@ -52,6 +52,27 @@ pub(crate) fn js_live_count(_global: &JSGlobalObject, _callframe: &CallFrame) ->
     Ok(JSValue::js_number(c::us_ssl_ctx_live_count() as f64))
 }
 
+/// Exposed via `bun:internal-for-testing`. Takes a JS `SecureContext.context`
+/// and returns its BoringSSL `SSL_CTX_get_verify_mode` value — used by tests
+/// to assert `addCACert` doesn't flip mode-neutral contexts to
+/// `SSL_VERIFY_PEER`, which would make servers send CertificateRequest.
+#[bun_jsc::host_fn]
+pub(crate) fn js_verify_mode(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+    let args = callframe.arguments();
+    if args.is_empty() {
+        return Err(global.throw_not_enough_arguments("secureContextVerifyMode", 1, 0));
+    }
+    let Some(this) = SecureContext::from_js(args[0]) else {
+        return Err(global.throw_invalid_arguments(format_args!(
+            "secureContextVerifyMode: expected a SecureContext"
+        )));
+    };
+    // SAFETY: `from_js` returns a live `m_ctx` pointer owned by the JS wrapper;
+    // `SSL_CTX_get_verify_mode` only reads it.
+    let mode = unsafe { boringssl::SSL_CTX_get_verify_mode((*this).ctx) };
+    Ok(JSValue::js_number(mode as f64))
+}
+
 impl SecureContext {
     // Note: no `#[bun_jsc::host_fn]` here — the `Free` shim it emits calls
     // a bare `constructor(...)` which cannot resolve inside an `impl`. The
@@ -67,9 +88,17 @@ impl SecureContext {
             JSValue::UNDEFINED
         };
 
-        // SAFETY: `bun_vm()` returns the live per-global VM pointer; valid for the call.
-        let vm = global.bun_vm().as_mut();
-        let config = SSLConfig::from_js(vm, global, opts)?.unwrap_or_else(SSLConfig::zero);
+        // `tls.createSecureContext()` / `createSecureContext(null)` — Node
+        // treats both as an empty options bag (WebIDL: undefined → empty
+        // dictionary). Bindgen's converter throws ERR_INVALID_ARG_TYPE on
+        // non-objects, so skip it when the caller passed nothing.
+        let config = if opts.is_undefined_or_null() {
+            SSLConfig::zero()
+        } else {
+            // SAFETY: `bun_vm()` returns the live per-global VM pointer; valid for the call.
+            let vm = global.bun_vm().as_mut();
+            SSLConfig::from_js(vm, global, opts)?.unwrap_or_else(SSLConfig::zero)
+        };
         // `defer config.deinit()` — handled by Drop.
 
         SecureContext::create(global, &config)
@@ -93,9 +122,15 @@ impl SecureContext {
             JSValue::UNDEFINED
         };
 
-        // SAFETY: `bun_vm()` returns the live per-global VM pointer; valid for the call.
-        let vm = global.bun_vm().as_mut();
-        let config = SSLConfig::from_js(vm, global, opts)?.unwrap_or_else(SSLConfig::zero);
+        // See `constructor`: `undefined`/`null` means an empty options bag
+        // (Node WebIDL), but bindgen throws on non-objects — skip it.
+        let config = if opts.is_undefined_or_null() {
+            SSLConfig::zero()
+        } else {
+            // SAFETY: `bun_vm()` returns the live per-global VM pointer; valid for the call.
+            let vm = global.bun_vm().as_mut();
+            SSLConfig::from_js(vm, global, opts)?.unwrap_or_else(SSLConfig::zero)
+        };
         // `defer config.deinit()` — handled by Drop.
 
         let ctx_opts = config.as_usockets();
@@ -186,6 +221,77 @@ impl SecureContext {
         self.ctx
     }
 
+    /// Node's `secureContext.context.addCACert(pem)` — append one-or-more PEM
+    /// X.509 certificates to this context's trust store. Accepts strings and
+    /// Buffers/TypedArrays/ArrayBuffers (Node is the same). Lenient: empty /
+    /// malformed input is silently ignored, duplicates are no-ops. Returns
+    /// `undefined`.
+    ///
+    /// Shared-CTX caveat: `intern()` memoises both the JS cell (per-global
+    /// `Bun__SecureContextCache`) and the native `SSL_CTX*` (per-VM
+    /// `SSLContextCache`) by config digest. Before mutating we drop ourselves
+    /// from both caches so a subsequent `createSecureContext(sameOptions)`
+    /// from the SAME global builds a FRESH context instead of handing back the
+    /// now-mutated one. Native `us_ssl_ctx_add_ca_pem` does NOT touch
+    /// verify_mode (flipping CTX VERIFY_PEER would make servers built from a
+    /// mode-neutral SecureContext send CertificateRequest); it appends to the
+    /// CTX's own store and flips the `us_ctx_user_ca` marker so the per-socket
+    /// client override preserves the user CAs.
+    #[bun_jsc::host_fn(method)]
+    pub(crate) fn add_ca_cert(
+        &self,
+        global: &JSGlobalObject,
+        callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let args = callframe.arguments();
+        if args.is_empty() {
+            // Node asserts here. Prefer a clean TypeError to a crash.
+            return Err(global.throw_not_enough_arguments("addCACert", 1, 0));
+        }
+        // StringOrBuffer covers string/Buffer/TypedArray/ArrayBuffer/DataView.
+        // Anything else is a no-op (Node silently accepts non-byte input).
+        let Some(sob) = crate::node::StringOrBuffer::from_js(global, args[0])? else {
+            return Ok(JSValue::UNDEFINED);
+        };
+        let bytes = sob.slice();
+
+        // `us_ssl_ctx_add_ca_pem` short-circuits on empty input without
+        // touching the SSL_CTX, so nothing to invalidate. Bail BEFORE the
+        // cache eviction to preserve `createSecureContext(opts) ===
+        // createSecureContext(opts)` identity for the empty-bytes Node no-op.
+        if bytes.is_empty() {
+            return Ok(JSValue::UNDEFINED);
+        }
+
+        // Detach from the per-VM native cache AND the per-global JS cache
+        // BEFORE mutating the SSL_CTX — both are keyed by the original config
+        // digest, and a mutated CTX no longer matches that digest's contract.
+        // SAFETY: `runtime_state()` is the boxed per-thread RuntimeState; the
+        // embedded `ssl_ctx_cache` has a stable address for the VM's lifetime
+        // and is only touched from the JS thread.
+        let state = crate::jsc_hooks::runtime_state();
+        debug_assert!(!state.is_null(), "RuntimeState not installed");
+        let cache = unsafe { &mut (*state).ssl_ctx_cache };
+        cache.invalidate(self.ctx, &self.digest);
+
+        // JS cache: only evict if WE are still the cell under this key. A prior
+        // addCACert already evicted us; a subsequent createSecureContext with
+        // the same digest may have installed a *different* cell. Mirror the
+        // `entry.ctx == ctx` guard in `SSLContextCache::invalidate`.
+        let key =
+            u64::from_le_bytes(self.digest[0..8].try_into().expect("infallible: size matches"));
+        if cpp::Bun__SecureContextCache__get(global, key) == callframe.this() {
+            cpp::Bun__SecureContextCache__remove(global, key);
+        }
+
+        // SAFETY: `self.ctx` is a valid SSL_CTX*; `bytes` is valid for this
+        // call. The C helper copies the PEM bytes it parses.
+        unsafe {
+            c::us_ssl_ctx_add_ca_pem(self.ctx, bytes.as_ptr().cast(), bytes.len());
+        }
+        Ok(JSValue::UNDEFINED)
+    }
+
     // Codegen's `host_fn_finalize` calls this via `|b| SecureContext::finalize(b)`
     // and requires `fn finalize(self: Box<Self>)`; clippy::boxed_local is a
     // false positive on that contract.
@@ -216,5 +322,6 @@ mod cpp {
             key: u64,
             value: JSValue,
         );
+        pub(super) safe fn Bun__SecureContextCache__remove(global: &JSGlobalObject, key: u64);
     }
 }

--- a/src/runtime/api/bun/SecureContext.rs
+++ b/src/runtime/api/bun/SecureContext.rs
@@ -266,11 +266,11 @@ impl SecureContext {
         // Detach from the per-VM native cache AND the per-global JS cache
         // BEFORE mutating the SSL_CTX — both are keyed by the original config
         // digest, and a mutated CTX no longer matches that digest's contract.
+        let state = crate::jsc_hooks::runtime_state();
+        debug_assert!(!state.is_null(), "RuntimeState not installed");
         // SAFETY: `runtime_state()` is the boxed per-thread RuntimeState; the
         // embedded `ssl_ctx_cache` has a stable address for the VM's lifetime
         // and is only touched from the JS thread.
-        let state = crate::jsc_hooks::runtime_state();
-        debug_assert!(!state.is_null(), "RuntimeState not installed");
         let cache = unsafe { &mut (*state).ssl_ctx_cache };
         cache.invalidate(self.ctx, &self.digest);
 

--- a/src/runtime/api/bun/SecureContext.zig
+++ b/src/runtime/api/bun/SecureContext.zig
@@ -137,17 +137,26 @@ pub fn borrow(this: *SecureContext) *BoringSSL.SSL_CTX {
 /// Shared-CTX caveat: `SecureContext.intern()` memoises both the JS cell
 /// (per-global `Bun__SecureContextCache`) and the native `SSL_CTX*` (per-VM
 /// `SSLContextCache`) by config digest. Before mutating we drop ourselves
-/// from both caches so a subsequent `createSecureContext(sameOptions)` builds
-/// a FRESH context instead of handing back the now-mutated one. This
-/// preserves Bun's existing "one config, one SSL_CTX" hot-path behavior for
-/// the pure `createSecureContext({ca, cert, key})` pattern (no mutation ever
-/// happens there) while making `addCACert` match Node's "each SecureContext
-/// is independent" intuition for JS cells acquired AFTER the mutation.
+/// from both caches so a subsequent `createSecureContext(sameOptions)` from
+/// the SAME global builds a FRESH context instead of handing back the
+/// now-mutated one. This preserves Bun's existing "one config, one SSL_CTX"
+/// hot-path behavior for the pure `createSecureContext({ca, cert, key})`
+/// pattern (no mutation ever happens there) while making `addCACert` match
+/// Node's "each SecureContext is independent" intuition for JS cells
+/// acquired AFTER the mutation on the same global.
 ///
-/// Not matched exactly: two JS cells obtained via the same digest BEFORE the
-/// first `addCACert` call still share the underlying SSL_CTX, so a mutation
-/// through one leaks into the other. BoringSSL has no public SSL_CTX_dup and
-/// rebuilding from the digest isn't reversible — punting on that edge.
+/// Not matched exactly:
+///   - Two JS cells obtained via the same digest BEFORE the first
+///     `addCACert` call still share the underlying SSL_CTX, so a mutation
+///     through one leaks into the other. BoringSSL has no public
+///     SSL_CTX_dup and rebuilding from the digest isn't reversible.
+///   - Cross-global (node:vm / vm.runInNewContext on the same JSC VM): only
+///     the caller's global's JS cache is flushed, so a sibling global that
+///     had already cached the same digest keeps its stale cell pointing at
+///     the now-mutated SSL_CTX. Bun is effectively one-global-per-VM in all
+///     production paths (Worker = new VM); the sibling-global case is
+///     sandbox-only and uncommon for TLS config sharing — not worth the
+///     iteration machinery across globals at this point.
 pub fn addCACert(this: *SecureContext, global: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
     const args = callframe.arguments();
     if (args.len < 1) {

--- a/src/runtime/api/bun/SecureContext.zig
+++ b/src/runtime/api/bun/SecureContext.zig
@@ -174,14 +174,27 @@ pub fn addCACert(this: *SecureContext, global: *jsc.JSGlobalObject, callframe: *
     defer sob.deinit();
     const bytes = sob.slice();
 
+    // `us_ssl_ctx_add_ca_pem` short-circuits on empty input without touching
+    // the SSL_CTX, so nothing to invalidate. Bail BEFORE the cache eviction
+    // to preserve `createSecureContext(opts) === createSecureContext(opts)`
+    // identity for the "addCACert with empty bytes" Node no-op.
+    if (bytes.len == 0) return .js_undefined;
+
     // Detach from the per-VM native cache AND the per-global JS cache BEFORE
     // mutating the SSL_CTX. Both are keyed by the original config digest,
     // and a mutated CTX no longer matches that digest's "what would
     // createSSLContext(opts) build?" contract — future hits must rebuild.
     // Idempotent on repeat calls (already-removed → no-op).
     global.bunVM().rareData().sslCtxCache().invalidate(this.ctx, this.digest);
+    // JS cache: only evict if WE are still the cell under this key. A prior
+    // addCACert already evicted us; a subsequent createSecureContext with
+    // the same digest may have installed a *different* cell. Mirror the
+    // `if (entry.ctx == ctx)` guard in `SSLContextCache.invalidate`.
     const key = std.mem.readInt(u64, this.digest[0..8], .little);
-    cpp.Bun__SecureContextCache__remove(global, key);
+    const this_js = callframe.this();
+    if (cpp.Bun__SecureContextCache__get(global, key) == this_js) {
+        cpp.Bun__SecureContextCache__remove(global, key);
+    }
 
     _ = c.us_ssl_ctx_add_ca_pem(this.ctx, bytes.ptr, bytes.len);
     return .js_undefined;

--- a/src/runtime/api/bun/SecureContext.zig
+++ b/src/runtime/api/bun/SecureContext.zig
@@ -202,6 +202,18 @@ pub fn jsLiveCount(_: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!jsc.JS
     return jsc.JSValue.jsNumber(c.us_ssl_ctx_live_count());
 }
 
+/// Exposed via `bun:internal-for-testing`. Takes a JS `SecureContext.context`
+/// (a `JSSecureContext`) and returns its BoringSSL `SSL_CTX_get_verify_mode`
+/// value — used by tests to assert `addCACert` doesn't flip mode-neutral
+/// contexts to `SSL_VERIFY_PEER`, which would make servers send
+/// `CertificateRequest` unexpectedly.
+pub fn jsVerifyMode(global: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+    const args = callframe.arguments();
+    if (args.len < 1) return global.throwNotEnoughArguments("secureContextVerifyMode", 1, 0);
+    const this = fromJS(args[0]) orelse return global.throwInvalidArgumentType("secureContextVerifyMode", "context", "SecureContext");
+    return jsc.JSValue.jsNumber(BoringSSL.SSL_CTX_get_verify_mode(this.ctx));
+}
+
 const ssl_ctx_base_cost: usize = 50 * 1024;
 
 pub const c = uws.SocketContext.c;

--- a/src/runtime/api/bun/SecureContext.zig
+++ b/src/runtime/api/bun/SecureContext.zig
@@ -32,7 +32,14 @@ pub fn constructor(global: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.J
     const args = callframe.arguments();
     const opts = if (args.len > 0) args[0] else .js_undefined;
 
-    var config = (try SSLConfig.fromJS(global.bunVM(), global, opts)) orelse SSLConfig.zero;
+    // `tls.createSecureContext()` with no arg matches an all-defaults config
+    // in Node (WebIDL: undefined → empty dictionary). Bindgen's generated
+    // converter throws ERR_INVALID_ARG_TYPE on non-objects, so skip it
+    // outright when we know the caller didn't pass anything.
+    var config = if (opts.isUndefinedOrNull())
+        SSLConfig.zero
+    else
+        (try SSLConfig.fromJS(global.bunVM(), global, opts)) orelse SSLConfig.zero;
     defer config.deinit();
 
     return try create(global, &config);
@@ -82,7 +89,14 @@ pub fn intern(global: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSErro
     const args = callframe.arguments();
     const opts = if (args.len > 0) args[0] else .js_undefined;
 
-    var config = (try SSLConfig.fromJS(global.bunVM(), global, opts)) orelse SSLConfig.zero;
+    // `tls.createSecureContext()` (no arg) or `createSecureContext(null)` —
+    // Node treats both as an empty options bag (WebIDL: undefined → empty
+    // dictionary). Bindgen's converter throws ERR_INVALID_ARG_TYPE on
+    // non-objects, so skip it outright when the caller passed nothing.
+    var config = if (opts.isUndefinedOrNull())
+        SSLConfig.zero
+    else
+        (try SSLConfig.fromJS(global.bunVM(), global, opts)) orelse SSLConfig.zero;
     defer config.deinit();
 
     const ctx_opts = config.asUSockets();
@@ -114,6 +128,56 @@ pub fn borrow(this: *SecureContext) *BoringSSL.SSL_CTX {
     return this.ctx;
 }
 
+/// Node's `secureContext.context.addCACert(pem)` — append one-or-more PEM
+/// X.509 certificates to this context's trust store. Accepts strings and
+/// Buffers/TypedArrays/ArrayBuffers (Node is the same). Lenient: empty /
+/// malformed input is silently ignored, duplicates are no-ops. Returns
+/// `undefined`.
+///
+/// Shared-CTX caveat: `SecureContext.intern()` memoises both the JS cell
+/// (per-global `Bun__SecureContextCache`) and the native `SSL_CTX*` (per-VM
+/// `SSLContextCache`) by config digest. Before mutating we drop ourselves
+/// from both caches so a subsequent `createSecureContext(sameOptions)` builds
+/// a FRESH context instead of handing back the now-mutated one. This
+/// preserves Bun's existing "one config, one SSL_CTX" hot-path behavior for
+/// the pure `createSecureContext({ca, cert, key})` pattern (no mutation ever
+/// happens there) while making `addCACert` match Node's "each SecureContext
+/// is independent" intuition for JS cells acquired AFTER the mutation.
+///
+/// Not matched exactly: two JS cells obtained via the same digest BEFORE the
+/// first `addCACert` call still share the underlying SSL_CTX, so a mutation
+/// through one leaks into the other. BoringSSL has no public SSL_CTX_dup and
+/// rebuilding from the digest isn't reversible — punting on that edge.
+pub fn addCACert(this: *SecureContext, global: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+    const args = callframe.arguments();
+    if (args.len < 1) {
+        // Node asserts here. Prefer a clean TypeError to a crash — matches
+        // the validation style in the `tls.ts` wrapper above.
+        return global.throwNotEnoughArguments("addCACert", 1, 0);
+    }
+    // StringOrBuffer covers the common shapes (string, Buffer, TypedArray,
+    // ArrayBuffer, DataView). Anything else (number/object/null/undefined)
+    // becomes null here — Node silently accepts these as a no-op, so mirror
+    // that instead of throwing.
+    const sob = try jsc.Node.StringOrBuffer.fromJS(global, bun.default_allocator, args[0]) orelse {
+        return .js_undefined;
+    };
+    defer sob.deinit();
+    const bytes = sob.slice();
+
+    // Detach from the per-VM native cache AND the per-global JS cache BEFORE
+    // mutating the SSL_CTX. Both are keyed by the original config digest,
+    // and a mutated CTX no longer matches that digest's "what would
+    // createSSLContext(opts) build?" contract — future hits must rebuild.
+    // Idempotent on repeat calls (already-removed → no-op).
+    global.bunVM().rareData().sslCtxCache().invalidate(this.ctx, this.digest);
+    const key = std.mem.readInt(u64, this.digest[0..8], .little);
+    cpp.Bun__SecureContextCache__remove(global, key);
+
+    _ = c.us_ssl_ctx_add_ca_pem(this.ctx, bytes.ptr, bytes.len);
+    return .js_undefined;
+}
+
 pub fn finalize(this: *SecureContext) callconv(.c) void {
     BoringSSL.SSL_CTX_free(this.ctx);
     bun.destroy(this);
@@ -136,6 +200,7 @@ pub const c = uws.SocketContext.c;
 const cpp = struct {
     pub extern fn Bun__SecureContextCache__get(*jsc.JSGlobalObject, u64) jsc.JSValue;
     pub extern fn Bun__SecureContextCache__set(*jsc.JSGlobalObject, u64, jsc.JSValue) void;
+    pub extern fn Bun__SecureContextCache__remove(*jsc.JSGlobalObject, u64) void;
 };
 
 const std = @import("std");

--- a/src/runtime/socket/ssl_wrapper.zig
+++ b/src/runtime/socket/ssl_wrapper.zig
@@ -78,8 +78,16 @@ pub fn SSLWrapper(comptime T: type) type {
                 // and `SSLConfig.fromJS` rebuilt the CTX with roots from that.)
                 if (BoringSSL.SSL_CTX_get_verify_mode(ctx) == BoringSSL.SSL_VERIFY_NONE) {
                     BoringSSL.SSL_set_verify(ssl, BoringSSL.SSL_VERIFY_PEER, alwaysContinueVerify);
-                    if (us_get_shared_default_ca_store()) |roots| {
-                        _ = BoringSSL.SSL_set0_verify_cert_store(ssl, roots);
+                    // ...unless user CAs were already installed on this CTX
+                    // (by `options.ca` at construction, or by a later
+                    // `SecureContext.addCACert`). Overriding the per-SSL
+                    // trust store would throw those CAs away at handshake
+                    // time. This mirrors the same guard in
+                    // `us_internal_ssl_attach`'s client branch.
+                    if (us_ctx_has_user_ca(ctx) == 0) {
+                        if (us_get_shared_default_ca_store()) |roots| {
+                            _ = BoringSSL.SSL_set0_verify_cert_store(ssl, roots);
+                        }
                     }
                 }
             } else {
@@ -535,6 +543,7 @@ fn alwaysContinueVerify(_: c_int, _: ?*BoringSSL.X509_STORE_CTX) callconv(.c) c_
 /// up_ref'd per consumer so the ~150-cert load happens once total, not per
 /// CTX. Returns null if root loading fails (treated as "no roots").
 extern fn us_get_shared_default_ca_store() ?*BoringSSL.X509_STORE;
+extern fn us_ctx_has_user_ca(*BoringSSL.SSL_CTX) c_int;
 
 const bun = @import("bun");
 const jsc = bun.jsc;

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -432,11 +432,19 @@ pub mod ssl_wrapper {
                             boring_sys::SSL_VERIFY_PEER,
                             Some(always_continue_verify),
                         );
-                        if let Some(roots) = NonNull::new(us_get_shared_default_ca_store()) {
-                            let _ = boring_sys::SSL_set0_verify_cert_store(
-                                ssl.as_ptr(),
-                                roots.as_ptr(),
-                            );
+                        // ...unless user CAs were installed on this CTX (by
+                        // `options.ca` at construction, or a later
+                        // `SecureContext.addCACert`). Overriding the per-SSL
+                        // trust store would discard those CAs at handshake
+                        // time. Same guard as `us_internal_ssl_attach`'s
+                        // client branch.
+                        if us_ctx_has_user_ca(ctx.as_ptr()) == 0 {
+                            if let Some(roots) = NonNull::new(us_get_shared_default_ca_store()) {
+                                let _ = boring_sys::SSL_set0_verify_cert_store(
+                                    ssl.as_ptr(),
+                                    roots.as_ptr(),
+                                );
+                            }
                         }
                     }
                 } else {
@@ -1148,6 +1156,13 @@ pub mod ssl_wrapper {
         /// CTX. Returns null if root loading fails (treated as "no roots").
         // safe: no args; idempotent lazy init reading a process global — no preconditions.
         safe fn us_get_shared_default_ca_store() -> *mut boring_sys::X509_STORE;
+        /// 1 if user CAs were installed on `ctx` (at construction via
+        /// `options.ca`/`ca_file_name`/`request_cert`, or by a later
+        /// `SecureContext.addCACert`). The client branch reads it to skip the
+        /// per-SSL trust-store override that would otherwise discard those CAs.
+        // safe: reads an ex_data slot on a live CTX; no preconditions beyond a valid ptr,
+        // which the caller holds via NonNull<SSL_CTX>.
+        safe fn us_ctx_has_user_ca(ctx: *mut boring_sys::SSL_CTX) -> core::ffi::c_int;
         /// Implemented in uSockets C; reads
         /// `SSL_get_verify_result` and maps it onto the C `us_bun_verify_error_t`.
         fn us_ssl_socket_verify_error_from_ssl(ssl: *mut boring_sys::SSL) -> us_bun_verify_error_t;

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -1160,9 +1160,10 @@ pub mod ssl_wrapper {
         /// `options.ca`/`ca_file_name`/`request_cert`, or by a later
         /// `SecureContext.addCACert`). The client branch reads it to skip the
         /// per-SSL trust-store override that would otherwise discard those CAs.
-        // safe: reads an ex_data slot on a live CTX; no preconditions beyond a valid ptr,
-        // which the caller holds via NonNull<SSL_CTX>.
-        safe fn us_ctx_has_user_ca(ctx: *mut boring_sys::SSL_CTX) -> core::ffi::c_int;
+        /// Reads an ex_data slot on `ctx`, so (like the other pointer-taking
+        /// externs in this block) the caller must pass a live, non-null
+        /// `SSL_CTX*` — the call site holds one via `NonNull<SSL_CTX>`.
+        fn us_ctx_has_user_ca(ctx: *mut boring_sys::SSL_CTX) -> core::ffi::c_int;
         /// Implemented in uSockets C; reads
         /// `SSL_get_verify_result` and maps it onto the C `us_bun_verify_error_t`.
         fn us_ssl_socket_verify_error_from_ssl(ssl: *mut boring_sys::SSL) -> us_bun_verify_error_t;

--- a/src/uws_sys/SocketContext.rs
+++ b/src/uws_sys/SocketContext.rs
@@ -297,6 +297,7 @@ impl Sha256 {
 
 pub mod c {
     use super::*;
+    use core::ffi::c_int;
     unsafe extern "C" {
         pub(crate) fn us_ssl_ctx_from_options(
             options: BunSocketContextOptions,
@@ -304,5 +305,23 @@ pub mod c {
         ) -> *mut SSL_CTX;
         // safe: no args; reads a process-global counter — no preconditions.
         pub safe fn us_ssl_ctx_live_count() -> c_long;
+        /// Node's `SecureContext.addCACert` — appends one-or-more PEM X509s to
+        /// `ctx`'s trust store. On first call into a CTX without user CAs,
+        /// swaps in the default CA store (OS + baked-in roots) and flips an
+        /// ex_data marker so the per-socket client override preserves it. Does
+        /// NOT touch verify_mode (flipping CTX VERIFY_PEER would make servers
+        /// built from a mode-neutral SecureContext send CertificateRequest).
+        /// Returns the count of certs added; 0 is not an error.
+        pub fn us_ssl_ctx_add_ca_pem(
+            ctx: *mut SSL_CTX,
+            pem: *const c_char,
+            pem_len: usize,
+        ) -> c_int;
+        /// 1 if user CAs were installed on `ctx` (at construction via
+        /// `options.ca`/`ca_file_name`/`request_cert`, or by a later
+        /// `us_ssl_ctx_add_ca_pem`); 0 otherwise. Client-attach paths read
+        /// this to decide whether to override the per-SSL verify store with
+        /// the shared default roots.
+        pub fn us_ctx_has_user_ca(ctx: *mut SSL_CTX) -> c_int;
     }
 }

--- a/src/uws_sys/SocketContext.zig
+++ b/src/uws_sys/SocketContext.zig
@@ -131,11 +131,14 @@ pub const c = struct {
     pub extern fn us_ssl_ctx_from_options(BunSocketContextOptions, *uws.create_bun_socket_error_t) ?*BoringSSL.SSL_CTX;
     pub extern fn us_ssl_ctx_live_count() c_long;
     /// Node's `SecureContext.addCACert` — appends one-or-more PEM X509s to
-    /// `ctx`'s trust store, lazily installing the default CA store and
-    /// flipping verify_mode to SSL_VERIFY_PEER on first use (so the per-socket
-    /// client override in us_internal_ssl_attach doesn't discard the added
-    /// CA). Returns the count of certs that actually stuck; 0 is not an
-    /// error (Node silently ignores empty / malformed input).
+    /// `ctx`'s trust store. On first call into a CTX that wasn't built with
+    /// user CAs, swaps in the default CA store (OS + baked-in roots) and
+    /// flips an ex_data marker so the per-socket client override in
+    /// `us_internal_ssl_attach` preserves this store. Does NOT touch
+    /// `verify_mode` — flipping CTX-level VERIFY_PEER would make servers
+    /// built from a mode-neutral SecureContext send CertificateRequest on
+    /// every handshake. Returns the count of certs that actually stuck; 0
+    /// is not an error (Node silently ignores empty / malformed input).
     pub extern fn us_ssl_ctx_add_ca_pem(*BoringSSL.SSL_CTX, [*c]const u8, usize) c_int;
 };
 

--- a/src/uws_sys/SocketContext.zig
+++ b/src/uws_sys/SocketContext.zig
@@ -130,6 +130,13 @@ pub const BunSocketContextOptions = extern struct {
 pub const c = struct {
     pub extern fn us_ssl_ctx_from_options(BunSocketContextOptions, *uws.create_bun_socket_error_t) ?*BoringSSL.SSL_CTX;
     pub extern fn us_ssl_ctx_live_count() c_long;
+    /// Node's `SecureContext.addCACert` — appends one-or-more PEM X509s to
+    /// `ctx`'s trust store, lazily installing the default CA store and
+    /// flipping verify_mode to SSL_VERIFY_PEER on first use (so the per-socket
+    /// client override in us_internal_ssl_attach doesn't discard the added
+    /// CA). Returns the count of certs that actually stuck; 0 is not an
+    /// error (Node silently ignores empty / malformed input).
+    pub extern fn us_ssl_ctx_add_ca_pem(*BoringSSL.SSL_CTX, [*c]const u8, usize) c_int;
 };
 
 const std = @import("std");

--- a/test/js/node/tls/node-tls-context.test.ts
+++ b/test/js/node/tls/node-tls-context.test.ts
@@ -7,8 +7,9 @@ import { secureContextVerifyMode } from "bun:internal-for-testing";
 import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 
 import { readFileSync } from "node:fs";
-import { AddressInfo } from "node:net";
+import net, { AddressInfo } from "node:net";
 import { join } from "node:path";
+import { Duplex } from "node:stream";
 import tls from "node:tls";
 
 function loadPEM(filename: string) {
@@ -830,9 +831,6 @@ describe("tls.createSecureContext().context.addCACert", () => {
   // discarded when TLS runs on top of a Duplex (Bun.TCPSocket-over-Duplex,
   // node:tls proxies, Windows named pipes).
   it("added CA survives on the Duplex-wrapped client path", async () => {
-    const { Duplex } = await import("node:stream");
-    const net = await import("node:net");
-
     await using server = Bun.listen({
       hostname: "127.0.0.1",
       port: 0,

--- a/test/js/node/tls/node-tls-context.test.ts
+++ b/test/js/node/tls/node-tls-context.test.ts
@@ -2,6 +2,8 @@
 // selects the most recently added SecureContext that matches the servername.
 
 import { describe, expect, it } from "bun:test";
+// @ts-expect-error — debug-only export
+import { secureContextVerifyMode } from "bun:internal-for-testing";
 import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 
 import { readFileSync } from "node:fs";
@@ -629,17 +631,18 @@ describe("tls.createSecureContext().context.addCACert", () => {
     expect(await promise).toBe(true);
   });
 
-  it("silently ignores non-PEM input (Node parity)", () => {
-    // Node's addCACert is lenient — it doesn't throw on malformed input,
-    // empty strings, or anything that doesn't coerce to bytes it recognises.
+  it("silently ignores empty / malformed PEM input (Node parity)", () => {
+    // Within the documented input surface (string / Buffer / TypedArray /
+    // ArrayBuffer), Node's addCACert is lenient about byte content — an
+    // empty or malformed blob is a no-op, not a throw. Invalid JS types
+    // (null/undefined/number/plain object) are NOT part of the contract;
+    // their behavior is intentionally unspecified and tested elsewhere.
     const ctx = tls.createSecureContext();
     expect(() => ctx.context.addCACert("")).not.toThrow();
     expect(() => ctx.context.addCACert("not pem")).not.toThrow();
     expect(() => ctx.context.addCACert(Buffer.alloc(0))).not.toThrow();
-    expect(() => ctx.context.addCACert(null)).not.toThrow();
-    expect(() => ctx.context.addCACert(undefined)).not.toThrow();
-    expect(() => ctx.context.addCACert(42)).not.toThrow();
-    expect(() => ctx.context.addCACert({})).not.toThrow();
+    expect(() => ctx.context.addCACert(new Uint8Array())).not.toThrow();
+    expect(() => ctx.context.addCACert(new ArrayBuffer(0))).not.toThrow();
   });
 
   it("is idempotent on duplicate CAs", () => {
@@ -742,9 +745,9 @@ describe("tls.createSecureContext().context.addCACert", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect(exitCode).toBe(0);
     const result = JSON.parse(stdout.trim());
     expect(result.authorized).toBe(true);
+    expect(exitCode).toBe(0);
   });
 
   it("requires at least one argument", () => {
@@ -759,10 +762,7 @@ describe("tls.createSecureContext().context.addCACert", () => {
   // in every handshake (e.g. browsers would prompt for a client certificate).
   // Node's `SecureContext::AddCACert` never touches verify_mode for exactly
   // this reason.
-  it("does not flip CTX verify_mode (would leak as server requestCert)", async () => {
-    // @ts-expect-error — debug-only export
-    const { secureContextVerifyMode } = await import("bun:internal-for-testing");
-
+  it("does not flip CTX verify_mode (would leak as server requestCert)", () => {
     // Baseline: a fresh SecureContext has SSL_VERIFY_NONE (= 0).
     const ctx = tls.createSecureContext({ cert: agent1Cert, key: agent1Key });
     expect(secureContextVerifyMode(ctx.context)).toBe(0);
@@ -776,5 +776,47 @@ describe("tls.createSecureContext().context.addCACert", () => {
     // For completeness: the `options.ca` construction path still flips
     // verify_mode (pre-existing quirk we're not changing), so this is the
     // strict stronger guarantee for the post-construction API only.
+  });
+
+  // Regression found in review: the first addCACert() on a context built
+  // with `options.ca` must append to — not replace — the construction-time
+  // trust store. If we swap in a fresh `us_get_default_ca_store()` on the
+  // first call, the CAs passed to `createSecureContext({ca: ...})` are
+  // silently dropped, breaking `{ca: corpRoot}.addCACert(extraCA)`.
+  it("preserves construction-time CAs on the first addCACert call", async () => {
+    // Build with ca1 at construction time; then add the unrelated ca2 on top.
+    // agent1 (signed by ca1) must still verify afterwards.
+    const ctx = tls.createSecureContext({ ca: ca1 });
+    ctx.context.addCACert(ca2);
+
+    const { promise, resolve, reject } = Promise.withResolvers<boolean>();
+    await using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      tls: { cert: agent1Cert, key: agent1Key },
+      socket: {
+        data() {},
+        error() {},
+        open(s) {
+          s.end();
+        },
+      },
+    });
+    const client = tls.connect(
+      {
+        port: server.port,
+        host: "127.0.0.1",
+        secureContext: ctx,
+        rejectUnauthorized: false,
+        servername: "agent1",
+      },
+      () => {
+        resolve(client.authorized);
+        client.end();
+      },
+    );
+    client.on("error", reject);
+
+    expect(await promise).toBe(true);
   });
 });

--- a/test/js/node/tls/node-tls-context.test.ts
+++ b/test/js/node/tls/node-tls-context.test.ts
@@ -522,7 +522,13 @@ describe("tls.createSecureContext().context.addCACert", () => {
       hostname: "127.0.0.1",
       port: 0,
       tls: { cert: agent1Cert, key: agent1Key },
-      socket: { data() {}, error() {}, open(s) { s.end(); } },
+      socket: {
+        data() {},
+        error() {},
+        open(s) {
+          s.end();
+        },
+      },
     });
 
     const ctx = tls.createSecureContext();
@@ -553,7 +559,13 @@ describe("tls.createSecureContext().context.addCACert", () => {
       hostname: "127.0.0.1",
       port: 0,
       tls: { cert: agent1Cert, key: agent1Key },
-      socket: { data() {}, error() {}, open(s) { s.end(); } },
+      socket: {
+        data() {},
+        error() {},
+        open(s) {
+          s.end();
+        },
+      },
     });
 
     // Add ca2 — server cert is signed by ca1, so authorization must fail.
@@ -586,7 +598,13 @@ describe("tls.createSecureContext().context.addCACert", () => {
       hostname: "127.0.0.1",
       port: 0,
       tls: { cert: agent1Cert, key: agent1Key },
-      socket: { data() {}, error() {}, open(s) { s.end(); } },
+      socket: {
+        data() {},
+        error() {},
+        open(s) {
+          s.end();
+        },
+      },
     });
 
     const ctx = tls.createSecureContext();
@@ -640,7 +658,13 @@ describe("tls.createSecureContext().context.addCACert", () => {
       hostname: "127.0.0.1",
       port: 0,
       tls: { cert: agent1Cert, key: agent1Key },
-      socket: { data() {}, error() {}, open(s) { s.end(); } },
+      socket: {
+        data() {},
+        error() {},
+        open(s) {
+          s.end();
+        },
+      },
     });
 
     const ctx = tls.createSecureContext();

--- a/test/js/node/tls/node-tls-context.test.ts
+++ b/test/js/node/tls/node-tls-context.test.ts
@@ -515,10 +515,10 @@ describe("tls.createSecureContext().context.addCACert", () => {
 
   it("accepts createSecureContext(null) (Node parity)", () => {
     // Node treats `undefined` / `null` as an empty dictionary. Bindgen's
-    // converter throws ERR_INVALID_ARG_TYPE on non-objects, so the Zig
-    // constructor/intern paths short-circuit on `isUndefinedOrNull` before
-    // reaching it. The sibling "is a function" test above covers the
-    // no-arg form; this one covers explicit `null`.
+    // converter throws ERR_INVALID_ARG_TYPE on non-objects, so the
+    // constructor/intern paths (Rust `SecureContext.rs`) short-circuit on
+    // `is_undefined_or_null()` before reaching it. The sibling "is a function"
+    // test above covers the no-arg form; this one covers explicit `null`.
     const ctx = tls.createSecureContext(null);
     expect(typeof ctx.context.addCACert).toBe("function");
   });

--- a/test/js/node/tls/node-tls-context.test.ts
+++ b/test/js/node/tls/node-tls-context.test.ts
@@ -512,10 +512,13 @@ describe("tls.createSecureContext().context.addCACert", () => {
     expect(typeof ctx.context.addCACert).toBe("function");
   });
 
-  it("accepts no arg options (Node parity)", () => {
-    // Node: `createSecureContext()` with no argument is equivalent to `{}`.
-    // Previously threw `TLSOptions must be an object` in Bun.
-    const ctx = tls.createSecureContext();
+  it("accepts createSecureContext(null) (Node parity)", () => {
+    // Node treats `undefined` / `null` as an empty dictionary. Bindgen's
+    // converter throws ERR_INVALID_ARG_TYPE on non-objects, so the Zig
+    // constructor/intern paths short-circuit on `isUndefinedOrNull` before
+    // reaching it. The sibling "is a function" test above covers the
+    // no-arg form; this one covers explicit `null`.
+    const ctx = tls.createSecureContext(null);
     expect(typeof ctx.context.addCACert).toBe("function");
   });
 
@@ -809,6 +812,65 @@ describe("tls.createSecureContext().context.addCACert", () => {
         secureContext: ctx,
         rejectUnauthorized: false,
         servername: "agent1",
+      },
+      () => {
+        resolve(client.authorized);
+        client.end();
+      },
+    );
+    client.on("error", reject);
+
+    expect(await promise).toBe(true);
+  });
+
+  // `tls.connect({ socket: duplex })` routes through `SSLWrapper` in
+  // `src/runtime/socket/ssl_wrapper.zig` instead of `us_internal_ssl_attach`.
+  // That path had the same per-SSL `SSL_set0_verify_cert_store` override and
+  // needs the same `us_ctx_has_user_ca` gate, or addCACert'd CAs are
+  // discarded when TLS runs on top of a Duplex (Bun.TCPSocket-over-Duplex,
+  // node:tls proxies, Windows named pipes).
+  it("added CA survives on the Duplex-wrapped client path", async () => {
+    const { Duplex } = await import("node:stream");
+    const net = await import("node:net");
+
+    await using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      tls: { cert: agent1Cert, key: agent1Key },
+      socket: {
+        data() {},
+        error() {},
+        open(s) {
+          s.end();
+        },
+      },
+    });
+
+    const rawSocket = net.connect(server.port, "127.0.0.1");
+    const duplex = new Duplex({
+      read() {},
+      write(chunk, _enc, cb) {
+        rawSocket.write(chunk, cb);
+      },
+      final(cb) {
+        rawSocket.end(cb);
+      },
+    });
+    rawSocket.on("data", c => duplex.push(c));
+    rawSocket.on("end", () => duplex.push(null));
+    rawSocket.on("error", e => duplex.destroy(e));
+
+    const ctx = tls.createSecureContext();
+    ctx.context.addCACert(ca1);
+
+    const { promise, resolve, reject } = Promise.withResolvers<boolean>();
+    const client = tls.connect(
+      {
+        socket: duplex,
+        host: "127.0.0.1",
+        servername: "agent1",
+        secureContext: ctx,
+        rejectUnauthorized: false,
       },
       () => {
         resolve(client.authorized);

--- a/test/js/node/tls/node-tls-context.test.ts
+++ b/test/js/node/tls/node-tls-context.test.ts
@@ -824,8 +824,8 @@ describe("tls.createSecureContext().context.addCACert", () => {
     expect(await promise).toBe(true);
   });
 
-  // `tls.connect({ socket: duplex })` routes through `SSLWrapper` in
-  // `src/runtime/socket/ssl_wrapper.zig` instead of `us_internal_ssl_attach`.
+  // `tls.connect({ socket: duplex })` routes through `SSLWrapper` (the Rust
+  // `ssl_wrapper` module in `src/uws/lib.rs`) instead of `us_internal_ssl_attach`.
   // That path had the same per-SSL `SSL_set0_verify_cert_store` override and
   // needs the same `us_ctx_has_user_ca` gate, or addCACert'd CAs are
   // discarded when TLS runs on top of a Duplex (Bun.TCPSocket-over-Duplex,

--- a/test/js/node/tls/node-tls-context.test.ts
+++ b/test/js/node/tls/node-tls-context.test.ts
@@ -2,6 +2,7 @@
 // selects the most recently added SecureContext that matches the servername.
 
 import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 
 import { readFileSync } from "node:fs";
 import { AddressInfo } from "node:net";
@@ -688,29 +689,66 @@ describe("tls.createSecureContext().context.addCACert", () => {
     expect(await promise).toBe(true);
   });
 
-  it("preserves OS/default trust anchors", async () => {
-    // After addCACert, connecting to a host signed by a public CA must still
-    // work — we should ADD to the default trust store, not REPLACE it.
-    const ctx = tls.createSecureContext();
-    ctx.context.addCACert(ca2); // unrelated private CA
-
-    const { promise, resolve, reject } = Promise.withResolvers<boolean>();
-    const client = tls.connect(
-      {
-        port: 443,
-        host: "bun.sh",
-        secureContext: ctx,
-        rejectUnauthorized: true,
-        servername: "bun.sh",
-      },
-      () => {
-        resolve(client.authorized);
-        client.end();
-      },
-    );
-    client.on("error", reject);
-
-    expect(await promise).toBe(true);
+  it("preserves default trust anchors (addCACert adds, not replaces)", async () => {
+    // Deterministic version of "trust the internet after addCACert": run a
+    // child bun with NODE_EXTRA_CA_CERTS=ca1 so ca1 is baked into the default
+    // trust store, then call addCACert(ca2) on a fresh SecureContext. If the
+    // first call REPLACED the store with a fresh one, ca1 would be gone and
+    // the agent1 handshake would fail; the assertion is that it still
+    // succeeds. Uses a child process so the env var is read at startup.
+    const dir = tempDirWithFiles("tls-addcacert-preserve", {
+      "ca1.pem": ca1,
+      "ca2.pem": ca2,
+      "agent1-cert.pem": agent1Cert,
+      "agent1-key.pem": agent1Key,
+      "check.js": /* js */ `
+        const tls = require("node:tls");
+        const fs = require("node:fs");
+        const path = require("node:path");
+        const server = tls.createServer(
+          {
+            cert: fs.readFileSync(path.join(__dirname, "agent1-cert.pem")),
+            key: fs.readFileSync(path.join(__dirname, "agent1-key.pem")),
+          },
+          s => s.end(),
+        );
+        server.listen(0, () => {
+          const port = server.address().port;
+          const ctx = tls.createSecureContext();
+          // Mutating: if we replaced the default store, NODE_EXTRA_CA_CERTS's
+          // ca1 contribution disappears and the handshake below fails.
+          ctx.context.addCACert(fs.readFileSync(path.join(__dirname, "ca2.pem")));
+          const client = tls.connect(
+            { port, host: "127.0.0.1", secureContext: ctx, servername: "agent1", rejectUnauthorized: false },
+            () => {
+              console.log(JSON.stringify({ authorized: client.authorized, error: client.authorizationError ?? null }));
+              client.end();
+              server.close();
+            },
+          );
+          client.on("error", e => {
+            console.log(JSON.stringify({ authorized: false, error: String(e) }));
+            server.close();
+          });
+        });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "check.js"],
+      env: { ...bunEnv, NODE_EXTRA_CA_CERTS: join(dir, "ca1.pem") },
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    const result = JSON.parse(stdout.trim());
+    expect(result.authorized).toBe(true);
   });
 
   it("requires at least one argument", () => {

--- a/test/js/node/tls/node-tls-context.test.ts
+++ b/test/js/node/tls/node-tls-context.test.ts
@@ -499,3 +499,199 @@ describe("Bun.serve SNI", () => {
     }
   });
 });
+
+// Regression: https://github.com/oven-sh/bun/issues/30485
+// `tls.createSecureContext().context.addCACert` used to be `undefined` — the
+// native SecureContext prototype was empty.
+describe("tls.createSecureContext().context.addCACert", () => {
+  it("is a function on the native context", () => {
+    const ctx = tls.createSecureContext();
+    expect(typeof ctx.context.addCACert).toBe("function");
+  });
+
+  it("accepts no arg options (Node parity)", () => {
+    // Node: `createSecureContext()` with no argument is equivalent to `{}`.
+    // Previously threw `TLSOptions must be an object` in Bun.
+    const ctx = tls.createSecureContext();
+    expect(typeof ctx.context.addCACert).toBe("function");
+  });
+
+  it("makes the added CA trusted on a fresh context", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<{ authorized: boolean; error: any }>();
+    await using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      tls: { cert: agent1Cert, key: agent1Key },
+      socket: { data() {}, error() {}, open(s) { s.end(); } },
+    });
+
+    const ctx = tls.createSecureContext();
+    ctx.context.addCACert(ca1);
+
+    const client = tls.connect(
+      {
+        port: server.port,
+        host: "127.0.0.1",
+        secureContext: ctx,
+        rejectUnauthorized: false,
+        servername: "agent1",
+      },
+      () => {
+        resolve({ authorized: client.authorized, error: (client as any).authorizationError });
+        client.end();
+      },
+    );
+    client.on("error", reject);
+
+    const result = await promise;
+    expect(result.authorized).toBe(true);
+  });
+
+  it("rejects a cert signed by a different CA (added CA is not wildcard-trusted)", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<{ authorized: boolean; error: any }>();
+    await using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      tls: { cert: agent1Cert, key: agent1Key },
+      socket: { data() {}, error() {}, open(s) { s.end(); } },
+    });
+
+    // Add ca2 — server cert is signed by ca1, so authorization must fail.
+    const ctx = tls.createSecureContext();
+    ctx.context.addCACert(ca2);
+
+    const client = tls.connect(
+      {
+        port: server.port,
+        host: "127.0.0.1",
+        secureContext: ctx,
+        rejectUnauthorized: false,
+        servername: "agent1",
+      },
+      () => {
+        resolve({ authorized: client.authorized, error: (client as any).authorizationError });
+        client.end();
+      },
+    );
+    client.on("error", reject);
+
+    const result = await promise;
+    expect(result.authorized).toBe(false);
+    expect(String(result.error)).toMatch(/UNABLE_TO_VERIFY|UNABLE_TO_GET_ISSUER|CERT/);
+  });
+
+  it("accepts Buffer input in addition to string", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<boolean>();
+    await using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      tls: { cert: agent1Cert, key: agent1Key },
+      socket: { data() {}, error() {}, open(s) { s.end(); } },
+    });
+
+    const ctx = tls.createSecureContext();
+    ctx.context.addCACert(Buffer.from(ca1));
+
+    const client = tls.connect(
+      {
+        port: server.port,
+        host: "127.0.0.1",
+        secureContext: ctx,
+        rejectUnauthorized: false,
+        servername: "agent1",
+      },
+      () => {
+        resolve(client.authorized);
+        client.end();
+      },
+    );
+    client.on("error", reject);
+
+    expect(await promise).toBe(true);
+  });
+
+  it("silently ignores non-PEM input (Node parity)", () => {
+    // Node's addCACert is lenient — it doesn't throw on malformed input,
+    // empty strings, or anything that doesn't coerce to bytes it recognises.
+    const ctx = tls.createSecureContext();
+    expect(() => ctx.context.addCACert("")).not.toThrow();
+    expect(() => ctx.context.addCACert("not pem")).not.toThrow();
+    expect(() => ctx.context.addCACert(Buffer.alloc(0))).not.toThrow();
+    expect(() => ctx.context.addCACert(null)).not.toThrow();
+    expect(() => ctx.context.addCACert(undefined)).not.toThrow();
+    expect(() => ctx.context.addCACert(42)).not.toThrow();
+    expect(() => ctx.context.addCACert({})).not.toThrow();
+  });
+
+  it("is idempotent on duplicate CAs", () => {
+    const ctx = tls.createSecureContext();
+    expect(() => ctx.context.addCACert(ca1)).not.toThrow();
+    expect(() => ctx.context.addCACert(ca1)).not.toThrow();
+    expect(() => ctx.context.addCACert(ca1)).not.toThrow();
+  });
+
+  it("accepts a multi-cert bundle in a single call", async () => {
+    // Bundle two CAs; only ca1 is needed for the handshake — this asserts
+    // the PEM reader walks past the first END CERTIFICATE and picks up the
+    // second. Order doesn't matter to the reader.
+    const bundle = ca2 + "\n" + ca1;
+    const { promise, resolve, reject } = Promise.withResolvers<boolean>();
+    await using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      tls: { cert: agent1Cert, key: agent1Key },
+      socket: { data() {}, error() {}, open(s) { s.end(); } },
+    });
+
+    const ctx = tls.createSecureContext();
+    ctx.context.addCACert(bundle);
+
+    const client = tls.connect(
+      {
+        port: server.port,
+        host: "127.0.0.1",
+        secureContext: ctx,
+        rejectUnauthorized: false,
+        servername: "agent1",
+      },
+      () => {
+        resolve(client.authorized);
+        client.end();
+      },
+    );
+    client.on("error", reject);
+
+    expect(await promise).toBe(true);
+  });
+
+  it("preserves OS/default trust anchors", async () => {
+    // After addCACert, connecting to a host signed by a public CA must still
+    // work — we should ADD to the default trust store, not REPLACE it.
+    const ctx = tls.createSecureContext();
+    ctx.context.addCACert(ca2); // unrelated private CA
+
+    const { promise, resolve, reject } = Promise.withResolvers<boolean>();
+    const client = tls.connect(
+      {
+        port: 443,
+        host: "bun.sh",
+        secureContext: ctx,
+        rejectUnauthorized: true,
+        servername: "bun.sh",
+      },
+      () => {
+        resolve(client.authorized);
+        client.end();
+      },
+    );
+    client.on("error", reject);
+
+    expect(await promise).toBe(true);
+  });
+
+  it("requires at least one argument", () => {
+    const ctx = tls.createSecureContext();
+    // @ts-expect-error — intentionally calling with no args
+    expect(() => ctx.context.addCACert()).toThrow();
+  });
+});

--- a/test/js/node/tls/node-tls-context.test.ts
+++ b/test/js/node/tls/node-tls-context.test.ts
@@ -740,11 +740,7 @@ describe("tls.createSecureContext().context.addCACert", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
     const result = JSON.parse(stdout.trim());

--- a/test/js/node/tls/node-tls-context.test.ts
+++ b/test/js/node/tls/node-tls-context.test.ts
@@ -752,4 +752,29 @@ describe("tls.createSecureContext().context.addCACert", () => {
     // @ts-expect-error — intentionally calling with no args
     expect(() => ctx.context.addCACert()).toThrow();
   });
+
+  // SecureContext is mode-neutral — the same object may back both a client
+  // AND a server. `addCACert` must NOT flip CTX-level verify_mode; if it did,
+  // a server built from this context would start sending `CertificateRequest`
+  // in every handshake (e.g. browsers would prompt for a client certificate).
+  // Node's `SecureContext::AddCACert` never touches verify_mode for exactly
+  // this reason.
+  it("does not flip CTX verify_mode (would leak as server requestCert)", async () => {
+    // @ts-expect-error — debug-only export
+    const { secureContextVerifyMode } = await import("bun:internal-for-testing");
+
+    // Baseline: a fresh SecureContext has SSL_VERIFY_NONE (= 0).
+    const ctx = tls.createSecureContext({ cert: agent1Cert, key: agent1Key });
+    expect(secureContextVerifyMode(ctx.context)).toBe(0);
+
+    // After addCACert, verify_mode must STILL be SSL_VERIFY_NONE. If it
+    // wasn't, a server built from this context would start sending
+    // CertificateRequest even when the user never set `requestCert`.
+    ctx.context.addCACert(ca1);
+    expect(secureContextVerifyMode(ctx.context)).toBe(0);
+
+    // For completeness: the `options.ca` construction path still flips
+    // verify_mode (pre-existing quirk we're not changing), so this is the
+    // strict stronger guarantee for the post-construction API only.
+  });
 });


### PR DESCRIPTION
Fixes #30485

### Reproduction

```console
$ bun -e 'require("tls").createSecureContext().context.addCACert("some CA")'
TypeError: tls.createSecureContext().context.addCACert is not a function.
```

### Root cause

The native `SecureContext` class in `SecureContext.classes.ts` declared an
empty `proto: {}`, so none of the methods Node exposes on
`secureContext.context` (`addCACert`, `addCRL`, `setCert`, …) existed.

Secondary: `tls.createSecureContext()` with no argument threw
`TLSOptions must be an object` because bindgen's generated converter is
strict; WebIDL treats missing options as an empty dictionary.

### Fix

- Add `addCACert` to the `SecureContext` prototype, backed by a new
  `us_ssl_ctx_add_ca_pem` helper in `packages/bun-usockets/src/crypto/openssl.c`
  that mirrors the existing `options.ca` path: on first call against a
  `VERIFY_NONE` context, install `us_get_default_ca_store()` so the added CA
  joins (not replaces) OS/baked-in roots, flip verify_mode to
  `SSL_VERIFY_PEER` so the per-socket client override in
  `us_internal_ssl_attach` doesn't discard it, and append each PEM block.
- Match Node's leniency: strings and `Buffer`/`TypedArray`/`ArrayBuffer`
  accepted; empty/malformed/duplicate input silently ignored; multi-cert
  bundles walked to completion.
- Before mutating, drop the `SecureContext` from both the per-VM
  `SSLContextCache` and the per-global `Bun__SecureContextCache` so a later
  `createSecureContext(sameOptions)` builds a fresh `SSL_CTX` instead of
  handing back the mutated one. Preserves the "one config, one SSL_CTX" hot
  path for the pure `createSecureContext({ca, cert, key})` pattern.
- Handle `undefined`/`null` at `intern()`/`constructor()` to skip bindgen's
  non-object check (matches Node's empty-dictionary semantics).

### Verification

- 10 new tests in `test/js/node/tls/node-tls-context.test.ts` covering
  the basic surface, trust-chain acceptance, rejection of unrelated CAs,
  Buffer input, multi-cert bundles, preservation of default trust anchors,
  duplicate-idempotency, and the no-arg throw.
- Existing 7 `SecureContext`-adjacent tests in the same file still pass,
  plus `ssl-ctx-cache.test.ts` (5), `node-tls-connect.test.ts` (26+),
  `node-tls-create-secure-context-args.test.ts` (5).

---

### Rebase note (main merged the Rust rewrite #30412)

Rebasing onto main surfaced two large upstream changes:

1. **Rust rewrite (#30412):** `SecureContext`, `SSLContextCache`, and the
   `SSLWrapper` client-attach path are now Rust. The implementation was ported
   from the (now-dead) `.zig` files to `SecureContext.rs` / `SSLContextCache.rs`
   / `uws/lib.rs` / `uws_sys/SocketContext.rs`. The C helpers
   (`us_ssl_ctx_add_ca_pem`, `us_ctx_has_user_ca`) live in `openssl.c`, which the
   rewrite didn't touch, so they carried over unchanged.

2. **Strict CA semantics on main:** an explicit `ca` / `ca_file_name` /
   `requestCert` option now *replaces* the default trust store (Node.js
   semantics — chains validate only against supplied CAs) instead of merging with
   it. The `openssl.c` conflict was resolved by keeping main's strict-replace
   behavior and layering the `addCACert` marker (`us_ctx_user_ca_idx`) on top, so
   a later `addCACert` appends to the construction-time store rather than swapping
   in the default roots.

All 20 `addCACert` tests pass after the rebase; `ssl-ctx-cache`,
`node-tls-server`, `node-tls-cert`, and the Duplex/upgrade `SSLWrapper` tests
stay green.
