### PR TITLE
fix(sourcemap): make InternalSourceMap::free_owned unsafe

### DIFF
--- a/src/jsc/SavedSourceMap.rs
+++ b/src/jsc/SavedSourceMap.rs
@@ -272,10 +272,12 @@ impl Drop for SavedSourceMap {
                     // SAFETY: blob was heap-allocated via `put_mappings`
                     // (`Box<[u8]>::into_raw`); the tagged pointer's address IS
                     // the blob's data pointer (InternalSourceMap is a thin view).
-                    (InternalSourceMap {
-                        data: ism as *const u8,
-                    })
-                    .free_owned();
+                    unsafe {
+                        (InternalSourceMap {
+                            data: ism as *const u8,
+                        })
+                        .free_owned();
+                    }
                 }
             }
             self.unlock();
@@ -365,10 +367,12 @@ impl SavedSourceMap {
                     // SAFETY: blob was heap-allocated via `put_mappings`
                     // (`Box<[u8]>::into_raw`); the tagged pointer's address IS
                     // the blob's data pointer (InternalSourceMap is a thin view).
-                    (InternalSourceMap {
-                        data: ism as *const u8,
-                    })
-                    .free_owned();
+                    unsafe {
+                        (InternalSourceMap {
+                            data: ism as *const u8,
+                        })
+                        .free_owned();
+                    }
                 }
                 *o.get_mut() = value.ptr();
             }

--- a/src/sourcemap/InternalSourceMap.rs
+++ b/src/sourcemap/InternalSourceMap.rs
@@ -197,21 +197,24 @@ impl InternalSourceMap {
         }
     }
 
-    /// Only call this when the blob was heap-allocated by `Builder`/`from_vlq` (e.g.
-    /// entries in `SavedSourceMap`). Do NOT call on views over the standalone
-    /// module graph section or any other borrowed memory.
-    // TODO(port): conditional ownership — intentionally NOT `impl Drop` because
-    // `InternalSourceMap` is a Copy view and may borrow non-owned memory. Phase B
-    // should split into an owning newtype with `impl Drop`.
-    pub fn free_owned(self) {
+    /// Free the heap-allocated blob backing `self`.
+    ///
+    /// # Safety
+    ///
+    /// The blob MUST have been heap-allocated by `Builder`/`from_vlq` (e.g.
+    /// entries in `SavedSourceMap` via `put_mappings`). Do NOT call on views
+    /// over the standalone module graph section or any other borrowed memory.
+    ///
+    /// TODO(port): conditional ownership — intentionally NOT `impl Drop` because
+    /// `InternalSourceMap` is a Copy view and may borrow non-owned memory. Phase B
+    /// should split into an owning newtype with `impl Drop`.
+    pub unsafe fn free_owned(self) {
         // SAFETY: caller guarantees the blob was produced by Builder/from_vlq via
         // the global allocator with this exact length.
-        unsafe {
-            drop(Box::<[u8]>::from_raw(core::slice::from_raw_parts_mut(
-                self.data.cast_mut(),
-                self.total_len(),
-            )));
-        }
+        drop(Box::<[u8]>::from_raw(core::slice::from_raw_parts_mut(
+            self.data.cast_mut(),
+            self.total_len(),
+        )));
     }
 
     pub fn memory_cost(self) -> usize {

--- a/src/sourcemap/InternalSourceMap.rs
+++ b/src/sourcemap/InternalSourceMap.rs
@@ -211,10 +211,12 @@ impl InternalSourceMap {
     pub unsafe fn free_owned(self) {
         // SAFETY: caller guarantees the blob was produced by Builder/from_vlq via
         // the global allocator with this exact length.
-        drop(Box::<[u8]>::from_raw(core::slice::from_raw_parts_mut(
-            self.data.cast_mut(),
-            self.total_len(),
-        )));
+        unsafe {
+            drop(Box::<[u8]>::from_raw(core::slice::from_raw_parts_mut(
+                self.data.cast_mut(),
+                self.total_len(),
+            )));
+        }
     }
 
     pub fn memory_cost(self) -> usize {


### PR DESCRIPTION
## Summary

Fix for #30768. `InternalSourceMap::free_owned()` calls `Box::from_raw` to free a heap-allocated blob backing the source map. However, `InternalSourceMap` is a `Copy` thin view that may point to either heap-allocated or borrowed memory — there is no runtime check to distinguish.

Calling `free_owned()` on a borrowed-memory view would free memory it does not own, causing use-after-free or allocator corruption.

## Fix

Make `free_owned` an `unsafe fn` with a properly documented `# Safety` section. The two call sites in `SavedSourceMap.rs` (which always pass heap-allocated blobs from `put_mappings`) now use explicit `unsafe {}` blocks with existing SAFETY comments preserved.

## Changes

- `src/sourcemap/InternalSourceMap.rs`: `pub fn free_owned(self)` → `pub unsafe fn free_owned(self)` with updated doc comment
- `src/jsc/SavedSourceMap.rs`: wrap both `free_owned()` call sites in `unsafe {}` blocks
