### PR TITLE
WebView.cdp(): reject instead of sync-throwing on no-session

### DIFF
--- a/docs/runtime/webview.mdx
+++ b/docs/runtime/webview.mdx
@@ -465,7 +465,7 @@ await view.cdp("DOM.focus", { nodeId });
 
 `cdp(method, params?)` returns the `result` object from the CDP response. If Chrome returns an error (unknown method, bad params), the promise rejects with its `error.message`.
 
-Commands are scoped to this view's session (they target this tab). You must `await navigate(...)` at least once before calling `cdp()` — the first navigation establishes the session. Calling `cdp()` before that throws `ERR_INVALID_STATE`.
+Commands are scoped to this view's session (they target this tab). You must `await navigate(...)` at least once before calling `cdp()` — the first navigation establishes the session. Calling `cdp()` before that returns a Promise that rejects with `ERR_INVALID_STATE`.
 
 `params` must be a JSON-serializable object; omit it for commands that take no parameters. One `cdp()` call may be in flight at a time per view.
 

--- a/src/runtime/webview/JSWebViewPrototype.cpp
+++ b/src/runtime/webview/JSWebViewPrototype.cpp
@@ -375,7 +375,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncCdp, (JSGlobalObject * globalObject, 
     // below stay synchronous (programmer error, no I/O happened yet).
     if (thisObject->m_sessionId.isEmpty()) {
         auto* err = createError(globalObject, ErrorCode::ERR_INVALID_STATE,
-            "WebView.cdp(): no session - await navigate() first"_s);
+            "Invalid state: WebView.cdp(): no session - await navigate() first"_s);
         RELEASE_AND_RETURN(scope,
             JSValue::encode(JSC::JSPromise::rejectedPromise(globalObject, err)));
     }

--- a/src/runtime/webview/JSWebViewPrototype.cpp
+++ b/src/runtime/webview/JSWebViewPrototype.cpp
@@ -365,9 +365,20 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncCdp, (JSGlobalObject * globalObject, 
     // command here would reach the wrong target. The user can `await
     // navigate(...)` first to get a session, or use Bun.WebView.chrome()
     // for browser-level commands (v2).
-    if (thisObject->m_sessionId.isEmpty())
-        return Bun::ERR::INVALID_STATE(scope, globalObject,
+    //
+    // Reject (not sync-throw): this is a state error that callers reach
+    // when Chrome dies before the attach chain completes — navigate()
+    // already rejected, and recovery code commonly does
+    // `void v.cdp('Page.stopLoading').catch(()=>{})`. A sync throw escapes
+    // that .catch() and replaces the original navigate() rejection with
+    // this misleading "await navigate() first" message. Arg-type checks
+    // below stay synchronous (programmer error, no I/O happened yet).
+    if (thisObject->m_sessionId.isEmpty()) {
+        auto* err = createError(globalObject, ErrorCode::ERR_INVALID_STATE,
             "WebView.cdp(): no session - await navigate() first"_s);
+        RELEASE_AND_RETURN(scope,
+            JSValue::encode(JSC::JSPromise::rejectedPromise(globalObject, err)));
+    }
 
     JSValue methodArg = callFrame->argument(0);
     if (!methodArg.isString())

--- a/test/js/bun/webview/webview-chrome-ws.test.ts
+++ b/test/js/bun/webview/webview-chrome-ws.test.ts
@@ -124,7 +124,9 @@ test("cdp() rejects (not sync-throws) with ERR_INVALID_STATE before first naviga
           await p.then(
             () => { throw new Error("cdp() resolved; expected rejection"); },
             err => {
-              if (err?.code !== "ERR_INVALID_STATE" || !/session.*navigate/i.test(err?.message))
+              // Bun::ERR::INVALID_STATE (the sync-throw helper this replaced)
+              // prepends "Invalid state: " — keep message parity.
+              if (err?.code !== "ERR_INVALID_STATE" || !/^Invalid state: .*session.*navigate/i.test(err?.message))
                 throw new Error("wrong rejection: " + err?.code + " " + err?.message);
             },
           );

--- a/test/js/bun/webview/webview-chrome-ws.test.ts
+++ b/test/js/bun/webview/webview-chrome-ws.test.ts
@@ -93,6 +93,57 @@ const it = remote ? test : test.todo;
 
 const html = (h: string) => "data:text/html," + encodeURIComponent(h);
 
+// cdp() before the first navigate → no sessionId → ERR_INVALID_STATE.
+// Must REJECT, not sync-throw: this state is reached when Chrome dies
+// before the Target.createTarget → attachToTarget chain completes, and
+// recovery code commonly does `void v.cdp(...).catch(()=>{})`. A sync
+// throw escapes that .catch() and replaces the real navigate() error with
+// the misleading "await navigate() first" message.
+//
+// Runs unconditionally (plain `test`, not `it`) and in a subprocess: an
+// explicit ws:// URL makes the constructor succeed without a Chrome
+// binary (WebSocket handshake is async; the guard fires before any I/O),
+// and the subprocess keeps the bogus URL out of this file's Transport
+// singleton so the remote-Chrome `it` tests above still connect cleanly.
+test("cdp() rejects (not sync-throws) with ERR_INVALID_STATE before first navigate", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const view = new Bun.WebView({
+          backend: { type: "chrome", url: "ws://127.0.0.1:1/devtools/browser/x" },
+          width: 100,
+          height: 100,
+        });
+        try {
+          // A sync throw here escapes the enclosing try and exits non-zero
+          // — that is the regression this test guards.
+          const p = view.cdp("Page.enable");
+          if (!(p instanceof Promise)) throw new Error("cdp() did not return a Promise: " + p);
+          await p.then(
+            () => { throw new Error("cdp() resolved; expected rejection"); },
+            err => {
+              if (err?.code !== "ERR_INVALID_STATE" || !/session.*navigate/i.test(err?.message))
+                throw new Error("wrong rejection: " + err?.code + " " + err?.message);
+            },
+          );
+          console.log("OK");
+        } finally {
+          view.close();
+        }
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr.trim()).toBe("");
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+});
+
 it("connect via full ws:// URL", async () => {
   // Direct connect, no discovery. Commands queue in Transport's
   // m_wsPending until the handshake completes; navigate() resolves after.

--- a/test/js/bun/webview/webview-chrome-ws.test.ts
+++ b/test/js/bun/webview/webview-chrome-ws.test.ts
@@ -104,7 +104,7 @@ const html = (h: string) => "data:text/html," + encodeURIComponent(h);
 // explicit ws:// URL makes the constructor succeed without a Chrome
 // binary (WebSocket handshake is async; the guard fires before any I/O),
 // and the subprocess keeps the bogus URL out of this file's Transport
-// singleton so the remote-Chrome `it` tests above still connect cleanly.
+// singleton so the remote-Chrome `it` tests below still connect cleanly.
 test("cdp() rejects (not sync-throws) with ERR_INVALID_STATE before first navigate", async () => {
   await using proc = Bun.spawn({
     cmd: [

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -262,11 +262,20 @@ it("chrome: cdp() raw passthrough", async () => {
 });
 
 it("chrome: cdp() guards — before navigate and params validation", async () => {
-  // Chrome before first navigate → no sessionId → INVALID_STATE.
+  // Chrome before first navigate → no sessionId → ERR_INVALID_STATE. This
+  // rejects (not sync-throws) so `void v.cdp(...).catch(()=>{})` recovery
+  // patterns are safe when Chrome dies before the attach chain completes —
+  // a sync throw escapes .catch() and masks the original navigate() error.
   const crView = new Bun.WebView({ backend: chrome, width: 100, height: 100 });
   try {
-    expect(() => crView.cdp("Page.enable")).toThrow(/session.*navigate/i);
-    // params validation: non-object rejected before any I/O.
+    const p = crView.cdp("Page.enable");
+    expect(p).toBeInstanceOf(Promise);
+    await expect(p).rejects.toMatchObject({
+      code: "ERR_INVALID_STATE",
+      message: expect.stringMatching(/session.*navigate/i),
+    });
+    // params validation: non-object still sync-throws before any I/O —
+    // programmer error, not a state error.
     await crView.navigate(html("<body></body>"));
     expect(() => crView.cdp("Page.enable", 42 as any)).toThrow(/object/);
   } finally {

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -272,7 +272,7 @@ it("chrome: cdp() guards — before navigate and params validation", async () =>
     expect(p).toBeInstanceOf(Promise);
     await expect(p).rejects.toMatchObject({
       code: "ERR_INVALID_STATE",
-      message: expect.stringMatching(/session.*navigate/i),
+      message: expect.stringMatching(/^Invalid state: .*session.*navigate/i),
     });
     // params validation: non-object still sync-throws before any I/O —
     // programmer error, not a state error.


### PR DESCRIPTION
## What

`WebView.cdp()` is Promise-returning everywhere except its no-session precondition (`m_sessionId` empty), which was a **synchronous** `ERR_INVALID_STATE` throw. This converts that one check to a rejected Promise — same error code, same message.

## Why

The no-session state isn't a programmer error — it's reached when the Chrome subprocess dies (binary blocked by endpoint security, immediate exit, signal) before the `Target.createTarget → attachToTarget → Page.enable` chain completes. In that case `navigate()` has already rejected with `"Chrome exited"` / `"Chrome process closed the pipe"` etc., and recovery code commonly does:

```ts
} catch (err) {
  void v.cdp('Page.stopLoading').catch(() => {})   // best-effort
  surface(err)                                     // ← never reached
}
```

A sync throw escapes `.catch()`, so the recovery line replaces the real `navigate()` error with the misleading `"no session - await navigate() first"` (which reads as "you forgot to navigate" when navigate is exactly what failed).

Arg-type validation (`method` not a string, `params` not an object) stays synchronous — those are programmer errors that don't depend on external process state, consistent with the rest of the prototype.

## Testing

`test/js/bun/webview/webview-chrome.test.ts` updated:
- asserts `cdp()` before navigate returns a `Promise` instance
- `.rejects.toMatchObject({code: "ERR_INVALID_STATE", message: /session.*navigate/i})`
- params-validation case unchanged (still sync throw)

The updated test fails on a build without this change (sync throw at the `crView.cdp("Page.enable")` call site).
