### PR TITLE
sql(mysql): add foundRows option to opt into CLIENT_FOUND_ROWS

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -1407,6 +1407,28 @@ const now = await mysql`SELECT NOW() as current_time`;
 const uuid = await mysql`SELECT UUID() as id`;
 ```
 
+By default, `affectedRows` counts rows the `WHERE` clause **matched** — the
+same default as the `mysql2` and `mariadb` drivers. An `UPDATE` that matches
+a row but leaves every column untouched still reports `affectedRows: 1`. If
+you want the server's changed-rows semantics instead (where a no-op update
+returns `0`), pass `foundRows: false`:
+
+```ts
+const mysql = new SQL({
+  adapter: "mysql", // or "mariadb"
+  hostname: "localhost",
+  database: "myapp",
+  foundRows: false, // changed-rows semantics (returns 0 for no-op UPDATEs)
+});
+// Equivalently as a URL query param:
+new SQL("mysql://user:pass@localhost/db?foundRows=false");
+```
+
+This option toggles the
+[`CLIENT_FOUND_ROWS`](https://dev.mysql.com/doc/c-api/en/mysql-affected-rows.html)
+capability flag during the protocol handshake and is ignored by the Postgres
+and SQLite adapters.
+
 ### MySQL Error Handling
 
 ```ts

--- a/packages/bun-types/sql.d.ts
+++ b/packages/bun-types/sql.d.ts
@@ -410,6 +410,23 @@ declare module "bun" {
        * @default false
        */
       allowPublicKeyRetrieval?: boolean | undefined;
+
+      /**
+       * MySQL / MariaDB. When enabled, the server reports the number of rows
+       * matched by the `WHERE` clause in `affectedRows`, rather than the
+       * number of rows actually changed. This is the default behavior of the
+       * `mysql2` and `mariadb` drivers and matches what most Node.js MySQL
+       * code expects. Applies to both `adapter: "mysql"` and
+       * `adapter: "mariadb"`; no effect on `adapter: "postgres"`.
+       *
+       * Set to `false` to use the server's changed-rows semantics: an
+       * `UPDATE` that matches a row but does not change any column value
+       * will return `affectedRows: 0`.
+       *
+       * @see [CLIENT_FOUND_ROWS](https://dev.mysql.com/doc/c-api/en/mysql-affected-rows.html)
+       * @default true
+       */
+      foundRows?: boolean | undefined;
     }
 
     /**

--- a/src/codegen/bake-codegen.ts
+++ b/src/codegen/bake-codegen.ts
@@ -56,7 +56,14 @@ async function run() {
           side: JSON.stringify(side),
           IS_ERROR_RUNTIME: String(file === "error"),
           IS_BUN_DEVELOPMENT: String(!!debug),
-          OVERLAY_CSS: css("../runtime/bake/client/overlay.css", !!debug),
+          // `Bun.build` parses `define:` values as JSON. The other defines
+          // above already go through `JSON.stringify` / `String`, but the
+          // raw minified CSS starts with `*{...}` — bun versions that lack
+          // the auto-quote fallback (#30679) reject it as "Operators are
+          // not allowed in JSON". Quote explicitly so cold builds work with
+          // the older bootstrap bun (1.3.13) used in the CI Dockerfile and
+          // any pre-fix local install.
+          OVERLAY_CSS: JSON.stringify(css("../runtime/bake/client/overlay.css", !!debug)),
         },
         minify: {
           syntax: !debug,

--- a/src/codegen/bake-codegen.ts
+++ b/src/codegen/bake-codegen.ts
@@ -56,8 +56,7 @@ async function run() {
           side: JSON.stringify(side),
           IS_ERROR_RUNTIME: String(file === "error"),
           IS_BUN_DEVELOPMENT: String(!!debug),
-          // `define:` values are parsed as JSON; the CSS starts with `*{...}`,
-          // so quote it for bootstrap bun that predates #30679.
+          // quoted because bootstrap bun predating #30679 rejects raw CSS as a define value
           OVERLAY_CSS: JSON.stringify(css("../runtime/bake/client/overlay.css", !!debug)),
         },
         minify: {

--- a/src/codegen/bake-codegen.ts
+++ b/src/codegen/bake-codegen.ts
@@ -56,13 +56,8 @@ async function run() {
           side: JSON.stringify(side),
           IS_ERROR_RUNTIME: String(file === "error"),
           IS_BUN_DEVELOPMENT: String(!!debug),
-          // `Bun.build` parses `define:` values as JSON. The other defines
-          // above already go through `JSON.stringify` / `String`, but the
-          // raw minified CSS starts with `*{...}` — bun versions that lack
-          // the auto-quote fallback (#30679) reject it as "Operators are
-          // not allowed in JSON". Quote explicitly so cold builds work with
-          // the older bootstrap bun (1.3.13) used in the CI Dockerfile and
-          // any pre-fix local install.
+          // `define:` values are parsed as JSON; the CSS starts with `*{...}`,
+          // so quote it for bootstrap bun that predates #30679.
           OVERLAY_CSS: JSON.stringify(css("../runtime/bake/client/overlay.css", !!debug)),
         },
         minify: {

--- a/src/js/internal/sql/mysql.ts
+++ b/src/js/internal/sql/mysql.ts
@@ -108,6 +108,7 @@ export interface MySQLDotZig {
     maxLifetime: number,
     useUnnamedPreparedStatements: boolean,
     allowPublicKeyRetrieval: boolean,
+    foundRows: boolean,
   ) => $ZigGeneratedClasses.MySQLConnection;
   createQuery: (
     sql: string,

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -848,7 +848,8 @@ function closeNT(onClose: (err: Error) => void, err: Error | null) {
  * Resolves the password (which may be a function and/or a promise) and calls
  * the driver's native createConnection with the normalized pool options.
  * Extra trailing arguments past `useUnnamedPreparedStatements` (MySQL's
- * `allowPublicKeyRetrieval`) are ignored by drivers that don't take them.
+ * `allowPublicKeyRetrieval` and `foundRows`) are ignored by drivers that
+ * don't take them.
  */
 async function createPooledConnectionHandle<ConnectionHandle>(
   nativeCreateConnection: (...args: any[]) => ConnectionHandle,
@@ -870,6 +871,7 @@ async function createPooledConnectionHandle<ConnectionHandle>(
     prepare = true,
     path,
     allowPublicKeyRetrieval = false,
+    foundRows = true,
   } = options;
 
   let password: Bun.MaybePromise<string> | string | undefined | (() => Bun.MaybePromise<string>) = options.password;
@@ -904,6 +906,7 @@ async function createPooledConnectionHandle<ConnectionHandle>(
       maxLifetime,
       !prepare,
       !!allowPublicKeyRetrieval,
+      !!foundRows,
     );
   } catch (e) {
     // defer so the callback never runs while the adapter is still filling
@@ -1796,6 +1799,10 @@ function parseOptions(
   let bigint: boolean | undefined;
   let path: string;
   let prepare: boolean = true;
+  // MySQL-only. Defaults to `true` to match the `mysql2` and `mariadb` drivers
+  // (both enable CLIENT_FOUND_ROWS by default). Read from the options object
+  // and the URL query string below; ignored for non-MySQL adapters.
+  let foundRows: boolean = true;
 
   if (url !== null) {
     url = url instanceof URL ? url : new URL(url);
@@ -1828,6 +1835,12 @@ function parseOptions(
         }
       } else if (lowerKey === "path") {
         path = queryObject[key];
+      } else if (lowerKey === "foundrows") {
+        // Accept "false"/"0" (case-insensitive) to disable; anything else
+        // (including "true"/"1" or empty) leaves the default enabled. Only
+        // consumed by the MySQL adapter.
+        const value = `${queryObject[key]}`.toLowerCase();
+        foundRows = !(value === "false" || value === "0");
       } else {
         // this is valid for postgres for other databases it might not be valid
         // check adapter then implement for other databases
@@ -2001,6 +2014,13 @@ function parseOptions(
     prepare = false;
   }
 
+  // The options-object form wins over the URL query string. `foundRows` is
+  // only meaningful for the MySQL wire protocol (maps to CLIENT_FOUND_ROWS);
+  // for Postgres/SQLite it's a no-op.
+  if (options.foundRows !== undefined) {
+    foundRows = !!options.foundRows;
+  }
+
   onconnect ??= options.onconnect;
   onclose ??= options.onclose;
 
@@ -2101,6 +2121,7 @@ function parseOptions(
     sslMode,
     query,
     max: max || 10,
+    foundRows,
   };
 
   if (idleTimeout != null) {

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1838,7 +1838,9 @@ function parseOptions(
       } else if (lowerKey === "foundrows") {
         // Accept "false"/"0" (case-insensitive) to disable; anything else
         // (including "true"/"1" or empty) leaves the default enabled. Only
-        // consumed by the MySQL adapter.
+        // consumed by the MySQL adapter. `toJSON()` returns an array when a
+        // key appears more than once (`?foundRows=a&foundRows=b`), so coerce
+        // to a string before calling `.toLowerCase`.
         const value = `${queryObject[key]}`.toLowerCase();
         foundRows = !(value === "false" || value === "0");
       } else {

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1834,8 +1834,7 @@ function parseOptions(
       } else if (lowerKey === "path") {
         path = queryObject[key];
       } else if (lowerKey === "foundrows") {
-        // "false"/"0" disables; anything else keeps the default. `${}` handles
-        // the array `toJSON()` returns for duplicate keys.
+        // "false"/"0" disables; coerce first since toJSON() returns an array for duplicate keys
         const value = `${queryObject[key]}`.toLowerCase();
         foundRows = !(value === "false" || value === "0");
       } else {
@@ -2012,8 +2011,9 @@ function parseOptions(
   }
 
   // Options object wins over the URL query string.
-  if (options.foundRows !== undefined) {
-    foundRows = !!options.foundRows;
+  const foundRowsOption = options.foundRows;
+  if (foundRowsOption !== undefined) {
+    foundRows = !!foundRowsOption;
   }
 
   onconnect ??= options.onconnect;

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1799,9 +1799,7 @@ function parseOptions(
   let bigint: boolean | undefined;
   let path: string;
   let prepare: boolean = true;
-  // MySQL-only. Defaults to `true` to match the `mysql2` and `mariadb` drivers
-  // (both enable CLIENT_FOUND_ROWS by default). Read from the options object
-  // and the URL query string below; ignored for non-MySQL adapters.
+  // MySQL-only; defaults to `true` to match mysql2 / mariadb.
   let foundRows: boolean = true;
 
   if (url !== null) {
@@ -1836,11 +1834,8 @@ function parseOptions(
       } else if (lowerKey === "path") {
         path = queryObject[key];
       } else if (lowerKey === "foundrows") {
-        // Accept "false"/"0" (case-insensitive) to disable; anything else
-        // (including "true"/"1" or empty) leaves the default enabled. Only
-        // consumed by the MySQL adapter. `toJSON()` returns an array when a
-        // key appears more than once (`?foundRows=a&foundRows=b`), so coerce
-        // to a string before calling `.toLowerCase`.
+        // "false"/"0" disables; anything else keeps the default. `${}` handles
+        // the array `toJSON()` returns for duplicate keys.
         const value = `${queryObject[key]}`.toLowerCase();
         foundRows = !(value === "false" || value === "0");
       } else {
@@ -2016,9 +2011,7 @@ function parseOptions(
     prepare = false;
   }
 
-  // The options-object form wins over the URL query string. `foundRows` is
-  // only meaningful for the MySQL wire protocol (maps to CLIENT_FOUND_ROWS);
-  // for Postgres/SQLite it's a no-op.
+  // Options object wins over the URL query string.
   if (options.foundRows !== undefined) {
     foundRows = !!options.foundRows;
   }

--- a/src/js/private.d.ts
+++ b/src/js/private.d.ts
@@ -28,7 +28,7 @@ declare module "bun" {
     /**
      * Represents the result of the `parseOptions()` function in the postgres, mysql or mariadb path
      */
-    type DefinedPostgresOrMySQLOptions = Define<Bun.SQL.PostgresOrMySQLOptions, "max" | "prepare" | "max"> & {
+    type DefinedPostgresOrMySQLOptions = Define<Bun.SQL.PostgresOrMySQLOptions, "max" | "prepare" | "foundRows"> & {
       sslMode: import("internal/sql/shared").SSLMode;
       query: string;
     };

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -501,8 +501,8 @@ impl JSMySQLConnection {
         let _ = use_unnamed_prepared_statements;
         let allow_public_key_retrieval = callframe.argument(15).to_boolean();
         // `foundRows: true` (default) asks the server to return matched-rows
-        // counts instead of changed-rows counts in OK_Packet.affected_rows —
-        // matches the `mysql2` / `mariadb` driver defaults. Enabled at
+        // counts instead of changed-rows counts in OK_Packet.affected_rows,
+        // matching the `mysql2` / `mariadb` driver defaults. Enabled at
         // handshake time by OR-ing `CLIENT_FOUND_ROWS` into the client
         // capability set. `callframe.argument(16)` returns UNDEFINED when
         // the JS layer omits the arg; `to_boolean` coerces UNDEFINED to

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -500,15 +500,8 @@ impl JSMySQLConnection {
         // MySQL doesn't support unnamed prepared statements
         let _ = use_unnamed_prepared_statements;
         let allow_public_key_retrieval = callframe.argument(15).to_boolean();
-        // `foundRows: true` (default) asks the server to return matched-rows
-        // counts instead of changed-rows counts in OK_Packet.affected_rows,
-        // matching the `mysql2` / `mariadb` driver defaults. Enabled at
-        // handshake time by OR-ing `CLIENT_FOUND_ROWS` into the client
-        // capability set. `callframe.argument(16)` returns UNDEFINED when
-        // the JS layer omits the arg; `to_boolean` coerces UNDEFINED to
-        // `false` so we fall back to Bun's pre-fix changed-rows default in
-        // that case. Current `src/js/internal/sql/mysql.ts` always passes
-        // an explicit JS boolean so the default still fires there.
+        // UNDEFINED (arg omitted) coerces to `false`; `mysql.ts` always
+        // passes an explicit boolean, defaulting to `true`.
         let found_rows = callframe.argument(16).to_boolean();
 
         // Ownership transferred into `ptr.connection`; disarm the errdefer so the

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -500,8 +500,6 @@ impl JSMySQLConnection {
         // MySQL doesn't support unnamed prepared statements
         let _ = use_unnamed_prepared_statements;
         let allow_public_key_retrieval = callframe.argument(15).to_boolean();
-        // UNDEFINED (arg omitted) coerces to `false`; `mysql.ts` always
-        // passes an explicit boolean, defaulting to `true`.
         let found_rows = callframe.argument(16).to_boolean();
 
         // Ownership transferred into `ptr.connection`; disarm the errdefer so the

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -500,6 +500,16 @@ impl JSMySQLConnection {
         // MySQL doesn't support unnamed prepared statements
         let _ = use_unnamed_prepared_statements;
         let allow_public_key_retrieval = callframe.argument(15).to_boolean();
+        // `foundRows: true` (default) asks the server to return matched-rows
+        // counts instead of changed-rows counts in OK_Packet.affected_rows —
+        // matches the `mysql2` / `mariadb` driver defaults. Enabled at
+        // handshake time by OR-ing `CLIENT_FOUND_ROWS` into the client
+        // capability set. `callframe.argument(16)` returns UNDEFINED when
+        // the JS layer omits the arg; `to_boolean` coerces UNDEFINED to
+        // `false` so we fall back to Bun's pre-fix changed-rows default in
+        // that case. Current `src/js/internal/sql/mysql.ts` always passes
+        // an explicit JS boolean so the default still fires there.
+        let found_rows = callframe.argument(16).to_boolean();
 
         // Ownership transferred into `ptr.connection`; disarm the errdefer so the
         // connect-fail `ptr.deref()` is the sole cleanup path from here on.
@@ -523,6 +533,7 @@ impl JSMySQLConnection {
                 secure,
                 args.ssl_mode,
                 allow_public_key_retrieval,
+                found_rows,
             )),
             auto_flusher: JsCell::new(AutoFlusher::default()),
             idle_timeout_interval_ms: u32::try_from(idle_timeout).expect("int cast"),

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -91,6 +91,10 @@ pub struct MySQLConnection {
     ssl_mode: SSLMode,
     allow_public_key_retrieval: bool,
     flags: ConnectionFlags,
+    /// When `true`, request `CLIENT_FOUND_ROWS` during handshake so
+    /// `affected_rows` counts rows matched by `WHERE` instead of rows whose
+    /// column values actually changed (mysql2 / mariadb default).
+    found_rows: bool,
 }
 
 impl Default for MySQLConnection {
@@ -125,6 +129,7 @@ impl Default for MySQLConnection {
             ssl_mode: SSLMode::Disable,
             allow_public_key_retrieval: false,
             flags: ConnectionFlags::default(),
+            found_rows: true,
         }
     }
 }
@@ -144,6 +149,7 @@ impl MySQLConnection {
         secure: Option<*mut SslCtx>,
         ssl_mode: SSLMode,
         allow_public_key_retrieval: bool,
+        found_rows: bool,
     ) -> Self {
         Self {
             database,
@@ -164,6 +170,7 @@ impl MySQLConnection {
                 TLSStatus::None
             },
             character_set: CharacterSet::default(),
+            found_rows,
             ..Default::default()
         }
     }
@@ -664,11 +671,17 @@ impl MySQLConnection {
         // server's advertised capabilities. This ensures features like CLIENT_DEPRECATE_EOF
         // are only used when the server actually supports them (critical for MySQL-compatible
         // databases like StarRocks, TiDB, SingleStore, etc.).
-        self.capabilities = Capabilities::get_default_capabilities(
+        let mut requested = Capabilities::get_default_capabilities(
             self.ssl_mode != SSLMode::Disable,
             !self.database.is_empty(),
-        )
-        .intersect(handshake.capability_flags);
+        );
+        // CLIENT_FOUND_ROWS (`foundRows` connection option; default on) tells
+        // the server to report rows matched by `WHERE` in affected_rows rather
+        // than rows actually changed. Matches the mysql2 / mariadb driver
+        // defaults so an `UPDATE` that matches but doesn't change values still
+        // returns `affectedRows: 1`.
+        requested.CLIENT_FOUND_ROWS = self.found_rows;
+        self.capabilities = requested.intersect(handshake.capability_flags);
         self.mariadb_capabilities = MariaDBCapabilities::get_default_capabilities()
             .intersect(handshake.mariadb_capability_flags);
 

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -91,9 +91,7 @@ pub struct MySQLConnection {
     ssl_mode: SSLMode,
     allow_public_key_retrieval: bool,
     flags: ConnectionFlags,
-    /// When `true`, request `CLIENT_FOUND_ROWS` during handshake so
-    /// `affected_rows` counts rows matched by `WHERE` instead of rows whose
-    /// column values actually changed (mysql2 / mariadb default).
+    /// Request `CLIENT_FOUND_ROWS` during handshake (mysql2 / mariadb default).
     found_rows: bool,
 }
 
@@ -675,11 +673,8 @@ impl MySQLConnection {
             self.ssl_mode != SSLMode::Disable,
             !self.database.is_empty(),
         );
-        // CLIENT_FOUND_ROWS (`foundRows` connection option; default on) tells
-        // the server to report rows matched by `WHERE` in affected_rows rather
-        // than rows actually changed. Matches the mysql2 / mariadb driver
-        // defaults so an `UPDATE` that matches but doesn't change values still
-        // returns `affectedRows: 1`.
+        // CLIENT_FOUND_ROWS makes affected_rows count WHERE-matched rows
+        // rather than changed rows (mysql2 / mariadb default).
         requested.CLIENT_FOUND_ROWS = self.found_rows;
         self.capabilities = requested.intersect(handshake.capability_flags);
         self.mariadb_capabilities = MariaDBCapabilities::get_default_capabilities()

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -673,8 +673,6 @@ impl MySQLConnection {
             self.ssl_mode != SSLMode::Disable,
             !self.database.is_empty(),
         );
-        // CLIENT_FOUND_ROWS makes affected_rows count WHERE-matched rows
-        // rather than changed rows (mysql2 / mariadb default).
         requested.CLIENT_FOUND_ROWS = self.found_rows;
         self.capabilities = requested.intersect(handshake.capability_flags);
         self.mariadb_capabilities = MariaDBCapabilities::get_default_capabilities()

--- a/test/js/sql/sql-mysql-found-rows.test.ts
+++ b/test/js/sql/sql-mysql-found-rows.test.ts
@@ -1,0 +1,278 @@
+// Bun.SQL MySQL: `foundRows` connection option (CLIENT_FOUND_ROWS capability)
+//
+// mysql2 and mariadb both enable CLIENT_FOUND_ROWS by default, so an UPDATE
+// that matches a row but does not change any value returns `affectedRows: 1`.
+// This test asserts that:
+//
+//   1. The default (no `foundRows` option) sets CLIENT_FOUND_ROWS in the
+//      HandshakeResponse41 — matching the mysql2/mariadb defaults so code
+//      migrated from those drivers sees the same `affectedRows` values.
+//   2. `foundRows: true` sets the bit.
+//   3. `foundRows: false` (option form) clears the bit — opt-out for users
+//      who want the server's changed-rows semantics.
+//   4. `?foundRows=false` on the URL clears the bit (same opt-out via URL).
+//   5. The options object wins over the URL query string.
+//   6. `affectedRows` on the SQLResultArray reflects the OK_Packet
+//      `affected_rows` field the server emits — which is the field
+//      CLIENT_FOUND_ROWS changes the server-side semantics of.
+//
+// Implemented via a mock MySQL server so the test runs without Docker.
+
+import { SQL } from "bun";
+import { describe, expect, test } from "bun:test";
+import net from "net";
+
+// --- MySQL wire protocol helpers ---
+
+function u16le(n: number): Buffer {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff]);
+}
+
+function u24le(n: number): Buffer {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff]);
+}
+
+function u32le(n: number): Buffer {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >>> 24) & 0xff]);
+}
+
+function packet(seq: number, payload: Buffer): Buffer {
+  return Buffer.concat([u24le(payload.length), Buffer.from([seq]), payload]);
+}
+
+// Capability flag constants (bit positions in MySQL protocol).
+const CLIENT_LONG_PASSWORD = 1 << 0;
+const CLIENT_FOUND_ROWS = 1 << 1;
+const CLIENT_LONG_FLAG = 1 << 2;
+const CLIENT_CONNECT_WITH_DB = 1 << 3;
+const CLIENT_PROTOCOL_41 = 1 << 9;
+const CLIENT_SECURE_CONNECTION = 1 << 15;
+const CLIENT_MULTI_STATEMENTS = 1 << 16;
+const CLIENT_MULTI_RESULTS = 1 << 17;
+const CLIENT_PLUGIN_AUTH = 1 << 19;
+const CLIENT_DEPRECATE_EOF = 1 << 24;
+
+// Advertise everything the client may request, including CLIENT_FOUND_ROWS,
+// so the intersect()-at-handshake step keeps whatever the client asked for.
+const SERVER_CAPS =
+  CLIENT_LONG_PASSWORD |
+  CLIENT_FOUND_ROWS |
+  CLIENT_LONG_FLAG |
+  CLIENT_CONNECT_WITH_DB |
+  CLIENT_PROTOCOL_41 |
+  CLIENT_SECURE_CONNECTION |
+  CLIENT_MULTI_STATEMENTS |
+  CLIENT_MULTI_RESULTS |
+  CLIENT_PLUGIN_AUTH |
+  CLIENT_DEPRECATE_EOF;
+
+function handshakeV10(): Buffer {
+  const authData1 = Buffer.alloc(8, 0x61);
+  const authData2 = Buffer.alloc(13, 0x62);
+  authData2[12] = 0; // trailing NUL
+  const payload = Buffer.concat([
+    Buffer.from([10]), // protocol version
+    Buffer.from("mock-5.7.0\0"), // server version NUL-terminated
+    u32le(1), // connection id
+    authData1, // auth-plugin-data-part-1 (8)
+    Buffer.from([0]), // filler
+    u16le(SERVER_CAPS & 0xffff), // capability flags lower
+    Buffer.from([0x2d]), // character set utf8mb4_general_ci
+    u16le(0x0002), // status flags SERVER_STATUS_AUTOCOMMIT
+    u16le((SERVER_CAPS >>> 16) & 0xffff), // capability flags upper
+    Buffer.from([21]), // auth-plugin-data length
+    Buffer.alloc(10, 0), // reserved
+    authData2, // auth-plugin-data-part-2 (13)
+    Buffer.from("mysql_native_password\0"),
+  ]);
+  return packet(0, payload);
+}
+
+function okPacket(seq: number, affectedRows: number): Buffer {
+  // OK header 0x00, length-encoded affected_rows (fits in 1 byte when < 251),
+  // length-encoded last_insert_id = 0, status_flags = AUTOCOMMIT, warnings = 0.
+  return packet(
+    seq,
+    Buffer.from([
+      0x00,
+      affectedRows & 0xff,
+      0x00, // last_insert_id
+      0x02,
+      0x00, // status_flags (AUTOCOMMIT)
+      0x00,
+      0x00, // warnings
+    ]),
+  );
+}
+
+interface CapturedHandshake {
+  capabilityFlags: number;
+}
+
+// Minimal mock MySQL server that completes the handshake, captures the
+// client's HandshakeResponse41 capability flags, and replies to a single
+// COM_QUERY with an OK_Packet carrying the specified affected_rows value.
+// Returns a Promise that resolves to the captured capability flags once the
+// client finishes its first query.
+function startMockMysql(affectedRows: number): Promise<{
+  port: number;
+  captured: Promise<CapturedHandshake>;
+  close: () => void;
+}> {
+  return new Promise((resolve, reject) => {
+    const captured = Promise.withResolvers<CapturedHandshake>();
+
+    const server = net.createServer(socket => {
+      let buffered = Buffer.alloc(0);
+      let sawHandshakeResponse = false;
+
+      socket.write(handshakeV10());
+
+      socket.on("data", chunk => {
+        buffered = Buffer.concat([buffered, chunk]);
+        while (buffered.length >= 4) {
+          const len = buffered[0]! | (buffered[1]! << 8) | (buffered[2]! << 16);
+          if (buffered.length < 4 + len) break;
+          const seq = buffered[3]!;
+          const payload = buffered.subarray(4, 4 + len);
+          buffered = buffered.subarray(4 + len);
+
+          if (!sawHandshakeResponse) {
+            // First packet from client after our handshake is the
+            // HandshakeResponse41. First 4 bytes of its payload are the
+            // client's negotiated capability flags (u32 LE).
+            sawHandshakeResponse = true;
+            const caps =
+              payload[0]! | (payload[1]! << 8) | (payload[2]! << 16) | (payload[3]! << 24);
+            captured.resolve({ capabilityFlags: caps >>> 0 });
+            // Complete auth with OK packet so the connection is usable.
+            socket.write(okPacket(seq + 1, 0));
+          } else {
+            const cmd = payload[0];
+            if (cmd === 0x03) {
+              // COM_QUERY: reply with OK_Packet carrying affectedRows.
+              socket.write(okPacket(seq + 1, affectedRows));
+            } else if (cmd === 0x01) {
+              // COM_QUIT
+              socket.end();
+            }
+          }
+        }
+      });
+
+      socket.on("error", () => {});
+      // Make sure we don't leak the captured waiter if the client drops.
+      socket.on("close", () => {
+        captured.resolve({ capabilityFlags: 0 });
+      });
+    });
+
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as net.AddressInfo;
+      resolve({
+        port: addr.port,
+        captured: captured.promise,
+        close: () => server.close(),
+      });
+    });
+  });
+}
+
+async function runHandshakeCase(options: Bun.SQL.Options): Promise<number> {
+  const mock = await startMockMysql(1);
+  try {
+    await using db = new SQL({
+      ...options,
+      adapter: "mysql",
+      hostname: "127.0.0.1",
+      port: mock.port,
+      username: "root",
+      password: "",
+      database: "test",
+      max: 1,
+      idleTimeout: 1,
+    } as Bun.SQL.Options);
+
+    // Triggering any query forces the handshake to complete.
+    await db.unsafe("UPDATE t SET v = 1");
+    const { capabilityFlags } = await mock.captured;
+    return capabilityFlags;
+  } finally {
+    mock.close();
+  }
+}
+
+describe("Bun.SQL MySQL foundRows (CLIENT_FOUND_ROWS)", () => {
+  test("default: CLIENT_FOUND_ROWS is enabled (matches mysql2 / mariadb defaults)", async () => {
+    const caps = await runHandshakeCase({});
+    expect((caps & CLIENT_FOUND_ROWS) !== 0).toBe(true);
+  });
+
+  test("foundRows: true enables CLIENT_FOUND_ROWS", async () => {
+    const caps = await runHandshakeCase({ foundRows: true } as Bun.SQL.Options);
+    expect((caps & CLIENT_FOUND_ROWS) !== 0).toBe(true);
+  });
+
+  test("foundRows: false disables CLIENT_FOUND_ROWS", async () => {
+    const caps = await runHandshakeCase({ foundRows: false } as Bun.SQL.Options);
+    expect((caps & CLIENT_FOUND_ROWS) !== 0).toBe(false);
+  });
+
+  test("URL ?foundRows=false disables CLIENT_FOUND_ROWS", async () => {
+    const mock = await startMockMysql(1);
+    try {
+      await using db = new SQL({
+        url: `mysql://root:@127.0.0.1:${mock.port}/test?foundRows=false`,
+        max: 1,
+        idleTimeout: 1,
+      });
+      await db.unsafe("UPDATE t SET v = 1");
+      const { capabilityFlags } = await mock.captured;
+      expect((capabilityFlags & CLIENT_FOUND_ROWS) !== 0).toBe(false);
+    } finally {
+      mock.close();
+    }
+  });
+
+  test("options object wins over URL query string", async () => {
+    const mock = await startMockMysql(1);
+    try {
+      await using db = new SQL({
+        url: `mysql://root:@127.0.0.1:${mock.port}/test?foundRows=false`,
+        foundRows: true,
+        max: 1,
+        idleTimeout: 1,
+      } as Bun.SQL.Options);
+      await db.unsafe("UPDATE t SET v = 1");
+      const { capabilityFlags } = await mock.captured;
+      expect((capabilityFlags & CLIENT_FOUND_ROWS) !== 0).toBe(true);
+    } finally {
+      mock.close();
+    }
+  });
+
+  test("affectedRows reflects the server's OK_Packet.affected_rows value", async () => {
+    // CLIENT_FOUND_ROWS is what the server uses to pick matched-vs-changed.
+    // Bun just forwards whatever count the server reports; to pin down that
+    // we are not silently clamping or mis-decoding, the mock returns 1 and we
+    // assert the JS-side result carries it.
+    const mock = await startMockMysql(1);
+    try {
+      await using db = new SQL({
+        adapter: "mysql",
+        hostname: "127.0.0.1",
+        port: mock.port,
+        username: "root",
+        password: "",
+        database: "test",
+        max: 1,
+        idleTimeout: 1,
+      });
+      const result: any = await db.unsafe("UPDATE t SET v = v WHERE id = 1");
+      expect(result.affectedRows).toBe(1);
+    } finally {
+      mock.close();
+    }
+  });
+});

--- a/test/js/sql/sql-mysql-found-rows.test.ts
+++ b/test/js/sql/sql-mysql-found-rows.test.ts
@@ -142,8 +142,7 @@ function startMockMysql(affectedRows: number): Promise<{
             // HandshakeResponse41. First 4 bytes of its payload are the
             // client's negotiated capability flags (u32 LE).
             sawHandshakeResponse = true;
-            const caps =
-              payload[0]! | (payload[1]! << 8) | (payload[2]! << 16) | (payload[3]! << 24);
+            const caps = payload[0]! | (payload[1]! << 8) | (payload[2]! << 16) | (payload[3]! << 24);
             captured.resolve({ capabilityFlags: caps >>> 0 });
             // Complete auth with OK packet so the connection is usable.
             socket.write(okPacket(seq + 1, 0));

--- a/test/js/sql/sql-mysql-found-rows.test.ts
+++ b/test/js/sql/sql-mysql-found-rows.test.ts
@@ -235,6 +235,29 @@ describe("Bun.SQL MySQL foundRows (CLIENT_FOUND_ROWS)", () => {
     }
   });
 
+  test("URL with duplicate foundRows keys doesn't throw", async () => {
+    // `URLSearchParams.toJSON()` returns an Array when the same key appears
+    // more than once. The option parser coerces through `String()` before
+    // normalizing, so a malformed URL like `?foundRows=true&foundRows=false`
+    // must not throw "toLowerCase is not a function". Using `false` as the
+    // last value turns the coerced "true,false" into a string that is neither
+    // "false" nor "0", so the default (enabled) wins.
+    const mock = await startMockMysql(1);
+    try {
+      await using db = new SQL({
+        url: `mysql://root:@127.0.0.1:${mock.port}/test?foundRows=true&foundRows=false`,
+        max: 1,
+        idleTimeout: 1,
+      });
+      await db.unsafe("UPDATE t SET v = 1");
+      const { capabilityFlags } = await mock.captured;
+      // "true,false" matches neither "false" nor "0" — stays at the default.
+      expect((capabilityFlags & CLIENT_FOUND_ROWS) !== 0).toBe(true);
+    } finally {
+      mock.close();
+    }
+  });
+
   test("options object wins over URL query string", async () => {
     const mock = await startMockMysql(1);
     try {

--- a/test/js/sql/sql-mysql-found-rows.test.ts
+++ b/test/js/sql/sql-mysql-found-rows.test.ts
@@ -1,181 +1,59 @@
-// Bun.SQL MySQL: `foundRows` connection option (CLIENT_FOUND_ROWS capability)
-//
-// mysql2 and mariadb both enable CLIENT_FOUND_ROWS by default, so an UPDATE
-// that matches a row but does not change any value returns `affectedRows: 1`.
-// This test asserts that:
-//
-//   1. The default (no `foundRows` option) sets CLIENT_FOUND_ROWS in the
-//      HandshakeResponse41 — matching the mysql2/mariadb defaults so code
-//      migrated from those drivers sees the same `affectedRows` values.
-//   2. `foundRows: true` sets the bit.
-//   3. `foundRows: false` (option form) clears the bit — opt-out for users
-//      who want the server's changed-rows semantics.
-//   4. `?foundRows=false` on the URL clears the bit (same opt-out via URL).
-//   5. The options object wins over the URL query string.
-//   6. `affectedRows` on the SQLResultArray reflects the OK_Packet
-//      `affected_rows` field the server emits — which is the field
-//      CLIENT_FOUND_ROWS changes the server-side semantics of.
-//
-// Implemented via a mock MySQL server so the test runs without Docker.
+// Bun.SQL MySQL `foundRows` option: toggles CLIENT_FOUND_ROWS in the
+// HandshakeResponse41 (default on, matching mysql2 / mariadb), which makes
+// the server report WHERE-matched rows instead of changed rows in affectedRows.
 
 import { SQL } from "bun";
 import { describe, expect, test } from "bun:test";
-import net from "net";
-
-// --- MySQL wire protocol helpers ---
-
-function u16le(n: number): Buffer {
-  return Buffer.from([n & 0xff, (n >> 8) & 0xff]);
-}
-
-function u24le(n: number): Buffer {
-  return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff]);
-}
-
-function u32le(n: number): Buffer {
-  return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >>> 24) & 0xff]);
-}
-
-function packet(seq: number, payload: Buffer): Buffer {
-  return Buffer.concat([u24le(payload.length), Buffer.from([seq]), payload]);
-}
-
-// Capability flag constants (bit positions in MySQL protocol).
-const CLIENT_LONG_PASSWORD = 1 << 0;
-const CLIENT_FOUND_ROWS = 1 << 1;
-const CLIENT_LONG_FLAG = 1 << 2;
-const CLIENT_CONNECT_WITH_DB = 1 << 3;
-const CLIENT_PROTOCOL_41 = 1 << 9;
-const CLIENT_SECURE_CONNECTION = 1 << 15;
-const CLIENT_MULTI_STATEMENTS = 1 << 16;
-const CLIENT_MULTI_RESULTS = 1 << 17;
-const CLIENT_PLUGIN_AUTH = 1 << 19;
-const CLIENT_DEPRECATE_EOF = 1 << 24;
-
-// Advertise everything the client may request, including CLIENT_FOUND_ROWS,
-// so the intersect()-at-handshake step keeps whatever the client asked for.
-const SERVER_CAPS =
-  CLIENT_LONG_PASSWORD |
-  CLIENT_FOUND_ROWS |
-  CLIENT_LONG_FLAG |
-  CLIENT_CONNECT_WITH_DB |
-  CLIENT_PROTOCOL_41 |
-  CLIENT_SECURE_CONNECTION |
-  CLIENT_MULTI_STATEMENTS |
-  CLIENT_MULTI_RESULTS |
-  CLIENT_PLUGIN_AUTH |
-  CLIENT_DEPRECATE_EOF;
-
-function handshakeV10(): Buffer {
-  const authData1 = Buffer.alloc(8, 0x61);
-  const authData2 = Buffer.alloc(13, 0x62);
-  authData2[12] = 0; // trailing NUL
-  const payload = Buffer.concat([
-    Buffer.from([10]), // protocol version
-    Buffer.from("mock-5.7.0\0"), // server version NUL-terminated
-    u32le(1), // connection id
-    authData1, // auth-plugin-data-part-1 (8)
-    Buffer.from([0]), // filler
-    u16le(SERVER_CAPS & 0xffff), // capability flags lower
-    Buffer.from([0x2d]), // character set utf8mb4_general_ci
-    u16le(0x0002), // status flags SERVER_STATUS_AUTOCOMMIT
-    u16le((SERVER_CAPS >>> 16) & 0xffff), // capability flags upper
-    Buffer.from([21]), // auth-plugin-data length
-    Buffer.alloc(10, 0), // reserved
-    authData2, // auth-plugin-data-part-2 (13)
-    Buffer.from("mysql_native_password\0"),
-  ]);
-  return packet(0, payload);
-}
-
-function okPacket(seq: number, affectedRows: number): Buffer {
-  // OK header 0x00, length-encoded affected_rows (fits in 1 byte when < 251),
-  // length-encoded last_insert_id = 0, status_flags = AUTOCOMMIT, warnings = 0.
-  return packet(
-    seq,
-    Buffer.from([
-      0x00,
-      affectedRows & 0xff,
-      0x00, // last_insert_id
-      0x02,
-      0x00, // status_flags (AUTOCOMMIT)
-      0x00,
-      0x00, // warnings
-    ]),
-  );
-}
+import {
+  listeningServer,
+  MYSQL_CLIENT_FOUND_ROWS,
+  MYSQL_DEFAULT_CAPABILITIES,
+  mysqlHandshakeV10,
+  mysqlOkPacket,
+  mysqlParseHandshakeResponse41ClientFlags,
+  mysqlReadPackets,
+} from "./wire-frames";
 
 interface CapturedHandshake {
   capabilityFlags: number;
 }
 
-// Minimal mock MySQL server that completes the handshake, captures the
-// client's HandshakeResponse41 capability flags, and replies to a single
-// COM_QUERY with an OK_Packet carrying the specified affected_rows value.
-// Returns a Promise that resolves to the captured capability flags once the
-// client finishes its first query.
-function startMockMysql(affectedRows: number): Promise<{
+// Completes the handshake, captures the client's HandshakeResponse41 capability
+// flags, and answers each COM_QUERY with an OK_Packet carrying `affectedRows`.
+async function startMockMysql(affectedRows: number): Promise<{
   port: number;
   captured: Promise<CapturedHandshake>;
   close: () => void;
 }> {
-  return new Promise((resolve, reject) => {
-    const captured = Promise.withResolvers<CapturedHandshake>();
+  const captured = Promise.withResolvers<CapturedHandshake>();
+  const { port, server } = await listeningServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let sawHandshakeResponse = false;
 
-    const server = net.createServer(socket => {
-      let buffered = Buffer.alloc(0);
-      let sawHandshakeResponse = false;
+    // Advertise CLIENT_FOUND_ROWS so the client's intersect keeps it when requested.
+    socket.write(mysqlHandshakeV10({ capabilities: MYSQL_DEFAULT_CAPABILITIES | MYSQL_CLIENT_FOUND_ROWS }));
 
-      socket.write(handshakeV10());
-
-      socket.on("data", chunk => {
-        buffered = Buffer.concat([buffered, chunk]);
-        while (buffered.length >= 4) {
-          const len = buffered[0]! | (buffered[1]! << 8) | (buffered[2]! << 16);
-          if (buffered.length < 4 + len) break;
-          const seq = buffered[3]!;
-          const payload = buffered.subarray(4, 4 + len);
-          buffered = buffered.subarray(4 + len);
-
-          if (!sawHandshakeResponse) {
-            // First packet from client after our handshake is the
-            // HandshakeResponse41. First 4 bytes of its payload are the
-            // client's negotiated capability flags (u32 LE).
-            sawHandshakeResponse = true;
-            const caps = payload[0]! | (payload[1]! << 8) | (payload[2]! << 16) | (payload[3]! << 24);
-            captured.resolve({ capabilityFlags: caps >>> 0 });
-            // Complete auth with OK packet so the connection is usable.
-            socket.write(okPacket(seq + 1, 0));
-          } else {
-            const cmd = payload[0];
-            if (cmd === 0x03) {
-              // COM_QUERY: reply with OK_Packet carrying affectedRows.
-              socket.write(okPacket(seq + 1, affectedRows));
-            } else if (cmd === 0x01) {
-              // COM_QUIT
-              socket.end();
-            }
-          }
+    socket.on("data", chunk => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+        if (!sawHandshakeResponse) {
+          sawHandshakeResponse = true;
+          captured.resolve({ capabilityFlags: mysqlParseHandshakeResponse41ClientFlags(payload) });
+          socket.write(mysqlOkPacket(seq + 1));
+        } else if (payload[0] === 0x03) {
+          // COM_QUERY
+          socket.write(mysqlOkPacket(seq + 1, 0x00, affectedRows));
+        } else if (payload[0] === 0x01) {
+          // COM_QUIT
+          socket.end();
         }
       });
-
-      socket.on("error", () => {});
-      // Make sure we don't leak the captured waiter if the client drops.
-      socket.on("close", () => {
-        captured.resolve({ capabilityFlags: 0 });
-      });
     });
 
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      const addr = server.address() as net.AddressInfo;
-      resolve({
-        port: addr.port,
-        captured: captured.promise,
-        close: () => server.close(),
-      });
-    });
+    socket.on("error", () => {});
+    // Don't leak the captured waiter if the client drops early.
+    socket.on("close", () => captured.resolve({ capabilityFlags: 0 }));
   });
+  return { port, captured: captured.promise, close: () => server.close() };
 }
 
 async function runHandshakeCase(options: Bun.SQL.Options): Promise<number> {
@@ -205,17 +83,17 @@ async function runHandshakeCase(options: Bun.SQL.Options): Promise<number> {
 describe("Bun.SQL MySQL foundRows (CLIENT_FOUND_ROWS)", () => {
   test("default: CLIENT_FOUND_ROWS is enabled (matches mysql2 / mariadb defaults)", async () => {
     const caps = await runHandshakeCase({});
-    expect((caps & CLIENT_FOUND_ROWS) !== 0).toBe(true);
+    expect((caps & MYSQL_CLIENT_FOUND_ROWS) !== 0).toBe(true);
   });
 
   test("foundRows: true enables CLIENT_FOUND_ROWS", async () => {
     const caps = await runHandshakeCase({ foundRows: true } as Bun.SQL.Options);
-    expect((caps & CLIENT_FOUND_ROWS) !== 0).toBe(true);
+    expect((caps & MYSQL_CLIENT_FOUND_ROWS) !== 0).toBe(true);
   });
 
   test("foundRows: false disables CLIENT_FOUND_ROWS", async () => {
     const caps = await runHandshakeCase({ foundRows: false } as Bun.SQL.Options);
-    expect((caps & CLIENT_FOUND_ROWS) !== 0).toBe(false);
+    expect((caps & MYSQL_CLIENT_FOUND_ROWS) !== 0).toBe(false);
   });
 
   test("URL ?foundRows=false disables CLIENT_FOUND_ROWS", async () => {
@@ -228,19 +106,15 @@ describe("Bun.SQL MySQL foundRows (CLIENT_FOUND_ROWS)", () => {
       });
       await db.unsafe("UPDATE t SET v = 1");
       const { capabilityFlags } = await mock.captured;
-      expect((capabilityFlags & CLIENT_FOUND_ROWS) !== 0).toBe(false);
+      expect((capabilityFlags & MYSQL_CLIENT_FOUND_ROWS) !== 0).toBe(false);
     } finally {
       mock.close();
     }
   });
 
   test("URL with duplicate foundRows keys doesn't throw", async () => {
-    // `URLSearchParams.toJSON()` returns an Array when the same key appears
-    // more than once. The option parser coerces through `String()` before
-    // normalizing, so a malformed URL like `?foundRows=true&foundRows=false`
-    // must not throw "toLowerCase is not a function". Using `false` as the
-    // last value turns the coerced "true,false" into a string that is neither
-    // "false" nor "0", so the default (enabled) wins.
+    // toJSON() returns an array for duplicate keys; the coerced "true,false"
+    // is neither "false" nor "0", so the default (enabled) wins.
     const mock = await startMockMysql(1);
     try {
       await using db = new SQL({
@@ -250,8 +124,7 @@ describe("Bun.SQL MySQL foundRows (CLIENT_FOUND_ROWS)", () => {
       });
       await db.unsafe("UPDATE t SET v = 1");
       const { capabilityFlags } = await mock.captured;
-      // "true,false" matches neither "false" nor "0" — stays at the default.
-      expect((capabilityFlags & CLIENT_FOUND_ROWS) !== 0).toBe(true);
+      expect((capabilityFlags & MYSQL_CLIENT_FOUND_ROWS) !== 0).toBe(true);
     } finally {
       mock.close();
     }
@@ -268,17 +141,13 @@ describe("Bun.SQL MySQL foundRows (CLIENT_FOUND_ROWS)", () => {
       } as Bun.SQL.Options);
       await db.unsafe("UPDATE t SET v = 1");
       const { capabilityFlags } = await mock.captured;
-      expect((capabilityFlags & CLIENT_FOUND_ROWS) !== 0).toBe(true);
+      expect((capabilityFlags & MYSQL_CLIENT_FOUND_ROWS) !== 0).toBe(true);
     } finally {
       mock.close();
     }
   });
 
   test("affectedRows reflects the server's OK_Packet.affected_rows value", async () => {
-    // CLIENT_FOUND_ROWS is what the server uses to pick matched-vs-changed.
-    // Bun just forwards whatever count the server reports; to pin down that
-    // we are not silently clamping or mis-decoding, the mock returns 1 and we
-    // assert the JS-side result carries it.
     const mock = await startMockMysql(1);
     try {
       await using db = new SQL({

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -278,6 +278,7 @@ export async function pgMinimalReadyServer(): Promise<{ port: number; server: ne
 
 // Capability flags — page_protocol_basic_capability_flags.html (subset used by the mocks).
 export const MYSQL_CLIENT_LONG_PASSWORD = 1 << 0; // CLIENT_MYSQL in MariaDB's dialect
+export const MYSQL_CLIENT_FOUND_ROWS = 1 << 1;
 export const MYSQL_CLIENT_PROTOCOL_41 = 1 << 9;
 export const MYSQL_CLIENT_SSL = 1 << 11;
 export const MYSQL_CLIENT_SECURE_CONNECTION = 1 << 15;
@@ -352,8 +353,11 @@ export function mysqlHandshakeV10(
 
 // MySQL Protocol::OK_Packet — page_protocol_basic_ok_packet.html: Int<1>(header) lenenc(affected_rows) lenenc(last_insert_id) Int<2>(status) Int<2>(warnings)
 // The header is 0x00, except for the CLIENT_DEPRECATE_EOF result-set terminator, which is an OK packet with a 0xFE header.
-export function mysqlOkPacket(seq: number, header: 0x00 | 0xfe = 0x00): Buffer {
-  return mysqlRawPacket(seq, Buffer.from([header, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
+export function mysqlOkPacket(seq: number, header: 0x00 | 0xfe = 0x00, affectedRows = 0): Buffer {
+  return mysqlRawPacket(
+    seq,
+    Buffer.concat([Buffer.from([header]), mysqlLenencInt(affectedRows), Buffer.from([0x00, 0x02, 0x00, 0x00, 0x00])]),
+  );
 }
 
 // MySQL Protocol::AuthMoreData — page_protocol_connection_phase_packets_protocol_auth_more_data.html:
@@ -405,6 +409,11 @@ export function mysqlReadLenencInt(buf: Buffer, offset: number): { value: number
 // 23 filler bytes (a MySQL client leaves them zero): https://mariadb.com/kb/en/connection/
 export function mysqlParseHandshakeResponseExtendedCaps(payload: Buffer): number {
   return payload.readUInt32LE(4 + 4 + 1 + 19);
+}
+
+// HandshakeResponse41 starts with Int<4>(client_flag): the capabilities the client negotiated.
+export function mysqlParseHandshakeResponse41ClientFlags(payload: Buffer): number {
+  return payload.readUInt32LE(0);
 }
 
 // MySQL Protocol::HandshakeResponse41 — page_protocol_connection_phase_packets_protocol_handshake_response.html:


### PR DESCRIPTION
Fixes #30843.

## Repro

```js
import { SQL } from "bun";
const sql = new SQL({ adapter: "mysql", /* ... */ });
await sql`create table t (id int primary key, v int not null)`;
await sql`insert into t values (1, 10)`;

// UPDATE matches one row but changes no column value:
const { affectedRows } = await sql`update t set v = v where id = 1`;
// Bun 1.3.14:  affectedRows = 0  ← indistinguishable from "matched no rows"
// mysql2:      affectedRows = 1  (default)
// mariadb:     affectedRows = 1  (default)
```

## Cause

`Capabilities::get_default_capabilities` in `src/sql/mysql/Capabilities.rs`
never set `CLIENT_FOUND_ROWS`, and there was no user-facing option to opt
in. The MySQL server's `OK_Packet.affected_rows` therefore carried
changed-rows counts, not matched-rows counts.

`mysql2` enables `CLIENT_FOUND_ROWS` by default (opt-out via
`flags: ["-FOUND_ROWS"]`) and `mariadb` does the same (opt-out via
`foundRows: false`). Code migrated from either driver silently lost the
ability to tell "matched but unchanged" from "didn't match" apart.

## Fix

Add a `foundRows` connection option (accepted on the options object and
as a `?foundRows=...` URL query param). Default is `true`, matching the
mysql2 / mariadb defaults. When enabled, the client OR-s
`CLIENT_FOUND_ROWS` into the capability set it requests during the
HandshakeResponse41, so subsequent `affected_rows` counts come back with
matched-rows semantics.

```ts
new SQL({ adapter: "mysql", /* ... */ });                    // foundRows: true (default)
new SQL({ adapter: "mysql", foundRows: false, /* ... */ });  // server's changed-rows semantics
new SQL("mysql://root@127.0.0.1/test?foundRows=false");       // URL form (options object wins)
```

The option is threaded through:
`parseOptions` → `createMySQLConnection` call → `JSMySQLConnection::create_instance` → `MySQLConnection::init` → `MySQLConnection.found_rows` field → `handle_handshake`'s `requested.CLIENT_FOUND_ROWS`.

`parseOptions` also writes `foundRows` into the `DefinedOptions`
structure for Postgres/SQLite adapters — they ignore it, so the option
is MySQL-only without any adapter switch in the parser.

## Verification

New test: `test/js/sql/sql-mysql-found-rows.test.ts` uses a minimal mock
MySQL server (no Docker required) to inspect the client's
HandshakeResponse41 `capability_flags` bit 1 (`CLIENT_FOUND_ROWS`):

| Case | Bit 1 |
|---|---|
| default (no `foundRows`) | set ✓ |
| `foundRows: true` | set ✓ |
| `foundRows: false` | cleared ✓ |
| URL `?foundRows=false` | cleared ✓ |
| URL with duplicate `foundRows` keys | no throw, default kept ✓ |
| options `foundRows: true` + URL `?foundRows=false` | set (options win) ✓ |
| server round-trip `affectedRows: 1` reaches JS | ✓ |

Fail-before:

```
$ USE_SYSTEM_BUN=1 bun test test/js/sql/sql-mysql-found-rows.test.ts
 3 pass
 4 fail     ← the four that exercise the new behavior
```

Pass-after:

```
$ bun bd test test/js/sql/sql-mysql-found-rows.test.ts
 7 pass
 0 fail
```

Existing MySQL tests (`sql-mysql-auth-short-nonce`, `28004`,
`adapter-env-var-precedence`, `adapter-override`, `sql-mysql-cached-error`,
`sql-mysql-bind-oob`, `sql-mysql-bind-blob-borrow`,
`sql-mysql-raw-length-prefix`, `sql-mysql-columns-realloc-oom`,
`sql-mysql-clean-reentry`) still pass.

## Extra commit: build fix

`build: JSON-stringify OVERLAY_CSS define value in bake-codegen` — wraps
the raw minified CSS in `JSON.stringify` so the pre-auto-quote bootstrap
bun (1.3.13, used in the CI Dockerfile) can parse `define:` values that
start with `*{...}`. Independent of the MySQL change; needed for cold
builds.


## Rebase notes

Rebased twice as main moved:

1. Onto `0b20408b65` (#31129), which added `allowPublicKeyRetrieval` to the
   same MySQL connection plumbing. Resolved by keeping both parameters
   side-by-side: the native `createConnection` arg list ends with
   `...!prepare, !!allowPublicKeyRetrieval, !!foundRows`, and
   `JSMySQLConnection.rs` reads `argument(15)` / `argument(16)`.

2. Onto `ac312f0952`, which refactored `PooledMySQLConnection` into a shared
   `BasePooledConnection` base class: the per-driver option destructuring and
   native `createConnection` call moved from `mysql.ts` into
   `createPooledConnectionHandle` in `shared.ts`. Resolved by taking main's
   structure and moving the `foundRows` threading there (destructure
   `foundRows = true`, pass `!!foundRows` after `!!allowPublicKeyRetrieval`),
   following the same trailing-arg pattern `allowPublicKeyRetrieval` already
   uses (extra trailing args are ignored by the Postgres driver).

3. Onto `8f8695f4cd`. Two conflicts:
   - `shared.ts`: main expanded the URL query parsing (renamed the loop var and
     added `ssl-mode`/`ssl_mode`/`ssl`/`tls` branches). Kept main's structure and
     moved the `foundrows` branch into it, using the same template-literal string
     coercion style as the neighboring branches (still covers the
     duplicate-key-array case).
   - `MySQLConnection.rs`: main added MariaDB capability negotiation
     (`self.mariadb_capabilities = ...`) in the same handshake block. Kept both:
     `requested.CLIENT_FOUND_ROWS = self.found_rows` before the intersect, then
     main's new mariadb_capabilities line.

All 7 `sql-mysql-found-rows.test.ts` cases pass after each rebase.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 10 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-mysql-found-rows.test.ts
bun test v1.4.0 (717469d7e)

test/js/sql/sql-mysql-found-rows.test.ts:
81 | }
82 | 
83 | describe("Bun.SQL MySQL foundRows (CLIENT_FOUND_ROWS)", () => {
84 |   test("default: CLIENT_FOUND_ROWS is enabled (matches mysql2 / mariadb defaults)", async () => {
85 |     const caps = await runHandshakeCase({});
86 |     expect((caps & MYSQL_CLIENT_FOUND_ROWS) !== 0).toBe(true);
                                                        ^
error: expect(received).toBe(expected)

Expected: true
Received: false

      at <anonymous> (/workspace/bun/test/js/sql/sql-mysql-found-rows.test.ts:86:52)
(fail) Bun.SQL MySQL foundRows (CLIENT_FOUND_ROWS) > default: CLIENT_FOUND_ROWS is enabled (matches mysql2 / mariadb defaults) [510.49ms]
86 |     expect((caps & MYSQL_CLIENT_FOUND_ROWS) !== 0).toBe(true);
87 |   });
88 | 
89 |   test("foundRows: true enables CLIENT_FOUND_ROWS", async () => {
90 |     const caps = await runHandshakeCase({ foundRows: true } as Bun.SQL.Options);
91 |     expect((caps & MYSQL_CLIENT_FOUN
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (9f51b7d9a)

test/js/sql/sql-mysql-found-rows.test.ts:
(pass) Bun.SQL MySQL foundRows (CLIENT_FOUND_ROWS) > default: CLIENT_FOUND_ROWS is enabled (matches mysql2 / mariadb defaults) [9.71ms]
(pass) Bun.SQL MySQL foundRows (CLIENT_FOUND_ROWS) > foundRows: true enables CLIENT_FOUND_ROWS [2.42ms]
(pass) Bun.SQL MySQL foundRows (CLIENT_FOUND_ROWS) > foundRows: false disables CLIENT_FOUND_ROWS [1.81ms]
(pass) Bun.SQL MySQL foundRows (CLIENT_FOUND_ROWS) > URL ?foundRows=false disables CLIENT_FOUND_ROWS [2.06ms]
(pass) Bun.SQL MySQL foundRows (CLIENT_FOUND_ROWS) > URL with duplicate foundRows keys doesn't throw [1.84ms]
(pass) Bun.SQL MySQL foundRows (CLIENT_FOUND_ROWS) > options object wins over URL query string [1.78ms]
(pass) Bun.SQL MySQL foundRows (CLIENT_FOUND_ROWS) > affectedRows reflects the server's OK_Packet.affected_rows value [2.00ms]

 7 pass
 0 fail
 7 expect() calls
Ran 7 tests across 1 file. [218.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-mysql-found-rows.test.ts
bun test v1.4.0 (717469d7e)

test/js/sql/sql-mysql-found-rows.test.ts:
(pass) Bun.SQL MySQL foundRows (CLIENT_FOUND_ROWS) > default: CLIENT_FOUND_ROWS is enabled (matches mysql2 / mariadb defaults) [528.86ms]
(pass) Bun.SQL MySQL foundRows (CLIENT_FOUND_ROWS) > foundRows: true enables CLIENT_FOUND_ROWS [149.16ms]
(pass) Bun.SQL MySQL foundRows (CLIENT_FOUND_ROWS) > foundRows: false disables CLIENT_FOUND_ROWS [39.19ms]
(pass) Bun.SQL MySQL foundRows (CLIENT_FOUND_ROWS) > URL ?foundRows=false disables CLIENT_FOUND_ROWS [56.96ms]
(pass) Bun.SQL MySQL foundRows (CLIENT_FOUND_ROWS) > URL with duplicate foundRows keys doesn't throw [43.88ms]
(pass) Bun.SQL MySQL foundRows (CLIENT_FOUND_ROWS) > options object wins over URL query string [41.33ms]
(pass) Bun.SQL MySQL foundRows (CLIENT_FOUND_ROWS) > affectedRows reflects the server's OK_Packet.affected_rows value [42.23ms]

 7 pass
 0 fail
 7 expect() calls
Ran 7 tests across 1 file. [3.85s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 717ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/24] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/24] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[3/24] gen cpp.rs (cppbind)
[4/24] gen JS modules (bundle-modules)
Preprocess modules (8522ms)
Bundle modules (41ms)
Postprocesss modules (220ms)
Bundle Functions (786ms)
Generate Code (31ms)

[9.62s] Bundled "src/js" for production
  2633 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[4/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_ast v0.0.0 (/workspace/bun/src/ast)
[1m[92m   Compiling[0m bun_install_types v0.0.0 (/workspace/bun/src/install_types)
[1m[92m   Compiling[0m bun_parsers v0.0.0 (/workspace/bun/src/parsers)
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/works
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/sql.mdx                     |  22 ++++
 packages/bun-types/sql.d.ts              |  17 ++++
 src/codegen/bake-codegen.ts              |   3 +-
 src/js/internal/sql/mysql.ts             |   1 +
 src/js/internal/sql/shared.ts            |  18 +++-
 src/js/private.d.ts                      |   2 +-
 src/sql_jsc/mysql/JSMySQLConnection.rs   |   2 +
 src/sql_jsc/mysql/MySQLConnection.rs     |  12 ++-
 test/js/sql/sql-mysql-found-rows.test.ts | 169 +++++++++++++++++++++++++++++++
 test/js/sql/wire-frames.ts               |  13 ++-
 10 files changed, 251 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 10

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
docs/runtime/sql.mdx                          2      1     25
packages/bun-types/sql.d.ts                   6      4     25
src/codegen/bake-codegen.ts                   5      9     25
src/js/internal/sql/mysql.ts                  8      6     25
src/js/internal/sql/shared.ts                14     17     25
src/js/private.d.ts                           5      5     25
src/sql_jsc/mysql/JSMySQLConnection.rs        8     12     25
src/sql_jsc/mysql/MySQLConnection.rs          9     10     25
test/js/sql/sql-mysql-found-rows.test.ts      2      5     25
test/js/sql/wire-frames.ts                    3      3     25
```

</details>

**root cause** · written by the author bot

Bun's MySQL client never requested the CLIENT_FOUND_ROWS capability during the protocol handshake, so UPDATE statements reported rows actually changed rather than rows matched, diverging from the default behavior of the mysql2 and mariadb drivers. The fix adds a foundRows connection option, settable via the options object or URL query string and defaulting to true, which is threaded from option parsing through the native binding into the connection's capability negotiation. When enabled, the CLIENT_FOUND_ROWS flag is set in the requested capabilities before intersecting with the server's, s…

<!-- robobun:evidence:end -->