### PR TITLE
Fix null deref in Bun.inspect when Proxy getPrototypeOf trap throws

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5444,7 +5444,10 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            iterating = proto ? proto.getObject() : nullptr;
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -451,6 +451,29 @@ const fixture = [
         },
       },
     ),
+  () =>
+    Object.setPrototypeOf(
+      { yolo: 1 },
+      new Proxy(
+        {},
+        {
+          getPrototypeOf() {
+            throw new Error("nope");
+          },
+        },
+      ),
+    ),
+  () =>
+    Object.create(
+      new Proxy(
+        { yolo: 1 },
+        {
+          getPrototypeOf() {
+            throw new Error("nope");
+          },
+        },
+      ),
+    ),
 ];
 
 describe("crash testing", () => {


### PR DESCRIPTION
Fuzzer found a crash (fingerprint `b01f1338ddbd3ba7`) where `Bun.inspect()` / `console.log()` dereferences null when the inspected object's prototype chain contains a Proxy whose `getPrototypeOf` trap throws.

## Repro

```js
const obj = {};
Object.setPrototypeOf(obj, new Proxy({}, {
  getPrototypeOf() { throw new Error("nope"); }
}));
Bun.inspect(obj);
```

## Root cause

In `JSC__JSValue__forEachPropertyImpl`, when walking the prototype chain:

```cpp
iterating = iterating->getPrototype(globalObject).getObject();
```

`getPrototype()` can throw (via a Proxy's `getPrototypeOf` trap) and return an empty `JSValue`. An empty `JSValue` passes `isCell()` but `asCell()` returns `nullptr`, so `.getObject()` calls a method on null.

## Fix

Clear the exception and treat an empty result as end of the prototype chain, matching how the fast path in the same function already handles this case.