### PR TITLE
FileReader: keep store alive while open error is thrown

### DIFF
--- a/src/runtime/webcore/FileReader.zig
+++ b/src/runtime/webcore/FileReader.zig
@@ -188,16 +188,15 @@ pub fn onStart(this: *FileReader) streams.Start {
         switch (this.lazy.blob.data) {
             .s3, .bytes => @panic("Invalid state in FileReader: expected file "),
             .file => |*file| {
-                defer {
-                    this.lazy.blob.deref();
-                    this.lazy = .none;
-                }
                 switch (Lazy.openFileBlob(file)) {
                     .err => |err| {
                         this.fd = bun.invalid_fd;
+                        // err.path borrows from the store; leave this.lazy for deinit()
                         return .{ .err = err };
                     },
                     .result => |opened| {
+                        this.lazy.blob.deref();
+                        this.lazy = .none;
                         bun.assert(opened.fd.isValid());
                         this.fd = opened.fd;
                         pollable = opened.pollable;

--- a/test/js/bun/util/bun-file.test.ts
+++ b/test/js/bun/util/bun-file.test.ts
@@ -160,3 +160,31 @@ test("Bun.file().json() with UTF-8 BOM does not free an interior pointer", async
   });
   expect(exitCode).toBe(0);
 });
+
+test("stream() open error after the Blob is collected keeps the path alive", async () => {
+  const dir = tempDirWithFiles("bun-file-stream-open-error", {});
+  const path = join(dir, "does-not-exist-🌟");
+
+  function makeStream() {
+    let f: Bun.BunFile | null = Bun.file(path);
+    const s = f.stream();
+    f = null;
+    return s;
+  }
+
+  const stream = makeStream();
+  for (let i = 0; i < 5; i++) {
+    Bun.gc(true);
+    await new Promise(r => setImmediate(r));
+  }
+
+  let caught: any;
+  try {
+    stream.getReader();
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).toBeDefined();
+  expect(caught.code).toBe("ENOENT");
+  expect(caught.path).toBe(path);
+});


### PR DESCRIPTION
### What does this PR do?

Fixes a use-after-free when `Bun.file(path).stream()` fails to open the file after the originating Blob has been garbage-collected.

`FileReader.onStart()` used a `defer` to drop its ref on the Blob store, but when `open()` fails the returned `sys.Error` borrows the path slice from that store. If the JS `Bun.file()` had already been collected, the `defer` dropped the last ref and freed the path before the caller converted the error to JS — ASAN use-after-poison in `toSystemError()`:

```
==18695==ERROR: AddressSanitizer: use-after-poison on address 0x7ae2c6e701c0 ...
    #0 __asan_memcpy
    #1 Io.fixed_buffer_stream.FixedBufferStream([]u8).write
    ...
    #6 sys.Error.toSystemError src/sys/Error.zig:284
    #7 sys_jsc.error_jsc.toJS
    #8 ReadableStream.JSReadableStreamSource.start src/runtime/webcore/ReadableStream.zig:644
```

The fix drops the lazy store ref only on the success path. On failure, `this.lazy` is left in place so the store (and its path) outlives `err.toJS()`; `FileReader.deinit()` releases it afterwards.

Found by Fuzzilli (flaky in REPRL mode — a prior iteration's lazy stream was started after its Blob had been collected).

### How did you verify your code works?

Deterministic repro (non-Latin1 path forces a heap-owned `encoded_slice`):

```js
function makeStream() {
  let f = Bun.file("/\u{1F600}/nope");
  const s = f.stream();
  f = null;
  return s;
}
const s = makeStream();
for (let i = 0; i < 5; i++) { Bun.gc(true); await new Promise(r => setImmediate(r)); }
s.getReader(); // use-after-poison before, clean ENOENT after
```

Added as a regression test in `test/js/bun/util/bun-file.test.ts`; it crashes the debug-asan build before this change and passes after.