### PR TITLE
console.takeHeapSnapshot: clear prior snapshots before building

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -5917,7 +5917,10 @@ pub(crate) extern "C" fn Bun__ConsoleObject__takeHeapSnapshot(
     _len: usize,
 ) {
     // TODO: this does an extra JSONStringify and we don't need it to!
-    let snapshot: [JSValue; 1] = [global_this.generate_heap_snapshot()];
+    let Ok(result) = global_this.generate_heap_snapshot() else {
+        return;
+    };
+    let snapshot: [JSValue; 1] = [result];
     // SAFETY: re-entry into our own host shim with a stack-local args slice.
     unsafe {
         message_with_type_and_level(

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -937,8 +937,8 @@ impl JSGlobalObject {
         })
     }
 
-    pub(crate) fn generate_heap_snapshot(&self) -> JSValue {
-        JSC__JSGlobalObject__generateHeapSnapshot(self)
+    pub(crate) fn generate_heap_snapshot(&self) -> JsResult<JSValue> {
+        crate::from_js_host_call(self, || JSC__JSGlobalObject__generateHeapSnapshot(self))
     }
 
     /// DEPRECATED — use [`TopExceptionScope`](crate::TopExceptionScope) to check for exceptions

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -42,6 +42,7 @@
 #include "JavaScriptCore/ExceptionHelpers.h"
 #include "JavaScriptCore/ExceptionScope.h"
 #include "JavaScriptCore/FunctionConstructor.h"
+#include "JavaScriptCore/HeapProfiler.h"
 #include "JavaScriptCore/HeapSnapshotBuilder.h"
 #include "JavaScriptCore/Identifier.h"
 #include "JavaScriptCore/IteratorOperations.h"
@@ -4109,14 +4110,21 @@ JSC::EncodedJSValue JSC__JSGlobalObject__generateHeapSnapshot(JSC::JSGlobalObjec
 
     Bun__Feature__heap_snapshot += 1;
 
-    JSC::HeapSnapshotBuilder snapshotBuilder(vm.ensureHeapProfiler());
+    vm.ensureHeapProfiler();
+    auto& heapProfiler = *vm.heapProfiler();
+    heapProfiler.clearSnapshots();
+
+    JSC::HeapSnapshotBuilder snapshotBuilder(heapProfiler);
     snapshotBuilder.buildSnapshot();
 
     WTF::String jsonString = snapshotBuilder.json();
+    if (jsonString.isNull()) {
+        JSC::throwOutOfMemoryError(globalObject, scope);
+        return {};
+    }
+    JSC::JSValue result = JSONParseWithException(globalObject, jsonString);
     RETURN_IF_EXCEPTION(scope, {});
-    JSC::EncodedJSValue result = JSC::JSValue::encode(JSONParse(globalObject, jsonString));
-    scope.releaseAssertNoException();
-    return result;
+    return JSC::JSValue::encode(result);
 }
 
 // One load. always_inline so ThinLTO importers and the inliner never leave

--- a/test/js/bun/util/console-takeHeapSnapshot.test.ts
+++ b/test/js/bun/util/console-takeHeapSnapshot.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("console.takeHeapSnapshot can be called repeatedly after a failed require", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        for (let i = 0; i < 5; i++) {
+          try { require("./does-not-exist-" + i); } catch {}
+          console.takeHeapSnapshot();
+          Bun.gc(true);
+        }
+        console.error("OK");
+      `,
+    ],
+    env: {
+      ...bunEnv,
+      BUN_JSC_validateExceptionChecks: "1",
+    },
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("OK");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fuzzilli hit a flaky SIGSEGV (fingerprint `a00ace4a94349590`) on:

```js
try { this.require("-1483416694"); } catch (e) {}
this.console.takeHeapSnapshot();
Bun.gc(true);
```

Two fixes in `console.takeHeapSnapshot()` → `JSC__JSGlobalObject__generateHeapSnapshot`:

**1. Clear prior snapshots before building.** The function created an `InspectorSnapshot`-type `HeapSnapshotBuilder` without clearing the profiler's existing snapshots. In a long-lived process (the fuzzer's REPRL loop reuses the VM for up to 1000 scripts), snapshots chain together and `HeapSnapshotBuilder::json()` walks every retained snapshot, dereferencing each `node.cell->classInfo()`. `Bun.generateHeapSnapshot()` already calls `heapProfiler.clearSnapshots()`; this makes `console.takeHeapSnapshot()` do the same.

**2. Check exceptions from `JSONParse` and make the callers exception-aware.** The C++ side had a `ThrowScope` whose destructor simulates a throw for the caller to check, but `JSGlobalObject::generate_heap_snapshot` (Rust/Zig) returned the bare `JSValue` straight into the console formatter without an exception scope — tripping `validateExceptionChecks` with `Unchecked JS exception: ... JSC__JSGlobalObject__generateHeapSnapshot`. Now:
- C++ uses `RETURN_IF_EXCEPTION(scope, {})` so it returns encoded zero on a real throw (matching the `zero_is_throw` contract)
- Rust/Zig wrap the FFI in `from_js_host_call` / `fromJSHostCall` and early-return on `Err`, so a real `JSONParse` exception propagates to JS instead of printing `undefined` first

The regression test runs the fuzzer's minimized sequence under `BUN_JSC_validateExceptionChecks=1`; it fails on main (unchecked-exception abort) and passes with this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 8 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/console-takeHeapSnapshot.test.ts
bun test v1.4.1 (861e9ae04)

test/js/bun/util/console-takeHeapSnapshot.test.ts:
23 |     stderr: "pipe",
24 |   });
25 | 
26 |   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
27 | 
28 |   expect(stderr).toContain("OK");
                      ^
error: expect(received).toContain(expected)

Expected to contain: "OK"
Received: "ERROR: Unchecked JS exception:\n    This scope can throw a JS exception: JSC__JSGlobalObject__generateHeapSnapshot @ ../../src/jsc/bindings/bindings.cpp:4108\n        (ExceptionScope::m_recursionDepth was 10)\n    But the exception was unchecked as of this scope: <rust> @ src/jsc/JSValue.rs:1084\n        (ExceptionScope::m_recursionDepth was 10)\n\nUnchecked exception detected at:\n\nASSERTION FAILED: exception check validation failed\nassertionFailureDueToUnreachableCode\nvendor/WebKit/Source/JavaScriptCore/runtime/VM.cpp(1648) : void JSC::VM::verifyExceptionCheckNeedIsSatisfied(unsigned int, ExceptionEventLocation &)\nno stacktrac
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (861e9ae04)

test/js/bun/util/console-takeHeapSnapshot.test.ts:
(pass) console.takeHeapSnapshot can be called repeatedly after a failed require [31.86ms]

 1 pass
 0 fail
 2 expect() calls
Ran 1 test across 1 file. [130.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/console-takeHeapSnapshot.test.ts
bun test v1.4.1 (861e9ae04)

test/js/bun/util/console-takeHeapSnapshot.test.ts:
(pass) console.takeHeapSnapshot can be called repeatedly after a failed require [1009.15ms]

 1 pass
 0 fail
 2 expect() calls
Ran 1 test across 1 file. [3.05s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 653ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/src/jsc/bindings/bindings.cpp.o
[2/7] gen generated_host_exports.rs
generated_host_exports.rs: 120 exports (host=5, lazy=10, generic=105, rust=0); 242 extern-C blocks audited
[3/7] gen cpp.rs (cppbind)
[3/7] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_semver v0.0.0 (/workspace/bun/src/semver)
[1m[92m   Compiling[0m bun_analytics v0.0.0 (/workspace/bun/src/analytics)
[1m[92m   Compiling[0m bun_install_types v0.0.0 (/workspace/bun/src/install_types)
[1m[92m   Compiling[0m bun_spawn_sys v0.0.0 (/workspace/bun/src/spawn_sys)
[1m[92m   Compiling[0m bun_options_types v0.0.0 (/workspace/bun/src/options_types)
[1m[92m   Compiling[0m bun_io v0.0.0 (/workspace/bun/src/io)
[1m[92m   Compiling[0m bun_api v0.0.0 (/workspace/bun/src/api)
[1m[92m   Compiling[0m bun_crash_handler v0.0.0 (/workspace/bun/src/crash_handler)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs                          |  5 +++-
 src/jsc/JSGlobalObject.rs                         |  4 +--
 src/jsc/bindings/bindings.cpp                     | 16 +++++++++---
 test/js/bun/util/console-takeHeapSnapshot.test.ts | 30 +++++++++++++++++++++++
 4 files changed, 48 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 8

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/jsc/ConsoleObject.rs                               1      2     11
src/jsc/JSGlobalObject.rs                              2      2     11
src/jsc/bindings/bindings.cpp                          6      6     11
test/js/bun/util/console-takeHeapSnapshot.test.ts      2      3     11
```

</details>

<!-- robobun:evidence:end -->