### PR TITLE
fix: `test.each` with empty array item no longer triggers false done callback timeout

### DIFF
--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -249,7 +249,7 @@ pub fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<
                 bound,
                 formatted_label.as_deref(),
                 &args.options,
-                callback_length.saturating_sub(args_list.len()),
+                callback_length.saturating_sub(args_list.len().max(1)),
                 line_no,
             )?;
 

--- a/test/js/bun/test/jest-each.test.ts
+++ b/test/js/bun/test/jest-each.test.ts
@@ -57,3 +57,21 @@ describe.each(["some", "cool", "strings"])("works with describe: %s", s => {
 describe("does not return zero", () => {
   expect(it.each([1, 2])("wat", () => {})).toBeUndefined();
 });
+
+
+describe("empty array item in each does not trigger done timeout", () => {
+  it.each([undefined, null, "", [], {}])("receives %s as argument without timing out", (arg) => {
+    // The callback should execute synchronously without bun interpreting it as having a done parameter.
+    // Previously, [] caused a false done-callback timeout because spreading an empty array
+    // left callback_length at 1.
+    if (Array.isArray(arg)) {
+      expect(arg).toBeArray();
+    } else if (arg === null) {
+      expect(arg).toBeNull();
+    } else if (arg === undefined) {
+      expect(arg).toBeUndefined();
+    } else {
+      expect(typeof arg).toBe(typeof arg);
+    }
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where `test.each` (or `it.each`) times out when one of the items in the array is an empty array `[]`.

**Reproducer:**
```js
test.each([undefined, null, '', [], {}])('test %s', (arg) => {
  expect(true).toBe(true);
});
```

The `[]` item causes a 5-second timeout with the error:
> this test timed out after 5000ms, before its done callback was called

**Root cause:** When `test.each` receives an item that is an array, it spreads the array elements as arguments to the callback. An empty array `[]` spreads to 0 arguments. The `callback_length` calculation (`callback_length.saturating_sub(args_list.len())`) then subtracts 0, leaving `callback_length = 1`. This makes bun think the test callback has a `done` parameter — triggering the timeout.

**Fix:** Use `args_list.len().max(1)` to ensure we always account for at least 1 argument being consumed by the each item. The callback always receives at least the item itself (via `bind`), so the original callback's parameter for that item should always be subtracted.

### How did you verify your code works?

- ✅ New test passes with built bun (30/30)
- ✅ New test fails with system bun (29 pass, 1 fail — the `[]` case times out)
- ✅ Existing jest-each tests all pass (no regressions)