### PR TITLE
node:cluster: fix net.Server worker EADDRINUSE and port:0 divergence

### DIFF
--- a/src/js/internal/cluster/RoundRobinHandle.ts
+++ b/src/js/internal/cluster/RoundRobinHandle.ts
@@ -6,6 +6,7 @@ let net;
 const sendHelper = $newRustFunction("node_cluster_binding.rs", "sendHelperPrimary", 4);
 
 const ArrayIsArray = Array.isArray;
+const ObjectAssign = Object.assign;
 
 const UV_TCP_IPV6ONLY = 1;
 const assert_fail = () => {
@@ -31,12 +32,18 @@ export default class RoundRobinHandle {
 
     if (fd >= 0) this.server.listen({ fd, backlog });
     else if (port >= 0) {
+      // Bun: IPC socket-handle passing isn't implemented yet, so the primary
+      // can't forward accepted connections to workers. Instead, workers bind
+      // the same port directly with SO_REUSEPORT (see net.ts
+      // listenOnPrimaryHandle). Bind with reusePort here too so workers can
+      // share the port while the primary resolves `port: 0`.
       this.server.listen({
         port,
         host: address,
         // Currently, net module only supports `ipv6Only` option in `flags`.
         ipv6Only: !!(flags & UV_TCP_IPV6ONLY),
         backlog,
+        reusePort: true,
       });
     } else
       this.server.listen({
@@ -46,10 +53,30 @@ export default class RoundRobinHandle {
         writableAll,
       }); // UNIX socket path.
     this.server.once("listening", () => {
-      this.handle = this.server._handle;
-      this.handle.onconnection = (err, handle) => this.distribute(err, handle);
+      const listener = this.server._handle;
       this.server._handle = null;
       this.server = null;
+      if (port >= 0) {
+        // Bun: cache the resolved sockname and stop accepting. Workers bind
+        // with SO_REUSEPORT and take all traffic; keeping the primary
+        // listening would steal ~1/(N+1) connections it cannot forward.
+        const sockname = {};
+        if (typeof listener.getsockname === "function") {
+          listener.getsockname(sockname);
+        }
+        this.handle = {
+          getsockname: out => {
+            ObjectAssign(out, sockname);
+            return 0;
+          },
+          stop: () => {},
+          close: () => {},
+        };
+        listener.stop?.();
+      } else {
+        this.handle = listener;
+        this.handle.onconnection = (err, handle) => this.distribute(err, handle);
+      }
     });
   }
 

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3604,13 +3604,26 @@ function listenInCluster(
     if (err) {
       throw new ExceptionWithHostPort(err, "bind", address, port);
     }
+    // Bun: IPC socket-handle passing isn't implemented yet, so the primary
+    // can't distribute accepted connections to workers (RoundRobinHandle is
+    // a stub). Instead, bind directly in the worker with SO_REUSEPORT so the
+    // kernel load-balances across workers. Use the port the primary resolved
+    // so that `port: 0` maps every worker to the same concrete port rather
+    // than N independent random ports.
+    let actualPort = port;
+    if (handle && typeof handle.getsockname === "function") {
+      const out: { port?: number } = {};
+      handle.getsockname(out);
+      const { port: resolvedPort } = out;
+      if (typeof resolvedPort === "number") actualPort = resolvedPort;
+    }
     server[kRealListen](
       path,
-      port,
+      actualPort,
       hostname,
       exclusive,
       ipv6Only,
-      reusePort,
+      true /* reusePort */,
       readableAll,
       writableAll,
       tls,

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -187,6 +187,8 @@ test("disconnect() on a cluster.Worker built around a plain object does not abor
 });
 
 // https://github.com/oven-sh/bun/issues/14727
+// Each test spawns a primary that forks two workers: three debug+ASAN bun
+// processes, so the default 5s per-test budget is not enough.
 describe("net.Server in cluster worker", () => {
   test("workers listening on port: 0 agree on a single port", async () => {
     // Previously each worker would bind its own random port because the
@@ -241,17 +243,19 @@ if (cluster.isPrimary) {
     expect(result.ports).toHaveLength(2);
     expect(result.ports[0]).toBe(result.ports[1]);
     expect(exitCode).toBe(0);
-  });
+  }, 20_000);
 
   // SO_REUSEPORT load-balancing only works on Linux; on other platforms
   // multiple workers still bind but one socket wins. The important part
   // (no EADDRINUSE crash) is covered by the port: 0 test above.
-  test.skipIf(!isLinux)("workers listening on a fixed port share it without EADDRINUSE", async () => {
-    // Previously the primary's RoundRobinHandle bound the port exclusively
-    // and the worker's own Bun.listen() on the same port failed with
-    // "Failed to listen at ::".
-    using dir = tempDir("cluster-net-fixed-port", {
-      "index.ts": `
+  test.skipIf(!isLinux)(
+    "workers listening on a fixed port share it without EADDRINUSE",
+    async () => {
+      // Previously the primary's RoundRobinHandle bound the port exclusively
+      // and the worker's own Bun.listen() on the same port failed with
+      // "Failed to listen at ::".
+      using dir = tempDir("cluster-net-fixed-port", {
+        "index.ts": `
 import cluster from "node:cluster";
 import net from "node:net";
 
@@ -278,9 +282,11 @@ if (cluster.isPrimary) {
           if (msg === "listening") {
             ready++;
             if (ready === 2) {
-              // Make several connections; SO_REUSEPORT should distribute them.
+              // Make enough connections that SO_REUSEPORT hashing is
+              // effectively guaranteed to hit both workers (P(all-same)
+              // with 64 conns and 2 listeners is ~1e-19).
               let done = 0;
-              const total = 16;
+              const total = 64;
               for (let j = 0; j < total; j++) {
                 const c = net.connect(port, "127.0.0.1");
                 c.on("data", (d) => {
@@ -315,20 +321,22 @@ if (cluster.isPrimary) {
   });
 }
 `,
-    });
+      });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "index.ts"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    const result = JSON.parse(stdout.trim());
-    // Both workers should have handled at least one connection.
-    expect(result.responders).toEqual(["worker-1", "worker-2"]);
-    expect(exitCode).toBe(0);
-  });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "index.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      const result = JSON.parse(stdout.trim());
+      // Both workers should have handled at least one connection.
+      expect(result.responders).toEqual(["worker-1", "worker-2"]);
+      expect(exitCode).toBe(0);
+    },
+    20_000,
+  );
 });

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, bunRun, joinP, tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, bunRun, isLinux, joinP, tempDir, tempDirWithFiles } from "harness";
 
 test("cloneable and transferable equals", () => {
   const dir = tempDirWithFiles("bun-test", {
@@ -184,4 +184,151 @@ test("disconnect() on a cluster.Worker built around a plain object does not abor
   });
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
   expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "returned self: true", exitCode: 0 });
+});
+
+// https://github.com/oven-sh/bun/issues/14727
+describe("net.Server in cluster worker", () => {
+  test("workers listening on port: 0 agree on a single port", async () => {
+    // Previously each worker would bind its own random port because the
+    // worker ignored the primary's resolved sockname and called Bun.listen()
+    // with the original port: 0.
+    using dir = tempDir("cluster-net-port0", {
+      "index.ts": `
+import cluster from "node:cluster";
+import net from "node:net";
+
+if (cluster.isPrimary) {
+  const ports: number[] = [];
+  for (let i = 0; i < 2; i++) {
+    const w = cluster.fork();
+    w.on("message", (msg) => {
+      if (typeof msg?.port === "number") {
+        ports.push(msg.port);
+        if (ports.length === 2) {
+          for (const worker of Object.values(cluster.workers!)) worker!.kill();
+          console.log(JSON.stringify({ ports, same: ports[0] === ports[1] }));
+          process.exit(ports[0] === ports[1] ? 0 : 1);
+        }
+      }
+    });
+    w.on("exit", (code) => {
+      if (code !== 0 && code !== null) process.exit(code);
+    });
+  }
+} else {
+  const server = net.createServer(() => {});
+  server.on("error", (err) => {
+    console.error("worker listen error:", err.message);
+    process.exit(1);
+  });
+  server.listen(0, () => {
+    process.send!({ port: server.address().port });
+  });
+}
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const result = JSON.parse(stdout.trim());
+    expect(result.ports).toHaveLength(2);
+    expect(result.ports[0]).toBe(result.ports[1]);
+    expect(exitCode).toBe(0);
+  });
+
+  // SO_REUSEPORT load-balancing only works on Linux; on other platforms
+  // multiple workers still bind but one socket wins. The important part
+  // (no EADDRINUSE crash) is covered by the port: 0 test above.
+  test.skipIf(!isLinux)("workers listening on a fixed port share it without EADDRINUSE", async () => {
+    // Previously the primary's RoundRobinHandle bound the port exclusively
+    // and the worker's own Bun.listen() on the same port failed with
+    // "Failed to listen at ::".
+    using dir = tempDir("cluster-net-fixed-port", {
+      "index.ts": `
+import cluster from "node:cluster";
+import net from "node:net";
+
+if (cluster.isPrimary) {
+  // Reserve a free port for the workers to share.
+  const probe = net.createServer().listen(0, () => {
+    const port = probe.address().port;
+    probe.close(() => {
+      let ready = 0;
+      const responders = new Set<string>();
+      const workers: import("node:cluster").Worker[] = [];
+      const finish = (code: number) => {
+        for (const w of workers) w.kill();
+        console.log(JSON.stringify({ responders: [...responders].sort() }));
+        process.exit(code);
+      };
+      for (let i = 0; i < 2; i++) {
+        const w = cluster.fork({ PORT: String(port) });
+        workers.push(w);
+        w.on("exit", (code) => {
+          if (code !== 0 && code !== null) process.exit(code);
+        });
+        w.on("message", (msg) => {
+          if (msg === "listening") {
+            ready++;
+            if (ready === 2) {
+              // Make several connections; SO_REUSEPORT should distribute them.
+              let done = 0;
+              const total = 16;
+              for (let j = 0; j < total; j++) {
+                const c = net.connect(port, "127.0.0.1");
+                c.on("data", (d) => {
+                  responders.add(d.toString().trim());
+                  c.end();
+                });
+                c.on("close", () => {
+                  done++;
+                  if (done === total) finish(0);
+                });
+                c.on("error", (err) => {
+                  console.error("connect error:", err.message);
+                  finish(1);
+                });
+              }
+            }
+          }
+        });
+      }
+    });
+  });
+} else {
+  const server = net.createServer((socket) => {
+    socket.end("worker-" + cluster.worker!.id);
+  });
+  server.on("error", (err) => {
+    console.error("worker listen error:", err.message);
+    process.exit(1);
+  });
+  server.listen(Number(process.env.PORT), () => {
+    process.send!("listening");
+  });
+}
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const result = JSON.parse(stdout.trim());
+    // Both workers should have handled at least one connection.
+    expect(result.responders).toEqual(["worker-1", "worker-2"]);
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
## Reproduction

```js
import cluster from "node:cluster";
import net from "node:net";

if (cluster.isPrimary) {
  for (let i = 0; i < 2; i++) cluster.fork();
} else {
  net.createServer(s => s.end("hi")).listen(19999);
}
```

Every worker crashes:

```
error: Failed to listen at ::
      at listenOnPrimaryHandle (node:net:1441:24)
      at rr (internal:cluster/child:100:31)
```

With `listen(0)` there's no crash, but each worker binds a *different* random port — the "cluster" is N independent servers. Node.js binds all workers to a single port in both cases.

## Root cause

`listenInCluster` in `node:net` calls `cluster._getServer`, which makes the primary bind the port via `RoundRobinHandle`. The callback then *also* calls `server[kRealListen]` → `Bun.listen({ port })` in the worker, ignoring the faux handle it was given. With a fixed port the primary already holds it exclusively, so the worker's bind fails; with `port: 0` the worker just picks an unrelated port.

In Node.js the worker would adopt the faux handle as `server._handle` and never bind — the primary accepts connections and hands them to workers via IPC. Bun can't do that yet: `sendHelperPrimary` in `node_cluster_binding.zig` discards the handle argument, and `Ipc.ts`'s `serialize()`/`parseHandle()` don't support `net.Socket`. So the primary's `RoundRobinHandle` listener was dead weight that only served to block the port.

## Fix

Treat `RoundRobinHandle` as a port resolver until IPC handle-passing lands:

- **`RoundRobinHandle.ts`**: for TCP, bind with `reusePort: true` so workers can share the port; once `'listening'` fires, cache the resolved sockname and stop accepting — otherwise the primary would swallow ~1/(N+1) of the connections it has no way to forward.
- **`net.ts` `listenOnPrimaryHandle`**: read the port the primary resolved from the faux handle's `getsockname()` and pass it to `kRealListen` with `reusePort: true`. All workers now bind the same port via `SO_REUSEPORT` and the kernel load-balances between them — the same approach `_http_server.ts` already uses for `http.createServer()` in a cluster worker.

Unix-socket and fd listens are unchanged.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/node/cluster.test.ts -t "net.Server in cluster worker"
  → 2 fail (ports differ / "Failed to listen at ::")
bun bd test test/js/node/cluster.test.ts -t "net.Server in cluster worker"
  → 2 pass
```

All `test/js/node/test/parallel/test-cluster-*.js` continue to pass.

Related to #14727 (the Windows half of that issue — `SO_REUSEPORT` not load-balancing on Windows — is a documented OS limitation in `docs/guides/http/cluster.mdx` and out of scope here; this fixes the `net.Server` + cluster path on platforms where `SO_REUSEPORT` works).

Fixes #17762
