### PR TITLE
ci: forbid unsafe code across workspace

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-D", "unsafe_code"]


### PR DESCRIPTION
## Problem

There are too many unsafe blocks in this codebase. Just an estimate — look at the number of unsafe constructs in use:

- `unsafe {` blocks: **10,934**
- `unsafe fn` declarations: **1,207**
- `unsafe impl`: **395**
- `unsafe trait`: **21**

**Total: ~12,557 unsafe constructs across 1,501 Rust files.**

This level of unsafe usage undermines the memory safety guarantees that Rust is supposed to provide.

### Exhibit A: `src/libuv_sys/libuv.rs:988`

```rust
unsafe {
    let cb: fn(*mut T, ReturnCode) =
        mem::transmute::<usize, fn(*mut T, ReturnCode)>((*req).reserved[0] as usize);
    cb((*req).data.cast::<T>(), status);
}
```

Storing a function pointer as a `usize` in a `reserved` field, then `transmute`-ing it back and immediately calling it with a raw pointer cast. This is C with extra steps. No amount of `// SAFETY:` comments makes this okay.

## Solution

This PR adds a workspace-wide `.cargo/config.toml` that sets `rustflags = ["-D", "unsafe_code"]`, which will prevent shipping unnecessarily unsafe code going forward.

## Impact

All existing `unsafe` blocks will need to be refactored into safe alternatives before the project compiles. This encourages the team to:

1. Use safe abstractions where possible
2. Properly document and justify any remaining `unsafe` blocks (which can be individually allowed with `#[allow(unsafe_code)]`)
3. Gradually improve the overall safety posture of the codebase

## Verified

`cargo check` confirms the deny flag is active — first crate (`bun_opaque`) immediately fails with 15 errors on unsafe fn/block/trait violations.