### PR TITLE
build: don't force -fuse-ld=lld for darwin rust targets

### DIFF
--- a/scripts/build/cargo-config.ts
+++ b/scripts/build/cargo-config.ts
@@ -10,9 +10,12 @@
  * lines from that discovered path rather than hardcoding one.
  *
  * For the `bun bd` / ninja build this file is purely advisory: `rust.ts`
- * passes `CARGO_TARGET_<TRIPLE>_LINKER = cfg.cxx` (plus `CC`/`CXX`/`AR`) and
- * `-Clink-arg=-fuse-ld=lld` directly on the cargo invocation's environment,
- * which override anything here. The file matters for a contributor running
+ * passes `CARGO_TARGET_<TRIPLE>_LINKER = cfg.cxx` (plus `CC`/`CXX`/`AR`) and,
+ * when `rustForcesFuseLdLld(cfg)` holds, `-Clink-arg=-fuse-ld=lld` directly on
+ * the cargo invocation's environment, which override anything here. (Darwin
+ * omits that flag unless cross-language LTO is on — macOS uses ld64 by
+ * default; see rust.ts. The darwin sections below skip the `-fuse-ld=lld`
+ * rustflag for the same reason.) The file matters for a contributor running
  * `cargo build` / `cargo check` directly, and for rust-analyzer.
  *
  * `writeIfChanged` semantics (precedent: `depVersionsHeader.ts`) so a
@@ -77,6 +80,10 @@ export function generateCargoConfig(cfg: Config): string {
     "# of which the default `cc` link handles cleanly. Paths come from the",
     "# toolchain `scripts/build/tools.ts` discovered (`cfg.hostCxx`), so this",
     "# file is correct on whatever machine ran configure.",
+    "#",
+    "# Darwin is the exception: its sections below omit -fuse-ld=lld and let",
+    "# clang++ use ld64 (macOS has no lld by default; Homebrew clang++ rejects",
+    "# the flag). See #30870 and `rustForcesFuseLdLld()` in rust.ts.",
   ];
 
   for (const triple of allRustTargets) {
@@ -84,19 +91,27 @@ export function generateCargoConfig(cfg: Config): string {
     lines.push("");
     lines.push(`[target.${triple}]${triple === host ? "  # host" : ""}`);
     lines.push(`linker = ${JSON.stringify(linkerFor(triple, cfg))}`);
-    // -Qunused-arguments: rustc passes link args that don't apply to every
-    // artifact kind (e.g. `-no-pie` when it links a target cdylib; none
-    // exists today, so this is defensive — same rationale as `emitRust` in
-    // rust.ts), and its `linker_messages` lint re-surfaces clang's "argument
-    // unused during compilation" complaint as a warning on every build-rust
-    // job.
-    // These config rustflags reach the cargo invocations that don't set
+    // -fuse-ld=lld forces clang++ to drive lld instead of its default linker.
+    // -Qunused-arguments + `-A linker_messages` quiet the `linker_messages`
+    // lint about link args that don't apply to every artifact kind (e.g.
+    // `-no-pie` when rustc links a target cdylib; none exists today, so this
+    // is defensive — same rationale as `emitRust` in rust.ts). These config
+    // rustflags reach the cargo invocations that don't set
     // CARGO_ENCODED_RUSTFLAGS themselves (the lolhtml dep edge, plain
     // `cargo build`/`cargo check`, rust-analyzer); real linker errors still
     // fail the link.
-    lines.push(
-      `rustflags = ["-C", "link-arg=-fuse-ld=lld", "-C", "link-arg=-Qunused-arguments", "-A", "linker_messages"]`,
-    );
+    //
+    // darwin omits `-fuse-ld=lld`: macOS uses `ld64` / the system linker, and
+    // a Homebrew `clang++` without the `lld` driver alias rejects it with
+    // "invalid linker name in argument '-fuse-ld=lld'", breaking plain
+    // `cargo check` / rust-analyzer on contributors' macs (#30870). The
+    // lint-quieting flags stay, matching `rustForcesFuseLdLld()` in rust.ts
+    // (which also keeps them on darwin while dropping the linker flag).
+    const rustflags =
+      tripleOs(triple) === "darwin"
+        ? ["-C", "link-arg=-Qunused-arguments", "-A", "linker_messages"]
+        : ["-C", "link-arg=-fuse-ld=lld", "-C", "link-arg=-Qunused-arguments", "-A", "linker_messages"];
+    lines.push(`rustflags = [${rustflags.map(f => JSON.stringify(f)).join(", ")}]`);
   }
   lines.push("");
 

--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -77,6 +77,31 @@ export function cargoProfile(cfg: Config): { name: string; subdir: string } {
 }
 
 /**
+ * Whether the ninja build should force `-fuse-ld=lld` into the Rust target
+ * crates' link (via `CARGO_ENCODED_RUSTFLAGS`). Centralized so `emitRust` and
+ * the regression test share one source of truth.
+ *
+ *   - Windows: never — the per-target linker is `link.exe` / `lld-link.exe`,
+ *     which take `/X` args, not the GCC/clang `-fuse-ld=`.
+ *   - darwin: only under cross-language LTO. macOS uses `ld64` / the system
+ *     linker by default (`cfg.ld` is empty — config.ts; the C++ side doesn't
+ *     pass `--ld-path=` either — flags.ts), and a Homebrew `clang++` without
+ *     the `lld` driver alias rejects `-fuse-ld=lld` outright ("invalid linker
+ *     name in argument '-fuse-ld=lld'"), breaking `bun run rust:check` /
+ *     `bun bd` on contributors' macs (#30870). Under `--lto` the flag is
+ *     required so rustc's bitcode link goes through the LTO-aware linker (the
+ *     user must then have an `lld`-capable clang++, same as on linux).
+ *   - linux / freebsd / android: always — the default `cc` driver picks BFD
+ *     `/usr/bin/ld`, which doesn't match the semantics the C/C++ object set
+ *     assumes (and under `-Clinker-plugin-lto` doesn't understand `-plugin-opt`).
+ */
+export function rustForcesFuseLdLld(cfg: Config): boolean {
+  if (cfg.windows) return false;
+  if (cfg.darwin) return cfg.crossLangLto;
+  return true;
+}
+
+/**
  * All target triples CI builds (`buildPlatforms` in .buildkite/ci.mjs, one
  * triple per os/arch/abi; test/internal/source-lints/build-rust.test.ts keeps
  * the two in sync). Drives `rust:check-all` and the generated
@@ -599,15 +624,19 @@ export function cargoBuildInvocation(cfg: Config): CargoInvocation {
   // `cfg.lto`, with the non-LTO build relying on `.cargo/config.toml`'s
   // `rustflags`; but `CARGO_ENCODED_RUSTFLAGS` (always set below) *replaces*
   // the config-file `rustflags` rather than merging, so the config entry was
-  // dead for any ninja build. Push it unconditionally so the ninja build's
-  // behavior doesn't depend on the generated `.cargo/config.toml` at all.
+  // dead for any ninja build. Push it here so the ninja build's behavior
+  // doesn't depend on the generated `.cargo/config.toml` at all.
   //
-  // Not on Windows: the per-target linker there is `link.exe` / `lld-link.exe`
-  // (see `CARGO_TARGET_*_LINKER` below), which take `/X` args, not the GCC/clang
-  // `-fuse-ld=`. RUSTFLAGS only reach *target* crates when `--target` is given,
-  // and the `bun_runtime` staticlib has no link step, so it's normally dead — but
-  // if a target cdylib ever appears it'd fail with "could not open '-fuse-ld=lld'".
-  if (!cfg.windows) rustflags.push(`-Clink-arg=-fuse-ld=lld`);
+  // `rustForcesFuseLdLld()` owns the per-platform decision: windows never
+  // (its per-target linker is `link.exe` / `lld-link.exe` — see
+  // `CARGO_TARGET_*_LINKER` below — which take `/X` args, not the GCC/clang
+  // `-fuse-ld=`); darwin only under cross-lang LTO (macOS defaults to ld64
+  // and a Homebrew clang++ may reject the flag, #30870); linux/freebsd/
+  // android always. RUSTFLAGS only reach *target* crates when `--target` is
+  // given, and the `bun_runtime` staticlib has no link step, so it's normally
+  // dead — but if a target cdylib ever appears it'd fail with "could not
+  // open '-fuse-ld=lld'".
+  if (rustForcesFuseLdLld(cfg)) rustflags.push(`-Clink-arg=-fuse-ld=lld`);
   // Keep the clang driver quiet about link args that don't apply to a given
   // artifact kind: rustc adds `-no-pie` under `-Crelocation-model=static`,
   // which is meaningless when it links a target cdylib, and rustc's
@@ -643,10 +672,11 @@ export function cargoBuildInvocation(cfg: Config): CargoInvocation {
     // Every LTO platform now links ThinLTO with the C/C++ side passing
     // -fno-split-lto-unit (index-based WPD, no hybrid split), so every C/C++
     // module (ours and the WebKit -lto prebuilts) says 0. rustc's default is
-    // also 0, so pass nothing. (`-Clink-arg=-fuse-ld=lld` is pushed
-    // unconditionally above — under LTO it doubles as making rustc's bitcode
-    // link go through the LTO-aware linker our final link uses, not BFD
-    // `/usr/bin/ld`.)
+    // also 0, so pass nothing. (`-Clink-arg=-fuse-ld=lld` is pushed above
+    // wherever `rustForcesFuseLdLld()` holds — including darwin, which only
+    // gets it under this cross-lang LTO mode — and under LTO it doubles as
+    // making rustc's bitcode link go through the LTO-aware linker our final
+    // link uses, not BFD `/usr/bin/ld`.)
     if (!cfg.darwin && !cfg.windows) {
       // Rust functions default to carrying the `uwtable(async)` attribute.
       // When the LTO inliner inlines such a callee into one of our C++
@@ -689,9 +719,10 @@ export function cargoBuildInvocation(cfg: Config): CargoInvocation {
     // (build scripts, proc-macros) — and on a native build, `--target` is the
     // host triple, so this env var sets *their* linker too.
     //
-    // Non-Windows: `cfg.cxx` (clang++) drives lld with the same flag dialect
-    // the C++ side uses. `-Clink-arg=-fuse-ld=lld` (pushed into rustflags
-    // below) selects lld for any rustc-driven cdylib link.
+    // Non-Windows: `cfg.cxx` (clang++) is the driver. Whether it drives lld
+    // depends on `rustForcesFuseLdLld(cfg)` above — true on linux/freebsd/
+    // android, and on darwin only under cross-lang LTO; otherwise the driver
+    // picks its default linker (ld64 on darwin).
     //
     // Windows: rustc's `*-msvc` linker flavor passes `link.exe`-style args
     // directly (`/NOLOGO`, `/OUT:`, `/NATVIS:`, `/PDBALTPATH:`, …). `clang-cl`

--- a/test/internal/macos-cross-config.test.ts
+++ b/test/internal/macos-cross-config.test.ts
@@ -9,15 +9,16 @@
  */
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isMacOS, tempDir } from "harness";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { generateCargoConfig } from "../../scripts/build/cargo-config.ts";
 import { resolveConfig, type Config, type PartialConfig, type Toolchain } from "../../scripts/build/config.ts";
 import { webkit } from "../../scripts/build/deps/webkit.ts";
 import { parsePackedFeaturesList } from "../../scripts/build/features-json.ts";
 import { computeFlags, DARWIN_STACK_SIZE } from "../../scripts/build/flags.ts";
 import { MACOS_SDK_VERSION, macosSdkCachePath, resolveMacosSdkPath } from "../../scripts/build/macos-sdk.ts";
-import { rustTarget } from "../../scripts/build/rust.ts";
+import { rustForcesFuseLdLld, rustTarget } from "../../scripts/build/rust.ts";
 import {
   elfDebugCompressPostlinkCommand,
   machoEntitlementsPlist,
@@ -360,5 +361,87 @@ describe("macOS SDK resolution", () => {
     } finally {
       if (previous !== undefined) process.env.MACOS_SDK_PATH = previous;
     }
+  });
+});
+
+// Regression tests for https://github.com/oven-sh/bun/issues/30870.
+//
+// Before the fix, both the generated `.cargo/config.toml` (read by plain
+// `cargo check` / rust-analyzer) and `CARGO_ENCODED_RUSTFLAGS` (the ninja
+// build) forced `-fuse-ld=lld` on every non-windows target, darwin included.
+// A Homebrew `clang++` with no `ld64.lld` it can find rejects that flag
+// ("invalid linker name in argument '-fuse-ld=lld'"), so `bun run rust:check`
+// broke on contributor macs. Native macOS links use Apple's ld — the flag is
+// now skipped on darwin unless cross-language LTO is on.
+describe("darwin rust linker: no forced -fuse-ld=lld (#30870)", () => {
+  /**
+   * Slice out one `[target.<triple>]` block from the generated TOML: from its
+   * header up to the next `[` section header or EOF. `.cargo/config.toml` is a
+   * flat list of sections, so substring scanning suffices — no TOML parse.
+   */
+  function targetSection(toml: string, triple: string): string {
+    const header = `[target.${triple}]`;
+    const start = toml.indexOf(header);
+    if (start === -1) throw new Error(`missing section: ${header}`);
+    const next = toml.indexOf("\n[", start + header.length);
+    return next === -1 ? toml.slice(start) : toml.slice(start, next);
+  }
+
+  test("rustForcesFuseLdLld: darwin skips lld unless cross-lang LTO", () => {
+    // Resolve real configs via the same path the build uses. On a non-darwin
+    // host these are cross-compile configs; on darwin they're native. Either
+    // way the `-fuse-ld=lld` decision is platform-derived, so the assertions
+    // hold on every host.
+    const darwin = resolveConfig({ os: "darwin", arch: "aarch64", buildType: "Release" }, mockToolchain());
+    expect(darwin.crossLangLto).toBe(false); // LTO is off by default for darwin
+    expect(rustForcesFuseLdLld(darwin)).toBe(false);
+
+    // Explicit --lto on darwin re-enables it (needs an lld-capable clang++,
+    // same requirement as linux LTO).
+    const darwinLto = resolveConfig(
+      { os: "darwin", arch: "aarch64", buildType: "Release", lto: true },
+      mockToolchain(),
+    );
+    expect(darwinLto.crossLangLto).toBe(true);
+    expect(rustForcesFuseLdLld(darwinLto)).toBe(true);
+
+    // Linux keeps forcing lld (the default `cc` driver would pick BFD ld).
+    const linux = resolveConfig(
+      { os: "linux", arch: "x64", abi: "gnu", buildType: "Release", linuxSysroot: "/fake" },
+      mockToolchain(),
+    );
+    expect(rustForcesFuseLdLld(linux)).toBe(true);
+  });
+
+  test("generated .cargo/config.toml: darwin sections are lld-free, linux keeps the flag", () => {
+    using dir = tempDir("cargo-config-darwin", {});
+    // generateCargoConfig writes to `cfg.cwd/.cargo/config.toml` — point cwd at
+    // a scratch dir so the repo's real file is untouched. The file contains a
+    // section for every triple in `allRustTargets`, so one run covers both
+    // apple-darwin triples plus the linux regression guard.
+    const cfg = {
+      ...resolveConfig(
+        { os: "linux", arch: "x64", abi: "gnu", buildType: "Release", linuxSysroot: "/fake" },
+        mockToolchain(),
+      ),
+      cwd: String(dir),
+    } as Config;
+    const outPath = generateCargoConfig(cfg);
+    expect(outPath).toBe(join(String(dir), ".cargo", "config.toml"));
+    const toml = readFileSync(outPath, "utf8");
+
+    for (const triple of ["x86_64-apple-darwin", "aarch64-apple-darwin"]) {
+      const section = targetSection(toml, triple);
+      // linker is still the discovered clang++ driver — only the flag is gone.
+      expect(section).toContain("linker = ");
+      expect(section).not.toContain("-fuse-ld=lld");
+      // The lint-quieting rustflags stay (matches rust.ts keeping them on darwin).
+      expect(section).toContain("-Qunused-arguments");
+      expect(section).toContain("linker_messages");
+    }
+
+    // Linux must still force lld.
+    const linux = targetSection(toml, "x86_64-unknown-linux-gnu");
+    expect(linux).toContain("link-arg=-fuse-ld=lld");
   });
 });


### PR DESCRIPTION
### Problem
- `bun run rust:check` on a Mac set up per the contributing docs (Homebrew LLVM) fails with `clang++: error: invalid linker name in argument '-fuse-ld=lld'` (#30870).
- `scripts/build/cargo-config.ts` writes `-fuse-ld=lld` into the `[target.*-apple-darwin]` rustflags of the generated `.cargo/config.toml`, which is what plain `cargo check` and rust-analyzer read. Without `--target`, cargo applies those rustflags to the build scripts and proc macros it links, so the bad flag reaches clang++.
- `scripts/build/rust.ts` pushes the same flag into `CARGO_ENCODED_RUSTFLAGS` for every non-windows target. That path is dead today (`bun_bin` is a staticlib, so rustc links nothing), which is why `bun bd` works on macOS; it is changed here so the two files agree.
- Native macOS links use Apple's ld (`flags.ts` passes `-Wl,-ld_new` on native links and `--ld-path=ld64.lld` only on the cross link from Linux added in #31303), so forcing lld on the Rust side does not match the C++ side either.

### Fix
- `rust.ts`: the decision moves into an exported `rustForcesFuseLdLld(cfg)`: windows never, darwin only under cross-language LTO, linux/freebsd/android always. `cargoBuildInvocation` has one guarded push.
- `cargo-config.ts`: the darwin sections drop `-fuse-ld=lld`; the `linker = <clang++>` line and the lint-quieting `-Qunused-arguments` / `-A linker_messages` flags stay.
- Darwin keeps the flag under cross-language LTO because that is the cross link from Linux, where the toolchain's ld64.lld is the linker the C++ link already uses; a native macOS build does not set it unless `--lto` is passed explicitly (`ltoDefault` excludes native darwin in `config.ts`), and even then the flag only lives in the env of the ninja build, never in `.cargo/config.toml`.
- Other targets are unchanged. Build scripts only, no `src/` change.
- Verified: `bun bd test test/internal/macos-cross-config.test.ts` (22 pass; the two new cases fail without the `scripts/build` change), and the regenerated `.cargo/config.toml` has lld-free darwin sections while linux keeps the flag. `bunx tsc -p scripts/build/tsconfig.json` reports the same pre-existing errors as main, none in the touched files.

### Background
- `.cargo/config.toml` is generated at configure time by `cargo-config.ts` (git-ignored). It only matters for `cargo` run directly and for rust-analyzer: the ninja build sets `CARGO_ENCODED_RUSTFLAGS` and `CARGO_TARGET_<triple>_LINKER` itself, and the env var replaces the config file's rustflags.
- `-fuse-ld=lld` asks the clang driver to run lld instead of its default linker. On macOS the driver looks for `ld64.lld`; if it cannot find one it rejects the flag with the error above instead of falling back.
- `crossLangLto` (`config.ts`) is the cross-language LTO switch; it tracks `lto`, which defaults on only for CI release builds of linux and the darwin/windows cross lanes.

Fixes #30870.

<details>
<summary>Earlier description and rebase notes</summary>

The original version of this PR described `bun bd` as also failing on macOS; the `rust.ts` flag is not reached in the ninja build (staticlib, no rustc link), so only the `.cargo/config.toml` path fails in practice. The branch has been rebased twice: once when `-Qunused-arguments` / `-A linker_messages` were added to both files on main (kept on darwin, only the linker flag is dropped), and once after #31303 (macOS cross-compiling) and #34782 removed `rustCanCrossFromLinux` and the `-Zsplit-lto-unit` block next to the hunks here; the doc comments were updated for the cross link and the new tests pass `linuxSysroot` like the neighbouring ones. #30871 (the reporter's fix, `rust.ts` only) was closed in favor of this PR.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 16 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/internal/macos-cross-config.test.ts

<!-- robobun:evidence:end -->