### PR TITLE
install: fix segfault in `bun patch --commit` for tarball/git/github deps

### DIFF
--- a/src/install/PackageManager/PackageManagerDirectories.zig
+++ b/src/install/PackageManager/PackageManagerDirectories.zig
@@ -466,15 +466,21 @@ pub fn pathForResolution(
 
 /// this is copy pasted from `installPackageWithNameAndResolution()`
 /// it's not great to do this
+///
+/// `string_buf` must be the string buffer that `resolution`'s strings are
+/// stored in. This is not always `manager.lockfile` — `doPatchCommit` loads
+/// its own lockfile from disk and passes resolutions from *that* lockfile,
+/// so slicing against `manager.lockfile` would read garbage (issue #17945).
 pub fn computeCacheDirAndSubpath(
     manager: *PackageManager,
     pkg_name: string,
     resolution: *const Resolution,
+    string_buf: []const u8,
     folder_path_buf: *bun.PathBuffer,
     patch_hash: ?u64,
 ) struct { cache_dir: std.fs.Dir, cache_dir_subpath: stringZ } {
     const name = pkg_name;
-    const buf = manager.lockfile.buffers.string_bytes.items;
+    const buf = string_buf;
     var cache_dir = std.fs.cwd();
     var cache_dir_subpath: stringZ = "";
 
@@ -484,14 +490,19 @@ pub fn computeCacheDirAndSubpath(
             cache_dir = manager.getCacheDirectory();
         },
         .git => {
-            cache_dir_subpath = manager.cachedGitFolderName(
-                &resolution.value.git,
+            cache_dir_subpath = cachedGitFolderNamePrint(
+                PackageManager.cached_package_folder_name_buf(),
+                resolution.value.git.resolved.slice(buf),
                 patch_hash,
             );
             cache_dir = manager.getCacheDirectory();
         },
         .github => {
-            cache_dir_subpath = manager.cachedGitHubFolderName(&resolution.value.github, patch_hash);
+            cache_dir_subpath = cachedGitHubFolderNamePrint(
+                PackageManager.cached_package_folder_name_buf(),
+                resolution.value.github.resolved.slice(buf),
+                patch_hash,
+            );
             cache_dir = manager.getCacheDirectory();
         },
         .folder => {
@@ -509,11 +520,19 @@ pub fn computeCacheDirAndSubpath(
             cache_dir = std.fs.cwd();
         },
         .local_tarball => {
-            cache_dir_subpath = manager.cachedTarballFolderName(resolution.value.local_tarball, patch_hash);
+            cache_dir_subpath = cachedTarballFolderNamePrint(
+                PackageManager.cached_package_folder_name_buf(),
+                resolution.value.local_tarball.slice(buf),
+                patch_hash,
+            );
             cache_dir = manager.getCacheDirectory();
         },
         .remote_tarball => {
-            cache_dir_subpath = manager.cachedTarballFolderName(resolution.value.remote_tarball, patch_hash);
+            cache_dir_subpath = cachedTarballFolderNamePrint(
+                PackageManager.cached_package_folder_name_buf(),
+                resolution.value.remote_tarball.slice(buf),
+                patch_hash,
+            );
             cache_dir = manager.getCacheDirectory();
         },
         .workspace => {

--- a/src/install/PackageManager/patchPackage.zig
+++ b/src/install/PackageManager/patchPackage.zig
@@ -635,7 +635,10 @@ pub fn preparePatch(manager: *PackageManager) !void {
             const existing_patchfile_hash = existing_patchfile_hash: {
                 var __sfb = std.heap.stackFallback(1024, manager.allocator);
                 const allocator = __sfb.get();
-                const name_and_version = std.fmt.allocPrint(allocator, "{s}@{f}", .{ name, actual_package.resolution.fmt(strbuf, .posix) }) catch unreachable;
+                // `strbuf` was captured before `parseWithJSON` above, which may have
+                // reallocated `lockfile.buffers.string_bytes`. Re-read it here so
+                // non-npm resolutions (tarball/git/github) slice the live buffer.
+                const name_and_version = std.fmt.allocPrint(allocator, "{s}@{f}", .{ name, actual_package.resolution.fmt(lockfile.buffers.string_bytes.items, .posix) }) catch unreachable;
                 defer allocator.free(name_and_version);
                 const name_and_version_hash = String.Builder.stringHash(name_and_version);
                 if (lockfile.patched_dependencies.get(name_and_version_hash)) |patched_dep| {

--- a/src/install/PackageManager/patchPackage.zig
+++ b/src/install/PackageManager/patchPackage.zig
@@ -148,6 +148,7 @@ pub fn doPatchCommit(
             const cache_result = manager.computeCacheDirAndSubpath(
                 name,
                 &actual_package.resolution,
+                lockfile.buffers.string_bytes.items,
                 &folder_path_buf,
                 null,
             );
@@ -171,6 +172,7 @@ pub fn doPatchCommit(
             const cache_result = manager.computeCacheDirAndSubpath(
                 pkg.name.slice(lockfile.buffers.string_bytes.items),
                 &pkg.resolution,
+                lockfile.buffers.string_bytes.items,
                 &folder_path_buf,
                 null,
             );
@@ -645,6 +647,7 @@ pub fn preparePatch(manager: *PackageManager) !void {
             const cache_result = manager.computeCacheDirAndSubpath(
                 name,
                 &actual_package.resolution,
+                lockfile.buffers.string_bytes.items,
                 &folder_path_buf,
                 existing_patchfile_hash,
             );
@@ -683,6 +686,7 @@ pub fn preparePatch(manager: *PackageManager) !void {
             const cache_result = manager.computeCacheDirAndSubpath(
                 pkg_name,
                 &pkg.resolution,
+                strbuf,
                 &folder_path_buf,
                 existing_patchfile_hash,
             );

--- a/src/install/patch_install.zig
+++ b/src/install/patch_install.zig
@@ -541,6 +541,7 @@ pub const PatchTask = struct {
         const stuff = pkg_manager.computeCacheDirAndSubpath(
             pkg_name.slice(pkg_manager.lockfile.buffers.string_bytes.items),
             resolution,
+            pkg_manager.lockfile.buffers.string_bytes.items,
             &folder_path_buf,
             patch_hash,
         );

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -528,7 +528,9 @@ module.exports = function isOdd(i) {
         "index.js": `console.log(require(${JSON.stringify(pkgName)}));`,
       });
 
-      expectNoError(await $`${bunExe()} pm pack --destination ${tempdir}`.env(bunEnv).cwd(join(tempdir, "tarball-src")));
+      expectNoError(
+        await $`${bunExe()} pm pack --destination ${tempdir}`.env(bunEnv).cwd(join(tempdir, "tarball-src")),
+      );
       expectNoError(await $`${bunExe()} i`.env(bunEnv).cwd(tempdir));
 
       const patchArg = makeArg(pkgName);

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -499,6 +499,65 @@ module.exports = function isOdd(i) {
     expect(stdout.toString()).toContain("hi\nhello\n");
   });
 
+  // https://github.com/oven-sh/bun/issues/17945
+  // https://github.com/oven-sh/bun/issues/25782
+  // `bun patch --commit` loads a fresh lockfile from disk but then sliced the
+  // resolution's strings against `manager.lockfile`'s string buffer instead of
+  // the freshly-loaded one. For resolutions whose strings are long enough to be
+  // stored as an offset (tarballs, git, github — npm versions happen to dodge
+  // it) this read garbage memory and segfaulted.
+  describe.each([
+    ["name argument", (name: string) => name],
+    ["path argument", (name: string) => `node_modules/${name}`],
+  ])("patch --commit a tarball dependency (%s)", (_, makeArg) => {
+    test("does not crash and writes the patch", async () => {
+      // Name and tarball path must both be > 8 bytes so the lockfile stores
+      // them as pointers into the string buffer rather than inline.
+      const pkgName = "my-tarball-package-with-a-long-name-to-force-pointer-storage";
+      const tempdir = tempDirWithFiles("patch-tarball", {
+        "tarball-src": {
+          "package.json": JSON.stringify({ name: pkgName, version: "1.0.0" }),
+          "index.js": "module.exports = 1;\n",
+        },
+        "package.json": JSON.stringify({
+          name: "bun-patch-test",
+          dependencies: {
+            [pkgName]: `./${pkgName}-1.0.0.tgz`,
+          },
+        }),
+        "index.js": `console.log(require(${JSON.stringify(pkgName)}));`,
+      });
+
+      expectNoError(await $`${bunExe()} pm pack --destination ${tempdir}`.env(bunEnv).cwd(join(tempdir, "tarball-src")));
+      expectNoError(await $`${bunExe()} i`.env(bunEnv).cwd(tempdir));
+
+      const patchArg = makeArg(pkgName);
+      expectNoError(await $`${bunExe()} patch ${patchArg}`.env(bunEnv).cwd(tempdir));
+
+      await $`echo ${"module.exports = 'patched';"} > ${join("node_modules", pkgName, "index.js")}`
+        .env(bunEnv)
+        .cwd(tempdir);
+
+      const commit = await $`${bunExe()} patch --commit ${patchArg}`.env(bunEnv).cwd(tempdir).throws(false);
+      expect(commit.stderr.toString()).not.toContain("error");
+      expect(commit.exitCode).toBe(0);
+
+      const pkgJson = await $`cat package.json`.env(bunEnv).cwd(tempdir).json();
+      const patchKey = `${pkgName}@./${pkgName}-1.0.0.tgz`;
+      expect(pkgJson.patchedDependencies).toEqual({
+        [patchKey]: `patches/${pkgName}@.%2F${pkgName}-1.0.0.tgz.patch`,
+      });
+
+      const patchContents = await $`cat ${pkgJson.patchedDependencies[patchKey]}`.env(bunEnv).cwd(tempdir).text();
+      expect(patchContents).toContain("+module.exports = 'patched';");
+
+      const run = await $`${bunExe()} run index.js`.env(bunEnv).cwd(tempdir).throws(false);
+      expect(run.stderr.toString()).toBe("");
+      expect(run.stdout.toString()).toBe("patched\n");
+      expect(run.exitCode).toBe(0);
+    });
+  });
+
   test("bad patch arg", async () => {
     const tempdir = tempDirWithFiles("lol", {
       "package.json": JSON.stringify({


### PR DESCRIPTION
Fixes #17945
Fixes #22773
Fixes #25782
Fixes #18792

## Repro

```sh
bun add leaflet@https://github.com/Leaflet/Leaflet/archive/611aee1c561ae57ccca1fd28c5410010e387386e.tar.gz
bun patch leaflet
bun patch --commit leaflet
# → panic(main thread): Segmentation fault at address 0x66
```

Or with a local tarball (no network — used in the regression test):

```sh
# tarball path must be > 8 bytes so it's stored as an offset, not inline
bun add pkg@./some-local-tarball.tgz
bun patch pkg
bun patch --commit pkg
# → panic(main thread): Segmentation fault at address 0x3C
```

## Cause

`doPatchCommit` allocates and loads a fresh `Lockfile` from disk into a local variable, pulls the package's `Resolution` out of *that* lockfile, and passes it to `manager.computeCacheDirAndSubpath()`.

Inside `computeCacheDirAndSubpath`, the resolution's `String` fields were sliced against **`manager.lockfile`**'s string buffer — the wrong buffer. Semver `String`s longer than 8 bytes are stored as `(offset, len)` into a string buffer, so slicing an offset from lockfile A against the buffer of lockfile B reads garbage memory and crashes in `String.Builder.stringHash` / `cachedTarballFolderNamePrint` / `cachedGitHubFolderNamePrint`.

npm resolutions happen to dodge this because `cachedNPMPackageFolderName` only reads numeric `major`/`minor`/`patch` fields (and hash values for pre/build tags), never slicing into the string buffer — which is why this wasn't noticed sooner.

## Fix

`computeCacheDirAndSubpath` now takes the resolution's string buffer as an explicit parameter and calls the `*Print` variants of the cache-folder-name helpers (which accept a pre-sliced `[]const u8`) instead of the `*Name` variants that hardcode `this.lockfile`. All five call sites pass the correct buffer:

- `doPatchCommit` (both arg-kind branches) → the locally-loaded lockfile's buffer
- `preparePatch` (both arg-kind branches) → `manager.lockfile`'s buffer (unchanged behavior)
- `PatchTask.newApplyPatchHash` → `pkg_manager.lockfile`'s buffer (unchanged behavior)

## Verification

New test in `test/cli/install/bun-patch.test.ts` creates a local tarball via `bun pm pack`, installs it, runs `bun patch` → edit → `bun patch --commit`, and asserts the patch file is written and `patchedDependencies` is populated. Both the name-arg (`pkg`) and path-arg (`node_modules/pkg`) variants are covered.

- `USE_SYSTEM_BUN=1 bun test bun-patch.test.ts -t 'tarball dependency'` → 2 fail (segfault)
- `bun bd test bun-patch.test.ts -t 'tarball dependency'` → 2 pass
- `bun run zig:check-all` → passes on all targets
