### PR TITLE
Fix crash in Bun.build() with many `conditions`

### DIFF
--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1087,9 +1087,10 @@ pub const ESMConditions = struct {
         var require_condition_map = ConditionsMap.init(allocator);
         var style_condition_map = ConditionsMap.init(allocator);
 
-        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
+        const addon_count: usize = if (allow_addons) 1 else 0;
+        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + addon_count + conditions.len);
+        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + addon_count + conditions.len);
+        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + addon_count + conditions.len);
         try style_condition_map.ensureTotalCapacity(defaults.len + 2 + conditions.len);
 
         import_condition_map.putAssumeCapacity("import", {});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -134,6 +134,18 @@ describe("Bun.build", () => {
     ).toThrow();
   });
 
+  test("many conditions does not crash", async () => {
+    const dir = tempDirWithFiles("bun-build-api-conditions", {
+      "index.js": `console.log("hello");`,
+    });
+    const build = await Bun.build({
+      entrypoints: [join(dir, "index.js")],
+      conditions: ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t"],
+    });
+    expect(build.success).toBe(true);
+    expect(build.outputs).toHaveLength(1);
+  });
+
   test("returns errors properly", async () => {
     Bun.gc(true);
     const build = await buildNoThrow({


### PR DESCRIPTION
## What does this PR do?

Fixes an assertion failure in `ESMConditions.init` when `Bun.build()` is called with a non-trivial number of `conditions`.

The capacity reservation used:

```zig
defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len
```

which Zig parses as:

```zig
defaults.len + 2 + (if (allow_addons) 1 else (0 + conditions.len))
```

When `allow_addons` is `true` (the default), `conditions.len` was dropped entirely from the capacity calculation. The subsequent `putAssumeCapacity` calls would then overflow the map and trip `assert(self.len < self.capacity)` in `MultiArrayList.addOneAssumeCapacity`.

Repro:

```js
await Bun.build({
  entrypoints: ["./index.js"],
  conditions: ["a", "b", "c", "d", "e", "f", "g"],
});
```

## How did you verify your code works?

- Added a regression test in `test/bundler/bun-build-api.test.ts` that passes 20 conditions; it crashes the bundle thread before this change and passes after.
- `bun bd test test/bundler/bun-build-api.test.ts` — all 40 tests pass.

Found by Fuzzilli (fingerprint `a16293634a0a5123`).