### PR TITLE
js_parser/lexer: saturate `\u{...}` hex multiply to avoid i64 overflow

### DIFF
--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -861,7 +861,7 @@ lexer_impl_header! {
                                         break 'variable_length;
                                     }
                                     match hex_digit_value_u32(c3 as u32) {
-                                        Some(d) => value = (value * 16) | d as i64,
+                                        Some(d) => value = value.saturating_mul(16) | d as i64,
                                         None => {
                                             self.end = (start + iter.i as usize)
                                                 .saturating_sub(width3 as usize);
@@ -904,7 +904,7 @@ lexer_impl_header! {
                                 let mut j: usize = 0;
                                 while j < 4 {
                                     match hex_digit_value_u32(c3 as u32) {
-                                        Some(d) => value = (value * 16) | d as i64,
+                                        Some(d) => value = value.saturating_mul(16) | d as i64,
                                         None => {
                                             self.end = (start + iter.i as usize)
                                                 .saturating_sub(width3 as usize);

--- a/src/parsers/toml/lexer.rs
+++ b/src/parsers/toml/lexer.rs
@@ -1083,7 +1083,7 @@ impl<'a> Lexer<'a> {
                                         break 'variable_length;
                                     }
                                     match hex_digit_value_u32(c3 as u32) {
-                                        Some(d) => value = (value * 16) | d as i64,
+                                        Some(d) => value = value.saturating_mul(16) | d as i64,
                                         None => {
                                             self.end = (start + iter.i as usize)
                                                 .saturating_sub(width3 as usize);
@@ -1123,7 +1123,7 @@ impl<'a> Lexer<'a> {
                                 let mut j: usize = 0;
                                 while j < 4 {
                                     match hex_digit_value_u32(c3 as u32) {
-                                        Some(d) => value = (value * 16) | d as i64,
+                                        Some(d) => value = value.saturating_mul(16) | d as i64,
                                         None => {
                                             self.end = (start + iter.i as usize)
                                                 .saturating_sub(width3 as usize);

--- a/test/js/bun/resolve/toml/toml-parse.test.ts
+++ b/test/js/bun/resolve/toml/toml-parse.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 test("Bun.TOML.parse with non-string input throws", () => {
   expect(() => Bun.TOML.parse(SharedArrayBuffer as any)).toThrow();
@@ -86,4 +87,29 @@ test("Bun.TOML.parse rejects array values without comma separators (#31252)", ()
   expect(Bun.TOML.parse("a = [1, 2, 3]")).toEqual({ a: [1, 2, 3] });
   // Trailing comma is legal TOML.
   expect(Bun.TOML.parse("a = [1, 2,]")).toEqual({ a: [1, 2] });
+});
+
+// https://github.com/oven-sh/bun/issues/30825
+// `\u{...}` escape with enough hex digits to overflow i64 used to panic
+// the debug lexer. The lexer now saturates the hex accumulator so the
+// `value > 1_114_111` range check fires normally, and (since #31252)
+// `Bun.TOML.parse` surfaces the logged range error as a throw.
+//
+// Run in a subprocess: without the fix the debug lexer panics, which
+// would take down the whole test runner if this ran inline. With the fix
+// the parser throws cleanly and the child exits 0 after printing "threw:".
+test("Bun.TOML.parse throws on out-of-range \\u{} escape (#30825)", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `try { Bun.TOML.parse('key = "\\\\u{3333333316aaaaaaa}"'); console.log("no-throw"); } catch (e) { console.log("threw:", e.message); }`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toStartWith("threw:");
+  expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/invalid-escape-sequences.test.ts
+++ b/test/regression/issue/invalid-escape-sequences.test.ts
@@ -204,6 +204,28 @@ test("invalid \\u{ followed by multi-byte codepoint does not panic (#30893)", as
   expect(exitCode).toBe(1);
 });
 
+// https://github.com/oven-sh/bun/issues/30825
+// A `\u{...}` escape with enough hex digits to overflow i64 used to panic
+// the debug lexer (`attempt to multiply with overflow`). It must report
+// the out-of-range error instead of crashing.
+test("Out-of-range \\u{} escape sequence reports a range error", async () => {
+  using dir = tempDir("escape-test", {
+    "test.js": `\\u{3333333316aaaaaaa}a`,
+  });
+
+  const { stderr, exitCode } = Bun.spawnSync({
+    cmd: [bunExe(), join(dir, "test.js")],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+    cwd: String(dir),
+  });
+
+  const err = stderr.toString();
+  expect(err).toContain("Unicode escape sequence is out of range");
+  expect(exitCode).toBe(1);
+});
+
 test("Valid unicode escapes in identifiers should work", async () => {
   // Test valid \u escape with 4 hex digits
   {


### PR DESCRIPTION
## Reproduction

```console
$ echo '\u{3333333316aaaaaaa}a' > /tmp/crash.js
$ bun-debug /tmp/crash.js
panic: attempt to multiply with overflow (src/js_parser/lexer.rs:864:60)
```

## Cause

In both the variable-length `\u{...}` and fixed-length `\uXXXX` unicode-escape
branches, the lexer accumulates the value with `value = value * 16 | d as i64`.
`value` is `i64` and grows unbounded while the loop consumes hex digits — the
explicit `value > 1_114_111` range check only fires _after_ the multiply, so
an escape with enough digits overflows `i64` before the check can catch it.
In debug builds Rust panics; in release the multiply wraps silently.

## Fix

Use `value.saturating_mul(16)` in both branches. Once `value` exceeds the
utf8.MaxRune threshold, `is_out_of_range` is set and stays set, so the
existing check + `add_range_error` path fires correctly with the saturated
value.

## Verification

```console
$ bun-debug /tmp/crash.js
1 | \u{3333333316aaaaaaa}a
    ^
error: Unicode escape sequence is out of range
    at /tmp/crash.js:1:1
```

Test added to `test/regression/issue/invalid-escape-sequences.test.ts`;
passes with fix, fails (panic + null exitCode + missing range-error text)
without.

Fixes #30825