### PR TITLE
Add unix socket path for database connection

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -660,6 +660,9 @@ const sql = new SQL({
   username: "dbuser",
   password: "secretpass",
 
+  // Connect via unix socket
+  path: "/run/postgresql",
+
   // Connection pool settings
   max: 20, // Maximum connections in pool
   idleTimeout: 30, // Close idle connections after 30s


### PR DESCRIPTION
### What does this PR do?

Add a hint that you can use a "path" attribute to connect to PostgreSQL databases with unix sockets.  

It seems to be the only way to authenticate via the linux user you are logged in (avoiding password).

https://github.com/oven-sh/bun/issues/17617

### How did you verify your code works?

There is no code.
