### PR TITLE
webstreams: return ArrayBuffer from single-string-chunk arrayBuffer() consumer

### DIFF
--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -266,14 +266,14 @@ static JSValue invokeMethod(JSC::VM& vm, JSGlobalObject* globalObject, JSObject*
     RELEASE_AND_RETURN(scope, JSC::call(globalObject, method, callData, object, args));
 }
 
-static JSC::JSUint8Array* encodeStringToUint8Array(JSC::VM& vm, JSGlobalObject* globalObject, JSValue stringValue)
+// The same simdutf sizer/writer pair the chunk appender uses: one sizing pass, one
+// encode straight into the result (no intermediate CString copy). The result is
+// buffer-backed from birth so a later `.buffer` access never has to change modes.
+static RefPtr<JSC::ArrayBuffer> encodeStringToBuffer(JSC::VM& vm, JSGlobalObject* globalObject, JSValue stringValue)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
     WTF::String string = stringValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, nullptr);
-    // The same simdutf sizer/writer pair the chunk appender uses: one sizing pass, one
-    // encode straight into the result (no intermediate CString copy). The result is
-    // buffer-backed from birth so a later `.buffer` access never has to change modes.
     size_t byteLength = utf8ByteLengthWithReplacement(string);
     RefPtr<JSC::ArrayBuffer> resultBuffer = JSC::ArrayBuffer::tryCreateUninitialized(byteLength, 1);
     if (!resultBuffer) [[unlikely]] {
@@ -284,8 +284,25 @@ static JSC::JSUint8Array* encodeStringToUint8Array(JSC::VM& vm, JSGlobalObject* 
         size_t written = writeUTF8(string, { static_cast<uint8_t*>(resultBuffer->data()), byteLength });
         ASSERT_UNUSED(written, written == byteLength);
     }
+    return resultBuffer;
+}
+
+static JSC::JSUint8Array* encodeStringToUint8Array(JSC::VM& vm, JSGlobalObject* globalObject, JSValue stringValue)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    RefPtr<JSC::ArrayBuffer> resultBuffer = encodeStringToBuffer(vm, globalObject, stringValue);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    size_t byteLength = resultBuffer->byteLength();
     auto* structure = globalObject->typedArrayStructureWithTypedArrayType<JSC::TypeUint8>();
     RELEASE_AND_RETURN(scope, JSC::JSUint8Array::create(globalObject, structure, WTF::move(resultBuffer), 0, byteLength));
+}
+
+static JSC::JSArrayBuffer* encodeStringToArrayBuffer(JSC::VM& vm, JSGlobalObject* globalObject, JSValue stringValue)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    RefPtr<JSC::ArrayBuffer> resultBuffer = encodeStringToBuffer(vm, globalObject, stringValue);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    RELEASE_AND_RETURN(scope, JSC::JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(JSC::ArrayBufferSharingMode::Default), WTF::move(resultBuffer)));
 }
 
 static bool appendChunkBytes(JSC::VM& vm, JSGlobalObject* globalObject, JSValue chunk, WTF::Vector<uint8_t>& bytes)
@@ -452,7 +469,7 @@ static JSValue convertChunksToArrayBuffer(JSGlobalObject* globalObject, JSValue 
             return JSC::JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(JSC::ArrayBufferSharingMode::Default), WTF::move(copied));
         }
         if (chunk.isString())
-            RELEASE_AND_RETURN(scope, encodeStringToUint8Array(vm, globalObject, chunk));
+            RELEASE_AND_RETURN(scope, encodeStringToArrayBuffer(vm, globalObject, chunk));
     }
     RELEASE_AND_RETURN(scope, concatenateChunks(vm, globalObject, chunks, /* asUint8Array */ false));
 }

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -910,3 +910,67 @@ test("Blob type from a consumed Response keeps the original content-type after c
   expect(stdout.trim().split("\n")).toEqual(["application/x-original-type-0000000000000001", "clone-ok", "churn-ok"]);
   expect(exitCode).toBe(0);
 });
+
+// https://github.com/oven-sh/bun/issues/30797
+test("Response.clone().bytes() returns a Uint8Array for multi-chunk binary bodies", async () => {
+  const chunks = [new Uint8Array([1, 2, 3, 4]), new Uint8Array([5, 6, 7, 8]), new Uint8Array([9, 10, 11, 12])];
+  const stream = new ReadableStream({
+    async pull(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+        await 1;
+      }
+      controller.close();
+    },
+  });
+
+  const response = new Response(stream);
+  const cloned = response.clone();
+
+  const originalBytes = await response.bytes();
+  const clonedBytes = await cloned.bytes();
+
+  expect(originalBytes).toBeInstanceOf(Uint8Array);
+  expect(clonedBytes).toBeInstanceOf(Uint8Array);
+  expect(clonedBytes).toEqual(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]));
+  expect(originalBytes).toEqual(clonedBytes);
+});
+
+// https://github.com/oven-sh/bun/issues/33157
+test("Response.bytes() from a CompressionStream body has a defined .length", async () => {
+  const source = new TextEncoder().encode(JSON.stringify({ message: "Testing Bun Response performance and bugs" }));
+
+  const compression = new CompressionStream("gzip");
+  const writer = compression.writable.getWriter();
+  writer.write(source);
+  writer.close();
+
+  const bytes = await new Response(compression.readable).bytes();
+
+  expect(bytes).toBeInstanceOf(Uint8Array);
+  expect(typeof bytes.length).toBe("number");
+  expect(bytes.length).toBe(bytes.byteLength);
+
+  const roundTripped = await new Response(
+    new Response(bytes).body!.pipeThrough(new DecompressionStream("gzip")),
+  ).bytes();
+  expect(roundTripped).toEqual(source);
+});
+
+// https://github.com/oven-sh/bun/issues/30797
+test("Response.arrayBuffer() returns a usable ArrayBuffer for a single string chunk body", async () => {
+  const stream = new ReadableStream({
+    async pull(controller) {
+      await 1;
+      controller.enqueue("hi");
+      controller.close();
+    },
+  });
+
+  const buffer = await new Response(stream).arrayBuffer();
+
+  expect(buffer).toBeInstanceOf(ArrayBuffer);
+  // A Uint8Array (the bug) would throw here: DataView requires a real ArrayBuffer.
+  expect(new DataView(buffer).byteLength).toBe(2);
+  expect(new TextDecoder().decode(buffer)).toBe("hi");
+});


### PR DESCRIPTION
## Background

This PR originally fixed `readableStreamToBytes` in the JS builtin `ReadableStream.ts`. Since then, #33193 rewrote webstreams in C++ (zero JS builtins), which already carries fixes for the two originally-reported issues:

- #30797 (`Response.clone().bytes()` returning `ArrayBuffer`) fixed on main
- #33157 (`Response.bytes()` from a `CompressionStream` body having `undefined` `.length`) fixed on main

I rebased onto main and verified both empirically.

## What still reproduces

One sibling case survived the rewrite: when a stream body yields exactly **one string chunk**, the C++ arrayBuffer consumer (`convertChunksToArrayBuffer` in `BunStreamConsumers.cpp`) returned `encodeStringToUint8Array(...)` a `Uint8Array`, not an `ArrayBuffer`. `Body.arrayBuffer()` must resolve to an `ArrayBuffer`, so this is a spec violation with a concrete failure:

```js
const s = new ReadableStream({ async pull(c){ await 1; c.enqueue("hi"); c.close(); } });
const ab = await new Response(s).arrayBuffer();
ab instanceof ArrayBuffer;   // false (bug) -> true (fixed)
new DataView(ab);            // throws "Expected ArrayBuffer for the first argument." (bug) -> ok (fixed)
```

## Fix

Factor the string encoder into `encodeStringToBuffer` (returns the backing `ArrayBuffer`) and add an `encodeStringToArrayBuffer` wrapper next to the existing `encodeStringToUint8Array`; use it in the arrayBuffer single-string-chunk path.

## Tests

`test/js/web/fetch/body-clone.test.ts`:
- single-string-chunk `arrayBuffer()` returns a usable `ArrayBuffer` (fails before this fix, asserts `new DataView(buffer)` works)
- multi-chunk `clone().bytes()` returns `Uint8Array` (#30797 regression guard)
- `CompressionStream` body `bytes()` has a defined `.length` (#33157 regression guard, round-trips through `DecompressionStream`)

Verified: the file fails before the fix (single-string test) and passes after.