### PR TITLE
rust: include `target_os = "android"` in linux-kernel cfg gates

### DIFF
--- a/scripts/build/workarounds.ts
+++ b/scripts/build/workarounds.ts
@@ -29,9 +29,18 @@
  *     ambiguous case.
  */
 
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { Config } from "./config.ts";
 import { BuildError } from "./error.ts";
 import { satisfiesRange } from "./tools.ts";
+
+/** Read a crate's locked version out of the repo's Cargo.lock. */
+function lockedCrateVersion(cfg: Config, name: string): string | undefined {
+  const lock = readFileSync(join(cfg.cwd, "Cargo.lock"), "utf8");
+  const m = lock.match(new RegExp(`\\nname = "${name}"\\nversion = "([^"]+)"`));
+  return m?.[1];
+}
 
 export interface Workaround {
   /** Short slug — shows up in the error message. */
@@ -138,6 +147,30 @@ export const workarounds: Workaround[] = [
     cleanup:
       `Delete needsMuslCrtDecompress(), MUSL_CRT_OBJECTS, the shim_crt_decompress rule, and the ` +
       `musl block in emitShims() (scripts/build/shims.ts), and this entry.`,
+  },
+  {
+    id: "android-posix-spawn-setsid-const",
+    issue: "https://github.com/rust-lang/libc/pull/5104",
+    description:
+      "The libc crate doesn't expose POSIX_SPAWN_SETSID for target_os = android, so the " +
+      "linux+android cfg arm in spawn_sys hardcodes 0x80 (the value glibc/musl/bionic share).",
+    // Cleanup is a source-code change, not a build-config change — once
+    // Cargo.lock's libc has the constant, the local 0x80 can go regardless
+    // of which target is being built. Gate to android so the threshold-bump
+    // hint doesn't bother host-only builds.
+    applies: cfg => cfg.abi === "android",
+    expectedToBeFixed: cfg => {
+      // PR #5104 targets `main` with `stable-nominated`; a 0.2.x cherry-pick
+      // follows. Best guess for the first 0.2.x with it — bump if the
+      // constant isn't actually there yet.
+      const FIXED_IN_LIBC = "0.2.187";
+      const v = lockedCrateVersion(cfg, "libc");
+      return v !== undefined && satisfiesRange(v, `>=${FIXED_IN_LIBC}`);
+    },
+    cleanup:
+      `In src/spawn_sys/posix_spawn.rs (Attr::set) and src/spawn_sys/spawn_process.rs ` +
+      `(options.detached block), replace the local 0x80 with libc::POSIX_SPAWN_SETSID, ` +
+      `drop the explanatory comments, and delete this entry.`,
   },
 ];
 

--- a/src/bun.rs
+++ b/src/bun.rs
@@ -817,12 +817,12 @@ pub use bun_sys::copy_file::{
 pub use bun_core::fmt::parse_double;
 
 pub fn is_missing_io_uring() -> bool {
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     {
         // it is not missing when it was not supposed to be there in the first place
         return false;
     }
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         static IS_MISSING: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
         *IS_MISSING.get_or_init(|| {
@@ -894,7 +894,7 @@ pub fn get_fd_path<'a>(fd: FD, buf: &'a mut PathBuffer) -> Result<&'a mut [u8], 
             );
         }
     }
-    #[cfg(all(not(debug_assertions), not(target_os = "linux")))]
+    #[cfg(all(not(debug_assertions), not(any(target_os = "linux", target_os = "android"))))]
     {
         return bun_sys::get_fd_path(fd.native(), buf);
     }
@@ -1034,9 +1034,9 @@ pub fn open_file_for_path(file_path: &bun_core::ZStr) -> Result<bun_sys::File, b
     }
     #[cfg(not(windows))]
     {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         let o_path = O::PATH;
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         let o_path = O::RDONLY;
         let flags: u32 = O::CLOEXEC | O::NOCTTY | o_path;
         let fd = bun_sys::open_z(file_path, O::to_packed(flags), 0)?;
@@ -1051,9 +1051,9 @@ pub fn open_dir_for_path(file_path: &bun_core::ZStr) -> Result<bun_sys::Dir, bun
     }
     #[cfg(not(windows))]
     {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         let o_path = O::PATH;
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         let o_path = O::RDONLY;
         let flags: u32 = O::CLOEXEC | O::NOCTTY | O::DIRECTORY | o_path;
         let fd = bun_sys::open_z(file_path, O::to_packed(flags), 0)?;
@@ -1105,7 +1105,7 @@ pub type Stat = bun_sys::Stat;
 
 #[cfg(target_os = "macos")]
 pub type StatFS = bun_sys::c::struct_statfs;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub type StatFS = bun_sys::c::struct_statfs;
 #[cfg(target_os = "freebsd")]
 pub type StatFS = bun_sys::c::struct_statfs;
@@ -1436,7 +1436,7 @@ pub fn mark_posix_only() -> ! {
     panic!("Assertion failure: this function should only be accessible on POSIX.");
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn linux_kernel_version() -> bun_semver::Version {
     bun_analytics::GenerateHeader::GeneratePlatform::kernel_version()
 }

--- a/src/bun_alloc/fallback.rs
+++ b/src/bun_alloc/fallback.rs
@@ -59,7 +59,7 @@ impl CAllocator {
             let usable = unsafe { libc::malloc_size(buf.as_ptr().cast()) };
             return new_len <= usable;
         }
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             // SAFETY: `buf` was allocated by libc malloc on this platform.
             let usable = unsafe { libc::malloc_usable_size(buf.as_mut_ptr().cast()) };

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1266,7 +1266,7 @@ macro_rules! err {
     // `err!(from e)` — convert a strum::IntoStaticStr enum error to bun_core::Error.
     (from $e:expr) => { $crate::Error::intern(<&'static str>::from(&$e)) };
     (@__cached $name:expr) => {{
-        #[cfg_attr(target_os = "linux", unsafe(link_section = ".bun_err"))]
+        #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".bun_err"))]
         static __E: ::core::sync::atomic::AtomicU16 = ::core::sync::atomic::AtomicU16::new(0);
         let __v = __E.load(::core::sync::atomic::Ordering::Relaxed);
         if __v != 0 {

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -893,7 +893,7 @@ pub fn last_index_before_char(in_: &[u8], char: u8, before: u8) -> Option<usize>
 
 #[inline]
 pub fn last_index_of_char(self_: &[u8], char: u8) -> Option<usize> {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         // SAFETY: memrchr scans within [self_.ptr, self_.ptr + self_.len).
         let start = unsafe { libc::memrchr(self_.as_ptr().cast(), char as c_int, self_.len()) };
@@ -902,7 +902,7 @@ pub fn last_index_of_char(self_: &[u8], char: u8) -> Option<usize> {
         }
         return Some(start as usize - self_.as_ptr() as usize);
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     {
         last_index_of_char_t(self_, char)
     }

--- a/src/bun_core/thread_id.rs
+++ b/src/bun_core/thread_id.rs
@@ -22,6 +22,7 @@
 //   else                                   → usize
 #[cfg(any(
     target_os = "linux",
+    target_os = "android",
     target_os = "freebsd",
     target_os = "netbsd",
     target_os = "openbsd",
@@ -43,6 +44,7 @@ pub type ThreadId = u64;
 
 #[cfg(not(any(
     target_os = "linux",
+    target_os = "android",
     target_os = "freebsd",
     target_os = "netbsd",
     target_os = "openbsd",
@@ -62,6 +64,7 @@ pub type ThreadId = usize;
 // Width-matched alias so `CriticalSection` can `compare_exchange` on it directly.
 #[cfg(any(
     target_os = "linux",
+    target_os = "android",
     target_os = "freebsd",
     target_os = "netbsd",
     target_os = "openbsd",
@@ -83,6 +86,7 @@ pub type AtomicThreadId = core::sync::atomic::AtomicU64;
 
 #[cfg(not(any(
     target_os = "linux",
+    target_os = "android",
     target_os = "freebsd",
     target_os = "netbsd",
     target_os = "openbsd",
@@ -110,7 +114,7 @@ pub const INVALID: ThreadId = ThreadId::MAX;
 /// debuggers/tracers report; falls back to `pthread_self()` as a `usize` on unknown targets.
 #[inline]
 pub fn current() -> ThreadId {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         // Zig: `LinuxThreadImpl.getCurrentId()` → `linux.gettid()`.
         // SAFETY: `gettid` takes no arguments and cannot fail.
@@ -179,6 +183,7 @@ pub fn current() -> ThreadId {
     }
     #[cfg(not(any(
         target_os = "linux",
+        target_os = "android",
         target_os = "freebsd",
         target_os = "netbsd",
         target_os = "openbsd",

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4854,7 +4854,7 @@ pub fn reload_process(clear_terminal: bool, may_return: bool) {
 
     #[cfg(unix)]
     unsafe {
-        #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
         {
             unsafe extern "C" {
                 safe fn on_before_reload_process_linux();
@@ -5545,27 +5545,27 @@ impl core::fmt::Display for f16 {
 // callsites (audited r5) are bundler/parser hot paths where Linux ftrace is
 // the profiling target. Windows/other platforms are no-ops in Zig too.
 pub mod perf {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     use core::sync::atomic::AtomicBool;
     use core::sync::atomic::{AtomicU8, Ordering};
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     use std::sync::Once;
 
     /// Per-span state returned by `trace()`. `end()` is idempotent; `Drop`
     /// calls it so `let _t = trace("x");` works as a scope guard.
     #[must_use = "bind to a local (`let _t = perf::trace(..)`) so the span has nonzero duration"]
     pub struct Ctx {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         linux: Option<Linux>,
     }
     impl Ctx {
         pub const DISABLED: Ctx = Ctx {
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             linux: None,
         };
         #[inline]
         pub fn end(&mut self) {
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             if let Some(l) = self.linux.take() {
                 l.end();
             }
@@ -5589,7 +5589,7 @@ pub mod perf {
 
     #[cold]
     fn is_enabled_init() -> bool {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         let on = crate::env_var::feature_flag::BUN_TRACE
             .get()
             .unwrap_or(false)
@@ -5599,7 +5599,7 @@ pub mod perf {
         // ftrace and signpost backends via `PerfEvent`); `bun_core::perf` is
         // the T0 subset for low-tier callers that cannot reach `bun_perf` and
         // only need Linux ftrace. T0 therefore reports disabled on macOS.
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         let on = false;
         IS_ENABLED.store(if on { ENABLED } else { DISABLED }, Ordering::Relaxed);
         on
@@ -5622,7 +5622,7 @@ pub mod perf {
             let _ = name;
             return Ctx::DISABLED;
         }
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             return Ctx {
                 linux: Some(Linux::init(name)),
@@ -5636,13 +5636,13 @@ pub mod perf {
     }
 
     // ── Linux ftrace backend (folded from src/perf/lib.rs) ────────────────
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     struct Linux {
         start_time: u64,
         name: &'static str,
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     impl Linux {
         fn is_supported() -> bool {
             static INIT_ONCE: Once = Once::new();
@@ -5686,7 +5686,7 @@ pub mod perf {
     /// `src/jsc/bindings/linux_perf_tracing.cpp`). Re-exported so `bun_perf`
     /// (the canonical signpost/ftrace entry point) imports these instead of
     /// re-declaring them — see src/perf/perf.zig:127-129 for the spec.
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub mod sys {
         unsafe extern "C" {
             /// No preconditions; returns 0/1 based on tracefs availability.

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -1930,7 +1930,7 @@ impl Error {
                 return Some(Error::ENOTFOUND);
             }
 
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             if eai == EAI::SOCKTYPE {
                 return Some(Error::ECONNREFUSED);
             }

--- a/src/clap/lib.rs
+++ b/src/clap/lib.rs
@@ -98,7 +98,7 @@ macro_rules! comptime_table {
     ($params:expr) => {
         $crate::comptime_table!(
             @build
-            { #[cfg_attr(target_os = "linux", unsafe(link_section = ".rodata.startup"))] }
+            { #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".rodata.startup"))] }
             $params
         )
     };

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -144,6 +144,7 @@ pub mod debug {
             }
             #[cfg(any(
                 target_os = "linux",
+                target_os = "android",
                 target_os = "freebsd",
                 target_os = "netbsd",
                 target_os = "dragonfly",
@@ -1102,6 +1103,7 @@ mod draft {
                             #[cfg(any(
                                 target_os = "macos",
                                 target_os = "linux",
+                                target_os = "android",
                                 target_os = "freebsd"
                             ))]
                             { /* no-op */ }
@@ -1510,7 +1512,7 @@ mod draft {
                         limit.rlim_cur,
                     );
 
-                    #[cfg(target_os = "linux")]
+                    #[cfg(any(target_os = "linux", target_os = "android"))]
                     {
                         if let Some(user) = env_var::USER::get() {
                             if !user.is_empty() {
@@ -1764,7 +1766,7 @@ mod draft {
                     .store(handle as *mut core::ffi::c_void, Ordering::Relaxed);
             }
         }
-        #[cfg(any(target_os = "macos", target_os = "linux", target_os = "freebsd"))]
+        #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android", target_os = "freebsd"))]
         {
             reset_on_posix();
         }
@@ -2905,7 +2907,7 @@ mod draft {
             let _ = spawn_result;
             let _ = url;
         }
-        #[cfg(any(target_os = "macos", target_os = "linux", target_os = "freebsd"))]
+        #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android", target_os = "freebsd"))]
         {
             let mut buf = bun_core::PathBuffer::default();
             let mut buf2 = bun_core::PathBuffer::default();
@@ -3168,7 +3170,7 @@ mod draft {
                 }
             }
         }
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             // In non-debug builds, use WTF's stack trace printer and return early
             if !cfg!(debug_assertions) {
@@ -3180,7 +3182,7 @@ mod draft {
             }
             // Otherwise fall through to llvm-symbolizer for debug builds
         }
-        #[cfg(not(any(windows, target_os = "linux")))]
+        #[cfg(not(any(windows, target_os = "linux", target_os = "android")))]
         {
             // Assume debug symbol tooling is reliable.
             let debug_info = match debug::get_self_debug_info() {

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -409,7 +409,7 @@ mod errno_name_tests {
         assert_eq!(Error::from_errno(0), Error::UNEXPECTED);
         assert_eq!(Error::from_errno(9999), Error::UNEXPECTED);
         // errno 11 is platform-specific: EAGAIN on linux/windows, EDEADLK on darwin/bsd.
-        #[cfg(any(target_os = "linux", windows, target_family = "wasm"))]
+        #[cfg(any(target_os = "linux", target_os = "android", windows, target_family = "wasm"))]
         {
             assert_eq!(Error::from_errno(11), Error::intern("EAGAIN"));
             assert_eq!(Error::from_errno(104), Error::intern("ECONNRESET"));
@@ -439,7 +439,7 @@ mod errno_name_tests {
         assert_eq!(Error::from_errno(max as i32), Error::UNEXPECTED);
 
         // Spot-check the last entry on each platform against the Zig source.
-        #[cfg(any(target_os = "linux", target_family = "wasm"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_family = "wasm"))]
         assert_eq!(system_errno_name(133), Some("EHWPOISON"));
         #[cfg(windows)]
         {
@@ -464,7 +464,7 @@ mod errno_name_tests {
             coreutils_error_map::get(2),
             Some("No such file or directory")
         );
-        #[cfg(any(target_os = "linux", windows, target_family = "wasm"))]
+        #[cfg(any(target_os = "linux", target_os = "android", windows, target_family = "wasm"))]
         assert_eq!(
             coreutils_error_map::get(11),
             Some("Resource temporarily unavailable")

--- a/src/exe_format/elf.rs
+++ b/src/exe_format/elf.rs
@@ -562,12 +562,12 @@ fn validate_elf64_le(data: &[u8]) -> Result<(), ElfError> {
 /// can run on macOS/Windows, in which case the host's linker layout is
 /// irrelevant and we want to normalize for portability (#24742).
 fn host_uses_nix_store_interpreter() -> bool {
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     {
         return false;
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         static COMPUTED: AtomicU8 = AtomicU8::new(0); // 0 unknown, 1 no, 2 yes
 

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -2108,7 +2108,7 @@ impl<'a> PackageInstall<'a> {
     }
 
     pub fn is_dangling_symlink(path: &ZStr) -> bool {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             match sys::open(path, sys::O::PATH, 0) {
                 Err(_) => return true,
@@ -2128,7 +2128,7 @@ impl<'a> PackageInstall<'a> {
                 }
             }
         }
-        #[cfg(not(any(target_os = "linux", windows)))]
+        #[cfg(not(any(target_os = "linux", target_os = "android", windows)))]
         {
             match sys::open(path, sys::O::PATH, 0) {
                 Err(_) => return true,

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -810,7 +810,7 @@ impl TarballStream {
                 let fd = open_output_file(dest, path, path_slice, mode)?;
                 self.entry_count += 1;
 
-                #[cfg(target_os = "linux")]
+                #[cfg(any(target_os = "linux", target_os = "android"))]
                 {
                     let size: usize = usize::try_from(entry.size().max(0)).expect("int cast");
                     if size > 1_000_000 {

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1026,7 +1026,7 @@ pub mod package_manifest {
             #[cfg(not(windows))]
             let _ = &mut realpath_buf;
 
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             let mut is_using_o_tmpfile = false;
 
             let file: File = 'brk: {
@@ -1039,7 +1039,7 @@ pub mod package_manifest {
                 // Do our best to use O_TMPFILE, so that if this process is interrupted, we don't leave a temporary file behind.
                 // O_TMPFILE is Linux-only. Not all filesystems support O_TMPFILE.
                 // https://manpages.debian.org/testing/manpages-dev/openat.2.en.html#O_TMPFILE
-                #[cfg(target_os = "linux")]
+                #[cfg(any(target_os = "linux", target_os = "android"))]
                 {
                     match File::openat(
                         cache_dir,
@@ -1116,7 +1116,7 @@ pub mod package_manifest {
                 return Ok(());
             }
 
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             if is_using_o_tmpfile {
                 let _close = CloseOnDrop::file(&file);
                 // Attempt #1.

--- a/src/io/ParentDeathWatchdog.rs
+++ b/src/io/ParentDeathWatchdog.rs
@@ -252,7 +252,7 @@ pub fn enable() {
             return;
         }
 
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             // PR_SET_PDEATHSIG: kernel sends SIGKILL when the thread that forked
             // us exits. Persists across exec; cleared on fork (Bun's own children
@@ -428,11 +428,11 @@ pub fn kill_descendants() {
 /// siblings (both have ppid==us). Returns the slice written; empty on
 /// non-Linux or enumeration failure.
 pub fn snapshot_children(out: &mut [libc::pid_t]) -> &[libc::pid_t] {
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     {
         return &out[..0];
     }
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         let self_pid = getpid();
         let n = list_child_pids(self_pid, out).unwrap_or(0);
@@ -453,11 +453,11 @@ pub fn snapshot_children(out: &mut [libc::pid_t]) -> &[libc::pid_t] {
 /// also land here and be killed — `--no-orphans` is opt-in aggressive cleanup
 /// and would kill it at process-exit via `kill_descendants()` anyway.
 pub fn kill_subreaper_adoptees(siblings: &[libc::pid_t]) {
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     {
         let _ = siblings;
     }
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         let self_pid = getpid();
         let mut buf: [libc::pid_t; 4096] = [0; 4096];
@@ -587,7 +587,7 @@ fn parent_pid_of(pid: libc::pid_t) -> libc::pid_t {
             return libc::pid_t::try_from(info.pbi_ppid).expect("int cast");
         }
     }
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         let mut path_buf = [0u8; 64];
         let Ok(path) = bun_core::fmt::buf_print_z(&mut path_buf, format_args!("/proc/{}/stat", pid)) else {
@@ -612,7 +612,7 @@ fn parent_pid_of(pid: libc::pid_t) -> libc::pid_t {
         };
         return bun_core::fmt::parse_decimal::<libc::pid_t>(ppid_str).unwrap_or(0);
     }
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
     {
         let _ = pid;
         0
@@ -642,11 +642,11 @@ fn list_child_pids(parent: libc::pid_t, out: &mut [libc::pid_t]) -> Option<usize
         }
         return Some((usize::try_from(rc).expect("int cast")).min(out.len()));
     }
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         return list_child_pids_linux(parent, out);
     }
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
     {
         let _ = (parent, out);
         None
@@ -657,7 +657,7 @@ fn list_child_pids(parent: libc::pid_t, out: &mut [libc::pid_t]) -> Option<usize
 /// `parent`. Each file is a space-separated list of child pids whose
 /// `getppid()` is `parent` and which were created by that specific thread.
 /// Requires CONFIG_PROC_CHILDREN (enabled on every distro kernel that matters).
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn list_child_pids_linux(parent: libc::pid_t, out: &mut [libc::pid_t]) -> Option<usize> {
     use std::io::Write;
 

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -238,7 +238,7 @@ pub trait PosixPipeWriter {
 /// Zig: `fn writeToFileType(comptime file_type: FileType) *const fn(...)` — folded into
 /// `try_write` above. Kept here as a free fn for the blocking-pipe path.
 fn write_to_blocking_pipe(fd: Fd, buf: &[u8]) -> sys::Result<usize> {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         if bun_sys::linux::RWFFlagSupport::is_maybe_supported() {
             return sys::write_nonblocking(fd, buf);

--- a/src/jsc/btjs.rs
+++ b/src/jsc/btjs.rs
@@ -16,7 +16,7 @@ use bun_core::{self, Error, err};
 mod zig_std_debug {
     #[allow(unused_imports)]
     use core::ffi::{c_int, c_void};
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     use core::sync::atomic::{AtomicI32, Ordering};
 
     use bun_core::{Error, err};
@@ -133,25 +133,25 @@ mod zig_std_debug {
     /// syscalls, bypassing memory page protection. Used by `StackIterator` to
     /// safely walk frame pointers without segfaulting on a corrupt stack.
     struct MemoryAccessor {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         mem: c_int, // -1 = uninit, -2 = unavailable, else /proc/<pid>/mem fd
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         mem: (),
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     static CACHED_PID: AtomicI32 = AtomicI32::new(-1);
 
     impl MemoryAccessor {
         const INIT: Self = Self {
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             mem: -1,
-            #[cfg(not(target_os = "linux"))]
+            #[cfg(not(any(target_os = "linux", target_os = "android")))]
             mem: (),
         };
 
         fn read(&mut self, address: usize, buf: &mut [u8]) -> bool {
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             loop {
                 match self.mem {
                     -2 => break,
@@ -244,7 +244,7 @@ mod zig_std_debug {
 
     impl Drop for MemoryAccessor {
         fn drop(&mut self) {
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             if self.mem >= 0 {
                 // SAFETY: self.mem is a valid fd we opened.
                 unsafe { libc::close(self.mem) };

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -2045,7 +2045,7 @@ impl Archiver {
                                 }
                                 // archive_read_data_into_fd reads in chunks of 1 MB
                                 // #define    MAX_WRITE    (1024 * 1024)
-                                #[cfg(target_os = "linux")]
+                                #[cfg(any(target_os = "linux", target_os = "android"))]
                                 {
                                     if size > 1_000_000 {
                                         let _ = bun_sys::preallocate_file(

--- a/src/perf/hw_timer.rs
+++ b/src/perf/hw_timer.rs
@@ -257,7 +257,7 @@ fn os_monotonic_ns() -> u64 {
             tv_sec: 0,
             tv_nsec: 0,
         };
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             // CLOCK_MONOTONIC, not _RAW: guaranteed vDSO (no syscall). _RAW only
             // joined the vDSO in 5.3.
@@ -273,7 +273,7 @@ fn os_monotonic_ns() -> u64 {
                 let _ = libc::clock_gettime(libc::CLOCK_MONOTONIC_RAW, &mut spec);
             }
         }
-        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
         {
             // SAFETY: spec is a valid out-pointer.
             unsafe {

--- a/src/perf/lib.rs
+++ b/src/perf/lib.rs
@@ -20,9 +20,9 @@ pub use crate::generated_perf_trace_events::PerfEvent;
 
 #[cfg(target_os = "macos")]
 pub type EnabledImpl = Darwin;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub type EnabledImpl = Linux;
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
 pub type EnabledImpl = Disabled;
 
 pub enum Ctx {
@@ -89,7 +89,7 @@ fn is_enabled_once() {
             IS_ENABLED.store(false, Ordering::SeqCst);
         }
     }
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         is_enabled_on_linux_once();
         if !Linux::is_supported() {
@@ -127,12 +127,12 @@ pub fn trace(event: PerfEvent) -> Ctx {
         // PERF(port): was comptime monomorphization (event id was comptime i32) — profile in Phase B
         return Ctx::Enabled(Darwin::init(event as i32));
     }
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         return Ctx::Enabled(Linux::init(event));
     }
     #[allow(unreachable_code)]
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
     {
         let _ = event;
         return Ctx::Disabled(Disabled);
@@ -195,13 +195,13 @@ mod darwin_impl {
     static OS_LOG_ONCE: Once = Once::new();
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub struct Linux {
     start_time: u64,
     event: PerfEvent,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 impl Linux {
     pub fn is_supported() -> bool {
         INIT_ONCE.call_once(Self::init_once);
@@ -242,12 +242,12 @@ impl Linux {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 static IS_INITIALIZED: AtomicBool = AtomicBool::new(false);
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 static INIT_ONCE: Once = Once::new();
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use bun_core::perf::sys::{Bun__linux_trace_emit, Bun__linux_trace_init};
 
 // ported from: src/perf/perf.zig

--- a/src/perf/tracy.rs
+++ b/src/perf/tracy.rs
@@ -718,7 +718,7 @@ fn dlsym<T: Copy>(symbol: &'static core::ffi::CStr) -> Option<T> {
 
         let sym_z = cstr_as_zstr(symbol);
 
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             // use LD_PRELOAD on linux (RTLD_DEFAULT lookup)
             if let Some(p) = bun_sys::dlsym_impl(None, sym_z) {
@@ -741,7 +741,7 @@ fn dlsym<T: Copy>(symbol: &'static core::ffi::CStr) -> Option<T> {
                     c"libTracyClient.dylib",
                     c"libTracyClient.so",
                 ];
-                #[cfg(target_os = "linux")]
+                #[cfg(any(target_os = "linux", target_os = "android"))]
                 const PATHS_TO_TRY: &[&core::ffi::CStr] = &[
                     c"/usr/local/lib/libtracy.so",
                     c"/usr/local/opt/tracy/lib/libtracy.so",
@@ -756,7 +756,7 @@ fn dlsym<T: Copy>(symbol: &'static core::ffi::CStr) -> Option<T> {
                 ];
                 #[cfg(windows)]
                 const PATHS_TO_TRY: &[&core::ffi::CStr] = &[c"tracy.dll"];
-                #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+                #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android", windows)))]
                 const PATHS_TO_TRY: &[&core::ffi::CStr] = &[];
 
                 // TODO(port): RTLD flags — Zig used `@bitCast(@as(i32, -2))` on

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -1908,14 +1908,14 @@ impl TmpfilePosix {
     pub(crate) fn close_and_delete(&mut self, name: &ZStr) {
         self.close();
 
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {
             if self.dir_fd == Fd::INVALID {
                 return;
             }
             let _ = bun_sys::unlinkat(self.dir_fd, name);
         }
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             let _ = name;
         }
@@ -2802,9 +2802,9 @@ impl RealFS {
             } else {
                 // PORT NOTE: Zig `bun.openFileForPath` (bun.zig:1900-1910) — O_PATH is
                 // Linux-only; macOS/BSD use O_RDONLY. Both add O_NOCTTY|O_CLOEXEC.
-                #[cfg(target_os = "linux")]
+                #[cfg(any(target_os = "linux", target_os = "android"))]
                 let flags = bun_sys::O::PATH | bun_sys::O::CLOEXEC | bun_sys::O::NOCTTY;
-                #[cfg(not(target_os = "linux"))]
+                #[cfg(not(any(target_os = "linux", target_os = "android")))]
                 let flags = bun_sys::O::RDONLY | bun_sys::O::CLOEXEC | bun_sys::O::NOCTTY;
                 bun_sys::open(absolute_path, flags, 0)?
             };
@@ -2979,9 +2979,9 @@ impl RealFS {
                 } else {
                     // PORT NOTE: Zig `bun.openFileForPath` (bun.zig:1900-1910) — O_PATH is
                     // Linux-only; macOS/BSD use O_RDONLY. Both add O_NOCTTY|O_CLOEXEC.
-                    #[cfg(target_os = "linux")]
+                    #[cfg(any(target_os = "linux", target_os = "android"))]
                     let flags = bun_sys::O::PATH | bun_sys::O::CLOEXEC | bun_sys::O::NOCTTY;
-                    #[cfg(not(target_os = "linux"))]
+                    #[cfg(not(any(target_os = "linux", target_os = "android")))]
                     let flags = bun_sys::O::RDONLY | bun_sys::O::CLOEXEC | bun_sys::O::NOCTTY;
                     bun_sys::open(absolute_path_c, flags, 0)?
                 };

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1475,9 +1475,9 @@ pub mod fs {
                     } else {
                         // PORT NOTE: Zig `bun.openFileForPath` (bun.zig:1900-1910) — O_PATH is
                         // Linux-only; macOS/BSD use O_RDONLY. Both add O_NOCTTY|O_CLOEXEC.
-                        #[cfg(target_os = "linux")]
+                        #[cfg(any(target_os = "linux", target_os = "android"))]
                         let flags = bun_sys::O::PATH | bun_sys::O::CLOEXEC | bun_sys::O::NOCTTY;
-                        #[cfg(not(target_os = "linux"))]
+                        #[cfg(not(any(target_os = "linux", target_os = "android")))]
                         let flags = bun_sys::O::RDONLY | bun_sys::O::CLOEXEC | bun_sys::O::NOCTTY;
                         bun_sys::open(absolute_path_c, flags, 0)?
                     };

--- a/src/runtime/allocators/LinuxMemFdAllocator.rs
+++ b/src/runtime/allocators/LinuxMemFdAllocator.rs
@@ -156,9 +156,9 @@ impl LinuxMemFdAllocator {
             // `std.posix.MAP`, so this *replaces* it (not OR). Mask out the
             // existing TYPE bits first so e.g. an incoming `MAP_PRIVATE` (0x02)
             // becomes `MAP_SHARED` (0x01), not `MAP_SHARED_VALIDATE` (0x03).
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             const MAP_TYPE: i32 = libc::MAP_TYPE;
-            #[cfg(not(target_os = "linux"))]
+            #[cfg(not(any(target_os = "linux", target_os = "android")))]
             const MAP_TYPE: i32 = 0x0f; // `std.posix.MAP.TYPE` is `u4` on every POSIX target
             let flags_mut = (flags & !MAP_TYPE) | libc::MAP_SHARED;
 
@@ -196,13 +196,13 @@ impl LinuxMemFdAllocator {
     }
 
     pub fn should_use(bytes: &[u8]) -> bool {
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {
             let _ = bytes;
             return false;
         }
 
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             if !sys::can_use_memfd() {
                 return false;
@@ -219,13 +219,13 @@ impl LinuxMemFdAllocator {
     }
 
     pub fn create(bytes: &[u8]) -> sys::Result<BlobStoreBytes> {
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {
             let _ = bytes;
             unreachable!();
         }
 
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             let mut label_buf = [0u8; 128];
             // Zig: `std.fmt.bufPrintZ(&label_buf, "memfd-num-{d}", .{n}) catch ""`

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -912,7 +912,7 @@ pub fn get_main(global_this: &JSGlobalObject) -> JSValue {
                 },
                 vm.main(),
                 // Open with the minimum permissions necessary for resolving the file path.
-                if cfg!(target_os = "linux") {
+                if cfg!(any(target_os = "linux", target_os = "android")) {
                     sys::O::PATH
                 } else {
                     sys::O::RDONLY

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -925,7 +925,7 @@ fn create_pty_posix(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {
                 | libc::BRKINT; // Signal interrupt on break
             // IUTF8: present in Linux/macOS/FreeBSD kernels but Zig std's
             // tc_iflag_t only exposes the field on Linux/macOS, so probe for it.
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
             {
                 t.c_iflag |= libc::IUTF8;
             }

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -110,13 +110,13 @@ impl Stdio {
     }
 
     pub fn can_use_memfd(&self, is_sync: bool, has_max_buffer: bool) -> bool {
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {
             let _ = (is_sync, has_max_buffer);
             return false;
         }
 
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         match self {
             Self::Blob(blob) => !blob.needs_to_read_file(),
             Self::Memfd(_) | Self::ArrayBuffer(_) => true,
@@ -126,13 +126,13 @@ impl Stdio {
     }
 
     pub fn use_memfd(&mut self, index: u32) -> bool {
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {
             let _ = index;
             return false;
         }
 
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             use crate::api::bun_process::spawn_sys;
             if !spawn_sys::can_use_memfd() {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -679,7 +679,7 @@ pub const BASE_RUNTIME_TRANSPILER_PARAMS: &[ParamType] =
 // built with `comptime_table!(.., cold)` and stay in plain `.rodata`, where
 // `src/startup.order` can still cluster the ones a sampled cold path actually
 // hits without weighing down the `.rodata.startup` fault-around window.
-#[cfg_attr(target_os = "linux", unsafe(link_section = ".rodata.startup"))]
+#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".rodata.startup"))]
 pub static AUTO_TABLE: &clap::ConvertedTable = clap::comptime_table!(AUTO_PARAMS);
 pub static RUN_TABLE: &clap::ConvertedTable = clap::comptime_table!(RUN_PARAMS, cold);
 pub static BUILD_TABLE: &clap::ConvertedTable = clap::comptime_table!(BUILD_PARAMS, cold);

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -545,7 +545,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
     /// not share `.text` pages with the hot `bun run <script>` dispatch path.
     #[cold]
     #[inline(never)]
-    #[cfg_attr(target_os = "linux", unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
     fn configure_run_transpiler_linker(this_transpiler: &mut Transpiler<'static>) {
         this_transpiler.resolver.opts.load_tsconfig_json = true;
         this_transpiler.options.load_tsconfig_json = true;
@@ -863,7 +863,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
     /// initializing JSC.
     #[cold]
     #[inline(never)]
-    #[cfg_attr(target_os = "linux", unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
     fn boot_bun_shell(
         ctx: &mut ContextData,
         entry_path: &[u8],
@@ -1662,7 +1662,7 @@ fn log_clear_msgs(vm: &mut VirtualMachine) {
 
 #[cold]
 #[inline(never)]
-#[cfg_attr(target_os = "linux", unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
 fn dump_build_error(vm: &mut VirtualMachine) {
     Output::flush();
     if let Some(log) = vm.log {
@@ -1682,7 +1682,7 @@ fn dump_build_error(vm: &mut VirtualMachine) {
 /// `.text.hot` fault-around window the `require('fs')` startup path pulls in.
 #[cold]
 #[inline(never)]
-#[cfg_attr(target_os = "linux", unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
 fn exit_with_unhandled_note(vm: &mut VirtualMachine) -> ! {
     vm.exit_handler.exit_code = 1;
     vm.on_exit();
@@ -1696,7 +1696,7 @@ fn exit_with_unhandled_note(vm: &mut VirtualMachine) -> ! {
 /// Cold `Err(err)` arm of `vm.load_entry_point` in `Run::start`.
 #[cold]
 #[inline(never)]
-#[cfg_attr(target_os = "linux", unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
 fn entry_point_load_failed(vm: &mut VirtualMachine, err: &bun_core::Error) -> ! {
     if log_has_msgs(vm) {
         dump_build_error(vm);
@@ -1715,7 +1715,7 @@ fn entry_point_load_failed(vm: &mut VirtualMachine, err: &bun_core::Error) -> ! 
 /// exit: bump the exit code and print the sourcemap note + version string.
 #[cold]
 #[inline(never)]
-#[cfg_attr(target_os = "linux", unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
 fn print_unhandled_version_note(vm: &mut VirtualMachine) {
     vm.exit_handler.exit_code = 1;
     bun_sourcemap::SavedSourceMap::MissingSourceMapNoteInfo::print();
@@ -1755,7 +1755,7 @@ impl RunCommand {
     /// `.text.hot` fault-around window the `require('fs')` startup path pulls in.
     #[cold]
     #[inline(never)]
-    #[cfg_attr(target_os = "linux", unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
     fn boot_failed_exit(ctx: &mut ContextData, display_name: &[u8], err: &bun_core::Error) -> ! {
         // SAFETY: `ctx.log` was set in `create_context_data` (single-threaded
         // CLI startup) and is process-lifetime.
@@ -3015,7 +3015,7 @@ impl RunCommand {
 
     #[cold]
     #[inline(never)]
-    #[cfg_attr(target_os = "linux", unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
     fn exec_as_if_node_missing_script() -> ! {
         Output::err_generic(
             "Missing script to execute. Bun's provided 'node' cli wrapper does not support a repl.",
@@ -3026,7 +3026,7 @@ impl RunCommand {
 
     #[cold]
     #[inline(never)]
-    #[cfg_attr(target_os = "linux", unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
     fn exec_as_if_node_boot_failed(
         ctx: &mut ContextData,
         basename: &[u8],

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -507,7 +507,7 @@ impl UpgradeCommand {
     );
 
     const MANUAL_UPGRADE_COMMAND: &'static str = {
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
         {
             "curl -fsSL https://bun.com/install | bash"
         }
@@ -515,7 +515,7 @@ impl UpgradeCommand {
         {
             "powershell -c 'irm bun.sh/install.ps1|iex'"
         }
-        #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "windows")))]
         {
             // TODO(port): Environment.os.displayString() at comptime
             "(TODO: Install script for this platform)"

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -5629,7 +5629,7 @@ impl NodeFS {
     }
 
     pub fn fstat(&mut self, args: &args::Fstat, _: Flavor) -> Maybe<ret::Fstat> {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         if sys::SUPPORTS_STATX_ON_LINUX.load(Ordering::Relaxed) {
             return match sys::fstatx(args.fd, sys::STATX_MASK_FOR_STATS) {
                 Ok(result) => Ok(Stats::init(&result, args.big_int)),
@@ -5765,7 +5765,7 @@ impl NodeFS {
 
     pub fn lstat(&mut self, args: &args::Lstat, _: Flavor) -> Maybe<ret::Lstat> {
         let path = args.path.slice_z(&mut self.sync_error_buf);
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         if sys::SUPPORTS_STATX_ON_LINUX.load(Ordering::Relaxed) {
             return match sys::lstatx(path, sys::STATX_MASK_FOR_STATS) {
                 Ok(result) => Ok(StatOrNotFound::Stats(Stats::init(&result, args.big_int))),
@@ -7889,7 +7889,7 @@ impl NodeFS {
                 )));
             }
         }
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         if sys::SUPPORTS_STATX_ON_LINUX.load(Ordering::Relaxed) {
             return match sys::statx(path, sys::STATX_MASK_FOR_STATS) {
                 Ok(result) => Ok(StatOrNotFound::Stats(Stats::init(&result, args.big_int))),

--- a/src/runtime/node/node_fs_binding.rs
+++ b/src/runtime/node/node_fs_binding.rs
@@ -438,7 +438,7 @@ pub fn create_memfd_for_testing(global: &JSGlobalObject, frame: &CallFrame) -> J
         return Ok(JSValue::UNDEFINED);
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     {
         let _ = arguments;
         return Err(global.throw(format_args!(
@@ -446,7 +446,7 @@ pub fn create_memfd_for_testing(global: &JSGlobalObject, frame: &CallFrame) -> J
         )));
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         let size = arguments.ptr[0].to_int64();
         match bun_sys::memfd_create(c"my_memfd", bun_sys::MemfdFlags::NonExecutable) {

--- a/src/runtime/node/node_fs_constant.rs
+++ b/src/runtime/node/node_fs_constant.rs
@@ -102,9 +102,9 @@ pub const O_DSYNC: i32 = O::DSYNC;
 /// Constant for fs.open(). Flag indicating to open the symbolic link itself rather than the resource it is pointing to.
 pub const O_SYMLINK: i32 = O::SYMLINK;
 /// Constant for fs.open(). When set, an attempt will be made to minimize caching effects of file I/O.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub const O_DIRECT: i32 = libc::O_DIRECT;
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub const O_DIRECT: i32 = 0;
 /// Constant for fs.open(). Flag indicating to open the file in nonblocking mode when possible.
 pub const O_NONBLOCK: i32 = O::NONBLOCK;

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -944,7 +944,7 @@ impl StatWatcher {
 // PORT NOTE: hoisted from inline `if (isLinux and supports_statx) ... else brk: { ... }`
 // at two call sites (InitialStatTask::work_pool_callback and StatWatcher::restat) — identical logic.
 fn restat_impl(path: &ZStr) -> bun_sys::Maybe<PosixStat> {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         if bun_sys::SUPPORTS_STATX_ON_LINUX.load(Ordering::Relaxed) {
             return bun_sys::statx(path, bun_sys::STATX_MASK_FOR_STATS);

--- a/src/runtime/node/time_like.rs
+++ b/src/runtime/node/time_like.rs
@@ -115,9 +115,9 @@ fn from_now() -> TimeLike {
     //        timestamps are not modified, but other error conditions may still
     libc::timespec {
         tv_sec: 0,
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         tv_nsec: libc::UTIME_NOW as _,
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         tv_nsec: bun_sys::c::UTIME_NOW as _,
     }
 }

--- a/src/runtime/shell/util.rs
+++ b/src/runtime/shell/util.rs
@@ -22,9 +22,9 @@ impl OutKind {
 // `bun_spawn` *crate* re-exports under the same name.
 pub use crate::api::bun_spawn::stdio::Stdio;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub type WatchFd = core::ffi::c_int; // std.posix.fd_t
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub type WatchFd = i32;
 
 // ported from: src/shell/util.zig

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2531,7 +2531,7 @@ impl BlobExt for Blob {
         global_this: &JSGlobalObject,
         was_string: bool,
     ) -> Result<Blob, bun_alloc::AllocError> {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             if crate::allocators::linux_mem_fd_allocator::LinuxMemFdAllocator::should_use(bytes_) {
                 if let Ok(result) =
@@ -2970,7 +2970,7 @@ impl BlobExt for Blob {
                     }
                 }
 
-                #[cfg(target_os = "linux")]
+                #[cfg(any(target_os = "linux", target_os = "android"))]
                 {
                     use crate::allocators::linux_mem_fd_allocator::LinuxMemFdAllocator;
                     // If we can use a copy-on-write clone of the buffer, do so.

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -494,7 +494,7 @@ impl WriteFile {
             return;
         }
 
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             // If it's a potentially large file, lets attempt to
             // preallocate the saved filesystem size.

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -242,7 +242,7 @@ fn find_chrome(explicit_path: Option<&CStr>) -> Option<ZBox> {
             }
         }
     }
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         let absolute: [&ZStr; 8] = [
             zstr!("/usr/bin/google-chrome-stable"),
@@ -358,7 +358,7 @@ fn find_playwright_shell() -> Option<ZBox> {
     }
 
     // Fall back to the non-cft linux arm64 layout.
-    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    #[cfg(all(any(target_os = "linux", target_os = "android"), target_arch = "aarch64"))]
     {
         let bin_parts2: [&[u8]; 3] = [
             cache_dir,
@@ -614,7 +614,7 @@ fn read_dev_tools_active_port(out_buf: &mut Vec<u8>) -> Option<()> {
         b"Library/Application Support/BraveSoftware/Brave-Browser/DevToolsActivePort",
         b"Library/Application Support/Microsoft Edge/DevToolsActivePort",
     ];
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     let candidates: &[&[u8]] = &[
         b".config/google-chrome/DevToolsActivePort",
         b".config/google-chrome-beta/DevToolsActivePort",
@@ -633,7 +633,7 @@ fn read_dev_tools_active_port(out_buf: &mut Vec<u8>) -> Option<()> {
         b"BraveSoftware\\Brave-Browser\\User Data\\DevToolsActivePort",
         b"Microsoft\\Edge\\User Data\\DevToolsActivePort",
     ];
-    #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android", windows)))]
     let candidates: &[&[u8]] = &[];
 
     let mut path_buf = path_buffer_pool::get();

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -47,7 +47,7 @@ pub mod spawn_sys {
     // (`can_use_memfd` is always-false there and `set_close_on_exec` is a
     // no-op since Win32 handles default to non-inheritable). Gated so the
     // re-export resolves without `bun_sys` having to ship Windows stubs.
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub use bun_sys::{MemfdFlags, MemfdFlags as MemfdFlag, memfd_create};
     #[cfg(unix)]
     pub use bun_sys::{can_use_memfd, set_close_on_exec};
@@ -92,7 +92,7 @@ pub use bun_spawn_sys::{
 /// inherently once-per-process — keep `EV_ONESHOT` there so the kernel
 /// auto-removes the filter.
 #[cfg(unix)]
-const PROCESS_POLL_ONE_SHOT: bool = !cfg!(target_os = "linux");
+const PROCESS_POLL_ONE_SHOT: bool = !cfg!(any(target_os = "linux", target_os = "android"));
 
 pub use crate::{ProcessExit, ProcessExitHandler, ProcessExitKind};
 
@@ -265,9 +265,9 @@ impl Process {
         bun_core::heap::into_raw(Box::new(Process {
             ref_count: bun_ptr::ThreadSafeRefCount::init(),
             pid: posix.pid,
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             pidfd: posix.pidfd.unwrap_or(0),
-            #[cfg(not(target_os = "linux"))]
+            #[cfg(not(any(target_os = "linux", target_os = "android")))]
             pidfd: (),
             event_loop,
             sync: sync_,
@@ -422,9 +422,9 @@ impl Process {
                 return Ok(());
             }
 
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             let watchfd = self.pidfd;
-            #[cfg(not(target_os = "linux"))]
+            #[cfg(not(any(target_os = "linux", target_os = "android")))]
             let watchfd = self.pid;
 
             let poll: *mut FilePoll = if matches!(self.poller, Poller::Fd(_)) {
@@ -622,7 +622,7 @@ impl Process {
             }
         }
 
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             use bun_sys::FdExt as _;
             if self.pidfd != Fd::INVALID.native() && self.pidfd > 0 {
@@ -1002,9 +1002,9 @@ pub mod waiter_thread_posix {
 
     pub struct WaiterThreadPosix {
         pub started: AtomicU32,
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         pub eventfd: Fd,
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         pub eventfd: (),
         pub js_process: ProcessQueue,
     }
@@ -1277,9 +1277,9 @@ pub mod waiter_thread_posix {
     unsafe impl Sync for Instance {}
     static INSTANCE: Instance = Instance(core::cell::UnsafeCell::new(WaiterThreadPosix {
         started: AtomicU32::new(0),
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         eventfd: Fd::INVALID,
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         eventfd: (),
         js_process: ProcessQueue::new(),
     }));
@@ -1322,7 +1322,7 @@ pub mod waiter_thread_posix {
 
             init().unwrap_or_else(|_| panic!("Failed to start WaiterThread"));
 
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             {
                 let one: [u8; 8] = (1usize).to_ne_bytes();
                 // SAFETY: write(2) is async-signal-safe; eventfd valid after init().
@@ -1339,7 +1339,7 @@ pub mod waiter_thread_posix {
                 return;
             }
 
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             {
                 // SAFETY: sigaction with a valid handler.
                 unsafe {
@@ -1365,7 +1365,7 @@ pub mod waiter_thread_posix {
             return Ok(());
         }
 
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             // All by-value `c_uint`/`c_int` args; the kernel validates flags
             // and returns -1/errno on failure — no memory-safety preconditions,
@@ -1391,7 +1391,7 @@ pub mod waiter_thread_posix {
         Ok(())
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     extern "C" fn wakeup(_: c_int) {
         let one: [u8; 8] = (1usize).to_ne_bytes();
         // eventfd is write-once in init() before this handler is installed.
@@ -1415,7 +1415,7 @@ pub mod waiter_thread_posix {
             // in `append()` (interior mutability via `active: UnsafeCell`).
             this.js_process.loop_();
 
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             {
                 // `eventfd` is written once in `init()` before this thread is
                 // spawned; read-only thereafter.
@@ -1435,7 +1435,7 @@ pub mod waiter_thread_posix {
                 // SAFETY: valid pollfd array.
                 let _ = unsafe { libc::poll(polls.as_mut_ptr(), 1, i32::MAX) };
             }
-            #[cfg(not(target_os = "linux"))]
+            #[cfg(not(any(target_os = "linux", target_os = "android")))]
             {
                 // SAFETY: sigwait with a valid (empty) mask.
                 unsafe {
@@ -3048,15 +3048,15 @@ mod spawn_process_body {
             // subreaper-adopted orphans (ppid==us) apart from `Bun.spawn` siblings
             // (also ppid==us). Typically empty — `bun run`/`bunx` have no JS VM —
             // but spawnSync can run inside a live VM (ffi.zig xcrun probe).
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             let mut siblings_buf = [0 as libc::pid_t; 64];
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             let siblings: &[libc::pid_t] = if no_orphans {
                 ParentDeathWatchdog::snapshot_children(&mut siblings_buf)
             } else {
                 &siblings_buf[0..0]
             };
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             if no_orphans {
                 // Subreaper: arm *before* spawn so a fast-daemonizing script can't
                 // reparent its grandchild to init in the gap. Process-wide and
@@ -3069,7 +3069,7 @@ mod spawn_process_body {
                 // SAFETY: prctl
                 let _ = unsafe { libc::prctl(libc::PR_SET_CHILD_SUBREAPER, 1) };
             }
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             scopeguard::defer! {
                 if no_orphans {
                     // Kill subreaper-adopted setsid daemons (ppid==us, not in the
@@ -3169,7 +3169,7 @@ mod spawn_process_body {
                     if pgid_pushed {
                         ParentDeathWatchdog::pop_sync_pgid();
                     }
-                    #[cfg(target_os = "linux")]
+                    #[cfg(any(target_os = "linux", target_os = "android"))]
                     {
                         // One last reap for anything we adopted as subreaper before
                         // the disarm defer above drops it (LIFO: this runs first).
@@ -3224,7 +3224,7 @@ mod spawn_process_body {
             // that are read *after* the wait, so falling through to the memfd block
             // below is required.
             let status: Status = 'blk: {
-                if no_orphans && (cfg!(target_os = "linux") || cfg!(target_os = "macos")) {
+                if no_orphans && (cfg!(any(target_os = "linux", target_os = "android")) || cfg!(target_os = "macos")) {
                     let ppid = ParentDeathWatchdog::ppid_to_watch().unwrap_or(0);
                     #[cfg(target_os = "macos")]
                     let r: Option<Maybe<Status>> = wait_mac_kqueue(
@@ -3236,7 +3236,7 @@ mod spawn_process_body {
                         &mut out_fds_to_wait_for,
                         &mut out_fds,
                     );
-                    #[cfg(target_os = "linux")]
+                    #[cfg(any(target_os = "linux", target_os = "android"))]
                     let r: Option<Maybe<Status>> = wait_linux_signalfd(
                         process.pid,
                         ppid,
@@ -3245,7 +3245,7 @@ mod spawn_process_body {
                         &mut out_fds_to_wait_for,
                         &mut out_fds,
                     );
-                    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+                    #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
                     let r: Option<Maybe<Status>> = {
                         let _ = ppid;
                         None
@@ -3307,7 +3307,7 @@ mod spawn_process_body {
                 reap_child(process.pid)
             };
 
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             {
                 for (idx, &memfd) in process.memfds[1..].iter().enumerate() {
                     if memfd {
@@ -3355,7 +3355,7 @@ mod spawn_process_body {
                 }
             }
 
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             if let Some(pidfd) = process.pidfd {
                 Fd::from_native(pidfd).close();
             }
@@ -3622,7 +3622,7 @@ mod spawn_process_body {
             }
         }
 
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         fn wait_linux_signalfd(
             child: libc::pid_t,
             ppid: libc::pid_t,

--- a/src/spawn_sys/posix_spawn.rs
+++ b/src/spawn_sys/posix_spawn.rs
@@ -260,9 +260,12 @@ pub mod bun_spawn {
             // that value when the flag bit isn't available.
             // TODO(port): Zig used `@hasDecl(bun.c, "POSIX_SPAWN_SETSID")`; approximated
             // here as unix-not-freebsd. Phase B should use a build-time cfg from bindgen.
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             {
-                self.detached = (flags & system::POSIX_SPAWN_SETSID as u16) != 0;
+                // glibc/musl/bionic <spawn.h> all define POSIX_SPAWN_SETSID as 0x80;
+                // the libc crate only exposes it for `target_os = "linux"`.
+                const POSIX_SPAWN_SETSID: u16 = 0x80;
+                self.detached = (flags & POSIX_SPAWN_SETSID) != 0;
             }
             #[cfg(target_os = "macos")]
             {
@@ -576,7 +579,7 @@ pub mod posix_spawn {
         //   setsid() + ioctl(TIOCSCTTY) before exec, which system posix_spawn can't do.
         //   For non-PTY spawns on macOS, we use system posix_spawn which is safer
         //   (Apple's posix_spawn uses a kernel fast-path that avoids fork() entirely).
-        let use_bun_spawn = cfg!(target_os = "linux")
+        let use_bun_spawn = cfg!(any(target_os = "linux", target_os = "android"))
             || cfg!(target_os = "freebsd")
             || (cfg!(target_os = "macos") && pty_slave_fd >= 0);
 

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -2,7 +2,7 @@
 //! `bun_spawn::process` so the fd/action plumbing has no event-loop
 //! dependency. `Process`/`Poller`/`WaiterThread`/`sync` stay in `bun_spawn`.
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use core::ffi::CStr;
 use core::ffi::c_char;
 #[cfg(target_os = "macos")]
@@ -37,9 +37,9 @@ pub type FdT = libc::c_int;
 #[cfg(not(unix))]
 pub type FdT = i32;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub type PidFdType = FdT;
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub type PidFdType = (); // u0 in Zig
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -499,7 +499,7 @@ impl PosixSpawnResult {
         self.extra_pipes.shrink_to_fit();
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     fn pidfd_flags_for_linux() -> u32 {
         // pidfd_nonblock only supported in 5.10+. The Zig path consults
         // `analytics.kernel_version()` (semver compare); until that helper is
@@ -509,7 +509,7 @@ impl PosixSpawnResult {
         bun_sys::O::NONBLOCK as u32
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn pifd_from_pid(&mut self) -> bun_sys::Result<PidFdType> {
         if crate::waiter_thread_flag::get() {
             return Err(bun_sys::Error::from_code(
@@ -574,7 +574,7 @@ impl PosixSpawnResult {
         }
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     pub fn pifd_from_pid(&mut self) -> bun_sys::Result<PidFdType> {
         Err(bun_sys::Error::from_code(
             bun_sys::E::ENOSYS,
@@ -712,9 +712,11 @@ pub fn spawn_process_posix(
 
     if options.detached {
         // TODO(port): @hasDecl check — assume present on platforms that define it.
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
-            flags |= libc::POSIX_SPAWN_SETSID as i32;
+            // glibc/musl/bionic <spawn.h> all define POSIX_SPAWN_SETSID as 0x80;
+            // the libc crate only exposes it for `target_os = "linux"`.
+            flags |= 0x80;
         }
         #[cfg(target_os = "macos")]
         {
@@ -728,7 +730,7 @@ pub fn spawn_process_posix(
     attr.pty_slave_fd = options.pty_slave_fd;
     attr.new_process_group = options.new_process_group;
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         // Explicit per-spawn value wins; otherwise no-orphans mode defaults
         // every child to SIGKILL-on-parent-death so non-Bun descendants are
@@ -773,7 +775,7 @@ pub fn spawn_process_posix(
     let mut dup_stdout_to_stderr: bool = false;
 
     // The label is only referenced from the Linux memfd fast-path below.
-    #[cfg_attr(not(target_os = "linux"), allow(unused_labels))]
+    #[cfg_attr(not(any(target_os = "linux", target_os = "android")), allow(unused_labels))]
     'stdio: for i in 0..3usize {
         let fileno = Fd::from_native(FdT::try_from(i).unwrap());
         let flag: u32 = (if i == 0 {
@@ -807,7 +809,7 @@ pub fn spawn_process_posix(
                 actions.open(fileno, path, flag | bun_sys::O::CREAT as u32, 0o664)?;
             }
             PosixStdio::Buffer => {
-                #[cfg(target_os = "linux")]
+                #[cfg(any(target_os = "linux", target_os = "android"))]
                 'use_memfd: {
                     if !options.stream && i > 0 && bun_sys::can_use_memfd() {
                         // use memfd if we can
@@ -996,7 +998,7 @@ pub fn spawn_process_posix(
             spawned.pid = pid;
             spawned.extra_pipes = extra_fds;
 
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             {
                 // If it's spawnSync and we want to block the entire thread
                 // don't even bother with pidfd. It's not necessary.

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -2184,7 +2184,7 @@ impl StandaloneModuleGraph {
             return from_bytes_alloc(base, len, offsets).map(Some);
         }
 
-        #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
         {
             let Some((base, len)) = elf::get_data() else {
                 return Ok(None);
@@ -2218,6 +2218,7 @@ impl StandaloneModuleGraph {
             target_os = "macos",
             windows,
             target_os = "linux",
+            target_os = "android",
             target_os = "freebsd"
         )))]
         {
@@ -2247,14 +2248,14 @@ impl StandaloneModuleGraph {
                         None => return,
                     }
                 }
-                #[cfg(target_os = "linux")]
+                #[cfg(any(target_os = "linux", target_os = "android"))]
                 {
                     match elf::get_data() {
                         Some(b) => b,
                         None => return,
                     }
                 }
-                #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+                #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
                 {
                     return;
                 }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -868,7 +868,7 @@ pub fn open_dir_for_iteration_os_path(dir: Fd, path: &bun_paths::OSPathSlice) ->
 }
 
 pub fn lstatat(fd: Fd, path: &ZStr) -> Result<Stat> {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         // sys.zig:874 — `bun.invalid_fd` means cwd-relative.
         let dirfd = if fd.is_valid() {
@@ -880,7 +880,7 @@ pub fn lstatat(fd: Fd, path: &ZStr) -> Result<Stat> {
         linux_syscall::fstatat(dirfd, path, libc::AT_SYMLINK_NOFOLLOW)
             .map_err(|e| Error::from_code_int(e, Tag::fstatat).with_path(path.as_bytes()))
     }
-    #[cfg(all(unix, not(target_os = "linux")))]
+    #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
     {
         let mut st = core::mem::MaybeUninit::<libc::stat>::uninit();
         // sys.zig:874 — `bun.invalid_fd` means cwd-relative.
@@ -1119,16 +1119,16 @@ impl Renameat2Flags {
                 flags |= 0x10;
             }
         }
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             if self.exchange {
-                flags |= libc::RENAME_EXCHANGE;
+                flags |= libc::RENAME_EXCHANGE as u32;
             }
             if self.exclude {
-                flags |= libc::RENAME_NOREPLACE;
+                flags |= libc::RENAME_NOREPLACE as u32;
             }
         }
-        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
         {
             if self.exchange {
                 flags |= 1;
@@ -1198,11 +1198,11 @@ pub mod O {
     // routes `openat_windows_impl` to the directory NtCreateFile path.
     #[cfg(windows)]
     pub const DIRECTORY: i32 = 0o200000;
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const PATH: i32 = libc::O_PATH;
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const NOATIME: i32 = libc::O_NOATIME;
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const TMPFILE: i32 = libc::O_TMPFILE;
     // sys.zig:209-212 — Windows defines these (non-zero) so the `O.PATH` /
     // `O.NOATIME` bit-tests in `openat_windows_impl` are meaningful.
@@ -1212,11 +1212,11 @@ pub mod O {
     pub const NOATIME: i32 = 0o1000000;
     #[cfg(windows)]
     pub const TMPFILE: i32 = 0o20200000;
-    #[cfg(all(unix, not(target_os = "linux")))]
+    #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
     pub const PATH: i32 = 0;
-    #[cfg(all(unix, not(target_os = "linux")))]
+    #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
     pub const NOATIME: i32 = 0;
-    #[cfg(all(unix, not(target_os = "linux")))]
+    #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
     pub const TMPFILE: i32 = 0;
     // sys.zig:66-216 — defined for every platform; Darwin-only flags map to 0
     // elsewhere so `flags & O.EVTONLY` etc. compile and are no-ops.
@@ -1567,9 +1567,9 @@ impl From<Tag> for &'static str {
 
 /// Max single read/write count (sys.zig:1832): Linux caps at 0x7ffff000;
 /// Darwin/BSD use signed 32-bit byte counts.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub const MAX_COUNT: usize = 0x7ffff000;
-#[cfg(all(unix, not(target_os = "linux")))]
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
 pub const MAX_COUNT: usize = i32::MAX as usize;
 #[cfg(windows)]
 pub const MAX_COUNT: usize = u32::MAX as usize;
@@ -1767,7 +1767,7 @@ mod posix_impl {
     // dispatchers entirely — see the `#[cfg(target_os = "linux")]` arms on
     // each public fn below — because rustix returns the errno in-band and we
     // don't want to round-trip through thread-local `errno`.
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     #[inline]
     unsafe fn sys_openat(d: i32, p: *const libc::c_char, f: i32, m: libc::c_uint) -> i32 {
         #[cfg(target_os = "macos")]
@@ -1779,7 +1779,7 @@ mod posix_impl {
             unsafe { libc::openat(d, p, f, m) }
         }
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     #[inline]
     unsafe fn sys_read(fd: i32, buf: *mut libc::c_void, n: usize) -> isize {
         #[cfg(target_os = "macos")]
@@ -1791,7 +1791,7 @@ mod posix_impl {
             unsafe { libc::read(fd, buf, n) }
         }
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     #[inline]
     unsafe fn sys_write(fd: i32, buf: *const libc::c_void, n: usize) -> isize {
         #[cfg(target_os = "macos")]
@@ -1803,7 +1803,7 @@ mod posix_impl {
             unsafe { libc::write(fd, buf, n) }
         }
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     #[inline]
     unsafe fn sys_pread(fd: i32, buf: *mut libc::c_void, n: usize, off: i64) -> isize {
         #[cfg(target_os = "macos")]
@@ -1815,7 +1815,7 @@ mod posix_impl {
             unsafe { libc::pread(fd, buf, n, off) }
         }
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     #[inline]
     unsafe fn sys_pwrite(fd: i32, buf: *const libc::c_void, n: usize, off: i64) -> isize {
         #[cfg(target_os = "macos")]
@@ -1951,12 +1951,12 @@ mod posix_impl {
             );
             Ok(Fd::from_native(rc))
         }
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             super::linux_syscall::openat(dir, path, flags, mode)
                 .map_err(|e| Error::from_code_int(e, Tag::open).with_path(path.as_bytes()))
         }
-        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
         {
             let rc = check_p!(
                 unsafe { sys_openat(dir.native(), path.as_ptr(), flags, mode as libc::c_uint) },
@@ -1970,7 +1970,7 @@ mod posix_impl {
         // fd.zig:266 — call close ONCE; never retry on EINTR (Linux may have already
         // released the fd, retrying would close someone else's). Only EBADF surfaces.
         // fd.zig:273 — Darwin uses `close$NOCANCEL` (avoid pthread cancellation point).
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             return match super::linux_syscall::close(fd.native()) {
                 Err(e) if e == libc::EBADF => {
@@ -1979,7 +1979,7 @@ mod posix_impl {
                 _ => Ok(()),
             };
         }
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {
             #[cfg(target_os = "macos")]
             let rc = super::nocancel::close(fd.native());
@@ -2002,12 +2002,12 @@ mod posix_impl {
             );
             Ok(n as usize)
         }
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             super::linux_syscall::read(fd, &mut buf[..len])
                 .map_err(|e| Error::from_code_int(e, Tag::read))
         }
-        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
         {
             let n = check!(
                 unsafe { sys_read(fd.native(), buf.as_mut_ptr().cast(), len) },
@@ -2027,12 +2027,12 @@ mod posix_impl {
             );
             Ok(n as usize)
         }
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             super::linux_syscall::write(fd, &buf[..len])
                 .map_err(|e| Error::from_code_int(e, Tag::write))
         }
-        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
         {
             let n = check!(
                 unsafe { sys_write(fd.native(), buf.as_ptr().cast(), len) },
@@ -2043,12 +2043,12 @@ mod posix_impl {
     }
     pub fn pread(fd: Fd, buf: &mut [u8], off: i64) -> Maybe<usize> {
         let len = buf.len().min(MAX_COUNT);
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             return super::linux_syscall::pread(fd, &mut buf[..len], off)
                 .map_err(|e| Error::from_code_int(e, Tag::pread));
         }
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {
             let n = check!(
                 unsafe { sys_pread(fd.native(), buf.as_mut_ptr().cast(), len, off) },
@@ -2059,12 +2059,12 @@ mod posix_impl {
     }
     pub fn pwrite(fd: Fd, buf: &[u8], off: i64) -> Maybe<usize> {
         let len = buf.len().min(MAX_COUNT);
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             return super::linux_syscall::pwrite(fd, &buf[..len], off)
                 .map_err(|e| Error::from_code_int(e, Tag::pwrite));
         }
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {
             let n = check!(
                 unsafe { sys_pwrite(fd.native(), buf.as_ptr().cast(), len, off) },
@@ -2074,12 +2074,12 @@ mod posix_impl {
         }
     }
     pub fn stat(path: &ZStr) -> Maybe<Stat> {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             return super::linux_syscall::stat(path)
                 .map_err(|e| Error::from_code_int(e, Tag::stat).with_path(path.as_bytes()));
         }
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {
             let mut st = core::mem::MaybeUninit::<Stat>::uninit();
             check_p!(
@@ -2091,12 +2091,12 @@ mod posix_impl {
         }
     }
     pub fn fstat(fd: Fd) -> Maybe<Stat> {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             return super::linux_syscall::fstat(fd)
                 .map_err(|e| Error::from_code_int(e, Tag::fstat));
         }
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {
             let mut st = core::mem::MaybeUninit::<Stat>::uninit();
             check!(
@@ -2107,12 +2107,12 @@ mod posix_impl {
         }
     }
     pub fn lstat(path: &ZStr) -> Maybe<Stat> {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             return super::linux_syscall::lstat(path)
                 .map_err(|e| Error::from_code_int(e, Tag::lstat).with_path(path.as_bytes()));
         }
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {
             let mut st = core::mem::MaybeUninit::<Stat>::uninit();
             check_p!(
@@ -2136,7 +2136,7 @@ mod posix_impl {
     // hand-rolled struct + raw-`syscall(SYS_statx, …)` wrapper. The kernel ABI
     // (struct layout, `STATX_*` bits) is identical across libcs.
     // ──────────────────────────────────────────────────────────────────────
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     mod linux_statx {
         // glibc / Android: libc 0.2.x exposes the full surface directly.
         #[cfg(not(target_env = "musl"))]
@@ -2230,17 +2230,17 @@ mod posix_impl {
         #[cfg(target_env = "musl")]
         pub(super) use musl::*;
     }
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     use linux_statx as lx;
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub static SUPPORTS_STATX_ON_LINUX: core::sync::atomic::AtomicBool =
         core::sync::atomic::AtomicBool::new(true);
 
     /// `STATX_*` request mask covering every field `node:fs Stats` consumes
     /// (sys.zig:614 `StatxField` — all variants OR'd, the only mask the Zig
     /// callers ever pass).
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const STATX_MASK_FOR_STATS: u32 = lx::STATX_TYPE
         | lx::STATX_MODE
         | lx::STATX_NLINK
@@ -2255,7 +2255,7 @@ mod posix_impl {
         | lx::STATX_BLOCKS;
 
     /// Linux kernel makedev encoding (glibc sys/sysmacros.h / <linux/kdev_t.h>).
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     #[inline]
     const fn statx_makedev(major: u32, minor: u32) -> u64 {
         let maj: u64 = (major & 0xFFF) as u64;
@@ -2263,7 +2263,7 @@ mod posix_impl {
         (maj << 8) | (min & 0xFF) | ((min & 0xFFF00) << 12)
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     fn statx_fallback(fd: Fd, path: Option<&ZStr>, flags: c_int) -> Maybe<PosixStat> {
         if let Some(p) = path {
             let r = if flags & libc::AT_SYMLINK_NOFOLLOW != 0 {
@@ -2277,7 +2277,7 @@ mod posix_impl {
         }
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     fn statx_impl(fd: Fd, path: Option<&ZStr>, flags: c_int, mask: u32) -> Maybe<PosixStat> {
         use core::sync::atomic::Ordering;
         let mut buf = core::mem::MaybeUninit::<lx::statx>::uninit();
@@ -2361,15 +2361,15 @@ mod posix_impl {
         }
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn fstatx(fd: Fd, mask: u32) -> Maybe<PosixStat> {
         statx_impl(fd, None, libc::AT_EMPTY_PATH, mask)
     }
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn statx(path: &ZStr, mask: u32) -> Maybe<PosixStat> {
         statx_impl(Fd::from_native(libc::AT_FDCWD), Some(path), 0, mask)
     }
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn lstatx(path: &ZStr, mask: u32) -> Maybe<PosixStat> {
         statx_impl(
             Fd::from_native(libc::AT_FDCWD),
@@ -2463,7 +2463,7 @@ mod posix_impl {
         to: &ZStr,
         flags: Renameat2Flags,
     ) -> Maybe<()> {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             // SAFETY: FFI; all pointers/fds valid for the duration of the call.
             check_p!(
@@ -2509,7 +2509,7 @@ mod posix_impl {
             );
             return Ok(());
         }
-        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
         {
             if flags.int() != 0 {
                 return Err(
@@ -2630,7 +2630,7 @@ mod posix_impl {
     /// uses `linkat(tmpfd, "", dirfd, name, AT_EMPTY_PATH)` (requires
     /// CAP_DAC_READ_SEARCH); falls back to `/proc/self/fd/N` + AT_SYMLINK_FOLLOW.
     /// Linux-only; on other unix this errors with EOPNOTSUPP (Zig same).
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn linkat_tmpfile(tmpfd: Fd, dirfd: Fd, name: &ZStr) -> Maybe<()> {
         // 0=unknown, 1=have CAP_DAC_READ_SEARCH, -1=no cap → use /proc fallback.
         static CAP_STATUS: core::sync::atomic::AtomicI32 = core::sync::atomic::AtomicI32::new(0);
@@ -2687,7 +2687,7 @@ mod posix_impl {
             return Ok(());
         }
     }
-    #[cfg(all(unix, not(target_os = "linux")))]
+    #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
     pub fn linkat_tmpfile(_tmpfd: Fd, _dirfd: Fd, name: &ZStr) -> Maybe<()> {
         // sys.zig:4010 — `linkatTmpfile` tags as `.link` (matches Linux arm).
         Err(Error::from_code_int(libc::EOPNOTSUPP, Tag::link).with_path(name.as_bytes()))
@@ -2792,12 +2792,12 @@ mod posix_impl {
         } else {
             libc::AT_FDCWD
         };
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             return super::linux_syscall::fstatat(dirfd, path, 0)
                 .map_err(|e| Error::from_code_int(e, Tag::fstatat).with_path(path.as_bytes()));
         }
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {
             let mut st = core::mem::MaybeUninit::<Stat>::uninit();
             check_p!(
@@ -3041,7 +3041,7 @@ mod posix_impl {
     ) -> Maybe<[Fd; 2]> {
         let _ = for_shell; // only meaningful on macOS
         let mut fds = [0i32; 2];
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             let ty = ty | libc::SOCK_CLOEXEC | if nonblock { libc::SOCK_NONBLOCK } else { 0 };
             check!(
@@ -3049,7 +3049,7 @@ mod posix_impl {
                 Tag::socketpair
             );
         }
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {
             check!(
                 safe_libc::socketpair(domain, ty, proto, &mut fds),
@@ -3126,7 +3126,7 @@ mod posix_impl {
 
     /// `pidfd_open(2)` — Linux ≥ 5.3. Returns a pollable fd referring to `pid`.
     /// Callers fall back to the waiter-thread on `ENOSYS`/`EPERM`/`EACCES`.
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn pidfd_open(pid: libc::pid_t, flags: u32) -> Maybe<Fd> {
         super::linux_syscall::pidfd_open(pid, flags)
             .map_err(|e| Error::from_code_int(e, Tag::pidfd_open))
@@ -3272,7 +3272,7 @@ mod posix_impl {
 
     // ── memfd (Linux only) — sys.zig:3237-3296 ──
     /// `bun.sys.MemfdFlags` (Zig: `enum(u32)`).
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     #[derive(Clone, Copy, PartialEq, Eq)]
     #[repr(u32)]
     pub enum MemfdFlags {
@@ -3283,7 +3283,7 @@ mod posix_impl {
         /// `MFD_NOEXEC_SEAL`
         CrossProcess = 0x0008,
     }
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     impl MemfdFlags {
         #[inline]
         fn older_kernel_flag(self) -> u32 {
@@ -3297,19 +3297,19 @@ mod posix_impl {
     /// `memfd_create` requires kernel ≥ 3.17. Latched true on first ENOSYS so
     /// callers can take their existing fallback (heap buffer / pipe / socketpair)
     /// without retrying the syscall on every Blob/spawn.
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     static MEMFD_ENOSYS: core::sync::atomic::AtomicBool =
         core::sync::atomic::AtomicBool::new(false);
 
     /// `bun.sys.canUseMemfd()` — false on non-Linux; on Linux, false once
     /// `memfd_create` has returned ENOSYS/EPERM/EACCES.
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     #[inline]
     pub fn can_use_memfd() -> bool {
         // TODO(port): also gate on `BUN_FEATURE_FLAG_DISABLE_MEMFD`.
         !MEMFD_ENOSYS.load(core::sync::atomic::Ordering::Relaxed)
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     #[inline]
     pub fn can_use_memfd() -> bool {
         false
@@ -3319,7 +3319,7 @@ mod posix_impl {
     /// Retries on EINTR; on EINVAL retries once with the pre-6.3 flag set
     /// (drops `MFD_EXEC`/`MFD_NOEXEC_SEAL`); on ENOSYS/EPERM/EACCES latches
     /// [`can_use_memfd`] to false.
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn memfd_create(name: &core::ffi::CStr, flags_: MemfdFlags) -> Maybe<Fd> {
         let mut flags: u32 = flags_ as u32;
         loop {
@@ -3347,7 +3347,7 @@ mod posix_impl {
     /// sys.zig:504 — `sendfile(src, dest, len)`. Clamps `len` (avoid EINVAL on
     /// >2GB), EINTR-retries, and attaches the *source* fd to the error
     /// (sys.zig:513 `errnoSysFd(rc, .sendfile, src)`).
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn sendfile(src: Fd, dest: Fd, len: usize) -> Maybe<usize> {
         let len = len.min(i32::MAX as usize - 1);
         loop {
@@ -3363,7 +3363,7 @@ mod posix_impl {
             return Ok(rc as usize);
         }
     }
-    #[cfg(all(unix, not(target_os = "linux")))]
+    #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
     pub fn sendfile(src: Fd, _dest: Fd, _len: usize) -> Maybe<usize> {
         // sys.zig:513 `errnoSysFd(rc, .sendfile, src)` — attach the *source* fd.
         Err(Error::from_code_int(libc::ENOSYS, Tag::sendfile).with_fd(src))
@@ -4378,7 +4378,7 @@ pub fn pwritev(fd: Fd, vecs: &[PlatformIoVecConst], offset: i64) -> Maybe<usize>
             }
             return Ok(rc as usize);
         }
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             // SAFETY: `PlatformIoVecConst` is layout-identical to `libc::iovec`.
             return unsafe {
@@ -4386,7 +4386,7 @@ pub fn pwritev(fd: Fd, vecs: &[PlatformIoVecConst], offset: i64) -> Maybe<usize>
             }
             .map_err(|e| Error::from_code_int(e, Tag::pwritev));
         }
-        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
         loop {
             let rc = unsafe {
                 libc::pwritev(
@@ -4494,13 +4494,13 @@ pub fn writev(fd: Fd, vecs: &[PlatformIoVec]) -> Maybe<usize> {
             }
             return Ok(rc as usize);
         }
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             // SAFETY: `PlatformIoVec` is `libc::iovec`.
             return unsafe { linux_syscall::writev(fd, vecs.as_ptr(), vecs.len()) }
                 .map_err(|e| Error::from_code_int(e, Tag::writev).with_fd(fd));
         }
-        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
         loop {
             // SAFETY: see above.
             let rc =
@@ -4544,13 +4544,13 @@ pub fn readv(fd: Fd, vecs: &[PlatformIoVec]) -> Maybe<usize> {
             }
             return Ok(rc as usize);
         }
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             // SAFETY: `PlatformIoVec` is `libc::iovec`.
             return unsafe { linux_syscall::readv(fd, vecs.as_ptr(), vecs.len()) }
                 .map_err(|e| Error::from_code_int(e, Tag::readv).with_fd(fd));
         }
-        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
         loop {
             // SAFETY: see above.
             let rc =
@@ -4597,13 +4597,13 @@ pub fn preadv(fd: Fd, vecs: &[PlatformIoVec], position: i64) -> Maybe<usize> {
             }
             return Ok(rc as usize);
         }
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             // SAFETY: `PlatformIoVec` is `libc::iovec`.
             return unsafe { linux_syscall::preadv(fd, vecs.as_ptr(), vecs.len(), position) }
                 .map_err(|e| Error::from_code_int(e, Tag::preadv).with_fd(fd));
         }
-        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
         loop {
             // SAFETY: see `readv`.
             let rc = unsafe {
@@ -7053,7 +7053,7 @@ pub fn set_file_offset(fd: Fd, offset: u64) -> Maybe<()> {
 
 // ── nonblocking read/write (preadv2/pwritev2 RWF_NOWAIT on Linux) ──
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 unsafe extern "C" {
     fn sys_preadv2(
         fd: c_int,
@@ -7070,12 +7070,12 @@ unsafe extern "C" {
         flags: u32,
     ) -> isize;
 }
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const RWF_NOWAIT: u32 = 0x00000008;
 
 /// sys.zig:4046 — Linux: `preadv2(.., RWF_NOWAIT)`; else plain `read`.
 pub fn read_nonblocking(fd: Fd, buf: &mut [u8]) -> Maybe<usize> {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     while linux::RWFFlagSupport::is_maybe_supported() {
         let iov = [libc::iovec {
             iov_base: buf.as_mut_ptr().cast(),
@@ -7105,7 +7105,7 @@ pub fn read_nonblocking(fd: Fd, buf: &mut [u8]) -> Maybe<usize> {
 }
 /// sys.zig:4099 — Linux: `pwritev2(.., RWF_NOWAIT)`; else plain `write`.
 pub fn write_nonblocking(fd: Fd, buf: &[u8]) -> Maybe<usize> {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     while linux::RWFFlagSupport::is_maybe_supported() {
         let iov = [libc::iovec {
             iov_base: buf.as_ptr().cast_mut().cast::<_>(),
@@ -7143,7 +7143,7 @@ pub fn preallocate_file(
     offset: i64,
     len: i64,
 ) -> core::result::Result<(), bun_core::Error> {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         // Result intentionally discarded (Zig: `_ = std.os.linux.fallocate(...)`)
         // — preallocation is best-effort.
@@ -7215,13 +7215,13 @@ pub fn clonefileat(_from_dir: Fd, from: &ZStr, _to_dir: Fd, to: &ZStr) -> Maybe<
 /// (linprocfs hardcodes "des@freebsd.org"). Under FreeBSD's Linuxulator
 /// `/proc/self/fd/*` doesn't readlink, but `/dev/fd/*` does.
 /// 0=unknown, 1=linux, 2=freebsd.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 static LINUX_KERNEL_CACHED: core::sync::atomic::AtomicU8 = core::sync::atomic::AtomicU8::new(0);
 
 /// sys.zig:3032 `LinuxKernel.cached.load(.acquire) == .freebsd` — non-probing
 /// fast-path check. Returns `true` only when a previous probe already proved
 /// FreeBSD's Linuxulator; never triggers the `/proc/version` read itself.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 #[inline]
 fn linux_kernel_cached_is_freebsd() -> bool {
     LINUX_KERNEL_CACHED.load(core::sync::atomic::Ordering::Acquire) == 2
@@ -7229,7 +7229,7 @@ fn linux_kernel_cached_is_freebsd() -> bool {
 
 /// sys.zig:659 `LinuxKernel.get()` — probing variant: reads `/proc/version`
 /// once (memoized) and returns whether this is FreeBSD's Linuxulator.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn linux_kernel_is_freebsd() -> bool {
     use core::sync::atomic::Ordering;
     let v = LINUX_KERNEL_CACHED.load(Ordering::Acquire);
@@ -7259,7 +7259,7 @@ fn linux_kernel_is_freebsd() -> bool {
 }
 
 /// sys.zig:2999 `getFdPathFreeBSDLinuxulator` — readlink `/dev/fd/N` (fdescfs).
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn get_fd_path_freebsd_linuxulator<'a>(
     fd: Fd,
     out: &'a mut bun_paths::PathBuffer,
@@ -7280,7 +7280,7 @@ fn get_fd_path_freebsd_linuxulator<'a>(
 /// sys.zig:2940 — fd → absolute path. Linux: readlink `/proc/self/fd/N`;
 /// macOS: `fcntl(F_GETPATH)`; Windows: `GetFinalPathNameByHandle`.
 pub fn get_fd_path<'a>(fd: Fd, out: &'a mut bun_paths::PathBuffer) -> Maybe<&'a mut [u8]> {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         // sys.zig:3032 — fast path: a previous call already proved this is
         // FreeBSD's Linuxulator. Skip the doomed `/proc/self/fd/N` readlink.
@@ -7357,6 +7357,7 @@ pub fn get_fd_path<'a>(fd: Fd, out: &'a mut bun_paths::PathBuffer) -> Maybe<&'a 
     }
     #[cfg(not(any(
         target_os = "linux",
+        target_os = "android",
         target_os = "macos",
         target_os = "freebsd",
         windows
@@ -7478,7 +7479,7 @@ pub fn move_file_z_with_handle(
                 0o644,
             )
             .map_err(bun_core::Error::from)?;
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             {
                 // Preallocation is best-effort.
                 let _ = safe_libc::fallocate(dst.native(), 0, 0, st.st_size);
@@ -7799,11 +7800,11 @@ pub mod posix {
     #[cfg(unix)]
     #[inline]
     pub unsafe fn read(fd: c_int, buf: *mut u8, count: usize) -> isize {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             unsafe { super::linux_syscall::read_raw(fd, buf, count) }
         }
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {
             unsafe { libc::read(fd, buf.cast(), count) }
         }
@@ -7811,11 +7812,11 @@ pub mod posix {
     #[cfg(unix)]
     #[inline]
     pub unsafe fn write(fd: c_int, buf: *const u8, count: usize) -> isize {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             unsafe { super::linux_syscall::write_raw(fd, buf, count) }
         }
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {
             unsafe { libc::write(fd, buf.cast(), count) }
         }
@@ -7944,7 +7945,7 @@ pub mod posix {
 
     // ── dynamic loading (Linux/FreeBSD) ──
     /// `std.posix.dl_iterate_phdr` — iterate loaded ELF objects.
-    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
     #[inline]
     pub unsafe fn dl_iterate_phdr(
         callback: unsafe extern "C" fn(*mut libc::dl_phdr_info, usize, *mut c_void) -> c_int,
@@ -8766,7 +8767,7 @@ pub fn copy_file_z_slow_with_handle(in_handle: Fd, to_dir: Fd, destination: &ZSt
         O::WRONLY | O::CREAT | O::CLOEXEC | O::TRUNC,
         0o644,
     )?;
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         // Preallocation is best-effort.
         let _ = safe_libc::fallocate(dst.native(), 0, 0, st.st_size);

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -2132,26 +2132,28 @@ mod posix_impl {
     // every Linux ABI. The Rust port uses `libc::statx`, which the `libc` crate
     // only exposes for glibc/Android (and musl behind the build-time
     // `musl_v1_2_3` cfg the cross-compile build never sets). The `linux_statx`
-    // shim below smooths that over: glibc/android re-export `libc`, musl gets a
-    // hand-rolled struct + raw-`syscall(SYS_statx, …)` wrapper. The kernel ABI
-    // (struct layout, `STATX_*` bits) is identical across libcs.
+    // shim below smooths that over: glibc re-exports `libc`; musl and Android
+    // (bionic only added the `statx()` libc wrapper at API 30, we link against
+    // 28) get a hand-rolled struct + raw-`syscall(SYS_statx, …)` wrapper. The
+    // kernel ABI (struct layout, `STATX_*` bits) is identical across libcs.
     // ──────────────────────────────────────────────────────────────────────
     #[cfg(any(target_os = "linux", target_os = "android"))]
     mod linux_statx {
-        // glibc / Android: libc 0.2.x exposes the full surface directly.
-        #[cfg(not(target_env = "musl"))]
+        // glibc: libc 0.2.x exposes the full surface directly.
+        #[cfg(all(target_os = "linux", not(target_env = "musl")))]
         pub(super) use libc::{
             AT_STATX_SYNC_AS_STAT, STATX_ATIME, STATX_BLOCKS, STATX_BTIME, STATX_CTIME, STATX_GID,
             STATX_INO, STATX_MODE, STATX_MTIME, STATX_NLINK, STATX_SIZE, STATX_TYPE, STATX_UID,
             statx,
         };
 
-        // musl: `libc` gates `statx`/`STATX_*` behind a build-script-detected
-        // `musl_v1_2_3` cfg that cross-compiles can't trigger. Define the
-        // kernel-ABI struct + bits ourselves and dispatch via raw `syscall`,
-        // matching what Zig's `std.os.linux.statx` does on every Linux ABI.
-        #[cfg(target_env = "musl")]
-        mod musl {
+        // musl/Android: `libc` gates `statx`/`STATX_*` behind a build-script
+        // `musl_v1_2_3` cfg that cross-compiles can't trigger, and bionic's
+        // `statx()` wrapper requires API 30. Define the kernel-ABI struct +
+        // bits ourselves and dispatch via raw `syscall`, matching what Zig's
+        // `std.os.linux.statx` does on every Linux ABI.
+        #[cfg(any(target_env = "musl", target_os = "android"))]
+        mod raw {
             #![allow(non_camel_case_types)]
             use core::ffi::{c_char, c_int, c_uint};
 
@@ -2227,8 +2229,8 @@ mod posix_impl {
                 unsafe { libc::syscall(libc::SYS_statx, dirfd, path, flags, mask, buf) as c_int }
             }
         }
-        #[cfg(target_env = "musl")]
-        pub(super) use musl::*;
+        #[cfg(any(target_env = "musl", target_os = "android"))]
+        pub(super) use raw::*;
     }
     #[cfg(any(target_os = "linux", target_os = "android"))]
     use linux_statx as lx;
@@ -3323,7 +3325,15 @@ mod posix_impl {
     pub fn memfd_create(name: &core::ffi::CStr, flags_: MemfdFlags) -> Maybe<Fd> {
         let mut flags: u32 = flags_ as u32;
         loop {
+            // bionic only added the `memfd_create()` libc wrapper at API 30; we
+            // link against API 28. Raw-syscall it (kernel has had it since 3.17).
             // SAFETY: `name` is a valid NUL-terminated C string.
+            #[cfg(target_os = "android")]
+            let rc = unsafe {
+                libc::syscall(libc::SYS_memfd_create, name.as_ptr(), flags) as core::ffi::c_int
+            };
+            // SAFETY: `name` is a valid NUL-terminated C string.
+            #[cfg(target_os = "linux")]
             let rc = unsafe { libc::memfd_create(name.as_ptr(), flags) };
             if rc < 0 {
                 let e = last_errno();

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -1174,7 +1174,7 @@ pub mod ssl_wrapper {
 /// correct field offsets of `parent_ptr`/`jsc_vm` after it.
 #[cfg(target_vendor = "apple")]
 type ZigMutex = u32; // os_unfair_lock
-#[cfg(any(target_os = "linux", target_os = "freebsd"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 type ZigMutex = u32;
 #[cfg(windows)]
 type ZigMutex = *mut c_void; // SRWLOCK


### PR DESCRIPTION
Zig models Android as `os.tag == .linux, abi == .android`, so `Environment.isLinux` was true on Android. Rust splits them into two `target_os` values, so `cfg!(target_os = "linux")` is false on Android — code ported from Zig's `isLinux` checks needs `any(target_os = "linux", target_os = "android")` to preserve semantics. `IS_LINUX` in `src/bun_core/env.rs` already documents this.

The most visible symptom was `StandaloneModuleGraph::from_executable()` falling through to its catch-all `unreachable!()` on every invocation, panicking → SIGILL at startup on Android.

### What changed

Audited every `#[cfg(target_os = "linux")]` / `cfg!(target_os = "linux")` that doesn't already mention `android`, and added it where the gated code is a Linux-**kernel** feature (epoll, /proc, memfd, prctl, pidfd, copy_file_range, sendfile, statx, O_PATH/O_TMPFILE, ELF `link_section`, ftrace, futex, etc.) rather than a glibc/musl libc feature.

Left alone:
- `target_env = "gnu"` / `target_env = "musl"` gates (libc-specific by definition)
- glibc-only symbols: `gnu_get_libc_version`, `backtrace`/`<execinfo.h>`, `__wrap_gettid`, `getaddrinfo_a` EAI extensions
- `EAI_ADDRFAMILY` value — bionic uses BSD-style `1`, not glibc's `-9`
- `MAP_SHARED_VALIDATE | MAP_SYNC` — not exposed by the libc crate for android
- sites that already have a dedicated `#[cfg(target_os = "android")]` arm (e.g. `pidfd_open` raw-syscall shim, `spawn_sync_inherit` fork+execvp fallback)

Three small follow-on fixes to keep `cargo check --target aarch64-linux-android` green:
- `libc::RENAME_EXCHANGE` / `RENAME_NOREPLACE` are `c_int` on android vs `c_uint` on linux → `as u32`
- `libc::POSIX_SPAWN_SETSID` isn't exposed by the libc crate for android (bionic value is `0x80`, same as glibc/musl) → local const at the two call sites

### Verification

`cargo check --workspace` passes on `{aarch64,x86_64}-linux-android`, `x86_64-unknown-linux-{gnu,musl}`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`, `x86_64-unknown-freebsd`.