### PR TITLE
Fix capacity miscount in ESMConditions.init

### DIFF
--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1087,10 +1087,9 @@ pub const ESMConditions = struct {
         var require_condition_map = ConditionsMap.init(allocator);
         var style_condition_map = ConditionsMap.init(allocator);
 
-        const addons_extra: usize = if (allow_addons) 1 else 0;
-        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + addons_extra + conditions.len);
-        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + addons_extra + conditions.len);
-        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + addons_extra + conditions.len);
+        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
+        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
+        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
         try style_condition_map.ensureTotalCapacity(defaults.len + 2 + conditions.len);
 
         import_condition_map.putAssumeCapacity("import", {});
@@ -1573,9 +1572,9 @@ pub fn loadersFromTransformOptions(allocator: std.mem.Allocator, _loaders: ?api.
         bun.StringArrayHashMap(Loader),
         allocator,
         input_loaders.extensions.len +
-            if (target.isBun()) default_loader_ext_bun.len else 0 +
-                if (target == .browser) default_loader_ext_browser.len else 0 +
-                    default_loader_ext.len,
+            (if (target.isBun()) default_loader_ext_bun.len else 0) +
+            (if (target == .browser) default_loader_ext_browser.len else 0) +
+            default_loader_ext.len,
         input_loaders.extensions,
         loader_values,
     );

--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1087,9 +1087,10 @@ pub const ESMConditions = struct {
         var require_condition_map = ConditionsMap.init(allocator);
         var style_condition_map = ConditionsMap.init(allocator);
 
-        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
+        const addons_extra: usize = if (allow_addons) 1 else 0;
+        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + addons_extra + conditions.len);
+        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + addons_extra + conditions.len);
+        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + addons_extra + conditions.len);
         try style_condition_map.ensureTotalCapacity(defaults.len + 2 + conditions.len);
 
         import_condition_map.putAssumeCapacity("import", {});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -575,6 +575,19 @@ describe("Bun.build", () => {
     expect(await bundle.outputs[0].text()).toBe("var o=/*@__PURE__*/console.log(1);export{o as OUT};\n");
   });
 
+  test.concurrent("many user conditions does not crash", async () => {
+    const fixture = tempDirWithFiles("build-many-conditions", {
+      "entry.ts": `export const x = 1;`,
+    });
+
+    const bundle = await Bun.build({
+      entrypoints: [join(fixture, "entry.ts")],
+      target: "bun",
+      conditions: ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"],
+    });
+    expect(bundle.success).toBe(true);
+  });
+
   test.concurrent(
     "you can write onLoad and onResolve plugins using the 'html' loader, and it includes script and link tags as bundled entrypoints",
     async () => {

--- a/test/js/bun/resolve/import-custom-condition.test.ts
+++ b/test/js/bun/resolve/import-custom-condition.test.ts
@@ -167,3 +167,22 @@ it("custom condition when don't match condition should resolves to default", asy
 
   expect(exitCode).toBe(1);
 });
+
+// https://github.com/oven-sh/bun/issues/30619
+it("many custom conditions resolve correctly", async () => {
+  for (const n of [4, 5, 6, 8, 12, 20]) {
+    const flags = [];
+    for (let i = 1; i < n; i++) flags.push(`--conditions=c${i}`);
+    flags.push("--conditions=first");
+    const { exitCode, stdout, stderr } = Bun.spawnSync({
+      cmd: [bunExe(), ...flags, `${dir}/test.js`],
+      env: bunEnv,
+      cwd: import.meta.dir,
+    });
+    expect({ n, exitCode, stdout: stdout.toString("utf8"), stderr: stderr.toString("utf8") }).toMatchObject({
+      n,
+      exitCode: 0,
+      stdout: "1\n",
+    });
+  }
+});


### PR DESCRIPTION
## What

`ESMConditions.init` computed the hash map capacity as:

```zig
defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len
```

which Zig parses as:

```zig
defaults.len + 2 + (if (allow_addons) 1 else (0 + conditions.len))
```

When `allow_addons` is `true` (the default), `conditions.len` was dropped from the capacity request entirely. With enough user `conditions` to exceed the allocator's rounded-up capacity (8), the subsequent `putAssumeCapacity` calls wrote past the reserved slots.

- In **debug** builds this tripped the `MultiArrayList.addOneAssumeCapacity` assert (found by Fuzzilli, fingerprint `6a3e4efbcd4ab6e8`).
- In **release** builds this was UB that caused export condition matching to silently break — with 5+ `--conditions` flags, resolution would fall back to `default` or fail with "Cannot find package".

## Fix

Hoist the `if` into a typed local so the addition associates correctly.

## Repro

```js
await Bun.build({
  entrypoints: ["./entry.ts"],
  target: "bun",
  conditions: ["a", "b", "c", "d", "e", "f"],
});
```

or at runtime:

```sh
bun --conditions a --conditions b --conditions c --conditions d --conditions e ./index.js
```

Fixes #30619
