### PR TITLE
Don't keep process alive for globalThis.onmessage on main thread

### DIFF
--- a/src/jsc/bindings/BunWorkerGlobalScope.cpp
+++ b/src/jsc/bindings/BunWorkerGlobalScope.cpp
@@ -1,6 +1,7 @@
 #include "config.h"
 
 #include "BunWorkerGlobalScope.h"
+#include "ScriptExecutionContext.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -11,24 +12,33 @@ void WorkerGlobalScope::onDidChangeListenerImpl(EventTarget& self, const AtomStr
 {
     if (eventType == eventNames().messageEvent) {
         auto& global = static_cast<WorkerGlobalScope&>(self);
+        auto* context = global.scriptExecutionContext();
+        // Inside a worker, a `message` listener on the global scope keeps the
+        // event loop alive so the worker can receive messages from its parent.
+        // On the main thread there is no parent to receive messages from, so
+        // `globalThis.onmessage = ...` / addEventListener("message", ...) must
+        // not prevent the process from exiting.
+        // https://github.com/oven-sh/bun/issues/24256
+        if (!context || context->isMainThread())
+            return;
         switch (kind) {
         case Add:
             if (global.m_messageEventCount == 0) {
-                global.scriptExecutionContext()->refEventLoop();
+                context->refEventLoop();
             }
             global.m_messageEventCount++;
             break;
         case Remove:
             global.m_messageEventCount--;
             if (global.m_messageEventCount == 0) {
-                global.scriptExecutionContext()->unrefEventLoop();
+                context->unrefEventLoop();
             }
             break;
         // I dont think clear in this context is ever called. If it is (search OnDidChangeListenerKind::Clear for the impl),
         // it may actually call once per event, in a way the Remove code above would suffice.
         case Clear:
             if (global.m_messageEventCount > 0) {
-                global.scriptExecutionContext()->unrefEventLoop();
+                context->unrefEventLoop();
             }
             global.m_messageEventCount = 0;
             break;

--- a/src/jsc/bindings/BunWorkerGlobalScope.cpp
+++ b/src/jsc/bindings/BunWorkerGlobalScope.cpp
@@ -15,11 +15,13 @@ void WorkerGlobalScope::onDidChangeListenerImpl(EventTarget& self, const AtomStr
         auto* context = global.scriptExecutionContext();
         // Inside a worker, a `message` listener on the global scope keeps the
         // event loop alive so the worker can receive messages from its parent.
-        // On the main thread there is no parent to receive messages from, so
+        // Outside a worker — the main thread, or a ShadowRealm (which gets its
+        // own ScriptExecutionContext but is never the target of parent
+        // messages) — there is nothing to wait for, so
         // `globalThis.onmessage = ...` / addEventListener("message", ...) must
         // not prevent the process from exiting.
         // https://github.com/oven-sh/bun/issues/24256
-        if (!context || context->isMainThread())
+        if (!context || !context->isWorker)
             return;
         switch (kind) {
         case Add:

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -567,6 +567,7 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
         };
 
         if (auto* worker = static_cast<WebCore::Worker*>(worker_ptr)) {
+            globalObject->scriptExecutionContext()->isWorker = true;
             initializeWorker(*worker);
         }
     }

--- a/test/js/web/workers/onmessage-main-thread.test.ts
+++ b/test/js/web/workers/onmessage-main-thread.test.ts
@@ -1,0 +1,57 @@
+// https://github.com/oven-sh/bun/issues/24256
+// https://github.com/oven-sh/bun/issues/24484
+//
+// The globalThis event target is backed by WorkerGlobalScope on every
+// Zig::GlobalObject. Adding a `message` listener there refs the event loop so
+// a worker stays alive to receive messages from its parent. Outside a worker
+// (main thread, ShadowRealm) there is no parent, so the listener must not
+// prevent the process from exiting.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+describe.each([
+  ["globalThis.onmessage", `globalThis.onmessage = () => {};`],
+  ['addEventListener("message")', `globalThis.addEventListener("message", () => {});`],
+  ["ShadowRealm onmessage", `new ShadowRealm().evaluate("globalThis.onmessage = () => {}; 0");`],
+])("%s on the main thread does not keep the process alive", (_, setup) => {
+  test("exits", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `${setup} console.log("hello world");`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("hello world\n");
+    expect(exitCode).toBe(0);
+  });
+});
+
+// The inverse: inside a worker, `onmessage` on the global scope MUST keep the
+// event loop alive so the worker can receive messages from its parent. The
+// worker below sets onmessage to a handler that clears itself after replying;
+// if the event-loop ref were not taken the worker would exit immediately and
+// the message would never be delivered.
+test("onmessage inside a worker keeps the worker alive", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const w = new Worker(
+          \`data:text/javascript,onmessage = e => { postMessage(e.data); onmessage = null; };\`,
+        );
+        w.onmessage = e => { console.log("got:" + e.data); w.onmessage = null; };
+        w.postMessage("hi");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("got:hi\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -257,6 +257,27 @@ describe("web worker", () => {
     });
   });
 
+  // https://github.com/oven-sh/bun/issues/24256
+  // On the main thread there is no parent to receive messages from, so a
+  // `message` listener on globalThis must not keep the process alive.
+  describe.each([
+    ["globalThis.onmessage", `globalThis.onmessage = () => {};`],
+    ['addEventListener("message")', `globalThis.addEventListener("message", () => {});`],
+  ])("%s on the main thread does not keep the process alive", (_, setup) => {
+    test("exits", async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", `${setup} console.log("hello world");`],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("hello world\n");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   test("worker with process.exit", done => {
     const worker = new Worker(new URL("worker-fixture-process-exit.js", import.meta.url).href, {
       smol: true,

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -258,11 +258,12 @@ describe("web worker", () => {
   });
 
   // https://github.com/oven-sh/bun/issues/24256
-  // On the main thread there is no parent to receive messages from, so a
+  // Outside a worker there is no parent to receive messages from, so a
   // `message` listener on globalThis must not keep the process alive.
   describe.each([
     ["globalThis.onmessage", `globalThis.onmessage = () => {};`],
     ['addEventListener("message")', `globalThis.addEventListener("message", () => {});`],
+    ["ShadowRealm onmessage", `new ShadowRealm().evaluate("globalThis.onmessage = () => {}; 0");`],
   ])("%s on the main thread does not keep the process alive", (_, setup) => {
     test("exits", async () => {
       await using proc = Bun.spawn({

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -257,28 +257,6 @@ describe("web worker", () => {
     });
   });
 
-  // https://github.com/oven-sh/bun/issues/24256
-  // Outside a worker there is no parent to receive messages from, so a
-  // `message` listener on globalThis must not keep the process alive.
-  describe.each([
-    ["globalThis.onmessage", `globalThis.onmessage = () => {};`],
-    ['addEventListener("message")', `globalThis.addEventListener("message", () => {});`],
-    ["ShadowRealm onmessage", `new ShadowRealm().evaluate("globalThis.onmessage = () => {}; 0");`],
-  ])("%s on the main thread does not keep the process alive", (_, setup) => {
-    test("exits", async () => {
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "-e", `${setup} console.log("hello world");`],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
-      expect(stdout).toBe("hello world\n");
-      expect(exitCode).toBe(0);
-    });
-  });
-
   test("worker with process.exit", done => {
     const worker = new Worker(new URL("worker-fixture-process-exit.js", import.meta.url).href, {
       smol: true,


### PR DESCRIPTION
Fixes #24256
Fixes #24484

## Repro

```js
console.log("hello world");
globalThis.onmessage = () => {};
```

Node prints `hello world` and exits. Bun prints `hello world` and hangs forever. Same for `globalThis.addEventListener("message", ...)`, and for the same thing evaluated inside a `ShadowRealm`. The `lzma` npm package (#24484) hits this by assigning `onmessage` on the main thread as part of its fake-worker shim.

## Cause

`WorkerGlobalScope` (in `BunWorkerGlobalScope.cpp`) backs the `globalThis` event target on **every** `Zig::GlobalObject` — main thread, workers, and ShadowRealms alike. Its `onDidChangeListenerImpl` hook calls `scriptExecutionContext()->refEventLoop()` whenever a `message` listener is added, so that a worker stays alive to receive messages from its parent.

Outside a worker there is no parent, so nothing ever sends a message, the ref is never balanced, and the event loop never drains.

## Fix

`ScriptExecutionContext` already has an `isWorker` flag that was never being set. Set it in `Zig__GlobalObject__create` when the global is created for a worker (`worker_ptr != nullptr`), and gate the ref/unref in `onDidChangeListenerImpl` on `context->isWorker`. This covers both the main thread and ShadowRealm globals (which get a fresh context identifier, so an `isMainThread()` check would miss them).

Worker threads are unaffected — the existing `worker-fixture-many-messages{,2}.js` fixtures (which rely on `addEventListener("message", ...)` / `onmessage = ...` keeping the worker alive) still complete successfully.

## Verification

New `test/js/web/workers/onmessage-main-thread.test.ts`:

- `globalThis.onmessage = fn` on main thread → process exits
- `addEventListener("message", fn)` on main thread → process exits
- `new ShadowRealm().evaluate("globalThis.onmessage = fn")` → process exits
- `onmessage = fn` inside a `Worker` → worker stays alive, receives and echoes a message, then exits cleanly

```
# without the fix
 1 pass, 3 fail (timeout, exit 143)

# with the fix
 4 pass, 0 fail
```

Also verified `require("lzma")` now exits cleanly.

Supersedes #27378 (same approach, stale/conflicting since the `src/bun.js/` → `src/jsc/` move).
