### PR TITLE
Fix crash when formatting WeakMap/WeakSet with user-defined `size` property

### DIFF
--- a/src/jsc/ConsoleObject.zig
+++ b/src/jsc/ConsoleObject.zig
@@ -2757,14 +2757,17 @@ pub const Formatter = struct {
                 writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
             },
             .Map => {
-                const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
-                const length = try length_value.coerce(i32, this.globalThis);
+                const is_weak = value.jsType() == .WeakMap;
+                const length = if (is_weak) 0 else length: {
+                    const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
+                    break :length try length_value.coerce(i32, this.globalThis);
+                };
 
                 const prev_quote_strings = this.quote_strings;
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
 
-                const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
+                const map_name = if (is_weak) "WeakMap" else "Map";
 
                 if (length == 0) {
                     return writer.print("{s} {{}}", .{map_name});
@@ -2864,14 +2867,17 @@ pub const Formatter = struct {
                 writer.writeAll("}");
             },
             .Set => {
-                const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
-                const length = try length_value.coerce(i32, this.globalThis);
+                const is_weak = value.jsType() == .WeakSet;
+                const length = if (is_weak) 0 else length: {
+                    const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
+                    break :length try length_value.coerce(i32, this.globalThis);
+                };
 
                 const prev_quote_strings = this.quote_strings;
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
 
-                const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
+                const set_name = if (is_weak) "WeakSet" else "Set";
 
                 if (length == 0) {
                     return writer.print("{s} {{}}", .{set_name});

--- a/src/test_runner/diff_format.zig
+++ b/src/test_runner/diff_format.zig
@@ -43,7 +43,9 @@ pub const DiffFormatter = struct {
                 1,
                 &received_buf.writer,
                 fmt_options,
-            ) catch {}; // TODO:
+            ) catch {
+                _ = this.globalThis.clearExceptionExceptTermination();
+            };
 
             JestPrettyFormat.format(
                 .Debug,
@@ -52,7 +54,9 @@ pub const DiffFormatter = struct {
                 1,
                 &expected_buf.writer,
                 fmt_options,
-            ) catch {}; // TODO:
+            ) catch {
+                _ = this.globalThis.clearExceptionExceptTermination();
+            };
         }
 
         var received_slice = received_buf.written();

--- a/src/test_runner/pretty_format.zig
+++ b/src/test_runner/pretty_format.zig
@@ -1307,14 +1307,17 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
                 },
                 .Map => {
-                    const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
-                    const length = length_value.toInt32();
+                    const is_weak = value.jsType() == .WeakMap;
+                    const length = if (is_weak) 0 else length: {
+                        const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
+                        break :length length_value.toInt32();
+                    };
 
                     const prev_quote_strings = this.quote_strings;
                     this.quote_strings = true;
                     defer this.quote_strings = prev_quote_strings;
 
-                    const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
+                    const map_name = if (is_weak) "WeakMap" else "Map";
 
                     if (length == 0) {
                         return writer.print("{s} {{}}", .{map_name});
@@ -1335,8 +1338,11 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll("\n");
                 },
                 .Set => {
-                    const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
-                    const length = length_value.toInt32();
+                    const is_weak = value.jsType() == .WeakSet;
+                    const length = if (is_weak) 0 else length: {
+                        const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
+                        break :length length_value.toInt32();
+                    };
 
                     const prev_quote_strings = this.quote_strings;
                     this.quote_strings = true;
@@ -1344,7 +1350,7 @@ pub const JestPrettyFormat = struct {
 
                     this.writeIndent(Writer, writer_) catch {};
 
-                    const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
+                    const set_name = if (is_weak) "WeakSet" else "Set";
 
                     if (length == 0) {
                         return writer.print("{s} {{}}", .{set_name});

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -734,6 +734,19 @@ it("MessageEvent", () => {
   `);
 });
 
+it("WeakMap/WeakSet with user-defined size property", () => {
+  const wm = new WeakMap();
+  wm.size = 1000;
+  expect(Bun.inspect(wm)).toBe("WeakMap {}");
+
+  const ws = new WeakSet();
+  ws.size = 1000;
+  expect(Bun.inspect(ws)).toBe("WeakSet {}");
+
+  expect(() => expect(wm).toEqual({})).toThrow();
+  expect(() => expect(ws).toEqual({})).toThrow();
+});
+
 it("CustomEvent", () => {
   const customEvent = new CustomEvent("custom", {
     detail: { value: 42, name: "test" },


### PR DESCRIPTION
Fuzzer fingerprint: `139c5bc4dce564e6`

## Repro

```js
const wm = new WeakMap();
wm.size = 1000;
Bun.inspect(wm); // TypeError: Type error
expect(wm).toEqual({}); // ASSERTION FAILED: !exception() || m_vm.hasPendingTerminationException()
```

## What happened

The `.Map` / `.Set` formatter branches in both `ConsoleObject.zig` and `pretty_format.zig` read `.size` to decide whether to iterate entries. `WeakMap` / `WeakSet` have no built-in `.size`, so normally this resolved to `0` and printed `WeakMap {}`. But if user code assigns a non-zero `.size`, the formatter called `forEachInIterable` on a non-iterable, which threw a `TypeError`.

In `Bun.inspect` that surfaced as a thrown JS error. In `expect().toEqual()`'s failure path, `DiffFormatter.format` swallowed the resulting `error.JSError` with `catch {}` without clearing the pending VM exception, then re-entered JSC and tripped the `ExceptionScope` assertion.

## Fix

- Never read `.size` or attempt to iterate `WeakMap` / `WeakSet`; they are not enumerable, so always print `WeakMap {}` / `WeakSet {}` (same as before when no `.size` was assigned).
- In `DiffFormatter`, clear any pending exception when a format call is swallowed so future formatter errors don't trip the assertion.