### PR TITLE
http: link undici reference for fetch TCP keepalive default

### DIFF
--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -201,7 +201,8 @@ pub fn onOpen(
     // of hanging until an application-level timeout. Without this, a
     // streaming `reader.read()` on a half-open socket blocks indefinitely.
     // Matches Node/undici, which calls `socket.setKeepAlive(true, 60e3)` in
-    // lib/core/connect.js (https://github.com/nodejs/undici/pull/1904).
+    // buildConnector:
+    // https://github.com/nodejs/undici/blob/f33a6cb615e1/lib/core/connect.js#L121-L124
     // TCP_KEEPIDLE=60, KEEPINTVL=1, KEEPCNT=10 — the latter two are hardcoded
     // in bsd_socket_keepalive. The kernel default TCP_KEEPIDLE is 7200s, so
     // bare SO_KEEPALIVE without the delay would be ineffective; 60 here sets

--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -200,10 +200,12 @@ pub fn onOpen(
     // middlebox state eviction, VPN disconnect) is detected in ~70s instead
     // of hanging until an application-level timeout. Without this, a
     // streaming `reader.read()` on a half-open socket blocks indefinitely.
-    // Matches Node/undici (TCP_KEEPIDLE=60, KEEPINTVL=1, KEEPCNT=10 — the
-    // latter two are hardcoded in bsd_socket_keepalive). The kernel default
-    // TCP_KEEPIDLE is 7200s, so bare SO_KEEPALIVE without the delay would be
-    // ineffective; 60 here sets TCP_KEEPIDLE=60s.
+    // Matches Node/undici, which calls `socket.setKeepAlive(true, 60e3)` in
+    // lib/core/connect.js (https://github.com/nodejs/undici/pull/1904).
+    // TCP_KEEPIDLE=60, KEEPINTVL=1, KEEPCNT=10 — the latter two are hardcoded
+    // in bsd_socket_keepalive. The kernel default TCP_KEEPIDLE is 7200s, so
+    // bare SO_KEEPALIVE without the delay would be ineffective; 60 here sets
+    // TCP_KEEPIDLE=60s.
     _ = socket.setKeepAlive(true, 60);
 
     if (client.signals.get(.aborted)) {


### PR DESCRIPTION
Follow-up to b9c757b8d3b11bcadbe7820149098e5b718ea111 (#30627).

The comment said "matches Node/undici" but didn't say where. Point it at the actual undici call site so the 60s value is traceable:

https://github.com/nodejs/undici/blob/f33a6cb615e1/lib/core/connect.js#L121-L124

```js
if (options.keepAlive == null || options.keepAlive) {
  const keepAliveInitialDelay = options.keepAliveInitialDelay === undefined ? 60e3 : options.keepAliveInitialDelay
  socket.setKeepAlive(true, keepAliveInitialDelay)
}
```

Introduced in nodejs/undici#1904. Comment-only change, no behavior difference.
