### PR TITLE
JSON lexer: tokenize `?`/`*`/`(`/`)` so `define` auto-quote can recover

### DIFF
--- a/src/parsers/json_lexer.rs
+++ b/src/parsers/json_lexer.rs
@@ -1295,8 +1295,8 @@ where
                 cp if cp == '~' as CodePoint => {
                     return self.add_unsupported_syntax_error("~ is not allowed in JSON");
                 }
-                // Note: `?`, `*`, `(` and `)` are deliberately NOT in this list.
-                // The JS lexer in JSON mode tokenizes them (TQuestion/TAsterisk/
+                // `?`, `*`, `(` and `)` deliberately do NOT raise. The JS
+                // lexer in JSON mode tokenizes them (TQuestion/TAsterisk/
                 // TOpenParen/TCloseParen) without erroring, which lets
                 // `JSONLikeParser::parse_expr`'s auto-quote fallback rescue an
                 // unquoted value that starts with one — e.g. a `Bun.build`
@@ -1304,6 +1304,25 @@ where
                 // with `*{...}` (`bake-codegen.ts`'s `OVERLAY_CSS`). Erroring
                 // here aborts `Lexer::init` before `parse_env_json` gets a
                 // chance to auto-quote.
+                //
+                // They get a dedicated arm (not the catch-all) because the spec
+                // arms (lexer.zig `'('`/`')'`/`'?'`/`'*'`) all `step()` past the
+                // char, while the catch-all leaves `code_point` on `contents[0]`.
+                // The auto-quote retry rebuilds the lexer (same state) and then
+                // calls `parse_string_literal_inner::<0>()`, whose leading
+                // `step()` must land on `contents[2]` so `contents[1]` is *not*
+                // inspected by the loop's `\n`/`\r`/`\\`/control arms — exactly
+                // as the spec lexer leaves it. Without the `step()` here,
+                // `"(\nrest"` truncates to `"("` and `"(\z"` triggers a spurious
+                // decode error, where the spec accepts both raw.
+                cp if cp == '?' as CodePoint
+                    || cp == '*' as CodePoint
+                    || cp == '(' as CodePoint
+                    || cp == ')' as CodePoint =>
+                {
+                    self.step();
+                    self.token = T::TSyntaxError;
+                }
                 cp if cp == '%' as CodePoint
                     || cp == '&' as CodePoint
                     || cp == '|' as CodePoint

--- a/src/parsers/json_lexer.rs
+++ b/src/parsers/json_lexer.rs
@@ -1295,19 +1295,24 @@ where
                 cp if cp == '~' as CodePoint => {
                     return self.add_unsupported_syntax_error("~ is not allowed in JSON");
                 }
-                cp if cp == '?' as CodePoint
-                    || cp == '%' as CodePoint
+                // Note: `?`, `*`, `(` and `)` are deliberately NOT in this list.
+                // The JS lexer in JSON mode tokenizes them (TQuestion/TAsterisk/
+                // TOpenParen/TCloseParen) without erroring, which lets
+                // `JSONLikeParser::parse_expr`'s auto-quote fallback rescue an
+                // unquoted value that starts with one — e.g. a `Bun.build`
+                // `define:` whose value is a raw minified CSS string starting
+                // with `*{...}` (`bake-codegen.ts`'s `OVERLAY_CSS`). Erroring
+                // here aborts `Lexer::init` before `parse_env_json` gets a
+                // chance to auto-quote.
+                cp if cp == '%' as CodePoint
                     || cp == '&' as CodePoint
                     || cp == '|' as CodePoint
                     || cp == '^' as CodePoint
                     || cp == '+' as CodePoint
-                    || cp == '*' as CodePoint
                     || cp == '=' as CodePoint
                     || cp == '<' as CodePoint
                     || cp == '>' as CodePoint
                     || cp == '!' as CodePoint
-                    || cp == '(' as CodePoint
-                    || cp == ')' as CodePoint
                     || cp == '`' as CodePoint =>
                 {
                     return self.add_unsupported_syntax_error("Operators are not allowed in JSON");

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -70,6 +70,31 @@ describe("Bun.build", () => {
     throw new Error("should have thrown");
   });
 
+  // A `define:` value that isn't valid JSON or a JS identifier is auto-quoted
+  // (treated as a string literal). The JSON lexer must not error eagerly on the
+  // first character — a raw minified CSS string starts with `*{...}`, which
+  // src/codegen/bake-codegen.ts passes verbatim as `OVERLAY_CSS`.
+  test("define values are auto-quoted when not valid JSON", async () => {
+    const dir = tempDirWithFiles("bun-build-define-auto-quote", {
+      "entry.ts": `declare const X: string; console.log(X);`,
+    });
+    for (const value of [
+      "*{box-sizing:border-box}.root{all:initial}",
+      "?foo",
+      "(parenthesized)",
+      ")close",
+      "abc{not json}",
+    ]) {
+      const result = await Bun.build({
+        entrypoints: [join(dir, "entry.ts")],
+        define: { X: value },
+      });
+      expect(result.success).toBe(true);
+      const out = await result.outputs[0].text();
+      expect(out).toContain(JSON.stringify(value));
+    }
+  });
+
   // https://github.com/oven-sh/bun/issues/12818
   test("sourcemap + build error crash case", async () => {
     const dir = tempDirWithFiles("build", {

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -74,25 +74,35 @@ describe("Bun.build", () => {
   // (treated as a string literal). The JSON lexer must not error eagerly on the
   // first character — a raw minified CSS string starts with `*{...}`, which
   // src/codegen/bake-codegen.ts passes verbatim as `OVERLAY_CSS`.
-  test("define values are auto-quoted when not valid JSON", async () => {
-    const dir = tempDirWithFiles("bun-build-define-auto-quote", {
-      "entry.ts": `declare const X: string; console.log(X);`,
-    });
-    for (const value of [
-      "*{box-sizing:border-box}.root{all:initial}",
-      "?foo",
-      "(parenthesized)",
-      ")close",
-      "abc{not json}",
-    ]) {
+  describe.each([
+    "*{box-sizing:border-box}.root{all:initial}",
+    "?foo",
+    "(parenthesized)",
+    ")close",
+    "abc{not json}",
+    // Leading-operator chars must `step()` before falling back to auto-quote so
+    // `parse_string_literal`'s leading `step()` lands past index 1 (matching the
+    // reference lexer). Otherwise a LF at index 1 truncates the value to `"("`.
+    "(\nrest",
+    "*\nrest",
+  ])("define value %j is auto-quoted when not valid JSON", value => {
+    test("emits a quoted string literal", async () => {
+      const dir = tempDirWithFiles("bun-build-define-auto-quote", {
+        "entry.ts": `declare const X: string; console.log(X);`,
+      });
       const result = await Bun.build({
         entrypoints: [join(dir, "entry.ts")],
         define: { X: value },
       });
       expect(result.success).toBe(true);
       const out = await result.outputs[0].text();
-      expect(out).toContain(JSON.stringify(value));
-    }
+      // The printer emits the define as a `"..."` string literal, or as a
+      // `` `...` `` template literal when the value contains a literal newline.
+      // Either way the full value — not a truncated prefix — must round-trip.
+      if (!out.includes("`" + value + "`")) {
+        expect(out).toContain(JSON.stringify(value));
+      }
+    });
   });
 
   // https://github.com/oven-sh/bun/issues/12818


### PR DESCRIPTION
## Summary
- The JSON lexer raised `Operators are not allowed in JSON` eagerly on `?`, `*`, `(`, `)`. That aborts `Lexer::init` before `parse_env_json`'s auto-quote fallback (which treats a non-JSON `define:` value as a string literal) ever runs.
- This broke building Bun itself: `bun run build:debug:noasan` failed in `bake-codegen.ts` because `OVERLAY_CSS` is a raw minified CSS string starting with `*{...}`:
  ```
  Errors while bundling Bake error runtime ...
  1 | *{box-sizing:border-box;margin:0;padding:0}.root{all:initial;--modal-bg:#202020;-
      ^
  error: Unsupported syntax: Operators are not allowed in JSON
  ```
- Drop `?`, `*`, `(`, `)` from the operators-error list so they fall through to the catch-all `TSyntaxError` path that `JSONLikeParser::parse_expr`'s auto-quote arm handles. The other operator characters (`%`, `&`, `|`, `^`, `+`, `=`, `<`, `>`, `!`, `` ` ``) keep erroring as before.
- Adds a regression test that `Bun.build({define: {X: "*{box-sizing:border-box}.root{}"}})` (and `?`/`(`/`)`/non-JSON-brace values) auto-quote into string literals.

## Test plan
- [x] `bun bd test test/bundler/bun-build-api.test.ts -t "auto-quoted"` — 1 pass
- [x] `bun bd test test/bundler/bun-build-api.test.ts` — 41 pass / 0 fail
- [x] `bun bd src/codegen/bake-codegen.ts --codegen-root=/tmp/x --debug=false` — emits `bake.client.js`, `bake.server.js`, `bake.error.js` with no errors
- [x] `cargo check -p bun_parsers` clean