### PR TITLE
Suppress deprecated declaration warnings on Unix builds

### DIFF
--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -556,6 +556,7 @@ export const bunOnlyFlags: Flag[] = [
       "-Wno-c++23-lambda-attributes",
       "-Wno-nullability-completeness",
       "-Wno-character-conversion",
+      "-Wno-deprecated-declarations",
       "-Werror",
     ],
     when: c => c.unix,


### PR DESCRIPTION
Fixes debug builds with Clang 21 on Debian 12, where libstdc++ 12 emits deprecated declaration warnings from std::stable_sort that are promoted to errors by -Werror.

  Tested with:
  - bun bd

