### PR TITLE
fix: pass a proper `parent` to `Module._resolveFilename` overrides for createRequire from ESM

### DIFF
--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -477,6 +477,7 @@ declare function $resolveSync(
   isESM?: boolean,
   isUserRequireResolve?: boolean,
   paths?: string[],
+  parentModule?: JSCommonJSModule | object,
 ): string;
 declare function $resume(): TODO;
 declare function $search(): TODO;

--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -16,7 +16,11 @@ export function require(this: JSCommonJSModule, _: string) {
 $overriddenName = "require";
 $visibility = "Private";
 export function overridableRequire(this: JSCommonJSModule, originalId: string, options: { paths?: string[] } = {}) {
-  const id = $resolveSync(originalId, this.filename, false, false, options ? options.paths : undefined);
+  // Pass `this` as the 6th argument so a user-overridden `Module._resolveFilename`
+  // sees a proper `parent` module object even when `this` wasn't registered in
+  // $requireMap (e.g. a require created by `createRequire(import.meta.url)`
+  // from an ESM file).
+  const id = $resolveSync(originalId, this.filename, false, false, options ? options.paths : undefined, this);
   if (id.startsWith("node:")) {
     if (id !== originalId) {
       // A terrible special case where Node.js allows non-prefixed built-ins to
@@ -152,6 +156,10 @@ export function requireResolve(
     false,
     true,
     options ? options.paths : undefined,
+    // Pass `this` as the parent module when available, so a user-overridden
+    // `Module._resolveFilename` sees a proper `parent` even when `this`
+    // wasn't registered in $requireMap.
+    typeof this === "object" ? this : undefined,
   );
 }
 

--- a/src/jsc/bindings/ExposeNodeModuleGlobals.cpp
+++ b/src/jsc/bindings/ExposeNodeModuleGlobals.cpp
@@ -112,8 +112,11 @@ extern "C" [[ZIG_EXPORT(check_slow)]] void Bun__REPL__setupGlobalRequire(
         filename, filename, dirname, SourceCode());
     moduleObject->hasEvaluated = true;
 
+    // Bind `require.resolve` to the same synthetic module object as `require`
+    // so that the JS-side `requireResolve` builtin can forward a real parent
+    // module to $resolveSync (matters for user-overridden `_resolveFilename`).
     auto* resolveFunction = JSBoundFunction::create(vm, globalObject,
-        globalObject->requireResolveFunctionUnbound(), filename,
+        globalObject->requireResolveFunctionUnbound(), moduleObject,
         ArgList(), 1, globalObject->commonStrings().resolveString(globalObject),
         makeSource("resolve"_s, SourceOrigin(), SourceTaintedOrigin::Untainted));
     RETURN_IF_EXCEPTION(scope, );

--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -299,6 +299,12 @@ extern "C" JSC::EncodedJSValue functionImportMeta__resolveSyncPrivate(JSC::JSGlo
     bool isESM = callFrame->argument(2).asBoolean();
     bool isRequireDotResolve = callFrame->argument(3).isTrue();
     JSValue userPathList = callFrame->argument(4);
+    // Optional 6th argument: the parent JSCommonJSModule object. Passed by
+    // `overridableRequire` / `requireResolve` so that a custom
+    // `Module._resolveFilename` override sees a real `parent` (matching
+    // Node.js) even when the calling module wasn't registered in
+    // `requireMap` — e.g. a `createRequire(import.meta.url)` from ESM.
+    JSValue parentModuleValue = callFrame->argument(5);
 
     RETURN_IF_EXCEPTION(scope, {});
 
@@ -320,6 +326,18 @@ extern "C" JSC::EncodedJSValue functionImportMeta__resolveSyncPrivate(JSC::JSGlo
                 if (overrideHandler) [[likely]] {
                     ASSERT(overrideHandler->isCallable());
                     JSValue parentModuleObject = globalObject->requireMap()->get(globalObject, from);
+
+                    // Fall back to the caller-supplied parent module when the
+                    // requireMap lookup misses. This is the case for a
+                    // `createRequire(import.meta.url)` bound require: the
+                    // synthetic JSCommonJSModule that `createBoundRequireFunction`
+                    // built is never inserted into requireMap, but it carries
+                    // the correct filename/id/path for the override handler.
+                    if (parentModuleObject.isUndefinedOrNull() && parentModuleValue.isCell()) {
+                        if (dynamicDowncast<Bun::JSCommonJSModule>(parentModuleValue)) {
+                            parentModuleObject = parentModuleValue;
+                        }
+                    }
 
                     JSValue parentID = jsUndefined();
                     if (auto* parent = dynamicDowncast<Bun::JSCommonJSModule>(parentModuleObject)) {

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -126,10 +126,13 @@ static bool evaluateCommonJSModuleOnce(JSC::VM& vm, Zig::GlobalObject* globalObj
     JSFunction* requireFunction = nullptr;
     const auto initializeModuleObject = [&]() {
         SourceCode resolveSourceCode = makeSource("resolve"_s, SourceOrigin(), SourceTaintedOrigin::Untainted);
+        // Bind `require.resolve` to the module object (matches the binding
+        // used by `require` itself) so that the JS-side `requireResolve`
+        // builtin can forward a real parent to $resolveSync.
         resolveFunction = JSC::JSBoundFunction::create(vm,
             globalObject,
             globalObject->requireResolveFunctionUnbound(),
-            moduleObject->filename(),
+            moduleObject,
             ArgList(), 1, globalObject->commonStrings().resolveString(globalObject), resolveSourceCode);
         RETURN_IF_EXCEPTION(scope, );
 
@@ -302,17 +305,22 @@ JSC_DEFINE_HOST_FUNCTION(requireResolvePathsFunction, (JSGlobalObject * globalOb
 
     RETURN_IF_EXCEPTION(scope, {});
 
-    // This function is not bound with the module object. This is because nearly
-    // no one uses this and it is not worth creating an extra bound function for
-    // every single module. Instead, we can unwrap the bound function that we
-    // can see through the `this`.
+    // `require.resolve` is a bound function. Its `boundThis` is the synthetic
+    // JSCommonJSModule created for this require; we extract its filename
+    // string to resolve lookup paths from. (Older binding used a JSString
+    // directly — accept that shape too for robustness.)
     JSValue thisValue = callframe->thisValue();
     auto* requireResolveBound = dynamicDowncast<JSC::JSBoundFunction>(thisValue);
     if (!requireResolveBound) [[unlikely]] {
         return JSValue::encode(constructEmptyArray(globalObject, nullptr, 0));
     }
     JSValue boundThis = requireResolveBound->boundThis();
-    JSString* filename = dynamicDowncast<JSString>(boundThis);
+    JSString* filename = nullptr;
+    if (auto* boundModule = dynamicDowncast<Bun::JSCommonJSModule>(boundThis)) {
+        filename = dynamicDowncast<JSString>(boundModule->filename());
+    } else {
+        filename = dynamicDowncast<JSString>(boundThis);
+    }
     if (!filename) [[unlikely]] {
         return JSValue::encode(constructEmptyArray(globalObject, nullptr, 0));
     }
@@ -1651,10 +1659,17 @@ JSObject* JSCommonJSModule::createBoundRequireFunction(VM& vm, JSGlobalObject* l
 
     SourceCode resolveSourceCode = makeSource("resolve"_s, SourceOrigin(), SourceTaintedOrigin::Untainted);
 
+    // Bind `require.resolve` to the same synthetic JSCommonJSModule as
+    // `require` itself. The JS-side `requireResolve` builtin extracts
+    // `this.filename` for the `from` path and forwards the whole module
+    // object to `$resolveSync` so that a user-overridden
+    // `Module._resolveFilename` sees a proper `parent` (matching Node.js)
+    // even for a `createRequire(import.meta.url)` require that was never
+    // registered in `requireMap`.
     JSFunction* resolveFunction = JSC::JSBoundFunction::create(vm,
         globalObject,
         globalObject->requireResolveFunctionUnbound(),
-        moduleObject->filename(),
+        moduleObject,
         ArgList(), 1, globalObject->commonStrings().resolveString(globalObject), resolveSourceCode);
     RETURN_IF_EXCEPTION(scope, nullptr);
 

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, ospath } from "harness";
+import { bunEnv, bunExe, ospath, tempDir } from "harness";
 import Module, { _nodeModulePaths, builtinModules, createRequire, isBuiltin, wrap } from "module";
 import path from "path";
 
@@ -92,6 +92,67 @@ describe.concurrent("node-module-module", () => {
     const stdout = await proc.stdout.text();
     expect(stdout.trim().endsWith("--pass--")).toBe(true);
     expect(await proc.exited).toBe(0);
+  });
+
+  // https://github.com/oven-sh/bun/issues/30546
+  // https://github.com/oven-sh/bun/issues/13076
+  // When user code (e.g. tsx) overrides Module._resolveFilename and delegates
+  // to the original, a `require` created via `createRequire(import.meta.url)`
+  // used to pass `parent = undefined` to the override. The original then had
+  // no referrer and couldn't resolve relative specifiers — the failure mode
+  // that reproduced as `Cannot find module '../data/patch.json' from ''` in
+  // css-tree.
+  test("createRequire() + _resolveFilename override gets a proper parent", async () => {
+    using dir = tempDir("create-require-resolve-override", {
+      "parent.mjs": `
+        import Module, { createRequire } from "node:module";
+        const seen = [];
+        const original = Module._resolveFilename;
+        Module._resolveFilename = function(request, parent, ...rest) {
+          seen.push({
+            request,
+            type: typeof parent,
+            filename: parent && parent.filename,
+            id: parent && parent.id,
+          });
+          return original.call(this, request, parent, ...rest);
+        };
+        const require = createRequire(import.meta.url);
+        const child = require("./child.json");
+        const resolved = require.resolve("./child.json");
+        console.log(JSON.stringify({ child, resolved, seen }));
+      `,
+      "child.json": '{"ok":true}',
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "parent.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    const { child, resolved, seen } = JSON.parse(stdout);
+    const parentPath = path.join(String(dir), "parent.mjs");
+    const childPath = path.join(String(dir), "child.json");
+    expect(child).toEqual({ ok: true });
+    expect(resolved).toBe(ospath(childPath));
+    // Both require() and require.resolve() from the ESM-created require must
+    // pass a parent object carrying filename/id to the override — not undefined.
+    expect(seen).toEqual([
+      { request: "./child.json", type: "object", filename: ospath(parentPath), id: ospath(parentPath) },
+      { request: "./child.json", type: "object", filename: ospath(parentPath), id: ospath(parentPath) },
+    ]);
   });
 
   test("Overwriting Module.prototype.require", async () => {

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -133,11 +133,7 @@ describe.concurrent("node-module-module", () => {
       stdout: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);


### PR DESCRIPTION
Fixes #30546 (duplicate of #13076).

## Repro

ESM file uses `createRequire(import.meta.url)`, user-land code (e.g. `tsx`) monkey-patches `Module._resolveFilename` and delegates back to the original:

```js
// parent.mjs
import Module, { createRequire } from 'node:module';
const original = Module._resolveFilename;
Module._resolveFilename = function (request, parent, ...rest) {
  return original.call(this, request, parent, ...rest);
};
const require = createRequire(import.meta.url);
require('./child.json');
```

Before this PR:

```console
$ bun parent.mjs
error: Cannot find module './child.json' from ''
```

css-tree's `lib/data-patch.js` reproduced this end-to-end as `Cannot find module '../data/patch.json' from ''` the moment anything registers an ESM loader hook.

## Cause

`createBoundRequireFunction` (in `JSCommonJSModule.cpp`) builds a synthetic `JSCommonJSModule` with the correct filename/id to serve as the `require`'s parent, but never inserts it into `requireMap`. The override dispatch in `functionImportMeta__resolveSyncPrivate` looked the parent up only by string key:

```cpp
JSValue parentModuleObject = globalObject->requireMap()->get(globalObject, from);
// miss → parentModuleObject = undefined → passed to override as parent
```

The override saw `parent = undefined`, delegated back to the original, and the original had no referrer to resolve relative paths from.

## Fix

Thread the caller's parent module through the existing `$resolveSync` intrinsic as a 6th argument, and fall back to it in C++ when the `requireMap` lookup misses. `require.resolve` is now bound to the same synthetic module object (consistent with `require` itself) so the same plumbing works for `require.resolve`; `require.resolve.paths` extracts the filename off the bound `JSCommonJSModule`.

After:

```console
$ bun-debug parent.mjs
OK
$ node parent.mjs  # (matches)
OK
```

## Test

`test/js/node/module/node-module-module.test.js` — new test asserts the override sees `parent.filename` / `parent.id` equal to the importer's path for both `require` and `require.resolve`, and that `require('./child.json')` actually returns the JSON contents.