### PR TITLE
perf_hooks: keep mark/measure counter in sync on clear-by-name

### DIFF
--- a/src/codegen/bake-codegen.ts
+++ b/src/codegen/bake-codegen.ts
@@ -53,7 +53,7 @@ async function run() {
           side: JSON.stringify(side),
           IS_ERROR_RUNTIME: String(file === "error"),
           IS_BUN_DEVELOPMENT: String(!!debug),
-          OVERLAY_CSS: css("../runtime/bake/client/overlay.css", !!debug),
+          OVERLAY_CSS: JSON.stringify(css("../runtime/bake/client/overlay.css", !!debug)),
         },
         minify: {
           syntax: !debug,

--- a/src/jsc/bindings/webcore/PerformanceUserTiming.cpp
+++ b/src/jsc/bindings/webcore/PerformanceUserTiming.cpp
@@ -100,12 +100,13 @@ size_t PerformanceUserTiming::memoryCost() const
     return size;
 }
 
-static void clearPerformanceEntries(PerformanceEntryMap& map, const String& name)
+static void clearPerformanceEntries(PerformanceEntryMap& map, const String& name, int64_t& counter)
 {
-    if (name.isNull())
+    if (name.isNull()) {
         map.clear();
-    else
-        map.remove(name);
+        counter = 0;
+    } else
+        counter -= static_cast<int64_t>(map.take(name).size());
 }
 
 static void addPerformanceEntry(PerformanceEntryMap& map, const String& name, PerformanceEntry& entry)
@@ -135,8 +136,7 @@ ExceptionOr<Ref<PerformanceMark>> PerformanceUserTiming::mark(JSC::JSGlobalObjec
 
 void PerformanceUserTiming::clearMarks(const String& markName)
 {
-    clearPerformanceEntries(m_marksMap, markName);
-    m_markCounter = 0;
+    clearPerformanceEntries(m_marksMap, markName, m_markCounter);
 }
 
 ExceptionOr<double> PerformanceUserTiming::convertMarkToTimestamp(const std::variant<String, double>& mark) const
@@ -308,8 +308,7 @@ ExceptionOr<Ref<PerformanceMeasure>> PerformanceUserTiming::measure(JSC::JSGloba
 
 void PerformanceUserTiming::clearMeasures(const String& measureName)
 {
-    clearPerformanceEntries(m_measuresMap, measureName);
-    m_measureCounter = 0;
+    clearPerformanceEntries(m_measuresMap, measureName, m_measureCounter);
 }
 
 static Vector<RefPtr<PerformanceEntry>> convertToEntrySequence(const PerformanceEntryMap& map, int64_t initialCapacity)

--- a/test/js/web/timers/performance-entries.test.ts
+++ b/test/js/web/timers/performance-entries.test.ts
@@ -1,5 +1,61 @@
 import { estimateShallowMemoryUsageOf } from "bun:jsc";
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("getEntries after clearMarks/clearMeasures by name", () => {
+  const { exitCode, stdout, stderr, signalCode } = Bun.spawnSync({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        performance.mark("a");
+        performance.mark("a");
+        performance.mark("b");
+        performance.clearMarks("a");
+        console.log(JSON.stringify(performance.getEntriesByType("mark").map(e => e.name)));
+        performance.clearMarks("nonexistent");
+        console.log(JSON.stringify(performance.getEntriesByType("mark").map(e => e.name)));
+        performance.mark("c");
+        console.log(JSON.stringify(performance.getEntriesByType("mark").map(e => e.name).sort()));
+
+        performance.measure("m1", "b");
+        performance.measure("m2", "b");
+        performance.clearMeasures("m1");
+        console.log(JSON.stringify(performance.getEntriesByType("measure").map(e => e.name)));
+        performance.clearMeasures("nonexistent");
+        console.log(JSON.stringify(performance.getEntriesByType("measure").map(e => e.name)));
+
+        console.log(JSON.stringify(performance.getEntries().map(e => e.name).sort()));
+
+        performance.clearMarks();
+        performance.clearMeasures();
+        console.log(JSON.stringify(performance.getEntries()));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stderrText = stderr
+    .toString()
+    .split("\n")
+    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+  expect({ exitCode, signalCode, stderr: stderrText }).toEqual({
+    exitCode: 0,
+    signalCode: undefined,
+    stderr: "",
+  });
+  expect(stdout.toString().trim().split("\n")).toEqual([
+    '["b"]',
+    '["b"]',
+    '["b","c"]',
+    '["m2"]',
+    '["m2"]',
+    '["b","c","m2"]',
+    "[]",
+  ]);
+});
 
 test("memory usage of Performance", () => {
   const initial = estimateShallowMemoryUsageOf(performance);


### PR DESCRIPTION
## What does this PR do?

`performance.clearMarks(name)` and `performance.clearMeasures(name)` unconditionally reset `m_markCounter` / `m_measureCounter` to `0`, even when only removing entries for a single name. That left the underlying map with more entries than the counter claimed, and a subsequent `getEntries()` / `getEntriesByType()` tripped the debug assertion in `convertToEntrySequence`:

```
ASSERTION FAILED: entries.size() <= safeInitialCapacity
src/jsc/bindings/webcore/PerformanceUserTiming.cpp(325)
```

Repro:
```js
performance.mark("a");
performance.mark("b");
performance.clearMarks("a");
performance.getEntriesByType("mark"); // assertion fails
```

Fix: `clearPerformanceEntries` now takes the counter by reference. On a full clear it resets to `0`; on a by-name clear it subtracts the size of the removed vector (via `map.take(name).size()`), so the counter stays equal to the total number of entries.

Also included: `bake-codegen.ts` now passes `OVERLAY_CSS` via `JSON.stringify(...)` instead of relying on the `define` auto-quote fallback from 314d044c0a, so codegen works with whichever bootstrap bun happens to run it.

## How did you verify your code works?

- Repro no longer asserts under the debug build.
- Added a regression test to `test/js/web/timers/performance-entries.test.ts` covering clear-by-name for both marks and measures (including clearing a nonexistent name and multiple entries under the same name). Verified it crashes the debug build without the fix and passes with it.
- `bun bd test test/js/web/timers/performance-entries.test.ts test/js/web/timers/performance.test.js test/js/node/perf_hooks/perf_hooks.test.ts` all pass.

Found by Fuzzilli.
