### PR TITLE
jsc: gate CallFrame::describe_frame on debug_assertions

### DIFF
--- a/src/jsc/CallFrame.rs
+++ b/src/jsc/CallFrame.rs
@@ -1,10 +1,11 @@
 use alloc::borrow::Cow;
-use core::ffi::{c_char, c_uint, c_void};
+use core::ffi::{c_uint, c_void};
 use core::marker::{PhantomData, PhantomPinned};
 
 use crate::virtual_machine::VirtualMachine;
 use crate::{JSGlobalObject, JSValue, VM};
 use bun_collections::IntegerBitSet;
+#[cfg(debug_assertions)]
 use bun_core::ZStr;
 
 #[allow(deprecated)]
@@ -185,6 +186,7 @@ impl CallFrame {
         CallerSrcLoc { str, line, column }
     }
 
+    #[cfg(debug_assertions)]
     pub fn describe_frame(&self) -> &ZStr {
         // SAFETY: FFI returns a NUL-terminated C string with lifetime tied to the frame.
         unsafe {
@@ -433,7 +435,8 @@ unsafe extern "C" {
         out_line: &mut c_uint,
         out_column: &mut c_uint,
     );
-    fn Bun__CallFrame__describeFrame(cf: *const CallFrame) -> *const c_char;
+    #[cfg(debug_assertions)]
+    fn Bun__CallFrame__describeFrame(cf: *const CallFrame) -> *const core::ffi::c_char;
 }
 
 // ported from: src/jsc/CallFrame.zig


### PR DESCRIPTION
`Bun__CallFrame__describeFrame` is only compiled into the C++ side under `#if ASSERT_ENABLED` (bindings.cpp), since `JSC::CallFrame::describeFrame()` itself is debug-only in JavaScriptCore. The Rust `extern` declared it unconditionally.

With Cargo's default `lto = "fat"` the dead `pub fn` is DCE'd in release, but `scripts/build/rust.ts` disables Cargo LTO for `cfg.asan` and `cfg.crossLangLto` builds. In those configs the reference survives in `bun_jsc`'s object file, and on Windows release the link fails:

```
lld-link: error: undefined symbol: Bun__CallFrame__describeFrame
```

(Linux/macOS happen to GC it via `--gc-sections` / `-dead_strip`.)

The only caller, `btjs::print_source_at_address`, is already `#[cfg(debug_assertions)]`, so gate the wrapper and FFI import the same way. Also cfg-gate the now-debug-only `ZStr` import and inline `c_char` to keep release builds warning-free.