### PR TITLE
bundler: log InvalidDataURL resolver failures instead of panicking

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1542,6 +1542,39 @@ pub mod bv2_impl {
         unsafe { (*p).into_static() }
     }
 
+    /// Logs resolver errors that `resolve()` returns without writing to any
+    /// log so `has_errors()` actually fires. Returns `true` when `err` is one
+    /// of those; shared by `run_resolver` and `resolve_import_records`.
+    #[cold]
+    pub(crate) fn log_unhandled_resolve_error(
+        log: &mut bun_ast::Log,
+        source: Option<&bun_ast::Source>,
+        range: bun_ast::Range,
+        err: _resolver::Error,
+        specifier: &[u8],
+        kind: ImportKind,
+        report: bool,
+    ) -> bool {
+        if err == _resolver::Error::InvalidDataURL {
+            if report {
+                bun_ast::Log::add_resolve_error_with_text_dupe(
+                    log,
+                    source,
+                    range,
+                    format_args!(
+                        "Could not resolve data URL: \"{}\"",
+                        bstr::BStr::new(specifier)
+                    ),
+                    specifier,
+                    kind,
+                );
+            }
+            return true;
+        }
+        // Other errors are logged by the resolver before it returns Failure.
+        false
+    }
+
     // Unified with the canonical definitions at the parent module level (this
     // avoids two distinct nominal `BundleV2`/`PendingImport`/`BakeOptions` types
     // that previously caused widespread "expected `BundleV2`, found `BundleV2`"
@@ -2340,8 +2373,18 @@ pub mod bv2_impl {
                                     );
                                 }
                             }
+                        } else {
+                            log_unhandled_resolve_error(
+                                log,
+                                source,
+                                import_record.range,
+                                err,
+                                &import_record.specifier,
+                                import_record.kind,
+                                !handles_import_errors
+                                    && !self.transpiler.options.ignore_module_resolution_errors,
+                            );
                         }
-                        // assume other errors are already in the log
                         return;
                     }
                 }
@@ -6247,8 +6290,22 @@ pub mod bv2_impl {
                                     }
                                 }
                             } else {
-                                // assume other errors are already in the log
-                                last_error = Some(err.into());
+                                let report = !import_record
+                                    .flags
+                                    .contains(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS)
+                                    && !self.transpiler.options.ignore_module_resolution_errors;
+                                let ours = log_unhandled_resolve_error(
+                                    log,
+                                    Some(source),
+                                    import_record.range,
+                                    err,
+                                    import_record.path.text,
+                                    import_record.kind,
+                                    report,
+                                );
+                                if !ours || report {
+                                    last_error = Some(err.into());
+                                }
                             }
                             continue 'outer;
                         }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1290,6 +1290,26 @@ impl<'a> Resolver<'a> {
 
         match DataURL::parse(import_path) {
             Err(_) => {
+                // Malformed data URL (e.g. "data:" with no comma). For url()
+                // tokens pass it through as external like http:// above; for
+                // JS imports the bundler surfaces a resolve error.
+                if kind.is_from_css() {
+                    if let Some(debug) = self.debug_logs.as_mut() {
+                        debug.add_note(b"Marking malformed \"dataurl\" as external".to_vec());
+                    }
+                    let _ = self.flush_debug_logs(FlushMode::Success);
+                    self.extension_order = original_order;
+                    return ResultUnion::Success(Result {
+                        import_kind: kind,
+                        path_pair: PathPair {
+                            primary: Path::init(import_path),
+                            secondary: None,
+                        },
+                        module_type: options::ModuleType::Unknown,
+                        flags: ResultFlags::IS_EXTERNAL,
+                        ..Default::default()
+                    });
+                }
                 self.extension_order = original_order;
                 return ResultUnion::Failure(crate::Error::InvalidDataURL);
             }

--- a/test/regression/issue/30621.test.ts
+++ b/test/regression/issue/30621.test.ts
@@ -1,0 +1,58 @@
+// https://github.com/oven-sh/bun/issues/30621
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
+
+async function build(dir: string, entry: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", entry, "--outdir=out"],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+test.concurrent("CSS url(data:) with no comma should not crash", async () => {
+  using dir = tempDir("30621-css", {
+    "style.css": `a{background:url(data:)}`,
+  });
+  const { stdout, stderr, exitCode } = await build(String(dir), "style.css");
+  expect({ stdout, stderr }).toEqual({ stdout: expect.stringContaining("Bundled"), stderr: "" });
+  expect(exitCode).toBe(0);
+  const css = await Bun.file(join(String(dir), "out", "style.css")).text();
+  expect(css).toContain(`url("data:")`);
+});
+
+test.concurrent("HTML favicon href=data: with no comma should not crash", async () => {
+  using dir = tempDir("30621-html", {
+    "index.html": `<!DOCTYPE html><html><head><link rel="icon" href="data:"></head><body><script src="./app.js"></script></body></html>`,
+    "app.js": `console.log(1);`,
+  });
+  const { stdout, stderr, exitCode } = await build(String(dir), "index.html");
+  expect({ stdout, stderr }).toEqual({ stdout: expect.stringContaining("Bundled"), stderr: "" });
+  expect(exitCode).toBe(0);
+  const html = await Bun.file(join(String(dir), "out", "index.html")).text();
+  expect(html).toContain(`href="data:"`);
+});
+
+test.concurrent("JS importing CSS with url(data:) should not crash", async () => {
+  using dir = tempDir("30621-js-css", {
+    "index.js": `import "./style.css";`,
+    "style.css": `a{background:url(data:)}`,
+  });
+  const { stdout, stderr, exitCode } = await build(String(dir), "index.js");
+  expect({ stdout, stderr }).toEqual({ stdout: expect.stringContaining("Bundled"), stderr: "" });
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("JS import of malformed data URL reports a resolve error", async () => {
+  using dir = tempDir("30621-js", {
+    "index.js": `import "data:";`,
+  });
+  const { stderr, exitCode } = await build(String(dir), "index.js");
+  expect(stderr).toContain(`Could not resolve data URL: "data:"`);
+  expect(exitCode).toBe(1);
+});


### PR DESCRIPTION
Fixes #30621

## Repro

```css
/* style.css */
a{background:url(data:)}
```

```sh
bun build style.css --outdir out
# panic: index out of bounds: the len is 0 but the index is 0
# bun_bundler::linker_context_mod::LinkerContext::create_exports_for_file
# src/bundler/linker_context/doStep5.rs:659
```

Also reproduces with `<link rel="icon" href="data:">` in an HTML entry point and `import "data:"` in JS.

## Cause

`url(data:)` is a malformed data URL (no comma, which `DataURL::parse` requires). The resolver returns `ResultUnion::Failure(InvalidDataURL)` without touching any log. `resolve_import_records` only records that in `last_error` (its non-`ModuleNotFound` arm is commented "assume other errors are already in the log", which is not true here), `run_resolution_for_parse_task` converts the parse result to `Err` with an empty log, and `on_parse_task_complete` skips logging because `process_log` is cleared. With `transpiler.log.errors == 0` the build proceeds past the `has_errors()` gate, the importer's AST slot stays at the empty placeholder (`parts.len() == 0`), and `create_exports_for_file` indexes `parts[NAMESPACE_EXPORT_PART_INDEX]`.

## Fix

`src/resolver/resolver.rs`: when `DataURL::parse` fails and the import is a `url()`-kind (CSS `url()`/`@import`, HTML asset attributes, all of which share `ImportKind::is_from_css()`), mark the URL external and pass it through verbatim, matching the adjacent handling of `http://`, `https://`, and `//`.

`src/bundler/bundle_v2.rs`: a new `log_unhandled_resolve_error` helper formats the diagnostic for resolver errors the resolver does not log itself. `run_resolver` (plugin fallback) and `resolve_import_records` (main path) both route their non-`ModuleNotFound` arm through it, so `import "data:"` in JS now reports `Could not resolve data URL: "data:"` and aborts before linking. `HANDLES_IMPORT_ERRORS` is honoured the same way it is for `ModuleNotFound`.

## Tests

`test/regression/issue/30621.test.ts` spawns `bun build` for four cases: CSS entry with `url(data:)`, HTML entry with `<link rel="icon" href="data:">`, JS entry importing that CSS, and `import "data:"` in JS. All four crash with the panic above on an unfixed build and pass with the fix. `test/js/bun/resolve/resolve-error.test.ts`, `test/bundler/bundler_edgecase.test.ts`, `test/bundler/esbuild/css.test.ts`, and `test/bundler/esbuild/loader.test.ts` still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 10 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/30621.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (2147fd9d8)

test/regression/issue/30621.test.ts:
(fail) CSS url(data:) with no comma should not crash [5007.56ms]
  ^ this test timed out after 5000ms.
(fail) HTML favicon href=data: with no comma should not crash [5007.78ms]
  ^ this test timed out after 5000ms.
(fail) JS importing CSS with url(data:) should not crash [5000.17ms]
  ^ this test timed out after 5000ms.
(fail) JS import of malformed data URL reports a resolve error [5000.20ms]
  ^ this test timed out after 5000ms.

 0 pass
 4 fail
Ran 4 tests across 1 file. [7.22s]
error: script "bd" exited with code 1
__F:4:S:0

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/regression/issue/30621.test.ts:
51 | test.concurrent("JS import of malformed data URL reports a resolve error", async () => {
52 |   using dir = tempDir("30621-js", {
53 |     "index.js": `import "data:";`,
54 |   });
55 |   const { stderr, exitCode } = await build(String(dir), "index.js");
56 |   expect(stderr).toContain(`Could not resolve data URL: "data:"`);
                      ^
error: expect(received).toContain(expected)

Expected to contain: "Could not resolve data URL: \"data:\""
Received: "============================================================\nBun Canary v1.4.0-canary.1 (1498d7b77) Linux x64\nLinux Kernel v6.17.0 | glibc v2.41\nCPU: sse42 popcnt avx avx2 avx512\nArgs: \"/workspace/bun/build/release/bun\" \"build\" \"index.js\" \"--outdir=out\"\n\nElapsed: 3ms | User: 0ms | Sys: 4ms\nRSS: 46.73 MB | Peak: 50.81 MB | Commit: 46.73 MB | Faults: 0\n\npanic: index out of bounds: the len is 0 but the index is 0\noh no: Bun has crashed. This indicates a bug in Bun, not your code.\n\nTo send a redacted crash report to Bun's team,\nplease file a GitHub issue using the link below:\n\n https://bun.report/1.4.0/l_21498
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/30621.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (2147fd9d8)

test/regression/issue/30621.test.ts:
(pass) JS import of malformed data URL reports a resolve error [210.90ms]
(pass) HTML favicon href=data: with no comma should not crash [295.25ms]
(pass) CSS url(data:) with no comma should not crash [400.19ms]
(pass) JS importing CSS with url(data:) should not crash [340.86ms]

 4 pass
 0 fail
 10 expect() calls
Ran 4 tests across 1 file. [2.52s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     2147fd9d89
  features     (none)

22 deps, 106 codegen, 1168 objects in 822ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [12.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [2.00ms]
[3/1231] gen bindgenv2
[4/1231] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1231] gen ErrorCode+*.h
[6/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [7.00ms]
[7/1231] gen ProcessBindingConstants.lut.h
Generating /work
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/bundle_v2.rs            | 63 +++++++++++++++++++++++++++++++++++--
 src/resolver/resolver.rs            | 20 ++++++++++++
 test/regression/issue/30621.test.ts | 58 ++++++++++++++++++++++++++++++++++
 3 files changed, 138 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 10

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/bundler/bundle_v2.rs                 1      2      8
src/resolver/resolver.rs                 1      1      8
test/regression/issue/30621.test.ts      0      2      8
```

</details>

**root cause** · written by the author bot

The crash happened because the resolver treated any string starting with "data:" as a valid data URL and immediately indexed into its parsed components, so a malformed URL like url(data:) with no media type or payload produced an empty component list and an out-of-bounds access. The fix makes the resolver return a dedicated InvalidDataURL error for malformed data URLs instead of assuming parsing succeeded, and the bundler now handles that error by logging a normal "Could not resolve data URL" resolve diagnostic through the same import-error gating as other resolution failures. As a result, …

<!-- robobun:evidence:end -->