### PR TITLE
runtime: exit on unsettled top-level await instead of spinning (Ctrl+C at @inquirer/prompts)

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1461,10 +1461,13 @@ impl VirtualMachine {
                     let global = self.global;
                     // `on_before_exit` armed this; clear it so a user
                     // `uncaughtException` listener is consulted instead of
-                    // `uncaught_exception` hard-exiting.
+                    // `uncaught_exception` hard-exiting, then restore so an
+                    // 'exit'-listener throw during `on_exit` still hard-exits.
+                    let was_exit_on_uncaught = self.exit_on_uncaught_exception;
                     self.exit_on_uncaught_exception = false;
                     // SAFETY: `global` valid for VM lifetime.
                     let _ = self.uncaught_exception(unsafe { &*global }, result, true);
+                    self.exit_on_uncaught_exception = was_exit_on_uncaught;
                     promise.set_handled();
                     self.pending_internal_promise_reported_at = self.hot_reload_counter;
                 }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2514,6 +2514,11 @@ impl VirtualMachine {
                     break;
                 }
                 if !self.is_event_loop_alive() {
+                    // JSC only roots the load-module promise while Pending; the
+                    // caller will tick (possibly GC) before reading its status
+                    // in `report_unsettled_entry_promise`, so keep it alive.
+                    JSValue::from_cell(promise).protect();
+                    self.pending_internal_promise_is_protected = true;
                     break;
                 }
                 self.auto_tick();

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1536,7 +1536,8 @@ impl VirtualMachine {
         }
 
         // Natural shutdown drains post-'exit' microtasks; exit()/fatal paths drop them.
-        let drain_after_exit = self.unhandled_error_counter == 0;
+        let drain_after_exit =
+            self.unhandled_error_counter == 0 && !self.is_handling_uncaught_exception;
         ExitHandler::dispatch_on_exit(self, drain_after_exit);
 
         // process.exit() never reaches drain_microtasks; flush AutoFlusher sinks here.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1376,6 +1376,7 @@ impl VirtualMachine {
                 return false;
             }
             self.run_error_handler(err, None);
+            self.unhandled_error_counter += 1;
             // SAFETY: `global_object` is the live VM global; `process_exit` is
             // `bun_runtime::node::process::exit` (main-thread `noreturn`).
             unsafe { (hooks.process_exit)(global_object.as_ptr(), 7) };
@@ -1399,6 +1400,7 @@ impl VirtualMachine {
                 // throws. No handler is running, so drop the recursion guard or
                 // that re-entry exits 7 ("handler threw") instead of 1.
                 self.is_handling_uncaught_exception = false;
+                self.unhandled_error_counter += 1;
                 // SAFETY: see above.
                 unsafe { (hooks.process_exit)(global_object.as_ptr(), 1) };
                 panic!("made it past process.exit()");

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1422,6 +1422,57 @@ impl VirtualMachine {
         Some(self.rare_data().hot_map())
     }
 
+    /// True when the entry module's evaluation promise is still `Pending`, i.e.
+    /// (once the loop has drained) an unsettled top-level await that
+    /// `load_entry_point` returned without waiting on.
+    pub fn entry_promise_is_pending(&self) -> bool {
+        match self.pending_internal_promise {
+            Some(p) => crate::JSPromise::status_ptr(p) == crate::js_promise::Status::Pending,
+            None => false,
+        }
+    }
+
+    /// Handle the entry module promise once the loop has fully drained (after
+    /// `on_before_exit`): still `Pending` is an unsettled top-level await (Node:
+    /// warn + exit 13, unless user code already set an exit code);
+    /// late-`Rejected` (the resumed body threw) is surfaced via
+    /// `uncaughtException` so a user handler can swallow it.
+    pub fn report_unsettled_entry_promise(&mut self) {
+        let Some(p) = self.pending_internal_promise else {
+            return;
+        };
+        match crate::JSPromise::status_ptr(p) {
+            crate::js_promise::Status::Pending => {
+                if self.exit_handler.exit_code == 0 {
+                    bun_core::pretty_errorln!(
+                        "<r><yellow>warn<r><d>:<r> Detected unsettled top-level await in <b>{}<r>",
+                        bstr::BStr::new(self.main()),
+                    );
+                    bun_core::Output::flush();
+                    self.exit_handler.exit_code = 13;
+                }
+            }
+            crate::js_promise::Status::Rejected => {
+                if self.pending_internal_promise_reported_at != self.hot_reload_counter {
+                    // SAFETY: `p` is a live GC cell tracked by the VM.
+                    let promise = unsafe { &mut *p };
+                    // SAFETY: `self.jsc_vm` set in `init`.
+                    let result = promise.result(unsafe { &*self.jsc_vm });
+                    let global = self.global;
+                    // `on_before_exit` armed this; clear it so a user
+                    // `uncaughtException` listener is consulted instead of
+                    // `uncaught_exception` hard-exiting.
+                    self.exit_on_uncaught_exception = false;
+                    // SAFETY: `global` valid for VM lifetime.
+                    let _ = self.uncaught_exception(unsafe { &*global }, result, true);
+                    promise.set_handled();
+                    self.pending_internal_promise_reported_at = self.hot_reload_counter;
+                }
+            }
+            crate::js_promise::Status::Fulfilled => {}
+        }
+    }
+
     pub fn on_before_exit(&mut self) {
         // Node only emits 'beforeExit' on a natural drain; a fatal uncaught
         // exception that brought us here is an implicit process.exit(1). Arm
@@ -2454,7 +2505,19 @@ impl VirtualMachine {
                 return Ok(promise);
             }
             self.event_loop_mut().perform_gc();
-            self.wait_for_promise(jsc::AnyPromise::Internal(promise));
+            // Not `wait_for_promise`: a never-settling TLA would busy-spin.
+            // Tick while work could settle it; on idle-with-pending, return
+            // so the caller fires beforeExit/exit and maps to exit code 13.
+            while crate::JSPromise::status_ptr(promise) == crate::js_promise::Status::Pending {
+                self.event_loop_mut().tick();
+                if crate::JSPromise::status_ptr(promise) != crate::js_promise::Status::Pending {
+                    break;
+                }
+                if !self.is_event_loop_alive() {
+                    break;
+                }
+                self.auto_tick();
+            }
         }
 
         Ok(self.pending_internal_promise.unwrap_or(promise))

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -506,8 +506,7 @@ impl ExitHandler {
         let exit_code = vm.exit_handler.exit_code;
         let emitted = Process__dispatchOnExit(vm.global(), exit_code);
         if drain_microtasks_after_emit && emitted {
-            // Promise microtasks only (JSC VM::drainMicrotasks): Node's
-            // InternalCallbackScope checkpoint skips nextTick once _exiting.
+            // Promise-only (not nextTick): Node's post-_exiting checkpoint skips nextTick.
             vm.jsc_vm().drain_microtasks();
         }
         if vm.worker.is_none() {
@@ -1427,11 +1426,9 @@ impl VirtualMachine {
         Some(self.rare_data().hot_map())
     }
 
-    /// True when `load_entry_point` returned with the entry module's
-    /// evaluation promise still `Pending` (an unsettled top-level await).
+    /// True when `load_entry_point` left the entry promise `Pending` (unsettled TLA).
     pub fn entry_promise_is_pending(&self) -> bool {
-        // Only valid when `load_entry_point` protected the pointer on its
-        // idle-with-pending break; a settled promise is GC-eligible.
+        // `is_protected` gate: an already-settled promise is unrooted and GC-eligible.
         self.pending_internal_promise_is_protected
             && matches!(
                 self.pending_internal_promise,
@@ -1439,13 +1436,9 @@ impl VirtualMachine {
             )
     }
 
-    /// Handle the entry promise after the loop fully drained: `Pending` is an
-    /// unsettled top-level await (Node: warn + exit 13); late-`Rejected` is
-    /// surfaced via `uncaughtException` so a user handler can swallow it.
+    /// After the loop drained: `Pending` → Node's warn + exit 13; late-`Rejected` → `uncaughtException`.
     pub fn report_unsettled_entry_promise(&mut self) {
-        // See `entry_promise_is_pending`: a settled-in-`load_entry_point`
-        // promise is unprotected and GC-eligible; early-Rejected is handled
-        // by the caller before the drain loop so nothing to do here.
+        // Unprotected = settled inside `load_entry_point`; pointer is GC-eligible.
         if !self.pending_internal_promise_is_protected {
             return;
         }
@@ -1470,8 +1463,7 @@ impl VirtualMachine {
                     // SAFETY: `self.jsc_vm` set in `init`.
                     let result = promise.result(unsafe { &*self.jsc_vm });
                     let global = self.global;
-                    // `on_before_exit` armed this; clear so a user listener is
-                    // consulted, then restore for the 'exit'-listener-throw path.
+                    // `on_before_exit` armed this; suspend so a user listener is consulted.
                     let was_exit_on_uncaught = self.exit_on_uncaught_exception;
                     self.exit_on_uncaught_exception = false;
                     // SAFETY: `global` valid for VM lifetime.
@@ -1541,9 +1533,7 @@ impl VirtualMachine {
             }
         }
 
-        // Node drains Promise microtasks once after the natural-shutdown
-        // 'exit' emit so rejections from listeners reach their handlers; an
-        // explicit process.exit() / fatal-exception path drops them.
+        // Natural shutdown drains post-'exit' microtasks; exit()/fatal paths drop them.
         let drain_after_exit = self.unhandled_error_counter == 0 && !self.is_shutting_down;
         ExitHandler::dispatch_on_exit(self, drain_after_exit);
 
@@ -2521,17 +2511,14 @@ impl VirtualMachine {
                 return Ok(promise);
             }
             self.event_loop_mut().perform_gc();
-            // Not `wait_for_promise`: a never-settling TLA would busy-spin.
-            // Tick while work could settle it; on idle-with-pending, return
-            // so the caller fires beforeExit/exit and maps to exit code 13.
+            // Not `wait_for_promise`: a never-settling TLA would busy-spin at 100% CPU.
             while crate::JSPromise::status_ptr(promise) == crate::js_promise::Status::Pending {
                 self.event_loop_mut().tick();
                 if crate::JSPromise::status_ptr(promise) != crate::js_promise::Status::Pending {
                     break;
                 }
                 if !self.is_event_loop_alive() {
-                    // JSC only roots the load-module promise while Pending;
-                    // the caller ticks (and may GC) before reading its status.
+                    // JSC unroots this once settled; protect before the caller may GC.
                     JSValue::from_cell(promise).protect();
                     self.pending_internal_promise_is_protected = true;
                     break;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1534,7 +1534,7 @@ impl VirtualMachine {
         }
 
         // Natural shutdown drains post-'exit' microtasks; exit()/fatal paths drop them.
-        let drain_after_exit = self.unhandled_error_counter == 0 && !self.is_shutting_down;
+        let drain_after_exit = self.unhandled_error_counter == 0;
         ExitHandler::dispatch_on_exit(self, drain_after_exit);
 
         // process.exit() never reaches drain_microtasks; flush AutoFlusher sinks here.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -368,7 +368,7 @@ unsafe extern "C" {
     safe fn Bun__emitHandledPromiseEvent(global: &JSGlobalObject, promise: JSValue) -> bool;
 
     safe fn Process__dispatchOnBeforeExit(global: &JSGlobalObject, code: u8);
-    safe fn Process__dispatchOnExit(global: &JSGlobalObject, code: u8);
+    safe fn Process__dispatchOnExit(global: &JSGlobalObject, code: u8) -> bool;
     safe fn Bun__closeAllSQLiteDatabasesForTermination();
     safe fn Bun__closeAllNodeSqliteDatabasesForTermination(global: &JSGlobalObject);
     safe fn Bun__WebView__closeAllForTermination();
@@ -502,9 +502,14 @@ impl ExitHandler {
     /// parent via `container_of` would escape the provenance of `&mut self`
     /// (which only covers the `ExitHandler` field). Callers pass the VM
     /// reference instead; the body re-enters JS so no `&mut` is held.
-    pub(crate) fn dispatch_on_exit(vm: &VirtualMachine) {
+    pub(crate) fn dispatch_on_exit(vm: &VirtualMachine, drain_microtasks_after_emit: bool) {
         let exit_code = vm.exit_handler.exit_code;
-        Process__dispatchOnExit(vm.global(), exit_code);
+        let emitted = Process__dispatchOnExit(vm.global(), exit_code);
+        if drain_microtasks_after_emit && emitted {
+            // Promise microtasks only (JSC VM::drainMicrotasks): Node's
+            // InternalCallbackScope checkpoint skips nextTick once _exiting.
+            vm.jsc_vm().drain_microtasks();
+        }
         if vm.worker.is_none() {
             Bun__closeAllSQLiteDatabasesForTermination();
             Bun__closeAllNodeSqliteDatabasesForTermination(vm.global());
@@ -1422,22 +1427,28 @@ impl VirtualMachine {
         Some(self.rare_data().hot_map())
     }
 
-    /// True when the entry module's evaluation promise is still `Pending`, i.e.
-    /// (once the loop has drained) an unsettled top-level await that
-    /// `load_entry_point` returned without waiting on.
+    /// True when `load_entry_point` returned with the entry module's
+    /// evaluation promise still `Pending` (an unsettled top-level await).
     pub fn entry_promise_is_pending(&self) -> bool {
-        match self.pending_internal_promise {
-            Some(p) => crate::JSPromise::status_ptr(p) == crate::js_promise::Status::Pending,
-            None => false,
-        }
+        // Only valid when `load_entry_point` protected the pointer on its
+        // idle-with-pending break; a settled promise is GC-eligible.
+        self.pending_internal_promise_is_protected
+            && matches!(
+                self.pending_internal_promise,
+                Some(p) if crate::JSPromise::status_ptr(p) == crate::js_promise::Status::Pending,
+            )
     }
 
-    /// Handle the entry module promise once the loop has fully drained (after
-    /// `on_before_exit`): still `Pending` is an unsettled top-level await (Node:
-    /// warn + exit 13, unless user code already set an exit code);
-    /// late-`Rejected` (the resumed body threw) is surfaced via
-    /// `uncaughtException` so a user handler can swallow it.
+    /// Handle the entry promise after the loop fully drained: `Pending` is an
+    /// unsettled top-level await (Node: warn + exit 13); late-`Rejected` is
+    /// surfaced via `uncaughtException` so a user handler can swallow it.
     pub fn report_unsettled_entry_promise(&mut self) {
+        // See `entry_promise_is_pending`: a settled-in-`load_entry_point`
+        // promise is unprotected and GC-eligible; early-Rejected is handled
+        // by the caller before the drain loop so nothing to do here.
+        if !self.pending_internal_promise_is_protected {
+            return;
+        }
         let Some(p) = self.pending_internal_promise else {
             return;
         };
@@ -1445,7 +1456,7 @@ impl VirtualMachine {
             crate::js_promise::Status::Pending => {
                 if self.exit_handler.exit_code == 0 {
                     bun_core::pretty_errorln!(
-                        "<r><yellow>warn<r><d>:<r> Detected unsettled top-level await in <b>{}<r>",
+                        "<r><yellow>warn<r><d>:<r> Detected unsettled top-level await at or below <b>{}<r>",
                         bstr::BStr::new(self.main()),
                     );
                     bun_core::Output::flush();
@@ -1459,10 +1470,8 @@ impl VirtualMachine {
                     // SAFETY: `self.jsc_vm` set in `init`.
                     let result = promise.result(unsafe { &*self.jsc_vm });
                     let global = self.global;
-                    // `on_before_exit` armed this; clear it so a user
-                    // `uncaughtException` listener is consulted instead of
-                    // `uncaught_exception` hard-exiting, then restore so an
-                    // 'exit'-listener throw during `on_exit` still hard-exits.
+                    // `on_before_exit` armed this; clear so a user listener is
+                    // consulted, then restore for the 'exit'-listener-throw path.
                     let was_exit_on_uncaught = self.exit_on_uncaught_exception;
                     self.exit_on_uncaught_exception = false;
                     // SAFETY: `global` valid for VM lifetime.
@@ -1532,7 +1541,11 @@ impl VirtualMachine {
             }
         }
 
-        ExitHandler::dispatch_on_exit(self);
+        // Node drains Promise microtasks once after the natural-shutdown
+        // 'exit' emit so rejections from listeners reach their handlers; an
+        // explicit process.exit() / fatal-exception path drops them.
+        let drain_after_exit = self.unhandled_error_counter == 0 && !self.is_shutting_down;
+        ExitHandler::dispatch_on_exit(self, drain_after_exit);
 
         // process.exit() never reaches drain_microtasks; flush AutoFlusher sinks here.
         if !self.is_inside_deferred_task_queue.get() {
@@ -2517,9 +2530,8 @@ impl VirtualMachine {
                     break;
                 }
                 if !self.is_event_loop_alive() {
-                    // JSC only roots the load-module promise while Pending; the
-                    // caller will tick (possibly GC) before reading its status
-                    // in `report_unsettled_entry_promise`, so keep it alive.
+                    // JSC only roots the load-module promise while Pending;
+                    // the caller ticks (and may GC) before reading its status.
                     JSValue::from_cell(promise).protect();
                     self.pending_internal_promise_is_protected = true;
                     break;

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -313,14 +313,8 @@ static void callUserEmitOverride(JSC::JSGlobalObject* globalObject, Process* pro
 
 static void dispatchExitInternal(JSC::JSGlobalObject* globalObject, Process* process, int exitCode)
 {
-    if (process->m_isExiting)
-        return;
-    process->m_isExiting = true;
     auto& emitter = process->wrapped();
     auto& vm = JSC::getVM(globalObject);
-
-    if (vm.hasTerminationRequest() || vm.hasExceptionsAfterHandlingTraps())
-        return;
 
     // Node: `_exiting` is set regardless of whether any 'exit' listener exists.
     process->putDirect(vm, Identifier::fromString(vm, "_exiting"_s), jsBoolean(true), 0);
@@ -894,6 +888,10 @@ extern "C" bool Process__dispatchOnExit(Zig::GlobalObject* globalObject, uint8_t
         process->m_isExitCodeObservable = true;
     // true = this call emitted; the Rust caller gates the post-emit drain on it.
     if (process->m_isExiting)
+        return false;
+    process->m_isExiting = true;
+    auto& vm = JSC::getVM(globalObject);
+    if (vm.hasTerminationRequest() || vm.hasExceptionsAfterHandlingTraps())
         return false;
     dispatchExitInternal(globalObject, process, exitCode);
     return true;
@@ -3414,7 +3412,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionReallyExit, (JSGlobalObject * globalObj
 
     auto* zigGlobal = defaultGlobalObject(globalObject);
     // Node's reallyExit is the raw exit that does not run 'exit' listeners. Arm
-    // m_isExiting so dispatchExitInternal (via Bun__Process__exit) skips them
+    // m_isExiting so Process__dispatchOnExit (via Bun__Process__exit) skips them
     // while native shutdown (profiles, cleanup hooks, SQLite close) still runs.
     zigGlobal->processObject()->m_isExiting = true;
     Bun__Process__exit(zigGlobal, exitCode);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -892,8 +892,7 @@ extern "C" bool Process__dispatchOnExit(Zig::GlobalObject* globalObject, uint8_t
     auto* process = globalObject->processObject();
     if (exitCode > 0)
         process->m_isExitCodeObservable = true;
-    // Returns true only when this call emitted 'exit'; the Rust caller uses
-    // that to decide the post-emit microtask drain (natural shutdown only).
+    // true = this call emitted; the Rust caller gates the post-emit drain on it.
     if (process->m_isExiting)
         return false;
     dispatchExitInternal(globalObject, process, exitCode);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -892,23 +892,7 @@ extern "C" void Process__dispatchOnExit(Zig::GlobalObject* globalObject, uint8_t
     auto* process = globalObject->processObject();
     if (exitCode > 0)
         process->m_isExitCodeObservable = true;
-    bool alreadyExiting = process->m_isExiting;
     dispatchExitInternal(globalObject, process, exitCode);
-
-    // Natural-shutdown path only: drain Promise microtasks once after
-    // 'exit' so shutdown-time rejections reach their handlers. An explicit
-    // process.exit() drops them (Node parity). Never drain nextTick here.
-    auto& vm = JSC::getVM(globalObject);
-    if (!alreadyExiting && !vm.hasTerminationRequest()) {
-        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        vm.drainMicrotasks();
-        if (auto* exception = scope.exception()) {
-            (void)scope.tryClearException();
-            if (!vm.hasPendingTerminationException()) {
-                Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
-            }
-        }
-    }
 }
 
 JSC_DEFINE_HOST_FUNCTION(Process_functionUptime, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
@@ -931,11 +915,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionExit, (JSC::JSGlobalObject * globalObje
     RETURN_IF_EXCEPTION(throwScope, {});
 
     auto exitCode = Bun__getExitCode(bunVM(zigGlobal));
-    if (exitCode > 0)
-        process->m_isExitCodeObservable = true;
-    // Explicit process.exit(): Node does not drain microtasks here, so
-    // call dispatchExitInternal directly (Process__dispatchOnExit drains).
-    dispatchExitInternal(zigGlobal, process, exitCode);
+    Process__dispatchOnExit(zigGlobal, exitCode);
 
     // process.reallyExit(exitCode);
     auto reallyExitVal = process->get(globalObject, Identifier::fromString(vm, "reallyExit"_s));

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -883,16 +883,21 @@ extern "C" void Process__dispatchOnBeforeExit(Zig::GlobalObject* globalObject, u
     }
 }
 
-extern "C" void Process__dispatchOnExit(Zig::GlobalObject* globalObject, uint8_t exitCode)
+extern "C" bool Process__dispatchOnExit(Zig::GlobalObject* globalObject, uint8_t exitCode)
 {
     if (!globalObject->hasProcessObject()) {
-        return;
+        return false;
     }
 
     auto* process = globalObject->processObject();
     if (exitCode > 0)
         process->m_isExitCodeObservable = true;
+    // Returns true only when this call emitted 'exit'; the Rust caller uses
+    // that to decide the post-emit microtask drain (natural shutdown only).
+    if (process->m_isExiting)
+        return false;
     dispatchExitInternal(globalObject, process, exitCode);
+    return true;
 }
 
 JSC_DEFINE_HOST_FUNCTION(Process_functionUptime, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -281,6 +281,36 @@ static JSValue constructProcessReleaseObject(VM& vm, JSObject* processObject)
     return release;
 }
 
+// Own-property `process.emit` override if the user installed one, else empty.
+// `getDirect` only: the prototype's `emitForBindings` early-returns when
+// `scriptExecutionContext()` is gone during natural shutdown.
+static JSC::JSValue userEmitOverride(JSC::VM& vm, Process* process)
+{
+    JSC::JSValue emitValue = process->getDirect(vm, JSC::Identifier::fromString(vm, "emit"_s));
+    if (!emitValue || JSC::getCallData(emitValue).type == JSC::CallData::Type::None)
+        return {};
+    return emitValue;
+}
+
+static void callUserEmitOverride(JSC::JSGlobalObject* globalObject, Process* process, JSC::JSValue emitValue, ASCIILiteral eventName, JSC::JSValue arg)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+
+    auto callData = JSC::getCallData(emitValue);
+    JSC::MarkedArgumentBuffer args;
+    args.append(JSC::jsString(vm, String(eventName)));
+    args.append(arg);
+    (void)JSC::profiledCall(globalObject, JSC::ProfilingReason::API, emitValue, callData, process, args);
+
+    if (auto* exception = scope.exception()) {
+        (void)scope.tryClearException();
+        if (!vm.hasPendingTerminationException()) {
+            Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        }
+    }
+}
+
 static void dispatchExitInternal(JSC::JSGlobalObject* globalObject, Process* process, int exitCode)
 {
     if (process->m_isExiting)
@@ -292,15 +322,16 @@ static void dispatchExitInternal(JSC::JSGlobalObject* globalObject, Process* pro
     if (vm.hasTerminationRequest() || vm.hasExceptionsAfterHandlingTraps())
         return;
 
-    auto event = Identifier::fromString(vm, "exit"_s);
-    if (!emitter.hasEventListeners(event)) {
-        return;
-    }
+    // Node: `_exiting` is set regardless of whether any 'exit' listener exists.
     process->putDirect(vm, Identifier::fromString(vm, "_exiting"_s), jsBoolean(true), 0);
 
-    MarkedArgumentBuffer arguments;
-    arguments.append(jsNumber(exitCode));
-    emitter.emit(event, arguments);
+    if (JSC::JSValue userEmit = userEmitOverride(vm, process)) {
+        callUserEmitOverride(globalObject, process, userEmit, "exit"_s, jsNumber(exitCode));
+    } else if (auto event = Identifier::fromString(vm, "exit"_s); emitter.hasEventListeners(event)) {
+        MarkedArgumentBuffer arguments;
+        arguments.append(jsNumber(exitCode));
+        emitter.emit(event, arguments);
+    }
 }
 
 JSC_DEFINE_CUSTOM_SETTER(Process_defaultSetter, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue value, JSC::PropertyName propertyName))
@@ -831,11 +862,20 @@ extern "C" void Process__dispatchOnBeforeExit(Zig::GlobalObject* globalObject, u
     }
     auto& vm = JSC::getVM(globalObject);
     auto* process = globalObject->processObject();
-    MarkedArgumentBuffer arguments;
-    arguments.append(jsNumber(exitCode));
     Bun__VirtualMachine__exitDuringUncaughtException(bunVM(vm));
-    auto fired = process->wrapped().emit(Identifier::fromString(vm, "beforeExit"_s), arguments);
-    if (fired) {
+
+    bool shouldDrainNextTick;
+    if (JSC::JSValue userEmit = userEmitOverride(vm, process)) {
+        callUserEmitOverride(globalObject, process, userEmit, "beforeExit"_s, jsNumber(exitCode));
+        // A user override's return value isn't a reliable "had listeners"
+        // signal; it may have queued nextTick work and returned falsy.
+        shouldDrainNextTick = true;
+    } else {
+        MarkedArgumentBuffer arguments;
+        arguments.append(jsNumber(exitCode));
+        shouldDrainNextTick = process->wrapped().emit(Identifier::fromString(vm, "beforeExit"_s), arguments);
+    }
+    if (shouldDrainNextTick) {
         if (globalObject->m_nextTickQueue) {
             auto nextTickQueue = globalObject->m_nextTickQueue.get();
             nextTickQueue->drain(vm, globalObject);
@@ -852,7 +892,23 @@ extern "C" void Process__dispatchOnExit(Zig::GlobalObject* globalObject, uint8_t
     auto* process = globalObject->processObject();
     if (exitCode > 0)
         process->m_isExitCodeObservable = true;
+    bool alreadyExiting = process->m_isExiting;
     dispatchExitInternal(globalObject, process, exitCode);
+
+    // Natural-shutdown path only: drain Promise microtasks once after
+    // 'exit' so shutdown-time rejections reach their handlers. An explicit
+    // process.exit() drops them (Node parity). Never drain nextTick here.
+    auto& vm = JSC::getVM(globalObject);
+    if (!alreadyExiting && !vm.hasTerminationRequest()) {
+        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+        vm.drainMicrotasks();
+        if (auto* exception = scope.exception()) {
+            (void)scope.tryClearException();
+            if (!vm.hasPendingTerminationException()) {
+                Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+            }
+        }
+    }
 }
 
 JSC_DEFINE_HOST_FUNCTION(Process_functionUptime, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
@@ -875,7 +931,11 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionExit, (JSC::JSGlobalObject * globalObje
     RETURN_IF_EXCEPTION(throwScope, {});
 
     auto exitCode = Bun__getExitCode(bunVM(zigGlobal));
-    Process__dispatchOnExit(zigGlobal, exitCode);
+    if (exitCode > 0)
+        process->m_isExitCodeObservable = true;
+    // Explicit process.exit(): Node does not drain microtasks here, so
+    // call dispatchExitInternal directly (Process__dispatchOnExit drains).
+    dispatchExitInternal(zigGlobal, process, exitCode);
 
     // process.reallyExit(exitCode);
     auto reallyExitVal = process->get(globalObject, Identifier::fromString(vm, "reallyExit"_s));

--- a/src/jsc/bindings/BunProcess.h
+++ b/src/jsc/bindings/BunProcess.h
@@ -51,7 +51,7 @@ public:
 
     bool m_isExitCodeObservable = false;
     bool m_sourceMapsEnabled = false;
-    // Re-entry guard for dispatchExitInternal. Per-Process (i.e. per-VM): a
+    // Re-entry guard for Process__dispatchOnExit. Per-Process (i.e. per-VM): a
     // function-local static would be shared across worker threads, so a
     // worker's exit would suppress the main thread's 'exit' event.
     bool m_isExiting = false;

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1574,7 +1574,7 @@ fn on_unhandled_rejection(
     // they may change process.exitCode). Run them before arming termination — a pending
     // termination exception makes dispatchExitInternal skip 'exit' (as terminate() should),
     // and its processIsExiting guard stops shutdown() from running them twice.
-    virtual_machine::ExitHandler::dispatch_on_exit(vm);
+    virtual_machine::ExitHandler::dispatch_on_exit(vm, false);
     let _ = worker.set_requested_terminate();
     // Do NOT call `worker.shutdown()` here —
     // `shutdown()` RETURNS, so calling it here would destroy

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1572,8 +1572,8 @@ fn on_unhandled_rejection(
     }
     // node runs the worker's process 'exit' handlers on an uncaught exception (code 1;
     // they may change process.exitCode). Run them before arming termination — a pending
-    // termination exception makes dispatchExitInternal skip 'exit' (as terminate() should),
-    // and its processIsExiting guard stops shutdown() from running them twice.
+    // termination exception makes Process__dispatchOnExit skip 'exit' (as terminate() should),
+    // and its m_isExiting guard stops shutdown() from running them twice.
     virtual_machine::ExitHandler::dispatch_on_exit(vm, false);
     let _ = worker.set_requested_terminate();
     // Do NOT call `worker.shutdown()` here —

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1570,8 +1570,7 @@ fn on_unhandled_rejection(
     {
         let _ = global_object.try_take_exception();
     }
-    // Fire 'exit' before arming termination (Process__dispatchOnExit skips
-    // under termination); m_isExiting stops shutdown() running them twice.
+    // Emit 'exit' before arming termination; m_isExiting prevents the shutdown() re-emit.
     virtual_machine::ExitHandler::dispatch_on_exit(vm, false);
     let _ = worker.set_requested_terminate();
     // Do NOT call `worker.shutdown()` here —

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1570,10 +1570,8 @@ fn on_unhandled_rejection(
     {
         let _ = global_object.try_take_exception();
     }
-    // node runs the worker's process 'exit' handlers on an uncaught exception (code 1;
-    // they may change process.exitCode). Run them before arming termination — a pending
-    // termination exception makes Process__dispatchOnExit skip 'exit' (as terminate() should),
-    // and its m_isExiting guard stops shutdown() from running them twice.
+    // Fire 'exit' before arming termination (Process__dispatchOnExit skips
+    // under termination); m_isExiting stops shutdown() running them twice.
     virtual_machine::ExitHandler::dispatch_on_exit(vm, false);
     let _ = worker.set_requested_terminate();
     // Do NOT call `worker.shutdown()` here —

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1646,6 +1646,11 @@ impl Run {
         vm.on_unhandled_rejection = Run::on_unhandled_rejection_before_close;
         vm.global().handle_rejected_promises();
         vm.on_exit();
+        // Node drains Promise microtasks once after a natural-shutdown 'exit'
+        // so a rejection queued from an 'exit' listener reaches its handler.
+        // Placed here (not in Process__dispatchOnExit) so the fatal-exception
+        // and worker-crash on_exit() paths keep Node's "drop them" behaviour.
+        vm.drain_microtasks();
 
         if ANY_UNHANDLED.load(Ordering::Relaxed) {
             print_unhandled_version_note(vm);

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1646,11 +1646,6 @@ impl Run {
         vm.on_unhandled_rejection = Run::on_unhandled_rejection_before_close;
         vm.global().handle_rejected_promises();
         vm.on_exit();
-        // Node drains Promise microtasks once after a natural-shutdown 'exit'
-        // so a rejection queued from an 'exit' listener reaches its handler.
-        // Placed here (not in Process__dispatchOnExit) so the fatal-exception
-        // and worker-crash on_exit() paths keep Node's "drop them" behaviour.
-        vm.drain_microtasks();
 
         if ANY_UNHANDLED.load(Ordering::Relaxed) {
             print_unhandled_version_note(vm);

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1566,9 +1566,24 @@ impl Run {
                 vm.event_loop_ref().tick_possibly_forever();
             }
         } else {
-            while vm.is_event_loop_alive() {
-                vm.tick();
-                vm.auto_tick_active();
+            loop {
+                while vm.is_event_loop_alive() {
+                    vm.tick();
+                    vm.auto_tick_active();
+                }
+
+                vm.on_before_exit();
+
+                // load_entry_point() may have left the entry promise pending.
+                // A beforeExit listener may have just scheduled work that
+                // settles it; drain once and re-enter if so.
+                if vm.entry_promise_is_pending() {
+                    vm.tick();
+                    if vm.is_event_loop_alive() {
+                        continue;
+                    }
+                }
+                break;
             }
 
             if ctx.runtime_options.eval.eval_and_print {
@@ -1618,7 +1633,9 @@ impl Run {
                 }
             }
 
-            vm.on_before_exit();
+            // Node: still-pending entry TLA → warn + exit 13; late-rejected
+            // (resumed body threw) → surface via uncaughtException.
+            vm.report_unsettled_entry_promise();
         }
 
         if log_has_msgs(vm) {

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -802,10 +802,9 @@ describe("should not hang", () => {
   }
 });
 
-describe("unref() + .exited with nothing else ref'd (Windows)", () => {
-  // Windows: with only an unref'd uv_process_t left, uv_run() used to skip its
-  // body and never dequeue the IOCP exit packet, so these children busy-spun
-  // forever. With nothing ref'd, Node exits 13 (unsettled top-level await).
+describe("unref() + await .exited with nothing else ref'd", () => {
+  // An unref'd child does not keep the loop alive, so a top-level
+  // `await p.exited` is an unsettled TLA: exit 13, do not busy-spin.
   for (const [name, body] of [
     ["unref() then await .exited", `const p = Bun.spawn(opts); p.unref(); await p.exited;`],
     [".exited then unref() then await", `const p = Bun.spawn(opts); const done = p.exited; p.unref(); await done;`],
@@ -829,8 +828,6 @@ describe("unref() + .exited with nothing else ref'd (Windows)", () => {
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([child.stdout.text(), child.stderr.text(), child.exited]);
-      // Node: an unref'd handle + a top-level await on it is an unsettled
-      // TLA — the process must exit 13, not wait on the unref'd child.
       expect(stderr).toContain("unsettled top-level await");
       expect({ stdout, exitCode, signalCode: child.signalCode }).toEqual({
         stdout: "",

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -805,7 +805,7 @@ describe("should not hang", () => {
 describe("unref() + .exited with nothing else ref'd (Windows)", () => {
   // Windows: with only an unref'd uv_process_t left, uv_run() used to skip its
   // body and never dequeue the IOCP exit packet, so these children busy-spun
-  // forever. us_loop_pump now forces one non-blocking iteration (POSIX parity).
+  // forever. With nothing ref'd, Node exits 13 (unsettled top-level await).
   for (const [name, body] of [
     ["unref() then await .exited", `const p = Bun.spawn(opts); p.unref(); await p.exited;`],
     [".exited then unref() then await", `const p = Bun.spawn(opts); const done = p.exited; p.unref(); await done;`],
@@ -829,10 +829,12 @@ describe("unref() + .exited with nothing else ref'd (Windows)", () => {
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([child.stdout.text(), child.stderr.text(), child.exited]);
-      expect({ stdout, stderr, exitCode, signalCode: child.signalCode }).toEqual({
-        stdout: "resolved\n",
-        stderr: "",
-        exitCode: 0,
+      // Node: an unref'd handle + a top-level await on it is an unsettled
+      // TLA — the process must exit 13, not wait on the unref'd child.
+      expect(stderr).toContain("unsettled top-level await");
+      expect({ stdout, exitCode, signalCode: child.signalCode }).toEqual({
+        stdout: "",
+        exitCode: 13,
         signalCode: null,
       });
     });

--- a/test/regression/issue/12694.test.ts
+++ b/test/regression/issue/12694.test.ts
@@ -1,0 +1,113 @@
+// https://github.com/oven-sh/bun/issues/12694
+// Ctrl+C at a raw-mode readline prompt (e.g. @inquirer/prompts) did not exit:
+// readline correctly closed on 0x03, but load_entry_point then busy-spun on
+// the never-settling top-level await at 100% CPU.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+
+// Bun.Terminal provides a PTY so process.stdin.isTTY is true and readline
+// enables raw mode; on Windows raw-mode ^C is delivered differently.
+test.skipIf(isWindows)("Ctrl+C at a raw-mode readline prompt exits instead of spinning on an unsettled TLA", async () => {
+  // @inquirer/prompts@5 reduced to the part this issue exercises:
+  //   readline.createInterface({ terminal: true }) + a top-level await.
+  // In raw mode Ctrl+C arrives as byte 0x03; readline's kTtyWrite maps it to
+  // close() → input.pause() + setRawMode(false). With nothing left alive,
+  // the process must exit (Node: exit 13, unsettled TLA) rather than spin.
+  const source = `
+    import * as readline from "node:readline";
+    const rl = readline.createInterface({
+      terminal: true,
+      input: process.stdin,
+      output: process.stdout,
+    });
+    rl.on("close", () => console.log("rl-closed"));
+    console.log("? prompt:");
+    await new Promise(resolve => rl.on("line", resolve));
+    console.log("unreachable");
+  `;
+
+  let output = "";
+  const prompt = Promise.withResolvers<void>();
+  const closed = Promise.withResolvers<void>();
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", source],
+    env: bunEnv,
+    terminal: {
+      data(_t, chunk) {
+        output += new TextDecoder().decode(chunk);
+        if (output.includes("? prompt:")) prompt.resolve();
+        if (output.includes("rl-closed")) closed.resolve();
+      },
+    },
+  });
+  const terminal = proc.terminal!;
+
+  await prompt.promise;
+  // Ctrl+C as a raw byte on the PTY.
+  terminal.write("\x03");
+  // readline must observe ^C and close (fails fast if the keypress path broke).
+  await closed.promise;
+
+  const exitCode = await proc.exited;
+
+  expect(output).not.toContain("unreachable");
+  expect(output).toContain("unsettled top-level await");
+  // 13 = Node's "unsettled top-level await" exit code.
+  expect(exitCode).toBe(13);
+});
+
+test.skipIf(isWindows)(
+  "Ctrl+C at a raw-mode prompt with a signal-exit style process.emit override rejects the prompt (inquirer flow)",
+  async () => {
+    // @inquirer/core@5 layers signal-exit on top: it overrides process.emit to
+    // observe 'exit' and reject the pending prompt. The .catch() must run.
+    const source = `
+      import * as readline from "node:readline";
+      const originalEmit = process.emit;
+      let rejectPrompt;
+      process.emit = function (ev, ...args) {
+        const ret = originalEmit.call(this, ev, ...args);
+        if (ev === "exit") rejectPrompt?.(new Error("force closed " + args[0]));
+        return ret;
+      };
+      const rl = readline.createInterface({
+        terminal: true,
+        input: process.stdin,
+        output: process.stdout,
+      });
+      console.log("? prompt:");
+      await new Promise((resolve, reject) => {
+        rejectPrompt = reject;
+        rl.on("line", l => { rl.close(); resolve(l); });
+      }).catch(e => {
+        console.log("CAUGHT " + e.message);
+        process.exit(0);
+      });
+    `;
+
+    let output = "";
+    const prompt = Promise.withResolvers<void>();
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      terminal: {
+        data(_t, chunk) {
+          output += new TextDecoder().decode(chunk);
+          if (output.includes("? prompt:")) prompt.resolve();
+        },
+      },
+    });
+    const terminal = proc.terminal!;
+
+    await prompt.promise;
+    terminal.write("\x03");
+
+    const exitCode = await proc.exited;
+
+    expect(output).toContain("CAUGHT force closed 13");
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/regression/issue/12694.test.ts
+++ b/test/regression/issue/12694.test.ts
@@ -8,13 +8,15 @@ import { bunEnv, bunExe, isWindows } from "harness";
 
 // Bun.Terminal provides a PTY so process.stdin.isTTY is true and readline
 // enables raw mode; on Windows raw-mode ^C is delivered differently.
-test.skipIf(isWindows)("Ctrl+C at a raw-mode readline prompt exits instead of spinning on an unsettled TLA", async () => {
-  // @inquirer/prompts@5 reduced to the part this issue exercises:
-  //   readline.createInterface({ terminal: true }) + a top-level await.
-  // In raw mode Ctrl+C arrives as byte 0x03; readline's kTtyWrite maps it to
-  // close() → input.pause() + setRawMode(false). With nothing left alive,
-  // the process must exit (Node: exit 13, unsettled TLA) rather than spin.
-  const source = `
+test.skipIf(isWindows)(
+  "Ctrl+C at a raw-mode readline prompt exits instead of spinning on an unsettled TLA",
+  async () => {
+    // @inquirer/prompts@5 reduced to the part this issue exercises:
+    //   readline.createInterface({ terminal: true }) + a top-level await.
+    // In raw mode Ctrl+C arrives as byte 0x03; readline's kTtyWrite maps it to
+    // close() → input.pause() + setRawMode(false). With nothing left alive,
+    // the process must exit (Node: exit 13, unsettled TLA) rather than spin.
+    const source = `
     import * as readline from "node:readline";
     const rl = readline.createInterface({
       terminal: true,
@@ -27,36 +29,37 @@ test.skipIf(isWindows)("Ctrl+C at a raw-mode readline prompt exits instead of sp
     console.log("unreachable");
   `;
 
-  let output = "";
-  const prompt = Promise.withResolvers<void>();
-  const closed = Promise.withResolvers<void>();
+    let output = "";
+    const prompt = Promise.withResolvers<void>();
+    const closed = Promise.withResolvers<void>();
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", source],
-    env: bunEnv,
-    terminal: {
-      data(_t, chunk) {
-        output += new TextDecoder().decode(chunk);
-        if (output.includes("? prompt:")) prompt.resolve();
-        if (output.includes("rl-closed")) closed.resolve();
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      terminal: {
+        data(_t, chunk) {
+          output += new TextDecoder().decode(chunk);
+          if (output.includes("? prompt:")) prompt.resolve();
+          if (output.includes("rl-closed")) closed.resolve();
+        },
       },
-    },
-  });
-  const terminal = proc.terminal!;
+    });
+    const terminal = proc.terminal!;
 
-  await prompt.promise;
-  // Ctrl+C as a raw byte on the PTY.
-  terminal.write("\x03");
-  // readline must observe ^C and close (fails fast if the keypress path broke).
-  await closed.promise;
+    await prompt.promise;
+    // Ctrl+C as a raw byte on the PTY.
+    terminal.write("\x03");
+    // readline must observe ^C and close (fails fast if the keypress path broke).
+    await closed.promise;
 
-  const exitCode = await proc.exited;
+    const exitCode = await proc.exited;
 
-  expect(output).not.toContain("unreachable");
-  expect(output).toContain("unsettled top-level await");
-  // 13 = Node's "unsettled top-level await" exit code.
-  expect(exitCode).toBe(13);
-});
+    expect(output).not.toContain("unreachable");
+    expect(output).toContain("unsettled top-level await");
+    // 13 = Node's "unsettled top-level await" exit code.
+    expect(exitCode).toBe(13);
+  },
+);
 
 test.skipIf(isWindows)(
   "Ctrl+C at a raw-mode prompt with a signal-exit style process.emit override rejects the prompt (inquirer flow)",

--- a/test/regression/issue/12694.test.ts
+++ b/test/regression/issue/12694.test.ts
@@ -4,10 +4,12 @@
 // the never-settling top-level await at 100% CPU.
 
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isDebug, isWindows } from "harness";
 
 // Bun.Terminal provides a PTY so process.stdin.isTTY is true and readline
 // enables raw mode; on Windows raw-mode ^C is delivered differently.
+const timeout = isDebug ? 30_000 : 10_000;
+
 test.skipIf(isWindows)(
   "Ctrl+C at a raw-mode readline prompt exits instead of spinning on an unsettled TLA",
   async () => {
@@ -31,7 +33,6 @@ test.skipIf(isWindows)(
 
     let output = "";
     const prompt = Promise.withResolvers<void>();
-    const closed = Promise.withResolvers<void>();
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", source],
@@ -40,25 +41,28 @@ test.skipIf(isWindows)(
         data(_t, chunk) {
           output += new TextDecoder().decode(chunk);
           if (output.includes("? prompt:")) prompt.resolve();
-          if (output.includes("rl-closed")) closed.resolve();
         },
       },
     });
     const terminal = proc.terminal!;
+    // Surface the PTY output if the child dies before printing the prompt.
+    proc.exited.then(code => {
+      prompt.reject(new Error(`child exited ${code} before prompt:\n${output}`));
+    });
 
     await prompt.promise;
     // Ctrl+C as a raw byte on the PTY.
     terminal.write("\x03");
-    // readline must observe ^C and close (fails fast if the keypress path broke).
-    await closed.promise;
 
     const exitCode = await proc.exited;
 
+    expect(output).toContain("rl-closed");
     expect(output).not.toContain("unreachable");
     expect(output).toContain("unsettled top-level await");
     // 13 = Node's "unsettled top-level await" exit code.
     expect(exitCode).toBe(13);
   },
+  timeout,
 );
 
 test.skipIf(isWindows)(
@@ -104,6 +108,9 @@ test.skipIf(isWindows)(
       },
     });
     const terminal = proc.terminal!;
+    proc.exited.then(code => {
+      prompt.reject(new Error(`child exited ${code} before expected output:\n${output}`));
+    });
 
     await prompt.promise;
     terminal.write("\x03");
@@ -113,4 +120,5 @@ test.skipIf(isWindows)(
     expect(output).toContain("CAUGHT force closed 13");
     expect(exitCode).toBe(0);
   },
+  timeout,
 );

--- a/test/regression/issue/17636.test.ts
+++ b/test/regression/issue/17636.test.ts
@@ -1,0 +1,216 @@
+// https://github.com/oven-sh/bun/issues/17636
+// @inquirer/prompts hang on stdin close: unsettled TLA + process.emit override bypassed
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+
+// All six tests spawn a child bun; under the ASAN debug build six
+// concurrent processes contend enough that the default 5s timeout
+// isn't always sufficient for the readline/stdin cases.
+const timeout = isDebug ? 30_000 : 10_000;
+
+test.concurrent(
+  "unsettled top-level await exits 13 once the event loop is idle instead of hanging",
+  async () => {
+    // stdin closes → readline closes → nothing left to settle the TLA.
+    const source = `
+    import * as readline from "node:readline";
+
+    const rl = readline.createInterface({
+      terminal: true,
+      input: process.stdin,
+      output: process.stdout,
+    });
+    rl.on("close", () => console.log("rl-closed"));
+    process.on("beforeExit", c => console.log("beforeExit", c));
+    process.on("exit", c => console.log("exit", c));
+
+    await new Promise(() => {});
+    console.log("unreachable");
+  `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      stdin: new Blob([""]),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["rl-closed", "beforeExit 0", "exit 13"]);
+    expect(stderr).toContain("unsettled top-level await");
+    expect(exitCode).toBe(13);
+  },
+  timeout,
+);
+
+test.concurrent(
+  "monkey-patched process.emit observes 'beforeExit' and 'exit' on natural shutdown",
+  async () => {
+    const source = `
+    const seen = [];
+    const original = process.emit;
+    process.emit = function (ev, ...args) {
+      seen.push(ev + ":" + args[0]);
+      return original.call(this, ev, ...args);
+    };
+    process.on("exit", () => console.log(JSON.stringify(seen)));
+  `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const seen = JSON.parse(stdout.trim());
+    expect(seen).toEqual(["beforeExit:0", "exit:0"]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);
+
+test.concurrent(
+  "signal-exit pattern rejects a pending TLA prompt on stdin close (inquirer flow)",
+  async () => {
+    // End-to-end reduction: patched process.emit observes 'exit', rejects
+    // the prompt, and the .catch() microtask runs before the process dies.
+    using dir = tempDir("issue-17636", {
+      "index.mjs": `
+      import * as readline from "node:readline";
+
+      // Minimal stand-in for the part of \`signal-exit\` that inquirer
+      // relies on: patch process.emit, call subscribers on 'exit'.
+      const onExitHandlers = [];
+      function onSignalExit(fn) { onExitHandlers.push(fn); }
+      const originalEmit = process.emit;
+      process.emit = function (ev, ...args) {
+        const ret = originalEmit.call(this, ev, ...args);
+        if (ev === "exit") {
+          for (const fn of onExitHandlers) fn(args[0], null);
+        }
+        return ret;
+      };
+
+      // Inquirer's createPrompt, reduced.
+      function prompt() {
+        const rl = readline.createInterface({
+          terminal: true,
+          input: process.stdin,
+          output: process.stdout,
+        });
+        return new Promise((resolve, reject) => {
+          onSignalExit((code, signal) => {
+            reject(new Error("User force closed the prompt with " + code + " " + signal));
+          });
+          rl.on("line", line => {
+            rl.close();
+            resolve(line);
+          });
+        });
+      }
+
+      await prompt().catch(e => {
+        console.log("CAUGHT:" + e.message);
+        process.exit(0);
+      });
+      console.log("unreachable");
+    `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdin: new Blob([""]),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("unsettled top-level await");
+    expect(stdout.trim()).toBe("CAUGHT:User force closed the prompt with 13 null");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);
+
+test.concurrent(
+  "Promise microtasks queued from an 'exit' listener run, but nextTick does not",
+  async () => {
+    // Node drains Promise microtasks once after 'exit'; nextTick is a
+    // no-op once _exiting is set (queued callbacks are dropped).
+    const source = `
+    process.on("exit", code => {
+      console.log("exit-listener:" + code);
+      Promise.resolve().then(() => console.log("microtask:" + process.exitCode));
+      process.nextTick(() => console.log("nexttick:SHOULD-NOT-RUN"));
+    });
+    process.exitCode = 5;
+  `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["exit-listener:5", "microtask:5"]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(5);
+  },
+  timeout,
+);
+
+test.concurrent(
+  "explicit process.exitCode suppresses the unsettled-TLA warning and exit 13",
+  async () => {
+    // Node: if user code set an exit code, the TLA-unsettled path respects it
+    // and does not overwrite with 13 or print the warning.
+    const source = `
+    process.exitCode = 7;
+    await new Promise(() => {});
+  `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("");
+    expect(stderr).not.toContain("unsettled");
+    expect(exitCode).toBe(7);
+  },
+  timeout,
+);
+
+test.concurrent(
+  "beforeExit listener that settles the TLA lets execution resume (no exit 13)",
+  async () => {
+    // Node parity: a beforeExit handler can resolve the pending top-level
+    // await, after which module evaluation continues past the await.
+    const source = `
+    let resolve;
+    process.on("beforeExit", () => resolve("ok"));
+    const v = await new Promise(r => { resolve = r; });
+    console.log("resumed:" + v);
+  `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.trim()).toBe("resumed:ok");
+    expect(stderr).not.toContain("unsettled");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);

--- a/test/regression/issue/17636.test.ts
+++ b/test/regression/issue/17636.test.ts
@@ -4,9 +4,8 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug, tempDir } from "harness";
 
-// All six tests spawn a child bun; under the ASAN debug build six
-// concurrent processes contend enough that the default 5s timeout
-// isn't always sufficient for the readline/stdin cases.
+// Each test spawns a child bun; under debug+ASAN concurrent spawns contend
+// enough that the default 5s timeout isn't always sufficient.
 const timeout = isDebug ? 30_000 : 10_000;
 
 test.concurrent(

--- a/test/regression/issue/17636.test.ts
+++ b/test/regression/issue/17636.test.ts
@@ -165,6 +165,35 @@ test.concurrent(
 );
 
 test.concurrent(
+  "Promise microtasks queued from a worker's 'exit' listener run",
+  async () => {
+    const source = `
+    import { Worker } from "node:worker_threads";
+    const w = new Worker(
+      \`process.on("exit", c => {
+         console.log("exit-listener:" + c);
+         Promise.resolve().then(() => console.log("microtask:" + c));
+       });\`,
+      { eval: true },
+    );
+    await new Promise(r => w.on("exit", r));
+  `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["exit-listener:0", "microtask:0"]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);
+
+test.concurrent(
   "explicit process.exitCode suppresses the unsettled-TLA warning and exit 13",
   async () => {
     // Node: if user code set an exit code, the TLA-unsettled path respects it

--- a/test/regression/issue/17636.test.ts
+++ b/test/regression/issue/17636.test.ts
@@ -214,3 +214,106 @@ test.concurrent(
   },
   timeout,
 );
+
+test.concurrent(
+  "explicit process.exit() does not drain microtasks queued from an 'exit' listener",
+  async () => {
+    // Mirror of the natural-shutdown microtask test: on explicit process.exit()
+    // Node drops them (and nextTick too); the drain is natural-shutdown only.
+    const source = `
+    process.on("exit", c => {
+      console.log("exit-listener:" + c);
+      Promise.resolve().then(() => console.log("LEAK-microtask"));
+      process.nextTick(() => console.log("LEAK-nexttick"));
+    });
+    process.exit(3);
+  `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["exit-listener:3"]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(3);
+  },
+  timeout,
+);
+
+test.concurrent(
+  "fatal uncaught exception does not drain microtasks queued from an 'exit' listener",
+  async () => {
+    // Node drops them on this path too; only natural shutdown drains.
+    const source = `
+    process.on("exit", c => {
+      console.log("exit-listener:" + c);
+      Promise.resolve().then(() => console.log("LEAK-microtask"));
+    });
+    throw new Error("boom");
+  `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["exit-listener:1"]);
+    expect(stderr).toContain("boom");
+    expect(exitCode).toBe(1);
+  },
+  timeout,
+);
+
+test.concurrent(
+  "beforeExit listener that rejects the TLA surfaces via uncaughtException (exit 1)",
+  async () => {
+    const source = `
+    let reject;
+    process.on("beforeExit", () => reject(new Error("boom")));
+    await new Promise((_, r) => { reject = r; });
+    console.log("unreachable");
+  `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("");
+    expect(stderr).toContain("boom");
+    expect(stderr).not.toContain("unsettled top-level await");
+    expect(exitCode).toBe(1);
+  },
+  timeout,
+);
+
+test.concurrent(
+  "beforeExit listener that rejects the TLA is swallowed by a user uncaughtException handler",
+  async () => {
+    const source = `
+    let reject;
+    process.on("uncaughtException", e => console.log("caught:" + e.message));
+    process.on("beforeExit", () => reject(new Error("boom")));
+    await new Promise((_, r) => { reject = r; });
+  `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.trim()).toBe("caught:boom");
+    expect(stderr).not.toContain("unsettled top-level await");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);

--- a/test/regression/issue/17636.test.ts
+++ b/test/regression/issue/17636.test.ts
@@ -298,6 +298,31 @@ test.concurrent(
 );
 
 test.concurrent(
+  "throw from a post-beforeExit task callback does not drain microtasks queued from an 'exit' listener",
+  async () => {
+    const source = `
+    process.on("beforeExit", () => setImmediate(() => { throw new Error("boom"); }));
+    process.on("exit", c => {
+      console.log("exit-listener:" + c);
+      Promise.resolve().then(() => console.log("LEAK-microtask"));
+    });
+  `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["exit-listener:1"]);
+    expect(stderr).toContain("boom");
+    expect(exitCode).toBe(1);
+  },
+  timeout,
+);
+
+test.concurrent(
   "beforeExit listener that rejects the TLA surfaces via uncaughtException (exit 1)",
   async () => {
     const source = `


### PR DESCRIPTION
Fixes #12694
Fixes #17636
Fixes #12918
Fixes #6592

## Repro

```js
// index.mjs  (package.json: {"type":"module","dependencies":{"@inquirer/prompts":"5.3.0"}})
import { input } from "@inquirer/prompts";
await input({ message: "Enter your name: ", transformer: i => i.trim() });
```

```console
$ bun index.mjs
? Enter your name:   <press Ctrl+C>
# before: process stays alive, 100% CPU
# after:
warn: Detected unsettled top-level await in .../index.mjs
# exit 13, matching Node
```

The stdin-close variant (`echo "" | bun index.mjs`, #17636) is the same hang via a different trigger.

## Root cause

Pressing Ctrl+C in a raw-mode readline prompt delivers byte `0x03` on stdin. readline's `kTtyWrite` maps that to `this.close()` correctly: `input.pause()` runs and `setRawMode(false)` restores the terminal. With stdin paused nothing in the event loop can settle the prompt's top-level `await`, and then three things go wrong compared to Node:

1. **`load_entry_point` busy-spins forever.** It waits on the entry module's evaluation promise via `wait_for_promise`, which loops `tick(); auto_tick();` until the promise settles. With an idle loop `auto_tick` takes the non-blocking `tick_without_idle()` path, so the wait degenerates into a 100% CPU spin. Node instead stops waiting, fires `beforeExit`, and maps the still-pending promise to exit code 13.

2. **`process.emit` overrides are bypassed for `beforeExit`/`exit`.** `signal-exit` (pulled in by inquirer) monkey-patches `process.emit` to observe shutdown and reject the pending prompt. Bun dispatched these two events through the C++ `EventEmitter::emit` on `process->wrapped()` directly, so the override never ran.

3. **Microtasks aren't drained after `'exit'`.** Even once signal-exit rejects the prompt, the `.catch()` is a microtask that never ran before the process died. Node drains once after `'exit'`.

## Fix

- `src/jsc/VirtualMachine.rs`, `load_entry_point`: replace the unconditional `wait_for_promise` with a loop that also breaks when `is_event_loop_alive()` is false, so an idle loop returns to the caller with a still-pending promise instead of spinning. Two new methods (`entry_promise_is_pending`, `report_unsettled_entry_promise`) carry the still-pending / late-rejected handling.
- `src/runtime/cli/run_command.rs`: fold `on_before_exit()` into the drain loop so a `beforeExit` listener that settles the TLA can resume it; after the loop fully drains, `report_unsettled_entry_promise()` warns and sets exit 13 (or surfaces a late rejection via `uncaughtException`).
- `src/jsc/bindings/BunProcess.cpp`, `dispatchExitInternal` / `Process__dispatchOnBeforeExit`: if `process.emit` was replaced as an own property, call that (matching Node). Set `process._exiting` unconditionally.
- `src/runtime/cli/run_command.rs`, after the natural-shutdown `on_exit()`: drain Promise microtasks once so a rejection queued from an `'exit'` listener reaches its handler. Scoped to this one call site so the fatal-uncaught-exception and worker-crash paths keep Node's "drop them" behaviour (guarded by tests).
- `src/jsc/VirtualMachine.rs`, `load_entry_point`: protect the entry promise when returning with it still pending. JSC only roots the load-module promise via its reaction chain while Pending, and the caller ticks (and may GC) before `report_unsettled_entry_promise` reads its status.

| Case | Node | Bun before | Bun after |
|---|---|---|---|
| Ctrl+C at `@inquirer/prompts` prompt | exit 13 | **hang, 100% CPU** | exit 13 |
| `await new Promise(() => {})` | warn + exit 13 | **hang, 100% CPU** | warn + exit 13 |
| `process.exitCode = 42; await new Promise(() => {})` | exit 42, no warn | **hang** | exit 42, no warn |
| `beforeExit` handler settles the TLA | resumes, exit 0 | **hang** | resumes, exit 0 |
| `process.emit = fn` override observes `beforeExit`/`exit` | yes | **no** | yes |
| microtask queued from `'exit'` listener runs | yes | **no** | yes |

## Verification

- `bun bd test test/regression/issue/12694.test.ts`: 2 pass (PTY-driven Ctrl+C via `Bun.Terminal`)
- `bun bd test test/regression/issue/17636.test.ts`: 10 pass
- `USE_SYSTEM_BUN=1 bun test` on both: all fail (timeout / wrong output) on unfixed bun
- Real `@inquirer/prompts@5.3.0` repro under a PTY: exits ~300ms after Ctrl+C with the unsettled-TLA warning
- `bun bd test test/js/node/process/process.test.js -t "beforeExit|exitCode|onExit"`: 26 pass
- `bun bd test test/cli/run/run-eval.test.ts`: 35 pass
- `bun bd test test/js/bun/resolve/{require-esm-transitive-tla,dynamic-import-tla-cycle}.test.ts`: 8 pass
- `bun bd test/js/node/test/parallel/test-process-beforeexit*.js`: pass

## Related

Supersedes #33286 (the focused TLA-only variant of the same fix; this one additionally covers the signal-exit / `process.emit` path the inquirer flow needs). Overlaps with the stale #29196 / #29739 / #29549 / #27215.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 15 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawn.test.ts test/regression/issue/12694.test.ts

<!-- robobun:evidence:end -->