### PR TITLE
fix: preserve non-ASCII chars in String.raw and RegExp.source - bun didn't print out a bun: ╭─╮

### DIFF
--- a/src/js_printer/js_printer.zig
+++ b/src/js_printer/js_printer.zig
@@ -1990,62 +1990,10 @@ fn NewPrinter(
         }
 
         fn printRawTemplateLiteral(p: *Printer, bytes: []const u8) void {
-            if (comptime is_json or !ascii_only) {
-                p.print(bytes);
-                return;
-            }
-
-            // Translate any non-ASCII to unicode escape sequences
-            // Note that this does not correctly handle malformed template literal strings
-            // template literal strings can contain invalid unicode code points
-            // and pretty much anything else
-            //
-            // we use WTF-8 here, but that's still not good enough.
-            //
-            var ascii_start: usize = 0;
-            var is_ascii = false;
-            var iter = CodepointIterator.init(bytes);
-            var cursor = CodepointIterator.Cursor{};
-
-            while (iter.next(&cursor)) {
-                switch (cursor.c) {
-                    // unlike other versions, we only want to mutate > 0x7F
-                    0...last_ascii => {
-                        if (!is_ascii) {
-                            ascii_start = cursor.i;
-                            is_ascii = true;
-                        }
-                    },
-                    else => {
-                        if (is_ascii) {
-                            p.print(bytes[ascii_start..cursor.i]);
-                            is_ascii = false;
-                        }
-
-                        switch (cursor.c) {
-                            0...0xFFFF => {
-                                p.print([_]u8{
-                                    '\\',
-                                    'u',
-                                    hex_chars[cursor.c >> 12],
-                                    hex_chars[(cursor.c >> 8) & 15],
-                                    hex_chars[(cursor.c >> 4) & 15],
-                                    hex_chars[cursor.c & 15],
-                                });
-                            },
-                            else => {
-                                p.print("\\u{");
-                                p.fmt("{x}", .{cursor.c}) catch unreachable;
-                                p.print("}");
-                            },
-                        }
-                    },
-                }
-            }
-
-            if (is_ascii) {
-                p.print(bytes[ascii_start..]);
-            }
+            // Raw template parts are exposed to JS as-is via String.raw and
+            // TemplateStringsArray.raw[i]; escaping non-ASCII to \uXXXX would
+            // change those property values at runtime.
+            p.print(bytes);
         }
 
         pub fn printExpr(p: *Printer, expr: Expr, level: Level, in_flags: ExprFlag.Set) void {
@@ -3252,70 +3200,9 @@ fn NewPrinter(
                 p.print(" ");
             }
 
-            if (comptime is_bun_platform) {
-                // Translate any non-ASCII to unicode escape sequences
-                var ascii_start: usize = 0;
-                var is_ascii = false;
-                var iter = CodepointIterator.init(e.value);
-                var cursor = CodepointIterator.Cursor{};
-                while (iter.next(&cursor)) {
-                    switch (cursor.c) {
-                        first_ascii...last_ascii => {
-                            if (!is_ascii) {
-                                ascii_start = cursor.i;
-                                is_ascii = true;
-                            }
-                        },
-                        else => {
-                            if (is_ascii) {
-                                p.print(e.value[ascii_start..cursor.i]);
-                                is_ascii = false;
-                            }
-
-                            switch (cursor.c) {
-                                0...0xFFFF => {
-                                    p.print([_]u8{
-                                        '\\',
-                                        'u',
-                                        hex_chars[cursor.c >> 12],
-                                        hex_chars[(cursor.c >> 8) & 15],
-                                        hex_chars[(cursor.c >> 4) & 15],
-                                        hex_chars[cursor.c & 15],
-                                    });
-                                },
-
-                                else => |c| {
-                                    const k = c - 0x10000;
-                                    const lo = @as(usize, @intCast(first_high_surrogate + ((k >> 10) & 0x3FF)));
-                                    const hi = @as(usize, @intCast(first_low_surrogate + (k & 0x3FF)));
-
-                                    p.print(&[_]u8{
-                                        '\\',
-                                        'u',
-                                        hex_chars[lo >> 12],
-                                        hex_chars[(lo >> 8) & 15],
-                                        hex_chars[(lo >> 4) & 15],
-                                        hex_chars[lo & 15],
-                                        '\\',
-                                        'u',
-                                        hex_chars[hi >> 12],
-                                        hex_chars[(hi >> 8) & 15],
-                                        hex_chars[(hi >> 4) & 15],
-                                        hex_chars[hi & 15],
-                                    });
-                                },
-                            }
-                        },
-                    }
-                }
-
-                if (is_ascii) {
-                    p.print(e.value[ascii_start..]);
-                }
-            } else {
-                // UTF8 sequence is fine
-                p.print(e.value);
-            }
+            // RegExp source is exposed to JS via RegExp.prototype.source;
+            // escaping non-ASCII to \uXXXX would change that property value.
+            p.print(e.value);
 
             // Need a space before the next identifier to avoid it turning into flags
             p.prev_reg_exp_end = p.writer.written;

--- a/src/jsc/AsyncModule.zig
+++ b/src/jsc/AsyncModule.zig
@@ -726,7 +726,13 @@ pub const AsyncModule = struct {
 
         return ResolvedSource{
             .allocator = null,
-            .source_code = bun.String.cloneLatin1(printer.ctx.getWritten()),
+            .source_code = brk: {
+                const written = printer.ctx.getWritten();
+                break :brk if (bun.strings.firstNonASCII(written) != null)
+                    bun.String.cloneUTF8(written)
+                else
+                    bun.String.cloneLatin1(written);
+            },
             .specifier = String.init(specifier),
             .source_url = String.init(path.text),
             .is_commonjs_module = parse_result.ast.has_commonjs_export_names or parse_result.ast.exports_kind == .cjs,

--- a/src/jsc/ModuleLoader.zig
+++ b/src/jsc/ModuleLoader.zig
@@ -576,7 +576,10 @@ pub fn transpileSourceCode(
                 .allocator = null,
                 .source_code = brk: {
                     const written = printer.ctx.getWritten();
-                    const result = cache.output_code orelse bun.String.cloneLatin1(written);
+                    const result = cache.output_code orelse if (bun.strings.firstNonASCII(written) != null)
+                        bun.String.cloneUTF8(written)
+                    else
+                        bun.String.cloneLatin1(written);
 
                     if (written.len > 1024 * 1024 * 2 or jsc_vm.smol) {
                         printer.ctx.buffer.deinit();

--- a/src/jsc/RuntimeTranspilerCache.zig
+++ b/src/jsc/RuntimeTranspilerCache.zig
@@ -17,7 +17,8 @@
 /// Version 18: Include ESM record (module info) with an ES Module, see #15758
 /// Version 19: Sourcemap blob is InternalSourceMap (varint stream + sync points), not VLQ.
 /// Version 20: InternalSourceMap stream is bit-packed windows.
-const expected_version = 20;
+/// Version 21: Preserve non-ASCII bytes in String.raw / RegExp.source (printer no longer escapes > 0x7F).
+const expected_version = 21;
 
 const debug = Output.scoped(.cache, .visible);
 const MINIMUM_CACHE_SIZE = 50 * 1024;
@@ -688,7 +689,10 @@ pub const RuntimeTranspilerCache = struct {
             return;
         }
         bun.assert(this.entry == null);
-        const output_code = bun.String.cloneLatin1(output_code_bytes);
+        const output_code = if (bun.strings.firstNonASCII(output_code_bytes) != null)
+            bun.String.cloneUTF8(output_code_bytes)
+        else
+            bun.String.cloneLatin1(output_code_bytes);
         this.output_code = output_code;
 
         toFile(this.input_byte_length.?, this.input_hash.?, this.features_hash.?, sourcemap, esm_record, output_code, this.exports_kind) catch |err| {
@@ -696,7 +700,7 @@ pub const RuntimeTranspilerCache = struct {
             return;
         };
         if (comptime bun.Environment.allow_assert)
-            debug("put() = {d} bytes", .{output_code.latin1().len});
+            debug("put() = {d} bytes", .{output_code.byteSlice().len});
     }
 };
 

--- a/src/jsc/RuntimeTranspilerStore.zig
+++ b/src/jsc/RuntimeTranspilerStore.zig
@@ -589,7 +589,10 @@ pub const RuntimeTranspilerStore = struct {
             const source_code = brk: {
                 const written = printer.ctx.getWritten();
 
-                const result = cache.output_code orelse bun.String.cloneLatin1(written);
+                const result = cache.output_code orelse if (bun.strings.firstNonASCII(written) != null)
+                    bun.String.cloneUTF8(written)
+                else
+                    bun.String.cloneLatin1(written);
 
                 if (written.len > 1024 * 1024 * 2 or vm.smol) {
                     printer.ctx.buffer.deinit();

--- a/test/bundler/transpiler/template-literal.test.ts
+++ b/test/bundler/transpiler/template-literal.test.ts
@@ -2,10 +2,10 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { join } from "path";
 
-// When targeting Bun's runtime,
-// We must escape latin1 characters in raw template literals
-// This is somewhat brittle
-test("template literal", () => {
+// Round-trips a fixture file through Bun's runtime transpiler to confirm the
+// cooked form of a template literal containing astral-plane characters (🐰)
+// survives transpile → JSC handoff with the expected bytes.
+test("template literal cooked form preserves astral-plane bytes", () => {
   const { stdout, exitCode } = Bun.spawnSync({
     cmd: [bunExe(), "run", join(import.meta.dir, "template-literal-fixture-test.js")],
     env: bunEnv,
@@ -15,8 +15,55 @@ test("template literal", () => {
 
   expect(exitCode).toBe(0);
   expect(stdout.toString()).toBe(
-    // This is base64 encoded contents of the template literal
-    // this narrows down the test to the transpiler instead of the runtime
+    // base64-encoded UTF-8 bytes the fixture writes out — comparing bytes
+    // rather than codepoints isolates this to the transpiler path.
     "8J+QsDEyMzEyM/CfkLDwn5Cw8J+QsPCfkLDwn5Cw8J+QsDEyM/CfkLAxMjPwn5CwMTIzMTIz8J+QsDEyM/CfkLAxMjPwn5CwLPCfkLB0cnVl",
   );
+});
+
+// Each case below confirms that `String.raw` returns the source bytes verbatim
+// for non-ASCII characters. Before the fix, Bun's printer re-escaped anything
+// > 0x7F in the raw portion of a template literal to `\uXXXX`, which then
+// showed up literally in `String.raw`'s output.
+test.each([
+  { name: "BMP box-drawing", input: "╭─╮", codepoints: [0x256d, 0x2500, 0x256e] },
+  { name: "Cyrillic", input: "Привет, Мир", codepoints: [...("Привет, Мир" as string)].map(c => c.codePointAt(0)!) },
+  { name: "CJK", input: "你好世界", codepoints: [...("你好世界" as string)].map(c => c.codePointAt(0)!) },
+  { name: "emoji (surrogate pair)", input: "Hello 🌍", codepoints: [...("Hello 🌍" as string)].map(c => c.codePointAt(0)!) },
+])("String.raw preserves non-ASCII: $name", async ({ input, codepoints }) => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `process.stdout.write(JSON.stringify({raw: String.raw\`${input}\`, codepoints: [...String.raw\`${input}\`].map(c => c.codePointAt(0))}))`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({ raw: input, codepoints });
+  expect(exitCode).toBe(0);
+});
+
+test("RegExp.prototype.source preserves non-ASCII", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `process.stdout.write(JSON.stringify({source: /╭─╮/.source, codepoints: [.../╭─╮/.source].map(c => c.codePointAt(0))}))`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({ source: "╭─╮", codepoints: [0x256d, 0x2500, 0x256e] });
+  expect(exitCode).toBe(0);
 });

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -77,6 +77,28 @@ describe("transpiler cache", () => {
     expect(b.stdout == "");
     expect(newCacheCount()).toBe(0);
   });
+  test("preserves non-ASCII bytes in String.raw across put/get", () => {
+    // Pad the source above MINIMUM_CACHE_SIZE so the runtime transpiler cache fires.
+    // The padding line must use UTF-8 byte length (50KB of ASCII '*'), then append the
+    // assertion code. The fix this test guards: put() used to clone the printer's UTF-8
+    // output as Latin-1, corrupting multi-byte sequences before they reached disk.
+    const filler = "/*" + "*".repeat(50 * 1024) + "*/\n";
+    const code = `process.stdout.write(JSON.stringify({ raw: String.raw\`╭─╮\`, source: /╭─╮/.source }));`;
+    writeFileSync(join(temp_dir, "a.js"), filler + code);
+
+    const expected = { raw: "╭─╮", source: "╭─╮" };
+
+    const a = bunRun(join(temp_dir, "a.js"), env);
+    expect(JSON.parse(a.stdout)).toEqual(expected);
+    expect(newCacheCount()).toBe(1);
+
+    // Second run reads from the cache. Both the on-disk encoding (utf8) and the load
+    // path must round-trip the bytes; if either is broken, JSON.parse fails or the
+    // codepoints come back as Latin-1 split bytes.
+    const b = bunRun(join(temp_dir, "a.js"), env);
+    expect(JSON.parse(b.stdout)).toEqual(expected);
+    expect(newCacheCount()).toBe(0);
+  });
   test("ignores files under 50kb", async () => {
     writeFileSync(join(temp_dir, "a.js"), dummyFile(50 * 1024 - 1, "1", "a"));
     const a = bunRun(join(temp_dir, "a.js"), env);


### PR DESCRIPTION
# Preserve non-ASCII bytes in `String.raw` and `RegExp.source`

## Summary

The runtime transpiler corrupted non-ASCII characters in two JS-visible
properties: the **raw** portion of template literals (exposed via `String.raw`
and `TemplateStringsArray.raw`) and the **source** of regex literals
(exposed via `RegExp.prototype.source`). Both contracts require the bytes to
round-trip verbatim; Bun's printer was re-escaping codepoints `> 0x7F` to
`\uXXXX`, which changed the runtime string values.

**Before:**

```js
String.raw`╭─╮`.length    // 18  (expected: 3)
/╭─╮/.source.length       // 18  (expected: 3)
String.raw`╭─╮`           // '╭─╮'  ← literal 18-char text
```

**After:** both return `3`, and

```js
[...String.raw`╭─╮`].map(c => c.codePointAt(0).toString(16))
// → ["256d", "2500", "256e"]
```

---

## Fix

Three paired parts — none alone is sufficient.

### 1. Printer — stop escaping (`src/js_printer/js_printer.zig`)

`printRawTemplateLiteral` and `printRegExpLiteral` now print source bytes
verbatim. The previous `ascii_only` / `is_bun_platform` escape loops violated
the source-verbatim contract of `.raw` and `.source`.

Cooked template strings, ordinary string literals, and identifiers still flow
through `writePreQuotedString` / the identifier printer and are unchanged.

### 2. JSC handoff — clone as UTF-8 when needed

Three runtime sites cloned the printer's output buffer as Latin-1. That was
safe only because the printer guaranteed ASCII-only output. With raw UTF-8
multi-byte sequences in the buffer, a 3-byte sequence like `E2 95 AD` (`╭`)
was mis-decoded as three Latin-1 chars `U+00E2 U+0095 U+00AD`.

```zig
const result = cache.output_code orelse if (bun.strings.firstNonASCII(written) != null)
    bun.String.cloneUTF8(written)
else
    bun.String.cloneLatin1(written);
```

`bun.strings.firstNonASCII` is SIMD-accelerated, so the ASCII fast path is
unchanged.

Sites updated:

- `src/jsc/ModuleLoader.zig` — primary module-load path
- `src/jsc/RuntimeTranspilerStore.zig` — async runtime transpile path
- `src/jsc/AsyncModule.zig` — async module path *(missed by [#18859][prev])*

### 3. Runtime transpiler cache — same bug on the disk path

`src/jsc/RuntimeTranspilerCache.zig`'s `put()` also called `cloneLatin1` on
the printer output before persisting. Without this fix, files large enough to
hit the cache (`> MINIMUM_CACHE_SIZE`) would lose non-ASCII bytes on first
write and remain wrong on every subsequent read.

- Same conditional `cloneUTF8` / `cloneLatin1` as the live paths.
- Cache version bumped **20 → 21** so entries written by older buggy builds
  are not reused.
- Debug log switched from `output_code.latin1().len` to
  `output_code.byteSlice().len` so the byte count is correct for either
  encoding.

---

## Prior art

This re-applies and extends [#18859][prev], which made the same printer +
JSC-handoff change but never merged. That PR missed `AsyncModule.zig`; this
PR includes it, plus the cache fix.

[prev]: https://github.com/oven-sh/bun/pull/18859

---

## Test plan

- [x] `bun bd test test/bundler/transpiler/template-literal.test.ts`
  — 6/6 pass: pre-existing astral-plane cooked-form test, 4 `String.raw`
  cases (BMP box-drawing, Cyrillic, CJK, surrogate-pair emoji), 1 regex
  `.source` case.
- [x] Same tests **fail** under `USE_SYSTEM_BUN=1 bun test …` — confirms they
  actually exercise the bug.
- [x] `bun bd test test/cli/run/transpiler-cache.test.ts` — new test pads a
  source file above `MINIMUM_CACHE_SIZE`, runs twice, and asserts
  `String.raw` / `/…/.source` round-trip on both the write and the read.
- [x] `bun bd test test/bundler/bundler_string.test.ts` — 59/59 pass, no
  bundler regression in template / string printing.
- [x] Repro confirmed at the CLI:

  ```sh
  bun bd -e 'console.log(String.raw`╭─╮`.length)'   # → 3
  bun bd -e 'console.log(/╭─╮/.source.length)'      # → 3
  ```

### Coverage

| Case | Codepoints |
| --- | --- |
| BMP box-drawing `╭─╮` | `U+256D U+2500 U+256E` |
| Cyrillic `Привет, Мир` | mixed BMP |
| CJK `你好世界` | `U+4F60 U+597D U+4E16 U+754C` |
| Emoji `Hello 🌍` | surrogate pair `U+1F30D` |
| Regex source `/╭─╮/` | BMP box-drawing |
| Cached transpile (>50 KB source) | BMP box-drawing, both write + read |
