### PR TITLE
Bun.Image: apply EXIF orientation to HEIC/TIFF/AVIF (macOS + Windows)

### DIFF
--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -241,6 +241,14 @@ export const linearFifoOrderedRemoveProbe = $newZigFunction(
   1,
 ) as (scenario: number) => number[];
 export const hasNonReifiedStatic = $newCppFunction("InternalForTesting.cpp", "jsFunction_hasReifiedStatic", 1);
+// exif::read(bytes, format) — format is the codecs::Format discriminant
+// (0=jpeg, 1=png, 2=webp, 3=heic, 4=avif, 5=bmp, 6=tiff, 7=gif); returns the
+// EXIF orientation value (1..8). Lets the format-dispatch + JPEG APP1 walk be
+// unit-tested on every platform (HEIC/TIFF/AVIF only decode on macOS/Windows).
+export const imageReadOrientation = $newZigFunction("runtime/image/exif.zig", "testing.readOrientation", 2) as (
+  bytes: Uint8Array,
+  format: number,
+) => number;
 
 interface setSocketOptionsFn {
   (socket: Bun.Socket, sendBuffer: 1, size: number): void;

--- a/src/jsc/bindings/image_coregraphics_shim.cpp
+++ b/src/jsc/bindings/image_coregraphics_shim.cpp
@@ -72,7 +72,9 @@ struct Syms {
     const uint8_t* (*CFDataGetBytePtr)(CFRef);
     CFRef (*CFStringCreateWithCString)(CFRef, const char*, uint32_t);
     CFRef (*CFNumberCreate)(CFRef, int, const void*);
+    bool (*CFNumberGetValue)(CFRef, int, void*);
     CFRef (*CFDictionaryCreate)(CFRef, const void**, const void**, long, const void*, const void*);
+    const void* (*CFDictionaryGetValue)(CFRef, const void*);
     // CoreGraphics
     CFRef (*CGColorSpaceCreateDeviceRGB)();
     void (*CGColorSpaceRelease)(CFRef);
@@ -85,6 +87,7 @@ struct Syms {
     // ImageIO
     CFRef (*CGImageSourceCreateWithData)(CFRef, CFRef);
     CFRef (*CGImageSourceCreateImageAtIndex)(CFRef, size_t, CFRef);
+    CFRef (*CGImageSourceCopyPropertiesAtIndex)(CFRef, size_t, CFRef);
     CFRef (*CGImageDestinationCreateWithData)(CFRef, CFRef, size_t, CFRef);
     void (*CGImageDestinationAddImage)(CFRef, CFRef, CFRef);
     bool (*CGImageDestinationFinalize)(CFRef);
@@ -98,6 +101,7 @@ struct Syms {
     // address and dereference at use-site).
     CFRef* kCFAllocatorNull;
     CFRef* kCGImageDestinationLossyCompressionQuality;
+    CFRef* kCGImagePropertyOrientation;
     const void* kCFTypeDictionaryKeyCallBacks;
     const void* kCFTypeDictionaryValueCallBacks;
 };
@@ -119,7 +123,9 @@ constexpr struct {
     SYM(CFDataGetBytePtr),
     SYM(CFStringCreateWithCString),
     SYM(CFNumberCreate),
+    SYM(CFNumberGetValue),
     SYM(CFDictionaryCreate),
+    SYM(CFDictionaryGetValue),
     SYM(CGColorSpaceCreateDeviceRGB),
     SYM(CGColorSpaceRelease),
     SYM(CGImageCreate),
@@ -130,6 +136,7 @@ constexpr struct {
     SYM(CGDataProviderRelease),
     SYM(CGImageSourceCreateWithData),
     SYM(CGImageSourceCreateImageAtIndex),
+    SYM(CGImageSourceCopyPropertiesAtIndex),
     SYM(CGImageDestinationCreateWithData),
     SYM(CGImageDestinationAddImage),
     SYM(CGImageDestinationFinalize),
@@ -140,6 +147,7 @@ constexpr struct {
     SYM(vImageVerticalReflect_ARGB8888),
     SYM(kCFAllocatorNull),
     SYM(kCGImageDestinationLossyCompressionQuality),
+    SYM(kCGImagePropertyOrientation),
     SYM(kCFTypeDictionaryKeyCallBacks),
     SYM(kCFTypeDictionaryValueCallBacks),
 };
@@ -180,6 +188,9 @@ const Syms* load()
 constexpr uint32_t kBunCGImageAlphaLast = 3; // straight RGBA, A in byte 3
 constexpr uint32_t kBunCFStringEncodingUTF8 = 0x08000100;
 constexpr int kBunCFNumberDoubleType = 13;
+// CFNumberGetValue type for SInt32 — orientation is stored as a small int in
+// the image-source properties dict.
+constexpr int kBunCFNumberSInt32Type = 3;
 // vImage_Flags — values copied verbatim from <Accelerate/vImage_Types.h>;
 // keep them in sync, the kvImageNoAllocate one used to be wrong (4 vs 512)
 // and silently turned every CG decode into 0xAA garbage in debug builds.
@@ -209,6 +220,31 @@ template<class R, class... A>
 inline R msg(const Syms* s, CFRef recv, CFRef sel, A... a)
 {
     return reinterpret_cast<R (*)(CFRef, CFRef, A...)>(s->objc_msgSend)(recv, sel, a...);
+}
+
+// EXIF orientation (TIFF tag 0x0112) for the first image in `src`. Values
+// 1..8 per EXIF spec; 1 (no-op) is returned for missing/invalid/out-of-range,
+// matching Sharp/libvips's "advisory, never fail decode" treatment.
+//
+// ImageIO parses this out of the container (EXIF TIFF IFD0 for
+// JPEG/TIFF/WebP; HEIC `irot`/`imir` transform properties mapped to EXIF
+// orientation) and exposes it via the properties dict. Apple documents that
+// CGImageSourceCreateImageAtIndex itself does NOT apply the orientation to
+// the returned pixels — the caller is expected to either draw through a
+// transform or rotate the decoded buffer, which is what we do below.
+inline int readOrientation(const Syms* s, CFRef src)
+{
+    CFRef props = s->CGImageSourceCopyPropertiesAtIndex(src, 0, nullptr);
+    if (!props) return 1;
+    int o = 1;
+    CFRef v = const_cast<void*>(s->CFDictionaryGetValue(props, *s->kCGImagePropertyOrientation));
+    if (v) {
+        int32_t raw = 0;
+        if (s->CFNumberGetValue(v, kBunCFNumberSInt32Type, &raw) && raw >= 1 && raw <= 8)
+            o = raw;
+    }
+    s->CFRelease(props);
+    return o;
 }
 
 // Image UTIs in preference order. PNG first (lossless, compact); then formats
@@ -245,6 +281,23 @@ inline CFRef generalPasteboard(const Syms* s)
         if (!cls) return nullptr;
     }
     return msg<CFRef>(s, cls, s->sel_registerName("generalPasteboard"));
+}
+
+// Two-phase result hand-off shared by encode/clipboard: each call site keeps
+// its own thread-local `pending` CFData. If `out` is set, copy the stashed
+// bytes there and signal the caller to return CG_OK; otherwise just drop a
+// stale pending result so a fresh probe starts clean.
+inline bool drainPending(const Syms* s, CFRef& pending, uint8_t* out, size_t* out_len)
+{
+    if (!pending) return false;
+    if (out) {
+        long n = s->CFDataGetLength(pending);
+        std::memcpy(out, s->CFDataGetBytePtr(pending), static_cast<size_t>(n));
+        *out_len = static_cast<size_t>(n);
+    }
+    s->CFRelease(pending);
+    pending = nullptr;
+    return out != nullptr;
 }
 
 } // namespace
@@ -309,6 +362,13 @@ int32_t bun_coregraphics_decode(const uint8_t* bytes, size_t len, uint64_t max_p
     // non-premultiplied alpha, which CGBitmapContext refuses — so the result
     // is straight RGBA with no premul→unpremul quantisation. kvImageNoAllocate
     // makes it write into the caller's bun.default_allocator buffer.
+    //
+    // Pixels come back in their *stored* orientation — EXIF/TIFF orientation
+    // tags (common on iPhone HEIC with Orientation=6) are NOT applied here.
+    // Callers that want Sharp's "auto-orient" behaviour call
+    // bun_coregraphics_orientation() and apply the transform with the
+    // existing flip/rotate vImage kernels, matching the JPEG codepath that
+    // reads the tag Rust-side and rotates post-decode. (#30235)
     VBuf buf { out, h, w, w * 4 };
     VFmt fmt { 8, 32, r.cs, kBunCGImageAlphaLast, 0, nullptr, 0 };
     auto rc = s->vImageBuffer_InitWithCGImage(&buf, &fmt, nullptr, r.img, kBunVImageNoAllocate);
@@ -318,6 +378,29 @@ int32_t bun_coregraphics_decode(const uint8_t* bytes, size_t len, uint64_t max_p
     // 0xAA — that's the garbage we shipped before the constant was fixed.
     if (rc != 0 || buf.data != out) return CG_DECODE_FAILED;
     return CG_OK;
+}
+
+// Read EXIF/TIFF orientation tag (IFD0 0x0112) from the first image in the
+// container. Returns 1..8 per EXIF spec; 1 (identity) for missing/invalid/
+// loader-failure, matching Sharp/libvips's "advisory, never fail" policy.
+//
+// Kept separate from decode so the Rust side owns the "apply or skip" decision
+// — `new Bun.Image(..., { autoOrient: false })` still wants raw stored pixels,
+// and the existing JPEG codepath already reads the tag Rust-side and rotates
+// post-decode via `apply_orientation`. One small ImageIO query here keeps
+// HEIC/TIFF/AVIF on the same auto-orient gate.
+int32_t bun_coregraphics_orientation(const uint8_t* bytes, size_t len)
+{
+    auto s = load();
+    if (!s) return 1;
+    Pool pool(s);
+    CFRef data = s->CFDataCreateWithBytesNoCopy(nullptr, bytes, static_cast<long>(len), *s->kCFAllocatorNull);
+    if (!data) return 1;
+    CFRef src = s->CGImageSourceCreateWithData(data, nullptr);
+    int o = src ? readOrientation(s, src) : 1;
+    if (src) s->CFRelease(src);
+    s->CFRelease(data);
+    return o;
 }
 
 // Encode RGBA8 → format. format: 0=jpeg, 1=png, 2=webp, 3=heic, 4=avif.
@@ -336,18 +419,7 @@ int32_t bun_coregraphics_encode(const uint8_t* rgba, uint32_t width, uint32_t he
     // encode. Safe: each WorkPool thread runs at most one PipelineTask at a
     // time, and the two calls are back-to-back in codecs.zig.
     thread_local CFRef pending = nullptr;
-    if (out && pending) {
-        long n = s->CFDataGetLength(pending);
-        std::memcpy(out, s->CFDataGetBytePtr(pending), static_cast<size_t>(n));
-        *out_len = static_cast<size_t>(n);
-        s->CFRelease(pending);
-        pending = nullptr;
-        return CG_OK;
-    }
-    if (pending) {
-        s->CFRelease(pending);
-        pending = nullptr;
-    }
+    if (drainPending(s, pending, out, out_len)) return CG_OK;
 
     static const char* kUti[] = {
         "public.jpeg", "public.png", "org.webmproject.webp",
@@ -502,19 +574,7 @@ int32_t bun_coregraphics_clipboard(uint8_t* out, size_t* out_len, int32_t probe_
     if (!s) return CG_UNAVAILABLE;
     Pool pool(s);
     thread_local CFRef pending = nullptr;
-
-    if (out && pending) {
-        long n = s->CFDataGetLength(pending);
-        std::memcpy(out, s->CFDataGetBytePtr(pending), static_cast<size_t>(n));
-        *out_len = static_cast<size_t>(n);
-        s->CFRelease(pending);
-        pending = nullptr;
-        return CG_OK;
-    }
-    if (pending) {
-        s->CFRelease(pending);
-        pending = nullptr;
-    }
+    if (drainPending(s, pending, out, out_len)) return CG_OK;
 
     CFRef pb = generalPasteboard(s);
     if (!pb) return CG_UNAVAILABLE;
@@ -559,6 +619,7 @@ int64_t bun_coregraphics_clipboard_change_count()
 // Environment.isMac so they're dead code, but LTO needs the definitions.
 extern "C" int bun_coregraphics_decode(const void*, unsigned long, unsigned long long, void*, void*, void*) { return 1; }
 extern "C" int bun_coregraphics_encode(const void*, unsigned, unsigned, int, int, void*, void*) { return 1; }
+extern "C" int bun_coregraphics_orientation(const void*, unsigned long) { return 1; }
 extern "C" int bun_coregraphics_scale(const void*, unsigned, unsigned, void*, unsigned, unsigned) { return 1; }
 extern "C" int bun_coregraphics_rotate90(const void*, unsigned, unsigned, void*, unsigned) { return 1; }
 extern "C" int bun_coregraphics_reflect(const void*, unsigned, unsigned, void*, int) { return 1; }

--- a/src/jsc/bindings/image_wic_shim.cpp
+++ b/src/jsc/bindings/image_wic_shim.cpp
@@ -1,19 +1,21 @@
-// Thin C wrapper around the one WIC interaction whose ABI is too fiddly to
-// hand-roll from Zig: IPropertyBag2::Write with a VARIANT. The rest of the
-// WIC backend (vtable-shaped COM calls) lives in src/image/backend_wic.zig
-// because those are plain function-pointer tables and have been stable; this
-// file exists so the SDK's own <oaidl.h> definition of VARIANT (with its
-// union/BRECORD/DECIMAL padding) is the source of truth instead of an extern
-// struct guess.
+// Thin C wrapper around the WIC interactions whose ABI is too fiddly to
+// hand-roll from Rust: IPropertyBag2::Write with a VARIANT, and
+// IWICMetadataQueryReader::GetMetadataByName with a PROPVARIANT. The rest of
+// the WIC backend (vtable-shaped COM calls) lives in
+// src/runtime/image/backend_wic.rs because those are plain function-pointer
+// tables and have been stable; this file exists so the SDK's own <oaidl.h>/
+// <propidl.h> definitions of VARIANT/PROPVARIANT (with their union/BRECORD/
+// DECIMAL padding) are the source of truth instead of an extern-struct guess.
 //
-// Kept header-light: only the option name + a float go in, so if we later
+// Kept header-light: only the option name + a scalar go in, so if we later
 // need more knobs (CompressionQuality, HeifCompressionMethod) they're one
-// branch each rather than a Zig-side VARIANT for every type.
+// branch each rather than a Rust-side VARIANT for every type.
 
 #if defined(_WIN32)
 
 #include <windows.h>
 #include <ocidl.h> // IPropertyBag2, PROPBAG2
+#include <wincodec.h> // IWICBitmapFrameDecode, IWICMetadataQueryReader
 #include <cstdint> // int32_t/uint8_t — not guaranteed by the SDK headers above
 
 static int32_t write1(void* props, const wchar_t* name, VARTYPE vt, void (*set)(VARIANT&))
@@ -54,9 +56,53 @@ extern "C" int32_t bun_wic_propbag_write_u8(void* props, const wchar_t* name, ui
     return write1(props, name, VT_UI1, [](VARIANT& var) { var.bVal = v; });
 }
 
+// EXIF/TIFF Orientation (tag 0x0112) for the frame. Returns 1..8 per the EXIF
+// spec; 1 (identity) for missing/out-of-range/any-failure to match Sharp's
+// "advisory, never fail decode" treatment. PROPVARIANT lives here for the same
+// reason VARIANT does — the SDK's own union layout is the source of truth.
+//
+// WIC's frame-level metadata-query reader is rooted at the *container*
+// format with per-format child blocks beneath, so the orientation path
+// differs by container (MSDN "Native Image Format Metadata Queries"):
+//  - /ifd/{ushort=274}         TIFF — IFD0 is mounted at /ifd (NOT at root;
+//                              `/{ushort=N}` is rejected at top level)
+//  - /heifProps/Orientation    HEIF — irot/imir → WICHeifOrientation, VT_UI2,
+//                              same 1..8 numbering as EXIF (Win10 1809+)
+//  - System.Photo.Orientation  policy expression fallback (JPEG/TIFF only —
+//                              HEIF is NOT in the policy mapping)
+// First path that yields a valid 1..8 wins; a SUCCEEDED-but-wrong-vt read
+// falls through to the next path rather than short-circuiting to identity.
+// (#30235)
+extern "C" int32_t bun_wic_read_orientation(void* frame)
+{
+    if (!frame) return 1;
+    IWICMetadataQueryReader* reader = nullptr;
+    if (FAILED(static_cast<IWICBitmapFrameDecode*>(frame)->GetMetadataQueryReader(&reader)) || !reader)
+        return 1;
+    int32_t result = 1;
+    static const wchar_t* const paths[] = {
+        L"/ifd/{ushort=274}",
+        L"/heifProps/Orientation",
+        L"System.Photo.Orientation",
+    };
+    for (auto path : paths) {
+        PROPVARIANT pv;
+        PropVariantInit(&pv);
+        if (SUCCEEDED(reader->GetMetadataByName(path, &pv)) && pv.vt == VT_UI2 && pv.uiVal >= 1 && pv.uiVal <= 8) {
+            result = pv.uiVal;
+            PropVariantClear(&pv);
+            break;
+        }
+        PropVariantClear(&pv);
+    }
+    reader->Release();
+    return result;
+}
+
 #else
-// Stubs so the symbols exist everywhere; backend_wic.zig is Windows-only so
+// Stubs so the symbols exist everywhere; backend_wic.rs is Windows-only so
 // these are never called, but the linker wants them.
 extern "C" int bun_wic_propbag_write_f32(void*, const void*, float) { return 0; }
 extern "C" int bun_wic_propbag_write_u8(void*, const void*, unsigned char) { return 0; }
+extern "C" int bun_wic_read_orientation(void*) { return 1; }
 #endif

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -912,8 +912,8 @@ impl Image {
                 Ok(p) => {
                     let mut w = p.width;
                     let mut h = p.height;
-                    if self.auto_orient && p.format == codecs::Format::Jpeg {
-                        let t = exif::read_jpeg(buf).transform();
+                    if self.auto_orient {
+                        let t = exif::read(buf, p.format).transform();
                         if t.rotate == 90 || t.rotate == 270 {
                             mem::swap(&mut w, &mut h);
                         }
@@ -1555,6 +1555,23 @@ impl<'a> PipelineTask<'a> {
             self.input.slice()
         };
 
+        // Sniff format and read EXIF orientation once up front. JPEG is a
+        // cheap byte walk; HEIC/TIFF/AVIF go through the system backend
+        // (ImageIO / WIC), which builds a fresh image-source per call — so
+        // resolving it once and reusing it across the metadata fast path, the
+        // decode-hint, and the apply-orientation gate below keeps the resize
+        // path (the #30235 repro) at one backend round-trip instead of three.
+        let src_format = codecs::Format::sniff(input).unwrap_or(codecs::Format::Png);
+        let orient = if self.auto_orient {
+            exif::read(input, src_format)
+        } else {
+            exif::Orientation::Normal
+        };
+        let orient_swaps_axes = {
+            let r = orient.transform().rotate;
+            r == 90 || r == 270
+        };
+
         // Header-only fast path for `.metadata()` — Sharp parses just the
         // IHDR/SOF/VP8 header; we used to decode the full RGBA buffer first
         // (~70× slower on a 1920×1080 PNG). EXIF orientation only swaps the
@@ -1564,11 +1581,8 @@ impl<'a> PipelineTask<'a> {
                 Ok(p) => {
                     let mut w = p.width;
                     let mut h = p.height;
-                    if self.auto_orient && p.format == codecs::Format::Jpeg {
-                        let t = exif::read_jpeg(input).transform();
-                        if t.rotate == 90 || t.rotate == 270 {
-                            mem::swap(&mut w, &mut h);
-                        }
+                    if orient_swaps_axes {
+                        mem::swap(&mut w, &mut h);
                     }
                     self.result = TaskResult::Meta {
                         w,
@@ -1598,11 +1612,7 @@ impl<'a> PipelineTask<'a> {
             // r.h==0 means "preserve aspect" — constrain on width only.
             let mut th = if r.h != 0 { r.h } else { r.w };
             let swap_explicit = self.pipeline.rotate == 90 || self.pipeline.rotate == 270;
-            let swap_exif = self.auto_orient && {
-                let t = exif::read_jpeg(input).transform();
-                t.rotate == 90 || t.rotate == 270
-            };
-            if swap_explicit != swap_exif {
+            if swap_explicit != orient_swaps_axes {
                 mem::swap(&mut tw, &mut th);
             }
             codecs::DecodeHint {
@@ -1622,28 +1632,37 @@ impl<'a> PipelineTask<'a> {
         };
         // `defer decoded.deinit()` — `codecs::Decoded` Drop frees rgba/icc.
 
-        let src_format = codecs::Format::sniff(input).unwrap_or(codecs::Format::Png);
-
-        // EXIF auto-orient: applied BEFORE any user op so resize targets and
-        // metadata report the visually-upright dimensions, the way Sharp does.
-        if self.auto_orient && src_format == codecs::Format::Jpeg {
-            let orient = exif::read_jpeg(input);
-            if orient != exif::Orientation::Normal {
-                if let Err(e) = apply_orientation(&mut decoded, orient) {
-                    self.result = TaskResult::Err(e);
-                    return;
-                }
-            }
-        }
-
+        // `.metadata()` on HEIC/AVIF/TIFF reaches here because `probe()` has no
+        // header parser for them and fell through to a full decode. We only
+        // need w/h/format — swap dimensions numerically from the orientation
+        // tag (same as the probe-success branch above) instead of physically
+        // rotating the just-decoded RGBA buffer Drop is about to free. That
+        // keeps `.metadata()` off a ~w*h*4 scratch allocation and a vImage
+        // rotate pass per call on iPhone-HEIC inputs.
         if matches!(self.kind, Kind::Metadata) {
-            // Reached only for HEIC/AVIF (probe fell through).
+            let mut w = decoded.width;
+            let mut h = decoded.height;
+            if orient_swaps_axes {
+                mem::swap(&mut w, &mut h);
+            }
             self.result = TaskResult::Meta {
-                w: decoded.width,
-                h: decoded.height,
+                w,
+                h,
                 format: src_format,
             };
             return;
+        }
+
+        // EXIF auto-orient: applied BEFORE any user op so resize targets and
+        // metadata report the visually-upright dimensions, the way Sharp does.
+        // Covers JPEG via the APP1/Exif walker and HEIC/TIFF/AVIF via the
+        // system backend (ImageIO on macOS, WIC on Windows), whose decoders
+        // hand back pixels in their *stored* orientation. (#30235)
+        if orient != exif::Orientation::Normal {
+            if let Err(e) = apply_orientation(&mut decoded, orient) {
+                self.result = TaskResult::Err(e);
+                return;
+            }
         }
 
         if matches!(self.kind, Kind::Placeholder) {

--- a/src/runtime/image/backend_coregraphics.rs
+++ b/src/runtime/image/backend_coregraphics.rs
@@ -86,6 +86,13 @@ unsafe extern "C" {
         out: *mut u8, // nullable
         out_len: *mut usize,
     ) -> i32;
+
+    // Read the first-image EXIF/TIFF orientation tag (1..8). ImageIO parses the
+    // JPEG APP1/Exif IFD, the TIFF IFD0, and HEIC `irot`/`imir` transform
+    // properties — all mapped to the same 1..8 enum — so one ImageIO call
+    // covers every system-backend format. Returns 1 (identity) on any failure.
+    #[allow(dead_code)] // referenced only on macOS (see `orientation` below)
+    fn bun_coregraphics_orientation(bytes: *const u8, len: usize) -> i32;
 }
 
 const CG_OK: i32 = 0;
@@ -148,6 +155,19 @@ pub fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, BackendE
         height: h,
         icc_profile: None,
     })
+}
+
+/// EXIF orientation (1..8) of the first image in `bytes`; 1 (identity) on any
+/// failure, to match Sharp's "advisory, never error the decode" treatment.
+/// See `exif::read` for why HEIC/TIFF/AVIF route through the system backend
+/// instead of the JPEG-marker walker in `exif.rs`. (#30235)
+// `codecs::orientation_via_system` only references this under
+// `#[cfg(any(target_os = "macos", windows))]`, so it's dead on a Linux build.
+#[allow(dead_code)]
+pub(crate) fn orientation(bytes: &[u8]) -> u8 {
+    // SAFETY: bytes is a valid slice; the shim only reads from it.
+    let raw = unsafe { bun_coregraphics_orientation(bytes.as_ptr(), bytes.len()) };
+    if (1..=8).contains(&raw) { raw as u8 } else { 1 }
 }
 
 #[allow(dead_code)]

--- a/src/runtime/image/backend_wic.rs
+++ b/src/runtime/image/backend_wic.rs
@@ -170,6 +170,51 @@ pub fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, BackendE
     })
 }
 
+/// EXIF orientation (1..8) of the first frame; 1 (identity) on any failure, to
+/// match Sharp's "advisory, never error the decode" treatment. Called via
+/// `exif::read` for HEIC/TIFF/AVIF: TIFF carries it in IFD0 tag 274; HEIF
+/// carries it as `irot`/`imir` boxes which WIC surfaces under `/heifProps`
+/// (NOT via the embedded Exif item — that can mismatch the irot value). See
+/// the shim for the query-path fallback. (#30235)
+pub(crate) fn orientation(bytes: &[u8]) -> u8 {
+    let Ok(f) = factory() else { return 1 };
+    if bytes.len() as u64 > u32::MAX as u64 {
+        return 1;
+    }
+
+    let Some(stream) = f.create_stream() else {
+        return 1;
+    };
+    scopeguard::defer! { release(stream.as_ptr()); }
+    if stream.initialize_from_memory(
+        bytes.as_ptr(),
+        u32::try_from(bytes.len()).expect("int cast"),
+    ) < 0
+    {
+        return 1;
+    }
+
+    // WICDecodeMetadataCacheOnDemand = 0 — match decode()'s value so the two
+    // CreateDecoderFromStream calls behave identically on the same bytes; the
+    // query reader populates lazily either way.
+    let Some(dec) = f.create_decoder_from_stream(stream.cast::<IUnknown>().as_ptr(), 0) else {
+        return 1;
+    };
+    scopeguard::defer! { release(dec.as_ptr()); }
+
+    let Some(frame) = dec.get_frame(0) else {
+        return 1;
+    };
+    scopeguard::defer! { release(frame.as_ptr()); }
+
+    // GetFrame returns IWICBitmapFrameDecode*; we type it as the
+    // IWICBitmapSource prefix elsewhere, but the shim casts it back to reach
+    // GetMetadataQueryReader (the slot after the IWICBitmapSource block).
+    // SAFETY: `frame` is a live COM pointer for the duration of this call.
+    let raw = unsafe { bun_wic_read_orientation(frame.as_ptr().cast::<c_void>()) };
+    if (1..=8).contains(&raw) { raw as u8 } else { 1 }
+}
+
 pub(crate) fn encode(
     rgba: &[u8],
     width: u32,
@@ -377,6 +422,12 @@ struct IUnknown {
 unsafe extern "C" {
     fn bun_wic_propbag_write_f32(props: *mut c_void, name: *const u16, value: f32) -> i32;
     fn bun_wic_propbag_write_u8(props: *mut c_void, name: *const u16, value: u8) -> i32;
+    // Orientation (1..8, EXIF numbering) for the first frame; 1 (identity) on
+    // any failure. The PROPVARIANT marshalling lives in the C++ shim for the
+    // same reason the IPropertyBag2 writes do — see image_wic_shim.cpp. The
+    // `frame` really is an `IWICBitmapFrameDecode*` (what `GetFrame` hands
+    // back); the shim casts it back to reach `GetMetadataQueryReader`.
+    fn bun_wic_read_orientation(frame: *mut c_void) -> i32;
 }
 
 /// WICHeifCompressionOption — the encoder defaults to `DontCare` (= picks

--- a/src/runtime/image/codecs.rs
+++ b/src/runtime/image/codecs.rs
@@ -326,6 +326,23 @@ fn decode_via_system(_bytes: &[u8], _max_pixels: u64) -> Result<Option<Decoded>,
     Ok(None)
 }
 
+/// EXIF orientation (1..8) read by the active system backend (ImageIO on
+/// macOS, WIC on Windows). `None` when there is no system backend, when the
+/// `bun` backend is selected, or on any reader failure — the caller then
+/// falls back to identity, matching JPEG's "no Exif segment" behaviour.
+///
+/// HEIC/TIFF/AVIF store orientation inside containers with nothing in common
+/// with JPEG markers (HEIF's `irot`/`imir` live behind an ISOBMFF box walk),
+/// so `exif::read_jpeg` can't reach it — we delegate to the backend that has
+/// already parsed the container. See `exif::read`. (#30235)
+pub(crate) fn orientation_via_system(_bytes: &[u8]) -> Option<u8> {
+    #[cfg(any(target_os = "macos", windows))]
+    if use_system() {
+        return Some(system_backend::orientation(_bytes));
+    }
+    None
+}
+
 #[inline]
 pub(crate) fn guard(w: u32, h: u32, max_pixels: u64) -> Result<(), Error> {
     // u64 mul cannot overflow from two u32 factors.

--- a/src/runtime/image/exif.rs
+++ b/src/runtime/image/exif.rs
@@ -21,6 +21,8 @@
 //! `None`/`.Normal` rather than an error. EXIF is advisory; we never fail
 //! decode over it.
 
+use super::codecs;
+
 #[repr(u8)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum Orientation {
@@ -134,6 +136,50 @@ pub fn read_jpeg(bytes: &[u8]) -> Orientation {
     Orientation::Normal
 }
 
+/// EXIF orientation for whatever container `bytes` is. The Zig-style walker in
+/// `read_jpeg` covers JPEG (APP1/Exif) and runs everywhere, including Linux
+/// where no system image backend exists. HEIC, TIFF, and AVIF store
+/// orientation inside containers with nothing in common with JPEG markers —
+/// HEIF's `irot`/`imir` transform properties live behind an ISOBMFF box walk,
+/// and HEIC's Exif item is reached via `iloc`/`iinf` — so we delegate to the
+/// system backend (ImageIO/WIC), which has already parsed all of them.
+/// Backends without a reader (or the `bun` backend) return `Normal`, matching
+/// JPEG's "no Exif segment" fallthrough.
+///
+/// PNG eXIf / WebP EXIF chunks exist but are rare (no major consumer writes
+/// them by default), so those stay at identity, mirroring `read_jpeg`'s
+/// JPEG-only scope. (#30235)
+pub fn read(bytes: &[u8], format: codecs::Format) -> Orientation {
+    match format {
+        codecs::Format::Jpeg => read_jpeg(bytes),
+        codecs::Format::Heic | codecs::Format::Avif | codecs::Format::Tiff => {
+            match codecs::orientation_via_system(bytes) {
+                Some(v) => from_u8(v),
+                None => Orientation::Normal,
+            }
+        }
+        codecs::Format::Png | codecs::Format::Webp | codecs::Format::Bmp | codecs::Format::Gif => {
+            Orientation::Normal
+        }
+    }
+}
+
+/// Map a raw EXIF value (1..8) to `Orientation`; anything else → `Normal`.
+#[inline]
+fn from_u8(v: u8) -> Orientation {
+    match v {
+        1 => Orientation::Normal,
+        2 => Orientation::Flop,
+        3 => Orientation::Rotate180,
+        4 => Orientation::Flip,
+        5 => Orientation::FlopRotate90,
+        6 => Orientation::Rotate90,
+        7 => Orientation::FlopRotate270,
+        8 => Orientation::Rotate270,
+        _ => Orientation::Normal,
+    }
+}
+
 fn parse_tiff(tiff: &[u8]) -> Option<Orientation> {
     if tiff.len() < 8 {
         return None;
@@ -204,6 +250,40 @@ fn rd32(b: &[u8], off: usize, big: bool) -> Option<u32> {
     } else {
         u32::from_le_bytes(bytes)
     })
+}
+
+/// Test-only bridge exposing [`read`] to `bun:internal-for-testing` so the
+/// format-dispatch + JPEG APP1/Exif walk can be unit-tested directly on every
+/// platform — the `Bun.Image` integration path can only reach this for
+/// HEIC/TIFF/AVIF on macOS/Windows (those formats don't decode on Linux), and
+/// only through a full decode. Registered via
+/// `$newZigFunction("runtime/image/exif.zig", "testing.readOrientation", 2)`;
+/// the `.zig` path is only the codegen key — the impl is this Rust function.
+pub mod testing {
+    use super::{codecs, read};
+    use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
+
+    /// `readOrientation(bytes: Uint8Array, format: number) -> number`.
+    /// `format` is the `codecs::Format` discriminant (0=Jpeg … 7=Gif); the
+    /// return is the EXIF orientation value (1..8).
+    pub fn read_orientation(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+        let Some(ab) = frame.argument(0).as_array_buffer(global) else {
+            return Err(global.throw(format_args!("readOrientation: expected a Uint8Array")));
+        };
+        let format = match frame.argument(1).to_int32() {
+            0 => codecs::Format::Jpeg,
+            1 => codecs::Format::Png,
+            2 => codecs::Format::Webp,
+            3 => codecs::Format::Heic,
+            4 => codecs::Format::Avif,
+            5 => codecs::Format::Bmp,
+            6 => codecs::Format::Tiff,
+            7 => codecs::Format::Gif,
+            n => return Err(global.throw(format_args!("readOrientation: bad format {n}"))),
+        };
+        let orientation = read(ab.byte_slice(), format) as u8;
+        Ok(JSValue::js_number_from_int32(i32::from(orientation)))
+    }
 }
 
 // ported from: src/runtime/image/exif.zig

--- a/test/internal/image-exif.test.ts
+++ b/test/internal/image-exif.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit coverage for the EXIF orientation dispatcher `exif::read`
+ * (src/runtime/image/exif.rs), exposed via `bun:internal-for-testing` as
+ * `imageReadOrientation(bytes, format)`.
+ *
+ * The `Bun.Image` integration test for this (the `Orientation=6` TIFF in
+ * test/js/bun/image/image.test.ts) can only run on macOS/Windows — HEIC/TIFF/
+ * AVIF have no decoder on Linux, so the full decode path is unreachable there.
+ * This unit test drives `exif::read` directly so the JPEG APP1/Exif walk and
+ * the per-format dispatch (JPEG → Zig-style walker; HEIC/TIFF/AVIF → system
+ * backend; everything else → identity) are exercised on every platform,
+ * including the Linux CI/gate lanes. (#30235)
+ */
+import { imageReadOrientation } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
+
+// codecs::Format discriminants (src/runtime/image/codecs.rs, #[repr(u8)]).
+const enum Format {
+  Jpeg = 0,
+  Png = 1,
+  Webp = 2,
+  Heic = 3,
+  Avif = 4,
+  Bmp = 5,
+  Tiff = 6,
+  Gif = 7,
+}
+
+// A minimal JPEG stream carrying an APP1/Exif segment with IFD0 tag 0x0112
+// (Orientation) set to `value`. `read_jpeg` only walks markers up to SOS, so
+// we don't need real scan data — SOI + the APP1 segment is enough.
+function jpegWithOrientation(value: number): Uint8Array {
+  // Big-endian TIFF ("MM\0*"), IFD0 at offset 8, one SHORT entry.
+  // prettier-ignore
+  const tiff = [
+    0x4d, 0x4d, 0x00, 0x2a, 0x00, 0x00, 0x00, 0x08, // header
+    0x00, 0x01,                                     // 1 entry
+    0x01, 0x12, 0x00, 0x03, 0x00, 0x00, 0x00, 0x01, // tag 0x0112, SHORT, count 1
+    (value >> 8) & 0xff, value & 0xff, 0x00, 0x00,  // value (packed in first 2 bytes)
+    0x00, 0x00, 0x00, 0x00,                         // next IFD = 0
+  ];
+  const exif = [...Buffer.from("Exif\0\0"), ...tiff];
+  const seglen = exif.length + 2; // segment length includes the 2 length bytes
+  // FF D8 (SOI) + FF E1 (APP1) + len + Exif payload + FF DA (SOS).
+  return new Uint8Array([0xff, 0xd8, 0xff, 0xe1, (seglen >> 8) & 0xff, seglen & 0xff, ...exif, 0xff, 0xda]);
+}
+
+test("exif::read parses JPEG APP1/Exif Orientation (each of 1..8)", () => {
+  for (let v = 1; v <= 8; v++) {
+    expect(imageReadOrientation(jpegWithOrientation(v), Format.Jpeg)).toBe(v);
+  }
+});
+
+test("exif::read returns Normal (1) for a JPEG with no Exif segment", () => {
+  // SOI + SOS, no APP1.
+  expect(imageReadOrientation(new Uint8Array([0xff, 0xd8, 0xff, 0xda]), Format.Jpeg)).toBe(1);
+});
+
+test("exif::read ignores an out-of-range Orientation value", () => {
+  // value 99 is not 1..8 → Normal.
+  expect(imageReadOrientation(jpegWithOrientation(99), Format.Jpeg)).toBe(1);
+});
+
+test("exif::read does not read Exif for non-JPEG container formats", () => {
+  // The same Exif-carrying bytes, dispatched as PNG/WebP/BMP/GIF, must NOT be
+  // walked as JPEG — those formats are identity in the dispatcher regardless
+  // of what the bytes contain.
+  const jpeg = jpegWithOrientation(6);
+  for (const fmt of [Format.Png, Format.Webp, Format.Bmp, Format.Gif]) {
+    expect(imageReadOrientation(jpeg, fmt)).toBe(1);
+  }
+});
+
+test("exif::read routes HEIC/TIFF/AVIF through the system backend", () => {
+  // On Linux there is no system backend, so the dispatcher returns Normal (1);
+  // on macOS/Windows ImageIO/WIC parse the container. Either way the call must
+  // not be misrouted to the JPEG walker — a small TIFF header dispatched as
+  // TIFF must never come back as a JPEG-parsed value.
+  const tiff = new Uint8Array([0x49, 0x49, 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00]);
+  for (const fmt of [Format.Heic, Format.Tiff, Format.Avif]) {
+    const o = imageReadOrientation(tiff, fmt);
+    expect(o).toBeGreaterThanOrEqual(1);
+    expect(o).toBeLessThanOrEqual(8);
+  }
+});

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -830,6 +830,94 @@ describe("Bun.Image", () => {
         expect((await new Bun.Image(out).metadata()).format).toBe(fmt);
       });
     }
+
+    // Regression for #30235. ImageIO's CGImageSourceCreateImageAtIndex (and
+    // WIC's decoder) hand back pixels in their *stored* orientation — an
+    // iPhone HEIC (and any EXIF/TIFF orientation-carrying container) looks
+    // rotated 90° vs how Preview / Photos render it. The auto-orient gate used
+    // to be JPEG-only because exif.rs's walker is JPEG-only; now the gate
+    // queries the system backend (ImageIO on macOS, WIC on Windows) for
+    // HEIC/TIFF/AVIF and runs the existing flip→flop→rotate pipeline, so Bun
+    // matches Sharp.
+    //
+    // TIFF is the test vehicle because (a) it routes through the same system
+    // backend on macOS/Windows, and (b) it's the only orientation-carrying
+    // format simple enough to hand-craft without a codec. (Coverage caveat:
+    // WIC reads HEIF orientation via /heifProps, not the IFD path TIFF uses,
+    // so this exercises the dispatch + apply_orientation glue but not the
+    // Windows HEIF probe specifically.)
+    test.skipIf(!isMacOS && !isWindows)("TIFF Orientation=6 auto-rotates via system backend", async () => {
+      // Hand-roll a 4×2 uncompressed RGB TIFF with Orientation=6. Little-
+      // endian ("II"), 13 IFD entries — all twelve TIFF 6.0 §8 baseline-RGB
+      // required tags plus Orientation, since WIC's IFD metadata reader
+      // declines to mount /ifd for a non-baseline IFD even when the pixel
+      // decoder accepts it. Layout: header 0..8, IFD count at 8, 13×12-byte
+      // entries 10..166, next-IFD 166..170, BitsPerSample 170..176,
+      // X/YResolution rationals 176..192, pixels 192..216. Tags sorted by ID.
+      const tiff = new Uint8Array(216);
+      const dv = new DataView(tiff.buffer);
+      tiff.set([0x49, 0x49, 0x2a, 0x00], 0); // "II" + magic 42
+      dv.setUint32(4, 8, true); // IFD0 at byte 8
+      dv.setUint16(8, 13, true); // 13 entries
+      const writeEntry = (i: number, tag: number, type: number, count: number, value: number) => {
+        const e = 10 + i * 12;
+        dv.setUint16(e, tag, true);
+        dv.setUint16(e + 2, type, true);
+        dv.setUint32(e + 4, count, true);
+        dv.setUint32(e + 8, value, true);
+      };
+      //             tag   type  count value/offset
+      writeEntry(0, 0x0100, 4, 1, 4); //    ImageWidth      = 4
+      writeEntry(1, 0x0101, 4, 1, 2); //    ImageLength     = 2
+      writeEntry(2, 0x0102, 3, 3, 170); //  BitsPerSample   → offset 170
+      writeEntry(3, 0x0103, 3, 1, 1); //    Compression     = none
+      writeEntry(4, 0x0106, 3, 1, 2); //    PhotoInterp     = RGB
+      writeEntry(5, 0x0111, 4, 1, 192); //  StripOffsets    → offset 192
+      writeEntry(6, 0x0112, 3, 1, 6); //    Orientation     = 6 (rotate 90° CW)
+      writeEntry(7, 0x0115, 3, 1, 3); //    SamplesPerPixel = 3
+      writeEntry(8, 0x0116, 4, 1, 2); //    RowsPerStrip    = 2
+      writeEntry(9, 0x0117, 4, 1, 24); //   StripByteCounts = 24
+      writeEntry(10, 0x011a, 5, 1, 176); // XResolution     → offset 176 (72/1)
+      writeEntry(11, 0x011b, 5, 1, 184); // YResolution     → offset 184 (72/1)
+      writeEntry(12, 0x0128, 3, 1, 2); //   ResolutionUnit  = inch
+      dv.setUint32(166, 0, true); // next IFD = 0
+      // BitsPerSample: 3 × u16 = 8, 8, 8
+      dv.setUint16(170, 8, true);
+      dv.setUint16(172, 8, true);
+      dv.setUint16(174, 8, true);
+      // X/YResolution rationals: 72/1
+      dv.setUint32(176, 72, true);
+      dv.setUint32(180, 1, true);
+      dv.setUint32(184, 72, true);
+      dv.setUint32(188, 1, true);
+      // 4×2 RGB pixels — distinctive so a misread shows up as a crash or
+      // wrong-colour PNG, not a silently equal output.
+      // prettier-ignore
+      const pixels = [
+        255, 0, 0,    0, 255, 0,    0, 0, 255,    128, 128, 128,
+        64, 64, 64,   200, 200, 200,   32, 64, 96,   100, 150, 200,
+      ];
+      tiff.set(pixels, 192);
+
+      // Without the fix: reports stored dims 4×2. With it: orientation swaps
+      // the axes so dims come back as 2×4.
+      const oriented = await new Bun.Image(tiff).metadata();
+      expect(oriented).toEqual({ width: 2, height: 4, format: "tiff" });
+
+      // Opting out of auto-orient should still land on the stored dims, so
+      // the fix didn't silently hard-wire the rotation into the decoder.
+      const raw = await new Bun.Image(tiff, { autoOrient: false }).metadata();
+      expect(raw).toEqual({ width: 4, height: 2, format: "tiff" });
+
+      // End-to-end: the reported fix workflow — resize → webp encode — must
+      // produce a WebP with the swapped aspect ratio, not the stored one.
+      // Source is 2:4 upright; fit:"inside" into a 100×100 box scales to
+      // 50×100 (height hits the cap first) — pin the exact dims so anything
+      // but the post-orient scaling regresses loudly, not just "not square".
+      // The un-fixed stored-orientation path would have landed at 100×50.
+      const webp = await new Bun.Image(tiff).resize(100, 100, { fit: "inside" }).webp({ quality: 80 }).bytes();
+      expect(await new Bun.Image(webp).metadata()).toEqual({ width: 50, height: 100, format: "webp" });
+    });
   });
 
   // @intFromFloat on NaN/Inf is UB; these used to abort the process.


### PR DESCRIPTION
Supersedes #30237. Fixes #30235.

iPhone HEIC (and any orientation-tagged TIFF/AVIF) came out rotated 90° from `Bun.Image` because the auto-orient gate only ran for JPEG — `exif.rs`'s reader is a JPEG APP1/Exif walker, and HEIC's orientation lives behind an ISOBMFF `irot`/`imir` box walk that has nothing in common with JPEG markers.

This extends the gate to HEIC/TIFF/AVIF by asking the system backend for the tag:

- **macOS** — `bun_coregraphics_orientation()` reads `kCGImagePropertyOrientation` via `CGImageSourceCopyPropertiesAtIndex`. ImageIO maps both EXIF IFD0 and HEIF `irot`/`imir` to the same 1..8 enum, so one call covers every system-backend format.
- **Windows** — `backend_wic::orientation()` reads tag 274 via `IWICMetadataQueryReader` (`/ifd/{ushort=274}`, then `/heifProps/Orientation`, then the `System.Photo.Orientation` policy name). PROPVARIANT marshalling lives in the C++ shim alongside the existing IPropertyBag2 writers.
- **Linux / `backend=bun`** — no system backend, returns identity (unchanged behaviour).

`exif::read(bytes, format)` is the single dispatch point; JPEG keeps using the ported Zig walker (`read_jpeg`), HEIC/TIFF/AVIF delegate to the system backend, and PNG/WebP/BMP/GIF stay at identity.

Also:
- `PipelineTask::run` now reads orientation **once** up front and reuses it across the decode-hint, metadata-fallthrough, and apply-orientation gates. An ImageIO/WIC source-create per call isn't free, so the resize path (the #30235 repro) stays at one backend round-trip.
- `.metadata()` on HEIC/TIFF/AVIF swaps dims numerically instead of physically rotating the decoded RGBA buffer it's about to free (skips a w×h×4 scratch alloc + vImage rotate).

The test hand-crafts a 4×2 TIFF with `Orientation=6` and asserts: `.metadata()` reports 2×4, `{autoOrient:false}` still reports 4×2, and `resize(100,100,{fit:"inside"}).webp()` produces 50×100 (not 100×50). It's gated `skipIf(!isMacOS && !isWindows)` — HEIC/TIFF/AVIF have no decoder on Linux, so the behaviour is exercised by the macOS and Windows CI lanes. The existing all-platform JPEG auto-orient tests guard the shared `run()` refactor.

> Note: this is a re-port of the original fix onto the Rust image subsystem (the image code was rewritten Zig→Rust in #30412 after this branch first opened). The C++ shims carry over unchanged; the Zig-side logic moved to `Image.rs` / `backend_coregraphics.rs` / `backend_wic.rs` / `codecs.rs` / `exif.rs`.
