### PR TITLE
transpiler: emit v3 source map from transformSync / transform

### DIFF
--- a/docs/runtime/transpiler.mdx
+++ b/docs/runtime/transpiler.mdx
@@ -106,6 +106,8 @@ const x: number = 1;
 const parsed = JSON.parse(map); // { version: 3, sources: [...], mappings: "..." }
 ```
 
+---
+
 ## `.scan()`
 
 The `.scan()` method scans source code and returns a list of its imports and exports, plus metadata about each one. [Type-only](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export) imports and exports are ignored.

--- a/docs/runtime/transpiler.mdx
+++ b/docs/runtime/transpiler.mdx
@@ -15,7 +15,7 @@ const transpiler = new Bun.Transpiler({
 
 ## `.transformSync()`
 
-Transpile code synchronously with the `.transformSync()` method. The transpiler does not resolve modules or execute the code. The result is a string of vanilla JavaScript code.
+Transpile code synchronously with the `.transformSync()` method. The transpiler does not resolve modules or execute the code. The result is a string of vanilla JavaScript code, unless the transpiler was constructed with `sourcemap: "external"` or `"linked"`, in which case it is a `{ code, map }` object — see [Source maps](#source-maps).
 
 <CodeGroup>
 ```ts transpile.ts icon="/icons/typescript.svg" 
@@ -62,7 +62,7 @@ transpiler.transformSync("<div>hi!</div>", "tsx");
 
 ## `.transform()`
 
-The `transform()` method is an async version of `.transformSync()` that returns a `Promise<string>`.
+The `transform()` method is an async version of `.transformSync()` that returns a `Promise<string>` (or a `Promise<{ code, map }>` when `sourcemap` is `"external"` or `"linked"` — see [Source maps](#source-maps)).
 
 ```js
 const transpiler = new Bun.Transpiler({ loader: "jsx" });
@@ -83,6 +83,28 @@ The `.transform()` method runs the transpiler in Bun's worker threadpool, so run
 If your code uses a macro, the transpiler may spawn a new copy of Bun's JavaScript runtime environment in that new thread.
 
 </Accordion>
+
+---
+
+## Source maps
+
+Pass the `sourcemap` option to emit a v3 source map alongside the transpiled code. The modes mirror [`Bun.build`](/bundler#sourcemap):
+
+- `"none"` / `false` (default) — no source map; `transformSync` / `transform` return a plain `string`.
+- `"inline"` / `true` — a base64-encoded map is appended to the returned code as a `//# sourceMappingURL=data:application/json;base64,…` footer. Still returns a `string`.
+- `"external"` — returns `{ code, map }`. `map` is the v3 source map as JSON text; the code has no `sourceMappingURL` footer.
+- `"linked"` — returns `{ code, map }`. The code also carries a `//# sourceMappingURL=<name>.map` comment so you can write a sibling `.map` file.
+
+```ts
+const transpiler = new Bun.Transpiler({ loader: "ts", sourcemap: "external" });
+
+const { code, map } = transpiler.transformSync(`
+interface Props { title: string }
+const x: number = 1;
+`);
+
+const parsed = JSON.parse(map); // { version: 3, sources: [...], mappings: "..." }
+```
 
 ## `.scan()`
 
@@ -226,6 +248,12 @@ interface TranspilerOptions {
   // Typically improves performance and decreases bundle size
   // Default: false
   inline?: boolean,
+
+  // Emit a v3 source map alongside the transpiled code
+  // "external" and "linked" change the return type of
+  // transform/transformSync to { code, map }
+  // Default: "none"
+  sourcemap?: "none" | "inline" | "external" | "linked" | boolean,
 }
 
 // Map import paths to macros
@@ -243,8 +271,10 @@ interface MacroMap {
 class Bun.Transpiler {
   constructor(options: TranspilerOptions)
 
-  transform(code: string, loader?: Loader): Promise<string>
-  transformSync(code: string, loader?: Loader): string
+  // Returns { code: string, map: string } instead of a string when the
+  // transpiler was constructed with sourcemap: "external" or "linked"
+  transform(code: string, loader?: Loader): Promise<string | { code: string, map: string }>
+  transformSync(code: string, loader?: Loader): string | { code: string, map: string }
 
   scan(code: string): {exports: string[], imports: Import[]}
   scanImports(code: string): Import[]

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2931,7 +2931,17 @@ declare module "bun" {
     };
   }
 
-  interface TranspilerOptions {
+  /**
+   * Values the `sourcemap` constructor option can take.
+   *
+   * Used as a generic parameter on {@link Transpiler} so the return type of
+   * `transformSync` / `transform` narrows to `string` or
+   * {@link TranspilerTransformResult} based on whether the transpiler is
+   * configured to return an external map.
+   */
+  type TranspilerSourceMapOption = "none" | "inline" | "external" | "linked" | boolean;
+
+  interface TranspilerOptions<SM extends TranspilerSourceMapOption = "none"> {
     /**
      * Replace key with value. Value must be a JSON string.
      * @example
@@ -3065,7 +3075,7 @@ declare module "bun" {
      *
      * @default "none"
      */
-    sourcemap?: "none" | "inline" | "external" | "linked" | boolean;
+    sourcemap?: SM;
   }
 
   /**
@@ -3105,8 +3115,18 @@ declare module "bun" {
     map: string;
   }
 
-  class Transpiler {
-    constructor(options?: TranspilerOptions);
+  /**
+   * Picks the return type for `transform` / `transformSync` based on the
+   * transpiler's `sourcemap` configuration. Only `"external"` and `"linked"`
+   * produce the `{ code, map }` object; every other mode stays a plain
+   * `string` so existing callers keep their current typing.
+   */
+  type TranspilerTransformReturn<SM extends TranspilerSourceMapOption> = SM extends "external" | "linked"
+    ? TranspilerTransformResult
+    : string;
+
+  class Transpiler<const SM extends TranspilerSourceMapOption = "none"> {
+    constructor(options?: TranspilerOptions<SM>);
 
     /**
      * Transpile code from TypeScript or JSX into valid JavaScript.
@@ -3122,7 +3142,7 @@ declare module "bun" {
     transform(
       code: Bun.StringOrBuffer,
       loader?: JavaScriptLoader,
-    ): Promise<string | TranspilerTransformResult>;
+    ): Promise<TranspilerTransformReturn<SM>>;
     /**
      * Transpile code from TypeScript or JSX into valid JavaScript.
      * This function does not resolve imports.
@@ -3132,14 +3152,14 @@ declare module "bun" {
       code: Bun.StringOrBuffer,
       loader: JavaScriptLoader,
       ctx: object,
-    ): string | TranspilerTransformResult;
+    ): TranspilerTransformReturn<SM>;
     /**
      * Transpile code from TypeScript or JSX into valid JavaScript.
      * This function does not resolve imports.
      * @param code The code to transpile
      * @param ctx An object to pass to macros
      */
-    transformSync(code: Bun.StringOrBuffer, ctx: object): string | TranspilerTransformResult;
+    transformSync(code: Bun.StringOrBuffer, ctx: object): TranspilerTransformReturn<SM>;
 
     /**
      * Transpile code from TypeScript or JSX into valid JavaScript.
@@ -3155,7 +3175,7 @@ declare module "bun" {
     transformSync(
       code: Bun.StringOrBuffer,
       loader?: JavaScriptLoader,
-    ): string | TranspilerTransformResult;
+    ): TranspilerTransformReturn<SM>;
 
     /**
      * Get a list of import paths and paths from a TypeScript, JSX, TSX, or JavaScript file.

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3048,6 +3048,24 @@ declare module "bun" {
      * @default false
      */
     replMode?: boolean;
+
+    /**
+     * Emit a v3 source map alongside the transpiled code.
+     *
+     * - `"none"` / `false` (default) — no source map; `transformSync` /
+     *   `transform` return a plain `string`.
+     * - `"inline"` / `true` — a base64-encoded v3 map is appended to the
+     *   returned code as a `//# sourceMappingURL=data:application/json;base64,…`
+     *   footer. Still returns a `string`.
+     * - `"external"` — returns `{ code, map }`. The returned code has no
+     *   `sourceMappingURL` footer; `map` is the v3 map as JSON text.
+     * - `"linked"` — returns `{ code, map }`. The returned code carries a
+     *   `//# sourceMappingURL=<name>.map` comment so the caller can write
+     *   a sibling map file.
+     *
+     * @default "none"
+     */
+    sourcemap?: "none" | "inline" | "external" | "linked" | boolean;
   }
 
   /**
@@ -3070,35 +3088,74 @@ declare module "bun" {
    * ```
    */
 
+  /**
+   * The shape returned by `Bun.Transpiler.transform` / `transformSync` when
+   * the transpiler is configured with `sourcemap: "external"` or
+   * `sourcemap: "linked"`. The `map` field holds a v3 source map as JSON
+   * text — callers typically `JSON.parse(result.map)` to work with it.
+   *
+   * For `sourcemap: "inline"` (and its `true` alias), the map is base64-
+   * encoded into a `//# sourceMappingURL=data:application/json;base64,…`
+   * footer on the returned string and no object is produced.
+   *
+   * For `sourcemap: "none"` (the default), a plain string is returned.
+   */
+  interface TranspilerTransformResult {
+    code: string;
+    map: string;
+  }
+
   class Transpiler {
     constructor(options?: TranspilerOptions);
 
     /**
      * Transpile code from TypeScript or JSX into valid JavaScript.
      * This function does not resolve imports.
+     *
+     * Returns a `string` when the transpiler's `sourcemap` option is unset,
+     * `false`, `"none"`, `"inline"`, or `true`. Returns
+     * `{ code, map }` (a {@link TranspilerTransformResult}) when `sourcemap`
+     * is `"external"` or `"linked"`.
+     *
      * @param code The code to transpile
      */
-    transform(code: Bun.StringOrBuffer, loader?: JavaScriptLoader): Promise<string>;
+    transform(
+      code: Bun.StringOrBuffer,
+      loader?: JavaScriptLoader,
+    ): Promise<string | TranspilerTransformResult>;
     /**
      * Transpile code from TypeScript or JSX into valid JavaScript.
      * This function does not resolve imports.
      * @param code The code to transpile
      */
-    transformSync(code: Bun.StringOrBuffer, loader: JavaScriptLoader, ctx: object): string;
+    transformSync(
+      code: Bun.StringOrBuffer,
+      loader: JavaScriptLoader,
+      ctx: object,
+    ): string | TranspilerTransformResult;
     /**
      * Transpile code from TypeScript or JSX into valid JavaScript.
      * This function does not resolve imports.
      * @param code The code to transpile
      * @param ctx An object to pass to macros
      */
-    transformSync(code: Bun.StringOrBuffer, ctx: object): string;
+    transformSync(code: Bun.StringOrBuffer, ctx: object): string | TranspilerTransformResult;
 
     /**
      * Transpile code from TypeScript or JSX into valid JavaScript.
      * This function does not resolve imports.
+     *
+     * Returns a `string` when the transpiler's `sourcemap` option is unset,
+     * `false`, `"none"`, `"inline"`, or `true`. Returns
+     * `{ code, map }` (a {@link TranspilerTransformResult}) when `sourcemap`
+     * is `"external"` or `"linked"`.
+     *
      * @param code The code to transpile
      */
-    transformSync(code: Bun.StringOrBuffer, loader?: JavaScriptLoader): string;
+    transformSync(
+      code: Bun.StringOrBuffer,
+      loader?: JavaScriptLoader,
+    ): string | TranspilerTransformResult;
 
     /**
      * Get a list of import paths and paths from a TypeScript, JSX, TSX, or JavaScript file.

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3079,26 +3079,6 @@ declare module "bun" {
   }
 
   /**
-   * Quickly transpile TypeScript, JSX, or JS to modern JavaScript.
-   *
-   * @example
-   * ```js
-   * const transpiler = new Bun.Transpiler();
-   * transpiler.transformSync(`
-   *   const App = () => <div>Hello World</div>;
-   * export default App;
-   * `);
-   * // This outputs:
-   * const output = `
-   * const App = () => jsx("div", {
-   *   children: "Hello World"
-   * }, undefined, false, undefined, this);
-   * export default App;
-   * `
-   * ```
-   */
-
-  /**
    * The shape returned by `Bun.Transpiler.transform` / `transformSync` when
    * the transpiler is configured with `sourcemap: "external"` or
    * `sourcemap: "linked"`. The `map` field holds a v3 source map as JSON
@@ -3125,6 +3105,25 @@ declare module "bun" {
     ? TranspilerTransformResult
     : string;
 
+  /**
+   * Quickly transpile TypeScript, JSX, or JS to modern JavaScript.
+   *
+   * @example
+   * ```js
+   * const transpiler = new Bun.Transpiler();
+   * transpiler.transformSync(`
+   *   const App = () => <div>Hello World</div>;
+   * export default App;
+   * `);
+   * // This outputs:
+   * const output = `
+   * const App = () => jsx("div", {
+   *   children: "Hello World"
+   * }, undefined, false, undefined, this);
+   * export default App;
+   * `
+   * ```
+   */
   class Transpiler<const SM extends TranspilerSourceMapOption = "none"> {
     constructor(options?: TranspilerOptions<SM>);
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2941,7 +2941,7 @@ declare module "bun" {
    */
   type TranspilerSourceMapOption = "none" | "inline" | "external" | "linked" | boolean;
 
-  interface TranspilerOptions<SM extends TranspilerSourceMapOption = "none"> {
+  interface TranspilerOptions<SM extends TranspilerSourceMapOption = TranspilerSourceMapOption> {
     /**
      * Replace key with value. Value must be a JSON string.
      * @example

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3139,20 +3139,13 @@ declare module "bun" {
      *
      * @param code The code to transpile
      */
-    transform(
-      code: Bun.StringOrBuffer,
-      loader?: JavaScriptLoader,
-    ): Promise<TranspilerTransformReturn<SM>>;
+    transform(code: Bun.StringOrBuffer, loader?: JavaScriptLoader): Promise<TranspilerTransformReturn<SM>>;
     /**
      * Transpile code from TypeScript or JSX into valid JavaScript.
      * This function does not resolve imports.
      * @param code The code to transpile
      */
-    transformSync(
-      code: Bun.StringOrBuffer,
-      loader: JavaScriptLoader,
-      ctx: object,
-    ): TranspilerTransformReturn<SM>;
+    transformSync(code: Bun.StringOrBuffer, loader: JavaScriptLoader, ctx: object): TranspilerTransformReturn<SM>;
     /**
      * Transpile code from TypeScript or JSX into valid JavaScript.
      * This function does not resolve imports.
@@ -3172,10 +3165,7 @@ declare module "bun" {
      *
      * @param code The code to transpile
      */
-    transformSync(
-      code: Bun.StringOrBuffer,
-      loader?: JavaScriptLoader,
-    ): TranspilerTransformReturn<SM>;
+    transformSync(code: Bun.StringOrBuffer, loader?: JavaScriptLoader): TranspilerTransformReturn<SM>;
 
     /**
      * Get a list of import paths and paths from a TypeScript, JSX, TSX, or JavaScript file.

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -1725,7 +1725,7 @@ impl SourceMapCapture {
     /// no AST to print (e.g. `parse_result.empty`) but the caller still
     /// asked for a source map. Matches the JSON shape
     /// `print_source_map_contents` produces for a zero-mapping chunk.
-    pub fn write_empty(&mut self, source: &bun_ast::Source) -> Result<(), bun_core::Error> {
+    pub fn write_empty(&mut self, source: &bun_ast::Source) -> Result<(), bun_sourcemap::Error> {
         let empty_chunk = bun_sourcemap::Chunk::init_empty();
         // An empty chunk's buffer is zero-length in either format, so
         // `print_source_map_contents` works regardless of `is_internal_format`.
@@ -1738,7 +1738,7 @@ impl JSPrinter::OnSourceMapChunk for SourceMapCapture {
         &mut self,
         chunk: bun_sourcemap::Chunk,
         source: &bun_ast::Source,
-    ) -> Result<(), bun_core::Error> {
+    ) -> JSPrinter::Result<()> {
         if self.is_internal_format {
             // `target: "bun"` routes through the printer's
             // `is_bun_platform=true` path which stores mappings as Bun's
@@ -1749,6 +1749,7 @@ impl JSPrinter::OnSourceMapChunk for SourceMapCapture {
         } else {
             chunk.print_source_map_contents::<false>(source, &mut self.json, true)
         }
+        .map_err(|_| JSPrinter::Error::WriteFailed)
     }
 }
 

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -873,7 +873,7 @@ impl TransformTask {
                 self.output_code = BunString::clone_utf8(buffer_writer.buffer.list.as_slice());
             }
             api::SourceMapMode::Linked => {
-                let mut map_name_buf = bun_paths::PathBuffer::uninit();
+                let mut map_name_buf = [0u8; 32];
                 let map_name = source_map_url_for(source_path, &mut map_name_buf);
                 bun_core::handle_oom(buffer_writer.buffer.append(b"\n//# sourceMappingURL="));
                 bun_core::handle_oom(buffer_writer.buffer.append(map_name));
@@ -1680,7 +1680,7 @@ fn build_transform_result(
             // Append a `//# sourceMappingURL=<source>.map` comment so the
             // emitted code references a sibling `.map` file the caller is
             // expected to write.
-            let mut map_name_buf = bun_paths::PathBuffer::uninit();
+            let mut map_name_buf = [0u8; 32];
             let map_name = source_map_url_for(source_path, &mut map_name_buf);
             bun_core::handle_oom(buffer_writer.buffer.append(b"\n//# sourceMappingURL="));
             bun_core::handle_oom(buffer_writer.buffer.append(map_name));
@@ -1756,10 +1756,11 @@ impl JSPrinter::OnSourceMapChunk for SourceMapCapture {
 /// `source_path` is the virtual file name we gave the parser (e.g.
 /// `input.ts`); we just append `.map` — the caller knows what to do with
 /// it. Falls back to `input.map` if we're handed an empty path.
-fn source_map_url_for<'buf>(
-    source_path: &[u8],
-    buf: &'buf mut bun_paths::PathBuffer,
-) -> &'buf [u8] {
+///
+/// `source_path` is always `Loader::stdin_name()` (longest: `input.json5`),
+/// so the output never exceeds 15 bytes — callers pass a small fixed buffer,
+/// not a `PathBuffer`.
+fn source_map_url_for<'buf>(source_path: &[u8], buf: &'buf mut [u8]) -> &'buf [u8] {
     let base: &[u8] = if source_path.is_empty() {
         b"input"
     } else {
@@ -1767,11 +1768,10 @@ fn source_map_url_for<'buf>(
     };
     const SUFFIX: &[u8] = b".map";
     let total = base.len() + SUFFIX.len();
-    let slot = buf.as_mut_slice();
-    debug_assert!(total <= slot.len());
-    slot[..base.len()].copy_from_slice(base);
-    slot[base.len()..total].copy_from_slice(SUFFIX);
-    &slot[..total]
+    debug_assert!(total <= buf.len());
+    buf[..base.len()].copy_from_slice(base);
+    buf[base.len()..total].copy_from_slice(SUFFIX);
+    &buf[..total]
 }
 
 /// Append `\n//# sourceMappingURL=data:application/json;base64,<base64>\n`

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -934,8 +934,8 @@ impl TransformTask {
             .into_js(global)
             .and_then(|code_js| {
                 let map_js = core::mem::take(&mut self.output_map).into_js(global)?;
-                let code_key = ZigString::static_(b"code");
-                let map_key = ZigString::static_(b"map");
+                let code_key = bun_core::EncodedSlice::latin1(b"code");
+                let map_key = bun_core::EncodedSlice::latin1(b"map");
                 JSValue::create_object2(global, &code_key, &map_key, code_js, map_js)
             });
         promise.settle(global, result)
@@ -1657,17 +1657,12 @@ fn build_transform_result(
 ) -> JsResult<JSValue> {
     match source_map_mode {
         api::SourceMapMode::None => {
-            let mut out = JscZigString::init(buffer_writer.buffer.list.as_slice());
-            out.set_output_encoding();
-            Ok(out.to_js(global))
+            bun_string_jsc::create_utf8_for_js(global, buffer_writer.buffer.list.as_slice())
         }
         api::SourceMapMode::Inline => {
             // Append the inline footer to the printer's buffer before the final copy.
             append_inline_source_map(&mut buffer_writer.buffer, capture.json.list.as_slice());
-
-            let mut out = JscZigString::init(buffer_writer.buffer.list.as_slice());
-            out.set_output_encoding();
-            Ok(out.to_js(global))
+            bun_string_jsc::create_utf8_for_js(global, buffer_writer.buffer.list.as_slice())
         }
         api::SourceMapMode::Linked => {
             // Reference a sibling `.map` file the caller is expected to write.
@@ -1767,20 +1762,12 @@ fn create_code_map_object(
     code_bytes: &[u8],
     map_bytes: &[u8],
 ) -> JsResult<JSValue> {
-    let mut code_zig = JscZigString::init(code_bytes);
-    code_zig.set_output_encoding();
-    let mut map_zig = JscZigString::init(map_bytes);
-    map_zig.set_output_encoding();
+    let code_js = bun_string_jsc::create_utf8_for_js(global, code_bytes)?;
+    let map_js = bun_string_jsc::create_utf8_for_js(global, map_bytes)?;
 
-    let code_key = ZigString::static_(b"code");
-    let map_key = ZigString::static_(b"map");
-    JSValue::create_object2(
-        global,
-        &code_key,
-        &map_key,
-        code_zig.to_js(global),
-        map_zig.to_js(global),
-    )
+    let code_key = bun_core::EncodedSlice::latin1(b"code");
+    let map_key = bun_core::EncodedSlice::latin1(b"map");
+    JSValue::create_object2(global, &code_key, &map_key, code_js, map_js)
 }
 
 fn named_exports_to_js(

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -698,7 +698,10 @@ impl TransformTask {
             input_code,
             output_code: BunString::EMPTY,
             output_map: BunString::EMPTY,
-            source_map: config.transform.source_map.unwrap_or(api::SourceMapMode::None),
+            source_map: config
+                .transform
+                .source_map
+                .unwrap_or(api::SourceMapMode::None),
             transpiler: transpiler_copy,
             macro_map: clone_macro_map(&config.macro_map),
             tsconfig: config
@@ -1627,8 +1630,13 @@ impl JSTranspiler {
 
         // TODO: benchmark if pooling this way is faster or moving is faster
         buffer_writer = printer.ctx;
-        let result =
-            build_transform_result(global, source_map_mode, &mut buffer_writer, &capture, source_path);
+        let result = build_transform_result(
+            global,
+            source_map_mode,
+            &mut buffer_writer,
+            &capture,
+            source_path,
+        );
         self.buffer_writer.set(Some(buffer_writer));
         result
     }
@@ -1792,7 +1800,13 @@ fn create_code_map_object(
 
     let code_key = ZigString::static_(b"code");
     let map_key = ZigString::static_(b"map");
-    JSValue::create_object2(global, &code_key, &map_key, code_zig.to_js(global), map_zig.to_js(global))
+    JSValue::create_object2(
+        global,
+        &code_key,
+        &map_key,
+        code_zig.to_js(global),
+        map_zig.to_js(global),
+    )
 }
 
 fn named_exports_to_js(

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -635,12 +635,10 @@ impl Config {
 pub(crate) struct TransformTask {
     pub input_code: ThreadIsolated<StringOrBuffer<'static>>,
     pub output_code: BunString,
-    /// Populated when `source_map != None` — a v3 JSON map string. Empty
-    /// otherwise. For `.inline`, the map is embedded in `output_code`
-    /// already and this field stays empty.
+    /// v3 JSON map for `.external` / `.linked`; empty otherwise
+    /// (`.inline` embeds the map in `output_code`).
     pub output_map: BunString,
-    /// Copied from the owning `JSTranspiler.Config` at task-create time so
-    /// the background thread doesn't race with config mutation.
+    /// Sourcemap mode snapshotted from the config at task creation.
     pub source_map: api::SourceMapMode,
     pub transpiler: core::mem::ManuallyDrop<Transpiler::Transpiler<'static>>,
     pub log: bun_ast::Log,
@@ -1263,11 +1261,8 @@ impl JSTranspiler {
         macro_js_ctx: MacroJSCtx,
     ) -> Option<ParseResult<'static>> {
         let config = self.config.get();
-        // Use the per-call loader (when provided) for the virtual source
-        // name, matching `TransformTask::run()`'s use of the override.
-        // The name ends up in `source.path.text` and flows into the v3
-        // map's `sources` array and the `//# sourceMappingURL=<name>.map`
-        // footer, so sync and async must agree on it for the same input.
+        // Use the per-call loader for the virtual source name so the sync and
+        // async paths emit the same map `sources` / footer for the same input.
         let name = loader.unwrap_or(config.default_loader).stdin_name();
 
         // In REPL mode, wrap potential object literals in parentheses
@@ -1667,9 +1662,7 @@ fn build_transform_result(
             Ok(out.to_js(global))
         }
         api::SourceMapMode::Inline => {
-            // Append `//# sourceMappingURL=data:application/json;base64,<map>`
-            // to the printed code. We reuse the printer's buffer so the
-            // footer lives alongside the code for the final string copy.
+            // Append the inline footer to the printer's buffer before the final copy.
             append_inline_source_map(&mut buffer_writer.buffer, capture.json.list.as_slice());
 
             let mut out = JscZigString::init(buffer_writer.buffer.list.as_slice());
@@ -1677,9 +1670,7 @@ fn build_transform_result(
             Ok(out.to_js(global))
         }
         api::SourceMapMode::Linked => {
-            // Append a `//# sourceMappingURL=<source>.map` comment so the
-            // emitted code references a sibling `.map` file the caller is
-            // expected to write.
+            // Reference a sibling `.map` file the caller is expected to write.
             let mut map_name_buf = [0u8; 32];
             let map_name = source_map_url_for(source_path, &mut map_name_buf);
             bun_core::handle_oom(buffer_writer.buffer.append(b"\n//# sourceMappingURL="));
@@ -1705,11 +1696,8 @@ fn build_transform_result(
 pub struct SourceMapCapture {
     /// v3 JSON map filled in by `on_source_map_chunk`.
     pub json: bun_core::MutableString,
-    /// `true` when the transpiler is targeting `bun`, which flips the
-    /// printer's sourcemap builder into the packed `InternalSourceMap`
-    /// format (see `getSourceMapBuilder` in js_printer). In that case
-    /// we must re-encode the chunk buffer from internal → VLQ before
-    /// emitting the v3 JSON map.
+    /// `target: "bun"` makes the printer emit packed `InternalSourceMap`
+    /// chunks instead of VLQ; those are re-encoded before JSON emission.
     pub is_internal_format: bool,
 }
 
@@ -1721,14 +1709,10 @@ impl SourceMapCapture {
         }
     }
 
-    /// Emit a valid but empty v3 map for `source` — used when there is
-    /// no AST to print (e.g. `parse_result.empty`) but the caller still
-    /// asked for a source map. Matches the JSON shape
-    /// `print_source_map_contents` produces for a zero-mapping chunk.
+    /// Emit a valid empty v3 map for `source` (no AST to print).
     pub fn write_empty(&mut self, source: &bun_ast::Source) -> Result<(), bun_sourcemap::Error> {
         let empty_chunk = bun_sourcemap::Chunk::init_empty();
-        // An empty chunk's buffer is zero-length in either format, so
-        // `print_source_map_contents` works regardless of `is_internal_format`.
+        // A zero-length buffer is valid in either chunk format.
         empty_chunk.print_source_map_contents::<false>(source, &mut self.json, true)
     }
 }
@@ -1740,11 +1724,7 @@ impl JSPrinter::OnSourceMapChunk for SourceMapCapture {
         source: &bun_ast::Source,
     ) -> JSPrinter::Result<()> {
         if self.is_internal_format {
-            // `target: "bun"` routes through the printer's
-            // `is_bun_platform=true` path which stores mappings as Bun's
-            // packed binary format in `chunk.buffer` instead of VLQ.
-            // `print_source_map_contents_from_internal` re-encodes to
-            // VLQ before emitting JSON so the result is a valid v3 map.
+            // Re-encode the packed internal chunk to VLQ first.
             chunk.print_source_map_contents_from_internal::<false>(source, &mut self.json, true)
         } else {
             chunk.print_source_map_contents::<false>(source, &mut self.json, true)
@@ -1753,14 +1733,9 @@ impl JSPrinter::OnSourceMapChunk for SourceMapCapture {
     }
 }
 
-/// Derive a `<source>.map` filename for the `sourceMappingURL` comment.
-/// `source_path` is the virtual file name we gave the parser (e.g.
-/// `input.ts`); we just append `.map` — the caller knows what to do with
-/// it. Falls back to `input.map` if we're handed an empty path.
-///
-/// `source_path` is always `Loader::stdin_name()` (longest: `input.json5`),
-/// so the output never exceeds 15 bytes — callers pass a small fixed buffer,
-/// not a `PathBuffer`.
+/// Append `.map` to the virtual source name (`input.ts` → `input.ts.map`,
+/// empty → `input.map`). The name is always `Loader::stdin_name()` (max 11
+/// bytes), so callers pass a small fixed buffer.
 fn source_map_url_for<'buf>(source_path: &[u8], buf: &'buf mut [u8]) -> &'buf [u8] {
     let base: &[u8] = if source_path.is_empty() {
         b"input"
@@ -1775,13 +1750,9 @@ fn source_map_url_for<'buf>(source_path: &[u8], buf: &'buf mut [u8]) -> &'buf [u
     &buf[..total]
 }
 
-/// Append `\n//# sourceMappingURL=data:application/json;base64,<base64>\n`
-/// to `buf`. Shared by the sync and async transform paths. The trailing
-/// newline matches both the `.linked` branch in this file and
-/// `Bun.build`'s inline emitter (src/bundler/linker_context/
-/// generateChunksInParallel), so two inline outputs can be safely
-/// concatenated without the second one being swallowed by the line
-/// comment.
+/// Append `\n//# sourceMappingURL=data:application/json;base64,<map>\n`.
+/// The trailing newline matches `Bun.build`'s inline emitter so concatenated
+/// outputs aren't swallowed by the line comment.
 fn append_inline_source_map(buf: &mut bun_core::MutableString, map_json: &[u8]) {
     const PREFIX: &[u8] = b"\n//# sourceMappingURL=data:application/json;base64,";
     let encode_len = bun_core::base64::encode_len(map_json);

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -635,6 +635,13 @@ impl Config {
 pub(crate) struct TransformTask {
     pub input_code: ThreadIsolated<StringOrBuffer<'static>>,
     pub output_code: BunString,
+    /// Populated when `source_map != None` — a v3 JSON map string. Empty
+    /// otherwise. For `.inline`, the map is embedded in `output_code`
+    /// already and this field stays empty.
+    pub output_map: BunString,
+    /// Copied from the owning `JSTranspiler.Config` at task-create time so
+    /// the background thread doesn't race with config mutation.
+    pub source_map: api::SourceMapMode,
     pub transpiler: core::mem::ManuallyDrop<Transpiler::Transpiler<'static>>,
     pub log: bun_ast::Log,
     pub err: Option<Error>,
@@ -690,6 +697,8 @@ impl TransformTask {
         let task = TransformTask {
             input_code,
             output_code: BunString::EMPTY,
+            output_map: BunString::EMPTY,
+            source_map: config.transform.source_map.unwrap_or(api::SourceMapMode::None),
             transpiler: transpiler_copy,
             macro_map: clone_macro_map(&config.macro_map),
             tsconfig: config
@@ -798,11 +807,15 @@ impl TransformTask {
             return;
         };
 
-        if parse_result.empty {
+        let want_source_map = self.source_map != api::SourceMapMode::None;
+
+        // Empty parse and no map requested: keep the legacy empty-string fast path.
+        if parse_result.empty && !want_source_map {
             self.output_code = BunString::EMPTY;
             return;
         }
 
+        let source_path = parse_result.source.path.text;
         let mut buffer_writer = JSPrinter::BufferWriter::init();
         buffer_writer
             .buffer
@@ -811,27 +824,64 @@ impl TransformTask {
         buffer_writer.reset();
 
         let mut printer = JSPrinter::BufferPrinter::init(buffer_writer);
-        // Same per-call `arena` that `set_arena(&arena)` and `parse()` used.
-        let printed = match self.transpiler.print(
-            &arena,
-            parse_result,
-            &mut printer,
-            Transpiler::transpiler::PrintFormat::EsmAscii,
-        ) {
-            Ok(n) => n,
-            Err(err) => {
+
+        let mut capture = SourceMapCapture::new(self.transpiler.options.target.is_bun());
+
+        if !parse_result.empty {
+            if want_source_map {
+                let handler = JSPrinter::SourceMapHandler::for_(&mut capture);
+                if let Err(err) = self.transpiler.print_with_source_map(
+                    &arena,
+                    parse_result,
+                    &mut printer,
+                    Transpiler::transpiler::PrintFormat::EsmAscii,
+                    handler,
+                    None,
+                ) {
+                    self.err = Some(err.into());
+                    return;
+                }
+            } else if let Err(err) = self.transpiler.print(
+                &arena,
+                parse_result,
+                &mut printer,
+                Transpiler::transpiler::PrintFormat::EsmAscii,
+            ) {
                 self.err = Some(err.into());
                 return;
             }
-        };
-
-        if printed > 0 {
-            buffer_writer = printer.ctx;
-            // `written()` reslices via `written_len`; copy out the printed
-            // bytes, then the local writer is dropped.
-            self.output_code = BunString::clone_utf8(buffer_writer.written());
         } else {
-            self.output_code = BunString::EMPTY;
+            // No AST to print, but a map was requested: emit a valid empty v3 map.
+            if let Err(err) = capture.write_empty(&parse_result.source) {
+                self.err = Some(err.into());
+                return;
+            }
+        }
+
+        // Reclaim the writer from the printer; its buffer holds the printed bytes.
+        buffer_writer = printer.ctx;
+
+        match self.source_map {
+            api::SourceMapMode::None => {
+                self.output_code = BunString::clone_utf8(buffer_writer.buffer.list.as_slice());
+            }
+            api::SourceMapMode::Inline => {
+                append_inline_source_map(&mut buffer_writer.buffer, capture.json.list.as_slice());
+                self.output_code = BunString::clone_utf8(buffer_writer.buffer.list.as_slice());
+            }
+            api::SourceMapMode::Linked => {
+                let mut map_name_buf = bun_paths::PathBuffer::uninit();
+                let map_name = source_map_url_for(source_path, &mut map_name_buf);
+                bun_core::handle_oom(buffer_writer.buffer.append(b"\n//# sourceMappingURL="));
+                bun_core::handle_oom(buffer_writer.buffer.append(map_name));
+                bun_core::handle_oom(buffer_writer.buffer.append_char(b'\n'));
+                self.output_code = BunString::clone_utf8(buffer_writer.buffer.list.as_slice());
+                self.output_map = BunString::clone_utf8(capture.json.list.as_slice());
+            }
+            api::SourceMapMode::External => {
+                self.output_code = BunString::clone_utf8(buffer_writer.buffer.list.as_slice());
+                self.output_map = BunString::clone_utf8(capture.json.list.as_slice());
+            }
         }
     }
 
@@ -866,10 +916,28 @@ impl TransformTask {
     }
 
     fn finish(&mut self, promise: &mut JSPromise, global: &JSGlobalObject) -> JsResult<()> {
-        promise.settle(
-            global,
-            core::mem::take(&mut self.output_code).into_js(global),
-        )
+        // Branch on the mode, not `output_map.is_empty()`: `.external` /
+        // `.linked` must return `{ code, map }` even for empty inputs.
+        let returns_object = matches!(
+            self.source_map,
+            api::SourceMapMode::External | api::SourceMapMode::Linked,
+        );
+        if !returns_object {
+            return promise.settle(
+                global,
+                core::mem::take(&mut self.output_code).into_js(global),
+            );
+        }
+
+        let result = core::mem::take(&mut self.output_code)
+            .into_js(global)
+            .and_then(|code_js| {
+                let map_js = core::mem::take(&mut self.output_map).into_js(global)?;
+                let code_key = ZigString::static_(b"code");
+                let map_key = ZigString::static_(b"map");
+                JSValue::create_object2(global, &code_key, &map_key, code_js, map_js)
+            });
+        promise.settle(global, result)
     }
 }
 
@@ -1192,7 +1260,12 @@ impl JSTranspiler {
         macro_js_ctx: MacroJSCtx,
     ) -> Option<ParseResult<'static>> {
         let config = self.config.get();
-        let name = config.default_loader.stdin_name();
+        // Use the per-call loader (when provided) for the virtual source
+        // name, matching `TransformTask::run()`'s use of the override.
+        // The name ends up in `source.path.text` and flows into the v3
+        // map's `sources` array and the `//# sourceMappingURL=<name>.map`
+        // footer, so sync and async must agree on it for the same input.
+        let name = loader.unwrap_or(config.default_loader).stdin_name();
 
         // In REPL mode, wrap potential object literals in parentheses
         // If code starts with { and doesn't end with ; it might be an object literal
@@ -1512,24 +1585,214 @@ impl JSTranspiler {
 
         buffer_writer.reset();
         let mut printer = JSPrinter::BufferPrinter::init(buffer_writer);
-        // SAFETY: see `transpiler_mut` — `print` does not re-enter JS.
-        // Same per-call `arena` that `set_arena(&arena)` and `parse()` used.
-        if let Err(err) = unsafe { self.transpiler_mut() }.print(
-            &arena,
-            parse_result,
-            &mut printer,
-            Transpiler::transpiler::PrintFormat::EsmAscii,
-        ) {
+
+        let source_map_mode = self
+            .config
+            .get()
+            .transform
+            .source_map
+            .unwrap_or(api::SourceMapMode::None);
+        let want_source_map = source_map_mode != api::SourceMapMode::None;
+        let is_bun_target = self.transpiler.get().options.target.is_bun();
+
+        let source_path = parse_result.source.path.text;
+
+        let mut capture = SourceMapCapture::new(is_bun_target);
+
+        // SAFETY: see `transpiler_mut` — `print`/`print_with_source_map` do
+        // not re-enter JS. Same per-call `arena` that `set_arena(&arena)` /
+        // `parse()` used.
+        let print_result = if want_source_map {
+            let handler = JSPrinter::SourceMapHandler::for_(&mut capture);
+            unsafe { self.transpiler_mut() }.print_with_source_map(
+                &arena,
+                parse_result,
+                &mut printer,
+                Transpiler::transpiler::PrintFormat::EsmAscii,
+                handler,
+                None,
+            )
+        } else {
+            unsafe { self.transpiler_mut() }.print(
+                &arena,
+                parse_result,
+                &mut printer,
+                Transpiler::transpiler::PrintFormat::EsmAscii,
+            )
+        };
+        if let Err(err) = print_result {
             self.buffer_writer.set(Some(printer.ctx));
             return Err(global.throw_error(err, "Failed to print code"));
         }
 
         // TODO: benchmark if pooling this way is faster or moving is faster
         buffer_writer = printer.ctx;
-        let result = bun_string_jsc::create_utf8_for_js(global, buffer_writer.written());
+        let result =
+            build_transform_result(global, source_map_mode, &mut buffer_writer, &capture, source_path);
         self.buffer_writer.set(Some(buffer_writer));
         result
     }
+}
+
+/// Produces the JS value returned from `transformSync` / `transform`.
+///
+/// - `sourcemap` unset / `None`           → a `string` (current behaviour)
+/// - `sourcemap: "inline"` / `true`       → a `string` with a trailing
+///   `//# sourceMappingURL=data:application/json;base64,...` footer
+/// - `sourcemap: "external"` / `"linked"` → `{ code: string, map: string }`
+///   where `map` is the v3 JSON map text. For `"linked"`, `code` also has
+///   a `//# sourceMappingURL=<source>.map` footer so downstream writers
+///   can produce the sibling `.map` file.
+fn build_transform_result(
+    global: &JSGlobalObject,
+    source_map_mode: api::SourceMapMode,
+    buffer_writer: &mut JSPrinter::BufferWriter,
+    capture: &SourceMapCapture,
+    source_path: &[u8],
+) -> JsResult<JSValue> {
+    match source_map_mode {
+        api::SourceMapMode::None => {
+            let mut out = JscZigString::init(buffer_writer.buffer.list.as_slice());
+            out.set_output_encoding();
+            Ok(out.to_js(global))
+        }
+        api::SourceMapMode::Inline => {
+            // Append `//# sourceMappingURL=data:application/json;base64,<map>`
+            // to the printed code. We reuse the printer's buffer so the
+            // footer lives alongside the code for the final string copy.
+            append_inline_source_map(&mut buffer_writer.buffer, capture.json.list.as_slice());
+
+            let mut out = JscZigString::init(buffer_writer.buffer.list.as_slice());
+            out.set_output_encoding();
+            Ok(out.to_js(global))
+        }
+        api::SourceMapMode::Linked => {
+            // Append a `//# sourceMappingURL=<source>.map` comment so the
+            // emitted code references a sibling `.map` file the caller is
+            // expected to write.
+            let mut map_name_buf = bun_paths::PathBuffer::uninit();
+            let map_name = source_map_url_for(source_path, &mut map_name_buf);
+            bun_core::handle_oom(buffer_writer.buffer.append(b"\n//# sourceMappingURL="));
+            bun_core::handle_oom(buffer_writer.buffer.append(map_name));
+            bun_core::handle_oom(buffer_writer.buffer.append_char(b'\n'));
+
+            create_code_map_object(
+                global,
+                buffer_writer.buffer.list.as_slice(),
+                capture.json.list.as_slice(),
+            )
+        }
+        api::SourceMapMode::External => create_code_map_object(
+            global,
+            buffer_writer.buffer.list.as_slice(),
+            capture.json.list.as_slice(),
+        ),
+    }
+}
+
+/// Captures the printer's source map chunk so we can emit a v3 JSON map
+/// from the synchronous and asynchronous transform paths.
+pub struct SourceMapCapture {
+    /// v3 JSON map filled in by `on_source_map_chunk`.
+    pub json: bun_core::MutableString,
+    /// `true` when the transpiler is targeting `bun`, which flips the
+    /// printer's sourcemap builder into the packed `InternalSourceMap`
+    /// format (see `getSourceMapBuilder` in js_printer). In that case
+    /// we must re-encode the chunk buffer from internal → VLQ before
+    /// emitting the v3 JSON map.
+    pub is_internal_format: bool,
+}
+
+impl SourceMapCapture {
+    pub fn new(is_internal_format: bool) -> Self {
+        Self {
+            json: bun_core::MutableString::init_empty(),
+            is_internal_format,
+        }
+    }
+
+    /// Emit a valid but empty v3 map for `source` — used when there is
+    /// no AST to print (e.g. `parse_result.empty`) but the caller still
+    /// asked for a source map. Matches the JSON shape
+    /// `print_source_map_contents` produces for a zero-mapping chunk.
+    pub fn write_empty(&mut self, source: &bun_ast::Source) -> Result<(), bun_core::Error> {
+        let empty_chunk = bun_sourcemap::Chunk::init_empty();
+        // An empty chunk's buffer is zero-length in either format, so
+        // `print_source_map_contents` works regardless of `is_internal_format`.
+        empty_chunk.print_source_map_contents::<false>(source, &mut self.json, true)
+    }
+}
+
+impl JSPrinter::OnSourceMapChunk for SourceMapCapture {
+    fn on_source_map_chunk(
+        &mut self,
+        chunk: bun_sourcemap::Chunk,
+        source: &bun_ast::Source,
+    ) -> Result<(), bun_core::Error> {
+        if self.is_internal_format {
+            // `target: "bun"` routes through the printer's
+            // `is_bun_platform=true` path which stores mappings as Bun's
+            // packed binary format in `chunk.buffer` instead of VLQ.
+            // `print_source_map_contents_from_internal` re-encodes to
+            // VLQ before emitting JSON so the result is a valid v3 map.
+            chunk.print_source_map_contents_from_internal::<false>(source, &mut self.json, true)
+        } else {
+            chunk.print_source_map_contents::<false>(source, &mut self.json, true)
+        }
+    }
+}
+
+/// Derive a `<source>.map` filename for the `sourceMappingURL` comment.
+/// `source_path` is the virtual file name we gave the parser (e.g.
+/// `input.ts`); we just append `.map` — the caller knows what to do with
+/// it. Falls back to `input.map` if we're handed an empty path.
+fn source_map_url_for<'buf>(
+    source_path: &[u8],
+    buf: &'buf mut bun_paths::PathBuffer,
+) -> &'buf [u8] {
+    let base: &[u8] = if source_path.is_empty() {
+        b"input"
+    } else {
+        source_path
+    };
+    const SUFFIX: &[u8] = b".map";
+    let total = base.len() + SUFFIX.len();
+    let slot = buf.as_mut_slice();
+    debug_assert!(total <= slot.len());
+    slot[..base.len()].copy_from_slice(base);
+    slot[base.len()..total].copy_from_slice(SUFFIX);
+    &slot[..total]
+}
+
+/// Append `\n//# sourceMappingURL=data:application/json;base64,<base64>\n`
+/// to `buf`. Shared by the sync and async transform paths. The trailing
+/// newline matches both the `.linked` branch in this file and
+/// `Bun.build`'s inline emitter (src/bundler/linker_context/
+/// generateChunksInParallel), so two inline outputs can be safely
+/// concatenated without the second one being swallowed by the line
+/// comment.
+fn append_inline_source_map(buf: &mut bun_core::MutableString, map_json: &[u8]) {
+    const PREFIX: &[u8] = b"\n//# sourceMappingURL=data:application/json;base64,";
+    let encode_len = bun_core::base64::encode_len(map_json);
+    let dest = bun_core::handle_oom(buf.writable_n_bytes(PREFIX.len() + encode_len + 1));
+    dest[..PREFIX.len()].copy_from_slice(PREFIX);
+    bun_core::base64::encode(&mut dest[PREFIX.len()..PREFIX.len() + encode_len], map_json);
+    dest[PREFIX.len() + encode_len] = b'\n';
+}
+
+fn create_code_map_object(
+    global: &JSGlobalObject,
+    code_bytes: &[u8],
+    map_bytes: &[u8],
+) -> JsResult<JSValue> {
+    let mut code_zig = JscZigString::init(code_bytes);
+    code_zig.set_output_encoding();
+    let mut map_zig = JscZigString::init(map_bytes);
+    map_zig.set_output_encoding();
+
+    let code_key = ZigString::static_(b"code");
+    let map_key = ZigString::static_(b"map");
+    JSValue::create_object2(global, &code_key, &map_key, code_zig.to_js(global), map_zig.to_js(global))
 }
 
 fn named_exports_to_js(

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -1602,11 +1602,11 @@ impl JSTranspiler {
 
         let mut capture = SourceMapCapture::new(is_bun_target);
 
-        // SAFETY: see `transpiler_mut` — `print`/`print_with_source_map` do
-        // not re-enter JS. Same per-call `arena` that `set_arena(&arena)` /
-        // `parse()` used.
         let print_result = if want_source_map {
             let handler = JSPrinter::SourceMapHandler::for_(&mut capture);
+            // SAFETY: see `transpiler_mut` — `print_with_source_map` does not
+            // re-enter JS. Same per-call `arena` that `set_arena(&arena)` /
+            // `parse()` used.
             unsafe { self.transpiler_mut() }.print_with_source_map(
                 &arena,
                 parse_result,
@@ -1616,6 +1616,8 @@ impl JSTranspiler {
                 None,
             )
         } else {
+            // SAFETY: see `transpiler_mut` — `print` does not re-enter JS.
+            // Same per-call `arena` that `set_arena(&arena)` / `parse()` used.
             unsafe { self.transpiler_mut() }.print(
                 &arena,
                 parse_result,

--- a/src/sourcemap/Chunk.rs
+++ b/src/sourcemap/Chunk.rs
@@ -47,6 +47,21 @@ impl Chunk {
         unsafe { core::ptr::read(self) }
     }
 
+    /// `chunk.buffer` holds a VLQ "mappings" string; emit the v3 JSON map.
+    pub fn print_source_map_contents<const ASCII_ONLY: bool>(
+        &self,
+        source: &Source,
+        mutable: &mut MutableString,
+        include_sources_contents: bool,
+    ) -> Result<(), crate::Error> {
+        print_source_map_contents_json::<ASCII_ONLY>(
+            source,
+            mutable,
+            include_sources_contents,
+            self.buffer.list.as_slice(),
+        )
+    }
+
     /// `chunk.buffer` holds an InternalSourceMap blob (the runtime path). Re-encode
     /// to a standard VLQ "mappings" string before emitting JSON.
     pub fn print_source_map_contents_from_internal<const ASCII_ONLY: bool>(

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -6148,7 +6148,14 @@ const y: number = 10;`;
       let shift = 0;
       let cont = true;
       while (cont) {
-        const digit = charset.indexOf(seg[offset++]);
+        const ch = seg[offset++];
+        const digit = charset.indexOf(ch);
+        if (digit === -1) {
+          // Fail fast on malformed VLQ. Without this guard, (digit & 32)
+          // stays truthy for `-1` and we loop forever — a test assertion
+          // failure would manifest as a CI hang, not a useful error.
+          throw new Error(`Invalid VLQ digit ${JSON.stringify(ch)} in segment ${JSON.stringify(seg)} at offset ${offset - 1}`);
+        }
         cont = (digit & 32) !== 0;
         value += (digit & 31) << shift;
         shift += 5;
@@ -6201,13 +6208,11 @@ const y: number = 10;`;
     expect(out).not.toContain("sourceMappingURL");
   });
 
-  it("returns a plain string when sourcemap is false or 'none'", () => {
-    for (const value of [false, "none"]) {
-      const t = new Bun.Transpiler({ loader: "ts", sourcemap: value });
-      const out = t.transformSync(input);
-      expect(typeof out).toBe("string");
-      expect(out).not.toContain("sourceMappingURL");
-    }
+  it.each([false, "none"])("returns a plain string when sourcemap is %p", value => {
+    const t = new Bun.Transpiler({ loader: "ts", sourcemap: value });
+    const out = t.transformSync(input);
+    expect(typeof out).toBe("string");
+    expect(out).not.toContain("sourceMappingURL");
   });
 
   it("'inline' appends a data URL and returns a string", () => {
@@ -6344,51 +6349,48 @@ const y: number = 10;`;
   // `.d.ts`-style sources) and empty inputs produce zero output bytes.
   // The documented contract for `sourcemap: "external"` / `"linked"` is
   // `{ code, map }` regardless, and the sync and async paths must agree.
-  const emptyInputs = [
-    { name: "empty input", src: "" },
-    { name: "type-only input", src: "interface Foo { x: number }" },
-  ];
-
-  for (const { name, src } of emptyInputs) {
-    it(`'external' returns { code, map } for ${name} (sync)`, () => {
-      const t = new Bun.Transpiler({ loader: "ts", sourcemap: "external" });
+  describe.each([
+    ["empty input", ""],
+    ["type-only input", "interface Foo { x: number }"],
+  ])("%s", (_name, src) => {
+    it.each(["external", "linked"])("'%s' returns { code, map } (sync)", mode => {
+      const t = new Bun.Transpiler({ loader: "ts", sourcemap: mode });
       const out = t.transformSync(src);
       expect(typeof out).toBe("object");
-      expect(out.code).toBe("");
+      expect(out.code.replace(/\n\/\/# sourceMappingURL=.*/s, "")).toBe("");
       expect(typeof out.map).toBe("string");
       const map = JSON.parse(out.map);
       expect(map).toMatchObject({ version: 3, sources: ["/input.ts"] });
     });
 
-    it(`'external' returns { code, map } for ${name} (async)`, async () => {
-      const t = new Bun.Transpiler({ loader: "ts", sourcemap: "external" });
-      const out = await t.transform(src);
+    it.each(["external", "linked"])("'%s' returns { code, map } (async)", async mode => {
       // Pre-fix, the async path silently fell back to `""` for empty
       // output while the sync path returned `{ code, map }` — see
       // oven-sh/bun#30540 review.
+      const t = new Bun.Transpiler({ loader: "ts", sourcemap: mode });
+      const out = await t.transform(src);
       expect(typeof out).toBe("object");
-      expect(out.code).toBe("");
       expect(typeof out.map).toBe("string");
       const map = JSON.parse(out.map);
       expect(map).toMatchObject({ version: 3, sources: ["/input.ts"] });
     });
 
-    it(`'linked' returns { code, map } for ${name} (async)`, async () => {
-      const t = new Bun.Transpiler({ loader: "ts", sourcemap: "linked" });
-      const out = await t.transform(src);
-      expect(typeof out).toBe("object");
-      expect(out.code).toMatch(/\/\/# sourceMappingURL=[^\s]+\.map/);
-      expect(typeof out.map).toBe("string");
+    it("'inline' returns a string with a trailing newline (sync)", () => {
+      const t = new Bun.Transpiler({ loader: "ts", sourcemap: "inline" });
+      const out = t.transformSync(src);
+      expect(typeof out).toBe("string");
+      expect(out).toContain("//# sourceMappingURL=data:application/json;base64,");
+      expect(out.endsWith("\n")).toBe(true);
     });
 
-    it(`'inline' returns a string with a trailing newline for ${name} (async)`, async () => {
+    it("'inline' returns a string with a trailing newline (async)", async () => {
       const t = new Bun.Transpiler({ loader: "ts", sourcemap: "inline" });
       const out = await t.transform(src);
       expect(typeof out).toBe("string");
       expect(out).toContain("//# sourceMappingURL=data:application/json;base64,");
       expect(out.endsWith("\n")).toBe(true);
     });
-  }
+  });
 
   // Sync and async must agree on the synthetic source filename even
   // when the caller passes a per-call loader that differs from the
@@ -6414,5 +6416,38 @@ const y: number = 10;`;
     const asyncFooter = async_.code.match(/sourceMappingURL=[^\s]+/)?.[0];
     expect(syncFooter).toBe(asyncFooter);
     expect(syncFooter).toBe("sourceMappingURL=input.ts.map");
+  });
+
+  // `target: "bun"` flips the printer's sourcemap builder into the
+  // packed InternalSourceMap binary format. The transform path has to
+  // re-encode that to standard VLQ before emitting the v3 JSON map,
+  // otherwise JSON.parse chokes on the raw binary bytes embedded in
+  // the `mappings` field.
+  it.each(["ts", "tsx", "jsx", "js"])(
+    'target: "bun" emits valid VLQ mappings for loader=%s (sync)',
+    loader => {
+      const t = new Bun.Transpiler({ loader, target: "bun", sourcemap: "external" });
+      const out = t.transformSync("const x = 1;\nconst y = 2;");
+      const parsed = JSON.parse(out.map);
+      // decodeMappings would throw on an invalid VLQ segment; a
+      // successful decode is our proof that the format is correct.
+      const decoded = decodeMappings(parsed.mappings);
+      expect(decoded.length).toBeGreaterThan(0);
+      for (const m of decoded) {
+        expect(m.originalLine).toBeGreaterThanOrEqual(0);
+        expect(m.originalColumn).toBeGreaterThanOrEqual(0);
+      }
+    },
+  );
+
+  it('target: "bun" with sourcemap: "inline" produces a parseable embedded map', () => {
+    const t = new Bun.Transpiler({ loader: "ts", target: "bun", sourcemap: "inline" });
+    const out = t.transformSync("const x: number = 1;");
+    const match = out.match(/sourceMappingURL=data:application\/json;base64,([A-Za-z0-9+/=]+)/);
+    expect(match).not.toBeNull();
+    const map = JSON.parse(atob(match[1]));
+    expect(map.version).toBe(3);
+    // No non-VLQ characters in the mappings field.
+    expect(map.mappings).toMatch(/^[A-Za-z0-9+/,;]*$/);
   });
 });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -6389,4 +6389,30 @@ const y: number = 10;`;
       expect(out.endsWith("\n")).toBe(true);
     });
   }
+
+  // Sync and async must agree on the synthetic source filename even
+  // when the caller passes a per-call loader that differs from the
+  // constructor's `default_loader`. Pre-fix, sync used
+  // `default_loader.stdinName()` (e.g. `"input.jsx"`) while async used
+  // the overridden loader — observable on `map.sources` and the
+  // `//# sourceMappingURL=<name>.map` footer.
+  it("per-call loader override affects sources name consistently (sync vs async)", async () => {
+    // No loader set in the constructor → default_loader = "jsx".
+    // Pass "ts" as the per-call override.
+    const t = new Bun.Transpiler({ sourcemap: "external" });
+    const sync = t.transformSync("const x: number = 5;", "ts");
+    const async_ = await t.transform("const x: number = 5;", "ts");
+    expect(JSON.parse(sync.map).sources).toEqual(JSON.parse(async_.map).sources);
+    expect(JSON.parse(sync.map).sources).toEqual(["/input.ts"]);
+  });
+
+  it("per-call loader override affects linked footer consistently (sync vs async)", async () => {
+    const t = new Bun.Transpiler({ sourcemap: "linked" });
+    const sync = t.transformSync("const x: number = 5;", "ts");
+    const async_ = await t.transform("const x: number = 5;", "ts");
+    const syncFooter = sync.code.match(/sourceMappingURL=[^\s]+/)?.[0];
+    const asyncFooter = async_.code.match(/sourceMappingURL=[^\s]+/)?.[0];
+    expect(syncFooter).toBe(asyncFooter);
+    expect(syncFooter).toBe("sourceMappingURL=input.ts.map");
+  });
 });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -6154,7 +6154,9 @@ const y: number = 10;`;
           // Fail fast on malformed VLQ. Without this guard, (digit & 32)
           // stays truthy for `-1` and we loop forever — a test assertion
           // failure would manifest as a CI hang, not a useful error.
-          throw new Error(`Invalid VLQ digit ${JSON.stringify(ch)} in segment ${JSON.stringify(seg)} at offset ${offset - 1}`);
+          throw new Error(
+            `Invalid VLQ digit ${JSON.stringify(ch)} in segment ${JSON.stringify(seg)} at offset ${offset - 1}`,
+          );
         }
         cont = (digit & 32) !== 0;
         value += (digit & 31) << shift;
@@ -6423,22 +6425,19 @@ const y: number = 10;`;
   // re-encode that to standard VLQ before emitting the v3 JSON map,
   // otherwise JSON.parse chokes on the raw binary bytes embedded in
   // the `mappings` field.
-  it.each(["ts", "tsx", "jsx", "js"])(
-    'target: "bun" emits valid VLQ mappings for loader=%s (sync)',
-    loader => {
-      const t = new Bun.Transpiler({ loader, target: "bun", sourcemap: "external" });
-      const out = t.transformSync("const x = 1;\nconst y = 2;");
-      const parsed = JSON.parse(out.map);
-      // decodeMappings would throw on an invalid VLQ segment; a
-      // successful decode is our proof that the format is correct.
-      const decoded = decodeMappings(parsed.mappings);
-      expect(decoded.length).toBeGreaterThan(0);
-      for (const m of decoded) {
-        expect(m.originalLine).toBeGreaterThanOrEqual(0);
-        expect(m.originalColumn).toBeGreaterThanOrEqual(0);
-      }
-    },
-  );
+  it.each(["ts", "tsx", "jsx", "js"])('target: "bun" emits valid VLQ mappings for loader=%s (sync)', loader => {
+    const t = new Bun.Transpiler({ loader, target: "bun", sourcemap: "external" });
+    const out = t.transformSync("const x = 1;\nconst y = 2;");
+    const parsed = JSON.parse(out.map);
+    // decodeMappings would throw on an invalid VLQ segment; a
+    // successful decode is our proof that the format is correct.
+    const decoded = decodeMappings(parsed.mappings);
+    expect(decoded.length).toBeGreaterThan(0);
+    for (const m of decoded) {
+      expect(m.originalLine).toBeGreaterThanOrEqual(0);
+      expect(m.originalColumn).toBeGreaterThanOrEqual(0);
+    }
+  });
 
   it('target: "bun" with sourcemap: "inline" produces a parseable embedded map', () => {
     const t = new Bun.Transpiler({ loader: "ts", target: "bun", sourcemap: "inline" });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -6216,6 +6216,10 @@ const y: number = 10;`;
 
     expect(typeof out).toBe("string");
     expect(out).toContain("//# sourceMappingURL=data:application/json;base64,");
+    // Match `Bun.build`'s inline emitter — the footer terminates with a
+    // newline so two inline outputs can be safely concatenated without
+    // the second one being swallowed by the `//#` line comment.
+    expect(out.endsWith("\n")).toBe(true);
 
     // Decode the embedded map and sanity-check v3 shape.
     const match = out.match(/sourceMappingURL=data:application\/json;base64,([A-Za-z0-9+/=]+)/);
@@ -6330,5 +6334,59 @@ const y: number = 10;`;
     const out = await t.transform(input);
     expect(typeof out).toBe("string");
     expect(out).toContain("//# sourceMappingURL=data:application/json;base64,");
+    // Parity with the sync path: trailing newline after the data URL.
+    expect(out.endsWith("\n")).toBe(true);
   });
+
+  // --- empty-input parity between sync and async ---
+  //
+  // Type-only TypeScript files (`interface Foo {}`, `type X = number;`,
+  // `.d.ts`-style sources) and empty inputs produce zero output bytes.
+  // The documented contract for `sourcemap: "external"` / `"linked"` is
+  // `{ code, map }` regardless, and the sync and async paths must agree.
+  const emptyInputs = [
+    { name: "empty input", src: "" },
+    { name: "type-only input", src: "interface Foo { x: number }" },
+  ];
+
+  for (const { name, src } of emptyInputs) {
+    it(`'external' returns { code, map } for ${name} (sync)`, () => {
+      const t = new Bun.Transpiler({ loader: "ts", sourcemap: "external" });
+      const out = t.transformSync(src);
+      expect(typeof out).toBe("object");
+      expect(out.code).toBe("");
+      expect(typeof out.map).toBe("string");
+      const map = JSON.parse(out.map);
+      expect(map).toMatchObject({ version: 3, sources: ["/input.ts"] });
+    });
+
+    it(`'external' returns { code, map } for ${name} (async)`, async () => {
+      const t = new Bun.Transpiler({ loader: "ts", sourcemap: "external" });
+      const out = await t.transform(src);
+      // Pre-fix, the async path silently fell back to `""` for empty
+      // output while the sync path returned `{ code, map }` — see
+      // oven-sh/bun#30540 review.
+      expect(typeof out).toBe("object");
+      expect(out.code).toBe("");
+      expect(typeof out.map).toBe("string");
+      const map = JSON.parse(out.map);
+      expect(map).toMatchObject({ version: 3, sources: ["/input.ts"] });
+    });
+
+    it(`'linked' returns { code, map } for ${name} (async)`, async () => {
+      const t = new Bun.Transpiler({ loader: "ts", sourcemap: "linked" });
+      const out = await t.transform(src);
+      expect(typeof out).toBe("object");
+      expect(out.code).toMatch(/\/\/# sourceMappingURL=[^\s]+\.map/);
+      expect(typeof out.map).toBe("string");
+    });
+
+    it(`'inline' returns a string with a trailing newline for ${name} (async)`, async () => {
+      const t = new Bun.Transpiler({ loader: "ts", sourcemap: "inline" });
+      const out = await t.transform(src);
+      expect(typeof out).toBe("string");
+      expect(out).toContain("//# sourceMappingURL=data:application/json;base64,");
+      expect(out.endsWith("\n")).toBe(true);
+    });
+  }
 });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -6117,3 +6117,218 @@ describe("same-target destructuring with an unstable target", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// oven-sh/bun#30538 — `sourcemap` option now threads a v3 source map
+// through to the JS-visible output. Behaviour matches `Bun.build`'s
+// `sourcemap` option:
+//   - unset / false / "none"  → returns string (unchanged)
+//   - "inline" / true         → string + inline `//# sourceMappingURL=data:...`
+//   - "external" / "linked"   → `{ code, map }` (map is v3 JSON text)
+describe("Bun.Transpiler sourcemap option", () => {
+  // Shared input: 6 lines, two `interface` declarations that the TS
+  // transpiler drops, plus the blank lines it collapses around them. The
+  // stripped output is only 2 lines, so any sensible sourcemap must
+  // re-map generated line 0 back to input line 1, and generated line 1
+  // back to input line 5.
+  const input = `interface Foo { x: number }
+const x: number = 5;
+
+interface Bar { y: string }
+
+const y: number = 10;`;
+
+  // Minimal VLQ decoder — plenty fast for the handful of mappings we
+  // emit, and avoids pulling in an external dependency. Returns an array
+  // of { generatedLine, generatedColumn, originalLine, originalColumn }
+  // records (zero-indexed, matching the v3 spec).
+  function decodeMappings(mappings) {
+    const charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    function decodeVLQ(seg, offset) {
+      let value = 0;
+      let shift = 0;
+      let cont = true;
+      while (cont) {
+        const digit = charset.indexOf(seg[offset++]);
+        cont = (digit & 32) !== 0;
+        value += (digit & 31) << shift;
+        shift += 5;
+      }
+      const negative = (value & 1) !== 0;
+      value >>= 1;
+      return [negative ? -value : value, offset];
+    }
+
+    const lines = mappings.split(";");
+    const out = [];
+    let genLine = 0;
+    let srcIdx = 0;
+    let origLine = 0;
+    let origCol = 0;
+    for (const line of lines) {
+      let genCol = 0;
+      if (line !== "") {
+        for (const segment of line.split(",")) {
+          const fields = [];
+          let offset = 0;
+          while (offset < segment.length) {
+            const [v, next] = decodeVLQ(segment, offset);
+            fields.push(v);
+            offset = next;
+          }
+          genCol += fields[0];
+          if (fields.length >= 4) {
+            srcIdx += fields[1];
+            origLine += fields[2];
+            origCol += fields[3];
+          }
+          out.push({
+            generatedLine: genLine,
+            generatedColumn: genCol,
+            originalLine: origLine,
+            originalColumn: origCol,
+          });
+        }
+      }
+      genLine++;
+    }
+    return out;
+  }
+
+  it("returns a plain string when sourcemap is unset", () => {
+    const t = new Bun.Transpiler({ loader: "ts" });
+    const out = t.transformSync(input);
+    expect(typeof out).toBe("string");
+    expect(out).not.toContain("sourceMappingURL");
+  });
+
+  it("returns a plain string when sourcemap is false or 'none'", () => {
+    for (const value of [false, "none"]) {
+      const t = new Bun.Transpiler({ loader: "ts", sourcemap: value });
+      const out = t.transformSync(input);
+      expect(typeof out).toBe("string");
+      expect(out).not.toContain("sourceMappingURL");
+    }
+  });
+
+  it("'inline' appends a data URL and returns a string", () => {
+    const t = new Bun.Transpiler({ loader: "ts", sourcemap: "inline" });
+    const out = t.transformSync(input);
+
+    expect(typeof out).toBe("string");
+    expect(out).toContain("//# sourceMappingURL=data:application/json;base64,");
+
+    // Decode the embedded map and sanity-check v3 shape.
+    const match = out.match(/sourceMappingURL=data:application\/json;base64,([A-Za-z0-9+/=]+)/);
+    expect(match).not.toBeNull();
+    const map = JSON.parse(atob(match[1]));
+    expect(map).toMatchObject({
+      version: 3,
+      sources: ["/input.ts"],
+      sourcesContent: [input],
+      names: [],
+    });
+    expect(typeof map.mappings).toBe("string");
+    expect(map.mappings.length).toBeGreaterThan(0);
+  });
+
+  it("true is treated as 'inline' (matches Bun.build alias)", () => {
+    const t = new Bun.Transpiler({ loader: "ts", sourcemap: true });
+    const out = t.transformSync(input);
+    expect(typeof out).toBe("string");
+    expect(out).toContain("//# sourceMappingURL=data:application/json;base64,");
+  });
+
+  it("'external' returns { code, map } with a v3 JSON map", () => {
+    const t = new Bun.Transpiler({ loader: "ts", sourcemap: "external" });
+    const out = t.transformSync(input);
+
+    expect(typeof out).toBe("object");
+    expect(typeof out.code).toBe("string");
+    expect(typeof out.map).toBe("string");
+    // external: the code has no sourceMappingURL footer.
+    expect(out.code).not.toContain("sourceMappingURL");
+
+    const map = JSON.parse(out.map);
+    expect(map).toMatchObject({
+      version: 3,
+      sources: ["/input.ts"],
+      sourcesContent: [input],
+      names: [],
+    });
+  });
+
+  it("'linked' returns { code, map } and appends //# sourceMappingURL= to code", () => {
+    const t = new Bun.Transpiler({ loader: "ts", sourcemap: "linked" });
+    const out = t.transformSync(input);
+
+    expect(typeof out).toBe("object");
+    expect(typeof out.code).toBe("string");
+    expect(typeof out.map).toBe("string");
+    // linked: code has a sibling-file reference; no inline data URL.
+    expect(out.code).toMatch(/\/\/# sourceMappingURL=[^\s]+\.map/);
+    expect(out.code).not.toContain("data:application/json");
+
+    // map is still valid v3 JSON.
+    const map = JSON.parse(out.map);
+    expect(map.version).toBe(3);
+    expect(typeof map.mappings).toBe("string");
+  });
+
+  it("mappings recover the original line numbers after TS stripping", () => {
+    // This is the motivating case from the issue: the generated file is
+    // 2 lines but the original was 6. The transpiler dropped two
+    // `interface` declarations plus the surrounding blank lines; the map
+    // must still point `const x` back at original line 1 and `const y`
+    // back at original line 5.
+    const t = new Bun.Transpiler({ loader: "ts", sourcemap: "external" });
+    const out = t.transformSync(input);
+
+    const code = out.code.trimEnd();
+    expect(code.split("\n")).toEqual(["const x = 5;", "const y = 10;"]);
+
+    const map = JSON.parse(out.map);
+    const decoded = decodeMappings(map.mappings);
+
+    // The first mapping on each generated line is the one that matters
+    // for stack-trace recovery.
+    const firstOnLine0 = decoded.find(m => m.generatedLine === 0);
+    const firstOnLine1 = decoded.find(m => m.generatedLine === 1);
+
+    expect(firstOnLine0).toMatchObject({
+      generatedLine: 0,
+      generatedColumn: 0,
+      originalLine: 1, // `const x: number = 5;`
+      originalColumn: 0,
+    });
+    expect(firstOnLine1).toMatchObject({
+      generatedLine: 1,
+      generatedColumn: 0,
+      originalLine: 5, // `const y: number = 10;`
+      originalColumn: 0,
+    });
+  });
+
+  it("async transform() mirrors the sync shape — string when unset", async () => {
+    const t = new Bun.Transpiler({ loader: "ts" });
+    const out = await t.transform(input);
+    expect(typeof out).toBe("string");
+    expect(out).not.toContain("sourceMappingURL");
+  });
+
+  it("async transform() returns { code, map } for 'external'", async () => {
+    const t = new Bun.Transpiler({ loader: "ts", sourcemap: "external" });
+    const out = await t.transform(input);
+    expect(typeof out).toBe("object");
+    expect(typeof out.code).toBe("string");
+    const map = JSON.parse(out.map);
+    expect(map.version).toBe(3);
+    expect(map.sources).toEqual(["/input.ts"]);
+  });
+
+  it("async transform() embeds the inline data URL for 'inline'", async () => {
+    const t = new Bun.Transpiler({ loader: "ts", sourcemap: "inline" });
+    const out = await t.transform(input);
+    expect(typeof out).toBe("string");
+    expect(out).toContain("//# sourceMappingURL=data:application/json;base64,");
+  });
+});

--- a/test/integration/bun-types/fixture/transpiler.ts
+++ b/test/integration/bun-types/fixture/transpiler.ts
@@ -53,4 +53,26 @@ import * as tsd from "./utilities";
   const t = new Bun.Transpiler({ loader: "ts", sourcemap: "linked" });
   const result = t.transformSync("const x: number = 1;");
   tsd.expectType<Bun.TranspilerTransformResult>(result);
+
+  const p = t.transform("const x: number = 1;");
+  tsd.expectType<Promise<Bun.TranspilerTransformResult>>(p);
+}
+
+// Explicitly-typed options must accept every sourcemap value, not just
+// the default. Regression guard for the `TranspilerOptions` generic
+// default — if it narrows to `"none"`, `sourcemap: "external"` here is
+// a type error.
+{
+  const opts: Bun.TranspilerOptions = { loader: "ts", sourcemap: "external" };
+  const t = new Bun.Transpiler(opts);
+  // Intermediate `opts` loses the literal type, so the return widens
+  // to the union of both shapes. We just want this to compile.
+  t.transformSync("const x: number = 1;");
+}
+
+// Narrowing via the explicit type argument still works.
+{
+  const opts: Bun.TranspilerOptions<"external"> = { loader: "ts", sourcemap: "external" };
+  const t = new Bun.Transpiler<"external">(opts);
+  tsd.expectType<Bun.TranspilerTransformResult>(t.transformSync("const x: number = 1;"));
 }

--- a/test/integration/bun-types/fixture/transpiler.ts
+++ b/test/integration/bun-types/fixture/transpiler.ts
@@ -1,0 +1,56 @@
+import * as tsd from "./utilities";
+
+// No sourcemap: return types must stay `string` so existing users who
+// assign the result to `string` keep compiling (bun-plugin-svelte is one).
+{
+  const t = new Bun.Transpiler({ loader: "ts" });
+  tsd.expectType<string>(t.transformSync("const x: number = 1;"));
+  tsd.expectType<Promise<string>>(t.transform("const x: number = 1;"));
+
+  // Assignable to `string`.
+  const s: string = t.transformSync("const x: number = 1;");
+  s.length;
+}
+
+// sourcemap: false — same as unset.
+{
+  const t = new Bun.Transpiler({ loader: "ts", sourcemap: false });
+  tsd.expectType<string>(t.transformSync("const x: number = 1;"));
+}
+
+// sourcemap: "none" — string.
+{
+  const t = new Bun.Transpiler({ loader: "ts", sourcemap: "none" });
+  tsd.expectType<string>(t.transformSync("const x: number = 1;"));
+}
+
+// sourcemap: "inline" — string (map embedded in the code).
+{
+  const t = new Bun.Transpiler({ loader: "ts", sourcemap: "inline" });
+  tsd.expectType<string>(t.transformSync("const x: number = 1;"));
+}
+
+// sourcemap: true — string (alias for "inline").
+{
+  const t = new Bun.Transpiler({ loader: "ts", sourcemap: true });
+  tsd.expectType<string>(t.transformSync("const x: number = 1;"));
+}
+
+// sourcemap: "external" — `{ code, map }`.
+{
+  const t = new Bun.Transpiler({ loader: "ts", sourcemap: "external" });
+  const result = t.transformSync("const x: number = 1;");
+  tsd.expectType<Bun.TranspilerTransformResult>(result);
+  tsd.expectType<string>(result.code);
+  tsd.expectType<string>(result.map);
+
+  const p = t.transform("const x: number = 1;");
+  tsd.expectType<Promise<Bun.TranspilerTransformResult>>(p);
+}
+
+// sourcemap: "linked" — `{ code, map }`.
+{
+  const t = new Bun.Transpiler({ loader: "ts", sourcemap: "linked" });
+  const result = t.transformSync("const x: number = 1;");
+  tsd.expectType<Bun.TranspilerTransformResult>(result);
+}


### PR DESCRIPTION
## Problem

`Bun.Transpiler` already accepted a `sourcemap` constructor option, but the option was consumed nowhere — `transformSync`/`transform` returned a plain string with no way for downstream tools to recover original line numbers after TS stripping.

Minimal repro from #30538, before:

```ts
const t = new Bun.Transpiler({ loader: 'ts', sourcemap: 'inline' });
const out = t.transformSync(
  `interface Foo { x: number }
const x: number = 5;

interface Bar { y: string }

const y: number = 10;`
);
// out === "const x = 5;\nconst y = 10;\n"   <- no map, anywhere
```

This makes it impossible for frameworks that build per-file compile pipelines around `Bun.Transpiler` (SFC compilers, TS-stripping loaders, custom transformer plugins) to chain sourcemaps; stack traces land on generated files instead of the `.ts` the user wrote.

## Fix

Thread the printer's `SourceMapHandler` into `transformSync` and the async `TransformTask::run()` in `src/runtime/api/JSTranspiler.rs`. When `sourcemap` is set, the v3 map is exposed via one of four shapes, matching `Bun.build`:

| `sourcemap` value | return type | `code` | `map` |
|---|---|---|---|
| unset / `false` / `"none"` | `string` (unchanged) | transpiled code | - |
| `true` / `"inline"` | `string` | code + `//# sourceMappingURL=data:application/json;base64,...` | - |
| `"external"` | `{ code, map }` | transpiled code (no footer) | v3 JSON map |
| `"linked"` | `{ code, map }` | code + `//# sourceMappingURL=<name>.map` | v3 JSON map |

Supporting changes:
- Restores `Chunk::print_source_map_contents` in `src/sourcemap/Chunk.rs` (removed as dead code in #35002; this PR is its caller for VLQ chunks). `target: "bun"` chunks arrive in the packed internal format and are re-encoded to VLQ via the existing `print_source_map_contents_from_internal`.
- `TransformTask` gains `output_map`; `bun_core::String` is RAII on main now, so refs release automatically on every path (`finish` consumes them via `mem::take(..).into_js`).
- `packages/bun-types/bun.d.ts`: `Transpiler<const SM>` narrows the return type per mode; plain-string callers keep `string`.
- `docs/runtime/transpiler.mdx`: new Source maps section plus updated return-shape prose and reference block.

Backwards-compatible: callers that don't set `sourcemap` keep getting a plain string, byte-identical to before.

## Testing

`describe("Bun.Transpiler sourcemap option")` in `test/bundler/transpiler/transpiler.test.js` (30 tests): shape matrix across sync/async, inline base64 decode + v3 shape assertions, VLQ mappings round-trip recovering the issue's original line numbers, empty/type-only input parity, per-call loader override parity, and `target: "bun"` emitting valid VLQ. Plus a tsd fixture (`test/integration/bun-types/fixture/transpiler.ts`) asserting the conditional return types.

`bun bd test test/bundler/transpiler/transpiler.test.js` -> 218 pass / 0 fail. `bun test test/integration/bun-types/bun-types.test.ts` -> 12/12.

## Background

- The transpiler prints through `BufferPrinter`; a `SourceMapHandler` is an optional callback the printer invokes once per file with a `Chunk` whose buffer holds the encoded mappings. `SourceMapCapture` (new) implements it and renders the v3 JSON.
- `bun_core::String` owns one WTF ref and derefs on `Drop`; `into_js` hands the ref to the JSString, so `finish` moves the fields out with `mem::take` and error paths clean up via `Drop`.

Closes #30538

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 29 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 26 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.1 (65362b53b)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.04ms]
(pass) Bun.Transpiler > normalizes \r\n [5.90ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [3.94ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [8.10ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.26ms]
(pass) Bun.Transpiler > property access inlining > works [2.66ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.63ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [48.01ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [22.64ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [304.86ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional
... (truncated)

release without fix: 31 failed, 22 skipped
bun test v1.4.1-canary.1 (65362b53b)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.10ms]
(pass) Bun.Transpiler > normalizes \r\n [0.16ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.07ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.12ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.03ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.02ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [0.63ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [0.31ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [7.61ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [0.34ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.05ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.1 (65362b53b)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.26ms]
(pass) Bun.Transpiler > normalizes \r\n [6.15ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.05ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [8.06ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.25ms]
(pass) Bun.Transpiler > property access inlining > works [3.06ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.56ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [48.42ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [22.06ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [302.75ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     214feb332b
  features     baseline

23 deps, 131 codegen, 1172 objects in 685ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [9.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1217] gen ErrorCode+*.h
[6/1217] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [19.00ms]
[7/1217] fetch zlib
[zlib] up to date
[8/1217] gen .bind.ts → GeneratedBindings.cpp
[9/1217] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[10/1217] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/b
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/transpiler.mdx                      |  40 ++-
 packages/bun-types/bun.d.ts                      |  82 +++++-
 src/runtime/api/JSTranspiler.rs                  | 302 +++++++++++++++++---
 src/sourcemap/Chunk.rs                           |  15 +
 test/bundler/transpiler/transpiler.test.js       | 333 +++++++++++++++++++++++
 test/integration/bun-types/fixture/transpiler.ts |  78 ++++++
 6 files changed, 806 insertions(+), 44 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 29

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
docs/runtime/transpiler.mdx                           3     10     84
packages/bun-types/bun.d.ts                           7      9     88
src/runtime/api/JSTranspiler.rs                      38     30     87
src/sourcemap/Chunk.rs                                4      1     84
test/bundler/transpiler/transpiler.test.js           27     23     84
test/integration/bun-types/fixture/transpiler.ts      1      2     85
```

</details>

<!-- robobun:evidence:end -->