### PR TITLE
napi: pass NULL js_callback to call_js_cb when no func was provided

### DIFF
--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2664,17 +2664,16 @@ impl ThreadSafeFunction {
                 js: cb_js,
                 napi_threadsafe_function_call_js,
             } => {
-                let js: JSValue = cb_js.get().unwrap_or(JSValue::UNDEFINED);
-
                 // SAFETY: `env` is held alive by `self.env` (`NapiEnvRef`) for the TSF's lifetime.
                 let env_ref = unsafe { &*env };
                 let _hs = NapiHandleScope::open_scoped(env_ref);
-                napi_threadsafe_function_call_js(
-                    env,
-                    napi_value::create(env_ref, js),
-                    self.ctx,
-                    task,
-                );
+                // Node.js passes NULL (not undefined) for js_callback when the TSF was
+                // created without a JS function; napi-rs and others rely on `== NULL`.
+                let js_callback = match cb_js.get() {
+                    Some(js) => napi_value::create(env_ref, js),
+                    None => napi_value(0),
+                };
+                napi_threadsafe_function_call_js(env, js_callback, self.ctx, task);
             }
         }
         Ok(())

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -911,6 +911,15 @@ nativeTests.test_napi_typeof_boxed_primitives = () => {
   console.log("All boxed primitive tests passed!");
 };
 
+// https://github.com/oven-sh/bun/issues/13771
+// Test that call_js_cb receives js_callback = NULL when the threadsafe
+// function was created with func = NULL.
+nativeTests.test_tsfn_null_js_callback = async () => {
+  nativeTests.test_issue_13771();
+  // The threadsafe function callback fires asynchronously.
+  await new Promise(resolve => setTimeout(resolve, 50));
+};
+
 // https://github.com/oven-sh/bun/issues/25933
 // Test that napi_typeof returns napi_function for callbacks wrapped in
 // AsyncContextFrame (which happens inside AsyncLocalStorage.run()).

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2267,6 +2267,41 @@ static napi_value test_napi_get_named_property_copied_string(const Napi::Callbac
   return ok(env);
 }
 
+// https://github.com/oven-sh/bun/issues/13771
+// When a threadsafe function is created with func = NULL, Node.js passes
+// NULL as js_callback to call_js_cb. Native modules (e.g. napi-rs,
+// lightningcss) check `js_callback == NULL` to detect this case, so we must
+// not pass a non-null value like `undefined` here.
+static napi_threadsafe_function tsfn_13771 = nullptr;
+
+static void test_issue_13771_callback(napi_env env, napi_value js_callback,
+                                      void *context, void *data) {
+  if (js_callback == nullptr) {
+    printf("PASS: js_callback is NULL\n");
+  } else {
+    napi_valuetype type;
+    napi_typeof(env, js_callback, &type);
+    printf("FAIL: js_callback is not NULL (napi_typeof = %d)\n", type);
+  }
+  napi_release_threadsafe_function(tsfn_13771, napi_tsfn_release);
+  tsfn_13771 = nullptr;
+}
+
+static napi_value test_issue_13771(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+  napi_value name = Napi::String::New(env, "tsfn_null_func");
+
+  NODE_API_CALL(env,
+                napi_create_threadsafe_function(
+                    env, /* func */ nullptr, /* async_resource */ nullptr,
+                    name, 0, 1, nullptr, nullptr, nullptr,
+                    &test_issue_13771_callback, &tsfn_13771));
+  NODE_API_CALL(env, napi_call_threadsafe_function(tsfn_13771, nullptr,
+                                                   napi_tsfn_nonblocking));
+  return env.Undefined();
+}
+
 // https://github.com/oven-sh/bun/issues/25933
 // When a threadsafe function is created inside AsyncLocalStorage.run(),
 // the js_callback gets wrapped in AsyncContextFrame. napi_typeof must
@@ -2429,6 +2464,7 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports,
                     test_external_buffer_with_pending_exception);
   REGISTER_FUNCTION(env, exports, test_napi_get_named_property_copied_string);
+  REGISTER_FUNCTION(env, exports, test_issue_13771);
   REGISTER_FUNCTION(env, exports, test_issue_25933);
   REGISTER_FUNCTION(env, exports, test_napi_make_callback_async_context_frame);
   REGISTER_FUNCTION(env, exports, test_napi_create_tsfn_async_context_frame);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -179,6 +179,17 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     });
   });
 
+  describe("issue_13771", () => {
+    it("call_js_cb receives NULL js_callback when threadsafe function was created with func = NULL", async () => {
+      // https://github.com/oven-sh/bun/issues/13771
+      // Native modules (e.g. napi-rs, lightningcss) check `js_callback == NULL`
+      // to detect when no JS function was provided. Bun was passing `undefined`
+      // instead, causing napi-rs type checks to panic.
+      const result = await checkSameOutput("test_tsfn_null_js_callback", []);
+      expect(result).toContain("PASS: js_callback is NULL");
+    });
+  });
+
   describe("napi_get_value_string_utf8 with buffer", () => {
     // see https://github.com/oven-sh/bun/issues/6949
     it("copies one char", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes #13771 — panic with vite+lightningcss when using `visitor`.

## Reproduction

```js
const lightningcss = require('lightningcss');
await lightningcss.bundleAsync({
  filename: '/tmp/test.css',
  visitor: {},
});
```

In Bun this crashes with:
```
thread '<unnamed>' panicked at napi/src/threadsafe_function.rs:235:57:
called `Result::unwrap()` on an `Err` value: Error { status: InvalidArg, reason: "expect Function, got: Undefined", maybe_raw: 0x0 }
```

In Node.js it works.

## Root cause

When a `visitor` is provided, lightningcss calls `napi_create_threadsafe_function` with `func = NULL` (since it doesn't need a JS callback, only the native `call_js_cb`):

```rust
ThreadsafeFunction::create(env.raw(), std::ptr::null_mut(), 0, move |ctx| { ... })
```

When the threadsafe function later fires, Node.js passes `NULL` as the `js_callback` argument to `call_js_cb` — [node_api.cc](https://github.com/nodejs/node/blob/v22.11.0/src/node_api.cc#L409-L416):

```cpp
napi_value js_callback = nullptr;
if (!ref.IsEmpty()) {
  v8::Local<v8::Function> js_cb = v8::Local<v8::Function>::New(env->isolate, ref);
  js_callback = v8impl::JsValueFromV8LocalValue(js_cb);
}
env->CallbackIntoModule<false>([&](napi_env env) { call_js_cb(env, js_callback, context, data); });
```

Bun was passing `undefined` instead of `NULL`. lightningcss's `call_js_cb` (a fork of napi-rs's) then does:

```rust
callback: if js_callback.is_null() {
  None
} else {
  Some(JsFunction::from_raw(raw_env, js_callback).unwrap()) // panics
},
```

Since `undefined` is not a null pointer, `is_null()` is false, and `JsFunction::from_raw` on `undefined` fails the `napi_typeof` check and panics.

## Fix

When the stored JS callback is empty (no func was provided to `napi_create_threadsafe_function`), pass a zero `napi_value` (null pointer) to `call_js_cb` instead of `undefined`, matching Node.js.

## Verification

- New `test/napi/napi.test.ts -t issue_13771` test: creates a TSF with `func = NULL` and verifies the native `call_js_cb` receives `js_callback == NULL`, compared against Node.js output. Fails on main, passes with this fix.
- Verified `lightningcss.bundleAsync({ visitor: {} })` now succeeds.
- Verified the original vite repro (`bun --bun x vite build` with lightningcss `visitor` configured) now builds successfully.