### PR TITLE
Fix crash when inspecting JSX elements with circular or non-object props

### DIFF
--- a/src/jsc/ConsoleObject.zig
+++ b/src/jsc/ConsoleObject.zig
@@ -1136,7 +1136,7 @@ pub const Formatter = struct {
 
         pub fn canHaveCircularReferences(tag: Tag) bool {
             return switch (tag) {
-                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event => true,
+                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event, .JSX => true,
                 else => false,
             };
         }
@@ -3140,13 +3140,11 @@ pub const Formatter = struct {
                     }
                 }
 
-                if (try value.get(this.globalThis, "props")) |props| {
+                if (try value.get(this.globalThis, "props")) |props| if (props.getObject()) |props_obj| {
                     const prev_quote_strings = this.quote_strings;
                     defer this.quote_strings = prev_quote_strings;
                     this.quote_strings = true;
 
-                    // SAFETY: JSX props are always objects
-                    const props_obj = props.getObject().?;
                     var props_iter = try jsc.JSPropertyIterator(.{
                         .skip_empty_name = true,
                         .include_value = true,
@@ -3303,7 +3301,7 @@ pub const Formatter = struct {
                             }
                         }
                     }
-                }
+                };
 
                 writer.writeAll(" />");
             },

--- a/src/test_runner/pretty_format.zig
+++ b/src/test_runner/pretty_format.zig
@@ -326,7 +326,7 @@ pub const JestPrettyFormat = struct {
             }
 
             pub inline fn canHaveCircularReferences(tag: Tag) bool {
-                return tag == .Array or tag == .Object or tag == .Map or tag == .Set;
+                return tag == .Array or tag == .Object or tag == .Map or tag == .Set or tag == .JSX;
             }
 
             const Result = struct {
@@ -1534,13 +1534,11 @@ pub const JestPrettyFormat = struct {
                         }
                     }
 
-                    if (try value.get(this.globalThis, "props")) |props| {
+                    if (try value.get(this.globalThis, "props")) |props| if (props.getObject()) |props_obj| {
                         const prev_quote_strings = this.quote_strings;
                         defer this.quote_strings = prev_quote_strings;
                         this.quote_strings = true;
 
-                        // SAFETY: JSX props are always an object.
-                        const props_obj = props.getObject().?;
                         var props_iter = try jsc.JSPropertyIterator(.{
                             .skip_empty_name = true,
                             .include_value = true,
@@ -1691,7 +1689,7 @@ pub const JestPrettyFormat = struct {
                                 }
                             }
                         }
-                    }
+                    };
 
                     writer.writeAll(" />");
                 },

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -316,6 +316,31 @@ it("jsx with fragment", () => {
   expect(input).toBe(output);
 });
 
+it("jsx with circular props does not crash", () => {
+  const el = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: {} };
+  el.props = el;
+  expect(Bun.inspect(el)).toContain("[Circular]");
+});
+
+it("jsx with circular key does not crash", () => {
+  const el = { $$typeof: Symbol.for("react.element"), type: "div" };
+  el.key = el;
+  expect(Bun.inspect(el)).toContain("[Circular]");
+});
+
+it("jsx with circular children does not crash", () => {
+  const el = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: {} };
+  el.props = { children: el };
+  expect(Bun.inspect(el)).toContain("[Circular]");
+});
+
+it("jsx with non-object props does not crash", () => {
+  for (const props of [123, "str", true, null, Symbol("x")]) {
+    const el = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props };
+    expect(() => Bun.inspect(el)).not.toThrow();
+  }
+});
+
 it("inspect", () => {
   expect(Bun.inspect(new TypeError("what")).includes("TypeError: what")).toBe(true);
   expect(Bun.inspect("hi")).toBe('"hi"');


### PR DESCRIPTION
## What does this PR do?

Fixes a segfault in `Bun.inspect()` / `console.log()` (and the jest pretty formatter) when formatting React elements that have been mutated to contain circular references or non-object `props`.

### Root cause

1. The `.JSX` tag was not included in `canHaveCircularReferences()`, so the visited-set / stack check that normally short-circuits cycles was skipped for React elements. A React element whose `props`, `key`, or `children` referred back to itself would recurse until the native stack overflowed.
2. The JSX formatter assumed `props` is always an object and did `props.getObject().?`, which panics when `props` is a primitive.

### Fix

- Add `.JSX` to `canHaveCircularReferences()` in both `ConsoleObject.zig` and `pretty_format.zig` so cycles print `[Circular]` instead of overflowing the stack.
- Guard the props iterator behind `props.getObject()` so non-object props are simply skipped.

### Repro

```js
const el = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: {} };
el.props = el;
Bun.inspect(el); // before: SIGSEGV, after: '<div ... props=[Circular] />'
```

## How did you verify your code works?

Added regression tests to `test/js/bun/util/inspect.test.js` covering circular `props`, circular `key`, circular `children`, and primitive `props`. Existing JSX inspect tests, console tests, and `md-react.test.ts` continue to pass.

Found by Fuzzilli (fingerprint `13aabad674c61341`).