### PR TITLE
Fix crash in Bun.build when passing many conditions

### DIFF
--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1087,9 +1087,9 @@ pub const ESMConditions = struct {
         var require_condition_map = ConditionsMap.init(allocator);
         var style_condition_map = ConditionsMap.init(allocator);
 
-        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
+        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + @as(usize, @intFromBool(allow_addons)) + conditions.len);
+        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + @as(usize, @intFromBool(allow_addons)) + conditions.len);
+        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + @as(usize, @intFromBool(allow_addons)) + conditions.len);
         try style_condition_map.ensureTotalCapacity(defaults.len + 2 + conditions.len);
 
         import_condition_map.putAssumeCapacity("import", {});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -70,6 +70,18 @@ describe("Bun.build", () => {
     throw new Error("should have thrown");
   });
 
+  test("many conditions does not crash", async () => {
+    const dir = tempDirWithFiles("bun-build-api-many-conditions", {
+      "index.js": `export default 1;`,
+    });
+    const build = await Bun.build({
+      entrypoints: [join(dir, "index.js")],
+      conditions: ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p"],
+    });
+    expect(build.success).toBe(true);
+    expect(build.outputs).toHaveLength(1);
+  });
+
   // https://github.com/oven-sh/bun/issues/12818
   test("sourcemap + build error crash case", async () => {
     const dir = tempDirWithFiles("build", {


### PR DESCRIPTION
## What does this PR do?

Fixes a crash in `Bun.build()` (and the CLI bundler) when the user passes enough `conditions` to exceed the under-reserved capacity of the ESM conditions maps.

### Root cause

In `ESMConditions.init`, the capacity reservation used:

```zig
defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len
```

Due to Zig's `if`-expression parsing, this is actually:

```zig
defaults.len + 2 + (if (allow_addons) 1 else (0 + conditions.len))
```

When `allow_addons` is `true` (the default), `conditions.len` was dropped from the capacity calculation entirely. The subsequent `putAssumeCapacity` calls then overflowed the map, tripping an assertion in debug builds and corrupting memory / segfaulting in release builds.

### Fix

Replace the `if` expression with `@intFromBool(allow_addons)`, matching the style already used elsewhere in this file and avoiding the precedence footgun.

## How did you verify your code works?

Added a regression test in `test/bundler/bun-build-api.test.ts` that calls `Bun.build` with 16 conditions. This segfaults on current canary and passes with the fix.

Also verified existing `packagejson/ExportsCustomConditions*` bundler tests still pass.

Found by Fuzzilli (fingerprint `d5aa656b6197a654`).