### PR TITLE
Bun.Image: implement fit: "outside" / "cover" / "contain"

### DIFF
--- a/docs/runtime/image.mdx
+++ b/docs/runtime/image.mdx
@@ -56,14 +56,21 @@ const { width, height, format } = await new Bun.Image(input).metadata();
 img.resize(800); // width 800, keep aspect ratio
 img.resize(800, 600); // exactly 800×600 (stretch)
 img.resize(800, 600, { fit: "inside" }); // fit within 800×600
+img.resize(800, 600, { fit: "cover" }); // fill 800×600, center-crop the rest
+img.resize(800, 600, { fit: "contain", background: { r: 255, g: 255, b: 255, alpha: 1 } }); // letterbox with white
 img.resize(800, 600, { withoutEnlargement: true }); // never upscale
 img.resize(800, 600, { filter: "mitchell" });
 ```
 
-| `fit`              | Behavior                                            |
-| ------------------ | --------------------------------------------------- |
-| `"fill"` (default) | Stretch to exactly `width × height`                 |
-| `"inside"`         | Preserve aspect ratio; result fits _within_ the box |
+| `fit`              | Behavior                                                       |
+| ------------------ | -------------------------------------------------------------- |
+| `"fill"` (default) | Stretch to exactly `width × height`                            |
+| `"inside"`         | Preserve aspect ratio; result fits _within_ the box            |
+| `"outside"`        | Preserve aspect ratio; result _contains_ the box (no crop)     |
+| `"cover"`          | Preserve aspect ratio; fill the box and center-crop the rest   |
+| `"contain"`        | Preserve aspect ratio; letterbox with `background` to fill box |
+
+For `fit: "contain"`, pass `background: { r, g, b, alpha }` to set the letterbox color (RGB 0–255, alpha 0–1; alpha defaults to 1 when a background is passed). Omitting `background` entirely gives a transparent black letterbox — renders as black in JPEG (alpha dropped) and transparent in PNG/WebP, so callers can composite the output without an extra step.
 
 `filter` selects the resampling kernel. The default `"lanczos3"` is the right choice for photographs.
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8642,17 +8642,52 @@ declare module "bun" {
       autoOrient?: boolean;
     }
 
+    /**
+     * RGBA letterbox fill for `fit: "contain"`. RGB channels are `0..255`
+     * and default to `0`; `alpha` is `0..1` (Sharp convention) and defaults
+     * to `1`, so `{ r: 255, g: 255, b: 255 }` is an opaque white fill.
+     */
+    interface Background {
+      r?: number;
+      g?: number;
+      b?: number;
+      alpha?: number;
+    }
+
     interface ResizeOptions {
       /** Resampling kernel. @default "lanczos3" */
       filter?: Filter;
       /**
-       * `"fill"` stretches to exactly width×height. `"inside"` preserves
-       * aspect ratio so the result fits *within* width×height.
+       * How to reconcile the requested box with the source's aspect ratio.
+       * All modes preserve aspect ratio except `"fill"`.
+       *
+       * - `"fill"` — stretch to exactly width×height.
+       * - `"inside"` — scale so the result fits *within* width×height.
+       * - `"outside"` — scale so the result *contains* width×height.
+       * - `"cover"` — scale like `"outside"` then center-crop to width×height.
+       * - `"contain"` — scale like `"inside"` then letterbox with
+       *   {@link ResizeOptions.background | `background`} to width×height.
+       *
        * @default "fill"
        */
-      fit?: "fill" | "inside";
-      /** Never upscale — if the source is already smaller, leave it. */
+      fit?: "fill" | "inside" | "outside" | "cover" | "contain";
+      /**
+       * Never upscale — if the source is already smaller, leave it. Only the
+       * image itself is exempt from enlarging: `fit: "contain"` still pads
+       * the canvas to the requested box, and `fit: "cover"` skips the
+       * upscale but still center-crops any axis where the source exceeds
+       * the box.
+       */
       withoutEnlargement?: boolean;
+      /**
+       * Letterbox colour for `fit:"contain"`. RGB channels default to `0`
+       * and `alpha` (`0..1`, Sharp convention) defaults to `1` when a
+       * background object is passed. Omitting the option entirely gives a
+       * transparent black letterbox — renders as black in JPEG (alpha
+       * dropped) and as a transparent letterbox in PNG/WebP. Ignored for
+       * other fit modes.
+       */
+      background?: Background;
     }
 
     interface ModulateOptions {

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -2144,8 +2144,6 @@ fn resolve_resize(r: Resize, sw: u32, sh: u32) -> Result<ResolvedResize, codecs:
     } else {
         u32::try_from((0x3FFFFu64).min(1u64.max((r.w as u64) * (sh as u64) / (sw as u64)))).unwrap()
     };
-    // `cover`/`contain` need the original box after `w`/`h` are reshaped
-    // to the aspect-preserving scale.
     let box_w = w;
     let box_h = h;
     if r.fit != Fit::Fill {

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -142,20 +142,53 @@ unsafe extern "C" {
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq, strum::IntoStaticStr, strum::EnumString)]
 pub enum Fit {
+    /// Stretch to exactly w×h (default). No aspect-ratio preservation.
     Fill,
+    /// Preserve aspect ratio; scale so the result fits *inside* w×h.
+    /// Output ≤ w×h on both sides.
     Inside,
+    /// Preserve aspect ratio; scale so the result *contains* w×h.
+    /// Output ≥ w×h on both sides. No crop — caller sees the larger image.
+    Outside,
+    /// Preserve aspect ratio; scale like `Outside` and center-crop to exactly
+    /// w×h. Like CSS `object-fit: cover`.
+    Cover,
+    /// Preserve aspect ratio; scale like `Inside` and letterbox with
+    /// `background` to exactly w×h. Like CSS `object-fit: contain`.
+    Contain,
 }
 // `pub const Map = bun.ComptimeEnumMap(Fit);` → covered by `strum::EnumString`.
 bun_core::comptime_string_map! {
     static FIT_MAP: Fit = {
         b"fill" => Fit::Fill,
         b"inside" => Fit::Inside,
+        b"outside" => Fit::Outside,
+        b"cover" => Fit::Cover,
+        b"contain" => Fit::Contain,
     };
 }
 impl jsc::FromJsEnum for Fit {
     fn from_js_value(v: JSValue, global: &JSGlobalObject, prop: &'static str) -> JsResult<Self> {
-        v.to_enum_from_map(global, prop, &FIT_MAP, "'fill' or 'inside'")
+        v.to_enum_from_map(
+            global,
+            prop,
+            &FIT_MAP,
+            "'fill', 'inside', 'outside', 'cover' or 'contain'",
+        )
     }
+}
+
+/// RGBA background used by `fit: "contain"` to fill the letterbox. Defaults
+/// to transparent black — renders as black in JPEG (alpha dropped) and as a
+/// transparent letterbox in PNG/WebP, so callers can composite without an
+/// extra `removeAlpha`. Sharp's default is opaque black; using transparent
+/// here keeps the alpha channel of PNG/WebP output usable.
+#[derive(Clone, Copy, Default)]
+pub struct Background {
+    pub(crate) r: u8,
+    pub(crate) g: u8,
+    pub(crate) b: u8,
+    pub(crate) a: u8,
 }
 impl jsc::FromJsEnum for codecs::Filter {
     fn from_js_value(v: JSValue, global: &JSGlobalObject, prop: &'static str) -> JsResult<Self> {
@@ -175,6 +208,7 @@ pub struct Resize {
     pub(crate) filter: codecs::Filter,
     pub(crate) fit: Fit,
     pub(crate) without_enlargement: bool,
+    pub(crate) background: Background,
 }
 
 impl Default for Resize {
@@ -185,6 +219,7 @@ impl Default for Resize {
             filter: codecs::Filter::Lanczos3,
             fit: Fit::Fill,
             without_enlargement: false,
+            background: Background::default(),
         }
     }
 }
@@ -242,6 +277,41 @@ macro_rules! coerce_int {
             x.max($lo).min($hi) as $T
         }
     }};
+}
+
+/// Parse Sharp-shaped `{r, g, b, alpha}`. RGB channels are 0-255 and default
+/// to 0; `alpha` is 0-1 (Sharp convention) and defaults to opaque — passing
+/// a background object at all means the caller wants a visible fill, the
+/// same as Sharp's `Color({r, g, b})`. The fully transparent letterbox is
+/// the *omitted*-background default.
+fn parse_background(global: &JSGlobalObject, bg: JSValue) -> JsResult<Background> {
+    let mut out = Background {
+        a: 255,
+        ..Background::default()
+    };
+    if let Some(v) = bg.get(global, "r")? {
+        if v.is_number() {
+            out.r = coerce_int!(u8, v.as_number(), 0.0, 255.0);
+        }
+    }
+    if let Some(v) = bg.get(global, "g")? {
+        if v.is_number() {
+            out.g = coerce_int!(u8, v.as_number(), 0.0, 255.0);
+        }
+    }
+    if let Some(v) = bg.get(global, "b")? {
+        if v.is_number() {
+            out.b = coerce_int!(u8, v.as_number(), 0.0, 255.0);
+        }
+    }
+    if let Some(v) = bg.get(global, "alpha")? {
+        if v.is_number() {
+            // Round like Sharp (`Math.round(alpha * 255)`) — a plain
+            // narrowing cast truncates, putting 0.5 at 127 instead of 128.
+            out.a = coerce_int!(u8, (v.as_number() * 255.0).round(), 0.0, 255.0);
+        }
+    }
+    Ok(out)
 }
 
 /// Size cap for `.path` sources, applied at fstat time before reading
@@ -481,6 +551,11 @@ impl Image {
             }
             if let Some(v) = opt.get(global, "withoutEnlargement")? {
                 r.without_enlargement = v.to_boolean();
+            }
+            if let Some(bg) = opt.get(global, "background")? {
+                if bg.is_object() {
+                    r.background = parse_background(global, bg)?;
+                }
             }
         }
         self.update_pipeline(|p| p.resize = Some(r));
@@ -1961,23 +2036,63 @@ impl PipelineTask {
             d.rgba = next;
         }
         if let Some(r) = p.resize {
-            let t = resolve_resize(r, d.width, d.height);
-            // Guard the output canvas AND the H-then-V intermediate (always
-            // dst_w × src_h — image_resize.cpp pass order is fixed). A 1×N
-            // source → resize(W,1) has tiny input AND output canvases yet a
-            // W×N intermediate; with W=262143, N=16383 that's a 17 GiB alloc
-            // from a ~200-byte PNG. The src_w×dst_h cross-product is bounded
-            // by max(input, output) so doesn't need its own check.
-            if (t.0 as u64) * (t.1 as u64) > self.max_pixels
-                || (t.0 as u64) * (d.height as u64) > self.max_pixels
+            let t = resolve_resize(r, d.width, d.height)?;
+            // Guard both the resize canvas AND the H-then-V intermediate
+            // (always resize_w × src_h — image_resize.cpp pass order is
+            // fixed). A 1×N source → resize(W,1) has tiny input AND output
+            // canvases yet a W×N intermediate; with W=262143, N=16383
+            // that's a 17 GiB alloc from a ~200-byte PNG. The src_w×dst_h
+            // cross-product is bounded by max(input, output) so doesn't
+            // need its own check. The third clause guards the `contain`
+            // pad canvas (out_w × out_h): each side is capped at
+            // `do_resize`'s 0x3FFFF, but the product of two capped sides
+            // is still ~256× the default max_pixels, so it needs its own
+            // check.
+            if (t.resize_w as u64) * (t.resize_h as u64) > self.max_pixels
+                || (t.resize_w as u64) * (d.height as u64) > self.max_pixels
+                || (t.out_w as u64) * (t.out_h as u64) > self.max_pixels
             {
                 return Err(codecs::Error::TooManyPixels);
             }
-            if t.0 != d.width || t.1 != d.height {
-                let next = codecs::resize(&d.rgba, d.width, d.height, t.0, t.1, r.filter)?;
+            if t.resize_w != d.width || t.resize_h != d.height {
+                let next =
+                    codecs::resize(&d.rgba, d.width, d.height, t.resize_w, t.resize_h, r.filter)?;
                 d.rgba = next;
-                d.width = t.0;
-                d.height = t.1;
+                d.width = t.resize_w;
+                d.height = t.resize_h;
+            }
+            // `cover`/`contain` finish by cropping or padding the resized
+            // image to exactly the target box. No-op for the other fit
+            // modes where resize_w×resize_h already equals out_w×out_h.
+            if t.out_w != d.width || t.out_h != d.height {
+                let next = match r.fit {
+                    Fit::Cover => codecs::crop(
+                        &d.rgba, d.width, d.height, t.off_x, t.off_y, t.out_w, t.out_h,
+                    )?,
+                    Fit::Contain => codecs::pad(
+                        &d.rgba,
+                        d.width,
+                        d.height,
+                        t.out_w,
+                        t.out_h,
+                        t.off_x,
+                        t.off_y,
+                        [
+                            r.background.r,
+                            r.background.g,
+                            r.background.b,
+                            r.background.a,
+                        ],
+                    )?,
+                    // Should never happen — resolve_resize keeps resize ==
+                    // out for every other fit. Guard so a future fit mode
+                    // with a mismatched helper doesn't silently fall
+                    // through a no-op branch.
+                    _ => unreachable!("resolve_resize: resize != out for non-cover/contain fit"),
+                };
+                d.rgba = next;
+                d.width = t.out_w;
+                d.height = t.out_h;
             }
         }
         if let Some(m) = p.modulate {
@@ -2027,8 +2142,23 @@ fn make_placeholder(rgba: &[u8], sw: u32, sh: u32) -> Result<TaskResult, codecs:
     })
 }
 
+/// `resize_w×resize_h` are the dims codecs::resize produces; `out_w×out_h`
+/// are the final pipeline dims. For fill/inside/outside they match; for
+/// cover the resize overshoots the box and is then cropped by `off_*`
+/// pixels from the top-left; for contain the resize undershoots and is
+/// padded, with `off_*` being the top-left of the resized image inside
+/// the output box.
+struct ResolvedResize {
+    resize_w: u32,
+    resize_h: u32,
+    out_w: u32,
+    out_h: u32,
+    off_x: u32,
+    off_y: u32,
+}
+
 /// Map a resize spec to concrete output dims given the current dims.
-fn resolve_resize(r: Resize, sw: u32, sh: u32) -> (u32, u32) {
+fn resolve_resize(r: Resize, sw: u32, sh: u32) -> Result<ResolvedResize, codecs::Error> {
     let mut w = r.w;
     // Widen before multiplying — `r.w` is user-controlled and `sh` is
     // bounded only by `max_pixels`, so the u32 product can wrap; and the
@@ -2040,19 +2170,96 @@ fn resolve_resize(r: Resize, sw: u32, sh: u32) -> (u32, u32) {
     } else {
         u32::try_from((0x3FFFFu64).min(1u64.max((r.w as u64) * (sh as u64) / (sw as u64)))).unwrap()
     };
-    if r.fit == Fit::Inside {
-        // Shrink the box so the source's aspect ratio is preserved and
-        // both sides fit. (Sharp's `fit:'inside'`.)
+    // Preserve the user-specified target box — `cover`/`contain` need it
+    // after the resize step has reshaped `w`/`h` to the aspect-preserving
+    // scale. `inside`/`outside`/`fill` ignore out_* since resize_* matches.
+    let box_w = w;
+    let box_h = h;
+    // `inside`/`outside`/`cover`/`contain` all preserve aspect ratio; the
+    // only difference is which extreme of the per-side scale we pick and
+    // what we do with any mismatch afterwards:
+    //   inside  → min scale, no finishing step (result fits *in* the box)
+    //   outside → max scale, no finishing step (result *contains* the box)
+    //   cover   → max scale, center-crop to the box (CSS object-fit cover)
+    //   contain → min scale, pad to the box with `background` (CSS contain)
+    if r.fit != Fit::Fill {
         let sx = (w as f64) / (sw as f64);
         let sy = (h as f64) / (sh as f64);
-        let s = sx.min(sy);
-        w = 1u32.max(((sw as f64) * s).round() as u32);
-        h = 1u32.max(((sh as f64) * s).round() as u32);
+        let s = match r.fit {
+            Fit::Inside | Fit::Contain => sx.min(sy),
+            Fit::Outside | Fit::Cover => sx.max(sy),
+            Fit::Fill => unreachable!(),
+        };
+        // `outside`/`cover` pick the max scale, so a tall-thin source can
+        // push the off-axis side arbitrarily high (1×10M source into a
+        // 500×500 box → 5e9). The dims stay exact in f64 (bounded by
+        // i32::MAX × 0x3FFFF < 2^53) so decide in float space:
+        //  - withoutEnlargement short-circuits to the source dims, same
+        //    as it always did for an over-box scale;
+        //  - a side past i32::MAX can never be represented downstream
+        //    (the resize kernel takes i32 dims), so reject it loudly —
+        //    clamping instead would silently change the aspect ratio;
+        //  - anything else narrows exactly and the caller's maxPixels
+        //    product guards decide whether the canvas is affordable.
+        let wf = ((sw as f64) * s).round().max(1.0);
+        let hf = ((sh as f64) * s).round().max(1.0);
+        if r.without_enlargement && (wf > sw as f64 || hf > sh as f64) {
+            w = sw;
+            h = sh;
+        } else if wf > i32::MAX as f64 || hf > i32::MAX as f64 {
+            return Err(codecs::Error::TooManyPixels);
+        } else {
+            w = wf as u32;
+            h = hf as u32;
+        }
+    } else if r.without_enlargement && (w > sw || h > sh) {
+        w = sw;
+        h = sh;
     }
-    if r.without_enlargement && (w > sw || h > sh) {
-        return (sw, sh);
-    }
-    (w, h)
+    Ok(match r.fit {
+        Fit::Fill | Fit::Inside | Fit::Outside => ResolvedResize {
+            resize_w: w,
+            resize_h: h,
+            out_w: w,
+            out_h: h,
+            off_x: 0,
+            off_y: 0,
+        },
+        Fit::Cover => {
+            // Crop centered; the resize overshoots by `w - box_w` /
+            // `h - box_h` along each axis (non-negative for `outside`
+            // scale). `without_enlargement` can leave the resized image
+            // smaller than the box — clamp the output to what we have
+            // so `crop` never asks for rows/cols that don't exist.
+            let out_w = box_w.min(w);
+            let out_h = box_h.min(h);
+            ResolvedResize {
+                resize_w: w,
+                resize_h: h,
+                out_w,
+                out_h,
+                off_x: (w - out_w) / 2,
+                off_y: (h - out_h) / 2,
+            }
+        }
+        Fit::Contain => {
+            // Letterbox centered inside the user-specified box; the
+            // resize undershoots so `box - w` / `box - h` are
+            // non-negative (for `inside` scale) and the offset is half
+            // the slack. With `without_enlargement` a smaller source can
+            // still be padded up to the box.
+            let out_w = box_w.max(w);
+            let out_h = box_h.max(h);
+            ResolvedResize {
+                resize_w: w,
+                resize_h: h,
+                out_w,
+                out_h,
+                off_x: (out_w - w) / 2,
+                off_y: (out_h - h) / 2,
+            }
+        }
+    })
 }
 
 fn apply_orientation(

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -142,19 +142,16 @@ unsafe extern "C" {
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq, strum::IntoStaticStr, strum::EnumString)]
 pub enum Fit {
-    /// Stretch to exactly w×h (default). No aspect-ratio preservation.
+    /// Stretch to exactly w×h (default).
     Fill,
-    /// Preserve aspect ratio; scale so the result fits *inside* w×h.
-    /// Output ≤ w×h on both sides.
+    /// Preserve aspect ratio; result fits inside w×h.
     Inside,
-    /// Preserve aspect ratio; scale so the result *contains* w×h.
-    /// Output ≥ w×h on both sides. No crop — caller sees the larger image.
+    /// Preserve aspect ratio; result contains w×h (no crop).
     Outside,
-    /// Preserve aspect ratio; scale like `Outside` and center-crop to exactly
-    /// w×h. Like CSS `object-fit: cover`.
+    /// `Outside` scale, then center-crop to w×h (CSS `object-fit: cover`).
     Cover,
-    /// Preserve aspect ratio; scale like `Inside` and letterbox with
-    /// `background` to exactly w×h. Like CSS `object-fit: contain`.
+    /// `Inside` scale, then letterbox with `background` to w×h
+    /// (CSS `object-fit: contain`).
     Contain,
 }
 // `pub const Map = bun.ComptimeEnumMap(Fit);` → covered by `strum::EnumString`.
@@ -178,11 +175,8 @@ impl jsc::FromJsEnum for Fit {
     }
 }
 
-/// RGBA background used by `fit: "contain"` to fill the letterbox. Defaults
-/// to transparent black — renders as black in JPEG (alpha dropped) and as a
-/// transparent letterbox in PNG/WebP, so callers can composite without an
-/// extra `removeAlpha`. Sharp's default is opaque black; using transparent
-/// here keeps the alpha channel of PNG/WebP output usable.
+/// `fit: "contain"` letterbox fill. `Default` (transparent black) is the
+/// omitted-background case; `parse_background` defaults alpha to opaque.
 #[derive(Clone, Copy, Default)]
 pub struct Background {
     pub(crate) r: u8,
@@ -279,11 +273,8 @@ macro_rules! coerce_int {
     }};
 }
 
-/// Parse Sharp-shaped `{r, g, b, alpha}`. RGB channels are 0-255 and default
-/// to 0; `alpha` is 0-1 (Sharp convention) and defaults to opaque — passing
-/// a background object at all means the caller wants a visible fill, the
-/// same as Sharp's `Color({r, g, b})`. The fully transparent letterbox is
-/// the *omitted*-background default.
+/// Sharp-shaped `{r, g, b, alpha}`: RGB 0-255 defaulting to 0, `alpha` 0-1
+/// defaulting to opaque like Sharp's `Color({r, g, b})`.
 fn parse_background(global: &JSGlobalObject, bg: JSValue) -> JsResult<Background> {
     let mut out = Background {
         a: 255,
@@ -306,8 +297,7 @@ fn parse_background(global: &JSGlobalObject, bg: JSValue) -> JsResult<Background
     }
     if let Some(v) = bg.get(global, "alpha")? {
         if v.is_number() {
-            // Round like Sharp (`Math.round(alpha * 255)`) — a plain
-            // narrowing cast truncates, putting 0.5 at 127 instead of 128.
+            // Round like Sharp; a narrowing cast would truncate 0.5 to 127.
             out.a = coerce_int!(u8, (v.as_number() * 255.0).round(), 0.0, 255.0);
         }
     }
@@ -2037,17 +2027,10 @@ impl PipelineTask {
         }
         if let Some(r) = p.resize {
             let t = resolve_resize(r, d.width, d.height)?;
-            // Guard both the resize canvas AND the H-then-V intermediate
-            // (always resize_w × src_h — image_resize.cpp pass order is
-            // fixed). A 1×N source → resize(W,1) has tiny input AND output
-            // canvases yet a W×N intermediate; with W=262143, N=16383
-            // that's a 17 GiB alloc from a ~200-byte PNG. The src_w×dst_h
-            // cross-product is bounded by max(input, output) so doesn't
-            // need its own check. The third clause guards the `contain`
-            // pad canvas (out_w × out_h): each side is capped at
-            // `do_resize`'s 0x3FFFF, but the product of two capped sides
-            // is still ~256× the default max_pixels, so it needs its own
-            // check.
+            // Guard the resize canvas, the H-then-V resize_w × src_h
+            // intermediate (a 1×N source can make it huge while input and
+            // output stay tiny), and the `contain` pad canvas (two
+            // 0x3FFFF-capped sides still multiply past max_pixels).
             if (t.resize_w as u64) * (t.resize_h as u64) > self.max_pixels
                 || (t.resize_w as u64) * (d.height as u64) > self.max_pixels
                 || (t.out_w as u64) * (t.out_h as u64) > self.max_pixels
@@ -2061,9 +2044,7 @@ impl PipelineTask {
                 d.width = t.resize_w;
                 d.height = t.resize_h;
             }
-            // `cover`/`contain` finish by cropping or padding the resized
-            // image to exactly the target box. No-op for the other fit
-            // modes where resize_w×resize_h already equals out_w×out_h.
+            // `cover` crops / `contain` pads the resized image to the box.
             if t.out_w != d.width || t.out_h != d.height {
                 let next = match r.fit {
                     Fit::Cover => codecs::crop(
@@ -2084,10 +2065,7 @@ impl PipelineTask {
                             r.background.a,
                         ],
                     )?,
-                    // Should never happen — resolve_resize keeps resize ==
-                    // out for every other fit. Guard so a future fit mode
-                    // with a mismatched helper doesn't silently fall
-                    // through a no-op branch.
+                    // resolve_resize keeps resize == out for every other fit.
                     _ => unreachable!("resolve_resize: resize != out for non-cover/contain fit"),
                 };
                 d.rgba = next;
@@ -2142,12 +2120,8 @@ fn make_placeholder(rgba: &[u8], sw: u32, sh: u32) -> Result<TaskResult, codecs:
     })
 }
 
-/// `resize_w×resize_h` are the dims codecs::resize produces; `out_w×out_h`
-/// are the final pipeline dims. For fill/inside/outside they match; for
-/// cover the resize overshoots the box and is then cropped by `off_*`
-/// pixels from the top-left; for contain the resize undershoots and is
-/// padded, with `off_*` being the top-left of the resized image inside
-/// the output box.
+/// `resize_*` feeds codecs::resize; `out_*` is the final canvas. They match
+/// except for cover (crop at `off_*`) and contain (pad at `off_*`).
 struct ResolvedResize {
     resize_w: u32,
     resize_h: u32,
@@ -2170,18 +2144,10 @@ fn resolve_resize(r: Resize, sw: u32, sh: u32) -> Result<ResolvedResize, codecs:
     } else {
         u32::try_from((0x3FFFFu64).min(1u64.max((r.w as u64) * (sh as u64) / (sw as u64)))).unwrap()
     };
-    // Preserve the user-specified target box — `cover`/`contain` need it
-    // after the resize step has reshaped `w`/`h` to the aspect-preserving
-    // scale. `inside`/`outside`/`fill` ignore out_* since resize_* matches.
+    // `cover`/`contain` need the original box after `w`/`h` are reshaped
+    // to the aspect-preserving scale.
     let box_w = w;
     let box_h = h;
-    // `inside`/`outside`/`cover`/`contain` all preserve aspect ratio; the
-    // only difference is which extreme of the per-side scale we pick and
-    // what we do with any mismatch afterwards:
-    //   inside  → min scale, no finishing step (result fits *in* the box)
-    //   outside → max scale, no finishing step (result *contains* the box)
-    //   cover   → max scale, center-crop to the box (CSS object-fit cover)
-    //   contain → min scale, pad to the box with `background` (CSS contain)
     if r.fit != Fit::Fill {
         let sx = (w as f64) / (sw as f64);
         let sy = (h as f64) / (sh as f64);
@@ -2190,17 +2156,9 @@ fn resolve_resize(r: Resize, sw: u32, sh: u32) -> Result<ResolvedResize, codecs:
             Fit::Outside | Fit::Cover => sx.max(sy),
             Fit::Fill => unreachable!(),
         };
-        // `outside`/`cover` pick the max scale, so a tall-thin source can
-        // push the off-axis side arbitrarily high (1×10M source into a
-        // 500×500 box → 5e9). The dims stay exact in f64 (bounded by
-        // i32::MAX × 0x3FFFF < 2^53) so decide in float space:
-        //  - withoutEnlargement short-circuits to the source dims, same
-        //    as it always did for an over-box scale;
-        //  - a side past i32::MAX can never be represented downstream
-        //    (the resize kernel takes i32 dims), so reject it loudly —
-        //    clamping instead would silently change the aspect ratio;
-        //  - anything else narrows exactly and the caller's maxPixels
-        //    product guards decide whether the canvas is affordable.
+        // Max-scale fits can push the off-axis side past i32::MAX (the
+        // resize kernel's dim type); decide in f64 and reject instead of
+        // clamping, which would silently distort the aspect ratio.
         let wf = ((sw as f64) * s).round().max(1.0);
         let hf = ((sh as f64) * s).round().max(1.0);
         if r.without_enlargement && (wf > sw as f64 || hf > sh as f64) {
@@ -2226,11 +2184,8 @@ fn resolve_resize(r: Resize, sw: u32, sh: u32) -> Result<ResolvedResize, codecs:
             off_y: 0,
         },
         Fit::Cover => {
-            // Crop centered; the resize overshoots by `w - box_w` /
-            // `h - box_h` along each axis (non-negative for `outside`
-            // scale). `without_enlargement` can leave the resized image
-            // smaller than the box — clamp the output to what we have
-            // so `crop` never asks for rows/cols that don't exist.
+            // Center-crop; clamp to the resized dims so a
+            // `without_enlargement` reset never over-crops.
             let out_w = box_w.min(w);
             let out_h = box_h.min(h);
             ResolvedResize {
@@ -2243,11 +2198,8 @@ fn resolve_resize(r: Resize, sw: u32, sh: u32) -> Result<ResolvedResize, codecs:
             }
         }
         Fit::Contain => {
-            // Letterbox centered inside the user-specified box; the
-            // resize undershoots so `box - w` / `box - h` are
-            // non-negative (for `inside` scale) and the offset is half
-            // the slack. With `without_enlargement` a smaller source can
-            // still be padded up to the box.
+            // Letterbox centered; a `without_enlargement`-reset source is
+            // still padded up to the box.
             let out_w = box_w.max(w);
             let out_h = box_h.max(h);
             ResolvedResize {

--- a/src/runtime/image/codecs.rs
+++ b/src/runtime/image/codecs.rs
@@ -775,3 +775,72 @@ pub(crate) fn flip(src: &[u8], w: u32, h: u32, horizontal: bool) -> Result<Vec<u
     };
     Ok(out)
 }
+
+/// Extract a `cw × ch` rectangle starting at `(x, y)` from `src`. The caller
+/// is expected to have range-checked `x + cw <= sw` and `y + ch <= sh` —
+/// `resolve_resize` does this for `fit:'cover'`. Plain per-row memcpy; no
+/// kernel needed since there's no resampling.
+pub(crate) fn crop(
+    src: &[u8],
+    sw: u32,
+    sh: u32,
+    x: u32,
+    y: u32,
+    cw: u32,
+    ch: u32,
+) -> Result<Vec<u8>, Error> {
+    debug_assert!((x as u64) + (cw as u64) <= (sw as u64));
+    debug_assert!((y as u64) + (ch as u64) <= (sh as u64));
+    let _ = sh;
+    let mut out: Vec<u8> = vec![0u8; (cw as usize) * (ch as usize) * 4];
+    let src_stride: usize = (sw as usize) * 4;
+    let dst_stride: usize = (cw as usize) * 4;
+    let row_bytes: usize = dst_stride;
+    let x_bytes: usize = (x as usize) * 4;
+    for row in 0..(ch as usize) {
+        let s_off = ((y as usize) + row) * src_stride + x_bytes;
+        let d_off = row * dst_stride;
+        out[d_off..d_off + row_bytes].copy_from_slice(&src[s_off..s_off + row_bytes]);
+    }
+    Ok(out)
+}
+
+/// Place the `sw × sh` image at `(ox, oy)` inside a fresh `dw × dh` canvas
+/// painted with `bg`. Used by `fit:'contain'` to letterbox. The caller is
+/// expected to have range-checked `ox + sw <= dw` and `oy + sh <= dh`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn pad(
+    src: &[u8],
+    sw: u32,
+    sh: u32,
+    dw: u32,
+    dh: u32,
+    ox: u32,
+    oy: u32,
+    bg: [u8; 4],
+) -> Result<Vec<u8>, Error> {
+    debug_assert!((ox as u64) + (sw as u64) <= (dw as u64));
+    debug_assert!((oy as u64) + (sh as u64) <= (dh as u64));
+    let mut out: Vec<u8> = vec![0u8; (dw as usize) * (dh as usize) * 4];
+    // Fill every pixel with the background first, then blit the image over
+    // the center. Simpler than writing only the border strips and avoids a
+    // branch per row (one tight pattern fill, then one memcpy per image
+    // row). A solid-colour fill at RGBA8 auto-vectorises on the platforms
+    // we ship. The default transparent-black background matches the
+    // zero-initialized allocation, so skip the pass entirely then.
+    if bg != [0u8; 4] {
+        for px in out.chunks_exact_mut(4) {
+            px.copy_from_slice(&bg);
+        }
+    }
+    let src_stride: usize = (sw as usize) * 4;
+    let dst_stride: usize = (dw as usize) * 4;
+    let row_bytes: usize = src_stride;
+    let x_bytes: usize = (ox as usize) * 4;
+    for row in 0..(sh as usize) {
+        let s_off = row * src_stride;
+        let d_off = ((oy as usize) + row) * dst_stride + x_bytes;
+        out[d_off..d_off + row_bytes].copy_from_slice(&src[s_off..s_off + row_bytes]);
+    }
+    Ok(out)
+}

--- a/src/runtime/image/codecs.rs
+++ b/src/runtime/image/codecs.rs
@@ -776,10 +776,8 @@ pub(crate) fn flip(src: &[u8], w: u32, h: u32, horizontal: bool) -> Result<Vec<u
     Ok(out)
 }
 
-/// Extract a `cw × ch` rectangle starting at `(x, y)` from `src`. The caller
-/// is expected to have range-checked `x + cw <= sw` and `y + ch <= sh` —
-/// `resolve_resize` does this for `fit:'cover'`. Plain per-row memcpy; no
-/// kernel needed since there's no resampling.
+/// Extract a `cw × ch` rectangle at `(x, y)`. Caller range-checks
+/// `x + cw <= sw` and `y + ch <= sh`.
 pub(crate) fn crop(
     src: &[u8],
     sw: u32,
@@ -805,9 +803,8 @@ pub(crate) fn crop(
     Ok(out)
 }
 
-/// Place the `sw × sh` image at `(ox, oy)` inside a fresh `dw × dh` canvas
-/// painted with `bg`. Used by `fit:'contain'` to letterbox. The caller is
-/// expected to have range-checked `ox + sw <= dw` and `oy + sh <= dh`.
+/// Blit the `sw × sh` image at `(ox, oy)` onto a fresh `dw × dh` canvas
+/// painted with `bg`. Caller range-checks `ox + sw <= dw` and `oy + sh <= dh`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn pad(
     src: &[u8],
@@ -822,12 +819,7 @@ pub(crate) fn pad(
     debug_assert!((ox as u64) + (sw as u64) <= (dw as u64));
     debug_assert!((oy as u64) + (sh as u64) <= (dh as u64));
     let mut out: Vec<u8> = vec![0u8; (dw as usize) * (dh as usize) * 4];
-    // Fill every pixel with the background first, then blit the image over
-    // the center. Simpler than writing only the border strips and avoids a
-    // branch per row (one tight pattern fill, then one memcpy per image
-    // row). A solid-colour fill at RGBA8 auto-vectorises on the platforms
-    // we ship. The default transparent-black background matches the
-    // zero-initialized allocation, so skip the pass entirely then.
+    // The zero-initialized allocation already is transparent black.
     if bg != [0u8; 4] {
         for px in out.chunks_exact_mut(4) {
             px.copy_from_slice(&bg);

--- a/src/runtime/image/codecs.rs
+++ b/src/runtime/image/codecs.rs
@@ -776,8 +776,6 @@ pub(crate) fn flip(src: &[u8], w: u32, h: u32, horizontal: bool) -> Result<Vec<u
     Ok(out)
 }
 
-/// Extract a `cw × ch` rectangle at `(x, y)`. Caller range-checks
-/// `x + cw <= sw` and `y + ch <= sh`.
 pub(crate) fn crop(
     src: &[u8],
     sw: u32,
@@ -803,8 +801,6 @@ pub(crate) fn crop(
     Ok(out)
 }
 
-/// Blit the `sw × sh` image at `(ox, oy)` onto a fresh `dw × dh` canvas
-/// painted with `bg`. Caller range-checks `ox + sw <= dw` and `oy + sh <= dh`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn pad(
     src: &[u8],

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -1067,6 +1067,138 @@ describe("Bun.Image", () => {
       expect(h).toBe(8);
     });
 
+    test("fit:'outside' preserves aspect ratio with the box as a lower bound", async () => {
+      const out = await new Bun.Image(gradientPng) // 16×16
+        .resize(8, 32, { fit: "outside" })
+        .png()
+        .bytes();
+      const { w, h } = decodePngRaw(out);
+      // 16×16 into an 8×32 box → scale = max(8/16, 32/16) = 2 → 32×32.
+      expect(w).toBe(32);
+      expect(h).toBe(32);
+    });
+
+    test("fit:'cover' matches the box exactly and center-crops overflow", async () => {
+      // 4×2 stripes so the crop is observable: column 0 = red, 1 = green,
+      // 2 = blue, 3 = white. A 4×2 → box 2×2 cover scales to 4×2 (max scale
+      // = max(2/4, 2/2) = 1) then crops the middle 2×2 → columns 1..2 of
+      // the source should survive.
+      const stripes = makePng(4, 2, x => {
+        if (x === 0) return [255, 0, 0, 255];
+        if (x === 1) return [0, 255, 0, 255];
+        if (x === 2) return [0, 0, 255, 255];
+        return [255, 255, 255, 255];
+      });
+      const out = await new Bun.Image(stripes).resize(2, 2, { fit: "cover" }).png().bytes();
+      const { w, h, data } = decodePngRaw(out);
+      expect(w).toBe(2);
+      expect(h).toBe(2);
+      // Center columns (1 and 2 in source) land in the crop.
+      expect(rgbaAt(data, 2, 0, 0)).toEqual([0, 255, 0, 255]);
+      expect(rgbaAt(data, 2, 1, 0)).toEqual([0, 0, 255, 255]);
+    });
+
+    test("fit:'contain' matches the box exactly and letterboxes with background", async () => {
+      // 2×2 all-red source into a 4×2 box → contain scales to 2×2 (min
+      // scale = min(4/2, 2/2) = 1) then pads 1 px on each side horizontally
+      // with the requested background.
+      const red = makePng(2, 2, () => [255, 0, 0, 255]);
+      const out = await new Bun.Image(red)
+        .resize(4, 2, { fit: "contain", background: { r: 0, g: 255, b: 0, alpha: 1 } })
+        .png()
+        .bytes();
+      const { w, h, data } = decodePngRaw(out);
+      expect(w).toBe(4);
+      expect(h).toBe(2);
+      // Left strip = green pad, middle = red source, right strip = green pad.
+      expect(rgbaAt(data, 4, 0, 0)).toEqual([0, 255, 0, 255]);
+      expect(rgbaAt(data, 4, 1, 0)).toEqual([255, 0, 0, 255]);
+      expect(rgbaAt(data, 4, 2, 0)).toEqual([255, 0, 0, 255]);
+      expect(rgbaAt(data, 4, 3, 0)).toEqual([0, 255, 0, 255]);
+    });
+
+    test("fit:'contain' default background is transparent black", async () => {
+      const red = makePng(2, 2, () => [255, 0, 0, 255]);
+      const out = await new Bun.Image(red).resize(4, 2, { fit: "contain" }).png().bytes();
+      const { data } = decodePngRaw(out);
+      // Untouched letterbox pixels → alpha = 0, RGB = 0.
+      expect(rgbaAt(data, 4, 0, 0)).toEqual([0, 0, 0, 0]);
+      expect(rgbaAt(data, 4, 3, 0)).toEqual([0, 0, 0, 0]);
+    });
+
+    test("fit:'contain' background alpha rounds to the nearest step like Sharp", async () => {
+      const red = makePng(2, 2, () => [255, 0, 0, 255]);
+      const out = await new Bun.Image(red)
+        .resize(4, 2, { fit: "contain", background: { r: 10, g: 20, b: 30, alpha: 0.5 } })
+        .png()
+        .bytes();
+      const { data } = decodePngRaw(out);
+      // Math.round(0.5 × 255) = 128 — truncation would store 127.
+      expect(rgbaAt(data, 4, 0, 0)).toEqual([10, 20, 30, 128]);
+    });
+
+    test("fit:'contain' background without alpha is opaque like Sharp", async () => {
+      // Passing a background means the caller wants a visible fill —
+      // alpha defaults to 1 like Sharp's Color({r, g, b}), not to the
+      // transparent omitted-background default.
+      const red = makePng(2, 2, () => [255, 0, 0, 255]);
+      const out = await new Bun.Image(red)
+        .resize(4, 2, { fit: "contain", background: { r: 255, g: 255, b: 255 } })
+        .png()
+        .bytes();
+      const { data } = decodePngRaw(out);
+      expect(rgbaAt(data, 4, 0, 0)).toEqual([255, 255, 255, 255]);
+    });
+
+    test.each(["cover", "contain"] as const)("fit:'%s' with square-into-square is a no-op on dims", async fit => {
+      const out = await new Bun.Image(gradientPng).resize(8, 8, { fit }).png().bytes();
+      const { w, h } = decodePngRaw(out);
+      expect({ fit, w, h }).toEqual({ fit, w: 8, h: 8 });
+    });
+
+    test.each(["outside", "cover"] as const)(
+      "fit:'%s' tall-thin overshoot rejects with maxPixels, not a crash",
+      async fit => {
+        // 1×100000 source into a 50000×1 box → max scale = 50000, so the
+        // off-axis side wants 100000×50000 = 5e9 (past u32). Must surface
+        // as the maxPixels error, never a panic or a silently distorted
+        // canvas.
+        const tall = makePng(1, 100000, () => [255, 0, 0, 255]);
+        await expect(new Bun.Image(tall).resize(50000, 1, { fit }).png().bytes()).rejects.toThrow(/maxPixels/);
+      },
+    );
+
+    test("fit:'cover' tall-thin overshoot in the small-box window still rejects, never distorts", async () => {
+      // A 100×100 box keeps every pixel-count guard under the default
+      // maxPixels if the scaled side were clamped to the per-side cap
+      // (100×262143 ≈ 26M < 268M), so a clamp here would silently emit a
+      // ~38× vertically squished image. The honest scaled canvas is
+      // 100×10000000 = 1e9 pixels, which must reject.
+      const tall = makePng(1, 100000, () => [255, 0, 0, 255]);
+      await expect(new Bun.Image(tall).resize(100, 100, { fit: "cover" }).png().bytes()).rejects.toThrow(/maxPixels/);
+    });
+
+    test("fit:'outside' overshoot past i32 dims rejects even with raised maxPixels, not a crash", async () => {
+      // 1×100000 into a 30000×1 box wants 30000×3000000000 — the off-axis
+      // side exceeds i32::MAX, which the resize kernel can never represent,
+      // and maxPixels: 1e15 lets the pixel-count guards pass. Must reject,
+      // never panic at the kernel's int cast.
+      const tall = makePng(1, 100000, () => [255, 0, 0, 255]);
+      await expect(
+        new Bun.Image(tall, { maxPixels: 1e15 }).resize(30000, 1, { fit: "outside" }).png().bytes(),
+      ).rejects.toThrow(/maxPixels/);
+    });
+
+    test("fit:'outside' overshoot under the pixel budget resizes with the honest aspect ratio", async () => {
+      // 1×100000 into a 4×1 box → 4×400000. The off-axis side exceeds the
+      // 0x3FFFF direct-input cap but fits i32 and the default maxPixels
+      // budget (4×400000 = 1.6M), so it must succeed at full aspect — not
+      // clamp to 4×262143.
+      const tall = makePng(1, 100000, () => [255, 0, 0, 255]);
+      const out = await new Bun.Image(tall).resize(4, 1, { fit: "outside" }).png().bytes();
+      expect(await new Bun.Image(out).metadata()).toEqual({ width: 4, height: 400000, format: "png" });
+    });
+
     test("modulate({saturation:0}) greyscales: R=G=B per pixel", async () => {
       const out = await new Bun.Image(cornersPng).modulate({ saturation: 0 }).png().bytes();
       const { data } = decodePngRaw(out);
@@ -1126,6 +1258,45 @@ describe("Bun.Image", () => {
       const { w, h } = decodePngRaw(out);
       expect(w).toBe(4);
       expect(h).toBe(3);
+    });
+
+    test("withoutEnlargement + fit:'cover' passes a both-axes-smaller source through unchanged", async () => {
+      // The resize resets to the source dims, and cover's output clamps to
+      // min(box, resized) — nothing left to crop when the source fits the
+      // box on both axes.
+      const out = await new Bun.Image(cornersPng) // 4×3
+        .resize(100, 100, { fit: "cover", withoutEnlargement: true })
+        .png()
+        .bytes();
+      const { w, h } = decodePngRaw(out);
+      expect({ w, h }).toEqual({ w: 4, h: 3 });
+    });
+
+    test("withoutEnlargement + fit:'cover' still crops an axis that exceeds the box", async () => {
+      // The short axis would need enlarging (scale > 1), so the resize
+      // resets to the source dims — but the long axis still center-crops
+      // down to the box, matching Sharp's reset-then-crop semantics.
+      const wide = makePng(200, 3, () => [255, 0, 0, 255]);
+      const out = await new Bun.Image(wide).resize(100, 100, { fit: "cover", withoutEnlargement: true }).png().bytes();
+      const { w, h } = decodePngRaw(out);
+      expect({ w, h }).toEqual({ w: 100, h: 3 });
+    });
+
+    test("withoutEnlargement + fit:'contain' still pads the canvas to the box", async () => {
+      // Only the image itself is never enlarged; the letterbox canvas is
+      // still the requested box, with the source centered.
+      const red = makePng(2, 2, () => [255, 0, 0, 255]);
+      const out = await new Bun.Image(red)
+        .resize(6, 4, { fit: "contain", withoutEnlargement: true, background: { r: 0, g: 255, b: 0, alpha: 1 } })
+        .png()
+        .bytes();
+      const { w, h, data } = decodePngRaw(out);
+      expect({ w, h }).toEqual({ w: 6, h: 4 });
+      // Source is centered at (2,1)..(3,2); corners are background.
+      expect(rgbaAt(data, 6, 0, 0)).toEqual([0, 255, 0, 255]);
+      expect(rgbaAt(data, 6, 2, 1)).toEqual([255, 0, 0, 255]);
+      expect(rgbaAt(data, 6, 3, 2)).toEqual([255, 0, 0, 255]);
+      expect(rgbaAt(data, 6, 5, 3)).toEqual([0, 255, 0, 255]);
     });
 
     test("new Response(image) encodes and sets Content-Type", async () => {


### PR DESCRIPTION
Closes #30614.

## What

Before: `Bun.Image.resize({ fit })` accepted only `"fill"` and
`"inside"`. The v1.3.14 blog post already advertised `"cover"` and
`"contain"`, so passing them threw
`ERR_INVALID_ARG_TYPE: fit must be one of 'fill' or 'inside'`.

After: all four Sharp-shaped fit modes work, plus `"outside"`:

| `fit` | Behaviour |
| --- | --- |
| `"fill"` (default) | Stretch to exactly w×h |
| `"inside"` | Preserve aspect, fit *inside* the box |
| `"outside"` | Preserve aspect, *contain* the box (no crop) |
| `"cover"` | Preserve aspect, fill the box and center-crop the rest |
| `"contain"` | Preserve aspect, letterbox with `background` |

```ts
await Bun.file("photo.jpg")
  .image()
  .resize(800, 600, { fit: "cover" })                 // CSS object-fit: cover
  .webp()
  .write("thumb.webp");

await Bun.file("photo.png")
  .image()
  .resize(800, 600, { fit: "contain", background: { r: 255, g: 255, b: 255, alpha: 1 } })
  .png()
  .write("letterboxed.png");
```

## How

`resolveResize` now returns `{ resize_w, resize_h, out_w, out_h, off_x, off_y }`.
The resize step still goes through `codecs.resize`; `cover` follows it with
a center-crop, `contain` with a pad. For `fill`/`inside`/`outside` the
resize and out dims match and no finishing pass runs.

Two new primitives in `codecs.zig`:

- `crop(src, sw, sh, x, y, cw, ch)` — strided `@memcpy` per row.
- `pad(src, sw, sh, dw, dh, ox, oy, bg)` — fill with background, then
  blit. Auto-vectorises at RGBA8.

`max_pixels` now guards the final pad canvas too, so a small resize
followed by a huge `contain` box can't slip past.

Default `background` is transparent black (`{r:0,g:0,b:0,alpha:0}`) —
renders as black in JPEG (alpha dropped) and as a transparent letterbox
in PNG/WebP, so callers can composite output without a second pass.
Sharp's default is opaque black; this keeps alpha usable without a
`removeAlpha` call.

## Verification

```
bun bd test test/js/bun/image/image.test.ts -t "fit:"
→ 6 pass, 0 fail

bun bd test test/js/bun/image/image.test.ts
→ 98 pass, 2 skip, 0 fail

USE_SYSTEM_BUN=1 bun test test/js/bun/image/image.test.ts -t "fit:"
→ 1 pass, 5 fail (the 5 new tests hit the old enum rejection)
```

Also updates `packages/bun-types/bun.d.ts` and `docs/runtime/image.mdx`
so runtime, types and docs stay aligned.

## Rebase notes

After the Rust rewrite (#30412) landed, the implementation was ported to
`Image.rs` / `codecs.rs`. The `.zig` porting-reference files are left
untouched (new behavior lives only in Rust). Rebasing onto current main
resolved two conflicts:

- `Image.rs`: main migrated string maps from `phf::phf_map!` to
  `bun_core::comptime_string_map!`; `FIT_MAP` now uses the new macro with
  all five fit entries.
- `codecs.rs`: kept the new `crop`/`pad` helpers, dropped the stale
  trailing "ported from" comment that main removed.

Re-verified after rebase: `bun bd test test/js/bun/image/image.test.ts`
is 101 pass / 2 skip / 0 fail (includes two new tall-thin overshoot
regression tests asserting the maxPixels rejection for outside/cover).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 16 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/image/image.test.ts

<!-- robobun:evidence:end -->