### PR TITLE
nix: fix development shell on macos

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -120,9 +120,7 @@
           pkgs.gdk-pixbuf
         ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
           # macOS specific dependencies
-          pkgs.darwin.apple_sdk.frameworks.CoreFoundation
-          pkgs.darwin.apple_sdk.frameworks.CoreServices
-          pkgs.darwin.apple_sdk.frameworks.Security
+          pkgs.apple-sdk_11
         ];
 
       in

--- a/shell.nix
+++ b/shell.nix
@@ -74,6 +74,8 @@ pkgs.mkShell rec {
     libdrm
     xorg.libxshmfence
     gdk-pixbuf
+  ] ++ lib.optionals stdenv.isDarwin [
+    apple-sdk_11
   ];
 
   shellHook = ''


### PR DESCRIPTION
### What does this PR do?
Fixes #30834 

### How did you verify your code works?
Tested on aarch64-darwin and x86-darwin. Cargo, rustc and everything else is now in PATH again when `nix develop` is ran (or direnv is used).
Does not affect nixos/linux but I tested it nonetheless to make sure.