### PR TITLE
fetch: strip IPv6 brackets before TLS cert verification

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1197,11 +1197,8 @@ fn unregister_abort_tracker_for_socket(socket: uws::InternalSocket) {
 /// Returns the hostname to use for TLS SNI and certificate verification.
 /// Priority: tls_props.server_name > client.url.hostname. The Host request
 /// header is an HTTP field only and never selects the TLS peer identity.
-/// IPv6 literals have their surrounding brackets stripped (e.g. "[::1]" -> "::1")
-/// so downstream consumers (boringssl::check_x509_server_identity, SNI's
-/// is_ip_address check, and any user-supplied checkServerIdentity callback) see
-/// the bare address. This mirrors Node.js, which strips brackets in
-/// urlToHttpOptions before the hostname reaches tls.checkServerIdentity.
+/// IPv6 brackets are stripped ("[::1]" -> "::1") so is_ip_address and
+/// checkServerIdentity see the bare address, like Node's urlToHttpOptions.
 pub(crate) fn get_tls_hostname<'c>(client: &'c HTTPClient<'_>, allow_proxy_url: bool) -> &'c [u8] {
     if allow_proxy_url {
         if let Some(proxy) = &client.http_proxy {
@@ -1225,8 +1222,7 @@ pub(crate) fn get_tls_hostname<'c>(client: &'c HTTPClient<'_>, allow_proxy_url: 
     strip_ipv6_brackets(client.url.hostname)
 }
 
-/// Strips surrounding `[` `]` from an IPv6 literal, e.g. "[::1]" -> "::1".
-/// Leaves non-bracketed hostnames unchanged.
+/// "[::1]" -> "::1"; non-bracketed hostnames pass through unchanged.
 fn strip_ipv6_brackets(host: &[u8]) -> &[u8] {
     if host.len() >= 2 && host[0] == b'[' && host[host.len() - 1] == b']' {
         &host[1..host.len() - 1]

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2742,7 +2742,7 @@ impl<'a> HTTPClient<'a> {
                     if let Some(ctx) = h3_ctx {
                         if !h3::ClientContext::as_mut(ctx).connect(
                             self,
-                            self.url.hostname,
+                            strip_ipv6_brackets(self.url.hostname),
                             alt_port,
                         ) {
                             self.fail(crate::Error::ConnectionRefused);
@@ -2800,7 +2800,7 @@ impl<'a> HTTPClient<'a> {
             };
             if !h3::ClientContext::as_mut(ctx).connect(
                 self,
-                self.url.hostname,
+                strip_ipv6_brackets(self.url.hostname),
                 self.url.get_port_auto(),
             ) {
                 self.fail(crate::Error::ConnectionRefused);

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1197,10 +1197,15 @@ fn unregister_abort_tracker_for_socket(socket: uws::InternalSocket) {
 /// Returns the hostname to use for TLS SNI and certificate verification.
 /// Priority: tls_props.server_name > client.url.hostname. The Host request
 /// header is an HTTP field only and never selects the TLS peer identity.
+/// IPv6 literals have their surrounding brackets stripped (e.g. "[::1]" -> "::1")
+/// so downstream consumers (boringssl::check_x509_server_identity, SNI's
+/// is_ip_address check, and any user-supplied checkServerIdentity callback) see
+/// the bare address. This mirrors Node.js, which strips brackets in
+/// urlToHttpOptions before the hostname reaches tls.checkServerIdentity.
 pub(crate) fn get_tls_hostname<'c>(client: &'c HTTPClient<'_>, allow_proxy_url: bool) -> &'c [u8] {
     if allow_proxy_url {
         if let Some(proxy) = &client.http_proxy {
-            return proxy.hostname;
+            return strip_ipv6_brackets(proxy.hostname);
         }
     }
     // Prefer the explicit TLS server_name (e.g. from Node.js servername option)
@@ -1213,11 +1218,21 @@ pub(crate) fn get_tls_hostname<'c>(client: &'c HTTPClient<'_>, allow_proxy_url: 
             // `client.tls_props`) without a `(ptr,len)` round-trip.
             let sn_slice = unsafe { bun_core::ffi::cstr(sn) }.to_bytes();
             if !sn_slice.is_empty() {
-                return sn_slice;
+                return strip_ipv6_brackets(sn_slice);
             }
         }
     }
-    client.url.hostname
+    strip_ipv6_brackets(client.url.hostname)
+}
+
+/// Strips surrounding `[` `]` from an IPv6 literal, e.g. "[::1]" -> "::1".
+/// Leaves non-bracketed hostnames unchanged.
+fn strip_ipv6_brackets(host: &[u8]) -> &[u8] {
+    if host.len() >= 2 && host[0] == b'[' && host[host.len() - 1] == b']' {
+        &host[1..host.len() - 1]
+    } else {
+        host
+    }
 }
 
 // ── support types ───────────────────────────────────────────────────────

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1220,13 +1220,17 @@ pub(crate) fn get_tls_hostname<'c>(client: &'c HTTPClient<'_>, allow_proxy_url: 
     strip_ipv6_brackets(client.url.hostname)
 }
 
-/// "[::1]" -> "::1"; non-bracketed hostnames pass through unchanged.
+/// "[::1]" -> "::1". Brackets stay on anything that is not an IPv6 literal
+/// ("[example.com]" as an explicit server_name must keep failing validation
+/// verbatim, as it does in Node.js).
 pub fn strip_ipv6_brackets(host: &[u8]) -> &[u8] {
     if host.len() >= 2 && host[0] == b'[' && host[host.len() - 1] == b']' {
-        &host[1..host.len() - 1]
-    } else {
-        host
+        let inner = &host[1..host.len() - 1];
+        if bun_core::ip_address::is_ipv6_address(inner) {
+            return inner;
+        }
     }
+    host
 }
 
 // ── support types ───────────────────────────────────────────────────────

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1221,7 +1221,7 @@ pub(crate) fn get_tls_hostname<'c>(client: &'c HTTPClient<'_>, allow_proxy_url: 
 }
 
 /// "[::1]" -> "::1"; non-bracketed hostnames pass through unchanged.
-fn strip_ipv6_brackets(host: &[u8]) -> &[u8] {
+pub fn strip_ipv6_brackets(host: &[u8]) -> &[u8] {
     if host.len() >= 2 && host[0] == b'[' && host[host.len() - 1] == b']' {
         &host[1..host.len() - 1]
     } else {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1220,9 +1220,7 @@ pub(crate) fn get_tls_hostname<'c>(client: &'c HTTPClient<'_>, allow_proxy_url: 
     strip_ipv6_brackets(client.url.hostname)
 }
 
-/// "[::1]" -> "::1". Brackets stay on anything that is not an IPv6 literal
-/// ("[example.com]" as an explicit server_name must keep failing validation
-/// verbatim, as it does in Node.js).
+/// "[::1]" -> "::1"; non-IPv6 values like "[example.com]" pass through verbatim, as in Node.
 pub fn strip_ipv6_brackets(host: &[u8]) -> &[u8] {
     if host.len() >= 2 && host[0] == b'[' && host[host.len() - 1] == b']' {
         let inner = &host[1..host.len() - 1];

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1197,8 +1197,6 @@ fn unregister_abort_tracker_for_socket(socket: uws::InternalSocket) {
 /// Returns the hostname to use for TLS SNI and certificate verification.
 /// Priority: tls_props.server_name > client.url.hostname. The Host request
 /// header is an HTTP field only and never selects the TLS peer identity.
-/// IPv6 brackets are stripped ("[::1]" -> "::1") so is_ip_address and
-/// checkServerIdentity see the bare address, like Node's urlToHttpOptions.
 pub(crate) fn get_tls_hostname<'c>(client: &'c HTTPClient<'_>, allow_proxy_url: bool) -> &'c [u8] {
     if allow_proxy_url {
         if let Some(proxy) = &client.http_proxy {

--- a/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
+++ b/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
@@ -149,7 +149,9 @@ impl WebSocketProxyTunnel {
             wrapper: OnceCell::new(),
             socket,
             write_buffer: JsCell::new(StreamBuffer::default()),
-            sni_hostname: Some(Box::<[u8]>::from(bun_http::strip_ipv6_brackets(sni_hostname))),
+            sni_hostname: Some(Box::<[u8]>::from(bun_http::strip_ipv6_brackets(
+                sni_hostname,
+            ))),
             reject_unauthorized,
         })
     }

--- a/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
+++ b/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
@@ -149,7 +149,7 @@ impl WebSocketProxyTunnel {
             wrapper: OnceCell::new(),
             socket,
             write_buffer: JsCell::new(StreamBuffer::default()),
-            sni_hostname: Some(Box::<[u8]>::from(sni_hostname)),
+            sni_hostname: Some(Box::<[u8]>::from(bun_http::strip_ipv6_brackets(sni_hostname))),
             reject_unauthorized,
         })
     }

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -417,7 +417,9 @@ where
                 // a specific certificate name.
                 if !host_slice.slice().is_empty() {
                     this.hostname
-                        .set(ZBox::from_bytes(bun_http::strip_ipv6_brackets(host_slice.slice())));
+                        .set(ZBox::from_bytes(bun_http::strip_ipv6_brackets(
+                            host_slice.slice(),
+                        )));
                 }
             }
 

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -452,7 +452,9 @@ where
             // not the wss:// target.
             if !display_host.is_empty() {
                 this.hostname
-                    .set(ZBox::from_bytes(bun_http::strip_ipv6_brackets(display_host)));
+                    .set(ZBox::from_bytes(bun_http::strip_ipv6_brackets(
+                        display_host,
+                    )));
             }
         }
 

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -416,7 +416,8 @@ where
                 // in the URL (wss+unix://name/path) to verify against
                 // a specific certificate name.
                 if !host_slice.slice().is_empty() {
-                    this.hostname.set(ZBox::from_bytes(host_slice.slice()));
+                    this.hostname
+                        .set(ZBox::from_bytes(bun_http::strip_ipv6_brackets(host_slice.slice())));
                 }
             }
 
@@ -448,7 +449,8 @@ where
             // dialed. For HTTPS proxy connections, that's the proxy host,
             // not the wss:// target.
             if !display_host.is_empty() {
-                this.hostname.set(ZBox::from_bytes(display_host));
+                this.hostname
+                    .set(ZBox::from_bytes(bun_http::strip_ipv6_brackets(display_host)));
             }
         }
 

--- a/test/js/web/fetch/fetch.tls.ipv6.test.ts
+++ b/test/js/web/fetch/fetch.tls.ipv6.test.ts
@@ -1,0 +1,94 @@
+// Regression test for https://github.com/oven-sh/bun/issues/30668
+//
+// The URL parser keeps the surrounding `[`/`]` on IPv6 hostnames. That bracketed
+// form must NOT leak into TLS certificate verification:
+//   - strings::is_ip_address("[::1]") is false, so the native fast path would
+//     take the DNS-name branch and skip the IP-SAN match on the cert.
+//   - node:tls.checkServerIdentity uses net.isIP("[::1]") === 0 and likewise
+//     falls through to CN matching and emits ERR_TLS_CERT_ALTNAME_INVALID.
+//
+// Node.js strips brackets in urlToHttpOptions before either verification path
+// runs. get_tls_hostname in src/http/lib.rs now mirrors that contract so every
+// TLS consumer (native cert check, SNI's is_ip_address check, and the
+// user-supplied checkServerIdentity callback) sees the bare address `::1`.
+//
+// This test lives in its own file rather than fetch.tls.test.ts because the
+// subprocess approach is sensitive to environment setup (HTTP_PROXY,
+// NO_PROXY) and we want a clean top-level env rather than sharing one with
+// other concurrent tests in that file.
+
+import { expect, it } from "bun:test";
+import { bunEnv, bunExe, isIPv6, tls as validTls } from "harness";
+
+// Skipped on Buildkite Linux — those AWS instances don't have IPv6 set up
+// (see `isIPv6` in harness.ts). Matches the gating pattern already used by
+// the directly analogous valkey-tls-verify.test.ts:177.
+it.skipIf(!isIPv6())("fetch with IPv6 literal hostname verifies the certificate", async () => {
+  using server = Bun.serve({
+    port: 0,
+    tls: validTls,
+    fetch() {
+      return new Response("Hello World");
+    },
+  });
+  const port = server.port;
+
+  // Drop HTTP_PROXY/HTTPS_PROXY so the container-level egress proxy doesn't
+  // intercept a request to [::1] (NO_PROXY doesn't match the bracketed form
+  // in some fetch paths).
+  const { HTTP_PROXY, HTTPS_PROXY, http_proxy, https_proxy, ...cleanEnv } = bunEnv;
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const tls = require("node:tls");
+        const cert = ${JSON.stringify(validTls.cert)};
+        const url = "https://[::1]:${port}/";
+        // Native fast path — no user-supplied checkServerIdentity. Native
+        // check_x509_server_identity must see "::1" (not "[::1]") so that
+        // strings::is_ip_address() picks the IP-SAN branch.
+        {
+          const res = await fetch(url, {
+            keepalive: false,
+            tls: { ca: cert, rejectUnauthorized: true },
+          });
+          console.log("native:", await res.text());
+        }
+        // User-supplied checkServerIdentity path — the hostname handed to
+        // the callback must be bracket-stripped so that
+        // node:tls.checkServerIdentity (net.isIP) accepts it, matching
+        // Node.js's urlToHttpOptions behavior.
+        {
+          let observed;
+          const res = await fetch(url, {
+            keepalive: false,
+            tls: {
+              ca: cert,
+              rejectUnauthorized: true,
+              checkServerIdentity(hostname, cert) {
+                observed = hostname;
+                return tls.checkServerIdentity(hostname, cert);
+              },
+            },
+          });
+          console.log("callback hostname:", observed);
+          console.log("js:", await res.text());
+        }
+      `,
+    ],
+    env: cleanEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  // Asserting stdout/stderr before exitCode produces a more useful failure
+  // message when the subprocess crashes unexpectedly.
+  expect(stdout).toBe("native: Hello World\ncallback hostname: ::1\njs: Hello World\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/web/fetch/fetch.tls.ipv6.test.ts
+++ b/test/js/web/fetch/fetch.tls.ipv6.test.ts
@@ -81,11 +81,7 @@ it.skipIf(!isIPv6())("fetch with IPv6 literal hostname verifies the certificate"
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   // Asserting stdout/stderr before exitCode produces a more useful failure
   // message when the subprocess crashes unexpectedly.
   expect(stdout).toBe("native: Hello World\ncallback hostname: ::1\njs: Hello World\n");

--- a/test/js/web/fetch/fetch.tls.ipv6.test.ts
+++ b/test/js/web/fetch/fetch.tls.ipv6.test.ts
@@ -12,10 +12,8 @@
 // TLS consumer (native cert check, SNI's is_ip_address check, and the
 // user-supplied checkServerIdentity callback) sees the bare address `::1`.
 //
-// This test lives in its own file rather than fetch.tls.test.ts because the
-// subprocess approach is sensitive to environment setup (HTTP_PROXY,
-// NO_PROXY) and we want a clean top-level env rather than sharing one with
-// other concurrent tests in that file.
+// A standalone file for this single TLS-verification concern, following the
+// fetch.tls.wildcard.test.ts precedent.
 
 import { expect, it } from "bun:test";
 import { bunEnv, bunExe, isIPv6, tls as validTls } from "harness";
@@ -26,6 +24,7 @@ import { bunEnv, bunExe, isIPv6, tls as validTls } from "harness";
 it.skipIf(!isIPv6())("fetch with IPv6 literal hostname verifies the certificate", async () => {
   using server = Bun.serve({
     port: 0,
+    hostname: "::1",
     tls: validTls,
     fetch() {
       return new Response("Hello World");
@@ -33,10 +32,16 @@ it.skipIf(!isIPv6())("fetch with IPv6 literal hostname verifies the certificate"
   });
   const port = server.port;
 
-  // Drop HTTP_PROXY/HTTPS_PROXY so the container-level egress proxy doesn't
-  // intercept a request to [::1] (NO_PROXY doesn't match the bracketed form
-  // in some fetch paths).
-  const { HTTP_PROXY, HTTPS_PROXY, http_proxy, https_proxy, ...cleanEnv } = bunEnv;
+  // Drop HTTP_PROXY/HTTPS_PROXY so an egress proxy doesn't intercept a
+  // request to [::1] (NO_PROXY doesn't match the bracketed form in some
+  // fetch paths).
+  const cleanEnv = {
+    ...bunEnv,
+    HTTP_PROXY: undefined,
+    HTTPS_PROXY: undefined,
+    http_proxy: undefined,
+    https_proxy: undefined,
+  };
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),

--- a/test/js/web/websocket/websocket.tls.ipv6.test.ts
+++ b/test/js/web/websocket/websocket.tls.ipv6.test.ts
@@ -1,0 +1,66 @@
+// Regression test for the WebSocket side of
+// https://github.com/oven-sh/bun/issues/30668: the client stored the
+// bracketed URL host ("[::1]"), so check_server_identity took the DNS-name
+// branch and never matched the cert's IP SAN, and the SNI is_ip_address gate
+// sent the bracketed literal as servername. The hostname is now stored
+// bracket-stripped (WebSocketUpgradeClient.rs, WebSocketProxyTunnel.rs).
+//
+// A standalone file for this single TLS-verification concern, following the
+// fetch.tls.ipv6.test.ts precedent.
+
+import { expect, it } from "bun:test";
+import { bunEnv, bunExe, isIPv6, tls as validTls } from "harness";
+
+// Skipped on Buildkite Linux — those AWS instances don't have IPv6 set up
+// (see `isIPv6` in harness.ts).
+it.skipIf(!isIPv6())("wss to an IPv6 literal verifies the certificate", async () => {
+  using server = Bun.serve({
+    port: 0,
+    hostname: "::1",
+    tls: validTls,
+    fetch(req, server) {
+      if (server.upgrade(req)) return;
+      return new Response("Upgrade failed", { status: 500 });
+    },
+    websocket: {
+      open(ws) {
+        ws.send("hello");
+      },
+      message() {},
+    },
+  });
+  const port = server.port;
+
+  // Subprocess so proxy env vars can't reroute the wss connection.
+  const cleanEnv = {
+    ...bunEnv,
+    HTTP_PROXY: undefined,
+    HTTPS_PROXY: undefined,
+    http_proxy: undefined,
+    https_proxy: undefined,
+  };
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const cert = ${JSON.stringify(validTls.cert)};
+        const ws = new WebSocket("wss://[::1]:${port}/", {
+          tls: { ca: cert, rejectUnauthorized: true },
+        });
+        const { promise, resolve, reject } = Promise.withResolvers();
+        ws.onmessage = e => resolve(e.data);
+        ws.onclose = e => reject(new Error("closed: " + e.code + " " + e.reason));
+        console.log("message:", await promise);
+        ws.close();
+      `,
+    ],
+    env: cleanEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("message: hello\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #30668

### Problem

- `fetch('https://[::1]:PORT/')` with `rejectUnauthorized: true` fails with `ERR_TLS_CERT_ALTNAME_INVALID` even when the cert carries an `IP:::1` SAN. A user-supplied `checkServerIdentity` callback receives the bracketed `"[::1]"`, so forwarding it to `node:tls.checkServerIdentity` also rejects (`net.isIP("[::1]") === 0` falls through to CN matching).
- The URL parser keeps the surrounding `[` `]` on IPv6 hostnames. That form reached both TLS verification paths: the native fast path (`check_x509_server_identity` gates on `is_ip_address`, which rejects brackets and takes the DNS-name branch) and the user callback.

### Fix

- Add `strip_ipv6_brackets` and apply it to every return path of `get_tls_hostname` in `src/http/lib.rs` (proxy hostname, `tls_props.server_name`, `url.hostname`).
- Node.js strips brackets in `urlToHttpOptions` before the hostname reaches `tls.checkServerIdentity`. This mirrors that contract at the single chokepoint, so the native cert check, the SNI `is_ip_address` check, and the user callback all see the bare `::1`. Since #35886, the proxy-tunnel inner handshake also routes through `get_tls_hostname`, so it is covered too.
- The WebSocket client has the same class of bug: it stored the bracketed URL host for its own verification and SNI. Store it bracket-stripped at the two set sites in `WebSocketUpgradeClient.rs` and in the proxy tunnel's `sni_hostname`, reusing the same helper (now `pub`).
- The HTTP/3 client also passed the bracketed `url.hostname` straight to `ClientContext::connect`, which uses it as both the QUIC dial host and the SNI/verification name. Both call sites now strip brackets.
- Non-bracketed hostnames pass through unchanged. DNS names and IPv4 literals are unaffected.
- Verified: `test/js/web/fetch/fetch.tls.ipv6.test.ts` exercises both fetch paths end to end against `https://[::1]:port/` and asserts the callback receives `"::1"`. `test/js/web/websocket/websocket.tls.ipv6.test.ts` does the same for `wss://[::1]:port/`. Both fail without the fix and pass with it. `fetch.tls.test.ts` and `fetch.tls.wildcard.test.ts` still pass.

### Background

- `get_tls_hostname` is the one place the HTTP client picks the name used for SNI and certificate verification. Every TLS consumer of fetch reads it.
- A certificate matches an IP literal through its IP SAN entries, not its DNS entries. The checker picks the IP branch only when `is_ip_address(hostname)` is true, which requires the bare address form.
- The test is gated on `isIPv6()` (Buildkite Linux agents have no IPv6) and lives in a standalone file for this one concern, following the `fetch.tls.wildcard.test.ts` precedent.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 12 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/web/fetch/fetch.tls.ipv6.test.ts" "test/js/web/websocket/websocket.tls.ipv6.test.ts"
bun test v1.4.1 (65362b53b)

test/js/web/fetch/fetch.tls.ipv6.test.ts:
87 |     stderr: "pipe",
88 |   });
89 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
90 |   // Asserting stdout/stderr before exitCode produces a more useful failure
91 |   // message when the subprocess crashes unexpectedly.
92 |   expect(stdout).toBe("native: Hello World\ncallback hostname: ::1\njs: Hello World\n");
                      ^
error: expect(received).toBe(expected)

- "native: Hello World
- callback hostname: ::1
- js: Hello World
- "
+ ""

- Expected  - 4
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch.tls.ipv6.test.ts:92:18)
(fail) fetch with IPv6 literal hostname verifies the certificate [1062.55ms]

test/js/web/websocket/websocket.tls.ipv6.test.ts:
58 |     env: cleanEnv,
59 |     stdout: "pipe",
60 |     stderr: "pipe",
61 |   });
62 |   const [stdout, stderr
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (bb1425b42)

test/js/web/fetch/fetch.tls.ipv6.test.ts:
(pass) fetch with IPv6 literal hostname verifies the certificate [39.11ms]

test/js/web/websocket/websocket.tls.ipv6.test.ts:
(pass) wss to an IPv6 literal verifies the certificate [8.18ms]

 2 pass
 0 fail
 6 expect() calls
Ran 2 tests across 2 files. [128.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/web/fetch/fetch.tls.ipv6.test.ts" "test/js/web/websocket/websocket.tls.ipv6.test.ts"
bun test v1.4.1 (65362b53b)

test/js/web/fetch/fetch.tls.ipv6.test.ts:
(pass) fetch with IPv6 literal hostname verifies the certificate [1232.17ms]

test/js/web/websocket/websocket.tls.ipv6.test.ts:
(pass) wss to an IPv6 literal verifies the certificate [397.30ms]

 2 pass
 0 fail
 6 expect() calls
Ran 2 tests across 2 files. [3.68s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 662ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/26] cc obj/packages/bun-usockets/src/bsd.c.o
[2/26] cc obj/packages/bun-usockets/src/context.c.o
[3/26] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[4/26] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[5/26] cxx obj/unified/UnifiedSource-packages_bun_usockets_src_crypto-0.cpp.o
[6/26] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[7/26] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[8/26] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[9/26] cc obj/packages/bun-usockets/src/fault_inject.c.o
[10/26] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[11/26] cc obj/packages/bun-usockets/src/loop.c.o
[12/26] cc obj/packages/bun-usockets/src/node_quic_shim.c.o
[13/26] cc obj/packages/bun-usockets/src/socket.c.o
[14/26] cc obj/packages/bun-usockets/src/udp.c.o
[15/26] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[16/26] cxx obj/src/jsc/bindings/bindings.cpp.o
[17/26] cc obj/packages/bun-usockets/src/quic.c.o
[18/26] cxx obj/unified/UnifiedSource-src_j
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/lib.rs                                    | 21 +++--
 .../websocket_client/WebSocketProxyTunnel.rs       |  4 +-
 .../websocket_client/WebSocketUpgradeClient.rs     | 10 ++-
 test/js/web/fetch/fetch.tls.ipv6.test.ts           | 95 ++++++++++++++++++++++
 test/js/web/websocket/websocket.tls.ipv6.test.ts   | 66 +++++++++++++++
 5 files changed, 188 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 12

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/http/lib.rs                                             11     14     11
src/http_jsc/websocket_client/WebSocketProxyTunnel.rs        1      1      7
src/http_jsc/websocket_client/WebSocketUpgradeClient.rs      4      5      7
test/js/web/fetch/fetch.tls.ipv6.test.ts                     1      2      7
test/js/web/websocket/websocket.tls.ipv6.test.ts             0      1      0
```

</details>

**root cause** · written by the author bot

Bun passed IPv6 hostnames to TLS certificate verification with their URL brackets still attached, so names like "[::1]" or "[ff:ff::ff]" never matched the certificate's IP entries and valid connections were rejected. The fix normalizes the hostname before verification by stripping the surrounding brackets across the fetch, WebSocket, and HTTP/3 TLS paths, so the bare IPv6 literal is used for SNI and certificate checks, matching Node's behavior. Brackets are removed only when the inner value parses as an IPv6 address, so bracketed non-IP names such as "[example.com]" still fail validation as…

<!-- robobun:evidence:end -->