### PR TITLE
Report exceptions thrown by DeferredWorkTimer tasks as uncaughtException

### DIFF
--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -1,5 +1,7 @@
 #include "config.h"
 #include <JavaScriptCore/VM.h>
+#include <JavaScriptCore/GlobalObjectMethodTable.h>
+#include <JavaScriptCore/TopExceptionScope.h>
 #include "JSCTaskScheduler.h"
 #include "BunClientData.h"
 
@@ -87,7 +89,14 @@ static void runPendingWork(void* bunVM, Bun::JSCTaskScheduler& scheduler, JSCDef
     holder.unlockEarly();
 
     if (pendingTicket && !pendingTicket->isCancelled()) {
+        auto& vm = job->vm();
+        auto* globalObject = job->ticket->target()->realm();
+        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         job->task(job->ticket.ptr());
+        if (auto* exception = scope.exception()) {
+            if (scope.clearExceptionExceptTermination())
+                globalObject->globalObjectMethodTable()->reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        }
     }
 
     delete job;

--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -1,5 +1,6 @@
 #include "config.h"
 #include <JavaScriptCore/VM.h>
+#include <JavaScriptCore/DeferredWorkTimerInlines.h>
 #include <JavaScriptCore/GlobalObjectMethodTable.h>
 #include <JavaScriptCore/TopExceptionScope.h>
 #include "JSCTaskScheduler.h"

--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -1,10 +1,10 @@
 #include "config.h"
 #include <JavaScriptCore/VM.h>
 #include <JavaScriptCore/DeferredWorkTimerInlines.h>
-#include <JavaScriptCore/GlobalObjectMethodTable.h>
 #include <JavaScriptCore/TopExceptionScope.h>
 #include "JSCTaskScheduler.h"
 #include "BunClientData.h"
+#include "ZigGlobalObject.h"
 
 using Ticket = JSC::DeferredWorkTimer::Ticket;
 using Task = JSC::DeferredWorkTimer::Task;
@@ -91,12 +91,12 @@ static void runPendingWork(void* bunVM, Bun::JSCTaskScheduler& scheduler, JSCDef
 
     if (pendingTicket && !pendingTicket->isCancelled()) {
         auto& vm = job->vm();
-        auto* globalObject = job->ticket->target()->realm();
+        auto* globalObject = defaultGlobalObject(job->ticket->target()->realm());
         auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         job->task(job->ticket.ptr());
         if (auto* exception = scope.exception()) {
             if (scope.clearExceptionExceptTermination())
-                globalObject->globalObjectMethodTable()->reportUncaughtExceptionAtEventLoop(globalObject, exception);
+                Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
         }
     }
 

--- a/test/js/bun/util/finalization-registry-throw.test.ts
+++ b/test/js/bun/util/finalization-registry-throw.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 test.concurrent("FinalizationRegistry callback that throws is reported as uncaughtException", async () => {

--- a/test/js/bun/util/finalization-registry-throw.test.ts
+++ b/test/js/bun/util/finalization-registry-throw.test.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test.concurrent("FinalizationRegistry callback that throws is reported as uncaughtException", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        let caught = null;
+        process.on("uncaughtException", (err) => {
+          caught = err;
+        });
+        const registry = new FinalizationRegistry(() => {
+          throw new Error("boom");
+        });
+        for (let i = 0; i < 1000; i++) {
+          registry.register({}, i);
+        }
+        (async () => {
+          for (let i = 0; i < 20; i++) {
+            Bun.gc(true);
+            await new Promise(r => setImmediate(r));
+            if (caught) break;
+          }
+          console.log(JSON.stringify({ caught: caught?.message ?? null }));
+        })();
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout.trim())).toEqual({ caught: "boom" });
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent(
+  "FinalizationRegistry callback that throws does not crash when triggered by generateHeapSnapshot",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          process.on("uncaughtException", () => {});
+          const registry = new FinalizationRegistry(() => {
+            ArrayBuffer();
+          });
+          (() => {
+            let obj = {};
+            registry.register(obj, "test");
+            obj = null;
+          })();
+          Bun.gc(true);
+          Bun.generateHeapSnapshot();
+          Bun.gc(true);
+          setImmediate(() => {});
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/js/bun/util/finalization-registry-throw.test.ts
+++ b/test/js/bun/util/finalization-registry-throw.test.ts
@@ -45,19 +45,25 @@ test.concurrent(
         bunExe(),
         "-e",
         `
-          process.on("uncaughtException", () => {});
+          let caught = null;
+          process.on("uncaughtException", (err) => {
+            caught = err;
+          });
           const registry = new FinalizationRegistry(() => {
             ArrayBuffer();
           });
-          (() => {
-            let obj = {};
-            registry.register(obj, "test");
-            obj = null;
+          for (let i = 0; i < 1000; i++) {
+            registry.register({}, i);
+          }
+          (async () => {
+            for (let i = 0; i < 20 && !caught; i++) {
+              Bun.gc(true);
+              Bun.generateHeapSnapshot();
+              Bun.gc(true);
+              await new Promise(r => setImmediate(r));
+            }
+            console.log(JSON.stringify({ caught: caught?.message ?? null }));
           })();
-          Bun.gc(true);
-          Bun.generateHeapSnapshot();
-          Bun.gc(true);
-          setImmediate(() => {});
         `,
       ],
       env: bunEnv,
@@ -66,7 +72,46 @@ test.concurrent(
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect(stdout).toBe("");
+    expect(JSON.parse(stdout.trim()).caught).toContain("ArrayBuffer");
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.concurrent(
+  "FinalizationRegistry callback that throws inside a node:vm context is reported as uncaughtException",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const vm = require("node:vm");
+          let caught = null;
+          process.on("uncaughtException", (err) => {
+            caught = err;
+          });
+          const ctx = vm.createContext({});
+          vm.runInContext(\`
+            globalThis.r = new FinalizationRegistry(() => { throw new Error("boom-in-vm"); });
+            for (let i = 0; i < 1000; i++) globalThis.r.register({}, i);
+          \`, ctx);
+          (async () => {
+            for (let i = 0; i < 20; i++) {
+              Bun.gc(true);
+              await new Promise(r => setImmediate(r));
+              if (caught) break;
+            }
+            console.log(JSON.stringify({ caught: caught?.message ?? null }));
+          })();
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ caught: "boom-in-vm" });
     expect(exitCode).toBe(0);
   },
 );


### PR DESCRIPTION
## What does this PR do?

Fixes a debug/ASAN assertion failure (`releaseAssertNoException`) when a `FinalizationRegistry` cleanup callback throws.

Fuzzilli fingerprint: `568b6f604bcb11d9`

```
ASSERTION FAILED: Unexpected exception observed on thread ...
Error Exception: calling ArrayBuffer constructor without new is invalid
!exception()
ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
```

### Root cause

Bun routes JSC's `DeferredWorkTimer` tasks through `Bun__runDeferredWork` → `runPendingWork`, which invoked `job->task(ticket)` with no exception handling. `JSFinalizationRegistry::runFinalizationCleanup` returns with the exception still pending when a user callback throws, so the validation scope in `JSCDeferredWorkTask::run` tripped `releaseAssertNoException()` in debug/ASAN builds. In release builds the pending exception was only caught accidentally by the post-task `drainMicrotasks()` call, which aborts the nextTick drain for that tick, and for `node:vm`-created registries it was silently dropped.

### Fix

Mirror JSC's own `DeferredWorkTimer::doWork()`: wrap the task in a `TopExceptionScope`, clear any non-termination exception after it runs, and report it via `Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(defaultGlobalObject(realm), …)` so it reaches `process.on('uncaughtException')` — matching Node.js — including when the registry lives in a `node:vm` context. Termination exceptions are left pending for the caller.

### Repro

```js
const registry = new FinalizationRegistry(() => {
  throw new Error("boom");
});
for (let i = 0; i < 1000; i++) registry.register({}, i);
for (let i = 0; i < 10; i++) {
  Bun.gc(true);
  await new Promise(r => setImmediate(r));
}
```

## How did you verify your code works?

- Added `test/js/bun/util/finalization-registry-throw.test.ts` covering the plain-GC, `generateHeapSnapshot`, and `node:vm` context trigger paths; all assert the error reaches `uncaughtException`.
- Verified all three tests fail (assertion crash / `caught: null`) on a pre-fix binary and pass with the fix.
- Verified behavior matches Node.js.

### Rebase notes

Rebased onto current main; dropped the earlier autofix.ci formatting commit (main now carries equivalent formatting) and the temporary `bake-codegen.ts` quoting workaround (no longer needed now that the define auto-quote recovery from #30679 is on main).
