### PR TITLE
Report exceptions thrown from DeferredWorkTimer tasks

### DIFF
--- a/src/codegen/bake-codegen.ts
+++ b/src/codegen/bake-codegen.ts
@@ -53,7 +53,7 @@ async function run() {
           side: JSON.stringify(side),
           IS_ERROR_RUNTIME: String(file === "error"),
           IS_BUN_DEVELOPMENT: String(!!debug),
-          OVERLAY_CSS: css("../runtime/bake/client/overlay.css", !!debug),
+          OVERLAY_CSS: JSON.stringify(css("../runtime/bake/client/overlay.css", !!debug)),
         },
         minify: {
           syntax: !debug,

--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -1,5 +1,7 @@
 #include "config.h"
 #include <JavaScriptCore/VM.h>
+#include <JavaScriptCore/GlobalObjectMethodTable.h>
+#include <JavaScriptCore/TopExceptionScope.h>
 #include "JSCTaskScheduler.h"
 #include "BunClientData.h"
 
@@ -87,7 +89,14 @@ static void runPendingWork(void* bunVM, Bun::JSCTaskScheduler& scheduler, JSCDef
     holder.unlockEarly();
 
     if (pendingTicket && !pendingTicket->isCancelled()) {
+        auto& vm = job->vm();
+        auto* globalObject = job->ticket->target()->realm();
+        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         job->task(job->ticket.ptr());
+        if (JSC::Exception* exception = scope.exception()) {
+            if (scope.clearExceptionExceptTermination())
+                globalObject->globalObjectMethodTable()->reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        }
     }
 
     delete job;

--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -1,5 +1,6 @@
 #include "config.h"
 #include <JavaScriptCore/VM.h>
+#include <JavaScriptCore/DeferredWorkTimerInlines.h>
 #include <JavaScriptCore/GlobalObjectMethodTable.h>
 #include <JavaScriptCore/TopExceptionScope.h>
 #include "JSCTaskScheduler.h"

--- a/test/js/bun/util/finalization-registry-throw.test.ts
+++ b/test/js/bun/util/finalization-registry-throw.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+describe.concurrent("FinalizationRegistry", () => {
+  const driver = (setup: string) => `
+    let caught = null;
+    process.on("uncaughtException", (err) => {
+      caught = err;
+    });
+    ${setup}
+    (function () {
+      let obj = {};
+      reg.register(obj, "held");
+      obj = null;
+    })();
+    for (let i = 0; i < 100 && !caught; i++) {
+      Bun.gc(true);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    if (!caught) throw new Error("finalizer did not run");
+    console.log("CAUGHT:" + caught.message);
+    console.log("DONE");
+  `;
+
+  test("throwing callback reports as uncaughtException instead of crashing", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", driver(`const reg = new FinalizationRegistry(() => { throw new Error("boom from finalizer"); });`)],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).toBe("");
+    expect(out).toContain("CAUGHT:boom from finalizer");
+    expect(out).toContain("DONE");
+    expect(code).toBe(0);
+  });
+
+  test("callback that is a constructor requiring new reports as uncaughtException", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", driver(`const reg = new FinalizationRegistry(ArrayBuffer);`)],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).toBe("");
+    expect(out).toContain("CAUGHT:");
+    expect(out).toContain("DONE");
+    expect(code).toBe(0);
+  });
+
+  test("unhandled throwing callback exits with non-zero code", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const reg = new FinalizationRegistry(() => { throw new Error("boom from finalizer"); });
+          (function () {
+            let obj = {};
+            reg.register(obj, "held");
+            obj = null;
+          })();
+          for (let i = 0; i < 100; i++) {
+            Bun.gc(true);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+          }
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).toContain("boom from finalizer");
+    expect(code).toBe(1);
+  });
+});

--- a/test/js/bun/util/finalization-registry-throw.test.ts
+++ b/test/js/bun/util/finalization-registry-throw.test.ts
@@ -24,7 +24,11 @@ describe.concurrent("FinalizationRegistry", () => {
 
   test("throwing callback reports as uncaughtException instead of crashing", async () => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", driver(`const reg = new FinalizationRegistry(() => { throw new Error("boom from finalizer"); });`)],
+      cmd: [
+        bunExe(),
+        "-e",
+        driver(`const reg = new FinalizationRegistry(() => { throw new Error("boom from finalizer"); });`),
+      ],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",


### PR DESCRIPTION
## What does this PR do?

`FinalizationRegistry` callbacks (and other JSC deferred-work tasks such as async Wasm compilation and `Atomics.waitAsync`) are dispatched on Bun's event loop through `JSCTaskScheduler::runPendingWork`.

Unlike JSC's own `DeferredWorkTimer::doWork`, `runPendingWork` did not catch exceptions thrown by the task. A throwing `FinalizationRegistry` callback would leave a pending exception on the VM, which then tripped the `releaseAssertNoException()` in the Rust-side `JSCDeferredWorkTask::run` wrapper, crashing the process in debug/ASAN builds.

### Fix

Catch the exception after running the task and route it through `reportUncaughtExceptionAtEventLoop` (i.e. `process.on('uncaughtException')`), matching both `DeferredWorkTimer::doWork` and Node.js. Termination exceptions are left pending for the caller to observe.

### Repro

```js
const reg = new FinalizationRegistry(() => { throw new Error("boom"); });
(function () {
  let obj = {};
  reg.register(obj, "held");
  obj = null;
})();
Bun.gc(true);
setTimeout(() => Bun.gc(true), 50);
setTimeout(() => {}, 500);
```

Before: `ASSERTION FAILED: !exception()` → SIGABRT in debug builds.
After: the error is reported via `uncaughtException` and the process exits with code 1 (or continues if the user installed a handler), matching Node.js.

Found by Fuzzilli (fingerprint `a78695a37ae6d5b1`).