### PR TITLE
bundler: fix capacity underflow in ESMConditions.init

### DIFF
--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1087,9 +1087,10 @@ pub const ESMConditions = struct {
         var require_condition_map = ConditionsMap.init(allocator);
         var style_condition_map = ConditionsMap.init(allocator);
 
-        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
+        const addons_extra: usize = if (allow_addons) 1 else 0;
+        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + addons_extra + conditions.len);
+        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + addons_extra + conditions.len);
+        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + addons_extra + conditions.len);
         try style_condition_map.ensureTotalCapacity(defaults.len + 2 + conditions.len);
 
         import_condition_map.putAssumeCapacity("import", {});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -649,6 +649,20 @@ describe("Bun.build", () => {
       expect(await html?.text()).toContain("<meta name='injected-by-plugin' content='true'>");
     },
   );
+
+  test("many custom conditions does not crash", async () => {
+    const dir = tempDirWithFiles("bun-build-api-many-conditions", {
+      "entry.ts": "export const a = 1;",
+    });
+    const conditions: string[] = [];
+    for (let i = 0; i < 64; i++) conditions.push("cond" + i);
+    const result = await Bun.build({
+      entrypoints: [join(dir, "entry.ts")],
+      conditions,
+      throw: false,
+    });
+    expect(result.success).toBe(true);
+  });
 });
 
 test.concurrent("macro with nested object", async () => {


### PR DESCRIPTION
## What does this PR do?

`ESMConditions.init` computed the hash map capacity as:

```zig
defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len
```

Zig parses the `else` branch as `0 + conditions.len`, so when `allow_addons` is true (the default for `Bun.build`), `conditions.len` was dropped from the reserved capacity. With enough user-supplied `conditions`, the subsequent `putAssumeCapacity` calls wrote past the reserved entries and tripped a debug assertion.

Extracted the conditional into a `usize` local so the intent is unambiguous.

## How did you verify your code works?

```js
const conditions = [];
for (let i = 0; i < 64; i++) conditions.push("cond" + i);
await Bun.build({ entrypoints: ["./entry.ts"], conditions });
```

Before: `panic: reached unreachable code` in `MultiArrayList.addOneAssumeCapacity`.
After: builds successfully.

Added a regression test in `test/bundler/bun-build-api.test.ts`.

Found by Fuzzilli (fingerprint `d96a4010049f941c`).