### PR TITLE
Validate `app.bundlerOptions` keys are objects in `Bun.serve`

### DIFF
--- a/src/bake/bake.zig
+++ b/src/bake/bake.zig
@@ -68,14 +68,17 @@ pub const UserOptions = struct {
         }
 
         if (try config.getOptional(global, "bundlerOptions", JSValue)) |js_options| {
+            if (!js_options.isObject()) {
+                return global.throwInvalidArguments("'" ++ api_name ++ ".bundlerOptions' must be an object", .{});
+            }
             if (try js_options.getOptional(global, "server", JSValue)) |server_options| {
-                bundler_options.server = try BuildConfigSubset.fromJS(global, server_options);
+                bundler_options.server = try BuildConfigSubset.fromJS(global, "server", server_options);
             }
             if (try js_options.getOptional(global, "client", JSValue)) |client_options| {
-                bundler_options.client = try BuildConfigSubset.fromJS(global, client_options);
+                bundler_options.client = try BuildConfigSubset.fromJS(global, "client", client_options);
             }
             if (try js_options.getOptional(global, "ssr", JSValue)) |ssr_options| {
-                bundler_options.ssr = try BuildConfigSubset.fromJS(global, ssr_options);
+                bundler_options.ssr = try BuildConfigSubset.fromJS(global, "ssr", ssr_options);
             }
         }
 
@@ -202,7 +205,11 @@ const BuildConfigSubset = struct {
     minify_identifiers: ?bool = null,
     minify_whitespace: ?bool = null,
 
-    pub fn fromJS(global: *jsc.JSGlobalObject, js_options: JSValue) bun.JSError!BuildConfigSubset {
+    pub fn fromJS(global: *jsc.JSGlobalObject, comptime name: []const u8, js_options: JSValue) bun.JSError!BuildConfigSubset {
+        if (!js_options.isObject()) {
+            return global.throwInvalidArguments("'" ++ api_name ++ ".bundlerOptions." ++ name ++ "' must be an object", .{});
+        }
+
         var options = BuildConfigSubset{};
 
         if (try js_options.getOptional(global, "sourcemap", JSValue)) |val| brk: {

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -678,7 +678,7 @@ describe("app.bundlerOptions validation", () => {
     expect(() => {
       // @ts-expect-error - Testing invalid input
       serve({ port: 0, app: { bundlerOptions: value } });
-    }).toThrow(TypeError);
+    }).toThrow("'app.bundlerOptions' must be an object");
   });
 
   describe.each(["server", "client", "ssr"])("bundlerOptions.%s", key => {
@@ -686,7 +686,7 @@ describe("app.bundlerOptions validation", () => {
       expect(() => {
         // @ts-expect-error - Testing invalid input
         serve({ port: 0, app: { bundlerOptions: { [key]: value } } });
-      }).toThrow(TypeError);
+      }).toThrow(`'app.bundlerOptions.${key}' must be an object`);
     });
   });
 });

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -670,3 +670,23 @@ describe("Bun.serve unix socket validation", () => {
     }
   });
 });
+
+describe("app.bundlerOptions validation", () => {
+  const primitives = [128n, 5, "str", true, Symbol()];
+
+  test.each(primitives)("throws when bundlerOptions is %p", value => {
+    expect(() => {
+      // @ts-expect-error - Testing invalid input
+      serve({ port: 0, app: { bundlerOptions: value } });
+    }).toThrow(TypeError);
+  });
+
+  describe.each(["server", "client", "ssr"])("bundlerOptions.%s", key => {
+    test.each(primitives)("throws when value is %p", value => {
+      expect(() => {
+        // @ts-expect-error - Testing invalid input
+        serve({ port: 0, app: { bundlerOptions: { [key]: value } } });
+      }).toThrow(TypeError);
+    });
+  });
+});


### PR DESCRIPTION
Fuzzer found a debug assertion failure when passing non-object values for `app.bundlerOptions` (or its `server` / `client` / `ssr` sub-keys) to `Bun.serve`.

```js
Bun.serve({ app: { bundlerOptions: { client: 128n } } });
// panic: reached unreachable code (debugAssert target.isObject() in JSValue.get)
```

`getOptional(..., JSValue)` returns any non-null/undefined value without type-checking, so a BigInt/number/string/etc. was passed straight into `BuildConfigSubset.fromJS`, which then called `.getOptional()` on it and tripped the `isObject()` assert.

Now throws a proper `TypeError: 'app.bundlerOptions.client' must be an object` instead.

Fingerprint: `e7c62943558380b8`