### PR TITLE
Fix WriteBarrier owner and add cellLock for JSCommonJSExtensions::m_registeredFunctions

### DIFF
--- a/src/jsc/bindings/JSCommonJSExtensions.cpp
+++ b/src/jsc/bindings/JSCommonJSExtensions.cpp
@@ -213,6 +213,7 @@ extern "C" uint32_t JSCommonJSExtensions__appendFunction(Zig::GlobalObject* glob
 extern "C" void JSCommonJSExtensions__setFunction(Zig::GlobalObject* globalObject, uint32_t index, JSC::JSValue value)
 {
     JSCommonJSExtensions* extensions = globalObject->lazyRequireExtensionsObject();
+    WTF::Locker locker { extensions->cellLock() };
     extensions->m_registeredFunctions[index].set(globalObject->vm(), extensions, value);
 }
 
@@ -305,10 +306,11 @@ void JSCommonJSExtensions::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 
-    // m_registeredFunctions is mutated by JSCommonJSExtensions__appendFunction
-    // and JSCommonJSExtensions__swapRemove on the mutator thread; take cellLock
-    // so a concurrent Vector reallocation does not free the backing buffer
-    // mid-scan when this runs on a parallel mark thread.
+    // m_registeredFunctions is mutated by JSCommonJSExtensions__appendFunction,
+    // JSCommonJSExtensions__setFunction, and JSCommonJSExtensions__swapRemove on
+    // the mutator thread; take cellLock so a concurrent Vector reallocation does
+    // not free the backing buffer mid-scan when this runs on a parallel mark
+    // thread.
     WTF::Locker locker { thisObject->cellLock() };
     for (auto& func : thisObject->m_registeredFunctions) {
         visitor.append(func);

--- a/src/jsc/bindings/JSCommonJSExtensions.cpp
+++ b/src/jsc/bindings/JSCommonJSExtensions.cpp
@@ -204,6 +204,7 @@ bool JSCommonJSExtensions::deleteProperty(JSC::JSCell* cell, JSC::JSGlobalObject
 extern "C" uint32_t JSCommonJSExtensions__appendFunction(Zig::GlobalObject* globalObject, JSC::JSValue value)
 {
     JSCommonJSExtensions* extensions = globalObject->lazyRequireExtensionsObject();
+    WTF::Locker locker { extensions->cellLock() };
     extensions->m_registeredFunctions.append(JSC::WriteBarrier<Unknown>());
     extensions->m_registeredFunctions.last().set(globalObject->vm(), extensions, value);
     return extensions->m_registeredFunctions.size() - 1;
@@ -212,12 +213,13 @@ extern "C" uint32_t JSCommonJSExtensions__appendFunction(Zig::GlobalObject* glob
 extern "C" void JSCommonJSExtensions__setFunction(Zig::GlobalObject* globalObject, uint32_t index, JSC::JSValue value)
 {
     JSCommonJSExtensions* extensions = globalObject->lazyRequireExtensionsObject();
-    extensions->m_registeredFunctions[index].set(globalObject->vm(), globalObject, value);
+    extensions->m_registeredFunctions[index].set(globalObject->vm(), extensions, value);
 }
 
 extern "C" uint32_t JSCommonJSExtensions__swapRemove(Zig::GlobalObject* globalObject, uint32_t index)
 {
     JSCommonJSExtensions* extensions = globalObject->lazyRequireExtensionsObject();
+    WTF::Locker locker { extensions->cellLock() };
     ASSERT(extensions->m_registeredFunctions.size() > 0);
     if (extensions->m_registeredFunctions.size() == 1) {
         extensions->m_registeredFunctions.clear();
@@ -226,7 +228,7 @@ extern "C" uint32_t JSCommonJSExtensions__swapRemove(Zig::GlobalObject* globalOb
     ASSERT(index < extensions->m_registeredFunctions.size());
     if (index < (extensions->m_registeredFunctions.size() - 1)) {
         JSValue last = extensions->m_registeredFunctions.takeLast().get();
-        extensions->m_registeredFunctions[index].set(globalObject->vm(), globalObject, last);
+        extensions->m_registeredFunctions[index].set(globalObject->vm(), extensions, last);
         return extensions->m_registeredFunctions.size();
     } else {
         extensions->m_registeredFunctions.removeLast();
@@ -303,6 +305,11 @@ void JSCommonJSExtensions::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 
+    // m_registeredFunctions is mutated by JSCommonJSExtensions__appendFunction
+    // and JSCommonJSExtensions__swapRemove on the mutator thread; take cellLock
+    // so a concurrent Vector reallocation does not free the backing buffer
+    // mid-scan when this runs on a parallel mark thread.
+    WTF::Locker locker { thisObject->cellLock() };
     for (auto& func : thisObject->m_registeredFunctions) {
         visitor.append(func);
     }

--- a/test/js/node/module/module-extensions-concurrent-gc.test.ts
+++ b/test/js/node/module/module-extensions-concurrent-gc.test.ts
@@ -1,21 +1,24 @@
-// JSCommonJSExtensions::m_registeredFunctions is a
-// WTF::Vector<WriteBarrier<Unknown>> visited by visitChildrenImpl on parallel
-// GC mark threads. All mutators (JSCommonJSExtensions__appendFunction /
-// __setFunction / __swapRemove) and the visitor must hold cellLock() so a
-// concurrent Vector reallocation cannot free the backing buffer while a mark
-// thread is mid-scan, and WriteBarrier::set() must pass the extensions object
-// (not the global object) as the owner cell so eden collections re-scan the
-// correct cell.
+// Concurrent-GC smoke test for Module._extensions / require.extensions.
 //
-// As with JSCommonJSModule::m_children (see module-children-concurrent-gc),
-// the race is not reliably observable as a crash in the default build because
-// the prebuilt debug WebKit uses bmalloc, so freed Vector buffers are neither
-// ASAN-poisoned nor scribbled. This test is kept as a regression guard for
-// the locking and the WriteBarrier owner — it churns Module._extensions under
-// collectContinuously so the JSCommonJSExtensions cell is repeatedly visited
-// on concurrent mark threads while the mutator registers/replaces/deletes
-// handlers, and asserts the program still runs to completion with correct
-// output.
+// Assigning, defining, and deleting handlers on Module._extensions routes
+// through JSCommonJSExtensions::put / defineOwnProperty / deleteProperty,
+// which store the handler via jsc.Strong in Zig (NodeModuleModule.zig
+// onRequireExtensionModify) and mutate own-property storage on the
+// JSCommonJSExtensions cell. This test churns those paths under
+// BUN_JSC_collectContinuously=1 so the cell is repeatedly visited on
+// concurrent mark threads (exercising JSCommonJSExtensions::visitChildrenImpl,
+// which takes cellLock() before scanning m_registeredFunctions) while the
+// mutator registers/replaces/deletes handlers with fresh closures each
+// iteration, and asserts the program runs to completion with correct output.
+//
+// Note: m_registeredFunctions itself is currently always empty — the three
+// JSCommonJSExtensions__{append,set,swapRemove}Function helpers have had no
+// Zig callers since #19231 switched CustomLoader.custom to jsc.Strong — so
+// this test cannot observe a regression in the cellLock() or WriteBarrier
+// owner fixes for those helpers. It is kept as a concurrent-GC regression
+// guard for the Module._extensions code paths that are live today, and for
+// visitChildrenImpl's locking should m_registeredFunctions ever be
+// repopulated.
 
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
@@ -24,7 +27,7 @@ import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 // identical across platforms; skip there (same rationale as
 // module-children-concurrent-gc.test.ts / issue 29519).
 test.skipIf(isWindows)(
-  "JSCommonJSExtensions m_registeredFunctions mutation under concurrent GC",
+  "JSCommonJSExtensions put/defineOwnProperty/deleteProperty under concurrent GC",
   async () => {
     const files: Record<string, string> = {
       "a.abc": `module.exports = "abc-default";\n`,

--- a/test/js/node/module/module-extensions-concurrent-gc.test.ts
+++ b/test/js/node/module/module-extensions-concurrent-gc.test.ts
@@ -1,0 +1,94 @@
+// JSCommonJSExtensions::m_registeredFunctions is a
+// WTF::Vector<WriteBarrier<Unknown>> visited by visitChildrenImpl on parallel
+// GC mark threads. All mutators (JSCommonJSExtensions__appendFunction /
+// __setFunction / __swapRemove) and the visitor must hold cellLock() so a
+// concurrent Vector reallocation cannot free the backing buffer while a mark
+// thread is mid-scan, and WriteBarrier::set() must pass the extensions object
+// (not the global object) as the owner cell so eden collections re-scan the
+// correct cell.
+//
+// As with JSCommonJSModule::m_children (see module-children-concurrent-gc),
+// the race is not reliably observable as a crash in the default build because
+// the prebuilt debug WebKit uses bmalloc, so freed Vector buffers are neither
+// ASAN-poisoned nor scribbled. This test is kept as a regression guard for
+// the locking and the WriteBarrier owner — it churns Module._extensions under
+// collectContinuously so the JSCommonJSExtensions cell is repeatedly visited
+// on concurrent mark threads while the mutator registers/replaces/deletes
+// handlers, and asserts the program still runs to completion with correct
+// output.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+// collectContinuously is very slow on Windows in CI and the code path is
+// identical across platforms; skip there (same rationale as
+// module-children-concurrent-gc.test.ts / issue 29519).
+test.skipIf(isWindows)(
+  "JSCommonJSExtensions m_registeredFunctions mutation under concurrent GC",
+  async () => {
+    const files: Record<string, string> = {
+      "a.abc": `module.exports = "abc-default";\n`,
+      "entry.cjs": `
+        const Module = require("module");
+        const path = require("path");
+        const target = path.join(__dirname, "a.abc");
+
+        // Drive put()/defineOwnProperty()/deleteProperty() on the
+        // JSCommonJSExtensions object while the concurrent marker visits it.
+        // Each iteration registers a fresh closure so the eden generation
+        // always has new cells reachable only via the extensions object.
+        let last;
+        for (let i = 0; i < 400; i++) {
+          const tag = "v" + i;
+          // put: custom loader (new function each time)
+          Module._extensions[".abc"] = function (mod, filename) {
+            mod._compile("module.exports = " + JSON.stringify(tag) + ";", filename);
+          };
+          // put: overwrite existing custom loader with another new function
+          Module._extensions[".abc"] = function (mod, filename) {
+            mod._compile("module.exports = " + JSON.stringify(tag + "-b") + ";", filename);
+          };
+          // defineOwnProperty path
+          Object.defineProperty(Module._extensions, ".xyz", {
+            value: Module._extensions[".js"],
+            configurable: true,
+            writable: true,
+            enumerable: true,
+          });
+          delete require.cache[target];
+          last = require(target);
+          // deleteProperty path
+          delete Module._extensions[".xyz"];
+        }
+        delete Module._extensions[".abc"];
+
+        if (last !== "v399-b") throw new Error("wrong: " + last);
+        console.log("ok " + last);
+      `,
+    };
+
+    using dir = tempDir("cjs-extensions-concurrent-gc", files);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.cjs"],
+      env: {
+        ...bunEnv,
+        BUN_JSC_collectContinuously: "1",
+      },
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Assert output before exit code so a failure shows the actual crash
+    // text. Debug/ASAN builds print a harmless "WARNING: ASAN interferes
+    // with JSC signal handlers" banner on stderr, so only surface stderr
+    // when the process failed.
+    expect(stdout.trim()).toBe("ok v399-b");
+    if (exitCode !== 0) expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  },
+  60_000,
+);


### PR DESCRIPTION
## What

Two GC-correctness fixes for `JSCommonJSExtensions::m_registeredFunctions` in `src/jsc/bindings/JSCommonJSExtensions.cpp`.

### 1. Wrong `WriteBarrier::set()` owner cell

`JSCommonJSExtensions__setFunction` (line 215) and `JSCommonJSExtensions__swapRemove` (line 229) pass `globalObject` as the owner argument to `WriteBarrier::set()`:

```cpp
extensions->m_registeredFunctions[index].set(globalObject->vm(), globalObject, value);
//                                                              ^^^^^^^^^^^^ should be extensions
```

`WriteBarrier::set(vm, owner, value)` registers `owner` in the GC's remembered set so the write is re-scanned during an eden collection. But it is `JSCommonJSExtensions::visitChildrenImpl` — not the global object's `visitChildren` — that scans `m_registeredFunctions`. With `globalObject` as the registered owner, an eden collection where `extensions` is already old/black and `value` is young never re-marks `value`, and it can be collected while still referenced. The next time `visitChildrenImpl` runs, `visitor.append(func)` reads a dangling cell pointer.

`JSCommonJSExtensions__appendFunction` (line 208) already passes the correct owner (`extensions`); these two call sites were the only ones that did not.

### 2. Missing `cellLock()` around `Vector<WriteBarrier<>>` mutation/visit

`m_registeredFunctions` is a `WTF::Vector<WriteBarrier<Unknown>>` mutated on the mutator thread by `__appendFunction` / `__setFunction` / `__swapRemove` (`append()` / `takeLast()` / `removeLast()` / `clear()`) without any lock, while `visitChildrenImpl` iterates it on parallel mark threads. A `Vector` reallocation can free the backing buffer while a mark thread is mid-scan, putting garbage `JSCell*` pointers on the mark stack.

This is the same pattern that was fixed for `JSCommonJSModule::m_children` in #29995 (`bd5149f927`). This change applies the same `cellLock()` discipline to `m_registeredFunctions`.

## Context

Found while auditing the bindings for sources of an intermittent JSC GC segfault on Linux x64 with concurrent GC enabled — `SlotVisitor::drain` faults on parallel-mark helper threads, and `~InlineCacheHandler()` faults during `Heap::finalizeUnconditionalFinalizers()`. These two issues are correctness bugs regardless of whether they are the root cause of those particular crash reports.

## Reproduction hint

```
BUN_JSC_collectContinuously=1 BUN_JSC_numberOfGCMarkers=8 BUN_JSC_useConcurrentGC=1
```

with a workload that registers/swaps `Module._extensions` handlers (e.g. `ts-node`, `source-map-support`) under load.
