### PR TITLE
lexer: advance cursor in peek() to avoid reading past end of source

### DIFF
--- a/src/js_parser/lexer.zig
+++ b/src/js_parser/lexer.zig
@@ -273,6 +273,7 @@ fn NewLexer_(
                 const next_codepoint = it.nextCodepointSlice();
                 if (next_codepoint.len == 0) break;
                 end_ix += next_codepoint.len;
+                it.current = end_ix;
             }
 
             return it.source.contents[original_i..end_ix];

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1571,6 +1571,19 @@ export default <>hi</>
     expect(() => bun.transformSync("bad??!?!?!")).toThrow("Unexpected ?");
   });
 
+  it("'<!' near end of source does not read past the buffer", () => {
+    // The lexer peeks 2 codepoints after seeing `<!` to check for `<!--`. Previously the peek
+    // helper re-read the same codepoint N times instead of advancing, overshooting the end of
+    // the source when fewer than N bytes remained (or when the next codepoint was multi-byte).
+    const t = new Bun.Transpiler({ loader: "js" });
+    expect(() => t.transformSync("<!x")).toThrow();
+    expect(() => t.transformSync("<!ñ")).toThrow();
+    expect(() => t.transformSync("<!")).toThrow();
+    expect(() => t.transformSync(Buffer.from([0x3c, 0x21, 0xf0]))).toThrow();
+    expect(() => t.transformSync("<!--")).toThrow("Legacy HTML comments not implemented yet");
+    expect(() => t.transformSync("<!-a")).toThrow();
+  });
+
   it("invalid logLevel throws", () => {
     expect(
       () =>

--- a/test/js/bun/transpiler/transpiler-truncated-utf8-fixture.ts
+++ b/test/js/bun/transpiler/transpiler-truncated-utf8-fixture.ts
@@ -62,6 +62,11 @@ const cases: Array<[string, number[]]> = [
   ["unterminated block comment at buffer end", [...Buffer.from("x=1/*"), ...Buffer.alloc(700, 0x63)]],
   ["unterminated block comment + 4-byte lead", [...Buffer.from("x=1/*"), ...Buffer.alloc(700, 0x63), 0xf0]],
   ["unterminated block comment + '*'", [...Buffer.from("x=1/*"), ...Buffer.alloc(700, 0x63), 0x2a]],
+  // After lexing `<!`, the lexer peeks 2 codepoints to check for `<!--`. The peek helper used
+  // to re-read the same codepoint N times instead of advancing, overshooting the end of the
+  // source when fewer than N bytes remained (or when the next codepoint was multi-byte).
+  ["<! + 1 ASCII byte", [0x3c, 0x21, 0x78]],
+  ["<! + 2-byte codepoint", [0x3c, 0x21, 0xc3, 0xb1]],
 ];
 
 for (const [name, bytes] of cases) {

--- a/test/js/bun/transpiler/transpiler-truncated-utf8.test.ts
+++ b/test/js/bun/transpiler/transpiler-truncated-utf8.test.ts
@@ -36,6 +36,8 @@ describe.skipIf(!(isLinux || isMacOS))("Bun.Transpiler.transformSync with trunca
         expect.stringContaining("ok: unterminated block comment at buffer end"),
         expect.stringContaining("ok: unterminated block comment + 4-byte lead"),
         expect.stringContaining("ok: unterminated block comment + '*'"),
+        expect.stringContaining("ok: <! + 1 ASCII byte"),
+        expect.stringContaining("ok: <! + 2-byte codepoint"),
         "DONE",
       ],
       stderr: "",


### PR DESCRIPTION
## What

Fixes an out-of-bounds read in the JS lexer's `peek(n)` helper.

`peek(n)` is meant to return the next `n` codepoints without consuming them. It loops `n` times calling `nextCodepointSlice()` and summing the widths. However, `nextCodepointSlice()` takes `*const LexerType` and does **not** advance `it.current`, so every iteration reads the **same** codepoint and the summed width overshoots the buffer whenever:

- fewer than `n` bytes remain in the source, or
- the next codepoint is multi-byte.

`peek()` already has `defer it.current = original_i;`, which shows the intent was for `current` to advance inside the loop and be restored afterward. This PR adds `it.current = end_ix;` inside the loop so each iteration inspects the next codepoint.

The only caller is the `<!` handler, which does `peek(2)` to check for the legacy `<!--` HTML comment opener. So the minimal repro is:

```js
new Bun.Transpiler().transformSync("<!x"); // panic: index out of bounds: index 4, len 3
new Bun.Transpiler().transformSync("<!ñ"); // panic: index out of bounds: index 6, len 4
```

In debug/ASAN builds this panics with `index out of bounds`. In release builds it reads adjacent memory (deterministically segfaults when the source is placed against a guard page).

Found by Fuzzilli, fingerprint `dd7ff95b25f99a65` — the fuzzer passed `Bun.allocUnsafe(3)` (random uninitialized bytes) into `Transpiler.transform()`, which occasionally produces bytes starting with `<!`.

## Tests

- Added `<!x` and `<!ñ` cases to the existing guard-page fixture (`test/js/bun/transpiler/transpiler-truncated-utf8.test.ts`) so the over-read faults deterministically in release builds too — fails on current `main`, passes with the fix.
- Added behavioral assertions in `test/bundler/transpiler/transpiler.test.js` covering `<!x`, `<!ñ`, `<!`, a truncated 4-byte lead, and confirming `<!--` still triggers the legacy-HTML-comment error.