### PR TITLE
SmallList: make set_len unsafe fn

### DIFF
--- a/src/collections/lib.rs
+++ b/src/collections/lib.rs
@@ -440,13 +440,17 @@ impl<T, const N: usize> SmallList<T, N> {
             self.0.reserve_exact(new_capacity as usize - cur);
         }
     }
-    /// Zig `setLen` — exposed as safe for API parity with the previous port
-    /// (whose only external caller shrinks to 0). Growing past the initialised
-    /// region is the caller's responsibility, same as before.
+    /// Zig `setLen` — raw length store (same contract as [`Vec::set_len`]).
+    ///
+    /// # Safety
+    /// - `new_len` must be ≤ `self.capacity()`.
+    /// - Every element in `0..new_len` must be initialised.
+    ///
+    /// In practice all callers shrink (either to `0` after draining by
+    /// `ptr::read`, or back to a previously-observed length).
     #[inline]
-    pub fn set_len(&mut self, new_len: u32) {
-        // SAFETY: matches the previous bun_css::SmallList::set_len contract
-        // (Zig callers treat this as a raw length store).
+    pub unsafe fn set_len(&mut self, new_len: u32) {
+        // SAFETY: the caller upholds the `Vec::set_len` contract above.
         unsafe { self.0.set_len(new_len as usize) }
     }
 
@@ -477,6 +481,75 @@ impl<T, const N: usize> SmallList<T, N> {
         for item in self.0.iter_mut() {
             func(item);
         }
+    }
+}
+
+#[cfg(test)]
+mod small_list_tests {
+    use super::SmallList;
+
+    /// `SmallList::set_len` must be `unsafe fn` — same contract as
+    /// [`Vec::set_len`]. With `#![deny(unused_unsafe)]` in effect, the
+    /// `unsafe { … }` block below only compiles when the callee is itself
+    /// `unsafe fn`; regressing the signature to safe would produce an
+    /// `unused_unsafe` compile error here.
+    ///
+    /// Exercises the shrink-to-0 shape of every real caller (CSS selector
+    /// builder, selector parser, `@layer` reset) — elements moved out via
+    /// `ptr::read`, then `set_len(0)` suppresses their `Drop`.
+    #[test]
+    #[deny(unused_unsafe)]
+    fn set_len_is_unsafe_and_shrink_to_zero_works() {
+        let mut sl: SmallList<Box<u32>, 2> = SmallList::default();
+        sl.append(Box::new(10));
+        sl.append(Box::new(20));
+        sl.append(Box::new(30)); // forces spill to heap
+        assert_eq!(sl.len(), 3);
+
+        let mut drained: Vec<Box<u32>> = Vec::with_capacity(3);
+        for i in 0..3 {
+            // SAFETY: each index read exactly once; `set_len(0)` below
+            // suppresses the source's `Drop` so no double-free.
+            drained.push(unsafe { core::ptr::read(&sl.slice()[i]) });
+        }
+        // SAFETY: shrink to 0 is always sound — `0 <= capacity` and the
+        // empty prefix is trivially initialised. The elements we just
+        // `ptr::read`'d out must not be re-dropped; `set_len(0)` is the
+        // exact primitive `Vec::set_len`/`SmallVec::set_len` expose for
+        // that, and it must stay `unsafe fn` (hence the `deny` above).
+        unsafe { sl.set_len(0) };
+        assert_eq!(sl.len(), 0);
+        assert!(sl.is_empty());
+
+        // Elements survived the move — `Box`'s `Drop` runs on `drained`
+        // only, not on `sl`. No double-free under Miri / ASan.
+        assert_eq!(*drained[0], 10);
+        assert_eq!(*drained[1], 20);
+        assert_eq!(*drained[2], 30);
+
+        // Subsequent pushes into the cleared list still work (capacity
+        // preserved, no corrupted Vec header).
+        sl.append(Box::new(99));
+        assert_eq!(sl.len(), 1);
+        assert_eq!(**sl.at(0), 99);
+    }
+
+    /// Mirrors `reset_enclosing_layer` in `css/css_parser.rs`: capture a
+    /// length, grow past it, then `set_len` back — safe so long as the
+    /// truncated suffix's `T` has no `Drop` to leak (here `u64: Copy`).
+    #[test]
+    fn set_len_shrink_to_prior_length() {
+        let mut sl: SmallList<u64, 1> = SmallList::default();
+        sl.append(1);
+        let old = sl.len();
+        sl.append(2);
+        sl.append(3);
+        assert_eq!(sl.len(), 3);
+        // SAFETY: `old` was previously observed; `old <= self.len()`, and
+        // `u64: Copy` means the truncated tail has no `Drop`.
+        unsafe { sl.set_len(old) };
+        assert_eq!(sl.len(), 1);
+        assert_eq!(*sl.at(0), 1);
     }
 }
 

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1766,7 +1766,12 @@ mod draft {
                     .store(handle as *mut core::ffi::c_void, Ordering::Relaxed);
             }
         }
-        #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android", target_os = "freebsd"))]
+        #[cfg(any(
+            target_os = "macos",
+            target_os = "linux",
+            target_os = "android",
+            target_os = "freebsd"
+        ))]
         {
             reset_on_posix();
         }
@@ -2907,7 +2912,12 @@ mod draft {
             let _ = spawn_result;
             let _ = url;
         }
-        #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android", target_os = "freebsd"))]
+        #[cfg(any(
+            target_os = "macos",
+            target_os = "linux",
+            target_os = "android",
+            target_os = "freebsd"
+        ))]
         {
             let mut buf = bun_core::PathBuffer::default();
             let mut buf2 = bun_core::PathBuffer::default();

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -968,7 +968,12 @@ impl<'a> CustomAtRuleParser for BundlerAtRuleParser<'a> {
     }
 
     fn reset_enclosing_layer(this: &mut Self, len: u32) {
-        this.enclosing_layer.v.set_len(len);
+        // SAFETY: `len` was captured by `enclosing_layer_length` earlier in
+        // `parse_block` before the layer was optionally grown via
+        // `push_to_enclosing_layer`, so it is always ≤ the current length
+        // (i.e. a shrink). Segments are `&'static [u8]` (Copy), so the
+        // truncated suffix has no `Drop` to leak.
+        unsafe { this.enclosing_layer.v.set_len(len) };
     }
 
     fn bump_anon_layer_count(this: &mut Self, amount: i32) {

--- a/src/css/selectors/builder.rs
+++ b/src/css/selectors/builder.rs
@@ -210,8 +210,15 @@ impl<Impl: ValidSelectorImpl> SelectorBuilder<Impl> {
         // it is safe to just set the length to 0.
         //
         // Combinators don't need to be deinitialized because they are simple enums.
-        self.simple_selectors.set_len(0);
-        self.combinators.set_len(0);
+        //
+        // SAFETY: shrink to 0. Every `GenericComponent<Impl>` was moved out of
+        // `simple_selectors` via `ptr::read` in the loop above, and
+        // `combinators` holds `(Combinator, usize)` pairs (`Copy`) that have
+        // no `Drop` to skip.
+        unsafe {
+            self.simple_selectors.set_len(0);
+            self.combinators.set_len(0);
+        }
 
         BuildResult {
             specificity_and_flags: spec,

--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -65,7 +65,10 @@ fn small_list_into_box<T, const N: usize>(mut sl: SmallList<T, N>) -> Box<[T]> {
             unsafe { v.push(core::ptr::read(src.get_unchecked(i))) };
         }
     }
-    sl.set_len(0);
+    // SAFETY: shrink to 0; `0 <= capacity` and the empty prefix is trivially
+    // initialised. Every original element was moved out via `ptr::read`
+    // above, so suppressing their `Drop` here is intentional.
+    unsafe { sl.set_len(0) };
     v.into_boxed_slice()
 }
 

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -409,7 +409,12 @@ mod errno_name_tests {
         assert_eq!(Error::from_errno(0), Error::UNEXPECTED);
         assert_eq!(Error::from_errno(9999), Error::UNEXPECTED);
         // errno 11 is platform-specific: EAGAIN on linux/windows, EDEADLK on darwin/bsd.
-        #[cfg(any(target_os = "linux", target_os = "android", windows, target_family = "wasm"))]
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "android",
+            windows,
+            target_family = "wasm"
+        ))]
         {
             assert_eq!(Error::from_errno(11), Error::intern("EAGAIN"));
             assert_eq!(Error::from_errno(104), Error::intern("ECONNRESET"));
@@ -464,7 +469,12 @@ mod errno_name_tests {
             coreutils_error_map::get(2),
             Some("No such file or directory")
         );
-        #[cfg(any(target_os = "linux", target_os = "android", windows, target_family = "wasm"))]
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "android",
+            windows,
+            target_family = "wasm"
+        ))]
         assert_eq!(
             coreutils_error_map::get(11),
             Some("Resource temporarily unavailable")

--- a/src/perf/tracy.rs
+++ b/src/perf/tracy.rs
@@ -756,7 +756,12 @@ fn dlsym<T: Copy>(symbol: &'static core::ffi::CStr) -> Option<T> {
                 ];
                 #[cfg(windows)]
                 const PATHS_TO_TRY: &[&core::ffi::CStr] = &[c"tracy.dll"];
-                #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android", windows)))]
+                #[cfg(not(any(
+                    target_os = "macos",
+                    target_os = "linux",
+                    target_os = "android",
+                    windows
+                )))]
                 const PATHS_TO_TRY: &[&core::ffi::CStr] = &[];
 
                 // TODO(port): RTLD flags — Zig used `@bitCast(@as(i32, -2))` on

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -679,7 +679,10 @@ pub const BASE_RUNTIME_TRANSPILER_PARAMS: &[ParamType] =
 // built with `comptime_table!(.., cold)` and stay in plain `.rodata`, where
 // `src/startup.order` can still cluster the ones a sampled cold path actually
 // hits without weighing down the `.rodata.startup` fault-around window.
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".rodata.startup"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".rodata.startup")
+)]
 pub static AUTO_TABLE: &clap::ConvertedTable = clap::comptime_table!(AUTO_PARAMS);
 pub static RUN_TABLE: &clap::ConvertedTable = clap::comptime_table!(RUN_PARAMS, cold);
 pub static BUILD_TABLE: &clap::ConvertedTable = clap::comptime_table!(BUILD_PARAMS, cold);

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -552,7 +552,10 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
     /// not share `.text` pages with the hot `bun run <script>` dispatch path.
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn configure_run_transpiler_linker(this_transpiler: &mut Transpiler<'static>) {
         this_transpiler.resolver.opts.load_tsconfig_json = true;
         this_transpiler.options.load_tsconfig_json = true;
@@ -870,7 +873,10 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
     /// initializing JSC.
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn boot_bun_shell(
         ctx: &mut ContextData,
         entry_path: &[u8],
@@ -1669,7 +1675,10 @@ fn log_clear_msgs(vm: &mut VirtualMachine) {
 
 #[cold]
 #[inline(never)]
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".text.unlikely")
+)]
 fn dump_build_error(vm: &mut VirtualMachine) {
     Output::flush();
     if let Some(log) = vm.log {
@@ -1689,7 +1698,10 @@ fn dump_build_error(vm: &mut VirtualMachine) {
 /// `.text.hot` fault-around window the `require('fs')` startup path pulls in.
 #[cold]
 #[inline(never)]
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".text.unlikely")
+)]
 fn exit_with_unhandled_note(vm: &mut VirtualMachine) -> ! {
     vm.exit_handler.exit_code = 1;
     vm.on_exit();
@@ -1703,7 +1715,10 @@ fn exit_with_unhandled_note(vm: &mut VirtualMachine) -> ! {
 /// Cold `Err(err)` arm of `vm.load_entry_point` in `Run::start`.
 #[cold]
 #[inline(never)]
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".text.unlikely")
+)]
 fn entry_point_load_failed(vm: &mut VirtualMachine, err: &bun_core::Error) -> ! {
     if log_has_msgs(vm) {
         dump_build_error(vm);
@@ -1722,7 +1737,10 @@ fn entry_point_load_failed(vm: &mut VirtualMachine, err: &bun_core::Error) -> ! 
 /// exit: bump the exit code and print the sourcemap note + version string.
 #[cold]
 #[inline(never)]
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".text.unlikely")
+)]
 fn print_unhandled_version_note(vm: &mut VirtualMachine) {
     vm.exit_handler.exit_code = 1;
     bun_sourcemap::SavedSourceMap::MissingSourceMapNoteInfo::print();
@@ -1762,7 +1780,10 @@ impl RunCommand {
     /// `.text.hot` fault-around window the `require('fs')` startup path pulls in.
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn boot_failed_exit(ctx: &mut ContextData, display_name: &[u8], err: &bun_core::Error) -> ! {
         // SAFETY: `ctx.log` was set in `create_context_data` (single-threaded
         // CLI startup) and is process-lifetime.
@@ -3022,7 +3043,10 @@ impl RunCommand {
 
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn exec_as_if_node_missing_script() -> ! {
         Output::err_generic(
             "Missing script to execute. Bun's provided 'node' cli wrapper does not support a repl.",
@@ -3033,7 +3057,10 @@ impl RunCommand {
 
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn exec_as_if_node_boot_failed(
         ctx: &mut ContextData,
         basename: &[u8],

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -515,7 +515,12 @@ impl UpgradeCommand {
         {
             "powershell -c 'irm bun.sh/install.ps1|iex'"
         }
-        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "windows")))]
+        #[cfg(not(any(
+            target_os = "linux",
+            target_os = "android",
+            target_os = "macos",
+            target_os = "windows"
+        )))]
         {
             // TODO(port): Environment.os.displayString() at comptime
             "(TODO: Install script for this platform)"

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4499,13 +4499,14 @@ pub(crate) fn resolve_embedded_file_to_buf(
     // Spec ModuleLoader.zig:43-45 — `tmpname(extname, buf, bun.hash(file.name))`.
     let mut tmpname_buf = bun_paths::path_buffer_pool::get();
     let tmpfilename =
-        Fs::FileSystem::tmpname(extname, &mut tmpname_buf[..], bun_wyhash::hash(file_name))
-            .ok()?;
+        Fs::FileSystem::tmpname(extname, &mut tmpname_buf[..], bun_wyhash::hash(file_name)).ok()?;
 
     // Spec ModuleLoader.zig:47 — `bun.fs.FileSystem.instance.tmpdir()`.
     // SAFETY: `FileSystem::instance()` returns the process-global singleton
     // pointer (initialized at startup).
-    let tmpdir = (unsafe { &mut *Fs::FileSystem::instance() }).tmpdir().ok()?;
+    let tmpdir = (unsafe { &mut *Fs::FileSystem::instance() })
+        .tmpdir()
+        .ok()?;
     let tmpdir_fd: bun_sys::Fd = tmpdir.fd;
 
     // Spec ModuleLoader.zig:50-51 — `bun.Tmpfile.create(tmpdir, tmpfilename)`.

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -358,7 +358,10 @@ fn find_playwright_shell() -> Option<ZBox> {
     }
 
     // Fall back to the non-cft linux arm64 layout.
-    #[cfg(all(any(target_os = "linux", target_os = "android"), target_arch = "aarch64"))]
+    #[cfg(all(
+        any(target_os = "linux", target_os = "android"),
+        target_arch = "aarch64"
+    ))]
     {
         let bin_parts2: [&[u8]; 3] = [
             cache_dir,
@@ -633,7 +636,12 @@ fn read_dev_tools_active_port(out_buf: &mut Vec<u8>) -> Option<()> {
         b"BraveSoftware\\Brave-Browser\\User Data\\DevToolsActivePort",
         b"Microsoft\\Edge\\User Data\\DevToolsActivePort",
     ];
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android", windows)))]
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "linux",
+        target_os = "android",
+        windows
+    )))]
     let candidates: &[&[u8]] = &[];
 
     let mut path_buf = path_buffer_pool::get();

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -3224,7 +3224,10 @@ mod spawn_process_body {
             // that are read *after* the wait, so falling through to the memfd block
             // below is required.
             let status: Status = 'blk: {
-                if no_orphans && (cfg!(any(target_os = "linux", target_os = "android")) || cfg!(target_os = "macos")) {
+                if no_orphans
+                    && (cfg!(any(target_os = "linux", target_os = "android"))
+                        || cfg!(target_os = "macos"))
+                {
                     let ppid = ParentDeathWatchdog::ppid_to_watch().unwrap_or(0);
                     #[cfg(target_os = "macos")]
                     let r: Option<Maybe<Status>> = wait_mac_kqueue(
@@ -3245,7 +3248,11 @@ mod spawn_process_body {
                         &mut out_fds_to_wait_for,
                         &mut out_fds,
                     );
-                    #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
+                    #[cfg(not(any(
+                        target_os = "linux",
+                        target_os = "android",
+                        target_os = "macos"
+                    )))]
                     let r: Option<Maybe<Status>> = {
                         let _ = ppid;
                         None

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -775,7 +775,10 @@ pub fn spawn_process_posix(
     let mut dup_stdout_to_stderr: bool = false;
 
     // The label is only referenced from the Linux memfd fast-path below.
-    #[cfg_attr(not(any(target_os = "linux", target_os = "android")), allow(unused_labels))]
+    #[cfg_attr(
+        not(any(target_os = "linux", target_os = "android")),
+        allow(unused_labels)
+    )]
     'stdio: for i in 0..3usize {
         let fileno = Fd::from_native(FdT::try_from(i).unwrap());
         let flag: u32 = (if i == 0 {

--- a/test/js/bun/css/small-list-set-len.test.ts
+++ b/test/js/bun/css/small-list-set-len.test.ts
@@ -1,0 +1,167 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import path from "node:path";
+
+// Exercises the three `SmallList::set_len` call sites in the CSS parser, all
+// of which are shrink-only today:
+//
+//   1. `src/css/selectors/parser.rs` `small_list_into_box`: drains a
+//      `SmallList<T,N>` into a `Box<[T]>` via `ptr::read` + `set_len(0)`
+//      to suppress the source's `Drop`. Hit by any selector containing a
+//      nested selector list (`:is(...)`, `:where(...)`, `:not(...)`).
+//
+//   2. `src/css/selectors/builder.rs` `build_with_specificity_and_flags`:
+//      `set_len(0)` after draining `simple_selectors` and `combinators`
+//      into the owned selector. Hit by every single rule parsed — but
+//      complex compound selectors with multiple combinators and trailing
+//      pseudo-class arguments stress it hardest.
+//
+//   3. `src/css/css_parser.rs` `reset_enclosing_layer`: `set_len(old_len)`
+//      after parsing a nested `@layer` block, restoring the layer name
+//      segment list to its length before the push. Hit by nested `@layer`
+//      blocks whose inner rule pushes a name onto the enclosing layer.
+//
+// The fix in PR #30773 changes the callee signature from safe to `unsafe fn`
+// — no runtime behaviour change. This test is a smoke-screen against a
+// future refactor silently breaking one of the three call sites (e.g.
+// `set_len` with the wrong length, or an accidental grow). Under `bun bd`'s
+// ASAN, the `ptr::read` + `set_len(0)` pattern would catch a double-free
+// or use-after-free on the moved-out payload.
+
+test("nested @layer blocks with complex selectors parse and round-trip through the bundler", async () => {
+  // Build nested @layer rules that exercise the `reset_enclosing_layer`
+  // path: each inner `@layer` push appends a name segment, then shrinks
+  // back via `set_len(old_len)` when the block closes.
+  //
+  // Each innermost rule uses a compound selector with `:is()`, `:where()`,
+  // `:not()`, multiple combinators, and trailing pseudo-classes so the
+  // selector builder drains into `components: Vec` via the `set_len(0)`
+  // path on every rule.
+  const layers = 32;
+  const rulesPerLayer = 16;
+
+  let css = "";
+  for (let i = 0; i < layers; i++) {
+    css += `@layer l${i} {\n`;
+    for (let r = 0; r < rulesPerLayer; r++) {
+      // Compound selector shape: `.a-0 > :is(.b-0, .b-1, .b-2) + .c-0 :where(.d-0, .d-1):not(.e-0):hover`
+      // exercises selector list drain (`:is`, `:where`, `:not`),
+      // combinators (`>`, `+`, descendant), and a trailing pseudo-class.
+      const sel = `.a-l${i}-r${r} > :is(.b-0, .b-1, .b-2)` + ` + .c-${r} :where(.d-0, .d-1):not(.e-${r}):hover`;
+      css += `  ${sel} { color: hsl(${r * 7}, 80%, 50%); }\n`;
+      // Also emit a plain rule so the selector builder runs on the simple
+      // path each iteration too.
+      css += `  .simple-l${i}-r${r} { padding: ${r}px; }\n`;
+    }
+  }
+  // Close all the `@layer` blocks.
+  css += "}\n".repeat(layers);
+
+  using dir = tempDir("css-small-list-set-len", {
+    "nested-layers.css": css,
+  });
+
+  const fixture =
+    `const result = await Bun.build({\n` +
+    `  entrypoints: [${JSON.stringify(path.join(String(dir), "nested-layers.css"))}],\n` +
+    `});\n` +
+    `if (!result.success) {\n` +
+    `  console.error(result.logs.join("\\n"));\n` +
+    `  process.exit(2);\n` +
+    `}\n` +
+    `const out = await result.outputs[0].text();\n` +
+    `// Characteristic fragments from different depths confirm the whole\n` +
+    `// nest survived parsing — including selectors from layer 0, the\n` +
+    `// middle, and the last layer (where reset_enclosing_layer was hit\n` +
+    `// the most times).\n` +
+    `console.log(JSON.stringify({\n` +
+    `  firstRule: out.includes(".a-l0-r0"),\n` +
+    `  midRule: out.includes(".a-l${layers >> 1}-r0"),\n` +
+    `  lastRule: out.includes(".a-l${layers - 1}-r${rulesPerLayer - 1}"),\n` +
+    `  // Selector-list payloads from :is/:where/:not survived the drain.\n` +
+    `  hasIsPayload: out.includes(".b-0") && out.includes(".b-2"),\n` +
+    `  hasWherePayload: out.includes(".d-0") && out.includes(".d-1"),\n` +
+    `  hasSimpleRules: out.includes(".simple-l0-r0") && out.includes(".simple-l${layers - 1}-r${rulesPerLayer - 1}"),\n` +
+    `}));\n`;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ exitCode, stderr: stderr.slice(-800) }).toMatchObject({ exitCode: 0 });
+
+  expect(JSON.parse(stdout.trim())).toEqual({
+    firstRule: true,
+    midRule: true,
+    lastRule: true,
+    hasIsPayload: true,
+    hasWherePayload: true,
+    hasSimpleRules: true,
+  });
+});
+
+test("selector list drain survives repeated :is() / :where() / :not() payloads", async () => {
+  // `small_list_into_box` in `src/css/selectors/parser.rs` is the drain
+  // path for selector-list pseudo-classes. Each `:is(a, b, c, ...)` in
+  // the input builds a `SmallList<Selector, N>`, reads every element out
+  // via `ptr::read`, then `set_len(0)`s to suppress the source's `Drop`.
+  //
+  // If `set_len` ever grew or skipped elements, ASAN would trip on the
+  // moved-out slot being read back (during the `into_box` output) or on
+  // `Drop` running twice (the suppressed source + the box).
+  //
+  // Keep payloads small so no list spills to the heap — the inline case
+  // is what most rules hit in practice.
+  const rules = 500;
+  let css = "";
+  for (let r = 0; r < rules; r++) {
+    css += `.r${r} :is(.a-${r}, .b-${r}) :where(.c-${r}, .d-${r})` + ` :not(.e-${r}, .f-${r}) { --v-${r}: ${r}; }\n`;
+  }
+
+  using dir = tempDir("css-small-list-drain", {
+    "drain.css": css,
+  });
+
+  const fixture =
+    `const result = await Bun.build({\n` +
+    `  entrypoints: [${JSON.stringify(path.join(String(dir), "drain.css"))}],\n` +
+    `});\n` +
+    `if (!result.success) {\n` +
+    `  console.error(result.logs.join("\\n"));\n` +
+    `  process.exit(2);\n` +
+    `}\n` +
+    `const out = await result.outputs[0].text();\n` +
+    `console.log(JSON.stringify({\n` +
+    `  firstDrain: out.includes(".a-0") && out.includes(".b-0"),\n` +
+    `  lastDrain: out.includes(".a-${rules - 1}") && out.includes(".b-${rules - 1}"),\n` +
+    `  // --v-* custom props come from the declaration block, i.e. the\n` +
+    `  // rule was fully parsed after the selector list drain.\n` +
+    `  firstDecl: out.includes("--v-0"),\n` +
+    `  lastDecl: out.includes("--v-${rules - 1}"),\n` +
+    `}));\n`;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ exitCode, stderr: stderr.slice(-800) }).toMatchObject({ exitCode: 0 });
+
+  expect(JSON.parse(stdout.trim())).toEqual({
+    firstDrain: true,
+    lastDrain: true,
+    firstDecl: true,
+    lastDecl: true,
+  });
+});


### PR DESCRIPTION
Closes #30770.

## Summary

`SmallList::set_len` is a raw length store — same semantics as [`Vec::set_len`]: the caller asserts `new_len <= self.capacity()` and that `0..new_len` is initialised. Exposing it as a safe `pub fn` let downstream crates violate those invariants without an `unsafe` block.

Mark it `unsafe fn` and wrap the three callers (all shrinks) with explicit `SAFETY` notes.

## Callers (all shrinks)

| Site | Shape | Why sound |
| --- | --- | --- |
| `css/selectors/builder.rs` — `build_with_specificity_and_flags` | `set_len(0)` after `ptr::read`ing each `GenericComponent<Impl>` out of `simple_selectors` into the returned `components: Vec`, and `combinators` is `(Combinator, usize)` (`Copy`) | every element moved out once; `set_len(0)` suppresses the deliberately-moved elements' `Drop` so no double-free |
| `css/selectors/parser.rs` — `small_list_into_box` | same `ptr::read` drain + `set_len(0)` pattern (mirrors Zig `toOwnedSlice`) | same reasoning |
| `css/css_parser.rs` — `BundlerAtRuleParser::reset_enclosing_layer` | `set_len(old_len)` where `old_len` was captured by `enclosing_layer_length` earlier in `parse_block` before the layer was optionally grown via `push_to_enclosing_layer` | `LayerName.v` segments are `&'static [u8]` (`Copy`); `old_len <= current_len` by construction (shrink) |

None of the call sites grow. The new doc-comment calls that out: `new_len` must be ≤ `capacity()` **and** the `0..new_len` prefix must be initialised (`Vec::set_len` contract).

## Test

Added `mod small_list_tests` in `src/collections/lib.rs` exercising both shapes under `Box<u32>` (non-trivial `Drop`) and `u64` (`Copy` shrink-to-prior-length). The zero-shrink test has `#[deny(unused_unsafe)]` so regressing `set_len` back to a safe signature would fail compilation there (the `unsafe { sl.set_len(0) }` block becomes unused).

## Verification

- `cargo check -p bun_collections` — clean.
- `cargo check -p bun_css` — clean.
- `cargo build -p bun_bin` — clean.

Note on the gate: this is a Rust-API-soundness change with **no runtime behavioral delta**. The three existing call sites were already careful (all shrinks), so a before/after TS test can't produce a fail→pass. The inline Rust unit test is the strongest evidence for this kind of fix (plus a compile-time `unused_unsafe` trip-wire).

`bun bd` locally hits an unrelated pre-existing bake-codegen failure (`defines.json:1:1` while bundling the bake client/server runtime CSS with an older prebuilt release bun) that also reproduces on clean `main` with my patch stashed — it's a bootstrapping issue, not something this diff touches.

## References

- `Vec::set_len` in std is `unsafe fn` for exactly this reason
- `SmallVec::set_len` upstream is also `unsafe fn`
