### PR TITLE
error: swallow Error.prepareStackTrace throws in computeErrorInfoWrapperToJSValue

### DIFF
--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -642,7 +642,23 @@ JSC::JSValue computeErrorInfoWrapperToJSValue(JSC::VM& vm, Vector<StackFrame>& s
     OrdinalNumber line = OrdinalNumber::fromOneBasedInt(line_in);
     OrdinalNumber column = OrdinalNumber::fromOneBasedInt(column_in);
 
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSValue result = computeErrorInfoToJSValue(vm, stackTrace, line, column, sourceURL, errorInstance, bunErrorData);
+    if (scope.exception()) [[unlikely]] {
+        // ErrorInstance::materializeErrorInfoIfNeeded (our only caller via
+        // vm.onComputeErrorInfoJSValue) unconditionally putDirects
+        // line/column/sourceURL/stack after we return, so getOwnPropertySlot
+        // ends up returning true with a pending exception and trips
+        // EXCEPTION_ASSERT(!scope.exception() || !result) in
+        // JSObject::getOwnPropertyDescriptor (and releaseAssertNoException in
+        // other host callers). Swallow the exception here like
+        // computeErrorInfoWrapperToString already does; result already holds
+        // the default-formatted stack string from formatStackTraceToJSValue's
+        // RETURN_IF_EXCEPTION fallback.
+        (void)scope.tryClearException();
+        if (!result)
+            result = jsUndefined();
+    }
 
     line_in = line.oneBasedInt();
     column_in = column.oneBasedInt();

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -25,7 +25,37 @@ test("throw inside Error.prepareStackTrace doesnt crash", () => {
     throw new Error("wat");
   };
 
-  expect(() => new Error().stack).toThrow("wat");
+  // Node throws the prepareStackTrace exception here; we swallow it and
+  // fall back to the default-formatted stack because
+  // ErrorInstance::materializeErrorInfoIfNeeded has no way to propagate a
+  // throw without violating the getOwnPropertySlot contract and tripping
+  // debug assertions (see computeErrorInfoWrapperToJSValue).
+  expect(typeof new Error().stack).toBe("string");
+});
+
+test("structuredClone of Error with throwing Error.prepareStackTrace doesnt crash", () => {
+  Error.prepareStackTrace = ArrayBuffer;
+  const e = new Error("test");
+  const cloned = structuredClone(e);
+  expect(cloned).toBeInstanceOf(Error);
+  expect(cloned.message).toBe("test");
+
+  Error.prepareStackTrace = () => {
+    throw new Error("boom");
+  };
+  const e2 = new Error("test2");
+  const cloned2 = structuredClone(e2);
+  expect(cloned2).toBeInstanceOf(Error);
+  expect(cloned2.message).toBe("test2");
+  expect(typeof cloned2.stack).toBe("string");
+});
+
+test("getOwnPropertyDescriptor of Error with throwing Error.prepareStackTrace doesnt crash", () => {
+  Error.prepareStackTrace = ArrayBuffer;
+  const e = new Error("test");
+  const desc = Object.getOwnPropertyDescriptor(e, "stack");
+  expect(typeof desc.value).toBe("string");
+  expect(Object.getOwnPropertyDescriptor(e, "line").value).toBeNumber();
 });
 
 test("capture stack trace", () => {
@@ -337,6 +367,7 @@ test("prepare stack trace call sites", () => {
 });
 
 test("sanity check", () => {
+  let frame0;
   function f1() {
     f2();
   }
@@ -349,25 +380,7 @@ test("sanity check", () => {
     let e = new Error("bad error!");
     let prevPrepareStackTrace = Error.prepareStackTrace;
     Error.prepareStackTrace = (e, s) => {
-      // getThis returns undefined in strict mode
-      expect(s[0].getThis()).toBe(undefined);
-      expect(s[0].getTypeName()).toBe("undefined");
-      // getFunction returns undefined in strict mode
-      expect(s[0].getFunction()).toBe(undefined);
-      expect(s[0].getFunctionName()).toBe("f3");
-      expect(s[0].getMethodName()).toBe("f3");
-      expect(typeof s[0].getLineNumber()).toBe("number");
-      expect(typeof s[0].getColumnNumber()).toBe("number");
-      expect(s[0].getFileName().includes("capture-stack-trace.test.js")).toBe(true);
-
-      expect(s[0].getEvalOrigin()).toBe(undefined);
-      expect(s[0].isToplevel()).toBe(true);
-      expect(s[0].isEval()).toBe(false);
-      expect(s[0].isNative()).toBe(false);
-      expect(s[0].isConstructor()).toBe(false);
-      expect(s[0].isAsync()).toBe(false);
-      expect(s[0].isPromiseAll()).toBe(false);
-      expect(s[0].getPromiseIndex()).toBe(null);
+      frame0 = s[0];
     };
     Error.captureStackTrace(e);
     expect(e.stack === undefined).toBe(true);
@@ -375,6 +388,26 @@ test("sanity check", () => {
   }
 
   f1();
+
+  // getThis returns undefined in strict mode
+  expect(frame0.getThis()).toBe(undefined);
+  expect(frame0.getTypeName()).toBe("undefined");
+  // getFunction returns undefined in strict mode
+  expect(frame0.getFunction()).toBe(undefined);
+  expect(frame0.getFunctionName()).toBe("f3");
+  expect(frame0.getMethodName()).toBe("f3");
+  expect(typeof frame0.getLineNumber()).toBe("number");
+  expect(typeof frame0.getColumnNumber()).toBe("number");
+  expect(frame0.getFileName().includes("capture-stack-trace.test.js")).toBe(true);
+
+  expect(frame0.getEvalOrigin()).toBe(undefined);
+  expect(frame0.isToplevel()).toBe(true);
+  expect(frame0.isEval()).toBe(false);
+  expect(frame0.isNative()).toBe(false);
+  expect(frame0.isConstructor()).toBe(false);
+  expect(frame0.isAsync()).toBe(false);
+  expect(frame0.isPromiseAll()).toBe(false);
+  expect(frame0.getPromiseIndex()).toBe(null);
 });
 
 test("CallFrame isEval works as expected", () => {
@@ -404,22 +437,25 @@ test("CallFrame isTopLevel returns false for Function constructor", () => {
   noInline(sloppyFn);
   const that = {};
 
+  let frames;
   Error.prepareStackTrace = (e, s) => {
-    expect(s[0].getFunctionName()).toBe(sloppyFn.displayName);
-    expect(s[0].getFunction()).toBe(sloppyFn);
-
-    expect(s[0].isToplevel()).toBe(false);
-    expect(s[0].isEval()).toBe(false);
-
-    // Strict-mode functions shouldn't have getThis or getFunction
-    // available.
-    expect(s[1].getThis()).toBe(undefined);
-    expect(s[1].getFunction()).toBe(undefined);
+    frames = s;
   };
 
   sloppyFn.call(that);
 
   Error.prepareStackTrace = prevPrepareStackTrace;
+
+  expect(frames[0].getFunctionName()).toBe(sloppyFn.displayName);
+  expect(frames[0].getFunction()).toBe(sloppyFn);
+
+  expect(frames[0].isToplevel()).toBe(false);
+  expect(frames[0].isEval()).toBe(false);
+
+  // Strict-mode functions shouldn't have getThis or getFunction
+  // available.
+  expect(frames[1].getThis()).toBe(undefined);
+  expect(frames[1].getFunction()).toBe(undefined);
 });
 
 test("CallFrame.p.getThisgetFunction: strict/sloppy mode interaction", () => {
@@ -429,18 +465,22 @@ test("CallFrame.p.getThisgetFunction: strict/sloppy mode interaction", () => {
   const sloppyFn = new Function("x", "x()");
   const that = {};
 
+  let frames;
   Error.prepareStackTrace = (e, s) => {
-    // The first strict mode function encounted during stack unwinding
-    // stops subsequent frames from having getThis\getFunction.
-    for (const t of s) {
-      expect(t.getThis()).toBe(undefined);
-      expect(t.getFunction()).toBe(undefined);
-    }
+    frames = s;
   };
 
   sloppyFn.call(that, strictFn);
 
   Error.prepareStackTrace = prevPrepareStackTrace;
+
+  // The first strict mode function encounted during stack unwinding
+  // stops subsequent frames from having getThis\getFunction.
+  expect(frames.length).toBeGreaterThan(0);
+  for (const t of frames) {
+    expect(t.getThis()).toBe(undefined);
+    expect(t.getFunction()).toBe(undefined);
+  }
 });
 
 test("CallFrame.p.isConstructor", () => {
@@ -506,6 +546,7 @@ test("err.stack should invoke prepareStackTrace", () => {
   var functionName = "";
   var parentLineNumber = -1;
   var referenceStack = "";
+  var fileNames = [];
   // Line numbers of the first two frames of a default-formatted stack string.
   function defaultStackLineNumbers(stack) {
     return String(stack)
@@ -523,8 +564,7 @@ test("err.stack should invoke prepareStackTrace", () => {
       lineNumber = s[0].getLineNumber();
       functionName = s[0].getFunctionName();
       parentLineNumber = s[1].getLineNumber();
-      expect(s[0].getFileName().includes("capture-stack-trace.test.js")).toBe(true);
-      expect(s[1].getFileName().includes("capture-stack-trace.test.js")).toBe(true);
+      fileNames = [s[0].getFileName(), s[1].getFileName()];
     };
     // `reference` shares `e`'s line so the default formatter (consulted after the
     // hook is removed) must report the same call-site lines prepareStackTrace saw.
@@ -543,6 +583,8 @@ test("err.stack should invoke prepareStackTrace", () => {
   expect(functionName).toBe("functionWithAName");
   expect(lineNumber).toBe(expectedLineNumber);
   expect(parentLineNumber).toBe(expectedParentLineNumber);
+  expect(fileNames[0].includes("capture-stack-trace.test.js")).toBe(true);
+  expect(fileNames[1].includes("capture-stack-trace.test.js")).toBe(true);
 });
 
 test("Error.prepareStackTrace inside a node:vm works", () => {
@@ -718,12 +760,9 @@ test("Error.prepareStackTrace propagates exceptions", () => {
 
 test("CallFrame.p.getScriptNameOrSourceURL inside eval", () => {
   let prevPrepareStackTrace = Error.prepareStackTrace;
+  let urls;
   const prepare = mock((e, s) => {
-    expect(s[0].getScriptNameOrSourceURL()).toBe("https://zombo.com/welcome-to-zombo.js");
-    expect(s[1].getScriptNameOrSourceURL()).toBe("https://zombo.com/welcome-to-zombo.js");
-    expect(s[2].getScriptNameOrSourceURL()).toBe("[native code]");
-    expect(s[3].getScriptNameOrSourceURL()).toBe(import.meta.path);
-    expect(s[4].getScriptNameOrSourceURL()).toBe(import.meta.path);
+    urls = s.slice(0, 5).map(f => f.getScriptNameOrSourceURL());
   });
   Error.prepareStackTrace = prepare;
   let evalScript = `(function() {
@@ -741,15 +780,20 @@ test("CallFrame.p.getScriptNameOrSourceURL inside eval", () => {
   Error.prepareStackTrace = prevPrepareStackTrace;
 
   expect(prepare).toHaveBeenCalledTimes(1);
+  expect(urls).toEqual([
+    "https://zombo.com/welcome-to-zombo.js",
+    "https://zombo.com/welcome-to-zombo.js",
+    "[native code]",
+    import.meta.path,
+    import.meta.path,
+  ]);
 });
 
 test("CallFrame.p.isAsync", async () => {
   let prevPrepareStackTrace = Error.prepareStackTrace;
+  let isAsyncResults;
   const prepare = mock((e, s) => {
-    expect(s[0].isAsync()).toBeFalse();
-    expect(s[1].isAsync()).toBeTrue();
-    expect(s[2].isAsync()).toBeTrue();
-    expect(s[3].isAsync()).toBeTrue();
+    isAsyncResults = s.slice(0, 4).map(f => f.isAsync());
   });
   Error.prepareStackTrace = prepare;
   async function foo() {
@@ -771,6 +815,7 @@ test("CallFrame.p.isAsync", async () => {
   Error.prepareStackTrace = prevPrepareStackTrace;
 
   expect(prepare).toHaveBeenCalledTimes(1);
+  expect(isAsyncResults).toEqual([false, true, true, true]);
 });
 
 test("captureStackTrace with constructor function not in stack returns error string", () => {


### PR DESCRIPTION
## What

`computeErrorInfoWrapperToJSValue` (the `vm.onComputeErrorInfoJSValue` hook) now clears any pending exception before returning, the same way `computeErrorInfoWrapperToString` already does.

## Why

Fuzzilli found a crash (fingerprint `7ef723ee9b8febc3`) where a user-supplied `Error.prepareStackTrace` throws (e.g. `Error.prepareStackTrace = ArrayBuffer`). The throw propagates out of the hook into `ErrorInstance::materializeErrorInfoIfNeeded`, which has no throw scope and unconditionally `putDirect`s `line`/`column`/`sourceURL`/`stack` afterwards. `ErrorInstance::getOwnPropertySlot` then returns `true` with an exception pending, violating JSC's contract and tripping:

- `EXCEPTION_ASSERT(!scope.exception() || !result)` in `JSObject::getOwnPropertyDescriptor` — hit by `structuredClone(error)` / `postMessage(error)` / `Object.getOwnPropertyDescriptor(error, "stack")`
- `releaseAssertNoException()` in Zig/Rust host-call validation scopes when any host function reads the error's `stack`/`line`/`column`/`sourceURL`

Minimal repro (debug/ASAN only):

```js
Error.prepareStackTrace = ArrayBuffer;
structuredClone(new Error("test"));
// ASSERTION FAILED: !scope.exception() || !result
// JSObject.cpp(3914) : bool JSC::JSObject::getOwnPropertyDescriptor(...)
```

With the exception cleared, `.stack` falls back to the default-formatted string that `formatStackTraceToJSValue` already produced before calling the user's `prepareStackTrace`. This diverges from Node (which propagates the throw), but matches what `computeErrorInfoWrapperToString` has done since that hook was added, and avoids the assertion in all paths that materialize error info. A proper propagating fix would need `ErrorInstance::getOwnPropertySlot` in WebKit to check for exceptions after materialize (as `defineOwnProperty`/`put` already do).
