### PR TITLE
Fix Transpiler.transformSync crash on empty source with minify.identifiers

### DIFF
--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -1577,6 +1577,10 @@ impl JSTranspiler {
             return Err(global.throw_value(log_ref.to_js(global, "Parse error")?));
         }
 
+        if parse_result.empty {
+            return Ok(JscZigString::EMPTY.to_js(global));
+        }
+
         let mut buffer_writer = self.buffer_writer.replace(None).unwrap_or_else(|| {
             let mut writer = JSPrinter::BufferWriter::init();
             bun_core::handle_oom(writer.buffer.grow_if_needed(code.len()));

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1703,6 +1703,33 @@ export default <>hi</>
     expect(exitCode).toBe(0);
   });
 
+  it("transformSync with minify.identifiers does not crash on empty source", async () => {
+    // An empty/whitespace-only source produces an empty AST with no symbol table; with
+    // minify.identifiers the printer used to look up module_ref/exports_ref and crash.
+    // Run in a subprocess so a crash surfaces as a test failure instead of taking down
+    // the test runner.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const t = new Bun.Transpiler({ minify: { identifiers: true } });
+          for (const src of ["", " ", "\\n\\t"]) {
+            if (t.transformSync(src) !== "") throw new Error("expected empty output for " + JSON.stringify(src));
+          }
+          process.stdout.write("ok");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("ok");
+    expect(exitCode).toBe(0);
+  });
+
   it("JSX keys", () => {
     var bun = new Bun.Transpiler({
       loader: "jsx",


### PR DESCRIPTION
### What

`Bun.Transpiler#transformSync` panicked when the input source was empty (or all whitespace) and `minify.identifiers` was enabled.

### Repro

```js
const t = new Bun.Transpiler({ minify: { identifiers: true } });
t.transformSync("");
// panic(main thread): reached unreachable code
//   at Symbol.Map.get → BabyList.mut → bun.assert (index < len)
```

### Root cause

`transpiler.parse()` short-circuits on empty / whitespace-only input, returning a `ParseResult{ .empty = true, .ast = js_ast.Ast.empty }`. The empty AST has `module_ref = Ref.None` (`source_index = 0`, `inner_index = 0`, `tag = .invalid`) and no symbols.

When `minify_identifiers` is on, `js_printer.printAst` calls `symbols.get(tree.module_ref)` for each of `module_ref`/`exports_ref`/`require_ref` so it can mark them as must-not-rename. `Symbol.Map.get` only rejects refs where `sourceIndex() == maxInt(Int)` or `.source_contents_slice`, so `Ref.None` falls through to `symbols_for_source.at(0).mut(0)` — hits `bun.assert(index < this.len)` because the symbol list is empty.

The async `transform` path already guards this at `JSTranspiler.zig:531` with an early-return when `parse_result.empty`. `transformSync` was missing the same guard.

### Fix

Mirror the async path: short-circuit with an empty string when `parse_result.empty` is true, before calling `transpiler.print`.