### PR TITLE
node:http: apply backpressure to request body when IncomingMessage buffer is full

### DIFF
--- a/src/js/node/_http_incoming.ts
+++ b/src/js/node/_http_incoming.ts
@@ -102,7 +102,12 @@ function onIncomingMessageResumeNodeHTTPResponse(this: IncomingMessage) {
       if ((bodyReadState & NodeHTTPBodyReadState.done) !== 0) {
         emitEOFIncomingMessage(this);
       }
-      this.push(resumed);
+      if (!this.push(resumed)) {
+        // Readable buffer is already full (e.g. the 'resume' event fired from
+        // a scheduled resume_() after pause() was called). Re-pause the
+        // socket so backpressure propagates; _read() will resume it again.
+        handle.pause();
+      }
     }
   }
 }
@@ -180,7 +185,18 @@ function onDataIncomingMessage(
     return;
   }
 
-  if (chunk && !this._dumped) this.push(chunk);
+  if (chunk && !this._dumped) {
+    // Mirror Node's parserOnBody: when push() returns false the Readable's
+    // internal buffer has exceeded its highWaterMark, so stop reading from
+    // the socket until _read() is called again (which will resume it).
+    // Without this, the socket keeps reading and the buffer grows unbounded.
+    if (!this.push(chunk) && !isLast) {
+      const handle = this[kHandle];
+      if (handle) {
+        handle.pause();
+      }
+    }
+  }
 
   if (isLast) {
     emitEOFIncomingMessage(this);

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1015,8 +1015,11 @@ const NodeHTTPServerSocket = class Socket extends Duplex {
         if ((bodyReadState & NodeHTTPBodyReadState.done) !== 0) {
           emitServerSocketEOFNT(this, req);
         }
-        if (req) {
-          req.push(resumed);
+        if (req && !req.push(resumed)) {
+          // The buffered-while-paused chunk overshot the Readable's
+          // highWaterMark; re-pause so the next _read() drives the cycle
+          // instead of letting the next network chunk land on a full buffer.
+          response.pause();
         }
         this.push(resumed);
       }

--- a/test/js/node/http/node-http-backpressure.test.ts
+++ b/test/js/node/http/node-http-backpressure.test.ts
@@ -64,6 +64,82 @@ describe("backpressure", () => {
     expect(totalBytes).toBe(TwoGBPayload.byteLength);
   }, 30_000);
 
+  // https://github.com/oven-sh/bun/issues/26332
+  // When the IncomingMessage (req) buffer fills up, socket reading must pause
+  // so TCP backpressure propagates to the client. Previously push()'s return
+  // value was ignored and the Readable's internal buffer grew unbounded.
+  it("applies backpressure on request body when IncomingMessage buffer is full", async () => {
+    const { promise: reqReceived, resolve: onReq } = Promise.withResolvers<http.IncomingMessage>();
+
+    const server = http.createServer((req, _res) => {
+      // Enter flowing mode (so _read() wires up the native ondata handler),
+      // then pause. The Readable buffer will fill up; once push() returns
+      // false the socket must stop reading.
+      req.on("data", () => {});
+      req.pause();
+      onReq(req);
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const port = (server.address() as AddressInfo).port;
+
+    let pullCount = 0;
+    const CHUNK = 256 * 1024;
+    const body = new ReadableStream(
+      {
+        pull(controller) {
+          pullCount++;
+          controller.enqueue(new Uint8Array(CHUNK));
+        },
+      },
+      { highWaterMark: 1 },
+    );
+
+    const controller = new AbortController();
+    fetch(`http://127.0.0.1:${port}/`, {
+      method: "POST",
+      body,
+      // @ts-ignore
+      duplex: "half",
+      signal: controller.signal,
+    }).catch(() => {});
+
+    const req = await reqReceived;
+    let finalPullCount = 0;
+    let finalReadableLength = 0;
+    try {
+      // Wait for the pull count to stabilize (backpressure kicked in) instead
+      // of waiting a fixed amount of time. Without the fix this never
+      // stabilizes — pullCount and req.readableLength grow unbounded — so
+      // the hard cap trips and the assertions below fail.
+      let last = -1;
+      let stable = 0;
+      for (let i = 0; i < 200 && stable < 5; i++) {
+        await new Promise(r => setTimeout(r, 20));
+        if (pullCount === last) stable++;
+        else stable = 0;
+        last = pullCount;
+        // Hard cap: with 256KB chunks, 512 pulls = 128MB pulled by the client.
+        // With working backpressure this stays well under 64 (Node.js ~16-40).
+        if (pullCount > 512) break;
+      }
+      finalPullCount = pullCount;
+      finalReadableLength = req.readableLength;
+    } finally {
+      // Tear down before asserting so a failing expect doesn't leave the
+      // server waiting on an open connection.
+      controller.abort();
+      req.destroy();
+      server.closeAllConnections();
+      server.close();
+    }
+
+    expect(finalPullCount).toBeGreaterThan(0);
+    expect(finalPullCount).toBeLessThan(512);
+    // The Readable buffer should be bounded near its highWaterMark (16KB by
+    // default) plus whatever was in flight while pausing, not hundreds of MB.
+    expect(finalReadableLength).toBeLessThan(8 * 1024 * 1024);
+  }, 30_000);
+
   it("should handle backpressure with more than INT_MAX bytes", async () => {
     // enough to fill the socket buffer
     const smallPayloadSize = 1024 * 1024;

--- a/test/js/node/http/node-http-backpressure.test.ts
+++ b/test/js/node/http/node-http-backpressure.test.ts
@@ -139,9 +139,9 @@ describe("backpressure", () => {
     // Without the fix this grows into the hundreds of MB on every platform.
     expect(finalReadableLength).toBeLessThan(8 * 1024 * 1024);
     if (process.platform !== "win32") {
-      // On Windows, doPause() in NodeHTTPResponse.zig intentionally does not
-      // call pauseSocket() (see the TODO there about UV_DISCONNECT/EOF
-      // detection), so TCP backpressure does not propagate to the client —
+      // On Windows, doPause() in NodeHTTPResponse.zig intentionally skips
+      // pauseSocket() because libuv does not deliver EOF while the socket is
+      // paused, so TCP backpressure does not propagate to the client there —
       // only the Readable's buffer is bounded. On every other platform the
       // client's pull count must also stabilise.
       expect(finalPullCount).toBeLessThan(512);

--- a/test/js/node/http/node-http-backpressure.test.ts
+++ b/test/js/node/http/node-http-backpressure.test.ts
@@ -134,10 +134,18 @@ describe("backpressure", () => {
     }
 
     expect(finalPullCount).toBeGreaterThan(0);
-    expect(finalPullCount).toBeLessThan(512);
     // The Readable buffer should be bounded near its highWaterMark (16KB by
     // default) plus whatever was in flight while pausing, not hundreds of MB.
+    // Without the fix this grows into the hundreds of MB on every platform.
     expect(finalReadableLength).toBeLessThan(8 * 1024 * 1024);
+    if (process.platform !== "win32") {
+      // On Windows, doPause() in NodeHTTPResponse.zig intentionally does not
+      // call pauseSocket() (see the TODO there about UV_DISCONNECT/EOF
+      // detection), so TCP backpressure does not propagate to the client —
+      // only the Readable's buffer is bounded. On every other platform the
+      // client's pull count must also stabilise.
+      expect(finalPullCount).toBeLessThan(512);
+    }
   }, 30_000);
 
   it("should handle backpressure with more than INT_MAX bytes", async () => {


### PR DESCRIPTION
Fixes #26332.

## Problem

When a client streams a large request body to a `node:http` server and the server consumes it slowly (e.g. via `Readable.toWeb(req).pipeTo(slowWritable)` or `req.on('data'); req.pause()`), the server's `IncomingMessage` internal buffer grows unbounded instead of applying TCP backpressure to the client.

## Repro

```ts
import http from "http";

const server = http.createServer((req, res) => {
  req.on("data", () => {});
  req.pause();               // never resume
});
server.listen(0, "127.0.0.1", () => {
  const port = server.address().port;
  let pulls = 0;
  const body = new ReadableStream({
    pull(c) { pulls++; c.enqueue(new Uint8Array(16 * 1024)); },
  }, { highWaterMark: 1 });
  fetch(`http://127.0.0.1:${port}`, { method: "POST", body, duplex: "half" });
  setInterval(() => console.log({ pulls, buffered: req.readableLength }), 300);
});
```

| | pulls @ 1s | `req.readableLength` @ 1s |
|---|---|---|
| Node.js | 265 | ~4 MB |
| Bun (before) | ~20,000 and growing | ~325 MB and growing |
| Bun (after) | ~180 | ~64 KB |

## Cause

`onDataIncomingMessage` in `src/js/node/_http_incoming.ts` pushed each body chunk into the Readable with `this.push(chunk)` but ignored the return value. When `push()` returns `false` the buffer has exceeded its highWaterMark, but nothing stopped the socket from reading more — so `onData` kept firing and every chunk was appended to the Readable's buffer.

Node.js's equivalent (`parserOnBody` in `lib/_http_common.js`) checks the return value and calls `readStop(socket)` to pause socket reads; `_read()` later calls `readStart(socket)` when the buffer drains.

## Fix

Check `push()`'s return value in `onDataIncomingMessage` (and the `'resume'`-event drain path) and call `handle.pause()` when it returns `false`. `_read()` already calls `socket.resume()` → `handle.resume()` when the Readable needs more data, so the existing resume path completes the cycle.

## Verification

New test in `test/js/node/http/node-http-backpressure.test.ts` starts a paused server, streams 256 KB chunks from the client, waits for the pull count to stabilize, and asserts both the client pull count and `req.readableLength` stay bounded. Fails on `main` (`pullCount` blows past 512 within ~150 ms), passes with this change, and passes in Node.js.

## Note on Windows

`doPause()` in `NodeHTTPResponse.zig` currently skips `pauseSocket()` on Windows (pre-existing TODO about UV_DISCONNECT/EOF detection). With this change the `IncomingMessage` Readable buffer is bounded on Windows too (chunks go to the native pause buffer instead of the JS buffer once `push()` returns `false`), but TCP-level backpressure to the client only takes effect on POSIX platforms. Fully closing the Windows gap requires resolving that TODO separately.