### PR TITLE
napi: skip non-cell values when appending to handle scope

### DIFF
--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -246,8 +246,16 @@ impl NapiHandleScope {
     /// callbacks, as the value must remain alive as long as the handle scope is active, even if the
     /// native module doesn't keep it visible on the stack.
     pub(super) fn append(env: &NapiEnv, value: JSValue) {
-        // SAFETY: env is valid; C++ appends to the current scope (interior mutability).
-        unsafe { NapiHandleScope__append(env.as_mut_ptr(), value.encoded()) }
+        // Only cells need to be kept alive by the handle scope. Non-cell values (numbers,
+        // booleans, null, undefined) are immediate values encoded directly in the JSValue and
+        // cannot be garbage collected, so tracking them wastes memory. This matches the isCell()
+        // check in the C++ toNapi() helper (napi.h). Without this, napi_create_int64 and friends
+        // would grow the handle scope's storage vector for every number returned, which is
+        // significant for native modules that return large arrays of numbers.
+        if value.is_cell() {
+            // SAFETY: env is valid; C++ appends to the current scope (interior mutability).
+            unsafe { NapiHandleScope__append(env.as_mut_ptr(), value.encoded()) }
+        }
     }
 
     /// Move a value from the current handle scope (which must be escapable) to the reserved escape

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -246,12 +246,9 @@ impl NapiHandleScope {
     /// callbacks, as the value must remain alive as long as the handle scope is active, even if the
     /// native module doesn't keep it visible on the stack.
     pub(super) fn append(env: &NapiEnv, value: JSValue) {
-        // Only cells need to be kept alive by the handle scope. Non-cell values (numbers,
-        // booleans, null, undefined) are immediate values encoded directly in the JSValue and
-        // cannot be garbage collected, so tracking them wastes memory. This matches the isCell()
-        // check in the C++ toNapi() helper (napi.h). Without this, napi_create_int64 and friends
-        // would grow the handle scope's storage vector for every number returned, which is
-        // significant for native modules that return large arrays of numbers.
+        // Only cells need to be kept alive by the handle scope. Non-cell immediates (numbers,
+        // booleans, null, undefined) cannot be garbage collected, so tracking them wastes memory.
+        // Matches the isCell() check in C++ toNapi() (napi.h).
         if value.is_cell() {
             // SAFETY: env is valid; C++ appends to the current scope (interior mutability).
             unsafe { NapiHandleScope__append(env.as_mut_ptr(), value.encoded()) }

--- a/test/napi/napi-app/js_test_helpers.cpp
+++ b/test/napi/napi-app/js_test_helpers.cpp
@@ -246,7 +246,8 @@ static napi_value create_many_int64(const Napi::CallbackInfo &info) {
   napi_env env = info.Env();
   uint32_t count;
   NODE_API_CALL(env, napi_get_value_uint32(env, info[0], &count));
-  napi_value element = nullptr;
+  napi_value element;
+  NODE_API_CALL(env, napi_get_undefined(env, &element));
   for (uint32_t i = 0; i < count; i++) {
     // Use a value outside the int32 range so it is encoded as a double in the
     // JSValue rather than an int32. This matches what rrule-rust produces

--- a/test/napi/napi-app/js_test_helpers.cpp
+++ b/test/napi/napi-app/js_test_helpers.cpp
@@ -236,6 +236,26 @@ static napi_value make_empty_array(const Napi::CallbackInfo &info) {
   return array;
 }
 
+// Calls napi_create_int64 `count` times inside a single native call the same
+// way napi-rs does when materialising a Vec<i64>. Used to verify that
+// creating many non-cell primitive values does not bloat the handle scope's
+// backing storage. Returns the final value so the loop cannot be optimised
+// away.
+// https://github.com/oven-sh/bun/issues/15055
+static napi_value create_many_int64(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  uint32_t count;
+  NODE_API_CALL(env, napi_get_value_uint32(env, info[0], &count));
+  napi_value element = nullptr;
+  for (uint32_t i = 0; i < count; i++) {
+    // Use a value outside the int32 range so it is encoded as a double in the
+    // JSValue rather than an int32. This matches what rrule-rust produces
+    // (packed datetimes like 20000101000001).
+    NODE_API_CALL(env, napi_create_int64(env, 20000000000000LL + i, &element));
+  }
+  return element;
+}
+
 static napi_value make_empty_object(const Napi::CallbackInfo &info) {
   napi_env env = info.Env();
   napi_value object;
@@ -431,6 +451,7 @@ void register_js_test_helpers(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, throw_error);
   REGISTER_FUNCTION(env, exports, create_and_throw_error);
   REGISTER_FUNCTION(env, exports, make_empty_array);
+  REGISTER_FUNCTION(env, exports, create_many_int64);
   REGISTER_FUNCTION(env, exports, make_empty_object);
   REGISTER_FUNCTION(env, exports, add_tag);
   REGISTER_FUNCTION(env, exports, try_add_tag);

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -741,6 +741,59 @@ nativeTests.test_reference_unref_in_finalizer_experimental = async gc => {
   throw new Error("Test FAILED: napi_reference_unref should have aborted for experimental module");
 };
 
+// https://github.com/oven-sh/bun/issues/15055
+//
+// Non-cell primitives (numbers, booleans, null, undefined) created by Zig-side
+// napi functions like napi_create_int64 were being appended to the handle
+// scope's storage vector even though they cannot be garbage collected. Native
+// modules that return large arrays of numbers (e.g. rrule-rust's between()
+// which returns ~500k packed datetimes) would grow the handle scope by several
+// MB per call. The GC does not know about that extra memory, so handle scopes
+// would accumulate until a full sweep ran.
+//
+// Prints "PASS" if RSS growth across the hot loop stays under the budget.
+// Exit code is 0 in both cases so the test harness compares stdout instead of
+// relying on a crash.
+nativeTests.test_napi_handle_scope_int64_does_not_bloat = async () => {
+  const count = 250_000;
+  const iterations = 30;
+  // Without the fix each call leaves ~count*8 bytes (~2 MB) of handle-scope
+  // storage behind, so 30 iterations is ~60 MB of retained vector storage.
+  // With the fix the handle scope never spills past its inline capacity and
+  // RSS stays flat. 20 MB sits comfortably between "fixed" (~0 MB) and
+  // "broken" (~50 MB) while leaving slack for allocator noise.
+  const budgetMB = 20;
+
+  const gc = () => {
+    if (typeof Bun === "object") Bun.gc(true);
+    else global.gc();
+  };
+  const rssMB = () => process.memoryUsage.rss() / 1024 / 1024;
+
+  // Sanity check the native helper once.
+  const sample = nativeTests.create_many_int64(4);
+  assert(sample === 20000000000003, `unexpected return value ${sample}`);
+
+  // Warm up so the baseline includes any one-time heap growth.
+  for (let i = 0; i < 3; i++) nativeTests.create_many_int64(count);
+  gc();
+  await new Promise(resolve => setTimeout(resolve, 0));
+  gc();
+
+  const baseline = rssMB();
+  for (let i = 0; i < iterations; i++) {
+    nativeTests.create_many_int64(count);
+  }
+  const after = rssMB();
+
+  const delta = after - baseline;
+  if (delta > budgetMB) {
+    console.log(`FAIL: RSS grew ${delta.toFixed(1)} MB (baseline ${baseline.toFixed(1)} -> ${after.toFixed(1)}); handle scope is retaining non-cell values`);
+  } else {
+    console.log("PASS");
+  }
+};
+
 nativeTests.test_create_bigint_words = () => {
   console.log(nativeTests.create_weird_bigints());
 };

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -743,13 +743,10 @@ nativeTests.test_reference_unref_in_finalizer_experimental = async gc => {
 
 // https://github.com/oven-sh/bun/issues/15055
 //
-// Non-cell primitives (numbers, booleans, null, undefined) created by Zig-side
-// napi functions like napi_create_int64 were being appended to the handle
-// scope's storage vector even though they cannot be garbage collected. Native
-// modules that return large arrays of numbers (e.g. rrule-rust's between()
-// which returns ~500k packed datetimes) would grow the handle scope by several
-// MB per call. The GC does not know about that extra memory, so handle scopes
-// would accumulate until a full sweep ran.
+// Non-cell primitives (numbers, booleans, null, undefined) created by napi
+// functions like napi_create_int64 must not be retained by the handle scope:
+// they cannot be garbage collected, so tracking them only bloats the scope's
+// storage vector (~8 bytes per value) for the lifetime of the native call.
 //
 // Prints "PASS" if RSS growth across the hot loop stays under the budget.
 // Exit code is 0 in both cases so the test harness compares stdout instead of

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -240,11 +240,8 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     });
     it("does not retain non-cell primitives from napi_create_int64", async () => {
       // https://github.com/oven-sh/bun/issues/15055
-      // Calling napi_create_int64 many times in one native call should not
-      // bloat the handle scope's storage vector, since numbers are immediate
-      // values encoded directly in the JSValue and cannot be garbage
-      // collected. Before the fix, every number was appended to the scope's
-      // WTF::Vector and the storage lingered until the scope cell was swept.
+      // Numbers are immediate values that cannot be garbage collected, so creating
+      // many of them in one native call must not bloat the handle scope's storage.
       const result = await checkSameOutput("test_napi_handle_scope_int64_does_not_bloat", []);
       expect(result).toContain("PASS");
     }, 15000);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -238,6 +238,16 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     it("keeps arguments moved off the stack alive", async () => {
       await checkSameOutput("test_napi_handle_scope_many_args", ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]);
     });
+    it("does not retain non-cell primitives from napi_create_int64", async () => {
+      // https://github.com/oven-sh/bun/issues/15055
+      // Calling napi_create_int64 many times in one native call should not
+      // bloat the handle scope's storage vector, since numbers are immediate
+      // values encoded directly in the JSValue and cannot be garbage
+      // collected. Before the fix, every number was appended to the scope's
+      // WTF::Vector and the storage lingered until the scope cell was swept.
+      const result = await checkSameOutput("test_napi_handle_scope_int64_does_not_bloat", []);
+      expect(result).toContain("PASS");
+    }, 15000);
   });
 
   describe("escapable_handle_scope", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes #15055 (memory growth with `rrule-rust` and similar napi-rs modules).

### Repro

```js
import { DateTime, Frequency, RRule, RRuleSet } from 'rrule-rust'; // v2.x

const set = new RRuleSet({
  dtstart: DateTime.utc(2000, 1, 1, 0, 0, 0),
  rrules: [new RRule({ frequency: Frequency.Minutely })],
  tzid: 'UTC',
});
const start = DateTime.utc(2000, 1, 1, 0, 0, 0);
const until = DateTime.utc(2001, 1, 1, 0, 0, 0);

for (let i = 0; i < 100; i++) set.between(start, until, false);
```

Each `between()` call returns ~527 000 `i64` values via `napi_create_int64`. RSS grows by several MB per call and only comes back after a full GC sweep.

### Root cause

`NapiHandleScope::append` (`src/runtime/napi/napi_body.rs`, used by `napi_value.set`/`napi_value.create`, and therefore by `napi_create_int64`, `napi_create_int32`, `napi_create_uint32`, ...) appended **every** returned value to the active handle scope's `WTF::Vector<WriteBarrier<Unknown>>` storage, including numbers, booleans, `null` and `undefined`.

Those are immediate values encoded directly in the `JSValue`; they are never heap-allocated and cannot be collected, so there is nothing for the handle scope to keep alive. The C++ `toNapi()` helper in `napi.h` already guards this with `val.isCell()`, but the Rust/Zig-implemented napi creators did not, so they bloated the scope while C++-implemented ones did not.

For the rrule-rust case, 527 000 `napi_create_int64` calls per native call grow the scope's vector to ~4 MB. The `NapiHandleScopeImpl` cell itself is tiny, and there is no `reportExtraMemoryAllocated` for the vector, so the GC has no pressure to sweep it. Over a hot loop, dozens of scopes accumulate before a sweep runs and RSS climbs.

The hard leak (vector storage never freed at all) was already fixed by #20108, which made `NapiHandleScopeImpl` destructible; this PR removes the wasted allocations in the first place.

### Fix

Add the matching `value.is_cell()` guard to `NapiHandleScope::append` in `src/runtime/napi/napi_body.rs`, mirroring C++ `toNapi()`. After the change, `napi_create_int64` and friends no longer touch the handle scope at all and the scope stays within its 16-slot inline capacity for number-heavy workloads.

(Earlier revisions of this PR also patched the Zig `NapiHandleScope.append` in `napi.zig`; main has since completed the Rust port and deleted that file, so only the Rust change remains.)

### Verification

New test `napi > handle_scope > does not retain non-cell primitives from napi_create_int64` calls `napi_create_int64` 250 000x per native call, 30 times, and asserts RSS growth stays under 20 MB.

| | RSS growth | Result |
|---|---|---|
| Node.js | ~0 MB | PASS |
| Bun (before) | ~56 MB | **FAIL** |
| Bun (after) | ~0 MB | PASS |

Bun 1.1.34 (issue reporter's version) with the rrule-rust repro, 100 iterations with forced GC between each:
- before: **+406 MB** retained
- after: fully recovers

### How did you verify your code works?

- `bun bd test test/napi/napi.test.ts -t "handle_scope"` -> all 8 pass
- `git checkout origin/main -- src/runtime/napi/napi_body.rs && bun bd test ...` -> fails with `RSS grew 55.9 MB`
- `USE_SYSTEM_BUN=1 bun test ...` -> fails (same)
- `cargo fmt --check` -> clean
