### PR TITLE
Fix crash in Bun.build with custom conditions

### DIFF
--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1087,9 +1087,10 @@ pub const ESMConditions = struct {
         var require_condition_map = ConditionsMap.init(allocator);
         var style_condition_map = ConditionsMap.init(allocator);
 
-        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
+        const addons_count: usize = if (allow_addons) 1 else 0;
+        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + addons_count + conditions.len);
+        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + addons_count + conditions.len);
+        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + addons_count + conditions.len);
         try style_condition_map.ensureTotalCapacity(defaults.len + 2 + conditions.len);
 
         import_condition_map.putAssumeCapacity("import", {});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -649,6 +649,36 @@ describe("Bun.build", () => {
       expect(await html?.text()).toContain("<meta name='injected-by-plugin' content='true'>");
     },
   );
+
+  test("does not crash with many custom conditions", async () => {
+    // ESMConditions.init under-reserved capacity when allow_addons was true
+    // (the default) due to `if`-expression precedence, so passing several
+    // custom conditions overflowed putAssumeCapacity and crashed the bundler
+    // thread. Run in a subprocess since the crash aborts the whole process.
+    const dir = tempDirWithFiles("bun-build-api-conditions", {
+      "entry.ts": "export const x = 1;",
+    });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const result = await Bun.build({
+            entrypoints: [${JSON.stringify(join(dir, "entry.ts"))}],
+            conditions: ["a", "b", "c", "d", "e", "f", "g", "h"],
+          });
+          console.log("success:" + result.success);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("success:true");
+    expect(exitCode).toBe(0);
+  });
 });
 
 test.concurrent("macro with nested object", async () => {


### PR DESCRIPTION
## What

Fixes a crash in `Bun.build()` (and anything going through `BundleOptions.fromApi`) when passing custom `conditions` with native addons enabled (the default).

## Why

`ESMConditions.init` reserved capacity for its condition maps using:

```zig
defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len
```

In Zig the `else` branch of an `if` expression consumes the full remaining expression, so this parses as:

```zig
defaults.len + 2 + (if (allow_addons) 1 else (0 + conditions.len))
```

When `allow_addons` was `true`, `conditions.len` was dropped from the reservation entirely. The subsequent `putAssumeCapacity` calls then overflowed the `MultiArrayList` backing store, tripping an assert in debug builds and segfaulting in release.

## How

Hoist the conditional into a `const addons_count: usize` so the arithmetic is unambiguous.

Found by Fuzzilli (`f2ec65306ddfaf9f`).