### PR TITLE
Preserve original Error stack when uncaughtException handler rethrows

### DIFF
--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -481,12 +481,18 @@ static void fromErrorInstance(ZigException& except, JSC::JSGlobalObject* global,
     auto& vm = JSC::getVM(global);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
+    // Prefer the Error instance's own stack (captured at construction) over
+    // the outer JSC::Exception wrapper's stack. When a user rethrows an
+    // existing Error — e.g. inside `process.on('uncaughtException')` — JSC
+    // wraps the value in a fresh Exception whose stack points at the
+    // `throw err` site. The interesting data is on the Error itself, not on
+    // the rethrow wrapper. This matches Node's behavior of using `err.stack`.
     bool getFromSourceURL = false;
-    if (stackTrace != nullptr && stackTrace->size() > 0) {
-        populateStackTrace(vm, *stackTrace, except.stack, global, flags);
-
-    } else if (err->stackTrace() != nullptr && err->stackTrace()->size() > 0) {
+    if (err->stackTrace() != nullptr && err->stackTrace()->size() > 0) {
         populateStackTrace(vm, *err->stackTrace(), except.stack, global, flags, FinalizerSafety::MustNotTriggerGC);
+
+    } else if (stackTrace != nullptr && stackTrace->size() > 0) {
+        populateStackTrace(vm, *stackTrace, except.stack, global, flags);
 
     } else {
         getFromSourceURL = true;
@@ -878,7 +884,15 @@ extern "C" void ZigException__collectSourceLines(JSC::EncodedJSValue jsException
         auto* jscException = uncheckedDowncast<JSC::Exception>(value);
         JSValue unwrapped = jscException->value();
 
-        if (jscException->stack().size() > 0) {
+        // Must mirror the stack-source selection used by `fromErrorInstance`
+        // above: OnlySourceLines indexes into the same frame vector recorded
+        // during OnlyPosition (via ZigStackFrame::jsc_stack_frame_index). If
+        // the Error has its own stack, use it; otherwise fall back to the
+        // wrapper's stack.
+        if (auto* error = dynamicDowncast<JSC::ErrorInstance>(unwrapped);
+            error && error->stackTrace() != nullptr && error->stackTrace()->size() > 0) {
+            populateStackTrace(global->vm(), *error->stackTrace(), exception->stack, global, PopulateStackTraceFlags::OnlySourceLines, FinalizerSafety::MustNotTriggerGC);
+        } else if (jscException->stack().size() > 0) {
             populateStackTrace(global->vm(), jscException->stack(), exception->stack, global, PopulateStackTraceFlags::OnlySourceLines);
         }
 

--- a/test/js/bun/test/dots.test.ts
+++ b/test/js/bun/test/dots.test.ts
@@ -87,7 +87,7 @@ test("dots 2", async () => {
     6 |   setTimeout(() => {
     7 |     resolve();
     8 |     throw new Error("unhandled error");
-                                             ^
+                      ^
     error: unhandled error
         at <anonymous> (file:NN:NN)
     (fail) failure

--- a/test/js/bun/test/only-failures.test.ts
+++ b/test/js/bun/test/only-failures.test.ts
@@ -39,7 +39,7 @@ test.concurrent("only-failures flag should show only failures", async () => {
     24 | 
     25 | test("another failing test", () => {
     26 |   throw new Error("This test fails");
-                                            ^
+                     ^
     error: This test fails
         at <anonymous> (file:NN:NN)
     (fail) another failing test

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -821,6 +821,34 @@ describe.concurrent(() => {
     expect(await proc.exited).toBe(1);
     expect(await proc.stderr.text()).toContain("bar");
   });
+
+  // https://github.com/oven-sh/bun/issues/30504
+  it("preserves the original Error stack when the uncaughtException handler rethrows", async () => {
+    using dir = tempDir("rethrow-uncaught", {
+      "index.cjs": `
+        'use strict';
+        process.on('uncaughtException', err => {
+          throw err;
+        });
+        function throwUncaughtError() {
+          throw new Error('Boom');
+        }
+        throwUncaughtError();
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(String(dir), "index.cjs")],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(exitCode).toBe(7);
+    // Stack must reference the original throw site inside throwUncaughtError,
+    // not only the `throw err` rethrow site inside the handler.
+    expect(stderr).toContain("throwUncaughtError");
+    expect(stderr).toContain("Boom");
+  });
 });
 
 it("process.hasUncaughtExceptionCaptureCallback", () => {

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -843,11 +843,11 @@ describe.concurrent(() => {
       stdout: "pipe",
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    expect(exitCode).toBe(7);
     // Stack must reference the original throw site inside throwUncaughtError,
     // not only the `throw err` rethrow site inside the handler.
     expect(stderr).toContain("throwUncaughtError");
     expect(stderr).toContain("Boom");
+    expect(exitCode).toBe(7);
   });
 });
 

--- a/test/regression/issue/12782.test.ts
+++ b/test/regression/issue/12782.test.ts
@@ -28,7 +28,7 @@ test("12782", async () => {
     4 | 
     5 | beforeAll(() => {
     6 |   if (!FOO) throw new Error("Environment variable FOO is not set");
-                                                                         ^
+                              ^
     error: Environment variable FOO is not set
         at <anonymous> (file:NN:NN)
     (fail) (unnamed)

--- a/test/regression/issue/19850/19850.test.ts
+++ b/test/regression/issue/19850/19850.test.ts
@@ -25,17 +25,17 @@ err-in-hook-and-multiple-tests.ts:
 2 | 
 3 | beforeEach(() => {
 4 |   throw new Error("beforeEach");
-                                  ^
+                ^
 error: beforeEach
-      at <anonymous> (/err-in-hook-and-multiple-tests.ts:4:31)
+      at <anonymous> (/err-in-hook-and-multiple-tests.ts:4:13)
 (fail) test 0
 1 | import { beforeEach, test } from "bun:test";
 2 | 
 3 | beforeEach(() => {
 4 |   throw new Error("beforeEach");
-                                  ^
+                ^
 error: beforeEach
-      at <anonymous> (/err-in-hook-and-multiple-tests.ts:4:31)
+      at <anonymous> (/err-in-hook-and-multiple-tests.ts:4:13)
 (fail) test 1
 
  0 pass


### PR DESCRIPTION
Fixes #30504.

## Repro

```js
process.on('uncaughtException', err => {
  throw err;
});
function throwUncaughtError() {
  throw new Error('Boom');  // line 5
}
throwUncaughtError();
```

## Before

```
3 | process.on('uncaughtException', err => {
4 |   throw err;
            ^
error: Boom
      at <anonymous> (rethrow.cjs:4:9)
```

Bun points at the rethrow site (line 4) and drops every frame from the original throw.

## After (and Node's behavior)

```
7 | function throwUncaughtError() {
8 |   throw new Error('Boom');
                ^
error: Boom
      at throwUncaughtError (rethrow.cjs:8:13)
      at <anonymous> (rethrow.cjs:11:1)
```

## Cause

When the listener does `throw err`, JSC wraps the pre-existing Error in a
fresh `JSC::Exception` that captures a new stack at the rethrow site.
`fromErrorInstance` (src/jsc/bindings/ZigException.cpp) preferred that
wrapper stack over the Error's own `stackTrace()`, so the original
frames captured at `new Error(...)` construction were thrown away.

## Fix

Swap the precedence in `fromErrorInstance` and in the OnlySourceLines
path of `ZigException__collectSourceLines` so the Error's own stack
wins. The wrapper stack is still used as a fallback when the Error has
none (rare — happens with synthetic rethrows of non-Error values, etc.).

## Verification

- New test: `test/js/node/process/process.test.js` > "preserves the
  original Error stack when the uncaughtException handler rethrows".
  Fails on main (`Received: ... at <anonymous> (.../index.cjs:4:17)"`);
  passes on this branch.
- Existing uncaughtException suite (`process.test.js` -t uncaughtException): 5/5 pass.
- `test/regression/issue/08794.test.ts`, `circular-error-stack.test.ts`,
  `circular-error-stack-edge-cases.test.ts`,
  `23022-stack-trace-iterator.test.ts`,
  `fix-bindings-stack-trace.test.ts`,
  `prepare-stack-trace-crash.test.ts`: all pass.
- `test/js/bun/test/stack.test.ts`,
  `test/js/bun/sourcemap/internal-sourcemap.test.ts`: all pass.
- Node compat sanity: `test-events-uncaught-exception-stack.js`,
  `test-exception-handler.js`, `test-exception-handler2.js`,
  `test-emit-after-uncaught-exception.js` all exit 0.
