### PR TITLE
Upgrade WebKit to 5488984d: fix require(ESM) diamond-dep deadlock

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,11 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "88b2f7a2159c913f7dd0d73c0e88d66138cd67ba";
+// TODO(before merge): switch to "2b6b1c39ef41955bb10d31430e6ef94eef2274a1" once
+// oven-sh/WebKit#225 is merged and autobuild-2b6b1c39ef41... is published.
+// Using the preview-PR tag lets bun CI validate against the patched WebKit
+// before that PR lands.
+export const WEBKIT_VERSION = "autobuild-preview-pr-225-2b6b1c39";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,11 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-// TODO(before merge): switch to "2b6b1c39ef41955bb10d31430e6ef94eef2274a1" once
-// oven-sh/WebKit#225 is merged and autobuild-2b6b1c39ef41... is published.
-// Using the preview-PR tag lets bun CI validate against the patched WebKit
-// before that PR lands.
-export const WEBKIT_VERSION = "autobuild-preview-pr-225-2b6b1c39";
+export const WEBKIT_VERSION = "5488984d20e0dbfe4be2c3ba8fb18eb81a5e0e8b";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/regression/issue/30493.test.ts
+++ b/test/regression/issue/30493.test.ts
@@ -1,0 +1,54 @@
+// https://github.com/oven-sh/bun/issues/30493
+//
+// `require()` of an ESM module whose graph contains a diamond dependency
+// through a barrel deadlocked (release) / aborted on `ASSERTION FAILED:
+// m_status == Status::Fetching` at ModuleRegistryEntry.cpp:254 (debug).
+// Regressed by the require(esm) sync-replay path; same root cause as
+// #30281 — `moduleRegistryModuleSettled` fired twice for the same entry
+// when `hostLoadImportedModule`'s synchronous-replay branch had already
+// driven `fetchComplete` inline while a stale normal-queue reaction was
+// still pending. Fix: oven-sh/WebKit#217.
+//
+// This is the dependency-free reduction of #30281; the react + MUI
+// variant is covered separately in 30281.test.ts.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+
+test("require() of ESM with diamond dependency through barrel does not deadlock", async () => {
+  using dir = tempDir("issue-30493", {
+    // shared.js: imports a synthetic builtin so its fetch goes through
+    // the normal microtask queue *before* the require(esm) entry point
+    // switches to synchronous draining — that ordering is what leaves a
+    // stale ModuleRegistryModuleSettled reaction queued. `path.posix.sep`
+    // so the snapshot is platform-stable.
+    "shared.js": `import path from 'path';\nexport const SHARED = path.posix.sep;\n`,
+    "barrel.js": `import { SHARED } from './shared.js';\nexport { SHARED };\nexport const BARREL = 'barrel';\n`,
+    "a.js": `import { SHARED } from './barrel.js';\nexport default function a() { return SHARED; }\n`,
+    "b.js": `import { BARREL } from './barrel.js';\nexport default function b() { return BARREL; }\n`,
+    "app.js": `import a from './a.js';\nimport b from './b.js';\nimport { SHARED } from './shared.js';\nexport default { a: a(), b: b(), shared: SHARED };\n`,
+    "entry.js": `const mod = require('./app.js');\nconsole.log(JSON.stringify(mod.default));\n`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  // Before the fix: release builds deadlock indefinitely; debug builds
+  // abort. signalAfter forces a clean failure for the deadlock case so
+  // the test reports stderr rather than timing out the whole file.
+  const KILL_SIGNAL = "SIGTERM";
+  const KILL_AFTER_MS = 5_000;
+  const killer = setTimeout(() => proc.kill(KILL_SIGNAL), KILL_AFTER_MS);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  clearTimeout(killer);
+
+  expect(normalizeBunSnapshot(stdout, dir)).toMatchInlineSnapshot(`"{"a":"/","b":"barrel","shared":"/"}"`);
+  expect(stderr).not.toContain("ASSERTION FAILED");
+  expect(proc.signalCode).not.toBe(KILL_SIGNAL);
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/30493.test.ts
+++ b/test/regression/issue/30493.test.ts
@@ -7,10 +7,10 @@
 // #30281 — `moduleRegistryModuleSettled` fired twice for the same entry
 // when `hostLoadImportedModule`'s synchronous-replay branch had already
 // driven `fetchComplete` inline while a stale normal-queue reaction was
-// still pending. Fix: oven-sh/WebKit#217.
+// still pending. Fix: oven-sh/WebKit#225.
 //
-// This is the dependency-free reduction of #30281; the react + MUI
-// variant is covered separately in 30281.test.ts.
+// This is the dependency-free reduction of #30281; it subsumes the
+// react + MUI repro from #30283.
 
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
@@ -36,19 +36,16 @@ test("require() of ESM with diamond dependency through barrel does not deadlock"
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
+    // Before the fix: release builds deadlock indefinitely; debug builds
+    // abort. Bound the subprocess so the assertions below show a clear
+    // failure instead of the test itself timing out.
+    timeout: 10_000,
   });
 
-  // Before the fix: release builds deadlock indefinitely; debug builds
-  // abort. signalAfter forces a clean failure for the deadlock case so
-  // the test reports stderr rather than timing out the whole file.
-  const KILL_SIGNAL = "SIGTERM";
-  const KILL_AFTER_MS = 5_000;
-  const killer = setTimeout(() => proc.kill(KILL_SIGNAL), KILL_AFTER_MS);
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  clearTimeout(killer);
 
   expect(normalizeBunSnapshot(stdout, dir)).toMatchInlineSnapshot(`"{"a":"/","b":"barrel","shared":"/"}"`);
-  expect(stderr).not.toContain("ASSERTION FAILED");
-  expect(proc.signalCode).not.toBe(KILL_SIGNAL);
+  // null ⇒ exited on its own; non-null ⇒ killed by the spawn timeout (deadlocked).
+  expect(proc.signalCode).toBeNull();
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/30493.test.ts
+++ b/test/regression/issue/30493.test.ts
@@ -48,4 +48,4 @@ test("require() of ESM with diamond dependency through barrel does not deadlock"
   // null ⇒ exited on its own; non-null ⇒ killed by the spawn timeout (deadlocked).
   expect(proc.signalCode).toBeNull();
   expect(exitCode).toBe(0);
-});
+}, 30_000);


### PR DESCRIPTION
## WebKit changes (88b2f7a2 → 5488984d)

Single commit on top of the previous pin:

### `module-loader: don't double-fire moduleRegistryModuleSettled after inline sync replay` (oven-sh/WebKit#225, rebased #217)

**File:** `Source/JavaScriptCore/runtime/JSMicrotask.cpp`

**What:** Adds a `modulePromise->status() != Pending` early-return guard to `moduleRegistryModuleSettled`, symmetric with the guard already present in `moduleRegistryFetchSettled`. Gated under `#if USE(BUN_JSC_ADDITIONS)`.

**Why:** `require()` of an ESM whose graph contained a diamond dependency through a barrel deadlocked (release) / aborted on `ASSERTION FAILED: m_status == Status::Fetching` (debug). `hostLoadImportedModule`'s synchronous-replay branch (taken when `require(esm)` is draining the synchronous module queue) calls `fetchComplete` + fulfills `modulePromise` inline. If a `ModuleRegistryFetchSettled` reaction had already run on the *normal* microtask queue for the same entry before sync mode was entered, it left a stale `ModuleRegistryModuleSettled` reaction queued there. When the normal queue later drained, that reaction re-entered `fetchComplete` on an already-`Fetched` entry.

No changes to `JSType.h`. No WebCore code-generator changes.

---

**Verification:**
- ✅ `test/regression/issue/30493.test.ts` fails on current `main` (assertion crash, empty stdout)
- ✅ Same test passes on `bun run build:local` with the patched WebKit
- ✅ Same test passes on `bun bd` with the prebuilt preview tarball
- ✅ Full bun CI green against `autobuild-preview-pr-225-2b6b1c39` (build #53556 — 67 pass, 3 pre-existing main flakes also red on #30522)

Fixes #30493
Fixes #30281
Closes #30283 (the dependency-free 6-file repro in this PR covers the same root cause without needing a react+MUI install)
