### PR TITLE
collections: drop MultiArrayList Sync impl (safe-API data race)

### DIFF
--- a/src/collections/multi_array_list.rs
+++ b/src/collections/multi_array_list.rs
@@ -440,6 +440,19 @@ pub trait SortContext {
 }
 
 /// Struct-of-arrays list. See module docs.
+///
+/// # Thread safety
+///
+/// `MultiArrayList` is `Send` (it's effectively a unique-owned `Box`-like
+/// handle over a single allocation) but deliberately **not** `Sync`. Several
+/// `&self` methods — `sort*` and `zero` — mutate the backing bytes through
+/// raw pointers (an interior-mutability pattern, chosen so callers can pass
+/// read-only column borrows into a sort context; see
+/// `sourcemap::Mapping::sort`). If the type were `Sync`, two threads could
+/// each call those methods concurrently through a shared reference — a data
+/// race, UB through a safe API. Because the inline `*mut u8` is already
+/// `!Sync`, we inherit the correct default; the Send impl below explicitly
+/// adds Send back, and we intentionally do NOT add an `unsafe impl Sync`.
 pub struct MultiArrayList<T, A: Allocator = Global> {
     bytes: *mut u8,
     len: usize,
@@ -448,9 +461,39 @@ pub struct MultiArrayList<T, A: Allocator = Global> {
     _marker: PhantomData<T>,
 }
 
-// SAFETY: `bytes` is uniquely owned; the only shared state is the allocator.
+// SAFETY: `bytes` is uniquely owned; a single owner is free to move the list
+// to another thread.
 unsafe impl<T: Send, A: Allocator + Send> Send for MultiArrayList<T, A> {}
-unsafe impl<T: Sync, A: Allocator + Sync> Sync for MultiArrayList<T, A> {}
+
+// No `unsafe impl Sync`. See the type-level doc comment for rationale — the
+// `&self` mutating methods (`sort*`, `zero`) would be racy under `Sync`.
+//
+// Compile-time proof that `MultiArrayList` is `!Sync` even when its payload is
+// `Sync`. Stable Rust has no negative trait bounds, so we use the
+// auto-trait-ambiguity trick (same pattern as `src/runtime/shell/subproc.rs`):
+// if `MultiArrayList<SyncRow>` ever becomes `Sync`, both blanket impls apply
+// and `_NOT_SYNC` fails to compile with "conflicting impls".
+#[doc(hidden)]
+#[allow(dead_code)]
+mod __sync_check {
+    use super::MultiArrayList;
+    #[derive(Clone, Copy)]
+    struct SyncRow {
+        a: u32,
+        b: u64,
+    }
+    trait NotSyncCheck<A> {
+        const OK: () = ();
+    }
+    impl<T: ?Sized> NotSyncCheck<()> for T {}
+    impl<T: ?Sized + Sync> NotSyncCheck<u8> for T {}
+    trait IsSendCheck {
+        const OK: () = ();
+    }
+    impl<T: ?Sized + Send> IsSendCheck for T {}
+    const _NOT_SYNC: () = <MultiArrayList<SyncRow> as NotSyncCheck<_>>::OK;
+    const _IS_SEND: () = <MultiArrayList<SyncRow> as IsSendCheck>::OK;
+}
 
 /// A `MultiArrayList::Slice` contains cached start pointers for each field in
 /// the list. These pointers are not normally stored to reduce the size of the

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1766,7 +1766,12 @@ mod draft {
                     .store(handle as *mut core::ffi::c_void, Ordering::Relaxed);
             }
         }
-        #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android", target_os = "freebsd"))]
+        #[cfg(any(
+            target_os = "macos",
+            target_os = "linux",
+            target_os = "android",
+            target_os = "freebsd"
+        ))]
         {
             reset_on_posix();
         }
@@ -2907,7 +2912,12 @@ mod draft {
             let _ = spawn_result;
             let _ = url;
         }
-        #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android", target_os = "freebsd"))]
+        #[cfg(any(
+            target_os = "macos",
+            target_os = "linux",
+            target_os = "android",
+            target_os = "freebsd"
+        ))]
         {
             let mut buf = bun_core::PathBuffer::default();
             let mut buf2 = bun_core::PathBuffer::default();

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -409,7 +409,12 @@ mod errno_name_tests {
         assert_eq!(Error::from_errno(0), Error::UNEXPECTED);
         assert_eq!(Error::from_errno(9999), Error::UNEXPECTED);
         // errno 11 is platform-specific: EAGAIN on linux/windows, EDEADLK on darwin/bsd.
-        #[cfg(any(target_os = "linux", target_os = "android", windows, target_family = "wasm"))]
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "android",
+            windows,
+            target_family = "wasm"
+        ))]
         {
             assert_eq!(Error::from_errno(11), Error::intern("EAGAIN"));
             assert_eq!(Error::from_errno(104), Error::intern("ECONNRESET"));
@@ -464,7 +469,12 @@ mod errno_name_tests {
             coreutils_error_map::get(2),
             Some("No such file or directory")
         );
-        #[cfg(any(target_os = "linux", target_os = "android", windows, target_family = "wasm"))]
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "android",
+            windows,
+            target_family = "wasm"
+        ))]
         assert_eq!(
             coreutils_error_map::get(11),
             Some("Resource temporarily unavailable")

--- a/src/perf/tracy.rs
+++ b/src/perf/tracy.rs
@@ -756,7 +756,12 @@ fn dlsym<T: Copy>(symbol: &'static core::ffi::CStr) -> Option<T> {
                 ];
                 #[cfg(windows)]
                 const PATHS_TO_TRY: &[&core::ffi::CStr] = &[c"tracy.dll"];
-                #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android", windows)))]
+                #[cfg(not(any(
+                    target_os = "macos",
+                    target_os = "linux",
+                    target_os = "android",
+                    windows
+                )))]
                 const PATHS_TO_TRY: &[&core::ffi::CStr] = &[];
 
                 // TODO(port): RTLD flags — Zig used `@bitCast(@as(i32, -2))` on

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -679,7 +679,10 @@ pub const BASE_RUNTIME_TRANSPILER_PARAMS: &[ParamType] =
 // built with `comptime_table!(.., cold)` and stay in plain `.rodata`, where
 // `src/startup.order` can still cluster the ones a sampled cold path actually
 // hits without weighing down the `.rodata.startup` fault-around window.
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".rodata.startup"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".rodata.startup")
+)]
 pub static AUTO_TABLE: &clap::ConvertedTable = clap::comptime_table!(AUTO_PARAMS);
 pub static RUN_TABLE: &clap::ConvertedTable = clap::comptime_table!(RUN_PARAMS, cold);
 pub static BUILD_TABLE: &clap::ConvertedTable = clap::comptime_table!(BUILD_PARAMS, cold);

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -552,7 +552,10 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
     /// not share `.text` pages with the hot `bun run <script>` dispatch path.
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn configure_run_transpiler_linker(this_transpiler: &mut Transpiler<'static>) {
         this_transpiler.resolver.opts.load_tsconfig_json = true;
         this_transpiler.options.load_tsconfig_json = true;
@@ -870,7 +873,10 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
     /// initializing JSC.
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn boot_bun_shell(
         ctx: &mut ContextData,
         entry_path: &[u8],
@@ -1669,7 +1675,10 @@ fn log_clear_msgs(vm: &mut VirtualMachine) {
 
 #[cold]
 #[inline(never)]
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".text.unlikely")
+)]
 fn dump_build_error(vm: &mut VirtualMachine) {
     Output::flush();
     if let Some(log) = vm.log {
@@ -1689,7 +1698,10 @@ fn dump_build_error(vm: &mut VirtualMachine) {
 /// `.text.hot` fault-around window the `require('fs')` startup path pulls in.
 #[cold]
 #[inline(never)]
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".text.unlikely")
+)]
 fn exit_with_unhandled_note(vm: &mut VirtualMachine) -> ! {
     vm.exit_handler.exit_code = 1;
     vm.on_exit();
@@ -1703,7 +1715,10 @@ fn exit_with_unhandled_note(vm: &mut VirtualMachine) -> ! {
 /// Cold `Err(err)` arm of `vm.load_entry_point` in `Run::start`.
 #[cold]
 #[inline(never)]
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".text.unlikely")
+)]
 fn entry_point_load_failed(vm: &mut VirtualMachine, err: &bun_core::Error) -> ! {
     if log_has_msgs(vm) {
         dump_build_error(vm);
@@ -1722,7 +1737,10 @@ fn entry_point_load_failed(vm: &mut VirtualMachine, err: &bun_core::Error) -> ! 
 /// exit: bump the exit code and print the sourcemap note + version string.
 #[cold]
 #[inline(never)]
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".text.unlikely")
+)]
 fn print_unhandled_version_note(vm: &mut VirtualMachine) {
     vm.exit_handler.exit_code = 1;
     bun_sourcemap::SavedSourceMap::MissingSourceMapNoteInfo::print();
@@ -1762,7 +1780,10 @@ impl RunCommand {
     /// `.text.hot` fault-around window the `require('fs')` startup path pulls in.
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn boot_failed_exit(ctx: &mut ContextData, display_name: &[u8], err: &bun_core::Error) -> ! {
         // SAFETY: `ctx.log` was set in `create_context_data` (single-threaded
         // CLI startup) and is process-lifetime.
@@ -3022,7 +3043,10 @@ impl RunCommand {
 
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn exec_as_if_node_missing_script() -> ! {
         Output::err_generic(
             "Missing script to execute. Bun's provided 'node' cli wrapper does not support a repl.",
@@ -3033,7 +3057,10 @@ impl RunCommand {
 
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn exec_as_if_node_boot_failed(
         ctx: &mut ContextData,
         basename: &[u8],

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -515,7 +515,12 @@ impl UpgradeCommand {
         {
             "powershell -c 'irm bun.sh/install.ps1|iex'"
         }
-        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "windows")))]
+        #[cfg(not(any(
+            target_os = "linux",
+            target_os = "android",
+            target_os = "macos",
+            target_os = "windows"
+        )))]
         {
             // TODO(port): Environment.os.displayString() at comptime
             "(TODO: Install script for this platform)"

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4499,13 +4499,14 @@ pub(crate) fn resolve_embedded_file_to_buf(
     // Spec ModuleLoader.zig:43-45 — `tmpname(extname, buf, bun.hash(file.name))`.
     let mut tmpname_buf = bun_paths::path_buffer_pool::get();
     let tmpfilename =
-        Fs::FileSystem::tmpname(extname, &mut tmpname_buf[..], bun_wyhash::hash(file_name))
-            .ok()?;
+        Fs::FileSystem::tmpname(extname, &mut tmpname_buf[..], bun_wyhash::hash(file_name)).ok()?;
 
     // Spec ModuleLoader.zig:47 — `bun.fs.FileSystem.instance.tmpdir()`.
     // SAFETY: `FileSystem::instance()` returns the process-global singleton
     // pointer (initialized at startup).
-    let tmpdir = (unsafe { &mut *Fs::FileSystem::instance() }).tmpdir().ok()?;
+    let tmpdir = (unsafe { &mut *Fs::FileSystem::instance() })
+        .tmpdir()
+        .ok()?;
     let tmpdir_fd: bun_sys::Fd = tmpdir.fd;
 
     // Spec ModuleLoader.zig:50-51 — `bun.Tmpfile.create(tmpdir, tmpfilename)`.

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -358,7 +358,10 @@ fn find_playwright_shell() -> Option<ZBox> {
     }
 
     // Fall back to the non-cft linux arm64 layout.
-    #[cfg(all(any(target_os = "linux", target_os = "android"), target_arch = "aarch64"))]
+    #[cfg(all(
+        any(target_os = "linux", target_os = "android"),
+        target_arch = "aarch64"
+    ))]
     {
         let bin_parts2: [&[u8]; 3] = [
             cache_dir,
@@ -633,7 +636,12 @@ fn read_dev_tools_active_port(out_buf: &mut Vec<u8>) -> Option<()> {
         b"BraveSoftware\\Brave-Browser\\User Data\\DevToolsActivePort",
         b"Microsoft\\Edge\\User Data\\DevToolsActivePort",
     ];
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android", windows)))]
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "linux",
+        target_os = "android",
+        windows
+    )))]
     let candidates: &[&[u8]] = &[];
 
     let mut path_buf = path_buffer_pool::get();

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -3224,7 +3224,10 @@ mod spawn_process_body {
             // that are read *after* the wait, so falling through to the memfd block
             // below is required.
             let status: Status = 'blk: {
-                if no_orphans && (cfg!(any(target_os = "linux", target_os = "android")) || cfg!(target_os = "macos")) {
+                if no_orphans
+                    && (cfg!(any(target_os = "linux", target_os = "android"))
+                        || cfg!(target_os = "macos"))
+                {
                     let ppid = ParentDeathWatchdog::ppid_to_watch().unwrap_or(0);
                     #[cfg(target_os = "macos")]
                     let r: Option<Maybe<Status>> = wait_mac_kqueue(
@@ -3245,7 +3248,11 @@ mod spawn_process_body {
                         &mut out_fds_to_wait_for,
                         &mut out_fds,
                     );
-                    #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
+                    #[cfg(not(any(
+                        target_os = "linux",
+                        target_os = "android",
+                        target_os = "macos"
+                    )))]
                     let r: Option<Maybe<Status>> = {
                         let _ = ppid;
                         None

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -775,7 +775,10 @@ pub fn spawn_process_posix(
     let mut dup_stdout_to_stderr: bool = false;
 
     // The label is only referenced from the Linux memfd fast-path below.
-    #[cfg_attr(not(any(target_os = "linux", target_os = "android")), allow(unused_labels))]
+    #[cfg_attr(
+        not(any(target_os = "linux", target_os = "android")),
+        allow(unused_labels)
+    )]
     'stdio: for i in 0..3usize {
         let fileno = Fd::from_native(FdT::try_from(i).unwrap());
         let flag: u32 = (if i == 0 {

--- a/test/regression/issue/30801.test.ts
+++ b/test/regression/issue/30801.test.ts
@@ -1,0 +1,46 @@
+// Regression test for https://github.com/oven-sh/bun/issues/30801
+//
+// `MultiArrayList` exposes safe `&self` methods that mutate the backing
+// bytes via raw pointers (`zero`, `sort`, `sort_span`, `sort_unstable`,
+// `sort_span_unstable`). The Rust port originally declared
+// `unsafe impl<T: Sync, A: Allocator + Sync> Sync for MultiArrayList<T, A>`,
+// which let two threads race through those writes via a shared reference —
+// a data race (UB) reachable through a fully safe API.
+//
+// The fix removes the `unsafe impl Sync`. This test guards the source so a
+// future refactor doesn't silently reintroduce it.
+//
+// Soundness is enforced at the type level, not at runtime — no observable
+// behaviour change is reachable from JS — so this test statically
+// inspects the Rust source. The build side of the invariant is also
+// encoded as a compile-time `__sync_check` module in the same file: if
+// `unsafe impl Sync` is re-added, `cargo check` (and therefore `bun bd`)
+// fails with a "conflicting impls" error.
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SRC = join(import.meta.dir, "..", "..", "..", "src", "collections", "multi_array_list.rs");
+
+test("MultiArrayList does not declare `unsafe impl Sync`", () => {
+  const source = readFileSync(SRC, "utf-8");
+
+  // Strip // line comments and /* */ block comments so a comment documenting
+  // the decision ("do NOT add unsafe impl Sync") doesn't false-match.
+  const stripped = source.replace(/\/\/[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "");
+
+  // Any `unsafe impl ... Sync for MultiArrayList<...>` in real code is a
+  // soundness regression: see the type's doc comment and issue #30801.
+  const syncImpl = /unsafe\s+impl\s*(?:<[^>]*>)?\s+Sync\s+for\s+MultiArrayList\b/;
+  expect(stripped).not.toMatch(syncImpl);
+});
+
+test("MultiArrayList keeps `unsafe impl Send` (the list is still movable)", () => {
+  const source = readFileSync(SRC, "utf-8");
+  const stripped = source.replace(/\/\/[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "");
+
+  // The fix only drops Sync; Send must remain so owned lists can still be
+  // moved between threads (e.g. handed off to worker threads).
+  const sendImpl = /unsafe\s+impl\s*(?:<[^>]*>)?\s+Send\s+for\s+MultiArrayList\b/;
+  expect(stripped).toMatch(sendImpl);
+});


### PR DESCRIPTION
Fixes #30801.

### Repro

```rust
// src/collections/multi_array_list.rs (before)
unsafe impl<T: Sync, A: Allocator + Sync> Sync for MultiArrayList<T, A> {}

pub fn zero(&self) {                                 // &self
    let (p, n) = self.allocated_bytes();
    if n != 0 { unsafe { ptr::write_bytes(p, 0, n) }; }
}

pub fn sort<C: SortContext>(&self, ctx: C) { /* swaps via ptr::swap_nonoverlapping */ }
```

With the old `unsafe impl Sync`, two threads could each hold
`&MultiArrayList` and invoke any of those methods concurrently — a
data race, UB reachable through a fully safe API.

### Cause

The Zig original (`src/collections/multi_array_list.zig`) took these by
value (`self: Self`), so the 'no shared mutation' invariant was
enforced at the language level. The Rust port kept the `&self`
ergonomic signatures (callers want to sort while holding a read-only
borrow of one column — see `sourcemap::Mapping::sort`) but also added
`unsafe impl Sync`, which together give a safe concurrent-write API.

### Fix

Drop the `Sync` impl. The inline `*mut u8` already makes the type
`!Sync` by default — the old `unsafe impl` was the only thing
overriding that. `Send` stays (unique-owned handle; moving is safe).

Document the interior-mutability invariant on the type and add a
compile-time auto-trait-ambiguity check (same pattern as
`src/runtime/shell/subproc.rs`) so a future re-add of `unsafe impl Sync`
fails `cargo check` with 'conflicting impls' rather than silently
reintroducing the race.

### Verification

- `cargo check -p bun_collections` — clean
- `cargo check --workspace` — clean; no downstream user relies on
  `Sync` (no `Arc<MultiArrayList>`, no cross-thread sharing in the
  tree)
- Temporarily re-adding `unsafe impl Sync` trips the compile-time check
  with `error[E0283]: type annotations needed … multiple 'impl's
  satisfying 'MultiArrayList<SyncRow>: NotSyncCheck<_>' found` — the
  intended signal
- `bun bd test test/regression/issue/30801.test.ts` — 2 pass, 0 fail;
  the same command with `src/` stashed fails on the same regex
  assertion, confirming the test exercises the fix