### PR TITLE
collections: delete dead/redundant unsafe trait methods from VecExt (mechanical subset)

### DIFF
--- a/src/bun_alloc/ast_alloc.rs
+++ b/src/bun_alloc/ast_alloc.rs
@@ -411,7 +411,7 @@ impl AstAlloc {
 
     /// Move `items` element-wise into a fresh AST-heap allocation. Replaces
     /// both `VecExt::from_owned_slice` (`Box<[T]>` → `Vec`) and
-    /// `VecExt::from_bump_slice` (leaked `&mut [T]` → `Vec`): in either case
+    /// `VecExt::from_bump_vec` (`ArenaVec<T>` → `Vec`): in either case
     /// the source storage is on the wrong heap, so a copy is unavoidable.
     #[inline]
     pub fn vec_from_iter<T, I: IntoIterator<Item = T>>(iter: I) -> AstVec<T> {

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -442,8 +442,6 @@ pub mod vec {
 
     /// Reserve `additional`, advance `len` by `additional`, and return the
     /// newly-exposed (uninitialized) tail. Zig `ArrayList.addManyAsSlice`.
-    /// Generic free-fn form of `bun_collections::VecExt::writable_slice` so
-    /// `bun_core::string` can call it without a `bun_collections` edge.
     ///
     /// # Safety
     /// Caller must fully write the returned slice before any read of

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -343,19 +343,13 @@ pub fn generate_symbol_import_and_use(
     );
     let dependencies =
         &mut parts[source_index as usize].slice_mut()[part_index as usize].dependencies;
-    // SAFETY: every element of `new_dependencies` is overwritten in the
-    // zip-loop immediately below before any read/drop.
-    let new_dependencies = unsafe { dependencies.writable_slice(part_ids.len()) };
-    debug_assert_eq!(part_ids.len(), new_dependencies.len());
-    for (part_id, dependency) in part_ids.iter().zip(new_dependencies.iter_mut()) {
-        *dependency = Dependency {
-            // PORT NOTE: `Dependency.source_index` is the structurally
-            // identical `bun_ast::Index`; convert by value until the
-            // two `Index` newtypes unify (Phase B-3).
-            source_index: bun_ast::Index::init(source_index_to_import_from.get()),
-            part_index: *part_id, // @truncate (already u32)
-        };
-    }
+    bun_core::vec::extend_from_fn(dependencies, part_ids.len(), |i| Dependency {
+        // PORT NOTE: `Dependency.source_index` is the structurally
+        // identical `bun_ast::Index`; convert by value until the
+        // two `Index` newtypes unify (Phase B-3).
+        source_index: bun_ast::Index::init(source_index_to_import_from.get()),
+        part_index: part_ids[i], // @truncate (already u32)
+    });
     Ok(())
 }
 

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -1003,10 +1003,8 @@ pub mod parse_worker {
                     },
                     Loc { start: 0 },
                 );
-                let require_args = bump.alloc_slice_fill_default::<Expr>(2);
-                require_args[0] = import_path;
-                let object_properties = bump.alloc_slice_fill_default::<G::Property>(1);
-                object_properties[0] = G::Property {
+                let mut object_properties = G::PropertyList::init_capacity(1);
+                object_properties.push(G::Property {
                     key: Some(Expr::init(
                         E::String {
                             data: b"type".into(),
@@ -1022,21 +1020,21 @@ pub mod parse_worker {
                         Loc { start: 0 },
                     )),
                     ..Default::default()
-                };
-                require_args[1] = Expr::init(
+                });
+                let mut require_args = bun_ast::ExprNodeList::init_capacity(2);
+                require_args.push(import_path);
+                require_args.push(Expr::init(
                     E::Object {
-                        // SAFETY: bump-owned slice; never grown via this Vec.
-                        properties: unsafe { G::PropertyList::from_bump_slice(object_properties) },
+                        properties: object_properties,
                         is_single_line: true,
                         ..Default::default()
                     },
                     Loc { start: 0 },
-                );
+                ));
                 let require_call = Expr::init(
                     E::Call {
                         target: require_property,
-                        // SAFETY: bump-owned slice; never grown via this Vec.
-                        args: unsafe { bun_ast::ExprNodeList::from_bump_slice(require_args) },
+                        args: require_args,
                         ..Default::default()
                     },
                     Loc { start: 0 },
@@ -1101,17 +1099,13 @@ pub mod parse_worker {
                     Loc { start: 0 },
                 );
 
-                let require_args = bump.alloc_slice_fill_default::<Expr>(1);
-                require_args[0] = import_path;
-
                 let root = Expr::init(
                     E::Call {
                         target: Expr {
                             data: ast::ExprData::ERequireCallTarget,
                             loc: Loc { start: 0 },
                         },
-                        // SAFETY: bump-owned slice; never grown via this Vec.
-                        args: unsafe { bun_ast::ExprNodeList::from_bump_slice(require_args) },
+                        args: bun_ast::ExprNodeList::init_one(import_path),
                         ..Default::default()
                     },
                     Loc { start: 0 },
@@ -2862,12 +2856,7 @@ pub mod parse_worker {
         // dealloc the box without running Drop.
         // SAFETY: `result` came from `bun_core::heap::into_raw(Box<Result>)`
         // above; uniquely owned. Dealloc with the same layout, no field Drop.
-        unsafe {
-            std::alloc::dealloc(
-                result.cast::<u8>(),
-                std::alloc::Layout::new::<Result>(),
-            )
-        };
+        unsafe { std::alloc::dealloc(result.cast::<u8>(), std::alloc::Layout::new::<Result>()) };
     }
 
     pub fn on_complete(result: *mut Result) {
@@ -2882,12 +2871,7 @@ pub mod parse_worker {
         // See `on_complete_mini` for why this is `dealloc`, not `drop(take(_))`.
         // SAFETY: `result` came from `bun_core::heap::into_raw(Box<Result>)`
         // above; uniquely owned. Dealloc with the same layout, no field Drop.
-        unsafe {
-            std::alloc::dealloc(
-                result.cast::<u8>(),
-                std::alloc::Layout::new::<Result>(),
-            )
-        };
+        unsafe { std::alloc::dealloc(result.cast::<u8>(), std::alloc::Layout::new::<Result>()) };
     }
 } // end mod parse_worker
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -7514,13 +7514,12 @@ pub mod bv2_impl {
                     .slice_mut()
                     .sort_by(|a, b| strings::order(&a.export_alias, &b.export_alias));
 
-                // Zig value-copies the Vec header so both `result[_]` and the
-                // map slot share the backing buffer; `rename_symbols_in_chunk`
-                // re-reads `imports_from_other_chunks.values()` afterwards. Taking
-                // would leave the map slot empty and break that consumer.
+                // `rename_symbols_in_chunk` re-reads
+                // `imports_from_other_chunks.values()` afterwards, so we can't
+                // take ownership of the map slot here.
                 list.push(CrossChunkImport {
                     chunk_index,
-                    sorted_import_items: import_items.shallow_copy(),
+                    sorted_import_items: import_items.clone(),
                 });
             }
 

--- a/src/bundler/linker_context/computeCrossChunkDependencies.rs
+++ b/src/bundler/linker_context/computeCrossChunkDependencies.rs
@@ -589,12 +589,16 @@ fn compute_cross_chunk_dependencies_with_chunk_metas(
                                 c.arena(),
                             );
                         for item in cross_chunk_import.sorted_import_items.slice() {
+                            // `StoreStr` borrows raw; `sorted_import_items` is
+                            // dropped on the next `list.clear()`, so copy the
+                            // alias bytes into the arena (per StoreStr contract).
+                            let alias = c.arena().alloc_slice_copy(item.export_alias.as_ref());
                             clauses.push(bun_ast::ClauseItem {
                                 name: bun_ast::LocRef {
                                     ref_: Some(item.r#ref),
                                     loc: bun_ast::Loc::EMPTY,
                                 },
-                                alias: bun_ast::StoreStr::new(item.export_alias.as_ref()),
+                                alias: bun_ast::StoreStr::new(alias),
                                 alias_loc: bun_ast::Loc::EMPTY,
                                 original_name: bun_ast::StoreStr::new(b"" as &[u8]),
                             });

--- a/src/bundler/ungate_support.rs
+++ b/src/bundler/ungate_support.rs
@@ -147,9 +147,7 @@ pub type CrossChunkImportItemList = Vec<CrossChunkImportItem>;
 #[derive(Default)]
 pub struct CrossChunkImport {
     pub chunk_index: IndexInt,
-    /// Borrowed view into `ImportsFromOtherChunks` — Zig's `BabyList` has no
-    /// destructor, so dropping `CrossChunkImport` must not free this buffer.
-    pub sorted_import_items: core::mem::ManuallyDrop<CrossChunkImportItemList>,
+    pub sorted_import_items: CrossChunkImportItemList,
 }
 /// `Chunk.zig:ImportsFromOtherChunks`.
 pub mod cross_chunk_import {

--- a/src/collections/vec_ext.rs
+++ b/src/collections/vec_ext.rs
@@ -30,45 +30,19 @@ pub trait VecExt<T>: Sized {
     fn move_from_list(list: Vec<T>) -> Self;
     fn from_owned_slice(items: Box<[T]>) -> Self;
     fn init_with_buffer_vec(buffer: Vec<T>) -> Self;
-    /// Arena-builder → owned `Vec<T>`.  In Zig this was zero-copy (arena ptr
-    /// adopted as `Borrowed`); in the Rust port the linker always called
-    /// `transfer_ownership` afterwards (full copy), so doing the copy up-front
-    /// here is no worse and lets the arena round-trip disappear.
-    ///
-    /// # Safety
-    /// Bitwise-**moves** every element out of `items` into a fresh allocation.
-    /// `items` must be a leaked bump-arena slice (`into_bump_slice_mut` /
-    /// `alloc_slice_*`) that will *never* have its elements read or dropped
-    /// again — i.e. no live `Vec<T>`/`BumpVec<T>` may still own them. Passing
-    /// a slice borrowed from a container that runs element destructors yields
-    /// a double-drop (PTR_AUDIT.md class #1: bitwise-copy of Drop-carrying
-    /// type while source is still live).
-    unsafe fn from_bump_slice(items: &mut [T]) -> Self;
-    /// Safe sibling of [`from_bump_slice`] for `T: Copy` — the
-    /// "source must never be element-dropped again" precondition holds
-    /// vacuously (`Copy` ⇒ no `Drop`), so the bitwise move degenerates to a
-    /// plain copy and needs no `unsafe` at the call site. Takes `&[T]`
-    /// (read-only) since nothing is logically moved out.
-    ///
-    /// Covers the dominant js_parser pattern
-    /// `arena.alloc_slice_copy(&[a, b]) → unsafe { from_bump_slice(..) }` (B-1
-    /// invariant: bump arena outlives the AST). Callers may pass the bump
-    /// slice directly, or skip the intermediate bump alloc entirely and pass
-    /// the stack array — both compile to one memcpy into the global heap.
+    /// `T: Copy` arena slice → owned `Vec<T>`. Covers the dominant js_parser
+    /// pattern `arena.alloc_slice_copy(&[a, b])` → owned list. Callers may
+    /// pass the bump slice directly, or skip the intermediate bump alloc
+    /// entirely and pass the stack array — both compile to one memcpy into the
+    /// global heap.
     fn from_arena_slice(items: &[T]) -> Self
     where
         T: Copy;
-    /// Safe sibling of [`from_bump_slice`]: consumes an `ArenaVec` (sole owner
-    /// of its elements + arena buffer), bitwise-moves every element into a
-    /// fresh global-allocator `Vec<T>`, and leaks the now-logically-empty
-    /// arena buffer back to the bump (reclaimed on arena reset, which never
-    /// runs element destructors). Ownership of every `T` transfers exactly
-    /// once, so no double-drop and no allocator-identity confusion is
+    /// Consumes an `ArenaVec` (sole owner of its elements + arena buffer),
+    /// bitwise-moves every element into a fresh `Vec<T, A>`, and frees the
+    /// now-logically-empty arena buffer. Ownership of every `T` transfers
+    /// exactly once, so no double-drop and no allocator-identity confusion is
     /// possible at the call site.
-    ///
-    /// Prefer this over `unsafe { from_bump_slice(v.into_bump_slice_mut()) }`
-    /// — it encodes the "source is leaked, never dropped again" contract in
-    /// the type system instead of a `// SAFETY:` comment.
     fn from_bump_vec(v: bun_alloc::ArenaVec<'_, T>) -> Self;
     /// Arena pre-reservation: `Vec` cannot allocate from a bump arena, so this
     /// becomes a global-allocator `with_capacity`.  The arena is ignored.
@@ -124,34 +98,18 @@ pub trait VecExt<T>: Sized {
     /// overwritten before any read (including Drop). Prefer
     /// [`unused_capacity_slice`] for `T` with validity invariants.
     unsafe fn expand_to_capacity(&mut self);
-    /// # Safety
-    /// Returns `&mut [T]` over `additional` uninitialized elements. Caller
-    /// must fully initialize the slice before any read/drop. Prefer
-    /// [`unused_capacity_slice`] + `set_len` for non-POD `T`.
-    unsafe fn writable_slice(&mut self, additional: usize) -> &mut [T];
-    /// # Safety
-    /// As [`writable_slice`] but skips `reserve`; caller must guarantee
-    /// `len + additional <= capacity` (debug-asserted). Zig:
-    /// `ArrayList.addManyAsSliceAssumeCapacity`.
-    unsafe fn writable_slice_assume_capacity(&mut self, additional: usize) -> &mut [T];
-    /// # Safety
-    /// As [`writable_slice`] but uses `reserve_exact` so the allocation grows
-    /// to *exactly* `len + additional`. Use when the buffer is the final
-    /// single-shot blob (sourcemap finalize, etc.).
-    unsafe fn writable_slice_exact(&mut self, additional: usize) -> &mut [T];
     /// Reserves `additional` and returns the first `additional` slots of
-    /// spare capacity as `MaybeUninit<T>`. Safe sibling of [`writable_slice`]:
-    /// caller writes some prefix then calls `set_len` (or [`uv_commit`] for
-    /// `Vec<u8>`) to commit. Unlike `spare_capacity_mut()` the returned slice
-    /// is exactly `additional` long, not `capacity - len`.
+    /// spare capacity as `MaybeUninit<T>`. Caller writes some prefix then
+    /// calls `set_len` (or [`bun_core::vec::commit_spare`] for `Vec<u8>`) to
+    /// commit. Unlike `spare_capacity_mut()` the returned slice is exactly
+    /// `additional` long, not `capacity - len`.
     fn reserve_spare(&mut self, additional: usize) -> &mut [core::mem::MaybeUninit<T>];
     /// `reserve(additional)` then [`expand_to_capacity`], returning the
     /// freshly-exposed tail as a raw `(ptr, len)` pair — i.e.
     /// `(next_out, avail_out)` for C streaming APIs (zlib, brotli, zstd).
-    /// Unlike [`writable_slice`] this exposes the *full* over-allocated
-    /// capacity (`cap - prev_len`), not exactly `additional`, so the FFI
-    /// callee can use the allocator's slack. Pass `additional = 0` when the
-    /// caller has already reserved.
+    /// Exposes the *full* over-allocated capacity (`cap - prev_len`), not
+    /// exactly `additional`, so the FFI callee can use the allocator's slack.
+    /// Pass `additional = 0` when the caller has already reserved.
     ///
     /// # Safety
     /// Same as [`expand_to_capacity`]: every byte in `[prev_len, cap)` must be
@@ -167,14 +125,9 @@ pub trait VecExt<T>: Sized {
     /// all callers are gone.
     #[inline]
     fn transfer_ownership(&mut self) {}
-    /// Non-owning header alias.  For `Vec` this is `from_raw_parts` into a
-    /// `ManuallyDrop` — same UB-if-dropped contract as before.
-    fn shallow_copy(&self) -> ManuallyDrop<Self>;
-    fn shallow_clone(&self) -> ManuallyDrop<Self>;
 
     // ── misc ──────────────────────────────────────────────────────────────
     fn unused_capacity_slice(&mut self) -> &mut [core::mem::MaybeUninit<T>];
-    fn allocated_slice(&mut self) -> &mut [core::mem::MaybeUninit<T>];
     fn memory_cost(&self) -> usize;
     fn sort_asc(&mut self)
     where
@@ -240,25 +193,10 @@ impl<T, A: Allocator + Default + 'static> VecExt<T> for Vec<T, A> {
         Self::move_from_list(buffer)
     }
     #[inline]
-    unsafe fn from_bump_slice(items: &mut [T]) -> Self {
-        // SAFETY: caller contract — `items` is a leaked bump-arena slice
-        // (`into_bump_slice_mut`); bitwise-move elements into a fresh `A`
-        // allocation, leaving the arena bytes abandoned (they were already
-        // leaked into the bump and will never be element-dropped).
-        let mut v = Vec::with_capacity_in(items.len(), A::default());
-        unsafe {
-            core::ptr::copy_nonoverlapping(items.as_ptr(), v.as_mut_ptr(), items.len());
-            v.set_len(items.len());
-        }
-        v
-    }
-    #[inline]
     fn from_arena_slice(items: &[T]) -> Self
     where
         T: Copy,
     {
-        // For `T: Copy` the `from_bump_slice` bitwise-move is just a memcpy and
-        // the source carries no destructor.
         let mut v = Vec::with_capacity_in(items.len(), A::default());
         v.extend_from_slice(items);
         v
@@ -424,29 +362,6 @@ impl<T, A: Allocator + Default + 'static> VecExt<T> for Vec<T, A> {
         // before being observed.
         unsafe { self.set_len(self.capacity()) };
     }
-    unsafe fn writable_slice(&mut self, additional: usize) -> &mut [T] {
-        self.reserve(additional);
-        let prev = self.len();
-        // SAFETY: caller contract — slice is fully written before any read.
-        unsafe { self.set_len(prev + additional) };
-        &mut self[prev..]
-    }
-    #[inline]
-    unsafe fn writable_slice_assume_capacity(&mut self, additional: usize) -> &mut [T] {
-        debug_assert!(self.len() + additional <= self.capacity());
-        let prev = self.len();
-        // SAFETY: caller contract — capacity asserted; slice fully written before any read.
-        unsafe { self.set_len(prev + additional) };
-        &mut self[prev..]
-    }
-    #[inline]
-    unsafe fn writable_slice_exact(&mut self, additional: usize) -> &mut [T] {
-        self.reserve_exact(additional);
-        let prev = self.len();
-        // SAFETY: caller contract — slice fully written before any read.
-        unsafe { self.set_len(prev + additional) };
-        &mut self[prev..]
-    }
     #[inline]
     fn reserve_spare(&mut self, additional: usize) -> &mut [core::mem::MaybeUninit<T>] {
         self.reserve(additional);
@@ -493,36 +408,10 @@ impl<T, A: Allocator + Default + 'static> VecExt<T> for Vec<T, A> {
     fn to_owned_slice(&mut self) -> Box<[T]> {
         self.move_to_list().into_boxed_slice()
     }
-    #[inline]
-    fn shallow_copy(&self) -> ManuallyDrop<Self> {
-        // SAFETY: caller must not drop/grow the alias; original stays the owner.
-        ManuallyDrop::new(unsafe {
-            Vec::from_raw_parts_in(
-                self.as_ptr().cast_mut(),
-                self.len(),
-                self.capacity(),
-                A::default(),
-            )
-        })
-    }
-    #[inline]
-    fn shallow_clone(&self) -> ManuallyDrop<Self> {
-        self.shallow_copy()
-    }
 
     #[inline]
     fn unused_capacity_slice(&mut self) -> &mut [core::mem::MaybeUninit<T>] {
         self.spare_capacity_mut()
-    }
-    #[inline]
-    fn allocated_slice(&mut self) -> &mut [core::mem::MaybeUninit<T>] {
-        // SAFETY: ptr[0..cap] is the full allocation.
-        unsafe {
-            core::slice::from_raw_parts_mut(
-                self.as_mut_ptr().cast::<core::mem::MaybeUninit<T>>(),
-                self.capacity(),
-            )
-        }
     }
     #[inline]
     fn memory_cost(&self) -> usize {
@@ -574,31 +463,17 @@ pub trait ByteVecExt {
     fn write(&mut self, str: &[u8]) -> Result<u32, AllocError>;
     fn write_latin1(&mut self, str: &[u8]) -> Result<u32, AllocError>;
     fn write_utf16(&mut self, str: &[u16]) -> Result<u32, AllocError>;
-    fn write_type_as_bytes_assume_capacity<Int: Copy>(&mut self, int: Int);
 
     /// libuv `uv_alloc_cb`-style: ensure **at least** `suggested` bytes of
     /// spare capacity past `len()`, then return the *full* spare-capacity
     /// slice (`len == capacity - len()`, which may exceed `suggested`).
     ///
     /// Callers that must hand libuv exactly `suggested` bytes slice the
-    /// result themselves: `&mut v.uv_alloc_spare(n)[..n]`.
+    /// result themselves: `&mut v.uv_alloc_spare(n)[..n]`. For a `&mut [u8]`
+    /// view (libuv `uv_buf_t` / `read(2)` target), call
+    /// [`bun_core::vec::reserve_spare_bytes`] / [`bun_core::vec::commit_spare`]
+    /// directly.
     fn uv_alloc_spare(&mut self, suggested: usize) -> &mut [core::mem::MaybeUninit<u8>];
-    /// As [`uv_alloc_spare`] but typed `&mut [u8]` so the result can be used
-    /// directly as a `uv_buf_t` / `read(2)` target without a per-site cast.
-    ///
-    /// # Safety
-    /// The returned bytes are **uninitialised**. Caller must only treat the
-    /// prefix actually written by the FFI/syscall as initialised (typically by
-    /// committing with [`uv_commit`]); the bytes must not be read before then.
-    unsafe fn uv_alloc_spare_u8(&mut self, suggested: usize) -> &mut [u8];
-    /// Commit `nread` bytes that the FFI/syscall just wrote into the slice
-    /// returned by [`uv_alloc_spare`] / [`uv_alloc_spare_u8`]: bumps `len` by
-    /// `nread`. Debug-asserts `len + nread <= capacity`.
-    ///
-    /// # Safety
-    /// The `nread` bytes at `[len, len + nread)` must have been initialised by
-    /// the preceding write into the spare slice.
-    unsafe fn uv_commit(&mut self, nread: usize);
 }
 
 impl ByteVecExt for Vec<u8> {
@@ -629,19 +504,6 @@ impl ByteVecExt for Vec<u8> {
         strings::convert_utf16_to_utf8_append(self, str);
         Ok((self.len() - initial) as u32)
     }
-    fn write_type_as_bytes_assume_capacity<Int: Copy>(&mut self, int: Int) {
-        let size = core::mem::size_of::<Int>();
-        debug_assert!(self.capacity() >= self.len() + size);
-        let prev = self.len();
-        // SAFETY: capacity asserted; writing `size` bytes into the uninit tail.
-        unsafe {
-            self.as_mut_ptr()
-                .add(prev)
-                .cast::<Int>()
-                .write_unaligned(int);
-            self.set_len(prev + size);
-        }
-    }
     #[inline]
     fn uv_alloc_spare(&mut self, suggested: usize) -> &mut [core::mem::MaybeUninit<u8>] {
         // `Vec::reserve` already amortises by doubling, so a plain
@@ -649,14 +511,6 @@ impl ByteVecExt for Vec<u8> {
         // dance is needed (it short-circuits internally).
         self.reserve(suggested);
         self.spare_capacity_mut()
-    }
-    #[inline]
-    unsafe fn uv_alloc_spare_u8(&mut self, suggested: usize) -> &mut [u8] {
-        unsafe { bun_core::vec::reserve_spare_bytes(self, suggested) }
-    }
-    #[inline]
-    unsafe fn uv_commit(&mut self, nread: usize) {
-        unsafe { bun_core::vec::commit_spare(self, nread) }
     }
 }
 
@@ -725,31 +579,11 @@ impl OffsetByteList {
 /// `A: Default + 'static` bound that `&'a MimallocArena` (i.e.
 /// [`bun_alloc::ArenaVec`]) does not satisfy. `src` and `dst` may use
 /// distinct allocators.
-///
-/// Ports the open-coded `reserve → ptr::copy(shift) → copy_nonoverlapping →
-/// set_len` pattern that translated Zig's `bun.copy`/`@memcpy` splice for
-/// non-`Copy` element types.
 pub fn prepend_from<T, A: Allocator, B: Allocator>(dst: &mut Vec<T, A>, src: &mut Vec<T, B>) {
-    let src_len = src.len();
-    if src_len == 0 {
+    if src.is_empty() {
         return;
     }
-    let dst_len = dst.len();
-    dst.reserve(src_len);
-    // SAFETY: `reserve` guarantees capacity for `dst_len + src_len`. The shift
-    // memmove and the front copy together fully initialize `[0, dst_len+src_len)`.
-    // We commit `dst`'s new length only *after* `src` has been logically emptied
-    // so no element is ever owned by both vecs (no double-drop on unwind — and
-    // none of the ptr ops below can panic anyway).
-    unsafe {
-        let base = dst.as_mut_ptr();
-        // Shift existing `dst` elements right (overlapping → memmove).
-        core::ptr::copy(base, base.add(src_len), dst_len);
-        // `src` is a separate allocation → non-overlapping with `dst`'s buffer.
-        core::ptr::copy_nonoverlapping(src.as_ptr(), base, src_len);
-        // Elements were bitwise-moved out of `src`; relinquish ownership first…
-        src.set_len(0);
-        // …then claim it in `dst`.
-        dst.set_len(dst_len + src_len);
-    }
+    // `Drain<'_, T, B>` is `ExactSizeIterator`, so `splice` reserves once and
+    // shifts the existing tail with a single memmove.
+    dst.splice(0..0, src.drain(..));
 }

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -16,8 +16,8 @@ use crate::defines::Define;
 use crate::lexer as js_lexer;
 use crate::p::P;
 use crate::parser::{
-    Jest, ParseStatementOptions, Runtime, RuntimeFeatures, RuntimeImports,
-    ScanPassResult, SideEffects, WrapMode,
+    Jest, ParseStatementOptions, Runtime, RuntimeFeatures, RuntimeImports, ScanPassResult,
+    SideEffects, WrapMode,
 };
 use bun_ast as js_ast;
 use bun_ast::g::Decl;
@@ -1424,12 +1424,7 @@ impl<'a> Parser<'a> {
                                 if let Some(id) = redirect_import_record_index {
                                     part.symbol_uses = Default::default();
                                     return Ok(crate::Result::Ast(Box::new(js_ast::Ast {
-                                        // Borrow the arena/Vec-backed records as a Vec view
-                                        // (matches `P::to_ast`); `p` is dropped immediately
-                                        // after this return so no double-ownership.
-                                        import_records: unsafe {
-                                            Vec::from_bump_slice(p.import_records.items_mut())
-                                        },
+                                        import_records: p.import_records.move_to_baby_list(p.arena),
                                         redirect_import_record_index: Some(id),
                                         named_imports: core::mem::take(&mut *p.named_imports),
                                         named_exports: core::mem::take(&mut p.named_exports),
@@ -1611,10 +1606,7 @@ impl<'a> Parser<'a> {
                     if let Some(star) = export_star_redirect {
                         return Ok(crate::Result::Ast(Box::new(js_ast::Ast {
                             // TODO(port): Zig set `.arena = p.arena`; arena ownership tracked elsewhere in Rust
-                            // See note on the matching arm above re double-ownership.
-                            import_records: unsafe {
-                                Vec::from_bump_slice(p.import_records.items_mut())
-                            },
+                            import_records: p.import_records.move_to_baby_list(p.arena),
                             redirect_import_record_index: Some(star.import_record_index),
                             named_imports: core::mem::take(&mut *p.named_imports),
                             named_exports: core::mem::take(&mut p.named_exports),

--- a/src/jsc/JSONLineBuffer.rs
+++ b/src/jsc/JSONLineBuffer.rs
@@ -132,15 +132,15 @@ impl JSONLineBuffer {
     }
 
     /// Notify the buffer that `nread` bytes were written directly into the
-    /// tail of `data` (via `data.uv_alloc_spare_u8()`).
+    /// tail of `data` (via `bun_core::vec::reserve_spare_bytes`).
     ///
     /// Takes a length, not a `&[u8]`, because the only caller's slice would
     /// alias `&mut self.data` — and only the length is used here. Passing the
     /// slice through would re-introduce the Stacked-Borrows hazard the
     /// `on_read` refactor removed.
     pub fn notify_written(&mut self, nread: usize) {
-        // SAFETY: caller (libuv on_read) wrote `nread` bytes into the uv_alloc_spare* slice.
-        unsafe { self.data.uv_commit(nread) };
+        // SAFETY: caller (libuv on_read) wrote `nread` bytes into the spare-capacity slice.
+        unsafe { bun_core::vec::commit_spare(&mut self.data, nread) };
         self.scan_for_newline();
     }
 }

--- a/src/jsc/ipc.rs
+++ b/src/jsc/ipc.rs
@@ -2148,12 +2148,15 @@ pub mod IPCHandlers {
             match &mut send_queue.incoming {
                 IncomingBuffer::Json(json_buf) => {
                     // SAFETY: libuv writes into this region before notify_written reads.
-                    let spare = unsafe { json_buf.data.uv_alloc_spare_u8(suggested_size) };
+                    let spare = unsafe {
+                        bun_core::vec::reserve_spare_bytes(&mut json_buf.data, suggested_size)
+                    };
                     &mut spare[..suggested_size]
                 }
                 IncomingBuffer::Advanced(adv_buf) => {
                     // SAFETY: libuv writes into this region before on_read commits.
-                    let spare = unsafe { adv_buf.uv_alloc_spare_u8(suggested_size) };
+                    let spare =
+                        unsafe { bun_core::vec::reserve_spare_bytes(adv_buf, suggested_size) };
                     &mut spare[..suggested_size]
                 }
             }
@@ -2238,7 +2241,7 @@ pub mod IPCHandlers {
                         unreachable!()
                     };
                     // SAFETY: `on_read_alloc` reserved ≥ nread bytes; libuv initialised them.
-                    unsafe { adv_buf.uv_commit(nread) };
+                    unsafe { bun_core::vec::commit_spare(adv_buf, nread) };
                     let total_len = adv_buf.len() as usize;
                     let mut slice_start: usize = 0;
 
@@ -2252,7 +2255,7 @@ pub mod IPCHandlers {
                                 Ok(r) => r,
                                 Err(IPCDecodeError::NotEnoughBytes) => {
                                     // copy the remaining bytes to the start of the buffer
-                                    // `total_len == adv_buf.len()` (captured post-uv_commit, never
+                                    // `total_len == adv_buf.len()` (captured post-commit_spare, never
                                     // grown in this loop) ⇒ exact `len - slice_start` truncate.
                                     adv_buf.drain_front(slice_start);
                                     log!("hit NotEnoughBytes3");

--- a/src/runtime/socket/WindowsNamedPipe.rs
+++ b/src/runtime/socket/WindowsNamedPipe.rs
@@ -249,7 +249,8 @@ impl WindowsNamedPipe {
 
     fn on_read_alloc(&mut self, suggested_size: usize) -> &mut [u8] {
         // SAFETY: libuv writes into this region before on_read commits.
-        let spare = unsafe { self.incoming.uv_alloc_spare_u8(suggested_size) };
+        let spare =
+            unsafe { bun_core::vec::reserve_spare_bytes(&mut self.incoming, suggested_size) };
         &mut spare[..suggested_size]
     }
 
@@ -261,7 +262,7 @@ impl WindowsNamedPipe {
     fn on_read(&mut self, nread: usize) {
         bun_output::scoped_log!(WindowsNamedPipe, "onRead ({})", nread);
         // SAFETY: `nread` bytes written by libuv into on_read_alloc's slice.
-        unsafe { self.incoming.uv_commit(nread) };
+        unsafe { bun_core::vec::commit_spare(&mut self.incoming, nread) };
 
         self.reset_timeout();
 

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -9,8 +9,6 @@ use crate::webcore::blob::{
     Blob, ClosingState, FileCloser, FileOpener, MAX_SIZE, SizeType, StoreRef,
 };
 use crate::webcore::node_types::PathOrFileDescriptor;
-#[cfg(windows)]
-use bun_collections::ByteVecExt as _;
 use bun_core::String as BunString;
 use bun_core::{self, Error};
 use bun_io::{self as io, FileAction};
@@ -1410,8 +1408,10 @@ impl<'a> ReadFileUV<'a> {
         this.read_off += SizeType::try_from(result.int()).expect("int cast");
         // SAFETY: libuv wrote result.int() bytes into remaining_buffer()'s spare slice.
         unsafe {
-            this.buffer
-                .uv_commit(usize::try_from(result.int()).expect("int cast"))
+            bun_core::vec::commit_spare(
+                &mut this.buffer,
+                usize::try_from(result.int()).expect("int cast"),
+            )
         };
 
         this.req.deinit();

--- a/src/sourcemap/InternalSourceMap.rs
+++ b/src/sourcemap/InternalSourceMap.rs
@@ -1240,15 +1240,14 @@ impl Builder {
             let total: usize = stream_offset as usize + self.win_stream.len() + STREAM_TAIL_PAD;
 
             let mut out = MutableString::init_empty();
-            // Zig: `out.list.resize(allocator, total)` leaves new bytes undefined.
-            // Every byte in [0..total) is written below: [0..24] zero-filled,
-            // [24..32] header u32s, [32..32+sync_bytes] sync table memcpy,
+            // One-shot blob; pre-size exactly. Every byte in [0..total) is
+            // overwritten below: [0..24] zero-filled, [24..32] header u32s,
+            // [32..32+sync_bytes] sync table memcpy,
             // [stream_offset..stream_offset+win_stream.len()] stream memcpy,
-            // [total-STREAM_TAIL_PAD..total] zero-filled. These ranges are
-            // contiguous (HEADER_SIZE==32, stream_offset==32+sync_bytes), so
-            // no uninit bytes are exposed by set_len.
-            // SAFETY: every byte in [0..total) is written below (see comment above).
-            let blob = unsafe { out.list.writable_slice_exact(total) };
+            // [total-STREAM_TAIL_PAD..total] zero-filled.
+            out.list.reserve_exact(total);
+            out.list.resize(total, 0);
+            let blob = &mut out.list[..];
 
             blob[0..24].fill(0);
             blob[24..28].copy_from_slice(


### PR DESCRIPTION
Part 1 of the `vec_ext.rs` safety cleanup. Deletes the trait methods that have zero or trivially-rewritable callers, leaving the contentious uninit-tail / allocator-transmute / borrowed-slice methods (`expand_to_capacity`, `reserve_expand_tail`, `move_from_list`/`move_to_list`, `from_borrowed_slice_dangerous`, `from_bump_vec` body) for a follow-up.

`unsafe` occurrences in `src/collections/vec_ext.rs`: **38 → 13**.

### Deleted

| Method | Callers | Replacement |
|---|---|---|
| `allocated_slice` | 0 | — |
| `write_type_as_bytes_assume_capacity` | 0 (PipeWriter has its own inherent fn) | — |
| `writable_slice_assume_capacity` | 0 | — |
| `uv_alloc_spare_u8` / `uv_commit` | 7 (thin re-exports) | call `bun_core::vec::{reserve_spare_bytes, commit_spare}` directly |
| `writable_slice` | 1 (`LinkerGraph`) | `bun_core::vec::extend_from_fn` |
| `writable_slice_exact` | 1 (`InternalSourceMap` cold finalize) | `reserve_exact` + `resize(n, 0)` |
| `from_bump_slice` | 5 | `ParseTask` ×3 → direct `init_capacity`/`init_one` + `push`; `parse_entry` ×2 → existing `move_to_baby_list` |
| `shallow_copy` / `shallow_clone` | 1 (`bundle_v2`) | `.clone()`; `CrossChunkImport.sorted_import_items` field changes `ManuallyDrop<List>` → plain `List` |

### Rewritten

- `prepend_from` body → safe `dst.splice(0..0, src.drain(..))`. `Drain` is `ExactSizeIterator`, so `splice` reserves once and shifts with a single memmove. Signature unchanged; both callers (`parse_entry`, `lower_esm_exports_hmr`) are cold post-parse fixups.

### Consumer fix

`computeCrossChunkDependencies.rs`: now that `sorted_import_items` is owned (dropped on the next `list.clear()`) instead of an aliasing `ManuallyDrop`, copy each `export_alias` into the linker arena before wrapping in `StoreStr` — per `StoreStr`'s "arena-owned or `'static`" contract. Caught by ASAN on `splitting.test.ts`.

### Tests

`bun bd test test/bundler/esbuild/` — 776 pass / 3 fail / 5 skip / 111 todo. The 3 failures are `packagejson/MainFieldsErrorMessage*` and reproduce identically on `origin/main` (pre-existing, unrelated to this change).
