### PR TITLE
Report uncaught exceptions from DeferredWorkTimer tasks

### DIFF
--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -1,5 +1,8 @@
 #include "config.h"
 #include <JavaScriptCore/VM.h>
+#include <JavaScriptCore/Exception.h>
+#include <JavaScriptCore/GlobalObjectMethodTable.h>
+#include <JavaScriptCore/TopExceptionScope.h>
 #include "JSCTaskScheduler.h"
 #include "BunClientData.h"
 
@@ -108,7 +111,14 @@ static void runPendingWork(void* bunVM, Bun::JSCTaskScheduler& scheduler, JSCDef
     holder.unlockEarly();
 
     if (pendingTicket && !pendingTicket->isCancelled()) {
+        auto& vm = job->vm();
+        auto* globalObject = pendingTicket->scriptExecutionOwner()->globalObject();
+        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         job->task(job->ticket.get());
+        if (auto* exception = scope.exception()) {
+            if (scope.clearExceptionExceptTermination())
+                globalObject->globalObjectMethodTable()->reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        }
     }
 
     delete job;

--- a/test/js/bun/util/finalization-registry-throwing-callback.test.ts
+++ b/test/js/bun/util/finalization-registry-throwing-callback.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// JSC schedules FinalizationRegistry cleanup through DeferredWorkTimer. Bun's
+// runPendingWork ran the task with no exception scope, so a throw from the
+// cleanup callback was left pending and tripped releaseAssertNoException() in
+// the Rust-side caller (SIGABRT in debug/ASAN builds). Upstream
+// DeferredWorkTimer::doWork catches the exception and routes it to
+// reportUncaughtExceptionAtEventLoop; runPendingWork must do the same.
+
+test.concurrent(
+  "FinalizationRegistry cleanup callback that throws reaches process.on('uncaughtException')",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        let caught = 0;
+        process.on("uncaughtException", err => {
+          if (String(err?.message ?? err).includes("cleanup-boom")) caught++;
+        });
+        const registry = new FinalizationRegistry(() => { throw new Error("cleanup-boom"); });
+        (function () {
+          for (let i = 0; i < 64; i++) registry.register({}, i);
+        })();
+        while (!caught) {
+          Bun.gc(true);
+          await new Promise(resolve => setImmediate(resolve));
+        }
+        registry;
+        console.log("caught=" + caught);
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout: stdout.trim(), stderr, signal: proc.signalCode }).toEqual({
+      stdout: expect.stringMatching(/^caught=\d+$/),
+      stderr: "",
+      signal: null,
+    });
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.concurrent("FinalizationRegistry cleanup continues past a throwing callback", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        let cleaned = 0;
+        let caught = 0;
+        process.on("uncaughtException", err => {
+          if (String(err?.message ?? err).includes("cleanup-boom")) caught++;
+        });
+        const registry = new FinalizationRegistry(h => {
+          cleaned++;
+          if (cleaned === 2) throw new Error("cleanup-boom");
+        });
+        const N = 10;
+        (function () {
+          for (let i = 0; i < N; i++) registry.register({}, i);
+        })();
+        // runFinalizationCleanup bails on the first throw; the remaining
+        // holdings stay queued on the registry and are picked up by the next
+        // GC-driven schedule once the exception is cleared.
+        for (let r = 0; cleaned < N && r < 200; r++) {
+          Bun.gc(true);
+          await new Promise(resolve => setImmediate(resolve));
+        }
+        registry;
+        console.log(JSON.stringify({ cleaned, caught }));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ ...JSON.parse(stdout.trim() || "{}"), stderr, signal: proc.signalCode }).toEqual({
+    cleaned: 10,
+    caught: 1,
+    stderr: "",
+    signal: null,
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### What does this PR do?

JSC schedules `FinalizationRegistry` cleanup (and `Atomics.waitAsync`, wasm streaming compilation) through `DeferredWorkTimer`. Upstream's `DeferredWorkTimer::doWork` wraps each task in a `TopExceptionScope` and routes any thrown exception to `reportUncaughtExceptionAtEventLoop`. Bun replaces that loop with `JSCTaskScheduler::runPendingWork` but skipped the exception handling, so an exception thrown from a `FinalizationRegistry` cleanup callback was left pending and tripped `releaseAssertNoException()` in the Rust-side caller.

Symptoms:

- **debug/ASAN**: SIGABRT on `ExceptionScope.h:62 releaseAssertNoException()` every run.
- **release**: the exception dangled until the next `GlobalObject::drainMicrotasks`, which short-circuits its next-tick drain and reports it as uncaught. If the registry itself becomes unreachable before another GC (it is only kept alive by the deferred-work ticket while cleanup is pending), the remaining holdings in the truncated batch are dropped with it.

Repro (asserts on ASAN, prints `cleaned= 2` on release; Node prints `cleaned= 10`):

```js
let cleaned = 0;
const reg = new FinalizationRegistry(h => { cleaned++; console.log('cleanup', h); if (cleaned === 2) throw new Error('cleanup-boom'); });
process.on('uncaughtException', e => console.log('uncaught:', e.message));
for (let i = 0; i < 10; i++) reg.register({}, i);
for (let r = 0; r < 6; r++) { Bun.gc(true); await new Promise(r2 => setTimeout(r2, 15)); }
console.log('DONE cleaned=', cleaned);
```

Before:

```
ASSERTION FAILED: Unexpected exception observed on thread ... at:
Error Exception: cleanup-boom
!exception()
JavaScriptCore/ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
```

### Fix

Wrap the deferred task in a `TopExceptionScope` and report any non-termination exception via `reportUncaughtExceptionAtEventLoop`, matching upstream `DeferredWorkTimer::doWork`. The error now surfaces as an `uncaughtException`, the validation scope in `JSCDeferredWorkTask::run` is satisfied, and remaining holdings on a still-reachable registry are picked up by the next GC-driven schedule.

Note on the release `cleaned=2` outcome above: `const reg` has no use after the registration loop, so once the first cleanup task's ticket is released the registry itself is collectible and its queued holdings go with it. That is spec-conformant GC behavior; keeping the registry reachable (`globalThis.__reg = reg`, or any later use) yields `cleaned=10` with this fix.

### How did you verify your code works?

`test/js/bun/util/finalization-registry-throwing-callback.test.ts` spawns a child that throws from a cleanup callback. Without the `src/` change both tests fail under `bun bd` with the child aborting on `releaseAssertNoException()`; with it both pass and the second test confirms all ten holdings are eventually cleaned with exactly one `uncaughtException`. `BUN_JSC_validateExceptionChecks=1` is clean.

Also covers Fuzzilli fingerprint `58b78b97e2e39882`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 12 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/finalization-registry-throwing-callback.test.ts
bun test v1.4.0 (9e680bdc1)

test/js/bun/util/finalization-registry-throwing-callback.test.ts:
37 |       stderr: "pipe",
38 |     });
39 | 
40 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
41 | 
42 |     expect({ stdout: stdout.trim(), stderr, signal: proc.signalCode }).toEqual({
                                                                            ^
error: expect(received).toEqual(expected)

  {
-   "signal": null,
-   "stderr": "",
-   "stdout": StringMatching /^caught=\d+$/,
+   "signal": "SIGABRT",
+   "stderr": 
+ "ASSERTION FAILED: Unexpected exception observed on thread Thread:0x70c5d60000c0 at:
+ The exception was thrown from thread Thread:0x70c5d60000c0 at:
+ Error Exception: cleanup-boom
+ 
+ !exception()
+ /root/.bun/build-cache/webkit-c9296e353e365ecf-debug-asan/include/JavaScriptCore/ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
+ no stacktrace available"
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (9e680bdc1)

test/js/bun/util/finalization-registry-throwing-callback.test.ts:
(pass) FinalizationRegistry cleanup callback that throws reaches process.on('uncaughtException') [11.80ms]
(pass) FinalizationRegistry cleanup continues past a throwing callback [12.60ms]

 2 pass
 0 fail
 4 expect() calls
Ran 2 tests across 1 file. [276.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/finalization-registry-throwing-callback.test.ts
bun test v1.4.0 (9e680bdc1)

test/js/bun/util/finalization-registry-throwing-callback.test.ts:
(pass) FinalizationRegistry cleanup callback that throws reaches process.on('uncaughtException') [477.59ms]
(pass) FinalizationRegistry cleanup continues past a throwing callback [479.17ms]

 2 pass
 0 fail
 4 expect() calls
Ran 2 tests across 1 file. [2.55s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 866ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[2/7] gen cpp.rs (cppbind)
[3/7] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[3/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 3m 56s
[4/7] link bun-profile
[5/7] bun-profile --revision
1.4.0-canary.1+9e680bdc1
[7/7] strip bun
[build] done
bun test v1.4.0-canary.1 (9e680bdc1)

test/js/bun/util/finalization-registry-throwing-callback.test.ts:
(pass) FinalizationRegistry cleanup callback that throws reaches process.on('uncaughtException') [12.52ms]
(pass) FinalizationRegistry cleanup continues past a throwing cal
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSCTaskScheduler.cpp              | 10 +++
 ...finalization-registry-throwing-callback.test.ts | 95 ++++++++++++++++++++++
 2 files changed, 105 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 12

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/bindings/JSCTaskScheduler.cpp                         4      7     17
…un/util/finalization-registry-throwing-callback.test.ts      0      4     17
```

</details>

<!-- robobun:evidence:end -->