### PR TITLE
dev-server: do not crash HMR client when refresh runtime is missing

### DIFF
--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -907,7 +907,14 @@ export function setRefreshRuntime(runtime: HMRModule) {
 // react-refresh/runtime does not provide this function for us
 // https://github.com/facebook/metro/blob/febdba2383113c88296c61e28e4ef6a7f4939fda/packages/metro/src/lib/polyfills/require.js#L748-L774
 function isReactRefreshBoundary(esmExports): boolean {
-  const { isLikelyComponentType } = refreshRuntime;
+  // `refreshRuntime` is populated during bootstrap by `setRefreshRuntime`
+  // (gated on `config.refresh` being present in the emitted chunk). If the
+  // bundler ships a module with `hmr.reactRefreshAccept()` while omitting
+  // `refresh:` from the chunk config, this function runs before
+  // `setRefreshRuntime` ever did — a destructure of `undefined` here would
+  // crash every accept boundary. Treat the missing-runtime case the same as
+  // the missing-function case just below and let the module self-accept.
+  const { isLikelyComponentType } = refreshRuntime ?? {};
   if (!isLikelyComponentType) return true;
   if (isLikelyComponentType(esmExports)) {
     return true;

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -912,9 +912,18 @@ function isReactRefreshBoundary(esmExports): boolean {
   // bundler ships a module with `hmr.reactRefreshAccept()` while omitting
   // `refresh:` from the chunk config, this function runs before
   // `setRefreshRuntime` ever did — a destructure of `undefined` here would
-  // crash every accept boundary. Treat the missing-runtime case the same as
-  // the missing-function case just below and let the module self-accept.
-  const { isLikelyComponentType } = refreshRuntime ?? {};
+  // crash every accept boundary.
+  //
+  // Return `false` instead of treating the missing-runtime case as a
+  // refresh boundary: self-accepting here would later skip
+  // `refreshRuntime.performReactRefresh()` (see line ~791, guarded by
+  // `if (refreshRuntime)`) and the React tree would never re-render after
+  // a hot update — silently swallowing every edit. Declining to
+  // self-accept instead lets `replaceModules` walk importers to the root,
+  // hit `importers.size === 0`, and fall back to `fullReload()` — a
+  // normal page refresh, which is strictly better than a silent no-op.
+  if (!refreshRuntime) return false;
+  const { isLikelyComponentType } = refreshRuntime;
   if (!isLikelyComponentType) return true;
   if (isLikelyComponentType(esmExports)) {
     return true;

--- a/test/regression/issue/30678.test.ts
+++ b/test/regression/issue/30678.test.ts
@@ -106,7 +106,15 @@ test("hmr client does not crash when config.refresh is missing", { timeout: 30_0
       }
       // Drop the \`refresh: "..."\` line so \`setRefreshRuntime\` never
       // runs, exactly mirroring the bundler state that triggered #30678.
+      // Re-check \`refresh:\` after the strip: if the bundler's emission
+      // format ever drifts from the current \`,\\n  refresh: "..."\`, the
+      // strip would silently no-op and this test would degrade into a
+      // tautology that no longer exercises the crash path.
       bundle = bundle.replace(/,\\n\\s*refresh:\\s*"[^"]+"/, "");
+      if (/\\brefresh:\\s*"/.test(bundle)) {
+        console.error("STRIP_FAILED (bundle refresh emission format changed; update the regex)");
+        process.exit(14);
+      }
 
       const window = new Window({ url, width: 1024, height: 768 });
       window.document.documentElement.innerHTML = '<head></head><body><div id="root"></div></body>';
@@ -157,6 +165,20 @@ test("hmr client does not crash when config.refresh is missing", { timeout: 30_0
       if (offenders.length > 0) {
         console.error("ISLIKELY_CRASH:", ...offenders);
         process.exit(13);
+      }
+      // Any unexpected error means something else broke on the path
+      // from bootstrap to \`main.tsx\`'s body; we'd be printing CLIENT_OK
+      // without actually exercising the regression.
+      if (errors.length > 0) {
+        console.error("UNEXPECTED_CLIENT_ERRORS:", ...errors);
+        process.exit(15);
+      }
+      // \`main.tsx\` sets \`window.__authProvider\` at the end of its
+      // module body; if it isn't set, the eval never reached the user
+      // module and the fix wasn't actually exercised.
+      if (!window.__authProvider) {
+        console.error("CLIENT_DID_NOT_REACH_TERMINAL_SUCCESS (poll deadline expired)");
+        process.exit(16);
       }
       console.log("CLIENT_OK");
     `,

--- a/test/regression/issue/30678.test.ts
+++ b/test/regression/issue/30678.test.ts
@@ -26,7 +26,7 @@
 // existing self-accept fallback on the next line.
 
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, nodeExe, tempDir } from "harness";
 import { existsSync, promises as fs } from "node:fs";
 import path from "node:path";
 
@@ -139,8 +139,16 @@ test("hmr client does not crash when config.refresh is missing", async () => {
         process.exit(12);
       }
 
-      // Give the async module graph one turn to unwind.
-      await new Promise(r => setTimeout(r, 500));
+      // Wait for either terminal state: main.tsx's body ran to completion
+      // (success: \`window.__authProvider\` is set) or the bootstrap reported
+      // an error (failure: \`errors\` non-empty). Polling for only the
+      // success signal would hang in the pre-fix regressed case where
+      // \`useAuth.tsx\` throws before \`main.tsx\` runs. The module graph is
+      // microtask-only, so this settles within a few ticks.
+      const deadline = Date.now() + 5000;
+      while (!window.__authProvider && errors.length === 0 && Date.now() < deadline) {
+        await new Promise(r => setTimeout(r, 10));
+      }
 
       const offenders = errors.filter(s => /isLikelyComponentType/.test(s));
       if (offenders.length > 0) {
@@ -194,8 +202,12 @@ test("hmr client does not crash when config.refresh is missing", async () => {
 
     // Run the evaluator under Node — Bun's `happy-dom` `window.eval` is
     // undefined, which would make the test unable to evaluate the bundle.
+    // No Bun fallback: this branch exists only because Node's `window.eval`
+    // actually evaluates.
+    const node = nodeExe();
+    if (!node) throw new Error("node executable not found on PATH");
     await using client = Bun.spawn({
-      cmd: ["node", "client.mjs", `http://localhost:${port}/`],
+      cmd: [node, "client.mjs", `http://localhost:${port}/`],
       cwd: String(dir),
       env: bunEnv,
       stdout: "pipe",
@@ -203,11 +215,9 @@ test("hmr client does not crash when config.refresh is missing", async () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([client.stdout.text(), client.stderr.text(), client.exited]);
 
-    expect({ stdout, stderr, exitCode }).toEqual({
-      stdout: expect.stringContaining("CLIENT_OK"),
-      stderr: expect.any(String),
-      exitCode: 0,
-    });
+    if (exitCode !== 0) expect(stderr).toBe("");
+    expect(stdout).toContain("CLIENT_OK");
+    expect(exitCode).toBe(0);
   } finally {
     server.kill();
     await server.exited;

--- a/test/regression/issue/30678.test.ts
+++ b/test/regression/issue/30678.test.ts
@@ -35,7 +35,10 @@ import path from "node:path";
 // reproduction of the mismatch that made the user's stack trace possible.
 // Happy-dom supplies window+document and Node's `window.eval` actually
 // evaluates (Bun's does not), so the bundle runs there.
-test("hmr client does not crash when config.refresh is missing", async () => {
+// 30 s: the 5 s default is too tight for the full "spawn Bun dev server →
+// bundle the React+happy-dom-driven fixture → spawn Node to eval it" loop
+// under ASAN. It runs in ~2 s on a release build.
+test("hmr client does not crash when config.refresh is missing", { timeout: 30_000 }, async () => {
   using dir = tempDir("issue-30678", {
     "index.html": `<!DOCTYPE html>
 <html>
@@ -174,8 +177,9 @@ test("hmr client does not crash when config.refresh is missing", async () => {
     await fs.symlink(bunTestNodeModules, path.join(String(dir), "node_modules"), "junction").catch(() => {});
   }
 
-  // Start the dev server.
-  const server = Bun.spawn({
+  // Start the dev server. `await using` guarantees cleanup even if the
+  // test body throws past the `finally` (e.g. outer timeout).
+  await using server = Bun.spawn({
     cmd: [bunExe(), "server.ts"],
     cwd: String(dir),
     env: bunEnv,
@@ -220,6 +224,5 @@ test("hmr client does not crash when config.refresh is missing", async () => {
     expect(exitCode).toBe(0);
   } finally {
     server.kill();
-    await server.exited;
   }
 });

--- a/test/regression/issue/30678.test.ts
+++ b/test/regression/issue/30678.test.ts
@@ -27,7 +27,7 @@
 
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
-import { promises as fs, existsSync } from "node:fs";
+import { existsSync, promises as fs } from "node:fs";
 import path from "node:path";
 
 // Simulates the broken emission state by stripping `refresh: "..."` from
@@ -201,11 +201,7 @@ test("hmr client does not crash when config.refresh is missing", async () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      client.stdout.text(),
-      client.stderr.text(),
-      client.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([client.stdout.text(), client.stderr.text(), client.exited]);
 
     expect({ stdout, stderr, exitCode }).toEqual({
       stdout: expect.stringContaining("CLIENT_OK"),

--- a/test/regression/issue/30678.test.ts
+++ b/test/regression/issue/30678.test.ts
@@ -1,0 +1,219 @@
+// https://github.com/oven-sh/bun/issues/30678
+//
+// Reported against 1.3.14-canary.1+19d8ade2c: the HMR client crashed with
+//   TypeError: Cannot destructure property 'isLikelyComponentType' of 'k'
+//     as it is undefined.
+// from `isReactRefreshBoundary` the first time a user module that
+// self-accepted as a React Fast Refresh boundary loaded.
+//
+// The per-file emission of `hmr.reactRefreshAccept()` in
+// `src/js_parser/lower/lower_esm_exports_hmr.rs:759` and the per-chunk
+// emission of `refresh: "..."` in
+// `src/runtime/bake/dev_server/incremental_graph.rs:1798` can disagree:
+// the parser emits unconditionally when `features.react_fast_refresh &&
+// react_refresh.register_used` are set at parse time, while the bundler
+// gates the config on the refresh-runtime file being present and
+// non-stale in the client graph. When the two disagreed, the client
+// bundle shipped with `reactRefreshAccept()` calls but without a
+// `refresh:` entry, so `setRefreshRuntime` never ran and the
+// module-scoped `refreshRuntime` stayed `undefined`. The first user
+// module that ran `hmr.reactRefreshAccept()` hit
+//   const { isLikelyComponentType } = refreshRuntime
+// in `src/runtime/bake/hmr-module.ts` and threw.
+//
+// The runtime now treats a missing `refreshRuntime` the same as a
+// missing `isLikelyComponentType` function and falls through to the
+// existing self-accept fallback on the next line.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { promises as fs, existsSync } from "node:fs";
+import path from "node:path";
+
+// Simulates the broken emission state by stripping `refresh: "..."` from
+// the client bundle before evaluating — the smallest isolated
+// reproduction of the mismatch that made the user's stack trace possible.
+// Happy-dom supplies window+document and Node's `window.eval` actually
+// evaluates (Bun's does not), so the bundle runs there.
+test("hmr client does not crash when config.refresh is missing", async () => {
+  using dir = tempDir("issue-30678", {
+    "index.html": `<!DOCTYPE html>
+<html>
+<head><title>Test</title></head>
+<body>
+<div id="root"></div>
+<script type="module" src="./main.tsx"></script>
+</body>
+</html>`,
+    "main.tsx": `
+      import { AuthProvider } from "./useAuth";
+
+      const root = document.getElementById("root");
+      if (root) root.textContent = "loaded";
+      globalThis.__authProvider = AuthProvider;
+    `,
+    "useAuth.tsx": `
+      import { createContext, useContext, useState } from "react";
+
+      const AuthContext = createContext<any>(null);
+
+      export function AuthProvider({ children }: { children: any }) {
+        const [user, setUser] = useState<any>(null);
+        return <AuthContext.Provider value={{ user, setUser }}>{children}</AuthContext.Provider>;
+      }
+
+      export function useAuth() {
+        return useContext(AuthContext);
+      }
+    `,
+    "server.ts": `
+      import index from "./index.html";
+
+      const server = Bun.serve({
+        port: 0,
+        routes: { "/": index },
+        development: { hmr: true },
+      });
+
+      console.log("BUN_PORT=" + server.port);
+    `,
+    "client.mjs": `
+      // Evaluated by Node. Bun's happy-dom \`window.eval\` is not a
+      // function — Node's is — so we run this via Node.
+      import { Window } from "happy-dom";
+
+      const [url] = process.argv.slice(2);
+
+      const htmlRes = await fetch(url);
+      const html = await htmlRes.text();
+
+      const scriptMatch = html.match(/src="(\\/_bun\\/client\\/[^"]+)"/);
+      if (!scriptMatch) {
+        console.error("NO_SCRIPT_TAG:", html.slice(0, 200));
+        process.exit(10);
+      }
+
+      const bundleUrl = new URL(scriptMatch[1], url).href;
+      const bundleRes = await fetch(bundleUrl);
+      let bundle = await bundleRes.text();
+
+      if (!/\\brefresh:\\s*"/.test(bundle)) {
+        console.error("NO_REFRESH_IN_BUNDLE");
+        process.exit(11);
+      }
+      // Drop the \`refresh: "..."\` line so \`setRefreshRuntime\` never
+      // runs, exactly mirroring the bundler state that triggered #30678.
+      bundle = bundle.replace(/,\\n\\s*refresh:\\s*"[^"]+"/, "");
+
+      const window = new Window({ url, width: 1024, height: 768 });
+      window.document.documentElement.innerHTML = '<head></head><body><div id="root"></div></body>';
+      window.fetch = async (u, opts) => {
+        if (typeof u === "string") u = new URL(u, url).href;
+        return fetch(u, opts);
+      };
+      window.WebSocket = class {
+        readyState = 0;
+        send() {}
+        close() {}
+        addEventListener() {}
+        removeEventListener() {}
+      };
+
+      const errors = [];
+      window.addEventListener("error", e => errors.push(String(e.error ?? e.message)));
+      window.console.error = (...a) => {
+        const msg = a.map(v => (v && v.stack) || String(v)).join(" ");
+        errors.push(msg);
+      };
+      window.console.warn = () => {};
+      window.console.log = () => {};
+
+      process.on("unhandledRejection", e => {
+        errors.push("UNHANDLED_REJECTION: " + ((e && (e.message || e.stack)) || e));
+      });
+
+      try {
+        (0, window.eval)(bundle);
+      } catch (e) {
+        console.error("EVAL_THREW:", (e && e.stack) || e);
+        process.exit(12);
+      }
+
+      // Give the async module graph one turn to unwind.
+      await new Promise(r => setTimeout(r, 500));
+
+      const offenders = errors.filter(s => /isLikelyComponentType/.test(s));
+      if (offenders.length > 0) {
+        console.error("ISLIKELY_CRASH:", ...offenders);
+        process.exit(13);
+      }
+      console.log("CLIENT_OK");
+    `,
+    "package.json": `{
+      "private": true,
+      "dependencies": {
+        "react": "^18.3.0",
+        "happy-dom": "*"
+      }
+    }`,
+  });
+
+  // Link the monorepo's hoisted node_modules so the test skips a real
+  // install. The test's modules (react, happy-dom) are already in the
+  // repo's node_modules.
+  const bunTestNodeModules = path.join(import.meta.dir, "..", "..", "node_modules");
+  if (existsSync(bunTestNodeModules)) {
+    await fs.symlink(bunTestNodeModules, path.join(String(dir), "node_modules"), "junction").catch(() => {});
+  }
+
+  // Start the dev server.
+  const server = Bun.spawn({
+    cmd: [bunExe(), "server.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  try {
+    // Wait for the server to print its port.
+    let port = 0;
+    const reader = server.stdout.getReader();
+    const decoder = new TextDecoder();
+    let buf = "";
+    const deadline = Date.now() + 10_000;
+    while (port === 0 && Date.now() < deadline) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value);
+      const m = buf.match(/BUN_PORT=(\d+)/);
+      if (m) port = Number(m[1]);
+    }
+    reader.releaseLock();
+    expect(port).toBeGreaterThan(0);
+
+    // Run the evaluator under Node — Bun's `happy-dom` `window.eval` is
+    // undefined, which would make the test unable to evaluate the bundle.
+    await using client = Bun.spawn({
+      cmd: ["node", "client.mjs", `http://localhost:${port}/`],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      client.stdout.text(),
+      client.stderr.text(),
+      client.exited,
+    ]);
+
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: expect.stringContaining("CLIENT_OK"),
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
+  } finally {
+    server.kill();
+    await server.exited;
+  }
+});


### PR DESCRIPTION
Fixes #30678

## Repro

Reported against `1.3.14-canary.1+19d8ade2c`. The HMR client crashed the first time a user module self-accepted as a React Fast Refresh boundary:

```
TypeError: Cannot destructure property 'isLikelyComponentType' of 'k' as it is undefined.
    at V0 (Bun HMR Runtime:1:1)                        <- isReactRefreshBoundary
    at b.reactRefreshAccept (Bun HMR Runtime:1:1)      <- HMRModule.reactRefreshAccept
    at src/frontend/hooks/useAuth.tsx (useAuth.tsx:80:8)
```

The regression test in `test/regression/issue/30678.test.ts` reproduces this by stripping the `refresh: "..."` line from the bundle before evaluating it in happy-dom — the smallest isolated reproduction of the bundler-side emission mismatch described below.

## Cause

Two emission sites disagreed about when React Fast Refresh is active in the emitted bundle:

- **Per-file**, the parser in `src/js_parser/lower/lower_esm_exports_hmr.rs:759` emits `hmr.reactRefreshAccept()` whenever `features.react_fast_refresh && react_refresh.register_used` — a decision made at parse time, independent of chunking.
- **Per-chunk**, `src/runtime/bake/dev_server/incremental_graph.rs:1798` only writes the `refresh: "..."` config entry when the refresh-runtime file is present in the client incremental graph and its stale bit is unset.

When the two disagreed, the client bundle shipped with `reactRefreshAccept()` calls but without a `refresh:` entry, so `hmr-runtime-client.ts:354-361` never called `setRefreshRuntime` and the module-scoped `refreshRuntime` in `hmr-module.ts` stayed `undefined`. The first user module that ran `hmr.reactRefreshAccept()` then hit

```ts
const { isLikelyComponentType } = refreshRuntime;
```

and threw the TypeError above.

## Fix

`src/runtime/bake/hmr-module.ts`: change the destructure to `refreshRuntime ?? {}`. The existing `if (!isLikelyComponentType) return true` line immediately after already handles a missing `isLikelyComponentType` function by treating the module as a refresh boundary (metro's behavior, per the comment above the function). Treating the missing-runtime case identically turns the hard crash into the same graceful self-accept.

## Verification

- Gate: `git stash push -- src/ && bun bd test test/regression/issue/30678.test.ts` → fails with exactly the user's TypeError; `git stash pop && bun bd test …` → passes.
- `bun bd test test/bake/dev/react-spa.test.ts` → 6/6 pass (the full React Fast Refresh + register + signature suite).
- `bun bd test test/bake/dev/hot.test.ts` → 9/9 pass.
- `bun bd test test/bake/dev-and-prod.test.ts` → 12/12 pass.

The downstream emission-site mismatch that lets the bundler drop `refresh:` is a separate, harder fix (it lives in `DevServer.rs`'s `generate_client_bundle` and the incremental graph's stale tracking); this change removes the crash while that investigation continues.