### PR TITLE
spawn: don't reinstall fault-signal handlers after sync-spawn signal forwarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1850,7 +1850,6 @@ dependencies = [
  "bun_alloc",
  "bun_analytics",
  "bun_core",
- "bun_crash_handler",
  "bun_dispatch",
  "bun_errno",
  "bun_event_loop",

--- a/src/codegen/bake-codegen.ts
+++ b/src/codegen/bake-codegen.ts
@@ -56,7 +56,12 @@ async function run() {
           side: JSON.stringify(side),
           IS_ERROR_RUNTIME: String(file === "error"),
           IS_BUN_DEVELOPMENT: String(!!debug),
-          OVERLAY_CSS: css("../runtime/bake/client/overlay.css", !!debug),
+          // The minified CSS starts with `*{box-sizing:...}`; pre-#30679
+          // codegen buns reject that before the `define` auto-quote fallback
+          // can treat it as a string. Quote it explicitly (as `side` already
+          // is) so building from source doesn't depend on the bootstrap bun's
+          // lexer behaviour.
+          OVERLAY_CSS: JSON.stringify(css("../runtime/bake/client/overlay.css", !!debug)),
         },
         minify: {
           syntax: !debug,

--- a/src/codegen/bake-codegen.ts
+++ b/src/codegen/bake-codegen.ts
@@ -56,11 +56,7 @@ async function run() {
           side: JSON.stringify(side),
           IS_ERROR_RUNTIME: String(file === "error"),
           IS_BUN_DEVELOPMENT: String(!!debug),
-          // The minified CSS starts with `*{box-sizing:...}`; pre-#30679
-          // codegen buns reject that before the `define` auto-quote fallback
-          // can treat it as a string. Quote it explicitly (as `side` already
-          // is) so building from source doesn't depend on the bootstrap bun's
-          // lexer behaviour.
+          // Quoted explicitly (like `side`): bootstrap buns older than #30679 can't auto-quote a value starting with `*`.
           OVERLAY_CSS: JSON.stringify(css("../runtime/bake/client/overlay.css", !!debug)),
         },
         minify: {

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1648,7 +1648,7 @@ mod draft {
     // in `reset_segfault_handler` on a double-remove).
 
     #[cfg(unix)]
-    pub fn reset_on_posix() {
+    fn reset_on_posix() {
         if Environment::ENABLE_ASAN {
             return;
         }

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -126,6 +126,7 @@ export const crash_handler = $rust("crash_handler.rs", "js_bindings.generate") a
   fastfail: () => void;
   trap: () => void;
   raiseIgnoringPanicHandler: () => void;
+  getFaultSignalHandlers: () => { SIGSEGV: string; SIGBUS: string; SIGILL: string; SIGFPE: string } | undefined;
 };
 
 export const upgrade_test_helpers = $rust("upgrade_command.rs", "upgrade_js_bindings.generate") as {

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -221,9 +221,7 @@ pub(crate) mod js_bindings {
         Global::raise_ignoring_panic_handler(bun_core::SignalCode::SIGSEGV);
     }
 
-    /// Current `sa_sigaction` of each CPU-fault signal, as hex strings (a u64
-    /// address does not round-trip through a JS number). Test-only; see
-    /// test/js/bun/spawn/sync-spawn-preserves-jsc-signal-handlers.test.ts.
+    /// Current `sa_sigaction` of each CPU-fault signal, as hex strings.
     #[bun_jsc::host_fn]
     fn js_get_fault_signal_handlers(
         global: &JSGlobalObject,

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -33,6 +33,10 @@ pub(crate) mod js_bindings {
                 "raiseIgnoringPanicHandler",
                 __jsc_host_js_raise_ignoring_panic_handler,
             ),
+            (
+                "getFaultSignalHandlers",
+                __jsc_host_js_get_fault_signal_handlers,
+            ),
         ];
         let obj = JSValue::create_empty_object(global, ENTRIES.len());
         for &(name, func) in ENTRIES {
@@ -215,6 +219,62 @@ pub(crate) mod js_bindings {
     ) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();
         Global::raise_ignoring_panic_handler(bun_core::SignalCode::SIGSEGV);
+    }
+
+    /// Snapshot the currently-installed `sa_sigaction` for each CPU-fault
+    /// signal. Returned as `{ SIGSEGV, SIGBUS, SIGILL, SIGFPE }` with hex
+    /// strings so JS can compare exact addresses across snapshots without
+    /// f64 rounding.
+    ///
+    /// Used to verify that JSC's `jscSignalHandler` — which handles VMTraps'
+    /// HLT-breakpoint SIGSEGV on DFG/FTL code — survives the CLI sync-spawn
+    /// signal-forwarding scope (`SignalForwarding` in `src/spawn/process.rs`).
+    /// The forwarding set excludes these signals by construction, so the
+    /// handlers must be identical before and after; a regression here means
+    /// something in that scope reinstalled a fault handler with `oldact=NULL`
+    /// and VMTraps will route its next HLT to the wrong place.
+    #[bun_jsc::host_fn]
+    pub fn js_get_fault_signal_handlers(
+        global: &JSGlobalObject,
+        _frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        #[cfg(unix)]
+        {
+            // Query via libc rather than duplicating the per-libc struct
+            // layout (`sa_flags` offset differs across glibc/musl/Darwin) in
+            // the JS caller. `sa_handler` / `sa_sigaction` are a union at
+            // offset 0 everywhere we ship, but going through libc keeps this
+            // honest.
+            fn handler(sig: libc::c_int) -> usize {
+                // SAFETY: zeroed sigaction is a valid query buffer; `act=NULL`
+                // is the documented "read current disposition" form.
+                let mut current: libc::sigaction = unsafe { core::mem::zeroed() };
+                // SAFETY: out-pointer to stack-local, act=NULL.
+                if unsafe { libc::sigaction(sig, core::ptr::null(), &raw mut current) } != 0 {
+                    return 0;
+                }
+                current.sa_sigaction
+            }
+            let obj = JSValue::create_empty_object(global, 4);
+            for (name, sig) in [
+                ("SIGSEGV", libc::SIGSEGV),
+                ("SIGBUS", libc::SIGBUS),
+                ("SIGILL", libc::SIGILL),
+                ("SIGFPE", libc::SIGFPE),
+            ] {
+                // Hex string: 64-bit addresses survive the trip through JS
+                // without losing precision, and equal strings ⇔ equal
+                // pointers.
+                let mut s = BunString::create_format(format_args!("{:x}", handler(sig)));
+                obj.put(global, name, s.transfer_to_js(global)?);
+            }
+            Ok(obj)
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = global;
+            Ok(JSValue::UNDEFINED)
+        }
     }
 
     #[bun_jsc::host_fn]

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -234,7 +234,7 @@ pub(crate) mod js_bindings {
     /// something in that scope reinstalled a fault handler with `oldact=NULL`
     /// and VMTraps will route its next HLT to the wrong place.
     #[bun_jsc::host_fn]
-    pub fn js_get_fault_signal_handlers(
+    fn js_get_fault_signal_handlers(
         global: &JSGlobalObject,
         _frame: &CallFrame,
     ) -> JsResult<JSValue> {

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -221,18 +221,9 @@ pub(crate) mod js_bindings {
         Global::raise_ignoring_panic_handler(bun_core::SignalCode::SIGSEGV);
     }
 
-    /// Snapshot the currently-installed `sa_sigaction` for each CPU-fault
-    /// signal. Returned as `{ SIGSEGV, SIGBUS, SIGILL, SIGFPE }` with hex
-    /// strings so JS can compare exact addresses across snapshots without
-    /// f64 rounding.
-    ///
-    /// Used to verify that JSC's `jscSignalHandler` — which handles VMTraps'
-    /// HLT-breakpoint SIGSEGV on DFG/FTL code — survives the CLI sync-spawn
-    /// signal-forwarding scope (`SignalForwarding` in `src/spawn/process.rs`).
-    /// The forwarding set excludes these signals by construction, so the
-    /// handlers must be identical before and after; a regression here means
-    /// something in that scope reinstalled a fault handler with `oldact=NULL`
-    /// and VMTraps will route its next HLT to the wrong place.
+    /// Current `sa_sigaction` of each CPU-fault signal, as hex strings (a u64
+    /// address does not round-trip through a JS number). Test-only; see
+    /// test/js/bun/spawn/sync-spawn-preserves-jsc-signal-handlers.test.ts.
     #[bun_jsc::host_fn]
     fn js_get_fault_signal_handlers(
         global: &JSGlobalObject,
@@ -240,16 +231,9 @@ pub(crate) mod js_bindings {
     ) -> JsResult<JSValue> {
         #[cfg(unix)]
         {
-            // Query via libc rather than duplicating the per-libc struct
-            // layout (`sa_flags` offset differs across glibc/musl/Darwin) in
-            // the JS caller. `sa_handler` / `sa_sigaction` are a union at
-            // offset 0 everywhere we ship, but going through libc keeps this
-            // honest.
             fn handler(sig: libc::c_int) -> usize {
-                // Zeroed sigaction is a valid query buffer; `act=NULL` is the
-                // documented "read current disposition" form.
                 let mut current: libc::sigaction = bun_core::ffi::zeroed();
-                // SAFETY: out-pointer to stack-local, act=NULL.
+                // SAFETY: act=NULL only reads the disposition into the stack-local out-pointer.
                 if unsafe { libc::sigaction(sig, core::ptr::null(), &raw mut current) } != 0 {
                     return 0;
                 }
@@ -262,9 +246,6 @@ pub(crate) mod js_bindings {
                 ("SIGILL", libc::SIGILL),
                 ("SIGFPE", libc::SIGFPE),
             ] {
-                // Hex string: 64-bit addresses survive the trip through JS
-                // without losing precision, and equal strings ⇔ equal
-                // pointers.
                 let mut s = BunString::create_format(format_args!("{:x}", handler(sig)));
                 obj.put(global, name, s.transfer_to_js(global)?);
             }

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -246,9 +246,9 @@ pub(crate) mod js_bindings {
             // offset 0 everywhere we ship, but going through libc keeps this
             // honest.
             fn handler(sig: libc::c_int) -> usize {
-                // SAFETY: zeroed sigaction is a valid query buffer; `act=NULL`
-                // is the documented "read current disposition" form.
-                let mut current: libc::sigaction = unsafe { core::mem::zeroed() };
+                // Zeroed sigaction is a valid query buffer; `act=NULL` is the
+                // documented "read current disposition" form.
+                let mut current: libc::sigaction = bun_core::ffi::zeroed();
                 // SAFETY: out-pointer to stack-local, act=NULL.
                 if unsafe { libc::sigaction(sig, core::ptr::null(), &raw mut current) } != 0 {
                     return 0;

--- a/src/spawn/Cargo.toml
+++ b/src/spawn/Cargo.toml
@@ -20,7 +20,6 @@ scopeguard.workspace = true
 bun_analytics.workspace = true
 bun_dispatch.workspace = true
 bun_core.workspace = true
-bun_crash_handler.workspace = true
 bun_event_loop.workspace = true
 bun_io.workspace = true
 bun_output.workspace = true

--- a/src/spawn/lib.rs
+++ b/src/spawn/lib.rs
@@ -9,8 +9,8 @@
 //! `bun_runtime` re-exports them. The only non-leaf dependencies are
 //! `bun_io` (`FilePoll`/`KeepAlive`/`EventLoopCtx`), `bun_ptr`
 //! (`ThreadSafeRefCount`), `bun_io` (`BufferedWriter`), `bun_event_loop`,
-//! `bun_threading`, and `bun_crash_handler` — none of which depend back on
-//! this crate, so no cycle.
+//! and `bun_threading` — none of which depend back on this crate, so no
+//! cycle.
 
 use core::ffi::c_char;
 

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -2854,11 +2854,6 @@ mod spawn_process_body {
 
         /// RAII guard around `Bun__registerSignalsForForwarding`: registers on
         /// construction, unregisters on drop.
-        ///
-        /// Must not touch SIGSEGV/SIGBUS/SIGILL/SIGFPE: JSC layers its VMTraps
-        /// handler over ours at init and chains real faults back to us, so
-        /// reinstalling the crash handler here breaks JIT interruption. See
-        /// test/js/bun/spawn/sync-spawn-preserves-jsc-signal-handlers.test.ts.
         #[cfg(unix)]
         struct SignalForwarding;
         #[cfg(unix)]

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -2853,8 +2853,26 @@ mod spawn_process_body {
         };
 
         /// RAII guard around `Bun__registerSignalsForForwarding`: registers on
-        /// construction, unregisters and restores the crash-handler signal
-        /// disposition on drop.
+        /// construction, unregisters on drop.
+        ///
+        /// The forwarding set (SIGINT/TERM/HUP/QUIT/ABRT/… — see
+        /// `FOR_EACH_SIGNAL` in c-bindings.cpp) does *not* include the
+        /// CPU-fault signals SIGSEGV/SIGBUS/SIGILL/SIGFPE, and
+        /// `Bun__unregisterSignalsForForwarding` restores every signal it
+        /// touched from `previous_actions[]`. So the fault-signal dispositions
+        /// are unchanged across this scope.
+        ///
+        /// An older version additionally called `crash_handler::reset_on_posix()`
+        /// here, which reinstalled Bun's crash handler on the fault signals
+        /// with `oldact=NULL`. That overwrote JSC's `jscSignalHandler`
+        /// (installed after `crash_handler::init()` by
+        /// `WTF::SignalHandlers::finalize()`) and broke signal-based VMTraps:
+        /// the HLT breakpoint JSC patches into DFG/FTL invalidation points to
+        /// interrupt the mutator for STW GC / `Worker.terminate()` / watchdog
+        /// would deliver SIGSEGV straight to Bun's crash reporter instead of
+        /// being recognised and jettisoned. `jscSignalHandler` already chains
+        /// unhandled faults to whatever was installed before it (our crash
+        /// handler), so there is nothing to restore here.
         #[cfg(unix)]
         struct SignalForwarding;
         #[cfg(unix)]
@@ -2869,7 +2887,6 @@ mod spawn_process_body {
         impl Drop for SignalForwarding {
             fn drop(&mut self) {
                 Bun__unregisterSignalsForForwarding();
-                bun_crash_handler::reset_on_posix();
             }
         }
 

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -2855,24 +2855,10 @@ mod spawn_process_body {
         /// RAII guard around `Bun__registerSignalsForForwarding`: registers on
         /// construction, unregisters on drop.
         ///
-        /// The forwarding set (SIGINT/TERM/HUP/QUIT/ABRT/… — see
-        /// `FOR_EACH_SIGNAL` in c-bindings.cpp) does *not* include the
-        /// CPU-fault signals SIGSEGV/SIGBUS/SIGILL/SIGFPE, and
-        /// `Bun__unregisterSignalsForForwarding` restores every signal it
-        /// touched from `previous_actions[]`. So the fault-signal dispositions
-        /// are unchanged across this scope.
-        ///
-        /// An older version additionally called `crash_handler::reset_on_posix()`
-        /// here, which reinstalled Bun's crash handler on the fault signals
-        /// with `oldact=NULL`. That overwrote JSC's `jscSignalHandler`
-        /// (installed after `crash_handler::init()` by
-        /// `WTF::SignalHandlers::finalize()`) and broke signal-based VMTraps:
-        /// the HLT breakpoint JSC patches into DFG/FTL invalidation points to
-        /// interrupt the mutator for STW GC / `Worker.terminate()` / watchdog
-        /// would deliver SIGSEGV straight to Bun's crash reporter instead of
-        /// being recognised and jettisoned. `jscSignalHandler` already chains
-        /// unhandled faults to whatever was installed before it (our crash
-        /// handler), so there is nothing to restore here.
+        /// Must not touch SIGSEGV/SIGBUS/SIGILL/SIGFPE: JSC layers its VMTraps
+        /// handler over ours at init and chains real faults back to us, so
+        /// reinstalling the crash handler here breaks JIT interruption. See
+        /// test/js/bun/spawn/sync-spawn-preserves-jsc-signal-handlers.test.ts.
         #[cfg(unix)]
         struct SignalForwarding;
         #[cfg(unix)]

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -83,8 +83,7 @@ describe("Bun.build", () => {
 
   // A `define:` value that isn't valid JSON or a JS identifier is auto-quoted
   // (treated as a string literal). The JSON lexer must not error eagerly on the
-  // first character — a raw minified CSS string starts with `*{...}`, which
-  // src/codegen/bake-codegen.ts passes verbatim as `OVERLAY_CSS`.
+  // first character — e.g. a raw minified CSS string starts with `*{...}`.
   describe.each([
     "*{box-sizing:border-box}.root{all:initial}",
     "?foo",

--- a/test/js/bun/spawn/sync-spawn-preserves-jsc-signal-handlers.test.ts
+++ b/test/js/bun/spawn/sync-spawn-preserves-jsc-signal-handlers.test.ts
@@ -43,9 +43,9 @@
 
 import { spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isPosix, tempDir, tmpdirSync } from "harness";
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { bunEnv, bunExe, isPosix, tempDir, tmpdirSync } from "harness";
 
 // Shared by the baseline process and the inner --changed test: print one
 // `HANDLER <sig> <addr>` line per CPU-fault signal via the internal probe
@@ -138,7 +138,10 @@ describe.skipIf(!isPosix)("CLI sync-spawn preserves JSC's fault-signal handlers"
     // One tracked change so --changed actually selects the probe and, more
     // importantly, actually runs the git subprocesses it needs to compute
     // the diff — those are the sync spawns under test.
-    writeFileSync(join(cwd, "probe.test.ts"), `import { test } from "bun:test";\n${probe}\ntest("noop", () => {});\n// touched\n`);
+    writeFileSync(
+      join(cwd, "probe.test.ts"),
+      `import { test } from "bun:test";\n${probe}\ntest("noop", () => {});\n// touched\n`,
+    );
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "--changed", "probe.test.ts"],

--- a/test/js/bun/spawn/sync-spawn-preserves-jsc-signal-handlers.test.ts
+++ b/test/js/bun/spawn/sync-spawn-preserves-jsc-signal-handlers.test.ts
@@ -1,0 +1,187 @@
+// JSC's signal-based VMTraps (the default when `JSC_usePollingTraps` is off)
+// interrupts running DFG/FTL code by patching a halt instruction (`hlt` on
+// x86, `dc zva, xzr` on arm64) over each invalidation point in the hot
+// CodeBlock. The mutator hits it, the kernel delivers SIGSEGV, and WTF's
+// `jscSignalHandler` looks the PC up in `DFG::pcCodeBlockMap`, jettisons the
+// CodeBlock (which patches the halt back to a jump to the OSR-exit thunk),
+// and returns `Handled`. The mutator then OSR-exits and reaches
+// `VMTraps::handleTraps()` to service the pending stop-the-world /
+// termination / watchdog request.
+//
+// That only works if `jscSignalHandler` is the installed SIGSEGV disposition.
+// `WTF::SignalHandlers::finalize()` installs it on top of whatever was there
+// at JSC init time (Bun's crash handler, or ASAN's) and chains unhandled
+// faults back down. Anything that later overwrites the fault-signal
+// dispositions with `oldact = NULL` breaks VMTraps: the next halt delivers
+// SIGSEGV to the wrong handler, which either crashes (Bun's noreturn crash
+// reporter) or, if the new handler returns, re-executes the halt forever.
+//
+// The CLI sync-spawn path (`bun run <pkg-script>`, `bun test --changed`
+// spawning git, `bunx`, `bun create`, …) wraps the child wait in a
+// signal-forwarding scope (`Bun__registerSignalsForForwarding` /
+// `Bun__unregisterSignalsForForwarding`) so SIGINT/SIGTERM reach the child.
+// The forwarding set deliberately excludes the CPU-fault signals, and the
+// unregister step restores every signal it touched from a saved snapshot, so
+// the fault handlers must be identical before and after. An earlier version
+// additionally reinstalled Bun's crash handler on SIGSEGV/SIGBUS/SIGILL/SIGFPE
+// at scope exit, clobbering `jscSignalHandler` — this test guards that
+// regression.
+//
+// `bun test --changed` is the one cross-platform path where the sync spawn
+// runs *inside a live JSC VM* (git runs after `VirtualMachine.init`) and JS
+// continues afterward in the same process, so we use it as the vehicle: the
+// inner test file records the fault-signal handlers once loaded, and the
+// outer test compares them with a baseline captured in a fresh process that
+// did no sync spawn at all.
+//
+// Note: debug ASAN builds never exhibited the regression because
+// `crash_handler::reset_on_posix()` early-returns under ASAN; release builds
+// did. The invariant asserted here (fault handlers identical with and
+// without a preceding sync spawn) is correct for both, so this test guards
+// the release behaviour even though `bun bd` alone cannot reproduce the
+// original failure.
+
+import { spawnSync } from "bun";
+import { describe, expect, test } from "bun:test";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { bunEnv, bunExe, isPosix, tempDir, tmpdirSync } from "harness";
+
+// Shared by the baseline process and the inner --changed test: print one
+// `HANDLER <sig> <addr>` line per CPU-fault signal via the internal probe
+// (which reads `sigaction(sig, NULL, &out)` in native code so the per-libc
+// struct layout stays out of JS).
+const probe = /* js */ `
+  const { crash_handler } = require("bun:internal-for-testing");
+  const h = crash_handler.getFaultSignalHandlers();
+  for (const name of ["SIGSEGV", "SIGBUS", "SIGILL", "SIGFPE"]) {
+    console.log("HANDLER", name, h[name]);
+  }
+`;
+
+function parseHandlers(text: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of text.split("\n")) {
+    const m = /^HANDLER (\S+) (\S+)$/.exec(line.trim());
+    if (m) out[m[1]] = m[2];
+  }
+  return out;
+}
+
+// git isn't a syscall; keep its environment hermetic so the inner
+// `bun test --changed` process's own git invocations don't pick up a
+// developer's global excludes/hooks/signing config. GIT_CONFIG_GLOBAL must
+// point at a real (empty) file — see test-changed.test.ts for the Windows
+// `NUL` caveat.
+const emptyGitConfig = join(tmpdirSync(), "empty.gitconfig");
+writeFileSync(emptyGitConfig, "");
+const env = {
+  ...bunEnv,
+  BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1",
+  GIT_CONFIG_NOSYSTEM: "1",
+  GIT_CONFIG_GLOBAL: emptyGitConfig,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@example.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@example.com",
+};
+
+function git(cwd: string, ...args: string[]) {
+  const res = spawnSync({ cmd: ["git", ...args], cwd, env, stdout: "pipe", stderr: "pipe" });
+  if (!res.success) throw new Error(`git ${args.join(" ")} failed in ${cwd}:\n${res.stderr.toString()}`);
+}
+
+describe.skipIf(!isPosix)("CLI sync-spawn preserves JSC's fault-signal handlers", () => {
+  test("SIGSEGV/SIGBUS dispositions are identical with and without a preceding sync spawn", async () => {
+    // Baseline: a fresh bun process that has initialised JSC but done no
+    // CLI-level sync spawn. Whatever handlers it reports are exactly what
+    // JSC's SignalHandlers::finalize() installed for SIGSEGV/SIGBUS — i.e.,
+    // jscSignalHandler — plus whatever SIGILL/SIGFPE happened to be (Bun's
+    // crash handler on release, ASAN's or SIG_DFL on debug; JSC does not
+    // register for those two in Bun's configuration).
+    const baseline = await (async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", probe],
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+      return parseHandlers(stdout);
+    })();
+
+    // SIGSEGV and SIGBUS both map to WTF's Signal::AccessFault and so share
+    // the same jscSignalHandler sigaction. If either is SIG_DFL the JSC
+    // signal layer never installed, which would make the rest of this test
+    // meaningless.
+    expect(baseline.SIGSEGV).toMatch(/^[0-9a-f]+$/);
+    expect(baseline.SIGSEGV).not.toBe("0");
+    expect(baseline.SIGBUS).toBe(baseline.SIGSEGV);
+
+    // Now run the same probe as a `bun test --changed` test file. That path
+    // initialises JSC, then sync-spawns `git rev-parse` / `git diff` /
+    // `git ls-files` (each one a full SignalForwarding register/drop cycle)
+    // to compute the changed-files set, *then* loads and runs the test file.
+    // The handlers it observes are therefore post-sync-spawn.
+    using dir = tempDir("sync-spawn-fault-handlers", {
+      "package.json": JSON.stringify({ name: "p", type: "module" }),
+      // Wrap the probe in a trivially-passing test so `bun test` exits 0;
+      // the outer test reads the HANDLER lines from stdout.
+      "probe.test.ts": `import { test } from "bun:test";\n${probe}\ntest("noop", () => {});\n`,
+    });
+    const cwd = String(dir);
+    git(cwd, "init", "-q");
+    git(cwd, "config", "commit.gpgsign", "false");
+    git(cwd, "add", "-A");
+    git(cwd, "commit", "-q", "-m", "initial");
+    // One tracked change so --changed actually selects the probe and, more
+    // importantly, actually runs the git subprocesses it needs to compute
+    // the diff — those are the sync spawns under test.
+    writeFileSync(join(cwd, "probe.test.ts"), `import { test } from "bun:test";\n${probe}\ntest("noop", () => {});\n// touched\n`);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--changed", "probe.test.ts"],
+      cwd,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // Surface the inner test's own failures/output before asserting on the
+    // handler snapshot — an empty HANDLER set below is much harder to
+    // diagnose than the original inner-test error.
+    expect({ stderrHasFail: stderr.includes("(fail)"), exitCode }).toEqual({ stderrHasFail: false, exitCode: 0 });
+    const afterSyncSpawn = parseHandlers(stdout);
+
+    // ASLR randomises the absolute addresses between the two processes, but
+    // the *shape* must match: whatever four handlers the baseline process
+    // had, the post-sync-spawn process must have an identical set of four
+    // relative to itself. Collapse each snapshot to equality classes
+    // (SIGSEGV is always class 0) so `{SEGV:X,BUS:X,ILL:Y,FPE:Z}` and
+    // `{SEGV:A,BUS:A,ILL:B,FPE:C}` both become `[0,0,1,2]`, while a
+    // regression that moved SIGSEGV onto a different function than the
+    // untouched SIGILL/SIGFPE produces a different partition.
+    const shape = (h: Record<string, string>) => {
+      const order = ["SIGSEGV", "SIGBUS", "SIGILL", "SIGFPE"];
+      const seen = new Map<string, number>();
+      return order.map(n => {
+        const v = h[n] ?? "missing";
+        if (!seen.has(v)) seen.set(v, seen.size);
+        return seen.get(v);
+      });
+    };
+    expect({
+      SIGSEGV: afterSyncSpawn.SIGSEGV,
+      SIGBUS: afterSyncSpawn.SIGBUS,
+      shapeAfter: shape(afterSyncSpawn),
+      shapeBaseline: shape(baseline),
+    }).toEqual({
+      SIGSEGV: expect.stringMatching(/^[0-9a-f]+$/),
+      SIGBUS: afterSyncSpawn.SIGSEGV,
+      shapeAfter: shape(baseline),
+      shapeBaseline: shape(baseline),
+    });
+    expect(afterSyncSpawn.SIGSEGV).not.toBe("0");
+  });
+});

--- a/test/js/bun/spawn/sync-spawn-preserves-jsc-signal-handlers.test.ts
+++ b/test/js/bun/spawn/sync-spawn-preserves-jsc-signal-handlers.test.ts
@@ -43,7 +43,7 @@
 
 import { spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isPosix, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isPosix, tempDir } from "harness";
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -68,31 +68,36 @@ function parseHandlers(text: string): Record<string, string> {
   return out;
 }
 
-// git isn't a syscall; keep its environment hermetic so the inner
-// `bun test --changed` process's own git invocations don't pick up a
-// developer's global excludes/hooks/signing config. GIT_CONFIG_GLOBAL must
-// point at a real (empty) file — see test-changed.test.ts for the Windows
-// `NUL` caveat.
-const emptyGitConfig = join(tmpdirSync(), "empty.gitconfig");
-writeFileSync(emptyGitConfig, "");
-const env = {
-  ...bunEnv,
-  BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1",
-  GIT_CONFIG_NOSYSTEM: "1",
-  GIT_CONFIG_GLOBAL: emptyGitConfig,
-  GIT_AUTHOR_NAME: "Test",
-  GIT_AUTHOR_EMAIL: "test@example.com",
-  GIT_COMMITTER_NAME: "Test",
-  GIT_COMMITTER_EMAIL: "test@example.com",
-};
-
-function git(cwd: string, ...args: string[]) {
-  const res = spawnSync({ cmd: ["git", ...args], cwd, env, stdout: "pipe", stderr: "pipe" });
-  if (!res.success) throw new Error(`git ${args.join(" ")} failed in ${cwd}:\n${res.stderr.toString()}`);
-}
-
 describe.skipIf(!isPosix)("CLI sync-spawn preserves JSC's fault-signal handlers", () => {
   test("SIGSEGV/SIGBUS dispositions are identical with and without a preceding sync spawn", async () => {
+    // git isn't a syscall; keep its environment hermetic so the inner
+    // `bun test --changed` process's own git invocations don't pick up a
+    // developer's global excludes/hooks/signing config. GIT_CONFIG_GLOBAL
+    // must point at a real (empty) file — see test-changed.test.ts for the
+    // Windows `NUL` caveat. Colocated with the test repo so the harness
+    // tempDir disposer cleans both up together.
+    using dir = tempDir("sync-spawn-fault-handlers", {
+      "empty.gitconfig": "",
+      "package.json": JSON.stringify({ name: "p", type: "module" }),
+      // Wrap the probe in a trivially-passing test so `bun test` exits 0;
+      // the outer test reads the HANDLER lines from stdout.
+      "probe.test.ts": `import { test } from "bun:test";\n${probe}\ntest("noop", () => {});\n`,
+    });
+    const cwd = String(dir);
+    const env = {
+      ...bunEnv,
+      BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1",
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_CONFIG_GLOBAL: join(cwd, "empty.gitconfig"),
+      GIT_AUTHOR_NAME: "Test",
+      GIT_AUTHOR_EMAIL: "test@example.com",
+      GIT_COMMITTER_NAME: "Test",
+      GIT_COMMITTER_EMAIL: "test@example.com",
+    };
+    const git = (...args: string[]) => {
+      const res = spawnSync({ cmd: ["git", ...args], cwd, env, stdout: "pipe", stderr: "pipe" });
+      if (!res.success) throw new Error(`git ${args.join(" ")} failed in ${cwd}:\n${res.stderr.toString()}`);
+    };
     // Baseline: a fresh bun process that has initialised JSC but done no
     // CLI-level sync spawn. Whatever handlers it reports are exactly what
     // JSC's SignalHandlers::finalize() installed for SIGSEGV/SIGBUS — i.e.,
@@ -124,17 +129,10 @@ describe.skipIf(!isPosix)("CLI sync-spawn preserves JSC's fault-signal handlers"
     // `git ls-files` (each one a full SignalForwarding register/drop cycle)
     // to compute the changed-files set, *then* loads and runs the test file.
     // The handlers it observes are therefore post-sync-spawn.
-    using dir = tempDir("sync-spawn-fault-handlers", {
-      "package.json": JSON.stringify({ name: "p", type: "module" }),
-      // Wrap the probe in a trivially-passing test so `bun test` exits 0;
-      // the outer test reads the HANDLER lines from stdout.
-      "probe.test.ts": `import { test } from "bun:test";\n${probe}\ntest("noop", () => {});\n`,
-    });
-    const cwd = String(dir);
-    git(cwd, "init", "-q");
-    git(cwd, "config", "commit.gpgsign", "false");
-    git(cwd, "add", "-A");
-    git(cwd, "commit", "-q", "-m", "initial");
+    git("init", "-q");
+    git("config", "commit.gpgsign", "false");
+    git("add", "-A");
+    git("commit", "-q", "-m", "initial");
     // One tracked change so --changed actually selects the probe and, more
     // importantly, actually runs the git subprocesses it needs to compute
     // the diff — those are the sync spawns under test.


### PR DESCRIPTION
## What does this PR do?

`SignalForwarding::drop` — the RAII cleanup around the CLI sync-spawn path used by `bun run <pkg-script>`, `bun test --changed`'s git probes, `bunx`, `bun create`, `bun pm version`, … — called `crash_handler::reset_on_posix()` after `Bun__unregisterSignalsForForwarding()`.

The signal-forwarding set (`FOR_EACH_SIGNAL` in `c-bindings.cpp`: `SIGINT`/`SIGTERM`/`SIGHUP`/`SIGQUIT`/`SIGABRT`/…) never included `SIGSEGV`/`SIGBUS`/`SIGILL`/`SIGFPE`, and the unregister call already restores every signal it touched from a saved snapshot. So the reset was a no-op for its stated purpose — but it reinstalled Bun's crash handler on the four fault signals with `oldact=NULL`, overwriting WTF's `jscSignalHandler` that `WTF::SignalHandlers::finalize()` had layered on top at JSC init.

## Why does it matter?

`jscSignalHandler` is what makes signal-based VMTraps work. When JSC needs to interrupt DFG/FTL code asynchronously — stop-the-world GC (`NeedStopTheWorld`), `Worker.terminate()` (`NeedTermination`), watchdog timeout — the `VMTraps::SignalSender` thread patches a halt instruction (`hlt` on x86, `dc zva, xzr` on arm64) over each invalidation point in the running CodeBlock. The mutator hits it, the kernel delivers `SIGSEGV`, and `jscSignalHandler` dispatches to the VMTraps lambda, which looks the PC up in `DFG::pcCodeBlockMap`, jettisons the CodeBlock (patching the halt back to a jump to the OSR-exit thunk), and returns `Handled`. The mutator OSR-exits and reaches `VMTraps::handleTraps()`.

With Bun's crash handler installed in its place, the halt delivers `SIGSEGV` straight to the crash reporter, and the process dies with a spurious "Segmentation fault in JIT code" whose stack shows a half-jettisoned CodeBlock. Users have been working around this with `BUN_JSC_usePollingTraps=1`.

## How

- Drop the `reset_on_posix()` call from `SignalForwarding::drop`. `jscSignalHandler` already chains unhandled faults to the handler it displaced (Bun's crash handler), so crash reporting is unchanged.
- Add a `bun:internal-for-testing` probe, `crash_handler.getFaultSignalHandlers()`, that returns the four current `sa_sigaction` addresses via `libc::sigaction`.
- Add a test that captures the fault-signal handler partition in a fresh `bun -e` process and in a `bun test --changed` process (the one cross-platform path where the sync-spawn scope runs inside a live JSC VM and JS continues afterward) and asserts they match.
- `reset_on_posix()` itself is now private to `crash_handler`; with the spawn call gone, `init()` in the same module is its only caller. `bun_spawn` no longer depends on `bun_crash_handler`.
- `bake-codegen.ts` passes `OVERLAY_CSS` through `JSON.stringify` like the neighbouring `side` define, so the codegen step does not depend on the bootstrap bun having the define auto-quoting from #30679 (it failed to build with an older bootstrap bun otherwise). The bundler test comment that pointed at the raw form is updated to match.

## Testing note

Debug ASAN builds never exhibited the regression because `reset_on_posix()` early-returns under `ENABLE_ASAN`. The test asserts the invariant — fault handlers identical with and without a preceding sync spawn — which holds for both build types, so it guards the release behaviour even though `bun bd` alone cannot reproduce the original failure. Release CI will catch a regression.

A companion change (oven-sh/WebKit#233) reorders `CommonData::invalidateLinkedCode()` so the HLT is patched to a jump *before* its PC is removed from `pcCodeBlockMap`, closing a separate window where `codeBlockForVMTrapPC()` can return `nullptr` for a still-live HLT.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 15 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->
