### PR TITLE
Bun.serve: keep Request wrapper rooted across server.fetch handler call

### DIFF
--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2605,10 +2605,12 @@ where
         if let Some(resp) = <Response as bun_jsc::JsClass>::from_js(response_value) {
             // SAFETY: `from_js` returns a live `*mut Response` (owned by its
             // JS wrapper, which `response_value` keeps alive). `request` is
-            // kept alive by `request_value` (its JS wrapper) for the duration
-            // of this synchronous frame.
+            // kept alive by `request_value` (its JS wrapper), which
+            // `ensure_still_alive()` below keeps rooted on the stack for the
+            // conservative GC scan until after this read.
             unsafe { (*resp).set_url((*request).url.get().clone()) };
         }
+        request_value.ensure_still_alive();
         Ok(JSPromise::resolved_promise_value(ctx, response_value))
     }
 

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -326,6 +326,23 @@ describe.concurrent("Server", () => {
     }
   });
 
+  test("server.fetch keeps the Request wrapper alive across GC while reading its url", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        for (let k = 0; k < 200; k++) new Array(64);
+        Bun.gc(true);
+        return new Response("ok");
+      },
+    });
+    const url = `http://${server.hostname}:${server.port}/`;
+    for (let i = 0; i < 20; i++) {
+      const response = await server.fetch(url);
+      Bun.gc(true);
+      expect(response.url).toBe(url);
+    }
+  });
+
   test("server should return a body for a OPTIONS Request", async () => {
     using server = Bun.serve({
       port: 0,

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -326,23 +326,6 @@ describe.concurrent("Server", () => {
     }
   });
 
-  test("server.fetch keeps the Request wrapper alive across GC while reading its url", async () => {
-    using server = Bun.serve({
-      port: 0,
-      fetch(req) {
-        for (let k = 0; k < 200; k++) new Array(64);
-        Bun.gc(true);
-        return new Response("ok");
-      },
-    });
-    const url = `http://${server.hostname}:${server.port}/`;
-    for (let i = 0; i < 20; i++) {
-      const response = await server.fetch(url);
-      Bun.gc(true);
-      expect(response.url).toBe(url);
-    }
-  });
-
   test("server should return a body for a OPTIONS Request", async () => {
     using server = Bun.serve({
       port: 0,
@@ -484,6 +467,24 @@ describe.concurrent("Server", () => {
     expect(stderr.toString("utf-8")).toBeEmpty();
     expect(exitCode).toBe(0);
   });
+});
+
+// Outside describe.concurrent: Bun.gc(true) is process-global.
+test("server.fetch keeps the Request wrapper alive across GC while reading its url", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      for (let k = 0; k < 200; k++) new Array(64);
+      Bun.gc(true);
+      return new Response("ok");
+    },
+  });
+  const url = `http://${server.hostname}:${server.port}/`;
+  for (let i = 0; i < 20; i++) {
+    const response = await server.fetch(url);
+    Bun.gc(true);
+    expect(response.url).toBe(url);
+  }
 });
 
 // By not timing out, this test passes.


### PR DESCRIPTION
Fuzzilli found a flaky SIGSEGV (fingerprint `2873d7dcb793dce4`) exercising `server.fetch()` followed by `Bun.gc(true)`.

The crash itself did not reproduce locally (25k+ attempts; flaky with no ASAN output), but code review of `on_fetch` revealed a GC hazard in the exact path exercised:

```rust
let request: *mut Request = bun_core::heap::into_raw(existing_request);
let request_value = unsafe { (*request).to_js(&global_this) };
let response_value = on_request.call(..., &[request_value]) ...;
// request_value is now dead; stack slot may be reused
...
unsafe { (*resp).set_url((*request).url.get().clone()) }; // UAF if wrapper was swept
```

After `to_js()` the heap `Request` is owned by its JS wrapper, rooted only by `request_value`. Once the handler call returns, `request_value` has no further use, so the optimizer may drop its stack slot before the later `(*request).url` read. A collection triggered by the user handler (or any allocation in between) can then sweep the wrapper, free the `Request`, and the read is a use-after-free.

The original Zig read `existing_request.url` from a stack-resident copy and so was immune; the Rust port collapsed the stack copy into the GC-owned heap allocation.

Fix: `request_value.ensure_still_alive()` after the last `*request` deref, matching the pattern already used in `on_request_for` (mod.rs:932, 995).

Adds a regression test that calls `server.fetch()` with a handler that forces GC before returning a `Response`, then verifies `response.url`.