### PR TITLE
Channel/DirectoryWatchStore: owner() returns *mut Parent, not &mut

### DIFF
--- a/src/runtime/bake/DevServer/DirectoryWatchStore.rs
+++ b/src/runtime/bake/DevServer/DirectoryWatchStore.rs
@@ -66,13 +66,22 @@ impl From<InsertError> for bun_core::Error {
 }
 
 impl DirectoryWatchStore {
-    pub fn owner(&mut self) -> &mut DevServer {
-        // SAFETY: `self` is always the `directory_watchers` field of a `DevServer`.
-        // TODO(port): `container_of` aliasing — returning &mut DevServer while
-        // &mut self is live is unsound under stacked borrows; Phase B may need
-        // to return *mut DevServer or restructure access.
+    /// Recover `*mut DevServer` from `self` (the `directory_watchers` field).
+    ///
+    /// Returns a raw pointer, NOT `&mut DevServer`: materialising a
+    /// `&mut DevServer` while `&mut self` is live would alias (stacked-borrows
+    /// UB — the pointer derived from `&mut self` only has provenance for the
+    /// field, not the whole parent). Callers dereference under `unsafe` and
+    /// must only touch fields disjoint from `directory_watchers`.
+    ///
+    /// Matches the shape of `impl_field_parent! { ... fn mut owner; }` — see
+    /// `bun_core::impl_field_parent!` for the convention.
+    #[inline]
+    pub fn owner(&mut self) -> *mut DevServer {
+        // SAFETY: `self` is always the `directory_watchers` field of a live
+        // `DevServer`. Pointer arithmetic only; no reference is formed here.
         unsafe {
-            &mut *bun_core::from_field_ptr!(
+            bun_core::from_field_ptr!(
                 DevServer,
                 directory_watchers,
                 std::ptr::from_mut::<Self>(self)
@@ -137,17 +146,22 @@ impl DirectoryWatchStore {
         // The `import_source` parameter is not a stable string. Since the
         // import source will be added to IncrementalGraph anyways, this is a
         // great place to share memory.
-        let dev = self.owner();
+        // SAFETY: `owner()` returns `*mut DevServer` — `self` is the
+        // `directory_watchers` field of the heap-allocated DevServer;
+        // `graph_safety_lock`, `client_graph`, and `server_graph` are all
+        // disjoint from `directory_watchers`, so dereferencing through `dev`
+        // for those fields does not alias `self`.
+        let dev: *mut DevServer = self.owner();
         // TODO(port): graph_safety_lock — assuming RAII guard semantics in Rust port.
-        let _guard = dev.graph_safety_lock.lock();
+        let _guard = unsafe { (*dev).graph_safety_lock.lock() };
         let owned_file_path: bun_ptr::RawSlice<u8> = match renderer {
             BakeGraph::Client => {
-                dev.client_graph
+                unsafe { &mut (*dev).client_graph }
                     .insert_empty(import_source, dev_server::FileKind::Unknown)?
                     .key
             }
             BakeGraph::Server | BakeGraph::Ssr => {
-                dev.server_graph
+                unsafe { &mut (*dev).server_graph }
                     .insert_empty(import_source, dev_server::FileKind::Unknown)?
                     .key
             }
@@ -171,8 +185,9 @@ impl DirectoryWatchStore {
     ) -> Result<(), InsertError> {
         debug_assert!(!specifier.is_empty());
         // TODO: watch the parent dir too.
-        // PORT NOTE: take a raw pointer so the &mut self borrow from owner() does
-        // not overlap subsequent self.* field accesses (Zig has no borrowck here).
+        // `owner()` returns `*mut DevServer` so no `&mut` reborrow is formed
+        // here — subsequent `self.*` field accesses can run without conflict;
+        // each deref `(*dev).field` is individually justified below.
         let dev: *mut DevServer = self.owner();
 
         let file_path_slice = file_path.slice();
@@ -381,7 +396,11 @@ impl DirectoryWatchStore {
             entry.dir,
         );
 
-        self.owner().bun_watcher.remove_at_index(
+        // SAFETY: `owner()` returns `*mut DevServer`; `bun_watcher` is
+        // disjoint from `directory_watchers` so the re-borrow through `dev`
+        // does not alias `self`.
+        let dev: *mut DevServer = self.owner();
+        unsafe { &mut (*dev).bun_watcher }.remove_at_index(
             bun_watcher::Kind::File,
             entry.watch_index,
             0,

--- a/src/runtime/cli/test/parallel/Channel.rs
+++ b/src/runtime/cli/test/parallel/Channel.rs
@@ -81,12 +81,24 @@ impl<Owner> Default for Channel<Owner> {
 }
 
 impl<Owner: ChannelOwner> Channel<Owner> {
+    /// Recover `*mut Owner` from `self` (a field of `Owner` at `Owner::OFFSET`).
+    ///
+    /// Returns a raw pointer, NOT `&mut Owner`: materialising a `&mut Owner`
+    /// while `&mut self` is live — `self` is an interior field of `Owner` —
+    /// would produce two overlapping `&mut` references (stacked-borrows UB).
+    /// Callers dereference under `unsafe` and must only touch fields of
+    /// `Owner` disjoint from the channel field.
+    ///
+    /// Mirrors Zig `@alignCast(@fieldParentPtr(owner_field, self))` and the
+    /// `fn mut owner;` form of [`bun_core::impl_field_parent!`] (not used here
+    /// because `impl_field_parent!` takes a literal field name and this
+    /// accessor is generic over `Owner`, with the offset coming from
+    /// `IntrusiveField::OFFSET` instead).
     #[inline]
-    fn owner(&mut self) -> &mut Owner {
-        // SAFETY: `self` is always embedded at `Owner::OFFSET` inside an
-        // `Owner` that outlives all callbacks (see module doc). Mirrors Zig
-        // `@alignCast(@fieldParentPtr(owner_field, self))`.
-        unsafe { &mut *Owner::from_field_ptr(std::ptr::from_mut(self)) }
+    fn owner(&mut self) -> *mut Owner {
+        // SAFETY: `self` is always the channel field of a live `Owner` (see
+        // module doc); pointer arithmetic only, no reference is formed here.
+        unsafe { Owner::from_field_ptr(std::ptr::from_mut(self)) }
     }
 }
 
@@ -482,21 +494,22 @@ impl<Owner: ChannelOwner> Channel<Owner> {
                 head += 5usize + len as usize;
                 continue;
             };
-            // PORT NOTE: borrowck split — `rd` borrows `self.r#in` while
-            // `owner()` would re-borrow `*self` mutably. Capture the owner raw
-            // pointer *before* forming `rd` (so the `&mut *self` reborrow ends
-            // immediately), then recover `&mut Owner` from it after. Same
-            // `container_of` arithmetic as `owner()`. The callback never
-            // touches `self.r#in` (it only reads `rd` and may write other
-            // channel fields / call `send()`), so the aliasing is sound.
-            let owner_ptr: *mut Owner = unsafe { Owner::from_field_ptr(std::ptr::from_mut(self)) };
+            // PORT NOTE: cannot form `&mut Owner` and hold it across `rd`
+            // (which borrows `self.r#in`) — the two would alias. Capture
+            // `*mut Owner` *before* forming `rd` so the reborrow ends
+            // immediately, then dispatch the callback through the raw
+            // pointer. The owner's `on_channel_frame` body may reach back
+            // into its `Channel` field (e.g. to call `send()`), but must not
+            // touch `self.r#in` for the lifetime of `rd` — the shared
+            // callers (Worker, WorkerCommands) only read `rd` or mutate
+            // other fields.
+            let owner_ptr: *mut Owner = self.owner();
             let mut rd = frame::Reader {
                 p: &self.r#in[head + 5..][..len as usize],
             };
-            // SAFETY: see `Channel::owner()` — `self` is embedded at
+            // SAFETY: see `Channel::owner` — `self` is embedded at
             // `Owner::OFFSET` inside an `Owner` that outlives all callbacks.
-            let owner: &mut Owner = unsafe { &mut *owner_ptr };
-            owner.on_channel_frame(kind, &mut rd);
+            unsafe { (*owner_ptr).on_channel_frame(kind, &mut rd) };
             head += 5usize + len as usize;
         }
         self.r#in.drain_front(head);
@@ -507,7 +520,14 @@ impl<Owner: ChannelOwner> Channel<Owner> {
             return;
         }
         self.done = true;
-        self.owner().on_channel_done();
+        // `owner()` returns `*mut Owner`, not `&mut Owner`: materialising a
+        // `&mut Owner` while `&mut self` is live would alias (see `owner()`).
+        // Dispatch through the raw pointer so no long-lived `&mut Owner` is
+        // held across any further channel mutation in the callback body.
+        // SAFETY: see `Channel::owner` — `self` is embedded at `Owner::OFFSET`
+        // inside an `Owner` that outlives all callbacks.
+        let owner: *mut Owner = self.owner();
+        unsafe { (*owner).on_channel_done() };
     }
 }
 


### PR DESCRIPTION
Closes #30791

## Problem

Two hand-rolled `owner()` accessors reconstruct `&mut Parent` from `&mut self` (a field of Parent) via `container_of` arithmetic:

- `Channel::owner()` (`src/runtime/cli/test/parallel/Channel.rs:85`)
- `DirectoryWatchStore::owner()` (`src/runtime/bake/DevServer/DirectoryWatchStore.rs:69`)

Materialising `&mut Parent` while `&mut self` is live produces two `&mut` references covering overlapping memory — stacked-borrows UB. The raw pointer derived from `std::ptr::from_mut(self)` only has provenance for the field, not the whole parent.

The codebase already encodes the correct pattern in `bun_core::impl_field_parent!`'s `fn mut owner;` arm (src/bun_core/lib.rs:864), and explicitly documents this reason in the macro doc-comment:

> The mut accessor returns `*mut $Parent` (NOT `&mut`) because `self` is a field of `$Parent` — materializing `&mut $Parent` while `&mut self` is live would alias.

The two call sites above were never converted. The live `DirectoryWatchStore` in `dev_server/mod.rs` already uses the right shape; this PR aligns the draft submodule at `DevServer/DirectoryWatchStore.rs` with it.

## Fix

Change both `owner()` methods to return `*mut Parent` and update the three call sites to dereference under `unsafe`, touching only fields disjoint from the child slot.

`Channel` (generic over `Owner`, so `impl_field_parent!` can't be used directly — the offset comes from `IntrusiveField::OFFSET`):

```diff
-    fn owner(&mut self) -> &mut Owner {
-        unsafe { &mut *Owner::from_field_ptr(std::ptr::from_mut(self)) }
-    }
+    fn owner(&mut self) -> *mut Owner {
+        unsafe { Owner::from_field_ptr(std::ptr::from_mut(self)) }
+    }
```

`DirectoryWatchStore` (draft submodule; the live copy in `dev_server/mod.rs` already does this):

```diff
-    pub fn owner(&mut self) -> &mut DevServer {
-        unsafe { &mut *bun_core::from_field_ptr!(DevServer, directory_watchers, ...) }
+    pub fn owner(&mut self) -> *mut DevServer {
+        unsafe { bun_core::from_field_ptr!(DevServer, directory_watchers, ...) }
     }
```

Call sites:

- `Channel::mark_done` → `let owner = self.owner(); unsafe { (*owner).on_channel_done() };`
- `Channel::ingest` → dispatch `on_channel_frame` through `*mut Owner` (was already doing the raw-ptr capture to avoid a different borrowck conflict with `rd`; now uses the new `owner()` helper instead of open-coding `Owner::from_field_ptr`).
- `DirectoryWatchStore::track_resolution_failure` → access `graph_safety_lock`, `client_graph`, `server_graph` through `(*dev).field` (all disjoint from `directory_watchers`).
- `DirectoryWatchStore::free_entry` → access `bun_watcher` through `(*dev).field` (disjoint).
- `DirectoryWatchStore::insert` already had `let dev: *mut DevServer = self.owner();` via coercion — now explicit.

Resolves the `TODO(port)` comment at `DirectoryWatchStore.rs:71-73` and the acknowledged-unsound pattern at `Channel.rs:89`.

## Verification

- `cargo check -p bun_runtime` clean.
- `bun bd` debug build clean.
- `test/cli/test/parallel.test.ts` (the primary consumer of `Channel`) passes against the fixed build on every test that passes on main. The 4 timing-sensitive tests that fail in this container fail identically without the change — pre-existing container flake.

Note on strict provenance: the fundamental `container_of` pattern — reconstructing a wider pointer from a narrower field pointer — is still formally UB under strict provenance (the field pointer doesn't carry whole-parent provenance). The issue triage called this out as "acknowledged unsound under strict provenance". This PR doesn't resolve that; it fixes the separate, stricter aliasing issue of materialising `&mut Parent` overlapping with `&mut self`, matching the `impl_field_parent!` house convention.
