### PR TITLE
install: stop `bun add -g` from walking above the global install dir

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1599,6 +1599,10 @@ pub fn init(
                 ) {
                     Ok(f) => break 'child f,
                     Err(e) if e.get_errno() == bun_sys::E::ENOENT => {
+                        // A package.json above the global dir belongs to another project (#30658).
+                        if cli.global {
+                            break;
+                        }
                         if let Some(parent) = bun_core::dirname(this_cwd) {
                             this_cwd = strings::without_trailing_slash(parent);
                             continue;
@@ -1669,8 +1673,8 @@ pub fn init(
             ZStr::from_buf(&original_package_json_path_buf[..], new_path_len);
         let child_cwd = &original_package_json_path.as_bytes()[..this_cwd.len()];
 
-        // Check if this is a workspace; if so, use root package
-        if subcommand.should_chdir_to_root() {
+        // Check if this is a workspace; if so, use root package (never for `-g`, #28247).
+        if subcommand.should_chdir_to_root() && !cli.global {
             if !created_package_json && !no_project {
                 while let Some(parent) = bun_core::dirname(this_cwd) {
                     let parent_without_trailing_slash = strings::without_trailing_slash(parent);

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2,7 +2,16 @@ import type { BunLockFile } from "bun";
 import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { access, appendFile, copyFile, mkdir, readlink, rm, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, readdirSorted, tmpdirSync, toBeValidBin, toBeWorkspaceLink, toHaveBins } from "harness";
+import {
+  bunExe,
+  bunEnv as env,
+  readdirSorted,
+  tempDir,
+  tmpdirSync,
+  toBeValidBin,
+  toBeWorkspaceLink,
+  toHaveBins,
+} from "harness";
 import { join, relative, resolve } from "path";
 import {
   check_npm_auth_type,
@@ -2935,4 +2944,197 @@ it("bun add --trust keeps the new package when another --trust package is alread
       "b-scripted": "file:./b-scripted",
     },
   });
+});
+
+// Global installs live in <home>/.bun/install/global for the tests below. Every
+// location is pinned explicitly so BUN_INSTALL* variables from the environment
+// running the tests cannot redirect them.
+function globalInstallEnv(home: string) {
+  return {
+    ...env,
+    HOME: home,
+    BUN_INSTALL: join(home, ".bun"),
+    BUN_INSTALL_GLOBAL_DIR: join(home, ".bun", "install", "global"),
+    BUN_INSTALL_BIN: join(home, ".bun", "bin"),
+  };
+}
+
+// The global dir does not exist before the first `bun add -g`. `init` chdirs
+// into it and used to walk up looking for a package.json, so a project
+// package.json in $HOME became the "global" project: the dependency was added
+// to ~/package.json and installed into ~/node_modules. The first global add
+// must instead create <global>/package.json and install there.
+it("first `bun add -g` creates the global package.json instead of adopting ~/package.json", async () => {
+  const homeProject = JSON.stringify({ name: "home-project", private: true });
+  using home = tempDir("bun-add-global-home-project", {
+    "package.json": homeProject,
+    "pkg/package.json": JSON.stringify({ name: "pkg", version: "1.0.0" }),
+  });
+  const homeDir = String(home);
+  const globalDir = join(homeDir, ".bun", "install", "global");
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "add", "-g", `file:${join(homeDir, "pkg").replaceAll("\\", "/")}`],
+    cwd: homeDir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env: globalInstallEnv(homeDir),
+  });
+
+  const err = await stderr.text();
+  expect(err).not.toContain("error:");
+  const out = await stdout.text();
+  expect(out).toContain("installed pkg@");
+  expect(await exited).toBe(0);
+
+  expect(await file(join(globalDir, "package.json")).json()).toEqual({
+    dependencies: { pkg: expect.any(String) },
+  });
+  expect(await file(join(globalDir, "node_modules", "pkg", "package.json")).json()).toEqual({
+    name: "pkg",
+    version: "1.0.0",
+  });
+
+  // The home project gained no lockfile or node_modules, and its package.json is untouched.
+  expect(await readdirSorted(homeDir)).toEqual([".bun", "package.json", "pkg"]);
+  expect(await file(join(homeDir, "package.json")).text()).toBe(homeProject);
+});
+
+// https://github.com/oven-sh/bun/issues/30658
+// Same walk-up, different symptom: a stray package.json with an old npm v1
+// package-lock.json next to it in a parent directory (typically $HOME on
+// Windows) was adopted as the root project, and lockfile migration then failed
+// with "Please upgrade package-lock.json to lockfileVersion 2 or 3".
+it("`bun add -g` ignores package.json/package-lock.json above the global dir", async () => {
+  using home = tempDir("bun-add-global-parent-lockfile", {
+    // stray files in the parent of <home>/.bun/install/global
+    "package.json": JSON.stringify({ name: "stray-root", version: "1.0.0" }),
+    "package-lock.json": JSON.stringify({
+      name: "stray-root",
+      version: "1.0.0",
+      lockfileVersion: 1,
+      requires: true,
+      dependencies: {},
+    }),
+    ".bun": { install: { global: {} } },
+  });
+
+  const { stdout, stderr, exited } = spawn({
+    // point at an unreachable registry so we never touch the real network,
+    // but still exercise the full init/walk-up code path that used to fail.
+    cmd: [bunExe(), "add", "-g", "--registry=http://127.0.0.1:1/", "chalk"],
+    cwd: `${home}`,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env: globalInstallEnv(`${home}`),
+  });
+
+  const err = await stderr.text();
+  // the bug: the stray lockfile used to get picked up and migration failed here.
+  expect(err).not.toContain("Please upgrade package-lock.json");
+  expect(err).not.toContain("lockfileVersion");
+  await stdout.text();
+  // The install itself fails (registry is unreachable on purpose), but the
+  // failure must come after lockfile migration, not from it.
+  expect(await exited).not.toBe(0);
+
+  // And the stray root's package.json must not have been mutated.
+  expect(await file(join(`${home}`, "package.json")).text()).toBe(
+    JSON.stringify({ name: "stray-root", version: "1.0.0" }),
+  );
+});
+
+// https://github.com/oven-sh/bun/issues/28247
+// Same walk-up problem, different symptom: if a parent directory's
+// package.json defines `workspaces` (plus any `workspace:*` deps), global
+// install used to hop onto it as the workspace root and then fail to
+// resolve those workspace-scoped deps:
+// "error: Workspace dependency \"…\" not found"
+// Global installs shouldn't participate in a parent workspace at all.
+it("`bun add -g` ignores a workspaces package.json above the global dir", async () => {
+  using home = tempDir("bun-add-global-parent-workspaces", {
+    // parent package.json declares workspaces + a workspace-protocol dep
+    // that doesn't actually exist on disk, the same shape as the reports.
+    "package.json": JSON.stringify({
+      name: "stray-root",
+      version: "1.0.0",
+      workspaces: ["packages/*"],
+      dependencies: { "@scope/nonexistent": "workspace:*" },
+    }),
+    ".bun": { install: { global: {} } },
+  });
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "add", "-g", "--registry=http://127.0.0.1:1/", "chalk"],
+    cwd: `${home}`,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env: globalInstallEnv(`${home}`),
+  });
+
+  const err = await stderr.text();
+  expect(err).not.toContain("Workspace dependency");
+  // If bun touches the parent workspace at all, its deps (this one in particular)
+  // would appear in the error output. They must not.
+  expect(err).not.toContain("@scope/nonexistent");
+  // Positive check: bun must have gotten *past* init into dependency
+  // resolution (and failed there on the unreachable registry), proving the
+  // walk-up path actually ran rather than an unrelated early init failure.
+  expect(err).toContain("Resolving dependencies");
+  await stdout.text();
+  expect(await exited).not.toBe(0);
+});
+
+// https://github.com/oven-sh/bun/issues/28247
+// The case above is caught by the walk-up break, because the global dir has
+// no package.json so the walk ascends to the parent. This variant instead
+// pins the *second* guard: the global dir already has a package.json (as it
+// would after a prior `bun add -g`), so the walk-up loop stops there on its
+// first iteration and the break never fires. The only thing that keeps the
+// parent workspace from being adopted as root is the `!cli.global` gate on
+// the workspace-root hop. The parent lists the global dir as a workspace
+// member so, without the gate, the hop adopts it and its `workspace:*` dep
+// fails to resolve.
+it("`bun add -g` does not adopt a parent workspace that lists the global dir", async () => {
+  using home = tempDir("bun-add-global-parent-workspace-member", {
+    "package.json": JSON.stringify({
+      name: "stray-root",
+      version: "1.0.0",
+      workspaces: [".bun/install/global"],
+      dependencies: { "@scope/nonexistent": "workspace:*" },
+    }),
+    // the global dir already has a package.json, so the walk-up loop stops
+    // here immediately and the first guard is never exercised.
+    ".bun": { install: { global: { "package.json": JSON.stringify({ name: "g", version: "1.0.0" }) } } },
+  });
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "add", "-g", "--registry=http://127.0.0.1:1/", "chalk"],
+    cwd: `${home}`,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env: globalInstallEnv(`${home}`),
+  });
+
+  const err = await stderr.text();
+  expect(err).not.toContain("Workspace dependency");
+  expect(err).not.toContain("@scope/nonexistent");
+  // Positive check: resolution began, so init got past the workspace-root hop
+  // instead of erroring out early (which would pass the negative checks too).
+  expect(err).toContain("Resolving dependencies");
+  // The parent workspace must be left untouched, not adopted as the root.
+  expect(await file(join(`${home}`, "package.json")).text()).toBe(
+    JSON.stringify({
+      name: "stray-root",
+      version: "1.0.0",
+      workspaces: [".bun/install/global"],
+      dependencies: { "@scope/nonexistent": "workspace:*" },
+    }),
+  );
+  await stdout.text();
+  expect(await exited).not.toBe(0);
 });


### PR DESCRIPTION
### Problem
- Until the first global install has created `<global dir>/package.json`, every `-g` command operates on the nearest `package.json` above the global dir instead. With a project `package.json` in `$HOME` (the global dir defaults to `~/.bun/install/global`): `bun add -g x` adds `x` to `~/package.json` and installs into `~/node_modules`, `bun remove -g x` deletes `x` from `~/package.json`, `bun pm ls -g` lists that project. Same with `BUN_INSTALL_GLOBAL_DIR` pointing anywhere below a directory that has a `package.json`. Reproduces on 1.3.14 and current main.
- Two reported symptoms of the same walk: a stray npm v1 `package-lock.json` next to the parent `package.json` aborts with `error: Please upgrade package-lock.json to lockfileVersion 2 or 3` (#30658), and a parent `package.json` with `workspaces` makes `bun update -g` / `bun add -g` fail with `error: Workspace dependency "..." not found` (#28247).
- Cause: `PackageManager::init` (`src/install/PackageManager.rs`) does `fchdir(global_dir)` for `-g` and then runs the ordinary root discovery: the ENOENT arm of the `package.json` loop walks to the parent directory, and the `should_chdir_to_root()` block afterwards hops further up to a parent workspace that lists the found directory.
- npm, pnpm and yarn pin the global prefix and create it; none of them search upward.

### Fix
- In the ENOENT arm, `break` when `cli.global` is set instead of walking to the parent. The code after the loop already handles a missing `package.json` for installs: `bun install -g <pkg>` creates it right there, and `bun add -g` gets `MissingPackageJSON`, which `update_package_json_and_install_and_cli` answers by creating `package.json` in the cwd (still the global dir) and retrying. Commands with nothing to act on (`update -g`, `remove -g`, `pm ls -g`, `outdated -g`) now get their normal "no package.json" error instead of someone else's project.
- Skip the workspace-root hop when `cli.global` is set, so a parent `package.json` listing the global dir in `workspaces` cannot adopt it once `<global dir>/package.json` exists.
- Verified with four tests in `test/cli/install/bun-add.test.ts`, all failing on the released binary and passing with this change:
  - first `bun add -g` (a `file:` dependency, no registry) creates `<global>/package.json` and `<global>/node_modules`, and `$HOME` keeps exactly its original `package.json` with no lockfile or `node_modules` added
  - stray `package.json` + v1 `package-lock.json` above the global dir (#30658)
  - parent `package.json` with `workspaces` above the global dir (#28247)
  - parent `package.json` whose `workspaces` lists the global dir itself, with `<global>/package.json` already present; this one only passes because of the second guard
- Also ran the existing `-g` tests in `bun-install-registry.test.ts`, `bun-update.test.ts`, `bun-prune.test.ts`, `bun-add-filter.test.ts` and `bun-add-catalog.test.ts` against this build; all pass. The tests pin `BUN_INSTALL`, `BUN_INSTALL_GLOBAL_DIR`, `BUN_INSTALL_BIN` and `HOME` to the fixture so the environment running them cannot redirect the global dir.

### Background
- Global install dir: `bun add -g` installs into a fixed directory (`$BUN_INSTALL_GLOBAL_DIR`, else `$BUN_INSTALL/install/global`, else `~/.bun/install/global`) that is a regular bun project with its own `package.json`, lockfile and `node_modules`; bins are linked from there into the global bin dir. `init` implements `-g` by `fchdir`ing into that directory and then running the same code path as a local install.
- Root discovery: for a local install, `init` walks from the cwd upward to the nearest `package.json` (so `bun add` works from a subdirectory), and then looks further up for a `package.json` whose `workspaces` include the directory it found, in which case the workspace root becomes the project. Both steps are what this change disables for `-g`; the directory bun has already `fchdir`ed into is the project by definition.

Fixes #30658.
Fixes #28247.

Fixes #40683 (#30658 was closed as a duplicate of it; both are the same walk-up above the global install directory).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 12 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-add.test.ts

<!-- robobun:evidence:end -->