### PR TITLE
fix(serve): use-after-free on reload() with TLS serverName + static routes

### DIFF
--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -613,6 +613,15 @@ public:
     void clearRoutes() {
         if (httpContext) {
             httpContext->getSocketContextData()->clearRoutes();
+            if constexpr (SSL) {
+                /* Also clear every SNI domain router. reload() frees the
+                 * user_data captured in route handlers, so leaving the old
+                 * handlers here would call into freed memory on the next
+                 * request that arrives with a matching SNI. */
+                for (auto &p : pendingServerNames) {
+                    *p.router = HttpRouter<typename HttpContextData<SSL>::RouterData>{};
+                }
+            }
         }
     }
 

--- a/packages/bun-uws/src/HttpContextData.h
+++ b/packages/bun-uws/src/HttpContextData.h
@@ -71,7 +71,8 @@ private:
 
     uint64_t maxHeaderSize = 0; // 0 means no limit
 
-    // TODO: SNI
+    // SNI domain routers are owned by TemplatedApp::pendingServerNames and
+    // cleared from TemplatedApp::clearRoutes(); we only own the default one.
     void clearRoutes() {
         this->router = HttpRouter<RouterData>{};
         this->currentRouter = &router;

--- a/src/runtime/server/server.zig
+++ b/src/runtime/server/server.zig
@@ -1177,6 +1177,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             }
 
             const route_list_value = this.setRoutes();
+            this.setRoutesForServerNames();
             if (new_config.had_routes_object) {
                 if (this.js_value.tryGet()) |server_js_value| {
                     if (server_js_value != .zero) {
@@ -1194,6 +1195,44 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             }
         }
 
+        /// When `tls.serverName` or SNI entries are configured, each gets its
+        /// own uWS router. `setRoutes()` only registers routes on whatever
+        /// `currentRouter` points at (the default one after `clearRoutes()`),
+        /// so after a reload we must re-apply routes to every SNI router too
+        /// — otherwise requests matching that SNI would have no handlers.
+        fn setRoutesForServerNames(this: *ThisServer) void {
+            if (comptime !ssl_enabled) return;
+            const app = this.app orelse return;
+            var any = false;
+
+            if (this.config.ssl_config) |*ssl_config| {
+                if (ssl_config.server_name) |server_name_ptr| {
+                    const server_name: [:0]const u8 = std.mem.span(server_name_ptr);
+                    if (server_name.len > 0) {
+                        any = true;
+                        app.domain(server_name);
+                        _ = this.setRoutes();
+                    }
+                }
+            }
+
+            if (this.config.sni) |*sni| {
+                for (sni.slice()) |*sni_ssl_config| {
+                    if (sni_ssl_config.server_name) |server_name_ptr| {
+                        const sni_servername: [:0]const u8 = std.mem.span(server_name_ptr);
+                        if (sni_servername.len > 0) {
+                            any = true;
+                            app.domain(sni_servername);
+                            _ = this.setRoutes();
+                        }
+                    }
+                }
+            }
+
+            // Restore the default router for any subsequent route registrations.
+            if (any) app.domain("");
+        }
+
         pub fn reloadStaticRoutes(this: *ThisServer) !bool {
             if (this.app == null) {
                 // Static routes will get cleaned up when the server is stopped
@@ -1203,6 +1242,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             this.app.?.clearRoutes();
             if (comptime has_h3) if (this.h3_app) |h3a| h3a.clearRoutes();
             const route_list_value = this.setRoutes();
+            this.setRoutesForServerNames();
             if (route_list_value != .zero) {
                 if (this.js_value.tryGet()) |server_js_value| {
                     if (server_js_value != .zero) {

--- a/test/regression/issue/19868.test.ts
+++ b/test/regression/issue/19868.test.ts
@@ -56,7 +56,11 @@ function fixture(tlsConfig: string, routeKind: "static" | "function") {
 describe("server.reload() with TLS serverName / SNI routers", () => {
   const tlsConfigs = [
     ["tls.serverName", `{ cert: ${cert}, key: ${key}, serverName: "localhost" }`],
-    ["tls SNI array", `[{ cert: ${cert}, key: ${key}, serverName: "localhost" }]`],
+    // First array element becomes ssl_config; only second-and-later elements
+    // populate config.sni. Keep the SNI hostname as the second entry so the
+    // request that sends SNI=localhost routes through the config.sni branch
+    // of setRoutesForServerNames().
+    ["tls SNI array", `[{ cert: ${cert}, key: ${key} }, { cert: ${cert}, key: ${key}, serverName: "localhost" }]`],
   ] as const;
 
   test.concurrent.each(tlsConfigs)(

--- a/test/regression/issue/19868.test.ts
+++ b/test/regression/issue/19868.test.ts
@@ -1,24 +1,27 @@
 // https://github.com/oven-sh/bun/issues/19868
+// https://github.com/oven-sh/bun/issues/21792
 //
 // When tls.serverName (or SNI entries) are configured, Bun.serve() registers
 // routes on both the default uWS router and an SNI-specific one.
 // server.reload() used to only clear + re-register the default router,
-// leaving the SNI router holding handlers that pointed at freed StaticRoute
-// objects. The next request that matched that SNI then crashed with a
-// use-after-free ("Invalid pointer tag" / segfault).
+// leaving the SNI router holding handlers that pointed at freed route
+// objects (StaticRoute / UserRoute). The next request that matched that
+// SNI crashed with a use-after-free ("Invalid pointer tag" / segfault).
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tls } from "harness";
 
 const cert = JSON.stringify(tls.cert);
 const key = JSON.stringify(tls.key);
 
-function fixture(tlsConfig: string) {
+function fixture(tlsConfig: string, routeKind: "static" | "function") {
+  const before = routeKind === "static" ? `new Response("before-reload")` : `() => new Response("before-reload")`;
+  const after = routeKind === "static" ? `new Response("after-reload")` : `() => new Response("after-reload")`;
   return /* ts */ `
     const server = Bun.serve({
       port: 0,
       tls: ${tlsConfig},
       routes: {
-        "/status": new Response("before-reload"),
+        "/status": ${before},
       },
       fetch() {
         return new Response("fallback");
@@ -27,7 +30,7 @@ function fixture(tlsConfig: string) {
 
     server.reload({
       routes: {
-        "/status": new Response("after-reload"),
+        "/status": ${after},
       },
       fetch() {
         return new Response("fallback2");
@@ -50,13 +53,29 @@ function fixture(tlsConfig: string) {
   `;
 }
 
-describe("#19868 server.reload() with TLS serverName + static routes", () => {
-  test.concurrent.each([
+describe("server.reload() with TLS serverName / SNI routers", () => {
+  const tlsConfigs = [
     ["tls.serverName", `{ cert: ${cert}, key: ${key}, serverName: "localhost" }`],
     ["tls SNI array", `[{ cert: ${cert}, key: ${key}, serverName: "localhost" }]`],
-  ])("does not crash and serves the reloaded route (%s)", async (_label, tlsConfig) => {
+  ] as const;
+
+  test.concurrent.each(tlsConfigs)(
+    "static route served from SNI router after reload (%s)",
+    async (_label, tlsConfig) => {
+      await run(tlsConfig, "static");
+    },
+  );
+
+  test.concurrent.each(tlsConfigs)(
+    "function route served from SNI router after reload (%s)",
+    async (_label, tlsConfig) => {
+      await run(tlsConfig, "function");
+    },
+  );
+
+  async function run(tlsConfig: string, routeKind: "static" | "function") {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", fixture(tlsConfig)],
+      cmd: [bunExe(), "-e", fixture(tlsConfig, routeKind)],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -74,5 +93,5 @@ describe("#19868 server.reload() with TLS serverName + static routes", () => {
       { status: 200, body: "after-reload" },
     ]);
     expect(exitCode).toBe(0);
-  });
+  }
 });

--- a/test/regression/issue/19868.test.ts
+++ b/test/regression/issue/19868.test.ts
@@ -1,0 +1,78 @@
+// https://github.com/oven-sh/bun/issues/19868
+//
+// When tls.serverName (or SNI entries) are configured, Bun.serve() registers
+// routes on both the default uWS router and an SNI-specific one.
+// server.reload() used to only clear + re-register the default router,
+// leaving the SNI router holding handlers that pointed at freed StaticRoute
+// objects. The next request that matched that SNI then crashed with a
+// use-after-free ("Invalid pointer tag" / segfault).
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tls } from "harness";
+
+const cert = JSON.stringify(tls.cert);
+const key = JSON.stringify(tls.key);
+
+function fixture(tlsConfig: string) {
+  return /* ts */ `
+    const server = Bun.serve({
+      port: 0,
+      tls: ${tlsConfig},
+      routes: {
+        "/status": new Response("before-reload"),
+      },
+      fetch() {
+        return new Response("fallback");
+      },
+    });
+
+    server.reload({
+      routes: {
+        "/status": new Response("after-reload"),
+      },
+      fetch() {
+        return new Response("fallback2");
+      },
+    });
+
+    const res = await fetch(\`https://localhost:\${server.port}/status\`, {
+      tls: { rejectUnauthorized: false },
+    });
+    console.log(JSON.stringify({ status: res.status, body: await res.text() }));
+
+    // A second request to make sure the connection is reusable and the
+    // SNI router didn't just happen to dispatch once.
+    const res2 = await fetch(\`https://localhost:\${server.port}/status\`, {
+      tls: { rejectUnauthorized: false },
+    });
+    console.log(JSON.stringify({ status: res2.status, body: await res2.text() }));
+
+    server.stop(true);
+  `;
+}
+
+describe("#19868 server.reload() with TLS serverName + static routes", () => {
+  test.concurrent.each([
+    ["tls.serverName", `{ cert: ${cert}, key: ${key}, serverName: "localhost" }`],
+    ["tls SNI array", `[{ cert: ${cert}, key: ${key}, serverName: "localhost" }]`],
+  ])("does not crash and serves the reloaded route (%s)", async (_label, tlsConfig) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture(tlsConfig)],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    const lines = stdout
+      .trim()
+      .split("\n")
+      .map(l => JSON.parse(l));
+    expect(lines).toEqual([
+      { status: 200, body: "after-reload" },
+      { status: 200, body: "after-reload" },
+    ]);
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #19868
Fixes #21792
Fixes #25515

## What

`server.reload()` crashed with `panic: Invalid pointer tag` (release) / ASAN use-after-poison (debug) when the server was configured with `tls.serverName` (or an SNI array) and `routes`.

Reported via Elysia, which internally calls `Bun.serve()` followed by `server.reload()` once its lazy modules resolve.

## Repro

```ts
import { tls } from "harness";

const server = Bun.serve({
  port: 0,
  tls: { ...tls, serverName: "localhost" },
  routes: { "/status": new Response("v1") },
  fetch: () => new Response("fallback"),
});

server.reload({
  routes: { "/status": new Response("v2") },
  fetch: () => new Response("fallback"),
});

await fetch(`https://localhost:${server.port}/status`, {
  tls: { rejectUnauthorized: false },
}); // 💥 panic: Invalid pointer tag
```

## Cause

When `tls.serverName` or SNI entries are configured, `Bun.serve()` creates a separate uWS `HttpRouter` for each server name and registers all routes on both the default router and each SNI router (via `app.domain(name)` + `setRoutes()`).

`server.reload()` did:
1. `app.clearRoutes()` — reset the default router. The SNI routers were **not** cleared (there was a `// TODO: SNI` on `HttpContextData::clearRoutes()`).
2. Free the old `StaticRoute` / `UserRoute` objects.
3. `setRoutes()` — register new routes on the default router only.

The SNI routers were left holding handlers that captured pointers to the freed route objects. The next request that arrived with a matching SNI selected the SNI router, dispatched into freed memory, and crashed.

The same gap in `reloadStaticRoutes()` meant HTML-bundle asset routes (the content-hashed `/chunk-*.js` files) were never registered on SNI routers after the bundle finished, so they fell through to the `/*` 404 fallback when a `serverName` was configured (#25515).

## Fix

- `TemplatedApp::clearRoutes()` now also resets every SNI domain router in `pendingServerNames`.
- `onReloadFromZig()` and `reloadStaticRoutes()` call a new `setRoutesForServerNames()` helper after `setRoutes()` to re-apply routes to each configured server name (`tls.serverName` and every SNI entry), mirroring what the initial `listen()` path does.

## Verification

```
$ bun bd test test/regression/issue/19868.test.ts
 4 pass, 0 fail

$ USE_SYSTEM_BUN=1 bun test test/regression/issue/19868.test.ts
 0 pass, 2 fail  (panic: Invalid pointer tag)
# function-route variant passes by luck on release (allocator reuse), but
# ASAN catches it as use-after-poison under `bun bd` without the fix.
```

Also verified: `bun-serve-ssl.test.ts`, `bun-serve-static.test.ts`, `bun-serve-routes.test.ts`, reload-related tests in `serve.test.ts`, and the original Elysia reproduction all pass.
