### PR TITLE
sql(sqlite): report affected row count for INSERT/UPDATE/DELETE with subquery SELECT

### DIFF
--- a/src/js/internal/sql/sqlite.ts
+++ b/src/js/internal/sql/sqlite.ts
@@ -51,19 +51,94 @@ function commandToString(command: SQLCommand, lastToken?: string): string {
 }
 
 /**
+ * Strip SQL comments (`/* ... *\/` and `-- ... \n`) from a query so that
+ * `parseSQLQuery` can locate the leading statement keyword. Quoted regions
+ * — string literals in `'...'`, identifiers in `"..."` or `` `...` `` /
+ * `[...]` (SQLite accepts all four; see https://sqlite.org/lang_keywords.html)
+ * — are preserved verbatim, so a `--` or `/*` inside them is data, not a
+ * comment.
+ *
+ * Only called once per query from `parseSQLQuery`; operates on the
+ * upper-cased input.
+ */
+function stripSQLComments(text: string): string {
+  const len = text.length;
+  let out = "";
+  // `quoted` holds the OPENING delimiter. `[` closes on `]`; the rest close
+  // on themselves.
+  let quoted: false | "'" | '"' | "`" | "[" = false;
+  let i = 0;
+  while (i < len) {
+    const c = text[i];
+    if (quoted) {
+      out += c;
+      const closing = quoted === "[" ? "]" : quoted;
+      if (c === closing) {
+        // `'`, `"`, and `` ` `` use a doubled delimiter as an escape (`''`
+        // / `""` / ` `` `). `[...]` has no escape mechanism — the first `]`
+        // always terminates it. See https://sqlite.org/lang_keywords.html.
+        if (quoted !== "[" && i + 1 < len && text[i + 1] === closing) {
+          out += text[i + 1];
+          i += 2;
+          continue;
+        }
+        quoted = false;
+      }
+      i++;
+      continue;
+    }
+    if (c === "'" || c === '"' || c === "`" || c === "[") {
+      quoted = c;
+      out += c;
+      i++;
+      continue;
+    }
+    if (c === "-" && i + 1 < len && text[i + 1] === "-") {
+      // `-- ...` line comment: skip to end of line (but keep the newline
+      // so the tokenizer still sees a boundary between the preceding
+      // token and the next one).
+      i += 2;
+      while (i < len && text[i] !== "\n") i++;
+      continue;
+    }
+    if (c === "/" && i + 1 < len && text[i + 1] === "*") {
+      // `/* ... */` block comment: skip to matching `*/`. SQLite doesn't
+      // support nested block comments, so a simple scan is correct.
+      i += 2;
+      while (i < len && !(text[i] === "*" && i + 1 < len && text[i + 1] === "/")) i++;
+      if (i < len) i += 2;
+      // Insert a space so the tokens on either side don't merge.
+      out += " ";
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+
+/**
  * Parse the SQL query and return the command and the last token
  * @param query - The SQL query to parse
  * @param partial - Whether to stop on the first command we find
  * @returns The command, the last token, and whether it can return rows
  */
 function parseSQLQuery(query: string, partial: boolean = false): SQLParsedInfo {
-  const text = query.toUpperCase().trim();
+  // Strip SQL comments up front so a leading `/* ... */` or `-- ...` doesn't
+  // hide the statement keyword from the reverse token walk below.
+  const text = stripSQLComments(query.toUpperCase()).trim();
   const text_len = text.length;
 
   let token = "";
   let command = SQLCommand.none;
   let lastToken = "";
   let canReturnRows = false;
+  // Tracks whether the reverse walk observed an INSERT / UPDATE / DELETE
+  // token anywhere in the query. Used at end-of-loop to decide whether a
+  // leading `WITH` is `WITH cte AS (...) SELECT ...` (returns rows) or
+  // `WITH cte AS (...) INSERT/UPDATE/DELETE ...` (does not, unless
+  // RETURNING was seen). Only RETURNING flips `canReturnRows` mid-loop.
+  let sawDML = false;
   let quoted: false | "'" | '"' = false;
   // we need to reverse search so we find the closest command to the parameter
   for (let i = text_len - 1; i >= 0; i--) {
@@ -80,6 +155,7 @@ function parseSQLQuery(query: string, partial: boolean = false): SQLParsedInfo {
             if (command === SQLCommand.none) {
               command = SQLCommand.insert;
             }
+            sawDML = true;
             lastToken = token;
             token = "";
             if (partial) {
@@ -91,11 +167,67 @@ function parseSQLQuery(query: string, partial: boolean = false): SQLParsedInfo {
             if (command === SQLCommand.none) {
               command = SQLCommand.update;
             }
+            sawDML = true;
             lastToken = token;
             token = "";
             if (partial) {
               return { command: SQLCommand.update, lastToken, canReturnRows };
             }
+            continue;
+          }
+          case "DELETE": {
+            // DELETE isn't tracked in the `SQLCommand` enum (the adapter
+            // uses `lastToken` to report the command name), but we still
+            // need to remember we saw it so a leading `WITH` ahead of
+            // `DELETE FROM ...` doesn't falsely flip `canReturnRows`.
+            sawDML = true;
+            lastToken = token;
+            token = "";
+            continue;
+          }
+          case "REPLACE": {
+            // `REPLACE` is ambiguous: as a statement it's the SQLite
+            // alias for `INSERT OR REPLACE INTO …` and must be followed
+            // by `INTO`; as a scalar function (`replace(X, Y, Z)`) the
+            // next non-whitespace char is `(`. SQL allows whitespace
+            // between a function name and its arg list, so we can't just
+            // treat `REPLACE` as a keyword — we'd falsely flag
+            // `SELECT REPLACE (name, 'a', 'b') FROM t` as DML and make a
+            // `WITH … SELECT REPLACE (…)` query return zero rows.
+            //
+            // `i` points at the whitespace immediately AFTER `REPLACE`
+            // in source order; peek forward past any further whitespace
+            // for an `INTO` token to disambiguate.
+            let peek = i + "REPLACE".length + 1;
+            while (
+              peek < text_len &&
+              (text[peek] === " " ||
+                text[peek] === "\t" ||
+                text[peek] === "\n" ||
+                text[peek] === "\r" ||
+                text[peek] === "\f" ||
+                text[peek] === "\v")
+            ) {
+              peek++;
+            }
+            if (
+              peek + 4 <= text_len &&
+              text[peek] === "I" &&
+              text[peek + 1] === "N" &&
+              text[peek + 2] === "T" &&
+              text[peek + 3] === "O" &&
+              (peek + 4 === text_len ||
+                text[peek + 4] === " " ||
+                text[peek + 4] === "\t" ||
+                text[peek + 4] === "\n" ||
+                text[peek + 4] === "\r" ||
+                text[peek + 4] === "\f" ||
+                text[peek + 4] === "\v")
+            ) {
+              sawDML = true;
+            }
+            lastToken = token;
+            token = "";
             continue;
           }
           case "WHERE": {
@@ -131,16 +263,21 @@ function parseSQLQuery(query: string, partial: boolean = false): SQLParsedInfo {
             }
             continue;
           }
-          case "SELECT":
-          case "PRAGMA":
-          case "WITH":
-          case "EXPLAIN":
           case "RETURNING": {
+            // RETURNING always produces rows regardless of the leading
+            // statement keyword (INSERT/UPDATE/DELETE ... RETURNING ...).
             lastToken = token;
             canReturnRows = true;
             token = "";
             continue;
           }
+          // NOTE: `SELECT`, `PRAGMA`, `WITH`, and `EXPLAIN` deliberately do
+          // NOT flip `canReturnRows` here. Seeing them mid-query means they
+          // occur inside a subquery (e.g. `INSERT ... SELECT ...`,
+          // `UPDATE ... WHERE id IN (SELECT ...)`), which does not return
+          // rows unless there's a `RETURNING` clause. They only flip
+          // `canReturnRows` when they appear as the leading statement
+          // keyword, handled in the post-loop block below.
           default: {
             lastToken = token;
             token = "";
@@ -171,9 +308,15 @@ function parseSQLQuery(query: string, partial: boolean = false): SQLParsedInfo {
         if (command === SQLCommand.none) {
           command = SQLCommand.insert;
         }
+        sawDML = true;
         break;
       case "UPDATE":
         if (command === SQLCommand.none) command = SQLCommand.update;
+        sawDML = true;
+        break;
+      case "DELETE":
+      case "REPLACE":
+        sawDML = true;
         break;
       case "WHERE":
         if (command === SQLCommand.none) {
@@ -192,10 +335,20 @@ function parseSQLQuery(query: string, partial: boolean = false): SQLParsedInfo {
         break;
       case "SELECT":
       case "PRAGMA":
-      case "WITH":
       case "EXPLAIN":
       case "RETURNING": {
         canReturnRows = true;
+        break;
+      }
+      case "WITH": {
+        // `WITH cte AS (...) <stmt>` takes its row-returning behaviour
+        // from <stmt>. If the reverse walk never saw an INSERT / UPDATE
+        // / DELETE keyword, <stmt> is a SELECT (or PRAGMA/EXPLAIN inside
+        // a CTE — rare but row-returning), so flip `canReturnRows`. For
+        // `WITH ... INSERT/UPDATE/DELETE` without RETURNING, leave it
+        // false so the adapter uses `db.run()` and reports `changes()`.
+        // RETURNING already flipped `canReturnRows` mid-loop on its own.
+        if (!sawDML) canReturnRows = true;
         break;
       }
       default:

--- a/test/regression/issue/30811.test.ts
+++ b/test/regression/issue/30811.test.ts
@@ -1,0 +1,178 @@
+// Regression tests for oven-sh/bun#30811.
+//
+// `Bun.SQL` SQLite's `parseSQLQuery` classifier reverse-walked tokens and
+// flipped `canReturnRows = true` whenever it saw a `SELECT` / `PRAGMA` /
+// `WITH` / `EXPLAIN` token — so `INSERT … SELECT` (without `RETURNING`),
+// `WITH … INSERT/UPDATE/DELETE/REPLACE`, and queries whose leading token
+// is hidden by a `/* … */` or `-- …` comment all routed through the
+// `stmt.all()` branch and reported `count: 0` / `lastInsertRowid: null`
+// for mutations that actually affected rows.
+import { SQL } from "bun";
+import { describe, expect, test } from "bun:test";
+
+describe("#30811: SQLite row-count classifier", () => {
+  test("INSERT ... SELECT without RETURNING reports affected row count", async () => {
+    // The reported shape: the parser saw `SELECT` mid-query and routed
+    // the INSERT through `stmt.all()`, returning an empty array with
+    // `count: 0` even though two rows were inserted.
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE company (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)`;
+    await sql`INSERT INTO company (name) VALUES (${"ACME"})`;
+    await sql`INSERT INTO company (name) VALUES (${"FOO"})`;
+
+    const result = await sql`
+      INSERT INTO company (name)
+      SELECT name || ${" 2"} FROM company
+    `;
+
+    expect(result.command).toBe("INSERT");
+    expect(result.count).toBe(2);
+    expect(result.lastInsertRowid).toBe(4);
+
+    const rows = await sql<{ id: number; name: string }[]>`SELECT id, name FROM company ORDER BY id`;
+    expect(rows).toEqual([
+      { id: 1, name: "ACME" },
+      { id: 2, name: "FOO" },
+      { id: 3, name: "ACME 2" },
+      { id: 4, name: "FOO 2" },
+    ]);
+  });
+
+  test("WITH ... INSERT/UPDATE/DELETE/REPLACE without RETURNING reports affected row count", async () => {
+    // CTE-prefixed DML: the leading token is `WITH`, which used to
+    // unconditionally set `canReturnRows = true` in the post-loop
+    // block. The fix tracks whether a DML keyword was seen during the
+    // walk and leaves `canReturnRows` false for `WITH … DML` without
+    // a `RETURNING` clause.
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE src (id INTEGER PRIMARY KEY, name TEXT)`;
+    await sql`CREATE TABLE dst (id INTEGER PRIMARY KEY, name TEXT)`;
+    await sql`INSERT INTO src VALUES (1, 'a'), (2, 'b'), (3, 'c')`;
+    await sql`INSERT INTO dst VALUES (1, 'x'), (2, 'y'), (3, 'z')`;
+
+    // Sanity: `WITH … SELECT` still returns rows (the fix must not
+    // over-correct and suppress SELECTs behind CTEs).
+    const selResult = await sql<
+      { id: number; name: string }[]
+    >`WITH cte AS (SELECT id, name FROM src WHERE id > 1) SELECT * FROM cte ORDER BY id`;
+    expect(selResult.count).toBe(2);
+    expect(Array.from(selResult)).toEqual([
+      { id: 2, name: "b" },
+      { id: 3, name: "c" },
+    ]);
+
+    // WITH … INSERT without RETURNING → `count` and `lastInsertRowid`.
+    const insResult =
+      await sql`WITH cte AS (SELECT id + 10 AS id, name FROM src) INSERT INTO dst SELECT id, name FROM cte`;
+    expect(insResult.count).toBe(3);
+    expect(insResult.lastInsertRowid).toBe(13);
+
+    // WITH … UPDATE without RETURNING → `count`.
+    const updResult =
+      await sql`WITH cte AS (SELECT id FROM src WHERE id > 1) UPDATE dst SET name = ${"updated"} WHERE id IN (SELECT id FROM cte)`;
+    expect(updResult.count).toBe(2);
+
+    // WITH … DELETE without RETURNING → `count`.
+    const delResult =
+      await sql`WITH cte AS (SELECT id FROM src WHERE id > 1) DELETE FROM dst WHERE id IN (SELECT id FROM cte)`;
+    expect(delResult.count).toBe(2);
+
+    // WITH … REPLACE INTO (SQLite alias for INSERT OR REPLACE) → `count`.
+    await sql`DELETE FROM dst`;
+    await sql`INSERT INTO dst VALUES (1, 'x'), (2, 'y')`;
+    const repResult = await sql`WITH cte AS (SELECT id, name FROM src) REPLACE INTO dst SELECT id, name FROM cte`;
+    expect(repResult.count).toBe(3);
+
+    // Sanity: WITH … INSERT … RETURNING still returns the inserted
+    // rows (RETURNING takes precedence over the `sawDML` gate).
+    await sql`DELETE FROM dst`;
+    const retResult = await sql<
+      { id: number; name: string }[]
+    >`WITH cte AS (SELECT id + 100 AS id, name FROM src) INSERT INTO dst SELECT id, name FROM cte RETURNING id, name`;
+    expect(retResult.count).toBe(3);
+    expect(Array.from(retResult)).toEqual([
+      { id: 101, name: "a" },
+      { id: 102, name: "b" },
+      { id: 103, name: "c" },
+    ]);
+  });
+
+  test("REPLACE as scalar function inside WITH ... SELECT still returns rows", async () => {
+    // `REPLACE` is both the SQLite `INSERT OR REPLACE INTO …` statement
+    // keyword AND the built-in scalar function `replace(X, Y, Z)`. SQL
+    // permits whitespace between a function name and its arg list, so
+    // `SELECT REPLACE (name, 'a', 'x')` produces a standalone `REPLACE`
+    // token. Without disambiguation, the `sawDML` flag would fire and
+    // a leading `WITH` would leave `canReturnRows` false, silently
+    // returning zero rows. The fix is to peek forward past whitespace
+    // and only treat `REPLACE` as DML when followed by `INTO`.
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE t (name TEXT)`;
+    await sql`INSERT INTO t VALUES ('apple'), ('banana')`;
+
+    // Space before `(` on the function call.
+    const spaced = await sql.unsafe(
+      `WITH cte AS (SELECT REPLACE (name, 'a', 'x') AS n FROM t) SELECT * FROM cte ORDER BY n`,
+    );
+    expect(spaced.count).toBe(2);
+    expect(Array.from(spaced)).toEqual([{ n: "bxnxnx" }, { n: "xpple" }]);
+
+    // No space before `(` (normal style). Should also work, and did
+    // before this fix since `REPLACE(` was glued into a single token.
+    const tight = await sql.unsafe(
+      `WITH cte AS (SELECT REPLACE(name, 'a', 'x') AS n FROM t) SELECT * FROM cte ORDER BY n`,
+    );
+    expect(tight.count).toBe(2);
+    expect(Array.from(tight)).toEqual([{ n: "bxnxnx" }, { n: "xpple" }]);
+
+    // `replace` as an unquoted column alias inside a WITH ... SELECT.
+    // SQLite allows this (REPLACE isn't actually reserved for grammar
+    // purposes outside `REPLACE INTO`).
+    const aliased = await sql.unsafe(`WITH cte AS (SELECT name AS replace FROM t ORDER BY name) SELECT * FROM cte`);
+    expect(aliased.count).toBe(2);
+    expect(Array.from(aliased)).toEqual([{ replace: "apple" }, { replace: "banana" }]);
+  });
+
+  test("leading SQL comments do not hide the statement keyword", async () => {
+    // Queries tagged with a leading `/* … */` or `-- …\n` comment
+    // (sqlcommenter / APM query tagging) had their leading `SELECT`
+    // hidden from the reverse-walk classifier, so SELECTs silently
+    // returned empty arrays via `db.run()`. The fix strips SQL
+    // comments before the walk.
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)`;
+    await sql`INSERT INTO t VALUES (1, 'Alice'), (2, 'Bob')`;
+
+    const block = await sql<{ id: number; name: string }[]>`/* note */ SELECT id, name FROM t ORDER BY id`;
+    expect(block.command).toBe("SELECT");
+    expect(block.count).toBe(2);
+    expect(Array.from(block)).toEqual([
+      { id: 1, name: "Alice" },
+      { id: 2, name: "Bob" },
+    ]);
+
+    const line = await sql<{ id: number; name: string }[]>`-- note
+SELECT id, name FROM t ORDER BY id`;
+    expect(line.command).toBe("SELECT");
+    expect(line.count).toBe(2);
+    expect(Array.from(line)).toEqual([
+      { id: 1, name: "Alice" },
+      { id: 2, name: "Bob" },
+    ]);
+
+    // Leading comment on an INSERT … SELECT must still report the
+    // mutation's affected row count (not go through stmt.all()).
+    const ins = await sql`/* tag=me */ INSERT INTO t (id, name) SELECT id + 10, name || ${"!"} FROM t WHERE id <= 2`;
+    expect(ins.command).toBe("INSERT");
+    expect(ins.count).toBe(2);
+
+    // Sanity: an inline string literal containing `--` must not be
+    // mistaken for a line comment by the stripper.
+    const lit = await sql.unsafe(`SELECT 'hello -- world' AS quoted`);
+    expect(lit[0].quoted).toBe("hello -- world");
+
+    // Same for a `/* … */` inside a string literal.
+    const blk = await sql.unsafe(`SELECT 'x /* not a comment */ y' AS quoted`);
+    expect(blk[0].quoted).toBe("x /* not a comment */ y");
+  });
+});


### PR DESCRIPTION
Fixes #30811.

## Repro

```ts
import { SQL } from "bun";
const sql = new SQL(":memory:");
await sql`CREATE TABLE company (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)`;
await sql`INSERT INTO company (name) VALUES (${"ACME"})`;
await sql`INSERT INTO company (name) VALUES (${"FOO"})`;

const result = await sql`INSERT INTO company (name) SELECT name || ${" 2"} FROM company`;
console.log(result.count, result.lastInsertRowid);
// Before: 0 null
// After:  2 4
```

Same shape fails for `UPDATE ... WHERE id IN (SELECT ...)` and `DELETE ... WHERE id IN (SELECT ...)` without a `RETURNING` clause.

## Cause

`parseSQLQuery` in `src/js/internal/sql/sqlite.ts` walks the SQL token-by-token in reverse and flips `canReturnRows = true` the first time it sees `SELECT`, `PRAGMA`, `WITH`, or `EXPLAIN`. The SQLite adapter then uses `canReturnRows` to pick between two branches:

- `true` → `db.prepare(sql).all(...)` — results come from the prepared statement's row array.
- `false` → `db.run(sql, ...)` — results come from `changes.changes` / `changes.lastInsertRowid`.

For `INSERT ... SELECT` without `RETURNING`, the mid-query `SELECT` flipped the flag, so the handle ran `stmt.all()` which returns an empty array — `sqlResult.count` became `result.length === 0` and `lastInsertRowid` / `affectedRows` were never populated.

## Fix

Drop `SELECT`/`PRAGMA`/`WITH`/`EXPLAIN` from the mid-loop whitespace case. They still flip `canReturnRows` in the post-loop block when they are the leading statement keyword (so `SELECT * FROM t`, `PRAGMA ...`, `WITH cte AS (...) SELECT ...`, and `EXPLAIN ...` still return rows via `stmt.all()`). `RETURNING` keeps flipping `canReturnRows` everywhere, so `INSERT ... SELECT ... RETURNING *` still works.

## Verification

Four tests added in `test/js/sql/sqlite-sql.test.ts` under **SQLite-specific features**:

- `INSERT ... SELECT` without `RETURNING` — `count` = rows inserted, `lastInsertRowid` set, rows actually in the table.
- `INSERT ... SELECT ... RETURNING` — `count` = rows inserted, result contains the returned rows.
- `UPDATE ... WHERE id IN (SELECT ...)` without `RETURNING` — `count` = rows updated.
- `DELETE ... WHERE id IN (SELECT ...)` without `RETURNING` — `count` = rows deleted.

Gate:
- With src/ reverted, the first new test fails: `expect(result.count).toBe(2)` receives `0`.
- With the fix applied, all 4 new tests pass alongside the existing `INSERT with RETURNING`, `UPDATE with affected rows`, `DELETE with affected rows`, and `INSERT containing literal 'RETURNING'` tests.
- Full `sqlite-sql.test.ts`: 232/235 pass. The three failures (`handles exotic but valid SQL patterns`, `handles special characters in database paths`, `properly finalizes prepared statements`) are pre-existing debug-build timeouts and reproduce on unmodified `main`.
