### PR TITLE
bundler: fix capacity under-reservation in ESMConditions.init

### DIFF
--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1087,9 +1087,10 @@ pub const ESMConditions = struct {
         var require_condition_map = ConditionsMap.init(allocator);
         var style_condition_map = ConditionsMap.init(allocator);
 
-        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
+        const addons_count: usize = if (allow_addons) 1 else 0;
+        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + addons_count + conditions.len);
+        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + addons_count + conditions.len);
+        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + addons_count + conditions.len);
         try style_condition_map.ensureTotalCapacity(defaults.len + 2 + conditions.len);
 
         import_condition_map.putAssumeCapacity("import", {});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -178,6 +178,18 @@ describe("Bun.build", () => {
     Bun.gc(true);
   });
 
+  test("many user conditions does not crash", async () => {
+    const conditions = Array.from({ length: 20 }, (_, i) => "cond" + i);
+    for (const target of ["bun", "node", "browser"] as const) {
+      const build = await Bun.build({
+        entrypoints: [join(import.meta.dir, "./fixtures/trivial/index.js")],
+        target,
+        conditions,
+      });
+      expect(build.success).toBe(true);
+    }
+  });
+
   test("Bun.write(BuildArtifact)", async () => {
     Bun.gc(true);
     const tmpdir = tempDirWithFiles("bun-build-api-write", {


### PR DESCRIPTION
Fuzzer found an assertion failure in `ESMConditions.init` when `Bun.build` is called with enough user `conditions`.

## Root cause

```zig
try import_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
```

In Zig, the `else` branch of an `if` expression consumes a full expression, so this parses as:

```zig
defaults.len + 2 + (if (allow_addons) 1 else (0 + conditions.len))
```

When `allow_addons` is true (the default), `conditions.len` is dropped from the reserved capacity. The subsequent `putAssumeCapacity` calls then overflow the reserved entries and trip `assert(self.len < self.capacity)` in `MultiArrayList.addOneAssumeCapacity`.

It usually didn't crash because `ensureTotalCapacity` rounds up, but with ~6+ user conditions it overflows the rounded capacity.

## Fix

Hoist the addon count into a local so the arithmetic is unambiguous.

Fingerprint: `3d29001f2932bffc`