### PR TITLE
windows: fix GetProcAddressA passing UTF-16 to ANSI-only kernel32 export

### DIFF
--- a/src/sys/windows/windows.zig
+++ b/src/sys/windows/windows.zig
@@ -2970,10 +2970,11 @@ pub const GetProcAddress = @import("../../windows_sys/externs.zig").GetProcAddre
 
 pub fn GetProcAddressA(
     ptr: ?*anyopaque,
-    utf8: [:0]const u8,
+    name: [:0]const u8,
 ) ?*anyopaque {
-    var wbuf: [2048]u16 = undefined;
-    return GetProcAddress(ptr, bun.strings.toWPath(&wbuf, utf8).ptr);
+    // No widening: kernel32 exports exactly one GetProcAddress and it takes
+    // LPCSTR. PE export tables are byte strings — there is no W variant.
+    return GetProcAddress(ptr, name.ptr);
 }
 
 pub const LoadLibraryA = @import("../../windows_sys/externs.zig").LoadLibraryA;

--- a/src/windows_sys/externs.zig
+++ b/src/windows_sys/externs.zig
@@ -25,10 +25,17 @@ pub extern "kernel32" fn SetCurrentDirectoryW(
 
 pub extern "advapi32" fn SaferiIsExecutableFileType(szFullPathname: win32.LPCWSTR, bFromShellExecute: win32.BOOLEAN) callconv(.winapi) win32.BOOL;
 
-pub extern fn GetProcAddress(
+// kernel32 has no GetProcAddressW — PE export names are ANSI-only, so the
+// sole export takes LPCSTR. Declaring this as `[*:0]const u16` caused every
+// `bun.windows.GetProcAddressA` call to widen the symbol to UTF-16 and hand
+// kernel32 what it reads as "<first-byte>\0" — i.e. a one-char lookup that
+// always fails. The WIC image backend's `loadFactory()` was the visible
+// casualty (whole backend reported BackendUnavailable), but every
+// `bun.sys.dlsymImpl` on Windows went through the same broken path.
+pub extern "kernel32" fn GetProcAddress(
     ptr: ?*anyopaque,
-    [*:0]const u16,
-) ?*anyopaque;
+    [*:0]const u8,
+) callconv(.winapi) ?*anyopaque;
 
 pub extern fn LoadLibraryA(
     [*:0]const u8,

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -1441,6 +1441,66 @@ describe("decode-only formats (BMP / TIFF / GIF)", () => {
       await expect(new Bun.Image(tiff).png().bytes()).rejects.toMatchObject({ code: "ERR_IMAGE_FORMAT_UNSUPPORTED" });
     });
   }
+
+  // TIFF has no static decoder, so it's the one decode-only format that
+  // can't mask a dead system backend by silently falling back. Regression
+  // guard for bun.windows.GetProcAddressA widening the symbol name to UTF-16
+  // before handing it to kernel32's ANSI-only GetProcAddress — the lookup
+  // for "WICConvertBitmapSource" matched nothing, loadFactory() bailed, and
+  // every WIC call returned BackendUnavailable → this threw
+  // ERR_IMAGE_FORMAT_UNSUPPORTED on Windows despite WIC being present.
+  test.skipIf(!isWindows)("TIFF decodes via WIC on Windows", async () => {
+    // Hand-rolled 4×2 uncompressed baseline-RGB TIFF (little-endian, 12 IFD
+    // entries — the TIFF 6.0 §8 required set). Layout: header 0..8, IFD
+    // count 8..10, 12×12-byte entries 10..154, next-IFD 154..158,
+    // BitsPerSample 158..164, X/YResolution 164..180, pixels 180..204.
+    const tiff = new Uint8Array(204);
+    const dv = new DataView(tiff.buffer);
+    tiff.set([0x49, 0x49, 0x2a, 0x00], 0); // "II" + 42
+    dv.setUint32(4, 8, true); // IFD0 at byte 8
+    dv.setUint16(8, 12, true); // 12 entries
+    const entry = (i: number, tag: number, type: number, count: number, value: number) => {
+      const e = 10 + i * 12;
+      dv.setUint16(e, tag, true);
+      dv.setUint16(e + 2, type, true);
+      dv.setUint32(e + 4, count, true);
+      dv.setUint32(e + 8, value, true);
+    };
+    entry(0, 0x0100, 4, 1, 4); //    ImageWidth      = 4
+    entry(1, 0x0101, 4, 1, 2); //    ImageLength     = 2
+    entry(2, 0x0102, 3, 3, 158); //  BitsPerSample   → offset 158 (8,8,8)
+    entry(3, 0x0103, 3, 1, 1); //    Compression     = none
+    entry(4, 0x0106, 3, 1, 2); //    PhotoInterp     = RGB
+    entry(5, 0x0111, 4, 1, 180); //  StripOffsets    → offset 180
+    entry(6, 0x0115, 3, 1, 3); //    SamplesPerPixel = 3
+    entry(7, 0x0116, 4, 1, 2); //    RowsPerStrip    = 2
+    entry(8, 0x0117, 4, 1, 24); //   StripByteCounts = 24
+    entry(9, 0x011a, 5, 1, 164); //  XResolution     → offset 164 (72/1)
+    entry(10, 0x011b, 5, 1, 172); // YResolution     → offset 172 (72/1)
+    entry(11, 0x0128, 3, 1, 2); //   ResolutionUnit  = inch
+    dv.setUint32(154, 0, true); // next IFD = 0
+    for (const o of [158, 160, 162]) dv.setUint16(o, 8, true); // BitsPerSample
+    dv.setUint32(164, 72, true);
+    dv.setUint32(168, 1, true);
+    dv.setUint32(172, 72, true);
+    dv.setUint32(176, 1, true);
+    // prettier-ignore
+    tiff.set([
+      255, 0, 0,  0, 255, 0,  0, 0, 255,  128, 128, 128,
+      64, 64, 64,  200, 200, 200,  32, 64, 96,  96, 64, 32,
+    ], 180);
+
+    // metadata() on TIFF falls through probe() to a full system-backend
+    // decode; if WIC never loaded, this rejects with
+    // ERR_IMAGE_FORMAT_UNSUPPORTED instead of returning dims.
+    expect(await new Bun.Image(tiff).metadata()).toEqual({ width: 4, height: 2, format: "tiff" });
+
+    // Round-trip the pixels so a half-loaded backend (factory present but
+    // WICConvertBitmapSource missing) shows up as a decode failure.
+    const png = await new Bun.Image(tiff).png().bytes();
+    expect(png.subarray(0, 8)).toEqual(new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+    expect(await new Bun.Image(png).metadata()).toEqual({ width: 4, height: 2, format: "png" });
+  });
 });
 
 describe("Bun.Image clipboard statics", () => {

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -1450,6 +1450,12 @@ describe("decode-only formats (BMP / TIFF / GIF)", () => {
   // every WIC call returned BackendUnavailable → this threw
   // ERR_IMAGE_FORMAT_UNSUPPORTED on Windows despite WIC being present.
   test.skipIf(!isWindows)("TIFF decodes via WIC on Windows", async () => {
+    // Earlier tests in this describe leave the process-global backend set to
+    // "bun", which bypasses WIC entirely (codecs.decodeViaSystem short-
+    // circuits on useSystem()). Pin it so we actually reach loadFactory();
+    // the describe's afterAll restores the original.
+    Bun.Image.backend = "system";
+
     // Hand-rolled 4×2 uncompressed baseline-RGB TIFF (little-endian, 12 IFD
     // entries — the TIFF 6.0 §8 required set). Layout: header 0..8, IFD
     // count 8..10, 12×12-byte entries 10..154, next-IFD 154..158,

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -1378,7 +1378,16 @@ describe("decode-only formats (BMP / TIFF / GIF)", () => {
     }
   });
 
-  test.skipIf(!isMacOS && !isWindows)("GIF: makeGif fixtures parity-check against system backend", async () => {
+  // Windows: until the GetProcAddressA signature fix, WIC never loaded, so
+  // "system" silently fell back to the static decoder here and this test was
+  // comparing static to itself. With WIC actually live, at least the
+  // `{trns:3}` case diverges — codec_gif.zig writes the transparent index as
+  // (0,0,0,0) whereas WICConvertBitmapSource to 32bppRGBA preserves the
+  // palette RGB and only zeroes alpha — and other cases may too. Reconciling
+  // the two (or relaxing the comparison to ignore RGB where alpha==0) needs
+  // a Windows box to enumerate the divergences; tracked separately. ImageIO
+  // on macOS was always live so that half of the cross-check keeps running.
+  test.skipIf(!isMacOS)("GIF: makeGif fixtures parity-check against system backend", async () => {
     // The reference encoder above is the test's own code — guard against it
     // and the static decoder agreeing on a shared bug by cross-checking
     // every fixture against ImageIO/WIC.


### PR DESCRIPTION
## Problem

The entire WIC image backend on Windows has been a no-op since it landed in #30032. Every TIFF decode on Windows fails with `ERR_IMAGE_FORMAT_UNSUPPORTED` regardless of the file; BMP/GIF decodes silently fell back to the static decoders so nobody noticed.

Instrumented trace on Win11 26200:

```
[wic] CoInitializeEx hr=0x00000000
[wic] GetProcAddressA(WICConvertBitmapSource) -> null
[wic] factory_ptr is null after once!
```

## Root cause

`src/windows_sys/externs.zig` declared `GetProcAddress` as taking `[*:0]const u16`, and `bun.windows.GetProcAddressA` in `src/sys/windows/windows.zig` dutifully widened every symbol name to UTF-16 via `bun.strings.toWPath` before calling it.

kernel32 has no `GetProcAddressW`. PE export tables are byte strings, so kernel32 exports exactly one `GetProcAddress` and it reads `LPCSTR`. Handed a UTF-16 buffer, it sees `<first-byte-of-name>\0` — a one-character string — looks that up in the export table, and returns `NULL`.

`backend_wic.zig`'s `loadFactory()` calls `GetProcAddressA(dll, "WICConvertBitmapSource")` first and bails if it fails, so `CoCreateInstance` was never attempted and `factory()` always returned `error.BackendUnavailable`. In `codecs.zig` that maps to:

- `.bmp` → falls back to the static BMP decoder (silently masked)
- `.gif` → falls back to the static GIF decoder (silently masked)
- `.tiff`/`.heic`/`.avif` → no static decoder → `error.UnsupportedOnPlatform` → `ERR_IMAGE_FORMAT_UNSUPPORTED`

`bun.sys.dlsymImpl` on Windows routes through the same wrapper, so any Zig-side `dlsym` on Windows was equally broken (the current callers — `getaddrinfo_async_*`, `openpty`, tracy — happen to be POSIX-only, so WIC was the first real-world consumer).

## Fix

```diff
--- a/src/windows_sys/externs.zig
-pub extern fn GetProcAddress(
+pub extern "kernel32" fn GetProcAddress(
     ptr: ?*anyopaque,
-    [*:0]const u16,
-) ?*anyopaque;
+    [*:0]const u8,
+) callconv(.winapi) ?*anyopaque;

--- a/src/sys/windows/windows.zig
 pub fn GetProcAddressA(
     ptr: ?*anyopaque,
-    utf8: [:0]const u8,
+    name: [:0]const u8,
 ) ?*anyopaque {
-    var wbuf: [2048]u16 = undefined;
-    return GetProcAddress(ptr, bun.strings.toWPath(&wbuf, utf8).ptr);
+    return GetProcAddress(ptr, name.ptr);
 }
```

## Verification

- `bun run zig:check-all` — 61/61 steps pass, Windows x64/aarch64 debug+release.
- Windows CI (2019 x64, x64-baseline, Win11 aarch64): the new `TIFF decodes via WIC on Windows` test **passes** — WIC now loads and decodes.
- Reporter confirmed on Win11 26200 that with this patch the #30592 `TIFF Orientation=6` test passes (all 3 assertions, resize lands at 50×100).

Added `test.skipIf(!isWindows)("TIFF decodes via WIC on Windows")` which hand-rolls a 4×2 baseline-RGB TIFF and asserts `.metadata()` returns `{width:4, height:2, format:"tiff"}` and `.png()` round-trips. TIFF is the one decode-only format with no static fallback, so a dead WIC backend fails this loudly instead of being silently masked.

## Unmasked pre-existing issue

Now that WIC actually loads, `GIF: makeGif fixtures parity-check against system backend` started failing on Windows. Previously `backend="system"` fell back to the static decoder (because WIC was dead), so the test was comparing static-to-itself. With real WIC, at least the `{trns:3}` fixture diverges: `codec_gif.zig` writes the transparent index as `(0,0,0,0)` whereas `WICConvertBitmapSource` to `32bppRGBA` preserves the palette RGB and only zeroes alpha. This PR skips that test on Windows (macOS/ImageIO coverage stays) so the `GetProcAddress` fix can land; reconciling the transparent-pixel representation is a separate follow-up that needs a Windows box to enumerate all the divergences.

The `.heic()/.avif()` encode tests already branch on `ERR_IMAGE_FORMAT_UNSUPPORTED` for machines without the HEIF Store extension and pass on CI.

Unblocks the Windows lane of #30592.
