### PR TITLE
Fail fast at startup when simdutf has no usable implementation for this CPU

### DIFF
--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -1,6 +1,7 @@
 // when we don't want to use @cInclude, we can just stick wrapper functions here
 #include "root.h"
 #include <cstdio>
+#include <cstdlib>
 
 #if !OS(WINDOWS)
 #include <wtf/WTFConfig.h>
@@ -22,6 +23,17 @@
 #include <corecrt_io.h>
 #endif // !OS(WINDOWS)
 #include <lshpack.h>
+
+// Runs before Output and the Windows env block are initialized, hence the CRT.
+extern "C" [[noreturn]] void bun_abort_missing_simd(const char* requirement, const char* hint)
+{
+    fprintf(stderr, "error: this CPU is missing %s support, which Bun requires for UTF-8 processing.\n%s", requirement, hint);
+    if (const char* forced = getenv("SIMDUTF_FORCE_IMPLEMENTATION")) {
+        fprintf(stderr, "  note: SIMDUTF_FORCE_IMPLEMENTATION is set to \"%s\"\n", forced);
+    }
+    fflush(stderr);
+    exit(134);
+}
 
 // Error condition is encoded as max int32_t.
 // The only error in this function is ESRCH (no process found)

--- a/src/runtime/bin_entry/mod.rs
+++ b/src/runtime/bin_entry/mod.rs
@@ -154,6 +154,11 @@ pub(crate) unsafe extern "C" fn main(argc: c_int, argv: *const *const c_char) ->
     //    for the entire process.
     unsafe { bun_core::init_argv(argc, argv) };
 
+    // Everything below this point (crash handler included) calls into simdutf.
+    if !bun_simdutf_sys::simdutf::has_any_implementation() {
+        abort_for_unsupported_simdutf();
+    }
+
     // 1. Crash handler first so anything below gets a usable trace.
     bun_crash_handler::init();
 
@@ -232,4 +237,32 @@ fn use_mimalloc_in_dependencies() {
             Some(bun_alloc::mimalloc::mi_free),
         );
     }
+}
+
+unsafe extern "C" {
+    fn bun_abort_missing_simd(
+        requirement: *const core::ffi::c_char,
+        hint: *const core::ffi::c_char,
+    ) -> !;
+}
+
+#[cold]
+fn abort_for_unsupported_simdutf() -> ! {
+    // x64 builds are -march=nehalem, so simdutf's lowest kernel is SSE4.2.
+    let requirement: &core::ffi::CStr = if cfg!(target_arch = "x86_64") {
+        c"SSE4.2"
+    } else if cfg!(target_arch = "aarch64") {
+        c"NEON"
+    } else {
+        c"SIMD"
+    };
+
+    let hint: &core::ffi::CStr = if cfg!(target_arch = "x86_64") {
+        c"  Bun's x64 builds target Nehalem-class (2008+) CPUs.\n  If this is a VM, enable host CPU passthrough (e.g. -cpu host for QEMU/KVM).\n"
+    } else {
+        c""
+    };
+
+    // SAFETY: both arguments are NUL-terminated static C strings.
+    unsafe { bun_abort_missing_simd(requirement.as_ptr(), hint.as_ptr()) }
 }

--- a/src/simdutf_sys/simdutf.rs
+++ b/src/simdutf_sys/simdutf.rs
@@ -282,3 +282,9 @@ pub mod base64 {
         }
     }
 }
+
+/// False when no compiled-in kernel runs on this CPU: simdutf's
+/// `unsupported_implementation` stub returns false for every query.
+pub fn has_any_implementation() -> bool {
+    validate::ascii(b"a")
+}

--- a/test/regression/issue/30613.test.ts
+++ b/test/regression/issue/30613.test.ts
@@ -1,0 +1,68 @@
+// https://github.com/oven-sh/bun/issues/30613
+//
+// On CPUs below Bun's x64 baseline (e.g. QEMU's default TCG vCPU, which only
+// advertises SSE3), simdutf's runtime dispatcher finds no usable kernel:
+// the build is compiled with -march=nehalem, which defines __SSE4_2__ and
+// therefore compiles out simdutf's scalar fallback. It then dispatches to an
+// `unsupported_implementation` stub whose methods all return 0/false/{OTHER,0}.
+//
+// Before the fix, Bun trusted those return values: validate_utf8 rejects
+// every file (bunfig.toml fails to load with "Invalid UTF-8 byte sequence"),
+// and first_non_ascii reports a non-ASCII byte at offset 0 for any input
+// longer than its 32-byte scalar fast path, so the scan loops built on it
+// never advance and `bun app.js` hangs forever. The original report on
+// v1.3.9 hit a slice-length underflow on the same stub and segfaulted after
+// ~16 seconds instead.
+//
+// We simulate that CPU by forcing simdutf onto a nonexistent implementation
+// name; simdutf's set_best() treats an unknown name exactly like an
+// unsupported CPU and installs the same stub.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isArm64 } from "harness";
+
+// On arm64 simdutf compiles exactly one kernel (NEON, which is mandatory on
+// aarch64), so SIMDUTF_SINGLE_IMPLEMENTATION == 1 and runtime dispatch is
+// bypassed entirely: SIMDUTF_FORCE_IMPLEMENTATION is ignored and there is no
+// way to reach the unsupported stub from the outside. The startup probe still
+// runs there; it just can never fail on real arm64 hardware.
+test.concurrent.skipIf(isArm64)(
+  "fails fast with a clear error when simdutf has no supported implementation",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "console.log('unreachable')"],
+      env: {
+        ...bunEnv,
+        // Any name not in simdutf's compiled-in list selects the unsupported
+        // stub, identical to running on a pre-SSE4.2 host.
+        SIMDUTF_FORCE_IMPLEMENTATION: "none-for-issue-30613",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The unfixed build either hangs in a first_non_ascii scan loop or fails
+    // with a bogus "Invalid UTF-8" error depending on what it reads first; the
+    // fixed build prints a diagnostic and exits cleanly before touching input.
+    expect(stderr).toContain("Bun requires");
+    expect(stderr).toContain("SIMDUTF_FORCE_IMPLEMENTATION");
+    expect(stdout).toBe("");
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(134);
+  },
+);
+
+test.concurrent("runs normally when a supported simdutf implementation is available", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", "console.log('ok')"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("ok\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- On an x64 CPU without SSE4.2 (QEMU's default TCG vCPU, pre-Nehalem hardware) Bun does not start cleanly: `bun app.js` hangs forever, or fails with a bogus `error: Invalid UTF-8 byte sequence` on a valid file, or (on the v1.3.9 release in the original report) segfaults after ~16 seconds and ~4 GB of allocations. There is no hint that the CPU is the problem.
- Cause: every x64 build is compiled with `-march=nehalem` (`scripts/build/flags.ts`), which makes simdutf compile out its scalar fallback on the assumption that its SSE4.2 kernel can always run. On a CPU without SSE4.2, simdutf's dispatcher finds no usable kernel and installs an `unsupported_implementation` stub whose functions all return 0/false. Bun trusts those answers: `validate_utf8` rejects every file, and `first_non_ascii` (`src/bun_core/lib.rs`) reports a non-ASCII byte at index 0 for any input longer than its 32-byte scalar fast path, so the scan loops built on it never advance.
- Regressed in v1.3.9, when the prebuilt WebKit (which is where simdutf is compiled) started receiving explicit `-march` flags (oven-sh/WebKit@596e48e); before that the scalar fallback was compiled in.

### Fix
- `bun_simdutf_sys::simdutf::has_any_implementation()` validates one ASCII byte. This forces simdutf's lazy dispatch to run, and the stub's `validate_ascii` unconditionally returns false, so the result distinguishes a real kernel from the stub without touching simdutf internals.
- `main()` in `src/runtime/bin_entry/mod.rs` calls it immediately after capturing argv, before the crash handler and the Windows environment conversion (both push strings through simdutf). On failure it calls `bun_abort_missing_simd` (`src/jsc/bindings/c-bindings.cpp`), which prints which instruction set is missing (SSE4.2 on x64, NEON on arm64), a VM hint, and the value of `SIMDUTF_FORCE_IMPLEMENTATION` if set, then exits 134. It uses the C runtime because `Output` is not initialized yet.
- Verified with `test/regression/issue/30613.test.ts`: setting `SIMDUTF_FORCE_IMPLEMENTATION` to an unknown name makes simdutf install the same stub as an unsupported CPU, so the test reproduces the bug on any x64 machine. Without the fix the child hangs or fails with the UTF-8 error; with it, stderr names the requirement and the exit code is 134. A second test confirms a normal run is unaffected. The forced-stub test is skipped on arm64, where simdutf compiles a single kernel and bypasses dispatch entirely.
- Also run: the probe against the unfixed debug build (`bun app.js` under the forced stub hangs until killed; `bun --version` and short `-e` scripts still work because they stay under the 32-byte scalar path), and `cargo clippy --workspace`.

### Background
- simdutf is the SIMD UTF-8/UTF-16/base64 library used by both WebKit and Bun (Bun reaches it through `wtf/SIMDUTF.h`, so it is compiled once, inside the prebuilt WebKit). It ships several kernels (icelake, haswell, westmere, fallback) and picks one at first use by reading CPUID. Kernels that the compile-time `-march` proves redundant are removed: with `-march=nehalem`, `__SSE4_2__` is defined, the westmere kernel "can always run", and the scalar fallback is dropped.
- `unsupported_implementation` is simdutf's placeholder for "no kernel matched". It is also what `SIMDUTF_FORCE_IMPLEMENTATION=<unknown name>` selects, which is what makes the bug testable without special hardware.
- #14745 asks for exactly this startup check. One limitation: like the rest of the binary, the probe and the diagnostic are compiled for nehalem. That is sufficient for the failures seen in practice (the CPU in #30613 executed Bun for 16 seconds before dying, so reaching `main()` is not the problem), but a CPU so old that nehalem codegen itself faults before `main()` would still die with SIGILL. Moving the check into a separately compiled object, as #14745 suggests, would be a build-system change and is out of scope here.
- Restoring actual support for pre-SSE4.2 CPUs would mean building WebKit's simdutf with `SIMDUTF_IMPLEMENTATION_FALLBACK=1`; that is a separate oven-sh/WebKit change. This PR only makes the failure immediate and explicit.

<details>
<summary>Earlier revisions of this PR</summary>

Previous iterations also added a Rosetta 2 recovery path, a `bun_warn_avx_missing` suppression under Rosetta, and a hint pointing users of the default (`-march=haswell`) x64 build at the baseline download. #34782 made every x64 build nehalem and removed `bun_warn_avx_missing` and `Environment::BASELINE`, which made all of that unreachable: under Rosetta 2 the translated CPUID still advertises SSE4.2 and PCLMULQDQ, so the westmere kernel matches and the stub is never installed. Those pieces were dropped when rebasing onto that change; the remaining diff is the startup check alone. Earlier `.zig` reference-file edits were likewise dropped when #32621 removed those files; the Rust `first_non_ascii` has no equivalent of the Zig slice underflow. #39895 then folded the `bun_bin` crate into `bun_runtime`, so the entry-point hunk moved from `src/bun_bin/lib.rs` to `src/runtime/bin_entry/mod.rs` unchanged, and the separate Cargo dependency became unnecessary (`bun_runtime` already depends on `bun_simdutf_sys`).

</details>

Fixes #30613
Fixes #14745

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 31 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/30613.test.ts"
bun test v1.4.1 (4448a2e21)

test/regression/issue/30613.test.ts:
43 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
44 | 
45 |     // The unfixed build either hangs in a first_non_ascii scan loop or fails
46 |     // with a bogus "Invalid UTF-8" error depending on what it reads first; the
47 |     // fixed build prints a diagnostic and exits cleanly before touching input.
48 |     expect(stderr).toContain("Bun requires");
                        ^
error: expect(received).toContain(expected)

Expected to contain: "Bun requires"
Received: "1 | [test]\n    ^\nerror: Invalid UTF-8 byte sequence\n    at /workspace/bun/bunfig.toml:1:1\n\nSyntaxError: failed to load bunfig\n"

      at <anonymous> (/workspace/bun/test/regression/issue/30613.test.ts:48:20)
(fail) fails fast with a clear error when simdutf has no supported implementation [158.70ms]
(pass) runs normally when a supported simdutf implementation is available [271.48ms]

 1 pass
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/regression/issue/30613.test.ts:
43 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
44 | 
45 |     // The unfixed build either hangs in a first_non_ascii scan loop or fails
46 |     // with a bogus "Invalid UTF-8" error depending on what it reads first; the
47 |     // fixed build prints a diagnostic and exits cleanly before touching input.
48 |     expect(stderr).toContain("Bun requires");
                        ^
error: expect(received).toContain(expected)

Expected to contain: "Bun requires"
Received: "1 | [test]\n    ^\nerror: Invalid UTF-8 byte sequence\n    at /workspace/bun/bunfig.toml:1:1\n\nSyntaxError: failed to load bunfig\n"

      at <anonymous> (/workspace/bun/test/regression/issue/30613.test.ts:48:20)
(fail) fails fast with a clear error when simdutf has no supported implementation [3.24ms]
(pass) runs normally when a supported simdutf implementation is available [6.75ms]

 1 pass
 1 fail
 4 expect() calls
Ran 2 tests across 1 file. [172.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/30613.test.ts"
bun test v1.4.1 (4448a2e21)

test/regression/issue/30613.test.ts:
(pass) fails fast with a clear error when simdutf has no supported implementation [76.95ms]
(pass) runs normally when a supported simdutf implementation is available [322.05ms]

 2 pass
 0 fail
 8 expect() calls
Ran 2 tests across 1 file. [2.62s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 729ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 242 extern-C blocks audited
[2/8] gen cpp.rs (cppbind)
[2/8] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_simdutf_sys v0.0.0 (/workspace/bun/src/simdutf_sys)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/c-bindings.cpp     | 12 +++++++
 src/runtime/bin_entry/mod.rs        | 33 ++++++++++++++++++
 src/simdutf_sys/simdutf.rs          |  6 ++++
 test/regression/issue/30613.test.ts | 68 +++++++++++++++++++++++++++++++++++++
 4 files changed, 119 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 31

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/jsc/bindings/c-bindings.cpp          7      7     20
src/runtime/bin_entry/mod.rs             2      2     20
src/simdutf_sys/simdutf.rs               5      6     21
test/regression/issue/30613.test.ts      2      9     20
```

</details>

<!-- robobun:evidence:end -->
