### PR TITLE
dev server: emit <link> tags in source order

### DIFF
--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -1580,7 +1580,13 @@ fn generateHTMLPayload(dev: *DevServer, route_bundle_index: RouteBundle.Index, r
     dev.client_graph.reset();
     try dev.traceAllRouteImports(route_bundle, &gts, .find_css);
 
+    // The graph's import lists are stored in reverse source order (see the
+    // comment above `new_imports` in `processChunkDependencies`), so DFS
+    // visits CSS roots in reverse source order. The cascade in CSS Cascade L4
+    // § 6.4.6 is "last declaration wins", so `<link>` tags must be emitted in
+    // source order — reverse the collected list to restore it.
     const css_ids = dev.client_graph.current_css_files.items;
+    std.mem.reverse(@TypeOf(css_ids[0]), css_ids);
 
     const payload_size = bundled_html.len +
         ("<link rel=\"stylesheet\" href=\"" ++ asset_prefix ++ "/0000000000000000.css\">").len * css_ids.len +
@@ -2133,7 +2139,9 @@ fn generateCssJSArray(dev: *DevServer, route_bundle: *RouteBundle) bun.JSError!j
     dev.client_graph.reset();
     try dev.traceAllRouteImports(route_bundle, &gts, .find_css);
 
+    // Reverse to restore source order (see comment in `generateHTMLPayload`).
     const names = dev.client_graph.current_css_files.items;
+    std.mem.reverse(@TypeOf(names[0]), names);
     const arr = try jsc.JSArray.createEmpty(dev.vm.global, names.len);
     for (names, 0..) |item, i| {
         var buf: [asset_prefix.len + @sizeOf(u64) * 2 + "/.css".len]u8 = undefined;
@@ -2756,7 +2764,9 @@ pub fn finalizeBundle(
                 gts.clear();
                 dev.client_graph.current_css_files.clearRetainingCapacity();
                 try dev.traceAllRouteImports(route_bundle, &gts, .find_css);
+                // Reverse to restore source order (see comment in `generateHTMLPayload`).
                 const css_ids = dev.client_graph.current_css_files.items;
+                std.mem.reverse(@TypeOf(css_ids[0]), css_ids);
 
                 try w.writeInt(i32, @intCast(css_ids.len), .little);
                 for (css_ids) |css_id| {

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -570,6 +570,44 @@ devTest("css import before create project relative", {
   },
 });
 
+// Regression test for https://github.com/oven-sh/bun/issues/30488
+// The dev server used to emit `<link rel="stylesheet">` tags in reverse source
+// order because the IncrementalGraph's import list stores edges head-first.
+// Per CSS Cascade L4 § 6.4.6 the later declaration of equal specificity wins,
+// so ordering of `<link>` tags must match source order.
+devTest("link tags are served in source order (issue #30488)", {
+  files: {
+    "index.html": `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <link rel="stylesheet" href="a.css">
+          <link rel="stylesheet" href="b.css">
+          <link rel="stylesheet" href="c.css">
+        </head>
+        <body>
+          <div class="target">should be green</div>
+        </body>
+      </html>
+    `,
+    "a.css": `.target { color: red; }`,
+    "b.css": `.target { color: blue; }`,
+    "c.css": `.target { color: green; }`,
+  },
+  async test(dev) {
+    const html = await dev.fetch("/").text();
+    const linkHrefs = [...html.matchAll(/<link[^>]+href="([^"]+\.css)"/g)].map(m => m[1]);
+    expect(linkHrefs).toHaveLength(3);
+
+    // Each link should resolve to the CSS whose source position matches its position in the HTML.
+    const markers = ["red", "#00f", "green"];
+    for (let i = 0; i < linkHrefs.length; i++) {
+      const css = await dev.fetch(linkHrefs[i]).text();
+      expect(css).toContain(markers[i]);
+    }
+  },
+});
+
 function extractCssUrl(backgroundImage: string): string {
   const url = backgroundImage.match(/url\((['"])(.*?)\1\)/);
   if (!url) {


### PR DESCRIPTION
## Reproduce

```bash
mkdir /tmp/repro && cd /tmp/repro
cat > index.html <<'EOF'
<!DOCTYPE html><html><head>
  <link rel="stylesheet" href="a.css">
  <link rel="stylesheet" href="b.css">
</head><body><div class="target">should be blue</div></body></html>
EOF
echo '.target { color: red; }'  > a.css
echo '.target { color: blue; }' > b.css
```

- `bun build ./index.html --outdir=dist` → `.target` is **blue** (correct).
- `bun ./index.html` (dev server) → `.target` is **red** — the link order is reversed, so `a.css` wins the cascade instead of `b.css`.

## Cause

`IncrementalGraph` stores each file's import edges as a singly-linked list built by prepending at the head. That leaves the list in reverse source order — a fact the comment above `new_imports` in `processChunkDependencies` calls out verbatim. The dev server's `.find_css` trace walks that list to populate `current_css_files`, which in turn drives the order of `<link rel="stylesheet">` tags injected into the served HTML.

Per [CSS Cascade L4 § 6.4.6](https://www.w3.org/TR/css-cascade-4/#cascade-order), two declarations of equal specificity resolve "last in source order wins". Reversing the link order flips the winner, so a page that loads `a.css` then `b.css` (where `b` overrides `a`) ended up with `a` winning in the dev server — the opposite of what `bun build` produces.

## Fix

Reverse `current_css_files` at each of the three consumption sites (`generateHTMLPayload`, `generateCssJSArray`, and the hot-update path in `finalizeBundle`) so the emitted `<link>` tags follow source order. This keeps the underlying linked-list insertion semantics untouched and only corrects the one list whose ordering is user-visible.

## Verification

- `bun bd test test/bake/dev/css.test.ts` → 14/14 pass (includes the new regression test).
- `git stash && bun bd test …` on the new test → fails with `Received: "/* c.css */\n.target {\n  color: green;\n}\n"` where `red` was expected, confirming the test exercises the fix.
- `bun bd test test/bake/dev/html.test.ts` and `test/bake/dev/hot.test.ts` also pass.

Supersedes the stale #28119 (which was rebased on a months-old main and covers only the JS→CSS variant; #30488 is the `<link>`-in-HTML variant of the same root cause).

Fixes #30488
Fixes #28117