### PR TITLE
Fix typo in query parameters for SQLite example

### DIFF
--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -86,11 +86,11 @@ import { Database } from "bun:sqlite";
 const strict = new Database(":memory:", { strict: true });
 
 // throws error because of the typo:
-const query = strict.query("SELECT $message;").all({ messag: "Hello world" });
+const query = strict.query("SELECT $message;").all({ message: "Hello world" });
 
 const notStrict = new Database(":memory:");
 // does not throw error:
-notStrict.query("SELECT $message;").all({ messag: "Hello world" });
+notStrict.query("SELECT $message;").all({ message: "Hello world" });
 ```
 
 ### Load via ES module import


### PR DESCRIPTION
### What does this PR do?
Just fixing typo in the query examples.

