### PR TITLE
expect: avoid expanding DOM internals in truthy/falsy failures

### DIFF
--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -17,10 +17,14 @@ use super::bun_test::{self};
 use super::diff_format::DiffFormatter;
 use super::execution::ExpectAssertions;
 use super::jest::Jest;
-use super::expect::{JSValueTestExt, FormatterTestExt, make_formatter};
+use super::expect::{
+    dom_element_outer_html_prefix, make_formatter, FormatterTestExt, JSValueTestExt,
+};
 use crate::expect_throw as throw;
 
 use bun_jsc::js_error_to_write_error;
+
+const DOM_ELEMENT_HTML_MAX_LEN: usize = 10_000;
 
 // Matcher submodules are declared in `super::expect` (mod.rs); this file
 // provides only the `Expect` payload + helpers they extend.
@@ -2047,6 +2051,35 @@ impl Expect {
             "\n\nReceived: <red>{}<r>\n",
             value.to_fmt(&mut formatter),
         )
+    }
+
+    #[inline]
+    pub fn run_boolean_matcher_predicate(
+        &self,
+        global: &JSGlobalObject,
+        frame: &CallFrame,
+        matcher_name: &'static str,
+        pred: impl FnOnce(JSValue) -> bool,
+    ) -> JsResult<JSValue> {
+        let (this, value, not) = self.matcher_prelude(global, frame.this(), matcher_name, "")?;
+        if pred(value) != not {
+            return Ok(JSValue::UNDEFINED);
+        }
+        let signature = Self::get_signature(matcher_name, "", not);
+        if let Some(received) = dom_element_outer_html_prefix(value, global, DOM_ELEMENT_HTML_MAX_LEN)? {
+            throw!(
+                this, global, signature,
+                "\n\nReceived: <red>{}<r>\n",
+                bstr::BStr::new(&received),
+            )
+        } else {
+            let mut formatter = make_formatter(global);
+            throw!(
+                this, global, signature,
+                "\n\nReceived: <red>{}<r>\n",
+                value.to_fmt(&mut formatter),
+            )
+        }
     }
 
     /// Shared scaffold for one-arg `expect(v).toStartWith/toEndWith/toInclude(expected)`

--- a/src/runtime/test_runner/expect/simple_matchers.rs
+++ b/src/runtime/test_runner/expect/simple_matchers.rs
@@ -14,7 +14,6 @@ crate::unary_predicate_matcher!(to_be_date, "toBeDate", |v| v.is_date());
 crate::unary_predicate_matcher!(to_be_defined, "toBeDefined", |v| !v.is_undefined());
 crate::unary_predicate_matcher!(to_be_false, "toBeFalse", |v| v.is_boolean()
     && !v.to_boolean());
-crate::unary_predicate_matcher!(to_be_falsy, "toBeFalsy", |v| !v.to_boolean());
 crate::unary_predicate_matcher!(to_be_function, "toBeFunction", |v| v.is_callable());
 crate::unary_predicate_matcher!(to_be_integer, "toBeInteger", |v| v.is_any_int());
 // codegen snake-cases `toBeNaN` → `to_be_na_n`
@@ -26,7 +25,6 @@ crate::unary_predicate_matcher!(to_be_number, "toBeNumber", |v| v.is_number());
 crate::unary_predicate_matcher!(to_be_string, "toBeString", |v| v.is_string());
 crate::unary_predicate_matcher!(to_be_symbol, "toBeSymbol", |v| v.is_symbol());
 crate::unary_predicate_matcher!(to_be_true, "toBeTrue", |v| v.is_boolean() && v.to_boolean());
-crate::unary_predicate_matcher!(to_be_truthy, "toBeTruthy", |v| v.to_boolean());
 crate::unary_predicate_matcher!(to_be_undefined, "toBeUndefined", |v| v.is_undefined());
 
 crate::unary_predicate_matcher!(to_be_finite, "toBeFinite", |v| v.is_number() && {
@@ -41,6 +39,22 @@ crate::unary_predicate_matcher!(to_be_positive, "toBePositive", |v| v.is_number(
     let n = v.as_number();
     n.round() > 0.0 && !n.is_infinite() && !n.is_nan()
 });
+
+impl Expect {
+    #[bun_jsc::host_fn(method)]
+    pub fn to_be_falsy(&self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+        self.run_boolean_matcher_predicate(global, frame, "toBeFalsy", |value| {
+            !value.to_boolean()
+        })
+    }
+
+    #[bun_jsc::host_fn(method)]
+    pub fn to_be_truthy(&self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+        self.run_boolean_matcher_predicate(global, frame, "toBeTruthy", |value| {
+            value.to_boolean()
+        })
+    }
+}
 
 // ── numeric ordering: toBe{Greater,Less}Than[OrEqual] ──────────────────────
 impl Expect {

--- a/src/runtime/test_runner/mod.rs
+++ b/src/runtime/test_runner/mod.rs
@@ -289,6 +289,83 @@ pub mod expect {
         f
     }
 
+    #[inline]
+    fn dom_element_outer_html_value(value: JSValue, global: &JSGlobalObject) -> JsResult<Option<JSValue>> {
+        if !value.is_object() {
+            return Ok(None);
+        }
+
+        let Some(node_type) = value.get(global, "nodeType")? else {
+            return Ok(None);
+        };
+        if !node_type.is_number() || node_type.to_int32() != 1 {
+            return Ok(None);
+        }
+
+        let Some(outer_html) = value.get(global, "outerHTML")? else {
+            return Ok(None);
+        };
+
+        Ok(outer_html.is_string().then_some(outer_html))
+    }
+
+    #[inline]
+    pub fn is_dom_element_like(value: JSValue, global: &JSGlobalObject) -> JsResult<bool> {
+        Ok(dom_element_outer_html_value(value, global)?.is_some())
+    }
+
+    #[inline]
+    pub fn dom_element_outer_html(value: JSValue, global: &JSGlobalObject) -> JsResult<Option<Vec<u8>>> {
+        let Some(outer_html) = dom_element_outer_html_value(value, global)? else {
+            return Ok(None);
+        };
+
+        let outer_html = outer_html.to_slice(global)?;
+        Ok(Some(outer_html.slice().to_vec()))
+    }
+
+    pub fn dom_element_outer_html_prefix(
+        value: JSValue,
+        global: &JSGlobalObject,
+        max_len: usize,
+    ) -> JsResult<Option<Vec<u8>>> {
+        let Some(outer_html_value) = dom_element_outer_html_value(value, global)? else {
+            return Ok(None);
+        };
+        let outer_html = outer_html_value.get_zig_string(global)?;
+
+        // Each UTF-16 or Latin-1 code unit contributes at least one UTF-8 byte.
+        // One extra unit detects truncation and keeps a surrogate pair intact.
+        let input_limit = max_len.saturating_add(1);
+        let (mut output, read, input_len) = if outer_html.is_16_bit() {
+            let input = outer_html.utf16_slice();
+            let input = &input[..input.len().min(input_limit)];
+            let utf8_len = bun_core::strings::element_length_utf16_into_utf8(input);
+            let output_len = utf8_len.min(max_len);
+            let mut output = Vec::with_capacity(output_len.saturating_add(3));
+            output.resize(output_len, 0);
+            let copied = bun_core::strings::copy_utf16_into_utf8_with_utf8_len(&mut output, input, utf8_len);
+            output.truncate(copied.written as usize);
+            (output, copied.read as usize, input.len())
+        } else {
+            let input = outer_html.slice();
+            let input = &input[..input.len().min(input_limit)];
+            let output_len = bun_core::strings::element_length_latin1_into_utf8(input).min(max_len);
+            let mut output = Vec::with_capacity(output_len.saturating_add(3));
+            output.resize(output_len, 0);
+            let copied = bun_core::strings::copy_latin1_into_utf8(&mut output, input);
+            output.truncate(copied.written as usize);
+            (output, copied.read as usize, input.len())
+        };
+        if read < input_len || input_len < outer_html.length() {
+            output.extend_from_slice(b"...");
+        }
+
+        // `outer_html` borrows the JS string's storage until the prefix is copied.
+        outer_html_value.ensure_still_alive();
+        Ok(Some(output))
+    }
+
     // ── numeric ordering matchers (toBe{Greater,Less}Than[OrEqual]) ───────
     // The four matchers are near-identical; collapse to one body
     // parameterised by relation.

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -10,7 +10,7 @@ use bun_jsc::{
 };
 use bun_core::{strings, ZigString, ZigStringSlice};
 
-use super::expect;
+use super::expect::{self, dom_element_outer_html, is_dom_element_like};
 use crate::webcore::BlobExt as _;
 
 /// `<tag>` colour templates used by the formatter, rewritten to ANSI (or
@@ -404,6 +404,7 @@ pub enum Tag {
     ArrayBuffer,
 
     JSX,
+    DOMElement,
     Event,
 }
 
@@ -513,6 +514,13 @@ impl Tag {
                 {
                     return Ok(TagResult { tag: Tag::JSX, cell: js_type });
                 }
+            }
+
+            // Userland DOM implementations like happy-dom/jsdom are ordinary
+            // JS objects to JSC. Format their markup instead of recursively
+            // expanding implementation internals.
+            if is_dom_element_like(value, global_this)? {
+                return Ok(TagResult { tag: Tag::DOMElement, cell: js_type });
             }
         }
 
@@ -2376,6 +2384,19 @@ impl<'a> Formatter<'a> {
                         }
                     }
                 }
+                Tag::DOMElement => {
+                    if let Some(html) = dom_element_outer_html(value, self.global_this)? {
+                        writer.write_all(&html);
+                        self.add_for_new_line(html.len());
+                        return Ok(());
+                    }
+
+                    return self.print_as::<W, { Tag::Object }, ENABLE_ANSI_COLORS>(
+                        writer.ctx,
+                        value,
+                        js_type,
+                    );
+                }
                 Tag::TypedArray => {
                     let array_buffer = value.as_array_buffer(self.global_this).unwrap();
                     let slice = array_buffer.byte_slice();
@@ -2580,6 +2601,10 @@ impl<'a> Formatter<'a> {
             Tag::JSX => {
                 self.print_as::<W, { Tag::JSX }, ENABLE_ANSI_COLORS>(writer, value, result.cell)
             }
+            Tag::DOMElement => self
+                .print_as::<W, { Tag::DOMElement }, ENABLE_ANSI_COLORS>(
+                    writer, value, result.cell,
+                ),
             Tag::Event => {
                 self.print_as::<W, { Tag::Event }, ENABLE_ANSI_COLORS>(writer, value, result.cell)
             }

--- a/test/regression/issue/25309.test.ts
+++ b/test/regression/issue/25309.test.ts
@@ -1,0 +1,111 @@
+// https://github.com/oven-sh/bun/issues/25309
+// toBeFalsy/toBeTruthy expanded DOM implementation internals, producing hundreds of MB of error output and very slow failures.
+import { expect, test } from "bun:test";
+import { Window } from "happy-dom";
+
+function createLargeElement() {
+  const document = new Window().document;
+  const root = document.createElement("div");
+
+  for (let index = 0; index < 100; index++) {
+    const child = document.createElement("div");
+    child.textContent = String(index);
+    root.appendChild(child);
+  }
+
+  return root;
+}
+
+function createElementWithMultibyteCharacterAtTruncationBoundary() {
+  const document = new Window().document;
+  const root = document.createElement("div");
+  root.textContent = Buffer.alloc(9_993, "a").toString() + "\u{1F600}" + "tail";
+  return root;
+}
+
+test("falsy matcher errors do not print complete large DOM trees", () => {
+  let message = "";
+  try {
+    expect(createLargeElement()).toBeFalsy();
+  } catch (error) {
+    message = (error as Error).message;
+  }
+
+  expect(message).toContain("expect(received).toBeFalsy()");
+  expect(message).toContain("<div><div>0</div>");
+  expect(message).not.toContain("Symbol(nodeArray)");
+  expect(message.length).toBeLessThan(500_000);
+});
+
+test("truthy matcher errors do not print complete large DOM trees", () => {
+  let message = "";
+  try {
+    expect(createLargeElement()).not.toBeTruthy();
+  } catch (error) {
+    message = (error as Error).message;
+  }
+
+  expect(message).toContain("expect(received).not.toBeTruthy()");
+  expect(message).toContain("<div><div>0</div>");
+  expect(message).not.toContain("Symbol(nodeArray)");
+  expect(message.length).toBeLessThan(500_000);
+});
+
+test("boolean matcher errors keep normal object details", () => {
+  let message = "";
+  try {
+    expect({ a: { b: { c: 1 } }, arr: [1, 2, 3] }).toBeFalsy();
+  } catch (error) {
+    message = (error as Error).message;
+  }
+
+  expect(message).toContain("c: 1");
+  expect(message).toContain("arr");
+});
+
+test("DOM element truncation does not split UTF-8 characters", () => {
+  let message = "";
+  try {
+    expect(createElementWithMultibyteCharacterAtTruncationBoundary()).toBeFalsy();
+  } catch (error) {
+    message = (error as Error).message;
+  }
+
+  expect(message).toContain("expect(received).toBeFalsy()");
+  expect(message).toContain("...");
+  expect(message).not.toContain("\uFFFD");
+  expect(message.length).toBeLessThan(20_000);
+});
+
+test("DOM element truncation caps ASCII output", () => {
+  const document = new Window().document;
+  const root = document.createElement("div");
+  root.textContent = Buffer.alloc(10_100, "a").toString() + "after-limit";
+
+  let message = "";
+  try {
+    expect(root).toBeFalsy();
+  } catch (error) {
+    message = (error as Error).message;
+  }
+
+  expect(message).toContain("...");
+  expect(message).not.toContain("after-limit");
+  expect(message.length).toBeLessThan(20_000);
+});
+
+test("non-boolean DOM formatting keeps content after the boolean matcher limit", () => {
+  const document = new Window().document;
+  const actual = document.createElement("div");
+  const expected = document.createElement("div");
+  actual.textContent = Buffer.alloc(10_100, "a").toString() + "after-limit";
+
+  let message = "";
+  try {
+    expect(actual).toEqual(expected);
+  } catch (error) {
+    message = (error as Error).message;
+  }
+
+  expect(message).toContain("after-limit");
+});


### PR DESCRIPTION
Fixes https://github.com/oven-sh/bun/issues/25309

### What changed

`toBeFalsy()` / `toBeTruthy()` failure messages now format DOM-like elements using their `outerHTML` instead of recursively expanding userland DOM implementation internals.

This avoids a large performance cliff with `happy-dom` / Testing Library elements, where Bun previously printed internal fields such as `Symbol(nodeArray)` and generated extremely large assertion failure messages.

The change is scoped to element-like objects with `nodeType === 1` and string `outerHTML`. Normal object assertion errors still keep their detailed output.

### Local results

On the external repro from #25309:

- before: `108.86s`
- after: `2.29s`

For a 100-child `happy-dom` element failure message:

- before: `196,637,845` bytes
- after: `1,342` bytes
- Jest/Node comparison: `1,341` bytes

The 1-byte difference from Jest is Bun’s trailing newline in the matcher error message; the rendered DOM markup length is the same.

### Tests

```sh
git diff --check
bun run build:release
build/release/bun test regression/issue/25309.test.ts
```