### PR TITLE
Fix crash in Bun.build with many conditions

### DIFF
--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1087,9 +1087,9 @@ pub const ESMConditions = struct {
         var require_condition_map = ConditionsMap.init(allocator);
         var style_condition_map = ConditionsMap.init(allocator);
 
-        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
+        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + @intFromBool(allow_addons) + conditions.len);
+        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + @intFromBool(allow_addons) + conditions.len);
+        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + @intFromBool(allow_addons) + conditions.len);
         try style_condition_map.ensureTotalCapacity(defaults.len + 2 + conditions.len);
 
         import_condition_map.putAssumeCapacity("import", {});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -649,6 +649,17 @@ describe("Bun.build", () => {
       expect(await html?.text()).toContain("<meta name='injected-by-plugin' content='true'>");
     },
   );
+
+  test.concurrent("many conditions does not crash", async () => {
+    const dir = tempDirWithFiles("bun-build-api-many-conditions", {
+      "index.ts": "export const a = 1;",
+    });
+    const result = await Bun.build({
+      entrypoints: [join(dir, "index.ts")],
+      conditions: ["c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10"],
+    });
+    expect(result.success).toBe(true);
+  });
 });
 
 test.concurrent("macro with nested object", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes an operator precedence bug in `ESMConditions.init` that caused a debug assertion failure (and potential memory corruption in release) when passing several `conditions` to `Bun.build()`.

The expression:
```zig
defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len
```
parses as:
```zig
defaults.len + 2 + (if (allow_addons) 1 else (0 + conditions.len))
```

So when `allow_addons` is `true` (the default), `conditions.len` is dropped from the reserved capacity and subsequent `putAssumeCapacity` calls overflow the map.

## How did you verify your code works?

Added a regression test that passes 10 conditions to `Bun.build()`. Before this fix it triggers `reached unreachable code` in `MultiArrayList.addOneAssumeCapacity`; after the fix it builds successfully.

Found by Fuzzilli (fingerprint `fdba7e39f969672c`).