### PR TITLE
Validate `Bun.serve()` `app.bundlerOptions` is an object

### DIFF
--- a/src/bake/bake.zig
+++ b/src/bake/bake.zig
@@ -68,14 +68,17 @@ pub const UserOptions = struct {
         }
 
         if (try config.getOptional(global, "bundlerOptions", JSValue)) |js_options| {
+            if (!js_options.isObject()) {
+                return global.throwInvalidArgumentTypeValue("bundlerOptions", "object", js_options);
+            }
             if (try js_options.getOptional(global, "server", JSValue)) |server_options| {
-                bundler_options.server = try BuildConfigSubset.fromJS(global, server_options);
+                bundler_options.server = try BuildConfigSubset.fromJS(global, "bundlerOptions.server", server_options);
             }
             if (try js_options.getOptional(global, "client", JSValue)) |client_options| {
-                bundler_options.client = try BuildConfigSubset.fromJS(global, client_options);
+                bundler_options.client = try BuildConfigSubset.fromJS(global, "bundlerOptions.client", client_options);
             }
             if (try js_options.getOptional(global, "ssr", JSValue)) |ssr_options| {
-                bundler_options.ssr = try BuildConfigSubset.fromJS(global, ssr_options);
+                bundler_options.ssr = try BuildConfigSubset.fromJS(global, "bundlerOptions.ssr", ssr_options);
             }
         }
 
@@ -202,8 +205,12 @@ const BuildConfigSubset = struct {
     minify_identifiers: ?bool = null,
     minify_whitespace: ?bool = null,
 
-    pub fn fromJS(global: *jsc.JSGlobalObject, js_options: JSValue) bun.JSError!BuildConfigSubset {
+    pub fn fromJS(global: *jsc.JSGlobalObject, comptime name: []const u8, js_options: JSValue) bun.JSError!BuildConfigSubset {
         var options = BuildConfigSubset{};
+
+        if (!js_options.isObject()) {
+            return global.throwInvalidArgumentTypeValue(name, "object", js_options);
+        }
 
         if (try js_options.getOptional(global, "sourcemap", JSValue)) |val| brk: {
             if (try bun.schema.api.SourceMapMode.fromJS(global, val)) |sourcemap| {
@@ -215,11 +222,16 @@ const BuildConfigSubset = struct {
         }
 
         if (try js_options.getOptional(global, "minify", JSValue)) |minify_options| brk: {
-            if (minify_options.isBoolean() and minify_options.asBoolean()) {
-                options.minify_syntax = minify_options.asBoolean();
-                options.minify_identifiers = minify_options.asBoolean();
-                options.minify_whitespace = minify_options.asBoolean();
+            if (minify_options.isBoolean()) {
+                const value = minify_options.asBoolean();
+                options.minify_syntax = value;
+                options.minify_identifiers = value;
+                options.minify_whitespace = value;
                 break :brk;
+            }
+
+            if (!minify_options.isObject()) {
+                return global.throwInvalidArgumentTypeValue(name ++ ".minify", "boolean or object", minify_options);
             }
 
             if (try minify_options.getBooleanLoose(global, "whitespace")) |value| {

--- a/test/js/bun/http/bun-serve-app-invalid-args.test.ts
+++ b/test/js/bun/http/bun-serve-app-invalid-args.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+
+test("Bun.serve() app.bundlerOptions must be an object", () => {
+  expect(() =>
+    // @ts-expect-error
+    Bun.serve({ app: { bundlerOptions: "not an object" } }),
+  ).toThrow(/"bundlerOptions" argument must be of type object/);
+});
+
+test("Bun.serve() app.bundlerOptions.{server,client,ssr} must be objects", () => {
+  for (const key of ["server", "client", "ssr"]) {
+    expect(() =>
+      // @ts-expect-error
+      Bun.serve({ app: { bundlerOptions: { [key]: "nope" } } }),
+    ).toThrow(new RegExp(`"bundlerOptions\\.${key}" argument must be of type object`));
+  }
+});
+
+test("Bun.serve() app.bundlerOptions.*.minify must be a boolean or object", () => {
+  expect(() =>
+    // @ts-expect-error
+    Bun.serve({ app: { bundlerOptions: { server: { minify: 123 } } } }),
+  ).toThrow(/"bundlerOptions\.server\.minify" argument must be of type boolean or object/);
+});

--- a/test/js/bun/http/bun-serve-app-invalid-args.test.ts
+++ b/test/js/bun/http/bun-serve-app-invalid-args.test.ts
@@ -22,3 +22,14 @@ test("Bun.serve() app.bundlerOptions.*.minify must be a boolean or object", () =
     Bun.serve({ app: { bundlerOptions: { server: { minify: 123 } } } }),
   ).toThrow(/"bundlerOptions\.server\.minify" argument must be of type boolean or object/);
 });
+
+test("Bun.serve() app.bundlerOptions.*.minify accepts boolean", () => {
+  for (const minify of [true, false, {}]) {
+    // Still throws because `framework` is required, but it must get past
+    // the bundlerOptions validation without crashing or rejecting `minify`.
+    expect(() =>
+      // @ts-expect-error
+      Bun.serve({ app: { bundlerOptions: { server: { minify } } } }),
+    ).toThrow(/'app' is missing 'framework'/);
+  }
+});


### PR DESCRIPTION
Passing a non-object value for `app.bundlerOptions` (or its `server`/`client`/`ssr` sub-options, or a non-boolean non-object `minify`) to `Bun.serve()` would hit a debug assertion in `JSValue.get()` and crash.

```js
Bun.serve({ app: { bundlerOptions: "not an object" } });
// panic: reached unreachable code (debugAssert target.isObject())
```

Now throws `ERR_INVALID_ARG_TYPE` instead.

Also fixes `minify: false` which previously fell through the boolean check and tried to read `.whitespace` off a boolean primitive.

Found by Fuzzilli (fingerprint `4160b7d95e4e6895`).