### PR TITLE
Fix crash in Bun.inspect when JSX props is non-object or circular

### DIFF
--- a/src/jsc/ConsoleObject.zig
+++ b/src/jsc/ConsoleObject.zig
@@ -1136,7 +1136,7 @@ pub const Formatter = struct {
 
         pub fn canHaveCircularReferences(tag: Tag) bool {
             return switch (tag) {
-                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event => true,
+                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event, .JSX => true,
                 else => false,
             };
         }
@@ -3140,13 +3140,12 @@ pub const Formatter = struct {
                     }
                 }
 
-                if (try value.get(this.globalThis, "props")) |props| {
+                if (try value.get(this.globalThis, "props")) |props| props: {
                     const prev_quote_strings = this.quote_strings;
                     defer this.quote_strings = prev_quote_strings;
                     this.quote_strings = true;
 
-                    // SAFETY: JSX props are always objects
-                    const props_obj = props.getObject().?;
+                    const props_obj = props.getObject() orelse break :props;
                     var props_iter = try jsc.JSPropertyIterator(.{
                         .skip_empty_name = true,
                         .include_value = true,

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -316,6 +316,39 @@ it("jsx with fragment", () => {
   expect(input).toBe(output);
 });
 
+it("jsx with non-object props does not crash", () => {
+  const el = {
+    $$typeof: Symbol.for("react.transitional.element"),
+    type: "div",
+    key: null,
+    ref: null,
+    props: 1,
+  };
+  expect(Bun.inspect(el)).toBe("<div />");
+});
+
+it("jsx with circular props does not crash", () => {
+  const el = {
+    $$typeof: Symbol.for("react.transitional.element"),
+    type: "div",
+    key: null,
+    ref: null,
+  };
+  el.props = el;
+  expect(Bun.inspect(el)).toContain("[Circular]");
+});
+
+it("jsx with circular children does not crash", () => {
+  const el = {
+    $$typeof: Symbol.for("react.transitional.element"),
+    type: "div",
+    key: null,
+    ref: null,
+  };
+  el.props = { children: el };
+  expect(Bun.inspect(el)).toContain("[Circular]");
+});
+
 it("inspect", () => {
   expect(Bun.inspect(new TypeError("what")).includes("TypeError: what")).toBe(true);
   expect(Bun.inspect("hi")).toBe('"hi"');


### PR DESCRIPTION
## What does this PR do?

Fixes two crashes in `Bun.inspect` / `console.log` when formatting JSX-like elements (objects with `$$typeof` set to the React element symbol):

1. **Null unwrap panic** — the formatter assumed `props` was always an object and unwrapped `props.getObject()` with `.?`. When `props` was a primitive (e.g. a number), this panicked with `attempt to use null value`.

2. **Stack overflow** — the `.JSX` tag was not included in `canHaveCircularReferences`, so the visited-object map and the `isSafeToRecurse` stack check were skipped. A circular reference reachable through `props` or `props.children` recursed until the process segfaulted.

Found by Fuzzilli (fingerprint `11b5374beaf7e44f`).

## Repro

```js
const el = {
  $$typeof: Symbol.for("react.transitional.element"),
  type: "div",
  key: null,
  ref: null,
};
el.props = el;
Bun.inspect(el); // SIGSEGV before, prints [Circular] after
```

```js
const el = {
  $$typeof: Symbol.for("react.transitional.element"),
  type: "div",
  key: null,
  ref: null,
  props: 1,
};
Bun.inspect(el); // panic: attempt to use null value before, prints <div /> after
```

## How did you verify your code works?

- Added regression tests to `test/js/bun/util/inspect.test.js`
- `bun bd test test/js/bun/util/inspect.test.js` — all 75 tests pass
- `USE_SYSTEM_BUN=1 bun test test/js/bun/util/inspect.test.js -t jsx` — segfaults without the fix
- `bun bd test test/js/bun/console/` and `test/js/web/console/console-log.test.ts` pass