### PR TITLE
Reject Blob read on write-only pollable fds instead of hanging

### DIFF
--- a/src/runtime/webcore/blob/read_file.zig
+++ b/src/runtime/webcore/blob/read_file.zig
@@ -405,6 +405,19 @@ pub const ReadFile = struct {
         // readable.
         if (this.could_block) {
             if (bun.isReadable(fd) == .not_ready) {
+                // A write-only fd (e.g. Bun.stdout when stdout is a pipe) will
+                // never become readable. Fail now instead of waiting forever.
+                if (comptime Environment.isPosix) {
+                    if (bun.sys.getFcntlFlags(fd).unwrap() catch null) |flags| {
+                        if ((flags & (bun.O.RDWR | bun.O.WRONLY)) == bun.O.WRONLY) {
+                            const err = bun.sys.Error.fromCode(.BADF, .read).withFd(fd);
+                            this.errno = bun.errnoToZigErr(err.errno);
+                            this.system_error = err.toSystemError();
+                            this.onFinish();
+                            return;
+                        }
+                    }
+                }
                 this.waitForReadable();
                 return;
             }

--- a/src/runtime/webcore/blob/read_file.zig
+++ b/src/runtime/webcore/blob/read_file.zig
@@ -372,6 +372,21 @@ pub const ReadFile = struct {
         if (this.errno != null)
             return this.onFinish();
 
+        // A write-only fd (e.g. Bun.stdout when stdout is a pipe) will never
+        // become readable, so polling for readability below would wait
+        // forever. Fail now before allocating the read buffer.
+        if (this.could_block and Environment.isPosix) {
+            if (bun.sys.getFcntlFlags(fd).unwrap() catch null) |flags| {
+                if ((flags & (bun.O.RDWR | bun.O.WRONLY)) == bun.O.WRONLY) {
+                    const err = bun.sys.Error.fromCode(.BADF, .read).withFd(fd);
+                    this.errno = bun.errnoToZigErr(err.errno);
+                    this.system_error = err.toSystemError();
+                    this.onFinish();
+                    return;
+                }
+            }
+        }
+
         // Special files might report a size of > 0, and be wrong.
         // so we should check specifically that its a regular file before trusting the size.
         if (this.size == 0 and bun.isRegularFile(this.file_store.mode)) {
@@ -405,19 +420,6 @@ pub const ReadFile = struct {
         // readable.
         if (this.could_block) {
             if (bun.isReadable(fd) == .not_ready) {
-                // A write-only fd (e.g. Bun.stdout when stdout is a pipe) will
-                // never become readable. Fail now instead of waiting forever.
-                if (comptime Environment.isPosix) {
-                    if (bun.sys.getFcntlFlags(fd).unwrap() catch null) |flags| {
-                        if ((flags & (bun.O.RDWR | bun.O.WRONLY)) == bun.O.WRONLY) {
-                            const err = bun.sys.Error.fromCode(.BADF, .read).withFd(fd);
-                            this.errno = bun.errnoToZigErr(err.errno);
-                            this.system_error = err.toSystemError();
-                            this.onFinish();
-                            return;
-                        }
-                    }
-                }
                 this.waitForReadable();
                 return;
             }

--- a/test/js/bun/util/bun-stdout-read-wronly.test.ts
+++ b/test/js/bun/util/bun-stdout-read-wronly.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tmpdirSync } from "harness";
+import { closeSync, constants, openSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+
+// Reading a Blob wrapping a write-only pollable fd (like the write end of a
+// pipe) used to hang forever: the ReadFile code would poll for readability,
+// get "not ready", and then register for EPOLLIN/EVFILT_READ on the write end,
+// which never fires. Now it rejects with EBADF instead of waiting.
+test.skipIf(isWindows)("Bun.file(fd).text() rejects on a write-only FIFO instead of hanging", async () => {
+  const dir = tmpdirSync();
+  const fifo = join(dir, "fifo");
+  Bun.spawnSync({ cmd: ["mkfifo", fifo], env: bunEnv });
+
+  // Open a non-blocking reader so opening the write side doesn't block.
+  const reader = openSync(fifo, constants.O_RDONLY | constants.O_NONBLOCK);
+  const writer = openSync(fifo, constants.O_WRONLY);
+  try {
+    let result: unknown;
+    try {
+      result = await Bun.file(writer).text();
+    } catch (e) {
+      result = e;
+    }
+    expect(result).toBeInstanceOf(Error);
+    expect((result as NodeJS.ErrnoException).code).toBe("EBADF");
+  } finally {
+    closeSync(writer);
+    closeSync(reader);
+    unlinkSync(fifo);
+  }
+});
+
+// This is the fuzzer-reduced case: HTMLRewriter picks up Blob.prototype.text as
+// the document text handler and synchronously waits on the returned promise.
+// When stdout is a shell pipe (O_WRONLY FIFO) this used to wedge the process.
+test.skipIf(isWindows)("HTMLRewriter.onDocument(Bun.stdout).transform() does not hang when stdout is a pipe", async () => {
+  const script = `
+    const r = new HTMLRewriter();
+    r.onDocument(Bun.stdout);
+    try { r.transform(new SharedArrayBuffer(16)); } catch {}
+    console.error("done");
+  `;
+  // Use a shell pipeline so the child's stdout is a real FIFO (write-only),
+  // matching how shells / fuzzilli set up stdio.
+  await using proc = Bun.spawn({
+    cmd: ["sh", "-c", `"$0" -e "$1" | cat > /dev/null`, bunExe(), script],
+    env: bunEnv,
+    stdin: "ignore",
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr.trim()).toBe("done");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/util/bun-stdout-read-wronly.test.ts
+++ b/test/js/bun/util/bun-stdout-read-wronly.test.ts
@@ -54,7 +54,7 @@ test.skipIf(isWindows)(
 
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-    expect(stderr.trim()).toBe("done");
+    expect(stderr).toContain("done");
     expect(exitCode).toBe(0);
   },
 );

--- a/test/js/bun/util/bun-stdout-read-wronly.test.ts
+++ b/test/js/bun/util/bun-stdout-read-wronly.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tmpdirSync } from "harness";
-import { closeSync, constants, openSync, unlinkSync } from "node:fs";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { closeSync, constants, openSync } from "node:fs";
 import { join } from "node:path";
 
 // Reading a Blob wrapping a write-only pollable fd (like the write end of a
@@ -8,8 +8,8 @@ import { join } from "node:path";
 // get "not ready", and then register for EPOLLIN/EVFILT_READ on the write end,
 // which never fires. Now it rejects with EBADF instead of waiting.
 test.skipIf(isWindows)("Bun.file(fd).text() rejects on a write-only FIFO instead of hanging", async () => {
-  const dir = tmpdirSync();
-  const fifo = join(dir, "fifo");
+  using dir = tempDir("bun-stdout-read-wronly", {});
+  const fifo = join(String(dir), "fifo");
   Bun.spawnSync({ cmd: ["mkfifo", fifo], env: bunEnv });
 
   // Open a non-blocking reader so opening the write side doesn't block.
@@ -27,7 +27,6 @@ test.skipIf(isWindows)("Bun.file(fd).text() rejects on a write-only FIFO instead
   } finally {
     closeSync(writer);
     closeSync(reader);
-    unlinkSync(fifo);
   }
 });
 

--- a/test/js/bun/util/bun-stdout-read-wronly.test.ts
+++ b/test/js/bun/util/bun-stdout-read-wronly.test.ts
@@ -34,25 +34,28 @@ test.skipIf(isWindows)("Bun.file(fd).text() rejects on a write-only FIFO instead
 // This is the fuzzer-reduced case: HTMLRewriter picks up Blob.prototype.text as
 // the document text handler and synchronously waits on the returned promise.
 // When stdout is a shell pipe (O_WRONLY FIFO) this used to wedge the process.
-test.skipIf(isWindows)("HTMLRewriter.onDocument(Bun.stdout).transform() does not hang when stdout is a pipe", async () => {
-  const script = `
+test.skipIf(isWindows)(
+  "HTMLRewriter.onDocument(Bun.stdout).transform() does not hang when stdout is a pipe",
+  async () => {
+    const script = `
     const r = new HTMLRewriter();
     r.onDocument(Bun.stdout);
     try { r.transform(new SharedArrayBuffer(16)); } catch {}
     console.error("done");
   `;
-  // Use a shell pipeline so the child's stdout is a real FIFO (write-only),
-  // matching how shells / fuzzilli set up stdio.
-  await using proc = Bun.spawn({
-    cmd: ["sh", "-c", `"$0" -e "$1" | cat > /dev/null`, bunExe(), script],
-    env: bunEnv,
-    stdin: "ignore",
-    stdout: "ignore",
-    stderr: "pipe",
-  });
+    // Use a shell pipeline so the child's stdout is a real FIFO (write-only),
+    // matching how shells / fuzzilli set up stdio.
+    await using proc = Bun.spawn({
+      cmd: ["sh", "-c", `"$0" -e "$1" | cat > /dev/null`, bunExe(), script],
+      env: bunEnv,
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "pipe",
+    });
 
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-  expect(stderr.trim()).toBe("done");
-  expect(exitCode).toBe(0);
-});
+    expect(stderr.trim()).toBe("done");
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
Fuzzer found a hang (fingerprint `signal:SIGUSR2`): `HTMLRewriter.onDocument(Bun.stdout).transform(...)` wedges the process when stdout is a shell pipe.

## Root cause

`Bun.stdout` is a file `Blob` wrapping fd 1. `HTMLRewriter.onDocument` looks up a `text` property on the handler object, finds `Blob.prototype.text`, and calls it during `transform`, then synchronously waits on the returned promise.

`Blob.text()` on an fd goes through `ReadFile`. For non-regular files (`could_block = true`) it polls for readability before the first read to avoid blocking. When the fd is the **write end** of a pipe (opened `O_WRONLY`), `poll(POLLIN)` reports not-ready forever, and the subsequent `epoll_ctl(EPOLLIN)` / `kevent(EVFILT_READ)` registration succeeds but never fires. The promise never settles and `waitForPromise` hangs the process.

## Fix

Before calling `waitForReadable()` on a pollable fd, check its access mode via `fcntl(F_GETFL)`. If it's `O_WRONLY`, reject with `EBADF` — the same error `read()` would have returned if we'd attempted it.

## Tests

- `Bun.file(writeOnlyFifoFd).text()` now rejects with EBADF instead of hanging
- `HTMLRewriter.onDocument(Bun.stdout).transform(...)` completes when stdout is a shell pipe

Both tests time out on main and pass with this change. `Bun.stdin.text()` on readable pipes continues to work.