### PR TITLE
bun test: interrupt synchronous infinite loops on --timeout

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1679,6 +1679,37 @@ impl JSValue {
             unsafe { Bun__JSValue__call(global, self, this_value, args.len(), args.as_ptr()) }
         })
     }
+
+    /// [`call`](Self::call) plus the microtask checkpoint after it, under a wall-clock limit of `seconds`.
+    /// `Ok(None)`: the limit cut them short at a safepoint, nothing is pending. A stop of the whole VM is `Err`.
+    #[track_caller]
+    pub fn call_with_deadline(
+        self,
+        global: &JSGlobalObject,
+        this_value: JSValue,
+        args: &[JSValue],
+        seconds: f64,
+    ) -> JsResult<Option<JSValue>> {
+        let mut timed_out = false;
+        let result = host_fn::from_js_host_call(global, || {
+            // SAFETY: as in `call`; `timed_out` outlives the call.
+            unsafe {
+                Bun__JSValue__callWithDeadline(
+                    global,
+                    self,
+                    this_value,
+                    args.len(),
+                    args.as_ptr(),
+                    seconds,
+                    &raw mut timed_out,
+                )
+            }
+        });
+        if timed_out {
+            return Ok(None);
+        }
+        result.map(Some)
+    }
 }
 
 /// RAII guard returned by [`JSValue::protected`]. Calls [`JSValue::unprotect`]
@@ -2133,6 +2164,15 @@ unsafe extern "C" {
         this_value: JSValue,
         args_len: usize,
         args_ptr: *const JSValue,
+    ) -> JSValue;
+    fn Bun__JSValue__callWithDeadline(
+        global: *const JSGlobalObject,
+        function: JSValue,
+        this_value: JSValue,
+        args_len: usize,
+        args_ptr: *const JSValue,
+        seconds: f64,
+        timed_out: *mut bool,
     ) -> JSValue;
     safe fn Bun__JSValue__protect(this: JSValue);
     safe fn Bun__JSValue__unprotect(this: JSValue);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3031,6 +3031,22 @@ uint8_t GlobalObject::drainMicrotasks()
     }
     scope.assertNoExceptionExceptTermination();
 
+    performMicrotaskCheckpoint();
+    // Only a termination is left pending by the checkpoint.
+    if (scope.exception()) [[unlikely]] {
+        Bun__VM__takeTerminationOutsideScript(this);
+        return 1;
+    }
+
+    return 0;
+}
+
+void GlobalObject::performMicrotaskCheckpoint()
+{
+    auto& vm = this->vm();
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    scope.assertNoException();
+
     // A checkpoint with no script on the stack ends an event loop callback: an
     // AsyncLocalStorage frame it installed with enterWith() must not leak into
     // the next one (everything queued runs under the frame it captured).
@@ -3040,26 +3056,20 @@ uint8_t GlobalObject::drainMicrotasks()
     if (auto nextTickQueue = this->m_nextTickQueue.get()) {
         nextTickQueue->drain(vm, this);
         if (auto* exception = scope.exception()) {
-            if (vm.isTerminationException(exception)) {
-                Bun__VM__takeTerminationOutsideScript(this);
-                return 1;
-            }
+            if (vm.isTerminationException(exception))
+                return;
             (void)scope.tryClearException();
             this->reportUncaughtExceptionAtEventLoop(this, exception);
-            return 0;
+            return;
         }
     }
     vm.drainMicrotasks();
     if (auto* exception = scope.exception()) {
-        if (vm.isTerminationException(exception)) {
-            Bun__VM__takeTerminationOutsideScript(this);
-            return 1;
-        }
+        if (vm.isTerminationException(exception))
+            return;
         (void)scope.tryClearException();
         this->reportUncaughtExceptionAtEventLoop(this, exception);
     }
-
-    return 0;
 }
 
 // The Rust event loop's entry to drainMicrotasks() (`EventLoop::exit()` and the

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -325,6 +325,9 @@ public:
     JSC::JSObject* bunObject() const { return m_bunObject.getInitializedOnMainThread(this); }
 
     uint8_t drainMicrotasks();
+    // drainMicrotasks()'s checkpoint for a caller that classifies a termination itself: an ordinary
+    // uncaught exception is reported here, a termination is left pending.
+    void performMicrotaskCheckpoint();
 
     void handleRejectedPromises();
     ALWAYS_INLINE void initGeneratedLazyClasses();

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -96,6 +96,7 @@
 #include "JavaScriptCore/ScriptExecutable.h"
 #include "JavaScriptCore/StackFrame.h"
 #include "JavaScriptCore/StackVisitor.h"
+#include "JavaScriptCore/TerminationDeadline.h"
 #include "JavaScriptCore/VM.h"
 #include "JavaScriptCore/WasmFaultSignalHandler.h"
 #include "ZigGlobalObject.h"
@@ -3326,6 +3327,46 @@ extern "C" JSC::EncodedJSValue Bun__JSValue__call(JSC::JSGlobalObject* globalObj
 
     RETURN_IF_EXCEPTION(scope, {});
     return JSC::JSValue::encode(result);
+}
+
+// Bun__JSValue__call plus the microtask checkpoint after it, under a wall-clock limit: bun:test's per-test
+// timeout for a callback that never yields to the event loop. Past the limit the VM's termination is requested
+// from a timer thread and the callback unwinds with the TerminationException. As in node:vm's runs
+// (NodeVMRunTermination) that termination is withdrawn here, beneath the FFI boundary, which takes a
+// termination that reaches it as the VM's stop; `*timedOut` reports it instead, with nothing pending.
+extern "C" JSC::EncodedJSValue Bun__JSValue__callWithDeadline(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue object,
+    JSC::EncodedJSValue thisObject, size_t argumentCount, const JSC::EncodedJSValue* arguments, double seconds, bool* timedOut)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    *timedOut = false;
+
+    Ref<JSC::TerminationDeadline> deadline = vm.addTerminationDeadline(MonotonicTime::now() + Seconds(seconds));
+    JSC::EncodedJSValue result = Bun__JSValue__call(globalObject, object, thisObject, argumentCount, arguments);
+    if (!scope.exception() && !WebCore::clientData(vm)->isStoppingOrStopped(vm)) [[likely]] {
+        uncheckedDowncast<Zig::GlobalObject>(globalObject)->performMicrotaskCheckpoint();
+        if (scope.exception()) [[unlikely]]
+            result = {};
+    }
+    deadline->cancel(vm);
+    if (!deadline->didFire()) [[likely]]
+        return result;
+
+    // The stop's request is indistinguishable from the deadline's; the stop wins and stays pending.
+    if (WebCore::clientData(vm)->isStoppingOrStopped(vm)) [[unlikely]]
+        return result;
+    vm.cancelTermination();
+    // A stop requested between the check above and the withdrawal went with it: request it again.
+    if (WebCore::clientData(vm)->isStoppingOrStopped(vm)) [[unlikely]]
+        vm.notifyNeedTermination();
+    // The TerminationException, or an error a finally block threw over it, is not the callback's result.
+    {
+        auto top = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+        if (top.exception())
+            top.clearException();
+    }
+    *timedOut = true;
+    return JSC::JSValue::encode(JSC::jsUndefined());
 }
 
 // CPP_DECL size_t JSC__PropertyNameArray__length(JSC__PropertyNameArray* arg0);

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1208,23 +1208,33 @@ impl EventLoop {
     }
 
     /// Prefer `runCallbackWithResult` unless you really need to make sure that microtasks are drained.
+    /// `deadline_seconds` is [`JSValue::call_with_deadline`]'s limit; `Ok(None)` means it cut the callback short.
     pub fn run_callback_with_result_and_forcefully_drain_microtasks(
         &mut self,
         callback: JSValue,
         global_object: &JSGlobalObject,
         this_value: JSValue,
         arguments: &[JSValue],
-    ) -> JsResult<JSValue> {
+        deadline_seconds: Option<f64>,
+    ) -> JsResult<Option<JSValue>> {
         // Same gate as `run_callback`.
         if global_object.has_exception() {
-            return Ok(JSValue::UNDEFINED);
+            return Ok(Some(JSValue::UNDEFINED));
         }
-        let result = callback.call(global_object, this_value, arguments)?;
+        let result = match deadline_seconds {
+            Some(seconds) => {
+                match callback.call_with_deadline(global_object, this_value, arguments, seconds)? {
+                    Some(result) => result,
+                    None => return Ok(None),
+                }
+            }
+            None => callback.call(global_object, this_value, arguments)?,
+        };
         result.ensure_still_alive();
         let jsc_vm = global_object.bun_vm().jsc_vm();
         self.drain_microtasks_with_global(global_object, jsc_vm)
             .map_err(|stopped| stopped.throw(global_object))?;
-        Ok(result)
+        Ok(Some(result))
     }
 
     /// Keep one poll registered with the loop so `us_loop_run_bun_tick` parks

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -1042,7 +1042,11 @@ fn step_sequence_one(
             // SAFETY: re-deref after run_test_callback; sequence_ptr still valid (sequences is a
             // Box<[ExecutionSequence]>, never reallocated during execution).
             let sequence = unsafe { &mut *sequence_ptr.as_ptr() };
-            let _ = next_item.evaluate_timeout(sequence, now);
+            if next_item.evaluate_timeout(sequence, now) {
+                // It never yielded, so the timer path that reaps its spawned processes did not run.
+                // `this` is stale across run_test_callback (see `BunTestCell::get`): re-derive.
+                buntest_strong.get().execution.kill_dangling_processes_on_timeout(global_this);
+            }
 
             // the result is available immediately; advance the sequence and run again.
             Execution::advance_sequence(buntest_ptr, sequence_ptr, group);

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1136,14 +1136,31 @@ impl BunTest {
 
         // SAFETY: `UnsafeCell`-derived; sole `&mut` at this point (before JS re-entry).
         unsafe { (*this).update_min_timeout(global_this, timeout) };
+
+        // The timer above cannot fire while the callback runs without yielding, so the call itself gets a
+        // deadline. The grace puts a callback it cuts short past its timespec for `evaluate_timeout`.
+        const DEADLINE_GRACE_SECONDS: f64 = 1.0;
+        let deadline_seconds = if timeout.eql(&Timespec::EPOCH) {
+            None
+        } else {
+            let now = Timespec::now_force_real_time();
+            let remaining_ns = if timeout.order(&now).is_gt() { timeout.duration(&now).ns() } else { 0 };
+            Some(remaining_ns as f64 / bun_core::time::NS_PER_S as f64 + DEADLINE_GRACE_SECONDS)
+        };
+
         let args_slice: &[JSValue] = if !done_arg.is_empty() { core::slice::from_ref(&done_arg) } else { &[] };
         let result: JSValue = match vm.event_loop_mut().run_callback_with_result_and_forcefully_drain_microtasks(
             cfg_callback,
             global_this,
             JSValue::UNDEFINED,
             args_slice,
+            deadline_seconds,
         ) {
-            Ok(v) => v,
+            Ok(Some(v)) => v,
+            Ok(None) => {
+                bun_core::scoped_log!(bun_test_group, "callTestCallback -> cut short by the deadline");
+                JSValue::ZERO
+            }
             Err(_) => {
                 global_this.clear_termination_exception();
                 // SAFETY: re-derive after JS callback returned; no outer `&mut` was held across it.

--- a/test/cli/test/test-timeout-behavior.test.ts
+++ b/test/cli/test/test-timeout-behavior.test.ts
@@ -1,6 +1,128 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isFlaky, isLinux } from "harness";
+import { bunEnv, bunExe, isFlaky, isLinux, tempDir } from "harness";
 import path from "path";
+
+// Runs `source` as a test file under `bun test --timeout=500` and returns its merged output.
+async function runWithTimeout(prefix: string, source: string) {
+  using dir = tempDir(prefix, { "loop.test.ts": source });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--timeout=500", "loop.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { combined: stdout + stderr, exitCode };
+}
+
+// https://github.com/oven-sh/bun/issues/21277
+// A synchronous infinite loop in a test body must be interrupted by the
+// per-test timeout. The event-loop timer alone cannot fire while JS is
+// running, so the callback runs under a termination deadline that cuts it
+// short at its next safepoint.
+test.concurrent("synchronous infinite loop is interrupted by --timeout", async () => {
+  const { combined, exitCode } = await runWithTimeout(
+    "timeout-sync-loop",
+    `
+      import { test } from "bun:test";
+      test("spins forever", () => {
+        while (true);
+      });
+      test("runs after the timed-out test", () => {});
+    `,
+  );
+
+  // The spinning test is reported as a timeout (not a generic failure),
+  // and the next test in the file still runs.
+  expect(combined).toContain("(fail) spins forever");
+  expect(combined).toContain("timed out after 500ms");
+  expect(combined).toContain("(pass) runs after the timed-out test");
+  expect(exitCode).toBe(1);
+});
+
+// The microtask checkpoint right after the callback runs under the same deadline.
+test.concurrent("synchronous infinite loop after awaited microtask is interrupted by --timeout", async () => {
+  const { combined, exitCode } = await runWithTimeout(
+    "timeout-sync-loop-microtask",
+    `
+      import { test } from "bun:test";
+      test("spins after await", async () => {
+        await Promise.resolve();
+        while (true);
+      });
+      test("runs after the timed-out test", () => {});
+    `,
+  );
+
+  expect(combined).toContain("(fail) spins after await");
+  expect(combined).toContain("timed out after 500ms");
+  expect(combined).toContain("(pass) runs after the timed-out test");
+  expect(exitCode).toBe(1);
+});
+
+// The deadline's termination must propagate through node:vm's Script and
+// Module evaluation when the user did not pass a {timeout} option of their own.
+test.concurrent("synchronous infinite loop inside node:vm without {timeout} is interrupted", async () => {
+  const { combined, exitCode } = await runWithTimeout(
+    "timeout-sync-loop-nodevm",
+    `
+      import { test } from "bun:test";
+      import vm from "node:vm";
+      test("spins inside runInThisContext", () => {
+        vm.runInThisContext("while (true);");
+      });
+      test("spins inside SourceTextModule.evaluate", async () => {
+        const mod = new vm.SourceTextModule("while (true);");
+        await mod.link(() => {});
+        await mod.evaluate();
+      });
+      test("runs after the timed-out tests", () => {});
+    `,
+  );
+
+  expect(combined).toContain("(fail) spins inside runInThisContext");
+  expect(combined).toContain("(fail) spins inside SourceTextModule.evaluate");
+  expect(combined.match(/timed out after 500ms/g)).toHaveLength(2);
+  expect(combined).toContain("(pass) runs after the timed-out tests");
+  expect(exitCode).toBe(1);
+});
+
+// The deadline covers the callback only, not the reporting of its failure:
+// printing the error re-enters user JS (here, a `message` getter). A
+// termination in there would outlive the runner's handling of the failure and
+// skip the next callback while reporting it as passing.
+test.concurrent("the deadline does not fire while a failure is being reported", async () => {
+  const { combined, exitCode } = await runWithTimeout(
+    "timeout-slow-error-message",
+    `
+      import { test, expect } from "bun:test";
+      test("throws", () => {
+        const error = new Error("boom");
+        let spun = false;
+        Object.defineProperty(error, "message", {
+          get() {
+            // Spin once, for longer than the 500ms timeout plus the deadline's grace.
+            if (!spun) {
+              spun = true;
+              const start = performance.now();
+              while (performance.now() - start < 2000) {}
+            }
+            return "boom";
+          },
+        });
+        throw error;
+      });
+      test("still runs and fails on its own assertion", () => {
+        expect(1).toBe(2);
+      });
+    `,
+  );
+
+  expect(combined).toContain("(fail) throws");
+  expect(combined).toContain("(fail) still runs and fails on its own assertion");
+  expect(exitCode).toBe(1);
+});
 
 if (isFlaky && isLinux) {
   test.todo("processes get killed");

--- a/test/js/bun/test/pretty-format-overflow.test.ts
+++ b/test/js/bun/test/pretty-format-overflow.test.ts
@@ -28,7 +28,8 @@ test("deep nesting", () => {
   }
 
   expect(nested).toEqual({ shouldNotMatch: true });
-});
+  // The diff takes seconds to format in debug builds, and the timeout interrupts synchronous work.
+}, 30_000);
 `,
     });
 


### PR DESCRIPTION
Fixes #21277

### Problem
- `bun test --timeout=1000` never interrupts `test("foo", () => { while (true); })`. The process hangs instead of reporting a timeout and exiting 1.
- The per-test timeout is an event-loop timer (`update_min_timeout`, `src/runtime/test_runner/bun_test.rs:1138`). `run_test_callback` arms it and then calls the test body on the same thread. A body that never yields never returns to the event loop, so the timer cannot fire.

### Fix
- New `Bun__JSValue__callWithDeadline` (`src/jsc/bindings/bindings.cpp`) runs the callback and the microtask checkpoint after it under `VM::addTerminationDeadline` (timeout plus a 1 s grace). When the deadline fires, the callback unwinds with the TerminationException at its next safepoint. The termination is withdrawn (`VM::cancelTermination`) inside the same C++ frame, and `*timedOut` reports it with nothing pending. This is the shape `NodeVMRunTermination` uses for node:vm's `timeout` option.
- Withdrawing beneath the FFI boundary matters: `takeTerminationOutsideScript` treats any termination that reaches Rust as the VM's stop, and asserts it. A stop of the whole VM still wins over the deadline and stays pending.
- `GlobalObject::drainMicrotasks()` is split so the checkpoint itself (`performMicrotaskCheckpoint`) leaves a termination pending for the caller to classify. `drainMicrotasks()` keeps taking it as the stop.
- `run_test_callback` maps a cut-short callback to "timed out" (`evaluate_timeout` reports it), and the sync-return path in `Execution.rs` reaps the test's spawned processes, which the timer path would have done.
- Verified: `test/cli/test/test-timeout-behavior.test.ts` (4 new cases, all fail on stock bun by hanging). Also `test/js/node/vm/`, the upstream `test-vm-timeout*.js` and `test-vm-sigint*.js`, `test/cli/test/`, `test/js/bun/test/`.

### Background
- A JSC termination is a request set on the VM from any thread (`notifyNeedTermination`). The VM honors it at the next safepoint by throwing the uncatchable TerminationException, which unwinds the whole JS stack.
- `TerminationDeadline` (#38660) is a wall-clock, per-call version of that request, served by a timer thread. `cancel()` stops it; `didFire()` says whether it fired. It replaced the CPU-time `Watchdog` this PR first used.
- Bun distinguishes "the VM is stopping" (`clientData(vm)->scriptAllowed()` false, set by worker `terminate()` or `process.exit()`) from a scoped termination. The stop is the only termination the Rust event loop expects to see.

<details><summary>Notes</summary>

Rebase note (fee210d1ba): #41190 added the AsyncLocalStorage `enterWith()` reset to `GlobalObject::drainMicrotasks()`, inside the block this PR moves into `performMicrotaskCheckpoint()`. The reset moved with it, so it still runs first in every checkpoint, including the one under the test deadline.

The first version of this PR armed JSC's `Watchdog` around the callback. #38660 removed the Watchdog bindings and added `TerminationDeadline`, `VM::cancelTermination` and `NodeVMRunTermination`, so the fix was re-based on those instead of merging hunks. The node:vm edits from the first version (propagating a foreign termination through `Script`/`Module` evaluation) are no longer needed: `NodeVMRunTermination::finish` already leaves a termination that is not its own pending.

Why the checkpoint runs under the same deadline: `test("x", async () => { await Promise.resolve(); while (true); })` returns a pending promise at the first `await`; the spin runs in the checkpoint right after the call. Without cover there the loop would hang as before. Work the test queues for later turns of the event loop (after a real async operation) is not covered, same as before.

Why the grace: `evaluate_timeout` decides "timed out" by comparing the wall clock against the entry's timespec after the callback returns. A deadline exactly at the timespec could leave that comparison short by timer granularity, so the deadline sits 1 s past it. A callback that finishes between the timeout and the deadline is reported as timed out by that same comparison, as before.

Test changes outside the new file: the inner fixture in `test/js/bun/test/pretty-format-overflow.test.ts` formats a 500-level diff, which takes over 6 s in debug builds; it now passes a 30 s timeout so the deadline does not cut it before the diff prints. (That fixture also stack-overflows in debug builds with an 8 MB stack, on main too; tracked separately.)

Pre-existing failures seen while running suites locally, unrelated to this diff: `test/js/node/vm/script-leak.test.ts` (5 s timeout in debug), `test/cli/test/parallel.test.ts` worker-id test (timing), `worker-terminate-lifetime.test.ts` dns.lookup case (LSan leak of `node_fs_binding::Binding`, see #35159 and #39684).

Repro: `bun test --timeout=1000 foo.test.ts` with `test("foo", () => { while (true); })` now prints `this test timed out after 1000ms` and exits 1 after about 2 s.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 17 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/test/test-timeout-behavior.test.ts

<!-- robobun:evidence:end -->
