### PR TITLE
fix(websocket): clamp close_reason_buf wrote_len to prevent OOB

### DIFF
--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -1667,7 +1667,10 @@ impl<const SSL: bool> WebSocket<SSL> {
                     cursor.set_position((pos + result.written as usize) as u64);
                 }
                 let wrote_len = cursor.position() as usize;
-                // SAFETY: close_reason_buf has 128 bytes; reinterpret first 125 as fixed array
+                // SAFETY: close_reason_buf has 128 bytes; reinterpret first 125 as fixed array.
+                // WebSocket close frame reason phrase max is 123 bytes per RFC 6455.
+                // Clamp wrote_len to prevent panic in send_close_with_body (slices body[..body_len]).
+                let wrote_len = wrote_len.min(125);
                 let buf_ptr = close_reason_buf.as_mut_ptr().cast::<[u8; 125]>();
                 this.send_close_with_body(code, Some(unsafe { &mut *buf_ptr }), wrote_len);
                 return;


### PR DESCRIPTION
## Summary

Fix for #30771. `send_close_with_body` takes a `&mut [u8; 125]` reference and slices it with `data[..body_len]`. If the close reason exceeds 125 bytes, the slice panics with an out-of-bounds index.

## Fix

Add `wrote_len.min(125)` to clamp the length before constructing the pointer cast and passing to `send_close_with_body`.

## Test

`test/js/web/websocket/websocket-close-fragmented.test.ts` — robobun reproduced the panic: `range end index 126 out of range for slice of length 125`.
