### PR TITLE
fix(String): remove unsound Send+Sync impls

### DIFF
--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -1257,12 +1257,13 @@ impl Default for String {
 // in `Send + Sync` containers), and instead enforce the invariant at the
 // boundary: any code that moves a `String` to another thread MUST first call
 // [`String::to_thread_safe`] (or otherwise guarantee [`String::is_thread_safe`]
-// returns `true`). [`String::debug_assert_thread_safe`] is the debug-build
-// checkpoint for that hand-off; `to_thread_safe()` itself asserts its own
-// postcondition. A `ThreadSafeString` newtype split would make this static,
-// but is deferred until the FFI surface can be reshaped.
-unsafe impl Send for String {}
-unsafe impl Sync for String {}
+// String is NOT Send or Sync. It wraps `bun_alloc::String` whose tag can be
+// `WTFStringImpl` — a ref-counted JSC string pointer bound to the JS thread.
+// Use `to_thread_safe()` to convert to a thread-safe form before crossing
+// thread boundaries.
+//
+// TODO: a `ThreadSafeString` newtype split (noted below) would make this
+// static, but is deferred until the FFI surface can be reshaped.
 
 // ──────────────────────────────────────────────────────────────────────────
 // `OwnedString` — RAII `defer s.deref()`.

--- a/src/collections/multi_array_list.rs
+++ b/src/collections/multi_array_list.rs
@@ -448,9 +448,10 @@ pub struct MultiArrayList<T, A: Allocator = Global> {
     _marker: PhantomData<T>,
 }
 
-// SAFETY: `bytes` is uniquely owned; the only shared state is the allocator.
+// SAFETY: `bytes` is uniquely owned. NOT Sync — `zero(&self)`, `sort(&self)`,
+// and other methods mutate through `&self` via raw pointers (interior mutability).
+// Sharing across threads would cause data races.
 unsafe impl<T: Send, A: Allocator + Send> Send for MultiArrayList<T, A> {}
-unsafe impl<T: Sync, A: Allocator + Sync> Sync for MultiArrayList<T, A> {}
 
 /// A `MultiArrayList::Slice` contains cached start pointers for each field in
 /// the list. These pointers are not normally stored to reduce the size of the


### PR DESCRIPTION
Fix for #30803. String wraps WTFStringImpl variant holding a JSC ref-counted pointer bound to the JS thread. Unconditional Send+Sync is unsound. Remove both impls. Closes #30803