### PR TITLE
ci: declare workflow-level `contents: read` on 3 workflows

### DIFF
--- a/.github/workflows/freebsd-smoke.yml
+++ b/.github/workflows/freebsd-smoke.yml
@@ -14,6 +14,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,9 @@ on:
 env:
   BUN_VERSION: "1.2.10"
 
+permissions:
+  contents: read
+
 jobs:
   lint-js:
     name: "Lint JavaScript"

--- a/.github/workflows/packages-ci.yml
+++ b/.github/workflows/packages-ci.yml
@@ -25,6 +25,9 @@ on:
 env:
   BUN_VERSION: "canary"
 
+permissions:
+  contents: read
+
 jobs:
   bun-plugin-svelte:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 3 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.