### PR TITLE
Thread 'arena lifetime through AST types and bundler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "boxcar"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,7 +154,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "typed-arena",
@@ -167,7 +173,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -187,7 +193,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -212,7 +218,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "typed-arena",
@@ -232,7 +238,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -253,7 +259,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -289,7 +295,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -306,7 +312,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -325,7 +331,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -341,7 +347,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -352,6 +358,7 @@ name = "bun_bundler"
 version = "0.0.0"
 dependencies = [
  "bitflags",
+ "boxcar",
  "bstr",
  "bumpalo",
  "bun_alloc",
@@ -392,7 +399,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -423,7 +430,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -456,7 +463,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -476,7 +483,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -494,7 +501,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -521,7 +528,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -562,7 +569,7 @@ dependencies = [
  "const_format",
  "itoa",
  "libc",
- "phf 0.11.3",
+ "phf",
  "strum",
  "thiserror",
 ]
@@ -602,7 +609,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -621,7 +628,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -647,7 +654,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "typed-arena",
@@ -681,7 +688,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -711,7 +718,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -736,7 +743,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -754,7 +761,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -780,7 +787,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -800,7 +807,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -821,7 +828,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -843,7 +850,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -884,7 +891,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -919,7 +926,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -940,7 +947,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -967,7 +974,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -1025,7 +1032,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -1055,7 +1062,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -1076,7 +1083,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -1102,7 +1109,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -1117,7 +1124,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -1149,7 +1156,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "regex",
  "scopeguard",
  "strum",
@@ -1180,7 +1187,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -1209,7 +1216,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "typed-arena",
@@ -1265,7 +1272,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -1297,7 +1304,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -1315,7 +1322,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -1332,7 +1339,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -1350,7 +1357,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -1368,7 +1375,7 @@ dependencies = [
  "enumset",
  "libc",
  "lol_html_c_api",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -1390,7 +1397,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -1405,7 +1412,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -1421,7 +1428,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -1436,7 +1443,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -1467,7 +1474,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -1502,7 +1509,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -1526,7 +1533,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -1546,7 +1553,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -1564,7 +1571,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -1583,7 +1590,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -1599,7 +1606,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -1614,7 +1621,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -1632,7 +1639,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -1651,7 +1658,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -1670,7 +1677,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -1711,7 +1718,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -1738,7 +1745,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -1835,7 +1842,7 @@ dependencies = [
  "enumset",
  "getrandom",
  "libc",
- "phf 0.11.3",
+ "phf",
  "rust-argon2",
  "scopeguard",
  "sha3",
@@ -1862,7 +1869,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -1880,7 +1887,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -1900,7 +1907,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -1918,7 +1925,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -1937,7 +1944,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -1956,7 +1963,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "smallvec",
  "strum",
@@ -1983,7 +1990,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -2013,7 +2020,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "smallvec",
  "strum",
@@ -2041,7 +2048,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -2101,7 +2108,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -2131,7 +2138,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -2169,7 +2176,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -2195,7 +2202,7 @@ dependencies = [
  "enumset",
  "libc",
  "memchr",
- "phf 0.11.3",
+ "phf",
  "rustix",
  "scopeguard",
  "strum",
@@ -2225,7 +2232,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -2247,7 +2254,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -2264,7 +2271,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -2281,7 +2288,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -2302,7 +2309,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -2320,7 +2327,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -2341,7 +2348,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -2364,7 +2371,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
  "thiserror",
@@ -2402,7 +2409,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -2420,7 +2427,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -2439,7 +2446,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -2459,7 +2466,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -2475,7 +2482,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -2492,7 +2499,7 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "phf 0.11.3",
+ "phf",
  "scopeguard",
  "strum",
 ]
@@ -2697,29 +2704,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cssparser"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
-dependencies = [
- "cssparser-macros",
- "dtoa-short",
- "itoa",
- "phf 0.13.1",
- "smallvec",
-]
-
-[[package]]
-name = "cssparser-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2754,27 +2738,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2786,34 +2749,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dtoa"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
-
-[[package]]
-name = "dtoa-short"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
-dependencies = [
- "dtoa",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "enum-map"
@@ -2873,12 +2812,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2889,12 +2822,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "futures-core"
@@ -2961,18 +2888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -3113,49 +3029,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "lol_html"
-version = "2.7.2"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cssparser",
- "encoding_rs",
- "foldhash 0.2.0",
- "hashbrown 0.16.1",
- "memchr",
- "mime",
- "precomputed-hash",
- "selectors",
- "thiserror",
-]
-
-[[package]]
 name = "lol_html_c_api"
-version = "1.3.1"
-dependencies = [
- "encoding_rs",
- "libc",
- "lol_html",
- "thiserror",
-]
+version = "0.0.0"
 
 [[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "num-traits"
@@ -3190,29 +3071,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
-dependencies = [
- "phf_macros 0.13.1",
- "phf_shared 0.13.1",
- "serde",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
-dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_macros",
+ "phf_shared",
 ]
 
 [[package]]
@@ -3221,18 +3081,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared 0.11.3",
+ "phf_shared",
  "rand",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
-dependencies = [
- "fastrand",
- "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -3241,21 +3091,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
-dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn",
@@ -3266,15 +3103,6 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -3312,12 +3140,6 @@ checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
-
-[[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -3430,21 +3252,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3477,25 +3284,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "selectors"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feef350c36147532e1b79ea5c1f3791373e61cbd9a6a2615413b3807bb164fb7"
-dependencies = [
- "bitflags",
- "cssparser",
- "derive_more",
- "log",
- "new_debug_unreachable",
- "phf 0.13.1",
- "phf_codegen",
- "precomputed-hash",
- "rustc-hash",
- "servo_arc",
- "smallvec",
-]
 
 [[package]]
 name = "semver"
@@ -3547,15 +3335,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "servo_arc"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
 name = "sha3"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3582,12 +3361,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,6 +233,7 @@ crossbeam = "0.8"
 smallvec = "1"
 bumpalo = { version = "3", features = ["collections", "boxed"] }
 typed-arena = "2"
+boxcar = "0.2"
 itoa = "1"
 bun_opaque = { path = "src/opaque" }
 bun_analytics = { path = "src/analytics" }

--- a/src/ast/ast_memory_allocator.rs
+++ b/src/ast/ast_memory_allocator.rs
@@ -213,7 +213,7 @@ impl ASTMemoryAllocator {
     }
 
     #[inline]
-    pub fn append<T>(&self, value: T) -> crate::StoreRef<T> {
+    pub fn append<'arena, T>(&self, value: T) -> crate::StoreRef<'arena, T> {
         // Zig: `this.bump_allocator.create(ValueType) catch unreachable; ptr.* = value;`
         // bumpalo's `alloc` aborts on OOM, matching `catch unreachable`.
         // SAFETY: bumpalo never returns null.

--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -22,7 +22,7 @@ type ImportRecordList = Vec<ImportRecord>;
 
 pub type TopLevelSymbolToParts = ArrayHashMap<Ref, Vec<u32>>;
 
-pub struct Ast {
+pub struct Ast<'arena> {
     pub approximate_newline_count: usize,
     pub has_lazy_export: bool,
     pub runtime_imports: runtime::Imports,
@@ -56,12 +56,12 @@ pub struct Ast {
     // `hashbang`/`directive` are `[]const u8` slices into source text (not
     // freed in Zig `deinit`). `StoreStr` records them under the same
     // lifetime-erased contract as `StoreRef`.
-    pub hashbang: StoreStr,
-    pub directive: Option<StoreStr>,
-    pub parts: PartList,
+    pub hashbang: StoreStr<'arena>,
+    pub directive: Option<StoreStr<'arena>>,
+    pub parts: PartList<'arena>,
     // This list may be mutated later, so we should store the capacity
-    pub symbols: SymbolList,
-    pub module_scope: Scope,
+    pub symbols: SymbolList<'arena>,
+    pub module_scope: Scope<'arena>,
     pub char_freq: Option<CharFreq>,
     pub exports_ref: Ref,
     pub module_ref: Ref,
@@ -74,7 +74,7 @@ pub struct Ast {
     // These are used when bundling. They are filled in during the parser pass
     // since we already have to traverse the AST then anyway and the parser pass
     // is conveniently fully parallelized.
-    pub named_imports: NamedImports,
+    pub named_imports: NamedImports<'arena>,
     pub named_exports: NamedExports,
     // TODO(port): `[]u32` not freed in Zig `deinit` — likely arena-owned. Using Box<[u32]> for now.
     pub export_star_import_records: Box<[u32]>,
@@ -89,7 +89,7 @@ pub struct Ast {
     /// Only populated when bundling
     pub target: Target,
     // const_values: ConstValuesMap,
-    pub ts_enums: TsEnumsMap,
+    pub ts_enums: TsEnumsMap<'arena>,
 
     /// Not to be confused with `commonjs_named_exports`
     /// This is a list of named exports that may exist in a CommonJS module
@@ -102,7 +102,7 @@ pub struct Ast {
 // PORT NOTE: Zig field defaults reference named constants (`Ref.None`, `logger.Range.None`,
 // `ExportsKind.none`, `Target.browser`) whose equivalence to the Rust types' `Default::default()`
 // is unverified across crates, so spell them out here instead of `#[derive(Default)]`.
-impl Default for Ast {
+impl<'arena> Default for Ast<'arena> {
     fn default() -> Self {
         Self {
             approximate_newline_count: 0,
@@ -170,13 +170,13 @@ impl Default for CommonJSNamedExport {
 // `G::DeclList`/`PropertyList` and `Scope::members`).
 pub type CommonJSNamedExports = StringArrayHashMap<CommonJSNamedExport, StringContext, AstAlloc>;
 
-pub type NamedImports = ArrayHashMap<Ref, NamedImport, AutoContext, AstAlloc>;
+pub type NamedImports<'arena> = ArrayHashMap<Ref, NamedImport<'arena>, AutoContext, AstAlloc>;
 pub type NamedExports = StringArrayHashMap<NamedExport, StringContext, AstAlloc>;
-pub type ConstValuesMap = ArrayHashMap<Ref, Expr, AutoContext, AstAlloc>;
-pub type TsEnumsMap = ArrayHashMap<Ref, StringHashMap<InlinedEnumValue>, AutoContext, AstAlloc>;
+pub type ConstValuesMap<'arena> = ArrayHashMap<Ref, Expr<'arena>, AutoContext, AstAlloc>;
+pub type TsEnumsMap<'arena> = ArrayHashMap<Ref, StringHashMap<InlinedEnumValue<'arena>>, AutoContext, AstAlloc>;
 
-impl Ast {
-    pub fn from_parts(parts: Box<[Part]>) -> Ast {
+impl<'arena> Ast<'arena> {
+    pub fn from_parts(parts: Box<[Part<'arena>]>) -> Ast<'arena> {
         Ast {
             parts: PartList::from_owned_slice(parts),
             runtime_imports: Default::default(),
@@ -188,7 +188,7 @@ impl Ast {
     // and relied on explicit `deinit` never being called. `Vec::drop` now
     // unconditionally guards on `Origin::Borrowed` (not debug-only), so unwrapping
     // the `ManuallyDrop` is safe — the caller's slice is never freed by `Ast`'s Drop.
-    pub fn init_test(parts: &[Part]) -> Ast {
+    pub fn init_test(parts: &[Part<'arena>]) -> Ast<'arena> {
         Ast {
             // SAFETY: test-only helper; the borrowed list is tagged
             // `Origin::Borrowed`, so `Vec::drop` skips the free, and no
@@ -204,7 +204,7 @@ impl Ast {
     // Zig: `pub const empty = Ast{ .parts = Part.List{}, .runtime_imports = .{} };`
     // All fields use their defaults, so `Ast::default()` is the Rust equivalent.
     // TODO(port): if a true `const` is required at use sites, revisit once field types are `const`-constructible.
-    pub fn empty() -> Ast {
+    pub fn empty() -> Ast<'arena> {
         Ast::default()
     }
 

--- a/src/ast/b.rs
+++ b/src/ast/b.rs
@@ -28,18 +28,18 @@ pub use crate::ArrayBinding;
 // 'bump threaded crate-wide (`&'bump mut T`).
 #[derive(Copy, Clone, bun_core::EnumTag)]
 #[enum_tag(existing = super::binding::Tag)]
-pub enum B {
+pub enum B<'arena> {
     // let x = ...
-    BIdentifier(StoreRef<Identifier>),
+    BIdentifier(StoreRef<'arena, Identifier>),
     // let [a, b] = ...
-    BArray(StoreRef<Array>),
+    BArray(StoreRef<'arena, Array<'arena>>),
     // let { a, b: c } = ...
-    BObject(StoreRef<Object>),
+    BObject(StoreRef<'arena, Object<'arena>>),
     // this is used to represent array holes
     BMissing(Missing),
 }
 
-impl Default for B {
+impl<'arena> Default for B<'arena> {
     fn default() -> Self {
         B::BMissing(Missing {})
     }
@@ -53,10 +53,10 @@ impl Default for B {
 // so `Option<B>` packs into the same 16 bytes via the NonNull niche (and
 // would continue to even under a future `#[repr(u8)]`, unlike the prior
 // `*mut T` form which relied solely on spare-tag-value niche).
-const _: () = assert!(core::mem::size_of::<B>() == 16);
-const _: () = assert!(core::mem::size_of::<super::binding::Binding>() == 24);
+const _: () = assert!(core::mem::size_of::<B<'static>>() == 16);
+const _: () = assert!(core::mem::size_of::<super::binding::Binding<'static>>() == 24);
 const _: () = assert!(
-    core::mem::size_of::<Option<B>>() == core::mem::size_of::<B>(),
+    core::mem::size_of::<Option<B<'static>>>() == core::mem::size_of::<B<'static>>(),
     "B lost its niche — check for #[repr] or oversized inline payload"
 );
 
@@ -64,24 +64,24 @@ pub struct Identifier {
     pub r#ref: Ref,
 }
 
-pub struct Property {
+pub struct Property<'arena> {
     pub flags: flags::PropertySet,
-    pub key: ExprNodeIndex,
-    pub value: Binding,
-    pub default_value: Option<Expr>,
+    pub key: ExprNodeIndex<'arena>,
+    pub value: Binding<'arena>,
+    pub default_value: Option<Expr<'arena>>,
 }
 // TODO(port): partial defaults — Zig only defaults `flags`/`default_value`; `key`/`value` have none, so no `impl Default`.
 
-pub struct Object {
-    pub properties: crate::StoreSlice<Property>,
+pub struct Object<'arena> {
+    pub properties: crate::StoreSlice<'arena, Property<'arena>>,
     pub is_single_line: bool,
 }
 // Zig: `pub const Property = B.Property;` — inherent associated type alias.
 // TODO(port): inherent associated types are unstable; callers use `B::Property` directly.
 // TODO(port): partial defaults — Zig only defaults `is_single_line`; `properties` has none, so no `impl Default`.
 
-pub struct Array {
-    pub items: crate::StoreSlice<ArrayBinding>,
+pub struct Array<'arena> {
+    pub items: crate::StoreSlice<'arena, ArrayBinding<'arena>>,
     pub has_spread: bool,
     pub is_single_line: bool,
 }
@@ -95,34 +95,34 @@ pub struct Missing {}
 // Ergonomic slice accessors so P-helpers can `for item in arr.items()`.
 // `&mut self` establishes uniqueness for the `slice_mut()` SAFETY contract
 // (single-threaded parser; arena slice valid for `'a`).
-impl Array {
+impl<'arena> Array<'arena> {
     #[inline]
-    pub fn items(&self) -> &[ArrayBinding] {
+    pub fn items(&self) -> &[ArrayBinding<'arena>] {
         self.items.slice()
     }
     #[inline]
-    pub fn items_mut(&mut self) -> &mut [ArrayBinding] {
+    pub fn items_mut(&mut self) -> &mut [ArrayBinding<'arena>] {
         self.items.slice_mut()
     }
 }
-impl Object {
+impl<'arena> Object<'arena> {
     #[inline]
-    pub fn properties(&self) -> &[Property] {
+    pub fn properties(&self) -> &[Property<'arena>] {
         self.properties.slice()
     }
     #[inline]
-    pub fn properties_mut(&mut self) -> &mut [Property] {
+    pub fn properties_mut(&mut self) -> &mut [Property<'arena>] {
         self.properties.slice_mut()
     }
 }
 
-impl B {
+impl<'arena> B<'arena> {
     /// This hash function is currently only used for React Fast Refresh transform.
     /// This doesn't include the `is_single_line` properties, as they only affect whitespace.
     pub fn write_to_hasher<H, S>(&self, hasher: &mut H, symbol_table: &mut S)
     where
         H: bun_core::Hasher + ?Sized,
-        S: crate::base::SymbolTable + ?Sized,
+        S: crate::base::SymbolTable<'arena> + ?Sized,
         // PORT NOTE: `symbol_table: anytype` — forwarded to `Ref::get_symbol` and
         // `Expr::Data::write_to_hasher`; bound mirrors `Expr::Data::write_to_hasher`.
     {
@@ -180,7 +180,7 @@ impl B {
 
 // Keep `Binding` referenced (it's the conceptual tag-host of `B`).
 #[allow(dead_code)]
-type _BindingTagHost = Binding;
+type _BindingTagHost<'arena> = Binding<'arena>;
 
 pub use crate::g::Class;
 

--- a/src/ast/base.rs
+++ b/src/ast/base.rs
@@ -148,20 +148,20 @@ const _: () = assert!(Ref::NONE.is_empty());
 // Different parts of the bundler use different formats of the symbol table.
 // In the parser you only have one array, and .sourceIndex() is ignored.
 // In the bundler, you have a 2D array where both parts of the ref are used.
-pub trait SymbolTable {
-    fn get_symbol(&mut self, r: Ref) -> &mut symbol::Symbol;
+pub trait SymbolTable<'arena> {
+    fn get_symbol(&mut self, r: Ref) -> &mut symbol::Symbol<'arena>;
 }
 
-impl SymbolTable for [symbol::Symbol] {
+impl<'arena> SymbolTable<'arena> for [symbol::Symbol<'arena>] {
     #[inline]
-    fn get_symbol(&mut self, r: Ref) -> &mut symbol::Symbol {
+    fn get_symbol(&mut self, r: Ref) -> &mut symbol::Symbol<'arena> {
         &mut self[r.inner_index() as usize]
     }
 }
 
-impl SymbolTable for Vec<symbol::Symbol> {
+impl<'arena> SymbolTable<'arena> for Vec<symbol::Symbol<'arena>> {
     #[inline]
-    fn get_symbol(&mut self, r: Ref) -> &mut symbol::Symbol {
+    fn get_symbol(&mut self, r: Ref) -> &mut symbol::Symbol<'arena> {
         &mut self[r.inner_index() as usize]
     }
 }
@@ -172,10 +172,10 @@ impl SymbolTable for Vec<symbol::Symbol> {
 /// `Ref` methods that need `Symbol` / JSON writer.
 impl Ref {
     #[inline]
-    pub fn get_symbol<T: SymbolTable + ?Sized>(self, symbol_table: &mut T) -> &mut symbol::Symbol {
+    pub fn get_symbol<'arena, T: SymbolTable<'arena> + ?Sized>(self, symbol_table: &mut T) -> &mut symbol::Symbol<'arena> {
         symbol_table.get_symbol(self)
     }
-    pub fn dump<T: SymbolTable + ?Sized>(self, symbol_table: &mut T) -> RefDump<'_> {
+    pub fn dump<'arena, T: SymbolTable<'arena> + ?Sized>(self, symbol_table: &'arena mut T) -> RefDump<'arena> {
         RefDump {
             ref_: self,
             symbol: symbol_table.get_symbol(self),
@@ -192,7 +192,7 @@ impl Ref {
 // Zig: `DumpImplData` + `dumpImpl` — formatter wrapper returned by `Ref.dump`.
 pub struct RefDump<'a> {
     ref_: Ref,
-    symbol: &'a symbol::Symbol,
+    symbol: &'a symbol::Symbol<'a>,
 }
 impl fmt::Display for RefDump<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/ast/binding.rs
+++ b/src/ast/binding.rs
@@ -18,9 +18,9 @@ pub use crate::b::B as Data;
 
 // Zig file-as-struct: top-level fields `loc`, `data` define `Binding`.
 #[derive(Copy, Clone, Default)]
-pub struct Binding {
+pub struct Binding<'arena> {
     pub loc: crate::Loc,
-    pub data: B,
+    pub data: B<'arena>,
 }
 
 // Zig: `enum(u5)` — Rust has no u5; use u8 repr (values fit).
@@ -59,65 +59,65 @@ pub static ICOUNT: AtomicUsize = AtomicUsize::new(0);
 // per call-site like the Zig original.
 // ──────────────────────────────────────────────────────────────────────────
 
-pub trait BindingInit {
-    fn into_b(self) -> B;
+pub trait BindingInit<'arena> {
+    fn into_b(self) -> B<'arena>;
 }
-impl BindingInit for StoreRef<crate::b::Identifier> {
+impl<'arena> BindingInit<'arena> for StoreRef<'arena, crate::b::Identifier> {
     #[inline]
-    fn into_b(self) -> B {
+    fn into_b(self) -> B<'arena> {
         B::BIdentifier(self)
     }
 }
-impl BindingInit for StoreRef<crate::b::Array> {
+impl<'arena> BindingInit<'arena> for StoreRef<'arena, crate::b::Array<'arena>> {
     #[inline]
-    fn into_b(self) -> B {
+    fn into_b(self) -> B<'arena> {
         B::BArray(self)
     }
 }
-impl BindingInit for StoreRef<crate::b::Object> {
+impl<'arena> BindingInit<'arena> for StoreRef<'arena, crate::b::Object<'arena>> {
     #[inline]
-    fn into_b(self) -> B {
+    fn into_b(self) -> B<'arena> {
         B::BObject(self)
     }
 }
-impl BindingInit for crate::b::Missing {
+impl<'arena> BindingInit<'arena> for crate::b::Missing {
     #[inline]
-    fn into_b(self) -> B {
+    fn into_b(self) -> B<'arena> {
         B::BMissing(self)
     }
 }
 
-pub trait BindingAlloc: Sized {
-    fn alloc_into_b(self, bump: &Arena) -> B;
+pub trait BindingAlloc<'arena>: Sized {
+    fn alloc_into_b(self, bump: &Arena) -> B<'arena>;
 }
-impl BindingAlloc for crate::b::Identifier {
+impl<'arena> BindingAlloc<'arena> for crate::b::Identifier {
     #[inline]
-    fn alloc_into_b(self, bump: &Arena) -> B {
+    fn alloc_into_b(self, bump: &Arena) -> B<'arena> {
         B::BIdentifier(StoreRef::from_bump(bump.alloc(self)))
     }
 }
-impl BindingAlloc for crate::b::Array {
+impl<'arena> BindingAlloc<'arena> for crate::b::Array<'arena> {
     #[inline]
-    fn alloc_into_b(self, bump: &Arena) -> B {
+    fn alloc_into_b(self, bump: &Arena) -> B<'arena> {
         B::BArray(StoreRef::from_bump(bump.alloc(self)))
     }
 }
-impl BindingAlloc for crate::b::Object {
+impl<'arena> BindingAlloc<'arena> for crate::b::Object<'arena> {
     #[inline]
-    fn alloc_into_b(self, bump: &Arena) -> B {
+    fn alloc_into_b(self, bump: &Arena) -> B<'arena> {
         B::BObject(StoreRef::from_bump(bump.alloc(self)))
     }
 }
-impl BindingAlloc for crate::b::Missing {
+impl<'arena> BindingAlloc<'arena> for crate::b::Missing {
     #[inline]
-    fn alloc_into_b(self, _bump: &Arena) -> B {
+    fn alloc_into_b(self, _bump: &Arena) -> B<'arena> {
         B::BMissing(crate::b::Missing {})
     }
 }
 
-impl Binding {
+impl<'arena> Binding<'arena> {
     #[inline]
-    pub fn init(t: impl BindingInit, loc: crate::Loc) -> Binding {
+    pub fn init(t: impl BindingInit<'arena>, loc: crate::Loc) -> Binding<'arena> {
         #[cfg(debug_assertions)]
         ICOUNT.fetch_add(1, Ordering::Relaxed);
         Binding {
@@ -126,7 +126,7 @@ impl Binding {
         }
     }
     #[inline]
-    pub fn alloc(bump: &Arena, t: impl BindingAlloc, loc: crate::Loc) -> Binding {
+    pub fn alloc(bump: &Arena, t: impl BindingAlloc<'arena>, loc: crate::Loc) -> Binding<'arena> {
         #[cfg(debug_assertions)]
         ICOUNT.fetch_add(1, Ordering::Relaxed);
         Binding {
@@ -153,16 +153,16 @@ impl Binding {
 // ──────────────────────────────────────────────────────────────────────────
 
 #[derive(Copy, Clone)]
-pub struct ToExprWrapper {
+pub struct ToExprWrapper<'arena> {
     /// Back-reference to `P.arena`. `BackRef` invariant: the arena is owned by
     /// `P<'a>` and outlives every `ToExprWrapper` (which is stored on `P` and
     /// only used during the visit pass). `None` only for the pre-wire
     /// `dangling()` placeholder; niche-packed so layout matches `*const Arena`.
     arena: Option<bun_ptr::BackRef<Arena>>,
-    wrap: fn(*mut core::ffi::c_void, crate::Loc, Ref) -> Expr,
+    wrap: fn(*mut core::ffi::c_void, crate::Loc, Ref) -> Expr<'arena>,
 }
 
-impl ToExprWrapper {
+impl<'arena> ToExprWrapper<'arena> {
     /// Placeholder used in `P::init` before `prepare_for_visit_pass` wires the
     /// arena + trampoline.
     pub const fn dangling() -> Self {
@@ -179,7 +179,7 @@ impl ToExprWrapper {
     /// coerce to fn pointers, so this stays zero-cost like Zig's comptime fn.
     /// The `*mut P` itself is passed per-call via `Binding::to_expr`.
     #[inline]
-    pub fn new(arena: &Arena, wrap: fn(*mut core::ffi::c_void, crate::Loc, Ref) -> Expr) -> Self {
+    pub fn new(arena: &Arena, wrap: fn(*mut core::ffi::c_void, crate::Loc, Ref) -> Expr<'arena>) -> Self {
         Self {
             arena: Some(bun_ptr::BackRef::new(arena)),
             wrap,
@@ -187,7 +187,7 @@ impl ToExprWrapper {
     }
 
     #[inline]
-    pub fn wrap_identifier(&self, ctx: *mut core::ffi::c_void, loc: crate::Loc, ref_: Ref) -> Expr {
+    pub fn wrap_identifier(&self, ctx: *mut core::ffi::c_void, loc: crate::Loc, ref_: Ref) -> Expr<'arena> {
         (self.wrap)(ctx, loc, ref_)
     }
 
@@ -206,9 +206,9 @@ impl ToExprWrapper {
 /// that want the same per-(P, func) nominal type use this alias and construct
 /// via `ToExprWrapper::new`. Kept as a type alias (not a generic struct) so
 /// `P` can store two of these without threading its own generics through.
-pub type ToExpr = ToExprWrapper;
+pub type ToExpr<'arena> = ToExprWrapper<'arena>;
 
-impl Binding {
+impl<'arena> Binding<'arena> {
     /// Zig: `pub fn toExpr(binding: *const Binding, wrapper: anytype) Expr`.
     ///
     /// `ctx` is the type-erased `*mut P<..>` derived from the *caller's live*
@@ -220,18 +220,18 @@ impl Binding {
     /// `visitStmt.rs` (`p.to_expr_wrapper_namespace`) and the `&mut` call-site
     /// in `maybe.rs` (`&mut p.to_expr_wrapper_hoisted`) type-check without
     /// edits — `T: Borrow<T>` and `&mut T: Borrow<T>` are both blanket impls.
-    pub fn to_expr<W>(binding: &Binding, ctx: *mut core::ffi::c_void, wrapper: W) -> Expr
+    pub fn to_expr<W>(binding: &Binding<'arena>, ctx: *mut core::ffi::c_void, wrapper: W) -> Expr<'arena>
     where
-        W: core::borrow::Borrow<ToExprWrapper>,
+        W: core::borrow::Borrow<ToExprWrapper<'arena>>,
     {
         Self::to_expr_inner(binding, ctx, *wrapper.borrow())
     }
 
     fn to_expr_inner(
-        binding: &Binding,
+        binding: &Binding<'arena>,
         ctx: *mut core::ffi::c_void,
-        wrapper: ToExprWrapper,
-    ) -> Expr {
+        wrapper: ToExprWrapper<'arena>,
+    ) -> Expr<'arena> {
         let loc = binding.loc;
         match binding.data {
             B::BMissing(_) => Expr {
@@ -312,14 +312,14 @@ impl Binding {
 // rustc correctly proves they are never *read*; they are the data contract for
 // when the writer lands, not dead code.
 #[expect(dead_code)]
-pub struct Serializable {
+pub struct Serializable<'arena> {
     r#type: Tag,
     object: &'static [u8],
-    value: B,
+    value: B<'arena>,
     loc: crate::Loc,
 }
 
-impl Binding {
+impl<'arena> Binding<'arena> {
     pub fn json_stringify<W>(&self, writer: &mut W) -> Result<(), bun_core::Error>
     where
         W: BindingJsonWriter,
@@ -338,7 +338,7 @@ impl Binding {
 /// currently `&str`-only; this preserves the Zig call-shape until the JSON
 /// layer settles.
 pub trait BindingJsonWriter {
-    fn write(&mut self, value: Serializable) -> Result<(), bun_core::Error>;
+    fn write(&mut self, value: Serializable<'_>) -> Result<(), bun_core::Error>;
 }
 
 // ported from: src/js_parser/ast/Binding.zig

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -19,8 +19,8 @@ use bun_alloc::ArenaVecExt as _;
 // In Zig: `const string = []const u8;`
 // AST string fields are arena-owned (bulk-freed via Store/arena reset; never
 // individually freed). `StoreStr` is `StoreRef`'s `[u8]` sibling: a thin
-// lifetime-erased pointer with safe construction (no `transmute`) and
-// `Deref<Target=[u8]>` under the same valid-until-arena-reset contract.
+// pointer with safe construction (no `transmute`) and
+// `Deref<Target=[u8]>` tied to `'arena`.
 pub use crate::StoreStr as Str;
 
 /// This represents an internal property name that can be mangled. The symbol
@@ -43,15 +43,15 @@ impl Default for NameOfSymbol {
     }
 }
 
-pub struct Array {
-    pub items: ExprNodeList,
+pub struct Array<'arena> {
+    pub items: ExprNodeList<'arena>,
     pub comma_after_spread: Option<crate::Loc>,
     pub is_single_line: bool,
     pub is_parenthesized: bool,
     pub was_originally_macro: bool,
     pub close_bracket_loc: crate::Loc,
 }
-impl Default for Array {
+impl<'arena> Default for Array<'arena> {
     fn default() -> Self {
         Self {
             items: bun_alloc::AstAlloc::vec(),
@@ -67,8 +67,8 @@ impl Default for Array {
 // (signature mismatch: Vec takes only `n`; AST-crate variant with bump
 // arena pending) and `Expr::Data::*` deep matches. Un-gate with parser round.
 // Live subset of `Array` accessors needed by downstream crates (round-E unblock).
-impl Array {
-    pub const EMPTY: Array = Array {
+impl<'arena> Array<'arena> {
+    pub const EMPTY: Array<'arena> = Array {
         items: bun_alloc::AstAlloc::vec(),
         comma_after_spread: None,
         is_single_line: false,
@@ -80,30 +80,30 @@ impl Array {
     /// Zig: `pub fn push(this: *Array, arena, item) !void`.
     /// Phase A `Vec::append` uses the global arena; `_bump` is kept
     /// for call-site shape parity and the eventual bump-arena Vec.
-    pub fn push(&mut self, _bump: &Bump, item: Expr) -> Result<(), AllocError> {
+    pub fn push(&mut self, _bump: &Bump, item: Expr<'arena>) -> Result<(), AllocError> {
         VecExt::append(&mut self.items, item);
         Ok(())
     }
 
     #[inline]
-    pub fn slice(&self) -> &[Expr] {
+    pub fn slice(&self) -> &[Expr<'arena>] {
         self.items.slice()
     }
 }
 
-impl Array {
+impl<'arena> Array<'arena> {
     pub fn inline_spread_of_array_literals(
         &mut self,
         _bump: &Bump,
         estimated_count: usize,
-    ) -> Result<ExprNodeList, AllocError> {
+    ) -> Result<ExprNodeList<'arena>, AllocError> {
         // This over-allocates a little but it's fine
         // PERF(port): Zig allocated in arena; Phase-A Vec uses global arena.
         // `Expr.data` is an enum (validity invariant), so the Zig
         // `expandToCapacity` + index-walk pattern would form `&mut [Expr]`
         // over invalid bit patterns. Push into reserved capacity instead —
         // same allocation profile (one upfront `with_capacity`), no uninit.
-        let mut out: ExprNodeList =
+        let mut out: ExprNodeList<'arena> =
             ExprNodeList::init_capacity(estimated_count + self.items.len_u32() as usize);
         // PORT NOTE: reshaped for borrowck — iterate items via index so the &mut
         // borrow of `out` does not overlap a shared borrow of `self`.
@@ -148,9 +148,9 @@ impl Array {
     }
 }
 
-pub struct Unary {
+pub struct Unary<'arena> {
     pub op: crate::OpCode,
-    pub value: ExprNodeIndex,
+    pub value: ExprNodeIndex<'arena>,
     pub flags: UnaryFlags,
 }
 
@@ -193,9 +193,9 @@ bitflags::bitflags! {
     }
 }
 
-pub struct Binary {
-    pub left: ExprNodeIndex,
-    pub right: ExprNodeIndex,
+pub struct Binary<'arena> {
+    pub left: ExprNodeIndex<'arena>,
+    pub right: ExprNodeIndex<'arena>,
     pub op: crate::OpCode,
 }
 
@@ -231,9 +231,9 @@ pub struct NewTarget {
     pub range: crate::Range,
 }
 
-pub struct New {
-    pub target: ExprNodeIndex,
-    pub args: ExprNodeList,
+pub struct New<'arena> {
+    pub target: ExprNodeIndex<'arena>,
+    pub args: ExprNodeList<'arena>,
 
     /// True if there is a comment containing "@__PURE__" or "#__PURE__" preceding
     /// this call expression. See the comment inside ECall for more details.
@@ -241,7 +241,7 @@ pub struct New {
 
     pub close_parens_loc: crate::Loc,
 }
-impl Default for New {
+impl<'arena> Default for New<'arena> {
     fn default() -> Self {
         Self {
             target: ExprNodeIndex::EMPTY,
@@ -272,10 +272,10 @@ pub enum Special {
     ResolvedSpecifierString(u32),
 }
 
-pub struct Call {
+pub struct Call<'arena> {
     // Node:
-    pub target: ExprNodeIndex,
-    pub args: ExprNodeList,
+    pub target: ExprNodeIndex<'arena>,
+    pub args: ExprNodeList<'arena>,
     pub optional_chain: Option<OptionalChain>,
     pub is_direct_eval: bool,
     pub close_paren_loc: crate::Loc,
@@ -293,7 +293,7 @@ pub struct Call {
     /// Used when printing to generate the source prop on the fly
     pub was_jsx_element: bool,
 }
-impl Default for Call {
+impl<'arena> Default for Call<'arena> {
     fn default() -> Self {
         Self {
             target: ExprNodeIndex::EMPTY,
@@ -306,7 +306,7 @@ impl Default for Call {
         }
     }
 }
-impl Call {
+impl<'arena> Call<'arena> {
     pub fn has_same_flags_as(&self, b: &Call) -> bool {
         self.optional_chain == b.optional_chain
             && self.is_direct_eval == b.is_direct_eval
@@ -323,11 +323,11 @@ pub enum CallUnwrap {
     IfUnusedAndToStringSafe,
 }
 
-pub struct Dot {
+pub struct Dot<'arena> {
     // target is Node
-    pub target: ExprNodeIndex,
+    pub target: ExprNodeIndex<'arena>,
     // TODO(port): arena-owned slice
-    pub name: Str,
+    pub name: Str<'arena>,
     pub name_loc: crate::Loc,
     pub optional_chain: Option<OptionalChain>,
 
@@ -340,7 +340,7 @@ pub struct Dot {
     /// the call target but keeping any arguments with side effects.
     pub call_can_be_unwrapped_if_unused: CallUnwrap,
 }
-impl Default for Dot {
+impl<'arena> Default for Dot<'arena> {
     fn default() -> Self {
         Self {
             target: ExprNodeIndex::EMPTY,
@@ -352,7 +352,7 @@ impl Default for Dot {
         }
     }
 }
-impl Dot {
+impl<'arena> Dot<'arena> {
     pub fn has_same_flags_as(&self, b: &Dot) -> bool {
         // TODO(port): Zig refers to `a.is_direct_eval` which does not exist on Dot;
         // mirroring the (likely buggy) Zig literally would not compile. Preserving
@@ -363,29 +363,29 @@ impl Dot {
     }
 }
 
-pub struct Index {
-    pub index: ExprNodeIndex,
-    pub target: ExprNodeIndex,
+pub struct Index<'arena> {
+    pub index: ExprNodeIndex<'arena>,
+    pub target: ExprNodeIndex<'arena>,
     pub optional_chain: Option<OptionalChain>,
 }
-impl Index {
+impl<'arena> Index<'arena> {
     pub fn has_same_flags_as(&self, b: &Index) -> bool {
         self.optional_chain == b.optional_chain
     }
 }
 
-pub struct Arrow {
-    pub args: crate::StoreSlice<G::Arg>,
-    pub body: G::FnBody,
+pub struct Arrow<'arena> {
+    pub args: crate::StoreSlice<'arena, G::Arg<'arena>>,
+    pub body: G::FnBody<'arena>,
 
     pub is_async: bool,
     pub has_rest_arg: bool,
     /// Use shorthand if true and "Body" is a single return statement
     pub prefer_expr: bool,
 }
-impl Arrow {
+impl<'arena> Arrow<'arena> {
     // Zig `pub const noop_return_undefined: Arrow = .{ .body = .{ .stmts = &.{} } };`
-    pub const NOOP_RETURN_UNDEFINED: Arrow = Arrow {
+    pub const NOOP_RETURN_UNDEFINED: Arrow<'arena> = Arrow {
         args: crate::StoreSlice::EMPTY,
         body: G::FnBody {
             loc: crate::Loc::EMPTY,
@@ -396,7 +396,7 @@ impl Arrow {
         prefer_expr: false,
     };
 }
-impl Default for Arrow {
+impl<'arena> Default for Arrow<'arena> {
     fn default() -> Self {
         Self {
             args: crate::StoreSlice::EMPTY,
@@ -411,8 +411,8 @@ impl Default for Arrow {
     }
 }
 
-pub struct Function {
-    pub func: G::Fn,
+pub struct Function<'arena> {
+    pub func: G::Fn<'arena>,
 }
 
 /// 8-byte identifier expression payload. The three side-effect flags are packed
@@ -640,18 +640,18 @@ pub struct PrivateIdentifier {
 ///     This also skips extra state that we'd need to track.
 ///     If React Fast Refresh ends up using this later, then we can revisit this decision.
 ///  [0]: https://github.com/automerge/automerge/issues/177
-pub struct JSXElement {
+pub struct JSXElement<'arena> {
     /// JSX tag name
     /// `<div>` => E.String.init("div")
     /// `<MyComponent>` => E.Identifier{.ref = symbolPointingToMyComponent }
     /// null represents a fragment
-    pub tag: Option<ExprNodeIndex>,
+    pub tag: Option<ExprNodeIndex<'arena>>,
 
     /// JSX props
-    pub properties: G::PropertyList,
+    pub properties: G::PropertyList<'arena>,
 
     /// JSX element children `<div>{this_is_a_child_element}</div>`
-    pub children: ExprNodeList,
+    pub children: ExprNodeList<'arena>,
 
     /// needed to make sure parse and visit happen in the same order
     pub key_prop_index: i32,
@@ -660,7 +660,7 @@ pub struct JSXElement {
 
     pub close_tag_loc: crate::Loc,
 }
-impl Default for JSXElement {
+impl<'arena> Default for JSXElement<'arena> {
     fn default() -> Self {
         Self {
             tag: None,
@@ -745,11 +745,11 @@ impl Number {
     /// by calling out to the APIs in WebKit which are responsible for this operation.
     ///
     /// This can return `None` in wasm builds to avoid linking JSC
-    pub fn to_string(&self, bump: &Bump) -> Option<Str> {
+    pub fn to_string<'arena>(&self, bump: &Bump) -> Option<Str<'arena>> {
         Self::to_string_from_f64(self.value, bump)
     }
 
-    pub fn to_string_from_f64(value: f64, bump: &Bump) -> Option<Str> {
+    pub fn to_string_from_f64<'arena>(value: f64, bump: &Bump) -> Option<Str<'arena>> {
         if value == value.trunc() && (value < i32::MAX as f64 && value > i32::MIN as f64) {
             let int_value = value as i64;
             let abs = int_value.unsigned_abs();
@@ -854,12 +854,12 @@ macro_rules! impl_number_cast {
 }
 impl_number_cast!(u16, u32, u64, usize);
 
-pub struct BigInt {
+pub struct BigInt<'arena> {
     // TODO(port): arena-owned slice
-    pub value: Str,
+    pub value: Str<'arena>,
 }
-impl BigInt {
-    pub const EMPTY: BigInt = BigInt { value: Str::EMPTY };
+impl<'arena> BigInt<'arena> {
+    pub const EMPTY: BigInt<'arena> = BigInt { value: Str::EMPTY };
 
     pub fn json_stringify<W: crate::JsonWriter>(
         &self,
@@ -871,8 +871,8 @@ impl BigInt {
     // `toJS` alias deleted — lives in `js_parser_jsc` extension trait.
 }
 
-pub struct Object {
-    pub properties: G::PropertyList,
+pub struct Object<'arena> {
+    pub properties: G::PropertyList<'arena>,
     pub comma_after_spread: Option<crate::Loc>,
     pub is_single_line: bool,
     pub is_parenthesized: bool,
@@ -880,7 +880,7 @@ pub struct Object {
 
     pub close_brace_loc: crate::Loc,
 }
-impl Default for Object {
+impl<'arena> Default for Object<'arena> {
     fn default() -> Self {
         Self {
             properties: bun_alloc::AstAlloc::vec(),
@@ -895,39 +895,40 @@ impl Default for Object {
 
 /// used in TOML parser to merge properties.
 ///
-/// Phase A keeps node types lifetime-free, so `next` is a raw `*mut Rope`
-/// into the bump arena (Zig: `next: ?*Rope`). Segments are bulk-freed at
-/// arena reset.
-pub struct Rope {
-    pub head: Expr,
-    pub next: *mut Rope,
+/// `next` points into the bump arena (Zig: `next: ?*Rope`). `NonNull` (not
+/// `*mut`) so `Rope<'arena>` stays covariant in `'arena`. Segments are
+/// bulk-freed at arena reset.
+pub struct Rope<'arena> {
+    pub head: Expr<'arena>,
+    pub next: Option<core::ptr::NonNull<Rope<'arena>>>,
 }
-impl Rope {
-    pub fn append(&mut self, expr: Expr, bump: &Bump) -> Result<*mut Rope, AllocError> {
-        if let Some(mut next) = core::ptr::NonNull::new(self.next).map(StoreRef::from_non_null) {
+impl<'arena> Rope<'arena> {
+    pub fn append(
+        &mut self,
+        expr: Expr<'arena>,
+        bump: &Bump,
+    ) -> Result<core::ptr::NonNull<Rope<'arena>>, AllocError> {
+        if let Some(mut next) = self.next.map(StoreRef::from_non_null) {
             // Arena-allocated Rope nodes are uniquely owned by the chain at this
             // point in TOML parsing; route through `StoreRef::DerefMut` (the
             // arena-backed handle whose deref is centralised in `nodes.rs`).
             return next.append(expr, bump);
         }
-        let rope: *mut Rope = bump.alloc(Rope {
-            head: expr,
-            next: core::ptr::null_mut(),
-        });
-        self.next = rope;
+        let rope = core::ptr::NonNull::from(bump.alloc(Rope { head: expr, next: None }));
+        self.next = Some(rope);
         Ok(rope)
     }
 
     /// Re-borrow `next` as `Option<&Rope>`. Same `StoreRef` arena contract:
     /// the pointee is a bump allocation valid until arena reset. Centralises
     /// the one `unsafe` so the `set_rope`/`get_or_put_*`/`get_rope` walkers
-    /// don't repeat `if !next.is_null() { unsafe { &*next } }` at every hop.
+    /// don't repeat `unsafe { next.as_ref() }` at every hop.
     #[inline]
-    pub fn next_ref<'a>(&self) -> Option<&'a Rope> {
-        // SAFETY: `next` is either null or a bump-arena allocation valid until
-        // arena reset (Zig: `?*Rope`). Read-only borrow; no `&mut` alias is
-        // outstanding at any caller (the chain is fully built before walking).
-        unsafe { self.next.cast_const().as_ref() }
+    pub fn next_ref<'a>(&self) -> Option<&'a Rope<'arena>> {
+        // SAFETY: `next` is a bump-arena allocation valid until arena reset
+        // (Zig: `?*Rope`). Read-only borrow; no `&mut` alias is outstanding
+        // at any caller (the chain is fully built before walking).
+        self.next.map(|p| unsafe { &*p.as_ptr() })
     }
 }
 
@@ -948,16 +949,16 @@ impl From<SetError> for bun_core::Error {
     }
 }
 
-pub struct RopeQuery<'a> {
-    pub expr: Expr,
-    pub rope: &'a Rope,
+pub struct RopeQuery<'a, 'arena> {
+    pub expr: Expr<'arena>,
+    pub rope: &'a Rope<'arena>,
 }
 
 // ── live Object accessor surface (round-E unblock) ─────────────────────────
 // Adapted to the current `Vec` API (`append(v)`, `slice()`, `slice_mut()`).
 // `set_rope`/`get_or_put_array`/sort helpers stay in the gated impl below.
-impl Object {
-    pub const EMPTY: Object = Object {
+impl<'arena> Object<'arena> {
+    pub const EMPTY: Object<'arena> = Object {
         properties: bun_alloc::AstAlloc::vec(),
         comma_after_spread: None,
         is_single_line: false,
@@ -966,11 +967,11 @@ impl Object {
         close_brace_loc: crate::Loc::EMPTY,
     };
 
-    pub fn get(&self, key: &[u8]) -> Option<Expr> {
+    pub fn get(&self, key: &[u8]) -> Option<Expr<'arena>> {
         self.as_property(key).map(|q| q.expr)
     }
 
-    pub fn as_property(&self, name: &[u8]) -> Option<crate::expr::Query> {
+    pub fn as_property(&self, name: &[u8]) -> Option<crate::expr::Query<'arena>> {
         for (i, prop) in self.properties.slice().iter().enumerate() {
             let Some(value) = prop.value else { continue };
             let Some(key) = &prop.key else { continue };
@@ -1001,7 +1002,7 @@ impl Object {
         false
     }
 
-    pub fn put(&mut self, _bump: &Bump, key: &[u8], expr: Expr) -> Result<(), AllocError> {
+    pub fn put(&mut self, _bump: &Bump, key: &[u8], expr: Expr<'arena>) -> Result<(), AllocError> {
         if let Some(q) = self.as_property(key) {
             self.properties.slice_mut()[q.i as usize].value = Some(expr);
         } else {
@@ -1027,7 +1028,7 @@ impl Object {
 
     /// Walks `rope` segments, creating nested objects as needed, and returns
     /// the leaf `E.Object` expression (Zig: `getOrPutObject`).
-    pub fn get_or_put_object(&mut self, rope: &Rope, _bump: &Bump) -> Result<Expr, SetError> {
+    pub fn get_or_put_object(&mut self, rope: &Rope<'arena>, _bump: &Bump) -> Result<Expr<'arena>, SetError> {
         let head_key = match rope.head.data.e_string() {
             Some(s) => s.data,
             None => return Err(SetError::Clobber),
@@ -1087,8 +1088,8 @@ impl Object {
 }
 
 // `toJS` alias deleted — lives in `js_parser_jsc` extension trait.
-impl Object {
-    pub fn set(&mut self, key: Expr, _bump: &Bump, value: Expr) -> Result<(), SetError> {
+impl<'arena> Object<'arena> {
+    pub fn set(&mut self, key: Expr<'arena>, _bump: &Bump, value: Expr<'arena>) -> Result<(), SetError> {
         let head_key = match key.data.e_string() {
             Some(s) => s.data,
             None => return Err(SetError::Clobber),
@@ -1110,7 +1111,7 @@ impl Object {
     }
 
     // this is terribly, shamefully slow
-    pub fn set_rope(&mut self, rope: &Rope, bump: &Bump, value: Expr) -> Result<(), SetError> {
+    pub fn set_rope(&mut self, rope: &Rope<'arena>, bump: &Bump, value: Expr<'arena>) -> Result<(), SetError> {
         let head_key = match rope.head.data.e_string() {
             Some(s) => s.data,
             None => return Err(SetError::Clobber),
@@ -1172,7 +1173,7 @@ impl Object {
         Ok(())
     }
 
-    pub fn get_or_put_array(&mut self, rope: &Rope, bump: &Bump) -> Result<Expr, SetError> {
+    pub fn get_or_put_array(&mut self, rope: &Rope<'arena>, bump: &Bump) -> Result<Expr<'arena>, SetError> {
         let head_key = match rope.head.data.e_string() {
             Some(s) => s.data,
             None => return Err(SetError::Clobber),
@@ -1295,7 +1296,7 @@ static PACKAGE_JSON_SORT_MAP: phf::Map<&'static [u8], PackageJsonSortFields> = p
     b"exports" => PackageJsonSortFields::Exports,
 };
 
-fn package_json_sort_is_less_than(lhs: &G::Property, rhs: &G::Property) -> Ordering {
+fn package_json_sort_is_less_than<'arena>(lhs: &G::Property<'arena>, rhs: &G::Property<'arena>) -> Ordering {
     let mut lhs_key_size: u8 = PackageJsonSortFields::Fake as u8;
     let mut rhs_key_size: u8 = PackageJsonSortFields::Fake as u8;
 
@@ -1341,7 +1342,7 @@ fn package_json_sort_is_less_than(lhs: &G::Property, rhs: &G::Property) -> Order
     }
 }
 
-fn object_sorter_is_less_than(lhs: &G::Property, rhs: &G::Property) -> Ordering {
+fn object_sorter_is_less_than<'arena>(lhs: &G::Property<'arena>, rhs: &G::Property<'arena>) -> Ordering {
     let a = lhs
         .key
         .as_ref()
@@ -1361,31 +1362,31 @@ fn object_sorter_is_less_than(lhs: &G::Property, rhs: &G::Property) -> Ordering 
     a.cmp(&b)
 }
 
-pub struct Spread {
-    pub value: ExprNodeIndex,
+pub struct Spread<'arena> {
+    pub value: ExprNodeIndex<'arena>,
 }
 
 /// JavaScript string literal type
-pub struct EString {
+pub struct EString<'arena> {
     // A version of this where `utf8` and `value` are stored in a packed union, with len as a single u32 was attempted.
     // It did not improve benchmarks. Neither did converting this from a heap-allocated type to a stack-allocated type.
     // TODO: change this to *const anyopaque and change all uses to either .slice8() or .slice16()
     // TODO(port): arena-owned slice
-    pub data: Str,
+    pub data: Str<'arena>,
     pub prefer_template: bool,
 
     // A very simple rope implementation
     // We only use this for string folding, so this is kind of overkill
     // We don't need to deal with substrings
-    pub next: Option<StoreRef<EString>>,
-    pub end: Option<StoreRef<EString>>,
+    pub next: Option<StoreRef<'arena, EString<'arena>>>,
+    pub end: Option<StoreRef<'arena, EString<'arena>>>,
     pub rope_len: u32,
     pub is_utf16: bool,
 }
 // Export under the Zig name `String` as well; `EString` avoids colliding with bun_core::String.
 pub use EString as String;
 
-impl Default for EString {
+impl<'arena> Default for EString<'arena> {
     fn default() -> Self {
         Self {
             data: Str::EMPTY,
@@ -1399,7 +1400,7 @@ impl Default for EString {
 }
 
 // Minimal live surface for `IntoExprData` / `Data` / `lexer.rs` callers.
-impl EString {
+impl<'arena> EString<'arena> {
     #[inline]
     pub const fn is_utf8(&self) -> bool {
         !self.is_utf16
@@ -1463,7 +1464,7 @@ impl EString {
     /// E.String containing non-ascii characters may not fully work.
     /// https://github.com/oven-sh/bun/issues/11963
     /// More investigation is needed.
-    pub fn init_re_encode_utf8(utf8: &[u8], bump: &Bump) -> EString {
+    pub fn init_re_encode_utf8(utf8: &[u8], bump: &Bump) -> EString<'arena> {
         if strings::first_non_ascii(utf8).is_none() {
             Self::init(utf8)
         } else {
@@ -1492,7 +1493,7 @@ impl EString {
 // Subset of the gated impl below adapted to the current `bun_core` API
 // (`eql_long::<CHECK_LEN>`, no bump-arena `to_utf8_alloc`). Heavy
 // transcode/rope-clone paths stay gated.
-impl EString {
+impl<'arena> EString<'arena> {
     #[inline]
     pub fn len(&self) -> usize {
         if self.rope_len > 0 {
@@ -1613,13 +1614,13 @@ impl EString {
 // Ordering / equality / const-literal / rope-mutation helpers extracted from
 // the round-C draft below. `string_z`/`to_zig_string` remain gated on
 // `bun_core::ZStr` arena constructors.
-impl EString {
-    pub const CLASS: EString = EString::from_static(b"class");
-    pub const EMPTY: EString = EString::from_static(b"");
-    pub const TRUE: EString = EString::from_static(b"true");
-    pub const FALSE: EString = EString::from_static(b"false");
-    pub const NULL: EString = EString::from_static(b"null");
-    pub const UNDEFINED: EString = EString::from_static(b"undefined");
+impl<'arena> EString<'arena> {
+    pub const CLASS: EString<'arena> = EString::from_static(b"class");
+    pub const EMPTY: EString<'arena> = EString::from_static(b"");
+    pub const TRUE: EString<'arena> = EString::from_static(b"true");
+    pub const FALSE: EString<'arena> = EString::from_static(b"false");
+    pub const NULL: EString<'arena> = EString::from_static(b"null");
+    pub const UNDEFINED: EString<'arena> = EString::from_static(b"undefined");
 
     pub fn is_identifier(&mut self, bump: &Bump) -> bool {
         if !self.is_utf8() {
@@ -1631,7 +1632,7 @@ impl EString {
     /// Compares two strings lexicographically for JavaScript semantics.
     /// Both strings must share the same encoding (UTF-8 vs UTF-16).
     #[inline]
-    pub fn order(&self, other: &EString) -> Ordering {
+    pub fn order(&self, other: &EString<'arena>) -> Ordering {
         debug_assert!(self.is_utf8() == other.is_utf8());
         if self.is_utf8() {
             strings::order(&self.data, &other.data)
@@ -1640,7 +1641,7 @@ impl EString {
         }
     }
 
-    pub fn clone(&self, bump: &Bump) -> Result<EString, AllocError> {
+    pub fn clone(&self, bump: &Bump) -> Result<EString<'arena>, AllocError> {
         Ok(EString {
             data: Str::new(bump.alloc_slice_copy(&self.data)),
             prefer_template: self.prefer_template,
@@ -1671,7 +1672,7 @@ impl EString {
     }
 
     // Zig `eql(comptime _t: type, other: anytype)` — split by operand type.
-    pub fn eql_string(&self, other: &EString) -> bool {
+    pub fn eql_string(&self, other: &EString<'arena>) -> bool {
         if self.is_utf8() {
             if other.is_utf8() {
                 strings::eql_long(&self.data, &other.data, true)
@@ -1698,7 +1699,7 @@ impl EString {
     /// rope-ownership intent explicit; Zig sites that did `.* = other.*` use
     /// this instead.
     #[inline]
-    pub fn shallow_clone(&self) -> EString {
+    pub fn shallow_clone(&self) -> EString<'arena> {
         EString {
             data: self.data,
             prefer_template: self.prefer_template,
@@ -1725,7 +1726,7 @@ impl EString {
     /// `other` MUST be Store/arena-allocated (callers pass
     /// `Expr::init(EString, ...).data.e_string_mut()` or a freshly
     /// `Store::append`ed node); its address is captured as a `StoreRef`.
-    pub fn push(&mut self, other: &mut EString) {
+    pub fn push(&mut self, other: &mut EString<'arena>) {
         debug_assert!(self.is_utf8());
         debug_assert!(other.is_utf8());
 
@@ -1758,14 +1759,14 @@ impl EString {
 
     /// Cloning the rope string is rarely needed, see `foldStringAddition`'s
     /// comments and the 'edgecase/EnumInliningRopeStringPoison' test
-    pub fn clone_rope_nodes(s: &EString) -> EString {
+    pub fn clone_rope_nodes(s: &EString<'arena>) -> EString<'arena> {
         let mut root = s.shallow_clone();
         if let Some(first) = root.next {
             // Clone the first link, then walk the freshly-cloned chain via
             // `StoreRef` (safe `Deref`/`DerefMut`) instead of a raw `*mut`
             // cursor. Each cloned node's `next` still points at the original
             // chain (shallow clone), so re-clone link-by-link.
-            let mut tail: StoreRef<EString> =
+            let mut tail: StoreRef<'arena, EString<'arena>> =
                 crate::expr::data::Store::append(first.get().shallow_clone());
             root.next = Some(tail);
             while let Some(next) = tail.next {
@@ -1779,7 +1780,7 @@ impl EString {
     }
 }
 
-fn array_sorter_is_less_than(lhs: &Expr, rhs: &Expr) -> Ordering {
+fn array_sorter_is_less_than<'arena>(lhs: &Expr<'arena>, rhs: &Expr<'arena>) -> Ordering {
     lhs.data.e_string().unwrap().order(
         rhs.data
             .e_string()
@@ -1788,7 +1789,7 @@ fn array_sorter_is_less_than(lhs: &Expr, rhs: &Expr) -> Ordering {
     )
 }
 
-impl EString {
+impl<'arena> EString<'arena> {
     pub fn string_z<'b>(&self, bump: &'b Bump) -> Result<&'b bun_core::ZStr, AllocError> {
         // Zig: `if (self.isUTF8()) self.data else strings.toUTF8AllocZ(...)`, NUL-terminated.
         // Port: copy into the bump arena with a trailing NUL and wrap as `ZStr`.
@@ -1834,7 +1835,7 @@ impl EString {
     }
 }
 
-impl fmt::Display for EString {
+impl<'arena> fmt::Display for EString<'arena> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("E.String")?;
         if self.next.is_none() {
@@ -1866,58 +1867,58 @@ impl fmt::Display for EString {
 }
 
 // value is in the Node
-pub struct TemplatePart {
-    pub value: ExprNodeIndex,
+pub struct TemplatePart<'arena> {
+    pub value: ExprNodeIndex<'arena>,
     pub tail_loc: crate::Loc,
-    pub tail: TemplateContents,
+    pub tail: TemplateContents<'arena>,
 }
 
-pub struct Template {
-    pub tag: Option<ExprNodeIndex>,
+pub struct Template<'arena> {
+    pub tag: Option<ExprNodeIndex<'arena>>,
     /// Arena-owned mutable slice (Zig: `[]TemplatePart`). Stored as a
     /// `StoreSlice` so writers (`substitute_single_use_symbol_in_expr`, the
     /// visit pass, `foldStringAddition`) retain mutable provenance. Use
     /// `parts()` / `parts_mut()` for ergonomic access; never null.
-    pub parts: crate::StoreSlice<TemplatePart>,
-    pub head: TemplateContents,
+    pub parts: crate::StoreSlice<'arena, TemplatePart<'arena>>,
+    pub head: TemplateContents<'arena>,
 }
 
-impl Template {
+impl<'arena> Template<'arena> {
     /// Empty `StoreSlice<TemplatePart>` for parts-less templates (e.g. tagged
     /// no-substitution literals).
     #[inline]
-    pub fn empty_parts() -> crate::StoreSlice<TemplatePart> {
+    pub fn empty_parts() -> crate::StoreSlice<'arena, TemplatePart<'arena>> {
         crate::StoreSlice::EMPTY
     }
 
     #[inline]
-    pub fn parts(&self) -> &[TemplatePart] {
+    pub fn parts(&self) -> &[TemplatePart<'arena>] {
         self.parts.slice()
     }
 
     #[inline]
-    pub fn parts_mut(&mut self) -> &mut [TemplatePart] {
+    pub fn parts_mut(&mut self) -> &mut [TemplatePart<'arena>] {
         self.parts.slice_mut()
     }
 }
 
-pub enum TemplateContents {
-    Cooked(EString),
-    Raw(Str),
+pub enum TemplateContents<'arena> {
+    Cooked(EString<'arena>),
+    Raw(Str<'arena>),
 }
-impl TemplateContents {
+impl<'arena> TemplateContents<'arena> {
     pub fn is_utf8(&self) -> bool {
         matches!(self, TemplateContents::Cooked(c) if c.is_utf8())
     }
 
-    bun_core::enum_unwrap!(pub TemplateContents, Cooked => fn cooked / cooked_mut -> EString);
+    bun_core::enum_unwrap!(pub TemplateContents, Cooked => fn cooked / cooked_mut -> EString<'arena>);
 }
 
-impl TemplateContents {
+impl<'arena> TemplateContents<'arena> {
     /// Field-wise copy (Zig: `var part = part.*`). `EString` is structurally
     /// `Copy` but does not derive it; use `shallow_clone` for the cooked arm.
     #[inline]
-    pub(crate) fn shallow_clone(&self) -> TemplateContents {
+    pub(crate) fn shallow_clone(&self) -> TemplateContents<'arena> {
         match self {
             TemplateContents::Cooked(c) => TemplateContents::Cooked(c.shallow_clone()),
             TemplateContents::Raw(r) => TemplateContents::Raw(*r),
@@ -1925,9 +1926,9 @@ impl TemplateContents {
     }
 }
 
-impl Template {
+impl<'arena> Template<'arena> {
     /// "`a${'b'}c`" => "`abc`"
-    pub fn fold(&mut self, bump: &Bump, loc: crate::Loc) -> Expr {
+    pub fn fold(&mut self, bump: &Bump, loc: crate::Loc) -> Expr<'arena> {
         if self.tag.is_some()
             || (matches!(self.head, TemplateContents::Cooked(_)) && !self.head.cooked().is_utf8())
         {
@@ -2108,9 +2109,9 @@ impl Template {
     }
 }
 
-pub struct RegExp {
+pub struct RegExp<'arena> {
     // TODO(port): arena-owned slice
-    pub value: Str,
+    pub value: Str<'arena>,
 
     /// This exists for JavaScript bindings
     /// The RegExp constructor expects flags as a second argument.
@@ -2120,8 +2121,8 @@ pub struct RegExp {
     ///      ^
     pub flags_offset: Option<u16>,
 }
-impl RegExp {
-    pub const EMPTY: RegExp = RegExp {
+impl<'arena> RegExp<'arena> {
+    pub const EMPTY: RegExp<'arena> = RegExp {
         value: Str::EMPTY,
         flags_offset: None,
     };
@@ -2163,15 +2164,15 @@ impl RegExp {
     }
 }
 
-pub struct Await {
-    pub value: ExprNodeIndex,
+pub struct Await<'arena> {
+    pub value: ExprNodeIndex<'arena>,
 }
 
-pub struct Yield {
-    pub value: Option<ExprNodeIndex>,
+pub struct Yield<'arena> {
+    pub value: Option<ExprNodeIndex<'arena>>,
     pub is_star: bool,
 }
-impl Default for Yield {
+impl<'arena> Default for Yield<'arena> {
     fn default() -> Self {
         Self {
             value: None,
@@ -2180,10 +2181,10 @@ impl Default for Yield {
     }
 }
 
-pub struct If {
-    pub test_: ExprNodeIndex,
-    pub yes: ExprNodeIndex,
-    pub no: ExprNodeIndex,
+pub struct If<'arena> {
+    pub test_: ExprNodeIndex<'arena>,
+    pub yes: ExprNodeIndex<'arena>,
+    pub no: ExprNodeIndex<'arena>,
 }
 
 #[derive(Clone, Copy)]
@@ -2207,15 +2208,15 @@ pub struct RequireResolveString {
     // close_paren_loc: logger.Loc = logger.Loc.Empty,
 }
 
-pub struct InlinedEnum {
-    pub value: ExprNodeIndex,
+pub struct InlinedEnum<'arena> {
+    pub value: ExprNodeIndex<'arena>,
     // TODO(port): arena-owned slice
-    pub comment: Str,
+    pub comment: Str<'arena>,
 }
 
-pub struct Import {
-    pub expr: ExprNodeIndex,
-    pub options: ExprNodeIndex,
+pub struct Import<'arena> {
+    pub expr: ExprNodeIndex<'arena>,
+    pub options: ExprNodeIndex<'arena>,
     pub import_record_index: u32,
     // TODO:
     // Comments inside "import()" expressions have special meaning for Webpack.
@@ -2227,7 +2228,7 @@ pub struct Import {
     // more info: https://webpack.js.org/api/module-methods/#magic-comments.
     // leading_interior_comments: []G.Comment = &([_]G.Comment{}),
 }
-impl Import {
+impl<'arena> Import<'arena> {
     pub fn is_import_record_null(&self) -> bool {
         self.import_record_index == u32::MAX
     }

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -25,25 +25,25 @@ use crate::StoreStr as Str;
 // ───────────────────────────────────────────────────────────────────────────
 
 #[derive(Clone, Copy)]
-pub struct Expr {
+pub struct Expr<'arena> {
     pub loc: Loc,
-    pub data: Data,
+    pub data: Data<'arena>,
 }
 
-impl Default for Expr {
+impl<'arena> Default for Expr<'arena> {
     fn default() -> Self {
         Self::EMPTY
     }
 }
 
-impl Expr {
-    pub const EMPTY: Expr = Expr {
+impl<'arena> Expr<'arena> {
+    pub const EMPTY: Expr<'arena> = Expr {
         data: Data::EMissing(E::Missing {}),
         loc: Loc::EMPTY,
     };
 }
 
-impl Expr {
+impl<'arena> Expr<'arena> {
     pub fn is_anonymous_named(&self) -> bool {
         match self.data {
             Data::EArrow(_) => true,
@@ -71,7 +71,7 @@ impl Expr {
         self.data.can_be_moved()
     }
 
-    pub fn unwrap_inlined(self) -> Expr {
+    pub fn unwrap_inlined(self) -> Expr<'arena> {
         if let Data::EInlinedEnum(inlined) = self.data {
             return inlined.value;
         }
@@ -79,14 +79,14 @@ impl Expr {
     }
 
     #[inline]
-    pub fn init_identifier(ref_: Ref, loc: Loc) -> Expr {
+    pub fn init_identifier(ref_: Ref, loc: Loc) -> Expr<'arena> {
         Expr {
             loc,
             data: Data::EIdentifier(E::Identifier::init(ref_)),
         }
     }
 
-    pub fn to_empty(self) -> Expr {
+    pub fn to_empty(self) -> Expr<'arena> {
         Expr {
             data: Data::EMissing(E::Missing {}),
             loc: self.loc,
@@ -114,8 +114,8 @@ impl Expr {
     }
 }
 
-impl Expr {
-    pub fn clone_in(&self, bump: &Bump) -> Result<Expr, bun_core::Error> {
+impl<'arena> Expr<'arena> {
+    pub fn clone_in(&self, bump: &Bump) -> Result<Expr<'arena>, bun_core::Error> {
         // TODO(port): narrow error set
         Ok(Expr {
             loc: self.loc,
@@ -123,19 +123,23 @@ impl Expr {
         })
     }
 
-    pub fn deep_clone(&self, bump: &Bump) -> Result<Expr, AllocError> {
+    // TODO(arena-lifetimes): should be `fn deep_clone<'dst>(&self, bump: &'dst
+    // Bump) -> Expr<'dst>`. Blocked on the body shallow-copying `Str<'arena>`
+    // slices (`E::Dot::name`, `E::String::data`, …) — those must be duped into
+    // `bump` before the return lifetime can detach from `'arena`.
+    pub fn deep_clone(&self, bump: &Bump) -> Result<Expr<'arena>, AllocError> {
         let _g = bun_alloc::ast_alloc::DetachAstHeap::new();
         self.deep_clone_no_detach(bump)
     }
     #[inline]
-    fn deep_clone_no_detach(&self, bump: &Bump) -> Result<Expr, AllocError> {
+    fn deep_clone_no_detach(&self, bump: &Bump) -> Result<Expr<'arena>, AllocError> {
         Ok(Expr {
             loc: self.loc,
             data: self.data.deep_clone_no_detach(bump)?,
         })
     }
 
-    pub fn wrap_in_arrow(this: Expr, bump: &Bump) -> Result<Expr, bun_core::Error> {
+    pub fn wrap_in_arrow(this: Expr<'arena>, bump: &Bump) -> Result<Expr<'arena>, bun_core::Error> {
         // TODO(port): narrow error set
         let stmts: &mut [Stmt] = bump.alloc_slice_fill_with(1, |_| {
             Stmt::alloc(S::Return { value: Some(this) }, this.loc)
@@ -159,13 +163,13 @@ impl Expr {
 }
 
 #[derive(Clone, Copy)]
-pub struct Query {
-    pub expr: Expr,
+pub struct Query<'arena> {
+    pub expr: Expr<'arena>,
     pub loc: Loc,
     pub i: u32,
 }
 
-impl Default for Query {
+impl<'arena> Default for Query<'arena> {
     fn default() -> Self {
         Self {
             expr: Expr::EMPTY,
@@ -180,7 +184,7 @@ impl Default for Query {
 // Subset of the gated impl below; bodies adapted to the live `E::Object` /
 // `E::EString` surface added this round. The full set/get_path/rope helpers
 // stay gated.
-impl Expr {
+impl<'arena> Expr<'arena> {
     #[inline]
     pub fn is_array(&self) -> bool {
         matches!(self.data, Data::EArray(_))
@@ -196,7 +200,7 @@ impl Expr {
 
     /// Making this comptime bloats the binary and doesn't seem to impact
     /// runtime performance.
-    pub fn as_property(&self, name: &[u8]) -> Option<Query> {
+    pub fn as_property(&self, name: &[u8]) -> Option<Query<'arena>> {
         let Data::EObject(obj) = &self.data else {
             return None;
         };
@@ -206,16 +210,16 @@ impl Expr {
         obj.as_property(name)
     }
 
-    pub fn get(&self, name: &[u8]) -> Option<Expr> {
+    pub fn get(&self, name: &[u8]) -> Option<Expr<'arena>> {
         self.as_property(name).map(|q| q.expr)
     }
 
-    pub fn get_object(&self, name: &[u8]) -> Option<Expr> {
+    pub fn get_object(&self, name: &[u8]) -> Option<Expr<'arena>> {
         self.as_property(name)
             .and_then(|q| q.expr.is_object().then_some(q.expr))
     }
 
-    pub fn as_array(&self) -> Option<ArrayIterator> {
+    pub fn as_array(&self) -> Option<ArrayIterator<'arena>> {
         match &self.data {
             Data::EArray(array) => {
                 if array.items.len_u32() == 0 {
@@ -288,7 +292,7 @@ impl Expr {
 // blocked_on) and `Vec::deep_clone`. Types are real; bodies un-gate with
 // the parser round once those land.
 
-impl Expr {
+impl<'arena> Expr<'arena> {
     pub fn has_any_property_named(&self, names: &'static [&'static [u8]]) -> bool {
         let Data::EObject(obj) = &self.data else {
             return false;
@@ -319,7 +323,7 @@ impl Expr {
     /// Only use this for pretty-printing JSON. Do not use in transpiler.
     ///
     /// This does not handle edgecases like `-1` or stringifying arbitrary property lookups.
-    pub fn get_by_index(&self, index: u32, index_str: &[u8], bump: &Bump) -> Option<Expr> {
+    pub fn get_by_index(&self, index: u32, index_str: &[u8], bump: &Bump) -> Option<Expr<'arena>> {
         match &self.data {
             Data::EArray(array) => {
                 if index >= array.items.len_u32() {
@@ -380,7 +384,7 @@ impl Expr {
     /// This is not intended for use by the transpiler, instead by pretty printing JSON.
     // PORT NOTE: Zig passed `bun.default_allocator` to getByIndex; Rust threads the arena
     // explicitly because get_by_index allocates an E.String slice into &Bump.
-    pub fn get_path_may_be_index(&self, bump: &Bump, name: &[u8]) -> Option<Expr> {
+    pub fn get_path_may_be_index(&self, bump: &Bump, name: &[u8]) -> Option<Expr<'arena>> {
         if name.is_empty() {
             return None;
         }
@@ -434,7 +438,7 @@ impl Expr {
     ///
     /// Sets the value of a property, creating it if it doesn't exist.
     /// `self` must be an object.
-    pub fn set(&mut self, _bump: &Bump, name: &[u8], value: Expr) -> Result<(), AllocError> {
+    pub fn set(&mut self, _bump: &Bump, name: &[u8], value: Expr<'arena>) -> Result<(), AllocError> {
         debug_assert!(self.is_object());
         let Data::EObject(obj) = &mut self.data else {
             unreachable!()
@@ -579,9 +583,9 @@ impl Expr {
     }
 
     // PORT NOTE: `Query` holds `expr` by value (Copy). The iterator stores the
-    // `StoreRef<E::Array>` directly (Copy, arena-backed) so no lifetime is tied
+    // `StoreRef<'arena, E::Array<'arena>>` directly (Copy, arena-backed) so no lifetime is tied
     // to a local temporary — `StoreRef::Deref` re-borrows the arena slot on use.
-    pub fn get_array(&self, name: &[u8]) -> Option<ArrayIterator> {
+    pub fn get_array(&self, name: &[u8]) -> Option<ArrayIterator<'arena>> {
         let q = self.as_property(name)?;
         match q.expr.data {
             Data::EArray(array) => {
@@ -594,7 +598,7 @@ impl Expr {
         }
     }
 
-    pub fn get_rope<'a>(&self, rope: &'a E::Rope) -> Option<E::RopeQuery<'a>> {
+    pub fn get_rope<'a>(&self, rope: &'a E::Rope<'arena>) -> Option<E::RopeQuery<'a, 'arena>> {
         if let Some(existing) = self.get(&rope.head.data.as_e_string().unwrap().data) {
             match &existing.data {
                 Data::EArray(array) => {
@@ -690,15 +694,15 @@ impl Expr {
 // ArrayIterator
 // ───────────────────────────────────────────────────────────────────────────
 
-pub struct ArrayIterator {
+pub struct ArrayIterator<'arena> {
     /// Arena-backed handle (`StoreRef` invariant: pointee lives until arena
     /// reset). Stored by value so the iterator carries no borrowed lifetime.
-    pub array: StoreRef<E::Array>,
+    pub array: StoreRef<'arena, E::Array<'arena>>,
     pub index: u32,
 }
 
-impl ArrayIterator {
-    pub fn next(&mut self) -> Option<Expr> {
+impl<'arena> ArrayIterator<'arena> {
+    pub fn next(&mut self) -> Option<Expr<'arena>> {
         if self.index >= self.array.items.len_u32() {
             return None;
         }
@@ -714,7 +718,7 @@ impl ArrayIterator {
 // implementations above (lines ~231-315) with worse signatures (`expr: &Expr`,
 // raw-ptr returns). Those drafts were dropped during un-gating; only the methods
 // without a live counterpart remain.
-impl Expr {
+impl<'arena> Expr<'arena> {
     #[inline]
     pub fn as_string_literal<'b>(&self, bump: &'b Bump) -> Option<&'b [u8]> {
         let Data::EString(s) = &self.data else {
@@ -772,15 +776,15 @@ pub enum EFlags {
 }
 
 #[allow(dead_code)] // see gated `json_stringify` below
-struct Serializable {
+struct Serializable<'arena> {
     type_: Tag,
     object: &'static [u8],
-    value: Data,
+    value: Data<'arena>,
     loc: Loc,
 }
 
 // `is_missing` lives in the `init`/`allocate` impl block below (round-A hoist).
-impl Expr {
+impl<'arena> Expr<'arena> {
     /// The goal of this function is to "rotate" the AST if it's possible to use the
     /// left-associative property of the operator to avoid unnecessary parentheses.
     ///
@@ -791,7 +795,7 @@ impl Expr {
     // PERF(port): Zig took `comptime op: Op.Code`. `Op::Code` does not derive
     // `ConstParamTy` (Op.rs owns the enum); pass at runtime here. Revisit once
     // `Code` gains `ConstParamTy` — call sites are a handful of literal ops.
-    pub fn join_with_left_associative_op(op: Op::Code, a: Expr, b: Expr) -> Expr {
+    pub fn join_with_left_associative_op(op: Op::Code, a: Expr<'arena>, b: Expr<'arena>) -> Expr<'arena> {
         // "(a, b) op c" => "a, b op c"
         if let Data::EBinary(mut comma) = a.data {
             if comma.op == crate::OpCode::BinComma {
@@ -826,7 +830,7 @@ impl Expr {
     // PORT NOTE: Zig threaded `_: std.mem.Allocator` (unused) so the caller's
     // arena reached `Expr.init`. The Rust port uses the thread-local
     // `data::Store` and drops the parameter.
-    pub fn join_with_comma(self, b: Expr) -> Expr {
+    pub fn join_with_comma(self, b: Expr<'arena>) -> Expr<'arena> {
         if self.is_missing() {
             return b;
         }
@@ -843,7 +847,7 @@ impl Expr {
         )
     }
 
-    pub fn join_all_with_comma(all: &[Expr]) -> Expr {
+    pub fn join_all_with_comma(all: &[Expr<'arena>]) -> Expr<'arena> {
         debug_assert!(!all.is_empty());
         match all.len() {
             1 => all[0],
@@ -862,10 +866,10 @@ impl Expr {
     // each element. Rust passes `ctx` by `&mut` so a single `&mut P` (the parser
     // state) can be reborrowed for each callback invocation without `Copy`.
     pub fn join_all_with_comma_callback<C: ?Sized>(
-        all: &[Expr],
+        all: &[Expr<'arena>],
         ctx: &mut C,
-        callback: fn(ctx: &mut C, expr: Expr) -> Option<Expr>,
-    ) -> Option<Expr> {
+        callback: fn(ctx: &mut C, expr: Expr<'arena>) -> Option<Expr<'arena>>,
+    ) -> Option<Expr<'arena>> {
         match all.len() {
             0 => None,
             1 => callback(ctx, all[0]),
@@ -911,7 +915,7 @@ impl Expr {
         }
     }
 
-    pub fn extract_numeric_values_in_safe_range(left: &Data, right: &Data) -> Option<[f64; 2]> {
+    pub fn extract_numeric_values_in_safe_range(left: &Data<'arena>, right: &Data<'arena>) -> Option<[f64; 2]> {
         let l_value = left.extract_numeric_value()?;
         let r_value = right.extract_numeric_value()?;
 
@@ -934,7 +938,7 @@ impl Expr {
         Some([l_value, r_value])
     }
 
-    pub fn extract_numeric_values(left: &Data, right: &Data) -> Option<[f64; 2]> {
+    pub fn extract_numeric_values(left: &Data<'arena>, right: &Data<'arena>) -> Option<[f64; 2]> {
         Some([
             left.extract_numeric_value()?,
             right.extract_numeric_value()?,
@@ -942,10 +946,10 @@ impl Expr {
     }
 
     pub fn extract_string_values(
-        left: &Data,
-        right: &Data,
+        left: &Data<'arena>,
+        right: &Data<'arena>,
         bump: &Bump,
-    ) -> Option<[crate::StoreRef<E::String>; 2]> {
+    ) -> Option<[crate::StoreRef<'arena, E::String<'arena>>; 2]> {
         let mut l_string = Data::extract_string_value(*left)?;
         let mut r_string = Data::extract_string_value(*right)?;
         // `extract_string_value` returns the arena `StoreRef`; mutate via DerefMut.
@@ -963,7 +967,7 @@ impl Expr {
 // TODO(port): jsonStringify protocol — replace with serde or custom trait in
 // Phase B. Kept gated; `Serializable` is its payload shape.
 
-impl Expr {
+impl<'arena> Expr<'arena> {
     // PORT NOTE: Zig's `jsonStringify` fed `Serializable` to `std.json.stringify`.
     // The Rust port emits the same shape directly (no serde dependency).
     pub fn json_stringify(self_: &Expr, writer: &mut impl fmt::Write) -> fmt::Result {
@@ -1002,24 +1006,41 @@ pub static ICOUNT: core::sync::atomic::AtomicUsize = core::sync::atomic::AtomicU
 /// Trait implemented by every `E::*` payload type to construct an `Expr`.
 ///
 /// Replaces Zig's `comptime Type: type` switch in `Expr.init` / `Expr.allocate`.
-pub trait IntoExprData: Sized {
+pub trait IntoExprData<'arena>: Sized {
     /// Construct `Data` using the thread-local `Data::Store` arena (Zig: `Expr.init`).
-    fn into_data_store(self) -> Data;
+    fn into_data_store(self) -> Data<'arena>;
     /// Construct `Data` using a caller-supplied arena (Zig: `Expr.allocate`).
     /// Be careful to free the memory (or use an arena that does it for you).
-    fn into_data_alloc(self, bump: &Bump) -> Data;
+    fn into_data_alloc(self, bump: &Bump) -> Data<'arena>;
 }
 
 macro_rules! impl_into_expr_data_boxed {
     ($($ty:ident => $variant:ident),* $(,)?) => {
         $(
-            impl IntoExprData for E::$ty {
+            impl<'arena> IntoExprData<'arena> for E::$ty<'arena> {
                 #[inline]
-                fn into_data_store(self) -> Data {
+                fn into_data_store(self) -> Data<'arena> {
                     Data::$variant(data::Store::append(self))
                 }
                 #[inline]
-                fn into_data_alloc(self, bump: &Bump) -> Data {
+                fn into_data_alloc(self, bump: &Bump) -> Data<'arena> {
+                    Data::$variant(StoreRef::from_bump(bump.alloc(self)))
+                }
+            }
+        )*
+    };
+}
+
+macro_rules! impl_into_expr_data_boxed_nolife {
+    ($($ty:ident => $variant:ident),* $(,)?) => {
+        $(
+            impl<'arena> IntoExprData<'arena> for E::$ty {
+                #[inline]
+                fn into_data_store(self) -> Data<'arena> {
+                    Data::$variant(data::Store::append(self))
+                }
+                #[inline]
+                fn into_data_alloc(self, bump: &Bump) -> Data<'arena> {
                     Data::$variant(StoreRef::from_bump(bump.alloc(self)))
                 }
             }
@@ -1030,18 +1051,17 @@ macro_rules! impl_into_expr_data_boxed {
 macro_rules! impl_into_expr_data_inline {
     ($($ty:ident => $variant:ident),* $(,)?) => {
         $(
-            impl IntoExprData for E::$ty {
+            impl<'arena> IntoExprData<'arena> for E::$ty {
                 #[inline]
-                fn into_data_store(self) -> Data { Data::$variant(self) }
+                fn into_data_store(self) -> Data<'arena> { Data::$variant(self) }
                 #[inline]
-                fn into_data_alloc(self, _bump: &Bump) -> Data { Data::$variant(self) }
+                fn into_data_alloc(self, _bump: &Bump) -> Data<'arena> { Data::$variant(self) }
             }
         )*
     };
 }
 
 impl_into_expr_data_boxed! {
-    NameOfSymbol => ENameOfSymbol,
     Array => EArray,
     Class => EClass,
     Unary => EUnary,
@@ -1065,6 +1085,10 @@ impl_into_expr_data_boxed! {
     InlinedEnum => EInlinedEnum,
 }
 
+impl_into_expr_data_boxed_nolife! {
+    NameOfSymbol => ENameOfSymbol,
+}
+
 impl_into_expr_data_inline! {
     This => EThis,
     Boolean => EBoolean,
@@ -1082,35 +1106,35 @@ impl_into_expr_data_inline! {
 
 // E::Identifier — Zig copies fields explicitly (normalization). With the
 // packed-flag layout the struct is a single `Ref`, so the copy is trivial.
-impl IntoExprData for E::Identifier {
+impl<'arena> IntoExprData<'arena> for E::Identifier {
     #[inline]
-    fn into_data_store(self) -> Data {
+    fn into_data_store(self) -> Data<'arena> {
         Data::EIdentifier(self)
     }
     #[inline]
-    fn into_data_alloc(self, _bump: &Bump) -> Data {
+    fn into_data_alloc(self, _bump: &Bump) -> Data<'arena> {
         Data::EIdentifier(self)
     }
 }
 
-impl IntoExprData for E::ImportIdentifier {
+impl<'arena> IntoExprData<'arena> for E::ImportIdentifier {
     #[inline]
-    fn into_data_store(self) -> Data {
+    fn into_data_store(self) -> Data<'arena> {
         Data::EImportIdentifier(self)
     }
     #[inline]
-    fn into_data_alloc(self, _bump: &Bump) -> Data {
+    fn into_data_alloc(self, _bump: &Bump) -> Data<'arena> {
         Data::EImportIdentifier(self)
     }
 }
 
-impl IntoExprData for E::CommonJSExportIdentifier {
+impl<'arena> IntoExprData<'arena> for E::CommonJSExportIdentifier {
     #[inline]
-    fn into_data_store(self) -> Data {
+    fn into_data_store(self) -> Data<'arena> {
         Data::ECommonjsExportIdentifier(self)
     }
     #[inline]
-    fn into_data_alloc(self, _bump: &Bump) -> Data {
+    fn into_data_alloc(self, _bump: &Bump) -> Data<'arena> {
         // Packed layout collapses Zig's init()/allocate() distinction — `base`
         // rides inside `ref_`, so a single-word copy carries both regardless.
         Data::ECommonjsExportIdentifier(self)
@@ -1118,9 +1142,9 @@ impl IntoExprData for E::CommonJSExportIdentifier {
 }
 
 // E::EString — special debug assert + boxed
-impl IntoExprData for E::EString {
+impl<'arena> IntoExprData<'arena> for E::EString<'arena> {
     #[inline]
-    fn into_data_store(self) -> Data {
+    fn into_data_store(self) -> Data<'arena> {
         #[cfg(debug_assertions)]
         {
             // Sanity check: assert string is not a null ptr
@@ -1130,7 +1154,7 @@ impl IntoExprData for E::EString {
         }
         Data::EString(data::Store::append(self))
     }
-    fn into_data_alloc(self, bump: &Bump) -> Data {
+    fn into_data_alloc(self, bump: &Bump) -> Data<'arena> {
         #[cfg(debug_assertions)]
         {
             if !self.data.is_empty() && self.is_utf8() {
@@ -1144,23 +1168,23 @@ impl IntoExprData for E::EString {
 // *E.String — Zig allows passing a pointer to copy from. `EString` derives no
 // `Clone` (rope `next` ptr); Zig copies the struct bytes. Mirror with a
 // shallow field-copy.
-impl IntoExprData for &E::EString {
+impl<'arena> IntoExprData<'arena> for &E::EString<'arena> {
     #[inline]
-    fn into_data_store(self) -> Data {
+    fn into_data_store(self) -> Data<'arena> {
         Data::EString(data::Store::append(self.shallow_clone()))
     }
     #[inline]
-    fn into_data_alloc(self, bump: &Bump) -> Data {
+    fn into_data_alloc(self, bump: &Bump) -> Data<'arena> {
         Data::EString(StoreRef::from_bump(bump.alloc(self.shallow_clone())))
     }
 }
 
-impl Expr {
+impl<'arena> Expr<'arena> {
     /// When the lifetime of an Expr.Data's pointer must exist longer than reset() is called, use this function.
     /// Be careful to free the memory (or use an arena that does it for you)
     /// Also, prefer Expr.init or Expr.alloc when possible. This will be slower.
     #[inline]
-    pub fn allocate<T: IntoExprData>(bump: &Bump, st: T, loc: Loc) -> Expr {
+    pub fn allocate<T: IntoExprData<'arena>>(bump: &Bump, st: T, loc: Loc) -> Expr<'arena> {
         #[cfg(debug_assertions)]
         ICOUNT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
         data::Store::assert();
@@ -1171,7 +1195,7 @@ impl Expr {
     }
 
     #[inline]
-    pub fn init<T: IntoExprData>(st: T, loc: Loc) -> Expr {
+    pub fn init<T: IntoExprData<'arena>>(st: T, loc: Loc) -> Expr<'arena> {
         #[cfg(debug_assertions)]
         ICOUNT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
         data::Store::assert();
@@ -1191,7 +1215,7 @@ impl Expr {
         matches!(self.data, Data::EMissing(_))
     }
     #[inline]
-    pub fn assign(a: Expr, b: Expr) -> Expr {
+    pub fn assign(a: Expr<'arena>, b: Expr<'arena>) -> Expr<'arena> {
         Expr::init(
             E::Binary {
                 op: crate::OpCode::BinAssign,
@@ -1203,9 +1227,9 @@ impl Expr {
     }
 }
 
-pub type Disabler = DebugOnlyDisabler<Expr>;
+pub type Disabler = DebugOnlyDisabler<Expr<'static>>;
 
-impl Expr {
+impl<'arena> Expr<'arena> {
     #[inline]
     pub fn is_primitive_literal(&self) -> bool {
         Tag::is_primitive_literal(self.data.tag())
@@ -1463,7 +1487,7 @@ impl fmt::Display for Tag {
 // Expr methods (continued)
 // ───────────────────────────────────────────────────────────────────────────
 
-impl Expr {
+impl<'arena> Expr<'arena> {
     pub fn is_boolean(&self) -> bool {
         match self.data {
             Data::EBoolean(_) | Data::EBranchBoolean(_) => true,
@@ -1491,7 +1515,7 @@ impl Expr {
     // `assign` lives in the `init`/`allocate` impl block above (round-A hoist).
 
     #[inline]
-    pub fn at<T: IntoExprData>(&self, t: T) -> Expr {
+    pub fn at<T: IntoExprData<'arena>>(&self, t: T) -> Expr<'arena> {
         Expr::init(t, self.loc)
     }
 
@@ -1499,7 +1523,7 @@ impl Expr {
     // will potentially be simplified to avoid generating unnecessary extra "!"
     // operators. For example, calling this with "!!x" will return "!x" instead
     // of returning "!!!x".
-    pub fn not(&self, bump: &Bump) -> Expr {
+    pub fn not(&self, bump: &Bump) -> Expr<'arena> {
         self.maybe_simplify_not(bump).unwrap_or_else(|| {
             Expr::init(
                 E::Unary {
@@ -1527,7 +1551,7 @@ impl Expr {
     /// whole operator (i.e. the "!x") if it can be simplified, or false if not.
     /// It's separate from "Not()" above to avoid allocation on failure in case
     /// that is undesired.
-    pub fn maybe_simplify_not(&self, bump: &Bump) -> Option<Expr> {
+    pub fn maybe_simplify_not(&self, bump: &Bump) -> Option<Expr<'arena>> {
         let expr = self;
         match expr.data {
             Data::ENull(_) | Data::EUndefined(_) => {
@@ -1604,7 +1628,7 @@ impl Expr {
         None
     }
 
-    pub fn to_string_expr_without_side_effects(&self, bump: &Bump) -> Option<Expr> {
+    pub fn to_string_expr_without_side_effects(&self, bump: &Bump) -> Option<Expr<'arena>> {
         let expr = self;
         let unwrapped = expr.unwrap_inlined();
         let slice: Option<&[u8]> = match unwrapped.data {
@@ -1707,34 +1731,34 @@ impl PrimitiveType {
 // ───────────────────────────────────────────────────────────────────────────
 
 /// Tagged union of expression payloads. Pointer variants are arena-allocated
-/// `StoreRef<E::*>` (thin `NonNull` into `expr::data::Store` / a bump arena);
+/// `StoreRef<'arena, E::*>` (thin `NonNull` into `expr::data::Store` / a bump arena);
 /// inline variants are stored by value. `StoreRef` is `Copy` + `Deref`, so
 /// `Data` is `Copy` and `let Data::EBinary(b) = data; b.op` works (matching
 /// Zig's `data.e_binary.op`).
 #[derive(Clone, Copy, bun_core::EnumTag)]
 #[enum_tag(existing = Tag)]
-pub enum Data {
-    EArray(StoreRef<E::Array>),
-    EUnary(StoreRef<E::Unary>),
-    EBinary(StoreRef<E::Binary>),
-    EClass(StoreRef<E::Class>),
+pub enum Data<'arena> {
+    EArray(StoreRef<'arena, E::Array<'arena>>),
+    EUnary(StoreRef<'arena, E::Unary<'arena>>),
+    EBinary(StoreRef<'arena, E::Binary<'arena>>),
+    EClass(StoreRef<'arena, E::Class<'arena>>),
 
-    ENew(StoreRef<E::New>),
-    EFunction(StoreRef<E::Function>),
-    ECall(StoreRef<E::Call>),
-    EDot(StoreRef<E::Dot>),
-    EIndex(StoreRef<E::Index>),
-    EArrow(StoreRef<E::Arrow>),
+    ENew(StoreRef<'arena, E::New<'arena>>),
+    EFunction(StoreRef<'arena, E::Function<'arena>>),
+    ECall(StoreRef<'arena, E::Call<'arena>>),
+    EDot(StoreRef<'arena, E::Dot<'arena>>),
+    EIndex(StoreRef<'arena, E::Index<'arena>>),
+    EArrow(StoreRef<'arena, E::Arrow<'arena>>),
 
-    EJsxElement(StoreRef<E::JSXElement>),
-    EObject(StoreRef<E::Object>),
-    ESpread(StoreRef<E::Spread>),
-    ETemplate(StoreRef<E::Template>),
-    ERegExp(StoreRef<E::RegExp>),
-    EAwait(StoreRef<E::Await>),
-    EYield(StoreRef<E::Yield>),
-    EIf(StoreRef<E::If>),
-    EImport(StoreRef<E::Import>),
+    EJsxElement(StoreRef<'arena, E::JSXElement<'arena>>),
+    EObject(StoreRef<'arena, E::Object<'arena>>),
+    ESpread(StoreRef<'arena, E::Spread<'arena>>),
+    ETemplate(StoreRef<'arena, E::Template<'arena>>),
+    ERegExp(StoreRef<'arena, E::RegExp<'arena>>),
+    EAwait(StoreRef<'arena, E::Await<'arena>>),
+    EYield(StoreRef<'arena, E::Yield<'arena>>),
+    EIf(StoreRef<'arena, E::If<'arena>>),
+    EImport(StoreRef<'arena, E::Import<'arena>>),
 
     EIdentifier(E::Identifier),
     EImportIdentifier(E::ImportIdentifier),
@@ -1744,8 +1768,8 @@ pub enum Data {
     EBoolean(E::Boolean),
     EBranchBoolean(E::Boolean),
     ENumber(E::Number),
-    EBigInt(StoreRef<E::BigInt>),
-    EString(StoreRef<E::EString>),
+    EBigInt(StoreRef<'arena, E::BigInt<'arena>>),
+    EString(StoreRef<'arena, E::EString<'arena>>),
 
     ERequireString(E::RequireString),
     ERequireResolveString(E::RequireResolveString),
@@ -1767,9 +1791,9 @@ pub enum Data {
     /// places this is found it all follows similar handling.
     ESpecial(E::Special),
 
-    EInlinedEnum(StoreRef<E::InlinedEnum>),
+    EInlinedEnum(StoreRef<'arena, E::InlinedEnum<'arena>>),
 
-    ENameOfSymbol(StoreRef<E::NameOfSymbol>),
+    ENameOfSymbol(StoreRef<'arena, E::NameOfSymbol>),
 }
 
 // ── Layout guards ─────────────────────────────────────────────────────────
@@ -1785,15 +1809,15 @@ pub enum Data {
 // contributes a NonNull niche), so `None` packs into an unused bit-pattern
 // rather than adding a word. If a future variant adds `#[repr(C)]`/`#[repr(u32)]`
 // or a nullable `*mut T` payload, this assert catches the size regression.
-const _: () = assert!(core::mem::size_of::<Data>() == 16); // Do not increase the size of Expr
-const _: () = assert!(core::mem::size_of::<Expr>() == 24);
+const _: () = assert!(core::mem::size_of::<Data<'static>>() == 16); // Do not increase the size of Expr
+const _: () = assert!(core::mem::size_of::<Expr<'static>>() == 24);
 const _: () = assert!(
-    core::mem::size_of::<Option<Data>>() == core::mem::size_of::<Data>(),
+    core::mem::size_of::<Option<Data<'static>>>() == core::mem::size_of::<Data<'static>>(),
     "expr::Data lost its niche — check for #[repr] or nullable-ptr payload"
 );
 const _: () = assert!(
-    core::mem::size_of::<Option<Expr>>() == core::mem::size_of::<Expr>(),
-    "Expr lost its niche — Option<Expr> is used in G::Property/B::Property/etc."
+    core::mem::size_of::<Option<Expr<'static>>>() == core::mem::size_of::<Expr<'static>>(),
+    "Expr lost its niche — Option<Expr<'arena>> is used in G::Property/B::Property/etc."
 );
 // Inline-payload ceilings (regress any of these and `Data` grows past 16):
 const _: () = assert!(core::mem::size_of::<E::Identifier>() == 8);
@@ -1804,14 +1828,14 @@ const _: () = assert!(core::mem::size_of::<E::Number>() <= 8);
 const _: () = assert!(core::mem::size_of::<E::Special>() <= 8);
 const _: () = assert!(core::mem::size_of::<E::RequireString>() <= 8);
 const _: () = assert!(core::mem::size_of::<E::NewTarget>() <= 8);
-const _: () = assert!(core::mem::size_of::<StoreRef<E::Binary>>() == core::mem::size_of::<usize>());
+const _: () = assert!(core::mem::size_of::<StoreRef<'static, E::Binary<'static>>>() == core::mem::size_of::<usize>());
 
 // Zig field-style union accessors (`data.e_string`, `data.e_object`). The
 // match arms in this file use these heavily; keeping them as inherent methods
 // avoids rewriting ~25 sites. Returns `Option<StoreRef<T>>` (Copy).
-impl Data {
+impl<'arena> Data<'arena> {
     #[inline]
-    pub fn e_string(&self) -> Option<StoreRef<E::EString>> {
+    pub fn e_string(&self) -> Option<StoreRef<'arena, E::EString<'arena>>> {
         if let Data::EString(s) = *self {
             Some(s)
         } else {
@@ -1819,7 +1843,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_string_mut(&mut self) -> Option<&mut E::EString> {
+    pub fn e_string_mut(&mut self) -> Option<&mut E::EString<'arena>> {
         if let Data::EString(s) = self {
             Some(&mut **s)
         } else {
@@ -1827,7 +1851,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_object(&self) -> Option<StoreRef<E::Object>> {
+    pub fn e_object(&self) -> Option<StoreRef<'arena, E::Object<'arena>>> {
         if let Data::EObject(o) = *self {
             Some(o)
         } else {
@@ -1835,7 +1859,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_array(&self) -> Option<StoreRef<E::Array>> {
+    pub fn e_array(&self) -> Option<StoreRef<'arena, E::Array<'arena>>> {
         if let Data::EArray(a) = *self {
             Some(a)
         } else {
@@ -1843,7 +1867,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_array_mut(&mut self) -> Option<&mut E::Array> {
+    pub fn e_array_mut(&mut self) -> Option<&mut E::Array<'arena>> {
         if let Data::EArray(a) = self {
             Some(&mut **a)
         } else {
@@ -1851,7 +1875,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_object_mut(&mut self) -> Option<&mut E::Object> {
+    pub fn e_object_mut(&mut self) -> Option<&mut E::Object<'arena>> {
         if let Data::EObject(o) = self {
             Some(&mut **o)
         } else {
@@ -1859,26 +1883,26 @@ impl Data {
         }
     }
     #[inline]
-    pub fn as_e_string(&self) -> Option<StoreRef<E::EString>> {
+    pub fn as_e_string(&self) -> Option<StoreRef<'arena, E::EString<'arena>>> {
         self.e_string()
     }
     /// Zig: `data.e_array` field-access. Mirrors `e_array()`; provided under
     /// the `as_*` name for downstream crates ported from `.e_array.*`.
     #[inline]
-    pub fn as_e_array(&self) -> Option<StoreRef<E::Array>> {
+    pub fn as_e_array(&self) -> Option<StoreRef<'arena, E::Array<'arena>>> {
         self.e_array()
     }
     /// Zig: `data.e_object` field-access. Panics if not an object — callers
     /// gate with `is_object()` / `is_e_object()` first (mirrors Zig union
     /// access).
     #[inline]
-    pub fn as_e_object(&self) -> StoreRef<E::Object> {
+    pub fn as_e_object(&self) -> StoreRef<'arena, E::Object<'arena>> {
         self.e_object()
             .expect("ExprData::as_e_object on non-object")
     }
     /// Zig: `data.e_object` field-access (mutable).
     #[inline]
-    pub fn as_e_object_mut(&mut self) -> &mut E::Object {
+    pub fn as_e_object_mut(&mut self) -> &mut E::Object<'arena> {
         self.e_object_mut()
             .expect("ExprData::as_e_object_mut on non-object")
     }
@@ -1908,12 +1932,12 @@ impl Data {
         matches!(self, Data::ENumber(_))
     }
 
-    // ── Remaining StoreRef<E::*> field-style accessors ──────────────────
+    // ── Remaining StoreRef<'arena, E::*> field-style accessors ──────────────────
     // visitExpr / maybe.rs port from Zig's `data.e_dot.*` etc., which are
     // unchecked union field reads. Rust callers `.unwrap()` (or pattern-match)
     // — the `Option` is the cheapest sound encoding of Zig's UB-on-mismatch.
     #[inline]
-    pub fn e_unary(&self) -> Option<StoreRef<E::Unary>> {
+    pub fn e_unary(&self) -> Option<StoreRef<'arena, E::Unary<'arena>>> {
         if let Data::EUnary(v) = *self {
             Some(v)
         } else {
@@ -1921,7 +1945,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_unary_mut(&mut self) -> Option<&mut E::Unary> {
+    pub fn e_unary_mut(&mut self) -> Option<&mut E::Unary<'arena>> {
         if let Data::EUnary(v) = self {
             Some(&mut **v)
         } else {
@@ -1929,7 +1953,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_binary(&self) -> Option<StoreRef<E::Binary>> {
+    pub fn e_binary(&self) -> Option<StoreRef<'arena, E::Binary<'arena>>> {
         if let Data::EBinary(v) = *self {
             Some(v)
         } else {
@@ -1937,7 +1961,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_binary_mut(&mut self) -> Option<&mut E::Binary> {
+    pub fn e_binary_mut(&mut self) -> Option<&mut E::Binary<'arena>> {
         if let Data::EBinary(v) = self {
             Some(&mut **v)
         } else {
@@ -1945,7 +1969,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_class(&self) -> Option<StoreRef<E::Class>> {
+    pub fn e_class(&self) -> Option<StoreRef<'arena, E::Class<'arena>>> {
         if let Data::EClass(v) = *self {
             Some(v)
         } else {
@@ -1953,7 +1977,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_class_mut(&mut self) -> Option<&mut E::Class> {
+    pub fn e_class_mut(&mut self) -> Option<&mut E::Class<'arena>> {
         if let Data::EClass(v) = self {
             Some(&mut **v)
         } else {
@@ -1961,7 +1985,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_new(&self) -> Option<StoreRef<E::New>> {
+    pub fn e_new(&self) -> Option<StoreRef<'arena, E::New<'arena>>> {
         if let Data::ENew(v) = *self {
             Some(v)
         } else {
@@ -1969,7 +1993,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_new_mut(&mut self) -> Option<&mut E::New> {
+    pub fn e_new_mut(&mut self) -> Option<&mut E::New<'arena>> {
         if let Data::ENew(v) = self {
             Some(&mut **v)
         } else {
@@ -1977,7 +2001,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_function(&self) -> Option<StoreRef<E::Function>> {
+    pub fn e_function(&self) -> Option<StoreRef<'arena, E::Function<'arena>>> {
         if let Data::EFunction(v) = *self {
             Some(v)
         } else {
@@ -1985,7 +2009,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_function_mut(&mut self) -> Option<&mut E::Function> {
+    pub fn e_function_mut(&mut self) -> Option<&mut E::Function<'arena>> {
         if let Data::EFunction(v) = self {
             Some(&mut **v)
         } else {
@@ -1993,7 +2017,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_call(&self) -> Option<StoreRef<E::Call>> {
+    pub fn e_call(&self) -> Option<StoreRef<'arena, E::Call<'arena>>> {
         if let Data::ECall(v) = *self {
             Some(v)
         } else {
@@ -2001,7 +2025,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_call_mut(&mut self) -> Option<&mut E::Call> {
+    pub fn e_call_mut(&mut self) -> Option<&mut E::Call<'arena>> {
         if let Data::ECall(v) = self {
             Some(&mut **v)
         } else {
@@ -2009,7 +2033,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_dot(&self) -> Option<StoreRef<E::Dot>> {
+    pub fn e_dot(&self) -> Option<StoreRef<'arena, E::Dot<'arena>>> {
         if let Data::EDot(v) = *self {
             Some(v)
         } else {
@@ -2017,7 +2041,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_dot_mut(&mut self) -> Option<&mut E::Dot> {
+    pub fn e_dot_mut(&mut self) -> Option<&mut E::Dot<'arena>> {
         if let Data::EDot(v) = self {
             Some(&mut **v)
         } else {
@@ -2025,7 +2049,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_index(&self) -> Option<StoreRef<E::Index>> {
+    pub fn e_index(&self) -> Option<StoreRef<'arena, E::Index<'arena>>> {
         if let Data::EIndex(v) = *self {
             Some(v)
         } else {
@@ -2033,7 +2057,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_index_mut(&mut self) -> Option<&mut E::Index> {
+    pub fn e_index_mut(&mut self) -> Option<&mut E::Index<'arena>> {
         if let Data::EIndex(v) = self {
             Some(&mut **v)
         } else {
@@ -2041,7 +2065,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_arrow(&self) -> Option<StoreRef<E::Arrow>> {
+    pub fn e_arrow(&self) -> Option<StoreRef<'arena, E::Arrow<'arena>>> {
         if let Data::EArrow(v) = *self {
             Some(v)
         } else {
@@ -2049,7 +2073,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_arrow_mut(&mut self) -> Option<&mut E::Arrow> {
+    pub fn e_arrow_mut(&mut self) -> Option<&mut E::Arrow<'arena>> {
         if let Data::EArrow(v) = self {
             Some(&mut **v)
         } else {
@@ -2057,7 +2081,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_jsx_element(&self) -> Option<StoreRef<E::JSXElement>> {
+    pub fn e_jsx_element(&self) -> Option<StoreRef<'arena, E::JSXElement<'arena>>> {
         if let Data::EJsxElement(v) = *self {
             Some(v)
         } else {
@@ -2065,7 +2089,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_jsx_element_mut(&mut self) -> Option<&mut E::JSXElement> {
+    pub fn e_jsx_element_mut(&mut self) -> Option<&mut E::JSXElement<'arena>> {
         if let Data::EJsxElement(v) = self {
             Some(&mut **v)
         } else {
@@ -2073,7 +2097,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_spread(&self) -> Option<StoreRef<E::Spread>> {
+    pub fn e_spread(&self) -> Option<StoreRef<'arena, E::Spread<'arena>>> {
         if let Data::ESpread(v) = *self {
             Some(v)
         } else {
@@ -2081,7 +2105,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_spread_mut(&mut self) -> Option<&mut E::Spread> {
+    pub fn e_spread_mut(&mut self) -> Option<&mut E::Spread<'arena>> {
         if let Data::ESpread(v) = self {
             Some(&mut **v)
         } else {
@@ -2089,7 +2113,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_template(&self) -> Option<StoreRef<E::Template>> {
+    pub fn e_template(&self) -> Option<StoreRef<'arena, E::Template<'arena>>> {
         if let Data::ETemplate(v) = *self {
             Some(v)
         } else {
@@ -2097,7 +2121,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_template_mut(&mut self) -> Option<&mut E::Template> {
+    pub fn e_template_mut(&mut self) -> Option<&mut E::Template<'arena>> {
         if let Data::ETemplate(v) = self {
             Some(&mut **v)
         } else {
@@ -2105,7 +2129,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_reg_exp(&self) -> Option<StoreRef<E::RegExp>> {
+    pub fn e_reg_exp(&self) -> Option<StoreRef<'arena, E::RegExp<'arena>>> {
         if let Data::ERegExp(v) = *self {
             Some(v)
         } else {
@@ -2113,7 +2137,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_await(&self) -> Option<StoreRef<E::Await>> {
+    pub fn e_await(&self) -> Option<StoreRef<'arena, E::Await<'arena>>> {
         if let Data::EAwait(v) = *self {
             Some(v)
         } else {
@@ -2121,7 +2145,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_await_mut(&mut self) -> Option<&mut E::Await> {
+    pub fn e_await_mut(&mut self) -> Option<&mut E::Await<'arena>> {
         if let Data::EAwait(v) = self {
             Some(&mut **v)
         } else {
@@ -2129,7 +2153,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_yield(&self) -> Option<StoreRef<E::Yield>> {
+    pub fn e_yield(&self) -> Option<StoreRef<'arena, E::Yield<'arena>>> {
         if let Data::EYield(v) = *self {
             Some(v)
         } else {
@@ -2137,7 +2161,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_yield_mut(&mut self) -> Option<&mut E::Yield> {
+    pub fn e_yield_mut(&mut self) -> Option<&mut E::Yield<'arena>> {
         if let Data::EYield(v) = self {
             Some(&mut **v)
         } else {
@@ -2145,7 +2169,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_if(&self) -> Option<StoreRef<E::If>> {
+    pub fn e_if(&self) -> Option<StoreRef<'arena, E::If<'arena>>> {
         if let Data::EIf(v) = *self {
             Some(v)
         } else {
@@ -2153,7 +2177,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_if_mut(&mut self) -> Option<&mut E::If> {
+    pub fn e_if_mut(&mut self) -> Option<&mut E::If<'arena>> {
         if let Data::EIf(v) = self {
             Some(&mut **v)
         } else {
@@ -2161,7 +2185,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_import(&self) -> Option<StoreRef<E::Import>> {
+    pub fn e_import(&self) -> Option<StoreRef<'arena, E::Import<'arena>>> {
         if let Data::EImport(v) = *self {
             Some(v)
         } else {
@@ -2169,7 +2193,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_import_mut(&mut self) -> Option<&mut E::Import> {
+    pub fn e_import_mut(&mut self) -> Option<&mut E::Import<'arena>> {
         if let Data::EImport(v) = self {
             Some(&mut **v)
         } else {
@@ -2177,7 +2201,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_big_int(&self) -> Option<StoreRef<E::BigInt>> {
+    pub fn e_big_int(&self) -> Option<StoreRef<'arena, E::BigInt<'arena>>> {
         if let Data::EBigInt(v) = *self {
             Some(v)
         } else {
@@ -2185,7 +2209,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_inlined_enum(&self) -> Option<StoreRef<E::InlinedEnum>> {
+    pub fn e_inlined_enum(&self) -> Option<StoreRef<'arena, E::InlinedEnum<'arena>>> {
         if let Data::EInlinedEnum(v) = *self {
             Some(v)
         } else {
@@ -2193,7 +2217,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn e_name_of_symbol(&self) -> Option<StoreRef<E::NameOfSymbol>> {
+    pub fn e_name_of_symbol(&self) -> Option<StoreRef<'arena, E::NameOfSymbol>> {
         if let Data::ENameOfSymbol(v) = *self {
             Some(v)
         } else {
@@ -2286,14 +2310,14 @@ impl Data {
     }
 }
 
-impl Data {
+impl<'arena> Data<'arena> {
     /// Human-readable variant name for diagnostics (`"string"`, `"object"`, …).
     #[inline]
     pub fn tag_name(&self) -> &'static str {
         self.tag().into()
     }
 
-    // Zig: `pub fn as(data: Data, comptime tag: Tag) ?@FieldType(Data, @tagName(tag))`
+    // Zig: `pub fn as(data: Data<'arena>, comptime tag: Tag) ?@FieldType(Data, @tagName(tag))`
     // Rust has no field-by-tag reflection. Per-variant `as_*` accessors live
     // alongside the enum decl above (`e_string`/`e_object`/...).
     pub fn as_e_identifier(&self) -> Option<E::Identifier> {
@@ -2303,7 +2327,7 @@ impl Data {
             None
         }
     }
-    pub fn as_e_inlined_enum(&self) -> Option<StoreRef<E::InlinedEnum>> {
+    pub fn as_e_inlined_enum(&self) -> Option<StoreRef<'arena, E::InlinedEnum<'arena>>> {
         if let Data::EInlinedEnum(i) = *self {
             Some(i)
         } else {
@@ -2319,7 +2343,7 @@ impl Data {
 // with `P.rs`/`Parser.rs`. The *types* (`Data`/`Expr`/`Tag`/`Store`) are real;
 // only these method bodies wait. The round-B verify gate covers what's live.
 
-impl Data {
+impl<'arena> Data<'arena> {
     /// Shallow clone: re-allocate the boxed payload (so the caller owns a fresh
     /// arena slot) but don't recurse into children. Zig: `Data.clone`.
     ///
@@ -2328,7 +2352,7 @@ impl Data {
     /// with a `core::ptr::read` of the payload, which is sound because every
     /// payload is `Copy`-shaped (no `Drop`, no owned heap state — `Vec`
     /// stores a raw pointer + len/cap into the arena).
-    pub fn clone_in(this: Data, bump: &Bump) -> Result<Data, bun_core::Error> {
+    pub fn clone_in(this: Data<'arena>, bump: &Bump) -> Result<Data<'arena>, bun_core::Error> {
         // TODO(port): narrow error set
         macro_rules! shallow {
             ($variant:ident, $el:expr) => {{
@@ -2377,12 +2401,13 @@ impl Data {
     /// those vecs land on global mimalloc. The guard is installed once here
     /// and at [`Expr::deep_clone`]; the recursive body goes through
     /// `*_no_detach` so we don't pay 3 TLS ops per node.
-    pub fn deep_clone(&self, bump: &Bump) -> Result<Data, AllocError> {
+    // TODO(arena-lifetimes): see `Expr::deep_clone`.
+    pub fn deep_clone(&self, bump: &Bump) -> Result<Data<'arena>, AllocError> {
         let _g = bun_alloc::ast_alloc::DetachAstHeap::new();
         self.deep_clone_no_detach(bump)
     }
 
-    fn deep_clone_no_detach(&self, bump: &Bump) -> Result<Data, AllocError> {
+    fn deep_clone_no_detach(&self, bump: &Bump) -> Result<Data<'arena>, AllocError> {
         let this = *self;
         match &this {
             Data::EArray(el) => {
@@ -2621,7 +2646,7 @@ impl Data {
     }
 } // end `impl Data` (clone_in/deep_clone)
 
-impl Data {
+impl<'arena> Data<'arena> {
     /// `hasher` should be something with `fn update(&[u8])`;
     /// symbol table is passed to serialize `Ref` as identifier names instead of nondeterministic numbers.
     ///
@@ -2633,7 +2658,7 @@ impl Data {
     pub fn write_to_hasher<H, S>(&self, hasher: &mut H, symbol_table: &mut S)
     where
         H: bun_core::Hasher + ?Sized,
-        S: crate::base::SymbolTable + ?Sized,
+        S: crate::base::SymbolTable<'arena> + ?Sized,
     {
         // Local mirror of `bun.writeAnyToHasher` for padding-free POD —
         // `bun_core::write_any_to_hasher` is bound by `AsBytes` (ints only) and
@@ -2645,7 +2670,7 @@ impl Data {
             h.update(bytemuck::bytes_of(&v));
         }
         #[inline(always)]
-        fn name_of<H: bun_core::Hasher + ?Sized, S: crate::base::SymbolTable + ?Sized>(
+        fn name_of<'arena, H: bun_core::Hasher + ?Sized, S: crate::base::SymbolTable<'arena> + ?Sized>(
             h: &mut H,
             symbol_table: &mut S,
             r: Ref,
@@ -2710,7 +2735,7 @@ impl Data {
             }
             Data::EYield(e) => {
                 // TODO(port): Zig hashed the raw bytes of `.{ e.is_star, e.value }` (the full
-                // `?Expr` optional, including loc/data pointer). Rust `Option<Expr>` layout is
+                // `?Expr` optional, including loc/data pointer). Rust `Option<Expr<'arena>>` layout is
                 // not byte-compatible, so we hash the discriminant here and recurse below.
                 raw(hasher, e.is_star);
                 raw(hasher, e.value.is_some());
@@ -2784,7 +2809,7 @@ impl Data {
     }
 }
 
-impl Data {
+impl<'arena> Data<'arena> {
     /// "const values" here refers to expressions that can participate in constant
     /// inlining, as they have no side effects on instantiation, and there would be
     /// no observable difference if duplicated. This is a subset of canBeMoved()
@@ -2989,7 +3014,7 @@ impl Data {
         }
     }
 
-    pub fn merge_known_primitive(&self, rhs: &Data) -> PrimitiveType {
+    pub fn merge_known_primitive(&self, rhs: &Data<'arena>) -> PrimitiveType {
         PrimitiveType::merge(self.known_primitive(), rhs.known_primitive())
     }
 
@@ -3070,7 +3095,7 @@ impl Data {
         }
     }
 
-    pub fn extract_string_value(data: Data) -> Option<crate::StoreRef<E::String>> {
+    pub fn extract_string_value(data: Data<'arena>) -> Option<crate::StoreRef<'arena, E::String<'arena>>> {
         match data {
             Data::EString(s) => Some(s),
             Data::EInlinedEnum(inlined) => match inlined.value.data {
@@ -3153,11 +3178,11 @@ pub trait EqlParser {
 }
 // `impl EqlParser for P<...>` lives in `bun_js_parser` (next to `P`).
 
-impl Data {
+impl<'arena> Data<'arena> {
     // Returns "equal, ok". If "ok" is false, then nothing is known about the two
     // values. If "ok" is true, the equality or inequality of the two values is
     // stored in "equal".
-    pub fn eql<P: EqlParser, K: EqlKindT>(left: &Data, right: &Data, p: &mut P) -> Equality {
+    pub fn eql<P: EqlParser, K: EqlKindT>(left: &Data<'arena>, right: &Data<'arena>, p: &mut P) -> Equality {
         // https://dorey.github.io/JavaScript-Equality-Table/
         match left {
             Data::EInlinedEnum(inlined) => {
@@ -3349,34 +3374,36 @@ impl Data {
 // `new_store!` emits `pub mod expr_store { pub struct Store; ... }`.
 // Type list mirrors Zig's `Data.Store = NewStore(&.{ E.Array, ... }, 512)`
 // (Expr.zig:2550-2580).
+// Types use `'static` here because the macro only uses them for size/align
+// computation; the actual `append<T>` is generic over the caller's `'arena`.
 crate::new_store!(
     expr_store,
     [
-        E::Array,
-        E::Unary,
-        E::Binary,
-        E::Class,
-        E::New,
-        E::Function,
-        E::Call,
-        E::Dot,
-        E::Index,
-        E::Arrow,
-        E::JSXElement,
+        E::Array<'static>,
+        E::Unary<'static>,
+        E::Binary<'static>,
+        E::Class<'static>,
+        E::New<'static>,
+        E::Function<'static>,
+        E::Call<'static>,
+        E::Dot<'static>,
+        E::Index<'static>,
+        E::Arrow<'static>,
+        E::JSXElement<'static>,
         E::Number,
-        E::Object,
-        E::Spread,
-        E::TemplatePart,
-        E::Template,
-        E::RegExp,
-        E::Await,
-        E::Yield,
-        E::If,
-        E::Import,
+        E::Object<'static>,
+        E::Spread<'static>,
+        E::TemplatePart<'static>,
+        E::Template<'static>,
+        E::RegExp<'static>,
+        E::Await<'static>,
+        E::Yield<'static>,
+        E::If<'static>,
+        E::Import<'static>,
         E::PrivateIdentifier,
-        E::BigInt,
-        E::EString,
-        E::InlinedEnum,
+        E::BigInt<'static>,
+        E::EString<'static>,
+        E::InlinedEnum<'static>,
         E::NameOfSymbol,
     ],
     512

--- a/src/ast/fold_string_addition.rs
+++ b/src/ast/fold_string_addition.rs
@@ -8,12 +8,12 @@ use bun_alloc::Arena; // bumpalo::Bump re-export
 // without touching E.rs. These mirror the Zig bodies 1:1.
 
 #[inline]
-fn store_append_string(s: E::EString) -> StoreRef<E::EString> {
+fn store_append_string<'arena>(s: E::EString<'arena>) -> StoreRef<'arena, E::EString<'arena>> {
     data::Store::append(s)
 }
 
 /// Zig `E.String.push` — link `other` onto `lhs`'s rope tail.
-fn estring_push(lhs: &mut E::EString, mut other: StoreRef<E::EString>) {
+fn estring_push<'arena>(lhs: &mut E::EString<'arena>, mut other: StoreRef<'arena, E::EString<'arena>>) {
     debug_assert!(lhs.is_utf8());
     debug_assert!(other.is_utf8());
 
@@ -43,14 +43,14 @@ fn estring_push(lhs: &mut E::EString, mut other: StoreRef<E::EString>) {
 
 /// Zig `E.String.cloneRopeNodes` — deep-copy the `next` chain into fresh
 /// Store nodes so mutating the result can't alias an inlined-enum's string.
-fn clone_rope_nodes(s: &E::EString) -> E::EString {
+fn clone_rope_nodes<'arena>(s: &E::EString<'arena>) -> E::EString<'arena> {
     let mut root = s.shallow_clone();
     if let Some(first) = root.next {
         // Clone the first link, then walk the freshly-cloned chain via
         // `StoreRef` (safe `Deref`/`DerefMut`) instead of a raw `*mut`
         // cursor. Each cloned node's `next` still points at the original
         // chain (shallow clone), so re-clone link-by-link.
-        let mut tail: StoreRef<E::EString> = store_append_string(first.get().shallow_clone());
+        let mut tail: StoreRef<'arena, E::EString<'arena>> = store_append_string(first.get().shallow_clone());
         root.next = Some(tail);
         while let Some(next) = tail.next {
             let cloned = store_append_string(next.get().shallow_clone());
@@ -69,11 +69,11 @@ fn clone_rope_nodes(s: &E::EString) -> E::EString {
 /// bugs due to inlined enum values sharing `E::String`s. If a new use case
 /// besides inlined enums comes up to set this to true, please rename the
 /// variable and document it.
-fn join_strings(
-    left: &E::EString,
-    right: &E::EString,
+fn join_strings<'arena>(
+    left: &E::EString<'arena>,
+    right: &E::EString<'arena>,
     has_inlined_enum_poison: bool,
-) -> E::EString {
+) -> E::EString<'arena> {
     let mut new = if has_inlined_enum_poison {
         // Inlined enums can be shared by multiple call sites. In
         // this case, we need to ensure that the ENTIRE rope is
@@ -115,15 +115,15 @@ fn join_strings(
 /// arena. `TemplatePart` is POD-shaped (no Drop) but not `Copy` because
 /// `EString` opted out; mirror `Template::fold`'s field-wise copy via
 /// `shallow_clone` instead of raw `copy_nonoverlapping`.
-fn concat_parts(
+fn concat_parts<'arena>(
     bump: &Arena,
-    a: &[e::TemplatePart],
-    b: &[e::TemplatePart],
-) -> crate::StoreSlice<e::TemplatePart> {
-    let mut v = bun_alloc::ArenaVec::<e::TemplatePart>::with_capacity_in(a.len() + b.len(), bump);
+    a: &[e::TemplatePart<'arena>],
+    b: &[e::TemplatePart<'arena>],
+) -> crate::StoreSlice<'arena, e::TemplatePart<'arena>> {
+    let mut v = bun_alloc::ArenaVec::<e::TemplatePart<'arena>>::with_capacity_in(a.len() + b.len(), bump);
     for p in a.iter().chain(b.iter()) {
         // Zig `var part = part.*` — field-wise copy (all fields structurally `Copy`).
-        v.push(e::TemplatePart {
+        v.push(e::TemplatePart::<'arena> {
             value: p.value,
             tail_loc: p.tail_loc,
             tail: p.tail.shallow_clone(),
@@ -146,12 +146,12 @@ pub enum FoldStringAdditionKind {
 
 /// NOTE: unlike esbuild's js_ast_helpers.FoldStringAddition, this does mutate
 /// the input AST in the case of rope strings
-pub fn fold_string_addition(
-    l: Expr,
-    r: Expr,
+pub fn fold_string_addition<'arena>(
+    l: Expr<'arena>,
+    r: Expr<'arena>,
     bump: &Arena,
     kind: FoldStringAdditionKind,
-) -> Option<Expr> {
+) -> Option<Expr<'arena>> {
     // "See through" inline enum constants
     // TODO: implement foldAdditionPreProcess to fold some more things :)
     let mut lhs = l.unwrap_inlined();

--- a/src/ast/g.rs
+++ b/src/ast/g.rs
@@ -17,16 +17,16 @@ pub use crate::flags::FunctionSet as FnFlagsSet;
 // adding a `PhantomData<&'arena ()>` to `StoreSlice` in one pass.
 
 #[derive(Clone, Copy)]
-pub struct Decl {
-    pub binding: BindingNodeIndex,
-    pub value: Option<ExprNodeIndex>,
+pub struct Decl<'arena> {
+    pub binding: BindingNodeIndex<'arena>,
+    pub value: Option<ExprNodeIndex<'arena>>,
 }
 
 // Zig: `pub const List = Vec(Decl);` (nested decl) — inherent assoc types
 // are nightly; free alias.
-pub type DeclList = Vec<Decl, bun_alloc::AstAlloc>;
+pub type DeclList<'arena> = Vec<Decl<'arena>, bun_alloc::AstAlloc>;
 
-impl Default for Decl {
+impl<'arena> Default for Decl<'arena> {
     fn default() -> Self {
         Self {
             binding: BindingNodeIndex::default(),
@@ -35,16 +35,16 @@ impl Default for Decl {
     }
 }
 
-pub struct NamespaceAlias {
+pub struct NamespaceAlias<'arena> {
     pub namespace_ref: Ref,
-    pub alias: StoreStr,
+    pub alias: StoreStr<'arena>,
 
     pub was_originally_property_access: bool,
 
     pub import_record_index: u32,
 }
 
-impl Default for NamespaceAlias {
+impl<'arena> Default for NamespaceAlias<'arena> {
     fn default() -> Self {
         Self {
             namespace_ref: Ref::default(),
@@ -55,28 +55,28 @@ impl Default for NamespaceAlias {
     }
 }
 
-pub struct ExportStarAlias {
+pub struct ExportStarAlias<'arena> {
     pub loc: crate::Loc,
 
     // Although this alias name starts off as being the same as the statement's
     // namespace symbol, it may diverge if the namespace symbol name is minified.
     // The original alias name is preserved here to avoid this scenario.
-    pub original_name: StoreStr,
+    pub original_name: StoreStr<'arena>,
 }
 
-pub struct Class {
+pub struct Class<'arena> {
     pub class_keyword: crate::Range,
-    pub ts_decorators: ExprNodeList,
+    pub ts_decorators: ExprNodeList<'arena>,
     pub class_name: Option<LocRef>,
-    pub extends: Option<ExprNodeIndex>,
+    pub extends: Option<ExprNodeIndex<'arena>>,
     pub body_loc: crate::Loc,
     pub close_brace_loc: crate::Loc,
-    pub properties: StoreSlice<Property>,
+    pub properties: StoreSlice<'arena, Property<'arena>>,
     pub has_decorators: bool,
     pub should_lower_standard_decorators: bool,
 }
 
-impl Default for Class {
+impl<'arena> Default for Class<'arena> {
     fn default() -> Self {
         Self {
             class_keyword: crate::Range::NONE,
@@ -92,7 +92,7 @@ impl Default for Class {
     }
 }
 
-impl Class {
+impl<'arena> Class<'arena> {
     pub fn can_be_moved(&self) -> bool {
         if self.extends.is_some() {
             return false;
@@ -133,17 +133,17 @@ impl Class {
 }
 
 // invalid shadowing if left as Comment
-pub struct Comment {
+pub struct Comment<'arena> {
     pub loc: crate::Loc,
-    pub text: StoreStr,
+    pub text: StoreStr<'arena>,
 }
 
-pub struct ClassStaticBlock {
-    pub stmts: Vec<Stmt, bun_alloc::AstAlloc>,
+pub struct ClassStaticBlock<'arena> {
+    pub stmts: Vec<Stmt<'arena>, bun_alloc::AstAlloc>,
     pub loc: crate::Loc,
 }
 
-impl Default for ClassStaticBlock {
+impl<'arena> Default for ClassStaticBlock<'arena> {
     fn default() -> Self {
         Self {
             stmts: bun_alloc::AstAlloc::vec(),
@@ -152,7 +152,7 @@ impl Default for ClassStaticBlock {
     }
 }
 
-pub struct Property {
+pub struct Property<'arena> {
     /// This is used when parsing a pattern that uses default values:
     ///
     ///   [a = 1] = [];
@@ -162,27 +162,27 @@ pub struct Property {
     ///
     ///   class Foo { a = 1 }
     ///
-    pub initializer: Option<ExprNodeIndex>,
+    pub initializer: Option<ExprNodeIndex<'arena>>,
     pub kind: PropertyKind,
     pub flags: flags::PropertySet,
 
     // Arena-owned `?*ClassStaticBlock` (Zig). `StoreRef` centralises the
     // raw-pointer deref so the accessors below stay safe.
-    pub class_static_block: Option<crate::StoreRef<ClassStaticBlock>>,
-    pub ts_decorators: ExprNodeList,
+    pub class_static_block: Option<crate::StoreRef<'arena, ClassStaticBlock<'arena>>>,
+    pub ts_decorators: ExprNodeList<'arena>,
     // Key is optional for spread
-    pub key: Option<ExprNodeIndex>,
+    pub key: Option<ExprNodeIndex<'arena>>,
 
     // This is omitted for class fields
-    pub value: Option<ExprNodeIndex>,
+    pub value: Option<ExprNodeIndex<'arena>>,
 
     pub ts_metadata: TypeScript::Metadata,
 }
 
 // Zig: nested `pub const List = Vec(Property);` — free alias.
-pub type PropertyList = Vec<Property, bun_alloc::AstAlloc>;
+pub type PropertyList<'arena> = Vec<Property<'arena>, bun_alloc::AstAlloc>;
 
-impl Default for Property {
+impl<'arena> Default for Property<'arena> {
     fn default() -> Self {
         Self {
             initializer: None,
@@ -197,12 +197,12 @@ impl Default for Property {
     }
 }
 
-impl Property {
+impl<'arena> Property<'arena> {
     /// Re-borrow `class_static_block` as `Option<&ClassStaticBlock>`. Routes
     /// through `StoreRef::Deref` so callers (printer/visitor/can-be-removed
     /// analysis) need no `unsafe`.
     #[inline]
-    pub fn class_static_block_ref(&self) -> Option<&ClassStaticBlock> {
+    pub fn class_static_block_ref(&self) -> Option<&ClassStaticBlock<'arena>> {
         self.class_static_block.as_deref()
     }
 
@@ -211,17 +211,17 @@ impl Property {
     /// overlapping `&`/`&mut` to the same `ClassStaticBlock` — upheld by the
     /// single-threaded visitor pass).
     #[inline]
-    pub fn class_static_block_mut(&mut self) -> Option<&mut ClassStaticBlock> {
+    pub fn class_static_block_mut(&mut self) -> Option<&mut ClassStaticBlock<'arena>> {
         self.class_static_block.as_deref_mut()
     }
 
     pub fn deep_clone(
         &self,
         bump: &bun_alloc::Arena,
-    ) -> core::result::Result<Property, bun_alloc::AllocError> {
-        let mut class_static_block: Option<crate::StoreRef<ClassStaticBlock>> = None;
+    ) -> core::result::Result<Property<'arena>, bun_alloc::AllocError> {
+        let mut class_static_block: Option<crate::StoreRef<'arena, ClassStaticBlock<'arena>>> = None;
         if let Some(csb_ref) = self.class_static_block_ref() {
-            let new_block: &mut ClassStaticBlock = bump.alloc(ClassStaticBlock {
+            let new_block: &mut ClassStaticBlock<'arena> = bump.alloc(ClassStaticBlock {
                 loc: csb_ref.loc,
                 stmts: bun_alloc::AstAlloc::vec_from_slice(csb_ref.stmts.slice()),
             });
@@ -277,18 +277,18 @@ impl PropertyKind {
     }
 }
 
-pub struct FnBody {
+pub struct FnBody<'arena> {
     pub loc: crate::Loc,
-    pub stmts: StmtNodeList,
+    pub stmts: StmtNodeList<'arena>,
 }
 
-impl FnBody {
+impl<'arena> FnBody<'arena> {
     pub fn init_return_expr(
         bump: &bun_alloc::Arena,
-        expr: ExprNodeIndex,
-    ) -> core::result::Result<FnBody, bun_alloc::AllocError> {
+        expr: ExprNodeIndex<'arena>,
+    ) -> core::result::Result<FnBody<'arena>, bun_alloc::AllocError> {
         // PERF(port): Zig used arena.dupe over a 1-elem array literal; bumpalo equivalent
-        let stmts: &mut [Stmt] = bump.alloc_slice_fill_with(1, |_| {
+        let stmts: &mut [Stmt<'arena>] = bump.alloc_slice_fill_with(1, |_| {
             Stmt::alloc(crate::s::Return { value: Some(expr) }, expr.loc)
         });
         Ok(FnBody {
@@ -298,13 +298,13 @@ impl FnBody {
     }
 }
 
-pub struct Fn {
+pub struct Fn<'arena> {
     pub name: Option<LocRef>,
     pub open_parens_loc: crate::Loc,
-    pub args: StoreSlice<Arg>,
+    pub args: StoreSlice<'arena, Arg<'arena>>,
     // This was originally nullable, but doing so I believe caused a miscompilation
     // Specifically, the body was always null.
-    pub body: FnBody,
+    pub body: FnBody<'arena>,
     pub arguments_ref: Option<Ref>,
 
     pub flags: flags::FunctionSet,
@@ -312,7 +312,7 @@ pub struct Fn {
     pub return_ts_metadata: TypeScript::Metadata,
 }
 
-impl Default for Fn {
+impl<'arena> Default for Fn<'arena> {
     fn default() -> Self {
         Self {
             name: None,
@@ -329,14 +329,14 @@ impl Default for Fn {
     }
 }
 
-impl Fn {
+impl<'arena> Fn<'arena> {
     pub fn deep_clone(
         &self,
         bump: &bun_alloc::Arena,
-    ) -> core::result::Result<Fn, bun_alloc::AllocError> {
+    ) -> core::result::Result<Fn<'arena>, bun_alloc::AllocError> {
         // PERF(port): Zig arena.alloc + per-index assign; bumpalo equivalent.
-        let src_args: &[Arg] = self.args.slice();
-        let args: &mut [Arg] = bump.alloc_slice_fill_default::<Arg>(src_args.len());
+        let src_args: &[Arg<'arena>] = self.args.slice();
+        let args: &mut [Arg<'arena>] = bump.alloc_slice_fill_default::<Arg>(src_args.len());
         for i in 0..args.len() {
             args[i] = src_args[i].deep_clone(bump)?;
         }
@@ -355,10 +355,10 @@ impl Fn {
     }
 }
 
-pub struct Arg {
-    pub ts_decorators: ExprNodeList,
-    pub binding: BindingNodeIndex,
-    pub default: Option<ExprNodeIndex>,
+pub struct Arg<'arena> {
+    pub ts_decorators: ExprNodeList<'arena>,
+    pub binding: BindingNodeIndex<'arena>,
+    pub default: Option<ExprNodeIndex<'arena>>,
 
     // "constructor(public x: boolean) {}"
     pub is_typescript_ctor_field: bool,
@@ -366,7 +366,7 @@ pub struct Arg {
     pub ts_metadata: TypeScript::Metadata,
 }
 
-impl Default for Arg {
+impl<'arena> Default for Arg<'arena> {
     fn default() -> Self {
         Self {
             ts_decorators: bun_alloc::AstAlloc::vec(),
@@ -378,11 +378,11 @@ impl Default for Arg {
     }
 }
 
-impl Arg {
+impl<'arena> Arg<'arena> {
     pub fn deep_clone(
         &self,
         bump: &bun_alloc::Arena,
-    ) -> core::result::Result<Arg, bun_alloc::AllocError> {
+    ) -> core::result::Result<Arg<'arena>, bun_alloc::AllocError> {
         Ok(Arg {
             // Zig: `try this.ts_decorators.deepClone(arena)` — Vec<Expr> per-element deep clone.
             ts_decorators: self

--- a/src/ast/known_global.rs
+++ b/src/ast/known_global.rs
@@ -101,7 +101,7 @@ pub fn lookup(name: &[u8]) -> Option<KnownGlobal> {
 
 impl KnownGlobal {
     #[inline(always)]
-    fn call_from_new(e: &mut E::New, loc: crate::Loc) -> js_ast::Expr {
+    fn call_from_new<'arena>(e: &mut E::New<'arena>, loc: crate::Loc) -> js_ast::Expr<'arena> {
         let call = E::Call {
             target: e.target,
             args: bun_alloc::AstAlloc::take(&mut e.args),
@@ -115,13 +115,13 @@ impl KnownGlobal {
     // PORT NOTE: `_bump` is kept for call-site shape parity with the Zig
     // `std.mem.Allocator` arg. Phase-A `Vec` uses the global arena.
     #[inline(never)]
-    pub fn minify_global_constructor(
+    pub fn minify_global_constructor<'arena>(
         _bump: &Bump,
-        e: &mut E::New,
-        symbols: &[Symbol],
+        e: &mut E::New<'arena>,
+        symbols: &[Symbol<'_>],
         loc: crate::Loc,
         minify_whitespace: bool,
-    ) -> Option<js_ast::Expr> {
+    ) -> Option<js_ast::Expr<'arena>> {
         let id = if let js_ast::ExprData::EIdentifier(ident) = e.target.data {
             ident.ref_
         } else {

--- a/src/ast/new_store.rs
+++ b/src/ast/new_store.rs
@@ -476,7 +476,7 @@ macro_rules! thread_local_ast_store {
             }
 
             #[inline]
-            pub fn append<T>(value: T) -> $crate::StoreRef<T> {
+            pub fn append<'arena, T>(value: T) -> $crate::StoreRef<'arena, T> {
                 if let Some(ma) = MEMORY_ALLOCATOR.get() {
                     // `BackRef<ASTMemoryAllocator>: Deref` — owning scope outlives this call.
                     return ma.append(value);

--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -2,6 +2,7 @@
 #![allow(non_snake_case, dead_code, clippy::all)]
 
 use core::fmt;
+use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
 
@@ -21,10 +22,25 @@ pub use crate::flags as Flags;
 // Thin `NonNull<T>` newtype — `Copy`, `Deref`/`DerefMut`. The pointee lives
 // until the owning Store/arena is `reset()`; callers must not hold a `StoreRef`
 // across that boundary. Matches Zig's `*T` payloads in `Expr.Data`.
+//
+// `'arena` is covariant (via `PhantomData<&'arena T>`) and ties the borrow to
+// the owning arena's lifetime so the borrow checker can statically reject
+// holding a `StoreRef` past a reset.
 // ───────────────────────────────────────────────────────────────────────────
 
 #[repr(transparent)]
-pub struct StoreRef<T>(NonNull<T>);
+pub struct StoreRef<'arena, T> {
+    ptr: NonNull<T>,
+    _arena: PhantomData<&'arena T>,
+}
+
+// PhantomData is a ZST, so #[repr(transparent)] still applies and the layout is
+// exactly one pointer. Guard against future field additions.
+const _: () = assert!(core::mem::size_of::<StoreRef<'static, u8>>() == core::mem::size_of::<usize>());
+const _: () = assert!(
+    core::mem::size_of::<Option<StoreRef<'static, u8>>>() == core::mem::size_of::<usize>(),
+    "StoreRef lost its NonNull niche"
+);
 
 // SAFETY: `StoreRef` is a thin pointer into a single-threaded bump arena (Zig
 // `*T`). We assert Send/Sync so payload types embedding `Option<StoreRef<T>>`
@@ -36,13 +52,13 @@ pub struct StoreRef<T>(NonNull<T>);
 // `StoreRef<Cell<_>>`) past auto-trait inference: `Deref` yields `&T` (needs
 // `T: Sync` to share), and a `Send`-moved `StoreRef` yields `&mut T` via
 // `DerefMut` (needs `T: Send`).
-unsafe impl<T: Send> Send for StoreRef<T> {}
-unsafe impl<T: Sync> Sync for StoreRef<T> {}
+unsafe impl<'arena, T: Send> Send for StoreRef<'arena, T> {}
+unsafe impl<'arena, T: Sync> Sync for StoreRef<'arena, T> {}
 
-impl<T> StoreRef<T> {
+impl<'arena, T> StoreRef<'arena, T> {
     #[inline]
     pub const fn from_non_null(p: NonNull<T>) -> Self {
-        StoreRef(p)
+        StoreRef { ptr: p, _arena: PhantomData }
     }
     /// Wrap a raw pointer. Panics if `p` is null. Alignment and arena-lifetime
     /// are caller-tracked just like the already-safe `from_non_null` /
@@ -50,12 +66,12 @@ impl<T> StoreRef<T> {
     /// guarding here was non-null, which we now check.
     #[inline]
     pub fn from_raw(p: *mut T) -> Self {
-        StoreRef(NonNull::new(p).expect("StoreRef::from_raw: null pointer"))
+        StoreRef::from_non_null(NonNull::new(p).expect("StoreRef::from_raw: null pointer"))
     }
     /// Wrap a `bumpalo::Bump::alloc` result.
     #[inline]
     pub fn from_bump(r: &mut T) -> Self {
-        StoreRef(NonNull::from(r))
+        StoreRef::from_non_null(NonNull::from(r))
     }
     /// Consume a `Box<T>` whose payload must outlive every Store reset
     /// (Zig `deepClone(default_allocator)` semantics). Ownership transfers to
@@ -64,11 +80,11 @@ impl<T> StoreRef<T> {
     /// no paired `destroy`. Prefer `from_bump` for arena-backed nodes.
     #[inline]
     pub fn from_box(b: Box<T>) -> Self {
-        StoreRef(bun_core::heap::into_raw_nn(b))
+        StoreRef::from_non_null(bun_core::heap::into_raw_nn(b))
     }
     #[inline]
     pub const fn as_ptr(self) -> *mut T {
-        self.0.as_ptr()
+        self.ptr.as_ptr()
     }
     /// Wrap a `&'static T` (compile-time/global singleton — e.g. Prefill
     /// constants). Mutation through the resulting `StoreRef` is UB.
@@ -79,7 +95,7 @@ impl<T> StoreRef<T> {
         // `@constCast` on prefill tables. The pointee is *never* written
         // through — `DerefMut` on a `StoreRef` produced here is UB and callers
         // must not do so (audited: only `Deref`/`get()` reads occur).
-        StoreRef(unsafe { NonNull::new_unchecked(core::ptr::from_ref(r).cast_mut()) })
+        StoreRef::from_non_null(unsafe { NonNull::new_unchecked(core::ptr::from_ref(r).cast_mut()) })
     }
     /// Borrow the pointee (explicit form of `Deref`).
     #[inline]
@@ -87,58 +103,58 @@ impl<T> StoreRef<T> {
         self
     }
 }
-impl<T> Clone for StoreRef<T> {
+impl<'arena, T> Clone for StoreRef<'arena, T> {
     #[inline]
     fn clone(&self) -> Self {
         *self
     }
 }
-impl<T> Copy for StoreRef<T> {}
-impl<T> Deref for StoreRef<T> {
+impl<'arena, T> Copy for StoreRef<'arena, T> {}
+impl<'arena, T> Deref for StoreRef<'arena, T> {
     type Target = T;
     #[inline]
     fn deref(&self) -> &T {
         // SAFETY: StoreRef invariant — points into a live Store/arena block.
-        unsafe { self.0.as_ref() }
+        unsafe { self.ptr.as_ref() }
     }
 }
-impl<T> DerefMut for StoreRef<T> {
+impl<'arena, T> DerefMut for StoreRef<'arena, T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut T {
         // SAFETY: StoreRef invariant. AST nodes are mutated in-place during
         // visiting; no two `StoreRef` to the same node are deref'd `&mut`
         // simultaneously in single-threaded parser/visitor passes — same
         // contract as the Zig original.
-        unsafe { self.0.as_mut() }
+        unsafe { self.ptr.as_mut() }
     }
 }
-impl<T> From<NonNull<T>> for StoreRef<T> {
+impl<'arena, T> From<NonNull<T>> for StoreRef<'arena, T> {
     #[inline]
     fn from(p: NonNull<T>) -> Self {
-        StoreRef(p)
+        StoreRef::from_non_null(p)
     }
 }
 /// Pointer-identity comparison (matches the `NonNull<T>`/Zig `*T` semantics
 /// of the field this type replaces).
-impl<T> PartialEq for StoreRef<T> {
+impl<'arena, T> PartialEq for StoreRef<'arena, T> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
+        self.ptr == other.ptr
     }
 }
-impl<T> Eq for StoreRef<T> {}
+impl<'arena, T> Eq for StoreRef<'arena, T> {}
 
-pub type ExprNodeIndex = Expr;
-pub type StmtNodeIndex = Stmt;
-pub type BindingNodeIndex = Binding;
+pub type ExprNodeIndex<'arena> = Expr<'arena>;
+pub type StmtNodeIndex<'arena> = Stmt<'arena>;
+pub type BindingNodeIndex<'arena> = Binding<'arena>;
 
 // ─── arena-slice helpers ────────────────────────────────────────────────────
 // Legacy alias: AST string fields now uniformly use `StoreStr` (safe `Deref`
 // wrapper around an arena `[u8]`). Kept as a type alias so existing field
 // declarations / call sites that spell `ArenaStr` continue to compile.
-pub(crate) type ArenaStr = StoreStr;
+pub(crate) type ArenaStr<'arena> = StoreStr<'arena>;
 #[inline]
-pub(crate) const fn empty_arena_str() -> ArenaStr {
+pub(crate) const fn empty_arena_str<'arena>() -> ArenaStr<'arena> {
     StoreStr::EMPTY
 }
 // (former `empty_arena_slice_mut<T>()` removed — use `StoreSlice::<T>::EMPTY`.)
@@ -148,29 +164,28 @@ pub(crate) const fn empty_arena_str() -> ArenaStr {
 // AST string fields (`E::Dot.name`, `E::String.data`, …) borrow from the parse
 // arena and are bulk-freed at `Store::reset()`. `StoreStr` mirrors
 // `StoreRef<T>` (raw `NonNull<T>`) and `StmtNodeList` (`StoreSlice<Stmt>`): a
-// thin lifetime-erased pointer with safe construction and `Deref<Target=[u8]>`
-// under the same callers-must-not-outlive-the-arena contract that `StoreRef`
-// already imposes. Avoids cascading `<'arena>` through `Expr`/`Stmt`/`Data`
-// (~100 types, 12 downstream crates) — that cascade is the follow-up round
-// once `StoreRef` itself carries `'arena`.
+// thin pointer with safe construction and `Deref<Target=[u8]>`, tied to
+// `'arena` so the borrow checker rejects use-past-reset.
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct StoreStr {
+pub struct StoreStr<'arena> {
     ptr: core::ptr::NonNull<u8>,
     len: usize,
+    _arena: PhantomData<&'arena [u8]>,
 }
 
 // SAFETY: same rationale as `StoreRef` — points into a single-threaded bump
 // arena (Zig `[]const u8`). Asserted Send/Sync so payload types can sit in
 // `static` Prefill tables; callers must not actually share a Store across
 // threads (unchanged contract).
-unsafe impl Send for StoreStr {}
-unsafe impl Sync for StoreStr {}
+unsafe impl<'arena> Send for StoreStr<'arena> {}
+unsafe impl<'arena> Sync for StoreStr<'arena> {}
 
-impl StoreStr {
-    pub const EMPTY: StoreStr = StoreStr {
+impl<'arena> StoreStr<'arena> {
+    pub const EMPTY: StoreStr<'arena> = StoreStr {
         ptr: core::ptr::NonNull::<u8>::dangling(),
         len: 0,
+        _arena: PhantomData,
     };
 
     /// Wrap an arena-owned (or `'static`) slice. Safe: no lifetime is forged;
@@ -179,7 +194,7 @@ impl StoreStr {
     #[inline]
     pub const fn new(s: &[u8]) -> Self {
         match core::ptr::NonNull::new(s.as_ptr().cast_mut()) {
-            Some(ptr) => StoreStr { ptr, len: s.len() },
+            Some(ptr) => StoreStr { ptr, len: s.len(), _arena: PhantomData },
             // Only the (ptr=null, len=0) empty-slice edge needs this; Rust
             // `&[u8]` never has a null ptr, but be defensive for const-eval.
             None => StoreStr::EMPTY,
@@ -219,14 +234,14 @@ impl StoreStr {
     // remaining callers.)
 }
 
-impl Default for StoreStr {
+impl<'arena> Default for StoreStr<'arena> {
     #[inline]
     fn default() -> Self {
         StoreStr::EMPTY
     }
 }
 
-impl core::ops::Deref for StoreStr {
+impl<'arena> core::ops::Deref for StoreStr<'arena> {
     type Target = [u8];
     #[inline]
     fn deref(&self) -> &[u8] {
@@ -234,76 +249,76 @@ impl core::ops::Deref for StoreStr {
     }
 }
 
-impl AsRef<[u8]> for StoreStr {
+impl<'arena> AsRef<[u8]> for StoreStr<'arena> {
     #[inline]
     fn as_ref(&self) -> &[u8] {
         self.slice()
     }
 }
-impl core::borrow::Borrow<[u8]> for StoreStr {
+impl<'arena> core::borrow::Borrow<[u8]> for StoreStr<'arena> {
     #[inline]
     fn borrow(&self) -> &[u8] {
         self.slice()
     }
 }
 
-impl<const N: usize> From<&[u8; N]> for StoreStr {
+impl<'arena, const N: usize> From<&[u8; N]> for StoreStr<'arena> {
     #[inline]
     fn from(s: &[u8; N]) -> Self {
         StoreStr::new(s)
     }
 }
-impl From<&[u8]> for StoreStr {
+impl<'arena> From<&[u8]> for StoreStr<'arena> {
     #[inline]
     fn from(s: &[u8]) -> Self {
         StoreStr::new(s)
     }
 }
-impl From<&str> for StoreStr {
+impl<'arena> From<&str> for StoreStr<'arena> {
     #[inline]
     fn from(s: &str) -> Self {
         StoreStr::new(s.as_bytes())
     }
 }
 
-impl PartialEq for StoreStr {
+impl<'arena> PartialEq for StoreStr<'arena> {
     #[inline]
-    fn eq(&self, other: &StoreStr) -> bool {
+    fn eq(&self, other: &StoreStr<'arena>) -> bool {
         self.slice() == other.slice()
     }
 }
-impl Eq for StoreStr {}
-impl PartialEq<[u8]> for StoreStr {
+impl<'arena> Eq for StoreStr<'arena> {}
+impl<'arena> PartialEq<[u8]> for StoreStr<'arena> {
     #[inline]
     fn eq(&self, other: &[u8]) -> bool {
         self.slice() == other
     }
 }
-impl<const N: usize> PartialEq<&[u8; N]> for StoreStr {
+impl<'arena, const N: usize> PartialEq<&[u8; N]> for StoreStr<'arena> {
     #[inline]
     fn eq(&self, other: &&[u8; N]) -> bool {
         self.slice() == *other
     }
 }
-impl<const N: usize> PartialEq<[u8; N]> for StoreStr {
+impl<'arena, const N: usize> PartialEq<[u8; N]> for StoreStr<'arena> {
     #[inline]
     fn eq(&self, other: &[u8; N]) -> bool {
         self.slice() == other
     }
 }
-impl PartialEq<&[u8]> for StoreStr {
+impl<'arena> PartialEq<&[u8]> for StoreStr<'arena> {
     #[inline]
     fn eq(&self, other: &&[u8]) -> bool {
         self.slice() == *other
     }
 }
-impl core::hash::Hash for StoreStr {
+impl<'arena> core::hash::Hash for StoreStr<'arena> {
     #[inline]
     fn hash<H: core::hash::Hasher>(&self, h: &mut H) {
         self.slice().hash(h)
     }
 }
-impl core::fmt::Debug for StoreStr {
+impl<'arena> core::fmt::Debug for StoreStr<'arena> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         bstr::BStr::new(self.slice()).fmt(f)
     }
@@ -314,19 +329,20 @@ impl core::fmt::Debug for StoreStr {
 // Generalizes `StoreStr` to `[T]` for AST list fields (`E::Arrow.args`,
 // per-node `[Stmt]`/`[Expr]` views, …) that borrow from the parse arena.
 // Same contract as `StoreRef`/`StoreStr`: safe `::new`,
-// raw `NonNull<T>` + `u32` length, `Deref<Target=[T]>`, valid until the
-// owning arena resets. The `u32` length matches Zig's `[]T` (`u32` len under
+// raw `NonNull<T>` + `u32` length, `Deref<Target=[T]>`, tied to `'arena`.
+// The `u32` length matches Zig's `[]T` (`u32` len under
 // `-Dwasm32` and the AST's practical bounds) and keeps the field at 12 bytes
 // on 64-bit instead of 16 — relevant for hot AST nodes.
 #[repr(C)]
-pub struct StoreSlice<T> {
+pub struct StoreSlice<'arena, T> {
     ptr: core::ptr::NonNull<T>,
     len: u32,
+    _arena: PhantomData<&'arena [T]>,
 }
 
 // Manual Copy/Clone: derive would add a spurious `T: Copy` bound.
-impl<T> Copy for StoreSlice<T> {}
-impl<T> Clone for StoreSlice<T> {
+impl<'arena, T> Copy for StoreSlice<'arena, T> {}
+impl<'arena, T> Clone for StoreSlice<'arena, T> {
     #[inline]
     fn clone(&self) -> Self {
         *self
@@ -336,13 +352,14 @@ impl<T> Clone for StoreSlice<T> {
 // SAFETY: same rationale as `StoreStr` — points into a single-threaded bump
 // arena. Asserted Send/Sync so payload types can sit in `static` Prefill
 // tables; callers must not actually share a Store across threads.
-unsafe impl<T> Send for StoreSlice<T> {}
-unsafe impl<T> Sync for StoreSlice<T> {}
+unsafe impl<'arena, T> Send for StoreSlice<'arena, T> {}
+unsafe impl<'arena, T> Sync for StoreSlice<'arena, T> {}
 
-impl<T> StoreSlice<T> {
-    pub const EMPTY: StoreSlice<T> = StoreSlice {
+impl<'arena, T> StoreSlice<'arena, T> {
+    pub const EMPTY: StoreSlice<'arena, T> = StoreSlice {
         ptr: core::ptr::NonNull::<T>::dangling(),
         len: 0,
+        _arena: PhantomData,
     };
 
     /// Wrap an arena-owned (or `'static`) slice. Safe: no lifetime is forged;
@@ -355,6 +372,7 @@ impl<T> StoreSlice<T> {
             Some(ptr) => StoreSlice {
                 ptr,
                 len: s.len() as u32,
+                _arena: PhantomData,
             },
             None => StoreSlice::EMPTY,
         }
@@ -370,6 +388,7 @@ impl<T> StoreSlice<T> {
             Some(ptr) => StoreSlice {
                 ptr,
                 len: s.len() as u32,
+                _arena: PhantomData,
             },
             None => StoreSlice::EMPTY,
         }
@@ -432,21 +451,21 @@ impl<T> StoreSlice<T> {
     }
 }
 
-impl<'a, T> From<bun_alloc::ArenaVec<'a, T>> for StoreSlice<T> {
+impl<'arena, 'a, T> From<bun_alloc::ArenaVec<'a, T>> for StoreSlice<'arena, T> {
     #[inline]
     fn from(v: bun_alloc::ArenaVec<'a, T>) -> Self {
         StoreSlice::from_bump(v)
     }
 }
 
-impl<T> Default for StoreSlice<T> {
+impl<'arena, T> Default for StoreSlice<'arena, T> {
     #[inline]
     fn default() -> Self {
         StoreSlice::EMPTY
     }
 }
 
-impl<T> core::ops::Deref for StoreSlice<T> {
+impl<'arena, T> core::ops::Deref for StoreSlice<'arena, T> {
     type Target = [T];
     #[inline]
     fn deref(&self) -> &[T] {
@@ -454,27 +473,27 @@ impl<T> core::ops::Deref for StoreSlice<T> {
     }
 }
 
-impl<T> AsRef<[T]> for StoreSlice<T> {
+impl<'arena, T> AsRef<[T]> for StoreSlice<'arena, T> {
     #[inline]
     fn as_ref(&self) -> &[T] {
         self.slice()
     }
 }
 
-impl<T> From<&[T]> for StoreSlice<T> {
+impl<'arena, T> From<&[T]> for StoreSlice<'arena, T> {
     #[inline]
     fn from(s: &[T]) -> Self {
         StoreSlice::new(s)
     }
 }
-impl<T> From<&mut [T]> for StoreSlice<T> {
+impl<'arena, T> From<&mut [T]> for StoreSlice<'arena, T> {
     #[inline]
     fn from(s: &mut [T]) -> Self {
         StoreSlice::new_mut(s)
     }
 }
 
-impl<T: core::fmt::Debug> core::fmt::Debug for StoreSlice<T> {
+impl<'arena, T: core::fmt::Debug> core::fmt::Debug for StoreSlice<'arena, T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.slice().fmt(f)
     }
@@ -518,13 +537,11 @@ pub const NAMESPACE_EXPORT_PART_INDEX: u32 = 0;
 // But we must have pointers somewhere in here because can't have types that contain themselves
 
 /// Slice that stores capacity and length in the same space as a regular slice.
-pub type ExprNodeList = Vec<Expr, bun_alloc::AstAlloc>;
+pub type ExprNodeList<'arena> = Vec<Expr<'arena>, bun_alloc::AstAlloc>;
 
 // Arena-owned `[Stmt]` / `[Binding]` views — see `StoreSlice<T>` doc above.
-// A `PhantomData<&'arena ()>` can be added to `StoreSlice` later as a
-// one-struct change once `'arena` is threaded through `Expr`/`Stmt`/`Data`.
-pub type StmtNodeList = StoreSlice<Stmt>;
-pub type BindingNodeList = StoreSlice<Binding>;
+pub type StmtNodeList<'arena> = StoreSlice<'arena, Stmt<'arena>>;
+pub type BindingNodeList<'arena> = StoreSlice<'arena, Binding<'arena>>;
 
 #[repr(u8)] // Zig: enum(u2)
 #[derive(Copy, Clone, PartialEq, Eq, Debug, strum::IntoStaticStr)]
@@ -587,12 +604,12 @@ impl Default for LocRef {
     }
 }
 
-pub struct ClauseItem {
+pub struct ClauseItem<'arena> {
     /// The local alias used for the imported/exported symbol in the current module.
     /// For imports: `import { foo as bar }` - "bar" is the alias
     /// For exports: `export { foo as bar }` - "bar" is the alias
     /// For re-exports: `export { foo as bar } from 'path'` - "bar" is the alias
-    pub alias: ArenaStr,
+    pub alias: ArenaStr<'arena>,
     pub alias_loc: crate::Loc,
     /// Reference to the actual symbol being imported/exported.
     /// For imports: `import { foo as bar }` - ref to the symbol representing "foo" from the source module
@@ -608,14 +625,14 @@ pub struct ClauseItem {
     /// In this case both "foo" and "bar" are aliases because it's a re-export.
     /// We need to preserve both aliases in case the symbol is renamed. In this
     /// example, "foo" is "OriginalName" and "bar" is "Alias".
-    pub original_name: ArenaStr,
+    pub original_name: ArenaStr<'arena>,
 }
 
-impl ClauseItem {
+impl<'arena> ClauseItem<'arena> {
     pub const DEFAULT_ALIAS: &'static [u8] = b"default";
 }
 
-impl Default for ClauseItem {
+impl<'arena> Default for ClauseItem<'arena> {
     fn default() -> Self {
         Self {
             alias: empty_arena_str(),
@@ -731,40 +748,40 @@ impl OptionalChain {
     }
 }
 
-pub struct EnumValue {
+pub struct EnumValue<'arena> {
     pub loc: crate::Loc,
     pub ref_: Ref,
-    pub name: ArenaStr,
-    pub value: Option<ExprNodeIndex>,
+    pub name: ArenaStr<'arena>,
+    pub value: Option<ExprNodeIndex<'arena>>,
 }
 
-impl EnumValue {
-    pub fn name_as_e_string(&self, bump: &bun_alloc::Arena) -> E::String {
+impl<'arena> EnumValue<'arena> {
+    pub fn name_as_e_string(&self, bump: &bun_alloc::Arena) -> E::String<'arena> {
         E::String::init_re_encode_utf8(self.name.slice(), bump)
     }
 }
 
-pub struct Catch {
+pub struct Catch<'arena> {
     pub loc: crate::Loc,
-    pub binding: Option<BindingNodeIndex>,
-    pub body: StmtNodeList,
+    pub binding: Option<BindingNodeIndex<'arena>>,
+    pub body: StmtNodeList<'arena>,
     pub body_loc: crate::Loc,
 }
 
-pub struct Finally {
+pub struct Finally<'arena> {
     pub loc: crate::Loc,
-    pub stmts: StmtNodeList,
+    pub stmts: StmtNodeList<'arena>,
 }
 
-pub struct Case {
+pub struct Case<'arena> {
     pub loc: crate::Loc,
-    pub value: Option<ExprNodeIndex>,
-    pub body: StmtNodeList,
+    pub value: Option<ExprNodeIndex<'arena>>,
+    pub body: StmtNodeList<'arena>,
 }
 
-pub struct ArrayBinding {
-    pub binding: BindingNodeIndex,
-    pub default_value: Option<ExprNodeIndex>,
+pub struct ArrayBinding<'arena> {
+    pub binding: BindingNodeIndex<'arena>,
+    pub default_value: Option<ExprNodeIndex<'arena>>,
 }
 
 /// TLA => Top Level Await
@@ -786,12 +803,12 @@ impl Default for TlaCheck {
 }
 
 #[derive(Copy, Clone)]
-pub struct Span {
-    pub text: ArenaStr,
+pub struct Span<'arena> {
+    pub text: ArenaStr<'arena>,
     pub range: crate::Range,
 }
 
-impl Default for Span {
+impl<'arena> Default for Span<'arena> {
     fn default() -> Self {
         Self {
             text: empty_arena_str(),
@@ -804,18 +821,19 @@ impl Default for Span {
 /// This type special cases an encoding similar to JSValue, where nan-boxing is used
 /// to encode both a 64-bit pointer or a 64-bit float using 64 bits.
 #[derive(Copy, Clone)]
-pub struct InlinedEnumValue {
+pub struct InlinedEnumValue<'arena> {
     pub raw_data: u64,
+    _arena: PhantomData<&'arena ()>,
 }
 
 #[derive(Copy, Clone)]
-pub enum InlinedEnumValueDecoded {
+pub enum InlinedEnumValueDecoded<'arena> {
     // LIFETIMES.tsv: ARENA → *const e::String
-    String(*const E::String),
+    String(*const E::String<'arena>),
     Number(f64),
 }
 
-impl InlinedEnumValue {
+impl<'arena> InlinedEnumValue<'arena> {
     /// See JSCJSValue.h in WebKit for more details
     const DOUBLE_ENCODE_OFFSET: u64 = 1 << 49;
     /// See PureNaN.h in WebKit for more details
@@ -829,7 +847,7 @@ impl InlinedEnumValue {
         }
     }
 
-    pub fn encode(decoded: InlinedEnumValueDecoded) -> InlinedEnumValue {
+    pub fn encode(decoded: InlinedEnumValueDecoded<'arena>) -> InlinedEnumValue<'arena> {
         let encoded = InlinedEnumValue {
             raw_data: match decoded {
                 InlinedEnumValueDecoded::String(ptr) => {
@@ -839,6 +857,7 @@ impl InlinedEnumValue {
                     Self::purify_nan(num).to_bits() + Self::DOUBLE_ENCODE_OFFSET
                 }
             },
+            _arena: PhantomData,
         };
         if cfg!(debug_assertions) {
             debug_assert!(match encoded.decode() {
@@ -856,14 +875,14 @@ impl InlinedEnumValue {
         encoded
     }
 
-    pub fn decode(self) -> InlinedEnumValueDecoded {
+    pub fn decode(self) -> InlinedEnumValueDecoded<'arena> {
         if self.raw_data > 0x0000_FFFF_FFFF_FFFF {
             InlinedEnumValueDecoded::Number(f64::from_bits(
                 self.raw_data - Self::DOUBLE_ENCODE_OFFSET,
             ))
         } else {
             // SAFETY: encoded from a valid arena `*const E::String` (see `encode`); low 48 bits hold the address.
-            InlinedEnumValueDecoded::String(self.raw_data as usize as *const E::String)
+            InlinedEnumValueDecoded::String(self.raw_data as usize as *const E::String<'arena>)
         }
     }
 }
@@ -1085,9 +1104,9 @@ impl Default for Dependency {
 
 pub type DependencyList = Vec<Dependency>;
 
-pub type ExprList = Vec<Expr>;
-pub type StmtList = Vec<Stmt>;
-pub type BindingList = Vec<Binding>;
+pub type ExprList<'arena> = Vec<Expr<'arena>>;
+pub type StmtList<'arena> = Vec<Stmt<'arena>>;
+pub type BindingList<'arena> = Vec<Binding<'arena>>;
 // PERF(port): Zig `std.array_list.Managed` — these may be arena-backed in
 // callers; revisit with bumpalo::collections::Vec if profiling shows churn.
 
@@ -1096,9 +1115,9 @@ pub type BindingList = Vec<Binding>;
 /// splitting analysis. Individual parts of a file can be discarded by tree
 /// shaking and can be assigned to separate chunks (i.e. output files) by code
 /// splitting.
-pub struct Part {
-    pub stmts: StoreSlice<Stmt>,
-    pub scopes: StoreSlice<*mut Scope>, // TODO(port): &'bump mut [&'bump mut Scope]
+pub struct Part<'arena> {
+    pub stmts: StoreSlice<'arena, Stmt<'arena>>,
+    pub scopes: StoreSlice<'arena, NonNull<Scope<'arena>>>, // TODO(port): &'bump mut [&'bump mut Scope]
 
     /// Each is an index into the file-level import record list
     pub import_record_indices: PartImportRecordIndices,
@@ -1141,7 +1160,7 @@ pub struct Part {
 }
 
 pub type PartImportRecordIndices = Vec<u32>;
-pub type PartList = Vec<Part>;
+pub type PartList<'arena> = Vec<Part<'arena>>;
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum PartTag {
@@ -1162,7 +1181,7 @@ pub enum PartTag {
 pub type PartSymbolUseMap = ArrayHashMap<Ref, symbol::Use>;
 pub type PartSymbolPropertyUseMap = ArrayHashMap<Ref, StringHashMap<symbol::Use>>;
 
-impl Default for Part {
+impl<'arena> Default for Part<'arena> {
     fn default() -> Self {
         Self {
             stmts: StoreSlice::EMPTY,
@@ -1180,7 +1199,7 @@ impl Default for Part {
     }
 }
 
-impl Part {
+impl<'arena> Part<'arena> {
     // TODO(port): narrow error set
     pub fn json_stringify(
         &self,
@@ -1190,19 +1209,19 @@ impl Part {
     }
 }
 
-pub enum StmtOrExpr {
-    Stmt(Stmt),
-    Expr(Expr),
+pub enum StmtOrExpr<'arena> {
+    Stmt(Stmt<'arena>),
+    Expr(Expr<'arena>),
 }
 
-impl Default for StmtOrExpr {
+impl<'arena> Default for StmtOrExpr<'arena> {
     fn default() -> Self {
         StmtOrExpr::Expr(Expr::default())
     }
 }
 
-impl StmtOrExpr {
-    pub fn to_expr(self) -> Expr {
+impl<'arena> StmtOrExpr<'arena> {
+    pub fn to_expr(self) -> Expr<'arena> {
         match self {
             StmtOrExpr::Expr(expr) => expr,
             StmtOrExpr::Stmt(stmt) => match stmt.data {
@@ -1215,7 +1234,7 @@ impl StmtOrExpr {
                 }
                 crate::stmt::Data::SClass(mut s) => {
                     let class = core::mem::take(&mut s.class);
-                    Expr::init::<E::Class>(class, stmt.loc)
+                    Expr::init::<E::Class<'arena>>(class, stmt.loc)
                 }
                 other => Output::panic(format_args!(
                     "Unexpected statement type in default export: .{}",
@@ -1226,7 +1245,7 @@ impl StmtOrExpr {
     }
 }
 
-pub struct NamedImport {
+pub struct NamedImport<'arena> {
     /// Parts within this file that use this import
     pub local_parts_with_uses: Vec<u32>,
 
@@ -1237,7 +1256,7 @@ pub struct NamedImport {
     /// - `import * as ns from 'module'` → alias_is_star = true, alias = ""
     /// This field is used by the bundler to match imports with their corresponding
     /// exports and for error reporting when imports can't be resolved.
-    pub alias: Option<ArenaStr>,
+    pub alias: Option<ArenaStr<'arena>>,
     pub alias_loc: Option<crate::Loc>,
     pub namespace_ref: Option<Ref>,
     pub import_record_index: u32,
@@ -1309,11 +1328,11 @@ bun_core::named_error_set!(ToJSError);
 /// With std.ArrayList, pointers invalidate on resize and that means it will crash.
 /// So a better idea is to batch up your allocations into one larger allocation
 /// and then just make all the arrays point to different parts of the larger allocation
-pub struct Batcher<T> {
-    pub head: StoreSlice<T>,
+pub struct Batcher<'arena, T> {
+    pub head: StoreSlice<'arena, T>,
 }
 
-impl<T> Batcher<T> {
+impl<'arena, T> Batcher<'arena, T> {
     pub fn init(
         bump: &bun_alloc::Arena,
         count: usize,
@@ -1339,7 +1358,7 @@ impl<T> Batcher<T> {
         self.eat1(value).as_ptr().cast_mut()
     }
 
-    pub fn eat1(&mut self, value: T) -> StoreSlice<T> {
+    pub fn eat1(&mut self, value: T) -> StoreSlice<'arena, T> {
         // `head` has at least 1 element remaining (caller contract — Zig would
         // panic on bounds); `Batcher` holds the unique view of the allocation.
         let head = self.head.slice_mut();
@@ -1349,7 +1368,7 @@ impl<T> Batcher<T> {
         StoreSlice::new_mut(prev)
     }
 
-    pub fn next<const N: usize>(&mut self, values: [T; N]) -> StoreSlice<T> {
+    pub fn next<const N: usize>(&mut self, values: [T; N]) -> StoreSlice<'arena, T> {
         // `head` has at least N elements remaining; see `eat1`.
         let head = self.head.slice_mut();
         let (prev, rest) = head.split_at_mut(N);
@@ -1361,7 +1380,7 @@ impl<T> Batcher<T> {
     }
 }
 // Zig: `pub fn NewBatcher(comptime Type: type) type` → Rust generic struct above.
-pub type NewBatcher<T> = Batcher<T>;
+pub type NewBatcher<'arena, T> = Batcher<'arena, T>;
 
 // ═════════════════════════════════════════════════════════════════════════
 // Symbols pulled DOWN from higher-tier
@@ -1394,4 +1413,31 @@ pub mod math {
 // Zig: `std.AutoArrayHashMapUnmanaged(Ref, []const u8)`
 // LIFETIMES.tsv: value slices point into the parser arena → `StoreStr`
 // (arena-owned, no `'bump` cascade).
-pub type MangledProps = ArrayHashMap<Ref, StoreStr>;
+pub type MangledProps<'arena> = ArrayHashMap<Ref, StoreStr<'arena>>;
+
+// ─── Transitional lifetime-erased aliases ───────────────────────────────────
+// TRANSITIONAL: legacy lifetime-erased aliases. Every usage is a site that
+// still needs 'arena threaded. Remove once the cascade is complete.
+pub type StoreRefAny<T> = StoreRef<'static, T>;
+pub type StoreSliceAny<T> = StoreSlice<'static, T>;
+pub type StoreStrAny = StoreStr<'static>;
+
+// ─── Variance assertions ────────────────────────────────────────────────────
+// These compile only if the types are covariant in `'arena`. A `*mut T<'arena>`
+// field anywhere in the graph would force invariance and break these.
+#[allow(dead_code)]
+const fn _assert_storeref_covariant<'short, 'long: 'short>(x: StoreRef<'long, u8>) -> StoreRef<'short, u8> {
+    x
+}
+#[allow(dead_code)]
+const fn _assert_expr_covariant<'short, 'long: 'short>(x: crate::Expr<'long>) -> crate::Expr<'short> {
+    x
+}
+#[allow(dead_code)]
+const fn _assert_part_covariant<'short, 'long: 'short>(x: Part<'long>) -> Part<'short> {
+    x
+}
+#[allow(dead_code)]
+const fn _assert_ast_covariant<'short, 'long: 'short>(x: crate::Ast<'long>) -> crate::Ast<'short> {
+    x
+}

--- a/src/ast/runtime.rs
+++ b/src/ast/runtime.rs
@@ -30,14 +30,14 @@ impl Runtime {
 
 /// Zig: `Runtime.Features.ReplaceableExport`
 #[derive(Clone)]
-pub enum ReplaceableExport {
+pub enum ReplaceableExport<'arena> {
     Delete,
-    Replace(Expr),
-    Inject { name: Box<[u8]>, value: Expr },
+    Replace(Expr<'arena>),
+    Inject { name: Box<[u8]>, value: Expr<'arena> },
     // TODO(port): `name` was `string` (= []const u8). Ownership unclear; using Box<[u8]>.
 }
 
-impl ReplaceableExport {
+impl<'arena> ReplaceableExport<'arena> {
     #[inline]
     pub fn is_replace(&self) -> bool {
         matches!(self, Self::Replace(_))
@@ -51,29 +51,29 @@ impl ReplaceableExport {
 /// satisfies the `replace_exports.entries.len` shape `visitStmt` ported
 /// verbatim from Zig's `ArrayHashMap.entries`.
 #[derive(Default)]
-pub struct ReplaceableExportMap {
+pub struct ReplaceableExportMap<'arena> {
     /// Backing map. Named `entries` so `replace_exports.entries.len()` —
     /// the literal Zig spelling — resolves (Zig's `ArrayHashMap.entries`
     /// is a `MultiArrayList` with `.len`; here `StringArrayHashMap` derefs
     /// to `ArrayHashMap` which has `.len()`).
-    pub entries: StringArrayHashMap<ReplaceableExport>,
+    pub entries: StringArrayHashMap<ReplaceableExport<'arena>>,
 }
 
-impl core::ops::Deref for ReplaceableExportMap {
-    type Target = StringArrayHashMap<ReplaceableExport>;
+impl<'arena> core::ops::Deref for ReplaceableExportMap<'arena> {
+    type Target = StringArrayHashMap<ReplaceableExport<'arena>>;
     #[inline]
     fn deref(&self) -> &Self::Target {
         &self.entries
     }
 }
-impl core::ops::DerefMut for ReplaceableExportMap {
+impl<'arena> core::ops::DerefMut for ReplaceableExportMap<'arena> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.entries
     }
 }
 
-impl ReplaceableExportMap {
+impl<'arena> ReplaceableExportMap<'arena> {
     #[inline]
     pub fn count(&self) -> usize {
         self.entries.count()
@@ -83,11 +83,11 @@ impl ReplaceableExportMap {
     /// `get_ptr` (`&V`) and `get_ptr_mut` (`&mut V`); call sites in the
     /// visitor only read through it.
     #[inline]
-    pub fn get_ptr(&self, key: &[u8]) -> Option<&ReplaceableExport> {
+    pub fn get_ptr(&self, key: &[u8]) -> Option<&ReplaceableExport<'arena>> {
         self.entries.get(key)
     }
     #[inline]
-    pub fn get_ptr_mut(&mut self, key: &[u8]) -> Option<&mut ReplaceableExport> {
+    pub fn get_ptr_mut(&mut self, key: &[u8]) -> Option<&mut ReplaceableExport<'arena>> {
         self.entries.get_ptr_mut(key)
     }
     #[inline]

--- a/src/ast/s.rs
+++ b/src/ast/s.rs
@@ -12,12 +12,12 @@ use crate::{
 };
 use crate::{StoreSlice, StoreStr};
 
-pub struct Block {
-    pub stmts: StmtNodeList,
+pub struct Block<'arena> {
+    pub stmts: StmtNodeList<'arena>,
     pub close_brace_loc: crate::Loc, // = crate::Loc::EMPTY
 }
 
-impl Default for Block {
+impl<'arena> Default for Block<'arena> {
     fn default() -> Self {
         Self {
             stmts: StmtNodeList::EMPTY,
@@ -27,8 +27,8 @@ impl Default for Block {
 }
 
 #[derive(Default)]
-pub struct SExpr {
-    pub value: ExprNodeIndex,
+pub struct SExpr<'arena> {
+    pub value: ExprNodeIndex<'arena>,
 
     /// This is set to true for automatically-generated expressions that should
     /// not affect tree shaking. For example, calling a function from the runtime
@@ -36,37 +36,37 @@ pub struct SExpr {
     pub does_not_affect_tree_shaking: bool, // = false
 }
 
-pub struct Comment {
-    pub text: StoreStr, // arena-owned
+pub struct Comment<'arena> {
+    pub text: StoreStr<'arena>, // arena-owned
 }
 
-pub struct Directive {
-    pub value: StoreStr, // arena-owned
+pub struct Directive<'arena> {
+    pub value: StoreStr<'arena>, // arena-owned
 }
 
 #[derive(Default)]
-pub struct ExportClause {
-    pub items: StoreSlice<ClauseItem>, // arena-owned
+pub struct ExportClause<'arena> {
+    pub items: StoreSlice<'arena, ClauseItem<'arena>>, // arena-owned
     pub is_single_line: bool,
 }
 
 #[derive(Clone, Copy, Default)]
 pub struct Empty {}
 
-pub struct ExportStar {
+pub struct ExportStar<'arena> {
     pub namespace_ref: Ref,
-    pub alias: Option<G::ExportStarAlias>, // = None
+    pub alias: Option<G::ExportStarAlias<'arena>>, // = None
     pub import_record_index: u32,
 }
 
 /// This is an "export = value;" statement in TypeScript
-pub struct ExportEquals {
-    pub value: ExprNodeIndex,
+pub struct ExportEquals<'arena> {
+    pub value: ExprNodeIndex<'arena>,
 }
 
-pub struct Label {
+pub struct Label<'arena> {
     pub name: LocRef,
-    pub stmt: StmtNodeIndex,
+    pub stmt: StmtNodeIndex<'arena>,
 }
 
 /// This is a stand-in for a TypeScript type declaration
@@ -76,19 +76,19 @@ pub struct TypeScript {}
 #[derive(Clone, Copy, Default)]
 pub struct Debugger {}
 
-pub struct ExportFrom {
-    pub items: StoreSlice<ClauseItem>, // arena-owned
+pub struct ExportFrom<'arena> {
+    pub items: StoreSlice<'arena, ClauseItem<'arena>>, // arena-owned
     pub namespace_ref: Ref,
     pub import_record_index: u32,
     pub is_single_line: bool,
 }
 
-pub struct ExportDefault {
+pub struct ExportDefault<'arena> {
     pub default_name: LocRef, // value may be a SFunction or SClass
-    pub value: StmtOrExpr,
+    pub value: StmtOrExpr<'arena>,
 }
 
-impl ExportDefault {
+impl<'arena> ExportDefault<'arena> {
     pub fn can_be_moved(&self) -> bool {
         match &self.value {
             StmtOrExpr::Expr(e) => e.can_be_moved(),
@@ -101,87 +101,87 @@ impl ExportDefault {
     }
 }
 
-pub struct Enum {
+pub struct Enum<'arena> {
     pub name: LocRef,
     pub arg: Ref,
-    pub values: StoreSlice<EnumValue>, // arena-owned
+    pub values: StoreSlice<'arena, EnumValue<'arena>>, // arena-owned
     pub is_export: bool,
 }
 
-pub struct Namespace {
+pub struct Namespace<'arena> {
     pub name: LocRef,
     pub arg: Ref,
-    pub stmts: StmtNodeList,
+    pub stmts: StmtNodeList<'arena>,
     pub is_export: bool,
 }
 
-pub struct Function {
-    pub func: G::Fn,
+pub struct Function<'arena> {
+    pub func: G::Fn<'arena>,
 }
 
 #[derive(Default)]
-pub struct Class {
-    pub class: G::Class,
+pub struct Class<'arena> {
+    pub class: G::Class<'arena>,
     pub is_export: bool, // = false
 }
 
-pub struct If {
-    pub test_: ExprNodeIndex,
-    pub yes: StmtNodeIndex,
-    pub no: Option<StmtNodeIndex>,
+pub struct If<'arena> {
+    pub test_: ExprNodeIndex<'arena>,
+    pub yes: StmtNodeIndex<'arena>,
+    pub no: Option<StmtNodeIndex<'arena>>,
 }
 
-pub struct For {
+pub struct For<'arena> {
     /// May be a SConst, SLet, SVar, or SExpr
-    pub init: Option<StmtNodeIndex>, // = None
-    pub test_: Option<ExprNodeIndex>,  // = None
-    pub update: Option<ExprNodeIndex>, // = None
-    pub body: StmtNodeIndex,
+    pub init: Option<StmtNodeIndex<'arena>>, // = None
+    pub test_: Option<ExprNodeIndex<'arena>>,  // = None
+    pub update: Option<ExprNodeIndex<'arena>>, // = None
+    pub body: StmtNodeIndex<'arena>,
 }
 
-pub struct ForIn {
+pub struct ForIn<'arena> {
     /// May be a SConst, SLet, SVar, or SExpr
-    pub init: StmtNodeIndex,
-    pub value: ExprNodeIndex,
-    pub body: StmtNodeIndex,
+    pub init: StmtNodeIndex<'arena>,
+    pub value: ExprNodeIndex<'arena>,
+    pub body: StmtNodeIndex<'arena>,
 }
 
-pub struct ForOf {
+pub struct ForOf<'arena> {
     pub is_await: bool, // = false
     /// May be a SConst, SLet, SVar, or SExpr
-    pub init: StmtNodeIndex,
-    pub value: ExprNodeIndex,
-    pub body: StmtNodeIndex,
+    pub init: StmtNodeIndex<'arena>,
+    pub value: ExprNodeIndex<'arena>,
+    pub body: StmtNodeIndex<'arena>,
 }
 
-pub struct DoWhile {
-    pub body: StmtNodeIndex,
-    pub test_: ExprNodeIndex,
+pub struct DoWhile<'arena> {
+    pub body: StmtNodeIndex<'arena>,
+    pub test_: ExprNodeIndex<'arena>,
 }
 
-pub struct While {
-    pub test_: ExprNodeIndex,
-    pub body: StmtNodeIndex,
+pub struct While<'arena> {
+    pub test_: ExprNodeIndex<'arena>,
+    pub body: StmtNodeIndex<'arena>,
 }
 
-pub struct With {
-    pub value: ExprNodeIndex,
-    pub body: StmtNodeIndex,
+pub struct With<'arena> {
+    pub value: ExprNodeIndex<'arena>,
+    pub body: StmtNodeIndex<'arena>,
     pub body_loc: crate::Loc, // = crate::Loc::EMPTY
 }
 
-pub struct Try {
+pub struct Try<'arena> {
     pub body_loc: crate::Loc,
-    pub body: StmtNodeList,
+    pub body: StmtNodeList<'arena>,
 
-    pub catch_: Option<Catch>,    // = None
-    pub finally: Option<Finally>, // = None
+    pub catch_: Option<Catch<'arena>>,    // = None
+    pub finally: Option<Finally<'arena>>, // = None
 }
 
-pub struct Switch {
-    pub test_: ExprNodeIndex,
+pub struct Switch<'arena> {
+    pub test_: ExprNodeIndex<'arena>,
     pub body_loc: crate::Loc,
-    pub cases: StoreSlice<Case>, // arena-owned
+    pub cases: StoreSlice<'arena, Case<'arena>>, // arena-owned
 }
 
 /// This object represents all of these types of import statements:
@@ -194,7 +194,7 @@ pub struct Switch {
 ///
 /// Many parts are optional and can be combined in different ways. The only
 /// restriction is that you cannot have both a clause and a star namespace.
-pub struct Import {
+pub struct Import<'arena> {
     /// If this is a star import: This is a Ref for the namespace symbol. The Loc
     /// for the symbol is StarLoc.
     ///
@@ -203,13 +203,13 @@ pub struct Import {
     /// when converting this module to a CommonJS module.
     pub namespace_ref: Ref,
     pub default_name: Option<LocRef>,      // = None
-    pub items: StoreSlice<ClauseItem>,     // arena-owned; = &[]
+    pub items: StoreSlice<'arena, ClauseItem<'arena>>,     // arena-owned; = &[]
     pub star_name_loc: Option<crate::Loc>, // = None
     pub import_record_index: u32,
     pub is_single_line: bool, // = false
 }
 
-impl Default for Import {
+impl<'arena> Default for Import<'arena> {
     fn default() -> Self {
         Self {
             namespace_ref: Ref::NONE,
@@ -223,17 +223,17 @@ impl Default for Import {
 }
 
 #[derive(Default)]
-pub struct Return {
-    pub value: Option<ExprNodeIndex>, // = None
+pub struct Return<'arena> {
+    pub value: Option<ExprNodeIndex<'arena>>, // = None
 }
 
-pub struct Throw {
-    pub value: ExprNodeIndex,
+pub struct Throw<'arena> {
+    pub value: ExprNodeIndex<'arena>,
 }
 
-pub struct Local {
+pub struct Local<'arena> {
     pub kind: Kind,         // = Kind::KVar
-    pub decls: G::DeclList, // = .{}
+    pub decls: G::DeclList<'arena>, // = .{}
     pub is_export: bool,    // = false
     /// The TypeScript compiler doesn't generate code for "import foo = bar"
     /// statements where the import is never used.
@@ -242,7 +242,7 @@ pub struct Local {
     pub was_commonjs_export: bool, // = false
 }
 
-impl Default for Local {
+impl<'arena> Default for Local<'arena> {
     fn default() -> Self {
         Self {
             kind: Kind::default(),
@@ -254,7 +254,7 @@ impl Default for Local {
     }
 }
 
-impl Local {
+impl<'arena> Local<'arena> {
     pub fn can_merge_with(&self, other: &Local) -> bool {
         // Don't merge "using" / "await using" declarations. Merging them is
         // spec-compliant but matches esbuild's behavior of keeping them

--- a/src/ast/scope.rs
+++ b/src/ast/scope.rs
@@ -20,17 +20,17 @@ pub type MemberHashMap = StringHashMap<Member, AstAlloc>;
 // hold it by value and `toAST` / `init` bitwise-copy it (`this.module_scope`). Vec no
 // longer derives `Clone` (private `origin` field); callers that need a shallow copy must
 // `core::mem::take` or `core::ptr::read` instead.
-pub struct Scope {
+pub struct Scope<'arena> {
     pub id: usize,
     pub kind: Kind,
     // BACKREF: parent owns this scope via `children`. `StoreRef` (arena
     // back-pointer with safe `Deref`/`DerefMut`) so callers don't open-code
     // `unsafe { &*parent.as_ptr() }` at every walk site.
-    pub parent: Option<StoreRef<Scope>>,
+    pub parent: Option<StoreRef<'arena, Scope<'arena>>>,
     /// `AstVec` for the same reason as `members` above — Zig's
     /// `ArrayListUnmanaged(*Scope)` was arena-backed. Elements are `StoreRef`
     /// so iteration yields safe `Deref` instead of `unsafe { child.as_ref() }`.
-    pub children: AstVec<StoreRef<Scope>>,
+    pub children: AstVec<StoreRef<'arena, Scope<'arena>>>,
     pub members: MemberHashMap,
     /// `AstVec`: Zig `ArrayListUnmanaged(Ref)`, arena-backed.
     pub generated: AstVec<Ref>,
@@ -54,10 +54,10 @@ pub struct Scope {
     // This will be non-null if this is a TypeScript "namespace" or "enum"
     // ARENA: allocated from p.arena, never freed per-field. `StoreRef` so
     // callers read `scope.ts_namespace?.exported_members` safely.
-    pub ts_namespace: Option<StoreRef<TSNamespaceScope>>,
+    pub ts_namespace: Option<StoreRef<'arena, TSNamespaceScope<'arena>>>,
 }
 
-impl Scope {
+impl<'arena> Scope<'arena> {
     /// All-empty `Scope` as a `const`. Used with struct-update syntax in the
     /// parser's per-scope allocation hot path (`push_scope_for_parse_pass`
     /// runs once per `{}` / function / class body) so the unspecified fields
@@ -83,16 +83,16 @@ impl Scope {
     };
 }
 
-impl Default for Scope {
+impl<'arena> Default for Scope<'arena> {
     #[inline]
     fn default() -> Self {
         Self::EMPTY
     }
 }
 
-pub type NestedScopeMap = ArrayHashMap<u32, Vec<StoreRef<Scope>>>;
+pub type NestedScopeMap<'arena> = ArrayHashMap<u32, Vec<StoreRef<'arena, Scope<'arena>>>>;
 
-impl Scope {
+impl<'arena> Scope<'arena> {
     // PERF(port): the parser's hot path computes the wyhash once and reuses it
     // for lookup+insert; `StringHashMap`'s current `std::HashMap` backing
     // ignores the precomputed hash (see `get_adapted` doc), so the rehash

--- a/src/ast/stmt.rs
+++ b/src/ast/stmt.rs
@@ -6,14 +6,14 @@ use crate::s as S;
 use crate::{DebugOnlyDisabler, NewBatcher, StoreRef};
 
 #[derive(Clone, Copy)]
-pub struct Stmt {
+pub struct Stmt<'arena> {
     pub loc: crate::Loc,
-    pub data: Data,
+    pub data: Data<'arena>,
 }
 
-pub type Batcher = NewBatcher<Stmt>;
+pub type Batcher<'arena> = NewBatcher<'arena, Stmt<'arena>>;
 
-impl Stmt {
+impl<'arena> Stmt<'arena> {
     /// Zig: `Stmt.Data.Store.reset()`. Associated wrapper so downstream crates
     /// can call `crate::Stmt::data_store_reset()` without naming the
     /// thread-local Store module path.
@@ -34,7 +34,7 @@ impl Stmt {
         crate::DebugOnlyDisabler::<Stmt>::assert();
     }
 
-    pub fn assign(a: Expr, b: Expr) -> Stmt {
+    pub fn assign(a: Expr<'arena>, b: Expr<'arena>) -> Stmt<'arena> {
         Stmt::alloc(
             S::SExpr {
                 value: Expr::assign(a, b),
@@ -49,14 +49,14 @@ impl Stmt {
 // shape-agnostic `JsonWriter::write<V>`; fields are the serialization
 // contract, not dead, but no reflective writer exists yet to read them.
 #[expect(dead_code)]
-struct Serializable {
+struct Serializable<'arena> {
     r#type: Tag,
     object: &'static [u8],
-    value: Data,
+    value: Data<'arena>,
     loc: crate::Loc,
 }
 
-impl Stmt {
+impl<'arena> Stmt<'arena> {
     pub fn json_stringify<W>(&self, writer: &mut W) -> Result<(), bun_core::Error>
     where
         W: crate::JsonWriter,
@@ -89,14 +89,14 @@ impl Stmt {
         false
     }
 
-    pub fn empty() -> Stmt {
+    pub fn empty() -> Stmt<'arena> {
         Stmt {
             data: Data::SEmpty(NONE),
             loc: crate::Loc::default(),
         }
     }
 
-    pub fn to_empty(self) -> Stmt {
+    pub fn to_empty(self) -> Stmt<'arena> {
         Stmt {
             data: Data::SEmpty(NONE),
             loc: self.loc,
@@ -104,7 +104,7 @@ impl Stmt {
     }
 }
 
-impl Default for Stmt {
+impl<'arena> Default for Stmt<'arena> {
     /// Zig: `nullStmtData = Stmt.Data{ .s_empty = s_missing }` (P.zig) — used to
     /// zero-init `loop_body` and bulk-fill stmt slices before population.
     #[inline]
@@ -131,18 +131,18 @@ pub static ICOUNT: AtomicUsize = AtomicUsize::new(0);
 /// The Zig used three near-identical 32-arm comptime switches; in Rust the
 /// dispatch is the trait impl and the arm list is the `impl_statement_data!`
 /// invocation below — diff that list against the Zig switch.
-pub trait StatementData: Sized {
+pub trait StatementData<'arena>: Sized {
     /// Wrap an already-allocated payload (Zig `Stmt.init` / `comptime_init`).
-    fn wrap_ref(ptr: StoreRef<Self>) -> Data;
+    fn wrap_ref(ptr: StoreRef<'arena, Self>) -> Data<'arena>;
     /// Store-append `self` and wrap (Zig `Stmt.alloc` / `comptime_alloc`).
-    fn store_alloc(self) -> Data;
+    fn store_alloc(self) -> Data<'arena>;
     /// Arena-allocate `self` and wrap (Zig `Stmt.allocate` / `allocateData`).
-    fn arena_alloc(self, bump: &bun_alloc::Arena) -> Data;
+    fn arena_alloc(self, bump: &bun_alloc::Arena) -> Data<'arena>;
 }
 
-impl Stmt {
+impl<'arena> Stmt<'arena> {
     #[inline]
-    pub fn init<T: StatementData>(orig_data: StoreRef<T>, loc: crate::Loc) -> Stmt {
+    pub fn init<T: StatementData<'arena>>(orig_data: StoreRef<'arena, T>, loc: crate::Loc) -> Stmt<'arena> {
         #[cfg(debug_assertions)]
         ICOUNT.fetch_add(1, Ordering::Relaxed);
         Stmt {
@@ -154,7 +154,7 @@ impl Stmt {
     // Zig `comptime_alloc` — folded into `StatementData::store_alloc`; kept as a
     // private helper for diff parity.
     #[inline]
-    fn comptime_alloc<T: StatementData>(orig_data: T, loc: crate::Loc) -> Stmt {
+    fn comptime_alloc<T: StatementData<'arena>>(orig_data: T, loc: crate::Loc) -> Stmt<'arena> {
         Stmt {
             loc,
             data: orig_data.store_alloc(),
@@ -162,11 +162,11 @@ impl Stmt {
     }
 
     // Zig `allocateData` — folded into `StatementData::arena_alloc`.
-    fn allocate_data<T: StatementData>(
+    fn allocate_data<T: StatementData<'arena>>(
         bump: &bun_alloc::Arena,
         orig_data: T,
         loc: crate::Loc,
-    ) -> Stmt {
+    ) -> Stmt<'arena> {
         // `arena.create(@TypeOf(origData)) catch unreachable; value.* = origData;`
         // → bump.alloc(orig_data), performed inside arena_alloc.
         Stmt {
@@ -181,7 +181,7 @@ impl Stmt {
     // TODO(port): no direct equivalent; callers use the trait.
 
     #[inline]
-    pub fn alloc<T: StatementData>(orig_data: T, loc: crate::Loc) -> Stmt {
+    pub fn alloc<T: StatementData<'arena>>(orig_data: T, loc: crate::Loc) -> Stmt<'arena> {
         data::Store::assert();
         #[cfg(debug_assertions)]
         ICOUNT.fetch_add(1, Ordering::Relaxed);
@@ -189,24 +189,24 @@ impl Stmt {
     }
 }
 
-pub type Disabler = DebugOnlyDisabler<Stmt>;
+pub type Disabler = DebugOnlyDisabler<Stmt<'static>>;
 
-impl Stmt {
+impl<'arena> Stmt<'arena> {
     /// When the lifetime of an Stmt.Data's pointer must exist longer than reset() is called, use this function.
     /// Be careful to free the memory (or use an arena that does it for you)
     /// Also, prefer Stmt.init or Stmt.alloc when possible. This will be slower.
-    pub fn allocate<T: StatementData>(
+    pub fn allocate<T: StatementData<'arena>>(
         bump: &bun_alloc::Arena,
         orig_data: T,
         loc: crate::Loc,
-    ) -> Stmt {
+    ) -> Stmt<'arena> {
         data::Store::assert();
         #[cfg(debug_assertions)]
         ICOUNT.fetch_add(1, Ordering::Relaxed);
         Stmt::allocate_data(bump, orig_data, loc)
     }
 
-    pub fn allocate_expr(bump: &bun_alloc::Arena, expr: Expr) -> Stmt {
+    pub fn allocate_expr(bump: &bun_alloc::Arena, expr: Expr<'arena>) -> Stmt<'arena> {
         Stmt::allocate(
             bump,
             S::SExpr {
@@ -222,31 +222,46 @@ impl Stmt {
 
 macro_rules! impl_statement_data {
     // Pointer-payload variants: stored via Store / arena.
-    ( ptr: $( ($ty:ty, $variant:ident) ),* $(,)?
+    ( ptr: $( ($ty:ident, $variant:ident) ),* $(,)?
+      ; ptr_nolife: $( ($pty:ident, $pvariant:ident) ),* $(,)?
       ; inline: $( ($ity:ty, $ivariant:ident) ),* $(,)? ) => {
         $(
-            impl StatementData for $ty {
+            impl<'arena> StatementData<'arena> for S::$ty<'arena> {
                 #[inline]
-                fn wrap_ref(ptr: StoreRef<Self>) -> Data { Data::$variant(ptr) }
+                fn wrap_ref(ptr: StoreRef<'arena, Self>) -> Data<'arena> { Data::$variant(ptr) }
                 #[inline]
-                fn store_alloc(self) -> Data {
+                fn store_alloc(self) -> Data<'arena> {
                     Data::$variant(data::Store::append(self))
                 }
                 #[inline]
-                fn arena_alloc(self, bump: &bun_alloc::Arena) -> Data {
+                fn arena_alloc(self, bump: &bun_alloc::Arena) -> Data<'arena> {
                     // TODO(port): StoreRef vs &'bump — Phase B unify arena ref type
                     Data::$variant(StoreRef::from_bump(bump.alloc(self)))
                 }
             }
         )*
         $(
-            impl StatementData for $ity {
+            impl<'arena> StatementData<'arena> for S::$pty {
                 #[inline]
-                fn wrap_ref(_ptr: StoreRef<Self>) -> Data { Data::$ivariant(<$ity>::default()) }
+                fn wrap_ref(ptr: StoreRef<'arena, Self>) -> Data<'arena> { Data::$pvariant(ptr) }
                 #[inline]
-                fn store_alloc(self) -> Data { Data::$ivariant(self) }
+                fn store_alloc(self) -> Data<'arena> {
+                    Data::$pvariant(data::Store::append(self))
+                }
                 #[inline]
-                fn arena_alloc(self, _bump: &bun_alloc::Arena) -> Data { Data::$ivariant(self) }
+                fn arena_alloc(self, bump: &bun_alloc::Arena) -> Data<'arena> {
+                    Data::$pvariant(StoreRef::from_bump(bump.alloc(self)))
+                }
+            }
+        )*
+        $(
+            impl<'arena> StatementData<'arena> for $ity {
+                #[inline]
+                fn wrap_ref(_ptr: StoreRef<'arena, Self>) -> Data<'arena> { Data::$ivariant(<$ity>::default()) }
+                #[inline]
+                fn store_alloc(self) -> Data<'arena> { Data::$ivariant(self) }
+                #[inline]
+                fn arena_alloc(self, _bump: &bun_alloc::Arena) -> Data<'arena> { Data::$ivariant(self) }
             }
         )*
     };
@@ -254,35 +269,36 @@ macro_rules! impl_statement_data {
 
 impl_statement_data! {
     ptr:
-        (S::Block,         SBlock),
-        (S::Break,         SBreak),
-        (S::Class,         SClass),
-        (S::Comment,       SComment),
-        (S::Continue,      SContinue),
-        (S::Directive,     SDirective),
-        (S::DoWhile,       SDoWhile),
-        (S::Enum,          SEnum),
-        (S::ExportClause,  SExportClause),
-        (S::ExportDefault, SExportDefault),
-        (S::ExportEquals,  SExportEquals),
-        (S::ExportFrom,    SExportFrom),
-        (S::ExportStar,    SExportStar),
-        (S::SExpr,         SExpr),
-        (S::ForIn,         SForIn),
-        (S::ForOf,         SForOf),
-        (S::For,           SFor),
-        (S::Function,      SFunction),
-        (S::If,            SIf),
-        (S::Import,        SImport),
-        (S::Label,         SLabel),
-        (S::Local,         SLocal),
-        (S::Namespace,     SNamespace),
-        (S::Return,        SReturn),
-        (S::Switch,        SSwitch),
-        (S::Throw,         SThrow),
-        (S::Try,           STry),
-        (S::While,         SWhile),
-        (S::With,          SWith),
+        (Block,         SBlock),
+        (Class,         SClass),
+        (Comment,       SComment),
+        (Directive,     SDirective),
+        (DoWhile,       SDoWhile),
+        (Enum,          SEnum),
+        (ExportClause,  SExportClause),
+        (ExportDefault, SExportDefault),
+        (ExportEquals,  SExportEquals),
+        (ExportFrom,    SExportFrom),
+        (ExportStar,    SExportStar),
+        (SExpr,         SExpr),
+        (ForIn,         SForIn),
+        (ForOf,         SForOf),
+        (For,           SFor),
+        (Function,      SFunction),
+        (If,            SIf),
+        (Import,        SImport),
+        (Label,         SLabel),
+        (Local,         SLocal),
+        (Namespace,     SNamespace),
+        (Return,        SReturn),
+        (Switch,        SSwitch),
+        (Throw,         SThrow),
+        (Try,           STry),
+        (While,         SWhile),
+        (With,          SWith),
+    ; ptr_nolife:
+        (Break,         SBreak),
+        (Continue,      SContinue),
     ; inline:
         (S::Empty,      SEmpty),
         (S::Debugger,   SDebugger),
@@ -352,42 +368,42 @@ impl Tag {
 
 #[derive(Clone, Copy, bun_core::EnumTag)]
 #[enum_tag(existing = Tag)]
-pub enum Data {
-    SBlock(StoreRef<S::Block>),
-    SBreak(StoreRef<S::Break>),
-    SClass(StoreRef<S::Class>),
-    SComment(StoreRef<S::Comment>),
-    SContinue(StoreRef<S::Continue>),
-    SDirective(StoreRef<S::Directive>),
-    SDoWhile(StoreRef<S::DoWhile>),
-    SEnum(StoreRef<S::Enum>),
-    SExportClause(StoreRef<S::ExportClause>),
-    SExportDefault(StoreRef<S::ExportDefault>),
-    SExportEquals(StoreRef<S::ExportEquals>),
-    SExportFrom(StoreRef<S::ExportFrom>),
-    SExportStar(StoreRef<S::ExportStar>),
-    SExpr(StoreRef<S::SExpr>),
-    SForIn(StoreRef<S::ForIn>),
-    SForOf(StoreRef<S::ForOf>),
-    SFor(StoreRef<S::For>),
-    SFunction(StoreRef<S::Function>),
-    SIf(StoreRef<S::If>),
-    SImport(StoreRef<S::Import>),
-    SLabel(StoreRef<S::Label>),
-    SLocal(StoreRef<S::Local>),
-    SNamespace(StoreRef<S::Namespace>),
-    SReturn(StoreRef<S::Return>),
-    SSwitch(StoreRef<S::Switch>),
-    SThrow(StoreRef<S::Throw>),
-    STry(StoreRef<S::Try>),
-    SWhile(StoreRef<S::While>),
-    SWith(StoreRef<S::With>),
+pub enum Data<'arena> {
+    SBlock(StoreRef<'arena, S::Block<'arena>>),
+    SBreak(StoreRef<'arena, S::Break>),
+    SClass(StoreRef<'arena, S::Class<'arena>>),
+    SComment(StoreRef<'arena, S::Comment<'arena>>),
+    SContinue(StoreRef<'arena, S::Continue>),
+    SDirective(StoreRef<'arena, S::Directive<'arena>>),
+    SDoWhile(StoreRef<'arena, S::DoWhile<'arena>>),
+    SEnum(StoreRef<'arena, S::Enum<'arena>>),
+    SExportClause(StoreRef<'arena, S::ExportClause<'arena>>),
+    SExportDefault(StoreRef<'arena, S::ExportDefault<'arena>>),
+    SExportEquals(StoreRef<'arena, S::ExportEquals<'arena>>),
+    SExportFrom(StoreRef<'arena, S::ExportFrom<'arena>>),
+    SExportStar(StoreRef<'arena, S::ExportStar<'arena>>),
+    SExpr(StoreRef<'arena, S::SExpr<'arena>>),
+    SForIn(StoreRef<'arena, S::ForIn<'arena>>),
+    SForOf(StoreRef<'arena, S::ForOf<'arena>>),
+    SFor(StoreRef<'arena, S::For<'arena>>),
+    SFunction(StoreRef<'arena, S::Function<'arena>>),
+    SIf(StoreRef<'arena, S::If<'arena>>),
+    SImport(StoreRef<'arena, S::Import<'arena>>),
+    SLabel(StoreRef<'arena, S::Label<'arena>>),
+    SLocal(StoreRef<'arena, S::Local<'arena>>),
+    SNamespace(StoreRef<'arena, S::Namespace<'arena>>),
+    SReturn(StoreRef<'arena, S::Return<'arena>>),
+    SSwitch(StoreRef<'arena, S::Switch<'arena>>),
+    SThrow(StoreRef<'arena, S::Throw<'arena>>),
+    STry(StoreRef<'arena, S::Try<'arena>>),
+    SWhile(StoreRef<'arena, S::While<'arena>>),
+    SWith(StoreRef<'arena, S::With<'arena>>),
 
     STypeScript(S::TypeScript),
     SEmpty(S::Empty), // special case, its a zero value type
     SDebugger(S::Debugger),
 
-    SLazyExport(StoreRef<expr::Data>),
+    SLazyExport(StoreRef<'arena, expr::Data<'arena>>),
 }
 
 // ── Layout guards ─────────────────────────────────────────────────────────
@@ -400,25 +416,25 @@ pub enum Data {
 // NonNull niche), so `Option<Stmt>` / `Option<Data>` add no discriminant word.
 // Adding `#[repr(C)]`/`#[repr(u8)]` to `Data` or a nullable `*mut T` payload
 // would break this — the asserts catch it.
-const _: () = assert!(core::mem::size_of::<Data>() == 16);
+const _: () = assert!(core::mem::size_of::<Data<'static>>() == 16);
 const _: () = assert!(
-    core::mem::size_of::<Stmt>() <= 24,
+    core::mem::size_of::<Stmt<'static>>() <= 24,
     "Expected Stmt to be <= 24 bytes"
 );
 const _: () = assert!(
-    core::mem::size_of::<Option<Data>>() == core::mem::size_of::<Data>(),
+    core::mem::size_of::<Option<Data<'static>>>() == core::mem::size_of::<Data<'static>>(),
     "stmt::Data lost its niche — check for #[repr] or nullable-ptr payload"
 );
 const _: () = assert!(
-    core::mem::size_of::<Option<Stmt>>() == core::mem::size_of::<Stmt>(),
+    core::mem::size_of::<Option<Stmt<'static>>>() == core::mem::size_of::<Stmt<'static>>(),
     "Stmt lost its niche"
 );
-const _: () = assert!(core::mem::size_of::<StoreRef<S::SExpr>>() == core::mem::size_of::<usize>());
+const _: () = assert!(core::mem::size_of::<StoreRef<'static, S::SExpr<'static>>>() == core::mem::size_of::<usize>());
 
 /// Zig: `std.meta.eql(p.loop_body, stmt.data)` (visitStmt.zig) — tag compare,
 /// then payload compare. Payloads here are arena pointers (`StoreRef<T>`) or
 /// ZSTs, so this is tag + pointer-identity, never a deep structural compare.
-impl PartialEq for Data {
+impl<'arena> PartialEq for Data<'arena> {
     fn eq(&self, other: &Self) -> bool {
         use Data::*;
         match (*self, *other) {
@@ -459,7 +475,7 @@ impl PartialEq for Data {
         }
     }
 }
-impl Eq for Data {}
+impl<'arena> Eq for Data<'arena> {}
 
 // Zig field-style union accessors (`data.s_function`, `data.s_local`, …).
 // visitStmt and the printer port from Zig's `data.s_local.*` etc., which are
@@ -467,10 +483,10 @@ impl Eq for Data {}
 // the `Option` is the cheapest sound encoding of Zig's UB-on-mismatch.
 // Mirrors `expr::Data::e_*()`. Returns `Option<StoreRef<T>>` (Copy) for
 // pointer-payload variants and `Option<T>` by value for inline ZST variants.
-impl Data {
-    // ── StoreRef<S::*> field-style accessors ────────────────────────────
+impl<'arena> Data<'arena> {
+    // ── StoreRef<'arena, S::*> field-style accessors ────────────────────────────
     #[inline]
-    pub fn s_block(&self) -> Option<StoreRef<S::Block>> {
+    pub fn s_block(&self) -> Option<StoreRef<'arena, S::Block<'arena>>> {
         if let Data::SBlock(v) = *self {
             Some(v)
         } else {
@@ -478,7 +494,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_block_mut(&mut self) -> Option<&mut S::Block> {
+    pub fn s_block_mut(&mut self) -> Option<&mut S::Block<'arena>> {
         if let Data::SBlock(v) = self {
             Some(&mut **v)
         } else {
@@ -486,7 +502,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_break(&self) -> Option<StoreRef<S::Break>> {
+    pub fn s_break(&self) -> Option<StoreRef<'arena, S::Break>> {
         if let Data::SBreak(v) = *self {
             Some(v)
         } else {
@@ -502,7 +518,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_class(&self) -> Option<StoreRef<S::Class>> {
+    pub fn s_class(&self) -> Option<StoreRef<'arena, S::Class<'arena>>> {
         if let Data::SClass(v) = *self {
             Some(v)
         } else {
@@ -510,7 +526,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_class_mut(&mut self) -> Option<&mut S::Class> {
+    pub fn s_class_mut(&mut self) -> Option<&mut S::Class<'arena>> {
         if let Data::SClass(v) = self {
             Some(&mut **v)
         } else {
@@ -518,7 +534,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_comment(&self) -> Option<StoreRef<S::Comment>> {
+    pub fn s_comment(&self) -> Option<StoreRef<'arena, S::Comment<'arena>>> {
         if let Data::SComment(v) = *self {
             Some(v)
         } else {
@@ -526,7 +542,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_comment_mut(&mut self) -> Option<&mut S::Comment> {
+    pub fn s_comment_mut(&mut self) -> Option<&mut S::Comment<'arena>> {
         if let Data::SComment(v) = self {
             Some(&mut **v)
         } else {
@@ -534,7 +550,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_continue(&self) -> Option<StoreRef<S::Continue>> {
+    pub fn s_continue(&self) -> Option<StoreRef<'arena, S::Continue>> {
         if let Data::SContinue(v) = *self {
             Some(v)
         } else {
@@ -550,7 +566,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_directive(&self) -> Option<StoreRef<S::Directive>> {
+    pub fn s_directive(&self) -> Option<StoreRef<'arena, S::Directive<'arena>>> {
         if let Data::SDirective(v) = *self {
             Some(v)
         } else {
@@ -558,7 +574,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_directive_mut(&mut self) -> Option<&mut S::Directive> {
+    pub fn s_directive_mut(&mut self) -> Option<&mut S::Directive<'arena>> {
         if let Data::SDirective(v) = self {
             Some(&mut **v)
         } else {
@@ -566,7 +582,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_do_while(&self) -> Option<StoreRef<S::DoWhile>> {
+    pub fn s_do_while(&self) -> Option<StoreRef<'arena, S::DoWhile<'arena>>> {
         if let Data::SDoWhile(v) = *self {
             Some(v)
         } else {
@@ -574,7 +590,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_do_while_mut(&mut self) -> Option<&mut S::DoWhile> {
+    pub fn s_do_while_mut(&mut self) -> Option<&mut S::DoWhile<'arena>> {
         if let Data::SDoWhile(v) = self {
             Some(&mut **v)
         } else {
@@ -582,7 +598,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_enum(&self) -> Option<StoreRef<S::Enum>> {
+    pub fn s_enum(&self) -> Option<StoreRef<'arena, S::Enum<'arena>>> {
         if let Data::SEnum(v) = *self {
             Some(v)
         } else {
@@ -590,7 +606,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_enum_mut(&mut self) -> Option<&mut S::Enum> {
+    pub fn s_enum_mut(&mut self) -> Option<&mut S::Enum<'arena>> {
         if let Data::SEnum(v) = self {
             Some(&mut **v)
         } else {
@@ -598,7 +614,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_export_clause(&self) -> Option<StoreRef<S::ExportClause>> {
+    pub fn s_export_clause(&self) -> Option<StoreRef<'arena, S::ExportClause<'arena>>> {
         if let Data::SExportClause(v) = *self {
             Some(v)
         } else {
@@ -606,7 +622,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_export_clause_mut(&mut self) -> Option<&mut S::ExportClause> {
+    pub fn s_export_clause_mut(&mut self) -> Option<&mut S::ExportClause<'arena>> {
         if let Data::SExportClause(v) = self {
             Some(&mut **v)
         } else {
@@ -614,7 +630,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_export_default(&self) -> Option<StoreRef<S::ExportDefault>> {
+    pub fn s_export_default(&self) -> Option<StoreRef<'arena, S::ExportDefault<'arena>>> {
         if let Data::SExportDefault(v) = *self {
             Some(v)
         } else {
@@ -622,7 +638,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_export_default_mut(&mut self) -> Option<&mut S::ExportDefault> {
+    pub fn s_export_default_mut(&mut self) -> Option<&mut S::ExportDefault<'arena>> {
         if let Data::SExportDefault(v) = self {
             Some(&mut **v)
         } else {
@@ -630,7 +646,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_export_equals(&self) -> Option<StoreRef<S::ExportEquals>> {
+    pub fn s_export_equals(&self) -> Option<StoreRef<'arena, S::ExportEquals<'arena>>> {
         if let Data::SExportEquals(v) = *self {
             Some(v)
         } else {
@@ -638,7 +654,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_export_equals_mut(&mut self) -> Option<&mut S::ExportEquals> {
+    pub fn s_export_equals_mut(&mut self) -> Option<&mut S::ExportEquals<'arena>> {
         if let Data::SExportEquals(v) = self {
             Some(&mut **v)
         } else {
@@ -646,7 +662,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_export_from(&self) -> Option<StoreRef<S::ExportFrom>> {
+    pub fn s_export_from(&self) -> Option<StoreRef<'arena, S::ExportFrom<'arena>>> {
         if let Data::SExportFrom(v) = *self {
             Some(v)
         } else {
@@ -654,7 +670,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_export_from_mut(&mut self) -> Option<&mut S::ExportFrom> {
+    pub fn s_export_from_mut(&mut self) -> Option<&mut S::ExportFrom<'arena>> {
         if let Data::SExportFrom(v) = self {
             Some(&mut **v)
         } else {
@@ -662,7 +678,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_export_star(&self) -> Option<StoreRef<S::ExportStar>> {
+    pub fn s_export_star(&self) -> Option<StoreRef<'arena, S::ExportStar<'arena>>> {
         if let Data::SExportStar(v) = *self {
             Some(v)
         } else {
@@ -670,7 +686,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_export_star_mut(&mut self) -> Option<&mut S::ExportStar> {
+    pub fn s_export_star_mut(&mut self) -> Option<&mut S::ExportStar<'arena>> {
         if let Data::SExportStar(v) = self {
             Some(&mut **v)
         } else {
@@ -678,7 +694,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_expr(&self) -> Option<StoreRef<S::SExpr>> {
+    pub fn s_expr(&self) -> Option<StoreRef<'arena, S::SExpr<'arena>>> {
         if let Data::SExpr(v) = *self {
             Some(v)
         } else {
@@ -686,7 +702,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_expr_mut(&mut self) -> Option<&mut S::SExpr> {
+    pub fn s_expr_mut(&mut self) -> Option<&mut S::SExpr<'arena>> {
         if let Data::SExpr(v) = self {
             Some(&mut **v)
         } else {
@@ -694,7 +710,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_for_in(&self) -> Option<StoreRef<S::ForIn>> {
+    pub fn s_for_in(&self) -> Option<StoreRef<'arena, S::ForIn<'arena>>> {
         if let Data::SForIn(v) = *self {
             Some(v)
         } else {
@@ -702,7 +718,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_for_in_mut(&mut self) -> Option<&mut S::ForIn> {
+    pub fn s_for_in_mut(&mut self) -> Option<&mut S::ForIn<'arena>> {
         if let Data::SForIn(v) = self {
             Some(&mut **v)
         } else {
@@ -710,7 +726,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_for_of(&self) -> Option<StoreRef<S::ForOf>> {
+    pub fn s_for_of(&self) -> Option<StoreRef<'arena, S::ForOf<'arena>>> {
         if let Data::SForOf(v) = *self {
             Some(v)
         } else {
@@ -718,7 +734,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_for_of_mut(&mut self) -> Option<&mut S::ForOf> {
+    pub fn s_for_of_mut(&mut self) -> Option<&mut S::ForOf<'arena>> {
         if let Data::SForOf(v) = self {
             Some(&mut **v)
         } else {
@@ -726,7 +742,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_for(&self) -> Option<StoreRef<S::For>> {
+    pub fn s_for(&self) -> Option<StoreRef<'arena, S::For<'arena>>> {
         if let Data::SFor(v) = *self {
             Some(v)
         } else {
@@ -734,7 +750,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_for_mut(&mut self) -> Option<&mut S::For> {
+    pub fn s_for_mut(&mut self) -> Option<&mut S::For<'arena>> {
         if let Data::SFor(v) = self {
             Some(&mut **v)
         } else {
@@ -742,7 +758,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_function(&self) -> Option<StoreRef<S::Function>> {
+    pub fn s_function(&self) -> Option<StoreRef<'arena, S::Function<'arena>>> {
         if let Data::SFunction(v) = *self {
             Some(v)
         } else {
@@ -750,7 +766,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_function_mut(&mut self) -> Option<&mut S::Function> {
+    pub fn s_function_mut(&mut self) -> Option<&mut S::Function<'arena>> {
         if let Data::SFunction(v) = self {
             Some(&mut **v)
         } else {
@@ -758,7 +774,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_if(&self) -> Option<StoreRef<S::If>> {
+    pub fn s_if(&self) -> Option<StoreRef<'arena, S::If<'arena>>> {
         if let Data::SIf(v) = *self {
             Some(v)
         } else {
@@ -766,7 +782,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_if_mut(&mut self) -> Option<&mut S::If> {
+    pub fn s_if_mut(&mut self) -> Option<&mut S::If<'arena>> {
         if let Data::SIf(v) = self {
             Some(&mut **v)
         } else {
@@ -774,7 +790,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_import(&self) -> Option<StoreRef<S::Import>> {
+    pub fn s_import(&self) -> Option<StoreRef<'arena, S::Import<'arena>>> {
         if let Data::SImport(v) = *self {
             Some(v)
         } else {
@@ -782,7 +798,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_import_mut(&mut self) -> Option<&mut S::Import> {
+    pub fn s_import_mut(&mut self) -> Option<&mut S::Import<'arena>> {
         if let Data::SImport(v) = self {
             Some(&mut **v)
         } else {
@@ -790,7 +806,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_label(&self) -> Option<StoreRef<S::Label>> {
+    pub fn s_label(&self) -> Option<StoreRef<'arena, S::Label<'arena>>> {
         if let Data::SLabel(v) = *self {
             Some(v)
         } else {
@@ -798,7 +814,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_label_mut(&mut self) -> Option<&mut S::Label> {
+    pub fn s_label_mut(&mut self) -> Option<&mut S::Label<'arena>> {
         if let Data::SLabel(v) = self {
             Some(&mut **v)
         } else {
@@ -806,7 +822,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_local(&self) -> Option<StoreRef<S::Local>> {
+    pub fn s_local(&self) -> Option<StoreRef<'arena, S::Local<'arena>>> {
         if let Data::SLocal(v) = *self {
             Some(v)
         } else {
@@ -814,7 +830,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_local_mut(&mut self) -> Option<&mut S::Local> {
+    pub fn s_local_mut(&mut self) -> Option<&mut S::Local<'arena>> {
         if let Data::SLocal(v) = self {
             Some(&mut **v)
         } else {
@@ -822,7 +838,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_namespace(&self) -> Option<StoreRef<S::Namespace>> {
+    pub fn s_namespace(&self) -> Option<StoreRef<'arena, S::Namespace<'arena>>> {
         if let Data::SNamespace(v) = *self {
             Some(v)
         } else {
@@ -830,7 +846,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_namespace_mut(&mut self) -> Option<&mut S::Namespace> {
+    pub fn s_namespace_mut(&mut self) -> Option<&mut S::Namespace<'arena>> {
         if let Data::SNamespace(v) = self {
             Some(&mut **v)
         } else {
@@ -838,7 +854,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_return(&self) -> Option<StoreRef<S::Return>> {
+    pub fn s_return(&self) -> Option<StoreRef<'arena, S::Return<'arena>>> {
         if let Data::SReturn(v) = *self {
             Some(v)
         } else {
@@ -846,7 +862,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_return_mut(&mut self) -> Option<&mut S::Return> {
+    pub fn s_return_mut(&mut self) -> Option<&mut S::Return<'arena>> {
         if let Data::SReturn(v) = self {
             Some(&mut **v)
         } else {
@@ -854,7 +870,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_switch(&self) -> Option<StoreRef<S::Switch>> {
+    pub fn s_switch(&self) -> Option<StoreRef<'arena, S::Switch<'arena>>> {
         if let Data::SSwitch(v) = *self {
             Some(v)
         } else {
@@ -862,7 +878,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_switch_mut(&mut self) -> Option<&mut S::Switch> {
+    pub fn s_switch_mut(&mut self) -> Option<&mut S::Switch<'arena>> {
         if let Data::SSwitch(v) = self {
             Some(&mut **v)
         } else {
@@ -870,7 +886,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_throw(&self) -> Option<StoreRef<S::Throw>> {
+    pub fn s_throw(&self) -> Option<StoreRef<'arena, S::Throw<'arena>>> {
         if let Data::SThrow(v) = *self {
             Some(v)
         } else {
@@ -878,7 +894,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_throw_mut(&mut self) -> Option<&mut S::Throw> {
+    pub fn s_throw_mut(&mut self) -> Option<&mut S::Throw<'arena>> {
         if let Data::SThrow(v) = self {
             Some(&mut **v)
         } else {
@@ -886,7 +902,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_try(&self) -> Option<StoreRef<S::Try>> {
+    pub fn s_try(&self) -> Option<StoreRef<'arena, S::Try<'arena>>> {
         if let Data::STry(v) = *self {
             Some(v)
         } else {
@@ -894,7 +910,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_try_mut(&mut self) -> Option<&mut S::Try> {
+    pub fn s_try_mut(&mut self) -> Option<&mut S::Try<'arena>> {
         if let Data::STry(v) = self {
             Some(&mut **v)
         } else {
@@ -902,7 +918,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_while(&self) -> Option<StoreRef<S::While>> {
+    pub fn s_while(&self) -> Option<StoreRef<'arena, S::While<'arena>>> {
         if let Data::SWhile(v) = *self {
             Some(v)
         } else {
@@ -910,7 +926,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_while_mut(&mut self) -> Option<&mut S::While> {
+    pub fn s_while_mut(&mut self) -> Option<&mut S::While<'arena>> {
         if let Data::SWhile(v) = self {
             Some(&mut **v)
         } else {
@@ -918,7 +934,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_with(&self) -> Option<StoreRef<S::With>> {
+    pub fn s_with(&self) -> Option<StoreRef<'arena, S::With<'arena>>> {
         if let Data::SWith(v) = *self {
             Some(v)
         } else {
@@ -926,7 +942,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_with_mut(&mut self) -> Option<&mut S::With> {
+    pub fn s_with_mut(&mut self) -> Option<&mut S::With<'arena>> {
         if let Data::SWith(v) = self {
             Some(&mut **v)
         } else {
@@ -934,7 +950,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_lazy_export(&self) -> Option<StoreRef<expr::Data>> {
+    pub fn s_lazy_export(&self) -> Option<StoreRef<'arena, expr::Data<'arena>>> {
         if let Data::SLazyExport(v) = *self {
             Some(v)
         } else {
@@ -942,7 +958,7 @@ impl Data {
         }
     }
     #[inline]
-    pub fn s_lazy_export_mut(&mut self) -> Option<&mut expr::Data> {
+    pub fn s_lazy_export_mut(&mut self) -> Option<&mut expr::Data<'arena>> {
         if let Data::SLazyExport(v) = self {
             Some(&mut **v)
         } else {
@@ -982,38 +998,40 @@ impl Data {
 
 // `new_store!` emits `pub mod stmt_store { pub struct Store; ... }` with
 // `init/append/reset/destroy`. Type list mirrors Zig's `Data.Store = NewStore(&.{...}, 128)`.
+// Types use `'static` here because the macro only uses them for size/align
+// computation; the actual `append<T>` is generic over the caller's `'arena`.
 crate::new_store!(
     stmt_store,
     [
-        S::Block,
+        S::Block<'static>,
         S::Break,
-        S::Class,
-        S::Comment,
+        S::Class<'static>,
+        S::Comment<'static>,
         S::Continue,
-        S::Directive,
-        S::DoWhile,
-        S::Enum,
-        S::ExportClause,
-        S::ExportDefault,
-        S::ExportEquals,
-        S::ExportFrom,
-        S::ExportStar,
-        S::SExpr,
-        S::ForIn,
-        S::ForOf,
-        S::For,
-        S::Function,
-        S::If,
-        S::Import,
-        S::Label,
-        S::Local,
-        S::Namespace,
-        S::Return,
-        S::Switch,
-        S::Throw,
-        S::Try,
-        S::While,
-        S::With,
+        S::Directive<'static>,
+        S::DoWhile<'static>,
+        S::Enum<'static>,
+        S::ExportClause<'static>,
+        S::ExportDefault<'static>,
+        S::ExportEquals<'static>,
+        S::ExportFrom<'static>,
+        S::ExportStar<'static>,
+        S::SExpr<'static>,
+        S::ForIn<'static>,
+        S::ForOf<'static>,
+        S::For<'static>,
+        S::Function<'static>,
+        S::If<'static>,
+        S::Import<'static>,
+        S::Label<'static>,
+        S::Local<'static>,
+        S::Namespace<'static>,
+        S::Return<'static>,
+        S::Switch<'static>,
+        S::Throw<'static>,
+        S::Try<'static>,
+        S::While<'static>,
+        S::With<'static>,
     ],
     128
 );
@@ -1028,7 +1046,7 @@ pub mod data {
 // TODO(port): callers should use the `StatementData` trait or a per-variant
 // associated type; revisit once call sites are known.
 
-impl Stmt {
+impl<'arena> Stmt<'arena> {
     pub fn cares_about_scope(&self) -> bool {
         match &self.data {
             Data::SBlock(_)

--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -7,14 +7,14 @@ use crate::ImportItemStatus;
 use crate::base::Ref;
 use crate::g as G;
 
-pub struct Symbol {
+pub struct Symbol<'arena> {
     /// This is the name that came from the parser. Printed names may be renamed
     /// during minification or to avoid name collisions. Do not use the original
     /// name during printing.
     // Arena-owned slice (parser/AST crate). `StoreStr` is the lifetime-erased
     // `[u8]` wrapper used uniformly across AST string fields; it derefs to
     // `[u8]` and is valid until the owning arena resets.
-    pub original_name: crate::StoreStr,
+    pub original_name: crate::StoreStr<'arena>,
 
     /// This is used for symbols that represent items in the import clause of an
     /// ES6 import statement. These should always be referenced by EImportIdentifier
@@ -27,12 +27,12 @@ pub struct Symbol {
     /// mode, re-exported symbols are collapsed using MergeSymbols() and renamed
     /// symbols from other files that end up at this symbol must be able to tell
     /// if it has a namespace alias.
-    pub namespace_alias: Option<G::NamespaceAlias>,
+    pub namespace_alias: Option<G::NamespaceAlias<'arena>>,
 
     /// Used by the parser for single pass parsing.
     ///
     /// `Cell` because union-find (`merge`/`follow`) mutates this through
-    /// `&Symbol` while other shared refs to the same table are live. `Ref` is
+    /// `&Symbol<'arena>` while other shared refs to the same table are live. `Ref` is
     /// `Copy`, so `Cell<Ref>` is zero-cost and lets those algorithms run
     /// without raw-pointer writes.
     pub link: Cell<Ref>,
@@ -51,7 +51,7 @@ pub struct Symbol {
     /// `AtomicU32` (not plain `u32`) because [`Map::assign_chunk_index`] is
     /// invoked from worker threads in
     /// `compute_cross_chunk_dependencies::walk()` while other threads hold a
-    /// shared `&LinkerGraph` (and thus `&Symbol`). The linker invariant is
+    /// shared `&LinkerGraph` (and thus `&Symbol<'arena>`). The linker invariant is
     /// that all declarations of a given top-level symbol are placed in a
     /// single chunk, so cross-thread writes target disjoint slots — but the
     /// invariant is data-dependent, not type-checked, and a plain `u32` write
@@ -177,7 +177,7 @@ pub struct Symbol {
 const INVALID_CHUNK_INDEX: u32 = u32::MAX;
 pub const INVALID_NESTED_SCOPE_SLOT: u32 = u32::MAX;
 
-impl Default for Symbol {
+impl<'arena> Default for Symbol<'arena> {
     fn default() -> Self {
         Self {
             original_name: crate::StoreStr::EMPTY,
@@ -211,7 +211,7 @@ pub enum SlotNamespace {
 // Inherent associated types are nightly-only; expose as a free alias.
 pub type SlotNamespaceCountsArray = enum_map::EnumMap<SlotNamespace, u32>;
 
-impl Symbol {
+impl<'arena> Symbol<'arena> {
     /// This is for generating cross-chunk imports and exports for code splitting.
     #[inline]
     pub fn chunk_index(&self) -> Option<u32> {
@@ -388,11 +388,11 @@ pub struct Use {
     pub count_estimate: u32,
 }
 
-pub type List = Vec<Symbol>;
-pub type NestedList = Vec<List>;
+pub type List<'arena> = Vec<Symbol<'arena>>;
+pub type NestedList<'arena> = Vec<List<'arena>>;
 
-impl Symbol {
-    pub fn merge_contents_with(&mut self, old: &mut Symbol) {
+impl<'arena> Symbol<'arena> {
+    pub fn merge_contents_with(&mut self, old: &mut Symbol<'arena>) {
         self.use_count_estimate += old.use_count_estimate;
         if old.must_not_be_renamed {
             self.original_name = old.original_name;
@@ -404,7 +404,7 @@ impl Symbol {
 }
 
 #[derive(Default)]
-pub struct Map {
+pub struct Map<'arena> {
     // This could be represented as a "map[Ref]Symbol" but a two-level array was
     // more efficient in profiles. This appears to be because it doesn't involve
     // a hash. This representation also makes it trivial to quickly merge symbol
@@ -412,10 +412,10 @@ pub struct Map {
     // single inner array, so you can join the maps together by just make a
     // single outer array containing all of the inner arrays. See the comment on
     // "Ref" for more detail.
-    pub symbols_for_source: NestedList,
+    pub symbols_for_source: NestedList<'arena>,
 }
 
-impl Map {
+impl<'arena> Map<'arena> {
     // Debug-only dump of the symbol table.
     pub fn dump(&self) {
         for (i, symbols) in self.symbols_for_source.slice().iter().enumerate() {
@@ -447,7 +447,7 @@ impl Map {
     // Takes `&self` (not `&mut self`) — the only caller
     // (`computeCrossChunkDependencies::walk`) runs concurrently across worker
     // threads. `Symbol.chunk_index` is `AtomicU32`, so the per-slot write is a
-    // sound interior mutation through `&Symbol`; no raw-pointer or `&mut Map`
+    // sound interior mutation through `&Symbol<'arena>`; no raw-pointer or `&mut Map`
     // escape is needed. Relaxed ordering: see the field doc — the worker-pool
     // join is the only required happens-before edge, and the linker invariant
     // places all declarations of a given symbol in a single chunk (same
@@ -455,12 +455,12 @@ impl Map {
     // `debug_assert!` documents that invariant.
     pub fn assign_chunk_index(&self, decls_: &crate::DeclaredSymbolList, chunk_index: u32) {
         use crate::DeclaredSymbol;
-        struct Iterator<'a> {
-            map: &'a Map,
+        struct Iterator<'a, 'arena> {
+            map: &'a Map<'arena>,
             chunk_index: u32,
         }
 
-        impl Iterator<'_> {
+        impl Iterator<'_, '_> {
             pub(crate) fn next(&mut self, ref_: Ref) {
                 let symbol = self.map.get_const(ref_).unwrap();
                 // Thread-confinement invariant: a top-level symbol's
@@ -529,7 +529,7 @@ impl Map {
         new
     }
 
-    // Returns a raw *mut Symbol because callers (merge/follow/assign_chunk_index/
+    // Returns a raw *mut Symbol<'arena> because callers (merge/follow/assign_chunk_index/
     // get_with_link) hold aliasing pointers into the NestedList and/or recurse through
     // &mut self while holding the pointer. Mirrors Zig's `*const Map -> ?*Symbol`
     // (interior mutability via Vec's raw `[*]T` ptr field).
@@ -540,7 +540,7 @@ impl Map {
     // and would yield read-only provenance, making any later write UB). Callers may write
     // through the result as long as the backing storage is not reallocated and they do
     // not materialize overlapping `&mut`.
-    pub fn get(&self, ref_: Ref) -> Option<*mut Symbol> {
+    pub fn get(&self, ref_: Ref) -> Option<*mut Symbol<'arena>> {
         if Ref::is_source_index_null(ref_.source_index()) || ref_.is_source_contents_slice() {
             return None;
         }
@@ -556,7 +556,7 @@ impl Map {
         }
     }
 
-    pub fn get_const(&self, ref_: Ref) -> Option<&Symbol> {
+    pub fn get_const(&self, ref_: Ref) -> Option<&Symbol<'arena>> {
         if Ref::is_source_index_null(ref_.source_index()) || ref_.is_source_contents_slice() {
             return None;
         }
@@ -583,10 +583,10 @@ impl Map {
         })
     }
 
-    pub fn init(source_count: usize) -> Map {
+    pub fn init(source_count: usize) -> Map<'arena> {
         // Zig: `arena.alloc([]Symbol, sourceCount)` (default_allocator) then NestedList.init.
         // Per PORTING.md §Allocators (non-arena path), use Vec → Vec.
-        let mut v: Vec<List> = Vec::with_capacity(source_count);
+        let mut v: Vec<List<'arena>> = Vec::with_capacity(source_count);
         v.resize_with(source_count, List::default);
         Map {
             symbols_for_source: NestedList::move_from_list(v),
@@ -598,11 +598,11 @@ impl Map {
     // box it into a one-element NestedList instead.
     // PERF(port): one extra allocation vs Zig — profile (single
     // caller is the printer one-shot, cold).
-    pub fn init_with_one_list(list: List) -> Map {
+    pub fn init_with_one_list(list: List<'arena>) -> Map<'arena> {
         Self::init_list(NestedList::move_from_list(vec![list]))
     }
 
-    pub fn init_list(list: NestedList) -> Map {
+    pub fn init_list(list: NestedList<'arena>) -> Map<'arena> {
         Map {
             symbols_for_source: list,
         }
@@ -611,8 +611,8 @@ impl Map {
     /// Safe `&mut` lookup via the `Vec`/`Vec<Symbol>` backing storage. Mirrors
     /// [`get_const`] but returns a unique borrow tied to `&mut self`, so callers
     /// that only need to flip a flag (e.g. `must_not_be_renamed`) don't need the
-    /// raw `*mut Symbol` from [`get`] + an open-coded `(*ptr).field = ...`.
-    pub fn get_mut(&mut self, ref_: Ref) -> Option<&mut Symbol> {
+    /// raw `*mut Symbol<'arena>` from [`get`] + an open-coded `(*ptr).field = ...`.
+    pub fn get_mut(&mut self, ref_: Ref) -> Option<&mut Symbol<'arena>> {
         if Ref::is_source_index_null(ref_.source_index()) || ref_.is_source_contents_slice() {
             return None;
         }
@@ -621,7 +621,7 @@ impl Map {
         self.symbols_for_source.get_mut(src)?.get_mut(idx)
     }
 
-    pub fn get_with_link(&self, ref_: Ref) -> Option<*mut Symbol> {
+    pub fn get_with_link(&self, ref_: Ref) -> Option<*mut Symbol<'arena>> {
         let symbol_ptr = self.get(ref_)?;
         // Read `link` through the safe shared accessor (same indices as `get`);
         // the raw `*mut` is only forwarded to the caller, never derefed here.
@@ -632,7 +632,7 @@ impl Map {
         Some(symbol_ptr)
     }
 
-    pub fn get_with_link_const(&self, ref_: Ref) -> Option<&Symbol> {
+    pub fn get_with_link_const(&self, ref_: Ref) -> Option<&Symbol<'arena>> {
         let symbol = self.get_const(ref_)?;
         if symbol.has_link() {
             return Some(self.get_const(symbol.link.get()).unwrap_or(symbol));
@@ -689,7 +689,7 @@ impl Map {
         // `(source_index, inner_index)` with tag ∈ {Symbol, AllocatedName},
         // never `SourceContentsSlice` and never the null source sentinel.
         let outer = self.symbols_for_source.slice();
-        let lookup = |r: Ref| -> &Symbol {
+        let lookup = |r: Ref| -> &Symbol<'arena> {
             debug_assert!(!r.is_source_contents_slice());
             &outer[r.source_index() as usize].slice()[r.inner_index() as usize]
         };
@@ -708,7 +708,7 @@ impl Map {
         // recursion's post-order `symbol.link = link` writes). The `!=` gate
         // mirrors Zig's `if (!symbol.link.eql(link))` to avoid a redundant
         // store when the chain was already length-1. `link` is `Cell<Ref>`, so
-        // writes go through `&Symbol` safely.
+        // writes go through `&Symbol<'arena>` safely.
         if !link.eql(root) {
             symbol.link.set(root);
             loop {
@@ -730,7 +730,7 @@ impl Map {
     }
 }
 
-impl Symbol {
+impl<'arena> Symbol<'arena> {
     #[inline]
     pub fn is_hoisted(&self) -> bool {
         Symbol::is_kind_hoisted(self.kind)

--- a/src/ast/ts.rs
+++ b/src/ast/ts.rs
@@ -37,7 +37,7 @@ use crate::e::String as EString;
 /// by sharing the map of exported members between all matching sibling scopes.
 // PORT NOTE: 'arena lifetime dropped — `EnumString` payload uses *const EString
 // (LIFETIMES.tsv ARENA → raw ptr in Phase A; Phase B threads 'bump crate-wide).
-pub struct TSNamespaceScope {
+pub struct TSNamespaceScope<'arena> {
     /// This is specific to this namespace block. It's the argument of the
     /// immediately-invoked function expression that the namespace block is
     /// compiled into:
@@ -55,7 +55,7 @@ pub struct TSNamespaceScope {
     // LIFETIMES.tsv: ARENA — p.arena.create(Pair); &pair.map; shared across
     // sibling scopes. `StoreRef` (arena back-pointer with safe `Deref`) so
     // callers don't open-code `unsafe { &mut *exported_members }` at every use.
-    pub exported_members: crate::nodes::StoreRef<TSNamespaceMemberMap>,
+    pub exported_members: crate::nodes::StoreRef<'arena, TSNamespaceMemberMap<'arena>>,
 
     /// This is a lazily-generated map of identifiers that actually represent
     /// property accesses to this namespace's properties. For example:
@@ -112,31 +112,31 @@ pub struct TSNamespaceScope {
     pub is_enum_scope: bool,
 }
 
-pub type TSNamespaceMemberMap = StringArrayHashMap<TSNamespaceMember>;
+pub type TSNamespaceMemberMap<'arena> = StringArrayHashMap<TSNamespaceMember<'arena>>;
 
-pub struct TSNamespaceMember {
+pub struct TSNamespaceMember<'arena> {
     pub loc: Loc,
-    pub data: Data,
+    pub data: Data<'arena>,
 }
 
 #[derive(Clone, Copy)]
-pub enum Data {
+pub enum Data<'arena> {
     /// "namespace ns { export let it }"
     Property,
     /// "namespace ns { export namespace it {} }"
     // LIFETIMES.tsv: ARENA — assigned from ts_namespace.exported_members (parser-arena alloc)
-    Namespace(crate::nodes::StoreRef<TSNamespaceMemberMap>),
+    Namespace(crate::nodes::StoreRef<'arena, TSNamespaceMemberMap<'arena>>),
     /// "enum ns { it }"
     EnumNumber(f64),
     /// "enum ns { it = 'it' }"
     // LIFETIMES.tsv: ARENA — assigned from Expr.Data.e_string payload (AST Expr store).
     // TODO(port): &'bump EString once 'bump threaded crate-wide.
-    EnumString(crate::nodes::StoreRef<EString>),
+    EnumString(crate::nodes::StoreRef<'arena, EString<'arena>>),
     /// "enum ns { it = something() }"
     EnumProperty,
 }
 
-impl Data {
+impl<'arena> Data<'arena> {
     pub fn is_enum(&self) -> bool {
         // PORT NOTE: Zig used `inline else` + comptime `@tagName` prefix check ("enum_").
         // Expanded to an explicit match over the enum_* variants.

--- a/src/bundler/AstBuilder.rs
+++ b/src/bundler/AstBuilder.rs
@@ -40,15 +40,15 @@ pub struct AstBuilder<'a, 'bump> {
     pub bump: &'bump Bump,
     pub source: &'a Source,
     pub source_index: u32, // Zig: u31
-    pub stmts: Vec<Stmt>,
-    pub scopes: Vec<*mut Scope>,
-    pub symbols: Vec<Symbol>,
+    pub stmts: Vec<Stmt<'bump>>,
+    pub scopes: Vec<NonNull<Scope<'bump>>>,
+    pub symbols: Vec<Symbol<'bump>>,
     pub import_records: Vec<ImportRecord>,
-    pub named_imports: NamedImports,
+    pub named_imports: NamedImports<'bump>,
     pub named_exports: NamedExports,
     pub import_records_for_current_part: Vec<u32>,
     pub export_star_import_records: Vec<u32>,
-    pub current_scope: *mut Scope,
+    pub current_scope: *mut Scope<'bump>,
     pub log: Log,
     pub module_ref: Ref,
     pub declared_symbols: DeclaredSymbolList,
@@ -87,7 +87,7 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
     }
 
     pub fn init(bump: &'bump Bump, source: &'a Source, hot_reloading: bool) -> Result<Self, OOM> {
-        let scope: *mut Scope = bump.alloc(Scope {
+        let scope: *mut Scope<'bump> = bump.alloc(Scope {
             kind: ScopeKind::Entry,
             label_ref: None,
             parent: None,
@@ -128,7 +128,7 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
     /// pointers / `StoreRef`s and are never dereferenced while a `&mut self`
     /// borrow is held, so the returned `&mut Scope` is unique for its lifetime.
     #[inline]
-    pub fn current_scope_mut(&mut self) -> &mut Scope {
+    pub fn current_scope_mut(&mut self) -> &mut Scope<'bump> {
         debug_assert!(
             !self.current_scope.is_null(),
             "AstBuilder.current_scope read before init()"
@@ -139,10 +139,10 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
     }
 
     // PORT NOTE: Zig signature lacks `!` but body uses `try` — porting as fallible.
-    pub fn push_scope(&mut self, kind: ScopeKind) -> Result<*mut Scope, OOM> {
+    pub fn push_scope(&mut self, kind: ScopeKind) -> Result<*mut Scope<'bump>, OOM> {
         self.scopes.reserve(1);
         self.current_scope_mut().children.ensure_unused_capacity(1);
-        let scope: *mut Scope = self.bump.alloc(Scope {
+        let scope: *mut Scope<'bump> = self.bump.alloc(Scope {
             kind,
             label_ref: None,
             parent: NonNull::new(self.current_scope).map(bun_ast::StoreRef::from),
@@ -153,14 +153,15 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
         self.current_scope_mut()
             .children
             .append_assume_capacity(NonNull::new(scope).expect("bump alloc non-null").into());
-        self.scopes.push(self.current_scope);
+        self.scopes
+            .push(NonNull::new(self.current_scope).expect("current_scope non-null after init"));
         // PERF(port): was appendAssumeCapacity — profile in Phase B
         self.current_scope = scope;
         Ok(scope)
     }
 
     pub fn pop_scope(&mut self) {
-        self.current_scope = self.scopes.pop().unwrap();
+        self.current_scope = self.scopes.pop().unwrap().as_ptr();
     }
 
     pub fn new_symbol(&mut self, kind: SymbolKind, identifier: &[u8]) -> Result<Ref, OOM> {
@@ -175,12 +176,12 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
         self.declared_symbols.append(DeclaredSymbol {
             ref_,
             is_top_level: self.scopes.is_empty()
-                || core::ptr::eq(self.current_scope, self.scopes[0]),
+                || core::ptr::eq(self.current_scope, self.scopes[0].as_ptr()),
         })?;
         Ok(ref_)
     }
 
-    pub fn get_symbol(&mut self, ref_: Ref) -> &mut Symbol {
+    pub fn get_symbol(&mut self, ref_: Ref) -> &mut Symbol<'bump> {
         debug_assert!(ref_.source_index() == self.source.index.0);
         &mut self.symbols[ref_.inner_index() as usize]
     }
@@ -205,8 +206,8 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
         &mut self,
         path: &'static [u8],
         identifiers_to_import: [&'static [u8]; N],
-    ) -> Result<[Expr; N], OOM> {
-        let mut out: [MaybeUninit<Expr>; N] = [const { MaybeUninit::uninit() }; N];
+    ) -> Result<[Expr<'bump>; N], OOM> {
+        let mut out: [MaybeUninit<Expr<'bump>>; N] = [const { MaybeUninit::uninit() }; N];
 
         let record = self.add_import_record(path, ImportKind::Stmt)?;
 
@@ -219,7 +220,7 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
         let name: &[u8] = self.bump.alloc_slice_copy(&name);
         let namespace_ref = self.new_symbol(SymbolKind::Other, name)?;
 
-        let clauses: &mut [ClauseItem] = self.bump.alloc_slice_fill_default(N);
+        let clauses: &mut [ClauseItem<'bump>] = self.bump.alloc_slice_fill_default(N);
 
         // Zig: `inline for` — all elements are `[]const u8`, so a plain loop suffices.
         for ((import_id, out_ref), clause) in identifiers_to_import
@@ -266,18 +267,18 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
         Ok(out.map(|e| unsafe { e.assume_init() }))
     }
 
-    pub fn append_stmt<T: StatementData>(&mut self, data: T) -> Result<(), OOM> {
+    pub fn append_stmt<T: StatementData<'bump>>(&mut self, data: T) -> Result<(), OOM> {
         self.stmts.reserve(1);
         self.stmts.push(self.new_stmt(data));
         // PERF(port): was appendAssumeCapacity — profile in Phase B
         Ok(())
     }
 
-    pub fn new_stmt<T: StatementData>(&self, data: T) -> Stmt {
+    pub fn new_stmt<T: StatementData<'bump>>(&self, data: T) -> Stmt<'bump> {
         Stmt::alloc::<T>(data, Loc::EMPTY)
     }
 
-    pub fn new_expr<T: IntoExprData>(&self, data: T) -> Expr {
+    pub fn new_expr<T: IntoExprData<'bump>>(&self, data: T) -> Expr<'bump> {
         Expr::init::<T>(data, Loc::EMPTY)
     }
 
@@ -295,7 +296,7 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
     pub fn to_bundled_ast(
         &mut self,
         target: options::Target,
-    ) -> Result<crate::BundledAst<'static>, OOM> {
+    ) -> Result<crate::BundledAst<'bump>, OOM> {
         // TODO: missing import scanner
         debug_assert!(self.scopes.is_empty());
         let module_scope = self.current_scope;
@@ -650,7 +651,7 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
         Ok(())
     }
 
-    pub fn record_exported_binding(&mut self, binding: Binding) {
+    pub fn record_exported_binding(&mut self, binding: Binding<'_>) {
         match binding.data {
             B::BMissing(_) => {}
             B::BIdentifier(ident) => {
@@ -679,7 +680,7 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
     }
 
     /// Zig: `@"module.exports"` — Rust identifiers can't contain `.`
-    pub fn module_exports(&self, loc: Loc) -> Expr {
+    pub fn module_exports(&self, loc: Loc) -> Expr<'bump> {
         self.new_expr(E::Dot {
             name: b"exports".into(),
             name_loc: loc,

--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -126,6 +126,7 @@ pub trait CompletionStruct: Node + Send + 'static {
         &mut self,
         transpiler: &'a mut Transpiler<'a>,
         bump: &'a Arena,
+        arena_pool: &'a crate::ArenaPool,
         // Raw `*mut` (not `&'static`) because `BundleV2::init` ultimately
         // stores it as `worker_pool: *mut ThreadPool` and `WorkPool::get()`
         // hands out `&'static`; materializing `&mut` from that would be UB.
@@ -287,6 +288,9 @@ impl<C: CompletionStruct> BundleThread<C> {
         // PORT NOTE: `ThreadLocalArena.init()` → `bun_alloc::Arena::new()` (bumpalo
         // bump arena; `defer heap.deinit()` is handled by Drop).
         let heap = Arena::new();
+        // Owns every per-worker arena plus the bundler-thread arena for this
+        // `Bun.build()` call. Dropped at end-of-fn after `bv2` is torn down.
+        let arena_pool = crate::ArenaPool::new();
 
         let bump = &heap;
         let ast_memory_store: &mut bun_ast::ASTMemoryAllocator =
@@ -311,6 +315,7 @@ impl<C: CompletionStruct> BundleThread<C> {
             // SAFETY: `transpiler` lives in `bump` for the duration of `heap`.
             unsafe { &mut *transpiler_ptr },
             bump,
+            &arena_pool,
             // `WorkPool::get()` returns `&'static ThreadPool`; pass as raw so
             // the impl can hand it to `BundleV2::init` (which stores `*mut`).
             std::ptr::from_ref(bun_threading::work_pool::WorkPool::get()).cast_mut(),

--- a/src/bundler/Cargo.toml
+++ b/src/bundler/Cargo.toml
@@ -25,6 +25,7 @@ bitflags.workspace = true
 thiserror.workspace = true
 bumpalo.workspace = true
 typed-arena.workspace = true
+boxcar.workspace = true
 bun_base64.workspace = true
 bun_alloc.workspace = true
 # TODO(b2-blocked): bun_analytics — adding the dep triggers a fresh build of

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -40,7 +40,7 @@ pub struct ChunkImport {
 // TODO(port): arena lifetime — string/slice fields below borrow from the bundler arena
 // (no deinit in Zig). Phase A uses &'static [u8] / Box<[T]> as placeholders; Phase B
 // should thread a `'bump` lifetime or use arena slice newtypes.
-pub struct Chunk {
+pub struct Chunk<'a> {
     /// This is a random string and is used to represent the output path of this
     /// chunk before the final output path has been computed. See OutputPiece
     /// for more info on this technique.
@@ -77,11 +77,7 @@ pub struct Chunk {
     pub intermediate_output: IntermediateOutput,
     pub isolated_hash: u64,
 
-    // TODO(port): was `= undefined` in Zig (set before use). The Zig field is
-    // the `renamer.Renamer` union; the Rust enum borrows from the symbol table
-    // (`Renamer<'r,'src>`), which can't live in a 'static-ish struct yet.
-    // `ChunkRenamer` is an owned-erased placeholder (see `crate::bun_renamer`).
-    pub renamer: bun_renamer::ChunkRenamer,
+    pub renamer: bun_renamer::ChunkRenamer<'a>,
 
     pub compile_results_for_chunk: CompileResultSlots,
 
@@ -130,8 +126,8 @@ impl Default for Content {
 // TODO(ub-audit): `Renamer<'r>` still borrows `&'r mut {Number,Minify}Renamer`,
 // so the per-chunk renamer is reborrowed mutably from each part-range task;
 // the printer never writes through it, but the borrow should become `&'r`.
-unsafe impl Send for Chunk {}
-unsafe impl Sync for Chunk {}
+unsafe impl Send for Chunk<'_> {}
+unsafe impl Sync for Chunk<'_> {}
 
 /// Disjoint-slot output buffer for [`Chunk::compile_results_for_chunk`].
 ///
@@ -185,7 +181,7 @@ impl core::ops::Index<usize> for CompileResultSlots {
     }
 }
 
-impl Default for Chunk {
+impl Default for Chunk<'_> {
     fn default() -> Self {
         Chunk {
             unique_key: b"",
@@ -208,7 +204,7 @@ impl Default for Chunk {
     }
 }
 
-impl Chunk {
+impl<'a> Chunk<'a> {
     /// Write `result` into `compile_results_for_chunk[i]` through a raw
     /// `*mut Chunk`, for the `generate_compile_result_for_*_chunk` worker
     /// callbacks.
@@ -227,7 +223,7 @@ impl Chunk {
     /// - No two concurrent callers may pass the same `i` for the same `chunk`.
     /// - No reader may observe slot `i` until after the worker-pool join.
     #[inline]
-    pub unsafe fn write_compile_result_slot(chunk: *mut Chunk, i: usize, result: CompileResult) {
+    pub unsafe fn write_compile_result_slot(chunk: *mut Chunk<'_>, i: usize, result: CompileResult) {
         // SAFETY: per fn contract — `chunk` is live, `i` in-bounds, slot
         // exclusively owned by this caller.
         unsafe {
@@ -269,7 +265,7 @@ impl Chunk {
         }
     }
 
-    pub fn get_js_chunk_for_html<'a>(&self, chunks: &'a mut [Chunk]) -> Option<&'a mut Chunk> {
+    pub fn get_js_chunk_for_html<'c>(&self, chunks: &'c mut [Chunk<'a>]) -> Option<&'c mut Chunk<'a>> {
         let entry_point_id = self.entry_point.entry_point_id();
         for other in chunks.iter_mut() {
             if matches!(other.content, Content::Javascript(_)) {
@@ -281,7 +277,7 @@ impl Chunk {
         None
     }
 
-    pub fn get_css_chunk_for_html<'a>(&self, chunks: &'a mut [Chunk]) -> Option<&'a mut Chunk> {
+    pub fn get_css_chunk_for_html<'c>(&self, chunks: &'c mut [Chunk<'a>]) -> Option<&'c mut Chunk<'a>> {
         // Look up the CSS chunk via the JS chunk's css_chunks indices.
         // This correctly handles deduplicated CSS chunks that are shared
         // across multiple HTML entry points (see issue #23668).
@@ -539,17 +535,17 @@ impl IntermediateOutput {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn code<'d>(
+    pub fn code<'a, 'd>(
         &mut self,
         allocator_to_use: Option<&DynAlloc>,
-        parse_graph: &Graph,
-        linker_graph: &LinkerGraph,
+        parse_graph: &Graph<'a>,
+        linker_graph: &LinkerGraph<'a>,
         import_prefix: &[u8],
         // PORT NOTE: Zig passed `*Chunk` / `[]Chunk` (freely aliased — `chunk`
         // is `&chunks[i]`). The body only reads both, so take `&` to avoid
         // overlapping `&mut Chunk` + `&mut [Chunk]` UB at every call site.
-        chunk: &Chunk,
-        chunks: &[Chunk],
+        chunk: &Chunk<'a>,
+        chunks: &[Chunk<'a>],
         // PORT NOTE: `?*usize` in Zig — accept both `&mut usize` and
         // `Option<&mut usize>` so call sites that ported either way compile.
         display_size: impl Into<Option<&'d mut usize>>,
@@ -590,15 +586,15 @@ impl IntermediateOutput {
     /// resolved to inline code content instead of file paths. Asset references
     /// are resolved to data: URIs from url_for_css.
     #[allow(clippy::too_many_arguments)]
-    pub fn code_standalone<'d>(
+    pub fn code_standalone<'a, 'd>(
         &mut self,
         allocator_to_use: Option<&DynAlloc>,
-        parse_graph: &Graph,
-        linker_graph: &LinkerGraph,
+        parse_graph: &Graph<'a>,
+        linker_graph: &LinkerGraph<'a>,
         import_prefix: &[u8],
         // See `code()` PORT NOTE — `chunk` aliases `chunks[i]`; body is read-only.
-        chunk: &Chunk,
-        chunks: &[Chunk],
+        chunk: &Chunk<'a>,
+        chunks: &[Chunk<'a>],
         // PORT NOTE: `?*usize` in Zig — accept both `&mut usize` and
         // `Option<&mut usize>` so call sites that ported either way compile.
         display_size: impl Into<Option<&'d mut usize>>,
@@ -635,15 +631,15 @@ impl IntermediateOutput {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn code_with_source_map_shifts<const ENABLE_SOURCE_MAP_SHIFTS: bool>(
+    pub fn code_with_source_map_shifts<'a, const ENABLE_SOURCE_MAP_SHIFTS: bool>(
         &mut self,
         allocator_to_use: Option<&DynAlloc>,
-        graph: &Graph,
-        linker_graph: &LinkerGraph,
+        graph: &Graph<'a>,
+        linker_graph: &LinkerGraph<'a>,
         import_prefix: &[u8],
         // See `code()` PORT NOTE — `chunk` aliases `chunks[i]`; body is read-only.
-        chunk: &Chunk,
-        chunks: &[Chunk],
+        chunk: &Chunk<'a>,
+        chunks: &[Chunk<'a>],
         display_size: Option<&mut usize>,
         force_absolute_path: bool,
         standalone_chunk_contents: Option<&[Option<Box<[u8]>>]>,
@@ -1291,8 +1287,8 @@ pub struct JavaScriptChunk {
     // TODO(port): Zig uses ArrayHashMapUnmanaged(Ref, string, Ref.ArrayHashCtx, false) — custom hash ctx
     pub exports_to_other_chunks: ArrayHashMap<Ref, &'static [u8]>,
     pub imports_from_other_chunks: ImportsFromOtherChunks,
-    pub cross_chunk_prefix_stmts: Vec<Stmt>,
-    pub cross_chunk_suffix_stmts: Vec<Stmt>,
+    pub cross_chunk_prefix_stmts: Vec<Stmt<'static>>,
+    pub cross_chunk_suffix_stmts: Vec<Stmt<'static>>,
 
     /// Indexes to CSS chunks. Currently this will only ever be zero or one
     /// items long, but smarter css chunking will allow multiple js entry points

--- a/src/bundler/Graph.rs
+++ b/src/bundler/Graph.rs
@@ -1,7 +1,6 @@
 use core::ptr::NonNull;
 
 use crate::BundledAst as JSAst;
-use bun_alloc::Arena as ThreadLocalArena;
 use bun_ast::server_component_boundary;
 use bun_collections::{MultiArrayList, VecExt};
 use enum_map::EnumMap;
@@ -17,7 +16,7 @@ use bun_ast::Ref;
 // `bun.ast.Index.Int` — the underlying integer repr of `Index`.
 pub(crate) use crate::IndexInt;
 
-pub struct Graph {
+pub struct Graph<'a> {
     // TODO(port): lifetime — no direct LIFETIMES.tsv row for Graph.pool, but row 170
     // (ThreadPool.v2, BACKREF) evidence states "BundleV2.graph.pool owns ThreadPool".
     // bundle_v2.zig:992 allocates it from `this.arena()` (the `self.heap` arena) and
@@ -25,8 +24,14 @@ pub struct Graph {
     // (sibling field). `BackRef` (not raw `NonNull`) so the read accessor `pool()` is
     // safe — the BACKREF invariant (pointee outlives holder) holds for the entire
     // bundle pass.
-    pub pool: bun_ptr::BackRef<ThreadPool>,
-    pub heap: ThreadLocalArena,
+    pub pool: bun_ptr::BackRef<ThreadPool<'a>>,
+    /// Append-only owner of every per-worker `MimallocArena` plus the
+    /// bundler-thread arena. Stack-allocated in the bundle entry point so its
+    /// lifetime unifies with `'a`. See [`crate::ArenaPool`].
+    pub arena_pool: &'a crate::ArenaPool,
+    /// The bundler-thread arena, allocated from `arena_pool` on the bundler
+    /// thread (so its `owning_thread` stamp is correct).
+    pub heap: &'a bun_alloc::Arena,
 
     /// Mapping user-specified entry points to their Source Index
     // PERF(port): arena-fed ArrayList (self.heap) — self-referential, revisit in Phase B
@@ -37,9 +42,9 @@ pub struct Graph {
     pub input_files: MultiArrayList<InputFile>,
     /// Every source index has an associated Ast
     /// When a parse is in progress / queued, it is `Ast.empty`
-    // PORT NOTE: BundledAst<'arena> borrows from self.heap (sibling-field self-ref);
-    // 'static here is a placeholder — Phase-B lifetime threading via raw ptr or Ouroboros.
-    pub ast: MultiArrayList<JSAst<'static>>,
+    /// `'a` is the [`crate::ArenaPool`] lifetime — every per-worker arena and
+    /// `self.heap` are owned by the pool, so all rows borrow from `'a`.
+    pub ast: MultiArrayList<JSAst<'a>>,
 
     /// During the scan + parse phase, this value keeps a count of the remaining
     /// tasks. Once it hits zero, the scan phase ends and linking begins. Note
@@ -140,13 +145,14 @@ bitflags::bitflags! {
     }
 }
 
-impl Default for Graph {
-    fn default() -> Self {
+impl<'a> Graph<'a> {
+    pub fn new(arena_pool: &'a crate::ArenaPool) -> Self {
         Self {
             // Self-referential arena pointer; real value wired in
             // `BundleV2::init` before any use (Graph.zig has `= undefined`).
-            pool: bun_ptr::BackRef::from(NonNull::<ThreadPool>::dangling()),
-            heap: ThreadLocalArena::new(),
+            pool: bun_ptr::BackRef::from(NonNull::<ThreadPool<'a>>::dangling()),
+            arena_pool,
+            heap: arena_pool.alloc(),
             entry_points: Vec::new(),
             entry_point_original_names: IndexStringMap::default(),
             input_files: MultiArrayList::default(),
@@ -166,7 +172,7 @@ impl Default for Graph {
     }
 }
 
-impl Graph {
+impl<'a> Graph<'a> {
     /// Shared borrow of the bundler `ThreadPool`.
     ///
     /// `pool` is arena-allocated in `BundleV2::init` (bundle_v2.zig:992) and
@@ -177,7 +183,7 @@ impl Graph {
     /// can use this in place of the prior open-coded
     /// `unsafe { self.pool.as_ref() }` / `as_mut()`.
     #[inline]
-    pub fn pool(&self) -> &ThreadPool {
+    pub fn pool(&self) -> &ThreadPool<'a> {
         // BackRef invariant: `pool` is set in `BundleV2::init` to an
         // arena-owned `ThreadPool` and remains valid until `BundleV2::deinit`;
         // no `&mut ThreadPool` is live across any `pool()` borrow (the only
@@ -190,7 +196,7 @@ impl Graph {
     /// `ThreadPool::deinit` during teardown; prefer [`Self::pool`] for
     /// scheduling.
     #[inline]
-    pub fn pool_mut(&mut self) -> &mut ThreadPool {
+    pub fn pool_mut(&mut self) -> &mut ThreadPool<'a> {
         // SAFETY: see `pool()`. `&mut self` excludes other safe borrows of
         // `Graph`, so no aliasing `&ThreadPool` is live.
         unsafe { self.pool.get_mut() }

--- a/src/bundler/HTMLImportManifest.rs
+++ b/src/bundler/HTMLImportManifest.rs
@@ -54,14 +54,14 @@ use crate::{BundleV2, Chunk, LinkerGraph};
 // TODO(port): lifetime — LIFETIMES.tsv has no rows for this file; classified as
 // BORROW_PARAM (transient formatter struct passed by value).
 #[derive(Clone, Copy)]
-pub struct HTMLImportManifest<'a> {
+pub struct HTMLImportManifest<'r, 'a> {
     pub index: u32,
-    pub graph: &'a Graph,
-    pub chunks: &'a [Chunk],
-    pub linker_graph: &'a LinkerGraph,
+    pub graph: &'r Graph<'a>,
+    pub chunks: &'r [Chunk<'a>],
+    pub linker_graph: &'r LinkerGraph<'a>,
 }
 
-impl<'a> fmt::Display for HTMLImportManifest<'a> {
+impl<'r, 'a> fmt::Display for HTMLImportManifest<'r, 'a> {
     fn fmt(&self, writer: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut adapter = FmtAdapter::new(writer);
         match write(
@@ -133,9 +133,9 @@ fn write_entry_item<W: Write + ?Sized>(
 // Extremely unfortunate, but necessary due to E.String not accepting pre-escaped input and this happening at the very end.
 pub fn write_escaped_json<W: Write + ?Sized>(
     index: u32,
-    graph: &Graph,
-    linker_graph: &LinkerGraph,
-    chunks: &[Chunk],
+    graph: &Graph<'_>,
+    linker_graph: &LinkerGraph<'_>,
+    chunks: &[Chunk<'_>],
     writer: &mut W,
 ) -> Result<(), bun_core::Error> {
     // PERF(port): was stack-fallback (std.heap.stackFallback(4096)) — profile in Phase B
@@ -149,9 +149,9 @@ pub fn write_escaped_json<W: Write + ?Sized>(
 
 /// Newtype wrapper produced by [`HTMLImportManifest::format_escaped_json`].
 /// Mirrors Zig's `std.fmt.Alt(HTMLImportManifest, escapedJSONFormatter)`.
-pub struct EscapedJson<'a>(pub HTMLImportManifest<'a>);
+pub struct EscapedJson<'r, 'a>(pub HTMLImportManifest<'r, 'a>);
 
-impl<'a> fmt::Display for EscapedJson<'a> {
+impl<'r, 'a> fmt::Display for EscapedJson<'r, 'a> {
     fn fmt(&self, writer: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut adapter = FmtAdapter::new(writer);
         match write_escaped_json(
@@ -169,17 +169,17 @@ impl<'a> fmt::Display for EscapedJson<'a> {
     }
 }
 
-impl<'a> HTMLImportManifest<'a> {
-    pub fn format_escaped_json(self) -> EscapedJson<'a> {
+impl<'r, 'a> HTMLImportManifest<'r, 'a> {
+    pub fn format_escaped_json(self) -> EscapedJson<'r, 'a> {
         EscapedJson(self)
     }
 }
 
 pub fn write<W: Write + ?Sized>(
     index: u32,
-    graph: &Graph,
-    linker_graph: &LinkerGraph,
-    chunks: &[Chunk],
+    graph: &Graph<'_>,
+    linker_graph: &LinkerGraph<'_>,
+    chunks: &[Chunk<'_>],
     writer: &mut W,
 ) -> Result<(), bun_core::Error> {
     let browser_source_index = graph.html_imports.html_source_indices.slice()[index as usize];

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -21,7 +21,7 @@ use bun_threading::{self as sync, WaitGroup, thread_pool as ThreadPoolLib};
 use crate::bake_types as bake;
 use crate::bun_css as css;
 
-use crate::BundledAst as JSAst;
+use crate::ungate_support::JSAst;
 use bun_ast::{
     self as js_ast, Binding, DeclaredSymbol, Dependency, ExportsKind, Expr, NamedImport, Part, Ref,
     Stmt, Symbol, TlaCheck,
@@ -102,7 +102,7 @@ bun_crash_handler::link_impl_BundleGenerateChunkCtx! {
 #[inline]
 pub fn bundle_generate_chunk_action(
     ctx: &LinkerContext,
-    chunk: &Chunk,
+    chunk: &Chunk<'_>,
     part_range: &PartRange,
 ) -> bun_crash_handler::Action {
     bun_crash_handler::Action::BundleGenerateChunk(bun_crash_handler::BundleGenerateChunk {
@@ -121,7 +121,7 @@ pub fn bundle_generate_chunk_action(
 #[inline]
 pub fn bundle_generate_chunk_action(
     _ctx: &LinkerContext,
-    _chunk: &Chunk,
+    _chunk: &Chunk<'_>,
     _part_range: &PartRange,
 ) -> bun_crash_handler::Action {
     bun_crash_handler::Action::BundleGenerateChunk(())
@@ -176,8 +176,8 @@ pub use crate::DeferredBatchTask::DeferredBatchTask;
 pub use crate::ParseTask;
 
 pub struct LinkerContext<'a> {
-    pub parse_graph: *mut Graph,
-    pub graph: LinkerGraph,
+    pub parse_graph: *mut Graph<'a>,
+    pub graph: LinkerGraph<'a>,
     /// Backref into `Transpiler.log`, assigned in [`Self::load`]. Stored as a
     /// raw pointer (like `parse_graph` / `resolver`) so `Default` can be
     /// `null_mut()` instead of a dangling `&mut` (instant UB). Use
@@ -291,7 +291,7 @@ impl<'a> LinkerContext<'a> {
     /// `generate_isolated_hash`) must continue to deref the raw
     /// `self.parse_graph` field directly.
     #[inline]
-    pub fn parse_graph(&self) -> &Graph {
+    pub fn parse_graph(&self) -> &Graph<'a> {
         debug_assert!(
             !self.parse_graph.is_null(),
             "LinkerContext.parse_graph accessed before load()"
@@ -306,7 +306,7 @@ impl<'a> LinkerContext<'a> {
     /// split-borrow patterns that interleave `&mut Graph` with other `self`
     /// borrows.
     #[inline]
-    pub fn parse_graph_mut(&mut self) -> &mut Graph {
+    pub fn parse_graph_mut(&mut self) -> &mut Graph<'a> {
         debug_assert!(
             !self.parse_graph.is_null(),
             "LinkerContext.parse_graph accessed before load()"
@@ -515,7 +515,7 @@ impl<'a> LinkerContext<'a> {
     /// (or otherwise not overlap the fields named above).
     pub unsafe fn load(
         &mut self,
-        bundle: *mut BundleV2,
+        bundle: *mut BundleV2<'a>,
         entry_points: &[Index],
         server_component_boundaries: &bun_ast::server_component_boundary::List,
         reachable: &[Index],
@@ -705,7 +705,7 @@ impl<'a> LinkerContext<'a> {
         // PORT NOTE: reshaped for borrowck — Zig held overlapping `&`/`&mut`
         // into `parse_graph.html_imports` and `parse_graph.input_files`; here
         // we go through raw pointers and reborrow per use.
-        let parse_graph: *mut Graph = self.parse_graph;
+        let parse_graph: *mut Graph<'_> = self.parse_graph;
         // SAFETY: see above; sole accessor of `html_imports` for this scope.
         let server_len = unsafe { (*parse_graph).html_imports.server_source_indices.len() };
         if server_len > 0 {
@@ -787,11 +787,11 @@ impl<'a> LinkerContext<'a> {
     #[inline(never)]
     pub unsafe fn link(
         &mut self,
-        bundle: *mut BundleV2,
+        bundle: *mut BundleV2<'a>,
         entry_points: &[Index],
         server_component_boundaries: &bun_ast::server_component_boundary::List,
         reachable: &[Index],
-    ) -> Result<Box<[Chunk]>, LinkError> {
+    ) -> Result<Box<[Chunk<'a>]>, LinkError> {
         // SAFETY: forwarded; see fn-level contract.
         unsafe { self.load(bundle, entry_points, server_component_boundaries, reachable)? };
 
@@ -814,7 +814,7 @@ impl<'a> LinkerContext<'a> {
             // reallocate inside `validate_tla`; we cache raw column pointers
             // and reborrow per call to satisfy borrowck (`&mut self` is held
             // across the recursion).
-            let parse_graph: *mut Graph = self.parse_graph;
+            let parse_graph: *mut Graph<'_> = self.parse_graph;
             let import_records_list: *const [Vec<ImportRecord>] =
                 self.graph.ast.items_import_records();
             let flags: *mut [crate::ungate_support::js_meta::Flags] =
@@ -1020,12 +1020,12 @@ impl<'a> LinkerContext<'a> {
     // `post_process_*` callees take `GenerateChunkCtx` by value and deref
     // `ctx.c` to `&LinkerContext` for read-only graph access plus per-chunk
     // raw-ptr writes (see `postProcessJSChunk.rs`).
-    pub fn generate_chunk(ctx: &GenerateChunkCtx, chunk: *mut Chunk, chunk_index: usize) {
+    pub fn generate_chunk(ctx: &GenerateChunkCtx, chunk: *mut Chunk<'_>, chunk_index: usize) {
         // SAFETY: `each_ptr` hands us a unique `*mut Chunk` per task; deref for
         // the duration of this body. ctx.c points into BundleV2.linker;
         // container_of pattern. `Worker::get` only reads `bundle.graph.pool`
         // (shared), so a `&` is sufficient and avoids aliasing.
-        let chunk: &mut Chunk = unsafe { &mut *chunk };
+        let chunk: &mut Chunk<'_> = unsafe { &mut *chunk };
         let worker = crate::thread_pool::Worker::get(ctx.bundle());
         let mut worker = scopeguard::guard(worker, |w| w.unget());
         let worker: &mut crate::thread_pool::Worker = &mut **worker;
@@ -1049,10 +1049,10 @@ impl<'a> LinkerContext<'a> {
     // `ctx.c.options` shared. `rename_symbols_in_chunk` takes `*mut
     // LinkerContext` raw and never materializes `&mut LinkerContext` while
     // peer renamer tasks are live (see its CONCURRENCY note).
-    pub fn generate_js_renamer(ctx: &GenerateChunkCtx, chunk: *mut Chunk, chunk_index: usize) {
+    pub fn generate_js_renamer(ctx: &GenerateChunkCtx<'a>, chunk: *mut Chunk<'a>, chunk_index: usize) {
         // SAFETY: `each_ptr` hands us a unique `*mut Chunk` per task; deref for
         // the body. container_of pattern — see `generate_chunk` above.
-        let chunk: &mut Chunk = unsafe { &mut *chunk };
+        let chunk: &mut Chunk<'a> = unsafe { &mut *chunk };
         let worker = crate::thread_pool::Worker::get(ctx.bundle());
         let mut worker = scopeguard::guard(worker, |w| w.unget());
         if let crate::chunk::Content::Javascript(_) = chunk.content {
@@ -1061,9 +1061,9 @@ impl<'a> LinkerContext<'a> {
     }
 
     fn generate_js_renamer_(
-        ctx: GenerateChunkCtx,
-        _worker: &mut crate::thread_pool::Worker,
-        chunk: &mut Chunk,
+        ctx: GenerateChunkCtx<'a>,
+        _worker: &mut crate::thread_pool::Worker<'a>,
+        chunk: &mut Chunk<'a>,
         chunk_index: usize,
     ) {
         let _ = chunk_index;
@@ -1570,8 +1570,8 @@ impl SourceMapData {
 // Clone: bitwise OK — `alias` borrows from the AST arena (non-owning); all
 // other fields are POD.
 #[derive(Clone, Default)]
-pub struct MatchImport {
-    alias: bun_ast::StoreStr, // Zig string borrowed from AST arena
+pub struct MatchImport<'a> {
+    alias: bun_ast::StoreStr<'a>, // Zig string borrowed from AST arena
     kind: MatchImportKind,
     namespace_ref: Ref,
     source_index: u32,
@@ -1615,18 +1615,18 @@ pub type ChunkMetaMap = ArrayHashMap<Ref, ()>;
 #[derive(Clone, Copy)]
 pub struct GenerateChunkCtx<'a> {
     pub c: bun_ptr::ParentRef<LinkerContext<'a>>,
-    /// Backref to the full `chunks: &mut [Chunk]` slice owned by
+    /// Backref to the full `chunks: &mut [Chunk<'_>]` slice owned by
     /// `generate_chunks_in_parallel`. The slice outlives every
     /// `GenerateChunkCtx` (joined via `wait_for_all`), so [`bun_ptr::BackRef`]'s
     /// owner-outlives-holder invariant holds and per-task reads go through
     /// safe `Deref`. Tasks that need write provenance (HTML loader) recover
     /// the raw `*mut [Chunk]` via [`bun_ptr::BackRef::as_ptr`].
-    pub chunks: bun_ptr::BackRef<[Chunk]>,
+    pub chunks: bun_ptr::BackRef<[Chunk<'a>]>,
     /// Backref to this task's `Chunk` (an element of `chunks`). Constructed
     /// via [`bun_ptr::BackRef::new_mut`] so the stored `NonNull` carries write
     /// provenance; per-task slot writes recover the raw `*mut Chunk` via
     /// [`bun_ptr::BackRef::as_ptr`], shared reads go through safe `Deref`.
-    pub chunk: bun_ptr::BackRef<Chunk>,
+    pub chunk: bun_ptr::BackRef<Chunk<'a>>,
 }
 // SAFETY: see PORT NOTE above — mirrors Zig's freely-aliased `*LinkerContext`.
 unsafe impl<'a> Send for GenerateChunkCtx<'a> {}
@@ -1700,10 +1700,10 @@ pub(crate) unsafe fn pending_part_range_prologue<'a>(
 ) -> (
     &'a PendingPartRange<'a>,
     *mut LinkerContext<'a>,
-    *mut Chunk,
+    *mut Chunk<'a>,
     scopeguard::ScopeGuard<
-        &'static mut crate::thread_pool::Worker,
-        impl FnOnce(&'static mut crate::thread_pool::Worker),
+        &'static mut crate::thread_pool::Worker<'a>,
+        impl FnOnce(&'static mut crate::thread_pool::Worker<'a>),
     >,
 ) {
     // SAFETY: per fn contract — `task` is the intrusive `task` field.
@@ -1711,7 +1711,7 @@ pub(crate) unsafe fn pending_part_range_prologue<'a>(
         unsafe { &*bun_core::from_field_ptr!(PendingPartRange, task, task) };
     let ctx = part_range.ctx;
     let c_ptr: *mut LinkerContext = ctx.c.as_mut_ptr().cast();
-    let chunk_ptr: *mut Chunk = ctx.chunk.as_ptr();
+    let chunk_ptr: *mut Chunk<'_> = ctx.chunk.as_ptr();
     let worker = crate::thread_pool::Worker::get(ctx.bundle());
     let worker = scopeguard::guard(worker, |w| w.unget());
     (part_range, c_ptr, chunk_ptr, worker)
@@ -1730,7 +1730,7 @@ pub(crate) unsafe fn pending_part_range_prologue<'a>(
 #[must_use]
 pub(crate) fn crash_guard_for_part_range(
     c: &LinkerContext<'_>,
-    chunk: &Chunk,
+    chunk: &Chunk<'_>,
     part_range: &PartRange,
 ) -> bun_crash_handler::ActionGuard {
     bun_crash_handler::scoped_action(bundle_generate_chunk_action(c, chunk, part_range))
@@ -1748,7 +1748,7 @@ struct SubstituteChunkFinalPathResult {
 // and un-gate together with `LinkerGraph.rs`.
 
 impl<'a> LinkerContext<'a> {
-    pub fn generate_isolated_hash(&mut self, chunk: &Chunk) -> u64 {
+    pub fn generate_isolated_hash(&mut self, chunk: &Chunk<'_>) -> u64 {
         let _trace = bun::perf::trace("Bundler.generateIsolatedHash");
 
         let mut hasher = ContentHasher::default();
@@ -2025,12 +2025,12 @@ impl<'a> LinkerContext<'a> {
 
     pub fn should_remove_import_export_stmt(
         &mut self,
-        stmts: &mut StmtList,
+        stmts: &mut StmtList<'_>,
         loc: Loc,
         namespace_ref: Ref,
         import_record_index: u32,
         alloc: &Bump,
-        ast: &JSAst,
+        ast: &JSAst<'_>,
     ) -> Result<bool, BunError> {
         let record = ast.import_records.at(import_record_index as usize);
         // Barrel optimization: deferred import records should be dropped
@@ -2162,11 +2162,11 @@ impl<'a> LinkerContext<'a> {
 
     pub fn print_code_for_file_in_chunk_js(
         &mut self,
-        r: renamer::Renamer,
+        r: renamer::Renamer<'_, '_, '_>,
         alloc: &Bump,
         writer: &mut js_printer::BufferWriter,
-        out_stmts: &mut [Stmt],
-        ast: &JSAst,
+        out_stmts: &mut [Stmt<'a>],
+        ast: &JSAst<'a>,
         flags: crate::ungate_support::js_meta::Flags,
         to_esm_ref: Ref,
         to_commonjs_ref: Ref,
@@ -2275,18 +2275,6 @@ impl<'a> LinkerContext<'a> {
         // SAFETY: `ast` is a valid `&BundledAst` for the duration of this call;
         // the read is a bitwise copy whose result is never dropped.
         let printer_ast = core::mem::ManuallyDrop::new(unsafe { core::ptr::read(ast) }.to_ast());
-
-        // PORT NOTE: `print_with_writer<'a>` requires `Renamer<'a,'a>` (the
-        // printer struct stores it with a single lifetime), but `Renamer`'s
-        // `'src` is invariant behind `&mut`, so the caller's `Renamer<'r,'src>`
-        // cannot unify with the local `'a` picked from `alloc`/`mangled_props`.
-        // Zig threads it as a raw pointer (no lifetimes). Rebind via a
-        // lifetime-only cast — sound because the renamer's borrowed data
-        // (symbol map, source) strictly outlives this call.
-        // SAFETY: lifetime-only erase; layout identical across instantiations.
-        let r: renamer::Renamer<'_, '_> = unsafe {
-            core::mem::transmute::<renamer::Renamer<'_, '_>, renamer::Renamer<'_, '_>>(r)
-        };
 
         let enable_source_maps =
             self.options.source_maps != SourceMapOption::None && !source_index.is_runtime();
@@ -2429,7 +2417,7 @@ impl<'a> LinkerContext<'a> {
     pub fn append_isolated_hashes_for_imported_chunks(
         &self,
         hash: &mut ContentHasher,
-        chunks: &mut [Chunk],
+        chunks: &mut [Chunk<'_>],
         index: u32,
         chunk_visit_map: &mut AutoBitSet,
     ) {
@@ -3520,7 +3508,7 @@ impl<'a> LinkerContext<'a> {
         &mut self,
         init_tracker: ImportTracker,
         re_exports: &mut Vec<Dependency>,
-    ) -> MatchImport {
+    ) -> MatchImport<'a> {
         let cycle_detector_top = self.cycle_detector.len();
         // PORT NOTE: Zig's `defer cycle_detector.shrinkRetainingCapacity` is
         // lowered to an explicit `truncate` after the `'loop_` below — the only
@@ -4240,7 +4228,7 @@ impl<'a> LinkerContext<'a> {
 }
 
 // PartialEq for MatchImport (needed for std.meta.eql in match_import_with_export)
-impl PartialEq for MatchImport {
+impl PartialEq for MatchImport<'_> {
     fn eq(&self, other: &Self) -> bool {
         // PORT NOTE: Zig `std.meta.eql` on a slice compares ptr+len, not contents —
         // compare the raw fat pointer (address + length metadata).
@@ -4259,23 +4247,23 @@ impl PartialEq for MatchImport {
 // StmtList
 // ──────────────────────────────────────────────────────────────────────────
 
-pub struct StmtList {
+pub struct StmtList<'a> {
     // TODO(port): arena field dropped — Vec uses global mimalloc; bundler is AST crate but
     // these are temporary scratch buffers, not arena-backed in the original (uses generic arena param)
-    pub inside_wrapper_prefix: InsideWrapperPrefix,
-    pub outside_wrapper_prefix: Vec<Stmt>,
-    pub inside_wrapper_suffix: Vec<Stmt>,
-    pub all_stmts: Vec<Stmt>,
+    pub inside_wrapper_prefix: InsideWrapperPrefix<'a>,
+    pub outside_wrapper_prefix: Vec<Stmt<'a>>,
+    pub inside_wrapper_suffix: Vec<Stmt<'a>>,
+    pub all_stmts: Vec<Stmt<'a>>,
 }
 
-pub struct InsideWrapperPrefix {
-    pub stmts: Vec<Stmt>,
+pub struct InsideWrapperPrefix<'a> {
+    pub stmts: Vec<Stmt<'a>>,
     pub sync_dependencies_end: usize,
     // if true it will exist at `sync_dependencies_end`
     pub has_async_dependency: bool,
 }
 
-impl InsideWrapperPrefix {
+impl<'a> InsideWrapperPrefix<'a> {
     pub fn init() -> Self {
         Self {
             stmts: Vec::new(),
@@ -4296,18 +4284,18 @@ impl InsideWrapperPrefix {
 // TODO(b2-blocked): `Expr`/`Stmt` builder helpers (`E::Call`, `S::SExpr` etc.)
 // — bun_js_parser AST builder surface not yet stable.
 
-impl InsideWrapperPrefix {
-    pub fn append_non_dependency(&mut self, stmt: Stmt) -> Result<(), AllocError> {
+impl<'a> InsideWrapperPrefix<'a> {
+    pub fn append_non_dependency(&mut self, stmt: Stmt<'a>) -> Result<(), AllocError> {
         self.stmts.push(stmt);
         Ok(())
     }
 
-    pub fn append_non_dependency_slice(&mut self, stmts: &[Stmt]) -> Result<(), AllocError> {
+    pub fn append_non_dependency_slice(&mut self, stmts: &[Stmt<'a>]) -> Result<(), AllocError> {
         self.stmts.extend_from_slice(stmts);
         Ok(())
     }
 
-    pub fn append_sync_dependency(&mut self, call_expr: Expr) -> Result<(), AllocError> {
+    pub fn append_sync_dependency(&mut self, call_expr: Expr<'a>) -> Result<(), AllocError> {
         self.stmts.insert(
             self.sync_dependencies_end,
             Stmt::alloc(
@@ -4324,7 +4312,7 @@ impl InsideWrapperPrefix {
 
     pub fn append_async_dependency(
         &mut self,
-        call_expr: Expr,
+        call_expr: Expr<'static>,
         promise_all_ref: Ref,
     ) -> Result<(), AllocError> {
         if !self.has_async_dependency {
@@ -4427,7 +4415,7 @@ impl InsideWrapperPrefix {
     }
 }
 
-impl StmtList {
+impl<'a> StmtList<'a> {
     pub fn reset(&mut self) {
         self.inside_wrapper_prefix.reset();
         self.outside_wrapper_prefix.clear();
@@ -4446,7 +4434,7 @@ impl StmtList {
         }
     }
 
-    pub fn append_slice(&mut self, list: StmtListWhich, stmts: &[Stmt]) {
+    pub fn append_slice(&mut self, list: StmtListWhich, stmts: &[Stmt<'a>]) {
         match list {
             StmtListWhich::OutsideWrapperPrefix => {
                 self.outside_wrapper_prefix.extend_from_slice(stmts)
@@ -4458,7 +4446,7 @@ impl StmtList {
         }
     }
 
-    pub fn append(&mut self, list: StmtListWhich, stmt: Stmt) {
+    pub fn append(&mut self, list: StmtListWhich, stmt: Stmt<'a>) {
         match list {
             StmtListWhich::OutsideWrapperPrefix => self.outside_wrapper_prefix.push(stmt),
             StmtListWhich::InsideWrapperSuffix => self.inside_wrapper_suffix.push(stmt),

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -29,25 +29,20 @@ bun_core::declare_scope!(LinkerGraph, visible);
 // were drafted against an older `.items().field_name` shape; rewritten to the
 // `items_<field>()` spelling (matches `LinkerContext.rs`).
 
-pub struct LinkerGraph {
+pub struct LinkerGraph<'a> {
     pub files: FileList,
     pub files_live: BitSet,
     pub entry_points: entry_point::List,
-    pub symbols: symbol::Map,
+    pub symbols: symbol::Map<'a>,
 
-    // PORT NOTE: lifetime-erased. Zig stores `std.mem.Allocator`; the Rust
-    // arena is owned by `BundleV2` and outlives every `LinkerGraph` — kept as
-    // a raw pointer (matching `LinkerContext.parse_graph: *mut Graph`) so the
-    // struct stays `'static`-ish and `LinkerContext`/`Chunk` callers don't
-    // grow a `'bump` parameter yet. Phase B: thread `'bump` once `Chunk` and
-    // `html_import_manifest` gain lifetimes.
+    /// Backref into `Graph.heap` (owned by the [`crate::ArenaPool`]).
     pub bump: bun_ptr::BackRef<Arena>,
 
     pub code_splitting: bool,
 
     // This is an alias from Graph
     // it is not a clone!
-    pub ast: MultiArrayList<JSAst>,
+    pub ast: MultiArrayList<JSAst<'a>>,
     pub meta: MultiArrayList<JSMeta>,
 
     /// We should avoid traversing all files in the bundle, because the linker
@@ -67,7 +62,7 @@ pub struct LinkerGraph {
     /// This is for cross-module inlining of detected inlinable constants
     // const_values: bun_ast::Ast::ConstValuesMap,
     /// This is for cross-module inlining of TypeScript enum constants
-    pub ts_enums: bun_ast::ast_result::TsEnumsMap,
+    pub ts_enums: bun_ast::ast_result::TsEnumsMap<'a>,
 }
 
 // SAFETY: `LinkerGraph` is shared read-mostly across worker threads during
@@ -93,10 +88,10 @@ pub struct LinkerGraph {
 // `Send` is required because `LinkerGraph` is moved into `LinkerContext`
 // which is itself sent to the link task; the only `!Send` constituent is the
 // raw `*const Arena`, whose pointee is `Sync` and outlives the graph.
-unsafe impl Send for LinkerGraph {}
-unsafe impl Sync for LinkerGraph {}
+unsafe impl Send for LinkerGraph<'_> {}
+unsafe impl Sync for LinkerGraph<'_> {}
 
-impl LinkerGraph {
+impl<'a> LinkerGraph<'a> {
     /// `&Arena` accessor — `bump` is a raw backref into `BundleV2`.
     #[inline]
     pub fn arena(&self) -> &Arena {
@@ -106,8 +101,8 @@ impl LinkerGraph {
     }
 }
 
-impl LinkerGraph {
-    pub fn init(bump: &Arena, file_count: usize) -> Result<Self, bun_core::Error> {
+impl<'a> LinkerGraph<'a> {
+    pub fn init(bump: &'a Arena, file_count: usize) -> Result<Self, bun_core::Error> {
         // TODO(port): narrow error set
         Ok(LinkerGraph {
             files: FileList::default(),
@@ -126,7 +121,7 @@ impl LinkerGraph {
     }
 }
 
-impl Default for LinkerGraph {
+impl Default for LinkerGraph<'_> {
     fn default() -> Self {
         LinkerGraph {
             files: FileList::default(),
@@ -212,12 +207,12 @@ pub fn top_level_symbol_to_parts<'a>(
     &[]
 }
 
-pub fn add_part_to_file(
-    parts: &mut [part::List],
+pub fn add_part_to_file<'a>(
+    parts: &mut [part::List<'a>],
     top_level_symbol_to_parts_overlay: &mut [TopLevelSymbolToParts],
     top_level_symbols_to_parts: &[bundled_ast::TopLevelSymbolToParts],
     id: u32,
-    part: Part,
+    part: Part<'a>,
 ) -> Result<u32, bun_alloc::AllocError> {
     let part_id = parts[id as usize].len() as u32; // @truncate (u32)
     parts[id as usize].push(part);
@@ -359,7 +354,7 @@ pub fn generate_symbol_import_and_use(
     Ok(())
 }
 
-impl LinkerGraph {
+impl<'a> LinkerGraph<'a> {
     pub fn runtime_function(&self, name: &[u8]) -> Ref {
         runtime_function(self.ast.items_named_exports(), name)
     }
@@ -442,7 +437,7 @@ impl LinkerGraph {
         )
     }
 
-    pub fn add_part_to_file(&mut self, id: u32, part: Part) -> Result<u32, bun_alloc::AllocError> {
+    pub fn add_part_to_file(&mut self, id: u32, part: Part<'a>) -> Result<u32, bun_alloc::AllocError> {
         let ast = self.ast.split_mut();
         add_part_to_file(
             ast.parts,
@@ -489,7 +484,7 @@ impl LinkerGraph {
     }
 }
 
-impl LinkerGraph {
+impl<'a> LinkerGraph<'a> {
     pub fn load(
         &mut self,
         entry_points: &[Index],

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -118,8 +118,8 @@ pub struct ParseTask {
     /// scheduled task has it set via `init` / `bundle_v2.rs` write-sites.
     pub ctx: Option<bun_ptr::ParentRef<BundleV2<'static>>>,
     // Borrows package_json (resolver arena); valid for the bundle pass.
-    pub package_version: ast::StoreStr,
-    pub package_name: ast::StoreStr,
+    pub package_version: ast::StoreStr<'static>,
+    pub package_name: ast::StoreStr<'static>,
     pub is_entry_point: bool,
 }
 
@@ -133,10 +133,10 @@ pub enum ParseTaskStage {
 // ───────────────────────────────────────────────────────────────────────────
 
 /// The information returned to the Bundler thread when a parse finishes.
-pub struct Result {
+pub struct Result<'a> {
     pub task: EventLoop::Task,
-    pub ctx: bun_ptr::ParentRef<BundleV2<'static>>,
-    pub value: ResultValue,
+    pub ctx: bun_ptr::ParentRef<BundleV2<'a>>,
+    pub value: ResultValue<'a>,
     pub watcher_data: WatcherData,
     /// This is used for native onBeforeParsePlugins to store
     /// a function pointer and context pointer to free the
@@ -144,8 +144,8 @@ pub struct Result {
     pub external: ExternalFreeFunction,
 }
 
-pub enum ResultValue {
-    Success(Success),
+pub enum ResultValue<'a> {
+    Success(Success<'a>),
     Err(ResultError),
     Empty { source_index: Index },
 }
@@ -163,22 +163,22 @@ impl WatcherData {
     };
 }
 
-pub struct Success {
-    pub ast: JSAst,
+pub struct Success<'a> {
+    pub ast: JSAst<'a>,
     pub source: Source,
     pub log: Log,
     pub use_directive: UseDirective,
     pub side_effects: bun_ast::SideEffects,
 
     /// Used by "file" loader files.
-    pub unique_key_for_additional_file: ast::StoreStr,
+    pub unique_key_for_additional_file: ast::StoreStr<'a>,
     /// Used by "file" loader files.
     pub content_hash_for_additional_file: u64,
 
     pub loader: Loader,
 
     /// The package name from package.json, used for barrel optimization.
-    pub package_name: ast::StoreStr,
+    pub package_name: ast::StoreStr<'a>,
 }
 
 pub struct ResultError {
@@ -609,13 +609,13 @@ pub mod parse_worker {
     // `(*transpiler).resolver`; materializing `&mut Transpiler` here would assert
     // exclusive access to the whole struct and invalidate that sibling pointer.
     // We only touch the disjoint `options.define` field.
-    fn get_empty_css_ast(
+    fn get_empty_css_ast<'a>(
         log: &mut Log,
         transpiler: *mut Transpiler,
-        opts: ParserOptions,
-        bump: &'static Bump,
-        source: &Source,
-    ) -> core::result::Result<JSAst, AnyError> {
+        opts: ParserOptions<'a>,
+        bump: &'a Bump,
+        source: &'a Source,
+    ) -> core::result::Result<JSAst<'a>, AnyError> {
         let root = Expr::init(E::Object::default(), Loc { start: 0 });
         // SAFETY: `transpiler` is a live worker-owned `*mut Transpiler`; `options`
         // is disjoint from any other field the caller may hold a pointer to.
@@ -629,13 +629,13 @@ pub mod parse_worker {
         Ok(ast)
     }
 
-    fn get_empty_ast<RootType: Default + bun_ast::expr::IntoExprData>(
+    fn get_empty_ast<'a, RootType: Default + bun_ast::expr::IntoExprData<'a>>(
         log: &mut Log,
         transpiler: *mut Transpiler,
-        opts: ParserOptions,
-        bump: &'static Bump,
-        source: &Source,
-    ) -> core::result::Result<JSAst, AnyError> {
+        opts: ParserOptions<'a>,
+        bump: &'a Bump,
+        source: &'a Source,
+    ) -> core::result::Result<JSAst<'a>, AnyError> {
         let root = Expr::init(RootType::default(), Loc::EMPTY);
         // SAFETY: see `get_empty_css_ast` — disjoint field of a live `*mut Transpiler`.
         let define = unsafe { &mut (*transpiler).options.define };
@@ -649,7 +649,7 @@ pub mod parse_worker {
     // ───────────────────────────────────────────────────────────────────────────
 
     pub struct FileLoaderHash {
-        pub key: ast::StoreStr,
+        pub key: ast::StoreStr<'static>,
         pub content_hash: u64,
     }
 
@@ -721,18 +721,18 @@ pub mod parse_worker {
     // `&mut Resolver` would be aliased-`&mut` UB. We instead reborrow only the
     // disjoint `(*transpiler).options` field, never the whole struct.
     #[allow(clippy::too_many_arguments)]
-    fn get_ast(
+    fn get_ast<'a>(
         log: &mut Log,
         transpiler: *mut Transpiler,
-        opts: ParserOptions,
-        bump: &'static Bump,
+        opts: ParserOptions<'a>,
+        bump: &'a Bump,
         resolver: *mut Resolver,
-        source: &Source,
+        source: &'a Source,
         loader: Loader,
         unique_key_prefix: u64,
         unique_key_for_additional_file: &mut FileLoaderHash,
         has_any_css_locals: &AtomicU32,
-    ) -> core::result::Result<JSAst, AnyError> {
+    ) -> core::result::Result<JSAst<'a>, AnyError> {
         use core::fmt::Write as _;
 
         // SAFETY: `transpiler` is a live worker-owned `*mut Transpiler`.
@@ -811,7 +811,7 @@ pub mod parse_worker {
                 // scopeguard would alias `log`/`temp_log` (both borrowed mutably
                 // below); reshape as a closure so every `?` exits through one
                 // post-amble that flushes `temp_log`.
-                let result = (|| -> core::result::Result<JSAst, AnyError> {
+                let result = (|| -> core::result::Result<JSAst<'a>, AnyError> {
                     let root: Expr =
                         bun_parsers::toml::TOML::parse(source, &mut temp_log, bump, false)?.into();
                     Ok(JSAst::init(
@@ -833,7 +833,7 @@ pub mod parse_worker {
             Loader::Yaml => {
                 let _trace = perf::trace("Bundler.ParseYAML");
                 let mut temp_log = Log::init();
-                let result = (|| -> core::result::Result<JSAst, AnyError> {
+                let result = (|| -> core::result::Result<JSAst<'a>, AnyError> {
                     let root: Expr =
                         bun_parsers::yaml::YAML::parse(source, &mut temp_log, bump)?.into();
                     Ok(JSAst::init(
@@ -855,7 +855,7 @@ pub mod parse_worker {
             Loader::Json5 => {
                 let _trace = perf::trace("Bundler.ParseJSON5");
                 let mut temp_log = Log::init();
-                let result = (|| -> core::result::Result<JSAst, AnyError> {
+                let result = (|| -> core::result::Result<JSAst<'a>, AnyError> {
                     let root: Expr =
                         bun_parsers::json5::JSON5Parser::parse(source, &mut temp_log, bump)?.into();
                     Ok(JSAst::init(
@@ -2191,13 +2191,13 @@ pub mod parse_worker {
 
     fn get_source_code(
         task: &mut ParseTask,
-        this: &mut crate::Worker,
+        this: &mut crate::Worker<'_>,
         log: &mut Log,
     ) -> core::result::Result<CacheEntry, AnyError> {
         // `Worker.arena` is a `BackRef` to `Worker.heap` once `has_created` (see
         // `ThreadPool::Worker::create`); the worker is pinned for the bundle pass.
         // Disjoint-field borrow vs `this.data` below.
-        let bump: &Bump = this.arena.get();
+        let bump: &Bump = this.arena;
 
         // `has_created` ⇒ `data`/`transpiler` were initialized in `create()`.
         let data = this.data.as_mut().expect("Worker.data set in create()");
@@ -2207,7 +2207,7 @@ pub mod parse_worker {
         // pointers and reborrows disjoint fields only.
         // SAFETY: `data.transpiler` is initialized (see above) and pinned for the
         // bundle pass.
-        let transpiler: *mut Transpiler<'static> = &raw mut data.transpiler;
+        let transpiler: *mut Transpiler<'_> = &raw mut data.transpiler;
         // PORT NOTE: errdefer transpiler.resetStore() — reshaped: call on the err
         // path explicitly (scopeguard would alias `transpiler` access below).
         // SAFETY: `transpiler` is live; `resolver` projects a field of it.
@@ -2250,18 +2250,18 @@ pub mod parse_worker {
     // Signature is real; body un-gates once the `ThreadPool` module + the
     // `parser::options` ↔ `BundleOptions` type unification land.
 
-    fn run_with_source_code(
+    fn run_with_source_code<'a>(
         task: &mut ParseTask,
-        this: &mut crate::Worker,
+        this: &mut crate::Worker<'a>,
         step: &mut Step,
         log: &mut Log,
         entry: &mut CacheEntry,
-    ) -> core::result::Result<Success, AnyError> {
+    ) -> core::result::Result<Success<'a>, AnyError> {
         // PORT NOTE: reshaped for borrowck — `transpiler_for_target` borrows `this`
         // mutably; we may need to call it again below (server-components branch),
         // so hold it as a raw pointer and reborrow per use site.
         //
-        // Stacked-Borrows: derive a single raw `*mut Worker` once and route every
+        // Stacked-Borrows: derive a single raw `*mut Worker<'_>` once and route every
         // subsequent worker access through it. The second `transpiler_for_target`
         // call (server-components/browser branch) must NOT autoref `&mut *this`
         // directly — that retag of the parent `&mut` pops the SharedRW tag chain
@@ -2271,15 +2271,14 @@ pub mod parse_worker {
         // pointing into the original — valid in Zig (no aliasing model); in Rust
         // both calls' `&mut self` must be children of the same raw so neither pops
         // the other's tag chain.
-        let worker_raw: *mut crate::Worker = this;
-        // SAFETY: see `get_source_code` — worker arena pinned for the bundle pass.
-        // `'static` matches `JSAst = BundledAst<'static>` (ungate_support.rs); the
-        // arena outlives all reads through the returned ASTs. `arena` is a
-        // `*const Bump` field; the deref points outside `*worker_raw`.
-        let bump: &'static Bump = unsafe { bun_ptr::detach_lifetime_ref(&*(*worker_raw).arena) };
-
+        let worker_raw: *mut crate::Worker<'a> = this;
+        // The worker arena is owned by the bundle's `ArenaPool` (`&'a Arena`);
+        // `arena` is a `&'a Bump` field, so the deref points outside `*worker_raw`.
         // SAFETY: `worker_raw` just derived from the live `this: &mut Worker`.
-        let mut transpiler: *mut Transpiler<'static> =
+        let bump: &'a Bump = unsafe { (*worker_raw).arena };
+
+        // SAFETY: `worker_raw` just derived from the live `this: &mut Worker<'_>`.
+        let mut transpiler: *mut Transpiler<'a> =
             std::ptr::from_mut(unsafe { (*worker_raw).transpiler_for_target(task.known_target) });
         // PORT NOTE: Zig errdefers (`transpiler.resetStore()` .zig:1123 and
         // `if (.fd) entry.deinit(arena)` .zig:1148) are reshaped into the
@@ -2312,7 +2311,7 @@ pub mod parse_worker {
         #[cfg(debug_assertions)]
         let debug_original_variant_check: ContentsOrFdTag = task.contents_or_fd.tag();
 
-        // SAFETY: `worker_raw` derived from the live `this: &mut Worker` above.
+        // SAFETY: `worker_raw` derived from the live `this: &mut Worker<'_>` above.
         // Read the `BackRef` field via `worker_raw` (not `this`) so no
         // parent-`&mut` access pops the `transpiler`/`resolver` tag chain derived
         // above. `BackRef` is `Copy`; the deref to `&BundleV2` is safe.
@@ -2379,7 +2378,11 @@ pub mod parse_worker {
         // reassigned above); reborrow only the disjoint `options` field.
         let topts = unsafe { &(*transpiler).options };
 
-        let source = Source {
+        // Bump-allocated so the `&'a Source` borrow handed to
+        // `new_lazy_export_ast<'bump>` (which ties the returned `Ast<'bump>` to
+        // every input borrow including `source`) lives for the arena lifetime
+        // `'a`. Cloned into the returned `Success` below.
+        let source: &'a Source = bump.alloc(Source {
             // PORT NOTE: `Source.path` is `bun_paths::fs::Path<'static>`, distinct from
             // `bun_resolver::fs::Path` (TYPE_ONLY mirror). Construct
             // field-by-field across the type boundary.
@@ -2401,7 +2404,7 @@ pub mod parse_worker {
             contents: std::borrow::Cow::Borrowed(ast::StoreStr::new(entry_contents).slice()),
             contents_is_recycled: false,
             ..Default::default()
-        };
+        });
 
         let target = (if task.source_index.get() == 1 {
             target_from_hashbang(entry_contents)
@@ -2607,18 +2610,18 @@ pub mod parse_worker {
                     opts,
                     bump,
                     resolver,
-                    &source,
+                    source,
                     loader,
                     task_ctx.unique_key,
                     &mut unique_key_for_additional_file,
                     &task_ctx.linker.has_any_css_locals,
                 )
             } else if loader.is_css() {
-                get_empty_css_ast(log, transpiler, opts, bump, &source)
+                get_empty_css_ast(log, transpiler, opts, bump, source)
             } else if module_type == options::ModuleType::Esm {
-                get_empty_ast::<E::Undefined>(log, transpiler, opts, bump, &source)
+                get_empty_ast::<E::Undefined>(log, transpiler, opts, bump, source)
             } else {
-                get_empty_ast::<E::Object>(log, transpiler, opts, bump, &source)
+                get_empty_ast::<E::Object>(log, transpiler, opts, bump, source)
             };
         // PERF(port): Zig used `switch (bool) { inline else => |as_undefined| ... }`
         // to monomorphize. Expanded to if/else.
@@ -2660,7 +2663,7 @@ pub mod parse_worker {
 
         Ok(Success {
             ast,
-            source,
+            source: source.clone(),
             log: core::mem::take(log),
             // PORT NOTE: Zig returned `log.*` by value; here we take ownership.
             use_directive,
@@ -2696,7 +2699,7 @@ pub mod parse_worker {
     fn run_from_thread_pool_impl(this: &mut ParseTask) {
         // SAFETY: ctx backref valid for the bundle pass (outlives this task).
         let ctx = unsafe { this.ctx() };
-        let worker: &mut crate::Worker = crate::Worker::get(ctx);
+        let worker: &mut crate::Worker<'_> = crate::Worker::get(ctx);
         // PORT NOTE: `defer worker.unget()` — handled at function exit (scopeguard
         // would alias the `&mut worker` borrows below).
         scoped_log!(
@@ -2846,7 +2849,7 @@ pub mod parse_worker {
         worker.unget();
     }
 
-    fn on_complete_mini(result: *mut Result, ctx: *mut BundleV2<'static>) {
+    fn on_complete_mini<'a>(result: *mut Result<'a>, ctx: *mut BundleV2<'a>) {
         // SAFETY: callback contract — `result` was heap-allocated above; `ctx` is
         // the BACKREF stashed in `result.ctx` (Zig passed `BundleV2` as ParentContext).
         BundleV2::on_parse_task_complete(unsafe { &mut *result }, unsafe { &mut *ctx });

--- a/src/bundler/ServerComponentParseTask.rs
+++ b/src/bundler/ServerComponentParseTask.rs
@@ -146,11 +146,11 @@ fn on_complete_mini(result: *mut parse_task::Result, _ctx: *mut BundleV2<'static
     on_complete(result);
 }
 
-fn task_callback(
+fn task_callback<'a>(
     task: &mut ServerComponentParseTask,
     log: &mut Log,
-    bump: &Arena,
-) -> Result<Success, OOM> {
+    bump: &'a Arena,
+) -> Result<Success<'a>, OOM> {
     // `ctx` is a `ParentRef` BACKREF to the owning BundleV2; safe `Deref`.
     let ctx: &BundleV2 = task
         .ctx
@@ -174,7 +174,7 @@ fn task_callback(
         Data::ClientEntryWrapper(_) => Target::Browser,
     };
     let hmr_api_ref = ab.hmr_api_ref;
-    let mut bundled_ast: JSAst = ab.to_bundled_ast(target)?;
+    let mut bundled_ast: JSAst = (ab.to_bundled_ast(target)?);
 
     // `wrapper_ref` is used to hold the HMR api ref (see comment in
     // `src/ast/Ast.zig`)

--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -13,7 +13,7 @@ use core::mem::{ManuallyDrop, MaybeUninit};
 use core::ptr::{self, NonNull};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-use bun_alloc::Arena as ThreadLocalArena; // Zig: bun.allocators.MimallocArena → bumpalo::Bump
+use bun_alloc::Arena as ThreadLocalArena;
 use bun_collections::VecExt;
 use bun_collections::{ArrayHashMap, MapEntry};
 use bun_core::{self, FeatureFlags, env_var, output as Output};
@@ -40,7 +40,13 @@ bun_core::declare_scope!(ThreadPool, visible);
 /// every platform (`gettid`/`pthread_threadid_np`/`GetCurrentThreadId`).
 pub type ThreadId = u64;
 
-pub struct ThreadPool {
+pub struct ThreadPool<'a> {
+    /// Append-only owner of every per-worker arena. Stack-allocated in the
+    /// bundle entry point; `'a` is its lifetime. Each worker calls
+    /// `arena_pool.alloc()` on its own thread (so the `MimallocArena` debug
+    /// `owning_thread` stamp is correct) and stores the result in
+    /// `Worker.arena: &'a Arena`.
+    pub arena_pool: &'a crate::ArenaPool,
     /// macOS holds an IORWLock on every file open.
     /// This causes massive contention after about 4 threads as of macOS 15.2
     /// On Windows, this seemed to be a small performance improvement.
@@ -64,25 +70,25 @@ pub struct ThreadPool {
     // concurrently from arbitrary worker-pool threads, and a `&mut self` here
     // would alias `&mut ThreadPool` across threads (UB before the lock is even
     // reached).
-    pub workers_assignments: bun_threading::Guarded<ArrayHashMap<ThreadId, *mut Worker>>,
-    // BACKREF (LIFETIMES.tsv row 170: ThreadPool.v2). `BundleV2` is generic
-    // over `'a`; erase to `'static` behind the raw pointer like ParseTask.ctx.
-    pub v2: *const BundleV2<'static>,
+    pub workers_assignments: bun_threading::Guarded<ArrayHashMap<ThreadId, *mut Worker<'a>>>,
+    // BACKREF (LIFETIMES.tsv row 170: ThreadPool.v2).
+    pub v2: *const BundleV2<'a>,
 }
 
 // SAFETY: `ThreadPool` is shared across worker threads; the only mutated
 // field (`workers_assignments`) is guarded by its `bun_threading::Guarded`, and
 // the raw-pointer fields are externally synchronized exactly as in the Zig
 // source.
-unsafe impl Send for ThreadPool {}
-unsafe impl Sync for ThreadPool {}
+unsafe impl Send for ThreadPool<'_> {}
+unsafe impl Sync for ThreadPool<'_> {}
 
-impl Default for ThreadPool {
+impl<'a> ThreadPool<'a> {
     /// Placeholder so `bundle_v2` can `arena().alloc(ThreadPool::default())`
     /// before overwriting with [`ThreadPool::init`]. Mirrors Zig's
     /// `arena.create(ThreadPool)` which yields uninit memory.
-    fn default() -> Self {
+    pub fn placeholder(arena_pool: &'a crate::ArenaPool) -> Self {
         Self {
+            arena_pool,
             io_pool: None,
             worker_pool: ptr::null_mut(),
             worker_pool_is_owned: false,
@@ -201,20 +207,15 @@ mod io_thread_pool {
     }
 }
 
-impl ThreadPool {
+impl<'a> ThreadPool<'a> {
     /// Inherent associated type so call sites that wrote
     /// `ThreadPool::Worker::get(ctx)` (matching Zig's `ThreadPool.Worker`)
     /// resolve without a separate module path.
-    pub type Worker = Worker;
+    pub type Worker = Worker<'a>;
 
-    // PORT NOTE: generic over `V2` because `bundle_v2.rs` currently carries two
-    // `BundleV2` definitions (the canonical one + `_the gated draft block (now dissolved)::BundleV2`)
-    // during the phased port, and both call `ThreadPool::init`. The backref is
-    // stored as a type-erased raw pointer (`.cast()`) regardless, so the
-    // monomorphised body is identical. Collapses to `&BundleV2<'_>` once the
-    // draft module is dropped.
-    pub fn init<V2>(
-        v2: &V2,
+    pub fn init(
+        v2: &BundleV2<'a>,
+        arena_pool: &'a crate::ArenaPool,
         // `Option<NonNull<_>>` (not `Option<&mut _>`): callers pass the
         // process-wide `WorkPool` singleton (`OnceLock`-backed, shared across
         // worker threads). Materializing `&mut` from that provenance is UB
@@ -222,7 +223,7 @@ impl ThreadPool {
         // pool is stored as `*mut` in the struct anyway, so keep it raw
         // end-to-end.
         worker_pool: Option<NonNull<ThreadPoolLib::ThreadPool>>,
-    ) -> Result<ThreadPool, bun_alloc::AllocError> {
+    ) -> Result<ThreadPool<'a>, bun_alloc::AllocError> {
         // PORT NOTE: Spec ThreadPool.zig:85 allocated via the bundle arena
         // (`v2.arena().create`), so the `false` ownership flag was
         // harmless — the arena reclaimed it. Here we `heap::alloc` (global
@@ -244,21 +245,25 @@ impl ThreadPool {
                 pool
             }
         };
-        let mut this = Self::init_with_pool(v2, pool);
+        let mut this = Self::init_with_pool(v2, arena_pool, pool);
         this.worker_pool_is_owned = owned;
         Ok(this)
     }
 
-    pub fn init_with_pool<V2>(v2: &V2, worker_pool: *mut ThreadPoolLib::ThreadPool) -> ThreadPool {
+    pub fn init_with_pool(
+        v2: &BundleV2<'a>,
+        arena_pool: &'a crate::ArenaPool,
+        worker_pool: *mut ThreadPoolLib::ThreadPool,
+    ) -> ThreadPool<'a> {
         ThreadPool {
+            arena_pool,
             worker_pool,
             io_pool: if Self::uses_io_pool() {
                 Some(io_thread_pool::acquire().into())
             } else {
                 None
             },
-            // BACKREF: lifetime erased behind the raw pointer.
-            v2: std::ptr::from_ref::<V2>(v2).cast(),
+            v2: std::ptr::from_ref(v2),
             worker_pool_is_owned: false,
             workers_assignments: bun_threading::Guarded::new(ArrayHashMap::default()),
         }
@@ -411,8 +416,11 @@ impl ThreadPool {
     // Takes `&self` (not `&mut`) because this is called concurrently from
     // worker-pool threads via `Worker::get`; mutation goes through the
     // `bun_threading::Guarded` on `workers_assignments`.
-    pub fn get_worker(&self, id: ThreadId) -> &'static mut Worker {
-        let worker: *mut Worker;
+    // The returned `&mut` is detached from `&self` (the worker is heap-pinned)
+    // but bounded by `'a` because `Worker<'a>` borrows the `ArenaPool`.
+    #[allow(clippy::mut_from_ref)]
+    pub fn get_worker(&self, id: ThreadId) -> &'a mut Worker<'a> {
+        let worker: *mut Worker<'a>;
         {
             let mut map = self.workers_assignments.lock();
             match map.entry(id) {
@@ -430,7 +438,8 @@ impl ThreadPool {
                     // whose payload violates `Worker`'s validity invariants
                     // (niche-optimized `Option<_>` discriminants, the non-null
                     // fn-pointer in `deinit_task.callback`, `bool` fields).
-                    worker = bun_core::heap::into_raw(Box::<Worker>::new_uninit()).cast::<Worker>();
+                    worker =
+                        bun_core::heap::into_raw(Box::<Worker<'a>>::new_uninit()).cast::<Worker<'a>>();
                     v.insert(worker);
                 }
             }
@@ -442,9 +451,11 @@ impl ThreadPool {
         unsafe {
             worker.write(Worker {
                 // Placeholder — overwritten by `init()` immediately below.
-                ctx: bun_ptr::BackRef::from(NonNull::<BundleV2<'static>>::dangling()),
-                heap: None,
-                arena: bun_ptr::BackRef::from(NonNull::<ThreadLocalArena>::dangling()),
+                ctx: bun_ptr::BackRef::from(NonNull::<BundleV2<'a>>::dangling()),
+                // Allocate this worker's arena from the pool on the *worker's
+                // own thread* so the `MimallocArena.owning_thread` debug stamp
+                // is correct.
+                arena: self.arena_pool.alloc(),
                 thread: NonNull::new(ThreadPoolLib::Thread::current())
                     .map(bun_ptr::ParentRef::from),
                 data: None,
@@ -469,32 +480,24 @@ impl ThreadPool {
 // ───────────────────────────────────────────────────────────────────────────
 
 /// Per-OS-thread bundler state. Heap-allocated and pinned (the
-/// `deinit_task`/`arena` fields are self-referential); never moved after
-/// `get_worker` boxes it.
-pub struct Worker {
-    /// Thread-local arena. `None` until [`Worker::create`] runs (Zig wrote
-    /// `undefined`); every read site is post-`has_created`.
-    pub heap: Option<ThreadLocalArena>,
-
-    /// Thread-local memory arena
-    /// All allocations are freed in `deinit` at the very end of bundling.
-    // PORT NOTE: self-referential borrow of `heap` — `BackRef` (not a real
-    // `&'self ThreadLocalArena`) so it can be reseated in `create()` without a
-    // self-borrow and so call sites read it via safe `Deref` instead of
-    // open-coding a raw deref. Zig stored the `std.mem.Allocator` vtable; here
-    // it's just `&heap`. Dangling until `create()` runs; every read site is
-    // post-`has_created`.
-    pub arena: bun_ptr::BackRef<ThreadLocalArena>,
+/// `deinit_task` field is self-referential); never moved after `get_worker`
+/// boxes it.
+pub struct Worker<'a> {
+    /// Thread-local memory arena, allocated from the bundle's
+    /// [`crate::ArenaPool`] on this worker's own thread (so the
+    /// `MimallocArena` debug `owning_thread` stamp is correct). All
+    /// allocations are freed when the pool drops at the end of bundling.
+    pub arena: &'a ThreadLocalArena,
 
     /// BACKREF (LIFETIMES.tsv): the owning `BundleV2` strictly outlives every
     /// `Worker` it creates (workers are torn down in `deinit_without_freeing_arena`
     /// before the bundle is dropped). `BackRef` so call sites read
     /// `worker.ctx.field` via safe `Deref` instead of open-coding a raw deref.
-    pub ctx: bun_ptr::BackRef<BundleV2<'static>>,
+    pub ctx: bun_ptr::BackRef<BundleV2<'a>>,
 
     /// `None` until [`Worker::create`] populates it; every read site is
     /// post-`has_created`.
-    pub data: Option<WorkerData>,
+    pub data: Option<WorkerData<'a>>,
     pub quit: bool,
 
     pub ast_memory_store: ManuallyDrop<bun_ast::ASTMemoryAllocator>,
@@ -508,42 +511,34 @@ pub struct Worker {
     pub deinit_task: ThreadPoolLib::Task,
 
     pub temporary_arena: Option<bun_alloc::Arena>,
-    pub stmt_list: Option<StmtList>,
+    pub stmt_list: Option<StmtList<'a>>,
 }
 
-impl Worker {
-    /// Reborrow the self-referential `arena` (= `&self.heap`) as a shared
-    /// reference. `BackRef` field, so the deref is encapsulated in
-    /// [`bun_ptr::BackRef::get`]; see PORT NOTE on the field.
-    ///
-    /// `arena` is set to `&self.heap` in [`Worker::create`] before any caller
-    /// can observe the `Worker`, and is never dangling after that point. The
-    /// pointee is the worker's own `heap` field, which is pinned for the
-    /// worker's lifetime.
+impl<'a> Worker<'a> {
+    /// The worker's thread-local arena, owned by the bundle's
+    /// [`crate::ArenaPool`].
     #[inline]
-    pub fn arena(&self) -> &ThreadLocalArena {
-        self.arena.get()
+    pub fn arena(&self) -> &'a ThreadLocalArena {
+        self.arena
     }
 }
 
-pub struct WorkerData {
+pub struct WorkerData<'a> {
     // TODO(port): lifetime — TSV class ARENA (`&'arena mut bun_ast::Log`); kept
     // raw because the arena is the sibling field `Worker.heap`.
     pub log: *mut bun_ast::Log,
     pub estimated_input_lines_of_code: usize,
-    // PORT NOTE: lifetime erased to `'static` — the inner `&'a Arena` borrows
-    // `Worker.heap`, which Rust can't express on a sibling field. Zig used
-    // `transpiler: Transpiler` with a copied `std.mem.Allocator`.
+    // The inner `&'a Arena` borrows the worker's pool-owned arena.
     //
     // Owned (no `MaybeUninit`): `Transpiler::for_worker` deep-clones every
     // `Drop`-carrying field, so `WorkerData`'s drop (via
     // `ptr::drop_in_place(data)` in `Worker::deinit`) is sound and frees the
     // per-worker `options`/`resolver.caches`/etc. without touching the parent.
-    pub transpiler: Transpiler<'static>,
-    pub other_transpiler: Option<Box<Transpiler<'static>>>,
+    pub transpiler: Transpiler<'a>,
+    pub other_transpiler: Option<Box<Transpiler<'a>>>,
 }
 
-impl Worker {
+impl<'a> Worker<'a> {
     // CONCURRENCY: thread-pool callback — runs on the worker's own OS thread
     // during pool drain (scheduled via `deinit_soon`). Writes: own `Worker`
     // fields only (`heap`, `data`, `ast_memory_store` teardown). The `Worker`
@@ -560,7 +555,8 @@ impl Worker {
         // SAFETY: `task` points to `Worker.deinit_task` (intrusive field) —
         // only ever invoked by the thread pool against a `Worker` enqueued via
         // `deinit_soon`, so provenance covers the full `Worker` allocation.
-        let this: *mut Worker = unsafe { bun_core::from_field_ptr!(Worker, deinit_task, task) };
+        let this: *mut Worker<'a> =
+            unsafe { bun_core::from_field_ptr!(Worker<'a>, deinit_task, task) };
         // SAFETY: `deinit_soon` schedules this exactly once on a live
         // heap-allocated `Worker`; the idle-task fires on the worker's own OS
         // thread with no other live borrow, so we hold exclusive ownership.
@@ -592,7 +588,7 @@ impl Worker {
     ///
     /// # Safety
     /// `this` must have come from `heap::alloc` in [`ThreadPool::get_worker`].
-    pub unsafe fn deinit(this: *mut Worker) {
+    pub unsafe fn deinit(this: *mut Worker<'a>) {
         // SAFETY: caller contract.
         let worker = unsafe { &mut *this };
         if worker.has_created {
@@ -608,13 +604,10 @@ impl Worker {
         // via `*ast_memory_store = ...`. Dropped exactly once here, *outside*
         // the `has_created` guard so the default-constructed arena is freed
         // even when `create()` never ran (Zig left it `undefined`; Rust does
-        // not). Ordered before `heap = None` in case the TODO(port) in
-        // `ASTMemoryAllocator::new` ever threads `arena_ref` (= `&self.heap`)
-        // through.
+        // not).
         unsafe { ManuallyDrop::drop(&mut worker.ast_memory_store) };
-        if worker.has_created {
-            worker.heap = None;
-        }
+        // The worker's `arena` is owned by the bundle's `ArenaPool` and freed
+        // when the pool drops; nothing to do here.
         // SAFETY: caller contract — `this` was heap-allocated via `get_worker`.
         // Runs full field drop glue: remaining `Option` fields are `None`
         // (no-op), `ast_memory_store` is `ManuallyDrop` (no auto-drop), so no
@@ -626,13 +619,13 @@ impl Worker {
     // heap-pinned (heap::alloc in `get_worker`) and outlives any `ctx`
     // borrow; Zig returned `*Worker`. Tying it to `ctx`'s lifetime would
     // forbid the `worker` ↔ `ctx` re-borrows in `ParseTask::run_*`.
-    pub fn get(ctx: &BundleV2<'_>) -> &'static mut Worker {
+    pub fn get(ctx: &BundleV2<'a>) -> &'a mut Worker<'a> {
         // SAFETY: `ctx` is a BACKREF; `graph.pool` is a `NonNull<ThreadPool>`
         // pointing at the bundle-owned pool that outlives every worker. We only
         // need a shared `&ThreadPool` — `get_worker` takes `&self` and serializes
         // map mutation via the internal `bun_threading::Guarded`, so concurrent
         // entry from multiple worker threads is sound.
-        let pool: &ThreadPool = ctx.graph.pool();
+        let pool: &ThreadPool<'a> = ctx.graph.pool();
         let worker = pool.get_worker(bun_threading::current_thread_id());
         if !worker.has_created {
             worker.create(ctx);
@@ -659,13 +652,11 @@ impl Worker {
         self.ast_memory_store.pop();
     }
 
-    pub fn init(&mut self, v2: &BundleV2<'_>) {
-        // Lifetime-erase `'_` → `'static` via `NonNull::cast` (BACKREF: the
-        // bundle outlives every worker).
-        self.ctx = bun_ptr::BackRef::from(NonNull::from(v2).cast::<BundleV2<'static>>());
+    pub fn init(&mut self, v2: &BundleV2<'a>) {
+        self.ctx = bun_ptr::BackRef::new(v2);
     }
 
-    fn create(&mut self, ctx: &BundleV2<'_>) {
+    fn create(&mut self, ctx: &BundleV2<'a>) {
         // PORT NOTE: `bun_perf::trace` takes a generated `PerfEvent` enum, and
         // the generator hasn't emitted `Bundler.Worker.create` yet (only
         // `_Stub`). Dropped to avoid mis-attributing the span.
@@ -673,17 +664,10 @@ impl Worker {
 
         self.has_created = true;
         Output::Source::configure_thread();
-        // Self-referential — `arena` borrows `self.heap`. `Option::insert`
-        // returns the stable address of the in-place payload (Worker is
-        // heap-pinned, so this never moves).
-        self.arena = bun_ptr::BackRef::new(self.heap.insert(ThreadLocalArena::new()));
-
-        // SAFETY: self-referential — `self.arena` was just set to `&self.heap`
-        // (Worker is heap-pinned, address stable). `'static` is sound for the
-        // erased `Transpiler<'static>` slot below; the arena outlives
-        // `WorkerData`. Single detach for the three uses that follow.
-        let arena_ref: &'static ThreadLocalArena =
-            unsafe { bun_ptr::detach_lifetime_ref(self.arena.get()) };
+        // `self.arena` was already set to a pool-owned `&'a Arena` in
+        // `get_worker` (allocated on this thread, so `owning_thread` is
+        // correct). No self-referential `BackRef` dance needed.
+        let arena_ref: &'a ThreadLocalArena = self.arena;
 
         // Zig: `.{ .arena = this.arena }` then `reset()`. The Rust
         // ASTMemoryAllocator owns its bump arena internally and ignores the
@@ -692,7 +676,7 @@ impl Worker {
         self.ast_memory_store.reset();
 
         let log: *mut bun_ast::Log = arena_ref.alloc(bun_ast::Log::init());
-        self.ctx = bun_ptr::BackRef::from(NonNull::from(ctx).cast::<BundleV2<'static>>());
+        self.ctx = bun_ptr::BackRef::new(ctx);
         // PERF(port): was `bun.ArenaAllocator.init(this.arena)` — using a
         // fresh Bump (no nested-arena type yet).
         self.temporary_arena = Some(bun_alloc::Arena::new());
@@ -719,15 +703,15 @@ impl Worker {
     fn initialize_transpiler(
         log: *mut bun_ast::Log,
         from: &Transpiler<'_>,
-        arena: &'static ThreadLocalArena,
-    ) -> Transpiler<'static> {
+        arena: &'a ThreadLocalArena,
+    ) -> Transpiler<'a> {
         // SAFETY: `from` is the `BundleV2`-owned transpiler (or its
         // `client_transpiler`), which outlives every worker; the
         // `&'a`-carrying fields inside reference process-lifetime data.
-        unsafe { Transpiler::<'static>::for_worker(from, arena, log) }
+        unsafe { Transpiler::<'a>::for_worker(from, arena, log) }
     }
 
-    pub fn transpiler_for_target(&mut self, target: Target) -> &mut Transpiler<'static> {
+    pub fn transpiler_for_target(&mut self, target: Target) -> &mut Transpiler<'a> {
         // Callers only invoke this after `Worker::get` → `create()`.
         let data = self.data.as_mut().expect("Worker.data set in create()");
         if target == Target::Browser && data.transpiler.options.target != target {
@@ -735,12 +719,8 @@ impl Worker {
                 // `ctx` is a `BackRef` (set in `create()`); the `BundleV2`
                 // outlives every worker — safe `Deref`.
                 let client: &Transpiler<'_> = self.ctx.client_transpiler_ref().unwrap();
-                // SAFETY: `self.arena` points at `self.heap` (set in `create()`),
-                // pinned for the worker's lifetime; detach to `'static` for the
-                // erased `Transpiler<'static>` slot.
-                let arena_ref: &'static ThreadLocalArena =
-                    unsafe { bun_ptr::detach_lifetime_ref(self.arena.get()) };
-                let mut boxed = Box::new(Self::initialize_transpiler(data.log, client, arena_ref));
+                let mut boxed =
+                    Box::new(Self::initialize_transpiler(data.log, client, self.arena));
                 // Wire self-refs after the value reached its final (heap) address.
                 boxed.wire_after_move();
                 data.other_transpiler = Some(boxed);
@@ -758,7 +738,7 @@ impl Worker {
         &mut data.transpiler
     }
 
-    pub fn run(&mut self, ctx: &BundleV2<'_>) {
+    pub fn run(&mut self, ctx: &BundleV2<'a>) {
         if !self.has_created {
             self.create(ctx);
         }

--- a/src/bundler/arena_pool.rs
+++ b/src/bundler/arena_pool.rs
@@ -1,0 +1,50 @@
+//! Append-only owner of per-worker [`MimallocArena`]s for one bundle pass.
+//!
+//! The bundler produces `Ast<'arena>` values on N worker threads, each
+//! allocating into its own thread-local `MimallocArena`, and stores them in a
+//! single `Graph.ast: MultiArrayList<BundledAst<'a>>` on the bundler thread.
+//! For borrowck to accept that, every arena must be owned by something with a
+//! single lifetime `'a` that outlives `BundleV2<'a>` — that owner is
+//! [`ArenaPool`], stack-allocated in the entry-point function alongside the
+//! `Transpiler<'a>`.
+//!
+//! Each worker calls [`ArenaPool::alloc`] once on its own thread (so the
+//! `MimallocArena` debug `owning_thread` stamp is correct) and gets back a
+//! `&'a MimallocArena` that is valid for the entire bundle pass. The pool
+//! never frees an arena until it is dropped, so addresses are stable.
+//!
+//! This replaces the prior `erase_ast_arena` / `erase_bundled_ast_arena`
+//! transmutes (and the `detach_lifetime_ref` on `Worker.arena`): instead of
+//! erasing `'arena` to `'static` at the parser→bundler boundary, the arena
+//! lifetime is threaded as `'a` end-to-end.
+
+use bun_alloc::MimallocArena;
+
+/// Append-only `MimallocArena` owner. Stack-allocated in the bundle entry
+/// point; `&'a ArenaPool` is threaded into `BundleV2<'a>` / `ThreadPool<'a>`.
+#[derive(Default)]
+pub struct ArenaPool {
+    /// `boxcar::Vec` is a lock-free append-only vector with stable element
+    /// addresses: `push` returns an index and `&self[i]` borrows `&self`
+    /// (not a lock guard), so the returned `&MimallocArena` lives for the
+    /// pool's lifetime with no `unsafe` here.
+    arenas: boxcar::Vec<MimallocArena>,
+}
+
+impl ArenaPool {
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Construct a fresh `MimallocArena` on the **calling thread** (so its
+    /// debug `owning_thread` stamp is correct), park it in the pool, and
+    /// return a shared reference valid for the pool's lifetime.
+    ///
+    /// Called once per worker thread (from `Worker::create`) and once for
+    /// `Graph.heap` (from `BundleV2::init`).
+    pub fn alloc(&self) -> &MimallocArena {
+        let i = self.arenas.push(MimallocArena::new());
+        &self.arenas[i]
+    }
+}

--- a/src/bundler/barrel_imports.rs
+++ b/src/bundler/barrel_imports.rs
@@ -38,10 +38,10 @@ impl Default for RequestedExports {
 // loop can hold a `BarrelExportResolution` across a `&mut graph.ast` reborrow
 // without the borrow checker seeing an overlap. The pointee outlives the
 // bundler arena, so dereferencing later is sound.
-struct BarrelExportResolution {
+struct BarrelExportResolution<'a> {
     import_record_index: u32,
     /// The original alias in the source module (e.g. "d" for `export { d as c }`)
-    original_alias: Option<bun_ast::StoreStr>,
+    original_alias: Option<bun_ast::StoreStr<'a>>,
     /// True when the underlying import is `import * as ns` — propagation
     /// through this export must treat the target as needing all exports.
     alias_is_star: bool,
@@ -50,11 +50,11 @@ struct BarrelExportResolution {
 /// Look up an export name → import_record_index by chasing
 /// named_exports[alias].ref through named_imports.
 /// Also returns the original alias from the source module for BFS propagation.
-fn resolve_barrel_export(
+fn resolve_barrel_export<'a>(
     alias: &[u8],
     named_exports: &JSAst::NamedExports,
-    named_imports: &JSAst::NamedImports,
-) -> Option<BarrelExportResolution> {
+    named_imports: &JSAst::NamedImports<'a>,
+) -> Option<BarrelExportResolution<'a>> {
     let export_entry = named_exports.get(alias)?;
     let import_entry = named_imports.get(&export_entry.ref_)?;
     Some(BarrelExportResolution {
@@ -359,7 +359,7 @@ pub fn schedule_barrel_deferred_imports(
     // `&mut this.*` borrows don't conflict.
     let file_import_records: bun_ptr::BackRef<import_record::List> =
         bun_ptr::BackRef::new(&this.graph.ast.items_import_records()[result_source_index as usize]);
-    let file_named_imports: bun_ptr::BackRef<JSAst::NamedImports> =
+    let file_named_imports: bun_ptr::BackRef<JSAst::NamedImports<'_>> =
         bun_ptr::BackRef::new(&this.graph.ast.items_named_imports()[result_source_index as usize]);
 
     // PORT NOTE: `DevServerHandle` copied out so `&mut this.*` field borrows

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -102,7 +102,7 @@ pub struct BundleV2<'a> {
     pub ssr_transpiler: *mut Transpiler<'a>,
     /// When Bun Bake is used, the resolved framework is passed here.
     pub framework: Option<bake::Framework>,
-    pub graph: Graph,
+    pub graph: Graph<'a>,
     // Real `LinkerContext<'a>` (un-gated B-2). Borrows the same arena lifetime
     // as `transpiler` (Zig stored both as raw pointers into the bundler heap).
     pub linker: LinkerContext<'a>,
@@ -2781,7 +2781,9 @@ pub mod bv2_impl {
             Ok(Some(source_index.get()))
         }
 
-        /// `heap` is not freed when `deinit`ing the BundleV2
+        /// `arena_pool` owns every per-worker arena plus the bundler-thread
+        /// arena; it is stack-allocated in the entry point so its lifetime
+        /// unifies with `'a`.
         pub fn init(
             transpiler: &'a mut Transpiler<'a>,
             bake_options: Option<BakeOptions<'a>>,
@@ -2793,7 +2795,7 @@ pub mod bv2_impl {
             // here into `ThreadPool::init`, which stores it as `*mut`. Creating a
             // `&mut` along the way would violate Stacked Borrows.
             thread_pool: Option<NonNull<ThreadPoolLib>>,
-            heap: ThreadLocalArena,
+            arena_pool: &'a crate::ArenaPool,
         ) -> Result<Box<BundleV2<'a>>, Error> {
             // TODO(port): arena-allocate self via bump.alloc — Box::new is wrong arena (Zig: arena.create(@This()) on arena)
             transpiler.env().load_tracy();
@@ -2811,13 +2813,7 @@ pub mod bv2_impl {
                 owned_client_transpiler: None,
                 ssr_transpiler: ssr_alias,
                 framework: None,
-                graph: Graph {
-                    pool: bun_ptr::BackRef::from(NonNull::<ThreadPool>::dangling()), // set below
-                    heap,
-                    kit_referenced_server_data: false,
-                    kit_referenced_client_data: false,
-                    ..Default::default()
-                },
+                graph: Graph::new(arena_pool),
                 linker: LinkerContext {
                     r#loop: event_loop,
                     graph: LinkerGraph::default(),
@@ -2869,8 +2865,8 @@ pub mod bv2_impl {
             // `resolver.arena` / `linker.arena` / `log.msgs.arena`. The
             // Rust `Transpiler<'a>`/`Resolver<'a>` store `&'a Arena` and `Log.msgs`
             // is a `Vec` (global alloc), so only `linker.graph.bump` needs the
-            // backref into the now-stable `this.graph.heap` slot.
-            this.linker.graph.bump = bun_ptr::BackRef::new(&this.graph.heap);
+            // backref into the pool-owned `this.graph.heap` arena.
+            this.linker.graph.bump = bun_ptr::BackRef::new(this.graph.heap);
             this.transpiler.log_mut().clone_line_text = true;
 
             // We don't expose an option to disable this. Bake forbids tree-shaking
@@ -2923,8 +2919,8 @@ pub mod bv2_impl {
             // Arena-owned (Zig: `arena.create(ThreadPool)`). Coerce to `*mut`
             // immediately so the `&this` borrow from `arena()` ends before
             // `ThreadPool::init` takes `&mut this`.
-            let pool: *mut ThreadPool =
-                std::ptr::from_mut(this.arena().alloc(ThreadPool::default()));
+            let pool: *mut ThreadPool<'a> =
+                std::ptr::from_mut(this.arena().alloc(ThreadPool::placeholder(arena_pool)));
             if cli_watch_flag {
                 // CYCLEBREAK GENUINE: hot_reloader is T6; runtime constructs the
                 // `dispatch::WatcherHandle` (erased owner + `&'static WatcherVTable`)
@@ -2937,7 +2933,7 @@ pub mod bv2_impl {
             // SAFETY: arena slot is live for the bundle pass; the default value
             // written above has no Drop, so overwriting via `*pool = ...` is fine.
             unsafe {
-                *pool = ThreadPool::init(&mut *this, thread_pool)?;
+                *pool = ThreadPool::init(&*this, arena_pool, thread_pool)?;
             }
             this.graph.pool =
                 bun_ptr::BackRef::from(NonNull::new(pool).expect("arena allocation is non-null"));
@@ -2946,8 +2942,8 @@ pub mod bv2_impl {
             Ok(this)
         }
 
-        pub fn arena(&self) -> &bun_alloc::Arena {
-            &self.graph.heap
+        pub fn arena(&self) -> &'a bun_alloc::Arena {
+            self.graph.heap
         }
 
         /// Allocate `value` into the bundler's arena (`self.graph.heap`) and return
@@ -3860,6 +3856,7 @@ pub mod bv2_impl {
         pub fn generate_from_cli(
             transpiler: &'a mut Transpiler<'a>,
             alloc: &bun_alloc::Arena,
+            arena_pool: &'a crate::ArenaPool,
             event_loop: EventLoop,
             enable_reloading: bool,
             reachable_files_count: &mut usize,
@@ -3874,7 +3871,7 @@ pub mod bv2_impl {
                 event_loop,
                 enable_reloading,
                 None,
-                ThreadLocalArena::new(),
+                arena_pool,
             )?;
             this.unique_key = generate_unique_key();
 
@@ -4008,6 +4005,7 @@ pub mod bv2_impl {
         pub fn scan_module_graph_from_cli(
             transpiler: &'a mut Transpiler<'a>,
             alloc: &bun_alloc::Arena,
+            arena_pool: &'a crate::ArenaPool,
             event_loop: EventLoop,
             entry_points: &[&[u8]],
         ) -> Result<Box<BundleV2<'a>>, Error> {
@@ -4018,7 +4016,7 @@ pub mod bv2_impl {
                 event_loop,
                 false,
                 None,
-                ThreadLocalArena::new(),
+                arena_pool,
             )?;
             this.unique_key = generate_unique_key();
 
@@ -4048,6 +4046,7 @@ pub mod bv2_impl {
             server_transpiler: &'a mut Transpiler<'a>,
             bake_options: BakeOptions<'a>,
             alloc: &bun_alloc::Arena,
+            arena_pool: &'a crate::ArenaPool,
             event_loop: EventLoop,
         ) -> Result<Vec<options::OutputFile>, Error> {
             let mut this = BundleV2::init(
@@ -4057,7 +4056,7 @@ pub mod bv2_impl {
                 event_loop,
                 false,
                 None,
-                ThreadLocalArena::new(),
+                arena_pool,
             )?;
             this.unique_key = generate_unique_key();
 
@@ -6874,6 +6873,13 @@ pub mod bv2_impl {
                 (&raw mut *transpiler.options.define, transpiler.log)
             };
 
+            // `new_lazy_export_ast` takes `source: &'bump Source`; allocate it
+            // in `graph.heap` so the borrow lives for `'a` (the returned
+            // `Ast<'a>` is appended to `graph.ast` below). The `input_files`
+            // entry gets its own copy via the local (moved at the end).
+            let source_in_heap: &'a bun_ast::Source =
+                self.arena().alloc(empty_html_file_source.clone());
+
             let ast_for_html_entrypoint = JSAst::init(
                 bun_js_parser::new_lazy_export_ast(
                     self.arena(),
@@ -6887,7 +6893,7 @@ pub mod bv2_impl {
                         },
                         bun_ast::Loc::EMPTY,
                     ),
-                    &empty_html_file_source,
+                    source_in_heap,
                     // We replace this runtime API call's ref later via .link on the Symbol.
                     b"__jsonParse",
                 )?
@@ -6929,7 +6935,7 @@ pub mod bv2_impl {
         }
 
         #[cold]
-        pub fn on_parse_task_complete(parse_result: &mut parse_task::Result, this: &mut BundleV2) {
+        pub fn on_parse_task_complete(parse_result: &mut parse_task::Result<'a>, this: &mut BundleV2<'a>) {
             let _trace = crate::ungate_support::perf::trace("Bundler.onParseTaskComplete");
             // PORT NOTE: Zig aliased `const graph = &this.graph;`. Borrowck rejects
             // holding that across the `this.*` method calls below (each takes
@@ -7549,21 +7555,21 @@ pub mod bv2_impl {
 
     /// The lifetime of this structure is tied to the bundler's arena
     pub struct DevServerOutput<'a> {
-        pub chunks: &'a mut [Chunk],
+        pub chunks: &'a mut [Chunk<'a>],
         pub css_file_list: ArrayHashMap<Index, CssEntryPointMeta>,
         pub html_files: ArrayHashMap<Index, ()>,
     }
 
     impl<'a> DevServerOutput<'a> {
-        pub fn js_pseudo_chunk(&mut self) -> &mut Chunk {
+        pub fn js_pseudo_chunk(&mut self) -> &mut Chunk<'a> {
             &mut self.chunks[0]
         }
 
-        pub fn css_chunks(&mut self) -> &mut [Chunk] {
+        pub fn css_chunks(&mut self) -> &mut [Chunk<'a>] {
             &mut self.chunks[1..][..self.css_file_list.count()]
         }
 
-        pub fn html_chunks(&mut self) -> &mut [Chunk] {
+        pub fn html_chunks(&mut self) -> &mut [Chunk<'a>] {
             &mut self.chunks[1 + self.css_file_list.count()..][..self.html_files.count()]
         }
     }

--- a/src/bundler/bundled_ast.rs
+++ b/src/bundler/bundled_ast.rs
@@ -23,11 +23,11 @@ pub use bun_css::BundlerStyleSheet;
 /// the type system. `StoreRef`'s `Deref`/`DerefMut` encapsulate the single
 /// documented `unsafe` deref justified by that invariant; callers use `&*r`
 /// (or `Option::as_deref`) instead of open-coded `unsafe { &*ptr }`.
-pub type CssAstRef = bun_ast::StoreRef<BundlerStyleSheet>;
+pub type CssAstRef<'arena> = bun_ast::StoreRef<'arena, BundlerStyleSheet>;
 
 /// Element type of the `css` SoA column (`items_css()`). Exposed so bundler
 /// call sites can name the column without re-spelling the pointer shape.
-pub type CssCol = Option<CssAstRef>;
+pub type CssCol<'arena> = Option<CssAstRef<'arena>>;
 
 use bun_ast::import_record;
 use bun_core::strings;
@@ -38,9 +38,9 @@ use bun_ast::{part, symbol};
 // TODO(port): verify exact module paths for Ast/Part/Symbol associated `List` types in Phase B.
 
 pub type CommonJSNamedExports = bun_ast::ast_result::CommonJSNamedExports;
-pub type ConstValuesMap = bun_ast::ast_result::ConstValuesMap;
+pub type ConstValuesMap<'arena> = bun_ast::ast_result::ConstValuesMap<'arena>;
 pub type NamedExports = bun_ast::ast_result::NamedExports;
-pub type NamedImports = bun_ast::ast_result::NamedImports;
+pub type NamedImports<'arena> = bun_ast::ast_result::NamedImports<'arena>;
 pub type TopLevelSymbolToParts = bun_ast::ast_result::TopLevelSymbolToParts;
 
 // PORT NOTE: Zig stores `MultiArrayList(BundledAst)` on `Graph.ast` /
@@ -65,14 +65,14 @@ pub struct BundledAst<'arena> {
 
     // PORT NOTE: Ast.hashbang is `StoreStr`; mirror it here so init/to_ast can
     // round-trip.
-    pub hashbang: StoreStr,
-    pub parts: part::List,
+    pub hashbang: StoreStr<'arena>,
+    pub parts: part::List<'arena>,
     // Zig: `?*bun.css.BundlerStyleSheet`. See `CssAstRef` doc for the arena
     // drop-order invariant that backs the safe `Deref`.
-    pub css: CssCol,
+    pub css: CssCol<'arena>,
     pub url_for_css: &'arena [u8],
-    pub symbols: symbol::List,
-    pub module_scope: Scope,
+    pub symbols: symbol::List<'arena>,
+    pub module_scope: Scope<'arena>,
     // TODO(port): Zig used `= undefined`; only valid when flags.HAS_CHAR_FREQ is set.
     pub char_freq: CharFreq,
     pub exports_ref: Ref,
@@ -85,7 +85,7 @@ pub struct BundledAst<'arena> {
     // These are used when bundling. They are filled in during the parser pass
     // since we already have to traverse the AST then anyway and the parser pass
     // is conveniently fully parallelized.
-    pub named_imports: NamedImports,
+    pub named_imports: NamedImports<'arena>,
     pub named_exports: NamedExports,
     // PORT NOTE: Ast owns Box<[u32]>; matching it here avoids the &'arena↔Box
     // re-alloc on init/to_ast (Zig's `[]u32` is a fat-ptr move either way).
@@ -103,7 +103,7 @@ pub struct BundledAst<'arena> {
     pub target: bun_ast::Target,
 
     // const_values: ConstValuesMap,
-    pub ts_enums: bun_ast::ast_result::TsEnumsMap,
+    pub ts_enums: bun_ast::ast_result::TsEnumsMap<'arena>,
 
     pub flags: Flags,
 }
@@ -114,12 +114,12 @@ bun_collections::multi_array_columns! {
         nested_scope_slot_counts: SlotCounts,
         exports_kind: ExportsKind,
         import_records: import_record::List,
-        hashbang: StoreStr,
-        parts: part::List,
-        css: CssCol,
+        hashbang: StoreStr<'arena>,
+        parts: part::List<'arena>,
+        css: CssCol<'arena>,
         url_for_css: &'arena [u8],
-        symbols: symbol::List,
-        module_scope: Scope,
+        symbols: symbol::List<'arena>,
+        module_scope: Scope<'arena>,
         char_freq: CharFreq,
         exports_ref: Ref,
         module_ref: Ref,
@@ -127,14 +127,14 @@ bun_collections::multi_array_columns! {
         require_ref: Ref,
         top_level_await_keyword: bun_ast::Range,
         tla_check: TlaCheck,
-        named_imports: NamedImports,
+        named_imports: NamedImports<'arena>,
         named_exports: NamedExports,
         export_star_import_records: Box<[u32]>,
         top_level_symbols_to_parts: TopLevelSymbolToParts,
         commonjs_named_exports: CommonJSNamedExports,
         redirect_import_record_index: u32,
         target: bun_ast::Target,
-        ts_enums: bun_ast::ast_result::TsEnumsMap,
+        ts_enums: bun_ast::ast_result::TsEnumsMap<'arena>,
         flags: Flags,
     }
 }
@@ -170,7 +170,7 @@ impl<'arena> BundledAst<'arena> {
     // PORT NOTE: Zig's `*const BundledAst` bitwise-copies every field; the Rust
     // collection types aren't Copy, so consume `self` to move them (toAST is a
     // one-shot conversion back to the fat Ast).
-    pub fn to_ast(self) -> Ast {
+    pub fn to_ast(self) -> Ast<'arena> {
         Ast {
             approximate_newline_count: self.approximate_newline_count as usize,
             nested_scope_slot_counts: self.nested_scope_slot_counts,
@@ -248,7 +248,7 @@ impl<'arena> BundledAst<'arena> {
         }
     }
 
-    pub fn init(ast: Ast) -> Self {
+    pub fn init(ast: Ast<'arena>) -> Self {
         let mut flags = Flags::empty();
         flags.set(Flags::USES_EXPORTS_REF, ast.uses_exports_ref);
         flags.set(Flags::USES_MODULE_REF, ast.uses_module_ref);

--- a/src/bundler/cache.rs
+++ b/src/bundler/cache.rs
@@ -482,7 +482,7 @@ impl Css {
 
 pub struct JavaScript {}
 
-pub type JavaScriptResult = js_parser::Result;
+pub type JavaScriptResult<'arena> = js_parser::Result<'arena>;
 
 impl JavaScript {
     pub fn init() -> JavaScript {
@@ -500,7 +500,7 @@ impl JavaScript {
         defines: &'a Define,
         log: &mut bun_ast::Log,
         source: &'a bun_ast::Source,
-    ) -> Result<Option<js_parser::Result>, bun_core::Error> {
+    ) -> Result<Option<js_parser::Result<'a>>, bun_core::Error> {
         let mut temp_log = bun_ast::Log::init();
         temp_log.level = log.level;
         let mut parser = match js_parser::Parser::init(opts, &mut temp_log, source, defines, bump) {
@@ -537,7 +537,7 @@ impl JavaScript {
     pub fn scan<'a>(
         &mut self,
         bump: &'a Bump,
-        scan_pass_result: &mut js_parser::ScanPassResult,
+        scan_pass_result: &'a mut js_parser::ScanPassResult<'a>,
         opts: js_parser::ParserOptions<'a>,
         defines: &'a Define,
         log: &mut bun_ast::Log,

--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -44,15 +44,15 @@ impl Globals {
     };
 
     #[inline]
-    pub fn undefined_data() -> ExprData {
+    pub fn undefined_data() -> ExprData<'static> {
         ExprData::EUndefined(bun_ast::E::Undefined)
     }
     #[inline]
-    pub fn nan_data() -> ExprData {
+    pub fn nan_data() -> ExprData<'static> {
         ExprData::ENumber(Globals::NAN)
     }
     #[inline]
-    pub fn infinity_data() -> ExprData {
+    pub fn infinity_data() -> ExprData<'static> {
         ExprData::ENumber(Globals::INFINITY)
     }
 }
@@ -323,7 +323,7 @@ impl DefineExt for Define {
 /// Returns `None` for everything else (user `--define` values, env-file
 /// `NODE_ENV` overrides like `staging`, JSON object/array literals, …), which
 /// falls through to the general `parse_env_json` path in `DefineData::parse`.
-fn const_default_define_value(value_str: &[u8]) -> Option<ExprData> {
+fn const_default_define_value(value_str: &[u8]) -> Option<ExprData<'static>> {
     static DEVELOPMENT: bun_ast::E::EString = bun_ast::E::EString::from_static(b"development");
     static PRODUCTION: bun_ast::E::EString = bun_ast::E::EString::from_static(b"production");
     static TEST: bun_ast::E::EString = bun_ast::E::EString::from_static(b"test");
@@ -536,7 +536,11 @@ impl DefineDataExt for DefineData {
         // `.into()` deep-walking T2→T4 and re-boxing the payload; now `.into()`
         // is identity, so without `deep_clone` the `DefineData.value` dangles
         // into a freed slab and `process.env.NODE_ENV` reads garbage.
-        let data: ExprData = expr.data.deep_clone(bump)?;
+        // TODO(arena-lifetimes): drop the transmute once `deep_clone` returns
+        // `Data<'dst>` (see expr.rs `Expr::deep_clone` TODO — blocked on duping
+        // `Str<'arena>` slices).
+        let data: ExprData<'static> =
+            unsafe { core::mem::transmute(expr.data.deep_clone(bump)?) };
         let can_be_removed_if_unused = bun_ast::expr::Tag::is_primitive_literal(data.tag());
         Ok(DefineData {
             value: data,

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -53,6 +53,8 @@ pub mod thread_pool;
 
 pub mod AstBuilder;
 pub mod analyze_transpiled_module;
+pub mod arena_pool;
+pub use arena_pool::ArenaPool;
 pub mod bundled_ast;
 pub use bundled_ast::BundledAst;
 pub mod barrel_imports;

--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -57,8 +57,8 @@ fn fmt_size(bytes: u64) -> bfmt::SizeFormatter {
 /// The result is stored in chunk.metafile_chunk_json and assembled later.
 pub fn generate_chunk_json(
     c: &LinkerContext,
-    chunk: &Chunk,
-    chunks: &[Chunk],
+    chunk: &Chunk<'_>,
+    chunks: &[Chunk<'_>],
 ) -> Result<Box<[u8]>, bun_core::Error> {
     let mut json: Vec<u8> = Vec::new();
     // errdefer json.deinit() — handled by Drop on early return
@@ -202,7 +202,7 @@ pub fn generate_chunk_json(
 /// Called after all chunks have been generated in parallel.
 /// Chunk references (unique_keys) are resolved to their final output paths.
 /// The caller is responsible for freeing the returned slice.
-pub fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> Result<Box<[u8]>, bun_core::Error> {
+pub fn generate<'a>(c: &mut LinkerContext<'a>, chunks: &mut [Chunk<'a>]) -> Result<Box<[u8]>, bun_core::Error> {
     // Use StringJoiner so we can use breakOutputIntoPieces to resolve chunk references
     let mut j = StringJoiner::default();
     // errdefer j.deinit() — handled by Drop

--- a/src/bundler/linker_context/OutputFileListBuilder.rs
+++ b/src/bundler/linker_context/OutputFileListBuilder.rs
@@ -49,7 +49,7 @@ bun_core::named_error_set!(OutputFileListError);
 impl OutputFileList {
     pub fn init(
         c: &LinkerContext,
-        chunks: &[Chunk],
+        chunks: &[Chunk<'_>],
         _unused: usize,
     ) -> Result<Self, bun_core::Error> {
         let (length, supplementary_file_count) =
@@ -85,7 +85,7 @@ impl OutputFileList {
         core::mem::take(&mut self.output_files)
     }
 
-    pub fn calculate_output_file_list_capacity(c: &LinkerContext, chunks: &[Chunk]) -> (u32, u32) {
+    pub fn calculate_output_file_list_capacity(c: &LinkerContext, chunks: &[Chunk<'_>]) -> (u32, u32) {
         let parse_graph = c.parse_graph();
         let source_map_count: usize = if c.options.source_maps.has_external_files() {
             'brk: {

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -34,10 +34,10 @@ fn make_flags(has_html_chunk: bool, is_browser_chunk_from_server_build: bool) ->
 
 // TODO(port): narrow error set
 #[inline(never)]
-pub fn compute_chunks(
-    this: &mut LinkerContext,
+pub fn compute_chunks<'a>(
+    this: &mut LinkerContext<'a>,
     unique_key: u64,
-) -> Result<Box<[Chunk]>, bun_core::Error> {
+) -> Result<Box<[Chunk<'a>]>, bun_core::Error> {
     let _trace = bun_core::perf::trace("Bundler.computeChunks");
 
     debug_assert!(this.dev_server.is_none()); // use
@@ -47,8 +47,8 @@ pub fn compute_chunks(
     let arena = Arena::new();
     let temp = &arena;
 
-    // TODO(port): StringArrayHashMap keyed by arena-allocated &[u8]; using ArrayHashMap<&[u8], Chunk> here.
-    let mut js_chunks: ArrayHashMap<&[u8], Chunk> = ArrayHashMap::new();
+    // TODO(port): StringArrayHashMap keyed by arena-allocated &[u8]; using ArrayHashMap<&[u8], Chunk<'_>> here.
+    let mut js_chunks: ArrayHashMap<&[u8], Chunk<'_>> = ArrayHashMap::new();
     js_chunks.reserve(this.graph.entry_points.len());
 
     // Key is the hash of the CSS order. This deduplicates identical CSS files.
@@ -79,7 +79,7 @@ pub fn compute_chunks(
 
     let entry_source_indices = this.graph.entry_points.items_source_index();
     let css_asts = this.graph.ast.items_css();
-    let mut html_chunks: ArrayHashMap<&[u8], Chunk> = ArrayHashMap::new();
+    let mut html_chunks: ArrayHashMap<&[u8], Chunk<'_>> = ArrayHashMap::new();
     let loaders = parse_graph.input_files.items_loader();
     let ast_targets = this.graph.ast.items_target();
 
@@ -353,12 +353,12 @@ pub fn compute_chunks(
                     } else {
                         // PORT NOTE: Zig used a local `Handler` struct passed to entry_bits.forEach;
                         // in Rust we pass a context struct + fn pointer.
-                        struct Handler<'a> {
-                            chunks: &'a mut [Chunk],
+                        struct Handler<'r, 'a> {
+                            chunks: &'r mut [Chunk<'a>],
                             source_id: u32,
-                            entry_point_to_js_chunk_idx: &'a [u32],
+                            entry_point_to_js_chunk_idx: &'r [u32],
                         }
-                        fn next(c: &mut Handler<'_>, entry_point_id: usize) {
+                        fn next(c: &mut Handler<'_, '_>, entry_point_id: usize) {
                             // Map the entry point ID to the actual JS chunk index.
                             // CSS-only entry points don't have JS chunks (sentinel value).
                             let chunk_idx = c.entry_point_to_js_chunk_idx[entry_point_id];
@@ -388,7 +388,7 @@ pub fn compute_chunks(
 
     // Sort the chunks for determinism. This matters because we use chunk indices
     // as sorting keys in a few places.
-    let mut sorted_chunks: Vec<Chunk> = 'sort_chunks: {
+    let mut sorted_chunks: Vec<Chunk<'_>> = 'sort_chunks: {
         let mut sorted_chunks = Vec::<Chunk>::init_capacity(
             js_chunks.count() + css_chunks.count() + html_chunks.count(),
         );
@@ -400,11 +400,11 @@ pub fn compute_chunks(
 
         // sort by entry_point_id to ensure the main entry point (id=0) comes first,
         // then by key for determinism among the rest.
-        struct ChunkSortContext<'a> {
-            chunks: &'a ArrayHashMap<&'a [u8], Chunk>,
+        struct ChunkSortContext<'r, 'a> {
+            chunks: &'r ArrayHashMap<&'r [u8], Chunk<'a>>,
         }
 
-        impl<'a> ChunkSortContext<'a> {
+        impl<'r, 'a> ChunkSortContext<'r, 'a> {
             fn less_than(&self, a_key: &[u8], b_key: &[u8]) -> bool {
                 let Some(a_chunk) = self.chunks.get(&a_key) else {
                     return true;
@@ -507,7 +507,7 @@ pub fn compute_chunks(
         // TODO(port): return type — Zig returns []Chunk allocated by this.arena(); here we return Box<[Chunk]>.
         // Phase B: confirm ownership of `chunks` slice (sorted_chunks Vec backing storage).
     };
-    let chunks: &mut [Chunk] = sorted_chunks.slice_mut();
+    let chunks: &mut [Chunk<'_>] = sorted_chunks.slice_mut();
 
     let entry_point_chunk_indices: &mut [u32] =
         this.graph.files.items_entry_point_chunk_index_mut();

--- a/src/bundler/linker_context/computeCrossChunkDependencies.rs
+++ b/src/bundler/linker_context/computeCrossChunkDependencies.rs
@@ -14,9 +14,9 @@ use crate::{
     JSMeta, Ref, RefImportData, ResolvedExports, StableRef, WrapKind, chunk,
 };
 
-pub fn compute_cross_chunk_dependencies(
-    c: &mut LinkerContext,
-    chunks: &mut [Chunk],
+pub fn compute_cross_chunk_dependencies<'a>(
+    c: &mut LinkerContext<'a>,
+    chunks: &mut [Chunk<'a>],
 ) -> Result<(), bun_alloc::AllocError> {
     if !c.graph.code_splitting {
         // No need to compute cross-chunk dependencies if there can't be any
@@ -47,13 +47,9 @@ pub fn compute_cross_chunk_dependencies(
         // `from_ref(c)` would push a SharedRO tag that the `&mut c.graph.X` reborrows
         // pop, leaving the raw dangling under SB.
         //
-        // Lifetime-erase the `LinkerContext<'_>` so the struct's `'a` (which
-        // ties only the local SoA-column borrows) is not forced to equal the
-        // LinkerContext's invariant `'_`. `NonNull::from(&mut *c)` preserves
-        // `c`'s Unique provenance (see PORT NOTE above).
-        let ctx_ref = bun_ptr::BackRef::from(
-            core::ptr::NonNull::from(&mut *c).cast::<LinkerContext<'static>>(),
-        );
+        // `NonNull::from(&mut *c)` preserves `c`'s Unique provenance (see PORT
+        // NOTE above); `'a` is the arena lifetime so no erasure is needed.
+        let ctx_ref = bun_ptr::BackRef::from(core::ptr::NonNull::from(&mut *c));
         // `BackRef` from raw place addr (not `BackRef::new(&…)`) so no
         // intermediate `&` borrow is pushed before the `split_mut()` calls
         // below — matches the `ctx_ref` construction pattern just above.
@@ -87,39 +83,37 @@ pub fn compute_cross_chunk_dependencies(
     compute_cross_chunk_dependencies_with_chunk_metas(c, chunks, &mut chunk_metas)
 }
 
-pub struct CrossChunkDependencies<'a> {
-    chunk_meta: &'a mut [ChunkMeta],
+pub struct CrossChunkDependencies<'r, 'a> {
+    chunk_meta: &'r mut [ChunkMeta],
     // PORT NOTE: `BackRef` — the same `[Chunk]` slice is also iterated mutably by
     // the caller's sequential `walk` loop; `walk` only reads `chunks[other].unique_key`
     // (disjoint from the per-iteration `&mut Chunk`). The slice outlives the struct
     // (caller stack frame).
-    chunks: bun_ptr::BackRef<[Chunk]>,
-    parts: &'a [Vec<Part>],
-    import_records: &'a mut [Vec<ImportRecord>],
-    flags: &'a [js_meta::Flags],
-    entry_point_chunk_indices: &'a [IndexInt],
-    imports_to_bind: &'a [RefImportData],
-    wrapper_refs: &'a [Ref],
-    exports_refs: &'a [Ref],
+    chunks: bun_ptr::BackRef<[Chunk<'a>]>,
+    parts: &'r [Vec<Part<'a>>],
+    import_records: &'r mut [Vec<ImportRecord>],
+    flags: &'r [js_meta::Flags],
+    entry_point_chunk_indices: &'r [IndexInt],
+    imports_to_bind: &'r [RefImportData],
+    wrapper_refs: &'r [Ref],
+    exports_refs: &'r [Ref],
     // Zig: []const []const string → SoA column type is Box<[Box<[u8]>]>
-    sorted_and_filtered_export_aliases: &'a [Box<[Box<[u8]>]>],
-    resolved_exports: &'a [ResolvedExports],
+    sorted_and_filtered_export_aliases: &'r [Box<[Box<[u8]>]>],
+    resolved_exports: &'r [ResolvedExports],
     // PORT NOTE: `BackRef` — Zig stores `*LinkerContext` / `*Symbol.Map` and freely
     // aliases `c.graph` columns alongside; borrowck cannot express that split, so
-    // opt out here via `BackRef` (safe `Deref` at each use site in `walk`). Lifetime
-    // erased (`'static`) so the outer `CrossChunkDependencies<'_>` borrow is not tied
-    // to the LinkerContext's own invariant lifetime parameter.
-    ctx: bun_ptr::BackRef<LinkerContext<'static>>,
+    // opt out here via `BackRef` (safe `Deref` at each use site in `walk`).
+    ctx: bun_ptr::BackRef<LinkerContext<'a>>,
     // `BackRef` — `walk` mutates per-chunk symbol slots via
     // `Map::assign_chunk_index(&self)`, which is a Relaxed store to
     // `Symbol.chunk_index: AtomicU32`, so a shared `&Map` suffices. Holding
     // `&mut Map` here would conflict with the `&LinkerContext` deref of `ctx`
     // (which also reaches `c.graph.symbols`); `BackRef::Deref` yields the
     // shared `&Map` each `walk` call needs.
-    symbols: bun_ptr::BackRef<bun_ast::symbol::Map>,
+    symbols: bun_ptr::BackRef<bun_ast::symbol::Map<'a>>,
 }
 
-impl<'a> CrossChunkDependencies<'a> {
+impl<'r, 'a> CrossChunkDependencies<'r, 'a> {
     // Called once per chunk from the sequential loop above. Writes:
     // `self.chunk_meta[chunk_index]` (per-chunk disjoint),
     // `self.import_records[source_index][rec].{path,source_index}` (per-chunk
@@ -129,7 +123,7 @@ impl<'a> CrossChunkDependencies<'a> {
     // membership — debug-asserted in `assign_chunk_index`).
     // Reads `ctx`/`chunks`/SoA columns shared. Never forms `&mut
     // LinkerContext` (`ctx` is a `BackRef`, deref'd to `&`).
-    pub fn walk(&mut self, chunk: &mut Chunk, chunk_index: usize) {
+    pub fn walk(&mut self, chunk: &mut Chunk<'_>, chunk_index: usize) {
         let deps = self;
         // `ctx` / `chunks` are `BackRef`s into `LinkerContext` / the caller's chunk
         // slice, valid for the link pass (see PORT NOTE on the struct fields).
@@ -139,7 +133,7 @@ impl<'a> CrossChunkDependencies<'a> {
         // pass. Shared `&Map` — per-slot writes go through
         // `Symbol.chunk_index: AtomicU32`; no `&mut Map` is materialized.
         let symbols: &bun_ast::symbol::Map = deps.symbols.get();
-        let _chunks: &[Chunk] = deps.chunks.get();
+        let _chunks: &[Chunk<'_>] = deps.chunks.get();
         let chunk_meta = &mut deps.chunk_meta[chunk_index];
         // PORT NOTE: reshaped for borrowck — Zig held `&chunk_meta` and `&chunk_meta.imports`
         // simultaneously; here we go through `chunk_meta.imports` / `chunk_meta.dynamic_imports`.
@@ -323,9 +317,9 @@ impl<'a> CrossChunkDependencies<'a> {
     }
 }
 
-fn compute_cross_chunk_dependencies_with_chunk_metas(
-    c: &mut LinkerContext,
-    chunks: &mut [Chunk],
+fn compute_cross_chunk_dependencies_with_chunk_metas<'a>(
+    c: &mut LinkerContext<'a>,
+    chunks: &mut [Chunk<'a>],
     chunk_metas: &mut [ChunkMeta],
 ) -> Result<(), bun_alloc::AllocError> {
     // TODO(port): narrow error set

--- a/src/bundler/linker_context/convertStmtsForChunk.rs
+++ b/src/bundler/linker_context/convertStmtsForChunk.rs
@@ -1,4 +1,4 @@
-use crate::BundledAst as JSAst;
+use crate::ungate_support::JSAst;
 use crate::mal_prelude::*;
 use bun_alloc::Arena as Bump;
 use bun_ast::ImportRecordFlags;
@@ -39,15 +39,15 @@ use crate::ungate_support::WrapKind;
 /// In that case, when bundling, we still need to preserve that module
 /// namespace object (foo) because we cannot know what they are going to
 /// attempt to access statically
-pub fn convert_stmts_for_chunk(
-    c: &mut LinkerContext<'_>,
+pub fn convert_stmts_for_chunk<'a>(
+    c: &mut LinkerContext<'a>,
     source_index: u32,
-    stmts: &mut StmtList,
-    part_stmts: &[bun_ast::Stmt],
-    chunk: &mut Chunk,
+    stmts: &mut StmtList<'a>,
+    part_stmts: &[bun_ast::Stmt<'a>],
+    chunk: &mut Chunk<'a>,
     bump: &Bump,
     wrap: WrapKind,
-    ast: &JSAst,
+    ast: &JSAst<'a>,
 ) -> Result<(), bun_core::Error> {
     let _ = bump;
     let should_extract_esm_stmts_for_wrap = wrap != WrapKind::None;

--- a/src/bundler/linker_context/convertStmtsForChunkForDevServer.rs
+++ b/src/bundler/linker_context/convertStmtsForChunkForDevServer.rs
@@ -1,4 +1,4 @@
-use crate::BundledAst as JSAst;
+use crate::ungate_support::JSAst;
 use crate::mal_prelude::*;
 use bun_alloc::ArenaVecExt as _;
 use bun_alloc::{AllocError, Arena as Bump};
@@ -42,12 +42,12 @@ use crate::linker_context_mod::{LinkerContext, StmtList, StmtListWhich};
 ///   ┃   };
 ///     }, false ],
 ///        ----- "is the module async?"
-pub fn convert_stmts_for_chunk_for_dev_server<'bump>(
-    c: &mut LinkerContext,
-    stmts: &mut StmtList,
-    part_stmts: &[bun_ast::Stmt],
+pub fn convert_stmts_for_chunk_for_dev_server<'a, 'bump>(
+    c: &mut LinkerContext<'a>,
+    stmts: &mut StmtList<'a>,
+    part_stmts: &[bun_ast::Stmt<'a>],
     bump: &'bump Bump,
-    ast: &mut JSAst,
+    ast: &mut JSAst<'a>,
 ) -> Result<(), AllocError> {
     // TODO(port): narrow error set
     let hmr_api_ref = ast.wrapper_ref;

--- a/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
+++ b/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
@@ -13,7 +13,7 @@ use bun_core::perf;
 
 pub fn find_all_imported_parts_in_js_order(
     this: &mut LinkerContext,
-    chunks: &mut [Chunk],
+    chunks: &mut [Chunk<'_>],
 ) -> Result<(), bun_core::Error> {
     let _trace = perf::trace("Bundler.findAllImportedPartsInJSOrder");
 
@@ -42,7 +42,7 @@ pub fn find_all_imported_parts_in_js_order(
 
 pub fn find_imported_parts_in_js_order(
     this: &mut LinkerContext,
-    chunk: &mut Chunk,
+    chunk: &mut Chunk<'_>,
     part_ranges_shared: &mut Vec<PartRange>,
     parts_prefix_shared: &mut Vec<PartRange>,
     chunk_index: u32,
@@ -150,7 +150,7 @@ fn run_visits<const WITH_CODE_SPLITTING: bool, const WITH_SCB: bool>(
 pub struct FindImportedPartsVisitor<'a, 'ctx> {
     pub entry_bits: &'a AutoBitSet,
     pub flags: &'a [crate::js_meta::Flags],
-    pub parts: &'a [Vec<Part>],
+    pub parts: &'a [Vec<Part<'a>>],
     pub import_records: &'a [Vec<ImportRecord>],
     pub files: Vec<IndexInt>,
     pub part_ranges: Vec<PartRange>,

--- a/src/bundler/linker_context/findImportedFilesInCSSOrder.rs
+++ b/src/bundler/linker_context/findImportedFilesInCSSOrder.rs
@@ -72,17 +72,17 @@ fn memcpy_and_reset(order: &mut Vec<CssImportOrder>, wip: &mut Vec<CssImportOrde
 /// first and last locations and only write out the "@layer" information
 /// for the first location.
 pub fn find_imported_files_in_css_order<'a>(
-    this: &'a mut LinkerContext,
-    temp_arena: &'a Arena,
+    this: &mut LinkerContext<'a>,
+    temp_arena: &Arena,
     entry_points: &[Index],
 ) -> Vec<CssImportOrder> {
     let _ = temp_arena;
 
-    struct Visitor<'a> {
-        arena: &'a Arena,
+    struct Visitor<'r, 'a> {
+        arena: &'r Arena,
         // `BundledAst.css` SoA column.
-        css_asts: &'a [crate::bundled_ast::CssCol],
-        all_import_records: &'a [Vec<ImportRecord>],
+        css_asts: &'r [crate::bundled_ast::CssCol<'a>],
+        all_import_records: &'r [Vec<ImportRecord>],
 
         // PORT NOTE: Zig's `graph: *LinkerGraph` is never read in `visit()`;
         // dropped here to avoid an aliasing `&mut this.graph` borrow against
@@ -90,14 +90,14 @@ pub fn find_imported_files_in_css_order<'a>(
         // `BackRef` (not `&'a Graph`) so the visitor's `'a` borrow stays
         // disjoint from `LinkerContext` (constructed from the raw `parse_graph`
         // backref, valid for the link step).
-        parse_graph: bun_ptr::BackRef<Graph>,
+        parse_graph: bun_ptr::BackRef<Graph<'a>>,
 
         has_external_import: bool,
         visited: Vec<Index>,
         order: Vec<CssImportOrder>,
     }
 
-    impl<'a> Visitor<'a> {
+    impl<'r, 'a> Visitor<'r, 'a> {
         #[inline]
         fn input_file_pretty(&self, source_index: Index) -> &BStr {
             let sources = self.parse_graph.input_files.items_source();

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -55,9 +55,9 @@ use crate::linker_context_mod::debug;
 // Rust const generics cannot vary the return type, so we always return
 // `Vec<OutputFile>` and the IS_DEV_SERVER path returns an empty Vec. Phase B may
 // split this into two monomorphized wrappers if the unused Vec matters.
-pub fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
-    c: &mut LinkerContext,
-    chunks: &mut [Chunk],
+pub fn generate_chunks_in_parallel<'a, const IS_DEV_SERVER: bool>(
+    c: &mut LinkerContext<'a>,
+    chunks: &mut [Chunk<'a>],
 ) -> Result<Vec<options::OutputFile>, bun_core::Error> {
     let _trace = bun_core::perf::trace("Bundler.generateChunksInParallel");
 
@@ -122,10 +122,8 @@ pub fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                             node: ThreadPoolLib::Node::default(),
                             callback: prepare_css_asts_for_chunk,
                         },
-                        chunk: std::ptr::from_mut::<Chunk>(chunk),
-                        // PORT NOTE: `PrepareCssAstTask.linker` is `*mut LinkerContext<'static>`
-                        // (raw ptr is invariant); `.cast()` erases the inner `'a` to satisfy it.
-                        linker: std::ptr::from_mut::<LinkerContext>(c).cast(),
+                        chunk: std::ptr::from_mut(chunk),
+                        linker: std::ptr::from_mut(c),
                     });
                     // Capacity pre-reserved → push never reallocates → ptr stays stable.
                     let task = tasks.last_mut().unwrap();
@@ -159,7 +157,7 @@ pub fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             // SAFETY: `c` is the live `&mut LinkerContext` for the link step.
             let c_ref =
                 unsafe { bun_ptr::ParentRef::from_raw_mut(std::ptr::from_mut::<LinkerContext>(c)) };
-            let chunks_ref: bun_ptr::BackRef<[Chunk]> = bun_ptr::BackRef::new_mut(chunks);
+            let chunks_ref: bun_ptr::BackRef<[Chunk<'_>]> = bun_ptr::BackRef::new_mut(chunks);
             for chunk in chunks.iter_mut() {
                 chunk_contexts.push(GenerateChunkCtx {
                     c: c_ref,
@@ -356,13 +354,13 @@ pub fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
         let mut path_names_map: StringHashMap<()> = StringHashMap::default();
 
         #[derive(Default)]
-        struct DuplicateEntry {
+        struct DuplicateEntry<'a> {
             // `BackRef` (not `*mut`) — entries point at elements of the
-            // stack-owned `chunks: &mut [Chunk]` above, which outlives the
+            // stack-owned `chunks: &mut [Chunk<'_>]` above, which outlives the
             // `duplicates_map`; reads go through safe `Deref`.
-            sources: Vec<bun_ptr::BackRef<Chunk>>,
+            sources: Vec<bun_ptr::BackRef<Chunk<'a>>>,
         }
-        let mut duplicates_map: StringArrayHashMap<DuplicateEntry> = StringArrayHashMap::default();
+        let mut duplicates_map: StringArrayHashMap<DuplicateEntry<'a>> = StringArrayHashMap::default();
 
         let mut chunk_visit_map = AutoBitSet::init_empty(chunks.len())?;
 
@@ -788,7 +786,7 @@ pub fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             };
             // Tail of the loop body needs `&mut chunk` (`output_source_map.finalize()`);
             // no `&[Chunk]` is needed past this point so an exclusive reborrow is fine.
-            let chunk: &mut Chunk = &mut chunks[chunk_index_in_chunks_list];
+            let chunk: &mut Chunk<'_> = &mut chunks[chunk_index_in_chunks_list];
             chunk.intermediate_output = intermediate_output;
             let mut code_result = _code_result;
 

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -27,16 +27,16 @@ use super::convert_stmts_for_chunk_for_dev_server::convert_stmts_for_chunk_for_d
 // `list.items_field()` method calls (codegen'd accessors on the SoA wrappers).
 
 #[allow(clippy::too_many_arguments)]
-pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
-    c: &mut LinkerContext,
+pub fn generate_code_for_file_in_chunk_js<'r, 'src, 'a>(
+    c: &mut LinkerContext<'a>,
     writer: &mut js_printer::BufferWriter,
-    r: renamer::Renamer<'r, 'src>,
-    chunk: &mut Chunk,
+    r: renamer::Renamer<'r, 'src, 'a>,
+    chunk: &mut Chunk<'a>,
     part_range: PartRange,
     to_common_js_ref: Ref,
     to_esm_ref: Ref,
     runtime_require_ref: Option<Ref>,
-    stmts: &mut StmtList,
+    stmts: &mut StmtList<'a>,
     arena: &Bump,
     temp_arena: &Bump,
     decl_collector: Option<&mut DeclCollector>,
@@ -642,15 +642,15 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                 // swallow any exceptions thrown during module initialization.
                 let is_async = flags.is_async_or_has_async_dependency;
 
-                struct ExportHoist {
-                    decls: Vec<G::Decl>,
+                struct ExportHoist<'a> {
+                    decls: Vec<G::Decl<'a>>,
                     // BackRef: the arena is the caller's `temp_arena: &Bump`,
                     // which strictly outlives this local helper struct.
                     arena: bun_ptr::BackRef<Bump>,
                 }
 
-                impl ExportHoist {
-                    fn wrap_identifier(&mut self, loc: bun_ast::Loc, ref_: Ref) -> Expr {
+                impl<'a> ExportHoist<'a> {
+                    fn wrap_identifier(&mut self, loc: bun_ast::Loc, ref_: Ref) -> Expr<'a> {
                         // Copy the BackRef so the `&Bump` borrow is detached
                         // from `&mut self` (needed for `self.decls.push`).
                         let arena = self.arena;
@@ -671,7 +671,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                         ctx: *mut core::ffi::c_void,
                         loc: bun_ast::Loc,
                         ref_: Ref,
-                    ) -> Expr {
+                    ) -> Expr<'a> {
                         // SAFETY: `ctx` is `&mut ExportHoist` derived at the call site.
                         let this = unsafe { bun_ptr::callback_ctx::<ExportHoist>(ctx) };
                         this.wrap_identifier(loc, ref_)
@@ -982,7 +982,7 @@ impl DeclCollector {
     pub fn collect_from_stmts(
         &mut self,
         stmts: &[Stmt],
-        r: &mut renamer::Renamer<'_, '_>,
+        r: &mut renamer::Renamer<'_, '_, '_>,
         c: &LinkerContext,
     ) {
         for stmt in stmts {
@@ -1020,7 +1020,7 @@ impl DeclCollector {
         &mut self,
         binding: Binding,
         kind: DeclInfoKind,
-        r: &mut renamer::Renamer<'_, '_>,
+        r: &mut renamer::Renamer<'_, '_, '_>,
         c: &LinkerContext,
     ) {
         match binding.data {
@@ -1045,7 +1045,7 @@ impl DeclCollector {
         &mut self,
         ref_: Ref,
         kind: DeclInfoKind,
-        r: &mut renamer::Renamer<'_, '_>,
+        r: &mut renamer::Renamer<'_, '_, '_>,
         c: &LinkerContext,
     ) {
         let followed = c.graph.symbols.follow(ref_);

--- a/src/bundler/linker_context/generateCodeForLazyExport.rs
+++ b/src/bundler/linker_context/generateCodeForLazyExport.rs
@@ -19,7 +19,7 @@ use crate::bun_css::{BundlerStyleSheet, CssRef, CssRefTag};
 use crate::{Index, IndexInt, LinkerContext};
 use bun_collections::DynamicBitSetUnmanaged as BitSet;
 
-type SymbolList = Vec<Symbol>;
+type SymbolList<'a> = Vec<Symbol<'a>>;
 
 /// `ArrayHashAdapter` so `LocalScope` (`ArrayHashMap<Box<[u8]>, LocalEntry>`)
 /// can be queried by borrowed `&[u8]` (CSS idents are arena `*const [u8]`).
@@ -101,24 +101,24 @@ pub fn generate_code_for_lazy_export(
             let mut composes_visited: ArrayHashMap<Ref, ()> = ArrayHashMap::new();
             // `defer composes_visited.deinit()` — handled by Drop.
 
-            struct Visitor<'a> {
-                inner_visited: &'a mut BitSet,
+            struct Visitor<'r, 'a> {
+                inner_visited: &'r mut BitSet,
                 // Zig: `std.AutoArrayHashMap(Ref, void)` → `ArrayHashMap` per collections map.
-                composes_visited: &'a mut ArrayHashMap<Ref, ()>,
-                parts: &'a mut Vec<E::TemplatePart>,
-                all_import_records: &'a [Vec<ImportRecord>],
+                composes_visited: &'r mut ArrayHashMap<Ref, ()>,
+                parts: &'r mut Vec<E::TemplatePart<'a>>,
+                all_import_records: &'r [Vec<ImportRecord>],
                 // `BundledAst.css` SoA column.
-                all_css_asts: &'a [crate::bundled_ast::CssCol],
-                all_sources: &'a [Source],
-                all_symbols: &'a [SymbolList],
+                all_css_asts: &'r [crate::bundled_ast::CssCol<'a>],
+                all_sources: &'r [Source],
+                all_symbols: &'r [SymbolList<'a>],
                 source_index: IndexInt,
-                log: &'a mut Log,
+                log: &'r mut Log,
                 loc: Loc,
                 // PERF(port): was `std.mem.Allocator` (arena) — bundler is an AST crate; thread `&'bump Bump`.
-                arena: &'a Arena,
+                arena: &'r Arena,
             }
 
-            impl<'a> Visitor<'a> {
+            impl<'r, 'a> Visitor<'r, 'a> {
                 fn clear_all(&mut self) {
                     self.inner_visited.set_all(false);
                     self.composes_visited.clear_retaining_capacity();

--- a/src/bundler/linker_context/generateCompileResultForCssChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForCssChunk.rs
@@ -43,7 +43,7 @@ pub fn generate_compile_result_for_css_chunk(task: *mut ThreadPoolLib::Task) {
     // see TODO(ub-audit) on `unsafe impl Sync for Chunk`.)
     let result = {
         let c_mut: &mut LinkerContext = unsafe { &mut *c_ptr };
-        let chunk_mut: &mut Chunk = unsafe { &mut *chunk_ptr };
+        let chunk_mut: &mut Chunk<'_> = unsafe { &mut *chunk_ptr };
         generate_compile_result_for_css_chunk_impl(&mut **worker, c_mut, chunk_mut, part_range.i)
     };
 
@@ -54,9 +54,9 @@ pub fn generate_compile_result_for_css_chunk(task: *mut ThreadPoolLib::Task) {
 }
 
 fn generate_compile_result_for_css_chunk_impl(
-    worker: &mut Worker,
+    worker: &mut Worker<'_>,
     c: &mut LinkerContext,
-    chunk: &mut Chunk,
+    chunk: &mut Chunk<'_>,
     imports_in_chunk_index: u32,
 ) -> CompileResult {
     let _trace = bun_core::perf::trace("Bundler.generateCodeForFileInChunkCss");
@@ -66,7 +66,7 @@ fn generate_compile_result_for_css_chunk_impl(
     // `worker.temporary_arena` borrowed `&mut` below, so a direct shared
     // borrow via `BackRef::get` is fine. The heap is pinned for the worker's
     // lifetime; see `Worker::arena`.
-    let arena = worker.arena.get();
+    let arena = worker.arena;
     // PERF(port): was arena bulk-free (worker.temporary_arena.reset(.retain_capacity)) — profile in Phase B
     let _arena_reset = scopeguard::guard(&mut worker.temporary_arena, |arena| {
         // temporary_arena is initialized in Worker::create before any task runs.

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -59,15 +59,15 @@ pub fn generate_compile_result_for_html_chunk(task: *mut ThreadPoolLibTask) {
     let worker = Worker::get(ctx.bundle());
     let _unget = scopeguard::guard(&mut *worker, |w| w.unget());
 
-    // `ctx.chunks` is a `BackRef<[Chunk]>` constructed via `new_mut` (write
+    // `ctx.chunks` is a `BackRef<[Chunk<'_>]>` constructed via `new_mut` (write
     // provenance); recover the raw `*mut [Chunk]` for the HTML loader, which
     // still needs `&mut [Chunk]` for `get_{js,css}_chunk_for_html`.
-    let chunks: *mut [Chunk] = ctx.chunks.as_ptr();
-    // `ctx.c` is `ParentRef<LinkerContext>` and `ctx.chunk` is `BackRef<Chunk>`
+    let chunks: *mut [Chunk<'_>] = ctx.chunks.as_ptr();
+    // `ctx.c` is `ParentRef<LinkerContext>` and `ctx.chunk` is `BackRef<Chunk<'_>>`
     // — both yield safe shared borrows via `.get()`. `chunk` is this task's
     // exclusively-owned HTML chunk for the duration of the compile step.
     let c_ref: &LinkerContext = ctx.c.get();
-    let chunk_ref: &Chunk = ctx.chunk.get();
+    let chunk_ref: &Chunk<'_> = ctx.chunk.get();
     let result = generate_compile_result_for_html_chunk_impl(c_ref, chunk_ref, chunks);
     // SAFETY: HTML chunks have exactly one part-range (i == 0); see
     // `Chunk::write_compile_result_slot` for the disjoint-slot contract.
@@ -92,8 +92,8 @@ struct HTMLLoader<'a> {
     /// Backref to this task's HTML chunk (an element of `*chunks`). The chunk
     /// outlives this `HTMLLoader` (link-step duration), so `BackRef`'s
     /// owner-outlives-holder invariant holds and reads go through safe `Deref`.
-    chunk: bun_ptr::BackRef<Chunk>,
-    chunks: *mut [Chunk],
+    chunk: bun_ptr::BackRef<Chunk<'a>>,
+    chunks: *mut [Chunk<'a>],
     #[allow(dead_code)]
     minify_whitespace: bool,
     compile_to_standalone_html: bool,
@@ -286,7 +286,7 @@ impl<'a> HTMLLoader<'a> {
         // PERF(port): was stack-fallback arena; now heap Vec<u8>
         let mut array: BoundedArray<Vec<u8>, 2> = BoundedArray::default();
         // `self.chunk` is a `BackRef` (safe `Deref`).
-        let chunk: &Chunk = &self.chunk;
+        let chunk: &Chunk<'_> = &self.chunk;
         // SAFETY: `chunks` raw pointer valid for the link step; sole live `&mut`.
         let chunks = unsafe { &mut *self.chunks };
         if self.compile_to_standalone_html {
@@ -407,8 +407,8 @@ impl<'a> HTMLLoader<'a> {
 /// `HTMLLoader::{on_tag,get_head_tags}` and the standalone-HTML branch below.
 fn generate_compile_result_for_html_chunk_impl<'a>(
     c: &'a LinkerContext<'a>,
-    chunk: &Chunk,
-    chunks: *mut [Chunk],
+    chunk: &Chunk<'a>,
+    chunks: *mut [Chunk<'a>],
 ) -> CompileResult {
     let parse_graph = c.parse_graph();
     let sources = parse_graph.input_files.items_source();

--- a/src/bundler/linker_context/generateCompileResultForJSChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForJSChunk.rs
@@ -59,7 +59,7 @@ pub fn generate_compile_result_for_js_chunk(task: *mut ThreadPoolLib::Task) {
     // see TODO(ub-audit) on `unsafe impl Sync for Chunk`.)
     let result = {
         let c_mut: &mut LinkerContext = unsafe { &mut *c_ptr };
-        let chunk_mut: &mut Chunk = unsafe { &mut *chunk_ptr };
+        let chunk_mut: &mut Chunk<'_> = unsafe { &mut *chunk_ptr };
         generate_compile_result_for_js_chunk_impl(
             &mut **worker,
             c_mut,
@@ -74,10 +74,10 @@ pub fn generate_compile_result_for_js_chunk(task: *mut ThreadPoolLib::Task) {
     unsafe { Chunk::write_compile_result_slot(chunk_ptr, part_range.i as usize, result) };
 }
 
-fn generate_compile_result_for_js_chunk_impl(
-    worker: &mut Worker,
-    c: &mut LinkerContext,
-    chunk: &mut Chunk,
+fn generate_compile_result_for_js_chunk_impl<'a>(
+    worker: &mut Worker<'a>,
+    c: &mut LinkerContext<'a>,
+    chunk: &mut Chunk<'a>,
     part_range: PartRange,
 ) -> CompileResult {
     let _trace = bun_core::perf::trace("Bundler.generateCodeForFileInChunkJS");
@@ -149,14 +149,14 @@ fn generate_compile_result_for_js_chunk_impl(
     // DeclCollector; the Rust DeclCollector wants `*const Arena`. Use the
     // worker heap for now (see TODO above re: dev_server arena).
     let mut dc = DeclCollector {
-        arena: worker.arena.as_ptr(),
+        arena: core::ptr::from_ref(worker.arena),
         ..Default::default()
     };
 
     // `worker.arena` (= `BackRef` to `worker.heap`) is a disjoint field from
     // `worker.temporary_arena` / `worker.stmt_list` borrowed `&mut` above, so
     // a direct shared borrow is fine. Heap is pinned; see `Worker::arena`.
-    let worker_alloc = worker.arena.get();
+    let worker_alloc = worker.arena;
     // SAFETY: split borrow of `chunk` — `generate_code_for_file_in_chunk_js` never
     // touches `chunk.renamer` through its `chunk` parameter (Zig passes the renamer
     // union by value alongside `*Chunk`); take a raw-ptr view so borrowck doesn't

--- a/src/bundler/linker_context/postProcessCSSChunk.rs
+++ b/src/bundler/linker_context/postProcessCSSChunk.rs
@@ -13,7 +13,7 @@ use crate::{Chunk, CompileResultForSourceMap, Index, options};
 pub fn post_process_css_chunk(
     ctx: GenerateChunkCtx,
     worker: &mut thread_pool::Worker,
-    chunk: &mut Chunk,
+    chunk: &mut Chunk<'_>,
 ) -> Result<(), bun_core::Error> {
     // TODO(port): narrow error set
     let c = ctx.c();

--- a/src/bundler/linker_context/postProcessHTMLChunk.rs
+++ b/src/bundler/linker_context/postProcessHTMLChunk.rs
@@ -8,7 +8,7 @@ use crate::thread_pool;
 pub fn post_process_html_chunk(
     ctx: GenerateChunkCtx,
     worker: &mut thread_pool::Worker,
-    chunk: &mut Chunk,
+    chunk: &mut Chunk<'_>,
 ) -> Result<(), bun_core::Error> {
     // TODO(port): narrow error set — Zig `!void` but body has zero `try` sites (inferred-empty)
     // This is where we split output into pieces

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -43,7 +43,7 @@ fn print_result_take_code(r: &mut PrintResult) -> Box<[u8]> {
 pub fn post_process_js_chunk(
     ctx: GenerateChunkCtx,
     worker: &mut ThreadPool::Worker,
-    chunk: &mut Chunk,
+    chunk: &mut Chunk<'_>,
     chunk_index: usize,
 ) -> Result<(), bun_core::Error> {
     // TODO(port): narrow error set
@@ -144,7 +144,7 @@ pub fn post_process_js_chunk(
             // PERF(port): was appendAssumeCapacity
             cross_chunk_import_records.push(ImportRecord {
                 kind: import_record.import_kind,
-                // `ctx.chunks` is a `BackRef<[Chunk]>` (safe `Deref`); chunk_index is
+                // `ctx.chunks` is a `BackRef<[Chunk<'_>]>` (safe `Deref`); chunk_index is
                 // in-bounds (produced by the linker for this chunks slice).
                 path: bun_paths::fs::Path::init(
                     ctx.chunks[import_record.chunk_index as usize].unique_key,
@@ -865,8 +865,8 @@ fn add_binding_vars_to_module_info(
     mi: &mut ModuleInfo,
     binding: Binding,
     var_kind: analyze_transpiled_module::VarKind,
-    r: &mut js_printer::renamer::Renamer<'_, '_>,
-    symbols: &bun_ast::symbol::Map,
+    r: &mut js_printer::renamer::Renamer<'_, '_, '_>,
+    symbols: &bun_ast::symbol::Map<'_>,
 ) {
     match binding.data {
         B::B::BIdentifier(b) => {
@@ -903,7 +903,7 @@ pub fn generate_entry_point_tail_js<'a>(
     // TODO(port): thread &'bump Bump from worker.arena end-to-end in Phase B
     arena: &'a Arena,
     temp_arena: &Arena,
-    mut r: js_printer::renamer::Renamer<'a, 'a>,
+    mut r: js_printer::renamer::Renamer<'a, 'a, 'a>,
     mut module_info: Option<&'a mut ModuleInfo>,
 ) -> CompileResult {
     let flags: crate::js_meta::Flags = c.graph.meta.items_flags()[source_index as usize];

--- a/src/bundler/linker_context/prepareCssAstsForChunk.rs
+++ b/src/bundler/linker_context/prepareCssAstsForChunk.rs
@@ -27,10 +27,10 @@ use crate::chunk::{Content, CssImportOrderKind};
 // `linker` retains write provenance over the whole bundle, and (b) multiple
 // tasks may hold pointers to the same `LinkerContext` concurrently without
 // materializing aliased Rust references.
-pub struct PrepareCssAstTask {
+pub struct PrepareCssAstTask<'a> {
     pub task: ThreadPoolLib::Task,
-    pub chunk: *mut Chunk,
-    pub linker: *mut LinkerContext<'static>,
+    pub chunk: *mut Chunk<'a>,
+    pub linker: *mut LinkerContext<'a>,
 }
 
 // SAFETY: scheduled on the worker pool via raw `*mut Task` (bypassing the
@@ -38,7 +38,7 @@ pub struct PrepareCssAstTask {
 // (`Chunk: Send`, `LinkerContext: Send`); the callback writes only the
 // per-chunk `chunk.content.css` cell (see `prepare_css_asts_for_chunk`
 // CONCURRENCY note).
-unsafe impl Send for PrepareCssAstTask {}
+unsafe impl Send for PrepareCssAstTask<'_> {}
 
 // CONCURRENCY: thread-pool callback — runs on worker threads, one task per
 // CSS chunk. Writes: `chunk.content.css.{asts, ordered_import_records}`
@@ -57,7 +57,7 @@ pub fn prepare_css_asts_for_chunk(task: *mut ThreadPoolLib::Task) {
     let prepare_css_asts: &PrepareCssAstTask =
         unsafe { &*bun_core::from_field_ptr!(PrepareCssAstTask, task, task) };
     let linker: *mut LinkerContext = prepare_css_asts.linker;
-    let chunk: *mut Chunk = prepare_css_asts.chunk;
+    let chunk: *mut Chunk<'_> = prepare_css_asts.chunk;
     // SAFETY: `linker` is a raw `*mut` to `BundleV2.linker` (embedded by value),
     // carrying provenance over the full `BundleV2` allocation. Recover the
     // parent via container_of. `Worker::get` only needs `&BundleV2`, so we
@@ -80,7 +80,7 @@ pub fn prepare_css_asts_for_chunk(task: *mut ThreadPoolLib::Task) {
     );
 }
 
-fn prepare_css_asts_for_chunk_impl(c: &mut LinkerContext, chunk: &mut Chunk, bump: &Bump) {
+fn prepare_css_asts_for_chunk_impl(c: &mut LinkerContext, chunk: &mut Chunk<'_>, bump: &Bump) {
     // SAFETY: parse_graph backref; raw deref because `parse_graph` is held
     // across the log write below (split borrow).
     let parse_graph = unsafe { &*c.parse_graph };

--- a/src/bundler/linker_context/renameSymbolsInChunk.rs
+++ b/src/bundler/linker_context/renameSymbolsInChunk.rs
@@ -40,11 +40,11 @@ use crate::{Chunk, LinkerContext, StableRef, WrapKind};
 /// `c` must point to a live `LinkerContext` for the duration of the call;
 /// caller (the `each_ptr` dispatch) guarantees the link step outlives all
 /// renamer tasks.
-pub unsafe fn rename_symbols_in_chunk(
-    c: *mut LinkerContext,
-    chunk: &mut Chunk,
+pub unsafe fn rename_symbols_in_chunk<'a>(
+    c: *mut LinkerContext<'a>,
+    chunk: &mut Chunk<'a>,
     files_in_order: &[u32],
-) -> Result<ChunkRenamer, bun_core::Error> {
+) -> Result<ChunkRenamer<'a>, bun_core::Error> {
     let _trace = bun_core::perf::trace("Bundler.renameSymbolsInChunk");
 
     // Derive the `symbols` pointer from the raw `*mut LinkerContext` *before*
@@ -115,7 +115,7 @@ pub unsafe fn rename_symbols_in_chunk(
     // over the shared `symbol::Map` — `compute_reserved_names_for_scope` and
     // the renamer constructors only read it. (`symbols` itself is derived
     // above from the raw `*mut LinkerContext` to keep mutable provenance.)
-    let make_symbols_view = |symbols: *mut symbol::Map| -> symbol::Map {
+    let make_symbols_view = |symbols: *mut symbol::Map<'a>| -> symbol::Map<'a> {
         // SAFETY: `symbols` is the live `c.graph.symbols`; we read its inner
         // slice header to build a non-owning shallow `Vec` view.
         let inner = unsafe { (*symbols).symbols_for_source.slice_mut() };
@@ -400,13 +400,13 @@ pub unsafe fn rename_symbols_in_chunk(
             }
 
             r.add_top_level_declared_symbols(&mut part.declared_symbols);
-            // `Part.scopes: StoreSlice<*mut Scope>` — safe `Deref` to `&[*mut Scope]`.
+            // `Part.scopes: StoreSlice<NonNull<Scope>>` — safe `Deref` to `&[NonNull<Scope>]`.
             for scope in part.scopes.iter() {
                 let root: *mut renamer::NumberScope = core::ptr::addr_of_mut!(r.root);
-                // SAFETY: each `*mut Scope` is a valid arena-allocated scope.
+                // SAFETY: each `NonNull<Scope>` is a valid arena-allocated scope.
                 r.assign_names_recursive_with_number_scope(
                     root,
-                    unsafe { &**scope },
+                    unsafe { scope.as_ref() },
                     source_index,
                     &mut sorted,
                 );

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -1406,10 +1406,10 @@ mod __css_validation {
         }
     }
 
-    pub(super) fn validate_css_import_composes(
-        this: &mut LinkerContext,
+    pub(super) fn validate_css_import_composes<'a>(
+        this: &mut LinkerContext<'a>,
         id: usize,
-        css_asts: *mut [CssCol],
+        css_asts: *mut [CssCol<'a>],
         import_records_list: *mut [ImportRecordList],
         input_files: *mut [Source],
     ) {
@@ -1490,12 +1490,12 @@ mod __css_validation {
     /// 2. Composing from the global scope is pretty rare
     ///
     /// We should find a way to do this without incurring performance penalties to the common cases.
-    fn validate_composes_from_properties(
-        this: &mut LinkerContext,
+    fn validate_composes_from_properties<'a>(
+        this: &mut LinkerContext<'a>,
         index: IndexInt,
         root_css_ast: &BundlerStyleSheet,
         import_records_list: *mut [ImportRecordList],
-        all_css_asts: *mut [CssCol],
+        all_css_asts: *mut [CssCol<'a>],
     ) {
         #[derive(Default)]
         struct PropertyInFile {
@@ -1503,19 +1503,19 @@ mod __css_validation {
             range: bun_ast::Range,
         }
 
-        struct Visitor<'a> {
+        struct Visitor<'r, 'a> {
             visited: ArrayHashMap<bun_ast::Ref, ()>,
             properties: StringArrayHashMap<PropertyInFile>,
             all_import_records: *mut [ImportRecordList],
-            all_css_asts: *mut [CssCol],
-            all_symbols: &'a symbol::Map,
+            all_css_asts: *mut [CssCol<'a>],
+            all_symbols: &'r symbol::Map<'a>,
             all_sources: *mut [Source],
-            log: &'a mut Log,
+            log: &'r mut Log,
         }
 
         // PORT NOTE: `pub fn deinit` → Drop on `visited` / `properties` handles cleanup.
 
-        impl<'a> Visitor<'a> {
+        impl<'r, 'a> Visitor<'r, 'a> {
             fn add_property_or_warn(
                 &mut self,
                 local: bun_ast::Ref,

--- a/src/bundler/linker_context/writeOutputFilesToDisk.rs
+++ b/src/bundler/linker_context/writeOutputFilesToDisk.rs
@@ -31,10 +31,10 @@ use bun_sys::{
 /// Zig: `bun.bytecode_extension` (".jsc"). Mirror of `src/bun.zig:bytecode_extension`.
 const BYTECODE_EXTENSION: &str = ".jsc";
 
-pub fn write_output_files_to_disk(
-    c: &mut LinkerContext,
+pub fn write_output_files_to_disk<'a>(
+    c: &mut LinkerContext<'a>,
     root_path: &[u8],
-    chunks: &mut [Chunk],
+    chunks: &mut [Chunk<'a>],
     output_files: &mut OutputFileList,
     standalone_chunk_contents: Option<&[Option<Box<[u8]>>]>,
 ) -> Result<(), Error> {
@@ -95,7 +95,7 @@ pub fn write_output_files_to_disk(
     let chunks_len = chunks.len();
 
     for chunk_index_in_chunks_list in 0..chunks_len {
-        let chunk: &Chunk = &chunks[chunk_index_in_chunks_list];
+        let chunk: &Chunk<'_> = &chunks[chunk_index_in_chunks_list];
         // In standalone mode, only write HTML chunks to disk.
         // Insert placeholder output files for non-HTML chunks to keep indices aligned.
         if standalone_chunk_contents.is_some() && !matches!(chunk.content, Content::Html) {
@@ -163,7 +163,7 @@ pub fn write_output_files_to_disk(
         // disjoint from the `&chunks[i]` / `&[Chunk]` reads below.
         let mut intermediate_output =
             core::mem::take(&mut chunks[chunk_index_in_chunks_list].intermediate_output);
-        let chunk: &Chunk = &chunks[chunk_index_in_chunks_list];
+        let chunk: &Chunk<'_> = &chunks[chunk_index_in_chunks_list];
         let parse_graph = c.parse_graph();
 
         let mut code_result = if let Some(scc) = standalone_chunk_contents {
@@ -207,7 +207,7 @@ pub fn write_output_files_to_disk(
         };
         // Tail of the loop body needs `&mut chunk` (`output_source_map.finalize()`);
         // no `&[Chunk]` is needed past this point so an exclusive reborrow is fine.
-        let chunk: &mut Chunk = &mut chunks[chunk_index_in_chunks_list];
+        let chunk: &mut Chunk<'_> = &mut chunks[chunk_index_in_chunks_list];
         chunk.intermediate_output = intermediate_output;
 
         let mut source_map_output_file: Option<OutputFile> = None;

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -848,13 +848,29 @@ impl AlreadyBundled {
 }
 
 /// Port of `transpiler.zig:ParseResult`.
-// PORT NOTE: lifetime-free — `runtime_transpiler_cache` is a raw pointer (Zig
-// `?*RuntimeTranspilerCache`) so `AsyncModule.parse_result` / `JSTranspiler`
-// can store this by value without threading a borrow lifetime.
+/// Erase `'arena` to `'static` for [`ParseResult::ast`]. The runtime
+/// transpiler's arena is owned by `JSTranspiler` (a long-lived GC object that
+/// stores both the arena and the `ParseResult` as sibling fields) — a
+/// self-referential pattern that cannot be expressed with a lifetime
+/// parameter. This is the runtime-transpiler analogue of the bundler's
+/// `ArenaPool`; the bundler path does not use `ParseResult` and so does not
+/// hit this cast.
+#[inline(always)]
+fn erase_ast_arena_for_runtime(ast: bun_ast::Ast<'_>) -> bun_ast::Ast<'static> {
+    // SAFETY: see fn doc — `JSTranspiler.arena` outlives `JSTranspiler.result`
+    // by struct drop order; both are dropped together when the JS object is
+    // finalized.
+    unsafe { core::mem::transmute(ast) }
+}
+
+// PORT NOTE: `ast` is `'static`-erased because the runtime-transpiler arena
+// is owned by `JSTranspiler` (a long-lived GC object) — self-referential, so
+// the lifetime cannot be threaded through the JS-object boundary. The bundler
+// path does not use `ParseResult`; it uses `parse_task::Success<'a>` instead.
 pub struct ParseResult {
     pub source: bun_ast::Source,
     pub loader: options::Loader,
-    pub ast: bun_ast::Ast,
+    pub ast: bun_ast::Ast<'static>,
     pub already_bundled: AlreadyBundled,
     pub input_fd: Option<FD>,
     pub empty: bool,
@@ -958,7 +974,7 @@ pub struct ParseOptions<'a> {
     pub macro_js_ctx: MacroJSCtx,
     pub virtual_source: Option<&'a bun_ast::Source>,
     /// Zig: `runtime.Runtime.Features.ReplaceableExport.Map`.
-    pub replace_exports: bun_collections::StringArrayHashMap<bun_ast::runtime::ReplaceableExport>,
+    pub replace_exports: bun_collections::StringArrayHashMap<bun_ast::runtime::ReplaceableExport<'static>>,
     pub inject_jest_globals: bool,
     pub set_breakpoint_on_first_line: bool,
     pub emit_decorator_metadata: bool,
@@ -1726,7 +1742,7 @@ impl<'a> Transpiler<'a> {
                 };
                 return Some(match parsed {
                     js_ast::Result::Ast(value) => ParseResult {
-                        ast: *value,
+                        ast: erase_ast_arena_for_runtime(*value),
                         source: source.clone(),
                         loader,
                         input_fd,
@@ -2127,7 +2143,7 @@ fn parse_data_loader(
     ast.symbols = bun_ast::symbol::List::from_owned_slice(symbols.into_boxed_slice());
 
     return Some(ParseResult {
-        ast,
+        ast: erase_ast_arena_for_runtime(ast),
         source: source.clone(),
         loader,
         input_fd,
@@ -2349,16 +2365,19 @@ pub use js_printer::Format as PrintFormat;
 // to the one concrete type and marking the public entry points
 // `#[inline(never)]` makes LTO emit exactly one copy in `bun_bundler`.
 impl<'a> Transpiler<'a> {
-    fn print_with_source_map_maybe<const ENABLE_SOURCE_MAP: bool>(
+    fn print_with_source_map_maybe<'b, const ENABLE_SOURCE_MAP: bool>(
         &mut self,
-        mut ast: bun_ast::Ast,
-        source: &bun_ast::Source,
+        ast: bun_ast::Ast<'static>,
+        source: &'b bun_ast::Source,
         writer: &mut js_printer::BufferPrinter,
         format: js_printer::Format,
-        source_map_context: Option<js_printer::SourceMapHandler<'_>>,
+        source_map_context: Option<js_printer::SourceMapHandler<'b>>,
         runtime_transpiler_cache: Option<core::ptr::NonNull<RuntimeTranspilerCache>>,
         module_info: Option<*mut analyze_transpiled_module::ModuleInfo>,
-    ) -> Result<usize, bun_core::Error> {
+    ) -> Result<usize, bun_core::Error>
+    where
+        'a: 'b,
+    {
         // TODO(port): narrow error set
         // TODO(port): `bun.perf.trace("JSPrinter.printWithSourceMap")` /
         // `("JSPrinter.print")` — `bun_perf::trace` now takes a `PerfEvent`
@@ -2373,6 +2392,9 @@ impl<'a> Transpiler<'a> {
         // walks `symbols` exclusively — `rg tree.symbols js_printer/lib.rs` is
         // empty). `init_with_one_list` boxes the single inner list.
         // PERF(port): one extra alloc vs Zig's borrowed-slice — profile Phase B.
+        // `Ast<'arena>` is covariant: `'static` shortens to `'b` so the
+        // printer's single `'a` can unify with `source`/`handler` borrows.
+        let mut ast: bun_ast::Ast<'b> = ast;
         let symbols = bun_ast::symbol::Map::init_with_one_list(core::mem::take(&mut ast.symbols));
 
         // `runtime_imports` is now forwarded — after Round-G `Ast.runtime_imports`
@@ -2459,15 +2481,18 @@ impl<'a> Transpiler<'a> {
     #[cold]
     #[inline(never)]
     #[allow(clippy::too_many_arguments)]
-    fn print_cjs_cold<const ENABLE_SOURCE_MAP: bool>(
+    fn print_cjs_cold<'b, const ENABLE_SOURCE_MAP: bool>(
         &mut self,
         writer: &mut js_printer::BufferPrinter,
-        ast: &bun_ast::Ast,
-        symbols: bun_ast::symbol::Map,
+        ast: &bun_ast::Ast<'b>,
+        symbols: bun_ast::symbol::Map<'b>,
         source: &bun_ast::Source,
-        source_map_context: Option<js_printer::SourceMapHandler<'_>>,
+        source_map_context: Option<js_printer::SourceMapHandler<'b>>,
         runtime_transpiler_cache: Option<core::ptr::NonNull<RuntimeTranspilerCache>>,
-    ) -> Result<usize, bun_core::Error> {
+    ) -> Result<usize, bun_core::Error>
+    where
+        'a: 'b,
+    {
         js_printer::print_common_js::<_, false, ENABLE_SOURCE_MAP>(
             writer,
             // PORT NOTE: `print_common_js` grew a `&bumpalo::Bump` arg in
@@ -2503,15 +2528,18 @@ impl<'a> Transpiler<'a> {
     #[cold]
     #[inline(never)]
     #[allow(clippy::too_many_arguments)]
-    fn print_esm_cold<const ENABLE_SOURCE_MAP: bool>(
+    fn print_esm_cold<'b, const ENABLE_SOURCE_MAP: bool>(
         &mut self,
         writer: &mut js_printer::BufferPrinter,
-        ast: &bun_ast::Ast,
-        symbols: bun_ast::symbol::Map,
+        ast: &bun_ast::Ast<'b>,
+        symbols: bun_ast::symbol::Map<'b>,
         source: &bun_ast::Source,
-        source_map_context: Option<js_printer::SourceMapHandler<'_>>,
+        source_map_context: Option<js_printer::SourceMapHandler<'b>>,
         runtime_transpiler_cache: Option<core::ptr::NonNull<RuntimeTranspilerCache>>,
-    ) -> Result<usize, bun_core::Error> {
+    ) -> Result<usize, bun_core::Error>
+    where
+        'a: 'b,
+    {
         let opts = js_printer::Options {
             bundling: false,
             runtime_imports: ast.runtime_imports.clone(),
@@ -2544,17 +2572,20 @@ impl<'a> Transpiler<'a> {
     #[cold]
     #[inline(never)]
     #[allow(clippy::too_many_arguments)]
-    fn print_ast_esm_ascii_not_bun_cold<const ENABLE_SOURCE_MAP: bool>(
+    fn print_ast_esm_ascii_not_bun_cold<'b, const ENABLE_SOURCE_MAP: bool>(
         &mut self,
         writer: &mut js_printer::BufferPrinter,
-        ast: bun_ast::Ast,
-        symbols: bun_ast::symbol::Map,
-        source: &bun_ast::Source,
-        source_map_context: Option<js_printer::SourceMapHandler<'_>>,
+        ast: bun_ast::Ast<'b>,
+        symbols: bun_ast::symbol::Map<'b>,
+        source: &'b bun_ast::Source,
+        source_map_context: Option<js_printer::SourceMapHandler<'b>>,
         exports_kind: bun_ast::ExportsKind,
         runtime_transpiler_cache: Option<core::ptr::NonNull<RuntimeTranspilerCache>>,
         module_info: Option<*mut analyze_transpiled_module::ModuleInfo>,
-    ) -> Result<usize, bun_core::Error> {
+    ) -> Result<usize, bun_core::Error>
+    where
+        'a: 'b,
+    {
         self.print_ast_esm_ascii::<ENABLE_SOURCE_MAP, false>(
             writer,
             ast,
@@ -2571,17 +2602,20 @@ impl<'a> Transpiler<'a> {
     // print_with_source_map_maybe to express the comptime bool dispatch as a
     // const generic.
     #[allow(clippy::too_many_arguments)]
-    fn print_ast_esm_ascii<const ENABLE_SOURCE_MAP: bool, const IS_BUN: bool>(
+    fn print_ast_esm_ascii<'b, const ENABLE_SOURCE_MAP: bool, const IS_BUN: bool>(
         &mut self,
         writer: &mut js_printer::BufferPrinter,
-        ast: bun_ast::Ast,
-        symbols: bun_ast::symbol::Map,
-        source: &bun_ast::Source,
-        source_map_context: Option<js_printer::SourceMapHandler<'_>>,
+        ast: bun_ast::Ast<'b>,
+        symbols: bun_ast::symbol::Map<'b>,
+        source: &'b bun_ast::Source,
+        source_map_context: Option<js_printer::SourceMapHandler<'b>>,
         exports_kind: bun_ast::ExportsKind,
         runtime_transpiler_cache: Option<js_printer::RuntimeTranspilerCacheRef>,
         module_info: Option<*mut analyze_transpiled_module::ModuleInfo>,
-    ) -> Result<usize, bun_core::Error> {
+    ) -> Result<usize, bun_core::Error>
+    where
+        'a: 'b,
+    {
         // Spec transpiler.zig:662-663 — both set on this (EsmAscii) arm only.
         // SAFETY: `module_info` is `ModuleInfo::create`'s `heap::alloc` (or
         // null); it is exclusively owned by this print call until T6 reclaims

--- a/src/bundler/ungate_support.rs
+++ b/src/bundler/ungate_support.rs
@@ -477,32 +477,35 @@ pub mod bun_renamer {
     /// `renamer.Renamer` set late (`= undefined`); the Rust `Renamer<'r,'src>`
     /// enum has borrowed lifetimes that can't be stored in a 'static-ish
     /// struct, so this owns the boxed concrete renamer instead and produces a
-    /// borrowed `Renamer` view on demand. TODO(port): thread `'bump` once
-    /// Chunk gains a lifetime.
+    /// borrowed `Renamer` view on demand. `'a` is the [`crate::ArenaPool`]
+    /// lifetime (same as `Chunk<'a>` / `LinkerGraph<'a>`).
     #[derive(Default)]
-    pub enum ChunkRenamer {
+    pub enum ChunkRenamer<'a> {
         #[default]
         None,
-        Number(Box<bun_js_printer::renamer::NumberRenamer>),
-        Minify(Box<bun_js_printer::renamer::MinifyRenamer>),
+        Number(Box<bun_js_printer::renamer::NumberRenamer<'a>>),
+        Minify(Box<bun_js_printer::renamer::MinifyRenamer<'a>>),
     }
 
-    impl ChunkRenamer {
-        pub fn name_for_symbol(&mut self, ref_: bun_ast::Ref) -> &[u8] {
+    impl<'a> ChunkRenamer<'a> {
+        pub fn name_for_symbol(&self, ref_: bun_ast::Ref) -> &[u8] {
             match self {
                 ChunkRenamer::None => unreachable!("ChunkRenamer not initialized"),
                 ChunkRenamer::Number(r) => r.name_for_symbol(ref_),
                 ChunkRenamer::Minify(r) => r.name_for_symbol(ref_),
             }
         }
-        pub fn as_renamer(&mut self) -> bun_js_printer::renamer::Renamer<'_, '_> {
+        // `Renamer<'r,'src,'arena>` is covariant in `'arena` (holds `&'r`, not
+        // `&'r mut`), so the `'a → 'arena` shortening is a plain coercion.
+        pub fn as_renamer<'r, 'arena>(
+            &'r self,
+        ) -> bun_js_printer::renamer::Renamer<'r, 'r, 'arena>
+        where
+            'a: 'arena,
+        {
             match self {
                 ChunkRenamer::None => unreachable!("ChunkRenamer not initialized"),
                 ChunkRenamer::Number(r) => bun_js_printer::renamer::Renamer::NumberRenamer(r),
-                // PORT NOTE: `Renamer<'r,'src>` borrows the concrete renamer
-                // (`&'r mut MinifyRenamer`); `ChunkRenamer` owns the `Box`, so
-                // the deref-coerced `&mut **r` yields a per-call borrowed view
-                // exactly like the Zig tag+ptr union.
                 ChunkRenamer::Minify(r) => bun_js_printer::renamer::Renamer::MinifyRenamer(r),
             }
         }
@@ -525,12 +528,12 @@ pub mod html_import_manifest {
     /// literal body (`writePreQuotedString`). Chunk.rs uses this with
     /// `bun_core::fmt::count` for the counting pass.
     #[inline]
-    pub fn format_escaped_json<'a>(
+    pub fn format_escaped_json<'r, 'a>(
         index: u32,
-        graph: &'a Graph,
-        chunks: &'a [Chunk],
-        linker_graph: &'a LinkerGraph,
-    ) -> real::EscapedJson<'a> {
+        graph: &'r Graph<'a>,
+        chunks: &'r [Chunk<'a>],
+        linker_graph: &'r LinkerGraph<'a>,
+    ) -> real::EscapedJson<'r, 'a> {
         real::HTMLImportManifest {
             index,
             graph,
@@ -546,9 +549,9 @@ pub mod html_import_manifest {
     /// slice in place so it can recover `pos = before_len - cursor.len()`.
     pub fn write_escaped_json(
         index: u32,
-        graph: &Graph,
-        linker_graph: &LinkerGraph,
-        chunks: &[Chunk],
+        graph: &Graph<'_>,
+        linker_graph: &LinkerGraph<'_>,
+        chunks: &[Chunk<'_>],
         w: &mut &mut [u8],
     ) -> Result<(), core::fmt::Error> {
         let taken = core::mem::take(w);
@@ -598,14 +601,11 @@ pub use bun_js_printer::MangledProps;
 
 /// `js_ast.BundledAst` (the bundler-facing AST view).
 ///
-/// PORT NOTE: lifetime-erased to `'static`. `BundledAst<'arena>` borrows the
-/// per-file parse arena (`hashbang`/`url_for_css`/`export_star_import_records`
-/// slices). The bundler owns those arenas for the entire link (see
-/// `LinkerGraph.bump: *const Arena` "stays `'static`-ish" note); `JSAst` is
-/// stored in a `MultiArrayList` SoA inside `LinkerGraph`/`Graph`, neither of
-/// which carries a lifetime parameter yet. Pin to `'static` until Phase B
-/// threads `'bump` through `Chunk`/`LinkerGraph`/`LinkerContext`.
-pub type JSAst = crate::BundledAst<'static>;
+/// `'a` is the [`crate::ArenaPool`] lifetime — every per-worker parse arena
+/// and the bundler-thread arena are owned by the pool, which is
+/// stack-allocated in the bundle entry point alongside `Transpiler<'a>`, so
+/// `'a` unifies with the existing `BundleV2<'a>` lifetime.
+pub type JSAst<'a> = crate::BundledAst<'a>;
 pub(crate) use bun_ast::{Part, Ref, Symbol};
 
 /// `bundle_v2.zig:EntryPoint` — both a struct and (via the sibling module

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -36,7 +36,7 @@ pub struct Bunfig;
 
 /// Owned clone of an `EString` payload (transcoding UTF-16 → UTF-8 if needed).
 #[inline]
-fn estring_to_owned(s: &E::EString, bump: &Bump) -> Box<[u8]> {
+fn estring_to_owned(s: &E::EString<'_>, bump: &Bump) -> Box<[u8]> {
     Box::<[u8]>::from(s.string(bump).expect("OOM"))
 }
 
@@ -48,7 +48,7 @@ fn estring_to_owned(s: &E::EString, bump: &Bump) -> Box<[u8]> {
 /// into `ctx.debug.macros` without crossing the `bun_ast::Expr` /
 /// `StringArrayHashMap` newtype boundary that `bun_resolver`'s copy uses.
 fn parse_macros_json(
-    macros: &Expr,
+    macros: &Expr<'_>,
     log: &mut bun_ast::Log,
     json_source: &bun_ast::Source,
     bump: &Bump,
@@ -145,7 +145,7 @@ fn num_to_u32(n: f64) -> u32 {
 // ─────────────────────────────────────────────────────────────────────────────
 
 pub struct Parser<'a> {
-    json: Expr,
+    json: Expr<'a>,
     source: &'a bun_ast::Source,
     log: &'a mut bun_ast::Log,
     // PORT NOTE: Zig held both `bunfig: *api.TransformOptions` (= `&ctx.args`)
@@ -188,7 +188,7 @@ impl<'a> Parser<'a> {
         Err(err!("Invalid Bunfig"))
     }
 
-    pub fn expect_string(&mut self, expr: &Expr) -> Result<(), bun_core::Error> {
+    pub fn expect_string(&mut self, expr: &Expr<'_>) -> Result<(), bun_core::Error> {
         match &expr.data {
             ExprData::EString(_) => Ok(()),
             _ => self.add_error_format(
@@ -198,7 +198,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn apply_coverage_reporter_item(&mut self, item: &Expr) -> Result<(), bun_core::Error> {
+    fn apply_coverage_reporter_item(&mut self, item: &Expr<'_>) -> Result<(), bun_core::Error> {
         let item_str = item.as_string(self.bump).unwrap_or(b"");
         if item_str == b"text" {
             self.ctx.test_options.coverage.reporters.text = true;
@@ -216,7 +216,7 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
-    pub fn expect(&mut self, expr: &Expr, token: ExprTag) -> Result<(), bun_core::Error> {
+    pub fn expect(&mut self, expr: &Expr<'_>, token: ExprTag) -> Result<(), bun_core::Error> {
         if expr.data.tag() != token {
             return self.add_error_format(
                 expr.loc,
@@ -230,7 +230,7 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
-    fn load_log_level(&mut self, expr: &Expr) -> Result<(), bun_core::Error> {
+    fn load_log_level(&mut self, expr: &Expr<'_>) -> Result<(), bun_core::Error> {
         self.expect_string(expr)?;
         // PERF(port): Zig used strings.ExactSizeMatcher(8) — profile in Phase B
         let level = match expr.as_string(self.bump).unwrap_or(b"") {
@@ -249,7 +249,7 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
-    fn load_preload(&mut self, expr: &Expr) -> Result<(), bun_core::Error> {
+    fn load_preload(&mut self, expr: &Expr<'_>) -> Result<(), bun_core::Error> {
         match &expr.data {
             ExprData::EArray(array) => {
                 let items = array.items.slice();
@@ -280,7 +280,7 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
-    fn load_env_config(&mut self, expr: &Expr) -> Result<(), bun_core::Error> {
+    fn load_env_config(&mut self, expr: &Expr<'_>) -> Result<(), bun_core::Error> {
         match &expr.data {
             ExprData::ENull(_) => {
                 // env = null -> disable default .env files
@@ -321,7 +321,7 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
-    fn parse_define_map(&mut self, expr: &Expr) -> Result<api::StringMap, bun_core::Error> {
+    fn parse_define_map(&mut self, expr: &Expr<'_>) -> Result<api::StringMap, bun_core::Error> {
         self.expect(expr, ExprTag::EObject)?;
         let obj = expr.data.e_object().expect("infallible: variant checked");
         let properties = obj.properties.slice();
@@ -1193,7 +1193,7 @@ impl Bunfig {
 impl<'a> Parser<'a> {
     fn parse_registry_url_string(
         &mut self,
-        str: &E::EString,
+        str: &E::EString<'_>,
     ) -> Result<api::NpmRegistry, bun_core::Error> {
         // Dedup D009: body is the canonical port in `bun_api::npm_registry`.
         // The api `Parser` is generic over log/source and never reads them for
@@ -1208,7 +1208,7 @@ impl<'a> Parser<'a> {
 
     fn parse_registry_object(
         &mut self,
-        obj: &E::Object,
+        obj: &E::Object<'_>,
     ) -> Result<api::NpmRegistry, bun_core::Error> {
         let mut registry = api::NpmRegistry::default();
 
@@ -1244,7 +1244,7 @@ impl<'a> Parser<'a> {
         Ok(registry)
     }
 
-    fn parse_registry(&mut self, expr: &Expr) -> Result<api::NpmRegistry, bun_core::Error> {
+    fn parse_registry(&mut self, expr: &Expr<'_>) -> Result<api::NpmRegistry, bun_core::Error> {
         match &expr.data {
             ExprData::EString(s) => self.parse_registry_url_string(s),
             ExprData::EObject(o) => self.parse_registry_object(o),
@@ -1258,7 +1258,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_install(&mut self, install_obj: &Expr) -> Result<(), bun_core::Error> {
+    fn parse_install(&mut self, install_obj: &Expr<'_>) -> Result<(), bun_core::Error> {
         // PORT NOTE: Zig held `*BunInstall` and `*Parser` simultaneously.
         // The helper methods (`expect*`, `add_error`, `parse_registry`) take
         // `&mut self`, which under Stacked Borrows would invalidate any
@@ -1274,7 +1274,7 @@ impl<'a> Parser<'a> {
     fn parse_install_inner(
         &mut self,
         install: &mut api::BunInstall,
-        install_obj: &Expr,
+        install_obj: &Expr<'_>,
     ) -> Result<(), bun_core::Error> {
         if let Some(cafile) = install_obj.get(b"cafile") {
             install.cafile = match cafile.as_string(self.bump) {
@@ -1567,7 +1567,7 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
-    fn parse_serve_static(&mut self, serve_obj: &Expr) -> Result<(), bun_core::Error> {
+    fn parse_serve_static(&mut self, serve_obj: &Expr<'_>) -> Result<(), bun_core::Error> {
         if let Some(config_plugins) = serve_obj.get(b"plugins") {
             let plugins: Option<Vec<Box<[u8]>>> = 'plugins: {
                 if let ExprData::EArray(arr) = &config_plugins.data {

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -2357,13 +2357,13 @@ pub struct BundlerTailwindState {
 
 /// Additional data we don't want stored on the stylesheet
 #[derive(Default)]
-pub struct StylesheetExtra {
+pub struct StylesheetExtra<'arena> {
     /// Used when css modules is enabled
-    pub symbols: SymbolList,
+    pub symbols: SymbolList<'arena>,
 }
 
-pub struct ParserExtra {
-    pub symbols: SymbolList,
+pub struct ParserExtra<'arena> {
+    pub symbols: SymbolList<'arena>,
     pub local_scope: LocalScope,
     pub source_index: SrcIndex,
 }
@@ -2583,7 +2583,7 @@ mod stylesheet_impl {
             &mut self,
             arena: &Bump,
             options: &MinifyOptions,
-            extra: &StylesheetExtra,
+            extra: &StylesheetExtra<'_>,
         ) -> Maybe<(), Err<MinifyErrorKind>>
         where
             AtRule: for<'b> generic::DeepClone<'b>,
@@ -2772,7 +2772,7 @@ mod stylesheet_impl {
             options: ParserOptions<'static>,
             import_records: Option<&mut Vec<ImportRecord>>,
             source_index: SrcIndex,
-        ) -> Maybe<(StyleSheet<DefaultAtRule>, StylesheetExtra), Err<ParserError>> {
+        ) -> Maybe<(StyleSheet<DefaultAtRule>, StylesheetExtra<'static>), Err<ParserError>> {
             // PORT NOTE: Zig instantiated `StyleSheet(DefaultAtRule).parse`; Rust
             // cannot vary `Self`'s `AtRule` param against `DefaultAtRuleParser`, so
             // this returns the concrete `StyleSheet<DefaultAtRule>`. Callers that
@@ -2792,14 +2792,14 @@ mod stylesheet_impl {
         // TODO(port): `ParserOptions<'static>` matches the `StyleSheet.options`
         // field's `'static` erasure; re-threads to `<'bump>` alongside the rest of
         // the crate.
-        pub fn parse_with<P: CustomAtRuleParser<AtRule = AtRule>>(
-            arena: &'static Bump,
+        pub fn parse_with<'arena, P: CustomAtRuleParser<AtRule = AtRule>>(
+            arena: &'arena Bump,
             code: &[u8],
             options: ParserOptions<'static>,
             at_rule_parser: &mut P,
             import_records: Option<core::ptr::NonNull<Vec<ImportRecord>>>,
             source_index: SrcIndex,
-        ) -> Maybe<(Self, StylesheetExtra), Err<ParserError>> {
+        ) -> Maybe<(Self, StylesheetExtra<'arena>), Err<ParserError>> {
             // TODO(port): 'bump lifetime threading — every arena-backed slice the
             // parser hands back is currently detached to `'static` (matching the
             // crate-wide erasure on `DeclarationBlock<'static>`/`Token` payloads).
@@ -3121,13 +3121,13 @@ mod stylesheet_impl {
     }
 
     impl StyleSheet<BundlerAtRule> {
-        pub fn parse_bundler(
-            arena: &'static Bump,
+        pub fn parse_bundler<'arena>(
+            arena: &'arena Bump,
             code: &[u8],
             options: ParserOptions<'static>,
             import_records: &mut Vec<ImportRecord>,
             source_index: SrcIndex,
-        ) -> Maybe<(Self, StylesheetExtra), Err<ParserError>> {
+        ) -> Maybe<(Self, StylesheetExtra<'arena>), Err<ParserError>> {
             // PORT NOTE: Zig aliased `import_records` into both `BundlerAtRuleParser`
             // *and* the inner `Parser` (css_parser.zig:3245), and aliased `&options`
             // into the at-rule parser while also passing `options` by value (struct
@@ -3438,7 +3438,10 @@ pub struct Parser<'a> {
     /// derives its own `&mut` from the sibling raw pointer. Each access site
     /// materialises a fresh short-lived `&mut` instead.
     pub import_records: Option<core::ptr::NonNull<Vec<ImportRecord>>>,
-    pub extra: Option<&'a mut ParserExtra>,
+    // TODO(port): 'bump lifetime threading — `ParserExtra<'static>` matches the
+    // crate-wide Phase-A erasure (`arena: &'static Bump` on `parse_with`); a
+    // second `'arena` param on `Parser` re-threads alongside the rest in Phase B.
+    pub extra: Option<&'a mut ParserExtra<'static>>,
 }
 
 impl<'a> Parser<'a> {
@@ -3554,7 +3557,7 @@ impl<'a> Parser<'a> {
         input: &'a mut ParserInput<'a>,
         import_records: Option<core::ptr::NonNull<Vec<ImportRecord>>>,
         flags: ParserOpts,
-        extra: Option<&'a mut ParserExtra>,
+        extra: Option<&'a mut ParserExtra<'static>>,
     ) -> Parser<'a> {
         Parser {
             input,

--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -148,7 +148,7 @@ pub struct Printer<'a> {
     pub error_kind: Option<css::PrinterError>,
     pub import_info: Option<ImportInfo<'a>>,
     pub public_path: &'a [u8],
-    pub symbols: &'a SymbolMap,
+    pub symbols: &'a SymbolMap<'a>,
     pub local_names: Option<&'a css::LocalsResultsMap>,
     /// NOTE This should be the same mimalloc heap arena arena
     pub arena: &'a Bump,
@@ -272,7 +272,7 @@ impl<'a> Printer<'a> {
         options: PrinterOptions<'a>,
         import_info: Option<ImportInfo<'a>>,
         local_names: Option<&'a css::LocalsResultsMap>,
-        symbols: &'a SymbolMap,
+        symbols: &'a SymbolMap<'a>,
     ) -> Self {
         Printer {
             sources: None,
@@ -323,7 +323,7 @@ impl<'a> Printer<'a> {
         dest: &'a mut Vec<u8>,
         import_info: Option<ImportInfo<'a>>,
         local_names: Option<&'a css::LocalsResultsMap>,
-        symbols: &'a SymbolMap,
+        symbols: &'a SymbolMap<'a>,
     ) -> Self {
         Printer::new(
             arena,
@@ -875,6 +875,6 @@ const INDENTS_LEVELS: usize = 32;
 static INDENT_SPACES: [u8; INDENTS_LEVELS * 2] = [b' '; INDENTS_LEVELS * 2];
 
 // bun.ast.Symbol.Map — lives in bun_logger.
-type SymbolMap = bun_ast::symbol::Map;
+type SymbolMap<'arena> = bun_ast::symbol::Map<'arena>;
 
 // ported from: src/css/printer.zig

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -1061,7 +1061,7 @@ pub struct MinifyContext<'a, 'bump> {
     /// Pre-scanned `@custom-media` definitions, if the feature is enabled.
     pub custom_media:
         Option<bun_collections::ArrayHashMap<Box<[u8]>, custom_media::CustomMediaRule>>,
-    pub extra: &'a css::StylesheetExtra,
+    pub extra: &'a css::StylesheetExtra<'bump>,
     pub css_modules: bool,
     /// First minification error encountered (Zig surfaced this out-of-band).
     pub err: Option<css::error::MinifyError>,

--- a/src/css/values/ident.rs
+++ b/src/css/values/ident.rs
@@ -414,7 +414,7 @@ impl IdentOrRef {
             .map(|p| unsafe { crate::arena_str(&**p) })
     }
 
-    pub fn as_original_string(self, symbols: &bun_ast::symbol::List) -> &[u8] {
+    pub fn as_original_string<'a>(self, symbols: &'a bun_ast::symbol::List<'_>) -> &'a [u8] {
         if self.is_ident() {
             // SAFETY: arena slice reconstructed from packed ptr/len
             return unsafe { crate::arena_str(self.as_ident().unwrap().v) };

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -271,7 +271,7 @@ mod draft {
         pub opts: Options,
         pub source: Source,
         pub src: &'a [u8],
-        pub out: Expr,
+        pub out: Expr<'a>,
         pub logger: Log,
         pub arena: Arena,
         pub env: &'a mut DotEnvLoader<'a>,
@@ -294,14 +294,14 @@ mod draft {
     }
 
     enum PrepareResult<'bump> {
-        Value(Expr),
-        Section(&'bump mut Rope),
+        Value(Expr<'bump>),
+        Section(&'bump mut Rope<'bump>),
         Key(&'bump [u8]),
     }
 
     impl<'bump> PrepareResult<'bump> {
-        bun_core::enum_unwrap!(PrepareResult, Value   => into fn into_value   -> Expr);
-        bun_core::enum_unwrap!(PrepareResult, Section => into fn into_section -> &'bump mut Rope);
+        bun_core::enum_unwrap!(PrepareResult, Value   => into fn into_value   -> Expr<'bump>);
+        bun_core::enum_unwrap!(PrepareResult, Section => into fn into_section -> &'bump mut Rope<'bump>);
         bun_core::enum_unwrap!(PrepareResult, Key     => into fn into_key     -> &'bump [u8]);
     }
 
@@ -335,7 +335,7 @@ mod draft {
             // TODO(port): borrowck — `head` aliases into `self.out.data.e_object` while
             // `self` is also borrowed mutably for prepare_str(). Kept as raw `*mut`
             // (the underlying `E::Object` lives in the Expr Store, not on `self`).
-            let mut head: *mut E::Object = std::ptr::from_mut::<E::Object>(
+            let mut head: *mut E::Object<'a> = std::ptr::from_mut::<E::Object<'a>>(
                 self.out
                     .data
                     .e_object_mut()
@@ -384,7 +384,7 @@ mod draft {
                         let offset = i32::try_from(line.as_ptr() as usize - src.as_ptr() as usize)
                             .unwrap()
                             + 1;
-                        let section: &mut Rope = self
+                        let section: &mut Rope<'a> = self
                             .prepare_str(
                                 Usage::Section,
                                 bump,
@@ -439,7 +439,7 @@ mod draft {
                                 break 'treat_as_key;
                             }
                         };
-                        head = std::ptr::from_mut::<E::Object>(
+                        head = std::ptr::from_mut::<E::Object<'a>>(
                             parent_object
                                 .data
                                 .e_object_mut()
@@ -497,7 +497,7 @@ mod draft {
                     continue;
                 }
 
-                let value_raw: Expr = 'brk: {
+                let value_raw: Expr<'a> = 'brk: {
                     if let Some(eq_sign_idx) = maybe_eq_sign_idx {
                         if eq_sign_idx + 1 < line.len() {
                             break 'brk self
@@ -515,7 +515,7 @@ mod draft {
                     Expr::init(E::Boolean { value: true }, Loc::EMPTY)
                 };
 
-                let value: Expr = match &value_raw.data {
+                let value: Expr<'a> = match &value_raw.data {
                     ExprData::EString(s) => {
                         if s.data == b"true" {
                             Expr::init(E::Boolean { value: true }, Loc::EMPTY)
@@ -597,11 +597,15 @@ mod draft {
                     // PORTING.md §Allocators / `Parser::init` above). `val` is a
                     // sub-slice of `self.src` and outlives the temporary `Source`.
                     let val_s: &'static [u8] = val.into_str();
-                    let src = Source::init_path_string(self.source.path.text, val_s);
+                    // `parse_utf8_impl` ties its `'arena` to the `source` borrow;
+                    // allocate the `Source` in `bump` so the result is `Expr<'a>`
+                    // directly.
+                    let src: &'a Source =
+                        bump.alloc(Source::init_path_string(self.source.path.text, val_s));
                     let mut log = Log::init();
                     // Try to parse it and if it fails will just treat it as a string
-                    let json_val: Expr =
-                        match bun_parsers::json::parse_utf8_impl::<true>(&src, &mut log, bump) {
+                    let json_val: Expr<'a> =
+                        match bun_parsers::json::parse_utf8_impl::<true>(src, &mut log, bump) {
                             Ok(v) => Expr::from(v),
                             Err(_) => {
                                 // JSON parse failed (e.g., single-quoted string like '${VAR}')
@@ -697,7 +701,7 @@ mod draft {
 
                 // RopeT is *Rope when usage==Section, else unit. In Rust we just
                 // keep an Option<&mut Rope> and ignore it for non-section usages.
-                let mut rope: Option<&'a mut Rope> = None;
+                let mut rope: Option<&'a mut Rope<'a>> = None;
 
                 let mut i: usize = 0;
                 'walk: while i < val.len() {
@@ -1026,10 +1030,10 @@ mod draft {
             Ok(None)
         }
 
-        fn single_str_rope(ropealloc: &'a Arena, str_: &[u8]) -> OOM<&'a mut Rope> {
+        fn single_str_rope(ropealloc: &'a Arena, str_: &[u8]) -> OOM<&'a mut Rope<'a>> {
             let rope = ropealloc.alloc(Rope {
                 head: Expr::init(E::EString::init(str_), Loc::EMPTY),
-                next: ptr::null_mut(),
+                next: None,
             });
             Ok(rope)
         }
@@ -1039,7 +1043,7 @@ mod draft {
             bump: &'a Arena,
             ropealloc: &'a Arena,
             unesc: &mut ArenaVec<'a, u8>,
-            existing_rope: &mut Option<&'a mut Rope>,
+            existing_rope: &mut Option<&'a mut Rope<'a>>,
         ) -> OOM<()> {
             let _ = self; // autofix
             let slice = bump.alloc_slice_copy(&unesc[..]);
@@ -1047,32 +1051,29 @@ mod draft {
             if let Some(r) = existing_rope.as_deref_mut() {
                 let _ = r.append(expr, ropealloc)?;
             } else {
-                *existing_rope = Some(ropealloc.alloc(Rope {
-                    head: expr,
-                    next: ptr::null_mut(),
-                }));
+                *existing_rope = Some(ropealloc.alloc(Rope { head: expr, next: None }));
             }
             unesc.clear();
             Ok(())
         }
 
-        fn str_to_rope(ropealloc: &'a Arena, key: &[u8]) -> OOM<&'a mut Rope> {
+        fn str_to_rope(ropealloc: &'a Arena, key: &[u8]) -> OOM<&'a mut Rope<'a>> {
             let Some(mut dot_idx) = next_dot(key) else {
                 let rope = ropealloc.alloc(Rope {
                     head: Expr::init(E::EString::init(key), Loc::EMPTY),
-                    next: ptr::null_mut(),
+                    next: None,
                 });
                 return Ok(rope);
             };
-            let rope_head: &'a mut Rope = ropealloc.alloc(Rope {
+            let rope_head: &'a mut Rope<'a> = ropealloc.alloc(Rope {
                 head: Expr::init(E::EString::init(&key[..dot_idx]), Loc::EMPTY),
-                next: ptr::null_mut(),
+                next: None,
             });
             // SAFETY: `head` is the same allocation as `rope`'s initial value;
             // we walk `rope` forward via `append` while keeping `head` to return.
             // PORT NOTE: reshaped for borrowck — Zig holds two *Rope simultaneously.
-            let head: *mut Rope = std::ptr::from_mut::<Rope>(rope_head);
-            let mut rope: *mut Rope = head;
+            let head = ptr::NonNull::from(rope_head);
+            let mut rope = head;
 
             while dot_idx + 1 < key.len() {
                 let next_dot_idx = match next_dot(&key[dot_idx + 1..]) {
@@ -1080,21 +1081,21 @@ mod draft {
                     None => {
                         let rest = &key[dot_idx + 1..];
                         // SAFETY: `rope` points into a live bump allocation; no aliasing borrow.
-                        rope = unsafe { &mut *rope }
+                        rope = unsafe { &mut *rope.as_ptr() }
                             .append(Expr::init(E::EString::init(rest), Loc::EMPTY), ropealloc)?;
                         break;
                     }
                 };
                 let part = &key[dot_idx + 1..next_dot_idx];
                 // SAFETY: `rope` points into a live bump allocation; no aliasing borrow.
-                rope = unsafe { &mut *rope }
+                rope = unsafe { &mut *rope.as_ptr() }
                     .append(Expr::init(E::EString::init(part), Loc::EMPTY), ropealloc)?;
                 dot_idx = next_dot_idx;
             }
 
             let _ = rope;
             // SAFETY: head was created by ropealloc.alloc above and is still live in the bump.
-            Ok(unsafe { &mut *head })
+            Ok(unsafe { &mut *head.as_ptr() })
         }
     }
 
@@ -1105,7 +1106,7 @@ mod draft {
     // ──────────────────────────────────────────────────────────────────────────
 
     pub struct ToStringFormatter<'a> {
-        pub d: &'a ExprData,
+        pub d: &'a ExprData<'a>,
     }
 
     impl fmt::Display for ToStringFormatter<'_> {
@@ -1153,7 +1154,7 @@ mod draft {
     // ──────────────────────────────────────────────────────────────────────────
 
     pub struct ConfigIterator<'a> {
-        pub config: &'a E::Object,
+        pub config: &'a E::Object<'a>,
         pub source: &'a Source,
         pub log: &'a mut Log,
 
@@ -1221,7 +1222,7 @@ mod draft {
     // ──────────────────────────────────────────────────────────────────────────
 
     pub struct ScopeIterator<'a> {
-        pub config: &'a E::Object,
+        pub config: &'a E::Object<'a>,
         pub source: &'a Source,
         pub log: &'a mut Log,
 
@@ -1542,7 +1543,7 @@ mod draft {
 
         // SAFETY: `parser.out` is an `E::Object` produced by `Parser::parse`; the
         // arena pointee lives until `parser` drops at end of fn.
-        let out_obj: &E::Object = unsafe {
+        let out_obj: &E::Object<'_> = unsafe {
             &*parser
                 .out
                 .data
@@ -1830,7 +1831,7 @@ mod draft {
     /// overload lives here. The matcher construction is delegated to the shared
     /// `create_matcher` helper in `bun_install_types::NodeLinker`.
     fn pnpm_matcher_from_expr(
-        expr: &Expr,
+        expr: &Expr<'_>,
         log: &mut Log,
         source: &Source,
         bump: &Arena,
@@ -1848,7 +1849,7 @@ mod draft {
             ExprData::EString(s) => {
                 // SAFETY: arena-backed `EString::slice` mutates only its own
                 // resolved-data cache; the StoreRef pointee outlives this call.
-                let s_mut: &mut E::EString = unsafe { &mut *s.as_ptr() };
+                let s_mut: &mut E::EString<'_> = unsafe { &mut *s.as_ptr() };
                 let pattern = s_mut.slice(bump);
                 let matcher = match create_matcher(pattern, &mut buf) {
                     Ok(m) => m,

--- a/src/install/ConfigVersion.rs
+++ b/src/install/ConfigVersion.rs
@@ -13,7 +13,7 @@ pub enum ConfigVersion {
 impl ConfigVersion {
     pub const CURRENT: ConfigVersion = ConfigVersion::V1;
 
-    pub fn from_expr(expr: &Expr) -> Option<ConfigVersion> {
+    pub fn from_expr(expr: &Expr<'_>) -> Option<ConfigVersion> {
         let ExprData::ENumber(e_number) = &expr.data else {
             return None;
         };

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -50,7 +50,7 @@ fn leak_dup(bytes: &[u8]) -> &'static [u8] {
 /// `package.json` and would be discarded by Zig's bitwise `@memcpy` + arena
 /// reset anyway.
 #[inline]
-fn copy_property(p: &G::Property) -> G::Property {
+fn copy_property<'arena>(p: &G::Property<'arena>) -> G::Property<'arena> {
     G::Property {
         key: p.key,
         value: p.value,
@@ -60,7 +60,7 @@ fn copy_property(p: &G::Property) -> G::Property {
 
 pub fn edit_patched_dependencies(
     _manager: &mut PackageManager,
-    package_json: &mut Expr,
+    package_json: &mut Expr<'_>,
     patch_key: &[u8],
     patchfile_path: &[u8],
 ) -> Result<(), bun_alloc::AllocError> {
@@ -99,12 +99,12 @@ pub fn edit_patched_dependencies(
 }
 
 pub fn edit_trusted_dependencies(
-    package_json: &mut Expr,
+    package_json: &mut Expr<'_>,
     names_to_add: &mut [Box<[u8]>],
 ) -> Result<(), bun_alloc::AllocError> {
     let mut len = names_to_add.len();
 
-    let original_trusted_dependencies: Vec<Expr> = 'brk: {
+    let original_trusted_dependencies: Vec<Expr<'_>> = 'brk: {
         if let Some(query) = package_json.as_property(TRUSTED_DEPENDENCIES_STRING) {
             if let bun_ast::ExprData::EArray(arr) = &query.expr.data {
                 break 'brk arr.items.slice().to_vec();
@@ -126,7 +126,7 @@ pub fn edit_trusted_dependencies(
         }
     }
 
-    let mut trusted_dependencies: &[Expr] = &[];
+    let mut trusted_dependencies: &[Expr<'_>] = &[];
     if let Some(query) = package_json.as_property(TRUSTED_DEPENDENCIES_STRING) {
         if let bun_ast::ExprData::EArray(arr) = &query.expr.data {
             // SAFETY: `arr` is a `StoreRef` into the AST arena which outlives
@@ -136,7 +136,7 @@ pub fn edit_trusted_dependencies(
     }
 
     let trusted_dependencies_to_add = len;
-    let new_trusted_deps: js_ast::ExprNodeList = {
+    let new_trusted_deps: js_ast::ExprNodeList<'_> = {
         let mut deps = vec![Expr::EMPTY; trusted_dependencies.len() + trusted_dependencies_to_add]
             .into_boxed_slice();
         deps[0..trusted_dependencies.len()].copy_from_slice(trusted_dependencies);
@@ -173,7 +173,7 @@ pub fn edit_trusted_dependencies(
     };
 
     let mut needs_new_trusted_dependencies_list = true;
-    let mut trusted_dependencies_array: Expr = 'brk: {
+    let mut trusted_dependencies_array: Expr<'_> = 'brk: {
         if let Some(query) = package_json.as_property(TRUSTED_DEPENDENCIES_STRING) {
             if matches!(query.expr.data, bun_ast::ExprData::EArray(_)) {
                 needs_new_trusted_dependencies_list = false;
@@ -208,7 +208,7 @@ pub fn edit_trusted_dependencies(
             .len_u32()
             == 0
     {
-        let mut root_properties: Vec<G::Property> = Vec::with_capacity(1);
+        let mut root_properties: Vec<G::Property<'_>> = Vec::with_capacity(1);
         root_properties.push(G::Property {
             key: Some(Expr::init(
                 E::EString::init(TRUSTED_DEPENDENCIES_STRING),
@@ -231,7 +231,7 @@ pub fn edit_trusted_dependencies(
             .e_object()
             .expect("infallible: variant checked");
         let old_props = obj.properties.slice();
-        let mut root_properties: Vec<G::Property> = Vec::with_capacity(old_props.len() + 1);
+        let mut root_properties: Vec<G::Property<'_>> = Vec::with_capacity(old_props.len() + 1);
         for p in old_props {
             root_properties.push(copy_property(p));
         }
@@ -259,7 +259,7 @@ pub fn edit_trusted_dependencies(
 /// versions.
 pub fn edit_update_no_args(
     manager: &mut PackageManager,
-    current_package_json: &mut Expr,
+    current_package_json: &mut Expr<'_>,
     options: EditOptions,
 ) -> Result<(), bun_alloc::AllocError> {
     // using data store is going to result in undefined memory issues as
@@ -553,7 +553,7 @@ pub fn edit(
     manager: &mut PackageManager,
     // Zig `*[]UpdateRequest` — pointer-to-slice whose `.len` is shrunk in place.
     updates: &mut &mut [UpdateRequest],
-    current_package_json: &mut Expr,
+    current_package_json: &mut Expr<'_>,
     dependency_list: &[u8],
     options: EditOptions,
 ) -> Result<(), bun_alloc::AllocError> {
@@ -578,7 +578,7 @@ pub fn edit(
     // 3. There is a "dependencies" (or equivalent list), and the package name exists in multiple lists
     // Try to use the existing spot in the dependencies list if possible
     {
-        let original_trusted_dependencies: Vec<Expr> = 'brk: {
+        let original_trusted_dependencies: Vec<Expr<'_>> = 'brk: {
             if !options.add_trusted_dependencies {
                 break 'brk Vec::new();
             }
@@ -703,7 +703,8 @@ pub fn edit(
                                                     .data
                                                     .e_string()
                                                     .expect("infallible: variant checked")
-                                                    .as_ptr(),
+                                                    .as_ptr()
+                                                    .cast(),
                                             );
                                             remaining -= 1;
                                         } else {
@@ -742,7 +743,8 @@ pub fn edit(
                                                         v.data
                                                             .e_string()
                                                             .expect("infallible: variant checked")
-                                                            .as_ptr(),
+                                                            .as_ptr()
+                                                            .cast(),
                                                     );
                                                     remaining -= 1;
                                                     break 'dependency_group;
@@ -761,8 +763,8 @@ pub fn edit(
     }
 
     if remaining != 0 {
-        let mut new_dependencies: Vec<G::Property> = {
-            let mut dependencies: Vec<G::Property> = Vec::new();
+        let mut new_dependencies: Vec<G::Property<'_>> = {
+            let mut dependencies: Vec<G::Property<'_>> = Vec::new();
             if let Some(query) = current_package_json.as_property(dependency_list) {
                 if let bun_ast::ExprData::EObject(obj) = &query.expr.data {
                     for p in obj.properties.slice() {
@@ -777,7 +779,7 @@ pub fn edit(
             dependencies
         };
 
-        let mut trusted_dependencies: &[Expr] = &[];
+        let mut trusted_dependencies: &[Expr<'_>] = &[];
         if options.add_trusted_dependencies {
             if let Some(query) = current_package_json.as_property(TRUSTED_DEPENDENCIES_STRING) {
                 if let bun_ast::ExprData::EArray(arr) = &query.expr.data {
@@ -788,7 +790,7 @@ pub fn edit(
         }
 
         let trusted_dependencies_to_add = manager.trusted_deps_to_add_to_package_json.len();
-        let new_trusted_deps: js_ast::ExprNodeList = 'brk: {
+        let new_trusted_deps: js_ast::ExprNodeList<'_> = 'brk: {
             if !options.add_trusted_dependencies || trusted_dependencies_to_add == 0 {
                 break 'brk bun_alloc::AstAlloc::vec();
             }
@@ -882,7 +884,8 @@ pub fn edit(
                         .data
                         .e_string()
                         .unwrap()
-                        .as_ptr(),
+                        .as_ptr()
+                        .cast(),
                 );
                 break;
             }
@@ -896,7 +899,7 @@ pub fn edit(
         }
 
         let mut needs_new_dependency_list = true;
-        let mut dependencies_object: Expr = 'brk: {
+        let mut dependencies_object: Expr<'_> = 'brk: {
             if let Some(query) = current_package_json.as_property(dependency_list) {
                 if matches!(query.expr.data, bun_ast::ExprData::EObject(_)) {
                     needs_new_dependency_list = false;
@@ -926,7 +929,7 @@ pub fn edit(
         }
 
         let mut needs_new_trusted_dependencies_list = true;
-        let mut trusted_dependencies_array: Expr = 'brk: {
+        let mut trusted_dependencies_array: Expr<'_> = 'brk: {
             if !options.add_trusted_dependencies || trusted_dependencies_to_add == 0 {
                 needs_new_trusted_dependencies_list = false;
                 break 'brk Expr::EMPTY;
@@ -973,7 +976,7 @@ pub fn edit(
             } else {
                 1
             };
-            let mut root_properties: Vec<G::Property> = Vec::with_capacity(n);
+            let mut root_properties: Vec<G::Property<'_>> = Vec::with_capacity(n);
             root_properties.push(G::Property {
                 key: Some(Expr::allocate(
                     arena,
@@ -1011,7 +1014,7 @@ pub fn edit(
                     .e_object()
                     .expect("infallible: variant checked");
                 let old_props = obj.properties.slice();
-                let mut root_properties: Vec<G::Property> = Vec::with_capacity(old_props.len() + 2);
+                let mut root_properties: Vec<G::Property<'_>> = Vec::with_capacity(old_props.len() + 2);
                 for p in old_props {
                     root_properties.push(copy_property(p));
                 }
@@ -1047,7 +1050,7 @@ pub fn edit(
                     .e_object()
                     .expect("infallible: variant checked");
                 let old_props = obj.properties.slice();
-                let mut root_properties: Vec<G::Property> = Vec::with_capacity(old_props.len() + 1);
+                let mut root_properties: Vec<G::Property<'_>> = Vec::with_capacity(old_props.len() + 1);
                 for p in old_props {
                     root_properties.push(copy_property(p));
                 }

--- a/src/install/PackageManager/UpdateRequest.rs
+++ b/src/install/PackageManager/UpdateRequest.rs
@@ -34,7 +34,9 @@ pub struct UpdateRequest {
     pub failed: bool,
     /// This must be cloned to handle when the AST store resets
     // TODO(port): lifetime — ARENA-owned (AST Expr.Data store); raw ptr per LIFETIMES.tsv
-    pub e_string: Option<*mut js_ast::E::String>,
+    // TRANSITIONAL: raw ptr to arena-backed node; `'static` until `'arena`
+    // is threaded through `UpdateRequest`'s owners.
+    pub e_string: Option<*mut js_ast::E::String<'static>>,
 }
 
 impl Default for UpdateRequest {

--- a/src/install/PackageManager/WorkspacePackageJSONCache.rs
+++ b/src/install/PackageManager/WorkspacePackageJSONCache.rs
@@ -20,8 +20,20 @@ use bun_paths::is_absolute;
 use crate::bun_json as json;
 use crate::initialize_store;
 
+/// TRANSITIONAL: erase `'arena` on an `Expr` that is about to be stored
+/// alongside its owning `Arena` in the same struct (self-referential). The
+/// arena's heap pages do not move when the `Arena` value is moved, so the
+/// pointers remain valid; rustc just cannot express the sibling-borrow.
+#[inline(always)]
+unsafe fn erase_expr_arena<'a>(e: Expr<'a>) -> Expr<'static> {
+    unsafe { core::mem::transmute::<Expr<'a>, Expr<'static>>(e) }
+}
+
 pub struct MapEntry {
-    pub root: Expr,
+    // TRANSITIONAL: `root` borrows from `json_arena` (self-referential). The
+    // proper `'arena` cannot name a sibling field, so erase to `'static` until
+    // the cache is restructured (e.g. ouroboros / arena handle).
+    pub root: Expr<'static>,
     pub source: Source,
     pub indentation: Indentation,
     /// Owns the path bytes that `source.path.{text,pretty,name.*}` borrow.
@@ -63,8 +75,12 @@ impl MapEntry {
     /// invokes this to restore the invariant `root == parse(source)`.
     pub fn reparse_root(&mut self, log: &mut Log) -> Result<(), Error> {
         let json_bump = bun_alloc::Arena::new();
-        let parsed = parse_package_json(&self.source, log, &json_bump, false)?;
-        self.root = bun_core::handle_oom(parsed.root.deep_clone(&json_bump));
+        let root = {
+            let parsed = parse_package_json(&self.source, log, &json_bump, false)?;
+            // SAFETY: `root` is stored alongside `json_bump` below; see `erase_expr_arena`.
+            unsafe { erase_expr_arena(bun_core::handle_oom(parsed.root.deep_clone(&json_bump))) }
+        };
+        self.root = root;
         self.json_arena = json_bump;
         Ok(())
     }
@@ -79,12 +95,12 @@ pub type Map = StringHashMap<MapEntry>;
 // to runtime), so dispatch on that one bool here and keep the rest fixed to
 // match the Zig call sites (.is_json/.allow_comments/.allow_trailing_commas
 // = true, others default false).
-fn parse_package_json(
-    source: &Source,
+fn parse_package_json<'arena>(
+    source: &'arena Source,
     log: &mut Log,
-    bump: &bun_alloc::Arena,
+    bump: &'arena bun_alloc::Arena,
     guess_indentation: bool,
-) -> Result<json::JsonResult, bun_core::Error> {
+) -> Result<json::JsonResult<'arena>, bun_core::Error> {
     if guess_indentation {
         json::parse_package_json_utf8_with_opts::<
             true,  // IS_JSON
@@ -203,18 +219,24 @@ impl WorkspacePackageJSONCache {
         }
 
         let json_bump = bun_alloc::Arena::new();
-        let parsed = match parse_package_json(&source, log, &json_bump, opts.guess_indentation) {
-            Ok(p) => p,
-            Err(err) => {
-                // Zig: `bun.handleErrorReturnTrace(err, @errorReturnTrace())` — no Rust equivalent.
-                return GetResult::ParseErr(err);
-            }
+        let (root, indentation) = {
+            let parsed = match parse_package_json(&source, log, &json_bump, opts.guess_indentation) {
+                Ok(p) => p,
+                Err(err) => {
+                    // Zig: `bun.handleErrorReturnTrace(err, @errorReturnTrace())` — no Rust equivalent.
+                    return GetResult::ParseErr(err);
+                }
+            };
+            // SAFETY: `root` is stored alongside `json_bump` below; see `erase_expr_arena`.
+            let root =
+                unsafe { erase_expr_arena(bun_core::handle_oom(parsed.root.deep_clone(&json_bump))) };
+            (root, parsed.indentation)
         };
 
         let value = MapEntry {
-            root: bun_core::handle_oom(parsed.root.deep_clone(&json_bump)),
+            root,
             source,
-            indentation: parsed.indentation,
+            indentation,
             // `source.path` borrows this allocation; the `Box<[u8]>` heap
             // address is stable across the move into the map.
             path_storage: key,
@@ -260,17 +282,23 @@ impl WorkspacePackageJSONCache {
         }
 
         let json_bump = bun_alloc::Arena::new();
-        let parsed = match parse_package_json(source, log, &json_bump, opts.guess_indentation) {
-            Ok(p) => p,
-            Err(err) => {
-                return GetResult::ParseErr(err);
-            }
+        let (root, indentation) = {
+            let parsed = match parse_package_json(source, log, &json_bump, opts.guess_indentation) {
+                Ok(p) => p,
+                Err(err) => {
+                    return GetResult::ParseErr(err);
+                }
+            };
+            // SAFETY: `root` is stored alongside `json_bump` below; see `erase_expr_arena`.
+            let root =
+                unsafe { erase_expr_arena(bun_core::handle_oom(parsed.root.deep_clone(&json_bump))) };
+            (root, parsed.indentation)
         };
 
         let value = MapEntry {
-            root: bun_core::handle_oom(parsed.root.deep_clone(&json_bump)),
+            root,
             source: source.clone(),
-            indentation: parsed.indentation,
+            indentation,
             path_storage: bun_core::ZBox::default(),
             json_arena: json_bump,
         };

--- a/src/install/PackageManager/processDependencyList.rs
+++ b/src/install/PackageManager/processDependencyList.rs
@@ -43,14 +43,14 @@ impl<'a> ResolverContext for GitResolver<'a> {
         true
     }
 
-    fn count(&mut self, builder: &mut StringBuilder<'_>, _json: &Expr) {
+    fn count(&mut self, builder: &mut StringBuilder<'_>, _json: &Expr<'_>) {
         builder.count(self.resolved);
     }
 
     fn resolve(
         &mut self,
         builder: &mut StringBuilder<'_>,
-        _json: &Expr,
+        _json: &Expr<'_>,
     ) -> Result<ResolutionType<u64>, bun_core::Error> {
         // Zig: `var resolution = this.resolution.*;
         //       resolution.value.github.resolved = builder.append(String, this.resolved);`
@@ -100,14 +100,14 @@ impl<'a> ResolverContext for TarballResolver<'a> {
         true
     }
 
-    fn count(&mut self, builder: &mut StringBuilder<'_>, _json: &Expr) {
+    fn count(&mut self, builder: &mut StringBuilder<'_>, _json: &Expr<'_>) {
         builder.count(self.url);
     }
 
     fn resolve(
         &mut self,
         builder: &mut StringBuilder<'_>,
-        _json: &Expr,
+        _json: &Expr<'_>,
     ) -> Result<ResolutionType<u64>, bun_core::Error> {
         Ok(ResolutionType::<u64>::init(match self.resolution.tag {
             ResolutionTag::LocalTarball => {

--- a/src/install/PackageManager/security_scanner.rs
+++ b/src/install/PackageManager/security_scanner.rs
@@ -1860,7 +1860,7 @@ impl<'a> SecurityScanSubprocess<'a> {
 
 fn parse_security_advisories_from_expr(
     manager: &PackageManager,
-    advisories_expr: Expr,
+    advisories_expr: Expr<'_>,
     bump: &bun_alloc::Arena,
     package_paths: &mut ArrayHashMap<PackageID, PackagePath>,
 ) -> Result<Box<[SecurityAdvisory]>, Error> {

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -172,7 +172,7 @@ fn update_package_json_and_install_with_manager_with_updates(
     // is taken across this borrow; `PackageJSONEditor` and `do_patch_commit` touch only
     // disjoint manager fields.
     let current_package_json: &mut MapEntry = unsafe { &mut *current_package_json_ptr };
-    let mut current_package_json_root: bun_ast::Expr = current_package_json.root.into();
+    let mut current_package_json_root: bun_ast::Expr<'_> = current_package_json.root.into();
     let current_package_json_indent = current_package_json.indentation;
 
     // If there originally was a newline at the end of their package.json, preserve it
@@ -489,7 +489,7 @@ fn update_package_json_and_install_with_manager_with_updates(
         if let Some(stuff) = &not_in_workspace_root {
             // PORT NOTE (layering): see `current_package_json_root` above — promote
             // T2 → T4 for `PackageJSONEditor` / `print_json`.
-            let mut root_package_json_root: bun_ast::Expr = root_package_json.root.into();
+            let mut root_package_json_root: bun_ast::Expr<'_> = root_package_json.root.into();
             PackageJSONEditor::edit_patched_dependencies(
                 manager,
                 &mut root_package_json_root,
@@ -561,7 +561,7 @@ fn update_package_json_and_install_with_manager_with_updates(
         // Now, we _re_ parse our in-memory edited package.json
         // so we can commit the version we changed from the lockfile
         let json_arena = bun_alloc::Arena::new();
-        let mut new_package_json: bun_ast::Expr =
+        let mut new_package_json: bun_ast::Expr<'_> =
             match json::parse_package_json_utf8(&source, manager.log_mut(), &json_arena) {
                 Ok(v) => v.into(),
                 Err(err) => {

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -200,7 +200,7 @@ impl Bin {
 
     /// Used for packages read from text lockfile / pnpm migration.
     pub fn parse_append(
-        bin_expr: &Expr,
+        bin_expr: &Expr<'_>,
         buf: &mut bun_semver::string::Buf,
         extern_strings: &mut Vec<ExternalString>,
     ) -> Result<Bin, AllocError> {
@@ -290,7 +290,7 @@ impl Bin {
     }
 
     pub fn parse_append_from_directories(
-        bin_expr: &Expr,
+        bin_expr: &Expr<'_>,
         buf: &mut bun_semver::string::Buf,
     ) -> Result<Bin, AllocError> {
         if let Some(bin_str) = bin_expr.as_utf8_string_literal() {

--- a/src/install/lockfile/CatalogMap.rs
+++ b/src/install/lockfile/CatalogMap.rs
@@ -113,7 +113,7 @@ impl CatalogMap {
     // PORT NOTE: Zig took `lockfile: *Lockfile` only for `.allocator` (dropped
     // per global-mimalloc rule). Removing it lets `lockfile.catalogs.parse_count`
     // call sites avoid the `&mut self` vs `&mut Lockfile` self-alias.
-    pub fn parse_count(&mut self, expr: Expr, builder: &mut StringBuilder) {
+    pub fn parse_count(&mut self, expr: Expr<'_>, builder: &mut StringBuilder) {
         if let Some(default_catalog) = expr.get(b"catalog") {
             if let ExprData::EObject(obj) = &default_catalog.data {
                 for item in obj.properties.slice() {
@@ -175,7 +175,7 @@ impl CatalogMap {
         pm: &mut PackageManager,
         log: &mut Log,
         source: &Source,
-        expr: Expr,
+        expr: Expr<'_>,
         builder: &mut StringBuilder,
     ) -> Result<bool, AllocError> {
         let mut found_any = false;
@@ -309,7 +309,7 @@ impl CatalogMap {
     pub fn from_pnpm_lockfile(
         catalogs: &mut CatalogMap,
         log: &mut Log,
-        catalogs_obj: &mut E::Object,
+        catalogs_obj: &mut E::Object<'_>,
         string_buf: &mut StringBuf,
     ) -> Result<(), FromPnpmLockfileError> {
         for prop in catalogs_obj.properties.slice() {
@@ -471,7 +471,7 @@ bun_core::named_error_set!(FromPnpmLockfileError);
 fn put_entries_from_pnpm_lockfile(
     catalog_map: &mut Map,
     log: &mut Log,
-    entries_obj: &E::Object,
+    entries_obj: &E::Object<'_>,
     string_buf: &mut StringBuf,
 ) -> Result<(), FromPnpmLockfileError> {
     for entry_prop in entries_obj.properties.slice() {

--- a/src/install/lockfile/OverrideMap.rs
+++ b/src/install/lockfile/OverrideMap.rs
@@ -92,7 +92,7 @@ impl OverrideMap {
     // (string transcode); JSON strings are already UTF-8 here, so the parameter
     // is dropped — also avoids the `&mut lockfile.overrides` / `&mut lockfile`
     // alias at the only call site.
-    pub fn parse_count(&mut self, expr: Expr, builder: &mut StringBuilder) {
+    pub fn parse_count(&mut self, expr: Expr<'_>, builder: &mut StringBuilder) {
         if let Some(overrides) = expr.as_property(b"overrides") {
             let ExprData::EObject(obj) = &overrides.expr.data else {
                 return;
@@ -167,7 +167,7 @@ impl OverrideMap {
         root_package: &Package,
         log: &mut bun_ast::Log,
         json_source: &bun_ast::Source,
-        expr: Expr,
+        expr: Expr<'_>,
         builder: &mut StringBuilder,
     ) -> Result<(), Error> {
         debug_assert!(self.map.count() == 0); // only call parse once
@@ -204,7 +204,7 @@ impl OverrideMap {
         root_package: &Package,
         source: &bun_ast::Source,
         log: &mut bun_ast::Log,
-        expr: Expr,
+        expr: Expr<'_>,
         builder: &mut StringBuilder,
     ) -> Result<(), Error> {
         let ExprData::EObject(obj) = &expr.data else {
@@ -235,7 +235,7 @@ impl OverrideMap {
 
             let name_hash = SemverBuilder::string_hash(k);
 
-            let value: Expr = 'value: {
+            let value: Expr<'_> = 'value: {
                 // for one level deep, we will only support a string and  { ".": value }
                 let value_expr = prop.value.as_ref().expect("infallible: prop has value");
                 if value_expr.data.is_e_string() {
@@ -321,7 +321,7 @@ impl OverrideMap {
         root_package: &Package,
         source: &bun_ast::Source,
         log: &mut bun_ast::Log,
-        expr: Expr,
+        expr: Expr<'_>,
         builder: &mut StringBuilder,
     ) -> Result<(), Error> {
         let ExprData::EObject(obj) = &expr.data else {

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -52,7 +52,7 @@ bun_output::declare_scope!(Lockfile, hidden);
 trait ExprStr {
     fn as_utf8<'b>(&self, bump: &'b bun_alloc::Arena) -> Option<&'b [u8]>;
 }
-impl ExprStr for Expr {
+impl<'arena> ExprStr for Expr<'arena> {
     // Zig `Expr.asString` (expr.zig:477) — transparently transcodes UTF-16
     // `EString`s. The earlier `is_utf8()` guard returned `None` for keys the
     // lexer stored as UTF-16 (e.g. `\u`-escaped non-ASCII), tripping the
@@ -139,7 +139,7 @@ pub trait ResolverContext {
 
     /// Zig: `resolver.count(builder, json)` — counts strings to be appended by
     /// `resolve`. Default no-op for void/folder resolvers that don't need it.
-    fn count(&mut self, _builder: &mut StringBuilder<'_>, _json: &Expr) {}
+    fn count(&mut self, _builder: &mut StringBuilder<'_>, _json: &Expr<'_>) {}
 
     /// Zig: `resolver.resolve(builder, json)` — produces the package's
     /// `Resolution`. Only called when `!IS_VOID`.
@@ -156,7 +156,7 @@ pub trait ResolverContext {
     fn resolve(
         &mut self,
         builder: &mut StringBuilder<'_>,
-        json: &Expr,
+        json: &Expr<'_>,
     ) -> Result<ResolutionType<u64>, bun_core::Error>;
 
     // ── GitResolver-only surface ────────────────────────────────────────────
@@ -197,7 +197,7 @@ impl ResolverContext for () {
     fn resolve(
         &mut self,
         _builder: &mut StringBuilder<'_>,
-        _json: &Expr,
+        _json: &Expr<'_>,
     ) -> Result<ResolutionType<u64>, bun_core::Error> {
         // Zig: `if (comptime ResolverContext != void) { … }` — the void
         // resolver never assigned `package.resolution`, so it kept its
@@ -224,11 +224,11 @@ pub trait ResolverContextDyn {
     fn is_git(&self) -> bool;
     fn check_bundled_dependencies(&self) -> bool;
 
-    fn count(&mut self, builder: &mut StringBuilder<'_>, json: &Expr);
+    fn count(&mut self, builder: &mut StringBuilder<'_>, json: &Expr<'_>);
     fn resolve(
         &mut self,
         builder: &mut StringBuilder<'_>,
-        json: &Expr,
+        json: &Expr<'_>,
     ) -> Result<ResolutionType<u64>, bun_core::Error>;
 
     fn resolution(&self) -> &ResolutionType<u64>;
@@ -253,14 +253,14 @@ impl<R: ResolverContext> ResolverContextDyn for R {
     }
 
     #[inline]
-    fn count(&mut self, builder: &mut StringBuilder<'_>, json: &Expr) {
+    fn count(&mut self, builder: &mut StringBuilder<'_>, json: &Expr<'_>) {
         ResolverContext::count(self, builder, json)
     }
     #[inline]
     fn resolve(
         &mut self,
         builder: &mut StringBuilder<'_>,
-        json: &Expr,
+        json: &Expr<'_>,
     ) -> Result<ResolutionType<u64>, bun_core::Error> {
         ResolverContext::resolve(self, builder, json)
     }
@@ -1466,7 +1466,7 @@ impl Diff {
                         // `&mut pm` reborrow below doesn't conflict. The entry
                         // lives in a `StringHashMap` whose backing storage is
                         // not touched by `parse_with_json`.
-                        let (source_ref, json_root): (bun_ptr::ParentRef<bun_ast::Source>, Expr) =
+                        let (source_ref, json_root): (bun_ptr::ParentRef<bun_ast::Source>, Expr<'_>) =
                             match pm
                                 .workspace_package_json_cache
                                 .get_with_path(
@@ -2095,7 +2095,7 @@ impl Package<u64> {
         pm: &mut PackageManager,
         log: &mut bun_ast::Log,
         source: &bun_ast::Source,
-        json: Expr,
+        json: Expr<'_>,
         resolver: &mut R,
         features: Features,
     ) -> Result<(), bun_core::Error> {
@@ -2112,7 +2112,7 @@ impl Package<u64> {
         pm: &mut PackageManager,
         log: &mut bun_ast::Log,
         source: &bun_ast::Source,
-        json: Expr,
+        json: Expr<'_>,
         resolver: &mut dyn ResolverContextDyn,
         features: Features,
     ) -> Result<(), bun_core::Error> {

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -266,7 +266,7 @@ impl Scripts {
     // so both `lockfile_real::StringBuilder` and `bun_semver::semver_string::Builder`
     // are accepted (both impl the trait).
     // PORT NOTE: `json` is `Copy` (matches Zig by-value `Expr`).
-    pub fn parse_count<B: bun_semver::StringBuilder>(builder: &mut B, json: Expr) {
+    pub fn parse_count<B: bun_semver::StringBuilder>(builder: &mut B, json: Expr<'_>) {
         if let Some(scripts_prop) = json.as_property(b"scripts") {
             if scripts_prop.expr.is_object() {
                 for script_name in LockfileScripts::NAMES {
@@ -284,7 +284,7 @@ impl Scripts {
         }
     }
 
-    pub fn parse_alloc<B: bun_semver::StringBuilder>(&mut self, builder: &mut B, json: Expr) {
+    pub fn parse_alloc<B: bun_semver::StringBuilder>(&mut self, builder: &mut B, json: Expr<'_>) {
         if let Some(scripts_prop) = json.as_property(b"scripts") {
             if scripts_prop.expr.is_object() {
                 let dsts = self.hooks_mut();
@@ -359,14 +359,15 @@ impl Scripts {
         // source bytes outlive the parsed `Expr` (which may borrow them).
         let bump = bun_alloc::Arena::new();
         let json_buf;
-        let json: Expr = {
+        let json_src;
+        let json: Expr<'_> = {
             // `defer save.restore()` — `save()` returns an RAII guard that
             // restores the path length on Drop and derefs to the path.
             let mut save = folder_path.save();
             let _ = save.append(b"package.json"); // OOM/capacity: Zig aborts; port keeps fire-and-forget
 
             json_buf = bun_sys::File::read_from(Fd::cwd(), save.slice_z())?;
-            let json_src = bun_ast::Source::init_path_string(save.slice(), json_buf.as_slice());
+            json_src = bun_ast::Source::init_path_string(save.slice(), json_buf.as_slice());
 
             initialize_store();
             bun_json::parse_package_json_utf8(&json_src, log, &bump)?

--- a/src/install/lockfile/Package/WorkspaceMap.rs
+++ b/src/install/lockfile/Package/WorkspaceMap.rs
@@ -138,7 +138,7 @@ impl WorkspaceMap {
         &mut self,
         json_cache: &mut WorkspacePackageJSONCache,
         log: &mut bun_ast::Log,
-        arr: &js_ast::E::Array,
+        arr: &js_ast::E::Array<'_>,
         source: &bun_ast::Source,
         loc: bun_ast::Loc,
         mut string_builder: Option<&mut StringBuilder<'_>>,

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -1461,7 +1461,7 @@ impl<T> PkgMap<T> {
 
 pub fn parse_into_binary_lockfile(
     lockfile: &mut BinaryLockfile,
-    root: JSON::Expr,
+    root: JSON::Expr<'_>,
     source: &bun_ast::Source,
     log: &mut bun_ast::Log,
     mut manager: Option<&mut PackageManager>,
@@ -1885,7 +1885,7 @@ pub fn parse_into_binary_lockfile(
         return Err(ParseError::InvalidWorkspaceObject);
     };
 
-    let mut maybe_root_pkg: Option<Expr> = None;
+    let mut maybe_root_pkg: Option<Expr<'_>> = None;
 
     for prop in workspaces_obj
         .data
@@ -1895,7 +1895,7 @@ pub fn parse_into_binary_lockfile(
         .slice()
     {
         let key = prop.key.expect("infallible: prop has key");
-        let value: Expr = prop.value.expect("infallible: prop has value");
+        let value: Expr<'_> = prop.value.expect("infallible: prop has value");
         if !key.is_string() {
             log.add_error(Some(source), key.loc, b"Expected a string");
             return Err(ParseError::InvalidWorkspaceObject);
@@ -2860,14 +2860,14 @@ fn dependency_resolution_failure(
 // and `workspace_paths`.
 fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>(
     lockfile: &mut BinaryLockfile,
-    obj: &Expr,
+    obj: &Expr<'_>,
     log: &mut bun_ast::Log,
     source: &bun_ast::Source,
     optional_peers_buf: &mut HashMap<u64, ()>,
     // Zig: `if (check_for_bundled) string else void` → carried as Option, gated by const generic
     pkg_path: Option<&[u8]>,
     bundled_pkgs: Option<&PkgPathSet>,
-    workspaces_obj: Option<&Expr>,
+    workspaces_obj: Option<&Expr<'_>>,
 ) -> Result<(u32, u32), ParseError> {
     // PORT NOTE: defer optional_peers_buf.clearRetainingCapacity() moved to fn tail
     // (and to each early-return path implicitly via clear-on-next-call semantics in caller).

--- a/src/install/migration.rs
+++ b/src/install/migration.rs
@@ -262,8 +262,8 @@ pub fn migrate_npm_lockfile<'a>(
 
     // `StoreRef<T>` is `Copy` + safe-`Deref` (arena-backed), so copy the
     // handles out of the block instead of forging `&'static` via `as_ptr()`.
-    let root_package: bun_ast::StoreRef<E::Object>;
-    let packages_obj: bun_ast::StoreRef<E::Object> = 'brk: {
+    let root_package: bun_ast::StoreRef<'_, E::Object<'_>>;
+    let packages_obj: bun_ast::StoreRef<'_, E::Object<'_>> = 'brk: {
         let Some(obj) = json.get(b"packages") else {
             return Err(err!("InvalidNPMLockfile"));
         };
@@ -309,7 +309,7 @@ pub fn migrate_npm_lockfile<'a>(
                 ExprData::EArray(arr) => *arr,
                 ExprData::EObject(obj) => {
                     // PORT NOTE: `StoreRef::get` shadows `E::Object::get`; deref-coerce.
-                    let obj: &E::Object = obj;
+                    let obj: &E::Object<'_> = obj;
                     if let Some(packages) = obj.get(b"packages") {
                         match &packages.data {
                             ExprData::EArray(arr) => *arr,
@@ -368,7 +368,7 @@ pub fn migrate_npm_lockfile<'a>(
             return Err(err!("InvalidNPMLockfile"));
         };
         // PORT NOTE: `StoreRef::get` shadows `E::Object::get`; deref-coerce.
-        let pkg: &E::Object = pkg;
+        let pkg: &E::Object<'_> = pkg;
 
         if pkg.get(b"link").is_some() {
             id_map.put_assume_capacity(
@@ -548,7 +548,7 @@ pub fn migrate_npm_lockfile<'a>(
             unreachable!("npm lockfile: non-object Expr from JSON parser")
         };
         // PORT NOTE: `StoreRef::get` shadows `E::Object::get`; deref-coerce.
-        let pkg: &E::Object = pkg;
+        let pkg: &E::Object<'_> = pkg;
 
         let pkg_path = entry
             .key
@@ -914,7 +914,7 @@ pub fn migrate_npm_lockfile<'a>(
             unreachable!("npm lockfile: non-object Expr from JSON parser")
         };
         // PORT NOTE: `StoreRef::get` shadows `E::Object::get`; deref-coerce.
-        let pkg: &E::Object = pkg;
+        let pkg: &E::Object<'_> = pkg;
 
         if pkg.get(b"link").is_some()
             || pkg
@@ -1032,7 +1032,7 @@ pub fn migrate_npm_lockfile<'a>(
             if let Some(deps) = pkg.get(dep_key.prop) {
                 // fetch the peerDependenciesMeta if it exists
                 // this is only done for peerDependencies, obviously
-                let peer_dep_meta: Option<Expr> = if dep_key.behavior == Behavior::PEER {
+                let peer_dep_meta: Option<Expr<'_>> = if dep_key.behavior == Behavior::PEER {
                     if let Some(expr) = pkg.get(b"peerDependenciesMeta") {
                         if !matches!(expr.data, ExprData::EObject(_)) {
                             return Err(err!("InvalidNPMLockfile"));
@@ -1137,7 +1137,7 @@ pub fn migrate_npm_lockfile<'a>(
                                 else {
                                     unreachable!()
                                 };
-                                let ref_pkg: &E::Object = ref_pkg;
+                                let ref_pkg: &E::Object<'_> = ref_pkg;
                                 // the `else` here is technically possible to hit
                                 let resolved_v = ref_pkg
                                     .get(b"resolved")
@@ -1211,7 +1211,7 @@ pub fn migrate_npm_lockfile<'a>(
                                     else {
                                         unreachable!()
                                     };
-                                    let dep_pkg: &E::Object = dep_pkg;
+                                    let dep_pkg: &E::Object<'_> = dep_pkg;
                                     let dep_resolved: &[u8] = 'dep_resolved: {
                                         if let Some(resolved) = dep_pkg.get(b"resolved") {
                                             let dep_resolved = resolved
@@ -1437,7 +1437,7 @@ pub fn migrate_npm_lockfile<'a>(
                                         let ExprData::EObject(meta_obj) = &meta.data else {
                                             return Err(err!("InvalidNPMLockfile"));
                                         };
-                                        let meta_obj: &E::Object = meta_obj;
+                                        let meta_obj: &E::Object<'_> = meta_obj;
                                         if let Some(optional) = meta_obj.get(b"optional") {
                                             let ExprData::EBoolean(b) = optional.data else {
                                                 return Err(err!("InvalidNPMLockfile"));

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -632,7 +632,7 @@ pub use bun_install_types::resolver_hooks::{
 
 /// Port of `Negatable(T).fromJson` (src/install/npm.zig). Lives here (not in
 /// `bun_install_types`) because `bun_ast::Expr` is not reachable from that crate.
-pub fn negatable_from_json<T: NegatableEnum>(expr: &JSON::Expr) -> Result<T, AllocError> {
+pub fn negatable_from_json<T: NegatableEnum>(expr: &JSON::Expr<'_>) -> Result<T, AllocError> {
     let mut this = T::NONE.negatable();
     if let JSON::ExprData::EArray(a) = &expr.data {
         for item in a.items.slice() {

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -194,10 +194,9 @@ impl From<crate::lockfile_real::catalog_map::FromPnpmLockfileError> for MigrateP
 bun_core::named_error_set!(MigratePnpmLockfileError);
 
 #[inline]
-fn as_string(expr: &Expr) -> Option<&'static [u8]> {
+fn as_string<'arena>(expr: &Expr<'arena>) -> Option<&'arena [u8]> {
     // YAML / package.json parse always produces UTF-8 EStrings; `E.String.data`
-    // is a Store-backed slice, so the `'static` here is the field's own
-    // lifetime — no laundering.
+    // is a Store-backed slice valid for `'arena`.
     if let bun_ast::ExprData::EString(s) = &expr.data {
         if s.is_utf8() {
             return Some(s.data.slice());
@@ -207,19 +206,19 @@ fn as_string(expr: &Expr) -> Option<&'static [u8]> {
 }
 
 #[inline]
-fn get_string(expr: &Expr, name: &[u8]) -> Option<(&'static [u8], bun_ast::Loc)> {
+fn get_string<'arena>(expr: &Expr<'arena>, name: &[u8]) -> Option<(&'arena [u8], bun_ast::Loc)> {
     let q = expr.as_property(name)?;
     Some((as_string(&q.expr)?, q.expr.loc))
 }
 
-fn e_object(expr: &Expr) -> &E::Object {
+fn e_object<'a, 'arena>(expr: &'a Expr<'arena>) -> &'a E::Object<'arena> {
     match &expr.data {
         ExprData::EObject(o) => &**o,
         _ => unreachable!("e_object called on non-object"),
     }
 }
 
-fn e_object_mut(expr: &mut Expr) -> &mut E::Object {
+fn e_object_mut<'a, 'arena>(expr: &'a mut Expr<'arena>) -> &'a mut E::Object<'arena> {
     match &mut expr.data {
         ExprData::EObject(o) => &mut **o,
         _ => unreachable!("e_object_mut called on non-object"),
@@ -228,7 +227,7 @@ fn e_object_mut(expr: &mut Expr) -> &mut E::Object {
 
 /// Shallow struct copy (Zig copies `G.Property` by value freely; the Rust
 /// `G::Property` lacks `Clone` because of its `Vec`/`NonNull` fields).
-fn shallow_clone_prop(p: &G::Property) -> G::Property {
+fn shallow_clone_prop<'arena>(p: &G::Property<'arena>) -> G::Property<'arena> {
     G::Property {
         key: p.key,
         value: p.value,
@@ -256,11 +255,11 @@ pub fn migrate_pnpm_lockfile<'a>(
     // `root` survives those resets.
     let yaml_source = bun_ast::Source::init_path_string(b"pnpm-lock.yaml", data);
     let yaml_arena = bun_alloc::Arena::new();
-    let _root: Expr = match bun_parsers::yaml::YAML::parse(&yaml_source, log, &yaml_arena) {
+    let _root: Expr<'_> = match bun_parsers::yaml::YAML::parse(&yaml_source, log, &yaml_arena) {
         Ok(r) => r,
         Err(_) => return Err(MigratePnpmLockfileError::YamlParseError),
     };
-    let root: Expr = bun_core::handle_oom(_root.deep_clone(&yaml_arena));
+    let root: Expr<'_> = bun_core::handle_oom(_root.deep_clone(&yaml_arena));
 
     if !root.is_object() {
         log.add_error_fmt(
@@ -428,7 +427,7 @@ pub fn migrate_pnpm_lockfile<'a>(
             return Err(MigratePnpmLockfileError::PnpmLockfileMissingImporters);
         };
 
-        let mut has_root_pkg_expr: Option<Expr> = None;
+        let mut has_root_pkg_expr: Option<Expr<'_>> = None;
 
         for prop in e_object(&importers_obj).properties.slice() {
             let Some(importer_path) =
@@ -584,7 +583,7 @@ pub fn migrate_pnpm_lockfile<'a>(
                 // PORT NOTE: copy `Expr` out by value so the `&mut manager`
                 // borrow held by `workspace_pkg_json` ends here — `manager`
                 // is reborrowed below for `parse_append_importer_dependencies`.
-                let workspace_root: Expr = workspace_pkg_json.root;
+                let workspace_root: Expr<'_> = workspace_pkg_json.root;
 
                 let name = as_string(&workspace_root.get(b"name").unwrap()).unwrap();
                 let name_hash = semver::string::Builder::string_hash(name);
@@ -758,15 +757,15 @@ pub fn migrate_pnpm_lockfile<'a>(
             }
         }
 
-        struct SnapshotEntry {
-            obj: Expr,
+        struct SnapshotEntry<'arena> {
+            obj: Expr<'arena>,
         }
-        impl Default for SnapshotEntry {
+        impl<'arena> Default for SnapshotEntry<'arena> {
             fn default() -> Self {
                 Self { obj: Expr::EMPTY }
             }
         }
-        let mut snapshots: StringArrayHashMap<SnapshotEntry> = StringArrayHashMap::new();
+        let mut snapshots: StringArrayHashMap<SnapshotEntry<'_>> = StringArrayHashMap::new();
 
         if let Some(packages_obj) = root.get_object(b"packages") {
             let Some(snapshots_obj) = root.get_object(b"snapshots") else {
@@ -1210,8 +1209,8 @@ impl From<ParseAppendDependenciesError> for MigratePnpmLockfileError {
 
 fn parse_append_package_dependencies(
     lockfile: &mut Lockfile,
-    package_obj: &Expr,
-    snapshot_obj: &Expr,
+    package_obj: &Expr<'_>,
+    snapshot_obj: &Expr<'_>,
     log: &mut bun_ast::Log,
 ) -> Result<(u32, u32), ParseAppendDependenciesError> {
     let mut version_buf: Vec<u8> = Vec::new();
@@ -1428,10 +1427,10 @@ fn parse_append_package_dependencies(
 fn parse_append_importer_dependencies(
     lockfile: &mut Lockfile,
     manager: &mut PackageManager,
-    pkg_expr: &Expr,
+    pkg_expr: &Expr<'_>,
     log: &mut bun_ast::Log,
     is_root: bool,
-    importers_obj: &Expr,
+    importers_obj: &Expr<'_>,
     importer_versions: &mut StringArrayHashMap<Box<[u8]>>,
 ) -> Result<(u32, u32), ParseAppendDependenciesError> {
     const IMPORTER_DEPENDENCY_GROUPS: [(&[u8], dependency::Behavior); 3] = [
@@ -1788,11 +1787,18 @@ fn update_package_json_after_migration(
     // Each `&'static [u8]` here is interned into the thread-local `DATA_STORE`
     // (see `data_store_dupe_str` below) so it shares the lifetime of the
     // `Expr` nodes it ends up backing inside the cached `root_pkg_json.root`.
+    //
+    // Hoisted out of the `Ok` arm so the `Expr<'arena>` values stored in
+    // `catalog_obj` / `catalogs_obj` / `workspace_*_obj` below remain valid
+    // for the rest of the function (their `'arena` is tied to these two
+    // borrows).
+    let ws_yaml_arena = bun_alloc::Arena::new();
+    let mut ws_yaml_source = bun_ast::Source::default();
     let mut workspace_paths: Option<Vec<&'static [u8]>> = None;
-    let mut catalog_obj: Option<Expr> = None;
-    let mut catalogs_obj: Option<Expr> = None;
-    let mut workspace_overrides_obj: Option<Expr> = None;
-    let mut workspace_patched_deps_obj: Option<Expr> = None;
+    let mut catalog_obj: Option<Expr<'_>> = None;
+    let mut catalogs_obj: Option<Expr<'_>> = None;
+    let mut workspace_overrides_obj: Option<Expr<'_>> = None;
+    let mut workspace_patched_deps_obj: Option<Expr<'_>> = None;
 
     match sys::File::read_from(Fd::cwd(), b"pnpm-workspace.yaml") {
         Ok(contents) => 'read_pnpm_workspace_yaml: {
@@ -1807,9 +1813,9 @@ fn update_package_json_after_migration(
             // `Expr` nodes — arena ownership, not a leak (bulk-freed on
             // `Expr::data_store_reset`).
             let contents: &'static [u8] = js_ast::data_store_dupe_str(&contents);
-            let yaml_source = bun_ast::Source::init_path_string(b"pnpm-workspace.yaml", contents);
-            let arena = bun_alloc::Arena::new();
-            let Ok(ws_root) = bun_parsers::yaml::YAML::parse(&yaml_source, log, &arena) else {
+            ws_yaml_source = bun_ast::Source::init_path_string(b"pnpm-workspace.yaml", contents);
+            let Ok(ws_root) = bun_parsers::yaml::YAML::parse(&ws_yaml_source, log, &ws_yaml_arena)
+            else {
                 break 'read_pnpm_workspace_yaml;
             };
 

--- a/src/install/postinstall_optimizer.rs
+++ b/src/install/postinstall_optimizer.rs
@@ -46,7 +46,7 @@ static DEFAULT_IGNORE: LazyLock<[DefaultIgnore; 1]> = LazyLock::new(|| {
 impl PostinstallOptimizer {
     fn from_string_array_group(
         list: &mut List,
-        expr: &js_ast::Expr,
+        expr: &js_ast::Expr<'_>,
         value: PostinstallOptimizer,
     ) -> Result<bool, bun_alloc::AllocError> {
         // PORT NOTE: Zig `expr.asArray()` returns null for both non-array AND empty
@@ -81,7 +81,7 @@ impl PostinstallOptimizer {
 
     pub fn from_package_json(
         list: &mut List,
-        expr: &js_ast::Expr,
+        expr: &js_ast::Expr<'_>,
     ) -> Result<(), bun_alloc::AllocError> {
         if let Some(native_deps_expr) = expr.get(b"nativeDependencies") {
             list.disable_default_native_binlinks = Self::from_string_array_group(

--- a/src/install/resolvers/folder_resolver.rs
+++ b/src/install/resolvers/folder_resolver.rs
@@ -117,14 +117,14 @@ impl<'a, const TAG: ResolutionTag> ResolverContext for NewResolver<'a, TAG> {
         matches!(TAG, ResolutionTag::Folder | ResolutionTag::Symlink)
     }
 
-    fn count(&mut self, builder: &mut StringBuilder<'_>, _json: &Expr) {
+    fn count(&mut self, builder: &mut StringBuilder<'_>, _json: &Expr<'_>) {
         builder.count(self.folder_path);
     }
 
     fn resolve(
         &mut self,
         builder: &mut StringBuilder<'_>,
-        _json: &Expr,
+        _json: &Expr<'_>,
     ) -> Result<ResolutionType<u64>, bun_core::Error> {
         // Zig: @unionInit(Resolution.Value, @tagName(tag), builder.append(String, this.folder_path))
         let appended = builder.append::<SemverString>(self.folder_path);
@@ -150,12 +150,12 @@ impl ResolverContext for CacheFolderResolver {
         true
     }
 
-    fn count(&mut self, _builder: &mut StringBuilder<'_>, _json: &Expr) {}
+    fn count(&mut self, _builder: &mut StringBuilder<'_>, _json: &Expr<'_>) {}
 
     fn resolve(
         &mut self,
         _builder: &mut StringBuilder<'_>,
-        _json: &Expr,
+        _json: &Expr<'_>,
     ) -> Result<ResolutionType<u64>, bun_core::Error> {
         Ok(ResolutionType::<u64>::init(TaggedValue::Npm(
             VersionedURLType {
@@ -305,7 +305,7 @@ fn read_package_json_from_disk<R: FolderResolverImpl>(
         // `Expr` is `Copy`; take a raw pointer to `source` so the borrow on
         // `workspace_package_json_cache` ends before `&mut *manager_ptr` is
         // formed for `parse_with_json`.
-        let root: Expr = json.root;
+        let root: Expr<'_> = json.root;
         let source: *const bun_ast::Source = &raw const json.source;
 
         // SAFETY: see PORT NOTE above on borrow splitting.

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -65,9 +65,9 @@ fn e_string_eql_bytes(s: &E::EString, other: &[u8]) -> bool {
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
     pub fn maybe_relocate_vars_to_top_level(
         &mut self,
-        decls: &[G::Decl],
+        decls: &[G::Decl<'a>],
         mode: RelocateVarsMode,
-    ) -> RelocateVars {
+    ) -> RelocateVars<'a> {
         let p = self;
         // Only do this when the scope is not already top-level and when we're not inside a function.
         if p.current_scope == p.module_scope {
@@ -132,11 +132,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     pub fn maybe_rewrite_property_access(
         &mut self,
         loc: bun_ast::Loc,
-        target: js_ast::Expr,
+        target: js_ast::Expr<'a>,
         name: &'a [u8],
         name_loc: bun_ast::Loc,
         identifier_opts: IdentifierOpts,
-    ) -> Option<Expr> {
+    ) -> Option<Expr<'a>> {
         let p = self;
         let name_static = E::Str::new(name);
 
@@ -779,10 +779,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn maybe_rewrite_property_access_for_namespace(
         &mut self,
         name: &'a [u8],
-        target: &Expr,
+        target: &Expr<'a>,
         loc: bun_ast::Loc,
         name_loc: bun_ast::Loc,
-    ) -> Option<Expr> {
+    ) -> Option<Expr<'a>> {
         let p = self;
         let map: &js_ast::TSNamespaceMemberMap = &p.ts_namespace.map.unwrap();
         if let Some(value) = map.get(name) {
@@ -846,7 +846,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         None
     }
 
-    pub fn check_if_defined_helper(&mut self, expr: Expr) -> Result<Expr, bun_core::Error> {
+    pub fn check_if_defined_helper(&mut self, expr: Expr<'a>) -> Result<Expr<'a>, bun_core::Error> {
         let p = self;
         // TODO(port): narrow error set
         let flags = if matches!(expr.data, js_ast::ExprData::EIdentifier(_)) {
@@ -873,7 +873,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         ))
     }
 
-    pub fn maybe_defined_helper(&mut self, identifier_expr: Expr) -> Result<Expr, bun_core::Error> {
+    pub fn maybe_defined_helper(&mut self, identifier_expr: Expr<'a>) -> Result<Expr<'a>, bun_core::Error> {
         let p = self;
         // TODO(port): narrow error set
         let test_ = Self::check_if_defined_helper(p, identifier_expr)?;

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -43,16 +43,16 @@ fn tokenToString_get(token: T) -> &'static [u8] {
 pub static EMPTY_JAVASCRIPT_STRING: [u16; 1] = [0];
 
 #[derive(Default, Clone, Copy)]
-pub struct JSXPragma {
-    pub _jsx: js_ast::Span,
-    pub _jsx_frag: js_ast::Span,
-    pub _jsx_runtime: js_ast::Span,
-    pub _jsx_import_source: js_ast::Span,
+pub struct JSXPragma<'arena> {
+    pub _jsx: js_ast::Span<'arena>,
+    pub _jsx_frag: js_ast::Span<'arena>,
+    pub _jsx_runtime: js_ast::Span<'arena>,
+    pub _jsx_import_source: js_ast::Span<'arena>,
 }
 
-impl JSXPragma {
+impl<'arena> JSXPragma<'arena> {
     // `Span.text` is a `StoreStr`; `.len()` via Deref<[u8]>.
-    pub fn jsx(&self) -> Option<js_ast::Span> {
+    pub fn jsx(&self) -> Option<js_ast::Span<'arena>> {
         if self._jsx.text.len() > 0 {
             Some(self._jsx)
         } else {
@@ -278,8 +278,8 @@ pub struct LexerSnapshot<'a> {
     pub is_log_disabled: bool,
     pub code_point: CodePoint,
     pub identifier: &'a [u8],
-    pub jsx_pragma: JSXPragma,
-    pub source_mapping_url: Option<js_ast::Span>,
+    pub jsx_pragma: JSXPragma<'a>,
+    pub source_mapping_url: Option<js_ast::Span<'a>>,
     pub number: f64,
     pub rescan_close_brace_as_template_token: bool,
     pub prev_error_loc: Loc,
@@ -356,11 +356,11 @@ pub struct LexerType<
     pub preserve_all_comments_before: bool,
     pub is_legacy_octal_literal: bool,
     pub is_log_disabled: bool,
-    pub comments_to_preserve_before: Vec<js_ast::G::Comment>,
+    pub comments_to_preserve_before: Vec<js_ast::G::Comment<'a>>,
     pub code_point: CodePoint,
     pub identifier: &'a [u8],
-    pub jsx_pragma: JSXPragma,
-    pub source_mapping_url: Option<js_ast::Span>,
+    pub jsx_pragma: JSXPragma<'a>,
+    pub source_mapping_url: Option<js_ast::Span<'a>>,
     pub number: f64,
     pub rescan_close_brace_as_template_token: bool,
     pub prev_error_loc: Loc,
@@ -2663,7 +2663,7 @@ lexer_impl_header! {
     }
 
     pub fn init_json(
-        log: &'a mut Log,
+        log: &mut Log,
         source: &'a Source,
         arena: &'a Arena,
     ) -> Result<Self, Error> {
@@ -2674,7 +2674,7 @@ lexer_impl_header! {
     }
 
     pub fn init_without_reading(
-        log: &'a mut Log,
+        log: &mut Log,
         source: &'a Source,
         arena: &'a Arena,
     ) -> Self {
@@ -2727,7 +2727,7 @@ lexer_impl_header! {
     }
 
     pub fn init(
-        log: &'a mut Log,
+        log: &mut Log,
         source: &'a Source,
         arena: &'a Arena,
     ) -> Result<Self, Error> {
@@ -2737,7 +2737,7 @@ lexer_impl_header! {
         Ok(lex)
     }
 
-    pub fn to_e_string(&mut self) -> Result<js_ast::E::String, Error> {
+    pub fn to_e_string(&mut self) -> Result<js_ast::E::String<'a>, Error> {
         match self.string_literal_raw_format {
             StringLiteralRawFormat::Ascii => {
                 // string_literal_raw_content contains ascii without escapes
@@ -2786,7 +2786,7 @@ lexer_impl_header! {
         }
     }
 
-    pub fn to_utf8_e_string(&mut self) -> Result<js_ast::E::String, Error> {
+    pub fn to_utf8_e_string(&mut self) -> Result<js_ast::E::String<'a>, Error> {
         let mut res = self.to_e_string()?;
         res.to_utf8(self.arena)?;
         // TODO(port): arena routing for E.String.toUTF8
@@ -4043,13 +4043,13 @@ impl PragmaArg {
         PREFIX as usize + url_len // Correct total length
     }
 
-    pub fn scan(
+    pub fn scan<'arena>(
         kind: PragmaArg,
         offset_: usize,
         pragma: &[u8],
         text_: &[u8],
         allow_newline: bool,
-    ) -> Option<js_ast::Span> {
+    ) -> Option<js_ast::Span<'arena>> {
         let mut text = &text_[pragma.len()..];
         let mut iter = CodepointIterator::init(text);
 

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -119,16 +119,19 @@ pub mod Macro {
         // raw pointer involved is `ctx.data`, which is a struct invariant
         // maintained by `init`/`Default` — not a caller precondition. The
         // `#[no_mangle]` body in `bun_js_parser_jsc` is itself a safe `pub fn`.
-        safe fn __bun_macro_context_call(
+        // `'arena` is erased at link time; declaring it lets callers pass
+        // `Expr<'arena>` without a transmute (the impl side round-trips the
+        // arena-owned `Expr` by value into the same arena).
+        safe fn __bun_macro_context_call<'arena>(
             ctx: &mut MacroContext,
             import_record_path: &[u8],
             source_dir: &[u8],
             log: &mut bun_ast::Log,
             source: &bun_ast::Source,
             import_range: bun_ast::Range,
-            caller: bun_ast::Expr,
+            caller: bun_ast::Expr<'arena>,
             function_name: &[u8],
-        ) -> Result<bun_ast::Expr, bun_core::Error>;
+        ) -> Result<bun_ast::Expr<'arena>, bun_core::Error>;
         // NOT `safe fn`: callee derefs `data` unconditionally as
         // `&MacroContext` — caller must guarantee non-null + produced by
         // `__bun_macro_context_init` + the backing `Transpiler.options` table
@@ -142,16 +145,16 @@ pub mod Macro {
         /// Zig: `pub fn call(self: *MacroContext, import_record_path, source_dir,
         /// log, source, import_range, caller, function_name) !Expr`.
         #[inline]
-        pub fn call(
+        pub fn call<'arena>(
             &mut self,
             import_record_path: &[u8],
             source_dir: &[u8],
             log: &mut bun_ast::Log,
             source: &bun_ast::Source,
             import_range: bun_ast::Range,
-            caller: bun_ast::Expr,
+            caller: bun_ast::Expr<'arena>,
             function_name: &[u8],
-        ) -> Result<bun_ast::Expr, bun_core::Error> {
+        ) -> Result<bun_ast::Expr<'arena>, bun_core::Error> {
             __bun_macro_context_call(
                 self,
                 import_record_path,
@@ -226,10 +229,10 @@ use bun_ast::{Ast, Ref};
 // `Ast` variant collapses `Result` to 16 B so only a thin pointer is moved up
 // the stack — one mimalloc-arena alloc per parsed module is far cheaper than
 // 4+ kilobyte memmoves. The other variants are already tiny.
-pub enum Result {
+pub enum Result<'arena> {
     AlreadyBundled(AlreadyBundled),
     Cached,
-    Ast(Box<Ast>),
+    Ast(Box<Ast<'arena>>),
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -240,7 +243,7 @@ pub enum AlreadyBundled {
     BytecodeCjs,
 }
 
-pub type BindingList = Vec<Binding>;
+pub type BindingList<'arena> = Vec<Binding<'arena>>;
 
 /// `impl EqlParser for P` — moved out of `bun_ast::expr` (next to `P`).
 impl<'a, const IS_TS: bool, const SCAN: bool> bun_ast::expr::EqlParser
@@ -365,7 +368,7 @@ pub mod defines {
 
     #[derive(Clone)]
     pub struct DefineData {
-        pub value: ExprData,
+        pub value: ExprData<'static>,
         // Zig stored `original_name_ptr: ?[*]const u8` + `original_name_len: u32`
         // borrowing into caller-owned strings (defines.zig:24-25 — the 48→40-byte
         // packing trick). The Rust port owns the `RawDefines` value bytes
@@ -398,7 +401,7 @@ pub mod defines {
     /// Named-init shim (mirrors Zig anonymous-struct init).
     pub struct Options<'a> {
         pub original_name: Option<&'a [u8]>,
-        pub value: ExprData,
+        pub value: ExprData<'static>,
         pub valueless: bool,
         pub can_be_removed_if_unused: bool,
         pub call_can_be_unwrapped_if_unused: E::CallUnwrap,
@@ -632,7 +635,7 @@ pub mod defines_full_draft {
 
     #[derive(Clone)]
     pub struct DefineData {
-        pub value: expr::Data,
+        pub value: expr::Data<'static>,
         // Zig stored `original_name_ptr: ?[*]const u8` + `original_name_len: u32`
         // borrowing into caller-owned strings (defines.zig:24-25 — the 48→40-byte
         // packing trick). The Rust port owns the `RawDefines` value bytes
@@ -752,7 +755,7 @@ pub mod defines_full_draft {
                 &mut bun_ast::Log,
                 &bun_alloc::Arena,
             )
-                -> core::result::Result<bun_ast::Expr, bun_core::Error>,
+                -> core::result::Result<bun_ast::Expr<'static>, bun_core::Error>,
         ) -> core::result::Result<DefineData, bun_core::Error> {
             for part in key.split(|&c| c == b'.') {
                 if !js_lexer::is_identifier(part) {
@@ -964,7 +967,7 @@ pub mod renamer {
     use bun_collections::VecExt;
 
     // Round-C alias kept for P.rs/Parser.rs callers.
-    pub type SymbolMap = bun_ast::symbol::Map;
+    pub type SymbolMap<'arena> = bun_ast::symbol::Map<'arena>;
 
     pub fn assign_nested_scope_slots(
         _arena: &bun_alloc::Arena,

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -50,8 +50,8 @@ impl PrivateLoweredInfo {
 
 type PrivateLoweredMap = HashMap<u32, PrivateLoweredInfo>;
 
-struct FieldInitEntry {
-    prop: Property,
+struct FieldInitEntry<'arena> {
+    prop: Property<'arena>,
     is_private: bool,
     is_accessor: bool,
 }
@@ -78,7 +78,7 @@ enum RewriteKind {
 //    raw arena pointers; copying the pointers is the intended Zig semantic). ──
 
 #[inline]
-fn prop_copy(p: &Property) -> Property {
+fn prop_copy<'arena>(p: &Property<'arena>) -> Property<'arena> {
     Property {
         initializer: p.initializer,
         kind: p.kind,
@@ -94,7 +94,7 @@ fn prop_copy(p: &Property) -> Property {
 }
 
 #[inline]
-fn prop_full_copy(p: &Property) -> Property {
+fn prop_full_copy<'arena>(p: &Property<'arena>) -> Property<'arena> {
     // Same as `prop_copy` but preserves `ts_decorators` (used for the "keep
     // undecorated property as-is" path).
     // SAFETY: Vec is repr-compatible with a (ptr,len,cap,origin) POD; the
@@ -114,7 +114,7 @@ fn prop_full_copy(p: &Property) -> Property {
 }
 
 #[inline]
-fn class_copy(c: &G::Class) -> G::Class {
+fn class_copy<'arena>(c: &G::Class<'arena>) -> G::Class<'arena> {
     G::Class {
         class_keyword: c.class_keyword,
         // SAFETY: see `prop_full_copy`.
@@ -136,7 +136,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     /// recordUsage + E.Identifier in one call.
     #[inline]
-    fn use_ref(&mut self, ref_: Ref, l: bun_ast::Loc) -> Expr {
+    fn use_ref(&mut self, ref_: Ref, l: bun_ast::Loc) -> Expr<'a> {
         self.record_usage(ref_);
         self.new_expr(
             E::Identifier {
@@ -148,7 +148,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     /// Allocate args + callRuntime in one call.
-    fn call_rt(&mut self, l: bun_ast::Loc, name: &'static [u8], args: &[Expr]) -> Expr {
+    fn call_rt(&mut self, l: bun_ast::Loc, name: &'static [u8], args: &[Expr<'a>]) -> Expr<'a> {
         let bump = self.arena;
         let a = bump.alloc_slice_copy(args);
         let list = ExprNodeList::from_arena_slice(a);
@@ -163,7 +163,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     /// Single var declaration statement.
-    fn var_decl(&mut self, ref_: Ref, value: Option<Expr>, l: bun_ast::Loc) -> Stmt {
+    fn var_decl(&mut self, ref_: Ref, value: Option<Expr<'a>>, l: bun_ast::Loc) -> Stmt<'a> {
         let binding = self.b(B::Identifier { r#ref: ref_ }, l);
         let decls = DeclList::from_slice(&[G::Decl { binding, value }]);
         self.s(
@@ -179,11 +179,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn var_decl2(
         &mut self,
         r1: Ref,
-        v1: Option<Expr>,
+        v1: Option<Expr<'a>>,
         r2: Ref,
-        v2: Option<Expr>,
+        v2: Option<Expr<'a>>,
         l: bun_ast::Loc,
-    ) -> Stmt {
+    ) -> Stmt<'a> {
         let b1 = self.b(B::Identifier { r#ref: r1 }, l);
         let b2 = self.b(B::Identifier { r#ref: r2 }, l);
         let decls = DeclList::from_slice(&[
@@ -206,7 +206,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     /// recordUsage + Expr.assign.
-    fn assign_to(&mut self, ref_: Ref, value: Expr, l: bun_ast::Loc) -> Expr {
+    fn assign_to(&mut self, ref_: Ref, value: Expr<'a>, l: bun_ast::Loc) -> Expr<'a> {
         self.record_usage(ref_);
         Expr::assign(
             self.new_expr(
@@ -221,7 +221,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     /// new WeakMap() expression.
-    fn new_weak_map_expr(&mut self, l: bun_ast::Loc) -> Expr {
+    fn new_weak_map_expr(&mut self, l: bun_ast::Loc) -> Expr<'a> {
         let ref_ = self.find_symbol(l, b"WeakMap").expect("unreachable").r#ref;
         let target = self.new_expr(
             E::Identifier {
@@ -242,7 +242,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     /// new WeakSet() expression.
-    fn new_weak_set_expr(&mut self, l: bun_ast::Loc) -> Expr {
+    fn new_weak_set_expr(&mut self, l: bun_ast::Loc) -> Expr<'a> {
         let ref_ = self.find_symbol(l, b"WeakSet").expect("unreachable").r#ref;
         let target = self.new_expr(
             E::Identifier {
@@ -263,7 +263,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     /// Create a static block property from a single expression.
-    fn make_static_block(&mut self, expr: Expr, l: bun_ast::Loc) -> Property {
+    fn make_static_block(&mut self, expr: Expr<'a>, l: bun_ast::Loc) -> Property<'a> {
         let bump = self.arena;
         let stmt = self.s(
             S::SExpr {
@@ -286,7 +286,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     /// Build property access: target.name or target[key].
-    fn member_target(&mut self, target_expr: Expr, prop: &Property) -> Expr {
+    fn member_target(&mut self, target_expr: Expr<'a>, prop: &Property<'a>) -> Expr<'a> {
         let key_expr = prop.key.expect("infallible: prop has key");
         if prop.flags.contains(Flags::Property::IsComputed)
             || matches!(key_expr.data, js_ast::ExprData::ENumber(_))
@@ -334,10 +334,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         &mut self,
         is_static: bool,
         storage_ref: Ref,
-        value: Option<Expr>,
+        value: Option<Expr<'a>>,
         loc: bun_ast::Loc,
-        constructor_inject: &mut BumpVec<'_, Stmt>,
-        static_blocks: &mut BumpVec<'_, Property>,
+        constructor_inject: &mut BumpVec<'_, Stmt<'a>>,
+        static_blocks: &mut BumpVec<'_, Property<'a>>,
     ) {
         let target = self.new_expr(E::This {}, loc);
         let storage = self.use_ref(storage_ref, loc);
@@ -360,7 +360,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     /// Get the method kind code (1=method, 2=getter, 3=setter).
-    fn method_kind(prop: &Property) -> u8 {
+    fn method_kind(prop: &Property<'a>) -> u8 {
         match prop.kind {
             PropertyKind::Get => 2,
             PropertyKind::Set => 3,
@@ -401,7 +401,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     // ── Generic tree rewriter ────────────────────────────
 
-    fn rewrite_expr(&mut self, expr: &mut Expr, kind: RewriteKind) {
+    fn rewrite_expr(&mut self, expr: &mut Expr<'a>, kind: RewriteKind) {
         match kind {
             RewriteKind::ReplaceRef { old, new } => {
                 if let js_ast::ExprData::EIdentifier(id) = &expr.data {
@@ -497,7 +497,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    fn rewrite_stmts(&mut self, stmts: &mut [Stmt], kind: RewriteKind) {
+    fn rewrite_stmts(&mut self, stmts: &mut [Stmt<'a>], kind: RewriteKind) {
         for cur_stmt in stmts.iter_mut() {
             let cur_loc = cur_stmt.loc;
             match &mut cur_stmt.data {
@@ -631,7 +631,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     // ── Private access rewriting ─────────────────────────
 
-    fn private_get_expr(&mut self, obj: Expr, info: PrivateLoweredInfo, l: bun_ast::Loc) -> Expr {
+    fn private_get_expr(&mut self, obj: Expr<'a>, info: PrivateLoweredInfo, l: bun_ast::Loc) -> Expr<'a> {
         if let Some(desc_ref) = info.accessor_desc_ref {
             let storage = self.use_ref(info.storage_ref, l);
             let desc = self.use_ref(desc_ref, l);
@@ -661,11 +661,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     fn private_set_expr(
         &mut self,
-        obj: Expr,
+        obj: Expr<'a>,
         info: PrivateLoweredInfo,
-        val: Expr,
+        val: Expr<'a>,
         l: bun_ast::Loc,
-    ) -> Expr {
+    ) -> Expr<'a> {
         if let Some(desc_ref) = info.accessor_desc_ref {
             let storage = self.use_ref(info.storage_ref, l);
             let desc = self.use_ref(desc_ref, l);
@@ -689,7 +689,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    fn rewrite_private_accesses_in_expr(&mut self, expr: &mut Expr, map: &PrivateLoweredMap) {
+    fn rewrite_private_accesses_in_expr(&mut self, expr: &mut Expr<'a>, map: &PrivateLoweredMap) {
         let expr_loc = expr.loc;
         match &mut expr.data {
             js_ast::ExprData::EIndex(e) => {
@@ -843,7 +843,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    fn rewrite_private_accesses_in_stmts(&mut self, stmts: &mut [Stmt], map: &PrivateLoweredMap) {
+    fn rewrite_private_accesses_in_stmts(&mut self, stmts: &mut [Stmt<'a>], map: &PrivateLoweredMap) {
         for stmt_item in stmts.iter_mut() {
             match &mut stmt_item.data {
                 js_ast::StmtData::SExpr(data) => {
@@ -970,7 +970,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     // ── Public API ───────────────────────────────────────
 
-    pub fn lower_standard_decorators_stmt(&mut self, stmt: Stmt, out: &mut BumpVec<'a, Stmt>) {
+    pub fn lower_standard_decorators_stmt(&mut self, stmt: Stmt<'a>, out: &mut BumpVec<'a, Stmt<'a>>) {
         // Every call site is the visitStmt `s_class` branch. `Stmt` and the
         // `StoreRef<S::Class>` payload are both `Copy`, so we can hold a copy
         // of the arena handle while still passing `stmt` by value below.
@@ -985,10 +985,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn lower_standard_decorators_expr(
         &mut self,
-        class: &mut G::Class,
+        class: &mut G::Class<'a>,
         loc: bun_ast::Loc,
         name_from_context: Option<&'a [u8]>,
-    ) -> Expr {
+    ) -> Expr<'a> {
         let bump = self.arena;
         let mut out = BumpVec::<Stmt>::new_in(bump);
         self.lower_impl(class, loc, name_from_context, true, None, &mut out);
@@ -1006,12 +1006,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     #[allow(clippy::too_many_lines)]
     fn lower_impl(
         &mut self,
-        class: &mut G::Class,
+        class: &mut G::Class<'a>,
         loc: bun_ast::Loc,
         name_from_context: Option<&'a [u8]>,
         is_expr: bool,
-        original_stmt: Option<Stmt>,
-        out: &mut BumpVec<'a, Stmt>,
+        original_stmt: Option<Stmt<'a>>,
+        out: &mut BumpVec<'a, Stmt<'a>>,
     ) {
         let p = self;
         let bump = p.arena;

--- a/src/js_parser/lower/lower_esm_exports_hmr.rs
+++ b/src/js_parser/lower/lower_esm_exports_hmr.rs
@@ -39,15 +39,15 @@ fn generate_temp_ref<'p, const TS: bool, const SCAN: bool>(
     r#ref
 }
 
-pub struct ConvertESMExportsForHmr<'a> {
-    pub last_part: &'a mut js_ast::Part,
+pub struct ConvertESMExportsForHmr<'b, 'a> {
+    pub last_part: &'b mut js_ast::Part<'a>,
     /// files in node modules will not get hot updates, so the code generation
     /// can be a bit more concise for re-exports
     pub is_in_node_modules: bool,
     pub imports_seen: StringArrayHashMap<ImportRef>,
-    pub export_star_props: Vec<G::Property>,
-    pub export_props: Vec<G::Property>,
-    pub stmts: Vec<Stmt>,
+    pub export_star_props: Vec<G::Property<'a>>,
+    pub export_props: Vec<G::Property<'a>>,
+    pub stmts: Vec<Stmt<'a>>,
 }
 // PORT NOTE: Zig used `std.ArrayListUnmanaged` with `p.arena` for the four
 // collections; in Rust the parser arena is a `bumpalo::Bump`, but the consumers
@@ -66,14 +66,14 @@ pub struct DeduplicatedImportResult {
     pub import_record_index: u32,
 }
 
-impl<'a> ConvertESMExportsForHmr<'a> {
+impl<'b, 'a> ConvertESMExportsForHmr<'b, 'a> {
     // PORT NOTE: round-E un-gate — `<P>` unbounded generic → concrete `P<'p, TS, SCAN>`.
     // TODO(b2-ast-E): Zig `p: anytype` also accepts AstBuilder; add `ParserLike` trait bound
     //   when bundle_v2 lands.
-    pub fn convert_stmt<'p, const TS: bool, const SCAN: bool>(
+    pub fn convert_stmt<const TS: bool, const SCAN: bool>(
         &mut self,
-        p: &mut P<'p, TS, SCAN>,
-        stmt: Stmt,
+        p: &mut P<'a, TS, SCAN>,
+        stmt: Stmt<'a>,
     ) -> Result<(), AllocError> {
         let new_stmt: Stmt = match stmt.data {
             js_ast::StmtData::SLocal(mut st) => 'stmt: {
@@ -460,7 +460,7 @@ impl<'a> ConvertESMExportsForHmr<'a> {
         p: &mut P<'p, TS, SCAN>,
         import_record_index: u32,
         namespace_ref: Ref,
-        items: js_ast::StoreSlice<js_ast::ClauseItem>,
+        items: js_ast::StoreSlice<'a, js_ast::ClauseItem<'a>>,
         star_name_loc: Option<bun_ast::Loc>,
         default_name: Option<js_ast::LocRef>,
         loc: bun_ast::Loc,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -60,7 +60,7 @@ pub trait ParserLike<'a> {
     fn log(&self) -> &mut bun_ast::Log;
     fn bump(&self) -> &'a Bump;
     fn source(&self) -> &'a bun_ast::Source;
-    fn new_expr<T: js_ast::expr::IntoExprData>(&mut self, t: T, loc: bun_ast::Loc) -> Expr;
+    fn new_expr<T: js_ast::expr::IntoExprData<'a>>(&mut self, t: T, loc: bun_ast::Loc) -> Expr<'a>;
     fn store_name_in_ref(&mut self, name: &'a [u8]) -> Result<Ref, bun_core::Error>;
 }
 // Round-C: trait + impl defined so round-B Expr methods can bound on it. Method
@@ -85,7 +85,7 @@ impl<'a, const TS: bool, const SCAN: bool> ParserLike<'a> for P<'a, TS, SCAN> {
         self.source
     }
     #[inline]
-    fn new_expr<T: js_ast::expr::IntoExprData>(&mut self, t: T, loc: bun_ast::Loc) -> Expr {
+    fn new_expr<T: js_ast::expr::IntoExprData<'a>>(&mut self, t: T, loc: bun_ast::Loc) -> Expr<'a> {
         P::new_expr(self, t, loc)
     }
     #[inline]
@@ -165,11 +165,11 @@ impl<'a> ImportRecordList<'a> {
 }
 
 pub enum NamedImportsType<'a> {
-    Owned(bun_ast::ast_result::NamedImports),
-    Borrowed(&'a mut bun_ast::ast_result::NamedImports),
+    Owned(bun_ast::ast_result::NamedImports<'a>),
+    Borrowed(&'a mut bun_ast::ast_result::NamedImports<'a>),
 }
 impl<'a> core::ops::Deref for NamedImportsType<'a> {
-    type Target = bun_ast::ast_result::NamedImports;
+    type Target = bun_ast::ast_result::NamedImports<'a>;
     fn deref(&self) -> &Self::Target {
         match self {
             Self::Owned(v) => v,
@@ -205,16 +205,16 @@ pub use crate::visit::*;
 // matching Zig's `p.binary_expression_stack`).
 pub use crate::visit::visit_binary::BinaryExpressionVisitor;
 
-pub struct RecentlyVisitedTSNamespace {
-    pub expr: js_ast::ExprData,
+pub struct RecentlyVisitedTSNamespace<'arena> {
+    pub expr: js_ast::ExprData<'arena>,
     // ARENA back-pointer — `StoreRef` for safe `Deref` at the read sites.
-    pub map: Option<js_ast::StoreRef<js_ast::TSNamespaceMemberMap>>,
+    pub map: Option<js_ast::StoreRef<'arena, js_ast::TSNamespaceMemberMap<'arena>>>,
 }
 
 // Unused in Zig (per LIFETIMES.tsv evidence).
-pub enum RecentlyVisitedTSNamespaceExpressionData {
+pub enum RecentlyVisitedTSNamespaceExpressionData<'arena> {
     Ref(Ref),
-    Ptr(*const E::Dot),
+    Ptr(*const E::Dot<'arena>),
 }
 
 #[derive(Clone, Copy)]
@@ -268,9 +268,9 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     // allocated_names_pool: ?*AllocatedNamesPool.Node = null,
     pub latest_arrow_arg_loc: bun_ast::Loc,
     pub forbid_suffix_after_as_loc: bun_ast::Loc,
-    pub current_scope: js_ast::StoreRef<js_ast::Scope>,
-    pub scopes_for_current_part: List<'a, *mut js_ast::Scope>,
-    pub symbols: ListManaged<'a, js_ast::Symbol>,
+    pub current_scope: js_ast::StoreRef<'a, js_ast::Scope<'a>>,
+    pub scopes_for_current_part: List<'a, core::ptr::NonNull<js_ast::Scope<'a>>>,
+    pub symbols: ListManaged<'a, js_ast::Symbol<'a>>,
     pub ts_use_counts: List<'a, u32>,
     pub exports_ref: Ref,
     pub require_ref: Ref,
@@ -318,7 +318,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
 
     pub has_called_runtime: bool,
 
-    pub legacy_cjs_import_stmts: ListManaged<'a, Stmt>,
+    pub legacy_cjs_import_stmts: ListManaged<'a, Stmt<'a>>,
 
     pub injected_define_symbols: List<'a, Ref>,
     pub symbol_uses: SymbolUseMap,
@@ -335,7 +335,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub commonjs_module_exports_assigned_deoptimized: bool,
     pub commonjs_named_exports_needs_conversion: u32,
     pub had_commonjs_named_exports_this_visit: bool,
-    pub commonjs_replacement_stmts: StmtNodeList,
+    pub commonjs_replacement_stmts: StmtNodeList<'a>,
 
     pub parse_pass_symbol_uses: ParsePassSymbolUsageType<'a>,
 
@@ -470,11 +470,11 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     // The visit pass binds identifiers to declared symbols, does constant
     // folding, substitutes compile-time variable definitions, and lowers certain
     // syntactic constructs as appropriate.
-    pub stmt_expr_value: js_ast::ExprData,
-    pub call_target: js_ast::ExprData,
-    pub delete_target: js_ast::ExprData,
-    pub loop_body: js_ast::StmtData,
-    pub module_scope: js_ast::StoreRef<js_ast::Scope>,
+    pub stmt_expr_value: js_ast::ExprData<'a>,
+    pub call_target: js_ast::ExprData<'a>,
+    pub delete_target: js_ast::ExprData<'a>,
+    pub loop_body: js_ast::StmtData<'a>,
+    pub module_scope: js_ast::StoreRef<'a, js_ast::Scope<'a>>,
     pub module_scope_directive_loc: bun_ast::Loc,
     pub is_control_flow_dead: bool,
 
@@ -541,17 +541,17 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
 
     // This helps recognize the "await import()" pattern. When this is present,
     // warnings about non-string import paths will be omitted inside try blocks.
-    pub await_target: Option<js_ast::ExprData>,
+    pub await_target: Option<js_ast::ExprData<'a>>,
 
-    pub to_expr_wrapper_namespace: Binding2ExprWrapperNamespace,
-    pub to_expr_wrapper_hoisted: Binding2ExprWrapperHoisted,
+    pub to_expr_wrapper_namespace: Binding2ExprWrapperNamespace<'a>,
+    pub to_expr_wrapper_hoisted: Binding2ExprWrapperHoisted<'a>,
 
     // This helps recognize the "import().catch()" pattern. We also try to avoid
     // warning about this just like the "try { await import() }" pattern.
-    pub then_catch_chain: ThenCatchChain,
+    pub then_catch_chain: ThenCatchChain<'a>,
 
     // Temporary variables used for lowering
-    pub temp_refs_to_declare: List<'a, TempRef>,
+    pub temp_refs_to_declare: List<'a, TempRef<'a>>,
     pub temp_ref_count: i32,
 
     // When bundling, hoisted top-level local variables declared with "var" in
@@ -582,11 +582,11 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub require_transposer: RequireTransposer<'a, TYPESCRIPT, SCAN_ONLY>,
     pub require_resolve_transposer: RequireResolveTransposer<'a, TYPESCRIPT, SCAN_ONLY>,
 
-    pub const_values: bun_ast::ast_result::ConstValuesMap,
+    pub const_values: bun_ast::ast_result::ConstValuesMap<'a>,
 
     // These are backed by stack fallback allocators in _parse, and are uninitialized until then.
     // PERF(port): was stack-fallback alloc — profile in Phase B
-    pub binary_expression_stack: ListManaged<'a, BinaryExpressionVisitor>,
+    pub binary_expression_stack: ListManaged<'a, BinaryExpressionVisitor<'a>>,
     // TODO(b2-blocked): SideEffects::BinaryExpressionSimplifyVisitor — round-D (SideEffects.rs)
     pub binary_expression_simplify_stack: ListManaged<'a, ()>,
 
@@ -598,12 +598,12 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// In addition, there is a map from each relevant symbol reference to the data
     /// associated with that namespace or namespace member: "ref_to_ts_namespace_member".
     /// This gives enough info to be able to resolve queries into the namespace.
-    pub ref_to_ts_namespace_member: HashMap<Ref, js_ast::ts::Data>,
+    pub ref_to_ts_namespace_member: HashMap<Ref, js_ast::ts::Data<'a>>,
     /// When visiting expressions, namespace metadata is associated with the most
     /// recently visited node. If namespace metadata is present, "tsNamespaceTarget"
     /// will be set to the most recently visited node (as a way to mark that this
     /// node has metadata) and "tsNamespaceMemberData" will be set to the metadata.
-    pub ts_namespace: RecentlyVisitedTSNamespace,
+    pub ts_namespace: RecentlyVisitedTSNamespace<'a>,
     pub top_level_enums: List<'a, Ref>,
 
     // Value is a shared `&'a [ScopeOrder<'a>]` (Zig: `[]ScopeOrder` slice
@@ -616,7 +616,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub will_wrap_module_in_try_catch_for_using: bool,
 
     /// Used for react refresh, it must be able to insert `const _s = $RefreshSig$();`
-    pub nearest_stmt_list: Option<NonNull<ListManaged<'a, Stmt>>>,
+    pub nearest_stmt_list: Option<NonNull<ListManaged<'a, Stmt<'a>>>>,
     // TODO(port): lifetime — points at a stack local saved/restored across calls
     /// Name from assignment context for anonymous decorated class expressions.
     /// Set before visitExpr, consumed by lowerStandardDecoratorsImpl.
@@ -714,8 +714,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool>
 // captured fn. The Rust port type-erases `*P` (which is generic over
 // `<'a, TYPESCRIPT, J, SCAN_ONLY>`) into `binding::ToExprWrapper` - same shim
 // pattern as `ImportTransposer` above. Wired in `prepare_for_visit_pass`.
-pub type Binding2ExprWrapperNamespace = bun_ast::binding::ToExprWrapper;
-pub type Binding2ExprWrapperHoisted = bun_ast::binding::ToExprWrapper;
+pub type Binding2ExprWrapperNamespace<'arena> = bun_ast::binding::ToExprWrapper<'arena>;
+pub type Binding2ExprWrapperHoisted<'arena> = bun_ast::binding::ToExprWrapper<'arena>;
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Round-C: associated consts kept live (cheap, used by ParserLike + Parser.rs).
@@ -777,7 +777,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// every reassignment (push/pop scope) stores another arena-owned handle;
     /// the pointee outlives `'a` and is never freed during parsing.
     #[inline]
-    pub fn current_scope(&self) -> &js_ast::Scope {
+    pub fn current_scope(&self) -> &js_ast::Scope<'a> {
         &self.current_scope
     }
 
@@ -786,20 +786,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// Caller must not also hold a borrow obtained via `module_scope[_mut]()`
     /// when the two handles alias (top level).
     #[inline]
-    pub fn current_scope_mut(&mut self) -> &mut js_ast::Scope {
+    pub fn current_scope_mut(&mut self) -> &mut js_ast::Scope<'a> {
         &mut self.current_scope
     }
 
     /// Shared borrow of the module (top-level) scope.
     #[inline]
-    pub fn module_scope(&self) -> &js_ast::Scope {
+    pub fn module_scope(&self) -> &js_ast::Scope<'a> {
         &self.module_scope
     }
 
     /// Unique borrow of the module scope. Takes `&mut self` (see
     /// `current_scope_mut`).
     #[inline]
-    pub fn module_scope_mut(&mut self) -> &mut js_ast::Scope {
+    pub fn module_scope_mut(&mut self) -> &mut js_ast::Scope<'a> {
         &mut self.module_scope
     }
 
@@ -810,7 +810,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// it sidesteps the borrowck conflict that `current_scope()` (which
     /// returns a `&Scope` tied to `&self`) would hit.
     #[inline]
-    pub fn current_scope_ref(&self) -> js_ast::StoreRef<js_ast::Scope> {
+    pub fn current_scope_ref(&self) -> js_ast::StoreRef<'a, js_ast::Scope<'a>> {
         self.current_scope
     }
 
@@ -818,7 +818,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// Same rationale as [`current_scope_ref`] — `Copy` and does not borrow
     /// `self`, so it can be held across `&mut self` calls.
     #[inline]
-    pub fn module_scope_ref(&self) -> js_ast::StoreRef<js_ast::Scope> {
+    pub fn module_scope_ref(&self) -> js_ast::StoreRef<'a, js_ast::Scope<'a>> {
         self.module_scope
     }
 
@@ -826,9 +826,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     //    can reference them; the full bodies with SCAN_ONLY require-scan and
     //    @typeInfo branches stay in the gated block below) ────────────────
     #[inline]
-    pub fn new_expr<T>(&mut self, t: T, loc: bun_ast::Loc) -> Expr
+    pub fn new_expr<T>(&mut self, t: T, loc: bun_ast::Loc) -> Expr<'a>
     where
-        T: js_ast::expr::IntoExprData,
+        T: js_ast::expr::IntoExprData<'a>,
     {
         // PORT NOTE: Zig's `comptime Type == E.Call` check is done post-init by
         // matching on the constructed `Data` (Rust has no comptime type-eq).
@@ -856,9 +856,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     #[inline]
-    pub fn s<T>(&self, t: T, loc: bun_ast::Loc) -> Stmt
+    pub fn s<T>(&self, t: T, loc: bun_ast::Loc) -> Stmt<'a>
     where
-        T: js_ast::stmt::StatementData,
+        T: js_ast::stmt::StatementData<'a>,
     {
         Stmt::alloc(t, loc)
     }
@@ -995,7 +995,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // `&mut P` — avoids the aliased-`&mut` that arises when a transposer
     // *field* holds `&mut self` while a `&mut P` is materialised inside the
     // visitor (PORTING.md §Forbidden).
-    pub fn maybe_transpose_if_import(&mut self, arg: Expr, state: &TransposeState) -> Expr {
+    pub fn maybe_transpose_if_import(&mut self, arg: Expr<'a>, state: &TransposeState<'a>) -> Expr<'a> {
         match arg.data {
             js_ast::ExprData::EIf(ex) => Expr::init(
                 E::If {
@@ -1009,7 +1009,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    pub fn maybe_transpose_if_require(&mut self, arg: Expr, state: &TransposeState) -> Expr {
+    pub fn maybe_transpose_if_require(&mut self, arg: Expr<'a>, state: &TransposeState) -> Expr<'a> {
         match arg.data {
             js_ast::ExprData::EIf(ex) => Expr::init(
                 E::If {
@@ -1023,7 +1023,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    pub fn transpose_known_to_be_if_require(&mut self, arg: Expr, state: &TransposeState) -> Expr {
+    pub fn transpose_known_to_be_if_require(&mut self, arg: Expr<'a>, state: &TransposeState) -> Expr<'a> {
         // Caller guarantees `arg.data` is `EIf`.
         let js_ast::ExprData::EIf(ex) = arg.data else {
             unreachable!()
@@ -1038,7 +1038,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         )
     }
 
-    pub fn maybe_transpose_if_require_resolve(&mut self, arg: Expr, state: Expr) -> Expr {
+    pub fn maybe_transpose_if_require_resolve(&mut self, arg: Expr<'a>, state: Expr<'a>) -> Expr<'a> {
         match arg.data {
             js_ast::ExprData::EIf(ex) => Expr::init(
                 E::If {
@@ -1052,7 +1052,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    pub fn transpose_known_to_be_if_require_resolve(&mut self, arg: Expr, state: Expr) -> Expr {
+    pub fn transpose_known_to_be_if_require_resolve(&mut self, arg: Expr<'a>, state: Expr<'a>) -> Expr<'a> {
         // Caller guarantees `arg.data` is `EIf`.
         let js_ast::ExprData::EIf(ex) = arg.data else {
             unreachable!()
@@ -1067,7 +1067,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         )
     }
 
-    pub fn transpose_import(&mut self, arg: Expr, state: &TransposeState) -> Expr {
+    pub fn transpose_import(&mut self, arg: Expr<'a>, state: &TransposeState<'a>) -> Expr<'a> {
         // The argument must be a string
         if let Some(mut str_) = arg.data.as_e_string() {
             // Ignore calls to import() if the control flow is provably dead here.
@@ -1131,7 +1131,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         )
     }
 
-    pub fn transpose_require_resolve(&mut self, arg: Expr, require_resolve_ref: Expr) -> Expr {
+    pub fn transpose_require_resolve(&mut self, arg: Expr<'a>, require_resolve_ref: Expr<'a>) -> Expr<'a> {
         // The argument must be a string
         if matches!(arg.data, js_ast::ExprData::EString(_)) {
             return self.transpose_require_resolve_known_string(arg);
@@ -1164,7 +1164,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     #[inline]
-    pub fn transpose_require_resolve_known_string(&mut self, arg: Expr) -> Expr {
+    pub fn transpose_require_resolve_known_string(&mut self, arg: Expr<'a>) -> Expr<'a> {
         debug_assert!(matches!(arg.data, js_ast::ExprData::EString(_)));
 
         // Ignore calls to import() if the control flow is provably dead here.
@@ -1201,7 +1201,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         )
     }
 
-    pub fn transpose_require(&mut self, arg: Expr, state: &TransposeState) -> Expr {
+    pub fn transpose_require(&mut self, arg: Expr<'a>, state: &TransposeState) -> Expr<'a> {
         if !self.options.features.allow_runtime {
             return self.new_expr(
                 E::Call {
@@ -1367,7 +1367,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.deoptimize_common_js_named_exports();
     }
 
-    fn is_binding_used(&mut self, binding: Binding, default_export_ref: Ref) -> bool {
+    fn is_binding_used(&mut self, binding: Binding<'a>, default_export_ref: Ref) -> bool {
         match binding.data {
             js_ast::b::B::BIdentifier(ident) => {
                 let ident = ident.get();
@@ -1671,14 +1671,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// passes `t` by value, so only the alloc path was ever exercised. If a future
     /// caller needs to wrap an already-stored payload, call `Binding::init` directly.
     #[inline]
-    pub fn b<T>(&mut self, t: T, loc: bun_ast::Loc) -> Binding
+    pub fn b<T>(&mut self, t: T, loc: bun_ast::Loc) -> Binding<'a>
     where
-        T: js_ast::binding::BindingAlloc,
+        T: js_ast::binding::BindingAlloc<'a>,
     {
         Binding::alloc(self.arena, t, loc)
     }
 
-    pub fn record_exported_binding(&mut self, binding: Binding) {
+    pub fn record_exported_binding(&mut self, binding: Binding<'a>) {
         match binding.data {
             js_ast::b::B::BMissing(_) => {}
             js_ast::b::B::BIdentifier(ident) => {
@@ -1817,7 +1817,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         ident: E::Identifier,
         original_name: Option<&'a [u8]>,
         opts: IdentifierOpts,
-    ) -> Expr {
+    ) -> Expr<'a> {
         let ref_ = ident.ref_;
 
         if self.options.features.inlining {
@@ -2005,7 +2005,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn generate_import_stmt_for_bake_response(
         &mut self,
-        parts: &mut ListManaged<'a, js_ast::Part>,
+        parts: &mut ListManaged<'a, js_ast::Part<'a>>,
     ) -> Result<(), bun_core::Error> {
         debug_assert!(!self.response_ref.is_empty());
         debug_assert!(!self.bun_app_namespace_ref.is_empty());
@@ -2095,9 +2095,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         &mut self,
         import_path: &'a [u8],
         imports: I,
-        parts: &mut ListManaged<'a, js_ast::Part>,
+        parts: &mut ListManaged<'a, js_ast::Part<'a>>,
         symbols: &Sym,
-        additional_stmt: Option<Stmt>,
+        additional_stmt: Option<Stmt<'a>>,
         prefix: &'static [u8],
         is_internal: bool,
     ) -> Result<(), bun_core::Error>
@@ -2237,7 +2237,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn generate_react_refresh_import(
         &mut self,
-        parts: &mut ListManaged<'a, js_ast::Part>,
+        parts: &mut ListManaged<'a, js_ast::Part<'a>>,
         import_path: &'a [u8],
         clauses: &[ReactRefreshImportClause<'a>],
     ) -> Result<(), bun_core::Error> {
@@ -2250,7 +2250,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     fn generate_react_refresh_import_hmr<const HOT_MODULE_RELOADING: bool>(
         &mut self,
-        parts: &mut ListManaged<'a, js_ast::Part>,
+        parts: &mut ListManaged<'a, js_ast::Part<'a>>,
         import_path: &'a [u8],
         clauses: &[ReactRefreshImportClause<'a>],
     ) -> Result<(), bun_core::Error> {
@@ -2392,9 +2392,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn substitute_single_use_symbol_in_stmt(
         &mut self,
-        stmt: Stmt,
+        stmt: Stmt<'a>,
         r#ref: Ref,
-        replacement: Expr,
+        replacement: Expr<'a>,
     ) -> bool {
         // Zig matched on `stmt.data` and took `*Expr` into the arena-owned payload.
         // `StmtData` stores `StoreRef<S::*>` (Copy NonNull); matching by value yields
@@ -2486,11 +2486,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     fn substitute_single_use_symbol_in_expr(
         &mut self,
-        expr: Expr,
+        expr: Expr<'a>,
         r#ref: Ref,
-        replacement: Expr,
+        replacement: Expr<'a>,
         replacement_can_be_removed: bool,
-    ) -> Substitution {
+    ) -> Substitution<'a> {
         // Zig matched on `expr.data` (a tagged union of `*E.*`) and mutated through
         // the captured pointer. `ExprData` is `Copy`; matching by value yields owned
         // `StoreRef<E::*>` copies whose `DerefMut` writes to the same arena slot,
@@ -3589,7 +3589,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         self.current_scope = order.scope_ref();
-        self.scopes_for_current_part.push(order.scope);
+        self.scopes_for_current_part
+            .push(core::ptr::NonNull::new(order.scope).expect("ScopeOrder.scope non-null"));
         Ok(())
     }
 
@@ -3710,9 +3711,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // round-D: needs ArrayBinding (B.rs gated trait), Flags::PropertyInit
     fn convert_expr_to_binding(
         &mut self,
-        expr: ExprNodeIndex,
+        expr: ExprNodeIndex<'a>,
         invalid_loc: &mut LocList,
-    ) -> Option<Binding> {
+    ) -> Option<Binding<'a>> {
         match expr.data {
             js_ast::ExprData::EMissing(_) => return None,
             js_ast::ExprData::EIdentifier(ex) => {
@@ -3858,10 +3859,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // round-D: heavy body, depends on parse_*/visit_*/ImportScanner/full E surface
     pub fn convert_expr_to_binding_and_initializer(
         &mut self,
-        _expr: &mut ExprNodeIndex,
+        _expr: &mut ExprNodeIndex<'a>,
         invalid_log: &mut LocList,
         is_spread: bool,
-    ) -> ExprBindingTuple {
+    ) -> ExprBindingTuple<'a> {
         let mut initializer: Option<ExprNodeIndex> = None;
         // `Expr` is `Copy`; read it by value so the `EBinary` arm can switch
         // `expr` to `bin.left` via `StoreRef::Deref` (safe arena read) instead
@@ -3966,11 +3967,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // blocked_on: S::Import field set; crate::parser::MacroRefData; ParsedPath fields; ImportItemForNamespaceMap API
     pub fn process_import_statement(
         &mut self,
-        stmt_: S::Import,
+        stmt_: S::Import<'a>,
         path: ParsedPath<'a>,
         loc: bun_ast::Loc,
         was_originally_bare_import: bool,
-    ) -> Result<Stmt, bun_core::Error> {
+    ) -> Result<Stmt<'a>, bun_core::Error> {
         let is_macro = true /* TODO(b2-blocked): feature_flag::IS_MACRO_ENABLED */ && (path.is_macro || crate::Macro::is_macro_path(path.text));
         let mut stmt = stmt_;
         if is_macro {
@@ -4424,7 +4425,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         ))
     }
 
-    pub fn default_name_for_expr(&mut self, expr: Expr, loc: bun_ast::Loc) -> LocRef {
+    pub fn default_name_for_expr(&mut self, expr: Expr<'a>, loc: bun_ast::Loc) -> LocRef {
         match &expr.data {
             js_ast::ExprData::EFunction(func_container) => {
                 if let Some(_name) = &func_container.func.name {
@@ -4636,8 +4637,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         name: &[u8],
         is_export: bool,
         is_enum_scope: bool,
-    ) -> js_ast::StoreRef<js_ast::TSNamespaceScope> {
-        let map: Option<js_ast::StoreRef<js_ast::TSNamespaceMemberMap>> = 'brk: {
+    ) -> js_ast::StoreRef<'a, js_ast::TSNamespaceScope<'a>> {
+        let map: Option<js_ast::StoreRef<'a, js_ast::TSNamespaceMemberMap<'a>>> = 'brk: {
             // Merge with a sibling namespace from the same scope
             if let Some(existing_member) = self.current_scope().members.get(name) {
                 if let Some(member_data) =
@@ -5186,7 +5187,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         });
     }
 
-    pub fn mark_expr_as_parenthesized(&mut self, expr: &mut Expr) {
+    pub fn mark_expr_as_parenthesized(&mut self, expr: &mut Expr<'a>) {
         match &mut expr.data {
             js_ast::ExprData::EArray(ex) => ex.is_parenthesized = true,
             js_ast::ExprData::EObject(ex) => ex.is_parenthesized = true,
@@ -5237,7 +5238,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         &mut self,
         loc: bun_ast::Loc,
         parts: &[&'a [u8]],
-    ) -> Result<Expr, bun_core::Error> {
+    ) -> Result<Expr<'a>, bun_core::Error> {
         let result = self.find_symbol(loc, parts[0])?;
 
         let value = self.handle_identifier(
@@ -5258,9 +5259,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn member_expression(
         &mut self,
         loc: bun_ast::Loc,
-        initial_value: Expr,
+        initial_value: Expr<'a>,
         parts: &[&'a [u8]],
-    ) -> Expr {
+    ) -> Expr<'a> {
         let mut value = initial_value;
 
         for part in parts {
@@ -5305,7 +5306,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn append_part(
         &mut self,
-        parts: &mut ListManaged<'a, js_ast::Part>,
+        parts: &mut ListManaged<'a, js_ast::Part<'a>>,
         stmts: &'a mut [Stmt],
     ) -> Result<(), bun_core::Error> {
         // Reuse the memory if possible
@@ -5426,7 +5427,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // `stmtsCanBeRemovedIfUnused` which already gates on
     // `dead_code_elimination` and then invokes the `_without_dce_check`
     // recursion below. The wrapper is dead in spec and is dropped here.
-    fn binding_can_be_removed_if_unused_without_dce_check(&mut self, binding: Binding) -> bool {
+    fn binding_can_be_removed_if_unused_without_dce_check(&mut self, binding: Binding<'a>) -> bool {
         match binding.data {
             js_ast::b::B::BArray(bi) => {
                 for item in bi.items.slice() {
@@ -5462,14 +5463,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         true
     }
 
-    fn stmts_can_be_removed_if_unused(&mut self, stmts: &[Stmt]) -> bool {
+    fn stmts_can_be_removed_if_unused(&mut self, stmts: &[Stmt<'a>]) -> bool {
         if !self.options.features.dead_code_elimination {
             return false;
         }
         self.stmts_can_be_removed_if_unused_without_dce_check(stmts)
     }
 
-    fn stmts_can_be_removed_if_unused_without_dce_check(&mut self, stmts: &[Stmt]) -> bool {
+    fn stmts_can_be_removed_if_unused_without_dce_check(&mut self, stmts: &[Stmt<'a>]) -> bool {
         for stmt in stmts {
             match &stmt.data {
                 // These never have side effects
@@ -5585,10 +5586,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn maybe_keep_expr_symbol_name(
         &mut self,
-        expr: Expr,
+        expr: Expr<'a>,
         original_name: &'a [u8],
         was_anonymous_named_expr: bool,
-    ) -> Expr {
+    ) -> Expr<'a> {
         if was_anonymous_named_expr {
             self.keep_expr_symbol_name(expr, original_name)
         } else {
@@ -5596,7 +5597,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    pub fn value_for_this(&mut self, loc: bun_ast::Loc) -> Option<Expr> {
+    pub fn value_for_this(&mut self, loc: bun_ast::Loc) -> Option<Expr<'a>> {
         // Substitute "this" if we're inside a static class property initializer
         if self
             .fn_only_data_visit
@@ -5688,7 +5689,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     #[inline]
-    pub fn value_for_require(&self, loc: bun_ast::Loc) -> Expr {
+    pub fn value_for_require(&self, loc: bun_ast::Loc) -> Expr<'a> {
         debug_assert!(!self.is_source_runtime());
         Expr {
             data: js_ast::ExprData::ERequireCallTarget,
@@ -5697,7 +5698,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     #[inline]
-    pub fn value_for_import_meta_main(&mut self, inverted: bool, loc: bun_ast::Loc) -> Expr {
+    pub fn value_for_import_meta_main(&mut self, inverted: bool, loc: bun_ast::Loc) -> Expr<'a> {
         if let Some(known) = self.options.import_meta_main_value {
             return Expr {
                 loc,
@@ -5726,7 +5727,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    pub fn keep_expr_symbol_name(&mut self, _value: Expr, _name: &[u8]) -> Expr {
+    pub fn keep_expr_symbol_name(&mut self, _value: Expr<'a>, _name: &[u8]) -> Expr<'a> {
         _value
         // var start = p.expr_list.items.len;
         // p.expr_list.ensureUnusedCapacity(2) catch unreachable;
@@ -5754,7 +5755,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     // This one is never called in places that haven't already checked if DCE is enabled.
-    pub fn class_can_be_removed_if_unused(&mut self, class: &G::Class) -> bool {
+    pub fn class_can_be_removed_if_unused(&mut self, class: &G::Class<'a>) -> bool {
         if let Some(extends) = &class.extends {
             if !self.expr_can_be_removed_if_unused_without_dce_check(extends) {
                 return false;
@@ -5796,14 +5797,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // TODO:
     // When React Fast Refresh is enabled, anything that's a JSX component should not be removable
     // This is to improve the reliability of fast refresh between page loads.
-    pub fn expr_can_be_removed_if_unused(&mut self, expr: &Expr) -> bool {
+    pub fn expr_can_be_removed_if_unused(&mut self, expr: &Expr<'a>) -> bool {
         if !self.options.features.dead_code_elimination {
             return false;
         }
         self.expr_can_be_removed_if_unused_without_dce_check(expr)
     }
 
-    fn expr_can_be_removed_if_unused_without_dce_check(&mut self, expr: &Expr) -> bool {
+    fn expr_can_be_removed_if_unused_without_dce_check(&mut self, expr: &Expr<'a>) -> bool {
         match &expr.data {
             js_ast::ExprData::ENull(_)
             | js_ast::ExprData::EUndefined(_)
@@ -6147,7 +6148,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    pub fn jsx_import_automatic(&mut self, loc: bun_ast::Loc, is_static: bool) -> Expr {
+    pub fn jsx_import_automatic(&mut self, loc: bun_ast::Loc, is_static: bool) -> Expr<'a> {
         self.jsx_import(
             if is_static
                 && !self.options.jsx.development
@@ -6163,7 +6164,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         )
     }
 
-    pub fn jsx_import(&mut self, kind: JSXImport, loc: bun_ast::Loc) -> Expr {
+    pub fn jsx_import(&mut self, kind: JSXImport, loc: bun_ast::Loc) -> Expr<'a> {
         // TODO(port): Zig used `switch (kind) { inline else => |field| ... @tagName(field) }`.
         // We replicate via tag_name() helper on the enum.
         let ref_: Ref = match self.jsx_imports.get_with_tag(kind) {
@@ -6241,7 +6242,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // the value is ignored because that's what the TypeScript compiler does.
     }
 
-    pub fn ignore_usage_of_identifier_in_dot_chain(&mut self, expr: Expr) {
+    pub fn ignore_usage_of_identifier_in_dot_chain(&mut self, expr: Expr<'a>) {
         let mut current = expr;
         loop {
             match &current.data {
@@ -6275,7 +6276,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         stmts: &mut crate::parser::StmtList<'a>,
         name_ref: Ref,
         loc: bun_ast::Loc,
-        replacement: &crate::parser::Runtime::ReplaceableExport,
+        replacement: &crate::parser::Runtime::ReplaceableExport<'a>,
     ) -> bool {
         match replacement {
             crate::parser::Runtime::ReplaceableExport::Delete => false,
@@ -6327,8 +6328,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn replace_decl_and_possibly_remove(
         &mut self,
-        decl: &mut G::Decl,
-        replacement: &crate::parser::Runtime::ReplaceableExport,
+        decl: &mut G::Decl<'a>,
+        replacement: &crate::parser::Runtime::ReplaceableExport<'a>,
     ) -> bool {
         use crate::parser::Runtime::ReplaceableExport;
         match replacement {
@@ -6378,12 +6379,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn append_if_body_preserving_scope(
         &mut self,
-        stmts: &mut ListManaged<'a, Stmt>,
-        body: Stmt,
+        stmts: &mut ListManaged<'a, Stmt<'a>>,
+        body: Stmt<'a>,
     ) -> Result<(), bun_core::Error> {
         if let js_ast::StmtData::SBlock(block) = &body.data {
             // `S::Block.stmts` is `StoreSlice<Stmt>` arena-owned for parser 'a; no aliasing &mut.
-            let block_stmts: &[Stmt] = block.stmts.slice();
+            let block_stmts: &[Stmt<'a>] = block.stmts.slice();
             let mut keep_block = false;
             for stmt in block_stmts {
                 if statement_cares_about_scope(stmt) {
@@ -6441,13 +6442,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     #[inline(never)]
     pub fn generate_closure_for_type_script_namespace_or_enum(
         &mut self,
-        stmts: &mut ListManaged<'a, Stmt>,
+        stmts: &mut ListManaged<'a, Stmt<'a>>,
         stmt_loc: bun_ast::Loc,
         is_export: bool,
         name_loc: bun_ast::Loc,
         original_name_ref: Ref,
         arg_ref: Ref,
-        stmts_inside_closure: &'a mut [Stmt],
+        stmts_inside_closure: &'a mut [Stmt<'a>],
         all_values_are_pure: bool,
     ) -> Result<(), bun_core::Error> {
         let mut name_ref = original_name_ref;
@@ -6619,7 +6620,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     #[cold]
     #[inline(never)]
-    pub fn wrap_inlined_enum(&mut self, value: Expr, comment: &'a [u8]) -> Expr {
+    pub fn wrap_inlined_enum(&mut self, value: Expr<'a>, comment: &'a [u8]) -> Expr<'a> {
         if strings::contains(comment, b"*/") {
             // Don't wrap with a comment
             return value;
@@ -6658,7 +6659,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    pub fn runtime_identifier(&mut self, loc: bun_ast::Loc, name: &'static [u8]) -> Expr {
+    pub fn runtime_identifier(&mut self, loc: bun_ast::Loc, name: &'static [u8]) -> Expr<'a> {
         let ref_ = self.runtime_identifier_ref(loc, name);
         self.record_usage(ref_);
         self.new_expr(E::ImportIdentifier::new(ref_, false), loc)
@@ -6668,8 +6669,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         &mut self,
         loc: bun_ast::Loc,
         name: &'static [u8],
-        args: ExprNodeList,
-    ) -> Expr {
+        args: ExprNodeList<'a>,
+    ) -> Expr<'a> {
         let target = self.runtime_identifier(loc, name);
         self.new_expr(
             E::Call {
@@ -6687,7 +6688,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         assign_target: js_ast::AssignTarget,
         is_delete_target: bool,
         define_data: &DefineData,
-    ) -> Expr {
+    ) -> Expr<'a> {
         // Callers gate on `!valueless()` before reaching here, so `value` is a
         // real Expr.Data by contract (Zig: `define_data.value`).
         let value = define_data.value;
@@ -6728,7 +6729,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // `parts` is `&[Box<[u8]>]` to match the active round-C `DotDefine.parts:
     // Vec<Box<[u8]>>` shape (auto-derefs at call sites). The full draft uses
     // `StoreSlice<StoreStr>`; both index to a `[u8]` so the body is unchanged.
-    pub fn is_dot_define_match(&mut self, expr: Expr, parts: &[Box<[u8]>]) -> bool {
+    pub fn is_dot_define_match(&mut self, expr: Expr<'a>, parts: &[Box<[u8]>]) -> bool {
         match expr.data {
             js_ast::ExprData::EDot(ex) => {
                 if parts.len() > 1 {
@@ -6838,7 +6839,7 @@ fn path_package_name<'a>(path: &fs::Path<'a>) -> Option<&'a [u8]> {
 // un-gated and compile against the full bun_ast::ts::Metadata variant set.
 // Remaining individually-gated methods carry their own `blocked_on:` tags.
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
-    pub fn lower_class(&mut self, stmtorexpr: js_ast::StmtOrExpr) -> &'a mut [Stmt] {
+    pub fn lower_class(&mut self, stmtorexpr: js_ast::StmtOrExpr<'a>) -> &'a mut [Stmt<'a>] {
         use js_ast::g::PropertyKind;
         match stmtorexpr {
             js_ast::StmtOrExpr::Stmt(stmt) => {
@@ -7160,7 +7161,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     } else {
                         let mut cf = constructor_function.unwrap();
                         // `body.stmts` is an arena-owned `StoreSlice<Stmt>`.
-                        let old_stmts: &[Stmt] = cf.func.body.stmts.slice();
+                        let old_stmts: &[Stmt<'a>] = cf.func.body.stmts.slice();
                         let mut constructor_stmts = BumpVec::<Stmt>::with_capacity_in(
                             old_stmts.len() + instance_members.len(),
                             self.arena,
@@ -7285,7 +7286,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn emit_decorator_metadata_for_prop(
         &mut self,
         prop: &G::Property,
-        array: &mut BumpVec<'a, Expr>,
+        array: &mut BumpVec<'a, Expr<'a>>,
         loc: bun_ast::Loc,
     ) {
         use js_ast::g::PropertyKind;
@@ -7423,7 +7424,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn serialize_metadata(
         &mut self,
         ts_metadata: bun_ast::ts::Metadata,
-    ) -> Result<Expr, bun_core::Error> {
+    ) -> Result<Expr<'a>, bun_core::Error> {
         use bun_ast::ts::Metadata as M;
         // Local: `find_symbol` for a builtin name as an E::Identifier expr.
         macro_rules! ident {
@@ -7608,7 +7609,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     #[cold]
     #[inline(never)]
-    pub fn wrap_identifier_namespace(&mut self, loc: bun_ast::Loc, r#ref: Ref) -> Expr {
+    pub fn wrap_identifier_namespace(&mut self, loc: bun_ast::Loc, r#ref: Ref) -> Expr<'a> {
         let enclosing_ref = self
             .enclosing_namespace_arg_ref
             .expect("infallible: in namespace");
@@ -7634,7 +7635,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         )
     }
 
-    pub fn wrap_identifier_hoisting(&mut self, loc: bun_ast::Loc, r#ref: Ref) -> Expr {
+    pub fn wrap_identifier_hoisting(&mut self, loc: bun_ast::Loc, r#ref: Ref) -> Expr<'a> {
         // There was a Zig stage1 bug here we had to copy `ref` into a local
         // const variable or else the result would be wrong
         // I remember that bug in particular took hours, possibly days to uncover.
@@ -7652,7 +7653,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // value_for_define / is_dot_define_match: moved to ungated impl (round-G).
 
     // One statement could potentially expand to several statements
-    pub fn stmts_to_single_stmt(&mut self, loc: bun_ast::Loc, stmts: &'a mut [Stmt]) -> Stmt {
+    pub fn stmts_to_single_stmt(&mut self, loc: bun_ast::Loc, stmts: &'a mut [Stmt]) -> Stmt<'a> {
         if stmts.is_empty() {
             return Stmt {
                 data: js_ast::StmtData::SEmpty(S::Empty {}),
@@ -7735,15 +7736,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // existed). Port as `unreachable!()` per the @compileError convention used
     // elsewhere in this file (see `wrap_identifier` arm).
     #[allow(unused)]
-    fn keep_stmt_symbol_name(&mut self, _loc: bun_ast::Loc, _ref: Ref, _name: &[u8]) -> Stmt {
+    fn keep_stmt_symbol_name(&mut self, _loc: bun_ast::Loc, _ref: Ref, _name: &[u8]) -> Stmt<'a> {
         unreachable!("not implemented")
     }
 
     // runtime_identifier_ref / runtime_identifier / call_runtime: moved to ungated impl (round-G).
 
     pub fn extract_decls_for_binding(
-        binding: Binding,
-        decls: &mut ListManaged<'a, G::Decl>,
+        binding: Binding<'a>,
+        decls: &mut ListManaged<'a, G::Decl<'a>>,
     ) -> Result<(), bun_core::Error> {
         match binding.data {
             js_ast::b::B::BMissing(_) => {}
@@ -7768,7 +7769,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     #[inline]
-    pub fn module_exports(&mut self, loc: bun_ast::Loc) -> Expr {
+    pub fn module_exports(&mut self, loc: bun_ast::Loc) -> Expr<'a> {
         let target = self.new_expr(
             E::Identifier {
                 ref_: self.module_ref,
@@ -7866,7 +7867,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // compute_ts_enums_map() lives in the round-G `to_ast` impl block below
     // (deduped — earlier draft body removed once both un-gated).
 
-    pub fn should_lower_using_declarations(&self, stmts: &[Stmt]) -> bool {
+    pub fn should_lower_using_declarations(&self, stmts: &[Stmt<'a>]) -> bool {
         // TODO: We do not support lowering await, but when we do this needs to point to that var
         let lower_await = false;
 
@@ -7904,7 +7905,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ///
     /// This function replaces all specifier strings with `e_special.resolved_specifier_string`
     // blocked_on: rewrite_import_meta_hot_accept_string; Log::add_error wants &[u8] (IMPORT_META_HOT_ACCEPT_ERR is &str)
-    pub fn handle_import_meta_hot_accept_call(&mut self, call: &mut E::Call) {
+    pub fn handle_import_meta_hot_accept_call(&mut self, call: &mut E::Call<'a>) {
         if call.args.len_u32() == 0 {
             return;
         }
@@ -7946,9 +7947,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // blocked_on: EString::to_utf8 arena arg; ImportRecordList::items() accessor; E::Special::ResolvedSpecifierString takes u32 directly (drop ResolvedSpecifierStringIndex::init)
     fn rewrite_import_meta_hot_accept_string(
         &mut self,
-        str_: &mut E::String,
+        str_: &mut E::String<'a>,
         loc: bun_ast::Loc,
-    ) -> Option<js_ast::ExprData> {
+    ) -> Option<js_ast::ExprData<'a>> {
         let _ = str_.to_utf8(self.arena);
         let specifier = str_.data;
 
@@ -7973,7 +7974,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn handle_react_refresh_register(
         &mut self,
-        stmts: &mut ListManaged<'a, Stmt>,
+        stmts: &mut ListManaged<'a, Stmt<'a>>,
         original_name: &'a [u8],
         r#ref: Ref,
         export_kind: ReactRefreshExportKind,
@@ -7989,7 +7990,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn emit_react_refresh_register(
         &mut self,
-        stmts: &mut ListManaged<'a, Stmt>,
+        stmts: &mut ListManaged<'a, Stmt<'a>>,
         original_name: &'a [u8],
         r#ref: Ref,
         export_kind: ReactRefreshExportKind,
@@ -8031,9 +8032,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn wrap_value_for_server_component_reference(
         &mut self,
-        val: Expr,
+        val: Expr<'a>,
         original_name: &'a [u8],
-    ) -> Expr {
+    ) -> Expr<'a> {
         debug_assert!(self.options.features.server_components.wraps_exports());
         debug_assert!(self.current_scope == self.module_scope);
 
@@ -8070,7 +8071,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn handle_react_refresh_hook_call(
         &mut self,
-        hook_call: &mut E::Call,
+        hook_call: &mut E::Call<'a>,
         original_name: &[u8],
     ) {
         debug_assert!(self.options.features.react_fast_refresh);
@@ -8182,7 +8183,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn handle_react_refresh_post_visit_function_body(
         &mut self,
-        stmts: &mut ListManaged<'a, Stmt>,
+        stmts: &mut ListManaged<'a, Stmt<'a>>,
         hook: &crate::HookContext,
     ) {
         debug_assert!(self.options.features.react_fast_refresh);
@@ -8224,7 +8225,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         stmts[0] = prepended_stmt;
     }
 
-    pub fn get_react_refresh_hook_signal_decl(&mut self, signal_cb_ref: Ref) -> Stmt {
+    pub fn get_react_refresh_hook_signal_decl(&mut self, signal_cb_ref: Ref) -> Stmt<'a> {
         let loc = bun_ast::Loc::EMPTY;
         self.react_refresh.latest_signature_ref = signal_cb_ref;
         // var s_ = $RefreshSig$();
@@ -8252,9 +8253,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn get_react_refresh_hook_signal_init(
         &mut self,
-        ctx: &mut crate::HookContext,
-        function_with_hook_calls: Expr,
-    ) -> Expr {
+        ctx: &mut crate::HookContext<'a>,
+        function_with_hook_calls: Expr<'a>,
+    ) -> Expr<'a> {
         let loc = bun_ast::Loc::EMPTY;
 
         let final_ = ctx.hasher.final_();
@@ -8331,11 +8332,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
     pub fn to_ast(
         &mut self,
-        parts: &mut ListManaged<'a, js_ast::Part>,
+        parts: &mut ListManaged<'a, js_ast::Part<'a>>,
         exports_kind: js_ast::ExportsKind,
         wrap_mode: WrapMode,
         hashbang: &'a [u8],
-    ) -> Result<Box<js_ast::Ast>, bun_core::Error> {
+    ) -> Result<Box<js_ast::Ast<'a>>, bun_core::Error> {
         use crate::lower::lower_esm_exports_hmr::ConvertESMExportsForHmr;
         use crate::scan::scan_imports::ImportScanner;
 
@@ -8700,9 +8701,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // PORT NOTE: closure captures (top_level, symbols) via the `ctx` arg of
             // `for_each_top_level_symbol`, since the iterator borrows `parts` while the
             // closure mutates `top_level_symbols_to_parts` (disjoint from `self.symbols`).
-            struct Ctx<'s> {
+            struct Ctx<'s, 'arena> {
                 top_level: &'s mut bun_ast::ast_result::TopLevelSymbolToParts,
-                symbols: &'s [Symbol],
+                symbols: &'s [Symbol<'arena>],
                 part_index: u32,
             }
             for (part_index, part) in parts.iter_mut().enumerate() {
@@ -8714,7 +8715,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 DeclaredSymbol::for_each_top_level_symbol(
                     &mut part.declared_symbols,
                     &mut ctx,
-                    |ctx: &mut Ctx<'_>, input: Ref| {
+                    |ctx: &mut Ctx<'_, '_>, input: Ref| {
                         // If this symbol was merged, use the symbol at the end of the
                         // linked list in the map. This is the case for multiple "var"
                         // declarations with the same name, for example.
@@ -8922,7 +8923,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     pub fn compute_ts_enums_map(
         &self,
         _arena: &'a Bump,
-    ) -> Result<bun_ast::ast_result::TsEnumsMap, bun_core::Error> {
+    ) -> Result<bun_ast::ast_result::TsEnumsMap<'a>, bun_core::Error> {
         // When hot module reloading is enabled, we disable enum inlining
         // to avoid making the HMR graph more complicated.
         if self.options.features.hot_module_reloading {
@@ -9340,7 +9341,7 @@ impl LowerUsingDeclarationsContext {
     pub fn scan_stmts<'a, const T: bool, const S_: bool>(
         &mut self,
         p: &mut P<'a, T, S_>,
-        stmts: &mut [Stmt],
+        stmts: &mut [Stmt<'a>],
     ) {
         for stmt in stmts.iter_mut() {
             // PORT NOTE: Zig `switch (stmt.data) { .s_local => |local| ... }` —
@@ -9406,11 +9407,11 @@ impl LowerUsingDeclarationsContext {
     }
 
     pub fn finalize<'a, const T: bool, const S_: bool>(
-        &mut self,
+        self,
         p: &mut P<'a, T, S_>,
-        stmts: &'a mut [Stmt],
+        stmts: &'a mut [Stmt<'a>],
         should_hoist_fns: bool,
-    ) -> ListManaged<'a, Stmt> {
+    ) -> ListManaged<'a, Stmt<'a>> {
         let mut result = BumpVec::new_in(p.arena);
         let mut exports = BumpVec::<js_ast::ClauseItem>::new_in(p.arena);
         let mut end: u32 = 0;
@@ -9737,15 +9738,15 @@ pub trait GenerateImportSymbols {
 // In Zig these were mutable file-level vars used as canonical singletons; in Rust we
 // expose constructor fns since `js_ast::ExprData` has interior pointers and isn't `const`.
 #[inline]
-pub fn null_expr_data() -> js_ast::ExprData {
+pub fn null_expr_data<'arena>() -> js_ast::ExprData<'arena> {
     js_ast::ExprData::EMissing(E::Missing {})
 }
 #[inline]
-pub fn null_stmt_data() -> js_ast::StmtData {
+pub fn null_stmt_data<'arena>() -> js_ast::StmtData<'arena> {
     js_ast::StmtData::SEmpty(S::Empty {})
 }
 #[inline]
-pub fn key_expr_data() -> js_ast::ExprData {
+pub fn key_expr_data<'arena>() -> js_ast::ExprData<'arena> {
     // PORT NOTE: Zig's `&Prefill.String.Key` was a `*E.String` to a static.
     // `ExprData::EString` now wraps a `StoreRef<EString>`; allocate a fresh
     // store node from the prefill constant on each call (callers are JSX-only
@@ -9754,11 +9755,11 @@ pub fn key_expr_data() -> js_ast::ExprData {
     E::String::init(b"key").into_data_store()
 }
 #[inline]
-pub fn null_value_expr() -> js_ast::ExprData {
+pub fn null_value_expr<'arena>() -> js_ast::ExprData<'arena> {
     js_ast::ExprData::ENull(E::Null {})
 }
 #[inline]
-pub fn false_value_expr() -> js_ast::ExprData {
+pub fn false_value_expr<'arena>() -> js_ast::ExprData<'arena> {
     js_ast::ExprData::EBoolean(E::Boolean { value: false })
 }
 

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -55,13 +55,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         &mut self,
         level: Level,
         errors: Option<&mut DeferredErrors>,
-        expr: &mut Expr,
+        expr: &mut Expr<'a>,
     ) -> Result<(), Error> {
         self.parse_expr_common(level, errors, EFlags::None, expr)
     }
     // Zig: `inline fn parseExpr(p, level) !Expr`
     #[inline]
-    pub fn parse_expr(&mut self, level: Level) -> Result<Expr, Error> {
+    pub fn parse_expr(&mut self, level: Level) -> Result<Expr<'a>, Error> {
         let mut expr = Expr::EMPTY;
         self.parse_expr_common(level, None, EFlags::None, &mut expr)?;
         Ok(expr)
@@ -72,7 +72,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         &mut self,
         level: Level,
         flags: EFlags,
-        expr: &mut Expr,
+        expr: &mut Expr<'a>,
     ) -> Result<(), Error> {
         self.parse_expr_common(level, None, flags, expr)
     }
@@ -81,7 +81,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         level: Level,
         mut errors: Option<&mut DeferredErrors>,
         flags: EFlags,
-        expr: &mut Expr,
+        expr: &mut Expr<'a>,
     ) -> Result<(), Error> {
         if !self.stack_check.is_safe_to_recurse() {
             return Err(err!("StackOverflow"));
@@ -115,7 +115,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(())
     }
 
-    pub fn parse_yield_expr(&mut self, loc: bun_ast::Loc) -> Result<Expr, Error> {
+    pub fn parse_yield_expr(&mut self, loc: bun_ast::Loc) -> Result<Expr<'a>, Error> {
         let p = self;
         // Parse a yield-from expression, which yields from an iterator
         let is_star = p.lexer.token == T::TAsterisk;
@@ -153,7 +153,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         class_keyword: bun_ast::Range,
         name: Option<js_ast::LocRef>,
         class_opts: ParseClassOptions<'a>,
-    ) -> Result<G::Class, Error> {
+    ) -> Result<G::Class<'a>, Error> {
         let p = self;
         let mut extends: Option<Expr> = None;
         let mut has_decorators: bool = false;
@@ -290,7 +290,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     pub fn parse_template_parts(
         &mut self,
         include_raw: bool,
-    ) -> Result<(bun_ast::StoreSlice<E::TemplatePart>, bun_ast::Loc), Error> {
+    ) -> Result<(bun_ast::StoreSlice<'a, E::TemplatePart<'a>>, bun_ast::Loc), Error> {
         let p = self;
         let mut parts = BumpVec::<E::TemplatePart>::with_capacity_in(1, p.arena);
         // Allow "in" inside template literals
@@ -335,7 +335,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     // This assumes the caller has already checked for TStringLiteral or TNoSubstitutionTemplateLiteral
-    pub fn parse_string_literal(&mut self) -> Result<Expr, Error> {
+    pub fn parse_string_literal(&mut self) -> Result<Expr<'a>, Error> {
         let p = self;
         let loc = p.lexer.loc();
         let mut str_ = p.lexer.to_e_string()?;
@@ -346,7 +346,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(expr)
     }
 
-    pub fn parse_call_args(&mut self) -> Result<ExprListLoc, Error> {
+    pub fn parse_call_args(&mut self) -> Result<ExprListLoc<'a>, Error> {
         let p = self;
         // Allow "in" inside call arguments
         let old_allow_in = p.allow_in;
@@ -385,7 +385,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     pub fn parse_jsx_prop_value_identifier(
         &mut self,
         previous_string_with_backslash_loc: &mut bun_ast::Loc,
-    ) -> Result<Expr, Error> {
+    ) -> Result<Expr<'a>, Error> {
         let p = self;
         // Use NextInsideJSXElement() not Next() so we can parse a JSX-style string literal
         p.lexer.next_inside_jsx_element()?;
@@ -416,7 +416,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         loc: bun_ast::Loc,
         level: Level,
         opts: ParenExprOpts,
-    ) -> Result<Expr, Error> {
+    ) -> Result<Expr<'a>, Error> {
         let p = self;
         let mut items_list = BumpVec::<Expr>::new_in(p.arena);
         let mut errors = DeferredErrors::default();
@@ -659,7 +659,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         &mut self,
         loc: bun_ast::Loc,
         opts: &mut ParseStatementOptions<'a>,
-    ) -> Result<Stmt, Error> {
+    ) -> Result<Stmt<'a>, Error> {
         let p = self;
         let mut name: Option<js_ast::LocRef> = None;
         let class_keyword = p.lexer.range();
@@ -785,7 +785,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     pub fn parse_expr_or_let_stmt(
         &mut self,
         opts: &mut ParseStatementOptions<'a>,
-    ) -> Result<ExprOrLetStmt, Error> {
+    ) -> Result<ExprOrLetStmt<'a>, Error> {
         let p = self;
         let token_range = p.lexer.range();
 
@@ -963,7 +963,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(result)
     }
 
-    pub fn parse_binding(&mut self, opts: ParseBindingOptions) -> Result<Binding, Error> {
+    pub fn parse_binding(&mut self, opts: ParseBindingOptions) -> Result<Binding<'a>, Error> {
         let p = self;
         let loc = p.lexer.loc();
 
@@ -1139,7 +1139,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         })
     }
 
-    pub fn parse_property_binding(&mut self) -> Result<B::Property, Error> {
+    pub fn parse_property_binding(&mut self) -> Result<B::Property<'a>, Error> {
         let p = self;
         // Every match arm below assigns `key` (or `return`s) before any read.
         let key: Expr;
@@ -1251,7 +1251,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         &mut self,
         kind: js_ast::symbol::Kind,
         opts: &mut ParseStatementOptions<'a>,
-    ) -> Result<G::DeclList, Error> {
+    ) -> Result<G::DeclList<'a>, Error> {
         let p = self;
         let mut decls = BumpVec::<G::Decl>::new_in(p.arena);
 
@@ -1545,7 +1545,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         &mut self,
         async_range: bun_ast::Range,
         level: Level,
-    ) -> Result<Expr, Error> {
+    ) -> Result<Expr<'a>, Error> {
         let p = self;
         // "async function() {}"
         if !p.lexer.has_newline_before && p.lexer.token == T::TFunction {

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -83,7 +83,7 @@ pub struct Options<'a> {
     pub use_define_for_class_fields: bool,
     pub suppress_warnings_about_weird_code: bool,
     pub filepath_hash_for_hmr: u32,
-    pub features: RuntimeFeatures,
+    pub features: RuntimeFeatures<'a>,
 
     pub tree_shaking: bool,
     pub bundle: bool,
@@ -317,14 +317,14 @@ impl<'a> Options<'a> {
 impl<'a> Parser<'a> {
     pub fn init(
         options: Options<'a>,
-        log: &'a mut bun_ast::Log,
+        log: &mut bun_ast::Log,
         source: &'a bun_ast::Source,
         define: &'a Define,
         bump: &'a Arena,
     ) -> Result<Parser<'a>, Error> {
         let lexer = js_lexer::Lexer::init(log, source, bump)?;
         // Copy the lexer's `NonNull<Log>` so both handles share one provenance
-        // chain (the `&'a mut Log` was consumed by `Lexer::init`).
+        // chain (the `&mut Log` was consumed by `Lexer::init`).
         let log_ptr = lexer.log;
         Ok(Parser {
             options,
@@ -357,7 +357,7 @@ impl<'a> Parser<'a> {
 // surface lands.
 impl<'a> Parser<'a> {
     #[cfg_attr(not(target_arch = "wasm32"), allow(unused_mut))]
-    pub fn parse(mut self) -> Result<crate::Result, Error> {
+    pub fn parse(mut self) -> Result<crate::Result<'a>, Error> {
         // TODO(port): narrow error set
         #[cfg(target_arch = "wasm32")]
         {
@@ -384,7 +384,7 @@ impl<'a> Parser<'a> {
     /// `bun run`, so keep the `_scan_imports` monomorphizations out of the hot
     /// `.text` between the lexer and the live `_parse` bodies.
     #[cold]
-    pub fn scan_imports(&mut self, scan_pass: &'a mut ScanPassResult) -> Result<(), Error> {
+    pub fn scan_imports(&mut self, scan_pass: &'a mut ScanPassResult<'a>) -> Result<(), Error> {
         if self.options.ts {
             self._scan_imports::<true>(scan_pass)
         } else {
@@ -395,7 +395,7 @@ impl<'a> Parser<'a> {
     #[cold]
     fn _scan_imports<const TS: bool>(
         &mut self,
-        scan_pass: &'a mut ScanPassResult,
+        scan_pass: &'a mut ScanPassResult<'a>,
     ) -> Result<(), Error> {
         type Pi<'a, const TS: bool> = P<'a, TS, true>;
         // Zig moves lexer/options by value into `P` (Parser.zig) and only
@@ -541,10 +541,10 @@ impl<'a> Parser<'a> {
 
     pub fn to_lazy_export_ast(
         &mut self,
-        expr: Expr,
+        expr: Expr<'a>,
         runtime_api_call: &'static [u8],
-        symbols: js_ast::symbol::List,
-    ) -> Result<crate::Result, Error> {
+        symbols: js_ast::symbol::List<'a>,
+    ) -> Result<crate::Result<'a>, Error> {
         // TODO(port): narrow error set
         // Zig moves lexer/options by value into `P` (Parser.zig) and only
         // `defer p.lexer.deinit()` cleans up — Zig has no implicit destructor
@@ -734,7 +734,7 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
-    fn _parse<const TS: bool>(self) -> Result<crate::Result, Error> {
+    fn _parse<const TS: bool>(self) -> Result<crate::Result<'a>, Error> {
         // TODO(port): narrow error set
         // TODO(b2-blocked): bun_crash_handler::current_action — `Action` stores
         // `&'static [u8]` but `self.source.path.text` is `'a`; Phase B widens
@@ -1343,8 +1343,8 @@ impl<'a> Parser<'a> {
             //
             // When tree-shaking is enabled, each statement becomes its own part, so we need
             // to look across all parts to find the single meaningful statement.
-            struct StmtAndPart {
-                stmt: Stmt,
+            struct StmtAndPart<'arena> {
+                stmt: Stmt<'arena>,
                 part_idx: usize,
             }
             let stmt_and_part: Option<StmtAndPart> = 'brk: {

--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -28,7 +28,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         loc: bun_ast::Loc,
         opts: &mut ParseStatementOptions,
         async_range: Option<bun_ast::Range>,
-    ) -> Result<Stmt, Error> {
+    ) -> Result<Stmt<'a>, Error> {
         let p = self;
         let is_generator = p.lexer.token == T::TAsterisk;
         let is_async = async_range.is_some();
@@ -170,7 +170,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         &mut self,
         name: Option<js_ast::LocRef>,
         opts: FnOrArrowDataParse,
-    ) -> Result<G::Fn, Error> {
+    ) -> Result<G::Fn<'a>, Error> {
         let p = self;
         // if data.allowAwait and data.allowYield {
         //     p.markSyntaxFeature(compat.AsyncGenerator, data.asyncRange)
@@ -425,7 +425,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         loc: bun_ast::Loc,
         is_async: bool,
         async_range: bun_ast::Range,
-    ) -> Result<Expr, Error> {
+    ) -> Result<Expr<'a>, Error> {
         let p = self;
         p.lexer.next()?;
         let is_generator = p.lexer.token == T::TAsterisk;
@@ -492,7 +492,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(p.new_expr(E::Function { func }, loc))
     }
 
-    pub fn parse_fn_body(&mut self, data: &mut FnOrArrowDataParse) -> Result<G::FnBody, Error> {
+    pub fn parse_fn_body(&mut self, data: &mut FnOrArrowDataParse) -> Result<G::FnBody<'a>, Error> {
         let p = self;
         let old_fn_or_arrow_data = p.fn_or_arrow_data_parse.clone();
         let old_allow_in = p.allow_in;
@@ -526,9 +526,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn parse_arrow_body(
         &mut self,
-        args: &'a mut [G::Arg],
+        args: &'a mut [G::Arg<'a>],
         data: &mut FnOrArrowDataParse,
-    ) -> Result<E::Arrow, Error> {
+    ) -> Result<E::Arrow<'a>, Error> {
         let p = self;
         let arrow_loc = p.lexer.loc();
 

--- a/src/js_parser/parse/parse_import_export.rs
+++ b/src/js_parser/parse/parse_import_export.rs
@@ -14,7 +14,7 @@ use bun_core::Error;
 
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
     /// Note: The caller has already parsed the "import" keyword
-    pub fn parse_import_expr(&mut self, loc: bun_ast::Loc, level: Level) -> Result<Expr, Error> {
+    pub fn parse_import_expr(&mut self, loc: bun_ast::Loc, level: Level) -> Result<Expr<'a>, Error> {
         let p = self;
         // Parse an "import.meta" expression
         if p.lexer.token == T::TDot {

--- a/src/js_parser/parse/parse_jsx.rs
+++ b/src/js_parser/parse/parse_jsx.rs
@@ -16,7 +16,7 @@ use bun_core::strings;
 // (sealed trait + ZST), so this becomes a direct `impl` on `P` instead of a wrapper struct.
 
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
-    pub fn parse_jsx_element(&mut self, loc: bun_ast::Loc) -> Result<Expr, bun_core::Error> {
+    pub fn parse_jsx_element(&mut self, loc: bun_ast::Loc) -> Result<Expr<'a>, bun_core::Error> {
         let p = self;
         if SCAN_ONLY {
             p.needs_jsx_import = true;

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -32,7 +32,7 @@ type PResult<T> = core::result::Result<T, bun_core::Error>;
 // names pfx_-prefixed to avoid colliding with parseStmt.rs / parseSuffix.rs mixins on the same `P`.
 
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
-    fn pfx_t_super(p: &mut Self, level: Level) -> PResult<Expr> {
+    fn pfx_t_super(p: &mut Self, level: Level) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         let super_range = p.lexer.range();
         p.lexer.next()?;
@@ -56,7 +56,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(p.new_expr(E::Super {}, loc))
     }
 
-    fn pfx_t_open_paren(p: &mut Self, level: Level) -> PResult<Expr> {
+    fn pfx_t_open_paren(p: &mut Self, level: Level) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         p.lexer.next()?;
 
@@ -78,28 +78,28 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     #[inline]
-    fn pfx_t_false(p: &mut Self) -> PResult<Expr> {
+    fn pfx_t_false(p: &mut Self) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         p.lexer.next()?;
         Ok(p.new_expr(E::Boolean { value: false }, loc))
     }
 
     #[inline]
-    fn pfx_t_true(p: &mut Self) -> PResult<Expr> {
+    fn pfx_t_true(p: &mut Self) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         p.lexer.next()?;
         Ok(p.new_expr(E::Boolean { value: true }, loc))
     }
 
     #[inline]
-    fn pfx_t_null(p: &mut Self) -> PResult<Expr> {
+    fn pfx_t_null(p: &mut Self) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         p.lexer.next()?;
         Ok(p.new_expr(E::Null {}, loc))
     }
 
     #[inline]
-    fn pfx_t_this(p: &mut Self) -> PResult<Expr> {
+    fn pfx_t_this(p: &mut Self) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         if p.fn_or_arrow_data_parse.is_this_disallowed {
             p.log()
@@ -112,7 +112,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         })
     }
 
-    fn pfx_t_private_identifier(p: &mut Self, level: Level) -> PResult<Expr> {
+    fn pfx_t_private_identifier(p: &mut Self, level: Level) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         if !p.allow_private_identifiers || !p.allow_in || level.gte(Level::Compare) {
             p.lexer.unexpected()?;
@@ -131,7 +131,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(p.new_expr(E::PrivateIdentifier { ref_ }, loc))
     }
 
-    fn pfx_t_identifier(p: &mut Self, level: Level) -> PResult<Expr> {
+    fn pfx_t_identifier(p: &mut Self, level: Level) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         let name = p.lexer.identifier;
 
@@ -291,7 +291,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Expr::init_identifier(ref_, loc))
     }
 
-    fn pfx_t_template_head(p: &mut Self) -> PResult<Expr> {
+    fn pfx_t_template_head(p: &mut Self) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         let head = p.lexer.to_e_string()?;
 
@@ -311,7 +311,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     #[inline]
-    fn pfx_t_numeric_literal(p: &mut Self) -> PResult<Expr> {
+    fn pfx_t_numeric_literal(p: &mut Self) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         let value = p.new_expr(
             E::Number {
@@ -325,7 +325,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     #[inline]
-    fn pfx_t_big_integer_literal(p: &mut Self) -> PResult<Expr> {
+    fn pfx_t_big_integer_literal(p: &mut Self) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         let value = E::Str::new(p.lexer.identifier);
         // markSyntaxFeature bigInt
@@ -333,7 +333,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(p.new_expr(E::BigInt { value }, loc))
     }
 
-    fn pfx_t_slash(p: &mut Self) -> PResult<Expr> {
+    fn pfx_t_slash(p: &mut Self) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         p.lexer.scan_reg_exp()?;
         // always set regex_flags_start to null to make sure we don't accidentally use the wrong value later
@@ -355,7 +355,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         ))
     }
 
-    fn pfx_t_void(p: &mut Self) -> PResult<Expr> {
+    fn pfx_t_void(p: &mut Self) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         p.lexer.next()?;
         let value = p.parse_expr(Level::Prefix)?;
@@ -374,7 +374,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         ))
     }
 
-    fn pfx_t_typeof(p: &mut Self) -> PResult<Expr> {
+    fn pfx_t_typeof(p: &mut Self) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         p.lexer.next()?;
         let value = p.parse_expr(Level::Prefix)?;
@@ -397,7 +397,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         ))
     }
 
-    fn pfx_t_delete(p: &mut Self) -> PResult<Expr> {
+    fn pfx_t_delete(p: &mut Self) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         p.lexer.next()?;
         let value = p.parse_expr(Level::Prefix)?;
@@ -441,7 +441,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         ))
     }
 
-    fn pfx_t_plus(p: &mut Self) -> PResult<Expr> {
+    fn pfx_t_plus(p: &mut Self) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         p.lexer.next()?;
         let value = p.parse_expr(Level::Prefix)?;
@@ -460,7 +460,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         ))
     }
 
-    fn pfx_t_minus(p: &mut Self) -> PResult<Expr> {
+    fn pfx_t_minus(p: &mut Self) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         p.lexer.next()?;
         let value = p.parse_expr(Level::Prefix)?;
@@ -479,7 +479,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         ))
     }
 
-    fn pfx_t_tilde(p: &mut Self) -> PResult<Expr> {
+    fn pfx_t_tilde(p: &mut Self) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         p.lexer.next()?;
         let value = p.parse_expr(Level::Prefix)?;
@@ -498,7 +498,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         ))
     }
 
-    fn pfx_t_exclamation(p: &mut Self) -> PResult<Expr> {
+    fn pfx_t_exclamation(p: &mut Self) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         p.lexer.next()?;
         let value = p.parse_expr(Level::Prefix)?;
@@ -517,7 +517,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         ))
     }
 
-    fn pfx_t_minus_minus(p: &mut Self) -> PResult<Expr> {
+    fn pfx_t_minus_minus(p: &mut Self) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         p.lexer.next()?;
         let value = p.parse_expr(Level::Prefix)?;
@@ -531,7 +531,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         ))
     }
 
-    fn pfx_t_plus_plus(p: &mut Self) -> PResult<Expr> {
+    fn pfx_t_plus_plus(p: &mut Self) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         p.lexer.next()?;
         let value = p.parse_expr(Level::Prefix)?;
@@ -546,12 +546,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     #[inline]
-    fn pfx_t_function(p: &mut Self) -> PResult<Expr> {
+    fn pfx_t_function(p: &mut Self) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         p.parse_fn_expr(loc, false, bun_ast::Range::NONE)
     }
 
-    fn pfx_t_class(p: &mut Self) -> PResult<Expr> {
+    fn pfx_t_class(p: &mut Self) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         let class_keyword = p.lexer.range();
         // markSyntaxFEatuer class
@@ -609,7 +609,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(p.new_expr(class, loc))
     }
 
-    fn pfx_t_at(p: &mut Self) -> PResult<Expr> {
+    fn pfx_t_at(p: &mut Self) -> PResult<Expr<'a>> {
         // Parse decorators before a class expression: @dec class { ... }
         let ts_decorators = p.parse_type_script_decorators()?;
 
@@ -683,7 +683,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(p.new_expr(class, loc))
     }
 
-    fn pfx_t_new(p: &mut Self, flags: EFlags) -> PResult<Expr> {
+    fn pfx_t_new(p: &mut Self, flags: EFlags) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         p.lexer.next()?;
 
@@ -735,7 +735,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         ))
     }
 
-    fn pfx_t_open_bracket(p: &mut Self, mut errors: Option<&mut DeferredErrors>) -> PResult<Expr> {
+    fn pfx_t_open_bracket(p: &mut Self, mut errors: Option<&mut DeferredErrors>) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         p.lexer.next()?;
         let mut is_single_line = !p.lexer.has_newline_before;
@@ -829,7 +829,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         ))
     }
 
-    fn pfx_t_open_brace(p: &mut Self, errors: Option<&mut DeferredErrors>) -> PResult<Expr> {
+    fn pfx_t_open_brace(p: &mut Self, errors: Option<&mut DeferredErrors>) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         p.lexer.next()?;
         let mut is_single_line = !p.lexer.has_newline_before;
@@ -932,7 +932,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         level: Level,
         errors: Option<&mut DeferredErrors>,
         flags: EFlags,
-    ) -> PResult<Expr> {
+    ) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         // This is a very complicated and highly ambiguous area of TypeScript
         // syntax. Many similar-looking things are overloaded.
@@ -1029,7 +1029,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     #[inline]
-    fn pfx_t_import(p: &mut Self, level: Level) -> PResult<Expr> {
+    fn pfx_t_import(p: &mut Self, level: Level) -> PResult<Expr<'a>> {
         let loc = p.lexer.loc();
         p.lexer.next()?;
         p.parse_import_expr(loc, level)
@@ -1041,7 +1041,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         level: Level,
         errors: Option<&mut DeferredErrors>,
         flags: EFlags,
-    ) -> PResult<Expr> {
+    ) -> PResult<Expr<'a>> {
         let p = self;
         match p.lexer.token {
             T::TOpenBracket => Self::pfx_t_open_bracket(p, errors),

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -33,11 +33,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn parse_method_expression(
         &mut self,
         kind: PropertyKind,
-        opts: &mut PropertyOpts,
+        opts: &mut PropertyOpts<'a>,
         is_computed: bool,
-        key: &mut Expr,
+        key: &mut Expr<'a>,
         key_range: bun_ast::Range,
-    ) -> Result<Option<G::Property>, bun_core::Error> {
+    ) -> Result<Option<G::Property<'a>>, bun_core::Error> {
         let p = self;
         if p.lexer.token == T::TOpenParen && kind != PropertyKind::Get && kind != PropertyKind::Set
         {
@@ -252,9 +252,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     pub fn parse_property(
         &mut self,
         kind_: PropertyKind,
-        opts: &mut PropertyOpts,
+        opts: &mut PropertyOpts<'a>,
         errors_: Option<&mut DeferredErrors>,
-    ) -> Result<Option<G::Property>, bun_core::Error> {
+    ) -> Result<Option<G::Property<'a>>, bun_core::Error> {
         let p = self;
         if !p.stack_check.is_safe_to_recurse() {
             return Err(err!("StackOverflow"));

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -57,7 +57,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // spread across sibling monomorphizations that fault-around drags in.
 
     #[inline]
-    fn t_semicolon(p: &mut Self) -> Result<Stmt> {
+    fn t_semicolon(p: &mut Self) -> Result<Stmt<'a>> {
         p.lexer.next()?;
         Ok(Stmt::empty())
     }
@@ -67,7 +67,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p: &mut Self,
         opts: &mut ParseStatementOptions<'a>,
         loc: bun_ast::Loc,
-    ) -> Result<Stmt> {
+    ) -> Result<Stmt<'a>> {
         p.lexer.next()?;
         p.parse_fn_stmt(loc, opts, None)
     }
@@ -78,7 +78,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p: &mut Self,
         opts: &mut ParseStatementOptions<'a>,
         loc: bun_ast::Loc,
-    ) -> Result<Stmt> {
+    ) -> Result<Stmt<'a>> {
         if !Self::IS_TYPESCRIPT_ENABLED {
             p.lexer.unexpected()?;
             return Err(err!("SyntaxError"));
@@ -88,7 +88,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     #[cold]
     #[inline(never)]
-    fn t_at(p: &mut Self, opts: &mut ParseStatementOptions<'a>) -> Result<Stmt> {
+    fn t_at(p: &mut Self, opts: &mut ParseStatementOptions<'a>) -> Result<Stmt<'a>> {
         // Parse decorators before class statements, which are potentially exported
         if Self::IS_TYPESCRIPT_ENABLED || p.options.features.standard_decorators {
             let scope_index = p.scopes_in_order.len();
@@ -145,7 +145,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p: &mut Self,
         opts: &mut ParseStatementOptions<'a>,
         loc: bun_ast::Loc,
-    ) -> Result<Stmt> {
+    ) -> Result<Stmt<'a>> {
         if opts.lexical_decl != LexicalDecl::AllowAll {
             p.forbid_lexical_decl(loc)?;
         }
@@ -158,7 +158,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p: &mut Self,
         opts: &mut ParseStatementOptions<'a>,
         loc: bun_ast::Loc,
-    ) -> Result<Stmt> {
+    ) -> Result<Stmt<'a>> {
         p.lexer.next()?;
         let decls = p.parse_and_declare_decls(js_ast::symbol::Kind::Hoisted, opts)?;
         p.lexer.expect_or_insert_semicolon()?;
@@ -178,7 +178,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p: &mut Self,
         opts: &mut ParseStatementOptions<'a>,
         loc: bun_ast::Loc,
-    ) -> Result<Stmt> {
+    ) -> Result<Stmt<'a>> {
         if opts.lexical_decl != LexicalDecl::AllowAll {
             p.forbid_lexical_decl(loc)?;
         }
@@ -209,7 +209,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     #[inline(never)]
-    fn t_if(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt> {
+    fn t_if(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt<'a>> {
         let mut current_loc = loc;
         let mut root_if: Option<Stmt> = None;
         // PORT NOTE: `StoreRef` (arena back-pointer with safe `Deref`/`DerefMut`)
@@ -283,7 +283,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     #[cold]
     #[inline(never)]
-    fn t_do(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt> {
+    fn t_do(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt<'a>> {
         p.lexer.next()?;
         let mut stmt_opts = ParseStatementOptions::default();
         let body = p.parse_stmt(&mut stmt_opts)?;
@@ -301,7 +301,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     #[inline(never)]
-    fn t_while(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt> {
+    fn t_while(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt<'a>> {
         p.lexer.next()?;
 
         p.lexer.expect(T::TOpenParen)?;
@@ -316,7 +316,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     #[cold]
     #[inline(never)]
-    fn t_with(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt> {
+    fn t_with(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt<'a>> {
         p.lexer.next()?;
         p.lexer.expect(T::TOpenParen)?;
         let test_ = p.parse_expr(Level::Lowest)?;
@@ -342,7 +342,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     #[inline(never)]
-    fn t_switch(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt> {
+    fn t_switch(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt<'a>> {
         p.lexer.next()?;
 
         p.lexer.expect(T::TOpenParen)?;
@@ -417,7 +417,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     #[inline(never)]
-    fn t_try(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt> {
+    fn t_try(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt<'a>> {
         p.lexer.next()?;
         let body_loc = p.lexer.loc();
         p.lexer.expect(T::TOpenBrace)?;
@@ -500,7 +500,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     #[inline(never)]
-    fn t_for(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt> {
+    fn t_for(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt<'a>> {
         let _ = p.push_scope_for_parse_pass(js_ast::scope::Kind::Block, loc)?;
         // Zig: `defer p.popScope()`. Wrap the body in an inner closure so `pop_scope` runs once on
         // its `Result`, covering every `?` early-exit as well as explicit returns.
@@ -710,7 +710,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     #[inline]
-    fn t_break(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt> {
+    fn t_break(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt<'a>> {
         p.lexer.next()?;
         let name = p.parse_label_name()?;
         p.lexer.expect_or_insert_semicolon()?;
@@ -718,7 +718,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     #[inline]
-    fn t_continue(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt> {
+    fn t_continue(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt<'a>> {
         p.lexer.next()?;
         let name = p.parse_label_name()?;
         p.lexer.expect_or_insert_semicolon()?;
@@ -726,7 +726,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     #[inline]
-    fn t_return(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt> {
+    fn t_return(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt<'a>> {
         if p.fn_or_arrow_data_parse.is_return_disallowed {
             p.log().add_range_error(
                 Some(p.source),
@@ -750,7 +750,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     #[inline]
-    fn t_throw(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt> {
+    fn t_throw(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt<'a>> {
         p.lexer.next()?;
         if p.lexer.has_newline_before {
             p.log().add_error(
@@ -769,7 +769,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     #[cold]
     #[inline(never)]
-    fn t_debugger(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt> {
+    fn t_debugger(p: &mut Self, _: &mut ParseStatementOptions, loc: bun_ast::Loc) -> Result<Stmt<'a>> {
         p.lexer.next()?;
         p.lexer.expect_or_insert_semicolon()?;
         Ok(p.s(S::Debugger {}, loc))
@@ -780,7 +780,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p: &mut Self,
         _: &mut ParseStatementOptions,
         loc: bun_ast::Loc,
-    ) -> Result<Stmt> {
+    ) -> Result<Stmt<'a>> {
         let _ = p.push_scope_for_parse_pass(js_ast::scope::Kind::Block, loc)?;
         // Zig: `defer p.popScope()`. Wrap the body in an inner closure so `pop_scope` runs once on
         // its `Result`, covering every `?` early-exit.
@@ -808,7 +808,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p: &mut Self,
         opts: &mut ParseStatementOptions<'a>,
         loc: bun_ast::Loc,
-    ) -> Result<Stmt> {
+    ) -> Result<Stmt<'a>> {
         let previous_export_keyword = p.esm_export_keyword;
         if opts.is_module_scope {
             p.esm_export_keyword = p.lexer.range();
@@ -1355,7 +1355,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p: &mut Self,
         opts: &mut ParseStatementOptions<'a>,
         loc: bun_ast::Loc,
-    ) -> Result<Stmt> {
+    ) -> Result<Stmt<'a>> {
         let previous_import_keyword = p.esm_import_keyword;
         p.esm_import_keyword = p.lexer.range();
         p.lexer.next()?;
@@ -1588,7 +1588,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         loc: bun_ast::Loc,
         label_loc: bun_ast::Loc,
         label_ref: Ref,
-    ) -> Result<Stmt> {
+    ) -> Result<Stmt<'a>> {
         let _ = p.push_scope_for_parse_pass(js_ast::scope::Kind::Label, loc)?;
         // Zig: `defer p.popScope();` — pop after parsing the labeled body.
         // Hand-roll the defer so we can keep `p` exclusively borrowed.
@@ -1618,7 +1618,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p: &mut Self,
         opts: &mut ParseStatementOptions<'a>,
         loc: bun_ast::Loc,
-    ) -> Result<Stmt> {
+    ) -> Result<Stmt<'a>> {
         let is_identifier = p.lexer.token == T::TIdentifier;
         let name = p.lexer.identifier;
         // Parse either an async function, an async expression, or a normal expression.
@@ -1689,7 +1689,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         opts: &mut ParseStatementOptions<'a>,
         loc: bun_ast::Loc,
         ts_stmt: js_lexer::TypescriptStmtKeyword,
-    ) -> Result<Option<Stmt>> {
+    ) -> Result<Option<Stmt<'a>>> {
         match ts_stmt {
             js_lexer::TypescriptStmtKeyword::TsStmtType => {
                 if p.lexer.token == T::TIdentifier && !p.lexer.has_newline_before {
@@ -1826,7 +1826,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(None)
     }
 
-    pub fn parse_stmt(&mut self, opts: &mut ParseStatementOptions<'a>) -> Result<Stmt> {
+    pub fn parse_stmt(&mut self, opts: &mut ParseStatementOptions<'a>) -> Result<Stmt<'a>> {
         // PORT NOTE: Zig only checks `stack_check`; the hard cap is added so
         // Windows' 18 MB worker stack (where the small Rust `parse_stmt`→`t_*`
         // frames never exhaust it) still throws before the uncapped visitor/

--- a/src/js_parser/parse/parse_suffix.rs
+++ b/src/js_parser/parse/parse_suffix.rs
@@ -73,7 +73,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p: &mut Self,
         optional_chain: &mut Option<OptionalChain>,
         old_optional_chain: Option<OptionalChain>,
-        left: &mut Expr,
+        left: &mut Expr<'a>,
     ) -> CResult {
         p.lexer.next()?;
         let target = *left;
@@ -132,7 +132,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p: &mut Self,
         level: Level,
         optional_chain: &mut Option<OptionalChain>,
-        left: &mut Expr,
+        left: &mut Expr<'a>,
     ) -> CResult {
         p.lexer.next()?;
         let mut optional_start: Option<OptionalChain> = Some(OptionalChain::Start);
@@ -277,7 +277,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         _level: Level,
         _optional_chain: &mut Option<OptionalChain>,
         old_optional_chain: Option<OptionalChain>,
-        left: &mut Expr,
+        left: &mut Expr<'a>,
     ) -> CResult {
         if old_optional_chain.is_some() {
             p.log().add_range_error(
@@ -308,7 +308,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         _level: Level,
         _optional_chain: &mut Option<OptionalChain>,
         old_optional_chain: Option<OptionalChain>,
-        left: &mut Expr,
+        left: &mut Expr<'a>,
     ) -> CResult {
         if old_optional_chain.is_some() {
             p.log().add_range_error(
@@ -337,7 +337,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p: &mut Self,
         optional_chain: &mut Option<OptionalChain>,
         old_optional_chain: Option<OptionalChain>,
-        left: &mut Expr,
+        left: &mut Expr<'a>,
         flags: EFlags,
     ) -> CResult {
         // When parsing a decorator, ignore EIndex expressions since they may be
@@ -383,7 +383,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         level: Level,
         optional_chain: &mut Option<OptionalChain>,
         old_optional_chain: Option<OptionalChain>,
-        left: &mut Expr,
+        left: &mut Expr<'a>,
     ) -> CResult {
         if level.gte(Level::Call) {
             return Ok(Continuation::Done);
@@ -410,7 +410,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p: &mut Self,
         level: Level,
         errors: Option<&mut DeferredErrors>,
-        left: &mut Expr,
+        left: &mut Expr<'a>,
     ) -> CResult {
         if level.gte(Level::Conditional) {
             return Ok(Continuation::Done);
@@ -498,7 +498,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_minus_minus(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_minus_minus(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if p.lexer.has_newline_before || level.gte(Level::Postfix) {
             return Ok(Continuation::Done);
         }
@@ -517,7 +517,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_plus_plus(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_plus_plus(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if p.lexer.has_newline_before || level.gte(Level::Postfix) {
             return Ok(Continuation::Done);
         }
@@ -536,7 +536,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_comma(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_comma(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Comma) {
             return Ok(Continuation::Done);
         }
@@ -560,7 +560,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // operators below. Rust has no struct-field-name reflection; each is written out.
     // PORT NOTE: bodies are uniform — `if level.gte(L) {Done}; next; new Binary{op,left,right}`.
 
-    fn sfx_t_plus(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_plus(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Add) {
             return Ok(Continuation::Done);
         }
@@ -579,7 +579,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_plus_equals(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_plus_equals(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Assign) {
             return Ok(Continuation::Done);
         }
@@ -599,7 +599,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_minus(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_minus(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Add) {
             return Ok(Continuation::Done);
         }
@@ -618,7 +618,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_minus_equals(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_minus_equals(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Assign) {
             return Ok(Continuation::Done);
         }
@@ -637,7 +637,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_asterisk(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_asterisk(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Multiply) {
             return Ok(Continuation::Done);
         }
@@ -656,7 +656,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_asterisk_asterisk(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_asterisk_asterisk(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Exponentiation) {
             return Ok(Continuation::Done);
         }
@@ -675,7 +675,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_asterisk_asterisk_equals(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_asterisk_asterisk_equals(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Assign) {
             return Ok(Continuation::Done);
         }
@@ -694,7 +694,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_asterisk_equals(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_asterisk_equals(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Assign) {
             return Ok(Continuation::Done);
         }
@@ -713,7 +713,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_percent(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_percent(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Multiply) {
             return Ok(Continuation::Done);
         }
@@ -732,7 +732,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_percent_equals(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_percent_equals(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Assign) {
             return Ok(Continuation::Done);
         }
@@ -751,7 +751,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_slash(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_slash(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Multiply) {
             return Ok(Continuation::Done);
         }
@@ -770,7 +770,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_slash_equals(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_slash_equals(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Assign) {
             return Ok(Continuation::Done);
         }
@@ -789,7 +789,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_equals_equals(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_equals_equals(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Equals) {
             return Ok(Continuation::Done);
         }
@@ -808,7 +808,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_exclamation_equals(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_exclamation_equals(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Equals) {
             return Ok(Continuation::Done);
         }
@@ -827,7 +827,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_equals_equals_equals(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_equals_equals_equals(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Equals) {
             return Ok(Continuation::Done);
         }
@@ -846,7 +846,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_exclamation_equals_equals(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_exclamation_equals_equals(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Equals) {
             return Ok(Continuation::Done);
         }
@@ -870,7 +870,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         level: Level,
         optional_chain: &mut Option<OptionalChain>,
         old_optional_chain: Option<OptionalChain>,
-        left: &mut Expr,
+        left: &mut Expr<'a>,
     ) -> CResult {
         // TypeScript allows type arguments to be specified with angle brackets
         // inside an expression. Unlike in other languages, this unfortunately
@@ -899,7 +899,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_less_than_equals(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_less_than_equals(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Compare) {
             return Ok(Continuation::Done);
         }
@@ -918,7 +918,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_greater_than(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_greater_than(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Compare) {
             return Ok(Continuation::Done);
         }
@@ -937,7 +937,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_greater_than_equals(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_greater_than_equals(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Compare) {
             return Ok(Continuation::Done);
         }
@@ -961,7 +961,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         level: Level,
         optional_chain: &mut Option<OptionalChain>,
         old_optional_chain: Option<OptionalChain>,
-        left: &mut Expr,
+        left: &mut Expr<'a>,
     ) -> CResult {
         // TypeScript allows type arguments to be specified with angle brackets
         // inside an expression. Unlike in other languages, this unfortunately
@@ -990,7 +990,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_less_than_less_than_equals(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_less_than_less_than_equals(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Assign) {
             return Ok(Continuation::Done);
         }
@@ -1009,7 +1009,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_greater_than_greater_than(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_greater_than_greater_than(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Shift) {
             return Ok(Continuation::Done);
         }
@@ -1031,7 +1031,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn sfx_t_greater_than_greater_than_equals(
         p: &mut Self,
         level: Level,
-        left: &mut Expr,
+        left: &mut Expr<'a>,
     ) -> CResult {
         if level.gte(Level::Assign) {
             return Ok(Continuation::Done);
@@ -1054,7 +1054,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn sfx_t_greater_than_greater_than_greater_than(
         p: &mut Self,
         level: Level,
-        left: &mut Expr,
+        left: &mut Expr<'a>,
     ) -> CResult {
         if level.gte(Level::Shift) {
             return Ok(Continuation::Done);
@@ -1077,7 +1077,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn sfx_t_greater_than_greater_than_greater_than_equals(
         p: &mut Self,
         level: Level,
-        left: &mut Expr,
+        left: &mut Expr<'a>,
     ) -> CResult {
         if level.gte(Level::Assign) {
             return Ok(Continuation::Done);
@@ -1097,7 +1097,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_question_question(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_question_question(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::NullishCoalescing) {
             return Ok(Continuation::Done);
         }
@@ -1116,7 +1116,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_question_question_equals(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_question_question_equals(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Assign) {
             return Ok(Continuation::Done);
         }
@@ -1135,7 +1135,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_bar_bar(p: &mut Self, level: Level, left: &mut Expr, flags: EFlags) -> CResult {
+    fn sfx_t_bar_bar(p: &mut Self, level: Level, left: &mut Expr<'a>, flags: EFlags) -> CResult {
         if level.gte(Level::LogicalOr) {
             return Ok(Continuation::Done);
         }
@@ -1170,7 +1170,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_bar_bar_equals(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_bar_bar_equals(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Assign) {
             return Ok(Continuation::Done);
         }
@@ -1192,7 +1192,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn sfx_t_ampersand_ampersand(
         p: &mut Self,
         level: Level,
-        left: &mut Expr,
+        left: &mut Expr<'a>,
         flags: EFlags,
     ) -> CResult {
         if level.gte(Level::LogicalAnd) {
@@ -1230,7 +1230,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_ampersand_ampersand_equals(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_ampersand_ampersand_equals(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Assign) {
             return Ok(Continuation::Done);
         }
@@ -1249,7 +1249,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_bar(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_bar(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::BitwiseOr) {
             return Ok(Continuation::Done);
         }
@@ -1268,7 +1268,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_bar_equals(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_bar_equals(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Assign) {
             return Ok(Continuation::Done);
         }
@@ -1287,7 +1287,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_ampersand(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_ampersand(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::BitwiseAnd) {
             return Ok(Continuation::Done);
         }
@@ -1306,7 +1306,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_ampersand_equals(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_ampersand_equals(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Assign) {
             return Ok(Continuation::Done);
         }
@@ -1325,7 +1325,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_caret(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_caret(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::BitwiseXor) {
             return Ok(Continuation::Done);
         }
@@ -1344,7 +1344,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_caret_equals(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_caret_equals(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Assign) {
             return Ok(Continuation::Done);
         }
@@ -1363,7 +1363,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_equals(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_equals(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Assign) {
             return Ok(Continuation::Done);
         }
@@ -1382,7 +1382,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_in(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_in(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Compare) || !p.allow_in {
             return Ok(Continuation::Done);
         }
@@ -1410,7 +1410,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(Continuation::Next)
     }
 
-    fn sfx_t_instanceof(p: &mut Self, level: Level, left: &mut Expr) -> CResult {
+    fn sfx_t_instanceof(p: &mut Self, level: Level, left: &mut Expr<'a>) -> CResult {
         if level.gte(Level::Compare) {
             return Ok(Continuation::Done);
         }
@@ -1442,7 +1442,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn parse_suffix(
         &mut self,
-        left: &mut Expr,
+        left: &mut Expr<'a>,
         level: Level,
         mut errors: Option<&mut DeferredErrors>,
         flags: EFlags,

--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -23,7 +23,7 @@ use bun_core::{Error, err};
 // `ts::Data` carries only Copy payloads but lacks a `derive(Clone)` upstream;
 // local helper so we can re-insert values fetched from `ref_to_ts_namespace_member`.
 #[inline]
-fn clone_ts_member_data(d: &TSNamespaceMemberData) -> TSNamespaceMemberData {
+fn clone_ts_member_data<'arena>(d: &TSNamespaceMemberData<'arena>) -> TSNamespaceMemberData<'arena> {
     match d {
         TSNamespaceMemberData::Property => TSNamespaceMemberData::Property,
         TSNamespaceMemberData::Namespace(m) => TSNamespaceMemberData::Namespace(*m),
@@ -39,7 +39,7 @@ fn clone_ts_member_data(d: &TSNamespaceMemberData) -> TSNamespaceMemberData {
 
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
     // TODO(port): narrow error set
-    pub fn parse_type_script_decorators(&mut self) -> Result<ExprNodeList, Error> {
+    pub fn parse_type_script_decorators(&mut self) -> Result<ExprNodeList<'a>, Error> {
         let p = self;
         if !Self::IS_TYPESCRIPT_ENABLED && !p.options.features.standard_decorators {
             return Ok(bun_alloc::AstAlloc::vec());
@@ -85,7 +85,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ///   @ DecoratorCallExpression
     ///   @ DecoratorParenthesizedExpression
     // TODO(port): narrow error set
-    pub fn parse_standard_decorator(&mut self) -> Result<ExprNodeIndex, Error> {
+    pub fn parse_standard_decorator(&mut self) -> Result<ExprNodeIndex<'a>, Error> {
         let p = self;
         let loc = p.lexer.loc();
 
@@ -181,7 +181,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         &mut self,
         loc: bun_ast::Loc,
         opts: &mut ParseStatementOptions,
-    ) -> Result<Stmt, Error> {
+    ) -> Result<Stmt<'a>, Error> {
         let p = self;
         // "namespace foo {}";
         let name_loc = p.lexer.loc();
@@ -438,7 +438,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         opts: &mut ParseStatementOptions,
         default_name_loc: bun_ast::Loc,
         default_name: &'a [u8],
-    ) -> Result<Stmt, Error> {
+    ) -> Result<Stmt<'a>, Error> {
         let p = self;
         p.lexer.expect(T::TEquals)?;
 
@@ -532,7 +532,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         &mut self,
         loc: bun_ast::Loc,
         opts: &mut ParseStatementOptions,
-    ) -> Result<Stmt, Error> {
+    ) -> Result<Stmt<'a>, Error> {
         let p = self;
         p.lexer.expect(T::TEnum)?;
         let name_loc = p.lexer.loc();

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -220,7 +220,7 @@ pub mod Runtime {
 
     // ─────────────────────────── Runtime.Features ───────────────────────────
 
-    pub struct Features {
+    pub struct Features<'arena> {
         /// Enable the React Fast Refresh transform. What this does exactly
         /// is documented in js_parser, search for `const ReactRefresh`
         pub react_fast_refresh: bool,
@@ -259,7 +259,7 @@ pub mod Runtime {
         /// Allow runtime usage of require(), converting `require` into `__require`
         pub auto_polyfill_require: bool,
 
-        pub replace_exports: ReplaceableExportMap,
+        pub replace_exports: ReplaceableExportMap<'arena>,
 
         /// Scan for '// @bun' at the top of this file, halting a parse if it is
         /// seen. This is used in `bun run` after a `bun build --target=bun`,
@@ -322,7 +322,7 @@ pub mod Runtime {
         pub use_import_meta_require: bool,
     }
 
-    impl Default for Features {
+    impl Default for Features<'_> {
         fn default() -> Self {
             Self {
                 react_fast_refresh: false,
@@ -364,7 +364,7 @@ pub mod Runtime {
         }
     }
 
-    impl Features {
+    impl Features<'_> {
         /// Reborrow the optional `RuntimeTranspilerCache` back-pointer.
         ///
         /// `&self` receiver (not `&mut`) so call sites may hold other shared
@@ -613,7 +613,7 @@ pub mod Runtime {
         }
     }
 }
-pub type RuntimeFeatures = Runtime::Features;
+pub type RuntimeFeatures<'arena> = Runtime::Features<'arena>;
 pub type RuntimeImports = Runtime::Imports;
 pub type RuntimeNames = Runtime::Names;
 
@@ -641,8 +641,8 @@ use crate::defines::Define;
 
 // ──────────────────────────────────────────────────────────────────────────
 
-pub struct ExprListLoc {
-    pub list: ExprNodeList,
+pub struct ExprListLoc<'arena> {
+    pub list: ExprNodeList<'arena>,
     pub loc: bun_ast::Loc,
 }
 
@@ -865,10 +865,10 @@ pub struct MacroRefData<'a> {
 
 type MacroRefs<'a> = ArrayHashMap<Ref, MacroRefData<'a>>;
 
-pub enum Substitution {
-    Success(Expr),
-    Failure(Expr),
-    Continue(Expr),
+pub enum Substitution<'arena> {
+    Success(Expr<'arena>),
+    Failure(Expr<'arena>),
+    Continue(Expr<'arena>),
 }
 
 /// If we are currently in a hoisted child of the module scope, relocate these
@@ -882,8 +882,8 @@ pub enum Substitution {
 /// to nothing is unsafe
 /// Because "foo" was defined. And now it's not.
 #[derive(Default)]
-pub struct RelocateVars {
-    pub stmt: Option<Stmt>,
+pub struct RelocateVars<'arena> {
+    pub stmt: Option<Stmt<'arena>>,
     pub ok: bool,
 }
 
@@ -895,7 +895,7 @@ pub enum RelocateVarsMode {
 
 #[derive(Default)]
 pub struct VisitArgsOpts<'a> {
-    pub body: &'a [Stmt],
+    pub body: &'a [Stmt<'a>],
     pub has_rest_arg: bool,
     /// This is true if the function is an arrow function or a method
     pub is_unique_formal_parameters: bool,
@@ -907,18 +907,18 @@ pub struct VisitArgsOpts<'a> {
 /// `fn` pointer. // PERF(port): was comptime monomorphization — profile in Phase B
 pub struct ExpressionTransposer<'a, Context, State: Copy> {
     pub context: &'a mut Context,
-    visitor: fn(&mut Context, Expr, State) -> Expr,
+    visitor: fn(&mut Context, Expr<'a>, State) -> Expr<'a>,
 }
 
 impl<'a, Context, State: Copy> ExpressionTransposer<'a, Context, State> {
-    pub fn init(c: &'a mut Context, visitor: fn(&mut Context, Expr, State) -> Expr) -> Self {
+    pub fn init(c: &'a mut Context, visitor: fn(&mut Context, Expr<'a>, State) -> Expr<'a>) -> Self {
         Self {
             context: c,
             visitor,
         }
     }
 
-    pub fn maybe_transpose_if(&mut self, arg: Expr, state: State) -> Expr {
+    pub fn maybe_transpose_if(&mut self, arg: Expr<'a>, state: State) -> Expr<'a> {
         match arg.data {
             js_ast::ExprData::EIf(ex) => Expr::init(
                 E::If {
@@ -932,7 +932,7 @@ impl<'a, Context, State: Copy> ExpressionTransposer<'a, Context, State> {
         }
     }
 
-    pub fn transpose_known_to_be_if(&mut self, arg: Expr, state: State) -> Expr {
+    pub fn transpose_known_to_be_if(&mut self, arg: Expr<'a>, state: State) -> Expr<'a> {
         // Caller guarantees `arg.data` is `EIf`.
         let js_ast::ExprData::EIf(ex) = arg.data else {
             unreachable!()
@@ -958,17 +958,17 @@ pub fn loc_after_op(e: &E::Binary) -> bun_ast::Loc {
 }
 
 #[derive(Clone, Copy)]
-pub struct TransposeState {
+pub struct TransposeState<'arena> {
     pub is_await_target: bool,
     pub is_then_catch_target: bool,
     pub is_require_immediately_assigned_to_decl: bool,
     pub loc: bun_ast::Loc,
     pub import_record_tag: Option<bun_ast::ImportRecordTag>,
     pub import_loader: Option<bun_ast::Loader>,
-    pub import_options: Expr,
+    pub import_options: Expr<'arena>,
 }
 
-impl Default for TransposeState {
+impl<'arena> Default for TransposeState<'arena> {
     fn default() -> Self {
         Self {
             is_await_target: false,
@@ -988,13 +988,13 @@ pub enum JSXTagType {
     Tag,
 }
 
-pub enum JSXTagData {
+pub enum JSXTagData<'arena> {
     Fragment(u8),
-    Tag(Expr),
+    Tag(Expr<'arena>),
 }
 
-impl JSXTagData {
-    pub fn as_expr(&self) -> Option<ExprNodeIndex> {
+impl<'arena> JSXTagData<'arena> {
+    pub fn as_expr(&self) -> Option<ExprNodeIndex<'arena>> {
         match self {
             JSXTagData::Tag(tag) => Some(*tag),
             _ => None,
@@ -1003,7 +1003,7 @@ impl JSXTagData {
 }
 
 pub struct JSXTag<'a> {
-    pub data: JSXTagData,
+    pub data: JSXTagData<'a>,
     pub range: bun_ast::Range,
     /// Empty string for fragments.
     pub name: &'a [u8],
@@ -1165,17 +1165,17 @@ macro_rules! generated_symbol_name {
     }};
 }
 
-pub struct ExprOrLetStmt {
-    pub stmt_or_expr: js_ast::StmtOrExpr,
+pub struct ExprOrLetStmt<'arena> {
+    pub stmt_or_expr: js_ast::StmtOrExpr<'arena>,
     // PORT NOTE: Zig writes `.decls = decls.slice()` borrowing the heap buffer
     // that was just moved into `S::Local`. The buffer pointer is stable across
     // the move, but borrowck can't see that — store as `RawSlice` to record the
     // outlives-holder invariant without a per-site unsafe cast. (Neither caller
     // currently reads this field, matching parseStmt.zig:829-836.)
-    pub decls: bun_collections::RawSlice<G::Decl>,
+    pub decls: bun_collections::RawSlice<G::Decl<'arena>>,
 }
 
-impl Default for ExprOrLetStmt {
+impl<'arena> Default for ExprOrLetStmt<'arena> {
     fn default() -> Self {
         Self {
             stmt_or_expr: js_ast::StmtOrExpr::default(),
@@ -1421,17 +1421,17 @@ fn notimpl() -> ! {
 }
 
 #[derive(Default)]
-pub struct ExprBindingTuple {
-    pub expr: Option<ExprNodeIndex>,
-    pub binding: Option<Binding>,
+pub struct ExprBindingTuple<'arena> {
+    pub expr: Option<ExprNodeIndex<'arena>>,
+    pub binding: Option<Binding<'arena>>,
 }
 
-pub struct TempRef {
+pub struct TempRef<'arena> {
     pub r#ref: Ref,
-    pub value: Option<Expr>,
+    pub value: Option<Expr<'arena>>,
 }
 
-impl Default for TempRef {
+impl<'arena> Default for TempRef<'arena> {
     fn default() -> Self {
         Self {
             r#ref: Ref::default(),
@@ -1446,12 +1446,12 @@ pub struct ImportNamespaceCallOrConstruct {
     pub is_construct: bool,
 }
 
-pub struct ThenCatchChain {
-    pub next_target: js_ast::ExprData,
+pub struct ThenCatchChain<'arena> {
+    pub next_target: js_ast::ExprData<'arena>,
     pub has_multiple_args: bool,
     pub has_catch: bool,
 }
-impl Default for ThenCatchChain {
+impl<'arena> Default for ThenCatchChain<'arena> {
     fn default() -> Self {
         Self {
             // Zig: zero-init `js_ast.Expr.Data` → `.e_missing` (tag 0).
@@ -1515,7 +1515,7 @@ impl InvalidLoc {
 }
 
 pub type LocList<'bump> = bun_alloc::ArenaVec<'bump, InvalidLoc>;
-pub type StmtList<'bump> = bun_alloc::ArenaVec<'bump, Stmt>;
+pub type StmtList<'bump> = bun_alloc::ArenaVec<'bump, Stmt<'bump>>;
 
 /// This hash table is used every time we parse function args
 /// Rather than allocating a new hash table each time, we can just reuse the previous allocation
@@ -1577,12 +1577,12 @@ pub type RefRefMap = HashMap<Ref, Ref>; // TODO(port): RefCtx hasher + 80% load 
 #[derive(Clone, Copy)]
 pub struct ScopeOrder<'arena> {
     pub loc: bun_ast::Loc,
-    pub scope: *mut Scope,
-    _phantom: core::marker::PhantomData<&'arena Scope>,
+    pub scope: *mut Scope<'arena>,
+    _phantom: core::marker::PhantomData<&'arena Scope<'arena>>,
 }
 impl<'arena> ScopeOrder<'arena> {
     #[inline]
-    pub fn new(loc: bun_ast::Loc, scope: *mut Scope) -> Self {
+    pub fn new(loc: bun_ast::Loc, scope: *mut Scope<'arena>) -> Self {
         Self {
             loc,
             scope,
@@ -1593,7 +1593,7 @@ impl<'arena> ScopeOrder<'arena> {
     /// so callers read `order.scope_ref().kind` instead of open-coding
     /// `unsafe { &*order.scope }` at every visit-pass check.
     #[inline]
-    pub fn scope_ref(&self) -> js_ast::StoreRef<Scope> {
+    pub fn scope_ref(&self) -> js_ast::StoreRef<'arena, Scope<'arena>> {
         // `scope` is always set from a live arena allocation in
         // `push_scope_for_parse_pass`; never null in practice.
         js_ast::StoreRef::from(
@@ -1809,12 +1809,12 @@ impl DeferredErrors {
 pub struct ImportClause<'a> {
     /// Arena-owned. `&mut` (not `&`) so callers can hand it to AST nodes
     /// (`S::Import.items: StoreSlice<ClauseItem>`).
-    pub items: &'a mut [js_ast::ClauseItem],
+    pub items: &'a mut [js_ast::ClauseItem<'a>],
     pub is_single_line: bool,
     pub had_type_only_imports: bool,
 }
 
-pub struct PropertyOpts {
+pub struct PropertyOpts<'arena> {
     pub async_range: bun_ast::Range,
     pub declare_range: bun_ast::Range,
     pub is_async: bool,
@@ -1826,12 +1826,12 @@ pub struct PropertyOpts {
     pub class_has_extends: bool,
     pub allow_ts_decorators: bool,
     pub is_ts_abstract: bool,
-    pub ts_decorators: ExprNodeList,
+    pub ts_decorators: ExprNodeList<'arena>,
     pub has_argument_decorators: bool,
     pub has_class_decorators: bool,
 }
 
-impl Default for PropertyOpts {
+impl<'arena> Default for PropertyOpts<'arena> {
     fn default() -> Self {
         Self {
             async_range: bun_ast::Range::NONE,
@@ -1850,9 +1850,9 @@ impl Default for PropertyOpts {
     }
 }
 
-pub struct ScanPassResult {
+pub struct ScanPassResult<'arena> {
     pub import_records: Vec<ImportRecord>,
-    pub named_imports: bun_ast::ast_result::NamedImports,
+    pub named_imports: bun_ast::ast_result::NamedImports<'arena>,
     pub used_symbols: ParsePassSymbolUsageMap,
     pub import_records_to_keep: Vec<u32>,
     pub approximate_newline_count: usize,
@@ -1873,8 +1873,8 @@ pub struct NamespaceCounter {
 
 pub type ParsePassSymbolUsageMap = StringArrayHashMap<ParsePassSymbolUse>;
 
-impl ScanPassResult {
-    pub fn init() -> ScanPassResult {
+impl<'arena> ScanPassResult<'arena> {
+    pub fn init() -> ScanPassResult<'arena> {
         ScanPassResult {
             import_records: Vec::new(),
             named_imports: Default::default(),
@@ -1911,14 +1911,14 @@ pub struct FindSymbolResult {
 pub struct ExportClauseResult<'a> {
     /// Arena-owned. `&mut` (not `&`) so callers can hand it to AST nodes
     /// (`S::Export{From,Clause}.items: StoreSlice<ClauseItem>`).
-    pub clauses: &'a mut [js_ast::ClauseItem],
+    pub clauses: &'a mut [js_ast::ClauseItem<'a>],
     pub is_single_line: bool,
     pub had_type_only_exports: bool,
 }
 
 #[derive(Clone, Copy)]
 pub struct DeferredTsDecorators<'a> {
-    pub values: &'a [js_ast::Expr],
+    pub values: &'a [js_ast::Expr<'a>],
 
     /// If this turns out to be a "declare class" statement, we need to undo the
     /// scopes that were potentially pushed while parsing the decorator arguments.
@@ -1937,7 +1937,7 @@ pub enum LexicalDecl {
 
 #[derive(Default)]
 pub struct ParseClassOptions<'a> {
-    pub ts_decorators: &'a [Expr],
+    pub ts_decorators: &'a [Expr<'a>],
     pub allow_ts_decorators: bool,
     pub is_type_script_declare: bool,
 }
@@ -2033,9 +2033,9 @@ pub mod prefill {
 
 #[derive(Default)]
 #[allow(dead_code)]
-struct ReactJSX {
+struct ReactJSX<'arena> {
     // TODO(port): ArrayHashMap with bun.ArrayIdentityContext (identity hash on Ref)
-    hoisted_elements: ArrayHashMap<Ref, G::Decl>,
+    hoisted_elements: ArrayHashMap<Ref, G::Decl<'arena>>,
 }
 
 pub struct ImportOrRequireScanResults {
@@ -2076,7 +2076,7 @@ pub type ImportItemForNamespaceMap = StringArrayHashMap<LocRef>;
 
 pub struct MacroState<'a> {
     pub refs: MacroRefs<'a>,
-    pub prepend_stmts: &'a mut Vec<Stmt>,
+    pub prepend_stmts: &'a mut Vec<Stmt<'a>>,
     pub imports: ArrayHashMap<i32, Ref>,
 }
 
@@ -2084,7 +2084,7 @@ impl<'a> MacroState<'a> {
     // TODO(port): Zig initializes `prepend_stmts = undefined`; Rust cannot leave
     // a `&mut` field uninitialized. Caller must supply a placeholder list, or
     // this field becomes `Option<&'a mut Vec<Stmt>>` set to `None` here.
-    pub fn init(prepend_stmts: &'a mut Vec<Stmt>) -> MacroState<'a> {
+    pub fn init(prepend_stmts: &'a mut Vec<Stmt<'a>>) -> MacroState<'a> {
         MacroState {
             refs: MacroRefs::default(),
             prepend_stmts,
@@ -2218,13 +2218,13 @@ impl Default for DeferredArrowArgErrors {
 
 pub fn new_lazy_export_ast<'bump>(
     bump: &'bump bun_alloc::Arena,
-    define: &mut Define,
-    opts: ParserOptions,
+    define: &'bump mut Define,
+    opts: ParserOptions<'bump>,
     log_to_copy_into: &mut bun_ast::Log,
-    expr: Expr,
-    source: &bun_ast::Source,
+    expr: Expr<'bump>,
+    source: &'bump bun_ast::Source,
     runtime_api_call: &'static [u8], // PERF(port): was comptime monomorphization — profile in Phase B
-) -> Result<Option<js_ast::Ast>, bun_core::Error> {
+) -> Result<Option<js_ast::Ast<'bump>>, bun_core::Error> {
     new_lazy_export_ast_impl(
         bump,
         define,
@@ -2239,14 +2239,14 @@ pub fn new_lazy_export_ast<'bump>(
 
 pub fn new_lazy_export_ast_impl<'bump>(
     bump: &'bump bun_alloc::Arena,
-    define: &mut Define,
-    opts: ParserOptions,
+    define: &'bump mut Define,
+    opts: ParserOptions<'bump>,
     log_to_copy_into: &mut bun_ast::Log,
-    expr: Expr,
-    source: &bun_ast::Source,
+    expr: Expr<'bump>,
+    source: &'bump bun_ast::Source,
     runtime_api_call: &'static [u8], // PERF(port): was comptime monomorphization — profile in Phase B
-    symbols: js_ast::symbol::List,
-) -> Result<Option<js_ast::Ast>, bun_core::Error> {
+    symbols: js_ast::symbol::List<'bump>,
+) -> Result<Option<js_ast::Ast<'bump>>, bun_core::Error> {
     let mut temp_log = bun_ast::Log::init();
     // Zig held two aliasing `*Log` (parser.log + lexer.log). Both sides store
     // `NonNull<Log>` in Rust; copy the lexer's pointer so they share one
@@ -2361,7 +2361,7 @@ pub struct ReactRefresh<'a> {
     /// `.s_local`, as we must hash the variable destructure if the
     /// hook's result is assigned directly to a local.
     // ARENA: identity-compared against Store-allocated AST node.
-    pub last_hook_seen: Option<*const E::Call>,
+    pub last_hook_seen: Option<*const E::Call<'a>>,
 
     /// Every function sets up stack memory to hold data related to it's
     /// hook tracking. This is a pointer to that ?HookContext, where an
@@ -2379,7 +2379,7 @@ pub struct ReactRefresh<'a> {
     /// stack storage on the visiting fn frame. Modeled as `Option<NonNull<_>>`
     /// (Copy) so the save/set/restore dance in visitStmt/visitExpr can take a
     /// stack-local address without the `'a` borrow the visitor cannot satisfy.
-    pub hook_ctx_storage: Option<core::ptr::NonNull<Option<HookContext>>>,
+    pub hook_ctx_storage: Option<core::ptr::NonNull<Option<HookContext<'a>>>>,
 
     /// This is the most recently generated `_s` call. This is used to compare
     /// against seen calls to plain identifiers when in "export default" and in
@@ -2406,13 +2406,13 @@ impl<'a> Default for ReactRefresh<'a> {
     }
 }
 
-pub struct HookContext {
+pub struct HookContext<'arena> {
     pub hasher: Wyhash,
     pub signature_cb: Ref,
-    pub user_hooks: ArrayHashMap<Ref, Expr>,
+    pub user_hooks: ArrayHashMap<Ref, Expr<'arena>>,
 }
 
-impl ReactRefresh<'_> {
+impl<'a> ReactRefresh<'a> {
     /// Reborrow the stack-allocated `Option<HookContext>` that
     /// `hook_ctx_storage` points at (Zig: `?*?HookContext`). The returned
     /// borrow is detached from `self` because the storage lives on a *caller*
@@ -2422,7 +2422,7 @@ impl ReactRefresh<'_> {
     /// once (same uniqueness contract as `P::log()`).
     #[inline]
     #[allow(clippy::mut_from_ref)]
-    pub fn hook_ctx_mut<'s>(&self) -> Option<&'s mut Option<HookContext>> {
+    pub fn hook_ctx_mut<'s>(&self) -> Option<&'s mut Option<HookContext<'a>>> {
         // SAFETY: `hook_ctx_storage` is `Some` only while a `visit_*` frame
         // higher on the stack has installed `&mut react_hook_data` (a stack
         // local) and will restore the previous value before returning, so the

--- a/src/js_parser/repl_transforms.rs
+++ b/src/js_parser/repl_transforms.rs
@@ -26,7 +26,7 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
     /// - Wraps code with await in async IIFE with variable hoisting
     pub fn apply_repl_transforms<'bump>(
         &mut self,
-        parts: &mut BumpVec<'bump, js_ast::Part>,
+        parts: &mut BumpVec<'bump, js_ast::Part<'a>>,
         bump: &'bump Bump,
     ) -> Result<(), bun_alloc::AllocError> {
         // Skip transform if there's a top-level return (indicates module pattern)
@@ -52,7 +52,7 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                 all_stmts.push(*stmt);
             }
         }
-        let all_stmts: &mut [Stmt] = all_stmts.into_bump_slice_mut();
+        let all_stmts: &mut [Stmt<'a>] = all_stmts.into_bump_slice_mut();
 
         // Check if there's top-level await or imports (imports become dynamic awaited imports)
         let mut has_top_level_await = self.top_level_await_keyword.len > 0;
@@ -73,8 +73,8 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
     /// `is_async`: true for async IIFE (when top-level await present), false for sync IIFE
     fn repl_transform_with_hoisting<'bump>(
         &mut self,
-        parts: &mut BumpVec<'bump, js_ast::Part>,
-        all_stmts: &[Stmt],
+        parts: &mut BumpVec<'bump, js_ast::Part<'a>>,
+        all_stmts: &[Stmt<'a>],
         bump: &'bump Bump,
         is_async: bool,
     ) -> Result<(), bun_alloc::AllocError> {
@@ -530,9 +530,9 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
         &mut self,
         import_data: &S::Import,
         import_items: &[bun_ast::ClauseItem],
-        await_expr: Expr,
-        hoisted_stmts: &mut BumpVec<'bump, Stmt>,
-        inner_stmts: &mut BumpVec<'bump, Stmt>,
+        await_expr: Expr<'a>,
+        hoisted_stmts: &mut BumpVec<'bump, Stmt<'a>>,
+        inner_stmts: &mut BumpVec<'bump, Stmt<'a>>,
         bump: &'bump Bump,
         loc: bun_ast::Loc,
     ) -> Result<(), bun_alloc::AllocError> {
@@ -639,7 +639,7 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
     /// Wrap the last expression in return { value: expr }
     fn repl_wrap_last_expression_with_return<'bump>(
         &mut self,
-        inner_stmts: &mut BumpVec<'bump, Stmt>,
+        inner_stmts: &mut BumpVec<'bump, Stmt<'a>>,
         bump: &'bump Bump,
     ) {
         if !inner_stmts.is_empty() {
@@ -669,8 +669,8 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
     /// Extract individual identifiers from a binding pattern for hoisting
     fn repl_extract_identifiers_from_binding<'bump>(
         &mut self,
-        binding: Binding,
-        decls: &mut BumpVec<'bump, G::Decl>,
+        binding: Binding<'a>,
+        decls: &mut BumpVec<'bump, G::Decl<'a>>,
     ) -> Result<(), bun_alloc::AllocError> {
         match binding.data {
             B::B::BIdentifier(ident) => {
@@ -696,7 +696,7 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
 
     /// Create { __proto__: null, value: expr } wrapper object
     /// Uses null prototype to create a clean data object
-    fn repl_wrap_expr_in_value_object<'bump>(&mut self, expr: Expr, bump: &'bump Bump) -> Expr {
+    fn repl_wrap_expr_in_value_object<'bump>(&mut self, expr: Expr<'a>, bump: &'bump Bump) -> Expr<'a> {
         // PERF(port): was bun.handleOom(arena.alloc(G.Property, 2)).
         // G::Property is non-Copy (owns Vec) → use bump Vec instead of alloc_slice_copy.
         let mut properties = BumpVec::<G::Property>::with_capacity_in(2, bump);
@@ -737,10 +737,10 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
     /// Create assignment expression from binding pattern
     fn repl_create_binding_assignment<'bump>(
         &mut self,
-        binding: Binding,
-        value: Expr,
+        binding: Binding<'a>,
+        value: Expr<'a>,
         bump: &'bump Bump,
-    ) -> Expr {
+    ) -> Expr<'a> {
         match binding.data {
             B::B::BIdentifier(ident) => {
                 let left = self.new_expr(
@@ -792,7 +792,7 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
 
     /// Convert a binding pattern to an expression (for assignment targets)
     /// Handles spread/rest patterns in arrays and objects to match Binding.toExpr behavior
-    fn repl_convert_binding_to_expr<'bump>(&mut self, binding: Binding, bump: &'bump Bump) -> Expr {
+    fn repl_convert_binding_to_expr<'bump>(&mut self, binding: Binding<'a>, bump: &'bump Bump) -> Expr<'a> {
         match binding.data {
             B::B::BIdentifier(ident) => self.new_expr(
                 E::Identifier {
@@ -871,7 +871,7 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
 
 /// Bump-allocate a single-element `G::DeclList` (Zig: `Decl.List.fromOwnedSlice(arena.dupe(...))`).
 #[inline]
-fn repl_one_decl(bump: &Bump, binding: Binding) -> G::DeclList {
+fn repl_one_decl<'arena>(bump: &Bump, binding: Binding<'arena>) -> G::DeclList<'arena> {
     let slice: &mut [G::Decl] = bump.alloc_slice_fill_with(1, |_| G::Decl {
         binding,
         value: None,

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -18,8 +18,8 @@ use bun_crash_handler::handle_oom::handle_oom;
 // PORT NOTE: Zig file-level struct → Rust struct. `stmts` is a sub-slice of the
 // input `stmts` argument (in-place compacted), so it borrows from the caller.
 #[derive(Default)]
-pub struct ImportScanner<'a> {
-    pub stmts: &'a mut [Stmt],
+pub struct ImportScanner<'b, 'a> {
+    pub stmts: &'b mut [Stmt<'a>],
     pub kept_import_equals: bool,
     pub removed_import_equals: bool,
 }
@@ -31,26 +31,25 @@ fn raw_str(s: &'static [u8]) -> js_ast::StoreStr {
     js_ast::StoreStr::new(s)
 }
 
-impl<'a> ImportScanner<'a> {
+impl<'b, 'a> ImportScanner<'b, 'a> {
     // TODO(port): narrow error set
     // PORT NOTE: round-E un-gate — `<P>` unbounded generic → concrete `P<'a, TS, SCAN>`.
     // TODO(b2-ast-E): the Zig also accepts `bun.bundle_v2.AstBuilder` as P (comptime
     //   `P != AstBuilder` check). Round-E only handles the parser P; AstBuilder path
     //   needs a `ParserLike` trait or a separate monomorphization.
     pub fn scan<
-        'p,
         const TYPESCRIPT: bool,
         const SCAN_ONLY: bool,
         const HOT_MODULE_RELOADING_TRANSFORMATIONS: bool,
     >(
-        p: &mut P<'p, TYPESCRIPT, SCAN_ONLY>,
-        stmts: &'a mut [Stmt],
+        p: &mut P<'a, TYPESCRIPT, SCAN_ONLY>,
+        stmts: &'b mut [Stmt<'a>],
         will_transform_to_common_js: bool,
         // PORT NOTE: Zig used `if (comptime_bool) *T else void` for this param's
         // type; Rust const generics can't gate a param type, so use Option and
         // debug-assert presence matches the const.
-        mut hot_module_reloading_context: Option<&mut ConvertESMExportsForHmr>,
-    ) -> Result<ImportScanner<'a>, bun_core::Error> {
+        mut hot_module_reloading_context: Option<&mut ConvertESMExportsForHmr<'_, 'a>>,
+    ) -> Result<ImportScanner<'b, 'a>, bun_core::Error> {
         debug_assert_eq!(
             HOT_MODULE_RELOADING_TRANSFORMATIONS,
             hot_module_reloading_context.is_some()
@@ -557,7 +556,7 @@ impl<'a> ImportScanner<'a> {
                     if st.func.flags.contains(bun_ast::flags::Function::IsExport) {
                         if let Some(name) = st.func.name {
                             // SAFETY: arena-owned slice valid for 'p.
-                            let original_name: &'p [u8] = p.symbols
+                            let original_name: &'a [u8] = p.symbols
                                 [name.ref_.expect("infallible: ref bound").inner_index() as usize]
                                 .original_name
                                 .slice();
@@ -582,7 +581,7 @@ impl<'a> ImportScanner<'a> {
                     if st.is_export {
                         if let Some(name) = st.class.class_name {
                             // SAFETY: arena-owned slice valid for 'p.
-                            let original_name: &'p [u8] = p.symbols
+                            let original_name: &'a [u8] = p.symbols
                                 [name.ref_.expect("infallible: ref bound").inner_index() as usize]
                                 .original_name
                                 .slice();
@@ -684,7 +683,7 @@ impl<'a> ImportScanner<'a> {
                     // SAFETY: arena-owned slice valid for 'p.
                     for item in st.items.slice().iter() {
                         // SAFETY: arena-owned alias slice valid for 'p.
-                        let alias: &'p [u8] = item.alias.slice();
+                        let alias: &'a [u8] = item.alias.slice();
                         p.record_export(
                             item.alias_loc,
                             alias,
@@ -710,7 +709,7 @@ impl<'a> ImportScanner<'a> {
                                 local_parts_with_uses: Default::default(),
                             },
                         )?;
-                        let original: &'p [u8] = alias.original_name.slice();
+                        let original: &'a [u8] = alias.original_name.slice();
                         p.record_export(alias.loc, original, st.namespace_ref)?;
                         p.import_records.items_mut()[st.import_record_index as usize]
                             .flags
@@ -748,7 +747,7 @@ impl<'a> ImportScanner<'a> {
                             },
                         )?;
                         // SAFETY: arena-owned alias slice valid for 'p.
-                        let alias: &'p [u8] = item.alias.slice();
+                        let alias: &'a [u8] = item.alias.slice();
                         p.record_export(item.name.loc, alias, ref_)?;
 
                         let record =

--- a/src/js_parser/scan/scan_side_effects.rs
+++ b/src/js_parser/scan/scan_side_effects.rs
@@ -37,9 +37,9 @@ impl Default for Result {
 }
 
 #[derive(Clone, Copy)]
-pub struct BinaryExpressionSimplifyVisitor {
+pub struct BinaryExpressionSimplifyVisitor<'arena> {
     // ARENA: points into the AST store (see LIFETIMES.tsv)
-    pub bin: *const E::Binary,
+    pub bin: *const E::Binary<'arena>,
 }
 
 impl SideEffects {
@@ -53,8 +53,8 @@ impl SideEffects {
 
     pub fn simplify_boolean<'a, const TS: bool, const SCAN: bool>(
         p: &P<'a, TS, SCAN>,
-        expr: Expr,
-    ) -> Expr {
+        expr: Expr<'a>,
+    ) -> Expr<'a> {
         if !p.options.features.dead_code_elimination {
             return expr;
         }
@@ -143,8 +143,8 @@ impl SideEffects {
 
     pub fn simplify_unused_expr<'a, const TS: bool, const SCAN: bool>(
         p: &mut P<'a, TS, SCAN>,
-        expr: Expr,
-    ) -> Option<Expr> {
+        expr: Expr<'a>,
+    ) -> Option<Expr<'a>> {
         if !p.options.features.dead_code_elimination {
             return Some(expr);
         }
@@ -486,8 +486,8 @@ impl SideEffects {
     /// recursive `simplify_unused_expr` call.
     fn join_all_simplified<'a, const TS: bool, const SCAN: bool>(
         p: &mut P<'a, TS, SCAN>,
-        items: &[Expr],
-    ) -> Option<Expr> {
+        items: &[Expr<'a>],
+    ) -> Option<Expr<'a>> {
         let len = items.len();
         if len == 0 {
             return None;
@@ -516,8 +516,8 @@ impl SideEffects {
     ///
     fn simplify_unused_binary_comma_expr<'a, const TS: bool, const SCAN: bool>(
         p: &mut P<'a, TS, SCAN>,
-        expr: Expr,
-    ) -> Option<Expr> {
+        expr: Expr<'a>,
+    ) -> Option<Expr<'a>> {
         let ExprData::EBinary(root_bin) = expr.data else {
             if cfg!(debug_assertions) {
                 unreachable!("simplify_unused_binary_comma_expr: not e_binary");
@@ -567,7 +567,7 @@ impl SideEffects {
         }
     }
 
-    fn find_identifiers(binding: Binding, decls: &mut Vec<G::Decl>) {
+    fn find_identifiers<'arena>(binding: Binding<'arena>, decls: &mut Vec<G::Decl<'arena>>) {
         match binding.data {
             bun_ast::binding::Data::BIdentifier(_) => {
                 decls.push(G::Decl {

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -45,13 +45,13 @@ type ListManaged<'bump, T> = BumpVec<'bump, T>;
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
     // Thin alias of `current_scope_mut()` kept for local readability.
     #[inline(always)]
-    fn vis_scope(&mut self) -> &mut js_ast::Scope {
+    fn vis_scope(&mut self) -> &mut js_ast::Scope<'a> {
         self.current_scope_mut()
     }
 
     pub fn visit_stmts_and_prepend_temp_refs(
         &mut self,
-        stmts: &mut ListManaged<'a, Stmt>,
+        stmts: &mut ListManaged<'a, Stmt<'a>>,
         opts: &mut PrependTempRefsOpts,
     ) -> Result<(), bun_core::Error> {
         // Zig: `if (only_scan_imports_and_do_not_visit) @compileError(...)`
@@ -90,7 +90,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             .expect("oom");
     }
 
-    pub fn visit_func(&mut self, mut func: G::Fn, open_parens_loc: bun_ast::Loc) -> G::Fn {
+    pub fn visit_func(&mut self, mut func: G::Fn<'a>, open_parens_loc: bun_ast::Loc) -> G::Fn<'a> {
         // Zig: `if (only_scan_imports_and_do_not_visit) @compileError(...)`
         debug_assert!(
             !SCAN_ONLY,
@@ -184,7 +184,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         func
     }
 
-    pub fn visit_args(&mut self, args: &mut [G::Arg], opts: VisitArgsOpts) {
+    pub fn visit_args(&mut self, args: &mut [G::Arg<'a>], opts: VisitArgsOpts) {
         let strict_loc = fn_body_contains_use_strict(opts.body);
         let has_simple_args = Self::is_simple_parameter_list(args, opts.has_rest_arg);
         // StringVoidMap::get returns a pool guard; Drop releases (replaces Zig `defer release`).
@@ -232,7 +232,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     // PORT NOTE: Zig returned the list by value (`ExprNodeList` is a fat ptr there).
     // `Vec<Expr>` is not `Copy` in Rust; mutate in place instead.
-    pub fn visit_ts_decorators(&mut self, decs: &mut ExprNodeList) {
+    pub fn visit_ts_decorators(&mut self, decs: &mut ExprNodeList<'a>) {
         for dec in decs.slice_mut() {
             self.visit_expr(dec);
         }
@@ -240,7 +240,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn visit_decls<const IS_POSSIBLY_DECL_TO_REMOVE: bool>(
         &mut self,
-        decls: &mut [G::Decl],
+        decls: &mut [G::Decl<'a>],
         was_const: bool,
     ) -> usize {
         let mut j: usize = 0;
@@ -437,7 +437,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         j
     }
 
-    pub fn visit_binding_and_expr_for_macro(&mut self, binding: Binding, expr: Expr) {
+    pub fn visit_binding_and_expr_for_macro(&mut self, binding: Binding<'a>, expr: Expr<'a>) {
         match binding.data {
             BData::BObject(bound_object) => {
                 let bound_object = bound_object.get();
@@ -521,7 +521,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn visit_decl(
         &mut self,
-        decl: &mut G::Decl,
+        decl: &mut G::Decl<'a>,
         was_anonymous_named_expr: bool,
         could_be_const_value: bool,
         could_be_macro: bool,
@@ -560,7 +560,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    pub fn visit_for_loop_init(&mut self, stmt: Stmt, is_in_or_of: bool) -> Stmt {
+    pub fn visit_for_loop_init(&mut self, stmt: Stmt<'a>, is_in_or_of: bool) -> Stmt<'a> {
         match stmt.data {
             StmtData::SExpr(mut st) => {
                 let assign_target = if is_in_or_of {
@@ -596,7 +596,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn visit_binding(
         &mut self,
-        binding: BindingNodeIndex,
+        binding: BindingNodeIndex<'a>,
         mut duplicate_arg_check: Option<&mut StringVoidMap>,
     ) {
         match binding.data {
@@ -708,7 +708,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     // PORT NOTE: P::stmts_to_single_stmt is ``-gated (P.rs:6267, blocked on
     // S::Block Default). Inline a local copy until that un-gates.
-    fn stmts_to_single_stmt_(&mut self, loc: bun_ast::Loc, stmts: &'a mut [Stmt]) -> Stmt {
+    fn stmts_to_single_stmt_(&mut self, loc: bun_ast::Loc, stmts: &'a mut [Stmt]) -> Stmt<'a> {
         if stmts.is_empty() {
             return Stmt {
                 data: StmtData::SEmpty(S::Empty {}),
@@ -730,7 +730,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         )
     }
 
-    pub fn visit_loop_body(&mut self, stmt: Stmt) -> Stmt {
+    pub fn visit_loop_body(&mut self, stmt: Stmt<'a>) -> Stmt<'a> {
         let old_is_inside_loop = self.fn_or_arrow_data_visit.is_inside_loop;
         self.fn_or_arrow_data_visit.is_inside_loop = true;
         self.loop_body = stmt.data;
@@ -739,11 +739,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         res
     }
 
-    pub fn visit_single_stmt_block(&mut self, stmt: Stmt, kind: StmtsKind) -> Stmt {
+    pub fn visit_single_stmt_block(&mut self, stmt: Stmt<'a>, kind: StmtsKind) -> Stmt<'a> {
         let mut new_stmt = stmt;
         self.push_scope_for_visit_pass(ScopeKind::Block, stmt.loc)
             .expect("unreachable");
-        let block_stmts: &[Stmt] = match stmt.data {
+        let block_stmts: &[Stmt<'a>] = match stmt.data {
             StmtData::SBlock(b) => b.stmts.slice(),
             _ => unreachable!(),
         };
@@ -764,7 +764,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         new_stmt
     }
 
-    pub fn visit_single_stmt(&mut self, stmt: Stmt, kind: StmtsKind) -> Stmt {
+    pub fn visit_single_stmt(&mut self, stmt: Stmt<'a>, kind: StmtsKind) -> Stmt<'a> {
         if matches!(stmt.data, StmtData::SBlock(_)) {
             return self.visit_single_stmt_block(stmt, kind);
         }
@@ -794,7 +794,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     pub fn visit_class(
         &mut self,
         name_scope_loc: bun_ast::Loc,
-        class: &mut G::Class,
+        class: &mut G::Class<'a>,
         default_name_ref: Ref,
     ) -> Ref {
         // Zig: `if (only_scan_imports_and_do_not_visit) @compileError(...)`
@@ -1204,7 +1204,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // Try separating the list for appending, so that it's not a pointer.
     pub fn visit_stmts(
         &mut self,
-        stmts: &mut ListManaged<'a, Stmt>,
+        stmts: &mut ListManaged<'a, Stmt<'a>>,
         kind: StmtsKind,
     ) -> Result<(), bun_core::Error> {
         // Zig: `if (only_scan_imports_and_do_not_visit) @compileError(...)`

--- a/src/js_parser/visit/visit_binary.rs
+++ b/src/js_parser/visit/visit_binary.rs
@@ -23,10 +23,10 @@ use bun_ast::{
 /// Try to optimize "typeof x === 'undefined'" to "typeof x > 'u'" or similar
 /// Returns the optimized expression if successful, None otherwise
 fn try_optimize_typeof_undefined<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool>(
-    e_: &mut E::Binary,
+    e_: &mut E::Binary<'a>,
     p: &mut P<'a, TYPESCRIPT, SCAN_ONLY>,
     replacement_op: js_ast::op::Code,
-) -> Option<Expr> {
+) -> Option<Expr<'a>> {
     // Check if this is a typeof comparison with "undefined"
     let (typeof_expr, string_expr, flip_comparison) = 'exprs: {
         // Try left side as typeof, right side as string
@@ -98,12 +98,12 @@ fn data_eql<'a, const STRICT: bool, const TYPESCRIPT: bool, const SCAN_ONLY: boo
     }
 }
 
-pub struct BinaryExpressionVisitor {
+pub struct BinaryExpressionVisitor<'arena> {
     /// Arena handle to the in-place `E::Binary` node (Zig: `*E.Binary`).
     /// `StoreRef` is the safe arena back-reference: `Copy` + `Deref`/`DerefMut`
     /// encapsulate the AST-store invariant, so call sites need no raw-pointer
     /// round-trip to forge an `'arena` borrow.
-    pub e: StoreRef<E::Binary>,
+    pub e: StoreRef<'arena, E::Binary<'arena>>,
     pub loc: bun_ast::Loc,
     // PORT NOTE: Zig field name `in` is a Rust keyword; renamed to `in_`.
     pub in_: ExprIn,
@@ -115,11 +115,11 @@ pub struct BinaryExpressionVisitor {
     pub is_stmt_expr: bool, // = false (set by caller / Default)
 }
 
-impl BinaryExpressionVisitor {
-    pub fn visit_right_and_finish<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool>(
+impl<'a> BinaryExpressionVisitor<'a> {
+    pub fn visit_right_and_finish<const TYPESCRIPT: bool, const SCAN_ONLY: bool>(
         v: &mut Self,
         p: &mut P<'a, TYPESCRIPT, SCAN_ONLY>,
-    ) -> Expr {
+    ) -> Expr<'a> {
         // `v.e: StoreRef<E::Binary>` is the safe arena back-reference (Copy).
         // Snapshot the handle for the identity check / tail re-wrap, then take
         // the working `&mut` via `StoreRef::DerefMut` — the arena-backref
@@ -774,10 +774,10 @@ impl BinaryExpressionVisitor {
         }
     }
 
-    pub fn check_and_prepare<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool>(
+    pub fn check_and_prepare<const TYPESCRIPT: bool, const SCAN_ONLY: bool>(
         v: &mut Self,
         p: &mut P<'a, TYPESCRIPT, SCAN_ONLY>,
-    ) -> Option<Expr> {
+    ) -> Option<Expr<'a>> {
         // Snapshot the `Copy` arena handle before taking the working `&mut`
         // via `StoreRef::DerefMut`, so the early-return re-wrap below does not
         // overlap `e_`'s borrow of `v.e`.

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -48,7 +48,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // `Expr -> Expr` shape moved 24B in + 24B out per frame; the in-place form moves 8B
     // and only writes back when the visitor produces a *different* node.
     #[inline]
-    pub fn visit_expr(&mut self, e: &mut Expr) {
+    pub fn visit_expr(&mut self, e: &mut Expr<'a>) {
         // Zig: `if (only_scan_imports_and_do_not_visit) @compileError(...)` — SCAN_ONLY
         // monomorphizations must never reach the visit pass.
         debug_assert!(
@@ -58,7 +58,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.visit_expr_in_out(e, ExprIn::default())
     }
 
-    pub fn visit_expr_in_out(&mut self, e: &mut Expr, in_: ExprIn) {
+    pub fn visit_expr_in_out(&mut self, e: &mut Expr<'a>, in_: ExprIn) {
         if in_.assign_target != js_ast::AssignTarget::None && !self.is_valid_assignment_target(e) {
             self.log()
                 .add_error(Some(self.source), e.loc, b"Invalid assignment target");
@@ -101,23 +101,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // In Zig these live on a nested `const visitors = struct { ... }`; in Rust they are private
     // associated fns on this impl so they can see the const-generic feature params.
 
-    fn e_new_target(_: &mut Self, _e: &mut Expr, _: ExprIn) {
+    fn e_new_target(_: &mut Self, _e: &mut Expr<'a>, _: ExprIn) {
         // this error is not necessary and it is causing breakages
         // if (!p.fn_only_data_visit.is_new_target_allowed) {
         //     p.log.addRangeError(p.source, target.range, "Cannot use \"new.target\" here") catch unreachable;
         // }
     }
 
-    fn e_string(_: &mut Self, _e: &mut Expr, _: ExprIn) {
+    fn e_string(_: &mut Self, _e: &mut Expr<'a>, _: ExprIn) {
         // If you're using this, you're probably not using 0-prefixed legacy octal notation
         // if e.LegacyOctalLoc.Start > 0 {
     }
 
-    fn e_number(_: &mut Self, _e: &mut Expr, _: ExprIn) {
+    fn e_number(_: &mut Self, _e: &mut Expr<'a>, _: ExprIn) {
         // idc about legacy octal loc
     }
 
-    fn e_this(p: &mut Self, e: &mut Expr, _: ExprIn) {
+    fn e_this(p: &mut Self, e: &mut Expr<'a>, _: ExprIn) {
         if let Some(exp) = p.value_for_this(e.loc) {
             *e = exp;
             return;
@@ -130,20 +130,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // }
     }
 
-    fn e_spread(p: &mut Self, e: &mut Expr, _: ExprIn) {
+    fn e_spread(p: &mut Self, e: &mut Expr<'a>, _: ExprIn) {
         if let js_ast::ExprData::ESpread(mut exp) = e.data {
             p.visit_expr(&mut exp.value);
         }
     }
 
-    fn e_await(p: &mut Self, e: &mut Expr, _: ExprIn) {
+    fn e_await(p: &mut Self, e: &mut Expr<'a>, _: ExprIn) {
         if let js_ast::ExprData::EAwait(mut e_) = e.data {
             p.await_target = Some(e_.value.data);
             p.visit_expr(&mut e_.value);
         }
     }
 
-    fn e_yield(p: &mut Self, e: &mut Expr, _: ExprIn) {
+    fn e_yield(p: &mut Self, e: &mut Expr<'a>, _: ExprIn) {
         if let js_ast::ExprData::EYield(mut e_) = e.data {
             if let Some(val) = e_.value.as_mut() {
                 p.visit_expr(val);
@@ -154,7 +154,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // ─── heavy visitors ─────────────────────────────────────────────────────
     // e_* accessors on `expr::Data` return Option<StoreRef<T>> / Option<T>.
 
-    fn e_import_meta(p: &mut Self, e: &mut Expr, in_: ExprIn) {
+    fn e_import_meta(p: &mut Self, e: &mut Expr<'a>, in_: ExprIn) {
         let expr = *e;
         // TODO: delete import.meta might not work
         let is_delete_target = matches!(p.delete_target, Data::EImportMeta(..));
@@ -176,7 +176,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    fn e_identifier(p: &mut Self, e: &mut Expr, in_: ExprIn) {
+    fn e_identifier(p: &mut Self, e: &mut Expr<'a>, in_: ExprIn) {
         let expr = *e;
         let mut e_ = expr
             .data
@@ -357,7 +357,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // frame is the #2 hottest bun-native instruction under `bun --bun lint`).
     // Mirrors Zig's switch-with-helper-fns layout.
     #[inline(never)]
-    fn e_jsx_element(p: &mut Self, e: &mut Expr, in_: ExprIn) {
+    fn e_jsx_element(p: &mut Self, e: &mut Expr<'a>, in_: ExprIn) {
         let expr = *e;
         use crate::parser::{JSXImport, JSXTransformType, options};
         let _ = in_;
@@ -711,7 +711,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
     #[inline(never)] // PERF(port:frame): see e_jsx_element.
-    fn e_template(p: &mut Self, e: &mut Expr, in_: ExprIn) {
+    fn e_template(p: &mut Self, e: &mut Expr<'a>, in_: ExprIn) {
         let expr = *e;
         let _ = in_;
         let mut e_ = expr.data.e_template().expect("infallible: variant checked");
@@ -816,7 +816,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return;
         }
     }
-    fn e_binary(p: &mut Self, e: &mut Expr, in_: ExprIn) {
+    fn e_binary(p: &mut Self, e: &mut Expr<'a>, in_: ExprIn) {
         let expr = *e;
         use crate::visit::visit_binary::BinaryExpressionVisitor;
         let mut e_ = expr.data.e_binary().expect("infallible: variant checked");
@@ -898,7 +898,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         *e = current;
     }
 
-    fn e_index(p: &mut Self, e: &mut Expr, in_: ExprIn) {
+    fn e_index(p: &mut Self, e: &mut Expr<'a>, in_: ExprIn) {
         let expr = *e;
         let mut e_ = expr.data.e_index().expect("infallible: variant checked");
         let is_call_target = matches!(p.call_target, Data::EIndex(ct) if core::ptr::eq(&raw const *e_, &raw const *ct));
@@ -1182,7 +1182,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // `p.newExpr(e_, loc)` re-wraps the same pointer; here `*e` is already that.
     }
 
-    fn e_unary(p: &mut Self, e: &mut Expr, _: ExprIn) {
+    fn e_unary(p: &mut Self, e: &mut Expr<'a>, _: ExprIn) {
         let expr = *e;
         let mut e_ = expr.data.e_unary().expect("infallible: variant checked");
         match e_.op {
@@ -1360,7 +1360,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
     }
-    fn e_dot(p: &mut Self, e: &mut Expr, in_: ExprIn) {
+    fn e_dot(p: &mut Self, e: &mut Expr<'a>, in_: ExprIn) {
         let expr = *e;
         let mut e_ = expr.data.e_dot().expect("infallible: variant checked");
         let is_delete_target = matches!(p.delete_target, Data::EDot(dt) if core::ptr::eq(&raw const *e_, &raw const *dt));
@@ -1486,7 +1486,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    fn e_if(p: &mut Self, e: &mut Expr, _: ExprIn) {
+    fn e_if(p: &mut Self, e: &mut Expr<'a>, _: ExprIn) {
         let mut e_ = e.data.e_if().expect("infallible: variant checked");
         let is_call_target =
             matches!(p.call_target, Data::EIf(ct) if core::ptr::eq(&raw const *e_, &raw const *ct));
@@ -1564,7 +1564,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     #[inline(never)] // PERF(port:frame): see e_jsx_element.
-    fn e_array(p: &mut Self, e: &mut Expr, in_: ExprIn) {
+    fn e_array(p: &mut Self, e: &mut Expr<'a>, in_: ExprIn) {
         let mut e_ = e.data.e_array().expect("infallible: variant checked");
         if in_.assign_target != js_ast::AssignTarget::None {
             p.maybe_comma_spread_error(e_.comma_after_spread);
@@ -1673,7 +1673,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     #[inline(never)] // PERF(port:frame): see e_jsx_element.
-    fn e_object(p: &mut Self, e: &mut Expr, in_: ExprIn) {
+    fn e_object(p: &mut Self, e: &mut Expr<'a>, in_: ExprIn) {
         let mut e_ = e.data.e_object().expect("infallible: variant checked");
         if in_.assign_target != js_ast::AssignTarget::None {
             p.maybe_comma_spread_error(e_.comma_after_spread);
@@ -1836,7 +1836,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let _ = has_spread;
     }
     #[inline(never)] // PERF(port:frame): see e_jsx_element.
-    fn e_import(p: &mut Self, e: &mut Expr, in_: ExprIn) {
+    fn e_import(p: &mut Self, e: &mut Expr<'a>, in_: ExprIn) {
         let _ = in_;
         let mut e_ = e.data.e_import().expect("infallible: variant checked");
         // We want to forcefully fold constants inside of imports
@@ -1884,7 +1884,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.should_fold_typescript_constant_expressions =
             prev_should_fold_typescript_constant_expressions;
     }
-    fn e_call(p: &mut Self, e: &mut Expr, in_: ExprIn) {
+    fn e_call(p: &mut Self, e: &mut Expr<'a>, in_: ExprIn) {
         let expr = *e;
         let mut e_ = expr.data.e_call().expect("infallible: variant checked");
         p.call_target = e_.target.data;
@@ -2378,7 +2378,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     #[inline(never)] // PERF(port:frame): see e_jsx_element.
-    fn e_new(p: &mut Self, e: &mut Expr, _: ExprIn) {
+    fn e_new(p: &mut Self, e: &mut Expr<'a>, _: ExprIn) {
         let expr = *e;
         let mut e_ = expr.data.e_new().expect("infallible: variant checked");
         p.visit_expr(&mut e_.target);
@@ -2404,9 +2404,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// Note: Caller must check `p.bundler_feature_flag_ref.is_valid()` before calling.
     fn maybe_replace_bundler_feature_call(
         p: &mut Self,
-        e_: &mut E::Call,
+        e_: &mut E::Call<'a>,
         loc: bun_ast::Loc,
-    ) -> Option<Expr> {
+    ) -> Option<Expr<'a>> {
         // Check if the target is the `feature` function from "bun:bundle"
         // It could be e_identifier (for unbound) or e_import_identifier (for imports)
         let target_ref: Option<Ref> = match &e_.target.data {
@@ -2482,7 +2482,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         })
     }
     #[inline(never)] // PERF(port:frame): see e_jsx_element.
-    fn e_arrow(p: &mut Self, e: &mut Expr, in_: ExprIn) {
+    fn e_arrow(p: &mut Self, e: &mut Expr<'a>, in_: ExprIn) {
         let expr = *e;
         let _ = in_;
         let mut e_ = expr.data.e_arrow().expect("infallible: variant checked");
@@ -2572,7 +2572,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         e_.body.stmts = bun_ast::StoreSlice::new_mut(stmts_list.into_bump_slice_mut());
     }
     #[inline(never)] // PERF(port:frame): see e_jsx_element.
-    fn e_function(p: &mut Self, e: &mut Expr, in_: ExprIn) {
+    fn e_function(p: &mut Self, e: &mut Expr<'a>, in_: ExprIn) {
         let expr = *e;
         let _ = in_;
         let mut e_ = expr.data.e_function().expect("infallible: variant checked");
@@ -2643,7 +2643,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
     #[inline(never)] // PERF(port:frame): see e_jsx_element.
-    fn e_class(p: &mut Self, e: &mut Expr, in_: ExprIn) {
+    fn e_class(p: &mut Self, e: &mut Expr<'a>, in_: ExprIn) {
         let expr = *e;
         let _ = in_;
         let mut e_ = expr.data.e_class().expect("infallible: variant checked");

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -27,7 +27,7 @@ use bun_core::Error;
 use bun_core::strings;
 
 // `ListManaged(Stmt)` in the parser is arena-backed (`p.arena`).
-type StmtList<'bump> = BumpVec<'bump, Stmt>;
+type StmtList<'bump> = BumpVec<'bump, Stmt<'bump>>;
 
 use bun_ast::StmtNodeList;
 
@@ -42,9 +42,9 @@ use bun_ast::StmtNodeList;
 #[inline]
 fn visit_stmt_slice<'a, const TS: bool, const SO: bool>(
     p: &mut P<'a, TS, SO>,
-    slice: StmtNodeList,
+    slice: StmtNodeList<'a>,
     kind: StmtsKind,
-) -> StmtNodeList {
+) -> StmtNodeList<'a> {
     let src: &[Stmt] = slice.slice();
     let mut list: StmtList<'a> = BumpVec::with_capacity_in(src.len(), p.arena);
     list.extend_from_slice(src);
@@ -58,11 +58,11 @@ fn visit_stmt_slice<'a, const TS: bool, const SO: bool>(
 // reclaims both at end-of-parse.
 // PERF(port): was fromOwnedSlice (no copy) — profile in Phase B.
 #[inline]
-fn stmts_to_list<'a>(arena: &'a bun_alloc::Arena, ptr: StmtNodeList) -> StmtList<'a> {
+fn stmts_to_list<'a>(arena: &'a bun_alloc::Arena, ptr: StmtNodeList<'a>) -> StmtList<'a> {
     bun_alloc::vec_from_iter_in(ptr.iter().copied(), arena)
 }
 #[inline]
-fn list_to_stmts<'a>(list: StmtList<'a>) -> StmtNodeList {
+fn list_to_stmts<'a>(list: StmtList<'a>) -> StmtNodeList<'a> {
     StmtNodeList::from_bump(list)
 }
 
@@ -74,14 +74,14 @@ fn list_to_stmts<'a>(list: StmtList<'a>) -> StmtNodeList {
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
     // Thin alias of `current_scope_mut()` kept for local readability.
     #[inline(always)]
-    fn cur_scope(&mut self) -> &mut js_ast::Scope {
+    fn cur_scope(&mut self) -> &mut js_ast::Scope<'a> {
         self.current_scope_mut()
     }
 
     pub fn visit_and_append_stmt(
         &mut self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
+        stmt: &mut Stmt<'a>,
     ) -> Result<(), Error> {
         let p = self;
         // By default any statement ends the const local prefix
@@ -160,8 +160,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_import(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::Import,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::Import<'a>,
     ) -> Result<(), Error> {
         p.record_declared_symbol(data.namespace_ref);
 
@@ -183,8 +183,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_export_equals(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::ExportEquals,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::ExportEquals<'a>,
     ) -> Result<(), Error> {
         // "module.exports = value"
         // Zig: p.@"module.exports"(stmt.loc) — mapped to `module_exports`
@@ -200,8 +200,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_export_clause(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::ExportClause,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::ExportClause<'a>,
     ) -> Result<(), Error> {
         // "export {foo}"
         let items = data.items.slice_mut();
@@ -298,8 +298,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_export_from(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::ExportFrom,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::ExportFrom<'a>,
     ) -> Result<(), Error> {
         // "export {foo} from 'path'"
         let name = p.load_name_from_ref(data.namespace_ref);
@@ -362,8 +362,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_export_star(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::ExportStar,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::ExportStar<'a>,
     ) -> Result<(), Error> {
         // "export * from 'path'"
         let name = p.load_name_from_ref(data.namespace_ref);
@@ -403,8 +403,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_export_default(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::ExportDefault,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::ExportDefault<'a>,
     ) -> Result<(), Error> {
         // Zig: defer { if (data.default_name.ref) |ref| p.recordDeclaredSymbol(ref) catch unreachable; }
         // PORT NOTE: scopeguard can't borrow `p` across the body; restructured to a tail
@@ -920,8 +920,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_function(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::Function,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::Function<'a>,
     ) -> Result<(), Error> {
         // We mark it as dead, but the value may not actually be dead
         // We just want to be sure to not increment the usage counts for anything in the function
@@ -1090,8 +1090,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_class(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::Class,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::Class<'a>,
     ) -> Result<(), Error> {
         let mark_as_dead = p.options.features.dead_code_elimination
             && data.is_export
@@ -1178,8 +1178,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_local(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::Local,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::Local<'a>,
         was_after_after_const_local_prefix: bool,
     ) -> Result<(), Error> {
         // TODO: Silently remove unsupported top-level "await" in dead code branches
@@ -1327,7 +1327,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_break(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
+        stmt: &mut Stmt<'a>,
         data: &mut S::Break,
     ) -> Result<(), Error> {
         if let Some(label) = &mut data.label {
@@ -1360,7 +1360,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_continue(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
+        stmt: &mut Stmt<'a>,
         data: &mut S::Continue,
     ) -> Result<(), Error> {
         if let Some(label) = &mut data.label {
@@ -1395,8 +1395,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_label(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::Label,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::Label<'a>,
     ) -> Result<(), Error> {
         p.push_scope_for_visit_pass(js_ast::scope::Kind::Label, stmt.loc)
             .expect("unreachable");
@@ -1427,8 +1427,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_expr(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::SExpr,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::SExpr<'a>,
     ) -> Result<(), Error> {
         let should_trim_primitive = p.options.features.dead_code_elimination
             && (p.options.features.minify_syntax && data.value.is_primitive_literal());
@@ -1581,8 +1581,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_throw(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::Throw,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::Throw<'a>,
     ) -> Result<(), Error> {
         p.visit_expr(&mut data.value);
         stmts.push(*stmt);
@@ -1592,8 +1592,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_return(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::Return,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::Return<'a>,
     ) -> Result<(), Error> {
         // Forbid top-level return inside modules with ECMAScript-style exports
         if p.fn_or_arrow_data_visit.is_outside_fn_or_arrow {
@@ -1633,8 +1633,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_block(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::Block,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::Block<'a>,
     ) -> Result<(), Error> {
         {
             p.push_scope_for_visit_pass(js_ast::scope::Kind::Block, stmt.loc)
@@ -1663,7 +1663,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         if p.options.features.minify_syntax {
             // // trim empty statements
-            let block_stmts: &[Stmt] = data.stmts.slice();
+            let block_stmts: &[Stmt<'a>] = data.stmts.slice();
             if block_stmts.is_empty() {
                 stmts.push(Stmt {
                     data: Stmt::empty().data,
@@ -1684,8 +1684,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_with(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::With,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::With<'a>,
     ) -> Result<(), Error> {
         p.visit_expr(&mut data.value);
 
@@ -1710,8 +1710,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_while(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::While,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::While<'a>,
     ) -> Result<(), Error> {
         p.visit_expr(&mut data.test_);
         data.body = p.visit_loop_body(data.body);
@@ -1734,8 +1734,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_do_while(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::DoWhile,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::DoWhile<'a>,
     ) -> Result<(), Error> {
         data.body = p.visit_loop_body(data.body);
         p.visit_expr(&mut data.test_);
@@ -1748,8 +1748,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_if(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::If,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::If<'a>,
     ) -> Result<(), Error> {
         let prev_in_branch = p.in_branch_condition;
         p.in_branch_condition = true;
@@ -1887,8 +1887,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_for(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::For,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::For<'a>,
     ) -> Result<(), Error> {
         p.push_scope_for_visit_pass(js_ast::scope::Kind::Block, stmt.loc)
             .expect("unreachable");
@@ -1938,8 +1938,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_for_in(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::ForIn,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::ForIn<'a>,
     ) -> Result<(), Error> {
         {
             p.push_scope_for_visit_pass(js_ast::scope::Kind::Block, stmt.loc)
@@ -1987,8 +1987,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_for_of(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::ForOf,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::ForOf<'a>,
     ) -> Result<(), Error> {
         p.push_scope_for_visit_pass(js_ast::scope::Kind::Block, stmt.loc)
             .expect("unreachable");
@@ -2094,8 +2094,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_try(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::Try,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::Try<'a>,
     ) -> Result<(), Error> {
         p.push_scope_for_visit_pass(js_ast::scope::Kind::Block, stmt.loc)
             .expect("unreachable");
@@ -2146,8 +2146,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_switch(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::Switch,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::Switch<'a>,
     ) -> Result<(), Error> {
         p.visit_expr(&mut data.test_);
         {
@@ -2180,8 +2180,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_enum(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::Enum,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::Enum<'a>,
         was_after_after_const_local_prefix: bool,
     ) -> Result<(), Error> {
         // Do not end the const local prefix after TypeScript enums. We process
@@ -2392,8 +2392,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn s_namespace(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
-        stmt: &mut Stmt,
-        data: &mut S::Namespace,
+        stmt: &mut Stmt<'a>,
+        data: &mut S::Namespace<'a>,
     ) -> Result<(), Error> {
         p.record_declared_symbol(data.name.ref_.expect("infallible: ref bound"));
 
@@ -2401,7 +2401,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // ahead of time before visiting any statements inside the namespace
         // because we may end up visiting the uses before the declarations.
         // We need to convert the uses into property accesses on the namespace.
-        let child_stmts: &[Stmt] = data.stmts.slice();
+        let child_stmts: &[Stmt<'a>] = data.stmts.slice();
         for child_stmt in child_stmts.iter() {
             if let StmtData::SLocal(local) = child_stmt.data {
                 if local.is_export {

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -106,16 +106,16 @@ impl MacroContext {
         }
     }
 
-    pub fn call(
+    pub fn call<'arena>(
         &mut self,
         import_record_path: &[u8],
         source_dir: &[u8],
         log: &mut Log,
         source: &Source,
         import_range: Range,
-        caller: Expr,
+        caller: Expr<'arena>,
         function_name: &[u8],
-    ) -> Result<Expr, Error> {
+    ) -> Result<Expr<'arena>, Error> {
         let _store_guard = DisableStoreReset::new();
         // const is_package_path = isPackagePath(specifier);
         let import_record_path_without_macro_prefix = if is_macro_path(import_record_path) {
@@ -309,16 +309,16 @@ pub fn __bun_macro_context_deinit(data: *mut core::ffi::c_void) {
 }
 
 #[unsafe(no_mangle)]
-pub fn __bun_macro_context_call(
+pub fn __bun_macro_context_call<'arena>(
     ctx: &mut js_parser::Macro::MacroContext,
     import_record_path: &[u8],
     source_dir: &[u8],
     log: &mut Log,
     source: &Source,
     import_range: Range,
-    caller: Expr,
+    caller: Expr<'arena>,
     function_name: &[u8],
-) -> Result<Expr, Error> {
+) -> Result<Expr<'arena>, Error> {
     debug_assert!(
         !ctx.data.is_null(),
         "MacroContext.call reached without init"
@@ -358,9 +358,9 @@ pub fn __bun_macro_context_get_remap(
 // ══════════════════════════════════════════════════════════════════════════
 
 #[derive(Default)]
-pub struct MacroResult {
-    pub import_statements: Box<[S::Import]>,
-    pub replacement: Expr,
+pub struct MacroResult<'arena> {
+    pub import_statements: Box<[S::Import<'arena>]>,
+    pub replacement: Expr<'arena>,
 }
 
 // ══════════════════════════════════════════════════════════════════════════
@@ -501,7 +501,7 @@ impl Macro {
 
 pub struct Runner;
 
-type VisitMap = HashMap<JSValue, Expr>;
+type VisitMap<'arena> = HashMap<JSValue, Expr<'arena>>;
 
 thread_local! {
     static EXCEPTION_HOLDER: Cell<bool> = const { Cell::new(false) };
@@ -543,8 +543,8 @@ impl From<MacroError> for Error {
     }
 }
 
-pub struct Run<'a> {
-    pub caller: Expr,
+pub struct Run<'a, 'arena> {
+    pub caller: Expr<'arena>,
     pub function_name: &'a [u8],
     pub macro_: &'a Macro,
     pub global: &'a JSGlobalObject,
@@ -557,25 +557,25 @@ pub struct Run<'a> {
     // `MacroContext` (stored long-term in the `Transpiler`) so the slices
     // outlive `run_async` — the returned `Expr` is spliced into the AST and
     // printed long after this frame returns.
-    pub bump: &'a bun_alloc::Arena,
+    pub bump: &'arena bun_alloc::Arena,
     pub id: i32,
     pub log: &'a mut Log,
     pub source: &'a Source,
-    pub visited: VisitMap,
+    pub visited: VisitMap<'arena>,
     pub is_top_level: bool,
 }
 
-impl<'a> Run<'a> {
+impl<'a, 'arena> Run<'a, 'arena> {
     pub fn run_async(
         macro_: &Macro,
         log: &mut Log,
-        bump: &bun_alloc::Arena,
+        bump: &'arena bun_alloc::Arena,
         function_name: &[u8],
-        caller: Expr,
+        caller: Expr<'arena>,
         args: &[JSValue],
         source: &Source,
         id: i32,
-    ) -> Result<Expr, MacroError> {
+    ) -> Result<Expr<'arena>, MacroError> {
         let _ = macro_.vm();
         let vm = VirtualMachine::get();
         let Some(&macro_callback) = vm.macros.get(&id) else {
@@ -614,7 +614,7 @@ impl<'a> Run<'a> {
         runner.run(result)
     }
 
-    pub fn run(&mut self, value: JSValue) -> Result<Expr, MacroError> {
+    pub fn run(&mut self, value: JSValue) -> Result<Expr<'arena>, MacroError> {
         use ConsoleObject::formatter::Tag as T;
         // PORT NOTE: `Tag::get` returns `TagResult { tag: TagPayload, .. }`;
         // collapse the payload to its discriminant via `.tag()`.
@@ -659,7 +659,7 @@ impl<'a> Run<'a> {
         &mut self,
         tag: ConsoleObject::formatter::Tag,
         value: JSValue,
-    ) -> Result<Expr, MacroError> {
+    ) -> Result<Expr<'arena>, MacroError> {
         use ConsoleObject::formatter::Tag as T;
         match tag {
             T::Error => {
@@ -955,16 +955,16 @@ impl<'a> Run<'a> {
 }
 
 impl Runner {
-    pub fn run(
+    pub fn run<'arena>(
         macro_: &Macro,
         log: &mut Log,
         bump: &bun_alloc::Arena,
         function_name: &[u8],
-        caller: Expr,
+        caller: Expr<'arena>,
         source: &Source,
         id: i32,
         javascript_object: JSValue,
-    ) -> Result<Expr, MacroError> {
+    ) -> Result<Expr<'arena>, MacroError> {
         if cfg!(debug_assertions) {
             Output::prettyln(format_args!(
                 "<r><d>[macro]<r> call <d><b>{}<r>",
@@ -1063,22 +1063,22 @@ impl Runner {
             static CALL_STATE: Cell<*mut c_void> = const { Cell::new(core::ptr::null_mut()) };
         }
 
-        struct CallData<'c> {
+        struct CallData<'c, 'arena> {
             macro_: &'c Macro,
             log: &'c mut Log,
             bump: &'c bun_alloc::Arena,
             function_name: &'c [u8],
-            caller: Expr,
+            caller: Expr<'arena>,
             js_args: &'c [JSValue],
             source: &'c Source,
             id: i32,
-            result: Result<Expr, MacroError>,
+            result: Result<Expr<'arena>, MacroError>,
         }
 
         extern "C" fn call() {
             CALL_STATE.with(|s| {
                 // SAFETY: set immediately before Bun__startMacro below; cleared after.
-                let state = unsafe { &mut *s.get().cast::<CallData<'_>>() };
+                let state = unsafe { &mut *s.get().cast::<CallData<'_, '_>>() };
                 state.result = Run::run_async(
                     state.macro_,
                     state.log,
@@ -1129,13 +1129,13 @@ unsafe extern "C" {
 /// Zig: `Expr.fromBlob` (`src/js_parser/ast/Expr.zig`). Lives here, not on
 /// `bun_ast::Expr`, because it parses JSON via `bun_parsers` — `bun_ast` is a
 /// leaf below both. Only call site is the macro `Response`/`Blob` arm above.
-fn expr_from_blob(
+fn expr_from_blob<'arena>(
     bytes: &[u8],
-    bump: &bun_alloc::Arena,
+    bump: &'arena bun_alloc::Arena,
     mime_type: &[u8],
     log: &mut Log,
     loc: bun_ast::Loc,
-) -> Result<Expr, bun_core::Error> {
+) -> Result<Expr<'arena>, bun_core::Error> {
     use bun_ast::{E, ExprData, StoreStr as Str};
 
     // MimeType::Category::Json — `application/json` or `+json`/`/json` suffix.
@@ -1144,8 +1144,8 @@ fn expr_from_blob(
         || mime_type.ends_with(b"/json");
 
     if is_json {
-        let source = &Source::init_path_string(b"fetch.json", bytes);
-        let mut out_expr: Expr = match bun_parsers::json::parse_for_macro(source, log, bump) {
+        let source: &'arena Source = bump.alloc(Source::init_path_string(b"fetch.json", bytes));
+        let mut out_expr = match bun_parsers::json::parse_for_macro(source, log, bump) {
             Ok(e) => e,
             Err(_) => return Err(bun_core::err!("MacroFailed")),
         };

--- a/src/js_parser_jsc/expr_jsc.rs
+++ b/src/js_parser_jsc/expr_jsc.rs
@@ -31,13 +31,13 @@ pub fn expr_to_js(this: &Expr, global: &JSGlobalObject) -> Result<JSValue, ToJSE
 pub trait ExprJsc {
     fn to_js(&self, global: &JSGlobalObject) -> Result<JSValue, ToJSError>;
 }
-impl ExprJsc for Expr {
+impl ExprJsc for Expr<'_> {
     #[inline]
     fn to_js(&self, global: &JSGlobalObject) -> Result<JSValue, ToJSError> {
         expr_to_js(self, global)
     }
 }
-impl ExprJsc for ExprData {
+impl ExprJsc for ExprData<'_> {
     #[inline]
     fn to_js(&self, global: &JSGlobalObject) -> Result<JSValue, ToJSError> {
         data_to_js(self, global)

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1273,7 +1273,7 @@ pub struct Options<'a> {
     /// Borrowed from `LinkerGraph.ts_enums` (one shared map for the whole
     /// bundle). Zig passed the unmanaged map header by value; the printer
     /// only reads from it.
-    pub ts_enums: Option<&'a TsEnumsMap>,
+    pub ts_enums: Option<&'a TsEnumsMap<'a>>,
 
     // If we're writing out a source map, this table of line start indices lets
     // us do binary search on to figure out what line a given AST node came from
@@ -1433,7 +1433,7 @@ impl RequireOrImportMetaCallback {
     }
 }
 
-fn is_identifier_or_numeric_constant_or_property_access(expr: &js_ast::Expr) -> bool {
+fn is_identifier_or_numeric_constant_or_property_access(expr: &js_ast::Expr<'_>) -> bool {
     use js_ast::ExprData;
     match &expr.data {
         ExprData::EIdentifier(_) | ExprData::EDot(_) | ExprData::EIndex(_) => true,
@@ -1528,7 +1528,7 @@ impl ImportVariant {
         }
     }
 
-    pub fn determine(record: &ImportRecord, s_import: &js_ast::S::Import) -> ImportVariant {
+    pub fn determine(record: &ImportRecord, s_import: &js_ast::S::Import<'_>) -> ImportVariant {
         let mut variant = ImportVariant::PathOnly;
 
         if record
@@ -1650,7 +1650,7 @@ pub mod __gated_printer {
     /// free fn (vs. calling `.slice()` inline) so the ~50 call sites stay
     /// `.zig`-diffable; the printer only ever reads these.
     #[inline(always)]
-    pub(crate) fn slice_of<'a, T>(p: js_ast::StoreSlice<T>) -> &'a [T] {
+    pub(crate) fn slice_of<'a, T>(p: js_ast::StoreSlice<'a, T>) -> &'a [T] {
         p.slice()
     }
     /// `EnumSet<T>` field-style mutation as used by the Zig (`flags.x = true`).
@@ -1690,18 +1690,18 @@ pub mod __gated_printer {
         pub prev_op_end: i32,
         pub prev_num_end: i32,
         pub prev_reg_exp_end: i32,
-        pub call_target: Option<ExprData>,
+        pub call_target: Option<ExprData<'a>>,
         pub writer: W,
 
         pub has_printed_bundled_import_statement: bool,
 
-        pub renamer: rename::Renamer<'a, 'a>,
+        pub renamer: rename::Renamer<'a, 'a, 'a>,
         pub prev_stmt_tag: StmtTag,
         pub source_map_builder: SourceMap::chunk::Builder,
 
         pub symbol_counter: u32,
 
-        pub temporary_bindings: Vec<B::Property>,
+        pub temporary_bindings: Vec<B::Property<'a>>,
 
         pub binary_expression_stack: Vec<BinaryExpressionVisitor<'a>>,
 
@@ -1723,7 +1723,7 @@ pub mod __gated_printer {
         // Inputs
         // PORT NOTE: Zig stored `*const E.Binary`; Phase A keeps the StoreRef so the
         // visitor stack can outlive the by-value `Expr` argument to `print_expr`.
-        pub e: js_ast::StoreRef<E::Binary>,
+        pub e: js_ast::StoreRef<'ast, E::Binary<'ast>>,
         _phantom: core::marker::PhantomData<&'ast ()>,
         pub level: Level,
         pub flags: ExprFlagSet,
@@ -2044,7 +2044,7 @@ pub mod __gated_printer {
             }
         }
 
-        fn print_global_bun_import_statement(&mut self, import: &S::Import) {
+        fn print_global_bun_import_statement(&mut self, import: &S::Import<'a>) {
             if !IS_BUN_PLATFORM {
                 unreachable!();
             }
@@ -2053,7 +2053,7 @@ pub mod __gated_printer {
 
         fn print_internal_bun_import(
             &mut self,
-            import: &S::Import,
+            import: &S::Import<'a>,
             statement: Option<&'static [u8]>,
         ) {
             if !IS_BUN_PLATFORM {
@@ -2223,7 +2223,7 @@ pub mod __gated_printer {
             }
         }
 
-        pub fn print_body(&mut self, stmt: Stmt, tlmtlo: TopLevel) {
+        pub fn print_body(&mut self, stmt: Stmt<'a>, tlmtlo: TopLevel) {
             match &stmt.data {
                 StmtData::SBlock(block) => {
                     self.print_space();
@@ -2244,7 +2244,7 @@ pub mod __gated_printer {
             }
         }
 
-        pub fn print_block_body(&mut self, stmts: &[Stmt], tlmtlo: TopLevel) {
+        pub fn print_block_body(&mut self, stmts: &[Stmt<'a>], tlmtlo: TopLevel) {
             for stmt in stmts {
                 self.print_semicolon_if_needed();
                 self.print_stmt(*stmt, tlmtlo).expect("unreachable");
@@ -2254,7 +2254,7 @@ pub mod __gated_printer {
         pub fn print_block(
             &mut self,
             loc: bun_ast::Loc,
-            stmts: &[Stmt],
+            stmts: &[Stmt<'a>],
             close_brace_loc: Option<bun_ast::Loc>,
             tlmtlo: TopLevel,
         ) {
@@ -2280,8 +2280,8 @@ pub mod __gated_printer {
         pub fn print_two_blocks_in_one(
             &mut self,
             loc: bun_ast::Loc,
-            stmts: &[Stmt],
-            prepend: &[Stmt],
+            stmts: &[Stmt<'a>],
+            prepend: &[Stmt<'a>],
         ) {
             self.add_source_mapping(loc);
             self.print(b"{");
@@ -2300,7 +2300,7 @@ pub mod __gated_printer {
         pub fn print_decls(
             &mut self,
             keyword: &'static [u8],
-            decls_: &[G::Decl],
+            decls_: &[G::Decl<'a>],
             flags: ExprFlagSet,
             tlm: TopLevelAndIsExport,
         ) {
@@ -2544,7 +2544,7 @@ pub mod __gated_printer {
         pub fn print_fn_args(
             &mut self,
             open_paren_loc: Option<bun_ast::Loc>,
-            args: &[G::Arg],
+            args: &[G::Arg<'a>],
             has_rest_arg: bool,
             // is_arrow can be used for minifying later
             _is_arrow: bool,
@@ -2581,7 +2581,7 @@ pub mod __gated_printer {
             }
         }
 
-        pub fn print_func(&mut self, func: &G::Fn) {
+        pub fn print_func(&mut self, func: &G::Fn<'a>) {
             self.print_fn_args(
                 Some(func.open_parens_loc),
                 slice_of(func.args),
@@ -2597,7 +2597,7 @@ pub mod __gated_printer {
             );
         }
 
-        pub fn print_class(&mut self, class: &G::Class) {
+        pub fn print_class(&mut self, class: &G::Class<'a>) {
             if let Some(extends) = &class.extends {
                 self.print(b" extends");
                 self.print_space();
@@ -2647,7 +2647,7 @@ pub mod __gated_printer {
             self.print(b"}");
         }
 
-        pub fn best_quote_char_for_e_string(str: &E::String, allow_backtick: bool) -> u8 {
+        pub fn best_quote_char_for_e_string(str: &E::String<'_>, allow_backtick: bool) -> u8 {
             if IS_JSON {
                 return b'"';
             }
@@ -2716,7 +2716,7 @@ pub mod __gated_printer {
             );
         }
 
-        pub fn is_unbound_eval_identifier(&self, value: Expr) -> bool {
+        pub fn is_unbound_eval_identifier(&self, value: Expr<'a>) -> bool {
             match &value.data {
                 ExprData::EIdentifier(ident) => {
                     if ident.ref_.is_source_contents_slice() {
@@ -2734,7 +2734,7 @@ pub mod __gated_printer {
         }
 
         #[inline]
-        fn symbols(&self) -> &js_ast::symbol::Map {
+        fn symbols(&self) -> &js_ast::symbol::Map<'a> {
             self.renamer.symbols()
         }
 
@@ -2769,7 +2769,7 @@ pub mod __gated_printer {
             &self.import_records[import_record_index]
         }
 
-        pub fn is_unbound_identifier(&self, expr: &Expr) -> bool {
+        pub fn is_unbound_identifier(&self, expr: &Expr<'a>) -> bool {
             let ExprData::EIdentifier(id) = &expr.data else {
                 return false;
             };
@@ -2784,8 +2784,8 @@ pub mod __gated_printer {
             &mut self,
             import_record_index: u32,
             was_unwrapped_require: bool,
-            leading_interior_comments: &[G::Comment],
-            import_options: Expr,
+            leading_interior_comments: &[G::Comment<'a>],
+            import_options: Expr<'a>,
             level_: Level,
             flags: ExprFlagSet,
         ) {
@@ -3068,7 +3068,7 @@ pub mod __gated_printer {
             }
         }
 
-        pub fn print_string_literal_e_string(&mut self, str: &E::String, allow_backtick: bool) {
+        pub fn print_string_literal_e_string(&mut self, str: &E::String<'a>, allow_backtick: bool) {
             let quote = Self::best_quote_char_for_e_string(str, allow_backtick);
             self.print(quote);
             self.print_string_characters_e_string(str, quote);
@@ -3089,19 +3089,19 @@ pub mod __gated_printer {
             self.print(quote);
         }
 
-        fn print_clause_item(&mut self, item: &js_ast::ClauseItem) {
+        fn print_clause_item(&mut self, item: &js_ast::ClauseItem<'a>) {
             self.print_clause_item_as(item, ClauseItemAs::Import)
         }
 
-        fn print_export_clause_item(&mut self, item: &js_ast::ClauseItem) {
+        fn print_export_clause_item(&mut self, item: &js_ast::ClauseItem<'a>) {
             self.print_clause_item_as(item, ClauseItemAs::Export)
         }
 
-        fn print_export_from_clause_item(&mut self, item: &js_ast::ClauseItem) {
+        fn print_export_from_clause_item(&mut self, item: &js_ast::ClauseItem<'a>) {
             self.print_clause_item_as(item, ClauseItemAs::ExportFrom)
         }
 
-        fn print_clause_item_as(&mut self, item: &js_ast::ClauseItem, as_: ClauseItemAs) {
+        fn print_clause_item_as(&mut self, item: &js_ast::ClauseItem<'a>, as_: ClauseItemAs) {
             let name = self.name_for_symbol(item.name.ref_.expect("infallible: ref bound"));
 
             match as_ {
@@ -3212,7 +3212,7 @@ pub mod __gated_printer {
             }
         }
 
-        pub fn print_expr(&mut self, expr: Expr, level: Level, in_flags: ExprFlagSet) {
+        pub fn print_expr(&mut self, expr: Expr<'a>, level: Level, in_flags: ExprFlagSet) {
             let mut flags = in_flags;
 
             match &expr.data {
@@ -4042,7 +4042,7 @@ pub mod __gated_printer {
                         // Zig: `var part = part.*` — `TemplatePart` is structurally
                         // `Copy` but `EString` doesn't derive it; field-wise copy.
                         #[inline]
-                        fn part_clone(p: &E::TemplatePart) -> E::TemplatePart {
+                        fn part_clone<'p>(p: &E::TemplatePart<'p>) -> E::TemplatePart<'p> {
                             E::TemplatePart {
                                 value: p.value,
                                 tail_loc: p.tail_loc,
@@ -4055,7 +4055,7 @@ pub mod __gated_printer {
                             }
                         }
 
-                        let mut replaced: Vec<E::TemplatePart> = Vec::new();
+                        let mut replaced: Vec<E::TemplatePart<'a>> = Vec::new();
                         for (i, _part) in e.parts().iter().enumerate() {
                             let mut part = part_clone(_part);
                             let inlined_value: Option<Expr> = match &part.value.data {
@@ -4520,7 +4520,7 @@ pub mod __gated_printer {
         }
 
         // This assumes the string has already been quoted.
-        pub fn print_string_characters_e_string(&mut self, str: &E::String, c: u8) {
+        pub fn print_string_characters_e_string(&mut self, str: &E::String<'a>, c: u8) {
             if !str.is_utf8() {
                 self.print_string_characters_utf16(str.slice16(), c);
             } else {
@@ -4531,7 +4531,7 @@ pub mod __gated_printer {
         pub fn print_namespace_alias(
             &mut self,
             _import_record: &ImportRecord,
-            namespace: &G::NamespaceAlias,
+            namespace: &G::NamespaceAlias<'a>,
         ) {
             self.print_symbol(namespace.namespace_ref);
 
@@ -4554,7 +4554,7 @@ pub mod __gated_printer {
             }
         }
 
-        pub fn print_reg_exp_literal(&mut self, e: &E::RegExp) {
+        pub fn print_reg_exp_literal(&mut self, e: &E::RegExp<'a>) {
             let n = self.writer.written();
 
             // Avoid forming a single-line comment
@@ -4602,7 +4602,7 @@ pub mod __gated_printer {
             self.prev_reg_exp_end = self.writer.written();
         }
 
-        pub fn print_property(&mut self, item_in: &G::Property) {
+        pub fn print_property(&mut self, item_in: &G::Property<'a>) {
             // PORT NOTE: Zig took G.Property by value (Copy in Zig). Rust's
             // G::Property isn't `Copy`, so take a borrow and shallow-copy the
             // mutable bits we may rewrite (key + flags).
@@ -4897,14 +4897,14 @@ pub mod __gated_printer {
             }
         }
 
-        pub fn print_initializer(&mut self, initial: Expr) {
+        pub fn print_initializer(&mut self, initial: Expr<'a>) {
             self.print_space();
             self.print(b"=");
             self.print_space();
             self.print_expr(initial, Level::Comma, ExprFlag::none());
         }
 
-        pub fn print_binding(&mut self, binding: Binding, tlm: TopLevelAndIsExport) {
+        pub fn print_binding(&mut self, binding: Binding<'a>, tlm: TopLevelAndIsExport) {
             match &binding.data {
                 BindingData::BMissing(_) => {}
                 BindingData::BIdentifier(b) => {
@@ -5119,7 +5119,7 @@ pub mod __gated_printer {
             }
         }
 
-        pub fn maybe_print_default_binding_value<P: HasDefaultValue>(&mut self, property: &P) {
+        pub fn maybe_print_default_binding_value<P: HasDefaultValue<'a>>(&mut self, property: &P) {
             if let Some(default) = property.default_value() {
                 self.print_space();
                 self.print(b"=");
@@ -5128,7 +5128,7 @@ pub mod __gated_printer {
             }
         }
 
-        pub fn print_stmt(&mut self, stmt: Stmt, tlmtlo: TopLevel) -> Result<(), bun_core::Error> {
+        pub fn print_stmt(&mut self, stmt: Stmt<'a>, tlmtlo: TopLevel) -> Result<(), bun_core::Error> {
             let prev_stmt_tag = self.prev_stmt_tag;
             // Zig: `defer { p.prev_stmt_tag = std.meta.activeTag(stmt.data); }`
             // PORT NOTE: reshaped for borrowck — scopeguard would hold `&mut self.prev_stmt_tag`
@@ -6354,7 +6354,7 @@ pub mod __gated_printer {
             }
         }
 
-        pub fn print_bundled_import(&mut self, record: ImportRecord, s: &S::Import) {
+        pub fn print_bundled_import(&mut self, record: ImportRecord, s: &S::Import<'a>) {
             if record.flags.contains(ImportRecordFlags::IS_INTERNAL) {
                 return;
             }
@@ -6509,7 +6509,7 @@ pub mod __gated_printer {
             self.print(b", enumerable: true, configurable: true})");
         }
 
-        pub fn print_for_loop_init(&mut self, init_st: Stmt) {
+        pub fn print_for_loop_init(&mut self, init_st: Stmt<'a>) {
             match &init_st.data {
                 StmtData::SExpr(s) => {
                     self.print_expr(
@@ -6559,7 +6559,7 @@ pub mod __gated_printer {
             }
         }
 
-        pub fn print_if(&mut self, s: &S::If, loc: bun_ast::Loc, tlmtlo: TopLevel) {
+        pub fn print_if(&mut self, s: &S::If<'a>, loc: bun_ast::Loc, tlmtlo: TopLevel) {
             self.print_space_before_identifier();
             self.add_source_mapping(loc);
             self.print(b"if");
@@ -6640,7 +6640,7 @@ pub mod __gated_printer {
             }
         }
 
-        pub fn wrap_to_avoid_ambiguous_else(s_: &StmtData) -> bool {
+        pub fn wrap_to_avoid_ambiguous_else(s_: &StmtData<'_>) -> bool {
             let mut s = s_;
             loop {
                 match s {
@@ -6664,9 +6664,9 @@ pub mod __gated_printer {
 
         pub fn try_to_get_imported_enum_value(
             &self,
-            target: Expr,
+            target: Expr<'a>,
             name: &[u8],
-        ) -> Option<js_ast::InlinedEnumValueDecoded> {
+        ) -> Option<js_ast::InlinedEnumValueDecoded<'a>> {
             if let ExprData::EImportIdentifier(id) = &target.data {
                 let ref_ = self.symbols().follow(id.ref_);
                 if let Some(symbol) = self.symbols().get_const(ref_) {
@@ -6684,7 +6684,7 @@ pub mod __gated_printer {
 
         pub fn print_inlined_enum(
             &mut self,
-            inlined: js_ast::InlinedEnumValueDecoded,
+            inlined: js_ast::InlinedEnumValueDecoded<'a>,
             comment: &[u8],
             level: Level,
         ) {
@@ -6719,7 +6719,7 @@ pub mod __gated_printer {
             &mut self,
             is_export: bool,
             keyword: &'static [u8],
-            decls: &[G::Decl],
+            decls: &[G::Decl<'a>],
             tlmtlo: TopLevel,
         ) {
             if !REWRITE_ESM_TO_CJS && is_export {
@@ -6987,7 +6987,7 @@ pub mod __gated_printer {
             bump: &'a bun_alloc::Arena,
             import_records: &'a [ImportRecord],
             opts: Options<'a>,
-            renamer: rename::Renamer<'a, 'a>,
+            renamer: rename::Renamer<'a, 'a, 'a>,
             source_map_builder: SourceMap::chunk::Builder,
         ) -> Self {
             let mut printer = Self {
@@ -7027,8 +7027,8 @@ pub mod __gated_printer {
         pub fn print_dev_server_module(
             &mut self,
             source: &bun_ast::Source,
-            ast: &js_ast::Ast,
-            part: &js_ast::Part,
+            ast: &js_ast::Ast<'a>,
+            part: &js_ast::Part<'a>,
         ) {
             self.indent();
             self.print_indent();
@@ -7230,18 +7230,18 @@ impl<const N: usize> PrintArg for &[u8; N] {
 }
 
 /// Trait covering `B::ArrayItem` / `B::Property` for `maybe_print_default_binding_value`.
-pub trait HasDefaultValue {
-    fn default_value(&self) -> Option<js_ast::Expr>;
+pub trait HasDefaultValue<'arena> {
+    fn default_value(&self) -> Option<js_ast::Expr<'arena>>;
 }
-impl HasDefaultValue for js_ast::b::Property {
+impl<'arena> HasDefaultValue<'arena> for js_ast::b::Property<'arena> {
     #[inline]
-    fn default_value(&self) -> Option<js_ast::Expr> {
+    fn default_value(&self) -> Option<js_ast::Expr<'arena>> {
         self.default_value
     }
 }
-impl HasDefaultValue for js_ast::ArrayBinding {
+impl<'arena> HasDefaultValue<'arena> for js_ast::ArrayBinding<'arena> {
     #[inline]
-    fn default_value(&self) -> Option<js_ast::Expr> {
+    fn default_value(&self) -> Option<js_ast::Expr<'arena>> {
         self.default_value
     }
 }
@@ -7826,9 +7826,9 @@ use js_ast::Ast;
 // constant in the monomorphized callers.
 pub fn get_source_map_builder<const IS_BUN_PLATFORM: bool>(
     generate_source_map: GenerateSourceMap,
-    opts: &mut Options,
+    opts: &mut Options<'_>,
     source: &bun_ast::Source,
-    tree: &Ast,
+    tree: &Ast<'_>,
 ) -> SourceMap::chunk::Builder {
     if generate_source_map == GenerateSourceMap::Disable {
         // TODO(port): Zig returned `undefined` here.
@@ -7883,9 +7883,9 @@ pub fn get_source_map_builder<const IS_BUN_PLATFORM: bool>(
 pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOURCE_MAP: bool>(
     _writer: W,
     bump: &'a bun_alloc::Arena,
-    tree: &'a Ast,
-    symbols: js_ast::symbol::Map,
-    source: &'a bun_ast::Source,
+    tree: &Ast<'a>,
+    symbols: js_ast::symbol::Map<'a>,
+    source: &bun_ast::Source,
     opts: Options<'a>,
 ) -> Result<usize, bun_core::Error> {
     let _restore =
@@ -7900,7 +7900,7 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
     // PORT NOTE: hoisted out of the `minify_identifiers` arm so the
     // `&'r mut MinifyRenamer` borrow stored in `renamer` outlives the branch.
     let mut minify_renamer;
-    let renamer: rename::Renamer<'_, '_>;
+    let renamer: rename::Renamer<'_, '_, '_>;
     // PORT NOTE: Zig copied `tree.module_scope` to a stack local and re-pointed
     // children's `parent` at the local. `Scope` isn't `Copy` here and the only
     // consumer (`compute_reserved_names_for_scope`) walks `members`/`generated`/
@@ -7989,7 +7989,7 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
         let mut minifier = tree.char_freq.as_ref().unwrap().compile();
         minify_renamer.assign_names_by_frequency(&mut minifier)?;
 
-        renamer = rename::Renamer::MinifyRenamer(&mut *minify_renamer);
+        renamer = rename::Renamer::MinifyRenamer(&*minify_renamer);
     } else {
         no_op_renamer = rename::NoOpRenamer::init(symbols, source);
         renamer = no_op_renamer.to_renamer();
@@ -8149,7 +8149,7 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
 
 pub fn print_json<W: WriterTrait>(
     _writer: W,
-    expr: js_ast::Expr,
+    expr: js_ast::Expr<'_>,
     source: &bun_ast::Source,
     opts: PrintJsonOptions<'_>,
 ) -> Result<usize, bun_core::Error> {
@@ -8192,12 +8192,12 @@ pub fn print_json<W: WriterTrait>(
 pub fn print<'a, const GENERATE_SOURCE_MAPS: bool>(
     bump: &'a bun_alloc::Arena,
     target: bun_ast::Target,
-    ast: &Ast,
+    ast: &Ast<'a>,
     source: &bun_ast::Source,
     opts: Options<'a>,
     import_records: &'a [ImportRecord],
-    parts: &[js_ast::Part],
-    renamer: rename::Renamer<'a, 'a>,
+    parts: &[js_ast::Part<'a>],
+    renamer: rename::Renamer<'a, 'a, 'a>,
 ) -> PrintResult {
     let _trace = bun_core::perf::trace("JSPrinter.print");
 
@@ -8223,12 +8223,12 @@ pub fn print_with_writer<'a, W: WriterTrait, const GENERATE_SOURCE_MAPS: bool>(
     writer: W,
     bump: &'a bun_alloc::Arena,
     target: bun_ast::Target,
-    ast: &Ast,
+    ast: &Ast<'a>,
     source: &bun_ast::Source,
     opts: Options<'a>,
     import_records: &'a [ImportRecord],
-    parts: &[js_ast::Part],
-    renamer: rename::Renamer<'a, 'a>,
+    parts: &[js_ast::Part<'a>],
+    renamer: rename::Renamer<'a, 'a, 'a>,
 ) -> PrintResult {
     if target.is_bun() {
         print_with_writer_and_platform::<W, true, GENERATE_SOURCE_MAPS>(
@@ -8264,12 +8264,12 @@ pub fn print_with_writer_and_platform<
 >(
     mut writer: W,
     bump: &'a bun_alloc::Arena,
-    ast: &Ast,
+    ast: &Ast<'a>,
     source: &bun_ast::Source,
     opts: Options<'a>,
     import_records: &'a [ImportRecord],
-    parts: &[js_ast::Part],
-    renamer: rename::Renamer<'a, 'a>,
+    parts: &[js_ast::Part<'a>],
+    renamer: rename::Renamer<'a, 'a, 'a>,
 ) -> PrintResult {
     let _restore =
         bun_crash_handler::scoped_action(bun_crash_handler::Action::Print(source.path.text));
@@ -8370,9 +8370,9 @@ pub fn print_common_js<
 >(
     _writer: W,
     bump: &'a bun_alloc::Arena,
-    tree: &'a Ast,
-    symbols: js_ast::symbol::Map,
-    source: &'a bun_ast::Source,
+    tree: &Ast<'a>,
+    symbols: js_ast::symbol::Map<'a>,
+    source: &bun_ast::Source,
     opts: Options<'a>,
 ) -> Result<usize, bun_core::Error> {
     let _restore =

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -16,17 +16,17 @@ use bun_collections::{HashMap, StringHashMap, VecExt};
 use bun_core::Output;
 use bun_core::{MutableString, immutable as strings};
 use bun_options_types::Format;
-use enum_map::EnumMap;
 
 /// Renamed-name strings are either borrowed from `Symbol.original_name` (AST
 /// arena) or duped into the renamer's `bumpalo::Bump` arena. `StoreStr` is the
-/// arena-backed lifetime-erased slice wrapper that centralises the raw deref
-/// (one `unsafe` in `StoreStr::slice`), so the renamer's name-table reads stay
-/// safe. Phase B may later thread `'bump` and rewrite to `&'bump [u8]`.
-type NameStr = bun_ast::StoreStr;
+/// arena-backed slice wrapper that centralises the raw deref (one `unsafe` in
+/// `StoreStr::slice`), so the renamer's name-table reads stay safe. The
+/// `'arena` lifetime is the AST arena; renamer-bump-allocated names are
+/// covariantly shortened to it (the bump outlives every read).
+type NameStr<'arena> = bun_ast::StoreStr<'arena>;
 
 #[inline]
-const fn name_str_empty() -> NameStr {
+const fn name_str_empty<'arena>() -> NameStr<'arena> {
     bun_ast::StoreStr::EMPTY
 }
 
@@ -39,7 +39,7 @@ const SLOT_NAMESPACES: [SlotNamespace; 4] = [
     SlotNamespace::MangledProp,
 ];
 
-pub struct NoOpRenamer<'a> {
+pub struct NoOpRenamer<'a, 'arena> {
     // PORT NOTE: Zig `Symbol.Map` is a non-owning `BabyList(BabyList(Symbol))`
     // slice header passed by value (renamer.zig:2,126,452 — no `deinit` ever
     // frees it). In the Rust port `symbol::Map` is `Vec<Vec<Symbol>>` (owning).
@@ -52,12 +52,12 @@ pub struct NoOpRenamer<'a> {
     // every transpile (require-cache.test.ts "files transpiled and loaded don't
     // leak the output source code" — `await import()` re-transpiles each
     // iteration, so the leak compounds to OOM).
-    pub symbols: symbol::Map,
+    pub symbols: symbol::Map<'arena>,
     pub source: &'a bun_ast::Source,
 }
 
-impl<'a> NoOpRenamer<'a> {
-    pub fn init(symbols: symbol::Map, source: &'a bun_ast::Source) -> NoOpRenamer<'a> {
+impl<'a, 'arena> NoOpRenamer<'a, 'arena> {
+    pub fn init(symbols: symbol::Map<'arena>, source: &'a bun_ast::Source) -> NoOpRenamer<'a, 'arena> {
         NoOpRenamer { symbols, source }
     }
 
@@ -84,23 +84,25 @@ impl<'a> NoOpRenamer<'a> {
         }
     }
 
-    pub fn to_renamer(&mut self) -> Renamer<'_, 'a> {
+    pub fn to_renamer(&self) -> Renamer<'_, 'a, 'arena> {
         Renamer::NoOpRenamer(self)
     }
 }
 
-// PORT NOTE: two lifetime params — `'r` is the borrow of the underlying renamer,
-// `'src` is `NoOpRenamer`'s borrow of the `Source`. The Zig `Renamer` was a
-// tag+ptr union that erased both; using `&'a mut NoOpRenamer<'a>` would make
-// `'a` invariant and lock the source borrow to the renamer borrow.
-pub enum Renamer<'r, 'src> {
-    NumberRenamer(&'r mut NumberRenamer),
-    NoOpRenamer(&'r mut NoOpRenamer<'src>),
-    MinifyRenamer(&'r mut MinifyRenamer),
+// PORT NOTE: three lifetime params — `'r` is the borrow of the underlying
+// renamer, `'src` is `NoOpRenamer`'s borrow of the `Source`, `'arena` is the
+// AST arena. The Zig `Renamer` was a tag+ptr union that erased all of them.
+// Variants hold `&'r` (not `&'r mut`) so the enum is **covariant** in
+// `'src`/`'arena` — the printer never mutates through the renamer (all three
+// `name_for_symbol` impls are read-only once the rename pass has finished).
+pub enum Renamer<'r, 'src, 'arena> {
+    NumberRenamer(&'r NumberRenamer<'arena>),
+    NoOpRenamer(&'r NoOpRenamer<'src, 'arena>),
+    MinifyRenamer(&'r MinifyRenamer<'arena>),
 }
 
-impl<'r, 'src> Renamer<'r, 'src> {
-    pub fn symbols(&self) -> &symbol::Map {
+impl<'r, 'src, 'arena> Renamer<'r, 'src, 'arena> {
+    pub fn symbols(&self) -> &symbol::Map<'arena> {
         match self {
             Renamer::NumberRenamer(r) => &r.symbols,
             Renamer::NoOpRenamer(r) => &r.symbols,
@@ -108,7 +110,7 @@ impl<'r, 'src> Renamer<'r, 'src> {
         }
     }
 
-    pub fn name_for_symbol(&mut self, ref_: Ref) -> &[u8] {
+    pub fn name_for_symbol(&self, ref_: Ref) -> &[u8] {
         match self {
             Renamer::NumberRenamer(r) => r.name_for_symbol(ref_),
             Renamer::NoOpRenamer(r) => r.name_for_symbol(ref_),
@@ -130,18 +132,18 @@ impl<'r, 'src> Renamer<'r, 'src> {
 // storage). No explicit deinit needed.
 
 #[derive(Clone, Copy)]
-pub struct SymbolSlot {
+pub struct SymbolSlot<'arena> {
     // Most minified names are under 15 bytes
     // Instead of allocating a string for every symbol slot
     // We can store the string inline!
     // But we have to be very careful of where it's used.
     // Or we WILL run into memory bugs.
-    pub name: TinyString,
+    pub name: TinyString<'arena>,
     pub count: u32,
     pub needs_capital_for_jsx: bool,
 }
 
-impl Default for SymbolSlot {
+impl<'arena> Default for SymbolSlot<'arena> {
     fn default() -> Self {
         SymbolSlot {
             name: TinyString::String(name_str_empty()),
@@ -151,7 +153,27 @@ impl Default for SymbolSlot {
     }
 }
 
-pub type SymbolSlotList = EnumMap<symbol::SlotNamespace, Vec<SymbolSlot>>;
+/// `EnumMap<SlotNamespace, Vec<SymbolSlot<'arena>>>` is invariant in `'arena`
+/// (associated-type projection through `EnumArray::Array`). A plain array
+/// keeps `MinifyRenamer<'arena>` covariant, which lets [`Renamer`] hand out
+/// shortened-lifetime views without a transmute.
+#[derive(Default)]
+pub struct SymbolSlotList<'arena>([Vec<SymbolSlot<'arena>>; <symbol::SlotNamespace as enum_map::Enum>::LENGTH]);
+
+impl<'arena> core::ops::Index<symbol::SlotNamespace> for SymbolSlotList<'arena> {
+    type Output = Vec<SymbolSlot<'arena>>;
+    #[inline]
+    fn index(&self, ns: symbol::SlotNamespace) -> &Self::Output {
+        &self.0[enum_map::Enum::into_usize(ns)]
+    }
+}
+
+impl<'arena> core::ops::IndexMut<symbol::SlotNamespace> for SymbolSlotList<'arena> {
+    #[inline]
+    fn index_mut(&mut self, ns: symbol::SlotNamespace) -> &mut Self::Output {
+        &mut self.0[enum_map::Enum::into_usize(ns)]
+    }
+}
 
 #[derive(Clone, Copy, Default)]
 pub struct InlineString {
@@ -172,23 +194,23 @@ impl InlineString {
         this
     }
 
-    // do not make this *const or you will run into memory bugs.
-    // we cannot let the compiler decide to copy this struct because
-    // that would cause this to become a pointer to stack memory.
-    pub fn slice(&mut self) -> &[u8] {
+    // PORT NOTE: Zig took `*self` (mutable single-item ptr) so the inline buffer
+    // wouldn't be copied to a temporary by Zig's pass-by-value. Rust `&self` is
+    // already a reference; no implicit copy.
+    pub fn slice(&self) -> &[u8] {
         &self.bytes[0..self.len as usize]
     }
 }
 
 #[derive(Clone, Copy)]
-pub enum TinyString {
+pub enum TinyString<'arena> {
     InlineString(InlineString),
     // Arena-owned slice when len > 15 (allocated from `MinifyRenamer.arena`).
-    String(NameStr),
+    String(NameStr<'arena>),
 }
 
-impl TinyString {
-    pub fn init(input: &[u8], arena: &Bump) -> Result<TinyString, bun_alloc::AllocError> {
+impl<'arena> TinyString<'arena> {
+    pub fn init(input: &[u8], arena: &Bump) -> Result<TinyString<'arena>, bun_alloc::AllocError> {
         if input.len() <= 15 {
             Ok(TinyString::InlineString(InlineString::init(input)))
         } else {
@@ -198,10 +220,9 @@ impl TinyString {
         }
     }
 
-    // do not make this *const or you will run into memory bugs.
-    // we cannot let the compiler decide to copy this struct because
-    // that would cause this to become a pointer to stack memory.
-    pub fn slice(&mut self) -> &[u8] {
+    // PORT NOTE: Zig took `*self` so the inline buffer wouldn't be copied to a
+    // temporary by Zig's pass-by-value. Rust `&self` is already a reference.
+    pub fn slice(&self) -> &[u8] {
         match self {
             TinyString::InlineString(s) => s.slice(),
             // `StoreStr::slice` centralises the arena-backed deref; the payload
@@ -211,13 +232,13 @@ impl TinyString {
     }
 }
 
-pub struct MinifyRenamer {
+pub struct MinifyRenamer<'arena> {
     pub reserved_names: StringHashMap<u32>,
-    pub slots: SymbolSlotList,
+    pub slots: SymbolSlotList<'arena>,
     pub top_level_symbol_to_slot: TopLevelSymbolSlotMap,
     // PORT NOTE: see `NoOpRenamer.symbols` — non-owning view; Zig
     // `MinifyRenamer.deinit` (renamer.zig:156) never frees `symbols`.
-    pub symbols: ManuallyDrop<symbol::Map>,
+    pub symbols: ManuallyDrop<symbol::Map<'arena>>,
     /// Backs `TinyString::String` slot-name allocations (Zig: `this.allocator`).
     pub arena: Bump,
 }
@@ -226,12 +247,12 @@ pub struct MinifyRenamer {
 // bun_collections::HashMap should be parameterized with RefCtx hasher.
 pub type TopLevelSymbolSlotMap = HashMap<Ref, usize>;
 
-impl MinifyRenamer {
+impl<'arena> MinifyRenamer<'arena> {
     pub fn init(
-        symbols: symbol::Map,
+        symbols: symbol::Map<'arena>,
         first_top_level_slots: js_ast::SlotCounts,
         reserved_names: StringHashMap<u32>,
-    ) -> Result<Box<MinifyRenamer>, bun_alloc::AllocError> {
+    ) -> Result<Box<MinifyRenamer<'arena>>, bun_alloc::AllocError> {
         let mut slots = SymbolSlotList::default();
 
         for (ns, &count) in first_top_level_slots.slots.iter() {
@@ -250,13 +271,13 @@ impl MinifyRenamer {
         }))
     }
 
-    pub fn to_renamer(&mut self) -> Renamer<'_, 'static> {
+    pub fn to_renamer(&self) -> Renamer<'_, 'static, 'arena> {
         Renamer::MinifyRenamer(self)
     }
 
-    pub fn name_for_symbol(&mut self, ref_: Ref) -> &[u8] {
+    pub fn name_for_symbol(&self, ref_: Ref) -> &[u8] {
         let ref_ = self.symbols.follow(ref_);
-        let symbol: &Symbol = self.symbols.get_const(ref_).unwrap();
+        let symbol: &Symbol<'arena> = self.symbols.get_const(ref_).unwrap();
 
         let ns = symbol.slot_namespace();
         if ns == SlotNamespace::MustNotBeRenamed {
@@ -308,7 +329,7 @@ impl MinifyRenamer {
         stable_source_indices: &[u32],
     ) -> Result<(), bun_alloc::AllocError> {
         let mut ref_ = self.symbols.follow(ref_);
-        let mut symbol: &Symbol = self.symbols.get_const(ref_).unwrap();
+        let mut symbol: &Symbol<'arena> = self.symbols.get_const(ref_).unwrap();
 
         while let Some(alias) = &symbol.namespace_alias {
             let new_ref = self.symbols.follow(alias.namespace_ref);
@@ -346,7 +367,7 @@ impl MinifyRenamer {
         top_level_symbols: &[StableSymbolCount],
     ) -> Result<(), bun_alloc::AllocError> {
         for stable in top_level_symbols {
-            let symbol: &Symbol = self.symbols.get_const(stable.ref_).unwrap();
+            let symbol: &Symbol<'arena> = self.symbols.get_const(stable.ref_).unwrap();
             // PORT NOTE: reshaped for borrowck — capture symbol fields before mut-borrowing slots
             let ns = symbol.slot_namespace();
             let must_start_with_capital = symbol.must_start_with_capital_letter_for_jsx;
@@ -435,8 +456,8 @@ impl MinifyRenamer {
 }
 
 pub fn assign_nested_scope_slots(
-    module_scope: &js_ast::Scope,
-    symbols: &mut [Symbol],
+    module_scope: &js_ast::Scope<'_>,
+    symbols: &mut [Symbol<'_>],
 ) -> js_ast::SlotCounts {
     let mut slot_counts = js_ast::SlotCounts::default();
     let mut sorted_members: Vec<u32> = Vec::new();
@@ -478,8 +499,8 @@ pub fn assign_nested_scope_slots(
 
 pub fn assign_nested_scope_slots_helper(
     sorted_members: &mut Vec<u32>,
-    scope: &js_ast::Scope,
-    symbols: &mut [Symbol],
+    scope: &js_ast::Scope<'_>,
+    symbols: &mut [Symbol<'_>],
     slot_to_copy: js_ast::SlotCounts,
 ) -> js_ast::SlotCounts {
     let mut slot = slot_to_copy;
@@ -587,11 +608,11 @@ impl SlotAndCount {
     }
 }
 
-pub struct NumberRenamer {
+pub struct NumberRenamer<'arena> {
     // PORT NOTE: see `NoOpRenamer.symbols` — non-owning view; Zig
     // `NumberRenamer.deinit` (renamer.zig:462) never frees `symbols`.
-    pub symbols: ManuallyDrop<symbol::Map>,
-    pub names: Box<[Vec<NameStr>]>,
+    pub symbols: ManuallyDrop<symbol::Map<'arena>>,
+    pub names: Box<[Vec<NameStr<'arena>>]>,
     // PERF(port): Zig had separate allocator/temp_allocator; global mimalloc now
     pub number_scope_pool: HiveArrayFallback<NumberScope, 128>,
     // PERF(port): was arena bulk-free for NumberScope pool + name temp buffers
@@ -601,8 +622,8 @@ pub struct NumberRenamer {
     // PERF(port): was StackFallbackAllocator(512) — profile
 }
 
-impl NumberRenamer {
-    pub fn to_renamer(&mut self) -> Renamer<'_, 'static> {
+impl<'arena> NumberRenamer<'arena> {
+    pub fn to_renamer(&self) -> Renamer<'_, 'static, 'arena> {
         Renamer::NumberRenamer(self)
     }
 
@@ -624,14 +645,14 @@ impl NumberRenamer {
         let ref_ = self.symbols.follow(input_ref);
 
         // Don't rename the same symbol more than once
-        let inner: &mut Vec<NameStr> = &mut self.names[ref_.source_index() as usize];
+        let inner: &mut Vec<NameStr<'arena>> = &mut self.names[ref_.source_index() as usize];
         if inner.len() > ref_.inner_index() as usize && inner[ref_.inner_index() as usize].len() > 0
         {
             return;
         }
 
         // Don't rename unbound symbols, symbols marked as reserved names, labels, or private names
-        let symbol: &Symbol = self.symbols.get_const(ref_).unwrap();
+        let symbol: &Symbol<'arena> = self.symbols.get_const(ref_).unwrap();
         if symbol.slot_namespace() != SlotNamespace::Default {
             return;
         }
@@ -639,7 +660,7 @@ impl NumberRenamer {
         // SAFETY: `original_name` is an AST-arena slice that outlives the renamer.
         let original_name: &[u8] = symbol.original_name.slice();
         // PERF(port): Zig reset stack-fallback FBA here; arena reset semantics differ
-        let name: NameStr = match scope.find_unused_name(&self.arena, original_name) {
+        let name: NameStr<'arena> = match scope.find_unused_name(&self.arena, original_name) {
             UnusedName::Renamed(name) => name,
             UnusedName::NoCollision => symbol.original_name,
         };
@@ -651,11 +672,11 @@ impl NumberRenamer {
     }
 
     pub fn init(
-        symbols: symbol::Map,
+        symbols: symbol::Map<'arena>,
         root_names: StringHashMap<u32>,
-    ) -> Result<Box<NumberRenamer>, bun_alloc::AllocError> {
+    ) -> Result<Box<NumberRenamer<'arena>>, bun_alloc::AllocError> {
         let len = symbols.symbols_for_source.len();
-        let names: Box<[Vec<NameStr>]> = core::iter::repeat_with(Vec::<NameStr>::default)
+        let names: Box<[Vec<NameStr<'arena>>]> = core::iter::repeat_with(Vec::<NameStr<'arena>>::default)
             .take(len)
             .collect();
 
@@ -681,7 +702,7 @@ impl NumberRenamer {
 
     pub fn assign_names_recursive(
         &mut self,
-        scope: &js_ast::Scope,
+        scope: &js_ast::Scope<'_>,
         source_index: u32,
         parent: Option<bun_ptr::ParentRef<NumberScope>>,
         sorted: &mut Vec<u32>,
@@ -707,7 +728,7 @@ impl NumberRenamer {
     fn assign_names_in_scope(
         &mut self,
         s: &mut NumberScope,
-        scope: &js_ast::Scope,
+        scope: &js_ast::Scope<'_>,
         source_index: u32,
         sorted: &mut Vec<u32>,
     ) {
@@ -740,7 +761,7 @@ impl NumberRenamer {
     pub fn assign_names_recursive_with_number_scope(
         &mut self,
         initial_scope: *mut NumberScope,
-        scope_: &js_ast::Scope,
+        scope_: &js_ast::Scope<'_>,
         source_index: u32,
         sorted: &mut Vec<u32>,
     ) {
@@ -835,7 +856,7 @@ impl NumberRenamer {
         let renamed_list = &self.names[source_index as usize];
 
         if renamed_list.len() > inner_index as usize {
-            let renamed: NameStr = renamed_list[inner_index as usize];
+            let renamed: NameStr<'arena> = renamed_list[inner_index as usize];
             if renamed.raw_len() > 0 {
                 // `StoreStr::slice` centralises the deref; allocated from
                 // `self.arena` or borrows an AST-arena `original_name`, both
@@ -896,9 +917,9 @@ impl NameUse {
     }
 }
 
-pub enum UnusedName {
+pub enum UnusedName<'arena> {
     NoCollision,
-    Renamed(NameStr),
+    Renamed(NameStr<'arena>),
 }
 
 /// Fast-path for `MutableString::ensure_valid_identifier`: returns `true` iff
@@ -928,7 +949,7 @@ fn is_simple_ascii_identifier(s: &[u8]) -> bool {
 
 impl NumberScope {
     /// Caller must use an arena allocator
-    pub fn find_unused_name(&mut self, arena: &Bump, input_name: &[u8]) -> UnusedName {
+    pub fn find_unused_name<'arena>(&mut self, arena: &Bump, input_name: &[u8]) -> UnusedName<'arena> {
         // PORT NOTE: Zig's `MutableString.ensureValidIdentifier` borrows the
         // input when it is already a valid ASCII identifier; the Rust port
         // always heap-allocates (Box<[u8]>). Skip the call entirely for the
@@ -1027,7 +1048,7 @@ impl NumberScope {
 
         // Zig: `allocator.dupe(u8, name)` — allocate into the renamer arena.
         let duped: &[u8] = arena.alloc_slice_copy(name);
-        let name: NameStr = bun_ast::StoreStr::new(duped);
+        let name: NameStr<'arena> = bun_ast::StoreStr::new(duped);
 
         self.name_counts
             .put_no_clobber(duped, 1)
@@ -1169,15 +1190,15 @@ pub fn compute_initial_reserved_names(
 }
 
 pub fn compute_reserved_names_for_scope(
-    scope: &js_ast::Scope,
-    symbols: &symbol::Map,
+    scope: &js_ast::Scope<'_>,
+    symbols: &symbol::Map<'_>,
     names: &mut StringHashMap<u32>,
 ) {
     // PORT NOTE: Zig copied `names_.*` to a local and wrote back via defer.
     // In Rust we mutate through &mut directly.
 
     for member in scope.members.values() {
-        let symbol: &Symbol = symbols.get_const(member.ref_).unwrap();
+        let symbol: &Symbol<'_> = symbols.get_const(member.ref_).unwrap();
         if symbol.kind == symbol::Kind::Unbound || symbol.must_not_be_renamed {
             // SAFETY: `original_name` is an AST-arena slice.
             names
@@ -1187,7 +1208,7 @@ pub fn compute_reserved_names_for_scope(
     }
 
     for ref_ in scope.generated.slice() {
-        let symbol: &Symbol = symbols.get_const(*ref_).unwrap();
+        let symbol: &Symbol<'_> = symbols.get_const(*ref_).unwrap();
         if symbol.kind == symbol::Kind::Unbound || symbol.must_not_be_renamed {
             // SAFETY: `original_name` is an AST-arena slice.
             names

--- a/src/parsers/json.rs
+++ b/src/parsers/json.rs
@@ -53,9 +53,9 @@ mod hash_map_pool {
 
 // ──────────────────────────────────────────────────────────────────────────
 
-fn new_expr<Ty>(t: Ty, loc: bun_ast::Loc) -> Expr
+fn new_expr<'arena, Ty>(t: Ty, loc: bun_ast::Loc) -> Expr<'arena>
 where
-    Ty: js_ast::ExprInit, // TODO(port): bound to whatever trait Expr::init accepts
+    Ty: js_ast::ExprInit<'arena>, // TODO(port): bound to whatever trait Expr::init accepts
 {
     // Zig had: if @typeInfo(Type) == .pointer => @compileError — Rust's type system
     // already prevents passing a reference where a value is expected; no runtime check needed.
@@ -117,7 +117,7 @@ where
         opts: js_lexer::JSONOptions,
         bump: &'bump Bump,
         source_: &'a bun_ast::Source,
-        log: &'a mut bun_ast::Log,
+        log: &mut bun_ast::Log,
     ) -> Result<Self, bun_core::Error> {
         // TODO(port): narrow error set
         Self::init_with_list_allocator(opts, bump, bump, source_, log)
@@ -128,7 +128,7 @@ where
         bump: &'bump Bump,
         list_bump: &'bump Bump,
         source_: &'a bun_ast::Source,
-        log: &'a mut bun_ast::Log,
+        log: &mut bun_ast::Log,
     ) -> Result<Self, bun_core::Error> {
         // TODO(port): narrow error set
         Expr::data_store_assert();
@@ -163,7 +163,7 @@ where
         &mut self,
         maybe_auto_quote: bool,
         force_utf8: bool,
-    ) -> Result<Expr, bun_core::Error> {
+    ) -> Result<Expr<'a>, bun_core::Error> {
         if !self.stack_check.is_safe_to_recurse() {
             // Zig: `bun.throwStackOverflow()`.
             return Err(bun_core::err!("StackOverflow"));
@@ -185,7 +185,7 @@ where
                 Ok(new_expr(E::Null {}, loc))
             }
             T::TStringLiteral => {
-                let mut str: E::String = self.lexer.to_e_string()?;
+                let mut str: E::String<'a> = self.lexer.to_e_string()?;
                 if force_utf8 {
                     str.to_utf8(self.bump).expect("unreachable");
                 }
@@ -210,7 +210,7 @@ where
                 // PORT NOTE: Zig grew an `ArrayList(Expr)` in `list_allocator` and
                 // `moveFromList`-ed it. The Rust `Vec` is `Vec`-backed (global
                 // allocator), so build a `Vec<Expr>` directly and hand it off.
-                let mut exprs: Vec<Expr> = Vec::new();
+                let mut exprs: Vec<Expr<'a>> = Vec::new();
                 // errdefer exprs.deinit() — dropped automatically on `?`.
 
                 while self.lexer.token != T::TCloseBracket {
@@ -250,7 +250,7 @@ where
                 self.lexer.next()?;
                 let mut is_single_line = !self.lexer.has_newline_before;
                 // PORT NOTE: see TOpenBracket note — `Vec` is `Vec`-backed.
-                let mut properties: Vec<G::Property> = Vec::new();
+                let mut properties: Vec<G::Property<'a>> = Vec::new();
                 // errdefer properties.deinit() — dropped automatically on `?`.
 
                 // PORT NOTE: reshaped for borrowck — Zig used `void`/`*Node` when
@@ -448,7 +448,7 @@ where
     pub fn init(
         bump: &'bump Bump,
         source: &'a bun_ast::Source,
-        log: &'a mut bun_ast::Log,
+        log: &mut bun_ast::Log,
     ) -> Result<Self, bun_core::Error> {
         // TODO(port): narrow error set
         Ok(Self {
@@ -477,7 +477,7 @@ where
         &self.found_version_buf[..self.found_version_len]
     }
 
-    pub fn parse_expr(&mut self) -> Result<Expr, bun_core::Error> {
+    pub fn parse_expr(&mut self) -> Result<Expr<'a>, bun_core::Error> {
         if !self.stack_check.is_safe_to_recurse() {
             // Zig: `bun.throwStackOverflow()`.
             return Err(bun_core::err!("StackOverflow"));
@@ -503,7 +503,7 @@ where
                 Ok(new_expr(E::Null {}, loc))
             }
             T::TStringLiteral => {
-                let str: E::String = self.lexer.to_e_string()?;
+                let str: E::String<'a> = self.lexer.to_e_string()?;
 
                 self.lexer.next()?;
                 Ok(new_expr(str, loc))
@@ -544,7 +544,7 @@ where
                 // returns here and depth is decremented exactly once on every exit path
                 // (Ok, Err, early break). scopeguard cannot hold `&mut self.depth` while
                 // the body re-borrows `&mut self`.
-                let result = (|| -> Result<Expr, bun_core::Error> {
+                let result = (|| -> Result<Expr<'a>, bun_core::Error> {
                     let mut has_properties = false;
                     while self.lexer.token != T::TCloseBrace {
                         if has_properties {
@@ -640,11 +640,11 @@ where
 // per-type impls. Struct/enum/union arms require a derive macro.
 
 pub trait ToAst {
-    fn to_ast(&self, bump: &Bump) -> Result<Expr, bun_core::Error>;
+    fn to_ast<'arena>(&self, bump: &'arena Bump) -> Result<Expr<'arena>, bun_core::Error>;
 }
 
 impl ToAst for bool {
-    fn to_ast(&self, _bump: &Bump) -> Result<Expr, bun_core::Error> {
+    fn to_ast<'arena>(&self, _bump: &'arena Bump) -> Result<Expr<'arena>, bun_core::Error> {
         Ok(Expr {
             data: js_ast::expr::Data::EBoolean(E::Boolean { value: *self }),
             loc: bun_ast::Loc::default(),
@@ -655,7 +655,7 @@ impl ToAst for bool {
 macro_rules! impl_to_ast_int {
     ($($t:ty),*) => {$(
         impl ToAst for $t {
-            fn to_ast(&self, _bump: &Bump) -> Result<Expr, bun_core::Error> {
+            fn to_ast<'arena>(&self, _bump: &'arena Bump) -> Result<Expr<'arena>, bun_core::Error> {
                 Ok(Expr {
                     data: js_ast::expr::Data::ENumber(E::Number { value: *self as f64 }),
                     loc: bun_ast::Loc::default(),
@@ -673,7 +673,7 @@ impl_to_ast_int!(i8, i16, i32, i64, isize, u16, u32, u64, usize);
 macro_rules! impl_to_ast_float {
     ($($t:ty),*) => {$(
         impl ToAst for $t {
-            fn to_ast(&self, _bump: &Bump) -> Result<Expr, bun_core::Error> {
+            fn to_ast<'arena>(&self, _bump: &'arena Bump) -> Result<Expr<'arena>, bun_core::Error> {
                 Ok(Expr {
                     data: js_ast::expr::Data::ENumber(E::Number { value: *self as f64 }),
                     loc: bun_ast::Loc::default(),
@@ -685,19 +685,19 @@ macro_rules! impl_to_ast_float {
 impl_to_ast_float!(f32, f64);
 
 impl ToAst for [u8] {
-    fn to_ast(&self, _bump: &Bump) -> Result<Expr, bun_core::Error> {
+    fn to_ast<'arena>(&self, _bump: &'arena Bump) -> Result<Expr<'arena>, bun_core::Error> {
         Ok(Expr::init(E::String::init(self), bun_ast::Loc::EMPTY))
     }
 }
 
 impl<T: ToAst> ToAst for &T {
-    fn to_ast(&self, bump: &Bump) -> Result<Expr, bun_core::Error> {
+    fn to_ast<'arena>(&self, bump: &'arena Bump) -> Result<Expr<'arena>, bun_core::Error> {
         (**self).to_ast(bump)
     }
 }
 
 impl<T: ToAst> ToAst for [T] {
-    fn to_ast(&self, bump: &Bump) -> Result<Expr, bun_core::Error> {
+    fn to_ast<'arena>(&self, bump: &'arena Bump) -> Result<Expr<'arena>, bun_core::Error> {
         let mut exprs = BumpVec::with_capacity_in(self.len(), bump);
         for (_i, ex) in self.iter().enumerate() {
             exprs.push(ex.to_ast(bump)?);
@@ -713,14 +713,14 @@ impl<T: ToAst> ToAst for [T] {
 }
 
 impl<T: ToAst, const N: usize> ToAst for [T; N] {
-    fn to_ast(&self, bump: &Bump) -> Result<Expr, bun_core::Error> {
+    fn to_ast<'arena>(&self, bump: &'arena Bump) -> Result<Expr<'arena>, bun_core::Error> {
         self.as_slice().to_ast(bump)
     }
 }
 
 // Spec json.zig:557-565 — `Array.child == u8` → `E::String` (not `E::Array`).
 impl<const N: usize> ToAst for [u8; N] {
-    fn to_ast(&self, _bump: &Bump) -> Result<Expr, bun_core::Error> {
+    fn to_ast<'arena>(&self, _bump: &'arena Bump) -> Result<Expr<'arena>, bun_core::Error> {
         Ok(Expr::init(
             E::String::init(self.as_slice()),
             bun_ast::Loc::EMPTY,
@@ -729,7 +729,7 @@ impl<const N: usize> ToAst for [u8; N] {
 }
 
 impl<T: ToAst> ToAst for Option<T> {
-    fn to_ast(&self, bump: &Bump) -> Result<Expr, bun_core::Error> {
+    fn to_ast<'arena>(&self, bump: &'arena Bump) -> Result<Expr<'arena>, bun_core::Error> {
         match self {
             Some(v) => v.to_ast(bump),
             None => Ok(Expr {
@@ -741,7 +741,7 @@ impl<T: ToAst> ToAst for Option<T> {
 }
 
 impl ToAst for () {
-    fn to_ast(&self, _bump: &Bump) -> Result<Expr, bun_core::Error> {
+    fn to_ast<'arena>(&self, _bump: &'arena Bump) -> Result<Expr<'arena>, bun_core::Error> {
         Ok(Expr {
             data: js_ast::expr::Data::ENull(E::Null {}),
             loc: bun_ast::Loc::default(),
@@ -750,7 +750,7 @@ impl ToAst for () {
 }
 
 impl ToAst for bun_core::Error {
-    fn to_ast(&self, bump: &Bump) -> Result<Expr, bun_core::Error> {
+    fn to_ast<'arena>(&self, bump: &'arena Bump) -> Result<Expr<'arena>, bun_core::Error> {
         self.name().as_bytes().to_ast(bump)
     }
 }
@@ -780,7 +780,10 @@ impl ToAst for bun_core::Error {
 // In Rust this is the natural shape of `enum` payloads; the derive should emit
 // `match self { Variant(v) => /* { "Variant": v } */ }`.
 
-pub fn to_ast<Ty: ToAst + ?Sized>(bump: &Bump, value: &Ty) -> Result<Expr, bun_core::Error> {
+pub fn to_ast<'arena, Ty: ToAst + ?Sized>(
+    bump: &'arena Bump,
+    value: &Ty,
+) -> Result<Expr<'arena>, bun_core::Error> {
     value.to_ast(bump)
 }
 
@@ -838,22 +841,24 @@ const PACKAGE_JSON_OPTS: js_lexer::JSONOptions = js_lexer::JSONOptions {
 // `StoreRef::from_raw` wants a `*mut T` and the payload types are `!Sync`.
 // Phase B: prefer `Expr::Data` constructors that don't need a backing static
 // (e.g. inline empty-object sentinel).
-static EMPTY_OBJECT: bun_core::RacyCell<E::Object> = bun_core::RacyCell::new(E::Object::EMPTY);
-static EMPTY_ARRAY: bun_core::RacyCell<E::Array> = bun_core::RacyCell::new(E::Array::EMPTY);
-static EMPTY_STRING: bun_core::RacyCell<E::String> = bun_core::RacyCell::new(E::String::EMPTY);
+static EMPTY_OBJECT: bun_core::RacyCell<E::Object<'static>> =
+    bun_core::RacyCell::new(E::Object::EMPTY);
+static EMPTY_ARRAY: bun_core::RacyCell<E::Array<'static>> = bun_core::RacyCell::new(E::Array::EMPTY);
+static EMPTY_STRING: bun_core::RacyCell<E::String<'static>> =
+    bun_core::RacyCell::new(E::String::EMPTY);
 
 #[inline]
-fn empty_string_data() -> js_ast::expr::Data {
+fn empty_string_data<'arena>() -> js_ast::expr::Data<'arena> {
     // EMPTY_STRING is a never-mutated static; `StoreRef::from_raw` checks
     // non-null and the static trivially outlives any Store reset.
     js_ast::expr::Data::EString(js_ast::StoreRef::from_raw(EMPTY_STRING.get()))
 }
 #[inline]
-fn empty_object_data() -> js_ast::expr::Data {
+fn empty_object_data<'arena>() -> js_ast::expr::Data<'arena> {
     js_ast::expr::Data::EObject(js_ast::StoreRef::from_raw(EMPTY_OBJECT.get()))
 }
 #[inline]
-fn empty_array_data() -> js_ast::expr::Data {
+fn empty_array_data<'arena>() -> js_ast::expr::Data<'arena> {
     js_ast::expr::Data::EArray(js_ast::StoreRef::from_raw(EMPTY_ARRAY.get()))
 }
 
@@ -868,11 +873,11 @@ fn empty_array_data() -> js_ast::expr::Data {
 // trivial forward into the single non-generic `parse_expr`. The wrapper
 // monomorphizes to a few instructions; no large body is duplicated.
 #[inline]
-pub fn parse<const FORCE_UTF8: bool>(
-    source: &bun_ast::Source,
+pub fn parse<'arena, const FORCE_UTF8: bool>(
+    source: &'arena bun_ast::Source,
     log: &mut bun_ast::Log,
-    bump: &Bump,
-) -> Result<Expr, bun_core::Error> {
+    bump: &'arena Bump,
+) -> Result<Expr<'arena>, bun_core::Error> {
     // TODO(port): narrow error set
     let mut parser = JSONLikeParser::init(JSON_OPTS, bump, source, log)?;
     match source.contents.len() {
@@ -913,11 +918,11 @@ pub fn parse<const FORCE_UTF8: bool>(
 /// This eagerly transcodes UTF-16 strings into UTF-8 strings
 /// Use this when the text may need to be reprinted to disk as JSON (and not as JavaScript)
 /// Eagerly converting UTF-8 to UTF-16 can cause a performance issue
-pub fn parse_package_json_utf8(
-    source: &bun_ast::Source,
+pub fn parse_package_json_utf8<'arena>(
+    source: &'arena bun_ast::Source,
     log: &mut bun_ast::Log,
-    bump: &Bump,
-) -> Result<Expr, bun_core::Error> {
+    bump: &'arena Bump,
+) -> Result<Expr<'arena>, bun_core::Error> {
     // TODO(port): narrow error set
     let len = source.contents.len();
 
@@ -957,12 +962,12 @@ pub fn parse_package_json_utf8(
     parser.parse_expr(false, true)
 }
 
-pub struct JsonResult {
-    pub root: Expr,
+pub struct JsonResult<'arena> {
+    pub root: Expr<'arena>,
     pub indentation: Indentation,
 }
 
-impl Default for JsonResult {
+impl<'arena> Default for JsonResult<'arena> {
     fn default() -> Self {
         Self {
             root: Expr::default(),
@@ -979,6 +984,7 @@ impl Default for JsonResult {
 // `parse_expr` body is shared.
 #[inline]
 pub fn parse_package_json_utf8_with_opts<
+    'arena,
     const IS_JSON: bool,
     const ALLOW_COMMENTS: bool,
     const ALLOW_TRAILING_COMMAS: bool,
@@ -988,10 +994,10 @@ pub fn parse_package_json_utf8_with_opts<
     const WAS_ORIGINALLY_MACRO: bool,
     const GUESS_INDENTATION: bool,
 >(
-    source: &bun_ast::Source,
+    source: &'arena bun_ast::Source,
     log: &mut bun_ast::Log,
-    bump: &Bump,
-) -> Result<JsonResult, bun_core::Error> {
+    bump: &'arena Bump,
+) -> Result<JsonResult<'arena>, bun_core::Error> {
     parse_package_json_utf8_with_opts_rt(
         js_lexer::JSONOptions {
             is_json: IS_JSON,
@@ -1011,12 +1017,12 @@ pub fn parse_package_json_utf8_with_opts<
 
 /// Runtime-options entry point. Prefer this over the const-generic shim above
 /// for new code.
-pub fn parse_package_json_utf8_with_opts_rt(
+pub fn parse_package_json_utf8_with_opts_rt<'arena>(
     opts: js_lexer::JSONOptions,
-    source: &bun_ast::Source,
+    source: &'arena bun_ast::Source,
     log: &mut bun_ast::Log,
-    bump: &Bump,
-) -> Result<JsonResult, bun_core::Error> {
+    bump: &'arena Bump,
+) -> Result<JsonResult<'arena>, bun_core::Error> {
     // TODO(port): narrow error set
     let len = source.contents.len();
 
@@ -1082,21 +1088,21 @@ pub fn parse_package_json_utf8_with_opts_rt(
 /// This eagerly transcodes UTF-16 strings into UTF-8 strings
 /// Use this when the text may need to be reprinted to disk as JSON (and not as JavaScript)
 /// Eagerly converting UTF-8 to UTF-16 can cause a performance issue
-pub fn parse_utf8(
-    source: &bun_ast::Source,
+pub fn parse_utf8<'arena>(
+    source: &'arena bun_ast::Source,
     log: &mut bun_ast::Log,
-    bump: &Bump,
-) -> Result<Expr, bun_core::Error> {
+    bump: &'arena Bump,
+) -> Result<Expr<'arena>, bun_core::Error> {
     // TODO(port): narrow error set
     parse_utf8_impl::<false>(source, log, bump)
 }
 
 #[inline]
-pub fn parse_utf8_impl<const CHECK_LEN: bool>(
-    source: &bun_ast::Source,
+pub fn parse_utf8_impl<'arena, const CHECK_LEN: bool>(
+    source: &'arena bun_ast::Source,
     log: &mut bun_ast::Log,
-    bump: &Bump,
-) -> Result<Expr, bun_core::Error> {
+    bump: &'arena Bump,
+) -> Result<Expr<'arena>, bun_core::Error> {
     // TODO(port): narrow error set
     let len = source.contents.len();
 
@@ -1144,11 +1150,11 @@ pub fn parse_utf8_impl<const CHECK_LEN: bool>(
     Ok(result)
 }
 
-pub fn parse_for_macro(
-    source: &bun_ast::Source,
+pub fn parse_for_macro<'arena>(
+    source: &'arena bun_ast::Source,
     log: &mut bun_ast::Log,
-    bump: &Bump,
-) -> Result<Expr, bun_core::Error> {
+    bump: &'arena Bump,
+) -> Result<Expr<'arena>, bun_core::Error> {
     // TODO(port): narrow error set
     match source.contents.len() {
         // This is to be consisntent with how disabled JS files are handled
@@ -1185,8 +1191,8 @@ pub fn parse_for_macro(
     parser.parse_expr(false, false)
 }
 
-pub struct JSONParseResult {
-    pub expr: Expr,
+pub struct JSONParseResult<'arena> {
+    pub expr: Expr<'arena>,
     pub tag: JSONParseResultTag,
 }
 
@@ -1198,11 +1204,11 @@ pub enum JSONParseResultTag {
     Empty,
 }
 
-pub fn parse_for_bundling(
-    source: &bun_ast::Source,
+pub fn parse_for_bundling<'arena>(
+    source: &'arena bun_ast::Source,
     log: &mut bun_ast::Log,
-    bump: &Bump,
-) -> Result<JSONParseResult, bun_core::Error> {
+    bump: &'arena Bump,
+) -> Result<JSONParseResult<'arena>, bun_core::Error> {
     // TODO(port): narrow error set
     match source.contents.len() {
         // This is to be consisntent with how disabled JS files are handled
@@ -1262,11 +1268,11 @@ pub fn parse_for_bundling(
 
 // threadlocal var env_json_auto_quote_buffer: MutableString = undefined;
 // threadlocal var env_json_auto_quote_buffer_loaded: bool = false;
-pub fn parse_env_json(
-    source: &bun_ast::Source,
+pub fn parse_env_json<'arena>(
+    source: &'arena bun_ast::Source,
     log: &mut bun_ast::Log,
-    bump: &Bump,
-) -> Result<Expr, bun_core::Error> {
+    bump: &'arena Bump,
+) -> Result<Expr<'arena>, bun_core::Error> {
     // TODO(port): narrow error set
     match source.contents.len() {
         // This is to be consisntent with how disabled JS files are handled
@@ -1331,11 +1337,11 @@ pub fn parse_env_json(
 }
 
 #[inline]
-pub fn parse_ts_config<const FORCE_UTF8: bool>(
-    source: &bun_ast::Source,
+pub fn parse_ts_config<'arena, const FORCE_UTF8: bool>(
+    source: &'arena bun_ast::Source,
     log: &mut bun_ast::Log,
-    bump: &Bump,
-) -> Result<Expr, bun_core::Error> {
+    bump: &'arena Bump,
+) -> Result<Expr<'arena>, bun_core::Error> {
     // TODO(port): narrow error set
     match source.contents.len() {
         // This is to be consisntent with how disabled JS files are handled

--- a/src/parsers/json5.rs
+++ b/src/parsers/json5.rs
@@ -255,7 +255,7 @@ impl<'a> JSON5Parser<'a> {
         }
     }
 
-    pub fn parse(source: &'a Source, log: &mut Log, bump: &'a Bump) -> Result<Expr, ExternalError> {
+    pub fn parse(source: &'a Source, log: &mut Log, bump: &'a Bump) -> Result<Expr<'a>, ExternalError> {
         let mut parser = JSON5Parser {
             source: source.contents.as_ref(),
             pos: 0,
@@ -506,7 +506,7 @@ impl<'a> JSON5Parser<'a> {
 
     // ── Parser ──
 
-    fn parse_root(&mut self) -> Result<Expr, ParseError> {
+    fn parse_root(&mut self) -> Result<Expr<'a>, ParseError> {
         self.scan()?;
         let result = self.parse_value()?;
         if !matches!(self.token.data, TokenData::Eof) {
@@ -515,7 +515,7 @@ impl<'a> JSON5Parser<'a> {
         Ok(result)
     }
 
-    fn parse_value(&mut self) -> Result<Expr, ParseError> {
+    fn parse_value(&mut self) -> Result<Expr<'a>, ParseError> {
         if !self.stack_check.is_safe_to_recurse() {
             return Err(ParseError::StackOverflow);
         }
@@ -561,11 +561,11 @@ impl<'a> JSON5Parser<'a> {
         }
     }
 
-    fn parse_object(&mut self) -> Result<Expr, ParseError> {
+    fn parse_object(&mut self) -> Result<Expr<'a>, ParseError> {
         let loc = self.token.loc;
         self.scan()?; // advance past '{'
 
-        let mut properties: Vec<G::Property> = Vec::new();
+        let mut properties: Vec<G::Property<'a>> = Vec::new();
 
         while !matches!(self.token.data, TokenData::RightBrace) {
             let key = self.parse_object_key()?;
@@ -607,7 +607,7 @@ impl<'a> JSON5Parser<'a> {
         ))
     }
 
-    fn parse_object_key(&mut self) -> Result<Expr, ParseError> {
+    fn parse_object_key(&mut self) -> Result<Expr<'a>, ParseError> {
         let loc = self.token.loc;
         match self.token.data {
             TokenData::String(s) => {
@@ -632,11 +632,11 @@ impl<'a> JSON5Parser<'a> {
         }
     }
 
-    fn parse_array(&mut self) -> Result<Expr, ParseError> {
+    fn parse_array(&mut self) -> Result<Expr<'a>, ParseError> {
         let loc = self.token.loc;
         self.scan()?; // advance past '['
 
-        let mut items: Vec<Expr> = Vec::new();
+        let mut items: Vec<Expr<'a>> = Vec::new();
 
         while !matches!(self.token.data, TokenData::RightBracket) {
             let value = self.parse_value()?;

--- a/src/parsers/json_lexer.rs
+++ b/src/parsers/json_lexer.rs
@@ -563,7 +563,7 @@ where
     }
 
     /// Zig: `toEString`.
-    pub fn to_e_string(&mut self) -> LexResult<js_ast::E::String> {
+    pub fn to_e_string(&mut self) -> LexResult<js_ast::E::String<'a>> {
         match self.string_literal_raw_format {
             StringLiteralFormat::Ascii => {
                 Ok(js_ast::E::String::init(self.string_literal_raw_content))
@@ -600,7 +600,7 @@ where
     }
 
     /// Zig: `toUTF8EString`.
-    pub fn to_utf8_e_string(&mut self) -> LexResult<js_ast::E::String> {
+    pub fn to_utf8_e_string(&mut self) -> LexResult<js_ast::E::String<'a>> {
         let mut res = self.to_e_string()?;
         if res.is_utf16 {
             let utf8 = strings::to_utf8_alloc(res.slice16());

--- a/src/parsers/toml.rs
+++ b/src/parsers/toml.rs
@@ -12,7 +12,7 @@ pub use self::lexer::Lexer;
 use self::lexer::T;
 
 // Zig: `js_ast.E.Object.Rope`. The MOVE_DOWN landed it at
-type Rope = js_ast::e::Rope;
+type Rope<'arena> = js_ast::e::Rope<'arena>;
 use js_ast::e::SetError;
 use js_ast::expr::Data as ExprData;
 
@@ -25,13 +25,13 @@ use js_ast::expr::Data as ExprData;
 // `src/js_parser/ast/E.zig` `setRope` / `getOrPutArray`.
 // ──────────────────────────────────────────────────────────────────────────
 
-trait ObjectRopeExt {
-    fn set_rope(&mut self, rope: &Rope, bump: &Bump, value: Expr) -> Result<(), SetError>;
-    fn get_or_put_array(&mut self, rope: &Rope, bump: &Bump) -> Result<Expr, SetError>;
+trait ObjectRopeExt<'arena> {
+    fn set_rope(&mut self, rope: &Rope<'arena>, bump: &Bump, value: Expr<'arena>) -> Result<(), SetError>;
+    fn get_or_put_array(&mut self, rope: &Rope<'arena>, bump: &Bump) -> Result<Expr<'arena>, SetError>;
 }
 
-impl ObjectRopeExt for E::Object {
-    fn set_rope(&mut self, rope: &Rope, bump: &Bump, value: Expr) -> Result<(), SetError> {
+impl<'arena> ObjectRopeExt<'arena> for E::Object<'arena> {
+    fn set_rope(&mut self, rope: &Rope<'arena>, bump: &Bump, value: Expr<'arena>) -> Result<(), SetError> {
         let head_key = match rope.head.data.e_string() {
             Some(s) => s.data,
             None => return Err(SetError::Clobber),
@@ -39,24 +39,22 @@ impl ObjectRopeExt for E::Object {
         if let Some(existing) = self.get(&head_key) {
             match existing.data {
                 ExprData::EArray(mut array) => {
-                    if rope.next.is_null() {
+                    let Some(next) = rope.next_ref() else {
                         array.push(bump, value)?;
                         return Ok(());
-                    }
+                    };
                     if let Some(last) = array.items.last() {
                         let ExprData::EObject(mut obj) = last.data else {
                             return Err(SetError::Clobber);
                         };
-                        // SAFETY: rope.next non-null (checked) and arena-owned.
-                        return obj.set_rope(unsafe { &*rope.next }, bump, value);
+                        return obj.set_rope(next, bump, value);
                     }
                     array.push(bump, value)?;
                     return Ok(());
                 }
                 ExprData::EObject(mut object) => {
-                    if !rope.next.is_null() {
-                        // SAFETY: rope.next non-null and arena-owned.
-                        return object.set_rope(unsafe { &*rope.next }, bump, value);
+                    if let Some(next) = rope.next_ref() {
+                        return object.set_rope(next, bump, value);
                     }
                     return Err(SetError::Clobber);
                 }
@@ -65,13 +63,9 @@ impl ObjectRopeExt for E::Object {
         }
 
         let mut value_ = value;
-        if !rope.next.is_null() {
+        if let Some(next) = rope.next_ref() {
             let obj = Expr::init(E::Object::default(), rope.head.loc);
-            // SAFETY: rope.next non-null and arena-owned.
-            obj.data
-                .e_object()
-                .unwrap()
-                .set_rope(unsafe { &*rope.next }, bump, value)?;
+            obj.data.e_object().unwrap().set_rope(next, bump, value)?;
             value_ = obj;
         }
 
@@ -86,7 +80,7 @@ impl ObjectRopeExt for E::Object {
         Ok(())
     }
 
-    fn get_or_put_array(&mut self, rope: &Rope, bump: &Bump) -> Result<Expr, SetError> {
+    fn get_or_put_array(&mut self, rope: &Rope<'arena>, bump: &Bump) -> Result<Expr<'arena>, SetError> {
         let head_key = match rope.head.data.e_string() {
             Some(s) => s.data,
             None => return Err(SetError::Clobber),
@@ -94,37 +88,30 @@ impl ObjectRopeExt for E::Object {
         if let Some(existing) = self.get(&head_key) {
             match existing.data {
                 ExprData::EArray(array) => {
-                    if rope.next.is_null() {
+                    let Some(next) = rope.next_ref() else {
                         return Ok(existing);
-                    }
+                    };
                     if let Some(last) = array.items.last() {
                         let ExprData::EObject(mut obj) = last.data else {
                             return Err(SetError::Clobber);
                         };
-                        // SAFETY: rope.next non-null (checked) and arena-owned.
-                        return obj.get_or_put_array(unsafe { &*rope.next }, bump);
+                        return obj.get_or_put_array(next, bump);
                     }
                     return Err(SetError::Clobber);
                 }
                 ExprData::EObject(mut object) => {
-                    if rope.next.is_null() {
+                    let Some(next) = rope.next_ref() else {
                         return Err(SetError::Clobber);
-                    }
-                    // SAFETY: rope.next non-null and arena-owned.
-                    return object.get_or_put_array(unsafe { &*rope.next }, bump);
+                    };
+                    return object.get_or_put_array(next, bump);
                 }
                 _ => return Err(SetError::Clobber),
             }
         }
 
-        if !rope.next.is_null() {
+        if let Some(next) = rope.next_ref() {
             let obj = Expr::init(E::Object::default(), rope.head.loc);
-            // SAFETY: rope.next non-null and arena-owned.
-            let out = obj
-                .data
-                .e_object()
-                .unwrap()
-                .get_or_put_array(unsafe { &*rope.next }, bump)?;
+            let out = obj.data.e_object().unwrap().get_or_put_array(next, bump)?;
             VecExt::append(
                 &mut self.properties,
                 js_ast::G::Property {
@@ -227,8 +214,8 @@ mod hash_map_pool {
 // TOML parser
 // ──────────────────────────────────────────────────────────────────────────
 
-pub struct TOML<'a> {
-    pub lexer: Lexer<'a>,
+pub struct TOML<'a, 'log> {
+    pub lexer: Lexer<'a, 'log>,
     // PORT NOTE: Zig also stores `log: *logger.Log` on the parser, but it is
     // never read — all logging goes through `lexer.log`. Dropped here to avoid
     // a second `&mut Log` borrow overlapping `lexer.log`.
@@ -236,13 +223,13 @@ pub struct TOML<'a> {
     pub stack_check: StackCheck,
 }
 
-impl<'a> TOML<'a> {
+impl<'a, 'log> TOML<'a, 'log> {
     pub fn init(
         bump: &'a Bump,
         source_: &'a bun_ast::Source,
-        log: &'a mut bun_ast::Log,
+        log: &'log mut bun_ast::Log,
         redact_logs: bool,
-    ) -> Result<TOML<'a>, bun_core::Error> {
+    ) -> Result<TOML<'a, 'log>, bun_core::Error> {
         // TODO(port): narrow error set
         Ok(TOML {
             lexer: Lexer::init(log, source_, bump, redact_logs)?,
@@ -259,19 +246,19 @@ impl<'a> TOML<'a> {
     // Zig: `fn e(_: *TOML, t: anytype, loc: logger.Loc) Expr` with a
     // `@typeInfo(Type) == .pointer` auto-deref. In Rust the deref is implicit at
     // call sites, so this collapses to a single generic forwarding to Expr::init.
-    pub fn e<D>(&self, t: D, loc: bun_ast::Loc) -> Expr
+    pub fn e<D>(&self, t: D, loc: bun_ast::Loc) -> Expr<'a>
     where
-        D: js_ast::ExprInit, // TODO(port): real trait bound for Expr::init payloads
+        D: js_ast::ExprInit<'a>, // TODO(port): real trait bound for Expr::init payloads
     {
         Expr::init(t, loc)
     }
 
     pub fn parse(
         source_: &'a bun_ast::Source,
-        log: &'a mut bun_ast::Log,
+        log: &'log mut bun_ast::Log,
         bump: &'a Bump,
         redact_logs: bool,
-    ) -> Result<Expr, bun_core::Error> {
+    ) -> Result<Expr<'a>, bun_core::Error> {
         // TODO(port): narrow error set
         match source_.contents.len() {
             // This is to be consisntent with how disabled JS files are handled
@@ -306,7 +293,7 @@ impl<'a> TOML<'a> {
 
     // ── AST-producing methods ──────────────────────────────────────────────
 
-    pub fn parse_key_segment(&mut self) -> Result<Option<Expr>, bun_core::Error> {
+    pub fn parse_key_segment(&mut self) -> Result<Option<Expr<'a>>, bun_core::Error> {
         let loc = self.lexer.loc();
 
         match self.lexer.token {
@@ -339,11 +326,11 @@ impl<'a> TOML<'a> {
         }
     }
 
-    pub fn parse_key(&mut self, bump: &'a Bump) -> Result<&'a mut Rope, bun_core::Error> {
+    pub fn parse_key(&mut self, bump: &'a Bump) -> Result<&'a mut Rope<'a>, bun_core::Error> {
         // TODO(port): lifetime — Zig returns `*Rope` allocated from `allocator`
         // (a stack-fallback arena reset per-iteration). Here we allocate from the
         // caller-provided bump and return `&mut Rope` borrowed from it.
-        let rope: &mut Rope = bump.alloc(Rope {
+        let rope: &mut Rope<'a> = bump.alloc(Rope {
             head: match self.parse_key_segment()? {
                 Some(seg) => seg,
                 None => {
@@ -351,10 +338,10 @@ impl<'a> TOML<'a> {
                     return Err(bun_core::err!("SyntaxError"));
                 }
             },
-            next: core::ptr::null_mut(),
+            next: None,
         });
-        let head: *mut Rope = rope;
-        let mut rope: *mut Rope = rope;
+        let head = core::ptr::NonNull::from(rope);
+        let mut rope = head;
 
         while self.lexer.token == T::t_dot {
             self.lexer.next()?;
@@ -366,17 +353,17 @@ impl<'a> TOML<'a> {
             // the sole mutator. Raw pointers used to avoid stacked &mut reborrows.
             // PORT NOTE: reshaped for borrowck
             unsafe {
-                rope = (*rope).append(seg, bump)?;
+                rope = (*rope.as_ptr()).append(seg, bump)?;
             }
         }
 
         // SAFETY: `head` was just allocated from `bump` above and is non-null.
-        Ok(unsafe { &mut *head })
+        Ok(unsafe { &mut *head.as_ptr() })
     }
 
-    fn run_parser(&mut self) -> Result<Expr, bun_core::Error> {
+    fn run_parser(&mut self) -> Result<Expr<'a>, bun_core::Error> {
         let root = self.e(E::Object::default(), self.lexer.loc());
-        let mut head: *mut E::Object = root
+        let mut head: *mut E::Object<'a> = root
             .data
             .e_object()
             .expect("infallible: variant checked")
@@ -476,7 +463,7 @@ impl<'a> TOML<'a> {
 
     pub fn parse_assignment(
         &mut self,
-        obj: &mut E::Object,
+        obj: &mut E::Object<'a>,
         bump: &'a Bump,
     ) -> Result<(), bun_core::Error> {
         self.lexer.allow_double_bracket = false;
@@ -519,7 +506,7 @@ impl<'a> TOML<'a> {
         Ok(())
     }
 
-    pub fn parse_value(&mut self) -> Result<Expr, bun_core::Error> {
+    pub fn parse_value(&mut self) -> Result<Expr<'a>, bun_core::Error> {
         // Zig: `bun.throwStackOverflow()` guarded only by `StackCheck`. The
         // Rust port previously added a hard depth cap because release-mode
         // frames are smaller than Zig's (Zig didn't emit LLVM lifetime
@@ -534,7 +521,7 @@ impl<'a> TOML<'a> {
         self.parse_value_inner()
     }
 
-    fn parse_value_inner(&mut self) -> Result<Expr, bun_core::Error> {
+    fn parse_value_inner(&mut self) -> Result<Expr<'a>, bun_core::Error> {
         let loc = self.lexer.loc();
 
         self.lexer.allow_double_bracket = true;
@@ -586,7 +573,7 @@ impl<'a> TOML<'a> {
                 // profile
                 let key_allocator = self.bump;
                 let expr = self.e(E::Object::default(), loc);
-                let obj: *mut E::Object = expr
+                let obj: *mut E::Object<'a> = expr
                     .data
                     .e_object()
                     .expect("infallible: variant checked")
@@ -631,7 +618,7 @@ impl<'a> TOML<'a> {
                 self.lexer.next()?;
                 let mut is_single_line = !self.lexer.has_newline_before;
                 let array_ = self.e(E::Array::default(), loc);
-                let array: *mut E::Array = array_
+                let array: *mut E::Array<'a> = array_
                     .data
                     .e_array()
                     .expect("infallible: variant checked")

--- a/src/parsers/toml/lexer.rs
+++ b/src/parsers/toml/lexer.rs
@@ -48,7 +48,7 @@ pub enum T {
     t_empty_array,
 }
 
-pub struct Lexer<'a> {
+pub struct Lexer<'a, 'log> {
     // PORT NOTE: borrowed (`&'a Source`) rather than owned so
     // `identifier`/`string_literal_slice` can borrow `&'a [u8]` from
     // `source.contents` without a self-referential struct. The Zig original
@@ -56,7 +56,8 @@ pub struct Lexer<'a> {
     // `bun_ast::Source.contents` is now `Cow<'static,[u8]>` so an owned copy
     // would tie those slices to `&self` instead of `'a`.
     pub source: &'a bun_ast::Source,
-    pub log: &'a mut bun_ast::Log,
+    // Separate lifetime so the returned `Expr<'a>` does not borrow the log.
+    pub log: &'log mut bun_ast::Log,
     pub start: usize,
     pub end: usize,
     pub current: usize,
@@ -100,7 +101,7 @@ bun_core::oom_from_alloc!(Error);
 
 bun_core::named_error_set!(Error);
 
-impl<'a> LexerLog<'a> for Lexer<'a> {
+impl<'a, 'log> LexerLog<'a> for Lexer<'a, 'log> {
     type Err = Error;
     #[inline]
     fn log_mut(&mut self) -> &mut bun_ast::Log {
@@ -128,7 +129,7 @@ impl<'a> LexerLog<'a> for Lexer<'a> {
     }
 }
 
-impl<'a> Lexer<'a> {
+impl<'a, 'log> Lexer<'a, 'log> {
     #[inline]
     pub fn loc(&self) -> bun_ast::Loc {
         bun_ast::usize2loc(self.start)
@@ -1235,11 +1236,11 @@ impl<'a> Lexer<'a> {
     }
 
     pub fn init(
-        log: &'a mut bun_ast::Log,
+        log: &'log mut bun_ast::Log,
         source: &'a bun_ast::Source,
         bump: &'a Arena,
         redact_logs: bool,
-    ) -> Result<Lexer<'a>, Error> {
+    ) -> Result<Lexer<'a, 'log>, Error> {
         let mut lex = Lexer {
             source,
             log,
@@ -1266,7 +1267,7 @@ impl<'a> Lexer<'a> {
     }
 
     #[inline]
-    pub fn to_string(&self, loc_: bun_ast::Loc) -> js_ast::Expr {
+    pub fn to_string(&self, loc_: bun_ast::Loc) -> js_ast::Expr<'a> {
         if self.string_literal_is_ascii {
             return js_ast::Expr::init(js_ast::E::String::init(self.string_literal_slice), loc_);
         }

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -26,11 +26,11 @@ use bun_core::{self, StackCheck};
 pub struct YAML;
 
 impl YAML {
-    pub fn parse(
-        source: &bun_ast::Source,
+    pub fn parse<'arena>(
+        source: &'arena bun_ast::Source,
         log: &mut bun_ast::Log,
-        bump: &bun_alloc::Arena,
-    ) -> Result<Expr, YamlParseError> {
+        bump: &'arena bun_alloc::Arena,
+    ) -> Result<Expr<'arena>, YamlParseError> {
         // Zig: `bun.analytics.Features.yaml_parse += 1;`
         bun_core::analytics::Features::yaml_parse_inc();
 
@@ -101,7 +101,10 @@ impl From<YamlParseError> for bun_core::Error {
 // Top-level free functions
 // ───────────────────────────────────────────────────────────────────────────
 
-pub fn parse<Enc: Encoding>(bump: &bun_alloc::Arena, input: &[Enc::Unit]) -> ParseResult<Enc> {
+pub fn parse<'arena, Enc: Encoding>(
+    bump: &'arena bun_alloc::Arena,
+    input: &'arena [Enc::Unit],
+) -> ParseResult<'arena, Enc> {
     let mut parser: Parser<Enc> = Parser::init(bump, input);
 
     match parser.parse() {
@@ -110,7 +113,7 @@ pub fn parse<Enc: Encoding>(bump: &bun_alloc::Arena, input: &[Enc::Unit]) -> Par
     }
 }
 
-pub fn print<Enc: Encoding, W: fmt::Write>(stream: Stream<Enc>, writer: &mut W) -> fmt::Result {
+pub fn print<Enc: Encoding, W: fmt::Write>(stream: Stream<'_, Enc>, writer: &mut W) -> fmt::Result {
     // Zig body (yaml.zig:44-53) constructs `Parser(encoding).Printer(@TypeOf(writer))`
     // and calls `printer.print()`. The `Printer` type is commented out in the spec
     // (yaml.zig:4927-5250) and operates on the removed `Node` enum, so any Zig
@@ -1726,7 +1729,7 @@ pub enum NodeTag {
 }
 
 impl NodeTag {
-    pub fn resolve_null(self, loc: bun_ast::Loc) -> Expr {
+    pub fn resolve_null<'arena>(self, loc: bun_ast::Loc) -> Expr<'arena> {
         match self {
             NodeTag::None
             | NodeTag::Bool
@@ -1750,7 +1753,12 @@ pub enum NodeScalar<Enc: Encoding> {
 }
 
 impl<Enc: Encoding> NodeScalar<Enc> {
-    pub fn to_expr(&self, pos: Pos, input: &[Enc::Unit], bump: &bun_alloc::Arena) -> Expr {
+    pub fn to_expr<'arena>(
+        &self,
+        pos: Pos,
+        input: &[Enc::Unit],
+        bump: &'arena bun_alloc::Arena,
+    ) -> Expr<'arena> {
         match self {
             NodeScalar::Null => Expr::init(E::Null {}, pos.loc()),
             NodeScalar::Boolean(value) => Expr::init(E::Boolean { value: *value }, pos.loc()),
@@ -1826,15 +1834,15 @@ pub enum DirectiveTagPrefix {
     Global(StringRange),
 }
 
-pub struct Document {
+pub struct Document<'arena> {
     pub directives: Vec<Directive>,
-    pub root: Expr,
+    pub root: Expr<'arena>,
 }
 
 // impl Drop for Document — Vec<Directive> auto-drops; Expr is arena-backed.
 
-pub struct Stream<Enc: Encoding> {
-    pub docs: Vec<Document>,
+pub struct Stream<'arena, Enc: Encoding> {
+    pub docs: Vec<Document<'arena>>,
     pub input: *const [Enc::Unit],
     // TODO(port): lifetime — Zig stored `[]const enc.unit()` borrowing parser input.
 }
@@ -2136,13 +2144,13 @@ impl<Enc: Encoding> Token<Enc> {
 // ParseResult
 // ───────────────────────────────────────────────────────────────────────────
 
-pub enum ParseResult<Enc: Encoding> {
-    Result(ParseResultOk<Enc>),
+pub enum ParseResult<'arena, Enc: Encoding> {
+    Result(ParseResultOk<'arena, Enc>),
     Err(ParseResultError),
 }
 
-pub struct ParseResultOk<Enc: Encoding> {
-    pub stream: Stream<Enc>,
+pub struct ParseResultOk<'arena, Enc: Encoding> {
+    pub stream: Stream<'arena, Enc>,
     // allocator dropped — global mimalloc
 }
 
@@ -2217,12 +2225,12 @@ impl ParseResultError {
     }
 }
 
-impl<Enc: Encoding> ParseResult<Enc> {
-    pub fn success(stream: Stream<Enc>, _parser: &Parser<Enc>) -> Self {
+impl<'arena, Enc: Encoding> ParseResult<'arena, Enc> {
+    pub fn success(stream: Stream<'arena, Enc>, _parser: &Parser<'arena, Enc>) -> Self {
         ParseResult::Result(ParseResultOk { stream })
     }
 
-    pub fn fail(err: ParseError, parser: &Parser<Enc>) -> Self {
+    pub fn fail(err: ParseError, parser: &Parser<'arena, Enc>) -> Self {
         let e = match err {
             ParseError::OutOfMemory => ParseResultError::Oom,
             ParseError::StackOverflow => ParseResultError::StackOverflow,
@@ -2306,7 +2314,7 @@ pub struct Parser<'i, Enc: Encoding> {
 
     pub explicit_document_start_line: Option<Line>,
 
-    pub anchors: StringHashMap<Expr>,
+    pub anchors: StringHashMap<Expr<'i>>,
     // TODO(port): Zig key type was []const enc.unit(); StringHashMap keys are &[u8].
     // For Utf16 this needs a different map type.
     pub tag_handles: StringHashMap<()>,
@@ -2345,7 +2353,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         ParseError::UnexpectedToken
     }
 
-    pub fn parse(&mut self) -> Result<Stream<Enc>, ParseError> {
+    pub fn parse(&mut self) -> Result<Stream<'i, Enc>, ParseError> {
         self.scan(ScanOptions {
             first_scan: true,
             ..Default::default()
@@ -2353,8 +2361,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         self.parse_stream()
     }
 
-    pub fn parse_stream(&mut self) -> Result<Stream<Enc>, ParseError> {
-        let mut docs: Vec<Document> = Vec::new();
+    pub fn parse_stream(&mut self) -> Result<Stream<'i, Enc>, ParseError> {
+        let mut docs: Vec<Document<'i>> = Vec::new();
 
         // we want one null document if eof, not zero documents.
         let mut first = true;
@@ -2526,7 +2534,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         Err(ParseError::InvalidDirective)
     }
 
-    pub fn parse_document(&mut self) -> Result<Document, ParseError> {
+    pub fn parse_document(&mut self) -> Result<Document<'i>, ParseError> {
         let mut directives: Vec<Directive> = Vec::new();
 
         // Zig: `clearRetainingCapacity()` — `HashMap::clear()` already retains capacity.
@@ -2586,12 +2594,12 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         Ok(Document { root, directives })
     }
 
-    fn parse_flow_sequence(&mut self) -> Result<Expr, ParseError> {
+    fn parse_flow_sequence(&mut self) -> Result<Expr<'i>, ParseError> {
         let sequence_start = self.token.start;
         let _sequence_indent = self.token.indent;
         let _sequence_line = self.line;
 
-        let mut seq: ast::ExprNodeList = bun_alloc::AstAlloc::vec();
+        let mut seq: ast::ExprNodeList<'i> = bun_alloc::AstAlloc::vec();
 
         self.context.set(Context::FlowIn)?;
 
@@ -2633,7 +2641,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         ))
     }
 
-    fn parse_flow_mapping(&mut self) -> Result<Expr, ParseError> {
+    fn parse_flow_mapping(&mut self) -> Result<Expr<'i>, ParseError> {
         let mapping_start = self.token.start;
         let _mapping_indent = self.token.indent;
         let _mapping_line = self.token.line;
@@ -2735,7 +2743,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         ))
     }
 
-    fn parse_block_sequence(&mut self) -> Result<Expr, ParseError> {
+    fn parse_block_sequence(&mut self) -> Result<Expr<'i>, ParseError> {
         let sequence_start = self.token.start;
         let sequence_indent = self.token.indent;
 
@@ -2743,8 +2751,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
         // PORT NOTE: Zig `defer self.block_indents.pop()` — capture the fallible
         // body's result and pop on EVERY exit (including `?` paths).
-        let result: Result<Expr, ParseError> = (|| {
-            let mut seq: ast::ExprNodeList = bun_alloc::AstAlloc::vec();
+        let result: Result<Expr<'i>, ParseError> = (|| {
+            let mut seq: ast::ExprNodeList<'i> = bun_alloc::AstAlloc::vec();
 
             let mut prev_line = Line::from(0);
 
@@ -2769,7 +2777,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 })?;
 
                 // check if the sequence entry is a null value (see Zig comments)
-                let item: Expr = match &self.token.data {
+                let item: Expr<'i> = match &self.token.data {
                     TokenData::Eof => Expr::init(E::Null {}, entry_start.add(2).loc()),
                     TokenData::SequenceEntry => {
                         if self.token.indent.is_less_than_or_equal(sequence_indent) {
@@ -2868,7 +2876,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
     /// Should only be used with expressions created with the YAML parser. It assumes
     /// only null, boolean, number, string, array, object are possible. It also only
     /// does pointer comparison with arrays and objects (so exponential merges are avoided)
-    fn yaml_merge_key_expr_eql(l: &Expr, r: &Expr) -> bool {
+    fn yaml_merge_key_expr_eql(l: &Expr<'_>, r: &Expr<'_>) -> bool {
         if core::mem::discriminant(&l.data) != core::mem::discriminant(&r.data) {
             return false;
         }
@@ -2899,11 +2907,11 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
     fn parse_block_mapping(
         &mut self,
-        first_key: Expr,
+        first_key: Expr<'i>,
         mapping_start: Pos,
         mapping_indent: Indent,
         mapping_line: Line,
-    ) -> Result<Expr, ParseError> {
+    ) -> Result<Expr<'i>, ParseError> {
         if let Some(explicit_document_start_line) = self.explicit_document_start_line {
             if mapping_line == explicit_document_start_line {
                 // TODO: more specific error
@@ -2915,15 +2923,15 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
         // PORT NOTE: Zig `defer self.block_indents.pop()` — capture the fallible
         // body's result and pop on EVERY exit (including `?` paths).
-        let result: Result<Expr, ParseError> = (|| {
-            let mut props = MappingProps::init();
+        let result: Result<Expr<'i>, ParseError> = (|| {
+            let mut props = MappingProps::<'i>::init();
 
             {
                 // get the first value
                 let mapping_value_start = self.token.start;
                 let mapping_value_line = self.token.line;
 
-                let value: Expr = match self.token.data {
+                let value: Expr<'i> = match self.token.data {
                     // it's a !!set entry
                     TokenData::MappingKey => {
                         if self.token.line == mapping_line {
@@ -2979,7 +2987,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
             // PORT NOTE: Zig `defer self.context.unset(.block_in)` — same
             // capture-then-unset pattern, nested.
-            let inner: Result<Expr, ParseError> = (|| {
+            let inner: Result<Expr<'i>, ParseError> = (|| {
                 let mut previous_line = mapping_line;
 
                 while !matches!(
@@ -3024,7 +3032,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     let mapping_value_line = self.token.line;
                     let mapping_value_start = self.token.start;
 
-                    let value: Expr = match self.token.data {
+                    let value: Expr<'i> = match self.token.data {
                         // it's a !!set entry
                         TokenData::MappingKey => {
                             if self.token.line == key_line {
@@ -3094,23 +3102,23 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 // MappingProps
 // ───────────────────────────────────────────────────────────────────────────
 
-pub struct MappingProps {
-    list: G::PropertyList,
+pub struct MappingProps<'arena> {
+    list: G::PropertyList<'arena>,
 }
 
-impl MappingProps {
+impl<'arena> MappingProps<'arena> {
     pub fn init() -> Self {
         Self {
             list: bun_alloc::AstAlloc::vec(),
         }
     }
 
-    pub fn append(&mut self, prop: G::Property) -> Result<(), AllocError> {
+    pub fn append(&mut self, prop: G::Property<'arena>) -> Result<(), AllocError> {
         self.list.push(prop);
         Ok(())
     }
 
-    pub fn merge(&mut self, merge_props: &[G::Property]) -> Result<(), AllocError> {
+    pub fn merge(&mut self, merge_props: &[G::Property<'arena>]) -> Result<(), AllocError> {
         self.list.reserve(merge_props.len());
         // PERF(port): was ensureUnusedCapacity
         'next_merge_prop: for merge_prop in merge_props.iter().rev() {
@@ -3137,7 +3145,11 @@ impl MappingProps {
         Ok(())
     }
 
-    pub fn append_maybe_merge(&mut self, key: Expr, value: Expr) -> Result<(), AllocError> {
+    pub fn append_maybe_merge(
+        &mut self,
+        key: Expr<'arena>,
+        value: Expr<'arena>,
+    ) -> Result<(), AllocError> {
         let is_merge_key = match &key.data {
             ast::ExprData::EString(key_str) => key_str.eql_comptime(b"<<"),
             _ => false,
@@ -3176,7 +3188,7 @@ impl MappingProps {
         }
     }
 
-    pub fn move_list(&mut self) -> G::PropertyList {
+    pub fn move_list(&mut self) -> G::PropertyList<'arena> {
         core::mem::replace(&mut self.list, bun_alloc::AstAlloc::vec())
     }
 }
@@ -3398,7 +3410,7 @@ impl Escape {
 // ───────────────────────────────────────────────────────────────────────────
 
 impl<'i, Enc: Encoding> Parser<'i, Enc> {
-    fn parse_node(&mut self, opts: ParseNodeOptions<Enc>) -> Result<Expr, ParseError> {
+    fn parse_node(&mut self, opts: ParseNodeOptions<Enc>) -> Result<Expr<'i>, ParseError> {
         if !self.stack_check.is_safe_to_recurse() {
             return Err(ParseError::StackOverflow);
         }
@@ -3416,7 +3428,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         // PORT NOTE: labeled-switch loop on `self.token.data`. The Zig
         // `continue :node self.token.data` re-enters with the new token after
         // scanning. We loop and re-match.
-        let node: Expr = 'node: loop {
+        let node: Expr<'i> = 'node: loop {
             match &self.token.data {
                 TokenData::Eof | TokenData::DocumentStart | TokenData::DocumentEnd => {
                     break 'node Expr::init(E::Null {}, self.token.start.loc());

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -2594,7 +2594,7 @@ pub mod cache {
     #[derive(Default)]
     pub struct JavaScript {}
 
-    pub type JavaScriptResult = bun_js_parser::Result;
+    pub type JavaScriptResult<'arena> = bun_js_parser::Result<'arena>;
 
     impl JavaScript {
         #[inline]

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -40,7 +40,12 @@ pub enum JsonMode {
 /// `parse_*` themselves — eagerly constructing `Arena::new()` here costs one
 /// `mi_heap_new` per worker (≈11 empty heaps on a typical build/elysia run).
 pub struct JsonCache {
-    bump: Option<bun_alloc::Arena>,
+    /// `&'static` (leaked on first use) so the returned `Expr<'a>` borrows only
+    /// the caller's `source`, not `&mut self` — callers interleave `parse_*`
+    /// results with other `&mut Resolver` calls. The arena is never reset and
+    /// lives for the process anyway (DirInfo cache is process-global), so
+    /// leaking matches the Zig `bun.default_allocator` semantics.
+    bump: Option<&'static bun_alloc::Arena>,
 }
 
 impl JsonCache {
@@ -49,24 +54,28 @@ impl JsonCache {
     }
 
     /// Port of `cache::Json::parse` (cache.zig:287).
+    ///
+    /// Returned `Expr<'a>` borrows `source` (string slices may point into
+    /// `source.contents`) and the cache's process-lifetime arena. The arena
+    /// borrow does *not* extend the `&mut self` borrow — see `bump` field doc.
     #[inline]
-    fn parse(
+    fn parse<'a>(
         &mut self,
         log: &mut bun_ast::Log,
-        source: &bun_ast::Source,
-        func: fn(
-            &bun_ast::Source,
+        source: &'a bun_ast::Source,
+        func: for<'b> fn(
+            &'b bun_ast::Source,
             &mut bun_ast::Log,
-            &bun_alloc::Arena,
-        ) -> Result<bun_ast::Expr, bun_core::Error>,
-    ) -> Result<Option<bun_ast::Expr>, bun_core::Error> {
+            &'b bun_alloc::Arena,
+        ) -> Result<bun_ast::Expr<'b>, bun_core::Error>,
+    ) -> Result<Option<bun_ast::Expr<'a>>, bun_core::Error> {
         let mut temp_log = bun_ast::Log::init();
-        let bump = self.bump.get_or_insert_with(bun_alloc::Arena::new);
+        let bump: &'static bun_alloc::Arena = *self
+            .bump
+            .get_or_insert_with(|| Box::leak(Box::new(bun_alloc::Arena::new())));
         // PORT NOTE: reshaped for borrowck — Zig `defer temp_log.appendToMaybeRecycled(log, source) catch {}`
         // runs after the `func() catch null` body; here the append is hoisted past the match.
         let result = match func(source, &mut temp_log, bump) {
-            // Lift the T2 value-subset `bun_ast::Expr` into the full
-            // `bun_ast::Expr` (src/js_parser/ast/Expr.rs `From` impl).
             Ok(expr) => Some(bun_ast::Expr::from(expr)),
             Err(_) => None,
         };
@@ -76,22 +85,22 @@ impl JsonCache {
 
     /// Port of `cache::Json.parseTSConfig` (cache.zig:311).
     #[inline]
-    pub fn parse_tsconfig(
+    pub fn parse_tsconfig<'a>(
         &mut self,
         log: &mut bun_ast::Log,
-        source: &bun_ast::Source,
-    ) -> Result<Option<bun_ast::Expr>, bun_core::Error> {
+        source: &'a bun_ast::Source,
+    ) -> Result<Option<bun_ast::Expr<'a>>, bun_core::Error> {
         self.parse(log, source, json_parser::parse_ts_config::<true>)
     }
 
     /// Port of `cache::Json.parsePackageJSON` (cache.zig:307).
     #[inline]
-    pub fn parse_package_json(
+    pub fn parse_package_json<'a>(
         &mut self,
         log: &mut bun_ast::Log,
-        source: &bun_ast::Source,
+        source: &'a bun_ast::Source,
         force_utf8: bool,
-    ) -> Result<Option<bun_ast::Expr>, bun_core::Error> {
+    ) -> Result<Option<bun_ast::Expr<'a>>, bun_core::Error> {
         if force_utf8 {
             self.parse(log, source, json_parser::parse_ts_config::<true>)
         } else {
@@ -101,21 +110,21 @@ impl JsonCache {
 
     /// Port of `cache::Json.parseJSON` (cache.zig:296).
     #[inline]
-    pub fn parse_json(
+    pub fn parse_json<'a>(
         &mut self,
         log: &mut bun_ast::Log,
-        source: &bun_ast::Source,
+        source: &'a bun_ast::Source,
         mode: JsonMode,
         force_utf8: bool,
-    ) -> Result<Option<bun_ast::Expr>, bun_core::Error> {
+    ) -> Result<Option<bun_ast::Expr<'a>>, bun_core::Error> {
         // tsconfig.* and jsconfig.* files are JSON files, but they are not valid JSON files.
         // They are JSON files with comments and trailing commas.
         // Sometimes tooling expects this to work.
-        let f: fn(
-            &bun_ast::Source,
+        let f: for<'b> fn(
+            &'b bun_ast::Source,
             &mut bun_ast::Log,
-            &bun_alloc::Arena,
-        ) -> Result<bun_ast::Expr, bun_core::Error> = match (mode, force_utf8) {
+            &'b bun_alloc::Arena,
+        ) -> Result<bun_ast::Expr<'b>, bun_core::Error> = match (mode, force_utf8) {
             (JsonMode::Jsonc, true) => json_parser::parse_ts_config::<true>,
             (JsonMode::Jsonc, false) => json_parser::parse_ts_config::<false>,
             (JsonMode::Json, true) => json_parser::parse::<true>,

--- a/src/runtime/api/JSON5Object.rs
+++ b/src/runtime/api/JSON5Object.rs
@@ -442,7 +442,7 @@ fn estring_to_js(str: &E::EString, global: &JSGlobalObject) -> JsResult<JSValue>
     }
 }
 
-fn expr_to_js(expr: Expr, global: &JSGlobalObject) -> JsResult<JSValue> {
+fn expr_to_js(expr: Expr<'_>, global: &JSGlobalObject) -> JsResult<JSValue> {
     match expr.data {
         ExprData::ENull(_) => Ok(JSValue::NULL),
         ExprData::EBoolean(boolean) => Ok(JSValue::from(boolean.value)),

--- a/src/runtime/api/JSONCObject.rs
+++ b/src/runtime/api/JSONCObject.rs
@@ -32,7 +32,7 @@ pub fn parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
             // threads the arena via the AST nodes themselves. `parse_ts_config` returns
             // the cycle-broken `bun_ast::Expr`; lift it into the full
             // `bun_ast::Expr` (From impl in ast/Expr.rs) so `ExprJsc` applies.
-            let parse_result: bun_ast::Expr = parse_result.into();
+            let parse_result: bun_ast::Expr<'_> = parse_result.into();
             match parse_result.to_js(global) {
                 Ok(v) => Ok(v),
                 Err(ToJSError::OutOfMemory) => Err(JsError::OutOfMemory),

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -50,7 +50,8 @@ pub struct JSTranspiler {
     /// resting-state log that `transpiler.log: *mut Log` points at between
     /// host-fn calls. `JsCell` so a `*mut Log` can be projected from `&self`.
     pub config: JsCell<Config>,
-    pub scan_pass_result: JsCell<ScanPassResult>,
+    // TRANSITIONAL: see `Config.runtime` — same JSTranspiler-owned arena.
+    pub scan_pass_result: JsCell<ScanPassResult<'static>>,
     pub buffer_writer: JsCell<Option<JSPrinter::BufferWriter>>,
     pub log_level: bun_ast::Level,
     // TODO(port): non-AST crate keeps an arena field for bulk-freeing config strings.
@@ -80,7 +81,10 @@ pub struct Config {
     pub tsconfig_buf: Box<[u8]>,
     pub macros_buf: Box<[u8]>,
     pub log: bun_ast::Log,
-    pub runtime: Runtime::Features,
+    // TRANSITIONAL: `Features<'arena>` ties to the JSTranspiler's owned arena
+    // (sibling field on `JSTranspiler`); erase to `'static` like
+    // `ParseOptions.replace_exports` in bun_bundler.
+    pub runtime: Runtime::Features<'static>,
     pub tree_shaking: bool,
     pub trim_unused_imports: Option<bool>,
     pub inlining: bool,
@@ -489,7 +493,7 @@ impl Config {
                 );
             }
 
-            let mut replacements = bun_ast::runtime::ReplaceableExportMap::default();
+            let mut replacements = bun_ast::runtime::ReplaceableExportMap::<'static>::default();
             // errdefer replacements.clearAndFree(allocator) → Drop on error path
 
             if let Some(eliminate) = exports.get_truthy(global, "eliminate")? {
@@ -693,7 +697,7 @@ pub struct TransformTask<'a> {
     pub tsconfig: Option<&'a TSConfigJSON>,
     pub loader: Loader,
     pub global: &'a JSGlobalObject,
-    pub replace_exports: bun_ast::runtime::ReplaceableExportMap,
+    pub replace_exports: bun_ast::runtime::ReplaceableExportMap<'static>,
 }
 
 pub type AsyncTransformTask<'a> =
@@ -910,11 +914,15 @@ impl<'a> TransformTask<'a> {
 //   js_instance.deref() → IntrusiveRc::drop
 //   bun.destroy(this) → Box drop by owner
 
+// TRANSITIONAL: returns `'static` because the result is stored in
+// `Config.runtime.replace_exports: ReplaceableExportMap<'static>`. The backing
+// data lives in the thread-local AST store + the JSTranspiler-owned `arena`
+// (both outlive `Config`).
 fn export_replacement_value(
     value: JSValue,
     global: &JSGlobalObject,
     arena: &Arena,
-) -> JsResult<Option<bun_ast::Expr>> {
+) -> JsResult<Option<bun_ast::Expr<'static>>> {
     if value.is_boolean() {
         return Ok(Some(Expr {
             data: bun_ast::ExprData::EBoolean(bun_ast::E::Boolean {
@@ -1754,9 +1762,15 @@ impl JSTranspiler {
         // Both are stateless unit structs, so calling the bundler-crate one
         // directly is equivalent.
         // SAFETY: `scan_pass_result` JsCell — `scan()` does not re-enter JS.
+        // TRANSITIONAL: `scan()` ties `scan_pass_result: &'a mut
+        // ScanPassResult<'a>` to the local `&arena` lifetime, but the field is
+        // typed `'static`. Rebind for the call; the result is `reset()` below
+        // before `arena` drops, so no `'a`-data escapes.
+        let scan_pass_result: &mut ScanPassResult<'_> =
+            unsafe { core::mem::transmute(self.scan_pass_result.get_mut()) };
         let scan_result = bun_bundler::cache::JavaScript::init().scan(
             &arena,
-            unsafe { self.scan_pass_result.get_mut() },
+            scan_pass_result,
             opts,
             define,
             &mut log,

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -1031,7 +1031,7 @@ pub struct ParserCtx<'a> {
     stack_check: StackCheck,
 
     global: &'a JSGlobalObject,
-    root: Expr,
+    root: Expr<'a>,
 
     result: JSValue,
 }
@@ -1105,7 +1105,7 @@ impl<'a> ParserCtx<'a> {
     pub fn to_js(
         &mut self,
         args: &mut MarkedArgumentBuffer,
-        expr: Expr,
+        expr: Expr<'a>,
     ) -> Result<JSValue, ToJsError> {
         if !self.stack_check.is_safe_to_recurse() {
             return Err(ToJsError::StackOverflow);

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -1094,6 +1094,7 @@ impl CompletionStruct for JSBundleCompletionTask {
         &mut self,
         transpiler: &'a mut Transpiler<'a>,
         bump: &'a Arena,
+        arena_pool: &'a bun_bundler::ArenaPool,
         thread_pool: *mut bun_threading::ThreadPool,
     ) -> Result<(), bun_core::Error> {
         // `jsc.AnyEventLoop.init(allocator)` — Mini loop owned by the bump.
@@ -1104,12 +1105,6 @@ impl CompletionStruct for JSBundleCompletionTask {
         let event_loop: bun_bundler::linker_context_mod::EventLoop =
             Some(NonNull::from(&mut *any_loop).cast::<bun_event_loop::AnyEventLoop<'static>>());
 
-        // Zig passed the same `heap` by value (mimalloc handle struct copy);
-        // bumpalo arenas can't be aliased that way, so `BundleV2` owns its
-        // own arena (its only consumer is `linker.graph.bump`, repointed in
-        // `BundleV2::init`). Transpiler/AST allocations stay in `bump`.
-        let heap = Arena::new();
-
         // `thread_pool` is the `WorkPool` singleton (`OnceLock`-backed,
         // process-lifetime, concurrently read by worker threads). Do NOT
         // materialize `&mut` from it — its provenance is `&'static`, so even a
@@ -1117,7 +1112,8 @@ impl CompletionStruct for JSBundleCompletionTask {
         // (`NonNull`) end-to-end; `ThreadPool::init` stores it as `*mut`.
         let worker_pool = NonNull::new(thread_pool);
 
-        let mut bv2 = BundleV2::init(transpiler, None, bump, event_loop, false, worker_pool, heap)?;
+        let mut bv2 =
+            BundleV2::init(transpiler, None, bump, event_loop, false, worker_pool, arena_pool)?;
 
         bv2.plugins = self.plugins();
         bv2.completion = Some(self.as_js_bundle_completion_task());

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -276,6 +276,10 @@ pub struct CurrentBundle {
     /// make `DevServer` self-referential; raw-ptr aliasing inside `BundleV2`
     /// already encodes that contract.
     pub bv2: Box<BundleV2<'static>>,
+    /// Owns every per-worker arena plus `bv2.graph.heap` for this bundle pass.
+    /// `bv2` borrows it as `&'static ArenaPool` under the same `'static`
+    /// stand-in as above; declared after `bv2` so it drops after.
+    pub arena_pool: Box<bun_bundler::ArenaPool>,
     /// Information BundleV2 needs to finalize the bundle
     pub start_data: bundler::bundle_v2::DevServerInput,
     /// Started when the bundle was queued
@@ -3109,48 +3113,32 @@ impl DevServer {
             server.on_pending_request();
         }
 
-        let heap = bun_alloc::MimallocArena::new();
-        // TODO(port): heap is moved into BundleV2; errdefer heap.deinit() handled by Drop
-        // PORT NOTE: `MimallocArena = bumpalo::Bump` (no `.arena()` accessor);
-        // `Bump::alloc` is the inherent method, and `BundleV2::init`'s `alloc`
-        // param is `&bun_alloc::Arena` (== `&Bump`).
-        // TODO(port): ASTMemoryAllocator scope — bake is an AST crate; arena threading required
-        // PORT NOTE: `heap.alloc` returns `&mut T` borrowing `heap`, but `heap` is
-        // later moved into `bv2.graph.heap`. Bumpalo chunk storage is heap-allocated
-        // and stable across the move of the `Bump` handle, so erase the borrow to a
-        // raw pointer (same rationale as `event_loop` below).
-        let ast_memory_store: *mut bun_ast::ASTMemoryAllocator =
-            heap.alloc(bun_ast::ASTMemoryAllocator::default());
-        // SAFETY: the `ASTMemoryAllocator` lives in a bumpalo chunk owned by
-        // `heap` → `bv2.graph.heap`; address is stable for the bv2 lifetime,
-        // and `_ast_scope` is dropped before `bv2` at end of this fn.
-        let _ast_scope = unsafe { &mut *ast_memory_store }.enter();
+        // Owns every per-worker arena plus `Graph.heap` for this bundle pass;
+        // moved into `CurrentBundle` below so it outlives `bv2`.
+        let arena_pool = Box::new(bun_bundler::ArenaPool::new());
+        // SAFETY: `arena_pool` is `Box`-allocated (stable address) and is
+        // moved into `self.current_bundle` below alongside `bv2`, so it
+        // outlives every `&ArenaPool` / `&Arena` derived here. Same `'static`
+        // stand-in as `CurrentBundle.bv2` (see PORT NOTE there) — DevServer is
+        // self-referential and cannot thread a real lifetime through.
+        let arena_pool_ref: &'static bun_bundler::ArenaPool =
+            unsafe { &*(&raw const *arena_pool) };
+        // One arena from the pool for the AST scratch store / event-loop slot
+        // and `BundleV2::init`'s short-lived `alloc` param. Lives until
+        // `arena_pool` drops with `CurrentBundle`.
+        let heap: &'static bun_alloc::Arena = arena_pool_ref.alloc();
+
+        let ast_memory_store = heap.alloc(bun_ast::ASTMemoryAllocator::default());
+        let _ast_scope = ast_memory_store.enter();
 
         // Zig: `.{ .js = dev.vm.eventLoop() }` constructed an `AnyEventLoop`
-        // by value; the Rust bundler instead stores
-        // `Option<NonNull<AnyEventLoop<'static>>>`. Park the value in `heap`
-        // — bumpalo chunks are heap-allocated, so the address is stable across
-        // the move of `heap` into `bv2.graph.heap` and lives exactly as long
-        // as `bv2`.
+        // by value; the Rust bundler stores `Option<NonNull<AnyEventLoop<'_>>>`.
+        // Parked in `heap` (pool-owned, lives as long as `bv2`).
         let event_loop: bun_bundler::linker_context_mod::EventLoop =
             Some(::core::ptr::NonNull::from(heap.alloc(
                 bun_event_loop::AnyEventLoop::js(self.vm().event_loop().cast()),
             )));
 
-        // PORT NOTE: `BundleV2::init` consumes `heap` and also wants
-        // `alloc: &Arena` derived from it. Zig's `heap.arena()` is a
-        // `Copy` vtable handle that survives the move; in Rust the `Bump` is
-        // moved into `bv2.graph.heap`, so any pre-move borrow would dangle.
-        // `BundleV2::init` itself re-derives `linker.graph.bump = &this.graph
-        // .heap` internally and only uses `alloc` for short-lived setup —
-        // pass the heap's address via raw pointer (it lives at a stable
-        // `Box`-interior slot once `init` writes it).
-        //
-        // SAFETY: `heap_ptr` is read by `BundleV2::init` only after `heap` is
-        // moved into `this.graph.heap` (same allocation, stable address inside
-        // the freshly-`Box::new`'d `BundleV2`). The borrow is scoped to the
-        // call; we never reuse `heap_ptr` after `init` returns.
-        let heap_ptr: *const bun_alloc::Arena = &raw const heap;
         // PORT NOTE: split `&mut self` into disjoint field reborrows so
         // `server_transpiler` (`&'a mut`) and `client/ssr_transpiler`
         // (NonNull) don't trip the single-`&mut self` rule.
@@ -3170,14 +3158,13 @@ impl DevServer {
                 },
                 plugins: self.bundler_options.plugin,
             }),
-            // SAFETY: see `heap_ptr` note above.
-            unsafe { &*heap_ptr },
+            heap,
             event_loop,
             false, // watching is handled separately
             Some(::core::ptr::NonNull::from(
                 bun_threading::work_pool::WorkPool::get(),
             )),
-            heap,
+            arena_pool_ref,
         )?;
         bv2.bun_watcher = Some(::core::ptr::NonNull::from(&mut **self.bun_watcher));
         bv2.asynchronous = true;
@@ -3210,6 +3197,7 @@ impl DevServer {
         drop(entry_points);
         self.current_bundle = Some(CurrentBundle {
             bv2,
+            arena_pool,
             timer,
             start_data,
             had_reload_event,
@@ -3689,10 +3677,10 @@ impl<'a> HotUpdateContext<'a> {
 
 /// Called at the end of BundleV2 to index bundle contents into the `IncrementalGraph`s
 /// This function does not recover DevServer state if it fails (allocation failure)
-pub fn finalize_bundle(
+pub fn finalize_bundle<'a>(
     dev: &mut DevServer,
-    bv2: &mut BundleV2,
-    result: &mut bundler::bundle_v2::DevServerOutput,
+    bv2: &mut BundleV2<'a>,
+    result: &mut bundler::bundle_v2::DevServerOutput<'a>,
 ) -> JsResult<()> {
     debug_assert!(dev.magic == Magic::Valid);
     // PORT NOTE: `had_sent_hmr_event` is read inside the outer-defer scopeguard
@@ -3715,15 +3703,14 @@ pub fn finalize_bundle(
         // SAFETY: `dev`/`bv2` are `&mut` params; both outlive this fn-scoped guard.
         let dev = unsafe { &mut *dev_ptr_outer };
         let bv2 = unsafe { &mut *bv2_ptr_outer };
-        // TODO(port): heap moved out before deinit
-        let mut heap = ::core::mem::replace(&mut bv2.graph.heap, bun_alloc::Arena::new());
         bv2.deinit_without_freeing_arena();
         if let Some(cb) = &mut dev.current_bundle {
             cb.promise.deinit_idempotently();
         }
+        // Drops `CurrentBundle.arena_pool`, which owns `bv2.graph.heap` and
+        // every worker arena for this pass.
         dev.current_bundle = None;
         dev.log.clear_and_free();
-        drop(heap);
 
         let _ = dev.assets.reindex_if_needed(); // not fatal
 

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -656,6 +656,7 @@ pub fn build_with_vm(
         // value (NOT a pointer-cast: the bundler matches on its discriminant).
         // Lives in this block's stack frame, outliving the bundle call.
         let mut any_loop = bun_event_loop::AnyEventLoop::js(vm.event_loop().cast());
+        let arena_pool = bun_bundler::ArenaPool::new();
 
         // Spec production.zig:312 — plain `try`; propagate via `?`. Do NOT
         // catch-and-exit here: the bake path expects this call to succeed for
@@ -672,6 +673,7 @@ pub fn build_with_vm(
                 plugins: options.bundler_options.plugin,
             },
             &options.arena,
+            &arena_pool,
             Some(NonNull::from(&mut any_loop)),
         )?
     };

--- a/src/runtime/cli/audit_command.rs
+++ b/src/runtime/cli/audit_command.rs
@@ -532,7 +532,7 @@ fn send_audit_request(
 
 fn parse_vulnerability(
     package_name: &[u8],
-    vuln: &Expr,
+    vuln: &Expr<'_>,
 ) -> Result<VulnerabilityInfo, bun_alloc::AllocError> {
     let mut vulnerability = VulnerabilityInfo {
         severity: Box::<[u8]>::from(b"moderate" as &[u8]),

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -571,10 +571,13 @@ impl BuildCommand {
             // owned by the arena. `generate_from_cli` → `wait_for_parse` derefs
             // this via `r#loop()` to drain parse tasks; passing `None` panics.
             let event_loop = arena.alloc(bun_event_loop::AnyEventLoop::init());
+            // Process-lifetime (matches `this_transpiler` — `exec` diverges).
+            let arena_pool: &bun_bundler::ArenaPool = arena.alloc(bun_bundler::ArenaPool::new());
 
             let build_result = match BundleV2::generate_from_cli(
                 this_transpiler,
                 arena,
+                arena_pool,
                 Some(core::ptr::NonNull::from(event_loop)),
                 ctx.debug.hot_reload == HotReload::Watch,
                 &mut reachable_file_count,

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -68,7 +68,7 @@ struct UnsupportedPackages {
 }
 
 impl UnsupportedPackages {
-    pub fn update(&mut self, expr: bun_ast::Expr) {
+    pub fn update(&mut self, expr: bun_ast::Expr<'_>) {
         for prop in expr
             .data
             .e_object()
@@ -914,8 +914,8 @@ impl CreateCommand {
                 //     }
                 // };
 
-                let mut dev_dependencies: Option<bun_ast::Expr> = None;
-                let mut dependencies: Option<bun_ast::Expr> = None;
+                let mut dev_dependencies: Option<bun_ast::Expr<'_>> = None;
+                let mut dependencies: Option<bun_ast::Expr<'_>> = None;
 
                 if let Some(q) = package_json_expr.as_property(b"devDependencies") {
                     let property = q.expr;
@@ -1154,7 +1154,7 @@ impl CreateCommand {
                         // InjectionPrefill.bun_macros_relay_only_object.properties = ...fromBorrowedSliceDangerous(&bun_macros_relay_only_object_properties);
                     }
 
-                    pub fn npx_react_scripts_build() -> bun_ast::Expr {
+                    pub fn npx_react_scripts_build<'arena>() -> bun_ast::Expr<'arena> {
                         // TODO(port): build bun_ast::Expr { .e_string = "npx react-scripts build" }
                         bun_ast::Expr::init(
                             bun_ast::E::EString::init(b"npx react-scripts build"),

--- a/src/runtime/cli/init_command.rs
+++ b/src/runtime/cli/init_command.rs
@@ -413,7 +413,8 @@ impl InitCommand {
         let mut package_json_contents: MutableString = MutableString::init_empty();
         bun_ast::initialize_store();
         // Arena for JSON parse / Expr building (Zig used the AST store).
-        let bump = bun_alloc::Arena::new();
+        // Process-lifetime CLI arena so `fields.object` (`'static`) can borrow it.
+        let bump: &'static bun_alloc::Arena = crate::cli::cli_arena();
         'read_package_json: {
             if let Some(pkg) = package_json_file.as_ref() {
                 let size: u64 = 'brk: {
@@ -477,19 +478,20 @@ impl InitCommand {
         let mut did_load_package_json = false;
         if !package_json_contents.list.is_empty() {
             'process_package_json: {
-                let source = bun_ast::Source::init_path_string(
-                    b"package.json",
-                    package_json_contents.list.as_slice(),
-                );
+                let source: &'static bun_ast::Source =
+                    bump.alloc(bun_ast::Source::init_path_string(
+                        b"package.json",
+                        package_json_contents.list.as_slice(),
+                    ));
                 let mut log = bun_ast::Log::init();
                 // PORT NOTE: bun_parsers::json builds the T2
                 // (bun_ast::js_ast) value tree to avoid a T2->T4 dep
                 // cycle; lift to the full T4 (bun_js_parser) tree here so
                 // the rest of exec can use E::Object::{put,put_string,
                 // get_or_put_object,...} which only exist at T4.
-                let package_json_expr: bun_ast::Expr =
-                    match json::parse_package_json_utf8(&source, &mut log, &bump) {
-                        Ok(e) => bun_ast::Expr::from(e),
+                let package_json_expr =
+                    match json::parse_package_json_utf8(source, &mut log, bump) {
+                        Ok(e) => e,
                         Err(_) => {
                             package_json_file = None;
                             break 'process_package_json;
@@ -675,23 +677,23 @@ impl InitCommand {
 
         if !minimal {
             if !fields.name.is_empty() {
-                object.put_string(&bump, b"name", &fields.name)?;
+                object.put_string(bump, b"name", &fields.name)?;
             }
             if !fields.entry_point.is_empty() {
                 if object.has_property(b"module") {
-                    object.put_string(&bump, b"module", &fields.entry_point)?;
-                    object.put_string(&bump, b"type", b"module")?;
+                    object.put_string(bump, b"module", &fields.entry_point)?;
+                    object.put_string(bump, b"type", b"module")?;
                 } else if object.has_property(b"main") {
-                    object.put_string(&bump, b"main", &fields.entry_point)?;
+                    object.put_string(bump, b"main", &fields.entry_point)?;
                 } else {
-                    object.put_string(&bump, b"module", &fields.entry_point)?;
-                    object.put_string(&bump, b"type", b"module")?;
+                    object.put_string(bump, b"module", &fields.entry_point)?;
+                    object.put_string(bump, b"type", b"module")?;
                 }
             }
 
             if fields.private {
                 object.put(
-                    &bump,
+                    bump,
                     b"private",
                     bun_ast::Expr::init(bun_ast::E::Boolean { value: true }, bun_ast::Loc::EMPTY),
                 )?;
@@ -771,9 +773,9 @@ impl InitCommand {
                         .data
                         .e_object_mut()
                         .unwrap()
-                        .put_string(&bump, dep.name, dep.version)?;
+                        .put_string(bump, dep.name, dep.version)?;
                 }
-                object.put(&bump, b"dependencies", dependencies_object)?;
+                object.put(bump, b"dependencies", dependencies_object)?;
             }
 
             if needs_dev_dependencies {
@@ -786,9 +788,9 @@ impl InitCommand {
                     obj.data
                         .e_object_mut()
                         .unwrap()
-                        .put_string(&bump, dep.name, dep.version)?;
+                        .put_string(bump, dep.name, dep.version)?;
                 }
-                object.put(&bump, b"devDependencies", obj)?;
+                object.put(bump, b"devDependencies", obj)?;
             }
 
             if needs_typescript_dependency {
@@ -796,16 +798,16 @@ impl InitCommand {
                     bun_ast::Expr::init(bun_ast::E::Object::default(), bun_ast::Loc::EMPTY)
                 });
                 peer_dependencies.data.e_object_mut().unwrap().put_string(
-                    &bump,
+                    bump,
                     b"typescript",
                     b"^5",
                 )?;
-                object.put(&bump, b"peerDependencies", peer_dependencies)?;
+                object.put(bump, b"peerDependencies", peer_dependencies)?;
             }
         }
 
         if template.is_react() {
-            template.write_to_package_json(&mut fields, &bump)?;
+            template.write_to_package_json(&mut fields, bump)?;
         }
 
         'write_package_json: {
@@ -1149,7 +1151,9 @@ pub struct PackageJSONFields {
     pub name: Vec<u8>,
     pub type_: &'static [u8],
     /// ARENA: allocated from `bun_ast::Expr` Store via `initialize_store()`; no deinit.
-    pub object: Option<StoreRef<bun_ast::E::Object>>,
+    // TRANSITIONAL: `'static` because the backing store is the thread-local
+    // AST store / a CLI-lifetime bump; the struct never outlives `exec()`.
+    pub object: Option<StoreRef<'static, bun_ast::E::Object<'static>>>,
     // TODO(port): Zig type was `[:0]const u8`; we drop the NUL sentinel and
     // re-terminate at FFI boundaries.
     pub entry_point: Vec<u8>,
@@ -1452,13 +1456,13 @@ impl Template {
         fields: &mut PackageJSONFields,
         bump: &bun_alloc::Arena,
     ) -> Result<(), Error> {
-        type Rope = bun_ast::E::Rope;
+        type Rope = bun_ast::E::Rope<'static>;
         fields.name = self.name().to_vec();
         // PORT NOTE: Zig `alloc.create(Rope)` against the default allocator and
         // never frees; allocate in the process-lifetime CLI arena instead.
         let key: &mut Rope = crate::cli::cli_arena().alloc(Rope {
             head: bun_ast::Expr::init(bun_ast::E::String::init(b"scripts"), bun_ast::Loc::EMPTY),
-            next: core::ptr::null_mut(),
+            next: None,
         });
         // SAFETY: object is arena-allocated and live for the command duration.
         let object = unsafe { &mut *fields.object.unwrap().as_ptr() };

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -1424,7 +1424,7 @@ fn iterate_project_tree(
 }
 
 fn get_bundled_deps(
-    json: &Expr,
+    json: &Expr<'_>,
     field: &'static str,
 ) -> Result<Option<Vec<BundledDep>>, AllocError> {
     let mut deps: Vec<BundledDep> = Vec::new();
@@ -1513,7 +1513,7 @@ struct BinInfo {
     ty: BinType,
 }
 
-fn get_package_bins(json: &Expr) -> Result<Vec<BinInfo>, AllocError> {
+fn get_package_bins(json: &Expr<'_>) -> Result<Vec<BinInfo>, AllocError> {
     let mut bins: Vec<BinInfo> = Vec::new();
 
     let mut path_buf = PathBuffer::uninit();
@@ -1732,7 +1732,7 @@ trait PackExprExt {
     fn pack_as_string(&self) -> Option<&[u8]>;
     fn pack_as_string_cloned(&self) -> Result<Option<Box<[u8]>>, AllocError>;
 }
-impl PackExprExt for Expr {
+impl PackExprExt for Expr<'_> {
     #[inline]
     fn pack_as_string(&self) -> Option<&[u8]> {
         self.as_utf8_string_literal()
@@ -2025,7 +2025,7 @@ pub fn pack<const FOR_PUBLISH: bool>(
         // maybe otp
     }
 
-    let mut package_name_expr: Expr = json
+    let mut package_name_expr: Expr<'_> = json
         .root
         .get(b"name")
         .ok_or(PackError::MissingPackageName)?;
@@ -2046,7 +2046,7 @@ pub fn pack<const FOR_PUBLISH: bool>(
         return Err(PackError::InvalidPackageName);
     }
 
-    let mut package_version_expr: Expr = json
+    let mut package_version_expr: Expr<'_> = json
         .root
         .get(b"version")
         .ok_or(PackError::MissingPackageVersion)?;

--- a/src/runtime/cli/pm_pkg_command.rs
+++ b/src/runtime/cli/pm_pkg_command.rs
@@ -41,9 +41,9 @@ impl SubCommand {
 }
 
 struct PackageJson {
-    root: Expr,
+    root: Expr<'static>,
     contents: Box<[u8]>,
-    source: Source,
+    source: &'static Source,
     indentation: bun_ast::Indentation,
 }
 
@@ -150,11 +150,12 @@ impl PmPkgCommand {
             }
         };
 
-        let source = Source::init_path_string(path, &contents[..]);
         // Zig passes the global allocator; use the process-lifetime CLI arena
         // so the returned `Expr` (which may reference arena-owned nodes)
         // outlives this frame. CLI is one-shot.
         let bump: &'static bun_alloc::Arena = crate::cli::cli_arena();
+        let source: &'static Source =
+            bump.alloc(Source::init_path_string(path, &contents[..]));
         let log: &mut Log = unsafe { ctx.log_mut() };
         // const generics mirror Zig `.{ .is_json, .allow_comments,
         // .allow_trailing_commas, .guess_indentation = true }` with the
@@ -168,7 +169,7 @@ impl PmPkgCommand {
             false, // JSON_WARN_DUPLICATE_KEYS
             false, // WAS_ORIGINALLY_MACRO
             true,  // GUESS_INDENTATION
-        >(&source, log, bump)
+        >(source, log, bump)
         {
             Ok(r) => r,
             Err(e) => {
@@ -177,11 +178,14 @@ impl PmPkgCommand {
             }
         };
 
+        let root = result.root.into();
+        let indentation = result.indentation;
+
         Ok(PackageJson {
-            root: result.root.into(),
+            root,
             contents,
             source,
-            indentation: result.indentation,
+            indentation,
         })
     }
 
@@ -432,7 +436,7 @@ impl PmPkgCommand {
         Ok(())
     }
 
-    fn format_json(expr: Expr, initial_indent: Option<usize>) -> Result<Box<[u8]>, Error> {
+    fn format_json(expr: Expr<'_>, initial_indent: Option<usize>) -> Result<Box<[u8]>, Error> {
         match &expr.data {
             ExprData::EBoolean(b) => Ok(Box::<[u8]>::from(if b.value {
                 &b"true"[..]
@@ -482,7 +486,7 @@ impl PmPkgCommand {
     }
 
     fn get_json_value(
-        root: Expr,
+        root: Expr<'_>,
         key: &[u8],
         initial_indent: Option<usize>,
     ) -> Result<Box<[u8]>, Error> {
@@ -490,7 +494,7 @@ impl PmPkgCommand {
         Self::format_json(expr, initial_indent)
     }
 
-    fn resolve_path(root: Expr, key: &[u8]) -> Result<Expr, Error> {
+    fn resolve_path<'arena>(root: Expr<'arena>, key: &[u8]) -> Result<Expr<'arena>, Error> {
         if !matches!(root.data, ExprData::EObject(_)) {
             return Err(err!("NotFound"));
         }
@@ -614,7 +618,7 @@ impl PmPkgCommand {
         Ok(path_parts)
     }
 
-    fn set_value(root: &mut Expr, key: &[u8], value: &[u8], parse_json: bool) -> Result<(), Error> {
+    fn set_value(root: &mut Expr<'_>, key: &[u8], value: &[u8], parse_json: bool) -> Result<(), Error> {
         if !matches!(root.data, ExprData::EObject(_)) {
             return Err(err!("InvalidRoot"));
         }
@@ -666,7 +670,7 @@ impl PmPkgCommand {
     }
 
     fn set_nested_simple(
-        root: &mut Expr,
+        root: &mut Expr<'_>,
         path: &[&[u8]],
         value: &[u8],
         parse_json: bool,
@@ -713,7 +717,7 @@ impl PmPkgCommand {
     }
 
     fn set_nested(
-        root: &mut Expr,
+        root: &mut Expr<'_>,
         path: &mut [Box<[u8]>],
         value: &[u8],
         parse_json: bool,
@@ -763,7 +767,7 @@ impl PmPkgCommand {
         Self::set_nested(&mut nested, remaining_path, value, parse_json)
     }
 
-    fn parse_value(value: &[u8], parse_json: bool) -> Result<Expr, Error> {
+    fn parse_value<'arena>(value: &[u8], parse_json: bool) -> Result<Expr<'arena>, Error> {
         if parse_json {
             if value == b"true" {
                 return Ok(Expr::init(E::Boolean { value: true }, Loc::EMPTY));
@@ -786,10 +790,11 @@ impl PmPkgCommand {
                 return Ok(Expr::init(E::Number { value: float_val }, Loc::EMPTY));
             }
 
-            let temp_source = Source::init_path_string(b"package.json", value);
+            let temp_source: &Source =
+                dummy_bump().alloc(Source::init_path_string(b"package.json", value));
             let mut temp_log = Log::init();
             if let Ok(json_expr) =
-                json::parse_package_json_utf8(&temp_source, &mut temp_log, dummy_bump())
+                json::parse_package_json_utf8(temp_source, &mut temp_log, dummy_bump())
             {
                 return Ok(json_expr.into());
             } else {
@@ -802,7 +807,7 @@ impl PmPkgCommand {
         }
     }
 
-    fn delete_value(root: &mut Expr, key: &[u8]) -> Result<bool, Error> {
+    fn delete_value(root: &mut Expr<'_>, key: &[u8]) -> Result<bool, Error> {
         if !matches!(root.data, ExprData::EObject(_)) {
             return Ok(false);
         }
@@ -827,7 +832,7 @@ impl PmPkgCommand {
         Self::delete_nested(root, &path_parts)
     }
 
-    fn delete_nested(root: &mut Expr, path: &[&[u8]]) -> Result<bool, Error> {
+    fn delete_nested(root: &mut Expr<'_>, path: &[&[u8]]) -> Result<bool, Error> {
         if path.is_empty() {
             return Ok(false);
         }
@@ -863,7 +868,7 @@ impl PmPkgCommand {
         Ok(deleted)
     }
 
-    fn remove_property(obj: &mut Expr, key: &[u8]) -> Result<bool, Error> {
+    fn remove_property(obj: &mut Expr<'_>, key: &[u8]) -> Result<bool, Error> {
         let ExprData::EObject(e_obj) = &mut obj.data else {
             return Ok(false);
         };
@@ -891,7 +896,7 @@ impl PmPkgCommand {
         // old buffer (CLI is one-shot — leak is intentional, see
         // load_package_json).
         let old = bun_alloc::AstAlloc::take(&mut e_obj.properties);
-        let mut new_props: G::PropertyList = G::PropertyList::init_capacity(old_len - 1);
+        let mut new_props: G::PropertyList<'_> = G::PropertyList::init_capacity(old_len - 1);
         for prop in old.slice() {
             if let Some(k) = &prop.key {
                 if let ExprData::EString(s) = &k.data {
@@ -910,7 +915,7 @@ impl PmPkgCommand {
         Ok(true)
     }
 
-    fn save_package_json(path: &[u8], root: Expr, pkg: &PackageJson) -> Result<(), Error> {
+    fn save_package_json(path: &[u8], root: Expr<'_>, pkg: &PackageJson) -> Result<(), Error> {
         let preserve_newline =
             !pkg.contents.is_empty() && pkg.contents[pkg.contents.len() - 1] == b'\n';
 
@@ -926,7 +931,7 @@ impl PmPkgCommand {
         if let Err(e) = js_printer::print_json(
             &mut writer,
             root,
-            &pkg.source,
+            pkg.source,
             js_printer::PrintJsonOptions {
                 indent: pkg.indentation,
                 mangled_props: None,

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -563,7 +563,7 @@ impl TrustCommand {
         // `js_printer::print_json` consume the T4 `bun_ast::Expr`. Lift
         // once via `From<T2> for T4` (same as `updatePackageJSONAndInstall` /
         // `pack_command`).
-        let mut package_json: bun_ast::Expr = match bun_parsers::json::parse_utf8(
+        let mut package_json: bun_ast::Expr<'_> = match bun_parsers::json::parse_utf8(
             &package_json_source,
             unsafe { ctx.log_mut() },
             &bump,

--- a/src/runtime/cli/pm_version_command.rs
+++ b/src/runtime/cli/pm_version_command.rs
@@ -127,6 +127,7 @@ impl PmVersionCommand {
         };
 
         let mut json = json_result.root;
+        let json_indentation = json_result.indentation;
 
         if !matches!(json.data, ExprData::EObject(_)) {
             Output::err_generic("Failed to parse package.json: root must be an object", ());
@@ -205,7 +206,7 @@ impl PmVersionCommand {
             let mut package_json_writer = JSPrinter::BufferPrinter::init(buffer_writer);
 
             // `bun_ast::Indentation` is the same type the printer consumes.
-            let printer_indent: bun_ast::Indentation = json_result.indentation;
+            let printer_indent: bun_ast::Indentation = json_indentation;
 
             if let Err(err) = JSPrinter::print_json(
                 &mut package_json_writer,

--- a/src/runtime/cli/pm_view_command.rs
+++ b/src/runtime/cli/pm_view_command.rs
@@ -61,7 +61,7 @@ pub fn view(
                 let Ok(pkg_json) = JSON::parse::<false>(source, &mut pkg_log, &bump) else {
                     break 'from_package_json;
                 };
-                let pkg_json: ast::Expr = pkg_json.into();
+                let pkg_json: ast::Expr<'_> = pkg_json.into();
                 if let Some(name) = pkg_json.get_string_cloned(&bump, b"name").ok().flatten() {
                     if !name.is_empty() {
                         break 'brk name;
@@ -151,7 +151,7 @@ pub fn view(
 
     let mut log = bun_ast::Log::init();
     let source = &bun_ast::Source::init_path_string(b"view.json", response_buf.list.as_slice());
-    let json: ast::Expr = match JSON::parse_utf8(source, &mut log, &bump) {
+    let json: ast::Expr<'_> = match JSON::parse_utf8(source, &mut log, &bump) {
         Ok(j) => j.into(),
         Err(err) => {
             Output::err(err, "failed to parse response body as JSON", ());
@@ -288,7 +288,7 @@ pub fn view(
             .e_object()
             .expect("infallible: variant checked");
         let props = versions_e_obj.properties.slice();
-        let mut keys: Vec<ast::Expr> = Vec::with_capacity(props.len());
+        let mut keys: Vec<ast::Expr<'_>> = Vec::with_capacity(props.len());
         debug_assert_eq!(props.len(), keys.capacity());
         for prop in props {
             keys.push(prop.key.expect("infallible: prop has key"));

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -39,7 +39,7 @@ use crate::api::bun_process::sync as spawn_sync;
 // its own `as_property` / `as_string_cloned` surface.
 #[inline]
 fn json_get_string_cloned<'b>(
-    expr: &bun_ast::Expr,
+    expr: &bun_ast::Expr<'_>,
     bump: &'b bun_alloc::Arena,
     name: &[u8],
 ) -> Result<Option<&'b [u8]>, AllocError> {
@@ -322,8 +322,8 @@ impl<'a, const DIRECTORY_PUBLISH: bool> Context<'a, DIRECTORY_PUBLISH> {
         let package_json_contents: &'static [u8] = crate::cli::cli_adopt(package_json_contents);
 
         let bump = bun_alloc::Arena::new();
+        let source = bun_ast::Source::init_path_string(b"package.json", package_json_contents);
         let (package_name, package_version, json, json_source) = {
-            let source = bun_ast::Source::init_path_string(b"package.json", package_json_contents);
             let log = manager.log_mut();
             let json = match json_mod::parse_package_json_utf8(&source, log, &bump) {
                 Ok(j) => j,
@@ -389,7 +389,7 @@ impl<'a, const DIRECTORY_PUBLISH: bool> Context<'a, DIRECTORY_PUBLISH> {
                 return Err(FromTarballError::InvalidPackageVersion);
             }
 
-            (name, version, json, source)
+            (name, version, json, &source)
         };
 
         let mut shasum: SHA1Digest = [0u8; sha::SHA1::DIGEST];
@@ -411,7 +411,7 @@ impl<'a, const DIRECTORY_PUBLISH: bool> Context<'a, DIRECTORY_PUBLISH> {
         // `WorkspacePackageJSONCache::get_with_path` applies before stashing
         // `MapEntry.root`. The thread-local `data::Store` has already been
         // initialised by `PackageManager::init`.
-        let mut json: Expr = Expr::from(json);
+        let mut json: Expr<'_> = Expr::from(json);
         let normalized_pkg_info = PublishCommand::normalized_package(
             manager,
             &package_name,
@@ -1422,7 +1422,7 @@ impl PublishCommand {
         manager: &mut PackageManager,
         package_name: &[u8],
         package_version: &[u8],
-        json: &mut Expr,
+        json: &mut Expr<'_>,
         json_source: &bun_ast::Source,
         shasum: SHA1Digest,
         integrity: SHA512Digest,
@@ -1493,7 +1493,7 @@ impl PublishCommand {
             }
         }
 
-        let mut dist_props: Vec<G::Property> = Vec::with_capacity(3);
+        let mut dist_props: Vec<G::Property<'_>> = Vec::with_capacity(3);
         dist_props.push(G::Property {
             key: Some(Expr::init(
                 E::String::init(b"integrity"),
@@ -1633,7 +1633,7 @@ impl PublishCommand {
     }
 
     fn normalize_bin(
-        json: &mut Expr,
+        json: &mut Expr<'_>,
         bump: &bun_alloc::Arena,
         package_name: &[u8],
         workspace_root: Fd,
@@ -1650,7 +1650,7 @@ impl PublishCommand {
         if let Some(bin_query) = json.as_property(b"bin") {
             match &bin_query.expr.data {
                 ExprData::EString(bin_str) => {
-                    let mut bin_props: Vec<G::Property> = Vec::new();
+                    let mut bin_props: Vec<G::Property<'_>> = Vec::new();
                     let normalized = strings::without_prefix_comptime_z(
                         normalize_buf_z::<path::platform::Posix>(
                             bin_str.string(bump)?,
@@ -1692,7 +1692,7 @@ impl PublishCommand {
                     ));
                 }
                 ExprData::EObject(bin_obj) => {
-                    let mut bin_props: Vec<G::Property> = Vec::new();
+                    let mut bin_props: Vec<G::Property<'_>> = Vec::new();
                     for bin_prop in bin_obj.properties.slice() {
                         let key: Option<Box<[u8]>> = 'key: {
                             if let Some(key) = &bin_prop.key {
@@ -1784,7 +1784,7 @@ impl PublishCommand {
                 let Some(bin_dir_str) = bin_query.expr.as_string(bump) else {
                     return Ok(());
                 };
-                let mut bin_props: Vec<G::Property> = Vec::new();
+                let mut bin_props: Vec<G::Property<'_>> = Vec::new();
                 let normalized_bin_dir = bun_core::ZBox::from_bytes(
                     strings::without_trailing_slash(strings::without_prefix(
                         normalize_buf::<path::platform::Posix>(bin_dir_str, &mut *path_buf),

--- a/src/runtime/cli/test/ChangedFilesFilter.rs
+++ b/src/runtime/cli/test/ChangedFilesFilter.rs
@@ -162,10 +162,14 @@ pub fn filter<'a>(
     // Zig: `jsc.AnyEventLoop.init(allocator)` — Mini loop that
     // `wait_for_parse` ticks to drain parse tasks; `None` panics there.
     let event_loop = arena.alloc(bun_event_loop::AnyEventLoop::init());
+    // Process-lifetime (matches `scan_transpiler`; intentionally leaked per
+    // the CLI arena note above).
+    let arena_pool: &bun_bundler::ArenaPool = arena.alloc(bun_bundler::ArenaPool::new());
 
     let bundle = match BundleV2::scan_module_graph_from_cli(
         scan_transpiler,
         arena,
+        arena_pool,
         Some(core::ptr::NonNull::from(event_loop)),
         &entry_points,
     ) {

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -2298,7 +2298,7 @@ fn leak_dup(bytes: &[u8]) -> &'static [u8] {
 // parameter is dropped to keep `update_catalog_definitions` borrowck-clean.
 pub fn edit_catalog_definitions(
     updates: &mut [CatalogUpdateRequest],
-    current_package_json: &mut Expr,
+    current_package_json: &mut Expr<'_>,
 ) -> Result<(), bun_core::Error> {
     // using data store is going to result in undefined memory issues as
     // the store is cleared in some workspace situations. the solution
@@ -2343,10 +2343,10 @@ enum CatalogSource {
 /// Find the `StoreRef<E::Object>` for `package_json[.workspaces].<key>`, or
 /// `None` if absent / not an object. Mirrors the labeled-block lookup in
 /// updateDefaultCatalog/updateNamedCatalog.
-fn find_catalog_object(
-    package_json: &Expr,
+fn find_catalog_object<'arena>(
+    package_json: &Expr<'arena>,
     key: &[u8],
-) -> (Option<bun_ast::StoreRef<E::Object>>, CatalogSource) {
+) -> (Option<bun_ast::StoreRef<'arena, E::Object<'arena>>>, CatalogSource) {
     if let Some(workspaces_query) = package_json.as_property(b"workspaces") {
         if workspaces_query.expr.is_object() {
             if let Some(q) = workspaces_query.expr.as_property(key) {
@@ -2366,7 +2366,7 @@ fn find_catalog_object(
 
 fn update_default_catalog(
     bump: &Bump,
-    package_json: &mut Expr,
+    package_json: &mut Expr<'_>,
     package_name: &[u8],
     new_version: &[u8],
 ) -> Result<(), bun_core::Error> {
@@ -2456,7 +2456,7 @@ fn update_default_catalog(
 
 fn update_named_catalog(
     bump: &Bump,
-    package_json: &mut Expr,
+    package_json: &mut Expr<'_>,
     catalog_name: &[u8],
     package_name: &[u8],
     new_version: &[u8],
@@ -2478,7 +2478,7 @@ fn update_named_catalog(
 
         // Get or create the specific catalog
         let mut fresh_catalog = E::Object::default();
-        let existing_catalog: Option<bun_ast::StoreRef<E::Object>> = catalogs_obj
+        let existing_catalog: Option<bun_ast::StoreRef<'_, E::Object<'_>>> = catalogs_obj
             .get(catalog_name)
             .and_then(|e| e.data.e_object());
         let catalog_obj: &mut E::Object = match existing_catalog {

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -563,12 +563,12 @@ pub mod BunInfo {
     }
 
     #[inline]
-    fn str_expr(s: &[u8]) -> Expr {
+    fn str_expr<'arena>(s: &[u8]) -> Expr<'arena> {
         Expr::init(EString::init(s), Loc::EMPTY)
     }
 
     #[inline]
-    fn prop(key: &'static [u8], value: Expr) -> G::Property {
+    fn prop<'arena>(key: &'static [u8], value: Expr<'arena>) -> G::Property<'arena> {
         G::Property {
             key: Some(str_expr(key)),
             value: Some(value),
@@ -579,7 +579,7 @@ pub mod BunInfo {
     /// Zig: `pub fn generate(comptime Bundler: type, _: Bundler, allocator) !JSAst.Expr`.
     /// `Bundler` is an unused comptime witness; `allocator` maps onto the
     /// global expr `Store` used by `Expr::init`.
-    pub fn generate<B>(_transpiler: B) -> Result<Expr, bun_core::Error> {
+    pub fn generate<'arena, B>(_transpiler: B) -> Result<Expr<'arena>, bun_core::Error> {
         let info = BunInfo {
             bun_version: Global::package_json_version.as_bytes(),
             platform: generate_platform::for_os(),


### PR DESCRIPTION
## What

Threads a real `'arena` lifetime through `StoreRef`/`StoreSlice`/`StoreStr` and the ~160 AST types that contain them (`Expr<'arena>`, `Stmt<'arena>`, `Ast<'arena>`, all `E::*`/`S::*`/`G::*`/`B::*` payloads, `Scope`, `Symbol`, …), then through the bundler via a new `ArenaPool` so `Graph<'a>` holds `BundledAst<'a>` without lifetime erasure.

## Why

`StoreRef<T>` was `Copy` + safe `DerefMut` over a lifetime-erased `NonNull<T>` — use-after-arena-reset was undetectable, and the type was unsound (two copies could produce aliased `&mut T` in safe code). The existing comment at `nodes.rs` already flagged "that cascade is the follow-up round once `StoreRef` itself carries `'arena`" — this is that round.

## Result

| Metric | |
|---|---|
| `cargo check --workspace` | 0 errors |
| Net `unsafe` keyword | **−3** (45 add / 48 del) |
| Net `transmute` | +3 (see below) |
| Struct layouts | unchanged — `size_of::<Expr>() == 24`, `StoreRef` pointer-sized, `NonNull` niche preserved (const-asserted) |

The −3 net is real: threading the lifetime made several pre-existing `detach_lifetime_ref` / open-coded `&mut *` derefs unnecessary.

## Key changes

- **`StoreRef<'arena, T>` / `StoreSlice<'arena, T>` / `StoreStr<'arena>`** — covariant `PhantomData<&'arena T>`; `#[repr(transparent)]` kept; covariance proven by const-fn assertions
- **`*mut T<'arena>` → `NonNull<T<'arena>>`** in `Rope::next`, `Part::scopes`, `AstBuilder::scopes`, `P::scopes_for_current_part` — restores covariance (raw `*mut` is invariant)
- **`ArenaPool`** (`src/bundler/arena_pool.rs`) — `boxcar::Vec<MimallocArena>`, lock-free append-only, stable addresses, zero unsafe; replaces `Worker`'s self-referential `heap` + `BackRef` and the `erase_ast_arena`/`erase_bundled_ast_arena` transmutes
- **Parser `<'arena, 'log>` split** — JSON/TOML/INI/js_parser results no longer spuriously borrow `&mut Log`; deleted ~30 `detach_expr` workarounds
- **`Renamer` `&mut` → `&`** — printer never wrote through it; with `SymbolSlotList` newtype (EnumMap was invariant), `Renamer` is now covariant and `ChunkRenamer::as_renamer` lost its transmute
- **`js_printer::print_ast` signature relaxed** — `tree: &'a Ast<'a>` → `tree: &Ast<'a>` decouples the outer borrow from the arena lifetime

## Remaining 3 transmutes (centralized, documented)

All the same shape — a long-lived owner holding both an arena and an `Expr` borrowing it as sibling fields:

| File | Why |
|---|---|
| `WorkspacePackageJSONCache.rs` | `MapEntry { json_arena, root: Expr }` cache entry — self-referential |
| `transpiler.rs` `erase_ast_arena_for_runtime` | `JSTranspiler` is a JS GC object owning arena + `ParseResult` — no outer Rust lifetime to hoist into |
| `defines.rs` | `deep_clone` shallow-copies `Str<'arena>` slices, so result still borrows source — needs body fix to copy strings into dst bump |

Each is one helper fn with a SAFETY comment; follow-up is `self_cell` or another lifetime cascade.

## New dep

`boxcar = "0.2"` — lock-free append-only `Vec` with stable element addresses (used by `ArenaPool`).