### PR TITLE
bundler: fix ESMConditions capacity miscomputation with custom conditions

### DIFF
--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1087,9 +1087,9 @@ pub const ESMConditions = struct {
         var require_condition_map = ConditionsMap.init(allocator);
         var style_condition_map = ConditionsMap.init(allocator);
 
-        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
+        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + @as(usize, if (allow_addons) 1 else 0) + conditions.len);
+        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + @as(usize, if (allow_addons) 1 else 0) + conditions.len);
+        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + @as(usize, if (allow_addons) 1 else 0) + conditions.len);
         try style_condition_map.ensureTotalCapacity(defaults.len + 2 + conditions.len);
 
         import_condition_map.putAssumeCapacity("import", {});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -649,6 +649,21 @@ describe("Bun.build", () => {
       expect(await html?.text()).toContain("<meta name='injected-by-plugin' content='true'>");
     },
   );
+
+  test.concurrent("many custom conditions does not crash", async () => {
+    // The capacity reserved for the ESM conditions map was miscomputed when
+    // node-addons were enabled (the default), so enough custom conditions
+    // would overflow the reserved capacity and assert/corrupt.
+    const dir = tempDirWithFiles("bun-build-conditions", {
+      "entry.ts": `export const x = 1;`,
+    });
+    const build = await Bun.build({
+      entrypoints: [join(dir, "entry.ts")],
+      conditions: ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"],
+    });
+    expect(build.success).toBe(true);
+    expect(build.outputs).toHaveLength(1);
+  });
 });
 
 test.concurrent("macro with nested object", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes an operator precedence bug in `ESMConditions.init` that caused `Bun.build({ conditions: [...] })` to assert (debug) or potentially corrupt memory (release) when enough custom conditions were passed.

The capacity reservation used:

```zig
defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len
```

which in Zig parses as:

```zig
defaults.len + 2 + (if (allow_addons) 1 else (0 + conditions.len))
```

So when `allow_addons` is true (the default), `conditions.len` was dropped from the reserved capacity entirely. The subsequent `putAssumeCapacity` calls then overflowed the reservation once the user-provided conditions plus the built-in defaults exceeded the miscomputed capacity.

## How did you verify your code works?

Added a regression test in `test/bundler/bun-build-api.test.ts` that builds with 12 custom conditions. It asserts on the unfixed debug binary and passes after the fix.

Fuzzer fingerprint: `f0f7002504dcbd1d`