### PR TITLE
install: reuse existing tarball URL entry in package.json

### DIFF
--- a/src/install/PackageManager/PackageJSONEditor.zig
+++ b/src/install/PackageManager/PackageJSONEditor.zig
@@ -459,7 +459,9 @@ pub fn edit(
                                 }
                                 break;
                             } else {
-                                if (request.version.tag == .github or request.version.tag == .git) {
+                                if (request.e_string == null and
+                                    (request.version.tag == .github or request.version.tag == .git or request.version.tag == .tarball))
+                                {
                                     for (query.expr.data.e_object.properties.slice()) |item| {
                                         if (item.value) |v| {
                                             const url = request.version.literal.slice(request.version_buf);

--- a/src/install/PackageManager/PackageJSONEditor.zig
+++ b/src/install/PackageManager/PackageJSONEditor.zig
@@ -459,7 +459,11 @@ pub fn edit(
                                 }
                                 break;
                             } else {
-                                if (request.e_string == null and
+                                // Only fall back to a URL-value match when the user did not
+                                // specify an explicit `alias@url`. With an explicit alias, the
+                                // user has asked for a specific key name, so reusing an existing
+                                // entry under a different key would silently drop the alias.
+                                if (request.e_string == null and !request.is_aliased and
                                     (request.version.tag == .github or request.version.tag == .git or request.version.tag == .tarball))
                                 {
                                     for (query.expr.data.e_object.properties.slice()) |item| {

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2390,6 +2390,64 @@ it("should not add duplicate package.json entries when installing the same tarba
   });
 });
 
+it("should honor an explicit alias for a tarball URL already present under a different key", async () => {
+  // `bun add <tarball-url>` keys the dep by the tarball's resolved name
+  // ("baz"). A subsequent `bun add myalias@<same-url>` must create the
+  // requested "myalias" key — the URL-value fallback introduced for #30499
+  // must not silently latch onto the existing entry under a different key.
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response(Bun.file(join(__dirname, "baz-0.0.3.tgz")));
+    },
+  });
+  const tarball_url = `${server.url.href.replace(/\/+$/, "")}/baz-0.0.3.tgz`;
+  setHandler(dummyRegistry([]));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+    }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "add", tarball_url],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    expect(await stderr.text()).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+  }
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "add", `myalias@${tarball_url}`],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  expect(await file(join(package_dir, "package.json")).json()).toStrictEqual({
+    name: "foo",
+    version: "0.0.1",
+    dependencies: {
+      baz: tarball_url,
+      myalias: tarball_url,
+    },
+  });
+});
+
 it("should add multiple dependencies specified on command line", async () => {
   expect(check_npm_auth_type.check).toBe(true);
   using server = Bun.serve({

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2342,7 +2342,7 @@ it("should not add duplicate package.json entries when installing the same tarba
 
   // First install — key should be the package name from the tarball ("baz").
   {
-    const { stderr, exited } = spawn({
+    const { stdout, stderr, exited } = spawn({
       cmd: [bunExe(), "add", tarball_url],
       cwd: package_dir,
       stdout: "pipe",
@@ -2350,7 +2350,10 @@ it("should not add duplicate package.json entries when installing the same tarba
       stderr: "pipe",
       env,
     });
-    expect(await stderr.text()).toContain("Saved lockfile");
+    const [out, err] = await Promise.all([stdout.text(), stderr.text()]);
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(out).toContain("installed baz@");
     expect(await exited).toBe(0);
   }
   expect(await file(join(package_dir, "package.json")).json()).toStrictEqual({
@@ -2363,7 +2366,7 @@ it("should not add duplicate package.json entries when installing the same tarba
 
   // Second install with the same URL — must not duplicate the "baz" key.
   {
-    const { stderr, exited } = spawn({
+    const { stdout, stderr, exited } = spawn({
       cmd: [bunExe(), "add", tarball_url],
       cwd: package_dir,
       stdout: "pipe",
@@ -2371,9 +2374,9 @@ it("should not add duplicate package.json entries when installing the same tarba
       stderr: "pipe",
       env,
     });
-    // No error on exit.
-    const err = await stderr.text();
+    const [out, err] = await Promise.all([stdout.text(), stderr.text()]);
     expect(err).not.toContain("error:");
+    expect(out).toContain("installed baz@");
     expect(await exited).toBe(0);
   }
 
@@ -2412,7 +2415,7 @@ it("should honor an explicit alias for a tarball URL already present under a dif
   );
 
   {
-    const { stderr, exited } = spawn({
+    const { stdout, stderr, exited } = spawn({
       cmd: [bunExe(), "add", tarball_url],
       cwd: package_dir,
       stdout: "pipe",
@@ -2420,12 +2423,15 @@ it("should honor an explicit alias for a tarball URL already present under a dif
       stderr: "pipe",
       env,
     });
-    expect(await stderr.text()).toContain("Saved lockfile");
+    const [out, err] = await Promise.all([stdout.text(), stderr.text()]);
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(out).toContain("installed baz@");
     expect(await exited).toBe(0);
   }
 
   {
-    const { stderr, exited } = spawn({
+    const { stdout, stderr, exited } = spawn({
       cmd: [bunExe(), "add", `myalias@${tarball_url}`],
       cwd: package_dir,
       stdout: "pipe",
@@ -2433,8 +2439,9 @@ it("should honor an explicit alias for a tarball URL already present under a dif
       stderr: "pipe",
       env,
     });
-    const err = await stderr.text();
+    const [out, err] = await Promise.all([stdout.text(), stderr.text()]);
     expect(err).not.toContain("error:");
+    expect(out).toContain("installed myalias@");
     expect(await exited).toBe(0);
   }
 

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2323,6 +2323,73 @@ it("should add local tarball dependency", async () => {
     await access(join(package_dir, "bun.lockb")));
 });
 
+it("should not add duplicate package.json entries when installing the same tarball URL twice (#30499)", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response(Bun.file(join(__dirname, "baz-0.0.3.tgz")));
+    },
+  });
+  const tarball_url = `${server.url.href.replace(/\/+$/, "")}/baz-0.0.3.tgz`;
+  setHandler(dummyRegistry([]));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+    }),
+  );
+
+  // First install — key should be the package name from the tarball ("baz").
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "add", tarball_url],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    expect(await stderr.text()).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+  }
+  expect(await file(join(package_dir, "package.json")).json()).toStrictEqual({
+    name: "foo",
+    version: "0.0.1",
+    dependencies: {
+      baz: tarball_url,
+    },
+  });
+
+  // Second install with the same URL — must not duplicate the "baz" key.
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "add", tarball_url],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    // No error on exit.
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  // Parsing with JSON.parse normalises duplicate keys by keeping only one, so
+  // we have to assert on the raw text to see that duplication did not happen.
+  const raw = await file(join(package_dir, "package.json")).text();
+  expect(raw.match(/"baz"\s*:/g) ?? []).toHaveLength(1);
+  expect(JSON.parse(raw)).toStrictEqual({
+    name: "foo",
+    version: "0.0.1",
+    dependencies: {
+      baz: tarball_url,
+    },
+  });
+});
+
 it("should add multiple dependencies specified on command line", async () => {
   expect(check_npm_auth_type.check).toBe(true);
   using server = Bun.serve({


### PR DESCRIPTION
Fixes #30499

## Repro

```sh
mkdir /tmp/test && cd /tmp/test
echo '{}' > package.json

bun install https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz
bun install https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz

cat package.json
# {
#   "dependencies": {
#     "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
#     "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"   <- dup
#   }
# }
```

## Cause

`PackageJSONEditor.edit` (`src/install/PackageManager/PackageJSONEditor.zig`) looks up existing deps by `UpdateRequest.getName()`. For a tarball URL that was passed without an explicit `name@url` alias, `is_aliased` is `false`, so `getName()` returns the URL literal rather than the resolved package name. `asProperty(name)` therefore searches for a property whose key is the URL and never finds the existing `"<pkg>"` key.

The fallback URL-value-match loop a few lines below only ran for `.github` and `.git` tags. `.tarball` fell through to the append path, which wrote the new entry keyed by `getResolvedName(lockfile)` ("lodash") on top of the existing `"lodash"` key without removing it — producing two keys with the same name.

## Fix

Extend the existing-URL fallback loop to also match `.tarball`, and guard the loop so a match in an earlier dependency list (e.g. `dependencies`) isn't re-counted when the inline for continues to the remaining lists (`devDependencies`, etc.).

## Verification

Added `should not add duplicate package.json entries when installing the same tarball URL twice (#30499)` in `test/cli/install/bun-add.test.ts`.

- `USE_SYSTEM_BUN=1 bun test test/cli/install/bun-add.test.ts -t '#30499'` — fails on the duplicate key (reproduces the bug).
- `bun bd test test/cli/install/bun-add.test.ts -t '#30499'` — passes with the fix.
- Existing tarball tests (`should add dependency with package.json in it and http tarball`, `should add local tarball dependency`, `should install tarball with tarball dependencies`) still pass.