### PR TITLE
docs(server): fix line-wrapped code span in HTTP/3 note

### DIFF
--- a/docs/runtime/http/server.mdx
+++ b/docs/runtime/http/server.mdx
@@ -207,8 +207,7 @@ Bun.serve({
 ```
 
 <Note>
-  `http3` is not supported with unix domain sockets — QUIC requires a UDP port. `http1: false` always requires `http3:
-  true`.
+  `http3` is not supported with unix domain sockets — QUIC requires a UDP port. `http1: false` requires `http3: true`.
 </Note>
 
 ---


### PR DESCRIPTION
Follow-up to #30583.

Prettier wrapped the inline `` `http3: true` `` span across two lines inside the `<Note>`, so per CommonMark code-span rules the newline + 2-space indent become literal spaces and it renders as `http3:   true`.

Dropped the redundant "always" so the line fits under `printWidth: 120` and stays prettier-stable.

Docs-only, no build needed.