### PR TITLE
domain: catch exceptions thrown inside setTimeout/setInterval/setImmediate callbacks

### DIFF
--- a/src/js/node/domain.ts
+++ b/src/js/node/domain.ts
@@ -21,14 +21,18 @@ function bindCallbackToDomain(d, cb) {
       // and the error is tagged as thrown rather than emitted.
       d.exit();
       if (typeof err === "object" && err !== null) {
-        ObjectDefineProperty(err, "domain", {
-          __proto__: null,
-          configurable: true,
-          enumerable: false,
-          value: d,
-          writable: true,
-        });
-        err.domainThrown = true;
+        // Best-effort: a frozen / non-extensible / proxy-backed thrown value
+        // must still reach the handler even if it cannot be decorated.
+        try {
+          ObjectDefineProperty(err, "domain", {
+            __proto__: null,
+            configurable: true,
+            enumerable: false,
+            value: d,
+            writable: true,
+          });
+          err.domainThrown = true;
+        } catch {}
       }
       d.emit("error", err);
     } finally {
@@ -75,15 +79,19 @@ domain.createDomain = domain.create = function () {
   function emitError(e) {
     e ||= $ERR_UNHANDLED_ERROR();
     if (typeof e === "object") {
-      e.domainEmitter = this;
-      ObjectDefineProperty(e, "domain", {
-        __proto__: null,
-        configurable: true,
-        enumerable: false,
-        value: d,
-        writable: true,
-      });
-      e.domainThrown = false;
+      // Best-effort: decoration failure on a frozen / non-extensible value
+      // must not prevent the error from reaching the handler.
+      try {
+        e.domainEmitter = this;
+        ObjectDefineProperty(e, "domain", {
+          __proto__: null,
+          configurable: true,
+          enumerable: false,
+          value: d,
+          writable: true,
+        });
+        e.domainThrown = false;
+      } catch {}
     }
     d.emit("error", e);
   }

--- a/src/js/node/domain.ts
+++ b/src/js/node/domain.ts
@@ -13,12 +13,14 @@ var domain: any = {};
 function bindCallbackToDomain(d, cb) {
   return function boundDomainCallback() {
     d.enter();
+    let exited = false;
     try {
       return cb.$apply(this, arguments);
     } catch (err) {
       // Match node: the domain is exited before its 'error' handler runs, so
       // work scheduled inside the handler is not bound to the failed domain,
       // and the error is tagged as thrown rather than emitted.
+      exited = true;
       d.exit();
       if (typeof err === "object" && err !== null) {
         // Best-effort: a frozen / non-extensible / proxy-backed thrown value
@@ -36,7 +38,7 @@ function bindCallbackToDomain(d, cb) {
       }
       d.emit("error", err);
     } finally {
-      d.exit();
+      if (!exited) d.exit();
     }
   };
 }

--- a/src/js/node/domain.ts
+++ b/src/js/node/domain.ts
@@ -5,10 +5,50 @@ const ObjectDefineProperty = Object.defineProperty;
 
 // Export Domain
 var domain: any = {};
+
+// Wrap `cb` so that when it runs, `d` is entered for the duration of the call
+// and any synchronous throw is routed through the domain's 'error' event.
+function bindCallbackToDomain(d, cb) {
+  return function boundDomainCallback() {
+    d.enter();
+    try {
+      return cb.$apply(this, arguments);
+    } catch (err) {
+      d._emitError(err);
+    } finally {
+      d.exit();
+    }
+  };
+}
+
+// Patch the global timer APIs once so that callbacks scheduled while a domain
+// is active are bound to that domain at schedule time, matching node's
+// implicit async binding for timers (https://github.com/oven-sh/bun/issues/30672).
+let timersPatched = false;
+function patchTimersOnce() {
+  if (timersPatched) return;
+  timersPatched = true;
+
+  function wrapTimerApi(orig) {
+    return function (callback, ...rest) {
+      const d = domain.active;
+      if (d && $isCallable(callback)) {
+        callback = bindCallbackToDomain(d, callback);
+      }
+      return orig(callback, ...rest);
+    };
+  }
+
+  globalThis.setTimeout = wrapTimerApi(globalThis.setTimeout);
+  globalThis.setInterval = wrapTimerApi(globalThis.setInterval);
+  globalThis.setImmediate = wrapTimerApi(globalThis.setImmediate);
+}
+
 domain.createDomain = domain.create = function () {
   if (!EventEmitter) {
     EventEmitter = require("node:events");
   }
+  patchTimersOnce();
   var d = new EventEmitter();
 
   function emitError(e) {
@@ -26,6 +66,7 @@ domain.createDomain = domain.create = function () {
     }
     d.emit("error", e);
   }
+  d._emitError = emitError;
 
   d.add = function (emitter) {
     emitter.on("error", emitError);
@@ -92,5 +133,9 @@ domain.createDomain = domain.create = function () {
 const stack: any[] = [];
 domain._stack = stack;
 domain.active = null;
+
+// Match node: after `require('domain')`, `process.domain` exists (and is null)
+// even if no domain has been entered yet.
+if ((process as any).domain === undefined) (process as any).domain = null;
 
 export default domain;

--- a/src/js/node/domain.ts
+++ b/src/js/node/domain.ts
@@ -16,7 +16,21 @@ function bindCallbackToDomain(d, cb) {
     try {
       return cb.$apply(this, arguments);
     } catch (err) {
-      d._emitError(err);
+      // Match node: the domain is exited before its 'error' handler runs, so
+      // work scheduled inside the handler is not bound to the failed domain,
+      // and the error is tagged as thrown rather than emitted.
+      d.exit();
+      if (typeof err === "object" && err !== null) {
+        ObjectDefineProperty(err, "domain", {
+          __proto__: null,
+          configurable: true,
+          enumerable: false,
+          value: d,
+          writable: true,
+        });
+        err.domainThrown = true;
+      }
+      d.emit("error", err);
     } finally {
       d.exit();
     }
@@ -73,7 +87,6 @@ domain.createDomain = domain.create = function () {
     }
     d.emit("error", e);
   }
-  d._emitError = emitError;
 
   d.add = function (emitter) {
     emitter.on("error", emitError);

--- a/src/js/node/domain.ts
+++ b/src/js/node/domain.ts
@@ -8,6 +8,24 @@ const ObjectGetOwnPropertyDescriptors = Object.getOwnPropertyDescriptors;
 // Export Domain
 var domain: any = {};
 
+// Tag `err` as thrown (best-effort: frozen / non-extensible / proxy-backed
+// values cannot be decorated) and dispatch it on the already-exited domain.
+function emitThrownError(d, err) {
+  if (typeof err === "object" && err !== null) {
+    try {
+      ObjectDefineProperty(err, "domain", {
+        __proto__: null,
+        configurable: true,
+        enumerable: false,
+        value: d,
+        writable: true,
+      });
+      err.domainThrown = true;
+    } catch {}
+  }
+  d.emit("error", err);
+}
+
 // Wrap `cb` so that when it runs, `d` is entered for the duration of the call
 // and any synchronous throw is routed through the domain's 'error' event.
 function bindCallbackToDomain(d, cb) {
@@ -18,25 +36,10 @@ function bindCallbackToDomain(d, cb) {
       return cb.$apply(this, arguments);
     } catch (err) {
       // Match node: the domain is exited before its 'error' handler runs, so
-      // work scheduled inside the handler is not bound to the failed domain,
-      // and the error is tagged as thrown rather than emitted.
+      // work scheduled inside the handler is not bound to the failed domain.
       exited = true;
       d.exit();
-      if (typeof err === "object" && err !== null) {
-        // Best-effort: a frozen / non-extensible / proxy-backed thrown value
-        // must still reach the handler even if it cannot be decorated.
-        try {
-          ObjectDefineProperty(err, "domain", {
-            __proto__: null,
-            configurable: true,
-            enumerable: false,
-            value: d,
-            writable: true,
-          });
-          err.domainThrown = true;
-        } catch {}
-      }
-      d.emit("error", err);
+      emitThrownError(d, err);
     } finally {
       if (!exited) d.exit();
     }
@@ -134,23 +137,10 @@ domain.createDomain = domain.create = function () {
     try {
       return fn.$apply(this, args);
     } catch (err) {
-      // Match node: exit before dispatching 'error' (see bindCallbackToDomain)
-      // and tag the error as thrown.
+      // Match node: exit before dispatching 'error' (see bindCallbackToDomain).
       exited = true;
       this.exit();
-      if (typeof err === "object" && err !== null) {
-        try {
-          ObjectDefineProperty(err, "domain", {
-            __proto__: null,
-            configurable: true,
-            enumerable: false,
-            value: d,
-            writable: true,
-          });
-          err.domainThrown = true;
-        } catch {}
-      }
-      d.emit("error", err);
+      emitThrownError(d, err);
     } finally {
       if (!exited) this.exit();
     }

--- a/src/js/node/domain.ts
+++ b/src/js/node/domain.ts
@@ -130,12 +130,29 @@ domain.createDomain = domain.create = function () {
   };
   d.run = function (fn, ...args) {
     this.enter();
+    let exited = false;
     try {
       return fn.$apply(this, args);
     } catch (err) {
-      emitError(err);
-    } finally {
+      // Match node: exit before dispatching 'error' (see bindCallbackToDomain)
+      // and tag the error as thrown.
+      exited = true;
       this.exit();
+      if (typeof err === "object" && err !== null) {
+        try {
+          ObjectDefineProperty(err, "domain", {
+            __proto__: null,
+            configurable: true,
+            enumerable: false,
+            value: d,
+            writable: true,
+          });
+          err.domainThrown = true;
+        } catch {}
+      }
+      d.emit("error", err);
+    } finally {
+      if (!exited) this.exit();
     }
   };
   d.dispose = function () {

--- a/src/js/node/domain.ts
+++ b/src/js/node/domain.ts
@@ -2,6 +2,8 @@
 let EventEmitter;
 
 const ObjectDefineProperty = Object.defineProperty;
+const ObjectDefineProperties = Object.defineProperties;
+const ObjectGetOwnPropertyDescriptors = Object.getOwnPropertyDescriptors;
 
 // Export Domain
 var domain: any = {};
@@ -30,13 +32,18 @@ function patchTimersOnce() {
   timersPatched = true;
 
   function wrapTimerApi(orig) {
-    return function (callback, ...rest) {
+    const wrapped = function (callback, ...rest) {
       const d = domain.active;
       if (d && $isCallable(callback)) {
         callback = bindCallbackToDomain(d, callback);
       }
       return orig(callback, ...rest);
     };
+    // Preserve own properties of the original, notably
+    // Symbol.for("nodejs.util.promisify.custom") so util.promisify(setTimeout)
+    // keeps returning the timers/promises implementation.
+    ObjectDefineProperties(wrapped, ObjectGetOwnPropertyDescriptors(orig));
+    return wrapped;
   }
 
   globalThis.setTimeout = wrapTimerApi(globalThis.setTimeout);

--- a/test/js/node/domain.test.ts
+++ b/test/js/node/domain.test.ts
@@ -1,0 +1,250 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/30672
+// Exceptions thrown inside `setTimeout` callbacks scheduled while a
+// domain is active should be routed to the domain's `'error'` handler.
+test.concurrent("domain catches setTimeout callback throws", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const domain = require("domain").create();
+      domain.on("error", err => {
+        console.log("domain caught:", err.message);
+      });
+      domain.run(() => {
+        setTimeout(() => {
+          throw new Error("boom");
+        }, 1);
+      });
+      setTimeout(() => {
+        console.log("still alive");
+      }, 20);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("domain caught: boom\nstill alive\n");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("domain catches setImmediate callback throws", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const domain = require("domain").create();
+      domain.on("error", err => {
+        console.log("caught:", err.message);
+      });
+      domain.run(() => {
+        setImmediate(() => {
+          throw new Error("immediate-boom");
+        });
+      });
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("caught: immediate-boom\n");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("domain catches setInterval callback throws", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const domain = require("domain").create();
+      let count = 0;
+      domain.on("error", err => {
+        count++;
+        console.log("caught:", err.message, count);
+        if (count >= 2) process.exit(0);
+      });
+      let handle;
+      domain.run(() => {
+        handle = setInterval(() => {
+          throw new Error("tick");
+        }, 5);
+      });
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toContain("caught: tick 1");
+  expect(stdout).toContain("caught: tick 2");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("domain.run synchronous throw is caught", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const domain = require("domain").create();
+      domain.on("error", err => {
+        console.log("caught:", err.message);
+      });
+      domain.run(() => {
+        throw new Error("sync");
+      });
+      console.log("after");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("caught: sync\nafter\n");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("domain maintains correct active domain across nested run()", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const domain = require("domain");
+      const d1 = domain.create();
+      const d2 = domain.create();
+      d1.on("error", err => console.log("d1:", err.message));
+      d2.on("error", err => console.log("d2:", err.message));
+      d1.run(() => {
+        console.log("in d1, active is d1:", domain.active === d1);
+        d2.run(() => {
+          console.log("in d2, active is d2:", domain.active === d2);
+          setTimeout(() => { throw new Error("inner-boom"); }, 5);
+        });
+        console.log("back in d1, active is d1:", domain.active === d1);
+      });
+      console.log("outside, active is null:", domain.active === null);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe(
+    "in d1, active is d1: true\n" +
+      "in d2, active is d2: true\n" +
+      "back in d1, active is d1: true\n" +
+      "outside, active is null: true\n" +
+      "d2: inner-boom\n",
+  );
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("domain.bind wraps a function to route throws through the domain", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const domain = require("domain").create();
+      domain.on("error", err => console.log("caught:", err.message));
+      const bound = domain.bind(() => {
+        throw new Error("bound-boom");
+      });
+      bound();
+      console.log("after");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("caught: bound-boom\nafter\n");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("process.domain reflects the currently-active domain", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const domain = require("domain");
+      const d = domain.create();
+      console.log("before:", process.domain);
+      d.run(() => {
+        console.log("during:", process.domain === d);
+      });
+      console.log("after:", process.domain);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("before: null\nduring: true\nafter: null\n");
+  expect(exitCode).toBe(0);
+});
+
+// Regression guard: an earlier draft of this fix attached a
+// `process.on("uncaughtException")` listener from `domain`. Because Bun treats
+// any such listener as "the error was handled", it caused every uncaught
+// exception — including ones thrown completely outside any domain — to be
+// silently swallowed once `domain` had been required anywhere in the process.
+// Requiring `domain` must not change the default crash behavior for code that
+// runs outside a domain.
+test.concurrent("requiring domain does not suppress unrelated uncaught exceptions", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      require("domain").create();
+      setTimeout(() => { throw new Error("should crash"); }, 1);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("should crash");
+  expect(exitCode).not.toBe(0);
+});

--- a/test/js/node/domain.test.ts
+++ b/test/js/node/domain.test.ts
@@ -31,9 +31,11 @@ test.concurrent("domain catches setTimeout callback throws", async () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
-  expect(stdout).toBe("domain caught: boom\nstill alive\n");
-  expect(exitCode).toBe(0);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "domain caught: boom\nstill alive\n",
+    stderr: "",
+    exitCode: 0,
+  });
 });
 
 test.concurrent("domain catches setImmediate callback throws", async () => {
@@ -60,9 +62,11 @@ test.concurrent("domain catches setImmediate callback throws", async () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
-  expect(stdout).toBe("caught: immediate-boom\n");
-  expect(exitCode).toBe(0);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "caught: immediate-boom\n",
+    stderr: "",
+    exitCode: 0,
+  });
 });
 
 test.concurrent("domain catches setInterval callback throws", async () => {
@@ -93,7 +97,6 @@ test.concurrent("domain catches setInterval callback throws", async () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
   expect(stdout).toContain("caught: tick 1");
   expect(stdout).toContain("caught: tick 2");
   expect(exitCode).toBe(0);
@@ -122,9 +125,11 @@ test.concurrent("domain.run synchronous throw is caught", async () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
-  expect(stdout).toBe("caught: sync\nafter\n");
-  expect(exitCode).toBe(0);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "caught: sync\nafter\n",
+    stderr: "",
+    exitCode: 0,
+  });
 });
 
 test.concurrent("domain maintains correct active domain across nested run()", async () => {
@@ -156,15 +161,15 @@ test.concurrent("domain maintains correct active domain across nested run()", as
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
-  expect(stdout).toBe(
-    "in d1, active is d1: true\n" +
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "in d1, active is d1: true\n" +
       "in d2, active is d2: true\n" +
       "back in d1, active is d1: true\n" +
       "outside, active is null: true\n" +
       "d2: inner-boom\n",
-  );
-  expect(exitCode).toBe(0);
+    stderr: "",
+    exitCode: 0,
+  });
 });
 
 test.concurrent("domain.bind wraps a function to route throws through the domain", async () => {
@@ -189,9 +194,11 @@ test.concurrent("domain.bind wraps a function to route throws through the domain
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
-  expect(stdout).toBe("caught: bound-boom\nafter\n");
-  expect(exitCode).toBe(0);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "caught: bound-boom\nafter\n",
+    stderr: "",
+    exitCode: 0,
+  });
 });
 
 test.concurrent("process.domain reflects the currently-active domain", async () => {
@@ -216,9 +223,11 @@ test.concurrent("process.domain reflects the currently-active domain", async () 
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
-  expect(stdout).toBe("before: null\nduring: true\nafter: null\n");
-  expect(exitCode).toBe(0);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "before: null\nduring: true\nafter: null\n",
+    stderr: "",
+    exitCode: 0,
+  });
 });
 
 // Regression guard: an earlier draft of this fix attached a
@@ -275,7 +284,9 @@ test.concurrent("patched timers keep util.promisify working", async () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
-  expect(stdout).toBe("custom: function\nwaited: true\n");
-  expect(exitCode).toBe(0);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "custom: function\nwaited: true\n",
+    stderr: "",
+    exitCode: 0,
+  });
 });

--- a/test/js/node/domain.test.ts
+++ b/test/js/node/domain.test.ts
@@ -162,7 +162,8 @@ test.concurrent("domain maintains correct active domain across nested run()", as
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect({ stdout, stderr, exitCode }).toEqual({
-    stdout: "in d1, active is d1: true\n" +
+    stdout:
+      "in d1, active is d1: true\n" +
       "in d2, active is d2: true\n" +
       "back in d1, active is d1: true\n" +
       "outside, active is null: true\n" +

--- a/test/js/node/domain.test.ts
+++ b/test/js/node/domain.test.ts
@@ -82,9 +82,8 @@ test.concurrent("domain catches setInterval callback throws", async () => {
         console.log("caught:", err.message, count);
         if (count >= 2) process.exit(0);
       });
-      let handle;
       domain.run(() => {
-        handle = setInterval(() => {
+        setInterval(() => {
           throw new Error("tick");
         }, 5);
       });

--- a/test/js/node/domain.test.ts
+++ b/test/js/node/domain.test.ts
@@ -349,3 +349,35 @@ test.concurrent("domain routes frozen thrown values to the handler", async () =>
     exitCode: 0,
   });
 });
+
+// Sync twin of the above: a synchronous throw inside d.run() also dispatches
+// 'error' with the domain already exited, so a timer scheduled by the handler
+// is not bound to the failed domain and its throw crashes the process.
+test.concurrent("domain error handler for run() sync throw runs outside the domain", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const domain = require("domain").create();
+      domain.on("error", err => {
+        console.log("active in handler:", process.domain === null);
+        console.log("domainThrown:", err.domainThrown);
+        setTimeout(() => { throw new Error("second"); }, 1);
+      });
+      domain.run(() => {
+        throw new Error("first");
+      });
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("active in handler: true\ndomainThrown: true\n");
+  expect(stderr).toContain("second");
+  expect(exitCode).not.toBe(0);
+});

--- a/test/js/node/domain.test.ts
+++ b/test/js/node/domain.test.ts
@@ -291,3 +291,36 @@ test.concurrent("patched timers keep util.promisify working", async () => {
     exitCode: 0,
   });
 });
+
+// Match node: the domain is exited before its 'error' handler runs. A timer
+// scheduled inside the handler must NOT be bound to the failed domain, so a
+// handler that retries throwing work crashes on the retry instead of looping
+// through the domain forever. The error is also tagged as thrown.
+test.concurrent("domain error handler runs outside the domain", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const domain = require("domain").create();
+      domain.on("error", err => {
+        console.log("active in handler:", process.domain === null);
+        console.log("domainThrown:", err.domainThrown);
+        setTimeout(() => { throw new Error("second"); }, 1);
+      });
+      domain.run(() => {
+        setTimeout(() => { throw new Error("first"); }, 1);
+      });
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("active in handler: true\ndomainThrown: true\n");
+  expect(stderr).toContain("second");
+  expect(exitCode).not.toBe(0);
+});

--- a/test/js/node/domain.test.ts
+++ b/test/js/node/domain.test.ts
@@ -231,13 +231,8 @@ test.concurrent("process.domain reflects the currently-active domain", async () 
   });
 });
 
-// Regression guard: an earlier draft of this fix attached a
-// `process.on("uncaughtException")` listener from `domain`. Because Bun treats
-// any such listener as "the error was handled", it caused every uncaught
-// exception — including ones thrown completely outside any domain — to be
-// silently swallowed once `domain` had been required anywhere in the process.
 // Requiring `domain` must not change the default crash behavior for code that
-// runs outside a domain.
+// runs outside a domain (an uncaught throw with no active domain still crashes).
 test.concurrent("requiring domain does not suppress unrelated uncaught exceptions", async () => {
   await using proc = Bun.spawn({
     cmd: [
@@ -272,10 +267,8 @@ test.concurrent("patched timers keep util.promisify working", async () => {
       require("domain").create();
       const custom = typeof setTimeout[Symbol.for("nodejs.util.promisify.custom")];
       const wait = util.promisify(setTimeout);
-      const start = Date.now();
       await wait(30);
       console.log("custom:", custom);
-      console.log("waited:", Date.now() - start >= 25);
       `,
     ],
     env: bunEnv,
@@ -286,16 +279,15 @@ test.concurrent("patched timers keep util.promisify working", async () => {
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect({ stdout, stderr, exitCode }).toEqual({
-    stdout: "custom: function\nwaited: true\n",
+    stdout: "custom: function\n",
     stderr: "",
     exitCode: 0,
   });
 });
 
-// Match node: the domain is exited before its 'error' handler runs. A timer
-// scheduled inside the handler must NOT be bound to the failed domain, so a
-// handler that retries throwing work crashes on the retry instead of looping
-// through the domain forever. The error is also tagged as thrown.
+// Match node: the domain is exited before its 'error' handler runs, so a timer
+// scheduled inside the handler is not bound to the failed domain and a retrying
+// handler crashes on the retry throw instead of looping through the domain.
 test.concurrent("domain error handler runs outside the domain", async () => {
   await using proc = Bun.spawn({
     cmd: [

--- a/test/js/node/domain.test.ts
+++ b/test/js/node/domain.test.ts
@@ -248,3 +248,34 @@ test.concurrent("requiring domain does not suppress unrelated uncaught exception
   expect(stderr).toContain("should crash");
   expect(exitCode).not.toBe(0);
 });
+
+// Patching the global timers must not drop their own properties, notably the
+// nodejs.util.promisify.custom symbol that makes util.promisify(setTimeout)
+// return the timers/promises implementation.
+test.concurrent("patched timers keep util.promisify working", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const util = require("util");
+      require("domain").create();
+      const custom = typeof setTimeout[Symbol.for("nodejs.util.promisify.custom")];
+      const wait = util.promisify(setTimeout);
+      const start = Date.now();
+      await wait(30);
+      console.log("custom:", custom);
+      console.log("waited:", Date.now() - start >= 25);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("custom: function\nwaited: true\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/domain.test.ts
+++ b/test/js/node/domain.test.ts
@@ -324,3 +324,36 @@ test.concurrent("domain error handler runs outside the domain", async () => {
   expect(stderr).toContain("second");
   expect(exitCode).not.toBe(0);
 });
+
+// A frozen / non-extensible thrown value cannot be decorated with the
+// domain / domainThrown properties, but must still reach the handler.
+test.concurrent("domain routes frozen thrown values to the handler", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const domain = require("domain").create();
+      domain.on("error", err => {
+        console.log("caught:", err.message);
+      });
+      domain.run(() => {
+        setTimeout(() => {
+          throw Object.freeze(new Error("frozen-boom"));
+        }, 1);
+      });
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "caught: frozen-boom\n",
+    stderr: "",
+    exitCode: 0,
+  });
+});


### PR DESCRIPTION
Fixes #30672

### What does this PR do?

Exceptions thrown inside `setTimeout` / `setInterval` / `setImmediate` callbacks scheduled while a domain is active were treated as uncaught instead of being routed to the domain's `'error'` handler:

```js
const domain = require('domain').create();
domain.on('error', err => console.log('domain caught:', err.message));
domain.run(() => {
  setTimeout(() => {
    throw new Error('boom');
  }, 1);
});
setTimeout(() => console.log('still alive'), 10);
```

Node prints `domain caught: boom` then `still alive`. Bun crashed with `error: boom` instead - the thrown error escaped the domain.

**Cause**: the domain module tracks the active domain (`d.enter()` / `d.exit()` maintain a stack mirrored onto `process.domain`), but nothing in the timer dispatch path consults it: a timer callback that throws goes straight to Bun's uncaught-exception handling, bypassing any active domain.

**Fix**: on first `domain.create()`, patch the global timer APIs. When a timer is scheduled while a domain is active, the callback is bound to that domain at schedule time. When it fires, the domain is entered for the duration of the call; on a throw, the domain is exited first (matching node, so work scheduled inside the `'error'` handler is not bound to the failed domain), the error is tagged `domainThrown = true` best-effort, and it is emitted on the domain. The wrapper preserves the original timer's own properties (notably `nodejs.util.promisify.custom`), and `process.domain` is initialized to `null` on module load to match node.

The branch was rebuilt on top of main after `src/js/node/domain.ts` gained its own `enter()` / `exit()` / stack implementation there (#32488); this PR is a minimal delta over that version.

### How did you verify your code works?

- `bun bd /tmp/repro.cjs` prints `domain caught: boom` + `still alive`, exit 0 (fails on main, verified at 3eaadbe963).
- The exit-before-emit ordering and `domainThrown` tagging were verified against node v26: a handler that schedules a retrying throw crashes on the retry in both node and this branch instead of looping through the domain.
- All node compat tests matching `test/js/node/test/parallel/*domain*` pass, plus `test-event-emitter-no-error-provided-to-error-event.js`, `test-http-client-response-domain.js`, `test-http-proxy-request-no-proxy-domain.mjs`, `test-next-tick-domain.js`, `test-timers-immediate-queue-throw.js`.
- New coverage in `test/js/node/domain.test.ts` (11 tests): setTimeout / setInterval / setImmediate routing, sync throws, nested `run()` active-domain tracking, `d.bind`, `process.domain` synchronization, handler-runs-outside-the-domain ordering, frozen thrown values, `util.promisify(setTimeout)` after patching, and a guard that requiring `domain` does not suppress unrelated uncaught exceptions.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 18 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/domain.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ec04d07f2)

test/js/node/domain.test.ts:
29 |     stderr: "pipe",
30 |   });
31 | 
32 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
33 | 
34 |   expect({ stdout, stderr, exitCode }).toEqual({
                                            ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "stderr": "",
+   "exitCode": 1,
+   "stderr": 
+ "3 |       domain.on("error", err => {
+ 4 |         console.log("domain caught:", err.message);
+ 5 |       });
+ 6 |       domain.run(() = {
+ 7 |         setTimeout(() => {
+ 8 |           throw new Error("boom");
+                                     ^
+ error: boom
+       at <anonymous> (/workspace/bun/[eval]:8:33)

... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (a6cb88cf0)

test/js/node/domain.test.ts:
(pass) domain catches setImmediate callback throws [24.99ms]
(pass) domain.bind wraps a function to route throws through the domain [22.70ms]
(pass) domain maintains correct active domain across nested run() [29.04ms]
(pass) domain routes frozen thrown values to the handler [23.37ms]
(pass) domain error handler for run() sync throw runs outside the domain [23.62ms]
(pass) domain error handler runs outside the domain [24.79ms]
(pass) domain.run synchronous throw is caught [37.65ms]
(pass) process.domain reflects the currently-active domain [34.12ms]
(pass) domain catches setTimeout callback throws [44.49ms]
(pass) requiring domain does not suppress unrelated uncaught exceptions [36.56ms]
(pass) domain catches setInterval callback throws [49.97ms]
(pass) patched timers keep util.promisify working [76.84ms]

 12 pass
 0 fail
 19 expect() calls
Ran 12 tests across 1 file. [269.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/domain.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ec04d07f2)

test/js/node/domain.test.ts:
(pass) domain.run synchronous throw is caught [622.49ms]
(pass) domain catches setTimeout callback throws [701.33ms]
(pass) domain catches setImmediate callback throws [694.39ms]
(pass) domain catches setInterval callback throws [704.43ms]
(pass) domain maintains correct active domain across nested run() [699.16ms]
(pass) domain.bind wraps a function to route throws through the domain [633.90ms]
(pass) process.domain reflects the currently-active domain [634.36ms]
(pass) requiring domain does not suppress unrelated uncaught exceptions [674.30ms]
(pass) domain error handler runs outside the domain [702.87ms]
(pass) patched timers keep util.promisify working [960.14ms]
(pass) domain routes frozen thr
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 725ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/119] gen JS modules (bundle-modules)
Preprocess modules (7385ms)
Bundle modules (33ms)
Postprocesss modules (196ms)
Bundle Functions (803ms)
Generate Code (79ms)

[8.51s] Bundled "src/js" for production
  2037 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[1/119] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current vers
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/domain.ts       | 104 ++++++++++--
 test/js/node/domain.test.ts | 382 ++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 475 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 9 passed · 1 rejected · iteration 18

<details><summary>evidence per changed file</summary>

```
file                         reads  edits  tests
src/js/node/domain.ts           19     30     29
test/js/node/domain.test.ts     10      9     28
```

</details>

**root cause** · written by the author bot

The root cause was that Bun's timer implementations in setTimeout, setInterval, and setImmediate invoked their callbacks directly, bypassing the domain module's mechanism for tracking the active domain and intercepting exceptions, so errors thrown in timer callbacks escaped as uncaught exceptions instead of reaching the domain's error handler. The fix updates the domain module in src/js/node/domain.ts to patch the global timer functions when a domain is active, wrapping each callback so it enters the domain before execution and routes any thrown error to the domain's error event, matching N…

<!-- robobun:evidence:end -->