### PR TITLE
--watch/--hot: exit on SIGINT/SIGTERM when a JS handler is installed

### DIFF
--- a/src/bun.js.zig
+++ b/src/bun.js.zig
@@ -388,7 +388,22 @@ pub const Run = struct {
 
         switch (this.ctx.debug.hot_reload) {
             .hot => jsc.hot_reloader.HotReloader.enableHotModuleReloading(vm, this.entry_path),
-            .watch => jsc.hot_reloader.WatchReloader.enableHotModuleReloading(vm, this.entry_path),
+            .watch => {
+                jsc.hot_reloader.WatchReloader.enableHotModuleReloading(vm, this.entry_path);
+                // On POSIX a `--watch` reload is a raw `execve` over the
+                // same PID. `killAllSubprocessesForWatchMode()` SIGTERMs the
+                // previous incarnation's `Bun.spawn` children just before
+                // that, but nothing `wait()`s them — they exit and sit as
+                // zombies parented to us. Reap them here (before the entry
+                // point runs, so no new children exist to confuse this).
+                // Uses `std.c.waitpid` directly — `std.posix.waitpid` treats
+                // ECHILD as `unreachable`, which is the normal first-run
+                // case with no prior incarnation.
+                if (comptime bun.Environment.isPosix) {
+                    var status: c_int = undefined;
+                    while (std.c.waitpid(-1, &status, std.c.W.NOHANG) > 0) {}
+                }
+            },
             else => {},
         }
 
@@ -488,11 +503,34 @@ pub const Run = struct {
                         vm.eventLoop().autoTickActive();
                     }
 
+                    // A JS `process.on('SIGINT'|'SIGTERM'|'SIGHUP')` listener
+                    // ran. Without this break the loop would go back to
+                    // `tickPossiblyForever()` and the process could never be
+                    // stopped short of SIGKILL. The handler (and any async
+                    // work it scheduled) has already drained above; now fall
+                    // through to the normal exit path.
+                    if (vm.watch_mode_terminating_signal != 0) break;
+
                     vm.onBeforeExit();
 
                     vm.reportExceptionInHotReloadedModuleIfNeeded();
 
+                    if (vm.watch_mode_terminating_signal != 0) break;
+
                     vm.eventLoop().tickPossiblyForever();
+                }
+
+                if (vm.watch_mode_terminating_signal != 0) {
+                    // Reap any `Bun.spawn` children the script's own cleanup
+                    // didn't get to, then exit `128 + signal` so callers see
+                    // the same code as default-disposition termination.
+                    if (comptime bun.Environment.isPosix) {
+                        if (vm.rare_data) |rare| rare.killAllSubprocessesForWatchMode();
+                    }
+                    if (vm.exit_handler.exit_code == 0) {
+                        const signal: bun.SignalCode = @enumFromInt(vm.watch_mode_terminating_signal);
+                        vm.exit_handler.exit_code = signal.toExitCode() orelse 0;
+                    }
                 }
             } else {
                 while (vm.isEventLoopAlive()) {

--- a/src/jsc/PosixSignalHandle.zig
+++ b/src/jsc/PosixSignalHandle.zig
@@ -93,6 +93,23 @@ pub const PosixSignalTask = struct {
     pub const new = bun.TrivialNew(@This());
     pub fn runFromJSThread(number: u8, globalObject: *jsc.JSGlobalObject) void {
         Bun__onSignalForJS(number, globalObject);
+
+        // `--watch`/`--hot` run a `while (true)` event loop that never falls
+        // through, so a JS-handled SIGINT/SIGTERM/SIGHUP would otherwise trap
+        // the signal but never exit. Record it so the watch loop can break
+        // out once the handler (and any work it kicked off) has drained.
+        // Only reached if a JS listener is registered — default disposition
+        // already terminates the process without going through here.
+        const vm = globalObject.bunVM();
+        if (vm.hot_reload != .none and vm.watch_mode_terminating_signal == 0) {
+            switch (number) {
+                @intFromEnum(bun.SignalCode.SIGINT),
+                @intFromEnum(bun.SignalCode.SIGTERM),
+                @intFromEnum(bun.SignalCode.SIGHUP),
+                => vm.watch_mode_terminating_signal = number,
+                else => {},
+            }
+        }
     }
 };
 

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -54,6 +54,13 @@ heap_profiler_config: ?HeapProfilerConfig = null,
 counters: Counters = .{},
 
 hot_reload: bun.cli.Command.HotReload = .none,
+/// Set when a JS `process.on('SIGINT'|'SIGTERM'|'SIGHUP')` listener fires
+/// while `--watch`/`--hot` is active. The watch-mode event loop in
+/// `bun.js.zig` is `while (true) { … tickPossiblyForever(); }` — it has no
+/// natural exit, so a trapped terminating signal would otherwise leave the
+/// process running forever. When non-zero the loop breaks and the process
+/// exits via the normal path (beforeExit/exit listeners, `128 + signal`).
+watch_mode_terminating_signal: u8 = 0,
 jsc_vm: *VM = undefined,
 
 /// hide bun:wrap from stack traces
@@ -301,10 +308,20 @@ pub fn getTLSRejectUnauthorized(this: *const VirtualMachine) bool {
 
 pub fn onSubprocessSpawn(this: *VirtualMachine, process: *bun.spawn.Process) void {
     this.auto_killer.onSubprocessSpawn(process);
+    if (comptime Environment.isPosix) {
+        if (this.hot_reload != .none) {
+            this.rareData().addSubprocessForWatchMode(process.pid);
+        }
+    }
 }
 
 pub fn onSubprocessExit(this: *VirtualMachine, process: *bun.spawn.Process) void {
     this.auto_killer.onSubprocessExit(process);
+    if (comptime Environment.isPosix) {
+        if (this.hot_reload != .none) {
+            if (this.rare_data) |rare| rare.removeSubprocessForWatchMode(process.pid);
+        }
+    }
 }
 
 pub fn getVerboseFetch(this: *VirtualMachine) bun.http.HTTPVerboseLevel {

--- a/src/jsc/hot_reloader.zig
+++ b/src/jsc/hot_reloader.zig
@@ -255,9 +255,15 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
 
                 if (comptime reload_immediately) {
                     Output.flush();
-                    if (comptime Ctx == ImportWatcher) {
-                        if (this.reloader.ctx.rare_data) |rare|
+                    if (comptime Ctx == VirtualMachine) {
+                        if (this.reloader.ctx.rare_data) |rare| {
                             rare.closeAllListenSocketsForWatchMode();
+                            // `execve` preserves our PID, so `Bun.spawn`
+                            // children survive the reload with no handle in
+                            // the new process image — every save would leak
+                            // another generation of them.
+                            rare.killAllSubprocessesForWatchMode();
+                        }
                     }
                     flushChangedPathsForReload();
                     bun.reloadProcess(bun.default_allocator, clear_screen, false);

--- a/src/jsc/rare_data.zig
+++ b/src/jsc/rare_data.zig
@@ -64,6 +64,16 @@ node_fs_stat_watcher_scheduler: ?bun.ptr.RefPtr(StatWatcherScheduler) = null,
 listening_sockets_for_watch_mode: std.ArrayListUnmanaged(bun.FD) = .{},
 listening_sockets_for_watch_mode_lock: bun.Mutex = .{},
 
+/// PIDs of live `Bun.spawn` children while `--watch`/`--hot` is active.
+/// Before a watch-mode reload `execve`s over this process (or the watch loop
+/// exits on SIGINT/SIGTERM), these are sent SIGTERM so they don't accumulate
+/// across reloads. Mirrors `listening_sockets_for_watch_mode` — the reload
+/// path runs on the watcher thread so the list is mutex-protected.
+/// POSIX-only: on Windows the watch-manager parent owns a Job Object with
+/// `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` which already reaps all descendants.
+spawned_subprocess_pids_for_watch_mode: if (bun.Environment.isPosix) std.ArrayListUnmanaged(std.posix.pid_t) else void = if (bun.Environment.isPosix) .{},
+spawned_subprocess_pids_for_watch_mode_lock: if (bun.Environment.isPosix) bun.Mutex else void = if (bun.Environment.isPosix) .{},
+
 fs_watchers_for_isolation: std.ArrayListUnmanaged(*FSWatcher) = .{},
 stat_watchers_for_isolation: std.ArrayListUnmanaged(*StatWatcher) = .{},
 
@@ -330,6 +340,40 @@ pub fn closeAllListenSocketsForWatchMode(this: *RareData) void {
         socket.close();
     }
     this.listening_sockets_for_watch_mode = .{};
+}
+
+pub fn addSubprocessForWatchMode(this: *RareData, pid: std.posix.pid_t) void {
+    if (comptime !bun.Environment.isPosix) return;
+    this.spawned_subprocess_pids_for_watch_mode_lock.lock();
+    defer this.spawned_subprocess_pids_for_watch_mode_lock.unlock();
+    this.spawned_subprocess_pids_for_watch_mode.append(bun.default_allocator, pid) catch {};
+}
+
+pub fn removeSubprocessForWatchMode(this: *RareData, pid: std.posix.pid_t) void {
+    if (comptime !bun.Environment.isPosix) return;
+    this.spawned_subprocess_pids_for_watch_mode_lock.lock();
+    defer this.spawned_subprocess_pids_for_watch_mode_lock.unlock();
+    if (std.mem.indexOfScalar(std.posix.pid_t, this.spawned_subprocess_pids_for_watch_mode.items, pid)) |i| {
+        _ = this.spawned_subprocess_pids_for_watch_mode.swapRemove(i);
+    }
+}
+
+/// Send SIGTERM to every tracked `Bun.spawn` child. Called from the
+/// watcher thread immediately before `execve` on file-change reload, and
+/// from the JS thread when the watch loop exits due to a terminating
+/// signal. PIDs are best-effort — if a child has already exited and its
+/// PID been recycled in the tiny window since `onSubprocessExit`, the
+/// stray SIGTERM is no worse than the status quo of leaking the process.
+pub fn killAllSubprocessesForWatchMode(this: *RareData) void {
+    if (comptime !bun.Environment.isPosix) return;
+    this.spawned_subprocess_pids_for_watch_mode_lock.lock();
+    defer this.spawned_subprocess_pids_for_watch_mode_lock.unlock();
+    for (this.spawned_subprocess_pids_for_watch_mode.items) |pid| {
+        if (pid > 0) {
+            _ = std.c.kill(pid, @intFromEnum(bun.SignalCode.SIGTERM));
+        }
+    }
+    this.spawned_subprocess_pids_for_watch_mode.clearRetainingCapacity();
 }
 
 pub fn addFSWatcherForIsolation(this: *RareData, watcher: *FSWatcher) void {

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -1,8 +1,9 @@
 import type { Subprocess } from "bun";
 import { spawn } from "bun";
-import { afterEach, expect, it } from "bun:test";
-import { bunEnv, bunExe, isBroken, isWindows, tmpdirSync } from "harness";
+import { afterEach, describe, expect, it } from "bun:test";
+import { bunEnv, bunExe, forEachLine, isBroken, isPosix, isWindows, tempDir, tmpdirSync } from "harness";
 import { rmSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 let watchee: Subprocess;
@@ -45,4 +46,157 @@ for (const dir of ["dir", "©️"]) {
 
 afterEach(() => {
   watchee?.kill();
+});
+
+// https://github.com/oven-sh/bun/issues/13539
+//
+// On POSIX `--watch` runs the script in-process with a `while (true)` event
+// loop so the watcher can keep the process alive between runs. If the script
+// registers `process.on('SIGINT', …)` the default disposition is replaced —
+// the handler runs, but nothing breaks out of that loop, so Ctrl+C can never
+// terminate the process short of SIGKILL.
+//
+// Windows uses a supervisor + Job Object and doesn't have this problem.
+describe.skipIf(!isPosix)("--watch / --hot with a JS signal handler", () => {
+  for (const flag of ["--watch", "--hot"] as const) {
+    for (const signal of ["SIGINT", "SIGTERM"] as const) {
+      it(`${flag}: exits on ${signal} after running the handler`, async () => {
+        using dir = tempDir("watch-signal", {
+          "child.mjs": `setInterval(() => {}, 1000);`,
+          "cluster.mjs": `
+            const children = [];
+            for (let i = 0; i < 2; i++) {
+              children.push(Bun.spawn([process.execPath, "child.mjs"], {
+                stdio: ["ignore", "ignore", "ignore"],
+                env: process.env,
+              }));
+            }
+            process.on(${JSON.stringify(signal)}, () => {
+              console.log("HANDLER_RAN");
+              for (const c of children) c.kill();
+            });
+            process.on("exit", () => console.log("EXIT_RAN"));
+            // Handler must be installed before the test sends the signal,
+            // so READY goes last.
+            console.log("READY " + children.map(c => c.pid).join(","));
+          `,
+        });
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), flag, "cluster.mjs"],
+          env: bunEnv,
+          cwd: String(dir),
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+
+        let childPids: number[] = [];
+        const stdoutLines: string[] = [];
+        for await (const line of forEachLine(proc.stdout)) {
+          stdoutLines.push(line);
+          if (line.startsWith("READY ")) {
+            childPids = line
+              .slice("READY ".length)
+              .split(",")
+              .map(s => parseInt(s, 10));
+            proc.kill(signal);
+          }
+        }
+        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+        // Handler ran first, then the normal exit path (process.on('exit')),
+        // then the process actually terminated with 128 + signal.
+        expect(stderr).toBe("");
+        expect(stdoutLines).toContain("HANDLER_RAN");
+        expect(stdoutLines).toContain("EXIT_RAN");
+        expect(childPids.length).toBe(2);
+        expect(exitCode).toBe(signal === "SIGINT" ? 130 : 143);
+
+        // The grandchildren the script spawned must not outlive it.
+        for (const pid of childPids) {
+          expect(() => process.kill(pid, 0)).toThrow();
+        }
+      });
+    }
+  }
+
+  it("--watch: kills Bun.spawn children on file-change reload", async () => {
+    using dir = tempDir("watch-reload-spawn", {
+      "child.mjs": `setInterval(() => {}, 1000);`,
+      "entry.mjs": `
+        const children = [];
+        for (let i = 0; i < 2; i++) {
+          children.push(Bun.spawn([process.execPath, "child.mjs"], {
+            stdio: ["ignore", "ignore", "ignore"],
+            env: process.env,
+          }));
+        }
+        console.log("SPAWNED " + children.map(c => c.pid).join(","));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--watch", "entry.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdio: ["ignore", "pipe", "inherit"],
+    });
+
+    const lines = forEachLine(proc.stdout);
+
+    // Use .next() directly — `for await … break/return` would call
+    // `return()` on the generator and close it for subsequent calls.
+    const nextGeneration = async () => {
+      while (true) {
+        const { value: line, done } = await lines.next();
+        if (done) throw new Error("watcher exited without spawning");
+        if (line.startsWith("SPAWNED ")) {
+          return line
+            .slice("SPAWNED ".length)
+            .split(",")
+            .map(s => parseInt(s, 10));
+        }
+      }
+    };
+
+    const isRunning = async (pid: number) => {
+      try {
+        const t = await Bun.file(`/proc/${pid}/status`).text();
+        return !t.includes("State:\tZ");
+      } catch {
+        return false; // gone entirely
+      }
+    };
+
+    // Three generations: before the fix all six children would still be
+    // running here; after, only the two from the current generation are.
+    const gen1 = await nextGeneration();
+    await writeFile(join(String(dir), "entry.mjs"), (await Bun.file(join(String(dir), "entry.mjs")).text()) + "\n// 1");
+    const gen2 = await nextGeneration();
+    await writeFile(join(String(dir), "entry.mjs"), (await Bun.file(join(String(dir), "entry.mjs")).text()) + "\n// 2");
+    const gen3 = await nextGeneration();
+
+    // `kill -0` succeeds on zombies too, so on Linux check /proc state
+    // directly. On macOS there's no /proc, so fall back to `kill -0` for
+    // gen1 only — it's been through two reap passes (gen2 and gen3 startup)
+    // so it's fully gone, whereas gen2 may briefly still be a zombie.
+    // Either way, before the fix gen1 would still be a live running
+    // process on both platforms.
+    if (process.platform === "linux") {
+      for (const pid of [...gen1, ...gen2]) {
+        expect(await isRunning(pid)).toBe(false);
+      }
+    } else {
+      for (const pid of gen1) {
+        expect(() => process.kill(pid, 0)).toThrow();
+      }
+    }
+
+    proc.kill("SIGKILL");
+    await proc.exited;
+    for (const pid of [...gen2, ...gen3]) {
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {}
+    }
+  });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes #13539.

### Repro

```js
// cluster.mjs
const buns = [];
for (let i = 0; i < navigator.hardwareConcurrency; i++) {
  buns.push(Bun.spawn(["bun", "child.mjs"], { stdio: ["inherit", "inherit", "inherit"] }));
}
process.on("SIGINT", () => { for (const b of buns) b.kill(); });
process.on("exit",  () => { for (const b of buns) b.kill(); });
```
```js
// child.mjs
setInterval(() => {}, 1000);
```
```sh
bun --watch cluster.mjs
# press Ctrl+C → SIGINT handler runs, but the process never exits
```

### Cause

On POSIX, `bun --watch`/`--hot` run the script **in-process** (no supervisor) with a `while (true) { … tickPossiblyForever() }` event loop in `bun.js.zig` so the watcher can keep the process alive between runs. That loop has no natural exit.

When the script calls `process.on('SIGINT', …)`, Bun installs its own `sigaction` for `SIGINT` that enqueues the signal to the JS event loop instead of terminating. The JS handler runs, but the outer `while (true)` just goes back to `tickPossiblyForever()`. The only way out was `SIGKILL`.

Without a JS handler, default disposition terminates the process and this never came up.

There was a second, related leak: on POSIX a `--watch` file-change reload is a raw `execve` over the same PID. `Bun.spawn` children survive that with no handle in the new process image, so every save leaked another generation of running children.

### Fix

**Signal exit** — `PosixSignalTask.runFromJSThread` now records `SIGINT`/`SIGTERM`/`SIGHUP` in `vm.watch_mode_terminating_signal` when `--watch`/`--hot` is active. After the inner event loop drains (so the JS handler and any async cleanup it kicked off have run), the watch loop checks the flag and breaks out to the normal exit path: `beforeExit`/`exit` listeners fire and the process exits `128 + signal`. Any remaining `Bun.spawn` children the script didn't clean up are `SIGTERM`ed on the way out.

**Reload leak** — track live `Bun.spawn` child PIDs in `RareData` (mutex-protected, same pattern as `listening_sockets_for_watch_mode`). Right before the watcher thread `execve`s on a file change, `SIGTERM` them all. The new incarnation reaps the resulting zombies at startup via `waitpid(-1, WNOHANG)` before the entry point runs.

Also fixes a dead-code typo in `hot_reloader.zig`: the `Ctx == ImportWatcher` guard around `closeAllListenSocketsForWatchMode()` was always false (`Ctx` is `VirtualMachine`, never `ImportWatcher`), so that cleanup had never actually run in the `--watch` reload path since it was added.

All of this is POSIX-only — on Windows the `--watch` supervisor owns a Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` which already kills all descendants on exit/reload.

### Verification

New tests in `test/cli/watch/watch.test.ts`:
- `--watch`/`--hot` × `SIGINT`/`SIGTERM`: process exits with `128+sig`, user handler runs first, `process.on('exit')` fires, grandchildren are gone
- `--watch` file-change reload: after 3 generations, earlier generations' children are no longer running

All fail on the baked bun (hang until test timeout / children still alive) and pass with this change. `zig:check-all` is clean on every target.

Fixes #9871