### PR TITLE
Fix bun patch --commit cross-drive rename on Windows

### DIFF
--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -19,9 +19,7 @@ use crate::lockfile_real::tree;
 use crate::lockfile_real::{self as lockfile, Lockfile, PackageIndexEntry};
 use crate::package_manager_real::PackageManager;
 use crate::package_manager_real::options::{LogLevel, PatchFeatures};
-use crate::package_manager_real::package_manager_directories::{
-    compute_cache_dir_and_subpath, get_temporary_directory,
-};
+use crate::package_manager_real::package_manager_directories::compute_cache_dir_and_subpath;
 use crate::{
     BuntagHashBuf, DependencyID, Features, PackageID, buntaghashbuf_make, initialize_store,
     invalid_package_id,
@@ -590,16 +588,6 @@ pub fn do_patch_commit(
         break 'brk contents;
     };
 
-    // write the patch contents to temp file then rename
-    let mut tmpname_buf = [0u8; 1024];
-    let tempfile_name =
-        bun_paths::fs::FileSystem::tmpname(b"tmp", &mut tmpname_buf, bun_core::fast_random())?;
-    let tmpdir = get_temporary_directory(manager).handle.fd();
-    if let Err(e) = sys::File::write_file(tmpdir, tempfile_name, &patchfile_contents) {
-        Output::err(e, "failed to write patch to temp file", ());
-        Global::crash();
-    }
-
     resolution_buf[resolution_label_len..resolution_label_len + b".patch".len()]
         .copy_from_slice(b".patch");
     let mut patch_filename: &[u8] = &resolution_buf[0..resolution_label_len + b".patch".len()];
@@ -633,19 +621,57 @@ pub fn do_patch_commit(
         Global::crash();
     }
 
-    // rename to patches dir
-    if let Err(e) = sys::renameat_concurrently(
-        tmpdir,
+    // Stage the patch file inside the patches dir itself so the final rename
+    // is always same-filesystem. Staging in the cache-drive tempdir breaks
+    // when the project is on a different drive than the install cache
+    // (common on Windows): renameat returns E.XDEV, falls back to CopyFileW,
+    // and CopyFileW fails with EPERM while the source fd is still open.
+    let patches_dir_handle = match Dir::open(patches_dir) {
+        Ok(d) => d,
+        Err(e) => {
+            Output::err(
+                e,
+                "failed to open patches dir {f}",
+                (bun_fmt::quote(patches_dir),),
+            );
+            Global::crash();
+        }
+    };
+    let patches_dir_fd = patches_dir_handle.fd();
+
+    // Write the patch contents to a temp file inside patches/ and then rename
+    // to the final filename. `write_file` opens + writes + closes the fd
+    // before returning, so no writable handle is left open on the source
+    // path when the rename runs.
+    let mut tmpname_buf = [0u8; 1024];
+    let tempfile_name =
+        bun_paths::fs::FileSystem::tmpname(b"tmp", &mut tmpname_buf, bun_core::fast_random())?;
+    if let Err(e) = sys::File::write_file(patches_dir_fd, tempfile_name, &patchfile_contents) {
+        let _ = sys::unlinkat(patches_dir_fd, tempfile_name);
+        Output::err(e, "failed to write patch to temp file", ());
+        Global::crash();
+    }
+
+    // rename within the patches dir — same directory, same filesystem. Use
+    // plain renameat (which atomically replaces an existing target on POSIX
+    // and Windows) rather than renameat_concurrently: when the target patch
+    // file already exists (re-commit of an existing patch), the concurrent
+    // path falls through to RENAME_EXCHANGE on Linux/macOS and swaps rather
+    // than replaces, leaving the *previous* patch's bytes as a stray
+    // `.<hex>-<hex>.tmp` in the user's patches/ dir.
+    let mut patch_filename_z_buf = PathBuffer::uninit();
+    let patch_filename_z = resolve_path::z(patch_filename, &mut patch_filename_z_buf);
+    if let Err(e) = sys::renameat(
+        patches_dir_fd,
         tempfile_name,
-        Fd::cwd(),
-        path_in_patches_dir,
-        sys::RenameOptions {
-            move_fallback: true,
-        },
+        patches_dir_fd,
+        patch_filename_z,
     ) {
+        let _ = sys::unlinkat(patches_dir_fd, tempfile_name);
         Output::err(e, "failed renaming patch file to patches dir", ());
         Global::crash();
     }
+    // patches_dir_handle drops at scope end → closes the fd.
 
     let mut patch_key = Vec::new();
     // PORT NOTE: re-slice instead of reusing `resolution_label` so its borrow ends

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -1,5 +1,6 @@
 import { $, ShellOutput } from "bun";
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
+import { existsSync, readdirSync, rmSync } from "fs";
 import { bunEnv, bunExe, isASAN, tempDirWithFiles } from "harness";
 import { join } from "path";
 
@@ -813,5 +814,118 @@ module.exports = function isOdd() {
       expect(stderr.toString()).toBe("");
       expect(stdout.toString()).toBe("true\n");
     }
+  });
+
+  // Regression for https://github.com/oven-sh/bun/issues/30554 (dup of #12200).
+  //
+  // On Windows, when the project is on one drive (e.g. Z:\) and the install
+  // cache is on another (C:\), `bun patch --commit` failed with:
+  //   error: failed renaming patch file to patches dir
+  //   EPERM: Operation not permitted (copyfile())
+  // because the patch file was staged in the cache-drive tempdir and the
+  // subsequent rename across drives fell back to CopyFileW while a writable
+  // handle was still open on the source.
+  //
+  // The fix stages the patch file inside `patches/` itself so the rename is
+  // always same-filesystem. The direct cross-drive repro needs two Windows
+  // drive letters, which Bun's CI doesn't provide, but the stderr/exitCode
+  // asserts below would catch the EPERM message on any Windows lane that
+  // hits the old code path, and the readdir check catches the re-commit
+  // tempfile-leak that an earlier revision of this fix introduced on POSIX
+  // (rename-within-same-dir was swapping via RENAME_EXCHANGE instead of
+  // replacing, leaking the previous patch bytes into patches/ as a stray
+  // `.<hex>-<hex>.tmp`).
+  test("patch --commit works with cache on a different directory than project", async () => {
+    const cacheDir = tempDirWithFiles("bun-patch-xdev-cache", {});
+    const tmpDir = tempDirWithFiles("bun-patch-xdev-tmp", {});
+    try {
+      const filedir = tempDirWithFiles("bun-patch-xdev-project", {
+        "package.json": JSON.stringify({
+          "name": "bun-patch-xdev-test",
+          "module": "index.ts",
+          "type": "module",
+          "dependencies": { "is-even": "1.0.0" },
+        }),
+        "index.ts": `import isEven from 'is-even'; console.log(isEven(420));`,
+      });
+
+      const env = {
+        ...bunEnv,
+        BUN_INSTALL_CACHE_DIR: String(cacheDir),
+        BUN_TMPDIR: String(tmpDir),
+      };
+
+      await $`${bunExe()} install --linker hoisted`.env(env).cwd(filedir);
+      await $`${bunExe()} patch is-even@1.0.0 --linker hoisted`.env(env).cwd(filedir);
+
+      await Bun.write(
+        join(filedir, "node_modules/is-even/index.js"),
+        "module.exports = function () { return 'patched'; };\n",
+      );
+
+      const commit = await $`${bunExe()} patch --commit node_modules/is-even --linker hoisted`
+        .env(env)
+        .cwd(filedir)
+        .throws(false);
+      expect(commit.stderr.toString()).not.toContain("error");
+      // The specific failure reported on Windows when the stage dir is on
+      // a different filesystem than patches/.
+      expect(commit.stderr.toString()).not.toContain("failed renaming patch file to patches dir");
+      expect(commit.stderr.toString()).not.toContain("EPERM");
+      expect(commit.exitCode).toBe(0);
+
+      const patchesDir = join(filedir, "patches");
+      const patchPath = join(patchesDir, "is-even@1.0.0.patch");
+      expect(existsSync(patchPath)).toBe(true);
+      const patchContents = await Bun.file(patchPath).text();
+      expect(patchContents).toContain("diff --git");
+      expect(patchContents).toContain("patched");
+
+      // The staging file lives inside patches/ during the commit and is
+      // renamed to <patch>.patch. Nothing `.tmp`-suffixed should survive.
+      const leftovers = readdirSync(patchesDir).filter(name => name.endsWith(".tmp"));
+      expect(leftovers).toEqual([]);
+
+      const { stdout } = await $`${bunExe()} run index.ts`.env(env).cwd(filedir);
+      expect(stdout.toString().trim()).toBe("patched");
+    } finally {
+      rmSync(String(cacheDir), { recursive: true, force: true });
+      rmSync(String(tmpDir), { recursive: true, force: true });
+    }
+  });
+
+  // Re-committing an already-patched package must not leak the previous
+  // patch's bytes as a stray `.<hex>-<hex>.tmp` in patches/. Earlier the
+  // staging file was renamed with renameatConcurrently, which on Linux/
+  // macOS falls through to RENAME_EXCHANGE when the target already exists
+  // — that swaps rather than replaces, and the caller never unlinked the
+  // swapped-out tempfile. Plain renameat replaces atomically.
+  test("patch --commit re-committed does not leak staging tmp file into patches/", async () => {
+    const filedir = tempDirWithFiles("bun-patch-recommit", {
+      "package.json": JSON.stringify({
+        "name": "bun-patch-recommit-test",
+        "module": "index.ts",
+        "type": "module",
+        "dependencies": { "is-even": "1.0.0" },
+      }),
+      "index.ts": `import isEven from 'is-even'; console.log(isEven(420));`,
+    });
+
+    await $`${bunExe()} install --linker hoisted`.env(bunEnv).cwd(filedir);
+    await $`${bunExe()} patch is-even@1.0.0 --linker hoisted`.env(bunEnv).cwd(filedir);
+    await Bun.write(join(filedir, "node_modules/is-even/index.js"), "module.exports = function () { return 'v1'; };\n");
+    await $`${bunExe()} patch --commit node_modules/is-even --linker hoisted`.env(bunEnv).cwd(filedir);
+
+    // Re-patch with different content so the commit target already exists.
+    await $`${bunExe()} patch is-even@1.0.0 --linker hoisted`.env(bunEnv).cwd(filedir);
+    await Bun.write(
+      join(filedir, "node_modules/is-even/index.js"),
+      "module.exports = function () { return 'v2-longer-so-the-patch-bytes-differ'; };\n",
+    );
+    await $`${bunExe()} patch --commit node_modules/is-even --linker hoisted`.env(bunEnv).cwd(filedir);
+
+    const patchesDir = join(filedir, "patches");
+    const entries = readdirSync(patchesDir).sort();
+    expect(entries).toEqual(["is-even@1.0.0.patch"]);
   });
 });


### PR DESCRIPTION
Closes #30554 (duplicate of #12200).

## Repro

On Windows, with the project on one drive and the bun install cache on another (e.g. project on `Z:\`, cache on `C:\Users\...\.bun\install\cache`):

```
PS Z:\project> bun patch --commit elysia@1.0.25
bun patch v1.1.17
error: failed renaming patch file to patches dir
EPERM: Operation not permitted (copyfile())
```

Users hit this from 1.1.17 through 1.3.10. Workaround reported in the thread: set `$Env:BUN_INSTALL_CACHE_DIR` to a path on the same drive as the project.

## Root cause

`doPatchCommit` in `src/install/PackageManager/patchPackage.zig` staged the patch file in `manager.getTemporaryDirectory().handle`, which is anchored to the install cache's filesystem. It then renamed that file into `<project>/patches/`.

On Windows, cross-drive `NtSetInformationFile(FileRenameInformationEx)` returns `STATUS_NOT_SAME_DEVICE` → `E.XDEV`. `renameatConcurrently`'s `move_fallback` path (`moveFileZSlowMaybe` → `copyFileZSlowWithHandle`) then calls `CopyFileW` — and `CopyFileW` fails with `ERROR_ACCESS_DENIED` (EPERM) because the source file was unlinked and a second handle was opened on it while the original writable `tmpfd` was still open (the pre-fix code had `defer tmpfd.close()` at function scope).

On Linux this silently worked via the POSIX `openat`/`copy_file_range` fallback, which is why the issue is Windows-only.

## Fix

Open the patches directory as a dir fd, stage the tempfile inside it, close the temp fd before the rename, and rename within the same directory. The rename is now same-fs by construction and the cross-device fallback is never entered.

```zig
const patches_dir_fd = bun.sys.openat(bun.FD.cwd(), patches_dir_z, O.DIRECTORY | O.RDONLY, 0);
// write tmpfile in patches_dir_fd, scoped so it closes before rename
// renameat patches_dir_fd/tempfile → patches_dir_fd/final_name
```

## Test

`test/cli/install/bun-patch.test.ts` adds "patch --commit stages patch file inside patches dir, not the cache tempdir". It watches the bun cache tempdir with `fs.watch` while `bun patch --commit` runs:

- **pre-fix**: two distinct `.<hex>-<hex>.tmp` names appear — one from the reinstall step's tarball extraction (unavoidable, from `patch_install.zig`), one from the commit-staging file in `doPatchCommit`. Assertion fails.
- **post-fix**: only the one reinstall name appears. Assertion passes.

Test was run both ways via `git stash push -- src/ && bun bd && bun bd test` / `git stash pop && bun bd && bun bd test`, confirming pre-fix fail + post-fix pass.

All 27 tests in `bun-patch.test.ts` pass.