### PR TITLE
Fix stack overflow when inspecting circular JSX elements

### DIFF
--- a/src/jsc/ConsoleObject.zig
+++ b/src/jsc/ConsoleObject.zig
@@ -1136,7 +1136,7 @@ pub const Formatter = struct {
 
         pub fn canHaveCircularReferences(tag: Tag) bool {
             return switch (tag) {
-                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event => true,
+                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event, .JSX => true,
                 else => false,
             };
         }

--- a/src/test_runner/pretty_format.zig
+++ b/src/test_runner/pretty_format.zig
@@ -326,7 +326,7 @@ pub const JestPrettyFormat = struct {
             }
 
             pub inline fn canHaveCircularReferences(tag: Tag) bool {
-                return tag == .Array or tag == .Object or tag == .Map or tag == .Set;
+                return tag == .Array or tag == .Object or tag == .Map or tag == .Set or tag == .JSX;
             }
 
             const Result = struct {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -316,6 +316,24 @@ it("jsx with fragment", () => {
   expect(input).toBe(output);
 });
 
+it("jsx with circular reference", () => {
+  const el = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: {} };
+  el.key = el;
+  expect(Bun.inspect(el)).toBe("<div key=[Circular] />");
+
+  const el2 = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: {} };
+  el2.props.foo = el2;
+  expect(Bun.inspect(el2)).toBe("<div foo=[Circular] />");
+
+  const el3 = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: {} };
+  el3.props.children = el3;
+  expect(Bun.inspect(el3)).toBe("<div>\n  [Circular]\n</div>");
+
+  const el4 = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: {} };
+  el4.props.children = [el4];
+  expect(Bun.inspect(el4)).toBe("<div>\n  [Circular]\n</div>");
+});
+
 it("inspect", () => {
   expect(Bun.inspect(new TypeError("what")).includes("TypeError: what")).toBe(true);
   expect(Bun.inspect("hi")).toBe('"hi"');


### PR DESCRIPTION
## What

`Bun.inspect` / `console.log` segfaulted with a stack overflow when a React element contained a reference to itself via `key`, `props`, or `children`.

```js
const el = { $$typeof: Symbol.for("react.element"), type: "div", props: {} };
el.key = el;
Bun.inspect(el); // SIGSEGV
```

## Why

The `.JSX` formatter tag was not included in `canHaveCircularReferences()`, so the visited-map and stack-depth guards were skipped. The formatter recursed into `key` / `props` / `children`, hit the same element, and looped until the native stack was exhausted.

## Fix

Add `.JSX` to `canHaveCircularReferences()` in both `ConsoleObject.zig` and `pretty_format.zig`. Circular JSX now prints `[Circular]` like other object types.

Found by Fuzzilli (fingerprint `471aa8ea6d631cd1`).