### PR TITLE
ci: add zizmor lint, explicit permissions on misc workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,7 @@
 # Project
 /.github/CODEOWNERS @Jarred-Sumner
+/.github/workflows/ @Jarred-Sumner
+/.buildkite/ @Jarred-Sumner
 
 # Tests
 /test/expectations.txt @Jarred-Sumner

--- a/.github/workflows/freebsd-smoke.yml
+++ b/.github/workflows/freebsd-smoke.yml
@@ -1,5 +1,8 @@
 name: FreeBSD smoke test
 
+permissions:
+  contents: read
+
 # Runs the cross-compiled FreeBSD binary inside a FreeBSD VM to verify it
 # actually starts and executes JavaScript. The build itself happens on
 # BuildKite (cross-compiled from Linux); this just validates the result.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: Lint
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   workflow_dispatch:

--- a/.github/workflows/packages-ci.yml
+++ b/.github/workflows/packages-ci.yml
@@ -1,5 +1,8 @@
 name: Packages CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/vscode-release.yml
+++ b/.github/workflows/vscode-release.yml
@@ -1,4 +1,8 @@
 name: VSCode Extension Publish
+
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -20,11 +20,10 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-      - name: Run zizmor
-        run: |
-          pipx install zizmor
-          zizmor --format sarif .github/ > zizmor.sarif || true
-      - uses: github/codeql-action/upload-sarif@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3
+      - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
         with:
-          sarif_file: zizmor.sarif
-          category: zizmor
+          version: 1.24.1
+          inputs: .github/
+          advanced-security: true
+        # advisory-only for now; uploads SARIF to code scanning but doesn't fail the job
+        continue-on-error: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,30 @@
+name: zizmor
+
+permissions:
+  contents: read
+  security-events: write
+
+on:
+  pull_request:
+    paths:
+      - ".github/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/**"
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        run: |
+          pipx install zizmor
+          zizmor --format sarif .github/ > zizmor.sarif || true
+      - uses: github/codeql-action/upload-sarif@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3
+        with:
+          sarif_file: zizmor.sarif
+          category: zizmor


### PR DESCRIPTION
Adds zizmor as an advisory SARIF check on `.github/**` changes. Adds explicit `permissions: contents: read` to a few workflows that were relying on the repo default. Adds CI paths to CODEOWNERS.