### PR TITLE
node:async_hooks: fire createHook lifecycle events for timers

### DIFF
--- a/src/js/internal/async_hooks.ts
+++ b/src/js/internal/async_hooks.ts
@@ -1,7 +1,8 @@
 // Minimal port of node's lib/internal/async_hooks.js surface for
-// --expose-internals consumers (vendored node tests). Bun's createHook is a
-// stub whose callbacks never fire; what CAN be tracked honestly is whether
-// any hook is currently enabled, which is all enabledHooksExist() reports.
+// --expose-internals consumers (vendored node tests). Bun's createHook is
+// partially implemented (full init/before/after/destroy for timers, init for
+// TickObject); what is tracked here is only whether any hook is currently
+// enabled, which is all enabledHooksExist() reports.
 let activeHooks = 0;
 
 function enabledHooksExist() {

--- a/src/js/internal/async_hooks_tick.ts
+++ b/src/js/internal/async_hooks_tick.ts
@@ -6,9 +6,11 @@
 // The array identity must stay stable (push/splice only, never reassign):
 // the nextTick closure captures it once at setup.
 //
-// Currently only TickObject `init` events are delivered (enough for
-// console.log/stream.write tick-coalescing tests); promise, timer and native
-// resource events are still unimplemented.
+// This bridge delivers only TickObject `init` events (enough for
+// console.log/stream.write tick-coalescing tests); promise and native resource
+// events are still unimplemented. Timer lifecycle events are delivered
+// separately by node/async_hooks.ts, which shares newAsyncId() below so timer
+// and tick async ids never collide.
 const tickInitHooks = [];
 let nextAsyncId = 1;
 

--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -359,13 +359,220 @@ function isEmptyFunction(f: Function) {
   return /^{\s*}$/.test(str);
 }
 
-const createHookNotImpl = createWarning(
-  "async_hooks.createHook is not implemented in Bun. Hooks can still be created but will never be called.",
+// `createHook` is partially implemented. Two resource kinds deliver events:
+//   - process.nextTick delivers `init` via the tickInitHooks bridge (see
+//     internal/async_hooks_tick.ts and builtins/ProcessObjectInternals.ts).
+//   - timers (setTimeout/setInterval/setImmediate) deliver the full init/
+//     before/after/destroy lifecycle via the wrapped globals installed by
+//     installTimerHooks() on the first enable().
+// Other resource types (promises, I/O, native handles) and `promiseResolve`
+// are still unimplemented. See https://github.com/oven-sh/bun/issues/30827.
+const createHookPartialWarning = createWarning(
+  "async_hooks.createHook is partially implemented in Bun. before/after/destroy only fire for timers " +
+    "(setTimeout/setInterval/setImmediate); promiseResolve and non-timer resource types are not emitted.",
   true,
 );
 
 let hasEnabledCreateHook = false;
 const kHookEnabled = Symbol("kHookEnabled");
+
+// Hooks whose timer lifecycle (init/before/after/destroy) should fire. A
+// record is pushed on enable() and removed (by identity) on disable();
+// emission iterates a snapshot so a hook mutating the set mid-dispatch cannot
+// reorder the remaining callbacks.
+const timerHooks: {
+  init?: Function;
+  before?: Function;
+  after?: Function;
+  destroy?: Function;
+}[] = [];
+let timerGlobalsPatched = false;
+
+// Tags stored on a timer handle. `kTimerKind` distinguishes Timeout from
+// Immediate so a mismatched clear (clearTimeout on an Immediate, and so on) is
+// a no-op, matching Node, which keeps the two APIs strictly paired.
+const kAsyncId = Symbol("bun.asyncId");
+const kDestroyed = Symbol("bun.asyncHooksDestroyed");
+const kTimerKind = Symbol("bun.asyncHooksTimerKind");
+
+// Tracks executionAsyncId()/triggerAsyncId() while inside a timer callback so a
+// timer created there records the enclosing timer as its trigger. The root is
+// 0, matching the AsyncResource.asyncId() stub which also returns 0 (see
+// test-async-hooks-recursive-stack-runInAsyncScope.js).
+let currentExecutionAsyncId = 0;
+let currentTriggerAsyncId = 0;
+
+// destroy is batched onto a microtask so it trails a synchronous after(), the
+// ordering Node produces. It uses queueMicrotask rather than process.nextTick
+// on purpose: when an init hook is enabled it is also registered on
+// tickInitHooks, and a process.nextTick here would be reported back to that
+// hook as a spurious init(TickObject) for this internal flush tick.
+let pendingDestroy: number[] | null = null;
+function scheduleDestroy(id: number) {
+  if (pendingDestroy === null) {
+    pendingDestroy = [id];
+    queueMicrotask(flushDestroyQueue);
+  } else {
+    pendingDestroy.push(id);
+  }
+}
+function flushDestroyQueue() {
+  const queue = pendingDestroy;
+  pendingDestroy = null;
+  if (!queue) return;
+  for (let i = 0; i < queue.length; i++) emitTimer("destroy", queue[i]);
+}
+
+// A throwing hook callback is fatal, matching Node (fatalError prints the stack
+// and exits, removing all uncaughtException listeners so they cannot suppress
+// it) and Bun's own TickObject path in ProcessObjectInternals.ts. console is a
+// user-mutable global, so shield the print; exit regardless.
+function reportHookError(err: unknown) {
+  try {
+    console.error(typeof (err as any)?.stack === "string" ? (err as any).stack : err);
+  } catch {}
+  process.exit(1);
+}
+
+function emitTimer(kind: "before" | "after" | "destroy", asyncId: number) {
+  const hooks = timerHooks.slice();
+  for (let i = 0; i < hooks.length; i++) {
+    const fn = hooks[i][kind];
+    if (fn) {
+      try {
+        fn(asyncId);
+      } catch (err) {
+        reportHookError(err);
+      }
+    }
+  }
+}
+
+function emitTimerInit(asyncId: number, type: string, triggerAsyncId: number, resource: any) {
+  const hooks = timerHooks.slice();
+  for (let i = 0; i < hooks.length; i++) {
+    const fn = hooks[i].init;
+    if (fn) {
+      try {
+        fn(asyncId, type, triggerAsyncId, resource);
+      } catch (err) {
+        reportHookError(err);
+      }
+    }
+  }
+}
+
+// Wrapping is installed on globalThis lazily on the first enable(), so a caller
+// that captured a timer reference earlier keeps the unwrapped native and
+// bypasses the hook layer. Node has the same property (its hooks live in a JS
+// prologue around the native call). The regression test pins this so a future
+// lower-level interception is a conscious opt-in.
+function installTimerHooks() {
+  if (timerGlobalsPatched) return;
+  timerGlobalsPatched = true;
+
+  const asyncHooksTick = require("internal/async_hooks_tick");
+  const g = globalThis as any;
+  const origSetTimeout = g.setTimeout;
+  const origSetInterval = g.setInterval;
+  const origSetImmediate = g.setImmediate;
+  const origClearTimeout = g.clearTimeout;
+  const origClearInterval = g.clearInterval;
+  const origClearImmediate = g.clearImmediate;
+  const kCustomPromisify = Symbol.for("nodejs.util.promisify.custom");
+
+  function wrapTimer(type: "Timeout" | "Immediate", orig: Function, isInterval: boolean) {
+    const wrapped = function (this: any, callback: any, ...rest: any[]) {
+      if (!$isCallable(callback) || timerHooks.length === 0) {
+        return orig.$apply(this, arguments);
+      }
+      const asyncId = asyncHooksTick.newAsyncId();
+      const triggerAsyncId = currentExecutionAsyncId;
+      let timer: any;
+      const wrappedCallback = function (this: any, ...args: any[]) {
+        const prevExec = currentExecutionAsyncId;
+        const prevTrig = currentTriggerAsyncId;
+        currentExecutionAsyncId = asyncId;
+        currentTriggerAsyncId = triggerAsyncId;
+        emitTimer("before", asyncId);
+        try {
+          return callback.$apply(this, args);
+        } finally {
+          emitTimer("after", asyncId);
+          // A non-repeating timer is done once it fires: mark destroyed so a
+          // later clear is a no-op, then queue the batched destroy (scheduled
+          // on a microtask; see scheduleDestroy).
+          if (!isInterval && timer && !timer[kDestroyed]) {
+            timer[kDestroyed] = true;
+            scheduleDestroy(asyncId);
+          }
+          currentExecutionAsyncId = prevExec;
+          currentTriggerAsyncId = prevTrig;
+        }
+      };
+      timer = orig.$call(this, wrappedCallback, ...rest);
+      if (timer && typeof timer === "object") {
+        timer[kAsyncId] = asyncId;
+        timer[kDestroyed] = false;
+        timer[kTimerKind] = type;
+        emitTimerInit(asyncId, type, triggerAsyncId, timer);
+      }
+      return timer;
+    };
+    // Forward util.promisify.custom so util.promisify(setTimeout) keeps
+    // returning the timers/promises variant. The wrapper is a fresh function;
+    // without this it misses the symbol and promisify falls back to the
+    // errback path (wrong arg order, promise never resolves).
+    const customPromisify = (orig as any)[kCustomPromisify];
+    if (customPromisify !== undefined) {
+      Object.defineProperty(wrapped, kCustomPromisify, { value: customPromisify, configurable: true });
+    }
+    return wrapped;
+  }
+
+  // clearTimeout/clearInterval pair with Timeout handles, clearImmediate with
+  // Immediate handles. A mismatched clear is a no-op in Node, so skip the
+  // destroy too: the timer is still going to fire.
+  function wrapClear(orig: Function, expectedKind: "Timeout" | "Immediate") {
+    return function (this: any, timer: any) {
+      if (
+        timer &&
+        typeof timer === "object" &&
+        timer[kAsyncId] != null &&
+        timer[kTimerKind] === expectedKind &&
+        !timer[kDestroyed]
+      ) {
+        timer[kDestroyed] = true;
+        scheduleDestroy(timer[kAsyncId]);
+      }
+      return orig.$apply(this, arguments);
+    };
+  }
+
+  g.setTimeout = wrapTimer("Timeout", origSetTimeout, false);
+  g.setInterval = wrapTimer("Timeout", origSetInterval, true);
+  g.setImmediate = wrapTimer("Immediate", origSetImmediate, false);
+  g.clearTimeout = wrapClear(origClearTimeout, "Timeout");
+  g.clearInterval = wrapClear(origClearInterval, "Timeout");
+  g.clearImmediate = wrapClear(origClearImmediate, "Immediate");
+
+  // node:timers snapshots the global timer functions into its exports at eval
+  // time. If it was required before the first enable(), those exports still
+  // point at the unwrapped natives; rewrite them so
+  // require("node:timers").setTimeout(...) also fires hooks regardless of load
+  // order. node:timers/promises captures the globals in module-level consts at
+  // load time and is a known gap.
+  try {
+    const timersMod = require("node:timers");
+    timersMod.setTimeout = g.setTimeout;
+    timersMod.setInterval = g.setInterval;
+    timersMod.setImmediate = g.setImmediate;
+    timersMod.clearTimeout = g.clearTimeout;
+    timersMod.clearInterval = g.clearInterval;
+    timersMod.clearImmediate = g.clearImmediate;
+  } catch {}
+}
+
 function createHook(hook) {
   validateObject(hook, "hook");
   const { init, before, after, destroy, promiseResolve } = hook;
@@ -376,12 +583,18 @@ function createHook(hook) {
   if (promiseResolve !== undefined && typeof promiseResolve !== "function")
     throw $ERR_ASYNC_CALLBACK("hook.promiseResolve");
 
+  // Drives timer emission; the same object identity removes the hook on
+  // disable(). promiseResolve is intentionally absent (never delivered). Note
+  // `init` also lives in `enabledInit` below: the two paths are independent
+  // (this record's `init` fires for timer resources, `enabledInit` fires for
+  // process.nextTick), so a given resource only ever triggers one of them.
+  const timerRecord = { init, before, after, destroy };
   let enabledInit;
+  let timerRegistered = false;
   return {
     enable() {
       if (init !== undefined && enabledInit === undefined) {
-        // init is delivered for TickObject resources (process.nextTick);
-        // other resource types are still unimplemented.
+        // init is delivered for TickObject resources (process.nextTick).
         // Per-instance wrapper: two hooks registered with the same init
         // function must stay independently removable (removal is by
         // identity, and removing the other instance's entry would reorder
@@ -389,8 +602,15 @@ function createHook(hook) {
         enabledInit = (asyncId, type, triggerAsyncId, resource) => init(asyncId, type, triggerAsyncId, resource);
         require("internal/async_hooks_tick").tickInitHooks.push(enabledInit);
       }
+      // Timers deliver the full init/before/after/destroy lifecycle via the
+      // globals wrapped lazily here.
+      if (!timerRegistered) {
+        timerRegistered = true;
+        timerHooks.push(timerRecord);
+        installTimerHooks();
+      }
       if (before !== undefined || after !== undefined || destroy !== undefined || promiseResolve !== undefined) {
-        createHookNotImpl(hook);
+        createHookPartialWarning(hook);
       }
       hasEnabledCreateHook = true;
       if (!this[kHookEnabled]) {
@@ -406,6 +626,11 @@ function createHook(hook) {
         if (idx !== -1) hooks.splice(idx, 1);
         enabledInit = undefined;
       }
+      if (timerRegistered) {
+        timerRegistered = false;
+        const idx = timerHooks.indexOf(timerRecord);
+        if (idx !== -1) timerHooks.splice(idx, 1);
+      }
       if (this[kHookEnabled]) {
         this[kHookEnabled] = false;
         require("internal/async_hooks").markHookDisabled();
@@ -415,16 +640,15 @@ function createHook(hook) {
   };
 }
 
-const executionAsyncIdNotImpl = createWarning(
-  "async_hooks.executionAsyncId/triggerAsyncId are not implemented in Bun. It will return 0 every time.",
-);
+// Returns the async id of the resource currently executing. Meaningful inside
+// a timer callback (the timer's asyncId) and 0 elsewhere, since only timers are
+// instrumented so far.
 function executionAsyncId() {
-  executionAsyncIdNotImpl();
-  return 0;
+  return currentExecutionAsyncId;
 }
 
 function triggerAsyncId() {
-  return 0;
+  return currentTriggerAsyncId;
 }
 
 const executionAsyncResourceWarning = createWarning(

--- a/test/js/node/async_hooks/createHook-timers.test.ts
+++ b/test/js/node/async_hooks/createHook-timers.test.ts
@@ -1,0 +1,462 @@
+// Issue #30827: `async_hooks.createHook({...}).enable()` was a no-op in Bun.
+// This file covers the partial implementation that now fires init/before/
+// after/destroy for timers (setTimeout / setInterval / setImmediate).
+//
+// The hook registration permanently wraps the global timer functions, so
+// every test spawns a fresh subprocess via `bunExe() -e '…'` to keep them
+// isolated — a hook registered by one test would otherwise leak into the
+// next one.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+async function runScript(script: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+test.concurrent("createHook fires init+destroy for setImmediate cancelled with clearImmediate", async () => {
+  // Log from a DIFFERENT callback than the timer whose after/destroy we
+  // want to observe — otherwise the log runs inside that timer's
+  // before/after window and misses its own trailing events.
+  const { stdout, stderr, exitCode } = await runScript(`
+      const async_hooks = require('async_hooks');
+      const events = [];
+      async_hooks.createHook({
+        init: (id, type) => events.push(['init', type]),
+        before: (id) => events.push(['before']),
+        after: (id) => events.push(['after']),
+        destroy: (id) => events.push(['destroy']),
+      }).enable();
+
+      const t = setImmediate(() => { events.push(['ran']); });
+      clearImmediate(t);
+
+      setTimeout(() => {
+        // Schedule the print outside the setTimeout's before/after scope.
+        setImmediate(() => setImmediate(() => {
+          console.log(JSON.stringify(events));
+        }));
+      }, 20);
+    `);
+  expect(stderr).toBe("");
+  // The setImmediate was cleared before it could run, so we never see
+  // ran for it — but we do see init + destroy.
+  const parsed = JSON.parse(stdout.trim());
+  expect(parsed).toContainEqual(["init", "Immediate"]);
+  expect(parsed).toContainEqual(["destroy"]);
+  expect(parsed).not.toContainEqual(["ran"]);
+  // The Immediate's destroy appears before the setTimeout's before
+  // (destroy is queued on a microtask after clearImmediate, which runs
+  // before the event loop reaches the 20ms timeout).
+  const destroyIdx = parsed.findIndex(e => e[0] === "destroy");
+  const beforeIdx = parsed.findIndex(e => e[0] === "before");
+  expect(destroyIdx).toBeLessThan(beforeIdx);
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("createHook fires init+before+after+destroy for setTimeout that fires", async () => {
+  const { stdout, stderr, exitCode } = await runScript(`
+      const async_hooks = require('async_hooks');
+      const events = [];
+      let timeoutId = null;
+      async_hooks.createHook({
+        init: (id, type) => {
+          if (type === 'Timeout' && timeoutId == null) timeoutId = id;
+          events.push(['init', id, type]);
+        },
+        before: (id) => events.push(['before', id]),
+        after: (id) => events.push(['after', id]),
+        destroy: (id) => events.push(['destroy', id]),
+      }).enable();
+
+      setTimeout(() => {
+        events.push(['cb', timeoutId]);
+        // Let after + destroy flush before printing.
+        setImmediate(() => setImmediate(() => {
+          console.log(JSON.stringify(events));
+        }));
+      }, 10);
+    `);
+  expect(stderr).toBe("");
+  const parsed = JSON.parse(stdout.trim());
+  const cbEvent = parsed.find(e => e[0] === "cb");
+  expect(cbEvent).toBeDefined();
+  const timeoutId = cbEvent[1];
+  // Init for the outer setTimeout precedes before+cb+after for the same id.
+  const initIdx = parsed.findIndex(e => e[0] === "init" && e[1] === timeoutId);
+  const beforeIdx = parsed.findIndex(e => e[0] === "before" && e[1] === timeoutId);
+  const cbIdx = parsed.findIndex(e => e[0] === "cb");
+  const afterIdx = parsed.findIndex(e => e[0] === "after" && e[1] === timeoutId);
+  const destroyIdx = parsed.findIndex(e => e[0] === "destroy" && e[1] === timeoutId);
+  expect(initIdx).toBeGreaterThanOrEqual(0);
+  expect(beforeIdx).toBeGreaterThan(initIdx);
+  expect(cbIdx).toBeGreaterThan(beforeIdx);
+  expect(afterIdx).toBeGreaterThan(cbIdx);
+  expect(destroyIdx).toBeGreaterThan(afterIdx);
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("createHook matches the issue #30827 expected output for Immediate+Timeout", async () => {
+  // Reproduces the issue body verbatim (modulo `process._rawDebug` — Bun
+  // doesn't implement it, so we use `console.log`). Expected Node output
+  // was: init 2 Immediate / init 3 Timeout / destroy 2 / before 3 /
+  // after 3 / destroy 3. We print from a nested setImmediate so the
+  // setTimeout's own after/destroy can be observed first.
+  const { stdout, stderr, exitCode } = await runScript(`
+      const async_hooks = require('async_hooks');
+      const out = [];
+      async_hooks.createHook({
+        init:    (id, provider) => out.push('init ' + provider),
+        before:  (id) => out.push('before'),
+        after:   (id) => out.push('after'),
+        destroy: (id) => out.push('destroy'),
+      }).enable();
+
+      const timerId1 = setImmediate(() => {
+        out.push('setImmediate-cb');
+      });
+      clearImmediate(timerId1);
+
+      setTimeout(() => {
+        setImmediate(() => setImmediate(() => {
+          console.log(out.join('\\n'));
+        }));
+      }, 20);
+    `);
+  expect(stderr).toBe("");
+  const lines = stdout.trim().split("\n");
+  // The cleared setImmediate never runs.
+  expect(lines).not.toContain("setImmediate-cb");
+  // The sequence must contain: init Immediate, init Timeout, destroy
+  // (of the Immediate), before, after (of the Timeout) — in that order.
+  const initImm = lines.indexOf("init Immediate");
+  const initTim = lines.indexOf("init Timeout");
+  const firstDestroy = lines.indexOf("destroy");
+  const firstBefore = lines.indexOf("before");
+  const firstAfter = lines.indexOf("after");
+  expect(initImm).toBeGreaterThanOrEqual(0);
+  expect(initTim).toBeGreaterThanOrEqual(0);
+  expect(firstDestroy).toBeGreaterThanOrEqual(0);
+  expect(firstBefore).toBeGreaterThanOrEqual(0);
+  expect(firstAfter).toBeGreaterThanOrEqual(0);
+  // init fires synchronously at creation, and the Immediate is created before
+  // the Timeout, so `init Immediate` must precede `init Timeout` — the exact
+  // order in the issue's expected output.
+  expect(initImm).toBeLessThan(initTim);
+  expect(initImm).toBeLessThan(firstDestroy);
+  expect(initTim).toBeLessThan(firstDestroy);
+  expect(firstDestroy).toBeLessThan(firstBefore);
+  expect(firstBefore).toBeLessThan(firstAfter);
+  // This program creates no process.nextTick resources, so Node emits no
+  // TickObject init. The internal destroy batching must not leak one either
+  // (it schedules via queueMicrotask, not process.nextTick, which would be
+  // reported back through the tickInitHooks bridge as a bogus TickObject).
+  expect(lines).not.toContain("init TickObject");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("createHook fires init+before+after per tick for setInterval", async () => {
+  // Log from two nested setImmediates so every before/after pair is
+  // observed before the print — including after/destroy of the interval.
+  const { stdout, stderr, exitCode } = await runScript(`
+    const async_hooks = require('async_hooks');
+    const events = [];
+    const intervalAsyncId = { value: null };
+    async_hooks.createHook({
+      init: (id, type) => {
+        if (type === 'Timeout' && intervalAsyncId.value == null) {
+          intervalAsyncId.value = id;
+        }
+        events.push(['init', id, type]);
+      },
+      before: (id) => events.push(['before', id]),
+      after: (id) => events.push(['after', id]),
+      destroy: (id) => events.push(['destroy', id]),
+    }).enable();
+
+    let ticks = 0;
+    const id = setInterval(() => {
+      events.push(['tick', ++ticks]);
+      if (ticks === 3) {
+        clearInterval(id);
+        setTimeout(() => {
+          setImmediate(() => setImmediate(() => {
+            console.log(JSON.stringify({ events, intervalId: intervalAsyncId.value }));
+          }));
+        }, 10);
+      }
+    }, 5);
+  `);
+  expect(stderr).toBe("");
+  const { events, intervalId } = JSON.parse(stdout.trim());
+  // Each interval tick has a matching before/after pair scoped to the
+  // interval's own async id.
+  const tickIndices = events.map((e, i) => (e[0] === "tick" ? i : -1)).filter(i => i !== -1);
+  expect(tickIndices).toHaveLength(3);
+  for (const tickIdx of tickIndices) {
+    // The tick must be bracketed by a before/after pair for the interval
+    // — but the body of the tick may itself spawn other timers (before
+    // `after` fires) so we scan outward rather than expecting immediate
+    // neighbours.
+    const beforeIdx = findLastIndex(events.slice(0, tickIdx), e => e[0] === "before" && e[1] === intervalId);
+    const afterIdx = events.findIndex((e, i) => i > tickIdx && e[0] === "after" && e[1] === intervalId);
+    expect(beforeIdx).toBeGreaterThanOrEqual(0);
+    expect(afterIdx).toBeGreaterThan(tickIdx);
+  }
+  // The interval had exactly one init (it's not re-initialized per tick).
+  const intervalInits = events.filter(e => e[0] === "init" && e[1] === intervalId);
+  expect(intervalInits).toHaveLength(1);
+  // After clearInterval, destroy must fire for the interval.
+  expect(events).toContainEqual(["destroy", intervalId]);
+  expect(exitCode).toBe(0);
+});
+
+// Array.prototype.findLastIndex polyfill for clarity in the interval test.
+function findLastIndex<T>(arr: T[], pred: (e: T) => boolean): number {
+  for (let i = arr.length - 1; i >= 0; i--) {
+    if (pred(arr[i])) return i;
+  }
+  return -1;
+}
+
+test.concurrent("createHook can be disabled to stop emitting events", async () => {
+  const { stdout, stderr, exitCode } = await runScript(`
+    const async_hooks = require('async_hooks');
+    const events = [];
+    const h = async_hooks.createHook({
+      init: (id, type) => events.push(['init', type]),
+    });
+    h.enable();
+    setTimeout(() => {}, 5);     // should emit init
+    h.disable();
+    setTimeout(() => {}, 10);    // should NOT emit init
+    setTimeout(() => {
+      console.log(JSON.stringify(events));
+    }, 30);
+  `);
+  expect(stderr).toBe("");
+  const parsed = JSON.parse(stdout.trim());
+  // Exactly one init: the first setTimeout. The one after .disable() plus
+  // the tail setTimeout (which fires the log) are both while the hook is
+  // disabled.
+  const inits = parsed.filter(e => e[0] === "init");
+  expect(inits).toEqual([["init", "Timeout"]]);
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent(
+  "createHook: mismatched clear APIs are no-ops (clearTimeout(Immediate) / clearImmediate(Timeout))",
+  async () => {
+    // Node pairs clearTimeout/clearInterval ↔ Timeout and clearImmediate ↔
+    // Immediate strictly — mismatched clears do NOT cancel the timer and
+    // therefore must not emit a `destroy` event. The `kTimerKind` guard
+    // inside `installTimerHooks` pins this behavior.
+    const { stdout, stderr, exitCode } = await runScript(`
+      const async_hooks = require('async_hooks');
+      const events = [];
+      async_hooks.createHook({
+        init: (id, type) => events.push(['init', id, type]),
+        before: (id) => events.push(['before', id]),
+        after: (id) => events.push(['after', id]),
+        destroy: (id) => events.push(['destroy', id]),
+      }).enable();
+
+      const imm = setImmediate(() => { events.push(['imm ran']); });
+      clearTimeout(imm);   // wrong API — must be a no-op, imm still fires
+
+      const tim = setTimeout(() => { events.push(['tim ran']); }, 10);
+      clearImmediate(tim); // wrong API — must be a no-op, tim still fires
+
+      setTimeout(() => {
+        setImmediate(() => setImmediate(() => {
+          console.log(JSON.stringify(events));
+        }));
+      }, 50);
+    `);
+    expect(stderr).toBe("");
+    const parsed = JSON.parse(stdout.trim());
+    // Both timers STILL FIRE because the clears used the wrong API.
+    expect(parsed).toContainEqual(["imm ran"]);
+    expect(parsed).toContainEqual(["tim ran"]);
+    // Crucially: for each timer there must be exactly ONE destroy (fired
+    // after the timer ran), not two (one spurious from the wrong-API clear
+    // plus one after firing). Find the async ids from init events and count.
+    const immEvent = parsed.find(e => e[0] === "init" && e[2] === "Immediate");
+    const timEvent = parsed.find(e => e[0] === "init" && e[2] === "Timeout");
+    expect(immEvent).toBeDefined();
+    expect(timEvent).toBeDefined();
+    const immId = immEvent![1];
+    const timId = timEvent![1];
+    const destroysForImm = parsed.filter(e => e[0] === "destroy" && e[1] === immId);
+    const destroysForTim = parsed.filter(e => e[0] === "destroy" && e[1] === timId);
+    expect(destroysForImm).toHaveLength(1);
+    expect(destroysForTim).toHaveLength(1);
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.concurrent(
+  "createHook fires events for require('node:timers').setTimeout regardless of module-load order",
+  async () => {
+    // `node:timers` snapshots the global timer functions into its default
+    // export at evaluation time. A dependency `require()`ing the module
+    // BEFORE the user enables hooks would otherwise leave those exports
+    // pointing at the unwrapped natives. `installTimerHooks` writes its
+    // wrappers back into the module's exports to close this gap.
+    const { stdout, stderr, exitCode } = await runScript(`
+    // Load node:timers FIRST so it snapshots the natives before .enable().
+    const timers = require('node:timers');
+    const async_hooks = require('async_hooks');
+    const events = [];
+    async_hooks.createHook({
+      init: (id, type) => events.push(['init', id, type]),
+      before: (id) => events.push(['before', id]),
+      after: (id) => events.push(['after', id]),
+      destroy: (id) => events.push(['destroy', id]),
+    }).enable();
+
+    // Call via the module export — must still emit lifecycle events.
+    timers.setTimeout(() => { events.push(['timers-cb']); }, 10);
+
+    // Give the timer room to fire, then print.
+    setTimeout(() => {
+      setImmediate(() => setImmediate(() => {
+        console.log(JSON.stringify(events));
+      }));
+    }, 40);
+  `);
+    expect(stderr).toBe("");
+    const parsed = JSON.parse(stdout.trim());
+    // The module-export call must fire init.
+    const timersCbIdx = parsed.findIndex(e => e[0] === "timers-cb");
+    expect(timersCbIdx).toBeGreaterThanOrEqual(0);
+    // Walk backwards from the callback invocation: the nearest prior
+    // 'before' is the before for the timers.setTimeout timer. If the
+    // wrapper was bypassed, timers-cb would sit outside any before/after.
+    const beforeTimersIdx = findLastIndex(parsed.slice(0, timersCbIdx), e => e[0] === "before");
+    expect(beforeTimersIdx).toBeGreaterThanOrEqual(0);
+    const timerAsyncId = parsed[beforeTimersIdx][1];
+    // And the matching after must be just past the callback.
+    const afterIdx = parsed.findIndex((e, i) => i > timersCbIdx && e[0] === "after" && e[1] === timerAsyncId);
+    expect(afterIdx).toBeGreaterThan(timersCbIdx);
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.concurrent("createHook: references captured before .enable() bypass the hook layer", async () => {
+  // Known limitation, documented in `installTimerHooks`: wrapping is
+  // installed on `globalThis` lazily on the first `.enable()`. A caller
+  // that captured the original reference earlier keeps the unwrapped
+  // function. Pinning this here so a future opt-in to lower-level
+  // interception is a conscious choice, not an accidental regression.
+  const { stdout, stderr, exitCode } = await runScript(`
+    const async_hooks = require('async_hooks');
+    // Capture BEFORE enabling the hook.
+    const capturedSetTimeout = setTimeout;
+
+    const events = [];
+    async_hooks.createHook({
+      init: (id, type) => events.push(['init', type]),
+      before: (id) => events.push(['before']),
+      after: (id) => events.push(['after']),
+      destroy: (id) => events.push(['destroy']),
+    }).enable();
+
+    // Called via the captured reference — bypasses the hook wrapper.
+    capturedSetTimeout(() => { events.push(['captured-cb']); }, 10);
+
+    // Also call via the global so we can confirm the wrapper is active.
+    setTimeout(() => {
+      setImmediate(() => setImmediate(() => {
+        console.log(JSON.stringify(events));
+      }));
+    }, 40);
+  `);
+  expect(stderr).toBe("");
+  const parsed = JSON.parse(stdout.trim());
+  // The captured-reference callback ran…
+  expect(parsed).toContainEqual(["captured-cb"]);
+  // …but no lifecycle events were emitted for it. The only inits we see
+  // are for the timers created after .enable() via the wrapped global
+  // (the outer setTimeout(…, 40) and the two nested setImmediates).
+  const inits = parsed.filter(e => e[0] === "init");
+  // Nothing should be "Immediate" pre-.enable() capture; we only created
+  // a setTimeout via the captured reference. If the wrapper had run for
+  // that call, inits would contain TWO "Timeout" entries (captured + tail)
+  // instead of one.
+  const timeoutInits = inits.filter(e => e[1] === "Timeout");
+  expect(timeoutInits).toHaveLength(1);
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("createHook: util.promisify(setTimeout) still resolves after .enable() (no regression)", async () => {
+  // Regression guard: `internal/promisify.ts` defines
+  // `Symbol.for("nodejs.util.promisify.custom")` on the native
+  // `globalThis.setTimeout`/`setImmediate`/`setInterval` at load time. Our
+  // wrapper is a brand-new function; if it doesn't forward that symbol
+  // onto itself, `util.promisify(setTimeout)` falls back to the generic
+  // errback wrapper which calls `setTimeout(delay, nodeCallback)` —
+  // wrong arg order — and the promise never resolves.
+  const { stdout, stderr, exitCode } = await runScript(`
+    const util = require('node:util');
+    const async_hooks = require('async_hooks');
+    async_hooks.createHook({ init: () => {} }).enable();
+
+    const sleep = util.promisify(setTimeout);
+    const sleepImm = util.promisify(setImmediate);
+
+    (async () => {
+      // Unref() the watchdogs so the subprocess exits as soon as the test's
+      // useful work is done — otherwise these ref'd 1s timers gate the whole
+      // subprocess's wall-clock on success.
+      const value = await Promise.race([
+        sleep(30, 'hello'),
+        new Promise((_, r) => setTimeout(() => r(new Error('TIMEOUT')), 1000).unref()),
+      ]);
+      const immValue = await Promise.race([
+        sleepImm('world'),
+        new Promise((_, r) => setTimeout(() => r(new Error('TIMEOUT imm')), 1000).unref()),
+      ]);
+      console.log(JSON.stringify({ value, immValue }));
+    })();
+  `);
+  expect(stderr).toBe("");
+  const parsed = JSON.parse(stdout.trim());
+  // Without the `promisify.custom` symbol forwarding, promisify falls back
+  // to the errback wrapper and `sleep(30, 'hello')` never resolves to
+  // 'hello' — the TIMEOUT racer wins and stderr is non-empty. Resolving
+  // to the exact passed-through value is the condition that proves the fix.
+  expect(parsed.value).toBe("hello");
+  expect(parsed.immValue).toBe("world");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("createHook validates hook shape (preserved pre-existing behavior)", async () => {
+  // This is the only async_hooks.createHook test that existed before
+  // #30827 — keep it green. `ERR_ASYNC_CALLBACK` must be thrown for any
+  // non-function hook property.
+  const { stdout, stderr, exitCode } = await runScript(`
+    const async_hooks = require('async_hooks');
+    const assert = require('assert');
+    const bad = [null, -1, 1, {}, []];
+    for (const name of ['init', 'before', 'after', 'destroy', 'promiseResolve']) {
+      for (const value of bad) {
+        assert.throws(
+          () => async_hooks.createHook({ [name]: value }),
+          { code: 'ERR_ASYNC_CALLBACK', name: 'TypeError' },
+        );
+      }
+    }
+    console.log('ok');
+  `);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Issue

[#30827](https://github.com/oven-sh/bun/issues/30827) — `async_hooks.createHook({...}).enable()` emitted no lifecycle events for timers. The repro from the report:

```js
const async_hooks = require('async_hooks');
async_hooks.createHook({
  init:    (id, type) => process._rawDebug('init', id, type),
  before:  (id) => process._rawDebug('before', id),
  after:   (id) => process._rawDebug('after', id),
  destroy: (id) => process._rawDebug('destroy', id),
}).enable();

const timerId1 = setImmediate(() => {});
clearImmediate(timerId1);
setTimeout(() => {}, 1000);
```

produced no output. Node emits `init Immediate / init Timeout / destroy / before / after / destroy`, which this branch now matches exactly.

## Cause

`createHook` delivers `init` for `TickObject` resources (`process.nextTick`) through the `tickInitHooks` bridge, but timers are not instrumented, so `setTimeout`/`setInterval`/`setImmediate` fire no `init`/`before`/`after`/`destroy`.

## Fix

Layer timer support on top of the existing `tickInitHooks` framework rather than replacing it:

- The first `.enable()` wraps the six global timer functions (`setTimeout`/`setInterval`/`setImmediate` + the three `clear*`). Each wrapper assigns an async id from the shared `newAsyncId()` counter (so timer and tick ids never collide), emits `init` at creation, `before`/`after` around the callback, and batches `destroy` onto a trailing microtask.
- The destroy flush is scheduled with `queueMicrotask`, not `process.nextTick`, so the internal flush is not reported back through the `tickInitHooks` init bridge as a spurious `init(TickObject)`. It still trails `after()`.
- `clearTimeout`/`clearInterval` pair with `Timeout` handles and `clearImmediate` with `Immediate` handles; a mismatched clear is a no-op and emits no `destroy`, matching Node.
- A throwing hook callback is fatal (`console.error(stack)` then `process.exit(1)`), matching Node's `fatalError` and Bun's existing `TickObject` path, so timer and tick hooks behave consistently.
- The wrapper returns the native Timer/Immediate object untouched, and forwards `util.promisify.custom` so `util.promisify(setTimeout)` keeps resolving. `node:timers` exports are rewritten to the wrappers so `require("node:timers").setTimeout(...)` also fires hooks regardless of load order.
- The `process.nextTick` init path is left exactly as it was. With no hook enabled the globals are untouched: zero overhead.
- `executionAsyncId()`/`triggerAsyncId()` now return the running timer's id inside a timer callback (0 elsewhere, matching the `AsyncResource.asyncId()` stub).

### Known limits

Timers only: promises, FS, and network handles still emit nothing, and `promiseResolve` is never delivered (a one-time warning under `BUN_FEATURE_FLAG_VERBOSE_WARNINGS` notes this). A reference captured before `.enable()` keeps the unwrapped native and bypasses the wrapper; Node has the same property. The public `set*`/`clear*` pairs are covered, but cancelling or rescheduling a timer through an internal mechanism instead (a numeric-id clear, `.refresh()`, `Symbol.dispose`, `_onTimeout`, `.close()`, or mutating `_repeat`) may not emit a matching `destroy`. These are noted as a grouped follow-up so a future lower-level interception is a conscious opt-in.

## Tests

`test/js/node/async_hooks/createHook-timers.test.ts`, 10 cases (each in a fresh subprocess since the wrappers replace globals process-wide): the #30827 repro verbatim (asserting the exact `init Immediate / init Timeout / destroy / before / after / destroy` order and no leaked `init TickObject`), `setTimeout`/`setImmediate`/`setInterval` lifecycle ordering, cancellation, `.disable()`, mismatched-clear no-op, `node:timers` load order, the captured-reference limit, `util.promisify(setTimeout)` resolving, and `ERR_ASYNC_CALLBACK` validation.

- Fail-before on `USE_SYSTEM_BUN=1`: 8/10 fail (the other 2 are pure validation assertions); all 10 pass on this branch.
- `test/js/node/async_hooks/` still green: 121 pass, 0 fail, 3 pre-existing todos.
- Vendored `test-stream-writable-samecb-singletick` (tick-coalescing) and `test-async-hooks-recursive-stack-runInAsyncScope` (`executionAsyncId` invariant) still pass.

## Rebase note

Main recently grew its own `createHook` init bridge ([#31826](https://github.com/oven-sh/bun/pull/31826): `internal/async_hooks_tick.ts` + `internal/async_hooks.ts`). This branch was rebased onto it and the timer work re-applied as an additive layer on top of that bridge, not a replacement. The diff is four files: `src/js/node/async_hooks.ts`, the test, and one-comment accuracy fixes in `src/js/internal/async_hooks_tick.ts` and `src/js/internal/async_hooks.ts`.