### PR TITLE
module-loader: narrow TLA re-entrancy skip to dynamic-import initiator (#30651)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,11 +3,12 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-// oven-sh/WebKit main: macOS + Windows artifacts cross-compiled on Linux,
-// -lto variants built with ThinLTO (per-module summaries for cross-language
-// importing), and the Windows ICU data table filtered + per-item zstd
-// compressed (lazily decompressed via bun_icu_decompress.cpp).
-export const WEBKIT_VERSION = "09f04cd5a489b7c0b44aed255bfafce2a316eada";
+// oven-sh/WebKit#230 preview (rebased onto main 9cb85a07, the upstream
+// WebKit 24362e675175 bump): narrows the TLA re-entrancy skip to the
+// dynamic-import initiator for #30651. macOS + Windows artifacts
+// cross-compiled on Linux, -lto variants ThinLTO, Windows ICU data
+// filtered + per-item zstd compressed.
+export const WEBKIT_VERSION = "autobuild-preview-pr-230-7dea873b";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3558,8 +3558,29 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
     // The C++ module loader now extracts `with.type` into a
     // ScriptFetchParameters before calling this hook, so `parameters` is
     // already the parsed RefPtr (or null). Just forward it.
+    //
+    // Pass the sourceOrigin-derived referrer key so JSC's
+    // requestImportModule can find the initiator CyclicModuleRecord in
+    // the registry (see #30651 — the initiator is used to tell the
+    // Nitro self-deadlock apart from unrelated parallel dynamic imports
+    // of the same TLA dep). Bun keys the registry by the file-system
+    // path (or the substring after `builtin://` for builtins), not the
+    // URL — mirror the resolve() path above.
+    JSC::Identifier referrerKey;
+    auto referrerURL = sourceOrigin.url();
+    if (!referrerURL.isEmpty()) {
+        String referrerKeyString;
+        if (referrerURL.protocolIsFile())
+            referrerKeyString = referrerURL.fileSystemPath();
+        else if (referrerURL.protocol() == "builtin"_s && referrerURL.string().startsWith("builtin://"_s))
+            referrerKeyString = referrerURL.string().substring(10);
+        else
+            referrerKeyString = referrerURL.string();
+        if (!referrerKeyString.isEmpty())
+            referrerKey = JSC::Identifier::fromString(vm, referrerKeyString);
+    }
     auto result = JSC::importModule(globalObject, resolvedIdentifier,
-        JSC::Identifier(), WTF::move(parameters), nullptr);
+        referrerKey, WTF::move(parameters), nullptr);
     if (scope.exception()) [[unlikely]] {
         return JSC::JSPromise::rejectedPromiseWithCaughtException(globalObject, scope);
     }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3488,7 +3488,7 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
     auto referrerKeyFromSourceOrigin = [&]() -> JSC::Identifier {
         const auto& url = sourceOrigin.url();
         if (url.isEmpty())
-            return { };
+            return {};
         String keyString;
         if (url.protocolIsFile()) {
             keyString = url.fileSystemPath();
@@ -3504,7 +3504,7 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
             keyString = url.string();
         }
         if (keyString.isEmpty())
-            return { };
+            return {};
         return JSC::Identifier::fromString(vm, keyString);
     };
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3477,6 +3477,37 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
         }
     }
 
+    // Registry key of the module whose body is initiating this dynamic
+    // import, for the #30651 dep == initiator discriminator. Inverts
+    // Zig::toSourceOrigin — `node:fs` is stored under `node:fs` but its
+    // sourceOrigin URL is `builtin://node/fs`, so a raw `substring(10)`
+    // would yield `node/fs` and miss the registry. Query-string-loaded
+    // file modules (`import("./x.mjs?v=1")`) are still not round-trip-
+    // recoverable from sourceOrigin alone — those fall back to the
+    // coarse VM::hasPendingDynamicImport() gate on the WebKit side.
+    auto referrerKeyFromSourceOrigin = [&]() -> JSC::Identifier {
+        const auto& url = sourceOrigin.url();
+        if (url.isEmpty())
+            return { };
+        String keyString;
+        if (url.protocolIsFile()) {
+            keyString = url.fileSystemPath();
+        } else if (url.protocol() == "builtin"_s && url.string().startsWith("builtin://"_s)) {
+            auto rest = url.string().substring(10);
+            if (rest.startsWith("node/"_s))
+                keyString = makeString("node:"_s, rest.substring(5));
+            else if (rest.startsWith("bun/"_s))
+                keyString = makeString("bun:"_s, rest.substring(4));
+            else
+                keyString = WTF::move(rest);
+        } else {
+            keyString = url.string();
+        }
+        if (keyString.isEmpty())
+            return { };
+        return JSC::Identifier::fromString(vm, keyString);
+    };
+
     JSC::Identifier resolvedIdentifier;
 
     auto moduleName = moduleNameValue->value(globalObject);
@@ -3485,7 +3516,7 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
         if (auto resolution = globalObject->onLoadPlugins.resolveVirtualModule(moduleName, sourceOrigin.url().protocolIsFile() ? sourceOrigin.url().fileSystemPath() : String())) {
             resolvedIdentifier = JSC::Identifier::fromString(vm, resolution.value());
 
-            auto result = JSC::importModule(globalObject, resolvedIdentifier, JSC::Identifier(), parameters, nullptr);
+            auto result = JSC::importModule(globalObject, resolvedIdentifier, referrerKeyFromSourceOrigin(), parameters, nullptr);
             if (scope.exception()) [[unlikely]] {
                 return JSC::JSPromise::rejectedPromiseWithCaughtException(globalObject, scope);
             }
@@ -3558,29 +3589,8 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
     // The C++ module loader now extracts `with.type` into a
     // ScriptFetchParameters before calling this hook, so `parameters` is
     // already the parsed RefPtr (or null). Just forward it.
-    //
-    // Pass the sourceOrigin-derived referrer key so JSC's
-    // requestImportModule can find the initiator CyclicModuleRecord in
-    // the registry (see #30651 — the initiator is used to tell the
-    // Nitro self-deadlock apart from unrelated parallel dynamic imports
-    // of the same TLA dep). Bun keys the registry by the file-system
-    // path (or the substring after `builtin://` for builtins), not the
-    // URL — mirror the resolve() path above.
-    JSC::Identifier referrerKey;
-    auto referrerURL = sourceOrigin.url();
-    if (!referrerURL.isEmpty()) {
-        String referrerKeyString;
-        if (referrerURL.protocolIsFile())
-            referrerKeyString = referrerURL.fileSystemPath();
-        else if (referrerURL.protocol() == "builtin"_s && referrerURL.string().startsWith("builtin://"_s))
-            referrerKeyString = referrerURL.string().substring(10);
-        else
-            referrerKeyString = referrerURL.string();
-        if (!referrerKeyString.isEmpty())
-            referrerKey = JSC::Identifier::fromString(vm, referrerKeyString);
-    }
     auto result = JSC::importModule(globalObject, resolvedIdentifier,
-        referrerKey, WTF::move(parameters), nullptr);
+        referrerKeyFromSourceOrigin(), WTF::move(parameters), nullptr);
     if (scope.exception()) [[unlikely]] {
         return JSC::JSPromise::rejectedPromiseWithCaughtException(globalObject, scope);
     }

--- a/src/runtime/bake/BakeGlobalObject.cpp
+++ b/src/runtime/bake/BakeGlobalObject.cpp
@@ -14,32 +14,6 @@ extern "C" BunString BakeToWindowsPath(BunString a);
 namespace Bake {
 using namespace JSC;
 
-// Map a SourceOrigin to the registry key JSC's requestImportModule looks
-// up to resolve the initiator CyclicModuleRecord (see #30651). Mirrors the
-// logic in Zig::GlobalObject::moduleLoaderImportModule: file:// → fs path,
-// builtin:// → substring after the prefix, bake:/ → the bake key, else the
-// URL string as-is. Returns an empty Identifier on nullptr/empty origin;
-// the WebKit side falls back to the coarse VM::hasPendingDynamicImport()
-// gate in that case.
-static JSC::Identifier bakeReferrerKeyFromSourceOrigin(JSC::VM& vm, const JSC::SourceOrigin& sourceOrigin)
-{
-    if (sourceOrigin.isNull())
-        return {};
-    const auto& url = sourceOrigin.url();
-    if (url.isEmpty())
-        return {};
-    String keyString;
-    if (url.protocolIsFile())
-        keyString = url.fileSystemPath();
-    else if (url.protocol() == "builtin"_s && url.string().startsWith("builtin://"_s))
-        keyString = url.string().substring(10);
-    else
-        keyString = url.string();
-    if (keyString.isEmpty())
-        return {};
-    return JSC::Identifier::fromString(vm, keyString);
-}
-
 JSC::JSPromise*
 bakeModuleLoaderImportModule(JSC::JSGlobalObject* global,
     JSC::JSModuleLoader* moduleLoader, JSC::JSString* moduleNameValue,
@@ -51,8 +25,19 @@ bakeModuleLoaderImportModule(JSC::JSGlobalObject* global,
     WTF::String keyString = moduleNameValue->getString(global);
     if (keyString.startsWith("bake:/"_s)) {
         auto& vm = JSC::getVM(global);
+        // Pass an empty referrer here rather than plumbing the source
+        // origin through for the #30651 dep == initiator discriminator.
+        // bakeModuleLoaderResolve's behavior depends on the referrer:
+        // with a `bake:/...` referrer, BakeProdResolve is fed the
+        // specifier as a referrer-relative path and rejects `bake:/...`
+        // inputs as "Non-relative import … in production assets". An
+        // empty referrer takes the `keyView.startsWith("bake:/")` branch
+        // (see bakeModuleLoaderResolve below) which calls BakeProdResolve
+        // with `"bake:/"` as the base instead. Bake dynamic imports
+        // therefore fall back to the coarse VM::hasPendingDynamicImport()
+        // gate on the WebKit side, matching pre-#30651 behavior.
         return JSC::importModule(global, JSC::Identifier::fromString(vm, keyString),
-            bakeReferrerKeyFromSourceOrigin(vm, sourceOrigin), WTF::move(parameters), nullptr);
+            JSC::Identifier(), WTF::move(parameters), nullptr);
     }
 
     if (!sourceOrigin.isNull() && sourceOrigin.string().startsWith("bake:/"_s)) {
@@ -71,11 +56,11 @@ bakeModuleLoaderImportModule(JSC::JSGlobalObject* global,
         BunString result = BakeProdResolve(global, Bun::toString(refererString), Bun::toString(keyString));
         RETURN_IF_EXCEPTION(scope, nullptr);
 
-        // refererString is already the bake:/ registry key — pass it as-is;
-        // bakeModuleLoaderResolve keys the registry by BakeProdResolve()'s
-        // output of which refererString is already a previously-produced key.
+        // Same reasoning as the bake:/ specifier branch above — passing
+        // `refererString` here would route through BakeProdResolve again
+        // via bakeModuleLoaderResolve and throw "Non-relative import".
         return JSC::importModule(global, JSC::Identifier::fromString(vm, result.toWTFString()),
-            JSC::Identifier::fromString(vm, refererString), WTF::move(parameters), nullptr);
+            JSC::Identifier(), WTF::move(parameters), nullptr);
     }
 
     // TODO: make static cast instead of jscast

--- a/src/runtime/bake/BakeGlobalObject.cpp
+++ b/src/runtime/bake/BakeGlobalObject.cpp
@@ -23,10 +23,10 @@ using namespace JSC;
 static JSC::Identifier bakeReferrerKeyFromSourceOrigin(JSC::VM& vm, const JSC::SourceOrigin& sourceOrigin)
 {
     if (sourceOrigin.isNull())
-        return { };
+        return {};
     const auto& url = sourceOrigin.url();
     if (url.isEmpty())
-        return { };
+        return {};
     String keyString;
     if (url.protocolIsFile())
         keyString = url.fileSystemPath();
@@ -35,7 +35,7 @@ static JSC::Identifier bakeReferrerKeyFromSourceOrigin(JSC::VM& vm, const JSC::S
     else
         keyString = url.string();
     if (keyString.isEmpty())
-        return { };
+        return {};
     return JSC::Identifier::fromString(vm, keyString);
 }
 

--- a/src/runtime/bake/BakeGlobalObject.cpp
+++ b/src/runtime/bake/BakeGlobalObject.cpp
@@ -19,7 +19,8 @@ using namespace JSC;
 // logic in Zig::GlobalObject::moduleLoaderImportModule: file:// → fs path,
 // builtin:// → substring after the prefix, bake:/ → the bake key, else the
 // URL string as-is. Returns an empty Identifier on nullptr/empty origin;
-// the WebKit side falls back to the coarse pre-PR gate in that case.
+// the WebKit side falls back to the coarse VM::hasPendingDynamicImport()
+// gate in that case.
 static JSC::Identifier bakeReferrerKeyFromSourceOrigin(JSC::VM& vm, const JSC::SourceOrigin& sourceOrigin)
 {
     if (sourceOrigin.isNull())

--- a/src/runtime/bake/BakeGlobalObject.cpp
+++ b/src/runtime/bake/BakeGlobalObject.cpp
@@ -14,6 +14,31 @@ extern "C" BunString BakeToWindowsPath(BunString a);
 namespace Bake {
 using namespace JSC;
 
+// Map a SourceOrigin to the registry key JSC's requestImportModule looks
+// up to resolve the initiator CyclicModuleRecord (see #30651). Mirrors the
+// logic in Zig::GlobalObject::moduleLoaderImportModule: file:// → fs path,
+// builtin:// → substring after the prefix, bake:/ → the bake key, else the
+// URL string as-is. Returns an empty Identifier on nullptr/empty origin;
+// the WebKit side falls back to the coarse pre-PR gate in that case.
+static JSC::Identifier bakeReferrerKeyFromSourceOrigin(JSC::VM& vm, const JSC::SourceOrigin& sourceOrigin)
+{
+    if (sourceOrigin.isNull())
+        return { };
+    const auto& url = sourceOrigin.url();
+    if (url.isEmpty())
+        return { };
+    String keyString;
+    if (url.protocolIsFile())
+        keyString = url.fileSystemPath();
+    else if (url.protocol() == "builtin"_s && url.string().startsWith("builtin://"_s))
+        keyString = url.string().substring(10);
+    else
+        keyString = url.string();
+    if (keyString.isEmpty())
+        return { };
+    return JSC::Identifier::fromString(vm, keyString);
+}
+
 JSC::JSPromise*
 bakeModuleLoaderImportModule(JSC::JSGlobalObject* global,
     JSC::JSModuleLoader* moduleLoader, JSC::JSString* moduleNameValue,
@@ -26,7 +51,7 @@ bakeModuleLoaderImportModule(JSC::JSGlobalObject* global,
     if (keyString.startsWith("bake:/"_s)) {
         auto& vm = JSC::getVM(global);
         return JSC::importModule(global, JSC::Identifier::fromString(vm, keyString),
-            JSC::Identifier(), WTF::move(parameters), nullptr);
+            bakeReferrerKeyFromSourceOrigin(vm, sourceOrigin), WTF::move(parameters), nullptr);
     }
 
     if (!sourceOrigin.isNull() && sourceOrigin.string().startsWith("bake:/"_s)) {
@@ -45,8 +70,11 @@ bakeModuleLoaderImportModule(JSC::JSGlobalObject* global,
         BunString result = BakeProdResolve(global, Bun::toString(refererString), Bun::toString(keyString));
         RETURN_IF_EXCEPTION(scope, nullptr);
 
+        // refererString is already the bake:/ registry key — pass it as-is;
+        // bakeModuleLoaderResolve keys the registry by BakeProdResolve()'s
+        // output of which refererString is already a previously-produced key.
         return JSC::importModule(global, JSC::Identifier::fromString(vm, result.toWTFString()),
-            JSC::Identifier(), WTF::move(parameters), nullptr);
+            JSC::Identifier::fromString(vm, refererString), WTF::move(parameters), nullptr);
     }
 
     // TODO: make static cast instead of jscast

--- a/test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
+++ b/test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
@@ -169,10 +169,21 @@ test("static sibling import waits for a TLA dep that suspended earlier in the sa
 // the Nitro self-deadlock the skip was written for) we must still take the
 // spec wait. Discriminator: the dynamic-import initiator the DFS was launched
 // from — skip only when dep == initiator.
+//
+// Timing note: `setTimeout` is the race condition this PR fixes. The first
+// dynamic import must fully complete its DFS (tla.mjs transitions to
+// EvaluatingAsync) before the second dynamic import's Evaluate() runs. File
+// fetching in the module loader is async I/O, so purely promise-chained
+// coordination inside JS can't sequence it deterministically — we need a
+// timer to yield to the loop iteration that drains the I/O completions
+// between the two imports.
 test("parallel dynamic imports of the same TLA dep wait instead of running against TDZ bindings", async () => {
   using dir = tempDir("parallel-dynamic-tla", {
     "driver.mjs": `
       const p1 = import("./entry1.mjs");
+      // 10ms is enough for p1's fetch+link+Evaluate() to complete and
+      // leave tla.mjs parked in EvaluatingAsync (its \`await\` is on a
+      // 100ms timer that outlives this delay).
       await new Promise(r => setTimeout(r, 10));
       const p2 = import("./entry2.mjs");
       await Promise.all([p1, p2]);

--- a/test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
+++ b/test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
@@ -217,9 +217,11 @@ test("parallel dynamic imports of the same TLA dep wait instead of running again
   expect(exitCode).toBe(0);
 });
 
-// Same as above but the TLA dep is reached indirectly through different parents
-// (so neither parent is on the DFS stack when the second one visits it). Guards
-// against discriminating by "is an asyncParentModule on the stack".
+// Variant of the "static sibling import waits for a TLA dep that suspended
+// earlier in the same Evaluate()" test above — the TLA dep is reached
+// indirectly through different parents (so neither parent is on the DFS
+// stack when the second one visits it). Guards against discriminating by
+// "is an asyncParentModule on the stack".
 test("static sibling import waits for an indirectly-shared TLA dep in the same Evaluate()", async () => {
   using dir = tempDir("static-sibling-tla-indirect", {
     "root.ts": `

--- a/test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
+++ b/test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
@@ -162,6 +162,50 @@ test("static sibling import waits for a TLA dep that suspended earlier in the sa
   expect(exitCode).toBe(0);
 });
 
+// #30651: same TDZ hole as #30259 but reached through two *separate* dynamic
+// imports — the #30262 fix keys on `asyncEvaluationOrder < asyncOrderWatermark`,
+// which fires whenever the TLA dep first suspended in a prior Evaluate() pass.
+// For a parallel dynamic import that just walks into the suspended dep (not
+// the Nitro self-deadlock the skip was written for) we must still take the
+// spec wait. Discriminator: the dynamic-import initiator the DFS was launched
+// from — skip only when dep == initiator.
+test("parallel dynamic imports of the same TLA dep wait instead of running against TDZ bindings", async () => {
+  using dir = tempDir("parallel-dynamic-tla", {
+    "driver.mjs": `
+      const p1 = import("./entry1.mjs");
+      await new Promise(r => setTimeout(r, 10));
+      const p2 = import("./entry2.mjs");
+      await Promise.all([p1, p2]);
+    `,
+    "entry1.mjs": `
+      import { foo } from "./tla.mjs";
+      console.log("entry1 foo:", foo);
+    `,
+    "entry2.mjs": `
+      import { foo } from "./tla.mjs";
+      console.log("entry2 foo:", foo);
+    `,
+    "tla.mjs": `
+      await new Promise(r => setTimeout(r, 100));
+      export const foo = 123;
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "driver.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim().split("\n").sort()).toEqual(["entry1 foo: 123", "entry2 foo: 123"]);
+  expect(exitCode).toBe(0);
+});
+
 // Same as above but the TLA dep is reached indirectly through different parents
 // (so neither parent is on the DFS stack when the second one visits it). Guards
 // against discriminating by "is an asyncParentModule on the stack".


### PR DESCRIPTION
Fixes #30651. Supersedes #30639 — that PR drops the re-entrancy skip entirely, which regresses the Nitro self-deadlock tests (marked `.todo` there). This PR keeps both the deadlock avoidance and the new TDZ fix working.

Paired with [oven-sh/WebKit#230](https://github.com/oven-sh/WebKit/pull/230); `WEBKIT_VERSION` points at its preview build.

## Repro

```js
// driver.mjs
const p1 = import("./entry1.mjs");
await new Promise(r => setTimeout(r, 10));
const p2 = import("./entry2.mjs");
await Promise.all([p1, p2]);

// entry1.mjs  +  entry2.mjs (each)
import { foo } from "./tla.mjs";
console.log(foo);

// tla.mjs
await new Promise(r => setTimeout(r, 100));
export const foo = 123;
```

On `1.3.14-canary.1+314ffe307` `entry2` throws `ReferenceError: Cannot access 'foo' before initialization`; Node runs it correctly. User-reported variant: `@lexical/react` 0.44+ (#30634) and `node-llama-cpp` (#30651).

## Cause

Same TDZ hole as #30259, but reached across *two separate* dynamic imports rather than static siblings inside one `Evaluate()`. The #30262 fix added three conditions to the Bun-specific re-entrancy skip at `AbstractModuleRecord::innerModuleEvaluation` 11.c.v:

- `depWasAlreadyEvaluatingAsync`
- `asyncEvaluationOrder < asyncOrderWatermark`
- `pendingAsyncDependencies == 0`

All three fire identically for the Nitro self-deadlock (skip needed — waiting would deadlock the import's own continuation) and the cross-`Evaluate()` parallel-dynamic-import bug (skip wrong — the spec wait is what we want; the dep's await is independent of our evaluation). The watermark check was designed for same-`Evaluate()` re-entrancy; it can't distinguish cross-`Evaluate()` cases where each dynamic import gets a fresh watermark.

## Fix

Add a fourth discriminator: `dep == dynamic-import-initiator`. The initiator is the `CyclicModuleRecord` whose JS body is awaiting the current import's result. Only skip if the dep is that module.

- Nitro deadlock: target statically re-imports the initiator → match → still skip (back-compat preserved).
- Parallel dynamic imports: dep and initiator are unrelated modules → no match → spec wait fires → importer correctly blocks until the TLA dep settles post-`await`.

Plumbing (all `#if USE(BUN_JSC_ADDITIONS)`-gated; non-Bun JSC builds unchanged):
1. `JSModuleLoader::requestImportModule` resolves the referrer URL to a `CyclicModuleRecord` via the module registry.
2. `loadModule` (dynamic overload) stashes it on the freshly-created `ModuleLoadingContext`.
3. `moduleLoadTopSettled` copies it onto the `ModuleLoaderPayload` that outlives the context through the dynamic-import pipeline.
4. `dynamicImportLoadSettled` pushes it onto `VM::m_modulesAwaitingDynamicImport` (a `HashCountedSet`) immediately before the target's `evaluate()` call, and pops after.
5. `innerModuleEvaluation` 11.c.v reads `vm.isModuleAwaitingDynamicImport(cyclic)` as the fourth condition alongside the existing three.

The bun-side change (`ZigGlobalObject::moduleLoaderImportModule`) passes the `sourceOrigin` URL (converted to a file-system path, matching the module registry's key format) as the referrer to `JSC::importModule`. Previously we passed an empty `Identifier`, so the initiator was never resolvable.

## Tests

`test/js/bun/resolve/dynamic-import-tla-cycle.test.ts`:

- NEW: **parallel dynamic imports of the same TLA dep wait instead of running against TDZ bindings** — fails on `main`, passes here.
- Existing **dynamic import inside TLA whose target imports the awaiter back does not deadlock** — still passes (Nitro back-compat preserved).
- Existing **dynamic import inside TLA of a non-entry module whose target imports it back does not deadlock** — still passes.
- Existing three static-sibling tests from #30262 — still pass.

## Rebase notes

This PR tracks a paired WebKit preview (oven-sh/WebKit#230), so `WEBKIT_VERSION` has to be re-pinned whenever `main` bumps WebKit. Most rebases only conflict on that one constant. The rebase onto the upstream WebKit `24362e675175` bump (oven-sh/WebKit#251) was the one non-trivial case: upstream dropped the `JSGlobalObject*` parameter from `JSPromise::performPromiseThenWithInternalMicrotask`. The two JSC commits were cherry-picked onto the new WebKit main with one manual resolution in `JSModuleLoader.cpp::continueDynamicImport` — kept the `#if USE(BUN_JSC_ADDITIONS)` routing via `dynamicPayload` (needed so `dynamicImportLoadSettled` can recover the initiator) while adopting the new no-`globalObject` signature. Everything else auto-merged.
