### PR TITLE
io(windows): remove UB fd-as-uv_handle_t cast in FilePoll::unregister

### DIFF
--- a/src/io/windows_event_loop.rs
+++ b/src/io/windows_event_loop.rs
@@ -120,17 +120,19 @@ impl FilePoll {
     }
 
     pub fn unregister(&mut self, _loop: &mut WindowsLoop) -> bool {
-        // TODO(@paperclover): This cast is extremely suspicious. At best, `fd` is
-        // the wrong type (it should be a uv handle), at worst this code is a
-        // crash due to invalid memory access.
-        // Zig does `@ptrFromInt(@as(u64, @bitCast(this.fd)))`; `Fd` is
-        // `#[repr(transparent)]` over `u64` on Windows, so the bitcast is just
-        // the public backing field.
-        // SAFETY: see TODO above — preserved verbatim from Zig.
-        unsafe {
-            uv::uv_unref(self.fd.0 as *mut uv::uv_handle_t);
-        }
-        true
+        // Unreachable on Windows: the four flags that gate `is_registered()`
+        // (`PollReadable`/`PollWritable`/`PollProcess`/`PollMachport`) are only
+        // inserted in POSIX-only code paths (kqueue/epoll registration). A
+        // Windows `FilePoll` is never registered with libuv directly — libuv
+        // handles own themselves via their own `uv_handle_t` structs, which
+        // are not stored in `self.fd`.
+        //
+        // This dropped the Zig-ported `uv_unref(@ptrFromInt(fd))` body: that
+        // cast reinterpreted a raw Windows file-descriptor integer as a
+        // `uv_handle_t*`, which is UB if it ever fired. Matches the pattern
+        // used by sibling `Waker::get_fd` / `Waker::init_with_file_descriptor`
+        // for other POSIX-only entry points in this file.
+        unreachable!("FilePoll::unregister is unsupported on Windows");
     }
 
     fn deinit_possibly_defer(&mut self, vm: EventLoopCtx, loop_: &mut WindowsLoop) {


### PR DESCRIPTION
Fixes #30775.

## What

`windows_event_loop::FilePoll::unregister` cast `self.fd.0` (a Windows file-descriptor integer) to `*mut uv_handle_t` and called `uv_unref` on it. The long-standing `TODO(@paperclover)` above the cast flagged it as "extremely suspicious… crash due to invalid memory access" — and it is: treating an fd integer as a `uv_handle_t*` is UB, and `uv_unref` writes to that handle's fields.

## Why it hasn't crashed in the wild

The body is dead code today. `is_registered()` (and the internal `deinit_possibly_defer` guard that calls `unregister`) gate on four flags: `PollReadable`, `PollWritable`, `PollProcess`, `PollMachport`. Searching the Rust tree:

- `Poll{Readable,Writable}` — only inserted in `lib.rs::apply_kqueue` (gated `#[cfg(any(target_os = "macos", target_os = "freebsd"))]`) and `register_for_epoll` (gated `#[cfg(any(target_os = "linux", target_os = "android"))]`).
- `PollProcess` / `PollMachport` — never inserted outside those POSIX paths.

On Windows, `FilePoll` is the `windows_event_loop` redefinition (`lib.rs:85`), and no Windows code path touches those flags. Net: `is_registered()` always returns `false` on Windows, so neither `deinit_possibly_defer` (internal) nor `FilePollRef::unregister` (the external wrapper in `lib.rs:1890`, itself guarded by the same flags at every call site in `PipeReader`/`dns`) ever reaches the cast. The reporter is flagging the TODO, not a reproducible crash.

## Fix

Drop the body and make the function `unreachable!("FilePoll::unregister is unsupported on Windows")`. Mirrors the pattern `Waker::get_fd` / `Waker::init_with_file_descriptor` already use in the same file for POSIX-only entry points, which the Zig original expressed with `@compileError`. If the invariant is ever broken by a future change, we get a clean panic instead of silent memory corruption.

## No regression test

This is dead Windows-only code being hardened pre-emptively — no reachable code path can exercise the change, and the CI gate host is Linux where `windows_event_loop` is `#[cfg(windows)]`'d out entirely. The reporter's concern is the TODO, not an observable crash. Same shape as #30715, which removed dead unsafe methods in `bun_collections` without adding tests.

## Verification

- `cargo check -p bun_io` (host Linux) ✅
- `cargo check -p bun_io --target x86_64-pc-windows-msvc` ✅
- `bun run rust:check-all` ✅ (10/10 targets)