### PR TITLE
init: scaffold bunfig.toml with minimumReleaseAge by default

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -33,6 +33,7 @@ Build a minimal HTTP server with `Bun.serve`, run it locally, then evolve it by 
     - .cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc -> CLAUDE.md
     - index.ts
     - tsconfig.json (for editor autocomplete)
+    - bunfig.toml
     - README.md
     ```
 

--- a/docs/runtime/templating/init.mdx
+++ b/docs/runtime/templating/init.mdx
@@ -24,6 +24,7 @@ bun init my-app
  + .cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc -> CLAUDE.md
  + index.ts
  + tsconfig.json (for editor autocomplete)
+ + bunfig.toml
  + README.md
 ```
 
@@ -41,6 +42,7 @@ It creates:
 
 - a `package.json` file with a name that defaults to the current directory name
 - a `tsconfig.json` file or a `jsconfig.json` file, depending if the entry point is a TypeScript file or not
+- a `bunfig.toml` file with [`minimumReleaseAge`](/pm/cli/install#minimum-release-age) enabled to protect against supply-chain attacks
 - an entry point which defaults to `index.ts` unless any of `index.{tsx, jsx, js, mts, mjs}` exist or the `package.json` specifies a `module` or `main` field
 - a `README.md` file
 

--- a/src/cli/init/bunfig.default.toml
+++ b/src/cli/init/bunfig.default.toml
@@ -3,7 +3,3 @@
 # versions published in the last 86400 seconds (1 day).
 # https://bun.com/docs/pm/cli/install#minimum-release-age
 minimumReleaseAge = 86400
-
-[serve.static]
-plugins = ["bun-plugin-tailwind"]
-env = "BUN_PUBLIC_*"

--- a/src/cli/init/react-app/bunfig.toml
+++ b/src/cli/init/react-app/bunfig.toml
@@ -1,2 +1,8 @@
+[install]
+# Protect against supply-chain attacks by rejecting package
+# versions published in the last 86400 seconds (1 day).
+# https://bun.com/docs/pm/cli/install#minimum-release-age
+minimumReleaseAge = 86400
+
 [serve.static]
 env = "BUN_PUBLIC_*"

--- a/src/cli/init/react-tailwind/bunfig.toml
+++ b/src/cli/init/react-tailwind/bunfig.toml
@@ -1,3 +1,8 @@
+[install]
+# Protect against supply-chain attacks by rejecting package
+# versions published in the last 86400 seconds (1 day).
+# https://bun.com/docs/pm/cli/install#minimum-release-age
+minimumReleaseAge = 86400
 
 [serve.static]
 plugins = ["bun-plugin-tailwind"]

--- a/src/cli/init_command.zig
+++ b/src/cli/init_command.zig
@@ -223,6 +223,7 @@ pub const InitCommand = struct {
         // "known" assets
         const @".gitignore" = @embedFile("init/gitignore.default");
         const @"tsconfig.json" = @embedFile("init/tsconfig.default.json");
+        const @"bunfig.toml" = @embedFile("init/bunfig.default.toml");
         const @"README.md" = @embedFile("init/README.default.md");
         const @"README2.md" = @embedFile("init/README2.default.md");
 
@@ -621,6 +622,7 @@ pub const InitCommand = struct {
             write_gitignore: bool,
             write_package_json: bool,
             write_tsconfig: bool,
+            write_bunfig: bool,
             write_readme: bool,
         };
 
@@ -628,10 +630,12 @@ pub const InitCommand = struct {
             .write_package_json = true,
             .write_tsconfig = true,
             .write_gitignore = !minimal,
+            .write_bunfig = !minimal,
             .write_readme = !minimal,
         };
 
         steps.write_gitignore = steps.write_gitignore and !existsZ(".gitignore");
+        steps.write_bunfig = steps.write_bunfig and !existsZ("bunfig.toml");
         steps.write_readme = steps.write_readme and !existsZ("README.md") and !existsZ("README") and !existsZ("README.txt") and !existsZ("README.mdx");
 
         steps.write_tsconfig = brk: {
@@ -820,6 +824,12 @@ pub const InitCommand = struct {
                             "jsconfig.json";
                         Assets.createFull("tsconfig.json", filename, " (for editor autocomplete)", false, .{}) catch break :brk;
                     }
+                }
+
+                if (steps.write_bunfig) {
+                    Assets.create("bunfig.toml", .{}) catch {
+                        // suppressed
+                    };
                 }
 
                 if (steps.write_readme) {

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -38,6 +38,7 @@ import path from "path";
     expect(fs.existsSync(path.join(temp, ".gitignore"))).toBe(true);
     expect(fs.existsSync(path.join(temp, "node_modules"))).toBe(true);
     expect(fs.existsSync(path.join(temp, "tsconfig.json"))).toBe(true);
+    expect(fs.existsSync(path.join(temp, "bunfig.toml"))).toBe(true);
   }, 30_000);
 
   test("bun init with piped cli", async () => {
@@ -74,6 +75,7 @@ import path from "path";
     expect(fs.existsSync(path.join(temp, ".gitignore"))).toBe(true);
     expect(fs.existsSync(path.join(temp, "node_modules"))).toBe(true);
     expect(fs.existsSync(path.join(temp, "tsconfig.json"))).toBe(true);
+    expect(fs.existsSync(path.join(temp, "bunfig.toml"))).toBe(true);
   }, 30_000);
 
   test("bun init in folder", async () => {
@@ -99,6 +101,7 @@ import path from "path";
       ".gitignore",
       "README.md",
       "bun.lock",
+      "bunfig.toml",
       "index.ts",
       "node_modules",
       "package.json",
@@ -138,6 +141,7 @@ import path from "path";
       ".gitignore",
       "README.md",
       "bun.lock",
+      "bunfig.toml",
       "index.ts",
       "node_modules",
       "package.json",
@@ -161,6 +165,7 @@ import path from "path";
       ".gitignore",
       "README.md",
       "bun.lock",
+      "bunfig.toml",
       "index.ts",
       "node_modules",
       "package.json",
@@ -170,6 +175,7 @@ import path from "path";
     await Bun.write(path.join(temp, "mydir/index.ts"), "my edited index.ts");
     await Bun.write(path.join(temp, "mydir/README.md"), "my edited README.md");
     await Bun.write(path.join(temp, "mydir/.gitignore"), "my edited .gitignore");
+    await Bun.write(path.join(temp, "mydir/bunfig.toml"), "# my edited bunfig.toml");
     await Bun.write(
       path.join(temp, "mydir/package.json"),
       JSON.stringify({
@@ -196,6 +202,7 @@ import path from "path";
       ".gitignore",
       "README.md",
       "bun.lock",
+      "bunfig.toml",
       "index.ts",
       "node_modules",
       "package.json",
@@ -205,6 +212,7 @@ import path from "path";
     expect(await Bun.file(path.join(temp, "mydir/index.ts")).text()).toMatchInlineSnapshot(`"my edited index.ts"`);
     expect(await Bun.file(path.join(temp, "mydir/README.md")).text()).toMatchInlineSnapshot(`"my edited README.md"`);
     expect(await Bun.file(path.join(temp, "mydir/.gitignore")).text()).toMatchInlineSnapshot(`"my edited .gitignore"`);
+    expect(await Bun.file(path.join(temp, "mydir/bunfig.toml")).text()).toMatchInlineSnapshot(`"# my edited bunfig.toml"`);
     expect(await Bun.file(path.join(temp, "mydir/package.json")).json()).toMatchInlineSnapshot(`
     {
       "devDependencies": {
@@ -324,5 +332,61 @@ import path from "path";
     expect(fs.existsSync(path.join(temp, "README.md"))).toBe(false);
     expect(fs.existsSync(path.join(temp, "CLAUDE.md"))).toBe(false);
     expect(fs.existsSync(path.join(temp, ".cursor"))).toBe(false);
+    expect(fs.existsSync(path.join(temp, "bunfig.toml"))).toBe(false);
   });
+
+  test("bun init writes bunfig.toml with minimumReleaseAge", async () => {
+    const temp = tempDirWithFiles("bun-init-bunfig", {});
+
+    const { exited } = Bun.spawn({
+      cmd: [bunExe(), "init", "-y"],
+      cwd: temp,
+      stdio: ["ignore", "inherit", "inherit"],
+      env: bunEnv,
+    });
+
+    expect(await exited).toBe(0);
+
+    const bunfig = fs.readFileSync(path.join(temp, "bunfig.toml"), "utf8");
+    expect(bunfig).toContain("[install]");
+    expect(bunfig).toContain("minimumReleaseAge");
+  }, 30_000);
+
+  test("bun init does not overwrite existing bunfig.toml", async () => {
+    const temp = tempDirWithFiles("bun-init-bunfig-exists", {
+      "bunfig.toml": "# existing\n",
+    });
+
+    const { exited } = Bun.spawn({
+      cmd: [bunExe(), "init", "-y"],
+      cwd: temp,
+      stdio: ["ignore", "inherit", "inherit"],
+      env: bunEnv,
+    });
+
+    expect(await exited).toBe(0);
+
+    const bunfig = fs.readFileSync(path.join(temp, "bunfig.toml"), "utf8");
+    expect(bunfig).toBe("# existing\n");
+  }, 30_000);
+
+  for (const flag of ["--react", "--react=tailwind", "--react=shadcn"]) {
+    test(`bun init ${flag} bunfig.toml has minimumReleaseAge`, async () => {
+      const temp = tempDirWithFiles(`bun-init-bunfig-${flag.replaceAll(/[^a-z]/g, "-")}`, {});
+
+      const { exited } = Bun.spawn({
+        cmd: [bunExe(), "init", flag],
+        cwd: temp,
+        stdio: ["ignore", "inherit", "inherit"],
+        env: bunEnv,
+      });
+
+      expect(await exited).toBe(0);
+
+      const bunfig = fs.readFileSync(path.join(temp, "bunfig.toml"), "utf8");
+      expect(bunfig).toContain("[install]");
+      expect(bunfig).toContain("minimumReleaseAge");
+      expect(bunfig).toContain("[serve.static]");
+    }, 30_000);
+  }
 });

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -212,7 +212,9 @@ import path from "path";
     expect(await Bun.file(path.join(temp, "mydir/index.ts")).text()).toMatchInlineSnapshot(`"my edited index.ts"`);
     expect(await Bun.file(path.join(temp, "mydir/README.md")).text()).toMatchInlineSnapshot(`"my edited README.md"`);
     expect(await Bun.file(path.join(temp, "mydir/.gitignore")).text()).toMatchInlineSnapshot(`"my edited .gitignore"`);
-    expect(await Bun.file(path.join(temp, "mydir/bunfig.toml")).text()).toMatchInlineSnapshot(`"# my edited bunfig.toml"`);
+    expect(await Bun.file(path.join(temp, "mydir/bunfig.toml")).text()).toMatchInlineSnapshot(
+      `"# my edited bunfig.toml"`,
+    );
     expect(await Bun.file(path.join(temp, "mydir/package.json")).json()).toMatchInlineSnapshot(`
     {
       "devDependencies": {

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -351,7 +351,7 @@ import path from "path";
 
     const bunfig = fs.readFileSync(path.join(temp, "bunfig.toml"), "utf8");
     expect(bunfig).toContain("[install]");
-    expect(bunfig).toContain("minimumReleaseAge");
+    expect(bunfig).toContain("minimumReleaseAge = 86400");
   }, 30_000);
 
   test("bun init does not overwrite existing bunfig.toml", async () => {
@@ -387,7 +387,7 @@ import path from "path";
 
       const bunfig = fs.readFileSync(path.join(temp, "bunfig.toml"), "utf8");
       expect(bunfig).toContain("[install]");
-      expect(bunfig).toContain("minimumReleaseAge");
+      expect(bunfig).toContain("minimumReleaseAge = 86400");
       expect(bunfig).toContain("[serve.static]");
     }, 30_000);
   }


### PR DESCRIPTION
## What

`bun init` now writes a `bunfig.toml` with `[install].minimumReleaseAge` enabled for all templates:

```toml
[install]
# Protect against supply-chain attacks by rejecting package
# versions published in the last 86400 seconds (1 day).
# https://bun.com/docs/pm/cli/install#minimum-release-age
minimumReleaseAge = 86400
```

- **Blank / Library**: new `bunfig.toml` is created (previously none was written)
- **React / Tailwind / Shadcn**: existing `bunfig.toml` templates gain the `[install]` section above their `[serve.static]` section
- **`--minimal`**: skipped, consistent with `.gitignore` / `README.md`
- An existing `bunfig.toml` is never overwritten

The file is written before the scaffolding `bun install` runs, so the initial install is also protected.

## How

- `src/cli/init/bunfig.default.toml` — new default asset
- `src/cli/init/react-{app,tailwind,shadcn}/bunfig.toml` — added `[install]` section
- `src/cli/init_command.zig` — register asset, add `write_bunfig` step (gated on `!minimal` and `!existsZ("bunfig.toml")`)
- `docs/runtime/templating/init.mdx`, `docs/quickstart.mdx` — list `bunfig.toml` in generated files

## Tests

`test/cli/init/init.test.ts` — 15 pass, 0 fail. New cases:

- `bun init` writes `bunfig.toml` containing `[install]` + `minimumReleaseAge`
- existing `bunfig.toml` is not overwritten
- `--minimal` does not create `bunfig.toml`
- `--react` / `--react=tailwind` / `--react=shadcn` bunfig includes both `[install]` and `[serve.static]`
- existing snapshot tests updated to include `bunfig.toml` in directory listings

## Notes

The default value is **86400 seconds (1 day)**. Happy to change to 2 days (aligning with #30529) or 3 days (matching the docs examples) — it's a one-line change to the template files.