### PR TITLE
Preserve non-ASCII bytes in String.raw and RegExp.source

### DIFF
--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -2586,7 +2586,7 @@ pub fn finalizeBundle(
                 dev.vm.printErrorLikeObjectToConsole(dev.vm.global.takeException(err));
                 @panic("Error thrown while evaluating server code. This is always a bug in the bundler.");
             };
-        } else c.BakeLoadServerHmrPatch(@ptrCast(dev.vm.global), bun.String.cloneLatin1(server_bundle)) catch |err| {
+        } else c.BakeLoadServerHmrPatch(@ptrCast(dev.vm.global), bun.String.cloneInferEncoding(server_bundle)) catch |err| {
             dev.vm.printErrorLikeObjectToConsole(dev.vm.global.takeException(err));
             @panic("Error thrown while evaluating server code. This is always a bug in the bundler.");
         };

--- a/src/bundler/OutputFile.zig
+++ b/src/bundler/OutputFile.zig
@@ -129,8 +129,21 @@ pub const Value = union(Kind) {
         return switch (v) {
             .noop => bun.String.empty,
             .buffer => |buf| {
-                // Use ExternalStringImpl to avoid cloning the string, at
-                // the cost of allocating space to remember the allocator.
+                // Bundler output can contain raw UTF-8 bytes from non-ASCII
+                // `String.raw` / `RegExp.source` literals (see #30563). The
+                // external-string fast path creates a Latin-1 WTFString,
+                // which can't represent multi-byte UTF-8 sequences. Fall
+                // through to `cloneInferEncoding` (which picks Latin-1 for
+                // pure ASCII and UTF-16 for non-ASCII) when the buffer is
+                // not pure ASCII, then free the buffer since the string
+                // takes its own copy.
+                if (bun.strings.firstNonASCII(buf.bytes)) |_| {
+                    defer buf.allocator.free(buf.bytes);
+                    return bun.String.cloneInferEncoding(buf.bytes);
+                }
+
+                // Pure ASCII: keep the zero-copy external-Latin-1 path that
+                // hands ownership of the bytes to WebKit.
                 const FreeContext = struct {
                     allocator: std.mem.Allocator,
 

--- a/src/js_printer/js_printer.zig
+++ b/src/js_printer/js_printer.zig
@@ -1990,62 +1990,11 @@ fn NewPrinter(
         }
 
         fn printRawTemplateLiteral(p: *Printer, bytes: []const u8) void {
-            if (comptime is_json or !ascii_only) {
-                p.print(bytes);
-                return;
-            }
-
-            // Translate any non-ASCII to unicode escape sequences
-            // Note that this does not correctly handle malformed template literal strings
-            // template literal strings can contain invalid unicode code points
-            // and pretty much anything else
-            //
-            // we use WTF-8 here, but that's still not good enough.
-            //
-            var ascii_start: usize = 0;
-            var is_ascii = false;
-            var iter = CodepointIterator.init(bytes);
-            var cursor = CodepointIterator.Cursor{};
-
-            while (iter.next(&cursor)) {
-                switch (cursor.c) {
-                    // unlike other versions, we only want to mutate > 0x7F
-                    0...last_ascii => {
-                        if (!is_ascii) {
-                            ascii_start = cursor.i;
-                            is_ascii = true;
-                        }
-                    },
-                    else => {
-                        if (is_ascii) {
-                            p.print(bytes[ascii_start..cursor.i]);
-                            is_ascii = false;
-                        }
-
-                        switch (cursor.c) {
-                            0...0xFFFF => {
-                                p.print([_]u8{
-                                    '\\',
-                                    'u',
-                                    hex_chars[cursor.c >> 12],
-                                    hex_chars[(cursor.c >> 8) & 15],
-                                    hex_chars[(cursor.c >> 4) & 15],
-                                    hex_chars[cursor.c & 15],
-                                });
-                            },
-                            else => {
-                                p.print("\\u{");
-                                p.fmt("{x}", .{cursor.c}) catch unreachable;
-                                p.print("}");
-                            },
-                        }
-                    },
-                }
-            }
-
-            if (is_ascii) {
-                p.print(bytes[ascii_start..]);
-            }
+            // The `.raw` portion of a tagged template literal (surfaced as
+            // `TemplateStringsArray.raw`, which `String.raw` reads) must
+            // round-trip the source bytes verbatim. Escaping codepoints > 0x7F
+            // to `\uXXXX` would silently change the runtime string value.
+            p.print(bytes);
         }
 
         pub fn printExpr(p: *Printer, expr: Expr, level: Level, in_flags: ExprFlag.Set) void {
@@ -3252,70 +3201,10 @@ fn NewPrinter(
                 p.print(" ");
             }
 
-            if (comptime is_bun_platform) {
-                // Translate any non-ASCII to unicode escape sequences
-                var ascii_start: usize = 0;
-                var is_ascii = false;
-                var iter = CodepointIterator.init(e.value);
-                var cursor = CodepointIterator.Cursor{};
-                while (iter.next(&cursor)) {
-                    switch (cursor.c) {
-                        first_ascii...last_ascii => {
-                            if (!is_ascii) {
-                                ascii_start = cursor.i;
-                                is_ascii = true;
-                            }
-                        },
-                        else => {
-                            if (is_ascii) {
-                                p.print(e.value[ascii_start..cursor.i]);
-                                is_ascii = false;
-                            }
-
-                            switch (cursor.c) {
-                                0...0xFFFF => {
-                                    p.print([_]u8{
-                                        '\\',
-                                        'u',
-                                        hex_chars[cursor.c >> 12],
-                                        hex_chars[(cursor.c >> 8) & 15],
-                                        hex_chars[(cursor.c >> 4) & 15],
-                                        hex_chars[cursor.c & 15],
-                                    });
-                                },
-
-                                else => |c| {
-                                    const k = c - 0x10000;
-                                    const lo = @as(usize, @intCast(first_high_surrogate + ((k >> 10) & 0x3FF)));
-                                    const hi = @as(usize, @intCast(first_low_surrogate + (k & 0x3FF)));
-
-                                    p.print(&[_]u8{
-                                        '\\',
-                                        'u',
-                                        hex_chars[lo >> 12],
-                                        hex_chars[(lo >> 8) & 15],
-                                        hex_chars[(lo >> 4) & 15],
-                                        hex_chars[lo & 15],
-                                        '\\',
-                                        'u',
-                                        hex_chars[hi >> 12],
-                                        hex_chars[(hi >> 8) & 15],
-                                        hex_chars[(hi >> 4) & 15],
-                                        hex_chars[hi & 15],
-                                    });
-                                },
-                            }
-                        },
-                    }
-                }
-
-                if (is_ascii) {
-                    p.print(e.value[ascii_start..]);
-                }
-            } else {
-                // UTF8 sequence is fine
-                p.print(e.value);
-            }
+            // `RegExp.prototype.source` must round-trip the source bytes
+            // verbatim. Escaping codepoints > 0x7F to `\uXXXX` would change
+            // what `.source` returns at runtime.
+            p.print(e.value);
 
             // Need a space before the next identifier to avoid it turning into flags
             p.prev_reg_exp_end = p.writer.written;

--- a/src/js_printer/js_printer.zig
+++ b/src/js_printer/js_printer.zig
@@ -1992,8 +1992,9 @@ fn NewPrinter(
         fn printRawTemplateLiteral(p: *Printer, bytes: []const u8) void {
             // The `.raw` portion of a tagged template literal (surfaced as
             // `TemplateStringsArray.raw`, which `String.raw` reads) must
-            // round-trip the source bytes verbatim. Escaping codepoints > 0x7F
-            // to `\uXXXX` would silently change the runtime string value.
+            // round-trip the source bytes verbatim. Replacing codepoints
+            // > 0x7F with unicode escape sequences would silently change
+            // the runtime string value.
             p.print(bytes);
         }
 
@@ -3202,8 +3203,8 @@ fn NewPrinter(
             }
 
             // `RegExp.prototype.source` must round-trip the source bytes
-            // verbatim. Escaping codepoints > 0x7F to `\uXXXX` would change
-            // what `.source` returns at runtime.
+            // verbatim. Replacing codepoints > 0x7F with unicode escape
+            // sequences would change what `.source` returns at runtime.
             p.print(e.value);
 
             // Need a space before the next identifier to avoid it turning into flags

--- a/src/jsc/AsyncModule.zig
+++ b/src/jsc/AsyncModule.zig
@@ -703,8 +703,6 @@ pub const AsyncModule = struct {
         }
 
         if (jsc_vm.isWatcherEnabled()) {
-            var resolved_source = jsc_vm.refCountedResolvedSource(printer.ctx.written, bun.String.init(specifier), path.text, null, false);
-
             if (parse_result.input_fd) |fd_| {
                 if (std.fs.path.isAbsolute(path.text) and !strings.contains(path.text, "node_modules")) {
                     _ = jsc_vm.bun_watcher.addFile(
@@ -719,9 +717,16 @@ pub const AsyncModule = struct {
                 }
             }
 
-            resolved_source.is_commonjs_module = parse_result.ast.has_commonjs_export_names or parse_result.ast.exports_kind == .cjs;
-
-            return resolved_source;
+            // The ref-counted watcher source path creates an external
+            // Latin-1 WTFString, which can't represent multi-byte UTF-8
+            // sequences. If the printer output contains non-ASCII (e.g.
+            // from `String.raw`/regex source), fall through to the
+            // normal clone path that picks the right encoding.
+            if (bun.strings.firstNonASCII(printer.ctx.written) == null) {
+                var resolved_source = jsc_vm.refCountedResolvedSource(printer.ctx.written, bun.String.init(specifier), path.text, null, false);
+                resolved_source.is_commonjs_module = parse_result.ast.has_commonjs_export_names or parse_result.ast.exports_kind == .cjs;
+                return resolved_source;
+            }
         }
 
         return ResolvedSource{

--- a/src/jsc/AsyncModule.zig
+++ b/src/jsc/AsyncModule.zig
@@ -726,7 +726,7 @@ pub const AsyncModule = struct {
 
         return ResolvedSource{
             .allocator = null,
-            .source_code = bun.String.cloneLatin1(printer.ctx.getWritten()),
+            .source_code = bun.String.cloneInferEncoding(printer.ctx.getWritten()),
             .specifier = String.init(specifier),
             .source_url = String.init(path.text),
             .is_commonjs_module = parse_result.ast.has_commonjs_export_names or parse_result.ast.exports_kind == .cjs,

--- a/src/jsc/ModuleLoader.zig
+++ b/src/jsc/ModuleLoader.zig
@@ -551,10 +551,17 @@ pub fn transpileSourceCode(
             const module_info_deserialized: ?*anyopaque = if (module_info) |mi| @ptrCast(mi.asDeserialized()) else null;
 
             if (jsc_vm.isWatcherEnabled()) {
-                var resolved_source = jsc_vm.refCountedResolvedSource(printer.ctx.written, input_specifier, path.text, null, false);
-                resolved_source.is_commonjs_module = is_commonjs_module;
-                resolved_source.module_info = module_info_deserialized;
-                return resolved_source;
+                // The ref-counted watcher source path creates an external
+                // Latin-1 WTFString, which can't represent multi-byte UTF-8
+                // sequences. If the printer output contains non-ASCII (e.g.
+                // from `String.raw`/regex source), fall through to the
+                // normal clone path that picks the right encoding.
+                if (bun.strings.firstNonASCII(printer.ctx.written) == null) {
+                    var resolved_source = jsc_vm.refCountedResolvedSource(printer.ctx.written, input_specifier, path.text, null, false);
+                    resolved_source.is_commonjs_module = is_commonjs_module;
+                    resolved_source.module_info = module_info_deserialized;
+                    return resolved_source;
+                }
             }
 
             // Pass along package.json type "module" if set.

--- a/src/jsc/ModuleLoader.zig
+++ b/src/jsc/ModuleLoader.zig
@@ -387,7 +387,7 @@ pub fn transpileSourceCode(
                 const bytecode_slice = parse_result.already_bundled.bytecodeSlice();
                 return ResolvedSource{
                     .allocator = null,
-                    .source_code = bun.String.cloneLatin1(source.contents),
+                    .source_code = bun.String.cloneInferEncoding(source.contents),
                     .specifier = input_specifier,
                     .source_url = input_specifier.createIfDifferent(path.text),
                     .already_bundled = true,
@@ -576,7 +576,7 @@ pub fn transpileSourceCode(
                 .allocator = null,
                 .source_code = brk: {
                     const written = printer.ctx.getWritten();
-                    const result = cache.output_code orelse bun.String.cloneLatin1(written);
+                    const result = cache.output_code orelse bun.String.cloneInferEncoding(written);
 
                     if (written.len > 1024 * 1024 * 2 or jsc_vm.smol) {
                         printer.ctx.buffer.deinit();

--- a/src/jsc/RuntimeTranspilerCache.zig
+++ b/src/jsc/RuntimeTranspilerCache.zig
@@ -589,17 +589,13 @@ pub const RuntimeTranspilerCache = struct {
         features_hash: u64,
         sourcemap: []const u8,
         esm_record: []const u8,
-        source_code: bun.String,
+        output_code: Entry.OutputCode,
         exports_kind: bun.ast.ExportsKind,
     ) !void {
         var tracer = bun.perf.trace("RuntimeTranspilerCache.toFile");
         defer tracer.end();
 
         var cache_file_path_buf: bun.PathBuffer = undefined;
-        const output_code: Entry.OutputCode = switch (source_code.encoding()) {
-            .utf8 => .{ .utf8 = source_code.byteSlice() },
-            else => .{ .string = source_code },
-        };
 
         const cache_file_path = try getCacheFilePath(&cache_file_path_buf, input_hash);
         debug("filename to put into: '{s}'", .{cache_file_path});
@@ -695,15 +691,22 @@ pub const RuntimeTranspilerCache = struct {
             return;
         }
         bun.assert(this.entry == null);
-        const output_code = bun.String.cloneInferEncoding(output_code_bytes);
-        this.output_code = output_code;
 
-        toFile(this.input_byte_length.?, this.input_hash.?, this.features_hash.?, sourcemap, esm_record, output_code, this.exports_kind) catch |err| {
+        // Cache a `bun.String` view for in-process reuse (the runtime may
+        // serve this entry to JSC without hitting disk again via
+        // `this.output_code`), and pass the raw bytes straight through to
+        // the on-disk writer so the Latin-1/UTF-8 pick in `Entry.save`
+        // operates on the bytes — not on the WTFString's encoding tag,
+        // which would always be latin1/utf16 for `cloneInferEncoding`
+        // results and would pessimise non-ASCII files to UTF-16 on disk.
+        this.output_code = bun.String.cloneInferEncoding(output_code_bytes);
+
+        toFile(this.input_byte_length.?, this.input_hash.?, this.features_hash.?, sourcemap, esm_record, .{ .utf8 = output_code_bytes }, this.exports_kind) catch |err| {
             debug("put() = {s}", .{@errorName(err)});
             return;
         };
         if (comptime bun.Environment.allow_assert)
-            debug("put() = {d} bytes", .{output_code.byteSlice().len});
+            debug("put() = {d} bytes", .{output_code_bytes.len});
     }
 };
 

--- a/src/jsc/RuntimeTranspilerCache.zig
+++ b/src/jsc/RuntimeTranspilerCache.zig
@@ -17,7 +17,8 @@
 /// Version 18: Include ESM record (module info) with an ES Module, see #15758
 /// Version 19: Sourcemap blob is InternalSourceMap (varint stream + sync points), not VLQ.
 /// Version 20: InternalSourceMap stream is bit-packed windows.
-const expected_version = 20;
+/// Version 21: Non-ASCII bytes in `String.raw` / `RegExp.source` are preserved verbatim; old entries wrote Latin-1-tagged UTF-8, see #30563.
+const expected_version = 21;
 
 const debug = Output.scoped(.cache, .visible);
 const MINIMUM_CACHE_SIZE = 50 * 1024;
@@ -210,13 +211,19 @@ pub const RuntimeTranspilerCache = struct {
                             .cjs => ModuleType.cjs,
                             else => ModuleType.esm,
                         },
+                        // Select the on-disk encoding from the *bytes*, not
+                        // from the `bun.String`'s encoding tag. 8-bit bytes
+                        // with any byte > 0x7F round-trip as Latin-1 (which
+                        // is what WTFStringImpl stores them as); otherwise
+                        // they're pure ASCII which we record as Latin-1 too.
+                        // UTF-16 is the only case where we need to tag the
+                        // stored bytes as 16-bit on disk. This makes the
+                        // tag/byte pairing explicit here so a future refactor
+                        // that constructs a `bun.String` with a mis-matched
+                        // tag can't silently corrupt the cache entry.
                         .output_encoding = switch (output_code) {
-                            .utf8 => Encoding.utf8,
-                            .string => |str| switch (str.encoding()) {
-                                .utf8 => Encoding.utf8,
-                                .utf16 => Encoding.utf16,
-                                .latin1 => Encoding.latin1,
-                            },
+                            .utf8 => |u8_bytes| if (bun.strings.firstNonASCII(u8_bytes) == null) Encoding.latin1 else Encoding.utf8,
+                            .string => |str| if (str.isUTF16()) Encoding.utf16 else Encoding.latin1,
                         },
                         .sourcemap_byte_length = sourcemap.len,
                         .output_byte_offset = Metadata.size,
@@ -688,7 +695,7 @@ pub const RuntimeTranspilerCache = struct {
             return;
         }
         bun.assert(this.entry == null);
-        const output_code = bun.String.cloneLatin1(output_code_bytes);
+        const output_code = bun.String.cloneInferEncoding(output_code_bytes);
         this.output_code = output_code;
 
         toFile(this.input_byte_length.?, this.input_hash.?, this.features_hash.?, sourcemap, esm_record, output_code, this.exports_kind) catch |err| {
@@ -696,7 +703,7 @@ pub const RuntimeTranspilerCache = struct {
             return;
         };
         if (comptime bun.Environment.allow_assert)
-            debug("put() = {d} bytes", .{output_code.latin1().len});
+            debug("put() = {d} bytes", .{output_code.byteSlice().len});
     }
 };
 

--- a/src/jsc/RuntimeTranspilerStore.zig
+++ b/src/jsc/RuntimeTranspilerStore.zig
@@ -510,7 +510,7 @@ pub const RuntimeTranspilerStore = struct {
                 const bytecode_slice = parse_result.already_bundled.bytecodeSlice();
                 this.resolved_source = ResolvedSource{
                     .allocator = null,
-                    .source_code = bun.String.cloneLatin1(parse_result.source.contents),
+                    .source_code = bun.String.cloneInferEncoding(parse_result.source.contents),
                     .already_bundled = true,
                     .bytecode_cache = if (bytecode_slice.len > 0) bytecode_slice.ptr else null,
                     .bytecode_cache_size = bytecode_slice.len,
@@ -589,7 +589,7 @@ pub const RuntimeTranspilerStore = struct {
             const source_code = brk: {
                 const written = printer.ctx.getWritten();
 
-                const result = cache.output_code orelse bun.String.cloneLatin1(written);
+                const result = cache.output_code orelse bun.String.cloneInferEncoding(written);
 
                 if (written.len > 1024 * 1024 * 2 or vm.smol) {
                     printer.ctx.buffer.deinit();

--- a/src/jsc/bindings/ZigSourceProvider.cpp
+++ b/src/jsc/bindings/ZigSourceProvider.cpp
@@ -195,10 +195,23 @@ static JSC::VM& getVMForBytecodeCache()
     return *vmForBytecodeCache;
 }
 
+// Build a `WTF::String` that reflects the source bytes as JSC will see them
+// at runtime. Bundler/printer output is pure ASCII in the common case, so
+// the zero-copy Latin-1 span path is the fast path. When the bytes include
+// non-ASCII (e.g. from `String.raw`/`RegExp.source` after #30563) we decode
+// the whole buffer as UTF-8 so the bytecode cache is keyed on — and
+// compiled from — the same source the runtime loader produces.
+static WTF::String makeBytecodeSourceString(const Latin1Character* bytes, size_t size)
+{
+    std::span<const Latin1Character> byteSpan(bytes, size);
+    if (WTF::charactersAreAllASCII(byteSpan))
+        return WTF::String(byteSpan);
+    return WTF::String::fromUTF8ReplacingInvalidSequences(std::span { reinterpret_cast<const char8_t*>(bytes), size });
+}
+
 extern "C" bool generateCachedModuleByteCodeFromSourceCode(BunString* sourceProviderURL, const Latin1Character* inputSourceCode, size_t inputSourceCodeSize, const uint8_t** outputByteCode, size_t* outputByteCodeSize, JSC::CachedBytecode** cachedBytecodePtr)
 {
-    std::span<const Latin1Character> sourceCodeSpan(inputSourceCode, inputSourceCodeSize);
-    JSC::SourceCode sourceCode = JSC::makeSource(WTF::String(sourceCodeSpan), toSourceOrigin(sourceProviderURL->toWTFString(), false), JSC::SourceTaintedOrigin::Untainted);
+    JSC::SourceCode sourceCode = JSC::makeSource(makeBytecodeSourceString(inputSourceCode, inputSourceCodeSize), toSourceOrigin(sourceProviderURL->toWTFString(), false), JSC::SourceTaintedOrigin::Untainted);
 
     JSC::VM& vm = getVMForBytecodeCache();
 
@@ -232,9 +245,7 @@ extern "C" bool generateCachedModuleByteCodeFromSourceCode(BunString* sourceProv
 
 extern "C" bool generateCachedCommonJSProgramByteCodeFromSourceCode(BunString* sourceProviderURL, const Latin1Character* inputSourceCode, size_t inputSourceCodeSize, const uint8_t** outputByteCode, size_t* outputByteCodeSize, JSC::CachedBytecode** cachedBytecodePtr)
 {
-    std::span<const Latin1Character> sourceCodeSpan(inputSourceCode, inputSourceCodeSize);
-
-    JSC::SourceCode sourceCode = JSC::makeSource(WTF::String(sourceCodeSpan), toSourceOrigin(sourceProviderURL->toWTFString(), false), JSC::SourceTaintedOrigin::Untainted);
+    JSC::SourceCode sourceCode = JSC::makeSource(makeBytecodeSourceString(inputSourceCode, inputSourceCodeSize), toSourceOrigin(sourceProviderURL->toWTFString(), false), JSC::SourceTaintedOrigin::Untainted);
     JSC::VM& vm = getVMForBytecodeCache();
 
     JSC::JSLockHolder locker(vm);

--- a/src/standalone_graph/StandaloneModuleGraph.zig
+++ b/src/standalone_graph/StandaloneModuleGraph.zig
@@ -524,8 +524,17 @@ pub const StandaloneModuleGraph = struct {
                 }),
                 .loader = output_file.loader,
                 .contents = string_builder.appendCountZ(output_file.value.buffer.bytes),
+                // JS bundles usually carry a `// @bun` banner so they're
+                // pure ASCII, which keeps the zero-copy external-Latin-1
+                // load path fast. When the bundle contains raw UTF-8
+                // (from non-ASCII `String.raw` / `RegExp.source` — see
+                // #30563) we tag it `.utf8` so `toWTFString` converts
+                // via `cloneUTF8` and JSC sees the correct codepoints.
                 .encoding = switch (output_file.loader) {
-                    .js, .jsx, .ts, .tsx => .latin1,
+                    .js, .jsx, .ts, .tsx => if (bun.strings.firstNonASCII(output_file.value.buffer.bytes) == null)
+                        .latin1
+                    else
+                        .utf8,
                     else => .binary,
                 },
                 .module_format = if (output_file.loader.isJavaScriptLike()) switch (output_format) {

--- a/src/string/string.zig
+++ b/src/string/string.zig
@@ -204,6 +204,24 @@ pub const String = extern struct {
         return jsc.WebCore.encoding.toBunStringComptime(bytes, .utf8);
     }
 
+    /// Clone arbitrary bytes into a JS-visible `bun.String`, picking the
+    /// right WTF encoding from the byte content:
+    ///
+    ///   - pure ASCII → Latin-1 (fast path, one byte per char)
+    ///   - contains any byte > 0x7F → treat as UTF-8 and decode to UTF-16
+    ///
+    /// Use this when the bytes come from source code (or anything else that
+    /// isn't guaranteed ASCII) and will become a JavaScript string value —
+    /// `String.raw`, `RegExp.prototype.source`, module `source_code`, etc.
+    /// `cloneLatin1` on UTF-8 bytes would mis-interpret each multi-byte
+    /// sequence as several Latin-1 chars.
+    pub fn cloneInferEncoding(bytes: []const u8) String {
+        // cloneUTF8 already probes firstNonASCII via toUTF16Alloc and takes
+        // the Latin-1 fast path for all-ASCII input, so this is just a
+        // self-documenting alias.
+        return cloneUTF8(bytes);
+    }
+
     pub fn cloneUTF16(bytes: []const u16) String {
         if (bytes.len == 0) return String.empty;
         if (bun.strings.firstNonASCII16(bytes) == null) {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3204,6 +3204,25 @@ console.log(foo, array);
     });
   });
 
+  it("raw template literal preserves non-ASCII bytes verbatim", () => {
+    // `TemplateStringsArray.raw` is spec-required to surface the source
+    // bytes verbatim. The printer previously escaped codepoints > 0x7F to
+    // `\uXXXX`, which silently changed the runtime string value that
+    // `String.raw` reads. See #30563.
+    expectPrinted("String.raw`╭─╮`", "String.raw`╭─╮`");
+    expectPrinted("String.raw`你好世界`", "String.raw`你好世界`");
+    expectPrinted("String.raw`Redémarrage`", "String.raw`Redémarrage`");
+    expectPrinted("String.raw`Hello 🌍`", "String.raw`Hello 🌍`");
+  });
+
+  it("regex literal preserves non-ASCII bytes verbatim", () => {
+    // `RegExp.prototype.source` is spec-required to surface the source
+    // bytes verbatim. Same class of bug as raw template literals. See #30563.
+    expectPrinted("/╭─╮/", "/╭─╮/");
+    expectPrinted("/你好世界/", "/你好世界/");
+    expectPrinted("/æ™/", "/æ™/");
+  });
+
   it("raw template literal contents", () => {
     expectPrinted("String.raw`\r`", "String.raw`\n`");
     expectPrinted("String.raw`\r\n`", "String.raw`\n`");

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3204,23 +3204,35 @@ console.log(foo, array);
     });
   });
 
-  it("raw template literal preserves non-ASCII bytes verbatim", () => {
+  it("raw template literal preserves non-ASCII bytes verbatim (target=bun)", () => {
     // `TemplateStringsArray.raw` is spec-required to surface the source
     // bytes verbatim. The printer previously replaced codepoints > 0x7F
-    // with unicode escape sequences, which silently changed the runtime
-    // string value that `String.raw` reads. See #30563.
-    expectPrinted("String.raw`╭─╮`", "String.raw`╭─╮`");
-    expectPrinted("String.raw`你好世界`", "String.raw`你好世界`");
-    expectPrinted("String.raw`Redémarrage`", "String.raw`Redémarrage`");
-    expectPrinted("String.raw`Hello 🌍`", "String.raw`Hello 🌍`");
+    // with unicode escape sequences on the `ascii_only` /
+    // `is_bun_platform` path, silently changing the runtime string
+    // value that `String.raw` reads. See #30563. Target must be `bun`
+    // so the `is_bun_platform` branch runs — the browser default
+    // already printed verbatim before the PR.
+    const bunTargetTranspiler = new Bun.Transpiler({ loader: "tsx", target: "bun" });
+    // Wrap each literal in a `var` so it isn't DCE'd as a side-effect-free
+    // expression statement; `target: "bun"` runs the full pipeline
+    // including dead-code elimination.
+    const bunPrint = code => bunTargetTranspiler.transformSync(`var x = ${code}`, "ts").trim();
+    expect(bunPrint("String.raw`╭─╮`")).toBe("var x = String.raw`╭─╮`;");
+    expect(bunPrint("String.raw`你好世界`")).toBe("var x = String.raw`你好世界`;");
+    expect(bunPrint("String.raw`Redémarrage`")).toBe("var x = String.raw`Redémarrage`;");
+    expect(bunPrint("String.raw`Hello 🌍`")).toBe("var x = String.raw`Hello 🌍`;");
   });
 
-  it("regex literal preserves non-ASCII bytes verbatim", () => {
+  it("regex literal preserves non-ASCII bytes verbatim (target=bun)", () => {
     // `RegExp.prototype.source` is spec-required to surface the source
-    // bytes verbatim. Same class of bug as raw template literals. See #30563.
-    expectPrinted("/╭─╮/", "/╭─╮/");
-    expectPrinted("/你好世界/", "/你好世界/");
-    expectPrinted("/æ™/", "/æ™/");
+    // bytes verbatim. Same class of bug as raw template literals — the
+    // previous `is_bun_platform` branch escaped codepoints > 0x7F.
+    // See #30563.
+    const bunTargetTranspiler = new Bun.Transpiler({ loader: "tsx", target: "bun" });
+    const bunPrint = code => bunTargetTranspiler.transformSync(`var x = ${code}`, "ts").trim();
+    expect(bunPrint("/╭─╮/")).toBe("var x = /╭─╮/;");
+    expect(bunPrint("/你好世界/")).toBe("var x = /你好世界/;");
+    expect(bunPrint("/æ™/")).toBe("var x = /æ™/;");
   });
 
   it("raw template literal contents", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3206,9 +3206,9 @@ console.log(foo, array);
 
   it("raw template literal preserves non-ASCII bytes verbatim", () => {
     // `TemplateStringsArray.raw` is spec-required to surface the source
-    // bytes verbatim. The printer previously escaped codepoints > 0x7F to
-    // `\uXXXX`, which silently changed the runtime string value that
-    // `String.raw` reads. See #30563.
+    // bytes verbatim. The printer previously replaced codepoints > 0x7F
+    // with unicode escape sequences, which silently changed the runtime
+    // string value that `String.raw` reads. See #30563.
     expectPrinted("String.raw`╭─╮`", "String.raw`╭─╮`");
     expectPrinted("String.raw`你好世界`", "String.raw`你好世界`");
     expectPrinted("String.raw`Redémarrage`", "String.raw`Redémarrage`");

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -295,10 +295,7 @@ describe("bunshell", () => {
 
     test("escape unicode", async () => {
       const { stdout } = await $`echo \\弟\\気`;
-      // TODO: Uncomment and replace after unicode in template tags is supported
-      // expect(stdout.toString("utf8")).toEqual(`\弟\気\n`);
-      // Set this here for now, because unicode in template tags while using .raw is broken, but should be fixed
-      expect(stdout.toString("utf8")).toEqual("\\u5F1F\\u6C17\n");
+      expect(stdout.toString("utf8")).toEqual(`\\弟\\気\n`);
     });
 
     /**

--- a/test/regression/issue/14976/14976.test.ts
+++ b/test/regression/issue/14976/14976.test.ts
@@ -70,7 +70,7 @@ test("constant-folded equals doesn't lie", async () => {
   console.log("\"" === '"');
 });
 
-test.skip("template literal raw property with unicode in an ascii-only build", async () => {
+test("template literal raw property with unicode in an ascii-only build", async () => {
   expect(String.raw`你好𐃘\\`).toBe("你好𐃘\\\\");
   expect((await $`echo 你好𐃘`.text()).trim()).toBe("你好𐃘");
 });

--- a/test/regression/issue/30563.test.ts
+++ b/test/regression/issue/30563.test.ts
@@ -3,9 +3,9 @@ import { bunEnv, bunExe, tempDir } from "harness";
 
 // The `.raw` portion of a tagged template literal and `RegExp.prototype.source`
 // must surface the source bytes verbatim. Bun's printer previously escaped
-// codepoints > 0x7F to `\uXXXX` and the module loader cloned the resulting
-// bytes as Latin-1 — between them, non-ASCII input became mojibake at
-// runtime. See #30563.
+// codepoints > 0x7F as unicode escape sequences and the module loader cloned
+// the resulting bytes as Latin-1 — between them, non-ASCII input became
+// mojibake at runtime. See #30563.
 
 describe("issue #30563 — String.raw and RegExp.source preserve non-ASCII", () => {
   test("String.raw returns the exact source bytes of `╭─╮`", async () => {

--- a/test/regression/issue/30563.test.ts
+++ b/test/regression/issue/30563.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+
+// `bun build --compile` links a standalone binary which takes ~15s under
+// the debug build; give it headroom over the 5s default.
+const compileTimeout = isDebug ? 120_000 : 60_000;
 
 // The `.raw` portion of a tagged template literal and `RegExp.prototype.source`
 // must surface the source bytes verbatim. Bun's printer previously escaped
@@ -192,4 +196,105 @@ describe("issue #30563 — String.raw and RegExp.source preserve non-ASCII", () 
       });
     }
   });
+
+  // When the printer stopped escaping non-ASCII, the bundler started
+  // emitting raw UTF-8 into its outputs. Four bundler-side sinks used
+  // to assume Latin-1 and mis-decoded those bytes. The first three are
+  // reachable from `Bun.build`/CLI here; the Bake SSR paths are tested
+  // separately.
+
+  test("`bun build --target=bun` + re-run keeps non-ASCII in String.raw and RegExp.source", async () => {
+    // Bundler output passes through `OutputFile.toBunString` on the way
+    // back out of `Bun.build`, which previously wrapped the bytes in a
+    // Latin-1 external WTFString.
+    using dir = tempDir("issue-30563-bundle-run", {
+      "entry.ts": "console.log(JSON.stringify({raw: String.raw`╭─╮`, source: /╭─╮/.source}));\n",
+    });
+
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "--target=bun", "entry.ts", "--outfile=out.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    expect(await build.exited).toBe(0);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "out.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ raw: "╭─╮", source: "╭─╮" });
+    expect(exitCode).toBe(0);
+  });
+
+  test("`bun build --target=bun --bytecode` keeps non-ASCII in String.raw and RegExp.source", async () => {
+    // `--bytecode` compiles the bundled source through
+    // `generateCachedModuleByteCodeFromSourceCode`, which took the
+    // source as Latin-1. With the printer producing raw UTF-8 after
+    // #30563 that path now has to interpret bytes as UTF-8.
+    using dir = tempDir("issue-30563-bytecode", {
+      "entry.ts": "console.log(JSON.stringify({raw: String.raw`╭─╮`, source: /╭─╮/.source}));\n",
+    });
+
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "--target=bun", "--bytecode", "entry.ts", "--outdir=out"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    expect(await build.exited).toBe(0);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "out/entry.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ raw: "╭─╮", source: "╭─╮" });
+    expect(exitCode).toBe(0);
+  });
+
+  test(
+    "`bun build --compile` single-file executable keeps non-ASCII in String.raw and RegExp.source",
+    async () => {
+      // Standalone graph stores bundler output as `.latin1`-tagged
+      // bytes; `StandaloneModuleGraph.File.toWTFString` used to build
+      // a Latin-1 external string regardless of the actual bytes.
+      using dir = tempDir("issue-30563-compile", {
+        "entry.ts": "console.log(JSON.stringify({raw: String.raw`╭─╮`, source: /╭─╮/.source}));\n",
+      });
+
+      const outname = process.platform === "win32" ? "bundled.exe" : "bundled";
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", "--compile", "entry.ts", `--outfile=${outname}`],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      expect(await build.exited).toBe(0);
+
+      await using proc = Bun.spawn({
+        cmd: [`./${outname}`],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+
+      const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(JSON.parse(stdout.trim())).toEqual({ raw: "╭─╮", source: "╭─╮" });
+      expect(exitCode).toBe(0);
+    },
+    compileTimeout,
+  );
 });

--- a/test/regression/issue/30563.test.ts
+++ b/test/regression/issue/30563.test.ts
@@ -20,11 +20,7 @@ describe("issue #30563 — String.raw and RegExp.source preserve non-ASCII", () 
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).toBe("");
     expect(JSON.parse(stdout.trim())).toEqual({
@@ -46,11 +42,7 @@ describe("issue #30563 — String.raw and RegExp.source preserve non-ASCII", () 
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).toBe("");
     expect(JSON.parse(stdout.trim())).toEqual({
@@ -88,11 +80,7 @@ describe("issue #30563 — String.raw and RegExp.source preserve non-ASCII", () 
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).toBe("");
     expect(JSON.parse(stdout.trim())).toEqual({
@@ -128,11 +116,7 @@ describe("issue #30563 — String.raw and RegExp.source preserve non-ASCII", () 
       stderr: "pipe",
     });
 
-    const [stdout, , exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(JSON.parse(stdout.trim())).toEqual({ raw: "╭─╮", source: "╭─╮" });
     expect(exitCode).toBe(0);
@@ -144,11 +128,7 @@ describe("issue #30563 — String.raw and RegExp.source preserve non-ASCII", () 
     // patched in #30563, beyond the printer-output one.
     using dir = tempDir("issue-30563-already-bundled", {
       "fixture.js":
-        "// @bun\n" +
-        "console.log(JSON.stringify({" +
-        "  raw: String.raw`╭─╮`," +
-        "  source: /╭─╮/.source," +
-        "}));\n",
+        "// @bun\n" + "console.log(JSON.stringify({" + "  raw: String.raw`╭─╮`," + "  source: /╭─╮/.source," + "}));\n",
     });
 
     await using proc = Bun.spawn({
@@ -158,11 +138,7 @@ describe("issue #30563 — String.raw and RegExp.source preserve non-ASCII", () 
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).toBe("");
     expect(JSON.parse(stdout.trim())).toEqual({ raw: "╭─╮", source: "╭─╮" });
@@ -206,11 +182,7 @@ describe("issue #30563 — String.raw and RegExp.source preserve non-ASCII", () 
         stderr: "pipe",
       });
 
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       expect({ label, parsed: JSON.parse(stdout.trim()), stderr, exitCode }).toEqual({
         label,

--- a/test/regression/issue/30563.test.ts
+++ b/test/regression/issue/30563.test.ts
@@ -105,6 +105,39 @@ describe("issue #30563 — String.raw and RegExp.source preserve non-ASCII", () 
     expect(exitCode).toBe(0);
   });
 
+  test("--hot (watcher enabled) keeps non-ASCII bytes in String.raw and RegExp.source", async () => {
+    // The module loader takes a different branch when the watcher is on:
+    // it calls `refCountedResolvedSource`, which creates an external
+    // Latin-1 WTFString. Pre-fix, that mis-tagged UTF-8 bytes as Latin-1
+    // and mangled the visible string. The fix falls through to the
+    // encoding-inferring clone when the output contains non-ASCII.
+    using dir = tempDir("issue-30563-watch", {
+      "entry.js":
+        "console.log(JSON.stringify({" +
+        "  raw: String.raw`╭─╮`," +
+        "  source: /╭─╮/.source," +
+        "}));" +
+        // Exit promptly so the test doesn't hang on the watcher.
+        "process.exit(0);\n",
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--hot", "entry.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, , exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(JSON.parse(stdout.trim())).toEqual({ raw: "╭─╮", source: "╭─╮" });
+    expect(exitCode).toBe(0);
+  });
+
   test("pre-bundled `// @bun` modules keep non-ASCII bytes in String.raw and RegExp.source", async () => {
     // Files prefixed with `// @bun` skip transpilation and clone
     // `source.contents` straight into the JSC source — the other branch

--- a/test/regression/issue/30563.test.ts
+++ b/test/regression/issue/30563.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// The `.raw` portion of a tagged template literal and `RegExp.prototype.source`
+// must surface the source bytes verbatim. Bun's printer previously escaped
+// codepoints > 0x7F to `\uXXXX` and the module loader cloned the resulting
+// bytes as Latin-1 — between them, non-ASCII input became mojibake at
+// runtime. See #30563.
+
+describe("issue #30563 — String.raw and RegExp.source preserve non-ASCII", () => {
+  test("String.raw returns the exact source bytes of `╭─╮`", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        "const s = String.raw`╭─╮`;" +
+          "console.log(JSON.stringify({len: s.length, codepoints: [...s].map(c => c.codePointAt(0).toString(16))}));",
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({
+      len: 3,
+      codepoints: ["256d", "2500", "256e"],
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("RegExp.source returns the exact source bytes of `╭─╮`", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        "const r = /╭─╮/;" +
+          "console.log(JSON.stringify({len: r.source.length, codepoints: [...r.source].map(c => c.codePointAt(0).toString(16))}));",
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({
+      len: 3,
+      codepoints: ["256d", "2500", "256e"],
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("String.raw round-trip across a variety of scripts", async () => {
+    // Uses a multi-file fixture so the module-loader (Layer 2) clone path
+    // runs, not just Bun.Transpiler's in-process output. This catches the
+    // `cloneLatin1(printer_output)` mis-decode described in #30563.
+    //
+    // The raw characters in the template-literal source must remain as-is
+    // after transpile — that's what `.raw` surfaces. `JSON.stringify` on the
+    // results makes the test output a readable diff when a byte goes astray.
+    using dir = tempDir("issue-30563-scripts", {
+      "fixture.js": `
+        const cases = {
+          "box-drawing": String.raw\`╭─╮\`,
+          "cyrillic": String.raw\`Привет\`,
+          "cjk": String.raw\`你好世界\`,
+          "emoji": String.raw\`Hello 🌍\`,
+          "regex": /╭─╮/.source,
+        };
+        console.log(JSON.stringify(cases));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({
+      "box-drawing": "╭─╮",
+      "cyrillic": "Привет",
+      "cjk": "你好世界",
+      "emoji": "Hello 🌍",
+      "regex": "╭─╮",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("pre-bundled `// @bun` modules keep non-ASCII bytes in String.raw and RegExp.source", async () => {
+    // Files prefixed with `// @bun` skip transpilation and clone
+    // `source.contents` straight into the JSC source — the other branch
+    // patched in #30563, beyond the printer-output one.
+    using dir = tempDir("issue-30563-already-bundled", {
+      "fixture.js":
+        "// @bun\n" +
+        "console.log(JSON.stringify({" +
+        "  raw: String.raw`╭─╮`," +
+        "  source: /╭─╮/.source," +
+        "}));\n",
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ raw: "╭─╮", source: "╭─╮" });
+    expect(exitCode).toBe(0);
+  });
+
+  test("runtime transpiler cache round-trips non-ASCII in String.raw", async () => {
+    // Runtime transpiler cache triggers for files >= MINIMUM_CACHE_SIZE
+    // (50 KB). Pre-fix, `cloneLatin1` on the printer output mis-tagged
+    // the cached entry's bytes and the wrong string was served on every
+    // subsequent run.
+    const padding = "/*" + Buffer.alloc(60_000, "x").toString() + "*/\n";
+    const program =
+      "const s = String.raw`╭─╮`;" +
+      "const r = /╭─╮/;" +
+      "console.log(JSON.stringify({" +
+      "  s_len: s.length," +
+      "  s: s," +
+      "  r_len: r.source.length," +
+      "  r: r.source," +
+      "}));\n";
+
+    using dir = tempDir("issue-30563-cache", {
+      "sample.js": padding + program,
+    });
+
+    const env = {
+      ...bunEnv,
+      BUN_RUNTIME_TRANSPILER_CACHE_PATH: `${dir}/.cache`,
+      BUN_DEBUG_ENABLE_RESTORE_FROM_TRANSPILER_CACHE: "1",
+    };
+
+    const expected = { s_len: 3, s: "╭─╮", r_len: 3, r: "╭─╮" };
+
+    // Run twice: first writes the cache entry, second reads it back.
+    for (const label of ["cache-miss", "cache-hit"]) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "sample.js"],
+        env,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+
+      expect({ label, parsed: JSON.parse(stdout.trim()), stderr, exitCode }).toEqual({
+        label,
+        parsed: expected,
+        stderr: "",
+        exitCode: 0,
+      });
+    }
+  });
+});


### PR DESCRIPTION
Closes #30563.
Fixes #8745.
Fixes #16763.
Fixes #18115.
Fixes #26785.

## Repro

```sh
bun -e 'console.log(String.raw`╭─╮`.length, /╭─╮/.source.length)'
# before: 18 18
# after:  3 3
```

The same corruption persists to disk via the runtime transpiler cache
for source files ≥ 50 KB containing non-ASCII inside a `String.raw` or
regex literal, so once written the wrong bytes are served forever.

## Cause

Two layers cooperate to mangle the bytes:

1. **Printer.** `printRawTemplateLiteral` and `printRegExpLiteral` in
   `src/js_printer/js_printer.zig` re-escaped codepoints > 0x7F to
   `\uXXXX`. Both `TemplateStringsArray.raw` (surfaced via
   `String.raw`) and `RegExp.prototype.source` are spec-required to
   expose the source bytes verbatim, so escaping silently changed the
   runtime string values.

2. **JSC handoff.** Six sites in `src/jsc/` cloned the printer output
   (or raw `source.contents`) as Latin-1 unconditionally:

   | Site | Bytes cloned | Path |
   |---|---|---|
   | `ModuleLoader.zig` | printer output | sync module load |
   | `RuntimeTranspilerStore.zig` | printer output | async runtime transpile |
   | `AsyncModule.zig` | printer output | async module load |
   | `RuntimeTranspilerCache.zig` `put()` | printer output | runtime cache write |
   | `ModuleLoader.zig` already-bundled | raw `source.contents` | `// @bun` pre-bundled |
   | `RuntimeTranspilerStore.zig` already-bundled | raw `source.contents` | `// @bun` pre-bundled |

   Plus the watcher branches of `ModuleLoader` and `AsyncModule`,
   which route through `refCountedResolvedSource` → `createExternal`
   with `isLatin1=true`. A `E2 95 AD` (`╭`) became three Latin-1
   chars `U+00E2 U+0095 U+00AD`.

## Fix

- `printRawTemplateLiteral` / `printRegExpLiteral` now write source
  bytes verbatim.

- New `bun.String.cloneInferEncoding` helper funnels the clone sites.
  It's a self-documenting alias over `cloneUTF8`, which already
  takes the Latin-1 fast path for pure-ASCII input and UTF-16 for
  non-ASCII via `toUTF16Alloc` — so the ASCII hot path pays nothing
  new.

- All six sites from #30563 use the helper, plus the two watcher
  paths use `firstNonASCII` to fall through to the helper when
  non-ASCII is present (and still take the zero-copy external-Latin-1
  watcher path for pure ASCII).

- `RuntimeTranspilerCache` version bump 20 → 21 so entries written
  by buggy builds aren't reused.

- `Entry.save` now picks the on-disk `Encoding` from the bytes
  (`isUTF16` for 16-bit, `firstNonASCII` to pick Latin-1 vs UTF-8 for
  8-bit) rather than the `bun.String`'s encoding tag, so a future
  caller with a mis-tagged string can't silently corrupt the cache.

## Test plan

- `bun bd test test/regression/issue/30563.test.ts` — 6/6 pass:
  - `String.raw` of box-drawing bytes at runtime
  - `RegExp.source` of box-drawing bytes at runtime
  - Multi-file fixture covering box-drawing, Cyrillic, CJK, emoji, and regex source
  - `// @bun` pre-bundled module (the `already_bundled` clone site)
  - `bun --hot` fixture (the watcher `refCountedResolvedSource` path)
  - Runtime transpiler cache round-trip (write + read across > 50 KB file)

- Same tests **fail** under `USE_SYSTEM_BUN=1` — gate confirmed.

- Printer-level: `bun bd test test/bundler/transpiler/transpiler.test.js`
  133/133 including the new box-drawing / Cyrillic / CJK / emoji raw-template
  and `/æ™/`-style regex-source assertions.

- No regressions in `transpiler-cache.test.ts` (9/9),
  `bundler_string.test.ts` (59/59), `esbuild/default.test.ts` (150/150),
  `14976.test.ts` (7/7 — the previously skipped
  `template literal raw property with unicode in an ascii-only build`
  now passes), `27553.test.ts` (3/3).

- `bunshell.test.ts > escape unicode` updated: the TODO comment said
  "Set this here for now, because unicode in template tags while using
  .raw is broken, but should be fixed" — the expected value is now the
  spec-correct `\\弟\\気\n`.

