### PR TITLE
semver: fix Tag.eql ignoring build metadata hash

### DIFF
--- a/src/semver/Version.rs
+++ b/src/semver/Version.rs
@@ -1136,8 +1136,8 @@ impl Tag {
     }
 
     pub fn eql(self, rhs: Tag) -> bool {
-        self.pre.hash == rhs.pre.hash
-    }
+    self.pre.hash == rhs.pre.hash && self.build.hash == rhs.build.hash
+}
 
     pub fn parse(sliced_string: SlicedString) -> TagResult {
         Self::parse_with_pre_count(sliced_string, 0)

--- a/src/semver/Version.zig
+++ b/src/semver/Version.zig
@@ -606,7 +606,7 @@ pub fn VersionType(comptime IntType: type) type {
             }
 
             pub fn eql(lhs: Tag, rhs: Tag) bool {
-                return lhs.pre.hash == rhs.pre.hash;
+                return lhs.pre.hash == rhs.pre.hash and lhs.build.hash == rhs.build.hash;
             }
 
             pub const TagResult = struct {


### PR DESCRIPTION
### What does this PR do?

`Tag.eql` in `src/semver/Version.zig` only compared the `pre` hash of a
semver tag, completely ignoring the `build` hash:

```zig
// before
pub fn eql(lhs: Tag, rhs: Tag) bool {
    return lhs.pre.hash == rhs.pre.hash;
}
```

This caused two versions that differ only in build metadata (e.g.
`1.0.0-alpha+build.1` vs `1.0.0-alpha+build.2`) to be considered
identical. Since `Tag.eql` is called by `Version.eql`, this affected
deduplication, lockfile version comparison, and exact-version range
matching throughout the package manager.

The fix adds the missing `build.hash` check:

```zig
// after
pub fn eql(lhs: Tag, rhs: Tag) bool {
    return lhs.pre.hash == rhs.pre.hash and lhs.build.hash == rhs.build.hash;
}
```

### How did you verify your code works?

- Traced the call chain: `Tag.eql` → `Version.eql` → deduplication /
  lockfile comparison paths to confirm the missing check had real impact.
- Verified that the existing `orderWithoutBuild` function is intentionally
  separate (for semver precedence), confirming `eql` must be strict.
- Versions without build metadata are unaffected: their `build.hash` is
  the zero value on both sides, so the added condition is always `true`
  for them.