### PR TITLE
Fix stack overflow when inspecting circular JSX elements

### DIFF
--- a/src/jsc/ConsoleObject.zig
+++ b/src/jsc/ConsoleObject.zig
@@ -1136,7 +1136,7 @@ pub const Formatter = struct {
 
         pub fn canHaveCircularReferences(tag: Tag) bool {
             return switch (tag) {
-                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event => true,
+                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event, .JSX => true,
                 else => false,
             };
         }
@@ -3140,13 +3140,12 @@ pub const Formatter = struct {
                     }
                 }
 
-                if (try value.get(this.globalThis, "props")) |props| {
+                if (try value.get(this.globalThis, "props")) |props| props: {
                     const prev_quote_strings = this.quote_strings;
                     defer this.quote_strings = prev_quote_strings;
                     this.quote_strings = true;
 
-                    // SAFETY: JSX props are always objects
-                    const props_obj = props.getObject().?;
+                    const props_obj = props.getObject() orelse break :props;
                     var props_iter = try jsc.JSPropertyIterator(.{
                         .skip_empty_name = true,
                         .include_value = true,

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -316,6 +316,34 @@ it("jsx with fragment", () => {
   expect(input).toBe(output);
 });
 
+it("jsx with circular props", () => {
+  const el = {
+    $$typeof: Symbol.for("react.element"),
+    type: "div",
+  };
+  el.props = el;
+  expect(Bun.inspect(el)).toContain("[Circular]");
+});
+
+it("jsx with circular children", () => {
+  const el = {
+    $$typeof: Symbol.for("react.element"),
+    type: "span",
+    props: {},
+  };
+  el.props.children = el;
+  expect(Bun.inspect(el)).toContain("[Circular]");
+});
+
+it("jsx with non-object props", () => {
+  const el = {
+    $$typeof: Symbol.for("react.element"),
+    type: "p",
+    props: 42,
+  };
+  expect(Bun.inspect(el)).toBe("<p />");
+});
+
 it("inspect", () => {
   expect(Bun.inspect(new TypeError("what")).includes("TypeError: what")).toBe(true);
   expect(Bun.inspect("hi")).toBe('"hi"');


### PR DESCRIPTION
## What does this PR do?

Fixes a stack overflow crash in `Bun.inspect` / `console.log` when formatting a React element whose `props` or `children` form a cycle back to the element itself.

```js
const el = {
  $$typeof: Symbol.for("react.element"),
  type: "div",
};
el.props = el;
Bun.inspect(el); // segfault (stack overflow)
```

The JSX formatter was not included in `canHaveCircularReferences()`, so the visited-map check never ran for `.JSX` tags and the formatter recursed until the stack blew out.

Also fixes a null-unwrap panic when `props` is set to a non-object value — the formatter assumed `props` was always an object and did `props.getObject().?`. Now it skips prop iteration when `props` is not an object.

## How did you verify your code works?

Added regression tests to `test/js/bun/util/inspect.test.js` covering circular `props`, circular `children`, and non-object `props`.

Found by Fuzzilli (fingerprint `380dfde18006ab21`).