### PR TITLE
build: enable parallel rustc frontend via -Zthreads=8

### DIFF
--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -412,6 +412,8 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
       : // armv8-a+crc isn't a CPU name — closest LLVM model with CRC baseline:
         "cortex-a72";
   rustflags.push(`-Ctarget-cpu=${cpuTarget}`);
+  // Parallelize the otherwise single-threaded rustc frontend (nightly-only).
+  rustflags.push("-Zthreads=8");
   // `bun_core::build_options::ENABLE_ASAN = cfg!(bun_asan)` — must agree with
   // the C++ `ASAN_ENABLED` macro so Global::exit() picks the same libc exit
   // path (`exit` vs `quick_exit`) that c-bindings.cpp registered Bun__onExit on.


### PR DESCRIPTION
## Summary

- Each crate's rustc frontend (parse, macro expansion, name resolution, type/borrow check, MIR) runs single-threaded by default. Cargo parallelizes across crates and rustc parallelizes codegen across codegen-units, but the frontend does not.
- The workspace crate graph is a funnel: ~110 crates collapse into a few large leaf crates (`bun_runtime`, `bun_css`, `bun_bundler`) that cannot start until their transitive deps finish. The tail of every cargo build is one large crate's frontend pinned to a single core while the rest of the machine sits idle.
- `-Zthreads=8` parallelizes that frontend. It is nightly-only, but the toolchain is already pinned to nightly and the build already passes `-Zbuild-std`, `-Zsanitizer`, and `-Zlocation-detail`, so this adds no new constraint.

## Test plan

- [ ] `bun bd` completes successfully (full debug build, no rustc ICE)
- [ ] Resulting `bun-debug` runs (`--revision` and a basic JS eval)
- [ ] Confirm `-Zthreads=8` is present in the cargo `CARGO_ENCODED_RUSTFLAGS` of generated `build.ninja`
- [ ] Benchmark clean cargo build wall-time on an idle machine, baseline vs. this change, interleaved and median-of-N
- [ ] CI green across targets (the rust-only job in particular)