### PR TITLE
collections: drop unsafe uninit-tail/allocator-transmute helpers from VecExt (part 2)

### DIFF
--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -178,24 +178,7 @@ pub type TsEnumsMap = ArrayHashMap<Ref, StringHashMap<InlinedEnumValue>, AutoCon
 impl Ast {
     pub fn from_parts(parts: Box<[Part]>) -> Ast {
         Ast {
-            parts: PartList::from_owned_slice(parts),
-            runtime_imports: Default::default(),
-            ..Default::default()
-        }
-    }
-
-    // Zig `initTest` borrowed `parts` via `Part.List.fromBorrowedSliceDangerous`
-    // and relied on explicit `deinit` never being called. `Vec::drop` now
-    // unconditionally guards on `Origin::Borrowed` (not debug-only), so unwrapping
-    // the `ManuallyDrop` is safe — the caller's slice is never freed by `Ast`'s Drop.
-    pub fn init_test(parts: &[Part]) -> Ast {
-        Ast {
-            // SAFETY: test-only helper; the borrowed list is tagged
-            // `Origin::Borrowed`, so `Vec::drop` skips the free, and no
-            // grow/free path is reached on `Ast.parts` before the borrow ends.
-            parts: std::mem::ManuallyDrop::into_inner(unsafe {
-                PartList::from_borrowed_slice_dangerous(parts)
-            }),
+            parts: parts.into_vec(),
             runtime_imports: Default::default(),
             ..Default::default()
         }

--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -586,10 +586,10 @@ impl Map {
     pub fn init(source_count: usize) -> Map {
         // Zig: `arena.alloc([]Symbol, sourceCount)` (default_allocator) then NestedList.init.
         // Per PORTING.md §Allocators (non-arena path), use Vec → Vec.
-        let mut v: Vec<List> = Vec::with_capacity(source_count);
+        let mut v: NestedList = Vec::with_capacity(source_count);
         v.resize_with(source_count, List::default);
         Map {
-            symbols_for_source: NestedList::move_from_list(v),
+            symbols_for_source: v,
         }
     }
 
@@ -599,7 +599,7 @@ impl Map {
     // PERF(port): one extra allocation vs Zig — profile (single
     // caller is the printer one-shot, cold).
     pub fn init_with_one_list(list: List) -> Map {
-        Self::init_list(NestedList::move_from_list(vec![list]))
+        Self::init_list(vec![list])
     }
 
     pub fn init_list(list: NestedList) -> Map {

--- a/src/bundler/AstBuilder.rs
+++ b/src/bundler/AstBuilder.rs
@@ -581,7 +581,7 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
         parts.mut_(1).scopes =
             bun_ast::StoreSlice::new_mut(self.bump.alloc_slice_copy(self.scopes.as_slice()));
         parts.mut_(1).import_record_indices =
-            Vec::<u32>::move_from_list(core::mem::take(&mut self.import_records_for_current_part));
+            core::mem::take(&mut self.import_records_for_current_part);
 
         // SAFETY: module_scope is a live arena allocation. `Scope` is no-Drop
         // arena POD; Zig bitwise-copied it (`module_scope.*`).
@@ -590,13 +590,11 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
         Ok(crate::BundledAst {
             parts,
             module_scope: module_scope_value,
-            symbols: symbol::List::move_from_list(core::mem::take(&mut self.symbols)),
+            symbols: core::mem::take(&mut self.symbols),
             exports_ref: Ref::NONE,
             wrapper_ref: Ref::NONE,
             module_ref: self.module_ref,
-            import_records: import_record::List::move_from_list(core::mem::take(
-                &mut self.import_records,
-            )),
+            import_records: core::mem::take(&mut self.import_records),
             export_star_import_records: Box::default(),
             approximate_newline_count: 1,
             exports_kind: ExportsKind::Esm,

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -3942,7 +3942,7 @@ impl<'a> LinkerContext<'a> {
                         .put(
                             import_ref,
                             crate::ImportData {
-                                re_exports: Vec::<Dependency>::move_from_list(re_exports),
+                                re_exports,
                                 data: ImportTracker {
                                     source_index: crate::Index::init(result.source_index),
                                     import_ref: result.r#ref,
@@ -3965,7 +3965,7 @@ impl<'a> LinkerContext<'a> {
                         .put(
                             import_ref,
                             crate::ImportData {
-                                re_exports: Vec::<Dependency>::move_from_list(re_exports),
+                                re_exports,
                                 data: ImportTracker {
                                     source_index: crate::Index::init(result.source_index),
                                     import_ref: result.r#ref,

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -693,7 +693,7 @@ pub fn compute_chunks(
     // is only assigned here on success, so no rollback guard is needed.)
     this.unique_key_buf = unique_key_builder.move_to_slice();
 
-    Ok(sorted_chunks.to_owned_slice())
+    Ok(sorted_chunks.into_boxed_slice())
     // TODO(port): return type — Zig returns []Chunk allocated by this.arena(); here we return Box<[Chunk]>.
     // Phase B: confirm ownership of `chunks` slice (sorted_chunks Vec backing storage).
 }

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -831,7 +831,7 @@ pub fn scan_imports_and_exports(
                 let entry_point_part_index = this.graph.add_part_to_file(
                     source_index,
                     Part {
-                        dependencies: Vec::<Dependency>::move_from_list(dependencies),
+                        dependencies,
                         can_be_removed_if_unused: false,
                         ..Default::default()
                     },

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2124,7 +2124,7 @@ fn parse_data_loader(
         }
     };
     let mut ast = bun_ast::Ast::from_parts(parts);
-    ast.symbols = bun_ast::symbol::List::from_owned_slice(symbols.into_boxed_slice());
+    ast.symbols = symbols;
 
     return Some(ParseResult {
         ast,

--- a/src/collections/vec_ext.rs
+++ b/src/collections/vec_ext.rs
@@ -93,28 +93,22 @@ pub trait VecExt<T>: Sized {
     fn replace_range(&mut self, start: usize, len: usize, new_items: &[T])
     where
         T: Clone;
-    /// # Safety
-    /// Exposes `self[len..capacity]` as initialized. Every element must be
-    /// overwritten before any read (including Drop). Prefer
-    /// [`unused_capacity_slice`] for `T` with validity invariants.
-    unsafe fn expand_to_capacity(&mut self);
     /// Reserves `additional` and returns the first `additional` slots of
     /// spare capacity as `MaybeUninit<T>`. Caller writes some prefix then
     /// calls `set_len` (or [`bun_core::vec::commit_spare`] for `Vec<u8>`) to
     /// commit. Unlike `spare_capacity_mut()` the returned slice is exactly
     /// `additional` long, not `capacity - len`.
     fn reserve_spare(&mut self, additional: usize) -> &mut [core::mem::MaybeUninit<T>];
-    /// `reserve(additional)` then [`expand_to_capacity`], returning the
-    /// freshly-exposed tail as a raw `(ptr, len)` pair — i.e.
-    /// `(next_out, avail_out)` for C streaming APIs (zlib, brotli, zstd).
-    /// Exposes the *full* over-allocated capacity (`cap - prev_len`), not
-    /// exactly `additional`, so the FFI callee can use the allocator's slack.
-    /// Pass `additional = 0` when the caller has already reserved.
+    /// `reserve(additional)` then return the spare-capacity tail as a raw
+    /// `(ptr, len)` pair — i.e. `(next_out, avail_out)` for C streaming APIs
+    /// (zlib, brotli, zstd). Exposes the *full* spare capacity (`cap - len`),
+    /// not exactly `additional`, so the FFI callee can use the allocator's
+    /// slack. Pass `additional = 0` when the caller has already reserved.
     ///
-    /// # Safety
-    /// Same as [`expand_to_capacity`]: every byte in `[prev_len, cap)` must be
-    /// written by the FFI callee (or `len` truncated back) before any read.
-    unsafe fn reserve_expand_tail(&mut self, additional: usize) -> (*mut T, usize);
+    /// `len()` is **not** advanced; the caller must `set_len()` after the FFI
+    /// write — and on each loop iteration when called repeatedly, so the next
+    /// call returns a fresh tail past the previous write.
+    fn ffi_spare_tail(&mut self, additional: usize) -> (*mut T, usize);
 
     // ── ownership transfer ────────────────────────────────────────────────
     fn move_to_list(&mut self) -> Vec<T>;
@@ -169,17 +163,9 @@ impl<T, A: Allocator + Default + 'static> VecExt<T> for Vec<T, A> {
     }
     #[inline]
     fn move_from_list(list: Vec<T>) -> Self {
-        // Mirror of the `move_to_list` fast-path: when `A == Global` this is a
-        // pointer adopt (Zig `moveFromList`, baby_list.zig:46), not a realloc.
-        // Hot Global callers: `FileReader`, `ByteStream`, `shell::Cmd`.
-        if core::any::TypeId::of::<A>() == core::any::TypeId::of::<std::alloc::Global>() {
-            // SAFETY: `A == Global`, so `Vec<T>` and `Vec<T, A>` have identical
-            // layout, allocator, and drop semantics.
-            let mut list = core::mem::ManuallyDrop::new(list);
-            return unsafe {
-                Vec::from_raw_parts_in(list.as_mut_ptr(), list.len(), list.capacity(), A::default())
-            };
-        }
+        // `A == Global` callers are identity and have been rewritten to drop
+        // this call entirely; only the cross-allocator (`AstAlloc`) callers
+        // remain, which always needed this realloc+move.
         let mut v = Vec::with_capacity_in(list.len(), A::default());
         v.extend(list);
         v
@@ -357,45 +343,25 @@ impl<T, A: Allocator + Default + 'static> VecExt<T> for Vec<T, A> {
         self.splice(start..start + len, new_items.iter().cloned());
     }
     #[inline]
-    unsafe fn expand_to_capacity(&mut self) {
-        // SAFETY: caller contract — every element in `[len, cap)` is written
-        // before being observed.
-        unsafe { self.set_len(self.capacity()) };
-    }
-    #[inline]
     fn reserve_spare(&mut self, additional: usize) -> &mut [core::mem::MaybeUninit<T>] {
         self.reserve(additional);
         &mut self.spare_capacity_mut()[..additional]
     }
     #[inline]
-    unsafe fn reserve_expand_tail(&mut self, additional: usize) -> (*mut T, usize) {
-        let prev = self.len();
+    fn ffi_spare_tail(&mut self, additional: usize) -> (*mut T, usize) {
         if additional != 0 {
             self.reserve(additional);
         }
-        let cap = self.capacity();
-        // SAFETY: caller contract — `[prev, cap)` is FFI-written or truncated before any read.
-        unsafe { self.set_len(cap) };
-        // SAFETY: `prev <= cap`; ptr is within (or one-past) the allocation.
-        (unsafe { self.as_mut_ptr().add(prev) }, cap - prev)
+        let spare = self.spare_capacity_mut();
+        (spare.as_mut_ptr().cast::<T>(), spare.len())
     }
 
     #[inline]
     fn move_to_list(&mut self) -> Vec<T> {
+        // `A == Global` callers are identity and have been rewritten to
+        // `mem::take`/direct move; only cross-allocator (`AstAlloc`) callers
+        // remain, which always needed this realloc+move.
         let taken = core::mem::replace(self, Vec::new_in(A::default()));
-        // Fast path: `Vec<T, Global>` → `Vec<T>` is a pointer move, not a
-        // realloc+memcpy. Restores zero-copy behavior on the HTTP streaming
-        // paths (`RequestContext::response_buf`, `ByteStream`); the copying
-        // path is still required for `AstAlloc` etc. where the buffer must
-        // migrate heaps.
-        if core::any::TypeId::of::<A>() == core::any::TypeId::of::<std::alloc::Global>() {
-            // SAFETY: `A == Global`, so `Vec<T, A>` and `Vec<T>` have the
-            // same layout, allocator, and drop semantics.
-            let mut taken = core::mem::ManuallyDrop::new(taken);
-            return unsafe {
-                Vec::from_raw_parts(taken.as_mut_ptr(), taken.len(), taken.capacity())
-            };
-        }
         let mut out = Vec::with_capacity(taken.len());
         out.extend(taken);
         out

--- a/src/css/properties/font.rs
+++ b/src/css/properties/font.rs
@@ -805,10 +805,8 @@ impl Font {
         };
 
         // PORT NOTE: Zig `Vec(FontFamily).parse` parsed a comma-separated
-        // list and packed it; route through `parse_comma_separated` + move.
-        let family = input
-            .parse_comma_separated(FontFamily::parse)
-            .map(Vec::<FontFamily>::move_from_list)?;
+        // list and packed it; route through `parse_comma_separated`.
+        let family = input.parse_comma_separated(FontFamily::parse)?;
 
         Ok(Font {
             family,

--- a/src/http/Decompressor.rs
+++ b/src/http/Decompressor.rs
@@ -131,16 +131,6 @@ impl Decompressor {
                 reader.zlib.avail_in = buffer.len() as u32;
 
                 let initial = body_out_str.list.len();
-                // PORT NOTE: Zig `expandToCapacity()` set `len = capacity` so the
-                // zlib output pointers could write into the spare region while
-                // `read_all` later truncated back to `total_out`. `read_all`'s
-                // grow-on-avail_out==0 path reads `list_ptr.len()` to compute the
-                // resume offset, so this `set_len(capacity)` is load-bearing —
-                // skipping it leaves `len == initial` and the next grow rewinds
-                // `next_out` to `ptr + initial`, overwriting freshly-inflated
-                // bytes (observed as mid-stream gzip/deflate corruption when a
-                // streamed body chunk decompresses past the reused buffer's
-                // capacity).
                 if body_out_str.list.capacity() == initial {
                     body_out_str.list.reserve(4096);
                 }
@@ -155,10 +145,11 @@ impl Decompressor {
                 // SAFETY: see `seat` contract — same buffer pair as initial seat.
                 let (_, out) = unsafe { seat(buffer, &mut body_out_str.list) };
                 reader.list_ptr = out;
-                // SAFETY: zlib writes the tail; `read_all` truncates to `total_out` before any read.
-                // `additional = 0`: the conditional reserve above already grew the buffer; `reserve(0)` is a no-op.
-                // `list_ptr.len() == initial` here (reserve does not change len), so the helper's internal `prev` matches.
-                let (next_out, avail_out) = unsafe { reader.list_ptr.reserve_expand_tail(0) };
+                // `list_ptr.len() == initial` here (reserve does not change len),
+                // so the spare tail starts at `ptr + initial`. `read_all` commits
+                // `len = total_out` per iteration before each subsequent reseat,
+                // so multi-round inflate never rewinds `next_out`.
+                let (next_out, avail_out) = reader.list_ptr.ffi_spare_tail(0);
                 reader.zlib.next_out = next_out;
                 reader.zlib.avail_out = avail_out as u32;
                 // we reset the total out so we can track how much we decompressed this time

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -581,13 +581,11 @@ impl<'a> Parser<'a> {
         // If we added to `p.symbols` it's going to fuck up all the indices
         // in the `symbols` array.
         debug_assert!(p.symbols.len() == 0);
-        let mut symbols_ = symbols;
         // PORT NOTE: Zig `moveToListManaged(arena)` rebinds the same
         // backing storage to an `ArrayList(arena)`. The Rust Vec
         // adapter returns a `std::Vec`; `p.symbols` is a bump-backed Vec, so
         // copy elements into the arena. Phase B may grow a zero-copy adapter.
-        p.symbols =
-            bun_alloc::vec_from_iter_in(symbols_.move_to_list_managed().into_iter(), p.arena);
+        p.symbols = bun_alloc::vec_from_iter_in(symbols.into_iter(), p.arena);
 
         p.prepare_for_visit_pass()?;
 

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -2595,22 +2595,22 @@ pub fn read_file_with_handle_impl<'p, 'buf, const USE_SHARED_BUFFER: bool, const
 
         let mut bytes_read: u64 = 0;
         shared_buffer.grow_by(size + 1)?;
-        // SAFETY: u8; `read_all` overwrites the exposed tail before any read.
-        unsafe { shared_buffer.list.expand_to_capacity() };
 
         // if you press save on a large file we might not read all the
         // bytes in the first few pread() calls. we only handle this on
         // stream because we assume that this only realistically happens
         // during HMR
         loop {
+            debug_assert_eq!(shared_buffer.list.len(), bytes_read as usize);
             // We use pread to ensure if the file handle was open, it doesn't seek from the last position
-            let read_count = match file.read_all(&mut shared_buffer.list[bytes_read as usize..]) {
+            // SAFETY: write-only spare; `read_all` only stores into it.
+            let spare = unsafe { bun_core::vec::spare_bytes_mut(&mut shared_buffer.list) };
+            let read_count = match file.read_all(spare) {
                 Ok(n) => n,
                 Err(err) => return Err(err.into()),
             };
-            shared_buffer
-                .list
-                .truncate(read_count + bytes_read as usize);
+            // SAFETY: `read_all` initialized `spare[..read_count]`.
+            unsafe { bun_core::vec::commit_spare(&mut shared_buffer.list, read_count) };
             file_contents_ptr = shared_buffer.list.as_ptr();
             file_contents_len = shared_buffer.list.len();
             debug!("read({}, {}) = {}", file.handle(), size, read_count);
@@ -2632,8 +2632,6 @@ pub fn read_file_with_handle_impl<'p, 'buf, const USE_SHARED_BUFFER: bool, const
 
                 if (bytes_read as usize) < new_size {
                     shared_buffer.grow_by(new_size - size)?;
-                    // SAFETY: u8; `read_all` overwrites the exposed tail before any read.
-                    unsafe { shared_buffer.list.expand_to_capacity() };
                     size = new_size;
                     continue;
                 }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4966,16 +4966,13 @@ impl NodeFS {
                 let clamped_size: usize = stat_size.min(8 * 1024 * 1024);
                 // PORT NOTE: Zig used `bun.default_allocator.alloc(u8, clamped_size)` —
                 // uninitialised heap. `Vec::resize` here was a debug-build hot path
-                // (byte-by-byte `extend_with`); use `expand_to_capacity` to match the spec
-                // (the slab is write-only — `Syscall::read` fills it from the kernel).
-                use bun_collections::vec_ext::VecExt as _;
+                // (byte-by-byte `extend_with`); hand the spare to the kernel directly.
                 if buf_to_free.try_reserve_exact(clamped_size).is_err() {
                     break 'maybe_allocate_large_temp_buf;
                 }
-                // SAFETY: `u8` has no validity invariant; the buffer is handed
-                // straight to the kernel which only stores into it.
-                unsafe { buf_to_free.expand_to_capacity() };
-                buf = &mut buf_to_free[..];
+                // SAFETY: write-only scratch; `Syscall::read` fills it from the
+                // kernel before any byte is observed.
+                buf = unsafe { bun_core::vec::spare_bytes_mut(&mut buf_to_free) };
             }
         }
         // buf_to_free dropped at scope exit
@@ -7334,13 +7331,10 @@ impl NodeFS {
         // PORT NOTE: Zig `buf.expandToCapacity()` then indexed `buf.items.ptr[total..cap]`
         // to read into uninitialised tail. `Vec::resize(cap, 0)` is *not* equivalent in
         // debug builds: it goes through `extend_with`'s byte-by-byte loop (no memset
-        // specialisation), which dominated `readFileSync` of large files. Match the spec
-        // exactly via `VecExt::expand_to_capacity` (the tail is write-only — `Syscall::read`
-        // hands it straight to the kernel, which only stores into it).
-        use bun_collections::vec_ext::VecExt as _;
-        // SAFETY: `u8` has no validity invariant; the buffer is handed straight
-        // to the kernel which only stores into it.
-        unsafe { buf.expand_to_capacity() };
+        // specialisation), which dominated `readFileSync` of large files. Read into the
+        // spare-capacity slice directly and commit `amt` per iteration — `buf.len()`
+        // tracks `total` throughout.
+        debug_assert_eq!(buf.len(), total);
 
         // Two-phase read: first up to `size`, then keep going until EOF.
         // PORT NOTE: Zig spelled this as `while (total < size) { ... } else { while (true) { ... } }`.
@@ -7356,9 +7350,13 @@ impl NodeFS {
             // Do NOT pre-grow here; growth happens only in the `total > size && amt != 0 &&
             // !has_max_size` arm below.
             let upper = (buf.capacity() as u64).min(max_size) as usize;
-            match Syscall::read(fd, &mut buf[total..upper]) {
+            // SAFETY: write-only window; the kernel only stores into it.
+            let window = unsafe { &mut bun_core::vec::spare_bytes_mut(&mut buf)[..upper - total] };
+            match Syscall::read(fd, window) {
                 Err(err) => return Err(err),
                 Ok(amt) => {
+                    // SAFETY: kernel initialized `buf[total..total+amt]`.
+                    unsafe { bun_core::vec::commit_spare(&mut buf, amt) };
                     total += amt;
 
                     if args.limit_size_for_javascript {
@@ -7379,8 +7377,6 @@ impl NodeFS {
                                 &args.path,
                             ));
                         }
-                        // SAFETY: `u8` has no validity invariant; kernel only stores.
-                        unsafe { buf.expand_to_capacity() };
                         continue;
                     }
 

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2972,10 +2972,7 @@ where
                             // If we've received the complete body by the time this function is called
                             // we can avoid streaming it and just send it all at once.
                             if byte_stream.has_received_last_chunk.get() {
-                                let mut byte_list = byte_stream.drain();
-                                this.blob = AnyBlob::from_array_list(
-                                    byte_list.move_to_list_managed(),
-                                );
+                                this.blob = AnyBlob::from_array_list(byte_stream.drain());
                                 this.response_body_readable_stream_ref.deinit();
                                 this.do_render_blob();
                                 return;
@@ -2989,8 +2986,7 @@ where
                                 readable_stream::Strong::init(stream, global_this);
 
                             this.byte_stream = Some(byte_stream_nn);
-                            let mut response_buf = byte_stream.drain();
-                            this.response_buf_owned = response_buf.move_to_list();
+                            this.response_buf_owned = byte_stream.drain();
 
                             // we don't set size here because even if we have a hint
                             // uWebSockets won't let us partially write streaming content

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -209,7 +209,7 @@ impl BufferedIoClosed {
         // single-threaded and this is the same pattern `subproc::on_close_io`
         // uses to take the done buffer.
         let buffer = unsafe { &mut *(std::sync::Arc::as_ptr(pipe).cast_mut()) }.take_buffer();
-        *state = BufferedIoState::Closed(Vec::<u8>::move_from_list(buffer));
+        *state = BufferedIoState::Closed(buffer);
     }
 }
 

--- a/src/runtime/webcore/ArrayBufferSink.rs
+++ b/src/runtime/webcore/ArrayBufferSink.rs
@@ -213,12 +213,11 @@ impl ArrayBufferSink {
 
         // `defer this.bytes = bun.Vec<u8>.empty` + `try toOwnedSlice` →
         // take ownership, leave empty in place.
-        let mut bytes = core::mem::take(&mut self.bytes);
         // Ownership transfers to JSC — `to_js` installs
         // `MarkedArrayBuffer_deallocator` which `mi_free`s the buffer when the
         // JS object is collected. Bun's global allocator is mimalloc, so the
         // `mi_is_in_heap_region` check in `to_js` succeeds.
-        let owned = bytes.to_owned_slice();
+        let owned = core::mem::take(&mut self.bytes).into_boxed_slice();
         ArrayBuffer::from_owned_bytes(
             owned,
             if as_uint8array {
@@ -239,11 +238,10 @@ impl ArrayBufferSink {
         self.done = true;
         self.signal.close(None);
         // `defer this.bytes = bun.Vec<u8>.empty` → take ownership, leave empty.
-        let mut bytes = core::mem::take(&mut self.bytes);
         // Ownership transfers to JSC; the caller wraps the returned
         // `ArrayBuffer` in `.to_js()` which installs `MarkedArrayBuffer_deallocator`
         // (frees via `mi_free` on GC). See `to_js` above.
-        let owned = bytes.to_owned_slice();
+        let owned = core::mem::take(&mut self.bytes).into_boxed_slice();
         Ok(ArrayBuffer::from_owned_bytes(
             owned,
             if self.as_uint8array {

--- a/src/runtime/webcore/ByteStream.rs
+++ b/src/runtime/webcore/ByteStream.rs
@@ -131,8 +131,7 @@ impl ByteStream {
         }
 
         if self.has_received_last_chunk.get() {
-            let buffer = self.buffer.replace(Vec::new());
-            return streams::Start::OwnedAndDone(Vec::<u8>::move_from_list(buffer));
+            return streams::Start::OwnedAndDone(self.buffer.replace(Vec::new()));
         }
 
         if self.high_water_mark == 0 {
@@ -250,7 +249,7 @@ impl ByteStream {
                         // PORT NOTE: reshaped for borrowck — move the owned Vec<u8> into `buffer`
                         // directly instead of round-tripping through `chunk` (which would borrow
                         // `stream`).
-                        self.buffer.set(owned.move_to_list_managed());
+                        self.buffer.set(owned);
                         let mut blob = self.to_any_blob().unwrap();
                         return action.fulfill(self.parent_const().global_this(), &mut blob);
                     }
@@ -361,9 +360,9 @@ impl ByteStream {
     ) -> Result<(), bun_alloc::AllocError> {
         if self.buffer.get().capacity() == 0 {
             match stream {
-                streams::Result::Owned(mut owned) | streams::Result::OwnedAndDone(mut owned) => {
+                streams::Result::Owned(owned) | streams::Result::OwnedAndDone(owned) => {
                     // Zig: `owned.moveToListManaged(allocator)` — moves the buffer, no copy.
-                    self.buffer.set(owned.move_to_list_managed());
+                    self.buffer.set(owned);
                     self.offset.set(self.offset.get() + offset);
                 }
                 streams::Result::TemporaryAndDone(temp) | streams::Result::Temporary(temp) => {
@@ -556,7 +555,7 @@ impl ByteStream {
 
     pub fn drain(&self) -> Vec<u8> {
         if !self.buffer.get().is_empty() {
-            return Vec::<u8>::move_from_list(self.buffer.replace(Vec::new()));
+            return self.buffer.replace(Vec::new());
         }
         Vec::<u8>::default()
     }

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -480,9 +480,7 @@ impl FileReader {
         if self.reader().is_done() {
             self.consume_reader_buffer();
             if !self.buffered.get().is_empty() {
-                return streams::Start::OwnedAndDone(Vec::<u8>::move_from_list(
-                    self.buffered.replace(Vec::new()),
-                ));
+                return streams::Start::OwnedAndDone(self.buffered.replace(Vec::new()));
             }
         } else {
             #[cfg(unix)]
@@ -669,10 +667,8 @@ impl FileReader {
                             });
                             drop(buffer); // clearAndFree
                         } else {
-                            self.pending.with_mut(|p| {
-                                p.result =
-                                    streams::Result::OwnedAndDone(Vec::<u8>::move_from_list(buffer))
-                            });
+                            self.pending
+                                .with_mut(|p| p.result = streams::Result::OwnedAndDone(buffer));
                         }
                     } else {
                         self.pending.with_mut(|p| p.result = streams::Result::Done);
@@ -711,10 +707,8 @@ impl FileReader {
                         debug_assert_eq!(buf.as_ptr(), unsafe { (*reader_buffer).as_ptr() });
                         let mut buffer = unsafe { mem::take(&mut *reader_buffer) };
                         buffer.truncate(buf.len()); // shrinkRetainingCapacity
-                        self.pending.with_mut(|p| {
-                            p.result =
-                                streams::Result::OwnedAndDone(Vec::<u8>::move_from_list(buffer))
-                        });
+                        self.pending
+                            .with_mut(|p| p.result = streams::Result::OwnedAndDone(buffer));
                     } else {
                         // SAFETY: see `reader_buffer` decl.
                         unsafe { (*reader_buffer).clear() };
@@ -742,9 +736,9 @@ impl FileReader {
 
                 self.pending.with_mut(|p| {
                     p.result = if self.reader().is_done() {
-                        streams::Result::OwnedAndDone(Vec::<u8>::move_from_list(buffered))
+                        streams::Result::OwnedAndDone(buffered)
                     } else {
-                        streams::Result::Owned(Vec::<u8>::move_from_list(buffered))
+                        streams::Result::Owned(buffered)
                     }
                 });
                 break 'pending !was_done;
@@ -897,9 +891,9 @@ impl FileReader {
                     );
                     let buffered = self.buffered.replace(Vec::new());
                     if self.reader().is_done() {
-                        return streams::Result::OwnedAndDone(Vec::<u8>::move_from_list(buffered));
+                        return streams::Result::OwnedAndDone(buffered);
                     }
-                    return streams::Result::Owned(Vec::<u8>::move_from_list(buffered));
+                    return streams::Result::Owned(buffered);
                 }
                 _ => {
                     // Spec FileReader.zig:544 `else => {}` falls through to set
@@ -928,7 +922,7 @@ impl FileReader {
 
     pub fn drain(&self) -> Vec<u8> {
         if !self.buffered.get().is_empty() {
-            let out = Vec::<u8>::move_from_list(self.buffered.replace(Vec::new()));
+            let out = self.buffered.replace(Vec::new());
             if cfg!(debug_assertions) {
                 debug_assert!(self.reader().buffer().as_ptr() != out.as_ptr());
             }
@@ -939,7 +933,7 @@ impl FileReader {
             return Vec::<u8>::default();
         }
 
-        Vec::<u8>::move_from_list(mem::take(self.reader().buffer()))
+        mem::take(self.reader().buffer())
     }
 
     pub fn set_ref_or_unref(&self, enable: bool) {
@@ -962,10 +956,8 @@ impl FileReader {
             if self.pending.get().state == streams::PendingState::Pending {
                 if !self.buffered.get().is_empty() {
                     let buffered = self.buffered.replace(Vec::new());
-                    self.pending.with_mut(|p| {
-                        p.result =
-                            streams::Result::OwnedAndDone(Vec::<u8>::move_from_list(buffered))
-                    });
+                    self.pending
+                        .with_mut(|p| p.result = streams::Result::OwnedAndDone(buffered));
                 } else {
                     self.pending.with_mut(|p| p.result = streams::Result::Done);
                 }

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -235,17 +235,9 @@ impl UTF8Fallback {
 
             strings::replace_latin1_with_utf8(&mut slice[..str_.len()]);
             if input.is_done() {
-                write_fn(
-                    ctx,
-                    streams::Result::OwnedAndDone(Vec::<u8>::from_owned_slice(
-                        slice.into_boxed_slice(),
-                    )),
-                )
+                write_fn(ctx, streams::Result::OwnedAndDone(slice))
             } else {
-                write_fn(
-                    ctx,
-                    streams::Result::Owned(Vec::<u8>::from_owned_slice(slice.into_boxed_slice())),
-                )
+                write_fn(ctx, streams::Result::Owned(slice))
             }
         }
     }
@@ -284,19 +276,9 @@ impl UTF8Fallback {
             // `.err = oom`.
             let allocated = strings::to_utf8_alloc(str_);
             if input.is_done() {
-                write_fn(
-                    ctx,
-                    streams::Result::OwnedAndDone(Vec::<u8>::from_owned_slice(
-                        allocated.into_boxed_slice(),
-                    )),
-                )
+                write_fn(ctx, streams::Result::OwnedAndDone(allocated))
             } else {
-                write_fn(
-                    ctx,
-                    streams::Result::Owned(Vec::<u8>::from_owned_slice(
-                        allocated.into_boxed_slice(),
-                    )),
-                )
+                write_fn(ctx, streams::Result::Owned(allocated))
             }
         }
     }

--- a/src/zlib/lib.rs
+++ b/src/zlib/lib.rs
@@ -510,8 +510,13 @@ impl<'a> ZlibReaderArrayList<'a> {
                 //   flush parameter).
 
                 if self.zlib.avail_out == 0 {
-                    // SAFETY: zlib writes the tail; len is truncated to `total_out` before any read.
-                    let (next_out, avail_out) = unsafe { self.list_ptr.reserve_expand_tail(4096) };
+                    let total_out = self.zlib.total_out as usize;
+                    debug_assert!(total_out <= self.list_ptr.capacity());
+                    // SAFETY: zlib has initialized `list_ptr[..total_out]`; commit so
+                    // the spare tail returned below starts past it (without this the
+                    // next iteration rewinds `next_out` and overwrites prior output).
+                    unsafe { self.list_ptr.set_len(total_out) };
+                    let (next_out, avail_out) = self.list_ptr.ffi_spare_tail(4096);
                     self.zlib.next_out = next_out;
                     self.zlib.avail_out = avail_out as uInt;
                 }
@@ -560,12 +565,9 @@ impl<'a> ZlibReaderArrayList<'a> {
 
         // defer epilogue (runs unconditionally):
         let total_out = self.zlib.total_out as usize;
-        if self.list_ptr.len() > total_out {
-            self.list_ptr.truncate(total_out);
-        } else if total_out < self.list_ptr.capacity() {
-            // SAFETY: zlib has written `total_out` bytes into list_ptr's buffer.
-            unsafe { self.list_ptr.set_len(total_out) };
-        }
+        debug_assert!(total_out <= self.list_ptr.capacity());
+        // SAFETY: zlib has written `total_out` bytes into list_ptr's buffer.
+        unsafe { self.list_ptr.set_len(total_out) };
 
         result
     }
@@ -1023,8 +1025,12 @@ impl<'a> ZlibCompressorArrayList<'a> {
                 //   flush parameter).
 
                 if self.zlib.avail_out == 0 {
-                    // SAFETY: zlib writes the tail; len is truncated to `total_out` before any read.
-                    let (next_out, avail_out) = unsafe { self.list_ptr.reserve_expand_tail(4096) };
+                    let total_out = self.zlib.total_out as usize;
+                    debug_assert!(total_out <= self.list_ptr.capacity());
+                    // SAFETY: zlib has initialized `list_ptr[..total_out]`; commit so
+                    // the spare tail returned below starts past it.
+                    unsafe { self.list_ptr.set_len(total_out) };
+                    let (next_out, avail_out) = self.list_ptr.ffi_spare_tail(4096);
                     self.zlib.next_out = next_out;
                     self.zlib.avail_out = avail_out as uInt;
                 }
@@ -1068,7 +1074,10 @@ impl<'a> ZlibCompressorArrayList<'a> {
 
         // defer epilogue (runs unconditionally):
         // Zig: this.list.shrinkRetainingCapacity(this.zlib.total_out); this.list_ptr.* = this.list;
-        self.list_ptr.truncate(self.zlib.total_out as usize);
+        let total_out = self.zlib.total_out as usize;
+        debug_assert!(total_out <= self.list_ptr.capacity());
+        // SAFETY: zlib has written `total_out` bytes into list_ptr's buffer.
+        unsafe { self.list_ptr.set_len(total_out) };
 
         result
     }


### PR DESCRIPTION
Stacked on #vecext-safe-1. Removes 9 of the remaining 13 `unsafe` occurrences in `src/collections/vec_ext.rs` (13 → 4).

## What changed

**`expand_to_capacity` — deleted.** The 5 `Vec<u8>` syscall-read callers (`node_fs.rs` ×3, `resolver/fs.rs` ×2) now use `bun_core::vec::spare_bytes_mut` + `commit_spare` per iteration, so `len()` tracks bytes-read instead of being pre-expanded to `capacity`. The `readFileSync` post-loop code paths were checked individually for the `len == total` invariant.

**`reserve_expand_tail` → safe `ffi_spare_tail`.** Returns `(spare.ptr, spare.len)` without bumping `len`. The zlib `read_all` loops now `set_len(total_out)` *per iteration* before reseating — without this, iteration 2 would rewind `next_out` and overwrite freshly-inflated bytes (the bug class documented at `Decompressor.rs:134`). Epilogues become unconditional `set_len(total_out)`.

**`move_from_list` / `move_to_list` — `TypeId == Global` fast-path removed.** Every `A == Global` caller (direct + transitive via `from_owned_slice`/`to_owned_slice`/`move_to_list_managed`) was rewritten to identity / `mem::take` / `into_boxed_slice` first, so the only remaining callers are cross-allocator (`AstAlloc`) and were already on the realloc+move path. Touches `FileReader`, `ByteStream`, `Sink`, `RequestContext`, `Cmd`, `ArrayBufferSink`, `AstBuilder`, `symbol::Map`, `LinkerContext`, `scanImportsAndExports`, `computeChunks`, `transpiler`, `font`, `parse_entry`, `ast_result`.

**Kept**: `from_bump_vec` (1 unsafe — std's memcpy `SpecExtend` is `IntoIter<T, Global>`-only; an `ArenaVec` would fall to a per-element loop on the parser hot path) and `from_borrowed_slice_dangerous` (3 unsafe — the renamer-constructor / CSS-printer signature cascade is deferred). `Ast::init_test` was the only other `from_borrowed_slice_dangerous` caller and was dead, so deleted.

## Residual

```
$ grep -c '\bunsafe\b' src/collections/vec_ext.rs
4
```
- 1 × `from_bump_vec` body
- 3 × `from_borrowed_slice_dangerous` (trait decl + impl header + body)

## Testing

`cargo check --workspace` clean. `bun bd test test/js/node/zlib/ test/js/node/fs/ test/js/web/fetch/` matches the base-branch baseline (same pre-existing failures; no new failures that aren't flaky timeouts under parallel load — re-ran each in isolation and they pass). Additionally exercised directly:

- 500 KB random-bytes inflate/gunzip round-trip (forces ~122 reseats) — byte-exact
- `readFileSync` at 1, 100, 4095, 4096, 4097, 256 KB, 256 KB+1, 5 MB (Buffer + utf8) — byte-exact
- `copyFileSync` 2 MB — byte-exact
- `fetch` of 200 KB random body served as ~200 gzip chunks — byte-exact

## ⚠️ Perf to watch

The `readFileSync` read loop is restructured (commit-per-iteration instead of expand-once-upfront). It should be a wash — same syscall pattern, same allocation pattern, no extra zeroing — but this path has had perf regressions before, so a large-file `readFileSync` benchmark before merge would be prudent.