### PR TITLE
fix(tls): handle bracketed IPv6 hostnames in checkServerIdentity

### DIFF
--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -368,9 +368,12 @@ function checkServerIdentity(hostname, cert) {
   let reason = "Unknown reason";
 
   hostname = unfqdn(hostname); // Remove trailing dot for error messages.
-  if (net.isIP(hostname)) {
-    valid = ArrayPrototypeIncludes.$call(ips, canonicalizeIP(hostname));
-    if (!valid) reason = `IP: ${hostname} is not in the cert's list: ` + ArrayPrototypeJoin.$call(ips, ", ");
+  // Strip IPv6 literal brackets before IP check — `net.isIP("[::1]")` returns 0
+  // because the brackets are not part of the address.
+  const unbracketed = RegExpPrototypeSymbolReplace.$call(/^\[|\]$/g, hostname, "");
+  if (net.isIP(unbracketed)) {
+    valid = ArrayPrototypeIncludes.$call(ips, canonicalizeIP(unbracketed));
+    if (!valid) reason = `IP: ${unbracketed} is not in the cert's list: ` + ArrayPrototypeJoin.$call(ips, ", ");
   } else if (dnsNames.length > 0 || subject?.CN) {
     const hostParts = splitHost(hostname);
     const wildcard = pattern => check(hostParts, pattern, true);

--- a/test/js/node/test/parallel/test-tls-check-server-identity.js
+++ b/test/js/node/test/parallel/test-tls-check-server-identity.js
@@ -305,6 +305,40 @@ const tests = [
     },
     error: 'IP: 127.0.0.1 is not in the cert\'s list: '
   },
+  // IPv6 addresses
+  {
+    host: '::1', cert: {
+      subjectaltname: 'IP Address:::1',
+      subject: {}
+    }
+  },
+  {
+    host: '[::1]', cert: {
+      subjectaltname: 'IP Address:::1',
+      subject: {}
+    }
+  },
+  {
+    host: '[2001:DB8::1]', cert: {
+      subjectaltname: 'IP Address:2001:DB8::1',
+      subject: {}
+    }
+  },
+  {
+    host: '[2001:DB8::2]', cert: {
+      subjectaltname: 'IP Address:2001:DB8::1',
+      subject: {}
+    },
+    error: 'IP: 2001:DB8::2 is not in the cert\'s list: ' +
+           '2001:db8::1'
+  },
+  {
+    host: '[::1]', cert: {
+      subjectaltname: 'DNS:a.com',
+      subject: {}
+    },
+    error: 'IP: ::1 is not in the cert\'s list: '
+  },
   {
     host: 'localhost', cert: {
       subjectaltname: 'DNS:a.com',


### PR DESCRIPTION
Strip IPv6 literal brackets before net.isIP() check, since net.isIP("[::1]") returns 0. The brackets are a URL convention, not part of the actual address, so they must be removed before IP validation and matching.

### What does this PR do?
Fixes `tls.checkServerIdentity` rejecting valid IPv6 hostnames in bracket form like `[::1]` or `[2001:db8::1]`. The brackets are a URL convention for IPv6 literals, not part of the actual IP address. Previously, `net.isIP("[::1]")` returned `0` (not an IP), causing the function to incorrectly treat it as a DNS name and always fail validation.

### How did you verified your code works?
- Stripped-bracket hostnames now pass `net.isIP()` correctly: `[::1]` → `::1` → `isIP=6`
- All 42 existing test cases in `test-tls-check-server-identity.js` continue to pass
- Added 6 new IPv6 test cases covering: bare `::1`, bracketed `[::1]`, uppercase `[2001:DB8::1]`, mismatched addresses, and bracketed IP against DNS-only SAN

