### PR TITLE
Fix null deref in forEachProperty when Proxy prototype getter throws

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5369,10 +5369,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasSlot = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasSlot)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5444,7 +5445,10 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototype" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            iterating = proto ? proto.getObject() : nullptr;
         }
     }
 

--- a/test/js/bun/util/inspect-proxy-prototype.test.ts
+++ b/test/js/bun/util/inspect-proxy-prototype.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+
+describe("Bun.inspect with Proxy in prototype chain", () => {
+  test("does not crash when a getter reached through a Proxy prototype throws", () => {
+    // The Expect prototype has getters (.rejects / .resolves) that mutate state and can
+    // throw when invoked in sequence. Going through a Proxy forces the slow property
+    // iteration path which invokes those getters.
+    const e = expect(1);
+    const proto = Object.getPrototypeOf(e);
+    Object.setPrototypeOf(e, new Proxy(proto, {}));
+    const out = Bun.inspect(e);
+    expect(out).toContain("toBe");
+  });
+
+  test("does not crash when a Proxy getPrototypeOf trap throws during iteration", () => {
+    class Foo {
+      bar() {}
+    }
+    const obj = new Foo();
+    const proto = Object.getPrototypeOf(obj);
+    Object.setPrototypeOf(
+      obj,
+      new Proxy(proto, {
+        getPrototypeOf() {
+          throw new Error("nope");
+        },
+      }),
+    );
+    const out = Bun.inspect(obj);
+    expect(out).toContain("bar");
+  });
+
+  test("does not crash when a Proxy get trap throws during iteration", () => {
+    class Foo {
+      bar() {}
+      baz() {}
+    }
+    const obj = new Foo();
+    const proto = Object.getPrototypeOf(obj);
+    let count = 0;
+    Object.setPrototypeOf(
+      obj,
+      new Proxy(proto, {
+        get(t, k, r) {
+          if (++count > 3) throw new Error("get fail");
+          return Reflect.get(t, k, r);
+        },
+      }),
+    );
+    expect(() => Bun.inspect(obj)).not.toThrow();
+  });
+});


### PR DESCRIPTION
Fuzzer fingerprint: `b8b8543bb6fc12e8`

## What
`Bun.inspect` / `console.log` crashed with a null-pointer deref when formatting an object whose prototype chain contains a Proxy and a getter reached through that Proxy throws.

Minimal repro:
```js
const { expect } = Bun.jest(import.meta.path);
const e = expect(1);
Object.setPrototypeOf(e, new Proxy(Object.getPrototypeOf(e), {}));
console.log(e); // null deref in JSValue::getObject()
```

## Why
The slow path of `JSC__JSValue__forEachPropertyImpl` walks the prototype chain using `PropertySlot::InternalMethodType::Get`, which means going through a Proxy actually *invokes* getters. The `Expect` prototype has stateful getters (`.rejects` then `.resolves`) where the second one throws.

When `getPropertySlot` throws it returns `false`, but the existing code did:
```cpp
if (!object->getPropertySlot(globalObject, property, slot))
    continue;
// Ignore exceptions from "Get" proxy traps.
CLEAR_IF_EXCEPTION(scope);
```
The `continue` runs before the exception is cleared, so it stays pending for the rest of the loop. At the end of the loop body we do `iterating->getPrototype(globalObject).getObject()`; for a Proxy, `getPrototype` sees the pending exception and returns an empty `JSValue`, and `.getObject()` on an empty value dereferences a null `JSCell*`.

## Fix
- Clear the exception from `getPropertySlot` *before* the `continue`.
- Guard the result of `getPrototype` and clear any exception from a throwing `getPrototypeOf` trap (matching what the fast path already does).

Added regression tests covering both a throwing getter and a throwing `getPrototypeOf` trap.