### PR TITLE
chore: inherit workspace lints in all member crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,6 +187,12 @@ lto = true
 codegen-units = 1
 strip = "symbols"
 
+[workspace.lints.rust]
+# `bun_asan` is set via RUSTFLAGS (`--cfg=bun_asan` + `--check-cfg=cfg(bun_asan)`)
+# by scripts/build/rust.ts for asan builds; register it here so a plain
+# `cargo build` / `cargo check` (without those flags) doesn't warn.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(bun_asan)'] }
+
 [workspace.lints.clippy]
 # Prefer `.cast::<T>()` / `.cast_const()` / `.cast_mut()` / `ptr::from_ref` /
 # `ptr::from_mut` over `as *const T` / `as *mut T`. The method forms cannot

--- a/src/analytics/Cargo.toml
+++ b/src/analytics/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/ast/Cargo.toml
+++ b/src/ast/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bytemuck = "1"
 strum.workspace = true

--- a/src/ast_jsc/Cargo.toml
+++ b/src/ast_jsc/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_core.workspace = true
 strum.workspace = true

--- a/src/base64/Cargo.toml
+++ b/src/base64/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/boringssl/Cargo.toml
+++ b/src/boringssl/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/boringssl_sys/Cargo.toml
+++ b/src/boringssl_sys/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 strum.workspace = true

--- a/src/brotli/Cargo.toml
+++ b/src/brotli/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/brotli_sys/Cargo.toml
+++ b/src/brotli_sys/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 strum.workspace = true

--- a/src/bun_alloc/Cargo.toml
+++ b/src/bun_alloc/Cargo.toml
@@ -6,10 +6,8 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
-# `bun_asan` is set via RUSTFLAGS (`--cfg=bun_asan`) by scripts/build/rust.ts
-# when building with address sanitizer; it is not a Cargo feature.
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(bun_asan)'] }
+[lints]
+workspace = true
 
 [dependencies]
 bun_opaque.workspace = true

--- a/src/bun_bin/Cargo.toml
+++ b/src/bun_bin/Cargo.toml
@@ -13,6 +13,9 @@ name = "bun_rust"
 path = "lib.rs"
 crate-type = ["staticlib"]
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_io.workspace = true
 libc.workspace = true

--- a/src/bun_core/Cargo.toml
+++ b/src/bun_core/Cargo.toml
@@ -6,11 +6,8 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
-[lints.rust]
-# `bun_asan` is set via RUSTFLAGS (`--cfg=bun_asan` + `--check-cfg=cfg(bun_asan)`)
-# by scripts/build/rust.ts for asan builds; register it here so a plain
-# `cargo build` / `cargo check` (without those flags) doesn't warn.
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(bun_asan)'] }
+[lints]
+workspace = true
 
 [dependencies]
 bytemuck = "1"

--- a/src/bun_core_macros/Cargo.toml
+++ b/src/bun_core_macros/Cargo.toml
@@ -7,6 +7,9 @@ edition.workspace = true
 path = "lib.rs"
 proc-macro = true
 
+[lints]
+workspace = true
+
 [dependencies]
 proc-macro2 = "1"
 quote = "1"

--- a/src/bun_output_tags/Cargo.toml
+++ b/src/bun_output_tags/Cargo.toml
@@ -5,3 +5,6 @@ edition.workspace = true
 
 [lib]
 path = "lib.rs"
+
+[lints]
+workspace = true

--- a/src/bundler/Cargo.toml
+++ b/src/bundler/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bytemuck = "1"
 bun_opaque.workspace = true

--- a/src/bundler_jsc/Cargo.toml
+++ b/src/bundler_jsc/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 bun_io.workspace = true

--- a/src/bunfig/Cargo.toml
+++ b/src/bunfig/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 # MOVE_DOWN(b0): bunfig parser + `Arguments::loadConfig` lifted out of
 # `bun_runtime::cli` so mid-tier crates (notably `bun_install`) can load
 # bunfig.toml without depending on tier-6. All deps below are already

--- a/src/cares_sys/Cargo.toml
+++ b/src/cares_sys/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 strum.workspace = true

--- a/src/clap/Cargo.toml
+++ b/src/clap/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/clap_macros/Cargo.toml
+++ b/src/clap_macros/Cargo.toml
@@ -7,6 +7,9 @@ edition.workspace = true
 path = "lib.rs"
 proc-macro = true
 
+[lints]
+workspace = true
+
 [dependencies]
 proc-macro2 = "1"
 quote = "1"

--- a/src/codegen/Cargo.toml
+++ b/src/codegen/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/collections/Cargo.toml
+++ b/src/collections/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 # `raw-entry` powers `StringHashMap::{get_hashed, put_static_key_hashed}` — the

--- a/src/crash_handler/Cargo.toml
+++ b/src/crash_handler/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/csrf/Cargo.toml
+++ b/src/csrf/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/css/Cargo.toml
+++ b/src/css/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/css_derive/Cargo.toml
+++ b/src/css_derive/Cargo.toml
@@ -7,6 +7,9 @@ edition.workspace = true
 path = "lib.rs"
 proc-macro = true
 
+[lints]
+workspace = true
+
 [dependencies]
 proc-macro2 = "1"
 quote = "1"

--- a/src/css_jsc/Cargo.toml
+++ b/src/css_jsc/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/dispatch/Cargo.toml
+++ b/src/dispatch/Cargo.toml
@@ -7,6 +7,9 @@ edition.workspace = true
 path = "lib.rs"
 proc-macro = true
 
+[lints]
+workspace = true
+
 [dependencies]
 syn = { version = "2", features = ["full", "fold"] }
 quote = "1"

--- a/src/dns/Cargo.toml
+++ b/src/dns/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/dotenv/Cargo.toml
+++ b/src/dotenv/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/errno/Cargo.toml
+++ b/src/errno/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/event_loop/Cargo.toml
+++ b/src/event_loop/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_dispatch.workspace = true
 strum.workspace = true

--- a/src/exe_format/Cargo.toml
+++ b/src/exe_format/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bytemuck = "1"
 thiserror.workspace = true

--- a/src/glob/Cargo.toml
+++ b/src/glob/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/hash/Cargo.toml
+++ b/src/hash/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 # XxHash32 / XxHash64 / XxHash3 — reference-compatible, matches Zig std.hash.XxHash* output.
 twox-hash = { version = "2", default-features = false, features = ["xxhash32", "xxhash64", "xxhash3_64"] }

--- a/src/highway/Cargo.toml
+++ b/src/highway/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/http/Cargo.toml
+++ b/src/http/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 thiserror.workspace = true
 strum.workspace = true

--- a/src/http_jsc/Cargo.toml
+++ b/src/http_jsc/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 strum.workspace = true

--- a/src/http_types/Cargo.toml
+++ b/src/http_types/Cargo.toml
@@ -10,6 +10,9 @@ path = "lib.rs"
 # Zig `Environment.ci_assert` → opt-in extra invariant checks (off by default).
 ci_assert = []
 
+[lints]
+workspace = true
+
 [dependencies]
 bytemuck = "1"
 strum.workspace = true

--- a/src/ini/Cargo.toml
+++ b/src/ini/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/install/Cargo.toml
+++ b/src/install/Cargo.toml
@@ -13,6 +13,9 @@ path = "lib.rs"
 # when those files are compiled by the separate `bun_shim_impl` crate.
 shim_standalone = []
 
+[lints]
+workspace = true
+
 [dependencies]
 bytemuck = "1"
 strum.workspace = true

--- a/src/install/windows-shim/Cargo.toml
+++ b/src/install/windows-shim/Cargo.toml
@@ -59,6 +59,10 @@ shim_standalone = []
 # no `#[no_mangle]` symbols, and inlines to the same (ptr, len*2) arithmetic
 # the hand-written `from_raw_parts` casts compiled to — so it adds zero link
 # roots and lets the shared source's `&[u16] → &[u8]` views stay safe.
+
+[lints]
+workspace = true
+
 [dependencies]
 
 [target.'cfg(windows)'.dependencies]

--- a/src/install_jsc/Cargo.toml
+++ b/src/install_jsc/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/install_types/Cargo.toml
+++ b/src/install_types/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/io/Cargo.toml
+++ b/src/io/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 strum.workspace = true

--- a/src/js/Cargo.toml
+++ b/src/js/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/js_parser/Cargo.toml
+++ b/src/js_parser/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bytemuck = "1"
 bun_dispatch.workspace = true

--- a/src/js_parser_jsc/Cargo.toml
+++ b/src/js_parser_jsc/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/js_printer/Cargo.toml
+++ b/src/js_printer/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bytemuck = "1"
 strum.workspace = true

--- a/src/jsc/Cargo.toml
+++ b/src/jsc/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 bun_jsc_macros.workspace = true

--- a/src/jsc_macros/Cargo.toml
+++ b/src/jsc_macros/Cargo.toml
@@ -7,6 +7,9 @@ edition.workspace = true
 path = "lib.rs"
 proc-macro = true
 
+[lints]
+workspace = true
+
 [dependencies]
 syn = { version = "2", features = ["full", "extra-traits"] }
 quote = "1"

--- a/src/libarchive/Cargo.toml
+++ b/src/libarchive/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bytemuck = "1"
 bun_opaque.workspace = true

--- a/src/libarchive_sys/Cargo.toml
+++ b/src/libarchive_sys/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 strum.workspace = true

--- a/src/libdeflate_sys/Cargo.toml
+++ b/src/libdeflate_sys/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 strum.workspace = true

--- a/src/libuv_sys/Cargo.toml
+++ b/src/libuv_sys/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/lolhtml_sys/Cargo.toml
+++ b/src/lolhtml_sys/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 # The C-API crate is pulled in as an rlib path dep so its `#[no_mangle]`

--- a/src/md/Cargo.toml
+++ b/src/md/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/meta/Cargo.toml
+++ b/src/meta/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/mimalloc_sys/Cargo.toml
+++ b/src/mimalloc_sys/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 strum.workspace = true

--- a/src/node-fallbacks/Cargo.toml
+++ b/src/node-fallbacks/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/opaque/Cargo.toml
+++ b/src/opaque/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 # Intentionally zero `[dependencies]` — this crate is the lowest-tier leaf so
 # every `*_sys` crate (and anything else with C-side opaque handles) can depend
 # on it without pulling a single transitive crate into its build graph.

--- a/src/options_types/Cargo.toml
+++ b/src/options_types/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 thiserror.workspace = true
 strum.workspace = true

--- a/src/output/Cargo.toml
+++ b/src/output/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_core.workspace = true
 

--- a/src/parsers/Cargo.toml
+++ b/src/parsers/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bytemuck = "1"
 thiserror.workspace = true

--- a/src/patch/Cargo.toml
+++ b/src/patch/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/patch_jsc/Cargo.toml
+++ b/src/patch_jsc/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/paths/Cargo.toml
+++ b/src/paths/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/perf/Cargo.toml
+++ b/src/perf/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/picohttp/Cargo.toml
+++ b/src/picohttp/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/picohttp_sys/Cargo.toml
+++ b/src/picohttp_sys/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/platform/Cargo.toml
+++ b/src/platform/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 strum.workspace = true

--- a/src/ptr/Cargo.toml
+++ b/src/ptr/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/resolve_builtins/Cargo.toml
+++ b/src/resolve_builtins/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/resolver/Cargo.toml
+++ b/src/resolver/Cargo.toml
@@ -9,6 +9,9 @@ path = "lib.rs"
 [features]
 debug_logs = []
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/router/Cargo.toml
+++ b/src/router/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 rust-argon2.workspace = true

--- a/src/s3_signing/Cargo.toml
+++ b/src/s3_signing/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/safety/Cargo.toml
+++ b/src/safety/Cargo.toml
@@ -10,6 +10,9 @@ path = "lib.rs"
 # Zig `Environment.ci_assert` → opt-in extra invariant checks (off by default).
 ci_assert = []
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/semver/Cargo.toml
+++ b/src/semver/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/semver_jsc/Cargo.toml
+++ b/src/semver_jsc/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_core.workspace = true
 strum.workspace = true

--- a/src/sha_hmac/Cargo.toml
+++ b/src/sha_hmac/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 strum.workspace = true

--- a/src/shell_parser/Cargo.toml
+++ b/src/shell_parser/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/simdutf_sys/Cargo.toml
+++ b/src/simdutf_sys/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/sourcemap/Cargo.toml
+++ b/src/sourcemap/Cargo.toml
@@ -9,6 +9,9 @@ workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 strum.workspace = true

--- a/src/sourcemap_jsc/Cargo.toml
+++ b/src/sourcemap_jsc/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 strum.workspace = true

--- a/src/spawn/Cargo.toml
+++ b/src/spawn/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 bstr.workspace = true

--- a/src/spawn_sys/Cargo.toml
+++ b/src/spawn_sys/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bstr.workspace = true
 libc.workspace = true

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/sql_jsc/Cargo.toml
+++ b/src/sql_jsc/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 bun_io.workspace = true

--- a/src/standalone_graph/Cargo.toml
+++ b/src/standalone_graph/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 strum.workspace = true

--- a/src/sys/Cargo.toml
+++ b/src/sys/Cargo.toml
@@ -10,6 +10,9 @@ path = "lib.rs"
 # Zig `Environment.ci_assert` → opt-in extra invariant checks (off by default).
 ci_assert = []
 
+[lints]
+workspace = true
+
 [dependencies]
 bytemuck = "1"
 bun_opaque.workspace = true

--- a/src/sys_jsc/Cargo.toml
+++ b/src/sys_jsc/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_core.workspace = true
 bun_jsc.workspace = true

--- a/src/tcc_sys/Cargo.toml
+++ b/src/tcc_sys/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 strum.workspace = true

--- a/src/threading/Cargo.toml
+++ b/src/threading/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 thiserror.workspace = true
 strum.workspace = true

--- a/src/transpiler/Cargo.toml
+++ b/src/transpiler/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 # `Transpiler` (the high-level wrapper around the parser/options/resolver/env
 # stack) physically lives in `bun_bundler::transpiler`. This crate is the

--- a/src/unicode/Cargo.toml
+++ b/src/unicode/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/url/Cargo.toml
+++ b/src/url/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/url_jsc/Cargo.toml
+++ b/src/url_jsc/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/uws/Cargo.toml
+++ b/src/uws/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 strum.workspace = true

--- a/src/uws_sys/Cargo.toml
+++ b/src/uws_sys/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 thiserror.workspace = true

--- a/src/valkey/Cargo.toml
+++ b/src/valkey/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 bstr.workspace = true

--- a/src/watcher/Cargo.toml
+++ b/src/watcher/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/which/Cargo.toml
+++ b/src/which/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/windows_sys/Cargo.toml
+++ b/src/windows_sys/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 # No dependencies. This is a tier-0 `#![no_std]` leaf crate of raw Win32
 # typedefs / consts / `extern "system"` blocks over `core::ffi` only. Keeping
 # the dep graph empty is load-bearing: `bun_shim_impl.exe` (the freestanding

--- a/src/wyhash/Cargo.toml
+++ b/src/wyhash/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/zlib/Cargo.toml
+++ b/src/zlib/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/zlib_sys/Cargo.toml
+++ b/src/zlib_sys/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true
 phf.workspace = true

--- a/src/zstd/Cargo.toml
+++ b/src/zstd/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [lib]
 path = "lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 bun_opaque.workspace = true
 strum.workspace = true


### PR DESCRIPTION
## Summary

- Adds `[lints]` with `workspace = true` to every workspace member crate so per-crate manifests opt into the shared `[workspace.lints]` policy.
- Lifts the `unexpected_cfgs` registration for `cfg(bun_asan)` from `bun_core` and `bun_alloc` into `[workspace.lints.rust]`. Side effect: `bun_safety` (which uses `cfg(bun_asan)` without registering it locally) is now covered too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Note: This allows for adding more workspace level lints in the near future.