### PR TITLE
node:cluster: let workers shut down gracefully on worker.disconnect()

### DIFF
--- a/src/js/internal/cluster/child.ts
+++ b/src/js/internal/cluster/child.ts
@@ -155,6 +155,13 @@ cluster._getServer = function (obj, options, cb) {
   });
 };
 
+// node:http binds its own SO_REUSEPORT socket instead of going through
+// _getServer, so it never enters `handles`. Register it so _disconnect closes it.
+cluster._trackServer = function (server) {
+  handles.set(server, server);
+  server.once("close", () => handles.delete(server));
+};
+
 function removeIndexesKey(indexesKey, index) {
   const indexSet = indexes.get(indexesKey);
   if (!indexSet) {
@@ -310,6 +317,9 @@ Worker.prototype.disconnect = function () {
 };
 
 Worker.prototype._disconnect = function (this: typeof Worker, primaryInitiated?) {
+  // The primary may ask to disconnect more than once; a second pass would
+  // close the servers again and tear down an already-closed channel.
+  if (this.exitedAfterDisconnect) return;
   this.exitedAfterDisconnect = true;
   let waitingCount = 1;
 

--- a/src/js/internal/cluster/child.ts
+++ b/src/js/internal/cluster/child.ts
@@ -155,8 +155,7 @@ cluster._getServer = function (obj, options, cb) {
   });
 };
 
-// node:http binds its own SO_REUSEPORT socket instead of going through
-// _getServer, so it never enters `handles`. Register it so _disconnect closes it.
+// For servers that listen without _getServer (node:http), so _disconnect still closes them.
 cluster._trackServer = function (server) {
   handles.set(server, server);
   server.once("close", () => handles.delete(server));
@@ -317,8 +316,6 @@ Worker.prototype.disconnect = function () {
 };
 
 Worker.prototype._disconnect = function (this: typeof Worker, primaryInitiated?) {
-  // The primary may ask to disconnect more than once; a second pass would
-  // close the servers again and tear down an already-closed channel.
   if (this.exitedAfterDisconnect) return;
   this.exitedAfterDisconnect = true;
   let waitingCount = 1;

--- a/src/js/internal/cluster/primary.ts
+++ b/src/js/internal/cluster/primary.ts
@@ -339,10 +339,13 @@ function send(worker, message, handle?, cb?) {
 }
 
 // Extend generic Worker with methods specific to the primary process.
+
+// Like Node, leave the channel up: the worker closes its servers, then
+// disconnects from its side (child.ts _disconnect). Tearing it down here
+// skips that shutdown and can drop an in-flight "online" message.
 Worker.prototype.disconnect = function () {
   this.exitedAfterDisconnect = true;
   send(this, { act: "disconnect" });
-  this.process.disconnect();
   removeHandlesForWorker(this, false);
   removeWorker(this);
   return this;

--- a/src/js/internal/cluster/primary.ts
+++ b/src/js/internal/cluster/primary.ts
@@ -339,10 +339,6 @@ function send(worker, message, handle?, cb?) {
 }
 
 // Extend generic Worker with methods specific to the primary process.
-
-// Like Node, leave the channel up: the worker closes its servers, then
-// disconnects from its side (child.ts _disconnect). Tearing it down here
-// skips that shutdown and can drop an in-flight "online" message.
 Worker.prototype.disconnect = function () {
   this.exitedAfterDisconnect = true;
   send(this, { act: "disconnect" });

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -601,6 +601,9 @@ Server.prototype.listen = function () {
 
     if (cluster === undefined) cluster = require("node:cluster");
 
+    // worker.disconnect() only closes servers the cluster child knows about.
+    cluster._trackServer(server);
+
     server.once("listening", () => {
       // No channel (NODE_UNIQUE_ID inherited by a plain child, or already disconnected): nothing to notify.
       if (!process.connected) return;

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { expect, setDefaultTimeout, test } from "bun:test";
 import {
   bunEnv,
   bunExe,
@@ -12,6 +12,8 @@ import {
   tls as tlsCerts,
 } from "harness";
 import net from "node:net";
+
+setDefaultTimeout(40_000);
 
 test.concurrent("cloneable and transferable equals", async () => {
   const dir = tempDirWithFiles("bun-test", {
@@ -1351,16 +1353,13 @@ test.concurrent(
     );
     expect(exitCode).toBe(0);
   },
-  40_000,
 );
 
 // A shutdown path and an error path both asking a worker to go away is the normal
 // race in a cluster manager, so Node makes the second disconnect() a no-op.
-test.concurrent(
-  "calling worker.disconnect() twice does not throw",
-  async () => {
-    using dir = tempDir("cluster-double-disconnect", {
-      "main.js": `
+test.concurrent("calling worker.disconnect() twice does not throw", async () => {
+  using dir = tempDir("cluster-double-disconnect", {
+    "main.js": `
       const cluster = require("node:cluster");
       if (cluster.isPrimary) {
         const worker = cluster.fork();
@@ -1372,31 +1371,27 @@ test.concurrent(
         cluster.on("disconnect", () => console.log("cluster-disconnect"));
       }
     `,
-    });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "main.js"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).not.toContain("ERR_IPC_DISCONNECTED");
-    // The primary and the worker share stdout, so their interleaving is not fixed.
-    const lines = stdout.split("\n").filter(Boolean).sort();
-    expect(lines).toEqual(["cluster-disconnect", "worker-exit 0 null"]);
-    expect(exitCode).toBe(0);
-  },
-  30_000,
-);
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("ERR_IPC_DISCONNECTED");
+  // The primary and the worker share stdout, so their interleaving is not fixed.
+  const lines = stdout.split("\n").filter(Boolean).sort();
+  expect(lines).toEqual(["cluster-disconnect", "worker-exit 0 null"]);
+  expect(exitCode).toBe(0);
+});
 
 // The primary keeps its end of the channel open, so a "disconnect" sent before the
 // worker booted does not swallow the "online" message coming the other way.
-test.concurrent(
-  "disconnecting a worker before it comes online still emits 'online'",
-  async () => {
-    using dir = tempDir("cluster-disconnect-before-online", {
-      "main.js": `
+test.concurrent("disconnecting a worker before it comes online still emits 'online'", async () => {
+  using dir = tempDir("cluster-disconnect-before-online", {
+    "main.js": `
       const cluster = require("node:cluster");
       if (cluster.isPrimary) {
         const worker = cluster.fork();
@@ -1405,17 +1400,15 @@ test.concurrent(
         worker.on("exit", code => console.log("worker-exit", code));
       }
     `,
-    });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "main.js"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "inherit",
-    });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect(stdout.split("\n").filter(Boolean).sort()).toEqual(["online", "worker-exit 0"]);
-    expect(exitCode).toBe(0);
-  },
-  30_000,
-);
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout.split("\n").filter(Boolean).sort()).toEqual(["online", "worker-exit 0"]);
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -1276,3 +1276,146 @@ if (cluster.isPrimary) {
   });
   expect(exitCode).toBe(0);
 }, 30_000);
+
+// Per https://nodejs.org/api/cluster.html#workerdisconnect, disconnect() closes the
+// worker's servers, waits for their 'close' events, then disconnects the channel.
+// node:http binds its own socket instead of using _getServer, so it needs tracking.
+test.concurrent(
+  "primary-initiated worker.disconnect() closes the worker's http server and the worker exits",
+  async () => {
+    using dir = tempDir("cluster-disconnect-http", {
+      "main.js": `
+        const cluster = require("node:cluster");
+        const http = require("node:http");
+        const net = require("node:net");
+
+        if (cluster.isPrimary) {
+          const worker = cluster.fork();
+          const disconnected = new Promise(resolve => worker.once("disconnect", resolve));
+          const exited = new Promise(resolve => worker.once("exit", (code, signal) => resolve({ code, signal })));
+
+          worker.on("message", async msg => {
+            if (msg.cmd !== "listening") return;
+            const port = msg.port;
+            const before = await (await fetch(\`http://127.0.0.1:\${port}/\`)).text();
+
+            worker.disconnect();
+
+            // The worker must close its server, disconnect the channel and
+            // exit on its own. If it never does (the bug), kill it so it
+            // cannot outlive the test, and report the failure.
+            let timer;
+            const timedOut = new Promise(resolve => {
+              timer = setTimeout(resolve, 20_000, "timeout");
+            });
+            const exit = await Promise.race([Promise.all([exited, disconnected]).then(([e]) => e), timedOut]);
+            clearTimeout(timer);
+            if (exit === "timeout") {
+              worker.process.kill("SIGKILL");
+              console.log(JSON.stringify({ fail: "worker did not exit after disconnect()" }));
+              process.exit(1);
+            }
+
+            // The worker is gone, so nothing may be listening on its port.
+            const after = await new Promise(resolve => {
+              const socket = net.connect(port, "127.0.0.1");
+              socket.once("connect", () => {
+                socket.destroy();
+                resolve("still listening");
+              });
+              socket.once("error", () => resolve("refused"));
+            });
+
+            console.log(JSON.stringify({ before, exit, exitedAfterDisconnect: worker.exitedAfterDisconnect, after }));
+            process.exit(0);
+          });
+        } else {
+          const server = http.createServer((req, res) => res.end("served-by-worker"));
+          server.listen(0, "127.0.0.1", () => {
+            process.send({ cmd: "listening", port: server.address().port });
+          });
+        }
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      // Inherited so that on regression the worker's output reaches the
+      // runner log instead of filling an unread pipe.
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout.trim()).toBe(
+      '{"before":"served-by-worker","exit":{"code":0,"signal":null},"exitedAfterDisconnect":true,"after":"refused"}',
+    );
+    expect(exitCode).toBe(0);
+  },
+  40_000,
+);
+
+// A shutdown path and an error path both asking a worker to go away is the normal
+// race in a cluster manager, so Node makes the second disconnect() a no-op.
+test.concurrent(
+  "calling worker.disconnect() twice does not throw",
+  async () => {
+    using dir = tempDir("cluster-double-disconnect", {
+      "main.js": `
+      const cluster = require("node:cluster");
+      if (cluster.isPrimary) {
+        const worker = cluster.fork();
+        worker.on("online", () => {
+          worker.disconnect();
+          worker.disconnect();
+        });
+        worker.on("exit", (code, signal) => console.log("worker-exit", code, signal));
+        cluster.on("disconnect", () => console.log("cluster-disconnect"));
+      }
+    `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("ERR_IPC_DISCONNECTED");
+    // The primary and the worker share stdout, so their interleaving is not fixed.
+    const lines = stdout.split("\n").filter(Boolean).sort();
+    expect(lines).toEqual(["cluster-disconnect", "worker-exit 0 null"]);
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);
+
+// The primary keeps its end of the channel open, so a "disconnect" sent before the
+// worker booted does not swallow the "online" message coming the other way.
+test.concurrent(
+  "disconnecting a worker before it comes online still emits 'online'",
+  async () => {
+    using dir = tempDir("cluster-disconnect-before-online", {
+      "main.js": `
+      const cluster = require("node:cluster");
+      if (cluster.isPrimary) {
+        const worker = cluster.fork();
+        worker.disconnect();
+        worker.on("online", () => console.log("online"));
+        worker.on("exit", code => console.log("worker-exit", code));
+      }
+    `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout.split("\n").filter(Boolean).sort()).toEqual(["online", "worker-exit 0"]);
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);


### PR DESCRIPTION
### Problem
- `worker.disconnect()` called from the primary does not shut a worker down cleanly. Three separate gaps, each reproduced by a test in `test/js/node/cluster.test.ts`:
  - A worker's `node:http` server keeps it alive forever. `_http_server.ts` binds its own socket in a worker instead of going through `cluster._getServer`, so the child's handle table (`src/js/internal/cluster/child.ts`, `handles`) never contains it and `_disconnect()` has nothing to close.
  - `Worker.prototype.disconnect` on the primary (`src/js/internal/cluster/primary.ts`) called `this.process.disconnect()` itself. The worker is supposed to close its servers and then disconnect from its side; closing the channel from the primary skips that, and if `disconnect()` is called before the worker has booted, the worker's `online` message is lost.
  - Calling `disconnect()` twice re-ran the worker's `_disconnect()`, which closed the servers again and tore down an already-closed channel. Node makes the repeat a no-op.
- The originally reported case (#20642: a `net.Server` keeping the worker alive) is already fixed on current main by the `kClusterOwner` linkage between `node:net` and the cluster child, so that part of this PR was dropped during the rebase. Its test passes on main without this change.

### Fix
- `child.ts`: add `cluster._trackServer(server)`, which puts a server into the handle table the disconnect protocol closes, and removes it when the server closes on its own. `_disconnect()` returns early if it already ran.
- `_http_server.ts`: call `cluster._trackServer` in the worker listen path.
- `primary.ts`: stop calling `this.process.disconnect()`; this matches Node's `Worker.prototype.disconnect`, which only sends the `disconnect` message and drops the worker's handles.
- Verification, debug build on current main:
  - `src/` reverted to main: the three new tests fail (http variant times out; the other two get no `online` / no events).
  - With the fix: all three pass; the rest of `cluster.test.ts` is unchanged.
  - All 80 `test/js/node/test/parallel/test-cluster-*.js` upstream tests pass.

### Background
- In `node:cluster`, a worker registers each listening server with the primary via `cluster._getServer`; the child keeps a table of those handles. `worker.disconnect()` in the primary sends an internal `disconnect` message, and the worker's `_disconnect()` closes everything in that table, waits for the close callbacks, and then calls `process.disconnect()` to drop the IPC channel, at which point nothing keeps its event loop alive and it exits. The primary emits `exit` when the process is gone.
- Bun's `node:http` does not use `_getServer` in workers; it listens on its own socket, so it falls outside that table unless registered explicitly.

<details>
<summary>Earlier shape of this PR</summary>

The PR originally shared an `owner_symbol` between `node:net` and the cluster child so the faux handle returned by `_getServer` could find its `net.Server`, which is what #20642 reports. main has since reworked that area (`kClusterOwner`, `kClusterFauxListen`), so after rebasing onto `95cb6939fa` the `net.ts` / `shared.ts` changes and the `net.Server` tests were removed as redundant. The three remaining fixes were squashed into one commit.
</details>

Fixes #20642

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 20 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/cluster.test.ts

<!-- robobun:evidence:end -->