### PR TITLE
bun-types: rename Bun.WebView back()/forward() to goBack()/goForward()

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8958,9 +8958,9 @@ declare module "bun" {
     resize(width: number, height: number): Promise<void>;
 
     /** Navigate back in session history. */
-    back(): Promise<void>;
+    goBack(): Promise<void>;
     /** Navigate forward in session history. */
-    forward(): Promise<void>;
+    goForward(): Promise<void>;
     /** Reload the current page. */
     reload(): Promise<void>;
 

--- a/test/integration/bun-types/fixture/webview.ts
+++ b/test/integration/bun-types/fixture/webview.ts
@@ -1,0 +1,19 @@
+import { expectType } from "./utilities";
+
+// https://github.com/oven-sh/bun/issues/30754
+// Bun.WebView's runtime exposes goBack()/goForward() (registered on the
+// prototype in src/runtime/webview/JSWebViewPrototype.cpp); the types once
+// advertised back()/forward(), which never existed at runtime.
+
+declare const webview: Bun.WebView;
+
+expectType(webview.goBack()).is<Promise<void>>();
+expectType(webview.goForward()).is<Promise<void>>();
+
+// The legacy names must stay rejected. The directives below are only
+// satisfied while back()/forward() are absent from the type; reintroducing
+// either makes the directive unused and fails this fixture's typecheck.
+// @ts-expect-error runtime API uses goBack(), not back()
+webview.back();
+// @ts-expect-error runtime API uses goForward(), not forward()
+webview.forward();


### PR DESCRIPTION
Fixes #30754

## What

`Bun.WebView` registers `goBack` / `goForward` on its prototype, but the
type declarations in `@types/bun` advertised them as `back` / `forward`.
Following the types got you `TypeError: view.back is not a function` at
runtime; calling the real `view.goBack()` got you a "property does not
exist" error in the IDE.

```ts
// From the issue.
await view.goBack();   // works at runtime, but IDE says 'does not exist'
await view.back();     // type-checks, throws TypeError at runtime
```

## Cause

Method registration in `src/runtime/webview/JSWebViewPrototype.cpp`:

```cpp
{ "goBack"_s,    ..., jsWebViewProtoFuncBack,    0 },
{ "goForward"_s, ..., jsWebViewProtoFuncForward, 0 },
```

All internal C++ code (`WebViewHost::goBack`, `CDP::Ops::goBack`,
`WK::Ops::goBack`) and existing tests (`webview-chrome.test.ts`) use
`goBack`/`goForward`. The `.d.ts` was the only place that deviated.

## Fix

Rename the two methods in `packages/bun-types/bun.d.ts` to match the
runtime. This is a types-only change, no native behavior changes.

## Verification

Adds `test/integration/bun-types/fixture/webview.ts`, which the bun-types
integration suite (`test/integration/bun-types/bun-types.test.ts`)
type-checks along with the other fixtures. It asserts `goBack()` /
`goForward()` resolve as `Promise<void>`, and marks `back()` / `forward()`
with `@ts-expect-error` so reintroducing either legacy name also fails.

Reverting the `bun.d.ts` rename makes the fixture fail to type-check
(`goBack`/`goForward` error with TS2551, and the `@ts-expect-error`
directives become unused, TS2578), so the suite turns red.

```console
$ bun test test/integration/bun-types/bun-types.test.ts
12 pass, 0 fail
```
