### PR TITLE
Fix capacity miscalculation in ESMConditions.init

### DIFF
--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1087,9 +1087,10 @@ pub const ESMConditions = struct {
         var require_condition_map = ConditionsMap.init(allocator);
         var style_condition_map = ConditionsMap.init(allocator);
 
-        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
+        const addons_count: usize = if (allow_addons) 1 else 0;
+        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + addons_count + conditions.len);
+        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + addons_count + conditions.len);
+        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + addons_count + conditions.len);
         try style_condition_map.ensureTotalCapacity(defaults.len + 2 + conditions.len);
 
         import_condition_map.putAssumeCapacity("import", {});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -682,6 +682,20 @@ export function testMacro(val: any) {
   );
 });
 
+test.concurrent("Bun.build does not crash with many conditions", async () => {
+  const dir = tempDirWithFilesAnon({
+    "entry.js": `console.log("hi");`,
+  });
+  for (let n = 0; n <= 16; n++) {
+    const conditions = Array.from({ length: n }, (_, i) => `cond${i}`);
+    const result = await Bun.build({
+      entrypoints: [join(dir, "entry.js")],
+      conditions,
+    });
+    expect(result.success).toBe(true);
+  }
+});
+
 // Since NODE_PATH has to be set, we need to run this test outside the bundler tests.
 test.concurrent("regression/NODE_PATHBuild api", async () => {
   const dir = tempDirWithFiles("node-path-build", {


### PR DESCRIPTION
## What does this PR do?

Fixes a debug assert / potential OOB write in `Bun.build()` / `bun build` when passing several entries in `conditions`.

In `ESMConditions.init`:

```zig
try import_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
```

Zig parses `if (allow_addons) 1 else 0 + conditions.len` as `if (allow_addons) 1 else (0 + conditions.len)`. Since `allow_addons` defaults to `true`, `conditions.len` was effectively dropped from the reserved capacity for the default/import/require condition maps. With enough user-supplied conditions (≥4 for `target: "bun"`), `putAssumeCapacity` overflows the backing array.

Repro:
```js
await Bun.build({
  entrypoints: ["./entry.js"],
  conditions: ["a", "b", "c", "d", "e", "f", "g", "h"],
});
```

## How did you verify your code works?

Added a regression test in `test/bundler/bun-build-api.test.ts` that builds with 0–16 conditions. Verified it crashes on main and passes with this fix.

<sup>fuzzer</sup>