### PR TITLE
NativeReadableStreamSource: reuse pull-buffer tail across reads instead of rotating every pull

### DIFF
--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2061,8 +2061,23 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
         let toEnqueue = view;
 
         if (remaining > 0) {
-          toEnqueue = view.subarray(0, result);
-          view = view.subarray(result);
+          if (result <= remaining) {
+            // The read filled less than half of the pull buffer (e.g. an SSE
+            // line or a small TTY/socket read). Copy the bytes out so the
+            // consumer holds a `result`-sized ArrayBuffer instead of pinning
+            // the whole `autoAllocateChunkSize` (256KB-2MB) buffer, and keep
+            // `view` so the next pull reuses the same allocation. Without
+            // this, every read that returned >0 bytes shrank `view` below
+            // `chunkSize`, forcing #getInternalBuffer to allocate a fresh
+            // chunkSize Uint8Array on the next pull while the consumer's
+            // subarray kept the previous one alive — on Windows that piles
+            // up MEM_COMMIT'd pages (commit charge >> RSS) until the system
+            // commit limit is hit.
+            toEnqueue = view.slice(0, result);
+          } else {
+            toEnqueue = view.subarray(0, result);
+            view = view.subarray(result);
+          }
         } else {
           view = undefined;
         }

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2061,19 +2061,21 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
         let toEnqueue = view;
 
         if (remaining > 0) {
-          if (!isClosed && result <= remaining) {
-            // Small read (≤ half the pull buffer — e.g. an SSE line or a
-            // line-buffered socket) with more data expected. Copy the bytes
-            // out so the consumer holds a `result`-sized ArrayBuffer instead
-            // of pinning the whole `autoAllocateChunkSize` (256KB-2MB)
-            // buffer, and keep `view` so the next pull reuses the same
-            // allocation. Without this, every read shrank `view` below
-            // `chunkSize`, so #getInternalBuffer allocated a fresh chunkSize
-            // Uint8Array on the next pull while each enqueued subarray kept
-            // the previous one alive — on Windows that piles up MEM_COMMIT'd
-            // pages (commit charge >> RSS) until the system commit limit is
-            // hit. Skip when isClosed since there is no next pull to reuse
-            // the buffer for and the slice would be pure extra allocation.
+          if (!isClosed && result * 4 <= view.length) {
+            // The read filled at most a quarter of the pull buffer (e.g. an
+            // SSE line or a small TTY/socket read) with more data expected.
+            // Copy the bytes out so the consumer holds a `result`-sized
+            // ArrayBuffer instead of pinning the whole autoAllocateChunkSize
+            // (256KB-2MB) buffer, and keep `view` so the next pull reuses
+            // the same allocation. Without this, every read shrank `view`
+            // below `chunkSize`, so #getInternalBuffer allocated a fresh
+            // chunkSize Uint8Array on the next pull while each enqueued
+            // subarray kept the previous one alive — on Windows that piles
+            // up MEM_COMMIT'd pages (commit charge >> RSS) until the system
+            // commit limit is hit. Skip when isClosed since there is no next
+            // pull to reuse the buffer for, and skip when the read is large
+            // (> 1/4 buffer) since the per-chunk slice allocation outweighs
+            // the at-most-4x pin amplification it would save.
             toEnqueue = view.slice(0, result);
           } else {
             toEnqueue = view.subarray(0, result);

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2038,14 +2038,16 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
       var chunk = this.$data;
       // #handleNumberResult stores the unfilled tail (view.subarray(result))
       // here, so consecutive reads write into advancing offsets of the same
-      // backing ArrayBuffer and the enqueued chunks share it. Only rotate to
-      // a fresh allocation once less than a quarter of the buffer remains;
-      // before this the threshold was `< chunkSize`, which is true after any
+      // backing ArrayBuffer and the enqueued chunks share it. Rotate only
+      // when there is no buffer or autoAllocateChunkSize has grown past the
+      // one we allocated — the tail itself is reused until a read fills it
+      // exactly and #handleNumberResult sets $data = undefined. The previous
+      // check was `chunk.length < chunkSize`, which is true after any
       // nonzero read, so every pull allocated a fresh 256KB-2MB Gigacage
       // buffer while the previous one was still pinned by the consumer's
       // subarray — on Windows that drove commit charge to tens of GB before
       // VirtualAlloc(MEM_COMMIT) failed in pas_compact_heap_reservation.
-      if (!chunk || chunk.length * 4 < chunkSize) {
+      if (!chunk || chunk.buffer.byteLength < chunkSize) {
         this.$data = chunk = new Uint8Array(chunkSize);
       }
       return chunk;

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2036,7 +2036,16 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
 
     #getInternalBuffer(chunkSize) {
       var chunk = this.$data;
-      if (!chunk || chunk.length < chunkSize) {
+      // #handleNumberResult stores the unfilled tail (view.subarray(result))
+      // here, so consecutive reads write into advancing offsets of the same
+      // backing ArrayBuffer and the enqueued chunks share it. Only rotate to
+      // a fresh allocation once less than a quarter of the buffer remains;
+      // before this the threshold was `< chunkSize`, which is true after any
+      // nonzero read, so every pull allocated a fresh 256KB-2MB Gigacage
+      // buffer while the previous one was still pinned by the consumer's
+      // subarray — on Windows that drove commit charge to tens of GB before
+      // VirtualAlloc(MEM_COMMIT) failed in pas_compact_heap_reservation.
+      if (!chunk || chunk.length * 4 < chunkSize) {
         this.$data = chunk = new Uint8Array(chunkSize);
       }
       return chunk;
@@ -2061,26 +2070,8 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
         let toEnqueue = view;
 
         if (remaining > 0) {
-          if (!isClosed && result * 4 <= view.length) {
-            // The read filled at most a quarter of the pull buffer (e.g. an
-            // SSE line or a small TTY/socket read) with more data expected.
-            // Copy the bytes out so the consumer holds a `result`-sized
-            // ArrayBuffer instead of pinning the whole autoAllocateChunkSize
-            // (256KB-2MB) buffer, and keep `view` so the next pull reuses
-            // the same allocation. Without this, every read shrank `view`
-            // below `chunkSize`, so #getInternalBuffer allocated a fresh
-            // chunkSize Uint8Array on the next pull while each enqueued
-            // subarray kept the previous one alive — on Windows that piles
-            // up MEM_COMMIT'd pages (commit charge >> RSS) until the system
-            // commit limit is hit. Skip when isClosed since there is no next
-            // pull to reuse the buffer for, and skip when the read is large
-            // (> 1/4 buffer) since the per-chunk slice allocation outweighs
-            // the at-most-4x pin amplification it would save.
-            toEnqueue = view.slice(0, result);
-          } else {
-            toEnqueue = view.subarray(0, result);
-            view = view.subarray(result);
-          }
+          toEnqueue = view.subarray(0, result);
+          view = view.subarray(result);
         } else {
           view = undefined;
         }

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2061,18 +2061,19 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
         let toEnqueue = view;
 
         if (remaining > 0) {
-          if (result <= remaining) {
-            // The read filled less than half of the pull buffer (e.g. an SSE
-            // line or a small TTY/socket read). Copy the bytes out so the
-            // consumer holds a `result`-sized ArrayBuffer instead of pinning
-            // the whole `autoAllocateChunkSize` (256KB-2MB) buffer, and keep
-            // `view` so the next pull reuses the same allocation. Without
-            // this, every read that returned >0 bytes shrank `view` below
-            // `chunkSize`, forcing #getInternalBuffer to allocate a fresh
-            // chunkSize Uint8Array on the next pull while the consumer's
-            // subarray kept the previous one alive — on Windows that piles
-            // up MEM_COMMIT'd pages (commit charge >> RSS) until the system
-            // commit limit is hit.
+          if (!isClosed && result <= remaining) {
+            // Small read (≤ half the pull buffer — e.g. an SSE line or a
+            // line-buffered socket) with more data expected. Copy the bytes
+            // out so the consumer holds a `result`-sized ArrayBuffer instead
+            // of pinning the whole `autoAllocateChunkSize` (256KB-2MB)
+            // buffer, and keep `view` so the next pull reuses the same
+            // allocation. Without this, every read shrank `view` below
+            // `chunkSize`, so #getInternalBuffer allocated a fresh chunkSize
+            // Uint8Array on the next pull while each enqueued subarray kept
+            // the previous one alive — on Windows that piles up MEM_COMMIT'd
+            // pages (commit charge >> RSS) until the system commit limit is
+            // hit. Skip when isClosed since there is no next pull to reuse
+            // the buffer for and the slice would be pure extra allocation.
             toEnqueue = view.slice(0, result);
           } else {
             toEnqueue = view.subarray(0, result);

--- a/test/js/web/streams/streams-leak.test.ts
+++ b/test/js/web/streams/streams-leak.test.ts
@@ -36,7 +36,7 @@ test("native ReadableStream small chunks don't pin autoAllocateChunkSize ArrayBu
 
   // Some chunks coalesce on the wire; we just need a meaningful sample
   // of small reads through the native pull path.
-  expect(chunks.length).toBeGreaterThan(100);
+  expect(chunks.length).toBeGreaterThan(20);
 
   const dataBytes = chunks.reduce((s, c) => s + c.byteLength, 0);
   const backingBytes = chunks.reduce((s, c) => s + c.buffer.byteLength, 0);

--- a/test/js/web/streams/streams-leak.test.ts
+++ b/test/js/web/streams/streams-leak.test.ts
@@ -1,6 +1,55 @@
 import { expect, test } from "bun:test";
 import { isWindows } from "harness";
 
+test("native ReadableStream small chunks don't pin autoAllocateChunkSize ArrayBuffers", async () => {
+  // The native pull buffer is 256KB. Before the fix, every read that
+  // returned bytes enqueued a subarray of that 256KB buffer (so the
+  // consumer's chunk pinned the whole thing) and the leftover tail —
+  // now shorter than chunkSize — forced a fresh 256KB allocation on
+  // the next pull. A stream of N small chunks therefore held N×256KB
+  // of Gigacage memory. On Windows the large heap commits those pages
+  // up front and only the scavenger releases them, so commit charge
+  // ran ahead of RSS until VirtualAlloc(MEM_COMMIT) failed inside
+  // pas_compact_heap_reservation_try_allocate.
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response(
+        new ReadableStream({
+          type: "direct",
+          async pull(controller) {
+            for (let i = 0; i < 1000; i++) {
+              controller.write("x\n");
+              await controller.flush();
+              await Bun.sleep(0);
+            }
+            controller.close();
+          },
+        }),
+      );
+    },
+  });
+
+  const resp = await fetch(server.url);
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of resp.body!) chunks.push(chunk);
+
+  // Some chunks coalesce on the wire; we just need a meaningful sample
+  // of small reads through the native pull path.
+  expect(chunks.length).toBeGreaterThan(100);
+
+  const dataBytes = chunks.reduce((s, c) => s + c.byteLength, 0);
+  const backingBytes = chunks.reduce((s, c) => s + c.buffer.byteLength, 0);
+
+  // Each enqueued chunk should own a buffer sized to the read, not the
+  // 256KB pull buffer. Allow generous slack for the handful of larger
+  // coalesced reads, page rounding, and the one reused pull buffer that
+  // may still back the final partially-filled chunk.
+  expect(backingBytes).toBeLessThan(dataBytes + 4 * 1024 * 1024);
+  // Pre-fix this was ~chunks.length * 256KB ≈ 25–250 MB.
+  expect(backingBytes).toBeLessThan(chunks.length * 64 * 1024);
+});
+
 const BYTES_TO_WRITE = 500_000;
 
 // https://github.com/oven-sh/bun/issues/12198

--- a/test/js/web/streams/streams-leak.test.ts
+++ b/test/js/web/streams/streams-leak.test.ts
@@ -1,15 +1,15 @@
 import { expect, test } from "bun:test";
 import { isWindows } from "harness";
 
-test("native ReadableStream small chunks don't pin autoAllocateChunkSize ArrayBuffers", async () => {
-  // The native pull buffer is 256KB. Before the fix, every read that
-  // returned bytes enqueued a subarray of that 256KB buffer (so the
-  // consumer's chunk pinned the whole thing) and the leftover tail —
-  // now shorter than chunkSize — forced a fresh 256KB allocation on
-  // the next pull. A stream of N small chunks therefore held N×256KB
-  // of Gigacage memory. On Windows the large heap commits those pages
-  // up front and only the scavenger releases them, so commit charge
-  // ran ahead of RSS until VirtualAlloc(MEM_COMMIT) failed inside
+test("native ReadableStream reuses the pull buffer across small reads", async () => {
+  // #getInternalBuffer used to rotate to a fresh autoAllocateChunkSize
+  // (256KB) Uint8Array whenever $data.length < chunkSize — true after
+  // every nonzero read, since #handleNumberResult stores the tail
+  // subarray. So every pull allocated a fresh 256KB Gigacage buffer
+  // while the previous one was still pinned by the consumer's enqueued
+  // subarray. On Windows libpas commits those pages up front and only
+  // the scavenger releases them, so commit charge ran ahead of RSS
+  // until VirtualAlloc(MEM_COMMIT) failed in
   // pas_compact_heap_reservation_try_allocate.
   using server = Bun.serve({
     port: 0,
@@ -38,16 +38,18 @@ test("native ReadableStream small chunks don't pin autoAllocateChunkSize ArrayBu
   // of small reads through the native pull path.
   expect(chunks.length).toBeGreaterThan(20);
 
-  const dataBytes = chunks.reduce((s, c) => s + c.byteLength, 0);
-  const backingBytes = chunks.reduce((s, c) => s + c.buffer.byteLength, 0);
+  // Consecutive small reads should land in the same backing buffer (the
+  // tail subarray is reused until < ¼ remains). 2KB of ~few-byte chunks
+  // fits well inside one 256KB buffer, so the whole stream should share
+  // a handful at most. Pre-fix every chunk had its own 256KB buffer, so
+  // this was ~chunks.length.
+  const distinctBuffers = new Set(chunks.map(c => c.buffer));
+  expect(distinctBuffers.size).toBeLessThan(8);
 
-  // Each enqueued chunk should own a buffer sized to the read, not the
-  // 256KB pull buffer. Allow generous slack for the handful of larger
-  // coalesced reads, page rounding, and the one reused pull buffer that
-  // may still back the final partially-filled chunk.
-  expect(backingBytes).toBeLessThan(dataBytes + 4 * 1024 * 1024);
+  let backingBytes = 0;
+  for (const buf of distinctBuffers) backingBytes += buf.byteLength;
   // Pre-fix this was ~chunks.length * 256KB ≈ 25–250 MB.
-  expect(backingBytes).toBeLessThan(chunks.length * 64 * 1024);
+  expect(backingBytes).toBeLessThan(4 * 1024 * 1024);
 });
 
 const BYTES_TO_WRITE = 500_000;

--- a/test/js/web/streams/streams-leak.test.ts
+++ b/test/js/web/streams/streams-leak.test.ts
@@ -39,10 +39,10 @@ test("native ReadableStream reuses the pull buffer across small reads", async ()
   expect(chunks.length).toBeGreaterThan(20);
 
   // Consecutive small reads should land in the same backing buffer (the
-  // tail subarray is reused until < ¼ remains). 2KB of ~few-byte chunks
-  // fits well inside one 256KB buffer, so the whole stream should share
-  // a handful at most. Pre-fix every chunk had its own 256KB buffer, so
-  // this was ~chunks.length.
+  // tail subarray is reused until a read fills it). 2KB of ~few-byte
+  // chunks fits well inside one 256KB buffer, so the whole stream should
+  // share a handful at most. Pre-fix every chunk had its own 256KB
+  // buffer, so this was ~chunks.length.
   const distinctBuffers = new Set(chunks.map(c => c.buffer));
   expect(distinctBuffers.size).toBeLessThan(8);
 


### PR DESCRIPTION
### What does this PR do?

`NativeReadableStreamSource#getInternalBuffer` allocates a fresh `autoAllocateChunkSize` (256KB, up to 2MB) `Uint8Array` whenever `$data.length < chunkSize`. `#handleNumberResult` stores the unfilled tail (`view.subarray(result)`) in `$data`, so after **any** nonzero read the tail is shorter than `chunkSize` and the next pull rotates to a fresh buffer — while the previous one is still pinned by the consumer's enqueued subarray. A stream of N reads therefore allocates N×256KB of Gigacage memory regardless of read size, even though `#handleNumberResult` already has the rotate-on-full logic (`view = undefined` when `remaining == 0`).

On Windows, libpas commits large-heap pages up front (`VirtualAlloc(MEM_COMMIT|MEM_RESERVE)`) and decommit is purely scavenger-driven (no allocate-side back-pressure — `PAS_PAGE_BALANCING_ENABLED` is false outside libmalloc). Commit charge runs far ahead of RSS until `VirtualAlloc(MEM_COMMIT)` fails inside `pas_compact_heap_reservation_try_allocate` while GC's ArrayBuffer sweep is allocating a `pas_large_sharing_pool` tree node. Observed crash at **29.6GB committed / 0.98GB RSS** on an 8.6GB Windows arm64 machine.

**How it got here:** `#getInternalBuffer` and the `chunk.length < chunkSize` check were introduced in #16349 / #16860 ("Rewrite internal Web Streams to use less memory"). Read alongside `#adjustHighWaterMark` — which doubles `autoAllocateChunkSize` when a read fills the buffer — the check's job is "rotate to a bigger buffer when `autoAllocateChunkSize` has grown past the one we allocated." That's a sensible guard. The same rewrite also made `#handleNumberResult` store the *tail* subarray in `$data` so consecutive reads could fill the same buffer at advancing offsets, with rotation when a read fills the tail exactly (`remaining == 0` → `view = undefined`). The two pieces don't compose: once `$data` holds a tail, `chunk.length < chunkSize` is true after every read regardless of whether `chunkSize` grew, so the buffer-growth check pre-empts the tail-reuse path on every pull and the reuse never happens.

**Fix:** compare against `chunk.buffer.byteLength` instead of `chunk.length`. That preserves the check's purpose — rotate when `autoAllocateChunkSize` has grown past the buffer we allocated — without firing on tail shrinkage. Consecutive reads write into advancing offsets of the same backing buffer (`JSC__JSValue__asArrayBuffer` → `view->vector()` is already `buffer + byteOffset`) until a read fills the tail exactly, at which point `#handleNumberResult` sets `$data = undefined` and the next pull rotates. The cost is the occasional short read at the end of each buffer's life when the source has more ready than the tail can hold.

Repro of the amplification (~2000 ~16-byte SSE chunks held in an array):

|  | distinct backing buffers | total backing | `heapStats().extraMemorySize` | RSS delta |
|---|---|---|---|---|
| before | ~887 (one per chunk) | 232 MB | 232 MB | +254 MB |
| after | 2 | 0.26 MB | 0.5 MB | +68 MB |

Likely also helps with #30415 (sustained small-chunk fetch polling on Linux — same per-pull rotation, manifests as RSS growth instead of commit-limit crash).

### How did you verify your code works?

- New test in `test/js/web/streams/streams-leak.test.ts` — streams ~1000 tiny chunks via fetch, holds them, asserts they share < 8 distinct backing ArrayBuffers totalling < 4MB. Fails on the released bun (`Received: 614` distinct buffers); passes with this change.
- `test/js/web/fetch/fetch-leak.test.ts` "should not leak using readable stream" — 3/3 pass.
- `test/js/web/fetch/body-stream.test.ts` — 9086 pass.
- `test/js/web/fetch/fetch.stream.test.ts` — 114 pass.
- `test/js/web/streams/` + `test/js/bun/stream/` — 621 pass.
- `test/js/bun/spawn/spawn-streaming-{stdin,stdout}.test.ts` — pass.