### PR TITLE
build: fix local WebKit configure on PIE-default distros

### DIFF
--- a/scripts/build/compile.ts
+++ b/scripts/build/compile.ts
@@ -422,7 +422,7 @@ export interface LinkOpts {
    */
   implicitInputs?: string[];
   /** Output linker map to this path (for debugging symbol bloat). */
-  linkerMapOutput?: string;
+  linkerMapOutput?: string | undefined;
 }
 
 /**

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -232,7 +232,10 @@ export const webkit: Dependency = {
     // PIC codegen here is pure overhead (GOT indirections + ~550 KB of
     // RW-segment vtables that would otherwise be shared RO). Android stays
     // PIC because bionic mandates PIE.
-    if (cfg.unix && cfg.abi !== "android") optFlags.push("-fno-pic", "-fno-pie");
+    // -no-pie rides along in CMAKE_C_FLAGS so try_compile() probes link on
+    // PIE-default distros — without it the driver still passes -pie and the
+    // -fno-pic probe object fails R_X86_64_32S relocation, killing FindThreads.
+    if (cfg.unix && cfg.abi !== "android") optFlags.push("-fno-pic", "-fno-pie", "-no-pie");
     if (cfg.lto) optFlags.push("-flto=full");
     if (cfg.pgoGenerate) optFlags.push(`-fprofile-generate=${cfg.pgoGenerate}`);
     if (cfg.pgoUse) {


### PR DESCRIPTION
## What

Pass `-no-pie` alongside `-fno-pic -fno-pie` in the `CMAKE_C_FLAGS` we hand to WebKit's local cmake configure.

## Why

23427dbc12 added `-fno-pic -fno-pie` to `optFlags` so JSC/WTF vtables land in `.rodata`. On distros where the clang driver defaults to `-pie` (Arch, current Ubuntu/Debian), cmake's `try_compile()` then compiles the probe with `-fno-pic` but still links it `-pie`, so every probe dies with:

```
relocation R_X86_64_32S against symbol `info_compiler' can not be used when making a PIE object; recompile with -fPIE
```

`FindThreads` is `REQUIRED`, so configure aborts. CI doesn't see this because the prebuilt-WebKit path never reconfigures.

`-no-pie` in `CMAKE_C_FLAGS` is ignored at `-c` time (and WebKit already prepends `-Qunused-arguments` for its own compiles) but suppresses the driver's default `-pie` when `try_compile` links the probe. Kept it in `optFlags` rather than `CMAKE_EXE_LINKER_FLAGS` because `spec.args` are appended last and would clobber source.ts's `--ld-path=${cfg.ld}`.

Prebuilt mode is unaffected — `build()` returns `{kind: "none"}` before `optFlags` is constructed.

## Also

`compile.ts`: widen `LinkOpts.linkerMapOutput` to `string | undefined` so the `cond ? path : undefined` call sites in `bun.ts` typecheck under `exactOptionalPropertyTypes`. Same pattern as `bun.ts:136,138`.

## Verified

- Before: `bun run build:local --target=configure-WebKit` → `CMake Error ... FindThreads`
- After: `Found Threads: TRUE`, `Configuring done`
- `bun x tsc --noEmit -p scripts/build/tsconfig.json` clean
- `build/debug/build.ninja` (prebuilt) contains no standalone `-no-pie`