### PR TITLE
install: break folder-dependency cycles in tree builder

### DIFF
--- a/src/install/lockfile/Tree.zig
+++ b/src/install/lockfile/Tree.zig
@@ -564,6 +564,29 @@ pub fn processSubtree(
             }
 
             if (pkg_resolutions[pkg_id].tag == .folder) {
+                // Folder dependencies are never hoisted. However, a folder dependency
+                // can resolve to a package that already appears in the current tree
+                // ancestry — for example, a `workspace:<path>` dependency inside a
+                // folder-installed package that resolves (via FolderResolution path
+                // reuse) back to that same folder package, or to another already-
+                // resolved folder package that transitively depends on this one.
+                // Placing and re-enqueueing it would loop forever, so detect the
+                // cycle by walking the parent trees and skip placement.
+                // https://github.com/oven-sh/bun/issues/25202
+                if (pkg_id == parent_pkg_id) {
+                    break :hoisted .dependency_loop;
+                }
+                var ancestor_id = this.id;
+                while (ancestor_id != invalid_id) : (ancestor_id = trees[ancestor_id].parent) {
+                    const ancestor_dep_id = trees[ancestor_id].dependency_id;
+                    const ancestor_pkg_id: PackageID = if (ancestor_dep_id == root_dep_id)
+                        0
+                    else
+                        builder.resolutions[ancestor_dep_id];
+                    if (ancestor_pkg_id == pkg_id) {
+                        break :hoisted .dependency_loop;
+                    }
+                }
                 break :hoisted .{ .placement = .{ .id = next.id } };
             }
 

--- a/src/install/lockfile/Tree.zig
+++ b/src/install/lockfile/Tree.zig
@@ -576,7 +576,10 @@ pub fn processSubtree(
                 if (pkg_id == parent_pkg_id) {
                     break :hoisted .dependency_loop;
                 }
-                var ancestor_id = this.id;
+                // `this` may be a dangling pointer after the `builder.list.append`
+                // above reallocated, so walk from `next.parent` (which was set to
+                // the original `this.id` and lives in the fresh `trees` slice).
+                var ancestor_id = next.parent;
                 while (ancestor_id != invalid_id) : (ancestor_id = trees[ancestor_id].parent) {
                     const ancestor_dep_id = trees[ancestor_id].dependency_id;
                     const ancestor_pkg_id: PackageID = if (ancestor_dep_id == root_dep_id)

--- a/test/regression/issue/25202.test.ts
+++ b/test/regression/issue/25202.test.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// https://github.com/oven-sh/bun/issues/25202
+// `bun i ../dir1` where dir1/package.json contains a `workspace:.` dependency
+// used to hang forever. The `workspace:.` dependency resolves (via
+// FolderResolution abs-path reuse) to the same package id as `../dir1`
+// itself, and the tree builder's `.folder` fast-path would re-enqueue it
+// without cycle detection.
+
+test("bun add of a folder whose package.json has a `workspace:.` self-reference does not hang", async () => {
+  using dir = tempDir("issue-25202-self", {
+    "dir1/package.json": JSON.stringify({
+      name: "test",
+      version: "1.0.0",
+      devDependencies: {
+        foo: "workspace:.",
+      },
+    }),
+    "dir2/.gitkeep": "",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install", "--linker=hoisted", "../dir1"],
+    env: bunEnv,
+    cwd: join(String(dir), "dir2"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("Saved lockfile");
+  expect(stdout).toContain("installed test@");
+  expect(exitCode).toBe(0);
+
+  const lock = await Bun.file(join(String(dir), "dir2", "bun.lock")).text();
+  expect(lock).toContain('"test": ["test@file:../dir1"');
+});
+
+test("bun install with two folder deps whose `workspace:` deps form a cycle does not hang", async () => {
+  using dir = tempDir("issue-25202-cycle", {
+    "pkg/package.json": JSON.stringify({
+      name: "pkg",
+      version: "1.0.0",
+      dependencies: {
+        other: "workspace:../pkg2",
+      },
+    }),
+    "pkg2/package.json": JSON.stringify({
+      name: "pkg2",
+      version: "1.0.0",
+      dependencies: {
+        back: "workspace:../pkg",
+      },
+    }),
+    "app/package.json": JSON.stringify({
+      name: "app",
+      dependencies: {
+        a: "file:../pkg",
+        b: "file:../pkg2",
+      },
+    }),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install", "--linker=hoisted"],
+    env: bunEnv,
+    cwd: join(String(dir), "app"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("Saved lockfile");
+  expect(stdout).toContain("+ a@");
+  expect(stdout).toContain("+ b@");
+  expect(exitCode).toBe(0);
+});
+
+test("bun add of a folder with `workspace:.` self-reference (isolated linker) does not hang", async () => {
+  using dir = tempDir("issue-25202-isolated", {
+    "dir1/package.json": JSON.stringify({
+      name: "test",
+      version: "1.0.0",
+      devDependencies: {
+        foo: "workspace:.",
+      },
+    }),
+    "dir2/.gitkeep": "",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install", "--linker=isolated", "../dir1"],
+    env: bunEnv,
+    cwd: join(String(dir), "dir2"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("Saved lockfile");
+  expect(stdout).toContain("installed test@");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/25202.test.ts
+++ b/test/regression/issue/25202.test.ts
@@ -106,3 +106,36 @@ test("bun add of a folder with `workspace:.` self-reference (isolated linker) do
   expect(stdout).toContain("installed test@");
   expect(exitCode).toBe(0);
 });
+
+// https://github.com/oven-sh/bun/issues/24735
+// A package that depends on itself via `"./"` installs fine the first time
+// (the transitive folder dep gets a fresh package id with no deps), but on
+// the second install the lockfile is loaded with both entries resolving to
+// the same package path and `resolve()` would loop forever rebuilding the
+// tree.
+test("installing a self-referential folder dependency twice does not hang", async () => {
+  using dir = tempDir("issue-24735", {
+    "package/package.json": JSON.stringify({
+      name: "package",
+      dependencies: {
+        package: "./",
+      },
+    }),
+  });
+
+  for (let i = 0; i < 2; i++) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--linker=hoisted", "./package"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("Saved lockfile");
+    expect(stdout).toContain("installed package@");
+    expect(exitCode).toBe(0);
+  }
+});


### PR DESCRIPTION
Fixes #25202.
Fixes #24735.

## Repro

```sh
mkdir -p /tmp/r/{dir1,dir2}
cat > /tmp/r/dir1/package.json <<'EOF'
{ "name": "test", "version": "1.0.0", "devDependencies": { "foo": "workspace:." } }
EOF
cd /tmp/r/dir2 && bun i ../dir1
# never exits, 100% CPU, memory grows unbounded
```

Two more variants that also hang:
- Two folder deps `a: file:../pkg` + `b: file:../pkg2` where `pkg` has `other: workspace:../pkg2` and `pkg2` has `back: workspace:../pkg`.
- #24735: a package with `"package": "./"` — the **second** `bun install ./package` hangs after loading the lockfile.

## Cause

`bun i ../dir1` resolves `test` as a `.folder` package and caches it in `manager.folders` keyed by the **absolute path hash** of `../dir1`.

`test`'s `foo: workspace:.` dep is then parsed relative to `dir1`, yielding the same absolute path. `FolderResolution.getOrPut` finds the existing entry and returns **the same package id** — so `foo` resolves to `test` itself (a `.folder` package with one dependency: `foo`).

During tree building in `Tree.processSubtree` (`src/install/lockfile/Tree.zig`), the `.folder` fast-path at

```zig
if (pkg_resolutions[pkg_id].tag == .folder) {
    break :hoisted .{ .placement = .{ .id = next.id } };
}
```

bypasses `hoistDependency()` entirely (which is where dedup/cycle detection happens for everything else). The dep is unconditionally placed in the new tree and, because `resolution_lists[pkg_id].len > 0`, re-enqueued for processing — which creates another tree, places `foo` (still pkg 1, still `.folder`), re-enqueues, forever. Each iteration appends a 44-byte `Tree.Builder.Entry` to the tree list.

The #24735 variant hits the same loop via `lockfile.resolve()` when loading a saved `bun.lock` whose entries map back to the same `.folder` package.

## Fix

Before placing a `.folder` dependency, walk the parent trees: if the dependency's package id already appears in the ancestry (including the current subtree's own package), treat it as a `.dependency_loop` and skip. Module resolution will find the package in the ancestor's `node_modules`.

This handles both the direct self-reference (`pkg_id == parent_pkg_id`) and indirect cycles across multiple folder packages.

## Verification

```
$ bun bd test test/regression/issue/25202.test.ts
(pass) bun add of a folder whose package.json has a `workspace:.` self-reference does not hang
(pass) bun install with two folder deps whose `workspace:` deps form a cycle does not hang
(pass) bun add of a folder with `workspace:.` self-reference (isolated linker) does not hang
(pass) installing a self-referential folder dependency twice does not hang
```

All 4 tests time out on 1.3.13.
