### PR TITLE
Fix crash in Bun.openInEditor when options is not an object

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -958,7 +958,7 @@ fn open_in_editor(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResu
     // this function, so every JS-visible coercion must finish before the
     // EDITOR_CONTEXT borrow below is taken (re-entry while borrowed panics).
     if let Some(opts) = arguments.next_eat() {
-        if !opts.is_undefined_or_null() {
+        if opts.is_object() {
             if let Some(editor_val) = opts.get_truthy(global_this, "editor")? {
                 editor_name = Some(editor_val.to_slice(global_this)?);
             }
@@ -970,6 +970,10 @@ fn open_in_editor(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResu
             if let Some(column_) = opts.get_truthy(global_this, "column")? {
                 column = Some(column_.to_slice(global_this)?);
             }
+        } else if !opts.is_undefined_or_null() {
+            return Err(
+                global_this.throw_invalid_arguments(format_args!("Expected options to be an object"))
+            );
         }
     }
 

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -971,9 +971,8 @@ fn open_in_editor(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResu
                 column = Some(column_.to_slice(global_this)?);
             }
         } else if !opts.is_undefined_or_null() {
-            return Err(
-                global_this.throw_invalid_arguments(format_args!("Expected options to be an object"))
-            );
+            return Err(global_this
+                .throw_invalid_arguments(format_args!("Expected options to be an object")));
         }
     }
 

--- a/test/js/bun/util/openInEditor.test.ts
+++ b/test/js/bun/util/openInEditor.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+
+describe("Bun.openInEditor", () => {
+  test.each([536870888, "str", true, 1n, Symbol()])(
+    "throws TypeError when options is a non-object primitive: %p",
+    value => {
+      expect(() => Bun.openInEditor("", value as any)).toThrow(
+        expect.objectContaining({
+          name: "TypeError",
+          code: "ERR_INVALID_ARG_TYPE",
+        }),
+      );
+    },
+  );
+
+  test.each([undefined, null])("does not throw options-type error when options is %p", value => {
+    let err: any;
+    try {
+      // empty path ensures we throw "No file path specified" (or "Failed to auto-detect editor")
+      // before ever spawning a real editor process
+      Bun.openInEditor("", value as any);
+    } catch (e: any) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect(err.code).not.toBe("ERR_INVALID_ARG_TYPE");
+  });
+});

--- a/test/js/bun/util/openInEditor.test.ts
+++ b/test/js/bun/util/openInEditor.test.ts
@@ -23,6 +23,7 @@ describe("Bun.openInEditor", () => {
       err = e;
     }
     expect(err).toBeDefined();
+    expect(err.message).toMatch(/^(No file path specified|Failed to auto-detect editor)$/);
     expect(err.code).not.toBe("ERR_INVALID_ARG_TYPE");
   });
 });


### PR DESCRIPTION
## What

`Bun.openInEditor(path, options)` crashed with a debug assertion when `options` was a primitive value (number, string, boolean, bigint, symbol) instead of an object.

```js
Bun.openInEditor({}, 536870888);
// panic(main thread): reached unreachable code
// debugAssert at JSValue.get (target.isObject())
```

## Why

`open_in_editor` in `src/runtime/api/BunObject.rs` checked `!opts.is_undefined_or_null()` before calling `opts.get_truthy()`, but `get_truthy` asserts the target is an object. Primitives like numbers pass the null check and fail the object assertion.

## Fix

Gate the option reads on `opts.is_object()` and throw `ERR_INVALID_ARG_TYPE` for any other non-nullish value, matching the pattern `Bun.mmap` already uses in the same file. `undefined` and `null` still fall through as before.

## Test

`test/js/bun/util/openInEditor.test.ts` passes an empty path so every case throws before an editor could be spawned. Fails on the baked release bun (5 of 7), passes with this change.

## Rebase notes

Originally fixed in `BunObject.zig` with a matching port in `BunObject.rs`. Main has since dropped the Zig file and refactored `open_in_editor` to hoist option coercion out of the `EDITOR_CONTEXT` borrow, so the branch was rebuilt on top of current main as a single commit; the change itself is unchanged, it just lives at the new location of the `opts` check.

Found by Fuzzilli (fingerprint `cb07f4d9d404f6d0`).
