### PR TITLE
bunx: forward --minimum-release-age to spawned bun add

### DIFF
--- a/docs/snippets/cli/bunx.mdx
+++ b/docs/snippets/cli/bunx.mdx
@@ -29,6 +29,12 @@ Execute an npm package executable (CLI). If the package isn't installed in `node
   Suppress output during installation
 </ParamField>
 
+<ParamField path="--minimum-release-age" type="number">
+  Only install packages published at least N seconds ago. Supply-chain defense: skips versions that are newer than the
+  threshold. A warm `bunx` cache is treated as stale whenever this flag is set to a positive value, so a previous cached
+  install can never bypass the gate. Set to `0` to disable the age gate and leave the cache untouched.
+</ParamField>
+
 ### Examples
 
 ```bash terminal icon="terminal"

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -1205,14 +1205,9 @@ impl BunxCommand {
                             bun_output::scoped_log!(bunx, "found stale binary: {}", BStr::new(out));
                             do_cache_bust = true;
                             if opts.no_install {
-                                // `--no-install` normally falls through to run
-                                // the stale cached binary with a warning. But
-                                // `--minimum-release-age` is a supply-chain
-                                // gate: running the cached binary would
-                                // silently bypass it, because re-resolution
-                                // (where the filter is applied) is what
-                                // `--no-install` specifically opts out of.
-                                // Refuse to run instead.
+                                // Running the stale cached binary under an
+                                // active age gate would silently bypass the
+                                // filter; refuse instead of falling through.
                                 if age_gate_forces_refresh {
                                     Output::err_generic(
                                         "Cannot use <b>--no-install<r> with <b>--minimum-release-age<r>: the cached binary for <b>{}<r> cannot be re-verified under the age gate without resolving a new version. Drop <b>--no-install<r> to allow re-resolution.",

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -156,8 +156,6 @@ impl Options {
                     }
                     opts.specified_package = Some(package_value);
                 } else if positional == b"--minimum-release-age" {
-                    // Spaced form: `--minimum-release-age <N>`.
-                    // Stored verbatim; `bun add` re-parses and validates.
                     i += 1;
                     if i >= argv.len() || argv[i].as_bytes().is_empty() {
                         Output::err_generic(
@@ -1489,8 +1487,6 @@ impl BunxCommand {
             args.append(b"--silent").expect("unreachable"); // upper bound is known
         }
 
-        // `min_age_combined` was built above (before `args`); append its slice
-        // when the flag was set. `bun add` re-parses and validates the value.
         if opts.minimum_release_age.is_some() {
             args.append(min_age_combined.as_slice())
                 .expect("unreachable"); // upper bound is known
@@ -1668,9 +1664,7 @@ impl BunxCommand {
                 bunx_cache_dir,
                 result_package_name,
                 false,
-                // Post-install — the freshly installed cache was resolved
-                // under the active age filter (or its absence), no need to
-                // force stale here.
+                // force_stale: freshly installed, already resolved under the gate.
                 false,
             ) {
                 if !strings::eql_long(&package_name_for_bin, initial_bin_name, true) {

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -57,9 +57,8 @@ pub struct Options {
     /// already downloaded. If its not, `bunx` exits with an error.
     pub(crate) no_install: bool,
     /// Raw value of `--minimum-release-age=<N>`, forwarded verbatim to the
-    /// spawned `bun add` so the same validation path runs. Stored as the
-    /// opaque argv slice (borrowed from `argv`) to avoid re-parsing the
-    /// number here.
+    /// spawned `bun add` so the same validation path runs (stored as the
+    /// opaque argv slice).
     pub(crate) minimum_release_age: Option<&'static [u8]>,
 }
 
@@ -234,13 +233,9 @@ impl Options {
         Ok(opts)
     }
 
-    /// Whether `--minimum-release-age=<N>` represents an active supply-chain
-    /// gate. A value of `0` (the documented disable spelling — see the
-    /// `handles 0 value to disable` test in `minimum-release-age.test.ts`)
-    /// is treated as "no gate"; we avoid forcing cache re-resolution or
-    /// hard-erroring `--no-install` in that case. Unparseable or negative
-    /// values are rejected in `validate_minimum_release_age` before parse
-    /// returns, so we never see them here.
+    /// Whether `--minimum-release-age=<N>` is an active supply-chain gate.
+    /// `0` is the documented disable spelling and means "no gate"; invalid
+    /// values were already rejected by `validate_minimum_release_age`.
     fn has_active_age_gate(&self) -> bool {
         match self.minimum_release_age {
             None => false,
@@ -248,16 +243,9 @@ impl Options {
         }
     }
 
-    /// Match `bun add`'s validation of `--minimum-release-age=<N>` (see
-    /// `CommandLineArguments.rs`'s handler): reject non-numeric values and
-    /// negative numbers with the same message, before bunx does any
-    /// filesystem mutation (the install-path cache wipe, the `force_stale`
-    /// cache wipe inside `get_bin_name_from_temp_directory`). Without this,
-    /// an unparseable or negative value like `--minimum-release-age=abc`
-    /// or `=-5` would wipe a fresh cache before `bun add` reports the
-    /// parse error. (Note: `parse_double` is a prefix-match parser, so a
-    /// value like `7d` is accepted as `7` here and by `bun add` — same
-    /// behavior, intentional.)
+    /// Match `bun add`'s validation of `--minimum-release-age=<N>`: reject
+    /// non-numeric and negative values with the same message, before bunx
+    /// mutates the filesystem (the cache wipes must not run on bad values).
     fn validate_minimum_release_age(value: &[u8]) {
         match bun_core::parse_double(value) {
             Ok(secs) if secs >= 0.0 => {}
@@ -466,14 +454,9 @@ impl BunxCommand {
         tempdir_name: &[u8],
         package_name: &[u8],
         with_stale_check: bool,
-        // When true, the cache is unconditionally treated as stale — used to
-        // honor `--minimum-release-age` on packages whose real bin name
-        // differs from the `initial_bin_name` guess (e.g. `@angular/cli` → `ng`).
-        // That path skips the top-level age-gate check inside the `'find`
-        // branch (cache probe at `.bin/<initial_bin_name>` misses), then falls
-        // through to this function to discover the real bin name. Without this
-        // flag, a fresh cache would be honored and the binary executed without
-        // re-resolution, bypassing the supply-chain gate.
+        // When true, a warm cache is unconditionally treated as stale so the
+        // spawned `bun add` re-applies `--minimum-release-age`; reached when
+        // the real bin name differs from the `initial_bin_name` guess.
         force_stale: bool,
     ) -> crate::Result<Box<[u8]>> {
         let mut subpath = PathBuffer::uninit();
@@ -543,15 +526,9 @@ impl BunxCommand {
             if is_stale {
                 let _ = target_package_json.close();
                 // If delete fails, oh well. Hope installation takes care of it.
-                // Under the 24h-mtime stale branch this wipe is the only one
-                // that runs; under `force_stale` (age gate) it's defense in
-                // depth — the install path in `exec` also wipes the cache
-                // before `bun add` (gated on `has_active_age_gate()`), because
-                // a surviving `bun.lock` would let `bun add` reuse the
-                // previous resolution even under `--force` and silently
-                // bypass the age filter for ranged specifiers like
-                // `@scope/pkg@^N`. Wiping here is harmless under `--no-install`
-                // because that path errors out in `exec` without installing.
+                // Under `force_stale` (age gate) this is defense in depth:
+                // the install path in `exec` also wipes the cache, since a
+                // surviving `bun.lock` would pin the previous resolution.
                 let _ = bun_sys::Dir::cwd().delete_tree(tempdir_name);
                 return Err(crate::Error::NeedToInstall);
             }
@@ -1095,14 +1072,9 @@ impl BunxCommand {
 
         let passthrough: &[Box<[u8]>] = opts.passthrough_list.as_slice();
 
-        // `--minimum-release-age=<N>` also forces cache-bust: without
-        // `--no-cache --force`, `bun add` would reuse the previous run's
-        // `bun.lock` + `node_modules` in the bunx cache dir, which defeats
-        // the re-resolution that lets the age filter pick a different
-        // version. This covers all paths that reach the install step with
-        // an active gate uniformly (the `'find`/`'find2` cache-hit branches
-        // also set `do_cache_bust = true` on their own, and those writes
-        // become redundant-no-ops here).
+        // An active age gate forces cache-bust: without `--no-cache --force`
+        // the spawned `bun add` would reuse the previous run's resolution,
+        // defeating the age filter's re-resolution.
         let mut do_cache_bust =
             update_request.version.tag == VersionTag::DistTag || opts.has_active_age_gate();
         let look_for_existing_bin = update_request.version.literal.is_empty()
@@ -1169,12 +1141,9 @@ impl BunxCommand {
                             do_cache_bust = true;
                             break 'try_run_existing;
                         }
-                        // `--minimum-release-age=<N>` is a supply-chain gate: the user is
-                        // asserting what versions they're willing to execute. A bunx-cache
-                        // hit from a previous run (which may have installed something the
-                        // gate now forbids) must not bypass that — force re-resolution so
-                        // the spawned `bun add` re-applies the filter. `=0` is the
-                        // documented disable value, so honor it by NOT forcing refresh.
+                        // A warm bunx cache must not bypass an active age
+                        // gate: treat it as stale so the spawned `bun add`
+                        // re-applies the filter (`=0` disables the gate).
                         let age_gate_forces_refresh = opts.has_active_age_gate();
                         let is_stale: bool = 'is_stale: {
                             if age_gate_forces_refresh {
@@ -1289,16 +1258,9 @@ impl BunxCommand {
                         root_dir_fd,
                         bunx_cache_dir,
                         result_package_name,
-                        // When `--minimum-release-age` is an active gate, force
-                        // the cache to be treated as stale so we re-resolve
-                        // through `bun add` (where the age filter is applied).
-                        // Without this, `bunx --minimum-release-age=<N> <pkg-
-                        // whose-bin-name-differs-from-initial-guess>` would
-                        // find the cached bin via
-                        // `get_bin_name_from_temp_directory` and run it —
-                        // bypassing the gate for packages like `@angular/cli`
-                        // (initial guess `cli`, real bin `ng`). `=0` is the
-                        // documented disable value and doesn't force refresh.
+                        // Under an active age gate, treat a warm cache as
+                        // stale so packages whose real bin name differs from
+                        // the initial guess still re-resolve via `bun add`.
                         opts.has_active_age_gate(),
                     ) {
                         Ok(package_name_for_bin) => {
@@ -1377,17 +1339,9 @@ impl BunxCommand {
                                         break 'try_run_existing;
                                     }
 
-                                    // Same supply-chain guard as the `'find` branch
-                                    // above: if this hit is under the bunx cache and
-                                    // `--minimum-release-age` is an active gate, the
-                                    // cached binary may be too recent. Don't run it
-                                    // — force re-resolution through `bun add`. This
-                                    // path is reachable when `get_bin_name` succeeded
-                                    // via `get_bin_name_from_project_directory`
-                                    // (which doesn't consult `force_stale`) and the
-                                    // user passed an explicit version literal (which
-                                    // gates out `'find2`'s local-bin probe above),
-                                    // so the bin is found in the bunx cache.
+                                    // Same guard as the `'find` branch: a hit
+                                    // under the bunx cache must not bypass an
+                                    // active age gate; force re-resolution.
                                     if strings::has_prefix(out, bunx_cache_dir)
                                         && opts.has_active_age_gate()
                                     {
@@ -1448,15 +1402,9 @@ impl BunxCommand {
         // Which is not very helpful.
 
         if opts.no_install {
-            // When an active age gate forced cache re-resolution (via
-            // `force_stale` in `get_bin_name_from_temp_directory`), the
-            // "could not find" message is misleading — there may well be a
-            // cached binary, it's just being treated as stale (or the cache
-            // is cold, in which case the flags are still incompatible for a
-            // different reason — `--no-install` with a gate asks bunx to
-            // verify age without resolving a version). Either way, the flag
-            // combination is inherently contradictory; surface the same
-            // actionable guidance as the matched-bin path.
+            // `--no-install` with an active age gate is contradictory: the
+            // package cannot be verified against the gate without resolving
+            // a version. Match the matched-bin path's error message.
             if opts.has_active_age_gate() {
                 Output::err_generic(
                     "Cannot use <b>--no-install<r> with <b>--minimum-release-age<r>: <b>{}<r> cannot be verified against the age gate without resolving a version, which <b>--no-install<r> opts out of. Drop <b>--no-install<r> to allow re-resolution.",
@@ -1471,19 +1419,9 @@ impl BunxCommand {
             Global::exit(1);
         }
 
-        // Under an active `--minimum-release-age`, wipe any stale bunx cache
-        // before re-resolving. `--no-cache --force` to `bun add` alone is
-        // insufficient: a surviving `bun.lock` pins the previous resolution
-        // and `bun add` reuses it, silently bypassing the age filter for
-        // ranged specifiers (empirically verified with
-        // `bunx @nestjs/cli@^11` against a warm cache). Centralizing the
-        // wipe here covers all three age-gate paths (`'find` stale-cache
-        // break, `'find2` cache-hit break, and the `get_bin_name_from_temp_directory`
-        // force_stale return) with a single call — no need to duplicate it
-        // at every `break 'try_run_existing` site. `delete_tree` is a
-        // best-effort recursive rm (same as the `is_stale` wipe in
-        // `get_bin_name_from_temp_directory`); failures will be caught by
-        // `make_open_path` just below.
+        // Under an active age gate, wipe the bunx cache before re-resolving:
+        // a surviving `bun.lock` lets `bun add --no-cache --force` reuse the
+        // previous resolution for ranged specifiers, bypassing the filter.
         if opts.has_active_age_gate() {
             let _ = bun_sys::Dir::cwd().delete_tree(bunx_cache_dir);
         }
@@ -1514,12 +1452,9 @@ impl BunxCommand {
             let _ = package_json.write_all(b"{}\n");
         }
 
-        // Forward `--minimum-release-age=<N>` to `bun add` so the supply-chain
-        // age gate applies to `bunx`. The value is opaque bytes — `bun add`
-        // re-parses and validates. Declared BEFORE `args` so its backing
-        // buffer outlives `args` (which borrows a slice of it) — locals drop
-        // in reverse declaration order, and `args`'s `Drop` runs while the
-        // borrow is still live.
+        // Forwarded verbatim to `bun add`, which re-parses and validates.
+        // Declared before `args` so the backing buffer outlives `args`'s
+        // borrow (locals drop in reverse declaration order).
         let min_age_combined: Vec<u8> = match opts.minimum_release_age {
             Some(value) => {
                 let prefix: &[u8] = b"--minimum-release-age=";

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -56,6 +56,11 @@ pub struct Options {
     /// Skip installing the package, only running the target command if its
     /// already downloaded. If its not, `bunx` exits with an error.
     pub(crate) no_install: bool,
+    /// Raw value of `--minimum-release-age=<N>`, forwarded verbatim to the
+    /// spawned `bun add` so the same validation path runs. Stored as the
+    /// opaque argv slice (borrowed from `argv`) to avoid re-parsing the
+    /// number here.
+    pub(crate) minimum_release_age: Option<&'static [u8]>,
 }
 
 impl Default for Options {
@@ -68,6 +73,7 @@ impl Default for Options {
             verbose_install: false,
             silent_install: false,
             no_install: false,
+            minimum_release_age: None,
         }
     }
 }
@@ -150,6 +156,30 @@ impl Options {
                         Global::exit(1);
                     }
                     opts.specified_package = Some(package_value);
+                } else if positional == b"--minimum-release-age" {
+                    // Spaced form: `--minimum-release-age <N>`.
+                    // Stored verbatim; `bun add` re-parses and validates.
+                    i += 1;
+                    if i >= argv.len() || argv[i].as_bytes().is_empty() {
+                        Output::err_generic(
+                            "--minimum-release-age requires a value",
+                            format_args!(""),
+                        );
+                        Global::exit(1);
+                    }
+                    Self::validate_minimum_release_age(argv[i].as_bytes());
+                    opts.minimum_release_age = Some(argv[i].as_bytes());
+                } else if positional.starts_with(b"--minimum-release-age=") {
+                    let value = &positional[b"--minimum-release-age=".len()..];
+                    if value.is_empty() {
+                        Output::err_generic(
+                            "--minimum-release-age requires a value",
+                            format_args!(""),
+                        );
+                        Global::exit(1);
+                    }
+                    Self::validate_minimum_release_age(value);
+                    opts.minimum_release_age = Some(value);
                 }
             } else {
                 if !found_subcommand_name {
@@ -202,6 +232,43 @@ impl Options {
             opts.package_name = maybe_package_name.unwrap();
         }
         Ok(opts)
+    }
+
+    /// Whether `--minimum-release-age=<N>` represents an active supply-chain
+    /// gate. A value of `0` (the documented disable spelling — see the
+    /// `handles 0 value to disable` test in `minimum-release-age.test.ts`)
+    /// is treated as "no gate"; we avoid forcing cache re-resolution or
+    /// hard-erroring `--no-install` in that case. Unparseable or negative
+    /// values are rejected in `validate_minimum_release_age` before parse
+    /// returns, so we never see them here.
+    fn has_active_age_gate(&self) -> bool {
+        match self.minimum_release_age {
+            None => false,
+            Some(v) => bun_core::parse_double(v).map(|s| s > 0.0).unwrap_or(false),
+        }
+    }
+
+    /// Match `bun add`'s validation of `--minimum-release-age=<N>` (see
+    /// `CommandLineArguments.rs`'s handler): reject non-numeric values and
+    /// negative numbers with the same message, before bunx does any
+    /// filesystem mutation (the install-path cache wipe, the `force_stale`
+    /// cache wipe inside `get_bin_name_from_temp_directory`). Without this,
+    /// an unparseable or negative value like `--minimum-release-age=abc`
+    /// or `=-5` would wipe a fresh cache before `bun add` reports the
+    /// parse error. (Note: `parse_double` is a prefix-match parser, so a
+    /// value like `7d` is accepted as `7` here and by `bun add` — same
+    /// behavior, intentional.)
+    fn validate_minimum_release_age(value: &[u8]) {
+        match bun_core::parse_double(value) {
+            Ok(secs) if secs >= 0.0 => {}
+            _ => {
+                Output::err_generic(
+                    "Expected --minimum-release-age to be a positive number: {}",
+                    (BStr::new(value),),
+                );
+                Global::exit(1);
+            }
+        }
     }
 }
 
@@ -399,6 +466,15 @@ impl BunxCommand {
         tempdir_name: &[u8],
         package_name: &[u8],
         with_stale_check: bool,
+        // When true, the cache is unconditionally treated as stale — used to
+        // honor `--minimum-release-age` on packages whose real bin name
+        // differs from the `initial_bin_name` guess (e.g. `@angular/cli` → `ng`).
+        // That path skips the top-level age-gate check inside the `'find`
+        // branch (cache probe at `.bin/<initial_bin_name>` misses), then falls
+        // through to this function to discover the real bin name. Without this
+        // flag, a fresh cache would be honored and the binary executed without
+        // re-resolution, bypassing the supply-chain gate.
+        force_stale: bool,
     ) -> crate::Result<Box<[u8]>> {
         let mut subpath = PathBuffer::uninit();
         if with_stale_check {
@@ -424,6 +500,9 @@ impl BunxCommand {
             let target_package_json = bun_sys::File::from_fd(target_package_json_fd);
 
             let is_stale: bool = 'is_stale: {
+                if force_stale {
+                    break 'is_stale true;
+                }
                 #[cfg(windows)]
                 {
                     use bun_sys::windows as win;
@@ -464,6 +543,15 @@ impl BunxCommand {
             if is_stale {
                 let _ = target_package_json.close();
                 // If delete fails, oh well. Hope installation takes care of it.
+                // Under the 24h-mtime stale branch this wipe is the only one
+                // that runs; under `force_stale` (age gate) it's defense in
+                // depth — the install path in `exec` also wipes the cache
+                // before `bun add` (gated on `has_active_age_gate()`), because
+                // a surviving `bun.lock` would let `bun add` reuse the
+                // previous resolution even under `--force` and silently
+                // bypass the age filter for ranged specifiers like
+                // `@scope/pkg@^N`. Wiping here is harmless under `--no-install`
+                // because that path errors out in `exec` without installing.
                 let _ = bun_sys::Dir::cwd().delete_tree(tempdir_name);
                 return Err(crate::Error::NeedToInstall);
             }
@@ -497,6 +585,7 @@ impl BunxCommand {
         toplevel_fd: Fd,
         tempdir_name: &[u8],
         package_name: &[u8],
+        force_stale: bool,
     ) -> Result<Box<[u8]>, GetBinNameError> {
         debug_assert!(toplevel_fd.is_valid());
         match Self::get_bin_name_from_project_directory(transpiler, toplevel_fd, package_name) {
@@ -511,6 +600,7 @@ impl BunxCommand {
                     tempdir_name,
                     package_name,
                     true,
+                    force_stale,
                 ) {
                     Ok(v) => Ok(v),
                     Err(err2) => {
@@ -1005,7 +1095,16 @@ impl BunxCommand {
 
         let passthrough: &[Box<[u8]>] = opts.passthrough_list.as_slice();
 
-        let mut do_cache_bust = update_request.version.tag == VersionTag::DistTag;
+        // `--minimum-release-age=<N>` also forces cache-bust: without
+        // `--no-cache --force`, `bun add` would reuse the previous run's
+        // `bun.lock` + `node_modules` in the bunx cache dir, which defeats
+        // the re-resolution that lets the age filter pick a different
+        // version. This covers all paths that reach the install step with
+        // an active gate uniformly (the `'find`/`'find2` cache-hit branches
+        // also set `do_cache_bust = true` on their own, and those writes
+        // become redundant-no-ops here).
+        let mut do_cache_bust =
+            update_request.version.tag == VersionTag::DistTag || opts.has_active_age_gate();
         let look_for_existing_bin = update_request.version.literal.is_empty()
             || update_request.version.tag != VersionTag::DistTag;
 
@@ -1070,7 +1169,17 @@ impl BunxCommand {
                             do_cache_bust = true;
                             break 'try_run_existing;
                         }
+                        // `--minimum-release-age=<N>` is a supply-chain gate: the user is
+                        // asserting what versions they're willing to execute. A bunx-cache
+                        // hit from a previous run (which may have installed something the
+                        // gate now forbids) must not bypass that — force re-resolution so
+                        // the spawned `bun add` re-applies the filter. `=0` is the
+                        // documented disable value, so honor it by NOT forcing refresh.
+                        let age_gate_forces_refresh = opts.has_active_age_gate();
                         let is_stale: bool = 'is_stale: {
+                            if age_gate_forces_refresh {
+                                break 'is_stale true;
+                            }
                             #[cfg(windows)]
                             {
                                 use bun_sys::windows as win;
@@ -1127,6 +1236,21 @@ impl BunxCommand {
                             bun_output::scoped_log!(bunx, "found stale binary: {}", BStr::new(out));
                             do_cache_bust = true;
                             if opts.no_install {
+                                // `--no-install` normally falls through to run
+                                // the stale cached binary with a warning. But
+                                // `--minimum-release-age` is a supply-chain
+                                // gate: running the cached binary would
+                                // silently bypass it, because re-resolution
+                                // (where the filter is applied) is what
+                                // `--no-install` specifically opts out of.
+                                // Refuse to run instead.
+                                if age_gate_forces_refresh {
+                                    Output::err_generic(
+                                        "Cannot use <b>--no-install<r> with <b>--minimum-release-age<r>: the cached binary for <b>{}<r> cannot be re-verified under the age gate without resolving a new version. Drop <b>--no-install<r> to allow re-resolution.",
+                                        (BStr::new(&update_request.name),),
+                                    );
+                                    Global::exit(1);
+                                }
                                 bun_core::warn!(
                                     "Using a stale installation of <b>{}<r> because --no-install was passed. Run `bunx` without --no-install to use a fresh binary.",
                                     BStr::new(&update_request.name),
@@ -1165,6 +1289,17 @@ impl BunxCommand {
                         root_dir_fd,
                         bunx_cache_dir,
                         result_package_name,
+                        // When `--minimum-release-age` is an active gate, force
+                        // the cache to be treated as stale so we re-resolve
+                        // through `bun add` (where the age filter is applied).
+                        // Without this, `bunx --minimum-release-age=<N> <pkg-
+                        // whose-bin-name-differs-from-initial-guess>` would
+                        // find the cached bin via
+                        // `get_bin_name_from_temp_directory` and run it —
+                        // bypassing the gate for packages like `@angular/cli`
+                        // (initial guess `cli`, real bin `ng`). `=0` is the
+                        // documented disable value and doesn't force refresh.
+                        opts.has_active_age_gate(),
                     ) {
                         Ok(package_name_for_bin) => {
                             // if we check the bin name and its actually the same, we don't need to check $PATH here again
@@ -1241,6 +1376,37 @@ impl BunxCommand {
                                         do_cache_bust = true;
                                         break 'try_run_existing;
                                     }
+
+                                    // Same supply-chain guard as the `'find` branch
+                                    // above: if this hit is under the bunx cache and
+                                    // `--minimum-release-age` is an active gate, the
+                                    // cached binary may be too recent. Don't run it
+                                    // — force re-resolution through `bun add`. This
+                                    // path is reachable when `get_bin_name` succeeded
+                                    // via `get_bin_name_from_project_directory`
+                                    // (which doesn't consult `force_stale`) and the
+                                    // user passed an explicit version literal (which
+                                    // gates out `'find2`'s local-bin probe above),
+                                    // so the bin is found in the bunx cache.
+                                    if strings::has_prefix(out, bunx_cache_dir)
+                                        && opts.has_active_age_gate()
+                                    {
+                                        bun_output::scoped_log!(
+                                            bunx,
+                                            "found stale binary (age gate): {}",
+                                            BStr::new(out),
+                                        );
+                                        do_cache_bust = true;
+                                        if opts.no_install {
+                                            Output::err_generic(
+                                                "Cannot use <b>--no-install<r> with <b>--minimum-release-age<r>: the cached binary for <b>{}<r> cannot be re-verified under the age gate without resolving a new version. Drop <b>--no-install<r> to allow re-resolution.",
+                                                (BStr::new(&update_request.name),),
+                                            );
+                                            Global::exit(1);
+                                        }
+                                        break 'try_run_existing;
+                                    }
+
                                     let stored = fs.dirname_store.append_slice(out)?;
                                     Run::run_binary(
                                         ctx,
@@ -1282,6 +1448,22 @@ impl BunxCommand {
         // Which is not very helpful.
 
         if opts.no_install {
+            // When an active age gate forced cache re-resolution (via
+            // `force_stale` in `get_bin_name_from_temp_directory`), the
+            // "could not find" message is misleading — there may well be a
+            // cached binary, it's just being treated as stale (or the cache
+            // is cold, in which case the flags are still incompatible for a
+            // different reason — `--no-install` with a gate asks bunx to
+            // verify age without resolving a version). Either way, the flag
+            // combination is inherently contradictory; surface the same
+            // actionable guidance as the matched-bin path.
+            if opts.has_active_age_gate() {
+                Output::err_generic(
+                    "Cannot use <b>--no-install<r> with <b>--minimum-release-age<r>: <b>{}<r> cannot be verified against the age gate without resolving a version, which <b>--no-install<r> opts out of. Drop <b>--no-install<r> to allow re-resolution.",
+                    (BStr::new(&update_request.name),),
+                );
+                Global::exit(1);
+            }
             Output::err_generic(
                 "Could not find an existing '{}' binary to run. Stopping because --no-install was passed.",
                 format_args!("{}", BStr::new(initial_bin_name)),
@@ -1289,6 +1471,22 @@ impl BunxCommand {
             Global::exit(1);
         }
 
+        // Under an active `--minimum-release-age`, wipe any stale bunx cache
+        // before re-resolving. `--no-cache --force` to `bun add` alone is
+        // insufficient: a surviving `bun.lock` pins the previous resolution
+        // and `bun add` reuses it, silently bypassing the age filter for
+        // ranged specifiers (empirically verified with
+        // `bunx @nestjs/cli@^11` against a warm cache). Centralizing the
+        // wipe here covers all three age-gate paths (`'find` stale-cache
+        // break, `'find2` cache-hit break, and the `get_bin_name_from_temp_directory`
+        // force_stale return) with a single call — no need to duplicate it
+        // at every `break 'try_run_existing` site. `delete_tree` is a
+        // best-effort recursive rm (same as the `is_stale` wipe in
+        // `get_bin_name_from_temp_directory`); failures will be caught by
+        // `make_open_path` just below.
+        if opts.has_active_age_gate() {
+            let _ = bun_sys::Dir::cwd().delete_tree(bunx_cache_dir);
+        }
         let bunx_install_dir = Fd::cwd().make_open_path(bunx_cache_dir)?;
         if !Self::is_trusted_opened_cache_dir(
             bunx_install_dir.fd,
@@ -1316,13 +1514,32 @@ impl BunxCommand {
             let _ = package_json.write_all(b"{}\n");
         }
 
+        // Forward `--minimum-release-age=<N>` to `bun add` so the supply-chain
+        // age gate applies to `bunx`. The value is opaque bytes — `bun add`
+        // re-parses and validates. Declared BEFORE `args` so its backing
+        // buffer outlives `args` (which borrows a slice of it) — locals drop
+        // in reverse declaration order, and `args`'s `Drop` runs while the
+        // borrow is still live.
+        let min_age_combined: Vec<u8> = match opts.minimum_release_age {
+            Some(value) => {
+                let prefix: &[u8] = b"--minimum-release-age=";
+                let mut buf = Vec::with_capacity(prefix.len() + value.len());
+                buf.extend_from_slice(prefix);
+                buf.extend_from_slice(value);
+                buf
+            }
+            None => Vec::new(),
+        };
+
         let install_args: [&[u8]; 4] = [
             bun_core::self_exe_path()?.as_bytes(),
             b"add",
             install_param.as_slice(),
             b"--no-summary",
         ];
-        let mut args: BoundedArray<&[u8], 8> =
+        // Capacity breakdown: 4 base + 2 cache-bust + 1 verbose + 1 silent
+        // + 1 minimum-release-age.
+        let mut args: BoundedArray<&[u8], 9> =
             BoundedArray::from_slice(&install_args).expect("unreachable"); // upper bound is known
 
         if do_cache_bust {
@@ -1340,6 +1557,13 @@ impl BunxCommand {
 
         if opts.silent_install {
             args.append(b"--silent").expect("unreachable"); // upper bound is known
+        }
+
+        // `min_age_combined` was built above (before `args`); append its slice
+        // when the flag was set. `bun add` re-parses and validates the value.
+        if opts.minimum_release_age.is_some() {
+            args.append(min_age_combined.as_slice())
+                .expect("unreachable"); // upper bound is known
         }
 
         let argv_to_use = args.slice();
@@ -1513,6 +1737,10 @@ impl BunxCommand {
                 this_transpiler,
                 bunx_cache_dir,
                 result_package_name,
+                false,
+                // Post-install — the freshly installed cache was resolved
+                // under the active age filter (or its absence), no need to
+                // force stale here.
                 false,
             ) {
                 if !strings::eql_long(&package_name_for_bin, initial_bin_name, true) {

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1992,6 +1992,7 @@ Flags:
   <cyan>--no-install<r>           Skip installation if package is not already installed
   <cyan>--verbose<r>              Enable verbose output during installation
   <cyan>--silent<r>               Suppress output during installation
+  <cyan>--minimum-release-age <blue>\\<seconds\\><r>  Only install packages published at least N seconds ago (security feature)
 
 Examples<d>:<r>
   <b><green>bunx<r> <blue>prisma<r> migrate<r>

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -2613,7 +2613,7 @@ export const scanner = {
         stderr: "pipe",
       });
 
-      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr.toLowerCase()).toContain("minimum-release-age");
       expect(exitCode).not.toBe(0);
     });
@@ -2630,7 +2630,7 @@ export const scanner = {
         stderr: "pipe",
       });
 
-      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr.toLowerCase()).toContain("minimum-release-age");
       expect(exitCode).not.toBe(0);
     });
@@ -2647,7 +2647,7 @@ export const scanner = {
         stderr: "pipe",
       });
 
-      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toContain("--minimum-release-age requires a value");
       expect(exitCode).not.toBe(0);
     });
@@ -2664,7 +2664,7 @@ export const scanner = {
         stderr: "pipe",
       });
 
-      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toContain("--minimum-release-age requires a value");
       expect(exitCode).not.toBe(0);
     });
@@ -3074,7 +3074,7 @@ export const scanner = {
         stderr: "pipe",
       });
 
-      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       // Sentinel binary must not have run.
       expect(stdout).not.toContain("CACHE_BYPASS_BUG_REPRO");
       // And the install step must have wiped the sentinel lockfile (the

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -2693,6 +2693,9 @@ export const scanner = {
       mkdirSync(pkgDir, { recursive: true });
       mkdirSync(binDir, { recursive: true });
       chmodSync(cacheRoot, 0o755);
+      // mkdirSync also created the intermediate `bunx-<uid>-@fake-scope` dir;
+      // chmod it too or `is_trusted_cache_root` refuses under umask 002.
+      chmodSync(join(String(tmp), `bunx-${uid}-${pkgName.split("/")[0]}`), 0o755);
       writeFileSync(join(cacheRoot, "package.json"), JSON.stringify({}));
       writeFileSync(
         join(pkgDir, "package.json"),
@@ -2818,6 +2821,9 @@ export const scanner = {
       mkdirSync(pkgDir, { recursive: true });
       mkdirSync(binDir, { recursive: true });
       chmodSync(cacheRoot, 0o755);
+      // mkdirSync also created the intermediate `bunx-<uid>-@fake-scope` dir;
+      // chmod it too or `is_trusted_cache_root` refuses under umask 002.
+      chmodSync(join(String(tmp), `bunx-${uid}-${pkgName.split("/")[0]}`), 0o755);
 
       // Root package.json — bunx uses its mtime for the 24h staleness check.
       writeFileSync(join(cacheRoot, "package.json"), JSON.stringify({}));
@@ -2924,6 +2930,9 @@ export const scanner = {
         const cacheBinDir = join(cacheRoot, "node_modules", ".bin");
         mkdirSync(cacheBinDir, { recursive: true });
         chmodSync(cacheRoot, 0o755);
+        // mkdirSync also created the intermediate `bunx-<uid>-@fake-scope` dir;
+        // chmod it too or `is_trusted_cache_root` refuses under umask 002.
+        chmodSync(join(String(tmp), `bunx-${uid}-${pkgName.split("/")[0]}`), 0o755);
         // Root package.json for the 24h staleness check.
         writeFileSync(join(cacheRoot, "package.json"), JSON.stringify({}));
         // Cached binary at the REAL bin name (not the initial-guess `cli`-style
@@ -2965,6 +2974,9 @@ export const scanner = {
       mkdirSync(pkgDir, { recursive: true });
       mkdirSync(binDir, { recursive: true });
       chmodSync(cacheRoot, 0o755);
+      // mkdirSync also created the intermediate `bunx-<uid>-@fake-scope` dir;
+      // chmod it too or `is_trusted_cache_root` refuses under umask 002.
+      chmodSync(join(String(tmp), `bunx-${uid}-${pkgName.split("/")[0]}`), 0o755);
 
       // Root package.json drives the 24h mtime staleness check.
       writeFileSync(join(cacheRoot, "package.json"), JSON.stringify({}));

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -2669,23 +2669,9 @@ export const scanner = {
       expect(exitCode).not.toBe(0);
     });
 
-    // Value validation must happen in `Options::parse`, matching `bun add`'s
-    // validation at `CommandLineArguments.rs` exactly, BEFORE bunx does any
-    // filesystem mutation or cache-execution decisions.
-    //
-    // Pre-fix, `has_active_age_gate()` had two leaky edge cases:
-    //   - Unparseable values (`=abc`) returned true via `Err(_) => true`, so
-    //     a fresh mismatched-bin cache got `force_stale`-wiped before
-    //     `bun add` surfaced the parse error.
-    //   - Negative values (`=-5`) parsed to `Ok(-5.0)` and returned false, so
-    //     on a warm cache the cached binary ran and the flag was silently
-    //     ignored — a supply-chain footgun for a typo'd sign. Cold cache
-    //     rejected the same input via `bun add`, yielding state-dependent
-    //     error reporting.
-    //
-    // Both are now rejected up-front in `Options::parse` with the same error
-    // text `bun add` uses. The warm cache must survive (no side effect) and
-    // the cached binary must not run.
+    // Invalid values must be rejected up-front with `bun add`'s error text,
+    // BEFORE any filesystem mutation: the warm cache must survive untouched
+    // and the cached binary must not run.
     test.skipIf(isWindows).each([
       ["abc", "non-numeric"],
       ["-5", "negative integer"],
@@ -2745,16 +2731,9 @@ export const scanner = {
     // vacuously via the cold-install path, providing no coverage of the
     // `age_gate_forces_refresh` short-circuit.
     test.skipIf(isWindows)("warm bunx cache does not bypass --minimum-release-age", async () => {
-      // bunx caches successful installs under $TMPDIR/bunx-<uid>-<pkg>@latest
-      // and re-runs the cached binary on the next invocation if it's less than
-      // 24h old. Without the age-gate refresh, a fresh cache from an earlier
-      // unrestricted run would let a later `--minimum-release-age=<big>`
-      // invocation silently execute the cached (possibly too-new) binary.
-      //
-      // Simulate a warm cache by pre-creating the expected cache path with a
-      // fake executable at <cache>/node_modules/.bin/<pkg>, then invoke bunx
-      // with a 100-year gate. The gate must force re-resolution via the
-      // spawned `bun add`, which errors out (no version satisfies 100 years).
+      // Simulate a warm cache (fake executable at the expected cache path),
+      // then invoke bunx with a 100-year gate: it must force re-resolution
+      // via `bun add` instead of running the cached binary.
       using dir = tempDir("bunx-min-age-warm", {});
       using cacheDir = tempDir("bunx-min-age-cache-warm", {});
       using tmp = tempDir("bunx-min-age-tmp-warm", {});
@@ -2787,10 +2766,9 @@ export const scanner = {
 
     // Same unix-only fake-cache layout as the warm-cache test above.
     test.skipIf(isWindows)("--no-install + --minimum-release-age refuses to run cached binary", async () => {
-      // When both flags are set on a warm cache, the normal `--no-install`
-      // fallback (warn and run the stale cached binary) would silently bypass
-      // the age gate — `--no-install` opts out of the re-resolution where
-      // the filter is applied. bunx must error out instead.
+      // On a warm cache, `--no-install`'s run-the-stale-binary fallback
+      // would bypass the age gate (re-resolution is what the flag opts out
+      // of); bunx must error instead.
       using dir = tempDir("bunx-min-age-noinstall", {});
       using cacheDir = tempDir("bunx-min-age-cache-noinstall", {});
       using tmp = tempDir("bunx-min-age-tmp-noinstall", {});
@@ -2821,17 +2799,9 @@ export const scanner = {
 
     // Same unix-only fake-cache layout as the other warm-cache tests above.
     test.skipIf(isWindows)("warm cache with mismatched bin name does not bypass --minimum-release-age", async () => {
-      // Regression: for scoped packages like `@angular/cli` (bin `ng`), bunx's
-      // first cache probe looks for `.bin/<initial_bin_name>` where the guess
-      // comes from the last path segment — here `cli`. That probe misses
-      // because the real bin is `ng`. Execution falls through to
-      // `get_bin_name_from_temp_directory` which reads the cached
-      // package.json's `bin` field, rewrites the probe path, and a second
-      // `which` call hits `.bin/ng` → `Run::run_binary`.
-      //
-      // Without threading the age gate into the cached-package.json
-      // staleness check, this path never sees `--minimum-release-age` and
-      // silently runs the cached (possibly-too-new) binary.
+      // Mismatched bin name (`@fake-scope/bin-mismatch` → bin `mytool`): the
+      // first cache probe misses and bin discovery reads the cached
+      // package.json; that path must also honor the age gate.
       using dir = tempDir("bunx-min-age-bin-mismatch", {});
       using cacheDir = tempDir("bunx-min-age-cache-bin-mismatch", {});
       using tmp = tempDir("bunx-min-age-tmp-bin-mismatch", {});
@@ -2874,11 +2844,9 @@ export const scanner = {
       expect(exitCode).not.toBe(0);
     });
 
-    // `--minimum-release-age=0` is the documented disable spelling (see
-    // `handles 0 value to disable` above). bunx must honor that for the
-    // cache-bypass checks — otherwise `=0` unnecessarily forces re-resolution
-    // on a warm cache, and `--no-install --minimum-release-age=0` hard-errors
-    // instead of running the cached binary.
+    // `=0` is the documented disable spelling: it must NOT force
+    // re-resolution on a warm cache, and `--no-install` + `=0` must run the
+    // cached binary instead of hard-erroring.
     test.skipIf(isWindows)("--minimum-release-age=0 honors cached binary (disable semantics)", async () => {
       using dir = tempDir("bunx-min-age-zero", {});
       using cacheDir = tempDir("bunx-min-age-cache-zero", {});
@@ -2925,13 +2893,9 @@ export const scanner = {
     test.skipIf(isWindows)(
       "warm cache with local project install + version literal does not bypass --minimum-release-age",
       async () => {
-        // Regression: when the project has a local `node_modules/<pkg>` install
-        // AND the user passes an explicit version (e.g. `bunx pkg@^1`),
-        // `get_bin_name` succeeds via `get_bin_name_from_project_directory`
-        // without consulting `force_stale`, then `'find2`'s local-bin probe
-        // is skipped (gated on `version.literal.is_empty()`), so execution
-        // hits the bunx-cache probe and `Run::run_binary` would run the
-        // cached binary with no age check.
+        // Local `node_modules/<pkg>` install + explicit version literal:
+        // bin discovery succeeds via the project directory and execution
+        // reaches the bunx-cache probe; the age gate must still apply.
         using dir = tempDir("bunx-min-age-local-install", {});
         using cacheDir = tempDir("bunx-min-age-cache-local-install", {});
         using tmp = tempDir("bunx-min-age-tmp-local-install", {});
@@ -2984,14 +2948,9 @@ export const scanner = {
 
     // Same unix-only fake-cache layout as the other warm-cache tests.
     test.skipIf(isWindows)("--no-install + --minimum-release-age + mismatched bin name: specific error", async () => {
-      // UX regression guard: when the bin name differs from the initial
-      // guess, bunx falls into `get_bin_name_from_temp_directory` with
-      // `force_stale=true` and returns `NeedToInstall`. The catch-all
-      // `if opts.no_install` that follows must surface the same specific
-      // "Cannot use --no-install with --minimum-release-age…" error the
-      // matched-bin `'find` path emits — not the generic "Could not find
-      // an existing '<initial-bin-name>' binary to run" message, which
-      // doesn't hint that the flag combination is the real problem.
+      // With a mismatched bin name, the `--no-install` catch-all must emit
+      // the specific "Cannot use --no-install with --minimum-release-age"
+      // error, not the generic could-not-find message.
       using dir = tempDir("bunx-min-age-noinstall-mismatched", {});
       using cacheDir = tempDir("bunx-min-age-cache-noinstall-mismatched", {});
       using tmp = tempDir("bunx-min-age-tmp-noinstall-mismatched", {});
@@ -3035,19 +2994,9 @@ export const scanner = {
     });
 
     test.skipIf(isWindows)("warm cache bun.lock is cleared before age-gated install", async () => {
-      // Regression: `--no-cache --force` to `bun add` is insufficient to
-      // force re-resolution under an active age gate when a `bun.lock`
-      // from a previous run survives in the bunx cache dir — `bun add`
-      // reuses the locked version even with `--force` for ranged
-      // specifiers like `pkg@^N`. The install path must wipe the tree
-      // before spawning `bun add` when an age gate is active.
-      //
-      // Seeds the warm cache (at a version-literal key) with a sentinel
-      // `bun.lock` and verifies the file is gone after the bunx
-      // invocation — the `delete_tree(bunx_cache_dir)` at the top of the
-      // install path ran. Uses `regular-package` (matched bin name, so
-      // the `'find` branch fires) and a range specifier so the final
-      // install step reaches `bun add` with `--no-cache --force`.
+      // A surviving `bun.lock` pins resolution even under `--no-cache
+      // --force`, so the install path must wipe the cache dir when the age
+      // gate is active. Seeds a sentinel lockfile and asserts it's gone.
       using dir = tempDir("bunx-min-age-lockfile", {});
       using cacheDir = tempDir("bunx-min-age-cache-lockfile", {});
       using tmp = tempDir("bunx-min-age-tmp-lockfile", {});

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -1,6 +1,8 @@
 import type { Server } from "bun";
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir } from "harness";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 // These tests drive real `bun install` runs against a mock registry, which is
 // slow under the debug/ASAN build — give them the same generous timeout the
@@ -2570,6 +2572,500 @@ export const scanner = {
       const regularPkg = receivedPackages.find((p: { name: string }) => p.name === "regular-package");
       expect(regularPkg).toBeDefined();
       expect(regularPkg.version).toBe("3.0.0");
+    });
+  });
+
+  // Regression test for https://github.com/oven-sh/bun/issues/30748 —
+  // `bunx --minimum-release-age` used to be silently accepted without being
+  // forwarded to the `bun add` subprocess, so the age gate had no effect.
+  describe("bunx", () => {
+    // `bunx` caches installs under TMPDIR and packages under BUN_INSTALL_CACHE_DIR;
+    // both must be isolated per test so the age-gated subprocess actually runs
+    // (a hit in either cache would let `bunx` skip the install step entirely).
+    const bunxEnv = (cacheDir: string, tmp: string) => ({
+      ...bunEnv,
+      BUN_INSTALL_CACHE_DIR: cacheDir,
+      BUN_TMPDIR: tmp,
+      TMPDIR: tmp,
+      TEMP: tmp,
+      npm_config_registry: mockRegistryUrl,
+    });
+
+    test("--minimum-release-age=<seconds> is forwarded to bun add", async () => {
+      using dir = tempDir("bunx-min-age-eq", {});
+      using cacheDir = tempDir("bunx-min-age-cache-eq", {});
+      using tmp = tempDir("bunx-min-age-tmp-eq", {});
+      // 100 years — nothing in `regular-package` can satisfy this, so the
+      // spawned `bun add` must error. The pre-fix behavior was to silently
+      // ignore the flag and install `3.0.0`.
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "x", "--minimum-release-age=3155760000", "regular-package"],
+        cwd: String(dir),
+        env: bunxEnv(String(cacheDir), String(tmp)),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr.toLowerCase()).toContain("minimum-release-age");
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("--minimum-release-age <seconds> (spaced) is forwarded to bun add", async () => {
+      using dir = tempDir("bunx-min-age-spaced", {});
+      using cacheDir = tempDir("bunx-min-age-cache-spaced", {});
+      using tmp = tempDir("bunx-min-age-tmp-spaced", {});
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "x", "--minimum-release-age", "3155760000", "regular-package"],
+        cwd: String(dir),
+        env: bunxEnv(String(cacheDir), String(tmp)),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr.toLowerCase()).toContain("minimum-release-age");
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("--minimum-release-age with no value errors", async () => {
+      using dir = tempDir("bunx-min-age-no-value", {});
+      using cacheDir = tempDir("bunx-min-age-cache-no-value", {});
+      using tmp = tempDir("bunx-min-age-tmp-no-value", {});
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "x", "--minimum-release-age"],
+        cwd: String(dir),
+        env: bunxEnv(String(cacheDir), String(tmp)),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("--minimum-release-age requires a value");
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("--minimum-release-age= (empty value) errors", async () => {
+      using dir = tempDir("bunx-min-age-empty", {});
+      using cacheDir = tempDir("bunx-min-age-cache-empty", {});
+      using tmp = tempDir("bunx-min-age-tmp-empty", {});
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "x", "--minimum-release-age=", "regular-package"],
+        cwd: String(dir),
+        env: bunxEnv(String(cacheDir), String(tmp)),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("--minimum-release-age requires a value");
+      expect(exitCode).not.toBe(0);
+    });
+
+    // Value validation must happen in `Options::parse`, matching `bun add`'s
+    // validation at `CommandLineArguments.rs` exactly, BEFORE bunx does any
+    // filesystem mutation or cache-execution decisions.
+    //
+    // Pre-fix, `has_active_age_gate()` had two leaky edge cases:
+    //   - Unparseable values (`=abc`) returned true via `Err(_) => true`, so
+    //     a fresh mismatched-bin cache got `force_stale`-wiped before
+    //     `bun add` surfaced the parse error.
+    //   - Negative values (`=-5`) parsed to `Ok(-5.0)` and returned false, so
+    //     on a warm cache the cached binary ran and the flag was silently
+    //     ignored — a supply-chain footgun for a typo'd sign. Cold cache
+    //     rejected the same input via `bun add`, yielding state-dependent
+    //     error reporting.
+    //
+    // Both are now rejected up-front in `Options::parse` with the same error
+    // text `bun add` uses. The warm cache must survive (no side effect) and
+    // the cached binary must not run.
+    test.skipIf(isWindows).each([
+      ["abc", "non-numeric"],
+      ["-5", "negative integer"],
+      ["-0.5", "negative float"],
+    ])("--minimum-release-age=%s rejected before filesystem mutation (%s)", async (bad, _label) => {
+      using dir = tempDir(`bunx-min-age-bad-${bad.replace(/[^a-z0-9]/gi, "_")}`, {});
+      using cacheDir = tempDir(`bunx-min-age-cache-bad-${bad.replace(/[^a-z0-9]/gi, "_")}`, {});
+      using tmp = tempDir(`bunx-min-age-tmp-bad-${bad.replace(/[^a-z0-9]/gi, "_")}`, {});
+
+      // Seed a warm mismatched-bin cache so both pre-fix regressions
+      // (cache wipe under `=abc`, cached binary run under `=-5`) would
+      // be observable without the fix.
+      const pkgName = "@fake-scope/validation-guard";
+      const realBin = "mytool";
+      const uid = process.getuid?.() ?? 0;
+      const cacheRoot = join(String(tmp), `bunx-${uid}-${pkgName}@latest`);
+      const pkgDir = join(cacheRoot, "node_modules", pkgName);
+      const binDir = join(cacheRoot, "node_modules", ".bin");
+      mkdirSync(pkgDir, { recursive: true });
+      mkdirSync(binDir, { recursive: true });
+      writeFileSync(join(cacheRoot, "package.json"), JSON.stringify({}));
+      writeFileSync(
+        join(pkgDir, "package.json"),
+        JSON.stringify({ name: pkgName, version: "1.0.0", bin: { [realBin]: `./bin/${realBin}.js` } }),
+      );
+      const binPath = join(binDir, realBin);
+      writeFileSync(binPath, "#!/bin/sh\necho VALIDATION_LEAKED\nexit 0\n");
+      chmodSync(binPath, 0o755);
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "x", `--minimum-release-age=${bad}`, pkgName],
+        cwd: String(dir),
+        env: bunxEnv(String(cacheDir), String(tmp)),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      // Same error text `bun add` uses — user sees a single consistent message.
+      expect(stderr).toContain("Expected --minimum-release-age to be a positive number");
+      expect(stderr).toContain(bad);
+      expect(exitCode).not.toBe(0);
+      // No cached binary ran (catches the negative-value silent-bypass
+      // regression).
+      expect(stdout).not.toContain("VALIDATION_LEAKED");
+      // Cache must not have been wiped before the parse error surfaced.
+      expect(existsSync(binPath)).toBe(true);
+      expect(existsSync(join(pkgDir, "package.json"))).toBe(true);
+    });
+
+    // The pre-seeded cache layout here is unix-specific: the cache key uses
+    // `process.getuid()` (undefined on Windows, where bunx keys on
+    // `user_unique_id()`), the bin path has no `.exe` suffix (bunx probes with
+    // `EXE_SUFFIX` on Windows), and the fake binary is a sh script. On
+    // Windows the fake cache is never matched; the test would pass
+    // vacuously via the cold-install path, providing no coverage of the
+    // `age_gate_forces_refresh` short-circuit.
+    test.skipIf(isWindows)("warm bunx cache does not bypass --minimum-release-age", async () => {
+      // bunx caches successful installs under $TMPDIR/bunx-<uid>-<pkg>@latest
+      // and re-runs the cached binary on the next invocation if it's less than
+      // 24h old. Without the age-gate refresh, a fresh cache from an earlier
+      // unrestricted run would let a later `--minimum-release-age=<big>`
+      // invocation silently execute the cached (possibly too-new) binary.
+      //
+      // Simulate a warm cache by pre-creating the expected cache path with a
+      // fake executable at <cache>/node_modules/.bin/<pkg>, then invoke bunx
+      // with a 100-year gate. The gate must force re-resolution via the
+      // spawned `bun add`, which errors out (no version satisfies 100 years).
+      using dir = tempDir("bunx-min-age-warm", {});
+      using cacheDir = tempDir("bunx-min-age-cache-warm", {});
+      using tmp = tempDir("bunx-min-age-tmp-warm", {});
+
+      const uid = process.getuid?.() ?? 0;
+      const binDir = join(String(tmp), `bunx-${uid}-regular-package@latest`, "node_modules", ".bin");
+      mkdirSync(binDir, { recursive: true });
+      const binPath = join(binDir, "regular-package");
+      // If bunx wrongly short-circuits to the cache, this fake binary runs
+      // and prints a sentinel the test asserts *never* appears.
+      writeFileSync(binPath, "#!/bin/sh\necho CACHE_BYPASS_BUG_REPRO\nexit 0\n");
+      chmodSync(binPath, 0o755);
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "x", "--minimum-release-age=3155760000", "regular-package"],
+        cwd: String(dir),
+        env: bunxEnv(String(cacheDir), String(tmp)),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      // The sentinel must not appear — cached binary must not have run.
+      expect(stdout).not.toContain("CACHE_BYPASS_BUG_REPRO");
+      expect(stderr.toLowerCase()).toContain("minimum-release-age");
+      expect(exitCode).not.toBe(0);
+    });
+
+    // Same unix-only fake-cache layout as the warm-cache test above.
+    test.skipIf(isWindows)("--no-install + --minimum-release-age refuses to run cached binary", async () => {
+      // When both flags are set on a warm cache, the normal `--no-install`
+      // fallback (warn and run the stale cached binary) would silently bypass
+      // the age gate — `--no-install` opts out of the re-resolution where
+      // the filter is applied. bunx must error out instead.
+      using dir = tempDir("bunx-min-age-noinstall", {});
+      using cacheDir = tempDir("bunx-min-age-cache-noinstall", {});
+      using tmp = tempDir("bunx-min-age-tmp-noinstall", {});
+
+      const uid = process.getuid?.() ?? 0;
+      const binDir = join(String(tmp), `bunx-${uid}-regular-package@latest`, "node_modules", ".bin");
+      mkdirSync(binDir, { recursive: true });
+      const binPath = join(binDir, "regular-package");
+      writeFileSync(binPath, "#!/bin/sh\necho CACHE_BYPASS_BUG_REPRO\nexit 0\n");
+      chmodSync(binPath, 0o755);
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "x", "--no-install", "--minimum-release-age=3155760000", "regular-package"],
+        cwd: String(dir),
+        env: bunxEnv(String(cacheDir), String(tmp)),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).not.toContain("CACHE_BYPASS_BUG_REPRO");
+      expect(stderr).toContain("--no-install");
+      expect(stderr).toContain("--minimum-release-age");
+      expect(exitCode).not.toBe(0);
+    });
+
+    // Same unix-only fake-cache layout as the other warm-cache tests above.
+    test.skipIf(isWindows)("warm cache with mismatched bin name does not bypass --minimum-release-age", async () => {
+      // Regression: for scoped packages like `@angular/cli` (bin `ng`), bunx's
+      // first cache probe looks for `.bin/<initial_bin_name>` where the guess
+      // comes from the last path segment — here `cli`. That probe misses
+      // because the real bin is `ng`. Execution falls through to
+      // `get_bin_name_from_temp_directory` which reads the cached
+      // package.json's `bin` field, rewrites the probe path, and a second
+      // `which` call hits `.bin/ng` → `Run::run_binary`.
+      //
+      // Without threading the age gate into the cached-package.json
+      // staleness check, this path never sees `--minimum-release-age` and
+      // silently runs the cached (possibly-too-new) binary.
+      using dir = tempDir("bunx-min-age-bin-mismatch", {});
+      using cacheDir = tempDir("bunx-min-age-cache-bin-mismatch", {});
+      using tmp = tempDir("bunx-min-age-tmp-bin-mismatch", {});
+
+      const uid = process.getuid?.() ?? 0;
+      // Use a scoped package so `initial_bin_name` (= last segment after `/`)
+      // doesn't match the real bin name — exactly the `@angular/cli` → `ng`
+      // shape. `package_fmt` on disk becomes literally `@scope/name@latest`.
+      const pkgName = "@fake-scope/bin-mismatch";
+      const realBin = "mytool";
+      const cacheRoot = join(String(tmp), `bunx-${uid}-${pkgName}@latest`);
+      const pkgDir = join(cacheRoot, "node_modules", pkgName);
+      const binDir = join(cacheRoot, "node_modules", ".bin");
+      mkdirSync(pkgDir, { recursive: true });
+      mkdirSync(binDir, { recursive: true });
+
+      // Root package.json — bunx uses its mtime for the 24h staleness check.
+      writeFileSync(join(cacheRoot, "package.json"), JSON.stringify({}));
+      // Target package's package.json — bin name differs from last segment.
+      writeFileSync(
+        join(pkgDir, "package.json"),
+        JSON.stringify({ name: pkgName, version: "1.0.0", bin: { [realBin]: `./bin/${realBin}.js` } }),
+      );
+      // The fake cached binary at the real bin name.
+      const binPath = join(binDir, realBin);
+      writeFileSync(binPath, "#!/bin/sh\necho CACHE_BYPASS_BUG_REPRO\nexit 0\n");
+      chmodSync(binPath, 0o755);
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "x", "--minimum-release-age=3155760000", pkgName],
+        cwd: String(dir),
+        env: bunxEnv(String(cacheDir), String(tmp)),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).not.toContain("CACHE_BYPASS_BUG_REPRO");
+      expect(exitCode).not.toBe(0);
+    });
+
+    // `--minimum-release-age=0` is the documented disable spelling (see
+    // `handles 0 value to disable` above). bunx must honor that for the
+    // cache-bypass checks — otherwise `=0` unnecessarily forces re-resolution
+    // on a warm cache, and `--no-install --minimum-release-age=0` hard-errors
+    // instead of running the cached binary.
+    test.skipIf(isWindows)("--minimum-release-age=0 honors cached binary (disable semantics)", async () => {
+      using dir = tempDir("bunx-min-age-zero", {});
+      using cacheDir = tempDir("bunx-min-age-cache-zero", {});
+      using tmp = tempDir("bunx-min-age-tmp-zero", {});
+
+      const uid = process.getuid?.() ?? 0;
+      const binDir = join(String(tmp), `bunx-${uid}-regular-package@latest`, "node_modules", ".bin");
+      mkdirSync(binDir, { recursive: true });
+      const binPath = join(binDir, "regular-package");
+      writeFileSync(binPath, "#!/bin/sh\necho ZERO_DISABLE_OK\nexit 0\n");
+      chmodSync(binPath, 0o755);
+
+      // Without --no-install: should run the cached binary, not force
+      // re-resolution via `bun add`.
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "x", "--minimum-release-age=0", "regular-package"],
+        cwd: String(dir),
+        env: bunxEnv(String(cacheDir), String(tmp)),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toContain("ZERO_DISABLE_OK");
+      expect(stderr).not.toContain("Cannot use --no-install");
+      expect(exitCode).toBe(0);
+
+      // With --no-install: same, since =0 isn't an active gate.
+      await using proc2 = Bun.spawn({
+        cmd: [bunExe(), "x", "--no-install", "--minimum-release-age=0", "regular-package"],
+        cwd: String(dir),
+        env: bunxEnv(String(cacheDir), String(tmp)),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout2, stderr2, exitCode2] = await Promise.all([proc2.stdout.text(), proc2.stderr.text(), proc2.exited]);
+      expect(stdout2).toContain("ZERO_DISABLE_OK");
+      expect(stderr2).not.toContain("Cannot use --no-install");
+      expect(exitCode2).toBe(0);
+    });
+
+    // Same unix-only fake-cache layout as the other warm-cache tests.
+    test.skipIf(isWindows)(
+      "warm cache with local project install + version literal does not bypass --minimum-release-age",
+      async () => {
+        // Regression: when the project has a local `node_modules/<pkg>` install
+        // AND the user passes an explicit version (e.g. `bunx pkg@^1`),
+        // `get_bin_name` succeeds via `get_bin_name_from_project_directory`
+        // without consulting `force_stale`, then `'find2`'s local-bin probe
+        // is skipped (gated on `version.literal.is_empty()`), so execution
+        // hits the bunx-cache probe and `Run::run_binary` would run the
+        // cached binary with no age check.
+        using dir = tempDir("bunx-min-age-local-install", {});
+        using cacheDir = tempDir("bunx-min-age-cache-local-install", {});
+        using tmp = tempDir("bunx-min-age-tmp-local-install", {});
+
+        const pkgName = "@fake-scope/local-and-cached";
+        const realBin = "mytool";
+        const uid = process.getuid?.() ?? 0;
+
+        // 1. Local project install: `<cwd>/node_modules/<pkg>/package.json`
+        //    with a bin entry. `get_bin_name_from_project_directory` reads
+        //    this and returns the real bin name, bypassing force_stale.
+        const localPkgDir = join(String(dir), "node_modules", pkgName);
+        mkdirSync(localPkgDir, { recursive: true });
+        writeFileSync(
+          join(localPkgDir, "package.json"),
+          JSON.stringify({
+            name: pkgName,
+            version: "1.0.0",
+            bin: { [realBin]: `./bin/${realBin}.js` },
+          }),
+        );
+
+        // 2. Warm bunx cache for the requested version literal `^1`.
+        //    `package_fmt` includes the literal verbatim.
+        const cacheRoot = join(String(tmp), `bunx-${uid}-${pkgName}@^1`);
+        const cacheBinDir = join(cacheRoot, "node_modules", ".bin");
+        mkdirSync(cacheBinDir, { recursive: true });
+        // Root package.json for the 24h staleness check.
+        writeFileSync(join(cacheRoot, "package.json"), JSON.stringify({}));
+        // Cached binary at the REAL bin name (not the initial-guess `cli`-style
+        // name). If bunx wrongly falls through, this sentinel prints.
+        const binPath = join(cacheBinDir, realBin);
+        writeFileSync(binPath, "#!/bin/sh\necho CACHE_BYPASS_BUG_REPRO\nexit 0\n");
+        chmodSync(binPath, 0o755);
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "x", "--minimum-release-age=3155760000", `${pkgName}@^1`],
+          cwd: String(dir),
+          env: bunxEnv(String(cacheDir), String(tmp)),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stdout).not.toContain("CACHE_BYPASS_BUG_REPRO");
+        expect(exitCode).not.toBe(0);
+      },
+    );
+
+    // Same unix-only fake-cache layout as the other warm-cache tests.
+    test.skipIf(isWindows)("--no-install + --minimum-release-age + mismatched bin name: specific error", async () => {
+      // UX regression guard: when the bin name differs from the initial
+      // guess, bunx falls into `get_bin_name_from_temp_directory` with
+      // `force_stale=true` and returns `NeedToInstall`. The catch-all
+      // `if opts.no_install` that follows must surface the same specific
+      // "Cannot use --no-install with --minimum-release-age…" error the
+      // matched-bin `'find` path emits — not the generic "Could not find
+      // an existing '<initial-bin-name>' binary to run" message, which
+      // doesn't hint that the flag combination is the real problem.
+      using dir = tempDir("bunx-min-age-noinstall-mismatched", {});
+      using cacheDir = tempDir("bunx-min-age-cache-noinstall-mismatched", {});
+      using tmp = tempDir("bunx-min-age-tmp-noinstall-mismatched", {});
+
+      const pkgName = "@fake-scope/no-install-mismatch";
+      const realBin = "mytool";
+      const uid = process.getuid?.() ?? 0;
+
+      const cacheRoot = join(String(tmp), `bunx-${uid}-${pkgName}@latest`);
+      const pkgDir = join(cacheRoot, "node_modules", pkgName);
+      const binDir = join(cacheRoot, "node_modules", ".bin");
+      mkdirSync(pkgDir, { recursive: true });
+      mkdirSync(binDir, { recursive: true });
+
+      // Root package.json drives the 24h mtime staleness check.
+      writeFileSync(join(cacheRoot, "package.json"), JSON.stringify({}));
+      // Target package's package.json advertises a bin named `mytool`;
+      // the initial-guess bin name is `no-install-mismatch`.
+      writeFileSync(
+        join(pkgDir, "package.json"),
+        JSON.stringify({ name: pkgName, version: "1.0.0", bin: { [realBin]: `./bin/${realBin}.js` } }),
+      );
+      const binPath = join(binDir, realBin);
+      writeFileSync(binPath, "#!/bin/sh\necho CACHE_BYPASS_BUG_REPRO\nexit 0\n");
+      chmodSync(binPath, 0o755);
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "x", "--no-install", "--minimum-release-age=3155760000", pkgName],
+        cwd: String(dir),
+        env: bunxEnv(String(cacheDir), String(tmp)),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).not.toContain("CACHE_BYPASS_BUG_REPRO");
+      expect(stderr).toContain("--no-install");
+      expect(stderr).toContain("--minimum-release-age");
+      expect(exitCode).not.toBe(0);
+    });
+
+    test.skipIf(isWindows)("warm cache bun.lock is cleared before age-gated install", async () => {
+      // Regression: `--no-cache --force` to `bun add` is insufficient to
+      // force re-resolution under an active age gate when a `bun.lock`
+      // from a previous run survives in the bunx cache dir — `bun add`
+      // reuses the locked version even with `--force` for ranged
+      // specifiers like `pkg@^N`. The install path must wipe the tree
+      // before spawning `bun add` when an age gate is active.
+      //
+      // Seeds the warm cache (at a version-literal key) with a sentinel
+      // `bun.lock` and verifies the file is gone after the bunx
+      // invocation — the `delete_tree(bunx_cache_dir)` at the top of the
+      // install path ran. Uses `regular-package` (matched bin name, so
+      // the `'find` branch fires) and a range specifier so the final
+      // install step reaches `bun add` with `--no-cache --force`.
+      using dir = tempDir("bunx-min-age-lockfile", {});
+      using cacheDir = tempDir("bunx-min-age-cache-lockfile", {});
+      using tmp = tempDir("bunx-min-age-tmp-lockfile", {});
+
+      const pkgName = "regular-package";
+      const uid = process.getuid?.() ?? 0;
+
+      const cacheRoot = join(String(tmp), `bunx-${uid}-${pkgName}@^2`);
+      const binDir = join(cacheRoot, "node_modules", ".bin");
+      mkdirSync(binDir, { recursive: true });
+      writeFileSync(join(cacheRoot, "package.json"), JSON.stringify({}));
+      const lockPath = join(cacheRoot, "bun.lock");
+      writeFileSync(lockPath, "SENTINEL_LOCKFILE_CONTENT_SHOULD_BE_WIPED");
+      const binPath = join(binDir, pkgName);
+      writeFileSync(binPath, "#!/bin/sh\necho CACHE_BYPASS_BUG_REPRO\nexit 0\n");
+      chmodSync(binPath, 0o755);
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "x", "--minimum-release-age=3155760000", `${pkgName}@^2`],
+        cwd: String(dir),
+        env: bunxEnv(String(cacheDir), String(tmp)),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      // Sentinel binary must not have run.
+      expect(stdout).not.toContain("CACHE_BYPASS_BUG_REPRO");
+      // And the install step must have wiped the sentinel lockfile (the
+      // test doesn't care whether the wipe happened before or after the
+      // `bun add` failure, only that it happened at all).
+      if (existsSync(lockPath)) {
+        expect(readFileSync(lockPath, "utf8")).not.toContain("SENTINEL_LOCKFILE_CONTENT_SHOULD_BE_WIPED");
+      }
+      expect(exitCode).not.toBe(0);
     });
   });
 });

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -2591,6 +2591,13 @@ export const scanner = {
       npm_config_registry: mockRegistryUrl,
     });
 
+    // bunx's `is_trusted_cache_root` refuses a cache dir with group/other-write
+    // bits set (and this check runs BEFORE any age-gate logic). `mkdirSync`
+    // under umask 002 produces 0o775, so every warm-cache test below must
+    // `chmodSync(cacheRoot, 0o755)` after creating the tree — otherwise the
+    // tests fail (or pass vacuously) on umask-002 systems. CI runs umask 022
+    // so this only bites local contributors; mirrors `bunx.test.ts`'s setup.
+
     test("--minimum-release-age=<seconds> is forwarded to bun add", async () => {
       using dir = tempDir("bunx-min-age-eq", {});
       using cacheDir = tempDir("bunx-min-age-cache-eq", {});
@@ -2699,6 +2706,7 @@ export const scanner = {
       const binDir = join(cacheRoot, "node_modules", ".bin");
       mkdirSync(pkgDir, { recursive: true });
       mkdirSync(binDir, { recursive: true });
+      chmodSync(cacheRoot, 0o755);
       writeFileSync(join(cacheRoot, "package.json"), JSON.stringify({}));
       writeFileSync(
         join(pkgDir, "package.json"),
@@ -2752,8 +2760,10 @@ export const scanner = {
       using tmp = tempDir("bunx-min-age-tmp-warm", {});
 
       const uid = process.getuid?.() ?? 0;
-      const binDir = join(String(tmp), `bunx-${uid}-regular-package@latest`, "node_modules", ".bin");
+      const cacheRoot = join(String(tmp), `bunx-${uid}-regular-package@latest`);
+      const binDir = join(cacheRoot, "node_modules", ".bin");
       mkdirSync(binDir, { recursive: true });
+      chmodSync(cacheRoot, 0o755);
       const binPath = join(binDir, "regular-package");
       // If bunx wrongly short-circuits to the cache, this fake binary runs
       // and prints a sentinel the test asserts *never* appears.
@@ -2786,8 +2796,10 @@ export const scanner = {
       using tmp = tempDir("bunx-min-age-tmp-noinstall", {});
 
       const uid = process.getuid?.() ?? 0;
-      const binDir = join(String(tmp), `bunx-${uid}-regular-package@latest`, "node_modules", ".bin");
+      const cacheRoot = join(String(tmp), `bunx-${uid}-regular-package@latest`);
+      const binDir = join(cacheRoot, "node_modules", ".bin");
       mkdirSync(binDir, { recursive: true });
+      chmodSync(cacheRoot, 0o755);
       const binPath = join(binDir, "regular-package");
       writeFileSync(binPath, "#!/bin/sh\necho CACHE_BYPASS_BUG_REPRO\nexit 0\n");
       chmodSync(binPath, 0o755);
@@ -2835,6 +2847,7 @@ export const scanner = {
       const binDir = join(cacheRoot, "node_modules", ".bin");
       mkdirSync(pkgDir, { recursive: true });
       mkdirSync(binDir, { recursive: true });
+      chmodSync(cacheRoot, 0o755);
 
       // Root package.json — bunx uses its mtime for the 24h staleness check.
       writeFileSync(join(cacheRoot, "package.json"), JSON.stringify({}));
@@ -2872,8 +2885,10 @@ export const scanner = {
       using tmp = tempDir("bunx-min-age-tmp-zero", {});
 
       const uid = process.getuid?.() ?? 0;
-      const binDir = join(String(tmp), `bunx-${uid}-regular-package@latest`, "node_modules", ".bin");
+      const cacheRoot = join(String(tmp), `bunx-${uid}-regular-package@latest`);
+      const binDir = join(cacheRoot, "node_modules", ".bin");
       mkdirSync(binDir, { recursive: true });
+      chmodSync(cacheRoot, 0o755);
       const binPath = join(binDir, "regular-package");
       writeFileSync(binPath, "#!/bin/sh\necho ZERO_DISABLE_OK\nexit 0\n");
       chmodSync(binPath, 0o755);
@@ -2944,6 +2959,7 @@ export const scanner = {
         const cacheRoot = join(String(tmp), `bunx-${uid}-${pkgName}@^1`);
         const cacheBinDir = join(cacheRoot, "node_modules", ".bin");
         mkdirSync(cacheBinDir, { recursive: true });
+        chmodSync(cacheRoot, 0o755);
         // Root package.json for the 24h staleness check.
         writeFileSync(join(cacheRoot, "package.json"), JSON.stringify({}));
         // Cached binary at the REAL bin name (not the initial-guess `cli`-style
@@ -2989,6 +3005,7 @@ export const scanner = {
       const binDir = join(cacheRoot, "node_modules", ".bin");
       mkdirSync(pkgDir, { recursive: true });
       mkdirSync(binDir, { recursive: true });
+      chmodSync(cacheRoot, 0o755);
 
       // Root package.json drives the 24h mtime staleness check.
       writeFileSync(join(cacheRoot, "package.json"), JSON.stringify({}));
@@ -3041,6 +3058,7 @@ export const scanner = {
       const cacheRoot = join(String(tmp), `bunx-${uid}-${pkgName}@^2`);
       const binDir = join(cacheRoot, "node_modules", ".bin");
       mkdirSync(binDir, { recursive: true });
+      chmodSync(cacheRoot, 0o755);
       writeFileSync(join(cacheRoot, "package.json"), JSON.stringify({}));
       const lockPath = join(cacheRoot, "bun.lock");
       writeFileSync(lockPath, "SENTINEL_LOCKFILE_CONTENT_SHOULD_BE_WIPED");


### PR DESCRIPTION
Fixes #30748.

## Repro

```console
$ rm -rf /tmp/x && mkdir -p /tmp/x && cd /tmp/x
$ bun x --minimum-release-age=3155760000 tsx --version
Resolving dependencies
Resolved, downloaded and extracted [63]
Saved lockfile
tsx v4.22.0
node v24.3.0
```

The 100-year gate (`3155760000` seconds) was silently ignored — `tsx` installed and ran the latest version anyway. `bun add --minimum-release-age=3155760000 tsx` with the same value correctly errors with *"All versions of tsx blocked by minimum-release-age"*, confirming the flag works for `bun install`/`bun add` but not for `bunx`.

## Cause

`bunx`'s arg parser in `src/runtime/cli/bunx_command.rs` recognizes a small whitelist (`--version`, `--revision`, `--verbose`, `--silent`, `--bun`/`-b`, `--no-install`, `--package`/`-p`) and lets every other `--flag` fall through the `if/else if` chain without being rejected *or* being forwarded. When `bunx` decides to install a package it spawns `bun add` with a hardcoded arg list that only adds the whitelisted flags:

```rust
let install_args = [self_exe, b"add", install_param, b"--no-summary"];
// + optionally --no-cache --force, --verbose, --silent
```

`--minimum-release-age` was never appended, so the spawned `bun add` never saw it → silent no-op.

## Fix

- Parse `--minimum-release-age=<N>` and `--minimum-release-age <N>` in `Options::parse`; store the value verbatim as opaque bytes (so `bun add` re-parses and validates — no duplication of the `parse_double` + range logic that already lives in `CommandLineArguments.rs`).
- Append `--minimum-release-age=<N>` to the spawned `bun add` argv. Grow the `BoundedArray` capacity from 8 to 9 to match.
- Error on missing value in the spaced form, matching `--package`'s behavior.

## Verification

```console
$ rm -rf /tmp/x && mkdir -p /tmp/x && cd /tmp/x
$ BUN_DEBUG_bunx=1 bun x --minimum-release-age=3155760000 tsx --version
[bunx] installing package: .../bun-debug add tsx@latest --no-summary --no-cache --force --minimum-release-age=3155760000
Resolving dependencies
Resolved, downloaded and extracted [2]
error: Package "tsx" with tag "latest" not found (all versions blocked by minimum-release-age: 3155760000 seconds)
error: tsx@latest failed to resolve
```

Spaced form (`--minimum-release-age 3155760000 tsx`) and `=0` passthrough also verified.

## Tests

Added three cases to `test/cli/install/minimum-release-age.test.ts` under a new `describe("bunx")` block, reusing the existing mock registry:

- `--minimum-release-age=<seconds>` is forwarded to `bun add`
- `--minimum-release-age <seconds>` (spaced) is forwarded to `bun add`
- `--minimum-release-age` with no value errors with "requires a value"

Each test isolates `BUN_INSTALL_CACHE_DIR` and `TMPDIR` per-test so `bunx`'s install cache can't mask the flag's effect.

Without the fix all 3 tests fail (the spaced form is even more obvious: `bunx` interprets `3155760000` as the package name and 404s). With the fix all pass. Full suite (51 tests) passes and `bunx.test.ts --package` still passes.

## Note: bake-codegen workaround bundled

The debug build on main currently fails in `src/codegen/bake-codegen.ts` because `OVERLAY_CSS` passes raw minified CSS as a `Bun.build` define value, which the Rust JSON lexer rejects with *"Operators are not allowed in JSON"* on the leading `*{...}`. One-line workaround: wrap the value in `JSON.stringify` so it's a valid JSON string, matching how the other three defines are passed. A proper JSON-lexer fix is in flight at #30679 — once that lands this workaround is a no-op.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 26 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/minimum-release-age.test.ts

<!-- robobun:evidence:end -->