### PR TITLE
fix(windows): load addons that hard-import node.exe

### DIFF
--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -91,6 +91,13 @@ pub mod kernel32 {
         pub fn WakeConditionVariable(ConditionVariable: *mut CONDITION_VARIABLE);
         pub fn WakeAllConditionVariable(ConditionVariable: *mut CONDITION_VARIABLE);
 
+        pub fn GetFullPathNameW(
+            lpFileName: LPCWSTR,
+            nBufferLength: DWORD,
+            lpBuffer: LPWSTR,
+            lpFilePart: *mut LPWSTR,
+        ) -> DWORD;
+
         /// No preconditions; reads the calling thread's ID.
         pub safe fn GetCurrentThreadId() -> DWORD;
     }
@@ -364,6 +371,8 @@ pub fn CreateIoCompletionPort(
 pub use bun_windows_sys::externs::BY_HANDLE_FILE_INFORMATION;
 pub use bun_windows_sys::externs::CreateFileW;
 pub use bun_windows_sys::externs::FILE_FLAG_BACKUP_SEMANTICS;
+pub use bun_windows_sys::externs::FILE_FLAG_OPEN_REPARSE_POINT;
+pub use bun_windows_sys::externs::GetFileAttributesW;
 /// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfileinformationbyhandle
 pub use bun_windows_sys::externs::GetFileInformationByHandle;
 pub use bun_windows_sys::externs::OPEN_EXISTING;
@@ -4614,11 +4623,239 @@ pub extern "C" fn Bun__LoadLibraryBunString(str_: &bun_core::String) -> *mut c_v
     };
     let len = data.len();
     buf.as_mut_slice()[len] = 0;
+    load_library_with_bun_node_fallback(&mut buf, len)
+}
+
+fn load_library_with_bun_node_fallback(
+    path: &mut bun_paths::WPathBuffer,
+    len: usize,
+) -> *mut c_void {
+    const LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR: DWORD = 0x00000100;
+    const LOAD_LIBRARY_SEARCH_DEFAULT_DIRS: DWORD = 0x00001000;
+    const LOAD_LIBRARY_FLAGS: DWORD =
+        LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS;
     const LOAD_WITH_ALTERED_SEARCH_PATH: DWORD = 0x00000008;
-    // SAFETY: buf NUL-terminated at [len]
-    unsafe {
-        kernel32::LoadLibraryExW(buf.as_ptr(), ptr::null_mut(), LOAD_WITH_ALTERED_SEARCH_PATH)
+
+    let (load_path, load_path_len) = resolve_absolute_load_library_path(path, len);
+    let path_slice = &load_path.as_slice()[..load_path_len];
+    let Some(addon_dir) = bun_paths::Dirname::dirname_u16(path_slice) else {
+        // SAFETY: load_path[load_path_len] is NUL-terminated.
+        let handle = unsafe {
+            kernel32::LoadLibraryExW(load_path.as_ptr(), ptr::null_mut(), LOAD_LIBRARY_FLAGS)
+        };
+        return handle;
+    };
+
+    let node_exe_name = bun_core::strings::w!("node.exe");
+    let node_alias_path_len = addon_dir.len() + 1 + node_exe_name.len();
+    if node_alias_path_len >= bun_paths::PATH_MAX_WIDE {
+        // SAFETY: load_path[load_path_len] is NUL-terminated.
+        return unsafe {
+            kernel32::LoadLibraryExW(load_path.as_ptr(), ptr::null_mut(), LOAD_LIBRARY_FLAGS)
+        };
     }
+
+    let mut node_alias_path = bun_paths::WPathBuffer::uninit();
+    node_alias_path.as_mut_slice()[..addon_dir.len()].copy_from_slice(addon_dir);
+    node_alias_path.as_mut_slice()[addon_dir.len()] = b'\\' as u16;
+    node_alias_path.as_mut_slice()[addon_dir.len() + 1..node_alias_path_len]
+        .copy_from_slice(node_exe_name);
+    node_alias_path.as_mut_slice()[node_alias_path_len] = 0;
+    let node_alias_path_ptr = node_alias_path.as_ptr();
+
+    // Ensure addons that hard-import "node.exe" bind to this Bun executable
+    // before the Windows loader can resolve that import to an external Node.js
+    // process.
+    let mut created_node_alias = false;
+    let mut existing_node_alias_handle = None;
+    let mut node_alias_already_existed = false;
+    if CreateHardLinkW(node_alias_path_ptr, exe_path_w().as_ptr(), None) != 0 {
+        created_node_alias = true;
+    } else {
+        let err = Win32Error::get();
+        if err == Win32Error::ALREADY_EXISTS || err == Win32Error::FILE_EXISTS {
+            existing_node_alias_handle = open_verified_bun_node_alias(node_alias_path_ptr);
+            node_alias_already_existed = existing_node_alias_handle.is_some();
+        } else if err == Win32Error::NOT_SAME_DEVICE {
+            if copy_bun_node_alias(node_alias_path_ptr) {
+                created_node_alias = true;
+            } else {
+                let copy_err = Win32Error::get();
+                if copy_err == Win32Error::ALREADY_EXISTS || copy_err == Win32Error::FILE_EXISTS {
+                    existing_node_alias_handle = open_verified_bun_node_alias(node_alias_path_ptr);
+                    node_alias_already_existed = existing_node_alias_handle.is_some();
+                }
+            }
+        }
+    }
+
+    struct NodeAliasGuard {
+        path: LPCWSTR,
+        created: bool,
+        handle: Option<HANDLE>,
+    }
+
+    impl Drop for NodeAliasGuard {
+        fn drop(&mut self) {
+            if let Some(handle) = self.handle.take() {
+                // SAFETY: handle was returned by CreateFileW and is owned by this guard.
+                unsafe {
+                    let _ = CloseHandle(handle);
+                }
+            }
+
+            if self.created {
+                // SAFETY: path points into node_alias_path, which outlives this guard.
+                unsafe {
+                    let _ = DeleteFileW(self.path);
+                }
+            }
+        }
+    }
+
+    let _node_alias_guard = NodeAliasGuard {
+        path: node_alias_path_ptr,
+        created: created_node_alias,
+        handle: existing_node_alias_handle,
+    };
+
+    // SAFETY: load_path[load_path_len] is NUL-terminated.
+    let handle = unsafe {
+        kernel32::LoadLibraryExW(load_path.as_ptr(), ptr::null_mut(), LOAD_LIBRARY_FLAGS)
+    };
+    if !handle.is_null() {
+        return handle;
+    }
+
+    // Compatibility fallback for addons that rely on PATH or CWD to find
+    // non-node.exe dependent DLLs. Avoid it when we could not make node.exe
+    // resolvable from the addon's directory.
+    if created_node_alias || node_alias_already_existed {
+        // SAFETY: load_path[load_path_len] is NUL-terminated.
+        return unsafe {
+            kernel32::LoadLibraryExW(
+                load_path.as_ptr(),
+                ptr::null_mut(),
+                LOAD_WITH_ALTERED_SEARCH_PATH,
+            )
+        };
+    }
+
+    ptr::null_mut()
+}
+
+fn resolve_absolute_load_library_path<'a>(
+    path: &'a mut bun_paths::WPathBuffer,
+    len: usize,
+) -> (&'a mut bun_paths::WPathBuffer, usize) {
+    if bun_paths::is_absolute_windows_wtf16(&path.as_slice()[..len]) {
+        return (path, len);
+    }
+
+    let mut cwd_buf = bun_paths::PathBuffer::uninit();
+    let Ok(cwd) = bun_core::getcwd(&mut cwd_buf) else {
+        return (path, len);
+    };
+    let mut relative_path_buf = bun_paths::PathBuffer::uninit();
+    let relative_path_len = {
+        let relative_path = bun_paths::strings::from_wpath(
+            relative_path_buf.as_mut_slice(),
+            &path.as_slice()[..len],
+        );
+        relative_path.len()
+    };
+    let mut absolute_path_buf = bun_paths::PathBuffer::uninit();
+    let Some(absolute_path) =
+        bun_paths::resolve_path::join_abs_string_buf_checked::<bun_paths::platform::Windows>(
+            cwd.as_bytes(),
+            absolute_path_buf.as_mut_slice(),
+            &[&relative_path_buf.as_slice()[..relative_path_len]],
+        )
+    else {
+        return (path, len);
+    };
+    let absolute_path_len =
+        bun_core::strings::convert_utf8_to_utf16_in_buffer(path.as_mut_slice(), absolute_path)
+            .len();
+    path.as_mut_slice()[absolute_path_len] = 0;
+    (path, absolute_path_len)
+}
+
+fn copy_bun_node_alias(node_alias_path: LPCWSTR) -> bool {
+    unsafe { CopyFileW(exe_path_w().as_ptr(), node_alias_path, TRUE) != 0 }
+}
+
+fn open_verified_bun_node_alias(node_alias_path: LPCWSTR) -> Option<HANDLE> {
+    let existing_handle = unsafe {
+        CreateFileW(
+            node_alias_path,
+            0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            ptr::null_mut(),
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT,
+            ptr::null_mut(),
+        )
+    };
+    if existing_handle == INVALID_HANDLE_VALUE {
+        return None;
+    }
+
+    let attributes = unsafe { GetFileAttributesW(node_alias_path) };
+    if attributes == INVALID_FILE_ATTRIBUTES || (attributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0 {
+        unsafe {
+            let _ = CloseHandle(existing_handle);
+        }
+        return None;
+    }
+
+    let exe_handle = unsafe {
+        CreateFileW(
+            exe_path_w().as_ptr(),
+            0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            ptr::null_mut(),
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            ptr::null_mut(),
+        )
+    };
+    if exe_handle == INVALID_HANDLE_VALUE {
+        unsafe {
+            let _ = CloseHandle(existing_handle);
+        }
+        return None;
+    }
+
+    let same_file = same_file_by_handle(existing_handle, exe_handle);
+    unsafe {
+        let _ = CloseHandle(exe_handle);
+    }
+
+    if same_file {
+        Some(existing_handle)
+    } else {
+        unsafe {
+            let _ = CloseHandle(existing_handle);
+        }
+        None
+    }
+}
+
+fn same_file_by_handle(left: HANDLE, right: HANDLE) -> bool {
+    let mut left_info: BY_HANDLE_FILE_INFORMATION = bun_core::ffi::zeroed();
+    let mut right_info: BY_HANDLE_FILE_INFORMATION = bun_core::ffi::zeroed();
+
+    if unsafe { GetFileInformationByHandle(left, &mut left_info) } == 0 {
+        return false;
+    }
+    if unsafe { GetFileInformationByHandle(right, &mut right_info) } == 0 {
+        return false;
+    }
+
+    left_info.dwVolumeSerialNumber == right_info.dwVolumeSerialNumber
+        && left_info.nFileIndexHigh == right_info.nFileIndexHigh
+        && left_info.nFileIndexLow == right_info.nFileIndexLow
 }
 
 pub use bun_windows_sys::externs::windows_enable_stdio_inheritance;

--- a/test/js/node/process/dlopen-duplicate-load.test.ts
+++ b/test/js/node/process/dlopen-duplicate-load.test.ts
@@ -1,16 +1,153 @@
 import { spawnSync } from "bun";
-import { beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
-import { join } from "path";
+import { describe, expect, jest, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDirWithFiles } from "harness";
+import { copyFileSync, existsSync, linkSync, realpathSync } from "node:fs";
+import { basename, join } from "path";
 
 // This test verifies that Bun can load the same native module multiple times
 // Previously, the second load would fail with "symbol 'napi_register_module_v1' not found"
 // because static constructors only run once, so the module registration wasn't replayed
 
 describe("process.dlopen duplicate loads", () => {
-  let addonPath: string;
+  jest.setTimeout(60_000);
+  const externalNodeExe = isWindows ? Bun.which("node") : null;
+  let duplicateLoadAddon: string | undefined;
 
-  beforeAll(() => {
+  function buildAddon(
+    prefix: string,
+    files: Record<string, string>,
+    sources: string[],
+    options: Record<string, string> = {},
+  ) {
+    const dir = tempDirWithFiles(prefix, {
+      ...files,
+      "binding.gyp": `
+{
+  "targets": [
+    {
+      "target_name": "addon",
+      "sources": ${JSON.stringify(sources)},
+      ${Object.entries(options)
+        .map(([key, value]) => `${JSON.stringify(key)}: ${JSON.stringify(value)}`)
+        .join(",\n      ")}
+    }
+  ]
+}
+`,
+      "package.json": JSON.stringify({
+        name: "test",
+        version: "1.0.0",
+        gypfile: true,
+        scripts: {
+          install: "node-gyp rebuild",
+        },
+        devDependencies: {
+          "node-gyp": "^11.2.0",
+        },
+      }),
+    });
+
+    const build = spawnSync({
+      cmd: [bunExe(), "install"],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+
+    if (!build.success) {
+      throw new Error("Failed to build native addon");
+    }
+
+    return {
+      dir,
+      addonPath: join(dir, "build", "Release", "addon.node"),
+    };
+  }
+
+  test.skipIf(!isWindows || !externalNodeExe || basename(externalNodeExe!).toLowerCase() === "bun.exe")("should not bind node.exe imports to an external Node.js process", () => {
+    const addonSource = `
+#include <node_api.h>
+
+static napi_value Hello(napi_env env, napi_callback_info info) {
+  napi_value result;
+  napi_create_string_utf8(env, "world", NAPI_AUTO_LENGTH, &result);
+  return result;
+}
+
+static napi_value Initialize(napi_env env, napi_value exports) {
+  napi_value fn;
+  napi_create_function(env, "hello", NAPI_AUTO_LENGTH, Hello, 0, &fn);
+  napi_set_named_property(env, exports, "hello", fn);
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Initialize)
+`;
+    const { dir, addonPath } = buildAddon("dlopen-node-import-test", { "addon.c": addonSource }, ["addon.c"], {
+      "win_delay_load_hook": "false",
+    });
+
+    expect(realpathSync(externalNodeExe!).toLowerCase()).not.toBe(realpathSync(bunExe()).toLowerCase());
+    copyFileSync(externalNodeExe!, join(dir, "node.exe"));
+    expect(existsSync(join(dir, "node.exe"))).toBe(true);
+
+    const testScript = `
+      const addon = require(${JSON.stringify(addonPath)});
+      console.log("hello:", addon.hello());
+    `;
+
+    const proc = spawnSync({
+      cmd: [bunExe(), "-e", testScript],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 10_000,
+    });
+
+    expect(proc.stderr.toString()).toBe("");
+    expect(proc.stdout.toString()).toBe("hello: world\n");
+    expect(proc.exitCode).toBe(0);
+  });
+
+  test.skipIf(!isWindows)("should not remove an existing node.exe next to the addon", () => {
+    const addonSource = `
+#include <node_api.h>
+
+static napi_value Initialize(napi_env env, napi_value exports) {
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Initialize)
+`;
+    const { dir, addonPath } = buildAddon("dlopen-existing-node-test", { "addon.c": addonSource }, ["addon.c"], {
+      "win_delay_load_hook": "false",
+    });
+
+    const existingNode = join(dir, "build", "Release", "node.exe");
+    try {
+      linkSync(bunExe(), existingNode);
+    } catch {
+      copyFileSync(bunExe(), existingNode);
+    }
+    expect(existsSync(existingNode)).toBe(true);
+
+    const proc = spawnSync({
+      cmd: [bunExe(), "-e", `require(${JSON.stringify(addonPath)});`],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 10_000,
+    });
+
+    expect(proc.stderr.toString()).toBe("");
+    expect(existsSync(existingNode)).toBe(true);
+    expect(proc.exitCode).toBe(0);
+  });
+
+  function duplicateLoadAddonPath() {
     const addonSource = `
 #include <node.h>
 
@@ -41,50 +178,15 @@ void Initialize(Local<Object> exports,
 NODE_MODULE_CONTEXT_AWARE(addon, demo::Initialize)
 `;
 
-    const bindingGyp = `
-{
-  "targets": [
-    {
-      "target_name": "addon",
-      "sources": [ "addon.cpp" ]
-    }
-  ]
-}
-`;
+    return buildAddon("dlopen-duplicate-test", { "addon.cpp": addonSource }, ["addon.cpp"]).addonPath;
+  }
 
-    const dir = tempDirWithFiles("dlopen-duplicate-test", {
-      "addon.cpp": addonSource,
-      "binding.gyp": bindingGyp,
-      "package.json": JSON.stringify({
-        name: "test",
-        version: "1.0.0",
-        gypfile: true,
-        scripts: {
-          install: "node-gyp rebuild",
-        },
-        devDependencies: {
-          "node-gyp": "^11.2.0",
-        },
-      }),
-    });
-
-    // Build the addon
-    const build = spawnSync({
-      cmd: [bunExe(), "install"],
-      cwd: dir,
-      env: bunEnv,
-      stdout: "inherit",
-      stderr: "inherit",
-    });
-
-    if (!build.success) {
-      throw new Error("Failed to build native addon");
-    }
-
-    addonPath = join(dir, "build", "Release", "addon.node");
-  });
+  function getDuplicateLoadAddon() {
+    return (duplicateLoadAddon ??= duplicateLoadAddonPath());
+  }
 
   test("should load the same module twice successfully", async () => {
+    const addonPath = getDuplicateLoadAddon();
     const testScript = `
       // First load
       const m1 = { exports: {} };
@@ -110,6 +212,8 @@ NODE_MODULE_CONTEXT_AWARE(addon, demo::Initialize)
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+    expect(stderr).toBe("");
+
     expect(stdout).toContain("First load: hello exists? true");
     expect(stdout).toContain("Second load: hello exists? true");
     expect(stdout).toContain("First module result: world");
@@ -118,6 +222,7 @@ NODE_MODULE_CONTEXT_AWARE(addon, demo::Initialize)
   });
 
   test("should load module with different exports objects", async () => {
+    const addonPath = getDuplicateLoadAddon();
     const testScript = `
       // First load with empty object
       const m1 = { exports: {} };
@@ -139,6 +244,8 @@ NODE_MODULE_CONTEXT_AWARE(addon, demo::Initialize)
     });
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
 
     expect(stdout).toContain("m1.exports.hello: world");
     expect(stdout).toContain("m2.exports.initial: true");


### PR DESCRIPTION
## Summary

Ports #30461 to the Rust implementation introduced by #30412.

On Windows, some published native addons hard-import `node.exe` instead of delay-loading it through node-gyp's default hook. If a real external `node.exe` is found by the Windows loader, Bun can bind the addon to the wrong process image and crash before Bun's N-API registration path runs.

This updates `src/sys/windows/mod.rs::Bun__LoadLibraryBunString` to:

- first load addons with `LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS`
- temporarily create an addon-local `node.exe` hardlink to the current Bun executable so hard imports resolve to Bun, not an external Node.js process
- preserve any existing addon-local `node.exe`
- only delete the temporary alias when this code created it
- only fall back to `LOAD_WITH_ALTERED_SEARCH_PATH` when the addon directory can resolve `node.exe` locally

The regression test remains Windows-only and builds a `.node` addon with `win_delay_load_hook: false` to reproduce the hard import behavior.

Fixes #30454.

## Tests

```console
$ cargo fmt --check --package bun_sys && cargo check -p bun_sys --quiet
# completed successfully; existing warnings only from unrelated crates

$ git diff --check
# no output
```

Notes:

- `bun bd --target=zig-check` no longer exists after the Rust rewrite (`ninja: error: unknown target 'zig-check'`).
- A `bun bd --target=bun-rust` attempt was blocked by a rustup network timeout while refreshing `nightly-2026-05-06`; after the vendor dependency was fetched, direct `cargo check -p bun_sys` passed.
