### PR TITLE
install: accept ms-style duration strings for minimumReleaseAge

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -263,11 +263,15 @@ A `configVersion` field in your lockfile controls the default. For a detailed ex
 
 ## Minimum release age
 
-To protect against supply chain attacks where malicious packages are quickly published, you can configure a minimum age requirement for npm packages. Bun filters out package versions published more recently than the specified threshold (in seconds) during installation.
+To protect against supply chain attacks where malicious packages are quickly published, you can configure a minimum age requirement for npm packages. Bun filters out package versions published more recently than the specified threshold during installation. The filter is disabled by default; pass `0` to disable it explicitly.
+
+The value accepts either an [`ms`](https://npmjs.com/package/ms)-style duration string (`3d`, `1 week`, `48h`) or a bare number of seconds:
 
 ```bash terminal icon="terminal"
 # Only install package versions published at least 3 days ago
-bun add @types/bun --minimum-release-age 259200 # seconds
+bun add @types/bun --minimum-release-age 3d
+# Or as a number of seconds:
+bun add @types/bun --minimum-release-age 259200
 ```
 
 You can also configure this in `bunfig.toml`:
@@ -275,7 +279,7 @@ You can also configure this in `bunfig.toml`:
 ```toml bunfig.toml icon="settings"
 [install]
 # Only install package versions published at least 3 days ago
-minimumReleaseAge = 259200 # seconds
+minimumReleaseAge = "3d" # or 259200 (seconds)
 
 # Exclude trusted packages from the age gate
 minimumReleaseAgeExcludes = ["@types/node", "typescript"]
@@ -342,8 +346,10 @@ concurrentScripts = 16 # (cpu count or GOMAXPROCS) x2
 linker = "hoisted"
 
 
-# minimum age config
-minimumReleaseAge = 259200 # seconds
+# skip package versions published within this period (security feature)
+# accepts ms-style duration strings ("2d", "48h", "1 week") or a number of seconds
+# (disabled by default; 0 also disables)
+minimumReleaseAge = 259200 # or "3d"
 minimumReleaseAgeExcludes = ["@types/node", "typescript"]
 ```
 

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -744,12 +744,14 @@ Learn more about [using and writing security scanners](/pm/security-scanner-api)
 
 ### `install.minimumReleaseAge`
 
-Configure a minimum age (in seconds) for npm package versions. During installation, Bun filters out package versions published more recently than this threshold. Default `null` (disabled).
+Configure a minimum age for npm package versions. During installation, Bun filters out package versions published more recently than this threshold. Accepts either a number of seconds or an [`ms`](https://npmjs.com/package/ms)-style duration string like `"2d"`, `"1 week"`, or `"48h"`. Set to `0` to disable. Default `null` (disabled).
 
 ```toml title="bunfig.toml" icon="settings"
 [install]
 # Only install package versions published at least 3 days ago
-minimumReleaseAge = 259200
+minimumReleaseAge = "3d"
+# Or as a number of seconds:
+# minimumReleaseAge = 259200
 ```
 
 See [Minimum release age](/pm/cli/install#minimum-release-age).

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -1077,6 +1077,86 @@ pub fn parse_ascii<T: core::str::FromStr>(s: &[u8]) -> Option<T> {
         .ok()
 }
 
+/// npm `ms`-style duration (`"2d"`, `"1.5 hours"`, bare `"250"` = ms) to milliseconds.
+pub fn parse_ms(input: &[u8]) -> Option<f64> {
+    const MS_PER_S: f64 = crate::time::MS_PER_S as f64;
+    const MS_PER_MIN: f64 = 60.0 * MS_PER_S;
+    const MS_PER_HOUR: f64 = 60.0 * MS_PER_MIN;
+    const MS_PER_DAY: f64 = crate::time::MS_PER_DAY as f64;
+    const MS_PER_WEEK: f64 = 7.0 * MS_PER_DAY;
+    const MS_PER_YEAR: f64 = 365.25 * MS_PER_DAY;
+
+    let remaining = input.trim_ascii();
+    if remaining.is_empty() {
+        return None;
+    }
+    // The npm `ms` package caps input at 100 characters.
+    if remaining.len() > 100 {
+        return None;
+    }
+
+    let mut i: usize = 0;
+    if matches!(remaining[0], b'+' | b'-') {
+        i += 1;
+    }
+    let mut saw_digit = false;
+    while i < remaining.len() && remaining[i].is_ascii_digit() {
+        saw_digit = true;
+        i += 1;
+    }
+    if i < remaining.len() && remaining[i] == b'.' {
+        i += 1;
+        while i < remaining.len() && remaining[i].is_ascii_digit() {
+            saw_digit = true;
+            i += 1;
+        }
+    }
+    if !saw_digit {
+        return None;
+    }
+
+    let value = parse_f64(&remaining[..i])?;
+
+    let rest = remaining[i..].trim_ascii();
+
+    let mut unit_buf = [0u8; 16];
+    if rest.len() > unit_buf.len() {
+        return None;
+    }
+    for (j, &c) in rest.iter().enumerate() {
+        unit_buf[j] = match c {
+            b'A'..=b'Z' => c | 0x20,
+            b'a'..=b'z' => c,
+            _ => return None,
+        };
+    }
+    let unit = &unit_buf[..rest.len()];
+
+    let multiplier: f64 = match unit {
+        b"" => 1.0,
+        b"ms" | b"msec" | b"msecs" | b"millisecond" | b"milliseconds" => 1.0,
+        b"s" | b"sec" | b"secs" | b"second" | b"seconds" => MS_PER_S,
+        b"m" | b"min" | b"mins" | b"minute" | b"minutes" => MS_PER_MIN,
+        b"h" | b"hr" | b"hrs" | b"hour" | b"hours" => MS_PER_HOUR,
+        b"d" | b"day" | b"days" => MS_PER_DAY,
+        b"w" | b"week" | b"weeks" => MS_PER_WEEK,
+        b"y" | b"yr" | b"yrs" | b"year" | b"years" => MS_PER_YEAR,
+        _ => return None,
+    };
+
+    Some(value * multiplier)
+}
+
+/// [`parse_ms`] but a bare number means seconds; `None` if unparseable, non-finite or negative.
+pub fn parse_seconds_or_duration_ms(input: &[u8]) -> Option<f64> {
+    let input = input.trim_ascii();
+    let ms = match parse_f64(input) {
+        Some(secs) => secs * crate::time::MS_PER_S as f64,
+        None => parse_ms(input)?,
+    };
+    (ms.is_finite() && ms >= 0.0).then_some(ms)
+}
+
 // ───────────────────────────────────────────────────────────────────────────
 // Latin-1 formatting
 // ───────────────────────────────────────────────────────────────────────────

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1475,20 +1475,33 @@ impl<'a> Parser<'a> {
         if let Some(min_age) = install_obj.get(b"minimumReleaseAge") {
             match &min_age.data {
                 ExprData::ENumber(seconds) => {
-                    if seconds.value() < 0.0 {
+                    let secs = seconds.value();
+                    if !(secs.is_finite() && secs >= 0.0) {
                         self.add_error(
                             min_age.loc,
-                            b"Expected positive number of seconds for minimumReleaseAge",
+                            b"Expected a non-negative number of seconds for minimumReleaseAge (0 disables)",
                         )?;
                         return Ok(());
                     }
                     const MS_PER_S: f64 = bun_core::time::MS_PER_S as f64;
-                    install.minimum_release_age_ms = Some(seconds.value() * MS_PER_S);
+                    install.minimum_release_age_ms = Some(secs * MS_PER_S);
+                }
+                ExprData::EString(s) => {
+                    let Some(ms) =
+                        bun_core::fmt::parse_seconds_or_duration_ms(s.string(self.bump)?)
+                    else {
+                        self.add_error(
+                            min_age.loc,
+                            b"Expected a non-negative number of seconds or a duration like \"2d\" for minimumReleaseAge",
+                        )?;
+                        return Ok(());
+                    };
+                    install.minimum_release_age_ms = Some(ms);
                 }
                 _ => {
                     self.add_error(
                         min_age.loc,
-                        b"Expected number of seconds for minimumReleaseAge",
+                        b"Expected a number of seconds or a duration string for minimumReleaseAge",
                     )?;
                 }
             }

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -117,7 +117,7 @@ const SHARED_TAIL_PARAMS: &[ParamType] = &[
         "--linker <STR>                        Linker strategy (one of \"isolated\" or \"hoisted\")"
     ),
     clap::param!(
-        "--minimum-release-age <NUM>           Only install packages published at least N seconds ago (security feature)"
+        "--minimum-release-age <STR>           Skip package versions published within this period (e.g. \"2d\", \"1 week\", or a number of seconds)"
     ),
     clap::param!(
         "--cpu <STR>...                        Override CPU architecture for optional dependencies (e.g., x64, arm64, * for all)"
@@ -1299,26 +1299,15 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
             cli.save_text_lockfile = Some(true);
         }
 
-        if let Some(min_age_secs) = args.option(b"--minimum-release-age") {
-            let secs: f64 = match bun_core::parse_double(min_age_secs) {
-                Ok(s) => s,
-                Err(_) => {
-                    Output::err_generic(
-                        "Expected --minimum-release-age to be a positive number: {}",
-                        (bstr::BStr::new(min_age_secs),),
-                    );
-                    Global::crash();
-                }
-            };
-            if secs < 0.0 {
+        if let Some(min_age) = args.option(b"--minimum-release-age") {
+            let Some(ms) = bun_core::fmt::parse_seconds_or_duration_ms(min_age) else {
                 Output::err_generic(
-                    "Expected --minimum-release-age to be a positive number: {}",
-                    (bstr::BStr::new(min_age_secs),),
+                    "Expected --minimum-release-age to be a non-negative number of seconds or a duration like \"2d\": {}",
+                    (bstr::BStr::new(min_age),),
                 );
                 Global::crash();
-            }
-            const MS_PER_S: f64 = bun_core::time::MS_PER_S as f64;
-            cli.minimum_release_age_ms = Some(secs * MS_PER_S);
+            };
+            cli.minimum_release_age_ms = Some(ms);
         }
 
         let omit_values = args.options(b"--omit");

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1018,7 +1018,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                 dependency.behavior.is_required(),
                             ) {
                                 let needs_extended_manifest =
-                                    this.options.minimum_release_age_ms.is_some();
+                                    this.options.minimum_release_age_gate_ms().is_some();
                                 if this.options.enable.manifest_cache() {
                                     let mut expired = false;
                                     // SAFETY: `this_ptr` is the live exclusive
@@ -1062,7 +1062,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                                 )
                                             {
                                                 if let Some(min_age_ms) =
-                                                    this.options.minimum_release_age_ms
+                                                    this.options.minimum_release_age_gate_ms()
                                                 {
                                                     if !loaded_manifest
                                                         .as_ref()
@@ -2416,7 +2416,7 @@ fn get_or_put_resolved_package(
             // materializing `&mut *this_ptr` after `name_str`/`scope` are
             // derived from it would pop their borrow-stack tags under SB.
             let cache_ctx = this.manifest_disk_cache_ctx();
-            let needs_ext = this.options.minimum_release_age_ms.is_some();
+            let needs_ext = this.options.minimum_release_age_gate_ms().is_some();
             let this_ptr: *mut PackageManager = this;
             // SAFETY: `string_bytes` is not resized between here and the
             // `find_result` lookup; `manifest` lives in `this.manifests` and
@@ -2465,19 +2465,19 @@ fn get_or_put_resolved_package(
             let version_result: Npm::FindVersionResult = match version.tag {
                 _ if latest_for_target => manifest.find_by_dist_tag_with_filter(
                     b"latest",
-                    this.options.minimum_release_age_ms,
+                    this.options.minimum_release_age_gate_ms(),
                     this.options.minimum_release_age_excludes,
                 ),
                 // SAFETY: `version.tag` discriminates the union arm.
                 dependency::version::Tag::DistTag => manifest.find_by_dist_tag_with_filter(
                     this.lockfile.str(&version.dist_tag().tag),
-                    this.options.minimum_release_age_ms,
+                    this.options.minimum_release_age_gate_ms(),
                     this.options.minimum_release_age_excludes,
                 ),
                 dependency::version::Tag::Npm => manifest.find_best_version_with_filter(
                     &version.npm().version,
                     this.lockfile.buffers.string_bytes.as_slice(),
-                    this.options.minimum_release_age_ms,
+                    this.options.minimum_release_age_gate_ms(),
                     this.options.minimum_release_age_excludes,
                 ),
                 _ => unreachable!(),

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -84,8 +84,7 @@ pub struct Options {
     // Security scanner module path
     pub security_scanner: Option<&'static [u8]>,
 
-    // Minimum release age in ms (security feature)
-    // Only install packages published at least N ms ago
+    // `Some(0.0)` is "explicitly disabled"; consumers use `minimum_release_age_gate_ms()`.
     pub minimum_release_age_ms: Option<f64>,
     // Packages to exclude from minimum release age checking
     pub minimum_release_age_excludes: Option<&'static [&'static [u8]]>,
@@ -238,6 +237,11 @@ impl AuthType {
 impl Options {
     pub fn should_print_command_name(&self) -> bool {
         self.log_level != LogLevel::Silent && self.do_.contains(Do::SUMMARY)
+    }
+
+    /// `None` when unset or `0`: nothing to filter, so no extended (`time`-bearing) manifest either.
+    pub fn minimum_release_age_gate_ms(&self) -> Option<f64> {
+        self.minimum_release_age_ms.filter(|&ms| ms > 0.0)
     }
 
     /// Resolve the registry scope for a (possibly @-scoped) package name.

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -70,7 +70,7 @@ impl PackageManager {
                 if let Some(latest_version) = manifest
                     .find_by_dist_tag_with_filter(
                         b"latest",
-                        self.options.minimum_release_age_ms,
+                        self.options.minimum_release_age_gate_ms(),
                         self.options.minimum_release_age_excludes,
                     )
                     .unwrap()

--- a/src/install/PackageManager/PopulateManifestCache.rs
+++ b/src/install/PackageManager/PopulateManifestCache.rs
@@ -179,7 +179,8 @@ pub fn populate_manifest_cache(
                 let pkg_name_slice = pkg_name.slice(string_buf);
                 // `options` is not mutated between here and the
                 // `start_manifest_task` call — read via the BACKREF `mgr_ref`.
-                let needs_extended_manifest = mgr_ref.options.minimum_release_age_ms.is_some();
+                let needs_extended_manifest =
+                    mgr_ref.options.minimum_release_age_gate_ms().is_some();
 
                 // `scope_for_package_name` borrows only `options` (via the
                 // BACKREF `mgr_ref`); `manifests` is a disjoint field projected
@@ -238,7 +239,8 @@ pub fn populate_manifest_cache(
 
                     // `options` read via BACKREF `mgr_ref` — see provenance-root
                     // note above.
-                    let needs_extended_manifest = mgr_ref.options.minimum_release_age_ms.is_some();
+                    let needs_extended_manifest =
+                        mgr_ref.options.minimum_release_age_gate_ms().is_some();
                     let package_name = pkg_names[pkg_id as usize].slice(string_buf);
                     // See disjoint-field note on the `.All` arm above.
                     let scope =
@@ -280,7 +282,8 @@ pub fn populate_manifest_cache(
                     continue;
                 }
                 let package_name = pkg_names[pkg_id as usize].slice(string_buf);
-                let needs_extended_manifest = mgr_ref.options.minimum_release_age_ms.is_some();
+                let needs_extended_manifest =
+                    mgr_ref.options.minimum_release_age_gate_ms().is_some();
                 let scope =
                     bun_ptr::BackRef::new(mgr_ref.options.scope_for_package_name(package_name));
                 // SAFETY: `manifests` is disjoint from `options`/`lockfile`; `manager_ptr` is the SRW root.

--- a/src/install/audit_fix.rs
+++ b/src/install/audit_fix.rs
@@ -628,7 +628,7 @@ pub fn plan_fixes(manager: &mut PackageManager, advisories: &[Advisory]) -> crat
     let log_msgs = &mut manager.log_mut().msgs;
 
     let cache_ctx = manager.manifest_disk_cache_ctx();
-    let min_age = manager.options.minimum_release_age_ms;
+    let min_age = manager.options.minimum_release_age_gate_ms();
     let excludes = manager.options.minimum_release_age_excludes;
     let buf = manager.lockfile.buffers.string_bytes.as_slice();
 

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -801,7 +801,7 @@ pub(crate) fn warn_orphaned_patches(manager: &mut PackageManager) {
 /// Newest release the rows still resolving to `pkg_id` allow, when it is newer than the installed one.
 fn newest_allowed(manager: &mut PackageManager, pkg_id: PackageID) -> Option<Box<[u8]>> {
     let cache_ctx = manager.manifest_disk_cache_ctx();
-    let min_age = manager.options.minimum_release_age_ms;
+    let min_age = manager.options.minimum_release_age_gate_ms();
     let excludes = manager.options.minimum_release_age_excludes;
     let lockfile: &Lockfile = &manager.lockfile;
     let buf = lockfile.buffers.string_bytes.as_slice();
@@ -1132,7 +1132,7 @@ fn plan_edges(
     populate_manifest_cache::populate_manifest_cache(manager, Packages::Exact(&ids))?;
 
     let cache_ctx = manager.manifest_disk_cache_ctx();
-    let min_age = manager.options.minimum_release_age_ms;
+    let min_age = manager.options.minimum_release_age_gate_ms();
     let excludes = manager.options.minimum_release_age_excludes;
     let buf = manager.lockfile.buffers.string_bytes.as_slice();
     let pkg_names = manager.lockfile.packages.items_name();

--- a/src/runtime/cli/outdated_command.rs
+++ b/src/runtime/cli/outdated_command.rs
@@ -343,7 +343,7 @@ impl OutdatedCommand {
         // (`&mut manager.manifests` against `&manager.lockfile` /
         // `&manager.options`).
         let cache_ctx = manager.manifest_disk_cache_ctx();
-        let min_age_ms = manager.options.minimum_release_age_ms;
+        let min_age_ms = manager.options.minimum_release_age_gate_ms();
         let needs_extended = min_age_ms.is_some();
         let excludes = manager.options.minimum_release_age_excludes;
 

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -829,7 +829,7 @@ impl UpdateInteractiveCommand {
         // `&manager.options`). The returned `OutdatedPackage`s do *not*
         // borrow from `manager`, so the caller may keep using it afterwards.
         let cache_ctx = manager.manifest_disk_cache_ctx();
-        let min_age_ms = manager.options.minimum_release_age_ms;
+        let min_age_ms = manager.options.minimum_release_age_gate_ms();
         let needs_extended = min_age_ms.is_some();
         let excludes = manager.options.minimum_release_age_excludes;
         let update_to_latest = manager.options.do_.update_to_latest();

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -1373,6 +1373,81 @@ describe("minimum-release-age", () => {
       expect(lockfile).toContain("regular-package@3.0.0");
     });
 
+    test("0 is equivalent to unset: requests the abbreviated manifest, not the extended one", async () => {
+      // `minimumReleaseAge = 0` disables the filter, so it must behave exactly
+      // like leaving the option unset — including not forcing the full
+      // (extended, `time`-bearing) registry manifest for every package. Use a
+      // dedicated registry that records the Accept header for the manifest
+      // request so we can assert the abbreviated form was requested.
+      const acceptHeaders: string[] = [];
+      await using registry = Bun.serve({
+        port: 0,
+        fetch(req) {
+          const url = new URL(req.url);
+          if (url.pathname === "/regular-package") {
+            const accept = req.headers.get("accept") ?? "";
+            acceptHeaders.push(accept);
+            const base = `http://localhost:${registry.port}`;
+            const versions = {
+              "1.0.0": {
+                name: "regular-package",
+                version: "1.0.0",
+                dist: { tarball: `${base}/regular-package/-/regular-package-1.0.0.tgz`, integrity: "sha512-fake1==" },
+              },
+              "2.0.0": {
+                name: "regular-package",
+                version: "2.0.0",
+                dist: { tarball: `${base}/regular-package/-/regular-package-2.0.0.tgz`, integrity: "sha512-fake2==" },
+              },
+            };
+            const full = {
+              name: "regular-package",
+              "dist-tags": { latest: "2.0.0" },
+              versions,
+              time: { "1.0.0": daysAgo(30), "2.0.0": daysAgo(1) },
+            };
+            if (accept.includes("application/vnd.npm.install-v1+json")) {
+              return Response.json({ name: full.name, "dist-tags": full["dist-tags"], versions });
+            }
+            return Response.json(full);
+          }
+          if (url.pathname.includes(".tgz")) {
+            const m = url.pathname.match(/\/([^\/]+)\/-\/\1-([\d.]+).tgz/)!;
+            return new Response(createTarball(m[1], m[2]), {
+              headers: { "Content-Type": "application/octet-stream" },
+            });
+          }
+          return new Response("not found", { status: 404 });
+        },
+      });
+
+      using dir = tempDir("zero-abbreviated-manifest", {
+        "package.json": JSON.stringify({ dependencies: { "regular-package": "*" } }),
+        "bunfig.toml": `[install]\nminimumReleaseAge = 0\nregistry = "http://localhost:${registry.port}"`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--no-verify"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+
+      // With 0 (disabled), no version is filtered -> latest wins.
+      const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+      expect(lockfile).toContain("regular-package@2.0.0");
+
+      // The manifest must have been fetched, and every request for it must use
+      // the abbreviated Accept header — disabling via 0 must not pull the
+      // extended (`application/json`) manifest that the age filter requires.
+      expect(acceptHeaders.length).toBeGreaterThan(0);
+      expect(acceptHeaders.every(a => a.includes("application/vnd.npm.install-v1+json"))).toBe(true);
+    });
+
     test("CLI flag accepts ms-style duration string", async () => {
       using dir = tempDir("cli-ms-string", {
         "package.json": JSON.stringify({

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -1373,6 +1373,158 @@ describe("minimum-release-age", () => {
       expect(lockfile).toContain("regular-package@3.0.0");
     });
 
+    test("CLI flag accepts ms-style duration string", async () => {
+      using dir = tempDir("cli-ms-string", {
+        "package.json": JSON.stringify({
+          dependencies: { "regular-package": "*" },
+        }),
+        ".npmrc": `registry=${mockRegistryUrl}`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--minimum-release-age", "5d", "--no-verify"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+
+      const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+      // 5 days -> 2.1.0 (6 days old) passes, 3.0.0 (1 day old) blocked
+      expect(lockfile).toContain("regular-package@2.1.0");
+      expect(lockfile).not.toContain("regular-package@3.0.0");
+    });
+
+    test("CLI flag accepts ms-style duration string with space", async () => {
+      using dir = tempDir("cli-ms-string-space", {
+        "package.json": JSON.stringify({
+          dependencies: { "regular-package": "*" },
+        }),
+        ".npmrc": `registry=${mockRegistryUrl}`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--minimum-release-age", "1 week", "--no-verify"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+
+      const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+      // 7 days -> 2.0.0 (10 days old) passes, 2.1.0 (6 days) and 3.0.0 (1 day) blocked
+      expect(lockfile).toContain("regular-package@2.0.0");
+      expect(lockfile).not.toContain("regular-package@2.1.0");
+      expect(lockfile).not.toContain("regular-package@3.0.0");
+    });
+
+    test("CLI flag rejects invalid duration string", async () => {
+      using dir = tempDir("cli-ms-invalid", {
+        "package.json": JSON.stringify({
+          dependencies: { "regular-package": "*" },
+        }),
+        ".npmrc": `registry=${mockRegistryUrl}`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--minimum-release-age", "banana"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("--minimum-release-age");
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("bunfig accepts ms-style duration string", async () => {
+      using dir = tempDir("bunfig-ms-string", {
+        "package.json": JSON.stringify({
+          dependencies: { "regular-package": "*" },
+        }),
+        "bunfig.toml": `[install]
+minimumReleaseAge = "5 days"
+registry = "${mockRegistryUrl}"`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+
+      const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+      expect(lockfile).toContain("regular-package@2.1.0");
+      expect(lockfile).not.toContain("regular-package@3.0.0");
+    });
+
+    test("bunfig bare-number string is seconds (matches unquoted form)", async () => {
+      using dir = tempDir("bunfig-ms-bare", {
+        "package.json": JSON.stringify({
+          dependencies: { "regular-package": "*" },
+        }),
+        "bunfig.toml": `[install]
+minimumReleaseAge = "${5 * SECONDS_PER_DAY}"
+registry = "${mockRegistryUrl}"`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+
+      const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+      // "432000" as a string should be 5 days (seconds), same as unquoted 432000
+      expect(lockfile).toContain("regular-package@2.1.0");
+      expect(lockfile).not.toContain("regular-package@3.0.0");
+    });
+
+    test("bunfig rejects invalid duration string", async () => {
+      using dir = tempDir("bunfig-ms-invalid", {
+        "package.json": JSON.stringify({
+          dependencies: { "regular-package": "*" },
+        }),
+        "bunfig.toml": `[install]
+minimumReleaseAge = "nope"
+registry = "${mockRegistryUrl}"`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("minimumReleaseAge");
+      expect(exitCode).not.toBe(0);
+    });
+
     test("global bunfig.toml configuration works", async () => {
       // Create a fake home directory with global bunfig
       using globalConfigDir = tempDir("global-config", {
@@ -2182,6 +2334,32 @@ describe("minimum-release-age", () => {
       // Should fail with error about invalid value
       expect(exitCode).toBe(1);
       expect(stderr.toLowerCase()).toMatch(/invalid|error/);
+    });
+
+    // TOML floats include bare `inf` / `nan`; they must be rejected like the
+    // quoted and CLI spellings instead of blocking everything or silently
+    // disabling the filter.
+    test.each(["inf", "-inf", "nan"])("rejects bare %s in bunfig", async literal => {
+      using dir = tempDir("bunfig-non-finite-age", {
+        "package.json": JSON.stringify({
+          dependencies: { "regular-package": "*" },
+        }),
+        "bunfig.toml": `[install]
+minimumReleaseAge = ${literal}
+registry = "${mockRegistryUrl}"`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("Expected a non-negative number of seconds for minimumReleaseAge");
+      expect(exitCode).not.toBe(0);
     });
   });
 


### PR DESCRIPTION
## What

`bun install`'s minimum-release-age filter now accepts an [`ms`](https://npmjs.com/package/ms)-style duration string in addition to a bare number of seconds, for both the `--minimum-release-age` CLI flag and the `[install].minimumReleaseAge` bunfig key:

```bash
bun add @types/bun --minimum-release-age 3d     # or "1 week", "48h", ...
bun add @types/bun --minimum-release-age 259200 # still works (seconds)
```

```toml
[install]
minimumReleaseAge = "3d"   # or 259200 (seconds)
```

## How

Commit 1, duration strings:

- `bun_core::fmt::parse_ms()`: npm `ms`-style parser (`y`/`w`/`d`/`h`/`m`/`s`/`ms`, long and short spellings, case-insensitive).
- `bun_core::fmt::parse_seconds_or_duration_ms()`: trims, parses a bare number as seconds (back-compat), otherwise falls back to `parse_ms`, and rejects non-finite or negative input. Both the CLI flag and the bunfig string form call it, so the two spellings cannot drift.
- The bunfig number form now also rejects non-finite values (TOML allows bare `inf` / `nan`), so every spelling validates the same way. `0` disables the filter in every spelling.

Commit 2, `0` really means disabled:

- The option is stored as `Some(0.0)` when the user writes `0`, and the `.is_some()` checks that decide whether to fetch the extended (`time`-bearing) registry manifest still fired, so `0` downloaded full manifests for every package while filtering nothing.
- Added `Options::minimum_release_age_gate_ms()`, which returns `None` for both unset and `0`, and routed every consumer through it: the manifest-fetch gates (enqueue, manifest-cache population, resolution, `bun outdated`, `bun update -i`, transitive update, `bun audit --fix`), the values passed to the `npm.rs` version filters, and the exact-version too-recent check. The stored `Some(0.0)` is kept so CLI-overrides-bunfig merging still works.

## Stacked follow-up

#31613 adds `Bun.ms()` on top of this PR and reuses `parse_ms`. (The 2-day default, #31608, was closed: the registry's abbreviated manifest has no publish times, so a default would force full manifests for everyone.)

## Verification

- `test/cli/install/minimum-release-age.test.ts`: 59 pass / 0 fail on debug+ASAN. New cases cover duration strings (CLI and bunfig, with and without spaces), bare-number-is-seconds, invalid strings, bare `inf` / `-inf` / `nan` in bunfig, and `minimumReleaseAge = 0` requesting the abbreviated manifest.
- `cargo clippy` clean on `bun_core`, `bun_bunfig`, `bun_install`, `bun_runtime`; `rustfmt --check` clean.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 47 · 14 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/minimum-release-age.test.ts
bun test v1.4.0 (3421b76a3)

test/cli/install/minimum-release-age.test.ts:
(pass) minimum-release-age > basic filtering > filters packages by minimum release age [336.14ms]
(pass) minimum-release-age > basic filtering > respects float values for days [216.74ms]
(pass) minimum-release-age > basic filtering > handles exact version requests [196.04ms]
(pass) minimum-release-age > stability checks > detects rapid bugfixes and selects stable version [234.27ms]
(pass) minimum-release-age > stability checks > detects rapid bugfixes with dist-tag (latest) [175.36ms]
(pass) minimum-release-age > stability checks > gives up after searching 7 days beyond age gate [186.75ms]
(pass) minimum-release-age > prerelease handling > filters canary versions correctly [218.14ms]
(pass) minimum-release-age > prerelease handling > compares only base prerelease tag (canary vs beta) [184.28ms]
(pass) minimum-release-age > prerelease handling > handles latest with prerelease dist-tag [182.42ms]
(pass) minimum-release-
... (truncated)

release without fix: 8 FAILED
bun test v1.4.0-canary.1 (b7a043103)

test/cli/install/minimum-release-age.test.ts:
(pass) minimum-release-age > basic filtering > filters packages by minimum release age [11.23ms]
(pass) minimum-release-age > basic filtering > respects float values for days [5.10ms]
(pass) minimum-release-age > basic filtering > handles exact version requests [3.73ms]
(pass) minimum-release-age > stability checks > detects rapid bugfixes and selects stable version [7.69ms]
(pass) minimum-release-age > stability checks > detects rapid bugfixes with dist-tag (latest) [5.90ms]
(pass) minimum-release-age > stability checks > gives up after searching 7 days beyond age gate [6.71ms]
(pass) minimum-release-age > prerelease handling > filters canary versions correctly [5.66ms]
(pass) minimum-release-age > prerelease handling > compares only base prerelease tag (canary vs beta) [3.93ms]
(pass) minimum-release-age > prerelease handling > handles latest with prerelease dist-tag [4.10ms]
(pass) minimum-release-age > 7-day give-up threshold > stops searching after 7 days beyond minimum age [5.97ms]
(pass) minimum-release-age > 7-day give-up threshold > with daily releases, gets the latest withi
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/minimum-release-age.test.ts
bun test v1.4.0 (3421b76a3)

test/cli/install/minimum-release-age.test.ts:
(pass) minimum-release-age > basic filtering > filters packages by minimum release age [324.76ms]
(pass) minimum-release-age > basic filtering > respects float values for days [206.54ms]
(pass) minimum-release-age > basic filtering > handles exact version requests [163.63ms]
(pass) minimum-release-age > stability checks > detects rapid bugfixes and selects stable version [238.67ms]
(pass) minimum-release-age > stability checks > detects rapid bugfixes with dist-tag (latest) [177.17ms]
(pass) minimum-release-age > stability checks > gives up after searching 7 days beyond age gate [217.68ms]
(pass) minimum-release-age > prerelease handling > filters canary versions correctly [234.06ms]
(pass) minimum-release-age > prerelease handling > compares only base prerelease tag (canary vs beta) [250.34ms]
(pass) minimum-release-age > prerelease handling > handles latest with prerelease dist-tag [199.57ms]
(pass) minimum-release-
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     3421b76a31
  features     baseline

22 deps, 123 codegen, 1176 objects in 887ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [19.00ms]
[2/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [16.00ms]
[3/1238] gen ErrorCode+*.h
[4/1238] fetch zlib
[zlib] up to date
[5/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1238] gen bindgenv2
[7/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [11.00ms]
[8/1238] fetch tinycc
[tinycc] up to date
[9/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1237] gen .bind.ts → GeneratedBindings.cp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/pm/cli/install.mdx                            |  16 +-
 docs/runtime/bunfig.mdx                            |   6 +-
 src/bun_core/fmt.rs                                |  80 +++++++
 src/bunfig/bunfig.rs                               |  21 +-
 src/install/PackageManager/CommandLineArguments.rs |  25 +-
 .../PackageManager/PackageManagerEnqueue.rs        |  12 +-
 .../PackageManager/PackageManagerOptions.rs        |   8 +-
 .../PackageManager/PackageManagerResolution.rs     |   2 +-
 .../PackageManager/PopulateManifestCache.rs        |   9 +-
 src/install/audit_fix.rs                           |   2 +-
 src/install/update_transitive.rs                   |   4 +-
 src/runtime/cli/outdated_command.rs                |   2 +-
 src/runtime/cli/update_interactive_command.rs      |   2 +-
 test/cli/install/minimum-release-age.test.ts       | 253 +++++++++++++++++++++
 14 files changed, 396 insertions(+), 46 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 47

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
docs/pm/cli/install.mdx                                     7      9    120
docs/runtime/bunfig.mdx                                     5      5    121
src/bun_core/fmt.rs                                        13     19    124
src/bunfig/bunfig.rs                                       10     13    121
src/install/PackageManager/CommandLineArguments.rs          8      9    121
src/install/PackageManager/PackageManagerEnqueue.rs         6      8    120
src/install/PackageManager/PackageManagerOptions.rs         9      9    122
src/install/PackageManager/PackageManagerResolution.rs      1      1    120
src/install/PackageManager/PopulateManifestCache.rs         3      7    120
src/install/audit_fix.rs                                    1      1    120
src/install/update_transitive.rs                            1      1    120
src/runtime/cli/outdated_command.rs                         6      6    122
src/runtime/cli/update_interactive_command.rs               6      8    122
test/cli/install/minimum-release-age.test.ts               16     15    120
```

</details>

<!-- robobun:evidence:end -->