### PR TITLE
http: enable TCP keepalive on fetch sockets

### DIFF
--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -195,6 +195,17 @@ pub fn onOpen(
     // completes. See https://github.com/oven-sh/bun/issues/30325.
     client.setTimeout(socket);
 
+    // Enable TCP keepalive so a half-open connection (peer closed but the
+    // FIN/RST never reached us — NAT timeout, wifi/cellular handoff,
+    // middlebox state eviction, VPN disconnect) is detected in ~70s instead
+    // of hanging until an application-level timeout. Without this, a
+    // streaming `reader.read()` on a half-open socket blocks indefinitely.
+    // Matches Node/undici (TCP_KEEPIDLE=60, KEEPINTVL=1, KEEPCNT=10 — the
+    // latter two are hardcoded in bsd_socket_keepalive). The kernel default
+    // TCP_KEEPIDLE is 7200s, so bare SO_KEEPALIVE without the delay would be
+    // ineffective; 60 here sets TCP_KEEPIDLE=60s.
+    _ = socket.setKeepAlive(true, 60);
+
     if (client.signals.get(.aborted)) {
         client.closeAndAbort(comptime is_ssl, socket);
         return error.ClientAborted;

--- a/test/js/web/fetch/fetch-tcp-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-tcp-keepalive.test.ts
@@ -1,0 +1,71 @@
+// Verifies that fetch() enables TCP keepalive (SO_KEEPALIVE + TCP_KEEPIDLE)
+// on its client sockets, matching Node/undici behavior. Without it, a
+// half-open connection (peer silently gone — NAT timeout, network break)
+// hangs until an application-level timeout instead of failing at ~70s.
+//
+// Linux-only: reads /proc/<pid>/net/tcp for the kernel's view of the
+// socket's keepalive timer. Other platforms skip.
+import { test, expect } from "bun:test";
+
+test.skipIf(process.platform !== "linux")(
+  "fetch sockets have TCP keepalive enabled",
+  async () => {
+    // Server that holds the connection open so the client socket stays
+    // ESTABLISHED long enough to inspect.
+    await using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        // Keep the response streaming so the client socket stays open
+        // while we inspect /proc/net/tcp from the client side.
+        return new Response(
+          new ReadableStream({
+            async start(controller) {
+              controller.enqueue(new TextEncoder().encode("hold"));
+              await Bun.sleep(500);
+              controller.close();
+            },
+          }),
+        );
+      },
+    });
+
+    const port = server.port;
+    const fetchPromise = fetch(`http://127.0.0.1:${port}/`);
+
+    // Give the connection a moment to establish
+    await Bun.sleep(50);
+
+    // Parse /proc/self/net/tcp: find ESTABLISHED (state 01) socket with
+    // remote port = server.port. Column 5 is the timer field
+    // "<timer_active>:<jiffies_until_expiry>". Per net/ipv4/tcp_ipv4.c
+    // get_tcp4_sock(): 0=no timer, 1=retransmit, 4=zero-window probe,
+    // 2=sk_timer armed — which is the keepalive timer on an idle
+    // established socket. Empirically: without SO_KEEPALIVE this field is
+    // "00:00000000"; with it, "02:<jiffies>".
+    const tcp = await Bun.file("/proc/self/net/tcp").text();
+    const portHex = port.toString(16).toUpperCase().padStart(4, "0");
+    let found = false;
+    let timerActive = "";
+    for (const line of tcp.split("\n").slice(1)) {
+      const cols = line.trim().split(/\s+/);
+      if (cols.length < 6) continue;
+      const [, remote, state, , timer] = cols.slice(1, 6);
+      // remote = server port. state 01 = ESTABLISHED. The client socket's
+      // remote_address is the server; the server's listening socket has
+      // state 0A and the server's accepted socket has the client port in
+      // remote — so this matches only the client side.
+      if (state === "01" && remote.endsWith(":" + portHex)) {
+        found = true;
+        timerActive = timer.split(":")[0];
+      }
+    }
+
+    // Drain the fetch so the server can clean up
+    const resp = await fetchPromise;
+    await resp.text();
+
+    expect(found).toBe(true);
+    // Without SO_KEEPALIVE: "00". With it: "02" (sk_timer armed).
+    expect(timerActive).not.toBe("00");
+  },
+);

--- a/test/js/web/fetch/fetch-tcp-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-tcp-keepalive.test.ts
@@ -5,69 +5,66 @@
 //
 // Linux-only: reads /proc/<pid>/net/tcp for the kernel's view of the
 // socket's keepalive timer. Other platforms skip.
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
-test.skipIf(process.platform !== "linux")(
-  "fetch sockets have TCP keepalive enabled",
-  async () => {
-    // Server that holds the connection open so the client socket stays
-    // ESTABLISHED long enough to inspect.
-    await using server = Bun.serve({
-      port: 0,
-      async fetch(req) {
-        // Keep the response streaming so the client socket stays open
-        // while we inspect /proc/net/tcp from the client side.
-        return new Response(
-          new ReadableStream({
-            async start(controller) {
-              controller.enqueue(new TextEncoder().encode("hold"));
-              await Bun.sleep(500);
-              controller.close();
-            },
-          }),
-        );
-      },
-    });
+test.skipIf(process.platform !== "linux")("fetch sockets have TCP keepalive enabled", async () => {
+  // Server that holds the connection open so the client socket stays
+  // ESTABLISHED long enough to inspect.
+  await using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      // Keep the response streaming so the client socket stays open
+      // while we inspect /proc/net/tcp from the client side.
+      return new Response(
+        new ReadableStream({
+          async start(controller) {
+            controller.enqueue(new TextEncoder().encode("hold"));
+            await Bun.sleep(500);
+            controller.close();
+          },
+        }),
+      );
+    },
+  });
 
-    const port = server.port;
-    // Await headers + first chunk so the socket is ESTABLISHED and the
-    // client's outbound GET has been ACKed (piggybacked on the response)
-    // before we read /proc — otherwise a retransmit timer (01) could mask
-    // the keepalive timer (02) in the kernel's timer field.
-    const resp = await fetch(`http://127.0.0.1:${port}/`);
-    const reader = resp.body!.getReader();
-    await reader.read();
+  const port = server.port;
+  // Await headers + first chunk so the socket is ESTABLISHED and the
+  // client's outbound GET has been ACKed (piggybacked on the response)
+  // before we read /proc — otherwise a retransmit timer (01) could mask
+  // the keepalive timer (02) in the kernel's timer field.
+  const resp = await fetch(`http://127.0.0.1:${port}/`);
+  const reader = resp.body!.getReader();
+  await reader.read();
 
-    // Parse /proc/self/net/tcp: find ESTABLISHED (state 01) socket with
-    // remote port = server.port. Column 5 is the timer field
-    // "<timer_active>:<jiffies_until_expiry>". Per net/ipv4/tcp_ipv4.c
-    // get_tcp4_sock(): 0=no timer, 1=retransmit, 4=zero-window probe,
-    // 2=sk_timer armed — which is the keepalive timer on an idle
-    // established socket. Empirically: without SO_KEEPALIVE this field is
-    // "00:00000000"; with it, "02:<jiffies>".
-    const tcp = await Bun.file("/proc/self/net/tcp").text();
-    const portHex = port.toString(16).toUpperCase().padStart(4, "0");
-    let found = false;
-    let timerActive = "";
-    for (const line of tcp.split("\n").slice(1)) {
-      const cols = line.trim().split(/\s+/);
-      if (cols.length < 6) continue;
-      const [, remote, state, , timer] = cols.slice(1, 6);
-      // remote = server port. state 01 = ESTABLISHED. The client socket's
-      // remote_address is the server; the server's listening socket has
-      // state 0A and the server's accepted socket has the client port in
-      // remote — so this matches only the client side.
-      if (state === "01" && remote.endsWith(":" + portHex)) {
-        found = true;
-        timerActive = timer.split(":")[0];
-      }
+  // Parse /proc/self/net/tcp: find ESTABLISHED (state 01) socket with
+  // remote port = server.port. Column 5 is the timer field
+  // "<timer_active>:<jiffies_until_expiry>". Per net/ipv4/tcp_ipv4.c
+  // get_tcp4_sock(): 0=no timer, 1=retransmit, 4=zero-window probe,
+  // 2=sk_timer armed — which is the keepalive timer on an idle
+  // established socket. Empirically: without SO_KEEPALIVE this field is
+  // "00:00000000"; with it, "02:<jiffies>".
+  const tcp = await Bun.file("/proc/self/net/tcp").text();
+  const portHex = port.toString(16).toUpperCase().padStart(4, "0");
+  let found = false;
+  let timerActive = "";
+  for (const line of tcp.split("\n").slice(1)) {
+    const cols = line.trim().split(/\s+/);
+    if (cols.length < 6) continue;
+    const [, remote, state, , timer] = cols.slice(1, 6);
+    // remote = server port. state 01 = ESTABLISHED. The client socket's
+    // remote_address is the server; the server's listening socket has
+    // state 0A and the server's accepted socket has the client port in
+    // remote — so this matches only the client side.
+    if (state === "01" && remote.endsWith(":" + portHex)) {
+      found = true;
+      timerActive = timer.split(":")[0];
     }
+  }
 
-    // Drain the fetch so the server can clean up
-    await reader.cancel();
+  // Drain the fetch so the server can clean up
+  await reader.cancel();
 
-    expect(found).toBe(true);
-    // Without SO_KEEPALIVE: "00". With it: "02" (sk_timer / keepalive armed).
-    expect(timerActive).toBe("02");
-  },
-);
+  expect(found).toBe(true);
+  // Without SO_KEEPALIVE: "00". With it: "02" (sk_timer / keepalive armed).
+  expect(timerActive).toBe("02");
+});

--- a/test/js/web/fetch/fetch-tcp-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-tcp-keepalive.test.ts
@@ -30,10 +30,13 @@ test.skipIf(process.platform !== "linux")(
     });
 
     const port = server.port;
-    const fetchPromise = fetch(`http://127.0.0.1:${port}/`);
-
-    // Give the connection a moment to establish
-    await Bun.sleep(50);
+    // Await headers + first chunk so the socket is ESTABLISHED and the
+    // client's outbound GET has been ACKed (piggybacked on the response)
+    // before we read /proc — otherwise a retransmit timer (01) could mask
+    // the keepalive timer (02) in the kernel's timer field.
+    const resp = await fetch(`http://127.0.0.1:${port}/`);
+    const reader = resp.body!.getReader();
+    await reader.read();
 
     // Parse /proc/self/net/tcp: find ESTABLISHED (state 01) socket with
     // remote port = server.port. Column 5 is the timer field
@@ -61,11 +64,10 @@ test.skipIf(process.platform !== "linux")(
     }
 
     // Drain the fetch so the server can clean up
-    const resp = await fetchPromise;
-    await resp.text();
+    await reader.cancel();
 
     expect(found).toBe(true);
-    // Without SO_KEEPALIVE: "00". With it: "02" (sk_timer armed).
-    expect(timerActive).not.toBe("00");
+    // Without SO_KEEPALIVE: "00". With it: "02" (sk_timer / keepalive armed).
+    expect(timerActive).toBe("02");
   },
 );


### PR DESCRIPTION
### What does this PR do?

Enables TCP keepalive (`SO_KEEPALIVE` + `TCP_KEEPIDLE=60s`) on `fetch()` client sockets.

Without this, when a connection becomes half-open — the peer is gone but the FIN/RST never reached us (NAT timeout, wifi/cellular handoff, middlebox state eviction, VPN disconnect) — the kernel never discovers it. A streaming `reader.read()` on such a socket blocks forever (or until an application-level timeout).

Node's fetch (undici) sets `SO_KEEPALIVE` with `TCP_KEEPIDLE=60s`, so a half-open connection is detected at ~70s (60s idle + 10 probes × 1s). This makes Bun match that behavior via the existing `socket.setKeepAlive()` → `bsd_socket_keepalive()` path, which already hardcodes `TCP_KEEPINTVL=1` and `TCP_KEEPCNT=10`.

The call is placed in `onOpen()` next to `client.setTimeout(socket)` (#30376) — socket-level, fires once per connection, inherited by keep-alive-reused requests.

### How did you verify your code works?

Added `test/js/web/fetch/fetch-tcp-keepalive.test.ts` (Linux-only) that:
- starts a streaming server, opens a `fetch()` to it
- reads `/proc/self/net/tcp` and finds the client socket (ESTABLISHED, remote port = server port)
- asserts the timer field is not `00:00000000` — i.e. the kernel's `sk_timer` (keepalive) is armed (`timer_active=02`)

Without this patch the timer field is `00`; with it, `02:<jiffies>`.
