### PR TITLE
docs: document RareData Box allocation invariant for borrow-splitting

### DIFF
--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -1753,6 +1753,7 @@ impl<const SSL: bool> WebSocket<SSL> {
             // reads `vm.uws_loop()` / `vm.event_loop_handle` and never touches
             // `vm.rare_data`, so the shared `&VirtualMachine` argument cannot
             // observe or invalidate the `&mut RareData` receiver.
+            // See also: VirtualMachine::rare_data() # Caller invariants doc.
             unsafe { (*vm_ptr).rare_data().ws_client_group::<SSL>(&*vm_ptr) }
         };
         if !Socket::<SSL>::adopt_group(

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -965,6 +965,21 @@ impl VirtualMachine {
         }
     }
 
+    /// Returns a mutable reference to the per-VM `RareData`.
+    ///
+    /// # Caller invariants
+    ///
+    /// The returned `&mut RareData` points into a **separate heap allocation**
+    /// (the `Box<RareData>` stored in `self.rare_data`), NOT into `self` or any
+    /// inline field of `VirtualMachine`. Callers such as
+    /// `WebSocket::new()` in `websocket_client.rs` rely on this property to
+    /// perform raw-pointer borrow-splitting — forming a shared `&VirtualMachine`
+    /// alongside the `&mut RareData` without aliasing, because the two references
+    /// occupy disjoint allocations under Stacked Borrows / Tree Borrows.
+    ///
+    /// If the `RareData` storage is ever changed from `Box` to an inline field,
+    /// those callers would silently become UB. Keep this invariant documented
+    /// and consider a Miri regression test.
     #[inline]
     pub fn rare_data(&mut self) -> &mut RareData {
         if self.rare_data.is_none() {


### PR DESCRIPTION
## Summary

Documents the invariant that `VirtualMachine::rare_data()` returns a reference into a **separate Box allocation**, which enables raw-pointer borrow-splitting patterns at call sites like `websocket_client.rs:1756`.

Without this documentation, a future refactor that moves RareData from `Box` to an inline field would silently introduce UB at the call sites.

## Changes

- `src/jsc/VirtualMachine.rs`: Add `# Caller invariants` doc section to `rare_data()` explaining the Box allocation property and naming the dependent call sites
- `src/http_jsc/websocket_client.rs`: Add cross-reference from the SAFETY comment back to the invariant doc

Refs #30767