### PR TITLE
bun:ffi: extract embedded shared libraries from bunfs in `dlopen()`

### DIFF
--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -559,12 +559,16 @@ pub extern "C" fn ModuleLoader__isBuiltin(data: *const u8, len: usize) -> bool {
 use bun_bundler::transpiler::PluginRunner;
 
 // PORT NOTE: `ModuleLoader.resolveEmbeddedFile` (spec ModuleLoader.zig:33-71)
-// has been MOVED to `bun_runtime::jsc_hooks::resolve_embedded_node_file_hook`
+// has been MOVED to `bun_runtime::jsc_hooks::resolve_embedded_file_to_buf`
 // per PORTING.md §Forbidden ("dep-cycle: MOVE the code to the right crate") —
 // the body reaches into `bun_standalone_graph` + `bun_sys::Tmpfile` +
-// `node::fs`, none of which are `bun_jsc` deps. Both Zig callers
-// (`Bun__resolveEmbeddedNodeFile` above, and the `.sqlite` arm of
-// `transpileSourceCode`) now live in `bun_runtime`.
+// `node::fs`, none of which are `bun_jsc` deps. Three Zig callers live in
+// `bun_runtime`:
+//   - `Bun__resolveEmbeddedNodeFile` above (extname `"node"`, goes through
+//     `LoaderHooks::resolve_embedded_node_file` to bridge the crate gap).
+//   - The `.sqlite` arm of `transpileSourceCode`.
+//   - `ffi_body::FFI::open` (extname `"so"`/`"dylib"`/`"dll"`; same-crate
+//     call to `resolve_embedded_file_to_buf`, no hook needed).
 
 /// Spec ModuleLoader.zig:73-83.
 #[unsafe(no_mangle)]

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -1473,7 +1473,7 @@ impl FFI {
 
         let mut filepath_buf = bun_paths::path_buffer_pool::get();
         let name: &[u8] = 'brk: {
-            let _ext: &[u8] = match () {
+            let ext: &[u8] = match () {
                 // Android shared libraries are `.so` (ELF, same as Linux/FreeBSD).
                 #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
                 () => b"so",
@@ -1483,14 +1483,25 @@ impl FFI {
                 () => b"dll",
                 // TODO(port): wasm @compileError("TODO")
             };
-            // TODO(b2-blocked): `ModuleLoader::resolve_embedded_file` lives in
-            // `crate::jsc_hooks` (private hook with a different signature) —
-            // wire the standalone-graph extraction once that surface is public.
-            let _ = (vm, &mut *filepath_buf);
-            #[allow(unreachable_code)]
-            if let Some(resolved) = None::<&[u8]> {
-                filepath_buf[resolved.len()] = 0;
-                break 'brk &filepath_buf[0..resolved.len()];
+            // Spec `ffi.zig:1030` — `ModuleLoader.resolveEmbeddedFile(vm, buf,
+            // name_slice.slice(), ext)` extracts a bunfs-embedded shared
+            // library (added via `import lib from "./lib.so" with { type:
+            // "file" }` and shipped through `bun build --compile`) to a real
+            // on-disk temp file, returning the tmpfile path; libc `dlopen(2)`
+            // can't see the bunfs virtual FS. The helper lives in
+            // `crate::jsc_hooks` — same crate, so a direct call.
+            let _ = vm;
+            if let Some(len) = crate::jsc_hooks::resolve_embedded_file_to_buf(
+                name_slice.slice(),
+                ext,
+                &mut filepath_buf[..],
+            ) {
+                // Spec `ffi.zig:1041` — NUL-terminate in place so `DynLib::open`
+                // can pass the slice to libc without copying. `resolve_*_to_buf`
+                // is bounded by `Fs::FileSystem::tmpname` + a tmpdir join (both
+                // fit in `PATH_MAX`), so `filepath_buf[len]` is in bounds.
+                filepath_buf[len] = 0;
+                break 'brk &filepath_buf[0..len];
             }
 
             break 'brk name_slice.slice();

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4463,29 +4463,27 @@ unsafe fn transpile_virtual_module(
     }
 }
 
-/// `LoaderHooks::resolve_embedded_node_file` body — port of
-/// `ModuleLoader.resolveEmbeddedFile` (spec ModuleLoader.zig:33-71) for the
-/// `process.dlopen()`-on-a-compiled-executable path. Extracts an embedded
-/// `.node` addon from the standalone module graph to a real on-disk temp file
-/// and writes the resulting path back into `*in_out_str`
-/// (`bun.String.cloneUTF8(result)`).
+/// Core of `ModuleLoader.resolveEmbeddedFile` (spec ModuleLoader.zig:33-71):
+/// finds an embedded file in the standalone module graph, materializes it to
+/// a real on-disk temp file with `extname`, and writes the resulting absolute
+/// path into `out_buf`. Returns the number of bytes written.
 ///
-/// # Safety
-/// `vm` is the live per-thread VM; `in_out_str` is a valid in/out
-/// `bun.String*` (C++ ABI, BunProcess.cpp). Caller (`Bun__resolveEmbeddedNodeFile`
-/// in `bun_jsc::module_loader`) has already checked
-/// `vm.standalone_module_graph.is_some()`.
-unsafe fn resolve_embedded_node_file_hook(
-    vm: *mut VirtualMachine,
-    in_out_str: *mut bun_core::String,
-) -> bool {
-    // Spec ModuleLoader.zig:1334-1337 — `in_out_str.toUTF8()` + `path_buffer_pool.get()`.
-    // SAFETY: per fn contract — `in_out_str` is a valid `bun.String*`.
-    let input_path_utf8 = unsafe { &*in_out_str }.to_utf8();
-    let input_path = input_path_utf8.slice();
+/// Called from two paths:
+///   - `resolve_embedded_node_file_hook` (`process.dlopen()` on a compiled
+///     executable; extname = `"node"`).
+///   - `bun:ffi` `dlopen()` on an embedded `with { type: "file" }` shared
+///     library (`ffi_body::FFI::open`; extname = `"so"` / `"dylib"` / `"dll"`).
+///
+/// Returns `None` when the path is empty, not present in the graph, or any
+/// filesystem step fails.
+pub(crate) fn resolve_embedded_file_to_buf(
+    input_path: &[u8],
+    extname: &[u8],
+    out_buf: &mut [u8],
+) -> Option<usize> {
     // Spec ModuleLoader.zig:34 — `if (input_path.len == 0) return null`.
     if input_path.is_empty() {
-        return false;
+        return None;
     }
 
     // Spec ModuleLoader.zig:35-36 — `vm.standalone_module_graph orelse return
@@ -4496,39 +4494,28 @@ unsafe fn resolve_embedded_node_file_hook(
     // read-only (instant UB under Stacked Borrows). Reach the concrete graph
     // via `Graph::get()` which hands out the `UnsafeCell` `*mut` (same path
     // as `load_standalone_sourcemap` / `node_fs`).
-    let _ = vm;
-    let Some(graph) = bun_standalone_graph::Graph::get() else {
-        return false;
-    };
+    let graph = bun_standalone_graph::Graph::get()?;
     // SAFETY: `graph` is the `UnsafeCell::get()` pointer to the
     // process-lifetime singleton; this hook runs on the JS thread and `find`
     // is read-only over the post-init `files` table.
-    let Some(file) = (unsafe { &mut *graph }).find(input_path) else {
-        return false;
-    };
+    let file = (unsafe { &mut *graph }).find(input_path)?;
     let file_name: &[u8] = file.name;
     let file_contents: &[u8] = file.contents.as_bytes();
 
-    // Spec ModuleLoader.zig:43-45 — `tmpname("node", buf, bun.hash(file.name))`.
+    // Spec ModuleLoader.zig:43-45 — `tmpname(extname, buf, bun.hash(file.name))`.
     let mut tmpname_buf = bun_paths::path_buffer_pool::get();
-    let Ok(tmpfilename) =
-        Fs::FileSystem::tmpname(b"node", &mut tmpname_buf[..], bun_wyhash::hash(file_name))
-    else {
-        return false;
-    };
+    let tmpfilename =
+        Fs::FileSystem::tmpname(extname, &mut tmpname_buf[..], bun_wyhash::hash(file_name))
+            .ok()?;
 
     // Spec ModuleLoader.zig:47 — `bun.fs.FileSystem.instance.tmpdir()`.
     // SAFETY: `FileSystem::instance()` returns the process-global singleton
     // pointer (initialized at startup).
-    let Ok(tmpdir) = (unsafe { &mut *Fs::FileSystem::instance() }).tmpdir() else {
-        return false;
-    };
+    let tmpdir = (unsafe { &mut *Fs::FileSystem::instance() }).tmpdir().ok()?;
     let tmpdir_fd: bun_sys::Fd = tmpdir.fd;
 
     // Spec ModuleLoader.zig:50-51 — `bun.Tmpfile.create(tmpdir, tmpfilename)`.
-    let Ok(tmpfile) = bun_sys::Tmpfile::create(tmpdir_fd, tmpfilename) else {
-        return false;
-    };
+    let tmpfile = bun_sys::Tmpfile::create(tmpdir_fd, tmpfilename).ok()?;
     let tmpfile_fd = tmpfile.fd;
     scopeguard::defer! {
         let _ = bun_sys::close(tmpfile_fd);
@@ -4552,21 +4539,51 @@ unsafe fn resolve_embedded_node_file_hook(
     )
     .is_err()
     {
-        return false;
+        return None;
     }
 
     // Spec ModuleLoader.zig:69 — `joinAbsStringBuf(RealFS.tmpdirPath(),
-    // path_buf, &.{tmpfilename}, .auto)`.
-    let mut path_buf = bun_paths::path_buffer_pool::get();
+    // path_buf, &.{tmpfilename}, .auto)`. `join_abs_string_buf` writes into
+    // `out_buf` and returns a slice pointing into it; capture the length so
+    // the caller knows how many bytes are live.
     let result = bun_paths::resolve_path::join_abs_string_buf::<bun_paths::platform::Auto>(
         Fs::RealFS::tmpdir_path(),
-        &mut path_buf[..],
+        out_buf,
         &[tmpfilename.as_bytes()],
     );
+    Some(result.len())
+}
+
+/// `LoaderHooks::resolve_embedded_node_file` body — port of
+/// `ModuleLoader.resolveEmbeddedFile` (spec ModuleLoader.zig:33-71) for the
+/// `process.dlopen()`-on-a-compiled-executable path. Delegates to
+/// [`resolve_embedded_file_to_buf`] with `extname = "node"` and writes the
+/// resulting on-disk path back into `*in_out_str`
+/// (`bun.String.cloneUTF8(result)`).
+///
+/// # Safety
+/// `vm` is the live per-thread VM; `in_out_str` is a valid in/out
+/// `bun.String*` (C++ ABI, BunProcess.cpp). Caller (`Bun__resolveEmbeddedNodeFile`
+/// in `bun_jsc::module_loader`) has already checked
+/// `vm.standalone_module_graph.is_some()`.
+unsafe fn resolve_embedded_node_file_hook(
+    vm: *mut VirtualMachine,
+    in_out_str: *mut bun_core::String,
+) -> bool {
+    // Spec ModuleLoader.zig:1334-1337 — `in_out_str.toUTF8()` + `path_buffer_pool.get()`.
+    // SAFETY: per fn contract — `in_out_str` is a valid `bun.String*`.
+    let input_path_utf8 = unsafe { &*in_out_str }.to_utf8();
+    let input_path = input_path_utf8.slice();
+    let _ = vm;
+
+    let mut path_buf = bun_paths::path_buffer_pool::get();
+    let Some(len) = resolve_embedded_file_to_buf(input_path, b"node", &mut path_buf[..]) else {
+        return false;
+    };
 
     // Spec ModuleLoader.zig:1339-1340 — `in_out_str.* = bun.String.cloneUTF8(result)`.
     // SAFETY: per fn contract.
-    unsafe { *in_out_str = bun_core::String::clone_utf8(result) };
+    unsafe { *in_out_str = bun_core::String::clone_utf8(&path_buf[..len]) };
     true
 }
 

--- a/test/regression/issue/30717.test.ts
+++ b/test/regression/issue/30717.test.ts
@@ -107,7 +107,10 @@ test.skipIf(isWindows || !cc)(
       console.error("run stderr:", runStderr);
     }
 
-    // Before the fix: `ERR_DLOPEN_FAILED: /$bunfs/root/libhello-XXXX.so: cannot open shared object file`.
+    // Before the fix stderr was `ERR_DLOPEN_FAILED` on the raw
+    // `/$bunfs/root/libhello-<hash>.so` path (libc `dlopen(2)` can't see
+    // the bunfs virtual FS); after the fix the lib is extracted to a real
+    // tmpfile under `RealFS.tmpdirPath()` and loaded cleanly.
     expect(runStderr).not.toContain("ERR_DLOPEN_FAILED");
     expect(runStdout).toContain("loaded: 42");
     expect(runExit).toBe(0);

--- a/test/regression/issue/30717.test.ts
+++ b/test/regression/issue/30717.test.ts
@@ -1,0 +1,116 @@
+// https://github.com/oven-sh/bun/issues/30717
+//
+// Regression: `bun build --compile` of a script that embeds a native library
+// with `{ type: "file" }` and opens it via `bun:ffi`'s `dlopen()` broke in the
+// Rust rewrite (1.3.14-canary, commit 23427dbc12). The Rust port at
+// `src/runtime/ffi/ffi_body.rs` shipped a stub where the Zig original called
+// `ModuleLoader.resolveEmbeddedFile` to materialize the bunfs-embedded library
+// to an on-disk tmpfile; the raw `/$bunfs/...` path fell through to libc
+// `dlopen(2)`, which can't see the bunfs virtual filesystem, and the load
+// failed with `ERR_DLOPEN_FAILED`. Last known-good was 1.3.13 (final Zig).
+//
+// `process.dlopen` for `.node` addons was unaffected — that path still
+// reaches the working `Bun__resolveEmbeddedNodeFile` hook. The ffi path
+// needed the same extraction with the platform extname (`so`/`dylib`/`dll`).
+
+import { expect, test } from "bun:test";
+import { existsSync, unlinkSync } from "fs";
+import { bunEnv, bunExe, isPosix, isWindows, tempDir } from "harness";
+import { join } from "path";
+
+const cc = Bun.which("clang") || Bun.which("gcc") || Bun.which("cc");
+
+// Skip on Windows for now — the repro uses clang/gcc to build a shared lib.
+// The fix is platform-independent (same stub in Rust ran for .dll too) but
+// building a .dll on Windows CI would need a different toolchain wrapper.
+test.skipIf(isWindows || !cc)(
+  'bun:ffi dlopen() works on an embedded `with { type: "file" }` shared library after `bun build --compile`',
+  async () => {
+    // `bun build --compile` reads + rewrites the entire executable (~100 MB
+    // debug, ~500 MB profile) via ELF-section inject on Linux, so the test
+    // is dominated by that single I/O step. 60 s matches `compile/HelloWorld`
+    // and other compile tests in `bundler_compile.test.ts`.
+    const libSuffix = isPosix ? (process.platform === "darwin" ? "dylib" : "so") : "dll";
+
+    using dir = tempDir("issue-30717", {
+      "hello.c": `
+        #include <stdint.h>
+        int32_t hello(void) { return 42; }
+      `,
+      "repro.js": `
+        import libpath from "./libhello.${libSuffix}" with { type: "file" };
+        import { dlopen, FFIType } from "bun:ffi";
+        const lib = dlopen(libpath, { hello: { args: [], returns: FFIType.i32 } });
+        console.log("loaded:", lib.symbols.hello());
+      `,
+    });
+    const dirPath = String(dir);
+
+    // Compile hello.c -> shared library.
+    const libPath = join(dirPath, `libhello.${libSuffix}`);
+    await using ccProc = Bun.spawn({
+      cmd: [cc!, "-shared", "-fPIC", "-o", libPath, join(dirPath, "hello.c")],
+      env: bunEnv,
+      cwd: dirPath,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [ccStderr, ccExit] = await Promise.all([ccProc.stderr.text(), ccProc.exited]);
+    expect(ccStderr).toBe("");
+    expect(ccExit).toBe(0);
+    expect(existsSync(libPath)).toBe(true);
+
+    // `bun build --compile` — bundles the .so into the standalone binary.
+    const outBin = join(dirPath, isWindows ? "repro.exe" : "repro");
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", "repro.js", "--outfile", outBin],
+      env: bunEnv,
+      cwd: dirPath,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [buildStdout, buildStderr, buildExit] = await Promise.all([
+      build.stdout.text(),
+      build.stderr.text(),
+      build.exited,
+    ]);
+    if (buildExit !== 0) {
+      console.error("build stdout:", buildStdout);
+      console.error("build stderr:", buildStderr);
+    }
+    expect(buildExit).toBe(0);
+    expect(existsSync(outBin)).toBe(true);
+
+    // Delete the on-disk library so the compiled binary must use the
+    // embedded copy — otherwise a passing test might just be hitting the
+    // backup `FileSystem::instance().abs(&[name])` path in `dlopen` (spec
+    // ffi.zig:1068-1073) which resolves `./libhello.so` relative to cwd.
+    unlinkSync(libPath);
+
+    // Run from a different cwd so cwd-relative resolution can't find the
+    // library on disk either.
+    await using run = Bun.spawn({
+      cmd: [outBin],
+      env: bunEnv,
+      cwd: "/",
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [runStdout, runStderr, runExit] = await Promise.all([
+      run.stdout.text(),
+      run.stderr.text(),
+      run.exited,
+    ]);
+    // Helpful diagnostic if it fails.
+    if (runExit !== 0) {
+      console.error("run stdout:", runStdout);
+      console.error("run stderr:", runStderr);
+    }
+
+    // Before the fix: `ERR_DLOPEN_FAILED: /$bunfs/root/libhello-XXXX.so: cannot open shared object file`.
+    expect(runStderr).not.toContain("ERR_DLOPEN_FAILED");
+    expect(runStdout).toContain("loaded: 42");
+    expect(runExit).toBe(0);
+  },
+  60_000,
+);

--- a/test/regression/issue/30717.test.ts
+++ b/test/regression/issue/30717.test.ts
@@ -57,8 +57,10 @@ test.skipIf(isWindows || !cc)(
     });
     const [ccStderr, ccExit] = await Promise.all([ccProc.stderr.text(), ccProc.exited]);
     expect(ccStderr).toBe("");
-    expect(ccExit).toBe(0);
     expect(existsSync(libPath)).toBe(true);
+    // CLAUDE.md: assert exit code last so stderr/output diffs are the first
+    // failure the reader sees.
+    expect(ccExit).toBe(0);
 
     // `bun build --compile` — bundles the .so into the standalone binary.
     const outBin = join(dirPath, isWindows ? "repro.exe" : "repro");
@@ -78,8 +80,8 @@ test.skipIf(isWindows || !cc)(
       console.error("build stdout:", buildStdout);
       console.error("build stderr:", buildStderr);
     }
-    expect(buildExit).toBe(0);
     expect(existsSync(outBin)).toBe(true);
+    expect(buildExit).toBe(0);
 
     // Delete the on-disk library so the compiled binary must use the
     // embedded copy — otherwise a passing test might just be hitting the

--- a/test/regression/issue/30717.test.ts
+++ b/test/regression/issue/30717.test.ts
@@ -96,11 +96,7 @@ test.skipIf(isWindows || !cc)(
       stderr: "pipe",
       stdout: "pipe",
     });
-    const [runStdout, runStderr, runExit] = await Promise.all([
-      run.stdout.text(),
-      run.stderr.text(),
-      run.exited,
-    ]);
+    const [runStdout, runStderr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
     // Helpful diagnostic if it fails.
     if (runExit !== 0) {
       console.error("run stdout:", runStdout);


### PR DESCRIPTION
## Reproduction

```js
// repro.js
import libpath from "./libhello.so" with { type: "file" };
import { dlopen, FFIType } from "bun:ffi";
const lib = dlopen(libpath, { hello: { args: [], returns: FFIType.i32 } });
console.log("loaded:", lib.symbols.hello());
```

```bash
clang -shared -fPIC -o libhello.so hello.c
bun repro.js                                    # works → "loaded: 42"
bun build --compile repro.js --outfile repro
./repro                                         # broken on canary
```

Fails with:

```
error: Failed to open library "/$bunfs/root/libhello-XXXX.so":
  /$bunfs/root/libhello-XXXX.so: cannot open shared object file: No such file or directory
 syscall: "dlopen", code: "ERR_DLOPEN_FAILED"
```

## Cause

Regression from the Rust rewrite (1.3.14-canary, commit `23427dbc12`;
last known-good `1.3.13`). The Rust port of `FFI.open`
(`src/runtime/ffi/ffi_body.rs:1486`) shipped a stub where the Zig
original called `jsc.ModuleLoader.resolveEmbeddedFile` to materialize
the bunfs-embedded library to an on-disk tmpfile. The raw `/$bunfs/...`
virtual path fell through to libc `dlopen(2)`, which can't see the
bunfs virtual filesystem.

`process.dlopen` (`.node` addons) was unaffected — that path still
reaches the working `Bun__resolveEmbeddedNodeFile` →
`resolve_embedded_node_file_hook`. The `PORT NOTE` at
`ModuleLoader.rs:561` enumerated only two Zig callers being ported; it
omitted `ffi.zig:1030`.

## Fix

Factor the extraction body out of `resolve_embedded_node_file_hook`
into `resolve_embedded_file_to_buf(input_path, extname, out_buf)`.
Keep the `.node` hook thin (pass `b"node"` and clone the result
into `in_out_str`). Call the helper from `ffi_body` with the
platform-chosen extname (`so`/`dylib`/`dll`). Same-crate call, no
new `LoaderHooks` entry needed.

## Verification

- `test/regression/issue/30717.test.ts`: compiles a C fixture, embeds
  it with `{ type: "file" }`, runs `bun build --compile`, deletes
  the on-disk `.so`, runs the compiled binary from a different cwd,
  asserts it prints `loaded: 42` without `ERR_DLOPEN_FAILED`.
  Fails on pre-fix tree (`ERR_DLOPEN_FAILED /$bunfs/root/…`), passes
  with the fix.
- Existing `test/napi/napi.test.ts` `--compile` tests still load
  `.node` addons correctly (refactor preserves behavior).
- Existing `test/js/bun/ffi/ffi.test.js` tests unchanged.

Fixes #30717.
Fixes #11598.
Fixes #14009.
