### PR TITLE
Fix crash in Bun.build when passing many conditions

### DIFF
--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1087,10 +1087,11 @@ pub const ESMConditions = struct {
         var require_condition_map = ConditionsMap.init(allocator);
         var style_condition_map = ConditionsMap.init(allocator);
 
-        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try style_condition_map.ensureTotalCapacity(defaults.len + 2 + conditions.len);
+        const addons_count: usize = if (allow_addons) 1 else 0;
+        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + addons_count + conditions.len);
+        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + addons_count + conditions.len);
+        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + addons_count + conditions.len);
+        try style_condition_map.ensureTotalCapacity(defaults.len + 2);
 
         import_condition_map.putAssumeCapacity("import", {});
         require_condition_map.putAssumeCapacity("require", {});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1211,3 +1211,18 @@ test.skipIf(!isDebug && !isASAN)(
   },
   120_000,
 );
+
+test("Bun.build with many conditions does not crash", async () => {
+  const dir = tempDirWithFilesAnon({
+    "entry.js": "console.log('hi')",
+  });
+
+  for (const target of ["browser", "bun", "node"] as const) {
+    const result = await Bun.build({
+      entrypoints: [join(dir, "entry.js")],
+      target,
+      conditions: ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p"],
+    });
+    expect(result.success).toBe(true);
+  }
+});


### PR DESCRIPTION
## What does this PR do?

`ESMConditions.init` computed map capacity as:

```zig
defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len
```

which parses as:

```zig
defaults.len + 2 + (if (allow_addons) 1 else (0 + conditions.len))
```

When `allow_addons` is true (the default), `conditions.len` was dropped from the capacity calculation, so `putAssumeCapacity` would write past the allocated entries and hit an assertion in debug builds (or segfault in release builds) once enough user-provided `conditions` were passed to `Bun.build`.

Also removed the unnecessary `+ conditions.len` from the style condition map capacity since user conditions are never added to it.

## How did you verify your code works?

Added a regression test that calls `Bun.build` with 16 conditions across each target. Before this fix, it segfaults on release and asserts on debug; after, it passes.

Found by fuzzing.