### PR TITLE
Fix crash in Bun.build() with many conditions

### DIFF
--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1087,9 +1087,9 @@ pub const ESMConditions = struct {
         var require_condition_map = ConditionsMap.init(allocator);
         var style_condition_map = ConditionsMap.init(allocator);
 
-        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
+        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + @as(usize, @intFromBool(allow_addons)) + conditions.len);
+        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + @as(usize, @intFromBool(allow_addons)) + conditions.len);
+        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + @as(usize, @intFromBool(allow_addons)) + conditions.len);
         try style_condition_map.ensureTotalCapacity(defaults.len + 2 + conditions.len);
 
         import_condition_map.putAssumeCapacity("import", {});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -649,6 +649,17 @@ describe("Bun.build", () => {
       expect(await html?.text()).toContain("<meta name='injected-by-plugin' content='true'>");
     },
   );
+
+  test("many conditions does not crash", async () => {
+    const dir = tempDirWithFiles("bun-build-many-conditions", {
+      "entry.ts": "export const x = 1;",
+    });
+    const result = await Bun.build({
+      entrypoints: [join(dir, "entry.ts")],
+      conditions: ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p"],
+    });
+    expect(result.success).toBe(true);
+  });
 });
 
 test.concurrent("macro with nested object", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a crash in `Bun.build()` when passing many entries in the `conditions` array.

`ESMConditions.init` reserves capacity with:

```zig
defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len
```

which parses as `defaults.len + 2 + (if (allow_addons) 1 else (0 + conditions.len))`. Since `allow_addons` defaults to `true`, `conditions.len` was never added to the reserved capacity, and the subsequent `putAssumeCapacity` calls would write past the end of the allocation once enough user conditions were provided — tripping an assertion in debug builds and segfaulting in release builds.

## How did you verify your code works?

Added a regression test that calls `Bun.build()` with 16 conditions. It segfaults on `main` and passes with this change.

Found by fuzzer, fingerprint `1863a6a2e74d3755`.