### PR TITLE
fix(bundler): don't let comments leak into minify renamer

### DIFF
--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -1331,6 +1331,45 @@ describe("bundler", () => {
       expect(code).toMatch(/=>\s*\{\s*return a \+ 1;?\s*\}/);
     },
   });
+
+  // https://github.com/oven-sh/bun/issues/30489
+  // Comments must not influence the renamer — two files that differ only
+  // in comments must produce byte-identical minified output.
+  //
+  // Stuff a 42-byte filler (past CharFreq.scanBig's 32-byte threshold)
+  // using characters that don't appear elsewhere in the source. Before
+  // the fix, those characters would leak into the histogram and reshape
+  // the chosen identifier letters; the expected output below pins the
+  // correct renamer output and so any leak makes the test fail.
+  const issue30489Baseline = /* js */ `
+    var aa = 1, bb = 2, cc = 3, dd = 4, ee = 5, ff = 6;
+    export function go() { return aa + bb + cc + dd + ee + ff; }
+  `;
+  // Use Buffer.alloc().toString() over "q".repeat() — faster in debug builds.
+  const issue30489Filler = Buffer.alloc(42, "q").toString();
+  // All variants must produce this exact minified output; any variant that
+  // differs means the comment's characters leaked into the renamer's histogram.
+  const issue30489ExpectedOutput = "var e=1,r=2,a=3,c=4,f=5,n=6;function o(){return e+r+a+c+f+n}export{o as go};\n";
+  const issue30489Variants = {
+    baseline: issue30489Baseline,
+    leadingLineComment: `// ${issue30489Filler}\n` + issue30489Baseline,
+    leadingBlockComment: `/* ${issue30489Filler} */\n` + issue30489Baseline,
+    midFileLineComment: issue30489Baseline.replace("export function", `// ${issue30489Filler}\nexport function`),
+    midFileBlockComment: issue30489Baseline.replace("export function", `/* ${issue30489Filler} */\nexport function`),
+    trailingLineComment: issue30489Baseline + `// ${issue30489Filler}\n`,
+    trailingBlockComment: issue30489Baseline + `/* ${issue30489Filler} */\n`,
+  };
+  for (const [variant, source] of Object.entries(issue30489Variants)) {
+    itBundled(`minify/CommentBleedIssue30489_${variant}`, {
+      files: { "/entry.js": source },
+      minifySyntax: true,
+      minifyIdentifiers: true,
+      minifyWhitespace: true,
+      onAfterBundle(api) {
+        expect(api.readFile("/out.js")).toBe(issue30489ExpectedOutput);
+      },
+    });
+  }
 });
 
 // The runtime transpiler (`bun run`/`bun test`) implicitly enables


### PR DESCRIPTION
## Problem

`bun build --minify` produces different output for the same code depending on whether (and what) comments appear in the source. From #30489:

```console
$ bun build --minify ./with-comment.js
var x=1,e=2,r=3,a=4,c=5,f=6;function n(){return x+e+r+a+c+f}export{n as go};

$ bun build --minify ./without-comment.js
var e=1,r=2,a=3,c=4,f=5,n=6;function o(){return e+r+a+c+f+n}export{o as go};
```

The letter chosen for each renamed identifier tracked the contents of the leading comment — stuff it with 42 `q`s and the output started `var q=1,…`.

## Cause

Two independent bugs in the character-frequency analysis that drives minified-identifier naming:

### A. `scanBig`/`scan_big` overwrote the histogram

`computeCharacterFrequency` calls `scan()` once for the source text (+1), then once per comment and import path (-1) to subtract them back out. For text `>= 32` bytes the code routes to `scanBig`, which did:

```zig
freqs[0..26].* = deltas['a' .. 'a' + 26].*;   // overwrite, not +=
```

`scanSmall` (the short-text path) correctly does `freqs[i] += delta`. `scanBig` wiped the buffer on every call, so any comment of 32+ bytes clobbered whatever the source-text scan had accumulated.

Fixed by switching the four final writes to element-wise `@Vector` adds so `scanBig` accumulates like `scanSmall` does. (The rewrite-in-rust port already carries this fix with a detailed port-note, so only the Zig side needed updating.)

### B. `track_comments` flipped on too late to see leading comments

`js_lexer.Lexer.init` calls `step() + next()` at construction, which consumes any comments at the top of the file *before* `track_comments` flips on. `scanCommentText` only appends to `all_comments` when the flag is true, so those leading comments were never recorded and never subtracted from the histogram.

Fixed by adding `initWithTrackComments` (Zig) / `init_with_track_comments` (Rust) that sets the flag before reading the first token, and threading `minify_identifiers` through from `Parser.init`.

### Drive-by: `scanSmall` digit off-by-one

Pre-existing: `scanSmall` mapped `'0'..'9'` to histogram slots 53..62, colliding `'9'` with `'_'` at slot 62; `scanBig` already used the correct 52..61. Fixed in both Zig and Rust so the two paths agree on `NameMinifier::DEFAULT_TAIL`'s slot layout.

## Verification

```console
$ bun build --minify ./with-comment.js
var e=1,r=2,a=3,c=4,f=5,n=6;function o(){return e+r+a+c+f+n}export{o as go};
```

Byte-identical across all comment placements. Tests in `test/bundler/bundler_minify.test.ts` cover leading / mid-file / trailing comments in both line- and block-comment forms, all padded to force the `scanBig` path.

## Rebase note

Rebased onto main (clean — no textual conflicts; git followed the file renames from the rewrite-in-rust commit). After rebase, the CLI reproducer showed the leading-comment leak was back — the bundler now parses through the Rust port, so the Zig-only fix didn't reach it. Ported all three changes to `src/js_parser/lexer.rs`, `src/js_parser/parse/parse_entry.rs`, and `src/ast/char_freq.rs` so both parsers stay in sync. The Zig fix is retained.

Fixes #30489.