### PR TITLE
Watch files handled by runtime plugin onLoad

### DIFF
--- a/src/jsc/ModuleLoader.zig
+++ b/src/jsc/ModuleLoader.zig
@@ -1119,9 +1119,27 @@ pub export fn Bun__transpileFile(
     return promise;
 }
 
+/// When a runtime plugin's onLoad handler matches a file, the normal transpile
+/// path (which is what registers the file with the watcher) is bypassed — the
+/// source text comes from the plugin, so the transpiler never opens the file
+/// and `input_file_fd` stays invalid. This helper ensures the underlying
+/// on-disk file still ends up in the watch list so that editing it triggers a
+/// reload, regardless of whether the plugin succeeded or threw.
+fn addPluginHandledPathToWatcher(jsc_vm: *VirtualMachine, namespace: []const u8, path: []const u8) void {
+    if (!jsc_vm.isWatcherEnabled()) return;
+    // Only watch real files in the default/"file" namespace. Virtual
+    // namespaces (e.g. "my-plugin:foo") have no on-disk backing file.
+    if (namespace.len > 0 and !strings.eqlComptime(namespace, "file")) return;
+    if (!std.fs.path.isAbsolute(path)) return;
+    if (strings.contains(path, "node_modules")) return;
+    const loader = jsc_vm.transpiler.options.loader(std.fs.path.extension(path));
+    _ = jsc_vm.bun_watcher.addFileByPathSlow(path, loader);
+}
+
 export fn Bun__runVirtualModule(globalObject: *JSGlobalObject, specifier_ptr: *const bun.String) JSValue {
     jsc.markBinding(@src());
-    if (globalObject.bunVM().plugin_runner == null) return JSValue.zero;
+    const jsc_vm = globalObject.bunVM();
+    if (jsc_vm.plugin_runner == null) return JSValue.zero;
 
     const specifier_slice = specifier_ptr.toUTF8(bun.default_allocator);
     defer specifier_slice.deinit();
@@ -1137,9 +1155,22 @@ export fn Bun__runVirtualModule(globalObject: *JSGlobalObject, specifier_ptr: *c
     else
         specifier[@min(namespace.len + 1, specifier.len)..];
 
-    return globalObject.runOnLoadPlugins(bun.String.init(namespace), bun.String.init(after_namespace), .bun) catch {
+    const result = globalObject.runOnLoadPlugins(bun.String.init(namespace), bun.String.init(after_namespace), .bun) catch {
+        // A plugin matched and threw. The file still needs to be watched so
+        // fixing the underlying source triggers a reload.
+        addPluginHandledPathToWatcher(jsc_vm, namespace, after_namespace);
         return JSValue.zero;
-    } orelse return .zero;
+    } orelse {
+        // No plugin matched — fall through to the normal transpile path,
+        // which handles the watcher itself.
+        return .zero;
+    };
+
+    // A plugin matched and returned a result (source text, an object, or a
+    // promise). The normal transpile path will be bypassed, so register the
+    // file here.
+    addPluginHandledPathToWatcher(jsc_vm, namespace, after_namespace);
+    return result;
 }
 
 fn getHardcodedModule(jsc_vm: *VirtualMachine, specifier: bun.String, hardcoded: HardcodedModule) ?ResolvedSource {

--- a/test/regression/issue/17270.test.ts
+++ b/test/regression/issue/17270.test.ts
@@ -71,7 +71,7 @@ describe.todoIf(isBroken && isWindows)(
 
       proc.kill();
       await proc.exited;
-    });
+    }, 15000);
 
     test("after onLoad succeeds", async () => {
       using dir = tempDir("watch-plugin-ok", {
@@ -106,6 +106,6 @@ describe.todoIf(isBroken && isWindows)(
 
       proc.kill();
       await proc.exited;
-    });
+    }, 15000);
   },
 );

--- a/test/regression/issue/17270.test.ts
+++ b/test/regression/issue/17270.test.ts
@@ -1,0 +1,108 @@
+// https://github.com/oven-sh/bun/issues/17270
+// `--watch` stops watching a file once a runtime plugin's onLoad handler
+// matches it, because the normal transpile path (which registers the file
+// with the watcher) is bypassed.
+import { spawn } from "bun";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, forEachLine, isBroken, isWindows, tempDir } from "harness";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const plugin = `
+import { plugin, file } from "bun";
+
+await plugin({
+  name: "repro",
+  setup(builder) {
+    builder.onLoad({ filter: /foo\\.js$/ }, async ({ path }) => {
+      const contents = await file(path).text();
+      if (contents.includes("BAD")) {
+        console.log("PLUGIN-ERROR");
+        throw new Error("bad contents in " + path);
+      }
+      return { contents, loader: "js" };
+    });
+  },
+});
+`;
+
+async function nextMatching(iter: AsyncGenerator<string>, needle: string) {
+  // Manual .next() — `for await` would call .return() on early exit and
+  // close the generator, but we need to keep reading across multiple calls.
+  while (true) {
+    const { value, done } = await iter.next();
+    if (done) throw new Error(`stream ended before seeing ${JSON.stringify(needle)}`);
+    if (value.includes(needle)) return value;
+  }
+}
+
+describe.todoIf(isBroken && isWindows)("issue #17270: --watch keeps watching files handled by runtime plugin onLoad", () => {
+  test("after onLoad throws", async () => {
+    using dir = tempDir("watch-plugin-throw", {
+      "bunfig.toml": `preload = ["./plugin.js"]\n`,
+      "plugin.js": plugin,
+      "entry.js": `import "./foo.js";\n`,
+      "foo.js": `BAD; console.log("hello v1");\n`,
+    });
+    const fooPath = join(String(dir), "foo.js");
+
+    await using proc = spawn({
+      cmd: [bunExe(), "--watch", "entry.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const iter = forEachLine(proc.stdout);
+
+    // First run: plugin throws, emits PLUGIN-ERROR on stdout before throwing.
+    expect(await nextMatching(iter, "PLUGIN-ERROR")).toContain("PLUGIN-ERROR");
+
+    // Fix the file. The watcher should pick this up and reload.
+    writeFileSync(fooPath, `console.log("hello v2");\n`);
+    expect(await nextMatching(iter, "hello v2")).toContain("hello v2");
+
+    // Subsequent edits to a plugin-handled file that previously succeeded
+    // must also be picked up.
+    writeFileSync(fooPath, `console.log("hello v3");\n`);
+    expect(await nextMatching(iter, "hello v3")).toContain("hello v3");
+
+    proc.kill();
+    await proc.exited;
+  });
+
+  test("after onLoad succeeds", async () => {
+    using dir = tempDir("watch-plugin-ok", {
+      "bunfig.toml": `preload = ["./plugin.js"]\n`,
+      "plugin.js": plugin,
+      "entry.js": `import "./foo.js";\n`,
+      "foo.js": `console.log("hello v1");\n`,
+    });
+    const fooPath = join(String(dir), "foo.js");
+
+    await using proc = spawn({
+      cmd: [bunExe(), "--watch", "entry.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const iter = forEachLine(proc.stdout);
+
+    expect(await nextMatching(iter, "hello v1")).toContain("hello v1");
+
+    writeFileSync(fooPath, `console.log("hello v2");\n`);
+    expect(await nextMatching(iter, "hello v2")).toContain("hello v2");
+
+    // Break it — the plugin should throw, and the watcher must keep
+    // tracking foo.js so that fixing it reloads again.
+    writeFileSync(fooPath, `BAD; console.log("hello v3");\n`);
+    expect(await nextMatching(iter, "PLUGIN-ERROR")).toContain("PLUGIN-ERROR");
+
+    writeFileSync(fooPath, `console.log("hello v4");\n`);
+    expect(await nextMatching(iter, "hello v4")).toContain("hello v4");
+
+    proc.kill();
+    await proc.exited;
+  });
+});

--- a/test/regression/issue/17270.test.ts
+++ b/test/regression/issue/17270.test.ts
@@ -36,73 +36,76 @@ async function nextMatching(iter: AsyncGenerator<string>, needle: string) {
   }
 }
 
-describe.todoIf(isBroken && isWindows)("issue #17270: --watch keeps watching files handled by runtime plugin onLoad", () => {
-  test("after onLoad throws", async () => {
-    using dir = tempDir("watch-plugin-throw", {
-      "bunfig.toml": `preload = ["./plugin.js"]\n`,
-      "plugin.js": plugin,
-      "entry.js": `import "./foo.js";\n`,
-      "foo.js": `BAD; console.log("hello v1");\n`,
-    });
-    const fooPath = join(String(dir), "foo.js");
+describe.todoIf(isBroken && isWindows)(
+  "issue #17270: --watch keeps watching files handled by runtime plugin onLoad",
+  () => {
+    test("after onLoad throws", async () => {
+      using dir = tempDir("watch-plugin-throw", {
+        "bunfig.toml": `preload = ["./plugin.js"]\n`,
+        "plugin.js": plugin,
+        "entry.js": `import "./foo.js";\n`,
+        "foo.js": `BAD; console.log("hello v1");\n`,
+      });
+      const fooPath = join(String(dir), "foo.js");
 
-    await using proc = spawn({
-      cmd: [bunExe(), "--watch", "entry.js"],
-      cwd: String(dir),
-      env: bunEnv,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+      await using proc = spawn({
+        cmd: [bunExe(), "--watch", "entry.js"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
 
-    const iter = forEachLine(proc.stdout);
+      const iter = forEachLine(proc.stdout);
 
-    // First run: plugin throws, emits PLUGIN-ERROR on stdout before throwing.
-    expect(await nextMatching(iter, "PLUGIN-ERROR")).toContain("PLUGIN-ERROR");
+      // First run: plugin throws, emits PLUGIN-ERROR on stdout before throwing.
+      expect(await nextMatching(iter, "PLUGIN-ERROR")).toContain("PLUGIN-ERROR");
 
-    // Fix the file. The watcher should pick this up and reload.
-    writeFileSync(fooPath, `console.log("hello v2");\n`);
-    expect(await nextMatching(iter, "hello v2")).toContain("hello v2");
+      // Fix the file. The watcher should pick this up and reload.
+      writeFileSync(fooPath, `console.log("hello v2");\n`);
+      expect(await nextMatching(iter, "hello v2")).toContain("hello v2");
 
-    // Subsequent edits to a plugin-handled file that previously succeeded
-    // must also be picked up.
-    writeFileSync(fooPath, `console.log("hello v3");\n`);
-    expect(await nextMatching(iter, "hello v3")).toContain("hello v3");
+      // Subsequent edits to a plugin-handled file that previously succeeded
+      // must also be picked up.
+      writeFileSync(fooPath, `console.log("hello v3");\n`);
+      expect(await nextMatching(iter, "hello v3")).toContain("hello v3");
 
-    proc.kill();
-    await proc.exited;
-  });
-
-  test("after onLoad succeeds", async () => {
-    using dir = tempDir("watch-plugin-ok", {
-      "bunfig.toml": `preload = ["./plugin.js"]\n`,
-      "plugin.js": plugin,
-      "entry.js": `import "./foo.js";\n`,
-      "foo.js": `console.log("hello v1");\n`,
-    });
-    const fooPath = join(String(dir), "foo.js");
-
-    await using proc = spawn({
-      cmd: [bunExe(), "--watch", "entry.js"],
-      cwd: String(dir),
-      env: bunEnv,
-      stdio: ["ignore", "pipe", "pipe"],
+      proc.kill();
+      await proc.exited;
     });
 
-    const iter = forEachLine(proc.stdout);
+    test("after onLoad succeeds", async () => {
+      using dir = tempDir("watch-plugin-ok", {
+        "bunfig.toml": `preload = ["./plugin.js"]\n`,
+        "plugin.js": plugin,
+        "entry.js": `import "./foo.js";\n`,
+        "foo.js": `console.log("hello v1");\n`,
+      });
+      const fooPath = join(String(dir), "foo.js");
 
-    expect(await nextMatching(iter, "hello v1")).toContain("hello v1");
+      await using proc = spawn({
+        cmd: [bunExe(), "--watch", "entry.js"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
 
-    writeFileSync(fooPath, `console.log("hello v2");\n`);
-    expect(await nextMatching(iter, "hello v2")).toContain("hello v2");
+      const iter = forEachLine(proc.stdout);
 
-    // Break it — the plugin should throw, and the watcher must keep
-    // tracking foo.js so that fixing it reloads again.
-    writeFileSync(fooPath, `BAD; console.log("hello v3");\n`);
-    expect(await nextMatching(iter, "PLUGIN-ERROR")).toContain("PLUGIN-ERROR");
+      expect(await nextMatching(iter, "hello v1")).toContain("hello v1");
 
-    writeFileSync(fooPath, `console.log("hello v4");\n`);
-    expect(await nextMatching(iter, "hello v4")).toContain("hello v4");
+      writeFileSync(fooPath, `console.log("hello v2");\n`);
+      expect(await nextMatching(iter, "hello v2")).toContain("hello v2");
 
-    proc.kill();
-    await proc.exited;
-  });
-});
+      // Break it — the plugin should throw, and the watcher must keep
+      // tracking foo.js so that fixing it reloads again.
+      writeFileSync(fooPath, `BAD; console.log("hello v3");\n`);
+      expect(await nextMatching(iter, "PLUGIN-ERROR")).toContain("PLUGIN-ERROR");
+
+      writeFileSync(fooPath, `console.log("hello v4");\n`);
+      expect(await nextMatching(iter, "hello v4")).toContain("hello v4");
+
+      proc.kill();
+      await proc.exited;
+    });
+  },
+);

--- a/test/regression/issue/17270.test.ts
+++ b/test/regression/issue/17270.test.ts
@@ -52,7 +52,7 @@ describe.todoIf(isBroken && isWindows)(
         cmd: [bunExe(), "--watch", "entry.js"],
         cwd: String(dir),
         env: bunEnv,
-        stdio: ["ignore", "pipe", "pipe"],
+        stdio: ["ignore", "pipe", "inherit"],
       });
 
       const iter = forEachLine(proc.stdout);
@@ -86,7 +86,7 @@ describe.todoIf(isBroken && isWindows)(
         cmd: [bunExe(), "--watch", "entry.js"],
         cwd: String(dir),
         env: bunEnv,
-        stdio: ["ignore", "pipe", "pipe"],
+        stdio: ["ignore", "pipe", "inherit"],
       });
 
       const iter = forEachLine(proc.stdout);


### PR DESCRIPTION
## What does this PR do?

Fixes #17270
Fixes #19496
Fixes #5844
Fixes #4790
Fixes #5431

When a runtime plugin's `onLoad` handler matches an imported file under `--watch` / `--hot`, edits to that file never trigger a reload. This happens both when the plugin throws (the reported case — e.g. a transpiler plugin hitting a parse error) **and** when it succeeds.

### Repro

```toml
# bunfig.toml
preload = ["./plugin.js"]
```
```js
// plugin.js
import { plugin, file } from "bun";
await plugin({
  name: "repro",
  setup(b) {
    b.onLoad({ filter: /foo\.js$/ }, async ({ path }) => {
      const contents = await file(path).text();
      if (contents.includes("BAD")) throw new Error("bad");
      return { contents, loader: "js" };
    });
  },
});
```
```js
// entry.js
import "./foo.js";
```
```sh
bun --watch entry.js
# edit foo.js → nothing happens
```

### Cause

The watcher is populated inside `transpileSourceCode` after the transpiler opens the source file (`input_file_fd`). When a plugin's `onLoad` matches, `Bun__runVirtualModule` returns the plugin result and the C++ side either rejects immediately (throw case) or calls `Bun__transpileVirtualModule` with a `virtual_source` (success case). In both paths the transpiler never opens the real file, so `input_file_fd` stays invalid and `bun_watcher.addFile` is never called.

The entry-point file happened to be covered anyway by a separate `addMainToWatcherIfNeeded` fallback, which masked the bug for single-file repros.

### Fix

In `Bun__runVirtualModule`, whenever a plugin matches (returns a value or throws), register the specifier with the watcher via `addFileByPathSlow` — for absolute paths in the default/`file` namespace, skipping `node_modules` (same filter the normal path uses). When no plugin matches we fall through to the existing transpile path unchanged.

## How did you verify your code works?

New regression test `test/regression/issue/17270.test.ts` covers:
- onLoad throws → fix file → reload → edit again → reload
- onLoad succeeds → edit → reload → break → reload → fix → reload

Both tests time out on `main` and pass with this change.

Also ran `test/cli/hot/watch.test.ts`, `test/cli/watch/watch.test.ts`, and `test/js/bun/plugin/plugins.test.ts` — all green.
