### PR TITLE
test: key TestRunner file-index map on the full path, not a truncated hash

### DIFF
--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -218,8 +218,8 @@ impl<'a> TestRunner<'a> {
     }
 
     pub fn get_or_put_file(&mut self, file_path: &'static [u8]) -> GetOrPutFileResult {
-        // Callers pass paths interned in FileSystem's filename_store, so the
-        // borrowed key slice outlives this map.
+        // The map boxes its own copy of the key; the &'static borrow is for
+        // the Source stored below.
         let entry = self.index.get_or_put(file_path).expect("unreachable");
         if entry.found_existing {
             return GetOrPutFileResult {

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -218,13 +218,8 @@ impl<'a> TestRunner<'a> {
     }
 
     pub fn get_or_put_file(&mut self, file_path: &'static [u8]) -> GetOrPutFileResult {
-        // Key on the full path string. A prior version truncated
-        // `bun_wyhash::hash(file_path)` to u32 and used that as the key; two
-        // distinct paths whose wyhash lower-32-bits collided would share a
-        // file_id, silently dropping the second file's Source and corrupting
-        // downstream per-file state (--randomize PRNG seed, --concurrent
-        // glob match). Callers pass paths interned in FileSystem's
-        // filename_store, so the slice outlives this map.
+        // Callers pass paths interned in FileSystem's filename_store, so the
+        // borrowed key slice outlives this map.
         let entry = self.index.get_or_put(file_path).expect("unreachable");
         if entry.found_existing {
             return GetOrPutFileResult {
@@ -292,7 +287,6 @@ bun_collections::multi_array_columns! {
         log: bun_ast::Log,
     }
 }
-// Key on the full path string (see `get_or_put_file` for the rationale).
 pub(crate) type FileMap = StringArrayHashMap<FileId>;
 
 #[allow(non_snake_case)]

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -3,7 +3,7 @@ use std::io::Write as _;
 
 use crate::cli::command::TestOptions;
 use crate::cli::test_command::CommandLineReporter;
-use bun_collections::{ArrayHashMap, MultiArrayList};
+use bun_collections::{MultiArrayList, StringArrayHashMap};
 use bun_core::Output;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{
@@ -218,11 +218,14 @@ impl<'a> TestRunner<'a> {
     }
 
     pub fn get_or_put_file(&mut self, file_path: &'static [u8]) -> GetOrPutFileResult {
-        // TODO: this is wrong. you can't put a hash as the key in a hashmap.
-        let entry = self
-            .index
-            .get_or_put(bun_wyhash::hash(file_path) as u32)
-            .expect("unreachable");
+        // Key on the full path string. A prior version truncated
+        // `bun_wyhash::hash(file_path)` to u32 and used that as the key; two
+        // distinct paths whose wyhash lower-32-bits collided would share a
+        // file_id, silently dropping the second file's Source and corrupting
+        // downstream per-file state (--randomize PRNG seed, --concurrent
+        // glob match). Callers pass paths interned in FileSystem's
+        // filename_store, so the slice outlives this map.
+        let entry = self.index.get_or_put(file_path).expect("unreachable");
         if entry.found_existing {
             return GetOrPutFileResult {
                 file_id: *entry.value_ptr,
@@ -289,8 +292,8 @@ bun_collections::multi_array_columns! {
         log: bun_ast::Log,
     }
 }
-// u32 keys hash as identity in bun_collections.
-pub(crate) type FileMap = ArrayHashMap<u32, u32>;
+// Key on the full path string (see `get_or_put_file` for the rationale).
+pub(crate) type FileMap = StringArrayHashMap<FileId>;
 
 #[allow(non_snake_case)]
 pub mod Jest {

--- a/test/cli/test/test-randomize.test.ts
+++ b/test/cli/test/test-randomize.test.ts
@@ -78,77 +78,73 @@ test.concurrent("--randomize and --seed work", async () => {
 // the birthday-paradox collision search takes ~5–10 s (vs ~50 ms release)
 // and would starve the sibling concurrent tests past their default 5s
 // timeout. A generous per-test timeout covers the slow debug path.
-test(
-  "--randomize: files whose u32-truncated path hashes collide get distinct per-file orders",
-  async () => {
-    // Find two filenames under an unpredictable tempDir prefix whose full
-    // wyhash differs but whose lower 32 bits match. Birthday collision on
-    // u32 is ~77k filenames at 50% probability, ~200k at 99%.
-    const tmpRoot = tempDirWithFiles("randomize-hash-collision", {});
-    // macOS: /tmp is a symlink to /private/tmp; the test runner resolves
-    // the real path, so the collision has to be found on that form.
-    const realRoot = isMacOS ? realpathSync(tmpRoot) : tmpRoot;
+test("--randomize: files whose u32-truncated path hashes collide get distinct per-file orders", async () => {
+  // Find two filenames under an unpredictable tempDir prefix whose full
+  // wyhash differs but whose lower 32 bits match. Birthday collision on
+  // u32 is ~77k filenames at 50% probability, ~200k at 99%.
+  const tmpRoot = tempDirWithFiles("randomize-hash-collision", {});
+  // macOS: /tmp is a symlink to /private/tmp; the test runner resolves
+  // the real path, so the collision has to be found on that form.
+  const realRoot = isMacOS ? realpathSync(tmpRoot) : tmpRoot;
 
-    let aIdx = -1;
-    let bIdx = -1;
-    const seen = new Map<number, number>();
-    const mask = 0xffffffffn;
-    for (let i = 0; i < 200_000; i++) {
-      const h = Number(Bun.hash(join(realRoot, `f${i}.test.ts`)) & mask);
-      if (seen.has(h)) {
-        aIdx = seen.get(h)!;
-        bIdx = i;
-        break;
-      }
-      seen.set(h, i);
+  let aIdx = -1;
+  let bIdx = -1;
+  const seen = new Map<number, number>();
+  const mask = 0xffffffffn;
+  for (let i = 0; i < 200_000; i++) {
+    const h = Number(Bun.hash(join(realRoot, `f${i}.test.ts`)) & mask);
+    if (seen.has(h)) {
+      aIdx = seen.get(h)!;
+      bIdx = i;
+      break;
     }
-    if (aIdx < 0) throw new Error("no u32 hash collision found in 200k filenames");
+    seen.set(h, i);
+  }
+  if (aIdx < 0) throw new Error("no u32 hash collision found in 200k filenames");
 
-    // Same body in both files so any difference in observed order comes
-    // from the per-file PRNG, not the tests themselves. Stdout prefixes
-    // let us attribute each "RUN" line to its file.
-    const body = (tag: string) => `
+  // Same body in both files so any difference in observed order comes
+  // from the per-file PRNG, not the tests themselves. Stdout prefixes
+  // let us attribute each "RUN" line to its file.
+  const body = (tag: string) => `
       import { test, expect } from "bun:test";
       test.each(["alpha","bravo","charlie","delta","echo","foxtrot","golf"])(
         "order: %s",
         (word) => { console.log("RUN ${tag} " + word); expect(typeof word).toBe("string"); },
       );
     `;
-    await Bun.write(join(tmpRoot, `f${aIdx}.test.ts`), body("A"));
-    await Bun.write(join(tmpRoot, `f${bIdx}.test.ts`), body("B"));
+  await Bun.write(join(tmpRoot, `f${aIdx}.test.ts`), body("A"));
+  await Bun.write(join(tmpRoot, `f${bIdx}.test.ts`), body("B"));
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "--randomize", "--seed=42"],
-      cwd: tmpRoot,
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(exitCode).toBe(0);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--randomize", "--seed=42"],
+    cwd: tmpRoot,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(exitCode).toBe(0);
 
-    const orderA = stdout
-      .split("\n")
-      .filter(l => l.startsWith("RUN A "))
-      .map(l => l.slice(6));
-    const orderB = stdout
-      .split("\n")
-      .filter(l => l.startsWith("RUN B "))
-      .map(l => l.slice(6));
-    const sorted = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf"].sort();
-    // Both files must have produced a full run. Under the old truncated-
-    // hash key the second file's Source was dropped entirely; loading it
-    // still happened via the module system, so its tests do run, but the
-    // assertion below is the one that actually catches the regression.
-    expect([...orderA].sort()).toEqual(sorted);
-    expect([...orderB].sort()).toEqual(sorted);
-    // The actual regression: colliding files must get distinct PRNG seeds,
-    // so their shuffled orders must differ. With the old truncated-hash
-    // key both arrays are identical.
-    expect(orderA).not.toEqual(orderB);
-  },
-  60_000,
-);
+  const orderA = stdout
+    .split("\n")
+    .filter(l => l.startsWith("RUN A "))
+    .map(l => l.slice(6));
+  const orderB = stdout
+    .split("\n")
+    .filter(l => l.startsWith("RUN B "))
+    .map(l => l.slice(6));
+  const sorted = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf"].sort();
+  // Both files must have produced a full run. Under the old truncated-
+  // hash key the second file's Source was dropped entirely; loading it
+  // still happened via the module system, so its tests do run, but the
+  // assertion below is the one that actually catches the regression.
+  expect([...orderA].sort()).toEqual(sorted);
+  expect([...orderB].sort()).toEqual(sorted);
+  // The actual regression: colliding files must get distinct PRNG seeds,
+  // so their shuffled orders must differ. With the old truncated-hash
+  // key both arrays are identical.
+  expect(orderA).not.toEqual(orderB);
+}, 60_000);
 
 test.concurrent("randomizes order of files", async () => {
   const dir = tempDirWithFiles(

--- a/test/cli/test/test-randomize.test.ts
+++ b/test/cli/test/test-randomize.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isMacOS, tempDirWithFiles } from "harness";
+import { realpathSync } from "node:fs";
+import { join } from "node:path";
 
 // test:
 // --randomize randomizes
@@ -63,6 +65,90 @@ test.concurrent("--randomize and --seed work", async () => {
   expect(unseededOrder).toEqual(unsortedOrder);
   expect(unseededSeed).toBeNull();
 });
+
+// https://github.com/oven-sh/bun/issues/30507
+// Regression: `TestRunner.getOrPutFile` used to key its index hashmap on
+// `@truncate(bun.hash(file_path), u32)`. Two distinct paths whose wyhash
+// lower-32-bits collide got the same file_id, the second file's Source was
+// dropped, and both ended up reading the first file's path.text when
+// deriving the per-file --randomize PRNG seed — so both files ran their
+// tests in the same order. The fix switches the map to a string-keyed map.
+//
+// Not `test.concurrent`: `Bun.hash` is ~170x slower in debug builds, so
+// the birthday-paradox collision search takes ~5–10 s (vs ~50 ms release)
+// and would starve the sibling concurrent tests past their default 5s
+// timeout. A generous per-test timeout covers the slow debug path.
+test(
+  "--randomize: files whose u32-truncated path hashes collide get distinct per-file orders",
+  async () => {
+    // Find two filenames under an unpredictable tempDir prefix whose full
+    // wyhash differs but whose lower 32 bits match. Birthday collision on
+    // u32 is ~77k filenames at 50% probability, ~200k at 99%.
+    const tmpRoot = tempDirWithFiles("randomize-hash-collision", {});
+    // macOS: /tmp is a symlink to /private/tmp; the test runner resolves
+    // the real path, so the collision has to be found on that form.
+    const realRoot = isMacOS ? realpathSync(tmpRoot) : tmpRoot;
+
+    let aIdx = -1;
+    let bIdx = -1;
+    const seen = new Map<number, number>();
+    const mask = 0xffffffffn;
+    for (let i = 0; i < 200_000; i++) {
+      const h = Number(Bun.hash(join(realRoot, `f${i}.test.ts`)) & mask);
+      if (seen.has(h)) {
+        aIdx = seen.get(h)!;
+        bIdx = i;
+        break;
+      }
+      seen.set(h, i);
+    }
+    if (aIdx < 0) throw new Error("no u32 hash collision found in 200k filenames");
+
+    // Same body in both files so any difference in observed order comes
+    // from the per-file PRNG, not the tests themselves. Stdout prefixes
+    // let us attribute each "RUN" line to its file.
+    const body = (tag: string) => `
+      import { test, expect } from "bun:test";
+      test.each(["alpha","bravo","charlie","delta","echo","foxtrot","golf"])(
+        "order: %s",
+        (word) => { console.log("RUN ${tag} " + word); expect(typeof word).toBe("string"); },
+      );
+    `;
+    await Bun.write(join(tmpRoot, `f${aIdx}.test.ts`), body("A"));
+    await Bun.write(join(tmpRoot, `f${bIdx}.test.ts`), body("B"));
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--randomize", "--seed=42"],
+      cwd: tmpRoot,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(exitCode).toBe(0);
+
+    const orderA = stdout
+      .split("\n")
+      .filter(l => l.startsWith("RUN A "))
+      .map(l => l.slice(6));
+    const orderB = stdout
+      .split("\n")
+      .filter(l => l.startsWith("RUN B "))
+      .map(l => l.slice(6));
+    const sorted = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf"].sort();
+    // Both files must have produced a full run. Under the old truncated-
+    // hash key the second file's Source was dropped entirely; loading it
+    // still happened via the module system, so its tests do run, but the
+    // assertion below is the one that actually catches the regression.
+    expect([...orderA].sort()).toEqual(sorted);
+    expect([...orderB].sort()).toEqual(sorted);
+    // The actual regression: colliding files must get distinct PRNG seeds,
+    // so their shuffled orders must differ. With the old truncated-hash
+    // key both arrays are identical.
+    expect(orderA).not.toEqual(orderB);
+  },
+  60_000,
+);
 
 test.concurrent("randomizes order of files", async () => {
   const dir = tempDirWithFiles(

--- a/test/cli/test/test-randomize.test.ts
+++ b/test/cli/test/test-randomize.test.ts
@@ -81,7 +81,10 @@ test.concurrent("--randomize and --seed work", async () => {
 test("--randomize: files whose u32-truncated path hashes collide get distinct per-file orders", async () => {
   // Find two filenames under an unpredictable tempDir prefix whose full
   // wyhash differs but whose lower 32 bits match. Birthday collision on
-  // u32 is ~77k filenames at 50% probability, ~200k at 99%.
+  // u32 is ~77k filenames at 50% probability; at the 400k cap the miss
+  // probability is exp(-400000^2 / 2^33) ~= 8e-9, so the search is
+  // effectively guaranteed to succeed. The typical hit still lands around
+  // 77k, so the cap only costs time in the astronomically rare tail.
   const tmpRoot = tempDirWithFiles("randomize-hash-collision", {});
   // macOS: /tmp is a symlink to /private/tmp; the test runner resolves
   // the real path, so the collision has to be found on that form.
@@ -91,7 +94,7 @@ test("--randomize: files whose u32-truncated path hashes collide get distinct pe
   let bIdx = -1;
   const seen = new Map<number, number>();
   const mask = 0xffffffffn;
-  for (let i = 0; i < 200_000; i++) {
+  for (let i = 0; i < 400_000; i++) {
     const h = Number(Bun.hash(join(realRoot, `f${i}.test.ts`)) & mask);
     if (seen.has(h)) {
       aIdx = seen.get(h)!;
@@ -100,7 +103,7 @@ test("--randomize: files whose u32-truncated path hashes collide get distinct pe
     }
     seen.set(h, i);
   }
-  if (aIdx < 0) throw new Error("no u32 hash collision found in 200k filenames");
+  if (aIdx < 0) throw new Error("no u32 hash collision found in 400k filenames");
 
   // 20 items: two independent Fisher–Yates shuffles collide by chance
   // with probability 1/20! (~4e-19), so `orderA != orderB` is effectively

--- a/test/cli/test/test-randomize.test.ts
+++ b/test/cli/test/test-randomize.test.ts
@@ -102,12 +102,16 @@ test("--randomize: files whose u32-truncated path hashes collide get distinct pe
   }
   if (aIdx < 0) throw new Error("no u32 hash collision found in 200k filenames");
 
+  // 20 items: two independent Fisher–Yates shuffles collide by chance
+  // with probability 1/20! (~4e-19), so `orderA != orderB` is effectively
+  // a deterministic assertion of "distinct PRNG seeds were used".
+  const words = Array.from({ length: 20 }, (_, i) => `w${i}`);
   // Same body in both files so any difference in observed order comes
   // from the per-file PRNG, not the tests themselves. Stdout prefixes
   // let us attribute each "RUN" line to its file.
   const body = (tag: string) => `
       import { test, expect } from "bun:test";
-      test.each(["alpha","bravo","charlie","delta","echo","foxtrot","golf"])(
+      test.each(${JSON.stringify(words)})(
         "order: %s",
         (word) => { console.log("RUN ${tag} " + word); expect(typeof word).toBe("string"); },
       );
@@ -122,8 +126,7 @@ test("--randomize: files whose u32-truncated path hashes collide get distinct pe
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(exitCode).toBe(0);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   const orderA = stdout
     .split("\n")
@@ -133,7 +136,7 @@ test("--randomize: files whose u32-truncated path hashes collide get distinct pe
     .split("\n")
     .filter(l => l.startsWith("RUN B "))
     .map(l => l.slice(6));
-  const sorted = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf"].sort();
+  const sorted = [...words].sort();
   // Both files must have produced a full run. Under the old truncated-
   // hash key the second file's Source was dropped entirely; loading it
   // still happened via the module system, so its tests do run, but the
@@ -144,6 +147,10 @@ test("--randomize: files whose u32-truncated path hashes collide get distinct pe
   // so their shuffled orders must differ. With the old truncated-hash
   // key both arrays are identical.
   expect(orderA).not.toEqual(orderB);
+  // Surface subprocess stderr if the run exited non-zero before asserting
+  // exit code — otherwise a CI failure is just "expected 0, got N".
+  if (exitCode !== 0) expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 }, 60_000);
 
 test.concurrent("randomizes order of files", async () => {


### PR DESCRIPTION
Fixes #30507

### Repro

/private/tmp/bunhash/file_7001.test.ts <-> /private/tmp/bunhash/file_43894.test.ts

### Cause

`TestRunner.getOrPutFile` keyed its index hashmap on
`@truncate(bun.hash(file_path), u32)`. Two distinct paths whose wyhash
lower-32-bits collided got the same `file_id`, the second file's
`Source` was silently dropped by the `found_existing` branch, and two
downstream consumers read the first file's path in its place:

- `src/test_runner/bun_test.zig:614-619` — per-file `--randomize` PRNG
  seed `hash(seed, files.items(.source)[file_id].path.text)`; colliding
  files shuffled to the same order.
- `src/test_runner/jest.zig:144-161` — `shouldFileRunConcurrently`
  glob-matches on the same path slot; colliding files inherited the first
  file's concurrency decision.

The bug was flagged on the line itself: `// TODO: this is wrong. you
can't put a hash as the key in a hashmap.` Birthday probability on u32
puts 50 % collision at ~77 k distinct paths, 99 % at ~200 k — monorepos
at that scale hit it every run, which is why it wasn't caught by Bun's
own 1,715-file suite.

### Fix

Key the map on the full path string:

```diff
-pub const Map = std.ArrayHashMapUnmanaged(u32, u32, ArrayIdentityContext, false);
+pub const Map = bun.StringArrayHashMapUnmanaged(File.ID);
```

`ArrayHashMap` still preserves insertion order (matching the existing
`files: MultiArrayList` indexed by `file_id`), and callers pass paths
interned in `FileSystem.instance.filename_store` which is a process-
lifetime `BSSStringList` — the slice outlives the map, no dupe needed.

### Verification

Regression test at `test/cli/test/test-randomize.test.ts`:

1. Creates a tempDir, resolves its real path (macOS /tmp → /private/tmp).
2. Brute-forces a u32 collision under that prefix via `Bun.hash`
   (same wyhash the runner uses).
3. Writes two colliding files with identical randomized bodies.
4. Runs `bun test --randomize --seed=42` and asserts the two files'
   orders differ.

Gate-checked: fails on stashed-src (`expect(orderA).not.toEqual(orderB)`
because both are the identical shuffled sequence), passes on the fix.

---

**Update (rebase onto main):** Main landed the Rust rewrite of the test runner (#30412), which reintroduced the u32-truncated-hash key in `TestRunner::get_or_put_file` with the original `TODO: this is wrong` comment intact. The Rust `FileMap` has been switched from `ArrayHashMap<u32, u32>` to `StringArrayHashMap<FileId>` in `src/runtime/test_runner/jest.rs` to match the Zig fix; the existing regression test still fails on stashed-`jest.rs` and passes on the fix.

---

**Update (rebase onto main):** Main deleted the Zig port of the test runner (`src/runtime/test_runner/jest.zig` is gone; only the Rust `jest.rs` remains). Dropped my now-obsolete `jest.zig` edits during the rebase; the fix lives entirely in `src/runtime/test_runner/jest.rs` (`FileMap = StringArrayHashMap<FileId>`, keyed on the full path). Gate re-checked: regression test fails on main's `jest.rs`, passes with the fix.