### PR TITLE
Fix capacity under-reservation in ESMConditions.init

### DIFF
--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1087,9 +1087,10 @@ pub const ESMConditions = struct {
         var require_condition_map = ConditionsMap.init(allocator);
         var style_condition_map = ConditionsMap.init(allocator);
 
-        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
+        const addons_count = @as(usize, @intFromBool(allow_addons));
+        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + addons_count + conditions.len);
+        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + addons_count + conditions.len);
+        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + addons_count + conditions.len);
         try style_condition_map.ensureTotalCapacity(defaults.len + 2 + conditions.len);
 
         import_condition_map.putAssumeCapacity("import", {});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -649,6 +649,24 @@ describe("Bun.build", () => {
       expect(await html?.text()).toContain("<meta name='injected-by-plugin' content='true'>");
     },
   );
+
+  test("many conditions does not crash", async () => {
+    const dir = tempDirWithFiles("bun-build-many-conditions", {
+      "entry.js": "export const x = 1;",
+    });
+
+    for (const target of ["node", "bun", "browser"] as const) {
+      for (let count = 1; count <= 20; count++) {
+        const conditions = Array.from({ length: count }, (_, i) => `custom${i}`);
+        const result = await Bun.build({
+          entrypoints: [join(dir, "entry.js")],
+          target,
+          conditions,
+        });
+        expect(result.success).toBe(true);
+      }
+    }
+  });
 });
 
 test.concurrent("macro with nested object", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a debug assertion / out-of-bounds write in `Bun.build()` when passing several custom `conditions`.

In `ESMConditions.init`, the capacity reservation used:

```zig
defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len
```

which Zig parses as:

```zig
defaults.len + 2 + (if (allow_addons) 1 else (0 + conditions.len))
```

So when `allow_addons` is `true` (the default for `Bun.build`), `conditions.len` was dropped from the reservation entirely. The subsequent `putAssumeCapacity` calls would then exceed the backing `MultiArrayList` capacity once enough user conditions were supplied, tripping `assert(self.len < self.capacity)` in debug (and writing past the allocation in release).

Repro that crashes before this change:

```js
await Bun.build({
  entrypoints: ["./entry.js"],
  target: "node",
  conditions: ["a", "b", "c", "d", "e", "f", "g"],
});
```

## How did you verify your code works?

- Reproduced the assertion failure with the script above against the unpatched debug build.
- `bun bd test test/bundler/bun-build-api.test.ts` — all 39 pass + 1 todo, including the new `many conditions does not crash` test which sweeps 1–20 conditions across `node`/`bun`/`browser` targets.
- Verified the new test segfaults against the unpatched canary (`USE_SYSTEM_BUN=1`).
- `bun bd test test/bundler/esbuild/packagejson.test.ts -t Conditions` — existing conditions tests still pass.

Fuzzer fingerprint: `c9b09baffd7363d6`