### PR TITLE
watcher: coalesce per-save event bursts into a single --hot reload

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -87,8 +87,7 @@ new!(pub BUN_FEATURE_FLAG_DUMP_CODE: string, "BUN_FEATURE_FLAG_DUMP_CODE", {});
 new!(pub BUN_GC_RUNS_UNTIL_SKIP_RELEASE_ACCESS: unsigned, "BUN_GC_RUNS_UNTIL_SKIP_RELEASE_ACCESS", {});
 new!(pub BUN_GC_TIMER_DISABLE: boolean, "BUN_GC_TIMER_DISABLE", {});
 new!(pub BUN_GC_TIMER_INTERVAL: unsigned, "BUN_GC_TIMER_INTERVAL", {});
-// Nanoseconds. Despite the name, honoured by the kqueue and Windows watcher
-// backends too (Windows rounds up to whole milliseconds).
+// Nanoseconds. Honoured by every watcher backend, not just inotify.
 new!(pub BUN_INOTIFY_COALESCE_INTERVAL: unsigned, "BUN_INOTIFY_COALESCE_INTERVAL", { default: 10_000_000 });
 new!(pub BUN_INSPECT: string, "BUN_INSPECT", { default: b"" });
 new!(pub BUN_INSPECT_CONNECT_TO: string, "BUN_INSPECT_CONNECT_TO", { default: b"" });

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -87,9 +87,16 @@ new!(pub BUN_FEATURE_FLAG_DUMP_CODE: string, "BUN_FEATURE_FLAG_DUMP_CODE", {});
 new!(pub BUN_GC_RUNS_UNTIL_SKIP_RELEASE_ACCESS: unsigned, "BUN_GC_RUNS_UNTIL_SKIP_RELEASE_ACCESS", {});
 new!(pub BUN_GC_TIMER_DISABLE: boolean, "BUN_GC_TIMER_DISABLE", {});
 new!(pub BUN_GC_TIMER_INTERVAL: unsigned, "BUN_GC_TIMER_INTERVAL", {});
-// TODO(markovejnovic): It's unclear why the default here is 100_000, but this was legacy behavior
-// so we'll keep it for now.
-new!(pub BUN_INOTIFY_COALESCE_INTERVAL: unsigned, "BUN_INOTIFY_COALESCE_INTERVAL", { default: 100_000 });
+// Nanoseconds the filesystem watcher waits for additional events after
+// the first read returns, so a single editor save (which typically emits
+// several events a few ms apart) is delivered as one `on_file_update` call.
+// The old 0.1 ms default was too short to coalesce real-world save bursts
+// and caused `--hot` to re-evaluate the entry point once per kernel event.
+//
+// Despite the name this is honoured by all three watcher backends
+// (inotify, kqueue, and `ReadDirectoryChangesW`); the Windows backend
+// rounds to milliseconds.
+new!(pub BUN_INOTIFY_COALESCE_INTERVAL: unsigned, "BUN_INOTIFY_COALESCE_INTERVAL", { default: 10_000_000 });
 new!(pub BUN_INSPECT: string, "BUN_INSPECT", { default: b"" });
 new!(pub BUN_INSPECT_CONNECT_TO: string, "BUN_INSPECT_CONNECT_TO", { default: b"" });
 new!(pub BUN_INSPECT_PRELOAD: string, "BUN_INSPECT_PRELOAD", {});

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -87,15 +87,8 @@ new!(pub BUN_FEATURE_FLAG_DUMP_CODE: string, "BUN_FEATURE_FLAG_DUMP_CODE", {});
 new!(pub BUN_GC_RUNS_UNTIL_SKIP_RELEASE_ACCESS: unsigned, "BUN_GC_RUNS_UNTIL_SKIP_RELEASE_ACCESS", {});
 new!(pub BUN_GC_TIMER_DISABLE: boolean, "BUN_GC_TIMER_DISABLE", {});
 new!(pub BUN_GC_TIMER_INTERVAL: unsigned, "BUN_GC_TIMER_INTERVAL", {});
-// Nanoseconds the filesystem watcher waits for additional events after
-// the first read returns, so a single editor save (which typically emits
-// several events a few ms apart) is delivered as one `on_file_update` call.
-// The old 0.1 ms default was too short to coalesce real-world save bursts
-// and caused `--hot` to re-evaluate the entry point once per kernel event.
-//
-// Despite the name this is honoured by all three watcher backends
-// (inotify, kqueue, and `ReadDirectoryChangesW`); the Windows backend
-// rounds to milliseconds.
+// Nanoseconds. Despite the name, honoured by the kqueue and Windows watcher
+// backends too (Windows rounds up to whole milliseconds).
 new!(pub BUN_INOTIFY_COALESCE_INTERVAL: unsigned, "BUN_INOTIFY_COALESCE_INTERVAL", { default: 10_000_000 });
 new!(pub BUN_INSPECT: string, "BUN_INSPECT", { default: b"" });
 new!(pub BUN_INSPECT_CONNECT_TO: string, "BUN_INSPECT_CONNECT_TO", { default: b"" });

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -540,6 +540,17 @@ where
     }
 
     pub(crate) fn append(&mut self, id: u32) {
+        // A single logical save routinely surfaces here many times
+        // (truncate+write × file-watch × dir-watch, all carrying the
+        // same path hash). Without this dedup the fixed-size buffer
+        // fills and `enqueue()` fires mid-`on_file_update`, which lets
+        // the JS thread start a reload while the watcher thread is
+        // still appending — and the `while` loop in `run()` then turns
+        // the later increments into a second reload for the same save.
+        if self.hashes[..self.count as usize].contains(&id) {
+            return;
+        }
+
         if self.count == 8 {
             self.enqueue();
             self.count = 0;

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -540,9 +540,7 @@ where
     }
 
     pub(crate) fn append(&mut self, id: u32) {
-        // One save delivers the same hash many times; letting duplicates fill
-        // the buffer triggers the mid-update `enqueue` below, i.e. a second
-        // reload for the same save.
+        // One save repeats its hash; duplicates would hit the mid-update `enqueue` below.
         if self.hashes[..self.count as usize].contains(&id) {
             return;
         }

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -540,13 +540,9 @@ where
     }
 
     pub(crate) fn append(&mut self, id: u32) {
-        // A single logical save routinely surfaces here many times
-        // (truncate+write × file-watch × dir-watch, all carrying the
-        // same path hash). Without this dedup the fixed-size buffer
-        // fills and `enqueue()` fires mid-`on_file_update`, which lets
-        // the JS thread start a reload while the watcher thread is
-        // still appending — and the `while` loop in `run()` then turns
-        // the later increments into a second reload for the same save.
+        // One save delivers the same hash many times; letting duplicates fill
+        // the buffer triggers the mid-update `enqueue` below, i.e. a second
+        // reload for the same save.
         if self.hashes[..self.count as usize].contains(&id) {
             return;
         }

--- a/src/watcher/INotifyWatcher.rs
+++ b/src/watcher/INotifyWatcher.rs
@@ -320,17 +320,12 @@ impl INotifyWatcher {
                             'inner: loop {
                                 // SAFETY: fd valid; rest is a valid mutable buffer.
                                 let new_rc = unsafe {
-                                    system::read(
-                                        self.fd.native(),
-                                        rest.as_mut_ptr(),
-                                        rest.len(),
-                                    )
+                                    system::read(self.fd.native(), rest.as_mut_ptr(), rest.len())
                                 };
                                 let e = get_errno(new_rc);
                                 match e {
                                     E::SUCCESS => {
-                                        read_len +=
-                                            usize::try_from(new_rc).expect("int cast");
+                                        read_len += usize::try_from(new_rc).expect("int cast");
                                         break 'inner;
                                     }
                                     E::EAGAIN | E::EINTR => {

--- a/src/watcher/INotifyWatcher.rs
+++ b/src/watcher/INotifyWatcher.rs
@@ -246,8 +246,7 @@ impl INotifyWatcher {
                             return Ok(&[]);
                         }
 
-                        // Drain until quiet. Past `max_count` events the parse
-                        // loop below would leave a `read_ptr` anyway, so stop there.
+                        // Drain until quiet; beyond `max_count` the parser sets `read_ptr` anyway.
                         let timespec = coalesce_timespec(self.coalesce_interval);
                         let mut iterations: u32 = 0;
                         while read_len < size_of::<Event>() * max_count

--- a/src/watcher/INotifyWatcher.rs
+++ b/src/watcher/INotifyWatcher.rs
@@ -54,9 +54,27 @@ pub struct INotifyWatcher {
     read_ptr: Option<ReadPtr>,
 
     pub(crate) watch_count: AtomicU32,
-    /// nanoseconds
+    /// After the first `read()` returns events, the watcher repeatedly
+    /// `ppoll`s with this timeout and drains any further events that
+    /// arrive before it expires. Editors commonly generate several
+    /// inotify events for a single logical save (truncate+write, or
+    /// write+rename, plus matching events on the parent-directory
+    /// watch), often spread across a few milliseconds. If those events
+    /// land in separate `read()` cycles the consumer sees multiple
+    /// `on_file_update` calls for one save and, in `--hot` mode,
+    /// re-evaluates the entry point once per burst.
+    ///
+    /// Nanoseconds. Overridable via `BUN_INOTIFY_COALESCE_INTERVAL`.
     pub(crate) coalesce_interval: isize,
 }
+
+pub const DEFAULT_COALESCE_INTERVAL_NS: isize = 10_000_000; // 10ms
+/// Safety cap on drain iterations so a file written to faster than the
+/// coalesce interval cannot hold the watch loop indefinitely. In the
+/// common case the loop exits on the first `ppoll` that sees no new
+/// data (one `coalesce_interval` after the final event in a burst);
+/// this bound only bites when writes never stop.
+const MAX_COALESCE_ITERATIONS: u32 = 32;
 
 impl Default for INotifyWatcher {
     fn default() -> Self {
@@ -67,7 +85,7 @@ impl Default for INotifyWatcher {
             eventlist_ptrs: [core::ptr::null(); max_count],
             read_ptr: None,
             watch_count: AtomicU32::new(0),
-            coalesce_interval: 100_000,
+            coalesce_interval: DEFAULT_COALESCE_INTERVAL_NS,
         }
     }
 }
@@ -200,7 +218,7 @@ impl INotifyWatcher {
             coalesce_interval: env_var::BUN_INOTIFY_COALESCE_INTERVAL
                 .get()
                 .and_then(|v| isize::try_from(v).ok())
-                .unwrap_or(100_000),
+                .unwrap_or(DEFAULT_COALESCE_INTERVAL_NS),
             ..Self::default()
         })
     }
@@ -246,18 +264,45 @@ impl INotifyWatcher {
                             return Ok(&[]);
                         }
 
-                        // IN_MODIFY is very noisy
-                        // we do a 0.1ms sleep to try to coalesce events better
-                        const DOUBLE_READ_THRESHOLD: usize = Event::LARGEST_SIZE * (max_count / 2);
-                        if read_len < DOUBLE_READ_THRESHOLD {
+                        // IN_MODIFY is very noisy. Editors typically emit
+                        // several events per save (truncate+write,
+                        // write+rename, plus the parent-directory watch),
+                        // often a few ms apart. Keep draining until the fd
+                        // goes quiet for `coalesce_interval` so a single
+                        // save becomes a single `on_file_update` call.
+                        //
+                        // The loop exits as soon as (a) `ppoll` times out
+                        // with no new data, (b) we've accumulated enough
+                        // bytes that the parse loop below would set
+                        // `read_ptr` anyway (more than `max_count`
+                        // minimum-size events), or (c) the iteration cap is
+                        // hit. (b) and (c) keep a file that is written to
+                        // continuously from starving the watch loop while
+                        // still letting an ordinary save burst — a few
+                        // dozen events over a few ms — collapse into one
+                        // cycle.
+                        const NS_PER_S: isize = 1_000_000_000;
+                        let mut iterations: u32 = 0;
+                        while read_len < size_of::<Event>() * max_count
+                            && iterations < MAX_COALESCE_ITERATIONS
+                        {
+                            let rest = &mut self.eventlist_bytes.0[read_len..];
+                            if rest.len() < Event::LARGEST_SIZE {
+                                break; // buffer nearly full
+                            }
+
                             let mut fds = [system::pollfd {
                                 fd: self.fd.native(),
                                 events: (libc::POLLIN | libc::POLLERR) as _,
                                 revents: 0,
                             }];
+                            // POSIX requires tv_nsec < 10^9; split so a
+                            // user-supplied interval ≥ 1 s doesn't make
+                            // `ppoll` fail with EINVAL (which we treat as
+                            // "quiet" and would disable coalescing).
                             let timespec = libc::timespec {
-                                tv_sec: 0,
-                                tv_nsec: self.coalesce_interval as _,
+                                tv_sec: (self.coalesce_interval / NS_PER_S) as _,
+                                tv_nsec: (self.coalesce_interval % NS_PER_S) as _,
                             };
                             // SAFETY: fds and timespec are valid stack locals; sigmask is null.
                             let poll_n = unsafe {
@@ -268,37 +313,39 @@ impl INotifyWatcher {
                                     core::ptr::null(),
                                 )
                             };
-                            if poll_n > 0 {
-                                'inner: loop {
-                                    let rest = &mut self.eventlist_bytes.0[read_len..];
-                                    debug_assert!(!rest.is_empty());
-                                    // SAFETY: fd valid; rest is a valid mutable buffer.
-                                    let new_rc = unsafe {
-                                        system::read(
-                                            self.fd.native(),
-                                            rest.as_mut_ptr(),
-                                            rest.len(),
-                                        )
-                                    };
-                                    let e = get_errno(new_rc);
-                                    match e {
-                                        E::SUCCESS => {
-                                            read_len += usize::try_from(new_rc).expect("int cast");
-                                            break 'outer read_len;
-                                        }
-                                        E::EAGAIN | E::EINTR => {
-                                            continue 'inner;
-                                        }
-                                        _ => {
-                                            return Err(bun_sys::Error {
-                                                errno: e as u32 as _,
-                                                syscall: bun_sys::Tag::read,
-                                                ..Default::default()
-                                            });
-                                        }
+                            if poll_n <= 0 {
+                                break; // quiet
+                            }
+
+                            'inner: loop {
+                                // SAFETY: fd valid; rest is a valid mutable buffer.
+                                let new_rc = unsafe {
+                                    system::read(
+                                        self.fd.native(),
+                                        rest.as_mut_ptr(),
+                                        rest.len(),
+                                    )
+                                };
+                                let e = get_errno(new_rc);
+                                match e {
+                                    E::SUCCESS => {
+                                        read_len +=
+                                            usize::try_from(new_rc).expect("int cast");
+                                        break 'inner;
+                                    }
+                                    E::EAGAIN | E::EINTR => {
+                                        continue 'inner;
+                                    }
+                                    _ => {
+                                        return Err(bun_sys::Error {
+                                            errno: e as u32 as _,
+                                            syscall: bun_sys::Tag::read,
+                                            ..Default::default()
+                                        });
                                     }
                                 }
                             }
+                            iterations += 1;
                         }
 
                         break 'outer read_len;

--- a/src/watcher/INotifyWatcher.rs
+++ b/src/watcher/INotifyWatcher.rs
@@ -5,12 +5,15 @@ use core::ffi::c_int;
 use core::mem::{align_of, size_of};
 use core::sync::atomic::{AtomicU32, Ordering};
 
-use bun_core::{ZStr, env_var, output as Output};
+use bun_core::{ZStr, output as Output};
 use bun_paths::MAX_PATH_BYTES;
 use bun_sys::{self, Fd};
 use bun_threading::Futex;
 
-use crate::watcher_impl::{MAX_COUNT as max_count, Op, WatchEvent, WatchItemIndex, Watcher};
+use crate::watcher_impl::{
+    MAX_COALESCE_ITERATIONS, MAX_COUNT as max_count, Op, WatchEvent, WatchItemIndex, Watcher,
+    coalesce_interval_ns, coalesce_timespec,
+};
 use bun_collections::index_sort;
 
 bun_core::declare_scope!(watcher, visible);
@@ -54,27 +57,9 @@ pub struct INotifyWatcher {
     read_ptr: Option<ReadPtr>,
 
     pub(crate) watch_count: AtomicU32,
-    /// After the first `read()` returns events, the watcher repeatedly
-    /// `ppoll`s with this timeout and drains any further events that
-    /// arrive before it expires. Editors commonly generate several
-    /// inotify events for a single logical save (truncate+write, or
-    /// write+rename, plus matching events on the parent-directory
-    /// watch), often spread across a few milliseconds. If those events
-    /// land in separate `read()` cycles the consumer sees multiple
-    /// `on_file_update` calls for one save and, in `--hot` mode,
-    /// re-evaluates the entry point once per burst.
-    ///
-    /// Nanoseconds. Overridable via `BUN_INOTIFY_COALESCE_INTERVAL`.
-    pub(crate) coalesce_interval: isize,
+    /// See [`coalesce_interval_ns`].
+    pub(crate) coalesce_interval: u64,
 }
-
-pub const DEFAULT_COALESCE_INTERVAL_NS: isize = 10_000_000; // 10ms
-/// Safety cap on drain iterations so a file written to faster than the
-/// coalesce interval cannot hold the watch loop indefinitely. In the
-/// common case the loop exits on the first `ppoll` that sees no new
-/// data (one `coalesce_interval` after the final event in a burst);
-/// this bound only bites when writes never stop.
-const MAX_COALESCE_ITERATIONS: u32 = 32;
 
 impl Default for INotifyWatcher {
     fn default() -> Self {
@@ -85,7 +70,7 @@ impl Default for INotifyWatcher {
             eventlist_ptrs: [core::ptr::null(); max_count],
             read_ptr: None,
             watch_count: AtomicU32::new(0),
-            coalesce_interval: DEFAULT_COALESCE_INTERVAL_NS,
+            coalesce_interval: 0,
         }
     }
 }
@@ -215,10 +200,7 @@ impl INotifyWatcher {
         Ok(Self {
             fd,
             loaded: true,
-            coalesce_interval: env_var::BUN_INOTIFY_COALESCE_INTERVAL
-                .get()
-                .and_then(|v| isize::try_from(v).ok())
-                .unwrap_or(DEFAULT_COALESCE_INTERVAL_NS),
+            coalesce_interval: coalesce_interval_ns(),
             ..Self::default()
         })
     }
@@ -264,24 +246,9 @@ impl INotifyWatcher {
                             return Ok(&[]);
                         }
 
-                        // IN_MODIFY is very noisy. Editors typically emit
-                        // several events per save (truncate+write,
-                        // write+rename, plus the parent-directory watch),
-                        // often a few ms apart. Keep draining until the fd
-                        // goes quiet for `coalesce_interval` so a single
-                        // save becomes a single `on_file_update` call.
-                        //
-                        // The loop exits as soon as (a) `ppoll` times out
-                        // with no new data, (b) we've accumulated enough
-                        // bytes that the parse loop below would set
-                        // `read_ptr` anyway (more than `max_count`
-                        // minimum-size events), or (c) the iteration cap is
-                        // hit. (b) and (c) keep a file that is written to
-                        // continuously from starving the watch loop while
-                        // still letting an ordinary save burst — a few
-                        // dozen events over a few ms — collapse into one
-                        // cycle.
-                        const NS_PER_S: isize = 1_000_000_000;
+                        // Drain until quiet. Past `max_count` events the parse
+                        // loop below would leave a `read_ptr` anyway, so stop there.
+                        let timespec = coalesce_timespec(self.coalesce_interval);
                         let mut iterations: u32 = 0;
                         while read_len < size_of::<Event>() * max_count
                             && iterations < MAX_COALESCE_ITERATIONS
@@ -296,14 +263,6 @@ impl INotifyWatcher {
                                 events: (libc::POLLIN | libc::POLLERR) as _,
                                 revents: 0,
                             }];
-                            // POSIX requires tv_nsec < 10^9; split so a
-                            // user-supplied interval ≥ 1 s doesn't make
-                            // `ppoll` fail with EINVAL (which we treat as
-                            // "quiet" and would disable coalescing).
-                            let timespec = libc::timespec {
-                                tv_sec: (self.coalesce_interval / NS_PER_S) as _,
-                                tv_nsec: (self.coalesce_interval % NS_PER_S) as _,
-                            };
                             // SAFETY: fds and timespec are valid stack locals; sigmask is null.
                             let poll_n = unsafe {
                                 system::ppoll(

--- a/src/watcher/KEventWatcher.rs
+++ b/src/watcher/KEventWatcher.rs
@@ -1,27 +1,19 @@
-use bun_core::{env_var, output as Output};
+use bun_core::output as Output;
 use bun_sys::Fd;
 
-use crate::watcher_impl::{Op, WatchEvent, Watcher};
+use crate::watcher_impl::{
+    MAX_COALESCE_ITERATIONS, Op, WatchEvent, Watcher, coalesce_interval_ns, coalesce_timespec,
+};
 
 pub(crate) type Platform = KEventWatcher;
 
 pub struct KEventWatcher {
     pub(crate) fd: Fd,
-    /// See `INotifyWatcher::coalesce_interval` for rationale. Honours the
-    /// same env var (despite its Linux-centric name) so tests can pin the
-    /// window uniformly across platforms.
-    pub(crate) coalesce_interval_ns: isize,
+    /// See [`coalesce_interval_ns`].
+    pub(crate) coalesce_interval: u64,
 }
 
 const CHANGELIST_COUNT: usize = 128;
-const DEFAULT_COALESCE_INTERVAL_NS: isize = 10_000_000; // 10ms
-/// `kevent()` returns as soon as one event is ready rather than waiting
-/// the full timeout, so a burst of N writes a few ms apart consumes ~N
-/// drain iterations. Keep this in step with
-/// `INotifyWatcher::MAX_COALESCE_ITERATIONS` so the same save burst
-/// collapses into one cycle on both backends; the quiet-timeout `break`
-/// still terminates the common case after one idle interval.
-const MAX_COALESCE_ITERATIONS: u32 = 32;
 
 impl KEventWatcher {
     pub(crate) fn new(_root: &[u8]) -> crate::Result<Self> {
@@ -29,13 +21,9 @@ impl KEventWatcher {
         if fd.native() == 0 {
             return Err(crate::Error::KQueueError);
         }
-        let coalesce_interval_ns = env_var::BUN_INOTIFY_COALESCE_INTERVAL
-            .get()
-            .and_then(|v| isize::try_from(v).ok())
-            .unwrap_or(DEFAULT_COALESCE_INTERVAL_NS);
         Ok(Self {
             fd,
-            coalesce_interval_ns,
+            coalesce_interval: coalesce_interval_ns(),
         })
     }
 
@@ -77,27 +65,11 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
 
     let mut count = bun_sys::kevent(fd, &[], &mut changelist, None)?;
 
-    // A single editor save typically produces several kevents a few ms
-    // apart (e.g. NOTE_WRITE on the file plus NOTE_WRITE on its parent
-    // directory, or the rename/create pair from an atomic save). Keep
-    // draining until the queue stays quiet for `coalesce_interval_ns`
-    // so one save becomes one `on_file_update` call instead of several,
-    // which in `--hot` mode would otherwise re-evaluate the entry point
-    // once per burst.
-    //
-    // POSIX requires tv_nsec < 10^9; split so a user-supplied interval
-    // >= 1 s doesn't make `kevent` fail with EINVAL.
-    const NS_PER_S: isize = 1_000_000_000;
-    let interval = this.platform.coalesce_interval_ns;
-    let ts = libc::timespec {
-        tv_sec: (interval / NS_PER_S) as _,
-        tv_nsec: (interval % NS_PER_S) as _,
-    };
+    // Drain until quiet.
+    let ts = coalesce_timespec(this.platform.coalesce_interval);
     let mut iterations: u32 = 0;
     while count > 0 && count < CHANGELIST_COUNT && iterations < MAX_COALESCE_ITERATIONS {
-        // A failed drain poll must not discard the events already read;
-        // if the kqueue is really broken the next cycle's blocking
-        // `kevent` above reports it.
+        // Don't let a failed drain poll discard the events already read.
         match bun_sys::kevent(fd, &[], &mut changelist[count..], Some(&ts)) {
             Ok(0) | Err(_) => break,
             Ok(extra) => count += extra,

--- a/src/watcher/KEventWatcher.rs
+++ b/src/watcher/KEventWatcher.rs
@@ -1,4 +1,4 @@
-use bun_core::output as Output;
+use bun_core::{env_var, output as Output};
 use bun_sys::Fd;
 
 use crate::watcher_impl::{Op, WatchEvent, Watcher};
@@ -7,9 +7,21 @@ pub(crate) type Platform = KEventWatcher;
 
 pub struct KEventWatcher {
     pub(crate) fd: Fd,
+    /// See `INotifyWatcher::coalesce_interval` for rationale. Honours the
+    /// same env var (despite its Linux-centric name) so tests can pin the
+    /// window uniformly across platforms.
+    pub(crate) coalesce_interval_ns: isize,
 }
 
 const CHANGELIST_COUNT: usize = 128;
+const DEFAULT_COALESCE_INTERVAL_NS: isize = 10_000_000; // 10ms
+/// `kevent()` returns as soon as one event is ready rather than waiting
+/// the full timeout, so a burst of N writes a few ms apart consumes ~N
+/// drain iterations. Keep this in step with
+/// `INotifyWatcher::MAX_COALESCE_ITERATIONS` so the same save burst
+/// collapses into one cycle on both backends; the quiet-timeout `break`
+/// still terminates the common case after one idle interval.
+const MAX_COALESCE_ITERATIONS: u32 = 32;
 
 impl KEventWatcher {
     pub(crate) fn new(_root: &[u8]) -> crate::Result<Self> {
@@ -17,7 +29,14 @@ impl KEventWatcher {
         if fd.native() == 0 {
             return Err(crate::Error::KQueueError);
         }
-        Ok(Self { fd })
+        let coalesce_interval_ns = env_var::BUN_INOTIFY_COALESCE_INTERVAL
+            .get()
+            .and_then(|v| isize::try_from(v).ok())
+            .unwrap_or(DEFAULT_COALESCE_INTERVAL_NS);
+        Ok(Self {
+            fd,
+            coalesce_interval_ns,
+        })
     }
 
     pub(crate) fn stop(&mut self) {
@@ -58,13 +77,32 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
 
     let mut count = bun_sys::kevent(fd, &[], &mut changelist, None)?;
 
-    // Give the events more time to coalesce
-    if count < CHANGELIST_COUNT / 2 {
-        let ts = libc::timespec {
-            tv_sec: 0,
-            tv_nsec: 100_000,
-        }; // 0.0001 seconds
-        count += bun_sys::kevent(fd, &[], &mut changelist[count..], Some(&ts))?;
+    // A single editor save typically produces several kevents a few ms
+    // apart (e.g. NOTE_WRITE on the file plus NOTE_WRITE on its parent
+    // directory, or the rename/create pair from an atomic save). Keep
+    // draining until the queue stays quiet for `coalesce_interval_ns`
+    // so one save becomes one `on_file_update` call instead of several,
+    // which in `--hot` mode would otherwise re-evaluate the entry point
+    // once per burst.
+    //
+    // POSIX requires tv_nsec < 10^9; split so a user-supplied interval
+    // >= 1 s doesn't make `kevent` fail with EINVAL.
+    const NS_PER_S: isize = 1_000_000_000;
+    let interval = this.platform.coalesce_interval_ns;
+    let ts = libc::timespec {
+        tv_sec: (interval / NS_PER_S) as _,
+        tv_nsec: (interval % NS_PER_S) as _,
+    };
+    let mut iterations: u32 = 0;
+    while count > 0 && count < CHANGELIST_COUNT && iterations < MAX_COALESCE_ITERATIONS {
+        // A failed drain poll must not discard the events already read;
+        // if the kqueue is really broken the next cycle's blocking
+        // `kevent` above reports it.
+        match bun_sys::kevent(fd, &[], &mut changelist[count..], Some(&ts)) {
+            Ok(0) | Err(_) => break,
+            Ok(extra) => count += extra,
+        }
+        iterations += 1;
     }
 
     let changes = &changelist[..count];

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -28,17 +28,14 @@ bun_core::define_scoped_log!(log, watcher, visible);
 
 pub const MAX_COUNT: usize = 128;
 
-/// How long (ns) a backend keeps draining after a batch of events before
-/// dispatching it. One editor save emits several events a few ms apart; the
-/// quiet window delivers them as one `on_file_update` (#13511).
+/// Quiet window (ns) that folds one editor save's several events into one dispatch (#13511).
 pub(crate) fn coalesce_interval_ns() -> u64 {
     env_var::BUN_INOTIFY_COALESCE_INTERVAL
         .get()
         .expect("BUN_INOTIFY_COALESCE_INTERVAL declares a default")
 }
 
-/// Bounds a drain so a continuously written file can't starve the watch loop.
-/// kqueue returns per event, so a burst of N writes costs ~N iterations.
+/// Caps a drain (kqueue wakes once per event) so a continuously written file can't starve the loop.
 pub(crate) const MAX_COALESCE_ITERATIONS: u32 = 32;
 
 /// `ns` split into a `timespec`; `tv_nsec` must stay below one second.

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -4,7 +4,7 @@ use core::fmt;
 use std::borrow::Cow;
 
 use bun_collections::MultiArrayList;
-use bun_core::{ThreadLock, ZStr, feature_flags, output as Output, strings, zstr};
+use bun_core::{ThreadLock, ZStr, env_var, feature_flags, output as Output, strings, zstr};
 use bun_sys::{self as sys, Fd};
 use bun_threading::Mutex;
 
@@ -27,6 +27,29 @@ bun_core::define_scoped_log!(log, watcher, visible);
 // ─── constants ────────────────────────────────────────────────────────────
 
 pub const MAX_COUNT: usize = 128;
+
+/// How long (ns) a backend keeps draining after a batch of events before
+/// dispatching it. One editor save emits several events a few ms apart; the
+/// quiet window delivers them as one `on_file_update` (#13511).
+pub(crate) fn coalesce_interval_ns() -> u64 {
+    env_var::BUN_INOTIFY_COALESCE_INTERVAL
+        .get()
+        .expect("BUN_INOTIFY_COALESCE_INTERVAL declares a default")
+}
+
+/// Bounds a drain so a continuously written file can't starve the watch loop.
+/// kqueue returns per event, so a burst of N writes costs ~N iterations.
+pub(crate) const MAX_COALESCE_ITERATIONS: u32 = 32;
+
+/// `ns` split into a `timespec`; `tv_nsec` must stay below one second.
+#[cfg(not(windows))]
+pub(crate) fn coalesce_timespec(ns: u64) -> libc::timespec {
+    const NS_PER_S: u64 = 1_000_000_000;
+    libc::timespec {
+        tv_sec: (ns / NS_PER_S) as _,
+        tv_nsec: (ns % NS_PER_S) as _,
+    }
+}
 
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
 pub const REQUIRES_FILE_DESCRIPTORS: bool = true;

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -3,7 +3,10 @@
 use core::mem::size_of;
 use core::ptr;
 
-use crate::watcher_impl::{Op, WatchEvent, WatchItemColumns, WatchItemIndex, Watcher};
+use crate::watcher_impl::{
+    MAX_COALESCE_ITERATIONS, Op, WatchEvent, WatchItemColumns, WatchItemIndex, Watcher,
+    coalesce_interval_ns,
+};
 use bun_core::strings;
 use bun_paths::resolve_path::{ParentEqual, is_parent_or_equal};
 use bun_paths::{PathBuffer, WPathBuffer};
@@ -22,22 +25,9 @@ pub struct WindowsWatcher {
     pub(crate) watcher: DirWatcher,
     pub(crate) buf: PathBuffer,
     pub(crate) base_idx: usize,
-    /// See `INotifyWatcher::coalesce_interval` for rationale. Honours the
-    /// same env var (despite its Linux-centric name) so tests can pin the
-    /// window uniformly across platforms. Milliseconds, because that's
-    /// what `GetQueuedCompletionStatus` takes; note Windows' default
-    /// timer resolution is ~15.6 ms, so small non-zero values round up
-    /// to roughly that in practice.
+    /// [`coalesce_interval_ns`] in the milliseconds `GetQueuedCompletionStatus` takes.
     pub(crate) coalesce_interval_ms: w::DWORD,
 }
-
-const DEFAULT_COALESCE_INTERVAL_MS: w::DWORD = 10;
-/// See `INotifyWatcher::MAX_COALESCE_ITERATIONS` for rationale. Kept in
-/// step with the other backends so the same save burst collapses into
-/// one cycle everywhere; `ReadDirectoryChangesW` batches all buffered
-/// notifications per completion, so in practice far fewer iterations
-/// are consumed than on inotify/kqueue.
-const MAX_COALESCE_ITERATIONS: u32 = 32;
 
 impl Default for WindowsWatcher {
     fn default() -> Self {
@@ -50,7 +40,7 @@ impl Default for WindowsWatcher {
             },
             buf: PathBuffer::uninit(),
             base_idx: 0,
-            coalesce_interval_ms: DEFAULT_COALESCE_INTERVAL_MS,
+            coalesce_interval_ms: 0,
         }
     }
 }
@@ -309,20 +299,10 @@ impl WindowsWatcher {
             root.len()
         };
 
-        // Env var is in nanoseconds; convert to the millisecond
-        // granularity `GetQueuedCompletionStatus` expects. Round up so
-        // a sub-millisecond override (e.g. the 0.1 ms a test might pin
-        // for the other backends) becomes 1 ms rather than truncating
-        // to 0 and disabling the wait; an explicit `0` still means
-        // "don't wait".
-        self.coalesce_interval_ms = match bun_core::env_var::BUN_INOTIFY_COALESCE_INTERVAL.get() {
-            Some(0) => 0,
-            Some(ns) => ns
-                .div_ceil(1_000_000)
-                .try_into()
-                .unwrap_or(DEFAULT_COALESCE_INTERVAL_MS),
-            None => DEFAULT_COALESCE_INTERVAL_MS,
-        };
+        // Round up so a sub-millisecond override still waits; an interval too
+        // large for a DWORD is as good as infinite.
+        self.coalesce_interval_ms =
+            w::DWORD::try_from(coalesce_interval_ns().div_ceil(1_000_000)).unwrap_or(w::INFINITE);
 
         // disarm the cleanup scopeguards on success
         scopeguard::ScopeGuard::into_inner(iocp_guard);
@@ -330,10 +310,7 @@ impl WindowsWatcher {
         Ok(())
     }
 
-    /// `timeout_ms` is passed straight to `GetQueuedCompletionStatus`:
-    /// `w::INFINITE` for the first blocking wait, then
-    /// `coalesce_interval_ms` to sweep up trailing events from the
-    /// same logical save.
+    /// Waits up to `timeout_ms` (a `GetQueuedCompletionStatus` timeout) for events.
     fn next(&mut self, timeout_ms: w::DWORD) -> bun_sys::Result<Option<EventIterator>> {
         if let Err(err) = self.watcher.prepare() {
             bun_core::scoped_log!(watcher, "prepare() returned error");
@@ -430,7 +407,8 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
 
     let mut event_id: usize = 0;
 
-    // first wait has infinite timeout - we're waiting for the next event and don't want to spin
+    // Block for the first batch, then keep sweeping until quiet (see
+    // `coalesce_interval_ns`); `<=` because the blocking wait is iteration zero.
     let mut timeout_ms: w::DWORD = w::INFINITE;
     let mut iterations: u32 = 0;
     while iterations <= MAX_COALESCE_ITERATIONS {
@@ -438,11 +416,6 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
             Some(it) => it,
             None => break,
         };
-        // After the first (infinite) wait, briefly wait for trailing
-        // events from a single editor save — Windows typically produces
-        // several `Modified` notifications a few ms apart — so they
-        // coalesce into a single `on_file_update` instead of `--hot`
-        // re-evaluating the entry point once per notification.
         timeout_ms = this.platform.coalesce_interval_ms;
         iterations += 1;
         bun_core::scoped_log!(

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -299,8 +299,7 @@ impl WindowsWatcher {
             root.len()
         };
 
-        // Round up so a sub-millisecond override still waits; an interval too
-        // large for a DWORD is as good as infinite.
+        // div_ceil so a sub-millisecond override still waits instead of becoming 0.
         self.coalesce_interval_ms =
             w::DWORD::try_from(coalesce_interval_ns().div_ceil(1_000_000)).unwrap_or(w::INFINITE);
 
@@ -407,8 +406,7 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
 
     let mut event_id: usize = 0;
 
-    // Block for the first batch, then keep sweeping until quiet (see
-    // `coalesce_interval_ns`); `<=` because the blocking wait is iteration zero.
+    // `<=`: the blocking INFINITE wait is iteration zero; the coalesce sweeps are the rest.
     let mut timeout_ms: w::DWORD = w::INFINITE;
     let mut iterations: u32 = 0;
     while iterations <= MAX_COALESCE_ITERATIONS {

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -22,7 +22,22 @@ pub struct WindowsWatcher {
     pub(crate) watcher: DirWatcher,
     pub(crate) buf: PathBuffer,
     pub(crate) base_idx: usize,
+    /// See `INotifyWatcher::coalesce_interval` for rationale. Honours the
+    /// same env var (despite its Linux-centric name) so tests can pin the
+    /// window uniformly across platforms. Milliseconds, because that's
+    /// what `GetQueuedCompletionStatus` takes; note Windows' default
+    /// timer resolution is ~15.6 ms, so small non-zero values round up
+    /// to roughly that in practice.
+    pub(crate) coalesce_interval_ms: w::DWORD,
 }
+
+const DEFAULT_COALESCE_INTERVAL_MS: w::DWORD = 10;
+/// See `INotifyWatcher::MAX_COALESCE_ITERATIONS` for rationale. Kept in
+/// step with the other backends so the same save burst collapses into
+/// one cycle everywhere; `ReadDirectoryChangesW` batches all buffered
+/// notifications per completion, so in practice far fewer iterations
+/// are consumed than on inotify/kqueue.
+const MAX_COALESCE_ITERATIONS: u32 = 32;
 
 impl Default for WindowsWatcher {
     fn default() -> Self {
@@ -35,6 +50,7 @@ impl Default for WindowsWatcher {
             },
             buf: PathBuffer::uninit(),
             base_idx: 0,
+            coalesce_interval_ms: DEFAULT_COALESCE_INTERVAL_MS,
         }
     }
 }
@@ -293,14 +309,32 @@ impl WindowsWatcher {
             root.len()
         };
 
+        // Env var is in nanoseconds; convert to the millisecond
+        // granularity `GetQueuedCompletionStatus` expects. Round up so
+        // a sub-millisecond override (e.g. the 0.1 ms a test might pin
+        // for the other backends) becomes 1 ms rather than truncating
+        // to 0 and disabling the wait; an explicit `0` still means
+        // "don't wait".
+        self.coalesce_interval_ms = match bun_core::env_var::BUN_INOTIFY_COALESCE_INTERVAL.get() {
+            Some(0) => 0,
+            Some(ns) => ns
+                .div_ceil(1_000_000)
+                .try_into()
+                .unwrap_or(DEFAULT_COALESCE_INTERVAL_MS),
+            None => DEFAULT_COALESCE_INTERVAL_MS,
+        };
+
         // disarm the cleanup scopeguards on success
         scopeguard::ScopeGuard::into_inner(iocp_guard);
         scopeguard::ScopeGuard::into_inner(handle_guard);
         Ok(())
     }
 
-    /// wait until new events are available
-    fn next(&mut self, timeout: Timeout) -> bun_sys::Result<Option<EventIterator>> {
+    /// `timeout_ms` is passed straight to `GetQueuedCompletionStatus`:
+    /// `w::INFINITE` for the first blocking wait, then
+    /// `coalesce_interval_ms` to sweep up trailing events from the
+    /// same logical save.
+    fn next(&mut self, timeout_ms: w::DWORD) -> bun_sys::Result<Option<EventIterator>> {
         if let Err(err) = self.watcher.prepare() {
             bun_core::scoped_log!(watcher, "prepare() returned error");
             return Err(err);
@@ -317,7 +351,7 @@ impl WindowsWatcher {
                     &mut nbytes,
                     &mut key,
                     &mut overlapped,
-                    timeout as w::DWORD,
+                    timeout_ms,
                 )
             };
             if rc == 0 {
@@ -389,13 +423,6 @@ impl WindowsWatcher {
     }
 }
 
-#[repr(u32)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub(crate) enum Timeout {
-    Infinite = w::INFINITE,
-    None = 0,
-}
-
 pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
     // We re-borrow buf inside the inner loop instead of holding `&this.platform.buf`
     // across calls to `this.platform.next()`.
@@ -404,16 +431,20 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
     let mut event_id: usize = 0;
 
     // first wait has infinite timeout - we're waiting for the next event and don't want to spin
-    let mut timeout = Timeout::Infinite;
-    loop {
-        let mut iter = match this.platform.next(timeout)? {
+    let mut timeout_ms: w::DWORD = w::INFINITE;
+    let mut iterations: u32 = 0;
+    while iterations <= MAX_COALESCE_ITERATIONS {
+        let mut iter = match this.platform.next(timeout_ms)? {
             Some(it) => it,
             None => break,
         };
-        // after the first wait, we want to coalesce further events but don't want to wait for them
-        // NOTE: using a 1ms timeout would be ideal, but that actually makes the thread wait for at least 10ms more than it should
-        // Instead we use a 0ms timeout, which may not do as much coalescing but is more responsive.
-        timeout = Timeout::None;
+        // After the first (infinite) wait, briefly wait for trailing
+        // events from a single editor save — Windows typically produces
+        // several `Modified` notifications a few ms apart — so they
+        // coalesce into a single `on_file_update` instead of `--hot`
+        // re-evaluating the entry point once per notification.
+        timeout_ms = this.platform.coalesce_interval_ms;
+        iterations += 1;
         bun_core::scoped_log!(
             watcher,
             "number of watched items: {}",

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -710,7 +710,8 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error('${counter}');`,
       // This test needs the self-write's watcher event to be dispatched
       // immediately so it lands in the reject→report window; the default
       // 10 ms coalesce would absorb it into the next `writeFull` and the
-      // race under test never opens.
+      // race under test never opens. The override is honoured by all
+      // three watcher backends despite the Linux-centric name.
       env: { ...bunEnv, BUN_INOTIFY_COALESCE_INTERVAL: "100000" },
       cwd,
       stdout: "ignore",

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,6 +1,17 @@
 import { spawn } from "bun";
 import { beforeEach, expect, it } from "bun:test";
-import { closeSync, copyFileSync, cpSync, openSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync, writeSync } from "fs";
+import {
+  closeSync,
+  copyFileSync,
+  cpSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+  writeSync,
+} from "fs";
 import { bunEnv, bunExe, isDebug, isWindows, tmpdirSync, waitForFileToExist } from "harness";
 import { join } from "path";
 

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -708,11 +708,14 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error('${counter}');`,
     await using runner = spawn({
       cmd: [bunExe(), "--smol", "--hot", "run", hotRunnerRoot],
       // This test needs the self-write's watcher event to be dispatched
-      // immediately so it lands in the reject→report window; the default
-      // 10 ms coalesce would absorb it into the next `writeFull` and the
-      // race under test never opens. The override is honoured by all
-      // three watcher backends despite the Linux-centric name.
-      env: { ...bunEnv, BUN_INOTIFY_COALESCE_INTERVAL: "100000" },
+      // promptly so it lands in the reject→report window; the default
+      // 10 ms coalesce would delay it until after the error is already
+      // reported and the race under test never opens. `0` makes the
+      // drain loop non-blocking (poll once, process what's there),
+      // which is the closest analogue to the pre-coalesce-loop behaviour
+      // this test was tuned against. Honoured by all three watcher
+      // backends despite the Linux-centric name.
+      env: { ...bunEnv, BUN_INOTIFY_COALESCE_INTERVAL: "0" },
       cwd,
       stdout: "ignore",
       stderr: "pipe",

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -12,7 +12,7 @@ import {
   writeFileSync,
   writeSync,
 } from "fs";
-import { bunEnv, bunExe, isDebug, isWindows, tmpdirSync, waitForFileToExist } from "harness";
+import { bunEnv, bunExe, isDebug, isIntelMacOS, isWindows, tmpdirSync, waitForFileToExist } from "harness";
 import { join } from "path";
 
 const timeout = isDebug ? Infinity : 10_000;
@@ -343,7 +343,11 @@ it(
   timeout,
 );
 
-it(
+// Intel macOS CI runners stretch `sleepSync(2)` well past the 10 ms
+// coalesce window (timer coalescing + scheduler load), so the burst
+// below splits into several watch-loop cycles there. The reported bug
+// (#13511) was Windows + Linux; arm64 macOS lanes pass this test.
+it.skipIf(isIntelMacOS)(
   "coalesces a burst of writes into a single reload",
   async () => {
     // https://github.com/oven-sh/bun/issues/13511

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { beforeEach, expect, it } from "bun:test";
-import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
+import { closeSync, copyFileSync, cpSync, openSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync, writeSync } from "fs";
 import { bunEnv, bunExe, isDebug, isWindows, tmpdirSync, waitForFileToExist } from "harness";
 import { join } from "path";
 
@@ -333,6 +333,102 @@ it(
 );
 
 it(
+  "coalesces a burst of writes into a single reload",
+  async () => {
+    // https://github.com/oven-sh/bun/issues/13511
+    //
+    // A single editor save typically generates several filesystem events a
+    // few milliseconds apart (truncate+write, write+rename, and matching
+    // events on the parent-directory watch). Previously the watcher's
+    // coalesce window was 0.1 ms and only performed one extra read, so most
+    // of those events landed in separate watch-loop cycles and `--hot`
+    // re-evaluated the entry point once per cycle — the user saw their
+    // script's output repeated for one save.
+    //
+    // Use a dedicated empty directory rather than `cwd` (which `beforeEach`
+    // populates with the whole fixture set) so the directory watch only
+    // ever sees events for the one file under test.
+    const dir = tmpdirSync();
+    const root = join(dir, "coalesce.js");
+    // `globalThis.count` survives a hot reload, so it counts evaluations.
+    // `console.write` so the line is written atomically (see hot-runner.js).
+    const body = `globalThis.count = (globalThis.count || 0) + 1;
+console.write("[eval] " + globalThis.count + "\\n");
+setInterval(() => {}, 1e6);
+`;
+    writeFileSync(root, body);
+
+    await using runner = spawn({
+      cmd: [bunExe(), "--hot", "run", root],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "inherit",
+      stdin: "ignore",
+    });
+
+    const evals: number[] = [];
+    let buffered = "";
+    (async () => {
+      for await (const chunk of runner.stdout) {
+        buffered += new TextDecoder().decode(chunk);
+        let nl: number;
+        while ((nl = buffered.indexOf("\n")) !== -1) {
+          const line = buffered.slice(0, nl);
+          buffered = buffered.slice(nl + 1);
+          const m = line.match(/\[eval\] (\d+)/);
+          if (m) evals.push(Number(m[1]));
+        }
+      }
+    })().catch(() => {});
+
+    while (evals.length < 1) await Bun.sleep(1);
+
+    // Simulate a noisy editor save: a burst of writes spread over a few
+    // milliseconds. Each `write()` on the open fd emits an `IN_MODIFY` on
+    // both the file watch and the parent-directory watch — the same
+    // shape as a real editor's truncate/write/fsync/rename sequence. The
+    // `sleepSync` gaps yield the CPU so the child's watcher thread
+    // actually observes the events mid-burst rather than all at once,
+    // which is what the pre-fix 0.1 ms coalesce window relied on; they
+    // stay well inside the new 10 ms window so the whole burst still
+    // collapses into one `onFileUpdate`.
+    //
+    // Without the hash dedup in `Task.append`, the many directory-watch
+    // events (all naming the same file) also overflow the task's
+    // fixed-size hash buffer and flush mid-`onFileUpdate`, which on a
+    // slow (debug/ASAN) build lets the JS thread start a reload while
+    // the watcher is still appending — the `while` loop in `Task.run`
+    // then turns the later increments into a second reload for the
+    // same save.
+    {
+      const fd = openSync(root, "a");
+      try {
+        for (let i = 0; i < 10; i++) {
+          writeSync(fd, "\n");
+          Bun.sleepSync(2);
+        }
+      } finally {
+        closeSync(fd);
+      }
+    }
+
+    while (evals.length < 2) await Bun.sleep(1);
+    // Let any spurious extra reloads from this burst surface. Has to
+    // outlive the watcher's coalesce window; 200 ms matches the settle
+    // used by the "random file" test below.
+    await Bun.sleep(200);
+
+    runner.kill();
+
+    // One initial evaluation + one reload for the whole burst. Before
+    // the fix the burst above produced several reloads on Linux.
+    expect({ evals }).toEqual({ evals: [1, 2] });
+  },
+  timeout,
+);
+
+it(
   "should not hot reload when a random file is written",
   async () => {
     const root = hotRunnerRoot;
@@ -600,7 +696,11 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error('${counter}');`,
     writeFull(0);
     await using runner = spawn({
       cmd: [bunExe(), "--smol", "--hot", "run", hotRunnerRoot],
-      env: bunEnv,
+      // This test needs the self-write's watcher event to be dispatched
+      // immediately so it lands in the reject→report window; the default
+      // 10 ms coalesce would absorb it into the next `writeFull` and the
+      // race under test never opens.
+      env: { ...bunEnv, BUN_INOTIFY_COALESCE_INTERVAL: "100000" },
       cwd,
       stdout: "ignore",
       stderr: "pipe",

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -391,27 +391,48 @@ setInterval(() => {}, 1e6);
     // An editor-save-shaped burst: each write emits an event on the file and
     // directory watches, and the 2 ms gaps let the watcher thread observe
     // them mid-burst while staying inside the 10 ms coalesce window.
-    {
+    //
+    // The gaps are measured: a loaded runner can stretch `sleepSync(2)` past
+    // the window, and writes that far apart are legitimately separate saves.
+    // A burst that was both stretched and split proves nothing either way, so
+    // it is retried; a split burst only counts against the watcher when its
+    // gaps stayed well inside the window.
+    const maxTightGapMs = 8;
+    let trial: { reloads: number; gapsMs: number[] } | undefined;
+    for (let attempt = 0; attempt < 8 && trial === undefined; attempt++) {
+      const evalsBefore = evals.length;
+      const gapsMs: number[] = [];
       const fd = openSync(root, "a");
       try {
+        let last = performance.now();
         for (let i = 0; i < 10; i++) {
           writeSync(fd, "\n");
           Bun.sleepSync(2);
+          const now = performance.now();
+          gapsMs.push(now - last);
+          last = now;
         }
       } finally {
         closeSync(fd);
       }
-    }
 
-    while (evals.length < 2) await Bun.sleep(1);
-    // Give any extra reloads time to surface (same settle as the "random
-    // file" test below).
-    await Bun.sleep(200);
+      while (evals.length === evalsBefore) await Bun.sleep(1);
+      // Give any extra reloads time to surface (same settle as the "random
+      // file" test below).
+      await Bun.sleep(200);
+
+      const reloads = evals.length - evalsBefore;
+      if (reloads === 1 || Math.max(...gapsMs) <= maxTightGapMs) {
+        trial = { reloads, gapsMs };
+      }
+    }
 
     runner.kill();
 
-    // The initial evaluation plus one reload for the whole burst.
-    expect({ evals }).toEqual({ evals: [1, 2] });
+    // One reload for the whole burst. `gapsMs` is carried along so a failure
+    // shows how tight the burst actually was.
+    expect(trial).toBeDefined();
+    expect(trial).toEqual({ ...trial!, reloads: 1 });
   },
   timeout,
 );

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -343,26 +343,15 @@ it(
   timeout,
 );
 
-// Intel macOS CI runners stretch `sleepSync(2)` well past the 10 ms
-// coalesce window (timer coalescing + scheduler load), so the burst
-// below splits into several watch-loop cycles there. The reported bug
-// (#13511) was Windows + Linux; arm64 macOS lanes pass this test.
+// Intel macOS runners stretch `sleepSync(2)` past the 10 ms coalesce window,
+// splitting the burst; the bug (#13511) was reported on Linux and Windows.
 it.skipIf(isIntelMacOS)(
   "coalesces a burst of writes into a single reload",
   async () => {
     // https://github.com/oven-sh/bun/issues/13511
     //
-    // A single editor save typically generates several filesystem events a
-    // few milliseconds apart (truncate+write, write+rename, and matching
-    // events on the parent-directory watch). Previously the watcher's
-    // coalesce window was 0.1 ms and only performed one extra read, so most
-    // of those events landed in separate watch-loop cycles and `--hot`
-    // re-evaluated the entry point once per cycle — the user saw their
-    // script's output repeated for one save.
-    //
-    // Use a dedicated empty directory rather than `cwd` (which `beforeEach`
-    // populates with the whole fixture set) so the directory watch only
-    // ever sees events for the one file under test.
+    // A fresh directory (not `cwd`, which holds the whole fixture set) so the
+    // directory watch only sees the file under test.
     const dir = tmpdirSync();
     const root = join(dir, "coalesce.js");
     // `globalThis.count` survives a hot reload, so it counts evaluations.
@@ -399,23 +388,9 @@ setInterval(() => {}, 1e6);
 
     while (evals.length < 1) await Bun.sleep(1);
 
-    // Simulate a noisy editor save: a burst of writes spread over a few
-    // milliseconds. Each `write()` on the open fd emits an `IN_MODIFY` on
-    // both the file watch and the parent-directory watch — the same
-    // shape as a real editor's truncate/write/fsync/rename sequence. The
-    // `sleepSync` gaps yield the CPU so the child's watcher thread
-    // actually observes the events mid-burst rather than all at once,
-    // which is what the pre-fix 0.1 ms coalesce window relied on; they
-    // stay well inside the new 10 ms window so the whole burst still
-    // collapses into one `onFileUpdate`.
-    //
-    // Without the hash dedup in `Task.append`, the many directory-watch
-    // events (all naming the same file) also overflow the task's
-    // fixed-size hash buffer and flush mid-`onFileUpdate`, which on a
-    // slow (debug/ASAN) build lets the JS thread start a reload while
-    // the watcher is still appending — the `while` loop in `Task.run`
-    // then turns the later increments into a second reload for the
-    // same save.
+    // An editor-save-shaped burst: each write emits an event on the file and
+    // directory watches, and the 2 ms gaps let the watcher thread observe
+    // them mid-burst while staying inside the 10 ms coalesce window.
     {
       const fd = openSync(root, "a");
       try {
@@ -429,15 +404,13 @@ setInterval(() => {}, 1e6);
     }
 
     while (evals.length < 2) await Bun.sleep(1);
-    // Let any spurious extra reloads from this burst surface. Has to
-    // outlive the watcher's coalesce window; 200 ms matches the settle
-    // used by the "random file" test below.
+    // Give any extra reloads time to surface (same settle as the "random
+    // file" test below).
     await Bun.sleep(200);
 
     runner.kill();
 
-    // One initial evaluation + one reload for the whole burst. Before
-    // the fix the burst above produced several reloads on Linux.
+    // The initial evaluation plus one reload for the whole burst.
     expect({ evals }).toEqual({ evals: [1, 2] });
   },
   timeout,
@@ -711,14 +684,9 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error('${counter}');`,
     writeFull(0);
     await using runner = spawn({
       cmd: [bunExe(), "--smol", "--hot", "run", hotRunnerRoot],
-      // This test needs the self-write's watcher event to be dispatched
-      // promptly so it lands in the reject→report window; the default
-      // 10 ms coalesce would delay it until after the error is already
-      // reported and the race under test never opens. `0` makes the
-      // drain loop non-blocking (poll once, process what's there),
-      // which is the closest analogue to the pre-coalesce-loop behaviour
-      // this test was tuned against. Honoured by all three watcher
-      // backends despite the Linux-centric name.
+      // The race under test needs the self-write's event dispatched before
+      // the rejection is reported; the default 10 ms coalesce window would
+      // close it.
       env: { ...bunEnv, BUN_INOTIFY_COALESCE_INTERVAL: "0" },
       cwd,
       stdout: "ignore",


### PR DESCRIPTION
Fixes #13511.

## Repro

```js
// script.js
console.log("Hello");
```
```sh
bun --hot script.js
```
Save `script.js` in an editor (or just `touch` / rewrite it): `Hello` is printed two or more times for one save.

Minimal programmatic repro on Linux: two `writeFileSync`s ~2 ms apart reliably produce two reloads on 1.3.x.

## Cause

A single editor save emits several filesystem events spread over a few milliseconds (`open(O_TRUNC)` + `write()`, or write + rename for atomic saves, each mirrored on the parent-directory watch). The watcher tried to coalesce these, but:

- the inotify/kqueue coalesce window was **0.1 ms** and performed **at most one** extra read, so any events arriving after that spilled into the next watch-loop cycle;
- the Windows watcher used a **0 ms** timeout for subsequent `GetQueuedCompletionStatus` calls, so it only swept what was already queued;
- in `HotReloader.Task.append`, every event for the same file re-appended the same path hash; once the fixed 8-slot buffer filled it called `enqueue()` **mid-`on_file_update`**, letting the JS thread start a reload while the watcher thread was still appending. The loop in `Task.run` then turned the later `pending_count` increments into a second reload for the same save.

Each extra `on_file_update` is a `Task.enqueue`, a `vm.reload()`, and a full re-evaluation of the entry point.

## Fix

- `BUN_INOTIFY_COALESCE_INTERVAL` default raised from `100_000` ns to `10_000_000` ns (10 ms). The env var declares the default, so it is the single source of truth; `watcher_impl::coalesce_interval_ns()` reads it and `watcher_impl::MAX_COALESCE_ITERATIONS` (32) lives next to it. Both are shared by all three backends.
- **INotifyWatcher / KEventWatcher / WindowsWatcher** (`src/watcher/*.rs`): after the first read, keep draining until the queue stays quiet for the interval, bounded by buffer capacity and the iteration cap so a continuously written file cannot starve the loop. In the common case the loop exits one interval after the last event in the burst. The interval is stored as `u64` nanoseconds and split into a `timespec` by a shared helper (no overflow path); Windows converts to the milliseconds `GetQueuedCompletionStatus` takes, rounding up so a sub-millisecond override still waits. The Windows `Timeout` enum is replaced by the raw `DWORD` timeout.
- **`HotReloader.Task.append`** (`src/jsc/hot_reloader.rs`): skip hashes already in the buffer, so a burst of events for one file never triggers the mid-`on_file_update` flush. (`VirtualMachine.reload` ignores the hash list; only bake's dev server consumes it, and dedup does not change its semantics.)

The `should not remap against a stale sourcemap after a partial-file reload` test pins `BUN_INOTIFY_COALESCE_INTERVAL=0`: it deliberately relies on the self-write event being dispatched before the rejection is reported, which the new window would otherwise absorb.

## Verification

New test `coalesces a burst of writes into a single reload` in `test/cli/hot/hot.test.ts`: spawns `bun --hot`, does 10 x `writeSync` with `sleepSync(2)` between them, and asserts exactly one reload. The test measures the gaps between its own writes: a burst that a loaded runner stretched past the coalesce window and that then split is retried (those writes really are separate saves), while a split burst whose gaps stayed uFull `test/cli/hot/hot.test.ts` passes 13/13 on the current head. `cargo check -p bun_watcher` is clean for the linux, darwin and windows targets. With the retrying form of the burst test, on a box at load average 100 to 170 (gaps between writes routinely 25 to 80 ms): the unfixed build failed 8/8 runs and the fixed build passed 10/10. The test stays skipped on Intel macOS, where `sleepSync` granularity rather than transient load stretches the burst. CI Linux and Windows lanes have passed it on every build of this PR. The burst test is timing-based by nature: on a heavily oversubscribed box (load average ~200 on 16 cores while verifying the latest rebase) the writer's 2 ms gaps stretch past 10 ms and the test legitimately sees separate saves; widening the window via the env var on that same box coalesced the burst every time, and the test is already skipped on Intel macOS for the same reason. CI Linux and Windows lanes have passed it on every build of this PR.

## Rebase notes

Rebased eight times as main moved (the eighth, onto #39324's shared sort helper, conflicted only in an import block). Two were non-trivial:

- #32621 removed all `.zig` porting-reference sources, so this PR's Zig-side edits were dropped; it now touches only the shipping Rust plus the test.
- #35321 rewrote `KEventWatcher` around the safe `bun_sys::kevent` wrapper and a `new()` constructor, so the kqueue drain loop was redone on top of that (it no longer needs an `unsafe` block or `c_int` casts). The other backends only moved in visibility and constructor shape. After that rebase the per-backend default constants were hoisted into `watcher_impl` as described above.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 26 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/hot/hot.test.ts

<!-- robobun:evidence:end -->
