### PR TITLE
fix(test): fire per-test timeout while fake timers are active

### DIFF
--- a/src/runtime/node/node_fs_stat_watcher.zig
+++ b/src/runtime/node/node_fs_stat_watcher.zig
@@ -88,7 +88,9 @@ pub const StatWatcherScheduler = struct {
         }
 
         // reschedule the timer
-        this.vm.timer.update(&this.event_loop_timer, &bun.timespec.msFromNow(.allow_mocked_time, interval));
+        // StatWatcherScheduler opts out of fake timers (allowFakeTimers() == false) and
+        // lives in the real timer heap, so its deadline must be computed from real time.
+        this.vm.timer.update(&this.event_loop_timer, &bun.timespec.msFromNow(.force_real_time, interval));
     }
 
     /// Schedule a task to set the timer in the main thread

--- a/src/runtime/timer/Timer.zig
+++ b/src/runtime/timer/Timer.zig
@@ -267,7 +267,14 @@ pub const All = struct {
         var maybe_now: ?timespec = null;
         while (this.timers.peek()) |min| {
             const now = maybe_now orelse now: {
-                const real_now = timespec.now(.allow_mocked_time);
+                // The real heap (this.timers) only ever contains timers whose deadlines
+                // are computed from real monotonic time: either fake timers were not
+                // active when the timer was inserted, or the timer's tag opts out of
+                // fake timers via allowFakeTimers(). Comparing against mocked time here
+                // would make real-time deadlines (e.g. the per-test timeout) appear to
+                // be in the far future while fake timers are active, so the event loop
+                // would sleep forever. Always compare the real heap against real time.
+                const real_now = timespec.now(.force_real_time);
                 maybe_now = real_now;
                 break :now real_now;
             };
@@ -329,7 +336,10 @@ pub const All = struct {
 
         if (this.timers.peek()) |timer| {
             if (!has_set_now.*) {
-                now.* = timespec.now(.allow_mocked_time);
+                // See the matching comment in getTimeout(): the real heap must be
+                // compared against real time even when fake timers are active, or
+                // real-time-based deadlines (test timeouts, WTFTimer, etc.) never fire.
+                now.* = timespec.now(.force_real_time);
                 has_set_now.* = true;
             }
             if (timer.next.greater(now)) {

--- a/test/regression/issue/26037/26037.test.ts
+++ b/test/regression/issue/26037/26037.test.ts
@@ -1,0 +1,131 @@
+// https://github.com/oven-sh/bun/issues/26037
+//
+// With jest.useFakeTimers() active, awaiting a Promise that depends on a
+// fake setTimeout (and never advancing the fake clock) should cause the test
+// to fail with a timeout — the same behavior as Jest. Before this fix, the
+// per-test timeout timer (which lives in the real timer heap with a real-time
+// deadline) was compared against the mocked clock (which starts at 0), so it
+// never fired and the test runner hung forever.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+async function runInnerTest(files: Record<string, string>, entry: string) {
+  using dir = tempDir("issue-26037", files);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", entry],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  // The inner tests use a 1s per-test timeout. On an unfixed build the child
+  // never exits at all, so cap the wait and kill it rather than letting this
+  // outer test sit until its own timeout. 10s leaves plenty of headroom for
+  // debug-build child startup while still producing a clear "hung" failure.
+  const exitCode = await Promise.race([
+    proc.exited,
+    Bun.sleep(10_000).then(() => "hung" as const),
+  ]);
+  if (exitCode === "hung") proc.kill();
+
+  const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text()]);
+  return { stdout, stderr, exitCode };
+}
+
+test.concurrent("test timeout fires while fake timers are active", async () => {
+  const { stdout, stderr, exitCode } = await runInnerTest(
+    {
+      "hang.test.ts": `
+        import { it, jest } from "bun:test";
+
+        it("hangs on fake setTimeout", async () => {
+          jest.useFakeTimers();
+          console.log("before-await");
+          // This setTimeout goes into the fake timer heap and nothing ever
+          // advances the fake clock, so the promise never resolves.
+          await new Promise(resolve => setTimeout(resolve, 0));
+          console.log("after-await");
+          jest.useRealTimers();
+        }, 1000);
+      `,
+    },
+    "hang.test.ts",
+  );
+
+  // The child reached the await (so fake timers were active at the time the
+  // per-test timeout should have fired) but never resolved past it.
+  expect(stdout).toContain("before-await");
+  expect(stdout).not.toContain("after-await");
+
+  // The test runner reported a timeout rather than hanging forever.
+  expect(exitCode).not.toBe("hung");
+  expect(stderr).toMatch(/timed out after \d+ms/i);
+  expect(stderr).toContain("1 fail");
+  expect(exitCode).toBe(1);
+}, 30_000);
+
+test.concurrent("test timeout fires when fake timers are enabled after the test starts", async () => {
+  // Regression guard for the @testing-library/user-event shape: useFakeTimers()
+  // is called *inside* the test body after the timeout timer has already been
+  // armed (with a real-time deadline) and inserted into the real heap.
+  const { stderr, exitCode } = await runInnerTest(
+    {
+      "late.test.ts": `
+        import { it, jest } from "bun:test";
+
+        it("enables fake timers mid-test then awaits", async () => {
+          // Do a microtask hop first so the test timeout timer is definitely
+          // armed before fake timers are enabled.
+          await Promise.resolve();
+          jest.useFakeTimers();
+          await new Promise(resolve => setTimeout(resolve, 0));
+          jest.useRealTimers();
+        }, 1000);
+      `,
+    },
+    "late.test.ts",
+  );
+
+  expect(exitCode).not.toBe("hung");
+  expect(stderr).toMatch(/timed out after \d+ms/i);
+  expect(stderr).toContain("1 fail");
+  expect(exitCode).toBe(1);
+}, 30_000);
+
+test.concurrent("real setTimeout scheduled before useFakeTimers still fires", async () => {
+  // Timers inserted into the real heap before fake timers are enabled have
+  // real-time deadlines. Draining the real heap against mocked time made them
+  // look perpetually "not due yet". After the fix they fire on schedule.
+  const { stderr, exitCode } = await runInnerTest(
+    {
+      "prior.test.ts": `
+        import { it, jest, expect } from "bun:test";
+
+        it("pre-fake-timer setTimeout fires", async () => {
+          let fired = false;
+          const p = new Promise<void>(resolve => {
+            setTimeout(() => {
+              fired = true;
+              resolve();
+            }, 50);
+          });
+          jest.useFakeTimers();
+          try {
+            await p;
+            expect(fired).toBe(true);
+          } finally {
+            jest.useRealTimers();
+          }
+        }, 1000);
+      `,
+    },
+    "prior.test.ts",
+  );
+
+  expect(stderr).not.toMatch(/timed out/i);
+  expect(exitCode).not.toBe("hung");
+  expect(stderr).toContain("1 pass");
+  expect(exitCode).toBe(0);
+}, 30_000);

--- a/test/regression/issue/26037/26037.test.ts
+++ b/test/regression/issue/26037/26037.test.ts
@@ -24,20 +24,19 @@ async function runInnerTest(files: Record<string, string>, entry: string) {
   // never exits at all, so cap the wait and kill it rather than letting this
   // outer test sit until its own timeout. 10s leaves plenty of headroom for
   // debug-build child startup while still producing a clear "hung" failure.
-  const exitCode = await Promise.race([
-    proc.exited,
-    Bun.sleep(10_000).then(() => "hung" as const),
-  ]);
+  const exitCode = await Promise.race([proc.exited, Bun.sleep(10_000).then(() => "hung" as const)]);
   if (exitCode === "hung") proc.kill();
 
   const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text()]);
   return { stdout, stderr, exitCode };
 }
 
-test.concurrent("test timeout fires while fake timers are active", async () => {
-  const { stdout, stderr, exitCode } = await runInnerTest(
-    {
-      "hang.test.ts": `
+test.concurrent(
+  "test timeout fires while fake timers are active",
+  async () => {
+    const { stdout, stderr, exitCode } = await runInnerTest(
+      {
+        "hang.test.ts": `
         import { it, jest } from "bun:test";
 
         it("hangs on fake setTimeout", async () => {
@@ -50,29 +49,33 @@ test.concurrent("test timeout fires while fake timers are active", async () => {
           jest.useRealTimers();
         }, 1000);
       `,
-    },
-    "hang.test.ts",
-  );
+      },
+      "hang.test.ts",
+    );
 
-  // The child reached the await (so fake timers were active at the time the
-  // per-test timeout should have fired) but never resolved past it.
-  expect(stdout).toContain("before-await");
-  expect(stdout).not.toContain("after-await");
+    // The child reached the await (so fake timers were active at the time the
+    // per-test timeout should have fired) but never resolved past it.
+    expect(stdout).toContain("before-await");
+    expect(stdout).not.toContain("after-await");
 
-  // The test runner reported a timeout rather than hanging forever.
-  expect(exitCode).not.toBe("hung");
-  expect(stderr).toMatch(/timed out after \d+ms/i);
-  expect(stderr).toContain("1 fail");
-  expect(exitCode).toBe(1);
-}, 30_000);
+    // The test runner reported a timeout rather than hanging forever.
+    expect(exitCode).not.toBe("hung");
+    expect(stderr).toMatch(/timed out after \d+ms/i);
+    expect(stderr).toContain("1 fail");
+    expect(exitCode).toBe(1);
+  },
+  30_000,
+);
 
-test.concurrent("test timeout fires when fake timers are enabled after the test starts", async () => {
-  // Regression guard for the @testing-library/user-event shape: useFakeTimers()
-  // is called *inside* the test body after the timeout timer has already been
-  // armed (with a real-time deadline) and inserted into the real heap.
-  const { stderr, exitCode } = await runInnerTest(
-    {
-      "late.test.ts": `
+test.concurrent(
+  "test timeout fires when fake timers are enabled after the test starts",
+  async () => {
+    // Regression guard for the @testing-library/user-event shape: useFakeTimers()
+    // is called *inside* the test body after the timeout timer has already been
+    // armed (with a real-time deadline) and inserted into the real heap.
+    const { stderr, exitCode } = await runInnerTest(
+      {
+        "late.test.ts": `
         import { it, jest } from "bun:test";
 
         it("enables fake timers mid-test then awaits", async () => {
@@ -84,23 +87,27 @@ test.concurrent("test timeout fires when fake timers are enabled after the test 
           jest.useRealTimers();
         }, 1000);
       `,
-    },
-    "late.test.ts",
-  );
+      },
+      "late.test.ts",
+    );
 
-  expect(exitCode).not.toBe("hung");
-  expect(stderr).toMatch(/timed out after \d+ms/i);
-  expect(stderr).toContain("1 fail");
-  expect(exitCode).toBe(1);
-}, 30_000);
+    expect(exitCode).not.toBe("hung");
+    expect(stderr).toMatch(/timed out after \d+ms/i);
+    expect(stderr).toContain("1 fail");
+    expect(exitCode).toBe(1);
+  },
+  30_000,
+);
 
-test.concurrent("real setTimeout scheduled before useFakeTimers still fires", async () => {
-  // Timers inserted into the real heap before fake timers are enabled have
-  // real-time deadlines. Draining the real heap against mocked time made them
-  // look perpetually "not due yet". After the fix they fire on schedule.
-  const { stderr, exitCode } = await runInnerTest(
-    {
-      "prior.test.ts": `
+test.concurrent(
+  "real setTimeout scheduled before useFakeTimers still fires",
+  async () => {
+    // Timers inserted into the real heap before fake timers are enabled have
+    // real-time deadlines. Draining the real heap against mocked time made them
+    // look perpetually "not due yet". After the fix they fire on schedule.
+    const { stderr, exitCode } = await runInnerTest(
+      {
+        "prior.test.ts": `
         import { it, jest, expect } from "bun:test";
 
         it("pre-fake-timer setTimeout fires", async () => {
@@ -120,12 +127,14 @@ test.concurrent("real setTimeout scheduled before useFakeTimers still fires", as
           }
         }, 1000);
       `,
-    },
-    "prior.test.ts",
-  );
+      },
+      "prior.test.ts",
+    );
 
-  expect(stderr).not.toMatch(/timed out/i);
-  expect(exitCode).not.toBe("hung");
-  expect(stderr).toContain("1 pass");
-  expect(exitCode).toBe(0);
-}, 30_000);
+    expect(stderr).not.toMatch(/timed out/i);
+    expect(exitCode).not.toBe("hung");
+    expect(stderr).toContain("1 pass");
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);

--- a/test/regression/issue/26037/26037.test.ts
+++ b/test/regression/issue/26037/26037.test.ts
@@ -21,22 +21,20 @@ async function runInnerTest(files: Record<string, string>, entry: string) {
   });
 
   // The inner tests use a 1s per-test timeout. On an unfixed build the child
-  // never exits at all, so cap the wait and kill it rather than letting this
-  // outer test sit until its own timeout. 10s leaves plenty of headroom for
-  // debug-build child startup while still producing a clear "hung" failure.
-  const exitCode = await Promise.race([proc.exited, Bun.sleep(10_000).then(() => "hung" as const)]);
+  // never exits at all, so cap the wait and kill it — 4s keeps us under the
+  // default outer test timeout while leaving headroom for debug-build child
+  // startup, and produces a clear "hung" failure rather than an outer timeout.
+  const exitCode = await Promise.race([proc.exited, Bun.sleep(4_000).then(() => "hung" as const)]);
   if (exitCode === "hung") proc.kill();
 
   const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text()]);
   return { stdout, stderr, exitCode };
 }
 
-test.concurrent(
-  "test timeout fires while fake timers are active",
-  async () => {
-    const { stdout, stderr, exitCode } = await runInnerTest(
-      {
-        "hang.test.ts": `
+test.concurrent("test timeout fires while fake timers are active", async () => {
+  const { stdout, stderr, exitCode } = await runInnerTest(
+    {
+      "hang.test.ts": `
         import { it, jest } from "bun:test";
 
         it("hangs on fake setTimeout", async () => {
@@ -49,33 +47,29 @@ test.concurrent(
           jest.useRealTimers();
         }, 1000);
       `,
-      },
-      "hang.test.ts",
-    );
+    },
+    "hang.test.ts",
+  );
 
-    // The child reached the await (so fake timers were active at the time the
-    // per-test timeout should have fired) but never resolved past it.
-    expect(stdout).toContain("before-await");
-    expect(stdout).not.toContain("after-await");
+  // The child reached the await (so fake timers were active at the time the
+  // per-test timeout should have fired) but never resolved past it.
+  expect(stdout).toContain("before-await");
+  expect(stdout).not.toContain("after-await");
 
-    // The test runner reported a timeout rather than hanging forever.
-    expect(exitCode).not.toBe("hung");
-    expect(stderr).toMatch(/timed out after \d+ms/i);
-    expect(stderr).toContain("1 fail");
-    expect(exitCode).toBe(1);
-  },
-  30_000,
-);
+  // The test runner reported a timeout rather than hanging forever.
+  expect(exitCode).not.toBe("hung");
+  expect(stderr).toMatch(/timed out after \d+ms/i);
+  expect(stderr).toContain("1 fail");
+  expect(exitCode).toBe(1);
+});
 
-test.concurrent(
-  "test timeout fires when fake timers are enabled after the test starts",
-  async () => {
-    // Regression guard for the @testing-library/user-event shape: useFakeTimers()
-    // is called *inside* the test body after the timeout timer has already been
-    // armed (with a real-time deadline) and inserted into the real heap.
-    const { stderr, exitCode } = await runInnerTest(
-      {
-        "late.test.ts": `
+test.concurrent("test timeout fires when fake timers are enabled after the test starts", async () => {
+  // Regression guard for the @testing-library/user-event shape: useFakeTimers()
+  // is called *inside* the test body after the timeout timer has already been
+  // armed (with a real-time deadline) and inserted into the real heap.
+  const { stderr, exitCode } = await runInnerTest(
+    {
+      "late.test.ts": `
         import { it, jest } from "bun:test";
 
         it("enables fake timers mid-test then awaits", async () => {
@@ -87,27 +81,23 @@ test.concurrent(
           jest.useRealTimers();
         }, 1000);
       `,
-      },
-      "late.test.ts",
-    );
+    },
+    "late.test.ts",
+  );
 
-    expect(exitCode).not.toBe("hung");
-    expect(stderr).toMatch(/timed out after \d+ms/i);
-    expect(stderr).toContain("1 fail");
-    expect(exitCode).toBe(1);
-  },
-  30_000,
-);
+  expect(exitCode).not.toBe("hung");
+  expect(stderr).toMatch(/timed out after \d+ms/i);
+  expect(stderr).toContain("1 fail");
+  expect(exitCode).toBe(1);
+});
 
-test.concurrent(
-  "real setTimeout scheduled before useFakeTimers still fires",
-  async () => {
-    // Timers inserted into the real heap before fake timers are enabled have
-    // real-time deadlines. Draining the real heap against mocked time made them
-    // look perpetually "not due yet". After the fix they fire on schedule.
-    const { stderr, exitCode } = await runInnerTest(
-      {
-        "prior.test.ts": `
+test.concurrent("real setTimeout scheduled before useFakeTimers still fires", async () => {
+  // Timers inserted into the real heap before fake timers are enabled have
+  // real-time deadlines. Draining the real heap against mocked time made them
+  // look perpetually "not due yet". After the fix they fire on schedule.
+  const { stderr, exitCode } = await runInnerTest(
+    {
+      "prior.test.ts": `
         import { it, jest, expect } from "bun:test";
 
         it("pre-fake-timer setTimeout fires", async () => {
@@ -127,14 +117,12 @@ test.concurrent(
           }
         }, 1000);
       `,
-      },
-      "prior.test.ts",
-    );
+    },
+    "prior.test.ts",
+  );
 
-    expect(stderr).not.toMatch(/timed out/i);
-    expect(exitCode).not.toBe("hung");
-    expect(stderr).toContain("1 pass");
-    expect(exitCode).toBe(0);
-  },
-  30_000,
-);
+  expect(stderr).not.toMatch(/timed out/i);
+  expect(exitCode).not.toBe("hung");
+  expect(stderr).toContain("1 pass");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #26037

## Repro

```ts
import { it, jest } from "bun:test";

it("hangs", async () => {
  jest.useFakeTimers();
  await new Promise(r => setTimeout(r, 0)); // fake timer, never advanced
  jest.useRealTimers();
}, 2000);
```

Before: hangs forever — the 2s per-test timeout never fires.
After: fails with `this test timed out after 2000ms` (matches Jest).

This is what's behind the reported hang with `@testing-library/user-event` + `jest.useFakeTimers()`. user-event calls `globalThis.setTimeout(fn, 0)` between synthetic events and doesn't auto-detect fake timers, so without `userEvent.setup({ advanceTimers: jest.advanceTimersByTime })` the click promise never resolves. That's also true in real Jest (verified with jest\@29.7 + jsdom) — the difference was that Jest's 5s default timeout killed the test, while Bun hung indefinitely.

## Cause

The real timer heap (`Timer.All.timers`) only ever holds entries whose deadlines are computed from **real** monotonic time:

- either fake timers weren't active when the entry was inserted, or
- the entry's tag opts out via `allowFakeTimers() == false` (`BunTest`, `WTFTimer`, `EventLoopDelayMonitor`, `StatWatcherScheduler`, `CronJob`) — all of which compute their `.next` with `.force_real_time`.

But `getTimeout()` and `next()` read `timespec.now(.allow_mocked_time)`, which returns the fake clock (≈ 0) once `jest.useFakeTimers()` is enabled. Every real-heap deadline then compared as "far in the future", so:

- `getTimeout()` told epoll/kqueue to sleep essentially forever, and
- `drainTimers()` → `next()` never popped the `BunTest` timeout timer.

## Fix

Compare the real heap against real time in both `getTimeout()` and `next()`. When fake timers aren't active the two modes return the same value, so this is a no-op for the normal path.

Also brought `StatWatcherScheduler` (the only opt-out tag that was still computing its deadline with `.allow_mocked_time`) in line with the others.

## Verification

`test/regression/issue/26037/26037.test.ts` — three spawned-child cases:

1. `useFakeTimers()` then await an un-advanced fake `setTimeout` → child reports `timed out after 1000ms` and exits 1 (before: child never exits).
2. Same but with a microtask hop before `useFakeTimers()` so the timeout timer is definitely already armed in the real heap.
3. A real `setTimeout` scheduled *before* `useFakeTimers()` still fires on schedule while fake timers are active.

Gate: all 3 fail without the `src/` changes, all 3 pass with them. Existing `fake-timers`, `setTimeout`, `fs.watchFile` suites and `test/regression/issue/25869.test.ts` unchanged.