### PR TITLE
sql(mysql): decode YEAR as 2-byte u16 in binary result rows (#30854)

### DIFF
--- a/src/codegen/bake-codegen.ts
+++ b/src/codegen/bake-codegen.ts
@@ -53,7 +53,9 @@ async function run() {
           side: JSON.stringify(side),
           IS_ERROR_RUNTIME: String(file === "error"),
           IS_BUN_DEVELOPMENT: String(!!debug),
-          OVERLAY_CSS: css("../runtime/bake/client/overlay.css", !!debug),
+          // Pre-quote so older bun bootstraps (before the JSON-lexer fix in
+          // #30679) don't choke on the leading `*` of the minified CSS.
+          OVERLAY_CSS: JSON.stringify(css("../runtime/bake/client/overlay.css", !!debug)),
         },
         minify: {
           syntax: !debug,

--- a/src/parsers/json_lexer.rs
+++ b/src/parsers/json_lexer.rs
@@ -1301,9 +1301,11 @@ where
                 // `JSONLikeParser::parse_expr`'s auto-quote fallback rescue an
                 // unquoted value that starts with one — e.g. a `Bun.build`
                 // `define:` whose value is a raw minified CSS string starting
-                // with `*{...}` (`bake-codegen.ts`'s `OVERLAY_CSS`). Erroring
-                // here aborts `Lexer::init` before `parse_env_json` gets a
-                // chance to auto-quote.
+                // with `*{...}` (the original motivating case was
+                // `bake-codegen.ts`'s `OVERLAY_CSS` before it was switched to
+                // `JSON.stringify(css(...))`; arbitrary user callers can still
+                // hit this). Erroring here aborts `Lexer::init` before
+                // `parse_env_json` gets a chance to auto-quote.
                 //
                 // They get a dedicated arm (not the catch-all) because the spec
                 // arms (lexer.zig `'('`/`')'`/`'?'`/`'*'`) all `step()` past the

--- a/src/sql_jsc/mysql/protocol/DecodeBinaryValue.rs
+++ b/src/sql_jsc/mysql/protocol/DecodeBinaryValue.rs
@@ -75,6 +75,27 @@ pub fn decode_binary_value<Context: ReaderContext>(
                 ..Default::default()
             })
         }
+        // YEAR is encoded as a 2-byte little-endian unsigned 16-bit integer in
+        // the binary result row (same wire shape as MYSQL_TYPE_SHORT, no length
+        // prefix). Without an explicit arm here, the default arm below reads
+        // `column_length` bytes — that is the ColumnDefinition41 display width
+        // (typically 4 for YEAR(4)) and over-reads by 2 bytes, misaligning the
+        // cursor for every subsequent column in the row. With NEWDECIMAL as
+        // the next column, the mis-read length byte would drive an unbounded
+        // wait for bytes that never arrive, hanging the query forever (#30854).
+        FieldType::MYSQL_TYPE_YEAR => {
+            if raw {
+                let data = reader.read(2)?;
+                return Ok(SQLDataCell::raw(Some(&data)));
+            }
+            Ok(SQLDataCell {
+                tag: CellTag::Uint4,
+                value: CellValue {
+                    uint4: reader.int::<u16>()? as u32,
+                },
+                ..Default::default()
+            })
+        }
         FieldType::MYSQL_TYPE_INT24 => {
             if raw {
                 // Binary protocol sends INT24 as a fixed 4-byte field; consume

--- a/src/sql_jsc/mysql/protocol/DecodeBinaryValue.zig
+++ b/src/sql_jsc/mysql/protocol/DecodeBinaryValue.zig
@@ -30,6 +30,20 @@ pub fn decodeBinaryValue(globalObject: *jsc.JSGlobalObject, field_type: types.Fi
             }
             return SQLDataCell{ .tag = .int4, .value = .{ .int4 = try reader.int(i16) } };
         },
+        // YEAR is encoded as a 2-byte little-endian unsigned 16-bit integer in
+        // the binary result row (same wire shape as MYSQL_TYPE_SHORT, no length
+        // prefix). Without an explicit branch here the `else` arm reads
+        // `column_length` bytes — that is the ColumnDefinition41 display width
+        // (typically 4 for YEAR(4)) and over-reads by 2 bytes, misaligning the
+        // cursor for every subsequent column in the row (#30854).
+        .MYSQL_TYPE_YEAR => {
+            if (raw) {
+                var data = try reader.read(2);
+                defer data.deinit();
+                return SQLDataCell.raw(&data);
+            }
+            return SQLDataCell{ .tag = .uint4, .value = .{ .uint4 = try reader.int(u16) } };
+        },
         .MYSQL_TYPE_INT24 => {
             if (raw) {
                 var data = try reader.read(3);

--- a/src/sql_jsc/mysql/protocol/DecodeBinaryValue.zig
+++ b/src/sql_jsc/mysql/protocol/DecodeBinaryValue.zig
@@ -30,20 +30,6 @@ pub fn decodeBinaryValue(globalObject: *jsc.JSGlobalObject, field_type: types.Fi
             }
             return SQLDataCell{ .tag = .int4, .value = .{ .int4 = try reader.int(i16) } };
         },
-        // YEAR is encoded as a 2-byte little-endian unsigned 16-bit integer in
-        // the binary result row (same wire shape as MYSQL_TYPE_SHORT, no length
-        // prefix). Without an explicit branch here the `else` arm reads
-        // `column_length` bytes — that is the ColumnDefinition41 display width
-        // (typically 4 for YEAR(4)) and over-reads by 2 bytes, misaligning the
-        // cursor for every subsequent column in the row (#30854).
-        .MYSQL_TYPE_YEAR => {
-            if (raw) {
-                var data = try reader.read(2);
-                defer data.deinit();
-                return SQLDataCell.raw(&data);
-            }
-            return SQLDataCell{ .tag = .uint4, .value = .{ .uint4 = try reader.int(u16) } };
-        },
         .MYSQL_TYPE_INT24 => {
             if (raw) {
                 var data = try reader.read(3);

--- a/src/sql_jsc/mysql/protocol/ResultSet.rs
+++ b/src/sql_jsc/mysql/protocol/ResultSet.rs
@@ -98,8 +98,18 @@ impl<'a> Row<'a> {
                     ..SQLDataCell::default()
                 };
             }
-            MYSQL_TYPE_TINY | MYSQL_TYPE_SHORT => {
-                if column.flags.contains(ColumnFlags::UNSIGNED) {
+            // YEAR joins TINY/SHORT in the text path for the same reason it
+            // shares the SHORT wire shape on the binary path: the server
+            // returns it as a bare ASCII integer (1901–2155 or 0000),
+            // mysql2's `text_parser.js` treats it as an integer, and the
+            // binary path now returns a JS number too. Without this arm
+            // YEAR falls through to the string catch-all, so
+            // `typeof row.year` silently flips between `.simple()` (string)
+            // and prepared (number). YEAR is always unsigned.
+            MYSQL_TYPE_TINY | MYSQL_TYPE_SHORT | MYSQL_TYPE_YEAR => {
+                if column.column_type == MYSQL_TYPE_YEAR
+                    || column.flags.contains(ColumnFlags::UNSIGNED)
+                {
                     let val: u16 = parse_int::<u16>(value.slice(), 10).unwrap_or(0);
                     *cell = SQLDataCell {
                         tag: Tag::Uint4,

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -72,8 +72,11 @@ describe("Bun.build", () => {
 
   // A `define:` value that isn't valid JSON or a JS identifier is auto-quoted
   // (treated as a string literal). The JSON lexer must not error eagerly on the
-  // first character — a raw minified CSS string starts with `*{...}`, which
-  // src/codegen/bake-codegen.ts passes verbatim as `OVERLAY_CSS`.
+  // first character — a raw minified CSS string starts with `*{...}`, which is
+  // a realistic shape for values users pass to `Bun.build({ define })`. (The
+  // in-tree `OVERLAY_CSS` consumer in `bake-codegen.ts` now pre-quotes via
+  // `JSON.stringify(css(...))` so older bootstraps build; arbitrary callers
+  // can still pass the unquoted form exercised here.)
   describe.each([
     "*{box-sizing:border-box}.root{all:initial}",
     "?foo",

--- a/test/js/sql/sql-mysql-year-newdecimal.test.ts
+++ b/test/js/sql/sql-mysql-year-newdecimal.test.ts
@@ -68,6 +68,7 @@ const MYSQL_TYPE_YEAR = 0x0d;
 const MYSQL_TYPE_NEWDECIMAL = 0xf6;
 const MYSQL_TYPE_DATETIME = 0x0c;
 const MYSQL_TYPE_VAR_STRING = 0xfd;
+const MYSQL_TYPE_INT24 = 0x09;
 
 // --- Packet builders -------------------------------------------------------
 
@@ -179,11 +180,23 @@ function encodeDatetime7(year: number, month: number, day: number, h: number, m:
   return Buffer.concat([Buffer.from([7]), u16le(year), Buffer.from([month, day, h, m, s])]);
 }
 
+// MYSQL_TYPE_INT24 (MEDIUMINT) is sent as a 4-byte little-endian integer on
+// the wire — the server zero-extends the high byte. Reading only 3 bytes
+// misaligns the cursor the same way YEAR did pre-fix.
+function encodeInt24(value: number): Buffer {
+  return u32le(value);
+}
+
 // --- Test ------------------------------------------------------------------
 
 interface MockOptions {
   // How to lay out the columns of the binary result row.
-  layout: "year-then-newdecimal" | "newdecimal-then-year" | "year-alone" | "year-then-datetime";
+  layout:
+    | "year-then-newdecimal"
+    | "newdecimal-then-year"
+    | "year-alone"
+    | "year-then-datetime"
+    | "int24-then-newdecimal";
   // Number of `?` placeholders in the prepared statement.
   numParams: number;
 }
@@ -236,6 +249,12 @@ function startMockServer(opts: MockOptions) {
                 { name: "ts", type: MYSQL_TYPE_DATETIME, columnLength: 19 },
               ];
               break;
+            case "int24-then-newdecimal":
+              preparedColumns = [
+                { name: "mi", type: MYSQL_TYPE_INT24, columnLength: 8 },
+                { name: "dec", type: MYSQL_TYPE_NEWDECIMAL, columnLength: 10 },
+              ];
+              break;
           }
           const paramDefs = Array.from({ length: opts.numParams }, (_, i) =>
             columnDefinition(`p${i}`, MYSQL_TYPE_VAR_STRING, 255),
@@ -258,6 +277,9 @@ function startMockServer(opts: MockOptions) {
               break;
             case "year-then-datetime":
               rowColumns = [encodeYear(2013), encodeDatetime7(2024, 5, 1, 12, 0, 0)];
+              break;
+            case "int24-then-newdecimal":
+              rowColumns = [encodeInt24(1_234_567), encodeNewdecimal("42.0")];
               break;
           }
           const packets: Buffer[] = [];
@@ -329,7 +351,26 @@ test("YEAR followed by DATETIME — DATETIME is not corrupted by a YEAR over-rea
   // A 2-byte YEAR over-read used to eat the DATETIME's length byte + a
   // pair of date bytes, driving the datetime decoder at absurd dates
   // (3588-06-02, 7435-05-31 in the reports) or an InvalidBinaryValue.
+  //
+  // MySQL's DATETIME wire format has no timezone: the decoder feeds the
+  // wall-clock components through `gregorianDateTimeToMS(..., localTime=
+  // true)`, so compare against a local-time Date constructor rather than
+  // `Date.UTC(...)` — test/preload.ts deliberately preserves the host's
+  // TZ in-process, so hard-coding a UTC offset would be flaky off-CI.
   const rows = await runQuery("year-then-datetime", "select y, ts from t where y = ?", [2013]);
   expect(rows[0].y).toBe(2013);
-  expect(rows[0].ts).toEqual(new Date(Date.UTC(2024, 4, 1, 12, 0, 0)));
+  expect(rows[0].ts).toEqual(new Date(2024, 4, 1, 12, 0, 0));
+});
+
+test("INT24/MEDIUMINT consumes 4 wire bytes, not 3", async () => {
+  // MYSQL_TYPE_INT24 is encoded on the binary wire as a 4-byte little-endian
+  // integer (server sign/zero-extends the high byte — mysql2 reads this with
+  // readInt32). The port originally advanced the cursor by only 3 bytes,
+  // leaving the extension byte in the stream. With NEWDECIMAL following,
+  // that orphaned byte becomes the next column's length prefix → garbage
+  // decimal or hang, identical failure mode to #30854 for YEAR. Single-
+  // column tests masked this because the extra byte ended the row cleanly.
+  const rows = await runQuery("int24-then-newdecimal", "select mi, dec from t where mi = ?", [1_234_567]);
+  expect(rows[0].mi).toBe(1_234_567);
+  expect(rows[0].dec).toBe("42.0");
 });

--- a/test/js/sql/sql-mysql-year-newdecimal.test.ts
+++ b/test/js/sql/sql-mysql-year-newdecimal.test.ts
@@ -1,0 +1,335 @@
+// Regression for https://github.com/oven-sh/bun/issues/30854
+//
+// MYSQL_TYPE_YEAR (0x0d) in the binary result-set protocol is a bare 2-byte
+// little-endian u16 — the same wire shape as MYSQL_TYPE_SHORT, with NO
+// length prefix. The MySQL client's binary-row decoder had no explicit
+// branch for YEAR, so it fell through to the default arm which read
+// `column_length` bytes (the ColumnDefinition41 *display width*, typically
+// 4 for `YEAR(4)`) instead. The cursor over-read by 2 bytes and misaligned
+// every subsequent column.
+//
+// When the next column is length-prefixed (NEWDECIMAL, VARCHAR, JSON, ...)
+// the stray bytes re-enter the length decoder as a length prefix, driving
+// the row parser into an unbounded wait — the query promise never resolves,
+// even though the event loop stays alive (#30854).
+//
+// Uses a minimal mock MySQL server so the test runs without Docker or a
+// live MySQL installation. We send a crafted binary-protocol row where
+// YEAR is immediately followed by NEWDECIMAL. Before the fix the
+// assertion below times out; after the fix the row decodes correctly.
+
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import { once } from "events";
+import net from "net";
+
+// --- MySQL wire format helpers ---------------------------------------------
+
+function u16le(n: number): Buffer {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff]);
+}
+function u24le(n: number): Buffer {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff]);
+}
+function u32le(n: number): Buffer {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >>> 24) & 0xff]);
+}
+function packet(seq: number, payload: Buffer): Buffer {
+  return Buffer.concat([u24le(payload.length), Buffer.from([seq]), payload]);
+}
+
+function lenenc(n: number): Buffer {
+  if (n < 0xfb) return Buffer.from([n]);
+  if (n < 0xffff) return Buffer.concat([Buffer.from([0xfc]), u16le(n)]);
+  if (n < 0xffffff) return Buffer.concat([Buffer.from([0xfd]), u24le(n)]);
+  throw new Error("lenenc: 8-byte form not needed for this test");
+}
+function lenencStr(s: string | Buffer): Buffer {
+  const buf = typeof s === "string" ? Buffer.from(s, "utf-8") : s;
+  return Buffer.concat([lenenc(buf.length), buf]);
+}
+
+// --- Capability flags ------------------------------------------------------
+
+const CLIENT_PROTOCOL_41 = 1 << 9;
+const CLIENT_SECURE_CONNECTION = 1 << 15;
+const CLIENT_PLUGIN_AUTH = 1 << 19;
+const CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA = 1 << 21;
+const CLIENT_DEPRECATE_EOF = 1 << 24;
+const SERVER_CAPS =
+  CLIENT_PROTOCOL_41 |
+  CLIENT_SECURE_CONNECTION |
+  CLIENT_PLUGIN_AUTH |
+  CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA |
+  CLIENT_DEPRECATE_EOF;
+
+// MYSQL_TYPE_* values. From src/sql/mysql/MySQLTypes.rs.
+const MYSQL_TYPE_YEAR = 0x0d;
+const MYSQL_TYPE_NEWDECIMAL = 0xf6;
+const MYSQL_TYPE_DATETIME = 0x0c;
+const MYSQL_TYPE_VAR_STRING = 0xfd;
+
+// --- Packet builders -------------------------------------------------------
+
+function handshakeV10(): Buffer {
+  const authData1 = Buffer.alloc(8, 0x61);
+  const authData2 = Buffer.alloc(13, 0x62);
+  authData2[12] = 0;
+  const payload = Buffer.concat([
+    Buffer.from([10]), // protocol version
+    Buffer.from("mock-5.7.0\0"),
+    u32le(1), // connection id
+    authData1,
+    Buffer.from([0]), // filler
+    u16le(SERVER_CAPS & 0xffff),
+    Buffer.from([0x2d]), // utf8mb4_general_ci
+    u16le(0x0002), // SERVER_STATUS_AUTOCOMMIT
+    u16le((SERVER_CAPS >>> 16) & 0xffff),
+    Buffer.from([21]), // length of auth-plugin-data
+    Buffer.alloc(10, 0), // reserved
+    authData2,
+    Buffer.from("mysql_native_password\0"),
+  ]);
+  return packet(0, payload);
+}
+
+function okPacket(seq: number, header = 0x00): Buffer {
+  return packet(seq, Buffer.from([header, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
+}
+
+function columnDefinition(name: string, type: number, columnLength: number): Buffer {
+  // ColumnDefinition41: catalog, schema, table, org_table, name, org_name (all
+  // lenenc strings), fixed-length-field-length (lenenc = 0x0c), character_set
+  // (u16), column_length (u32), column_type (u8), flags (u16), decimals (u8),
+  // plus 2 reserved bytes.
+  return Buffer.concat([
+    lenencStr("def"),
+    lenencStr(""),
+    lenencStr("t"),
+    lenencStr("t"),
+    lenencStr(name),
+    lenencStr(name),
+    Buffer.from([0x0c]), // fixed-length-fields length = 12
+    u16le(33), // utf8_general_ci
+    u32le(columnLength), // column_length (display width)
+    Buffer.from([type]),
+    u16le(0), // flags
+    Buffer.from([0]), // decimals
+    Buffer.from([0, 0]), // reserved
+  ]);
+}
+
+// COM_STMT_PREPARE response: OK header + num_params param defs + num_columns column defs.
+// CLIENT_DEPRECATE_EOF was negotiated in the handshake, so no trailing EOF packets.
+function stmtPrepareOK(startSeq: number, statementId: number, params: Buffer[], columns: Buffer[]): Buffer {
+  const packets: Buffer[] = [];
+  let seq = startSeq;
+  packets.push(
+    packet(
+      seq++,
+      Buffer.concat([
+        Buffer.from([0x00]),
+        u32le(statementId),
+        u16le(columns.length), // num_columns
+        u16le(params.length), // num_params
+        Buffer.from([0x00]), // reserved
+        u16le(0), // warning_count
+      ]),
+    ),
+  );
+  for (const p of params) packets.push(packet(seq++, p));
+  for (const col of columns) packets.push(packet(seq++, col));
+  return Buffer.concat(packets);
+}
+
+// Binary row: 0x00 header, then NULL bitmap of (num_columns + 7 + 2) / 8
+// bytes (integer division per the MySQL spec — two reserved bits up front),
+// then each non-null column's binary encoding.
+function binaryRow(seq: number, numColumns: number, columnBytes: Buffer[]): Buffer {
+  const bitmapLen = Math.floor((numColumns + 7 + 2) / 8);
+  return packet(
+    seq,
+    Buffer.concat([
+      Buffer.from([0x00]), // packet header
+      Buffer.alloc(bitmapLen, 0), // NULL bitmap — no NULLs
+      ...columnBytes,
+    ]),
+  );
+}
+
+function deprecateEofOk(seq: number): Buffer {
+  return packet(seq, Buffer.from([0xfe, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
+}
+
+// --- The payloads exercising the bug ---------------------------------------
+
+// MYSQL_TYPE_YEAR is a bare 2-byte little-endian u16 on the wire. 2022 → 0xe6 0x07.
+function encodeYear(year: number): Buffer {
+  return u16le(year);
+}
+
+// MYSQL_TYPE_NEWDECIMAL is length-prefixed ASCII. "123" → 0x03 0x31 0x32 0x33.
+function encodeNewdecimal(text: string): Buffer {
+  return lenencStr(text);
+}
+
+// MYSQL_TYPE_DATETIME (binary): 1 length byte + 4/7/11 bytes. Use the 7-byte
+// form: length=7, year(u16), month, day, hour, minute, second.
+function encodeDatetime7(year: number, month: number, day: number, h: number, m: number, s: number): Buffer {
+  return Buffer.concat([Buffer.from([7]), u16le(year), Buffer.from([month, day, h, m, s])]);
+}
+
+// --- Test ------------------------------------------------------------------
+
+interface MockOptions {
+  // How to lay out the columns of the binary result row.
+  layout: "year-then-newdecimal" | "newdecimal-then-year" | "year-alone" | "year-then-datetime";
+  // Number of `?` placeholders in the prepared statement.
+  numParams: number;
+}
+
+function startMockServer(opts: MockOptions) {
+  const server = net.createServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let authed = false;
+    let preparedColumns: { name: string; type: number; columnLength: number }[] = [];
+
+    socket.write(handshakeV10());
+
+    socket.on("data", chunk => {
+      buffered = Buffer.concat([buffered, chunk]);
+      while (buffered.length >= 4) {
+        const len = buffered[0] | (buffered[1] << 8) | (buffered[2] << 16);
+        if (buffered.length < 4 + len) break;
+        const seq = buffered[3];
+        const payload = buffered.subarray(4, 4 + len);
+        buffered = buffered.subarray(4 + len);
+
+        if (!authed) {
+          authed = true;
+          socket.write(okPacket(seq + 1));
+          continue;
+        }
+
+        const cmd = payload[0];
+        if (cmd === 0x16 /* COM_STMT_PREPARE */) {
+          // Pick the column set for this layout.
+          switch (opts.layout) {
+            case "year-then-newdecimal":
+              preparedColumns = [
+                { name: "fullYear", type: MYSQL_TYPE_YEAR, columnLength: 4 },
+                { name: "milliseconds", type: MYSQL_TYPE_NEWDECIMAL, columnLength: 10 },
+              ];
+              break;
+            case "newdecimal-then-year":
+              preparedColumns = [
+                { name: "milliseconds", type: MYSQL_TYPE_NEWDECIMAL, columnLength: 10 },
+                { name: "fullYear", type: MYSQL_TYPE_YEAR, columnLength: 4 },
+              ];
+              break;
+            case "year-alone":
+              preparedColumns = [{ name: "value", type: MYSQL_TYPE_YEAR, columnLength: 4 }];
+              break;
+            case "year-then-datetime":
+              preparedColumns = [
+                { name: "y", type: MYSQL_TYPE_YEAR, columnLength: 4 },
+                { name: "ts", type: MYSQL_TYPE_DATETIME, columnLength: 19 },
+              ];
+              break;
+          }
+          const paramDefs = Array.from({ length: opts.numParams }, (_, i) =>
+            columnDefinition(`p${i}`, MYSQL_TYPE_VAR_STRING, 255),
+          );
+          const colDefs = preparedColumns.map(c => columnDefinition(c.name, c.type, c.columnLength));
+          socket.write(stmtPrepareOK(seq + 1, 1, paramDefs, colDefs));
+        } else if (cmd === 0x17 /* COM_STMT_EXECUTE */) {
+          // Build the result set for this layout.
+          const colDefs = preparedColumns.map(c => columnDefinition(c.name, c.type, c.columnLength));
+          let rowColumns: Buffer[];
+          switch (opts.layout) {
+            case "year-then-newdecimal":
+              rowColumns = [encodeYear(2022), encodeNewdecimal("123")];
+              break;
+            case "newdecimal-then-year":
+              rowColumns = [encodeNewdecimal("123"), encodeYear(2022)];
+              break;
+            case "year-alone":
+              rowColumns = [encodeYear(2022)];
+              break;
+            case "year-then-datetime":
+              rowColumns = [encodeYear(2013), encodeDatetime7(2024, 5, 1, 12, 0, 0)];
+              break;
+          }
+          const packets: Buffer[] = [];
+          let s = seq + 1;
+          packets.push(packet(s++, Buffer.from([colDefs.length]))); // column count
+          for (const cd of colDefs) packets.push(packet(s++, cd));
+          packets.push(binaryRow(s++, preparedColumns.length, rowColumns));
+          packets.push(deprecateEofOk(s++));
+          socket.write(Buffer.concat(packets));
+        } else {
+          socket.end();
+        }
+      }
+    });
+    socket.on("error", () => {});
+  });
+  server.listen(0, "127.0.0.1");
+  return server;
+}
+
+async function runQuery(layout: MockOptions["layout"], query: string, params: unknown[]) {
+  const server = startMockServer({ layout, numParams: params.length });
+  try {
+    await once(server, "listening");
+    const { port } = server.address() as net.AddressInfo;
+    await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
+    // .unsafe() with a non-empty params array uses the binary/prepared
+    // protocol (COM_STMT_PREPARE + COM_STMT_EXECUTE), which routes the
+    // result row through decode_binary_value — where the bug lives.
+    return await sql.unsafe(query, params);
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+}
+
+test("MYSQL_TYPE_YEAR decodes as a number (#30854, #29471)", async () => {
+  const rows = await runQuery("year-alone", "select year(?) as value", ["2022-11-21 19:33:56.123"]);
+  // Before the fix: value was a 4-byte Buffer (e.g. <Buffer e6 07 07 00>).
+  // After the fix: value is the number 2022 (decoded from the 2-byte u16).
+  expect(rows[0].value).toBe(2022);
+});
+
+test("NEWDECIMAL followed by YEAR — YEAR decodes correctly (#30854)", async () => {
+  const rows = await runQuery(
+    "newdecimal-then-year",
+    "select round(microsecond(?) / 1000) as milliseconds, year(?) as fullYear",
+    ["2022-11-21 19:33:56.123", "2022-11-21 19:33:56.123"],
+  );
+  // Before the fix this arrangement already resolved, but the YEAR value
+  // was a Buffer. Guard both columns.
+  expect(rows[0].milliseconds).toBe("123");
+  expect(rows[0].fullYear).toBe(2022);
+});
+
+test("YEAR followed by NEWDECIMAL does not hang the query promise (#30854)", async () => {
+  // This is the defining case from the issue. Pre-fix the decoder
+  // over-read YEAR by 2 bytes, mis-consumed the NEWDECIMAL length prefix,
+  // then waited forever for bytes that never arrive.
+  const rows = await runQuery(
+    "year-then-newdecimal",
+    "select year(?) as fullYear, round(microsecond(?) / 1000) as milliseconds",
+    ["2022-11-21 19:33:56.123", "2022-11-21 19:33:56.123"],
+  );
+  expect(rows[0].fullYear).toBe(2022);
+  expect(rows[0].milliseconds).toBe("123");
+});
+
+test("YEAR followed by DATETIME — DATETIME is not corrupted by a YEAR over-read (#29471)", async () => {
+  // A 2-byte YEAR over-read used to eat the DATETIME's length byte + a
+  // pair of date bytes, driving the datetime decoder at absurd dates
+  // (3588-06-02, 7435-05-31 in the reports) or an InvalidBinaryValue.
+  const rows = await runQuery("year-then-datetime", "select y, ts from t where y = ?", [2013]);
+  expect(rows[0].y).toBe(2013);
+  expect(rows[0].ts).toEqual(new Date(Date.UTC(2024, 4, 1, 12, 0, 0)));
+});


### PR DESCRIPTION
Fixes #30854. Also fixes #29471 (same root cause).

## Repro

Against a real MySQL (MariaDB's `year()` returns `LONG`, so it doesn't trip the bug):

```js
import { SQL } from "bun";
const sql = new SQL("mysql://root:pw@127.0.0.1:3306/sys");
const value = "2022-11-21 19:33:56.123";
await sql.unsafe(
  "select year(cast(? as datetime(3))) as fullYear, round(microsecond(cast(? as datetime(3))) / 1000) as milliseconds",
  [value, value],
);
// hangs forever — the query promise never resolves
```

Also: `select year(...)` alone returned `<Buffer e6 07 07 00>` instead of `2022`, and a `DATETIME` following a `YEAR` column decoded as garbage dates (`3588-06-02`, `7435-05-31`) — see #29471.

## Root cause

`src/sql_jsc/mysql/protocol/DecodeBinaryValue.rs` had no explicit arm for `MYSQL_TYPE_YEAR` and fell through to the default:

```rust
_ => {
    let data = reader.read(column_length as usize)?;
    Ok(SQLDataCell::raw(Some(&data)))
}
```

`column_length` is the `ColumnDefinition41` **display width** (4 for `YEAR(4)`), but `YEAR` in the MySQL binary result-row protocol is a bare 2-byte little-endian u16 — same shape as `MYSQL_TYPE_SHORT`, with no length prefix. The decoder over-reads by 2 bytes and misaligns the cursor for every following column in the row.

Wire evidence:

- Year 2022 is `e6 07` (2 bytes) on the wire. The reporter saw `<Buffer e6 07 07 00>` — the correct 2 bytes plus 2 stolen from whatever came next.
- Year 2013 is `dd 07`; the original #29471 report saw `<Buffer dd 07 07 ea>` and the `DATETIME` immediately after decoded as `3588-06-02`.

### Why it hangs when NEWDECIMAL follows

Expected wire bytes for a `year, newdecimal` row:

```
e6 07              ← YEAR (u16, 2022)
03 31 32 33        ← NEWDECIMAL (length 0x03, "123")
```

With the bug:

1. YEAR arm consumes `column_length` = 4 bytes → eats `e6 07 03 31`.
2. NEWDECIMAL arm calls `encode_len_string()`. The next byte is `0x32` (50) — read as a length prefix. The decoder asks for 50 more bytes, only 1 (`0x33`) is left, and the row parser blocks waiting for the rest of a packet that will never arrive.

The process stays alive (the reporter's `setTimeout` still fires), but the query promise never resolves.

When the order is reversed (`NEWDECIMAL, YEAR`), NEWDECIMAL consumes correctly via `encode_len_string`; YEAR still over-reads by 2 bytes, but those 2 bytes land inside the packet trailer or at EOF, so the query resolves with the wrong buffer value instead of hanging.

## Fix

Add an explicit `MYSQL_TYPE_YEAR` arm that reads exactly 2 bytes and returns a `uint4` cell. Shape mirrors the existing `MYSQL_TYPE_SHORT` unsigned branch (YEAR is always unsigned).

Cross-checked against `mysql2`'s binary parser: `lib/parsers/binary_parser.js` treats `Types.YEAR` as a direct `packet.readInt16()` (2-byte LE u16, no length prefix) in the same switch as `SHORT`.

## Verification

New regression test: `test/js/sql/sql-mysql-year-newdecimal.test.ts`. Mock MySQL server (modeled on `sql-mysql-raw-length-prefix.test.ts`) so the test runs without Docker. Covers four column layouts and fails pre-fix on all four:

| Layout | Pre-fix | Post-fix |
|---|---|---|
| `YEAR` alone | wrong value | `2022` |
| `NEWDECIMAL, YEAR` | `milliseconds=""`, `fullYear=""` | `"123"`, `2022` |
| `YEAR, NEWDECIMAL` | **times out at 5s** | both correct |
| `YEAR, DATETIME` | wrong year + corrupted date | `2013`, correct `Date` |

Fail-before → pass-after with `src/sql_jsc/mysql/protocol/DecodeBinaryValue.rs` reverted:

```
(fail) MYSQL_TYPE_YEAR decodes as a number (#30854, #29471) — Expected 2022, got ""
(fail) NEWDECIMAL followed by YEAR — YEAR decodes correctly (#30854) — Expected "123", got ""
(fail) YEAR followed by NEWDECIMAL does not hang the query promise (#30854) — timed out after 5000ms
(fail) YEAR followed by DATETIME — DATETIME is not corrupted by a YEAR over-read (#29471) — Expected 2013, got ""
```

After the fix: 4 pass, 0 fail.

Existing mock-based MySQL tests (`sql-mysql-raw-length-prefix`, `sql-mysql-auth-short-nonce`, `sql-mysql-clean-reentry`) still pass.