### PR TITLE
Fix stack overflow in Bun.inspect with circular JSX elements

### DIFF
--- a/src/jsc/ConsoleObject.zig
+++ b/src/jsc/ConsoleObject.zig
@@ -1136,7 +1136,7 @@ pub const Formatter = struct {
 
         pub fn canHaveCircularReferences(tag: Tag) bool {
             return switch (tag) {
-                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event => true,
+                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event, .JSX => true,
                 else => false,
             };
         }
@@ -3140,13 +3140,12 @@ pub const Formatter = struct {
                     }
                 }
 
-                if (try value.get(this.globalThis, "props")) |props| {
+                if (try value.get(this.globalThis, "props")) |props| props: {
                     const prev_quote_strings = this.quote_strings;
                     defer this.quote_strings = prev_quote_strings;
                     this.quote_strings = true;
 
-                    // SAFETY: JSX props are always objects
-                    const props_obj = props.getObject().?;
+                    const props_obj = props.getObject() orelse break :props;
                     var props_iter = try jsc.JSPropertyIterator(.{
                         .skip_empty_name = true,
                         .include_value = true,

--- a/src/test_runner/pretty_format.zig
+++ b/src/test_runner/pretty_format.zig
@@ -326,7 +326,7 @@ pub const JestPrettyFormat = struct {
             }
 
             pub inline fn canHaveCircularReferences(tag: Tag) bool {
-                return tag == .Array or tag == .Object or tag == .Map or tag == .Set;
+                return tag == .Array or tag == .Object or tag == .Map or tag == .Set or tag == .JSX;
             }
 
             const Result = struct {
@@ -1534,13 +1534,12 @@ pub const JestPrettyFormat = struct {
                         }
                     }
 
-                    if (try value.get(this.globalThis, "props")) |props| {
+                    if (try value.get(this.globalThis, "props")) |props| props: {
                         const prev_quote_strings = this.quote_strings;
                         defer this.quote_strings = prev_quote_strings;
                         this.quote_strings = true;
 
-                        // SAFETY: JSX props are always an object.
-                        const props_obj = props.getObject().?;
+                        const props_obj = props.getObject() orelse break :props;
                         var props_iter = try jsc.JSPropertyIterator(.{
                             .skip_empty_name = true,
                             .include_value = true,

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -335,7 +335,9 @@ it("jsx with circular reference as props object", () => {
     props: {},
   };
   el.props = el;
-  expect(Bun.inspect(el)).toContain("[Circular]");
+  expect(Bun.inspect(el)).toBe(
+    `<div $$typeof=Symbol(react.transitional.element) type="div" key=null ref=null props=[Circular] />`,
+  );
 });
 
 it("jsx with circular reference in key", () => {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -316,6 +316,56 @@ it("jsx with fragment", () => {
   expect(input).toBe(output);
 });
 
+it("jsx with circular reference in props", () => {
+  const el = {
+    $$typeof: Symbol.for("react.element"),
+    type: "div",
+    props: {},
+  };
+  el.props.foo = el;
+  expect(Bun.inspect(el)).toBe("<div foo=[Circular] />");
+});
+
+it("jsx with circular reference as props object", () => {
+  const el = {
+    $$typeof: Symbol.for("react.transitional.element"),
+    type: "div",
+    key: null,
+    ref: null,
+    props: {},
+  };
+  el.props = el;
+  expect(Bun.inspect(el)).toContain("[Circular]");
+});
+
+it("jsx with circular reference in key", () => {
+  const el = {
+    $$typeof: Symbol.for("react.element"),
+    type: "div",
+  };
+  el.key = el;
+  expect(Bun.inspect(el)).toBe("<div key=[Circular] />");
+});
+
+it("jsx with circular reference in children", () => {
+  const el = {
+    $$typeof: Symbol.for("react.element"),
+    type: "div",
+    props: { children: null },
+  };
+  el.props.children = el;
+  expect(Bun.inspect(el)).toBe("<div>\n  [Circular]\n</div>");
+});
+
+it("jsx with non-object props", () => {
+  const el = {
+    $$typeof: Symbol.for("react.element"),
+    type: "div",
+    props: 123,
+  };
+  expect(Bun.inspect(el)).toBe("<div />");
+});
+
 it("inspect", () => {
   expect(Bun.inspect(new TypeError("what")).includes("TypeError: what")).toBe(true);
   expect(Bun.inspect("hi")).toBe('"hi"');


### PR DESCRIPTION
`Bun.inspect()` / `console.log()` crashed with a stack overflow when given a React element that referenced itself via `key`, `props`, or `children`.

```js
const el = {
  $$typeof: Symbol.for("react.element"),
  type: "div",
  props: {},
};
el.props.foo = el;
Bun.inspect(el); // SIGSEGV
```

The JSX branch of the formatter recursively prints `key`, each prop value, and `children`, but `.JSX` was missing from `canHaveCircularReferences()` so it skipped both the visited-map check and the `isSafeToRecurse()` stack guard. Any cycle through a JSX element recursed until the stack blew out.

Fix: include `.JSX` in `canHaveCircularReferences()` in both `ConsoleObject.zig` and `pretty_format.zig` so cycles print as `[Circular]`.

Also replaced `props.getObject().?` with `props.getObject() orelse break :props` — the "JSX props are always objects" assumption is not true for arbitrary objects shaped like React elements, and unwrapping panicked on `props: 123`.

Found by Fuzzilli.