### PR TITLE
collections: replace ObjectPool intrusive linked-list with Vec<T> free list

### DIFF
--- a/src/bun_core/deprecated.rs
+++ b/src/bun_core/deprecated.rs
@@ -91,11 +91,9 @@ pub fn buffered_reader_size<const SIZE: usize, R: DeprecatedRead>(
 // ──────────────────────────────────────────────────────────────────────────
 //
 // DEDUP(D050): the Rust port of `SinglyLinkedList` / `SinglyLinkedNode` was
-// removed — the canonical implementation lives at
-// `bun_collections::pool::{SinglyLinkedList, Node}`. The two had diverged
-// (`data: T` vs `data: MaybeUninit<T>`, `*mut`-null vs `Option<*mut>` returns)
-// and this copy had zero callers outside its own unit test. New consumers
-// should depend on `bun_collections::pool` directly.
+// removed — the only consumer (`bun_collections::pool::ObjectPool`) now uses a
+// `Vec<T>` free list, and `DevServer` carries its own local `Vec<NonNull<Node>>`.
+// New consumers should use `Vec` directly.
 
 // ──────────────────────────────────────────────────────────────────────────
 // DoublyLinkedList

--- a/src/collections/lib.rs
+++ b/src/collections/lib.rs
@@ -32,7 +32,7 @@ pub mod linear_fifo;
 // stable: enum const params → const usize/bool, inherent assoc → free aliases.
 pub mod bit_set;
 pub mod pool;
-pub use pool::{ObjectPool, ObjectPoolTrait, ObjectPoolType, PoolGuard};
+pub use pool::{ObjectPool, ObjectPoolType, PoolGuard};
 pub mod comptime_string_map;
 pub use comptime_string_map::{ComptimeStringMap, ComptimeStringMapWithKeyType};
 #[path = "StaticHashMap.rs"]

--- a/src/collections/pool.rs
+++ b/src/collections/pool.rs
@@ -1,245 +1,45 @@
 use core::cell::RefCell;
-use core::marker::PhantomData;
-use core::mem::{MaybeUninit, offset_of};
-use core::ptr;
 
-use bun_core::Error;
-
-// ──────────────────────────────────────────────────────────────────────────
-// SinglyLinkedList
-// ──────────────────────────────────────────────────────────────────────────
-//
-// PORT NOTE: Zig's `SinglyLinkedList(comptime T: type, comptime Parent: type)`
-// threads `Parent` only so that `Node.release()` can call `Parent.release(node)`.
-// In Rust the only `Parent` is `ObjectPool`, so `Node::release` is provided as
-// an inherent method on `ObjectPool` instead and the `Parent` type param is
-// dropped here. Diff readers: `node.release()` call sites become
-// `ObjectPool::<..>::release(node)`.
-
-/// Node inside the linked list wrapping the actual data.
-#[repr(C)]
-pub struct Node<T> {
-    // INTRUSIVE: pool.zig:7 — next link in singly-linked free list
-    pub next: *mut Node<T>,
-    // PORT NOTE: Zig stored `std.mem.Allocator param` here so `destroyNode`
-    // could free via the originating allocator. In Rust the global mimalloc
-    // allocator owns every `Box<Node<T>>`, so the field is dropped and
-    // `destroy_node` uses `heap::take`.
-    //
-    // PORT NOTE: `MaybeUninit<T>` not `T` — Zig's `else undefined` (pool.zig:203)
-    // is well-defined-until-read, but Rust's `assume_init()` on uninit bytes is
-    // immediate UB for any `T` with validity invariants. Callers that use
-    // `INIT == None` write `data` before reading, so we keep the bytes
-    // uninitialized and only `assume_init_*` at access sites.
-    pub data: MaybeUninit<T>,
-}
-
-// PORT NOTE: `pub const Data = T;` (inherent assoc type) is nightly-only;
-// callers can write `T` directly.
-
-impl<T> Node<T> {
-    /// Read `(*p).next` for a known-non-null, live node pointer. Centralises
-    /// the `unsafe { (*p).next }` walk that appears throughout this module's
-    /// list traversals. Caller contract: `p` points at a live `Node<T>` (never
-    /// null — debug-asserted).
-    #[inline(always)]
-    fn next_of(p: *const Node<T>) -> *mut Node<T> {
-        debug_assert!(!p.is_null());
-        // SAFETY: every call site passes a node either just popped from the
-        // free list, just compared non-null in the surrounding `while`/`if`,
-        // or `&self`/`self.first` after an explicit null check.
-        unsafe { (*p).next }
-    }
-
-    /// Access the pooled value.
-    ///
-    /// # Safety
-    /// `data` must be initialized: either the pool was instantiated with
-    /// `T::INIT == Some(_)`, or the caller wrote to `data` after `get()`,
-    /// or the node was created via `push(value)`.
-    #[inline]
-    pub unsafe fn data_ref(&self) -> &T {
-        // SAFETY: caller guarantees `data` is initialized.
-        unsafe { self.data.assume_init_ref() }
-    }
-
-    /// See [`Node::data_ref`] for safety requirements.
-    #[inline]
-    pub unsafe fn data_mut(&mut self) -> &mut T {
-        // SAFETY: caller guarantees `data` is initialized.
-        unsafe { self.data.assume_init_mut() }
-    }
-
-    /// Insert a new node after the current one.
-    ///
-    /// Arguments:
-    ///     new_node: Pointer to the new node to insert.
-    pub fn insert_after(&mut self, new_node: &mut Node<T>) {
-        new_node.next = self.next;
-        self.next = std::ptr::from_mut::<Node<T>>(new_node);
-    }
-
-    /// Remove a node from the list.
-    ///
-    /// Arguments:
-    ///     node: Pointer to the node to be removed.
-    /// Returns:
-    ///     node removed
-    pub fn remove_next(&mut self) -> Option<*mut Node<T>> {
-        let next_node = if self.next.is_null() {
-            return None;
-        } else {
-            self.next
-        };
-        self.next = Node::next_of(next_node);
-        Some(next_node)
-    }
-
-    /// Iterate over the singly-linked list from this node, until the final node is found.
-    /// This operation is O(N).
-    pub fn find_last(&mut self) -> *mut Node<T> {
-        let mut it: *mut Node<T> = std::ptr::from_mut::<Node<T>>(self);
-        loop {
-            let next = Node::next_of(it);
-            if next.is_null() {
-                return it;
-            }
-            it = next;
-        }
-    }
-
-    /// Iterate over each next node, returning the count of all nodes except the starting one.
-    /// This operation is O(N).
-    pub fn count_children(&self) -> usize {
-        let mut count: usize = 0;
-        let mut it: *const Node<T> = self.next;
-        while !it.is_null() {
-            count += 1;
-            it = Node::next_of(it);
-        }
-        count
-    }
-
-    // PORT NOTE: `pub inline fn release(node: *Node) void { Parent.release(node) }`
-    // is expressed as `ObjectPool::<T, ..>::release(node)` at call sites; see
-    // module-level note above.
-}
-
-pub struct SinglyLinkedList<T> {
-    // INTRUSIVE: pool.zig:59 — list head; popFirst hands node to caller
-    pub first: *mut Node<T>,
-}
-
-impl<T> Default for SinglyLinkedList<T> {
-    fn default() -> Self {
-        Self {
-            first: ptr::null_mut(),
-        }
-    }
-}
-
-impl<T> SinglyLinkedList<T> {
-    /// Insert a new node at the head.
-    ///
-    /// Arguments:
-    ///     new_node: Pointer to the new node to insert.
-    pub fn prepend(&mut self, new_node: *mut Node<T>) {
-        // SAFETY: caller guarantees new_node is a live, exclusively-owned Node
-        unsafe { (*new_node).next = self.first };
-        self.first = new_node;
-    }
-
-    /// Remove a node from the list.
-    ///
-    /// Arguments:
-    ///     node: Pointer to the node to be removed.
-    pub fn remove(&mut self, node: *mut Node<T>) {
-        if self.first == node {
-            self.first = Node::next_of(node);
-        } else {
-            // SAFETY: self.first is non-null (else the `==` above would have
-            // matched the null `node`, which callers never pass)
-            let mut current_elm = self.first;
-            // SAFETY: walk live list nodes; Zig's `.?` would panic on null —
-            // mirror that with an unchecked deref (debug_assert in Phase B).
-            unsafe {
-                while (*current_elm).next != node {
-                    current_elm = (*current_elm).next;
-                }
-                (*current_elm).next = (*node).next;
-            }
-        }
-    }
-
-    /// Remove and return the first node in the list.
-    ///
-    /// Returns:
-    ///     A pointer to the first node in the list.
-    pub fn pop_first(&mut self) -> Option<*mut Node<T>> {
-        let first = if self.first.is_null() {
-            return None;
-        } else {
-            self.first
-        };
-        self.first = Node::next_of(first);
-        Some(first)
-    }
-
-    /// Iterate over all nodes, returning the count.
-    /// This operation is O(N).
-    pub fn len(&self) -> usize {
-        if !self.first.is_null() {
-            // SAFETY: first is non-null and live
-            1 + unsafe { (*self.first).count_children() }
-        } else {
-            0
-        }
-    }
-}
+use bun_core::UnwrapOrOom;
 
 // ──────────────────────────────────────────────────────────────────────────
 // ObjectPool
 // ──────────────────────────────────────────────────────────────────────────
+//
+// PORT NOTE: the original Zig design threaded `Box<Node<T>>` through an
+// intrusive `SinglyLinkedList`. No `ObjectPool` caller needs node address
+// stability, so the free list is now a plain `Vec<T>` (push/pop) and values
+// move in/out by value. The lone non-ObjectPool consumer of the intrusive
+// list (`DevServer`'s deferred-request queue) carries its own local `Node`
+// struct + `Vec<NonNull<Node>>`.
 
-const LOG_ALLOCATIONS: bool = false;
+/// Behavior hooks the Zig version expressed via `comptime Init: fn(...)` and
+/// `std.meta.hasFn(Type, "reset")`.
+pub trait ObjectPoolType: Sized + 'static {
+    /// Construct a fresh value when the pool is empty. Mirrors Zig's
+    /// `comptime Init: fn(allocator) Type`; every Rust impl supplies one,
+    /// so the `MaybeUninit` payload + `INIT == None` branch are gone.
+    fn init() -> Self;
 
-/// Behavior hooks the Zig version expressed via `comptime Init: ?fn(...)` and
-/// `std.meta.hasFn(Type, "reset")`. Per PORTING.md §Comptime reflection,
-/// optional-decl checks become a trait with default methods.
-pub trait ObjectPoolType: Sized {
-    /// Mirrors `comptime Init: ?fn(allocator) anyerror!Type`. `None` ⇒ the
-    /// Zig path that left `data` as `undefined`.
-    const INIT: Option<fn() -> Result<Self, Error>> = None;
-
-    /// Mirrors `if (std.meta.hasFn(Type, "reset")) node.data.reset()`.
+    /// Called on a value just popped from the free list, before handing it
+    /// to the caller. Mirrors `if (std.meta.hasFn(Type, "reset")) data.reset()`.
     /// Default is a no-op; types that had `.reset()` in Zig override this.
     #[inline]
     fn reset(&mut self) {}
 }
 
-/// Per-pool mutable state. Zig's `DataStruct`.
+/// Per-pool mutable state.
 pub struct DataStruct<T> {
-    pub list: SinglyLinkedList<T>,
-    pub loaded: bool,
-    // PORT NOTE: Zig used `MaxCountInt = std.math.IntFittingRange(0, max_count)`.
-    // Rust const generics cannot pick an integer type from a const value; use
-    // `usize` and accept the few extra bytes.
-    // PERF(port): was IntFittingRange — profile in Phase B
-    pub count: usize,
+    free: Vec<T>,
 }
 
 impl<T> Default for DataStruct<T> {
     fn default() -> Self {
-        Self {
-            // PORT NOTE: Zig had `list: LinkedList = undefined` — we zero it.
-            list: SinglyLinkedList::default(),
-            loaded: false,
-            count: 0,
-        }
+        Self { free: Vec::new() }
     }
 }
 
-/// Object pool with a singly-linked free list.
+/// Object pool backed by a `Vec<T>` free list.
 ///
 /// `THREADSAFE == true`  ⇒ storage is thread-local (one free list per thread).
 /// `THREADSAFE == false` ⇒ storage is a single process-wide static.
@@ -252,10 +52,6 @@ pub struct ObjectPool<
     S = UnwiredStorage,
 >(core::marker::PhantomData<(T, S)>);
 
-// PORT NOTE: `pub const List = SinglyLinkedList(T)` / `pub const Node = Node(T)`
-// inherent assoc types are nightly-only; callers write `SinglyLinkedList<T>` /
-// `Node<T>` directly.
-
 /// Per-monomorphization storage hook. Generic statics are not expressible in
 /// Rust, so each `(T, THREADSAFE, MAX_COUNT)` instantiation must provide its
 /// own `thread_local!` / `static` via this trait — typically generated by
@@ -266,8 +62,7 @@ pub trait PoolStorage<T>: 'static {
 }
 
 /// Fallback storage that panics on first use. Lets `ObjectPool<T, ..>` name a
-/// concrete type before its storage is wired (matches the prior `data()`
-/// `unreachable!`).
+/// concrete type before its storage is wired.
 pub struct UnwiredStorage;
 impl<T: 'static> PoolStorage<T> for UnwiredStorage {
     fn with<R>(_f: impl FnOnce(&RefCell<DataStruct<T>>) -> R) -> R {
@@ -278,254 +73,96 @@ impl<T: 'static> PoolStorage<T> for UnwiredStorage {
     }
 }
 
-/// Trait alias so callers can name `<Pool as ObjectPoolTrait>::Node` without
-/// knowing the concrete generics.
-pub trait ObjectPoolTrait {
-    type Item;
-    type Node;
-}
-
-impl<T: ObjectPoolType, const TS: bool, const MAX: usize, S> ObjectPoolTrait
-    for ObjectPool<T, TS, MAX, S>
-{
-    type Item = T;
-    type Node = Node<T>;
-}
-
 /// RAII handle for a pooled `T`. Derefs to the inner value; on `Drop`, the
-/// node is returned to its pool. Replaces the Zig `get()` + `defer release()`
+/// value is returned to its pool. Replaces the Zig `get()` + `defer release()`
 /// pair.
-pub struct PoolGuard<'a, T: ObjectPoolType + 'static> {
-    node: *mut Node<T>,
-    release: fn(*mut Node<T>),
-    _marker: PhantomData<&'a mut T>,
+pub struct PoolGuard<T: ObjectPoolType> {
+    value: Option<T>,
+    release: fn(T),
 }
 
-impl<'a, T: ObjectPoolType> core::ops::Deref for PoolGuard<'a, T> {
+impl<T: ObjectPoolType> core::ops::Deref for PoolGuard<T> {
     type Target = T;
     #[inline]
     fn deref(&self) -> &T {
-        // SAFETY: `node` is exclusively owned for the guard's lifetime and its
-        // `data` was initialized by the pool's `get()` path before being handed
-        // out (either via `T::INIT` or by reuse of a previously-written node).
-        unsafe { (*self.node).data.assume_init_ref() }
+        self.value.as_ref().expect("PoolGuard already released")
     }
 }
 
-impl<'a, T: ObjectPoolType> core::ops::DerefMut for PoolGuard<'a, T> {
+impl<T: ObjectPoolType> core::ops::DerefMut for PoolGuard<T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut T {
-        // SAFETY: see `Deref` impl.
-        unsafe { (*self.node).data.assume_init_mut() }
+        self.value.as_mut().expect("PoolGuard already released")
     }
 }
 
-impl<'a, T: ObjectPoolType> Drop for PoolGuard<'a, T> {
+impl<T: ObjectPoolType> Drop for PoolGuard<T> {
     fn drop(&mut self) {
-        (self.release)(self.node);
+        if let Some(value) = self.value.take() {
+            (self.release)(value);
+        }
     }
 }
 
-impl<'a, T: ObjectPoolType> PoolGuard<'a, T> {
-    /// Raw pointer to the underlying node (for callers that need to stash it
-    /// across an FFI boundary). The guard still owns the node.
-    #[inline]
-    pub fn node_ptr(&self) -> *mut Node<T> {
-        self.node
-    }
-}
-
-impl<T: ObjectPoolType + 'static, const THREADSAFE: bool, const MAX_COUNT: usize, S>
+impl<T: ObjectPoolType, const THREADSAFE: bool, const MAX_COUNT: usize, S>
     ObjectPool<T, THREADSAFE, MAX_COUNT, S>
 where
     S: PoolStorage<T>,
 {
-    // We want this to be global
-    // but we don't want to create 3 global variables per pool
-    // instead, we create one global variable per pool
-    //
-    // PORT NOTE: Rust cannot place a `static` / `thread_local!` inside a
-    // generic `impl`; storage is supplied via the `S: PoolStorage<T>` type
-    // parameter (see `object_pool!` for the usual declaration).
+    /// `MAX_COUNT == 0` means "uncapped" (matches the original Zig semantics).
     #[inline]
-    pub fn data<R>(f: impl FnOnce(&RefCell<DataStruct<T>>) -> R) -> R {
-        S::with(f)
-    }
-
     pub fn full() -> bool {
-        if MAX_COUNT == 0 {
-            return false;
-        }
-        Self::data(|cell| {
-            let d = cell.borrow();
-            d.loaded && d.count >= MAX_COUNT
-        })
+        MAX_COUNT > 0 && S::with(|cell| cell.borrow().free.len() >= MAX_COUNT)
     }
 
+    #[inline]
     pub fn has() -> bool {
-        Self::data(|cell| {
-            let d = cell.borrow();
-            d.loaded && !d.list.first.is_null()
-        })
+        S::with(|cell| !cell.borrow().free.is_empty())
     }
 
-    pub fn push(pooled: T) {
-        if cfg!(debug_assertions) {
-            // PORT NOTE: Zig gated on `env.allow_assert`; that is
-            // `Environment.isDebug` ⇒ `cfg!(debug_assertions)`.
-            debug_assert!(!Self::full());
-        }
-
-        let new_node = bun_core::heap::into_raw(Box::new(Node::<T> {
-            next: ptr::null_mut(),
-            data: MaybeUninit::new(pooled),
-        }));
-        Self::release(new_node);
-    }
-
-    pub fn get_if_exists() -> Option<*mut Node<T>> {
-        Self::data(|cell| {
-            let mut d = cell.borrow_mut();
-            if !d.loaded {
-                return None;
-            }
-
-            let node = d.list.pop_first()?;
-            // SAFETY: node was just popped from the free list and is exclusively owned;
-            // free-list nodes always carry initialized `data` (they reach the list
-            // via `push` or `release` of a previously-used node).
-            unsafe { (*node).data.assume_init_mut().reset() };
-            if MAX_COUNT > 0 {
-                d.count = d.count.saturating_sub(1);
-            }
-
-            Some(node)
-        })
-    }
-
-    pub fn first() -> *mut T {
-        // SAFETY: `get_node()` always returns a valid, exclusively-owned node
-        unsafe { (*Self::get_node()).data.as_mut_ptr() }
-    }
-
-    /// Zig `get()` — pop a node from the free list or allocate a fresh one.
-    pub fn get_node() -> *mut Node<T> {
-        let reused = Self::data(|cell| {
-            let mut d = cell.borrow_mut();
-            if d.loaded {
-                if let Some(node) = d.list.pop_first() {
-                    // SAFETY: node just popped from free list, exclusively owned;
-                    // free-list nodes always carry initialized `data`.
-                    unsafe { (*node).data.assume_init_mut().reset() };
-                    if MAX_COUNT > 0 {
-                        d.count = d.count.saturating_sub(1);
-                    }
-                    return Some(node);
-                }
-            }
-            None
-        });
-        if let Some(node) = reused {
-            return node;
-        }
-
-        if LOG_ALLOCATIONS {
-            // PORT NOTE: Zig wrote to stderr via std.fs; banned here. Phase B
-            // can route through `bun_core::Output` if this is ever flipped on.
-            // TODO(port): log "Allocate {type_name} - {size} bytes"
-        }
-
-        // Matches Zig's `data = if (Init) |i| i(..) else undefined` (pool.zig:203).
-        // For `INIT == None` the bytes stay uninitialized; the caller MUST write
-        // `data` before any read (and before `release()`, since `destroy_node`
-        // assumes it is initialized when dropping).
-        let data = match T::INIT {
-            Some(init_) => MaybeUninit::new(init_().expect("unreachable")),
-            None => MaybeUninit::uninit(),
-        };
-        bun_core::heap::into_raw(Box::new(Node::<T> {
-            next: ptr::null_mut(),
-            data,
-        }))
-    }
-
-    /// RAII front-door: pop or allocate a node and wrap it in a `PoolGuard`
-    /// that returns it to this pool on `Drop`.
-    pub fn get() -> PoolGuard<'static, T> {
+    /// RAII front-door: pop or init a value and wrap it in a `PoolGuard` that
+    /// returns it to this pool on `Drop`.
+    #[inline]
+    pub fn get() -> PoolGuard<T> {
         PoolGuard {
-            node: Self::get_node(),
-            release: Self::release,
-            _marker: PhantomData,
+            value: Some(Self::take()),
+            release: Self::put,
         }
     }
 
-    pub fn release_value(value: *mut T) {
-        // SAFETY: `value` points to the `data` field of a live `Node<T>`
-        let node = unsafe { bun_core::from_field_ptr!(Node<T>, data, value) };
-        Self::release(node);
+    /// Pop a value from the free list (resetting it) or `init()` a fresh one.
+    /// Caller owns the result; pair with [`Self::put`] to recycle.
+    #[inline]
+    pub fn take() -> T {
+        Self::take_if_exists().unwrap_or_else(T::init)
     }
 
-    pub fn release(node: *mut Node<T>) {
-        let overflowed = Self::data(|cell| {
+    /// Pop a value from the free list and reset it; `None` if the pool is empty.
+    #[inline]
+    pub fn take_if_exists() -> Option<T> {
+        let mut value = S::with(|cell| cell.borrow_mut().free.pop())?;
+        value.reset();
+        Some(value)
+    }
+
+    /// Return a value to the pool. If the pool is at `MAX_COUNT`, the value is
+    /// dropped instead.
+    #[inline]
+    pub fn put(value: T) {
+        S::with(|cell| {
             let mut d = cell.borrow_mut();
-            if MAX_COUNT > 0 && d.count >= MAX_COUNT {
-                if LOG_ALLOCATIONS {
-                    // TODO(port): log "Free {type_name} - {size} bytes"
-                }
-                return true;
-            }
-
-            if MAX_COUNT > 0 {
-                d.count = d.count.saturating_add(1);
-            }
-
-            if d.loaded {
-                d.list.prepend(node);
+            if MAX_COUNT > 0 && d.free.len() >= MAX_COUNT {
+                drop(value);
             } else {
-                d.list = SinglyLinkedList { first: node };
-                d.loaded = true;
+                d.free.push(value);
             }
-            false
         });
-        if overflowed {
-            Self::destroy_node(node);
-        }
     }
 
+    /// Drop every pooled value and release the free-list buffer.
+    #[inline]
     pub fn delete_all() {
-        let mut next = Self::data(|cell| {
-            let mut dat = cell.borrow_mut();
-            if !dat.loaded {
-                return ptr::null_mut();
-            }
-            dat.loaded = false;
-            dat.count = 0;
-            let head = dat.list.first;
-            dat.list.first = ptr::null_mut();
-            head
-        });
-        while !next.is_null() {
-            let node = next;
-            next = Node::next_of(node);
-            Self::destroy_node(node);
-        }
-    }
-
-    fn destroy_node(node: *mut Node<T>) {
-        // TODO(port): Zig special-cased `Type != bun.Vec<u8>` here to skip
-        // `bun.memory.deinit(&node.data)` for `Vec<u8>` (a known leak the Zig
-        // comment calls out). In Rust, dropping `T` is the moral equivalent of
-        // `bun.memory.deinit`. If `Vec<u8>` (the `Vec<u8>` port) must keep
-        // leaking for compat, gate its `Drop` there — not here.
-        //
-        // SAFETY: `node` was created via `heap::alloc` in `push`/`get` and
-        // is exclusively owned by the caller. `data` is initialized: `destroy_node`
-        // is only reached from `release()` (caller had a usable node, so `data`
-        // was written) or `delete_all()` (free-list nodes, always initialized).
-        unsafe {
-            (*node).data.assume_init_drop();
-            drop(bun_core::heap::take(node));
-        }
+        S::with(|cell| *cell.borrow_mut() = DataStruct::default());
     }
 }
 
@@ -536,7 +173,7 @@ where
 /// Declare an `ObjectPool` alias plus its backing static/thread-local storage.
 ///
 /// ```ignore
-/// // thread-local free list, capped at 32 nodes
+/// // thread-local free list, capped at 32 entries
 /// object_pool!(pub StringVoidMapPool: StringVoidMap, threadsafe, 32);
 /// // process-wide free list, uncapped
 /// object_pool!(BufferPool: Vec<u8>, global, 0);
@@ -636,8 +273,10 @@ macro_rules! __paste_storage {
 /// Zig: `Npm.Registry.BodyPool = ObjectPool(MutableString, MutableString.init2048, true, 8)`
 /// (src/install/npm.zig). Init = `init2048`; reuse = `.reset()`.
 impl ObjectPoolType for bun_core::MutableString {
-    const INIT: Option<fn() -> Result<Self, Error>> =
-        Some(|| bun_core::MutableString::init2048().map_err(Into::into));
+    #[inline]
+    fn init() -> Self {
+        bun_core::MutableString::init2048().unwrap_or_oom()
+    }
     #[inline]
     fn reset(&mut self) {
         bun_core::MutableString::reset(self);

--- a/src/collections/vec_ext.rs
+++ b/src/collections/vec_ext.rs
@@ -661,7 +661,10 @@ impl ByteVecExt for Vec<u8> {
 }
 
 impl crate::pool::ObjectPoolType for Vec<u8> {
-    const INIT: Option<fn() -> Result<Self, bun_core::Error>> = Some(|| Ok(Vec::new()));
+    #[inline]
+    fn init() -> Self {
+        Vec::new()
+    }
     #[inline]
     fn reset(&mut self) {
         self.clear();

--- a/src/http/zlib.rs
+++ b/src/http/zlib.rs
@@ -1,21 +1,36 @@
 use bun_core::MutableString;
 use bun_zlib::{ZlibError, ZlibReaderArrayList};
 
-// PORT NOTE: Zig used `bun.ObjectPool(MutableString, initMutableString, false, 4)` and
-// recovered the node via `container_of`. `MutableString` is a foreign type so we
-// cannot impl `ObjectPoolType` for it directly (orphan rule); a `#[repr(transparent)]`
-// newtype lets us cast `*mut PooledMutableString` ↔ `*mut MutableString` at the API
-// boundary.
+// PORT NOTE: Zig used `bun.ObjectPool(MutableString, initMutableString, false, 4)`.
+// `MutableString` already has an `ObjectPoolType` impl in `bun_collections` (with
+// `init2048`); a `#[repr(transparent)]` newtype gives this pool its own
+// `init_empty` constructor without colliding.
 mod buffer_pool {
     use super::*;
     use bun_collections::ObjectPoolType;
 
     #[repr(transparent)]
-    pub(super) struct PooledMutableString(pub MutableString);
+    pub struct PooledMutableString(pub MutableString);
+
+    impl core::ops::Deref for PooledMutableString {
+        type Target = MutableString;
+        #[inline]
+        fn deref(&self) -> &MutableString {
+            &self.0
+        }
+    }
+    impl core::ops::DerefMut for PooledMutableString {
+        #[inline]
+        fn deref_mut(&mut self) -> &mut MutableString {
+            &mut self.0
+        }
+    }
 
     impl ObjectPoolType for PooledMutableString {
-        const INIT: Option<fn() -> Result<Self, bun_core::Error>> =
-            Some(|| Ok(PooledMutableString(MutableString::init_empty())));
+        #[inline]
+        fn init() -> Self {
+            PooledMutableString(MutableString::init_empty())
+        }
         #[inline]
         fn reset(&mut self) {
             self.0.reset();
@@ -26,24 +41,13 @@ mod buffer_pool {
     // `threadsafe = false` ⇒ `global` storage mode.
     bun_collections::object_pool!(pub BufferPool: PooledMutableString, global, 4);
 
-    pub fn get() -> *mut MutableString {
-        // TODO(port): Zig returns `*MutableString` borrowed from a pool node; consider an RAII
-        // guard in Phase B so callers don't hand-pair get/put.
-        // SAFETY: `first()` returns a valid `*mut PooledMutableString` whose data is initialized
-        // (INIT is Some); #[repr(transparent)] makes the cast to `*mut MutableString` sound.
-        BufferPool::first().cast::<MutableString>()
-    }
-
-    pub fn put(mutable: *mut MutableString) {
-        // SAFETY: `mutable` was returned by `get()` above; #[repr(transparent)] cast is sound;
-        // `release_value` recovers the parent node via offset_of.
-        unsafe {
-            (*mutable).reset();
-            BufferPool::release_value(mutable.cast::<PooledMutableString>());
-        }
+    /// RAII guard derefing to a pooled `MutableString`; returned to the pool on
+    /// `Drop`. (Currently no callers; kept for parity with the Zig API.)
+    pub fn get() -> bun_collections::PoolGuard<PooledMutableString> {
+        BufferPool::get()
     }
 }
-pub use buffer_pool::{get, put};
+pub use buffer_pool::get;
 
 pub fn decompress(compressed_data: &[u8], output: &mut MutableString) -> Result<(), ZlibError> {
     let mut reader = ZlibReaderArrayList::init_with_options_and_list_allocator(

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1535,10 +1535,10 @@ impl StringVoidMap {
         self.map.contains_key(key)
     }
 
-    fn init() -> Result<StringVoidMap, bun_core::Error> {
-        Ok(StringVoidMap {
+    fn init() -> StringVoidMap {
+        StringVoidMap {
             map: StringHashMap::default(),
-        })
+        }
     }
 
     pub fn reset(&mut self) {
@@ -1549,13 +1549,16 @@ impl StringVoidMap {
     /// Returns an RAII guard that derefs to `&mut StringVoidMap` and is
     /// returned to the pool on `Drop` (replaces Zig's `get` + `defer release`).
     #[inline]
-    pub fn get() -> bun_collections::pool::PoolGuard<'static, StringVoidMap> {
+    pub fn get() -> bun_collections::pool::PoolGuard<StringVoidMap> {
         StringVoidMapPool::get()
     }
 }
 
 impl bun_collections::pool::ObjectPoolType for StringVoidMap {
-    const INIT: Option<fn() -> Result<Self, bun_core::Error>> = Some(StringVoidMap::init);
+    #[inline]
+    fn init() -> Self {
+        StringVoidMap::init()
+    }
     #[inline]
     fn reset(&mut self) {
         StringVoidMap::reset(self)

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -188,9 +188,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let strict_loc = fn_body_contains_use_strict(opts.body);
         let has_simple_args = Self::is_simple_parameter_list(args, opts.has_rest_arg);
         // StringVoidMap::get returns a pool guard; Drop releases (replaces Zig `defer release`).
-        let mut duplicate_args_check: Option<
-            bun_collections::pool::PoolGuard<'static, StringVoidMap>,
-        > = None;
+        let mut duplicate_args_check: Option<bun_collections::pool::PoolGuard<StringVoidMap>> =
+            None;
 
         // Section 15.2.1 Static Semantics: Early Errors: "It is a Syntax Error if
         // FunctionBodyContainsUseStrict of FunctionBody is true and

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -901,10 +901,10 @@ impl<'a> TablePrinter<'a> {
                 ));
 
                 // `defer` block: release pooled visit map after formatting.
-                // PORT NOTE: Zig's `defer` body also nulls
+                // PORT NOTE: Zig's `defer` body also clears
                 // `this.value_formatter.map_node`, but `shallow_clone()`
-                // already guarantees the source's `map_node` is `None`, so
-                // only the local clone needs draining. `Formatter::Drop` does
+                // already guarantees the source isn't pooled, so only the
+                // local clone needs draining. `Formatter::Drop` does
                 // the same release, so a plain scope is sufficient.
                 {
                     let result = value_formatter.format::<ENABLE_ANSI_COLORS>(
@@ -913,15 +913,16 @@ impl<'a> TablePrinter<'a> {
                         value,
                         self.global_object,
                     );
-                    if let Some(mut node) = value_formatter.map_node.take() {
-                        self.value_formatter.map_node = None;
-                        let data = formatter::visited::node_data_mut(&mut node);
-                        if data.capacity() > 512 {
-                            data.deinit();
+                    if value_formatter.map_from_pool {
+                        value_formatter.map_from_pool = false;
+                        self.value_formatter.map_from_pool = false;
+                        let mut map = core::mem::take(&mut value_formatter.map);
+                        if map.capacity() > 512 {
+                            map.deinit();
                         } else {
-                            data.clear();
+                            map.clear();
                         }
-                        formatter::visited::Pool::release(node.as_ptr());
+                        formatter::visited::Pool::put(map);
                     }
                     result?;
                 }
@@ -1743,12 +1744,9 @@ pub mod formatter {
         /// `RawSlice` carries the outlives-holder invariant instead.
         pub remaining_values: bun_ptr::RawSlice<JSValue>,
         pub map: visited::Map,
-        /// Pooled backing for `map`. `None` until the first cell that can have
-        /// circular refs is formatted; `Drop` returns it to `visited::Pool`.
-        /// Raw pointer (not `Box`) because `visited::Pool` owns the
-        /// `heap::alloc`/`from_raw` lifecycle — mirrors Zig
-        /// `?*Visited.Pool.Node`.
-        pub map_node: Option<core::ptr::NonNull<visited::PoolNode>>,
+        /// `true` once `map`'s allocation was taken from `visited::Pool`;
+        /// `Drop` returns it there. Mirrors Zig `?*Visited.Pool.Node`.
+        pub map_from_pool: bool,
         pub hide_native: bool,
         pub indent: u32,
         pub depth: u16,
@@ -1778,7 +1776,7 @@ pub mod formatter {
                 global_this,
                 remaining_values: bun_ptr::RawSlice::EMPTY,
                 map: visited::Map::default(),
-                map_node: None,
+                map_from_pool: false,
                 hide_native: false,
                 indent: 0,
                 depth: 0,
@@ -1803,21 +1801,21 @@ pub mod formatter {
         }
 
         /// Zig copies `Formatter` by value (`var f = this.value_formatter;`).
-        /// In Rust `Formatter` has a `Drop` impl and owns `map`/`map_node`,
-        /// so a bit-copy via `ptr::read` would double-free. The Zig copy
-        /// only ever ships scalar config — `map`/`map_node` are always empty
-        /// on the source at the call sites — so we copy those fields
-        /// explicitly and leave `map`/`map_node` fresh on the clone.
+        /// In Rust `Formatter` has a `Drop` impl and owns `map`, so a bit-copy
+        /// via `ptr::read` would double-free. The Zig copy only ever ships
+        /// scalar config — `map` is always empty on the source at the call
+        /// sites — so we copy those fields explicitly and leave `map` fresh on
+        /// the clone.
         pub(super) fn shallow_clone(&self) -> Self {
             debug_assert!(
-                self.map_node.is_none(),
+                !self.map_from_pool,
                 "shallow_clone source must not own a visited map"
             );
             Self {
                 global_this: self.global_this,
                 remaining_values: self.remaining_values,
                 map: visited::Map::default(),
-                map_node: None,
+                map_from_pool: false,
                 hide_native: self.hide_native,
                 indent: self.indent,
                 depth: self.depth,
@@ -1858,22 +1856,17 @@ pub mod formatter {
 
     impl Drop for Formatter<'_> {
         fn drop(&mut self) {
-            if let Some(mut node) = self.map_node.take() {
-                // Move the working map back into the pooled node, shrink if it
-                // ballooned, then return the node to the thread-local pool.
-                // Mirrors `Formatter.deinit` (ConsoleObject.zig:1016-1024).
-                let map = core::mem::take(&mut self.map);
-                // `node_data_mut` is safe: `Map::INIT` is `Some`, so the
-                // pooled slot already holds an (empty, post-`take`) `Map`;
-                // assigning over it drops that empty value and moves `map` in.
-                let data = visited::node_data_mut(&mut node);
-                *data = map;
-                if data.capacity() > 512 {
-                    data.deinit();
+            if self.map_from_pool {
+                // Move the working map back into the pool, shrinking if it
+                // ballooned. Mirrors `Formatter.deinit` (ConsoleObject.zig:1016-1024).
+                self.map_from_pool = false;
+                let mut map = core::mem::take(&mut self.map);
+                if map.capacity() > 512 {
+                    map.deinit();
                 } else {
-                    data.clear();
+                    map.clear();
                 }
-                visited::Pool::release(node.as_ptr());
+                visited::Pool::put(map);
             }
         }
     }
@@ -1981,31 +1974,18 @@ pub mod formatter {
         }
 
         impl bun_collections::pool::ObjectPoolType for Map {
-            // Zig: `ObjectPool(Map, Map.init, true, 16)` — fresh nodes start
+            // Zig: `ObjectPool(Map, Map.init, true, 16)` — fresh entries start
             // with an empty map so `clearRetainingCapacity()` on first use is
             // well-defined.
-            const INIT: Option<fn() -> Result<Self, bun_core::Error>> = Some(|| Ok(Map::default()));
+            #[inline]
+            fn init() -> Self {
+                Map::default()
+            }
         }
 
-        // Thread-local free list, capped at 16 nodes — matches Zig
+        // Thread-local free list, capped at 16 entries — matches Zig
         // `threadsafe = true, max_count = 16`.
         bun_collections::object_pool!(pub Pool: Map, threadsafe, 16);
-        pub type PoolNode = bun_collections::pool::Node<Map>;
-
-        /// Safe `&mut Map` accessor for a pooled node. `Map::INIT` is `Some`,
-        /// so every node returned by [`Pool::get_node`] carries an initialized
-        /// `data` payload, and the caller exclusively owns the node until
-        /// [`Pool::release`]. Centralises the `NonNull::as_mut()` +
-        /// `assume_init_mut()` pair so the four call sites in this file (and
-        /// the cause-chain guard in `VirtualMachine::print_error_instance`)
-        /// don't each open-code two `unsafe` operations.
-        #[inline]
-        pub fn node_data_mut(node: &mut core::ptr::NonNull<PoolNode>) -> &mut Map {
-            // SAFETY: `Map::INIT` is `Some`, so `data` is initialized for
-            // every node from `Pool::get_node()`; the caller owns `node`
-            // exclusively until `Pool::release`, so forming `&mut` is sound.
-            unsafe { node.as_mut().data.assume_init_mut() }
-        }
     }
 
     // ───────────────────────────────────────────────────────────────────────
@@ -3503,13 +3483,9 @@ pub mod formatter {
                 return Ok(false);
             }
 
-            if self.map_node.is_none() {
-                let mut node = core::ptr::NonNull::new(visited::Pool::get_node())
-                    .expect("ObjectPool::get_node always returns a valid heap node");
-                let data = visited::node_data_mut(&mut node);
-                data.clear();
-                self.map = core::mem::take(data);
-                self.map_node = Some(node);
+            if !self.map_from_pool {
+                self.map = visited::Pool::take();
+                self.map_from_pool = true;
             }
 
             let entry = self.map.get_or_put(value).expect("unreachable");
@@ -4121,7 +4097,7 @@ pub mod formatter {
             // Temporarily remove from the visited map to allow
             // printErrorlikeObject to process it. The circular reference
             // check is already done in print_as, so we know it's safe.
-            let was_in_map = if self.map_node.is_some() {
+            let was_in_map = if self.map_from_pool {
                 self.map.remove(&value).is_some()
             } else {
                 false

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6018,13 +6018,9 @@ impl VirtualMachine {
         let mut exception_list = exception_list;
         for &err in &errors_to_append {
             // Circular-ref guard for cause chains.
-            if formatter.map_node.is_none() {
-                let mut node = NonNull::new(console_object::formatter::visited::Pool::get_node())
-                    .expect("ObjectPool::get_node always returns a valid heap node");
-                let data = console_object::formatter::visited::node_data_mut(&mut node);
-                data.clear();
-                formatter.map = core::mem::take(data);
-                formatter.map_node = Some(node);
+            if !formatter.map_from_pool {
+                formatter.map = console_object::formatter::visited::Pool::take();
+                formatter.map_from_pool = true;
             }
 
             let entry = formatter.map.get_or_put(err).expect("unreachable");

--- a/src/parsers/toml.rs
+++ b/src/parsers/toml.rs
@@ -166,9 +166,8 @@ mod hash_map_pool {
     pub(super) type HashMap = bun_collections::HashMap<u64, ()>;
 
     // bun.deprecated.SinglyLinkedList(HashMap)
-    // The Rust mapping is `bun_collections::pool::{SinglyLinkedList, Node}`, but
-    // that stores `MaybeUninit<T>`; this freelist wants `data: T` directly, so it
-    // keeps a local intrusive node with a raw `next` pointer to match shape.
+    // Local intrusive node with a raw `next` pointer; `bun_collections::ObjectPool`
+    // would work here too, but this preserves the Zig freelist shape verbatim.
     pub(super) struct Node {
         pub data: HashMap,
         pub next: *mut Node,

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -624,7 +624,7 @@ pub fn init(options: Options) -> JsResult<Box<DevServer>> {
             NextBundle {
                 route_queue: Default::default(),
                 reload_event: None,
-                requests: deferred_request::List::default(),
+                requests: deferred_request::List::new(),
                 promise: DeferredPromise::default(),
             }
         );
@@ -1135,15 +1135,11 @@ impl Drop for DevServer {
         }
 
         {
-            let mut r = self.next_bundle.requests.first;
-            while !r.is_null() {
-                // SAFETY: intrusive list node; `data` was written by `defer_request`.
-                let request = unsafe { &mut *r };
-                let data = unsafe { request.data.assume_init_mut() };
+            for r in ::core::mem::take(&mut self.next_bundle.requests) {
+                // SAFETY: hive-slot node; `data` was written by `defer_request`.
+                let data = unsafe { (*r.as_ptr()).data.assume_init_mut() };
                 debug_assert!(!matches!(data.handler, Handler::ServerHandler(_)));
-                let next = request.next;
                 data.deref_();
-                r = next;
             }
             self.next_bundle.promise.deinit_idempotently();
         }
@@ -2198,7 +2194,7 @@ impl DevServer {
             deferred_data.weak_ref();
         }
 
-        requests_array.prepend(deferred_ptr);
+        requests_array.push(::core::ptr::NonNull::new(deferred_ptr).expect("hive slot"));
         Ok(())
     }
 }
@@ -2916,8 +2912,20 @@ pub mod deferred_request {
     /// is very silly. This contributes to ~6kb of the initial DevServer allocation.
     pub const MAX_PREALLOCATED: usize = 16;
 
-    pub type List = bun_collections::pool::SinglyLinkedList<DeferredRequest>;
-    pub type Node = bun_collections::pool::Node<DeferredRequest>;
+    /// Nodes are owned by `dev.deferred_request_pool` (a `HiveArrayFallback`
+    /// — stable addresses required for the uWS abort-callback registration).
+    /// `List` is a `Vec` of borrowed pointers; LIFO push/pop matches the
+    /// original `SinglyLinkedList` `prepend`/`pop_first`.
+    pub type List = Vec<::core::ptr::NonNull<Node>>;
+
+    /// `data` is `MaybeUninit` so `HiveArrayFallback::put`'s `drop_in_place`
+    /// is a no-op — `__deinit` already tore down the payload, and on the
+    /// `prepare_and_save_js_request_context` failure path `data` was never
+    /// written.
+    #[repr(C)]
+    pub struct Node {
+        pub data: ::core::mem::MaybeUninit<DeferredRequest>,
+    }
 
     bun_output::define_scoped_log!(debug_log_dr, DlogeferredRequest, hidden);
     pub(super) use debug_log_dr;
@@ -3014,8 +3022,8 @@ impl DeferredRequest {
             bun_core::from_field_ptr!(deferred_request::Node, data, std::ptr::from_mut(self))
         };
         // SAFETY: dev backref is valid while the pool entry exists; `node` is a
-        // fully-initialized hive slot. `pool::Node<T>` has no drop glue (`data`
-        // is `MaybeUninit`), so `put`'s in-place drop is a no-op — `__deinit`
+        // fully-initialized hive slot. `Node` has no drop glue (`data` is
+        // `MaybeUninit`), so `put`'s in-place drop is a no-op — `__deinit`
         // already tore down the payload.
         unsafe {
             (*self.dev.cast_mut()).deferred_request_pool.put(node);
@@ -3219,7 +3227,7 @@ impl DevServer {
         });
 
         self.next_bundle.promise = DeferredPromise::default();
-        self.next_bundle.requests = deferred_request::List::default();
+        self.next_bundle.requests = deferred_request::List::new();
         self.next_bundle.route_queue.clear_retaining_capacity();
         Ok(())
     }
@@ -3778,16 +3786,15 @@ pub fn finalize_bundle(
         // SAFETY: see `current_bundle!` SAFETY above; this `defer!` runs
         // before `_outer_defer` (LIFO), so `current_bundle_ptr` is still live.
         let current_bundle = unsafe { &mut *current_bundle_ptr_defer };
-        if !current_bundle.requests.first.is_null() {
+        if !current_bundle.requests.is_empty() {
             // cannot be an assertion because in the case of OOM, the request list was not drained.
             Output::debug(
-                "current_bundle.requests.first != null. this leaves pending requests without an error page!",
+                "current_bundle.requests not empty. this leaves pending requests without an error page!",
             );
         }
-        while let Some(node) = current_bundle.requests.pop_first() {
-            // SAFETY: pop_first returns a live `*mut Node<T>`; `data` was
-            // initialized by `defer_request`.
-            let req = unsafe { (*node).data.assume_init_mut() };
+        while let Some(node) = current_bundle.requests.pop() {
+            // SAFETY: hive-slot node; `data` was initialized by `defer_request`.
+            let req = unsafe { (*node.as_ptr()).data.assume_init_mut() };
             req.abort();
             req.deref_();
         }
@@ -4551,10 +4558,9 @@ pub fn finalize_bundle(
             )?;
         }
 
-        while let Some(node) = current_bundle!().requests.pop_first() {
-            // SAFETY: `pop_first` hands back ownership of the intrusive node;
-            // `data` was initialized by `defer_request`.
-            let req = unsafe { (*node).data.assume_init_mut() };
+        while let Some(node) = current_bundle!().requests.pop() {
+            // SAFETY: hive-slot node; `data` was initialized by `defer_request`.
+            let req = unsafe { (*node.as_ptr()).data.assume_init_mut() };
             let req_ptr = std::ptr::from_mut::<DeferredRequest>(req);
             // SAFETY: the node stays alive until `deref_()` releases it below.
             scopeguard::defer! { unsafe { (*req_ptr).deref_() } };
@@ -4656,11 +4662,9 @@ pub fn finalize_bundle(
             } else {
                 'brk: {
                     let route_bundle_index = 'rbi: {
-                        let first = current_bundle!().requests.first;
-                        if !first.is_null() {
-                            // SAFETY: first is an intrusive list node valid while current_bundle.requests holds it
-                            // SAFETY: `data` was initialized by `defer_request`.
-                            break 'rbi unsafe { (*first).data.assume_init_ref() }
+                        if let Some(&first) = current_bundle!().requests.last() {
+                            // SAFETY: hive-slot node; `data` was initialized by `defer_request`.
+                            break 'rbi unsafe { (*first.as_ptr()).data.assume_init_ref() }
                                 .route_bundle_index;
                         }
                         let route_bundle_indices =
@@ -4721,14 +4725,11 @@ pub fn finalize_bundle(
 
     // Set all the deferred routes to the .loaded state up front
     {
-        let mut node = current_bundle!().requests.first;
-        while !node.is_null() {
-            // SAFETY: node is an intrusive list node valid while current_bundle.requests holds it;
-            // `data` was initialized by `defer_request`.
-            let n = unsafe { &*node };
-            let rb = dev.route_bundle_ptr(unsafe { n.data.assume_init_ref() }.route_bundle_index);
+        for &n in current_bundle!().requests.iter() {
+            // SAFETY: hive-slot node; `data` was initialized by `defer_request`.
+            let rb = dev
+                .route_bundle_ptr(unsafe { (*n.as_ptr()).data.assume_init_ref() }.route_bundle_index);
             rb.server_state = route_bundle::State::Loaded;
-            node = n.next;
         }
     }
 
@@ -4749,10 +4750,9 @@ pub fn finalize_bundle(
             .resolve(vm.global(), JSValue::TRUE)?;
     }
 
-    while let Some(node) = current_bundle!().requests.pop_first() {
-        // SAFETY: `pop_first` hands back ownership of the intrusive node;
-        // `data` was initialized by `defer_request`.
-        let req = unsafe { (*node).data.assume_init_mut() };
+    while let Some(node) = current_bundle!().requests.pop() {
+        // SAFETY: hive-slot node; `data` was initialized by `defer_request`.
+        let req = unsafe { (*node.as_ptr()).data.assume_init_mut() };
         let req_ptr = std::ptr::from_mut::<DeferredRequest>(req);
         // SAFETY: the node stays alive until `deref_()` releases it below.
         scopeguard::defer! { unsafe { (*req_ptr).deref_() } };
@@ -4803,7 +4803,7 @@ impl DevServer {
 
         // If there were pending requests, begin another bundle.
         if self.next_bundle.reload_event.is_some()
-            || !self.next_bundle.requests.first.is_null()
+            || !self.next_bundle.requests.is_empty()
             || self.next_bundle.promise.strong.has_value()
         {
             // PERF(port): was stack-fallback (4096)
@@ -6449,11 +6449,10 @@ impl DevServer {
 
     pub fn on_plugins_rejected(&mut self) -> Result<(), bun_core::Error> {
         self.plugin_state = PluginState::Err;
-        while let Some(item) = self.next_bundle.requests.pop_first() {
-            // SAFETY: `pop_first` returns a valid `*mut Node<DeferredRequest>`;
-            // `data` was initialized by `defer_request`.
+        while let Some(item) = self.next_bundle.requests.pop() {
+            // SAFETY: hive-slot node; `data` was initialized by `defer_request`.
             unsafe {
-                let d = (*item).data.assume_init_mut();
+                let d = (*item.as_ptr()).data.assume_init_mut();
                 d.abort();
                 d.deref_();
             }

--- a/src/runtime/bake/DevServer/memory_cost.rs
+++ b/src/runtime/bake/DevServer/memory_cost.rs
@@ -165,7 +165,7 @@ pub fn memory_cost_detailed(dev: &DevServer) -> MemoryCost {
     // .current_bundle
     if let Some(bundle) = &dev.current_bundle {
         // PORT NOTE: Zig walked the intrusive list (`while (r) |req| : (r = req.next)`)
-        // only to count nodes; `SinglyLinkedList::len()` does the same O(N) walk.
+        // only to count nodes.
         other_bytes += bundle.requests.len() * size_of::<deferred_request::Node>();
     }
     // .next_bundle

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -172,7 +172,7 @@ impl JestPrettyFormat {
         options: FormatOptions,
     ) -> JsResult<()> {
         let mut fmt: Formatter;
-        // Zig: defer { if (fmt.map_node) |node| { node.data = fmt.map; node.data.clearRetainingCapacity(); node.release(); } }
+        // Zig: defer { if (fmt.map_node) |node| { ... node.release(); } } — handled by `Drop`.
         // (.zig:79-85). Realized as `impl Drop for Formatter` below — the pool
         // node is acquired lazily inside `print_as` and swapped back on every
         // exit path of this function (early return, `?` propagation, happy path).
@@ -290,7 +290,7 @@ impl JestPrettyFormat {
             let _ = writer.flush();
         }
 
-        // map_node release handled by `impl Drop for Formatter`.
+        // pooled map release handled by `impl Drop for Formatter`.
         result
     }
 }
@@ -326,11 +326,13 @@ pub mod visited {
     }
 
     // `ObjectPool<T, ..>` requires `T: ObjectPoolType`. Mirrors Zig's
-    // `ObjectPool(Map, Map.init, true, 16)` — `INIT` allocates an empty map,
-    // `reset` is `clearRetainingCapacity` (handled by callers via `.clear()`).
+    // `ObjectPool(Map, Map.init, true, 16)` — `init` allocates an empty map,
+    // `reset` is `clearRetainingCapacity`.
     impl bun_collections::pool::ObjectPoolType for Map {
-        const INIT: Option<fn() -> Result<Self, bun_core::Error>> =
-            Some(|| Ok(Map::default()));
+        #[inline]
+        fn init() -> Self {
+            Map::default()
+        }
         #[inline]
         fn reset(&mut self) {
             self.0.clear();
@@ -338,18 +340,18 @@ pub mod visited {
     }
 
     // Mirrors Zig's `ObjectPool(Map, Map.init, true, 16)` — thread-local free
-    // list, capped at 16 nodes. `object_pool!` wires the per-monomorphization
+    // list, capped at 16 entries. `object_pool!` wires the per-monomorphization
     // storage; without it `ObjectPool<Map, true, 16>` defaults to
-    // `UnwiredStorage` which panics on first `get_node()`.
+    // `UnwiredStorage` which panics on first use.
     bun_collections::object_pool!(pub Pool: Map, threadsafe, 16);
-    pub type PoolNode = <Pool as bun_collections::pool::ObjectPoolTrait>::Node;
 }
 
 pub struct Formatter<'a> {
     pub remaining_values: &'a [JSValue],
     pub map: visited::Map,
-    /// Lazily acquired from `visited::Pool`; released back in `Drop`.
-    pub map_node: Option<core::ptr::NonNull<visited::PoolNode>>,
+    /// `true` once `map`'s allocation was taken from `visited::Pool`; `Drop`
+    /// returns it there.
+    pub map_from_pool: bool,
     pub hide_native: bool,
     pub global_this: &'a JSGlobalObject,
     pub indent: u32,
@@ -364,7 +366,7 @@ impl<'a> Formatter<'a> {
         Self {
             remaining_values: &[],
             map: visited::Map::default(),
-            map_node: None,
+            map_from_pool: false,
             hide_native: false,
             global_this: global,
             indent: 0,
@@ -394,23 +396,17 @@ impl<'a> Formatter<'a> {
 
 // Mirrors the top-level Zig defer in `JestPrettyFormat.format` (.zig:79-85):
 // `defer { if (fmt.map_node) |node| { node.data = fmt.map; node.data.clearRetainingCapacity(); node.release(); } }`
-// The node is acquired lazily inside `print_as` via `visited::Pool::get_node()`;
+// The map is acquired lazily inside `print_as` via `visited::Pool::take()`;
 // releasing here covers every exit path of `format` (early `len == 1` return,
 // `?` propagation from `Tag::get`/`fmt.format`, and the happy path) without
 // the borrow-aliasing a `scopeguard` would introduce.
 impl Drop for Formatter<'_> {
     fn drop(&mut self) {
-        if let Some(node) = self.map_node.take() {
-            // SAFETY: `node` came from `visited::Pool::get_node()` and is
-            // exclusively owned for this `Formatter`'s lifetime; its `data` was
-            // initialized by `Map::INIT`, so `assume_init_mut` observes a valid
-            // `Map`.
-            unsafe {
-                let data = (*node.as_ptr()).data.assume_init_mut();
-                *data = core::mem::take(&mut self.map);
-                data.clear();
-                visited::Pool::release(node.as_ptr());
-            }
+        if self.map_from_pool {
+            self.map_from_pool = false;
+            let mut map = core::mem::take(&mut self.map);
+            map.clear();
+            visited::Pool::put(map);
         }
     }
 }
@@ -1212,25 +1208,13 @@ impl<'a> Formatter<'a> {
         let mut writer = WrappedWriter::new(writer_);
 
         if FORMAT.can_have_circular_references() {
-            if self.map_node.is_none() {
+            if !self.map_from_pool {
                 // PORT NOTE: `visited::Pool::get()` returns an RAII `PoolGuard` that
-                // would release on scope exit; the Zig spec stashes the raw node on
+                // would release on scope exit; the Zig spec stashes the map on
                 // `self` and releases it from `JestPrettyFormat::format`'s defer, so
-                // take the raw node directly. `data` is initialized by
-                // `Map::INIT` (see `visited::Map: ObjectPoolType`).
-                let node = core::ptr::NonNull::new(visited::Pool::get_node())
-                    .expect("ObjectPool::get_node never returns null");
-                self.map_node = Some(node);
-                // PORT NOTE: Zig (.zig:878-880) does a struct copy aliasing the same
-                // backing buffer. Rust takes the map here and swaps it back into
-                // `node.data` at release time (see JestPrettyFormat::format tail),
-                // so the pooled allocation is retained across uses.
-                // SAFETY: see above.
-                unsafe {
-                    let data = (*node.as_ptr()).data.assume_init_mut();
-                    data.clear();
-                    self.map = core::mem::take(data);
-                }
+                // take the value directly and put it back in `Drop`.
+                self.map = visited::Pool::take();
+                self.map_from_pool = true;
             }
 
             let entry = self.map.get_or_put(value).expect("unreachable");

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -22,10 +22,6 @@ use crate::webcore::{AutoFlusher, ByteListPool};
 bun_core::declare_scope!(HTTPServerWritableLog, visible);
 bun_core::declare_scope!(NetworkSinkLog, visible);
 
-/// `bun.ObjectPool(bun.Vec<u8>, ...)::Node` — pooled buffer node type used by
-/// `HTTPServerWritable.pooled_buffer`.
-pub type ByteListPoolNode = bun_collections::pool::Node<Vec<u8>>;
-
 // NetworkSink stores a borrowed `*MultiPartUpload`. Now that `webcore::s3` is
 // wired, alias the module to the real type so `bun_s3::MultiPartUpload` resolves
 // for callers that still spell it that way.
@@ -1081,7 +1077,9 @@ pub type UwsResponse<const SSL: bool, const HTTP3: bool> = c_void;
 pub struct HTTPServerWritable<const SSL: bool, const HTTP3: bool> {
     pub res: Option<*mut UwsResponse<SSL, HTTP3>>,
     pub buffer: Vec<u8>,
-    pub pooled_buffer: Option<NonNull<ByteListPoolNode>>,
+    /// `true` ⇒ `buffer`'s allocation came from `ByteListPool` and should be
+    /// returned there on `unregister_auto_flusher`.
+    pub buffer_from_pool: bool,
     pub offset: BlobSizeType,
 
     pub is_listening_for_abort: bool,
@@ -1114,7 +1112,7 @@ impl<const SSL: bool, const HTTP3: bool> Default for HTTPServerWritable<SSL, HTT
         Self {
             res: None,
             buffer: Vec::<u8>::default(),
-            pooled_buffer: None,
+            buffer_from_pool: false,
             offset: 0,
             is_listening_for_abort: false,
             wrote: 0,
@@ -1240,8 +1238,8 @@ impl<const SSL: bool, const HTTP3: bool> crate::webcore::sink::JsSinkAbi
 // TODO(b2-blocked): full impl depends on `bun_uws::Response<SSL>`
 // const-generic dispatch (the body casts `res` to `*mut uws::Response` without
 // the SSL/H3 parameter), `bun_event_loop::AutoFlusher` free-fns (the local
-// `crate::webcore::AutoFlusher` is a fieldless stub), and `ByteListPool::Node`
-// data access. Un-gate once the UwsResponse type-dispatch trait lands.
+// `crate::webcore::AutoFlusher` is a fieldless stub). Un-gate once the
+// UwsResponse type-dispatch trait lands.
 
 impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
     /// Const-generic → runtime dispatch for the type-erased `res` field.
@@ -1524,21 +1522,11 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         let _ = self.flush_promise(); // TODO: properly propagate exception upwards
 
         if self.buffer.capacity() == 0 {
-            debug_assert!(self.pooled_buffer.is_none());
+            debug_assert!(!self.buffer_from_pool);
             if FeatureFlags::HTTP_BUFFER_POOLING {
-                if let Some(pooled_node) = ByteListPool::get_if_exists() {
-                    let pooled_node = NonNull::new(pooled_node)
-                        .expect("ByteListPool::get_if_exists returns a live heap node when Some");
-                    self.pooled_buffer = Some(pooled_node);
-                    // SAFETY: pooled_node is a valid pool checkout; `data` was
-                    // written by `ByteListPool::push` (or zero-initialized).
-                    // Move the Vec<u8> out by bitwise read and reset the slot.
-                    self.buffer = unsafe {
-                        core::mem::replace(
-                            (*pooled_node.as_ptr()).data.assume_init_mut(),
-                            Vec::<u8>::default(),
-                        )
-                    };
+                if let Some(pooled) = ByteListPool::take_if_exists() {
+                    self.buffer = pooled;
+                    self.buffer_from_pool = true;
                 }
             }
         }
@@ -1955,30 +1943,20 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         }
 
         if !FeatureFlags::HTTP_BUFFER_POOLING {
-            debug_assert!(self.pooled_buffer.is_none());
+            debug_assert!(!self.buffer_from_pool);
         }
 
-        if let Some(pooled) = self.pooled_buffer {
+        if self.buffer_from_pool {
             self.buffer.clear();
             if self.buffer.capacity() > 64 * 1024 {
                 self.buffer.clear_and_free();
             }
-            // SAFETY: pooled is a valid pool node checkout
-            unsafe {
-                (*pooled.as_ptr()).data =
-                    core::mem::MaybeUninit::new(core::mem::take(&mut self.buffer));
-            }
-
-            self.buffer = Vec::<u8>::default();
-            self.pooled_buffer = None;
-            // PORT NOTE: Zig `pooled.release()` → Rust `ObjectPool::release(node)`
-            // (the Node `Parent` back-ref was dropped in the port; see pool.rs).
-            ByteListPool::release(pooled.as_ptr());
+            self.buffer_from_pool = false;
+            ByteListPool::put(core::mem::take(&mut self.buffer));
         } else if self.buffer.capacity() == 0 {
             //
         } else if FeatureFlags::HTTP_BUFFER_POOLING && !ByteListPool::full() {
-            let buffer = core::mem::take(&mut self.buffer);
-            ByteListPool::push(buffer);
+            ByteListPool::put(core::mem::take(&mut self.buffer));
         } else {
             // Don't release this buffer until destroy() is called
             self.buffer.clear();


### PR DESCRIPTION
## What

Removes all 16 `unsafe` blocks from `src/collections/pool.rs` by replacing the intrusive `SinglyLinkedList<Node<T>>` free list with a plain `Vec<T>`.

## Why

No `ObjectPool` caller needs node address stability — pooled values are only ever accessed through `PoolGuard` deref or moved into a struct field. The intrusive list, `MaybeUninit<T>` payload, and raw-pointer `Node` API existed only to mirror the Zig shape.

## How

- **`ObjectPoolType::init` is now mandatory and infallible** (`fn init() -> Self`). Every existing impl already supplied `INIT = Some(|| Ok(..))`, so the `MaybeUninit` payload and `INIT == None` branch were dead.
- **Free list is `Vec<T>`** — push/pop replaces `prepend`/`pop_first`; `len()` becomes O(1); thread-local `Drop` runs `T::drop` on thread exit (was a leak before for pools not in `delete_all_pools_for_thread_exit`).
- **`PoolGuard<T>` holds `Option<T>` by value** (mirrors `bun_paths::path_buffer_pool::PoolGuard`). The `'a` lifetime parameter is dropped.
- **New value-based API**: `take()`, `take_if_exists()`, `put()` replace `get_node()`, `get_if_exists()`, `release()`, `push()`, `first()`, `release_value()`. `take*()` calls `T::reset()` on the popped value, preserving the original behavior.
- **`MAX_COUNT == 0` still means "uncapped"** — `full()` and `put()` guard with `MAX_COUNT > 0 && ...`.
- **DevServer's deferred-request queue** was the only non-ObjectPool consumer of `SinglyLinkedList`/`Node`. It now carries a local `struct Node { data: MaybeUninit<DeferredRequest> }` (named field so `from_field_ptr!` keeps working) + `Vec<NonNull<Node>>`. The hive-slot addresses stay stable for uWS callbacks; only the `.next`-link traversal moves to `Vec` iteration.

## Callers updated

`ConsoleObject`/`VirtualMachine`/`pretty_format` `Formatter.map_node: Option<NonNull<PoolNode>>` → `map_from_pool: bool`; `streams::HTTPServerWritable.pooled_buffer` likewise. `http/zlib.rs::buffer_pool::get` now returns a `PoolGuard` (zero callers; kept for API parity). `StringVoidMap`/`Vec<u8>`/`MutableString` impls switch to `fn init()`.

Removed: `SinglyLinkedList`, `Node`, `ObjectPoolTrait`, `PoolGuard::node_ptr`.
