### PR TITLE
fix(install): Resolve the requested version when `bun add` targets a peer dependency

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2153,6 +2153,18 @@ fn get_or_put_resolved_package(
     success_fn: SuccessFn,
 ) -> crate::Result<Option<ResolvedPackageResult>> {
     if install_peer && behavior.is_peer() {
+        // `bun add x@1.0.0` or `bun update x` names `x` explicitly. If no
+        // resolved candidate satisfies the requested range, the fallback
+        // below would bind the peer to the version the user asked to move
+        // off of. Skip the fallback for update targets so they resolve
+        // fresh through `find_best_version`. The satisfies scan still runs
+        // first. After the run saves the lockfile, the fresh resolution is
+        // a satisfying candidate, so the replay scan in `bun.lock`
+        // (`resolve_peer_dep_version_based`) picks the same package.
+        let explicit_update_target = this
+            .update_requests
+            .iter()
+            .any(|request| request.name_hash == dependency.name_hash);
         if let Some(index) = this.lockfile.package_index.get(&name_hash) {
             let resolutions = this.lockfile.packages.items_resolution();
             match index {
@@ -2171,12 +2183,13 @@ fn get_or_put_resolved_package(
 
                         let res_tag = resolutions[existing_id as usize].tag;
                         let ver_tag = version.tag;
-                        if (res_tag == ResolutionTag::Npm
-                            && ver_tag == dependency::version::Tag::Npm)
-                            || (res_tag == ResolutionTag::Git
-                                && ver_tag == dependency::version::Tag::Git)
-                            || (res_tag == ResolutionTag::Github
-                                && ver_tag == dependency::version::Tag::Github)
+                        if !explicit_update_target
+                            && ((res_tag == ResolutionTag::Npm
+                                && ver_tag == dependency::version::Tag::Npm)
+                                || (res_tag == ResolutionTag::Git
+                                    && ver_tag == dependency::version::Tag::Git)
+                                || (res_tag == ResolutionTag::Github
+                                    && ver_tag == dependency::version::Tag::Github))
                         {
                             let existing_package = this.lockfile.packages.get(existing_id as usize);
                             this.log_mut().add_warning_fmt(
@@ -2220,12 +2233,13 @@ fn get_or_put_resolved_package(
                     if (list[0] as usize) < resolutions.len() {
                         let res_tag = resolutions[list[0] as usize].tag;
                         let ver_tag = version.tag;
-                        if (res_tag == ResolutionTag::Npm
-                            && ver_tag == dependency::version::Tag::Npm)
-                            || (res_tag == ResolutionTag::Git
-                                && ver_tag == dependency::version::Tag::Git)
-                            || (res_tag == ResolutionTag::Github
-                                && ver_tag == dependency::version::Tag::Github)
+                        if !explicit_update_target
+                            && ((res_tag == ResolutionTag::Npm
+                                && ver_tag == dependency::version::Tag::Npm)
+                                || (res_tag == ResolutionTag::Git
+                                    && ver_tag == dependency::version::Tag::Git)
+                                || (res_tag == ResolutionTag::Github
+                                    && ver_tag == dependency::version::Tag::Github))
                         {
                             let existing_package_id = list[0];
                             let existing_package =

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3074,7 +3074,11 @@ fn is_deferred_peer(dep: &Dependency) -> bool {
 /// candidate, and only when it is the same kind as the dependency (the
 /// "incorrect peer dependency" case; the fresh resolver inspects only
 /// `list[0]` there, and reproducing its choice exactly is the point of
-/// this helper). Returns `None` when no package with the name exists
+/// this helper). The fresh resolver skips that fallback for explicit
+/// update targets (`bun add x@1.0.0`) and resolves fresh. By the time
+/// the lockfile is saved, the fresh resolution is a satisfying
+/// candidate, so the scan here picks the same package without the
+/// update-run context. Returns `None` when no package with the name exists
 /// or the fallback is a different kind; the caller then falls back to
 /// the path walk.
 ///

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -3867,6 +3867,56 @@ describe("hoisting", async () => {
     expect(await exists(join(packageDir, "node_modules", "peer-deps-fixed", "node_modules"))).toBeFalse();
   });
 
+  test("bun add exact version when root also has peerDependency on same name", async () => {
+    await writeFile(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        peerDependencies: { "no-deps": "^1" },
+      }),
+    );
+
+    let { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    expect(await exited).toBe(0);
+    expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+      version: "1.1.0",
+    });
+
+    ({ stderr, exited } = spawn({
+      cmd: [bunExe(), "add", "no-deps@1.0.0"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    }));
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).not.toContain("incorrect peer dependency");
+    expect(await exited).toBe(0);
+    expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+      version: "1.0.0",
+    });
+
+    // A plain install after the add must keep the pin.
+    ({ stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    }));
+    expect(await exited).toBe(0);
+    expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+      version: "1.0.0",
+    });
+  });
+
   test("root workspace (other than root) dependency will not hoist incorrect peer", async () => {
     await Promise.all([
       write(


### PR DESCRIPTION
Related to #15711 and #22150.

# Why

`bun add x@1.0.0` does not install 1.0.0 when `x` is already in the tree as a peer dependency.

```bash
# package.json: { "peerDependencies": { "no-deps": "^1" } }
bun install          # resolves no-deps@1.1.0
bun add no-deps@1.0.0
cat node_modules/no-deps/package.json  # still 1.1.0
```

The deferred-peer pass in `get_or_put_resolved_package` looks for a resolved package that satisfies the peer range. When nothing satisfies, it binds the peer to the existing package anyway and warns `incorrect peer dependency "no-deps@1.1.0"`. The version I asked for is never fetched.

# How

We skip that fallback when an update request from this run names the dependency. The edge then resolves fresh through `findBestVersion`. The satisfies scan still runs first, and plain `bun install` has no update requests, so nothing else changes.

The `bun.lock` replay scan needs no code change. The fresh resolution is a satisfying candidate once the lockfile is saved, so the scan picks the same package on load. I updated its comment.

# Test Plan

- Added a test in `test/cli/install/bun-install-registry.test.ts`: install with a root peer `^1`, run `bun add no-deps@1.0.0`, expect 1.0.0 on disk with no warning, then a plain install keeps the pin. It fails on main.
- Ran `bun bd test test/cli/install/bun-install-registry.test.ts`
- Ran `bun bd test test/cli/install/bun-add.test.ts`
- Ran `bun bd test test/cli/install/bun-update.test.ts`
