### PR TITLE
Clear exception in process.nextTick lazy property callback

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3913,6 +3913,8 @@ static JSValue constructMainModuleProperty(VM& vm, JSObject* processObject)
 
 JSValue Process::constructNextTickFn(JSC::VM& vm, Zig::GlobalObject* globalObject)
 {
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+
     JSNextTickQueue* nextTickQueueObject;
     if (!globalObject->m_nextTickQueue) {
         nextTickQueueObject = JSNextTickQueue::create(globalObject);
@@ -3930,6 +3932,11 @@ JSValue Process::constructNextTickFn(JSC::VM& vm, Zig::GlobalObject* globalObjec
     args.append(JSC::JSFunction::create(vm, globalObject, 1, String(), jsFunctionReportUncaughtException, ImplementationVisibility::Private));
 
     JSValue nextTickFunction = JSC::profiledCall(globalObject, ProfilingReason::API, initializer, JSC::getCallData(initializer), globalObject->globalThis(), args);
+    if (auto* exception = scope.exception()) {
+        (void)scope.tryClearException();
+        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        return jsUndefined();
+    }
     if (nextTickFunction && nextTickFunction.isObject()) {
         this->m_nextTickFunction.set(vm, this, nextTickFunction.getObject());
     }

--- a/test/js/node/process/process-stdio-stack-overflow-fixture.js
+++ b/test/js/node/process/process-stdio-stack-overflow-fixture.js
@@ -17,6 +17,8 @@ function F(a, ...b) {
     else if (which === "stdout") void process.stdout;
     else if (which === "stderr") void process.stderr;
     else if (which === "openStdin") process.openStdin();
+    else if (which === "nextTick") process.nextTick(() => {});
+    else if (which === "emitWarning") process.emitWarning("w", "ExperimentalWarning");
   } catch {}
   process.reallyExit(0);
 }

--- a/test/js/node/process/process-stdio-stack-overflow.test.ts
+++ b/test/js/node/process/process-stdio-stack-overflow.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import path from "path";
 
-test.each(["stdin", "stdout", "stderr", "openStdin"])(
+test.each(["stdin", "stdout", "stderr", "openStdin", "nextTick", "emitWarning"])(
   "process.%s lazy init near stack limit does not assert",
   which => {
     const { stderr, signalCode } = spawnSync({


### PR DESCRIPTION
Fuzzer found a debug assertion crash (`JSObjectInlines.h:102`):

```
ASSERTION FAILED: !scope.exception() || vm.hasPendingTerminationException() || !hasProperty
JSObjectInlines.h(102) : JSValue JSC::JSObject::get(JSGlobalObject *, PropertyName) const
```

### Repro

```js
function f() {
  try { new f(); } catch {}
  process.emitWarning("w", "ExperimentalWarning");
}
new f();
```

### Root cause

`process.nextTick` is defined in the static property table as a `PropertyCallback` (`constructProcessNextTickFn`). The callback calls into JS via `JSC::profiledCall` to run the `initializeNextTickQueue` builtin. When this runs near the stack limit, the JS call throws a `RangeError` and the callback returns with the exception still pending.

JSC's `setUpStaticFunctionSlot` / `reifyStaticProperty` do not check for exceptions after invoking a `LazyPropertyCallback` — they `putDirect` whatever was returned and return `true` from `getPropertySlot`. This violates the contract checked by `EXCEPTION_ASSERT` in `JSObject::get` (property found + exception pending).

The path that hits this from the repro: `process.emitWarning` → `emitWarningErrorInstance` → `queueNextTick` → `this->get(globalObject, "nextTick")` → `setUpStaticFunctionSlot` → `constructNextTickFn` → `profiledCall` throws.

### Fix

Match what `constructStdin`/`constructStdout`/`constructStderr` already do for the same situation: catch and clear the exception, report it via `reportUncaughtExceptionAtEventLoop`, and return `jsUndefined()` so the property is reified to a valid value and no exception is left pending.

Added regression coverage for `nextTick` and `emitWarning` to the existing lazy-init-near-stack-limit test.