### PR TITLE
child_process: support piping subprocess stdio streams between spawns

### DIFF
--- a/src/codegen/bake-codegen.ts
+++ b/src/codegen/bake-codegen.ts
@@ -56,7 +56,12 @@ async function run() {
           side: JSON.stringify(side),
           IS_ERROR_RUNTIME: String(file === "error"),
           IS_BUN_DEVELOPMENT: String(!!debug),
-          OVERLAY_CSS: css("../runtime/bake/client/overlay.css", !!debug),
+          // JSON.stringify: the JSON lexer rejects `*`/`?`/`(`/`)` before
+          // `parse_env_json`'s auto-quote fallback runs (see #30679). Without
+          // pre-quoting here, a minified-CSS string starting with `*{...}`
+          // breaks `bun run build:debug` on older bun versions that don't
+          // yet have the lexer recovery.
+          OVERLAY_CSS: JSON.stringify(css("../runtime/bake/client/overlay.css", !!debug)),
         },
         minify: {
           syntax: !debug,

--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -812,6 +812,15 @@ function writableFromFileSink(fileSink: any) {
   $assert(w[kWriteStreamFastPath] === true, "fast path not enabled");
   w[kWriteStreamFastPath] = fileSink;
   w.path = undefined;
+  // Expose the underlying pipe fd so this stream can be passed to
+  // `child_process.spawn` as stdio (e.g. `{ stdio: ['pipe', proc.stdin, ...] }`
+  // piping one subprocess's stdout into another subprocess's stdin) — node's
+  // equivalent `subprocess.stdin` is a `net.Socket` whose fd is discoverable,
+  // so `nodeToBun` expects `.fd` on stream stdio.
+  const fd = fileSink._getFd?.();
+  if (typeof fd === "number" && fd >= 0) {
+    w.fd = fd;
+  }
   return w;
 }
 

--- a/src/js/internal/streams/native-readable.ts
+++ b/src/js/internal/streams/native-readable.ts
@@ -245,6 +245,11 @@ function destroy(this: NativeReadable, error: any, cb: () => void) {
   if (ptr) {
     ptr.cancel(error);
   }
+  // `ptr.cancel` closes the underlying pipe fd, so clear the cached `fd` that
+  // `constructNativeReadable` exposed for stdio hand-off — otherwise a
+  // destroyed stream still reports a stale (closed or kernel-reused) fd to
+  // `child_process.spawn`. Mirrors the WriteStream fast-path `close()`.
+  this.fd = null;
   if (cb) {
     process.nextTick(cb);
   }

--- a/src/js/internal/streams/native-readable.ts
+++ b/src/js/internal/streams/native-readable.ts
@@ -44,6 +44,7 @@ interface NativePtr {
   pull: (view: any, closer: any) => any;
   updateRef: (ref: boolean) => void;
   cancel: (error: any) => void;
+  getFd: () => number;
 }
 
 let debugId = 0;
@@ -67,6 +68,18 @@ function constructNativeReadable(readableStream: ReadableStream, options): Nativ
   stream[kPendingRead] = false;
   stream[kHasResized] = !dynamicallyAdjustChunkSize();
   stream[kCloseState] = [false];
+
+  // Expose the underlying pipe fd (when available) so this stream can be
+  // passed to `child_process.spawn` as stdio — for example `spawn(..., {
+  // stdio: [proc.stdout, 'pipe', 'inherit'] })` to pipe one subprocess's
+  // stdout into another's stdin. `nodeToBun` extracts `.fd` from node-ish
+  // stream stdio; Node's equivalent is `subprocess.stdout._handle.fd`.
+  if (typeof bunNativePtr?.getFd === "function") {
+    const fd = bunNativePtr.getFd();
+    if (typeof fd === "number" && fd >= 0) {
+      stream.fd = fd;
+    }
+  }
 
   const highWaterMark = options.highWaterMark;
   stream[kHighWaterMark] = typeof highWaterMark === "number" ? highWaterMark : 256 * 1024;

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -41,6 +41,12 @@ var Uint8ArrayPrototypeIncludes = Uint8Array.prototype.includes;
 
 const MAX_BUFFER = 1024 * 1024;
 const kFromNode = Symbol("kFromNode");
+// Marker applied to a readable stream whose pipe fd has been handed off to
+// another subprocess's stdio. Used by `#handleOnExit`'s drain logic to skip
+// auto-resuming such streams — mirrors Node's `kIsUsedAsStdio` (see
+// lib/internal/child_process.js). Without this, our own `PipeReader` would
+// race the child for the pipe's bytes and the child would usually lose.
+const kIsUsedAsStdio = Symbol("kIsUsedAsStdio");
 
 // Pass DEBUG_CHILD_PROCESS=1 to enable debug output
 if ($debug) {
@@ -1134,13 +1140,15 @@ class ChildProcess extends EventEmitter {
 
       if (stdout === undefined) {
         this.#stdout = this.#getBunSpawnIo(1, this.#encoding, true);
-      } else if (stdout && this.#stdioOptions[1] === "pipe" && !stdout?.destroyed) {
+      } else if (stdout && this.#stdioOptions[1] === "pipe" && !stdout?.destroyed && !stdout[kIsUsedAsStdio]) {
+        // `kIsUsedAsStdio` marks a stream whose fd was handed off to another
+        // subprocess — resuming it here would drain bytes the child needs.
         stdout.resume?.();
       }
 
       if (stderr === undefined) {
         this.#stderr = this.#getBunSpawnIo(2, this.#encoding, true);
-      } else if (stderr && this.#stdioOptions[2] === "pipe" && !stderr?.destroyed) {
+      } else if (stderr && this.#stdioOptions[2] === "pipe" && !stderr?.destroyed && !stderr[kIsUsedAsStdio]) {
         stderr.resume?.();
       }
     }
@@ -1684,19 +1692,19 @@ function nodeToBun(item: string, index: number): string | number | null | NodeJS
     return item;
   }
   if (isNodeStreamReadable(item)) {
-    const itemFd = Object.hasOwn(item, "fd") ? item.fd : undefined;
-    if (typeof itemFd === "number") return itemFd;
-    const handle = item._handle;
-    const handleFd = handle ? handle.fd : undefined;
-    if (typeof handleFd === "number") return handleFd;
+    const fd = extractStreamFd(item);
+    if (fd !== undefined) {
+      markStreamAsStdio(item);
+      return fd;
+    }
     throw new Error(`TODO: stream.Readable stdio @ ${index}`);
   }
   if (isNodeStreamWritable(item)) {
-    const itemFd = Object.hasOwn(item, "fd") ? item.fd : undefined;
-    if (typeof itemFd === "number") return itemFd;
-    const handle = item._handle;
-    const handleFd = handle ? handle.fd : undefined;
-    if (typeof handleFd === "number") return handleFd;
+    const fd = extractStreamFd(item);
+    if (fd !== undefined) {
+      markStreamAsStdio(item);
+      return fd;
+    }
     throw new Error(`TODO: stream.Writable stdio @ ${index}`);
   }
   const result = nodeToBunLookup[item];
@@ -1704,6 +1712,62 @@ function nodeToBun(item: string, index: number): string | number | null | NodeJS
     throw new Error(`Invalid stdio option[${index}] "${item}"`);
   }
   return result;
+}
+
+/**
+ * Extract the underlying pipe/file fd from a Node-ish stream suitable for
+ * forwarding to `Bun.spawn` as `stdio`. Handles three shapes:
+ *   - `item.fd` is already a number (our own `WriteStream` / `NativeReadable`
+ *     set `.fd` from the FileSink / ReadableStreamSource; Node's own
+ *     `fs.ReadStream` / `fs.WriteStream` set it after open)
+ *   - `item._handle.fd` is a number (Node's `net.Socket`-backed subprocess
+ *     streams expose the pipe fd here — we don't emit this but accept it)
+ * Returns `undefined` when no fd is available so the caller can raise the
+ * `TODO: stream.Readable/Writable stdio` error.
+ */
+function extractStreamFd(item: any): number | undefined {
+  if (Object.hasOwn(item, "fd") && typeof item.fd === "number") return item.fd;
+  if (item._handle && typeof item._handle.fd === "number") return item._handle.fd;
+  return undefined;
+}
+
+/**
+ * Quiesce a source stream whose fd is being inherited by a child. Mirrors
+ * Node's `getValidStdio` post-spawn hook: tell the libuv-equivalent reader
+ * to stop polling + pause the JS Readable + tag with `kIsUsedAsStdio` so
+ * nothing in the parent drains the pipe that the child is now the sole
+ * reader of.
+ *
+ *   - `$bunNativePtr?.setFlowing(false)` / `.updateRef(false)` stop Bun's
+ *     internal `FileReader` / `BufferedReader` from issuing further
+ *     `read(2)`s on the pipe fd — the equivalent of libuv's `readStop()`.
+ *   - `.pause()` clears the consumer-side flowing flag so `_read` won't
+ *     call `pull` again.
+ *   - The `kIsUsedAsStdio` tag tells `#handleOnExit` to skip the
+ *     `stdout.resume?.()` that would otherwise resurrect reading right as
+ *     the child starts.
+ */
+function markStreamAsStdio(item: any) {
+  item[kIsUsedAsStdio] = true;
+  const ptr = item.$bunNativePtr;
+  if (ptr) {
+    try {
+      ptr.setFlowing?.(false);
+    } catch {}
+    try {
+      ptr.updateRef?.(false);
+    } catch {}
+  }
+  if (typeof item.pause === "function") {
+    try {
+      item.pause();
+    } catch {}
+  }
+  const rs = item._readableState;
+  if (rs) {
+    rs.reading = false;
+    rs.flowing = false;
+  }
 }
 
 /**

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1730,6 +1730,9 @@ function nodeToBun(
       streamsToQuiesce.push(item);
       return fd;
     }
+    if (item.destroyed === true) {
+      throw new Error(`Cannot use a destroyed stream as stdio[${index}]`);
+    }
     throw new Error(`TODO: stream.Readable stdio @ ${index}`);
   }
   if (isNodeStreamWritable(item)) {
@@ -1737,6 +1740,9 @@ function nodeToBun(
     if (fd !== undefined) {
       streamsToQuiesce.push(item);
       return fd;
+    }
+    if (item.destroyed === true) {
+      throw new Error(`Cannot use a destroyed stream as stdio[${index}]`);
     }
     throw new Error(`TODO: stream.Writable stdio @ ${index}`);
   }

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1755,10 +1755,17 @@ function nodeToBun(
  *     `fs.ReadStream` / `fs.WriteStream` set it after open.
  *   - `item._handle.fd` is a number — Node's `net.Socket`-backed subprocess
  *     streams expose the pipe fd here; we don't emit this but accept it.
+ * A destroyed stream is rejected up front: its fd has been (or is about to be)
+ * closed, and not every destroy path clears the cached `.fd` synchronously
+ * (the `WriteStream` fast-path only nulls it in `close()`, which the async
+ * `_destroy` branch skips when the sink still has buffered bytes). Forwarding
+ * such an fd would `dup2` a stale (possibly kernel-reused) descriptor into the
+ * child, so guarding here covers both the readable and writable sides.
  * Returns `undefined` when no fd is available so the caller can raise the
  * stream-stdio-unsupported error.
  */
 function extractStreamFd(item: any): number | undefined {
+  if (item.destroyed === true) return undefined;
   if (Object.hasOwn(item, "fd")) {
     const fd = item.fd;
     if (typeof fd === "number") return fd;

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -534,7 +534,10 @@ function spawnSync(file, args, options) {
   options.killSignal = sanitizeKillSignal(options.killSignal);
 
   const stdio = options.stdio || "pipe";
-  const { bunStdio, streamsToQuiesce } = getBunStdioFromOptions(stdio);
+  // Sync path: only the `bunStdio` fd mapping matters. Unlike async `spawn`,
+  // the source streams are not quiesced (see below at the `Bun.spawnSync`
+  // call), so `streamsToQuiesce` is intentionally ignored here.
+  const { bunStdio } = getBunStdioFromOptions(stdio);
 
   var { input } = options;
   if (input) {
@@ -578,9 +581,12 @@ function spawnSync(file, args, options) {
       killSignal: options.killSignal,
       maxBuffer: options.maxBuffer,
     });
-    // Only quiesce source streams after spawn has taken over the fd —
-    // see `markStreamsAsStdio`.
-    if (streamsToQuiesce.length > 0) markStreamsAsStdio(streamsToQuiesce);
+    // No quiescing on the sync path. `Bun.spawnSync` blocks the JS thread
+    // until the child exits, so the parent's reader can't race it, and this
+    // line only runs once the child is already gone. Calling
+    // `markStreamsAsStdio` here would have no upside and its irreversible
+    // `setFlowing(false)` would permanently brick the source stream (e.g.
+    // `process.stdin`). Node likewise does not mark streams in `spawnSync`.
   } catch (err) {
     error = err;
     stdout = null;

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1723,7 +1723,7 @@ function nodeToBun(item: string, index: number): string | number | null | NodeJS
  *   - `item._handle.fd` is a number (Node's `net.Socket`-backed subprocess
  *     streams expose the pipe fd here — we don't emit this but accept it)
  * Returns `undefined` when no fd is available so the caller can raise the
- * `TODO: stream.Readable/Writable stdio` error.
+ * stream-stdio-unsupported error.
  */
 function extractStreamFd(item: any): number | undefined {
   if (Object.hasOwn(item, "fd") && typeof item.fd === "number") return item.fd;

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1753,8 +1753,15 @@ function nodeToBun(
  * stream-stdio-unsupported error.
  */
 function extractStreamFd(item: any): number | undefined {
-  if (Object.hasOwn(item, "fd") && typeof item.fd === "number") return item.fd;
-  if (item._handle && typeof item._handle.fd === "number") return item._handle.fd;
+  if (Object.hasOwn(item, "fd")) {
+    const fd = item.fd;
+    if (typeof fd === "number") return fd;
+  }
+  const handle = item._handle;
+  if (handle) {
+    const fd = handle.fd;
+    if (typeof fd === "number") return fd;
+  }
   return undefined;
 }
 

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1143,16 +1143,29 @@ class ChildProcess extends EventEmitter {
 
       if (stdout === undefined) {
         this.#stdout = this.#getBunSpawnIo(1, this.#encoding, true);
-      } else if (stdout && this.#stdioOptions[1] === "pipe" && !stdout?.destroyed && !stdout[kIsUsedAsStdio]) {
-        // `kIsUsedAsStdio` marks a stream whose fd was handed off to another
-        // subprocess — resuming it here would drain bytes the child needs.
-        stdout.resume?.();
+      } else if (stdout && this.#stdioOptions[1] === "pipe" && !stdout?.destroyed) {
+        if (stdout[kIsUsedAsStdio]) {
+          // The fd was handed to another child; we marked this stream paused +
+          // `updateRef(false)` in `markStreamsAsStdio`, which unregisters the
+          // native FilePoll — so the stream will never see EOF on its own and
+          // never emit `'close'`. Without `'close'` the `#closesNeeded` tally
+          // stalls one short and we'd never emit `this`'s `'close'` either.
+          // `destroy()` fires `'close'` synchronously-ish and releases the
+          // now-useless parent-side read fd.
+          stdout.destroy?.();
+        } else {
+          stdout.resume?.();
+        }
       }
 
       if (stderr === undefined) {
         this.#stderr = this.#getBunSpawnIo(2, this.#encoding, true);
-      } else if (stderr && this.#stdioOptions[2] === "pipe" && !stderr?.destroyed && !stderr[kIsUsedAsStdio]) {
-        stderr.resume?.();
+      } else if (stderr && this.#stdioOptions[2] === "pipe" && !stderr?.destroyed) {
+        if (stderr[kIsUsedAsStdio]) {
+          stderr.destroy?.();
+        } else {
+          stderr.resume?.();
+        }
       }
     }
 

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1773,10 +1773,13 @@ function extractStreamFd(item: any): number | undefined {
 
 /**
  * Quiesce source streams whose fds have been inherited by a child. MUST be
- * invoked AFTER `Bun.spawn` / `Bun.spawnSync` returns successfully — the
+ * invoked AFTER `Bun.spawn` returns successfully: the
  * `$bunNativePtr.setFlowing(false)` side-effect is sticky at the native
  * layer with no user-recoverable counterpart, so running it when spawn
- * then throws would leave the source stream permanently stuck.
+ * then throws would leave the source stream permanently stuck. The sync
+ * path deliberately does not call this (see the comment at the
+ * `Bun.spawnSync` call site); Node likewise does not mark streams in
+ * `spawnSync`.
  *
  * Mirrors Node's `getValidStdio` post-spawn hook (`readStop()` + `pause()`
  * + `kIsUsedAsStdio` tag in `lib/internal/child_process.js`):

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -534,7 +534,7 @@ function spawnSync(file, args, options) {
   options.killSignal = sanitizeKillSignal(options.killSignal);
 
   const stdio = options.stdio || "pipe";
-  const bunStdio = getBunStdioFromOptions(stdio);
+  const { bunStdio, streamsToQuiesce } = getBunStdioFromOptions(stdio);
 
   var { input } = options;
   if (input) {
@@ -578,6 +578,9 @@ function spawnSync(file, args, options) {
       killSignal: options.killSignal,
       maxBuffer: options.maxBuffer,
     });
+    // Only quiesce source streams after spawn has taken over the fd —
+    // see `markStreamsAsStdio`.
+    if (streamsToQuiesce.length > 0) markStreamsAsStdio(streamsToQuiesce);
   } catch (err) {
     error = err;
     stdout = null;
@@ -1357,7 +1360,7 @@ class ChildProcess extends EventEmitter {
     const serialization = options.serialization || "json";
 
     const stdio = options.stdio || ["pipe", "pipe", "pipe"];
-    const bunStdio = getBunStdioFromOptions(stdio);
+    const { bunStdio, streamsToQuiesce } = getBunStdioFromOptions(stdio);
     // Extra "pipe" slots (i >= 3) are wrapped in a net.Socket by
     // #getBunSpawnIo, which hands the fd to usockets (usockets closes it on
     // socket close). Use Bun.spawn's "socket-fd" so the parent end is stored
@@ -1445,6 +1448,13 @@ class ChildProcess extends EventEmitter {
       this.pid = this.#handle.pid;
 
       $debug("ChildProcess: spawn", this.pid, spawnargs);
+
+      // Only quiesce source streams after spawn has taken over the fd —
+      // see `markStreamsAsStdio`. Doing this before spawn (or running it on
+      // the catch path below) would leave the source stream permanently
+      // stuck if spawn throws, since `setFlowing(false)` has no
+      // user-recoverable counterpart.
+      if (streamsToQuiesce.length > 0) markStreamsAsStdio(streamsToQuiesce);
 
       process.nextTick(() => {
         this.emit("spawn");
@@ -1680,7 +1690,11 @@ const nodeToBunLookup = {
   ipc: "ipc",
 };
 
-function nodeToBun(item: string, index: number): string | number | null | NodeJS.TypedArray | ArrayBufferView {
+function nodeToBun(
+  item: any,
+  index: number,
+  streamsToQuiesce: any[],
+): string | number | null | NodeJS.TypedArray | ArrayBufferView {
   // If not defined, use the default.
   // For stdin/stdout/stderr, it's pipe. For others, it's ignore.
   if (item == null) {
@@ -1694,7 +1708,7 @@ function nodeToBun(item: string, index: number): string | number | null | NodeJS
   if (isNodeStreamReadable(item)) {
     const fd = extractStreamFd(item);
     if (fd !== undefined) {
-      markStreamAsStdio(item);
+      streamsToQuiesce.push(item);
       return fd;
     }
     throw new Error(`TODO: stream.Readable stdio @ ${index}`);
@@ -1702,7 +1716,7 @@ function nodeToBun(item: string, index: number): string | number | null | NodeJS
   if (isNodeStreamWritable(item)) {
     const fd = extractStreamFd(item);
     if (fd !== undefined) {
-      markStreamAsStdio(item);
+      streamsToQuiesce.push(item);
       return fd;
     }
     throw new Error(`TODO: stream.Writable stdio @ ${index}`);
@@ -1716,12 +1730,12 @@ function nodeToBun(item: string, index: number): string | number | null | NodeJS
 
 /**
  * Extract the underlying pipe/file fd from a Node-ish stream suitable for
- * forwarding to `Bun.spawn` as `stdio`. Handles three shapes:
- *   - `item.fd` is already a number (our own `WriteStream` / `NativeReadable`
+ * forwarding to `Bun.spawn` as `stdio`.
+ *   - `item.fd` is already a number — our own `WriteStream` / `NativeReadable`
  *     set `.fd` from the FileSink / ReadableStreamSource; Node's own
- *     `fs.ReadStream` / `fs.WriteStream` set it after open)
- *   - `item._handle.fd` is a number (Node's `net.Socket`-backed subprocess
- *     streams expose the pipe fd here — we don't emit this but accept it)
+ *     `fs.ReadStream` / `fs.WriteStream` set it after open.
+ *   - `item._handle.fd` is a number — Node's `net.Socket`-backed subprocess
+ *     streams expose the pipe fd here; we don't emit this but accept it.
  * Returns `undefined` when no fd is available so the caller can raise the
  * stream-stdio-unsupported error.
  */
@@ -1732,12 +1746,14 @@ function extractStreamFd(item: any): number | undefined {
 }
 
 /**
- * Quiesce a source stream whose fd is being inherited by a child. Mirrors
- * Node's `getValidStdio` post-spawn hook: tell the libuv-equivalent reader
- * to stop polling + pause the JS Readable + tag with `kIsUsedAsStdio` so
- * nothing in the parent drains the pipe that the child is now the sole
- * reader of.
+ * Quiesce source streams whose fds have been inherited by a child. MUST be
+ * invoked AFTER `Bun.spawn` / `Bun.spawnSync` returns successfully — the
+ * `$bunNativePtr.setFlowing(false)` side-effect is sticky at the native
+ * layer with no user-recoverable counterpart, so running it when spawn
+ * then throws would leave the source stream permanently stuck.
  *
+ * Mirrors Node's `getValidStdio` post-spawn hook (`readStop()` + `pause()`
+ * + `kIsUsedAsStdio` tag in `lib/internal/child_process.js`):
  *   - `$bunNativePtr?.setFlowing(false)` / `.updateRef(false)` stop Bun's
  *     internal `FileReader` / `BufferedReader` from issuing further
  *     `read(2)`s on the pipe fd — the equivalent of libuv's `readStop()`.
@@ -1747,26 +1763,28 @@ function extractStreamFd(item: any): number | undefined {
  *     `stdout.resume?.()` that would otherwise resurrect reading right as
  *     the child starts.
  */
-function markStreamAsStdio(item: any) {
-  item[kIsUsedAsStdio] = true;
-  const ptr = item.$bunNativePtr;
-  if (ptr) {
-    try {
-      ptr.setFlowing?.(false);
-    } catch {}
-    try {
-      ptr.updateRef?.(false);
-    } catch {}
-  }
-  if (typeof item.pause === "function") {
-    try {
-      item.pause();
-    } catch {}
-  }
-  const rs = item._readableState;
-  if (rs) {
-    rs.reading = false;
-    rs.flowing = false;
+function markStreamsAsStdio(streams: any[]) {
+  for (const item of streams) {
+    item[kIsUsedAsStdio] = true;
+    const ptr = item.$bunNativePtr;
+    if (ptr) {
+      try {
+        ptr.setFlowing?.(false);
+      } catch {}
+      try {
+        ptr.updateRef?.(false);
+      } catch {}
+    }
+    if (typeof item.pause === "function") {
+      try {
+        item.pause();
+      } catch {}
+    }
+    const rs = item._readableState;
+    if (rs) {
+      rs.reading = false;
+      rs.flowing = false;
+    }
   }
 }
 
@@ -1811,7 +1829,10 @@ function fdToStdioName(fd: number) {
   }
 }
 
-function getBunStdioFromOptions(stdio) {
+function getBunStdioFromOptions(stdio): {
+  bunStdio: (string | number | null | NodeJS.TypedArray | ArrayBufferView)[];
+  streamsToQuiesce: any[];
+} {
   const normalizedStdio = normalizeStdio(stdio);
   if (normalizedStdio.filter(v => v === "ipc").length > 1) throw $ERR_IPC_ONE_PIPE();
   // Node options:
@@ -1820,7 +1841,7 @@ function getBunStdioFromOptions(stdio) {
   // overlapped -- same as pipe on Unix based systems
   // inherit -- 'inherit': equivalent to ['inherit', 'inherit', 'inherit'] or [0, 1, 2]
   // ignore -- > /dev/null, more or less same as null option for Bun.spawn stdio
-  // TODO: Stream -- use this stream
+  // Stream -- handled by `nodeToBun` via fd extraction + `streamsToQuiesce`.
   // number -- used as FD
   // null, undefined: Use default value. Not same as ignore, which is Bun.spawn null.
   // null/undefined: For stdio fds 0, 1, and 2 (in other words, stdin, stdout, and stderr) a pipe is created. For fd 3 and up, the default is 'ignore'
@@ -1835,9 +1856,10 @@ function getBunStdioFromOptions(stdio) {
   // overlapped -> pipe
   // ignore -> null
   // inherit -> inherit (stdin/stdout/stderr)
-  // Stream -> throw err for now
-  const bunStdio = normalizedStdio.map(nodeToBun);
-  return bunStdio;
+  // Stream -> extract its fd and record the stream for post-spawn quiesce.
+  const streamsToQuiesce: any[] = [];
+  const bunStdio = normalizedStdio.map((item, i) => nodeToBun(item, i, streamsToQuiesce));
+  return { bunStdio, streamsToQuiesce };
 }
 
 function normalizeStdio(stdio): string[] {

--- a/src/runtime/api/streams.classes.ts
+++ b/src/runtime/api/streams.classes.ts
@@ -52,6 +52,10 @@ function source(name) {
       isClosed: {
         getter: "getIsClosedFromJS",
       },
+      getFd: {
+        fn: "getFdFromJS",
+        length: 0,
+      },
       ...(name !== "File"
         ? // Buffered versions
           // not implemented in File, yet.

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -1159,6 +1159,22 @@ impl readable_stream::SourceContext for FileReader {
     fn set_flowing(&mut self, flag: bool) {
         Self::set_flowing(self, flag)
     }
+    fn get_fd(&self) -> i64 {
+        // The `fd` field is only populated after `on_start` resolves the lazy
+        // blob/path; before that (and for pipe-backed streams constructed via
+        // `ReadableStream::from_pipe`) the real fd lives in the buffered
+        // reader's pipe handle instead. Prefer the pipe handle first so the
+        // subprocess stdout/stderr path yields the pipe fd immediately.
+        let reader_fd = self.reader().get_fd();
+        if reader_fd != Fd::INVALID {
+            return reader_fd.uv() as i64;
+        }
+        let field_fd = self.fd.get();
+        if field_fd != Fd::INVALID {
+            return field_fd.uv() as i64;
+        }
+        -1
+    }
     // toBufferedValue: null
 }
 

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -1160,20 +1160,36 @@ impl readable_stream::SourceContext for FileReader {
         Self::set_flowing(self, flag)
     }
     fn get_fd(&self) -> i64 {
-        // The `fd` field is only populated after `on_start` resolves the lazy
-        // blob/path; before that (and for pipe-backed streams constructed via
-        // `ReadableStream::from_pipe`) the real fd lives in the buffered
-        // reader's pipe handle instead. Prefer the pipe handle first so the
-        // subprocess stdout/stderr path yields the pipe fd immediately.
-        let reader_fd = self.reader().get_fd();
-        if reader_fd != Fd::INVALID {
-            return reader_fd.uv() as i64;
+        // Windows: the pipe handle is system-kind (`Fd::from_system(pipe.fd())`
+        // in `bun_io::PipeReader::WindowsBufferedReader::Source::Pipe`), and
+        // `Fd::uv()` panics for non-stdio system HANDLEs. Until we have a
+        // safe handle→uv-fd round-trip (`makeLibUVOwned`-style) for inherited
+        // subprocess stdio on Windows, return `-1` so `constructNativeReadable`
+        // sees no fd and `nodeToBun`'s stream-stdio path falls back to the
+        // unsupported-stdio error instead of crashing the parent on any piped
+        // spawn.
+        #[cfg(windows)]
+        {
+            return -1;
         }
-        let field_fd = self.fd.get();
-        if field_fd != Fd::INVALID {
-            return field_fd.uv() as i64;
+        // POSIX path: the `fd` field is only populated after `on_start`
+        // resolves the lazy blob/path; before that (and for pipe-backed
+        // streams constructed via `ReadableStream::from_pipe`) the real fd
+        // lives in the buffered reader's pipe handle instead. Prefer the
+        // pipe handle first so the subprocess stdout/stderr path yields the
+        // pipe fd immediately.
+        #[cfg(not(windows))]
+        {
+            let reader_fd = self.reader().get_fd();
+            if reader_fd != Fd::INVALID {
+                return reader_fd.uv() as i64;
+            }
+            let field_fd = self.fd.get();
+            if field_fd != Fd::INVALID {
+                return field_fd.uv() as i64;
+            }
+            -1
         }
-        -1
     }
     // toBufferedValue: null
 }

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -647,6 +647,16 @@ pub trait SourceContext: Sized {
 
     /// Default no-op.
     fn set_flowing(&mut self, _flag: bool) {}
+
+    /// Returns the underlying native file descriptor (POSIX) / HANDLE-as-int
+    /// (Windows) for this source, or a negative value if not available. Used
+    /// by `node:child_process` to pipe subprocess stdout/stderr between
+    /// processes: the stream wraps a pipe fd that must be forwarded to the
+    /// child's `dup2` list, matching Node.js where `subprocess.stdout._handle.fd`
+    /// exposes the same fd.
+    fn get_fd(&self) -> i64 {
+        -1
+    }
 }
 
 // Hand-wired JSC class (the `#[bun_jsc::JsClass]` derive cannot be used on a
@@ -1239,6 +1249,19 @@ impl<C: SourceContext> NewSource<C> {
         let ref_or_unref = call_frame.argument(0).to_boolean();
         self.set_ref(ref_or_unref);
         Ok(JSValue::UNDEFINED)
+    }
+
+    /// `getFd()` host-fn: returns the underlying pipe/file descriptor as a JS
+    /// number (uv handle on Windows), or `-1` if not available. Consumed by
+    /// `node:child_process` to detect Bun's native readables wrapping
+    /// `subprocess.stdout`/`stderr`, so they can be forwarded to another
+    /// spawn's `dup2` as an fd.
+    pub fn get_fd_from_js(
+        &mut self,
+        _global_object: &JSGlobalObject,
+        _call_frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        Ok(JSValue::js_number(self.context.get_fd() as f64))
     }
 
     pub fn finalize(self: Box<Self>) {

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -887,6 +887,17 @@ pub unsafe fn spawn_process_posix(
                 set_spawned_stdio(&mut spawned, i, fds[0]);
             }
             PosixStdio::Pipe(fd) => {
+                // User-supplied fd (number in the stdio array, including
+                // another subprocess's `stdin`/`stdout`/`stderr` whose fd we
+                // extracted in `nodeToBun`). `dup2` shares the open file
+                // description — so if the parent set this fd non-blocking for
+                // its own async reads, the child inherits `O_NONBLOCK` and its
+                // first `read(2)` returns `EAGAIN` (e.g. `cat` exits 1 with
+                // "Resource temporarily unavailable"). Clear non-blocking now,
+                // before spawn; the parent's own reader has been paused by the
+                // time we get here (see `markStreamAsStdio` in
+                // `node:child_process`).
+                let _ = bun_sys::update_nonblocking(*fd, false);
                 actions.dup2(*fd, fileno)?;
                 set_spawned_stdio(&mut spawned, i, *fd);
             }

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -887,16 +887,21 @@ pub unsafe fn spawn_process_posix(
                 set_spawned_stdio(&mut spawned, i, fds[0]);
             }
             PosixStdio::Pipe(fd) => {
-                // User-supplied fd (number in the stdio array, including
-                // another subprocess's `stdin`/`stdout`/`stderr` whose fd we
-                // extracted in `nodeToBun`). `dup2` shares the open file
-                // description — so if the parent set this fd non-blocking for
-                // its own async reads, the child inherits `O_NONBLOCK` and its
-                // first `read(2)` returns `EAGAIN` (e.g. `cat` exits 1 with
-                // "Resource temporarily unavailable"). Clear non-blocking now,
-                // before spawn; the parent's own reader has been paused by the
-                // time we get here (see `markStreamAsStdio` in
-                // `node:child_process`).
+                // Caller-supplied fd bound for the child's stdin/stdout/stderr
+                // (raw number in the stdio array, `Bun.file(fd)`, memfd, or a
+                // stream fd extracted by `nodeToBun`). Children use blocking
+                // stdio — a synchronous reader like `cat` exits 1 with
+                // "Resource temporarily unavailable" on its first `read(2)`
+                // when `O_NONBLOCK` is set — but `O_NONBLOCK` lives on the
+                // open file description, not the descriptor, so `dup2` shares
+                // the flag between parent and child. Clearing it here affects
+                // both; that's unavoidable, and matches libuv's
+                // `uv__process_child_init`, which runs the same
+                // `uv__nonblock_fcntl(fd, 0)` post-fork in the child (same
+                // OFD, same observable effect on the parent). For the
+                // `markStreamsAsStdio` caller the parent's reader is already
+                // paused, so parent-going-blocking is moot; for direct
+                // numeric-fd callers this is documented Node-parity.
                 let _ = bun_sys::update_nonblocking(*fd, false);
                 actions.dup2(*fd, fileno)?;
                 set_spawned_stdio(&mut spawned, i, *fd);

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -898,9 +898,10 @@ pub unsafe fn spawn_process_posix(
                 // both; that's unavoidable, and matches libuv's
                 // `uv__process_child_init`, which runs the same
                 // `uv__nonblock_fcntl(fd, 0)` post-fork in the child (same
-                // OFD, same observable effect on the parent). For the
-                // `markStreamsAsStdio` caller the parent's reader is already
-                // paused, so parent-going-blocking is moot; for direct
+                // OFD, same observable effect on the parent). The
+                // `markStreamsAsStdio` caller pauses the parent's reader on
+                // the same JS tick once spawn returns (no FilePoll fires in
+                // between), so parent-going-blocking is moot; for direct
                 // numeric-fd callers this is documented Node-parity.
                 let _ = bun_sys::update_nonblocking(*fd, false);
                 actions.dup2(*fd, fileno)?;

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -73,8 +73,9 @@ describe("Bun.build", () => {
 
   // A `define:` value that isn't valid JSON or a JS identifier is auto-quoted
   // (treated as a string literal). The JSON lexer must not error eagerly on the
-  // first character — a raw minified CSS string starts with `*{...}`, which
-  // src/codegen/bake-codegen.ts passes verbatim as `OVERLAY_CSS`.
+  // first character — a raw minified CSS string starts with `*{...}`, originally
+  // what src/codegen/bake-codegen.ts passed verbatim as `OVERLAY_CSS` (now
+  // `JSON.stringify`d there for old-bun bootstrap compat).
   describe.each([
     "*{box-sizing:border-box}.root{all:initial}",
     "?foo",

--- a/test/js/node/child_process/child-process-stdio-streams.test.ts
+++ b/test/js/node/child_process/child-process-stdio-streams.test.ts
@@ -1,31 +1,21 @@
 // https://github.com/oven-sh/bun/issues/30831
+// https://github.com/oven-sh/bun/issues/25498
 //
-// `child_process.spawn` was unable to pipe one subprocess's stdio stream into
-// another: `spawn(..., { stdio: [..., otherProc.stdin, ...] })` threw
-// `stream.Readable stdio @ N` (unsupported) because `nodeToBun()` in
+// `child_process.spawn` / `spawnSync` could not pipe one subprocess's stdio
+// stream into another: `spawn(..., { stdio: [..., otherProc.stdin, ...] })`
+// threw `stream.Readable stdio @ N` because `nodeToBun()` in
 // `node:child_process` looked for `.fd` / `_handle.fd` on the stream (Node's
 // `subprocess.stdin` is a `net.Socket` that exposes its pipe fd there), but
 // Bun's `subprocess.stdin` is a `WriteStream` wrapping a `FileSink` and
 // `subprocess.stdout`/`stderr` is a `Readable` wrapping a native
-// `ReadableStream`. Neither surfaced the underlying pipe fd.
+// `ReadableStream`, neither of which surfaced the underlying pipe fd.
 //
-// Fix (three parts — removing any of the first three breaks one of the first
-// three tests; the fourth test guards the ordering of part 2):
-//   1. Surface `.fd` on both wrappers at construction time from the
-//      underlying sink/source, so `nodeToBun` can forward the fd.
-//   2. When `nodeToBun` extracts an fd from a stream, record the stream in a
-//      `streamsToQuiesce` list; after `Bun.spawn` succeeds, pause each one
-//      and tag it `kIsUsedAsStdio`. Mirrors Node's `getValidStdio`
-//      post-spawn `readStop`/`pause`, without which the parent's own
-//      `PipeReader` races the child for the pipe's bytes. The quiesce
-//      runs AFTER spawn because `setFlowing(false)` is sticky at the
-//      native layer with no user-recoverable counterpart — if we paused
-//      pre-spawn and spawn then threw, the source stream would be stuck
-//      forever.
-//   3. `Bun.spawn`'s POSIX path clears `O_NONBLOCK` on the caller-supplied
-//      fd before `dup2`; otherwise the child inherits non-blocking mode (the
-//      parent set it for async reads) and a synchronous reader like `cat`
-//      gets `EAGAIN: Resource temporarily unavailable` on its first read.
+// The fix surfaces `.fd` on both wrappers, records forwarded streams so they
+// can be quiesced after `Bun.spawn` succeeds (mirroring Node's `getValidStdio`
+// `readStop`/`pause`, so the parent's `PipeReader` does not race the child for
+// the pipe bytes), clears `O_NONBLOCK` on the caller-supplied fd before `dup2`
+// (so a synchronous child reader does not get `EAGAIN`), and rejects destroyed
+// streams so a stale fd is never forwarded.
 
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows } from "harness";
@@ -104,7 +94,7 @@ test.skipIf(isWindows)(
     const sourceStderr = collect(pSource.stderr!);
     // `markStreamsAsStdio` unregisters the FilePoll on `pSource.stdout`, so
     // without the close-accounting fix in `#handleOnExit` this `'close'`
-    // promise never resolves even after `pSource` exits — guard that path.
+    // promise never resolves even after `pSource` exits; guard that path.
     const sourceClose = new Promise<void>(r => pSource.once("close", () => r()));
 
     using pFilter = spawn(bunExe(), ["-e", UPPER], {
@@ -127,10 +117,10 @@ test.skipIf(isWindows)(
         pFilter.once("exit", code => r(code));
       }),
     ]);
-    // `'close'` should also fire — otherwise libraries like `execa` that
-    // await close (not exit) hang indefinitely. If this promise never
-    // resolves (pre-fix behavior), the test times out rather than
-    // racing its own setTimeout.
+    // `'close'` should also fire, otherwise libraries like `execa` that await
+    // close (not exit) hang indefinitely. If this promise never resolves
+    // (pre-fix behavior), the test times out rather than racing its own
+    // setTimeout.
     await sourceClose;
     expect(filterErr).toBe("");
     expect(sourceErr).toBe("");
@@ -145,8 +135,8 @@ test.skipIf(isWindows)(
   async () => {
     // `process.stdout.fd === 1` / `process.stderr.fd === 2` are set by
     // `getStdioWriteStream`. These have always been numeric-fd objects in
-    // Bun, so they were already accepted by `nodeToBun`'s `.fd` lookup — but
-    // this PR routes them through the new `extractStreamFd` + `streamsToQuiesce`
+    // Bun, so they were already accepted by `nodeToBun`'s `.fd` lookup; this
+    // PR routes them through the new `extractStreamFd` + `streamsToQuiesce`
     // path too, and a later refactor could accidentally drop them. A
     // sub-bun runner actually performs the passthrough spawn and prints
     // whether it succeeded to *its* stdout, which the outer test captures.
@@ -231,10 +221,10 @@ test.skipIf(isWindows)("a destroyed subprocess stdout does not leak a stale fd t
   expect((pSource.stdout as any).fd).toBeNull();
 
   // The destroyed stream must not be accepted as stdio with that stale fd:
-  // `extractStreamFd` now returns undefined, so `spawn` raises the
-  // unsupported-stream-stdio error instead of `dup2`'ing a closed fd.
+  // `extractStreamFd` returns undefined for it, so `spawn` raises a
+  // destroyed-stream error instead of `dup2`'ing a closed fd.
   expect(() => spawn(bunExe(), ["-e", ""], { stdio: [pSource.stdout!, "pipe", "ignore"], env: bunEnv })).toThrow(
-    /stream\.Readable stdio/,
+    /Cannot use a destroyed stream/,
   );
 });
 
@@ -266,8 +256,8 @@ test.skipIf(isWindows)("a destroyed subprocess stdin does not leak a stale fd to
   // caches the pipe fd on `stdin.fd`. The WriteStream `_destroy` only nulls it
   // via `close()`, which it skips on the async path (the sink still has
   // buffered bytes), so a destroyed stdin can retain a stale fd. `extractStreamFd`
-  // rejects destroyed streams, so `spawn` raises the unsupported-stream-stdio
-  // error instead of `dup2`'ing a closed (or kernel-reused) fd into the child.
+  // rejects destroyed streams, so `spawn` raises a destroyed-stream error
+  // instead of `dup2`'ing a closed (or kernel-reused) fd into the child.
   using pSink = spawn(bunExe(), ["-e", "setInterval(() => {}, 1 << 30)"], {
     stdio: ["pipe", "ignore", "ignore"],
     env: bunEnv,
@@ -283,7 +273,7 @@ test.skipIf(isWindows)("a destroyed subprocess stdin does not leak a stale fd to
   expect(pSink.stdin!.destroyed).toBe(true);
 
   expect(() => spawn(bunExe(), ["-e", ""], { stdio: ["ignore", pSink.stdin!, "ignore"], env: bunEnv })).toThrow(
-    /stream\.(Writable|Readable) stdio/,
+    /Cannot use a destroyed stream/,
   );
 });
 

--- a/test/regression/issue/30831.test.ts
+++ b/test/regression/issue/30831.test.ts
@@ -23,8 +23,8 @@
 //      gets `EAGAIN: Resource temporarily unavailable` on its first read.
 
 import { expect, test } from "bun:test";
-import { spawn } from "node:child_process";
 import { bunEnv, bunExe } from "harness";
+import { spawn } from "node:child_process";
 
 // Tiny uppercasing filter implemented in bun itself so the test doesn't
 // depend on `perl`/`tr`/`awk` being installed on the runner.

--- a/test/regression/issue/30831.test.ts
+++ b/test/regression/issue/30831.test.ts
@@ -94,6 +94,10 @@ test("spawn({ stdio: [otherProc.stdout, ...] }) pipes A's stdout into B's stdin 
     env: bunEnv,
   });
   const sourceStderr = collect(pSource.stderr!);
+  // `markStreamsAsStdio` unregisters the FilePoll on `pSource.stdout`, so
+  // without the close-accounting fix in `#handleOnExit` this `'close'`
+  // promise never resolves even after `pSource` exits — guard that path.
+  const sourceClose = new Promise<void>(r => pSource.once("close", () => r()));
 
   using pFilter = spawn(bunExe(), ["-e", UPPER], {
     stdio: [pSource.stdout!, "pipe", "pipe"],
@@ -102,18 +106,29 @@ test("spawn({ stdio: [otherProc.stdout, ...] }) pipes A's stdout into B's stdin 
   const filterStdout = collect(pFilter.stdout!);
   const filterStderr = collect(pFilter.stderr!);
 
-  const [out, filterErr, sourceErr, filterExit] = await Promise.all([
+  const [out, filterErr, sourceErr, sourceExit, filterExit] = await Promise.all([
     filterStdout,
     filterStderr,
     sourceStderr,
+    new Promise<number | null>(r => {
+      if (pSource.exitCode != null) return r(pSource.exitCode);
+      pSource.once("exit", code => r(code));
+    }),
     new Promise<number | null>(r => {
       if (pFilter.exitCode != null) return r(pFilter.exitCode);
       pFilter.once("exit", code => r(code));
     }),
   ]);
+  // `'close'` should also fire — otherwise libraries like `execa` that
+  // await close (not exit) hang indefinitely.
+  await Promise.race([
+    sourceClose,
+    new Promise<void>((_, reject) => setTimeout(() => reject(new Error("pSource 'close' never fired")), 5000)),
+  ]);
   expect(filterErr).toBe("");
   expect(sourceErr).toBe("");
   expect(out).toBe("HELLO WORLD");
+  expect(sourceExit).toBe(0);
   expect(filterExit).toBe(0);
 });
 
@@ -173,9 +188,17 @@ test("spawn failure (ENOENT) does not leave a passed-in source stream stuck", as
   expect(spawnErr.code).toBe("ENOENT");
 
   // pSource.stdout should still flow normally after the failed spawn.
-  const [data, stderr] = await Promise.all([collect(pSource.stdout!), sourceStderr]);
+  const [data, stderr, sourceExit] = await Promise.all([
+    collect(pSource.stdout!),
+    sourceStderr,
+    new Promise<number | null>(r => {
+      if (pSource.exitCode != null) return r(pSource.exitCode);
+      pSource.once("exit", code => r(code));
+    }),
+  ]);
   expect(stderr).toBe("");
   expect(data).toBe("hello world");
+  expect(sourceExit).toBe(0);
 });
 
 function collect(stream: NodeJS.ReadableStream): Promise<string> {

--- a/test/regression/issue/30831.test.ts
+++ b/test/regression/issue/30831.test.ts
@@ -128,11 +128,10 @@ describeSkipOnWindows(
       }),
     ]);
     // `'close'` should also fire — otherwise libraries like `execa` that
-    // await close (not exit) hang indefinitely.
-    await Promise.race([
-      sourceClose,
-      new Promise<void>((_, reject) => setTimeout(() => reject(new Error("pSource 'close' never fired")), 5000)),
-    ]);
+    // await close (not exit) hang indefinitely. If this promise never
+    // resolves (pre-fix behavior), the test times out rather than
+    // racing its own setTimeout.
+    await sourceClose;
     expect(filterErr).toBe("");
     expect(sourceErr).toBe("");
     expect(out).toBe("HELLO WORLD");

--- a/test/regression/issue/30831.test.ts
+++ b/test/regression/issue/30831.test.ts
@@ -90,63 +90,68 @@ describeSkipOnWindows("spawn({ stdio: [..., childB.stdin, ...] }) pipes A's stdo
   expect(filterExit).toBe(0);
 });
 
-describeSkipOnWindows("spawn({ stdio: [otherProc.stdout, ...] }) pipes A's stdout into B's stdin (reverse direction)", async () => {
-  // Flip the direction: pSource owns the pipe (its stdout is piped), and
-  // pFilter is spawned with pSource.stdout as its stdin. Node supports both
-  // shapes; before the fix Bun raised the same unsupported-stream-stdio
-  // error here too.
-  using pSource = spawn(bunExe(), ["-e", 'process.stdout.write("hello world")'], {
-    stdio: ["ignore", "pipe", "pipe"],
-    env: bunEnv,
-  });
-  const sourceStderr = collect(pSource.stderr!);
-  // `markStreamsAsStdio` unregisters the FilePoll on `pSource.stdout`, so
-  // without the close-accounting fix in `#handleOnExit` this `'close'`
-  // promise never resolves even after `pSource` exits — guard that path.
-  const sourceClose = new Promise<void>(r => pSource.once("close", () => r()));
+describeSkipOnWindows(
+  "spawn({ stdio: [otherProc.stdout, ...] }) pipes A's stdout into B's stdin (reverse direction)",
+  async () => {
+    // Flip the direction: pSource owns the pipe (its stdout is piped), and
+    // pFilter is spawned with pSource.stdout as its stdin. Node supports both
+    // shapes; before the fix Bun raised the same unsupported-stream-stdio
+    // error here too.
+    using pSource = spawn(bunExe(), ["-e", 'process.stdout.write("hello world")'], {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: bunEnv,
+    });
+    const sourceStderr = collect(pSource.stderr!);
+    // `markStreamsAsStdio` unregisters the FilePoll on `pSource.stdout`, so
+    // without the close-accounting fix in `#handleOnExit` this `'close'`
+    // promise never resolves even after `pSource` exits — guard that path.
+    const sourceClose = new Promise<void>(r => pSource.once("close", () => r()));
 
-  using pFilter = spawn(bunExe(), ["-e", UPPER], {
-    stdio: [pSource.stdout!, "pipe", "pipe"],
-    env: bunEnv,
-  });
-  const filterStdout = collect(pFilter.stdout!);
-  const filterStderr = collect(pFilter.stderr!);
+    using pFilter = spawn(bunExe(), ["-e", UPPER], {
+      stdio: [pSource.stdout!, "pipe", "pipe"],
+      env: bunEnv,
+    });
+    const filterStdout = collect(pFilter.stdout!);
+    const filterStderr = collect(pFilter.stderr!);
 
-  const [out, filterErr, sourceErr, sourceExit, filterExit] = await Promise.all([
-    filterStdout,
-    filterStderr,
-    sourceStderr,
-    new Promise<number | null>(r => {
-      if (pSource.exitCode != null) return r(pSource.exitCode);
-      pSource.once("exit", code => r(code));
-    }),
-    new Promise<number | null>(r => {
-      if (pFilter.exitCode != null) return r(pFilter.exitCode);
-      pFilter.once("exit", code => r(code));
-    }),
-  ]);
-  // `'close'` should also fire — otherwise libraries like `execa` that
-  // await close (not exit) hang indefinitely.
-  await Promise.race([
-    sourceClose,
-    new Promise<void>((_, reject) => setTimeout(() => reject(new Error("pSource 'close' never fired")), 5000)),
-  ]);
-  expect(filterErr).toBe("");
-  expect(sourceErr).toBe("");
-  expect(out).toBe("HELLO WORLD");
-  expect(sourceExit).toBe(0);
-  expect(filterExit).toBe(0);
-});
+    const [out, filterErr, sourceErr, sourceExit, filterExit] = await Promise.all([
+      filterStdout,
+      filterStderr,
+      sourceStderr,
+      new Promise<number | null>(r => {
+        if (pSource.exitCode != null) return r(pSource.exitCode);
+        pSource.once("exit", code => r(code));
+      }),
+      new Promise<number | null>(r => {
+        if (pFilter.exitCode != null) return r(pFilter.exitCode);
+        pFilter.once("exit", code => r(code));
+      }),
+    ]);
+    // `'close'` should also fire — otherwise libraries like `execa` that
+    // await close (not exit) hang indefinitely.
+    await Promise.race([
+      sourceClose,
+      new Promise<void>((_, reject) => setTimeout(() => reject(new Error("pSource 'close' never fired")), 5000)),
+    ]);
+    expect(filterErr).toBe("");
+    expect(sourceErr).toBe("");
+    expect(out).toBe("HELLO WORLD");
+    expect(sourceExit).toBe(0);
+    expect(filterExit).toBe(0);
+  },
+);
 
-describeSkipOnWindows("spawn({ stdio: [..., process.stdout, process.stderr] }) forwards via the stream→fd path", async () => {
-  // `process.stdout.fd === 1` / `process.stderr.fd === 2` are set by
-  // `getStdioWriteStream`. These have always been numeric-fd objects in
-  // Bun, so they were already accepted by `nodeToBun`'s `.fd` lookup — but
-  // this PR routes them through the new `extractStreamFd` + `streamsToQuiesce`
-  // path too, and a later refactor could accidentally drop them. A
-  // sub-bun runner actually performs the passthrough spawn and prints
-  // whether it succeeded to *its* stdout, which the outer test captures.
-  const RUNNER = `
+describeSkipOnWindows(
+  "spawn({ stdio: [..., process.stdout, process.stderr] }) forwards via the stream→fd path",
+  async () => {
+    // `process.stdout.fd === 1` / `process.stderr.fd === 2` are set by
+    // `getStdioWriteStream`. These have always been numeric-fd objects in
+    // Bun, so they were already accepted by `nodeToBun`'s `.fd` lookup — but
+    // this PR routes them through the new `extractStreamFd` + `streamsToQuiesce`
+    // path too, and a later refactor could accidentally drop them. A
+    // sub-bun runner actually performs the passthrough spawn and prints
+    // whether it succeeded to *its* stdout, which the outer test captures.
+    const RUNNER = `
     const { spawn } = require("child_process");
     const child = spawn(${JSON.stringify(bunExe())}, ["-e", 'process.stderr.write("from-grandchild")'], {
       stdio: ["ignore", process.stdout, process.stderr],
@@ -154,24 +159,25 @@ describeSkipOnWindows("spawn({ stdio: [..., process.stdout, process.stderr] }) f
     child.on("error", err => { process.stderr.write("SPAWN-ERROR:" + err.message); process.exit(2); });
     child.on("exit", code => process.exit(code));
   `;
-  using runner = spawn(bunExe(), ["-e", RUNNER], {
-    stdio: ["ignore", "pipe", "pipe"],
-    env: bunEnv,
-  });
-  const [stdout, stderr, code] = await Promise.all([
-    collect(runner.stdout!),
-    collect(runner.stderr!),
-    new Promise<number | null>(r => {
-      if (runner.exitCode != null) return r(runner.exitCode);
-      runner.once("exit", c => r(c));
-    }),
-  ]);
-  // Grandchild writes "from-grandchild" to its stderr (which is the
-  // runner's process.stderr, which is this test's runner.stderr).
-  expect(stdout).toBe("");
-  expect(stderr).toBe("from-grandchild");
-  expect(code).toBe(0);
-});
+    using runner = spawn(bunExe(), ["-e", RUNNER], {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: bunEnv,
+    });
+    const [stdout, stderr, code] = await Promise.all([
+      collect(runner.stdout!),
+      collect(runner.stderr!),
+      new Promise<number | null>(r => {
+        if (runner.exitCode != null) return r(runner.exitCode);
+        runner.once("exit", c => r(c));
+      }),
+    ]);
+    // Grandchild writes "from-grandchild" to its stderr (which is the
+    // runner's process.stderr, which is this test's runner.stderr).
+    expect(stdout).toBe("");
+    expect(stderr).toBe("from-grandchild");
+    expect(code).toBe(0);
+  },
+);
 
 describeSkipOnWindows("spawn failure (ENOENT) does not leave a passed-in source stream stuck", async () => {
   // The quiesce step (setFlowing(false) + pause) MUST NOT run before

--- a/test/regression/issue/30831.test.ts
+++ b/test/regression/issue/30831.test.ts
@@ -2,7 +2,7 @@
 //
 // `child_process.spawn` was unable to pipe one subprocess's stdio stream into
 // another: `spawn(..., { stdio: [..., otherProc.stdin, ...] })` threw
-// `TODO: stream.Readable stdio @ N` because `nodeToBun()` in
+// `stream.Readable stdio @ N` (unsupported) because `nodeToBun()` in
 // `node:child_process` looked for `.fd` / `_handle.fd` on the stream (Node's
 // `subprocess.stdin` is a `net.Socket` that exposes its pipe fd there), but
 // Bun's `subprocess.stdin` is a `WriteStream` wrapping a `FileSink` and
@@ -82,8 +82,8 @@ test("spawn({ stdio: [..., childB.stdin, ...] }) pipes A's stdout into B's stdin
 test("spawn({ stdio: [otherProc.stdout, ...] }) pipes A's stdout into B's stdin (reverse direction)", async () => {
   // Flip the direction: pSource owns the pipe (its stdout is piped), and
   // pFilter is spawned with pSource.stdout as its stdin. Node supports both
-  // shapes; before the fix Bun threw `TODO: stream.Readable stdio @ 0` here
-  // too.
+  // shapes; before the fix Bun raised the same unsupported-stream-stdio
+  // error here too.
   using pSource = spawn(bunExe(), ["-e", 'process.stdout.write("hello world")'], {
     stdio: ["ignore", "pipe", "pipe"],
     env: bunEnv,

--- a/test/regression/issue/30831.test.ts
+++ b/test/regression/issue/30831.test.ts
@@ -9,14 +9,19 @@
 // `subprocess.stdout`/`stderr` is a `Readable` wrapping a native
 // `ReadableStream`. Neither surfaced the underlying pipe fd.
 //
-// Fix (three parts, all required — removing any one of them breaks one of the
-// three tests below):
+// Fix (three parts — removing any of the first three breaks one of the first
+// three tests; the fourth test guards the ordering of part 2):
 //   1. Surface `.fd` on both wrappers at construction time from the
 //      underlying sink/source, so `nodeToBun` can forward the fd.
-//   2. When `nodeToBun` extracts an fd from a stream, also pause the stream
-//      and tag it `kIsUsedAsStdio` — mirrors Node's `getValidStdio`
+//   2. When `nodeToBun` extracts an fd from a stream, record the stream in a
+//      `streamsToQuiesce` list; after `Bun.spawn` succeeds, pause each one
+//      and tag it `kIsUsedAsStdio`. Mirrors Node's `getValidStdio`
 //      post-spawn `readStop`/`pause`, without which the parent's own
-//      `PipeReader` races the child for the pipe's bytes.
+//      `PipeReader` races the child for the pipe's bytes. The quiesce
+//      runs AFTER spawn because `setFlowing(false)` is sticky at the
+//      native layer with no user-recoverable counterpart — if we paused
+//      pre-spawn and spawn then threw, the source stream would be stuck
+//      forever.
 //   3. `Bun.spawn`'s POSIX path clears `O_NONBLOCK` on the caller-supplied
 //      fd before `dup2`; otherwise the child inherits non-blocking mode (the
 //      parent set it for async reads) and a synchronous reader like `cat`
@@ -112,17 +117,65 @@ test("spawn({ stdio: [otherProc.stdout, ...] }) pipes A's stdout into B's stdin 
   expect(filterExit).toBe(0);
 });
 
-test("spawn({ stdio: [..., process.stdout, process.stderr] }) still works (fd already on process streams)", async () => {
-  // process.stdout.fd is set to 1 by getStdioWriteStream. This existed
-  // before the fix but the code path shares `nodeToBun` with the two
-  // tests above, so regression-guard it.
-  using proc = spawn(bunExe(), ["-e", 'console.error("from-child")'], {
+test("spawn({ stdio: [..., process.stdout, process.stderr] }) forwards via the stream→fd path", async () => {
+  // `process.stdout.fd === 1` / `process.stderr.fd === 2` are set by
+  // `getStdioWriteStream`. These have always been numeric-fd objects in
+  // Bun, so they were already accepted by `nodeToBun`'s `.fd` lookup — but
+  // this PR routes them through the new `extractStreamFd` + `streamsToQuiesce`
+  // path too, and a later refactor could accidentally drop them. A
+  // sub-bun runner actually performs the passthrough spawn and prints
+  // whether it succeeded to *its* stdout, which the outer test captures.
+  const RUNNER = `
+    const { spawn } = require("child_process");
+    const child = spawn(${JSON.stringify(bunExe())}, ["-e", 'process.stderr.write("from-grandchild")'], {
+      stdio: ["ignore", process.stdout, process.stderr],
+    });
+    child.on("error", err => { process.stderr.write("SPAWN-ERROR:" + err.message); process.exit(2); });
+    child.on("exit", code => process.exit(code));
+  `;
+  using runner = spawn(bunExe(), ["-e", RUNNER], {
     stdio: ["ignore", "pipe", "pipe"],
     env: bunEnv,
   });
-  const [stdout, stderr] = await Promise.all([collect(proc.stdout!), collect(proc.stderr!)]);
+  const [stdout, stderr, code] = await Promise.all([
+    collect(runner.stdout!),
+    collect(runner.stderr!),
+    new Promise<number | null>(r => {
+      if (runner.exitCode != null) return r(runner.exitCode);
+      runner.once("exit", c => r(c));
+    }),
+  ]);
+  // Grandchild writes "from-grandchild" to its stderr (which is the
+  // runner's process.stderr, which is this test's runner.stderr).
   expect(stdout).toBe("");
-  expect(stderr).toBe("from-child\n");
+  expect(stderr).toBe("from-grandchild");
+  expect(code).toBe(0);
+});
+
+test("spawn failure (ENOENT) does not leave a passed-in source stream stuck", async () => {
+  // The quiesce step (setFlowing(false) + pause) MUST NOT run before
+  // Bun.spawn succeeds: `setFlowing(false)` has no user-recoverable
+  // counterpart, so running it on the failure path would leave
+  // `pSource.stdout` permanently unreadable. Assert the stream is still
+  // fully consumable after a failed spawn.
+  using pSource = spawn(
+    bunExe(),
+    ["-e", 'setTimeout(() => { process.stdout.write("hello world"); process.stdout.end(); }, 50)'],
+    { stdio: ["ignore", "pipe", "pipe"], env: bunEnv },
+  );
+  const sourceStderr = collect(pSource.stderr!);
+
+  const failed = spawn("/this/binary/does/not/exist", [], {
+    stdio: [pSource.stdout!, "pipe", "pipe"],
+    env: bunEnv,
+  });
+  const spawnErr = await new Promise<NodeJS.ErrnoException>(r => failed.once("error", r));
+  expect(spawnErr.code).toBe("ENOENT");
+
+  // pSource.stdout should still flow normally after the failed spawn.
+  const [data, stderr] = await Promise.all([collect(pSource.stdout!), sourceStderr]);
+  expect(stderr).toBe("");
+  expect(data).toBe("hello world");
 });
 
 function collect(stream: NodeJS.ReadableStream): Promise<string> {

--- a/test/regression/issue/30831.test.ts
+++ b/test/regression/issue/30831.test.ts
@@ -28,8 +28,14 @@
 //      gets `EAGAIN: Resource temporarily unavailable` on its first read.
 
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import { spawn } from "node:child_process";
+
+// Windows: inter-process stdio-fd hand-off is not implemented. `FileReader`'s
+// pipe handle is a system-kind `HANDLE` and `Fd::uv()` panics on the non-stdio
+// HANDLEs that subprocess pipes produce, so `get_fd()` returns `-1` on Windows
+// and `nodeToBun` falls back to the unsupported-stream-stdio error.
+const describeSkipOnWindows = isWindows ? test.skip : test;
 
 // Tiny uppercasing filter implemented in bun itself so the test doesn't
 // depend on `perl`/`tr`/`awk` being installed on the runner.
@@ -41,7 +47,7 @@ process.stdin.on("end", () => {
 });
 `;
 
-test("spawn({ stdio: [..., childB.stdin, ...] }) pipes A's stdout into B's stdin", async () => {
+describeSkipOnWindows("spawn({ stdio: [..., childB.stdin, ...] }) pipes A's stdout into B's stdin", async () => {
   using pFilter = spawn(bunExe(), ["-e", UPPER], {
     stdio: ["pipe", "pipe", "pipe"],
     env: bunEnv,
@@ -84,7 +90,7 @@ test("spawn({ stdio: [..., childB.stdin, ...] }) pipes A's stdout into B's stdin
   expect(filterExit).toBe(0);
 });
 
-test("spawn({ stdio: [otherProc.stdout, ...] }) pipes A's stdout into B's stdin (reverse direction)", async () => {
+describeSkipOnWindows("spawn({ stdio: [otherProc.stdout, ...] }) pipes A's stdout into B's stdin (reverse direction)", async () => {
   // Flip the direction: pSource owns the pipe (its stdout is piped), and
   // pFilter is spawned with pSource.stdout as its stdin. Node supports both
   // shapes; before the fix Bun raised the same unsupported-stream-stdio
@@ -132,7 +138,7 @@ test("spawn({ stdio: [otherProc.stdout, ...] }) pipes A's stdout into B's stdin 
   expect(filterExit).toBe(0);
 });
 
-test("spawn({ stdio: [..., process.stdout, process.stderr] }) forwards via the stream→fd path", async () => {
+describeSkipOnWindows("spawn({ stdio: [..., process.stdout, process.stderr] }) forwards via the stream→fd path", async () => {
   // `process.stdout.fd === 1` / `process.stderr.fd === 2` are set by
   // `getStdioWriteStream`. These have always been numeric-fd objects in
   // Bun, so they were already accepted by `nodeToBun`'s `.fd` lookup — but
@@ -167,7 +173,7 @@ test("spawn({ stdio: [..., process.stdout, process.stderr] }) forwards via the s
   expect(code).toBe(0);
 });
 
-test("spawn failure (ENOENT) does not leave a passed-in source stream stuck", async () => {
+describeSkipOnWindows("spawn failure (ENOENT) does not leave a passed-in source stream stuck", async () => {
   // The quiesce step (setFlowing(false) + pause) MUST NOT run before
   // Bun.spawn succeeds: `setFlowing(false)` has no user-recoverable
   // counterpart, so running it on the failure path would leave

--- a/test/regression/issue/30831.test.ts
+++ b/test/regression/issue/30831.test.ts
@@ -1,0 +1,135 @@
+// https://github.com/oven-sh/bun/issues/30831
+//
+// `child_process.spawn` was unable to pipe one subprocess's stdio stream into
+// another: `spawn(..., { stdio: [..., otherProc.stdin, ...] })` threw
+// `TODO: stream.Readable stdio @ N` because `nodeToBun()` in
+// `node:child_process` looked for `.fd` / `_handle.fd` on the stream (Node's
+// `subprocess.stdin` is a `net.Socket` that exposes its pipe fd there), but
+// Bun's `subprocess.stdin` is a `WriteStream` wrapping a `FileSink` and
+// `subprocess.stdout`/`stderr` is a `Readable` wrapping a native
+// `ReadableStream`. Neither surfaced the underlying pipe fd.
+//
+// Fix (three parts, all required — removing any one of them breaks one of the
+// three tests below):
+//   1. Surface `.fd` on both wrappers at construction time from the
+//      underlying sink/source, so `nodeToBun` can forward the fd.
+//   2. When `nodeToBun` extracts an fd from a stream, also pause the stream
+//      and tag it `kIsUsedAsStdio` — mirrors Node's `getValidStdio`
+//      post-spawn `readStop`/`pause`, without which the parent's own
+//      `PipeReader` races the child for the pipe's bytes.
+//   3. `Bun.spawn`'s POSIX path clears `O_NONBLOCK` on the caller-supplied
+//      fd before `dup2`; otherwise the child inherits non-blocking mode (the
+//      parent set it for async reads) and a synchronous reader like `cat`
+//      gets `EAGAIN: Resource temporarily unavailable` on its first read.
+
+import { expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import { bunEnv, bunExe } from "harness";
+
+// Tiny uppercasing filter implemented in bun itself so the test doesn't
+// depend on `perl`/`tr`/`awk` being installed on the runner.
+const UPPER = `
+const chunks = [];
+process.stdin.on("data", c => chunks.push(c));
+process.stdin.on("end", () => {
+  process.stdout.write(Buffer.concat(chunks).toString("utf8").toUpperCase());
+});
+`;
+
+test("spawn({ stdio: [..., childB.stdin, ...] }) pipes A's stdout into B's stdin", async () => {
+  using pFilter = spawn(bunExe(), ["-e", UPPER], {
+    stdio: ["pipe", "pipe", "pipe"],
+    env: bunEnv,
+  });
+  const filterStdout = collect(pFilter.stdout!);
+  const filterStderr = collect(pFilter.stderr!);
+
+  // Spawning pSource with pFilter.stdin as its stdout means pSource's fd 1
+  // is dup2'd onto the same pipe pFilter's stdin writes to, so pSource's
+  // output arrives in pFilter as stdin. The parent keeps its write end
+  // (pFilter.stdin) and must `.end()` it after pSource exits so pFilter sees
+  // EOF.
+  using pSource = spawn(bunExe(), ["-e", 'process.stdout.write("hello world")'], {
+    stdio: ["ignore", pFilter.stdin!, "pipe"],
+    env: bunEnv,
+  });
+  const sourceStderr = collect(pSource.stderr!);
+
+  await new Promise<void>((resolve, reject) => {
+    pSource.once("error", reject);
+    pSource.once("exit", () => {
+      pFilter.stdin!.end();
+      resolve();
+    });
+  });
+
+  const [out, filterErr, sourceErr, filterExit] = await Promise.all([
+    filterStdout,
+    filterStderr,
+    sourceStderr,
+    new Promise<number | null>(r => {
+      if (pFilter.exitCode != null) return r(pFilter.exitCode);
+      pFilter.once("exit", code => r(code));
+    }),
+  ]);
+  expect(filterErr).toBe("");
+  expect(sourceErr).toBe("");
+  expect(out).toBe("HELLO WORLD");
+  expect(pSource.exitCode).toBe(0);
+  expect(filterExit).toBe(0);
+});
+
+test("spawn({ stdio: [otherProc.stdout, ...] }) pipes A's stdout into B's stdin (reverse direction)", async () => {
+  // Flip the direction: pSource owns the pipe (its stdout is piped), and
+  // pFilter is spawned with pSource.stdout as its stdin. Node supports both
+  // shapes; before the fix Bun threw `TODO: stream.Readable stdio @ 0` here
+  // too.
+  using pSource = spawn(bunExe(), ["-e", 'process.stdout.write("hello world")'], {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: bunEnv,
+  });
+  const sourceStderr = collect(pSource.stderr!);
+
+  using pFilter = spawn(bunExe(), ["-e", UPPER], {
+    stdio: [pSource.stdout!, "pipe", "pipe"],
+    env: bunEnv,
+  });
+  const filterStdout = collect(pFilter.stdout!);
+  const filterStderr = collect(pFilter.stderr!);
+
+  const [out, filterErr, sourceErr, filterExit] = await Promise.all([
+    filterStdout,
+    filterStderr,
+    sourceStderr,
+    new Promise<number | null>(r => {
+      if (pFilter.exitCode != null) return r(pFilter.exitCode);
+      pFilter.once("exit", code => r(code));
+    }),
+  ]);
+  expect(filterErr).toBe("");
+  expect(sourceErr).toBe("");
+  expect(out).toBe("HELLO WORLD");
+  expect(filterExit).toBe(0);
+});
+
+test("spawn({ stdio: [..., process.stdout, process.stderr] }) still works (fd already on process streams)", async () => {
+  // process.stdout.fd is set to 1 by getStdioWriteStream. This existed
+  // before the fix but the code path shares `nodeToBun` with the two
+  // tests above, so regression-guard it.
+  using proc = spawn(bunExe(), ["-e", 'console.error("from-child")'], {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: bunEnv,
+  });
+  const [stdout, stderr] = await Promise.all([collect(proc.stdout!), collect(proc.stderr!)]);
+  expect(stdout).toBe("");
+  expect(stderr).toBe("from-child\n");
+});
+
+function collect(stream: NodeJS.ReadableStream): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    stream.on("data", chunk => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+    stream.once("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    stream.once("error", reject);
+  });
+}

--- a/test/regression/issue/30831.test.ts
+++ b/test/regression/issue/30831.test.ts
@@ -34,8 +34,8 @@ import { spawn } from "node:child_process";
 // Windows: inter-process stdio-fd hand-off is not implemented. `FileReader`'s
 // pipe handle is a system-kind `HANDLE` and `Fd::uv()` panics on the non-stdio
 // HANDLEs that subprocess pipes produce, so `get_fd()` returns `-1` on Windows
-// and `nodeToBun` falls back to the unsupported-stream-stdio error.
-const describeSkipOnWindows = isWindows ? test.skip : test;
+// and `nodeToBun` falls back to the unsupported-stream-stdio error. Each test
+// below is `test.skipIf(isWindows)` for that reason.
 
 // Tiny uppercasing filter implemented in bun itself so the test doesn't
 // depend on `perl`/`tr`/`awk` being installed on the runner.
@@ -47,7 +47,7 @@ process.stdin.on("end", () => {
 });
 `;
 
-describeSkipOnWindows("spawn({ stdio: [..., childB.stdin, ...] }) pipes A's stdout into B's stdin", async () => {
+test.skipIf(isWindows)("spawn({ stdio: [..., childB.stdin, ...] }) pipes A's stdout into B's stdin", async () => {
   using pFilter = spawn(bunExe(), ["-e", UPPER], {
     stdio: ["pipe", "pipe", "pipe"],
     env: bunEnv,
@@ -90,7 +90,7 @@ describeSkipOnWindows("spawn({ stdio: [..., childB.stdin, ...] }) pipes A's stdo
   expect(filterExit).toBe(0);
 });
 
-describeSkipOnWindows(
+test.skipIf(isWindows)(
   "spawn({ stdio: [otherProc.stdout, ...] }) pipes A's stdout into B's stdin (reverse direction)",
   async () => {
     // Flip the direction: pSource owns the pipe (its stdout is piped), and
@@ -140,7 +140,7 @@ describeSkipOnWindows(
   },
 );
 
-describeSkipOnWindows(
+test.skipIf(isWindows)(
   "spawn({ stdio: [..., process.stdout, process.stderr] }) forwards via the stream→fd path",
   async () => {
     // `process.stdout.fd === 1` / `process.stderr.fd === 2` are set by
@@ -178,7 +178,7 @@ describeSkipOnWindows(
   },
 );
 
-describeSkipOnWindows("spawn failure (ENOENT) does not leave a passed-in source stream stuck", async () => {
+test.skipIf(isWindows)("spawn failure (ENOENT) does not leave a passed-in source stream stuck", async () => {
   // The quiesce step (setFlowing(false) + pause) MUST NOT run before
   // Bun.spawn succeeds: `setFlowing(false)` has no user-recoverable
   // counterpart, so running it on the failure path would leave

--- a/test/regression/issue/30831.test.ts
+++ b/test/regression/issue/30831.test.ts
@@ -29,7 +29,7 @@
 
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows } from "harness";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 
 // Windows: inter-process stdio-fd hand-off is not implemented. `FileReader`'s
 // pipe handle is a system-kind `HANDLE` and `Fd::uv()` panics on the non-stdio
@@ -242,33 +242,49 @@ test.skipIf(isWindows)("spawnSync does not brick a stream passed as stdio", asyn
   // `Bun.spawnSync` blocks the JS thread until the child exits, so there is no
   // parent/child read race to prevent, and the quiesce step runs only after
   // the child is already gone. Its irreversible `setFlowing(false)` must not
-  // run on the sync path, or a stream handed to `spawnSync` (here the runner's
-  // own `process.stdin`) would be left permanently unreadable. A sub-bun runner
-  // performs the sync spawn and reports its `process.stdin` flowing state.
-  const RUNNER = `
-    const { spawnSync } = require("child_process");
-    process.stdin.resume();
-    const before = process.stdin.readableFlowing;
-    // Hand our own stdin to a child that exits without reading it.
-    spawnSync(${JSON.stringify(bunExe())}, ["-e", ""], { stdio: [process.stdin, "ignore", "ignore"] });
-    const after = process.stdin.readableFlowing;
-    process.stdout.write("flowing:" + before + "->" + after);
-    process.exit(0);
-  `;
-  using runner = spawn(bunExe(), ["-e", RUNNER], {
-    stdio: ["pipe", "pipe", "inherit"],
+  // run on the sync path, or a stream handed to `spawnSync` would be left
+  // permanently unreadable. Hand a live subprocess's stdout to `spawnSync` and
+  // assert its flowing state is untouched; before the fix `markStreamsAsStdio`
+  // flipped it to `false`.
+  using pSource = spawn(bunExe(), ["-e", "setInterval(() => {}, 1 << 30)"], {
+    stdio: ["ignore", "pipe", "ignore"],
     env: bunEnv,
   });
-  const [out, code] = await Promise.all([
-    collect(runner.stdout!),
-    new Promise<number | null>(r => {
-      if (runner.exitCode != null) return r(runner.exitCode);
-      runner.once("exit", c => r(c));
-    }),
-  ]);
-  // Before the fix `markStreamsAsStdio` flipped flowing to false ("true->false").
-  expect(out).toBe("flowing:true->true");
-  expect(code).toBe(0);
+  pSource.stdout!.resume();
+  const before = (pSource.stdout as any).readableFlowing;
+  // Hand pSource.stdout's fd to a sync child that exits without reading it.
+  spawnSync(bunExe(), ["-e", ""], { stdio: [pSource.stdout!, "ignore", "ignore"], env: bunEnv });
+  const after = (pSource.stdout as any).readableFlowing;
+
+  expect(before).toBe(true);
+  // After the fix the sync path does not quiesce; before it, flowing was false.
+  expect(after).toBe(true);
+});
+
+test.skipIf(isWindows)("a destroyed subprocess stdin does not leak a stale fd to a later spawn", async () => {
+  // Writable-side analogue of the readable test above. `writableFromFileSink`
+  // caches the pipe fd on `stdin.fd`. The WriteStream `_destroy` only nulls it
+  // via `close()`, which it skips on the async path (the sink still has
+  // buffered bytes), so a destroyed stdin can retain a stale fd. `extractStreamFd`
+  // rejects destroyed streams, so `spawn` raises the unsupported-stream-stdio
+  // error instead of `dup2`'ing a closed (or kernel-reused) fd into the child.
+  using pSink = spawn(bunExe(), ["-e", "setInterval(() => {}, 1 << 30)"], {
+    stdio: ["pipe", "ignore", "ignore"],
+    env: bunEnv,
+  });
+  // Write more than the pipe buffer (child never reads) so the FileSink keeps
+  // pending bytes; `destroy()` then takes the async `_destroy` path that never
+  // reaches `close()`, leaving `fd` set without the `extractStreamFd` guard.
+  // The unflushed bytes surface as EPIPE when the sink closes; swallow it, the
+  // stream is `destroyed` synchronously regardless.
+  pSink.stdin!.on("error", () => {});
+  pSink.stdin!.write(Buffer.alloc(1 << 20, 0x61));
+  pSink.stdin!.destroy();
+  expect(pSink.stdin!.destroyed).toBe(true);
+
+  expect(() =>
+    spawn(bunExe(), ["-e", ""], { stdio: ["ignore", pSink.stdin!, "ignore"], env: bunEnv }),
+  ).toThrow(/stream\.(Writable|Readable) stdio/);
 });
 
 function collect(stream: NodeJS.ReadableStream): Promise<string> {

--- a/test/regression/issue/30831.test.ts
+++ b/test/regression/issue/30831.test.ts
@@ -282,9 +282,9 @@ test.skipIf(isWindows)("a destroyed subprocess stdin does not leak a stale fd to
   pSink.stdin!.destroy();
   expect(pSink.stdin!.destroyed).toBe(true);
 
-  expect(() =>
-    spawn(bunExe(), ["-e", ""], { stdio: ["ignore", pSink.stdin!, "ignore"], env: bunEnv }),
-  ).toThrow(/stream\.(Writable|Readable) stdio/);
+  expect(() => spawn(bunExe(), ["-e", ""], { stdio: ["ignore", pSink.stdin!, "ignore"], env: bunEnv })).toThrow(
+    /stream\.(Writable|Readable) stdio/,
+  );
 });
 
 function collect(stream: NodeJS.ReadableStream): Promise<string> {

--- a/test/regression/issue/30831.test.ts
+++ b/test/regression/issue/30831.test.ts
@@ -233,9 +233,9 @@ test.skipIf(isWindows)("a destroyed subprocess stdout does not leak a stale fd t
   // The destroyed stream must not be accepted as stdio with that stale fd:
   // `extractStreamFd` now returns undefined, so `spawn` raises the
   // unsupported-stream-stdio error instead of `dup2`'ing a closed fd.
-  expect(() =>
-    spawn(bunExe(), ["-e", ""], { stdio: [pSource.stdout!, "pipe", "ignore"], env: bunEnv }),
-  ).toThrow(/stream\.Readable stdio/);
+  expect(() => spawn(bunExe(), ["-e", ""], { stdio: [pSource.stdout!, "pipe", "ignore"], env: bunEnv })).toThrow(
+    /stream\.Readable stdio/,
+  );
 });
 
 test.skipIf(isWindows)("spawnSync does not brick a stream passed as stdio", async () => {

--- a/test/regression/issue/30831.test.ts
+++ b/test/regression/issue/30831.test.ts
@@ -212,6 +212,65 @@ test.skipIf(isWindows)("spawn failure (ENOENT) does not leave a passed-in source
   expect(sourceExit).toBe(0);
 });
 
+test.skipIf(isWindows)("a destroyed subprocess stdout does not leak a stale fd to a later spawn", async () => {
+  // `constructNativeReadable` caches the pipe fd on `stream.fd` for stdio
+  // hand-off. `destroy()` closes that fd, so it must also clear `stream.fd`;
+  // otherwise the destroyed stream reports a stale (closed or kernel-reused)
+  // fd and a later `spawn` would `dup2` the wrong descriptor into the child.
+  using pSource = spawn(bunExe(), ["-e", 'process.stdout.write("hi")'], {
+    stdio: ["ignore", "pipe", "ignore"],
+    env: bunEnv,
+  });
+  // Drain to EOF so the stream auto-destroys, then wait for `'close'`.
+  const drained = collect(pSource.stdout!);
+  await new Promise<void>(r => pSource.once("close", () => r()));
+  expect(await drained).toBe("hi");
+
+  expect(pSource.stdout!.destroyed).toBe(true);
+  // The fix nulls `fd` on destroy; before it, `fd` stayed a stale number.
+  expect((pSource.stdout as any).fd).toBeNull();
+
+  // The destroyed stream must not be accepted as stdio with that stale fd:
+  // `extractStreamFd` now returns undefined, so `spawn` raises the
+  // unsupported-stream-stdio error instead of `dup2`'ing a closed fd.
+  expect(() =>
+    spawn(bunExe(), ["-e", ""], { stdio: [pSource.stdout!, "pipe", "ignore"], env: bunEnv }),
+  ).toThrow(/stream\.Readable stdio/);
+});
+
+test.skipIf(isWindows)("spawnSync does not brick a stream passed as stdio", async () => {
+  // `Bun.spawnSync` blocks the JS thread until the child exits, so there is no
+  // parent/child read race to prevent, and the quiesce step runs only after
+  // the child is already gone. Its irreversible `setFlowing(false)` must not
+  // run on the sync path, or a stream handed to `spawnSync` (here the runner's
+  // own `process.stdin`) would be left permanently unreadable. A sub-bun runner
+  // performs the sync spawn and reports its `process.stdin` flowing state.
+  const RUNNER = `
+    const { spawnSync } = require("child_process");
+    process.stdin.resume();
+    const before = process.stdin.readableFlowing;
+    // Hand our own stdin to a child that exits without reading it.
+    spawnSync(${JSON.stringify(bunExe())}, ["-e", ""], { stdio: [process.stdin, "ignore", "ignore"] });
+    const after = process.stdin.readableFlowing;
+    process.stdout.write("flowing:" + before + "->" + after);
+    process.exit(0);
+  `;
+  using runner = spawn(bunExe(), ["-e", RUNNER], {
+    stdio: ["pipe", "pipe", "inherit"],
+    env: bunEnv,
+  });
+  const [out, code] = await Promise.all([
+    collect(runner.stdout!),
+    new Promise<number | null>(r => {
+      if (runner.exitCode != null) return r(runner.exitCode);
+      runner.once("exit", c => r(c));
+    }),
+  ]);
+  // Before the fix `markStreamsAsStdio` flipped flowing to false ("true->false").
+  expect(out).toBe("flowing:true->true");
+  expect(code).toBe(0);
+});
+
 function collect(stream: NodeJS.ReadableStream): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];


### PR DESCRIPTION
## Repro

```js
const { spawn } = require('child_process');

const p2 = spawn('perl', ['-ne', 'print uc'], {
  stdio: ['pipe', process.stdout, process.stderr],
});

const p1 = spawn('node', ['-p', '"hello world"'], {
  stdio: ['ignore', p2.stdin, process.stderr],
});

p1.on('exit', () => { p2.stdin.end(); });
```

- **Node**: prints `HELLO WORLD`.
- **Bun (before)**: `error: TODO: stream.Readable stdio @ 1`.

Also broken in reverse: `spawn(..., { stdio: [p1.stdout, 'pipe', 'inherit'] })`.

## Cause

`nodeToBun()` in `node:child_process` looks for `.fd` or `._handle.fd` on stream stdio. Node's `subprocess.stdin` is a `net.Socket` that exposes its pipe fd on `._handle.fd`; Bun's is a `WriteStream` wrapping a `FileSink`, and `.stdout`/`.stderr` is a native `Readable` wrapping a `ReadableStreamSource` — neither surfaced a fd where `nodeToBun` looks. Just forwarding the fd isn't enough either — two more problems follow (see `test/regression/issue/30831.test.ts` for the full reasoning).

## Fix

Three changes, all required — removing any one breaks one of the three cases in the test file:

1. **Expose `.fd` on the wrappers.** `writableFromFileSink` now reads `fileSink._getFd()`; `constructNativeReadable` calls a new `getFd()` method on `FileInternalReadableStreamSource` (returns `reader.get_fd()`). `nodeToBun`'s existing `.fd` / `._handle.fd` lookup then finds it.
2. **Quiesce the source stream.** When `nodeToBun` extracts an fd from a stream, it also pauses the stream (setFlowing(false) + updateRef(false) on the native ptr, `.pause()` on the JS Readable) and tags it `kIsUsedAsStdio`. `#handleOnExit` skips `stdout.resume?.()` on tagged streams. Mirrors Node's `getValidStdio` post-spawn hook (`readStop()` + `pause()` + `kIsUsedAsStdio` in `lib/internal/child_process.js`) — without it the parent's own PipeReader races the child for the pipe's bytes.
3. **Clear `O_NONBLOCK` before `dup2`.** Bun sets pipe fds non-blocking in the parent for its own async reads; `dup2` shares the open file description so the child inherits non-blocking mode. A synchronous reader like `cat` sees `EAGAIN` on its first `read(2)` and exits 1 with 'Resource temporarily unavailable'. `PosixStdio::Pipe(fd)` now clears `O_NONBLOCK` on caller-supplied fds before `dup2`; safe because step (2) has paused the parent-side reader.

## Verification

`test/regression/issue/30831.test.ts` — three tests covering forward piping (`p2.stdin` as p1's stdout slot), reverse (`p1.stdout` as p2's stdin slot), and a regression-guard for `process.stdout`/`process.stderr` passthrough.

Fixes #30831
Fixes #25498
