### PR TITLE
process: clear exception in nextTick lazy PropertyCallback

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3913,6 +3913,7 @@ static JSValue constructMainModuleProperty(VM& vm, JSObject* processObject)
 
 JSValue Process::constructNextTickFn(JSC::VM& vm, Zig::GlobalObject* globalObject)
 {
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSNextTickQueue* nextTickQueueObject;
     if (!globalObject->m_nextTickQueue) {
         nextTickQueueObject = JSNextTickQueue::create(globalObject);
@@ -3930,6 +3931,11 @@ JSValue Process::constructNextTickFn(JSC::VM& vm, Zig::GlobalObject* globalObjec
     args.append(JSC::JSFunction::create(vm, globalObject, 1, String(), jsFunctionReportUncaughtException, ImplementationVisibility::Private));
 
     JSValue nextTickFunction = JSC::profiledCall(globalObject, ProfilingReason::API, initializer, JSC::getCallData(initializer), globalObject->globalThis(), args);
+    if (auto* exception = scope.exception()) {
+        (void)scope.tryClearException();
+        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        return jsUndefined();
+    }
     if (nextTickFunction && nextTickFunction.isObject()) {
         this->m_nextTickFunction.set(vm, this, nextTickFunction.getObject());
     }

--- a/test/js/node/process/process-nexttick.test.js
+++ b/test/js/node/process/process-nexttick.test.js
@@ -2,6 +2,7 @@
 // mess with timers, producing unreliable results. You must manually test this
 // in Node.
 import { expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 const isBun = !!process.versions.bun;
 
 it("process.nextTick", async () => {
@@ -1035,4 +1036,30 @@ it("process.nextTick and AsyncLocalStorage.enterWith don't conflict", async () =
 
   expect(call1).toBe(true);
   expect(call2).toBe(true);
+});
+
+it("lazy process.nextTick initialization near stack limit does not crash", async () => {
+  // The process.nextTick lazy PropertyCallback runs JS which can throw a stack
+  // overflow when first evaluated near the stack limit. That must not trip the
+  // EXCEPTION_ASSERT inside JSObject::get().
+  const src = `
+    let remaining = 30;
+    function f() {
+      try { f(); } catch {}
+      if (remaining-- > 0) {
+        try { new Worker("data:text/javascript,").unref(); } catch {}
+      }
+    }
+    f();
+    console.log("ok");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toContain("ok");
+  expect(proc.signalCode).toBeNull();
 });


### PR DESCRIPTION
## What does this PR do?

Fixes a debug assertion crash (`JSObjectInlines.h:102`) found by Fuzzilli.

`process.nextTick` is a `LazyPropertyCallback` that runs JS (`processObjectInternalsInitializeNextTickQueueCodeGenerator`) via `profiledCall` on first access. When that first access happens near the stack limit — e.g. `new Worker(...)` (which calls `process.emitOnNextTick` → `queueNextTick` → `get("nextTick")`) invoked immediately after a caught stack overflow — the JS call throws a `RangeError`.

JSC's `LazyPropertyCallback` / `reifyStaticProperty` / `setUpStaticFunctionSlot` path does not expect the callback to throw: it still returns `hasProperty = true` from `getPropertySlot`, which trips the `EXCEPTION_ASSERT(!scope.exception() || ... || !hasProperty)` in `JSObject::get()`.

`constructStdin`/`constructStdout`/`constructStderr` already handle this exact case by catching the exception, reporting it via `reportUncaughtExceptionAtEventLoop`, and returning `jsUndefined()`. This PR applies the same pattern to `constructNextTickFn`.

Related to #19650 (same root cause — lazy property callbacks that run JS near the stack limit). This PR fixes the `process.nextTick` instance; the `Bun.$` instance reported there is a separate callback not addressed here.

## Repro

```js
function f() {
  try { f(); } catch {}
  new Worker("data:text/javascript,");
}
f();
```

Before: `ASSERTION FAILED: !scope.exception() || vm.hasPendingTerminationException() || !hasProperty` → SIGABRT.
After: the stack overflow is reported as an uncaught exception and the process continues.

## How did you verify your code works?

- Reproduced the assertion failure with the debug build on `main`.
- Verified the assertion no longer fires with this change.
- Added a regression test in `test/js/node/process/process-nexttick.test.js` that fails on `main` (debug) and passes with this fix.
- Ran the full `process-nexttick.test.js` suite: 8/8 pass.
