### PR TITLE
install: resolve .npmrc auth tokens against the request URL (fixes #30513)

### DIFF
--- a/src/ini/ini.zig
+++ b/src/ini/ini.zig
@@ -1226,13 +1226,22 @@ pub fn loadNpmrc(
             // aren't credentials, so they don't contribute darts.
             switch (conf_item.optname) {
                 ._authToken, ._auth, .username, ._password => {
-                    const dart_host = bun.strings.withoutTrailingSlash(conf_item_url.host);
+                    const dart_host_raw = bun.strings.withoutTrailingSlash(conf_item_url.host);
                     const dart_path = bun.strings.withoutTrailingSlash(conf_item_url.pathname);
                     // Normalize an empty/root path to "" so hash lookups are stable.
                     const dart_path_norm = if (dart_path.len == 0 or std.mem.eql(u8, dart_path, "/"))
                         ""
                     else
                         dart_path;
+                    // Hostnames are case-insensitive (DNS); `matches()` uses
+                    // a case-insensitive compare at request time. Lowercase
+                    // the host before building the hash key and storing it
+                    // on the entry, so `//Git.Example.com/` and
+                    // `//git.example.com/` collapse into a single dart and
+                    // later overrides can replace earlier entries reliably.
+                    const dart_host = try allocator.alloc(u8, dart_host_raw.len);
+                    _ = std.ascii.lowerString(dart_host, dart_host_raw);
+
                     // Host+path concatenated is the nerf-dart key. Using
                     // "\x00" as a separator keeps it unambiguous without
                     // extra state.
@@ -1244,22 +1253,40 @@ pub fn loadNpmrc(
                     const gop = try auth_by_dart.getOrPut(key_buf);
                     if (!gop.found_existing) {
                         gop.value_ptr.* = .{
-                            .host = try allocator.dupe(u8, dart_host),
+                            .host = dart_host,
                             .path = try allocator.dupe(u8, dart_path_norm),
                         };
                     } else {
                         allocator.free(key_buf);
+                        allocator.free(dart_host);
                     }
 
                     // Repeated entries for the same nerf-dart (common when
                     // `~/.npmrc` and the project `.npmrc` both set the
-                    // same key) replace the previous value; free the
-                    // prior slice so we don't leak across overrides.
+                    // same key) replace the previous value. Auth modes
+                    // `_authToken` / `_auth` / `username`+`_password` are
+                    // mutually exclusive, and `finalize()` prefers
+                    // `auth_b64` whenever it's non-empty — so when a later
+                    // entry switches modes, clear the previous mode's
+                    // fields so they don't linger on the finalised entry.
                     switch (conf_item.optname) {
                         ._authToken => {
                             if (try conf_item.dupeValueDecoded(allocator, log, source)) |x| {
                                 if (gop.value_ptr.token.len > 0) allocator.free(gop.value_ptr.token);
                                 gop.value_ptr.token = x;
+                                // `_authToken` wins over Basic / user+pass halves.
+                                if (gop.value_ptr.auth_b64.len > 0) {
+                                    allocator.free(gop.value_ptr.auth_b64);
+                                    gop.value_ptr.auth_b64 = "";
+                                }
+                                if (gop.value_ptr.username.len > 0) {
+                                    allocator.free(gop.value_ptr.username);
+                                    gop.value_ptr.username = "";
+                                }
+                                if (gop.value_ptr.password.len > 0) {
+                                    allocator.free(gop.value_ptr.password);
+                                    gop.value_ptr.password = "";
+                                }
                             }
                         },
                         ._auth => {
@@ -1268,17 +1295,48 @@ pub fn loadNpmrc(
                             const new_auth = try allocator.dupe(u8, conf_item.value);
                             if (gop.value_ptr.auth_b64.len > 0) allocator.free(gop.value_ptr.auth_b64);
                             gop.value_ptr.auth_b64 = new_auth;
+                            // `_auth` wins over Bearer / user+pass halves.
+                            if (gop.value_ptr.token.len > 0) {
+                                allocator.free(gop.value_ptr.token);
+                                gop.value_ptr.token = "";
+                            }
+                            if (gop.value_ptr.username.len > 0) {
+                                allocator.free(gop.value_ptr.username);
+                                gop.value_ptr.username = "";
+                            }
+                            if (gop.value_ptr.password.len > 0) {
+                                allocator.free(gop.value_ptr.password);
+                                gop.value_ptr.password = "";
+                            }
                         },
                         .username => {
                             if (try conf_item.dupeValueDecoded(allocator, log, source)) |x| {
                                 if (gop.value_ptr.username.len > 0) allocator.free(gop.value_ptr.username);
                                 gop.value_ptr.username = x;
+                                // `username`+`_password` win over Bearer / pre-encoded `_auth`.
+                                if (gop.value_ptr.token.len > 0) {
+                                    allocator.free(gop.value_ptr.token);
+                                    gop.value_ptr.token = "";
+                                }
+                                if (gop.value_ptr.auth_b64.len > 0) {
+                                    allocator.free(gop.value_ptr.auth_b64);
+                                    gop.value_ptr.auth_b64 = "";
+                                }
                             }
                         },
                         ._password => {
                             if (try conf_item.dupeValueDecoded(allocator, log, source)) |x| {
                                 if (gop.value_ptr.password.len > 0) allocator.free(gop.value_ptr.password);
                                 gop.value_ptr.password = x;
+                                // `username`+`_password` win over Bearer / pre-encoded `_auth`.
+                                if (gop.value_ptr.token.len > 0) {
+                                    allocator.free(gop.value_ptr.token);
+                                    gop.value_ptr.token = "";
+                                }
+                                if (gop.value_ptr.auth_b64.len > 0) {
+                                    allocator.free(gop.value_ptr.auth_b64);
+                                    gop.value_ptr.auth_b64 = "";
+                                }
                             }
                         },
                         else => unreachable,

--- a/src/ini/ini.zig
+++ b/src/ini/ini.zig
@@ -1207,7 +1207,13 @@ pub fn loadNpmrc(
         // (token, auth, username, password) and is finalised at the end
         // into `install.auth_configurations`.
         var auth_by_dart = bun.StringHashMap(Registry.AuthConfigurationBuilder).init(allocator);
-        defer auth_by_dart.deinit();
+        defer {
+            // The map stores heap-allocated dart-keys; its own deinit
+            // only frees table storage, so release each key explicitly.
+            var key_it = auth_by_dart.keyIterator();
+            while (key_it.next()) |k| allocator.free(k.*);
+            auth_by_dart.deinit();
+        }
 
         for (configs.items) |conf_item| {
             const conf_item_url = bun.URL.parse(conf_item.registry_url);
@@ -1339,17 +1345,34 @@ pub fn loadNpmrc(
         }
 
         // Serialize the nerf-dart map into a flat slice for the manager.
+        // `loadNpmrcConfig` calls us once per `.npmrc` file with a shared
+        // `configs` accumulator, so on each call `auth_by_dart` is rebuilt
+        // from every entry seen so far. That means the fresh list already
+        // subsumes the previous one — replace (don't append) to avoid
+        // stale duplicates that would let an earlier file shadow a later
+        // override at an identical nerf-dart.
         if (auth_by_dart.count() > 0) {
             const previous = install.auth_configurations;
-            const list = try allocator.alloc(Registry.AuthConfiguration, previous.len + auth_by_dart.count());
-            @memcpy(list[0..previous.len], previous);
+            const list = try allocator.alloc(Registry.AuthConfiguration, auth_by_dart.count());
             var it = auth_by_dart.valueIterator();
-            var i: usize = previous.len;
+            var i: usize = 0;
             while (it.next()) |v| : (i += 1) {
                 list[i] = try v.finalize(allocator);
             }
             install.auth_configurations = list;
-            if (previous.len > 0) allocator.free(previous);
+            // Release the stale slice. The strings inside those stale
+            // entries came from this same allocator; the fresh list
+            // carries its own duplicates (builder.finalize duped them),
+            // so freeing here doesn't dangle any slice in `list`.
+            if (previous.len > 0) {
+                for (previous) |*p| {
+                    if (p.host.len > 0) allocator.free(p.host);
+                    if (p.path.len > 0) allocator.free(p.path);
+                    if (p.token.len > 0) allocator.free(p.token);
+                    if (p.auth.len > 0) allocator.free(p.auth);
+                }
+                allocator.free(previous);
+            }
         }
     }
 }

--- a/src/ini/ini.zig
+++ b/src/ini/ini.zig
@@ -1251,20 +1251,35 @@ pub fn loadNpmrc(
                         allocator.free(key_buf);
                     }
 
+                    // Repeated entries for the same nerf-dart (common when
+                    // `~/.npmrc` and the project `.npmrc` both set the
+                    // same key) replace the previous value; free the
+                    // prior slice so we don't leak across overrides.
                     switch (conf_item.optname) {
                         ._authToken => {
-                            if (try conf_item.dupeValueDecoded(allocator, log, source)) |x| gop.value_ptr.token = x;
+                            if (try conf_item.dupeValueDecoded(allocator, log, source)) |x| {
+                                if (gop.value_ptr.token.len > 0) allocator.free(gop.value_ptr.token);
+                                gop.value_ptr.token = x;
+                            }
                         },
                         ._auth => {
                             // Keep `_auth` base64-encoded — that's what the
                             // HTTP client wants for Basic auth headers.
-                            gop.value_ptr.auth_b64 = try allocator.dupe(u8, conf_item.value);
+                            const new_auth = try allocator.dupe(u8, conf_item.value);
+                            if (gop.value_ptr.auth_b64.len > 0) allocator.free(gop.value_ptr.auth_b64);
+                            gop.value_ptr.auth_b64 = new_auth;
                         },
                         .username => {
-                            if (try conf_item.dupeValueDecoded(allocator, log, source)) |x| gop.value_ptr.username = x;
+                            if (try conf_item.dupeValueDecoded(allocator, log, source)) |x| {
+                                if (gop.value_ptr.username.len > 0) allocator.free(gop.value_ptr.username);
+                                gop.value_ptr.username = x;
+                            }
                         },
                         ._password => {
-                            if (try conf_item.dupeValueDecoded(allocator, log, source)) |x| gop.value_ptr.password = x;
+                            if (try conf_item.dupeValueDecoded(allocator, log, source)) |x| {
+                                if (gop.value_ptr.password.len > 0) allocator.free(gop.value_ptr.password);
+                                gop.value_ptr.password = x;
+                            }
                         },
                         else => unreachable,
                     }

--- a/src/ini/ini.zig
+++ b/src/ini/ini.zig
@@ -1199,8 +1199,72 @@ pub fn loadNpmrc(
             }
         }
 
+        // Global nerf-dart map: key = "host[\x00][/path]" (normalized, no
+        // trailing slash). Used at request time so a token scoped to
+        // `/api/v4/projects/568/packages/npm/` authenticates tarball URLs
+        // under that path even when the scoped registry's URL lives at a
+        // different path. Each value accumulates the halves of the entry
+        // (token, auth, username, password) and is finalised at the end
+        // into `install.auth_configurations`.
+        var auth_by_dart = bun.StringHashMap(Registry.AuthConfigurationBuilder).init(allocator);
+        defer auth_by_dart.deinit();
+
         for (configs.items) |conf_item| {
             const conf_item_url = bun.URL.parse(conf_item.registry_url);
+
+            // Record credential-bearing entries on the global nerf-dart map
+            // so the manager can do request-time longest-prefix lookup.
+            // The per-scope loop below still does its pathname-equality
+            // attachment for backward compat with consumers that read
+            // scope.token / scope.auth directly. Email / cert / key options
+            // aren't credentials, so they don't contribute darts.
+            switch (conf_item.optname) {
+                ._authToken, ._auth, .username, ._password => {
+                    const dart_host = bun.strings.withoutTrailingSlash(conf_item_url.host);
+                    const dart_path = bun.strings.withoutTrailingSlash(conf_item_url.pathname);
+                    // Normalize an empty/root path to "" so hash lookups are stable.
+                    const dart_path_norm = if (dart_path.len == 0 or std.mem.eql(u8, dart_path, "/"))
+                        ""
+                    else
+                        dart_path;
+                    // Host+path concatenated is the nerf-dart key. Using
+                    // "\x00" as a separator keeps it unambiguous without
+                    // extra state.
+                    const key_buf = try allocator.alloc(u8, dart_host.len + 1 + dart_path_norm.len);
+                    @memcpy(key_buf[0..dart_host.len], dart_host);
+                    key_buf[dart_host.len] = 0;
+                    @memcpy(key_buf[dart_host.len + 1 ..], dart_path_norm);
+
+                    const gop = try auth_by_dart.getOrPut(key_buf);
+                    if (!gop.found_existing) {
+                        gop.value_ptr.* = .{
+                            .host = try allocator.dupe(u8, dart_host),
+                            .path = try allocator.dupe(u8, dart_path_norm),
+                        };
+                    } else {
+                        allocator.free(key_buf);
+                    }
+
+                    switch (conf_item.optname) {
+                        ._authToken => {
+                            if (try conf_item.dupeValueDecoded(allocator, log, source)) |x| gop.value_ptr.token = x;
+                        },
+                        ._auth => {
+                            // Keep `_auth` base64-encoded — that's what the
+                            // HTTP client wants for Basic auth headers.
+                            gop.value_ptr.auth_b64 = try allocator.dupe(u8, conf_item.value);
+                        },
+                        .username => {
+                            if (try conf_item.dupeValueDecoded(allocator, log, source)) |x| gop.value_ptr.username = x;
+                        },
+                        ._password => {
+                            if (try conf_item.dupeValueDecoded(allocator, log, source)) |x| gop.value_ptr.password = x;
+                        },
+                        else => unreachable,
+                    }
+                },
+                .email, .certfile, .keyfile => {},
+            }
 
             if (std.mem.eql(u8, bun.strings.withoutTrailingSlash(default_registry_url.host), bun.strings.withoutTrailingSlash(conf_item_url.host)) and
                 std.mem.eql(u8, bun.strings.withoutTrailingSlash(default_registry_url.pathname), bun.strings.withoutTrailingSlash(conf_item_url.pathname)))
@@ -1272,6 +1336,20 @@ pub fn loadNpmrc(
                     continue;
                 }
             }
+        }
+
+        // Serialize the nerf-dart map into a flat slice for the manager.
+        if (auth_by_dart.count() > 0) {
+            const previous = install.auth_configurations;
+            const list = try allocator.alloc(Registry.AuthConfiguration, previous.len + auth_by_dart.count());
+            @memcpy(list[0..previous.len], previous);
+            var it = auth_by_dart.valueIterator();
+            var i: usize = previous.len;
+            while (it.next()) |v| : (i += 1) {
+                list[i] = try v.finalize(allocator);
+            }
+            install.auth_configurations = list;
+            if (previous.len > 0) allocator.free(previous);
         }
     }
 }

--- a/src/install/NetworkTask.zig
+++ b/src/install/NetworkTask.zig
@@ -177,14 +177,25 @@ fn scopePathLen(scope: *const Npm.Registry.Scope) usize {
 
 fn resolveAuth(pm: *const PackageManager, scope: *const Npm.Registry.Scope, url_str: string) AuthForRequest {
     if (pm.matchAuthForUrl(url_str)) |match| {
-        // Prefer the nerf-dart match when it's strictly more specific than
-        // the scope's path, OR when the scope has no pre-resolved
-        // credentials (the scope-population loop in `loadNpmrc` only
-        // attaches on exact path equality, so a parent-path nerf-dart
-        // that covers the scope URL never lands on the scope itself).
-        // This matches npm's request-time lookup.
+        // Prefer the nerf-dart match when:
+        //   - the request's host differs from the scope's host (the
+        //     scope's credentials belong to a different host and
+        //     must never leak cross-host — common when metadata and
+        //     tarballs are served from different domains, e.g. a
+        //     separate CDN for tarball downloads), or
+        //   - the nerf-dart path is strictly more specific than the
+        //     scope's own path (npm's longest-prefix rule), or
+        //   - the scope has no pre-resolved credentials (a parent-
+        //     path nerf-dart covering the scope URL never lands on
+        //     the scope itself via the legacy per-scope loop).
+        const req_url = URL.parse(url_str);
+        const req_host = strings.withoutTrailingSlash(req_url.host);
+        const scope_host = strings.withoutTrailingSlash(scope.url.host);
+        // Hostnames are case-insensitive per DNS.
+        const same_host = req_host.len == scope_host.len and
+            (req_host.len == 0 or strings.eqlCaseInsensitiveASCIIICheckLength(req_host, scope_host));
         const has_scope_creds = scope.token.len > 0 or scope.auth.len > 0;
-        if (match.path_len > scopePathLen(scope) or !has_scope_creds) {
+        if (!same_host or match.path_len > scopePathLen(scope) or !has_scope_creds) {
             return .{ .token = match.token, .auth = match.auth };
         }
     }

--- a/src/install/NetworkTask.zig
+++ b/src/install/NetworkTask.zig
@@ -158,24 +158,57 @@ const accept_header_value_extended = "application/json, */*";
 const default_headers_buf: string = "Accept" ++ accept_header_value;
 const extended_headers_buf: string = "Accept" ++ accept_header_value_extended;
 
-fn appendAuth(header_builder: *HeaderBuilder, scope: *const Npm.Registry.Scope) void {
-    if (scope.token.len > 0) {
-        header_builder.appendFmt("Authorization", "Bearer {s}", .{scope.token});
-    } else if (scope.auth.len > 0) {
-        header_builder.appendFmt("Authorization", "Basic {s}", .{scope.auth});
+/// Credentials selected for a single outgoing request. `resolveAuth` picks
+/// them by matching the request URL against the `.npmrc` nerf darts first
+/// (longest-prefix wins), falling back to the scope's pre-resolved
+/// `token`/`auth` when no nerf dart matches the request URL more
+/// specifically.
+const AuthForRequest = struct {
+    token: string = "",
+    auth: string = "",
+};
+
+/// Length of the scope URL's pathname (without trailing slash). Used to
+/// decide whether a nerf-dart match on the request URL beats the scope's
+/// own path.
+fn scopePathLen(scope: *const Npm.Registry.Scope) usize {
+    return strings.withoutTrailingSlash(scope.url.pathname).len;
+}
+
+fn resolveAuth(pm: *const PackageManager, scope: *const Npm.Registry.Scope, url_str: string) AuthForRequest {
+    if (pm.matchAuthForUrl(url_str)) |match| {
+        // Prefer the nerf-dart match when it's strictly more specific than
+        // the scope's path, OR when the scope has no pre-resolved
+        // credentials (the scope-population loop in `loadNpmrc` only
+        // attaches on exact path equality, so a parent-path nerf-dart
+        // that covers the scope URL never lands on the scope itself).
+        // This matches npm's request-time lookup.
+        const has_scope_creds = scope.token.len > 0 or scope.auth.len > 0;
+        if (match.path_len > scopePathLen(scope) or !has_scope_creds) {
+            return .{ .token = match.token, .auth = match.auth };
+        }
+    }
+    return .{ .token = scope.token, .auth = scope.auth };
+}
+
+fn appendAuth(header_builder: *HeaderBuilder, creds: AuthForRequest) void {
+    if (creds.token.len > 0) {
+        header_builder.appendFmt("Authorization", "Bearer {s}", .{creds.token});
+    } else if (creds.auth.len > 0) {
+        header_builder.appendFmt("Authorization", "Basic {s}", .{creds.auth});
     } else {
         return;
     }
     header_builder.append("npm-auth-type", "legacy");
 }
 
-fn countAuth(header_builder: *HeaderBuilder, scope: *const Npm.Registry.Scope) void {
-    if (scope.token.len > 0) {
+fn countAuth(header_builder: *HeaderBuilder, creds: AuthForRequest) void {
+    if (creds.token.len > 0) {
         header_builder.count("Authorization", "");
-        header_builder.content.cap += "Bearer ".len + scope.token.len;
-    } else if (scope.auth.len > 0) {
+        header_builder.content.cap += "Bearer ".len + creds.token.len;
+    } else if (creds.auth.len > 0) {
         header_builder.count("Authorization", "");
-        header_builder.content.cap += "Basic ".len + scope.auth.len;
+        header_builder.content.cap += "Basic ".len + creds.auth.len;
     } else {
         return;
     }
@@ -272,7 +305,8 @@ pub fn forManifest(
 
     var header_builder = HeaderBuilder{};
 
-    countAuth(&header_builder, scope);
+    const manifest_creds = resolveAuth(this.package_manager, scope, this.url_buf);
+    countAuth(&header_builder, manifest_creds);
 
     if (etag.len != 0) {
         header_builder.count("If-None-Match", etag);
@@ -290,7 +324,7 @@ pub fn forManifest(
         }
         try header_builder.allocate(allocator);
 
-        appendAuth(&header_builder, scope);
+        appendAuth(&header_builder, manifest_creds);
 
         if (etag.len != 0) {
             header_builder.append("If-None-Match", etag);
@@ -398,15 +432,16 @@ pub fn forTarball(
     var header_builder = HeaderBuilder{};
     var header_buf: string = "";
 
+    const tarball_creds = resolveAuth(this.package_manager, scope, this.url_buf);
     if (authorization == .allow_authorization) {
-        countAuth(&header_builder, scope);
+        countAuth(&header_builder, tarball_creds);
     }
 
     if (header_builder.header_count > 0) {
         try header_builder.allocate(allocator);
 
         if (authorization == .allow_authorization) {
-            appendAuth(&header_builder, scope);
+            appendAuth(&header_builder, tarball_creds);
         }
 
         header_buf = header_builder.content.ptr.?[0..header_builder.content.len];

--- a/src/install/PackageManager.zig
+++ b/src/install/PackageManager.zig
@@ -1222,6 +1222,7 @@ pub const formatLaterVersionInCache = resolution.formatLaterVersionInCache;
 pub const getInstalledVersionsFromDiskCache = resolution.getInstalledVersionsFromDiskCache;
 pub const resolveFromDiskCache = resolution.resolveFromDiskCache;
 pub const scopeForPackageName = resolution.scopeForPackageName;
+pub const matchAuthForUrl = resolution.matchAuthForUrl;
 pub const verifyResolutions = resolution.verifyResolutions;
 
 pub const progress_zig = @import("./PackageManager/ProgressStrings.zig");

--- a/src/install/PackageManager/PackageManagerOptions.zig
+++ b/src/install/PackageManager/PackageManagerOptions.zig
@@ -13,6 +13,13 @@ did_override_default_scope: bool = false,
 scope: Npm.Registry.Scope = undefined,
 
 registries: Npm.Registry.Map = .{},
+
+/// All `.npmrc` auth entries, preserved for request-time longest-prefix
+/// matching. A tarball URL returned in a metadata response may live at a
+/// different path than the scoped registry URL (common pattern on
+/// self-hosted GitLab); we match those URLs against these nerf darts and
+/// fall back to the scope's pre-resolved token when nothing matches.
+auth_configurations: []const Npm.Registry.AuthConfiguration = &.{},
 cache_directory: string = "",
 enable: Enable = .{},
 do: Do = .{},
@@ -256,6 +263,10 @@ pub fn load(
                 if (registry.url.len == 0) registry.url = base.url;
                 try this.registries.put(allocator, Npm.Registry.Scope.hash(name), try Npm.Registry.Scope.fromAPI(name, registry, allocator, env));
             }
+        }
+
+        if (config.auth_configurations.len > 0) {
+            this.auth_configurations = config.auth_configurations;
         }
 
         if (config.ca) |ca| {

--- a/src/install/PackageManager/PackageManagerResolution.zig
+++ b/src/install/PackageManager/PackageManagerResolution.zig
@@ -60,27 +60,23 @@ pub fn matchAuthForUrl(this: *const PackageManager, url_str: string) ?Npm.Regist
 
     var best: ?*const Npm.Registry.AuthConfiguration = null;
     var best_path_len: usize = 0;
-    var best_has_creds = false;
 
     for (this.options.auth_configurations) |*entry| {
+        // Ignore entries that carry no usable credentials (e.g. a
+        // `username` without the matching `_password` half). An empty
+        // entry at a deeper path must not shadow a credentialed match
+        // at a shorter path — npm's rule is "longest nerf-dart with
+        // credentials wins".
+        if (entry.token.len == 0 and entry.auth.len == 0) continue;
         if (!entry.matches(req_host, req_path)) continue;
-        const has_creds = entry.token.len > 0 or entry.auth.len > 0;
 
-        // Longer path wins; on a tie, prefer the one with credentials so an
-        // `email`-only entry at a longer path doesn't shadow a token/auth
-        // at the same or shorter path.
-        if (best == null or
-            entry.path.len > best_path_len or
-            (entry.path.len == best_path_len and has_creds and !best_has_creds))
-        {
+        if (best == null or entry.path.len > best_path_len) {
             best = entry;
             best_path_len = entry.path.len;
-            best_has_creds = has_creds;
         }
     }
 
     if (best) |entry| {
-        if (entry.token.len == 0 and entry.auth.len == 0) return null;
         return .{
             .token = entry.token,
             .auth = entry.auth,

--- a/src/install/PackageManager/PackageManagerResolution.zig
+++ b/src/install/PackageManager/PackageManagerResolution.zig
@@ -42,6 +42,54 @@ pub fn scopeForPackageName(this: *const PackageManager, name: string) *const Npm
     ) orelse &this.options.scope;
 }
 
+/// Find the `.npmrc` auth entry whose nerf-dart (`//host[/path]/`) is the
+/// longest path-segment prefix of `url_str`. Returns `null` when no entry
+/// matches the URL's host — callers fall back to the scope's pre-resolved
+/// credentials in that case. Matches npm's request-time lookup so that a
+/// token scoped to `/api/v4/projects/568/packages/npm/` authenticates
+/// tarball URLs under that path even when the scoped-registry URL lives at
+/// a different path (e.g. `/api/v4/packages/npm/`).
+pub fn matchAuthForUrl(this: *const PackageManager, url_str: string) ?Npm.Registry.AuthConfiguration.Match {
+    if (this.options.auth_configurations.len == 0) return null;
+
+    const url = URL.parse(url_str);
+    if (url.host.len == 0) return null;
+
+    const req_host = bun.strings.withoutTrailingSlash(url.host);
+    const req_path = bun.strings.withoutTrailingSlash(url.pathname);
+
+    var best: ?*const Npm.Registry.AuthConfiguration = null;
+    var best_path_len: usize = 0;
+    var best_has_creds = false;
+
+    for (this.options.auth_configurations) |*entry| {
+        if (!entry.matches(req_host, req_path)) continue;
+        const has_creds = entry.token.len > 0 or entry.auth.len > 0;
+
+        // Longer path wins; on a tie, prefer the one with credentials so an
+        // `email`-only entry at a longer path doesn't shadow a token/auth
+        // at the same or shorter path.
+        if (best == null or
+            entry.path.len > best_path_len or
+            (entry.path.len == best_path_len and has_creds and !best_has_creds))
+        {
+            best = entry;
+            best_path_len = entry.path.len;
+            best_has_creds = has_creds;
+        }
+    }
+
+    if (best) |entry| {
+        if (entry.token.len == 0 and entry.auth.len == 0) return null;
+        return .{
+            .token = entry.token,
+            .auth = entry.auth,
+            .path_len = entry.path.len,
+        };
+    }
+    return null;
+}
+
 pub fn getInstalledVersionsFromDiskCache(this: *PackageManager, tags_buf: *std.array_list.Managed(u8), package_name: []const u8, allocator: std.mem.Allocator) !std.array_list.Managed(Semver.Version) {
     var list = std.array_list.Managed(Semver.Version).init(allocator);
     var dir = this.getCacheDirectory().openDir(package_name, .{
@@ -225,6 +273,7 @@ const bun = @import("bun");
 const Environment = bun.Environment;
 const OOM = bun.OOM;
 const Output = bun.Output;
+const URL = bun.URL;
 const strings = bun.strings;
 
 const Semver = bun.Semver;

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -377,6 +377,79 @@ pub const Registry = struct {
 
     pub const Map = std.HashMapUnmanaged(u64, Scope, IdentityContext(u64), 80);
 
+    /// A single `.npmrc` auth entry (`//host[/path]/:_authToken=…` etc.),
+    /// kept so the manager can do npm-style longest-prefix lookup at request
+    /// time. The registry scope's pre-resolved `token`/`auth` is still used
+    /// as a fallback, but when a request URL (e.g. a tarball URL that lives
+    /// at a different path than the scoped registry) matches one of these
+    /// nerf darts more specifically, these credentials win.
+    pub const AuthConfiguration = struct {
+        /// `host[:port]` without any trailing slash, lower-cased by the url parser.
+        host: string = "",
+        /// Path prefix without trailing slash. Empty means "covers the whole host".
+        path: string = "",
+        /// Bearer token (`_authToken`), empty if unset.
+        token: string = "",
+        /// `base64("user:pass")`, empty if unset. Populated from `_auth` or
+        /// from `username` + `_password`.
+        auth: string = "",
+
+        pub const Match = struct {
+            token: string = "",
+            auth: string = "",
+            /// Length of the matched path; callers compare this against the
+            /// scope's path length to decide whether the nerf-dart match is
+            /// more specific than whatever produced the scope's own token.
+            path_len: usize = 0,
+        };
+
+        /// Check whether the request URL (host + path) is covered by this
+        /// nerf dart. Matching is npm-compatible: exact, or the nerf dart's
+        /// path is a path-segment prefix of the request path. The empty path
+        /// covers the entire host.
+        pub fn matches(self: *const AuthConfiguration, req_host: string, req_path: string) bool {
+            if (!strings.eql(self.host, req_host)) return false;
+            if (self.path.len == 0) return true;
+            if (self.path.len > req_path.len) return false;
+            if (strings.eql(self.path, req_path)) return true;
+            if (!strings.startsWith(req_path, self.path)) return false;
+            // Segment boundary: avoid `/api/v4` matching `/api/v41`.
+            return req_path[self.path.len] == '/';
+        }
+    };
+
+    /// Transient accumulator used by `loadNpmrc` while building the nerf-dart
+    /// map. Holds the raw `username` / `_password` halves so we can combine
+    /// them into `base64("user:pass")` after every entry has been seen.
+    pub const AuthConfigurationBuilder = struct {
+        host: string = "",
+        path: string = "",
+        token: string = "",
+        auth_b64: string = "",
+        username: string = "",
+        password: string = "",
+
+        pub fn finalize(self: *AuthConfigurationBuilder, allocator: std.mem.Allocator) !AuthConfiguration {
+            var auth = self.auth_b64;
+            if (auth.len == 0 and self.username.len > 0 and self.password.len > 0) {
+                const raw = try allocator.alloc(u8, self.username.len + 1 + self.password.len);
+                defer allocator.free(raw);
+                @memcpy(raw[0..self.username.len], self.username);
+                raw[self.username.len] = ':';
+                @memcpy(raw[self.username.len + 1 ..], self.password);
+
+                const b64 = try allocator.alloc(u8, std.base64.standard.Encoder.calcSize(raw.len));
+                auth = std.base64.standard.Encoder.encode(b64, raw);
+            }
+            return .{
+                .host = self.host,
+                .path = self.path,
+                .token = self.token,
+                .auth = auth,
+            };
+        }
+    };
+
     const PackageVersionResponse = union(Tag) {
         pub const Tag = enum {
             cached,

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -430,6 +430,15 @@ pub const Registry = struct {
         password: string = "",
 
         pub fn finalize(self: *AuthConfigurationBuilder, allocator: std.mem.Allocator) !AuthConfiguration {
+            // `username`/`_password` halves aren't carried onto the final
+            // entry: we either combine them into a base64 `auth` now, or
+            // drop them. Either way they're this call's temp storage, so
+            // free them here — the builder itself is discarded shortly.
+            defer {
+                if (self.username.len > 0) allocator.free(self.username);
+                if (self.password.len > 0) allocator.free(self.password);
+            }
+
             var auth = self.auth_b64;
             if (auth.len == 0 and self.username.len > 0 and self.password.len > 0) {
                 const raw = try allocator.alloc(u8, self.username.len + 1 + self.password.len);

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -384,9 +384,15 @@ pub const Registry = struct {
     /// at a different path than the scoped registry) matches one of these
     /// nerf darts more specifically, these credentials win.
     pub const AuthConfiguration = struct {
-        /// `host[:port]` without any trailing slash, lower-cased by the url parser.
+        /// `host[:port]` without any trailing slash, as written in `.npmrc`.
+        /// Compared case-insensitively against the request URL's host in
+        /// `matches()` — hostnames are case-insensitive per DNS, and
+        /// `bun.URL.parse` preserves the source casing, so a `.npmrc` with
+        /// `//Git.Example.com/` still matches a request to `git.example.com`.
         host: string = "",
         /// Path prefix without trailing slash. Empty means "covers the whole host".
+        /// Paths are compared case-sensitively (HTTP paths are case-sensitive
+        /// per RFC 3986).
         path: string = "",
         /// Bearer token (`_authToken`), empty if unset.
         token: string = "",
@@ -408,7 +414,8 @@ pub const Registry = struct {
         /// path is a path-segment prefix of the request path. The empty path
         /// covers the entire host.
         pub fn matches(self: *const AuthConfiguration, req_host: string, req_path: string) bool {
-            if (!strings.eql(self.host, req_host)) return false;
+            if (self.host.len != req_host.len) return false;
+            if (self.host.len > 0 and !strings.eqlCaseInsensitiveASCIIICheckLength(self.host, req_host)) return false;
             if (self.path.len == 0) return true;
             if (self.path.len > req_path.len) return false;
             if (strings.eql(self.path, req_path)) return true;

--- a/src/options_types/schema.zig
+++ b/src/options_types/schema.zig
@@ -2977,6 +2977,13 @@ pub const api = struct {
         /// scoped
         scoped: ?NpmRegistryMap = null,
 
+        /// All `_authToken` / `_auth` / `username` / `_password` entries
+        /// parsed from `.npmrc`, keyed by their nerf-dart (`//host[/path]/`).
+        /// Used by the package manager to authenticate requests whose URL
+        /// (e.g. a tarball URL from a metadata response) lives at a different
+        /// path than the scoped registry URL. See `Npm.Registry.AuthConfiguration`.
+        auth_configurations: []bun.install.Npm.Registry.AuthConfiguration = &.{},
+
         /// lockfile_path
         lockfile_path: ?[]const u8 = null,
 

--- a/test/regression/issue/30513.test.ts
+++ b/test/regression/issue/30513.test.ts
@@ -1,0 +1,241 @@
+// Regression test for https://github.com/oven-sh/bun/issues/30513.
+//
+// The scoped-registry URL and the `_authToken` live at different paths on
+// the same host — a common GitLab consumer pattern where packages are
+// *published* per-project but *consumed* through the instance-wide
+// endpoint. The tarball URL returned in metadata is under the token's
+// path (`/api/v4/projects/568/...`) but the registry URL is not
+// (`/api/v4/packages/npm/...`). bun ≤ 1.3.10 sent the token because it
+// only compared hostnames; 1.3.11 started comparing host *and* path
+// exactly and stopped sending the token, so the tarball fetch 404s.
+//
+// Fix: match the request URL against every `_authToken` nerf dart at
+// request time (longest-prefix wins), matching npm's behaviour.
+
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
+
+type TarballHit = { url: string; authorization: string | null };
+
+const TOKEN = "GLPAT-EXAMPLE-TOKEN-xyz";
+const PKG_NAME = "@altpay/web-ui-kit";
+const PKG_VERSION = "0.3.6";
+// Matches GitLab: metadata lives at the instance-level path, but the
+// tarball URL inside the metadata resolves to a project-level path.
+const METADATA_PATH = "/api/v4/packages/npm";
+const TARBALL_PATH = "/api/v4/projects/568/packages/npm";
+
+// A minimal gzipped tarball containing just a `package.json`. Generated
+// once at module load and reused across tests so each test is stable.
+function makeTarball(): Buffer {
+  // Build a `package/package.json` tar entry (512 bytes header + 512-byte
+  // aligned body), then two 512-byte zero blocks as the end-of-archive
+  // marker, then gzip the whole thing with Bun.gzipSync.
+  const body = Buffer.from(JSON.stringify({ name: PKG_NAME, version: PKG_VERSION }));
+  const bodyBlockSize = Math.ceil(body.length / 512) * 512;
+  const bodyBlock = Buffer.alloc(bodyBlockSize);
+  body.copy(bodyBlock);
+
+  const header = Buffer.alloc(512);
+  header.write("package/package.json", 0, "ascii"); // name
+  header.write("0000644 ", 100, "ascii"); // mode
+  header.write("0000000 ", 108, "ascii"); // uid
+  header.write("0000000 ", 116, "ascii"); // gid
+  header.write(body.length.toString(8).padStart(11, "0") + " ", 124, "ascii"); // size
+  header.write("00000000000 ", 136, "ascii"); // mtime
+  header.write("        ", 148, "ascii"); // placeholder for checksum while computing
+  header.write("0", 156, "ascii"); // typeflag (regular file)
+  header.write("ustar\x0000", 257, "binary"); // magic + version
+  // Compute checksum over the header with spaces in the checksum slot.
+  let sum = 0;
+  for (const byte of header) sum += byte;
+  header.write(sum.toString(8).padStart(6, "0") + "\x00 ", 148, "ascii");
+
+  const trailer = Buffer.alloc(1024);
+  const tar = Buffer.concat([header, bodyBlock, trailer]);
+  return Buffer.from(Bun.gzipSync(tar));
+}
+const TARBALL = makeTarball();
+
+const tarballHits: TarballHit[] = [];
+let server: ReturnType<typeof Bun.serve>;
+
+beforeAll(() => {
+  server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const path = decodeURIComponent(url.pathname);
+
+      // Metadata: instance-level endpoint. For this regression we only
+      // care about auth on the tarball request, so the metadata endpoint
+      // happily serves the response whether or not auth was sent.
+      if (path === `${METADATA_PATH}/${PKG_NAME}`) {
+        const manifest = {
+          name: PKG_NAME,
+          "dist-tags": { latest: PKG_VERSION },
+          versions: {
+            [PKG_VERSION]: {
+              name: PKG_NAME,
+              version: PKG_VERSION,
+              dist: {
+                tarball: `http://${url.host}${TARBALL_PATH}/${PKG_NAME}/-/${PKG_NAME}-${PKG_VERSION}.tgz`,
+                shasum: Bun.SHA1.hash(TARBALL, "hex"),
+              },
+            },
+          },
+        };
+        return Response.json(manifest);
+      }
+
+      // Tarball: project-level endpoint. We record what auth header the
+      // client sent so the assertions below can verify that the token
+      // keyed to this path actually travelled on the request.
+      if (path === `${TARBALL_PATH}/${PKG_NAME}/-/${PKG_NAME}-${PKG_VERSION}.tgz`) {
+        tarballHits.push({
+          url: req.url,
+          authorization: req.headers.get("authorization"),
+        });
+        // Mirror GitLab: 404 on unauthenticated package-registry
+        // requests. With the fix, the token reaches us and we hand
+        // back the tarball.
+        if (req.headers.get("authorization") !== `Bearer ${TOKEN}`) {
+          return new Response("not found", { status: 404 });
+        }
+        return new Response(TARBALL, {
+          headers: { "content-type": "application/octet-stream" },
+        });
+      }
+
+      return new Response("unexpected path: " + path, { status: 500 });
+    },
+  });
+});
+
+afterAll(() => {
+  server?.stop(true);
+});
+
+test("auth token applies to tarball URL when token path diverges from registry URL path", async () => {
+  tarballHits.length = 0;
+  const origin = `http://${server.hostname}:${server.port}`;
+  using dir = tempDir("issue-30513", {
+    "package.json": JSON.stringify({
+      name: "issue-30513-consumer",
+      version: "0.0.0",
+      dependencies: { [PKG_NAME]: PKG_VERSION },
+    }),
+    // The two `.npmrc` paths deliberately diverge:
+    //  - scoped-registry path: /api/v4/packages/npm/
+    //  - _authToken nerf-dart: /api/v4/projects/568/packages/npm/
+    // Neither is a prefix of the other. The tarball URL from the
+    // metadata response *is* under the auth nerf-dart; 1.3.11+ stopped
+    // sending the token on that request. With the fix, the longest-
+    // prefix match of the tarball URL picks up the token.
+    ".npmrc": [
+      `@altpay:registry=${origin}${METADATA_PATH}/`,
+      `//${server.hostname}:${server.port}${TARBALL_PATH}/:_authToken=${TOKEN}`,
+      `always-auth=true`,
+    ].join("\n"),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: tmpdirSync() },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const tarballAuthHeaders = tarballHits.map(h => h.authorization);
+  expect({ exitCode, stderr, stdout, tarballAuthHeaders }).toEqual({
+    exitCode: 0,
+    stderr: expect.stringMatching(/./), // bun always writes progress to stderr
+    stdout: expect.stringContaining(PKG_NAME),
+    tarballAuthHeaders: [`Bearer ${TOKEN}`],
+  });
+});
+
+test("parent-path nerf-dart covers deeper scoped-registry URL (related: #28233)", async () => {
+  // The token is scoped to the root of the host; the scoped registry
+  // lives under `/api/v4/packages/npm/`. npm's longest-prefix rule
+  // means the root token must authenticate requests to that scoped
+  // registry. Covering this with the same code path that fixes #30513
+  // confirms the request-time lookup handles both directions — parent
+  // of (this case) and divergent (the primary test above) — uniformly.
+  tarballHits.length = 0;
+  const origin = `http://${server.hostname}:${server.port}`;
+  using dir = tempDir("issue-30513-parent", {
+    "package.json": JSON.stringify({
+      name: "issue-30513-parent-consumer",
+      version: "0.0.0",
+      dependencies: { [PKG_NAME]: PKG_VERSION },
+    }),
+    ".npmrc": [
+      `@altpay:registry=${origin}${METADATA_PATH}/`,
+      // Token keyed to the bare host — parent of both paths used by
+      // the mock server. With just the pre-1.3.11 host-only check this
+      // worked; with exact-path matching it stopped working; with
+      // request-time longest-prefix it works again.
+      `//${server.hostname}:${server.port}/:_authToken=${TOKEN}`,
+      `always-auth=true`,
+    ].join("\n"),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: tmpdirSync() },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  void stdout;
+  void stderr;
+
+  expect({ exitCode, tarballAuthHeaders: tarballHits.map(h => h.authorization) }).toEqual({
+    exitCode: 0,
+    tarballAuthHeaders: [`Bearer ${TOKEN}`],
+  });
+});
+
+test("longest nerf-dart wins when multiple entries could match the request URL", async () => {
+  // Sanity: a broader root-path token must lose to a deeper project-
+  // level token on the same host, so the "most specific wins" rule from
+  // npm is observed at request time.
+  tarballHits.length = 0;
+  const origin = `http://${server.hostname}:${server.port}`;
+  using dir = tempDir("issue-30513-longest", {
+    "package.json": JSON.stringify({
+      name: "issue-30513-longest-consumer",
+      version: "0.0.0",
+      dependencies: { [PKG_NAME]: PKG_VERSION },
+    }),
+    ".npmrc": [
+      `@altpay:registry=${origin}${METADATA_PATH}/`,
+      // Root-host token: wrong value, should be ignored for the tarball
+      // because a more specific nerf-dart below matches the tarball URL.
+      `//${server.hostname}:${server.port}/:_authToken=wrong-root-token`,
+      // Project-level token: the correct one.
+      `//${server.hostname}:${server.port}${TARBALL_PATH}/:_authToken=${TOKEN}`,
+      `always-auth=true`,
+    ].join("\n"),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: tmpdirSync() },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  void stdout;
+  void stderr;
+
+  expect({ exitCode, tarballAuthHeaders: tarballHits.map(h => h.authorization) }).toEqual({
+    exitCode: 0,
+    tarballAuthHeaders: [`Bearer ${TOKEN}`],
+  });
+});

--- a/test/regression/issue/30513.test.ts
+++ b/test/regression/issue/30513.test.ts
@@ -222,9 +222,7 @@ test("project .npmrc overrides home .npmrc for the same nerf-dart", async () => 
   using homeDir = tempDir("issue-30513-home", {
     // Home .npmrc: a *wrong* token keyed to the same nerf-dart the
     // project uses. If bun picks this one the tarball will 404.
-    ".npmrc": [
-      `//${server.hostname}:${server.port}${TARBALL_PATH}/:_authToken=home-wrong-token`,
-    ].join("\n"),
+    ".npmrc": [`//${server.hostname}:${server.port}${TARBALL_PATH}/:_authToken=home-wrong-token`].join("\n"),
   });
   const origin = `http://${server.hostname}:${server.port}`;
   using dir = tempDir("issue-30513-layered", {
@@ -254,7 +252,11 @@ test("project .npmrc overrides home .npmrc for the same nerf-dart", async () => 
   });
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-  expect({ exitCode, hasError: stderr.includes("error:"), tarballAuthHeaders: tarballHits.map(h => h.authorization) }).toEqual({
+  expect({
+    exitCode,
+    hasError: stderr.includes("error:"),
+    tarballAuthHeaders: tarballHits.map(h => h.authorization),
+  }).toEqual({
     exitCode: 0,
     hasError: false,
     tarballAuthHeaders: [`Bearer ${TOKEN}`],
@@ -292,7 +294,11 @@ test("auth token matches case-insensitively on hostname", async () => {
   });
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-  expect({ exitCode, hasError: stderr.includes("error:"), tarballAuthHeaders: tarballHits.map(h => h.authorization) }).toEqual({
+  expect({
+    exitCode,
+    hasError: stderr.includes("error:"),
+    tarballAuthHeaders: tarballHits.map(h => h.authorization),
+  }).toEqual({
     exitCode: 0,
     hasError: false,
     tarballAuthHeaders: [`Bearer ${TOKEN}`],

--- a/test/regression/issue/30513.test.ts
+++ b/test/regression/issue/30513.test.ts
@@ -210,6 +210,95 @@ test("parent-path nerf-dart covers deeper scoped-registry URL (related: #28233)"
   });
 });
 
+test("project .npmrc overrides home .npmrc for the same nerf-dart", async () => {
+  // npm's layered-config precedence: project .npmrc must win over
+  // ~/.npmrc at the same nerf-dart. When both files are loaded, the
+  // pre-fix code appended each rebuild onto the previous slice, so the
+  // home entry stayed at index 0 and was picked by the first-match
+  // tie-break — sending the wrong token. The fix replaces the slice
+  // on each load, so the project's override correctly wins.
+  tarballHits.length = 0;
+  using cacheDir = tempDir("issue-30513-layered-cache", {});
+  using homeDir = tempDir("issue-30513-home", {
+    // Home .npmrc: a *wrong* token keyed to the same nerf-dart the
+    // project uses. If bun picks this one the tarball will 404.
+    ".npmrc": [
+      `//${server.hostname}:${server.port}${TARBALL_PATH}/:_authToken=home-wrong-token`,
+    ].join("\n"),
+  });
+  const origin = `http://${server.hostname}:${server.port}`;
+  using dir = tempDir("issue-30513-layered", {
+    "package.json": JSON.stringify({
+      name: "issue-30513-layered-consumer",
+      version: "0.0.0",
+      dependencies: { [PKG_NAME]: PKG_VERSION },
+    }),
+    ".npmrc": [
+      `@altpay:registry=${origin}${METADATA_PATH}/`,
+      `//${server.hostname}:${server.port}${TARBALL_PATH}/:_authToken=${TOKEN}`,
+      `always-auth=true`,
+    ].join("\n"),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      BUN_INSTALL_CACHE_DIR: String(cacheDir),
+      XDG_CONFIG_HOME: String(homeDir),
+      HOME: String(homeDir),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect({ exitCode, hasError: stderr.includes("error:"), tarballAuthHeaders: tarballHits.map(h => h.authorization) }).toEqual({
+    exitCode: 0,
+    hasError: false,
+    tarballAuthHeaders: [`Bearer ${TOKEN}`],
+  });
+});
+
+test("auth token matches case-insensitively on hostname", async () => {
+  // Hostnames are case-insensitive per DNS. A `.npmrc` that writes the
+  // host with mixed case should still authenticate requests whose URL
+  // host uses a different case. Pre-fix, the raw `strings.eql`
+  // comparison on `bun.URL.parse(...).host` — which preserves source
+  // casing — made this fail. We use `Localhost` in the nerf-dart and
+  // request through `localhost` (which the server is also bound to).
+  tarballHits.length = 0;
+  using cacheDir = tempDir("issue-30513-case-cache", {});
+  using dir = tempDir("issue-30513-case", {
+    "package.json": JSON.stringify({
+      name: "issue-30513-case-consumer",
+      version: "0.0.0",
+      dependencies: { [PKG_NAME]: PKG_VERSION },
+    }),
+    ".npmrc": [
+      `@altpay:registry=http://localhost:${server.port}${METADATA_PATH}/`,
+      `//Localhost:${server.port}${TARBALL_PATH}/:_authToken=${TOKEN}`,
+      `always-auth=true`,
+    ].join("\n"),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: String(cacheDir) },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect({ exitCode, hasError: stderr.includes("error:"), tarballAuthHeaders: tarballHits.map(h => h.authorization) }).toEqual({
+    exitCode: 0,
+    hasError: false,
+    tarballAuthHeaders: [`Bearer ${TOKEN}`],
+  });
+});
+
 test("longest nerf-dart wins when multiple entries could match the request URL", async () => {
   // Sanity: a broader root-path token must lose to a deeper project-
   // level token on the same host, so the "most specific wins" rule from

--- a/test/regression/issue/30513.test.ts
+++ b/test/regression/issue/30513.test.ts
@@ -92,6 +92,27 @@ beforeAll(() => {
         return Response.json(manifest);
       }
 
+      // Cross-host variant: the manifest is served from the registry
+      // but the tarball URL points at the separate CDN server. Used
+      // by the cross-host test below.
+      if (path === `${METADATA_PATH}-cdn/${PKG_NAME}`) {
+        const manifest = {
+          name: PKG_NAME,
+          "dist-tags": { latest: PKG_VERSION },
+          versions: {
+            [PKG_VERSION]: {
+              name: PKG_NAME,
+              version: PKG_VERSION,
+              dist: {
+                tarball: `http://${cdnServer.hostname}:${cdnServer.port}/${PKG_NAME}-${PKG_VERSION}.tgz`,
+                shasum: Bun.SHA1.hash(TARBALL, "hex"),
+              },
+            },
+          },
+        };
+        return Response.json(manifest);
+      }
+
       // Tarball: project-level endpoint. We record what auth header the
       // client sent so the assertions below can verify that the token
       // keyed to this path actually travelled on the request.
@@ -115,8 +136,39 @@ beforeAll(() => {
   });
 });
 
+// Secondary "CDN" server — separate host from the main registry,
+// used by the cross-host test to verify that a scope's credentials
+// aren't leaked to a different host when that host has its own
+// nerf-dart configured. Both servers bind to `localhost` but differ
+// by port, which is part of the URL host — so the request host
+// (`localhost:CDN_PORT`) differs from the scope's host
+// (`localhost:REGISTRY_PORT`).
+const CDN_TOKEN = "CDN-BEARER-ONLY-TOKEN";
+const cdnHits: TarballHit[] = [];
+let cdnServer: ReturnType<typeof Bun.serve>;
+
+beforeAll(() => {
+  cdnServer = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const path = decodeURIComponent(url.pathname);
+      if (path === `/${PKG_NAME}-${PKG_VERSION}.tgz`) {
+        const authHeader = req.headers.get("authorization");
+        cdnHits.push({ url: req.url, authorization: authHeader });
+        if (authHeader !== `Bearer ${CDN_TOKEN}`) {
+          return new Response("cdn: not found", { status: 404 });
+        }
+        return new Response(TARBALL, { headers: { "content-type": "application/octet-stream" } });
+      }
+      return new Response("unexpected cdn path: " + path, { status: 500 });
+    },
+  });
+});
+
 afterAll(() => {
   server?.stop(true);
+  cdnServer?.stop(true);
 });
 
 test("auth token applies to tarball URL when token path diverges from registry URL path", async () => {
@@ -396,6 +448,51 @@ test("later auth mode clears earlier one on the same dart", async () => {
     exitCode: 0,
     hasError: false,
     tarballAuthHeaders: [`Basic ${BASIC_AUTH_B64}`],
+  });
+});
+
+test("scope's credentials don't leak to a different host with its own nerf-dart", async () => {
+  // When the metadata registry and the tarball CDN are on different
+  // hosts, the scope's pre-resolved token belongs to the *registry*
+  // host and must not be sent to the CDN. If the user has a separate
+  // nerf-dart configured for the CDN, that's what should travel on
+  // the tarball request. Pre-fix, the length compare
+  // (match.path_len > scopePathLen(scope)) was performed across
+  // hosts — a 0-char path on the CDN lost to a 20-char path on the
+  // registry, so the registry's token was silently sent to the CDN.
+  cdnHits.length = 0;
+  using cacheDir = tempDir("issue-30513-cross-host-cache", {});
+  using dir = tempDir("issue-30513-cross-host", {
+    "package.json": JSON.stringify({
+      name: "issue-30513-cross-host-consumer",
+      version: "0.0.0",
+      dependencies: { [PKG_NAME]: PKG_VERSION },
+    }),
+    ".npmrc": [
+      `@altpay:registry=http://localhost:${server.port}${METADATA_PATH}-cdn/`,
+      `//localhost:${server.port}${METADATA_PATH}-cdn/:_authToken=REGISTRY-TOKEN-MUST-NOT-LEAK`,
+      `//localhost:${cdnServer.port}/:_authToken=${CDN_TOKEN}`,
+      `always-auth=true`,
+    ].join("\n"),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: String(cacheDir) },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect({
+    exitCode,
+    hasError: stderr.includes("error:"),
+    cdnAuthHeaders: cdnHits.map(h => h.authorization),
+  }).toEqual({
+    exitCode: 0,
+    hasError: false,
+    cdnAuthHeaders: [`Bearer ${CDN_TOKEN}`],
   });
 });
 

--- a/test/regression/issue/30513.test.ts
+++ b/test/regression/issue/30513.test.ts
@@ -13,7 +13,7 @@
 // request time (longest-prefix wins), matching npm's behaviour.
 
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 type TarballHit = { url: string; authorization: string | null };
 
@@ -119,6 +119,7 @@ afterAll(() => {
 test("auth token applies to tarball URL when token path diverges from registry URL path", async () => {
   tarballHits.length = 0;
   const origin = `http://${server.hostname}:${server.port}`;
+  using cacheDir = tempDir("issue-30513-cache", {});
   using dir = tempDir("issue-30513", {
     "package.json": JSON.stringify({
       name: "issue-30513-consumer",
@@ -142,17 +143,18 @@ test("auth token applies to tarball URL when token path diverges from registry U
   await using proc = Bun.spawn({
     cmd: [bunExe(), "install"],
     cwd: String(dir),
-    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: tmpdirSync() },
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: String(cacheDir) },
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-  const tarballAuthHeaders = tarballHits.map(h => h.authorization);
-  expect({ exitCode, stderr, stdout, tarballAuthHeaders }).toEqual({
+  // The stable signal for this regression is the recorded Authorization
+  // header on the tarball request; the reporter-output assertions
+  // (stdout progress, non-empty stderr) vary with install's reporter.
+  expect({ exitCode, hasError: stderr.includes("error:"), tarballAuthHeaders: tarballHits.map(h => h.authorization) }).toEqual({
     exitCode: 0,
-    stderr: expect.stringMatching(/./), // bun always writes progress to stderr
-    stdout: expect.stringContaining(PKG_NAME),
+    hasError: false,
     tarballAuthHeaders: [`Bearer ${TOKEN}`],
   });
 });
@@ -166,6 +168,7 @@ test("parent-path nerf-dart covers deeper scoped-registry URL (related: #28233)"
   // of (this case) and divergent (the primary test above) — uniformly.
   tarballHits.length = 0;
   const origin = `http://${server.hostname}:${server.port}`;
+  using cacheDir = tempDir("issue-30513-parent-cache", {});
   using dir = tempDir("issue-30513-parent", {
     "package.json": JSON.stringify({
       name: "issue-30513-parent-consumer",
@@ -186,16 +189,15 @@ test("parent-path nerf-dart covers deeper scoped-registry URL (related: #28233)"
   await using proc = Bun.spawn({
     cmd: [bunExe(), "install"],
     cwd: String(dir),
-    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: tmpdirSync() },
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: String(cacheDir) },
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  void stdout;
-  void stderr;
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-  expect({ exitCode, tarballAuthHeaders: tarballHits.map(h => h.authorization) }).toEqual({
+  expect({ exitCode, hasError: stderr.includes("error:"), tarballAuthHeaders: tarballHits.map(h => h.authorization) }).toEqual({
     exitCode: 0,
+    hasError: false,
     tarballAuthHeaders: [`Bearer ${TOKEN}`],
   });
 });
@@ -206,6 +208,7 @@ test("longest nerf-dart wins when multiple entries could match the request URL",
   // npm is observed at request time.
   tarballHits.length = 0;
   const origin = `http://${server.hostname}:${server.port}`;
+  using cacheDir = tempDir("issue-30513-longest-cache", {});
   using dir = tempDir("issue-30513-longest", {
     "package.json": JSON.stringify({
       name: "issue-30513-longest-consumer",
@@ -226,16 +229,15 @@ test("longest nerf-dart wins when multiple entries could match the request URL",
   await using proc = Bun.spawn({
     cmd: [bunExe(), "install"],
     cwd: String(dir),
-    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: tmpdirSync() },
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: String(cacheDir) },
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  void stdout;
-  void stderr;
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-  expect({ exitCode, tarballAuthHeaders: tarballHits.map(h => h.authorization) }).toEqual({
+  expect({ exitCode, hasError: stderr.includes("error:"), tarballAuthHeaders: tarballHits.map(h => h.authorization) }).toEqual({
     exitCode: 0,
+    hasError: false,
     tarballAuthHeaders: [`Bearer ${TOKEN}`],
   });
 });

--- a/test/regression/issue/30513.test.ts
+++ b/test/regression/issue/30513.test.ts
@@ -57,6 +57,10 @@ function makeTarball(): Buffer {
 }
 const TARBALL = makeTarball();
 
+// base64("user:TOKEN") — used by the auth-mode test to verify Basic
+// auth works when a later `_auth` overrides an earlier `_authToken`.
+const BASIC_AUTH_B64 = Buffer.from(`user:${TOKEN}`).toString("base64");
+
 const tarballHits: TarballHit[] = [];
 let server: ReturnType<typeof Bun.serve>;
 
@@ -92,14 +96,13 @@ beforeAll(() => {
       // client sent so the assertions below can verify that the token
       // keyed to this path actually travelled on the request.
       if (path === `${TARBALL_PATH}/${PKG_NAME}/-/${PKG_NAME}-${PKG_VERSION}.tgz`) {
-        tarballHits.push({
-          url: req.url,
-          authorization: req.headers.get("authorization"),
-        });
+        const authHeader = req.headers.get("authorization");
+        tarballHits.push({ url: req.url, authorization: authHeader });
         // Mirror GitLab: 404 on unauthenticated package-registry
         // requests. With the fix, the token reaches us and we hand
-        // back the tarball.
-        if (req.headers.get("authorization") !== `Bearer ${TOKEN}`) {
+        // back the tarball. Accept either the correct Bearer or the
+        // matching Basic (used by the `_auth` mode-switch test).
+        if (authHeader !== `Bearer ${TOKEN}` && authHeader !== `Basic ${BASIC_AUTH_B64}`) {
           return new Response("not found", { status: 404 });
         }
         return new Response(TARBALL, {
@@ -302,6 +305,97 @@ test("auth token matches case-insensitively on hostname", async () => {
     exitCode: 0,
     hasError: false,
     tarballAuthHeaders: [`Bearer ${TOKEN}`],
+  });
+});
+
+test("case-insensitive host dedup lets later entries override earlier ones for the same dart", async () => {
+  // If two nerf-darts differ only in host casing they refer to the same
+  // logical dart (DNS hosts are case-insensitive). The later entry must
+  // win; pre-fix, the raw-cased hash key let both builders co-exist and
+  // the "winner" was whichever came first in iteration order.
+  tarballHits.length = 0;
+  using cacheDir = tempDir("issue-30513-case-dedup-cache", {});
+  using dir = tempDir("issue-30513-case-dedup", {
+    "package.json": JSON.stringify({
+      name: "issue-30513-case-dedup-consumer",
+      version: "0.0.0",
+      dependencies: { [PKG_NAME]: PKG_VERSION },
+    }),
+    ".npmrc": [
+      `@altpay:registry=http://localhost:${server.port}${METADATA_PATH}/`,
+      // First entry in the file — wrong value, mixed case.
+      `//Localhost:${server.port}${TARBALL_PATH}/:_authToken=case-dedup-wrong-token`,
+      // Second entry — correct value, lowercase. Must override.
+      `//localhost:${server.port}${TARBALL_PATH}/:_authToken=${TOKEN}`,
+      `always-auth=true`,
+    ].join("\n"),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: String(cacheDir) },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect({
+    exitCode,
+    hasError: stderr.includes("error:"),
+    tarballAuthHeaders: tarballHits.map(h => h.authorization),
+  }).toEqual({
+    exitCode: 0,
+    hasError: false,
+    tarballAuthHeaders: [`Bearer ${TOKEN}`],
+  });
+});
+
+test("later auth mode clears earlier one on the same dart", async () => {
+  // `_authToken` / `_auth` / `username`+`_password` are mutually
+  // exclusive. When a later `.npmrc` entry switches modes on the same
+  // dart, the earlier mode must be dropped. Scenario: the user
+  // initially configured a Bearer token, then switched to Basic
+  // auth by setting `_auth` on the same dart. Pre-fix, both fields
+  // stayed set on the builder; `appendAuth` prefers `Bearer` over
+  // `Basic`, so the stale Bearer from the first entry was sent and
+  // the server 404'd. With the fix, the later `_auth` clears the
+  // stale token and the correct Basic header goes out.
+  tarballHits.length = 0;
+  using cacheDir = tempDir("issue-30513-auth-mode-cache", {});
+  using dir = tempDir("issue-30513-auth-mode", {
+    "package.json": JSON.stringify({
+      name: "issue-30513-auth-mode-consumer",
+      version: "0.0.0",
+      dependencies: { [PKG_NAME]: PKG_VERSION },
+    }),
+    ".npmrc": [
+      `@altpay:registry=http://localhost:${server.port}${METADATA_PATH}/`,
+      // First entry: a Bearer token that the server will reject.
+      `//${server.hostname}:${server.port}${TARBALL_PATH}/:_authToken=stale-bearer-must-be-cleared`,
+      // Second entry: the correct Basic auth on the same dart.
+      `//${server.hostname}:${server.port}${TARBALL_PATH}/:_auth=${BASIC_AUTH_B64}`,
+      `always-auth=true`,
+    ].join("\n"),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: String(cacheDir) },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect({
+    exitCode,
+    hasError: stderr.includes("error:"),
+    tarballAuthHeaders: tarballHits.map(h => h.authorization),
+  }).toEqual({
+    exitCode: 0,
+    hasError: false,
+    tarballAuthHeaders: [`Basic ${BASIC_AUTH_B64}`],
   });
 });
 

--- a/test/regression/issue/30513.test.ts
+++ b/test/regression/issue/30513.test.ts
@@ -152,7 +152,11 @@ test("auth token applies to tarball URL when token path diverges from registry U
   // The stable signal for this regression is the recorded Authorization
   // header on the tarball request; the reporter-output assertions
   // (stdout progress, non-empty stderr) vary with install's reporter.
-  expect({ exitCode, hasError: stderr.includes("error:"), tarballAuthHeaders: tarballHits.map(h => h.authorization) }).toEqual({
+  expect({
+    exitCode,
+    hasError: stderr.includes("error:"),
+    tarballAuthHeaders: tarballHits.map(h => h.authorization),
+  }).toEqual({
     exitCode: 0,
     hasError: false,
     tarballAuthHeaders: [`Bearer ${TOKEN}`],
@@ -195,7 +199,11 @@ test("parent-path nerf-dart covers deeper scoped-registry URL (related: #28233)"
   });
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-  expect({ exitCode, hasError: stderr.includes("error:"), tarballAuthHeaders: tarballHits.map(h => h.authorization) }).toEqual({
+  expect({
+    exitCode,
+    hasError: stderr.includes("error:"),
+    tarballAuthHeaders: tarballHits.map(h => h.authorization),
+  }).toEqual({
     exitCode: 0,
     hasError: false,
     tarballAuthHeaders: [`Bearer ${TOKEN}`],
@@ -235,7 +243,11 @@ test("longest nerf-dart wins when multiple entries could match the request URL",
   });
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-  expect({ exitCode, hasError: stderr.includes("error:"), tarballAuthHeaders: tarballHits.map(h => h.authorization) }).toEqual({
+  expect({
+    exitCode,
+    hasError: stderr.includes("error:"),
+    tarballAuthHeaders: tarballHits.map(h => h.authorization),
+  }).toEqual({
     exitCode: 0,
     hasError: false,
     tarballAuthHeaders: [`Bearer ${TOKEN}`],


### PR DESCRIPTION
Fixes #30513.

## Problem

A regression in 1.3.11 (commit `e5ac0ee`, PR #26351 for #26350) tightened
`.npmrc` auth matching from host-only to host-and-exact-path. That fix
was correct for #26350 but over-corrected: npm's spec calls for
longest-prefix matching against the **request URL**, not exact matching
against the **registry URL**.

The common self-hosted GitLab pattern trips this:

```ini
@altpay:registry=https://git.macellan.net/api/v4/packages/npm/
//git.macellan.net/api/v4/projects/568/packages/npm/:_authToken=GLPAT_TOKEN
always-auth=true
```

GitLab's metadata endpoint at `/api/v4/packages/npm/` resolves to tarball
URLs under `/api/v4/projects/568/packages/npm/`. Neither path is a prefix
of the other, so bun 1.3.11+ never attaches the token to the scope and
sends the tarball request with no `Authorization` header. GitLab masks
unauthenticated registry requests as 404 and the install fails.

## Fix

Match every `.npmrc` auth entry against the request URL at request time
by longest nerf-dart prefix — npm's actual behaviour.

- `loadNpmrc` now collects every `_authToken` / `_auth` / `username` /
  `_password` entry into a flat list keyed by its nerf-dart
  (`//host[/path]/`), stored on `BunInstall.auth_configurations`.
  Per-scope token attachment (the old code path used for #26350) still
  runs, so `scope.token` / `scope.auth` remain populated for
  backward-compat.
- `NetworkTask.forManifest` / `forTarball` call a new
  `PackageManager.matchAuthForUrl(url)` that walks the list and picks
  the entry whose path is the longest prefix of the request URL. On ties
  the entry with actual credentials wins (so an `email`-only entry at a
  deeper path doesn't shadow a token at the root).
- The nerf-dart match wins over the scope's pre-resolved token when
  it's strictly more specific, **or** when the scope has no credentials
  at all (covers #28233's parent-path direction).

Same mechanism handles both directions uniformly:
- #30513 (this issue): token path is a sibling/divergent from the
  registry path but a prefix of the tarball URL.
- #28233: token path is a parent of the registry path.

## Verification

`test/regression/issue/30513.test.ts` spins up a mock registry with the
exact GitLab divergent-paths layout. Three cases:
1. The issue's reproduction — diverging registry vs. token paths, token
   covers tarball URL.
2. Parent-path token (#28233 direction).
3. Longest-match wins when a root-host token and a project-level token
   could both match.

All three fail on `main` with the `null` Authorization header the issue
reports, and pass with this change.

Existing coverage stays green:
- `npmrc > applies auth tokens to default registry correctly - same host different paths` (#26350 positive).
- `npmrc > auth token not applied when paths don't match - same host` (#26350 negative).
- `bun-install > should handle @scoped authentication`.
- All 11 `redacted-config-logs` tests.

## Files

- `src/install/npm.zig` — new `Npm.Registry.AuthConfiguration` (and
  transient `AuthConfigurationBuilder` used only by `loadNpmrc`).
- `src/options_types/schema.zig` — `BunInstall.auth_configurations`
  field.
- `src/ini/ini.zig` — populate the flat list during config load.
- `src/install/PackageManager/PackageManagerOptions.zig` — carry the
  list through to the manager.
- `src/install/PackageManager/PackageManagerResolution.zig` —
  `matchAuthForUrl` (longest-prefix lookup with segment-boundary check).
- `src/install/PackageManager.zig` — re-export.
- `src/install/NetworkTask.zig` — switch `countAuth` / `appendAuth` to
  take resolved credentials instead of a scope; call `matchAuthForUrl`
  at request time.
- `test/regression/issue/30513.test.ts` — three-case regression test.