### PR TITLE
watcher: wake the watcher thread on shutdown so torn-down dev servers release it

### DIFF
--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -66,6 +66,13 @@ pub mod kernel32 {
             lpOverlapped: LPOVERLAPPED,
             lpCompletionRoutine: LPOVERLAPPED_COMPLETION_ROUTINE,
         ) -> BOOL;
+        pub fn CancelIoEx(hFile: HANDLE, lpOverlapped: LPOVERLAPPED) -> BOOL;
+        pub fn PostQueuedCompletionStatus(
+            CompletionPort: HANDLE,
+            dwNumberOfBytesTransferred: DWORD,
+            dwCompletionKey: ULONG_PTR,
+            lpOverlapped: LPOVERLAPPED,
+        ) -> BOOL;
 
         // safe: by-value `HANDLE` + `DWORD`; a bad handle yields
         // `WAIT_FAILED` + GetLastError, no UB.

--- a/src/watcher/INotifyWatcher.rs
+++ b/src/watcher/INotifyWatcher.rs
@@ -3,7 +3,7 @@
 
 use core::ffi::c_int;
 use core::mem::{align_of, size_of};
-use core::sync::atomic::{AtomicU32, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use bun_core::{ZStr, env_var, output as Output};
 use bun_paths::MAX_PATH_BYTES;
@@ -41,6 +41,8 @@ pub(crate) type Platform = INotifyWatcher;
 
 pub struct INotifyWatcher {
     pub(crate) fd: Fd,
+    /// eventfd that `wake()` signals; `read()` polls it alongside `fd`.
+    wake_fd: Fd,
     pub(crate) loaded: bool,
 
     // Avoid statically allocating because it increases the binary size.
@@ -54,6 +56,8 @@ pub struct INotifyWatcher {
     read_ptr: Option<ReadPtr>,
 
     pub(crate) watch_count: AtomicU32,
+    /// Set by `wake()`; `read()` returns nothing once it is set.
+    shutdown_requested: AtomicBool,
     /// nanoseconds
     pub(crate) coalesce_interval: isize,
 }
@@ -62,11 +66,13 @@ impl Default for INotifyWatcher {
     fn default() -> Self {
         Self {
             fd: Fd::INVALID,
+            wake_fd: Fd::INVALID,
             loaded: false,
             eventlist_bytes: bun_core::boxed_zeroed(),
             eventlist_ptrs: [core::ptr::null(); max_count],
             read_ptr: None,
             watch_count: AtomicU32::new(0),
+            shutdown_requested: AtomicBool::new(false),
             coalesce_interval: 100_000,
         }
     }
@@ -193,9 +199,17 @@ impl INotifyWatcher {
             return Err(crate::Error::Sys(errno));
         }
         let fd = Fd::from_native(raw);
+        let wake_fd = match bun_sys::eventfd(0, libc::EFD_CLOEXEC) {
+            Ok(wake_fd) => wake_fd,
+            Err(err) => {
+                let _ = bun_sys::close(fd);
+                return Err(err.into());
+            }
+        };
         bun_core::scoped_log!(watcher, "{} init", fd);
         Ok(Self {
             fd,
+            wake_fd,
             loaded: true,
             coalesce_interval: env_var::BUN_INOTIFY_COALESCE_INTERVAL
                 .get()
@@ -223,11 +237,53 @@ impl INotifyWatcher {
         // of self.eventlist_bytes across the whole function.
         let read_len: usize = if let Some(ptr) = self.read_ptr {
             Futex::wait_forever(&self.watch_count, 0);
+            if self.shutdown_requested.load(Ordering::Acquire) {
+                return Ok(&[]);
+            }
             i = ptr.i;
             ptr.len as usize
         } else {
             'outer: loop {
                 Futex::wait_forever(&self.watch_count, 0);
+
+                // Wait here rather than in `read()` so `wake_fd` can interrupt it.
+                let mut fds = [
+                    system::pollfd {
+                        fd: self.fd.native(),
+                        events: (libc::POLLIN | libc::POLLERR) as _,
+                        revents: 0,
+                    },
+                    system::pollfd {
+                        fd: self.wake_fd.native(),
+                        events: libc::POLLIN as _,
+                        revents: 0,
+                    },
+                ];
+                // SAFETY: fds is a valid stack array; a null timeout blocks
+                // indefinitely; sigmask is null.
+                let poll_n = unsafe {
+                    system::ppoll(
+                        fds.as_mut_ptr(),
+                        fds.len(),
+                        core::ptr::null(),
+                        core::ptr::null(),
+                    )
+                };
+                if self.shutdown_requested.load(Ordering::Acquire) {
+                    return Ok(&[]);
+                }
+                if poll_n < 0 {
+                    match bun_sys::get_errno(poll_n) {
+                        E::EINTR | E::EAGAIN => continue 'outer,
+                        e => {
+                            return Err(bun_sys::Error {
+                                errno: e as u32 as _,
+                                syscall: bun_sys::Tag::poll,
+                                ..Default::default()
+                            });
+                        }
+                    }
+                }
 
                 // SAFETY: fd is a valid inotify fd; buffer is valid for eventlist_bytes.len() bytes.
                 let rc = unsafe {
@@ -365,6 +421,18 @@ impl INotifyWatcher {
             let _ = bun_sys::close(self.fd);
             self.fd = Fd::INVALID;
         }
+        if self.wake_fd != Fd::INVALID {
+            let _ = bun_sys::close(self.wake_fd);
+            self.wake_fd = Fd::INVALID;
+        }
+    }
+
+    /// Unblocks `read()` whether it is parked on `watch_count` or in `ppoll`.
+    pub(crate) fn wake(&self) {
+        self.shutdown_requested.store(true, Ordering::Release);
+        self.watch_count.fetch_add(1, Ordering::Release);
+        Futex::wake(&self.watch_count, u32::MAX);
+        let _ = bun_sys::write(self.wake_fd, &1u64.to_ne_bytes());
     }
 }
 

--- a/src/watcher/KEventWatcher.rs
+++ b/src/watcher/KEventWatcher.rs
@@ -11,13 +11,35 @@ pub struct KEventWatcher {
 
 const CHANGELIST_COUNT: usize = 128;
 
+/// Idents are per filter, so this cannot collide with an `EVFILT_VNODE` fd.
+const WAKE_IDENT: usize = 0;
+
+fn wake_event(flags: u16, fflags: u32) -> libc::kevent {
+    let mut ev: libc::kevent = bun_core::ffi::zeroed();
+    ev.ident = WAKE_IDENT;
+    ev.filter = libc::EVFILT_USER;
+    ev.flags = flags;
+    ev.fflags = fflags;
+    ev
+}
+
 impl KEventWatcher {
     pub(crate) fn new(_root: &[u8]) -> crate::Result<Self> {
         let fd = bun_sys::kqueue()?;
         if fd.native() == 0 {
             return Err(crate::Error::KQueueError);
         }
-        Ok(Self { fd })
+        let mut this = Self { fd };
+        if let Err(err) = bun_sys::kevent(
+            fd,
+            &[wake_event(libc::EV_ADD | libc::EV_CLEAR, 0)],
+            &mut [],
+            None,
+        ) {
+            this.stop();
+            return Err(err.into());
+        }
+        Ok(this)
     }
 
     pub(crate) fn stop(&mut self) {
@@ -25,6 +47,11 @@ impl KEventWatcher {
             let _ = bun_sys::close(self.fd);
             self.fd = Fd::INVALID;
         }
+    }
+
+    /// Runs under `Watcher.mutex`, which `thread_body` takes before `stop()`, so `fd` is open.
+    pub(crate) fn wake(&self) {
+        let _ = bun_sys::kevent(self.fd, &[wake_event(0, libc::NOTE_TRIGGER)], &mut [], None);
     }
 }
 
@@ -67,14 +94,17 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
         count += bun_sys::kevent(fd, &[], &mut changelist[count..], Some(&ts))?;
     }
 
-    let changes = &changelist[..count];
+    // Drops the `EVFILT_USER` event posted by `wake()`.
+    let mut changes = changelist[..count]
+        .iter()
+        .filter(|event| event.filter == libc::EVFILT_VNODE);
     let watchevents = &mut this.watch_events[..count];
     let mut out_len: usize = 0;
-    if let [first, rest @ ..] = changes {
+    if let Some(first) = changes.next() {
         watchevents[0] = watch_event_from_kevent(first);
         out_len = 1;
         let mut prev_event = first;
-        for event in rest {
+        for event in changes {
             if prev_event.udata == event.udata {
                 let new = watch_event_from_kevent(event);
                 watchevents[out_len - 1].merge(new);
@@ -85,6 +115,9 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
             prev_event = event;
             out_len += 1;
         }
+    }
+    if out_len == 0 {
+        return Ok(());
     }
 
     this.dispatch_file_updates(out_len, out_len);

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -108,12 +108,9 @@ pub struct Watcher {
     // Storing the `top_level_dir` slice directly avoids a forward-decl
     // dependency on the higher-tier `bun_resolver::fs::FileSystem` type.
     // allocator field dropped — global mimalloc (see §Allocators)
-    /// Whether `thread_main` is running. Written by the watcher thread, read
-    /// by `start`/`shutdown` on the main thread. The actual `ThreadId` value
-    /// was never read — only `is_some()`/`is_none()` — so this is a `bool`.
+    /// The thread owns the allocation: set by `start()`, cleared under `mutex` by `thread_body`.
     pub(crate) watchloop_handle: bun_core::AtomicCell<bool>,
     pub(crate) cwd: &'static [u8],
-    pub(crate) thread: Option<std::thread::JoinHandle<()>>,
     /// Main thread clears this in `shutdown`; watcher thread polls it in
     /// `watch_loop` and the platform `watch_loop_cycle`.
     pub(crate) running: bun_core::AtomicCell<bool>,
@@ -134,6 +131,13 @@ pub struct Watcher {
     pub(crate) on_error: fn(*mut (), sys::Error),
 
     pub thread_lock: ThreadLock,
+}
+
+impl Drop for Watcher {
+    fn drop(&mut self) {
+        // `MultiArrayList` frees only its slab, not the owned `file_path`s.
+        self.watchlist.drop_elements();
+    }
 }
 
 /// Context types passed to `Watcher::init` implement this trait.
@@ -198,7 +202,6 @@ impl Watcher {
             watch_events: vec![WatchEvent::default(); MAX_COUNT].into_boxed_slice(),
             changed_filepaths: [const { None }; MAX_COUNT],
             watchloop_handle: bun_core::AtomicCell::new(false),
-            thread: None,
             running: bun_core::AtomicCell::new(true),
             close_descriptors: bun_core::AtomicCell::new(false),
             evict_list: [0; MAX_EVICTION_COUNT],
@@ -254,7 +257,8 @@ impl Watcher {
             std::thread::sleep(std::time::Duration::from_millis(10));
             spawn().map_err(|_| first)
         });
-        self.thread = Some(handle.map_err(|e| {
+        // Never joined (the thread frees the Watcher itself); dropping the handle detaches it.
+        handle.map_err(|e| {
             self.watchloop_handle.store(false);
             // Windows: raw_os_error() is a Win32 GetLastError() code, so
             // route it through the u32 (Win32Error) mapper rather than
@@ -270,7 +274,7 @@ impl Watcher {
                 .map(bun_errno::from_errno)
                 .unwrap_or(bun_errno::SystemErrno::EAGAIN);
             crate::Error::Sys(errno)
-        })?);
+        })?;
         Ok(())
     }
 
@@ -279,37 +283,42 @@ impl Watcher {
     // Per PORTING.md, `pub fn deinit` is never the public name; renamed to
     // `shutdown` (not `close(self)` because ownership may transfer to the
     // watcher thread instead of dropping here).
-    // TODO: ownership model — needs heap::take or an Arc to make this sound.
     /// # Safety
     /// `this` must be the unique heap pointer returned from `init()`; ownership
     /// transfers here on the no-thread path (the Box is reclaimed).
     pub unsafe fn shutdown(this: *mut Self, close_descriptors: bool) {
-        let free = {
+        {
             // SAFETY: caller passes the unique heap pointer returned from init().
-            // Shared access suffices (atomics + mutex + column reads); the borrow
+            // Shared access suffices (atomics + mutex + `wake()`); the borrow
             // ends before the free below.
             let me = unsafe { &*this };
+            me.mutex.lock();
             if me.watchloop_handle.load() {
-                me.mutex.lock();
                 me.close_descriptors.store(close_descriptors);
                 me.running.store(false);
+                me.platform.wake();
                 me.mutex.unlock();
-                false
-            } else {
-                if close_descriptors && me.running.load() {
-                    let fds = me.watchlist.items_fd();
-                    for &fd in fds {
-                        let _ = bun_sys::close(fd);
-                    }
-                }
-                true
+                // The thread may free `this` as soon as the mutex is released.
+                return;
             }
-        };
-        if free {
-            // watchlist freed by Drop on Box
-            // SAFETY: this was heap-allocated by caller of init(); no borrow of it
-            // is live here.
-            drop(unsafe { bun_core::heap::take(this) });
+            me.mutex.unlock();
+        }
+
+        // SAFETY: this was heap-allocated by caller of init(); no thread owns it
+        // and no borrow of it is live here.
+        unsafe { bun_core::heap::take(this) }.release(close_descriptors);
+    }
+
+    /// Runs on whichever side ends up freeing the allocation.
+    fn release(&mut self, close_descriptors: bool) {
+        self.platform.stop();
+        if close_descriptors {
+            // Entries added without an fd (e.g. plugin-loaded files) hold `Fd::INVALID`.
+            for &fd in self.watchlist.items_fd() {
+                if fd.is_valid() {
+                    let _ = bun_sys::close(fd);
+                }
+            }
         }
     }
 
@@ -332,9 +341,6 @@ impl Watcher {
         // argument is still protected is UB under Stacked Borrows / Tree Borrows.
         let owner_still_alive = unsafe { (*this).thread_body() };
 
-        // Close trace file if open
-        WatcherTrace::deinit();
-
         Output::flush();
 
         if !owner_still_alive {
@@ -346,34 +352,30 @@ impl Watcher {
         Ok(())
     }
 
+    /// Returns `true` if ownership went back to the owner, which may free `self` once unlocked.
     fn thread_body(&mut self) -> bool {
-        self.watchloop_handle.store(true);
         self.thread_lock.lock();
         Output::Source::configure_named_thread(zstr!("File Watcher"));
 
         log!("Watcher started");
 
-        let owner_still_alive = match self.watch_loop() {
-            Err(err) => {
-                self.watchloop_handle.store(false);
-                self.platform.stop();
-                let running = self.running.load();
-                if running {
-                    (self.on_error)(self.ctx, err);
-                }
-                running
-            }
-            Ok(()) => false,
-        };
+        let result = self.watch_loop();
 
-        // deinit and close descriptors if needed
-        if self.close_descriptors.load() {
-            let fds = self.watchlist.items_fd();
-            for &fd in fds {
-                let _ = bun_sys::close(fd);
+        // `shutdown()` may still hold the mutex; this orders `stop()` and the free after it.
+        self.mutex.lock();
+        if let Err(err) = result {
+            if self.running.load() {
+                // Under the mutex (like `on_file_update`) so the owner outlives the callback.
+                (self.on_error)(self.ctx, err);
+                self.watchloop_handle.store(false);
+                self.mutex.unlock();
+                return true;
             }
         }
-        owner_still_alive
+        self.mutex.unlock();
+
+        self.release(self.close_descriptors.load());
+        false
     }
 
     pub fn flush_evictions(&mut self) {

--- a/src/watcher/WatcherTrace.rs
+++ b/src/watcher/WatcherTrace.rs
@@ -6,9 +6,7 @@ use bun_threading::Guarded;
 
 use crate::watcher_impl::{ChangedFilePath, WatchEvent, WatchList};
 
-/// Optional trace file for debugging watcher events.
-// Wrapped in `bun_threading::Guarded` (cheap when
-// uncontended; only the watcher thread touches this after init).
+/// Shared by every watcher in the process; flushed on every write, so it stays open until exit.
 static TRACE_FILE: Guarded<Option<File>> = Guarded::new(None);
 
 /// Initialize trace file if BUN_WATCHER_TRACE env var is set.
@@ -171,11 +169,4 @@ pub(crate) fn write_events(
     if writer.write_all(b"}}\n").is_err() {
         return;
     }
-}
-
-/// Close the trace file if open
-// free-function `deinit` (no `self`), so this stays a plain fn
-// rather than `impl Drop`.
-pub(crate) fn deinit() {
-    let _ = TRACE_FILE.lock().take();
 }

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -22,6 +22,8 @@ pub struct WindowsWatcher {
     pub(crate) watcher: DirWatcher,
     pub(crate) buf: PathBuffer,
     pub(crate) base_idx: usize,
+    /// A read is outstanding: the kernel may write into `watcher` until its packet is dequeued.
+    armed: bool,
 }
 
 impl Default for WindowsWatcher {
@@ -35,6 +37,7 @@ impl Default for WindowsWatcher {
             },
             buf: PathBuffer::uninit(),
             base_idx: 0,
+            armed: false,
         }
     }
 }
@@ -299,93 +302,153 @@ impl WindowsWatcher {
         Ok(())
     }
 
+    /// An outstanding read is reused, so `overlapped`/`buf` are never handed to two reads.
+    fn arm(&mut self) -> bun_sys::Result<()> {
+        if !self.armed {
+            self.watcher.prepare()?;
+            self.armed = true;
+        }
+        Ok(())
+    }
+
+    /// Every read started by `arm()` yields exactly one packet carrying `watcher.overlapped`.
+    fn dequeue(&mut self, timeout_ms: w::DWORD) -> Packet {
+        let mut nbytes: w::DWORD = 0;
+        let mut key: w::ULONG_PTR = 0;
+        let mut overlapped: *mut w::OVERLAPPED = ptr::null_mut();
+        // SAFETY: iocp is a valid IOCP handle; out-params are valid stack locals.
+        let rc = unsafe {
+            w::kernel32::GetQueuedCompletionStatus(
+                self.iocp,
+                &mut nbytes,
+                &mut key,
+                &mut overlapped,
+                timeout_ms,
+            )
+        };
+        let err = if rc == 0 {
+            w::Win32Error::get()
+        } else {
+            w::Win32Error::SUCCESS
+        };
+
+        if overlapped == &raw mut self.watcher.overlapped {
+            self.armed = false;
+            return Packet::Ours { nbytes, err };
+        }
+        if !overlapped.is_null() {
+            return Packet::Foreign;
+        }
+        if rc != 0 {
+            return Packet::Wake;
+        }
+        // `WAIT_TIMEOUT` (258) — not yet a named const on `bun_sys::windows::Win32Error`.
+        if err == w::Win32Error::TIMEOUT || err == w::Win32Error(258) {
+            return Packet::Timeout;
+        }
+        Packet::PortError(err)
+    }
+
     /// wait until new events are available
     fn next(&mut self, timeout: Timeout) -> bun_sys::Result<Option<EventIterator>> {
-        if let Err(err) = self.watcher.prepare() {
+        if let Err(err) = self.arm() {
             bun_core::scoped_log!(watcher, "prepare() returned error");
             return Err(err);
         }
 
-        let mut nbytes: w::DWORD = 0;
-        let mut key: w::ULONG_PTR = 0;
-        let mut overlapped: *mut w::OVERLAPPED = ptr::null_mut();
         loop {
-            // SAFETY: iocp is a valid IOCP handle; out-params are valid stack locals.
-            let rc = unsafe {
-                w::kernel32::GetQueuedCompletionStatus(
-                    self.iocp,
-                    &mut nbytes,
-                    &mut key,
-                    &mut overlapped,
-                    timeout as w::DWORD,
-                )
-            };
-            if rc == 0 {
-                let err = w::Win32Error::get();
-                // `WAIT_TIMEOUT` (258) — not yet a named const on `bun_sys::windows::Win32Error`.
-                if err == w::Win32Error::TIMEOUT || err == w::Win32Error(258) {
-                    return Ok(None);
-                } else {
+            match self.dequeue(timeout as w::DWORD) {
+                Packet::Timeout => return Ok(None),
+                // Posted by `wake()`; `watch_loop` re-checks `running`.
+                Packet::Wake => return Ok(None),
+                Packet::Foreign => continue,
+                Packet::PortError(err) => {
                     bun_core::scoped_log!(watcher, "GetQueuedCompletionStatus failed: {}", err.0);
-                    return Err(bun_sys::Error {
-                        errno: bun_sys::SystemErrno::init(err.0 as u32)
-                            .unwrap_or(bun_sys::SystemErrno::EINVAL)
-                            as _,
-                        syscall: bun_sys::Tag::watch,
-                        ..Default::default()
-                    });
+                    return Err(win32_watch_error(err));
                 }
-            }
-
-            if !overlapped.is_null() {
-                // ignore possible spurious events
-                if overlapped != &mut self.watcher.overlapped as *mut w::OVERLAPPED {
-                    continue;
+                Packet::Ours { err, .. } if err != w::Win32Error::SUCCESS => {
+                    bun_core::scoped_log!(watcher, "ReadDirectoryChangesW failed: {}", err.0);
+                    return Err(win32_watch_error(err));
                 }
-                if nbytes == 0 {
-                    // ReadDirectoryChangesW internal change-buffer overflow — too many
-                    // events arrived between drain and re-arm. This is NOT a shutdown
-                    // signal: stop() closes the dir handle, which surfaces as rc==0 /
-                    // ERROR_OPERATION_ABORTED above, never as rc!=0 && nbytes==0. Per
-                    // MSDN, the function returns zero bytes when its internal buffer
-                    // overflows. Drop the lost events, re-arm, and keep watching so
-                    // --hot picks up the next change. Returning ESHUTDOWN here kills
-                    // the watcher thread and the --hot child silently exits
-                    // (hot.test.ts "should work with sourcemap generation" flake).
+                Packet::Ours { nbytes: 0, .. } => {
+                    // Per MSDN a zero-byte success means the kernel's change buffer overflowed;
+                    // erroring out here made --hot exit silently (hot.test.ts sourcemap flake).
                     bun_core::scoped_log!(
                         watcher,
                         "ReadDirectoryChangesW buffer overflow (nbytes==0); re-arming"
                     );
-                    if let Err(err) = self.watcher.prepare() {
-                        return Err(err);
-                    }
+                    self.arm()?;
                     continue;
                 }
-                return Ok(Some(EventIterator {
-                    watcher: BackRef::new(&self.watcher),
-                    offset: 0,
-                    has_next: true,
-                }));
-            } else {
-                bun_core::scoped_log!(
-                    watcher,
-                    "GetQueuedCompletionStatus returned no overlapped event"
-                );
-                return Err(bun_sys::Error {
-                    errno: bun_sys::SystemErrno::EINVAL as _,
-                    syscall: bun_sys::Tag::watch,
-                    ..Default::default()
-                });
+                Packet::Ours { .. } => {
+                    return Ok(Some(EventIterator {
+                        watcher: BackRef::new(&self.watcher),
+                        offset: 0,
+                        has_next: true,
+                    }));
+                }
             }
         }
     }
 
     pub(crate) fn stop(&mut self) {
-        // SAFETY: handles were opened in init() and are valid until stop() is called once.
-        unsafe {
-            w::CloseHandle(self.watcher.dir_handle);
-            w::CloseHandle(self.iocp);
+        if self.armed {
+            // The caller frees `watcher` next; if `CancelIoEx` fails the packet is already queued.
+            // SAFETY: dir_handle is the open directory handle from init(); a
+            // null OVERLAPPED cancels all I/O issued on it.
+            let _ = unsafe { w::kernel32::CancelIoEx(self.watcher.dir_handle, ptr::null_mut()) };
+            while self.armed {
+                match self.dequeue(DRAIN_TIMEOUT_MS) {
+                    Packet::Ours { .. } | Packet::Foreign | Packet::Wake => {}
+                    Packet::Timeout | Packet::PortError(_) => break,
+                }
+            }
         }
+        if self.watcher.dir_handle != w::INVALID_HANDLE_VALUE {
+            // SAFETY: opened in init(); cleared below so this runs at most once.
+            let _ = unsafe { w::CloseHandle(self.watcher.dir_handle) };
+            self.watcher.dir_handle = w::INVALID_HANDLE_VALUE;
+        }
+        if self.iocp != w::INVALID_HANDLE_VALUE {
+            // SAFETY: created in init(); cleared below so this runs at most once.
+            let _ = unsafe { w::CloseHandle(self.iocp) };
+            self.iocp = w::INVALID_HANDLE_VALUE;
+        }
+    }
+
+    /// Runs under `Watcher.mutex`, which `thread_body` takes before `stop()`, so `iocp` is open.
+    pub(crate) fn wake(&self) {
+        // SAFETY: iocp is a live port; the packet carries no OVERLAPPED, which
+        // `dequeue` reports as `Packet::Wake`.
+        let _ =
+            unsafe { w::kernel32::PostQueuedCompletionStatus(self.iocp, 0, 0, ptr::null_mut()) };
+    }
+}
+
+/// Cancellation completes in microseconds; this only bounds the pathological case.
+const DRAIN_TIMEOUT_MS: w::DWORD = 1000;
+
+enum Packet {
+    /// `err` is `SUCCESS` unless the read failed or was cancelled.
+    Ours {
+        nbytes: w::DWORD,
+        err: w::Win32Error,
+    },
+    /// Carries an OVERLAPPED that is not ours.
+    Foreign,
+    /// Posted by `wake()`.
+    Wake,
+    Timeout,
+    /// `GetQueuedCompletionStatus` failed without dequeuing anything.
+    PortError(w::Win32Error),
+}
+
+fn win32_watch_error(err: w::Win32Error) -> bun_sys::Error {
+    bun_sys::Error {
+        errno: bun_sys::SystemErrno::init(err.0 as u32).unwrap_or(bun_sys::SystemErrno::EINVAL)
+            as _,
+        syscall: bun_sys::Tag::watch,
+        ..Default::default()
     }
 }
 

--- a/test/bake/dev-server-watcher-release.test.ts
+++ b/test/bake/dev-server-watcher-release.test.ts
@@ -1,0 +1,54 @@
+// https://github.com/oven-sh/bun/issues/21017
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import path from "node:path";
+
+const fixtureDir = path.join(import.meta.dir, "fixtures", "watcher-release");
+const fixtureFiles = ["dev-server-teardown-fixture.ts", "index.html", "entry.ts"];
+
+test("tearing down a dev server also tears down its watcher thread", async () => {
+  // The fixture modifies one of its own files, so it runs from a scratch copy.
+  using dir = tempDir(
+    "watcher-release",
+    Object.fromEntries(
+      await Promise.all(fixtureFiles.map(async name => [name, await Bun.file(path.join(fixtureDir, name)).text()])),
+    ),
+  );
+  using traceDir = tempDir("watcher-release-trace", {});
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), fixtureFiles[0]],
+    env: { ...bunEnv, BUN_WATCHER_TRACE: path.join(String(traceDir), "trace.log") },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr }).toEqual({
+    stdout: expect.stringContaining("PASS"),
+    stderr: expect.anything(),
+  });
+
+  if (isLinux) {
+    // Without the fix every dev server leaves one parked watcher thread and one
+    // inotify instance behind: 20 for the listen failures and 5 for the served
+    // servers. The deltas can dip below zero when a thread from an earlier
+    // teardown exits inside a measured window, and unrelated threads may
+    // appear, hence bounds rather than exact values.
+    const result = JSON.parse(stdout.split("\n").find(line => line.startsWith("{"))!);
+    expect(result).toEqual({
+      listenFail: { threads: expect.any(Number), inotify: expect.any(Number) },
+      served: { threads: expect.any(Number), inotify: expect.any(Number) },
+      survivorTraced: true,
+    });
+    expect(result.listenFail.inotify).toBeLessThanOrEqual(0);
+    expect(result.listenFail.threads).toBeLessThan(10);
+    expect(result.served.inotify).toBeLessThanOrEqual(0);
+    expect(result.served.threads).toBeLessThan(3);
+  }
+
+  expect(exitCode).toBe(0);
+});

--- a/test/bake/fixtures/watcher-release/dev-server-teardown-fixture.ts
+++ b/test/bake/fixtures/watcher-release/dev-server-teardown-fixture.ts
@@ -1,0 +1,133 @@
+// Run from a scratch copy of this directory: the survivor below rewrites entry.ts.
+import html from "./index.html";
+import { existsSync, readFileSync, readdirSync, readlinkSync, writeFileSync } from "node:fs";
+
+const isLinux = process.platform === "linux";
+const traceFile = process.env.BUN_WATCHER_TRACE;
+
+function threadCount(): number {
+  const m = readFileSync("/proc/self/status", "utf8").match(/Threads:\s*(\d+)/);
+  if (!m) throw new Error("no Threads: line in /proc/self/status");
+  return parseInt(m[1], 10);
+}
+
+function inotifyFdCount(): number {
+  let n = 0;
+  for (const name of readdirSync("/proc/self/fd")) {
+    let target: string;
+    try {
+      target = readlinkSync(`/proc/self/fd/${name}`);
+    } catch {
+      // Closed between readdir and readlink (the readdir handle itself, for one).
+      continue;
+    }
+    if (target.startsWith("anon_inode:inotify")) n++;
+  }
+  return n;
+}
+
+interface Deltas {
+  threads: number;
+  inotify: number;
+}
+
+// Runs `body`, then waits for the watcher threads it tore down to exit. With
+// the fix this converges almost immediately; without it the threads are parked
+// forever, so a short deadline is enough.
+async function measure(body: () => Promise<void>): Promise<Deltas | null> {
+  if (!isLinux) {
+    await body();
+    return null;
+  }
+  const threadsBefore = threadCount();
+  const inotifyBefore = inotifyFdCount();
+  await body();
+  const deadline = Date.now() + 1000;
+  let deltas: Deltas;
+  while (true) {
+    deltas = { threads: threadCount() - threadsBefore, inotify: inotifyFdCount() - inotifyBefore };
+    if ((deltas.threads <= 0 && deltas.inotify <= 0) || Date.now() > deadline) return deltas;
+    await Bun.sleep(20);
+  }
+}
+
+function serve() {
+  return Bun.serve({
+    port: 0,
+    development: true,
+    routes: { "/": html },
+    fetch: () => new Response("unreachable"),
+  });
+}
+
+// The issue's scenario: the dev server fails to listen, so its watcher is torn
+// down before the watcher thread has anything to watch.
+async function listenFailures(): Promise<void> {
+  using blocker = Bun.serve({
+    port: 0,
+    fetch: () => new Response("blocked"),
+  });
+
+  for (let i = 0; i < 20; i++) {
+    try {
+      Bun.serve({
+        port: blocker.port,
+        reusePort: false,
+        development: true,
+        routes: { "/": html },
+        fetch: () => new Response("unreachable"),
+      });
+      throw new Error(`iteration ${i}: Bun.serve unexpectedly succeeded on a busy port`);
+    } catch (e: any) {
+      if (e?.code !== "EADDRINUSE") throw e;
+    }
+  }
+}
+
+async function serveOnce(): Promise<void> {
+  const server = serve();
+  const response = await fetch(server.url);
+  if (response.status !== 200) throw new Error(`expected 200 from the dev server, got ${response.status}`);
+  await response.arrayBuffer();
+  await server.stop(true);
+}
+
+// The dev server served a request first, so the watcher thread is blocked
+// waiting for filesystem events on real watches when it is torn down.
+async function servedThenStopped(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await serveOnce();
+  }
+}
+
+// A dev server that stays up while the others are torn down. Afterwards a change
+// to one of its files must still reach BUN_WATCHER_TRACE, which every watcher in
+// the process shares.
+async function startSurvivor() {
+  const server = serve();
+  await (await fetch(server.url)).arrayBuffer();
+  return async function finish(): Promise<boolean> {
+    let traced = false;
+    for (let attempt = 0; !traced && attempt < 10; attempt++) {
+      writeFileSync("./entry.ts", `document.title = "changed ${attempt}";\n`);
+      const until = Date.now() + 200;
+      while (!traced && Date.now() < until) {
+        await Bun.sleep(20);
+        traced = existsSync(traceFile!) && readFileSync(traceFile!, "utf8").includes("entry.ts");
+      }
+    }
+    await server.stop(true);
+    return traced;
+  };
+}
+
+const listenFail = await measure(listenFailures);
+const finishSurvivor = isLinux && traceFile ? await startSurvivor() : null;
+// The first bundle also starts the bundler thread pool, which stays alive, so
+// it has to happen before the measured window below.
+if (!finishSurvivor) await serveOnce();
+const served = await measure(servedThenStopped);
+const survivorTraced = finishSurvivor ? await finishSurvivor() : null;
+
+if (isLinux) console.log(JSON.stringify({ listenFail, served, survivorTraced }));
+console.log("PASS");

--- a/test/bake/fixtures/watcher-release/entry.ts
+++ b/test/bake/fixtures/watcher-release/entry.ts
@@ -1,0 +1,1 @@
+document.getElementById("root")!.textContent = "entry";

--- a/test/bake/fixtures/watcher-release/index.html
+++ b/test/bake/fixtures/watcher-release/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./entry.ts"></script>
+  </body>
+</html>


### PR DESCRIPTION
Fixes #21017 (the remaining part; see Background for what main already fixed).

### Problem

- `Watcher::shutdown()` only flipped `running` under the mutex. Nothing woke the watcher thread, so every `Bun.serve({ development: true })` that was torn down (a failed listen as in the issue, or a normal `server.stop()`) left a `FileWatcher` thread parked forever, plus its inotify instance / kqueue / directory handle and the `Watcher` allocation. 20 failed listens on the unfixed build leave 20 threads and 20 inotify instances behind (`test/bake/dev-server-watcher-release.test.ts`), which ends in `EMFILE while initializing file watcher` on hosts with a small `max_user_instances`.
- The watch-error path handed the allocation back to the owner by clearing `watchloop_handle` outside any lock and kept using `self` afterwards (`thread_body`, `Watcher.rs`), while `shutdown()` read the flag without the lock and could free the allocation concurrently.
- Windows: `next()` called `ReadDirectoryChangesW` on every call, including when the previous read on the same `OVERLAPPED`/buffer was still outstanding (`WindowsWatcher.rs`), and the thread freed the `Watcher` with a read still armed into its inline buffer.
- Two more bugs were hidden only because the thread never exited, and surface as soon as it does (each was hit by an existing test on this branch). A third, `NewServer` dropping the bake arena before the `DevServer` that lives in it, was split out and has landed on `main` as #39630, which this branch now relies on (the new fixture hit it as an intermittent SEGV):
  - Teardown closed every watchlist fd, but entries added without an fd (plugin-loaded files) hold `Fd::INVALID`, which trips `close()`'s debug assertion (`test/bake/serve-plugins-dev-server.test.ts` aborted).
  - `MultiArrayList`'s `Drop` frees only its slab, so the owned `WatchItem.file_path`s leaked once the `Watcher` was actually freed (LSan on the asan lane), and `thread_main` closed the process-global `BUN_WATCHER_TRACE` file the first time any watcher exited (pointed out in #36253).

### Fix

- Per-platform `wake()`, called by `shutdown()` under the mutex:
  - Linux: `read()` now waits in `ppoll()` on the inotify fd plus an eventfd; `wake()` sets a flag, bumps the `watch_count` futex (for a watcher with nothing to watch yet) and writes the eventfd.
  - macOS/FreeBSD: an `EVFILT_USER` event registered on the kqueue; `wake()` triggers it and `watch_loop_cycle` ignores it.
  - Windows: `wake()` posts a bare packet with `PostQueuedCompletionStatus`; `next()` reports it as `Packet::Wake` and returns so `watch_loop` re-checks `running`.
- Ownership: `start()` sets `watchloop_handle` before spawning (as on main); `thread_body` now takes the mutex after `watch_loop` returns, so it cannot run `stop()` or free the allocation while `shutdown()` is still inside its critical section, and the hand-back after a watch error (flag clear, `on_error`) happens under that mutex, which `shutdown()` also holds while reading the flag. `on_error` runs under the mutex deliberately: `on_file_update` is already dispatched under it, and it is what keeps the owner alive for the callback. Whichever side frees the allocation runs the same `release()` (`platform.stop()` + close the watched fds, skipping `Fd::INVALID`), and `Drop for Watcher` drops the watchlist rows.
- Windows teardown: `armed` tracks the single outstanding read; `arm()` only issues a new read when none is outstanding, and `stop()` runs `CancelIoEx` and dequeues that read's completion packet before closing the handles, so the kernel is done with the buffer before the allocation is freed. The drain is bounded by a 1s timeout per packet.
- The per-thread `WatcherTrace::deinit()` is removed (every batch is flushed on write, so the shared file simply lives until exit); the write-only `thread` field is removed.
- Verification:
  - `test/bake/dev-server-watcher-release.test.ts` runs a fixture that fails 20 listens on a busy port, then serves and stops 5 dev servers while a sixth stays up, and on Linux checks via `/proc` that no threads or inotify instances are left behind and that a file change in the surviving server still reaches `BUN_WATCHER_TRACE`. `USE_SYSTEM_BUN=1`: fails with `inotify: 20` / `inotify: 5`. `bun bd`: passes (deltas 0), 10+ consecutive runs locally, also under the CI asan lane's LSan settings.
  - Linux (`bun bd`, also with `BUN_DESTRUCT_VM_ON_EXIT=1` + `detect_leaks=1`): `test/bake/deinitialization.test.ts`, `test/bake/serve-plugins-dev-server.test.ts`, `test/cli/hot/*.test.ts`, `test/cli/watch/*.test.ts` pass.
  - Windows x64 (`bun bd` on a Windows box): the regression test, `serve-plugins-dev-server`, `deinitialization` (66 runs; the only failures were a pre-existing usockets crash in `us_internal_socket_follow_adopted` that also shows up as a CI flake on unrelated PRs, reported separately), and `test/cli/hot` + `test/cli/watch` pass.
  - `cargo check -p bun_watcher` and clippy on the Linux, Windows and macOS targets; the macOS path is only exercised by CI.

### Background

- The watcher is a heap `Watcher` shared between the owner (DevServer, `--hot`) and a thread it spawns; the thread blocks in the platform wait (inotify `read`, `kevent`, `GetQueuedCompletionStatus`) and frees the `Watcher` itself when it notices `running == false`. `shutdown()` therefore never frees the allocation once a thread exists; it only signals it. `watchloop_handle` is the "a thread owns this" flag.
- The issue's original crash (the thread started after `shutdown()` had already freed the `Watcher`, because the flag used to be set by the spawned thread) was fixed on main by #36165, which sets the flag in `start()`. This PR covers what that left: the thread and its resources were still never released, and the error-path hand-off was still racy.
- eventfd / `EVFILT_USER` / a null-`OVERLAPPED` completion packet are the standard ways to interrupt a thread blocked in `ppoll` / `kevent` / IOCP from another thread without closing the fd or handle it is waiting on (closing it from another thread does not reliably unblock the waiter, and on Windows the kernel keeps writing into the read buffer until the cancelled read's completion is dequeued).
- The bake arena: a dev server's options and transpilers are allocated in a `MimallocArena` owned by `ServerConfig.bake`; the arena has to outlive `DevServer::drop`, which reads from it.
- #36253 is an earlier, now conflicting attempt at the same thread leak (Linux eventfd, macOS mach port, Windows left leaking); this PR is rebased on current main and also covers Windows and the bugs listed above. #32443 addressed the spawn race that #36165 has since fixed on main. #39197 (merged) frees evicted entries' paths; the `Drop for Watcher` here covers the entries still in the list at teardown, which #39197 explicitly leaves to this PR.

<details>
<summary>Probe: exposing the three hidden bugs</summary>

- Drop order (now #39630 on `main`): with the wake in place but without it, the fixture SEGV'd in roughly 1 of 4 ASAN runs inside `DevServer::drop` while dropping `bundler_framework_views` (arena-resident); 0 of 25 with it.
- Invalid fds: `serve-plugins-dev-server.test.ts` "plugin setup resolves" aborted with `assertion failed: fd != Fd::INVALID` from `bun_sys::close` on every run; plugin-loaded files are added with `Fd::INVALID` on non-kqueue platforms (`bundle_v2.rs` `on_load`).
- Paths/trace: LSan reported the `Cow::Owned` path from `append_file_assume_capacity::<true>` (16 bytes) on the same test; the surviving-server part of the fixture fails (`survivorTraced: false`) if the `WatcherTrace::deinit()` call is put back.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 25 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bake/dev-server-watcher-release.test.ts

<!-- robobun:evidence:end -->
