### PR TITLE
collections: rewrite DynamicBitSet on Box<[usize]> with safe BitSetRef/BitSetMut views

### DIFF
--- a/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
+++ b/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
@@ -70,7 +70,7 @@ pub fn find_imported_parts_in_js_order(
 
     // PORT NOTE: reshaped for borrowck — capture before constructing visitor
     let with_code_splitting = this.graph.code_splitting;
-    let with_scb = this.graph.is_scb_bitset.bit_length > 0;
+    let with_scb = this.graph.is_scb_bitset.bit_length() > 0;
 
     // PORT NOTE: the Zig visitor holds a *LinkerContext alongside SoA column slices
     // borrowed from it, and mutates one column (`entry_point_chunk_index`). Rust

--- a/src/collections/bit_set.rs
+++ b/src/collections/bit_set.rs
@@ -36,6 +36,8 @@
 //!   allocator, in order to save space.
 
 use core::mem;
+use core::ptr::{self, NonNull};
+use core::slice;
 
 use bun_alloc::AllocError;
 
@@ -768,18 +770,46 @@ impl<const SIZE: usize, const NUM_MASKS: usize> ArrayBitSet<SIZE, NUM_MASKS> {
 
 /// A bit set with runtime-known size, backed by an allocated slice of usize.
 ///
-/// Storage is owned via `Box<[usize]>` and freed on `Drop`. For non-owning
-/// views into a shared buffer (e.g. `DynamicBitSetList`), use `BitSetRef` /
-/// `BitSetMut`.
-#[derive(Default)]
+/// Storage is an owned `Box<[usize]>` stored as a thin pointer (the slice
+/// length is always `num_masks(bit_length)`, so the fat-pointer length word
+/// is redundant) and freed on `Drop`. For non-owning views into a shared
+/// buffer (e.g. `DynamicBitSetList`), use `BitSetRef` / `BitSetMut`.
 pub struct DynamicBitSetUnmanaged {
-    /// The number of valid items in this bit set
-    pub bit_length: usize,
+    /// The number of valid items in this bit set.
+    ///
+    /// Private because the `masks` invariant (and thus `Drop`) derives the
+    /// allocation length from it. Read via `bit_length()` / `capacity()`;
+    /// mutate via `resize()`.
+    bit_length: usize,
 
     /// The bit masks, ordered with lower indices first.
     /// Padding bits at the end must be zeroed.
-    /// `len() == num_masks(bit_length)`; empty for `bit_length == 0`.
-    masks: Box<[usize]>,
+    ///
+    /// Invariant: `(masks, num_masks(bit_length))` is the `(data, len)` of a
+    /// `Box<[usize]>` — `NonNull::dangling()` with length 0 when
+    /// `bit_length == 0`, otherwise a live allocation of exactly
+    /// `num_masks(bit_length)` words. All access goes through
+    /// `masks_slice{,_mut}` / `take_box` / `from_box`.
+    masks: NonNull<usize>,
+}
+
+const _: () = assert!(mem::size_of::<DynamicBitSetUnmanaged>() == 2 * mem::size_of::<usize>());
+
+impl Default for DynamicBitSetUnmanaged {
+    #[inline(always)]
+    fn default() -> Self {
+        Self {
+            bit_length: 0,
+            masks: NonNull::dangling(),
+        }
+    }
+}
+
+impl Drop for DynamicBitSetUnmanaged {
+    #[inline]
+    fn drop(&mut self) {
+        drop(self.take_box());
+    }
 }
 
 /// Shared borrowed view of a bitset's mask words. `Copy`; binary ops on
@@ -802,7 +832,7 @@ impl<'a> From<&'a DynamicBitSetUnmanaged> for BitSetRef<'a> {
     fn from(s: &'a DynamicBitSetUnmanaged) -> Self {
         Self {
             bit_length: s.bit_length,
-            masks: &s.masks,
+            masks: s.masks_slice(),
         }
     }
 }
@@ -895,14 +925,15 @@ impl<'a> BitSetMut<'a> {
 
     pub fn copy_into<'b>(&mut self, other: impl Into<BitSetRef<'b>>) {
         let other = other.into();
+        debug_assert!(self.bit_length >= other.bit_length);
         let bit_length = self.bit_length;
         if bit_length == 0 {
             return;
         }
         let num_masks = self.masks.len();
-        for (a, &b) in self.masks.iter_mut().zip(other.masks) {
-            *a = b;
-        }
+        let src_masks = other.masks.len();
+        self.masks[..src_masks].copy_from_slice(other.masks);
+        self.masks[src_masks..].fill(0);
         let padding_bits =
             u32::try_from(num_masks * DYN_MASK_BITS as usize - bit_length).expect("int cast");
         let last_item_mask = usize::MAX >> padding_bits;
@@ -920,16 +951,50 @@ const DYN_MASK_BITS: u32 = usize::BITS;
 impl DynamicBitSetUnmanaged {
     pub const EMPTY: fn() -> Self = Self::default;
 
+    /// Construct from an owned mask buffer. `masks.len()` must equal
+    /// `num_masks(bit_length)`.
+    #[inline(always)]
+    fn from_box(bit_length: usize, masks: Box<[usize]>) -> Self {
+        debug_assert_eq!(masks.len(), Self::num_masks(bit_length));
+        let ptr = Box::into_raw(masks).cast::<usize>();
+        // SAFETY: `Box::into_raw` never returns null; for an empty slice it
+        // yields `NonNull::dangling()`.
+        let masks = unsafe { NonNull::new_unchecked(ptr) };
+        Self { bit_length, masks }
+    }
+
+    /// Take ownership of the mask buffer, leaving `self` as a valid empty
+    /// bitset (`bit_length == 0`, dangling pointer).
+    #[inline(always)]
+    fn take_box(&mut self) -> Box<[usize]> {
+        let len = Self::num_masks(self.bit_length);
+        let data = mem::replace(&mut self.masks, NonNull::dangling()).as_ptr();
+        self.bit_length = 0;
+        // SAFETY: the `(masks, num_masks(bit_length))` invariant guarantees
+        // this is exactly the `(data, len)` that `Box::<[usize]>::into_raw`
+        // produced in `from_box` (or the dangling/0 empty box for a default
+        // instance). `self` was just reset to empty, so this is the unique
+        // reconstruction.
+        unsafe { Box::from_raw(ptr::slice_from_raw_parts_mut(data, len)) }
+    }
+
     /// Borrow the mask words as a shared slice of length `num_masks(bit_length)`.
     #[inline(always)]
     pub fn masks_slice(&self) -> &[usize] {
-        &self.masks
+        let len = Self::num_masks(self.bit_length);
+        // SAFETY: the `(masks, num_masks(bit_length))` invariant guarantees
+        // `masks` points to `len` initialized words owned by `self` (or is
+        // dangling with `len == 0`). The returned borrow is tied to `&self`.
+        unsafe { slice::from_raw_parts(self.masks.as_ptr(), len) }
     }
 
     /// Borrow the mask words as an exclusive slice of length `num_masks(bit_length)`.
     #[inline(always)]
     pub fn masks_slice_mut(&mut self) -> &mut [usize] {
-        &mut self.masks
+        let len = Self::num_masks(self.bit_length);
+        // SAFETY: as `masks_slice`; `&mut self` guarantees exclusive access to
+        // the owned allocation for the lifetime of the returned borrow.
+        unsafe { slice::from_raw_parts_mut(self.masks.as_ptr(), len) }
     }
 
     #[inline(always)]
@@ -941,7 +1006,7 @@ impl DynamicBitSetUnmanaged {
     pub fn as_mut(&mut self) -> BitSetMut<'_> {
         BitSetMut {
             bit_length: self.bit_length,
-            masks: &mut self.masks,
+            masks: self.masks_slice_mut(),
         }
     }
 
@@ -969,24 +1034,27 @@ impl DynamicBitSetUnmanaged {
 
         if new_masks == 0 {
             debug_assert!(new_len == 0);
-            self.masks = Box::default();
-            self.bit_length = 0;
+            drop(self.take_box());
             return Ok(());
         }
 
         if new_masks != old_masks {
-            let mut v = Vec::from(mem::take(&mut self.masks));
+            let mut v = self.take_box().into_vec();
             if new_masks > v.len() {
                 if let Err(e) = v.try_reserve_exact(new_masks - v.len()) {
                     // Restore the original allocation so `self` stays valid.
-                    self.masks = v.into_boxed_slice();
+                    *self = Self::from_box(old_len, v.into_boxed_slice());
                     let _ = e;
                     return Err(AllocError);
                 }
             }
             v.resize(new_masks, bool_mask_usize(fill));
-            self.masks = v.into_boxed_slice();
+            *self = Self::from_box(new_len, v.into_boxed_slice());
+        } else {
+            self.bit_length = new_len;
         }
+
+        let masks = self.masks_slice_mut();
 
         // If we increased in size, we need to set any new bits
         // to the fill value.
@@ -996,7 +1064,7 @@ impl DynamicBitSetUnmanaged {
                 let old_padding_bits =
                     u32::try_from(old_masks * DYN_MASK_BITS as usize - old_len).expect("int cast");
                 let old_mask = usize::MAX >> old_padding_bits;
-                self.masks[old_masks - 1] |= !old_mask;
+                masks[old_masks - 1] |= !old_mask;
             }
             // new mask words were filled by `v.resize` above
         }
@@ -1006,10 +1074,9 @@ impl DynamicBitSetUnmanaged {
             let padding_bits =
                 u32::try_from(new_masks * DYN_MASK_BITS as usize - new_len).expect("int cast");
             let last_item_mask = usize::MAX >> padding_bits;
-            self.masks[new_masks - 1] &= last_item_mask;
+            masks[new_masks - 1] &= last_item_mask;
         }
 
-        self.bit_length = new_len;
         Ok(())
     }
 
@@ -1017,13 +1084,19 @@ impl DynamicBitSetUnmanaged {
     pub fn clone(&self) -> Result<Self, AllocError> {
         let mut copy = Self::default();
         copy.resize(self.bit_length, false)?;
-        copy.masks.copy_from_slice(&self.masks);
+        copy.masks_slice_mut().copy_from_slice(self.masks_slice());
         Ok(copy)
     }
 
     /// Returns the number of bits in this bit set
     #[inline(always)]
     pub fn capacity(&self) -> usize {
+        self.bit_length
+    }
+
+    /// Returns the number of bits in this bit set (Zig spelling of `capacity()`).
+    #[inline(always)]
+    pub fn bit_length(&self) -> usize {
         self.bit_length
     }
 
@@ -1042,7 +1115,7 @@ impl DynamicBitSetUnmanaged {
     }
 
     pub fn bytes(&self) -> &[u8] {
-        bun_core::cast_slice::<usize, u8>(&self.masks)
+        bun_core::cast_slice::<usize, u8>(self.masks_slice())
     }
 
     /// Returns the total number of set bits in this bit set.
@@ -1061,7 +1134,7 @@ impl DynamicBitSetUnmanaged {
             Self::num_masks(self.bit_length),
             Self::num_masks(other.bit_length)
         );
-        for (a, b) in self.masks.iter().zip(other.masks) {
+        for (a, b) in self.masks_slice().iter().zip(other.masks) {
             if (a & b) != 0 {
                 return true;
             }
@@ -1117,14 +1190,15 @@ impl DynamicBitSetUnmanaged {
             return;
         }
         let num_masks = Self::num_masks(self.bit_length);
-        for (a, &b) in self.masks.iter_mut().zip(toggles.masks) {
+        let masks = self.masks_slice_mut();
+        for (a, &b) in masks.iter_mut().zip(toggles.masks) {
             *a ^= b;
         }
 
         let padding_bits =
             u32::try_from(num_masks * DYN_MASK_BITS as usize - bit_length).expect("int cast");
         let last_item_mask = usize::MAX >> padding_bits;
-        self.masks[num_masks - 1] &= last_item_mask;
+        masks[num_masks - 1] &= last_item_mask;
     }
 
     pub fn set_all(&mut self, value: bool) {
@@ -1181,7 +1255,7 @@ impl DynamicBitSetUnmanaged {
     pub fn set_intersection<'a>(&mut self, other: impl Into<BitSetRef<'a>>) {
         let other = other.into();
         debug_assert!(other.bit_length == self.bit_length);
-        for (a, &b) in self.masks.iter_mut().zip(other.masks) {
+        for (a, &b) in self.masks_slice_mut().iter_mut().zip(other.masks) {
             *a &= b;
         }
     }
@@ -1194,7 +1268,12 @@ impl DynamicBitSetUnmanaged {
         let other = other.into();
         let third = third.into();
         debug_assert!(other.bit_length == self.bit_length);
-        for ((a, &b), &c) in self.masks.iter_mut().zip(other.masks).zip(third.masks) {
+        for ((a, &b), &c) in self
+            .masks_slice_mut()
+            .iter_mut()
+            .zip(other.masks)
+            .zip(third.masks)
+        {
             *a = (*a & !b) & !c;
         }
     }
@@ -1202,7 +1281,7 @@ impl DynamicBitSetUnmanaged {
     pub fn set_exclude<'a>(&mut self, other: impl Into<BitSetRef<'a>>) {
         let other = other.into();
         debug_assert!(other.bit_length == self.bit_length);
-        for (a, &b) in self.masks.iter_mut().zip(other.masks) {
+        for (a, &b) in self.masks_slice_mut().iter_mut().zip(other.masks) {
             *a &= !b;
         }
     }
@@ -1255,7 +1334,7 @@ impl DynamicBitSetUnmanaged {
         if self.bit_length != other.bit_length {
             return false;
         }
-        for (&a, &b) in self.masks.iter().zip(other.masks) {
+        for (&a, &b) in self.masks_slice().iter().zip(other.masks) {
             if a & b != b {
                 return false;
             }

--- a/src/collections/bit_set.rs
+++ b/src/collections/bit_set.rs
@@ -1268,6 +1268,7 @@ impl DynamicBitSetUnmanaged {
         let other = other.into();
         let third = third.into();
         debug_assert!(other.bit_length == self.bit_length);
+        debug_assert!(third.bit_length == self.bit_length);
         for ((a, &b), &c) in self
             .masks_slice_mut()
             .iter_mut()

--- a/src/collections/bit_set.rs
+++ b/src/collections/bit_set.rs
@@ -36,8 +36,6 @@
 //!   allocator, in order to save space.
 
 use core::mem;
-use core::ptr;
-use core::slice;
 
 use bun_alloc::AllocError;
 
@@ -768,26 +766,148 @@ impl<const SIZE: usize, const NUM_MASKS: usize> ArrayBitSet<SIZE, NUM_MASKS> {
 
 // ──────────────────────── DynamicBitSetUnmanaged ────────────────────────
 
-/// A bit set with runtime-known size, backed by an allocated slice
-/// of usize.  The allocator must be tracked externally by the user.
+/// A bit set with runtime-known size, backed by an allocated slice of usize.
 ///
-// TODO(port): the Zig type stores `masks: [*]MaskInt` where `masks[-1]` holds
-// the true allocation length (needed because Zig's allocator API requires the
-// original length on free). The Rust port keeps the same layout because
-// `List` constructs borrowed views into a shared buffer that must look like
-// freestanding `DynamicBitSetUnmanaged`s. Phase B may refactor to `Vec<usize>`
-// once `List` is reworked.
+/// Storage is owned via `Box<[usize]>` and freed on `Drop`. For non-owning
+/// views into a shared buffer (e.g. `DynamicBitSetList`), use `BitSetRef` /
+/// `BitSetMut`.
+#[derive(Default)]
 pub struct DynamicBitSetUnmanaged {
     /// The number of valid items in this bit set
     pub bit_length: usize,
 
     /// The bit masks, ordered with lower indices first.
     /// Padding bits at the end must be zeroed.
-    pub masks: *mut usize,
-    // This pointer is one usize after the actual allocation.
-    // That slot holds the size of the true allocation, which
-    // is needed by Zig's allocator interface in case a shrink
-    // fails.
+    /// `len() == num_masks(bit_length)`; empty for `bit_length == 0`.
+    masks: Box<[usize]>,
+}
+
+/// Shared borrowed view of a bitset's mask words. `Copy`; binary ops on
+/// owned/mutable bitsets accept any type that converts into this.
+#[derive(Clone, Copy)]
+pub struct BitSetRef<'a> {
+    pub bit_length: usize,
+    masks: &'a [usize],
+}
+
+/// Exclusive borrowed view of a bitset's mask words. Returned by
+/// `DynamicBitSetList::at_mut`.
+pub struct BitSetMut<'a> {
+    pub bit_length: usize,
+    masks: &'a mut [usize],
+}
+
+impl<'a> From<&'a DynamicBitSetUnmanaged> for BitSetRef<'a> {
+    #[inline(always)]
+    fn from(s: &'a DynamicBitSetUnmanaged) -> Self {
+        Self {
+            bit_length: s.bit_length,
+            masks: &s.masks,
+        }
+    }
+}
+impl<'a> From<&'a DynamicBitSet> for BitSetRef<'a> {
+    #[inline(always)]
+    fn from(s: &'a DynamicBitSet) -> Self {
+        Self::from(&s.unmanaged)
+    }
+}
+impl<'a, 'b> From<&'b BitSetRef<'a>> for BitSetRef<'a> {
+    #[inline(always)]
+    fn from(r: &'b BitSetRef<'a>) -> Self {
+        *r
+    }
+}
+impl<'a, 'b> From<&'b BitSetMut<'a>> for BitSetRef<'b> {
+    #[inline(always)]
+    fn from(r: &'b BitSetMut<'a>) -> Self {
+        Self {
+            bit_length: r.bit_length,
+            masks: r.masks,
+        }
+    }
+}
+
+impl<'a> BitSetRef<'a> {
+    pub fn is_set(&self, index: usize) -> bool {
+        debug_assert!(index < self.bit_length);
+        (self.masks[word_mask_index(index)] & word_mask_bit(index)) != 0
+    }
+
+    pub fn count(&self) -> usize {
+        let mut total: usize = 0;
+        for mask in self.masks {
+            total += mask.count_ones() as usize;
+        }
+        total
+    }
+
+    pub fn eql<'b>(&self, other: impl Into<BitSetRef<'b>>) -> bool {
+        let other = other.into();
+        self.bit_length == other.bit_length && self.masks == other.masks
+    }
+
+    pub fn subset_of<'b>(&self, other: impl Into<BitSetRef<'b>>) -> bool {
+        let other = other.into();
+        if self.bit_length != other.bit_length {
+            return false;
+        }
+        for (&a, &b) in self.masks.iter().zip(other.masks) {
+            if a & b != a {
+                return false;
+            }
+        }
+        true
+    }
+
+    pub fn iterator<const KIND_SET: bool, const DIR_FWD: bool>(
+        &self,
+    ) -> BitSetIterator<'a, KIND_SET, DIR_FWD> {
+        let num_masks = self.masks.len();
+        let padding_bits =
+            u32::try_from(num_masks * DYN_MASK_BITS as usize - self.bit_length).expect("int cast");
+        let last_item_mask = usize::MAX >> padding_bits;
+        BitSetIterator::init(self.masks, last_item_mask)
+    }
+}
+
+impl<'a> BitSetMut<'a> {
+    #[inline(always)]
+    pub fn as_ref(&self) -> BitSetRef<'_> {
+        BitSetRef {
+            bit_length: self.bit_length,
+            masks: self.masks,
+        }
+    }
+
+    pub fn set(&mut self, index: usize) {
+        debug_assert!(index < self.bit_length);
+        self.masks[word_mask_index(index)] |= word_mask_bit(index);
+    }
+
+    pub fn set_union<'b>(&mut self, other: impl Into<BitSetRef<'b>>) {
+        let other = other.into();
+        debug_assert_eq!(other.bit_length, self.bit_length);
+        for (a, &b) in self.masks.iter_mut().zip(other.masks) {
+            *a |= b;
+        }
+    }
+
+    pub fn copy_into<'b>(&mut self, other: impl Into<BitSetRef<'b>>) {
+        let other = other.into();
+        let bit_length = self.bit_length;
+        if bit_length == 0 {
+            return;
+        }
+        let num_masks = self.masks.len();
+        for (a, &b) in self.masks.iter_mut().zip(other.masks) {
+            *a = b;
+        }
+        let padding_bits =
+            u32::try_from(num_masks * DYN_MASK_BITS as usize - bit_length).expect("int cast");
+        let last_item_mask = usize::MAX >> padding_bits;
+        self.masks[num_masks - 1] &= last_item_mask;
+    }
 }
 
 /// The integer type used to represent a mask in this bit set
@@ -797,94 +917,35 @@ pub type DynShiftInt = u32;
 
 const DYN_MASK_BITS: u32 = usize::BITS;
 
-// Never modified — the Zig comment about needing `static mut` was a Zig
-// limitation (no const-ptr → mut-ptr cast at comptime). All writes through
-// `self.masks` are guarded by `num_masks() > 0`, which is false for the empty
-// sentinel (bit_length == 0). Kept in a `RacyCell` (not `.rodata`) so that
-// forming a `*mut usize` to it remains a legally-mutable pointer target —
-// writing through a pointer derived from an immutable `static` would be UB
-// even if it never happens at runtime, and it lets `masks_slice_mut` form a
-// zero-length `&mut [usize]` without provenance hazards.
-static EMPTY_MASKS_DATA: bun_core::RacyCell<[usize; 2]> = bun_core::RacyCell::new([0, 0]);
-
-#[inline(always)]
-fn empty_masks_ptr() -> *mut usize {
-    // SAFETY: pointer arithmetic into a static array; index 1 is in-bounds.
-    // The `*mut` is never written through while pointing at this static.
-    unsafe { EMPTY_MASKS_DATA.get().cast::<usize>().add(1) }
-}
-
-impl Default for DynamicBitSetUnmanaged {
-    fn default() -> Self {
-        Self {
-            bit_length: 0,
-            masks: empty_masks_ptr(),
-        }
-    }
-}
-
 impl DynamicBitSetUnmanaged {
     pub const EMPTY: fn() -> Self = Self::default;
-    // TODO(port): Zig has `pub const empty: Self = .{ ... }` as a const value.
-    // Rust can't const-init a static-mut-derived pointer; callers should use
-    // `DynamicBitSetUnmanaged::default()`.
 
     /// Borrow the mask words as a shared slice of length `num_masks(bit_length)`.
     #[inline(always)]
     pub fn masks_slice(&self) -> &[usize] {
-        let n = Self::num_masks(self.bit_length);
-        // SAFETY: `masks` is never null (defaults to `empty_masks_ptr()`) and
-        // points to at least `n` valid, initialized usize words, maintained by
-        // `resize` / `List::at`. Padding bits in the last word are zeroed.
-        unsafe { slice::from_raw_parts(self.masks, n) }
+        &self.masks
     }
 
     /// Borrow the mask words as an exclusive slice of length `num_masks(bit_length)`.
-    ///
-    /// Note: two `DynamicBitSetUnmanaged` values may share storage (see
-    /// `DynamicBitSetList::at`). Callers must not hold a `masks_slice_mut()`
-    /// borrow on one view while another aliasing view is read or written.
     #[inline(always)]
     pub fn masks_slice_mut(&mut self) -> &mut [usize] {
-        let n = Self::num_masks(self.bit_length);
-        // SAFETY: see `masks_slice`. `&mut self` gives us exclusive access to
-        // *this* struct; the caller is responsible for not aliasing the
-        // underlying storage via another view.
-        unsafe { slice::from_raw_parts_mut(self.masks, n) }
+        &mut self.masks
     }
 
-    /// Raw pointer to the mask words. Use this (not `masks_slice{,_mut}`) when
-    /// `self` and another `DynamicBitSetUnmanaged` may point at the same
-    /// storage and both are accessed in the same operation — forming
-    /// overlapping `&mut [usize]` / `&[usize]` would be UB.
     #[inline(always)]
-    pub fn masks_ptr(&self) -> *mut usize {
-        self.masks
+    pub fn as_ref(&self) -> BitSetRef<'_> {
+        BitSetRef::from(self)
     }
 
-    /// `self.masks[i] = f(self.masks[i], other.masks[i])` for every mask word.
-    /// Centralises the binary set-op loop (`set_union` / `set_intersection` /
-    /// `set_exclude` / `toggle_set` / `copy_into`) behind a single audited
-    /// raw-pointer access. Raw pointers — not `masks_slice{,_mut}` — because
-    /// `other.masks` may alias `self.masks` when both are views from the same
-    /// `DynamicBitSetList`; forming overlapping `&mut [usize]` / `&[usize]`
-    /// would be UB. `f` receives copied `usize` values, so the per-index read
-    /// happens-before the write even when `src == dst`.
     #[inline(always)]
-    fn zip_masks_raw(&mut self, other: &Self, mut f: impl FnMut(usize, usize) -> usize) {
-        let num_masks = Self::num_masks(self.bit_length);
-        let dst = self.masks;
-        let src = other.masks;
-        for i in 0..num_masks {
-            // SAFETY: `i < num_masks(self.bit_length)`; `dst`/`src` each point
-            // at ≥ `num_masks` initialized words (`resize`/`List::at` invariant).
-            // The two pointers may be equal — see method doc.
-            unsafe { *dst.add(i) = f(*dst.add(i), *src.add(i)) };
+    pub fn as_mut(&mut self) -> BitSetMut<'_> {
+        BitSetMut {
+            bit_length: self.bit_length,
+            masks: &mut self.masks,
         }
     }
 
     /// Creates a bit set with no elements present.
-    /// If bit_length is not zero, deinit must eventually be called.
     pub fn init_empty(bit_length: usize) -> Result<Self, AllocError> {
         let mut this = Self::default();
         this.resize(bit_length, false)?;
@@ -892,7 +953,6 @@ impl DynamicBitSetUnmanaged {
     }
 
     /// Creates a bit set with all elements present.
-    /// If bit_length is not zero, deinit must eventually be called.
     pub fn init_full(bit_length: usize) -> Result<Self, AllocError> {
         let mut this = Self::default();
         this.resize(bit_length, true)?;
@@ -901,55 +961,31 @@ impl DynamicBitSetUnmanaged {
 
     /// Resizes to a new bit_length.  If the new length is larger
     /// than the old length, fills any added bits with `fill`.
-    /// If new_len is not zero, deinit must eventually be called.
+    /// On allocation failure `self` is left unchanged.
     pub fn resize(&mut self, new_len: usize, fill: bool) -> Result<(), AllocError> {
         let old_len = self.bit_length;
-
         let old_masks = Self::num_masks(old_len);
         let new_masks = Self::num_masks(new_len);
 
-        // SAFETY: `self.masks - 1` is the start of the true allocation (or the
-        // start of EMPTY_MASKS_DATA), and `(self.masks - 1)[0]` holds its
-        // length. Maintained by this function.
-        let alloc_base = unsafe { self.masks.sub(1) };
-        let old_alloc_len = unsafe { *alloc_base };
-
         if new_masks == 0 {
             debug_assert!(new_len == 0);
-            // SAFETY: alloc_base/old_alloc_len describe a valid allocation
-            // (possibly the static EMPTY_MASKS_DATA, in which case len==0 and
-            // free is a no-op handled by `dyn_free`).
-            unsafe { dyn_free(alloc_base, old_alloc_len) };
-            self.masks = empty_masks_ptr();
+            self.masks = Box::default();
             self.bit_length = 0;
             return Ok(());
         }
 
-        'realloc: {
-            if old_alloc_len == new_masks + 1 {
-                break 'realloc;
-            }
-            // If realloc fails, it may mean one of two things.
-            // If we are growing, it means we are out of memory.
-            // If we are shrinking, it means the allocator doesn't
-            // want to move the allocation.  This means we need to
-            // hold on to the extra 8 bytes required to be able to free
-            // this allocation properly.
-            // SAFETY: alloc_base/old_alloc_len describe the current allocation.
-            let new_alloc = match unsafe { dyn_realloc(alloc_base, old_alloc_len, new_masks + 1) } {
-                Ok(p) => p,
-                Err(err) => {
-                    if new_masks + 1 > old_alloc_len {
-                        return Err(err);
-                    }
-                    break 'realloc;
+        if new_masks != old_masks {
+            let mut v = Vec::from(mem::take(&mut self.masks));
+            if new_masks > v.len() {
+                if let Err(e) = v.try_reserve_exact(new_masks - v.len()) {
+                    // Restore the original allocation so `self` stays valid.
+                    self.masks = v.into_boxed_slice();
+                    let _ = e;
+                    return Err(AllocError);
                 }
-            };
-
-            // SAFETY: new_alloc points to at least new_masks+1 usize words.
-            unsafe { *new_alloc = new_masks + 1 };
-            // SAFETY: new_alloc points to at least new_masks+1 words; +1 is in-bounds.
-            self.masks = unsafe { new_alloc.add(1) };
+            }
+            v.resize(new_masks, bool_mask_usize(fill));
+            self.masks = v.into_boxed_slice();
         }
 
         // If we increased in size, we need to set any new bits
@@ -960,19 +996,9 @@ impl DynamicBitSetUnmanaged {
                 let old_padding_bits =
                     u32::try_from(old_masks * DYN_MASK_BITS as usize - old_len).expect("int cast");
                 let old_mask = usize::MAX >> old_padding_bits;
-                // SAFETY: index in [0, new_masks).
-                unsafe { *self.masks.add(old_masks - 1) |= !old_mask };
+                self.masks[old_masks - 1] |= !old_mask;
             }
-
-            // fill in any new masks
-            if new_masks > old_masks {
-                let fill_value = bool_mask_usize(fill);
-                // SAFETY: range [old_masks, new_masks) is within the allocation.
-                unsafe {
-                    slice::from_raw_parts_mut(self.masks.add(old_masks), new_masks - old_masks)
-                        .fill(fill_value);
-                }
-            }
+            // new mask words were filled by `v.resize` above
         }
 
         // Zero out the padding bits
@@ -980,29 +1006,18 @@ impl DynamicBitSetUnmanaged {
             let padding_bits =
                 u32::try_from(new_masks * DYN_MASK_BITS as usize - new_len).expect("int cast");
             let last_item_mask = usize::MAX >> padding_bits;
-            // SAFETY: new_masks > 0 here.
-            unsafe { *self.masks.add(new_masks - 1) &= last_item_mask };
+            self.masks[new_masks - 1] &= last_item_mask;
         }
 
-        // And finally, save the new length.
         self.bit_length = new_len;
         Ok(())
-    }
-
-    /// deinitializes the array and releases its memory.
-    /// The passed allocator must be the same one used for
-    /// init* or resize in the past.
-    // TODO(port): kept as an explicit method (not `Drop`) because `List` hands
-    // out non-owning `DynamicBitSetUnmanaged` views that must NOT free on drop.
-    pub fn deinit(&mut self) {
-        self.resize(0, false).expect("unreachable");
     }
 
     /// Creates a duplicate of this bit set, using the new allocator.
     pub fn clone(&self) -> Result<Self, AllocError> {
         let mut copy = Self::default();
         copy.resize(self.bit_length, false)?;
-        copy.masks_slice_mut().copy_from_slice(self.masks_slice());
+        copy.masks.copy_from_slice(&self.masks);
         Ok(copy)
     }
 
@@ -1027,9 +1042,7 @@ impl DynamicBitSetUnmanaged {
     }
 
     pub fn bytes(&self) -> &[u8] {
-        // `masks_slice()` already encapsulates the `(ptr, num_masks)` invariant;
-        // reinterpreting `&[usize]` as `&[u8]` is a safe POD cast.
-        bun_core::cast_slice::<usize, u8>(self.masks_slice())
+        bun_core::cast_slice::<usize, u8>(&self.masks)
     }
 
     /// Returns the total number of set bits in this bit set.
@@ -1042,12 +1055,13 @@ impl DynamicBitSetUnmanaged {
         total
     }
 
-    pub fn has_intersection(&self, other: &Self) -> bool {
+    pub fn has_intersection<'a>(&self, other: impl Into<BitSetRef<'a>>) -> bool {
+        let other = other.into();
         debug_assert_eq!(
             Self::num_masks(self.bit_length),
             Self::num_masks(other.bit_length)
         );
-        for (a, b) in self.masks_slice().iter().zip(other.masks_slice()) {
+        for (a, b) in self.masks.iter().zip(other.masks) {
             if (a & b) != 0 {
                 return true;
             }
@@ -1095,19 +1109,22 @@ impl DynamicBitSetUnmanaged {
     /// Flips all bits in this bit set which are present
     /// in the toggles bit set.  Both sets must have the
     /// same bit_length.
-    pub fn toggle_set(&mut self, toggles: &Self) {
+    pub fn toggle_set<'a>(&mut self, toggles: impl Into<BitSetRef<'a>>) {
+        let toggles = toggles.into();
         debug_assert!(toggles.bit_length == self.bit_length);
         let bit_length = self.bit_length;
         if bit_length == 0 {
             return;
         }
         let num_masks = Self::num_masks(self.bit_length);
-        self.zip_masks_raw(toggles, |a, b| a ^ b);
+        for (a, &b) in self.masks.iter_mut().zip(toggles.masks) {
+            *a ^= b;
+        }
 
         let padding_bits =
             u32::try_from(num_masks * DYN_MASK_BITS as usize - bit_length).expect("int cast");
         let last_item_mask = usize::MAX >> padding_bits;
-        self.masks_slice_mut()[num_masks - 1] &= last_item_mask;
+        self.masks[num_masks - 1] &= last_item_mask;
     }
 
     pub fn set_all(&mut self, value: bool) {
@@ -1145,51 +1162,49 @@ impl DynamicBitSetUnmanaged {
         self.masks_slice_mut()[num_masks - 1] &= last_item_mask;
     }
 
-    pub fn copy_into(&mut self, other: &Self) {
-        let bit_length = self.bit_length;
-        // avoid underflow if bit_length is zero
-        if bit_length == 0 {
-            return;
-        }
-
-        let num_masks = Self::num_masks(self.bit_length);
-        self.zip_masks_raw(other, |_, b| b);
-
-        let padding_bits =
-            u32::try_from(num_masks * DYN_MASK_BITS as usize - bit_length).expect("int cast");
-        let last_item_mask = usize::MAX >> padding_bits;
-        self.masks_slice_mut()[num_masks - 1] &= last_item_mask;
+    pub fn copy_into<'a>(&mut self, other: impl Into<BitSetRef<'a>>) {
+        self.as_mut().copy_into(other);
     }
 
     /// Performs a union of two bit sets, and stores the
     /// result in the first one.  Bits in the result are
     /// set if the corresponding bits were set in either input.
     /// The two sets must both be the same bit_length.
-    pub fn set_union(&mut self, other: &Self) {
-        debug_assert!(other.bit_length == self.bit_length);
-        self.zip_masks_raw(other, |a, b| a | b);
+    pub fn set_union<'a>(&mut self, other: impl Into<BitSetRef<'a>>) {
+        self.as_mut().set_union(other);
     }
 
     /// Performs an intersection of two bit sets, and stores
     /// the result in the first one.  Bits in the result are
     /// set if the corresponding bits were set in both inputs.
     /// The two sets must both be the same bit_length.
-    pub fn set_intersection(&mut self, other: &Self) {
+    pub fn set_intersection<'a>(&mut self, other: impl Into<BitSetRef<'a>>) {
+        let other = other.into();
         debug_assert!(other.bit_length == self.bit_length);
-        self.zip_masks_raw(other, |a, b| a & b);
+        for (a, &b) in self.masks.iter_mut().zip(other.masks) {
+            *a &= b;
+        }
     }
 
-    pub fn set_exclude_two(&mut self, other: &Self, third: &Self) {
+    pub fn set_exclude_two<'a, 'b>(
+        &mut self,
+        other: impl Into<BitSetRef<'a>>,
+        third: impl Into<BitSetRef<'b>>,
+    ) {
+        let other = other.into();
+        let third = third.into();
         debug_assert!(other.bit_length == self.bit_length);
-        // Two passes is equivalent to the original fused loop: each word is
-        // independent, so `(a & !b) & !c` per index is associative across passes.
-        self.zip_masks_raw(other, |a, b| a & !b);
-        self.zip_masks_raw(third, |a, c| a & !c);
+        for ((a, &b), &c) in self.masks.iter_mut().zip(other.masks).zip(third.masks) {
+            *a = (*a & !b) & !c;
+        }
     }
 
-    pub fn set_exclude(&mut self, other: &Self) {
+    pub fn set_exclude<'a>(&mut self, other: impl Into<BitSetRef<'a>>) {
+        let other = other.into();
         debug_assert!(other.bit_length == self.bit_length);
-        self.zip_masks_raw(other, |a, b| a & !b);
+        for (a, &b) in self.masks.iter_mut().zip(other.masks) {
+            *a &= !b;
+        }
     }
 
     /// Finds the index of the first set bit.
@@ -1223,34 +1238,24 @@ impl DynamicBitSetUnmanaged {
 
     /// Returns true iff every corresponding bit in both
     /// bit sets are the same.
-    pub fn eql(&self, other: &Self) -> bool {
-        if self.bit_length != other.bit_length {
-            return false;
-        }
-        self.masks_slice() == other.masks_slice()
+    pub fn eql<'a>(&self, other: impl Into<BitSetRef<'a>>) -> bool {
+        self.as_ref().eql(other)
     }
 
     /// Returns true iff the first bit set is the subset
     /// of the second one.
-    pub fn subset_of(&self, other: &Self) -> bool {
-        if self.bit_length != other.bit_length {
-            return false;
-        }
-        for (&a, &b) in self.masks_slice().iter().zip(other.masks_slice()) {
-            if a & b != a {
-                return false;
-            }
-        }
-        true
+    pub fn subset_of<'a>(&self, other: impl Into<BitSetRef<'a>>) -> bool {
+        self.as_ref().subset_of(other)
     }
 
     /// Returns true iff the first bit set is the superset
     /// of the second one.
-    pub fn superset_of(&self, other: &Self) -> bool {
+    pub fn superset_of<'a>(&self, other: impl Into<BitSetRef<'a>>) -> bool {
+        let other = other.into();
         if self.bit_length != other.bit_length {
             return false;
         }
-        for (&a, &b) in self.masks_slice().iter().zip(other.masks_slice()) {
+        for (&a, &b) in self.masks.iter().zip(other.masks) {
             if a & b != b {
                 return false;
             }
@@ -1279,154 +1284,60 @@ impl DynamicBitSetUnmanaged {
     }
 }
 
-/// Do not resize the bitsets!
-///
-/// Single buffer for multiple bitsets of equal length. Does not
-/// implement all methods of DynamicBitSetUnmanaged and should
-/// be used carefully.
-///
-/// `buf` is a raw heap allocation rather than `Box<[usize]>` because `at()` /
-/// `set()` / `set_union()` hand out and write through `*mut usize` views while
-/// only holding `&self`. With `Box<[usize]>`, the only way to reach the data
-/// from `&self` is `Deref` → `&[usize]` → `as_ptr()`, which yields a pointer
-/// with shared-read-only provenance — writing through it (as the old code did
-/// via `.cast_mut()`) is UB under Stacked Borrows. Owning the allocation as a
-/// raw pointer means the heap words are never covered by a `&`/`&mut`
-/// reference, so reads and writes through `at()`-derived pointers carry the
-/// original allocation's full read-write provenance.
+/// Single buffer for `n` bitsets of equal `bit_length`. `at()` / `at_mut()`
+/// hand out borrowed `BitSetRef` / `BitSetMut` views into the shared buffer.
 pub struct DynamicBitSetList {
-    buf: ptr::NonNull<usize>,
-    buf_len: usize,
+    buf: Box<[usize]>,
     pub n: usize,
     pub bit_length: usize,
 }
 
 impl DynamicBitSetList {
     pub fn init_empty(n: usize, bit_length: usize) -> Result<Self, AllocError> {
-        let masks = DynamicBitSetUnmanaged::num_masks(bit_length);
-        let single_bitset_buf_size = masks + 1;
-        let buf_len = single_bitset_buf_size * n;
-
-        if buf_len == 0 {
-            return Ok(Self {
-                buf: ptr::NonNull::dangling(),
-                buf_len: 0,
-                n,
-                bit_length,
-            });
-        }
-
-        let layout = core::alloc::Layout::array::<usize>(buf_len).map_err(|_| AllocError)?;
-        // SAFETY: `buf_len > 0` so layout has nonzero size.
-        let raw = unsafe { std::alloc::alloc_zeroed(layout) }.cast::<usize>();
-        let buf = ptr::NonNull::new(raw).ok_or(AllocError)?;
-
-        for i in 0..n {
-            // SAFETY: `i * single_bitset_buf_size < buf_len`; allocation is
-            // zero-initialized and at least `buf_len` words long.
-            unsafe { *buf.as_ptr().add(i * single_bitset_buf_size) = single_bitset_buf_size };
-        }
-
+        let stride = DynamicBitSetUnmanaged::num_masks(bit_length);
+        let len = n.checked_mul(stride).ok_or(AllocError)?;
+        let mut v = Vec::new();
+        v.try_reserve_exact(len).map_err(|_| AllocError)?;
+        v.resize(len, 0usize);
         Ok(Self {
-            buf,
-            buf_len,
+            buf: v.into_boxed_slice(),
             n,
             bit_length,
         })
     }
 
-    /// Borrow the `i`th bitset as a non-owning `DynamicBitSetUnmanaged` view.
-    ///
-    /// The returned view's `masks` pointer aliases `self.buf`. It is a raw
-    /// pointer with no lifetime, so the borrow checker will **not** prevent
-    /// use-after-free: the caller must ensure `self` is not dropped (and `buf`
-    /// not reallocated — impossible today, no resize API) while the view is
-    /// live. All current callers (`hoisted_install`, `isolated_install`,
-    /// `PackageInstaller::can_run_scripts`) satisfy this by keeping the list
-    /// alive for the view's entire use. The view must not be `deinit`ed.
-    pub fn at(&self, i: usize) -> DynamicBitSetUnmanaged {
+    #[inline(always)]
+    fn stride(&self) -> usize {
+        DynamicBitSetUnmanaged::num_masks(self.bit_length)
+    }
+
+    /// Borrow the `i`th bitset as a shared view.
+    pub fn at(&self, i: usize) -> BitSetRef<'_> {
         debug_assert!(i < self.n, "DynamicBitSetList::at index out of bounds");
-        let num_masks = DynamicBitSetUnmanaged::num_masks(self.bit_length);
-        let single_bitset_buf_size = num_masks + 1;
-
-        let offset = single_bitset_buf_size * i;
-
-        DynamicBitSetUnmanaged {
+        let s = self.stride();
+        BitSetRef {
             bit_length: self.bit_length,
-            // SAFETY: `i < n` (asserted), so `offset + 1 + num_masks <= buf_len`
-            // and the pointer is in-bounds. `buf` is a raw allocation never
-            // reborrowed as `&[usize]`/`&mut [usize]`, so this `*mut` carries
-            // full read-write provenance and writes through it via the returned
-            // view (e.g. from `set`/`set_union`) are sound even though we only
-            // hold `&self` here — `&self` freezes the pointer *value*, not the
-            // pointee.
-            masks: unsafe { self.buf.as_ptr().add(offset).add(1) },
+            masks: &self.buf[i * s..(i + 1) * s],
         }
     }
 
-    pub fn set(&self, i: usize, j: usize) {
-        let mut bitset = self.at(i);
-        bitset.set(j);
-    }
-
-    pub fn set_union(&self, i: usize, other: &DynamicBitSetUnmanaged) {
-        let mut bitset = self.at(i);
-        bitset.set_union(other);
-    }
-}
-
-impl Drop for DynamicBitSetList {
-    fn drop(&mut self) {
-        if self.buf_len == 0 {
-            return;
+    /// Borrow the `i`th bitset as an exclusive view.
+    pub fn at_mut(&mut self, i: usize) -> BitSetMut<'_> {
+        debug_assert!(i < self.n, "DynamicBitSetList::at_mut index out of bounds");
+        let s = self.stride();
+        BitSetMut {
+            bit_length: self.bit_length,
+            masks: &mut self.buf[i * s..(i + 1) * s],
         }
-        let layout = core::alloc::Layout::array::<usize>(self.buf_len).expect("unreachable");
-        // SAFETY: `buf` was allocated in `init_empty` with exactly this layout
-        // and has not been freed (no other code path deallocates it).
-        unsafe { std::alloc::dealloc(self.buf.as_ptr().cast(), layout) };
     }
-}
 
-// `buf` is a uniquely-owned heap allocation of plain `usize`s; moving the
-// owning struct between threads is as safe as moving a `Box<[usize]>`.
-unsafe impl Send for DynamicBitSetList {}
-
-// Raw allocation helpers for DynamicBitSetUnmanaged. These mirror Zig's
-// allocator.alloc/realloc/free with the size-at-[-1] header convention.
-// TODO(port): move to bun_alloc if useful elsewhere.
-
-unsafe fn dyn_free(base: *mut usize, len: usize) {
-    if len == 0 {
-        // EMPTY_MASKS_DATA sentinel — nothing to free.
-        return;
+    pub fn set(&mut self, i: usize, j: usize) {
+        self.at_mut(i).set(j);
     }
-    let layout = core::alloc::Layout::array::<usize>(len).expect("unreachable");
-    // SAFETY: caller guarantees `base` was allocated with this layout.
-    unsafe { std::alloc::dealloc(base.cast(), layout) };
-}
 
-unsafe fn dyn_realloc(
-    base: *mut usize,
-    old_len: usize,
-    new_len: usize,
-) -> Result<*mut usize, AllocError> {
-    let new_layout = core::alloc::Layout::array::<usize>(new_len).map_err(|_| AllocError)?;
-    if old_len == 0 {
-        // SAFETY: new_layout is nonzero size (caller never passes new_len==0
-        // through this path).
-        let p = unsafe { std::alloc::alloc(new_layout) };
-        if p.is_null() {
-            return Err(AllocError);
-        }
-        return Ok(p.cast());
+    pub fn set_union<'a>(&mut self, i: usize, other: impl Into<BitSetRef<'a>>) {
+        self.at_mut(i).set_union(other);
     }
-    let old_layout = core::alloc::Layout::array::<usize>(old_len).expect("unreachable");
-    // SAFETY: caller guarantees `base` was allocated with `old_layout`.
-    let p = unsafe { std::alloc::realloc(base.cast(), old_layout, new_layout.size()) };
-    if p.is_null() {
-        return Err(AllocError);
-    }
-    Ok(p.cast())
 }
 
 // ───────────────────────────── AutoBitSet ─────────────────────────────
@@ -1553,15 +1464,6 @@ impl AutoBitSet {
 // type alias for any external callers.
 pub type AutoBitSetIterator<'a, const KIND_SET: bool, const DIR_FWD: bool> =
     BitSetIterator<'a, KIND_SET, DIR_FWD>;
-
-impl Drop for AutoBitSet {
-    fn drop(&mut self) {
-        match self {
-            AutoBitSet::Static(_) => {}
-            AutoBitSet::Dynamic(d) => d.deinit(),
-        }
-    }
-}
 
 // ───────────────────────────── DynamicBitSet ─────────────────────────────
 
@@ -1736,12 +1638,6 @@ impl DynamicBitSet {
         &self,
     ) -> BitSetIterator<'_, KIND_SET, DIR_FWD> {
         self.unmanaged.iterator::<KIND_SET, DIR_FWD>()
-    }
-}
-
-impl Drop for DynamicBitSet {
-    fn drop(&mut self) {
-        self.unmanaged.deinit();
     }
 }
 

--- a/src/collections/lib.rs
+++ b/src/collections/lib.rs
@@ -32,7 +32,7 @@ pub mod linear_fifo;
 // stable: enum const params → const usize/bool, inherent assoc → free aliases.
 pub mod bit_set;
 pub mod pool;
-pub use pool::{ObjectPool, ObjectPoolTrait, ObjectPoolType, PoolGuard};
+pub use pool::{ObjectPool, ObjectPoolType, PoolGuard};
 pub mod comptime_string_map;
 pub use comptime_string_map::{ComptimeStringMap, ComptimeStringMapWithKeyType};
 #[path = "StaticHashMap.rs"]
@@ -48,8 +48,8 @@ pub use paste::paste as __mal_paste;
 pub use vec_ext::{ByteVecExt, OffsetByteList, VecExt, prepend_from};
 
 pub use bit_set::{
-    AutoBitSet, DynamicBitSet, DynamicBitSetList, DynamicBitSetUnmanaged, IntegerBitSet,
-    StaticBitSet,
+    AutoBitSet, BitSetMut, BitSetRef, DynamicBitSet, DynamicBitSetList, DynamicBitSetUnmanaged,
+    IntegerBitSet, StaticBitSet,
 };
 
 // Re-export for back-compat (`bun_jsc::host_fn`, `multi_array_list` import

--- a/src/collections/lib.rs
+++ b/src/collections/lib.rs
@@ -32,7 +32,7 @@ pub mod linear_fifo;
 // stable: enum const params → const usize/bool, inherent assoc → free aliases.
 pub mod bit_set;
 pub mod pool;
-pub use pool::{ObjectPool, ObjectPoolType, PoolGuard};
+pub use pool::{ObjectPool, ObjectPoolTrait, ObjectPoolType, PoolGuard};
 pub mod comptime_string_map;
 pub use comptime_string_map::{ComptimeStringMap, ComptimeStringMapWithKeyType};
 #[path = "StaticHashMap.rs"]

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -367,9 +367,8 @@ pub fn install_isolated_packages(
                     }
                     scratch.set_exclude(&provides.at(pkg_id as usize));
 
-                    let mut dst = leaking_peers.at(pkg_id as usize);
-                    if !scratch.eql(&dst) {
-                        dst.copy_into(&scratch);
+                    if !scratch.eql(leaking_peers.at(pkg_id as usize)) {
+                        leaking_peers.at_mut(pkg_id as usize).copy_into(&scratch);
                         changed = true;
                     }
                 }

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -459,7 +459,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
         &mut self,
         are_new_files_stale: bool,
     ) -> Result<(), bun_alloc::AllocError> {
-        let want = self.bundled_files.count().max(self.stale_files.bit_length);
+        let want = self.bundled_files.count().max(self.stale_files.bit_length());
         // Align forward to 8 usize words (8*64 bits).
         const STEP: usize = core::mem::size_of::<usize>() * 8 * 8;
         let aligned = want.div_ceil(STEP) * STEP;
@@ -645,7 +645,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
             self.first_import.push(None);
         }
 
-        if self.stale_files.bit_length > file_index.get() as usize {
+        if self.stale_files.bit_length() > file_index.get() as usize {
             self.stale_files.unset(file_index.get() as usize);
         }
 
@@ -1366,7 +1366,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
             self.first_dep.push(None);
             self.first_import.push(None);
         }
-        if self.stale_files.bit_length > idx {
+        if self.stale_files.bit_length() > idx {
             self.stale_files.set(idx);
         }
 

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -277,7 +277,7 @@ impl GraphTraceState {
             Side::Client => &mut self.client_bits,
             Side::Server => &mut self.server_bits,
         };
-        if b.unmanaged.bit_length < new_size {
+        if b.unmanaged.bit_length() < new_size {
             b.resize(new_size, false)?;
         }
         Ok(())

--- a/test/bundler/bundler_splitting_many_entrypoints.test.ts
+++ b/test/bundler/bundler_splitting_many_entrypoints.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect } from "bun:test";
+import { readdirSync } from "fs";
+import { itBundled } from "./expectBundled";
+
+// Regression coverage for the DynamicBitSetUnmanaged / AutoBitSet rewrite.
+//
+// With more than AUTO_STATIC_BITS (= 127) entry points, the per-file and
+// per-chunk `entry_bits` stored in LinkerGraph/Chunk flip from the inline
+// ArrayBitSet arm to the heap-allocated DynamicBitSetUnmanaged arm, and
+// chunk assignment runs `has_intersection` / `clone` / `set` / Drop on the
+// dynamic path for every (file × entry) pair. This test pins that path to a
+// known-good output so future changes to the bitset storage (thin-pointer
+// packing, Drop, resize) can't silently corrupt chunk assignment.
+
+describe("bundler", () => {
+  const N = 150; // > 127 so AutoBitSet::needs_dynamic(N) is true
+
+  const files: Record<string, string> = {
+    "/shared.js": `export const shared = 1;`,
+  };
+  const entryPoints: string[] = [];
+  for (let i = 0; i < N; i++) {
+    const p = `/e${i}.js`;
+    files[p] = `import { shared } from "./shared.js"; console.log(shared + ${i});`;
+    entryPoints.push(p);
+  }
+  // Spot-check first / mid / last entries (running all N is too slow); the
+  // onAfterBundle chunk-shape check below covers the full set.
+  const run = [0, 64, 127, N - 1].map(i => ({
+    file: `/out/e${i}.js`,
+    stdout: String(1 + i),
+  }));
+
+  itBundled("splitting/DynamicEntryBitsManyEntrypoints", {
+    files,
+    entryPoints,
+    splitting: true,
+    run,
+    onAfterBundle(api) {
+      // With splitting, `shared.js` must land in exactly one shared chunk
+      // (not be duplicated into every entry). If entry_bits intersection is
+      // wrong the linker either over-splits or inlines `shared` everywhere.
+      const outputs = readdirSync(api.outdir).filter(f => f.endsWith(".js"));
+      let copies = 0;
+      for (const f of outputs) {
+        if (api.readFile("/out/" + f).includes("shared = 1")) copies++;
+      }
+      expect(copies).toBe(1);
+      // Exactly N entry chunks + 1 shared chunk.
+      expect(outputs.length).toBe(N + 1);
+    },
+  });
+});


### PR DESCRIPTION
Rewrites `DynamicBitSetUnmanaged` and `DynamicBitSetList` to reduce the 23 `unsafe` blocks in `src/collections/bit_set.rs` to 4, each backed by a single documented invariant.

> [!NOTE]
> This is a behavior-preserving refactor (maintainer-requested). `test/bundler/bundler_splitting_many_entrypoints.test.ts` is regression coverage for the rewritten Dynamic arm — it passes on `main` too, because the point is that nothing observable changed.

## What changed

**`DynamicBitSetUnmanaged`** — `*mut usize` + size-at-`ptr[-1]` allocation header replaced with an owned `Box<[usize]>` stored as a **thin** `NonNull<usize>`:
- The slice length is always `num_masks(bit_length)`, so the fat-pointer length word was redundant. The struct stays `2 * size_of::<usize>()` (16 bytes on 64-bit) — enforced by a `const` assert — so `AUTO_STATIC_BITS` remains 127 and `size_of::<AutoBitSet>()` remains 24.
- Four private helpers encapsulate all pointer handling: `from_box` / `take_box` convert to and from `Box<[usize]>`, `masks_slice{,_mut}` borrow as `&[usize]` / `&mut [usize]`. Everything else is safe slice code.
- Deletes `EMPTY_MASKS_DATA` static sentinel, `empty_masks_ptr()`, `dyn_free`, `dyn_realloc`, `masks_ptr()`, `zip_masks_raw()`, `deinit()`.
- `resize()` reimplemented on `Vec` with `try_reserve_exact` (single allocation per grow); on OOM the original allocation is restored so `self` stays valid.
- Binary ops (`set_union`, `set_intersection`, `set_exclude{,_two}`, `copy_into`, `toggle_set`, `eql`, `subset_of`, `superset_of`, `has_intersection`) now take `impl Into<BitSetRef<'a>>` so existing call sites that pass `&DynamicBitSetUnmanaged`, `&DynamicBitSet`, or list views keep compiling.
- Gains `Drop`. This fixes leaks where bitsets were overwritten without `deinit()`: `LinkerGraph.rs:505`/`654`, `isolated_install.rs:341` (`scratch`), `bundle_v2.rs` `scb_bitset`/visitor locals.
- `bit_length` is now private (read via `bit_length()` / `capacity()`) since `Drop` derives the allocation length from it.

**New view types** — `BitSetRef<'a>` (Copy) / `BitSetMut<'a>`:
- Borrowed slices with `bit_length`; carry the read/mutate API used by list views.
- `From` impls for `&DynamicBitSetUnmanaged`, `&DynamicBitSet`, `&BitSetRef`, `&BitSetMut`.

**`DynamicBitSetList`** — `NonNull<usize>` + manual `alloc_zeroed`/`dealloc` replaced with `Box<[usize]>`:
- `at(&self, i) -> BitSetRef<'_>`; new `at_mut(&mut self, i) -> BitSetMut<'_>`. The old `at()` returned a fabricated `DynamicBitSetUnmanaged` whose raw pointer aliased the buffer with no lifetime — borrowck now tracks the borrow.
- `set` / `set_union` change `&self` → `&mut self` (all 3 callers already hold `mut` bindings).
- Per-slot length header dropped (was only needed so a fabricated view's `masks.sub(1)` would read sanely); buffer is `n` words smaller.
- `Drop` and `unsafe impl Send` deleted (auto-derived via `Box<[usize]>`).

**`AutoBitSet` / `DynamicBitSet`** — explicit `Drop` impls deleted (the inner type drops automatically).

## Files touched

- `src/collections/bit_set.rs` — the rewrite
- `src/collections/lib.rs` — export `BitSetRef` / `BitSetMut`
- `src/install/isolated_install.rs` — one call site that wrote through `at()` now uses `at_mut()`
- `src/bundler/linker_context/findAllImportedPartsInJSOrder.rs`, `src/runtime/bake/dev_server/{mod,incremental_graph}.rs` — `.bit_length` field → `.bit_length()` getter
- `test/bundler/bundler_splitting_many_entrypoints.test.ts` — 150 entry points + `splitting: true` to force `entry_bits` onto the Dynamic arm; checks chunk shape (exactly one shared chunk, N+1 outputs) and runtime output at word boundaries

All other callers (`hoisted_install.rs`, `PackageInstaller.rs`, `LinkerGraph.rs`, `bundle_v2.rs`, `dev_server/*`, `CodeCoverage.rs`, etc.) compile unchanged via the `Into<BitSetRef>` glue.
