### PR TITLE
collections: crate-wide #![deny(unsafe_code)] (integration of #30718 + #30723-30730 + #30736-30737)

### DIFF
--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -178,24 +178,7 @@ pub type TsEnumsMap = ArrayHashMap<Ref, StringHashMap<InlinedEnumValue>, AutoCon
 impl Ast {
     pub fn from_parts(parts: Box<[Part]>) -> Ast {
         Ast {
-            parts: PartList::from_owned_slice(parts),
-            runtime_imports: Default::default(),
-            ..Default::default()
-        }
-    }
-
-    // Zig `initTest` borrowed `parts` via `Part.List.fromBorrowedSliceDangerous`
-    // and relied on explicit `deinit` never being called. `Vec::drop` now
-    // unconditionally guards on `Origin::Borrowed` (not debug-only), so unwrapping
-    // the `ManuallyDrop` is safe — the caller's slice is never freed by `Ast`'s Drop.
-    pub fn init_test(parts: &[Part]) -> Ast {
-        Ast {
-            // SAFETY: test-only helper; the borrowed list is tagged
-            // `Origin::Borrowed`, so `Vec::drop` skips the free, and no
-            // grow/free path is reached on `Ast.parts` before the borrow ends.
-            parts: std::mem::ManuallyDrop::into_inner(unsafe {
-                PartList::from_borrowed_slice_dangerous(parts)
-            }),
+            parts: parts.into_vec(),
             runtime_imports: Default::default(),
             ..Default::default()
         }

--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -586,10 +586,10 @@ impl Map {
     pub fn init(source_count: usize) -> Map {
         // Zig: `arena.alloc([]Symbol, sourceCount)` (default_allocator) then NestedList.init.
         // Per PORTING.md §Allocators (non-arena path), use Vec → Vec.
-        let mut v: Vec<List> = Vec::with_capacity(source_count);
+        let mut v: NestedList = Vec::with_capacity(source_count);
         v.resize_with(source_count, List::default);
         Map {
-            symbols_for_source: NestedList::move_from_list(v),
+            symbols_for_source: v,
         }
     }
 
@@ -599,7 +599,7 @@ impl Map {
     // PERF(port): one extra allocation vs Zig — profile (single
     // caller is the printer one-shot, cold).
     pub fn init_with_one_list(list: List) -> Map {
-        Self::init_list(NestedList::move_from_list(vec![list]))
+        Self::init_list(vec![list])
     }
 
     pub fn init_list(list: NestedList) -> Map {

--- a/src/bun_alloc/ast_alloc.rs
+++ b/src/bun_alloc/ast_alloc.rs
@@ -411,7 +411,7 @@ impl AstAlloc {
 
     /// Move `items` element-wise into a fresh AST-heap allocation. Replaces
     /// both `VecExt::from_owned_slice` (`Box<[T]>` → `Vec`) and
-    /// `VecExt::from_bump_slice` (leaked `&mut [T]` → `Vec`): in either case
+    /// `VecExt::from_bump_vec` (`ArenaVec<T>` → `Vec`): in either case
     /// the source storage is on the wrong heap, so a copy is unavoidable.
     #[inline]
     pub fn vec_from_iter<T, I: IntoIterator<Item = T>>(iter: I) -> AstVec<T> {

--- a/src/bun_core/deprecated.rs
+++ b/src/bun_core/deprecated.rs
@@ -91,11 +91,9 @@ pub fn buffered_reader_size<const SIZE: usize, R: DeprecatedRead>(
 // ──────────────────────────────────────────────────────────────────────────
 //
 // DEDUP(D050): the Rust port of `SinglyLinkedList` / `SinglyLinkedNode` was
-// removed — the canonical implementation lives at
-// `bun_collections::pool::{SinglyLinkedList, Node}`. The two had diverged
-// (`data: T` vs `data: MaybeUninit<T>`, `*mut`-null vs `Option<*mut>` returns)
-// and this copy had zero callers outside its own unit test. New consumers
-// should depend on `bun_collections::pool` directly.
+// removed — the only consumer (`bun_collections::pool::ObjectPool`) now uses a
+// `Vec<T>` free list, and `DevServer` carries its own local `Vec<NonNull<Node>>`.
+// New consumers should use `Vec` directly.
 
 // ──────────────────────────────────────────────────────────────────────────
 // DoublyLinkedList

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -442,8 +442,6 @@ pub mod vec {
 
     /// Reserve `additional`, advance `len` by `additional`, and return the
     /// newly-exposed (uninitialized) tail. Zig `ArrayList.addManyAsSlice`.
-    /// Generic free-fn form of `bun_collections::VecExt::writable_slice` so
-    /// `bun_core::string` can call it without a `bun_collections` edge.
     ///
     /// # Safety
     /// Caller must fully write the returned slice before any read of

--- a/src/bundler/AstBuilder.rs
+++ b/src/bundler/AstBuilder.rs
@@ -581,7 +581,7 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
         parts.mut_(1).scopes =
             bun_ast::StoreSlice::new_mut(self.bump.alloc_slice_copy(self.scopes.as_slice()));
         parts.mut_(1).import_record_indices =
-            Vec::<u32>::move_from_list(core::mem::take(&mut self.import_records_for_current_part));
+            core::mem::take(&mut self.import_records_for_current_part);
 
         // SAFETY: module_scope is a live arena allocation. `Scope` is no-Drop
         // arena POD; Zig bitwise-copied it (`module_scope.*`).
@@ -590,13 +590,11 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
         Ok(crate::BundledAst {
             parts,
             module_scope: module_scope_value,
-            symbols: symbol::List::move_from_list(core::mem::take(&mut self.symbols)),
+            symbols: core::mem::take(&mut self.symbols),
             exports_ref: Ref::NONE,
             wrapper_ref: Ref::NONE,
             module_ref: self.module_ref,
-            import_records: import_record::List::move_from_list(core::mem::take(
-                &mut self.import_records,
-            )),
+            import_records: core::mem::take(&mut self.import_records),
             export_star_import_records: Box::default(),
             approximate_newline_count: 1,
             exports_kind: ExportsKind::Esm,

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -3942,7 +3942,7 @@ impl<'a> LinkerContext<'a> {
                         .put(
                             import_ref,
                             crate::ImportData {
-                                re_exports: Vec::<Dependency>::move_from_list(re_exports),
+                                re_exports,
                                 data: ImportTracker {
                                     source_index: crate::Index::init(result.source_index),
                                     import_ref: result.r#ref,
@@ -3965,7 +3965,7 @@ impl<'a> LinkerContext<'a> {
                         .put(
                             import_ref,
                             crate::ImportData {
-                                re_exports: Vec::<Dependency>::move_from_list(re_exports),
+                                re_exports,
                                 data: ImportTracker {
                                     source_index: crate::Index::init(result.source_index),
                                     import_ref: result.r#ref,

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -343,19 +343,13 @@ pub fn generate_symbol_import_and_use(
     );
     let dependencies =
         &mut parts[source_index as usize].slice_mut()[part_index as usize].dependencies;
-    // SAFETY: every element of `new_dependencies` is overwritten in the
-    // zip-loop immediately below before any read/drop.
-    let new_dependencies = unsafe { dependencies.writable_slice(part_ids.len()) };
-    debug_assert_eq!(part_ids.len(), new_dependencies.len());
-    for (part_id, dependency) in part_ids.iter().zip(new_dependencies.iter_mut()) {
-        *dependency = Dependency {
-            // PORT NOTE: `Dependency.source_index` is the structurally
-            // identical `bun_ast::Index`; convert by value until the
-            // two `Index` newtypes unify (Phase B-3).
-            source_index: bun_ast::Index::init(source_index_to_import_from.get()),
-            part_index: *part_id, // @truncate (already u32)
-        };
-    }
+    bun_core::vec::extend_from_fn(dependencies, part_ids.len(), |i| Dependency {
+        // PORT NOTE: `Dependency.source_index` is the structurally
+        // identical `bun_ast::Index`; convert by value until the
+        // two `Index` newtypes unify (Phase B-3).
+        source_index: bun_ast::Index::init(source_index_to_import_from.get()),
+        part_index: part_ids[i], // @truncate (already u32)
+    });
     Ok(())
 }
 

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -1003,10 +1003,8 @@ pub mod parse_worker {
                     },
                     Loc { start: 0 },
                 );
-                let require_args = bump.alloc_slice_fill_default::<Expr>(2);
-                require_args[0] = import_path;
-                let object_properties = bump.alloc_slice_fill_default::<G::Property>(1);
-                object_properties[0] = G::Property {
+                let mut object_properties = G::PropertyList::init_capacity(1);
+                object_properties.push(G::Property {
                     key: Some(Expr::init(
                         E::String {
                             data: b"type".into(),
@@ -1022,21 +1020,21 @@ pub mod parse_worker {
                         Loc { start: 0 },
                     )),
                     ..Default::default()
-                };
-                require_args[1] = Expr::init(
+                });
+                let mut require_args = bun_ast::ExprNodeList::init_capacity(2);
+                require_args.push(import_path);
+                require_args.push(Expr::init(
                     E::Object {
-                        // SAFETY: bump-owned slice; never grown via this Vec.
-                        properties: unsafe { G::PropertyList::from_bump_slice(object_properties) },
+                        properties: object_properties,
                         is_single_line: true,
                         ..Default::default()
                     },
                     Loc { start: 0 },
-                );
+                ));
                 let require_call = Expr::init(
                     E::Call {
                         target: require_property,
-                        // SAFETY: bump-owned slice; never grown via this Vec.
-                        args: unsafe { bun_ast::ExprNodeList::from_bump_slice(require_args) },
+                        args: require_args,
                         ..Default::default()
                     },
                     Loc { start: 0 },
@@ -1101,17 +1099,13 @@ pub mod parse_worker {
                     Loc { start: 0 },
                 );
 
-                let require_args = bump.alloc_slice_fill_default::<Expr>(1);
-                require_args[0] = import_path;
-
                 let root = Expr::init(
                     E::Call {
                         target: Expr {
                             data: ast::ExprData::ERequireCallTarget,
                             loc: Loc { start: 0 },
                         },
-                        // SAFETY: bump-owned slice; never grown via this Vec.
-                        args: unsafe { bun_ast::ExprNodeList::from_bump_slice(require_args) },
+                        args: bun_ast::ExprNodeList::init_one(import_path),
                         ..Default::default()
                     },
                     Loc { start: 0 },
@@ -2862,12 +2856,7 @@ pub mod parse_worker {
         // dealloc the box without running Drop.
         // SAFETY: `result` came from `bun_core::heap::into_raw(Box<Result>)`
         // above; uniquely owned. Dealloc with the same layout, no field Drop.
-        unsafe {
-            std::alloc::dealloc(
-                result.cast::<u8>(),
-                std::alloc::Layout::new::<Result>(),
-            )
-        };
+        unsafe { std::alloc::dealloc(result.cast::<u8>(), std::alloc::Layout::new::<Result>()) };
     }
 
     pub fn on_complete(result: *mut Result) {
@@ -2882,12 +2871,7 @@ pub mod parse_worker {
         // See `on_complete_mini` for why this is `dealloc`, not `drop(take(_))`.
         // SAFETY: `result` came from `bun_core::heap::into_raw(Box<Result>)`
         // above; uniquely owned. Dealloc with the same layout, no field Drop.
-        unsafe {
-            std::alloc::dealloc(
-                result.cast::<u8>(),
-                std::alloc::Layout::new::<Result>(),
-            )
-        };
+        unsafe { std::alloc::dealloc(result.cast::<u8>(), std::alloc::Layout::new::<Result>()) };
     }
 } // end mod parse_worker
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -7514,13 +7514,12 @@ pub mod bv2_impl {
                     .slice_mut()
                     .sort_by(|a, b| strings::order(&a.export_alias, &b.export_alias));
 
-                // Zig value-copies the Vec header so both `result[_]` and the
-                // map slot share the backing buffer; `rename_symbols_in_chunk`
-                // re-reads `imports_from_other_chunks.values()` afterwards. Taking
-                // would leave the map slot empty and break that consumer.
+                // `rename_symbols_in_chunk` re-reads
+                // `imports_from_other_chunks.values()` afterwards, so we can't
+                // take ownership of the map slot here.
                 list.push(CrossChunkImport {
                     chunk_index,
-                    sorted_import_items: import_items.shallow_copy(),
+                    sorted_import_items: import_items.clone(),
                 });
             }
 

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -693,7 +693,7 @@ pub fn compute_chunks(
     // is only assigned here on success, so no rollback guard is needed.)
     this.unique_key_buf = unique_key_builder.move_to_slice();
 
-    Ok(sorted_chunks.to_owned_slice())
+    Ok(sorted_chunks.into_boxed_slice())
     // TODO(port): return type — Zig returns []Chunk allocated by this.arena(); here we return Box<[Chunk]>.
     // Phase B: confirm ownership of `chunks` slice (sorted_chunks Vec backing storage).
 }

--- a/src/bundler/linker_context/computeCrossChunkDependencies.rs
+++ b/src/bundler/linker_context/computeCrossChunkDependencies.rs
@@ -589,12 +589,16 @@ fn compute_cross_chunk_dependencies_with_chunk_metas(
                                 c.arena(),
                             );
                         for item in cross_chunk_import.sorted_import_items.slice() {
+                            // `StoreStr` borrows raw; `sorted_import_items` is
+                            // dropped on the next `list.clear()`, so copy the
+                            // alias bytes into the arena (per StoreStr contract).
+                            let alias = c.arena().alloc_slice_copy(item.export_alias.as_ref());
                             clauses.push(bun_ast::ClauseItem {
                                 name: bun_ast::LocRef {
                                     ref_: Some(item.r#ref),
                                     loc: bun_ast::Loc::EMPTY,
                                 },
-                                alias: bun_ast::StoreStr::new(item.export_alias.as_ref()),
+                                alias: bun_ast::StoreStr::new(alias),
                                 alias_loc: bun_ast::Loc::EMPTY,
                                 original_name: bun_ast::StoreStr::new(b"" as &[u8]),
                             });

--- a/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
+++ b/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
@@ -70,7 +70,7 @@ pub fn find_imported_parts_in_js_order(
 
     // PORT NOTE: reshaped for borrowck — capture before constructing visitor
     let with_code_splitting = this.graph.code_splitting;
-    let with_scb = this.graph.is_scb_bitset.bit_length > 0;
+    let with_scb = this.graph.is_scb_bitset.bit_length() > 0;
 
     // PORT NOTE: the Zig visitor holds a *LinkerContext alongside SoA column slices
     // borrowed from it, and mutates one column (`entry_point_chunk_index`). Rust

--- a/src/bundler/linker_context/renameSymbolsInChunk.rs
+++ b/src/bundler/linker_context/renameSymbolsInChunk.rs
@@ -412,7 +412,7 @@ pub unsafe fn rename_symbols_in_chunk(
                 );
             }
             // Zig: `@TypeOf(r.number_scope_pool.hive.used).initEmpty()`.
-            r.number_scope_pool.hive.used = bun_collections::hive_array::HiveBitSet::init_empty();
+            r.number_scope_pool.reset();
         }
     }
 

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -831,7 +831,7 @@ pub fn scan_imports_and_exports(
                 let entry_point_part_index = this.graph.add_part_to_file(
                     source_index,
                     Part {
-                        dependencies: Vec::<Dependency>::move_from_list(dependencies),
+                        dependencies,
                         can_be_removed_if_unused: false,
                         ..Default::default()
                     },

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2124,7 +2124,7 @@ fn parse_data_loader(
         }
     };
     let mut ast = bun_ast::Ast::from_parts(parts);
-    ast.symbols = bun_ast::symbol::List::from_owned_slice(symbols.into_boxed_slice());
+    ast.symbols = symbols;
 
     return Some(ParseResult {
         ast,

--- a/src/bundler/ungate_support.rs
+++ b/src/bundler/ungate_support.rs
@@ -147,9 +147,7 @@ pub type CrossChunkImportItemList = Vec<CrossChunkImportItem>;
 #[derive(Default)]
 pub struct CrossChunkImport {
     pub chunk_index: IndexInt,
-    /// Borrowed view into `ImportsFromOtherChunks` — Zig's `BabyList` has no
-    /// destructor, so dropping `CrossChunkImport` must not free this buffer.
-    pub sorted_import_items: core::mem::ManuallyDrop<CrossChunkImportItemList>,
+    pub sorted_import_items: CrossChunkImportItemList,
 }
 /// `Chunk.zig:ImportsFromOtherChunks`.
 pub mod cross_chunk_import {

--- a/src/collections/StaticHashMap.rs
+++ b/src/collections/StaticHashMap.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 // https://github.com/lithdew/rheia/blob/162293d0f0e8d6572a8954c0add83f13f76b3cc6/hash_map.zig
 // Apache License 2.0
 

--- a/src/collections/array_hash_map.rs
+++ b/src/collections/array_hash_map.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)]
 //! Port of Zig's `std.ArrayHashMap` family + Bun's string-keyed wrappers
 //! (`bun.StringArrayHashMap`, `bun.StringHashMap`,
 //! `bun.CaseInsensitiveASCIIStringArrayHashMap`, `bun.StringHashMapUnowned`).

--- a/src/collections/array_hash_map.rs
+++ b/src/collections/array_hash_map.rs
@@ -206,40 +206,24 @@ pub struct Entry<'a, K, V> {
     pub value_ptr: &'a mut V,
 }
 
-/// Insertion-order iterator yielding `Entry`. Resettable (Zig callers do
-/// `it.reset()` to rewind; here `index = 0`).
-pub struct Iter<'a, K, V> {
-    keys: *mut K,
-    values: *mut V,
-    len: usize,
-    index: usize,
-    _marker: PhantomData<&'a mut [(K, V)]>,
-}
-
-impl<'a, K, V> Iter<'a, K, V> {
-    #[inline]
-    pub fn reset(&mut self) {
-        self.index = 0;
-    }
-}
+/// Insertion-order iterator yielding `Entry`. The two backing columns are
+/// distinct `Vec`s, so a safe `Zip<IterMut, IterMut>` already yields the
+/// disjoint `(&mut K, &mut V)` pair Zig's `*K`/`*V` expressed.
+pub struct Iter<'a, K, V>(
+    core::iter::Zip<core::slice::IterMut<'a, K>, core::slice::IterMut<'a, V>>,
+);
 
 impl<'a, K, V> Iterator for Iter<'a, K, V> {
     type Item = Entry<'a, K, V>;
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        if self.index >= self.len {
-            return None;
-        }
-        let i = self.index;
-        self.index += 1;
-        // SAFETY: `keys`/`values` point at `len`-element Vec backing arrays
-        // borrowed mutably for `'a`; each index is yielded at most once so the
-        // returned `&mut`s are disjoint.
-        unsafe {
-            Some(Entry {
-                key_ptr: &mut *self.keys.add(i),
-                value_ptr: &mut *self.values.add(i),
-            })
-        }
+        self.0
+            .next()
+            .map(|(key_ptr, value_ptr)| Entry { key_ptr, value_ptr })
+    }
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
     }
 }
 
@@ -506,31 +490,6 @@ impl<K, V, C, A: MapAllocator> ArrayHashMap<K, V, C, A> {
         Ok(())
     }
 
-    /// Zig: `map.entries.len = n` after `ensureTotalCapacity(n)` — bulk-resize
-    /// the backing columns so callers can `keys_mut().copy_from_slice(...)` /
-    /// `values_mut().copy_from_slice(...)` and then `re_index()`. Mirrors the
-    /// pattern in `lockfile/bun.lockb.zig`'s `Serializer.load`.
-    ///
-    /// # Safety
-    /// `n` must not exceed reserved capacity, and every element in
-    /// `old_len..n` of each column must be fully written before any read
-    /// (including `re_index`, which reads `keys`). For `Copy` POD keys/values
-    /// (the only callers today) the intermediate uninit window is sound as
-    /// long as it is filled immediately.
-    pub unsafe fn set_entries_len(&mut self, n: usize) {
-        debug_assert!(n <= self.keys.capacity());
-        debug_assert!(n <= self.values.capacity());
-        debug_assert!(n <= self.hashes.capacity());
-        // SAFETY: caller contract above; matches Zig `.entries.len = n`.
-        unsafe {
-            self.keys.set_len(n);
-            self.values.set_len(n);
-            self.hashes.set_len(n);
-        }
-        // Caller is about to overwrite keys/values then `re_index()`.
-        self.drop_index();
-    }
-
     /// Zig `ensureTotalCapacityContext`: same as `ensure_total_capacity` but
     /// takes an explicit `ctx` for the stored key type. This port maintains no
     /// separate index header (lookup scans the cached `hashes` vec), so the
@@ -670,13 +629,7 @@ impl<K, V, C, A: MapAllocator> ArrayHashMap<K, V, C, A> {
     }
 
     pub fn iterator(&mut self) -> Iter<'_, K, V> {
-        Iter {
-            keys: self.keys.as_mut_ptr(),
-            values: self.values.as_mut_ptr(),
-            len: self.keys.len(),
-            index: 0,
-            _marker: PhantomData,
-        }
+        Iter(self.keys.iter_mut().zip(self.values.iter_mut()))
     }
 
     pub fn clear_retaining_capacity(&mut self) {
@@ -722,20 +675,19 @@ impl<K, V, C, A: MapAllocator> ArrayHashMap<K, V, C, A> {
     #[inline]
     fn find_hash<F: Fn(&K, usize) -> bool>(&self, h: u32, eq: F) -> Option<usize> {
         if let Some(index) = self.index.as_deref() {
-            let hashes = self.hashes.as_ptr();
-            let keys = self.keys.as_ptr();
+            let hashes = &self.hashes[..];
+            let keys = &self.keys[..];
             return index
                 .find(spread_hash(h), |&i| {
-                    let i = i as usize;
-                    // SAFETY: bounds-check elision on the hot probe path.
                     // Every `i` stored in `self.index` satisfies
                     // `i < self.hashes.len() == self.keys.len()` — it was
                     // inserted by `push_entry`/`rebuild_index` with that
                     // bound, and every path that shrinks or permutes those
                     // vecs either patches the index in place
                     // (`index_swap_remove`/`index_remove_tail`) or calls
-                    // `drop_index()` first.
-                    unsafe { *hashes.add(i) == h && eq(&*keys.add(i), i) }
+                    // `drop_index()` first — so this bounds check never fires.
+                    let i = i as usize;
+                    hashes[i] == h && eq(&keys[i], i)
                 })
                 .map(|&i| i as usize);
         }
@@ -786,7 +738,7 @@ impl<K, V, C, A: MapAllocator> ArrayHashMap<K, V, C, A> {
     }
 
     /// Invalidate the accelerator. Called by operations that permute entry
-    /// indices wholesale (`sort`, `re_index`, bulk `set_entries_len`); paired
+    /// indices wholesale (`sort`, `re_index`, bulk `fill_from_columns`); paired
     /// with an immediate `rebuild_index()` when the map is past the threshold
     /// so subsequent lookups never silently fall back to O(n) linear scan.
     /// Point removals (`pop`/`swap_remove`) instead patch the index in place
@@ -881,22 +833,15 @@ impl<K, V, C, A: MapAllocator> ArrayHashMap<K, V, C, A> {
     }
 
     fn gop_at(&mut self, index: usize, found_existing: bool) -> GetOrPutResult<'_, K, V> {
-        // SAFETY: `keys` and `values` are distinct allocations; producing one
-        // `&mut` into each is sound even though both derive from `&mut self`.
-        // `index < self.keys.len() == self.values.len()` — every caller
-        // (`get_or_put*`/`put_index`) passes the index just returned by
-        // `push_entry` or `find_hash`.
-        let (key_ptr, value_ptr) = unsafe {
-            (
-                &mut *self.keys.as_mut_ptr().add(index),
-                &mut *self.values.as_mut_ptr().add(index),
-            )
-        };
+        // `keys` and `values` are distinct struct fields; borrowck permits one
+        // `&mut` into each simultaneously. Every caller (`get_or_put*`/
+        // `put_index`) passes the index just returned by `push_entry` or
+        // `find_hash`, so `index < len`.
         GetOrPutResult {
             found_existing,
             index,
-            key_ptr,
-            value_ptr,
+            key_ptr: &mut self.keys[index],
+            value_ptr: &mut self.values[index],
         }
     }
 
@@ -997,6 +942,39 @@ impl<K, V, C: ArrayHashContext<K>, A: MapAllocator> ArrayHashMap<K, V, C, A> {
             self.hashes[i] = self.ctx.hash(k);
         }
         self.drop_index();
+        if self.keys.len() > INDEX_THRESHOLD {
+            self.rebuild_index();
+        }
+        Ok(())
+    }
+
+    /// Bulk-load the map from parallel key/value iterators, replacing any
+    /// existing contents. Safe replacement for the Zig `entries.len = n;
+    /// keys.copy_from_slice(...); values.copy_from_slice(...); re_index()`
+    /// idiom (`lockfile/bun.lockb.zig`'s `Serializer.load`): instead of
+    /// exposing an uninitialised window via `Vec::set_len`, the columns are
+    /// filled by `extend` and the hash column / index are derived from the
+    /// final keys. Panics if the two iterators yield different lengths.
+    pub fn fill_from_columns(
+        &mut self,
+        keys: impl IntoIterator<Item = K>,
+        values: impl IntoIterator<Item = V>,
+    ) -> Result<(), AllocError> {
+        self.keys.clear();
+        self.values.clear();
+        self.hashes.clear();
+        self.drop_index();
+        self.keys.extend(keys);
+        self.values.extend(values);
+        assert_eq!(
+            self.keys.len(),
+            self.values.len(),
+            "fill_from_columns: key/value iterator length mismatch",
+        );
+        self.hashes.reserve(self.keys.len());
+        for k in &self.keys {
+            self.hashes.push(self.ctx.hash(k));
+        }
         if self.keys.len() > INDEX_THRESHOLD {
             self.rebuild_index();
         }
@@ -1574,8 +1552,7 @@ impl<A: Allocator + Default> StringHashMapKey<A> {
     #[inline]
     pub const fn borrowed(s: &'static [u8]) -> Self {
         // `&[u8]`'s pointer is always non-null (dangling for `len == 0`).
-        // SAFETY: `as_ptr()` on a slice reference is never null.
-        let ptr = unsafe { core::ptr::NonNull::new_unchecked(s.as_ptr() as *mut u8) };
+        let ptr = core::ptr::NonNull::from_ref(s).cast::<u8>();
         Self {
             ptr,
             len_tag: s.len(),
@@ -1597,8 +1574,8 @@ impl<A: Allocator + Default> StringHashMapKey<A> {
         // is the same instance. `into_raw_with_allocator` because on current
         // nightly `Box::into_raw` is restricted to `Box<T, Global>`.
         let (raw, _alloc) = Box::into_raw_with_allocator(b);
-        // SAFETY: `Box::into_raw_with_allocator` never returns null.
-        let ptr = unsafe { core::ptr::NonNull::new_unchecked(raw.cast::<u8>()) };
+        // `Box::into_raw_with_allocator` never returns null.
+        let ptr = core::ptr::NonNull::new(raw.cast::<u8>()).unwrap();
         Self {
             ptr,
             len_tag: len | SHMK_OWNED_BIT,

--- a/src/collections/bit_set.rs
+++ b/src/collections/bit_set.rs
@@ -36,6 +36,8 @@
 //!   allocator, in order to save space.
 
 use core::mem;
+use core::ptr::{self, NonNull};
+use core::slice;
 
 use bun_alloc::AllocError;
 
@@ -768,18 +770,46 @@ impl<const SIZE: usize, const NUM_MASKS: usize> ArrayBitSet<SIZE, NUM_MASKS> {
 
 /// A bit set with runtime-known size, backed by an allocated slice of usize.
 ///
-/// Storage is owned via `Box<[usize]>` and freed on `Drop`. For non-owning
-/// views into a shared buffer (e.g. `DynamicBitSetList`), use `BitSetRef` /
-/// `BitSetMut`.
-#[derive(Default)]
+/// Storage is an owned `Box<[usize]>` stored as a thin pointer (the slice
+/// length is always `num_masks(bit_length)`, so the fat-pointer length word
+/// is redundant) and freed on `Drop`. For non-owning views into a shared
+/// buffer (e.g. `DynamicBitSetList`), use `BitSetRef` / `BitSetMut`.
 pub struct DynamicBitSetUnmanaged {
-    /// The number of valid items in this bit set
-    pub bit_length: usize,
+    /// The number of valid items in this bit set.
+    ///
+    /// Private because the `masks` invariant (and thus `Drop`) derives the
+    /// allocation length from it. Read via `bit_length()` / `capacity()`;
+    /// mutate via `resize()`.
+    bit_length: usize,
 
     /// The bit masks, ordered with lower indices first.
     /// Padding bits at the end must be zeroed.
-    /// `len() == num_masks(bit_length)`; empty for `bit_length == 0`.
-    masks: Box<[usize]>,
+    ///
+    /// Invariant: `(masks, num_masks(bit_length))` is the `(data, len)` of a
+    /// `Box<[usize]>` — `NonNull::dangling()` with length 0 when
+    /// `bit_length == 0`, otherwise a live allocation of exactly
+    /// `num_masks(bit_length)` words. All access goes through
+    /// `masks_slice{,_mut}` / `take_box` / `from_box`.
+    masks: NonNull<usize>,
+}
+
+const _: () = assert!(mem::size_of::<DynamicBitSetUnmanaged>() == 2 * mem::size_of::<usize>());
+
+impl Default for DynamicBitSetUnmanaged {
+    #[inline(always)]
+    fn default() -> Self {
+        Self {
+            bit_length: 0,
+            masks: NonNull::dangling(),
+        }
+    }
+}
+
+impl Drop for DynamicBitSetUnmanaged {
+    #[inline]
+    fn drop(&mut self) {
+        drop(self.take_box());
+    }
 }
 
 /// Shared borrowed view of a bitset's mask words. `Copy`; binary ops on
@@ -802,7 +832,7 @@ impl<'a> From<&'a DynamicBitSetUnmanaged> for BitSetRef<'a> {
     fn from(s: &'a DynamicBitSetUnmanaged) -> Self {
         Self {
             bit_length: s.bit_length,
-            masks: &s.masks,
+            masks: s.masks_slice(),
         }
     }
 }
@@ -895,14 +925,15 @@ impl<'a> BitSetMut<'a> {
 
     pub fn copy_into<'b>(&mut self, other: impl Into<BitSetRef<'b>>) {
         let other = other.into();
+        debug_assert!(self.bit_length >= other.bit_length);
         let bit_length = self.bit_length;
         if bit_length == 0 {
             return;
         }
         let num_masks = self.masks.len();
-        for (a, &b) in self.masks.iter_mut().zip(other.masks) {
-            *a = b;
-        }
+        let src_masks = other.masks.len();
+        self.masks[..src_masks].copy_from_slice(other.masks);
+        self.masks[src_masks..].fill(0);
         let padding_bits =
             u32::try_from(num_masks * DYN_MASK_BITS as usize - bit_length).expect("int cast");
         let last_item_mask = usize::MAX >> padding_bits;
@@ -920,16 +951,50 @@ const DYN_MASK_BITS: u32 = usize::BITS;
 impl DynamicBitSetUnmanaged {
     pub const EMPTY: fn() -> Self = Self::default;
 
+    /// Construct from an owned mask buffer. `masks.len()` must equal
+    /// `num_masks(bit_length)`.
+    #[inline(always)]
+    fn from_box(bit_length: usize, masks: Box<[usize]>) -> Self {
+        debug_assert_eq!(masks.len(), Self::num_masks(bit_length));
+        let ptr = Box::into_raw(masks).cast::<usize>();
+        // SAFETY: `Box::into_raw` never returns null; for an empty slice it
+        // yields `NonNull::dangling()`.
+        let masks = unsafe { NonNull::new_unchecked(ptr) };
+        Self { bit_length, masks }
+    }
+
+    /// Take ownership of the mask buffer, leaving `self` as a valid empty
+    /// bitset (`bit_length == 0`, dangling pointer).
+    #[inline(always)]
+    fn take_box(&mut self) -> Box<[usize]> {
+        let len = Self::num_masks(self.bit_length);
+        let data = mem::replace(&mut self.masks, NonNull::dangling()).as_ptr();
+        self.bit_length = 0;
+        // SAFETY: the `(masks, num_masks(bit_length))` invariant guarantees
+        // this is exactly the `(data, len)` that `Box::<[usize]>::into_raw`
+        // produced in `from_box` (or the dangling/0 empty box for a default
+        // instance). `self` was just reset to empty, so this is the unique
+        // reconstruction.
+        unsafe { Box::from_raw(ptr::slice_from_raw_parts_mut(data, len)) }
+    }
+
     /// Borrow the mask words as a shared slice of length `num_masks(bit_length)`.
     #[inline(always)]
     pub fn masks_slice(&self) -> &[usize] {
-        &self.masks
+        let len = Self::num_masks(self.bit_length);
+        // SAFETY: the `(masks, num_masks(bit_length))` invariant guarantees
+        // `masks` points to `len` initialized words owned by `self` (or is
+        // dangling with `len == 0`). The returned borrow is tied to `&self`.
+        unsafe { slice::from_raw_parts(self.masks.as_ptr(), len) }
     }
 
     /// Borrow the mask words as an exclusive slice of length `num_masks(bit_length)`.
     #[inline(always)]
     pub fn masks_slice_mut(&mut self) -> &mut [usize] {
-        &mut self.masks
+        let len = Self::num_masks(self.bit_length);
+        // SAFETY: as `masks_slice`; `&mut self` guarantees exclusive access to
+        // the owned allocation for the lifetime of the returned borrow.
+        unsafe { slice::from_raw_parts_mut(self.masks.as_ptr(), len) }
     }
 
     #[inline(always)]
@@ -941,7 +1006,7 @@ impl DynamicBitSetUnmanaged {
     pub fn as_mut(&mut self) -> BitSetMut<'_> {
         BitSetMut {
             bit_length: self.bit_length,
-            masks: &mut self.masks,
+            masks: self.masks_slice_mut(),
         }
     }
 
@@ -969,24 +1034,27 @@ impl DynamicBitSetUnmanaged {
 
         if new_masks == 0 {
             debug_assert!(new_len == 0);
-            self.masks = Box::default();
-            self.bit_length = 0;
+            drop(self.take_box());
             return Ok(());
         }
 
         if new_masks != old_masks {
-            let mut v = Vec::from(mem::take(&mut self.masks));
+            let mut v = self.take_box().into_vec();
             if new_masks > v.len() {
                 if let Err(e) = v.try_reserve_exact(new_masks - v.len()) {
                     // Restore the original allocation so `self` stays valid.
-                    self.masks = v.into_boxed_slice();
+                    *self = Self::from_box(old_len, v.into_boxed_slice());
                     let _ = e;
                     return Err(AllocError);
                 }
             }
             v.resize(new_masks, bool_mask_usize(fill));
-            self.masks = v.into_boxed_slice();
+            *self = Self::from_box(new_len, v.into_boxed_slice());
+        } else {
+            self.bit_length = new_len;
         }
+
+        let masks = self.masks_slice_mut();
 
         // If we increased in size, we need to set any new bits
         // to the fill value.
@@ -996,7 +1064,7 @@ impl DynamicBitSetUnmanaged {
                 let old_padding_bits =
                     u32::try_from(old_masks * DYN_MASK_BITS as usize - old_len).expect("int cast");
                 let old_mask = usize::MAX >> old_padding_bits;
-                self.masks[old_masks - 1] |= !old_mask;
+                masks[old_masks - 1] |= !old_mask;
             }
             // new mask words were filled by `v.resize` above
         }
@@ -1006,10 +1074,9 @@ impl DynamicBitSetUnmanaged {
             let padding_bits =
                 u32::try_from(new_masks * DYN_MASK_BITS as usize - new_len).expect("int cast");
             let last_item_mask = usize::MAX >> padding_bits;
-            self.masks[new_masks - 1] &= last_item_mask;
+            masks[new_masks - 1] &= last_item_mask;
         }
 
-        self.bit_length = new_len;
         Ok(())
     }
 
@@ -1017,13 +1084,19 @@ impl DynamicBitSetUnmanaged {
     pub fn clone(&self) -> Result<Self, AllocError> {
         let mut copy = Self::default();
         copy.resize(self.bit_length, false)?;
-        copy.masks.copy_from_slice(&self.masks);
+        copy.masks_slice_mut().copy_from_slice(self.masks_slice());
         Ok(copy)
     }
 
     /// Returns the number of bits in this bit set
     #[inline(always)]
     pub fn capacity(&self) -> usize {
+        self.bit_length
+    }
+
+    /// Returns the number of bits in this bit set (Zig spelling of `capacity()`).
+    #[inline(always)]
+    pub fn bit_length(&self) -> usize {
         self.bit_length
     }
 
@@ -1042,7 +1115,7 @@ impl DynamicBitSetUnmanaged {
     }
 
     pub fn bytes(&self) -> &[u8] {
-        bun_core::cast_slice::<usize, u8>(&self.masks)
+        bun_core::cast_slice::<usize, u8>(self.masks_slice())
     }
 
     /// Returns the total number of set bits in this bit set.
@@ -1061,7 +1134,7 @@ impl DynamicBitSetUnmanaged {
             Self::num_masks(self.bit_length),
             Self::num_masks(other.bit_length)
         );
-        for (a, b) in self.masks.iter().zip(other.masks) {
+        for (a, b) in self.masks_slice().iter().zip(other.masks) {
             if (a & b) != 0 {
                 return true;
             }
@@ -1117,14 +1190,15 @@ impl DynamicBitSetUnmanaged {
             return;
         }
         let num_masks = Self::num_masks(self.bit_length);
-        for (a, &b) in self.masks.iter_mut().zip(toggles.masks) {
+        let masks = self.masks_slice_mut();
+        for (a, &b) in masks.iter_mut().zip(toggles.masks) {
             *a ^= b;
         }
 
         let padding_bits =
             u32::try_from(num_masks * DYN_MASK_BITS as usize - bit_length).expect("int cast");
         let last_item_mask = usize::MAX >> padding_bits;
-        self.masks[num_masks - 1] &= last_item_mask;
+        masks[num_masks - 1] &= last_item_mask;
     }
 
     pub fn set_all(&mut self, value: bool) {
@@ -1181,7 +1255,7 @@ impl DynamicBitSetUnmanaged {
     pub fn set_intersection<'a>(&mut self, other: impl Into<BitSetRef<'a>>) {
         let other = other.into();
         debug_assert!(other.bit_length == self.bit_length);
-        for (a, &b) in self.masks.iter_mut().zip(other.masks) {
+        for (a, &b) in self.masks_slice_mut().iter_mut().zip(other.masks) {
             *a &= b;
         }
     }
@@ -1194,7 +1268,12 @@ impl DynamicBitSetUnmanaged {
         let other = other.into();
         let third = third.into();
         debug_assert!(other.bit_length == self.bit_length);
-        for ((a, &b), &c) in self.masks.iter_mut().zip(other.masks).zip(third.masks) {
+        for ((a, &b), &c) in self
+            .masks_slice_mut()
+            .iter_mut()
+            .zip(other.masks)
+            .zip(third.masks)
+        {
             *a = (*a & !b) & !c;
         }
     }
@@ -1202,7 +1281,7 @@ impl DynamicBitSetUnmanaged {
     pub fn set_exclude<'a>(&mut self, other: impl Into<BitSetRef<'a>>) {
         let other = other.into();
         debug_assert!(other.bit_length == self.bit_length);
-        for (a, &b) in self.masks.iter_mut().zip(other.masks) {
+        for (a, &b) in self.masks_slice_mut().iter_mut().zip(other.masks) {
             *a &= !b;
         }
     }
@@ -1255,7 +1334,7 @@ impl DynamicBitSetUnmanaged {
         if self.bit_length != other.bit_length {
             return false;
         }
-        for (&a, &b) in self.masks.iter().zip(other.masks) {
+        for (&a, &b) in self.masks_slice().iter().zip(other.masks) {
             if a & b != b {
                 return false;
             }

--- a/src/collections/bit_set.rs
+++ b/src/collections/bit_set.rs
@@ -1268,6 +1268,7 @@ impl DynamicBitSetUnmanaged {
         let other = other.into();
         let third = third.into();
         debug_assert!(other.bit_length == self.bit_length);
+        debug_assert!(third.bit_length == self.bit_length);
         for ((a, &b), &c) in self
             .masks_slice_mut()
             .iter_mut()

--- a/src/collections/bit_set.rs
+++ b/src/collections/bit_set.rs
@@ -36,8 +36,6 @@
 //!   allocator, in order to save space.
 
 use core::mem;
-use core::ptr;
-use core::slice;
 
 use bun_alloc::AllocError;
 
@@ -768,26 +766,148 @@ impl<const SIZE: usize, const NUM_MASKS: usize> ArrayBitSet<SIZE, NUM_MASKS> {
 
 // ──────────────────────── DynamicBitSetUnmanaged ────────────────────────
 
-/// A bit set with runtime-known size, backed by an allocated slice
-/// of usize.  The allocator must be tracked externally by the user.
+/// A bit set with runtime-known size, backed by an allocated slice of usize.
 ///
-// TODO(port): the Zig type stores `masks: [*]MaskInt` where `masks[-1]` holds
-// the true allocation length (needed because Zig's allocator API requires the
-// original length on free). The Rust port keeps the same layout because
-// `List` constructs borrowed views into a shared buffer that must look like
-// freestanding `DynamicBitSetUnmanaged`s. Phase B may refactor to `Vec<usize>`
-// once `List` is reworked.
+/// Storage is owned via `Box<[usize]>` and freed on `Drop`. For non-owning
+/// views into a shared buffer (e.g. `DynamicBitSetList`), use `BitSetRef` /
+/// `BitSetMut`.
+#[derive(Default)]
 pub struct DynamicBitSetUnmanaged {
     /// The number of valid items in this bit set
     pub bit_length: usize,
 
     /// The bit masks, ordered with lower indices first.
     /// Padding bits at the end must be zeroed.
-    pub masks: *mut usize,
-    // This pointer is one usize after the actual allocation.
-    // That slot holds the size of the true allocation, which
-    // is needed by Zig's allocator interface in case a shrink
-    // fails.
+    /// `len() == num_masks(bit_length)`; empty for `bit_length == 0`.
+    masks: Box<[usize]>,
+}
+
+/// Shared borrowed view of a bitset's mask words. `Copy`; binary ops on
+/// owned/mutable bitsets accept any type that converts into this.
+#[derive(Clone, Copy)]
+pub struct BitSetRef<'a> {
+    pub bit_length: usize,
+    masks: &'a [usize],
+}
+
+/// Exclusive borrowed view of a bitset's mask words. Returned by
+/// `DynamicBitSetList::at_mut`.
+pub struct BitSetMut<'a> {
+    pub bit_length: usize,
+    masks: &'a mut [usize],
+}
+
+impl<'a> From<&'a DynamicBitSetUnmanaged> for BitSetRef<'a> {
+    #[inline(always)]
+    fn from(s: &'a DynamicBitSetUnmanaged) -> Self {
+        Self {
+            bit_length: s.bit_length,
+            masks: &s.masks,
+        }
+    }
+}
+impl<'a> From<&'a DynamicBitSet> for BitSetRef<'a> {
+    #[inline(always)]
+    fn from(s: &'a DynamicBitSet) -> Self {
+        Self::from(&s.unmanaged)
+    }
+}
+impl<'a, 'b> From<&'b BitSetRef<'a>> for BitSetRef<'a> {
+    #[inline(always)]
+    fn from(r: &'b BitSetRef<'a>) -> Self {
+        *r
+    }
+}
+impl<'a, 'b> From<&'b BitSetMut<'a>> for BitSetRef<'b> {
+    #[inline(always)]
+    fn from(r: &'b BitSetMut<'a>) -> Self {
+        Self {
+            bit_length: r.bit_length,
+            masks: r.masks,
+        }
+    }
+}
+
+impl<'a> BitSetRef<'a> {
+    pub fn is_set(&self, index: usize) -> bool {
+        debug_assert!(index < self.bit_length);
+        (self.masks[word_mask_index(index)] & word_mask_bit(index)) != 0
+    }
+
+    pub fn count(&self) -> usize {
+        let mut total: usize = 0;
+        for mask in self.masks {
+            total += mask.count_ones() as usize;
+        }
+        total
+    }
+
+    pub fn eql<'b>(&self, other: impl Into<BitSetRef<'b>>) -> bool {
+        let other = other.into();
+        self.bit_length == other.bit_length && self.masks == other.masks
+    }
+
+    pub fn subset_of<'b>(&self, other: impl Into<BitSetRef<'b>>) -> bool {
+        let other = other.into();
+        if self.bit_length != other.bit_length {
+            return false;
+        }
+        for (&a, &b) in self.masks.iter().zip(other.masks) {
+            if a & b != a {
+                return false;
+            }
+        }
+        true
+    }
+
+    pub fn iterator<const KIND_SET: bool, const DIR_FWD: bool>(
+        &self,
+    ) -> BitSetIterator<'a, KIND_SET, DIR_FWD> {
+        let num_masks = self.masks.len();
+        let padding_bits =
+            u32::try_from(num_masks * DYN_MASK_BITS as usize - self.bit_length).expect("int cast");
+        let last_item_mask = usize::MAX >> padding_bits;
+        BitSetIterator::init(self.masks, last_item_mask)
+    }
+}
+
+impl<'a> BitSetMut<'a> {
+    #[inline(always)]
+    pub fn as_ref(&self) -> BitSetRef<'_> {
+        BitSetRef {
+            bit_length: self.bit_length,
+            masks: self.masks,
+        }
+    }
+
+    pub fn set(&mut self, index: usize) {
+        debug_assert!(index < self.bit_length);
+        self.masks[word_mask_index(index)] |= word_mask_bit(index);
+    }
+
+    pub fn set_union<'b>(&mut self, other: impl Into<BitSetRef<'b>>) {
+        let other = other.into();
+        debug_assert_eq!(other.bit_length, self.bit_length);
+        for (a, &b) in self.masks.iter_mut().zip(other.masks) {
+            *a |= b;
+        }
+    }
+
+    pub fn copy_into<'b>(&mut self, other: impl Into<BitSetRef<'b>>) {
+        let other = other.into();
+        let bit_length = self.bit_length;
+        if bit_length == 0 {
+            return;
+        }
+        let num_masks = self.masks.len();
+        for (a, &b) in self.masks.iter_mut().zip(other.masks) {
+            *a = b;
+        }
+        let padding_bits =
+            u32::try_from(num_masks * DYN_MASK_BITS as usize - bit_length).expect("int cast");
+        let last_item_mask = usize::MAX >> padding_bits;
+        self.masks[num_masks - 1] &= last_item_mask;
+    }
 }
 
 /// The integer type used to represent a mask in this bit set
@@ -797,94 +917,35 @@ pub type DynShiftInt = u32;
 
 const DYN_MASK_BITS: u32 = usize::BITS;
 
-// Never modified — the Zig comment about needing `static mut` was a Zig
-// limitation (no const-ptr → mut-ptr cast at comptime). All writes through
-// `self.masks` are guarded by `num_masks() > 0`, which is false for the empty
-// sentinel (bit_length == 0). Kept in a `RacyCell` (not `.rodata`) so that
-// forming a `*mut usize` to it remains a legally-mutable pointer target —
-// writing through a pointer derived from an immutable `static` would be UB
-// even if it never happens at runtime, and it lets `masks_slice_mut` form a
-// zero-length `&mut [usize]` without provenance hazards.
-static EMPTY_MASKS_DATA: bun_core::RacyCell<[usize; 2]> = bun_core::RacyCell::new([0, 0]);
-
-#[inline(always)]
-fn empty_masks_ptr() -> *mut usize {
-    // SAFETY: pointer arithmetic into a static array; index 1 is in-bounds.
-    // The `*mut` is never written through while pointing at this static.
-    unsafe { EMPTY_MASKS_DATA.get().cast::<usize>().add(1) }
-}
-
-impl Default for DynamicBitSetUnmanaged {
-    fn default() -> Self {
-        Self {
-            bit_length: 0,
-            masks: empty_masks_ptr(),
-        }
-    }
-}
-
 impl DynamicBitSetUnmanaged {
     pub const EMPTY: fn() -> Self = Self::default;
-    // TODO(port): Zig has `pub const empty: Self = .{ ... }` as a const value.
-    // Rust can't const-init a static-mut-derived pointer; callers should use
-    // `DynamicBitSetUnmanaged::default()`.
 
     /// Borrow the mask words as a shared slice of length `num_masks(bit_length)`.
     #[inline(always)]
     pub fn masks_slice(&self) -> &[usize] {
-        let n = Self::num_masks(self.bit_length);
-        // SAFETY: `masks` is never null (defaults to `empty_masks_ptr()`) and
-        // points to at least `n` valid, initialized usize words, maintained by
-        // `resize` / `List::at`. Padding bits in the last word are zeroed.
-        unsafe { slice::from_raw_parts(self.masks, n) }
+        &self.masks
     }
 
     /// Borrow the mask words as an exclusive slice of length `num_masks(bit_length)`.
-    ///
-    /// Note: two `DynamicBitSetUnmanaged` values may share storage (see
-    /// `DynamicBitSetList::at`). Callers must not hold a `masks_slice_mut()`
-    /// borrow on one view while another aliasing view is read or written.
     #[inline(always)]
     pub fn masks_slice_mut(&mut self) -> &mut [usize] {
-        let n = Self::num_masks(self.bit_length);
-        // SAFETY: see `masks_slice`. `&mut self` gives us exclusive access to
-        // *this* struct; the caller is responsible for not aliasing the
-        // underlying storage via another view.
-        unsafe { slice::from_raw_parts_mut(self.masks, n) }
+        &mut self.masks
     }
 
-    /// Raw pointer to the mask words. Use this (not `masks_slice{,_mut}`) when
-    /// `self` and another `DynamicBitSetUnmanaged` may point at the same
-    /// storage and both are accessed in the same operation — forming
-    /// overlapping `&mut [usize]` / `&[usize]` would be UB.
     #[inline(always)]
-    pub fn masks_ptr(&self) -> *mut usize {
-        self.masks
+    pub fn as_ref(&self) -> BitSetRef<'_> {
+        BitSetRef::from(self)
     }
 
-    /// `self.masks[i] = f(self.masks[i], other.masks[i])` for every mask word.
-    /// Centralises the binary set-op loop (`set_union` / `set_intersection` /
-    /// `set_exclude` / `toggle_set` / `copy_into`) behind a single audited
-    /// raw-pointer access. Raw pointers — not `masks_slice{,_mut}` — because
-    /// `other.masks` may alias `self.masks` when both are views from the same
-    /// `DynamicBitSetList`; forming overlapping `&mut [usize]` / `&[usize]`
-    /// would be UB. `f` receives copied `usize` values, so the per-index read
-    /// happens-before the write even when `src == dst`.
     #[inline(always)]
-    fn zip_masks_raw(&mut self, other: &Self, mut f: impl FnMut(usize, usize) -> usize) {
-        let num_masks = Self::num_masks(self.bit_length);
-        let dst = self.masks;
-        let src = other.masks;
-        for i in 0..num_masks {
-            // SAFETY: `i < num_masks(self.bit_length)`; `dst`/`src` each point
-            // at ≥ `num_masks` initialized words (`resize`/`List::at` invariant).
-            // The two pointers may be equal — see method doc.
-            unsafe { *dst.add(i) = f(*dst.add(i), *src.add(i)) };
+    pub fn as_mut(&mut self) -> BitSetMut<'_> {
+        BitSetMut {
+            bit_length: self.bit_length,
+            masks: &mut self.masks,
         }
     }
 
     /// Creates a bit set with no elements present.
-    /// If bit_length is not zero, deinit must eventually be called.
     pub fn init_empty(bit_length: usize) -> Result<Self, AllocError> {
         let mut this = Self::default();
         this.resize(bit_length, false)?;
@@ -892,7 +953,6 @@ impl DynamicBitSetUnmanaged {
     }
 
     /// Creates a bit set with all elements present.
-    /// If bit_length is not zero, deinit must eventually be called.
     pub fn init_full(bit_length: usize) -> Result<Self, AllocError> {
         let mut this = Self::default();
         this.resize(bit_length, true)?;
@@ -901,55 +961,31 @@ impl DynamicBitSetUnmanaged {
 
     /// Resizes to a new bit_length.  If the new length is larger
     /// than the old length, fills any added bits with `fill`.
-    /// If new_len is not zero, deinit must eventually be called.
+    /// On allocation failure `self` is left unchanged.
     pub fn resize(&mut self, new_len: usize, fill: bool) -> Result<(), AllocError> {
         let old_len = self.bit_length;
-
         let old_masks = Self::num_masks(old_len);
         let new_masks = Self::num_masks(new_len);
 
-        // SAFETY: `self.masks - 1` is the start of the true allocation (or the
-        // start of EMPTY_MASKS_DATA), and `(self.masks - 1)[0]` holds its
-        // length. Maintained by this function.
-        let alloc_base = unsafe { self.masks.sub(1) };
-        let old_alloc_len = unsafe { *alloc_base };
-
         if new_masks == 0 {
             debug_assert!(new_len == 0);
-            // SAFETY: alloc_base/old_alloc_len describe a valid allocation
-            // (possibly the static EMPTY_MASKS_DATA, in which case len==0 and
-            // free is a no-op handled by `dyn_free`).
-            unsafe { dyn_free(alloc_base, old_alloc_len) };
-            self.masks = empty_masks_ptr();
+            self.masks = Box::default();
             self.bit_length = 0;
             return Ok(());
         }
 
-        'realloc: {
-            if old_alloc_len == new_masks + 1 {
-                break 'realloc;
-            }
-            // If realloc fails, it may mean one of two things.
-            // If we are growing, it means we are out of memory.
-            // If we are shrinking, it means the allocator doesn't
-            // want to move the allocation.  This means we need to
-            // hold on to the extra 8 bytes required to be able to free
-            // this allocation properly.
-            // SAFETY: alloc_base/old_alloc_len describe the current allocation.
-            let new_alloc = match unsafe { dyn_realloc(alloc_base, old_alloc_len, new_masks + 1) } {
-                Ok(p) => p,
-                Err(err) => {
-                    if new_masks + 1 > old_alloc_len {
-                        return Err(err);
-                    }
-                    break 'realloc;
+        if new_masks != old_masks {
+            let mut v = Vec::from(mem::take(&mut self.masks));
+            if new_masks > v.len() {
+                if let Err(e) = v.try_reserve_exact(new_masks - v.len()) {
+                    // Restore the original allocation so `self` stays valid.
+                    self.masks = v.into_boxed_slice();
+                    let _ = e;
+                    return Err(AllocError);
                 }
-            };
-
-            // SAFETY: new_alloc points to at least new_masks+1 usize words.
-            unsafe { *new_alloc = new_masks + 1 };
-            // SAFETY: new_alloc points to at least new_masks+1 words; +1 is in-bounds.
-            self.masks = unsafe { new_alloc.add(1) };
+            }
+            v.resize(new_masks, bool_mask_usize(fill));
+            self.masks = v.into_boxed_slice();
         }
 
         // If we increased in size, we need to set any new bits
@@ -960,19 +996,9 @@ impl DynamicBitSetUnmanaged {
                 let old_padding_bits =
                     u32::try_from(old_masks * DYN_MASK_BITS as usize - old_len).expect("int cast");
                 let old_mask = usize::MAX >> old_padding_bits;
-                // SAFETY: index in [0, new_masks).
-                unsafe { *self.masks.add(old_masks - 1) |= !old_mask };
+                self.masks[old_masks - 1] |= !old_mask;
             }
-
-            // fill in any new masks
-            if new_masks > old_masks {
-                let fill_value = bool_mask_usize(fill);
-                // SAFETY: range [old_masks, new_masks) is within the allocation.
-                unsafe {
-                    slice::from_raw_parts_mut(self.masks.add(old_masks), new_masks - old_masks)
-                        .fill(fill_value);
-                }
-            }
+            // new mask words were filled by `v.resize` above
         }
 
         // Zero out the padding bits
@@ -980,29 +1006,18 @@ impl DynamicBitSetUnmanaged {
             let padding_bits =
                 u32::try_from(new_masks * DYN_MASK_BITS as usize - new_len).expect("int cast");
             let last_item_mask = usize::MAX >> padding_bits;
-            // SAFETY: new_masks > 0 here.
-            unsafe { *self.masks.add(new_masks - 1) &= last_item_mask };
+            self.masks[new_masks - 1] &= last_item_mask;
         }
 
-        // And finally, save the new length.
         self.bit_length = new_len;
         Ok(())
-    }
-
-    /// deinitializes the array and releases its memory.
-    /// The passed allocator must be the same one used for
-    /// init* or resize in the past.
-    // TODO(port): kept as an explicit method (not `Drop`) because `List` hands
-    // out non-owning `DynamicBitSetUnmanaged` views that must NOT free on drop.
-    pub fn deinit(&mut self) {
-        self.resize(0, false).expect("unreachable");
     }
 
     /// Creates a duplicate of this bit set, using the new allocator.
     pub fn clone(&self) -> Result<Self, AllocError> {
         let mut copy = Self::default();
         copy.resize(self.bit_length, false)?;
-        copy.masks_slice_mut().copy_from_slice(self.masks_slice());
+        copy.masks.copy_from_slice(&self.masks);
         Ok(copy)
     }
 
@@ -1027,9 +1042,7 @@ impl DynamicBitSetUnmanaged {
     }
 
     pub fn bytes(&self) -> &[u8] {
-        // `masks_slice()` already encapsulates the `(ptr, num_masks)` invariant;
-        // reinterpreting `&[usize]` as `&[u8]` is a safe POD cast.
-        bun_core::cast_slice::<usize, u8>(self.masks_slice())
+        bun_core::cast_slice::<usize, u8>(&self.masks)
     }
 
     /// Returns the total number of set bits in this bit set.
@@ -1042,12 +1055,13 @@ impl DynamicBitSetUnmanaged {
         total
     }
 
-    pub fn has_intersection(&self, other: &Self) -> bool {
+    pub fn has_intersection<'a>(&self, other: impl Into<BitSetRef<'a>>) -> bool {
+        let other = other.into();
         debug_assert_eq!(
             Self::num_masks(self.bit_length),
             Self::num_masks(other.bit_length)
         );
-        for (a, b) in self.masks_slice().iter().zip(other.masks_slice()) {
+        for (a, b) in self.masks.iter().zip(other.masks) {
             if (a & b) != 0 {
                 return true;
             }
@@ -1095,19 +1109,22 @@ impl DynamicBitSetUnmanaged {
     /// Flips all bits in this bit set which are present
     /// in the toggles bit set.  Both sets must have the
     /// same bit_length.
-    pub fn toggle_set(&mut self, toggles: &Self) {
+    pub fn toggle_set<'a>(&mut self, toggles: impl Into<BitSetRef<'a>>) {
+        let toggles = toggles.into();
         debug_assert!(toggles.bit_length == self.bit_length);
         let bit_length = self.bit_length;
         if bit_length == 0 {
             return;
         }
         let num_masks = Self::num_masks(self.bit_length);
-        self.zip_masks_raw(toggles, |a, b| a ^ b);
+        for (a, &b) in self.masks.iter_mut().zip(toggles.masks) {
+            *a ^= b;
+        }
 
         let padding_bits =
             u32::try_from(num_masks * DYN_MASK_BITS as usize - bit_length).expect("int cast");
         let last_item_mask = usize::MAX >> padding_bits;
-        self.masks_slice_mut()[num_masks - 1] &= last_item_mask;
+        self.masks[num_masks - 1] &= last_item_mask;
     }
 
     pub fn set_all(&mut self, value: bool) {
@@ -1145,51 +1162,49 @@ impl DynamicBitSetUnmanaged {
         self.masks_slice_mut()[num_masks - 1] &= last_item_mask;
     }
 
-    pub fn copy_into(&mut self, other: &Self) {
-        let bit_length = self.bit_length;
-        // avoid underflow if bit_length is zero
-        if bit_length == 0 {
-            return;
-        }
-
-        let num_masks = Self::num_masks(self.bit_length);
-        self.zip_masks_raw(other, |_, b| b);
-
-        let padding_bits =
-            u32::try_from(num_masks * DYN_MASK_BITS as usize - bit_length).expect("int cast");
-        let last_item_mask = usize::MAX >> padding_bits;
-        self.masks_slice_mut()[num_masks - 1] &= last_item_mask;
+    pub fn copy_into<'a>(&mut self, other: impl Into<BitSetRef<'a>>) {
+        self.as_mut().copy_into(other);
     }
 
     /// Performs a union of two bit sets, and stores the
     /// result in the first one.  Bits in the result are
     /// set if the corresponding bits were set in either input.
     /// The two sets must both be the same bit_length.
-    pub fn set_union(&mut self, other: &Self) {
-        debug_assert!(other.bit_length == self.bit_length);
-        self.zip_masks_raw(other, |a, b| a | b);
+    pub fn set_union<'a>(&mut self, other: impl Into<BitSetRef<'a>>) {
+        self.as_mut().set_union(other);
     }
 
     /// Performs an intersection of two bit sets, and stores
     /// the result in the first one.  Bits in the result are
     /// set if the corresponding bits were set in both inputs.
     /// The two sets must both be the same bit_length.
-    pub fn set_intersection(&mut self, other: &Self) {
+    pub fn set_intersection<'a>(&mut self, other: impl Into<BitSetRef<'a>>) {
+        let other = other.into();
         debug_assert!(other.bit_length == self.bit_length);
-        self.zip_masks_raw(other, |a, b| a & b);
+        for (a, &b) in self.masks.iter_mut().zip(other.masks) {
+            *a &= b;
+        }
     }
 
-    pub fn set_exclude_two(&mut self, other: &Self, third: &Self) {
+    pub fn set_exclude_two<'a, 'b>(
+        &mut self,
+        other: impl Into<BitSetRef<'a>>,
+        third: impl Into<BitSetRef<'b>>,
+    ) {
+        let other = other.into();
+        let third = third.into();
         debug_assert!(other.bit_length == self.bit_length);
-        // Two passes is equivalent to the original fused loop: each word is
-        // independent, so `(a & !b) & !c` per index is associative across passes.
-        self.zip_masks_raw(other, |a, b| a & !b);
-        self.zip_masks_raw(third, |a, c| a & !c);
+        for ((a, &b), &c) in self.masks.iter_mut().zip(other.masks).zip(third.masks) {
+            *a = (*a & !b) & !c;
+        }
     }
 
-    pub fn set_exclude(&mut self, other: &Self) {
+    pub fn set_exclude<'a>(&mut self, other: impl Into<BitSetRef<'a>>) {
+        let other = other.into();
         debug_assert!(other.bit_length == self.bit_length);
-        self.zip_masks_raw(other, |a, b| a & !b);
+        for (a, &b) in self.masks.iter_mut().zip(other.masks) {
+            *a &= !b;
+        }
     }
 
     /// Finds the index of the first set bit.
@@ -1223,34 +1238,24 @@ impl DynamicBitSetUnmanaged {
 
     /// Returns true iff every corresponding bit in both
     /// bit sets are the same.
-    pub fn eql(&self, other: &Self) -> bool {
-        if self.bit_length != other.bit_length {
-            return false;
-        }
-        self.masks_slice() == other.masks_slice()
+    pub fn eql<'a>(&self, other: impl Into<BitSetRef<'a>>) -> bool {
+        self.as_ref().eql(other)
     }
 
     /// Returns true iff the first bit set is the subset
     /// of the second one.
-    pub fn subset_of(&self, other: &Self) -> bool {
-        if self.bit_length != other.bit_length {
-            return false;
-        }
-        for (&a, &b) in self.masks_slice().iter().zip(other.masks_slice()) {
-            if a & b != a {
-                return false;
-            }
-        }
-        true
+    pub fn subset_of<'a>(&self, other: impl Into<BitSetRef<'a>>) -> bool {
+        self.as_ref().subset_of(other)
     }
 
     /// Returns true iff the first bit set is the superset
     /// of the second one.
-    pub fn superset_of(&self, other: &Self) -> bool {
+    pub fn superset_of<'a>(&self, other: impl Into<BitSetRef<'a>>) -> bool {
+        let other = other.into();
         if self.bit_length != other.bit_length {
             return false;
         }
-        for (&a, &b) in self.masks_slice().iter().zip(other.masks_slice()) {
+        for (&a, &b) in self.masks.iter().zip(other.masks) {
             if a & b != b {
                 return false;
             }
@@ -1279,154 +1284,60 @@ impl DynamicBitSetUnmanaged {
     }
 }
 
-/// Do not resize the bitsets!
-///
-/// Single buffer for multiple bitsets of equal length. Does not
-/// implement all methods of DynamicBitSetUnmanaged and should
-/// be used carefully.
-///
-/// `buf` is a raw heap allocation rather than `Box<[usize]>` because `at()` /
-/// `set()` / `set_union()` hand out and write through `*mut usize` views while
-/// only holding `&self`. With `Box<[usize]>`, the only way to reach the data
-/// from `&self` is `Deref` → `&[usize]` → `as_ptr()`, which yields a pointer
-/// with shared-read-only provenance — writing through it (as the old code did
-/// via `.cast_mut()`) is UB under Stacked Borrows. Owning the allocation as a
-/// raw pointer means the heap words are never covered by a `&`/`&mut`
-/// reference, so reads and writes through `at()`-derived pointers carry the
-/// original allocation's full read-write provenance.
+/// Single buffer for `n` bitsets of equal `bit_length`. `at()` / `at_mut()`
+/// hand out borrowed `BitSetRef` / `BitSetMut` views into the shared buffer.
 pub struct DynamicBitSetList {
-    buf: ptr::NonNull<usize>,
-    buf_len: usize,
+    buf: Box<[usize]>,
     pub n: usize,
     pub bit_length: usize,
 }
 
 impl DynamicBitSetList {
     pub fn init_empty(n: usize, bit_length: usize) -> Result<Self, AllocError> {
-        let masks = DynamicBitSetUnmanaged::num_masks(bit_length);
-        let single_bitset_buf_size = masks + 1;
-        let buf_len = single_bitset_buf_size * n;
-
-        if buf_len == 0 {
-            return Ok(Self {
-                buf: ptr::NonNull::dangling(),
-                buf_len: 0,
-                n,
-                bit_length,
-            });
-        }
-
-        let layout = core::alloc::Layout::array::<usize>(buf_len).map_err(|_| AllocError)?;
-        // SAFETY: `buf_len > 0` so layout has nonzero size.
-        let raw = unsafe { std::alloc::alloc_zeroed(layout) }.cast::<usize>();
-        let buf = ptr::NonNull::new(raw).ok_or(AllocError)?;
-
-        for i in 0..n {
-            // SAFETY: `i * single_bitset_buf_size < buf_len`; allocation is
-            // zero-initialized and at least `buf_len` words long.
-            unsafe { *buf.as_ptr().add(i * single_bitset_buf_size) = single_bitset_buf_size };
-        }
-
+        let stride = DynamicBitSetUnmanaged::num_masks(bit_length);
+        let len = n.checked_mul(stride).ok_or(AllocError)?;
+        let mut v = Vec::new();
+        v.try_reserve_exact(len).map_err(|_| AllocError)?;
+        v.resize(len, 0usize);
         Ok(Self {
-            buf,
-            buf_len,
+            buf: v.into_boxed_slice(),
             n,
             bit_length,
         })
     }
 
-    /// Borrow the `i`th bitset as a non-owning `DynamicBitSetUnmanaged` view.
-    ///
-    /// The returned view's `masks` pointer aliases `self.buf`. It is a raw
-    /// pointer with no lifetime, so the borrow checker will **not** prevent
-    /// use-after-free: the caller must ensure `self` is not dropped (and `buf`
-    /// not reallocated — impossible today, no resize API) while the view is
-    /// live. All current callers (`hoisted_install`, `isolated_install`,
-    /// `PackageInstaller::can_run_scripts`) satisfy this by keeping the list
-    /// alive for the view's entire use. The view must not be `deinit`ed.
-    pub fn at(&self, i: usize) -> DynamicBitSetUnmanaged {
+    #[inline(always)]
+    fn stride(&self) -> usize {
+        DynamicBitSetUnmanaged::num_masks(self.bit_length)
+    }
+
+    /// Borrow the `i`th bitset as a shared view.
+    pub fn at(&self, i: usize) -> BitSetRef<'_> {
         debug_assert!(i < self.n, "DynamicBitSetList::at index out of bounds");
-        let num_masks = DynamicBitSetUnmanaged::num_masks(self.bit_length);
-        let single_bitset_buf_size = num_masks + 1;
-
-        let offset = single_bitset_buf_size * i;
-
-        DynamicBitSetUnmanaged {
+        let s = self.stride();
+        BitSetRef {
             bit_length: self.bit_length,
-            // SAFETY: `i < n` (asserted), so `offset + 1 + num_masks <= buf_len`
-            // and the pointer is in-bounds. `buf` is a raw allocation never
-            // reborrowed as `&[usize]`/`&mut [usize]`, so this `*mut` carries
-            // full read-write provenance and writes through it via the returned
-            // view (e.g. from `set`/`set_union`) are sound even though we only
-            // hold `&self` here — `&self` freezes the pointer *value*, not the
-            // pointee.
-            masks: unsafe { self.buf.as_ptr().add(offset).add(1) },
+            masks: &self.buf[i * s..(i + 1) * s],
         }
     }
 
-    pub fn set(&self, i: usize, j: usize) {
-        let mut bitset = self.at(i);
-        bitset.set(j);
-    }
-
-    pub fn set_union(&self, i: usize, other: &DynamicBitSetUnmanaged) {
-        let mut bitset = self.at(i);
-        bitset.set_union(other);
-    }
-}
-
-impl Drop for DynamicBitSetList {
-    fn drop(&mut self) {
-        if self.buf_len == 0 {
-            return;
+    /// Borrow the `i`th bitset as an exclusive view.
+    pub fn at_mut(&mut self, i: usize) -> BitSetMut<'_> {
+        debug_assert!(i < self.n, "DynamicBitSetList::at_mut index out of bounds");
+        let s = self.stride();
+        BitSetMut {
+            bit_length: self.bit_length,
+            masks: &mut self.buf[i * s..(i + 1) * s],
         }
-        let layout = core::alloc::Layout::array::<usize>(self.buf_len).expect("unreachable");
-        // SAFETY: `buf` was allocated in `init_empty` with exactly this layout
-        // and has not been freed (no other code path deallocates it).
-        unsafe { std::alloc::dealloc(self.buf.as_ptr().cast(), layout) };
     }
-}
 
-// `buf` is a uniquely-owned heap allocation of plain `usize`s; moving the
-// owning struct between threads is as safe as moving a `Box<[usize]>`.
-unsafe impl Send for DynamicBitSetList {}
-
-// Raw allocation helpers for DynamicBitSetUnmanaged. These mirror Zig's
-// allocator.alloc/realloc/free with the size-at-[-1] header convention.
-// TODO(port): move to bun_alloc if useful elsewhere.
-
-unsafe fn dyn_free(base: *mut usize, len: usize) {
-    if len == 0 {
-        // EMPTY_MASKS_DATA sentinel — nothing to free.
-        return;
+    pub fn set(&mut self, i: usize, j: usize) {
+        self.at_mut(i).set(j);
     }
-    let layout = core::alloc::Layout::array::<usize>(len).expect("unreachable");
-    // SAFETY: caller guarantees `base` was allocated with this layout.
-    unsafe { std::alloc::dealloc(base.cast(), layout) };
-}
 
-unsafe fn dyn_realloc(
-    base: *mut usize,
-    old_len: usize,
-    new_len: usize,
-) -> Result<*mut usize, AllocError> {
-    let new_layout = core::alloc::Layout::array::<usize>(new_len).map_err(|_| AllocError)?;
-    if old_len == 0 {
-        // SAFETY: new_layout is nonzero size (caller never passes new_len==0
-        // through this path).
-        let p = unsafe { std::alloc::alloc(new_layout) };
-        if p.is_null() {
-            return Err(AllocError);
-        }
-        return Ok(p.cast());
+    pub fn set_union<'a>(&mut self, i: usize, other: impl Into<BitSetRef<'a>>) {
+        self.at_mut(i).set_union(other);
     }
-    let old_layout = core::alloc::Layout::array::<usize>(old_len).expect("unreachable");
-    // SAFETY: caller guarantees `base` was allocated with `old_layout`.
-    let p = unsafe { std::alloc::realloc(base.cast(), old_layout, new_layout.size()) };
-    if p.is_null() {
-        return Err(AllocError);
-    }
-    Ok(p.cast())
 }
 
 // ───────────────────────────── AutoBitSet ─────────────────────────────
@@ -1553,15 +1464,6 @@ impl AutoBitSet {
 // type alias for any external callers.
 pub type AutoBitSetIterator<'a, const KIND_SET: bool, const DIR_FWD: bool> =
     BitSetIterator<'a, KIND_SET, DIR_FWD>;
-
-impl Drop for AutoBitSet {
-    fn drop(&mut self) {
-        match self {
-            AutoBitSet::Static(_) => {}
-            AutoBitSet::Dynamic(d) => d.deinit(),
-        }
-    }
-}
 
 // ───────────────────────────── DynamicBitSet ─────────────────────────────
 
@@ -1736,12 +1638,6 @@ impl DynamicBitSet {
         &self,
     ) -> BitSetIterator<'_, KIND_SET, DIR_FWD> {
         self.unmanaged.iterator::<KIND_SET, DIR_FWD>()
-    }
-}
-
-impl Drop for DynamicBitSet {
-    fn drop(&mut self) {
-        self.unmanaged.deinit();
     }
 }
 

--- a/src/collections/bit_set.rs
+++ b/src/collections/bit_set.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)]
 //! This is a fork of Zig standard library bit_set.zig
 //! - https://github.com/ziglang/zig/pull/14129
 //! - AutoBitset which optimally chooses between a dynamic or static bitset.

--- a/src/collections/comptime_string_map.rs
+++ b/src/collections/comptime_string_map.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 //! Comptime string map optimized for small sets of disparate string keys.
 //! Works by separating the keys by length at comptime and only checking strings of
 //! equal length at runtime.

--- a/src/collections/hive_array.rs
+++ b/src/collections/hive_array.rs
@@ -1,5 +1,4 @@
-use core::marker::PhantomData;
-use core::mem::{ManuallyDrop, MaybeUninit, size_of};
+use core::mem::{MaybeUninit, size_of};
 use core::ptr::NonNull;
 
 use bun_core::asan;
@@ -105,18 +104,6 @@ impl<const CAPACITY: usize> HiveBitSet<CAPACITY> {
     /// Forward iterator over set bits. Mirrors `IntegerBitSet::iter_set`.
     #[inline]
     pub fn iter_set(&self) -> HiveBitSetIter<CAPACITY> {
-        self.iterator::<true, true>()
-    }
-
-    /// Signature mirrors `IntegerBitSet::iterator` so existing
-    /// `hive.used.iterator::<true, true>()` callers compile unchanged. Only
-    /// the `<KIND_SET=true, DIR_FWD=true>` combination is implemented (the
-    /// only one used in-tree); other params assert.
-    #[inline]
-    pub fn iterator<const KIND_SET: bool, const DIR_FWD: bool>(
-        &self,
-    ) -> HiveBitSetIter<CAPACITY> {
-        const { assert!(KIND_SET && DIR_FWD, "HiveBitSet::iterator only supports <true,true>") };
         HiveBitSetIter {
             masks: self.masks,
             word: 0,
@@ -149,11 +136,19 @@ impl<const CAPACITY: usize> HiveBitSetIter<CAPACITY> {
 /// An array that efficiently tracks which elements are in use.
 /// The pointers are intended to be stable
 /// Sorta related to https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0447r15.html
+///
+/// MODULE INVARIANT: `used.is_set(i) ⇔ buffer[i] is a fully-initialized T`.
+/// The bit is set only by [`HiveSlot::write`]/[`HiveSlot::assume_init`] (which
+/// hold `&mut HiveArray` while writing) and unset only by [`put`](Self::put)/
+/// [`put_raw`](Self::put_raw)/[`take`](Self::take)/[`release_at`](Self::release_at)/
+/// [`reset`](Self::reset). With `buffer`/`used` private, safe code cannot
+/// desync the invariant — `mem::forget(slot)` is harmless because `claim()`
+/// does not set the bit.
 // PORT NOTE: Zig's `capacity: u16` is widened to `usize` here because Rust array
 // lengths require a `usize` const generic on stable.
 pub struct HiveArray<T, const CAPACITY: usize> {
-    pub buffer: [MaybeUninit<T>; CAPACITY],
-    pub used: HiveBitSet<CAPACITY>,
+    buffer: [MaybeUninit<T>; CAPACITY],
+    used: HiveBitSet<CAPACITY>,
 }
 
 impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
@@ -168,51 +163,6 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
             buffer: [const { MaybeUninit::uninit() }; CAPACITY],
             used: HiveBitSet::init_empty(),
         }
-    }
-
-    /// Placement-new constructor: write the empty state directly into `*out`
-    /// without materializing `Self` on the stack.
-    ///
-    /// `Self` embeds `[MaybeUninit<T>; CAPACITY]` inline, which for the
-    /// install pools (`NetworkTask` × 128, `Task` × 64) is hundreds of KB.
-    /// Rust has no result-location semantics, so `out.write(Self::init())`
-    /// first builds the value in the caller's frame and `memcpy`s it — LLVM
-    /// does **not** elide that temporary. This entry point only writes the
-    /// 256 B `used` bitset; `buffer` is `MaybeUninit` and needs no
-    /// initialization (uninitialized bytes are a valid bit-pattern for it).
-    ///
-    /// # Safety
-    /// `out` must be non-null, properly aligned, and valid for writes of
-    /// `size_of::<Self>()` bytes. The previous contents are not dropped.
-    #[inline]
-    pub unsafe fn init_in_place(out: *mut Self) {
-        // SAFETY: caller contract — `out` is aligned and writable. We form a
-        // place expression on `*out` only to project to `used`; no `&mut Self`
-        // is created over the (uninitialized) whole struct.
-        unsafe {
-            core::ptr::addr_of_mut!((*out).used).write(HiveBitSet::init_empty());
-        }
-        // `buffer: [MaybeUninit<T>; CAPACITY]` intentionally untouched.
-    }
-
-    /// Claim a slot and return a raw pointer to its **uninitialized** storage.
-    ///
-    /// Prefer [`get_init`](Self::get_init) / [`emplace`](Self::emplace) /
-    /// [`claim`](Self::claim), which encode the "a `used` slot is always
-    /// fully initialized" invariant in the type system. This entry point
-    /// hands out `*mut T` to garbage; forming `&mut T` over it is instant UB
-    /// when `T` has niche-bearing fields, and an early return between `get()`
-    /// and the caller's `ptr::write` leaves the slot claimed-but-uninit so a
-    /// later [`put`](Self::put) drops garbage.
-    #[deprecated = "returns *mut T to uninitialized memory; use get_init / emplace / claim"]
-    pub fn get(&mut self) -> Option<*mut T> {
-        let Some(index) = self.used.find_first_unset() else {
-            return None;
-        };
-        self.used.set(index);
-        let ret = self.buffer[index].as_mut_ptr();
-        asan::unpoison(ret.cast(), size_of::<T>());
-        Some(ret)
     }
 
     /// One-shot claim + write. Preferred entry point — no uninit window.
@@ -230,7 +180,7 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
     /// and must return the value to be stored there.
     #[inline]
     pub fn emplace(&mut self, init: impl FnOnce(NonNull<T>) -> T) -> Option<NonNull<T>> {
-        let slot = self.claim()?;
+        let mut slot = self.claim()?;
         let addr = slot.addr();
         Some(slot.write(init(addr)))
     }
@@ -243,26 +193,14 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
     /// The returned token borrows `self` for `'_`; precompute any raw
     /// back-pointers to the parent struct *before* calling `claim()` if they
     /// are needed inside the initializer.
+    ///
+    /// The `used` bit is **not** set until [`HiveSlot::write`]/
+    /// [`HiveSlot::assume_init`] commits the slot; dropping or forgetting the
+    /// token leaves the slot free.
     pub fn claim(&mut self) -> Option<HiveSlot<'_, T, CAPACITY>> {
         let index = self.used.find_first_unset()?;
-        self.used.set(index);
-        let slot = NonNull::from(&mut self.buffer[index]);
-        asan::unpoison(slot.as_ptr().cast(), size_of::<T>());
-        let owner = core::ptr::from_mut(self) as usize;
-        // Tagged-pointer scheme requires the low bit clear for inline slots.
-        // `HiveArray` is at least pointer-aligned via `IntegerBitSet`'s
-        // backing word, and in practice `align_of::<T>() >= 2` for every `T`
-        // we pool; assert in debug so a future 1-byte `T` is caught.
-        debug_assert_eq!(
-            owner & 1,
-            0,
-            "HiveArray must be >=2-byte aligned for HiveSlot owner tag"
-        );
-        Some(HiveSlot {
-            slot,
-            owner,
-            _marker: PhantomData,
-        })
+        asan::unpoison(self.buffer[index].as_mut_ptr().cast(), size_of::<T>());
+        Some(HiveSlot(Some(SlotInner::Inline { hive: self, index })))
     }
 
     /// Recycle a slot **without** running `T::drop`. Safe: if `value` does not
@@ -280,11 +218,71 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
         true
     }
 
-    pub fn at(&mut self, index: u16) -> *mut T {
-        debug_assert!((index as usize) < CAPACITY);
-        let ret = self.buffer[index as usize].as_mut_ptr();
-        asan::assert_unpoisoned(ret.cast::<u8>());
-        ret
+    /// Release slot `i` without running `T::drop` (by-index counterpart to
+    /// [`put_raw`](Self::put_raw)). For callers that hold an index rather than
+    /// the original pointer.
+    #[inline]
+    pub fn release_at(&mut self, i: usize) {
+        debug_assert!(i < CAPACITY);
+        debug_assert!(self.used.is_set(i));
+        asan::poison(self.buffer[i].as_mut_ptr().cast(), size_of::<T>());
+        self.used.unset(i);
+    }
+
+    /// Safe `&mut T` access to an occupied slot. `None` if `i` is out of range
+    /// or unused.
+    #[inline]
+    pub fn at_mut(&mut self, i: usize) -> Option<&mut T> {
+        if i < CAPACITY && self.used.is_set(i) {
+            // SAFETY: module invariant — `used.is_set(i) ⇔ buffer[i] initialized`.
+            Some(unsafe { self.buffer[i].assume_init_mut() })
+        } else {
+            None
+        }
+    }
+
+    /// Move the value out of slot `i` and release the slot. `None` if `i` is
+    /// out of range or unused.
+    #[inline]
+    pub fn take(&mut self, i: usize) -> Option<T> {
+        if i < CAPACITY && self.used.is_set(i) {
+            self.used.unset(i);
+            // SAFETY: module invariant — bit was set ⇔ slot initialized; we
+            // unset the bit so the slot is now logically free and ownership of
+            // the `T` transfers to the caller.
+            let v = unsafe { self.buffer[i].assume_init_read() };
+            asan::poison(self.buffer[i].as_mut_ptr().cast(), size_of::<T>());
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    /// Iterator over indices of occupied slots. The iterator copies the bitset
+    /// at construction time, so the hive can be borrowed `&mut` (e.g. via
+    /// [`at_mut`](Self::at_mut)) inside the loop body.
+    #[inline]
+    pub fn used_iter(&self) -> HiveBitSetIter<CAPACITY> {
+        self.used.iter_set()
+    }
+
+    /// `true` if any slot is occupied.
+    #[inline]
+    pub fn any_used(&self) -> bool {
+        self.used.find_first_set().is_some()
+    }
+
+    #[inline]
+    pub fn is_used(&self, i: usize) -> bool {
+        i < CAPACITY && self.used.is_set(i)
+    }
+
+    /// Mark every slot free **without** running `T::drop` on any contents.
+    /// Only valid when the caller has already torn down / moved out every live
+    /// value (or `T` is POD). Bulk equivalent of [`put_raw`](Self::put_raw).
+    #[inline]
+    pub fn reset(&mut self) {
+        self.used = HiveBitSet::init_empty();
     }
 
     pub fn index_of(&self, value: *const T) -> Option<u32> {
@@ -313,21 +311,24 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
 
     /// Return a slot to the pool, dropping the contained `T` in place.
     ///
-    /// Returns `false` (and drops nothing) if `value` does not point into
-    /// this hive's buffer.
+    /// Returns `false` (and drops nothing) if `value` does not point into this
+    /// hive's buffer or the slot's `used` bit is already clear (double-put
+    /// guard).
     ///
-    /// # Safety
-    /// If `value` points into this hive, it must point to a fully-initialized
-    /// `T` previously obtained via [`get`](Self::get) and written by the
-    /// caller. The slot is dropped in place; passing a moved-from or
-    /// uninitialized slot is UB for `T` with drop glue.
-    pub unsafe fn put(&mut self, value: *mut T) -> bool {
+    /// Safe: with the module invariant maintained internally, any `value` for
+    /// which `index_of` succeeds and `used.is_set` holds was written via
+    /// [`HiveSlot::write`]/[`HiveSlot::assume_init`] — the latter is `unsafe`
+    /// and its caller asserted full initialization.
+    pub fn put(&mut self, value: *mut T) -> bool {
         let Some(index) = self.index_of(value) else {
             return false;
         };
-
-        debug_assert!(self.used.is_set(index as usize));
-        debug_assert!(self.buffer[index as usize].as_ptr().cast::<T>() == value.cast_const());
+        let i = index as usize;
+        if !self.used.is_set(i) {
+            debug_assert!(false, "HiveArray::put on unclaimed slot (double put?)");
+            return false;
+        }
+        debug_assert!(self.buffer[i].as_ptr().cast::<T>() == value.cast_const());
 
         // PORT NOTE: Zig wrote `value.* = undefined;` — Zig has no destructors,
         // so the slot was simply marked logically uninitialized. In the Rust
@@ -336,11 +337,10 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
         // before recycling so the put/get cycle does not leak it. Callers that
         // pre-clean fields (`PooledSocket::release_parked_refs`) leave only
         // trivially-droppable residuals, so this is idempotent for them.
-        // SAFETY: caller contract — `value` is a fully-initialized `T` in `buffer`.
-        unsafe { core::ptr::drop_in_place(value) };
+        // SAFETY: module invariant — `used.is_set(i) ⇔ buffer[i] initialized`.
+        unsafe { self.buffer[i].assume_init_drop() };
         asan::poison(value.cast(), size_of::<T>());
-
-        self.used.unset(index as usize);
+        self.used.unset(i);
         true
     }
 }
@@ -351,36 +351,26 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
 
 /// Linear reservation token for a claimed-but-uninitialized hive slot.
 ///
-/// `HiveArray` slots are `[MaybeUninit<T>; CAP]`. The legacy [`HiveArray::get`]
-/// contract was two-phase — claim a `*mut T` to garbage, then `ptr::write` it
-/// — which opened three UB hazards in the gap: (H1) early-return / `?` / panic
-/// leaves the slot claimed-uninit so a later `put()` drops garbage; (H2)
-/// `&mut *p` over uninit `T` is instant validity UB when `T` has niches; (H3)
-/// partial field-write then `assume_init_ref` on the whole slot.
+/// The legacy two-phase contract (claim a `*mut T` to garbage, then
+/// `ptr::write` it) opened UB hazards in the gap: early-return / `?` / panic
+/// left the slot claimed-uninit, and `&mut *p` over uninit `T` is instant
+/// validity UB when `T` has niches.
 ///
 /// `HiveSlot` encodes the invariant **"a `used` slot is always fully
-/// initialized"** in the type system: you cannot obtain the stable
-/// initialized `*mut T` without going through [`write`](Self::write) (or the
-/// `unsafe` [`assume_init`](Self::assume_init) escape hatch). If the token is
-/// dropped (early return, `?`, panic) the slot is released **without** running
-/// `T::drop` — it was never written.
-///
-/// Two-pointer-sized; `owner` is a tagged `usize`:
-///   - low bit `0` ⇒ `*mut HiveArray<T, CAP>` (release = unset `used` bit + poison),
-///   - low bit `1` ⇒ heap `Box<MaybeUninit<T>>` (release = dealloc, no `T::drop`).
-///
-/// **Aliasing note** (matches the `BackRef<T>` precedent in `bun_ptr`): the
-/// token stores a raw `*mut HiveArray` rather than `&'h mut HiveArray`. The
-/// `PhantomData<&'h mut _>` keeps it lifetime-scoped to the `claim()` borrow,
-/// but the structural guarantee — the hive is a field of a long-lived owner
-/// that is not moved between `claim()` and `write()` — is the caller's, same
-/// as every back-pointer in the port.
+/// initialized"** in the type system: the `used` bit is set only when
+/// [`write`](Self::write) (or the `unsafe` [`assume_init`](Self::assume_init))
+/// commits the slot. If the token is dropped (early return, `?`, panic) the
+/// slot stays free — no bit was set, no `T::drop` runs. `mem::forget(slot)`
+/// is likewise harmless (slot stays free; next `claim()` reuses it).
 #[must_use = "claimed hive slot is leaked if neither written nor dropped"]
-pub struct HiveSlot<'h, T, const CAPACITY: usize> {
-    slot: NonNull<MaybeUninit<T>>,
-    /// Tagged owner; see type-level docs.
-    owner: usize,
-    _marker: PhantomData<&'h mut HiveArray<T, CAPACITY>>,
+pub struct HiveSlot<'h, T, const CAPACITY: usize>(Option<SlotInner<'h, T, CAPACITY>>);
+
+enum SlotInner<'h, T, const CAPACITY: usize> {
+    Inline {
+        hive: &'h mut HiveArray<T, CAPACITY>,
+        index: usize,
+    },
+    Heap(Box<MaybeUninit<T>>),
 }
 
 impl<'h, T, const CAPACITY: usize> HiveSlot<'h, T, CAPACITY> {
@@ -388,8 +378,8 @@ impl<'h, T, const CAPACITY: usize> HiveSlot<'h, T, CAPACITY> {
     /// libuv/uws user-data pointer) **before** [`write`](Self::write), as long
     /// as nothing dereferences it until after `write()`.
     #[inline]
-    pub fn addr(&self) -> NonNull<T> {
-        self.slot.cast::<T>()
+    pub fn addr(&mut self) -> NonNull<T> {
+        NonNull::from(self.as_uninit()).cast()
     }
 
     /// `&mut MaybeUninit<T>` for piecewise init via `addr_of_mut!`. Prefer
@@ -397,59 +387,57 @@ impl<'h, T, const CAPACITY: usize> HiveSlot<'h, T, CAPACITY> {
     /// (`create_in`-style constructors that take `&mut MaybeUninit<Self>`).
     #[inline]
     pub fn as_uninit(&mut self) -> &mut MaybeUninit<T> {
-        // SAFETY: `slot` is a unique live pointer into the hive buffer (or a
-        // freshly leaked `Box<MaybeUninit<T>>`); the `&mut self` receiver
-        // guarantees no other `&mut` to the same `MaybeUninit<T>` exists.
-        unsafe { self.slot.as_mut() }
+        match self.0.as_mut().expect("HiveSlot already consumed") {
+            SlotInner::Inline { hive, index } => &mut hive.buffer[*index],
+            SlotInner::Heap(b) => b,
+        }
     }
 
-    /// Move `value` into the slot and return the stable initialized pointer.
-    /// Consumes the token (its `Drop` does not run).
+    /// Move `value` into the slot, mark it occupied, and return the stable
+    /// initialized pointer. Consumes the token.
     #[inline]
-    pub fn write(self, value: T) -> NonNull<T> {
-        let mut this = ManuallyDrop::new(self);
-        NonNull::from(this.as_uninit().write(value))
+    pub fn write(mut self, value: T) -> NonNull<T> {
+        match self.0.take().expect("HiveSlot already consumed") {
+            SlotInner::Inline { hive, index } => {
+                let p = NonNull::from(hive.buffer[index].write(value));
+                hive.used.set(index);
+                p
+            }
+            SlotInner::Heap(b) => NonNull::from(Box::leak(b).write(value)),
+        }
     }
 
     /// Caller has fully initialized the slot via [`as_uninit`](Self::as_uninit)
-    /// (or by writing through [`addr`](Self::addr)). Consumes the token.
+    /// (or by writing through [`addr`](Self::addr)). Marks the slot occupied
+    /// and consumes the token.
     ///
     /// # Safety
     /// Every field of `T` must be initialized, including padding-adjacent
     /// niches (enum discriminants, `NonNull`, `Box`, `&`). Calling this on a
     /// partially-written slot is the exact UB this type exists to prevent.
     #[inline]
-    pub unsafe fn assume_init(self) -> NonNull<T> {
-        let this = ManuallyDrop::new(self);
-        this.slot.cast::<T>()
+    pub unsafe fn assume_init(mut self) -> NonNull<T> {
+        match self.0.take().expect("HiveSlot already consumed") {
+            SlotInner::Inline { hive, index } => {
+                hive.used.set(index);
+                NonNull::from(&mut hive.buffer[index]).cast()
+            }
+            SlotInner::Heap(b) => NonNull::from(Box::leak(b)).cast(),
+        }
     }
 }
 
 impl<T, const CAPACITY: usize> Drop for HiveSlot<'_, T, CAPACITY> {
     fn drop(&mut self) {
-        if self.owner & 1 == 0 {
-            // Inline hive slot: unset the `used` bit and re-poison. Do NOT
-            // `drop_in_place` — the slot was never `.write()`n.
-            let hive = self.owner as *mut HiveArray<T, CAPACITY>;
-            // SAFETY: `owner` was set from `core::ptr::from_mut(self)` in
-            // `HiveArray::claim`; the hive is a field of a long-lived owner
-            // that has not been moved (structural back-pointer guarantee).
-            // No `&mut HiveArray` is live across this drop — `claim()`'s
-            // borrow was released when the raw pointer was captured.
-            unsafe {
-                let index = (*hive)
-                    .index_of(self.slot.as_ptr().cast::<T>())
-                    .expect("HiveSlot points outside its owning hive");
-                asan::poison(self.slot.as_ptr().cast(), size_of::<T>());
-                (*hive).used.unset(index as usize);
+        match self.0.take() {
+            // Bit was never set; just re-poison so asan still catches a stale
+            // `addr()` deref after the token is dropped.
+            Some(SlotInner::Inline { hive, index }) => {
+                asan::poison(hive.buffer[index].as_mut_ptr().cast(), size_of::<T>());
             }
-        } else {
-            // Heap fallback slot: reclaim the `Box<MaybeUninit<T>>` allocation.
-            // `MaybeUninit<T>` has no drop glue, so this deallocates without
-            // touching `T`.
-            // SAFETY: `slot` was produced by `Box::leak(Box::<MaybeUninit<T>>::new_uninit())`
-            // in `Fallback::claim` and has not been freed.
-            drop(unsafe { Box::from_raw(self.slot.as_ptr()) });
+            // `Box<MaybeUninit<T>>` drop deallocates without running `T::drop`.
+            Some(SlotInner::Heap(_)) => {}
+            None => {}
         }
     }
 }
@@ -461,7 +449,7 @@ impl<T, const CAPACITY: usize> Drop for HiveSlot<'_, T, CAPACITY> {
 // `CAPACITY > 0` checks below preserve the original gating.
 // PERF(port): zero-capacity case carried a zero-size hive in Zig — profile in Phase B.
 pub struct Fallback<T, const CAPACITY: usize> {
-    pub hive: HiveArray<T, CAPACITY>,
+    hive: HiveArray<T, CAPACITY>,
     // PORT NOTE: `std.mem.Allocator param` dropped — global mimalloc.
 }
 
@@ -470,19 +458,6 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
         Self {
             hive: HiveArray::init(),
         }
-    }
-
-    /// Placement-new constructor — see [`HiveArray::init_in_place`]. Only
-    /// writes the 256 B occupancy bitset; the `[MaybeUninit<T>; CAPACITY]`
-    /// buffer is left untouched.
-    ///
-    /// # Safety
-    /// `out` must be non-null, properly aligned, and valid for writes of
-    /// `size_of::<Self>()` bytes. The previous contents are not dropped.
-    #[inline]
-    pub unsafe fn init_in_place(out: *mut Self) {
-        // SAFETY: caller contract.
-        unsafe { HiveArray::<T, CAPACITY>::init_in_place(core::ptr::addr_of_mut!((*out).hive)) };
     }
 
     /// Heap-allocate an empty `Fallback` without materializing it on the
@@ -494,50 +469,24 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
     /// zeros into a stack temporary and then `memcpy`s the **full** 816 KB
     /// into the heap allocation, committing both ~812 KB of stack pages and
     /// ~812 KB of heap pages that are never read. This entry point allocates
-    /// raw heap storage and writes only the 256-byte `used` bitset via
-    /// [`init_in_place`](Self::init_in_place); the `[MaybeUninit<T>; CAPACITY]`
-    /// buffer is left untouched (uninitialized bytes are a valid bit-pattern
-    /// for `MaybeUninit`).
-    ///
-    /// The returned allocation is leaked — callers stash it in a per-thread
-    /// static for the process lifetime (Zig: `threadlocal var pool`).
+    /// raw heap storage and writes only the 256-byte `used` bitset; the
+    /// `[MaybeUninit<T>; CAPACITY]` buffer is left untouched (uninitialized
+    /// bytes are a valid bit-pattern for `MaybeUninit`).
     #[inline]
-    pub fn new_boxed() -> NonNull<Self> {
+    pub fn new_boxed() -> Box<Self> {
         let mut boxed = Box::<Self>::new_uninit();
         // SAFETY: `boxed` is a fresh heap allocation — non-null, aligned for
-        // `Self`, and valid for writes of `size_of::<Self>()` bytes.
-        unsafe { Self::init_in_place(boxed.as_mut_ptr()) };
-        // SAFETY: `init_in_place` fully initialized `hive.used`; `hive.buffer`
-        // is `[MaybeUninit<T>; CAPACITY]`, for which uninitialized bytes are a
-        // valid representation. Every field of `Self` is therefore valid.
-        NonNull::from(Box::leak(unsafe { boxed.assume_init() }))
-    }
-
-    /// See [`HiveArray::get`] — same UB hazards, plus the heap path leaks a
-    /// `Box<MaybeUninit<T>>` if the caller early-returns before `ptr::write`.
-    #[deprecated = "returns *mut T to uninitialized memory; use get_init / emplace / claim"]
-    pub fn get(&mut self) -> *mut T {
-        // Forget the token so its `Drop` does not release the slot — legacy
-        // callers expect the slot to remain claimed until their later `put()`.
-        ManuallyDrop::new(self.claim()).addr().as_ptr()
-    }
-
-    #[deprecated = "returns *mut T to uninitialized memory; use get_init / emplace / claim"]
-    pub fn get_and_see_if_new(&mut self, new: &mut bool) -> *mut T {
-        if CAPACITY > 0 {
-            #[allow(deprecated)]
-            if let Some(value) = self.hive.get() {
-                *new = false;
-                return value;
-            }
+        // `Self`, and valid for writes of `size_of::<Self>()` bytes. We form a
+        // place expression on `*out` only to project to `hive.used`; no
+        // `&mut Self` is created over the (uninitialized) whole struct. After
+        // the write, `hive.used` is fully initialized and `hive.buffer` is
+        // `[MaybeUninit<T>; CAPACITY]` for which uninitialized bytes are a
+        // valid representation, so `assume_init()` is sound.
+        unsafe {
+            let out = boxed.as_mut_ptr();
+            core::ptr::addr_of_mut!((*out).hive.used).write(HiveBitSet::init_empty());
+            boxed.assume_init()
         }
-
-        bun_core::heap::into_raw(Box::<T>::new_uninit()).cast::<T>()
-    }
-
-    #[deprecated = "returns *mut T to uninitialized memory; use get_init / emplace / claim"]
-    pub fn try_get(&mut self) -> *mut T {
-        ManuallyDrop::new(self.claim()).addr().as_ptr()
     }
 
     /// One-shot claim + write. Preferred entry point — no uninit window.
@@ -550,28 +499,28 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
     /// See [`HiveArray::emplace`]. Infallible (heap fallback).
     #[inline]
     pub fn emplace(&mut self, init: impl FnOnce(NonNull<T>) -> T) -> NonNull<T> {
-        let slot = self.claim();
+        let mut slot = self.claim();
         let addr = slot.addr();
         slot.write(init(addr))
     }
 
     /// See [`HiveArray::claim`]. Infallible: when the inline hive is full,
-    /// the returned token owns a freshly-allocated heap slot (tagged so its
-    /// `Drop` deallocates without running `T::drop`).
+    /// the returned token owns a freshly-allocated heap slot whose `Drop`
+    /// deallocates without running `T::drop`.
     pub fn claim(&mut self) -> HiveSlot<'_, T, CAPACITY> {
         if CAPACITY > 0 {
             if let Some(slot) = self.hive.claim() {
                 return slot;
             }
         }
-        let slot = NonNull::from(Box::leak(Box::<T>::new_uninit()));
-        HiveSlot {
-            slot,
-            // Low bit 1 ⇒ heap slot. The hive pointer is not needed on the
-            // release path (dealloc is `Box::from_raw(slot)`).
-            owner: 1,
-            _marker: PhantomData,
-        }
+        HiveSlot(Some(SlotInner::Heap(Box::new_uninit())))
+    }
+
+    /// See [`HiveArray::reset`]. Heap-fallback slots are caller-managed and
+    /// not tracked here, so this only clears the inline bitset.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.hive.reset();
     }
 
     /// Recycle a slot **without** running `T::drop`. Counterpart to
@@ -579,20 +528,18 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
     ///
     /// # Safety
     /// `value` must have been obtained from this `Fallback` (via `get_init` /
-    /// `emplace` / `claim().write()` / the deprecated `get` family) and not
-    /// yet returned. The contained `T` is **not** dropped — caller must have
-    /// already moved out / destructured anything with drop glue, or `T` must
-    /// be POD.
+    /// `emplace` / `claim().write()`) and not yet returned. The contained `T`
+    /// is **not** dropped — caller must have already moved out / destructured
+    /// anything with drop glue, or `T` must be POD.
     pub unsafe fn put_raw(&mut self, value: *mut T) {
         if CAPACITY > 0 {
             if self.hive.put_raw(value) {
                 return;
             }
         }
-        // SAFETY: caller contract — `value` is a heap slot from `claim()` /
-        // `get()`; it was allocated as `Box<MaybeUninit<T>>` (same layout as
-        // `Box<T>`). Reclaiming as `MaybeUninit<T>` deallocates without
-        // running `T::drop`.
+        // SAFETY: caller contract — `value` is a heap slot from `claim()`; it
+        // was allocated as `Box<MaybeUninit<T>>` (same layout as `Box<T>`).
+        // Reclaiming as `MaybeUninit<T>` deallocates without running `T::drop`.
         drop(unsafe { Box::from_raw(value.cast::<MaybeUninit<T>>()) });
     }
 
@@ -610,21 +557,19 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
     ///
     /// # Safety
     /// `value` must point to a fully-initialized `T` previously obtained from
-    /// [`get`](Self::get) / [`get_and_see_if_new`](Self::get_and_see_if_new) /
-    /// [`try_get`](Self::try_get) on this `Fallback` and subsequently written
-    /// by the caller.
+    /// this `Fallback` via `get_init` / `emplace` / `claim().write()` /
+    /// `claim().assume_init()` and not yet returned. The heap path has no
+    /// membership check, so a foreign pointer is UB.
     pub unsafe fn put(&mut self, value: *mut T) {
         if CAPACITY > 0 {
-            // SAFETY: caller contract — `value` is fully initialized.
-            if unsafe { self.hive.put(value) } {
+            if self.hive.put(value) {
                 return;
             }
         }
 
-        // SAFETY: `value` was produced by `heap::into_raw(Box::<T>::new_uninit())`
-        // in `get_impl`/`get_and_see_if_new`/`try_get` above (it is not in the
-        // hive), and the caller has since fully initialized it. `destroy`
-        // reconstructs the `Box<T>` and runs `T::drop`.
+        // SAFETY: caller contract — `value` was produced by the heap path of
+        // `claim().write()` (`Box::leak`); `destroy` reconstructs the `Box<T>`
+        // and runs `T::drop`.
         unsafe { bun_core::heap::destroy(value) };
     }
 }
@@ -648,7 +593,7 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
 #[repr(C)]
 pub struct HiveRef<T, const CAPACITY: usize> {
     pub ref_count: u32,
-    pub pool: *mut Fallback<HiveRef<T, CAPACITY>, CAPACITY>,
+    pub pool: NonNull<Fallback<HiveRef<T, CAPACITY>, CAPACITY>>,
     pub value: T,
 }
 
@@ -659,20 +604,16 @@ impl<T, const CAPACITY: usize> HiveRef<T, CAPACITY> {
     /// Zig: `pub fn init(value, allocator) !*@This()`.
     ///
     /// # Safety
-    /// `pool` must be valid for the entire lifetime of the returned
-    /// `HiveRef` (i.e. until its `ref_count` drops to zero and it is `put`
-    /// back). Callers hold the pool in a long-lived owner (e.g. `VirtualMachine`).
-    pub unsafe fn init(value: T, pool: *mut Fallback<Self, CAPACITY>) -> *mut Self {
-        // SAFETY: caller contract — `pool` is dereferenceable.
-        unsafe {
-            (*pool)
-                .get_init(HiveRef {
-                    ref_count: 1,
-                    pool,
-                    value,
-                })
-                .as_ptr()
-        }
+    /// `pool` must be valid for the entire lifetime of the returned `HiveRef`
+    /// (i.e. until its `ref_count` drops to zero and it is `put` back).
+    /// Callers hold the pool in a long-lived owner (e.g. `VirtualMachine`).
+    pub unsafe fn init(value: T, pool: &mut Fallback<Self, CAPACITY>) -> NonNull<Self> {
+        let pool_ptr = NonNull::from(&mut *pool);
+        pool.get_init(HiveRef {
+            ref_count: 1,
+            pool: pool_ptr,
+            value,
+        })
     }
 
     pub fn ref_(&mut self) -> &mut Self {
@@ -686,15 +627,12 @@ impl<T, const CAPACITY: usize> HiveRef<T, CAPACITY> {
         let ref_count = self.ref_count;
         self.ref_count = ref_count - 1;
         if ref_count == 1 {
-            let pool = self.pool;
-            // SAFETY: `self` was produced by `init` above, so `pool` is the
-            // pool that owns this slot and is still live (caller contract on
-            // `init`). Zig's `if @hasDecl(T, "deinit") this.value.deinit()` maps
-            // to `T::drop`, which `Fallback::put` now runs (it drops the whole
-            // `HiveRef` in place before recycling/freeing the slot).
-            unsafe {
-                (*pool).put(std::ptr::from_mut::<Self>(self));
-            }
+            let mut pool = self.pool;
+            // SAFETY: BACKREF — `init`'s contract is that the pool outlives
+            // every `HiveRef` it hands out. Zig's `if @hasDecl(T, "deinit")
+            // this.value.deinit()` maps to `T::drop`, which `Fallback::put`
+            // runs (it drops the whole `HiveRef` in place before recycling).
+            unsafe { pool.as_mut().put(core::ptr::from_mut(self)) };
             return None;
         }
         Some(self)
@@ -702,7 +640,6 @@ impl<T, const CAPACITY: usize> HiveRef<T, CAPACITY> {
 }
 
 #[cfg(test)]
-#[allow(deprecated)]
 mod tests {
     use super::*;
 
@@ -717,36 +654,29 @@ mod tests {
         let mut a = HiveArray::<Int, SIZE>::init();
 
         {
-            let b = a.get().unwrap();
-            // SAFETY: `b` points into `a.buffer` and was just unpoisoned by `get()`.
-            unsafe { *b = 0 };
-            assert!(a.get().unwrap() != b);
-            assert_eq!(a.index_of(b), Some(0));
-            // SAFETY: `b` is a fully-initialized hive slot.
-            assert!(unsafe { a.put(b) });
-            assert!(a.get().unwrap() == b);
-            let c = a.get().unwrap();
-            // SAFETY: `c` points into `a.buffer` and was just unpoisoned by `get()`.
-            unsafe { *c = 123 };
+            let b = a.get_init(0).unwrap();
+            assert_eq!(a.index_of(b.as_ptr()), Some(0));
+            let b2 = a.get_init(0).unwrap();
+            assert!(b2 != b);
+            assert!(a.put(b.as_ptr()));
+            assert!(a.get_init(0).unwrap() == b);
+            let c = a.get_init(123).unwrap();
+            assert_eq!(*a.at_mut(a.index_of(c.as_ptr()).unwrap() as usize).unwrap(), 123);
             let mut d: Int = 12345;
-            // SAFETY: `&mut d` is foreign — `put` returns `false` and drops nothing.
-            assert!(unsafe { a.put(&mut d) } == false);
+            assert!(a.put(&mut d) == false);
             assert!(a.r#in(&d) == false);
         }
 
-        a.used = IntegerBitSet::init_empty();
+        a.reset();
         {
             for i in 0..SIZE {
-                let b = a.get().unwrap();
-                // SAFETY: `b` points into `a.buffer` and was just unpoisoned by `get()`.
-                unsafe { *b = 0 };
-                assert_eq!(a.index_of(b), Some(u32::try_from(i).expect("int cast")));
-                // SAFETY: `b` is a fully-initialized hive slot.
-                assert!(unsafe { a.put(b) });
-                assert!(a.get().unwrap() == b);
+                let b = a.get_init(0).unwrap();
+                assert_eq!(a.index_of(b.as_ptr()), Some(u32::try_from(i).expect("int cast")));
+                assert!(a.put(b.as_ptr()));
+                assert!(a.get_init(0).unwrap() == b);
             }
             for _ in 0..SIZE {
-                assert!(a.get().is_none());
+                assert!(a.get_init(0).is_none());
             }
         }
     }
@@ -763,32 +693,44 @@ mod tests {
         }
 
         let mut a = HiveArray::<D, 4>::init();
-        // Dropped token releases the slot without running D::drop.
+        // Dropped token leaves the slot free without running D::drop.
         drop(a.claim().unwrap());
-        assert!(!a.used.is_set(0));
+        assert!(!a.is_used(0));
         assert_eq!(DROPS.load(Ordering::Relaxed), 0);
+
+        // Forgotten token also leaves the slot free (bit never set).
+        core::mem::forget(a.claim().unwrap());
+        assert!(!a.is_used(0));
+        assert!(a.at_mut(0).is_none());
 
         // write() commits and put() drops.
         let p = a.get_init(D(7)).unwrap();
-        assert!(a.used.is_set(0));
+        assert!(a.is_used(0));
         assert_eq!(DROPS.load(Ordering::Relaxed), 0);
-        // SAFETY: `p` is a fully-initialized hive slot.
-        unsafe { a.put(p.as_ptr()) };
+        a.put(p.as_ptr());
         assert_eq!(DROPS.load(Ordering::Relaxed), 1);
 
-        // put_raw() does not drop.
+        // take() moves out without dropping; caller drops.
         let p = a.get_init(D(8)).unwrap();
-        assert!(a.put_raw(p.as_ptr()));
+        let i = a.index_of(p.as_ptr()).unwrap() as usize;
+        let v = a.take(i).unwrap();
         assert_eq!(DROPS.load(Ordering::Relaxed), 1);
+        drop(v);
+        assert_eq!(DROPS.load(Ordering::Relaxed), 2);
+
+        // put_raw() does not drop.
+        let p = a.get_init(D(9)).unwrap();
+        assert!(a.put_raw(p.as_ptr()));
+        assert_eq!(DROPS.load(Ordering::Relaxed), 2);
 
         // Fallback heap path: dropped token deallocates without D::drop.
         let mut f = Fallback::<D, 0>::init();
         drop(f.claim());
-        assert_eq!(DROPS.load(Ordering::Relaxed), 1);
-        let p = f.get_init(D(9));
+        assert_eq!(DROPS.load(Ordering::Relaxed), 2);
+        let p = f.get_init(D(10));
         // SAFETY: heap slot from this Fallback.
         unsafe { f.put(p.as_ptr()) };
-        assert_eq!(DROPS.load(Ordering::Relaxed), 2);
+        assert_eq!(DROPS.load(Ordering::Relaxed), 3);
     }
 }
 

--- a/src/collections/hive_array.rs
+++ b/src/collections/hive_array.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)]
 use core::mem::{MaybeUninit, size_of};
 use core::ptr::NonNull;
 

--- a/src/collections/identity_context.rs
+++ b/src/collections/identity_context.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 use core::marker::PhantomData;
 
 /// Trait covering the Zig `@typeInfo(Key)` switch in `IdentityContext.hash`:

--- a/src/collections/lib.rs
+++ b/src/collections/lib.rs
@@ -13,6 +13,10 @@
 )]
 #![allow(incomplete_features, internal_features)]
 #![allow(unused, non_snake_case, clippy::all)]
+// Safety posture: deny by default; modules with irreducible unsafe (SoA layout,
+// MaybeUninit pools, FFI/arena pointer round-trips) opt back in via a
+// module-level `#![allow(unsafe_code)]` and document each remaining block.
+#![deny(unsafe_code)]
 #![warn(unused_must_use, unreachable_pub)]
 
 extern crate self as bun_collections;

--- a/src/collections/lib.rs
+++ b/src/collections/lib.rs
@@ -32,7 +32,7 @@ pub mod linear_fifo;
 // stable: enum const params → const usize/bool, inherent assoc → free aliases.
 pub mod bit_set;
 pub mod pool;
-pub use pool::{ObjectPool, ObjectPoolTrait, ObjectPoolType, PoolGuard};
+pub use pool::{ObjectPool, ObjectPoolType, PoolGuard};
 pub mod comptime_string_map;
 pub use comptime_string_map::{ComptimeStringMap, ComptimeStringMapWithKeyType};
 #[path = "StaticHashMap.rs"]

--- a/src/collections/lib.rs
+++ b/src/collections/lib.rs
@@ -8,7 +8,8 @@
     const_cmp,
     const_trait_impl,
     core_intrinsics,
-    allocator_api
+    allocator_api,
+    maybe_uninit_fill
 )]
 #![allow(incomplete_features, internal_features)]
 #![allow(unused, non_snake_case, clippy::all)]

--- a/src/collections/lib.rs
+++ b/src/collections/lib.rs
@@ -32,7 +32,7 @@ pub mod linear_fifo;
 // stable: enum const params → const usize/bool, inherent assoc → free aliases.
 pub mod bit_set;
 pub mod pool;
-pub use pool::{ObjectPool, ObjectPoolTrait, ObjectPoolType, PoolGuard};
+pub use pool::{ObjectPool, ObjectPoolType, PoolGuard};
 pub mod comptime_string_map;
 pub use comptime_string_map::{ComptimeStringMap, ComptimeStringMapWithKeyType};
 #[path = "StaticHashMap.rs"]
@@ -48,8 +48,8 @@ pub use paste::paste as __mal_paste;
 pub use vec_ext::{ByteVecExt, OffsetByteList, VecExt, prepend_from};
 
 pub use bit_set::{
-    AutoBitSet, DynamicBitSet, DynamicBitSetList, DynamicBitSetUnmanaged, IntegerBitSet,
-    StaticBitSet,
+    AutoBitSet, BitSetMut, BitSetRef, DynamicBitSet, DynamicBitSetList, DynamicBitSetUnmanaged,
+    IntegerBitSet, StaticBitSet,
 };
 
 // Re-export for back-compat (`bun_jsc::host_fn`, `multi_array_list` import

--- a/src/collections/lib.rs
+++ b/src/collections/lib.rs
@@ -32,7 +32,7 @@ pub mod linear_fifo;
 // stable: enum const params → const usize/bool, inherent assoc → free aliases.
 pub mod bit_set;
 pub mod pool;
-pub use pool::{ObjectPool, ObjectPoolType, PoolGuard};
+pub use pool::{ObjectPool, ObjectPoolTrait, ObjectPoolType, PoolGuard};
 pub mod comptime_string_map;
 pub use comptime_string_map::{ComptimeStringMap, ComptimeStringMapWithKeyType};
 #[path = "StaticHashMap.rs"]

--- a/src/collections/lib.rs
+++ b/src/collections/lib.rs
@@ -430,6 +430,17 @@ impl<T, const N: usize> SmallList<T, N> {
         self.0.clear()
     }
     #[inline]
+    pub fn truncate(&mut self, new_len: u32) {
+        self.0.truncate(new_len as usize)
+    }
+    #[inline]
+    pub fn drain<R: core::ops::RangeBounds<usize>>(
+        &mut self,
+        range: R,
+    ) -> smallvec::Drain<'_, [T; N]> {
+        self.0.drain(range)
+    }
+    #[inline]
     pub fn reserve(&mut self, additional: u32) {
         self.0.reserve(additional as usize)
     }
@@ -439,15 +450,6 @@ impl<T, const N: usize> SmallList<T, N> {
         if (new_capacity as usize) > cur {
             self.0.reserve_exact(new_capacity as usize - cur);
         }
-    }
-    /// Zig `setLen` — exposed as safe for API parity with the previous port
-    /// (whose only external caller shrinks to 0). Growing past the initialised
-    /// region is the caller's responsibility, same as before.
-    #[inline]
-    pub fn set_len(&mut self, new_len: u32) {
-        // SAFETY: matches the previous bun_css::SmallList::set_len contract
-        // (Zig callers treat this as a raw length store).
-        unsafe { self.0.set_len(new_len as usize) }
     }
 
     // ── conversion / clone ─────────────────────────────────────────────────

--- a/src/collections/linear_fifo.rs
+++ b/src/collections/linear_fifo.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)]
 // clone of zig stdlib
 // except, this one vectorizes
 

--- a/src/collections/linear_fifo.rs
+++ b/src/collections/linear_fifo.rs
@@ -6,13 +6,8 @@
 
 use core::marker::PhantomData;
 use core::mem::{self, MaybeUninit};
-use core::ptr;
 
 use bun_alloc::AllocError;
-
-// TODO(port): std.heap.page_size_min — Zig resolves this per-target; 4096 is the
-// conservative minimum on every platform Bun ships on.
-const PAGE_SIZE_MIN: usize = 4096;
 
 /// Mirrors Zig's `LinearFifoBufferType = union(enum)`.
 ///
@@ -32,18 +27,19 @@ pub enum LinearFifoBufferType {
 /// Backing-storage abstraction replacing Zig's `comptime buffer_type` switch.
 /// `POWERS_OF_TWO` mirrors the Zig `powers_of_two` const inside the returned
 /// struct; `DYNAMIC` mirrors `buffer_type == .Dynamic`.
-// TODO(port): the Zig fn returns structurally different layouts per variant;
-// trait+assoc-consts is the closest stable-Rust encoding. Phase B: confirm all
-// in-tree callers are covered by the three impls below.
+///
+/// The storage is exposed as `&[MaybeUninit<T>]`: only the `[head, head+count)`
+/// ring-subrange is initialized at any time, and the fifo's accessors are the
+/// sole place that narrows that to `&[T]`.
 pub trait LinearFifoBuffer<T> {
     const POWERS_OF_TWO: bool;
     const DYNAMIC: bool;
 
-    fn as_slice(&self) -> &[T];
-    fn as_mut_slice(&mut self) -> &mut [T];
+    fn storage(&self) -> &[MaybeUninit<T>];
+    fn storage_mut(&mut self) -> &mut [MaybeUninit<T>];
     #[inline]
     fn len(&self) -> usize {
-        self.as_slice().len()
+        self.storage().len()
     }
 
     /// Reallocate to exactly `new_size` elements, preserving the prefix.
@@ -51,71 +47,11 @@ pub trait LinearFifoBuffer<T> {
     fn realloc(&mut self, _new_size: usize) -> Result<(), AllocError> {
         unreachable!("realloc on non-Dynamic LinearFifo buffer")
     }
-
-    /// Allocate fresh storage of `new_size` and return the old buffer so the
-    /// caller can copy out of it before drop.
-    fn alloc_swap(&mut self, _new_size: usize) -> Result<Box<[MaybeUninit<T>]>, AllocError> {
-        unreachable!("alloc_swap on non-Dynamic LinearFifo buffer")
-    }
-}
-
-/// Reinterpret `&[MaybeUninit<T>]` as `&[T]`. `MaybeUninit<T>` has identical
-/// layout to `T`; exposing uninitialized bytes as `T` is sound only when any
-/// bit pattern is a valid `T` (in-tree LinearFifo users are byte buffers —
-/// see the `StaticBuffer` TODO below). Centralises the four per-buffer-kind
-/// casts behind one audited block.
-#[inline(always)]
-fn assume_init_slice<T>(s: &[MaybeUninit<T>]) -> &[T] {
-    // SAFETY: see fn doc.
-    unsafe { &*(ptr::from_ref::<[MaybeUninit<T>]>(s) as *const [T]) }
-}
-
-/// Mutable variant of [`assume_init_slice`]. The input borrow is consumed by
-/// the cast, so the returned `&mut [T]` is the sole live reference into the
-/// allocation for its lifetime.
-#[inline(always)]
-fn assume_init_slice_mut<T>(s: &mut [MaybeUninit<T>]) -> &mut [T] {
-    // SAFETY: see `assume_init_slice`.
-    unsafe { &mut *(ptr::from_mut::<[MaybeUninit<T>]>(s) as *mut [T]) }
-}
-
-/// Shift `slice[1..]` down to `slice[0..len-1]` (memmove). Used by
-/// `ordered_remove_item` for the four wrap/non-wrap segment shifts. Not
-/// `slice::copy_within` because that requires `T: Copy`; this fifo permits
-/// move-only `T` (the duplicated tail slot is logically discarded by the
-/// subsequent `count -= 1`).
-#[inline(always)]
-fn shift_down_one<T>(slice: &mut [T]) {
-    if slice.len() <= 1 {
-        return;
-    }
-    // SAFETY: src `[1..len)` and dst `[0..len-1)` are both in-bounds of
-    // `slice`; `ptr::copy` handles the overlap.
-    unsafe { ptr::copy(slice.as_ptr().add(1), slice.as_mut_ptr(), slice.len() - 1) };
-}
-
-#[cfg(debug_assertions)]
-#[inline(always)]
-fn poison<T>(slice: &mut [T], n: usize) {
-    debug_assert!(n <= slice.len());
-    // SAFETY: writing 0xAA into the byte representation of `n` slots that are
-    // about to be logically discarded; never read as `T` again.
-    unsafe {
-        ptr::write_bytes(
-            slice.as_mut_ptr().cast::<u8>(),
-            0xAA,
-            n * mem::size_of::<T>(),
-        )
-    };
 }
 
 // ── .Static ───────────────────────────────────────────────────────────────────
 
-/// `buffer_type == .Static` — inline `[T; N]` storage.
-// TODO(port): Zig leaves the array `undefined`; we use MaybeUninit and expose
-// it as &[T] via pointer cast. Sound only for `T` whose any-bit-pattern is
-// valid (in-tree users are byte buffers). Phase B: bound `T: Copy` or rework
-// accessors to MaybeUninit if a non-POD T appears.
+/// `buffer_type == .Static` — inline `[MaybeUninit<T>; N]` storage.
 pub struct StaticBuffer<T, const N: usize>([MaybeUninit<T>; N]);
 
 impl<T, const N: usize> LinearFifoBuffer<T> for StaticBuffer<T, N> {
@@ -123,30 +59,30 @@ impl<T, const N: usize> LinearFifoBuffer<T> for StaticBuffer<T, N> {
     const DYNAMIC: bool = false;
 
     #[inline]
-    fn as_slice(&self) -> &[T] {
-        assume_init_slice(self.0.as_slice())
+    fn storage(&self) -> &[MaybeUninit<T>] {
+        &self.0
     }
     #[inline]
-    fn as_mut_slice(&mut self) -> &mut [T] {
-        assume_init_slice_mut(self.0.as_mut_slice())
+    fn storage_mut(&mut self) -> &mut [MaybeUninit<T>] {
+        &mut self.0
     }
 }
 
 // ── .Slice ────────────────────────────────────────────────────────────────────
 
-/// `buffer_type == .Slice` — caller-provided `[]T`.
-pub struct SliceBuffer<'a, T>(&'a mut [T]);
+/// `buffer_type == .Slice` — caller-provided `[MaybeUninit<T>]`.
+pub struct SliceBuffer<'a, T>(&'a mut [MaybeUninit<T>]);
 
 impl<'a, T> LinearFifoBuffer<T> for SliceBuffer<'a, T> {
     const POWERS_OF_TWO: bool = false; // Any size slice could be passed in
     const DYNAMIC: bool = false;
 
     #[inline]
-    fn as_slice(&self) -> &[T] {
+    fn storage(&self) -> &[MaybeUninit<T>] {
         self.0
     }
     #[inline]
-    fn as_mut_slice(&mut self) -> &mut [T] {
+    fn storage_mut(&mut self) -> &mut [MaybeUninit<T>] {
         self.0
     }
 }
@@ -164,27 +100,32 @@ impl<T> LinearFifoBuffer<T> for DynamicBuffer<T> {
     const DYNAMIC: bool = true;
 
     #[inline]
-    fn as_slice(&self) -> &[T] {
-        assume_init_slice(&self.0)
+    fn storage(&self) -> &[MaybeUninit<T>] {
+        &self.0
     }
     #[inline]
-    fn as_mut_slice(&mut self) -> &mut [T] {
-        assume_init_slice_mut(&mut self.0)
+    fn storage_mut(&mut self) -> &mut [MaybeUninit<T>] {
+        &mut self.0
     }
 
     fn realloc(&mut self, new_size: usize) -> Result<(), AllocError> {
-        // Zig: `self.allocator.realloc(self.buf, size)` preserving prefix.
-        let mut new = Box::<[T]>::new_uninit_slice(new_size);
-        let n = self.0.len().min(new_size);
-        // SAFETY: disjoint allocations; MaybeUninit copy is always sound.
-        unsafe { ptr::copy_nonoverlapping(self.0.as_ptr(), new.as_mut_ptr(), n) };
-        self.0 = new;
+        // Box→Vec is alloc-free; Vec's grow path does the prefix-preserving
+        // bitwise copy internally (sound for MaybeUninit<T> regardless of T).
+        // try_reserve_exact + restore on Err preserves the old buffer on OOM
+        // so head/count never describe freed storage during unwind.
+        let old_len = self.0.len();
+        let mut v: Vec<MaybeUninit<T>> = mem::take(&mut self.0).into_vec();
+        if new_size > old_len {
+            if let Err(_) = v.try_reserve_exact(new_size - old_len) {
+                self.0 = v.into_boxed_slice(); // restore
+                return Err(AllocError);
+            }
+            v.resize_with(new_size, MaybeUninit::uninit);
+        } else {
+            v.truncate(new_size); // MaybeUninit drop is a no-op
+        }
+        self.0 = v.into_boxed_slice();
         Ok(())
-    }
-
-    fn alloc_swap(&mut self, new_size: usize) -> Result<Box<[MaybeUninit<T>]>, AllocError> {
-        let new = Box::<[T]>::new_uninit_slice(new_size);
-        Ok(mem::replace(&mut self.0, new))
     }
 }
 
@@ -221,7 +162,7 @@ impl<T, const N: usize> LinearFifo<T, StaticBuffer<T, N>> {
 
 impl<'a, T> LinearFifo<T, SliceBuffer<'a, T>> {
     /// `init` for `.Slice`.
-    pub fn init(buf: &'a mut [T]) -> Self {
+    pub fn init(buf: &'a mut [MaybeUninit<T>]) -> Self {
         Self {
             buf: SliceBuffer(buf),
             head: 0,
@@ -275,67 +216,23 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
     }
 
     pub fn realign(&mut self) {
+        if self.head == 0 {
+            return;
+        }
         let buf_len = self.buf_len();
-        if buf_len - self.head >= self.count {
-            // this copy overlaps
-            let count = self.count;
-            let head = self.head;
-            let buf = self.buf.as_mut_slice();
-            // SAFETY: src/dst within same allocation; ptr::copy is memmove.
-            unsafe { ptr::copy(buf.as_ptr().add(head), buf.as_mut_ptr(), count) };
-            self.head = 0;
+        let head = self.head;
+        let count = self.count;
+        let storage = self.buf.storage_mut();
+        if buf_len - head >= count {
+            // Non-wrapped: rotate only the prefix that contains live data.
+            // (rotate_left is O(head+count) vs the previous O(count) memmove;
+            // a `T: Copy` `copy_within` fast-path would need specialization.
+            // realign is only reached from grow/shrink/contiguous-miss paths.)
+            storage[..head + count].rotate_left(head);
         } else {
-            // Zig: `var tmp: [page_size_min / 2 / @sizeOf(T)]T = undefined;`
-            // Stable Rust cannot size a stack array by `size_of::<T>()`, so use
-            // a fixed byte scratch and compute the element count at runtime.
-            // PERF(port): was stack array sized by page_size/2/sizeof(T) — same
-            // byte footprint here, no heap.
-            //
-            // The scratch is a `[MaybeUninit<u8>; _]` (alignment 1). Reading or
-            // writing through it as `*mut T` would violate
-            // `ptr::copy_nonoverlapping`'s alignment precondition for any
-            // `align_of::<T>() > 1`, so the tmp↔buf transfers are done at byte
-            // granularity instead — `*mut u8` only requires 1-byte alignment,
-            // which both the scratch and `buf` (cast down from `*T`) satisfy.
-            let mut tmp_bytes = [MaybeUninit::<u8>::uninit(); PAGE_SIZE_MIN / 2];
-            let tmp_ptr: *mut u8 = tmp_bytes.as_mut_ptr().cast::<u8>();
-            let t_size = mem::size_of::<T>();
-            let tmp_len = (PAGE_SIZE_MIN / 2) / t_size;
-
-            while self.head != 0 {
-                let n = self.head.min(tmp_len);
-                let m = buf_len - n;
-                let buf = self.buf.as_mut_slice();
-                // SAFETY: `tmp` is disjoint from `buf`. The tmp↔buf copies move
-                // `n * size_of::<T>()` raw bytes (no `T` typed access through
-                // the 1-aligned scratch). The buf→buf shift overlaps, so use
-                // `ptr::copy` (memmove); it operates on properly-aligned `*T`.
-                unsafe {
-                    ptr::copy_nonoverlapping(buf.as_ptr().cast::<u8>(), tmp_ptr, n * t_size);
-                    ptr::copy(buf.as_ptr().add(n), buf.as_mut_ptr(), m);
-                    ptr::copy_nonoverlapping(
-                        tmp_ptr,
-                        buf.as_mut_ptr().add(m).cast::<u8>(),
-                        n * t_size,
-                    );
-                }
-                self.head -= n;
-            }
+            storage.rotate_left(head);
         }
-        // set unused area to undefined
-        #[cfg(debug_assertions)]
-        {
-            let count = self.count;
-            let unused = &mut self.buf.as_mut_slice()[count..];
-            // SAFETY: poisoning unused tail; matches Zig `@memset(unused, undefined)`.
-            unsafe {
-                ptr::write_bytes(
-                    unused.as_mut_ptr().cast::<u8>(),
-                    0xAA,
-                    unused.len() * mem::size_of::<T>(),
-                );
-            }
-        }
+        self.head = 0;
     }
 
     /// Reduce allocated capacity to `size`.
@@ -370,18 +267,8 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
             } else {
                 size
             };
-            // Zig: alloc new, memcpy readableSlice(0) bytes, free old.
-            let count = self.count;
-            let old = self.buf.alloc_swap(new_size)?;
-            if count > 0 {
-                let new = self.buf.as_mut_slice();
-                // After realign(), head==0 so readableSlice(0) == old[0..count].
-                // SAFETY: old and new are disjoint allocations.
-                unsafe {
-                    ptr::copy_nonoverlapping(old.as_ptr().cast::<T>(), new.as_mut_ptr(), count);
-                }
-            }
-            // `self.allocator.free(self.buf)` — `old` drops here.
+            // After realign(), head==0; realloc preserves the [0..count) prefix.
+            self.buf.realloc(new_size)?;
             self.head = 0;
             Ok(())
         } else {
@@ -412,15 +299,18 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
         let buf_len = self.buf_len();
         let head = self.head;
         let count = self.count;
-        let buf = self.buf.as_mut_slice();
+        let storage = self.buf.storage_mut();
         let mut start = head + offset;
-        if start >= buf_len {
+        let raw = if start >= buf_len {
             start -= buf_len;
-            &mut buf[start..start + (count - offset)]
+            &mut storage[start..start + (count - offset)]
         } else {
             let end = (head + count).min(buf_len);
-            &mut buf[start..end]
-        }
+            &mut storage[start..end]
+        };
+        // SAFETY: every slot in the [head, head+count) ring-range is
+        // initialized; `raw` is a subslice of that range (offset <= count).
+        unsafe { raw.assume_init_mut() }
     }
 
     /// Returns a readable slice from `offset`
@@ -429,35 +319,41 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
             return &[];
         }
         let buf_len = self.buf_len();
-        let buf = self.buf.as_slice();
+        let storage = self.buf.storage();
         let mut start = self.head + offset;
-        if start >= buf_len {
+        let raw = if start >= buf_len {
             start -= buf_len;
-            &buf[start..start + (self.count - offset)]
+            &storage[start..start + (self.count - offset)]
         } else {
             let end = (self.head + self.count).min(buf_len);
-            &buf[start..end]
+            &storage[start..end]
+        };
+        // SAFETY: every slot in the [head, head+count) ring-range is
+        // initialized; `raw` is a subslice of that range (offset <= count).
+        unsafe { raw.assume_init_ref() }
+    }
+
+    /// The two contiguous initialized halves of the ring buffer, in logical
+    /// order — `(a, b)` such that `a ++ b` is the readable sequence. Mirrors
+    /// `VecDeque::as_mut_slices` but at the `MaybeUninit` layer (used only
+    /// internally for in-place permutations, so no `assume_init` needed).
+    fn readable_segments_mut(&mut self) -> (&mut [MaybeUninit<T>], &mut [MaybeUninit<T>]) {
+        let buf_len = self.buf_len();
+        let head = self.head;
+        let count = self.count;
+        let storage = self.buf.storage_mut();
+        if buf_len - head >= count {
+            (&mut storage[head..head + count], &mut [][..])
+        } else {
+            let wrap_len = count - (buf_len - head);
+            let (front, back) = storage.split_at_mut(head);
+            (back, &mut front[..wrap_len])
         }
     }
 
     /// Discard first `count` items in the fifo
     pub fn discard(&mut self, count: usize) {
         debug_assert!(count <= self.count);
-
-        #[cfg(debug_assertions)]
-        {
-            // set old range to undefined. Note: may be wrapped around
-            // PORT NOTE: reshaped for borrowck — capture len, then re-borrow.
-            let slice_len = self.readable_slice_mut(0).len();
-            if slice_len >= count {
-                poison(self.readable_slice_mut(0), count);
-            } else {
-                poison(self.readable_slice_mut(0), slice_len);
-                let rem = count - slice_len;
-                poison(self.readable_slice_mut(slice_len), rem);
-            }
-        }
-
         let mut head = self.head + count;
         if B::POWERS_OF_TWO {
             // Note it is safe to do a wrapping subtract as
@@ -475,9 +371,11 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
         if self.count == 0 {
             return None;
         }
-        // SAFETY: buf[head] is in the readable region (count > 0); we move it
-        // out and immediately discard(1), so the slot is never read again.
-        let c = unsafe { ptr::read(self.buf.as_slice().as_ptr().add(self.head)) };
+        let head = self.head;
+        // SAFETY: storage[head] is in the readable region (count > 0); we move
+        // it out and immediately discard(1), so the slot is never read as T
+        // again before being rewritten.
+        let c = unsafe { self.buf.storage()[head].assume_init_read() };
         self.discard(1);
         Some(c)
     }
@@ -515,7 +413,7 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
 
     /// Returns the first section of writable buffer.
     /// Note that this may be of length 0.
-    pub fn writable_slice(&mut self, offset: usize) -> &mut [T] {
+    pub fn writable_slice(&mut self, offset: usize) -> &mut [MaybeUninit<T>] {
         let buf_len = self.buf_len();
         if offset > buf_len {
             return &mut [];
@@ -523,20 +421,20 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
         let head = self.head;
         let count = self.count;
         let writable = buf_len - count;
-        let buf = self.buf.as_mut_slice();
+        let storage = self.buf.storage_mut();
         let tail = head + offset + count;
         if tail < buf_len {
-            &mut buf[tail..]
+            &mut storage[tail..]
         } else {
             let start = tail - buf_len;
-            &mut buf[start..start + (writable - offset)]
+            &mut storage[start..start + (writable - offset)]
         }
     }
 
     /// Returns a writable buffer of at least `size` items, allocating memory as needed.
     /// Use `fifo.update` once you've written data to it.
     // TODO(port): narrow error set
-    pub fn writable_with_size(&mut self, size: usize) -> Result<&mut [T], AllocError> {
+    pub fn writable_with_size(&mut self, size: usize) -> Result<&mut [MaybeUninit<T>], AllocError> {
         self.ensure_unused_capacity(size)?;
 
         // try to avoid realigning buffer
@@ -572,7 +470,7 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
                 let writable = self.writable_slice(0);
                 debug_assert!(!writable.is_empty());
                 let n = writable.len().min(src_left.len());
-                writable[..n].copy_from_slice(&src_left[..n]);
+                writable[..n].write_copy_of_slice(&src_left[..n]);
                 n
             };
             self.update(n);
@@ -595,11 +493,7 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
         } else {
             tail %= self.buf_len();
         }
-        // SAFETY: `tail` is in-bounds (capacity reserved by caller). The slot is
-        // logically uninitialized — `ptr::write` matches Zig assignment semantics
-        // (no drop of the prior bit-pattern), required for non-`Copy` `T` whose
-        // backing storage is `MaybeUninit<T>`.
-        unsafe { ptr::write(self.buf.as_mut_slice().as_mut_ptr().add(tail), item) };
+        self.buf.storage_mut()[tail].write(item);
         self.update(1);
     }
 
@@ -617,19 +511,6 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
 
     // TODO(port): `pub fn writer(self: *Self) Writer` — see Reader/Writer note.
 
-    /// Make `count` items available before the current read location
-    fn rewind(&mut self, count: usize) {
-        debug_assert!(self.writable_length() >= count);
-
-        let mut head = self.head + (self.buf_len() - count);
-        if B::POWERS_OF_TWO {
-            head &= self.buf_len() - 1;
-        } else {
-            head %= self.buf_len();
-        }
-        self.head = head;
-        self.count += count;
-    }
 
     /// Place data back into the read stream
     // TODO(port): narrow error set
@@ -639,20 +520,24 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
     {
         self.ensure_unused_capacity(src.len())?;
 
-        self.rewind(src.len());
-
-        // PORT NOTE: reshaped for borrowck — copy into first chunk in a scoped
-        // block, drop borrow, then re-borrow for the wrapped chunk.
-        let slice_len = {
-            let s = self.readable_slice_mut(0);
-            let n = s.len().min(src.len());
-            s[..n].copy_from_slice(&src[..n]);
-            s.len()
-        };
-        if src.len() > slice_len {
-            let slice2 = self.readable_slice_mut(slice_len);
-            slice2[..src.len() - slice_len].copy_from_slice(&src[slice_len..]);
+        // Compute where the rewound head will land, fill those (currently
+        // uninitialized) slots first, then commit head/count. Avoids forming
+        // `&mut [T]` over uninit storage via `readable_slice_mut`.
+        let buf_len = self.buf_len();
+        let mut new_head = self.head + (buf_len - src.len());
+        if B::POWERS_OF_TWO {
+            new_head &= buf_len - 1;
+        } else {
+            new_head %= buf_len;
         }
+        let storage = self.buf.storage_mut();
+        let first_len = (buf_len - new_head).min(src.len());
+        storage[new_head..new_head + first_len].write_copy_of_slice(&src[..first_len]);
+        if src.len() > first_len {
+            storage[..src.len() - first_len].write_copy_of_slice(&src[first_len..]);
+        }
+        self.head = new_head;
+        self.count += src.len();
         Ok(())
     }
 
@@ -663,68 +548,36 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
         T: Copy,
     {
         debug_assert!(offset < self.count);
-
-        let mut index = self.head + offset;
-        if B::POWERS_OF_TWO {
-            index &= self.buf_len() - 1;
-        } else {
-            index %= self.buf_len();
-        }
-        self.buf.as_slice()[index]
+        self.readable_slice(offset)[0]
     }
 
     /// Returns the item at `offset`.
     /// Asserts offset is within bounds.
     pub fn peek_item_mut(&mut self, offset: usize) -> &mut T {
         debug_assert!(offset < self.count);
-
-        let mut index = self.head + offset;
-        if B::POWERS_OF_TWO {
-            index &= self.buf_len() - 1;
-        } else {
-            index %= self.buf_len();
-        }
-        &mut self.buf.as_mut_slice()[index]
+        &mut self.readable_slice_mut(offset)[0]
     }
 
     /// Remove one item at `offset` and MOVE all items after it up one.
+    ///
+    /// The removed element is **not** dropped (matches the Zig original) — it
+    /// is left in the now-unreadable tail slot. Only use with `T` that has no
+    /// drop glue, or follow up with explicit cleanup.
     pub fn ordered_remove_item(&mut self, offset: usize) {
         if offset == 0 {
             return self.discard(1);
         }
-
         debug_assert!(offset < self.count);
 
-        let buf_len = self.buf_len();
-        let head = self.head;
-        let count = self.count;
-
-        if buf_len - head >= count {
-            // If it doesnt overflow past the end, there is one copy to be done
-            let buf = self.buf.as_mut_slice();
-            shift_down_one(&mut buf[head + offset..]);
+        let (a, b) = self.readable_segments_mut();
+        if offset < a.len() {
+            a[offset..].rotate_left(1);
+            if !b.is_empty() {
+                mem::swap(a.last_mut().unwrap(), &mut b[0]);
+                b.rotate_left(1);
+            }
         } else {
-            let mut index = head + offset;
-            if B::POWERS_OF_TWO {
-                index &= buf_len - 1;
-            } else {
-                index %= buf_len;
-            }
-            let buf = self.buf.as_mut_slice();
-            if index < head {
-                // If the item to remove is before the head, one slice is moved.
-                shift_down_one(&mut buf[index..count - head]);
-            } else {
-                // The items before and after the head have to be shifted
-                // SAFETY: buf[0] is initialized (it's in the wrapped readable
-                // region); we move it to the end after shifting.
-                let wrap = unsafe { ptr::read(buf.as_ptr()) };
-                shift_down_one(&mut buf[index..]);
-                // SAFETY: writing into the last slot; previous occupant already
-                // shifted down.
-                unsafe { ptr::write(buf.as_mut_ptr().add(buf_len - 1), wrap) };
-                shift_down_one(&mut buf[..head - count]);
-            }
+            b[offset - a.len()..].rotate_left(1);
         }
         self.count -= 1;
     }
@@ -737,7 +590,7 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
     // land as). Stubbed with generic bounds matching the called methods.
     pub fn pump<R, W, E>(&mut self, mut src_reader: R, dest_writer: &mut W) -> Result<(), E>
     where
-        R: FnMut(&mut [T]) -> Result<usize, E>,
+        R: FnMut(&mut [MaybeUninit<T>]) -> Result<usize, E>,
         W: FnMut(&[T]) -> Result<usize, E>,
     {
         debug_assert!(self.buf_len() > 0);
@@ -777,6 +630,13 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
 // a `where B: LinearFifoBuffer<u8>` bound on the generic impl (which would not
 // constrain `T`).
 impl<B: LinearFifoBuffer<u8>> LinearFifo<u8, B> {
+    /// As [`writable_with_size`] but zero-fills the returned region and hands
+    /// it back as `&mut [u8]`. For callers (websocket frame assembly) that
+    /// pass the buffer to APIs taking `&mut [u8]` and read-modify-write it.
+    pub fn writable_with_size_zeroed(&mut self, size: usize) -> Result<&mut [u8], AllocError> {
+        Ok(self.writable_with_size(size)?.write_filled(0u8))
+    }
+
     /// Same as `read` except it returns an error union
     /// The purpose of this function existing is to match `std.io.Reader` API.
     fn read_fn(&mut self, dest: &mut [u8]) -> Result<usize, core::convert::Infallible> {
@@ -850,7 +710,7 @@ mod tests {
             let buf = fifo.writable_with_size(12).unwrap();
             assert_eq!(12usize, buf.len());
             for i in 0..10 {
-                buf[i] = i as u8 + b'a';
+                buf[i].write(i as u8 + b'a');
             }
             fifo.update(10);
             assert_eq!(b"abcdefghij", fifo.readable_slice(0));
@@ -880,7 +740,7 @@ mod tests {
     // TODO(port): macro-generate the full T×buffer_type matrix in Phase B.
     #[test]
     fn linear_fifo_generic_u8_static() {
-        let mut fifo: LinearFifo<u8, StaticBuffer<u8, 32>> = LinearFifo::init();
+        let mut fifo = LinearFifo::<u8, StaticBuffer<u8, 32>>::init();
 
         fifo.write(&[0, 1, 1, 0, 1]).unwrap();
         assert_eq!(5usize, fifo.readable_length());
@@ -906,6 +766,28 @@ mod tests {
             let n = fifo.read(&mut read_buf);
             assert_eq!(3usize, n); // NOTE: It should be the number of items.
         }
+    }
+
+    #[test]
+    fn ordered_remove_across_wrap() {
+        // Exercise the segment-swap path: cap 8, head 5, count 6 → wrap at 3.
+        let mut fifo = LinearFifo::<u32, StaticBuffer<u32, 8>>::init();
+        for i in 0..8 {
+            fifo.write_item(i).unwrap();
+        }
+        for _ in 0..5 {
+            fifo.read_item();
+        }
+        // readable = [5,6,7] then write 3 more → [5,6,7,100,101,102], head=5
+        fifo.write_item(100).unwrap();
+        fifo.write_item(101).unwrap();
+        fifo.write_item(102).unwrap();
+        assert_eq!(6, fifo.readable_length());
+        // remove offset 1 (value 6) → [5,7,100,101,102]
+        fifo.ordered_remove_item(1);
+        let mut out = [0u32; 5];
+        assert_eq!(5, fifo.read(&mut out));
+        assert_eq!([5, 7, 100, 101, 102], out);
     }
 }
 

--- a/src/collections/multi_array_list.rs
+++ b/src/collections/multi_array_list.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)]
 //! Port of `std.MultiArrayList` with the following Bun-specific additions:
 //!
 //! * `zero` method to zero-initialize memory.

--- a/src/collections/multi_array_list.rs
+++ b/src/collections/multi_array_list.rs
@@ -21,13 +21,38 @@
 //! accessors take a `const NAME: &'static str` generic and verify both the
 //! name and the requested column type against the reflected field's `TypeId`
 //! at compile time, so the column API is fully type-safe with no derive.
+//!
+//! ## Unsafe budget
+//!
+//! This module is the designated `#[allow(unsafe_code)]` exception in
+//! `bun_collections`: a single-allocation SoA buffer with typed column
+//! projection has no safe-std equivalent. Every raw operation is funnelled
+//! through a small primitive set so that each irreducible unsafe pattern
+//! appears exactly once:
+//!
+//! | primitive                       | unsafe op                |
+//! | ------------------------------- | ------------------------ |
+//! | [`column_base`]                 | `NonNull::add`           |
+//! | [`Col::as_slice`]               | `slice::from_raw_parts`  |
+//! | [`ColMut::as_mut_slice`]        | `slice::from_raw_parts_mut` |
+//! | [`Slice::scatter`]              | per-field byte copy      |
+//! | [`Slice::gather`]               | per-field byte copy + `assume_init` |
+//! | [`MultiArrayList::zero`]        | `ptr::write_bytes`       |
+//! | [`MultiArrayList::free_allocated_bytes`] | `Allocator::deallocate` |
+//! | [`__mal_split_mut_impl`] macro  | N-way disjoint `from_raw_parts_mut` |
+//!
+//! plus `unsafe impl Send`/`Sync` and the `pub unsafe fn` caller-contract
+//! signatures on [`set_len`](MultiArrayList::set_len) and
+//! [`column_bytes_mut`](Slice::column_bytes_mut). All row-level mutations
+//! (insert/remove/swap/append/grow/clone) are rebuilt on safe
+//! `<[MaybeUninit<u8>]>` slice ops over [`Col`]/[`ColMut`] views.
 
 use core::alloc::Layout;
 use core::any::TypeId;
 use core::marker::PhantomData;
 use core::mem::type_info::{Type as TypeInfo, TypeKind};
 use core::mem::{ManuallyDrop, MaybeUninit};
-use core::ptr;
+use core::ptr::{self, NonNull};
 use std::alloc::{Allocator, Global};
 
 use bun_alloc::AllocError;
@@ -303,6 +328,11 @@ impl<T> Reflected<T> {
     const COUNT: usize = field_count::<T>();
     const ALIGN: usize = core::mem::align_of::<T>();
 
+    /// Dangling sentinel for an empty buffer. Aligned to `align_of::<T>()`,
+    /// which is `≥ align_of::<F>()` for every field `F`, so casting it to any
+    /// `*const F` yields a valid (non-null, aligned) zero-length-slice base.
+    const DANGLING: NonNull<u8> = NonNull::<T>::dangling().cast::<u8>();
+
     /// `[FieldMeta; COUNT]` in declaration order.
     const META: [FieldMeta; MAX_FIELDS] = {
         let fields = fields_of::<T>();
@@ -433,6 +463,80 @@ impl<T> Reflected<T> {
     }
 }
 
+// ───────────────────────── column primitives ─────────────────────────
+
+/// Base pointer of column `fi` within a buffer of `cap` elements.
+///
+/// **Module invariant** (`INVARIANT:column_base`): `bytes` is either
+/// `Reflected::<T>::DANGLING` with `cap == 0`, or the start of a live
+/// allocation of `ELEM_BYTES * cap` bytes at `align_of::<T>()` alignment.
+/// Under that invariant the result is `T`-aligned for `cap == 0` and aligned
+/// to field `fi`'s true alignment for `cap > 0` (see [`align_sort_key`]).
+#[inline(always)]
+fn column_base<T>(bytes: NonNull<u8>, cap: usize, fi: usize) -> NonNull<u8> {
+    debug_assert!(fi < Reflected::<T>::COUNT);
+    let off = Reflected::<T>::COLUMN_OFFSET_PER_CAP[fi] * cap;
+    // SAFETY: `INVARIANT:column_base` — `cap == 0` ⇒ `off == 0` and `add(0)`
+    // is always defined; `cap > 0` ⇒ `off ≤ ELEM_BYTES * cap` so the result
+    // stays in-bounds of the allocation. `add` retains the `inbounds` GEP
+    // hint that `wrapping_add` would drop.
+    unsafe { bytes.add(off) }
+}
+
+/// Shared typed view of one column. Thin wrapper that exists solely so that
+/// every `from_raw_parts` in this module routes through one audited site.
+struct Col<'a, F> {
+    ptr: NonNull<F>,
+    len: usize,
+    _marker: PhantomData<&'a [F]>,
+}
+
+impl<'a, F> Col<'a, F> {
+    /// **Module invariant** (`INVARIANT:col`): only fed `(ptr, len)` where
+    /// `ptr` is non-null, aligned for `F`, and either dangling with `len == 0`
+    /// or pointing into a column holding `≥ len` initialized `F`s valid for
+    /// `'a`. Upheld by every internal caller; not exposed.
+    #[inline(always)]
+    fn new(ptr: NonNull<F>, len: usize) -> Self {
+        Self {
+            ptr,
+            len,
+            _marker: PhantomData,
+        }
+    }
+
+    #[inline(always)]
+    fn as_slice(self) -> &'a [F] {
+        // SAFETY: `INVARIANT:col`.
+        unsafe { core::slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+    }
+}
+
+/// Exclusive typed view of one column. See [`Col`].
+struct ColMut<'a, F> {
+    ptr: NonNull<F>,
+    len: usize,
+    _marker: PhantomData<&'a mut [F]>,
+}
+
+impl<'a, F> ColMut<'a, F> {
+    /// `INVARIANT:col`, plus exclusive access for `'a`.
+    #[inline(always)]
+    fn new(ptr: NonNull<F>, len: usize) -> Self {
+        Self {
+            ptr,
+            len,
+            _marker: PhantomData,
+        }
+    }
+
+    #[inline(always)]
+    fn as_mut_slice(self) -> &'a mut [F] {
+        // SAFETY: `INVARIANT:col` + exclusive access.
+        unsafe { core::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len) }
+    }
+}
+
 /// Index-based comparison context for `sort` / `sort_span` / `sort_unstable`.
 /// Zig: `ctx: anytype` with `fn lessThan(ctx, a_index: usize, b_index: usize) bool`.
 pub trait SortContext {
@@ -441,7 +545,7 @@ pub trait SortContext {
 
 /// Struct-of-arrays list. See module docs.
 pub struct MultiArrayList<T, A: Allocator = Global> {
-    bytes: *mut u8,
+    bytes: NonNull<u8>,
     len: usize,
     capacity: usize,
     alloc: A,
@@ -456,9 +560,15 @@ unsafe impl<T: Sync, A: Allocator + Sync> Sync for MultiArrayList<T, A> {}
 /// the list. These pointers are not normally stored to reduce the size of the
 /// list in memory. If you are accessing multiple fields, call `slice()` first
 /// to compute the pointers, and then get the field arrays from the slice.
+///
+/// **Known soundness gap**: `Slice<T>: Copy` lets a caller hold two copies and
+/// call `items_mut` / `set` on both, aliasing `&mut`. Removing `Copy` breaks a
+/// large number of `.slice()` snapshot sites that intentionally exploit it for
+/// borrowck (see `LinkerGraph::load`, `bundle_v2`). Tracked separately; treat
+/// `Slice<T>` as a raw-pointer set and avoid overlapping mutable views.
 pub struct Slice<T> {
     /// Indexed by declaration-order field index.
-    ptrs: [*mut u8; MAX_FIELDS],
+    ptrs: [NonNull<u8>; MAX_FIELDS],
     len: usize,
     capacity: usize,
     _marker: PhantomData<T>,
@@ -475,11 +585,28 @@ impl<T> Copy for Slice<T> {}
 
 impl<T> Slice<T> {
     pub const EMPTY: Self = Self {
-        ptrs: [ptr::null_mut(); MAX_FIELDS],
+        ptrs: [Reflected::<T>::DANGLING; MAX_FIELDS],
         len: 0,
         capacity: 0,
         _marker: PhantomData,
     };
+
+    /// Build a `Slice` over a raw buffer. `INVARIANT:column_base` applies.
+    #[inline]
+    fn from_raw(bytes: NonNull<u8>, len: usize, cap: usize) -> Self {
+        let mut ptrs = [Reflected::<T>::DANGLING; MAX_FIELDS];
+        let mut fi = 0;
+        while fi < Reflected::<T>::COUNT {
+            ptrs[fi] = column_base::<T>(bytes, cap, fi);
+            fi += 1;
+        }
+        Self {
+            ptrs,
+            len,
+            capacity: cap,
+            _marker: PhantomData,
+        }
+    }
 
     #[inline]
     pub fn len(&self) -> usize {
@@ -491,6 +618,19 @@ impl<T> Slice<T> {
         self.len == 0
     }
 
+    /// Typed column base for field `fi`. Substitutes a properly-aligned
+    /// dangling pointer when `F` is a ZST (the computed column offset is not
+    /// guaranteed `align_of::<F>()`-aligned for over-aligned ZSTs). For
+    /// `cap == 0` no substitution is needed: `ptrs[fi]` is
+    /// `Reflected::<T>::DANGLING`, which is already aligned for every field.
+    #[inline(always)]
+    fn col_ptr<F>(&self, fi: usize) -> NonNull<F> {
+        if core::mem::size_of::<F>() == 0 {
+            return NonNull::<F>::dangling();
+        }
+        self.ptrs[fi].cast::<F>()
+    }
+
     /// Returns the column slice for field `NAME` typed as `&[F]`.
     ///
     /// Compile-time checked: a const-eval assertion verifies that `T` has a
@@ -498,27 +638,14 @@ impl<T> Slice<T> {
     #[inline]
     pub fn items<const NAME: &'static str, F>(&self) -> &[F] {
         let fi = const { Reflected::<T>::check::<NAME, F>() };
-        let p = if self.capacity == 0 || core::mem::size_of::<F>() == 0 {
-            ptr::NonNull::<F>::dangling().as_ptr()
-        } else {
-            self.ptrs[fi].cast::<F>()
-        };
-        // SAFETY: ZST/empty → dangling is valid for any length; otherwise
-        // column `fi` is `capacity` contiguous `F`s and `len <= capacity`.
-        unsafe { core::slice::from_raw_parts(p, self.len) }
+        Col::new(self.col_ptr::<F>(fi), self.len).as_slice()
     }
 
     /// Returns the mutable column slice for field `NAME` typed as `&mut [F]`.
     #[inline]
     pub fn items_mut<const NAME: &'static str, F>(&mut self) -> &mut [F] {
         let fi = const { Reflected::<T>::check::<NAME, F>() };
-        let p = if self.capacity == 0 || core::mem::size_of::<F>() == 0 {
-            ptr::NonNull::<F>::dangling().as_ptr()
-        } else {
-            self.ptrs[fi].cast::<F>()
-        };
-        // SAFETY: see `items`. `&mut self` enforces exclusive column access.
-        unsafe { core::slice::from_raw_parts_mut(p, self.len) }
+        ColMut::new(self.col_ptr::<F>(fi), self.len).as_mut_slice()
     }
 
     /// Raw column pointer for callers that need simultaneous mutable access to
@@ -533,16 +660,23 @@ impl<T> Slice<T> {
     #[inline]
     pub fn items_raw<const NAME: &'static str, F>(&self) -> *mut F {
         let fi = const { Reflected::<T>::check::<NAME, F>() };
-        if self.capacity == 0 || core::mem::size_of::<F>() == 0 {
-            return ptr::NonNull::<F>::dangling().as_ptr();
-        }
-        self.ptrs[fi].cast::<F>()
+        self.col_ptr::<F>(fi).as_ptr()
     }
 
-    /// Raw column pointer for byte-level operations (internal use).
-    #[inline]
-    fn ptr(&self, field_index: usize) -> *mut u8 {
-        self.ptrs[field_index]
+    /// `&[MaybeUninit<u8>]` over column `fi`'s `len` initialized elements.
+    /// `MaybeUninit<u8>` has alignment 1, so any column base satisfies
+    /// `INVARIANT:col`.
+    #[inline(always)]
+    fn column_uninit(&self, fi: usize) -> &[MaybeUninit<u8>] {
+        let sz = Reflected::<T>::META[fi].size;
+        Col::new(self.ptrs[fi].cast::<MaybeUninit<u8>>(), self.len * sz).as_slice()
+    }
+
+    /// `&mut [MaybeUninit<u8>]` over column `fi`'s `len` elements.
+    #[inline(always)]
+    fn column_uninit_mut(&mut self, fi: usize) -> &mut [MaybeUninit<u8>] {
+        let sz = Reflected::<T>::META[fi].size;
+        ColMut::new(self.ptrs[fi].cast::<MaybeUninit<u8>>(), self.len * sz).as_mut_slice()
     }
 
     /// Raw byte view of column `field_index` (declaration order). For
@@ -554,12 +688,8 @@ impl<T> Slice<T> {
     #[inline]
     pub unsafe fn column_bytes_mut(&mut self, field_index: usize) -> &mut [u8] {
         debug_assert!(field_index < Reflected::<T>::COUNT);
-        let size = Reflected::<T>::META[field_index].size;
-        if size == 0 || self.capacity == 0 {
-            return &mut [];
-        }
-        // SAFETY: column `field_index` is `len * size` bytes within the allocation.
-        unsafe { core::slice::from_raw_parts_mut(self.ptrs[field_index], self.len * size) }
+        let sz = Reflected::<T>::META[field_index].size;
+        ColMut::new(self.ptrs[field_index].cast::<u8>(), self.len * sz).as_mut_slice()
     }
 
     /// `size_of` the `field_index`th field (declaration order).
@@ -573,8 +703,7 @@ impl<T> Slice<T> {
             index < self.len,
             "MultiArrayList::Slice::set: index out of bounds"
         );
-        // SAFETY: `index < len <= capacity`; ptrs are valid columns.
-        unsafe { scatter::<T>(&self.ptrs, index, elem) };
+        self.scatter(index, elem);
     }
 
     /// Gather a `T` by per-field `ptr::read` from each column.
@@ -589,8 +718,7 @@ impl<T> Slice<T> {
             index < self.len,
             "MultiArrayList::Slice::get: index out of bounds"
         );
-        // SAFETY: `index < len <= capacity`; ptrs are valid columns.
-        ManuallyDrop::new(unsafe { gather::<T>(&self.ptrs, index) })
+        ManuallyDrop::new(self.gather(index))
     }
 
     pub fn to_multi_array_list(self) -> MultiArrayList<T> {
@@ -608,59 +736,122 @@ impl<T> Slice<T> {
             _marker: PhantomData,
         }
     }
-}
 
-// ───────────────────── scatter / gather (byte-level) ──────────────────────
+    // ── private row ops (safe std slice ops over `column_uninit_mut`) ──
 
-/// Scatter `elem`'s fields into the per-field column pointers at `index`.
-///
-/// # Safety
-/// `ptrs[i]` must point to a column of at least `index + 1` elements of the
-/// `i`th field's type.
-#[inline]
-unsafe fn scatter<T>(ptrs: &[*mut u8; MAX_FIELDS], index: usize, elem: T) {
-    let elem = ManuallyDrop::new(elem);
-    let src = (&raw const *elem).cast::<u8>();
-    let n = Reflected::<T>::COUNT;
-    let mut i = 0;
-    while i < n {
-        let m = Reflected::<T>::META[i];
-        if m.size != 0 {
-            // SAFETY: `src + offset` points to the field within `elem`;
-            // `ptrs[i] + index * size` is the column slot. Both regions are
-            // `m.size` bytes and do not overlap (stack vs heap).
-            unsafe {
-                ptr::copy_nonoverlapping(src.add(m.offset), ptrs[i].add(index * m.size), m.size);
+    /// memmove rows `[src, src+n)` → `[dst, dst+n)` in every column.
+    #[inline]
+    fn copy_rows_within(&mut self, src: usize, dst: usize, n: usize) {
+        if n == 0 {
+            return;
+        }
+        debug_assert!(src.max(dst) + n <= self.len);
+        for fi in 0..Reflected::<T>::COUNT {
+            let sz = Reflected::<T>::META[fi].size;
+            if sz == 0 {
+                continue;
+            }
+            self.column_uninit_mut(fi)
+                .copy_within(src * sz..(src + n) * sz, dst * sz);
+        }
+    }
+
+    /// Swap rows `a` and `b` in every column.
+    #[inline]
+    fn swap_rows(&mut self, a: usize, b: usize) {
+        if a == b {
+            return;
+        }
+        let (lo, hi) = if a < b { (a, b) } else { (b, a) };
+        debug_assert!(hi < self.len);
+        for fi in 0..Reflected::<T>::COUNT {
+            let sz = Reflected::<T>::META[fi].size;
+            if sz == 0 {
+                continue;
+            }
+            let col = self.column_uninit_mut(fi);
+            let (l, r) = col.split_at_mut(hi * sz);
+            l[lo * sz..(lo + 1) * sz].swap_with_slice(&mut r[..sz]);
+        }
+    }
+
+    /// memcpy rows `[0, n)` of `src` → `[dst_off, dst_off+n)` of `self`.
+    /// `src` and `self` must be backed by **distinct** allocations (every
+    /// internal caller — grow / shrink / clone / append-other — satisfies this).
+    #[inline]
+    fn copy_rows_from(&mut self, dst_off: usize, src: &Slice<T>, n: usize) {
+        if n == 0 {
+            return;
+        }
+        debug_assert!(n <= src.len);
+        debug_assert!(dst_off + n <= self.len);
+        for fi in 0..Reflected::<T>::COUNT {
+            let sz = Reflected::<T>::META[fi].size;
+            if sz == 0 {
+                continue;
+            }
+            debug_assert_ne!(
+                self.ptrs[fi], src.ptrs[fi],
+                "copy_rows_from: aliased columns"
+            );
+            let dst = &mut self.column_uninit_mut(fi)[dst_off * sz..(dst_off + n) * sz];
+            dst.copy_from_slice(&src.column_uninit(fi)[..n * sz]);
+        }
+    }
+
+    /// Scatter `elem`'s fields into the column slots at `index`.
+    /// Safe: `index < self.len` is the only precondition, asserted by [`set`].
+    #[inline]
+    fn scatter(&mut self, index: usize, elem: T) {
+        debug_assert!(index < self.len);
+        let elem = ManuallyDrop::new(elem);
+        let src = (&raw const *elem).cast::<u8>();
+        // SAFETY: per `INVARIANT:column_base`, `ptrs[i]` addresses a column of
+        // `≥ len` slots of field `i`; `index < len`. `src + offset` addresses
+        // field `i` within the stack `elem`. Regions are `m.size` bytes, stack
+        // vs heap, never overlap.
+        unsafe {
+            let mut i = 0;
+            while i < Reflected::<T>::COUNT {
+                let m = Reflected::<T>::META[i];
+                if m.size != 0 {
+                    ptr::copy_nonoverlapping(
+                        src.add(m.offset),
+                        self.ptrs[i].as_ptr().add(index * m.size),
+                        m.size,
+                    );
+                }
+                i += 1;
             }
         }
-        i += 1;
     }
-}
 
-/// Gather a `T` from the per-field column pointers at `index`.
-///
-/// # Safety
-/// `ptrs[i]` must point to a column of at least `index + 1` initialized
-/// elements of the `i`th field's type.
-#[inline]
-unsafe fn gather<T>(ptrs: &[*mut u8; MAX_FIELDS], index: usize) -> T {
-    let mut out = MaybeUninit::<T>::uninit();
-    let dst = out.as_mut_ptr().cast::<u8>();
-    let n = Reflected::<T>::COUNT;
-    let mut i = 0;
-    while i < n {
-        let m = Reflected::<T>::META[i];
-        if m.size != 0 {
-            // SAFETY: see `scatter`.
-            unsafe {
-                ptr::copy_nonoverlapping(ptrs[i].add(index * m.size), dst.add(m.offset), m.size);
+    /// Gather a `T` from the column slots at `index`. Bitwise copy; caller
+    /// is responsible for ownership semantics (see [`get`] / [`drop_elements`]).
+    #[inline]
+    fn gather(&self, index: usize) -> T {
+        debug_assert!(index < self.len);
+        let mut out = MaybeUninit::<T>::uninit();
+        let dst = out.as_mut_ptr().cast::<u8>();
+        // SAFETY: see `scatter`. Every named-field byte of `out` is written;
+        // padding stays uninitialized, which `assume_init` permits (matches
+        // `ptr::read` semantics).
+        unsafe {
+            let mut i = 0;
+            while i < Reflected::<T>::COUNT {
+                let m = Reflected::<T>::META[i];
+                if m.size != 0 {
+                    ptr::copy_nonoverlapping(
+                        self.ptrs[i].as_ptr().add(index * m.size),
+                        dst.add(m.offset),
+                        m.size,
+                    );
+                }
+                i += 1;
             }
+            out.assume_init()
         }
-        i += 1;
     }
-    // SAFETY: every named field byte has been written; padding bytes remain
-    // uninitialized, which is permitted for `T` (matches `ptr::read` semantics).
-    unsafe { out.assume_init() }
 }
 
 // ───────────────────────────── MultiArrayList ─────────────────────────────
@@ -673,7 +864,7 @@ impl<T> Default for MultiArrayList<T, Global> {
 
 impl<T> MultiArrayList<T, Global> {
     pub const EMPTY: Self = Self {
-        bytes: ptr::null_mut(),
+        bytes: Reflected::<T>::DANGLING,
         len: 0,
         capacity: 0,
         alloc: Global,
@@ -686,7 +877,7 @@ impl<T, A: Allocator> MultiArrayList<T, A> {
     #[inline]
     pub const fn new_in(alloc: A) -> Self {
         Self {
-            bytes: ptr::null_mut(),
+            bytes: Reflected::<T>::DANGLING,
             len: 0,
             capacity: 0,
             alloc,
@@ -726,40 +917,18 @@ impl<T, A: Allocator> MultiArrayList<T, A> {
     /// Compute pointers to the start of each field of the array.
     /// If you need to access multiple fields, calling this may
     /// be more efficient than calling `items()` multiple times.
+    #[inline]
     pub fn slice(&self) -> Slice<T> {
-        let mut result = Slice::<T> {
-            ptrs: [ptr::null_mut(); MAX_FIELDS],
-            len: self.len,
-            capacity: self.capacity,
-            _marker: PhantomData,
-        };
-        let (bytes, fields) = Reflected::<T>::SIZES;
-        let mut p = self.bytes;
-        let mut k = 0;
-        while k < Reflected::<T>::COUNT {
-            result.ptrs[fields[k]] = p;
-            // SAFETY: `p` walks within the single allocation of
-            // `capacity_in_bytes(self.capacity)` bytes (or is null when
-            // capacity == 0, in which case bytes[k] * 0 == 0 and add(0) is OK).
-            // `add` keeps the `inbounds` GEP hint that `wrapping_add` drops.
-            p = unsafe { p.add(bytes[k] * self.capacity) };
-            k += 1;
-        }
-        result
+        Slice::from_raw(self.bytes, self.len, self.capacity)
     }
 
-    /// Compute the column base pointer for field index `fi`.
-    #[inline]
-    fn column_ptr_by_index(&self, fi: usize) -> *mut u8 {
-        if self.capacity == 0 {
-            return ptr::null_mut();
+    /// Typed column base for field `fi`. See [`Slice::col_ptr`].
+    #[inline(always)]
+    fn col_ptr<F>(&self, fi: usize) -> NonNull<F> {
+        if core::mem::size_of::<F>() == 0 {
+            return NonNull::<F>::dangling();
         }
-        // SAFETY: column offset within the single allocation; always in-bounds.
-        // `add` keeps the `inbounds` GEP hint that `wrapping_add` drops.
-        unsafe {
-            self.bytes
-                .add(Reflected::<T>::COLUMN_OFFSET_PER_CAP[fi] * self.capacity)
-        }
+        column_base::<T>(self.bytes, self.capacity, fi).cast::<F>()
     }
 
     /// Get the shared slice of values for field `NAME`.
@@ -769,27 +938,14 @@ impl<T, A: Allocator> MultiArrayList<T, A> {
     #[inline]
     pub fn items<const NAME: &'static str, F>(&self) -> &[F] {
         let fi = const { Reflected::<T>::check::<NAME, F>() };
-        let p = if self.capacity == 0 || core::mem::size_of::<F>() == 0 {
-            ptr::NonNull::<F>::dangling().as_ptr()
-        } else {
-            self.column_ptr_by_index(fi).cast::<F>()
-        };
-        // SAFETY: ZST/empty → dangling is valid for any length; otherwise the
-        // column holds `capacity` aligned `F`s and `len <= capacity`.
-        unsafe { core::slice::from_raw_parts(p, self.len) }
+        Col::new(self.col_ptr::<F>(fi), self.len).as_slice()
     }
 
     /// Get the mutable slice of values for field `NAME`.
     #[inline]
     pub fn items_mut<const NAME: &'static str, F>(&mut self) -> &mut [F] {
         let fi = const { Reflected::<T>::check::<NAME, F>() };
-        let p = if self.capacity == 0 || core::mem::size_of::<F>() == 0 {
-            ptr::NonNull::<F>::dangling().as_ptr()
-        } else {
-            self.column_ptr_by_index(fi).cast::<F>()
-        };
-        // SAFETY: see `items`. `&mut self` enforces exclusive column access.
-        unsafe { core::slice::from_raw_parts_mut(p, self.len) }
+        ColMut::new(self.col_ptr::<F>(fi), self.len).as_mut_slice()
     }
 
     /// Raw column pointer; see [`Slice::items_raw`]. Obtaining the pointer is
@@ -797,10 +953,7 @@ impl<T, A: Allocator> MultiArrayList<T, A> {
     #[inline]
     pub fn items_raw<const NAME: &'static str, F>(&self) -> *mut F {
         let fi = const { Reflected::<T>::check::<NAME, F>() };
-        if self.capacity == 0 || core::mem::size_of::<F>() == 0 {
-            return ptr::NonNull::<F>::dangling().as_ptr();
-        }
-        self.column_ptr_by_index(fi).cast::<F>()
+        self.col_ptr::<F>(fi).as_ptr()
     }
 
     /// Overwrite one array element with new data.
@@ -883,45 +1036,18 @@ impl<T, A: Allocator> MultiArrayList<T, A> {
     pub fn insert_assume_capacity(&mut self, index: usize, elem: T) {
         debug_assert!(self.len < self.capacity);
         debug_assert!(index <= self.len);
+        let tail = self.len - index;
         self.len += 1;
-        let mut slices = self.slice();
-        for fi in 0..Reflected::<T>::COUNT {
-            let size = Reflected::<T>::META[fi].size;
-            if size == 0 {
-                continue;
-            }
-            let base = slices.ptr(fi);
-            let mut i = self.len - 1;
-            while i > index {
-                // SAFETY: `i` and `i-1` are < len <= capacity; column is contiguous.
-                unsafe {
-                    ptr::copy_nonoverlapping(base.add((i - 1) * size), base.add(i * size), size);
-                }
-                i -= 1;
-            }
-        }
-        slices.set(index, elem);
+        let mut s = self.slice();
+        s.copy_rows_within(index, index + 1, tail);
+        s.scatter(index, elem);
     }
 
     pub fn append_list_assume_capacity(&mut self, other: &Self) {
         let offset = self.len;
         self.len += other.len;
-        let other_slice = other.slice();
-        let this_slice = self.slice();
-        for fi in 0..Reflected::<T>::COUNT {
-            let size = Reflected::<T>::META[fi].size;
-            if size != 0 {
-                // SAFETY: `offset + other.len <= self.capacity` (caller contract);
-                // columns are contiguous and non-overlapping (distinct allocations).
-                unsafe {
-                    ptr::copy_nonoverlapping(
-                        other_slice.ptr(fi),
-                        this_slice.ptr(fi).add(offset * size),
-                        other.len * size,
-                    );
-                }
-            }
-        }
+        let mut s = self.slice();
+        s.copy_rows_from(offset, &other.slice(), other.len);
     }
 
     /// Remove the specified item from the list, swapping the last
@@ -932,23 +1058,9 @@ impl<T, A: Allocator> MultiArrayList<T, A> {
             index < self.len,
             "MultiArrayList::swap_remove: index out of bounds"
         );
-        let slices = self.slice();
-        for fi in 0..Reflected::<T>::COUNT {
-            let size = Reflected::<T>::META[fi].size;
-            if size == 0 {
-                continue;
-            }
-            let base = slices.ptr(fi);
-            // SAFETY: `index < len` and `len-1 < len <= capacity`. Regions overlap
-            // exactly when `index == len-1` (src == dst), which `copy` handles.
-            unsafe {
-                ptr::copy(
-                    base.add((self.len - 1) * size),
-                    base.add(index * size),
-                    size,
-                );
-            }
-        }
+        let last = self.len - 1;
+        let mut s = self.slice();
+        s.copy_rows_within(last, index, 1);
         self.len -= 1;
     }
 
@@ -959,22 +1071,9 @@ impl<T, A: Allocator> MultiArrayList<T, A> {
             index < self.len,
             "MultiArrayList::ordered_remove: index out of bounds"
         );
-        let slices = self.slice();
-        for fi in 0..Reflected::<T>::COUNT {
-            let size = Reflected::<T>::META[fi].size;
-            if size == 0 {
-                continue;
-            }
-            let base = slices.ptr(fi);
-            let mut i = index;
-            while i < self.len - 1 {
-                // SAFETY: `i` and `i+1` are < len <= capacity.
-                unsafe {
-                    ptr::copy_nonoverlapping(base.add((i + 1) * size), base.add(i * size), size);
-                }
-                i += 1;
-            }
-        }
+        let tail = self.len - 1 - index;
+        let mut s = self.slice();
+        s.copy_rows_within(index + 1, index, tail);
         self.len -= 1;
     }
 
@@ -994,38 +1093,24 @@ impl<T, A: Allocator> MultiArrayList<T, A> {
         debug_assert!(new_len <= self.capacity);
         debug_assert!(new_len <= self.len);
 
-        let other_layout = layout_for::<T>(new_len);
-        let other_bytes = match aligned_alloc(&self.alloc, other_layout) {
+        let new_bytes = match aligned_alloc::<T, _>(&self.alloc, layout_for::<T>(new_len)) {
             Ok(p) => p,
             Err(_) => {
                 self.len = new_len;
                 return;
             }
         };
-        // Copy columns into the fresh allocation.
         self.len = new_len;
-        let self_slice = self.slice();
-        let mut dst = other_bytes;
-        let (bytes, fields) = Reflected::<T>::SIZES;
-        for k in 0..Reflected::<T>::COUNT {
-            let size = bytes[k];
-            if size != 0 {
-                // SAFETY: both columns hold `new_len` elements; allocations distinct.
-                unsafe {
-                    ptr::copy_nonoverlapping(self_slice.ptr(fields[k]), dst, new_len * size);
-                }
-            }
-            // SAFETY: within the fresh allocation; always in-bounds.
-            dst = unsafe { dst.add(size * new_len) };
-        }
+        let mut dst = Slice::<T>::from_raw(new_bytes, new_len, new_len);
+        dst.copy_rows_from(0, &self.slice(), new_len);
         self.free_allocated_bytes();
-        self.bytes = other_bytes;
+        self.bytes = new_bytes;
         self.capacity = new_len;
     }
 
     pub fn clear_and_free(&mut self) {
         self.free_allocated_bytes();
-        self.bytes = ptr::null_mut();
+        self.bytes = Reflected::<T>::DANGLING;
         self.len = 0;
         self.capacity = 0;
     }
@@ -1046,12 +1131,7 @@ impl<T, A: Allocator> MultiArrayList<T, A> {
         if core::mem::needs_drop::<T>() && self.len != 0 {
             let s = self.slice();
             for i in 0..self.len {
-                // SAFETY: `i < len <= capacity`; every column holds an
-                // initialized field at `i`. `gather` bit-copies those bytes
-                // into a stack `T`; dropping it runs each field's destructor
-                // exactly once. The SoA bytes for row `i` are not read again:
-                // `len` is zeroed immediately after the loop.
-                unsafe { drop(gather::<T>(&s.ptrs, i)) };
+                drop(s.gather(i));
             }
         }
         self.len = 0;
@@ -1084,28 +1164,10 @@ impl<T, A: Allocator> MultiArrayList<T, A> {
     /// `new_capacity` must be greater or equal to `len`.
     pub fn set_capacity(&mut self, new_capacity: usize) -> Result<(), AllocError> {
         debug_assert!(new_capacity >= self.len);
-        let new_layout = layout_for::<T>(new_capacity);
-        let new_bytes = aligned_alloc(&self.alloc, new_layout)?;
-        if self.len == 0 {
-            self.free_allocated_bytes();
-            self.bytes = new_bytes;
-            self.capacity = new_capacity;
-            return Ok(());
-        }
-        // Copy each column into the new allocation, then free the old one.
-        let self_slice = self.slice();
-        let mut dst = new_bytes;
-        let (bytes, fields) = Reflected::<T>::SIZES;
-        for k in 0..Reflected::<T>::COUNT {
-            let size = bytes[k];
-            if size != 0 {
-                // SAFETY: both columns hold `self.len` elements; allocations distinct.
-                unsafe {
-                    ptr::copy_nonoverlapping(self_slice.ptr(fields[k]), dst, self.len * size);
-                }
-            }
-            // SAFETY: within the fresh allocation; always in-bounds.
-            dst = unsafe { dst.add(size * new_capacity) };
+        let new_bytes = aligned_alloc::<T, _>(&self.alloc, layout_for::<T>(new_capacity))?;
+        if self.len != 0 {
+            let mut dst = Slice::<T>::from_raw(new_bytes, self.len, new_capacity);
+            dst.copy_rows_from(0, &self.slice(), self.len);
         }
         self.free_allocated_bytes();
         self.bytes = new_bytes;
@@ -1121,43 +1183,14 @@ impl<T, A: Allocator> MultiArrayList<T, A> {
         let mut result = Self::new_in(self.alloc.clone());
         result.ensure_total_capacity(self.len)?;
         result.len = self.len;
-        let self_slice = self.slice();
-        let result_slice = result.slice();
-        for fi in 0..Reflected::<T>::COUNT {
-            let size = Reflected::<T>::META[fi].size;
-            if size != 0 {
-                // SAFETY: both columns hold `self.len` elements; allocations distinct.
-                unsafe {
-                    ptr::copy_nonoverlapping(
-                        self_slice.ptr(fi),
-                        result_slice.ptr(fi),
-                        self.len * size,
-                    );
-                }
-            }
-        }
+        let mut dst = result.slice();
+        dst.copy_rows_from(0, &self.slice(), self.len);
         Ok(result)
     }
 
-    fn sort_internal<C: SortContext, const STABLE: bool>(&self, a: usize, b: usize, ctx: C) {
-        let slice = self.slice();
-        let swap = |a_index: usize, b_index: usize| {
-            for fi in 0..Reflected::<T>::COUNT {
-                let size = Reflected::<T>::META[fi].size;
-                if size != 0 {
-                    let base = slice.ptr(fi);
-                    // SAFETY: indices are < len; columns are contiguous; a != b
-                    // is guaranteed by sort impls.
-                    unsafe {
-                        ptr::swap_nonoverlapping(
-                            base.add(a_index * size),
-                            base.add(b_index * size),
-                            size,
-                        );
-                    }
-                }
-            }
-        };
+    fn sort_internal<C: SortContext, const STABLE: bool>(&mut self, a: usize, b: usize, ctx: C) {
+        let mut slice = self.slice();
+        let swap = |ai: usize, bi: usize| slice.swap_rows(ai, bi);
         let less = |ai: usize, bi: usize| ctx.less_than(ai, bi);
 
         match STABLE {
@@ -1167,31 +1200,27 @@ impl<T, A: Allocator> MultiArrayList<T, A> {
     }
 
     /// Stable sort by index-based context.
-    pub fn sort<C: SortContext>(&self, ctx: C) {
+    pub fn sort<C: SortContext>(&mut self, ctx: C) {
         self.sort_internal::<C, true>(0, self.len, ctx);
     }
 
     /// Stable sort of `[a, b)` by index-based context.
-    pub fn sort_span<C: SortContext>(&self, a: usize, b: usize, ctx: C) {
+    pub fn sort_span<C: SortContext>(&mut self, a: usize, b: usize, ctx: C) {
         self.sort_internal::<C, true>(a, b, ctx);
     }
 
     /// Unstable sort by index-based context.
-    pub fn sort_unstable<C: SortContext>(&self, ctx: C) {
+    pub fn sort_unstable<C: SortContext>(&mut self, ctx: C) {
         self.sort_internal::<C, false>(0, self.len, ctx);
     }
 
     /// Unstable sort of `[a, b)` by index-based context.
-    pub fn sort_span_unstable<C: SortContext>(&self, a: usize, b: usize, ctx: C) {
+    pub fn sort_span_unstable<C: SortContext>(&mut self, a: usize, b: usize, ctx: C) {
         self.sort_internal::<C, false>(a, b, ctx);
     }
 
     pub fn capacity_in_bytes(capacity: usize) -> usize {
         Reflected::<T>::ELEM_BYTES * capacity
-    }
-
-    fn allocated_bytes(&self) -> (*mut u8, usize) {
-        (self.bytes, Self::capacity_in_bytes(self.capacity))
     }
 
     /// Returns the amount of memory used by this list, in bytes.
@@ -1200,11 +1229,14 @@ impl<T, A: Allocator> MultiArrayList<T, A> {
     }
 
     /// Zero-initialize all allocated memory.
-    pub fn zero(&self) {
-        let (p, n) = self.allocated_bytes();
+    pub fn zero(&mut self) {
+        let n = Self::capacity_in_bytes(self.capacity);
         if n != 0 {
-            // SAFETY: `p` is the start of an allocation of `n` bytes.
-            unsafe { ptr::write_bytes(p, 0, n) };
+            // SAFETY: `bytes` is the start of an allocation of `n` bytes
+            // (`INVARIANT:column_base`, with `capacity > 0` implied by `n > 0`).
+            // Kept as `write_bytes`: `[MaybeUninit<u8>]::fill` is not
+            // memset-specialized, and this is on the bundler hot path.
+            unsafe { ptr::write_bytes(self.bytes.as_ptr(), 0, n) };
         }
     }
 
@@ -1212,16 +1244,13 @@ impl<T, A: Allocator> MultiArrayList<T, A> {
     /// repeat call is a no-op. Safe: `bytes`/`capacity` are private and every
     /// constructor/mutator upholds the invariant that when
     /// `layout_for::<T>(self.capacity)` is `Some(layout)`, `self.bytes` is a
-    /// live non-null allocation from `self.alloc` with exactly `layout` (see
+    /// live allocation from `self.alloc` with exactly `layout` (see
     /// [`aligned_alloc`] / [`set_capacity`]).
     fn free_allocated_bytes(&mut self) {
         if let Some(layout) = layout_for::<T>(self.capacity) {
-            // SAFETY: type invariant above — `self.bytes` is non-null and was
-            // allocated by `self.alloc` with exactly `layout`.
-            unsafe {
-                self.alloc
-                    .deallocate(ptr::NonNull::new_unchecked(self.bytes), layout)
-            };
+            // SAFETY: type invariant above — `self.bytes` was allocated by
+            // `self.alloc` with exactly `layout`.
+            unsafe { self.alloc.deallocate(self.bytes, layout) };
             // Re-establish the invariant immediately so an (accidental) second
             // call before the caller installs a new buffer is a no-op rather
             // than a double-free. Callers overwrite both fields right after.
@@ -1253,14 +1282,7 @@ impl<T, A: Allocator> Drop for MultiArrayList<T, A> {
         // `LineOffsetTable.columns_for_non_ascii: Vec<i32>`), call
         // [`MultiArrayList::drop_elements`] before letting this run, or the
         // column payloads leak.
-        if let Some(layout) = layout_for::<T>(self.capacity) {
-            // SAFETY: `bytes` was allocated with exactly `layout` and is
-            // freed exactly once here.
-            unsafe {
-                self.alloc
-                    .deallocate(ptr::NonNull::new_unchecked(self.bytes), layout)
-            };
-        }
+        self.free_allocated_bytes();
     }
 }
 
@@ -1306,13 +1328,16 @@ fn layout_for<T>(capacity: usize) -> Option<Layout> {
     Some(Layout::from_size_align(n, Reflected::<T>::ALIGN).expect("MultiArrayList layout overflow"))
 }
 
-fn aligned_alloc<A: Allocator>(alloc: &A, layout: Option<Layout>) -> Result<*mut u8, AllocError> {
+fn aligned_alloc<T, A: Allocator>(
+    alloc: &A,
+    layout: Option<Layout>,
+) -> Result<NonNull<u8>, AllocError> {
     let Some(layout) = layout else {
-        return Ok(ptr::null_mut());
+        return Ok(Reflected::<T>::DANGLING);
     };
     alloc
         .allocate(layout)
-        .map(|p| p.as_ptr().cast::<u8>())
+        .map(|p| p.cast::<u8>())
         .map_err(|_| AllocError)
 }
 
@@ -1322,7 +1347,7 @@ fn bun_collections_sort_context(
     a: usize,
     b: usize,
     less: impl Fn(usize, usize) -> bool,
-    swap: impl Fn(usize, usize),
+    mut swap: impl FnMut(usize, usize),
 ) {
     debug_assert!(a <= b);
     if a >= b {
@@ -1343,7 +1368,7 @@ fn bun_collections_sort_unstable_context(
     a: usize,
     b: usize,
     less: impl Fn(usize, usize) -> bool,
-    swap: impl Fn(usize, usize),
+    mut swap: impl FnMut(usize, usize),
 ) {
     debug_assert!(a <= b);
     if b - a < 2 {
@@ -1353,7 +1378,7 @@ fn bun_collections_sort_unstable_context(
     let mut i = a + (b - a) / 2;
     while i > a {
         i -= 1;
-        sift_down(a, i, b, &less, &swap);
+        sift_down(a, i, b, &less, &mut swap);
     }
 
     i = b;
@@ -1363,7 +1388,7 @@ fn bun_collections_sort_unstable_context(
             break;
         }
         swap(a, i);
-        sift_down(a, a, i, &less, &swap);
+        sift_down(a, a, i, &less, &mut swap);
     }
 }
 
@@ -1372,7 +1397,7 @@ fn sift_down(
     target: usize,
     b: usize,
     less: &impl Fn(usize, usize) -> bool,
-    swap: &impl Fn(usize, usize),
+    swap: &mut impl FnMut(usize, usize),
 ) {
     let mut cur = target;
     loop {
@@ -1461,6 +1486,71 @@ mod tests {
         list.push(Borrowed { name: b"hi", n: 7 }).unwrap();
         assert_eq!(list.items::<"name", &[u8]>()[0], b"hi");
         assert_eq!(list.items::<"n", u32>()[0], 7);
+    }
+
+    #[test]
+    fn empty_items_aligned() {
+        // Exercise the `cap == 0` path: must yield a valid empty `&[u64]`
+        // (i.e. a `u64`-aligned dangling base, not `NonNull::<u8>::dangling()`).
+        let list = MultiArrayList::<Foo>::default();
+        assert_eq!(list.items::<"c", u64>(), &[] as &[u64]);
+        let s = Slice::<Foo>::EMPTY;
+        assert_eq!(s.items::<"c", u64>(), &[] as &[u64]);
+    }
+
+    #[test]
+    fn insert_ordered_remove_memmove() {
+        let mut list = MultiArrayList::<Foo>::default();
+        for i in 0..6u32 {
+            list.push(Foo {
+                a: i,
+                b: i as u8,
+                c: i as u64,
+            })
+            .unwrap();
+        }
+        list.insert(
+            2,
+            Foo {
+                a: 99,
+                b: 99,
+                c: 99,
+            },
+        )
+        .unwrap();
+        assert_eq!(list.items::<"a", u32>(), &[0, 1, 99, 2, 3, 4, 5]);
+        list.ordered_remove(2);
+        assert_eq!(list.items::<"a", u32>(), &[0, 1, 2, 3, 4, 5]);
+        list.swap_remove(1);
+        assert_eq!(list.items::<"a", u32>(), &[0, 5, 2, 3, 4]);
+    }
+
+    #[test]
+    fn sort_swaps_all_columns() {
+        let mut list = MultiArrayList::<Foo>::default();
+        for i in (0..5u32).rev() {
+            list.push(Foo {
+                a: i,
+                b: i as u8,
+                c: i as u64 * 10,
+            })
+            .unwrap();
+        }
+        let raw = list.items_raw::<"a", u32>();
+        let len = list.len();
+        struct Ctx {
+            a: *const u32,
+            len: usize,
+        }
+        impl SortContext for Ctx {
+            fn less_than(&self, ai: usize, bi: usize) -> bool {
+                debug_assert!(ai < self.len && bi < self.len);
+                unsafe { *self.a.add(ai) < *self.a.add(bi) }
+            }
+        }
+        list.sort(Ctx { a: raw, len });
+        assert_eq!(list.items::<"a", u32>(), &[0, 1, 2, 3, 4]);
+        assert_eq!(list.items::<"c", u64>(), &[0, 10, 20, 30, 40]);
     }
 }
 

--- a/src/collections/pool.rs
+++ b/src/collections/pool.rs
@@ -1,245 +1,45 @@
 use core::cell::RefCell;
-use core::marker::PhantomData;
-use core::mem::{MaybeUninit, offset_of};
-use core::ptr;
 
-use bun_core::Error;
-
-// ──────────────────────────────────────────────────────────────────────────
-// SinglyLinkedList
-// ──────────────────────────────────────────────────────────────────────────
-//
-// PORT NOTE: Zig's `SinglyLinkedList(comptime T: type, comptime Parent: type)`
-// threads `Parent` only so that `Node.release()` can call `Parent.release(node)`.
-// In Rust the only `Parent` is `ObjectPool`, so `Node::release` is provided as
-// an inherent method on `ObjectPool` instead and the `Parent` type param is
-// dropped here. Diff readers: `node.release()` call sites become
-// `ObjectPool::<..>::release(node)`.
-
-/// Node inside the linked list wrapping the actual data.
-#[repr(C)]
-pub struct Node<T> {
-    // INTRUSIVE: pool.zig:7 — next link in singly-linked free list
-    pub next: *mut Node<T>,
-    // PORT NOTE: Zig stored `std.mem.Allocator param` here so `destroyNode`
-    // could free via the originating allocator. In Rust the global mimalloc
-    // allocator owns every `Box<Node<T>>`, so the field is dropped and
-    // `destroy_node` uses `heap::take`.
-    //
-    // PORT NOTE: `MaybeUninit<T>` not `T` — Zig's `else undefined` (pool.zig:203)
-    // is well-defined-until-read, but Rust's `assume_init()` on uninit bytes is
-    // immediate UB for any `T` with validity invariants. Callers that use
-    // `INIT == None` write `data` before reading, so we keep the bytes
-    // uninitialized and only `assume_init_*` at access sites.
-    pub data: MaybeUninit<T>,
-}
-
-// PORT NOTE: `pub const Data = T;` (inherent assoc type) is nightly-only;
-// callers can write `T` directly.
-
-impl<T> Node<T> {
-    /// Read `(*p).next` for a known-non-null, live node pointer. Centralises
-    /// the `unsafe { (*p).next }` walk that appears throughout this module's
-    /// list traversals. Caller contract: `p` points at a live `Node<T>` (never
-    /// null — debug-asserted).
-    #[inline(always)]
-    fn next_of(p: *const Node<T>) -> *mut Node<T> {
-        debug_assert!(!p.is_null());
-        // SAFETY: every call site passes a node either just popped from the
-        // free list, just compared non-null in the surrounding `while`/`if`,
-        // or `&self`/`self.first` after an explicit null check.
-        unsafe { (*p).next }
-    }
-
-    /// Access the pooled value.
-    ///
-    /// # Safety
-    /// `data` must be initialized: either the pool was instantiated with
-    /// `T::INIT == Some(_)`, or the caller wrote to `data` after `get()`,
-    /// or the node was created via `push(value)`.
-    #[inline]
-    pub unsafe fn data_ref(&self) -> &T {
-        // SAFETY: caller guarantees `data` is initialized.
-        unsafe { self.data.assume_init_ref() }
-    }
-
-    /// See [`Node::data_ref`] for safety requirements.
-    #[inline]
-    pub unsafe fn data_mut(&mut self) -> &mut T {
-        // SAFETY: caller guarantees `data` is initialized.
-        unsafe { self.data.assume_init_mut() }
-    }
-
-    /// Insert a new node after the current one.
-    ///
-    /// Arguments:
-    ///     new_node: Pointer to the new node to insert.
-    pub fn insert_after(&mut self, new_node: &mut Node<T>) {
-        new_node.next = self.next;
-        self.next = std::ptr::from_mut::<Node<T>>(new_node);
-    }
-
-    /// Remove a node from the list.
-    ///
-    /// Arguments:
-    ///     node: Pointer to the node to be removed.
-    /// Returns:
-    ///     node removed
-    pub fn remove_next(&mut self) -> Option<*mut Node<T>> {
-        let next_node = if self.next.is_null() {
-            return None;
-        } else {
-            self.next
-        };
-        self.next = Node::next_of(next_node);
-        Some(next_node)
-    }
-
-    /// Iterate over the singly-linked list from this node, until the final node is found.
-    /// This operation is O(N).
-    pub fn find_last(&mut self) -> *mut Node<T> {
-        let mut it: *mut Node<T> = std::ptr::from_mut::<Node<T>>(self);
-        loop {
-            let next = Node::next_of(it);
-            if next.is_null() {
-                return it;
-            }
-            it = next;
-        }
-    }
-
-    /// Iterate over each next node, returning the count of all nodes except the starting one.
-    /// This operation is O(N).
-    pub fn count_children(&self) -> usize {
-        let mut count: usize = 0;
-        let mut it: *const Node<T> = self.next;
-        while !it.is_null() {
-            count += 1;
-            it = Node::next_of(it);
-        }
-        count
-    }
-
-    // PORT NOTE: `pub inline fn release(node: *Node) void { Parent.release(node) }`
-    // is expressed as `ObjectPool::<T, ..>::release(node)` at call sites; see
-    // module-level note above.
-}
-
-pub struct SinglyLinkedList<T> {
-    // INTRUSIVE: pool.zig:59 — list head; popFirst hands node to caller
-    pub first: *mut Node<T>,
-}
-
-impl<T> Default for SinglyLinkedList<T> {
-    fn default() -> Self {
-        Self {
-            first: ptr::null_mut(),
-        }
-    }
-}
-
-impl<T> SinglyLinkedList<T> {
-    /// Insert a new node at the head.
-    ///
-    /// Arguments:
-    ///     new_node: Pointer to the new node to insert.
-    pub fn prepend(&mut self, new_node: *mut Node<T>) {
-        // SAFETY: caller guarantees new_node is a live, exclusively-owned Node
-        unsafe { (*new_node).next = self.first };
-        self.first = new_node;
-    }
-
-    /// Remove a node from the list.
-    ///
-    /// Arguments:
-    ///     node: Pointer to the node to be removed.
-    pub fn remove(&mut self, node: *mut Node<T>) {
-        if self.first == node {
-            self.first = Node::next_of(node);
-        } else {
-            // SAFETY: self.first is non-null (else the `==` above would have
-            // matched the null `node`, which callers never pass)
-            let mut current_elm = self.first;
-            // SAFETY: walk live list nodes; Zig's `.?` would panic on null —
-            // mirror that with an unchecked deref (debug_assert in Phase B).
-            unsafe {
-                while (*current_elm).next != node {
-                    current_elm = (*current_elm).next;
-                }
-                (*current_elm).next = (*node).next;
-            }
-        }
-    }
-
-    /// Remove and return the first node in the list.
-    ///
-    /// Returns:
-    ///     A pointer to the first node in the list.
-    pub fn pop_first(&mut self) -> Option<*mut Node<T>> {
-        let first = if self.first.is_null() {
-            return None;
-        } else {
-            self.first
-        };
-        self.first = Node::next_of(first);
-        Some(first)
-    }
-
-    /// Iterate over all nodes, returning the count.
-    /// This operation is O(N).
-    pub fn len(&self) -> usize {
-        if !self.first.is_null() {
-            // SAFETY: first is non-null and live
-            1 + unsafe { (*self.first).count_children() }
-        } else {
-            0
-        }
-    }
-}
+use bun_core::UnwrapOrOom;
 
 // ──────────────────────────────────────────────────────────────────────────
 // ObjectPool
 // ──────────────────────────────────────────────────────────────────────────
+//
+// PORT NOTE: the original Zig design threaded `Box<Node<T>>` through an
+// intrusive `SinglyLinkedList`. No `ObjectPool` caller needs node address
+// stability, so the free list is now a plain `Vec<T>` (push/pop) and values
+// move in/out by value. The lone non-ObjectPool consumer of the intrusive
+// list (`DevServer`'s deferred-request queue) carries its own local `Node`
+// struct + `Vec<NonNull<Node>>`.
 
-const LOG_ALLOCATIONS: bool = false;
+/// Behavior hooks the Zig version expressed via `comptime Init: fn(...)` and
+/// `std.meta.hasFn(Type, "reset")`.
+pub trait ObjectPoolType: Sized + 'static {
+    /// Construct a fresh value when the pool is empty. Mirrors Zig's
+    /// `comptime Init: fn(allocator) Type`; every Rust impl supplies one,
+    /// so the `MaybeUninit` payload + `INIT == None` branch are gone.
+    fn init() -> Self;
 
-/// Behavior hooks the Zig version expressed via `comptime Init: ?fn(...)` and
-/// `std.meta.hasFn(Type, "reset")`. Per PORTING.md §Comptime reflection,
-/// optional-decl checks become a trait with default methods.
-pub trait ObjectPoolType: Sized {
-    /// Mirrors `comptime Init: ?fn(allocator) anyerror!Type`. `None` ⇒ the
-    /// Zig path that left `data` as `undefined`.
-    const INIT: Option<fn() -> Result<Self, Error>> = None;
-
-    /// Mirrors `if (std.meta.hasFn(Type, "reset")) node.data.reset()`.
+    /// Called on a value just popped from the free list, before handing it
+    /// to the caller. Mirrors `if (std.meta.hasFn(Type, "reset")) data.reset()`.
     /// Default is a no-op; types that had `.reset()` in Zig override this.
     #[inline]
     fn reset(&mut self) {}
 }
 
-/// Per-pool mutable state. Zig's `DataStruct`.
+/// Per-pool mutable state.
 pub struct DataStruct<T> {
-    pub list: SinglyLinkedList<T>,
-    pub loaded: bool,
-    // PORT NOTE: Zig used `MaxCountInt = std.math.IntFittingRange(0, max_count)`.
-    // Rust const generics cannot pick an integer type from a const value; use
-    // `usize` and accept the few extra bytes.
-    // PERF(port): was IntFittingRange — profile in Phase B
-    pub count: usize,
+    free: Vec<T>,
 }
 
 impl<T> Default for DataStruct<T> {
     fn default() -> Self {
-        Self {
-            // PORT NOTE: Zig had `list: LinkedList = undefined` — we zero it.
-            list: SinglyLinkedList::default(),
-            loaded: false,
-            count: 0,
-        }
+        Self { free: Vec::new() }
     }
 }
 
-/// Object pool with a singly-linked free list.
+/// Object pool backed by a `Vec<T>` free list.
 ///
 /// `THREADSAFE == true`  ⇒ storage is thread-local (one free list per thread).
 /// `THREADSAFE == false` ⇒ storage is a single process-wide static.
@@ -252,10 +52,6 @@ pub struct ObjectPool<
     S = UnwiredStorage,
 >(core::marker::PhantomData<(T, S)>);
 
-// PORT NOTE: `pub const List = SinglyLinkedList(T)` / `pub const Node = Node(T)`
-// inherent assoc types are nightly-only; callers write `SinglyLinkedList<T>` /
-// `Node<T>` directly.
-
 /// Per-monomorphization storage hook. Generic statics are not expressible in
 /// Rust, so each `(T, THREADSAFE, MAX_COUNT)` instantiation must provide its
 /// own `thread_local!` / `static` via this trait — typically generated by
@@ -266,8 +62,7 @@ pub trait PoolStorage<T>: 'static {
 }
 
 /// Fallback storage that panics on first use. Lets `ObjectPool<T, ..>` name a
-/// concrete type before its storage is wired (matches the prior `data()`
-/// `unreachable!`).
+/// concrete type before its storage is wired.
 pub struct UnwiredStorage;
 impl<T: 'static> PoolStorage<T> for UnwiredStorage {
     fn with<R>(_f: impl FnOnce(&RefCell<DataStruct<T>>) -> R) -> R {
@@ -278,254 +73,96 @@ impl<T: 'static> PoolStorage<T> for UnwiredStorage {
     }
 }
 
-/// Trait alias so callers can name `<Pool as ObjectPoolTrait>::Node` without
-/// knowing the concrete generics.
-pub trait ObjectPoolTrait {
-    type Item;
-    type Node;
-}
-
-impl<T: ObjectPoolType, const TS: bool, const MAX: usize, S> ObjectPoolTrait
-    for ObjectPool<T, TS, MAX, S>
-{
-    type Item = T;
-    type Node = Node<T>;
-}
-
 /// RAII handle for a pooled `T`. Derefs to the inner value; on `Drop`, the
-/// node is returned to its pool. Replaces the Zig `get()` + `defer release()`
+/// value is returned to its pool. Replaces the Zig `get()` + `defer release()`
 /// pair.
-pub struct PoolGuard<'a, T: ObjectPoolType + 'static> {
-    node: *mut Node<T>,
-    release: fn(*mut Node<T>),
-    _marker: PhantomData<&'a mut T>,
+pub struct PoolGuard<T: ObjectPoolType> {
+    value: Option<T>,
+    release: fn(T),
 }
 
-impl<'a, T: ObjectPoolType> core::ops::Deref for PoolGuard<'a, T> {
+impl<T: ObjectPoolType> core::ops::Deref for PoolGuard<T> {
     type Target = T;
     #[inline]
     fn deref(&self) -> &T {
-        // SAFETY: `node` is exclusively owned for the guard's lifetime and its
-        // `data` was initialized by the pool's `get()` path before being handed
-        // out (either via `T::INIT` or by reuse of a previously-written node).
-        unsafe { (*self.node).data.assume_init_ref() }
+        self.value.as_ref().expect("PoolGuard already released")
     }
 }
 
-impl<'a, T: ObjectPoolType> core::ops::DerefMut for PoolGuard<'a, T> {
+impl<T: ObjectPoolType> core::ops::DerefMut for PoolGuard<T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut T {
-        // SAFETY: see `Deref` impl.
-        unsafe { (*self.node).data.assume_init_mut() }
+        self.value.as_mut().expect("PoolGuard already released")
     }
 }
 
-impl<'a, T: ObjectPoolType> Drop for PoolGuard<'a, T> {
+impl<T: ObjectPoolType> Drop for PoolGuard<T> {
     fn drop(&mut self) {
-        (self.release)(self.node);
+        if let Some(value) = self.value.take() {
+            (self.release)(value);
+        }
     }
 }
 
-impl<'a, T: ObjectPoolType> PoolGuard<'a, T> {
-    /// Raw pointer to the underlying node (for callers that need to stash it
-    /// across an FFI boundary). The guard still owns the node.
-    #[inline]
-    pub fn node_ptr(&self) -> *mut Node<T> {
-        self.node
-    }
-}
-
-impl<T: ObjectPoolType + 'static, const THREADSAFE: bool, const MAX_COUNT: usize, S>
+impl<T: ObjectPoolType, const THREADSAFE: bool, const MAX_COUNT: usize, S>
     ObjectPool<T, THREADSAFE, MAX_COUNT, S>
 where
     S: PoolStorage<T>,
 {
-    // We want this to be global
-    // but we don't want to create 3 global variables per pool
-    // instead, we create one global variable per pool
-    //
-    // PORT NOTE: Rust cannot place a `static` / `thread_local!` inside a
-    // generic `impl`; storage is supplied via the `S: PoolStorage<T>` type
-    // parameter (see `object_pool!` for the usual declaration).
+    /// `MAX_COUNT == 0` means "uncapped" (matches the original Zig semantics).
     #[inline]
-    pub fn data<R>(f: impl FnOnce(&RefCell<DataStruct<T>>) -> R) -> R {
-        S::with(f)
-    }
-
     pub fn full() -> bool {
-        if MAX_COUNT == 0 {
-            return false;
-        }
-        Self::data(|cell| {
-            let d = cell.borrow();
-            d.loaded && d.count >= MAX_COUNT
-        })
+        MAX_COUNT > 0 && S::with(|cell| cell.borrow().free.len() >= MAX_COUNT)
     }
 
+    #[inline]
     pub fn has() -> bool {
-        Self::data(|cell| {
-            let d = cell.borrow();
-            d.loaded && !d.list.first.is_null()
-        })
+        S::with(|cell| !cell.borrow().free.is_empty())
     }
 
-    pub fn push(pooled: T) {
-        if cfg!(debug_assertions) {
-            // PORT NOTE: Zig gated on `env.allow_assert`; that is
-            // `Environment.isDebug` ⇒ `cfg!(debug_assertions)`.
-            debug_assert!(!Self::full());
-        }
-
-        let new_node = bun_core::heap::into_raw(Box::new(Node::<T> {
-            next: ptr::null_mut(),
-            data: MaybeUninit::new(pooled),
-        }));
-        Self::release(new_node);
-    }
-
-    pub fn get_if_exists() -> Option<*mut Node<T>> {
-        Self::data(|cell| {
-            let mut d = cell.borrow_mut();
-            if !d.loaded {
-                return None;
-            }
-
-            let node = d.list.pop_first()?;
-            // SAFETY: node was just popped from the free list and is exclusively owned;
-            // free-list nodes always carry initialized `data` (they reach the list
-            // via `push` or `release` of a previously-used node).
-            unsafe { (*node).data.assume_init_mut().reset() };
-            if MAX_COUNT > 0 {
-                d.count = d.count.saturating_sub(1);
-            }
-
-            Some(node)
-        })
-    }
-
-    pub fn first() -> *mut T {
-        // SAFETY: `get_node()` always returns a valid, exclusively-owned node
-        unsafe { (*Self::get_node()).data.as_mut_ptr() }
-    }
-
-    /// Zig `get()` — pop a node from the free list or allocate a fresh one.
-    pub fn get_node() -> *mut Node<T> {
-        let reused = Self::data(|cell| {
-            let mut d = cell.borrow_mut();
-            if d.loaded {
-                if let Some(node) = d.list.pop_first() {
-                    // SAFETY: node just popped from free list, exclusively owned;
-                    // free-list nodes always carry initialized `data`.
-                    unsafe { (*node).data.assume_init_mut().reset() };
-                    if MAX_COUNT > 0 {
-                        d.count = d.count.saturating_sub(1);
-                    }
-                    return Some(node);
-                }
-            }
-            None
-        });
-        if let Some(node) = reused {
-            return node;
-        }
-
-        if LOG_ALLOCATIONS {
-            // PORT NOTE: Zig wrote to stderr via std.fs; banned here. Phase B
-            // can route through `bun_core::Output` if this is ever flipped on.
-            // TODO(port): log "Allocate {type_name} - {size} bytes"
-        }
-
-        // Matches Zig's `data = if (Init) |i| i(..) else undefined` (pool.zig:203).
-        // For `INIT == None` the bytes stay uninitialized; the caller MUST write
-        // `data` before any read (and before `release()`, since `destroy_node`
-        // assumes it is initialized when dropping).
-        let data = match T::INIT {
-            Some(init_) => MaybeUninit::new(init_().expect("unreachable")),
-            None => MaybeUninit::uninit(),
-        };
-        bun_core::heap::into_raw(Box::new(Node::<T> {
-            next: ptr::null_mut(),
-            data,
-        }))
-    }
-
-    /// RAII front-door: pop or allocate a node and wrap it in a `PoolGuard`
-    /// that returns it to this pool on `Drop`.
-    pub fn get() -> PoolGuard<'static, T> {
+    /// RAII front-door: pop or init a value and wrap it in a `PoolGuard` that
+    /// returns it to this pool on `Drop`.
+    #[inline]
+    pub fn get() -> PoolGuard<T> {
         PoolGuard {
-            node: Self::get_node(),
-            release: Self::release,
-            _marker: PhantomData,
+            value: Some(Self::take()),
+            release: Self::put,
         }
     }
 
-    pub fn release_value(value: *mut T) {
-        // SAFETY: `value` points to the `data` field of a live `Node<T>`
-        let node = unsafe { bun_core::from_field_ptr!(Node<T>, data, value) };
-        Self::release(node);
+    /// Pop a value from the free list (resetting it) or `init()` a fresh one.
+    /// Caller owns the result; pair with [`Self::put`] to recycle.
+    #[inline]
+    pub fn take() -> T {
+        Self::take_if_exists().unwrap_or_else(T::init)
     }
 
-    pub fn release(node: *mut Node<T>) {
-        let overflowed = Self::data(|cell| {
+    /// Pop a value from the free list and reset it; `None` if the pool is empty.
+    #[inline]
+    pub fn take_if_exists() -> Option<T> {
+        let mut value = S::with(|cell| cell.borrow_mut().free.pop())?;
+        value.reset();
+        Some(value)
+    }
+
+    /// Return a value to the pool. If the pool is at `MAX_COUNT`, the value is
+    /// dropped instead.
+    #[inline]
+    pub fn put(value: T) {
+        S::with(|cell| {
             let mut d = cell.borrow_mut();
-            if MAX_COUNT > 0 && d.count >= MAX_COUNT {
-                if LOG_ALLOCATIONS {
-                    // TODO(port): log "Free {type_name} - {size} bytes"
-                }
-                return true;
-            }
-
-            if MAX_COUNT > 0 {
-                d.count = d.count.saturating_add(1);
-            }
-
-            if d.loaded {
-                d.list.prepend(node);
+            if MAX_COUNT > 0 && d.free.len() >= MAX_COUNT {
+                drop(value);
             } else {
-                d.list = SinglyLinkedList { first: node };
-                d.loaded = true;
+                d.free.push(value);
             }
-            false
         });
-        if overflowed {
-            Self::destroy_node(node);
-        }
     }
 
+    /// Drop every pooled value and release the free-list buffer.
+    #[inline]
     pub fn delete_all() {
-        let mut next = Self::data(|cell| {
-            let mut dat = cell.borrow_mut();
-            if !dat.loaded {
-                return ptr::null_mut();
-            }
-            dat.loaded = false;
-            dat.count = 0;
-            let head = dat.list.first;
-            dat.list.first = ptr::null_mut();
-            head
-        });
-        while !next.is_null() {
-            let node = next;
-            next = Node::next_of(node);
-            Self::destroy_node(node);
-        }
-    }
-
-    fn destroy_node(node: *mut Node<T>) {
-        // TODO(port): Zig special-cased `Type != bun.Vec<u8>` here to skip
-        // `bun.memory.deinit(&node.data)` for `Vec<u8>` (a known leak the Zig
-        // comment calls out). In Rust, dropping `T` is the moral equivalent of
-        // `bun.memory.deinit`. If `Vec<u8>` (the `Vec<u8>` port) must keep
-        // leaking for compat, gate its `Drop` there — not here.
-        //
-        // SAFETY: `node` was created via `heap::alloc` in `push`/`get` and
-        // is exclusively owned by the caller. `data` is initialized: `destroy_node`
-        // is only reached from `release()` (caller had a usable node, so `data`
-        // was written) or `delete_all()` (free-list nodes, always initialized).
-        unsafe {
-            (*node).data.assume_init_drop();
-            drop(bun_core::heap::take(node));
-        }
+        S::with(|cell| *cell.borrow_mut() = DataStruct::default());
     }
 }
 
@@ -536,7 +173,7 @@ where
 /// Declare an `ObjectPool` alias plus its backing static/thread-local storage.
 ///
 /// ```ignore
-/// // thread-local free list, capped at 32 nodes
+/// // thread-local free list, capped at 32 entries
 /// object_pool!(pub StringVoidMapPool: StringVoidMap, threadsafe, 32);
 /// // process-wide free list, uncapped
 /// object_pool!(BufferPool: Vec<u8>, global, 0);
@@ -636,8 +273,10 @@ macro_rules! __paste_storage {
 /// Zig: `Npm.Registry.BodyPool = ObjectPool(MutableString, MutableString.init2048, true, 8)`
 /// (src/install/npm.zig). Init = `init2048`; reuse = `.reset()`.
 impl ObjectPoolType for bun_core::MutableString {
-    const INIT: Option<fn() -> Result<Self, Error>> =
-        Some(|| bun_core::MutableString::init2048().map_err(Into::into));
+    #[inline]
+    fn init() -> Self {
+        bun_core::MutableString::init2048().unwrap_or_oom()
+    }
     #[inline]
     fn reset(&mut self) {
         bun_core::MutableString::reset(self);

--- a/src/collections/pool.rs
+++ b/src/collections/pool.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 use core::cell::RefCell;
 
 use bun_core::UnwrapOrOom;

--- a/src/collections/string_map.rs
+++ b/src/collections/string_map.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 //! Port of `bun.StringMap` (`src/bun.zig`).
 //!
 //! A `StringArrayHashMap<Box<[u8]>>` plus a `dupe_keys` flag controlling

--- a/src/collections/vec_ext.rs
+++ b/src/collections/vec_ext.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)]
 //! `VecExt` / `ByteVecExt` — Zig-ported method vocabulary on `Vec<T>`.
 //!
 //! Migration shim from the deleted `BabyList<T>` (see

--- a/src/collections/vec_ext.rs
+++ b/src/collections/vec_ext.rs
@@ -30,45 +30,19 @@ pub trait VecExt<T>: Sized {
     fn move_from_list(list: Vec<T>) -> Self;
     fn from_owned_slice(items: Box<[T]>) -> Self;
     fn init_with_buffer_vec(buffer: Vec<T>) -> Self;
-    /// Arena-builder → owned `Vec<T>`.  In Zig this was zero-copy (arena ptr
-    /// adopted as `Borrowed`); in the Rust port the linker always called
-    /// `transfer_ownership` afterwards (full copy), so doing the copy up-front
-    /// here is no worse and lets the arena round-trip disappear.
-    ///
-    /// # Safety
-    /// Bitwise-**moves** every element out of `items` into a fresh allocation.
-    /// `items` must be a leaked bump-arena slice (`into_bump_slice_mut` /
-    /// `alloc_slice_*`) that will *never* have its elements read or dropped
-    /// again — i.e. no live `Vec<T>`/`BumpVec<T>` may still own them. Passing
-    /// a slice borrowed from a container that runs element destructors yields
-    /// a double-drop (PTR_AUDIT.md class #1: bitwise-copy of Drop-carrying
-    /// type while source is still live).
-    unsafe fn from_bump_slice(items: &mut [T]) -> Self;
-    /// Safe sibling of [`from_bump_slice`] for `T: Copy` — the
-    /// "source must never be element-dropped again" precondition holds
-    /// vacuously (`Copy` ⇒ no `Drop`), so the bitwise move degenerates to a
-    /// plain copy and needs no `unsafe` at the call site. Takes `&[T]`
-    /// (read-only) since nothing is logically moved out.
-    ///
-    /// Covers the dominant js_parser pattern
-    /// `arena.alloc_slice_copy(&[a, b]) → unsafe { from_bump_slice(..) }` (B-1
-    /// invariant: bump arena outlives the AST). Callers may pass the bump
-    /// slice directly, or skip the intermediate bump alloc entirely and pass
-    /// the stack array — both compile to one memcpy into the global heap.
+    /// `T: Copy` arena slice → owned `Vec<T>`. Covers the dominant js_parser
+    /// pattern `arena.alloc_slice_copy(&[a, b])` → owned list. Callers may
+    /// pass the bump slice directly, or skip the intermediate bump alloc
+    /// entirely and pass the stack array — both compile to one memcpy into the
+    /// global heap.
     fn from_arena_slice(items: &[T]) -> Self
     where
         T: Copy;
-    /// Safe sibling of [`from_bump_slice`]: consumes an `ArenaVec` (sole owner
-    /// of its elements + arena buffer), bitwise-moves every element into a
-    /// fresh global-allocator `Vec<T>`, and leaks the now-logically-empty
-    /// arena buffer back to the bump (reclaimed on arena reset, which never
-    /// runs element destructors). Ownership of every `T` transfers exactly
-    /// once, so no double-drop and no allocator-identity confusion is
+    /// Consumes an `ArenaVec` (sole owner of its elements + arena buffer),
+    /// bitwise-moves every element into a fresh `Vec<T, A>`, and frees the
+    /// now-logically-empty arena buffer. Ownership of every `T` transfers
+    /// exactly once, so no double-drop and no allocator-identity confusion is
     /// possible at the call site.
-    ///
-    /// Prefer this over `unsafe { from_bump_slice(v.into_bump_slice_mut()) }`
-    /// — it encodes the "source is leaked, never dropped again" contract in
-    /// the type system instead of a `// SAFETY:` comment.
     fn from_bump_vec(v: bun_alloc::ArenaVec<'_, T>) -> Self;
     /// Arena pre-reservation: `Vec` cannot allocate from a bump arena, so this
     /// becomes a global-allocator `with_capacity`.  The arena is ignored.
@@ -124,34 +98,18 @@ pub trait VecExt<T>: Sized {
     /// overwritten before any read (including Drop). Prefer
     /// [`unused_capacity_slice`] for `T` with validity invariants.
     unsafe fn expand_to_capacity(&mut self);
-    /// # Safety
-    /// Returns `&mut [T]` over `additional` uninitialized elements. Caller
-    /// must fully initialize the slice before any read/drop. Prefer
-    /// [`unused_capacity_slice`] + `set_len` for non-POD `T`.
-    unsafe fn writable_slice(&mut self, additional: usize) -> &mut [T];
-    /// # Safety
-    /// As [`writable_slice`] but skips `reserve`; caller must guarantee
-    /// `len + additional <= capacity` (debug-asserted). Zig:
-    /// `ArrayList.addManyAsSliceAssumeCapacity`.
-    unsafe fn writable_slice_assume_capacity(&mut self, additional: usize) -> &mut [T];
-    /// # Safety
-    /// As [`writable_slice`] but uses `reserve_exact` so the allocation grows
-    /// to *exactly* `len + additional`. Use when the buffer is the final
-    /// single-shot blob (sourcemap finalize, etc.).
-    unsafe fn writable_slice_exact(&mut self, additional: usize) -> &mut [T];
     /// Reserves `additional` and returns the first `additional` slots of
-    /// spare capacity as `MaybeUninit<T>`. Safe sibling of [`writable_slice`]:
-    /// caller writes some prefix then calls `set_len` (or [`uv_commit`] for
-    /// `Vec<u8>`) to commit. Unlike `spare_capacity_mut()` the returned slice
-    /// is exactly `additional` long, not `capacity - len`.
+    /// spare capacity as `MaybeUninit<T>`. Caller writes some prefix then
+    /// calls `set_len` (or [`bun_core::vec::commit_spare`] for `Vec<u8>`) to
+    /// commit. Unlike `spare_capacity_mut()` the returned slice is exactly
+    /// `additional` long, not `capacity - len`.
     fn reserve_spare(&mut self, additional: usize) -> &mut [core::mem::MaybeUninit<T>];
     /// `reserve(additional)` then [`expand_to_capacity`], returning the
     /// freshly-exposed tail as a raw `(ptr, len)` pair — i.e.
     /// `(next_out, avail_out)` for C streaming APIs (zlib, brotli, zstd).
-    /// Unlike [`writable_slice`] this exposes the *full* over-allocated
-    /// capacity (`cap - prev_len`), not exactly `additional`, so the FFI
-    /// callee can use the allocator's slack. Pass `additional = 0` when the
-    /// caller has already reserved.
+    /// Exposes the *full* over-allocated capacity (`cap - prev_len`), not
+    /// exactly `additional`, so the FFI callee can use the allocator's slack.
+    /// Pass `additional = 0` when the caller has already reserved.
     ///
     /// # Safety
     /// Same as [`expand_to_capacity`]: every byte in `[prev_len, cap)` must be
@@ -167,14 +125,9 @@ pub trait VecExt<T>: Sized {
     /// all callers are gone.
     #[inline]
     fn transfer_ownership(&mut self) {}
-    /// Non-owning header alias.  For `Vec` this is `from_raw_parts` into a
-    /// `ManuallyDrop` — same UB-if-dropped contract as before.
-    fn shallow_copy(&self) -> ManuallyDrop<Self>;
-    fn shallow_clone(&self) -> ManuallyDrop<Self>;
 
     // ── misc ──────────────────────────────────────────────────────────────
     fn unused_capacity_slice(&mut self) -> &mut [core::mem::MaybeUninit<T>];
-    fn allocated_slice(&mut self) -> &mut [core::mem::MaybeUninit<T>];
     fn memory_cost(&self) -> usize;
     fn sort_asc(&mut self)
     where
@@ -240,25 +193,10 @@ impl<T, A: Allocator + Default + 'static> VecExt<T> for Vec<T, A> {
         Self::move_from_list(buffer)
     }
     #[inline]
-    unsafe fn from_bump_slice(items: &mut [T]) -> Self {
-        // SAFETY: caller contract — `items` is a leaked bump-arena slice
-        // (`into_bump_slice_mut`); bitwise-move elements into a fresh `A`
-        // allocation, leaving the arena bytes abandoned (they were already
-        // leaked into the bump and will never be element-dropped).
-        let mut v = Vec::with_capacity_in(items.len(), A::default());
-        unsafe {
-            core::ptr::copy_nonoverlapping(items.as_ptr(), v.as_mut_ptr(), items.len());
-            v.set_len(items.len());
-        }
-        v
-    }
-    #[inline]
     fn from_arena_slice(items: &[T]) -> Self
     where
         T: Copy,
     {
-        // For `T: Copy` the `from_bump_slice` bitwise-move is just a memcpy and
-        // the source carries no destructor.
         let mut v = Vec::with_capacity_in(items.len(), A::default());
         v.extend_from_slice(items);
         v
@@ -424,29 +362,6 @@ impl<T, A: Allocator + Default + 'static> VecExt<T> for Vec<T, A> {
         // before being observed.
         unsafe { self.set_len(self.capacity()) };
     }
-    unsafe fn writable_slice(&mut self, additional: usize) -> &mut [T] {
-        self.reserve(additional);
-        let prev = self.len();
-        // SAFETY: caller contract — slice is fully written before any read.
-        unsafe { self.set_len(prev + additional) };
-        &mut self[prev..]
-    }
-    #[inline]
-    unsafe fn writable_slice_assume_capacity(&mut self, additional: usize) -> &mut [T] {
-        debug_assert!(self.len() + additional <= self.capacity());
-        let prev = self.len();
-        // SAFETY: caller contract — capacity asserted; slice fully written before any read.
-        unsafe { self.set_len(prev + additional) };
-        &mut self[prev..]
-    }
-    #[inline]
-    unsafe fn writable_slice_exact(&mut self, additional: usize) -> &mut [T] {
-        self.reserve_exact(additional);
-        let prev = self.len();
-        // SAFETY: caller contract — slice fully written before any read.
-        unsafe { self.set_len(prev + additional) };
-        &mut self[prev..]
-    }
     #[inline]
     fn reserve_spare(&mut self, additional: usize) -> &mut [core::mem::MaybeUninit<T>] {
         self.reserve(additional);
@@ -493,36 +408,10 @@ impl<T, A: Allocator + Default + 'static> VecExt<T> for Vec<T, A> {
     fn to_owned_slice(&mut self) -> Box<[T]> {
         self.move_to_list().into_boxed_slice()
     }
-    #[inline]
-    fn shallow_copy(&self) -> ManuallyDrop<Self> {
-        // SAFETY: caller must not drop/grow the alias; original stays the owner.
-        ManuallyDrop::new(unsafe {
-            Vec::from_raw_parts_in(
-                self.as_ptr().cast_mut(),
-                self.len(),
-                self.capacity(),
-                A::default(),
-            )
-        })
-    }
-    #[inline]
-    fn shallow_clone(&self) -> ManuallyDrop<Self> {
-        self.shallow_copy()
-    }
 
     #[inline]
     fn unused_capacity_slice(&mut self) -> &mut [core::mem::MaybeUninit<T>] {
         self.spare_capacity_mut()
-    }
-    #[inline]
-    fn allocated_slice(&mut self) -> &mut [core::mem::MaybeUninit<T>] {
-        // SAFETY: ptr[0..cap] is the full allocation.
-        unsafe {
-            core::slice::from_raw_parts_mut(
-                self.as_mut_ptr().cast::<core::mem::MaybeUninit<T>>(),
-                self.capacity(),
-            )
-        }
     }
     #[inline]
     fn memory_cost(&self) -> usize {
@@ -574,31 +463,17 @@ pub trait ByteVecExt {
     fn write(&mut self, str: &[u8]) -> Result<u32, AllocError>;
     fn write_latin1(&mut self, str: &[u8]) -> Result<u32, AllocError>;
     fn write_utf16(&mut self, str: &[u16]) -> Result<u32, AllocError>;
-    fn write_type_as_bytes_assume_capacity<Int: Copy>(&mut self, int: Int);
 
     /// libuv `uv_alloc_cb`-style: ensure **at least** `suggested` bytes of
     /// spare capacity past `len()`, then return the *full* spare-capacity
     /// slice (`len == capacity - len()`, which may exceed `suggested`).
     ///
     /// Callers that must hand libuv exactly `suggested` bytes slice the
-    /// result themselves: `&mut v.uv_alloc_spare(n)[..n]`.
+    /// result themselves: `&mut v.uv_alloc_spare(n)[..n]`. For a `&mut [u8]`
+    /// view (libuv `uv_buf_t` / `read(2)` target), call
+    /// [`bun_core::vec::reserve_spare_bytes`] / [`bun_core::vec::commit_spare`]
+    /// directly.
     fn uv_alloc_spare(&mut self, suggested: usize) -> &mut [core::mem::MaybeUninit<u8>];
-    /// As [`uv_alloc_spare`] but typed `&mut [u8]` so the result can be used
-    /// directly as a `uv_buf_t` / `read(2)` target without a per-site cast.
-    ///
-    /// # Safety
-    /// The returned bytes are **uninitialised**. Caller must only treat the
-    /// prefix actually written by the FFI/syscall as initialised (typically by
-    /// committing with [`uv_commit`]); the bytes must not be read before then.
-    unsafe fn uv_alloc_spare_u8(&mut self, suggested: usize) -> &mut [u8];
-    /// Commit `nread` bytes that the FFI/syscall just wrote into the slice
-    /// returned by [`uv_alloc_spare`] / [`uv_alloc_spare_u8`]: bumps `len` by
-    /// `nread`. Debug-asserts `len + nread <= capacity`.
-    ///
-    /// # Safety
-    /// The `nread` bytes at `[len, len + nread)` must have been initialised by
-    /// the preceding write into the spare slice.
-    unsafe fn uv_commit(&mut self, nread: usize);
 }
 
 impl ByteVecExt for Vec<u8> {
@@ -629,19 +504,6 @@ impl ByteVecExt for Vec<u8> {
         strings::convert_utf16_to_utf8_append(self, str);
         Ok((self.len() - initial) as u32)
     }
-    fn write_type_as_bytes_assume_capacity<Int: Copy>(&mut self, int: Int) {
-        let size = core::mem::size_of::<Int>();
-        debug_assert!(self.capacity() >= self.len() + size);
-        let prev = self.len();
-        // SAFETY: capacity asserted; writing `size` bytes into the uninit tail.
-        unsafe {
-            self.as_mut_ptr()
-                .add(prev)
-                .cast::<Int>()
-                .write_unaligned(int);
-            self.set_len(prev + size);
-        }
-    }
     #[inline]
     fn uv_alloc_spare(&mut self, suggested: usize) -> &mut [core::mem::MaybeUninit<u8>] {
         // `Vec::reserve` already amortises by doubling, so a plain
@@ -649,14 +511,6 @@ impl ByteVecExt for Vec<u8> {
         // dance is needed (it short-circuits internally).
         self.reserve(suggested);
         self.spare_capacity_mut()
-    }
-    #[inline]
-    unsafe fn uv_alloc_spare_u8(&mut self, suggested: usize) -> &mut [u8] {
-        unsafe { bun_core::vec::reserve_spare_bytes(self, suggested) }
-    }
-    #[inline]
-    unsafe fn uv_commit(&mut self, nread: usize) {
-        unsafe { bun_core::vec::commit_spare(self, nread) }
     }
 }
 
@@ -725,31 +579,11 @@ impl OffsetByteList {
 /// `A: Default + 'static` bound that `&'a MimallocArena` (i.e.
 /// [`bun_alloc::ArenaVec`]) does not satisfy. `src` and `dst` may use
 /// distinct allocators.
-///
-/// Ports the open-coded `reserve → ptr::copy(shift) → copy_nonoverlapping →
-/// set_len` pattern that translated Zig's `bun.copy`/`@memcpy` splice for
-/// non-`Copy` element types.
 pub fn prepend_from<T, A: Allocator, B: Allocator>(dst: &mut Vec<T, A>, src: &mut Vec<T, B>) {
-    let src_len = src.len();
-    if src_len == 0 {
+    if src.is_empty() {
         return;
     }
-    let dst_len = dst.len();
-    dst.reserve(src_len);
-    // SAFETY: `reserve` guarantees capacity for `dst_len + src_len`. The shift
-    // memmove and the front copy together fully initialize `[0, dst_len+src_len)`.
-    // We commit `dst`'s new length only *after* `src` has been logically emptied
-    // so no element is ever owned by both vecs (no double-drop on unwind — and
-    // none of the ptr ops below can panic anyway).
-    unsafe {
-        let base = dst.as_mut_ptr();
-        // Shift existing `dst` elements right (overlapping → memmove).
-        core::ptr::copy(base, base.add(src_len), dst_len);
-        // `src` is a separate allocation → non-overlapping with `dst`'s buffer.
-        core::ptr::copy_nonoverlapping(src.as_ptr(), base, src_len);
-        // Elements were bitwise-moved out of `src`; relinquish ownership first…
-        src.set_len(0);
-        // …then claim it in `dst`.
-        dst.set_len(dst_len + src_len);
-    }
+    // `Drain<'_, T, B>` is `ExactSizeIterator`, so `splice` reserves once and
+    // shifts the existing tail with a single memmove.
+    dst.splice(0..0, src.drain(..));
 }

--- a/src/collections/vec_ext.rs
+++ b/src/collections/vec_ext.rs
@@ -93,28 +93,22 @@ pub trait VecExt<T>: Sized {
     fn replace_range(&mut self, start: usize, len: usize, new_items: &[T])
     where
         T: Clone;
-    /// # Safety
-    /// Exposes `self[len..capacity]` as initialized. Every element must be
-    /// overwritten before any read (including Drop). Prefer
-    /// [`unused_capacity_slice`] for `T` with validity invariants.
-    unsafe fn expand_to_capacity(&mut self);
     /// Reserves `additional` and returns the first `additional` slots of
     /// spare capacity as `MaybeUninit<T>`. Caller writes some prefix then
     /// calls `set_len` (or [`bun_core::vec::commit_spare`] for `Vec<u8>`) to
     /// commit. Unlike `spare_capacity_mut()` the returned slice is exactly
     /// `additional` long, not `capacity - len`.
     fn reserve_spare(&mut self, additional: usize) -> &mut [core::mem::MaybeUninit<T>];
-    /// `reserve(additional)` then [`expand_to_capacity`], returning the
-    /// freshly-exposed tail as a raw `(ptr, len)` pair — i.e.
-    /// `(next_out, avail_out)` for C streaming APIs (zlib, brotli, zstd).
-    /// Exposes the *full* over-allocated capacity (`cap - prev_len`), not
-    /// exactly `additional`, so the FFI callee can use the allocator's slack.
-    /// Pass `additional = 0` when the caller has already reserved.
+    /// `reserve(additional)` then return the spare-capacity tail as a raw
+    /// `(ptr, len)` pair — i.e. `(next_out, avail_out)` for C streaming APIs
+    /// (zlib, brotli, zstd). Exposes the *full* spare capacity (`cap - len`),
+    /// not exactly `additional`, so the FFI callee can use the allocator's
+    /// slack. Pass `additional = 0` when the caller has already reserved.
     ///
-    /// # Safety
-    /// Same as [`expand_to_capacity`]: every byte in `[prev_len, cap)` must be
-    /// written by the FFI callee (or `len` truncated back) before any read.
-    unsafe fn reserve_expand_tail(&mut self, additional: usize) -> (*mut T, usize);
+    /// `len()` is **not** advanced; the caller must `set_len()` after the FFI
+    /// write — and on each loop iteration when called repeatedly, so the next
+    /// call returns a fresh tail past the previous write.
+    fn ffi_spare_tail(&mut self, additional: usize) -> (*mut T, usize);
 
     // ── ownership transfer ────────────────────────────────────────────────
     fn move_to_list(&mut self) -> Vec<T>;
@@ -169,17 +163,9 @@ impl<T, A: Allocator + Default + 'static> VecExt<T> for Vec<T, A> {
     }
     #[inline]
     fn move_from_list(list: Vec<T>) -> Self {
-        // Mirror of the `move_to_list` fast-path: when `A == Global` this is a
-        // pointer adopt (Zig `moveFromList`, baby_list.zig:46), not a realloc.
-        // Hot Global callers: `FileReader`, `ByteStream`, `shell::Cmd`.
-        if core::any::TypeId::of::<A>() == core::any::TypeId::of::<std::alloc::Global>() {
-            // SAFETY: `A == Global`, so `Vec<T>` and `Vec<T, A>` have identical
-            // layout, allocator, and drop semantics.
-            let mut list = core::mem::ManuallyDrop::new(list);
-            return unsafe {
-                Vec::from_raw_parts_in(list.as_mut_ptr(), list.len(), list.capacity(), A::default())
-            };
-        }
+        // `A == Global` callers are identity and have been rewritten to drop
+        // this call entirely; only the cross-allocator (`AstAlloc`) callers
+        // remain, which always needed this realloc+move.
         let mut v = Vec::with_capacity_in(list.len(), A::default());
         v.extend(list);
         v
@@ -357,45 +343,25 @@ impl<T, A: Allocator + Default + 'static> VecExt<T> for Vec<T, A> {
         self.splice(start..start + len, new_items.iter().cloned());
     }
     #[inline]
-    unsafe fn expand_to_capacity(&mut self) {
-        // SAFETY: caller contract — every element in `[len, cap)` is written
-        // before being observed.
-        unsafe { self.set_len(self.capacity()) };
-    }
-    #[inline]
     fn reserve_spare(&mut self, additional: usize) -> &mut [core::mem::MaybeUninit<T>] {
         self.reserve(additional);
         &mut self.spare_capacity_mut()[..additional]
     }
     #[inline]
-    unsafe fn reserve_expand_tail(&mut self, additional: usize) -> (*mut T, usize) {
-        let prev = self.len();
+    fn ffi_spare_tail(&mut self, additional: usize) -> (*mut T, usize) {
         if additional != 0 {
             self.reserve(additional);
         }
-        let cap = self.capacity();
-        // SAFETY: caller contract — `[prev, cap)` is FFI-written or truncated before any read.
-        unsafe { self.set_len(cap) };
-        // SAFETY: `prev <= cap`; ptr is within (or one-past) the allocation.
-        (unsafe { self.as_mut_ptr().add(prev) }, cap - prev)
+        let spare = self.spare_capacity_mut();
+        (spare.as_mut_ptr().cast::<T>(), spare.len())
     }
 
     #[inline]
     fn move_to_list(&mut self) -> Vec<T> {
+        // `A == Global` callers are identity and have been rewritten to
+        // `mem::take`/direct move; only cross-allocator (`AstAlloc`) callers
+        // remain, which always needed this realloc+move.
         let taken = core::mem::replace(self, Vec::new_in(A::default()));
-        // Fast path: `Vec<T, Global>` → `Vec<T>` is a pointer move, not a
-        // realloc+memcpy. Restores zero-copy behavior on the HTTP streaming
-        // paths (`RequestContext::response_buf`, `ByteStream`); the copying
-        // path is still required for `AstAlloc` etc. where the buffer must
-        // migrate heaps.
-        if core::any::TypeId::of::<A>() == core::any::TypeId::of::<std::alloc::Global>() {
-            // SAFETY: `A == Global`, so `Vec<T, A>` and `Vec<T>` have the
-            // same layout, allocator, and drop semantics.
-            let mut taken = core::mem::ManuallyDrop::new(taken);
-            return unsafe {
-                Vec::from_raw_parts(taken.as_mut_ptr(), taken.len(), taken.capacity())
-            };
-        }
         let mut out = Vec::with_capacity(taken.len());
         out.extend(taken);
         out

--- a/src/collections/vec_ext.rs
+++ b/src/collections/vec_ext.rs
@@ -661,7 +661,10 @@ impl ByteVecExt for Vec<u8> {
 }
 
 impl crate::pool::ObjectPoolType for Vec<u8> {
-    const INIT: Option<fn() -> Result<Self, bun_core::Error>> = Some(|| Ok(Vec::new()));
+    #[inline]
+    fn init() -> Self {
+        Vec::new()
+    }
     #[inline]
     fn reset(&mut self) {
         self.clear();

--- a/src/collections/zig_hash_map.rs
+++ b/src/collections/zig_hash_map.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 //! Port of Zig's `std.HashMapUnmanaged` — open-addressing, linear-probe,
 //! tombstone-on-delete, power-of-two capacity, 80% max load. Layout (and
 //! therefore iteration order) must match the Zig spec exactly because callers

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -968,7 +968,7 @@ impl<'a> CustomAtRuleParser for BundlerAtRuleParser<'a> {
     }
 
     fn reset_enclosing_layer(this: &mut Self, len: u32) {
-        this.enclosing_layer.v.set_len(len);
+        this.enclosing_layer.v.truncate(len);
     }
 
     fn bump_anon_layer_count(this: &mut Self, amount: i32) {

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -968,6 +968,7 @@ impl<'a> CustomAtRuleParser for BundlerAtRuleParser<'a> {
     }
 
     fn reset_enclosing_layer(this: &mut Self, len: u32) {
+        debug_assert!(len <= this.enclosing_layer.v.len());
         this.enclosing_layer.v.truncate(len);
     }
 

--- a/src/css/properties/font.rs
+++ b/src/css/properties/font.rs
@@ -805,10 +805,8 @@ impl Font {
         };
 
         // PORT NOTE: Zig `Vec(FontFamily).parse` parsed a comma-separated
-        // list and packed it; route through `parse_comma_separated` + move.
-        let family = input
-            .parse_comma_separated(FontFamily::parse)
-            .map(Vec::<FontFamily>::move_from_list)?;
+        // list and packed it; route through `parse_comma_separated`.
+        let family = input.parse_comma_separated(FontFamily::parse)?;
 
         Ok(Font {
             family,

--- a/src/css/selectors/builder.rs
+++ b/src/css/selectors/builder.rs
@@ -153,76 +153,26 @@ impl<Impl: ValidSelectorImpl> SelectorBuilder<Impl> {
         &mut self,
         spec: SpecificityAndFlags,
     ) -> BuildResult<Impl> {
-        // PORT NOTE: reshaped for borrowck — capture combinators.len()
-        // before borrowing simple_selectors.slice().
-        let combinators_len = self.combinators.len();
-
-        let (rest, current) = split_from_end::<GenericComponent<Impl>>(
-            self.simple_selectors.slice(),
-            self.current_len,
-        );
-        let combinators = self.combinators.slice();
-
         let mut components: Vec<GenericComponent<Impl>> = Vec::new();
 
-        let mut current_simple_selectors_i: usize = 0;
-        let mut combinator_i: i64 = i64::try_from(combinators_len).expect("int cast") - 1;
-        let mut rest_of_simple_selectors = rest;
-        let mut current_simple_selectors = current;
-
-        loop {
-            if current_simple_selectors_i < current_simple_selectors.len() {
-                // PORT NOTE: Zig copies the component by value here (struct copy).
-                // `GenericComponent<Impl>` is not `Copy`; we bitwise-move it out
-                // via `ptr::read` — sound because every element of
-                // `simple_selectors` is consumed exactly once across the loop,
-                // and `set_len(0)` below suppresses the source slice's `Drop`.
-                // SAFETY: each index is read at most once (the cursor
-                // monotonically advances; `rest_of_simple_selectors` is the
-                // disjoint prefix of the previous `current` slice). The source
-                // storage is leaked-then-truncated via `set_len(0)`.
-                let moved = unsafe {
-                    core::ptr::read(&raw const current_simple_selectors[current_simple_selectors_i])
-                };
-                components.push(moved);
-                current_simple_selectors_i += 1;
-            } else {
-                if combinator_i >= 0 {
-                    let (combo, len) =
-                        combinators[usize::try_from(combinator_i).expect("int cast")];
-                    let (rest2, current2) =
-                        split_from_end::<GenericComponent<Impl>>(rest_of_simple_selectors, len);
-                    rest_of_simple_selectors = rest2;
-                    current_simple_selectors_i = 0;
-                    current_simple_selectors = current2;
-                    combinator_i -= 1;
-                    components.push(GenericComponent::Combinator(combo));
-                    continue;
-                }
-                break;
-            }
+        // Emit compounds right-to-left (matching order), each compound's simple
+        // selectors left-to-right. `drain(at..)` moves the suffix out by value;
+        // draining a suffix is shift-free.
+        let at = self.simple_selectors.len() as usize - self.current_len;
+        components.extend(self.simple_selectors.drain(at..));
+        for &(combo, len) in self.combinators.slice().iter().rev() {
+            components.push(GenericComponent::Combinator(combo));
+            let at = self.simple_selectors.len() as usize - len;
+            components.extend(self.simple_selectors.drain(at..));
         }
-
-        // This function should take every component from `self.simple_selectors`
-        // and place it into `components` and return it.
-        //
-        // This means that we shouldn't leak any `GenericComponent<Impl>`, so
-        // it is safe to just set the length to 0.
-        //
-        // Combinators don't need to be deinitialized because they are simple enums.
-        self.simple_selectors.set_len(0);
-        self.combinators.set_len(0);
+        debug_assert_eq!(self.simple_selectors.len(), 0);
+        self.combinators.clear_retaining_capacity();
 
         BuildResult {
             specificity_and_flags: spec,
             components,
         }
     }
-}
-
-pub fn split_from_end<T>(s: &[T], at: usize) -> (&[T], &[T]) {
-    let midpoint = s.len() - at;
-    (&s[0..midpoint], &s[midpoint..])
 }
 
 // ported from: src/css/selectors/builder.zig

--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -51,24 +51,6 @@ type Str = &'static [u8]; // arena-backed `[]const u8` source slice
 // which are identity-copied (matches generics.zig "const strings" fast-path).
 use css::generics::{CssEql, CssHash};
 
-/// Drain a `SmallList<T, N>` into a `Box<[T]>`. `SmallList` has no `into_vec`;
-/// this bitwise-moves each element out and `set_len(0)`s the source so its
-/// `Drop` doesn't double-free. Mirrors Zig `toOwnedSlice`.
-fn small_list_into_box<T, const N: usize>(mut sl: SmallList<T, N>) -> Box<[T]> {
-    let len = sl.len() as usize;
-    let mut v: Vec<T> = Vec::with_capacity(len);
-    {
-        let src = sl.slice();
-        for i in 0..len {
-            // SAFETY: each index is read exactly once; `set_len(0)` below
-            // prevents `SmallList::drop` from re-dropping the moved elements.
-            unsafe { v.push(core::ptr::read(src.get_unchecked(i))) };
-        }
-    }
-    sl.set_len(0);
-    v.into_boxed_slice()
-}
-
 /// Allocate an ASCII-lowercased copy of `name` in the parse-session bump arena.
 /// Zig used `parser.arena().alloc(u8, n)` (the bump arena owns the buffer
 /// for the parse session and frees it on arena reset). Returns a raw arena
@@ -1659,10 +1641,10 @@ impl<Impl: SelectorImpl> Default for GenericSelector<Impl> {
 impl<Impl: SelectorImpl> GenericSelectorList<Impl> {
     /// Consume `self.v` and return a heap slice — used by `:is()`/`:where()`/
     /// `:has()`/`:not()`/`:nth-*(.. of ..)` which store `Box<[Selector]>` to
-    /// keep `Component` small. See `small_list_into_box`.
+    /// keep `Component` small.
     #[inline]
     pub fn into_boxed_selectors(self) -> Box<[GenericSelector<Impl>]> {
-        small_list_into_box(self.v)
+        self.v.to_owned_slice()
     }
 }
 

--- a/src/event_loop/MiniEventLoop.rs
+++ b/src/event_loop/MiniEventLoop.rs
@@ -360,7 +360,7 @@ impl<'a> MiniEventLoop<'a> {
                 if task.is_null() {
                     break;
                 }
-                writable[0] = task;
+                writable[0].write(task);
                 writable = &mut writable[1..];
                 written += 1;
                 if writable.is_empty() {

--- a/src/http/Decompressor.rs
+++ b/src/http/Decompressor.rs
@@ -131,16 +131,6 @@ impl Decompressor {
                 reader.zlib.avail_in = buffer.len() as u32;
 
                 let initial = body_out_str.list.len();
-                // PORT NOTE: Zig `expandToCapacity()` set `len = capacity` so the
-                // zlib output pointers could write into the spare region while
-                // `read_all` later truncated back to `total_out`. `read_all`'s
-                // grow-on-avail_out==0 path reads `list_ptr.len()` to compute the
-                // resume offset, so this `set_len(capacity)` is load-bearing —
-                // skipping it leaves `len == initial` and the next grow rewinds
-                // `next_out` to `ptr + initial`, overwriting freshly-inflated
-                // bytes (observed as mid-stream gzip/deflate corruption when a
-                // streamed body chunk decompresses past the reused buffer's
-                // capacity).
                 if body_out_str.list.capacity() == initial {
                     body_out_str.list.reserve(4096);
                 }
@@ -155,10 +145,11 @@ impl Decompressor {
                 // SAFETY: see `seat` contract — same buffer pair as initial seat.
                 let (_, out) = unsafe { seat(buffer, &mut body_out_str.list) };
                 reader.list_ptr = out;
-                // SAFETY: zlib writes the tail; `read_all` truncates to `total_out` before any read.
-                // `additional = 0`: the conditional reserve above already grew the buffer; `reserve(0)` is a no-op.
-                // `list_ptr.len() == initial` here (reserve does not change len), so the helper's internal `prev` matches.
-                let (next_out, avail_out) = unsafe { reader.list_ptr.reserve_expand_tail(0) };
+                // `list_ptr.len() == initial` here (reserve does not change len),
+                // so the spare tail starts at `ptr + initial`. `read_all` commits
+                // `len = total_out` per iteration before each subsequent reseat,
+                // so multi-round inflate never rewinds `next_out`.
+                let (next_out, avail_out) = reader.list_ptr.ffi_spare_tail(0);
                 reader.zlib.next_out = next_out;
                 reader.zlib.avail_out = avail_out as u32;
                 // we reset the total out so we can track how much we decompressed this time

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -212,21 +212,6 @@ fn h2_session_as_mut<'a>(
     s.map(|mut s| unsafe { s.as_mut() })
 }
 
-/// Upgrade a `*mut PooledSocket<SSL>` returned by `HiveArray::at` to `&mut`.
-///
-/// INVARIANT: every caller obtains `p` from `pending_sockets.at(idx)` while
-/// iterating `pending_sockets.used` (the slot's `used` bit is set), so the
-/// slot is an initialised `PooledSocket` written by `release_socket`. The
-/// HiveArray data array is disjoint from the `used` bitset the iterator
-/// borrows, so the returned `&mut` does not alias it. HTTP-thread-only.
-/// Centralises the raw `&mut *socket_ptr` upgrade repeated at each HiveArray
-/// scan.
-#[inline]
-fn pooled_socket_mut<'a, const SSL: bool>(p: *mut PooledSocket<SSL>) -> &'a mut PooledSocket<SSL> {
-    // SAFETY: see INVARIANT above.
-    unsafe { &mut *p }
-}
-
 impl<const SSL: bool> PooledSocket<SSL> {
     /// Mutable access to the parked HTTP/2 session.
     ///
@@ -633,7 +618,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
             // borrow held by the `HiveSlot` doesn't conflict with a whole-`self`
             // borrow inside the initializer.
             let owner: *mut Self = self;
-            if let Some(slot) = self.pending_sockets.claim() {
+            if let Some(mut slot) = self.pending_sockets.claim() {
                 // The slot's stable address is registered as the socket's
                 // user-data *before* the `PooledSocket` is written; nothing
                 // dereferences it until after `slot.write()` below. If the
@@ -724,13 +709,11 @@ impl<const SSL: bool> HTTPContext<SSL> {
             return None;
         }
 
-        let mut iter = self.pending_sockets.used.iterator::<true, true>();
+        let mut iter = self.pending_sockets.used_iter();
 
         while let Some(pending_socket_index) = iter.next() {
-            let socket_ptr = self
-                .pending_sockets
-                .at(u16::try_from(pending_socket_index).expect("int cast"));
-            let socket = pooled_socket_mut(socket_ptr);
+            let socket = self.pending_sockets.at_mut(pending_socket_index).unwrap();
+            let socket_ptr: *mut PooledSocket<SSL> = socket;
             if socket.port != port {
                 continue;
             }
@@ -811,11 +794,10 @@ impl<const SSL: bool> HTTPContext<SSL> {
                 let tunnel: Option<crate::proxy_tunnel::RefPtr> = socket.proxy_tunnel.take();
                 socket.target_hostname = Box::default();
                 let h2_session = socket.h2_session.take();
-                // SAFETY: `socket_ptr` is a fully-initialized hive slot; the
-                // owned-heap fields (ssl_config/tunnel/target_hostname/h2_session)
-                // were just moved out / cleared, so the in-place drop in `put`
-                // touches only trivially-droppable residuals.
-                let ok = unsafe { self.pending_sockets.put(socket_ptr) };
+                // The owned-heap fields (ssl_config/tunnel/target_hostname/
+                // h2_session) were just moved out / cleared, so the in-place
+                // drop in `put` touches only trivially-droppable residuals.
+                let ok = self.pending_sockets.put(socket_ptr);
                 debug_assert!(ok);
                 bun_core::scoped_log!(
                     HTTPContext,
@@ -1059,12 +1041,9 @@ impl<const SSL: bool> Drop for HTTPContext<SSL> {
         // Without force-close, the socket stays linked and the context refcount never
         // reaches 0, leaking the SSL_CTX.
         {
-            let mut iter = self.pending_sockets.used.iterator::<true, true>();
+            let mut iter = self.pending_sockets.used_iter();
             while let Some(idx) = iter.next() {
-                let pooled_ptr = self
-                    .pending_sockets
-                    .at(u16::try_from(idx).expect("int cast"));
-                let pooled = pooled_socket_mut(pooled_ptr);
+                let pooled = self.pending_sockets.at_mut(idx).unwrap();
                 // Do NOT call rp.data.shutdown() here — it drives
                 // SSLWrapper.shutdown → triggerCloseCallback →
                 // onClose(handlers.ctx), and handlers.ctx is the
@@ -1228,8 +1207,9 @@ impl<const SSL: bool> Handler<SSL> {
             slot.owner
         };
         // SAFETY: owner is the HiveArray backing this slot; address-stable
-        // (static or Box-allocated) and outlives any pooled entry.
-        let ok = unsafe { (*owner).pending_sockets.put(pooled_ptr) };
+        // (static or Box-allocated) and outlives any pooled entry. The unsafe
+        // is for the `*owner` deref; `put` itself is safe.
+        let ok = unsafe { &mut *owner }.pending_sockets.put(pooled_ptr);
         debug_assert!(ok);
     }
 

--- a/src/http/zlib.rs
+++ b/src/http/zlib.rs
@@ -1,21 +1,36 @@
 use bun_core::MutableString;
 use bun_zlib::{ZlibError, ZlibReaderArrayList};
 
-// PORT NOTE: Zig used `bun.ObjectPool(MutableString, initMutableString, false, 4)` and
-// recovered the node via `container_of`. `MutableString` is a foreign type so we
-// cannot impl `ObjectPoolType` for it directly (orphan rule); a `#[repr(transparent)]`
-// newtype lets us cast `*mut PooledMutableString` ↔ `*mut MutableString` at the API
-// boundary.
+// PORT NOTE: Zig used `bun.ObjectPool(MutableString, initMutableString, false, 4)`.
+// `MutableString` already has an `ObjectPoolType` impl in `bun_collections` (with
+// `init2048`); a `#[repr(transparent)]` newtype gives this pool its own
+// `init_empty` constructor without colliding.
 mod buffer_pool {
     use super::*;
     use bun_collections::ObjectPoolType;
 
     #[repr(transparent)]
-    pub(super) struct PooledMutableString(pub MutableString);
+    pub struct PooledMutableString(pub MutableString);
+
+    impl core::ops::Deref for PooledMutableString {
+        type Target = MutableString;
+        #[inline]
+        fn deref(&self) -> &MutableString {
+            &self.0
+        }
+    }
+    impl core::ops::DerefMut for PooledMutableString {
+        #[inline]
+        fn deref_mut(&mut self) -> &mut MutableString {
+            &mut self.0
+        }
+    }
 
     impl ObjectPoolType for PooledMutableString {
-        const INIT: Option<fn() -> Result<Self, bun_core::Error>> =
-            Some(|| Ok(PooledMutableString(MutableString::init_empty())));
+        #[inline]
+        fn init() -> Self {
+            PooledMutableString(MutableString::init_empty())
+        }
         #[inline]
         fn reset(&mut self) {
             self.0.reset();
@@ -26,24 +41,13 @@ mod buffer_pool {
     // `threadsafe = false` ⇒ `global` storage mode.
     bun_collections::object_pool!(pub BufferPool: PooledMutableString, global, 4);
 
-    pub fn get() -> *mut MutableString {
-        // TODO(port): Zig returns `*MutableString` borrowed from a pool node; consider an RAII
-        // guard in Phase B so callers don't hand-pair get/put.
-        // SAFETY: `first()` returns a valid `*mut PooledMutableString` whose data is initialized
-        // (INIT is Some); #[repr(transparent)] makes the cast to `*mut MutableString` sound.
-        BufferPool::first().cast::<MutableString>()
-    }
-
-    pub fn put(mutable: *mut MutableString) {
-        // SAFETY: `mutable` was returned by `get()` above; #[repr(transparent)] cast is sound;
-        // `release_value` recovers the parent node via offset_of.
-        unsafe {
-            (*mutable).reset();
-            BufferPool::release_value(mutable.cast::<PooledMutableString>());
-        }
+    /// RAII guard derefing to a pooled `MutableString`; returned to the pool on
+    /// `Drop`. (Currently no callers; kept for parity with the Zig API.)
+    pub fn get() -> bun_collections::PoolGuard<PooledMutableString> {
+        BufferPool::get()
     }
 }
-pub use buffer_pool::{get, put};
+pub use buffer_pool::get;
 
 pub fn decompress(compressed_data: &[u8], output: &mut MutableString) -> Result<(), ZlibError> {
     let mut reader = ZlibReaderArrayList::init_with_options_and_list_allocator(

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -466,7 +466,7 @@ impl<const SSL: bool> WebSocket<SSL> {
                         return 0;
                     }
                 };
-                writable[..data.len()].copy_from_slice(data);
+                writable[..data.len()].write_copy_of_slice(data);
                 self.receive_buffer.update(data.len());
             }
 
@@ -533,7 +533,7 @@ impl<const SSL: bool> WebSocket<SSL> {
             .receive_buffer
             .writable_with_size(data.len())
             .expect("unreachable");
-        writable[..data.len()].copy_from_slice(data);
+        writable[..data.len()].write_copy_of_slice(data);
         self.receive_buffer.update(data.len());
 
         if left_in_fragment >= data.len()
@@ -1154,7 +1154,7 @@ impl<const SSL: bool> WebSocket<SSL> {
 
                 // Create the compressed frame
                 let frame_size = WebsocketHeader::frame_size_including_mask(compressed.len());
-                let writable = match self.send_buffer.writable_with_size(frame_size) {
+                let writable = match self.send_buffer.writable_with_size_zeroed(frame_size) {
                     Ok(w) => w,
                     Err(_) => return false,
                 };
@@ -1193,7 +1193,7 @@ impl<const SSL: bool> WebSocket<SSL> {
 
         let writable = self
             .send_buffer
-            .writable_with_size(write_len)
+            .writable_with_size_zeroed(write_len)
             .expect("unreachable");
         bytes.copy(
             &self.global_this,

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -882,58 +882,43 @@ impl NetworkTask {
         self.response = HTTPClientResult::default();
     }
 
-    /// Initialize a freshly-vended pool slot in place, mirroring Zig's
+    /// Build a fresh `NetworkTask` value mirroring Zig's
     /// `network_task.* = .{ .task_id = …, .callback = undefined, .allocator = …,
     /// .package_manager = …, .apply_patch_task = … }` — a full struct overwrite
-    /// that resets every other field to its struct default. The slot may be
-    /// uninitialized heap memory (from `HiveArrayFallback::get()`'s
-    /// `Box::new_uninit()` fallback) or stale (reused hive slot whose prior
-    /// contents ARE now dropped on `put` since 1e76047), so each field is
-    /// written via `addr_of_mut!().write()` without dropping the previous
-    /// value — the slot is freshly poisoned/uninit from `get()`.
+    /// that resets every other field to its struct default.
     ///
-    /// Fields that are `= undefined` in Zig (`unsafe_http_client`, `callback`,
-    /// `request_buffer`, `response_buffer`) are written here with drop-safe
-    /// placeholders so subsequent `=` assignments in `for_manifest`/
-    /// `for_tarball` do not drop uninitialized memory. `unsafe_http_client`
-    /// stays bitwise-untouched (it is `MaybeUninit`, so leaving it uninit is
-    /// sound under the `&mut NetworkTask` the caller forms next; it is
-    /// overwritten without drop by `for_manifest`/`for_tarball`).
-    ///
-    /// # Safety
-    /// `slot` must be the unique handle to a `HiveArrayFallback<NetworkTask>`
-    /// slot returned by `get()`; its prior contents are treated as garbage
-    /// (matches Zig — no destructors run).
-    pub unsafe fn write_init(
-        slot: *mut NetworkTask,
+    /// Zig-`undefined` fields (`unsafe_http_client`, `callback`,
+    /// `request_buffer`, `response_buffer`) get drop-safe placeholders so
+    /// subsequent `=` assignments in `for_manifest`/`for_tarball` do not drop
+    /// uninitialized memory. `unsafe_http_client` is `MaybeUninit::uninit()`
+    /// (overwritten without drop by `for_manifest`/`for_tarball`).
+    pub fn new(
         task_id: crate::package_manager_task::Id,
         package_manager: *mut PackageManager,
         apply_patch_task: Option<Box<PatchTask>>,
-    ) {
-        use core::ptr::addr_of_mut;
-        unsafe {
-            addr_of_mut!((*slot).task_id).write(task_id);
+    ) -> Self {
+        Self {
+            unsafe_http_client: MaybeUninit::uninit(),
+            task_id,
             // SAFETY: `package_manager` is the live owner of this task; write
             // provenance is required for `for_manifest`/`for_tarball`'s
             // `assume_mut`, so callers pass `*mut` (not `*const`).
-            addr_of_mut!((*slot).package_manager)
-                .write(bun_ptr::ParentRef::from_raw_mut(package_manager));
-            addr_of_mut!((*slot).apply_patch_task).write(apply_patch_task);
+            package_manager: unsafe { bun_ptr::ParentRef::from_raw_mut(package_manager) },
+            apply_patch_task,
             // Struct-default fields (Zig: `= .{}` / `= 0` / `= null` / `= &[_]u8{}`).
-            addr_of_mut!((*slot).response).write(HTTPClientResult::default());
-            addr_of_mut!((*slot).url_buf).write(Box::default());
-            addr_of_mut!((*slot).retried).write(0);
-            addr_of_mut!((*slot).next).write(bun_threading::Link::new());
-            addr_of_mut!((*slot).tarball_stream).write(None);
-            addr_of_mut!((*slot).streaming_extract_task).write(ptr::null_mut());
-            addr_of_mut!((*slot).streaming_committed).write(false);
-            addr_of_mut!((*slot).signal_store).write(http::signals::Store::default());
-            // Zig-`undefined` fields: write drop-safe placeholders so the
-            // plain `=` in `for_manifest`/`for_tarball` drops a valid value.
-            // (`unsafe_http_client` is `MaybeUninit` — left uninitialized.)
-            addr_of_mut!((*slot).request_buffer).write(MutableString::init_empty());
-            addr_of_mut!((*slot).response_buffer).write(MutableString::init_empty());
-            addr_of_mut!((*slot).callback).write(Callback::LocalTarball);
+            response: HTTPClientResult::default(),
+            url_buf: Box::default(),
+            retried: 0,
+            next: bun_threading::Link::new(),
+            tarball_stream: None,
+            streaming_extract_task: ptr::null_mut(),
+            streaming_committed: false,
+            signal_store: http::signals::Store::default(),
+            // Zig-`undefined` fields: drop-safe placeholders so the plain `=`
+            // in `for_manifest`/`for_tarball` drops a valid value.
+            request_buffer: MutableString::init_empty(),
+            response_buffer: MutableString::init_empty(),
+            callback: Callback::LocalTarball,
         }
     }
 }

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -424,8 +424,8 @@ pub struct PackageManager {
     pub pending_pre_calc_hashes: AtomicU32,
     pub pending_tasks: AtomicU32,
     pub total_tasks: u32,
-    pub preallocated_network_tasks: PreallocatedNetworkTasks,
-    pub preallocated_resolve_tasks: PreallocatedTaskStore,
+    pub preallocated_network_tasks: Box<PreallocatedNetworkTasks>,
+    pub preallocated_resolve_tasks: Box<PreallocatedTaskStore>,
 
     /// items are only inserted into this if they took more than 500ms
     pub lifecycle_script_time_log: LifecycleScriptTimeLog,
@@ -1979,15 +1979,11 @@ pub fn init(
                 core::ptr::addr_of_mut!((*p).$field).write($val)
             };
         }
-        // The two large pools: in-place init that only zeros the 256 B
-        // occupancy bitset and leaves `[MaybeUninit<T>; N]` untouched — no
-        // stack temporary, no memcpy.
-        PreallocatedNetworkTasks::init_in_place(core::ptr::addr_of_mut!(
-            (*p).preallocated_network_tasks
-        ));
-        PreallocatedTaskStore::init_in_place(core::ptr::addr_of_mut!(
-            (*p).preallocated_resolve_tasks
-        ));
+        // The two large pools: `new_boxed` writes only the 256 B occupancy
+        // bitset and leaves `[MaybeUninit<T>; N]` untouched — no stack
+        // temporary, no memcpy.
+        wr!(preallocated_network_tasks, PreallocatedNetworkTasks::new_boxed());
+        wr!(preallocated_resolve_tasks, PreallocatedTaskStore::new_boxed());
 
         wr!(cache_directory_, None);
         wr!(cache_directory_path, ZBox::from_bytes(b"")); // TODO(port): default ""
@@ -2430,14 +2426,10 @@ pub fn init_with_runtime_once(
                 core::ptr::addr_of_mut!((*p).$field).write($val)
             };
         }
-        // The two large pools: in-place init that only zeros the 256 B
-        // occupancy bitset and leaves `[MaybeUninit<T>; N]` untouched.
-        PreallocatedNetworkTasks::init_in_place(core::ptr::addr_of_mut!(
-            (*p).preallocated_network_tasks
-        ));
-        PreallocatedTaskStore::init_in_place(core::ptr::addr_of_mut!(
-            (*p).preallocated_resolve_tasks
-        ));
+        // The two large pools: `new_boxed` writes only the 256 B occupancy
+        // bitset and leaves `[MaybeUninit<T>; N]` untouched.
+        wr!(preallocated_network_tasks, PreallocatedNetworkTasks::new_boxed());
+        wr!(preallocated_resolve_tasks, PreallocatedTaskStore::new_boxed());
 
         wr!(cache_directory_, None);
         wr!(cache_directory_path, ZBox::from_bytes(b"")); // TODO(port): default

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -355,29 +355,29 @@ pub fn enqueue_parse_npm_package(
     name: StringOrTinyString,
     network_task: *mut NetworkTask,
 ) -> *mut ThreadPool::Task {
-    let task = this.preallocated_resolve_tasks.get();
-    // SAFETY: task is a freshly acquired slot from the preallocated pool; we own the write.
+    let value = Task::Task {
+        package_manager: Some(bun_ptr::ParentRef::from(core::ptr::NonNull::from(
+            &mut *this,
+        ))),
+        log: bun_ast::Log::init(),
+        tag: crate::package_manager_task::Tag::PackageManifest,
+        request: crate::package_manager_task::Request {
+            package_manifest: ManuallyDrop::new(
+                crate::package_manager_task::PackageManifestRequest {
+                    // SAFETY: `network_task` is a freshly-vended pool slot; the
+                    // `'static` reborrow matches the `Task<'static>` slot lifetime.
+                    network: unsafe { &mut *network_task },
+                    name,
+                },
+            ),
+        },
+        id: task_id,
+        // TODO(port): `data: undefined` — Task::data left uninitialized in Zig
+        ..Task::uninit()
+    };
+    let task = this.preallocated_resolve_tasks.get_init(value).as_ptr();
+    // SAFETY: `get_init` just fully initialized the slot.
     unsafe {
-        task.write(Task::Task {
-            package_manager: Some(bun_ptr::ParentRef::from_raw_mut(std::ptr::from_mut::<
-                PackageManager,
-            >(this))),
-            log: bun_ast::Log::init(),
-            tag: crate::package_manager_task::Tag::PackageManifest,
-            request: crate::package_manager_task::Request {
-                package_manifest: ManuallyDrop::new(
-                    crate::package_manager_task::PackageManifestRequest {
-                        // SAFETY: `network_task` is a freshly-vended pool slot; the
-                        // `'static` reborrow matches the `Task<'static>` slot lifetime.
-                        network: &mut *network_task,
-                        name,
-                    },
-                ),
-            },
-            id: task_id,
-            // TODO(port): `data: undefined` — Task::data left uninitialized in Zig
-            ..Task::uninit()
-        });
         &raw mut (*task).threadpool_task
     }
 }
@@ -1158,14 +1158,8 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                 // preallocated pool, not `string_bytes`; with
                                 // `name_str` lifetime-detached above, `this`
                                 // is free to reborrow `&mut`.
-                                let network_task = this.get_network_task();
-                                // SAFETY: `network_task` is the unique handle to a
-                                // freshly-vended pool slot. Zig's `network_task.* = .{ ... }`
-                                // resets every defaulted field; `write_init` mirrors that
-                                // (callback is `= undefined` and overwritten by `for_manifest`).
-                                unsafe {
-                                    NetworkTask::write_init(network_task, task_id, this_ptr, None);
-                                }
+                                let network_task =
+                                    this.get_network_task(task_id, this_ptr, None);
 
                                 let scope = this.scope_for_package_name(name_str);
                                 // SAFETY: network_task points to a valid initialized NetworkTask slot
@@ -1656,37 +1650,32 @@ fn init_extract_task(
     tarball: &ExtractTarball,
     network_task: *mut NetworkTask,
 ) -> *mut Task::Task<'static> {
-    let task = this.preallocated_resolve_tasks.get();
-    // SAFETY: task is a freshly acquired uninitialized slot from the preallocated
-    // pool; we own the write. `ptr::write` (no drop of prior value) matches Zig's
-    // `task.* = Task{...}` semantics on uninit memory.
-    unsafe {
-        task.write(Task::Task {
-            package_manager: Some(bun_ptr::ParentRef::from_raw_mut(std::ptr::from_mut::<
-                PackageManager,
-            >(this))),
-            log: bun_ast::Log::init(),
-            tag: crate::package_manager_task::Tag::Extract,
-            request: crate::package_manager_task::Request {
-                extract: ManuallyDrop::new(crate::package_manager_task::ExtractRequest {
-                    // SAFETY: `network_task` is a freshly-vended pool slot; the
-                    // `'static` reborrow matches the `Task<'static>` slot lifetime.
-                    network: &mut *network_task,
-                    tarball: ExtractTarball {
-                        skip_verify: !this
-                            .options
-                            .do_
-                            .contains(crate::package_manager_real::options::Do::VERIFY_INTEGRITY),
-                        ..*tarball
-                    },
-                }),
-            },
-            id: (*network_task).task_id,
-            // TODO(port): `data: undefined`
-            ..Task::uninit()
-        });
-        task
-    }
+    let value = Task::Task {
+        package_manager: Some(bun_ptr::ParentRef::from(core::ptr::NonNull::from(
+            &mut *this,
+        ))),
+        log: bun_ast::Log::init(),
+        tag: crate::package_manager_task::Tag::Extract,
+        request: crate::package_manager_task::Request {
+            extract: ManuallyDrop::new(crate::package_manager_task::ExtractRequest {
+                // SAFETY: `network_task` is a freshly-vended pool slot; the
+                // `'static` reborrow matches the `Task<'static>` slot lifetime.
+                network: unsafe { &mut *network_task },
+                tarball: ExtractTarball {
+                    skip_verify: !this
+                        .options
+                        .do_
+                        .contains(crate::package_manager_real::options::Do::VERIFY_INTEGRITY),
+                    ..*tarball
+                },
+            }),
+        },
+        // SAFETY: `network_task` is a fully-initialized pool slot.
+        id: unsafe { (*network_task).task_id },
+        // TODO(port): `data: undefined`
+        ..Task::uninit()
+    };
+    this.preallocated_resolve_tasks.get_init(value).as_ptr()
 }
 
 pub fn enqueue_extract_npm_package(
@@ -1800,74 +1789,72 @@ pub fn enqueue_git_checkout(
     // if patched then we need to do apply step after network task is done
     patch_name_and_version_hash: Option<u64>,
 ) -> *mut ThreadPool::Task {
-    let task = this.preallocated_resolve_tasks.get();
-    // SAFETY: task is a freshly acquired uninitialized slot from the preallocated
-    // pool; we own the write. `ptr::write` (no drop of prior value) matches Zig's
-    // `task.* = Task{...}` semantics on uninit memory.
-    unsafe {
-        task.write(Task::Task {
-            package_manager: Some(bun_ptr::ParentRef::from_raw_mut(std::ptr::from_mut::<
-                PackageManager,
-            >(this))),
-            log: bun_ast::Log::init(),
-            tag: crate::package_manager_task::Tag::GitCheckout,
-            request: crate::package_manager_task::Request {
-                git_checkout: ManuallyDrop::new(crate::package_manager_task::GitCheckoutRequest {
-                    repo_dir: dir,
-                    resolution,
-                    dependency_id,
-                    name: StringOrTinyString::init_append_if_needed(
-                        name,
-                        &mut crate::network_task::filename_store_appender(),
-                    )
-                    .expect("unreachable"),
-                    url: StringOrTinyString::init_append_if_needed(
-                        // `resolution.tag == Git` for the git-checkout path.
-                        this.lockfile.str(&resolution.git().repo),
-                        &mut crate::network_task::filename_store_appender(),
-                    )
-                    .expect("unreachable"),
-                    resolved: StringOrTinyString::init_append_if_needed(
-                        resolved,
-                        &mut crate::network_task::filename_store_appender(),
-                    )
-                    .expect("unreachable"),
-                    env: crate::repository::SharedEnv::get(this.env_mut()),
-                }),
-            },
-            apply_patch_task: if let Some(h) = patch_name_and_version_hash {
-                let dep_name_hash =
-                    this.lockfile.buffers.dependencies[dependency_id as usize].name_hash;
-                let pkg_id = match this
-                    .lockfile
-                    .package_index
-                    .get(&dep_name_hash)
-                    .unwrap_or_else(|| panic!("Package not found"))
-                {
-                    PackageIndexEntry::Id(p) => *p,
-                    PackageIndexEntry::Ids(ps) => ps[0], // TODO is this correct
-                };
-                let patch_hash = this
-                    .lockfile
-                    .patched_dependencies
-                    .get(&h)
-                    .unwrap()
-                    .patchfile_hash()
-                    .unwrap();
-                let pt = PatchTask::new_apply_patch_hash(this, pkg_id, patch_hash, h);
-                // SAFETY: `pt` is fresh from `heap::alloc`; reclaim ownership.
-                let mut pt = bun_core::heap::take(pt);
-                pt.callback.apply_mut().task_id = Some(task_id);
-                Some(pt)
-            } else {
-                None
-            },
-            id: task_id,
-            // TODO(port): `data: undefined`
-            ..Task::uninit()
-        });
-        &raw mut (*task).threadpool_task
-    }
+    // Build the `Task` value before claiming a hive slot — the `.expect()`s
+    // below can unwind, and `Task` carries drop glue. See `enqueue_git_clone`.
+    let value = Task::Task {
+        package_manager: Some(bun_ptr::ParentRef::from(core::ptr::NonNull::from(
+            &mut *this,
+        ))),
+        log: bun_ast::Log::init(),
+        tag: crate::package_manager_task::Tag::GitCheckout,
+        request: crate::package_manager_task::Request {
+            git_checkout: ManuallyDrop::new(crate::package_manager_task::GitCheckoutRequest {
+                repo_dir: dir,
+                resolution,
+                dependency_id,
+                name: StringOrTinyString::init_append_if_needed(
+                    name,
+                    &mut crate::network_task::filename_store_appender(),
+                )
+                .expect("unreachable"),
+                url: StringOrTinyString::init_append_if_needed(
+                    // `resolution.tag == Git` for the git-checkout path.
+                    this.lockfile.str(&resolution.git().repo),
+                    &mut crate::network_task::filename_store_appender(),
+                )
+                .expect("unreachable"),
+                resolved: StringOrTinyString::init_append_if_needed(
+                    resolved,
+                    &mut crate::network_task::filename_store_appender(),
+                )
+                .expect("unreachable"),
+                env: crate::repository::SharedEnv::get(this.env_mut()),
+            }),
+        },
+        apply_patch_task: if let Some(h) = patch_name_and_version_hash {
+            let dep_name_hash =
+                this.lockfile.buffers.dependencies[dependency_id as usize].name_hash;
+            let pkg_id = match this
+                .lockfile
+                .package_index
+                .get(&dep_name_hash)
+                .unwrap_or_else(|| panic!("Package not found"))
+            {
+                PackageIndexEntry::Id(p) => *p,
+                PackageIndexEntry::Ids(ps) => ps[0], // TODO is this correct
+            };
+            let patch_hash = this
+                .lockfile
+                .patched_dependencies
+                .get(&h)
+                .unwrap()
+                .patchfile_hash()
+                .unwrap();
+            let pt = PatchTask::new_apply_patch_hash(this, pkg_id, patch_hash, h);
+            // SAFETY: `pt` is fresh from `heap::alloc`; reclaim ownership.
+            let mut pt = unsafe { bun_core::heap::take(pt) };
+            pt.callback.apply_mut().task_id = Some(task_id);
+            Some(pt)
+        } else {
+            None
+        },
+        id: task_id,
+        // TODO(port): `data: undefined`
+        ..Task::uninit()
+    };
+    let task = this.preallocated_resolve_tasks.get_init(value).as_ptr();
+    // SAFETY: `get_init` just fully initialized the slot.
+    unsafe { &raw mut (*task).threadpool_task }
 }
 
 fn enqueue_local_tarball(

--- a/src/install/PackageManager/PopulateManifestCache.rs
+++ b/src/install/PackageManager/PopulateManifestCache.rs
@@ -74,18 +74,11 @@ fn start_manifest_task(
     // TODO(port): lifetime — BACKREF.
     let manager_backref: *mut PackageManager = manager;
 
-    // Take the pool slot as a raw pointer so borrowck releases `manager` for the
-    // `enqueue_network_task` tail.
-    let net_ptr: *mut NetworkTask = run_tasks::get_network_task(manager);
     // Zig: `task.* = .{ .package_manager = manager, .callback = undefined,
     //                   .task_id = task_id, .allocator = manager.allocator };`
-    // — full struct overwrite that resets every other field to its struct
-    // default. The slot may be uninitialized (heap fallback) or stale (reused
-    // hive slot).
-    // SAFETY: `net_ptr` is the unique handle to a freshly-vended pool slot; no
-    // other alias exists until we hand it to `enqueue_network_task`.
-    unsafe { NetworkTask::write_init(net_ptr, task_id, manager_backref, None) };
-    // SAFETY: `write_init` populated every field with a drop-safe value;
+    let net_ptr: *mut NetworkTask =
+        run_tasks::get_network_task(manager, task_id, manager_backref, None);
+    // SAFETY: `get_network_task` returns a fully-initialized pool slot;
     // `unsafe_http_client` is `MaybeUninit` and overwritten by `for_manifest`.
     let task = unsafe { &mut *net_ptr };
     // `scope` points into `manager.options` which is not mutated by

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1707,8 +1707,15 @@ pub fn drain_dependency_list(this: &mut PackageManager) {
     let _ = schedule_tasks(this);
 }
 
-pub fn get_network_task(this: &mut PackageManager) -> *mut NetworkTask {
-    this.preallocated_network_tasks.get()
+pub fn get_network_task(
+    this: &mut PackageManager,
+    task_id: Task::Id,
+    package_manager: *mut PackageManager,
+    apply_patch_task: Option<Box<PatchTask>>,
+) -> *mut NetworkTask {
+    this.preallocated_network_tasks
+        .get_init(NetworkTask::new(task_id, package_manager, apply_patch_task))
+        .as_ptr()
 }
 
 pub fn alloc_github_url(this: &PackageManager, repository: &Repository) -> Vec<u8> {
@@ -1811,19 +1818,11 @@ pub fn generate_network_task_for_tarball<'a>(
     // back-pointer (TODO(port): lifetime — BACKREF).
     let this_backref: *mut PackageManager = this;
 
-    // Take the pool slot as a raw pointer so borrowck releases `this` for the
-    // streaming-setup tail. Reborrowed `&mut` per-statement below.
-    let net_ptr: *mut NetworkTask = get_network_task(this);
     // Zig: `network_task.* = .{ .task_id, .callback = undefined, .allocator,
     // .package_manager, .apply_patch_task }` — full struct overwrite that resets
-    // every other field (`retried`, `response`, `streaming_committed`,
-    // `tarball_stream`, `streaming_extract_task`, `next`, `url_buf`,
-    // `signal_store`) to its struct default. The slot may be uninitialized
-    // (`HiveArrayFallback::get()` heap fallback) or stale (reused hive slot).
-    // SAFETY: `net_ptr` is the unique handle to a freshly-vended pool slot; no
-    // other alias exists until we return it.
-    unsafe { NetworkTask::write_init(net_ptr, task_id, this_backref, apply_patch_task) };
-    // SAFETY: `write_init` populated every field with a drop-safe value;
+    // every other field to its struct default.
+    let net_ptr: *mut NetworkTask = get_network_task(this, task_id, this_backref, apply_patch_task);
+    // SAFETY: `get_network_task` returns a fully-initialized pool slot;
     // `unsafe_http_client` is `MaybeUninit` and overwritten by `for_tarball`.
     let network_task = unsafe { &mut *net_ptr };
 
@@ -1928,8 +1927,13 @@ impl PackageManager {
         is_network_task_required(self, task_id)
     }
     #[inline]
-    pub fn get_network_task(&mut self) -> *mut NetworkTask {
-        get_network_task(self)
+    pub fn get_network_task(
+        &mut self,
+        task_id: Task::Id,
+        package_manager: *mut PackageManager,
+        apply_patch_task: Option<Box<PatchTask>>,
+    ) -> *mut NetworkTask {
+        get_network_task(self, task_id, package_manager, apply_patch_task)
     }
     #[inline]
     pub fn alloc_github_url(&self, repository: &Repository) -> Vec<u8> {

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -367,9 +367,8 @@ pub fn install_isolated_packages(
                     }
                     scratch.set_exclude(&provides.at(pkg_id as usize));
 
-                    let mut dst = leaking_peers.at(pkg_id as usize);
-                    if !scratch.eql(&dst) {
-                        dst.copy_into(&scratch);
+                    if !scratch.eql(leaking_peers.at(pkg_id as usize)) {
+                        leaking_peers.at_mut(pkg_id as usize).copy_into(&scratch);
                         changed = true;
                     }
                 }

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -1152,54 +1152,23 @@ impl Lockfile {
 
                 workspace_paths_builder.allocate()?;
 
-                // SAFETY: capacity reserved by `ensure_total_capacity` above; every
-                // slot in `0..old.count()` is overwritten by the copy/zip loops below
-                // before `re_index()` reads them. Mirrors Zig `entries.len = n`.
-                unsafe {
-                    new.workspace_paths
-                        .set_entries_len(old.workspace_paths.count())
-                };
-
-                debug_assert_eq!(
-                    old.workspace_paths.values().len(),
-                    new.workspace_paths.values().len()
-                );
-                for (src, dest) in old
-                    .workspace_paths
-                    .values()
-                    .iter()
-                    .zip(new.workspace_paths.values_mut().iter_mut())
-                {
-                    *dest =
-                        workspace_paths_builder.append::<SemverString>(src.slice(old_string_buf));
-                }
-                new.workspace_paths
-                    .keys_mut()
-                    .copy_from_slice(old.workspace_paths.keys());
+                new.workspace_paths.fill_from_columns(
+                    old.workspace_paths.keys().iter().copied(),
+                    old.workspace_paths.values().iter().map(|src| {
+                        workspace_paths_builder.append::<SemverString>(src.slice(old_string_buf))
+                    }),
+                )?;
 
                 new.workspace_versions
                     .ensure_total_capacity(old.workspace_versions.count())?;
-                // SAFETY: capacity reserved immediately above; every slot is filled by
-                // the zip loop below before `re_index()`. Mirrors Zig `entries.len = n`.
-                unsafe {
-                    new.workspace_versions
-                        .set_entries_len(old.workspace_versions.count())
-                };
-                for (src, dest) in versions
-                    .iter()
-                    .zip(new.workspace_versions.values_mut().iter_mut())
-                {
-                    *dest = src.append(old_string_buf, &mut workspace_paths_builder);
-                }
-
-                new.workspace_versions
-                    .keys_mut()
-                    .copy_from_slice(old.workspace_versions.keys());
+                new.workspace_versions.fill_from_columns(
+                    old.workspace_versions.keys().iter().copied(),
+                    versions
+                        .iter()
+                        .map(|src| src.append(old_string_buf, &mut workspace_paths_builder)),
+                )?;
 
                 workspace_paths_builder.clamp();
-
-                new.workspace_versions.re_index()?;
-                new.workspace_paths.re_index()?;
             }
         }
 

--- a/src/install/lockfile/bun.lockb.rs
+++ b/src/install/lockfile/bun.lockb.rs
@@ -442,22 +442,10 @@ pub fn load(
                     lockfile
                         .workspace_versions
                         .ensure_total_capacity(workspace_versions_list.len())?;
-                    // SAFETY: capacity reserved above; both columns are fully
-                    // overwritten by `copy_from_slice` before `re_index` reads them.
-                    unsafe {
-                        lockfile
-                            .workspace_versions
-                            .set_entries_len(workspace_versions_list.len());
-                    }
-                    lockfile
-                        .workspace_versions
-                        .keys_mut()
-                        .copy_from_slice(&workspace_package_name_hashes);
-                    lockfile
-                        .workspace_versions
-                        .values_mut()
-                        .copy_from_slice(&workspace_versions_list);
-                    lockfile.workspace_versions.re_index()?;
+                    lockfile.workspace_versions.fill_from_columns(
+                        workspace_package_name_hashes,
+                        workspace_versions_list,
+                    )?;
                 }
 
                 {
@@ -471,23 +459,9 @@ pub fn load(
                     lockfile
                         .workspace_paths
                         .ensure_total_capacity(workspace_paths_strings.len())?;
-
-                    // SAFETY: capacity reserved above; both columns are fully
-                    // overwritten by `copy_from_slice` before `re_index` reads them.
-                    unsafe {
-                        lockfile
-                            .workspace_paths
-                            .set_entries_len(workspace_paths_strings.len());
-                    }
                     lockfile
                         .workspace_paths
-                        .keys_mut()
-                        .copy_from_slice(&workspace_paths_hashes);
-                    lockfile
-                        .workspace_paths
-                        .values_mut()
-                        .copy_from_slice(&workspace_paths_strings);
-                    lockfile.workspace_paths.re_index()?;
+                        .fill_from_columns(workspace_paths_hashes, workspace_paths_strings)?;
                 }
             } else {
                 stream.pos -= 8;
@@ -506,16 +480,9 @@ pub fn load(
 
                 lockfile.trusted_dependencies = Some(Default::default());
                 let td = lockfile.trusted_dependencies.as_mut().unwrap();
-                td.ensure_total_capacity(trusted_dependencies_hashes.len())?;
-
-                // SAFETY: capacity reserved above; keys are fully overwritten
-                // by `copy_from_slice` before `re_index` reads them; value type
-                // is `()` so its column needs no init.
-                unsafe {
-                    td.set_entries_len(trusted_dependencies_hashes.len());
-                }
-                td.keys_mut().copy_from_slice(&trusted_dependencies_hashes);
-                td.re_index()?;
+                let n = trusted_dependencies_hashes.len();
+                td.ensure_total_capacity(n)?;
+                td.fill_from_columns(trusted_dependencies_hashes, core::iter::repeat_n((), n))?;
             } else if next_num == HAS_EMPTY_TRUSTED_DEPENDENCIES_TAG {
                 // trusted dependencies exists in package.json but is an empty array.
                 lockfile.trusted_dependencies = Some(Default::default());

--- a/src/io/windows_event_loop.rs
+++ b/src/io/windows_event_loop.rs
@@ -89,19 +89,14 @@ impl FilePoll {
         owner: Owner,
     ) -> *mut FilePoll {
         // Crate-private backref-deref accessor — single live `&mut Store` borrow.
-        let poll = vm.file_polls_mut().get();
-        // SAFETY: `get()` returns a valid, uniquely-owned, *uninitialized* slot from the
-        // HiveArray pool. We must not materialize `&mut FilePoll` (validity invariant
-        // requires initialized memory); write the whole value through the raw pointer.
-        unsafe {
-            poll.write(FilePoll {
+        vm.file_polls_mut()
+            .get_init(FilePoll {
                 fd,
                 flags,
                 owner,
                 next_to_free: ptr::null_mut(),
-            });
-        }
-        poll
+            })
+            .as_ptr()
     }
 
     // PORT NOTE: not `impl Drop` — FilePoll lives in a HiveArray pool slot, not a Box;
@@ -289,8 +284,8 @@ impl Store {
         }
     }
 
-    pub fn get(&mut self) -> *mut FilePoll {
-        self.hive.get()
+    pub fn get_init(&mut self, value: FilePoll) -> ptr::NonNull<FilePoll> {
+        self.hive.get_init(value)
     }
 
     pub fn process_deferred_frees(&mut self) {

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -581,13 +581,11 @@ impl<'a> Parser<'a> {
         // If we added to `p.symbols` it's going to fuck up all the indices
         // in the `symbols` array.
         debug_assert!(p.symbols.len() == 0);
-        let mut symbols_ = symbols;
         // PORT NOTE: Zig `moveToListManaged(arena)` rebinds the same
         // backing storage to an `ArrayList(arena)`. The Rust Vec
         // adapter returns a `std::Vec`; `p.symbols` is a bump-backed Vec, so
         // copy elements into the arena. Phase B may grow a zero-copy adapter.
-        p.symbols =
-            bun_alloc::vec_from_iter_in(symbols_.move_to_list_managed().into_iter(), p.arena);
+        p.symbols = bun_alloc::vec_from_iter_in(symbols.into_iter(), p.arena);
 
         p.prepare_for_visit_pass()?;
 

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -16,8 +16,8 @@ use crate::defines::Define;
 use crate::lexer as js_lexer;
 use crate::p::P;
 use crate::parser::{
-    Jest, ParseStatementOptions, Runtime, RuntimeFeatures, RuntimeImports,
-    ScanPassResult, SideEffects, WrapMode,
+    Jest, ParseStatementOptions, Runtime, RuntimeFeatures, RuntimeImports, ScanPassResult,
+    SideEffects, WrapMode,
 };
 use bun_ast as js_ast;
 use bun_ast::g::Decl;
@@ -1424,12 +1424,7 @@ impl<'a> Parser<'a> {
                                 if let Some(id) = redirect_import_record_index {
                                     part.symbol_uses = Default::default();
                                     return Ok(crate::Result::Ast(Box::new(js_ast::Ast {
-                                        // Borrow the arena/Vec-backed records as a Vec view
-                                        // (matches `P::to_ast`); `p` is dropped immediately
-                                        // after this return so no double-ownership.
-                                        import_records: unsafe {
-                                            Vec::from_bump_slice(p.import_records.items_mut())
-                                        },
+                                        import_records: p.import_records.move_to_baby_list(p.arena),
                                         redirect_import_record_index: Some(id),
                                         named_imports: core::mem::take(&mut *p.named_imports),
                                         named_exports: core::mem::take(&mut p.named_exports),
@@ -1611,10 +1606,7 @@ impl<'a> Parser<'a> {
                     if let Some(star) = export_star_redirect {
                         return Ok(crate::Result::Ast(Box::new(js_ast::Ast {
                             // TODO(port): Zig set `.arena = p.arena`; arena ownership tracked elsewhere in Rust
-                            // See note on the matching arm above re double-ownership.
-                            import_records: unsafe {
-                                Vec::from_bump_slice(p.import_records.items_mut())
-                            },
+                            import_records: p.import_records.move_to_baby_list(p.arena),
                             redirect_import_record_index: Some(star.import_record_index),
                             named_imports: core::mem::take(&mut *p.named_imports),
                             named_exports: core::mem::take(&mut p.named_exports),

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1535,10 +1535,10 @@ impl StringVoidMap {
         self.map.contains_key(key)
     }
 
-    fn init() -> Result<StringVoidMap, bun_core::Error> {
-        Ok(StringVoidMap {
+    fn init() -> StringVoidMap {
+        StringVoidMap {
             map: StringHashMap::default(),
-        })
+        }
     }
 
     pub fn reset(&mut self) {
@@ -1549,13 +1549,16 @@ impl StringVoidMap {
     /// Returns an RAII guard that derefs to `&mut StringVoidMap` and is
     /// returned to the pool on `Drop` (replaces Zig's `get` + `defer release`).
     #[inline]
-    pub fn get() -> bun_collections::pool::PoolGuard<'static, StringVoidMap> {
+    pub fn get() -> bun_collections::pool::PoolGuard<StringVoidMap> {
         StringVoidMapPool::get()
     }
 }
 
 impl bun_collections::pool::ObjectPoolType for StringVoidMap {
-    const INIT: Option<fn() -> Result<Self, bun_core::Error>> = Some(StringVoidMap::init);
+    #[inline]
+    fn init() -> Self {
+        StringVoidMap::init()
+    }
     #[inline]
     fn reset(&mut self) {
         StringVoidMap::reset(self)

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -188,9 +188,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let strict_loc = fn_body_contains_use_strict(opts.body);
         let has_simple_args = Self::is_simple_parameter_list(args, opts.has_rest_arg);
         // StringVoidMap::get returns a pool guard; Drop releases (replaces Zig `defer release`).
-        let mut duplicate_args_check: Option<
-            bun_collections::pool::PoolGuard<'static, StringVoidMap>,
-        > = None;
+        let mut duplicate_args_check: Option<bun_collections::pool::PoolGuard<StringVoidMap>> =
+            None;
 
         // Section 15.2.1 Static Semantics: Early Errors: "It is a Syntax Error if
         // FunctionBodyContainsUseStrict of FunctionBody is true and

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -686,14 +686,13 @@ impl NumberRenamer {
         parent: Option<bun_ptr::ParentRef<NumberScope>>,
         sorted: &mut Vec<u32>,
     ) {
-        let s: *mut NumberScope = self.number_scope_pool.get();
-        // SAFETY: `s` is a valid pool slot (HiveArrayFallback::get never returns null).
-        unsafe {
-            s.write(NumberScope {
+        let s: *mut NumberScope = self
+            .number_scope_pool
+            .get_init(NumberScope {
                 parent,
                 name_counts: StringHashMap::default(),
-            });
-        }
+            })
+            .as_ptr();
 
         self.assign_names_recursive_with_number_scope(s, scope, source_index, sorted);
 
@@ -750,20 +749,18 @@ impl NumberRenamer {
 
         loop {
             if scope.members.count() > 0 || scope.generated.len_u32() > 0 {
-                let new_child_scope: *mut NumberScope = self.number_scope_pool.get();
-                // SAFETY: `new_child_scope` is a valid pool slot.
-                unsafe {
-                    new_child_scope.write(NumberScope {
-                        // `s` is non-null (either `initial_scope` or a fresh
-                        // pool slot from a prior iteration); the new child
-                        // outlives this `ParentRef` only until `put()` below.
+                // `s` is non-null (either `initial_scope` or a fresh pool slot
+                // from a prior iteration); the new child outlives this
+                // `ParentRef` only until `put()` below.
+                s = self
+                    .number_scope_pool
+                    .get_init(NumberScope {
                         parent: Some(bun_ptr::ParentRef::from(
                             core::ptr::NonNull::new(s).expect("number_scope non-null"),
                         )),
                         name_counts: StringHashMap::default(),
-                    });
-                }
-                s = new_child_scope;
+                    })
+                    .as_ptr();
 
                 // SAFETY: s is a valid pool slot just initialized above
                 self.assign_names_in_scope(unsafe { &mut *s }, scope, source_index, sorted);

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -901,10 +901,10 @@ impl<'a> TablePrinter<'a> {
                 ));
 
                 // `defer` block: release pooled visit map after formatting.
-                // PORT NOTE: Zig's `defer` body also nulls
+                // PORT NOTE: Zig's `defer` body also clears
                 // `this.value_formatter.map_node`, but `shallow_clone()`
-                // already guarantees the source's `map_node` is `None`, so
-                // only the local clone needs draining. `Formatter::Drop` does
+                // already guarantees the source isn't pooled, so only the
+                // local clone needs draining. `Formatter::Drop` does
                 // the same release, so a plain scope is sufficient.
                 {
                     let result = value_formatter.format::<ENABLE_ANSI_COLORS>(
@@ -913,15 +913,16 @@ impl<'a> TablePrinter<'a> {
                         value,
                         self.global_object,
                     );
-                    if let Some(mut node) = value_formatter.map_node.take() {
-                        self.value_formatter.map_node = None;
-                        let data = formatter::visited::node_data_mut(&mut node);
-                        if data.capacity() > 512 {
-                            data.deinit();
+                    if value_formatter.map_from_pool {
+                        value_formatter.map_from_pool = false;
+                        self.value_formatter.map_from_pool = false;
+                        let mut map = core::mem::take(&mut value_formatter.map);
+                        if map.capacity() > 512 {
+                            map.deinit();
                         } else {
-                            data.clear();
+                            map.clear();
                         }
-                        formatter::visited::Pool::release(node.as_ptr());
+                        formatter::visited::Pool::put(map);
                     }
                     result?;
                 }
@@ -1743,12 +1744,9 @@ pub mod formatter {
         /// `RawSlice` carries the outlives-holder invariant instead.
         pub remaining_values: bun_ptr::RawSlice<JSValue>,
         pub map: visited::Map,
-        /// Pooled backing for `map`. `None` until the first cell that can have
-        /// circular refs is formatted; `Drop` returns it to `visited::Pool`.
-        /// Raw pointer (not `Box`) because `visited::Pool` owns the
-        /// `heap::alloc`/`from_raw` lifecycle — mirrors Zig
-        /// `?*Visited.Pool.Node`.
-        pub map_node: Option<core::ptr::NonNull<visited::PoolNode>>,
+        /// `true` once `map`'s allocation was taken from `visited::Pool`;
+        /// `Drop` returns it there. Mirrors Zig `?*Visited.Pool.Node`.
+        pub map_from_pool: bool,
         pub hide_native: bool,
         pub indent: u32,
         pub depth: u16,
@@ -1778,7 +1776,7 @@ pub mod formatter {
                 global_this,
                 remaining_values: bun_ptr::RawSlice::EMPTY,
                 map: visited::Map::default(),
-                map_node: None,
+                map_from_pool: false,
                 hide_native: false,
                 indent: 0,
                 depth: 0,
@@ -1803,21 +1801,21 @@ pub mod formatter {
         }
 
         /// Zig copies `Formatter` by value (`var f = this.value_formatter;`).
-        /// In Rust `Formatter` has a `Drop` impl and owns `map`/`map_node`,
-        /// so a bit-copy via `ptr::read` would double-free. The Zig copy
-        /// only ever ships scalar config — `map`/`map_node` are always empty
-        /// on the source at the call sites — so we copy those fields
-        /// explicitly and leave `map`/`map_node` fresh on the clone.
+        /// In Rust `Formatter` has a `Drop` impl and owns `map`, so a bit-copy
+        /// via `ptr::read` would double-free. The Zig copy only ever ships
+        /// scalar config — `map` is always empty on the source at the call
+        /// sites — so we copy those fields explicitly and leave `map` fresh on
+        /// the clone.
         pub(super) fn shallow_clone(&self) -> Self {
             debug_assert!(
-                self.map_node.is_none(),
+                !self.map_from_pool,
                 "shallow_clone source must not own a visited map"
             );
             Self {
                 global_this: self.global_this,
                 remaining_values: self.remaining_values,
                 map: visited::Map::default(),
-                map_node: None,
+                map_from_pool: false,
                 hide_native: self.hide_native,
                 indent: self.indent,
                 depth: self.depth,
@@ -1858,22 +1856,17 @@ pub mod formatter {
 
     impl Drop for Formatter<'_> {
         fn drop(&mut self) {
-            if let Some(mut node) = self.map_node.take() {
-                // Move the working map back into the pooled node, shrink if it
-                // ballooned, then return the node to the thread-local pool.
-                // Mirrors `Formatter.deinit` (ConsoleObject.zig:1016-1024).
-                let map = core::mem::take(&mut self.map);
-                // `node_data_mut` is safe: `Map::INIT` is `Some`, so the
-                // pooled slot already holds an (empty, post-`take`) `Map`;
-                // assigning over it drops that empty value and moves `map` in.
-                let data = visited::node_data_mut(&mut node);
-                *data = map;
-                if data.capacity() > 512 {
-                    data.deinit();
+            if self.map_from_pool {
+                // Move the working map back into the pool, shrinking if it
+                // ballooned. Mirrors `Formatter.deinit` (ConsoleObject.zig:1016-1024).
+                self.map_from_pool = false;
+                let mut map = core::mem::take(&mut self.map);
+                if map.capacity() > 512 {
+                    map.deinit();
                 } else {
-                    data.clear();
+                    map.clear();
                 }
-                visited::Pool::release(node.as_ptr());
+                visited::Pool::put(map);
             }
         }
     }
@@ -1981,31 +1974,18 @@ pub mod formatter {
         }
 
         impl bun_collections::pool::ObjectPoolType for Map {
-            // Zig: `ObjectPool(Map, Map.init, true, 16)` — fresh nodes start
+            // Zig: `ObjectPool(Map, Map.init, true, 16)` — fresh entries start
             // with an empty map so `clearRetainingCapacity()` on first use is
             // well-defined.
-            const INIT: Option<fn() -> Result<Self, bun_core::Error>> = Some(|| Ok(Map::default()));
+            #[inline]
+            fn init() -> Self {
+                Map::default()
+            }
         }
 
-        // Thread-local free list, capped at 16 nodes — matches Zig
+        // Thread-local free list, capped at 16 entries — matches Zig
         // `threadsafe = true, max_count = 16`.
         bun_collections::object_pool!(pub Pool: Map, threadsafe, 16);
-        pub type PoolNode = bun_collections::pool::Node<Map>;
-
-        /// Safe `&mut Map` accessor for a pooled node. `Map::INIT` is `Some`,
-        /// so every node returned by [`Pool::get_node`] carries an initialized
-        /// `data` payload, and the caller exclusively owns the node until
-        /// [`Pool::release`]. Centralises the `NonNull::as_mut()` +
-        /// `assume_init_mut()` pair so the four call sites in this file (and
-        /// the cause-chain guard in `VirtualMachine::print_error_instance`)
-        /// don't each open-code two `unsafe` operations.
-        #[inline]
-        pub fn node_data_mut(node: &mut core::ptr::NonNull<PoolNode>) -> &mut Map {
-            // SAFETY: `Map::INIT` is `Some`, so `data` is initialized for
-            // every node from `Pool::get_node()`; the caller owns `node`
-            // exclusively until `Pool::release`, so forming `&mut` is sound.
-            unsafe { node.as_mut().data.assume_init_mut() }
-        }
     }
 
     // ───────────────────────────────────────────────────────────────────────
@@ -3503,13 +3483,9 @@ pub mod formatter {
                 return Ok(false);
             }
 
-            if self.map_node.is_none() {
-                let mut node = core::ptr::NonNull::new(visited::Pool::get_node())
-                    .expect("ObjectPool::get_node always returns a valid heap node");
-                let data = visited::node_data_mut(&mut node);
-                data.clear();
-                self.map = core::mem::take(data);
-                self.map_node = Some(node);
+            if !self.map_from_pool {
+                self.map = visited::Pool::take();
+                self.map_from_pool = true;
             }
 
             let entry = self.map.get_or_put(value).expect("unreachable");
@@ -4121,7 +4097,7 @@ pub mod formatter {
             // Temporarily remove from the visited map to allow
             // printErrorlikeObject to process it. The circular reference
             // check is already done in print_as, so we know it's safe.
-            let was_in_map = if self.map_node.is_some() {
+            let was_in_map = if self.map_from_pool {
                 self.map.remove(&value).is_some()
             } else {
                 false

--- a/src/jsc/JSONLineBuffer.rs
+++ b/src/jsc/JSONLineBuffer.rs
@@ -132,15 +132,15 @@ impl JSONLineBuffer {
     }
 
     /// Notify the buffer that `nread` bytes were written directly into the
-    /// tail of `data` (via `data.uv_alloc_spare_u8()`).
+    /// tail of `data` (via `bun_core::vec::reserve_spare_bytes`).
     ///
     /// Takes a length, not a `&[u8]`, because the only caller's slice would
     /// alias `&mut self.data` — and only the length is used here. Passing the
     /// slice through would re-introduce the Stacked-Borrows hazard the
     /// `on_read` refactor removed.
     pub fn notify_written(&mut self, nread: usize) {
-        // SAFETY: caller (libuv on_read) wrote `nread` bytes into the uv_alloc_spare* slice.
-        unsafe { self.data.uv_commit(nread) };
+        // SAFETY: caller (libuv on_read) wrote `nread` bytes into the spare-capacity slice.
+        unsafe { bun_core::vec::commit_spare(&mut self.data, nread) };
         self.scan_for_newline();
     }
 }

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -216,7 +216,7 @@ pub fn set_break_point_on_first_line() -> bool {
 
 pub struct RuntimeTranspilerStore {
     pub generation_number: AtomicU32,
-    pub store: TranspilerJobStore,
+    pub store: Box<TranspilerJobStore>,
     pub enabled: bool,
     pub queue: Queue,
 }
@@ -227,7 +227,7 @@ impl Default for RuntimeTranspilerStore {
     fn default() -> Self {
         Self {
             generation_number: AtomicU32::new(0),
-            store: TranspilerJobStore::init(),
+            store: TranspilerJobStore::new_boxed(),
             enabled: true,
             queue: Queue::new(),
         }
@@ -266,10 +266,7 @@ impl RuntimeTranspilerStore {
         // valid in-bounds field place without forming an intermediate reference.
         unsafe {
             addr_of_mut!((*out).generation_number).write(AtomicU32::new(0));
-            // `store.hive.buffer: [MaybeUninit<TranspilerJob>; 64]` —
-            // intentionally left untouched (uninit is a valid value).
-            addr_of_mut!((*out).store.hive.used)
-                .write(bun_collections::hive_array::HiveBitSet::init_empty());
+            addr_of_mut!((*out).store).write(TranspilerJobStore::new_boxed());
             addr_of_mut!((*out).enabled).write(true);
             addr_of_mut!((*out).queue).write(Queue::new());
         }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6018,13 +6018,9 @@ impl VirtualMachine {
         let mut exception_list = exception_list;
         for &err in &errors_to_append {
             // Circular-ref guard for cause chains.
-            if formatter.map_node.is_none() {
-                let mut node = NonNull::new(console_object::formatter::visited::Pool::get_node())
-                    .expect("ObjectPool::get_node always returns a valid heap node");
-                let data = console_object::formatter::visited::node_data_mut(&mut node);
-                data.clear();
-                formatter.map = core::mem::take(data);
-                formatter.map_node = Some(node);
+            if !formatter.map_from_pool {
+                formatter.map = console_object::formatter::visited::Pool::take();
+                formatter.map_from_pool = true;
             }
 
             let entry = formatter.map.get_or_put(err).expect("unreachable");

--- a/src/jsc/ipc.rs
+++ b/src/jsc/ipc.rs
@@ -2148,12 +2148,15 @@ pub mod IPCHandlers {
             match &mut send_queue.incoming {
                 IncomingBuffer::Json(json_buf) => {
                     // SAFETY: libuv writes into this region before notify_written reads.
-                    let spare = unsafe { json_buf.data.uv_alloc_spare_u8(suggested_size) };
+                    let spare = unsafe {
+                        bun_core::vec::reserve_spare_bytes(&mut json_buf.data, suggested_size)
+                    };
                     &mut spare[..suggested_size]
                 }
                 IncomingBuffer::Advanced(adv_buf) => {
                     // SAFETY: libuv writes into this region before on_read commits.
-                    let spare = unsafe { adv_buf.uv_alloc_spare_u8(suggested_size) };
+                    let spare =
+                        unsafe { bun_core::vec::reserve_spare_bytes(adv_buf, suggested_size) };
                     &mut spare[..suggested_size]
                 }
             }
@@ -2238,7 +2241,7 @@ pub mod IPCHandlers {
                         unreachable!()
                     };
                     // SAFETY: `on_read_alloc` reserved ≥ nread bytes; libuv initialised them.
-                    unsafe { adv_buf.uv_commit(nread) };
+                    unsafe { bun_core::vec::commit_spare(adv_buf, nread) };
                     let total_len = adv_buf.len() as usize;
                     let mut slice_start: usize = 0;
 
@@ -2252,7 +2255,7 @@ pub mod IPCHandlers {
                                 Ok(r) => r,
                                 Err(IPCDecodeError::NotEnoughBytes) => {
                                     // copy the remaining bytes to the start of the buffer
-                                    // `total_len == adv_buf.len()` (captured post-uv_commit, never
+                                    // `total_len == adv_buf.len()` (captured post-commit_spare, never
                                     // grown in this loop) ⇒ exact `len - slice_start` truncate.
                                     adv_buf.drain_front(slice_start);
                                     log!("hit NotEnoughBytes3");

--- a/src/parsers/toml.rs
+++ b/src/parsers/toml.rs
@@ -166,9 +166,8 @@ mod hash_map_pool {
     pub(super) type HashMap = bun_collections::HashMap<u64, ()>;
 
     // bun.deprecated.SinglyLinkedList(HashMap)
-    // The Rust mapping is `bun_collections::pool::{SinglyLinkedList, Node}`, but
-    // that stores `MaybeUninit<T>`; this freelist wants `data: T` directly, so it
-    // keeps a local intrusive node with a raw `next` pointer to match shape.
+    // Local intrusive node with a raw `next` pointer; `bun_collections::ObjectPool`
+    // would work here too, but this preserves the Zig freelist shape verbatim.
     pub(super) struct Node {
         pub data: HashMap,
         pub next: *mut Node,

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -2595,22 +2595,22 @@ pub fn read_file_with_handle_impl<'p, 'buf, const USE_SHARED_BUFFER: bool, const
 
         let mut bytes_read: u64 = 0;
         shared_buffer.grow_by(size + 1)?;
-        // SAFETY: u8; `read_all` overwrites the exposed tail before any read.
-        unsafe { shared_buffer.list.expand_to_capacity() };
 
         // if you press save on a large file we might not read all the
         // bytes in the first few pread() calls. we only handle this on
         // stream because we assume that this only realistically happens
         // during HMR
         loop {
+            debug_assert_eq!(shared_buffer.list.len(), bytes_read as usize);
             // We use pread to ensure if the file handle was open, it doesn't seek from the last position
-            let read_count = match file.read_all(&mut shared_buffer.list[bytes_read as usize..]) {
+            // SAFETY: write-only spare; `read_all` only stores into it.
+            let spare = unsafe { bun_core::vec::spare_bytes_mut(&mut shared_buffer.list) };
+            let read_count = match file.read_all(spare) {
                 Ok(n) => n,
                 Err(err) => return Err(err.into()),
             };
-            shared_buffer
-                .list
-                .truncate(read_count + bytes_read as usize);
+            // SAFETY: `read_all` initialized `spare[..read_count]`.
+            unsafe { bun_core::vec::commit_spare(&mut shared_buffer.list, read_count) };
             file_contents_ptr = shared_buffer.list.as_ptr();
             file_contents_len = shared_buffer.list.len();
             debug!("read({}, {}) = {}", file.handle(), size, read_count);
@@ -2632,8 +2632,6 @@ pub fn read_file_with_handle_impl<'p, 'buf, const USE_SHARED_BUFFER: bool, const
 
                 if (bytes_read as usize) < new_size {
                     shared_buffer.grow_by(new_size - size)?;
-                    // SAFETY: u8; `read_all` overwrites the exposed tail before any read.
-                    unsafe { shared_buffer.list.expand_to_capacity() };
                     size = new_size;
                     continue;
                 }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -7371,13 +7371,8 @@ impl H2FrameParser {
         };
         let this: *mut H2FrameParser = if ENABLE_ALLOCATOR_POOL {
             POOL.with_borrow_mut(|pool| {
-                let pool = pool.get_or_insert_with(|| Box::new(H2FrameParserHiveAllocator::init()));
-                let slot = pool.try_get();
-                // SAFETY: `slot` is a freshly-claimed, uninitialised `*mut H2FrameParser`
-                // (HiveArray slot or fallback `Box<MaybeUninit<_>>`); `write` moves
-                // `init` in without dropping prior contents.
-                unsafe { slot.write(init) };
-                slot
+                let pool = pool.get_or_insert_with(H2FrameParserHiveAllocator::new_boxed);
+                pool.get_init(init).as_ptr()
             })
         } else {
             bun_core::heap::into_raw(Box::new(init))

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -2090,9 +2090,13 @@ impl DevServer {
         req: ReqOrSaved,
         resp: AnyResponse,
     ) -> Result<(), bun_core::Error> {
-        let deferred_ptr = self.deferred_request_pool.get();
-        // SAFETY: HiveArrayFallback::get returns an exclusively-owned, live node ptr
-        // (heap-allocates on overflow; never null).
+        let deferred_ptr = self
+            .deferred_request_pool
+            .get_init(deferred_request::Node {
+                data: ::core::mem::MaybeUninit::uninit(),
+            })
+            .as_ptr();
+        // SAFETY: `get_init` returns an exclusively-owned, live node ptr.
         let deferred = unsafe { &mut *deferred_ptr };
         // Precompute the data slot pointer (used inside the initializer for
         // abort-callback registration) before borrowing `deferred.data` for `.write()`.

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -624,7 +624,7 @@ pub fn init(options: Options) -> JsResult<Box<DevServer>> {
             NextBundle {
                 route_queue: Default::default(),
                 reload_event: None,
-                requests: deferred_request::List::default(),
+                requests: deferred_request::List::new(),
                 promise: DeferredPromise::default(),
             }
         );
@@ -1135,15 +1135,11 @@ impl Drop for DevServer {
         }
 
         {
-            let mut r = self.next_bundle.requests.first;
-            while !r.is_null() {
-                // SAFETY: intrusive list node; `data` was written by `defer_request`.
-                let request = unsafe { &mut *r };
-                let data = unsafe { request.data.assume_init_mut() };
+            for r in ::core::mem::take(&mut self.next_bundle.requests) {
+                // SAFETY: hive-slot node; `data` was written by `defer_request`.
+                let data = unsafe { (*r.as_ptr()).data.assume_init_mut() };
                 debug_assert!(!matches!(data.handler, Handler::ServerHandler(_)));
-                let next = request.next;
                 data.deref_();
-                r = next;
             }
             self.next_bundle.promise.deinit_idempotently();
         }
@@ -2198,7 +2194,7 @@ impl DevServer {
             deferred_data.weak_ref();
         }
 
-        requests_array.prepend(deferred_ptr);
+        requests_array.push(::core::ptr::NonNull::new(deferred_ptr).expect("hive slot"));
         Ok(())
     }
 }
@@ -2916,8 +2912,20 @@ pub mod deferred_request {
     /// is very silly. This contributes to ~6kb of the initial DevServer allocation.
     pub const MAX_PREALLOCATED: usize = 16;
 
-    pub type List = bun_collections::pool::SinglyLinkedList<DeferredRequest>;
-    pub type Node = bun_collections::pool::Node<DeferredRequest>;
+    /// Nodes are owned by `dev.deferred_request_pool` (a `HiveArrayFallback`
+    /// — stable addresses required for the uWS abort-callback registration).
+    /// `List` is a `Vec` of borrowed pointers; LIFO push/pop matches the
+    /// original `SinglyLinkedList` `prepend`/`pop_first`.
+    pub type List = Vec<::core::ptr::NonNull<Node>>;
+
+    /// `data` is `MaybeUninit` so `HiveArrayFallback::put`'s `drop_in_place`
+    /// is a no-op — `__deinit` already tore down the payload, and on the
+    /// `prepare_and_save_js_request_context` failure path `data` was never
+    /// written.
+    #[repr(C)]
+    pub struct Node {
+        pub data: ::core::mem::MaybeUninit<DeferredRequest>,
+    }
 
     bun_output::define_scoped_log!(debug_log_dr, DlogeferredRequest, hidden);
     pub(super) use debug_log_dr;
@@ -3014,8 +3022,8 @@ impl DeferredRequest {
             bun_core::from_field_ptr!(deferred_request::Node, data, std::ptr::from_mut(self))
         };
         // SAFETY: dev backref is valid while the pool entry exists; `node` is a
-        // fully-initialized hive slot. `pool::Node<T>` has no drop glue (`data`
-        // is `MaybeUninit`), so `put`'s in-place drop is a no-op — `__deinit`
+        // fully-initialized hive slot. `Node` has no drop glue (`data` is
+        // `MaybeUninit`), so `put`'s in-place drop is a no-op — `__deinit`
         // already tore down the payload.
         unsafe {
             (*self.dev.cast_mut()).deferred_request_pool.put(node);
@@ -3219,7 +3227,7 @@ impl DevServer {
         });
 
         self.next_bundle.promise = DeferredPromise::default();
-        self.next_bundle.requests = deferred_request::List::default();
+        self.next_bundle.requests = deferred_request::List::new();
         self.next_bundle.route_queue.clear_retaining_capacity();
         Ok(())
     }
@@ -3778,16 +3786,15 @@ pub fn finalize_bundle(
         // SAFETY: see `current_bundle!` SAFETY above; this `defer!` runs
         // before `_outer_defer` (LIFO), so `current_bundle_ptr` is still live.
         let current_bundle = unsafe { &mut *current_bundle_ptr_defer };
-        if !current_bundle.requests.first.is_null() {
+        if !current_bundle.requests.is_empty() {
             // cannot be an assertion because in the case of OOM, the request list was not drained.
             Output::debug(
-                "current_bundle.requests.first != null. this leaves pending requests without an error page!",
+                "current_bundle.requests not empty. this leaves pending requests without an error page!",
             );
         }
-        while let Some(node) = current_bundle.requests.pop_first() {
-            // SAFETY: pop_first returns a live `*mut Node<T>`; `data` was
-            // initialized by `defer_request`.
-            let req = unsafe { (*node).data.assume_init_mut() };
+        while let Some(node) = current_bundle.requests.pop() {
+            // SAFETY: hive-slot node; `data` was initialized by `defer_request`.
+            let req = unsafe { (*node.as_ptr()).data.assume_init_mut() };
             req.abort();
             req.deref_();
         }
@@ -4551,10 +4558,9 @@ pub fn finalize_bundle(
             )?;
         }
 
-        while let Some(node) = current_bundle!().requests.pop_first() {
-            // SAFETY: `pop_first` hands back ownership of the intrusive node;
-            // `data` was initialized by `defer_request`.
-            let req = unsafe { (*node).data.assume_init_mut() };
+        while let Some(node) = current_bundle!().requests.pop() {
+            // SAFETY: hive-slot node; `data` was initialized by `defer_request`.
+            let req = unsafe { (*node.as_ptr()).data.assume_init_mut() };
             let req_ptr = std::ptr::from_mut::<DeferredRequest>(req);
             // SAFETY: the node stays alive until `deref_()` releases it below.
             scopeguard::defer! { unsafe { (*req_ptr).deref_() } };
@@ -4656,11 +4662,9 @@ pub fn finalize_bundle(
             } else {
                 'brk: {
                     let route_bundle_index = 'rbi: {
-                        let first = current_bundle!().requests.first;
-                        if !first.is_null() {
-                            // SAFETY: first is an intrusive list node valid while current_bundle.requests holds it
-                            // SAFETY: `data` was initialized by `defer_request`.
-                            break 'rbi unsafe { (*first).data.assume_init_ref() }
+                        if let Some(&first) = current_bundle!().requests.last() {
+                            // SAFETY: hive-slot node; `data` was initialized by `defer_request`.
+                            break 'rbi unsafe { (*first.as_ptr()).data.assume_init_ref() }
                                 .route_bundle_index;
                         }
                         let route_bundle_indices =
@@ -4721,14 +4725,11 @@ pub fn finalize_bundle(
 
     // Set all the deferred routes to the .loaded state up front
     {
-        let mut node = current_bundle!().requests.first;
-        while !node.is_null() {
-            // SAFETY: node is an intrusive list node valid while current_bundle.requests holds it;
-            // `data` was initialized by `defer_request`.
-            let n = unsafe { &*node };
-            let rb = dev.route_bundle_ptr(unsafe { n.data.assume_init_ref() }.route_bundle_index);
+        for &n in current_bundle!().requests.iter() {
+            // SAFETY: hive-slot node; `data` was initialized by `defer_request`.
+            let rb = dev
+                .route_bundle_ptr(unsafe { (*n.as_ptr()).data.assume_init_ref() }.route_bundle_index);
             rb.server_state = route_bundle::State::Loaded;
-            node = n.next;
         }
     }
 
@@ -4749,10 +4750,9 @@ pub fn finalize_bundle(
             .resolve(vm.global(), JSValue::TRUE)?;
     }
 
-    while let Some(node) = current_bundle!().requests.pop_first() {
-        // SAFETY: `pop_first` hands back ownership of the intrusive node;
-        // `data` was initialized by `defer_request`.
-        let req = unsafe { (*node).data.assume_init_mut() };
+    while let Some(node) = current_bundle!().requests.pop() {
+        // SAFETY: hive-slot node; `data` was initialized by `defer_request`.
+        let req = unsafe { (*node.as_ptr()).data.assume_init_mut() };
         let req_ptr = std::ptr::from_mut::<DeferredRequest>(req);
         // SAFETY: the node stays alive until `deref_()` releases it below.
         scopeguard::defer! { unsafe { (*req_ptr).deref_() } };
@@ -4803,7 +4803,7 @@ impl DevServer {
 
         // If there were pending requests, begin another bundle.
         if self.next_bundle.reload_event.is_some()
-            || !self.next_bundle.requests.first.is_null()
+            || !self.next_bundle.requests.is_empty()
             || self.next_bundle.promise.strong.has_value()
         {
             // PERF(port): was stack-fallback (4096)
@@ -6449,11 +6449,10 @@ impl DevServer {
 
     pub fn on_plugins_rejected(&mut self) -> Result<(), bun_core::Error> {
         self.plugin_state = PluginState::Err;
-        while let Some(item) = self.next_bundle.requests.pop_first() {
-            // SAFETY: `pop_first` returns a valid `*mut Node<DeferredRequest>`;
-            // `data` was initialized by `defer_request`.
+        while let Some(item) = self.next_bundle.requests.pop() {
+            // SAFETY: hive-slot node; `data` was initialized by `defer_request`.
             unsafe {
-                let d = (*item).data.assume_init_mut();
+                let d = (*item.as_ptr()).data.assume_init_mut();
                 d.abort();
                 d.deref_();
             }

--- a/src/runtime/bake/DevServer/memory_cost.rs
+++ b/src/runtime/bake/DevServer/memory_cost.rs
@@ -165,7 +165,7 @@ pub fn memory_cost_detailed(dev: &DevServer) -> MemoryCost {
     // .current_bundle
     if let Some(bundle) = &dev.current_bundle {
         // PORT NOTE: Zig walked the intrusive list (`while (r) |req| : (r = req.next)`)
-        // only to count nodes; `SinglyLinkedList::len()` does the same O(N) walk.
+        // only to count nodes.
         other_bytes += bundle.requests.len() * size_of::<deferred_request::Node>();
     }
     // .next_bundle

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -459,7 +459,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
         &mut self,
         are_new_files_stale: bool,
     ) -> Result<(), bun_alloc::AllocError> {
-        let want = self.bundled_files.count().max(self.stale_files.bit_length);
+        let want = self.bundled_files.count().max(self.stale_files.bit_length());
         // Align forward to 8 usize words (8*64 bits).
         const STEP: usize = core::mem::size_of::<usize>() * 8 * 8;
         let aligned = want.div_ceil(STEP) * STEP;
@@ -645,7 +645,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
             self.first_import.push(None);
         }
 
-        if self.stale_files.bit_length > file_index.get() as usize {
+        if self.stale_files.bit_length() > file_index.get() as usize {
             self.stale_files.unset(file_index.get() as usize);
         }
 
@@ -1366,7 +1366,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
             self.first_dep.push(None);
             self.first_import.push(None);
         }
-        if self.stale_files.bit_length > idx {
+        if self.stale_files.bit_length() > idx {
             self.stale_files.set(idx);
         }
 

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -277,7 +277,7 @@ impl GraphTraceState {
             Side::Client => &mut self.client_bits,
             Side::Server => &mut self.server_bits,
         };
-        if b.unmanaged.bit_length < new_size {
+        if b.unmanaged.bit_length() < new_size {
             b.resize(new_size, false)?;
         }
         Ok(())

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -283,10 +283,8 @@ pub mod lib_info {
                     // `MaybeUninit::uninit().assume_init()` write was UB regardless of
                     // POD-ness.
                     let pos = (*request).cache.pos_in_pending();
-                    this.pending_host_cache_native.with_mut(|c| {
-                        let slot = c.buffer[pos as usize].as_mut_ptr();
-                        c.put_raw(slot);
-                    });
+                    this.pending_host_cache_native
+                        .with_mut(|c| c.release_at(pos as usize));
                 }
                 // Drop the KeepAlive + resolver ref that `GetAddrInfoRequest.init` took.
                 DNSLookup::destroy(&raw mut (*request).head);
@@ -4065,7 +4063,7 @@ impl Resolver {
 
     fn any_requests_pending(&self) -> bool {
         // TODO(port): Zig used @typeInfo to iterate all `pending_*` fields.
-        macro_rules! check { ($($f:ident),*) => { $( if self.$f.get().used.find_first_set().is_some() { return true; } )* } }
+        macro_rules! check { ($($f:ident),*) => { $( if self.$f.get().any_used() { return true; } )* } }
         check!(
             pending_host_cache_cares,
             pending_host_cache_native,
@@ -4237,13 +4235,8 @@ impl Resolver {
         cache_field: PendingCacheField,
     ) -> R::PendingCacheKey {
         let cache = R::pending_cache(self, cache_field);
-        debug_assert!(cache.used.is_set(index as usize));
-        // SAFETY: `used` bit is set ⇒ slot was initialized by `get_or_put_into_resolve_pending_cache`
-        // + `*Request::init`. `PendingCacheKey` is POD; reading by value then unsetting the bit
-        // hands ownership of the slot back to the HiveArray (Zig's `= undefined`).
-        let entry = unsafe { core::ptr::read(cache.buffer[index as usize].as_ptr()) };
-        cache.used.unset(index as usize);
-        entry
+        // `take()` moves the value out and releases the slot (Zig's `= undefined`).
+        cache.take(index as usize).expect("pending-cache slot")
     }
 
     // Monomorphic helpers used by the drain* fns below.
@@ -4253,26 +4246,15 @@ impl Resolver {
         field: PendingCacheField,
     ) -> get_addr_info_request::PendingCacheKey {
         let cache = self.pending_host_cache(field);
-        debug_assert!(cache.used.is_set(index as usize));
-        let entry = unsafe { core::ptr::read(cache.buffer[index as usize].as_ptr()) };
-        cache.used.unset(index as usize);
-        entry
+        cache.take(index as usize).expect("pending-cache slot")
     }
     fn get_key_addr(&self, index: u8) -> get_host_by_addr_info_request::PendingCacheKey {
-        self.pending_addr_cache_cares.with_mut(|cache| {
-            debug_assert!(cache.used.is_set(index as usize));
-            let entry = unsafe { core::ptr::read(cache.buffer[index as usize].as_ptr()) };
-            cache.used.unset(index as usize);
-            entry
-        })
+        self.pending_addr_cache_cares
+            .with_mut(|cache| cache.take(index as usize).expect("pending-cache slot"))
     }
     fn get_key_nameinfo(&self, index: u8) -> get_name_info_request::PendingCacheKey {
-        self.pending_nameinfo_cache_cares.with_mut(|cache| {
-            debug_assert!(cache.used.is_set(index as usize));
-            let entry = unsafe { core::ptr::read(cache.buffer[index as usize].as_ptr()) };
-            cache.used.unset(index as usize);
-            entry
-        })
+        self.pending_nameinfo_cache_cares
+            .with_mut(|cache| cache.take(index as usize).expect("pending-cache slot"))
     }
 
     pub fn drain_pending_cares<T: CAresRecordType>(
@@ -4287,17 +4269,10 @@ impl Resolver {
         let _g = unsafe { Self::ref_scope(self.as_ctx_ptr()) };
 
         // TODO(port): generic getKey over T::CACHE_FIELD
-        let key = {
-            let cache = self.pending_cache_for::<T>(T::CACHE_FIELD);
-            debug_assert!(cache.used.is_set(index as usize));
-            // SAFETY: `used` bit is set ⇒ slot was initialized by
-            // `get_or_put_into_resolve_pending_cache` + `*Request::init`.
-            // `PendingCacheKey` is POD; reading by value then unsetting the bit hands
-            // ownership of the slot back to the HiveArray (Zig's `= undefined`).
-            let key = unsafe { core::ptr::read(cache.buffer[index as usize].as_ptr()) };
-            cache.used.unset(index as usize);
-            key
-        };
+        let key = self
+            .pending_cache_for::<T>(T::CACHE_FIELD)
+            .take(index as usize)
+            .expect("pending-cache slot");
 
         let Some(addr) = result else {
             unsafe {
@@ -4608,11 +4583,10 @@ impl Resolver {
         // PORT NOTE: Zig used `@field(this, field)` over a comptime string. We dispatch via
         // `HasPendingCacheKey::pending_cache`; the body is identical across all `R`.
         let cache = R::pending_cache(self, field);
-        let mut inflight_iter = cache.used.iter_set();
+        let mut inflight_iter = cache.used_iter();
 
         while let Some(index) = inflight_iter.next() {
-            // SAFETY: `used` bit is set ⇒ slot was initialized.
-            let entry = unsafe { &mut *cache.buffer[index].as_mut_ptr() };
+            let entry = cache.at_mut(index).unwrap();
             if R::key_hash(entry) == R::key_hash(key) && R::key_len(entry) == R::key_len(key) {
                 return LookupCacheHit::Inflight(std::ptr::from_mut(entry));
             }
@@ -4631,11 +4605,10 @@ impl Resolver {
         field: PendingCacheField,
     ) -> CacheHit {
         let cache = self.pending_host_cache(field);
-        let mut inflight_iter = cache.used.iter_set();
+        let mut inflight_iter = cache.used_iter();
 
         while let Some(index) = inflight_iter.next() {
-            // SAFETY: `used` bit is set ⇒ slot was initialized.
-            let entry = unsafe { &mut *cache.buffer[index].as_mut_ptr() };
+            let entry = cache.at_mut(index).unwrap();
             if entry.hash == key.hash && entry.len == key.len {
                 return CacheHit::Inflight(std::ptr::from_mut(entry));
             }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -287,7 +287,7 @@ unsafe fn init_runtime_state(
         // allocations use the same heap as the global allocator and skip the
         // `mi_heap_new`/`mi_heap_destroy` pair.
         transpiler_arena: Box::new(bun_alloc::Arena::borrowing_default()),
-        body_value_pool: Box::new(crate::webcore::body::HiveAllocator::init()),
+        body_value_pool: crate::webcore::body::HiveAllocator::new_boxed(),
     }));
     RUNTIME_STATE.with(|c| c.set(state));
 
@@ -1172,11 +1172,11 @@ unsafe fn init_request_body_value(_vm: *mut VirtualMachine, body: *mut c_void) -
     // its `body_value_pool` `Box` payload is heap-stable for the
     // VM's lifetime (BACKREF contract on `HiveRef::allocator`).
     let value = unsafe { core::ptr::read(body.cast::<Value>()) };
-    let pool: *mut crate::webcore::body::HiveAllocator =
-        unsafe { &raw mut *(*state).body_value_pool };
     // Spec returns `!*HiveRef` with the only `try` site being the pool
     // allocation; `bun.handleOom`-style crash matches Zig.
-    unsafe { HiveRef::init(value, pool) }.cast::<c_void>()
+    unsafe { HiveRef::init(value, &mut (*state).body_value_pool) }
+        .cast::<c_void>()
+        .as_ptr()
 }
 
 /// `WebCore.ObjectURLRegistry.singleton().has(specifier["blob:".len..])` —

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4966,16 +4966,13 @@ impl NodeFS {
                 let clamped_size: usize = stat_size.min(8 * 1024 * 1024);
                 // PORT NOTE: Zig used `bun.default_allocator.alloc(u8, clamped_size)` —
                 // uninitialised heap. `Vec::resize` here was a debug-build hot path
-                // (byte-by-byte `extend_with`); use `expand_to_capacity` to match the spec
-                // (the slab is write-only — `Syscall::read` fills it from the kernel).
-                use bun_collections::vec_ext::VecExt as _;
+                // (byte-by-byte `extend_with`); hand the spare to the kernel directly.
                 if buf_to_free.try_reserve_exact(clamped_size).is_err() {
                     break 'maybe_allocate_large_temp_buf;
                 }
-                // SAFETY: `u8` has no validity invariant; the buffer is handed
-                // straight to the kernel which only stores into it.
-                unsafe { buf_to_free.expand_to_capacity() };
-                buf = &mut buf_to_free[..];
+                // SAFETY: write-only scratch; `Syscall::read` fills it from the
+                // kernel before any byte is observed.
+                buf = unsafe { bun_core::vec::spare_bytes_mut(&mut buf_to_free) };
             }
         }
         // buf_to_free dropped at scope exit
@@ -7334,13 +7331,10 @@ impl NodeFS {
         // PORT NOTE: Zig `buf.expandToCapacity()` then indexed `buf.items.ptr[total..cap]`
         // to read into uninitialised tail. `Vec::resize(cap, 0)` is *not* equivalent in
         // debug builds: it goes through `extend_with`'s byte-by-byte loop (no memset
-        // specialisation), which dominated `readFileSync` of large files. Match the spec
-        // exactly via `VecExt::expand_to_capacity` (the tail is write-only — `Syscall::read`
-        // hands it straight to the kernel, which only stores into it).
-        use bun_collections::vec_ext::VecExt as _;
-        // SAFETY: `u8` has no validity invariant; the buffer is handed straight
-        // to the kernel which only stores into it.
-        unsafe { buf.expand_to_capacity() };
+        // specialisation), which dominated `readFileSync` of large files. Read into the
+        // spare-capacity slice directly and commit `amt` per iteration — `buf.len()`
+        // tracks `total` throughout.
+        debug_assert_eq!(buf.len(), total);
 
         // Two-phase read: first up to `size`, then keep going until EOF.
         // PORT NOTE: Zig spelled this as `while (total < size) { ... } else { while (true) { ... } }`.
@@ -7356,9 +7350,13 @@ impl NodeFS {
             // Do NOT pre-grow here; growth happens only in the `total > size && amt != 0 &&
             // !has_max_size` arm below.
             let upper = (buf.capacity() as u64).min(max_size) as usize;
-            match Syscall::read(fd, &mut buf[total..upper]) {
+            // SAFETY: write-only window; the kernel only stores into it.
+            let window = unsafe { &mut bun_core::vec::spare_bytes_mut(&mut buf)[..upper - total] };
+            match Syscall::read(fd, window) {
                 Err(err) => return Err(err),
                 Ok(amt) => {
+                    // SAFETY: kernel initialized `buf[total..total+amt]`.
+                    unsafe { bun_core::vec::commit_spare(&mut buf, amt) };
                     total += amt;
 
                     if args.limit_size_for_javascript {
@@ -7379,8 +7377,6 @@ impl NodeFS {
                                 &args.path,
                             ));
                         }
-                        // SAFETY: `u8` has no validity invariant; kernel only stores.
-                        unsafe { buf.expand_to_capacity() };
                         continue;
                     }
 

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2972,10 +2972,7 @@ where
                             // If we've received the complete body by the time this function is called
                             // we can avoid streaming it and just send it all at once.
                             if byte_stream.has_received_last_chunk.get() {
-                                let mut byte_list = byte_stream.drain();
-                                this.blob = AnyBlob::from_array_list(
-                                    byte_list.move_to_list_managed(),
-                                );
+                                this.blob = AnyBlob::from_array_list(byte_stream.drain());
                                 this.response_body_readable_stream_ref.deinit();
                                 this.do_render_blob();
                                 return;
@@ -2989,8 +2986,7 @@ where
                                 readable_stream::Strong::init(stream, global_this);
 
                             this.byte_stream = Some(byte_stream_nn);
-                            let mut response_buf = byte_stream.drain();
-                            this.response_buf_owned = response_buf.move_to_list();
+                            this.response_buf_owned = byte_stream.drain();
 
                             // we don't set size here because even if we have a hint
                             // uWebSockets won't let us partially write streaming content

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -702,22 +702,17 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
         // SAFETY: `request_pool` points at a process-static (or
         // server-owned) `HiveArray::Fallback`; valid for the server's lifetime.
-        let ctx_slot = unsafe { (*server.request_pool).try_get() };
-        // SAFETY: `try_get` hands out an uninitialized slot; `create()` fully
-        // initializes it via `MaybeUninit::write`.
-        let ctx_uninit = unsafe {
-            &mut *ctx_slot.cast::<core::mem::MaybeUninit<ServerRequestContext<SSL, DEBUG>>>()
-        };
+        let mut slot = unsafe { (*server.request_pool).claim() };
         ServerRequestContext::<SSL, DEBUG>::create(
-            ctx_uninit,
+            slot.as_uninit(),
             this,
             std::ptr::from_mut::<uws_sys::Request>(req).cast::<c_void>(),
             any_response_from::<SSL>(resp),
             should_deinit_context,
             method,
         );
-        // SAFETY: fully initialized by `create()`.
-        let ctx: *mut ServerRequestContext<SSL, DEBUG> = ctx_slot;
+        // SAFETY: fully initialized by `create()` via `MaybeUninit::write`.
+        let ctx: *mut ServerRequestContext<SSL, DEBUG> = unsafe { slot.assume_init() }.as_ptr();
         let ctx_mut = unsafe { &mut *ctx };
 
         // `VirtualMachine::jsc_vm()` is the safe accessor for the JSC VM
@@ -2967,7 +2962,7 @@ macro_rules! impl_server_pools {
                         // `Box::new(Pool::init())` builds the ~816 KB pool on
                         // the stack and `memcpy`s it into the heap (no NRVO);
                         // `new_boxed` writes only the 256 B bitset in place.
-                        p = Pool::new_boxed().as_ptr();
+                        p = Box::into_raw(Pool::new_boxed());
                         cell.set(p);
                     }
                     p
@@ -2982,7 +2977,7 @@ macro_rules! impl_server_pools {
                 POOL.with(|cell| {
                     let mut p = cell.get();
                     if p.is_null() {
-                        p = Pool::new_boxed().as_ptr();
+                        p = Box::into_raw(Pool::new_boxed());
                         cell.set(p);
                     }
                     p

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3143,7 +3143,7 @@ where
                     !self.h3_request_pool.is_null(),
                     "H3 request dispatched but h3_request_pool was never allocated (listen() H3 path not taken)"
                 );
-                let slot = (*self.h3_request_pool).claim();
+                let mut slot = (*self.h3_request_pool).claim();
                 Ctx::create_in(
                     slot.addr().as_ptr().cast(),
                     self_ptr,
@@ -3155,7 +3155,7 @@ where
                 // SAFETY: `create_in` fully initialized the slot via `MaybeUninit::write`.
                 slot.assume_init().as_ptr().cast()
             } else {
-                let slot = (*self.request_pool).claim();
+                let mut slot = (*self.request_pool).claim();
                 Ctx::create_in(
                     slot.addr().as_ptr().cast(),
                     self_ptr,
@@ -3412,18 +3412,18 @@ where
         this.pending_requests += 1;
         req.set_yield(false);
         // SAFETY: pointer is non-null and owns a fresh pool slot.
-        let ctx_slot = unsafe { (*this.request_pool).get() };
+        let mut slot = unsafe { (*this.request_pool).claim() };
         let should_deinit_context = core::cell::Cell::new(false);
         <ServerRequestContext<SSL, DEBUG> as RequestCtxOps>::create_in(
-            ctx_slot,
+            slot.addr().as_ptr(),
             self_ptr,
             req,
             resp,
             Some(bun_ptr::BackRef::new(&should_deinit_context)),
             None,
         );
-        // SAFETY: ctx_slot was just initialized by create_in.
-        let ctx = unsafe { &mut *ctx_slot };
+        // SAFETY: `create_in` fully initialized the slot via `MaybeUninit::write`.
+        let ctx = unsafe { &mut *slot.assume_init().as_ptr() };
 
         let body_hive = crate::webcore::body::hive_alloc(this.vm().as_mut(), BodyValue::Null);
         // SAFETY: hive_alloc returns a freshly-initialized hive slot; live until

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -209,7 +209,7 @@ impl BufferedIoClosed {
         // single-threaded and this is the same pattern `subproc::on_close_io`
         // uses to take the done buffer.
         let buffer = unsafe { &mut *(std::sync::Arc::as_ptr(pipe).cast_mut()) }.take_buffer();
-        *state = BufferedIoState::Closed(Vec::<u8>::move_from_list(buffer));
+        *state = BufferedIoState::Closed(buffer);
     }
 }
 

--- a/src/runtime/socket/WindowsNamedPipe.rs
+++ b/src/runtime/socket/WindowsNamedPipe.rs
@@ -249,7 +249,8 @@ impl WindowsNamedPipe {
 
     fn on_read_alloc(&mut self, suggested_size: usize) -> &mut [u8] {
         // SAFETY: libuv writes into this region before on_read commits.
-        let spare = unsafe { self.incoming.uv_alloc_spare_u8(suggested_size) };
+        let spare =
+            unsafe { bun_core::vec::reserve_spare_bytes(&mut self.incoming, suggested_size) };
         &mut spare[..suggested_size]
     }
 
@@ -261,7 +262,7 @@ impl WindowsNamedPipe {
     fn on_read(&mut self, nread: usize) {
         bun_output::scoped_log!(WindowsNamedPipe, "onRead ({})", nread);
         // SAFETY: `nread` bytes written by libuv into on_read_alloc's slice.
-        unsafe { self.incoming.uv_commit(nread) };
+        unsafe { bun_core::vec::commit_spare(&mut self.incoming, nread) };
 
         self.reset_timeout();
 

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -172,7 +172,7 @@ impl JestPrettyFormat {
         options: FormatOptions,
     ) -> JsResult<()> {
         let mut fmt: Formatter;
-        // Zig: defer { if (fmt.map_node) |node| { node.data = fmt.map; node.data.clearRetainingCapacity(); node.release(); } }
+        // Zig: defer { if (fmt.map_node) |node| { ... node.release(); } } — handled by `Drop`.
         // (.zig:79-85). Realized as `impl Drop for Formatter` below — the pool
         // node is acquired lazily inside `print_as` and swapped back on every
         // exit path of this function (early return, `?` propagation, happy path).
@@ -290,7 +290,7 @@ impl JestPrettyFormat {
             let _ = writer.flush();
         }
 
-        // map_node release handled by `impl Drop for Formatter`.
+        // pooled map release handled by `impl Drop for Formatter`.
         result
     }
 }
@@ -326,11 +326,13 @@ pub mod visited {
     }
 
     // `ObjectPool<T, ..>` requires `T: ObjectPoolType`. Mirrors Zig's
-    // `ObjectPool(Map, Map.init, true, 16)` — `INIT` allocates an empty map,
-    // `reset` is `clearRetainingCapacity` (handled by callers via `.clear()`).
+    // `ObjectPool(Map, Map.init, true, 16)` — `init` allocates an empty map,
+    // `reset` is `clearRetainingCapacity`.
     impl bun_collections::pool::ObjectPoolType for Map {
-        const INIT: Option<fn() -> Result<Self, bun_core::Error>> =
-            Some(|| Ok(Map::default()));
+        #[inline]
+        fn init() -> Self {
+            Map::default()
+        }
         #[inline]
         fn reset(&mut self) {
             self.0.clear();
@@ -338,18 +340,18 @@ pub mod visited {
     }
 
     // Mirrors Zig's `ObjectPool(Map, Map.init, true, 16)` — thread-local free
-    // list, capped at 16 nodes. `object_pool!` wires the per-monomorphization
+    // list, capped at 16 entries. `object_pool!` wires the per-monomorphization
     // storage; without it `ObjectPool<Map, true, 16>` defaults to
-    // `UnwiredStorage` which panics on first `get_node()`.
+    // `UnwiredStorage` which panics on first use.
     bun_collections::object_pool!(pub Pool: Map, threadsafe, 16);
-    pub type PoolNode = <Pool as bun_collections::pool::ObjectPoolTrait>::Node;
 }
 
 pub struct Formatter<'a> {
     pub remaining_values: &'a [JSValue],
     pub map: visited::Map,
-    /// Lazily acquired from `visited::Pool`; released back in `Drop`.
-    pub map_node: Option<core::ptr::NonNull<visited::PoolNode>>,
+    /// `true` once `map`'s allocation was taken from `visited::Pool`; `Drop`
+    /// returns it there.
+    pub map_from_pool: bool,
     pub hide_native: bool,
     pub global_this: &'a JSGlobalObject,
     pub indent: u32,
@@ -364,7 +366,7 @@ impl<'a> Formatter<'a> {
         Self {
             remaining_values: &[],
             map: visited::Map::default(),
-            map_node: None,
+            map_from_pool: false,
             hide_native: false,
             global_this: global,
             indent: 0,
@@ -394,23 +396,17 @@ impl<'a> Formatter<'a> {
 
 // Mirrors the top-level Zig defer in `JestPrettyFormat.format` (.zig:79-85):
 // `defer { if (fmt.map_node) |node| { node.data = fmt.map; node.data.clearRetainingCapacity(); node.release(); } }`
-// The node is acquired lazily inside `print_as` via `visited::Pool::get_node()`;
+// The map is acquired lazily inside `print_as` via `visited::Pool::take()`;
 // releasing here covers every exit path of `format` (early `len == 1` return,
 // `?` propagation from `Tag::get`/`fmt.format`, and the happy path) without
 // the borrow-aliasing a `scopeguard` would introduce.
 impl Drop for Formatter<'_> {
     fn drop(&mut self) {
-        if let Some(node) = self.map_node.take() {
-            // SAFETY: `node` came from `visited::Pool::get_node()` and is
-            // exclusively owned for this `Formatter`'s lifetime; its `data` was
-            // initialized by `Map::INIT`, so `assume_init_mut` observes a valid
-            // `Map`.
-            unsafe {
-                let data = (*node.as_ptr()).data.assume_init_mut();
-                *data = core::mem::take(&mut self.map);
-                data.clear();
-                visited::Pool::release(node.as_ptr());
-            }
+        if self.map_from_pool {
+            self.map_from_pool = false;
+            let mut map = core::mem::take(&mut self.map);
+            map.clear();
+            visited::Pool::put(map);
         }
     }
 }
@@ -1212,25 +1208,13 @@ impl<'a> Formatter<'a> {
         let mut writer = WrappedWriter::new(writer_);
 
         if FORMAT.can_have_circular_references() {
-            if self.map_node.is_none() {
+            if !self.map_from_pool {
                 // PORT NOTE: `visited::Pool::get()` returns an RAII `PoolGuard` that
-                // would release on scope exit; the Zig spec stashes the raw node on
+                // would release on scope exit; the Zig spec stashes the map on
                 // `self` and releases it from `JestPrettyFormat::format`'s defer, so
-                // take the raw node directly. `data` is initialized by
-                // `Map::INIT` (see `visited::Map: ObjectPoolType`).
-                let node = core::ptr::NonNull::new(visited::Pool::get_node())
-                    .expect("ObjectPool::get_node never returns null");
-                self.map_node = Some(node);
-                // PORT NOTE: Zig (.zig:878-880) does a struct copy aliasing the same
-                // backing buffer. Rust takes the map here and swaps it back into
-                // `node.data` at release time (see JestPrettyFormat::format tail),
-                // so the pooled allocation is retained across uses.
-                // SAFETY: see above.
-                unsafe {
-                    let data = (*node.as_ptr()).data.assume_init_mut();
-                    data.clear();
-                    self.map = core::mem::take(data);
-                }
+                // take the value directly and put it back in `Drop`.
+                self.map = visited::Pool::take();
+                self.map_from_pool = true;
             }
 
             let entry = self.map.get_or_put(value).expect("unreachable");

--- a/src/runtime/webcore/ArrayBufferSink.rs
+++ b/src/runtime/webcore/ArrayBufferSink.rs
@@ -213,12 +213,11 @@ impl ArrayBufferSink {
 
         // `defer this.bytes = bun.Vec<u8>.empty` + `try toOwnedSlice` →
         // take ownership, leave empty in place.
-        let mut bytes = core::mem::take(&mut self.bytes);
         // Ownership transfers to JSC — `to_js` installs
         // `MarkedArrayBuffer_deallocator` which `mi_free`s the buffer when the
         // JS object is collected. Bun's global allocator is mimalloc, so the
         // `mi_is_in_heap_region` check in `to_js` succeeds.
-        let owned = bytes.to_owned_slice();
+        let owned = core::mem::take(&mut self.bytes).into_boxed_slice();
         ArrayBuffer::from_owned_bytes(
             owned,
             if as_uint8array {
@@ -239,11 +238,10 @@ impl ArrayBufferSink {
         self.done = true;
         self.signal.close(None);
         // `defer this.bytes = bun.Vec<u8>.empty` → take ownership, leave empty.
-        let mut bytes = core::mem::take(&mut self.bytes);
         // Ownership transfers to JSC; the caller wraps the returned
         // `ArrayBuffer` in `.to_js()` which installs `MarkedArrayBuffer_deallocator`
         // (frees via `mi_free` on GC). See `to_js` above.
-        let owned = bytes.to_owned_slice();
+        let owned = core::mem::take(&mut self.bytes).into_boxed_slice();
         Ok(ArrayBuffer::from_owned_bytes(
             owned,
             if self.as_uint8array {

--- a/src/runtime/webcore/ByteStream.rs
+++ b/src/runtime/webcore/ByteStream.rs
@@ -131,8 +131,7 @@ impl ByteStream {
         }
 
         if self.has_received_last_chunk.get() {
-            let buffer = self.buffer.replace(Vec::new());
-            return streams::Start::OwnedAndDone(Vec::<u8>::move_from_list(buffer));
+            return streams::Start::OwnedAndDone(self.buffer.replace(Vec::new()));
         }
 
         if self.high_water_mark == 0 {
@@ -250,7 +249,7 @@ impl ByteStream {
                         // PORT NOTE: reshaped for borrowck — move the owned Vec<u8> into `buffer`
                         // directly instead of round-tripping through `chunk` (which would borrow
                         // `stream`).
-                        self.buffer.set(owned.move_to_list_managed());
+                        self.buffer.set(owned);
                         let mut blob = self.to_any_blob().unwrap();
                         return action.fulfill(self.parent_const().global_this(), &mut blob);
                     }
@@ -361,9 +360,9 @@ impl ByteStream {
     ) -> Result<(), bun_alloc::AllocError> {
         if self.buffer.get().capacity() == 0 {
             match stream {
-                streams::Result::Owned(mut owned) | streams::Result::OwnedAndDone(mut owned) => {
+                streams::Result::Owned(owned) | streams::Result::OwnedAndDone(owned) => {
                     // Zig: `owned.moveToListManaged(allocator)` — moves the buffer, no copy.
-                    self.buffer.set(owned.move_to_list_managed());
+                    self.buffer.set(owned);
                     self.offset.set(self.offset.get() + offset);
                 }
                 streams::Result::TemporaryAndDone(temp) | streams::Result::Temporary(temp) => {
@@ -556,7 +555,7 @@ impl ByteStream {
 
     pub fn drain(&self) -> Vec<u8> {
         if !self.buffer.get().is_empty() {
-            return Vec::<u8>::move_from_list(self.buffer.replace(Vec::new()));
+            return self.buffer.replace(Vec::new());
         }
         Vec::<u8>::default()
     }

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -480,9 +480,7 @@ impl FileReader {
         if self.reader().is_done() {
             self.consume_reader_buffer();
             if !self.buffered.get().is_empty() {
-                return streams::Start::OwnedAndDone(Vec::<u8>::move_from_list(
-                    self.buffered.replace(Vec::new()),
-                ));
+                return streams::Start::OwnedAndDone(self.buffered.replace(Vec::new()));
             }
         } else {
             #[cfg(unix)]
@@ -669,10 +667,8 @@ impl FileReader {
                             });
                             drop(buffer); // clearAndFree
                         } else {
-                            self.pending.with_mut(|p| {
-                                p.result =
-                                    streams::Result::OwnedAndDone(Vec::<u8>::move_from_list(buffer))
-                            });
+                            self.pending
+                                .with_mut(|p| p.result = streams::Result::OwnedAndDone(buffer));
                         }
                     } else {
                         self.pending.with_mut(|p| p.result = streams::Result::Done);
@@ -711,10 +707,8 @@ impl FileReader {
                         debug_assert_eq!(buf.as_ptr(), unsafe { (*reader_buffer).as_ptr() });
                         let mut buffer = unsafe { mem::take(&mut *reader_buffer) };
                         buffer.truncate(buf.len()); // shrinkRetainingCapacity
-                        self.pending.with_mut(|p| {
-                            p.result =
-                                streams::Result::OwnedAndDone(Vec::<u8>::move_from_list(buffer))
-                        });
+                        self.pending
+                            .with_mut(|p| p.result = streams::Result::OwnedAndDone(buffer));
                     } else {
                         // SAFETY: see `reader_buffer` decl.
                         unsafe { (*reader_buffer).clear() };
@@ -742,9 +736,9 @@ impl FileReader {
 
                 self.pending.with_mut(|p| {
                     p.result = if self.reader().is_done() {
-                        streams::Result::OwnedAndDone(Vec::<u8>::move_from_list(buffered))
+                        streams::Result::OwnedAndDone(buffered)
                     } else {
-                        streams::Result::Owned(Vec::<u8>::move_from_list(buffered))
+                        streams::Result::Owned(buffered)
                     }
                 });
                 break 'pending !was_done;
@@ -897,9 +891,9 @@ impl FileReader {
                     );
                     let buffered = self.buffered.replace(Vec::new());
                     if self.reader().is_done() {
-                        return streams::Result::OwnedAndDone(Vec::<u8>::move_from_list(buffered));
+                        return streams::Result::OwnedAndDone(buffered);
                     }
-                    return streams::Result::Owned(Vec::<u8>::move_from_list(buffered));
+                    return streams::Result::Owned(buffered);
                 }
                 _ => {
                     // Spec FileReader.zig:544 `else => {}` falls through to set
@@ -928,7 +922,7 @@ impl FileReader {
 
     pub fn drain(&self) -> Vec<u8> {
         if !self.buffered.get().is_empty() {
-            let out = Vec::<u8>::move_from_list(self.buffered.replace(Vec::new()));
+            let out = self.buffered.replace(Vec::new());
             if cfg!(debug_assertions) {
                 debug_assert!(self.reader().buffer().as_ptr() != out.as_ptr());
             }
@@ -939,7 +933,7 @@ impl FileReader {
             return Vec::<u8>::default();
         }
 
-        Vec::<u8>::move_from_list(mem::take(self.reader().buffer()))
+        mem::take(self.reader().buffer())
     }
 
     pub fn set_ref_or_unref(&self, enable: bool) {
@@ -962,10 +956,8 @@ impl FileReader {
             if self.pending.get().state == streams::PendingState::Pending {
                 if !self.buffered.get().is_empty() {
                     let buffered = self.buffered.replace(Vec::new());
-                    self.pending.with_mut(|p| {
-                        p.result =
-                            streams::Result::OwnedAndDone(Vec::<u8>::move_from_list(buffered))
-                    });
+                    self.pending
+                        .with_mut(|p| p.result = streams::Result::OwnedAndDone(buffered));
                 } else {
                     self.pending.with_mut(|p| p.result = streams::Result::Done);
                 }

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -235,17 +235,9 @@ impl UTF8Fallback {
 
             strings::replace_latin1_with_utf8(&mut slice[..str_.len()]);
             if input.is_done() {
-                write_fn(
-                    ctx,
-                    streams::Result::OwnedAndDone(Vec::<u8>::from_owned_slice(
-                        slice.into_boxed_slice(),
-                    )),
-                )
+                write_fn(ctx, streams::Result::OwnedAndDone(slice))
             } else {
-                write_fn(
-                    ctx,
-                    streams::Result::Owned(Vec::<u8>::from_owned_slice(slice.into_boxed_slice())),
-                )
+                write_fn(ctx, streams::Result::Owned(slice))
             }
         }
     }
@@ -284,19 +276,9 @@ impl UTF8Fallback {
             // `.err = oom`.
             let allocated = strings::to_utf8_alloc(str_);
             if input.is_done() {
-                write_fn(
-                    ctx,
-                    streams::Result::OwnedAndDone(Vec::<u8>::from_owned_slice(
-                        allocated.into_boxed_slice(),
-                    )),
-                )
+                write_fn(ctx, streams::Result::OwnedAndDone(allocated))
             } else {
-                write_fn(
-                    ctx,
-                    streams::Result::Owned(Vec::<u8>::from_owned_slice(
-                        allocated.into_boxed_slice(),
-                    )),
-                )
+                write_fn(ctx, streams::Result::Owned(allocated))
             }
         }
     }

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -9,8 +9,6 @@ use crate::webcore::blob::{
     Blob, ClosingState, FileCloser, FileOpener, MAX_SIZE, SizeType, StoreRef,
 };
 use crate::webcore::node_types::PathOrFileDescriptor;
-#[cfg(windows)]
-use bun_collections::ByteVecExt as _;
 use bun_core::String as BunString;
 use bun_core::{self, Error};
 use bun_io::{self as io, FileAction};
@@ -1410,8 +1408,10 @@ impl<'a> ReadFileUV<'a> {
         this.read_off += SizeType::try_from(result.int()).expect("int cast");
         // SAFETY: libuv wrote result.int() bytes into remaining_buffer()'s spare slice.
         unsafe {
-            this.buffer
-                .uv_commit(usize::try_from(result.int()).expect("int cast"))
+            bun_core::vec::commit_spare(
+                &mut this.buffer,
+                usize::try_from(result.int()).expect("int cast"),
+            )
         };
 
         this.req.deinit();

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -22,10 +22,6 @@ use crate::webcore::{AutoFlusher, ByteListPool};
 bun_core::declare_scope!(HTTPServerWritableLog, visible);
 bun_core::declare_scope!(NetworkSinkLog, visible);
 
-/// `bun.ObjectPool(bun.Vec<u8>, ...)::Node` — pooled buffer node type used by
-/// `HTTPServerWritable.pooled_buffer`.
-pub type ByteListPoolNode = bun_collections::pool::Node<Vec<u8>>;
-
 // NetworkSink stores a borrowed `*MultiPartUpload`. Now that `webcore::s3` is
 // wired, alias the module to the real type so `bun_s3::MultiPartUpload` resolves
 // for callers that still spell it that way.
@@ -1081,7 +1077,9 @@ pub type UwsResponse<const SSL: bool, const HTTP3: bool> = c_void;
 pub struct HTTPServerWritable<const SSL: bool, const HTTP3: bool> {
     pub res: Option<*mut UwsResponse<SSL, HTTP3>>,
     pub buffer: Vec<u8>,
-    pub pooled_buffer: Option<NonNull<ByteListPoolNode>>,
+    /// `true` ⇒ `buffer`'s allocation came from `ByteListPool` and should be
+    /// returned there on `unregister_auto_flusher`.
+    pub buffer_from_pool: bool,
     pub offset: BlobSizeType,
 
     pub is_listening_for_abort: bool,
@@ -1114,7 +1112,7 @@ impl<const SSL: bool, const HTTP3: bool> Default for HTTPServerWritable<SSL, HTT
         Self {
             res: None,
             buffer: Vec::<u8>::default(),
-            pooled_buffer: None,
+            buffer_from_pool: false,
             offset: 0,
             is_listening_for_abort: false,
             wrote: 0,
@@ -1240,8 +1238,8 @@ impl<const SSL: bool, const HTTP3: bool> crate::webcore::sink::JsSinkAbi
 // TODO(b2-blocked): full impl depends on `bun_uws::Response<SSL>`
 // const-generic dispatch (the body casts `res` to `*mut uws::Response` without
 // the SSL/H3 parameter), `bun_event_loop::AutoFlusher` free-fns (the local
-// `crate::webcore::AutoFlusher` is a fieldless stub), and `ByteListPool::Node`
-// data access. Un-gate once the UwsResponse type-dispatch trait lands.
+// `crate::webcore::AutoFlusher` is a fieldless stub). Un-gate once the
+// UwsResponse type-dispatch trait lands.
 
 impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
     /// Const-generic → runtime dispatch for the type-erased `res` field.
@@ -1524,21 +1522,11 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         let _ = self.flush_promise(); // TODO: properly propagate exception upwards
 
         if self.buffer.capacity() == 0 {
-            debug_assert!(self.pooled_buffer.is_none());
+            debug_assert!(!self.buffer_from_pool);
             if FeatureFlags::HTTP_BUFFER_POOLING {
-                if let Some(pooled_node) = ByteListPool::get_if_exists() {
-                    let pooled_node = NonNull::new(pooled_node)
-                        .expect("ByteListPool::get_if_exists returns a live heap node when Some");
-                    self.pooled_buffer = Some(pooled_node);
-                    // SAFETY: pooled_node is a valid pool checkout; `data` was
-                    // written by `ByteListPool::push` (or zero-initialized).
-                    // Move the Vec<u8> out by bitwise read and reset the slot.
-                    self.buffer = unsafe {
-                        core::mem::replace(
-                            (*pooled_node.as_ptr()).data.assume_init_mut(),
-                            Vec::<u8>::default(),
-                        )
-                    };
+                if let Some(pooled) = ByteListPool::take_if_exists() {
+                    self.buffer = pooled;
+                    self.buffer_from_pool = true;
                 }
             }
         }
@@ -1955,30 +1943,20 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         }
 
         if !FeatureFlags::HTTP_BUFFER_POOLING {
-            debug_assert!(self.pooled_buffer.is_none());
+            debug_assert!(!self.buffer_from_pool);
         }
 
-        if let Some(pooled) = self.pooled_buffer {
+        if self.buffer_from_pool {
             self.buffer.clear();
             if self.buffer.capacity() > 64 * 1024 {
                 self.buffer.clear_and_free();
             }
-            // SAFETY: pooled is a valid pool node checkout
-            unsafe {
-                (*pooled.as_ptr()).data =
-                    core::mem::MaybeUninit::new(core::mem::take(&mut self.buffer));
-            }
-
-            self.buffer = Vec::<u8>::default();
-            self.pooled_buffer = None;
-            // PORT NOTE: Zig `pooled.release()` → Rust `ObjectPool::release(node)`
-            // (the Node `Parent` back-ref was dropped in the port; see pool.rs).
-            ByteListPool::release(pooled.as_ptr());
+            self.buffer_from_pool = false;
+            ByteListPool::put(core::mem::take(&mut self.buffer));
         } else if self.buffer.capacity() == 0 {
             //
         } else if FeatureFlags::HTTP_BUFFER_POOLING && !ByteListPool::full() {
-            let buffer = core::mem::take(&mut self.buffer);
-            ByteListPool::push(buffer);
+            ByteListPool::put(core::mem::take(&mut self.buffer));
         } else {
             // Don't release this buffer until destroy() is called
             self.buffer.clear();

--- a/src/sourcemap/InternalSourceMap.rs
+++ b/src/sourcemap/InternalSourceMap.rs
@@ -1240,15 +1240,14 @@ impl Builder {
             let total: usize = stream_offset as usize + self.win_stream.len() + STREAM_TAIL_PAD;
 
             let mut out = MutableString::init_empty();
-            // Zig: `out.list.resize(allocator, total)` leaves new bytes undefined.
-            // Every byte in [0..total) is written below: [0..24] zero-filled,
-            // [24..32] header u32s, [32..32+sync_bytes] sync table memcpy,
+            // One-shot blob; pre-size exactly. Every byte in [0..total) is
+            // overwritten below: [0..24] zero-filled, [24..32] header u32s,
+            // [32..32+sync_bytes] sync table memcpy,
             // [stream_offset..stream_offset+win_stream.len()] stream memcpy,
-            // [total-STREAM_TAIL_PAD..total] zero-filled. These ranges are
-            // contiguous (HEADER_SIZE==32, stream_offset==32+sync_bytes), so
-            // no uninit bytes are exposed by set_len.
-            // SAFETY: every byte in [0..total) is written below (see comment above).
-            let blob = unsafe { out.list.writable_slice_exact(total) };
+            // [total-STREAM_TAIL_PAD..total] zero-filled.
+            out.list.reserve_exact(total);
+            out.list.resize(total, 0);
+            let blob = &mut out.list[..];
 
             blob[0..24].fill(0);
             blob[24..28].copy_from_slice(

--- a/src/sourcemap/Mapping.rs
+++ b/src/sourcemap/Mapping.rs
@@ -202,19 +202,15 @@ impl List {
     }
 
     pub fn sort(&mut self) {
-        // PORT NOTE: reshaped for borrowck — `MultiArrayList::sort(&self, ctx)` takes
-        // `&self` (it swaps via raw column ptrs internally), so the `generated` column
-        // borrow does not conflict. The `Slice` is captured by-value so its lifetime
-        // is detached from `list`.
-        both_lists!(&self.r#impl, |list| {
-            // SAFETY: column borrow is read-only; `sort` swaps via raw ptrs.
-            let generated = unsafe {
-                core::slice::from_raw_parts(
-                    list.items_raw::<"generated", LineColumnOffset>(),
-                    list.len(),
-                )
-            };
-            list.sort(SortContext { generated });
+        // `MultiArrayList::sort(&mut self, ctx)` swaps the `generated` column
+        // in place, so the comparator cannot hold a `&[LineColumnOffset]` over
+        // it (that aliased the swap before this rewrite). Instead capture the
+        // raw column base + len; the column is never reallocated during sort.
+        both_lists!(&mut self.r#impl, |list| {
+            let generated: *const LineColumnOffset =
+                list.items_raw::<"generated", LineColumnOffset>();
+            let len = list.len();
+            list.sort(SortContext { generated, len });
         })
     }
 
@@ -309,14 +305,18 @@ impl List {
     }
 }
 
-struct SortContext<'a> {
-    generated: &'a [LineColumnOffset],
+struct SortContext {
+    generated: *const LineColumnOffset,
+    len: usize,
 }
 
-impl<'a> bun_collections::multi_array_list::SortContext for SortContext<'a> {
+impl bun_collections::multi_array_list::SortContext for SortContext {
     fn less_than(&self, a_index: usize, b_index: usize) -> bool {
-        let a = self.generated[a_index];
-        let b = self.generated[b_index];
+        debug_assert!(a_index < self.len && b_index < self.len);
+        // SAFETY: indices are `< len`; `generated` is the column base pointer
+        // captured before sort, which swaps elements in place but never
+        // reallocates, so it remains valid for `len` reads throughout.
+        let (a, b) = unsafe { (*self.generated.add(a_index), *self.generated.add(b_index)) };
 
         if a.lines.zero_based() != b.lines.zero_based() {
             return a.lines.zero_based() < b.lines.zero_based();
@@ -688,7 +688,8 @@ pub fn parse(
                             err: err!("InvalidNameIndexDelta"),
                             value: i32::from(c),
                             loc: Loc {
-                                start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
+                                start: i32::try_from(bytes.len() - remain.len())
+                                    .unwrap_or(i32::MAX),
                             },
                         });
                     }

--- a/src/threading/channel.rs
+++ b/src/threading/channel.rs
@@ -61,7 +61,7 @@ impl<T: Copy, const N: usize> Channel<T, StaticBuffer<T, N>> {
 
 impl<'a, T: Copy> Channel<T, SliceBuffer<'a, T>> {
     #[inline]
-    pub fn init_slice(buf: &'a mut [T]) -> Self {
+    pub fn init_slice(buf: &'a mut [MaybeUninit<T>]) -> Self {
         Self::with_buffer(LinearFifo::<T, SliceBuffer<'a, T>>::init(buf))
     }
 }

--- a/src/zlib/lib.rs
+++ b/src/zlib/lib.rs
@@ -510,8 +510,13 @@ impl<'a> ZlibReaderArrayList<'a> {
                 //   flush parameter).
 
                 if self.zlib.avail_out == 0 {
-                    // SAFETY: zlib writes the tail; len is truncated to `total_out` before any read.
-                    let (next_out, avail_out) = unsafe { self.list_ptr.reserve_expand_tail(4096) };
+                    let total_out = self.zlib.total_out as usize;
+                    debug_assert!(total_out <= self.list_ptr.capacity());
+                    // SAFETY: zlib has initialized `list_ptr[..total_out]`; commit so
+                    // the spare tail returned below starts past it (without this the
+                    // next iteration rewinds `next_out` and overwrites prior output).
+                    unsafe { self.list_ptr.set_len(total_out) };
+                    let (next_out, avail_out) = self.list_ptr.ffi_spare_tail(4096);
                     self.zlib.next_out = next_out;
                     self.zlib.avail_out = avail_out as uInt;
                 }
@@ -560,12 +565,9 @@ impl<'a> ZlibReaderArrayList<'a> {
 
         // defer epilogue (runs unconditionally):
         let total_out = self.zlib.total_out as usize;
-        if self.list_ptr.len() > total_out {
-            self.list_ptr.truncate(total_out);
-        } else if total_out < self.list_ptr.capacity() {
-            // SAFETY: zlib has written `total_out` bytes into list_ptr's buffer.
-            unsafe { self.list_ptr.set_len(total_out) };
-        }
+        debug_assert!(total_out <= self.list_ptr.capacity());
+        // SAFETY: zlib has written `total_out` bytes into list_ptr's buffer.
+        unsafe { self.list_ptr.set_len(total_out) };
 
         result
     }
@@ -1023,8 +1025,12 @@ impl<'a> ZlibCompressorArrayList<'a> {
                 //   flush parameter).
 
                 if self.zlib.avail_out == 0 {
-                    // SAFETY: zlib writes the tail; len is truncated to `total_out` before any read.
-                    let (next_out, avail_out) = unsafe { self.list_ptr.reserve_expand_tail(4096) };
+                    let total_out = self.zlib.total_out as usize;
+                    debug_assert!(total_out <= self.list_ptr.capacity());
+                    // SAFETY: zlib has initialized `list_ptr[..total_out]`; commit so
+                    // the spare tail returned below starts past it.
+                    unsafe { self.list_ptr.set_len(total_out) };
+                    let (next_out, avail_out) = self.list_ptr.ffi_spare_tail(4096);
                     self.zlib.next_out = next_out;
                     self.zlib.avail_out = avail_out as uInt;
                 }
@@ -1068,7 +1074,10 @@ impl<'a> ZlibCompressorArrayList<'a> {
 
         // defer epilogue (runs unconditionally):
         // Zig: this.list.shrinkRetainingCapacity(this.zlib.total_out); this.list_ptr.* = this.list;
-        self.list_ptr.truncate(self.zlib.total_out as usize);
+        let total_out = self.zlib.total_out as usize;
+        debug_assert!(total_out <= self.list_ptr.capacity());
+        // SAFETY: zlib has written `total_out` bytes into list_ptr's buffer.
+        unsafe { self.list_ptr.set_len(total_out) };
 
         result
     }

--- a/test/bundler/bundler_splitting_many_entrypoints.test.ts
+++ b/test/bundler/bundler_splitting_many_entrypoints.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect } from "bun:test";
+import { readdirSync } from "fs";
+import { itBundled } from "./expectBundled";
+
+// Regression coverage for the DynamicBitSetUnmanaged / AutoBitSet rewrite.
+//
+// With more than AUTO_STATIC_BITS (= 127) entry points, the per-file and
+// per-chunk `entry_bits` stored in LinkerGraph/Chunk flip from the inline
+// ArrayBitSet arm to the heap-allocated DynamicBitSetUnmanaged arm, and
+// chunk assignment runs `has_intersection` / `clone` / `set` / Drop on the
+// dynamic path for every (file × entry) pair. This test pins that path to a
+// known-good output so future changes to the bitset storage (thin-pointer
+// packing, Drop, resize) can't silently corrupt chunk assignment.
+
+describe("bundler", () => {
+  const N = 150; // > 127 so AutoBitSet::needs_dynamic(N) is true
+
+  const files: Record<string, string> = {
+    "/shared.js": `export const shared = 1;`,
+  };
+  const entryPoints: string[] = [];
+  for (let i = 0; i < N; i++) {
+    const p = `/e${i}.js`;
+    files[p] = `import { shared } from "./shared.js"; console.log(shared + ${i});`;
+    entryPoints.push(p);
+  }
+  // Spot-check first / mid / last entries (running all N is too slow); the
+  // onAfterBundle chunk-shape check below covers the full set.
+  const run = [0, 64, 127, N - 1].map(i => ({
+    file: `/out/e${i}.js`,
+    stdout: String(1 + i),
+  }));
+
+  itBundled("splitting/DynamicEntryBitsManyEntrypoints", {
+    files,
+    entryPoints,
+    splitting: true,
+    run,
+    onAfterBundle(api) {
+      // With splitting, `shared.js` must land in exactly one shared chunk
+      // (not be duplicated into every entry). If entry_bits intersection is
+      // wrong the linker either over-splits or inlines `shared` everywhere.
+      const outputs = readdirSync(api.outdir).filter(f => f.endsWith(".js"));
+      let copies = 0;
+      for (const f of outputs) {
+        if (api.readFile("/out/" + f).includes("shared = 1")) copies++;
+      }
+      expect(copies).toBe(1);
+      // Exactly N entry chunks + 1 shared chunk.
+      expect(outputs.length).toBe(N + 1);
+    },
+  });
+});


### PR DESCRIPTION
**Draft / integration preview.** This branch merges all 8 of the `bun_collections` safety PRs and adds the crate-level lint attributes. Land #30718, #30723, #30724, #30726, #30727, #30729, #30730, #30736, #30737 first, then rebase this onto main — the only net change will be the 13 attribute lines.

## What this branch proves

All 9 PRs compose without conflicts and the full workspace (`cargo check -p bun_bin`) compiles cleanly.

## Lint attributes added

- `#![deny(unsafe_code)]` at crate root (`lib.rs`)
- `#![forbid(unsafe_code)]` on the zero-unsafe modules: `pool`, `comptime_string_map`, `identity_context`, `string_map`, `zig_hash_map`, `StaticHashMap` (`array_list` already had it from #30715)
- `#![allow(unsafe_code)]` on the residual modules: `bit_set`, `multi_array_list`, `hive_array`, `array_hash_map`, `vec_ext`, `linear_fifo`

## Residual unsafe (grep, includes doc-comment hits)

| module | grep | actual | what remains |
|---|---|---|---|
| `multi_array_list` | 18 | ~13 | SoA column projection primitives — designated exception |
| `hive_array` | 14 | 12 | `Fallback::put` (FFI `*mut` round-trip), `assume_init_*` accessors, `new_boxed` |
| `array_hash_map` | 9 | 8 | packed `StringHashMapKey` (Send/Sync/Drop/Deref) + `put_borrowed` lifetime-erase |
| `bit_set` | 4 | 4 | `NonNull<usize>` ↔ `Box<[usize]>` round-trip (kept struct at 16B for LinkerGraph) |
| `vec_ext` | 4 | 4 | `from_bump_vec` body (SpecExtend Global-only) + `from_borrowed_slice_dangerous` (renamer ctor cascade deferred) |
| `linear_fifo` | 3 | 3 | `assume_init` over `[head, head+count)` invariant — same core as `std::VecDeque` |
| `lib` | 1 | 0 | doc-comment only |
| **total** | **53** | **~44** | down from **179** |

## Gap to "one exception module"

Reaching only `multi_array_list` requires three cascading lifetime refactors outside `bun_collections`:
1. `array_hash_map` 8→0: `StringHashMap<'k,V,A>` through `ast::Scope<'src>` → `js_parser::P<'src>` (~15 files)
2. `vec_ext` 4→0: renamer ctor `&symbol::Map` lifetime threading + accept `from_bump_vec` per-element loop on parser hot path
3. `hive_array` 12→?: `Fallback::put` irreducible while callers stash `*mut T` in FFI user-data; could move `HiveRef` to `jsc_hooks` (−2)

Each is its own medium PR.