### PR TITLE
transpiler: fix use-after-free in async transform() error path

### DIFF
--- a/src/runtime/api/JSTranspiler.zig
+++ b/src/runtime/api/JSTranspiler.zig
@@ -495,6 +495,17 @@ pub const TransformTask = struct {
         var arena = MimallocArena.init();
         defer arena.deinit();
 
+        // Log message text/notes may be allocated in the arena by the parser.
+        // Deep-copy them into default_allocator before the arena is freed so
+        // `then()` can safely read them on the JS thread.
+        defer if (this.log.msgs.items.len > 0) {
+            var cloned = logger.Log.init(bun.default_allocator);
+            cloned.level = this.log.level;
+            this.log.cloneToWithRecycled(&cloned, true) catch {};
+            this.log.msgs.clearAndFree();
+            this.log = cloned;
+        };
+
         const allocator = arena.allocator();
         var ast_memory_allocator = bun.handleOom(allocator.create(JSAst.ASTMemoryAllocator));
         var ast_scope = ast_memory_allocator.enter(allocator);

--- a/test/js/bun/transpiler/transpiler-async-error-uaf.test.ts
+++ b/test/js/bun/transpiler/transpiler-async-error-uaf.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// `TransformTask.run()` parses with an arena allocator and frees it before
+// `then()` runs on the JS thread. Error messages whose text was allocated in
+// the arena used to be read after the arena was freed.
+test("concurrent async transform() rejections do not read freed arena memory", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const t = new Bun.Transpiler();
+        const ps = [];
+        for (let i = 0; i < 200; i++) {
+          ps.push(
+            t.transform("const @@@ x = {{{{{ !!!! import export from }}}}}").then(
+              () => { throw new Error("should have rejected"); },
+              e => {
+                String(e);
+                for (const err of e?.errors ?? []) String(err);
+                return e;
+              },
+            ),
+          );
+        }
+        const results = await Promise.all(ps);
+        const e = results[0];
+        if (!e || e.name !== "AggregateError") throw new Error("expected AggregateError, got " + e);
+        if (!Array.isArray(e.errors) || e.errors.length === 0) throw new Error("expected errors array");
+        if (!String(e.errors[0]).includes("Expected identifier"))
+          throw new Error("unexpected first error: " + String(e.errors[0]));
+        console.log("ok", e.errors.length);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toMatch(/^ok \d+$/);
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

`Bun.Transpiler#transform()` (async) could read freed arena memory when the parse produced errors, tripping an ASAN use-after-poison in debug builds.

## Why

`TransformTask.run()` runs the parser on a worker thread using a local `MimallocArena` as the transpiler allocator, then frees the arena on return. The parser/lexer allocate error-message **text** and **notes** with that arena allocator. Those `Msg`s are shallow-copied into `TransformTask.log` (only the outer `msgs` list uses `bun.default_allocator`).

When `then()` later runs on the JS thread and calls `this.log.toJS()` → `BuildMessage.create` → `Msg.clone` → `Data.clone`, it `dupe`s the arena-backed text after the arena is already freed.

```
#1 mem.Allocator.dupe
#2 logger.Data.clone              logger.zig:232
#3 logger.Msg.clone               logger.zig:416
#4 BuildMessage.create            BuildMessage.zig:54
#5 logger_jsc.logToJS             logger_jsc.zig:59
#6 JSTranspiler.TransformTask.then JSTranspiler.zig:572
```

## How

Add a `defer` in `TransformTask.run()` (ordered before `arena.deinit()`) that deep-copies any log messages into `bun.default_allocator` via `cloneToWithRecycled(&cloned, true)`, so `then()` reads stable memory.

## Repro

```js
const t = new Bun.Transpiler();
const ps = [];
for (let i = 0; i < 200; i++) {
  ps.push(t.transform("const @@@ x = {{{{{ !!!! import export from }}}}}").catch(e => {
    String(e);
    for (const err of e?.errors ?? []) String(err);
  }));
}
await Promise.all(ps);
```

Found by Fuzzilli.