### PR TITLE
Fix segfault inspecting JSX with circular props

### DIFF
--- a/src/jsc/ConsoleObject.zig
+++ b/src/jsc/ConsoleObject.zig
@@ -1136,7 +1136,7 @@ pub const Formatter = struct {
 
         pub fn canHaveCircularReferences(tag: Tag) bool {
             return switch (tag) {
-                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event => true,
+                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event, .JSX => true,
                 else => false,
             };
         }

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -316,6 +316,20 @@ it("jsx with fragment", () => {
   expect(input).toBe(output);
 });
 
+it("jsx with circular props does not crash", () => {
+  const el = Bun.markdown.react("hello");
+  el.props = el;
+  const out = Bun.inspect(el);
+  expect(out).toContain("[Circular]");
+});
+
+it("jsx with circular children does not crash", () => {
+  const el = Bun.markdown.react("hello");
+  el.props.children = el;
+  const out = Bun.inspect(el);
+  expect(out).toContain("[Circular]");
+});
+
 it("inspect", () => {
   expect(Bun.inspect(new TypeError("what")).includes("TypeError: what")).toBe(true);
   expect(Bun.inspect("hi")).toBe('"hi"');


### PR DESCRIPTION
### What

`Bun.inspect` (and `console.log`) segfaulted on JSX/React elements where `props` (or any property other than `children`) pointed back at the element itself, creating a circular reference.

### Repro

```js
const el = Bun.markdown.react("hello");
el.props = el;
Bun.inspect(el); // SIGSEGV (stack overflow)
```

### Root cause

The generic `printAs` path guards against circular references by tracking visited objects in a map and by checking the stack budget — but only when `Tag.canHaveCircularReferences()` returns `true` for the current tag. `.JSX` was missing from that list, so inspecting a JSX element just recursed into `this.format` for each prop with no bookkeeping. When a prop referenced the element itself, this ran until the native stack was exhausted.

### Fix

Add `.JSX` to `canHaveCircularReferences()`. The existing visited-map + stack-check code in `printAs` then handles JSX the same as `Object`, `Array`, `Map`, etc.: the second visit prints `[Circular]` instead of recursing.

Added regression tests covering circular `props` and circular `children`.