### PR TITLE
WebKit: fix Set iteration corrupting large-integer keys to INT32_MIN (#30757)

### DIFF
--- a/test/regression/issue/30757.test.ts
+++ b/test/regression/issue/30757.test.ts
@@ -1,0 +1,131 @@
+// https://github.com/oven-sh/bun/issues/30757
+// Set/Map iteration corrupted oversized integer-valued doubles to INT32_MIN.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test.concurrent("Set iteration preserves numeric values outside Int32 range", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const values = [
+        1751241600000,          // epoch-ms timestamp from the bug report
+        2147483648,             // INT32_MAX + 1
+        -2147483649,            // INT32_MIN - 1
+        4294967296,             // 2^32
+        Number.MAX_SAFE_INTEGER,
+        -Number.MAX_SAFE_INTEGER,
+        1e15,
+      ];
+      const out = {};
+      for (const v of values) {
+        out[String(v)] = [...new Set([v])][0];
+      }
+      // ±Infinity and NaN can't round-trip through JSON (all three serialize
+      // to null), so do identity checks in-subprocess and ship the booleans.
+      out.posInfPreserved = [...new Set([Infinity])][0] === Infinity;
+      out.negInfPreserved = [...new Set([-Infinity])][0] === -Infinity;
+      out.nanPreserved = Number.isNaN([...new Set([NaN])][0]);
+      console.log(JSON.stringify(out));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    "1751241600000": 1751241600000,
+    "2147483648": 2147483648,
+    "-2147483649": -2147483649,
+    "4294967296": 4294967296,
+    "9007199254740991": Number.MAX_SAFE_INTEGER,
+    "-9007199254740991": -Number.MAX_SAFE_INTEGER,
+    "1000000000000000": 1e15,
+    posInfPreserved: true,
+    negInfPreserved: true,
+    nanPreserved: true,
+  });
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("Set.has does not match the INT32_MIN corruption target after normalization", async () => {
+  // Before the fix, `add(1751241600000)` normalized the key to INT32_MIN,
+  // so `s.has(-2147483648)` spuriously returned true. Size was 1 either
+  // way, but adding multiple oversized doubles collapsed them all into a
+  // single bucket.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const s = new Set();
+      s.add(1);
+      s.add(2);
+      s.add(1751241600000);
+      s.add(9007199254740991);
+      console.log(JSON.stringify({
+        size: s.size,
+        iterated: [...s],
+        hasOriginal: s.has(1751241600000),
+        hasCorruptionTarget: s.has(-2147483648),
+      }));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    size: 4,
+    iterated: [1, 2, 1751241600000, 9007199254740991],
+    hasOriginal: true,
+    hasCorruptionTarget: false,
+  });
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("Map iteration preserves numeric keys outside Int32 range", async () => {
+  // Map shares normalizeMapKey with Set via OrderedHashTable. Cover it
+  // too so the fix is locked in for both.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const m = new Map();
+      m.set(1751241600000, "a");
+      m.set(9007199254740991, "b");
+      m.set(1, "c");
+      console.log(JSON.stringify({
+        size: m.size,
+        keys: [...m.keys()],
+        values: [...m.values()],
+        getOriginal: m.get(1751241600000),
+        getCorruptionTarget: m.get(-2147483648) ?? null,
+      }));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    size: 3,
+    keys: [1751241600000, 9007199254740991, 1],
+    values: ["a", "b", "c"],
+    getOriginal: "a",
+    getCorruptionTarget: null,
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #30757.

## Root cause

WebKit `HashMapHelper.h::normalizeMapKey` did `int i = static_cast<int>(d)` before its `i == d` round-trip check. Out-of-range `static_cast<int>(double)` is UB (LLVM `fptosi` → poison); under LTO the optimizer folded the branch and the integer path was always taken, normalizing every oversized integer-valued double key to `jsNumber(INT32_MIN)`. Non-LTO builds got away with it because hardware `cvttsd2si` returns INT32_MIN on overflow and the compare filtered the bad case.

```js
[...new Set([1751241600000])][0]       // got: -2147483648, want: 1751241600000
new Set([1751241600000]).has(-1 << 31) // true (spurious)
```

`.has(originalValue)` still worked because lookup hashed the stored (corrupted) normalized key against itself. Tagged Int32s, fractional doubles, strings — all unaffected.

## Fix

Fixed in WebKit by replacing the UB cast with `truncateDoubleToInt32` (`Source/WTF/wtf/MathExtras.h` — hardware `cvttsd2si` on x86_64, `fcvtzs` on arm64), which returns INT32_MIN on overflow so the subsequent `i == d` filter works as intended. Picked up in bun when main bumped WebKit to `0d85951a`.

## Test

`test/regression/issue/30757.test.ts` — three concurrent tests spawning subprocesses to exercise the real iteration path:

- `Set` round-trip preserves every value in the failure table (timestamp, ±(INT32_MAX+1), 2^32, MAX_SAFE_INTEGER, ±Infinity (identity-checked in-subprocess), NaN)
- `s.size` stays 4 with mixed small + oversized keys and `s.has(-2147483648)` no longer spuriously matches oversized keys
- Same shape for `Map` (same normalizer)

Coverage note: the Set/Map corruption only manifests in LTO release builds (UB-under-LTO), so `bun bd` passes with or without the WebKit pin. Real coverage lands in the Linux release-LTO CI lane, which exercised the failing path against the pre-fix WebKit and now passes against `0d85951a`.