### PR TITLE
ffi: cfg-gate local tcc_delete extern to match bun_tcc_sys

### DIFF
--- a/src/runtime/ffi/mod.rs
+++ b/src/runtime/ffi/mod.rs
@@ -118,10 +118,24 @@ mod TCC {
         pub struct State;
     }
     // Raw extern so the handle can be freed even while the method-ful
-    // `bun_tcc_sys::State` API stays gated.
+    // `bun_tcc_sys::State` API stays gated. Keep this predicate in sync with
+    // `bun_tcc_sys::tcc_externs!` / `cfg.tinycc` in `scripts/build/config.ts`.
     // TODO(port): move to <area>_sys
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "freebsd",
+        all(windows, target_arch = "aarch64")
+    )))]
     unsafe extern "C" {
         pub fn tcc_delete(s: *mut State);
+    }
+    #[cfg(any(
+        target_os = "android",
+        target_os = "freebsd",
+        all(windows, target_arch = "aarch64")
+    ))]
+    pub unsafe fn tcc_delete(_s: *mut State) {
+        unreachable!("tcc_delete: TinyCC not built on this target (cfg.tinycc = false)");
     }
 }
 


### PR DESCRIPTION
`src/runtime/ffi/mod.rs` declares its own unconditional `extern "C" { fn tcc_delete }`, separate from `bun_tcc_sys::tcc_externs!` which correctly cfg-gates the libtcc externs on `cfg.tinycc` (= NOT android / freebsd / windows-aarch64, where `libtcc.a` isn't built).

`Function::drop` calls it inside `if let Some(state)` — `state` is never `Some` on those targets so the call is dead at runtime, but with cargo LTO overridden off (asan / linker-plugin-lto path in `rust.ts`) the symbol reference survives into the staticlib and link fails:

```
lld-link: error: undefined symbol: tcc_delete
```

Gate the local extern on the same predicate as `tcc_externs!` and provide an `unreachable!()` stub on the disabled targets, mirroring what `src/tcc_sys/tcc.rs` already does.