### PR TITLE
fix(s3): avoid double-freeing path when presign throws after store creation

### DIFF
--- a/src/runtime/webcore/Blob.zig
+++ b/src/runtime/webcore/Blob.zig
@@ -2069,6 +2069,7 @@ pub fn constructBunFile(
 
     if (path == .path) {
         if (strings.hasPrefixComptime(path.path.slice(), "s3://")) {
+            errdefer path.deinit();
             return try S3File.constructInternalJS(globalObject, path.path, options);
         }
     }

--- a/src/runtime/webcore/S3Client.zig
+++ b/src/runtime/webcore/S3Client.zig
@@ -145,7 +145,7 @@ pub const S3Client = struct {
         const arguments = callframe.arguments_old(2).slice();
         var args = jsc.CallFrame.ArgumentsSlice.init(globalThis.bunVM(), arguments);
         defer args.deinit();
-        const path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
+        var path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
             if (args.len() == 0) {
                 return globalThis.ERR(.MISSING_ARGS, "Expected a path to presign", .{}).throw();
             }
@@ -155,6 +155,7 @@ pub const S3Client = struct {
 
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
+        path = .{ .string = bun.PathString.empty };
         defer blob.detach();
         return S3File.getPresignUrlFrom(&blob, globalThis, options);
     }
@@ -163,7 +164,7 @@ pub const S3Client = struct {
         const arguments = callframe.arguments_old(2).slice();
         var args = jsc.CallFrame.ArgumentsSlice.init(globalThis.bunVM(), arguments);
         defer args.deinit();
-        const path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
+        var path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
             if (args.len() == 0) {
                 return globalThis.ERR(.MISSING_ARGS, "Expected a path to check if it exists", .{}).throw();
             }
@@ -172,6 +173,7 @@ pub const S3Client = struct {
         errdefer path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
+        path = .{ .string = bun.PathString.empty };
         defer blob.detach();
         return S3File.S3BlobStatTask.exists(globalThis, &blob);
     }
@@ -180,7 +182,7 @@ pub const S3Client = struct {
         const arguments = callframe.arguments_old(2).slice();
         var args = jsc.CallFrame.ArgumentsSlice.init(globalThis.bunVM(), arguments);
         defer args.deinit();
-        const path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
+        var path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
             if (args.len() == 0) {
                 return globalThis.ERR(.MISSING_ARGS, "Expected a path to check the size of", .{}).throw();
             }
@@ -189,6 +191,7 @@ pub const S3Client = struct {
         errdefer path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
+        path = .{ .string = bun.PathString.empty };
         defer blob.detach();
         return S3File.S3BlobStatTask.size(globalThis, &blob);
     }
@@ -197,7 +200,7 @@ pub const S3Client = struct {
         const arguments = callframe.arguments_old(2).slice();
         var args = jsc.CallFrame.ArgumentsSlice.init(globalThis.bunVM(), arguments);
         defer args.deinit();
-        const path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
+        var path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
             if (args.len() == 0) {
                 return globalThis.ERR(.MISSING_ARGS, "Expected a path to check the stat of", .{}).throw();
             }
@@ -206,6 +209,7 @@ pub const S3Client = struct {
         errdefer path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
+        path = .{ .string = bun.PathString.empty };
         defer blob.detach();
         return S3File.S3BlobStatTask.stat(globalThis, &blob);
     }
@@ -214,7 +218,7 @@ pub const S3Client = struct {
         const arguments = callframe.arguments_old(3).slice();
         var args = jsc.CallFrame.ArgumentsSlice.init(globalThis.bunVM(), arguments);
         defer args.deinit();
-        const path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
+        var path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
             return globalThis.ERR(.MISSING_ARGS, "Expected a path to write to", .{}).throw();
         };
         errdefer path.deinit();
@@ -224,6 +228,7 @@ pub const S3Client = struct {
 
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
+        path = .{ .string = bun.PathString.empty };
         defer blob.detach();
         var blob_internal: PathOrBlob = .{ .blob = blob };
         return Blob.writeFileInternal(globalThis, &blob_internal, data, .{
@@ -248,12 +253,13 @@ pub const S3Client = struct {
         const arguments = callframe.arguments_old(2).slice();
         var args = jsc.CallFrame.ArgumentsSlice.init(globalThis.bunVM(), arguments);
         defer args.deinit();
-        const path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
+        var path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
             return globalThis.ERR(.MISSING_ARGS, "Expected a path to unlink", .{}).throw();
         };
         errdefer path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
+        path = .{ .string = bun.PathString.empty };
         defer blob.detach();
         return blob.store.?.data.s3.unlink(blob.store.?, globalThis, options);
     }

--- a/src/runtime/webcore/S3Client.zig
+++ b/src/runtime/webcore/S3Client.zig
@@ -305,7 +305,7 @@ pub const S3Client = struct {
         const path = (try jsc.Node.PathLike.fromJS(globalThis, &args)) orelse {
             return globalThis.throwInvalidArguments("Expected file path string", .{});
         };
-
+        errdefer path.deinit();
         return try S3File.constructInternalJS(globalThis, path, args.nextEat());
     }
     pub fn staticStat(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {

--- a/src/runtime/webcore/S3File.zig
+++ b/src/runtime/webcore/S3File.zig
@@ -84,6 +84,7 @@ pub fn presign(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.J
             }
             const options = args.nextEat();
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             defer blob.deinit();
             return try getPresignUrlFrom(&blob, globalThis, options);
         },
@@ -114,6 +115,7 @@ pub fn unlink(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JS
             }
             const options = args.nextEat();
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             defer blob.deinit();
             return try blob.store.?.data.s3.unlink(blob.store.?, globalThis, options);
         },
@@ -151,6 +153,7 @@ pub fn write(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSE
                 return globalThis.throwInvalidArguments("Expected a S3 or path to upload", .{});
             }
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             defer blob.deinit();
 
             var blob_internal: PathOrBlob = .{ .blob = blob };
@@ -190,6 +193,7 @@ pub fn size(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSEr
                 return globalThis.throwInvalidArguments("Expected a S3 or path to get size", .{});
             }
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             defer blob.deinit();
 
             return S3BlobStatTask.size(globalThis, &blob);
@@ -223,6 +227,7 @@ pub fn exists(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JS
                 return globalThis.throwInvalidArguments("Expected a S3 or path to check if it exists", .{});
             }
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             defer blob.deinit();
 
             return S3BlobStatTask.exists(globalThis, &blob);
@@ -574,6 +579,7 @@ pub fn stat(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSEr
                 return globalThis.throwInvalidArguments("Expected a S3 or path to get size", .{});
             }
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             defer blob.deinit();
 
             return S3BlobStatTask.stat(globalThis, &blob);

--- a/src/runtime/webcore/S3File.zig
+++ b/src/runtime/webcore/S3File.zig
@@ -268,7 +268,10 @@ pub fn constructS3FileWithS3CredentialsAndOptions(
             break :brk bun.handleOom(Blob.Store.initS3WithReferencedCredentials(path, null, default_credentials, bun.default_allocator));
         }
     };
-    errdefer store.deinit();
+    errdefer {
+        store.data.s3.pathlike = .{ .string = bun.PathString.empty };
+        store.deinit();
+    }
     store.data.s3.options = aws_options.options;
     store.data.s3.acl = aws_options.acl;
     store.data.s3.storage_class = aws_options.storage_class;
@@ -312,7 +315,10 @@ pub fn constructS3FileWithS3Credentials(
     var aws_options = try S3.S3Credentials.getCredentialsWithOptions(existing_credentials, .{}, options, null, null, false, globalObject);
     defer aws_options.deinit();
     const store = bun.handleOom(Blob.Store.initS3(path, null, aws_options.credentials, bun.default_allocator));
-    errdefer store.deinit();
+    errdefer {
+        store.data.s3.pathlike = .{ .string = bun.PathString.empty };
+        store.deinit();
+    }
     store.data.s3.options = aws_options.options;
     store.data.s3.acl = aws_options.acl;
     store.data.s3.storage_class = aws_options.storage_class;

--- a/src/runtime/webcore/S3File.zig
+++ b/src/runtime/webcore/S3File.zig
@@ -624,6 +624,7 @@ pub fn constructInternal(
     const path = (try jsc.Node.PathLike.fromJS(globalObject, &args)) orelse {
         return globalObject.throwInvalidArguments("Expected file path string", .{});
     };
+    errdefer path.deinit();
     return constructS3FileInternal(globalObject, path, args.nextEat());
 }
 

--- a/test/js/bun/s3/s3-presign-error-path-free.test.ts
+++ b/test/js/bun/s3/s3-presign-error-path-free.test.ts
@@ -31,4 +31,22 @@ describe("S3 presign error after store construction does not double-free path", 
     expect(() => client.presign("some/path", { expiresIn: -1 })).toThrow("expiresIn");
     Bun.gc(true);
   });
+
+  test("options.type getter throws after store is created", () => {
+    const client = new Bun.S3Client({
+      accessKeyId: "x",
+      secretAccessKey: "y",
+      bucket: "b",
+      endpoint: "http://localhost",
+    });
+    let n = 0;
+    const opts = {
+      get type() {
+        if (n++ === 0) return undefined;
+        throw new Error("boom");
+      },
+    };
+    expect(() => client.presign("\u{1F600}/k", opts)).toThrow("boom");
+    Bun.gc(true);
+  });
 });

--- a/test/js/bun/s3/s3-presign-error-path-free.test.ts
+++ b/test/js/bun/s3/s3-presign-error-path-free.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+
+// When an S3 operation throws after the blob store has been constructed
+// (e.g. invalid presign options), the path was being freed twice: once by
+// the blob's defer cleanup and again by the caller's errdefer. This tripped
+// a refcount assertion in debug builds.
+
+describe("S3 presign error after store construction does not double-free path", () => {
+  test("static S3Client.presign", () => {
+    expect(() => Bun.S3Client.presign("some/path", { expiresIn: -1 })).toThrow("expiresIn");
+    Bun.gc(true);
+  });
+
+  test("static S3Client.presign with non-latin1 path", () => {
+    expect(() => Bun.S3Client.presign("\u{1F600}/path", { expiresIn: -1 })).toThrow("expiresIn");
+    Bun.gc(true);
+  });
+
+  test("Bun.s3.presign", () => {
+    expect(() => Bun.s3.presign("some/path", { expiresIn: -1 })).toThrow("expiresIn");
+    Bun.gc(true);
+  });
+
+  test("instance presign", () => {
+    const client = new Bun.S3Client({
+      accessKeyId: "x",
+      secretAccessKey: "y",
+      bucket: "b",
+      endpoint: "http://localhost",
+    });
+    expect(() => client.presign("some/path", { expiresIn: -1 })).toThrow("expiresIn");
+    Bun.gc(true);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a crash (debug assertion / heap corruption) when S3 operations throw an error after the blob store has already taken ownership of the path.

```js
Bun.S3Client.presign("foo"); // no credentials in env → panic in debug builds
```

### Root cause

`Blob.Store.initS3` moves the `PathLike` into the store without adding a reference. Callers in `S3File.zig` and `S3Client.zig` were written as:

```zig
errdefer path.deinit();
var blob = try constructS3File...(path, ...);   // store now owns path
defer blob.deinit();                             // frees path
return try getPresignUrlFrom(&blob, ...);        // can throw
```

When the final call threw (missing credentials, invalid `expiresIn`, invalid method, etc.), `defer blob.deinit()` freed the path via the store's destructor, and then the outer `errdefer path.deinit()` freed the same `PathLike` again — over-derefing the `WTFStringImpl` (latin1 case) or double-freeing the allocation (`encoded_slice` case), hitting `bun.assert` in `WTFStringImpl.deref`.

### Fix

Clear the caller's path right after the store takes ownership so the `errdefer` becomes a no-op. This is the same pattern already used in `Blob.findOrCreateFileFromPath`.

Applied to: `presign`, `unlink`, `write`, `size`, `exists`, `stat` (static and instance variants).

## How did you verify your code works?

- Minimal repro `Bun.S3Client.presign("NFC")` panics on debug builds before, throws `ERR_S3_MISSING_CREDENTIALS` cleanly after.
- Added regression test using `{ expiresIn: -1 }` to deterministically hit the post-construction error path regardless of env credentials, covering static, `Bun.s3`, instance, and non-latin1 path variants.
- Existing S3 validation tests pass.

Fuzzer fingerprint: `5308c20fced315a7`