### PR TITLE
bake: validate app.bundlerOptions and its server/client/ssr fields are objects

### DIFF
--- a/src/bake/bake.zig
+++ b/src/bake/bake.zig
@@ -68,14 +68,17 @@ pub const UserOptions = struct {
         }
 
         if (try config.getOptional(global, "bundlerOptions", JSValue)) |js_options| {
+            if (!js_options.isObject()) {
+                return global.throwInvalidArguments("'" ++ api_name ++ ".bundlerOptions' must be an object", .{});
+            }
             if (try js_options.getOptional(global, "server", JSValue)) |server_options| {
-                bundler_options.server = try BuildConfigSubset.fromJS(global, server_options);
+                bundler_options.server = try BuildConfigSubset.fromJS(global, "server", server_options);
             }
             if (try js_options.getOptional(global, "client", JSValue)) |client_options| {
-                bundler_options.client = try BuildConfigSubset.fromJS(global, client_options);
+                bundler_options.client = try BuildConfigSubset.fromJS(global, "client", client_options);
             }
             if (try js_options.getOptional(global, "ssr", JSValue)) |ssr_options| {
-                bundler_options.ssr = try BuildConfigSubset.fromJS(global, ssr_options);
+                bundler_options.ssr = try BuildConfigSubset.fromJS(global, "ssr", ssr_options);
             }
         }
 
@@ -202,8 +205,12 @@ const BuildConfigSubset = struct {
     minify_identifiers: ?bool = null,
     minify_whitespace: ?bool = null,
 
-    pub fn fromJS(global: *jsc.JSGlobalObject, js_options: JSValue) bun.JSError!BuildConfigSubset {
+    pub fn fromJS(global: *jsc.JSGlobalObject, comptime property_name: []const u8, js_options: JSValue) bun.JSError!BuildConfigSubset {
         var options = BuildConfigSubset{};
+
+        if (!js_options.isObject()) {
+            return global.throwInvalidArguments("'" ++ api_name ++ ".bundlerOptions." ++ property_name ++ "' must be an object", .{});
+        }
 
         if (try js_options.getOptional(global, "sourcemap", JSValue)) |val| brk: {
             if (try bun.schema.api.SourceMapMode.fromJS(global, val)) |sourcemap| {

--- a/test/bake/app-options-validation.test.ts
+++ b/test/bake/app-options-validation.test.ts
@@ -10,16 +10,14 @@ describe("Bun.serve app.bundlerOptions validation", () => {
     ).toThrow("'app.bundlerOptions' must be an object");
   });
 
-  for (const key of ["server", "client", "ssr"] as const) {
-    for (const value of [1073741824, "foo", true]) {
-      test(`throws when bundlerOptions.${key} is ${JSON.stringify(value)}`, () => {
-        expect(() =>
-          Bun.serve({
-            // @ts-expect-error
-            app: { bundlerOptions: { [key]: value } },
-          }),
-        ).toThrow(`'app.bundlerOptions.${key}' must be an object`);
-      });
-    }
-  }
+  describe.each(["server", "client", "ssr"] as const)("bundlerOptions.%s", key => {
+    test.each([1073741824, "foo", true])("throws when value is %p", value => {
+      expect(() =>
+        Bun.serve({
+          // @ts-expect-error
+          app: { bundlerOptions: { [key]: value } },
+        }),
+      ).toThrow(`'app.bundlerOptions.${key}' must be an object`);
+    });
+  });
 });

--- a/test/bake/app-options-validation.test.ts
+++ b/test/bake/app-options-validation.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+
+describe("Bun.serve app.bundlerOptions validation", () => {
+  test("throws when bundlerOptions is not an object", () => {
+    expect(() =>
+      Bun.serve({
+        // @ts-expect-error
+        app: { bundlerOptions: 42 },
+      }),
+    ).toThrow("'app.bundlerOptions' must be an object");
+  });
+
+  for (const key of ["server", "client", "ssr"] as const) {
+    for (const value of [1073741824, "foo", true]) {
+      test(`throws when bundlerOptions.${key} is ${JSON.stringify(value)}`, () => {
+        expect(() =>
+          Bun.serve({
+            // @ts-expect-error
+            app: { bundlerOptions: { [key]: value } },
+          }),
+        ).toThrow(`'app.bundlerOptions.${key}' must be an object`);
+      });
+    }
+  }
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a debug assertion crash (`reached unreachable code`) in `Bun.serve()` when `app.bundlerOptions` or one of its `server`/`client`/`ssr` fields is a non-object value (e.g. a number, string, or boolean).

`BuildConfigSubset.fromJS` called `.getOptional()` on its argument without first checking that it was an object, tripping the `bun.debugAssert(target.isObject())` inside `JSValue.get`. The same issue applied to `bundlerOptions` itself.

### Repro

```js
Bun.serve({
  app: {
    bundlerOptions: {
      ssr: 1073741824,
    },
  },
});
```

Before:
```
panic(main thread): reached unreachable code
bun.debugAssert
jsc.JSValue.JSValue.get
jsc.JSValue.JSValue.getOptional
bake.bake.BuildConfigSubset.fromJS
bake.bake.UserOptions.fromJS
```

After:
```
TypeError: 'app.bundlerOptions.ssr' must be an object
 code: "ERR_INVALID_ARG_TYPE"
```

## How did you verify your code works?

Added `test/bake/app-options-validation.test.ts` covering `bundlerOptions` and each of `server`/`client`/`ssr` with non-object values.

Found by Fuzzilli (fingerprint `40903585822636ec`).