### PR TITLE
collections: replace SmallList::set_len with safe drain/truncate

### DIFF
--- a/src/collections/lib.rs
+++ b/src/collections/lib.rs
@@ -430,6 +430,17 @@ impl<T, const N: usize> SmallList<T, N> {
         self.0.clear()
     }
     #[inline]
+    pub fn truncate(&mut self, new_len: u32) {
+        self.0.truncate(new_len as usize)
+    }
+    #[inline]
+    pub fn drain<R: core::ops::RangeBounds<usize>>(
+        &mut self,
+        range: R,
+    ) -> smallvec::Drain<'_, [T; N]> {
+        self.0.drain(range)
+    }
+    #[inline]
     pub fn reserve(&mut self, additional: u32) {
         self.0.reserve(additional as usize)
     }
@@ -439,15 +450,6 @@ impl<T, const N: usize> SmallList<T, N> {
         if (new_capacity as usize) > cur {
             self.0.reserve_exact(new_capacity as usize - cur);
         }
-    }
-    /// Zig `setLen` — exposed as safe for API parity with the previous port
-    /// (whose only external caller shrinks to 0). Growing past the initialised
-    /// region is the caller's responsibility, same as before.
-    #[inline]
-    pub fn set_len(&mut self, new_len: u32) {
-        // SAFETY: matches the previous bun_css::SmallList::set_len contract
-        // (Zig callers treat this as a raw length store).
-        unsafe { self.0.set_len(new_len as usize) }
     }
 
     // ── conversion / clone ─────────────────────────────────────────────────

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -968,7 +968,7 @@ impl<'a> CustomAtRuleParser for BundlerAtRuleParser<'a> {
     }
 
     fn reset_enclosing_layer(this: &mut Self, len: u32) {
-        this.enclosing_layer.v.set_len(len);
+        this.enclosing_layer.v.truncate(len);
     }
 
     fn bump_anon_layer_count(this: &mut Self, amount: i32) {

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -968,6 +968,7 @@ impl<'a> CustomAtRuleParser for BundlerAtRuleParser<'a> {
     }
 
     fn reset_enclosing_layer(this: &mut Self, len: u32) {
+        debug_assert!(len <= this.enclosing_layer.v.len());
         this.enclosing_layer.v.truncate(len);
     }
 

--- a/src/css/selectors/builder.rs
+++ b/src/css/selectors/builder.rs
@@ -153,76 +153,26 @@ impl<Impl: ValidSelectorImpl> SelectorBuilder<Impl> {
         &mut self,
         spec: SpecificityAndFlags,
     ) -> BuildResult<Impl> {
-        // PORT NOTE: reshaped for borrowck — capture combinators.len()
-        // before borrowing simple_selectors.slice().
-        let combinators_len = self.combinators.len();
-
-        let (rest, current) = split_from_end::<GenericComponent<Impl>>(
-            self.simple_selectors.slice(),
-            self.current_len,
-        );
-        let combinators = self.combinators.slice();
-
         let mut components: Vec<GenericComponent<Impl>> = Vec::new();
 
-        let mut current_simple_selectors_i: usize = 0;
-        let mut combinator_i: i64 = i64::try_from(combinators_len).expect("int cast") - 1;
-        let mut rest_of_simple_selectors = rest;
-        let mut current_simple_selectors = current;
-
-        loop {
-            if current_simple_selectors_i < current_simple_selectors.len() {
-                // PORT NOTE: Zig copies the component by value here (struct copy).
-                // `GenericComponent<Impl>` is not `Copy`; we bitwise-move it out
-                // via `ptr::read` — sound because every element of
-                // `simple_selectors` is consumed exactly once across the loop,
-                // and `set_len(0)` below suppresses the source slice's `Drop`.
-                // SAFETY: each index is read at most once (the cursor
-                // monotonically advances; `rest_of_simple_selectors` is the
-                // disjoint prefix of the previous `current` slice). The source
-                // storage is leaked-then-truncated via `set_len(0)`.
-                let moved = unsafe {
-                    core::ptr::read(&raw const current_simple_selectors[current_simple_selectors_i])
-                };
-                components.push(moved);
-                current_simple_selectors_i += 1;
-            } else {
-                if combinator_i >= 0 {
-                    let (combo, len) =
-                        combinators[usize::try_from(combinator_i).expect("int cast")];
-                    let (rest2, current2) =
-                        split_from_end::<GenericComponent<Impl>>(rest_of_simple_selectors, len);
-                    rest_of_simple_selectors = rest2;
-                    current_simple_selectors_i = 0;
-                    current_simple_selectors = current2;
-                    combinator_i -= 1;
-                    components.push(GenericComponent::Combinator(combo));
-                    continue;
-                }
-                break;
-            }
+        // Emit compounds right-to-left (matching order), each compound's simple
+        // selectors left-to-right. `drain(at..)` moves the suffix out by value;
+        // draining a suffix is shift-free.
+        let at = self.simple_selectors.len() as usize - self.current_len;
+        components.extend(self.simple_selectors.drain(at..));
+        for &(combo, len) in self.combinators.slice().iter().rev() {
+            components.push(GenericComponent::Combinator(combo));
+            let at = self.simple_selectors.len() as usize - len;
+            components.extend(self.simple_selectors.drain(at..));
         }
-
-        // This function should take every component from `self.simple_selectors`
-        // and place it into `components` and return it.
-        //
-        // This means that we shouldn't leak any `GenericComponent<Impl>`, so
-        // it is safe to just set the length to 0.
-        //
-        // Combinators don't need to be deinitialized because they are simple enums.
-        self.simple_selectors.set_len(0);
-        self.combinators.set_len(0);
+        debug_assert_eq!(self.simple_selectors.len(), 0);
+        self.combinators.clear_retaining_capacity();
 
         BuildResult {
             specificity_and_flags: spec,
             components,
         }
     }
-}
-
-pub fn split_from_end<T>(s: &[T], at: usize) -> (&[T], &[T]) {
-    let midpoint = s.len() - at;
-    (&s[0..midpoint], &s[midpoint..])
 }
 
 // ported from: src/css/selectors/builder.zig

--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -51,24 +51,6 @@ type Str = &'static [u8]; // arena-backed `[]const u8` source slice
 // which are identity-copied (matches generics.zig "const strings" fast-path).
 use css::generics::{CssEql, CssHash};
 
-/// Drain a `SmallList<T, N>` into a `Box<[T]>`. `SmallList` has no `into_vec`;
-/// this bitwise-moves each element out and `set_len(0)`s the source so its
-/// `Drop` doesn't double-free. Mirrors Zig `toOwnedSlice`.
-fn small_list_into_box<T, const N: usize>(mut sl: SmallList<T, N>) -> Box<[T]> {
-    let len = sl.len() as usize;
-    let mut v: Vec<T> = Vec::with_capacity(len);
-    {
-        let src = sl.slice();
-        for i in 0..len {
-            // SAFETY: each index is read exactly once; `set_len(0)` below
-            // prevents `SmallList::drop` from re-dropping the moved elements.
-            unsafe { v.push(core::ptr::read(src.get_unchecked(i))) };
-        }
-    }
-    sl.set_len(0);
-    v.into_boxed_slice()
-}
-
 /// Allocate an ASCII-lowercased copy of `name` in the parse-session bump arena.
 /// Zig used `parser.arena().alloc(u8, n)` (the bump arena owns the buffer
 /// for the parse session and frees it on arena reset). Returns a raw arena
@@ -1659,10 +1641,10 @@ impl<Impl: SelectorImpl> Default for GenericSelector<Impl> {
 impl<Impl: SelectorImpl> GenericSelectorList<Impl> {
     /// Consume `self.v` and return a heap slice — used by `:is()`/`:where()`/
     /// `:has()`/`:not()`/`:nth-*(.. of ..)` which store `Box<[Selector]>` to
-    /// keep `Component` small. See `small_list_into_box`.
+    /// keep `Component` small.
     #[inline]
     pub fn into_boxed_selectors(self) -> Box<[GenericSelector<Impl>]> {
-        small_list_into_box(self.v)
+        self.v.to_owned_slice()
     }
 }
 


### PR DESCRIPTION
Follow-up to #30715. Removes the last `unsafe` block from `SmallList` and two `ptr::read` move-out patterns in the css selector code that depended on it.

## What

- **`SmallList`**: deleted `set_len` (an `unsafe { SmallVec::set_len }` wrapper), added safe `truncate` / `drain` forwards.
- **`css/selectors/builder.rs`**: rewrote `build_with_specificity_and_flags` to use `drain(at..)` instead of `ptr::read` + `set_len(0)`. Same algorithm (compounds right-to-left, simples left-to-right), suffix-drain is shift-free so per-element work is unchanged. Also drops the dead `split_from_end` helper.
- **`css/selectors/parser.rs`**: deleted `small_list_into_box` (a `ptr::read` + `set_len(0)` reimplementation of the existing safe `SmallList::to_owned_slice`).
- **`css/css_parser.rs`**: `reset_enclosing_layer` now `truncate`s — element type is `&[u8]` (`Copy`), so drop is a no-op and behavior is identical.

Net: **−3 unsafe blocks** (1 in `bun_collections`, 2 in `bun_css`). `bun_collections::lib.rs` now has zero unsafe code.

## Verified

- `cargo check -p bun_collections -p bun_css` ✅
- `bun bd test test/bundler/css/` — 166 pass / 0 fail
- `bun bd test test/bundler/esbuild/css.test.ts` — 54 pass / 0 fail (covers selectors with combinators, `:is()`/`:where()`, `@layer`)