### PR TITLE
Bun.serve: rename `h3`/`h1` options to `http3`/`http1`

### DIFF
--- a/bench/snippets/http3-hello.js
+++ b/bench/snippets/http3-hello.js
@@ -44,8 +44,8 @@ var i = 0;
 
 const server = Bun.serve({
   port: 3001,
-  h3: true,
-  h1: true,
+  http3: true,
+  http1: true,
   tls: { cert, key, rejectUnauthorized: false },
   routes: { "/hi": new Response("hello!") },
   fetch(req) {

--- a/docs/runtime/http/server.mdx
+++ b/docs/runtime/http/server.mdx
@@ -169,6 +169,50 @@ Unlike unix domain sockets, abstract namespace sockets are not bound to the file
 
 ---
 
+## HTTP/3 (QUIC)
+
+<Note>HTTP/3 support in `Bun.serve` is **experimental** and may change in future releases.</Note>
+
+`Bun.serve` can also listen for HTTP/3 over QUIC. Set `http3: true` together with [`tls`](./tls) — HTTP/3 always requires TLS.
+
+```ts
+Bun.serve({
+  tls: {
+    key: Bun.file("./key.pem"),
+    cert: Bun.file("./cert.pem"),
+  },
+  http3: true, // [!code ++]
+  fetch(req) {
+    return new Response("Hello over HTTP/3!");
+  },
+});
+```
+
+When `http3` is enabled, the server listens on the same port over both TCP (HTTP/1.1) and UDP (HTTP/3). HTTP/1.1 responses include an `Alt-Svc` header advertising the HTTP/3 endpoint so capable clients can upgrade automatically.
+
+To serve HTTP/3 only — no TCP listener at all — set `http1: false`:
+
+```ts
+Bun.serve({
+  tls: {
+    key: Bun.file("./key.pem"),
+    cert: Bun.file("./cert.pem"),
+  },
+  http3: true,
+  http1: false, // [!code ++]
+  fetch(req) {
+    return new Response("HTTP/3 only");
+  },
+});
+```
+
+<Note>
+  `http3` is not supported with unix domain sockets — QUIC requires a UDP port. `http1: false` always requires `http3:
+  true`.
+</Note>
+
+---
+
 ## idleTimeout
 
 By default, `Bun.serve` closes connections after **10 seconds** of inactivity. A connection is considered idle when there is no data being sent or received — this includes in-flight requests where your handler is still running but hasn't written any bytes to the response yet. Browsers and `fetch()` clients will see this as a connection reset.

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -760,15 +760,17 @@ declare module "bun" {
       /**
        * Also listen for HTTP/3 (QUIC) on the same port. Requires {@link tls}.
        * @default false
+       * @experimental
        */
-      h3?: boolean;
+      http3?: boolean;
 
       /**
-       * Listen for HTTP/1.1 (and HTTP/2) over TCP. Set to `false` together
-       * with `h3: true` to serve HTTP/3 only.
+       * Listen for HTTP/1.1 over TCP. Set to `false` together with
+       * `http3: true` to serve HTTP/3 only.
        * @default true
+       * @experimental
        */
-      h1?: boolean;
+      http1?: boolean;
 
       /**
        * Sets the number of seconds to wait before timing out a connection

--- a/packages/h3blast/README.md
+++ b/packages/h3blast/README.md
@@ -1,7 +1,7 @@
 # h3blast
 
 A small, very fast HTTP/3 load generator built directly on **lsquic**. It exists
-to stress `Bun.serve({ h3: true })` without going through curl or a Node QUIC
+to stress `Bun.serve({ http3: true })` without going through curl or a Node QUIC
 shim — same lsquic, same BoringSSL, same packet path as the server side.
 
 ```

--- a/packages/h3blast/test-server.js
+++ b/packages/h3blast/test-server.js
@@ -30,8 +30,8 @@ spawnSync(
 
 const server = Bun.serve({
   port: Number(process.argv[2] ?? process.env.PORT ?? 3443),
-  h3: true,
-  h1: false,
+  http3: true,
+  http1: false,
   tls: { cert: readFileSync(certPath, "utf8"), key: readFileSync(keyPath, "utf8") },
   fetch() {
     return new Response("Hello, World!");

--- a/scripts/build/deps/lsquic.ts
+++ b/scripts/build/deps/lsquic.ts
@@ -1,6 +1,6 @@
 /**
  * lsquic — Litespeed's QUIC and HTTP/3 implementation. Powers Bun.serve's
- * `h3: true` listener.
+ * `http3: true` listener.
  *
  * DirectBuild: ~85 .c files from src/liblsquic. The upstream build runs a
  * Perl script to generate lsquic_versions_to_string.c at configure time;

--- a/src/runtime/server/ServerConfig.zig
+++ b/src/runtime/server/ServerConfig.zig
@@ -52,8 +52,8 @@ reuse_port: bool = false,
 id: []const u8 = "",
 allow_hot: bool = true,
 ipv6_only: bool = false,
-h3: bool = false,
-h1: bool = true,
+http3: bool = false,
+http1: bool = true,
 
 is_node_http: bool = false,
 had_routes_object: bool = false,
@@ -862,13 +862,13 @@ pub fn fromJS(
         }
         if (global.hasException()) return error.JSError;
 
-        if (try arg.get(global, "h3")) |v| {
-            args.h3 = v.toBoolean();
+        if (try arg.get(global, "http3")) |v| {
+            args.http3 = v.toBoolean();
         }
         if (global.hasException()) return error.JSError;
 
-        if (try arg.get(global, "h1")) |v| {
-            args.h1 = v.toBoolean();
+        if (try arg.get(global, "http1")) |v| {
+            args.http1 = v.toBoolean();
         }
         if (global.hasException()) return error.JSError;
 
@@ -983,15 +983,15 @@ pub fn fromJS(
             }
         }
 
-        if (args.h3) {
+        if (args.http3) {
             if (args.ssl_config == null) {
                 return global.throwInvalidArguments("HTTP/3 requires 'tls' to be set", .{});
             }
-        } else if (!args.h1) {
-            return global.throwInvalidArguments("Cannot disable h1 without enabling h3", .{});
+        } else if (!args.http1) {
+            return global.throwInvalidArguments("Cannot disable http1 without enabling http3", .{});
         }
-        if (!args.h1 and args.address == .unix) {
-            return global.throwInvalidArguments("Cannot disable h1 with a unix socket — HTTP/3 over AF_UNIX is not supported", .{});
+        if (!args.http1 and args.address == .unix) {
+            return global.throwInvalidArguments("Cannot disable http1 with a unix socket — HTTP/3 over AF_UNIX is not supported", .{});
         }
     } else {
         return global.throwInvalidArguments("Bun.serve expects an object", .{});

--- a/src/runtime/server/server.zig
+++ b/src/runtime/server/server.zig
@@ -1563,9 +1563,9 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             return this.activeSocketsCount() > 0;
         }
 
-        /// True while either the TCP listen socket or (h1: false) the QUIC
+        /// True while either the TCP listen socket or (http1: false) the QUIC
         /// listen socket is bound. The lifecycle code uses this rather than
-        /// `this.listener != null` so an h3-only server is still treated as
+        /// `this.listener != null` so an HTTP/3-only server is still treated as
         /// running.
         pub fn hasListener(this: *const ThisServer) bool {
             if (this.listener != null) return true;
@@ -3061,7 +3061,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 this.app = app;
 
                 if (comptime has_h3) {
-                    if (this.config.h3) {
+                    if (this.config.http3) {
                         this.h3_app = uws.H3.App.create(ssl_options, this.config.idleTimeout) orelse {
                             if (!globalThis.hasException()) {
                                 globalThis.throw("Failed to create HTTP/3 server", .{}) catch {};
@@ -3173,7 +3173,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                         }
                     }
 
-                    if (this.config.h1) {
+                    if (this.config.http1) {
                         app.listenWithConfig(*ThisServer, this, onListen, .{
                             .port = tcp.port,
                             .host = host,
@@ -3197,7 +3197,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                                 this.deinit();
                                 return .zero;
                             }
-                            if (!this.config.h1) this.vm.event_loop_handle = Async.Loop.get();
+                            if (!this.config.http1) this.vm.event_loop_handle = Async.Loop.get();
                         }
                     }
                 },
@@ -3207,7 +3207,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                         // QUIC over AF_UNIX is non-standard and Alt-Svc can't
                         // advertise it. Drop the H3 listener rather than wire
                         // an exotic transport nobody can reach.
-                        bun.Output.warn("h3: true with a unix socket — HTTP/3 listener skipped", .{});
+                        bun.Output.warn("http3: true with a unix socket — HTTP/3 listener skipped", .{});
                         h3a.destroy();
                         this.h3_app = null;
                     };

--- a/src/uws_sys/quic/Context.zig
+++ b/src/uws_sys/quic/Context.zig
@@ -1,6 +1,6 @@
 //! `us_quic_socket_context_t` — one lsquic engine + its event-loop wiring.
 //! For the client there is exactly one of these per HTTP-thread loop and it
-//! lives for the process; the server creates one per `Bun.serve({h3:true})`.
+//! lives for the process; the server creates one per `Bun.serve({http3:true})`.
 
 pub const Context = opaque {
     extern fn us_create_quic_client_context(loop: *uws.Loop, ext_size: c_uint, conn_ext: c_uint, stream_ext: c_uint) ?*Context;

--- a/test/js/bun/http/fetch-h3.ts
+++ b/test/js/bun/http/fetch-h3.ts
@@ -148,10 +148,10 @@ export function httpProtocols(): Array<{
   protocol: "http/1.1" | "http/3";
   fetch: (url: string | URL, init?: Init) => Promise<Response>;
   /** Serve options to spread into Bun.serve() for this protocol. */
-  serve: { tls?: object; h3?: boolean };
+  serve: { tls?: object; http3?: boolean };
 }> {
   return [
     { protocol: "http/1.1", fetch: (u, i) => fetch(u, i as RequestInit), serve: {} },
-    { protocol: "http/3", fetch: fetchH3, serve: { tls, h3: true } },
+    { protocol: "http/3", fetch: fetchH3, serve: { tls, http3: true } },
   ];
 }

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -5,7 +5,7 @@ import { join } from "path";
 
 // Native HTTP/3 fetch wrapper. Every request in this file forces
 // `protocol: "http3"` so a regression that silently falls back to TCP
-// surfaces as a connect failure (the fixtures bind UDP via `h3: true`).
+// surfaces as a connect failure (the fixtures bind UDP via `http3: true`).
 const fetchH3 = (port: number, path: string, init: RequestInit & { signal?: AbortSignal } = {}) =>
   fetch(`https://127.0.0.1:${port}${path}`, {
     ...init,
@@ -21,8 +21,8 @@ const big = Buffer.alloc(512 * 1024, "abcdefghijklmnop");
 const server = serve({
   port: 0,
   tls: ${JSON.stringify(tls)},
-  h3: true,
-  h1: process.env.H3_ONLY !== "1",
+  http3: true,
+  http1: process.env.H3_ONLY !== "1",
   routes: {
     "/api/:id": req => new Response("id=" + req.params.id, { headers: { "x-route": "api" } }),
     "/route-only": { POST: () => new Response("posted") },
@@ -270,7 +270,7 @@ describe("Bun.serve HTTP/3", () => {
     });
   });
 
-  test("h1: false rejects HTTP/1.1 but accepts HTTP/3", async () => {
+  test("http1: false rejects HTTP/1.1 but accepts HTTP/3", async () => {
     await withServer(
       async port => {
         const h3 = await fetchH3(port, "/hello");
@@ -284,13 +284,13 @@ describe("Bun.serve HTTP/3", () => {
     );
   });
 
-  // With h1:false the TCP listen socket is never created, so server.url /
+  // With http1:false the TCP listen socket is never created, so server.url /
   // server.address / server.stop() must consult the QUIC listener.
-  test("h1: false — url/address/stop see the QUIC listener", async () => {
+  test("http1: false — url/address/stop see the QUIC listener", async () => {
     const script = `
       const tls = ${JSON.stringify(tls)};
       const server = Bun.serve({
-        port: 0, tls, h3: true, h1: false,
+        port: 0, tls, http3: true, http1: false,
         fetch: () => new Response("ok"),
       });
       console.error("PORT=" + server.port);
@@ -323,7 +323,7 @@ describe("Bun.serve HTTP/3", () => {
     const script = `
       const tls = ${JSON.stringify(tls)};
       const server = Bun.serve({
-        port: 0, tls, h3: true,
+        port: 0, tls, http3: true,
         maxRequestBodySize: 64 * 1024,
         async fetch(req) {
           try { await req.arrayBuffer(); return new Response("read"); }
@@ -384,7 +384,7 @@ describe("Bun.serve HTTP/3", () => {
     const script = `
       const tls = ${JSON.stringify(tls)};
       const server = Bun.serve({
-        port: 0, tls, h3: true,
+        port: 0, tls, http3: true,
         routes: { "/*": { GET: () => new Response("from-route") } },
         fetch: req => new Response("from-fetch:" + req.method),
       });
@@ -413,9 +413,9 @@ describe("Bun.serve HTTP/3", () => {
     });
   });
 
-  test("validation: h3 without tls throws", async () => {
+  test("validation: http3 without tls throws", async () => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", "Bun.serve({ port: 0, h3: true, fetch: () => new Response('x') })"],
+      cmd: [bunExe(), "-e", "Bun.serve({ port: 0, http3: true, fetch: () => new Response('x') })"],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -449,15 +449,15 @@ describe("Bun.serve HTTP/3", () => {
     });
   });
 
-  test("validation: h1:false without h3 throws", async () => {
+  test("validation: http1:false without http3 throws", async () => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", "Bun.serve({ port: 0, h1: false, fetch: () => new Response('x') })"],
+      cmd: [bunExe(), "-e", "Bun.serve({ port: 0, http1: false, fetch: () => new Response('x') })"],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    expect(stderr.toLowerCase()).toContain("h1");
+    expect(stderr.toLowerCase()).toContain("http1");
     expect(exitCode).not.toBe(0);
   });
 });
@@ -824,7 +824,7 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
     const script = `
       const tls = ${JSON.stringify(tls)};
       let server = Bun.serve({
-        port: 0, tls, h3: true,
+        port: 0, tls, http3: true,
         routes: { "/old": new Response("old-route") },
         fetch: () => new Response("fallback", { status: 404 }),
       });
@@ -858,7 +858,7 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
     const script = `
       const tls = ${JSON.stringify(tls)};
       const server = Bun.serve({
-        port: 0, tls, h3: true,
+        port: 0, tls, http3: true,
         fetch: () => new Response("alive"),
       });
       console.error("PORT=" + server.port);
@@ -891,7 +891,7 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
       const tls = ${JSON.stringify(tls)};
       let stopping = false, inflight = 0;
       const server = Bun.serve({
-        port: 0, tls, h3: true, idleTimeout: 30,
+        port: 0, tls, http3: true, idleTimeout: 30,
         async fetch(req) {
           const url = new URL(req.url);
           if (url.pathname === "/slow") {
@@ -936,7 +936,7 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
     using dir = tempDir("serve-http3-exit", {
       "server.mjs": `
         const server = Bun.serve({
-          port: 0, tls: ${JSON.stringify(tls)}, h3: true, h1: false,
+          port: 0, tls: ${JSON.stringify(tls)}, http3: true, http1: false,
           fetch: () => new Response("ok"),
         });
         console.error("PORT=" + server.port);
@@ -974,7 +974,7 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
       const tls = ${JSON.stringify(tls)};
       let aborted = 0;
       const server = Bun.serve({
-        port: 0, tls, h3: true,
+        port: 0, tls, http3: true,
         async fetch(req) {
           const url = new URL(req.url);
           if (url.pathname === "/hang") {
@@ -1013,7 +1013,7 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
 
 describe("Bun.serve HTTP/3 production", () => {
   // E: H1 responses advertise the H3 endpoint so browsers can discover it.
-  test("Alt-Svc emitted on HTTP/1.1 responses when h3 is enabled", async () => {
+  test("Alt-Svc emitted on HTTP/1.1 responses when http3 is enabled", async () => {
     await withServer(async port => {
       // The fetch()/static-route/file-route response paths each write
       // headers from a different place; all three must advertise h3.
@@ -1037,7 +1037,7 @@ describe("Bun.serve HTTP/3 production", () => {
     const script = `
       const tls = ${JSON.stringify(tls)};
       const server = Bun.serve({
-        port: 0, tls, h3: true,
+        port: 0, tls, http3: true,
         websocket: { message() {} },
         fetch(req, srv) {
           const ok = srv.upgrade(req);

--- a/test/js/bun/http/serve-protocols.test.ts
+++ b/test/js/bun/http/serve-protocols.test.ts
@@ -14,14 +14,14 @@ const cases: Array<{
   protocol: Proto;
   fetch: (url: string | URL, init?: any) => Promise<Response>;
   scheme: "https" | "http";
-  serve: { tls?: typeof tls; h3?: boolean };
+  serve: { tls?: typeof tls; http3?: boolean };
 }> = [
   { protocol: "http/1.1", fetch, scheme: "http", serve: {} },
   {
     protocol: "http/3",
     fetch: (url, init) => fetch(url, { ...init, protocol: "http3", tls: { rejectUnauthorized: false } } as any),
     scheme: "https",
-    serve: { tls, h3: true },
+    serve: { tls, http3: true },
   },
 ];
 

--- a/test/js/bun/stream/direct-readable-stream.test.tsx
+++ b/test/js/bun/stream/direct-readable-stream.test.tsx
@@ -312,8 +312,8 @@ describe("ReactDOM", () => {
         server = serve({
           port: 0,
           tls,
-          h3: true,
-          h1: false,
+          http3: true,
+          http1: false,
           routes: {
             "/:i": async req =>
               new Response(await renderToReadableStream(cases[Number(req.params.i)][1]), {

--- a/test/js/web/fetch/body-stream.test.ts
+++ b/test/js/web/fetch/body-stream.test.ts
@@ -7,13 +7,14 @@ const port = 0;
 const globalFetch = fetch;
 
 // Run the entire suite once over plain HTTP/1.1 and once over HTTP/3 so the
-// streaming-body matrix exercises both transports end-to-end. The h3 row uses
-// `h1: false` so a regression that silently falls back to TCP fails outright.
+// streaming-body matrix exercises both transports end-to-end. The http/3 row
+// uses `http1: false` so a regression that silently falls back to TCP fails
+// outright.
 describe.each([
-  { name: "http/1.1", h3: false },
-  { name: "http/3", h3: true },
-])("body-stream over $name", ({ h3 }) => {
-  const fetch: typeof globalFetch = h3
+  { name: "http/1.1", http3: false },
+  { name: "http/3", http3: true },
+])("body-stream over $name", ({ http3 }) => {
+  const fetch: typeof globalFetch = http3
     ? (input, init) => globalFetch(input, { ...init, protocol: "http3", tls: { rejectUnauthorized: false } } as any)
     : globalFetch;
 
@@ -253,7 +254,7 @@ describe.each([
     const handler = {
       ...opts,
       port: 0,
-      ...(h3 ? { tls, h3: true, h1: false } : {}),
+      ...(http3 ? { tls, http3: true, http1: false } : {}),
       fetch(req) {
         try {
           return opts.fetch(req);
@@ -277,7 +278,7 @@ describe.each([
       server.reload(handler);
     }
 
-    const scheme = h3 ? "https" : "http";
+    const scheme = http3 ? "https" : "http";
     try {
       await cb(`${scheme}://${server.hostname}:${server.port}`);
     } catch (e) {
@@ -321,7 +322,7 @@ describe.each([
             // in a debug+ASAN build the per-packet cost pushes those past the
             // default timeout without exercising any path the smaller sizes
             // don't already cover.
-            const inputLengths = h3
+            const inputLengths = http3
               ? [1, 2, 12, 95, 1024, 64 * 1024]
               : [1, 2, 12, 95, 1024, 1024 * 1024, 1024 * 1024 * 2];
             for (let inputLength of inputLengths) {

--- a/test/js/web/fetch/fetch-http3-adversarial.test.ts
+++ b/test/js/web/fetch/fetch-http3-adversarial.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { tls } from "harness";
 
 // Adversarial fuzzer-style coverage for the HTTP/3 large-body path. The server
-// binds UDP only (`h1: false`) so a fetch that silently fell back to HTTP/1.1
+// binds UDP only (`http1: false`) so a fetch that silently fell back to HTTP/1.1
 // would ECONNREFUSED — every pass here proves the QUIC path carried the bytes.
 let server: Server;
 let base: string;
@@ -12,8 +12,8 @@ beforeAll(() => {
   server = Bun.serve({
     port: 0,
     tls,
-    h3: true,
-    h1: false,
+    http3: true,
+    http1: false,
     routes: {
       "/echo": async req => {
         const body = await req.bytes();

--- a/test/js/web/fetch/fetch-http3-client.test.ts
+++ b/test/js/web/fetch/fetch-http3-client.test.ts
@@ -2,7 +2,7 @@ import { gzipSync, type Server } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir, tls } from "harness";
 
-// In-process server with `h1: false` so the build under test binds UDP only.
+// In-process server with `http1: false` so the build under test binds UDP only.
 // A fetch that silently fell back to HTTP/1.1 would get ECONNREFUSED, which
 // is what makes this suite prove `protocol: "http3"` actually works.
 let server: Server;
@@ -13,8 +13,8 @@ beforeAll(async () => {
   server = Bun.serve({
     port: 0,
     tls,
-    h3: true,
-    h1: false,
+    http3: true,
+    http1: false,
     routes: {
       "/hello": () => new Response("hello over h3", { headers: { "x-proto": "h3" } }),
       "/echo": async req => {
@@ -153,7 +153,7 @@ beforeAll(async () => {
     await fetch(`${base}/hello`, { tls: { rejectUnauthorized: false } });
     tcpReached = true;
   } catch {}
-  if (tcpReached) throw new Error("server accepted TCP; h1:false not honoured — suite would not prove HTTP/3");
+  if (tcpReached) throw new Error("server accepted TCP; http1:false not honoured — suite would not prove HTTP/3");
 });
 
 // Don't await: the H3 client's pooled session to this origin stays open
@@ -394,7 +394,7 @@ describe("fetch protocol: http3", () => {
     // unusable so the next fetch (new port → new session) isn't disrupted by
     // the draining ones still on the shared UDP socket.
     for (let i = 0; i < 30; i++) {
-      const s = Bun.serve({ port: 0, tls, h3: true, h1: false, routes: { "/n": () => new Response(String(i)) } });
+      const s = Bun.serve({ port: 0, tls, http3: true, http1: false, routes: { "/n": () => new Response(String(i)) } });
       const res = await fetch(`https://127.0.0.1:${s.port}/n`, h3);
       expect(await res.text()).toBe(String(i));
       s.stop(true);
@@ -551,8 +551,8 @@ test("retries on a fresh session when a pooled session is stale (port reuse)", a
     port: 0,
     reusePort: true,
     tls,
-    h3: true,
-    h1: false,
+    http3: true,
+    http1: false,
     fetch: async req => {
       if (new URL(req.url).pathname === "/hang") {
         await new Promise<void>(r => (release = r));
@@ -565,7 +565,7 @@ test("retries on a fresh session when a pooled session is stale (port reuse)", a
   expect(await fetch(`https://127.0.0.1:${port}/`, h3).then(r => r.text())).toBe("a");
   const inflight = fetch(`https://127.0.0.1:${port}/hang`, h3);
   await Bun.sleep(50);
-  const b = Bun.serve({ port, reusePort: true, tls, h3: true, h1: false, fetch: () => new Response("b") });
+  const b = Bun.serve({ port, reusePort: true, tls, http3: true, http1: false, fetch: () => new Response("b") });
   // Abrupt stop sends CONNECTION_CLOSE then closes the fd, so /hang's
   // stream closes before any response — that's the retryOrFail trigger.
   a.stop(true);
@@ -579,21 +579,21 @@ test("retries on a fresh session when a pooled session is stale (port reuse)", a
 });
 
 // Subprocess so the experimental flag is process-scoped and the in-process
-// server above (h1: false) doesn't interfere — this server keeps h1 on so the
-// first fetch goes over TCP and reads Alt-Svc.
+// server above (http1: false) doesn't interfere — this server keeps http1 on
+// so the first fetch goes over TCP and reads Alt-Svc.
 describe("Alt-Svc upgrade (--experimental-http3-fetch)", () => {
-  // The fixture starts a server with both h1+h3 listening on the same port,
-  // does two fetches with no `protocol:` hint, and prints the alt-svc header
-  // plus the live h3 session count after each. With the flag on, fetch #1
-  // goes over h1 (sessions=0) and records Alt-Svc; fetch #2 goes over QUIC
-  // (sessions=1).
+  // The fixture starts a server with both http1+http3 listening on the same
+  // port, does two fetches with no `protocol:` hint, and prints the alt-svc
+  // header plus the live http/3 session count after each. With the flag on,
+  // fetch #1 goes over http/1.1 (sessions=0) and records Alt-Svc; fetch #2
+  // goes over QUIC (sessions=1).
   const fixture = `
     import { fetchH3Internals } from "bun:internal-for-testing";
     const { liveCounts } = fetchH3Internals;
     using server = Bun.serve({
       port: 0,
       tls: ${JSON.stringify(tls)},
-      h3: true,
+      http3: true,
       fetch: () => new Response("ok"),
     });
     const url = "https://127.0.0.1:" + server.port + "/";


### PR DESCRIPTION
## What

Renames the `Bun.serve()` `ServerConfig` HTTP/3 options from the abbreviated `h3` / `h1` to the spelled-out `http3` / `http1`.

```ts
// before
Bun.serve({ tls, h3: true, h1: false, fetch })

// after
Bun.serve({ tls, http3: true, http1: false, fetch })
```

These options have not shipped in a release yet, so this is a clean rename with no backwards-compat aliases.

## Changes

- **`src/runtime/server/ServerConfig.zig` / `server.zig`**: rename the `ServerConfig` struct fields and the JS option lookups (`arg.get(global, "http3")`, etc.); update the validation error messages and the unix-socket warning.
- **`packages/bun-types/serve.d.ts`**: rename the type declarations, drop the incorrect "(and HTTP/2)" from the `http1` JSDoc (Bun.serve does not support HTTP/2), and mark both options `@experimental`.
- **`docs/runtime/http/server.mdx`**: add an "HTTP/3 (QUIC)" section documenting `http3` / `http1`, Alt-Svc, the unix-socket limitation, and the experimental status.
- **Tests**: update `Bun.serve({ http3, http1 })` call sites, test names, and the validation error-message assertion across the HTTP/3 suites (`serve-http3.test.ts`, `serve-protocols.test.ts`, `body-stream.test.ts`, `fetch-http3-client.test.ts`, `fetch-http3-adversarial.test.ts`, `direct-readable-stream.test.tsx`, `fetch-h3.ts`, `packages/h3blast/`).

## Notes

- The internal `uws.AnyRequest` union variants (`.h1`/`.h3`) are left as-is — those tag a transport, not a config option.
- The `fetch()` `protocol` option (`"http1.1" | "h1" | "http2" | "h2" | "http3" | "h3"`) is unchanged; it already accepts both spellings.
- `zig:check` and the `bun-types` `tsc` test pass locally. The full HTTP/3 test suite will run in CI.