### PR TITLE
test: pin Bun.build with many conditions + sync options.zig reference

### DIFF
--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1087,9 +1087,9 @@ pub const ESMConditions = struct {
         var require_condition_map = ConditionsMap.init(allocator);
         var style_condition_map = ConditionsMap.init(allocator);
 
-        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
-        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len);
+        try default_condition_amp.ensureTotalCapacity(defaults.len + 2 + @as(usize, @intFromBool(allow_addons)) + conditions.len);
+        try import_condition_map.ensureTotalCapacity(defaults.len + 2 + @as(usize, @intFromBool(allow_addons)) + conditions.len);
+        try require_condition_map.ensureTotalCapacity(defaults.len + 2 + @as(usize, @intFromBool(allow_addons)) + conditions.len);
         try style_condition_map.ensureTotalCapacity(defaults.len + 2 + conditions.len);
 
         import_condition_map.putAssumeCapacity("import", {});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -134,6 +134,18 @@ describe("Bun.build", () => {
     ).toThrow();
   });
 
+  test("many conditions does not crash", async () => {
+    const dir = tempDirWithFiles("bun-build-api-conditions", {
+      "entry.js": "export const x = 1;",
+    });
+    const build = await Bun.build({
+      entrypoints: [join(dir, "entry.js")],
+      conditions: ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p"],
+    });
+    expect(build.success).toBe(true);
+    expect(build.outputs).toHaveLength(1);
+  });
+
   test("returns errors properly", async () => {
     Bun.gc(true);
     const build = await buildNoThrow({


### PR DESCRIPTION
Fuzzer fingerprint: `685808bc48561019`

Closes #30619

## What

Adds a regression test for `Bun.build()` with many `conditions`, and corrects an operator-precedence bug in the `options.zig` porting reference.

## Background

Fuzzilli found a crash in `ESMConditions.init` where

```zig
defaults.len + 2 + if (allow_addons) 1 else 0 + conditions.len
```

parses as `defaults.len + 2 + (if (allow_addons) 1 else (0 + conditions.len))`, dropping `conditions.len` from the capacity reservation when `allow_addons` is true and overflowing subsequent `putAssumeCapacity` calls. This is also the root cause of #30619 (4+ `--conditions` falling back to `default`).

**However**, the fuzzer binary predates #30412. On current `main`, `Bun.build` / `--conditions` go through `src/bundler/options.rs`, where `ESMConditions::init` already extracts `addon_extra` into a separate binding and uses `.insert()` rather than assume-capacity — so the shipped binary does not have this bug. Verified: with the `.zig` change reverted, a fresh `bun bd` build handles 16 conditions and `--conditions` resolution correctly.

## Changes

- **`test/bundler/bun-build-api.test.ts`**: regression test pinning that `Bun.build` with 16 `conditions` succeeds. This guards against the bug being reintroduced.
- **`src/bundler/options.zig`**: sync the porting reference — replace the ambiguous `if` expression with `@intFromBool(allow_addons)` so the reference matches the (already-correct) `options.rs` semantics.
