### PR TITLE
Report exceptions from DeferredWorkTimer tasks as uncaught

### DIFF
--- a/src/codegen/bake-codegen.ts
+++ b/src/codegen/bake-codegen.ts
@@ -53,7 +53,7 @@ async function run() {
           side: JSON.stringify(side),
           IS_ERROR_RUNTIME: String(file === "error"),
           IS_BUN_DEVELOPMENT: String(!!debug),
-          OVERLAY_CSS: css("../runtime/bake/client/overlay.css", !!debug),
+          OVERLAY_CSS: JSON.stringify(css("../runtime/bake/client/overlay.css", !!debug)),
         },
         minify: {
           syntax: !debug,

--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -90,7 +90,7 @@ static void runPendingWork(void* bunVM, Bun::JSCTaskScheduler& scheduler, JSCDef
 
     if (pendingTicket && !pendingTicket->isCancelled()) {
         auto& vm = job->vm();
-        auto* globalObject = job->ticket->target()->realm();
+        auto* globalObject = defaultGlobalObject(job->ticket->target()->realm());
         auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         job->task(job->ticket.ptr());
         if (JSC::Exception* exception = scope.exception()) {

--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -2,6 +2,7 @@
 #include <JavaScriptCore/VM.h>
 #include "JSCTaskScheduler.h"
 #include "BunClientData.h"
+#include "ZigGlobalObject.h"
 
 using Ticket = JSC::DeferredWorkTimer::Ticket;
 using Task = JSC::DeferredWorkTimer::Task;
@@ -87,7 +88,14 @@ static void runPendingWork(void* bunVM, Bun::JSCTaskScheduler& scheduler, JSCDef
     holder.unlockEarly();
 
     if (pendingTicket && !pendingTicket->isCancelled()) {
+        auto& vm = job->vm();
+        auto* globalObject = job->ticket->target()->realm();
+        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         job->task(job->ticket.ptr());
+        if (JSC::Exception* exception = scope.exception()) {
+            if (scope.clearExceptionExceptTermination())
+                Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        }
     }
 
     delete job;

--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -1,5 +1,6 @@
 #include "config.h"
 #include <JavaScriptCore/VM.h>
+#include <JavaScriptCore/DeferredWorkTimerInlines.h>
 #include "JSCTaskScheduler.h"
 #include "BunClientData.h"
 #include "ZigGlobalObject.h"

--- a/test/js/bun/util/finalization-registry-throwing-callback.test.ts
+++ b/test/js/bun/util/finalization-registry-throwing-callback.test.ts
@@ -1,6 +1,13 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
+function stripAsanWarnings(s: string) {
+  return s
+    .split("\n")
+    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+}
+
 test("FinalizationRegistry callback that throws does not crash the process", async () => {
   // A FinalizationRegistry cleanup callback runs from a JSC DeferredWorkTimer
   // task. If the callback throws, the exception must be reported as an
@@ -13,8 +20,10 @@ test("FinalizationRegistry callback that throws does not crash the process", asy
       `
         const fr = new FinalizationRegistry(ArrayBuffer);
         (() => { fr.register({}, "held"); })();
-        Bun.gc(true);
-        setImmediate(() => {});
+        for (let i = 0; i < 30; i++) {
+          Bun.gc(true);
+          await new Promise(r => setImmediate(r));
+        }
       `,
     ],
     env: bunEnv,
@@ -39,8 +48,10 @@ test("FinalizationRegistry callback that throws is catchable via uncaughtExcepti
         });
         const fr = new FinalizationRegistry(() => { throw new Error("boom"); });
         (() => { fr.register({}, 1); })();
-        Bun.gc(true);
-        setImmediate(() => {});
+        for (let i = 0; i < 30; i++) {
+          Bun.gc(true);
+          await new Promise(r => setImmediate(r));
+        }
       `,
     ],
     env: bunEnv,
@@ -49,7 +60,7 @@ test("FinalizationRegistry callback that throws is catchable via uncaughtExcepti
   });
 
   const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(err).toBe("");
+  expect(stripAsanWarnings(err)).toBe("");
   expect(out).toContain("caught:boom");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/util/finalization-registry-throwing-callback.test.ts
+++ b/test/js/bun/util/finalization-registry-throwing-callback.test.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("FinalizationRegistry callback that throws does not crash the process", async () => {
+  // A FinalizationRegistry cleanup callback runs from a JSC DeferredWorkTimer
+  // task. If the callback throws, the exception must be reported as an
+  // uncaught exception rather than leaking past the task runner (which would
+  // trip an exception-scope assertion in debug builds).
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const fr = new FinalizationRegistry(ArrayBuffer);
+        (() => { fr.register({}, "held"); })();
+        Bun.gc(true);
+        setImmediate(() => {});
+      `,
+    ],
+    env: bunEnv,
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+
+  const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(err).not.toContain("ASSERTION");
+  expect(err).toContain("calling ArrayBuffer constructor without new is invalid");
+  expect(exitCode).toBeLessThan(128);
+});
+
+test("FinalizationRegistry callback that throws is catchable via uncaughtException", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        process.on("uncaughtException", (err) => {
+          console.log("caught:" + err.message);
+        });
+        const fr = new FinalizationRegistry(() => { throw new Error("boom"); });
+        (() => { fr.register({}, 1); })();
+        Bun.gc(true);
+        setImmediate(() => {});
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(err).toBe("");
+  expect(out).toContain("caught:boom");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/util/finalization-registry-throwing-callback.test.ts
+++ b/test/js/bun/util/finalization-registry-throwing-callback.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 test("FinalizationRegistry callback that throws does not crash the process", async () => {

--- a/test/js/bun/util/finalization-registry-throwing-callback.test.ts
+++ b/test/js/bun/util/finalization-registry-throwing-callback.test.ts
@@ -23,9 +23,9 @@ test("FinalizationRegistry callback that throws does not crash the process", asy
   });
 
   const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-  expect(err).not.toContain("ASSERTION");
   expect(err).toContain("calling ArrayBuffer constructor without new is invalid");
   expect(exitCode).toBeLessThan(128);
+  expect(proc.signalCode).toBeNull();
 });
 
 test("FinalizationRegistry callback that throws is catchable via uncaughtException", async () => {


### PR DESCRIPTION
When a `FinalizationRegistry` cleanup callback (or any other `DeferredWorkTimer` task) throws, the exception was leaking out of `Bun__runDeferredWork`. In debug/ASAN builds this trips the caller's `assertNoExceptionExceptTermination()` in `JSCDeferredWorkTask::run`:

```
ASSERTION FAILED: Unexpected exception observed
!exception()
ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
```

### Repro

```js
const fr = new FinalizationRegistry(ArrayBuffer);
(() => { fr.register({}, "held"); })();
Bun.gc(true);
setImmediate(() => {});
```

`ArrayBuffer` is callable so it passes the `FinalizationRegistry` constructor check, but throws when invoked without `new`. Any throwing cleanup callback reproduces.

### Fix

Match JSC's own `DeferredWorkTimer::doWork`: wrap the task invocation in a `TopExceptionScope` and, if a non-termination exception is pending afterward, clear it and report it via `reportUncaughtExceptionAtEventLoop`. This routes the error through `process.on("uncaughtException")` as Node does.

Found by Fuzzilli (fingerprint `bfc05fc36c3ce2cf`).