### PR TITLE
repl: route vm_mut through VirtualMachine::as_mut for sound provenance

### DIFF
--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -86,18 +86,22 @@ fn vm_set_execution_forbidden(vm: *mut jsc::VM, forbidden: bool) {
 
 /// Reborrow `&VirtualMachine` as `&mut VirtualMachine`.
 ///
-/// SAFETY: The Zig spec passes `*JSC.VirtualMachine` (mutable, freely-aliasing)
+/// The Zig spec passes `*JSC.VirtualMachine` (mutable, freely-aliasing)
 /// everywhere; `VirtualMachine` is single-threaded per JS thread and the REPL
 /// is the sole driver of `tick()` / `wait_for_promise()` here. Phase-B port
-/// stores `&VirtualMachine` for borrowck simplicity and casts at the call site.
+/// stores `&VirtualMachine` for borrowck simplicity and reborrows at the call
+/// site.
+///
+/// Routes through [`VirtualMachine::as_mut`] so the `&mut` comes from the
+/// thread-local `*mut` installed by `init()` — not from `&vm` laundered via
+/// `cast_mut()`, which would hit the `invalid_reference_casting` lint for
+/// good reason (`&self`-derived provenance cannot legally be promoted to
+/// `&mut`). Same single-JS-thread soundness contract as
+/// `VirtualMachine::as_mut`; keep the borrow short and do not hold it across
+/// reentrant JS calls.
 #[inline]
-#[allow(invalid_reference_casting)]
 fn vm_mut<'a>(vm: &'a VirtualMachine) -> &'a mut VirtualMachine {
-    // Launder through a raw pointer; rustc's `invalid_reference_casting` lint is
-    // silenced above because the Zig spec's `*JSC.VirtualMachine` is a freely-
-    // aliasing mutable pointer and `VirtualMachine` is `!Sync` single-thread state.
-    let ptr: *mut VirtualMachine = core::ptr::from_ref(vm).cast_mut();
-    unsafe { &mut *ptr }
+    vm.as_mut()
 }
 
 // ============================================================================


### PR DESCRIPTION
Closes #30790.

## What

`src/runtime/cli/repl.rs` had a private helper that hand-laundered `&VirtualMachine` into `&mut VirtualMachine` via a raw pointer cast, with `#[allow(invalid_reference_casting)]` silencing rustc's deny-by-default lint:

```rust
#[inline]
#[allow(invalid_reference_casting)]
fn vm_mut<'a>(vm: &'a VirtualMachine) -> &'a mut VirtualMachine {
    let ptr: *mut VirtualMachine = core::ptr::from_ref(vm).cast_mut();
    unsafe { &mut *ptr }
}
```

Under Rust's stacked/tree borrows model a `&mut` whose provenance starts as `&T` is UB regardless of aliasing facts at runtime — that's exactly what `invalid_reference_casting` reports, and why it's deny-by-default.

## Fix

Replace the body with the existing sound helper in `src/jsc/VirtualMachine.rs:664`:

```rust
#[inline]
fn vm_mut<'a>(vm: &'a VirtualMachine) -> &'a mut VirtualMachine {
    vm.as_mut()
}
```

`VirtualMachine::as_mut` routes through `Self::get_mut_ptr()` — the thread-local `*mut VirtualMachine` installed in `init()` — so the provenance chain is `*mut → &mut`, not `&self → &mut`. No lint allow needed. Same single-JS-thread soundness contract as every other caller (`src/install_jsc/ini_jsc.rs`, `src/runtime/test_runner/Execution.rs`, `src/runtime/webcore/s3/simple_request.rs`, …).

The shim's signature is unchanged so all ~16 call sites (`tick()`, `wait_for_promise`, `auto_tick_active`, macro context init) keep compiling as-is.

## Verification

- `cargo check -p bun_runtime` — clean (no new warnings).
- `bun bd test test/js/bun/repl/repl.test.ts` — 105 pass / 0 fail. Covers promise ticking, macro context init, tab completion, multiline input, TypeScript, top-level await, .editor, Ctrl+C/Ctrl+D, and history — every call site of `vm_mut`.

No runtime behavior change: the old code happened to work because `VirtualMachine` is a per-thread singleton, but the provenance was wrong and the lint was being actively silenced. The fix makes the `&mut` legally derivable instead of just happening not to trip.

## Why option 1 (replace body) over option 2 (mark `unsafe fn`)

The reporter's suggested fix of `unsafe fn vm_mut` moves the same unsound provenance pattern behind an `unsafe` block at each call site; it doesn't actually fix the stacked-borrows UB, it just opts callers in. Routing through `VirtualMachine::as_mut` removes the UB entirely — callers no longer need to justify anything because there's nothing to justify.

<details>
<summary>Why no behavioral regression test?</summary>

This is a compile-time/Miri-detectable soundness fix: the old code and new code produce identical machine code and identical observable behavior. There is no runtime input that exercises the fix differently from the pre-fix version, so a "fails before, passes after" test cannot exist. The `#[allow(invalid_reference_casting)]` being gone is the permanent guard — any future regression of the pattern fails to compile.

Existing REPL coverage (`test/js/bun/repl/repl.test.ts`, 105 tests, all green) exercises every `vm_mut` call site end-to-end.

</details>