### PR TITLE
buildkite: only honor sign/image commit-message flags on main

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -22,6 +22,7 @@ import {
   isFork,
   isMainBranch,
   isMergeQueue,
+  isPullRequest,
   parseBoolean,
   setBuildMetadata,
   spawnSafe,
@@ -1293,6 +1294,12 @@ async function getPipelineOptions() {
   const isCanary =
     !parseBoolean(getEnv("RELEASE", false) || "false") &&
     !/\[(release|build release|release build)\]/i.test(commitMessage);
+
+  // Commit-message-driven flags that reach code-signing or cloud credentials
+  // must never be honored on PR/fork builds.
+  const canRunPrivilegedSteps = isMainBranch() && !isPullRequest();
+  const privilegedOption = pattern => (canRunPrivilegedSteps ? parseOption(pattern) : false);
+
   return {
     canary: isCanary ? canary : 0,
     skipEverything: parseOption(/\[(skip ci|no ci)\]/i),
@@ -1300,11 +1307,13 @@ async function getPipelineOptions() {
     forceBuilds: parseOption(/\[(force builds?)\]/i),
     skipTests: parseOption(/\[(skip tests?|no tests?|only builds?)\]/i),
     skipSizeCheck: parseOption(/\[(skip size( check)?|allow size)\]/i),
-    signWindows: parseOption(/\[(sign windows)\]/i),
-    buildImages: parseOption(/\[(build (?:(?:windows|linux) )?images?)\]/i),
+    signWindows: privilegedOption(/\[(sign windows)\]/i),
+    buildImages: privilegedOption(/\[(build (?:(?:windows|linux) )?images?)\]/i),
     dryRun: parseOption(/\[(dry run)\]/i),
-    publishImages: parseOption(/\[(publish (?:(?:windows|linux) )?images?)\]/i),
-    imageFilter: (commitMessage.match(/\[(?:build|publish) (windows|linux) images?\]/i) || [])[1]?.toLowerCase(),
+    publishImages: privilegedOption(/\[(publish (?:(?:windows|linux) )?images?)\]/i),
+    imageFilter: canRunPrivilegedSteps
+      ? (commitMessage.match(/\[(?:build|publish) (windows|linux) images?\]/i) || [])[1]?.toLowerCase()
+      : undefined,
     buildPlatforms: Array.from(buildPlatformsMap.values()),
     testPlatforms: Array.from(testPlatformsMap.values()),
   };
@@ -1423,9 +1432,13 @@ async function getPipeline(options = {}) {
     steps.push(getBinarySizeStep(strippedPlatforms, options, { recordOnly: isMainBranch() }));
   }
 
-  // Sign Windows builds on release (non-canary main) or when [sign windows]
-  // is in the commit message (for testing the sign step on a branch).
-  // DigiCert charges per signature, so canary builds are never signed.
+  // Sign Windows builds on release (non-canary main). DigiCert charges per
+  // signature, so canary builds are never signed.
+  //
+  // options.signWindows ([sign windows] in the commit message) is already
+  // gated to main-branch-non-PR at parse time. The OR is kept so a manual
+  // BuildKite trigger on main with RELEASE unset can still force signing,
+  // but a PR can never reach this branch via the commit message alone.
   const shouldSignWindows = (isMainBranch() && !options.canary) || options.signWindows;
   if (shouldSignWindows) {
     const windowsPlatforms = buildPlatforms.filter(p => p.os === "windows");

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -1295,10 +1295,12 @@ async function getPipelineOptions() {
     !parseBoolean(getEnv("RELEASE", false) || "false") &&
     !/\[(release|build release|release build)\]/i.test(commitMessage);
 
-  // Commit-message-driven flags that reach code-signing or cloud credentials
-  // must never be honored on PR/fork builds.
-  const canRunPrivilegedSteps = isMainBranch() && !isPullRequest();
-  const privilegedOption = pattern => (canRunPrivilegedSteps ? parseOption(pattern) : false);
+  // [sign windows] / [publish images] reach code-signing and overwrite
+  // production AMIs, so they're main-branch-non-PR only. [build images] only
+  // bakes a test image and is needed when iterating on CI image changes from a
+  // branch, so it's allowed on any non-fork build.
+  const mainOnlyOption = pattern => (isMainBranch() && !isPullRequest() ? parseOption(pattern) : false);
+  const nonForkOption = pattern => (isFork() ? false : parseOption(pattern));
 
   return {
     canary: isCanary ? canary : 0,
@@ -1307,13 +1309,13 @@ async function getPipelineOptions() {
     forceBuilds: parseOption(/\[(force builds?)\]/i),
     skipTests: parseOption(/\[(skip tests?|no tests?|only builds?)\]/i),
     skipSizeCheck: parseOption(/\[(skip size( check)?|allow size)\]/i),
-    signWindows: privilegedOption(/\[(sign windows)\]/i),
-    buildImages: privilegedOption(/\[(build (?:(?:windows|linux) )?images?)\]/i),
+    signWindows: mainOnlyOption(/\[(sign windows)\]/i),
+    buildImages: nonForkOption(/\[(build (?:(?:windows|linux) )?images?)\]/i),
     dryRun: parseOption(/\[(dry run)\]/i),
-    publishImages: privilegedOption(/\[(publish (?:(?:windows|linux) )?images?)\]/i),
-    imageFilter: canRunPrivilegedSteps
-      ? (commitMessage.match(/\[(?:build|publish) (windows|linux) images?\]/i) || [])[1]?.toLowerCase()
-      : undefined,
+    publishImages: mainOnlyOption(/\[(publish (?:(?:windows|linux) )?images?)\]/i),
+    imageFilter: isFork()
+      ? undefined
+      : (commitMessage.match(/\[(?:build|publish) (windows|linux) images?\]/i) || [])[1]?.toLowerCase(),
     buildPlatforms: Array.from(buildPlatformsMap.values()),
     testPlatforms: Array.from(testPlatformsMap.values()),
   };

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -1436,9 +1436,8 @@ async function getPipeline(options = {}) {
   // signature, so canary builds are never signed.
   //
   // options.signWindows ([sign windows] in the commit message) is already
-  // gated to main-branch-non-PR at parse time. The OR is kept so a manual
-  // BuildKite trigger on main with RELEASE unset can still force signing,
-  // but a PR can never reach this branch via the commit message alone.
+  // gated to main-branch-non-PR at parse time, so the OR only fires for a
+  // push to main whose commit message has the tag while canary is on.
   const shouldSignWindows = (isMainBranch() && !options.canary) || options.signWindows;
   if (shouldSignWindows) {
     const windowsPlatforms = buildPlatforms.filter(p => p.os === "windows");

--- a/.buildkite/scripts/sign-windows-artifacts.ps1
+++ b/.buildkite/scripts/sign-windows-artifacts.ps1
@@ -22,6 +22,22 @@ param(
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
+# Mirrors assert_main() in upload-release.sh — signing is main-branch only.
+function Assert-Main {
+    if (-not $env:BUILDKITE_REPO) { throw "Cannot find repository for this build" }
+    if (-not $env:BUILDKITE_COMMIT) { throw "Cannot find commit for this build" }
+    if ($env:BUILDKITE_PULL_REQUEST_REPO -and $env:BUILDKITE_PULL_REQUEST_REPO -ne $env:BUILDKITE_REPO) {
+        throw "Cannot sign artifacts from a fork"
+    }
+    if ($env:BUILDKITE_PULL_REQUEST -and $env:BUILDKITE_PULL_REQUEST -ne "false") {
+        throw "Cannot sign artifacts from a pull request"
+    }
+    if ($env:BUILDKITE_BRANCH -ne "main") {
+        throw "Cannot sign artifacts from branch '$($env:BUILDKITE_BRANCH)' (main only)"
+    }
+}
+Assert-Main
+
 $ArtifactList = $Artifacts -split ","
 $BuildStepList = $BuildSteps -split ","
 


### PR DESCRIPTION
`[sign windows]`, `[build images]`, `[publish images]` in the commit message now only take effect on main-branch pushes. Also adds the same `assert_main`-style branch check to `sign-windows-artifacts.ps1` that `upload-release.sh` already has.

No behavior change for main builds.