### PR TITLE
install: close per-file fds in isolated FileCopier

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1766,7 +1766,12 @@ mod draft {
                     .store(handle as *mut core::ffi::c_void, Ordering::Relaxed);
             }
         }
-        #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android", target_os = "freebsd"))]
+        #[cfg(any(
+            target_os = "macos",
+            target_os = "linux",
+            target_os = "android",
+            target_os = "freebsd"
+        ))]
         {
             reset_on_posix();
         }
@@ -2907,7 +2912,12 @@ mod draft {
             let _ = spawn_result;
             let _ = url;
         }
-        #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android", target_os = "freebsd"))]
+        #[cfg(any(
+            target_os = "macos",
+            target_os = "linux",
+            target_os = "android",
+            target_os = "freebsd"
+        ))]
         {
             let mut buf = bun_core::PathBuffer::default();
             let mut buf2 = bun_core::PathBuffer::default();

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -409,7 +409,12 @@ mod errno_name_tests {
         assert_eq!(Error::from_errno(0), Error::UNEXPECTED);
         assert_eq!(Error::from_errno(9999), Error::UNEXPECTED);
         // errno 11 is platform-specific: EAGAIN on linux/windows, EDEADLK on darwin/bsd.
-        #[cfg(any(target_os = "linux", target_os = "android", windows, target_family = "wasm"))]
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "android",
+            windows,
+            target_family = "wasm"
+        ))]
         {
             assert_eq!(Error::from_errno(11), Error::intern("EAGAIN"));
             assert_eq!(Error::from_errno(104), Error::intern("ECONNRESET"));
@@ -464,7 +469,12 @@ mod errno_name_tests {
             coreutils_error_map::get(2),
             Some("No such file or directory")
         );
-        #[cfg(any(target_os = "linux", target_os = "android", windows, target_family = "wasm"))]
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "android",
+            windows,
+            target_family = "wasm"
+        ))]
         assert_eq!(
             coreutils_error_map::get(11),
             Some("Resource temporarily unavailable")

--- a/src/install/isolated_install/FileCopier.rs
+++ b/src/install/isolated_install/FileCopier.rs
@@ -242,7 +242,10 @@ impl FileCopier {
                             return sys::Result::Err(err);
                         }
                     };
-                // `defer src.close()` → handled by Drop on `src`.
+                // Zig: `defer src.close()`. `Fd` is Copy with no Drop impl,
+                // so close explicitly via guard — otherwise every iteration
+                // leaks an fd until the rlimit is exhausted.
+                let _close_src = sys::CloseOnDrop::new(src);
 
                 let dest = match dest_dir.create_file_z(entry.path, Default::default()) {
                     Ok(f) => f,
@@ -269,7 +272,8 @@ impl FileCopier {
                         }
                     }
                 };
-                // `defer dest.close()` → handled by Drop on `dest`.
+                // Zig: `defer dest.close()`. `File` is Copy with no Drop impl.
+                let _close_dest = sys::CloseOnDrop::file(&dest);
 
                 #[cfg(unix)]
                 {

--- a/src/perf/tracy.rs
+++ b/src/perf/tracy.rs
@@ -756,7 +756,12 @@ fn dlsym<T: Copy>(symbol: &'static core::ffi::CStr) -> Option<T> {
                 ];
                 #[cfg(windows)]
                 const PATHS_TO_TRY: &[&core::ffi::CStr] = &[c"tracy.dll"];
-                #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android", windows)))]
+                #[cfg(not(any(
+                    target_os = "macos",
+                    target_os = "linux",
+                    target_os = "android",
+                    windows
+                )))]
                 const PATHS_TO_TRY: &[&core::ffi::CStr] = &[];
 
                 // TODO(port): RTLD flags — Zig used `@bitCast(@as(i32, -2))` on

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -679,7 +679,10 @@ pub const BASE_RUNTIME_TRANSPILER_PARAMS: &[ParamType] =
 // built with `comptime_table!(.., cold)` and stay in plain `.rodata`, where
 // `src/startup.order` can still cluster the ones a sampled cold path actually
 // hits without weighing down the `.rodata.startup` fault-around window.
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".rodata.startup"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".rodata.startup")
+)]
 pub static AUTO_TABLE: &clap::ConvertedTable = clap::comptime_table!(AUTO_PARAMS);
 pub static RUN_TABLE: &clap::ConvertedTable = clap::comptime_table!(RUN_PARAMS, cold);
 pub static BUILD_TABLE: &clap::ConvertedTable = clap::comptime_table!(BUILD_PARAMS, cold);

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -545,7 +545,10 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
     /// not share `.text` pages with the hot `bun run <script>` dispatch path.
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn configure_run_transpiler_linker(this_transpiler: &mut Transpiler<'static>) {
         this_transpiler.resolver.opts.load_tsconfig_json = true;
         this_transpiler.options.load_tsconfig_json = true;
@@ -863,7 +866,10 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
     /// initializing JSC.
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn boot_bun_shell(
         ctx: &mut ContextData,
         entry_path: &[u8],
@@ -1662,7 +1668,10 @@ fn log_clear_msgs(vm: &mut VirtualMachine) {
 
 #[cold]
 #[inline(never)]
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".text.unlikely")
+)]
 fn dump_build_error(vm: &mut VirtualMachine) {
     Output::flush();
     if let Some(log) = vm.log {
@@ -1682,7 +1691,10 @@ fn dump_build_error(vm: &mut VirtualMachine) {
 /// `.text.hot` fault-around window the `require('fs')` startup path pulls in.
 #[cold]
 #[inline(never)]
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".text.unlikely")
+)]
 fn exit_with_unhandled_note(vm: &mut VirtualMachine) -> ! {
     vm.exit_handler.exit_code = 1;
     vm.on_exit();
@@ -1696,7 +1708,10 @@ fn exit_with_unhandled_note(vm: &mut VirtualMachine) -> ! {
 /// Cold `Err(err)` arm of `vm.load_entry_point` in `Run::start`.
 #[cold]
 #[inline(never)]
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".text.unlikely")
+)]
 fn entry_point_load_failed(vm: &mut VirtualMachine, err: &bun_core::Error) -> ! {
     if log_has_msgs(vm) {
         dump_build_error(vm);
@@ -1715,7 +1730,10 @@ fn entry_point_load_failed(vm: &mut VirtualMachine, err: &bun_core::Error) -> ! 
 /// exit: bump the exit code and print the sourcemap note + version string.
 #[cold]
 #[inline(never)]
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".text.unlikely")
+)]
 fn print_unhandled_version_note(vm: &mut VirtualMachine) {
     vm.exit_handler.exit_code = 1;
     bun_sourcemap::SavedSourceMap::MissingSourceMapNoteInfo::print();
@@ -1755,7 +1773,10 @@ impl RunCommand {
     /// `.text.hot` fault-around window the `require('fs')` startup path pulls in.
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn boot_failed_exit(ctx: &mut ContextData, display_name: &[u8], err: &bun_core::Error) -> ! {
         // SAFETY: `ctx.log` was set in `create_context_data` (single-threaded
         // CLI startup) and is process-lifetime.
@@ -3015,7 +3036,10 @@ impl RunCommand {
 
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn exec_as_if_node_missing_script() -> ! {
         Output::err_generic(
             "Missing script to execute. Bun's provided 'node' cli wrapper does not support a repl.",
@@ -3026,7 +3050,10 @@ impl RunCommand {
 
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn exec_as_if_node_boot_failed(
         ctx: &mut ContextData,
         basename: &[u8],

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -515,7 +515,12 @@ impl UpgradeCommand {
         {
             "powershell -c 'irm bun.sh/install.ps1|iex'"
         }
-        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "windows")))]
+        #[cfg(not(any(
+            target_os = "linux",
+            target_os = "android",
+            target_os = "macos",
+            target_os = "windows"
+        )))]
         {
             // TODO(port): Environment.os.displayString() at comptime
             "(TODO: Install script for this platform)"

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4505,13 +4505,14 @@ pub(crate) fn resolve_embedded_file_to_buf(
     // Spec ModuleLoader.zig:43-45 — `tmpname(extname, buf, bun.hash(file.name))`.
     let mut tmpname_buf = bun_paths::path_buffer_pool::get();
     let tmpfilename =
-        Fs::FileSystem::tmpname(extname, &mut tmpname_buf[..], bun_wyhash::hash(file_name))
-            .ok()?;
+        Fs::FileSystem::tmpname(extname, &mut tmpname_buf[..], bun_wyhash::hash(file_name)).ok()?;
 
     // Spec ModuleLoader.zig:47 — `bun.fs.FileSystem.instance.tmpdir()`.
     // SAFETY: `FileSystem::instance()` returns the process-global singleton
     // pointer (initialized at startup).
-    let tmpdir = (unsafe { &mut *Fs::FileSystem::instance() }).tmpdir().ok()?;
+    let tmpdir = (unsafe { &mut *Fs::FileSystem::instance() })
+        .tmpdir()
+        .ok()?;
     let tmpdir_fd: bun_sys::Fd = tmpdir.fd;
 
     // Spec ModuleLoader.zig:50-51 — `bun.Tmpfile.create(tmpdir, tmpfilename)`.

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -358,7 +358,10 @@ fn find_playwright_shell() -> Option<ZBox> {
     }
 
     // Fall back to the non-cft linux arm64 layout.
-    #[cfg(all(any(target_os = "linux", target_os = "android"), target_arch = "aarch64"))]
+    #[cfg(all(
+        any(target_os = "linux", target_os = "android"),
+        target_arch = "aarch64"
+    ))]
     {
         let bin_parts2: [&[u8]; 3] = [
             cache_dir,
@@ -633,7 +636,12 @@ fn read_dev_tools_active_port(out_buf: &mut Vec<u8>) -> Option<()> {
         b"BraveSoftware\\Brave-Browser\\User Data\\DevToolsActivePort",
         b"Microsoft\\Edge\\User Data\\DevToolsActivePort",
     ];
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android", windows)))]
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "linux",
+        target_os = "android",
+        windows
+    )))]
     let candidates: &[&[u8]] = &[];
 
     let mut path_buf = path_buffer_pool::get();

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -3224,7 +3224,10 @@ mod spawn_process_body {
             // that are read *after* the wait, so falling through to the memfd block
             // below is required.
             let status: Status = 'blk: {
-                if no_orphans && (cfg!(any(target_os = "linux", target_os = "android")) || cfg!(target_os = "macos")) {
+                if no_orphans
+                    && (cfg!(any(target_os = "linux", target_os = "android"))
+                        || cfg!(target_os = "macos"))
+                {
                     let ppid = ParentDeathWatchdog::ppid_to_watch().unwrap_or(0);
                     #[cfg(target_os = "macos")]
                     let r: Option<Maybe<Status>> = wait_mac_kqueue(
@@ -3245,7 +3248,11 @@ mod spawn_process_body {
                         &mut out_fds_to_wait_for,
                         &mut out_fds,
                     );
-                    #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
+                    #[cfg(not(any(
+                        target_os = "linux",
+                        target_os = "android",
+                        target_os = "macos"
+                    )))]
                     let r: Option<Maybe<Status>> = {
                         let _ = ppid;
                         None

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -775,7 +775,10 @@ pub fn spawn_process_posix(
     let mut dup_stdout_to_stderr: bool = false;
 
     // The label is only referenced from the Linux memfd fast-path below.
-    #[cfg_attr(not(any(target_os = "linux", target_os = "android")), allow(unused_labels))]
+    #[cfg_attr(
+        not(any(target_os = "linux", target_os = "android")),
+        allow(unused_labels)
+    )]
     'stdio: for i in 0..3usize {
         let fileno = Fd::from_native(FdT::try_from(i).unwrap());
         let flag: u32 = (if i == 0 {

--- a/test/cli/install/install-fd-leak.test.ts
+++ b/test/cli/install/install-fd-leak.test.ts
@@ -1,0 +1,117 @@
+import { Archive, spawn, write } from "bun";
+import { beforeAll, describe, expect, test } from "bun:test";
+import { rm } from "fs/promises";
+import { bunEnv, bunExe, isMacOS, isWindows, readdirSorted, tempDir } from "harness";
+import { join } from "path";
+
+// Installing a package with many files must not exhaust the file-descriptor
+// table. The Rust port of the isolated-install copyfile path
+// (`src/install/isolated_install/FileCopier.rs`) replaced Zig's
+// `defer src.close()` / `defer dest.close()` with comments saying "handled by
+// Drop", but `Fd` and `bun_sys::File` are Copy types with no Drop impl, so
+// every iteration leaked two fds and a low NOFILE rlimit triggered EMFILE.
+//
+// Run the matrix to keep all linker × backend copy paths covered. The package
+// comes from a local tarball so this never touches a registry, and each test
+// also re-installs after invalidating the existing copy to cover the
+// uninstall-then-reinstall path.
+
+const NUM_FILES = 1500;
+const FD_LIMIT = 1024;
+
+const LINKERS = ["isolated", "hoisted"] as const;
+const BACKENDS = (["copyfile", "hardlink"] as const).concat(isMacOS ? (["clonefile"] as const) : []);
+
+// `ulimit` isn't available on Windows; skip the matrix there.
+describe.skipIf(isWindows)("install does not leak file descriptors", () => {
+  let tgz: string;
+
+  beforeAll(async () => {
+    const pkgFiles: Record<string, string> = {
+      "package/package.json": JSON.stringify({ name: "many-files-pkg", version: "1.0.0" }),
+    };
+    for (let i = 0; i < NUM_FILES; i++) {
+      pkgFiles[`package/f${i}.js`] = `module.exports=${i};`;
+    }
+
+    // Don't `using` here: the tarball must outlive beforeAll.
+    const tgzDir = tempDir("fd-leak-tgz", {});
+    tgz = join(String(tgzDir), "many-files.tgz");
+    await Archive.write(tgz, pkgFiles, { compress: "gzip" });
+  });
+
+  for (const linker of LINKERS) {
+    for (const backend of BACKENDS) {
+      test.concurrent(`--linker=${linker} --backend=${backend}`, async () => {
+        using projDir = tempDir(`fd-leak-${linker}-${backend}`, {
+          "package.json": JSON.stringify({
+            name: "fd-leak-proj",
+            dependencies: { "many-files-pkg": `file:${tgz}` },
+          }),
+        });
+        // Per-test cache so cache state can't leak between matrix entries, and
+        // so cache → node_modules stays on the same filesystem (otherwise
+        // hardlink/clonefile silently fall back to copyfile and the matrix
+        // doesn't actually vary).
+        using cacheDir = tempDir(`fd-leak-cache-${linker}-${backend}`, {});
+
+        const installed =
+          linker === "isolated"
+            ? async () => {
+                const storeDir = (await readdirSorted(join(String(projDir), "node_modules", ".bun"))).find(d =>
+                  d.startsWith("many-files-pkg@"),
+                );
+                expect(storeDir).toBeDefined();
+                return join(String(projDir), "node_modules", ".bun", storeDir!, "node_modules", "many-files-pkg");
+              }
+            : async () => join(String(projDir), "node_modules", "many-files-pkg");
+
+        const install = async () => {
+          // Run with a low hard NOFILE limit. Bun raises the soft limit up to
+          // the hard limit at startup, so the hard limit is what bounds us.
+          // Without per-file fd cleanup, ~750 copyfile copies (2 fds each)
+          // exceed it.
+          await using proc = spawn({
+            cmd: [
+              "bash",
+              "-c",
+              `ulimit -Sn ${FD_LIMIT} && ulimit -Hn ${FD_LIMIT} && exec "$1" install --linker="$2" --backend="$3"`,
+              "bash",
+              bunExe(),
+              linker,
+              backend,
+            ],
+            cwd: String(projDir),
+            env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: String(cacheDir) },
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+          const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+          expect(stderr).not.toContain("EMFILE");
+          expect(exitCode).toBe(0);
+          // Confirm the copy actually happened — every file must land.
+          const files = await readdirSorted(await installed());
+          expect(files.length).toBe(NUM_FILES + 1); // + package.json
+        };
+
+        // Cold install: extract tarball → cache → node_modules.
+        await install();
+
+        // Invalidate the existing install so the next install must delete and
+        // re-copy from the warm cache. The verifier looks at different things
+        // per linker.
+        if (linker === "isolated") {
+          await rm(join(String(projDir), "node_modules", ".bun"), { recursive: true, force: true });
+        } else {
+          await write(
+            join(await installed(), "package.json"),
+            JSON.stringify({ name: "many-files-pkg", version: "0.0.0-stale" }),
+          );
+        }
+
+        // Warm reinstall: cache → uninstall → node_modules.
+        await install();
+      });
+    }
+  }
+});


### PR DESCRIPTION
## Summary

- `FileCopier::copy()` (the isolated-install copy path) opened a source `Fd` and a destination `File` per copied file but never closed either — the Rust port replaced Zig's `defer src.close()` / `defer dest.close()` with comments saying the close is "handled by Drop", but `Fd` and `bun_sys::File` are `Copy` types with no `Drop` impl. Installing a project whose isolated `node_modules` goes through the copyfile fallback (e.g. when the cache and project are on different filesystems) leaked ~2 fds per file until `EMFILE`.
- Add `sys::CloseOnDrop` guards mirroring the original Zig `defer`s.
- Add `test/cli/install/install-fd-leak.test.ts`: builds a 1500-file tarball with `Bun.Archive`, installs it under `ulimit -n 1024` across `--linker={isolated,hoisted}` × `--backend={copyfile,hardlink}` (+ `clonefile` on macOS), then invalidates the existing install and reinstalls to also cover the uninstall-then-reinstall path. Skipped on Windows (no `ulimit`). Each test gets its own `BUN_INSTALL_CACHE_DIR` so cache state can't leak between matrix entries.

Diagnosed via `strace`: a single `bun install` showed ~72k `openat()` against ~14k `close()`, with the per-thread trace showing only directory fds being released. The test fails on the unfixed binary at `EMFILE: copy file f503.js` (≈ 1024 / 2) and passes with the guards.

## Test plan

- [x] `bun bd test test/cli/install/install-fd-leak.test.ts`
- [x] `bun bd test test/cli/install/isolated-install.test.ts`
- [x] Verified the new test fails before the fix (`EMFILE: copy file f503.js`) and passes after
- [x] `bun install` against a real isolated project (~4.6k packages) now peaks at ~258 open fds, was previously hitting `EMFILE` at the rlimit