### PR TITLE
Fix require() of ESM with diamond through barrel deadlocking (#30493)

### DIFF
--- a/test/regression/issue/30493.test.ts
+++ b/test/regression/issue/30493.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/30493
+//
+// Regression: require() of an ESM graph whose entry point directly imports a
+// module that's also reachable through a re-exporting barrel deadlocked (on
+// macOS) or tripped `ASSERT(m_status == Status::Fetching)` in
+// ModuleRegistryEntry::fetchComplete (on Linux debug). Root cause was the
+// JSC module-loader rewrite: when `hostLoadImportedModule`'s synchronous
+// re-entry path force-fulfilled a diamond-shared module's fetchPromise and
+// called `fetchComplete` inline, the queued `moduleRegistryModuleSettled`
+// microtask still ran later and called `fetchComplete` a second time on the
+// already-Fetched entry.
+test("require() of ESM with diamond dependency through barrel does not deadlock", async () => {
+  using dir = tempDir("issue-30493", {
+    "shared.js": `import path from 'path';\nexport const SHARED = path.sep;\n`,
+    "barrel.js": `import { SHARED } from './shared.js';\nexport { SHARED };\nexport const BARREL = 'barrel';\n`,
+    "a.js": `import { SHARED } from './barrel.js';\nexport default function a() { return SHARED; }\n`,
+    "b.js": `import { BARREL } from './barrel.js';\nexport default function b() { return BARREL; }\n`,
+    "app.js": `import a from './a.js';\nimport b from './b.js';\nimport { SHARED } from './shared.js';\nexport default { a: a(), b: b(), shared: SHARED };\n`,
+    "entry.js": `const mod = require('./app.js');\nconsole.log(JSON.stringify(mod.default));\n`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  // shared: path.sep on darwin/linux is "/", on windows "\\".
+  expect(JSON.parse(stdout.trim())).toEqual({ a: "/", b: "barrel", shared: "/" });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #30493. Requires oven-sh/WebKit#223 to land first.

## Repro

`require('./app.js')` where:
- `app.js` imports `a.js`, `b.js`, and `shared.js` directly
- `a.js` and `b.js` both import from `barrel.js`
- `barrel.js` re-exports from `shared.js`
- `shared.js` imports a synthetic builtin like `node:path`

On Linux debug: `ASSERT(m_status == Status::Fetching)` at `vendor/WebKit/Source/JavaScriptCore/runtime/ModuleRegistryEntry.cpp:254`. On Darwin: process hangs. Regressed by the module-loader rewrite in #29393.

## Root cause

During the synchronous drain that services `require(esm)`, `hostLoadImportedModule` has a `BUN_JSC_ADDITIONS` inline fast path (`JSModuleLoader.cpp:712`) that handles a dep whose fetchPromise is already fulfilled but whose modulePromise is still pending: it calls `makeModule`, then `entry->fetchComplete(record)`, then `modulePromise->fulfillPromise(record)`.

Meanwhile, the async pipeline had queued a `ModuleRegistryFetchSettled` microtask for the same entry. That handler has a correct bail-out (`modulePromise->status() != Pending \u2192 return`) \u2014 but it checks this *after* calling `makeModule` and attaching `ModuleRegistryModuleSettled` to the new `makeModulePromise`. Wait, even better: actually the fetch-settled handler does bail early. The leak is that a *separate, earlier* invocation of `ModuleRegistryFetchSettled` (queued before the inline path ran) already created its own `makeModulePromise` and attached `ModuleRegistryModuleSettled` to it. That queued `moduleRegistryModuleSettled` has **no** bail-out of its own, so it runs and calls `entry->fetchComplete(otherRecord)` a second time \u2014 the ASSERT trips; in release it silently overwrites the entry's record with a duplicate parse that nothing else references.

The specific trigger for `node:path` is that it's a `SyntheticSourceProvider`: `makeModule` runs the generator (`InternalModuleRegistry::requireId`) synchronously, which executes JS and gives the inline re-entry path plenty of opportunity to hit.

## Fix

The WebKit-side fix (oven-sh/WebKit#223) mirrors the `moduleRegistryFetchSettled` guard into `moduleRegistryModuleSettled`: skip when `modulePromise->status() != Pending`. The inline path has already produced a valid record and resolved the promise; the queued copy is redundant.

This Bun PR adds the regression test. It needs to land together with the WebKit bump (will follow once #223 merges + preview/release tarballs are built).

## Test

`test/regression/issue/30493.test.ts` \u2014 spawns `bun run entry.js` on the diamond+synthetic-builtin setup and asserts the expected JSON output. Verified locally with a `debug-local` Bun built against the WebKit PR branch:

```
bun test v1.3.14 (450072ba)
test/regression/issue/30493.test.ts:
(pass) require() of ESM with diamond dependency through barrel does not deadlock [1047ms]
1 pass, 0 fail, 3 expect() calls
```

Fail-before verified by reverting the WebKit change only (no Bun source changes needed to exercise the bug):

```
(fail) require() of ESM with diamond dependency through barrel does not deadlock
  ASSERTION FAILED: m_status == Status::Fetching
  vendor/WebKit/Source/JavaScriptCore/runtime/ModuleRegistryEntry.cpp(254)
```

Existing ESM-require tests (`test/js/bun/resolve/require-esm-*.test.ts`, `test/js/node/module/require-extensions.test.ts`) all still pass.