### PR TITLE
dispatch: make fs-uv or-patterns table-generated; debug-panic the wildcards

### DIFF
--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -47,8 +47,6 @@ use bun_jsc::{JSGlobalObject, JsResult};
 /// (`UVFSRequest`); they complete on the JS thread and re-enter through the
 /// task queue under a per-op tag. Every other async fs op is a `bun_jsc::Job`.
 /// Row shape: `$tag $ty;` (`task_tag::*` const, `fs_async::*` alias).
-/// Un-gated: the tags exist on every platform, and non-Windows match arms
-/// use it for their or-patterns.
 macro_rules! for_each_fs_uv_op {
     ($m:ident) => {
         $m! {

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -61,6 +61,29 @@ macro_rules! for_each_fs_uv_op {
 macro_rules! __fs_pat {
     ($($tag:ident $ty:ident;)*) => { $(task_tag::$tag)|* };
 }
+/// Expand the fs-op table to its row count (usize const expr).
+///
+/// Paired with a `const _: () = assert!` so a drift between this table and
+/// its consumers fails the build. The `run_task` site generates its outer
+/// guard from the same table, but `__bun_release_task_at_shutdown` hand-writes
+/// the outer or-pattern (the tags exist on every platform while this macro is
+/// Windows-gated) — if that list and this table desync, the inner wildcard
+/// there becomes reachable, which is release-build UB.
+#[cfg(windows)]
+macro_rules! __fs_count {
+    ($($tag:ident $ty:ident;)*) => { { [$(__fs_count!(@unit $tag)),*].len() } };
+    (@unit $tag:ident) => { () };
+}
+
+/// Compile-time guard: the `for_each_fs_uv_op!` table must stay at 7 rows,
+/// matching the hand-written `Open | Close | Read | Readv | Write | Writev |
+/// StatFS` or-pattern in `__bun_release_task_at_shutdown`. Update both when
+/// adding a row.
+#[cfg(windows)]
+const _: () = assert!(
+    for_each_fs_uv_op!(__fs_count) == 7,
+    "for_each_fs_uv_op! row count drifted — update the shutdown-release or-pattern too",
+);
 
 // ── per-variant payload types ────────────────────────────────────────────────
 // (high-tier owns them all; grouped by source module)
@@ -427,8 +450,22 @@ pub(crate) fn run_task(
             macro_rules! __fs_run {
                 ($($tag:ident $ty:ident;)*) => { match task.tag {
                     $(task_tag::$tag => cast!(fs_async::$ty).run_from_js_thread()?,)*
-                    // SAFETY: outer arm guard proves one of the table tags matched.
-                    _ => unsafe { core::hint::unreachable_unchecked() },
+                    // SAFETY: the outer arm guard and these arms expand from the
+                    // same `for_each_fs_uv_op!` table, so one of them matched;
+                    // the `__fs_count` assert pins the table. In debug/ASAN
+                    // builds panic instead of invoking UB so a regression
+                    // surfaces as a controlled crash before release.
+                    _ => {
+                        if cfg!(debug_assertions) {
+                            unreachable!(
+                                "fs-uv dispatch: tag {} passed outer or-pattern \
+                                 but missed inner match — table desync?",
+                                task.tag.0,
+                            );
+                        }
+                        // SAFETY: see arm comment.
+                        unsafe { core::hint::unreachable_unchecked() }
+                    }
                 }};
             }
             for_each_fs_uv_op!(__fs_run);
@@ -1329,8 +1366,24 @@ fn __bun_release_task_unrun(task: bun_event_loop::Task) {
                 macro_rules! __fs_release {
                     ($($tag:ident $ty:ident;)*) => { match task.tag {
                         $(task_tag::$tag => release!(fs_async::$ty),)*
-                        // SAFETY: the outer arm proves one of the table tags matched.
-                        _ => unsafe { core::hint::unreachable_unchecked() },
+                        // SAFETY: the hand-written outer or-pattern lists the same
+                        // 7 tags as `for_each_fs_uv_op!` (the `__fs_count` assert
+                        // pins the table; the or-pattern is hand-written because
+                        // the tags exist on every platform while the table macro
+                        // is Windows-gated). In debug/ASAN builds panic instead
+                        // of invoking UB so a desync surfaces as a controlled
+                        // crash before release.
+                        _ => {
+                            if cfg!(debug_assertions) {
+                                unreachable!(
+                                    "fs-uv shutdown release: tag {} passed outer \
+                                     or-pattern but missed inner match — table desync?",
+                                    task.tag.0,
+                                );
+                            }
+                            // SAFETY: see arm comment.
+                            unsafe { core::hint::unreachable_unchecked() }
+                        }
                     }};
                 }
                 for_each_fs_uv_op!(__fs_release);

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -47,7 +47,10 @@ use bun_jsc::{JSGlobalObject, JsResult};
 /// (`UVFSRequest`); they complete on the JS thread and re-enter through the
 /// task queue under a per-op tag. Every other async fs op is a `bun_jsc::Job`.
 /// Row shape: `$tag $ty;` (`task_tag::*` const, `fs_async::*` alias).
-#[cfg(windows)]
+///
+/// Not Windows-gated: the tags exist on every platform, and every consumer
+/// (the `run_task` arm, the shutdown-release arm) generates its outer
+/// or-pattern from this one table so the guards cannot drift apart.
 macro_rules! for_each_fs_uv_op {
     ($m:ident) => {
         $m! {
@@ -57,33 +60,9 @@ macro_rules! for_each_fs_uv_op {
     };
 }
 /// Expand the fs-op table to an or-pattern over `task_tag::*` (pattern position).
-#[cfg(windows)]
 macro_rules! __fs_pat {
     ($($tag:ident $ty:ident;)*) => { $(task_tag::$tag)|* };
 }
-/// Expand the fs-op table to its row count (usize const expr).
-///
-/// Paired with a `const _: () = assert!` so a drift between this table and
-/// its consumers fails the build. The `run_task` site generates its outer
-/// guard from the same table, but `__bun_release_task_at_shutdown` hand-writes
-/// the outer or-pattern (the tags exist on every platform while this macro is
-/// Windows-gated) — if that list and this table desync, the inner wildcard
-/// there becomes reachable, which is release-build UB.
-#[cfg(windows)]
-macro_rules! __fs_count {
-    ($($tag:ident $ty:ident;)*) => { { [$(__fs_count!(@unit $tag)),*].len() } };
-    (@unit $tag:ident) => { () };
-}
-
-/// Compile-time guard: the `for_each_fs_uv_op!` table must stay at 7 rows,
-/// matching the hand-written `Open | Close | Read | Readv | Write | Writev |
-/// StatFS` or-pattern in `__bun_release_task_at_shutdown`. Update both when
-/// adding a row.
-#[cfg(windows)]
-const _: () = assert!(
-    for_each_fs_uv_op!(__fs_count) == 7,
-    "for_each_fs_uv_op! row count drifted — update the shutdown-release or-pattern too",
-);
 
 // ── per-variant payload types ────────────────────────────────────────────────
 // (high-tier owns them all; grouped by source module)
@@ -450,20 +429,13 @@ pub(crate) fn run_task(
             macro_rules! __fs_run {
                 ($($tag:ident $ty:ident;)*) => { match task.tag {
                     $(task_tag::$tag => cast!(fs_async::$ty).run_from_js_thread()?,)*
-                    // SAFETY: the outer arm guard and these arms expand from the
-                    // same `for_each_fs_uv_op!` table, so one of them matched;
-                    // the `__fs_count` assert pins the table. In debug/ASAN
-                    // builds panic instead of invoking UB so a regression
-                    // surfaces as a controlled crash before release.
+                    // SAFETY: outer guard and these arms expand from the same
+                    // table; debug builds panic instead of invoking UB.
                     _ => {
                         if cfg!(debug_assertions) {
-                            unreachable!(
-                                "fs-uv dispatch: tag {} passed outer or-pattern \
-                                 but missed inner match — table desync?",
-                                task.tag.0,
-                            );
+                            unreachable!("fs-uv dispatch: unmatched tag {}", task.tag.0);
                         }
-                        // SAFETY: see arm comment.
+                        // SAFETY: see above.
                         unsafe { core::hint::unreachable_unchecked() }
                     }
                 }};
@@ -1354,34 +1326,19 @@ fn __bun_release_task_unrun(task: bun_event_loop::Task) {
             #[cfg(not(windows))]
             unreachable!("windows-only tag");
         }
-        task_tag::Open
-        | task_tag::Close
-        | task_tag::Read
-        | task_tag::Readv
-        | task_tag::Write
-        | task_tag::Writev
-        | task_tag::StatFS => {
+        for_each_fs_uv_op!(__fs_pat) => {
             #[cfg(windows)]
             {
                 macro_rules! __fs_release {
                     ($($tag:ident $ty:ident;)*) => { match task.tag {
                         $(task_tag::$tag => release!(fs_async::$ty),)*
-                        // SAFETY: the hand-written outer or-pattern lists the same
-                        // 7 tags as `for_each_fs_uv_op!` (the `__fs_count` assert
-                        // pins the table; the or-pattern is hand-written because
-                        // the tags exist on every platform while the table macro
-                        // is Windows-gated). In debug/ASAN builds panic instead
-                        // of invoking UB so a desync surfaces as a controlled
-                        // crash before release.
+                        // SAFETY: outer guard and these arms expand from the same
+                        // table; debug builds panic instead of invoking UB.
                         _ => {
                             if cfg!(debug_assertions) {
-                                unreachable!(
-                                    "fs-uv shutdown release: tag {} passed outer \
-                                     or-pattern but missed inner match — table desync?",
-                                    task.tag.0,
-                                );
+                                unreachable!("fs-uv shutdown release: unmatched tag {}", task.tag.0);
                             }
-                            // SAFETY: see arm comment.
+                            // SAFETY: see above.
                             unsafe { core::hint::unreachable_unchecked() }
                         }
                     }};

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -47,10 +47,8 @@ use bun_jsc::{JSGlobalObject, JsResult};
 /// (`UVFSRequest`); they complete on the JS thread and re-enter through the
 /// task queue under a per-op tag. Every other async fs op is a `bun_jsc::Job`.
 /// Row shape: `$tag $ty;` (`task_tag::*` const, `fs_async::*` alias).
-///
-/// Not Windows-gated: the tags exist on every platform, and every consumer
-/// (the `run_task` arm, the shutdown-release arm) generates its outer
-/// or-pattern from this one table so the guards cannot drift apart.
+/// Un-gated: the tags exist on every platform, and non-Windows match arms
+/// use it for their or-patterns.
 macro_rules! for_each_fs_uv_op {
     ($m:ident) => {
         $m! {

--- a/test/internal/source-lints/fs-uv-dispatch.test.ts
+++ b/test/internal/source-lints/fs-uv-dispatch.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test";
+import path from "path";
+
+// The `for_each_fs_uv_op!` x-macro in src/runtime/dispatch.rs stamps the
+// Windows libuv fs-request dispatch arms. Its inner matches end in a wildcard
+// whose unreachability rests on the outer match guard listing exactly the
+// same tags (#30787). Two invariants keep that wildcard from becoming
+// release-build UB:
+//
+// 1. Every consumer derives its outer or-pattern from the table via
+//    `for_each_fs_uv_op!(__fs_pat)`. A hand-written
+//    `task_tag::Open | task_tag::Close | ...` list can silently drift when a
+//    row is added, making the inner `unreachable_unchecked()` reachable.
+//
+// 2. The inner-match wildcards panic under `cfg!(debug_assertions)` before
+//    falling through to `unreachable_unchecked()`, so a dispatch regression
+//    surfaces as a controlled crash in debug/ASAN builds instead of UB.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const source = await Bun.file(path.join(root, "src/runtime/dispatch.rs")).text();
+
+test("fs-uv consumers derive their or-patterns from the table", () => {
+  // Both the run_task arm and the shutdown-release arm must expand the guard
+  // from the macro, never hand-write the tag list.
+  const generated = source.match(/for_each_fs_uv_op!\(__fs_pat\)/g) ?? [];
+  expect(generated.length).toBeGreaterThanOrEqual(2);
+
+  // A hand-written multi-tag or-pattern over the uv fs tags is the drift
+  // hazard this lint exists to reject.
+  expect(source).not.toMatch(/task_tag::Open\s*\n?\s*\|\s*task_tag::Close/);
+});
+
+test("fs-uv inner-match wildcards panic in debug builds before unreachable_unchecked", () => {
+  // Each inner dispatch macro (`__fs_run`, `__fs_release`) spans from its
+  // `macro_rules!` definition to the `for_each_fs_uv_op!` invocation that
+  // expands it. Within that span, the wildcard must contain the
+  // `cfg!(debug_assertions)` panic guard.
+  for (const name of ["__fs_run", "__fs_release"]) {
+    const start = source.indexOf(`macro_rules! ${name}`);
+    expect(start).toBeGreaterThan(-1);
+    const end = source.indexOf(`for_each_fs_uv_op!(${name})`, start);
+    expect(end).toBeGreaterThan(start);
+    const body = source.slice(start, end);
+    expect(body).toContain("core::hint::unreachable_unchecked()");
+    expect(body).toContain("cfg!(debug_assertions)");
+  }
+});

--- a/test/js/node/fs/fs-async-dispatch-smoke.test.ts
+++ b/test/js/node/fs/fs-async-dispatch-smoke.test.ts
@@ -1,0 +1,240 @@
+// Smoke coverage for the async `node:fs` dispatch paths behind
+// `src/runtime/dispatch.rs::run_task`. Most async fs ops are `bun_jsc::Job`s;
+// on Windows seven of them (Open/Close/Read/Write/Readv/Writev/StatFS) are
+// libuv requests that re-enter the task queue and dispatch through the
+// `for_each_fs_uv_op!` x-macro table (pinned at 7 rows by a compile-time
+// `assert!` on `for_each_fs_uv_op!(__fs_count)` in dispatch.rs — this file
+// is the runtime half of that pair).
+//
+// Each test exercises one async fs op through its user-facing API so a
+// future dispatch regression (missing arm, wrong `fs_async::*` alias)
+// surfaces as an observable test failure rather than silent UB.
+
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import * as fscb from "node:fs";
+import * as fs from "node:fs/promises";
+import { join } from "node:path";
+
+describe.concurrent("node:fs async dispatch smoke", () => {
+  test("stat / lstat / fstat", async () => {
+    using dir = tempDir("fs-disp-stat", { "f.txt": "hi" });
+    const p = join(String(dir), "f.txt");
+    expect((await fs.stat(p)).size).toBe(2);
+    expect((await fs.lstat(p)).isFile()).toBe(true);
+    const fh = await fs.open(p, "r");
+    try {
+      expect((await fh.stat()).size).toBe(2); // fstat
+    } finally {
+      await fh.close();
+    }
+  });
+
+  test("open / read / write / close", async () => {
+    using dir = tempDir("fs-disp-open", {});
+    const p = join(String(dir), "f.txt");
+    const fh = await fs.open(p, "w+");
+    try {
+      await fh.write("abc"); // write
+      const buf = Buffer.alloc(3);
+      await fh.read(buf, 0, 3, 0); // read
+      expect(buf.toString()).toBe("abc");
+    } finally {
+      await fh.close(); // close
+    }
+  });
+
+  test("readFile / writeFile / appendFile", async () => {
+    using dir = tempDir("fs-disp-rw", {});
+    const p = join(String(dir), "f.txt");
+    await fs.writeFile(p, "x");
+    await fs.appendFile(p, "y");
+    expect(await fs.readFile(p, "utf8")).toBe("xy");
+  });
+
+  test("copyFile", async () => {
+    using dir = tempDir("fs-disp-cp", { "a.txt": "src" });
+    const src = join(String(dir), "a.txt");
+    const dst = join(String(dir), "b.txt");
+    await fs.copyFile(src, dst);
+    expect(await fs.readFile(dst, "utf8")).toBe("src");
+  });
+
+  test("truncate / ftruncate", async () => {
+    using dir = tempDir("fs-disp-tr", { "f.txt": "helloworld" });
+    const p = join(String(dir), "f.txt");
+    await fs.truncate(p, 5);
+    expect(await fs.readFile(p, "utf8")).toBe("hello");
+    const fh = await fs.open(p, "r+");
+    try {
+      await fh.truncate(3); // ftruncate
+    } finally {
+      await fh.close();
+    }
+    expect(await fs.readFile(p, "utf8")).toBe("hel");
+  });
+
+  test("writev / readv", async () => {
+    using dir = tempDir("fs-disp-wv", {});
+    const p = join(String(dir), "f.txt");
+    const fh = await fs.open(p, "w+");
+    try {
+      await fh.writev([Buffer.from("ab"), Buffer.from("cd")]); // writev
+      const bufs = [Buffer.alloc(2), Buffer.alloc(2)];
+      await fh.readv(bufs, 0); // readv
+      expect(Buffer.concat(bufs).toString()).toBe("abcd");
+    } finally {
+      await fh.close();
+    }
+  });
+
+  test("rename", async () => {
+    using dir = tempDir("fs-disp-rn", { "a.txt": "1" });
+    const src = join(String(dir), "a.txt");
+    const dst = join(String(dir), "b.txt");
+    await fs.rename(src, dst);
+    expect(await fs.readFile(dst, "utf8")).toBe("1");
+  });
+
+  test("readdir", async () => {
+    using dir = tempDir("fs-disp-rd", { "a.txt": "", "b.txt": "" });
+    const entries = (await fs.readdir(String(dir))).sort();
+    expect(entries).toEqual(["a.txt", "b.txt"]);
+  });
+
+  test("readdir recursive", async () => {
+    using dir = tempDir("fs-disp-rdr", { "a.txt": "", "sub/b.txt": "" });
+    const entries = (await fs.readdir(String(dir), { recursive: true })).sort();
+    expect(entries).toContain("a.txt");
+    expect(entries.some(e => e.endsWith("b.txt"))).toBe(true);
+  });
+
+  test("rm / rmdir", async () => {
+    using dir = tempDir("fs-disp-rm", { "a.txt": "", sub: {} });
+    await fs.rm(join(String(dir), "a.txt"));
+    await fs.rmdir(join(String(dir), "sub"));
+    expect((await fs.readdir(String(dir))).length).toBe(0);
+  });
+
+  test("chown / fchown", async () => {
+    using dir = tempDir("fs-disp-ch", { "f.txt": "" });
+    const p = join(String(dir), "f.txt");
+    const s = await fs.stat(p);
+    await fs.chown(p, s.uid, s.gid);
+    const fh = await fs.open(p, "r");
+    try {
+      await fh.chown(s.uid, s.gid); // fchown
+    } finally {
+      await fh.close();
+    }
+  });
+
+  // On Windows `Syscall::lchown` routes through `uv_fs_lchown`, which is a
+  // no-op success matching Node (`node_fs.rs::lchown`), so this runs everywhere.
+  test("lchown", async () => {
+    using dir = tempDir("fs-disp-lch", { "f.txt": "" });
+    const p = join(String(dir), "f.txt");
+    const s = await fs.stat(p);
+    await fs.lchown(p, s.uid, s.gid);
+  });
+
+  test("utimes / lutimes / futimes", async () => {
+    using dir = tempDir("fs-disp-ut", { "f.txt": "" });
+    const p = join(String(dir), "f.txt");
+    const t = new Date();
+    await fs.utimes(p, t, t);
+    await fs.lutimes(p, t, t);
+    const fh = await fs.open(p, "r+");
+    try {
+      await fh.utimes(t, t); // futimes
+    } finally {
+      await fh.close();
+    }
+  });
+
+  test("chmod / fchmod", async () => {
+    using dir = tempDir("fs-disp-cm", { "f.txt": "" });
+    const p = join(String(dir), "f.txt");
+    await fs.chmod(p, 0o644);
+    const fh = await fs.open(p, "r+");
+    try {
+      await fh.chmod(0o644); // fchmod
+    } finally {
+      await fh.close();
+    }
+  });
+
+  // `fs.lchmod` is only defined when `constants.O_SYMLINK` exists (macOS-only,
+  // see the `O_SYMLINK` gates in `src/js/node/fs.ts`), so the lchmod path is
+  // platform-gated; skip with a visible marker on Linux/Windows instead of
+  // silently no-oping.
+  test.skipIf(typeof fscb.lchmod !== "function")("lchmod", async () => {
+    using dir = tempDir("fs-disp-lcm", { "f.txt": "" });
+    const p = join(String(dir), "f.txt");
+    await new Promise<void>((resolve, reject) => fscb.lchmod(p, 0o644, err => (err ? reject(err) : resolve())));
+  });
+
+  test("link / symlink / readlink / unlink", async () => {
+    using dir = tempDir("fs-disp-ln", { "src.txt": "s" });
+    const src = join(String(dir), "src.txt");
+    const hard = join(String(dir), "hard.txt");
+    const sym = join(String(dir), "sym.txt");
+    await fs.link(src, hard);
+    await fs.symlink(src, sym);
+    expect(await fs.readlink(sym)).toBe(src);
+    await fs.unlink(hard);
+    await fs.unlink(sym);
+  });
+
+  test("realpath / realpath.native", async () => {
+    using dir = tempDir("fs-disp-rp", { "f.txt": "" });
+    const p = join(String(dir), "f.txt");
+    // `fs.promises.realpath` routes through `node_fs_binding::realpath`
+    // (`RealpathNonNative` in node_fs_binding.rs).
+    expect(await fs.realpath(p)).toBeTruthy();
+    // `fs.realpath.native` routes through `realpath_native` (`Realpath`),
+    // the distinct native-realpath implementation.
+    const r = await new Promise<string | Buffer>((resolve, reject) =>
+      fscb.realpath.native(p, (err, res) => (err ? reject(err) : resolve(res))),
+    );
+    expect(r).toBeTruthy();
+  });
+
+  test("mkdir / mkdtemp", async () => {
+    using dir = tempDir("fs-disp-mk", {});
+    await fs.mkdir(join(String(dir), "sub"));
+    const tmp = await fs.mkdtemp(join(String(dir), "pfx-"));
+    expect(tmp.startsWith(join(String(dir), "pfx-"))).toBe(true);
+  });
+
+  test("fsync / fdatasync", async () => {
+    using dir = tempDir("fs-disp-fs", { "f.txt": "" });
+    const fh = await fs.open(join(String(dir), "f.txt"), "w");
+    try {
+      await fh.sync(); // fsync
+      await fh.datasync(); // fdatasync
+    } finally {
+      await fh.close();
+    }
+  });
+
+  test("access", async () => {
+    using dir = tempDir("fs-disp-ac", { "f.txt": "" });
+    await fs.access(join(String(dir), "f.txt"));
+  });
+
+  test("exists", async () => {
+    using dir = tempDir("fs-disp-ex", { "f.txt": "" });
+    // `fs.exists` (callback, deprecated) hits the dedicated exists path.
+    const exists = await new Promise<boolean>(resolve => fscb.exists(join(String(dir), "f.txt"), resolve));
+    expect(exists).toBe(true);
+  });
+
+  // On Windows `fs.statfs` is a `UVFSRequest` dispatched through the `StatFS`
+  // row of `for_each_fs_uv_op!`; keep unguarded so that arm is covered there.
+  test("statfs", async () => {
+    using dir = tempDir("fs-disp-sfs", {});
+    const s = await fs.statfs(String(dir));
+    expect(typeof s.type).toBe("number");
+  });
+});

--- a/test/js/node/fs/fs-async-dispatch-smoke.test.ts
+++ b/test/js/node/fs/fs-async-dispatch-smoke.test.ts
@@ -2,9 +2,7 @@
 // `src/runtime/dispatch.rs::run_task`. Most async fs ops are `bun_jsc::Job`s;
 // on Windows seven of them (Open/Close/Read/Write/Readv/Writev/StatFS) are
 // libuv requests that re-enter the task queue and dispatch through the
-// `for_each_fs_uv_op!` x-macro table (pinned at 7 rows by a compile-time
-// `assert!` on `for_each_fs_uv_op!(__fs_count)` in dispatch.rs — this file
-// is the runtime half of that pair).
+// `for_each_fs_uv_op!` x-macro table in dispatch.rs.
 //
 // Each test exercises one async fs op through its user-facing API so a
 // future dispatch regression (missing arm, wrong `fs_async::*` alias)


### PR DESCRIPTION
Closes #30787.

### Problem

- Issue #30787 flagged a `core::hint::unreachable_unchecked()` in the wildcard of a macro-generated match in `src/runtime/dispatch.rs`, reachable (as UB) if the outer match guard and the inner dispatch table ever desync.
- After the dispatch restructure on main, the pattern lives in the Windows-only `for_each_fs_uv_op!` table (Open/Close/Read/Write/Readv/Writev/StatFS), consumed at two sites: the `run_task` arm and the shutdown-release arm in `__bun_release_task_unrun`.
- The shutdown-release arm hand-wrote its 7-tag or-pattern while the inner match expanded from the macro, so a table edit that missed the hand-written list would have made its `unreachable_unchecked()` wildcard reachable: release-build UB.

### Fix

- Un-gate `for_each_fs_uv_op!`/`__fs_pat` (the tags exist on every platform; only the `#[cfg(windows)]` bodies name `fs_async` types) and expand the shutdown-release or-pattern from the table. Both sites now derive guard and match from one source, so they cannot desync.
- Both inner-match wildcards panic with a diagnostic under `cfg!(debug_assertions)` before falling through to `unreachable_unchecked()` in release, so a regression surfaces as a controlled crash in debug/ASAN builds. Release codegen is unchanged (`cfg!` const-folds).
- Verified: `cargo check -p bun_runtime` on Linux and `--target x86_64-pc-windows-msvc`, plus `bun bd test test/js/node/fs/fs-async-dispatch-smoke.test.ts` (21 pass / 1 platform-gated skip).

### Test

- `test/internal/source-lints/fs-uv-dispatch.test.ts` pins the two invariants as a source lint (the idiom used for other source-level rules in that directory): consumers must derive or-patterns from the table, and the wildcards must carry the debug panic. It fails against the pre-change `dispatch.rs` and passes with it.
- `test/js/node/fs/fs-async-dispatch-smoke.test.ts` exercises every async `node:fs` op through its user-facing API; on Windows the seven uv-request ops route through the hardened dispatch arms. Regression coverage: the production change is behavior-neutral on a correct build, so this file passes on both sides by design.

### Background

- `run_task` is bun's event-loop task dispatcher: tasks carry a `(tag, ptr)` pair, and a big `match` on the tag casts the pointer to the right payload type. X-macro tables stamp groups of similar arms.
- An inner re-match inside an or-pattern arm needs a wildcard to satisfy exhaustiveness; when outer guard and inner arms expand from the same table, that wildcard is provably unreachable, which is what sanctioned the `unreachable_unchecked()`.

<details>
<summary>Earlier iterations (pre-rebase)</summary>

The PR originally targeted the pre-restructure dispatch, where 42 fs ops shared a `for_each_fs_async_op!` table. It added a `__fs_count` row-count `const _: () = assert!(... == 42)` and debug-panic wildcards, verified by hand-deleting a row (build failed with the drift message). The rebase onto the restructured main (fs ops became `bun_jsc::Job`s; only 7 Windows libuv ops remain table-dispatched) replaced the count assert with the stronger fix above: generating every consumer's or-pattern from the single table removes the desync class instead of detecting it.

</details>