### PR TITLE
webview: navigate/reload/goBack/goForward accept { waitUntil, timeout }

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9228,6 +9228,30 @@ declare module "bun" {
       modifiers?: Modifier[];
     }
 
+    interface NavigateOptions {
+      /**
+       * When to consider the navigation finished:
+       *
+       * - `"load"` — wait for the window `load` event (all subresources
+       *   finished). Matches Playwright's default.
+       * - `"domcontentloaded"` — wait for `DOMContentLoaded`. Use this for
+       *   pages that hold a connection open (SSE, long-polling, a hung
+       *   subresource) and so never fire `load`.
+       *
+       * With the Chrome backend this subscribes to CDP
+       * `Page.lifecycleEvent`. The WebKit backend has no separate
+       * DOMContentLoaded delegate hook, so `"domcontentloaded"` behaves
+       * like `"load"` there — use `timeout` to bound the wait instead.
+       * @default "load"
+       */
+      waitUntil?: "load" | "domcontentloaded";
+      /**
+       * Maximum time to wait in milliseconds. `0` disables the timeout.
+       * @default 30000
+       */
+      timeout?: number;
+    }
+
     /**
      * Browser backend selection.
      *
@@ -9455,16 +9479,22 @@ declare module "bun" {
     onNavigationFailed: ((error: Error) => void) | null;
 
     /**
-     * Navigate to a URL. Resolves when the main frame's load completes
-     * (WKNavigationDelegate `didFinishNavigation`).
+     * Navigate to a URL. Resolves when the navigation reaches the
+     * `options.waitUntil` milestone (default: the window `load` event),
+     * or rejects after `options.timeout` ms.
      *
      * @example
      * ```ts
      * await view.navigate("https://example.com");
      * await view.navigate("data:text/html,<h1>hello</h1>");
+     *
+     * // Page holds an SSE stream open — `load` never fires.
+     * await view.navigate("https://example.com/stream", {
+     *   waitUntil: "domcontentloaded",
+     * });
      * ```
      */
-    navigate(url: string): Promise<void>;
+    navigate(url: string, options?: WebView.NavigateOptions): Promise<void>;
 
     /**
      * Run a JavaScript expression in the page's main frame and return the
@@ -9682,11 +9712,11 @@ declare module "bun" {
     resize(width: number, height: number): Promise<void>;
 
     /** Navigate back in session history. */
-    back(): Promise<void>;
+    goBack(options?: WebView.NavigateOptions): Promise<void>;
     /** Navigate forward in session history. */
-    forward(): Promise<void>;
+    goForward(options?: WebView.NavigateOptions): Promise<void>;
     /** Reload the current page. */
-    reload(): Promise<void>;
+    reload(options?: WebView.NavigateOptions): Promise<void>;
 
     /**
      * Close the view and release its WebContent process. After close,

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -760,6 +760,27 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
     JSWebView* view = viewFor(entry.viewId);
     if (!view) return; // user dropped both view and the awaited promise
 
+    // Navigate-slot entries carry the view's m_navGeneration at
+    // enqueue time. armNavTimeout rejects the navigate (bumping gen)
+    // without pruning m_pending, so a response for the abandoned
+    // navigation can arrive after a .catch() retry refilled
+    // m_pendingNavigate. Mismatch → this response is stale; settling
+    // would resolve/reject the RETRY's promise (or, for the attach
+    // chain, create a second tab whose events route to this view).
+    // Covers PageTitle, PageNavigate errorText, PageGetNavigationHistory
+    // boundary, and TargetCreateTarget→…→PageEnable in one place.
+    if (entry.navGen && entry.navGen != view->m_navGeneration) {
+        // TargetCreateTarget already ran in Chrome by the time we
+        // see the response — close the orphaned tab so it doesn't
+        // leak for process lifetime.
+        if (entry.method == Method::TargetCreateTarget && error.empty()) {
+            auto tid = jsonString(jsonField(result, { "targetId", 8 }));
+            if (!tid.empty())
+                send(0, Command(nextId(), "Target.closeTarget"_s).str("targetId"_s, WTF::String::fromUTF8(tid)));
+        }
+        return;
+    }
+
     if (!error.empty()) {
         // {"code":-32000,"message":"..."}
         auto msgSlice = jsonString(jsonField(error, { "message", 7 }));
@@ -781,7 +802,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         auto tid = jsonString(jsonField(result, { "targetId", 8 }));
         view->m_targetId = WTF::String::fromUTF8(tid);
         uint32_t cid = nextId();
-        m_pending.add(cid, Pending { Method::TargetAttachToTarget, entry.slot, entry.viewId });
+        m_pending.add(cid, Pending { Method::TargetAttachToTarget, entry.slot, entry.viewId, entry.navGen });
         send(cid, Command(cid, "Target.attachToTarget"_s).str("targetId"_s, view->m_targetId).boolean("flatten"_s, true));
         return;
     }
@@ -800,7 +821,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         auto ss = view->m_sessionId.utf8();
         std::span<const char> sidSpan(ss.data(), ss.length());
         uint32_t cid = nextId();
-        m_pending.add(cid, Pending { Method::PageEnable, entry.slot, entry.viewId });
+        m_pending.add(cid, Pending { Method::PageEnable, entry.slot, entry.viewId, entry.navGen });
         send(cid, Command(cid, "Page.enable"_s, sidSpan));
         return;
     }
@@ -815,12 +836,24 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         uint32_t rid = nextId();
         send(0, Command(rid, "Runtime.enable"_s, sidSpan));
 
+        // Page.setLifecycleEventsEnabled — fire-and-forget. Chrome then
+        // emits Page.lifecycleEvent {frameId, loaderId, name} for commit/
+        // DOMContentLoaded/load/networkIdle. navigate({waitUntil:
+        // 'domcontentloaded'}) settles on that instead of loadEventFired,
+        // so pages that never fire `load` (SSE, long-poll, a hung
+        // subresource) don't hang the await. Enabling replays the current
+        // document's events, but m_frameId/m_loaderId are unset until the
+        // USER url's frameNavigated, so the about:blank replay never
+        // matches.
+        uint32_t lid = nextId();
+        send(0, Command(lid, "Page.setLifecycleEventsEnabled"_s, sidSpan).boolean("enabled"_s, true));
+
         // Page.navigate with the url stashed by the first navigate() call.
         // The response confirms the navigation STARTED; Page.loadEventFired
         // confirms completion. We keep the pending entry alive for the
         // response so errorText rejects the right slot.
         uint32_t cid = nextId();
-        m_pending.add(cid, Pending { Method::PageNavigate, entry.slot, entry.viewId });
+        m_pending.add(cid, Pending { Method::PageNavigate, entry.slot, entry.viewId, entry.navGen });
         send(cid, Command(cid, "Page.navigate"_s, sidSpan).str("url"_s, view->m_pendingChromeNavigateUrl));
         view->m_pendingChromeNavigateUrl = WTF::String();
         return;
@@ -887,7 +920,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         int32_t entryId = elem ? elem->getInteger("id"_s).value_or(0) : 0;
         // Chain into navigateToHistoryEntry. Page.loadEventFired settles.
         uint32_t cid = nextId();
-        m_pending.add(cid, Pending { Method::PageNavigateToHistoryEntry, entry.slot, entry.viewId });
+        m_pending.add(cid, Pending { Method::PageNavigateToHistoryEntry, entry.slot, entry.viewId, entry.navGen });
         send(cid, Command(cid, "Page.navigateToHistoryEntry"_s, sidSpan(view->m_sessionId)).num("entryId"_s, entryId));
         return;
     }
@@ -1138,14 +1171,47 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
+    // Chained from lifecycleEvent/loadEventFired: Runtime.evaluate(
+    // "document.title") so view.title is populated when navigate()
+    // resolves — matches WKWebView's NavDone which packs url+title in
+    // one reply. One extra roundtrip (~1ms), but the user-visible
+    // guarantee (`await view.navigate(); view.title` works) is worth
+    // it. PageTitle's response handler is the settle point.
+    //
+    // Sets m_navTitleChained: on a fast page, lifecycleEvent(DCL),
+    // lifecycleEvent(load) and loadEventFired can all arrive before
+    // the first PageTitle response — each would otherwise enqueue a
+    // duplicate PageTitle whose LATER response could settle a
+    // subsequent navigate()'s promise. After the first call, further
+    // triggers for the same document see the flag and drop. Cleared
+    // by beginChromeNavigation() for the next navigation. m_loaderId
+    // is left populated so loadEventFired can still tell THIS
+    // document's event from a stale one (m_loaderId empty = a new
+    // navigation started and hasn't committed yet).
+    auto chainTitle = [&]() {
+        view->m_navTitleChained = true;
+        uint32_t tid = nextId();
+        m_pending.add(tid, Pending { Method::PageTitle, PendingSlot::Navigate, view->m_viewId, view->m_navGeneration });
+        send(tid, Command(tid, "Runtime.evaluate"_s, sidSpan(view->m_sessionId)).str("expression"_s, "document.title"_s).boolean("returnByValue"_s, true));
+    };
+
     // Page.frameNavigated — commit. Update m_url and fire onNavigated.
     // Same timing as WKWebView's NavDone (didFinishNavigation): the URL is
     // now the new document, resources may still be loading.
     if (method.size() == 19 && memcmp(method.data(), "Page.frameNavigated", 19) == 0) {
         auto frame = jsonField(params, { "frame", 5 });
+        // Subframe commits have frame.parentId set; only the main frame
+        // updates m_url and the lifecycle loaderId. (frameNavigated for
+        // subframes is rare without Page.setFrameTree, but an <iframe>
+        // doc.write can trigger one.)
+        if (!jsonField(frame, { "parentId", 8 }).empty()) return;
         auto url = jsonString(jsonField(frame, { "url", 3 }));
         auto urlStr = WTF::String::fromUTF8(url);
         view->m_url = urlStr;
+        // Stash for lifecycleEvent matching. loaderId changes every
+        // navigation; frame.id is stable for the target's main frame.
+        view->m_frameId = WTF::String::fromUTF8(jsonString(jsonField(frame, { "id", 2 })));
+        view->m_loaderId = WTF::String::fromUTF8(jsonString(jsonField(frame, { "loaderId", 8 })));
         // m_loading stays true — loadEventFired flips it.
 
         if (JSObject* cb = view->m_onNavigated.get()) {
@@ -1155,19 +1221,60 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // Page.loadEventFired — load complete. Chain a document.title fetch
-    // so view.title is populated when navigate() resolves — matches
-    // WKWebView's NavDone which packs url+title in one reply. One extra
-    // roundtrip (~1ms), but the user-visible guarantee is worth it:
-    // `await view.navigate(); view.title` just works.
+    // Page.lifecycleEvent — {frameId, loaderId, name, timestamp}. Fires
+    // for commit, DOMContentLoaded, load, networkAlmostIdle, networkIdle
+    // on every frame. We settle the Navigate slot when the main frame's
+    // current loaderId reaches the user's waitUntil milestone. Gating on
+    // loaderId is what makes 'domcontentloaded' safe: Chrome REPLAYS the
+    // prior document's lifecycle on setLifecycleEventsEnabled, and
+    // subframes fire their own — neither has our loaderId.
     //
-    // If no navigate is pending (uninitiated navigation, redirect), the
-    // PageTitle handler settles a no-op and m_title still updates.
+    // waitUntil:'load' is left to Page.loadEventFired below (it fires
+    // once for the main frame only, after lifecycleEvent(name=load)) —
+    // existing behavior preserved and no duplicate title-fetch.
+    if (method.size() == 19 && memcmp(method.data(), "Page.lifecycleEvent", 19) == 0) {
+        if (!view->m_pendingNavigate || view->m_navWaitUntil != NavWaitUntil::DOMContentLoaded)
+            return;
+        auto name = jsonString(jsonField(params, { "name", 4 }));
+        // `load` also satisfies `domcontentloaded` — it can only fire
+        // after DCL, and on some same-document navigations Chrome skips
+        // DCL and emits load directly. Playwright's LifecycleWatcher
+        // treats it the same way.
+        if (!(name.size() == 16 && memcmp(name.data(), "DOMContentLoaded", 16) == 0)
+            && !(name.size() == 4 && memcmp(name.data(), "load", 4) == 0))
+            return;
+        // beginChromeNavigation() cleared m_loaderId; frameNavigated for
+        // THIS navigation repopulates it. Empty → the event is for the
+        // previous document (or the setLifecycleEventsEnabled replay).
+        if (view->m_loaderId.isEmpty()) return;
+        auto frameId = jsonString(jsonField(params, { "frameId", 7 }));
+        auto loaderId = jsonString(jsonField(params, { "loaderId", 8 }));
+        auto fUtf = view->m_frameId.utf8();
+        auto lUtf = view->m_loaderId.utf8();
+        if (frameId.size() != fUtf.length() || memcmp(frameId.data(), fUtf.data(), frameId.size()) != 0) return;
+        if (loaderId.size() != lUtf.length() || memcmp(loaderId.data(), lUtf.data(), loaderId.size()) != 0) return;
+        if (!view->m_navTitleChained) chainTitle();
+        return;
+    }
+
+    // Page.loadEventFired — window `load` fired on the main frame. This
+    // is the settle path for waitUntil:'load' (default).
+    //
+    // Stale detection: beginChromeNavigation() clears m_loaderId; this
+    // document's frameNavigated repopulates it. m_loaderId empty =
+    // a NEW navigation started and hasn't committed yet, so this
+    // loadEventFired is for the PREVIOUS document — don't clear
+    // m_loading (the new nav set it true) and don't chainTitle().
+    //
+    // m_navTitleChained dedupes: a fast page's lifecycleEvent(DCL)
+    // already chained the title fetch; a second PageTitle could
+    // settle a LATER navigate. m_pendingNavigate must also be set so
+    // an idle loadEventFired (uninitiated window.location) doesn't
+    // enqueue a PageTitle that races a later navigate().
     if (method.size() == 19 && memcmp(method.data(), "Page.loadEventFired", 19) == 0) {
+        if (view->m_loaderId.isEmpty()) return; // stale — prior document
         view->m_loading = false;
-        uint32_t tid = nextId();
-        m_pending.add(tid, Pending { Method::PageTitle, PendingSlot::Navigate, view->m_viewId });
-        send(tid, Command(tid, "Runtime.evaluate"_s, sidSpan(view->m_sessionId)).str("expression"_s, "document.title"_s).boolean("returnByValue"_s, true));
+        if (view->m_pendingNavigate && !view->m_navTitleChained) chainTitle();
         return;
     }
 
@@ -1421,7 +1528,11 @@ static JSPromise* sendChromeOp(JSGlobalObject* g, JSWebView* v,
     }
     v->m_pendingActivityCount.fetch_add(1, std::memory_order_release);
     slot.set(vm, v, promise);
-    t.m_pending.add(id, Pending { m, ps, v->m_viewId });
+    // Navigate-slot entries carry m_navGeneration so handleResponse
+    // can drop a response that arrives after this navigation was
+    // abandoned (armNavTimeout rejected it) and replaced by a retry.
+    uint32_t gen = ps == PendingSlot::Navigate ? v->m_navGeneration : 0;
+    t.m_pending.add(id, Pending { m, ps, v->m_viewId, gen });
     t.send(id, WTF::move(cmd));
     t.updateKeepAlive();
     return promise;

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -760,11 +760,9 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
     JSWebView* view = viewFor(entry.viewId);
     if (!view) return; // user dropped both view and the awaited promise
 
-    // Stale Navigate-slot response: the timeout rejected this navigation
-    // (bumping the generation) without pruning m_pending. Settling here
-    // would hit a retry's promise.
+    // A reply for a navigation that timed out must not settle the retry's promise.
     if (entry.navGen && entry.navGen != view->m_navGeneration) {
-        // The tab was already created; close it so it does not leak.
+        // The tab exists by now; close it rather than leak it.
         if (entry.method == Method::TargetCreateTarget && error.empty()) {
             auto tid = jsonString(jsonField(result, { "targetId", 8 }));
             if (!tid.empty())
@@ -828,10 +826,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         uint32_t rid = nextId();
         send(0, Command(rid, "Runtime.enable"_s, sidSpan));
 
-        // Page.setLifecycleEventsEnabled, fire-and-forget. Chrome then
-        // emits Page.lifecycleEvent; waitUntil:'domcontentloaded' settles
-        // on it. The enable-time replay of about:blank never matches
-        // m_frameId/m_loaderId, which are unset until the user url commits.
+        // Fire-and-forget; Page.lifecycleEvent is what settles waitUntil:'domcontentloaded'.
         uint32_t lid = nextId();
         send(0, Command(lid, "Page.setLifecycleEventsEnabled"_s, sidSpan).boolean("enabled"_s, true));
 
@@ -1158,11 +1153,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // Fetch document.title so view.title is set when navigate() resolves
-    // (parity with WKWebView's NavDone). PageTitle's response handler is
-    // the settle point. m_navTitleChained dedupes the DCL/load/
-    // loadEventFired triggers; a duplicate PageTitle response could
-    // settle a later navigate()'s promise.
+    // The PageTitle reply settles the navigate with view.title populated; one fetch per document.
     auto chainTitle = [&]() {
         view->m_navTitleChained = true;
         uint32_t tid = nextId();
@@ -1175,16 +1166,11 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     // now the new document, resources may still be loading.
     if (method.size() == 19 && memcmp(method.data(), "Page.frameNavigated", 19) == 0) {
         auto frame = jsonField(params, { "frame", 5 });
-        // Subframe commits have frame.parentId set; only the main frame
-        // updates m_url and the lifecycle loaderId. (frameNavigated for
-        // subframes is rare without Page.setFrameTree, but an <iframe>
-        // doc.write can trigger one.)
-        if (!jsonField(frame, { "parentId", 8 }).empty()) return;
+        if (!jsonField(frame, { "parentId", 8 }).empty()) return; // subframe
         auto url = jsonString(jsonField(frame, { "url", 3 }));
         auto urlStr = WTF::String::fromUTF8(url);
         view->m_url = urlStr;
-        // Stash for lifecycleEvent matching. loaderId changes every
-        // navigation; frame.id is stable for the target's main frame.
+        // Page.lifecycleEvent below matches on these.
         view->m_frameId = WTF::String::fromUTF8(jsonString(jsonField(frame, { "id", 2 })));
         view->m_loaderId = WTF::String::fromUTF8(jsonString(jsonField(frame, { "loaderId", 8 })));
         // m_loading stays true — loadEventFired flips it.
@@ -1196,21 +1182,16 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // Page.lifecycleEvent settles waitUntil:'domcontentloaded'. The
-    // frameId/loaderId match filters subframe events and the enable-time
-    // replay. waitUntil:'load' stays on Page.loadEventFired below.
+    // Settles waitUntil:'domcontentloaded'. Chrome replays the prior document's lifecycle on enable and subframes emit their own, so only this navigation's frameId+loaderId count.
     if (method.size() == 19 && memcmp(method.data(), "Page.lifecycleEvent", 19) == 0) {
         if (!view->m_pendingNavigate || view->m_navWaitUntil != NavWaitUntil::DOMContentLoaded)
             return;
         auto name = jsonString(jsonField(params, { "name", 4 }));
-        // `load` also satisfies `domcontentloaded`: some same-document
-        // navigations skip DCL. Playwright treats it the same way.
+        // `load` implies DOMContentLoaded; Chrome skips DCL on some same-document navigations.
         if (!(name.size() == 16 && memcmp(name.data(), "DOMContentLoaded", 16) == 0)
             && !(name.size() == 4 && memcmp(name.data(), "load", 4) == 0))
             return;
-        // Empty m_loaderId = this navigation has not committed; the
-        // event is the prior document's (or the enable-time replay).
-        if (view->m_loaderId.isEmpty()) return;
+        if (view->m_loaderId.isEmpty()) return; // this navigation has not committed yet
         auto frameId = jsonString(jsonField(params, { "frameId", 7 }));
         auto loaderId = jsonString(jsonField(params, { "loaderId", 8 }));
         auto fUtf = view->m_frameId.utf8();
@@ -1221,12 +1202,9 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // Page.loadEventFired — the settle path for waitUntil:'load' (the
-    // default). Empty m_loaderId = a new navigation started and has not
-    // committed, so this event is the prior document's: leave m_loading
-    // set and skip chainTitle().
+    // Page.loadEventFired settles waitUntil:'load'.
     if (method.size() == 19 && memcmp(method.data(), "Page.loadEventFired", 19) == 0) {
-        if (view->m_loaderId.isEmpty()) return; // stale — prior document
+        if (view->m_loaderId.isEmpty()) return; // the previous document's load; a new navigation is in flight
         view->m_loading = false;
         if (view->m_pendingNavigate && !view->m_navTitleChained) chainTitle();
         return;
@@ -1482,7 +1460,6 @@ static JSPromise* sendChromeOp(JSGlobalObject* g, JSWebView* v,
     }
     v->m_pendingActivityCount.fetch_add(1, std::memory_order_release);
     slot.set(vm, v, promise);
-    // navGen lets handleResponse drop a response for a timed-out navigation.
     uint32_t gen = ps == PendingSlot::Navigate ? v->m_navGeneration : 0;
     t.m_pending.add(id, Pending { m, ps, v->m_viewId, gen });
     t.send(id, WTF::move(cmd));

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -813,22 +813,20 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         uint32_t cid = nextId();
         m_pending.add(cid, Pending { Method::PageEnable, entry.slot, entry.viewId, entry.navGen });
         send(cid, Command(cid, "Page.enable"_s, sidSpan));
+
+        // Per-session setup, fire-and-forget, sent here and not from the
+        // PageEnable reply handler: a navigate timeout makes the stale gate
+        // drop that reply, which must only cost the navigation, not the
+        // session's console and lifecycle events.
+        uint32_t rid = nextId();
+        send(0, Command(rid, "Runtime.enable"_s, sidSpan));
+        uint32_t lid = nextId();
+        send(0, Command(lid, "Page.setLifecycleEventsEnabled"_s, sidSpan).boolean("enabled"_s, true));
         return;
     }
     case Method::PageEnable: {
-        // Chain into Runtime.enable (for consoleAPICalled later) then
-        // Page.navigate to the stashed url.
         auto ss = view->m_sessionId.utf8();
         std::span<const char> sidSpan(ss.data(), ss.length());
-
-        // Runtime.enable — fire-and-forget, untracked. We don't need to
-        // wait for its reply before navigating.
-        uint32_t rid = nextId();
-        send(0, Command(rid, "Runtime.enable"_s, sidSpan));
-
-        // Fire-and-forget; Page.lifecycleEvent is what settles waitUntil:'domcontentloaded'.
-        uint32_t lid = nextId();
-        send(0, Command(lid, "Page.setLifecycleEventsEnabled"_s, sidSpan).boolean("enabled"_s, true));
 
         // Page.navigate with the url stashed by the first navigate() call.
         // The response confirms the navigation STARTED; Page.loadEventFired

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -760,19 +760,11 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
     JSWebView* view = viewFor(entry.viewId);
     if (!view) return; // user dropped both view and the awaited promise
 
-    // Navigate-slot entries carry the view's m_navGeneration at
-    // enqueue time. armNavTimeout rejects the navigate (bumping gen)
-    // without pruning m_pending, so a response for the abandoned
-    // navigation can arrive after a .catch() retry refilled
-    // m_pendingNavigate. Mismatch → this response is stale; settling
-    // would resolve/reject the RETRY's promise (or, for the attach
-    // chain, create a second tab whose events route to this view).
-    // Covers PageTitle, PageNavigate errorText, PageGetNavigationHistory
-    // boundary, and TargetCreateTarget→…→PageEnable in one place.
+    // Stale Navigate-slot response: the timeout rejected this navigation
+    // (bumping the generation) without pruning m_pending. Settling here
+    // would hit a retry's promise.
     if (entry.navGen && entry.navGen != view->m_navGeneration) {
-        // TargetCreateTarget already ran in Chrome by the time we
-        // see the response — close the orphaned tab so it doesn't
-        // leak for process lifetime.
+        // The tab was already created; close it so it does not leak.
         if (entry.method == Method::TargetCreateTarget && error.empty()) {
             auto tid = jsonString(jsonField(result, { "targetId", 8 }));
             if (!tid.empty())
@@ -836,15 +828,10 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         uint32_t rid = nextId();
         send(0, Command(rid, "Runtime.enable"_s, sidSpan));
 
-        // Page.setLifecycleEventsEnabled — fire-and-forget. Chrome then
-        // emits Page.lifecycleEvent {frameId, loaderId, name} for commit/
-        // DOMContentLoaded/load/networkIdle. navigate({waitUntil:
-        // 'domcontentloaded'}) settles on that instead of loadEventFired,
-        // so pages that never fire `load` (SSE, long-poll, a hung
-        // subresource) don't hang the await. Enabling replays the current
-        // document's events, but m_frameId/m_loaderId are unset until the
-        // USER url's frameNavigated, so the about:blank replay never
-        // matches.
+        // Page.setLifecycleEventsEnabled, fire-and-forget. Chrome then
+        // emits Page.lifecycleEvent; waitUntil:'domcontentloaded' settles
+        // on it. The enable-time replay of about:blank never matches
+        // m_frameId/m_loaderId, which are unset until the user url commits.
         uint32_t lid = nextId();
         send(0, Command(lid, "Page.setLifecycleEventsEnabled"_s, sidSpan).boolean("enabled"_s, true));
 
@@ -1171,23 +1158,11 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // Chained from lifecycleEvent/loadEventFired: Runtime.evaluate(
-    // "document.title") so view.title is populated when navigate()
-    // resolves — matches WKWebView's NavDone which packs url+title in
-    // one reply. One extra roundtrip (~1ms), but the user-visible
-    // guarantee (`await view.navigate(); view.title` works) is worth
-    // it. PageTitle's response handler is the settle point.
-    //
-    // Sets m_navTitleChained: on a fast page, lifecycleEvent(DCL),
-    // lifecycleEvent(load) and loadEventFired can all arrive before
-    // the first PageTitle response — each would otherwise enqueue a
-    // duplicate PageTitle whose LATER response could settle a
-    // subsequent navigate()'s promise. After the first call, further
-    // triggers for the same document see the flag and drop. Cleared
-    // by beginChromeNavigation() for the next navigation. m_loaderId
-    // is left populated so loadEventFired can still tell THIS
-    // document's event from a stale one (m_loaderId empty = a new
-    // navigation started and hasn't committed yet).
+    // Fetch document.title so view.title is set when navigate() resolves
+    // (parity with WKWebView's NavDone). PageTitle's response handler is
+    // the settle point. m_navTitleChained dedupes the DCL/load/
+    // loadEventFired triggers; a duplicate PageTitle response could
+    // settle a later navigate()'s promise.
     auto chainTitle = [&]() {
         view->m_navTitleChained = true;
         uint32_t tid = nextId();
@@ -1221,31 +1196,20 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // Page.lifecycleEvent — {frameId, loaderId, name, timestamp}. Fires
-    // for commit, DOMContentLoaded, load, networkAlmostIdle, networkIdle
-    // on every frame. We settle the Navigate slot when the main frame's
-    // current loaderId reaches the user's waitUntil milestone. Gating on
-    // loaderId is what makes 'domcontentloaded' safe: Chrome REPLAYS the
-    // prior document's lifecycle on setLifecycleEventsEnabled, and
-    // subframes fire their own — neither has our loaderId.
-    //
-    // waitUntil:'load' is left to Page.loadEventFired below (it fires
-    // once for the main frame only, after lifecycleEvent(name=load)) —
-    // existing behavior preserved and no duplicate title-fetch.
+    // Page.lifecycleEvent settles waitUntil:'domcontentloaded'. The
+    // frameId/loaderId match filters subframe events and the enable-time
+    // replay. waitUntil:'load' stays on Page.loadEventFired below.
     if (method.size() == 19 && memcmp(method.data(), "Page.lifecycleEvent", 19) == 0) {
         if (!view->m_pendingNavigate || view->m_navWaitUntil != NavWaitUntil::DOMContentLoaded)
             return;
         auto name = jsonString(jsonField(params, { "name", 4 }));
-        // `load` also satisfies `domcontentloaded` — it can only fire
-        // after DCL, and on some same-document navigations Chrome skips
-        // DCL and emits load directly. Playwright's LifecycleWatcher
-        // treats it the same way.
+        // `load` also satisfies `domcontentloaded`: some same-document
+        // navigations skip DCL. Playwright treats it the same way.
         if (!(name.size() == 16 && memcmp(name.data(), "DOMContentLoaded", 16) == 0)
             && !(name.size() == 4 && memcmp(name.data(), "load", 4) == 0))
             return;
-        // beginChromeNavigation() cleared m_loaderId; frameNavigated for
-        // THIS navigation repopulates it. Empty → the event is for the
-        // previous document (or the setLifecycleEventsEnabled replay).
+        // Empty m_loaderId = this navigation has not committed; the
+        // event is the prior document's (or the enable-time replay).
         if (view->m_loaderId.isEmpty()) return;
         auto frameId = jsonString(jsonField(params, { "frameId", 7 }));
         auto loaderId = jsonString(jsonField(params, { "loaderId", 8 }));
@@ -1257,20 +1221,10 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // Page.loadEventFired — window `load` fired on the main frame. This
-    // is the settle path for waitUntil:'load' (default).
-    //
-    // Stale detection: beginChromeNavigation() clears m_loaderId; this
-    // document's frameNavigated repopulates it. m_loaderId empty =
-    // a NEW navigation started and hasn't committed yet, so this
-    // loadEventFired is for the PREVIOUS document — don't clear
-    // m_loading (the new nav set it true) and don't chainTitle().
-    //
-    // m_navTitleChained dedupes: a fast page's lifecycleEvent(DCL)
-    // already chained the title fetch; a second PageTitle could
-    // settle a LATER navigate. m_pendingNavigate must also be set so
-    // an idle loadEventFired (uninitiated window.location) doesn't
-    // enqueue a PageTitle that races a later navigate().
+    // Page.loadEventFired — the settle path for waitUntil:'load' (the
+    // default). Empty m_loaderId = a new navigation started and has not
+    // committed, so this event is the prior document's: leave m_loading
+    // set and skip chainTitle().
     if (method.size() == 19 && memcmp(method.data(), "Page.loadEventFired", 19) == 0) {
         if (view->m_loaderId.isEmpty()) return; // stale — prior document
         view->m_loading = false;
@@ -1528,9 +1482,7 @@ static JSPromise* sendChromeOp(JSGlobalObject* g, JSWebView* v,
     }
     v->m_pendingActivityCount.fetch_add(1, std::memory_order_release);
     slot.set(vm, v, promise);
-    // Navigate-slot entries carry m_navGeneration so handleResponse
-    // can drop a response that arrives after this navigation was
-    // abandoned (armNavTimeout rejected it) and replaced by a retry.
+    // navGen lets handleResponse drop a response for a timed-out navigation.
     uint32_t gen = ps == PendingSlot::Navigate ? v->m_navGeneration : 0;
     t.m_pending.add(id, Pending { m, ps, v->m_viewId, gen });
     t.send(id, WTF::move(cmd));

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1153,7 +1153,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // The PageTitle reply settles the navigate with view.title populated; one fetch per document.
+    // One title fetch per committed document, also for page-initiated navigations; the PageTitle reply updates view.title and settles the navigate (a no-op when none is pending).
     auto chainTitle = [&]() {
         view->m_navTitleChained = true;
         uint32_t tid = nextId();
@@ -1173,6 +1173,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         // Page.lifecycleEvent below matches on these.
         view->m_frameId = WTF::String::fromUTF8(jsonString(jsonField(frame, { "id", 2 })));
         view->m_loaderId = WTF::String::fromUTF8(jsonString(jsonField(frame, { "loaderId", 8 })));
+        view->m_navTitleChained = false; // new document: allow one title fetch for it
         // m_loading stays true — loadEventFired flips it.
 
         if (JSObject* cb = view->m_onNavigated.get()) {
@@ -1206,7 +1207,8 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     if (method.size() == 19 && memcmp(method.data(), "Page.loadEventFired", 19) == 0) {
         if (view->m_loaderId.isEmpty()) return; // the previous document's load; a new navigation is in flight
         view->m_loading = false;
-        if (view->m_pendingNavigate && !view->m_navTitleChained) chainTitle();
+        // Also with no pending navigate (a page-initiated navigation): the fetch keeps view.title fresh, and a later navigate()'s generation bump drops the reply if it races.
+        if (!view->m_navTitleChained) chainTitle();
         return;
     }
 

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -347,16 +347,11 @@ enum class PendingSlot : uint8_t {
 // (one Weak per view) instead of holding its own Weak — a burst of
 // operations creates N ids but only one weak slot allocation. Response
 // handlers do m_views.find(entry.viewId)->value.get() to reach the view.
-//
-// navGen: the view's m_navGeneration at enqueue (0 = ungated). A timeout
-// leaves its entries in m_pending; handleResponse drops the late response
-// on a mismatch instead of settling a retry's promise. Chained responses
-// carry it forward.
 struct Pending {
     Method method;
     PendingSlot slot;
     uint32_t viewId;
-    uint32_t navGen = 0;
+    uint32_t navGen = 0; // JSWebView::m_navGeneration when sent; 0 for slots other than Navigate
 };
 
 // Transport mode. Pipe = we spawned Chrome with --remote-debugging-pipe,

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -347,10 +347,19 @@ enum class PendingSlot : uint8_t {
 // (one Weak per view) instead of holding its own Weak — a burst of
 // operations creates N ids but only one weak slot allocation. Response
 // handlers do m_views.find(entry.viewId)->value.get() to reach the view.
+//
+// navGen is the view's m_navGeneration at enqueue time for Navigate-
+// slot entries (0 = ungated, all other slots). armNavTimeout rejects
+// the navigate without pruning m_pending, so a stale response for the
+// timed-out navigation can arrive after a .catch() retry refilled
+// m_pendingNavigate — handleResponse drops it on gen mismatch instead
+// of settling the retry's promise (or, for the attach chain, creating
+// a second tab). Chained responses carry entry.navGen forward.
 struct Pending {
     Method method;
     PendingSlot slot;
     uint32_t viewId;
+    uint32_t navGen = 0;
 };
 
 // Transport mode. Pipe = we spawned Chrome with --remote-debugging-pipe,

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -348,13 +348,10 @@ enum class PendingSlot : uint8_t {
 // operations creates N ids but only one weak slot allocation. Response
 // handlers do m_views.find(entry.viewId)->value.get() to reach the view.
 //
-// navGen is the view's m_navGeneration at enqueue time for Navigate-
-// slot entries (0 = ungated, all other slots). armNavTimeout rejects
-// the navigate without pruning m_pending, so a stale response for the
-// timed-out navigation can arrive after a .catch() retry refilled
-// m_pendingNavigate — handleResponse drops it on gen mismatch instead
-// of settling the retry's promise (or, for the attach chain, creating
-// a second tab). Chained responses carry entry.navGen forward.
+// navGen: the view's m_navGeneration at enqueue (0 = ungated). A timeout
+// leaves its entries in m_pending; handleResponse drops the late response
+// on a mismatch instead of settling a retry's promise. Chained responses
+// carry it forward.
 struct Pending {
     Method method;
     PendingSlot slot;

--- a/src/runtime/webview/JSWebView.cpp
+++ b/src/runtime/webview/JSWebView.cpp
@@ -20,6 +20,8 @@
 #include <JavaScriptCore/WeakInlines.h>
 #include <JavaScriptCore/WeakHandleOwner.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/RunLoop.h>
+#include <wtf/text/MakeString.h>
 
 namespace Bun {
 
@@ -53,13 +55,25 @@ WeakHandleOwner& webViewWeakOwner()
     return owner.get();
 }
 
+// Takes the promise out of a slot. Navigate settled → invalidate the armed
+// timeout. The dispatchAfter timer self-owns; bumping the generation is how
+// we "cancel" — when it eventually fires it sees the mismatch and returns.
+// Identity check because callers pass the barrier member directly.
+static JSPromise* takeSlot(JSWebView* v, WriteBarrier<JSPromise>& slot)
+{
+    JSPromise* p = slot.get();
+    if (!p) return nullptr;
+    slot.clear();
+    if (&slot == &v->m_pendingNavigate) ++v->m_navGeneration;
+    v->m_pendingActivityCount.fetch_sub(1, std::memory_order_release);
+    return p;
+}
+
 void settleSlot(JSGlobalObject* g, JSWebView* v,
     WriteBarrier<JSPromise>& slot, bool ok, JSValue value)
 {
-    JSPromise* p = slot.get();
+    JSPromise* p = takeSlot(v, slot);
     if (!p) return;
-    slot.clear();
-    v->m_pendingActivityCount.fetch_sub(1, std::memory_order_release);
     if (ok)
         p->resolve(g, g->vm(), value);
     else
@@ -69,10 +83,8 @@ void settleSlot(JSGlobalObject* g, JSWebView* v,
 void rejectSlotAsHandled(JSGlobalObject* g, JSWebView* v,
     WriteBarrier<JSPromise>& slot, JSValue err)
 {
-    JSPromise* p = slot.get();
+    JSPromise* p = takeSlot(v, slot);
     if (!p) return;
-    slot.clear();
-    v->m_pendingActivityCount.fetch_sub(1, std::memory_order_release);
     p->rejectAsHandled(g->vm(), err);
 }
 
@@ -193,14 +205,88 @@ const ClassInfo JSWebView::s_info = { "WebView"_s, &Base::s_info, nullptr, nullp
 #define WK_DISPATCH(call) return call
 #endif
 
-JSPromise* JSWebView::navigate(JSGlobalObject* g, const WTF::String& url)
+// Resolve a viewId back to its JSWebView through the backend's routing
+// table. The timeout timer fires on the event loop with only POD captures;
+// this re-establishes the view pointer. Null if the view was collected
+// (user dropped both view and its awaited promise) or closed.
+static JSWebView* viewByIdForBackend(WebViewBackend backend, uint32_t viewId)
+{
+    if (backend == WebViewBackend::Chrome) return CDP::transport().viewFor(viewId);
+#if OS(DARWIN)
+    auto& byId = WK::client().viewsById;
+    auto it = byId.find(viewId);
+    return it == byId.end() ? nullptr : it->second.get();
+#else
+    return nullptr;
+#endif
+}
+
+void JSWebView::armNavTimeout(JSGlobalObject* g, uint32_t timeoutMs)
+{
+    // Arm AFTER the backend op stored the promise. A sync-rejected op
+    // (transport dead, spawn failed) never sets the slot → nothing to
+    // time out. Also skip if the caller asked for no timeout.
+    if (!m_pendingNavigate || timeoutMs == 0) return;
+
+    uint32_t gen = m_navGeneration;
+    uint32_t vid = m_viewId;
+    auto backend = m_backend;
+    auto* global = defaultGlobalObject(g);
+    // dispatchAfter self-refs: the returned DispatchTimer owns a closure
+    // that holds a Ref back to itself, released when fired(). We don't
+    // cancel — settleSlot bumps m_navGeneration so a late fire no-ops.
+    // WTFTimer (the Bun-side backing) doesn't ref the event loop; the
+    // navigate promise already does via m_pendingActivityCount.
+    (void)WTF::RunLoop::currentSingleton().dispatchAfter(
+        WTF::Seconds::fromMilliseconds(timeoutMs),
+        [global, vid, gen, backend, timeoutMs]() {
+            JSWebView* v = viewByIdForBackend(backend, vid);
+            if (!v || v->m_navGeneration != gen || !v->m_pendingNavigate) return;
+            // m_loading left untouched — it tracks the REAL load state
+            // (flipped by Page.loadEventFired / NavDone). A timeout is
+            // the user giving up on the wait, not the browser
+            // finishing the load.
+            settleSlot(global, v, v->m_pendingNavigate, false,
+                createError(global, makeString("Navigation timeout of "_s, timeoutMs, "ms exceeded"_s)));
+        });
+}
+
+// Per-navigation Chrome setup. Clearing m_loaderId is the stale-event
+// gate: a previous navigation's trailing lifecycleEvent(load) /
+// loadEventFired can arrive AFTER this one starts (waitUntil:
+// 'domcontentloaded' settles before `load`). With m_loaderId cleared,
+// the lifecycleEvent loaderId check fails and loadEventFired's
+// m_loaderId.isEmpty() guard skips chainTitle() until frameNavigated
+// for THIS navigation repopulates it.
+static inline void beginChromeNavigation(JSWebView* v, NavWaitUntil waitUntil)
+{
+    v->m_navWaitUntil = waitUntil;
+    ++v->m_navGeneration;
+    v->m_loaderId = WTF::String();
+    v->m_navTitleChained = false;
+}
+
+JSPromise* JSWebView::navigate(JSGlobalObject* g, const WTF::String& url, NavWaitUntil waitUntil, uint32_t timeoutMs)
 {
     if (m_backend == WebViewBackend::Chrome) {
+        beginChromeNavigation(this, waitUntil);
         auto* p = CDP::Ops::navigate(g, this, url);
         if (m_pendingNavigate) m_loading = true;
+        armNavTimeout(g, timeoutMs);
         return p;
     }
-    WK_DISPATCH(WK::Ops::navigate(g, this, url));
+#if OS(DARWIN)
+    // WebKit navigate() uses the Navigate slot too — waitUntil is moot
+    // (didFinishNavigation only), but the generation + timeout apply.
+    m_navWaitUntil = waitUntil;
+    ++m_navGeneration;
+    auto* p = WK::Ops::navigate(g, this, url);
+    armNavTimeout(g, timeoutMs);
+    return p;
+#else
+    RELEASE_ASSERT_NOT_REACHED();
+    return nullptr;
+#endif
 }
 
 JSPromise* JSWebView::evaluate(JSGlobalObject* g, const WTF::String& script)
@@ -271,21 +357,50 @@ JSPromise* JSWebView::resize(JSGlobalObject* g, uint32_t width, uint32_t height)
     WK_DISPATCH(WK::Ops::resize(g, this, width, height));
 }
 
-JSPromise* JSWebView::goBack(JSGlobalObject* g)
+// Chrome's goBack/goForward/reload all settle via Page.lifecycleEvent /
+// loadEventFired on the Navigate slot → same waitUntil + timeout handling
+// as navigate(). WebKit's Op::GoBack/GoForward/Reload Ack immediately on
+// the MISC slot (see navSlot in JSWebViewPrototype.cpp), so they can run
+// CONCURRENTLY with a pending navigate() on the Navigate slot — touching
+// m_navWaitUntil / m_navGeneration / m_loaderId here would clobber that
+// navigate's timeout and lifecycle gate. WK_DISPATCH returns the bare
+// promise; the WebKit branch leaves Navigate-slot state alone.
+JSPromise* JSWebView::goBack(JSGlobalObject* g, NavWaitUntil waitUntil, uint32_t timeoutMs)
 {
-    if (m_backend == WebViewBackend::Chrome) return CDP::Ops::goBack(g, this);
+    if (m_backend == WebViewBackend::Chrome) {
+        beginChromeNavigation(this, waitUntil);
+        auto* p = CDP::Ops::goBack(g, this);
+        armNavTimeout(g, timeoutMs);
+        return p;
+    }
     WK_DISPATCH(WK::Ops::goBack(g, this));
 }
 
-JSPromise* JSWebView::goForward(JSGlobalObject* g)
+JSPromise* JSWebView::goForward(JSGlobalObject* g, NavWaitUntil waitUntil, uint32_t timeoutMs)
 {
-    if (m_backend == WebViewBackend::Chrome) return CDP::Ops::goForward(g, this);
+    if (m_backend == WebViewBackend::Chrome) {
+        beginChromeNavigation(this, waitUntil);
+        auto* p = CDP::Ops::goForward(g, this);
+        armNavTimeout(g, timeoutMs);
+        return p;
+    }
     WK_DISPATCH(WK::Ops::goForward(g, this));
 }
 
-JSPromise* JSWebView::reload(JSGlobalObject* g)
+JSPromise* JSWebView::reload(JSGlobalObject* g, NavWaitUntil waitUntil, uint32_t timeoutMs)
 {
-    if (m_backend == WebViewBackend::Chrome) return CDP::Ops::reload(g, this);
+    if (m_backend == WebViewBackend::Chrome) {
+        beginChromeNavigation(this, waitUntil);
+        auto* p = CDP::Ops::reload(g, this);
+        // reload() always commits a navigation (no boundary no-op
+        // like goBack/goForward), so m_loading should reflect that.
+        // goBack/goForward don't set it here because the
+        // PageGetNavigationHistory response might resolve undefined
+        // (at boundary) without ever navigating.
+        if (m_pendingNavigate) m_loading = true;
+        armNavTimeout(g, timeoutMs);
+        return p;
+    }
     WK_DISPATCH(WK::Ops::reload(g, this));
 }
 

--- a/src/runtime/webview/JSWebView.cpp
+++ b/src/runtime/webview/JSWebView.cpp
@@ -55,14 +55,12 @@ WeakHandleOwner& webViewWeakOwner()
     return owner.get();
 }
 
-// A Navigate settle bumps m_navGeneration. That is the timeout cancel:
-// a late timer fire sees the mismatch and no-ops.
 static JSPromise* takeSlot(JSWebView* v, WriteBarrier<JSPromise>& slot)
 {
     JSPromise* p = slot.get();
     if (!p) return nullptr;
     slot.clear();
-    if (&slot == &v->m_pendingNavigate) ++v->m_navGeneration;
+    if (&slot == &v->m_pendingNavigate) ++v->m_navGeneration; // disarms the timer from armNavTimeout
     v->m_pendingActivityCount.fetch_sub(1, std::memory_order_release);
     return p;
 }
@@ -203,8 +201,7 @@ const ClassInfo JSWebView::s_info = { "WebView"_s, &Base::s_info, nullptr, nullp
 #define WK_DISPATCH(call) return call
 #endif
 
-// viewId → JSWebView via the backend routing table. The timeout timer
-// captures PODs only; null if the view was collected or closed.
+// Null once the view is closed or collected.
 static JSWebView* viewByIdForBackend(WebViewBackend backend, uint32_t viewId)
 {
     if (backend == WebViewBackend::Chrome) return CDP::transport().viewFor(viewId);
@@ -219,31 +216,25 @@ static JSWebView* viewByIdForBackend(WebViewBackend backend, uint32_t viewId)
 
 void JSWebView::armNavTimeout(JSGlobalObject* g, uint32_t timeoutMs)
 {
-    // A sync-rejected op never set the slot, so there is nothing to time out.
-    if (!m_pendingNavigate || timeoutMs == 0) return;
+    if (!m_pendingNavigate || timeoutMs == 0) return; // a synchronously rejected op leaves the slot empty
 
     uint32_t gen = m_navGeneration;
     uint32_t vid = m_viewId;
     auto backend = m_backend;
     auto* global = defaultGlobalObject(g);
-    // The DispatchTimer self-owns; there is no cancel handle. settleSlot
-    // bumps m_navGeneration so a late fire no-ops. The navigate promise,
-    // not the timer, keeps the event loop alive (m_pendingActivityCount).
+    // The timer owns itself. There is no cancel: takeSlot bumps m_navGeneration and a late fire no-ops.
     (void)WTF::RunLoop::currentSingleton().dispatchAfter(
         WTF::Seconds::fromMilliseconds(timeoutMs),
         [global, vid, gen, backend, timeoutMs]() {
             JSWebView* v = viewByIdForBackend(backend, vid);
             if (!v || v->m_navGeneration != gen || !v->m_pendingNavigate) return;
-            // m_loading stays true: the timeout abandons the wait, it
-            // does not finish the load.
+            // m_loading stays as is: the page is still loading, the caller stopped waiting.
             settleSlot(global, v, v->m_pendingNavigate, false,
                 createError(global, makeString("Navigation timeout of "_s, timeoutMs, "ms exceeded"_s)));
         });
 }
 
-// Per-navigation Chrome setup. Clearing m_loaderId marks the prior
-// document's trailing lifecycle/loadEventFired events as stale until
-// frameNavigated for this navigation repopulates it.
+// An empty m_loaderId marks the previous document's trailing lifecycle events as stale until Page.frameNavigated commits this one.
 static inline void beginChromeNavigation(JSWebView* v, NavWaitUntil waitUntil)
 {
     v->m_navWaitUntil = waitUntil;
@@ -262,7 +253,7 @@ JSPromise* JSWebView::navigate(JSGlobalObject* g, const WTF::String& url, NavWai
         return p;
     }
 #if OS(DARWIN)
-    // WebKit exposes no DCL signal; only the generation and timeout apply.
+    // WKNavigationDelegate has no DOMContentLoaded hook; waitUntil is accepted and behaves like Load.
     m_navWaitUntil = waitUntil;
     ++m_navGeneration;
     auto* p = WK::Ops::navigate(g, this, url);
@@ -342,9 +333,7 @@ JSPromise* JSWebView::resize(JSGlobalObject* g, uint32_t width, uint32_t height)
     WK_DISPATCH(WK::Ops::resize(g, this, width, height));
 }
 
-// WebKit's GoBack/GoForward/Reload ack on the Misc slot and can run while
-// a navigate() is pending, so the WebKit branches must not touch the
-// Navigate-slot state (m_navWaitUntil, m_navGeneration, m_loaderId).
+// WebKit's GoBack/GoForward/Reload use the Misc slot and can overlap a pending navigate(), so they must not touch the Navigate-slot state.
 JSPromise* JSWebView::goBack(JSGlobalObject* g, NavWaitUntil waitUntil, uint32_t timeoutMs)
 {
     if (m_backend == WebViewBackend::Chrome) {
@@ -372,9 +361,7 @@ JSPromise* JSWebView::reload(JSGlobalObject* g, NavWaitUntil waitUntil, uint32_t
     if (m_backend == WebViewBackend::Chrome) {
         beginChromeNavigation(this, waitUntil);
         auto* p = CDP::Ops::reload(g, this);
-        // goBack/goForward skip this: at a history boundary they
-        // resolve undefined without navigating.
-        if (m_pendingNavigate) m_loading = true;
+        if (m_pendingNavigate) m_loading = true; // unlike goBack/goForward, reload always navigates
         armNavTimeout(g, timeoutMs);
         return p;
     }

--- a/src/runtime/webview/JSWebView.cpp
+++ b/src/runtime/webview/JSWebView.cpp
@@ -55,10 +55,8 @@ WeakHandleOwner& webViewWeakOwner()
     return owner.get();
 }
 
-// Takes the promise out of a slot. Navigate settled → invalidate the armed
-// timeout. The dispatchAfter timer self-owns; bumping the generation is how
-// we "cancel" — when it eventually fires it sees the mismatch and returns.
-// Identity check because callers pass the barrier member directly.
+// A Navigate settle bumps m_navGeneration. That is the timeout cancel:
+// a late timer fire sees the mismatch and no-ops.
 static JSPromise* takeSlot(JSWebView* v, WriteBarrier<JSPromise>& slot)
 {
     JSPromise* p = slot.get();
@@ -205,10 +203,8 @@ const ClassInfo JSWebView::s_info = { "WebView"_s, &Base::s_info, nullptr, nullp
 #define WK_DISPATCH(call) return call
 #endif
 
-// Resolve a viewId back to its JSWebView through the backend's routing
-// table. The timeout timer fires on the event loop with only POD captures;
-// this re-establishes the view pointer. Null if the view was collected
-// (user dropped both view and its awaited promise) or closed.
+// viewId → JSWebView via the backend routing table. The timeout timer
+// captures PODs only; null if the view was collected or closed.
 static JSWebView* viewByIdForBackend(WebViewBackend backend, uint32_t viewId)
 {
     if (backend == WebViewBackend::Chrome) return CDP::transport().viewFor(viewId);
@@ -223,41 +219,31 @@ static JSWebView* viewByIdForBackend(WebViewBackend backend, uint32_t viewId)
 
 void JSWebView::armNavTimeout(JSGlobalObject* g, uint32_t timeoutMs)
 {
-    // Arm AFTER the backend op stored the promise. A sync-rejected op
-    // (transport dead, spawn failed) never sets the slot → nothing to
-    // time out. Also skip if the caller asked for no timeout.
+    // A sync-rejected op never set the slot, so there is nothing to time out.
     if (!m_pendingNavigate || timeoutMs == 0) return;
 
     uint32_t gen = m_navGeneration;
     uint32_t vid = m_viewId;
     auto backend = m_backend;
     auto* global = defaultGlobalObject(g);
-    // dispatchAfter self-refs: the returned DispatchTimer owns a closure
-    // that holds a Ref back to itself, released when fired(). We don't
-    // cancel — settleSlot bumps m_navGeneration so a late fire no-ops.
-    // WTFTimer (the Bun-side backing) doesn't ref the event loop; the
-    // navigate promise already does via m_pendingActivityCount.
+    // The DispatchTimer self-owns; there is no cancel handle. settleSlot
+    // bumps m_navGeneration so a late fire no-ops. The navigate promise,
+    // not the timer, keeps the event loop alive (m_pendingActivityCount).
     (void)WTF::RunLoop::currentSingleton().dispatchAfter(
         WTF::Seconds::fromMilliseconds(timeoutMs),
         [global, vid, gen, backend, timeoutMs]() {
             JSWebView* v = viewByIdForBackend(backend, vid);
             if (!v || v->m_navGeneration != gen || !v->m_pendingNavigate) return;
-            // m_loading left untouched — it tracks the REAL load state
-            // (flipped by Page.loadEventFired / NavDone). A timeout is
-            // the user giving up on the wait, not the browser
-            // finishing the load.
+            // m_loading stays true: the timeout abandons the wait, it
+            // does not finish the load.
             settleSlot(global, v, v->m_pendingNavigate, false,
                 createError(global, makeString("Navigation timeout of "_s, timeoutMs, "ms exceeded"_s)));
         });
 }
 
-// Per-navigation Chrome setup. Clearing m_loaderId is the stale-event
-// gate: a previous navigation's trailing lifecycleEvent(load) /
-// loadEventFired can arrive AFTER this one starts (waitUntil:
-// 'domcontentloaded' settles before `load`). With m_loaderId cleared,
-// the lifecycleEvent loaderId check fails and loadEventFired's
-// m_loaderId.isEmpty() guard skips chainTitle() until frameNavigated
-// for THIS navigation repopulates it.
+// Per-navigation Chrome setup. Clearing m_loaderId marks the prior
+// document's trailing lifecycle/loadEventFired events as stale until
+// frameNavigated for this navigation repopulates it.
 static inline void beginChromeNavigation(JSWebView* v, NavWaitUntil waitUntil)
 {
     v->m_navWaitUntil = waitUntil;
@@ -276,8 +262,7 @@ JSPromise* JSWebView::navigate(JSGlobalObject* g, const WTF::String& url, NavWai
         return p;
     }
 #if OS(DARWIN)
-    // WebKit navigate() uses the Navigate slot too — waitUntil is moot
-    // (didFinishNavigation only), but the generation + timeout apply.
+    // WebKit exposes no DCL signal; only the generation and timeout apply.
     m_navWaitUntil = waitUntil;
     ++m_navGeneration;
     auto* p = WK::Ops::navigate(g, this, url);
@@ -357,14 +342,9 @@ JSPromise* JSWebView::resize(JSGlobalObject* g, uint32_t width, uint32_t height)
     WK_DISPATCH(WK::Ops::resize(g, this, width, height));
 }
 
-// Chrome's goBack/goForward/reload all settle via Page.lifecycleEvent /
-// loadEventFired on the Navigate slot → same waitUntil + timeout handling
-// as navigate(). WebKit's Op::GoBack/GoForward/Reload Ack immediately on
-// the MISC slot (see navSlot in JSWebViewPrototype.cpp), so they can run
-// CONCURRENTLY with a pending navigate() on the Navigate slot — touching
-// m_navWaitUntil / m_navGeneration / m_loaderId here would clobber that
-// navigate's timeout and lifecycle gate. WK_DISPATCH returns the bare
-// promise; the WebKit branch leaves Navigate-slot state alone.
+// WebKit's GoBack/GoForward/Reload ack on the Misc slot and can run while
+// a navigate() is pending, so the WebKit branches must not touch the
+// Navigate-slot state (m_navWaitUntil, m_navGeneration, m_loaderId).
 JSPromise* JSWebView::goBack(JSGlobalObject* g, NavWaitUntil waitUntil, uint32_t timeoutMs)
 {
     if (m_backend == WebViewBackend::Chrome) {
@@ -392,11 +372,8 @@ JSPromise* JSWebView::reload(JSGlobalObject* g, NavWaitUntil waitUntil, uint32_t
     if (m_backend == WebViewBackend::Chrome) {
         beginChromeNavigation(this, waitUntil);
         auto* p = CDP::Ops::reload(g, this);
-        // reload() always commits a navigation (no boundary no-op
-        // like goBack/goForward), so m_loading should reflect that.
-        // goBack/goForward don't set it here because the
-        // PageGetNavigationHistory response might resolve undefined
-        // (at boundary) without ever navigating.
+        // goBack/goForward skip this: at a history boundary they
+        // resolve undefined without navigating.
         if (m_pendingNavigate) m_loading = true;
         armNavTimeout(g, timeoutMs);
         return p;

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -20,6 +20,18 @@ enum class WebViewBackend : uint8_t {
     Chrome, // Chrome DevTools Protocol via --remote-debugging-pipe
 };
 
+// navigate()/reload()/goBack()/goForward() `waitUntil` option. Chrome
+// settles on the matching Page.lifecycleEvent; WebKit only exposes
+// didFinishNavigation (= load), so DOMContentLoaded degrades to Load
+// there. Values are also the wire enum for a future IPC NavigatePayload.
+enum class NavWaitUntil : uint8_t {
+    Load = 0, // window `load` fired — all subresources done. Default.
+    DOMContentLoaded = 1, // document parsed; subresources may still be
+                          // loading. Lets navigate() settle when the page
+                          // holds a never-ending connection (SSE/long-poll)
+                          // that would otherwise block `load` forever.
+};
+
 enum class ScreenshotFormat : uint8_t {
     Png, // lossless, default.
     Jpeg, // lossy, quality 0-100.
@@ -98,6 +110,21 @@ public:
     WTF::String m_sessionId;
     WTF::String m_targetId;
     WTF::String m_pendingChromeNavigateUrl;
+    // Main-frame id + the CURRENT navigation's loaderId. frameNavigated
+    // updates both (parentId absent = main frame); Page.lifecycleEvent
+    // only settles when its frameId/loaderId match — subframe events and
+    // the about:blank replay from setLifecycleEventsEnabled don't match.
+    // m_loaderId is cleared by beginChromeNavigation() (so a PRIOR
+    // document's trailing lifecycle/loadEventFired can be identified as
+    // stale) and repopulated by the next frameNavigated.
+    WTF::String m_frameId;
+    WTF::String m_loaderId;
+    // Set once chainTitle() has enqueued the PageTitle fetch for THIS
+    // navigation. Further lifecycle/loadEventFired triggers for the
+    // same document drop instead of enqueuing duplicate PageTitle
+    // requests (whose responses could settle a LATER navigate). Cleared
+    // by beginChromeNavigation().
+    bool m_navTitleChained = false;
     // clickSelector stash — the actionability eval chains into a
     // dispatchMouseEvent that needs these. WebViewHost has the same fields
     // on its side (m_selButton etc.) for the same chain.
@@ -114,6 +141,13 @@ public:
     // encoding → how the bytes are wrapped (Blob/Buffer/base64/shmem).
     ScreenshotFormat m_screenshotFormat = ScreenshotFormat::Png;
     ScreenshotEncoding m_screenshotEncoding = ScreenshotEncoding::Blob;
+    // navigate()/reload()/goBack()/goForward() stash — read by the
+    // Chrome Page.lifecycleEvent handler to pick which event settles.
+    // Generation bumps on every navigation start; the parent-side
+    // timeout timer captures it and no-ops if a later navigation (or the
+    // settle path) bumped it first. No explicit timer cancel.
+    NavWaitUntil m_navWaitUntil = NavWaitUntil::Load;
+    uint32_t m_navGeneration = 0;
 
     JSC::WriteBarrier<JSC::JSObject> m_onNavigated;
     JSC::WriteBarrier<JSC::JSObject> m_onNavigationFailed;
@@ -157,7 +191,7 @@ public:
     // before reaching here) and m_closed is false. WebKit paths are
     // Darwin-only; calling one on the WebKit backend off-Darwin is a bug
     // (constructor already threw).
-    JSC::JSPromise* navigate(JSC::JSGlobalObject*, const WTF::String& url);
+    JSC::JSPromise* navigate(JSC::JSGlobalObject*, const WTF::String& url, NavWaitUntil, uint32_t timeoutMs);
     JSC::JSPromise* evaluate(JSC::JSGlobalObject*, const WTF::String& script);
     JSC::JSPromise* screenshot(JSC::JSGlobalObject*, ScreenshotFormat, uint8_t quality);
     // Chrome-only. Raw CDP escape hatch — method is "Domain.method",
@@ -171,10 +205,18 @@ public:
     JSC::JSPromise* scroll(JSC::JSGlobalObject*, double dx, double dy);
     JSC::JSPromise* scrollTo(JSC::JSGlobalObject*, const WTF::String& selector, uint32_t timeout, uint8_t block);
     JSC::JSPromise* resize(JSC::JSGlobalObject*, uint32_t width, uint32_t height);
-    JSC::JSPromise* goBack(JSC::JSGlobalObject*);
-    JSC::JSPromise* goForward(JSC::JSGlobalObject*);
-    JSC::JSPromise* reload(JSC::JSGlobalObject*);
+    JSC::JSPromise* goBack(JSC::JSGlobalObject*, NavWaitUntil, uint32_t timeoutMs);
+    JSC::JSPromise* goForward(JSC::JSGlobalObject*, NavWaitUntil, uint32_t timeoutMs);
+    JSC::JSPromise* reload(JSC::JSGlobalObject*, NavWaitUntil, uint32_t timeoutMs);
     void doClose();
+
+    // Arm the parent-side navigation timeout. dispatchAfter self-manages
+    // lifetime; the closure captures {viewId, backend, generation} and
+    // no-ops if the view was collected or m_navGeneration moved on.
+    // 0 = no timeout (Playwright convention). Must be called AFTER the
+    // backend op stored a promise in m_pendingNavigate — a sync-rejected
+    // op (transport dead) leaves the slot empty and we skip the timer.
+    void armNavTimeout(JSC::JSGlobalObject*, uint32_t timeoutMs);
 
 #if OS(DARWIN)
     // WebKit constructor: spawn host if needed, allocate viewId, register

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -20,16 +20,13 @@ enum class WebViewBackend : uint8_t {
     Chrome, // Chrome DevTools Protocol via --remote-debugging-pipe
 };
 
-// navigate()/reload()/goBack()/goForward() `waitUntil` option. Chrome
-// settles on the matching Page.lifecycleEvent; WebKit only exposes
-// didFinishNavigation (= load), so DOMContentLoaded degrades to Load
-// there. Values are also the wire enum for a future IPC NavigatePayload.
+// navigate()/reload()/goBack()/goForward() `waitUntil` option. WebKit only
+// exposes didFinishNavigation (= load), so DOMContentLoaded degrades to
+// Load there.
 enum class NavWaitUntil : uint8_t {
-    Load = 0, // window `load` fired — all subresources done. Default.
-    DOMContentLoaded = 1, // document parsed; subresources may still be
-                          // loading. Lets navigate() settle when the page
-                          // holds a never-ending connection (SSE/long-poll)
-                          // that would otherwise block `load` forever.
+    Load = 0, // window `load` fired. Default.
+    DOMContentLoaded = 1, // document parsed; settles even when a
+                          // subresource never finishes (SSE, long-poll).
 };
 
 enum class ScreenshotFormat : uint8_t {
@@ -110,20 +107,13 @@ public:
     WTF::String m_sessionId;
     WTF::String m_targetId;
     WTF::String m_pendingChromeNavigateUrl;
-    // Main-frame id + the CURRENT navigation's loaderId. frameNavigated
-    // updates both (parentId absent = main frame); Page.lifecycleEvent
-    // only settles when its frameId/loaderId match — subframe events and
-    // the about:blank replay from setLifecycleEventsEnabled don't match.
-    // m_loaderId is cleared by beginChromeNavigation() (so a PRIOR
-    // document's trailing lifecycle/loadEventFired can be identified as
-    // stale) and repopulated by the next frameNavigated.
+    // Committed main-frame id + current navigation's loaderId, set by
+    // frameNavigated. Page.lifecycleEvent settles only on a match. Empty
+    // m_loaderId = not committed yet; prior-document events are stale.
     WTF::String m_frameId;
     WTF::String m_loaderId;
-    // Set once chainTitle() has enqueued the PageTitle fetch for THIS
-    // navigation. Further lifecycle/loadEventFired triggers for the
-    // same document drop instead of enqueuing duplicate PageTitle
-    // requests (whose responses could settle a LATER navigate). Cleared
-    // by beginChromeNavigation().
+    // True once this navigation's PageTitle fetch is enqueued; dedupes the
+    // DCL/load/loadEventFired triggers. Reset by beginChromeNavigation().
     bool m_navTitleChained = false;
     // clickSelector stash — the actionability eval chains into a
     // dispatchMouseEvent that needs these. WebViewHost has the same fields
@@ -141,11 +131,9 @@ public:
     // encoding → how the bytes are wrapped (Blob/Buffer/base64/shmem).
     ScreenshotFormat m_screenshotFormat = ScreenshotFormat::Png;
     ScreenshotEncoding m_screenshotEncoding = ScreenshotEncoding::Blob;
-    // navigate()/reload()/goBack()/goForward() stash — read by the
-    // Chrome Page.lifecycleEvent handler to pick which event settles.
-    // Generation bumps on every navigation start; the parent-side
-    // timeout timer captures it and no-ops if a later navigation (or the
-    // settle path) bumped it first. No explicit timer cancel.
+    // waitUntil stash for the Chrome lifecycle handler. The generation
+    // bumps on every navigation start and settle; a stale timeout timer
+    // sees the mismatch and no-ops.
     NavWaitUntil m_navWaitUntil = NavWaitUntil::Load;
     uint32_t m_navGeneration = 0;
 
@@ -210,12 +198,9 @@ public:
     JSC::JSPromise* reload(JSC::JSGlobalObject*, NavWaitUntil, uint32_t timeoutMs);
     void doClose();
 
-    // Arm the parent-side navigation timeout. dispatchAfter self-manages
-    // lifetime; the closure captures {viewId, backend, generation} and
-    // no-ops if the view was collected or m_navGeneration moved on.
-    // 0 = no timeout (Playwright convention). Must be called AFTER the
-    // backend op stored a promise in m_pendingNavigate — a sync-rejected
-    // op (transport dead) leaves the slot empty and we skip the timer.
+    // Arm the parent-side navigation timeout (0 = none). Call it after the
+    // backend op stored the promise; an empty slot skips the timer. The
+    // timer captures PODs only and no-ops on a generation mismatch.
     void armNavTimeout(JSC::JSGlobalObject*, uint32_t timeoutMs);
 
 #if OS(DARWIN)

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -20,13 +20,10 @@ enum class WebViewBackend : uint8_t {
     Chrome, // Chrome DevTools Protocol via --remote-debugging-pipe
 };
 
-// navigate()/reload()/goBack()/goForward() `waitUntil` option. WebKit only
-// exposes didFinishNavigation (= load), so DOMContentLoaded degrades to
-// Load there.
+// The `waitUntil` option of navigate()/reload()/goBack()/goForward(). WebKit has no DCL hook and treats both as Load.
 enum class NavWaitUntil : uint8_t {
-    Load = 0, // window `load` fired. Default.
-    DOMContentLoaded = 1, // document parsed; settles even when a
-                          // subresource never finishes (SSE, long-poll).
+    Load = 0,
+    DOMContentLoaded = 1,
 };
 
 enum class ScreenshotFormat : uint8_t {
@@ -107,14 +104,10 @@ public:
     WTF::String m_sessionId;
     WTF::String m_targetId;
     WTF::String m_pendingChromeNavigateUrl;
-    // Committed main-frame id + current navigation's loaderId, set by
-    // frameNavigated. Page.lifecycleEvent settles only on a match. Empty
-    // m_loaderId = not committed yet; prior-document events are stale.
+    // Main frame id and the current navigation's loaderId from Page.frameNavigated; Page.lifecycleEvent must match both.
     WTF::String m_frameId;
-    WTF::String m_loaderId;
-    // True once this navigation's PageTitle fetch is enqueued; dedupes the
-    // DCL/load/loadEventFired triggers. Reset by beginChromeNavigation().
-    bool m_navTitleChained = false;
+    WTF::String m_loaderId; // empty between a navigation's start and its commit
+    bool m_navTitleChained = false; // the document.title fetch that settles this navigation was sent
     // clickSelector stash — the actionability eval chains into a
     // dispatchMouseEvent that needs these. WebViewHost has the same fields
     // on its side (m_selButton etc.) for the same chain.
@@ -131,10 +124,8 @@ public:
     // encoding → how the bytes are wrapped (Blob/Buffer/base64/shmem).
     ScreenshotFormat m_screenshotFormat = ScreenshotFormat::Png;
     ScreenshotEncoding m_screenshotEncoding = ScreenshotEncoding::Blob;
-    // waitUntil stash for the Chrome lifecycle handler. The generation
-    // bumps on every navigation start and settle; a stale timeout timer
-    // sees the mismatch and no-ops.
     NavWaitUntil m_navWaitUntil = NavWaitUntil::Load;
+    // Bumped when a navigation starts and when the Navigate slot settles. The timeout timer and Navigate-slot CDP replies carry the value they were created under and no-op on mismatch.
     uint32_t m_navGeneration = 0;
 
     JSC::WriteBarrier<JSC::JSObject> m_onNavigated;
@@ -198,9 +189,7 @@ public:
     JSC::JSPromise* reload(JSC::JSGlobalObject*, NavWaitUntil, uint32_t timeoutMs);
     void doClose();
 
-    // Arm the parent-side navigation timeout (0 = none). Call it after the
-    // backend op stored the promise; an empty slot skips the timer. The
-    // timer captures PODs only and no-ops on a generation mismatch.
+    // Rejects m_pendingNavigate after timeoutMs (0 = never). Call after the backend op stored the promise.
     void armNavTimeout(JSC::JSGlobalObject*, uint32_t timeoutMs);
 
 #if OS(DARWIN)

--- a/src/runtime/webview/JSWebViewConstructor.cpp
+++ b/src/runtime/webview/JSWebViewConstructor.cpp
@@ -361,8 +361,7 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
         if (consoleCallback) view->m_onConsole.set(vm, view, consoleCallback);
         // No user code ever holds this promise; handled, so a rejection
         // (close mid-load, crash) cannot surface as unhandledRejection.
-        // timeoutMs=0: a default timeout would abandon the tracked
-        // initial load of a slow page.
+        // No timeout: nothing could observe it, and it would stop `loading`/`title` tracking on a slow page.
         if (!initialUrl.isEmpty()) {
             if (auto* p = view->navigate(globalObject, initialUrl, NavWaitUntil::Load, 0)) p->markAsHandled();
         }
@@ -386,9 +385,9 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
     // (including the next navigate()) serializes behind it. If it rejects
     // (bad URL), the next op's checkSlot sees the slot cleared and proceeds.
     // No user code ever holds this promise; handled, so a rejection cannot
-    // surface as unhandledRejection. timeoutMs=0 as in the Chrome path.
+    // surface as unhandledRejection.
     if (!initialUrl.isEmpty()) {
-        if (auto* p = view->navigate(globalObject, initialUrl, NavWaitUntil::Load, 0)) p->markAsHandled();
+        if (auto* p = view->navigate(globalObject, initialUrl, NavWaitUntil::Load, 0)) p->markAsHandled(); // no timeout, as above
     }
     return JSValue::encode(view);
 #endif

--- a/src/runtime/webview/JSWebViewConstructor.cpp
+++ b/src/runtime/webview/JSWebViewConstructor.cpp
@@ -361,9 +361,8 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
         if (consoleCallback) view->m_onConsole.set(vm, view, consoleCallback);
         // No user code ever holds this promise; handled, so a rejection
         // (close mid-load, crash) cannot surface as unhandledRejection.
-        // timeoutMs=0: the constructor has no option to configure a
-        // timeout, and a default one would settle the Navigate slot (and
-        // stop tracking `loading`/`title`) before a slow page finishes.
+        // timeoutMs=0: a default timeout would abandon the tracked
+        // initial load of a slow page.
         if (!initialUrl.isEmpty()) {
             if (auto* p = view->navigate(globalObject, initialUrl, NavWaitUntil::Load, 0)) p->markAsHandled();
         }
@@ -387,8 +386,7 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
     // (including the next navigate()) serializes behind it. If it rejects
     // (bad URL), the next op's checkSlot sees the slot cleared and proceeds.
     // No user code ever holds this promise; handled, so a rejection cannot
-    // surface as unhandledRejection. timeoutMs=0 for the same reason as
-    // the Chrome path above.
+    // surface as unhandledRejection. timeoutMs=0 as in the Chrome path.
     if (!initialUrl.isEmpty()) {
         if (auto* p = view->navigate(globalObject, initialUrl, NavWaitUntil::Load, 0)) p->markAsHandled();
     }

--- a/src/runtime/webview/JSWebViewConstructor.cpp
+++ b/src/runtime/webview/JSWebViewConstructor.cpp
@@ -361,8 +361,11 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
         if (consoleCallback) view->m_onConsole.set(vm, view, consoleCallback);
         // No user code ever holds this promise; handled, so a rejection
         // (close mid-load, crash) cannot surface as unhandledRejection.
+        // timeoutMs=0: the constructor has no option to configure a
+        // timeout, and a default one would settle the Navigate slot (and
+        // stop tracking `loading`/`title`) before a slow page finishes.
         if (!initialUrl.isEmpty()) {
-            if (auto* p = view->navigate(globalObject, initialUrl)) p->markAsHandled();
+            if (auto* p = view->navigate(globalObject, initialUrl, NavWaitUntil::Load, 0)) p->markAsHandled();
         }
         return JSValue::encode(view);
     }
@@ -384,9 +387,10 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
     // (including the next navigate()) serializes behind it. If it rejects
     // (bad URL), the next op's checkSlot sees the slot cleared and proceeds.
     // No user code ever holds this promise; handled, so a rejection cannot
-    // surface as unhandledRejection.
+    // surface as unhandledRejection. timeoutMs=0 for the same reason as
+    // the Chrome path above.
     if (!initialUrl.isEmpty()) {
-        if (auto* p = view->navigate(globalObject, initialUrl)) p->markAsHandled();
+        if (auto* p = view->navigate(globalObject, initialUrl, NavWaitUntil::Load, 0)) p->markAsHandled();
     }
     return JSValue::encode(view);
 #endif

--- a/src/runtime/webview/JSWebViewPrototype.cpp
+++ b/src/runtime/webview/JSWebViewPrototype.cpp
@@ -207,6 +207,59 @@ static VirtualKey virtualKeyFromName(const WTF::String& s)
     return VirtualKey::Character;
 }
 
+// { waitUntil?: 'load'|'domcontentloaded', timeout?: number } — shared by
+// navigate/reload/goBack/goForward. Playwright defaults: 'load', 30000ms;
+// timeout: 0 disables. Returns false on validation error (scope has the
+// pending exception).
+static bool parseNavOptions(JSGlobalObject* g, ThrowScope& scope, JSValue opts,
+    NavWaitUntil& waitUntil, uint32_t& timeout)
+{
+    auto& vm = g->vm();
+    waitUntil = NavWaitUntil::Load;
+    timeout = 30000;
+    if (!opts.isObject()) return true;
+    JSObject* o = opts.getObject();
+
+    JSValue w = o->get(g, Identifier::fromString(vm, "waitUntil"_s));
+    RETURN_IF_EXCEPTION(scope, false);
+    if (!w.isUndefined()) {
+        if (!w.isString()) {
+            Bun::ERR::INVALID_ARG_TYPE(scope, g, "options.waitUntil"_s, "string"_s, w);
+            return false;
+        }
+        WTF::String ws = w.toWTFString(g);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (ws == "load"_s) {
+            waitUntil = NavWaitUntil::Load;
+        } else if (ws == "domcontentloaded"_s) {
+            waitUntil = NavWaitUntil::DOMContentLoaded;
+        } else {
+            Bun::ERR::INVALID_ARG_VALUE(scope, g, "options.waitUntil"_s, w,
+                "must be \"load\" or \"domcontentloaded\""_s);
+            return false;
+        }
+    }
+
+    JSValue t = o->get(g, Identifier::fromString(vm, "timeout"_s));
+    RETURN_IF_EXCEPTION(scope, false);
+    if (!t.isUndefined()) {
+        double tn = t.toNumber(g);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (!std::isfinite(tn) || tn < 0) {
+            Bun::ERR::INVALID_ARG_VALUE(scope, g, "options.timeout"_s, t,
+                "must be a non-negative finite number"_s);
+            return false;
+        }
+        // Clamp to uint32 ms range (~49.7 days). Anything larger is
+        // effectively "no timeout" anyway. ceil so a positive sub-ms
+        // value (e.g. a computed `deadline - now` that lands at 0.3)
+        // still arms a 1ms timer instead of truncating to the 0 =
+        // "disable" sentinel.
+        timeout = static_cast<uint32_t>(std::min(std::ceil(tn), static_cast<double>(std::numeric_limits<uint32_t>::max())));
+    }
+    return true;
+}
+
 // --- Core ops ---------------------------------------------------------------
 
 JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncNavigate, (JSGlobalObject * globalObject, CallFrame* callFrame))
@@ -222,8 +275,15 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncNavigate, (JSGlobalObject * globalObj
     WTF::String url = urlArg.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
+    NavWaitUntil waitUntil;
+    uint32_t timeout;
+    if (!parseNavOptions(globalObject, scope, callFrame->argument(1), waitUntil, timeout)) return {};
+    // Option-object getters can call user code that closes the view.
+    if (thisObject->m_closed)
+        return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_STATE, "WebView is closed"_s);
+
     if (!checkSlot(globalObject, scope, thisObject->m_pendingNavigate, "a navigation"_s)) return {};
-    return JSValue::encode(thisObject->navigate(globalObject, url));
+    return JSValue::encode(thisObject->navigate(globalObject, url, waitUntil, timeout));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncEvaluate, (JSGlobalObject * globalObject, CallFrame* callFrame))
@@ -626,8 +686,13 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncBack, (JSGlobalObject * globalObject,
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* thisObject = unwrapThis(globalObject, scope, callFrame, "goBack"_s);
     RETURN_IF_EXCEPTION(scope, {});
+    NavWaitUntil waitUntil;
+    uint32_t timeout;
+    if (!parseNavOptions(globalObject, scope, callFrame->argument(0), waitUntil, timeout)) return {};
+    if (thisObject->m_closed)
+        return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_STATE, "WebView is closed"_s);
     if (!checkSlot(globalObject, scope, navSlot(thisObject), "a navigation"_s)) return {};
-    return JSValue::encode(thisObject->goBack(globalObject));
+    return JSValue::encode(thisObject->goBack(globalObject, waitUntil, timeout));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncForward, (JSGlobalObject * globalObject, CallFrame* callFrame))
@@ -636,8 +701,13 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncForward, (JSGlobalObject * globalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* thisObject = unwrapThis(globalObject, scope, callFrame, "goForward"_s);
     RETURN_IF_EXCEPTION(scope, {});
+    NavWaitUntil waitUntil;
+    uint32_t timeout;
+    if (!parseNavOptions(globalObject, scope, callFrame->argument(0), waitUntil, timeout)) return {};
+    if (thisObject->m_closed)
+        return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_STATE, "WebView is closed"_s);
     if (!checkSlot(globalObject, scope, navSlot(thisObject), "a navigation"_s)) return {};
-    return JSValue::encode(thisObject->goForward(globalObject));
+    return JSValue::encode(thisObject->goForward(globalObject, waitUntil, timeout));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncReload, (JSGlobalObject * globalObject, CallFrame* callFrame))
@@ -646,8 +716,13 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncReload, (JSGlobalObject * globalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* thisObject = unwrapThis(globalObject, scope, callFrame, "reload"_s);
     RETURN_IF_EXCEPTION(scope, {});
+    NavWaitUntil waitUntil;
+    uint32_t timeout;
+    if (!parseNavOptions(globalObject, scope, callFrame->argument(0), waitUntil, timeout)) return {};
+    if (thisObject->m_closed)
+        return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_STATE, "WebView is closed"_s);
     if (!checkSlot(globalObject, scope, navSlot(thisObject), "a navigation"_s)) return {};
-    return JSValue::encode(thisObject->reload(globalObject));
+    return JSValue::encode(thisObject->reload(globalObject, waitUntil, timeout));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncClose, (JSGlobalObject * globalObject, CallFrame* callFrame))

--- a/src/runtime/webview/JSWebViewPrototype.cpp
+++ b/src/runtime/webview/JSWebViewPrototype.cpp
@@ -207,8 +207,7 @@ static VirtualKey virtualKeyFromName(const WTF::String& s)
     return VirtualKey::Character;
 }
 
-// { waitUntil?: 'load'|'domcontentloaded', timeout?: number }. Playwright
-// defaults: 'load', 30000ms; timeout 0 disables. False = exception thrown.
+// { waitUntil?: "load" | "domcontentloaded", timeout?: number }. False means the scope holds an exception.
 static bool parseNavOptions(JSGlobalObject* g, ThrowScope& scope, JSValue opts,
     NavWaitUntil& waitUntil, uint32_t& timeout)
 {
@@ -248,8 +247,7 @@ static bool parseNavOptions(JSGlobalObject* g, ThrowScope& scope, JSValue opts,
                 "must be a non-negative finite number"_s);
             return false;
         }
-        // ceil keeps a positive sub-ms value from truncating to the
-        // 0 = "disable" sentinel; larger values clamp to uint32 ms.
+        // ceil: a positive sub-millisecond value must not truncate to 0, which means "no timeout".
         timeout = static_cast<uint32_t>(std::min(std::ceil(tn), static_cast<double>(std::numeric_limits<uint32_t>::max())));
     }
     return true;

--- a/src/runtime/webview/JSWebViewPrototype.cpp
+++ b/src/runtime/webview/JSWebViewPrototype.cpp
@@ -207,10 +207,8 @@ static VirtualKey virtualKeyFromName(const WTF::String& s)
     return VirtualKey::Character;
 }
 
-// { waitUntil?: 'load'|'domcontentloaded', timeout?: number } — shared by
-// navigate/reload/goBack/goForward. Playwright defaults: 'load', 30000ms;
-// timeout: 0 disables. Returns false on validation error (scope has the
-// pending exception).
+// { waitUntil?: 'load'|'domcontentloaded', timeout?: number }. Playwright
+// defaults: 'load', 30000ms; timeout 0 disables. False = exception thrown.
 static bool parseNavOptions(JSGlobalObject* g, ThrowScope& scope, JSValue opts,
     NavWaitUntil& waitUntil, uint32_t& timeout)
 {
@@ -250,11 +248,8 @@ static bool parseNavOptions(JSGlobalObject* g, ThrowScope& scope, JSValue opts,
                 "must be a non-negative finite number"_s);
             return false;
         }
-        // Clamp to uint32 ms range (~49.7 days). Anything larger is
-        // effectively "no timeout" anyway. ceil so a positive sub-ms
-        // value (e.g. a computed `deadline - now` that lands at 0.3)
-        // still arms a 1ms timer instead of truncating to the 0 =
-        // "disable" sentinel.
+        // ceil keeps a positive sub-ms value from truncating to the
+        // 0 = "disable" sentinel; larger values clamp to uint32 ms.
         timeout = static_cast<uint32_t>(std::min(std::ceil(tn), static_cast<double>(std::numeric_limits<uint32_t>::max())));
     }
     return true;

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -976,6 +976,187 @@ it("chrome: reload resolves after Page.loadEventFired", async () => {
   expect(after).not.toBe(before);
 });
 
+// --- navigate({ waitUntil, timeout }) -------------------------------------
+// A page whose main document is parseable but whose only subresource
+// never finishes → `load` never fires. Without { waitUntil:
+// "domcontentloaded" } (or a timeout), `await navigate()` hangs forever
+// on Page.loadEventFired.
+
+it("chrome: navigate({waitUntil:'domcontentloaded'}) settles when `load` never fires", async () => {
+  // Main document is tiny; /hang keeps the connection open so the
+  // <img> subresource never completes → the page's `load` event never
+  // fires (Chrome waits for all <img>s). DOMContentLoaded DOES fire —
+  // the document is fully parsed.
+  let releaseHang: (() => void) | undefined;
+  await using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/hang") {
+        // A ReadableStream that enqueues nothing until we release it.
+        // Chrome treats the <img> as loading while the body is open.
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              releaseHang = () => {
+                try {
+                  controller.close();
+                } catch {}
+              };
+            },
+          }),
+          { headers: { "content-type": "image/png" } },
+        );
+      }
+      return new Response(`<!doctype html><title>dcl</title><body>ready<img src="/hang"></body>`, {
+        headers: { "content-type": "text/html" },
+      });
+    },
+  });
+
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  try {
+    // `load` never fires; Page.lifecycleEvent(name=DOMContentLoaded)
+    // does. The handler matches on the main frame's loaderId (stashed
+    // by frameNavigated) so the about:blank replay and any subframe
+    // events can't mis-settle it.
+    await view.navigate(`http://127.0.0.1:${server.port}/`, { waitUntil: "domcontentloaded" });
+    // `await navigate()` chains Runtime.evaluate("document.title")
+    // before settling, so title/url are populated at DCL too.
+    expect(view.title).toBe("dcl");
+    // view.loading tracks the REAL load state (flipped by loadEventFired),
+    // not the user's waitUntil milestone — still loading here.
+    expect(view.loading).toBe(true);
+    // The DOM is fully parsed at DOMContentLoaded.
+    expect(await view.evaluate("document.body.textContent")).toBe("ready");
+    expect(await view.evaluate("document.readyState")).toBe("interactive");
+  } finally {
+    // Let the <img> finish so close() doesn't race Chrome's network stack.
+    releaseHang?.();
+  }
+});
+
+it("chrome: navigate({timeout}) rejects when `load` never fires", async () => {
+  let releaseHang: (() => void) | undefined;
+  await using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/hang") {
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              releaseHang = () => {
+                try {
+                  controller.close();
+                } catch {}
+              };
+            },
+          }),
+          { headers: { "content-type": "image/png" } },
+        );
+      }
+      return new Response(`<!doctype html><body><img src="/hang"></body>`, {
+        headers: { "content-type": "text/html" },
+      });
+    },
+  });
+
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  try {
+    // Default waitUntil:'load' — loadEventFired never comes. The
+    // parent-side RunLoop::dispatchAfter timer rejects. No cancel: the
+    // timer captures m_navGeneration and no-ops if a later navigate
+    // (or this settle) bumped it.
+    await expect(view.navigate(`http://127.0.0.1:${server.port}/`, { timeout: 500 })).rejects.toThrow(
+      /Navigation timeout of 500ms exceeded/,
+    );
+    // The slot is clear after the timeout rejection — a fresh
+    // navigate works and its own 30s default timer is independent
+    // (generation bumped).
+    await view.navigate(html("<body>after</body>"));
+    expect(await view.evaluate("document.body.textContent")).toBe("after");
+  } finally {
+    releaseHang?.();
+  }
+});
+
+it("chrome: reload({waitUntil:'domcontentloaded'}) settles on DCL", async () => {
+  // reload() has no loaderId in its CDP response; frameNavigated
+  // supplies it. Same lifecycleEvent path as navigate().
+  let releaseHang: (() => void) | undefined;
+  let hits = 0;
+  await using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/hang") {
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              releaseHang = () => {
+                try {
+                  controller.close();
+                } catch {}
+              };
+            },
+          }),
+          { headers: { "content-type": "image/png" } },
+        );
+      }
+      hits++;
+      return new Response(`<!doctype html><body data-hit="${hits}"><img src="/hang"></body>`, {
+        headers: { "content-type": "text/html" },
+      });
+    },
+  });
+
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  try {
+    await view.navigate(`http://127.0.0.1:${server.port}/`, { waitUntil: "domcontentloaded" });
+    expect(await view.evaluate("document.body.dataset.hit")).toBe("1");
+    releaseHang?.();
+    await view.reload({ waitUntil: "domcontentloaded" });
+    expect(await view.evaluate("document.body.dataset.hit")).toBe("2");
+  } finally {
+    releaseHang?.();
+  }
+});
+
+it("chrome: navigate({waitUntil:'domcontentloaded'}) ignores subframe lifecycle events", async () => {
+  // The <iframe> fires its own Page.lifecycleEvent(DOMContentLoaded)
+  // before the main document does (it's srcdoc — parsed inline). The
+  // frameId gate (main frame only, matched against m_frameId from
+  // frameNavigated) must filter it out.
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(html(`<!doctype html><body><iframe srcdoc="<p>sub</p>"></iframe><p id=m>main</p></body>`), {
+    waitUntil: "domcontentloaded",
+  });
+  // If the subframe's DCL had settled us, #m wouldn't exist yet (the
+  // iframe is before it in the stream). Settling on the MAIN frame's
+  // DCL means the whole document is parsed.
+  expect(await view.evaluate("document.getElementById('m')?.textContent")).toBe("main");
+});
+
+it("chrome: navigate() option validation", () => {
+  // Option parsing throws before any I/O. Needs a valid `this` so we
+  // construct a view (Chrome is already up from earlier tests); the
+  // throws happen in parseNavOptions before the slot check.
+  const v = new Bun.WebView({ backend: chrome, width: 100, height: 100 });
+  try {
+    expect(() => v.navigate("about:blank", { waitUntil: "networkidle" as any })).toThrow(
+      /must be "load" or "domcontentloaded"/,
+    );
+    expect(() => v.navigate("about:blank", { waitUntil: 42 as any })).toThrow(/waitUntil.*string/);
+    expect(() => v.navigate("about:blank", { timeout: -1 })).toThrow(/non-negative finite/);
+    expect(() => v.navigate("about:blank", { timeout: Infinity })).toThrow(/non-negative finite/);
+    // reload/goBack/goForward share parseNavOptions.
+    expect(() => v.reload({ waitUntil: "x" as any })).toThrow(/must be "load" or "domcontentloaded"/);
+  } finally {
+    v.close();
+  }
+});
+
 it("chrome: sequential navigates work", async () => {
   await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
 

--- a/test/js/bun/webview/webview-navigate-options.test.ts
+++ b/test/js/bun/webview/webview-navigate-options.test.ts
@@ -1,0 +1,418 @@
+// navigate({ waitUntil, timeout }) against a MOCK CDP endpoint.
+//
+// The real-Chrome coverage lives in webview-chrome.test.ts (gated on a
+// local Chrome binary, todo'd otherwise). This file exercises the same
+// code paths WITHOUT a browser: a Bun.serve WebSocket handler speaks
+// just enough CDP to drive the attach chain and emit Page.lifecycleEvent
+// / Page.loadEventFired on demand. That makes the waitUntil + timeout
+// logic testable on any CI lane, and makes the assertions exact (no
+// Chrome timing variance).
+//
+// Separate file because CDP::Transport is a process singleton — the
+// first `new Bun.WebView()` locks the backend mode (pipe vs. WebSocket)
+// and the endpoint. Mixing a mock WS here with the spawned-Chrome tests
+// in the same process would poison the other file.
+//
+// Each test runs in a SUBPROCESS for the same reason: one mock server
+// per test, one fresh Transport singleton per test.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// --- Mock CDP server --------------------------------------------------------
+// Inlined into the -e script so no fixture file is needed. The mock
+// understands exactly the attach-chain methods (Target.createTarget →
+// Target.attachToTarget → Page.enable → Page.setLifecycleEventsEnabled →
+// Runtime.enable → Page.navigate) plus the post-navigate Runtime.evaluate
+// for document.title. Everything else gets an empty {} result.
+//
+// `behavior` controls what lifecycle events the mock emits after
+// Page.navigate — this is what distinguishes the test cases:
+//   - "dcl-only": frameNavigated + lifecycleEvent(DOMContentLoaded).
+//     NEVER sends loadEventFired. navigate({waitUntil:'domcontentloaded'})
+//     should resolve; default navigate() should time out.
+//   - "load": frameNavigated + loadEventFired. Default navigate resolves.
+//   - "silent": nothing. navigate() hangs until timeout.
+//   - "stale-load": first navigate → DCL only (settles). Second
+//     navigate → emit the FIRST nav's trailing lifecycleEvent(load) +
+//     loadEventFired BEFORE the second nav commits, then never emit
+//     anything for the second nav. Proves beginChromeNavigation()'s
+//     m_loaderId clear stops stale events from settling a later
+//     navigate.
+//
+// frameId "F" / loaderId "L<n>" are the main frame; the mock ALSO emits
+// a subframe lifecycleEvent (frameId "SUB") to prove the frameId/
+// loaderId gate filters it out.
+const mockCDP = `
+function startMockCDP(behavior) {
+  const sid = "SESS";
+  let navN = 0;
+  const send = (ws, obj) => ws.send(JSON.stringify(obj));
+  const ev = (ws, method, params) => send(ws, { method, params, sessionId: sid });
+  const frameNavigated = (ws, loaderId, url) =>
+    ev(ws, "Page.frameNavigated", {
+      frame: { id: "F", loaderId, url,
+               domainAndRegistry: "", securityOrigin: "null", mimeType: "text/html",
+               adFrameStatus: { adFrameType: "none" }, secureContextType: "Secure",
+               crossOriginIsolatedContextType: "NotIsolated", gatedAPIFeatures: [] },
+      type: "Navigation",
+    });
+
+  return Bun.serve({
+    port: 0,
+    fetch(req, server) {
+      if (server.upgrade(req)) return;
+      return new Response("not ws", { status: 400 });
+    },
+    websocket: {
+      open() {},
+      message(ws, raw) {
+        const msg = JSON.parse(String(raw));
+        const reply = (result) =>
+          send(ws, msg.sessionId
+            ? { id: msg.id, result, sessionId: msg.sessionId }
+            : { id: msg.id, result });
+
+        switch (msg.method) {
+          case "Target.createTarget":
+            return reply({ targetId: "T" });
+          case "Target.attachToTarget":
+            return reply({ sessionId: sid });
+          case "Page.enable":
+          case "Page.setLifecycleEventsEnabled":
+          case "Runtime.enable":
+          case "Target.closeTarget":
+            return reply({});
+          case "Page.reload":
+          case "Page.navigate": {
+            const n = ++navN;
+            const L = "L" + n;
+            const url = msg.params?.url ?? "about:blank";
+            reply({ frameId: "F", loaderId: L });
+            // Subframe DCL FIRST — must be ignored by the frameId gate.
+            // If the handler matched on name alone, this would settle
+            // the navigate before the main document committed.
+            ev(ws, "Page.lifecycleEvent", {
+              frameId: "SUB", loaderId: "SL", name: "DOMContentLoaded", timestamp: 1,
+            });
+
+            if (behavior === "stale-load") {
+              if (n === 1) {
+                // First nav: DCL-only so the user settles and can
+                // start a second navigate.
+                frameNavigated(ws, L, url);
+                ev(ws, "Page.lifecycleEvent", {
+                  frameId: "F", loaderId: L, name: "DOMContentLoaded", timestamp: 2,
+                });
+              } else {
+                // Second nav: emit the FIRST nav's trailing load
+                // events (loaderId L1) BEFORE this nav commits. With
+                // the stale-gate, m_loaderId is empty here so both
+                // the lifecycleEvent loaderId check and
+                // loadEventFired's isEmpty() guard drop them.
+                ev(ws, "Page.lifecycleEvent", {
+                  frameId: "F", loaderId: "L1", name: "load", timestamp: 3,
+                });
+                ev(ws, "Page.loadEventFired", { timestamp: 3 });
+                // Never commit url2 — the test asserts it stays pending.
+              }
+              return;
+            }
+
+            // Main-frame commit: sets m_frameId/m_loaderId.
+            frameNavigated(ws, L, url);
+            if (behavior === "dcl-only") {
+              ev(ws, "Page.lifecycleEvent", {
+                frameId: "F", loaderId: L, name: "DOMContentLoaded", timestamp: 2,
+              });
+              // No loadEventFired — the page "never finishes loading".
+            } else if (behavior === "load") {
+              ev(ws, "Page.lifecycleEvent", {
+                frameId: "F", loaderId: L, name: "DOMContentLoaded", timestamp: 2,
+              });
+              ev(ws, "Page.lifecycleEvent", {
+                frameId: "F", loaderId: L, name: "load", timestamp: 3,
+              });
+              ev(ws, "Page.loadEventFired", { timestamp: 3 });
+            }
+            // "silent": nothing — navigate() has only the timeout to save it.
+            return;
+          }
+          case "Runtime.evaluate":
+            // document.title → PageTitle chain. The handler reads
+            // result.result.value.
+            return reply({ result: { type: "string", value: "mock-title" } });
+          default:
+            return reply({});
+        }
+      },
+    },
+  });
+}
+`;
+
+async function run(behavior: "dcl-only" | "load" | "silent" | "stale-load", body: string) {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      mockCDP +
+        `
+await using server = startMockCDP(${JSON.stringify(behavior)});
+const view = new Bun.WebView({
+  backend: { type: "chrome", url: \`ws://127.0.0.1:\${server.port}/devtools/browser/mock\` },
+  width: 100, height: 100,
+});
+try {
+${body}
+} finally {
+  view.close();
+}
+`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+// --- waitUntil: 'domcontentloaded' -----------------------------------------
+
+test.concurrent(
+  "navigate({waitUntil:'domcontentloaded'}) settles on Page.lifecycleEvent when load never fires",
+  async () => {
+    // The mock emits frameNavigated + lifecycleEvent(DOMContentLoaded) for
+    // the main frame, and NEVER loadEventFired. Without waitUntil:
+    // 'domcontentloaded', navigate() would hang until the 30s timeout.
+    // With it, the lifecycleEvent handler matches frameId=="F" &&
+    // loaderId=="L" && name=="DOMContentLoaded", chains a document.title
+    // fetch, and resolves.
+    //
+    // The mock ALSO sends a subframe DCL (frameId "SUB") BEFORE the main
+    // frame commits — the frameId gate must drop it. A naive name-only
+    // match would settle on the subframe event.
+    const { stdout, stderr, exitCode } = await run(
+      "dcl-only",
+      `
+    await view.navigate("http://example/dcl", { waitUntil: "domcontentloaded", timeout: 10_000 });
+    // PageTitle chain ran — Runtime.evaluate("document.title") → "mock-title".
+    console.log("title=" + view.title);
+    // m_loading tracks the REAL load state; loadEventFired never came.
+    console.log("loading=" + view.loading);
+    console.log("url=" + view.url);
+    `,
+    );
+    expect(stderr).toBe("");
+    expect(stdout.trim().split("\n")).toEqual(["title=mock-title", "loading=true", "url=http://example/dcl"]);
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.concurrent("navigate() default waitUntil:'load' settles on Page.loadEventFired", async () => {
+  // Backward compat: no options → waitUntil:'load' → loadEventFired
+  // settles. The lifecycleEvent(DOMContentLoaded) arrives first but is
+  // ignored because m_navWaitUntil == Load.
+  const { stdout, stderr, exitCode } = await run(
+    "load",
+    `
+    await view.navigate("http://example/load");
+    console.log("title=" + view.title + " loading=" + view.loading);
+    `,
+  );
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("title=mock-title loading=false");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("reload({waitUntil:'domcontentloaded'}) settles on lifecycleEvent", async () => {
+  // reload() shares the Navigate slot and the same lifecycle path as
+  // navigate(). "dcl-only" never emits loadEventFired, so both the
+  // initial navigate and the reload must settle via
+  // Page.lifecycleEvent(DOMContentLoaded). The mock handles
+  // Page.reload identically to Page.navigate (same event sequence,
+  // fresh loaderId).
+  const { stdout, stderr, exitCode } = await run(
+    "dcl-only",
+    `
+    await view.navigate("http://example/a", { waitUntil: "domcontentloaded" });
+    await view.reload({ waitUntil: "domcontentloaded", timeout: 10_000 });
+    console.log("ok title=" + view.title);
+    `,
+  );
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("ok title=mock-title");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent(
+  "navigate({waitUntil:'domcontentloaded'}) on a fast page doesn't enqueue duplicate title fetches",
+  async () => {
+    // "load" mock emits DCL + load + loadEventFired all before the
+    // first PageTitle response arrives. Without the m_navTitleChained
+    // flag set by chainTitle(), each of the three would enqueue its
+    // own PageTitle — and a duplicate response can settle the NEXT
+    // navigate's promise early. With the flag, only the first trigger
+    // chains; the rest see m_navTitleChained and drop.
+    //
+    // Two back-to-back DCL navigates: if duplicate PageTitle from
+    // nav1 leaked and settled nav2, nav2 would resolve with
+    // view.url == nav1's url (nav2's frameNavigated hadn't arrived
+    // yet at the time of the stale settle).
+    const { stdout, stderr, exitCode } = await run(
+      "load",
+      `
+    await view.navigate("http://example/one", { waitUntil: "domcontentloaded" });
+    await view.navigate("http://example/two", { waitUntil: "domcontentloaded" });
+    // Each navigate committed — url reflects the LAST one. A leaked
+    // duplicate PageTitle from /one would have settled /two with
+    // url still /one.
+    console.log("url=" + view.url + " title=" + view.title);
+    // loadEventFired fired for /two (mock emits it in "load" mode)
+    // so m_loading flipped even though we settled on DCL.
+    console.log("loading=" + view.loading);
+    `,
+    );
+    expect(stderr).toBe("");
+    expect(stdout.trim().split("\n")).toEqual(["url=http://example/two title=mock-title", "loading=false"]);
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.concurrent(
+  "stale loadEventFired from a prior 'domcontentloaded' navigate does not settle the next one",
+  async () => {
+    // Regression: navigate(url1, {waitUntil:'domcontentloaded'}) settles
+    // before url1's window `load` fires. A second navigate() can then
+    // start, and url1's trailing lifecycleEvent(load)+loadEventFired
+    // arrive while nav2 is pending. Without the m_loaderId clear in
+    // beginChromeNavigation(), those stale events pass the gate (the
+    // old loaderId is still cached) and chainTitle() settles nav2's
+    // promise before its own document committed.
+    //
+    // The mock's "stale-load" arm emits exactly that: nav1 → DCL only;
+    // nav2 → stale lifecycleEvent(load,L1) + loadEventFired, then
+    // nothing for nav2. With the fix, nav2 stays pending.
+    const { stdout, stderr, exitCode } = await run(
+      "stale-load",
+      `
+    await view.navigate("http://example/one", { waitUntil: "domcontentloaded" });
+    // nav1 settled on DCL; its load hasn't fired. nav2 starts and
+    // clears m_loaderId. The mock then sends nav1's trailing load
+    // events — they must NOT settle nav2.
+    const nav2 = view.navigate("http://example/two", { waitUntil: "load", timeout: 0 });
+    let settled = "pending";
+    nav2.then(() => settled = "resolved", e => settled = "rejected:" + e.message);
+    await Bun.sleep(300);
+    // url should still be nav1's — nav2 never committed in the mock.
+    // loading should still be TRUE — nav2 set it and nav1's stale
+    // loadEventFired (m_loaderId empty) must not clear it.
+    console.log("nav2=" + settled + " url=" + view.url + " loading=" + view.loading);
+    // And with waitUntil:'domcontentloaded' on nav2 the stale
+    // lifecycleEvent(load, L1) must ALSO be rejected by the loaderId
+    // check (m_loaderId empty). Close the view to reject nav2 so the
+    // process exits; the test only cares it was still pending.
+    `,
+    );
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("nav2=pending url=http://example/one loading=true");
+    expect(exitCode).toBe(0);
+  },
+);
+
+// --- timeout ---------------------------------------------------------------
+
+test.concurrent("navigate({timeout}) rejects when no lifecycle event arrives", async () => {
+  // "silent" mock: Page.navigate reply + frameNavigated, but no
+  // DCL/load/loadEventFired — navigate() has only the parent-side
+  // dispatchAfter timer to save it.
+  const { stdout, stderr, exitCode } = await run(
+    "silent",
+    `
+    const t0 = performance.now();
+    try {
+      await view.navigate("http://example/hang", { timeout: 300 });
+      console.log("FAIL: resolved");
+    } catch (e) {
+      const elapsed = performance.now() - t0;
+      // Fired after ~300ms (WTFTimer via Bun's event loop). Loose
+      // lower bound; upper bound generous for slow CI.
+      console.log("rejected=" + /Navigation timeout of 300ms exceeded/.test(e.message)
+        + " elapsed>=250=" + (elapsed >= 250));
+    }
+    // Slot is clear — a second navigate with timeout:0 would hang
+    // forever on this mock, so give it a short one and assert it
+    // rejects with ITS OWN message (generation-counter isolated the
+    // previous timer).
+    try {
+      await view.navigate("http://example/hang2", { timeout: 200 });
+      console.log("FAIL: second resolved");
+    } catch (e) {
+      console.log("second=" + /Navigation timeout of 200ms exceeded/.test(e.message));
+    }
+    `,
+  );
+  expect(stderr).toBe("");
+  expect(stdout.trim().split("\n")).toEqual(["rejected=true elapsed>=250=true", "second=true"]);
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("navigate({timeout}): stale timer does not reject a later navigation", async () => {
+  // First navigate settles on DCL at ~0ms with a 400ms timeout armed.
+  // Second navigate (silent mock would hang) starts immediately with
+  // timeout:0 (disabled). The first navigate's 400ms timer FIRES while
+  // the second navigate is pending — the generation-counter check must
+  // make it no-op instead of rejecting the second navigate's promise.
+  const { stdout, stderr, exitCode } = await run(
+    "dcl-only",
+    `
+    await view.navigate("http://example/a", { waitUntil: "domcontentloaded", timeout: 400 });
+    // Second navigate: never settles on this mock (no loadEventFired),
+    // no timeout. Race it against a 700ms sleep — if the stale 400ms
+    // timer from the first navigate wrongly rejected it, the promise
+    // would settle before 700ms.
+    const nav2 = view.navigate("http://example/b", { waitUntil: "load", timeout: 0 });
+    let settled = "pending";
+    nav2.then(() => settled = "resolved", e => settled = "rejected:" + e.message);
+    await Bun.sleep(700);
+    console.log("after-stale=" + settled);
+    `,
+  );
+  expect(stderr).toBe("");
+  // Still pending after the first navigate's stale 400ms timer fired.
+  expect(stdout.trim()).toBe("after-stale=pending");
+  expect(exitCode).toBe(0);
+});
+
+// --- validation ------------------------------------------------------------
+
+test.concurrent("navigate() option validation throws before I/O", async () => {
+  // No CDP traffic needed — the throws happen in parseNavOptions
+  // before the slot check. Use the silent mock just to get a view.
+  const { stdout, stderr, exitCode } = await run(
+    "silent",
+    `
+    const cases = [
+      ["waitUntil networkidle", () => view.navigate("about:blank", { waitUntil: "networkidle" })],
+      ["waitUntil number",      () => view.navigate("about:blank", { waitUntil: 42 })],
+      ["timeout negative",      () => view.navigate("about:blank", { timeout: -1 })],
+      ["timeout Infinity",      () => view.navigate("about:blank", { timeout: Infinity })],
+      ["reload waitUntil",      () => view.reload({ waitUntil: "nope" })],
+    ];
+    for (const [name, fn] of cases) {
+      try { fn(); console.log("FAIL", name); }
+      catch (e) { console.log(name + ": " + e.code); }
+    }
+    `,
+  );
+  expect(stderr).toBe("");
+  expect(stdout.trim().split("\n")).toEqual([
+    "waitUntil networkidle: ERR_INVALID_ARG_VALUE",
+    "waitUntil number: ERR_INVALID_ARG_TYPE",
+    "timeout negative: ERR_INVALID_ARG_VALUE",
+    "timeout Infinity: ERR_INVALID_ARG_VALUE",
+    "reload waitUntil: ERR_INVALID_ARG_VALUE",
+  ]);
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/webview/webview-navigate-options.test.ts
+++ b/test/js/bun/webview/webview-navigate-options.test.ts
@@ -47,6 +47,7 @@ const mockCDP = `
 function startMockCDP(behavior) {
   const sid = "SESS";
   let navN = 0;
+  let evalN = 0;
   const send = (ws, obj) => ws.send(JSON.stringify(obj));
   const ev = (ws, method, params) => send(ws, { method, params, sessionId: sid });
   const frameNavigated = (ws, loaderId, url) =>
@@ -126,7 +127,7 @@ function startMockCDP(behavior) {
                 frameId: "F", loaderId: L, name: "DOMContentLoaded", timestamp: 2,
               });
               // No loadEventFired — the page "never finishes loading".
-            } else if (behavior === "load") {
+            } else if (behavior === "load" || behavior === "uninitiated") {
               ev(ws, "Page.lifecycleEvent", {
                 frameId: "F", loaderId: L, name: "DOMContentLoaded", timestamp: 2,
               });
@@ -138,10 +139,22 @@ function startMockCDP(behavior) {
             // "silent": nothing — navigate() has only the timeout to save it.
             return;
           }
-          case "Runtime.evaluate":
+          case "Runtime.evaluate": {
             // document.title → PageTitle chain. The handler reads
             // result.result.value.
-            return reply({ result: { type: "string", value: "mock-title" } });
+            const k = ++evalN;
+            if (behavior !== "uninitiated") return reply({ result: { type: "string", value: "mock-title" } });
+            reply({ result: { type: "string", value: "title-" + k } });
+            // After each settled title, simulate a PAGE-initiated
+            // navigation (location.href style): frameNavigated +
+            // loadEventFired with no Page.navigate command. Two in a
+            // row prove the per-document title-fetch reset.
+            if (k <= 2) {
+              frameNavigated(ws, "U" + k, "http://example/self" + k);
+              ev(ws, "Page.loadEventFired", { timestamp: 10 + k });
+            }
+            return;
+          }
           default:
             return reply({});
         }
@@ -151,7 +164,7 @@ function startMockCDP(behavior) {
 }
 `;
 
-async function run(behavior: "dcl-only" | "load" | "silent" | "stale-load", body: string) {
+async function run(behavior: "dcl-only" | "load" | "silent" | "stale-load" | "uninitiated", body: string) {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -382,6 +395,30 @@ test.concurrent("navigate({timeout}): stale timer does not reject a later naviga
   expect(stderr).toBe("");
   // Still pending after the first navigate's stale 400ms timer fired.
   expect(stdout.trim()).toBe("after-stale=pending");
+  expect(exitCode).toBe(0);
+});
+
+// --- page-initiated navigations --------------------------------------------
+
+test.concurrent("view.title updates after a page-initiated navigation", async () => {
+  // The "uninitiated" mock settles navigate() with "title-1", then
+  // emits frameNavigated + loadEventFired with NO Page.navigate
+  // command (location.href style), twice. Each commit must chain a
+  // fresh PageTitle fetch: the loadEventFired handler cannot gate on
+  // m_pendingNavigate (none is pending), and frameNavigated must
+  // reset the per-document dedupe flag or the second one is skipped.
+  const { stdout, stderr, exitCode } = await run(
+    "uninitiated",
+    `
+    await view.navigate("http://example/first");
+    console.log("t1=" + view.title);
+    const deadline = Date.now() + 10_000;
+    while (view.title !== "title-3" && Date.now() < deadline) await Bun.sleep(5);
+    console.log("t3=" + view.title + " url=" + view.url + " loading=" + view.loading);
+    `,
+  );
+  expect(stderr).toBe("");
+  expect(stdout.trim().split("\n")).toEqual(["t1=title-1", "t3=title-3 url=http://example/self2 loading=false"]);
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/bun/webview/webview-navigate-options.test.ts
+++ b/test/js/bun/webview/webview-navigate-options.test.ts
@@ -48,6 +48,7 @@ function startMockCDP(behavior) {
   const sid = "SESS";
   let navN = 0;
   let evalN = 0;
+  let lifecycleEnabled = false;
   const send = (ws, obj) => ws.send(JSON.stringify(obj));
   const ev = (ws, method, params) => send(ws, { method, params, sessionId: sid });
   const frameNavigated = (ws, loaderId, url) =>
@@ -80,7 +81,16 @@ function startMockCDP(behavior) {
           case "Target.attachToTarget":
             return reply({ sessionId: sid });
           case "Page.enable":
+            // "slow-enable": hold the reply long enough for a short
+            // navigate timeout to fire mid-attach.
+            if (behavior === "slow-enable") {
+              setTimeout(() => reply({}), 2000);
+              return;
+            }
+            return reply({});
           case "Page.setLifecycleEventsEnabled":
+            lifecycleEnabled = true;
+            return reply({});
           case "Runtime.enable":
           case "Target.closeTarget":
             return reply({});
@@ -116,6 +126,18 @@ function startMockCDP(behavior) {
                 });
                 ev(ws, "Page.loadEventFired", { timestamp: 3 });
                 // Never commit url2 — the test asserts it stays pending.
+              }
+              return;
+            }
+
+            if (behavior === "slow-enable") {
+              // Lifecycle events only flow if the client actually sent
+              // Page.setLifecycleEventsEnabled for this session.
+              frameNavigated(ws, L, url);
+              if (lifecycleEnabled) {
+                ev(ws, "Page.lifecycleEvent", {
+                  frameId: "F", loaderId: L, name: "DOMContentLoaded", timestamp: 2,
+                });
               }
               return;
             }
@@ -164,7 +186,10 @@ function startMockCDP(behavior) {
 }
 `;
 
-async function run(behavior: "dcl-only" | "load" | "silent" | "stale-load" | "uninitiated", body: string) {
+async function run(
+  behavior: "dcl-only" | "load" | "silent" | "stale-load" | "uninitiated" | "slow-enable",
+  body: string,
+) {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -395,6 +420,33 @@ test.concurrent("navigate({timeout}): stale timer does not reject a later naviga
   expect(stderr).toBe("");
   // Still pending after the first navigate's stale 400ms timer fired.
   expect(stdout.trim()).toBe("after-stale=pending");
+  expect(exitCode).toBe(0);
+});
+
+// --- attach-chain races ------------------------------------------------------
+
+test.concurrent("a first-navigate timeout during the attach chain does not break the session", async () => {
+  // The mock holds the Page.enable reply for 2s, so navigate({timeout:300})
+  // rejects mid-attach and the stale gate drops the late reply. The
+  // per-session setup (Runtime.enable, Page.setLifecycleEventsEnabled)
+  // must go out from the attach step, not from that dropped reply: the
+  // mock emits lifecycleEvent(DCL) only if it received
+  // setLifecycleEventsEnabled, and the second navigate settles on it.
+  const { stdout, stderr, exitCode } = await run(
+    "slow-enable",
+    `
+    const first = await view.navigate("http://example/one", { timeout: 300 })
+      .then(() => "resolved", e => "rejected: " + e.message);
+    console.log("first=" + first);
+    await view.navigate("http://example/two", { waitUntil: "domcontentloaded", timeout: 3000 });
+    console.log("second=ok url=" + view.url);
+    `,
+  );
+  expect(stderr).toBe("");
+  expect(stdout.trim().split("\n")).toEqual([
+    "first=rejected: Navigation timeout of 300ms exceeded",
+    "second=ok url=http://example/two",
+  ]);
   expect(exitCode).toBe(0);
 });
 


### PR DESCRIPTION
### Problem
- `await view.navigate(url)` settles only on `Page.loadEventFired`. A page that keeps a subresource open (SSE, a hung `<img>`) never fires `load`, so the await hangs.
- There is no timeout. Playwright and Puppeteer expose both options on `goto()`.

### Fix
- `navigate`, `reload`, `goBack`, `goForward` take `{ waitUntil: "load" | "domcontentloaded", timeout }` (defaults `"load"`, 30000 ms, `0` disables). WebKit: `"domcontentloaded"` degrades to `"load"` (no DCL delegate hook).
- Chrome: the attach chain enables `Page.lifecycleEvent`. A `"domcontentloaded"` wait settles when the event's `frameId` and `loaderId` match the main frame's last `Page.frameNavigated`; replayed and subframe events never match. `"load"` still uses `Page.loadEventFired`.
- Timeout: `JSWebView::armNavTimeout` schedules a `WTF::RunLoop::dispatchAfter` closure keyed by `{viewId, generation}`. Settling the Navigate slot bumps `m_navGeneration`, so a late timer does nothing. Navigate-slot `Pending` entries carry their generation, so a stale reply cannot settle a retry.
- Verified: `test/js/bun/webview/webview-navigate-options.test.ts` (new, mock CDP, 8 tests, no Chrome) and 5 real-Chrome tests in `webview-chrome.test.ts` (all 63 pass). Also the rest of `test/js/bun/webview/` and `bun-types.test.ts`.

### Background
- `JSWebView` holds one pending promise per slot (`m_pendingNavigate`, ...). The Chrome backend maps each CDP command id to a `Pending { method, slot, viewId }` entry and settles that slot on reply.
- CDP `Page.lifecycleEvent` reports `DOMContentLoaded`, `load`, `networkIdle` per frame and `loaderId` (one per document load). Enabling it replays the current document's events, hence the loaderId match.
- `WTF::RunLoop::dispatchAfter` is WebKit's delayed dispatch, backed by `WTFTimer` on bun's event loop. The timer has no cancel handle; the generation counter is the cancel.

<details><summary>Notes</summary>

**History.** Opened 2026-05-13, all CI lanes green on build #54352, closed by the stale bot on 2026-09-02, reopened and rebased onto `main@6f27257` the same day. The rebase had one conflict: `JSWebViewConstructor.cpp` now marks the constructor's navigate promise handled (#40992). Both are kept: `markAsHandled()` and `timeoutMs=0` for the constructor's initial navigate. The generation bump moved into a shared `takeSlot` helper so `rejectSlotAsHandled` (close(), browser death) also invalidates an armed timer.

**Real Chrome.** Chrome refuses to start as root without `--no-sandbox`, so on a root container run the real-Chrome files with `BUN_CHROME_PATH` pointing at a wrapper script that adds the flag. The mock tests need nothing.

**Mock transport.** `webview-navigate-options.test.ts` drives the connect-mode transport with a `Bun.serve` WebSocket that speaks CDP. `fake-chrome-fixture.ts` (pipe mode) exists on main for the spawn path. Both fakes stay: the ws mock is the only CI coverage of connect mode, and the lifecycle scenarios (DCL-only, silent, stale load) are per-test behaviours that would need several new fixture flags.

**Gate.** With `src/` at base, `webview-navigate-options.test.ts` fails 7 of 8 (the default-`load` test passes). With the fix, 8 of 8.

**Deferred, needs a maintainer's scope call.**
- WebKit timeout does not reset the host's `m_navPending`. After a timeout the next `navigate()` rejects with "navigation already pending". Needs a new `Op::CancelNavigate` IPC message. `view.close()` works.
- A stale `Page.frameNavigated` can re-arm the event gate in the sub-millisecond window where the timeout fires as the old navigation commits and the user retries in `.catch()`. Needs the expected loaderId from the `Page.navigate` reply (Playwright's LifecycleWatcher), which `Page.reload` and `navigateToHistoryEntry` do not return.
- A stale `Target.attachToTarget` reply does not close its tab (one round trip after `createTarget` set `m_targetId`). Needs `targetId` carried in `Pending`. #39075 covers the `close()` side of this.
- `goBack`/`goForward` do not set `m_loading = true`; `reload()` does.
- `view.title` no longer refreshes on page-initiated navigations. `view.url` still does through `frameNavigated`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/webview/webview-chrome.test.ts

<!-- robobun:evidence:end -->