### PR TITLE
jsc: handle exceptions thrown from deferred work tasks

### DIFF
--- a/src/codegen/bake-codegen.ts
+++ b/src/codegen/bake-codegen.ts
@@ -37,7 +37,7 @@ function css(file: string, is_development: boolean): string {
     stdio: ["ignore", "pipe", "pipe"],
   });
   if (!success) throw new Error(stderr.toString("utf-8"));
-  return stdout.toString("utf-8");
+  return stdout.toString("utf-8").trimEnd();
 }
 
 async function run() {
@@ -53,7 +53,7 @@ async function run() {
           side: JSON.stringify(side),
           IS_ERROR_RUNTIME: String(file === "error"),
           IS_BUN_DEVELOPMENT: String(!!debug),
-          OVERLAY_CSS: css("../runtime/bake/client/overlay.css", !!debug),
+          OVERLAY_CSS: JSON.stringify(css("../runtime/bake/client/overlay.css", !!debug)),
         },
         minify: {
           syntax: !debug,

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1766,7 +1766,12 @@ mod draft {
                     .store(handle as *mut core::ffi::c_void, Ordering::Relaxed);
             }
         }
-        #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android", target_os = "freebsd"))]
+        #[cfg(any(
+            target_os = "macos",
+            target_os = "linux",
+            target_os = "android",
+            target_os = "freebsd"
+        ))]
         {
             reset_on_posix();
         }
@@ -2907,7 +2912,12 @@ mod draft {
             let _ = spawn_result;
             let _ = url;
         }
-        #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android", target_os = "freebsd"))]
+        #[cfg(any(
+            target_os = "macos",
+            target_os = "linux",
+            target_os = "android",
+            target_os = "freebsd"
+        ))]
         {
             let mut buf = bun_core::PathBuffer::default();
             let mut buf2 = bun_core::PathBuffer::default();

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -409,7 +409,12 @@ mod errno_name_tests {
         assert_eq!(Error::from_errno(0), Error::UNEXPECTED);
         assert_eq!(Error::from_errno(9999), Error::UNEXPECTED);
         // errno 11 is platform-specific: EAGAIN on linux/windows, EDEADLK on darwin/bsd.
-        #[cfg(any(target_os = "linux", target_os = "android", windows, target_family = "wasm"))]
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "android",
+            windows,
+            target_family = "wasm"
+        ))]
         {
             assert_eq!(Error::from_errno(11), Error::intern("EAGAIN"));
             assert_eq!(Error::from_errno(104), Error::intern("ECONNRESET"));
@@ -464,7 +469,12 @@ mod errno_name_tests {
             coreutils_error_map::get(2),
             Some("No such file or directory")
         );
-        #[cfg(any(target_os = "linux", target_os = "android", windows, target_family = "wasm"))]
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "android",
+            windows,
+            target_family = "wasm"
+        ))]
         assert_eq!(
             coreutils_error_map::get(11),
             Some("Resource temporarily unavailable")

--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -2,6 +2,7 @@
 #include <JavaScriptCore/VM.h>
 #include <JavaScriptCore/TopExceptionScope.h>
 #include <JavaScriptCore/GlobalObjectMethodTable.h>
+#include <JavaScriptCore/DeferredWorkTimerInlines.h>
 #include "JSCTaskScheduler.h"
 #include "BunClientData.h"
 

--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -1,5 +1,7 @@
 #include "config.h"
 #include <JavaScriptCore/VM.h>
+#include <JavaScriptCore/TopExceptionScope.h>
+#include <JavaScriptCore/GlobalObjectMethodTable.h>
 #include "JSCTaskScheduler.h"
 #include "BunClientData.h"
 
@@ -87,7 +89,14 @@ static void runPendingWork(void* bunVM, Bun::JSCTaskScheduler& scheduler, JSCDef
     holder.unlockEarly();
 
     if (pendingTicket && !pendingTicket->isCancelled()) {
+        auto& vm = job->vm();
+        auto* globalObject = job->ticket->target()->realm();
+        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         job->task(job->ticket.ptr());
+        if (auto* exception = scope.exception()) {
+            if (scope.clearExceptionExceptTermination())
+                globalObject->globalObjectMethodTable()->reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        }
     }
 
     delete job;

--- a/src/perf/tracy.rs
+++ b/src/perf/tracy.rs
@@ -756,7 +756,12 @@ fn dlsym<T: Copy>(symbol: &'static core::ffi::CStr) -> Option<T> {
                 ];
                 #[cfg(windows)]
                 const PATHS_TO_TRY: &[&core::ffi::CStr] = &[c"tracy.dll"];
-                #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android", windows)))]
+                #[cfg(not(any(
+                    target_os = "macos",
+                    target_os = "linux",
+                    target_os = "android",
+                    windows
+                )))]
                 const PATHS_TO_TRY: &[&core::ffi::CStr] = &[];
 
                 // TODO(port): RTLD flags — Zig used `@bitCast(@as(i32, -2))` on

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -679,7 +679,10 @@ pub const BASE_RUNTIME_TRANSPILER_PARAMS: &[ParamType] =
 // built with `comptime_table!(.., cold)` and stay in plain `.rodata`, where
 // `src/startup.order` can still cluster the ones a sampled cold path actually
 // hits without weighing down the `.rodata.startup` fault-around window.
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".rodata.startup"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".rodata.startup")
+)]
 pub static AUTO_TABLE: &clap::ConvertedTable = clap::comptime_table!(AUTO_PARAMS);
 pub static RUN_TABLE: &clap::ConvertedTable = clap::comptime_table!(RUN_PARAMS, cold);
 pub static BUILD_TABLE: &clap::ConvertedTable = clap::comptime_table!(BUILD_PARAMS, cold);

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -552,7 +552,10 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
     /// not share `.text` pages with the hot `bun run <script>` dispatch path.
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn configure_run_transpiler_linker(this_transpiler: &mut Transpiler<'static>) {
         this_transpiler.resolver.opts.load_tsconfig_json = true;
         this_transpiler.options.load_tsconfig_json = true;
@@ -870,7 +873,10 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
     /// initializing JSC.
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn boot_bun_shell(
         ctx: &mut ContextData,
         entry_path: &[u8],
@@ -1669,7 +1675,10 @@ fn log_clear_msgs(vm: &mut VirtualMachine) {
 
 #[cold]
 #[inline(never)]
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".text.unlikely")
+)]
 fn dump_build_error(vm: &mut VirtualMachine) {
     Output::flush();
     if let Some(log) = vm.log {
@@ -1689,7 +1698,10 @@ fn dump_build_error(vm: &mut VirtualMachine) {
 /// `.text.hot` fault-around window the `require('fs')` startup path pulls in.
 #[cold]
 #[inline(never)]
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".text.unlikely")
+)]
 fn exit_with_unhandled_note(vm: &mut VirtualMachine) -> ! {
     vm.exit_handler.exit_code = 1;
     vm.on_exit();
@@ -1703,7 +1715,10 @@ fn exit_with_unhandled_note(vm: &mut VirtualMachine) -> ! {
 /// Cold `Err(err)` arm of `vm.load_entry_point` in `Run::start`.
 #[cold]
 #[inline(never)]
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".text.unlikely")
+)]
 fn entry_point_load_failed(vm: &mut VirtualMachine, err: &bun_core::Error) -> ! {
     if log_has_msgs(vm) {
         dump_build_error(vm);
@@ -1722,7 +1737,10 @@ fn entry_point_load_failed(vm: &mut VirtualMachine, err: &bun_core::Error) -> ! 
 /// exit: bump the exit code and print the sourcemap note + version string.
 #[cold]
 #[inline(never)]
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".text.unlikely")
+)]
 fn print_unhandled_version_note(vm: &mut VirtualMachine) {
     vm.exit_handler.exit_code = 1;
     bun_sourcemap::SavedSourceMap::MissingSourceMapNoteInfo::print();
@@ -1762,7 +1780,10 @@ impl RunCommand {
     /// `.text.hot` fault-around window the `require('fs')` startup path pulls in.
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn boot_failed_exit(ctx: &mut ContextData, display_name: &[u8], err: &bun_core::Error) -> ! {
         // SAFETY: `ctx.log` was set in `create_context_data` (single-threaded
         // CLI startup) and is process-lifetime.
@@ -3022,7 +3043,10 @@ impl RunCommand {
 
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn exec_as_if_node_missing_script() -> ! {
         Output::err_generic(
             "Missing script to execute. Bun's provided 'node' cli wrapper does not support a repl.",
@@ -3033,7 +3057,10 @@ impl RunCommand {
 
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn exec_as_if_node_boot_failed(
         ctx: &mut ContextData,
         basename: &[u8],

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -515,7 +515,12 @@ impl UpgradeCommand {
         {
             "powershell -c 'irm bun.sh/install.ps1|iex'"
         }
-        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "windows")))]
+        #[cfg(not(any(
+            target_os = "linux",
+            target_os = "android",
+            target_os = "macos",
+            target_os = "windows"
+        )))]
         {
             // TODO(port): Environment.os.displayString() at comptime
             "(TODO: Install script for this platform)"

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4499,13 +4499,14 @@ pub(crate) fn resolve_embedded_file_to_buf(
     // Spec ModuleLoader.zig:43-45 — `tmpname(extname, buf, bun.hash(file.name))`.
     let mut tmpname_buf = bun_paths::path_buffer_pool::get();
     let tmpfilename =
-        Fs::FileSystem::tmpname(extname, &mut tmpname_buf[..], bun_wyhash::hash(file_name))
-            .ok()?;
+        Fs::FileSystem::tmpname(extname, &mut tmpname_buf[..], bun_wyhash::hash(file_name)).ok()?;
 
     // Spec ModuleLoader.zig:47 — `bun.fs.FileSystem.instance.tmpdir()`.
     // SAFETY: `FileSystem::instance()` returns the process-global singleton
     // pointer (initialized at startup).
-    let tmpdir = (unsafe { &mut *Fs::FileSystem::instance() }).tmpdir().ok()?;
+    let tmpdir = (unsafe { &mut *Fs::FileSystem::instance() })
+        .tmpdir()
+        .ok()?;
     let tmpdir_fd: bun_sys::Fd = tmpdir.fd;
 
     // Spec ModuleLoader.zig:50-51 — `bun.Tmpfile.create(tmpdir, tmpfilename)`.

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -358,7 +358,10 @@ fn find_playwright_shell() -> Option<ZBox> {
     }
 
     // Fall back to the non-cft linux arm64 layout.
-    #[cfg(all(any(target_os = "linux", target_os = "android"), target_arch = "aarch64"))]
+    #[cfg(all(
+        any(target_os = "linux", target_os = "android"),
+        target_arch = "aarch64"
+    ))]
     {
         let bin_parts2: [&[u8]; 3] = [
             cache_dir,
@@ -633,7 +636,12 @@ fn read_dev_tools_active_port(out_buf: &mut Vec<u8>) -> Option<()> {
         b"BraveSoftware\\Brave-Browser\\User Data\\DevToolsActivePort",
         b"Microsoft\\Edge\\User Data\\DevToolsActivePort",
     ];
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android", windows)))]
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "linux",
+        target_os = "android",
+        windows
+    )))]
     let candidates: &[&[u8]] = &[];
 
     let mut path_buf = path_buffer_pool::get();

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -3224,7 +3224,10 @@ mod spawn_process_body {
             // that are read *after* the wait, so falling through to the memfd block
             // below is required.
             let status: Status = 'blk: {
-                if no_orphans && (cfg!(any(target_os = "linux", target_os = "android")) || cfg!(target_os = "macos")) {
+                if no_orphans
+                    && (cfg!(any(target_os = "linux", target_os = "android"))
+                        || cfg!(target_os = "macos"))
+                {
                     let ppid = ParentDeathWatchdog::ppid_to_watch().unwrap_or(0);
                     #[cfg(target_os = "macos")]
                     let r: Option<Maybe<Status>> = wait_mac_kqueue(
@@ -3245,7 +3248,11 @@ mod spawn_process_body {
                         &mut out_fds_to_wait_for,
                         &mut out_fds,
                     );
-                    #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
+                    #[cfg(not(any(
+                        target_os = "linux",
+                        target_os = "android",
+                        target_os = "macos"
+                    )))]
                     let r: Option<Maybe<Status>> = {
                         let _ = ppid;
                         None

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -775,7 +775,10 @@ pub fn spawn_process_posix(
     let mut dup_stdout_to_stderr: bool = false;
 
     // The label is only referenced from the Linux memfd fast-path below.
-    #[cfg_attr(not(any(target_os = "linux", target_os = "android")), allow(unused_labels))]
+    #[cfg_attr(
+        not(any(target_os = "linux", target_os = "android")),
+        allow(unused_labels)
+    )]
     'stdio: for i in 0..3usize {
         let fileno = Fd::from_native(FdT::try_from(i).unwrap());
         let flag: u32 = (if i == 0 {

--- a/test/js/bun/jsc/finalization-registry-throw.test.ts
+++ b/test/js/bun/jsc/finalization-registry-throw.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("FinalizationRegistry callback that throws is reported as uncaughtException", async () => {
+  const src = `
+    let caught = 0;
+    process.on("uncaughtException", () => caught++);
+    const fr = new FinalizationRegistry(() => { throw new Error("boom"); });
+    (function () {
+      for (let i = 0; i < 10; i++) fr.register({}, i);
+    })();
+    for (let i = 0; i < 20; i++) {
+      Bun.gc(true);
+      await new Promise(r => setImmediate(r));
+      if (caught > 0) break;
+    }
+    console.log("caught=" + caught);
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr }).toEqual({ stdout: expect.stringMatching(/^caught=\d+\n$/), stderr: "" });
+  const caught = parseInt(stdout.match(/caught=(\d+)/)![1]);
+  expect(caught).toBeGreaterThan(0);
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

When a `FinalizationRegistry` cleanup callback (or any other JSC deferred-work task — `WebAssembly.compile`, `Atomics.waitAsync`) throws, debug/ASAN builds abort with:

```
ASSERTION FAILED: Unexpected exception observed
!exception()
ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
```

Found by Fuzzilli (fingerprint `110761d7b563f911`).

## Why

Bun overrides JSC's `DeferredWorkTimer` via `JSCTaskScheduler` so that deferred work runs through Bun's event loop instead of JSC's `RunLoop`. The override's `runPendingWork()` calls `job->task(...)` directly and never looks at `vm.exception()` afterwards. If the task throws (e.g. `new FinalizationRegistry(() => { throw new Error() })` after the target is collected), the exception is still pending when control returns to Rust's `JSCDeferredWorkTask::run`, whose validation scope then asserts.

JSC's own `DeferredWorkTimer::doWork()` wraps the task call in a `TopExceptionScope` and reports any pending non-termination exception via `reportUncaughtExceptionAtEventLoop`. This patch does the same in `runPendingWork()`, so the exception is delivered to `process.on('uncaughtException')` (matching Node.js) instead of aborting the process in debug builds.

Release builds were accidentally correct — the validation scope is a no-op there and the leaked exception happened to be picked up by a later event-loop check — but the exception was being handled at the wrong layer.

## Repro

```js
const fr = new FinalizationRegistry(() => { throw new Error("boom"); });
(function () { for (let i = 0; i < 10; i++) fr.register({}, i); })();
for (let i = 0; i < 5; i++) {
  Bun.gc(true);
  await new Promise(r => setImmediate(r));
}
```

## Also

`bake-codegen.ts`: wrap `OVERLAY_CSS` in `JSON.stringify` so codegen works when driven by a host Bun that predates the `define` auto-quote lexer fix in 314d044c0a. Generated `bake.*.js` are byte-identical.