### PR TITLE
fix(Channel): avoid &mut aliasing in container_of pattern

### DIFF
--- a/src/runtime/cli/test/parallel/Channel.rs
+++ b/src/runtime/cli/test/parallel/Channel.rs
@@ -81,12 +81,19 @@ impl<Owner> Default for Channel<Owner> {
 }
 
 impl<Owner: ChannelOwner> Channel<Owner> {
+    /// Recover a raw pointer to the owning struct from `&mut self`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure `self` is embedded in a live `Owner` with
+    /// whole-`Owner` provenance. The returned pointer must not be used to
+    /// create `&mut Owner` while `&mut self` is live — the two would alias.
     #[inline]
-    fn owner(&mut self) -> &mut Owner {
-        // SAFETY: `self` is always embedded at `Owner::OFFSET` inside an
-        // `Owner` that outlives all callbacks (see module doc). Mirrors Zig
+    unsafe fn owner_ptr(&mut self) -> *mut Owner {
+        // SAFETY: `self` is embedded at `Owner::OFFSET` inside a live
+        // `Owner` that outlives all callbacks. Mirrors Zig
         // `@alignCast(@fieldParentPtr(owner_field, self))`.
-        unsafe { &mut *Owner::from_field_ptr(std::ptr::from_mut(self)) }
+        Owner::from_field_ptr(std::ptr::from_mut(self))
     }
 }
 
@@ -493,10 +500,10 @@ impl<Owner: ChannelOwner> Channel<Owner> {
             let mut rd = frame::Reader {
                 p: &self.r#in[head + 5..][..len as usize],
             };
-            // SAFETY: see `Channel::owner()` — `self` is embedded at
-            // `Owner::OFFSET` inside an `Owner` that outlives all callbacks.
-            let owner: &mut Owner = unsafe { &mut *owner_ptr };
-            owner.on_channel_frame(kind, &mut rd);
+            // SAFETY: `self` is embedded at `Owner::OFFSET` inside an
+            // `Owner` that outlives all callbacks. Raw pointer deref
+            // avoids materializing `&mut Owner` alongside `&mut self`.
+            unsafe { (*owner_ptr).on_channel_frame(kind, &mut rd) };
             head += 5usize + len as usize;
         }
         self.r#in.drain_front(head);
@@ -507,7 +514,8 @@ impl<Owner: ChannelOwner> Channel<Owner> {
             return;
         }
         self.done = true;
-        self.owner().on_channel_done();
+        // SAFETY: `self` is embedded in a live `Owner` (see `owner_ptr` doc).
+        unsafe { (*self.owner_ptr()).on_channel_done() };
     }
 }
 


### PR DESCRIPTION
## Summary

Fix for #30791. `Channel::owner()` returned `&mut Owner` reconstructed from `&mut self` (a field of `Owner`), materializing two live `&mut` references to overlapping memory — a borrowck/runtime aliasing violation.

The Zig original freely aliased mutable pointers, so this was fine there. In Rust, the `container_of` pattern must avoid creating contradictory references on the same allocation.

## Fix

Replace `fn owner(&mut self) -> &mut Owner` with `unsafe fn owner_ptr(&mut self) -> *mut Owner`. Update call sites to use raw pointer deref `(*ptr).method()` instead of `&mut` reborrow, preventing the aliasing violation.

## Changes

- `src/runtime/cli/test/parallel/Channel.rs`: `owner()` → `unsafe fn owner_ptr()` returning `*mut Owner`; rewrite call sites to use raw pointer deref

Closes #30791
