### PR TITLE
collections: safe HiveSlot enum + defer used-bit to write(); migrate deprecated get()

### DIFF
--- a/src/bundler/linker_context/renameSymbolsInChunk.rs
+++ b/src/bundler/linker_context/renameSymbolsInChunk.rs
@@ -412,7 +412,7 @@ pub unsafe fn rename_symbols_in_chunk(
                 );
             }
             // Zig: `@TypeOf(r.number_scope_pool.hive.used).initEmpty()`.
-            r.number_scope_pool.hive.used = bun_collections::hive_array::HiveBitSet::init_empty();
+            r.number_scope_pool.reset();
         }
     }
 

--- a/src/collections/hive_array.rs
+++ b/src/collections/hive_array.rs
@@ -1,5 +1,4 @@
-use core::marker::PhantomData;
-use core::mem::{ManuallyDrop, MaybeUninit, size_of};
+use core::mem::{MaybeUninit, size_of};
 use core::ptr::NonNull;
 
 use bun_core::asan;
@@ -105,18 +104,6 @@ impl<const CAPACITY: usize> HiveBitSet<CAPACITY> {
     /// Forward iterator over set bits. Mirrors `IntegerBitSet::iter_set`.
     #[inline]
     pub fn iter_set(&self) -> HiveBitSetIter<CAPACITY> {
-        self.iterator::<true, true>()
-    }
-
-    /// Signature mirrors `IntegerBitSet::iterator` so existing
-    /// `hive.used.iterator::<true, true>()` callers compile unchanged. Only
-    /// the `<KIND_SET=true, DIR_FWD=true>` combination is implemented (the
-    /// only one used in-tree); other params assert.
-    #[inline]
-    pub fn iterator<const KIND_SET: bool, const DIR_FWD: bool>(
-        &self,
-    ) -> HiveBitSetIter<CAPACITY> {
-        const { assert!(KIND_SET && DIR_FWD, "HiveBitSet::iterator only supports <true,true>") };
         HiveBitSetIter {
             masks: self.masks,
             word: 0,
@@ -149,11 +136,19 @@ impl<const CAPACITY: usize> HiveBitSetIter<CAPACITY> {
 /// An array that efficiently tracks which elements are in use.
 /// The pointers are intended to be stable
 /// Sorta related to https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0447r15.html
+///
+/// MODULE INVARIANT: `used.is_set(i) ⇔ buffer[i] is a fully-initialized T`.
+/// The bit is set only by [`HiveSlot::write`]/[`HiveSlot::assume_init`] (which
+/// hold `&mut HiveArray` while writing) and unset only by [`put`](Self::put)/
+/// [`put_raw`](Self::put_raw)/[`take`](Self::take)/[`release_at`](Self::release_at)/
+/// [`reset`](Self::reset). With `buffer`/`used` private, safe code cannot
+/// desync the invariant — `mem::forget(slot)` is harmless because `claim()`
+/// does not set the bit.
 // PORT NOTE: Zig's `capacity: u16` is widened to `usize` here because Rust array
 // lengths require a `usize` const generic on stable.
 pub struct HiveArray<T, const CAPACITY: usize> {
-    pub buffer: [MaybeUninit<T>; CAPACITY],
-    pub used: HiveBitSet<CAPACITY>,
+    buffer: [MaybeUninit<T>; CAPACITY],
+    used: HiveBitSet<CAPACITY>,
 }
 
 impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
@@ -168,51 +163,6 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
             buffer: [const { MaybeUninit::uninit() }; CAPACITY],
             used: HiveBitSet::init_empty(),
         }
-    }
-
-    /// Placement-new constructor: write the empty state directly into `*out`
-    /// without materializing `Self` on the stack.
-    ///
-    /// `Self` embeds `[MaybeUninit<T>; CAPACITY]` inline, which for the
-    /// install pools (`NetworkTask` × 128, `Task` × 64) is hundreds of KB.
-    /// Rust has no result-location semantics, so `out.write(Self::init())`
-    /// first builds the value in the caller's frame and `memcpy`s it — LLVM
-    /// does **not** elide that temporary. This entry point only writes the
-    /// 256 B `used` bitset; `buffer` is `MaybeUninit` and needs no
-    /// initialization (uninitialized bytes are a valid bit-pattern for it).
-    ///
-    /// # Safety
-    /// `out` must be non-null, properly aligned, and valid for writes of
-    /// `size_of::<Self>()` bytes. The previous contents are not dropped.
-    #[inline]
-    pub unsafe fn init_in_place(out: *mut Self) {
-        // SAFETY: caller contract — `out` is aligned and writable. We form a
-        // place expression on `*out` only to project to `used`; no `&mut Self`
-        // is created over the (uninitialized) whole struct.
-        unsafe {
-            core::ptr::addr_of_mut!((*out).used).write(HiveBitSet::init_empty());
-        }
-        // `buffer: [MaybeUninit<T>; CAPACITY]` intentionally untouched.
-    }
-
-    /// Claim a slot and return a raw pointer to its **uninitialized** storage.
-    ///
-    /// Prefer [`get_init`](Self::get_init) / [`emplace`](Self::emplace) /
-    /// [`claim`](Self::claim), which encode the "a `used` slot is always
-    /// fully initialized" invariant in the type system. This entry point
-    /// hands out `*mut T` to garbage; forming `&mut T` over it is instant UB
-    /// when `T` has niche-bearing fields, and an early return between `get()`
-    /// and the caller's `ptr::write` leaves the slot claimed-but-uninit so a
-    /// later [`put`](Self::put) drops garbage.
-    #[deprecated = "returns *mut T to uninitialized memory; use get_init / emplace / claim"]
-    pub fn get(&mut self) -> Option<*mut T> {
-        let Some(index) = self.used.find_first_unset() else {
-            return None;
-        };
-        self.used.set(index);
-        let ret = self.buffer[index].as_mut_ptr();
-        asan::unpoison(ret.cast(), size_of::<T>());
-        Some(ret)
     }
 
     /// One-shot claim + write. Preferred entry point — no uninit window.
@@ -230,7 +180,7 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
     /// and must return the value to be stored there.
     #[inline]
     pub fn emplace(&mut self, init: impl FnOnce(NonNull<T>) -> T) -> Option<NonNull<T>> {
-        let slot = self.claim()?;
+        let mut slot = self.claim()?;
         let addr = slot.addr();
         Some(slot.write(init(addr)))
     }
@@ -243,26 +193,14 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
     /// The returned token borrows `self` for `'_`; precompute any raw
     /// back-pointers to the parent struct *before* calling `claim()` if they
     /// are needed inside the initializer.
+    ///
+    /// The `used` bit is **not** set until [`HiveSlot::write`]/
+    /// [`HiveSlot::assume_init`] commits the slot; dropping or forgetting the
+    /// token leaves the slot free.
     pub fn claim(&mut self) -> Option<HiveSlot<'_, T, CAPACITY>> {
         let index = self.used.find_first_unset()?;
-        self.used.set(index);
-        let slot = NonNull::from(&mut self.buffer[index]);
-        asan::unpoison(slot.as_ptr().cast(), size_of::<T>());
-        let owner = core::ptr::from_mut(self) as usize;
-        // Tagged-pointer scheme requires the low bit clear for inline slots.
-        // `HiveArray` is at least pointer-aligned via `IntegerBitSet`'s
-        // backing word, and in practice `align_of::<T>() >= 2` for every `T`
-        // we pool; assert in debug so a future 1-byte `T` is caught.
-        debug_assert_eq!(
-            owner & 1,
-            0,
-            "HiveArray must be >=2-byte aligned for HiveSlot owner tag"
-        );
-        Some(HiveSlot {
-            slot,
-            owner,
-            _marker: PhantomData,
-        })
+        asan::unpoison(self.buffer[index].as_mut_ptr().cast(), size_of::<T>());
+        Some(HiveSlot(Some(SlotInner::Inline { hive: self, index })))
     }
 
     /// Recycle a slot **without** running `T::drop`. Safe: if `value` does not
@@ -280,11 +218,71 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
         true
     }
 
-    pub fn at(&mut self, index: u16) -> *mut T {
-        debug_assert!((index as usize) < CAPACITY);
-        let ret = self.buffer[index as usize].as_mut_ptr();
-        asan::assert_unpoisoned(ret.cast::<u8>());
-        ret
+    /// Release slot `i` without running `T::drop` (by-index counterpart to
+    /// [`put_raw`](Self::put_raw)). For callers that hold an index rather than
+    /// the original pointer.
+    #[inline]
+    pub fn release_at(&mut self, i: usize) {
+        debug_assert!(i < CAPACITY);
+        debug_assert!(self.used.is_set(i));
+        asan::poison(self.buffer[i].as_mut_ptr().cast(), size_of::<T>());
+        self.used.unset(i);
+    }
+
+    /// Safe `&mut T` access to an occupied slot. `None` if `i` is out of range
+    /// or unused.
+    #[inline]
+    pub fn at_mut(&mut self, i: usize) -> Option<&mut T> {
+        if i < CAPACITY && self.used.is_set(i) {
+            // SAFETY: module invariant — `used.is_set(i) ⇔ buffer[i] initialized`.
+            Some(unsafe { self.buffer[i].assume_init_mut() })
+        } else {
+            None
+        }
+    }
+
+    /// Move the value out of slot `i` and release the slot. `None` if `i` is
+    /// out of range or unused.
+    #[inline]
+    pub fn take(&mut self, i: usize) -> Option<T> {
+        if i < CAPACITY && self.used.is_set(i) {
+            self.used.unset(i);
+            // SAFETY: module invariant — bit was set ⇔ slot initialized; we
+            // unset the bit so the slot is now logically free and ownership of
+            // the `T` transfers to the caller.
+            let v = unsafe { self.buffer[i].assume_init_read() };
+            asan::poison(self.buffer[i].as_mut_ptr().cast(), size_of::<T>());
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    /// Iterator over indices of occupied slots. The iterator copies the bitset
+    /// at construction time, so the hive can be borrowed `&mut` (e.g. via
+    /// [`at_mut`](Self::at_mut)) inside the loop body.
+    #[inline]
+    pub fn used_iter(&self) -> HiveBitSetIter<CAPACITY> {
+        self.used.iter_set()
+    }
+
+    /// `true` if any slot is occupied.
+    #[inline]
+    pub fn any_used(&self) -> bool {
+        self.used.find_first_set().is_some()
+    }
+
+    #[inline]
+    pub fn is_used(&self, i: usize) -> bool {
+        i < CAPACITY && self.used.is_set(i)
+    }
+
+    /// Mark every slot free **without** running `T::drop` on any contents.
+    /// Only valid when the caller has already torn down / moved out every live
+    /// value (or `T` is POD). Bulk equivalent of [`put_raw`](Self::put_raw).
+    #[inline]
+    pub fn reset(&mut self) {
+        self.used = HiveBitSet::init_empty();
     }
 
     pub fn index_of(&self, value: *const T) -> Option<u32> {
@@ -313,21 +311,24 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
 
     /// Return a slot to the pool, dropping the contained `T` in place.
     ///
-    /// Returns `false` (and drops nothing) if `value` does not point into
-    /// this hive's buffer.
+    /// Returns `false` (and drops nothing) if `value` does not point into this
+    /// hive's buffer or the slot's `used` bit is already clear (double-put
+    /// guard).
     ///
-    /// # Safety
-    /// If `value` points into this hive, it must point to a fully-initialized
-    /// `T` previously obtained via [`get`](Self::get) and written by the
-    /// caller. The slot is dropped in place; passing a moved-from or
-    /// uninitialized slot is UB for `T` with drop glue.
-    pub unsafe fn put(&mut self, value: *mut T) -> bool {
+    /// Safe: with the module invariant maintained internally, any `value` for
+    /// which `index_of` succeeds and `used.is_set` holds was written via
+    /// [`HiveSlot::write`]/[`HiveSlot::assume_init`] — the latter is `unsafe`
+    /// and its caller asserted full initialization.
+    pub fn put(&mut self, value: *mut T) -> bool {
         let Some(index) = self.index_of(value) else {
             return false;
         };
-
-        debug_assert!(self.used.is_set(index as usize));
-        debug_assert!(self.buffer[index as usize].as_ptr().cast::<T>() == value.cast_const());
+        let i = index as usize;
+        if !self.used.is_set(i) {
+            debug_assert!(false, "HiveArray::put on unclaimed slot (double put?)");
+            return false;
+        }
+        debug_assert!(self.buffer[i].as_ptr().cast::<T>() == value.cast_const());
 
         // PORT NOTE: Zig wrote `value.* = undefined;` — Zig has no destructors,
         // so the slot was simply marked logically uninitialized. In the Rust
@@ -336,11 +337,10 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
         // before recycling so the put/get cycle does not leak it. Callers that
         // pre-clean fields (`PooledSocket::release_parked_refs`) leave only
         // trivially-droppable residuals, so this is idempotent for them.
-        // SAFETY: caller contract — `value` is a fully-initialized `T` in `buffer`.
-        unsafe { core::ptr::drop_in_place(value) };
+        // SAFETY: module invariant — `used.is_set(i) ⇔ buffer[i] initialized`.
+        unsafe { self.buffer[i].assume_init_drop() };
         asan::poison(value.cast(), size_of::<T>());
-
-        self.used.unset(index as usize);
+        self.used.unset(i);
         true
     }
 }
@@ -351,36 +351,26 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
 
 /// Linear reservation token for a claimed-but-uninitialized hive slot.
 ///
-/// `HiveArray` slots are `[MaybeUninit<T>; CAP]`. The legacy [`HiveArray::get`]
-/// contract was two-phase — claim a `*mut T` to garbage, then `ptr::write` it
-/// — which opened three UB hazards in the gap: (H1) early-return / `?` / panic
-/// leaves the slot claimed-uninit so a later `put()` drops garbage; (H2)
-/// `&mut *p` over uninit `T` is instant validity UB when `T` has niches; (H3)
-/// partial field-write then `assume_init_ref` on the whole slot.
+/// The legacy two-phase contract (claim a `*mut T` to garbage, then
+/// `ptr::write` it) opened UB hazards in the gap: early-return / `?` / panic
+/// left the slot claimed-uninit, and `&mut *p` over uninit `T` is instant
+/// validity UB when `T` has niches.
 ///
 /// `HiveSlot` encodes the invariant **"a `used` slot is always fully
-/// initialized"** in the type system: you cannot obtain the stable
-/// initialized `*mut T` without going through [`write`](Self::write) (or the
-/// `unsafe` [`assume_init`](Self::assume_init) escape hatch). If the token is
-/// dropped (early return, `?`, panic) the slot is released **without** running
-/// `T::drop` — it was never written.
-///
-/// Two-pointer-sized; `owner` is a tagged `usize`:
-///   - low bit `0` ⇒ `*mut HiveArray<T, CAP>` (release = unset `used` bit + poison),
-///   - low bit `1` ⇒ heap `Box<MaybeUninit<T>>` (release = dealloc, no `T::drop`).
-///
-/// **Aliasing note** (matches the `BackRef<T>` precedent in `bun_ptr`): the
-/// token stores a raw `*mut HiveArray` rather than `&'h mut HiveArray`. The
-/// `PhantomData<&'h mut _>` keeps it lifetime-scoped to the `claim()` borrow,
-/// but the structural guarantee — the hive is a field of a long-lived owner
-/// that is not moved between `claim()` and `write()` — is the caller's, same
-/// as every back-pointer in the port.
+/// initialized"** in the type system: the `used` bit is set only when
+/// [`write`](Self::write) (or the `unsafe` [`assume_init`](Self::assume_init))
+/// commits the slot. If the token is dropped (early return, `?`, panic) the
+/// slot stays free — no bit was set, no `T::drop` runs. `mem::forget(slot)`
+/// is likewise harmless (slot stays free; next `claim()` reuses it).
 #[must_use = "claimed hive slot is leaked if neither written nor dropped"]
-pub struct HiveSlot<'h, T, const CAPACITY: usize> {
-    slot: NonNull<MaybeUninit<T>>,
-    /// Tagged owner; see type-level docs.
-    owner: usize,
-    _marker: PhantomData<&'h mut HiveArray<T, CAPACITY>>,
+pub struct HiveSlot<'h, T, const CAPACITY: usize>(Option<SlotInner<'h, T, CAPACITY>>);
+
+enum SlotInner<'h, T, const CAPACITY: usize> {
+    Inline {
+        hive: &'h mut HiveArray<T, CAPACITY>,
+        index: usize,
+    },
+    Heap(Box<MaybeUninit<T>>),
 }
 
 impl<'h, T, const CAPACITY: usize> HiveSlot<'h, T, CAPACITY> {
@@ -388,8 +378,8 @@ impl<'h, T, const CAPACITY: usize> HiveSlot<'h, T, CAPACITY> {
     /// libuv/uws user-data pointer) **before** [`write`](Self::write), as long
     /// as nothing dereferences it until after `write()`.
     #[inline]
-    pub fn addr(&self) -> NonNull<T> {
-        self.slot.cast::<T>()
+    pub fn addr(&mut self) -> NonNull<T> {
+        NonNull::from(self.as_uninit()).cast()
     }
 
     /// `&mut MaybeUninit<T>` for piecewise init via `addr_of_mut!`. Prefer
@@ -397,59 +387,57 @@ impl<'h, T, const CAPACITY: usize> HiveSlot<'h, T, CAPACITY> {
     /// (`create_in`-style constructors that take `&mut MaybeUninit<Self>`).
     #[inline]
     pub fn as_uninit(&mut self) -> &mut MaybeUninit<T> {
-        // SAFETY: `slot` is a unique live pointer into the hive buffer (or a
-        // freshly leaked `Box<MaybeUninit<T>>`); the `&mut self` receiver
-        // guarantees no other `&mut` to the same `MaybeUninit<T>` exists.
-        unsafe { self.slot.as_mut() }
+        match self.0.as_mut().expect("HiveSlot already consumed") {
+            SlotInner::Inline { hive, index } => &mut hive.buffer[*index],
+            SlotInner::Heap(b) => b,
+        }
     }
 
-    /// Move `value` into the slot and return the stable initialized pointer.
-    /// Consumes the token (its `Drop` does not run).
+    /// Move `value` into the slot, mark it occupied, and return the stable
+    /// initialized pointer. Consumes the token.
     #[inline]
-    pub fn write(self, value: T) -> NonNull<T> {
-        let mut this = ManuallyDrop::new(self);
-        NonNull::from(this.as_uninit().write(value))
+    pub fn write(mut self, value: T) -> NonNull<T> {
+        match self.0.take().expect("HiveSlot already consumed") {
+            SlotInner::Inline { hive, index } => {
+                let p = NonNull::from(hive.buffer[index].write(value));
+                hive.used.set(index);
+                p
+            }
+            SlotInner::Heap(b) => NonNull::from(Box::leak(b).write(value)),
+        }
     }
 
     /// Caller has fully initialized the slot via [`as_uninit`](Self::as_uninit)
-    /// (or by writing through [`addr`](Self::addr)). Consumes the token.
+    /// (or by writing through [`addr`](Self::addr)). Marks the slot occupied
+    /// and consumes the token.
     ///
     /// # Safety
     /// Every field of `T` must be initialized, including padding-adjacent
     /// niches (enum discriminants, `NonNull`, `Box`, `&`). Calling this on a
     /// partially-written slot is the exact UB this type exists to prevent.
     #[inline]
-    pub unsafe fn assume_init(self) -> NonNull<T> {
-        let this = ManuallyDrop::new(self);
-        this.slot.cast::<T>()
+    pub unsafe fn assume_init(mut self) -> NonNull<T> {
+        match self.0.take().expect("HiveSlot already consumed") {
+            SlotInner::Inline { hive, index } => {
+                hive.used.set(index);
+                NonNull::from(&mut hive.buffer[index]).cast()
+            }
+            SlotInner::Heap(b) => NonNull::from(Box::leak(b)).cast(),
+        }
     }
 }
 
 impl<T, const CAPACITY: usize> Drop for HiveSlot<'_, T, CAPACITY> {
     fn drop(&mut self) {
-        if self.owner & 1 == 0 {
-            // Inline hive slot: unset the `used` bit and re-poison. Do NOT
-            // `drop_in_place` — the slot was never `.write()`n.
-            let hive = self.owner as *mut HiveArray<T, CAPACITY>;
-            // SAFETY: `owner` was set from `core::ptr::from_mut(self)` in
-            // `HiveArray::claim`; the hive is a field of a long-lived owner
-            // that has not been moved (structural back-pointer guarantee).
-            // No `&mut HiveArray` is live across this drop — `claim()`'s
-            // borrow was released when the raw pointer was captured.
-            unsafe {
-                let index = (*hive)
-                    .index_of(self.slot.as_ptr().cast::<T>())
-                    .expect("HiveSlot points outside its owning hive");
-                asan::poison(self.slot.as_ptr().cast(), size_of::<T>());
-                (*hive).used.unset(index as usize);
+        match self.0.take() {
+            // Bit was never set; just re-poison so asan still catches a stale
+            // `addr()` deref after the token is dropped.
+            Some(SlotInner::Inline { hive, index }) => {
+                asan::poison(hive.buffer[index].as_mut_ptr().cast(), size_of::<T>());
             }
-        } else {
-            // Heap fallback slot: reclaim the `Box<MaybeUninit<T>>` allocation.
-            // `MaybeUninit<T>` has no drop glue, so this deallocates without
-            // touching `T`.
-            // SAFETY: `slot` was produced by `Box::leak(Box::<MaybeUninit<T>>::new_uninit())`
-            // in `Fallback::claim` and has not been freed.
-            drop(unsafe { Box::from_raw(self.slot.as_ptr()) });
+            // `Box<MaybeUninit<T>>` drop deallocates without running `T::drop`.
+            Some(SlotInner::Heap(_)) => {}
+            None => {}
         }
     }
 }
@@ -461,7 +449,7 @@ impl<T, const CAPACITY: usize> Drop for HiveSlot<'_, T, CAPACITY> {
 // `CAPACITY > 0` checks below preserve the original gating.
 // PERF(port): zero-capacity case carried a zero-size hive in Zig — profile in Phase B.
 pub struct Fallback<T, const CAPACITY: usize> {
-    pub hive: HiveArray<T, CAPACITY>,
+    hive: HiveArray<T, CAPACITY>,
     // PORT NOTE: `std.mem.Allocator param` dropped — global mimalloc.
 }
 
@@ -470,19 +458,6 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
         Self {
             hive: HiveArray::init(),
         }
-    }
-
-    /// Placement-new constructor — see [`HiveArray::init_in_place`]. Only
-    /// writes the 256 B occupancy bitset; the `[MaybeUninit<T>; CAPACITY]`
-    /// buffer is left untouched.
-    ///
-    /// # Safety
-    /// `out` must be non-null, properly aligned, and valid for writes of
-    /// `size_of::<Self>()` bytes. The previous contents are not dropped.
-    #[inline]
-    pub unsafe fn init_in_place(out: *mut Self) {
-        // SAFETY: caller contract.
-        unsafe { HiveArray::<T, CAPACITY>::init_in_place(core::ptr::addr_of_mut!((*out).hive)) };
     }
 
     /// Heap-allocate an empty `Fallback` without materializing it on the
@@ -494,50 +469,24 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
     /// zeros into a stack temporary and then `memcpy`s the **full** 816 KB
     /// into the heap allocation, committing both ~812 KB of stack pages and
     /// ~812 KB of heap pages that are never read. This entry point allocates
-    /// raw heap storage and writes only the 256-byte `used` bitset via
-    /// [`init_in_place`](Self::init_in_place); the `[MaybeUninit<T>; CAPACITY]`
-    /// buffer is left untouched (uninitialized bytes are a valid bit-pattern
-    /// for `MaybeUninit`).
-    ///
-    /// The returned allocation is leaked — callers stash it in a per-thread
-    /// static for the process lifetime (Zig: `threadlocal var pool`).
+    /// raw heap storage and writes only the 256-byte `used` bitset; the
+    /// `[MaybeUninit<T>; CAPACITY]` buffer is left untouched (uninitialized
+    /// bytes are a valid bit-pattern for `MaybeUninit`).
     #[inline]
-    pub fn new_boxed() -> NonNull<Self> {
+    pub fn new_boxed() -> Box<Self> {
         let mut boxed = Box::<Self>::new_uninit();
         // SAFETY: `boxed` is a fresh heap allocation — non-null, aligned for
-        // `Self`, and valid for writes of `size_of::<Self>()` bytes.
-        unsafe { Self::init_in_place(boxed.as_mut_ptr()) };
-        // SAFETY: `init_in_place` fully initialized `hive.used`; `hive.buffer`
-        // is `[MaybeUninit<T>; CAPACITY]`, for which uninitialized bytes are a
-        // valid representation. Every field of `Self` is therefore valid.
-        NonNull::from(Box::leak(unsafe { boxed.assume_init() }))
-    }
-
-    /// See [`HiveArray::get`] — same UB hazards, plus the heap path leaks a
-    /// `Box<MaybeUninit<T>>` if the caller early-returns before `ptr::write`.
-    #[deprecated = "returns *mut T to uninitialized memory; use get_init / emplace / claim"]
-    pub fn get(&mut self) -> *mut T {
-        // Forget the token so its `Drop` does not release the slot — legacy
-        // callers expect the slot to remain claimed until their later `put()`.
-        ManuallyDrop::new(self.claim()).addr().as_ptr()
-    }
-
-    #[deprecated = "returns *mut T to uninitialized memory; use get_init / emplace / claim"]
-    pub fn get_and_see_if_new(&mut self, new: &mut bool) -> *mut T {
-        if CAPACITY > 0 {
-            #[allow(deprecated)]
-            if let Some(value) = self.hive.get() {
-                *new = false;
-                return value;
-            }
+        // `Self`, and valid for writes of `size_of::<Self>()` bytes. We form a
+        // place expression on `*out` only to project to `hive.used`; no
+        // `&mut Self` is created over the (uninitialized) whole struct. After
+        // the write, `hive.used` is fully initialized and `hive.buffer` is
+        // `[MaybeUninit<T>; CAPACITY]` for which uninitialized bytes are a
+        // valid representation, so `assume_init()` is sound.
+        unsafe {
+            let out = boxed.as_mut_ptr();
+            core::ptr::addr_of_mut!((*out).hive.used).write(HiveBitSet::init_empty());
+            boxed.assume_init()
         }
-
-        bun_core::heap::into_raw(Box::<T>::new_uninit()).cast::<T>()
-    }
-
-    #[deprecated = "returns *mut T to uninitialized memory; use get_init / emplace / claim"]
-    pub fn try_get(&mut self) -> *mut T {
-        ManuallyDrop::new(self.claim()).addr().as_ptr()
     }
 
     /// One-shot claim + write. Preferred entry point — no uninit window.
@@ -550,28 +499,28 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
     /// See [`HiveArray::emplace`]. Infallible (heap fallback).
     #[inline]
     pub fn emplace(&mut self, init: impl FnOnce(NonNull<T>) -> T) -> NonNull<T> {
-        let slot = self.claim();
+        let mut slot = self.claim();
         let addr = slot.addr();
         slot.write(init(addr))
     }
 
     /// See [`HiveArray::claim`]. Infallible: when the inline hive is full,
-    /// the returned token owns a freshly-allocated heap slot (tagged so its
-    /// `Drop` deallocates without running `T::drop`).
+    /// the returned token owns a freshly-allocated heap slot whose `Drop`
+    /// deallocates without running `T::drop`.
     pub fn claim(&mut self) -> HiveSlot<'_, T, CAPACITY> {
         if CAPACITY > 0 {
             if let Some(slot) = self.hive.claim() {
                 return slot;
             }
         }
-        let slot = NonNull::from(Box::leak(Box::<T>::new_uninit()));
-        HiveSlot {
-            slot,
-            // Low bit 1 ⇒ heap slot. The hive pointer is not needed on the
-            // release path (dealloc is `Box::from_raw(slot)`).
-            owner: 1,
-            _marker: PhantomData,
-        }
+        HiveSlot(Some(SlotInner::Heap(Box::new_uninit())))
+    }
+
+    /// See [`HiveArray::reset`]. Heap-fallback slots are caller-managed and
+    /// not tracked here, so this only clears the inline bitset.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.hive.reset();
     }
 
     /// Recycle a slot **without** running `T::drop`. Counterpart to
@@ -579,20 +528,18 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
     ///
     /// # Safety
     /// `value` must have been obtained from this `Fallback` (via `get_init` /
-    /// `emplace` / `claim().write()` / the deprecated `get` family) and not
-    /// yet returned. The contained `T` is **not** dropped — caller must have
-    /// already moved out / destructured anything with drop glue, or `T` must
-    /// be POD.
+    /// `emplace` / `claim().write()`) and not yet returned. The contained `T`
+    /// is **not** dropped — caller must have already moved out / destructured
+    /// anything with drop glue, or `T` must be POD.
     pub unsafe fn put_raw(&mut self, value: *mut T) {
         if CAPACITY > 0 {
             if self.hive.put_raw(value) {
                 return;
             }
         }
-        // SAFETY: caller contract — `value` is a heap slot from `claim()` /
-        // `get()`; it was allocated as `Box<MaybeUninit<T>>` (same layout as
-        // `Box<T>`). Reclaiming as `MaybeUninit<T>` deallocates without
-        // running `T::drop`.
+        // SAFETY: caller contract — `value` is a heap slot from `claim()`; it
+        // was allocated as `Box<MaybeUninit<T>>` (same layout as `Box<T>`).
+        // Reclaiming as `MaybeUninit<T>` deallocates without running `T::drop`.
         drop(unsafe { Box::from_raw(value.cast::<MaybeUninit<T>>()) });
     }
 
@@ -610,21 +557,19 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
     ///
     /// # Safety
     /// `value` must point to a fully-initialized `T` previously obtained from
-    /// [`get`](Self::get) / [`get_and_see_if_new`](Self::get_and_see_if_new) /
-    /// [`try_get`](Self::try_get) on this `Fallback` and subsequently written
-    /// by the caller.
+    /// this `Fallback` via `get_init` / `emplace` / `claim().write()` /
+    /// `claim().assume_init()` and not yet returned. The heap path has no
+    /// membership check, so a foreign pointer is UB.
     pub unsafe fn put(&mut self, value: *mut T) {
         if CAPACITY > 0 {
-            // SAFETY: caller contract — `value` is fully initialized.
-            if unsafe { self.hive.put(value) } {
+            if self.hive.put(value) {
                 return;
             }
         }
 
-        // SAFETY: `value` was produced by `heap::into_raw(Box::<T>::new_uninit())`
-        // in `get_impl`/`get_and_see_if_new`/`try_get` above (it is not in the
-        // hive), and the caller has since fully initialized it. `destroy`
-        // reconstructs the `Box<T>` and runs `T::drop`.
+        // SAFETY: caller contract — `value` was produced by the heap path of
+        // `claim().write()` (`Box::leak`); `destroy` reconstructs the `Box<T>`
+        // and runs `T::drop`.
         unsafe { bun_core::heap::destroy(value) };
     }
 }
@@ -648,7 +593,7 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
 #[repr(C)]
 pub struct HiveRef<T, const CAPACITY: usize> {
     pub ref_count: u32,
-    pub pool: *mut Fallback<HiveRef<T, CAPACITY>, CAPACITY>,
+    pub pool: NonNull<Fallback<HiveRef<T, CAPACITY>, CAPACITY>>,
     pub value: T,
 }
 
@@ -659,20 +604,16 @@ impl<T, const CAPACITY: usize> HiveRef<T, CAPACITY> {
     /// Zig: `pub fn init(value, allocator) !*@This()`.
     ///
     /// # Safety
-    /// `pool` must be valid for the entire lifetime of the returned
-    /// `HiveRef` (i.e. until its `ref_count` drops to zero and it is `put`
-    /// back). Callers hold the pool in a long-lived owner (e.g. `VirtualMachine`).
-    pub unsafe fn init(value: T, pool: *mut Fallback<Self, CAPACITY>) -> *mut Self {
-        // SAFETY: caller contract — `pool` is dereferenceable.
-        unsafe {
-            (*pool)
-                .get_init(HiveRef {
-                    ref_count: 1,
-                    pool,
-                    value,
-                })
-                .as_ptr()
-        }
+    /// `pool` must be valid for the entire lifetime of the returned `HiveRef`
+    /// (i.e. until its `ref_count` drops to zero and it is `put` back).
+    /// Callers hold the pool in a long-lived owner (e.g. `VirtualMachine`).
+    pub unsafe fn init(value: T, pool: &mut Fallback<Self, CAPACITY>) -> NonNull<Self> {
+        let pool_ptr = NonNull::from(&mut *pool);
+        pool.get_init(HiveRef {
+            ref_count: 1,
+            pool: pool_ptr,
+            value,
+        })
     }
 
     pub fn ref_(&mut self) -> &mut Self {
@@ -686,15 +627,12 @@ impl<T, const CAPACITY: usize> HiveRef<T, CAPACITY> {
         let ref_count = self.ref_count;
         self.ref_count = ref_count - 1;
         if ref_count == 1 {
-            let pool = self.pool;
-            // SAFETY: `self` was produced by `init` above, so `pool` is the
-            // pool that owns this slot and is still live (caller contract on
-            // `init`). Zig's `if @hasDecl(T, "deinit") this.value.deinit()` maps
-            // to `T::drop`, which `Fallback::put` now runs (it drops the whole
-            // `HiveRef` in place before recycling/freeing the slot).
-            unsafe {
-                (*pool).put(std::ptr::from_mut::<Self>(self));
-            }
+            let mut pool = self.pool;
+            // SAFETY: BACKREF — `init`'s contract is that the pool outlives
+            // every `HiveRef` it hands out. Zig's `if @hasDecl(T, "deinit")
+            // this.value.deinit()` maps to `T::drop`, which `Fallback::put`
+            // runs (it drops the whole `HiveRef` in place before recycling).
+            unsafe { pool.as_mut().put(core::ptr::from_mut(self)) };
             return None;
         }
         Some(self)
@@ -702,7 +640,6 @@ impl<T, const CAPACITY: usize> HiveRef<T, CAPACITY> {
 }
 
 #[cfg(test)]
-#[allow(deprecated)]
 mod tests {
     use super::*;
 
@@ -717,36 +654,29 @@ mod tests {
         let mut a = HiveArray::<Int, SIZE>::init();
 
         {
-            let b = a.get().unwrap();
-            // SAFETY: `b` points into `a.buffer` and was just unpoisoned by `get()`.
-            unsafe { *b = 0 };
-            assert!(a.get().unwrap() != b);
-            assert_eq!(a.index_of(b), Some(0));
-            // SAFETY: `b` is a fully-initialized hive slot.
-            assert!(unsafe { a.put(b) });
-            assert!(a.get().unwrap() == b);
-            let c = a.get().unwrap();
-            // SAFETY: `c` points into `a.buffer` and was just unpoisoned by `get()`.
-            unsafe { *c = 123 };
+            let b = a.get_init(0).unwrap();
+            assert_eq!(a.index_of(b.as_ptr()), Some(0));
+            let b2 = a.get_init(0).unwrap();
+            assert!(b2 != b);
+            assert!(a.put(b.as_ptr()));
+            assert!(a.get_init(0).unwrap() == b);
+            let c = a.get_init(123).unwrap();
+            assert_eq!(*a.at_mut(a.index_of(c.as_ptr()).unwrap() as usize).unwrap(), 123);
             let mut d: Int = 12345;
-            // SAFETY: `&mut d` is foreign — `put` returns `false` and drops nothing.
-            assert!(unsafe { a.put(&mut d) } == false);
+            assert!(a.put(&mut d) == false);
             assert!(a.r#in(&d) == false);
         }
 
-        a.used = IntegerBitSet::init_empty();
+        a.reset();
         {
             for i in 0..SIZE {
-                let b = a.get().unwrap();
-                // SAFETY: `b` points into `a.buffer` and was just unpoisoned by `get()`.
-                unsafe { *b = 0 };
-                assert_eq!(a.index_of(b), Some(u32::try_from(i).expect("int cast")));
-                // SAFETY: `b` is a fully-initialized hive slot.
-                assert!(unsafe { a.put(b) });
-                assert!(a.get().unwrap() == b);
+                let b = a.get_init(0).unwrap();
+                assert_eq!(a.index_of(b.as_ptr()), Some(u32::try_from(i).expect("int cast")));
+                assert!(a.put(b.as_ptr()));
+                assert!(a.get_init(0).unwrap() == b);
             }
             for _ in 0..SIZE {
-                assert!(a.get().is_none());
+                assert!(a.get_init(0).is_none());
             }
         }
     }
@@ -763,32 +693,44 @@ mod tests {
         }
 
         let mut a = HiveArray::<D, 4>::init();
-        // Dropped token releases the slot without running D::drop.
+        // Dropped token leaves the slot free without running D::drop.
         drop(a.claim().unwrap());
-        assert!(!a.used.is_set(0));
+        assert!(!a.is_used(0));
         assert_eq!(DROPS.load(Ordering::Relaxed), 0);
+
+        // Forgotten token also leaves the slot free (bit never set).
+        core::mem::forget(a.claim().unwrap());
+        assert!(!a.is_used(0));
+        assert!(a.at_mut(0).is_none());
 
         // write() commits and put() drops.
         let p = a.get_init(D(7)).unwrap();
-        assert!(a.used.is_set(0));
+        assert!(a.is_used(0));
         assert_eq!(DROPS.load(Ordering::Relaxed), 0);
-        // SAFETY: `p` is a fully-initialized hive slot.
-        unsafe { a.put(p.as_ptr()) };
+        a.put(p.as_ptr());
         assert_eq!(DROPS.load(Ordering::Relaxed), 1);
 
-        // put_raw() does not drop.
+        // take() moves out without dropping; caller drops.
         let p = a.get_init(D(8)).unwrap();
-        assert!(a.put_raw(p.as_ptr()));
+        let i = a.index_of(p.as_ptr()).unwrap() as usize;
+        let v = a.take(i).unwrap();
         assert_eq!(DROPS.load(Ordering::Relaxed), 1);
+        drop(v);
+        assert_eq!(DROPS.load(Ordering::Relaxed), 2);
+
+        // put_raw() does not drop.
+        let p = a.get_init(D(9)).unwrap();
+        assert!(a.put_raw(p.as_ptr()));
+        assert_eq!(DROPS.load(Ordering::Relaxed), 2);
 
         // Fallback heap path: dropped token deallocates without D::drop.
         let mut f = Fallback::<D, 0>::init();
         drop(f.claim());
-        assert_eq!(DROPS.load(Ordering::Relaxed), 1);
-        let p = f.get_init(D(9));
+        assert_eq!(DROPS.load(Ordering::Relaxed), 2);
+        let p = f.get_init(D(10));
         // SAFETY: heap slot from this Fallback.
         unsafe { f.put(p.as_ptr()) };
-        assert_eq!(DROPS.load(Ordering::Relaxed), 2);
+        assert_eq!(DROPS.load(Ordering::Relaxed), 3);
     }
 }
 

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -212,21 +212,6 @@ fn h2_session_as_mut<'a>(
     s.map(|mut s| unsafe { s.as_mut() })
 }
 
-/// Upgrade a `*mut PooledSocket<SSL>` returned by `HiveArray::at` to `&mut`.
-///
-/// INVARIANT: every caller obtains `p` from `pending_sockets.at(idx)` while
-/// iterating `pending_sockets.used` (the slot's `used` bit is set), so the
-/// slot is an initialised `PooledSocket` written by `release_socket`. The
-/// HiveArray data array is disjoint from the `used` bitset the iterator
-/// borrows, so the returned `&mut` does not alias it. HTTP-thread-only.
-/// Centralises the raw `&mut *socket_ptr` upgrade repeated at each HiveArray
-/// scan.
-#[inline]
-fn pooled_socket_mut<'a, const SSL: bool>(p: *mut PooledSocket<SSL>) -> &'a mut PooledSocket<SSL> {
-    // SAFETY: see INVARIANT above.
-    unsafe { &mut *p }
-}
-
 impl<const SSL: bool> PooledSocket<SSL> {
     /// Mutable access to the parked HTTP/2 session.
     ///
@@ -633,7 +618,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
             // borrow held by the `HiveSlot` doesn't conflict with a whole-`self`
             // borrow inside the initializer.
             let owner: *mut Self = self;
-            if let Some(slot) = self.pending_sockets.claim() {
+            if let Some(mut slot) = self.pending_sockets.claim() {
                 // The slot's stable address is registered as the socket's
                 // user-data *before* the `PooledSocket` is written; nothing
                 // dereferences it until after `slot.write()` below. If the
@@ -724,13 +709,11 @@ impl<const SSL: bool> HTTPContext<SSL> {
             return None;
         }
 
-        let mut iter = self.pending_sockets.used.iterator::<true, true>();
+        let mut iter = self.pending_sockets.used_iter();
 
         while let Some(pending_socket_index) = iter.next() {
-            let socket_ptr = self
-                .pending_sockets
-                .at(u16::try_from(pending_socket_index).expect("int cast"));
-            let socket = pooled_socket_mut(socket_ptr);
+            let socket = self.pending_sockets.at_mut(pending_socket_index).unwrap();
+            let socket_ptr: *mut PooledSocket<SSL> = socket;
             if socket.port != port {
                 continue;
             }
@@ -811,11 +794,10 @@ impl<const SSL: bool> HTTPContext<SSL> {
                 let tunnel: Option<crate::proxy_tunnel::RefPtr> = socket.proxy_tunnel.take();
                 socket.target_hostname = Box::default();
                 let h2_session = socket.h2_session.take();
-                // SAFETY: `socket_ptr` is a fully-initialized hive slot; the
-                // owned-heap fields (ssl_config/tunnel/target_hostname/h2_session)
-                // were just moved out / cleared, so the in-place drop in `put`
-                // touches only trivially-droppable residuals.
-                let ok = unsafe { self.pending_sockets.put(socket_ptr) };
+                // The owned-heap fields (ssl_config/tunnel/target_hostname/
+                // h2_session) were just moved out / cleared, so the in-place
+                // drop in `put` touches only trivially-droppable residuals.
+                let ok = self.pending_sockets.put(socket_ptr);
                 debug_assert!(ok);
                 bun_core::scoped_log!(
                     HTTPContext,
@@ -1059,12 +1041,9 @@ impl<const SSL: bool> Drop for HTTPContext<SSL> {
         // Without force-close, the socket stays linked and the context refcount never
         // reaches 0, leaking the SSL_CTX.
         {
-            let mut iter = self.pending_sockets.used.iterator::<true, true>();
+            let mut iter = self.pending_sockets.used_iter();
             while let Some(idx) = iter.next() {
-                let pooled_ptr = self
-                    .pending_sockets
-                    .at(u16::try_from(idx).expect("int cast"));
-                let pooled = pooled_socket_mut(pooled_ptr);
+                let pooled = self.pending_sockets.at_mut(idx).unwrap();
                 // Do NOT call rp.data.shutdown() here — it drives
                 // SSLWrapper.shutdown → triggerCloseCallback →
                 // onClose(handlers.ctx), and handlers.ctx is the
@@ -1228,8 +1207,9 @@ impl<const SSL: bool> Handler<SSL> {
             slot.owner
         };
         // SAFETY: owner is the HiveArray backing this slot; address-stable
-        // (static or Box-allocated) and outlives any pooled entry.
-        let ok = unsafe { (*owner).pending_sockets.put(pooled_ptr) };
+        // (static or Box-allocated) and outlives any pooled entry. The unsafe
+        // is for the `*owner` deref; `put` itself is safe.
+        let ok = unsafe { &mut *owner }.pending_sockets.put(pooled_ptr);
         debug_assert!(ok);
     }
 

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -882,58 +882,43 @@ impl NetworkTask {
         self.response = HTTPClientResult::default();
     }
 
-    /// Initialize a freshly-vended pool slot in place, mirroring Zig's
+    /// Build a fresh `NetworkTask` value mirroring Zig's
     /// `network_task.* = .{ .task_id = …, .callback = undefined, .allocator = …,
     /// .package_manager = …, .apply_patch_task = … }` — a full struct overwrite
-    /// that resets every other field to its struct default. The slot may be
-    /// uninitialized heap memory (from `HiveArrayFallback::get()`'s
-    /// `Box::new_uninit()` fallback) or stale (reused hive slot whose prior
-    /// contents ARE now dropped on `put` since 1e76047), so each field is
-    /// written via `addr_of_mut!().write()` without dropping the previous
-    /// value — the slot is freshly poisoned/uninit from `get()`.
+    /// that resets every other field to its struct default.
     ///
-    /// Fields that are `= undefined` in Zig (`unsafe_http_client`, `callback`,
-    /// `request_buffer`, `response_buffer`) are written here with drop-safe
-    /// placeholders so subsequent `=` assignments in `for_manifest`/
-    /// `for_tarball` do not drop uninitialized memory. `unsafe_http_client`
-    /// stays bitwise-untouched (it is `MaybeUninit`, so leaving it uninit is
-    /// sound under the `&mut NetworkTask` the caller forms next; it is
-    /// overwritten without drop by `for_manifest`/`for_tarball`).
-    ///
-    /// # Safety
-    /// `slot` must be the unique handle to a `HiveArrayFallback<NetworkTask>`
-    /// slot returned by `get()`; its prior contents are treated as garbage
-    /// (matches Zig — no destructors run).
-    pub unsafe fn write_init(
-        slot: *mut NetworkTask,
+    /// Zig-`undefined` fields (`unsafe_http_client`, `callback`,
+    /// `request_buffer`, `response_buffer`) get drop-safe placeholders so
+    /// subsequent `=` assignments in `for_manifest`/`for_tarball` do not drop
+    /// uninitialized memory. `unsafe_http_client` is `MaybeUninit::uninit()`
+    /// (overwritten without drop by `for_manifest`/`for_tarball`).
+    pub fn new(
         task_id: crate::package_manager_task::Id,
         package_manager: *mut PackageManager,
         apply_patch_task: Option<Box<PatchTask>>,
-    ) {
-        use core::ptr::addr_of_mut;
-        unsafe {
-            addr_of_mut!((*slot).task_id).write(task_id);
+    ) -> Self {
+        Self {
+            unsafe_http_client: MaybeUninit::uninit(),
+            task_id,
             // SAFETY: `package_manager` is the live owner of this task; write
             // provenance is required for `for_manifest`/`for_tarball`'s
             // `assume_mut`, so callers pass `*mut` (not `*const`).
-            addr_of_mut!((*slot).package_manager)
-                .write(bun_ptr::ParentRef::from_raw_mut(package_manager));
-            addr_of_mut!((*slot).apply_patch_task).write(apply_patch_task);
+            package_manager: unsafe { bun_ptr::ParentRef::from_raw_mut(package_manager) },
+            apply_patch_task,
             // Struct-default fields (Zig: `= .{}` / `= 0` / `= null` / `= &[_]u8{}`).
-            addr_of_mut!((*slot).response).write(HTTPClientResult::default());
-            addr_of_mut!((*slot).url_buf).write(Box::default());
-            addr_of_mut!((*slot).retried).write(0);
-            addr_of_mut!((*slot).next).write(bun_threading::Link::new());
-            addr_of_mut!((*slot).tarball_stream).write(None);
-            addr_of_mut!((*slot).streaming_extract_task).write(ptr::null_mut());
-            addr_of_mut!((*slot).streaming_committed).write(false);
-            addr_of_mut!((*slot).signal_store).write(http::signals::Store::default());
-            // Zig-`undefined` fields: write drop-safe placeholders so the
-            // plain `=` in `for_manifest`/`for_tarball` drops a valid value.
-            // (`unsafe_http_client` is `MaybeUninit` — left uninitialized.)
-            addr_of_mut!((*slot).request_buffer).write(MutableString::init_empty());
-            addr_of_mut!((*slot).response_buffer).write(MutableString::init_empty());
-            addr_of_mut!((*slot).callback).write(Callback::LocalTarball);
+            response: HTTPClientResult::default(),
+            url_buf: Box::default(),
+            retried: 0,
+            next: bun_threading::Link::new(),
+            tarball_stream: None,
+            streaming_extract_task: ptr::null_mut(),
+            streaming_committed: false,
+            signal_store: http::signals::Store::default(),
+            // Zig-`undefined` fields: drop-safe placeholders so the plain `=`
+            // in `for_manifest`/`for_tarball` drops a valid value.
+            request_buffer: MutableString::init_empty(),
+            response_buffer: MutableString::init_empty(),
+            callback: Callback::LocalTarball,
         }
     }
 }

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -424,8 +424,8 @@ pub struct PackageManager {
     pub pending_pre_calc_hashes: AtomicU32,
     pub pending_tasks: AtomicU32,
     pub total_tasks: u32,
-    pub preallocated_network_tasks: PreallocatedNetworkTasks,
-    pub preallocated_resolve_tasks: PreallocatedTaskStore,
+    pub preallocated_network_tasks: Box<PreallocatedNetworkTasks>,
+    pub preallocated_resolve_tasks: Box<PreallocatedTaskStore>,
 
     /// items are only inserted into this if they took more than 500ms
     pub lifecycle_script_time_log: LifecycleScriptTimeLog,
@@ -1979,15 +1979,11 @@ pub fn init(
                 core::ptr::addr_of_mut!((*p).$field).write($val)
             };
         }
-        // The two large pools: in-place init that only zeros the 256 B
-        // occupancy bitset and leaves `[MaybeUninit<T>; N]` untouched — no
-        // stack temporary, no memcpy.
-        PreallocatedNetworkTasks::init_in_place(core::ptr::addr_of_mut!(
-            (*p).preallocated_network_tasks
-        ));
-        PreallocatedTaskStore::init_in_place(core::ptr::addr_of_mut!(
-            (*p).preallocated_resolve_tasks
-        ));
+        // The two large pools: `new_boxed` writes only the 256 B occupancy
+        // bitset and leaves `[MaybeUninit<T>; N]` untouched — no stack
+        // temporary, no memcpy.
+        wr!(preallocated_network_tasks, PreallocatedNetworkTasks::new_boxed());
+        wr!(preallocated_resolve_tasks, PreallocatedTaskStore::new_boxed());
 
         wr!(cache_directory_, None);
         wr!(cache_directory_path, ZBox::from_bytes(b"")); // TODO(port): default ""
@@ -2430,14 +2426,10 @@ pub fn init_with_runtime_once(
                 core::ptr::addr_of_mut!((*p).$field).write($val)
             };
         }
-        // The two large pools: in-place init that only zeros the 256 B
-        // occupancy bitset and leaves `[MaybeUninit<T>; N]` untouched.
-        PreallocatedNetworkTasks::init_in_place(core::ptr::addr_of_mut!(
-            (*p).preallocated_network_tasks
-        ));
-        PreallocatedTaskStore::init_in_place(core::ptr::addr_of_mut!(
-            (*p).preallocated_resolve_tasks
-        ));
+        // The two large pools: `new_boxed` writes only the 256 B occupancy
+        // bitset and leaves `[MaybeUninit<T>; N]` untouched.
+        wr!(preallocated_network_tasks, PreallocatedNetworkTasks::new_boxed());
+        wr!(preallocated_resolve_tasks, PreallocatedTaskStore::new_boxed());
 
         wr!(cache_directory_, None);
         wr!(cache_directory_path, ZBox::from_bytes(b"")); // TODO(port): default

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -355,29 +355,29 @@ pub fn enqueue_parse_npm_package(
     name: StringOrTinyString,
     network_task: *mut NetworkTask,
 ) -> *mut ThreadPool::Task {
-    let task = this.preallocated_resolve_tasks.get();
-    // SAFETY: task is a freshly acquired slot from the preallocated pool; we own the write.
+    let value = Task::Task {
+        package_manager: Some(bun_ptr::ParentRef::from(core::ptr::NonNull::from(
+            &mut *this,
+        ))),
+        log: bun_ast::Log::init(),
+        tag: crate::package_manager_task::Tag::PackageManifest,
+        request: crate::package_manager_task::Request {
+            package_manifest: ManuallyDrop::new(
+                crate::package_manager_task::PackageManifestRequest {
+                    // SAFETY: `network_task` is a freshly-vended pool slot; the
+                    // `'static` reborrow matches the `Task<'static>` slot lifetime.
+                    network: unsafe { &mut *network_task },
+                    name,
+                },
+            ),
+        },
+        id: task_id,
+        // TODO(port): `data: undefined` — Task::data left uninitialized in Zig
+        ..Task::uninit()
+    };
+    let task = this.preallocated_resolve_tasks.get_init(value).as_ptr();
+    // SAFETY: `get_init` just fully initialized the slot.
     unsafe {
-        task.write(Task::Task {
-            package_manager: Some(bun_ptr::ParentRef::from_raw_mut(std::ptr::from_mut::<
-                PackageManager,
-            >(this))),
-            log: bun_ast::Log::init(),
-            tag: crate::package_manager_task::Tag::PackageManifest,
-            request: crate::package_manager_task::Request {
-                package_manifest: ManuallyDrop::new(
-                    crate::package_manager_task::PackageManifestRequest {
-                        // SAFETY: `network_task` is a freshly-vended pool slot; the
-                        // `'static` reborrow matches the `Task<'static>` slot lifetime.
-                        network: &mut *network_task,
-                        name,
-                    },
-                ),
-            },
-            id: task_id,
-            // TODO(port): `data: undefined` — Task::data left uninitialized in Zig
-            ..Task::uninit()
-        });
         &raw mut (*task).threadpool_task
     }
 }
@@ -1158,14 +1158,8 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                 // preallocated pool, not `string_bytes`; with
                                 // `name_str` lifetime-detached above, `this`
                                 // is free to reborrow `&mut`.
-                                let network_task = this.get_network_task();
-                                // SAFETY: `network_task` is the unique handle to a
-                                // freshly-vended pool slot. Zig's `network_task.* = .{ ... }`
-                                // resets every defaulted field; `write_init` mirrors that
-                                // (callback is `= undefined` and overwritten by `for_manifest`).
-                                unsafe {
-                                    NetworkTask::write_init(network_task, task_id, this_ptr, None);
-                                }
+                                let network_task =
+                                    this.get_network_task(task_id, this_ptr, None);
 
                                 let scope = this.scope_for_package_name(name_str);
                                 // SAFETY: network_task points to a valid initialized NetworkTask slot
@@ -1656,37 +1650,32 @@ fn init_extract_task(
     tarball: &ExtractTarball,
     network_task: *mut NetworkTask,
 ) -> *mut Task::Task<'static> {
-    let task = this.preallocated_resolve_tasks.get();
-    // SAFETY: task is a freshly acquired uninitialized slot from the preallocated
-    // pool; we own the write. `ptr::write` (no drop of prior value) matches Zig's
-    // `task.* = Task{...}` semantics on uninit memory.
-    unsafe {
-        task.write(Task::Task {
-            package_manager: Some(bun_ptr::ParentRef::from_raw_mut(std::ptr::from_mut::<
-                PackageManager,
-            >(this))),
-            log: bun_ast::Log::init(),
-            tag: crate::package_manager_task::Tag::Extract,
-            request: crate::package_manager_task::Request {
-                extract: ManuallyDrop::new(crate::package_manager_task::ExtractRequest {
-                    // SAFETY: `network_task` is a freshly-vended pool slot; the
-                    // `'static` reborrow matches the `Task<'static>` slot lifetime.
-                    network: &mut *network_task,
-                    tarball: ExtractTarball {
-                        skip_verify: !this
-                            .options
-                            .do_
-                            .contains(crate::package_manager_real::options::Do::VERIFY_INTEGRITY),
-                        ..*tarball
-                    },
-                }),
-            },
-            id: (*network_task).task_id,
-            // TODO(port): `data: undefined`
-            ..Task::uninit()
-        });
-        task
-    }
+    let value = Task::Task {
+        package_manager: Some(bun_ptr::ParentRef::from(core::ptr::NonNull::from(
+            &mut *this,
+        ))),
+        log: bun_ast::Log::init(),
+        tag: crate::package_manager_task::Tag::Extract,
+        request: crate::package_manager_task::Request {
+            extract: ManuallyDrop::new(crate::package_manager_task::ExtractRequest {
+                // SAFETY: `network_task` is a freshly-vended pool slot; the
+                // `'static` reborrow matches the `Task<'static>` slot lifetime.
+                network: unsafe { &mut *network_task },
+                tarball: ExtractTarball {
+                    skip_verify: !this
+                        .options
+                        .do_
+                        .contains(crate::package_manager_real::options::Do::VERIFY_INTEGRITY),
+                    ..*tarball
+                },
+            }),
+        },
+        // SAFETY: `network_task` is a fully-initialized pool slot.
+        id: unsafe { (*network_task).task_id },
+        // TODO(port): `data: undefined`
+        ..Task::uninit()
+    };
+    this.preallocated_resolve_tasks.get_init(value).as_ptr()
 }
 
 pub fn enqueue_extract_npm_package(
@@ -1800,74 +1789,72 @@ pub fn enqueue_git_checkout(
     // if patched then we need to do apply step after network task is done
     patch_name_and_version_hash: Option<u64>,
 ) -> *mut ThreadPool::Task {
-    let task = this.preallocated_resolve_tasks.get();
-    // SAFETY: task is a freshly acquired uninitialized slot from the preallocated
-    // pool; we own the write. `ptr::write` (no drop of prior value) matches Zig's
-    // `task.* = Task{...}` semantics on uninit memory.
-    unsafe {
-        task.write(Task::Task {
-            package_manager: Some(bun_ptr::ParentRef::from_raw_mut(std::ptr::from_mut::<
-                PackageManager,
-            >(this))),
-            log: bun_ast::Log::init(),
-            tag: crate::package_manager_task::Tag::GitCheckout,
-            request: crate::package_manager_task::Request {
-                git_checkout: ManuallyDrop::new(crate::package_manager_task::GitCheckoutRequest {
-                    repo_dir: dir,
-                    resolution,
-                    dependency_id,
-                    name: StringOrTinyString::init_append_if_needed(
-                        name,
-                        &mut crate::network_task::filename_store_appender(),
-                    )
-                    .expect("unreachable"),
-                    url: StringOrTinyString::init_append_if_needed(
-                        // `resolution.tag == Git` for the git-checkout path.
-                        this.lockfile.str(&resolution.git().repo),
-                        &mut crate::network_task::filename_store_appender(),
-                    )
-                    .expect("unreachable"),
-                    resolved: StringOrTinyString::init_append_if_needed(
-                        resolved,
-                        &mut crate::network_task::filename_store_appender(),
-                    )
-                    .expect("unreachable"),
-                    env: crate::repository::SharedEnv::get(this.env_mut()),
-                }),
-            },
-            apply_patch_task: if let Some(h) = patch_name_and_version_hash {
-                let dep_name_hash =
-                    this.lockfile.buffers.dependencies[dependency_id as usize].name_hash;
-                let pkg_id = match this
-                    .lockfile
-                    .package_index
-                    .get(&dep_name_hash)
-                    .unwrap_or_else(|| panic!("Package not found"))
-                {
-                    PackageIndexEntry::Id(p) => *p,
-                    PackageIndexEntry::Ids(ps) => ps[0], // TODO is this correct
-                };
-                let patch_hash = this
-                    .lockfile
-                    .patched_dependencies
-                    .get(&h)
-                    .unwrap()
-                    .patchfile_hash()
-                    .unwrap();
-                let pt = PatchTask::new_apply_patch_hash(this, pkg_id, patch_hash, h);
-                // SAFETY: `pt` is fresh from `heap::alloc`; reclaim ownership.
-                let mut pt = bun_core::heap::take(pt);
-                pt.callback.apply_mut().task_id = Some(task_id);
-                Some(pt)
-            } else {
-                None
-            },
-            id: task_id,
-            // TODO(port): `data: undefined`
-            ..Task::uninit()
-        });
-        &raw mut (*task).threadpool_task
-    }
+    // Build the `Task` value before claiming a hive slot — the `.expect()`s
+    // below can unwind, and `Task` carries drop glue. See `enqueue_git_clone`.
+    let value = Task::Task {
+        package_manager: Some(bun_ptr::ParentRef::from(core::ptr::NonNull::from(
+            &mut *this,
+        ))),
+        log: bun_ast::Log::init(),
+        tag: crate::package_manager_task::Tag::GitCheckout,
+        request: crate::package_manager_task::Request {
+            git_checkout: ManuallyDrop::new(crate::package_manager_task::GitCheckoutRequest {
+                repo_dir: dir,
+                resolution,
+                dependency_id,
+                name: StringOrTinyString::init_append_if_needed(
+                    name,
+                    &mut crate::network_task::filename_store_appender(),
+                )
+                .expect("unreachable"),
+                url: StringOrTinyString::init_append_if_needed(
+                    // `resolution.tag == Git` for the git-checkout path.
+                    this.lockfile.str(&resolution.git().repo),
+                    &mut crate::network_task::filename_store_appender(),
+                )
+                .expect("unreachable"),
+                resolved: StringOrTinyString::init_append_if_needed(
+                    resolved,
+                    &mut crate::network_task::filename_store_appender(),
+                )
+                .expect("unreachable"),
+                env: crate::repository::SharedEnv::get(this.env_mut()),
+            }),
+        },
+        apply_patch_task: if let Some(h) = patch_name_and_version_hash {
+            let dep_name_hash =
+                this.lockfile.buffers.dependencies[dependency_id as usize].name_hash;
+            let pkg_id = match this
+                .lockfile
+                .package_index
+                .get(&dep_name_hash)
+                .unwrap_or_else(|| panic!("Package not found"))
+            {
+                PackageIndexEntry::Id(p) => *p,
+                PackageIndexEntry::Ids(ps) => ps[0], // TODO is this correct
+            };
+            let patch_hash = this
+                .lockfile
+                .patched_dependencies
+                .get(&h)
+                .unwrap()
+                .patchfile_hash()
+                .unwrap();
+            let pt = PatchTask::new_apply_patch_hash(this, pkg_id, patch_hash, h);
+            // SAFETY: `pt` is fresh from `heap::alloc`; reclaim ownership.
+            let mut pt = unsafe { bun_core::heap::take(pt) };
+            pt.callback.apply_mut().task_id = Some(task_id);
+            Some(pt)
+        } else {
+            None
+        },
+        id: task_id,
+        // TODO(port): `data: undefined`
+        ..Task::uninit()
+    };
+    let task = this.preallocated_resolve_tasks.get_init(value).as_ptr();
+    // SAFETY: `get_init` just fully initialized the slot.
+    unsafe { &raw mut (*task).threadpool_task }
 }
 
 fn enqueue_local_tarball(

--- a/src/install/PackageManager/PopulateManifestCache.rs
+++ b/src/install/PackageManager/PopulateManifestCache.rs
@@ -74,18 +74,11 @@ fn start_manifest_task(
     // TODO(port): lifetime — BACKREF.
     let manager_backref: *mut PackageManager = manager;
 
-    // Take the pool slot as a raw pointer so borrowck releases `manager` for the
-    // `enqueue_network_task` tail.
-    let net_ptr: *mut NetworkTask = run_tasks::get_network_task(manager);
     // Zig: `task.* = .{ .package_manager = manager, .callback = undefined,
     //                   .task_id = task_id, .allocator = manager.allocator };`
-    // — full struct overwrite that resets every other field to its struct
-    // default. The slot may be uninitialized (heap fallback) or stale (reused
-    // hive slot).
-    // SAFETY: `net_ptr` is the unique handle to a freshly-vended pool slot; no
-    // other alias exists until we hand it to `enqueue_network_task`.
-    unsafe { NetworkTask::write_init(net_ptr, task_id, manager_backref, None) };
-    // SAFETY: `write_init` populated every field with a drop-safe value;
+    let net_ptr: *mut NetworkTask =
+        run_tasks::get_network_task(manager, task_id, manager_backref, None);
+    // SAFETY: `get_network_task` returns a fully-initialized pool slot;
     // `unsafe_http_client` is `MaybeUninit` and overwritten by `for_manifest`.
     let task = unsafe { &mut *net_ptr };
     // `scope` points into `manager.options` which is not mutated by

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1707,8 +1707,15 @@ pub fn drain_dependency_list(this: &mut PackageManager) {
     let _ = schedule_tasks(this);
 }
 
-pub fn get_network_task(this: &mut PackageManager) -> *mut NetworkTask {
-    this.preallocated_network_tasks.get()
+pub fn get_network_task(
+    this: &mut PackageManager,
+    task_id: Task::Id,
+    package_manager: *mut PackageManager,
+    apply_patch_task: Option<Box<PatchTask>>,
+) -> *mut NetworkTask {
+    this.preallocated_network_tasks
+        .get_init(NetworkTask::new(task_id, package_manager, apply_patch_task))
+        .as_ptr()
 }
 
 pub fn alloc_github_url(this: &PackageManager, repository: &Repository) -> Vec<u8> {
@@ -1811,19 +1818,11 @@ pub fn generate_network_task_for_tarball<'a>(
     // back-pointer (TODO(port): lifetime — BACKREF).
     let this_backref: *mut PackageManager = this;
 
-    // Take the pool slot as a raw pointer so borrowck releases `this` for the
-    // streaming-setup tail. Reborrowed `&mut` per-statement below.
-    let net_ptr: *mut NetworkTask = get_network_task(this);
     // Zig: `network_task.* = .{ .task_id, .callback = undefined, .allocator,
     // .package_manager, .apply_patch_task }` — full struct overwrite that resets
-    // every other field (`retried`, `response`, `streaming_committed`,
-    // `tarball_stream`, `streaming_extract_task`, `next`, `url_buf`,
-    // `signal_store`) to its struct default. The slot may be uninitialized
-    // (`HiveArrayFallback::get()` heap fallback) or stale (reused hive slot).
-    // SAFETY: `net_ptr` is the unique handle to a freshly-vended pool slot; no
-    // other alias exists until we return it.
-    unsafe { NetworkTask::write_init(net_ptr, task_id, this_backref, apply_patch_task) };
-    // SAFETY: `write_init` populated every field with a drop-safe value;
+    // every other field to its struct default.
+    let net_ptr: *mut NetworkTask = get_network_task(this, task_id, this_backref, apply_patch_task);
+    // SAFETY: `get_network_task` returns a fully-initialized pool slot;
     // `unsafe_http_client` is `MaybeUninit` and overwritten by `for_tarball`.
     let network_task = unsafe { &mut *net_ptr };
 
@@ -1928,8 +1927,13 @@ impl PackageManager {
         is_network_task_required(self, task_id)
     }
     #[inline]
-    pub fn get_network_task(&mut self) -> *mut NetworkTask {
-        get_network_task(self)
+    pub fn get_network_task(
+        &mut self,
+        task_id: Task::Id,
+        package_manager: *mut PackageManager,
+        apply_patch_task: Option<Box<PatchTask>>,
+    ) -> *mut NetworkTask {
+        get_network_task(self, task_id, package_manager, apply_patch_task)
     }
     #[inline]
     pub fn alloc_github_url(&self, repository: &Repository) -> Vec<u8> {

--- a/src/io/windows_event_loop.rs
+++ b/src/io/windows_event_loop.rs
@@ -89,19 +89,14 @@ impl FilePoll {
         owner: Owner,
     ) -> *mut FilePoll {
         // Crate-private backref-deref accessor — single live `&mut Store` borrow.
-        let poll = vm.file_polls_mut().get();
-        // SAFETY: `get()` returns a valid, uniquely-owned, *uninitialized* slot from the
-        // HiveArray pool. We must not materialize `&mut FilePoll` (validity invariant
-        // requires initialized memory); write the whole value through the raw pointer.
-        unsafe {
-            poll.write(FilePoll {
+        vm.file_polls_mut()
+            .get_init(FilePoll {
                 fd,
                 flags,
                 owner,
                 next_to_free: ptr::null_mut(),
-            });
-        }
-        poll
+            })
+            .as_ptr()
     }
 
     // PORT NOTE: not `impl Drop` — FilePoll lives in a HiveArray pool slot, not a Box;
@@ -289,8 +284,8 @@ impl Store {
         }
     }
 
-    pub fn get(&mut self) -> *mut FilePoll {
-        self.hive.get()
+    pub fn get_init(&mut self, value: FilePoll) -> ptr::NonNull<FilePoll> {
+        self.hive.get_init(value)
     }
 
     pub fn process_deferred_frees(&mut self) {

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -686,14 +686,13 @@ impl NumberRenamer {
         parent: Option<bun_ptr::ParentRef<NumberScope>>,
         sorted: &mut Vec<u32>,
     ) {
-        let s: *mut NumberScope = self.number_scope_pool.get();
-        // SAFETY: `s` is a valid pool slot (HiveArrayFallback::get never returns null).
-        unsafe {
-            s.write(NumberScope {
+        let s: *mut NumberScope = self
+            .number_scope_pool
+            .get_init(NumberScope {
                 parent,
                 name_counts: StringHashMap::default(),
-            });
-        }
+            })
+            .as_ptr();
 
         self.assign_names_recursive_with_number_scope(s, scope, source_index, sorted);
 
@@ -750,20 +749,18 @@ impl NumberRenamer {
 
         loop {
             if scope.members.count() > 0 || scope.generated.len_u32() > 0 {
-                let new_child_scope: *mut NumberScope = self.number_scope_pool.get();
-                // SAFETY: `new_child_scope` is a valid pool slot.
-                unsafe {
-                    new_child_scope.write(NumberScope {
-                        // `s` is non-null (either `initial_scope` or a fresh
-                        // pool slot from a prior iteration); the new child
-                        // outlives this `ParentRef` only until `put()` below.
+                // `s` is non-null (either `initial_scope` or a fresh pool slot
+                // from a prior iteration); the new child outlives this
+                // `ParentRef` only until `put()` below.
+                s = self
+                    .number_scope_pool
+                    .get_init(NumberScope {
                         parent: Some(bun_ptr::ParentRef::from(
                             core::ptr::NonNull::new(s).expect("number_scope non-null"),
                         )),
                         name_counts: StringHashMap::default(),
-                    });
-                }
-                s = new_child_scope;
+                    })
+                    .as_ptr();
 
                 // SAFETY: s is a valid pool slot just initialized above
                 self.assign_names_in_scope(unsafe { &mut *s }, scope, source_index, sorted);

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -216,7 +216,7 @@ pub fn set_break_point_on_first_line() -> bool {
 
 pub struct RuntimeTranspilerStore {
     pub generation_number: AtomicU32,
-    pub store: TranspilerJobStore,
+    pub store: Box<TranspilerJobStore>,
     pub enabled: bool,
     pub queue: Queue,
 }
@@ -227,7 +227,7 @@ impl Default for RuntimeTranspilerStore {
     fn default() -> Self {
         Self {
             generation_number: AtomicU32::new(0),
-            store: TranspilerJobStore::init(),
+            store: TranspilerJobStore::new_boxed(),
             enabled: true,
             queue: Queue::new(),
         }
@@ -266,10 +266,7 @@ impl RuntimeTranspilerStore {
         // valid in-bounds field place without forming an intermediate reference.
         unsafe {
             addr_of_mut!((*out).generation_number).write(AtomicU32::new(0));
-            // `store.hive.buffer: [MaybeUninit<TranspilerJob>; 64]` —
-            // intentionally left untouched (uninit is a valid value).
-            addr_of_mut!((*out).store.hive.used)
-                .write(bun_collections::hive_array::HiveBitSet::init_empty());
+            addr_of_mut!((*out).store).write(TranspilerJobStore::new_boxed());
             addr_of_mut!((*out).enabled).write(true);
             addr_of_mut!((*out).queue).write(Queue::new());
         }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -7371,13 +7371,8 @@ impl H2FrameParser {
         };
         let this: *mut H2FrameParser = if ENABLE_ALLOCATOR_POOL {
             POOL.with_borrow_mut(|pool| {
-                let pool = pool.get_or_insert_with(|| Box::new(H2FrameParserHiveAllocator::init()));
-                let slot = pool.try_get();
-                // SAFETY: `slot` is a freshly-claimed, uninitialised `*mut H2FrameParser`
-                // (HiveArray slot or fallback `Box<MaybeUninit<_>>`); `write` moves
-                // `init` in without dropping prior contents.
-                unsafe { slot.write(init) };
-                slot
+                let pool = pool.get_or_insert_with(H2FrameParserHiveAllocator::new_boxed);
+                pool.get_init(init).as_ptr()
             })
         } else {
             bun_core::heap::into_raw(Box::new(init))

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -2090,9 +2090,13 @@ impl DevServer {
         req: ReqOrSaved,
         resp: AnyResponse,
     ) -> Result<(), bun_core::Error> {
-        let deferred_ptr = self.deferred_request_pool.get();
-        // SAFETY: HiveArrayFallback::get returns an exclusively-owned, live node ptr
-        // (heap-allocates on overflow; never null).
+        let deferred_ptr = self
+            .deferred_request_pool
+            .get_init(deferred_request::Node {
+                data: ::core::mem::MaybeUninit::uninit(),
+            })
+            .as_ptr();
+        // SAFETY: `get_init` returns an exclusively-owned, live node ptr.
         let deferred = unsafe { &mut *deferred_ptr };
         // Precompute the data slot pointer (used inside the initializer for
         // abort-callback registration) before borrowing `deferred.data` for `.write()`.

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -283,10 +283,8 @@ pub mod lib_info {
                     // `MaybeUninit::uninit().assume_init()` write was UB regardless of
                     // POD-ness.
                     let pos = (*request).cache.pos_in_pending();
-                    this.pending_host_cache_native.with_mut(|c| {
-                        let slot = c.buffer[pos as usize].as_mut_ptr();
-                        c.put_raw(slot);
-                    });
+                    this.pending_host_cache_native
+                        .with_mut(|c| c.release_at(pos as usize));
                 }
                 // Drop the KeepAlive + resolver ref that `GetAddrInfoRequest.init` took.
                 DNSLookup::destroy(&raw mut (*request).head);
@@ -4065,7 +4063,7 @@ impl Resolver {
 
     fn any_requests_pending(&self) -> bool {
         // TODO(port): Zig used @typeInfo to iterate all `pending_*` fields.
-        macro_rules! check { ($($f:ident),*) => { $( if self.$f.get().used.find_first_set().is_some() { return true; } )* } }
+        macro_rules! check { ($($f:ident),*) => { $( if self.$f.get().any_used() { return true; } )* } }
         check!(
             pending_host_cache_cares,
             pending_host_cache_native,
@@ -4237,13 +4235,8 @@ impl Resolver {
         cache_field: PendingCacheField,
     ) -> R::PendingCacheKey {
         let cache = R::pending_cache(self, cache_field);
-        debug_assert!(cache.used.is_set(index as usize));
-        // SAFETY: `used` bit is set ⇒ slot was initialized by `get_or_put_into_resolve_pending_cache`
-        // + `*Request::init`. `PendingCacheKey` is POD; reading by value then unsetting the bit
-        // hands ownership of the slot back to the HiveArray (Zig's `= undefined`).
-        let entry = unsafe { core::ptr::read(cache.buffer[index as usize].as_ptr()) };
-        cache.used.unset(index as usize);
-        entry
+        // `take()` moves the value out and releases the slot (Zig's `= undefined`).
+        cache.take(index as usize).expect("pending-cache slot")
     }
 
     // Monomorphic helpers used by the drain* fns below.
@@ -4253,26 +4246,15 @@ impl Resolver {
         field: PendingCacheField,
     ) -> get_addr_info_request::PendingCacheKey {
         let cache = self.pending_host_cache(field);
-        debug_assert!(cache.used.is_set(index as usize));
-        let entry = unsafe { core::ptr::read(cache.buffer[index as usize].as_ptr()) };
-        cache.used.unset(index as usize);
-        entry
+        cache.take(index as usize).expect("pending-cache slot")
     }
     fn get_key_addr(&self, index: u8) -> get_host_by_addr_info_request::PendingCacheKey {
-        self.pending_addr_cache_cares.with_mut(|cache| {
-            debug_assert!(cache.used.is_set(index as usize));
-            let entry = unsafe { core::ptr::read(cache.buffer[index as usize].as_ptr()) };
-            cache.used.unset(index as usize);
-            entry
-        })
+        self.pending_addr_cache_cares
+            .with_mut(|cache| cache.take(index as usize).expect("pending-cache slot"))
     }
     fn get_key_nameinfo(&self, index: u8) -> get_name_info_request::PendingCacheKey {
-        self.pending_nameinfo_cache_cares.with_mut(|cache| {
-            debug_assert!(cache.used.is_set(index as usize));
-            let entry = unsafe { core::ptr::read(cache.buffer[index as usize].as_ptr()) };
-            cache.used.unset(index as usize);
-            entry
-        })
+        self.pending_nameinfo_cache_cares
+            .with_mut(|cache| cache.take(index as usize).expect("pending-cache slot"))
     }
 
     pub fn drain_pending_cares<T: CAresRecordType>(
@@ -4287,17 +4269,10 @@ impl Resolver {
         let _g = unsafe { Self::ref_scope(self.as_ctx_ptr()) };
 
         // TODO(port): generic getKey over T::CACHE_FIELD
-        let key = {
-            let cache = self.pending_cache_for::<T>(T::CACHE_FIELD);
-            debug_assert!(cache.used.is_set(index as usize));
-            // SAFETY: `used` bit is set ⇒ slot was initialized by
-            // `get_or_put_into_resolve_pending_cache` + `*Request::init`.
-            // `PendingCacheKey` is POD; reading by value then unsetting the bit hands
-            // ownership of the slot back to the HiveArray (Zig's `= undefined`).
-            let key = unsafe { core::ptr::read(cache.buffer[index as usize].as_ptr()) };
-            cache.used.unset(index as usize);
-            key
-        };
+        let key = self
+            .pending_cache_for::<T>(T::CACHE_FIELD)
+            .take(index as usize)
+            .expect("pending-cache slot");
 
         let Some(addr) = result else {
             unsafe {
@@ -4608,11 +4583,10 @@ impl Resolver {
         // PORT NOTE: Zig used `@field(this, field)` over a comptime string. We dispatch via
         // `HasPendingCacheKey::pending_cache`; the body is identical across all `R`.
         let cache = R::pending_cache(self, field);
-        let mut inflight_iter = cache.used.iter_set();
+        let mut inflight_iter = cache.used_iter();
 
         while let Some(index) = inflight_iter.next() {
-            // SAFETY: `used` bit is set ⇒ slot was initialized.
-            let entry = unsafe { &mut *cache.buffer[index].as_mut_ptr() };
+            let entry = cache.at_mut(index).unwrap();
             if R::key_hash(entry) == R::key_hash(key) && R::key_len(entry) == R::key_len(key) {
                 return LookupCacheHit::Inflight(std::ptr::from_mut(entry));
             }
@@ -4631,11 +4605,10 @@ impl Resolver {
         field: PendingCacheField,
     ) -> CacheHit {
         let cache = self.pending_host_cache(field);
-        let mut inflight_iter = cache.used.iter_set();
+        let mut inflight_iter = cache.used_iter();
 
         while let Some(index) = inflight_iter.next() {
-            // SAFETY: `used` bit is set ⇒ slot was initialized.
-            let entry = unsafe { &mut *cache.buffer[index].as_mut_ptr() };
+            let entry = cache.at_mut(index).unwrap();
             if entry.hash == key.hash && entry.len == key.len {
                 return CacheHit::Inflight(std::ptr::from_mut(entry));
             }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -287,7 +287,7 @@ unsafe fn init_runtime_state(
         // allocations use the same heap as the global allocator and skip the
         // `mi_heap_new`/`mi_heap_destroy` pair.
         transpiler_arena: Box::new(bun_alloc::Arena::borrowing_default()),
-        body_value_pool: Box::new(crate::webcore::body::HiveAllocator::init()),
+        body_value_pool: crate::webcore::body::HiveAllocator::new_boxed(),
     }));
     RUNTIME_STATE.with(|c| c.set(state));
 
@@ -1172,11 +1172,11 @@ unsafe fn init_request_body_value(_vm: *mut VirtualMachine, body: *mut c_void) -
     // its `body_value_pool` `Box` payload is heap-stable for the
     // VM's lifetime (BACKREF contract on `HiveRef::allocator`).
     let value = unsafe { core::ptr::read(body.cast::<Value>()) };
-    let pool: *mut crate::webcore::body::HiveAllocator =
-        unsafe { &raw mut *(*state).body_value_pool };
     // Spec returns `!*HiveRef` with the only `try` site being the pool
     // allocation; `bun.handleOom`-style crash matches Zig.
-    unsafe { HiveRef::init(value, pool) }.cast::<c_void>()
+    unsafe { HiveRef::init(value, &mut (*state).body_value_pool) }
+        .cast::<c_void>()
+        .as_ptr()
 }
 
 /// `WebCore.ObjectURLRegistry.singleton().has(specifier["blob:".len..])` —

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -702,22 +702,17 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
         // SAFETY: `request_pool` points at a process-static (or
         // server-owned) `HiveArray::Fallback`; valid for the server's lifetime.
-        let ctx_slot = unsafe { (*server.request_pool).try_get() };
-        // SAFETY: `try_get` hands out an uninitialized slot; `create()` fully
-        // initializes it via `MaybeUninit::write`.
-        let ctx_uninit = unsafe {
-            &mut *ctx_slot.cast::<core::mem::MaybeUninit<ServerRequestContext<SSL, DEBUG>>>()
-        };
+        let mut slot = unsafe { (*server.request_pool).claim() };
         ServerRequestContext::<SSL, DEBUG>::create(
-            ctx_uninit,
+            slot.as_uninit(),
             this,
             std::ptr::from_mut::<uws_sys::Request>(req).cast::<c_void>(),
             any_response_from::<SSL>(resp),
             should_deinit_context,
             method,
         );
-        // SAFETY: fully initialized by `create()`.
-        let ctx: *mut ServerRequestContext<SSL, DEBUG> = ctx_slot;
+        // SAFETY: fully initialized by `create()` via `MaybeUninit::write`.
+        let ctx: *mut ServerRequestContext<SSL, DEBUG> = unsafe { slot.assume_init() }.as_ptr();
         let ctx_mut = unsafe { &mut *ctx };
 
         // `VirtualMachine::jsc_vm()` is the safe accessor for the JSC VM
@@ -2967,7 +2962,7 @@ macro_rules! impl_server_pools {
                         // `Box::new(Pool::init())` builds the ~816 KB pool on
                         // the stack and `memcpy`s it into the heap (no NRVO);
                         // `new_boxed` writes only the 256 B bitset in place.
-                        p = Pool::new_boxed().as_ptr();
+                        p = Box::into_raw(Pool::new_boxed());
                         cell.set(p);
                     }
                     p
@@ -2982,7 +2977,7 @@ macro_rules! impl_server_pools {
                 POOL.with(|cell| {
                     let mut p = cell.get();
                     if p.is_null() {
-                        p = Pool::new_boxed().as_ptr();
+                        p = Box::into_raw(Pool::new_boxed());
                         cell.set(p);
                     }
                     p

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3143,7 +3143,7 @@ where
                     !self.h3_request_pool.is_null(),
                     "H3 request dispatched but h3_request_pool was never allocated (listen() H3 path not taken)"
                 );
-                let slot = (*self.h3_request_pool).claim();
+                let mut slot = (*self.h3_request_pool).claim();
                 Ctx::create_in(
                     slot.addr().as_ptr().cast(),
                     self_ptr,
@@ -3155,7 +3155,7 @@ where
                 // SAFETY: `create_in` fully initialized the slot via `MaybeUninit::write`.
                 slot.assume_init().as_ptr().cast()
             } else {
-                let slot = (*self.request_pool).claim();
+                let mut slot = (*self.request_pool).claim();
                 Ctx::create_in(
                     slot.addr().as_ptr().cast(),
                     self_ptr,
@@ -3412,18 +3412,18 @@ where
         this.pending_requests += 1;
         req.set_yield(false);
         // SAFETY: pointer is non-null and owns a fresh pool slot.
-        let ctx_slot = unsafe { (*this.request_pool).get() };
+        let mut slot = unsafe { (*this.request_pool).claim() };
         let should_deinit_context = core::cell::Cell::new(false);
         <ServerRequestContext<SSL, DEBUG> as RequestCtxOps>::create_in(
-            ctx_slot,
+            slot.addr().as_ptr(),
             self_ptr,
             req,
             resp,
             Some(bun_ptr::BackRef::new(&should_deinit_context)),
             None,
         );
-        // SAFETY: ctx_slot was just initialized by create_in.
-        let ctx = unsafe { &mut *ctx_slot };
+        // SAFETY: `create_in` fully initialized the slot via `MaybeUninit::write`.
+        let ctx = unsafe { &mut *slot.assume_init().as_ptr() };
 
         let body_hive = crate::webcore::body::hive_alloc(this.vm().as_mut(), BodyValue::Null);
         // SAFETY: hive_alloc returns a freshly-initialized hive slot; live until


### PR DESCRIPTION
Part 7 of the bun_collections safety roadmap. `src/collections/hive_array.rs`: 29 → 12 unsafe.

## Design

**`HiveSlot` is now a safe enum** (`Inline { hive: &'h mut HiveArray, index } | Heap(Box<MaybeUninit<T>>)`) instead of a tagged-usize raw back-pointer. The key soundness change vs. the previous design: **`claim()` no longer sets the used-bit** — `write()`/`assume_init()` set it when they commit the slot. This makes the module invariant `used.is_set(i) ⇔ buffer[i] initialized` unbreakable from safe code:

- `mem::forget(slot)` → bit never set → slot stays free → next `claim()` reuses it
- `drop(slot)` → bit never set → no-op (just re-poison for asan)
- borrowck (HiveSlot holds `&'h mut HiveArray`) prevents double-claim while a token is live

With that invariant solid, `HiveArray::put()`/`at_mut()`/`take()` become safe fns. `buffer`/`used` are now private with safe accessors `at_mut`, `take`, `any_used`, `used_iter`, `is_used`, `reset`, `release_at` covering every in-tree access pattern (notably the dns.rs move-out-by-index sites).

`Fallback::new_boxed` keeps its single `Box::new_uninit` + `addr_of_mut!(bitset).write` unsafe block (now returns `Box<Self>` instead of leaked `NonNull`). Not switched to `boxed_zeroed` — that would `alloc_zeroed` the full ~816 KB `RequestContext`×2048 buffer, contradicting the documented intent of leaving the `MaybeUninit` array page-uncommitted.

Deleted: `init_in_place` (both), deprecated `get`/`try_get`/`get_and_see_if_new`, `at(u16)`, `HiveBitSet::iterator::<_,_>`, the `pooled_socket_mut` raw-deref helper in HTTPContext.

## Residual unsafe (12)

| count | site | why irreducible |
|-:|-|-|
| 3 | `at_mut`/`take`/`put` `assume_init_{mut,read,drop}` | core bitset⇔init invariant; checked at runtime |
| 1 | `unsafe fn HiveSlot::assume_init` | placement-new escape hatch (server `create_in`) |
| 1 | `Fallback::new_boxed` | `Box::new_uninit` + partial-field write to avoid page-commit |
| 2 | `unsafe fn Fallback::put` + `heap::destroy` | heap path has no membership check; same contract as `Box::from_raw` |
| 2 | `unsafe fn Fallback::put_raw` + `Box::from_raw` | same |
| 1 | `unsafe fn HiveRef::init` | BACKREF lifetime contract (pool outlives ref) |
| 1 | `unref` `pool.as_mut()` | BACKREF deref |
| 1 | test `Fallback::put` | exercises the unsafe-fn |

## Caller migrations

- `dns.rs`: 5× `ptr::read(buffer[i])`+`used.unset(i)` → `take(i)`; 2× `&mut *buffer[i].as_mut_ptr()` → `at_mut(i)`; `buffer[pos].as_mut_ptr()`+`put_raw` → `release_at(pos)`; `used.find_first_set().is_some()` → `any_used()`; `used.iter_set()` → `used_iter()`
- `HTTPContext.rs`: `used.iterator`+`at()`+`pooled_socket_mut` → `used_iter()`+`at_mut()`; `put()` now safe
- `server/{mod,server_body}.rs`: `try_get`/`get` → `claim()`+`as_uninit()`+`assume_init()`; `new_boxed().as_ptr()` → `Box::into_raw(new_boxed())`
- `PackageManager.rs`: pool fields boxed; `init_in_place` → `new_boxed()`
- `NetworkTask.rs`: `unsafe fn write_init(*mut, ...)` → `fn new(...) -> Self` value constructor
- `runTasks.rs`/`PopulateManifestCache.rs`/`PackageManagerEnqueue.rs`: `get_network_task()` takes the init args and does `get_init(NetworkTask::new(...))`; 3× resolve-task `get()`+`ptr::write` → build value first then `get_init()`
- `RuntimeTranspilerStore.rs`: `store` field boxed; direct `store.hive.used` write → `new_boxed()`
- `renamer.rs`: 2× `get()`+`ptr::write` → `get_init()`
- `renameSymbolsInChunk.rs`: `hive.used = init_empty()` → `reset()`
- `h2_frame_parser.rs`: `try_get()`+`write` → `get_init()`; `Box::new(init())` → `new_boxed()`
- `windows_event_loop.rs`: `Store::get()`+`poll.write()` → `get_init()`
- `DevServer.rs`: `get()` → `get_init(Node{data: uninit})`
- `jsc_hooks.rs`: `Box::new(HiveAllocator::init())` → `new_boxed()`; `HiveRef::init` `*mut` param → `&mut`, `NonNull` return → `.as_ptr()`

## Testing

- `cargo check` clean across `bun_collections`, `bun_runtime`, `bun_install`, `bun_http`, `bun_io`, `bun_js_printer`, `bun_bundler`, `bun_jsc` (linux + windows targets)
- `bun bd test test/js/bun/http/serve.test.ts` — 190 pass / 0 fail
- `bun bd test test/cli/install/bun-install.test.ts` — 172 pass / 0 fail
- `bun bd test test/js/bun/dns/ test/js/node/dns/` — 144 pass / 0 fail
- `bun bd test test/bundler/bundler_minify.test.ts` — 32 pass / 0 fail
- `test/js/web/fetch/fetch.test.ts` — 338 pass / 3 fail (identical to base branch)
- `test/js/node/http2/` — `node-http2-upgrade.test.mts` SEGV and `maxSessionMemory` timeout both reproduce on the base branch (`origin/claude/pool-safe`) without this change
