### PR TITLE
Bun.serve: validate `app.bundlerOptions` is an object

### DIFF
--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -208,14 +208,22 @@ impl UserOptions {
         }
 
         if let Some(js_options) = get_optional_value(config, global, b"bundlerOptions")? {
+            if !js_options.is_object() {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "'{}.bundlerOptions' must be an object",
+                    API_NAME,
+                )));
+            }
             if let Some(server_options) = get_optional_value(js_options, global, b"server")? {
-                bundler_options.server = BuildConfigSubset::from_js(global, server_options)?;
+                bundler_options.server =
+                    BuildConfigSubset::from_js(global, "server", server_options)?;
             }
             if let Some(client_options) = get_optional_value(js_options, global, b"client")? {
-                bundler_options.client = BuildConfigSubset::from_js(global, client_options)?;
+                bundler_options.client =
+                    BuildConfigSubset::from_js(global, "client", client_options)?;
             }
             if let Some(ssr_options) = get_optional_value(js_options, global, b"ssr")? {
-                bundler_options.ssr = BuildConfigSubset::from_js(global, ssr_options)?;
+                bundler_options.ssr = BuildConfigSubset::from_js(global, "ssr", ssr_options)?;
             }
         }
 
@@ -405,8 +413,19 @@ pub struct BuildConfigSubset {
 }
 
 impl BuildConfigSubset {
-    pub fn from_js(global: &JSGlobalObject, js_options: JSValue) -> JsResult<BuildConfigSubset> {
+    pub fn from_js(
+        global: &JSGlobalObject,
+        name: &str,
+        js_options: JSValue,
+    ) -> JsResult<BuildConfigSubset> {
         let mut options = BuildConfigSubset::default();
+
+        if !js_options.is_object() {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "'{}.bundlerOptions.{}' must be an object",
+                API_NAME, name,
+            )));
+        }
 
         'brk: {
             let Some(val) = get_optional_value(js_options, global, b"sourcemap")? else {
@@ -429,11 +448,19 @@ impl BuildConfigSubset {
             let Some(minify_options) = get_optional_value(js_options, global, b"minify")? else {
                 break 'brk;
             };
-            if minify_options.is_boolean() && minify_options.as_boolean() {
-                options.minify_syntax = Some(minify_options.as_boolean());
-                options.minify_identifiers = Some(minify_options.as_boolean());
-                options.minify_whitespace = Some(minify_options.as_boolean());
+            if minify_options.is_boolean() {
+                let enabled = minify_options.as_boolean();
+                options.minify_syntax = Some(enabled);
+                options.minify_identifiers = Some(enabled);
+                options.minify_whitespace = Some(enabled);
                 break 'brk;
+            }
+
+            if !minify_options.is_object() {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "'{}.bundlerOptions.{}.minify' must be a boolean or an object",
+                    API_NAME, name,
+                )));
             }
 
             if let Some(value) = get_boolean_loose(minify_options, global, b"whitespace")? {

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -685,11 +685,7 @@ describe("app.bundlerOptions validation", () => {
       { bundlerOptions: { client: "x" } },
       "'app.bundlerOptions.client' must be an object",
     ],
-    [
-      "bundlerOptions.ssr is a bigint",
-      { bundlerOptions: { ssr: 1n } },
-      "'app.bundlerOptions.ssr' must be an object",
-    ],
+    ["bundlerOptions.ssr is a bigint", { bundlerOptions: { ssr: 1n } }, "'app.bundlerOptions.ssr' must be an object"],
     [
       "bundlerOptions.server.minify is a number",
       { bundlerOptions: { server: { minify: 123 } } },

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -670,3 +670,44 @@ describe("Bun.serve unix socket validation", () => {
     }
   });
 });
+
+describe("app.bundlerOptions validation", () => {
+  test.each([
+    ["bundlerOptions is a string", { bundlerOptions: "hello" }, "'app.bundlerOptions' must be an object"],
+    ["bundlerOptions is a number", { bundlerOptions: 123 }, "'app.bundlerOptions' must be an object"],
+    [
+      "bundlerOptions.server is a number",
+      { bundlerOptions: { server: 123 } },
+      "'app.bundlerOptions.server' must be an object",
+    ],
+    [
+      "bundlerOptions.client is a string",
+      { bundlerOptions: { client: "x" } },
+      "'app.bundlerOptions.client' must be an object",
+    ],
+    [
+      "bundlerOptions.ssr is a bigint",
+      { bundlerOptions: { ssr: 1n } },
+      "'app.bundlerOptions.ssr' must be an object",
+    ],
+    [
+      "bundlerOptions.server.minify is a number",
+      { bundlerOptions: { server: { minify: 123 } } },
+      "'app.bundlerOptions.server.minify' must be a boolean or an object",
+    ],
+  ])("throws when %s", (_, app, message) => {
+    expect(() => {
+      // @ts-expect-error - Testing runtime validation of invalid types
+      using server = serve({ port: 0, app });
+      server.stop();
+    }).toThrow(message);
+  });
+
+  test("does not throw when minify is false", () => {
+    expect(() => {
+      // @ts-expect-error - Testing runtime validation
+      using server = serve({ port: 0, app: { bundlerOptions: { server: { minify: false } } } });
+      server.stop();
+    }).toThrow("'app' is missing 'framework'");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a debug assertion crash (`reached unreachable code` at `JSValue.get`) when passing a non-object primitive to `app.bundlerOptions` or its nested options in `Bun.serve()`.

```js
Bun.serve({ app: { bundlerOptions: "hello" } });
// Before: panic: reached unreachable code (debug assert in JSValue.get)
// After:  TypeError: 'app.bundlerOptions' must be an object
```

Also fixed:
- `app.bundlerOptions.{server,client,ssr}` (same assertion when given a primitive)
- `app.bundlerOptions.*.minify` (same assertion when given a non-boolean primitive), and `minify: false` previously left the `minify_*` fields unset so the production default could re-enable minification; it now explicitly disables all three

Found by Fuzzilli (fingerprint `5e94ac4bb3645671`).

### Rebase note

`src/bake/bake.zig` was deleted on main as part of the Rust rewrite, so after rebasing the fix lives only in `src/runtime/bake/bake_body.rs` (the Rust port of the same `UserOptions::from_js` / `BuildConfigSubset::from_js` logic).

## How did you verify your code works?

Added regression tests to `test/js/bun/http/bun-serve-args.test.ts`.
