### PR TITLE
install: fix `bun update -i` rendering `ai` as `air` from OSC 8 ST byte collision

### DIFF
--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -1800,16 +1800,25 @@ impl UpdateInteractiveCommand {
                         !package_url.is_empty(),
                     );
 
+                    // PORT NOTE: route through the `pretty!` macro (compile-time
+                    // `<tag>` rewrite) rather than `Output::pretty(format_args!(..))`
+                    // — the hyperlink emits OSC 8 terminator bytes `ESC \` and the
+                    // function-form re-runs the tag parser over the already-rendered
+                    // output, so the `\` would be eaten by the `\<` escape arm and
+                    // the trailing `r` of the `<r>` reset tag would leak as literal
+                    // text. See issue #30693 ("ai" → "air"). Matches Zig, where
+                    // `Output.pretty` is `comptime fmt` and the tag rewrite runs on
+                    // the template before substitution.
                     if selected {
                         if checkbox_color == "red" {
-                            Output::pretty(format_args!("<r><red>{}<r>", hyperlink));
+                            bun_core::pretty!("<r><red>{}<r>", hyperlink);
                         } else if checkbox_color == "yellow" {
-                            Output::pretty(format_args!("<r><yellow>{}<r>", hyperlink));
+                            bun_core::pretty!("<r><yellow>{}<r>", hyperlink);
                         } else {
-                            Output::pretty(format_args!("<r><green>{}<r>", hyperlink));
+                            bun_core::pretty!("<r><green>{}<r>", hyperlink);
                         }
                     } else {
-                        Output::pretty(format_args!("<r>{}<r>", hyperlink));
+                        bun_core::pretty!("<r>{}<r>", hyperlink);
                     }
 
                     // Print dev/peer/optional tag if applicable

--- a/test/regression/issue/30693.test.ts
+++ b/test/regression/issue/30693.test.ts
@@ -1,0 +1,112 @@
+// https://github.com/oven-sh/bun/issues/30693
+//
+// Regression: `bun update --interactive` against the default npm registry
+// emits an OSC 8 hyperlink (`\x1b]8;;URL\x1b\TEXT\x1b]8;;\x1b\`) inside a
+// `<r>{TEXT}<r>` bun-format template. The Rust port previously rendered that
+// via `Output::pretty(format_args!("<r>{}<r>", hyperlink))`, which substitutes
+// the hyperlink *first* then runs the `<tag>`-to-ANSI parser over the result.
+// The `\` byte of the OSC 8 ST `ESC \` collides with the parser's `\<` escape
+// arm and swallows the opening `<` of the trailing `<r>` reset tag, leaking
+// the literal `r` as plain text after the hyperlinked name. A package named
+// `ai` rendered as `air`.
+//
+// The fix routes those call sites through the `pretty!` macro (compile-time
+// tag rewrite), matching the Zig `comptime fmt` semantics so substituted
+// bytes never pass through the tag parser.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test.concurrent("issue #30693: short package names don't leak trailing 'r' from OSC 8 hyperlink", async () => {
+  // `ai` is the canonical repro — short name placed immediately before the
+  // `<r>` reset tag so the corruption is one character, fully visible.
+  // Use a very old pinned version so the registry reliably reports a newer
+  // version as available (the outdated-row renderer is what emits the link).
+  using dir = tempDir("issue-30693", {
+    "package.json": JSON.stringify({
+      name: "issue-30693-repro",
+      version: "1.0.0",
+      dependencies: {
+        "ai": "0.0.1",
+      },
+    }),
+  });
+
+  // Must install first so the manifest is cached and the outdated scan has
+  // data to render.
+  await using installProc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const installExit = await installProc.exited;
+  // Skip if install failed (e.g. offline / registry flake in CI) — the test
+  // genuinely needs the default registry to cache a manifest for `ai`.
+  if (installExit !== 0) {
+    const stderr = await installProc.stderr.text();
+    console.warn(`skipping #30693 test — \`bun install\` failed (${installExit}): ${stderr.slice(0, 200)}`);
+    return;
+  }
+
+  // `FORCE_COLOR=1` is the trigger for `Output::enable_ansi_colors_stdout()`
+  // which gates the hyperlink path. Combined with the default npm registry
+  // (no bunfig here, so `uses_default_registry == true`), the hyperlink
+  // branch of `TerminalHyperlink::Display` emits the ST bytes that collided
+  // with the pretty parser.
+  await using updateProc = Bun.spawn({
+    cmd: [bunExe(), "update", "--interactive", "--dry-run"],
+    cwd: String(dir),
+    env: { ...bunEnv, FORCE_COLOR: "1" },
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  // Exit the interactive prompt cleanly — send ctrl-c so the command
+  // returns without writing anything. Output already flushed by then.
+  updateProc.stdin.write("\x03");
+  updateProc.stdin.end();
+
+  const [stdout, stderr] = await Promise.all([updateProc.stdout.text(), updateProc.stderr.text()]);
+  await updateProc.exited;
+
+  // The rendered hyperlink wraps the package name in OSC 8:
+  //   ESC ]8;; URL ESC \ TEXT ESC ]8;; ESC \
+  // When the pretty parser was run over the substituted bytes, it ate the
+  // closing `\` of the ST and leaked the `r` of the trailing `<r>` reset
+  // tag, producing `...ESC ]8;; ESC < r` on the wire. Any terminal that
+  // closes the OSC on a non-ST delimiter renders the `r` as plain text,
+  // so the package name `ai` shows as `air`.
+  //
+  // Assertion 1: `ai` never appears with a trailing `r` character
+  //              immediately after a (possibly empty) hyperlink close.
+  expect(stdout).not.toMatch(/\x1b\]8;;\x1b[^\\]r/);
+
+  // Assertion 2: the parser must not have consumed the ST backslash of any
+  //              OSC 8 terminator. Every `ESC ]8;;` must end in `ESC \`
+  //              (the ST) before the next renderable char, except where
+  //              the URL itself is empty and the closer is `ESC ]8;; ESC \`.
+  // Find every OSC 8 start and check it's followed by a valid ST within
+  // the URL field (no `ESC` appears inside URLs in our renderer).
+  const osc8Opens = [...stdout.matchAll(/\x1b\]8;;([^\x1b]*)/g)];
+  for (const match of osc8Opens) {
+    const urlPart = match[1];
+    const afterUrl = stdout.slice(match.index! + match[0].length);
+    // The byte right after the URL must be ESC, and the byte after that
+    // must be `\` (0x5C). If the pretty parser ate the `\`, the next byte
+    // would be `<` (consumed `<` of `<r>`) — that's the bug signature.
+    expect(afterUrl[0]).toBe("\x1b");
+    expect(afterUrl[1]).toBe("\\");
+  }
+
+  // Assertion 3: after any OSC 8 close (`ESC ]8;; ESC \`), the next byte
+  //              must NOT be a bare `r` — the signature of the leaked
+  //              `<r>` reset tag when `<` was eaten by the `\<` escape arm.
+  expect(stdout).not.toMatch(/\x1b\]8;;\x1b\\r(?!\\)/);
+
+  // Sanity: the interactive command shouldn't have crashed.
+  expect(stderr).not.toContain("panic");
+  expect(stderr).not.toContain("segfault");
+});

--- a/test/regression/issue/30693.test.ts
+++ b/test/regression/issue/30693.test.ts
@@ -69,7 +69,9 @@ test.concurrent("issue #30693: short package names don't leak trailing 'r' from 
   updateProc.stdin.write("\x03");
   updateProc.stdin.end();
 
-  const [stdout, stderr] = await Promise.all([updateProc.stdout.text(), updateProc.stderr.text()]);
+  const stdout = await updateProc.stdout.text();
+  // Drain stderr so the process exits cleanly under `await using`.
+  await updateProc.stderr.text();
   await updateProc.exited;
 
   // The rendered hyperlink wraps the package name in OSC 8:
@@ -91,8 +93,14 @@ test.concurrent("issue #30693: short package names don't leak trailing 'r' from 
   // Find every OSC 8 start and check it's followed by a valid ST within
   // the URL field (no `ESC` appears inside URLs in our renderer).
   const osc8Opens = [...stdout.matchAll(/\x1b\]8;;([^\x1b]*)/g)];
+  // Must actually have exercised the hyperlink path — otherwise the
+  // terminator checks below vacuously pass and the test no longer
+  // regression-gates anything. The default registry + FORCE_COLOR=1
+  // setup above is what gates the hyperlink branch of
+  // TerminalHyperlink::Display; if this fails the fixture is wrong, not
+  // the fix.
+  expect(osc8Opens.length).toBeGreaterThan(0);
   for (const match of osc8Opens) {
-    const urlPart = match[1];
     const afterUrl = stdout.slice(match.index! + match[0].length);
     // The byte right after the URL must be ESC, and the byte after that
     // must be `\` (0x5C). If the pretty parser ate the `\`, the next byte
@@ -105,8 +113,4 @@ test.concurrent("issue #30693: short package names don't leak trailing 'r' from 
   //              must NOT be a bare `r` — the signature of the leaked
   //              `<r>` reset tag when `<` was eaten by the `\<` escape arm.
   expect(stdout).not.toMatch(/\x1b\]8;;\x1b\\r(?!\\)/);
-
-  // Sanity: the interactive command shouldn't have crashed.
-  expect(stderr).not.toContain("panic");
-  expect(stderr).not.toContain("segfault");
 });


### PR DESCRIPTION
## Repro

\`bun update --interactive\` against the default npm registry with colors enabled. Any short-named dependency right before a reset tag shows a trailing \`r\`:

```
$ bun update -i
? Select packages to update - Space to toggle, Enter to confirm
❯ □ air   0.0.1  →  5.x.x  6.x.x     # should be "ai"
```

First regressed in the Rust port (v1.3.14-canary.1 / #30412). Last good was v1.3.14.

## Cause

Each package row ran through \`Output::pretty(format_args!(\"<r>{}<r>\", hyperlink))\`. The function-form \`Output::pretty\` substitutes \`{}\` via \`format_args\` first, *then* feeds the rendered bytes to \`pretty_fmt_runtime\` for the \`<tag>\`-to-ANSI rewrite.

\`TerminalHyperlink::Display\` writes an OSC 8 hyperlink whose string terminator is \`ESC \\\\\`. After substitution the parser walks:

```
…\x1b]8;; \x1b \\ < r >
              ↑  ↑  ↑
              ST  starts \\< escape arm
                  ↑
                  emits `<`, consumes the `\\`
                       ↑
                       falls through as literal 'r'
                          ↑
                          stray `>` arm silently drops it
```

The closing ST is corrupted, so any OSC 8-aware terminal ends the link at the first non-ST byte, and the \`r\` leaks as regular text.

In the Zig original this never triggers because \`Output.pretty\` is \`inline fn pretty(comptime fmt: string, args: anytype)\` — the tag rewrite runs on the template before \`{s}\` substitution, so the runtime \`\\\\\` bytes never pass through the parser.

## Fix

Route the four hyperlink call sites through the \`bun_core::pretty!\` macro. That macro runs the \`pretty_fmt!\` proc-macro over the template at compile time and leaves \`format_args!\` to substitute \`{}\` at runtime — matching Zig's \`comptime fmt\` semantics. The \`\\\\\` bytes from the OSC 8 ST stay in the interpolated value and never hit the tag parser.

Scope is intentionally narrow: only the four sites that embed a hyperlink are changed. \`TerminalHyperlink::Display\` still emits \`ESC \\\\\` (no wire-format change).

## Verification

\`test/regression/issue/30693.test.ts\` installs \`ai\` (short name pinned to \`0.0.1\`), runs \`bun update --interactive --dry-run\` with \`FORCE_COLOR=1\`, and asserts every OSC 8 opener is followed by an \`ESC \\\\\` terminator — not \`ESC <\`. Fails on pre-fix with the exact corruption (\`…\\x1b]8;;…\\x1b<\`); passes with fix.

```
$ bun bd test test/regression/issue/30693.test.ts
(pass) issue #30693: short package names don't leak trailing 'r' from OSC 8 hyperlink [1642ms]
 1 pass
 0 fail
 8 expect() calls
```

Fixes #30693