### PR TITLE
Fix crash in Bun.build when passing many custom conditions

### DIFF
--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1087,9 +1087,9 @@ pub const ESMConditions = struct {
         var require_condition_map = ConditionsMap.init(allocator);
         var style_condition_map = ConditionsMap.init(allocator);
 
-        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
+        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + @as(usize, @intFromBool(allow_addons)) + conditions.len);
+        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + @as(usize, @intFromBool(allow_addons)) + conditions.len);
+        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + @as(usize, @intFromBool(allow_addons)) + conditions.len);
         try style_condition_map.ensureTotalCapacity(defaults.len + 2 + conditions.len);
 
         import_condition_map.putAssumeCapacity("import", {});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -422,6 +422,17 @@ describe("Bun.build", () => {
     expect(x.logs[0].position).toEqual(null);
   });
 
+  test.concurrent("many custom conditions do not crash", async () => {
+    const dir = tempDirWithFiles("bun-build-many-conditions", {
+      "index.ts": `export const a = 1;`,
+    });
+    const x = await Bun.build({
+      entrypoints: [join(dir, "index.ts")],
+      conditions: ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p"],
+    });
+    expect(x.success).toBe(true);
+  });
+
   test.concurrent("warnings do not fail a build", async () => {
     const x = await Bun.build({
       entrypoints: [join(import.meta.dir, "./fixtures/jsx-warning/index.jsx")],


### PR DESCRIPTION
## What does this PR do?

Fixes a debug assertion / capacity underflow in `ESMConditions.init` triggered by passing several custom `conditions` to `Bun.build()`.

The capacity reservation used:

```zig
defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len
```

which Zig parses as:

```zig
defaults.len + 2 + (if (allow_addons) 1 else (0 + conditions.len))
```

When `allow_addons` is `true` (the default), `conditions.len` was never counted toward the reserved capacity, so the subsequent `putAssumeCapacity` calls overflowed the map once a handful of custom conditions were supplied.

Replaced the ternary with `@intFromBool` to avoid the precedence footgun.

## How did you verify your code works?

Repro that panics on `main` and passes with this change:

```js
await Bun.build({
  conditions: ["a", "b", "c", "d", "e", "f", "g"],
  entrypoints: ["./index.ts"],
});
```

Added a regression test in `test/bundler/bun-build-api.test.ts`.

Found by Fuzzilli (fingerprint `4b17c3a7de281a5f`).