### PR TITLE
bundler: fix capacity miscalculation in ESMConditions.init

### DIFF
--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1087,9 +1087,10 @@ pub const ESMConditions = struct {
         var require_condition_map = ConditionsMap.init(allocator);
         var style_condition_map = ConditionsMap.init(allocator);
 
-        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
+        const addon_count = @as(usize, @intFromBool(allow_addons));
+        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + addon_count + conditions.len);
+        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + addon_count + conditions.len);
+        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + addon_count + conditions.len);
         try style_condition_map.ensureTotalCapacity(defaults.len + 2 + conditions.len);
 
         import_condition_map.putAssumeCapacity("import", {});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -649,6 +649,19 @@ describe("Bun.build", () => {
       expect(await html?.text()).toContain("<meta name='injected-by-plugin' content='true'>");
     },
   );
+
+  test("many custom conditions does not crash", async () => {
+    const dir = tempDirWithFiles("bun-build-api-many-conditions", {
+      "entry.js": "console.log(1)",
+    });
+
+    const result = await Bun.build({
+      entrypoints: [join(dir, "entry.js")],
+      conditions: ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"],
+    });
+
+    expect(result.success).toBe(true);
+  });
 });
 
 test.concurrent("macro with nested object", async () => {


### PR DESCRIPTION
Fuzzer fingerprint: `800f7f8cb62e7ad8`

## What

`ESMConditions.init` reserved capacity with:

```zig
defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len
```

In Zig this parses as `defaults.len + 2 + (if (allow_addons) 1 else (0 + conditions.len))`. When `allow_addons` is true (the default), the user-supplied `conditions.len` was dropped entirely from the reserved capacity. The subsequent `putAssumeCapacity` calls then wrote past the allocation once enough custom conditions were provided, tripping a debug assertion in `MultiArrayList.addOneAssumeCapacity` (and a heap buffer overflow in release).

Minimal repro:

```js
await Bun.build({
  entrypoints: ["./entry.js"],
  conditions: ["a", "b", "c", "d", "e", "f"],
});
```

## Fix

Pull the addon count out into a `usize` so the addition is unambiguous.