### PR TITLE
Bun.serve: finish h3/h1 → http3/http1 ServerConfig rename in Rust

### DIFF
--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -57,8 +57,8 @@ pub struct ServerConfig {
     pub id: Box<[u8]>,
     pub allow_hot: bool,
     pub ipv6_only: bool,
-    pub h3: bool,
-    pub h1: bool,
+    pub http3: bool,
+    pub http1: bool,
 
     pub is_node_http: bool,
     pub had_routes_object: bool,
@@ -91,8 +91,8 @@ impl Default for ServerConfig {
             id: Box::default(),
             allow_hot: true,
             ipv6_only: false,
-            h3: false,
-            h1: true,
+            http3: false,
+            http1: true,
             is_node_http: false,
             had_routes_object: false,
             static_routes: Vec::new(),
@@ -282,7 +282,7 @@ impl ServerConfig {
         // Rust cannot alias owned Vec/Box/Strong; instead move every owning
         // field into `that` and leave the Copy scalars in place on `self` —
         // matching Zig's observable post-state for `self` (idle_timeout,
-        // development, reuse_port, h1/h3, etc. retained; resources gone) and
+        // development, reuse_port, http1/http3, etc. retained; resources gone) and
         // ensuring the assignment-drop of the residual `self` is a no-op.
         let mut that = ServerConfig {
             address: core::mem::take(&mut self.address),
@@ -305,8 +305,8 @@ impl ServerConfig {
             id: core::mem::take(&mut self.id),
             allow_hot: self.allow_hot,
             ipv6_only: self.ipv6_only,
-            h3: self.h3,
-            h1: self.h1,
+            http3: self.http3,
+            http1: self.http1,
             is_node_http: self.is_node_http,
             had_routes_object: self.had_routes_object,
             static_routes: core::mem::take(&mut self.static_routes),
@@ -1265,14 +1265,14 @@ impl ServerConfig {
         }
 
         if let Some(v) = arg.get(global, "http3")? {
-            args.h3 = v.to_boolean();
+            args.http3 = v.to_boolean();
         }
         if global.has_exception() {
             return Err(JsError::Thrown);
         }
 
         if let Some(v) = arg.get(global, "http1")? {
-            args.h1 = v.to_boolean();
+            args.http1 = v.to_boolean();
         }
         if global.has_exception() {
             return Err(JsError::Thrown);
@@ -1409,18 +1409,18 @@ impl ServerConfig {
             }
         }
 
-        if args.h3 {
+        if args.http3 {
             if args.ssl_config.is_none() {
                 return Err(
                     global.throw_invalid_arguments(format_args!("HTTP/3 requires 'tls' to be set"))
                 );
             }
-        } else if !args.h1 {
+        } else if !args.http1 {
             return Err(global.throw_invalid_arguments(format_args!(
                 "Cannot disable http1 without enabling http3"
             )));
         }
-        if !args.h1 && matches!(args.address, Address::Unix(_)) {
+        if !args.http1 && matches!(args.address, Address::Unix(_)) {
             return Err(global.throw_invalid_arguments(format_args!(
                 "Cannot disable http1 with a unix socket — HTTP/3 over AF_UNIX is not supported",
             )));

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -276,7 +276,7 @@ pub struct NewServer<const SSL: bool, const DEBUG: bool> {
     pub pending_requests: usize,
     pub request_pool: *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, false>,
     /// Zig: `if (has_h3) *H3RequestContext.RequestContextStackAllocator else void`.
-    /// Null until the H3 listen path runs (`HAS_H3 && config.h3`); never
+    /// Null until the H3 listen path runs (`HAS_H3 && config.http3`); never
     /// allocated when `!SSL`. Kept as a raw nullable pointer rather than a
     /// conditional field so the struct stays uniform across monomorphizations.
     pub h3_request_pool: *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, true>,
@@ -1870,7 +1870,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             // Zig gates this on `comptime has_h3` (server.zig:1827) so plain
             // HTTP servers never allocate the ~816 KB H3 pool. We go one step
             // further and defer to the H3-listen path (`listen()` below) so
-            // HTTPS servers that don't enable `config.h3` don't pay either.
+            // HTTPS servers that don't enable `config.http3` don't pay either.
             h3_request_pool: core::ptr::null_mut(),
             all_closed_promise: jsc::JSPromiseStrong::default(),
             listen_callback: jsc::AnyTask::AnyTask {
@@ -2455,7 +2455,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             };
             unsafe { (*this).app = Some(app) };
 
-            if Self::HAS_H3 && this_ref.config.h3 {
+            if Self::HAS_H3 && this_ref.config.http3 {
                 let idle_timeout = this_ref.config.idle_timeout as u32;
                 let h3 = match uws_sys::h3::App::create(ssl_options, idle_timeout) {
                     Some(a) => Some(a),
@@ -2629,7 +2629,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             Tcp { port: u16, host: *const c_char },
             Unix { ptr: *const u8, len: usize },
         }
-        let (addr, h1, options) = {
+        let (addr, http1, options) = {
             let cfg = &this_ref.get().config;
             let addr = match &cfg.address {
                 server_config::Address::Tcp { port, hostname } => {
@@ -2653,19 +2653,19 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     len: unix.as_bytes().len(),
                 },
             };
-            (addr, cfg.h1, cfg.get_usockets_options())
+            (addr, cfg.http1, cfg.get_usockets_options())
         };
 
         match addr {
             Addr::Tcp { port, host } => {
                 // diverges from Zig: makes port:0 reliable for H3.
-                // With `{port: 0, h3: true}` we bind TCP:0 (kernel picks N),
+                // With `{port: 0, http3: true}` we bind TCP:0 (kernel picks N),
                 // then must bind UDP:N for QUIC so Alt-Svc works. UDP:N may
                 // already be held by an unrelated process. When the user asked
                 // for "any port" (0), close TCP:N and retry the whole TCP+UDP
                 // bind so the kernel picks a fresh N. Never retry a
                 // user-specified non-zero port.
-                let max_attempts: u8 = if Self::HAS_H3 && h1 && port == 0 {
+                let max_attempts: u8 = if Self::HAS_H3 && http1 && port == 0 {
                     3
                 } else {
                     1
@@ -2673,7 +2673,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 let mut attempt: u8 = 0;
                 loop {
                     attempt += 1;
-                    if h1 {
+                    if http1 {
                         // SAFETY: app is a live uws handle owned by this server. No
                         // `&*this` is live across this call; the trampoline's
                         // `&mut *this` is the sole borrow while it runs.
@@ -2736,7 +2736,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                                     // deinit + return ZERO.
                                 }
                             }
-                            if !this_ref.config.h1 {
+                            if !this_ref.config.http1 {
                                 // SAFETY: per-thread VM singleton; no aliasing `&mut`.
                                 jsc::VirtualMachine::get().as_mut().event_loop_handle =
                                     Some(bun_io::Loop::get());
@@ -2753,7 +2753,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         // advertise it; drop the H3 listener instead of wiring
                         // an exotic transport nobody can reach.
                         bun_core::Output::warn(format_args!(
-                            "h3: true with a unix socket — HTTP/3 listener skipped"
+                            "http3: true with a unix socket — HTTP/3 listener skipped"
                         ));
                         // SAFETY: h3a is a live H3::App handle just taken from self.h3_app.
                         unsafe { uws_sys::h3::App::destroy(h3a) };

--- a/src/uws_sys/quic/Context.rs
+++ b/src/uws_sys/quic/Context.rs
@@ -1,6 +1,6 @@
 //! `us_quic_socket_context_t` — one lsquic engine + its event-loop wiring.
 //! For the client there is exactly one of these per HTTP-thread loop and it
-//! lives for the process; the server creates one per `Bun.serve({h3:true})`.
+//! lives for the process; the server creates one per `Bun.serve({http3:true})`.
 
 use core::ffi::{CStr, c_char, c_int, c_uint, c_void};
 

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -460,6 +460,26 @@ describe("Bun.serve HTTP/3", () => {
     expect(stderr.toLowerCase()).toContain("http1");
     expect(exitCode).not.toBe(0);
   });
+
+  test("validation: http3 with unix socket warns and skips H3 listener", async () => {
+    using dir = tempDir("serve-http3-unix", {});
+    const sock = join(String(dir), "h3.sock");
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `using s = Bun.serve({ unix: ${JSON.stringify(sock)}, tls: ${JSON.stringify(tls)}, http3: true, fetch: () => new Response("x") }); console.log("listening");`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("http3: true with a unix socket — HTTP/3 listener skipped");
+    expect(stderr).not.toContain("h3: true");
+    expect(stdout).toContain("listening");
+    expect(exitCode).toBe(0);
+  });
 });
 
 // Cases ported from h2o t/40http3 and aioquic interop. Each test gets its own


### PR DESCRIPTION
The Rust port of #30583 covered the user-facing JS option names (`"http3"`/`"http1"`) and validation error messages, but left the internal `ServerConfig` struct fields as `h3`/`h1` and one stderr warning string as `"h3: true with a unix socket — HTTP/3 listener skipped"`.

This finishes the rename:

- `ServerConfig::{h3,h1}` → `{http3,http1}` (fields, defaults, clone, all reads in `ServerConfig.rs`/`mod.rs`)
- unix-socket warning string `"h3: true ..."` → `"http3: true ..."`
- doc comments in `mod.rs` and `uws_sys/quic/Context.rs`

Transport-layer names (`uws_sys::h3::`, `h3_app`, `on_h3_listen`, `AnyRequest::H1`, `HTTPClient.h3`) are left as-is, matching #30583.

Adds `serve-http3.test.ts` → `validation: http3 with unix socket warns and skips H3 listener` to cover the warning text.