### PR TITLE
Add cargo-miri support and fix HiveArray aliasing UB

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "rust:check": "cargo check --workspace --keep-going",
     "rust:check-all": "bun scripts/rust-check-all.ts",
     "rust:clippy": "cargo clippy --workspace --keep-going",
+    "rust:miri": "bun scripts/rust-miri.ts",
     "codegen:string-maps": "for f in src/**/*.string-map.ts; do bun src/codegen/generate-string-map.ts \"$f\" \"${f%.string-map.ts}.generated.rs\"; done",
     "codegen:verify": "bun run codegen:string-maps && git diff --exit-code 'src/**/*.generated.rs' || (echo '\\n*.generated.rs is stale — run `bun run codegen:string-maps` and commit the result.' >&2; exit 1)",
     "clang-format": "./scripts/run-clang-format.sh format",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,8 @@
 [toolchain]
 channel = "nightly-2026-05-06"
 # rust-src is needed for -Zbuild-std (Tier 3 targets like
-# aarch64-unknown-freebsd have no prebuilt std). targets ensures the
+# aarch64-unknown-freebsd have no prebuilt std). miri is for
+# `bun run rust:miri`. targets ensures the
 # Tier 2 cross-targets' prebuilt std is installed for THIS toolchain
 # (bootstrap.sh / Dockerfile install only for the *default* toolchain at
 # image-build time, so a `channel` bump here would otherwise leave the
@@ -16,7 +17,7 @@ channel = "nightly-2026-05-06"
 # comes with the toolchain install regardless; they're listed here so a dev
 # running `bun run rust:check-all` or `cargo check --target` from any host
 # still gets prebuilt std for every Tier 1/2 triple.
-components = ["rust-src", "rustfmt"]
+components = ["rust-src", "rustfmt", "clippy", "miri"]
 targets = [
   "aarch64-unknown-linux-gnu",
   "x86_64-unknown-linux-gnu",

--- a/scripts/rust-miri.ts
+++ b/scripts/rust-miri.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env bun
+/**
+ * `cargo miri test` for the FFI-free crate set.
+ *
+ * Miri interprets MIR and catches UB (use-after-free, out-of-bounds,
+ * uninit reads, data races, aliasing violations) at runtime. It cannot call
+ * foreign functions, so this only covers the pure-Rust corner of the
+ * workspace — which is also where `unsafe` density is highest.
+ *
+ * Aliasing model: `-Zmiri-tree-borrows`, not the default Stacked Borrows.
+ * Stacked Borrows invalidates every raw pointer derived from `&mut self` the
+ * moment a later `&mut self` is formed — which is the entire premise of
+ * `HiveArray`, `MultiArrayList`, the slot pools, etc. (claim a stable
+ * `*mut T`, mutate the container, deref the pointer afterward). Tree Borrows
+ * is the candidate replacement spec, allows that pattern, and still catches
+ * the bugs we care about.
+ *
+ * Usage:
+ *   bun run rust:miri              # default safe crate set
+ *   bun run rust:miri -p bun_foo   # extra args go straight to cargo miri test
+ */
+
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+
+const repo = resolve(import.meta.dirname, "..");
+
+// Crates that pass `cargo miri test` under Tree Borrows. To add one it must
+// (a) have at least one `#[test]`, (b) compile under `--cfg test`, (c) not
+// call into `extern "C"` at test runtime — Miri reports
+// `unsupported operation: can't call foreign function` if it does.
+const MIRI_CRATES = [
+  "bun_ast",
+  "bun_base64",
+  "bun_clap",
+  "bun_collections",
+  "bun_dispatch",
+  "bun_errno",
+  "bun_hash",
+  "bun_http_types",
+  "bun_md",
+  "bun_paths",
+  "bun_ptr",
+  "bun_resolve_builtins",
+  "bun_shell_parser",
+  "bun_wyhash",
+];
+
+function run(cmd: string, args: string[], opts: Parameters<typeof spawnSync>[2] = {}) {
+  return spawnSync(cmd, args, { stdio: "inherit", cwd: repo, ...opts });
+}
+
+if (spawnSync("cargo", ["miri", "--version"], { encoding: "utf8" }).status !== 0) {
+  console.log("\x1b[36m[setup]\x1b[0m rustup component add miri");
+  if (run("rustup", ["component", "add", "miri"]).status !== 0) process.exit(1);
+}
+
+// `bun_core/build.rs` needs `build_options.rs`; cargo can't resolve the
+// workspace until `vendor/lolhtml/` (a path dep) exists. Both come from the
+// configure step, which is a no-op when already done.
+const buildOptionsRs = resolve(repo, "build/debug/codegen/build_options.rs");
+const lolhtmlCargo = resolve(repo, "vendor/lolhtml/c-api/Cargo.toml");
+if (!existsSync(buildOptionsRs) || !existsSync(lolhtmlCargo)) {
+  console.log("\x1b[36m[setup]\x1b[0m bun run build --configure-only");
+  if (run("bun", ["run", "build", "--configure-only"]).status !== 0) process.exit(1);
+  if (!existsSync(lolhtmlCargo) && run("ninja", ["-C", "build/debug", "clone-lolhtml"]).status !== 0) {
+    process.exit(1);
+  }
+}
+
+const extraArgs = process.argv.slice(2);
+const crateArgs = extraArgs.length > 0 ? extraArgs : MIRI_CRATES.flatMap(c => ["-p", c]);
+
+console.log(`\x1b[36m[miri]\x1b[0m cargo miri test ${crateArgs.join(" ")}`);
+const r = run("cargo", ["miri", "test", ...crateArgs], {
+  env: {
+    ...process.env,
+    MIRIFLAGS: ["-Zmiri-tree-borrows", process.env.MIRIFLAGS ?? ""].join(" ").trim(),
+  },
+});
+process.exit(r.status ?? 1);

--- a/scripts/rust-miri.ts
+++ b/scripts/rust-miri.ts
@@ -67,6 +67,18 @@ if (!existsSync(buildOptionsRs) || !existsSync(lolhtmlCargo)) {
   if (!existsSync(lolhtmlCargo) && run("ninja", ["-C", "build/debug", "clone-lolhtml"]).status !== 0) {
     process.exit(1);
   }
+  // Re-check: configure can succeed without producing these (e.g. partial
+  // checkout, ninja target rename) — fail fast instead of letting cargo
+  // produce a confusing workspace-resolution error.
+  for (const [path, hint] of [
+    [buildOptionsRs, "bun run build --configure-only"],
+    [lolhtmlCargo, "ninja -C build/debug clone-lolhtml"],
+  ] as const) {
+    if (!existsSync(path)) {
+      console.error(`\x1b[31m[error]\x1b[0m ${path} still missing after setup — try: ${hint}`);
+      process.exit(1);
+    }
+  }
 }
 
 const extraArgs = process.argv.slice(2);

--- a/scripts/rust-miri.ts
+++ b/scripts/rust-miri.ts
@@ -51,11 +51,6 @@ function run(cmd: string, args: string[], opts: Parameters<typeof spawnSync>[2] 
   return spawnSync(cmd, args, { stdio: "inherit", cwd: repo, ...opts });
 }
 
-if (spawnSync("cargo", ["miri", "--version"], { encoding: "utf8" }).status !== 0) {
-  console.log("\x1b[36m[setup]\x1b[0m rustup component add miri");
-  if (run("rustup", ["component", "add", "miri"]).status !== 0) process.exit(1);
-}
-
 // `bun_core/build.rs` needs `build_options.rs`; cargo can't resolve the
 // workspace until `vendor/lolhtml/` (a path dep) exists. Both come from the
 // configure step, which is a no-op when already done.

--- a/scripts/rust-miri.ts
+++ b/scripts/rust-miri.ts
@@ -32,6 +32,7 @@ const repo = resolve(import.meta.dirname, "..");
 // `unsupported operation: can't call foreign function` if it does.
 const MIRI_CRATES = [
   "bun_ast",
+  "bun_base64",
   "bun_clap",
   "bun_collections",
   "bun_dispatch",

--- a/scripts/rust-miri.ts
+++ b/scripts/rust-miri.ts
@@ -32,7 +32,6 @@ const repo = resolve(import.meta.dirname, "..");
 // `unsupported operation: can't call foreign function` if it does.
 const MIRI_CRATES = [
   "bun_ast",
-  "bun_base64",
   "bun_clap",
   "bun_collections",
   "bun_dispatch",

--- a/scripts/rust-miri.ts
+++ b/scripts/rust-miri.ts
@@ -20,8 +20,8 @@
  *   bun run rust:miri -p bun_foo   # extra args go straight to cargo miri test
  */
 
-import { existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 
 const repo = resolve(import.meta.dirname, "..");

--- a/src/ast/b.rs
+++ b/src/ast/b.rs
@@ -10,19 +10,23 @@ pub use crate::ArrayBinding;
 /// declarations (s_local), which is how destructuring assignments
 /// are represented in memory. Consider a basic example.
 ///
-///     let hello = world;
-///         ^       ^
-///         |       E.Identifier
-///         B.Identifier
+/// ```text
+/// let hello = world;
+///     ^       ^
+///     |       E.Identifier
+///     B.Identifier
+/// ```
 ///
 /// Bindings can be nested
 ///
-///                B.Array
-///                | B.Identifier
-///                | |
-///     let { foo: [ bar ] } = ...
-///         ----------------
-///         B.Object
+/// ```text
+///            B.Array
+///            | B.Identifier
+///            | |
+/// let { foo: [ bar ] } = ...
+///     ----------------
+///     B.Object
+/// ```
 // Zig: `union(Binding.Tag)` — tag enum lives on `Binding::Tag`.
 // PORT NOTE: arena values are referenced via `StoreRef<T>` (LIFETIMES.tsv: ARENA)
 // rather than a threaded `&'bump mut T`.

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -175,20 +175,21 @@ bitflags::bitflags! {
         /// because that syntax is invalid in strict mode. We also need to make sure
         /// we don't accidentally change the return value:
         ///
-        ///   Returns false:
-        ///     "var a; delete (a)"
-        ///     "var a = Object.freeze({b: 1}); delete (a.b)"
-        ///     "var a = Object.freeze({b: 1}); delete (a?.b)"
-        ///     "var a = Object.freeze({b: 1}); delete (a['b'])"
-        ///     "var a = Object.freeze({b: 1}); delete (a?.['b'])"
+        /// ```text
+        /// Returns false:
+        ///   "var a; delete (a)"
+        ///   "var a = Object.freeze({b: 1}); delete (a.b)"
+        ///   "var a = Object.freeze({b: 1}); delete (a?.b)"
+        ///   "var a = Object.freeze({b: 1}); delete (a['b'])"
+        ///   "var a = Object.freeze({b: 1}); delete (a?.['b'])"
         ///
-        ///   Returns true:
-        ///     "var a; delete (0, a)"
-        ///     "var a = Object.freeze({b: 1}); delete (true && a.b)"
-        ///     "var a = Object.freeze({b: 1}); delete (false || a?.b)"
-        ///     "var a = Object.freeze({b: 1}); delete (null ?? a?.['b'])"
-        ///
-        ///     "var a = Object.freeze({b: 1}); delete (true ? a['b'] : a['b'])"
+        /// Returns true:
+        ///   "var a; delete (0, a)"
+        ///   "var a = Object.freeze({b: 1}); delete (true && a.b)"
+        ///   "var a = Object.freeze({b: 1}); delete (false || a?.b)"
+        ///   "var a = Object.freeze({b: 1}); delete (null ?? a?.['b'])"
+        ///   "var a = Object.freeze({b: 1}); delete (true ? a['b'] : a['b'])"
+        /// ```
         const WAS_ORIGINALLY_DELETE_OF_IDENTIFIER_OR_PROPERTY_ACCESS = 1 << 1;
     }
 }

--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -809,15 +809,60 @@ pub mod zig_base64 {
             test_decode_ignore_space(codecs, b"foobar", b" Z m 9 v Y m F y ");
 
             // test getting some api errors
-            test_error(codecs, b"A", Error::InvalidPadding, Some(Error::InvalidPadding));
-            test_error(codecs, b"AA", Error::InvalidPadding, Some(Error::InvalidPadding));
-            test_error(codecs, b"AAA", Error::InvalidPadding, Some(Error::InvalidPadding));
-            test_error(codecs, b"A..A", Error::InvalidCharacter, Some(Error::InvalidCharacter));
-            test_error(codecs, b"AA=A", Error::InvalidPadding, Some(Error::InvalidPadding));
-            test_error(codecs, b"AA/=", Error::InvalidPadding, Some(Error::InvalidPadding));
-            test_error(codecs, b"A/==", Error::InvalidPadding, Some(Error::InvalidPadding));
-            test_error(codecs, b"A===", Error::InvalidPadding, Some(Error::InvalidPadding));
-            test_error(codecs, b"====", Error::InvalidPadding, Some(Error::InvalidPadding));
+            test_error(
+                codecs,
+                b"A",
+                Error::InvalidPadding,
+                Some(Error::InvalidPadding),
+            );
+            test_error(
+                codecs,
+                b"AA",
+                Error::InvalidPadding,
+                Some(Error::InvalidPadding),
+            );
+            test_error(
+                codecs,
+                b"AAA",
+                Error::InvalidPadding,
+                Some(Error::InvalidPadding),
+            );
+            test_error(
+                codecs,
+                b"A..A",
+                Error::InvalidCharacter,
+                Some(Error::InvalidCharacter),
+            );
+            test_error(
+                codecs,
+                b"AA=A",
+                Error::InvalidPadding,
+                Some(Error::InvalidPadding),
+            );
+            test_error(
+                codecs,
+                b"AA/=",
+                Error::InvalidPadding,
+                Some(Error::InvalidPadding),
+            );
+            test_error(
+                codecs,
+                b"A/==",
+                Error::InvalidPadding,
+                Some(Error::InvalidPadding),
+            );
+            test_error(
+                codecs,
+                b"A===",
+                Error::InvalidPadding,
+                Some(Error::InvalidPadding),
+            );
+            test_error(
+                codecs,
+                b"====",
+                Error::InvalidPadding,
+                Some(Error::InvalidPadding),
+            );
 
             test_no_space_left_error(codecs, b"AA==");
             test_no_space_left_error(codecs, b"AAA=");
@@ -859,14 +904,49 @@ pub mod zig_base64 {
             //     `b"AAA="`) decodes successfully.
             //
             // Inputs without `=` produce the same error for both.
-            test_error(codecs, b"A", Error::InvalidPadding, Some(Error::InvalidPadding));
+            test_error(
+                codecs,
+                b"A",
+                Error::InvalidPadding,
+                Some(Error::InvalidPadding),
+            );
             test_error(codecs, b"AAA=", Error::InvalidCharacter, None);
-            test_error(codecs, b"A..A", Error::InvalidCharacter, Some(Error::InvalidCharacter));
-            test_error(codecs, b"AA=A", Error::InvalidCharacter, Some(Error::InvalidPadding));
-            test_error(codecs, b"AA/=", Error::InvalidCharacter, Some(Error::InvalidCharacter));
-            test_error(codecs, b"A/==", Error::InvalidCharacter, Some(Error::InvalidCharacter));
-            test_error(codecs, b"A===", Error::InvalidCharacter, Some(Error::InvalidPadding));
-            test_error(codecs, b"====", Error::InvalidCharacter, Some(Error::InvalidPadding));
+            test_error(
+                codecs,
+                b"A..A",
+                Error::InvalidCharacter,
+                Some(Error::InvalidCharacter),
+            );
+            test_error(
+                codecs,
+                b"AA=A",
+                Error::InvalidCharacter,
+                Some(Error::InvalidPadding),
+            );
+            test_error(
+                codecs,
+                b"AA/=",
+                Error::InvalidCharacter,
+                Some(Error::InvalidCharacter),
+            );
+            test_error(
+                codecs,
+                b"A/==",
+                Error::InvalidCharacter,
+                Some(Error::InvalidCharacter),
+            );
+            test_error(
+                codecs,
+                b"A===",
+                Error::InvalidCharacter,
+                Some(Error::InvalidPadding),
+            );
+            test_error(
+                codecs,
+                b"====",
+                Error::InvalidCharacter,
+                Some(Error::InvalidPadding),
+            );
 
             test_no_space_left_error(codecs, b"AA");
             test_no_space_left_error(codecs, b"AAA");

--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -420,8 +420,10 @@ pub mod zig_base64 {
     pub const URL_SAFE_ALPHABET_CHARS: [u8; 64] =
         *b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
+    // `None` pad char matches upstream `std.base64.urlSafeBase64DecoderWithIgnore`
+    // (the vendored `base64.zig` predates that fix and still passes `'='`).
     pub const fn url_safe_base64_decoder_with_ignore(ignore: &[u8]) -> Base64DecoderWithIgnore {
-        Base64DecoderWithIgnore::init(URL_SAFE_ALPHABET_CHARS, Some(b'='), ignore)
+        Base64DecoderWithIgnore::init(URL_SAFE_ALPHABET_CHARS, None, ignore)
     }
 
     /// URL-safe Base64 codecs, with padding

--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -420,6 +420,9 @@ pub mod zig_base64 {
     pub const URL_SAFE_ALPHABET_CHARS: [u8; 64] =
         *b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
+    /// Shared by both [`URL_SAFE`] and [`URL_SAFE_NO_PAD`] (mirrors the `.zig`
+    /// sibling). It always builds a *padded* decoder, so for `URL_SAFE_NO_PAD`
+    /// it does NOT match the codec's `pad_char` — feed it padded input.
     pub const fn url_safe_base64_decoder_with_ignore(ignore: &[u8]) -> Base64DecoderWithIgnore {
         Base64DecoderWithIgnore::init(URL_SAFE_ALPHABET_CHARS, Some(b'='), ignore)
     }
@@ -433,7 +436,11 @@ pub mod zig_base64 {
         decoder: Base64Decoder::init(URL_SAFE_ALPHABET_CHARS, Some(b'=')),
     };
 
-    /// URL-safe Base64 codecs, without padding
+    /// URL-safe Base64 codecs, without padding.
+    ///
+    /// Note: `decoder_with_ignore` here is the *padded* decoder (see comment on
+    /// [`url_safe_base64_decoder_with_ignore`]) — it does not match this codec's
+    /// `pad_char`. Use `decoder` for unpadded input.
     pub static URL_SAFE_NO_PAD: Codecs = Codecs {
         alphabet_chars: URL_SAFE_ALPHABET_CHARS,
         pad_char: None,
@@ -783,13 +790,15 @@ pub mod zig_base64 {
         fn test_base64() {
             let codecs = &STANDARD;
 
-            test_all_apis(codecs, b"", b"");
-            test_all_apis(codecs, b"f", b"Zg==");
-            test_all_apis(codecs, b"fo", b"Zm8=");
-            test_all_apis(codecs, b"foo", b"Zm9v");
-            test_all_apis(codecs, b"foob", b"Zm9vYg==");
-            test_all_apis(codecs, b"fooba", b"Zm9vYmE=");
-            test_all_apis(codecs, b"foobar", b"Zm9vYmFy");
+            // STANDARD's `decoder_with_ignore` matches its `pad_char`, so
+            // both decoders take the same encoded form.
+            test_all_apis(codecs, b"", b"", b"");
+            test_all_apis(codecs, b"f", b"Zg==", b"Zg==");
+            test_all_apis(codecs, b"fo", b"Zm8=", b"Zm8=");
+            test_all_apis(codecs, b"foo", b"Zm9v", b"Zm9v");
+            test_all_apis(codecs, b"foob", b"Zm9vYg==", b"Zm9vYg==");
+            test_all_apis(codecs, b"fooba", b"Zm9vYmE=", b"Zm9vYmE=");
+            test_all_apis(codecs, b"foobar", b"Zm9vYmFy", b"Zm9vYmFy");
 
             test_decode_ignore_space(codecs, b"", b" ");
             test_decode_ignore_space(codecs, b"f", b"Z g= =");
@@ -800,15 +809,15 @@ pub mod zig_base64 {
             test_decode_ignore_space(codecs, b"foobar", b" Z m 9 v Y m F y ");
 
             // test getting some api errors
-            test_error(codecs, b"A", Error::InvalidPadding);
-            test_error(codecs, b"AA", Error::InvalidPadding);
-            test_error(codecs, b"AAA", Error::InvalidPadding);
-            test_error(codecs, b"A..A", Error::InvalidCharacter);
-            test_error(codecs, b"AA=A", Error::InvalidPadding);
-            test_error(codecs, b"AA/=", Error::InvalidPadding);
-            test_error(codecs, b"A/==", Error::InvalidPadding);
-            test_error(codecs, b"A===", Error::InvalidPadding);
-            test_error(codecs, b"====", Error::InvalidPadding);
+            test_error(codecs, b"A", Error::InvalidPadding, Some(Error::InvalidPadding));
+            test_error(codecs, b"AA", Error::InvalidPadding, Some(Error::InvalidPadding));
+            test_error(codecs, b"AAA", Error::InvalidPadding, Some(Error::InvalidPadding));
+            test_error(codecs, b"A..A", Error::InvalidCharacter, Some(Error::InvalidCharacter));
+            test_error(codecs, b"AA=A", Error::InvalidPadding, Some(Error::InvalidPadding));
+            test_error(codecs, b"AA/=", Error::InvalidPadding, Some(Error::InvalidPadding));
+            test_error(codecs, b"A/==", Error::InvalidPadding, Some(Error::InvalidPadding));
+            test_error(codecs, b"A===", Error::InvalidPadding, Some(Error::InvalidPadding));
+            test_error(codecs, b"====", Error::InvalidPadding, Some(Error::InvalidPadding));
 
             test_no_space_left_error(codecs, b"AA==");
             test_no_space_left_error(codecs, b"AAA=");
@@ -820,31 +829,44 @@ pub mod zig_base64 {
         fn test_base64_url_safe_no_pad() {
             let codecs = &URL_SAFE_NO_PAD;
 
-            test_all_apis(codecs, b"", b"");
-            test_all_apis(codecs, b"f", b"Zg");
-            test_all_apis(codecs, b"fo", b"Zm8");
-            test_all_apis(codecs, b"foo", b"Zm9v");
-            test_all_apis(codecs, b"foob", b"Zm9vYg");
-            test_all_apis(codecs, b"fooba", b"Zm9vYmE");
-            test_all_apis(codecs, b"foobar", b"Zm9vYmFy");
+            // `URL_SAFE_NO_PAD.decoder_with_ignore` is the *padded* decoder
+            // (the field is shared with `URL_SAFE` — see the comment on
+            // `url_safe_base64_decoder_with_ignore`), so the third parameter
+            // is what *that* decoder accepts, not what `encoder` produces.
+            test_all_apis(codecs, b"", b"", b"");
+            test_all_apis(codecs, b"f", b"Zg", b"Zg==");
+            test_all_apis(codecs, b"fo", b"Zm8", b"Zm8=");
+            test_all_apis(codecs, b"foo", b"Zm9v", b"Zm9v");
+            test_all_apis(codecs, b"foob", b"Zm9vYg", b"Zm9vYg==");
+            test_all_apis(codecs, b"fooba", b"Zm9vYmE", b"Zm9vYmE=");
+            test_all_apis(codecs, b"foobar", b"Zm9vYmFy", b"Zm9vYmFy");
 
             test_decode_ignore_space(codecs, b"", b" ");
-            test_decode_ignore_space(codecs, b"f", b"Z g ");
-            test_decode_ignore_space(codecs, b"fo", b"    Zm8");
+            test_decode_ignore_space(codecs, b"f", b"Z g= =");
+            test_decode_ignore_space(codecs, b"fo", b"    Zm8=");
             test_decode_ignore_space(codecs, b"foo", b"Zm9v    ");
-            test_decode_ignore_space(codecs, b"foob", b"Zm9vYg   ");
-            test_decode_ignore_space(codecs, b"fooba", b"Zm9v YmE");
+            test_decode_ignore_space(codecs, b"foob", b"Zm9vYg = = ");
+            test_decode_ignore_space(codecs, b"fooba", b"Zm9v YmE=");
             test_decode_ignore_space(codecs, b"foobar", b" Z m 9 v Y m F y ");
 
-            // test getting some api errors
-            test_error(codecs, b"A", Error::InvalidPadding);
-            test_error(codecs, b"AAA=", Error::InvalidCharacter);
-            test_error(codecs, b"A..A", Error::InvalidCharacter);
-            test_error(codecs, b"AA=A", Error::InvalidCharacter);
-            test_error(codecs, b"AA/=", Error::InvalidCharacter);
-            test_error(codecs, b"A/==", Error::InvalidCharacter);
-            test_error(codecs, b"A===", Error::InvalidCharacter);
-            test_error(codecs, b"====", Error::InvalidCharacter);
+            // `codecs.decoder` (pad_char: None) and the padded
+            // `decoder_with_ignore` classify `=`-containing inputs differently:
+            //
+            //   - `decoder` treats `=` as `InvalidCharacter` (not in the
+            //     unpadded alphabet at all).
+            //   - `decoder_with_ignore` treats `=` as padding; mismatched
+            //     padding is `InvalidPadding`, and well-formed padding (e.g.
+            //     `b"AAA="`) decodes successfully.
+            //
+            // Inputs without `=` produce the same error for both.
+            test_error(codecs, b"A", Error::InvalidPadding, Some(Error::InvalidPadding));
+            test_error(codecs, b"AAA=", Error::InvalidCharacter, None);
+            test_error(codecs, b"A..A", Error::InvalidCharacter, Some(Error::InvalidCharacter));
+            test_error(codecs, b"AA=A", Error::InvalidCharacter, Some(Error::InvalidPadding));
+            test_error(codecs, b"AA/=", Error::InvalidCharacter, Some(Error::InvalidCharacter));
+            test_error(codecs, b"A/==", Error::InvalidCharacter, Some(Error::InvalidCharacter));
+            test_error(codecs, b"A===", Error::InvalidCharacter, Some(Error::InvalidPadding));
+            test_error(codecs, b"====", Error::InvalidCharacter, Some(Error::InvalidPadding));
 
             test_no_space_left_error(codecs, b"AA");
             test_no_space_left_error(codecs, b"AAA");
@@ -852,7 +874,15 @@ pub mod zig_base64 {
             test_no_space_left_error(codecs, b"AAAAAA");
         }
 
-        fn test_all_apis(codecs: &Codecs, expected_decoded: &[u8], expected_encoded: &[u8]) {
+        /// `expected_with_ignore` is the input for `Base64DecoderWithIgnore`,
+        /// which may differ from `expected_encoded` when the codec's
+        /// `decoder_with_ignore` doesn't share its `pad_char` (URL-safe family).
+        fn test_all_apis(
+            codecs: &Codecs,
+            expected_decoded: &[u8],
+            expected_encoded: &[u8],
+            expected_with_ignore: &[u8],
+        ) {
             // Base64Encoder
             {
                 let mut buffer = [0u8; 0x100];
@@ -876,11 +906,12 @@ pub mod zig_base64 {
             {
                 let decoder_ignore_nothing = (codecs.decoder_with_ignore)(b"");
                 let mut buffer = [0u8; 0x100];
-                let upper = decoder_ignore_nothing.calc_size_upper_bound(expected_encoded.len());
+                let upper =
+                    decoder_ignore_nothing.calc_size_upper_bound(expected_with_ignore.len());
                 let decoded = &mut buffer[0..upper];
                 let mut written: usize = 0;
                 decoder_ignore_nothing
-                    .decode(decoded, expected_encoded, &mut written)
+                    .decode(decoded, expected_with_ignore, &mut written)
                     .unwrap();
                 assert!(written <= decoded.len());
                 assert_eq!(expected_decoded, &decoded[0..written]);
@@ -899,7 +930,16 @@ pub mod zig_base64 {
             assert_eq!(expected_decoded, &decoded[0..written]);
         }
 
-        fn test_error(codecs: &Codecs, encoded: &[u8], expected_err: Error) {
+        /// `expected_with_ignore` is the error `decoder_with_ignore` reports
+        /// for the same input, or `None` if it accepts the input. Differs from
+        /// `expected_err` when the codec's `decoder_with_ignore` doesn't share
+        /// its `pad_char` (URL-safe family).
+        fn test_error(
+            codecs: &Codecs,
+            encoded: &[u8],
+            expected_err: Error,
+            expected_with_ignore: Option<Error>,
+        ) {
             let decoder_ignore_space = (codecs.decoder_with_ignore)(b" ");
             let mut buffer = [0u8; 0x100];
             match codecs.decoder.calc_size_for_slice(encoded) {
@@ -914,9 +954,10 @@ pub mod zig_base64 {
             }
 
             let mut written: usize = 0;
-            match decoder_ignore_space.decode(&mut buffer[..], encoded, &mut written) {
-                Ok(_) => panic!("ExpectedError"),
-                Err(err) => assert_eq!(err, expected_err),
+            let result = decoder_ignore_space.decode(&mut buffer[..], encoded, &mut written);
+            match expected_with_ignore {
+                Some(expected) => assert_eq!(result.unwrap_err(), expected),
+                None => assert!(result.is_ok()),
             }
         }
 

--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -420,10 +420,8 @@ pub mod zig_base64 {
     pub const URL_SAFE_ALPHABET_CHARS: [u8; 64] =
         *b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
-    // `None` pad char matches upstream `std.base64.urlSafeBase64DecoderWithIgnore`
-    // (the vendored `base64.zig` predates that fix and still passes `'='`).
     pub const fn url_safe_base64_decoder_with_ignore(ignore: &[u8]) -> Base64DecoderWithIgnore {
-        Base64DecoderWithIgnore::init(URL_SAFE_ALPHABET_CHARS, None, ignore)
+        Base64DecoderWithIgnore::init(URL_SAFE_ALPHABET_CHARS, Some(b'='), ignore)
     }
 
     /// URL-safe Base64 codecs, with padding

--- a/src/clap/streaming.rs
+++ b/src/clap/streaming.rs
@@ -769,8 +769,9 @@ mod tests {
         ];
         test_err(&params, &[b"q"], b"Invalid argument 'q'\n");
         test_err(&params, &[b"-q"], b"Invalid argument '-q'\n");
-        test_err(&params, &[b"--q"], b"Invalid argument '--q'\n");
-        test_err(&params, &[b"--q=1"], b"Invalid argument '--q'\n");
+        // Unrecognized long flags are skipped (opt-in warning), not errors.
+        test_no_err(&params, &[b"--q"], &[]);
+        test_no_err(&params, &[b"--q=1"], &[]);
         test_err(
             &params,
             &[b"-a=1"],

--- a/src/collections/StaticHashMap.rs
+++ b/src/collections/StaticHashMap.rs
@@ -870,7 +870,9 @@ mod tests {
 
     #[test]
     fn hash_map_put_get_delete_grow() {
-        for seed in 0..128u64 {
+        // Miri is ~100× slower; 2 seeds still exercises grow (`shift` assert below).
+        const SEEDS: u64 = if cfg!(miri) { 2 } else { 128 };
+        for seed in 0..SEEDS {
             // TODO(port): replace with xoshiro256++ to match Zig DefaultPrng.
             let mut state = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1);
             let mut next = || {

--- a/src/collections/bit_set.rs
+++ b/src/collections/bit_set.rs
@@ -1885,42 +1885,8 @@ pub struct Range {
 
 // ───────────────────────────── Tests ─────────────────────────────
 
-// TODO(port): the Zig source defines test helper fns (`testEql`, `testBitSet`,
-// `testPureBitSet`, `testStaticBitSet`, ...) but no `test "..." {}` blocks
-// actually invoke them — dead code carried from the std fork. Ported as
-// `#[cfg(test)]` helpers; Phase B should add `#[test]` entry points or delete.
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // TODO(port): these helpers used `anytype` to accept Integer/Array/Dynamic
-    // bit sets uniformly. Rust would need a common trait. Stubbed pending
-    // Phase B trait extraction.
-
-    #[allow(dead_code)]
-    fn fill_even<const SIZE: usize, const M: usize>(set: &mut ArrayBitSet<SIZE, M>, len: usize)
-    where
-        [(); num_masks_for(SIZE)]:,
-    {
-        for i in 0..len {
-            set.set_value(i, i & 1 == 0);
-        }
-    }
-
-    #[allow(dead_code)]
-    fn fill_odd<const SIZE: usize, const M: usize>(set: &mut ArrayBitSet<SIZE, M>, len: usize)
-    where
-        [(); num_masks_for(SIZE)]:,
-    {
-        for i in 0..len {
-            set.set_value(i, i & 1 == 1);
-        }
-    }
-
-    // TODO(port): `testEql`, `testSubsetOf`, `testSupersetOf`, `testBitSet`,
-    // `testPureBitSet`, `testStaticBitSet` omitted — they rely on Zig
-    // `anytype` duck-typing across all bitset variants and `@hasField`
-    // reflection (`needs_ptr`). Re-author in Phase B against a `BitSet` trait.
-}
+// TODO(port): the Zig source's test helpers (`testEql`, `testBitSet`, …) are
+// dead code carried from the std fork — no `test` block invokes them. They
+// rely on `anytype` duck-typing; re-author against a trait when adding tests.
 
 // ported from: src/collections/bit_set.zig

--- a/src/collections/hive_array.rs
+++ b/src/collections/hive_array.rs
@@ -256,13 +256,17 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
     /// if `index` is out of bounds or the slot is free — a stale index is
     /// `None`, not UB.
     ///
-    /// `set()`/`unset()` are `pub(crate)` and `alloc()` writes before setting
-    /// the bit, so an occupied slot is always initialized. Calling `box_at`
-    /// twice for the same index without dropping the first box aliases the
-    /// slot — same footgun class as `mem::forget(MutexGuard)` deadlocks; the
-    /// runtime check catches stale/OOB indices, not double-recovery.
+    /// # Safety
+    /// The slot at `index`, if occupied, must hold a fully-initialized `T`,
+    /// and no other live access path ([`HiveSlot`], [`HiveBox`], `*mut T`) to
+    /// it may exist. The bitset check cannot prove this: [`claim`](Self::claim)
+    /// and the deprecated [`get`](Self::get) family set the `used` bit *before*
+    /// the slot is written, so safe code holding a claim token can have an
+    /// occupied-but-uninit slot. Pools that only use [`alloc`](Self::alloc)/
+    /// [`get_init`](Self::get_init) (which write before returning) trivially
+    /// satisfy this.
     #[inline]
-    pub fn box_at(&self, index: usize) -> Option<HiveBox<'_, T, CAPACITY>> {
+    pub unsafe fn box_at(&self, index: usize) -> Option<HiveBox<'_, T, CAPACITY>> {
         if index >= CAPACITY || !self.used.is_set(index) {
             return None;
         }
@@ -535,7 +539,7 @@ impl<'a, T, const CAPACITY: usize> HiveBox<'a, T, CAPACITY> {
     /// Slot index in the owning pool, for storage in an opaque callback context.
     #[inline]
     pub fn index(&self) -> usize {
-        // SAFETY: `slot` always points into `owner.buffer`.
+        // `slot` always points into `owner.buffer`, so `index_of` never fails.
         self.owner
             .index_of(self.slot.as_ptr())
             .expect("HiveBox slot in owner") as usize
@@ -1455,16 +1459,17 @@ mod tests {
         // Hand the boxes back without running Drop (the index is the token).
         core::mem::forget(b0);
         core::mem::forget(b1);
-        let v1 = pool.box_at(i1).unwrap().into_inner();
-        let v0 = pool.box_at(i0).unwrap().into_inner();
+        // SAFETY: `i0`/`i1` were alloc'd above; no other access path.
+        let v1 = unsafe { pool.box_at(i1) }.unwrap().into_inner();
+        let v0 = unsafe { pool.box_at(i0) }.unwrap().into_inner();
         assert_eq!(v0.v, 10);
         assert_eq!(v1.v, 20);
         assert!(!pool.used.is_set(i0));
         assert!(!pool.used.is_set(i1));
         // Stale index: bit was unset by `into_inner()`, second recovery is `None`.
-        assert!(pool.box_at(i0).is_none());
-        // OOB index: runtime check, not UB.
-        assert!(pool.box_at(999).is_none());
+        // SAFETY: stale/OOB indices are caught at runtime — `None`, not UB.
+        assert!(unsafe { pool.box_at(i0) }.is_none());
+        assert!(unsafe { pool.box_at(999) }.is_none());
     }
 }
 

--- a/src/collections/hive_array.rs
+++ b/src/collections/hive_array.rs
@@ -65,15 +65,19 @@ impl<const CAPACITY: usize> HiveBitSet<CAPACITY> {
         (self.masks[index / WORD_BITS].get() >> (index % WORD_BITS)) & 1 != 0
     }
 
+    /// `pub(crate)` — toggling occupancy from outside `HiveArray` while a
+    /// `HiveSlot` for the same index is alive would let a re-`claim()` alias
+    /// it. Use [`HiveArray::claim`]/[`put`](HiveArray::put)/[`take_at`](HiveArray::take_at).
     #[inline]
-    pub fn set(&self, index: usize) {
+    pub(crate) fn set(&self, index: usize) {
         debug_assert!(index < CAPACITY);
         let w = index / WORD_BITS;
         self.masks[w].set(self.masks[w].get() | (1usize << (index % WORD_BITS)));
     }
 
+    /// `pub(crate)` — see [`set`](Self::set).
     #[inline]
-    pub fn unset(&self, index: usize) {
+    pub(crate) fn unset(&self, index: usize) {
         debug_assert!(index < CAPACITY);
         let w = index / WORD_BITS;
         self.masks[w].set(self.masks[w].get() & !(1usize << (index % WORD_BITS)));
@@ -227,6 +231,22 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
                 .add(index)
                 .cast::<T>()
         }
+    }
+
+    /// Extract the value at `index` and free the slot. For pools that track
+    /// occupancy by index instead of pointer (Zig `cache[idx] = undefined`).
+    ///
+    /// # Safety
+    /// `index` must be occupied (`used` bit set) with a fully-initialized `T`,
+    /// and no other live access path (`HiveSlot`, `*mut T` from [`ptr_at`](Self::ptr_at))
+    /// to the same slot may exist.
+    #[inline]
+    pub unsafe fn take_at(&self, index: usize) -> T {
+        debug_assert!(self.used.is_set(index));
+        // SAFETY: caller contract — slot is occupied with an initialized `T`.
+        let value = unsafe { core::ptr::read(self.ptr_at(index)) };
+        self.used.unset(index);
+        value
     }
 
     /// Claim a slot and return a raw pointer to its **uninitialized** storage.

--- a/src/collections/hive_array.rs
+++ b/src/collections/hive_array.rs
@@ -66,8 +66,9 @@ impl<const CAPACITY: usize> HiveBitSet<CAPACITY> {
     }
 
     /// `pub(crate)` — toggling occupancy from outside `HiveArray` while a
-    /// `HiveSlot` for the same index is alive would let a re-`claim()` alias
-    /// it. Use [`HiveArray::claim`]/[`put`](HiveArray::put)/[`take_at`](HiveArray::take_at).
+    /// `HiveSlot`/`HiveBox` for the same index is alive would let a
+    /// re-`claim()` alias it. Use [`HiveArray::claim`]/[`alloc`](HiveArray::alloc)/
+    /// [`put`](HiveArray::put)/[`box_at`](HiveArray::box_at).
     #[inline]
     pub(crate) fn set(&self, index: usize) {
         debug_assert!(index < CAPACITY);
@@ -251,21 +252,25 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
     }
 
     /// Recover a [`HiveBox`] for a slot previously allocated via [`alloc`](Self::alloc)
-    /// whose [`index()`](HiveBox::index) was stored externally (e.g. in a callback
-    /// context). For pools that track occupancy by index instead of pointer.
+    /// whose [`index()`](HiveBox::index) was stored across a callback. `None`
+    /// if `index` is out of bounds or the slot is free — a stale index is
+    /// `None`, not UB.
     ///
-    /// # Safety
-    /// `index` must be occupied (`used` bit set) with a fully-initialized `T`,
-    /// and no other live access path ([`HiveSlot`], [`HiveBox`], `*mut T` from
-    /// [`ptr_at`](Self::ptr_at)) to the same slot may exist.
+    /// `set()`/`unset()` are `pub(crate)` and `alloc()` writes before setting
+    /// the bit, so an occupied slot is always initialized. Calling `box_at`
+    /// twice for the same index without dropping the first box aliases the
+    /// slot — same footgun class as `mem::forget(MutexGuard)` deadlocks; the
+    /// runtime check catches stale/OOB indices, not double-recovery.
     #[inline]
-    pub unsafe fn box_at(&self, index: usize) -> HiveBox<'_, T, CAPACITY> {
-        debug_assert!(self.used.is_set(index));
-        HiveBox {
-            // SAFETY: `ptr_at` asserts `index < CAPACITY` and never returns null.
+    pub fn box_at(&self, index: usize) -> Option<HiveBox<'_, T, CAPACITY>> {
+        if index >= CAPACITY || !self.used.is_set(index) {
+            return None;
+        }
+        Some(HiveBox {
+            // SAFETY: `index < CAPACITY` (checked above); `ptr_at` is in-bounds.
             slot: unsafe { NonNull::new_unchecked(self.ptr_at(index)) },
             owner: self,
-        }
+        })
     }
 
     /// Claim a slot and return a raw pointer to its **uninitialized** storage.
@@ -1450,13 +1455,16 @@ mod tests {
         // Hand the boxes back without running Drop (the index is the token).
         core::mem::forget(b0);
         core::mem::forget(b1);
-        // SAFETY: slots `i0`/`i1` were just alloc'd, no other access path exists.
-        let v1 = unsafe { pool.box_at(i1) }.into_inner();
-        let v0 = unsafe { pool.box_at(i0) }.into_inner();
+        let v1 = pool.box_at(i1).unwrap().into_inner();
+        let v0 = pool.box_at(i0).unwrap().into_inner();
         assert_eq!(v0.v, 10);
         assert_eq!(v1.v, 20);
         assert!(!pool.used.is_set(i0));
         assert!(!pool.used.is_set(i1));
+        // Stale index: bit was unset by `into_inner()`, second recovery is `None`.
+        assert!(pool.box_at(i0).is_none());
+        // OOB index: runtime check, not UB.
+        assert!(pool.box_at(999).is_none());
     }
 }
 

--- a/src/collections/hive_array.rs
+++ b/src/collections/hive_array.rs
@@ -1117,7 +1117,15 @@ mod tests {
 
         // Inline allocation: ref to 2, unref to 1, unref to 0 → returned.
         // SAFETY: `pool` outlives every HiveRef created from `pool_ptr`.
-        let r = unsafe { HiveRef::init(Tracked { v: 1, drops: &drops }, pool_ptr) };
+        let r = unsafe {
+            HiveRef::init(
+                Tracked {
+                    v: 1,
+                    drops: &drops,
+                },
+                pool_ptr,
+            )
+        };
         // SAFETY: `r` is live (ref_count == 1) until the final unref returns None.
         unsafe {
             assert_eq!((*r).ref_count.get(), 1);
@@ -1131,9 +1139,33 @@ mod tests {
 
         // Heap allocation: fill the hive first, then init another.
         // SAFETY: same pool contract.
-        let inline0 = unsafe { HiveRef::init(Tracked { v: 2, drops: &drops }, pool_ptr) };
-        let inline1 = unsafe { HiveRef::init(Tracked { v: 3, drops: &drops }, pool_ptr) };
-        let heap = unsafe { HiveRef::init(Tracked { v: 4, drops: &drops }, pool_ptr) };
+        let inline0 = unsafe {
+            HiveRef::init(
+                Tracked {
+                    v: 2,
+                    drops: &drops,
+                },
+                pool_ptr,
+            )
+        };
+        let inline1 = unsafe {
+            HiveRef::init(
+                Tracked {
+                    v: 3,
+                    drops: &drops,
+                },
+                pool_ptr,
+            )
+        };
+        let heap = unsafe {
+            HiveRef::init(
+                Tracked {
+                    v: 4,
+                    drops: &drops,
+                },
+                pool_ptr,
+            )
+        };
         assert!(pool.r#in(inline0));
         assert!(pool.r#in(inline1));
         assert!(!pool.r#in(heap));
@@ -1157,7 +1189,15 @@ mod tests {
 
         // Drop releases the slot when the count hits zero.
         // SAFETY: `pool` outlives every handle.
-        let mut h = unsafe { HiveRefHandle::new(Tracked { v: 1, drops: &drops }, pool_ptr) };
+        let mut h = unsafe {
+            HiveRefHandle::new(
+                Tracked {
+                    v: 1,
+                    drops: &drops,
+                },
+                pool_ptr,
+            )
+        };
         assert_eq!(h.v, 1);
         h.v = 11;
         assert_eq!(h.v, 11);
@@ -1170,7 +1210,15 @@ mod tests {
 
         // into_raw / from_raw round-trip preserves the count.
         // SAFETY: `pool` outlives every handle.
-        let h = unsafe { HiveRefHandle::new(Tracked { v: 2, drops: &drops }, pool_ptr) };
+        let h = unsafe {
+            HiveRefHandle::new(
+                Tracked {
+                    v: 2,
+                    drops: &drops,
+                },
+                pool_ptr,
+            )
+        };
         let raw = h.into_raw();
         assert_eq!(drops.get(), 1);
         // SAFETY: `raw` carries a +1 from `into_raw`.
@@ -1180,8 +1228,24 @@ mod tests {
 
         // Heap fallback path (CAP=1, second handle spills).
         // SAFETY: `pool` outlives every handle.
-        let inline = unsafe { HiveRefHandle::new(Tracked { v: 3, drops: &drops }, pool_ptr) };
-        let heap = unsafe { HiveRefHandle::new(Tracked { v: 4, drops: &drops }, pool_ptr) };
+        let inline = unsafe {
+            HiveRefHandle::new(
+                Tracked {
+                    v: 3,
+                    drops: &drops,
+                },
+                pool_ptr,
+            )
+        };
+        let heap = unsafe {
+            HiveRefHandle::new(
+                Tracked {
+                    v: 4,
+                    drops: &drops,
+                },
+                pool_ptr,
+            )
+        };
         assert!(pool.r#in(inline.as_ptr()));
         assert!(!pool.r#in(heap.as_ptr()));
         drop(heap);

--- a/src/collections/hive_array.rs
+++ b/src/collections/hive_array.rs
@@ -1,7 +1,7 @@
 use core::cell::{Cell, UnsafeCell};
 use core::marker::PhantomData;
 use core::mem::{ManuallyDrop, MaybeUninit, size_of};
-use core::ops::{Deref, DerefMut};
+use core::ops::Deref;
 use core::ptr::NonNull;
 
 use bun_core::asan;
@@ -705,19 +705,18 @@ impl<T, const CAPACITY: usize> HiveRef<T, CAPACITY> {
     /// `this` must point at a live `HiveRef` produced by [`init`](Self::init).
     /// On `None` the slot has been recycled — do not use `this` afterward.
     pub unsafe fn unref(this: *mut Self) -> Option<*mut Self> {
-        // SAFETY: caller contract — `this` is a live HiveRef slot.
-        let ref_count = unsafe { (*this).ref_count.get() };
-        unsafe { (*this).ref_count.set(ref_count - 1) };
-        if ref_count == 1 {
-            // SAFETY: `pool` outlives every slot it hands out (init contract).
-            // Zig's `if @hasDecl(T, "deinit") this.value.deinit()` maps to
-            // `T::drop`, which `Fallback::put` runs (drops the whole `HiveRef`
-            // in place before recycling/freeing the slot).
-            unsafe {
+        // SAFETY: caller contract — `this` is a live `HiveRef` slot, and
+        // `(*this).pool` outlives every slot it hands out (`init` contract).
+        // Zig's `if @hasDecl(T, "deinit") this.value.deinit()` maps to `T::drop`,
+        // which `Fallback::put` runs (drops the whole `HiveRef` in place).
+        unsafe {
+            let ref_count = (*this).ref_count.get();
+            (*this).ref_count.set(ref_count - 1);
+            if ref_count == 1 {
                 let pool = (*this).pool;
                 (*pool).put(this);
+                return None;
             }
-            return None;
         }
         Some(this)
     }
@@ -731,6 +730,15 @@ pub struct HiveRefHandle<T, const CAP: usize> {
 }
 
 impl<T, const CAP: usize> HiveRefHandle<T, CAP> {
+    /// The one place the type-level invariant is asserted: a handle exists
+    /// ⇒ `ref_count >= 1` ⇒ the slot is live and initialized. `Deref`/`Clone`
+    /// route through here so they're plain safe code.
+    #[inline]
+    fn slot(&self) -> &HiveRef<T, CAP> {
+        // SAFETY: type invariant (above).
+        unsafe { self.ptr.as_ref() }
+    }
+
     /// Allocate a slot from `pool` with refcount 1.
     ///
     /// # Safety
@@ -739,8 +747,7 @@ impl<T, const CAP: usize> HiveRefHandle<T, CAP> {
         // SAFETY: caller contract — `pool` is dereferenceable + outlives the slot.
         let ptr = unsafe { HiveRef::init(value, pool) };
         Self {
-            // SAFETY: `Fallback::get_init` never returns null.
-            ptr: unsafe { NonNull::new_unchecked(ptr) },
+            ptr: NonNull::new(ptr).expect("Fallback::get_init returned null"),
         }
     }
 
@@ -756,9 +763,8 @@ impl<T, const CAP: usize> HiveRefHandle<T, CAP> {
     /// `ptr` must be a live slot whose `+1` has not already been released.
     #[inline]
     pub unsafe fn from_raw(ptr: *mut HiveRef<T, CAP>) -> Self {
-        // SAFETY: caller contract — `ptr` is non-null and live.
         Self {
-            ptr: unsafe { NonNull::new_unchecked(ptr) },
+            ptr: NonNull::new(ptr).expect("HiveRefHandle::from_raw(null)"),
         }
     }
 
@@ -767,30 +773,34 @@ impl<T, const CAP: usize> HiveRefHandle<T, CAP> {
     pub fn as_ptr(&self) -> *mut HiveRef<T, CAP> {
         self.ptr.as_ptr()
     }
+
+    /// Exclusive access to the payload. `None` if there are other live handles
+    /// — same shape as [`Rc::get_mut`](std::rc::Rc::get_mut). A blanket
+    /// `DerefMut` would be unsound: `Clone` takes `&self`, so a second handle
+    /// could be made while a `&mut T` from `deref_mut()` is outstanding.
+    #[inline]
+    pub fn get_mut(&mut self) -> Option<&mut T> {
+        if self.slot().ref_count.get() != 1 {
+            return None;
+        }
+        // SAFETY: refcount == 1 ⇒ this handle is the only owner; `&mut self`
+        // proves no other access path through it.
+        Some(unsafe { &mut (*self.ptr.as_ptr()).value })
+    }
 }
 
 impl<T, const CAP: usize> Deref for HiveRefHandle<T, CAP> {
     type Target = T;
     #[inline]
     fn deref(&self) -> &T {
-        // SAFETY: a handle exists ⇒ refcount >= 1 ⇒ slot is live and initialized.
-        unsafe { &(*self.ptr.as_ptr()).value }
-    }
-}
-
-impl<T, const CAP: usize> DerefMut for HiveRefHandle<T, CAP> {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut T {
-        // SAFETY: a handle exists ⇒ refcount >= 1 ⇒ slot is live and initialized.
-        unsafe { &mut (*self.ptr.as_ptr()).value }
+        &self.slot().value
     }
 }
 
 impl<T, const CAP: usize> Clone for HiveRefHandle<T, CAP> {
     #[inline]
     fn clone(&self) -> Self {
-        // SAFETY: a handle exists ⇒ slot is live.
-        unsafe { (*self.ptr.as_ptr()).ref_() };
+        self.slot().ref_();
         Self { ptr: self.ptr }
     }
 }
@@ -798,7 +808,7 @@ impl<T, const CAP: usize> Clone for HiveRefHandle<T, CAP> {
 impl<T, const CAP: usize> Drop for HiveRefHandle<T, CAP> {
     #[inline]
     fn drop(&mut self) {
-        // SAFETY: a handle exists ⇒ slot is live; `unref` recycles on count==0.
+        // SAFETY: type invariant — `ptr` is live; `unref` recycles on count==0.
         unsafe { HiveRef::unref(self.ptr.as_ptr()) };
     }
 }
@@ -1199,10 +1209,13 @@ mod tests {
             )
         };
         assert_eq!(h.v, 1);
-        h.v = 11;
+        // Sole owner: `get_mut` succeeds.
+        h.get_mut().unwrap().v = 11;
         assert_eq!(h.v, 11);
         let h2 = h.clone();
         assert_eq!(h2.v, 11);
+        // Shared: `get_mut` is `None` while another handle is live.
+        assert!(h.get_mut().is_none());
         drop(h);
         assert_eq!(drops.get(), 0);
         drop(h2);

--- a/src/collections/hive_array.rs
+++ b/src/collections/hive_array.rs
@@ -334,12 +334,17 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
         })
     }
 
-    /// Recycle a slot **without** running `T::drop`. Safe: if `value` does not
-    /// point into this hive, returns `false` and is a no-op. Use when the
-    /// caller has already moved the contents out / destructured them, or when
-    /// `T` is POD and the slot is being released on an error path before it
-    /// was fully initialized (Zig `value.* = undefined`).
-    pub fn put_raw(&self, value: *mut T) -> bool {
+    /// Recycle a slot **without** running `T::drop`. If `value` does not point
+    /// into this hive, returns `false` and is a no-op. Use when the caller has
+    /// already moved the contents out / destructured them, or when `T` is POD
+    /// and the slot is being released on an error path before it was fully
+    /// initialized (Zig `value.* = undefined`).
+    ///
+    /// # Safety
+    /// No live token ([`HiveSlot`], [`HiveBox`]) may exist for this slot — once
+    /// the `used` bit is cleared, [`alloc`](Self::alloc)/[`claim`](Self::claim)
+    /// can hand it out again, aliasing the stale token's `DerefMut`/`Drop`.
+    pub unsafe fn put_raw(&self, value: *mut T) -> bool {
         let Some(index) = self.index_of(value) else {
             return false;
         };
@@ -551,8 +556,8 @@ impl<'a, T, const CAPACITY: usize> HiveBox<'a, T, CAPACITY> {
         let this = ManuallyDrop::new(self);
         // SAFETY: `slot` is a fully-initialized `T` exclusively owned by this box.
         let value = unsafe { core::ptr::read(this.slot.as_ptr()) };
-        // Free the slot WITHOUT running `T::drop` — ownership just moved out.
-        this.owner.put_raw(this.slot.as_ptr());
+        // SAFETY: `this` is being consumed — no other token for this slot exists.
+        unsafe { this.owner.put_raw(this.slot.as_ptr()) };
         value
     }
 }
@@ -715,7 +720,8 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
     /// be POD.
     pub unsafe fn put_raw(&self, value: *mut T) {
         if CAPACITY > 0 {
-            if self.hive.put_raw(value) {
+            // SAFETY: caller contract (this fn is `unsafe`).
+            if unsafe { self.hive.put_raw(value) } {
                 return;
             }
         }
@@ -1013,7 +1019,8 @@ mod tests {
 
         // put_raw() does not drop.
         let p = a.get_init(mk(8)).unwrap();
-        assert!(a.put_raw(p.as_ptr()));
+        // SAFETY: `p` is the only token for its slot.
+        assert!(unsafe { a.put_raw(p.as_ptr()) });
         assert_eq!(drops.get(), 1);
 
         // Fallback heap path: dropped token deallocates without Drop.
@@ -1045,7 +1052,8 @@ mod tests {
             assert_eq!((*p.as_ptr()).me, p.as_ptr().cast_const());
             assert_eq!((*p.as_ptr()).tag, 1);
         }
-        assert!(a.put_raw(p.as_ptr()));
+        // SAFETY: `p` is the only token for its slot.
+        assert!(unsafe { a.put_raw(p.as_ptr()) });
 
         // Same on Fallback's heap path.
         let f = Fallback::<SelfAddr, 0>::init();
@@ -1057,6 +1065,7 @@ mod tests {
         unsafe {
             assert_eq!((*p.as_ptr()).me, p.as_ptr().cast_const());
             assert_eq!((*p.as_ptr()).tag, 2);
+            // SAFETY: `p` is the only token for its slot.
             f.put_raw(p.as_ptr());
         }
     }
@@ -1077,14 +1086,16 @@ mod tests {
         unsafe {
             assert_eq!(*p.as_ptr(), [10, 20]);
         }
-        assert!(a.put_raw(p.as_ptr()));
+        // SAFETY: `p` is the only token for its slot.
+        assert!(unsafe { a.put_raw(p.as_ptr()) });
 
         // write() returns the same address as addr().
         let slot = a.claim().unwrap();
         let pre = slot.addr().as_ptr();
         let p = slot.write([30, 40]);
         assert_eq!(pre, p.as_ptr());
-        assert!(a.put_raw(p.as_ptr()));
+        // SAFETY: `p` is the only token for its slot.
+        assert!(unsafe { a.put_raw(p.as_ptr()) });
     }
 
     #[test]
@@ -1101,8 +1112,10 @@ mod tests {
             assert_eq!(*a.at(0), 100);
             assert_eq!(*a.at(1), 200);
         }
-        assert!(a.put_raw(p0.as_ptr()));
-        assert!(a.put_raw(p1.as_ptr()));
+        // SAFETY: only token for its slot.
+        assert!(unsafe { a.put_raw(p0.as_ptr()) });
+        // SAFETY: only token for its slot.
+        assert!(unsafe { a.put_raw(p1.as_ptr()) });
     }
 
     #[test]
@@ -1393,8 +1406,10 @@ mod tests {
         let _s1 = a.get_init(1).unwrap();
         let s2 = a.get_init(2).unwrap();
         let _s3 = a.get_init(3).unwrap();
-        assert!(a.put_raw(s0.as_ptr()));
-        assert!(a.put_raw(s2.as_ptr()));
+        // SAFETY: only token for its slot.
+        assert!(unsafe { a.put_raw(s0.as_ptr()) });
+        // SAFETY: only token for its slot.
+        assert!(unsafe { a.put_raw(s2.as_ptr()) });
 
         assert_eq!(a.used.find_first_set(), Some(1));
         assert_eq!(a.used.find_first_unset(), Some(0));
@@ -1421,7 +1436,8 @@ mod tests {
             assert_eq!(a.used.find_first_set(), None);
             let p = a.get_init(7).unwrap();
             assert_eq!(*p.as_ptr(), 7);
-            assert!(a.put_raw(p.as_ptr()));
+            // SAFETY: `p` is the only token for its slot.
+            assert!(unsafe { a.put_raw(p.as_ptr()) });
         }
     }
 

--- a/src/collections/hive_array.rs
+++ b/src/collections/hive_array.rs
@@ -216,8 +216,10 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
     /// the slot to be claimed and initialized.
     #[inline]
     pub fn ptr_at(&self, index: usize) -> *mut T {
-        debug_assert!(index < CAPACITY);
-        // SAFETY: `index < CAPACITY`; in-bounds offset within the same allocation.
+        // `assert!`, not `debug_assert!` — `ptr.add()` past the end is UB, not
+        // a panic, in release builds. Keep this a safe `pub fn`.
+        assert!(index < CAPACITY);
+        // SAFETY: `index < CAPACITY` (asserted above); in-bounds offset.
         unsafe {
             self.buffer
                 .get()
@@ -406,13 +408,17 @@ impl<'h, T, const CAPACITY: usize> HiveSlot<'h, T, CAPACITY> {
     }
 
     /// `&mut MaybeUninit<T>` for piecewise init via `addr_of_mut!`. Prefer
-    /// [`write`](Self::write); this exists for `repr(C)` placement-new
-    /// (`create_in`-style constructors that take `&mut MaybeUninit<Self>`).
+    /// [`write`](Self::write).
+    ///
+    /// # Safety
+    /// No other live access path to this slot may exist. With `&self` pool
+    /// receivers, `HiveSlot` no longer holds an exclusive borrow of the hive,
+    /// so the borrowck cannot prove uniqueness — the caller must (e.g. don't
+    /// `unset()` the slot's `used` bit and re-`claim()` it while this token is
+    /// alive).
     #[inline]
-    pub fn as_uninit(&mut self) -> &mut MaybeUninit<T> {
-        // SAFETY: `slot` is a unique live pointer into the hive buffer (or a
-        // freshly leaked `Box<MaybeUninit<T>>`); the `&mut self` receiver
-        // guarantees no other borrow of the same `MaybeUninit<T>` exists.
+    pub unsafe fn as_uninit(&mut self) -> &mut MaybeUninit<T> {
+        // SAFETY: caller contract (above).
         unsafe { self.slot.as_mut() }
     }
 
@@ -953,7 +959,8 @@ mod tests {
         // addr() is stable and matches the post-write pointer.
         let mut slot = a.claim().unwrap();
         let pre = slot.addr().as_ptr();
-        slot.as_uninit().write([10, 20]);
+        // SAFETY: `slot` is the only token for this slot.
+        unsafe { slot.as_uninit() }.write([10, 20]);
         // SAFETY: as_uninit().write() fully initialized the slot.
         let p = unsafe { slot.assume_init() };
         assert_eq!(pre, p.as_ptr());

--- a/src/collections/hive_array.rs
+++ b/src/collections/hive_array.rs
@@ -233,20 +233,39 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
         }
     }
 
-    /// Extract the value at `index` and free the slot. For pools that track
-    /// occupancy by index instead of pointer (Zig `cache[idx] = undefined`).
+    /// Allocate a slot as a single-owner [`HiveBox`]. `None` if the inline
+    /// hive is full.
+    #[inline]
+    pub fn alloc(&self, value: T) -> Option<HiveBox<'_, T, CAPACITY>> {
+        let index = self.used.find_first_unset()?;
+        self.used.set(index);
+        let p = self.ptr_at(index);
+        asan::unpoison(p.cast(), size_of::<T>());
+        // SAFETY: `index` was just claimed; the slot is in-bounds and unaliased.
+        unsafe { p.write(value) };
+        Some(HiveBox {
+            // SAFETY: `ptr_at` never returns null (in-bounds offset into `buffer`).
+            slot: unsafe { NonNull::new_unchecked(p) },
+            owner: self,
+        })
+    }
+
+    /// Recover a [`HiveBox`] for a slot previously allocated via [`alloc`](Self::alloc)
+    /// whose [`index()`](HiveBox::index) was stored externally (e.g. in a callback
+    /// context). For pools that track occupancy by index instead of pointer.
     ///
     /// # Safety
     /// `index` must be occupied (`used` bit set) with a fully-initialized `T`,
-    /// and no other live access path (`HiveSlot`, `*mut T` from [`ptr_at`](Self::ptr_at))
-    /// to the same slot may exist.
+    /// and no other live access path ([`HiveSlot`], [`HiveBox`], `*mut T` from
+    /// [`ptr_at`](Self::ptr_at)) to the same slot may exist.
     #[inline]
-    pub unsafe fn take_at(&self, index: usize) -> T {
+    pub unsafe fn box_at(&self, index: usize) -> HiveBox<'_, T, CAPACITY> {
         debug_assert!(self.used.is_set(index));
-        // SAFETY: caller contract — slot is occupied with an initialized `T`.
-        let value = unsafe { core::ptr::read(self.ptr_at(index)) };
-        self.used.unset(index);
-        value
+        HiveBox {
+            // SAFETY: `ptr_at` asserts `index < CAPACITY` and never returns null.
+            slot: unsafe { NonNull::new_unchecked(self.ptr_at(index)) },
+            owner: self,
+        }
     }
 
     /// Claim a slot and return a raw pointer to its **uninitialized** storage.
@@ -492,6 +511,67 @@ impl<T, const CAPACITY: usize> Drop for HiveSlot<'_, T, CAPACITY> {
             // in `Fallback::claim` and has not been freed.
             drop(unsafe { Box::from_raw(self.slot.as_ptr()) });
         }
+    }
+}
+
+/// Single-owner handle to an initialized [`HiveArray`] slot. `Box<T>`-shaped:
+/// `Drop` returns the slot to the pool, [`into_inner`](Self::into_inner)
+/// extracts the value. Single-owner (no `Clone`), so [`DerefMut`] is sound.
+///
+/// For pools whose tokens cross an opaque round-trip as a slot *index* (e.g.
+/// the c-ares callback context in `dns_jsc`), store [`index()`](Self::index)
+/// and recover via [`HiveArray::box_at`].
+pub struct HiveBox<'a, T, const CAPACITY: usize> {
+    slot: NonNull<T>,
+    owner: &'a HiveArray<T, CAPACITY>,
+}
+
+impl<'a, T, const CAPACITY: usize> HiveBox<'a, T, CAPACITY> {
+    /// Slot index in the owning pool, for storage in an opaque callback context.
+    #[inline]
+    pub fn index(&self) -> usize {
+        // SAFETY: `slot` always points into `owner.buffer`.
+        self.owner
+            .index_of(self.slot.as_ptr())
+            .expect("HiveBox slot in owner") as usize
+    }
+
+    /// Extract the value, freeing the slot. Inverse of [`HiveArray::alloc`].
+    #[inline]
+    pub fn into_inner(self) -> T {
+        let this = ManuallyDrop::new(self);
+        // SAFETY: `slot` is a fully-initialized `T` exclusively owned by this box.
+        let value = unsafe { core::ptr::read(this.slot.as_ptr()) };
+        // Free the slot WITHOUT running `T::drop` — ownership just moved out.
+        this.owner.put_raw(this.slot.as_ptr());
+        value
+    }
+}
+
+impl<T, const CAPACITY: usize> Deref for HiveBox<'_, T, CAPACITY> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        // SAFETY: `slot` is a fully-initialized, exclusively-owned `T`.
+        unsafe { self.slot.as_ref() }
+    }
+}
+
+impl<T, const CAPACITY: usize> core::ops::DerefMut for HiveBox<'_, T, CAPACITY> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut T {
+        // SAFETY: `slot` is a fully-initialized, exclusively-owned `T`; no
+        // `Clone` impl, so this is the only `&mut` access path.
+        unsafe { self.slot.as_mut() }
+    }
+}
+
+impl<T, const CAPACITY: usize> Drop for HiveBox<'_, T, CAPACITY> {
+    #[inline]
+    fn drop(&mut self) {
+        // SAFETY: `slot` is a fully-initialized `T` owned by this box; `put`
+        // drops it in place and frees the slot.
+        unsafe { self.owner.put(self.slot.as_ptr()) };
     }
 }
 
@@ -1334,6 +1414,49 @@ mod tests {
             assert_eq!(*p.as_ptr(), 7);
             assert!(a.put_raw(p.as_ptr()));
         }
+    }
+
+    #[test]
+    fn hive_box_lifecycle() {
+        let drops = core::cell::Cell::new(0u32);
+        let mk = |v| Tracked { v, drops: &drops };
+
+        let pool = HiveArray::<Tracked, 4>::init();
+
+        // alloc → Deref/DerefMut → Drop returns the slot, drops T.
+        {
+            let mut b = pool.alloc(mk(1)).unwrap();
+            assert_eq!(b.v, 1);
+            b.v = 11;
+            assert_eq!(b.v, 11);
+        }
+        assert_eq!(drops.get(), 1);
+        assert!(!pool.used.is_set(0));
+
+        // alloc → into_inner extracts T without running its Drop.
+        let b = pool.alloc(mk(2)).unwrap();
+        let i = b.index();
+        let val = b.into_inner();
+        assert_eq!(val.v, 2);
+        assert_eq!(drops.get(), 1);
+        assert!(!pool.used.is_set(i));
+        drop(val);
+        assert_eq!(drops.get(), 2);
+
+        // alloc → store index → recover via box_at — the dns.rs pattern.
+        let b0 = pool.alloc(mk(10)).unwrap();
+        let b1 = pool.alloc(mk(20)).unwrap();
+        let (i0, i1) = (b0.index(), b1.index());
+        // Hand the boxes back without running Drop (the index is the token).
+        core::mem::forget(b0);
+        core::mem::forget(b1);
+        // SAFETY: slots `i0`/`i1` were just alloc'd, no other access path exists.
+        let v1 = unsafe { pool.box_at(i1) }.into_inner();
+        let v0 = unsafe { pool.box_at(i0) }.into_inner();
+        assert_eq!(v0.v, 10);
+        assert_eq!(v1.v, 20);
+        assert!(!pool.used.is_set(i0));
+        assert!(!pool.used.is_set(i1));
     }
 }
 

--- a/src/collections/hive_array.rs
+++ b/src/collections/hive_array.rs
@@ -1,5 +1,7 @@
+use core::cell::{Cell, UnsafeCell};
 use core::marker::PhantomData;
 use core::mem::{ManuallyDrop, MaybeUninit, size_of};
+use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
 
 use bun_core::asan;
@@ -17,14 +19,14 @@ use bun_core::asan;
 ///
 /// We can't spell `[usize; (CAPACITY+63)/64]` without `generic_const_exprs`
 /// (which would virally add `where` bounds on every `HiveArray` consumer), so
-/// this uses a fixed `[usize; 32]` backing array — 2048 bits, which is the
-/// largest in-tree `HiveArray` capacity. Only the first
-/// `ceil(CAPACITY/64)` words are touched, so smaller pools pay 256 B of dead
-/// storage (negligible next to `buffer: [MaybeUninit<T>; CAPACITY]`).
+/// this uses a fixed `[Cell<usize>; 32]` backing array — 2048 bits, which is the
+/// largest in-tree `HiveArray` capacity. Only the first `ceil(CAPACITY/64)`
+/// words are touched, so smaller pools pay 256 B of dead storage (negligible
+/// next to `buffer`). The words are `Cell` so the bitset can be mutated through
+/// a `&self` pool, matching `HiveArray`'s interior-mutability model.
 #[repr(C)]
-#[derive(Clone, Copy)]
 pub struct HiveBitSet<const CAPACITY: usize> {
-    masks: [usize; HIVE_BITSET_WORDS],
+    masks: [Cell<usize>; HIVE_BITSET_WORDS],
 }
 
 const HIVE_BITSET_WORDS: usize = 32;
@@ -53,33 +55,35 @@ impl<const CAPACITY: usize> HiveBitSet<CAPACITY> {
 
     pub const fn init_empty() -> Self {
         Self {
-            masks: [0; HIVE_BITSET_WORDS],
+            masks: [const { Cell::new(0) }; HIVE_BITSET_WORDS],
         }
     }
 
     #[inline]
     pub fn is_set(&self, index: usize) -> bool {
         debug_assert!(index < CAPACITY);
-        (self.masks[index / WORD_BITS] >> (index % WORD_BITS)) & 1 != 0
+        (self.masks[index / WORD_BITS].get() >> (index % WORD_BITS)) & 1 != 0
     }
 
     #[inline]
-    pub fn set(&mut self, index: usize) {
+    pub fn set(&self, index: usize) {
         debug_assert!(index < CAPACITY);
-        self.masks[index / WORD_BITS] |= 1usize << (index % WORD_BITS);
+        let w = index / WORD_BITS;
+        self.masks[w].set(self.masks[w].get() | (1usize << (index % WORD_BITS)));
     }
 
     #[inline]
-    pub fn unset(&mut self, index: usize) {
+    pub fn unset(&self, index: usize) {
         debug_assert!(index < CAPACITY);
-        self.masks[index / WORD_BITS] &= !(1usize << (index % WORD_BITS));
+        let w = index / WORD_BITS;
+        self.masks[w].set(self.masks[w].get() & !(1usize << (index % WORD_BITS)));
     }
 
     #[inline]
     pub fn find_first_set(&self) -> Option<usize> {
         let mut i = 0;
         while i < Self::NUM_WORDS {
-            let m = self.masks[i];
+            let m = self.masks[i].get();
             if m != 0 {
                 return Some(i * WORD_BITS + m.trailing_zeros() as usize);
             }
@@ -97,7 +101,7 @@ impl<const CAPACITY: usize> HiveBitSet<CAPACITY> {
             } else {
                 usize::MAX
             };
-            let inv = !self.masks[i] & live_mask;
+            let inv = !self.masks[i].get() & live_mask;
             if inv != 0 {
                 return Some(i * WORD_BITS + inv.trailing_zeros() as usize);
             }
@@ -124,8 +128,10 @@ impl<const CAPACITY: usize> HiveBitSet<CAPACITY> {
                 "HiveBitSet::iterator only supports <true,true>"
             )
         };
+        // Snapshot the live words into a non-`Cell` array so the iterator can
+        // outlive transient mutations of the source bitset.
         HiveBitSetIter {
-            masks: self.masks,
+            masks: self.masks.each_ref().map(Cell::get),
             word: 0,
         }
     }
@@ -156,10 +162,14 @@ impl<const CAPACITY: usize> HiveBitSetIter<CAPACITY> {
 /// An array that efficiently tracks which elements are in use.
 /// The pointers are intended to be stable
 /// Sorta related to https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0447r15.html
+///
+/// All slot operations take `&self` and the buffer is `UnsafeCell` — slot
+/// pointers come from `UnsafeCell::get()` and so survive `&self` reborrows of
+/// the pool (the `bumpalo` / `typed-arena` shape). `HiveArray` is `!Sync`.
 // PORT NOTE: Zig's `capacity: u16` is widened to `usize` here because Rust array
 // lengths require a `usize` const generic on stable.
 pub struct HiveArray<T, const CAPACITY: usize> {
-    pub buffer: [MaybeUninit<T>; CAPACITY],
+    buffer: UnsafeCell<[MaybeUninit<T>; CAPACITY]>,
     pub used: HiveBitSet<CAPACITY>,
 }
 
@@ -172,7 +182,7 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
 
     pub const fn init() -> Self {
         Self {
-            buffer: [const { MaybeUninit::uninit() }; CAPACITY],
+            buffer: UnsafeCell::new([const { MaybeUninit::uninit() }; CAPACITY]),
             used: HiveBitSet::init_empty(),
         }
     }
@@ -193,13 +203,28 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
     /// `size_of::<Self>()` bytes. The previous contents are not dropped.
     #[inline]
     pub unsafe fn init_in_place(out: *mut Self) {
-        // SAFETY: caller contract — `out` is aligned and writable. We form a
-        // place expression on `*out` only to project to `used`; no `&mut Self`
-        // is created over the (uninitialized) whole struct.
+        // SAFETY: caller contract — `out` is aligned and writable; only the
+        // `used` field is projected and written.
         unsafe {
             core::ptr::addr_of_mut!((*out).used).write(HiveBitSet::init_empty());
         }
-        // `buffer: [MaybeUninit<T>; CAPACITY]` intentionally untouched.
+        // `buffer: UnsafeCell<[MaybeUninit<T>; CAPACITY]>` intentionally untouched.
+    }
+
+    /// Raw pointer to slot `index`. Carries the buffer's `UnsafeCell` tag so
+    /// it survives later `&self` reborrows. Safe to obtain; deref requires
+    /// the slot to be claimed and initialized.
+    #[inline]
+    pub fn ptr_at(&self, index: usize) -> *mut T {
+        debug_assert!(index < CAPACITY);
+        // SAFETY: `index < CAPACITY`; in-bounds offset within the same allocation.
+        unsafe {
+            self.buffer
+                .get()
+                .cast::<MaybeUninit<T>>()
+                .add(index)
+                .cast::<T>()
+        }
     }
 
     /// Claim a slot and return a raw pointer to its **uninitialized** storage.
@@ -212,12 +237,10 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
     /// and the caller's `ptr::write` leaves the slot claimed-but-uninit so a
     /// later [`put`](Self::put) drops garbage.
     #[deprecated = "returns *mut T to uninitialized memory; use get_init / emplace / claim"]
-    pub fn get(&mut self) -> Option<*mut T> {
-        let Some(index) = self.used.find_first_unset() else {
-            return None;
-        };
+    pub fn get(&self) -> Option<*mut T> {
+        let index = self.used.find_first_unset()?;
         self.used.set(index);
-        let ret = self.buffer[index].as_mut_ptr();
+        let ret = self.ptr_at(index);
         asan::unpoison(ret.cast(), size_of::<T>());
         Some(ret)
     }
@@ -227,7 +250,7 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
     /// Returns `None` (and does **not** consume `value`'s slot) if the hive
     /// is full; on `None` the caller still owns `value` and must drop it.
     #[inline]
-    pub fn get_init(&mut self, value: T) -> Option<NonNull<T>> {
+    pub fn get_init(&self, value: T) -> Option<NonNull<T>> {
         Some(self.claim()?.write(value))
     }
 
@@ -236,7 +259,7 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
     /// inside its own constructor). `init` receives the slot's stable address
     /// and must return the value to be stored there.
     #[inline]
-    pub fn emplace(&mut self, init: impl FnOnce(NonNull<T>) -> T) -> Option<NonNull<T>> {
+    pub fn emplace(&self, init: impl FnOnce(NonNull<T>) -> T) -> Option<NonNull<T>> {
         let slot = self.claim()?;
         let addr = slot.addr();
         Some(slot.write(init(addr)))
@@ -246,28 +269,17 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
     /// [`emplace`](Self::emplace) are insufficient — typically when the caller
     /// must interleave fallible work between claim and commit, or perform
     /// `repr(C)` placement-new via [`HiveSlot::as_uninit`].
-    ///
-    /// The returned token borrows `self` for `'_`; precompute any raw
-    /// back-pointers to the parent struct *before* calling `claim()` if they
-    /// are needed inside the initializer.
-    pub fn claim(&mut self) -> Option<HiveSlot<'_, T, CAPACITY>> {
+    pub fn claim(&self) -> Option<HiveSlot<'_, T, CAPACITY>> {
         let index = self.used.find_first_unset()?;
         self.used.set(index);
-        let slot = NonNull::from(&mut self.buffer[index]);
+        // SAFETY: `index < CAPACITY` ⇒ in-bounds; `UnsafeCell::get` is non-null.
+        let slot = unsafe {
+            NonNull::new_unchecked(self.buffer.get().cast::<MaybeUninit<T>>().add(index))
+        };
         asan::unpoison(slot.as_ptr().cast(), size_of::<T>());
-        let owner = core::ptr::from_mut(self) as usize;
-        // Tagged-pointer scheme requires the low bit clear for inline slots.
-        // `HiveArray` is at least pointer-aligned via `IntegerBitSet`'s
-        // backing word, and in practice `align_of::<T>() >= 2` for every `T`
-        // we pool; assert in debug so a future 1-byte `T` is caught.
-        debug_assert_eq!(
-            owner & 1,
-            0,
-            "HiveArray must be >=2-byte aligned for HiveSlot owner tag"
-        );
         Some(HiveSlot {
             slot,
-            owner,
+            owner: core::ptr::from_ref(self),
             _marker: PhantomData,
         })
     }
@@ -277,7 +289,7 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
     /// caller has already moved the contents out / destructured them, or when
     /// `T` is POD and the slot is being released on an error path before it
     /// was fully initialized (Zig `value.* = undefined`).
-    pub fn put_raw(&mut self, value: *mut T) -> bool {
+    pub fn put_raw(&self, value: *mut T) -> bool {
         let Some(index) = self.index_of(value) else {
             return false;
         };
@@ -287,16 +299,16 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
         true
     }
 
-    pub fn at(&mut self, index: u16) -> *mut T {
+    pub fn at(&self, index: u16) -> *mut T {
         debug_assert!((index as usize) < CAPACITY);
-        let ret = self.buffer[index as usize].as_mut_ptr();
+        let ret = self.ptr_at(index as usize);
         asan::assert_unpoisoned(ret.cast::<u8>());
         ret
     }
 
     pub fn index_of(&self, value: *const T) -> Option<u32> {
         asan::assert_unpoisoned(value.cast::<u8>());
-        let start = self.buffer.as_ptr().cast::<T>();
+        let start = self.buffer.get().cast::<T>();
         // One-past-the-end pointer of `buffer`; `wrapping_add` is sound for
         // the in-allocation offset and matches `add` exactly here.
         let end = start.wrapping_add(CAPACITY);
@@ -307,13 +319,13 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
         // aligned to the size of T
         let index = ((value as usize) - (start as usize)) / size_of::<T>();
         debug_assert!(index < CAPACITY);
-        debug_assert!(self.buffer[index].as_ptr().cast::<T>() == value);
+        debug_assert!(self.ptr_at(index).cast_const() == value);
         Some(u32::try_from(index).expect("int cast"))
     }
 
     pub fn r#in(&self, value: *const T) -> bool {
         asan::assert_unpoisoned(value.cast::<u8>());
-        let start = self.buffer.as_ptr().cast::<T>();
+        let start = self.buffer.get().cast::<T>();
         let end = start.wrapping_add(CAPACITY);
         (value as usize) >= (start as usize) && (value as usize) < (end as usize)
     }
@@ -328,13 +340,13 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
     /// `T` previously obtained via [`get`](Self::get) and written by the
     /// caller. The slot is dropped in place; passing a moved-from or
     /// uninitialized slot is UB for `T` with drop glue.
-    pub unsafe fn put(&mut self, value: *mut T) -> bool {
+    pub unsafe fn put(&self, value: *mut T) -> bool {
         let Some(index) = self.index_of(value) else {
             return false;
         };
 
         debug_assert!(self.used.is_set(index as usize));
-        debug_assert!(self.buffer[index as usize].as_ptr().cast::<T>() == value.cast_const());
+        debug_assert!(self.ptr_at(index as usize).cast_const() == value.cast_const());
 
         // PORT NOTE: Zig wrote `value.* = undefined;` — Zig has no destructors,
         // so the slot was simply marked logically uninitialized. In the Rust
@@ -372,22 +384,16 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
 /// dropped (early return, `?`, panic) the slot is released **without** running
 /// `T::drop` — it was never written.
 ///
-/// Two-pointer-sized; `owner` is a tagged `usize`:
-///   - low bit `0` ⇒ `*mut HiveArray<T, CAP>` (release = unset `used` bit + poison),
-///   - low bit `1` ⇒ heap `Box<MaybeUninit<T>>` (release = dealloc, no `T::drop`).
-///
-/// **Aliasing note** (matches the `BackRef<T>` precedent in `bun_ptr`): the
-/// token stores a raw `*mut HiveArray` rather than `&'h mut HiveArray`. The
-/// `PhantomData<&'h mut _>` keeps it lifetime-scoped to the `claim()` borrow,
-/// but the structural guarantee — the hive is a field of a long-lived owner
-/// that is not moved between `claim()` and `write()` — is the caller's, same
-/// as every back-pointer in the port.
+/// Two-pointer-sized; `owner` discriminates release behavior:
+///   - non-null ⇒ `*const HiveArray<T, CAP>` (release = unset `used` bit + poison),
+///   - null     ⇒ heap `Box<MaybeUninit<T>>` (release = dealloc, no `T::drop`).
 #[must_use = "claimed hive slot is leaked if neither written nor dropped"]
 pub struct HiveSlot<'h, T, const CAPACITY: usize> {
     slot: NonNull<MaybeUninit<T>>,
-    /// Tagged owner; see type-level docs.
-    owner: usize,
-    _marker: PhantomData<&'h mut HiveArray<T, CAPACITY>>,
+    /// Typed `*const` (not `usize` + low-bit tag) so provenance survives `Drop`.
+    /// Null = heap-fallback sentinel (`from_ref(self)` is never null).
+    owner: *const HiveArray<T, CAPACITY>,
+    _marker: PhantomData<&'h HiveArray<T, CAPACITY>>,
 }
 
 impl<'h, T, const CAPACITY: usize> HiveSlot<'h, T, CAPACITY> {
@@ -406,7 +412,7 @@ impl<'h, T, const CAPACITY: usize> HiveSlot<'h, T, CAPACITY> {
     pub fn as_uninit(&mut self) -> &mut MaybeUninit<T> {
         // SAFETY: `slot` is a unique live pointer into the hive buffer (or a
         // freshly leaked `Box<MaybeUninit<T>>`); the `&mut self` receiver
-        // guarantees no other `&mut` to the same `MaybeUninit<T>` exists.
+        // guarantees no other borrow of the same `MaybeUninit<T>` exists.
         unsafe { self.slot.as_mut() }
     }
 
@@ -414,8 +420,13 @@ impl<'h, T, const CAPACITY: usize> HiveSlot<'h, T, CAPACITY> {
     /// Consumes the token (its `Drop` does not run).
     #[inline]
     pub fn write(self, value: T) -> NonNull<T> {
-        let mut this = ManuallyDrop::new(self);
-        NonNull::from(this.as_uninit().write(value))
+        let this = ManuallyDrop::new(self);
+        let p = this.slot.cast::<T>();
+        // SAFETY: `slot` is a unique claimed reservation; nothing reads through
+        // it before this write. Writing through the raw ptr (not `&mut`) keeps
+        // the `UnsafeCell` tag alive for callers holding sibling slot pointers.
+        unsafe { p.as_ptr().write(value) };
+        p
     }
 
     /// Caller has fully initialized the slot via [`as_uninit`](Self::as_uninit)
@@ -434,15 +445,12 @@ impl<'h, T, const CAPACITY: usize> HiveSlot<'h, T, CAPACITY> {
 
 impl<T, const CAPACITY: usize> Drop for HiveSlot<'_, T, CAPACITY> {
     fn drop(&mut self) {
-        if self.owner & 1 == 0 {
+        if !self.owner.is_null() {
             // Inline hive slot: unset the `used` bit and re-poison. Do NOT
             // `drop_in_place` — the slot was never `.write()`n.
-            let hive = self.owner as *mut HiveArray<T, CAPACITY>;
-            // SAFETY: `owner` was set from `core::ptr::from_mut(self)` in
-            // `HiveArray::claim`; the hive is a field of a long-lived owner
-            // that has not been moved (structural back-pointer guarantee).
-            // No `&mut HiveArray` is live across this drop — `claim()`'s
-            // borrow was released when the raw pointer was captured.
+            let hive = self.owner;
+            // SAFETY: `owner` was set from `from_ref(self)` in `HiveArray::claim`
+            // and the hive outlives `'h` (PhantomData lifetime).
             unsafe {
                 let index = (*hive)
                     .index_of(self.slot.as_ptr().cast::<T>())
@@ -523,14 +531,14 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
     /// See [`HiveArray::get`] — same UB hazards, plus the heap path leaks a
     /// `Box<MaybeUninit<T>>` if the caller early-returns before `ptr::write`.
     #[deprecated = "returns *mut T to uninitialized memory; use get_init / emplace / claim"]
-    pub fn get(&mut self) -> *mut T {
+    pub fn get(&self) -> *mut T {
         // Forget the token so its `Drop` does not release the slot — legacy
         // callers expect the slot to remain claimed until their later `put()`.
         ManuallyDrop::new(self.claim()).addr().as_ptr()
     }
 
     #[deprecated = "returns *mut T to uninitialized memory; use get_init / emplace / claim"]
-    pub fn get_and_see_if_new(&mut self, new: &mut bool) -> *mut T {
+    pub fn get_and_see_if_new(&self, new: &mut bool) -> *mut T {
         if CAPACITY > 0 {
             #[allow(deprecated)]
             if let Some(value) = self.hive.get() {
@@ -543,20 +551,20 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
     }
 
     #[deprecated = "returns *mut T to uninitialized memory; use get_init / emplace / claim"]
-    pub fn try_get(&mut self) -> *mut T {
+    pub fn try_get(&self) -> *mut T {
         ManuallyDrop::new(self.claim()).addr().as_ptr()
     }
 
     /// One-shot claim + write. Preferred entry point — no uninit window.
     /// Infallible: spills to a heap `Box<T>` when the inline hive is full.
     #[inline]
-    pub fn get_init(&mut self, value: T) -> NonNull<T> {
+    pub fn get_init(&self, value: T) -> NonNull<T> {
         self.claim().write(value)
     }
 
     /// See [`HiveArray::emplace`]. Infallible (heap fallback).
     #[inline]
-    pub fn emplace(&mut self, init: impl FnOnce(NonNull<T>) -> T) -> NonNull<T> {
+    pub fn emplace(&self, init: impl FnOnce(NonNull<T>) -> T) -> NonNull<T> {
         let slot = self.claim();
         let addr = slot.addr();
         slot.write(init(addr))
@@ -565,7 +573,7 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
     /// See [`HiveArray::claim`]. Infallible: when the inline hive is full,
     /// the returned token owns a freshly-allocated heap slot (tagged so its
     /// `Drop` deallocates without running `T::drop`).
-    pub fn claim(&mut self) -> HiveSlot<'_, T, CAPACITY> {
+    pub fn claim(&self) -> HiveSlot<'_, T, CAPACITY> {
         if CAPACITY > 0 {
             if let Some(slot) = self.hive.claim() {
                 return slot;
@@ -574,9 +582,9 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
         let slot = NonNull::from(Box::leak(Box::<T>::new_uninit()));
         HiveSlot {
             slot,
-            // Low bit 1 ⇒ heap slot. The hive pointer is not needed on the
-            // release path (dealloc is `Box::from_raw(slot)`).
-            owner: 1,
+            // Null ⇒ heap slot. The hive pointer is not needed on the release
+            // path (dealloc is `Box::from_raw(slot)`).
+            owner: core::ptr::null(),
             _marker: PhantomData,
         }
     }
@@ -590,7 +598,7 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
     /// yet returned. The contained `T` is **not** dropped — caller must have
     /// already moved out / destructured anything with drop glue, or `T` must
     /// be POD.
-    pub unsafe fn put_raw(&mut self, value: *mut T) {
+    pub unsafe fn put_raw(&self, value: *mut T) {
         if CAPACITY > 0 {
             if self.hive.put_raw(value) {
                 return;
@@ -620,7 +628,7 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
     /// [`get`](Self::get) / [`get_and_see_if_new`](Self::get_and_see_if_new) /
     /// [`try_get`](Self::try_get) on this `Fallback` and subsequently written
     /// by the caller.
-    pub unsafe fn put(&mut self, value: *mut T) {
+    pub unsafe fn put(&self, value: *mut T) {
         if CAPACITY > 0 {
             // SAFETY: caller contract — `value` is fully initialized.
             if unsafe { self.hive.put(value) } {
@@ -628,10 +636,9 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
             }
         }
 
-        // SAFETY: `value` was produced by `heap::into_raw(Box::<T>::new_uninit())`
-        // in `get_impl`/`get_and_see_if_new`/`try_get` above (it is not in the
-        // hive), and the caller has since fully initialized it. `destroy`
-        // reconstructs the `Box<T>` and runs `T::drop`.
+        // SAFETY: `value` was produced by the heap-fallback path of `claim()` /
+        // `get()` (it is not in the hive), and the caller has since fully
+        // initialized it. `destroy` reconstructs the `Box<T>` and runs `T::drop`.
         unsafe { bun_core::heap::destroy(value) };
     }
 }
@@ -652,10 +659,13 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
 /// Intrusive ref-counted slot allocated from a `HiveArray::Fallback` pool.
 /// `pool` is a BACKREF (LIFETIMES.tsv class) — the pool strictly outlives
 /// every `HiveRef` it hands out, so a raw pointer is the honest mapping.
+///
+/// Prefer [`HiveRefHandle`] in new code; the raw `init`/`ref_`/`unref` family
+/// remains for FFI ingress points that hold the slot as a `*mut HiveRef`.
 #[repr(C)]
 pub struct HiveRef<T, const CAPACITY: usize> {
-    pub ref_count: u32,
-    pub pool: *mut Fallback<HiveRef<T, CAPACITY>, CAPACITY>,
+    pub ref_count: Cell<u32>,
+    pub pool: *const Fallback<HiveRef<T, CAPACITY>, CAPACITY>,
     pub value: T,
 }
 
@@ -669,12 +679,12 @@ impl<T, const CAPACITY: usize> HiveRef<T, CAPACITY> {
     /// `pool` must be valid for the entire lifetime of the returned
     /// `HiveRef` (i.e. until its `ref_count` drops to zero and it is `put`
     /// back). Callers hold the pool in a long-lived owner (e.g. `VirtualMachine`).
-    pub unsafe fn init(value: T, pool: *mut Fallback<Self, CAPACITY>) -> *mut Self {
+    pub unsafe fn init(value: T, pool: *const Fallback<Self, CAPACITY>) -> *mut Self {
         // SAFETY: caller contract — `pool` is dereferenceable.
         unsafe {
             (*pool)
                 .get_init(HiveRef {
-                    ref_count: 1,
+                    ref_count: Cell::new(1),
                     pool,
                     value,
                 })
@@ -682,29 +692,114 @@ impl<T, const CAPACITY: usize> HiveRef<T, CAPACITY> {
         }
     }
 
-    pub fn ref_(&mut self) -> &mut Self {
-        self.ref_count += 1;
+    #[inline]
+    pub fn ref_(&self) -> &Self {
+        self.ref_count.set(self.ref_count.get() + 1);
         self
     }
 
-    /// Zig: `pub fn unref(this) ?*@This()` — returns `null` when the count hit
+    /// Zig: `pub fn unref(this) ?*@This()` — returns `None` when the count hit
     /// zero and the slot was returned to the pool.
-    pub fn unref(&mut self) -> Option<&mut Self> {
-        let ref_count = self.ref_count;
-        self.ref_count = ref_count - 1;
+    ///
+    /// # Safety
+    /// `this` must point at a live `HiveRef` produced by [`init`](Self::init).
+    /// On `None` the slot has been recycled — do not use `this` afterward.
+    pub unsafe fn unref(this: *mut Self) -> Option<*mut Self> {
+        // SAFETY: caller contract — `this` is a live HiveRef slot.
+        let ref_count = unsafe { (*this).ref_count.get() };
+        unsafe { (*this).ref_count.set(ref_count - 1) };
         if ref_count == 1 {
-            let pool = self.pool;
-            // SAFETY: `self` was produced by `init` above, so `pool` is the
-            // pool that owns this slot and is still live (caller contract on
-            // `init`). Zig's `if @hasDecl(T, "deinit") this.value.deinit()` maps
-            // to `T::drop`, which `Fallback::put` now runs (it drops the whole
-            // `HiveRef` in place before recycling/freeing the slot).
+            // SAFETY: `pool` outlives every slot it hands out (init contract).
+            // Zig's `if @hasDecl(T, "deinit") this.value.deinit()` maps to
+            // `T::drop`, which `Fallback::put` runs (drops the whole `HiveRef`
+            // in place before recycling/freeing the slot).
             unsafe {
-                (*pool).put(std::ptr::from_mut::<Self>(self));
+                let pool = (*this).pool;
+                (*pool).put(this);
             }
             return None;
         }
-        Some(self)
+        Some(this)
+    }
+}
+
+/// Owning handle to a refcounted [`HiveRef`] pool slot. `Clone` increments,
+/// `Drop` decrements and recycles when the count hits zero. Cross FFI with
+/// [`into_raw`](Self::into_raw) / [`from_raw`](Self::from_raw), like `Rc`/`Box`.
+pub struct HiveRefHandle<T, const CAP: usize> {
+    ptr: NonNull<HiveRef<T, CAP>>,
+}
+
+impl<T, const CAP: usize> HiveRefHandle<T, CAP> {
+    /// Allocate a slot from `pool` with refcount 1.
+    ///
+    /// # Safety
+    /// `pool` must outlive every handle/raw pointer derived from it.
+    pub unsafe fn new(value: T, pool: *const Fallback<HiveRef<T, CAP>, CAP>) -> Self {
+        // SAFETY: caller contract — `pool` is dereferenceable + outlives the slot.
+        let ptr = unsafe { HiveRef::init(value, pool) };
+        Self {
+            // SAFETY: `Fallback::get_init` never returns null.
+            ptr: unsafe { NonNull::new_unchecked(ptr) },
+        }
+    }
+
+    /// Hand the slot to FFI without decrementing. Pair with [`from_raw`].
+    #[inline]
+    pub fn into_raw(self) -> *mut HiveRef<T, CAP> {
+        ManuallyDrop::new(self).ptr.as_ptr()
+    }
+
+    /// Reclaim ownership of a `+1` ref returned by [`into_raw`].
+    ///
+    /// # Safety
+    /// `ptr` must be a live slot whose `+1` has not already been released.
+    #[inline]
+    pub unsafe fn from_raw(ptr: *mut HiveRef<T, CAP>) -> Self {
+        // SAFETY: caller contract — `ptr` is non-null and live.
+        Self {
+            ptr: unsafe { NonNull::new_unchecked(ptr) },
+        }
+    }
+
+    /// Raw pointer for FFI/intrusive use. Does not affect the refcount.
+    #[inline]
+    pub fn as_ptr(&self) -> *mut HiveRef<T, CAP> {
+        self.ptr.as_ptr()
+    }
+}
+
+impl<T, const CAP: usize> Deref for HiveRefHandle<T, CAP> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        // SAFETY: a handle exists ⇒ refcount >= 1 ⇒ slot is live and initialized.
+        unsafe { &(*self.ptr.as_ptr()).value }
+    }
+}
+
+impl<T, const CAP: usize> DerefMut for HiveRefHandle<T, CAP> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut T {
+        // SAFETY: a handle exists ⇒ refcount >= 1 ⇒ slot is live and initialized.
+        unsafe { &mut (*self.ptr.as_ptr()).value }
+    }
+}
+
+impl<T, const CAP: usize> Clone for HiveRefHandle<T, CAP> {
+    #[inline]
+    fn clone(&self) -> Self {
+        // SAFETY: a handle exists ⇒ slot is live.
+        unsafe { (*self.ptr.as_ptr()).ref_() };
+        Self { ptr: self.ptr }
+    }
+}
+
+impl<T, const CAP: usize> Drop for HiveRefHandle<T, CAP> {
+    #[inline]
+    fn drop(&mut self) {
+        // SAFETY: a handle exists ⇒ slot is live; `unref` recycles on count==0.
+        unsafe { HiveRef::unref(self.ptr.as_ptr()) };
     }
 }
 
@@ -721,7 +816,7 @@ mod tests {
         // PORT NOTE: Zig used `u127`; Rust has no arbitrary-width ints. `u128` is the closest.
         type Int = u128;
 
-        let mut a = HiveArray::<Int, SIZE>::init();
+        let a = HiveArray::<Int, SIZE>::init();
 
         {
             let b = a.get().unwrap();
@@ -741,7 +836,8 @@ mod tests {
             assert!(a.r#in(&d) == false);
         }
 
-        a.used = IntegerBitSet::init_empty();
+        let mut a = a;
+        a.used = HiveBitSet::init_empty();
         {
             for i in 0..SIZE {
                 let b = a.get().unwrap();
@@ -758,44 +854,382 @@ mod tests {
         }
     }
 
+    /// Drop-counting payload. Each test that needs it owns its own `Cell` so
+    /// tests stay independent (`AtomicU32` static would leak counts across
+    /// tests run in the same process).
+    struct Tracked<'c> {
+        v: u64,
+        drops: &'c core::cell::Cell<u32>,
+    }
+    impl Drop for Tracked<'_> {
+        fn drop(&mut self) {
+            self.drops.set(self.drops.get() + 1);
+        }
+    }
+
     #[test]
     fn hive_slot_drop_releases_without_dtor() {
-        use core::sync::atomic::{AtomicU32, Ordering};
-        static DROPS: AtomicU32 = AtomicU32::new(0);
-        struct D(#[allow(dead_code)] u64);
-        impl Drop for D {
-            fn drop(&mut self) {
-                DROPS.fetch_add(1, Ordering::Relaxed);
-            }
-        }
+        let drops = core::cell::Cell::new(0u32);
+        let mk = |v| Tracked { v, drops: &drops };
 
-        let mut a = HiveArray::<D, 4>::init();
-        // Dropped token releases the slot without running D::drop.
+        let a = HiveArray::<Tracked, 4>::init();
+        // Dropped token releases the slot without running Drop.
         drop(a.claim().unwrap());
         assert!(!a.used.is_set(0));
-        assert_eq!(DROPS.load(Ordering::Relaxed), 0);
+        assert_eq!(drops.get(), 0);
 
         // write() commits and put() drops.
-        let p = a.get_init(D(7)).unwrap();
+        let p = a.get_init(mk(7)).unwrap();
         assert!(a.used.is_set(0));
-        assert_eq!(DROPS.load(Ordering::Relaxed), 0);
+        assert_eq!(drops.get(), 0);
         // SAFETY: `p` is a fully-initialized hive slot.
         unsafe { a.put(p.as_ptr()) };
-        assert_eq!(DROPS.load(Ordering::Relaxed), 1);
+        assert_eq!(drops.get(), 1);
 
         // put_raw() does not drop.
-        let p = a.get_init(D(8)).unwrap();
+        let p = a.get_init(mk(8)).unwrap();
         assert!(a.put_raw(p.as_ptr()));
-        assert_eq!(DROPS.load(Ordering::Relaxed), 1);
+        assert_eq!(drops.get(), 1);
 
-        // Fallback heap path: dropped token deallocates without D::drop.
-        let mut f = Fallback::<D, 0>::init();
+        // Fallback heap path: dropped token deallocates without Drop.
+        let f = Fallback::<Tracked, 0>::init();
         drop(f.claim());
-        assert_eq!(DROPS.load(Ordering::Relaxed), 1);
-        let p = f.get_init(D(9));
+        assert_eq!(drops.get(), 1);
+        let p = f.get_init(mk(9));
         // SAFETY: heap slot from this Fallback.
         unsafe { f.put(p.as_ptr()) };
-        assert_eq!(DROPS.load(Ordering::Relaxed), 2);
+        assert_eq!(drops.get(), 2);
+    }
+
+    #[test]
+    fn emplace_sees_own_address() {
+        struct SelfAddr {
+            me: *const SelfAddr,
+            tag: u32,
+        }
+
+        let a = HiveArray::<SelfAddr, 4>::init();
+        let p = a
+            .emplace(|addr| SelfAddr {
+                me: addr.as_ptr(),
+                tag: 1,
+            })
+            .unwrap();
+        // SAFETY: `p` was just written by emplace.
+        unsafe {
+            assert_eq!((*p.as_ptr()).me, p.as_ptr().cast_const());
+            assert_eq!((*p.as_ptr()).tag, 1);
+        }
+        assert!(a.put_raw(p.as_ptr()));
+
+        // Same on Fallback's heap path.
+        let f = Fallback::<SelfAddr, 0>::init();
+        let p = f.emplace(|addr| SelfAddr {
+            me: addr.as_ptr(),
+            tag: 2,
+        });
+        // SAFETY: `p` was just written by emplace; this is a heap slot.
+        unsafe {
+            assert_eq!((*p.as_ptr()).me, p.as_ptr().cast_const());
+            assert_eq!((*p.as_ptr()).tag, 2);
+            f.put_raw(p.as_ptr());
+        }
+    }
+
+    #[test]
+    fn slot_addr_as_uninit_assume_init() {
+        let a = HiveArray::<[u32; 2], 4>::init();
+
+        // addr() is stable and matches the post-write pointer.
+        let mut slot = a.claim().unwrap();
+        let pre = slot.addr().as_ptr();
+        slot.as_uninit().write([10, 20]);
+        // SAFETY: as_uninit().write() fully initialized the slot.
+        let p = unsafe { slot.assume_init() };
+        assert_eq!(pre, p.as_ptr());
+        // SAFETY: slot is initialized.
+        unsafe {
+            assert_eq!(*p.as_ptr(), [10, 20]);
+        }
+        assert!(a.put_raw(p.as_ptr()));
+
+        // write() returns the same address as addr().
+        let slot = a.claim().unwrap();
+        let pre = slot.addr().as_ptr();
+        let p = slot.write([30, 40]);
+        assert_eq!(pre, p.as_ptr());
+        assert!(a.put_raw(p.as_ptr()));
+    }
+
+    #[test]
+    fn at_returns_claimed_slot() {
+        let a = HiveArray::<u64, 4>::init();
+        let p0 = a.get_init(100).unwrap();
+        let p1 = a.get_init(200).unwrap();
+        assert_eq!(a.at(0), p0.as_ptr());
+        assert_eq!(a.at(1), p1.as_ptr());
+        assert_eq!(a.ptr_at(0), p0.as_ptr());
+        assert_eq!(a.ptr_at(1), p1.as_ptr());
+        // SAFETY: both slots are initialized.
+        unsafe {
+            assert_eq!(*a.at(0), 100);
+            assert_eq!(*a.at(1), 200);
+        }
+        assert!(a.put_raw(p0.as_ptr()));
+        assert!(a.put_raw(p1.as_ptr()));
+    }
+
+    #[test]
+    fn fallback_inline_then_heap() {
+        const CAP: usize = 2;
+        let drops = core::cell::Cell::new(0u32);
+        let mk = |v| Tracked { v, drops: &drops };
+
+        let f = Fallback::<Tracked, CAP>::init();
+
+        // Two inline slots, then two heap slots.
+        let inline0 = f.get_init(mk(0));
+        let inline1 = f.get_init(mk(1));
+        let heap0 = f.get_init(mk(2));
+        let heap1 = f.get_init(mk(3));
+
+        assert!(f.r#in(inline0.as_ptr()));
+        assert!(f.r#in(inline1.as_ptr()));
+        assert!(!f.r#in(heap0.as_ptr()));
+        assert!(!f.r#in(heap1.as_ptr()));
+        // SAFETY: all four are initialized.
+        unsafe {
+            assert_eq!((*inline0.as_ptr()).v, 0);
+            assert_eq!((*inline1.as_ptr()).v, 1);
+            assert_eq!((*heap0.as_ptr()).v, 2);
+            assert_eq!((*heap1.as_ptr()).v, 3);
+        }
+
+        // Return one inline, one heap — interleaved with new claims.
+        // SAFETY: `inline0` and `heap0` are initialized slots from `f`.
+        unsafe {
+            f.put(inline0.as_ptr());
+            f.put(heap0.as_ptr());
+        }
+        assert_eq!(drops.get(), 2);
+
+        // The freed inline slot is reused; the freed heap slot is gone.
+        let reuse = f.get_init(mk(4));
+        assert_eq!(reuse.as_ptr(), inline0.as_ptr());
+        assert!(f.r#in(reuse.as_ptr()));
+
+        // SAFETY: remaining live slots.
+        unsafe {
+            f.put(inline1.as_ptr());
+            f.put(heap1.as_ptr());
+            f.put(reuse.as_ptr());
+        }
+        assert_eq!(drops.get(), 5);
+    }
+
+    #[test]
+    fn fallback_claim_drop_inline_and_heap() {
+        // Inline token: dropping releases the bit.
+        let f = Fallback::<u64, 1>::init();
+        drop(f.claim());
+        assert!(!f.hive.used.is_set(0));
+
+        // Heap token (CAP=0 forces it): dropping deallocates without touching
+        // the hive — its `owner` is null. Pin the inline slot first so the
+        // bit-stays-set assertion is meaningful for the CAP>0 case too.
+        let f = Fallback::<u64, 1>::init();
+        let inline = f.get_init(1);
+        assert!(f.hive.used.is_set(0));
+        drop(f.claim());
+        assert!(f.hive.used.is_set(0));
+        // SAFETY: `inline` is a live initialized slot from `f`.
+        unsafe { f.put(inline.as_ptr()) };
+        assert!(!f.hive.used.is_set(0));
+    }
+
+    #[test]
+    fn fallback_deprecated_get_apis() {
+        const CAP: usize = 1;
+        let f = Fallback::<u64, CAP>::init();
+
+        // get() / try_get(): inline first, heap after the hive fills.
+        let p0 = f.get();
+        assert!(f.r#in(p0));
+        let p1 = f.try_get();
+        assert!(!f.r#in(p1));
+        // SAFETY: caller owns the uninitialized slots and writes before reading.
+        unsafe {
+            p0.write(11);
+            p1.write(22);
+            assert_eq!(*p0, 11);
+            assert_eq!(*p1, 22);
+            f.put(p0);
+            f.put(p1);
+        }
+
+        // get_and_see_if_new(): caller pre-inits to true; flipped false on
+        // an inline (recycled) hit, left true when a fresh heap box is made.
+        let mut new = true;
+        let p0 = f.get_and_see_if_new(&mut new);
+        assert!(!new);
+        let mut new = true;
+        let p1 = f.get_and_see_if_new(&mut new);
+        assert!(new);
+        // SAFETY: same as above.
+        unsafe {
+            p0.write(33);
+            p1.write(44);
+            f.put_raw(p0);
+            f.put_raw(p1);
+        }
+    }
+
+    #[test]
+    fn fallback_new_boxed_and_init_in_place() {
+        const CAP: usize = 4;
+
+        let boxed = Fallback::<u64, CAP>::new_boxed();
+        // SAFETY: `new_boxed` returns a valid heap allocation.
+        unsafe {
+            let f = &*boxed.as_ptr();
+            for i in 0..CAP {
+                let p = f.get_init(i as u64 * 10);
+                assert!(f.r#in(p.as_ptr()));
+                assert_eq!(*p.as_ptr(), i as u64 * 10);
+            }
+            // 5th claim spills to heap.
+            let p = f.get_init(999);
+            assert!(!f.r#in(p.as_ptr()));
+            f.put(p.as_ptr());
+            // `new_boxed` is leaked by design; reclaim for the test.
+            drop(Box::from_raw(boxed.as_ptr()));
+        }
+    }
+
+    #[test]
+    fn hive_ref_lifecycle() {
+        let drops = core::cell::Cell::new(0u32);
+
+        const CAP: usize = 2;
+        type Pool<'c> = HiveAllocator<Tracked<'c>, CAP>;
+        let pool: Pool = Fallback::init();
+        let pool_ptr: *const Pool = &pool;
+
+        // Inline allocation: ref to 2, unref to 1, unref to 0 → returned.
+        // SAFETY: `pool` outlives every HiveRef created from `pool_ptr`.
+        let r = unsafe { HiveRef::init(Tracked { v: 1, drops: &drops }, pool_ptr) };
+        // SAFETY: `r` is live (ref_count == 1) until the final unref returns None.
+        unsafe {
+            assert_eq!((*r).ref_count.get(), 1);
+            (*r).ref_();
+            assert_eq!((*r).ref_count.get(), 2);
+            assert!(HiveRef::unref(r).is_some());
+            assert_eq!((*r).ref_count.get(), 1);
+            assert!(HiveRef::unref(r).is_none());
+        }
+        assert_eq!(drops.get(), 1);
+
+        // Heap allocation: fill the hive first, then init another.
+        // SAFETY: same pool contract.
+        let inline0 = unsafe { HiveRef::init(Tracked { v: 2, drops: &drops }, pool_ptr) };
+        let inline1 = unsafe { HiveRef::init(Tracked { v: 3, drops: &drops }, pool_ptr) };
+        let heap = unsafe { HiveRef::init(Tracked { v: 4, drops: &drops }, pool_ptr) };
+        assert!(pool.r#in(inline0));
+        assert!(pool.r#in(inline1));
+        assert!(!pool.r#in(heap));
+        // SAFETY: all three are live.
+        unsafe {
+            assert!(HiveRef::unref(heap).is_none());
+            assert!(HiveRef::unref(inline1).is_none());
+            assert!(HiveRef::unref(inline0).is_none());
+        }
+        assert_eq!(drops.get(), 4);
+    }
+
+    #[test]
+    fn hive_ref_handle_lifecycle() {
+        let drops = core::cell::Cell::new(0u32);
+
+        const CAP: usize = 1;
+        type Pool<'c> = HiveAllocator<Tracked<'c>, CAP>;
+        let pool: Pool = Fallback::init();
+        let pool_ptr: *const Pool = &pool;
+
+        // Drop releases the slot when the count hits zero.
+        // SAFETY: `pool` outlives every handle.
+        let mut h = unsafe { HiveRefHandle::new(Tracked { v: 1, drops: &drops }, pool_ptr) };
+        assert_eq!(h.v, 1);
+        h.v = 11;
+        assert_eq!(h.v, 11);
+        let h2 = h.clone();
+        assert_eq!(h2.v, 11);
+        drop(h);
+        assert_eq!(drops.get(), 0);
+        drop(h2);
+        assert_eq!(drops.get(), 1);
+
+        // into_raw / from_raw round-trip preserves the count.
+        // SAFETY: `pool` outlives every handle.
+        let h = unsafe { HiveRefHandle::new(Tracked { v: 2, drops: &drops }, pool_ptr) };
+        let raw = h.into_raw();
+        assert_eq!(drops.get(), 1);
+        // SAFETY: `raw` carries a +1 from `into_raw`.
+        let h = unsafe { HiveRefHandle::<Tracked, CAP>::from_raw(raw) };
+        drop(h);
+        assert_eq!(drops.get(), 2);
+
+        // Heap fallback path (CAP=1, second handle spills).
+        // SAFETY: `pool` outlives every handle.
+        let inline = unsafe { HiveRefHandle::new(Tracked { v: 3, drops: &drops }, pool_ptr) };
+        let heap = unsafe { HiveRefHandle::new(Tracked { v: 4, drops: &drops }, pool_ptr) };
+        assert!(pool.r#in(inline.as_ptr()));
+        assert!(!pool.r#in(heap.as_ptr()));
+        drop(heap);
+        drop(inline);
+        assert_eq!(drops.get(), 4);
+    }
+
+    #[test]
+    fn hive_bitset_iteration() {
+        let a = HiveArray::<u8, 8>::init();
+        assert_eq!(a.used.find_first_set(), None);
+        assert_eq!(a.used.find_first_unset(), Some(0));
+
+        // Claim slots 0..3, then free 0 and 2 so the set is {1, 3}.
+        let s0 = a.get_init(0).unwrap();
+        let _s1 = a.get_init(1).unwrap();
+        let s2 = a.get_init(2).unwrap();
+        let _s3 = a.get_init(3).unwrap();
+        assert!(a.put_raw(s0.as_ptr()));
+        assert!(a.put_raw(s2.as_ptr()));
+
+        assert_eq!(a.used.find_first_set(), Some(1));
+        assert_eq!(a.used.find_first_unset(), Some(0));
+
+        let mut it = a.used.iter_set();
+        assert_eq!(it.next(), Some(1));
+        assert_eq!(it.next(), Some(3));
+        assert_eq!(it.next(), None);
+
+        // The explicit-param form is the same as iter_set().
+        let mut it = a.used.iterator::<true, true>();
+        assert_eq!(it.next(), Some(1));
+        assert_eq!(it.next(), Some(3));
+        assert_eq!(it.next(), None);
+    }
+
+    #[test]
+    fn init_in_place_zeroes_only_bitset() {
+        let mut a: MaybeUninit<HiveArray<u64, 4>> = MaybeUninit::uninit();
+        // SAFETY: stack allocation, properly aligned, valid for writes.
+        unsafe {
+            HiveArray::init_in_place(a.as_mut_ptr());
+            let a = &*a.as_ptr();
+            assert_eq!(a.used.find_first_set(), None);
+            let p = a.get_init(7).unwrap();
+            assert_eq!(*p.as_ptr(), 7);
+            assert!(a.put_raw(p.as_ptr()));
+        }
     }
 }
 

--- a/src/collections/lib.rs
+++ b/src/collections/lib.rs
@@ -40,7 +40,9 @@ pub mod static_hash_map;
 pub use static_hash_map::StaticHashMap;
 
 pub use bounded_array::BoundedArray;
-pub use hive_array::{Fallback as HiveArrayFallback, HiveArray, HiveRef, HiveRefHandle, HiveSlot};
+pub use hive_array::{
+    Fallback as HiveArrayFallback, HiveArray, HiveBox, HiveRef, HiveRefHandle, HiveSlot,
+};
 pub use linear_fifo::{LinearFifo, LinearFifoBufferType};
 pub use multi_array_list::MultiArrayList;
 #[doc(hidden)]

--- a/src/collections/lib.rs
+++ b/src/collections/lib.rs
@@ -40,7 +40,7 @@ pub mod static_hash_map;
 pub use static_hash_map::StaticHashMap;
 
 pub use bounded_array::BoundedArray;
-pub use hive_array::{Fallback as HiveArrayFallback, HiveArray, HiveRef, HiveSlot};
+pub use hive_array::{Fallback as HiveArrayFallback, HiveArray, HiveRef, HiveRefHandle, HiveSlot};
 pub use linear_fifo::{LinearFifo, LinearFifoBufferType};
 pub use multi_array_list::MultiArrayList;
 #[doc(hidden)]

--- a/src/collections/linear_fifo.rs
+++ b/src/collections/linear_fifo.rs
@@ -880,7 +880,7 @@ mod tests {
     // TODO(port): macro-generate the full T×buffer_type matrix in Phase B.
     #[test]
     fn linear_fifo_generic_u8_static() {
-        let mut fifo: LinearFifo<u8, StaticBuffer<u8, 32>> = LinearFifo::init();
+        let mut fifo = LinearFifo::<u8, StaticBuffer<u8, 32>>::init();
 
         fifo.write(&[0, 1, 1, 0, 1]).unwrap();
         assert_eq!(5usize, fifo.readable_length());

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1659,12 +1659,6 @@ pub struct RuntimeHooks {
     /// `NodeFS` lives in `bun_runtime`; the high tier boxes one and returns
     /// the type-erased pointer. Stored back into `vm.node_fs`.
     pub create_node_fs: unsafe fn(vm: *mut VirtualMachine) -> *mut c_void,
-    /// `Body.Value.HiveRef.init(body, &vm.body_value_pool)` — spec
-    /// VirtualMachine.zig:255. The hive allocator lives inside `runtime_state`
-    /// (high tier); `body` and the returned `*mut Body.Value.HiveRef` are
-    /// erased here and cast back on the `bun_runtime` side.
-    pub init_request_body_value:
-        unsafe fn(vm: *mut VirtualMachine, body: *mut c_void) -> *mut c_void,
     /// `WebCore.ObjectURLRegistry.singleton().has(specifier["blob:".len..])` —
     /// spec VirtualMachine.zig:1760. Registry lives in `bun_runtime::webcore`.
     pub has_blob_url: fn(blob_id: &[u8]) -> bool,
@@ -3027,22 +3021,6 @@ impl VirtualMachine {
             .transform_options
             .unhandled_rejections
             .unwrap_or(UnhandledRejections::Bun)
-    }
-
-    /// Spec VirtualMachine.zig:255 `initRequestBodyValue`.
-    ///
-    /// `body` is a `*mut bun_runtime::webcore::Body::Value`; the returned
-    /// pointer is a `*mut Body::Value::HiveRef`. Both types live in the
-    /// higher `bun_runtime` tier (forward-dep on `bun_jsc`), so they're
-    /// type-erased here and dispatched through [`RuntimeHooks`]. Callers in
-    /// `bun_runtime` cast back.
-    pub fn init_request_body_value(&mut self, body: *mut c_void) -> *mut c_void {
-        let hooks = runtime_hooks().expect("runtime hooks not installed");
-        // SAFETY: hook contract — `body` is a `Body::Value` allocated by the
-        // same `bun_runtime` build that registered the hook; `self` is the
-        // live per-thread VM (which owns the hive allocator inside
-        // `runtime_state`).
-        unsafe { (hooks.init_request_body_value)(self, body) }
     }
 
     /// Spec VirtualMachine.zig:279 `uvLoop`.

--- a/src/paths/component_iterator.rs
+++ b/src/paths/component_iterator.rs
@@ -412,8 +412,10 @@ mod tests {
         assert_eq!(it.last().unwrap().name, b"c");
         assert_eq!(it.previous().unwrap().name, b"b");
         assert_eq!(it.previous().unwrap().name, b"a");
+        // `previous()` returning `None` doesn't rewind the cursor — still on `a`.
         assert!(it.previous().is_none());
-        assert_eq!(it.next().unwrap().name, b"a");
         assert_eq!(it.next().unwrap().name, b"b");
+        assert_eq!(it.next().unwrap().name, b"c");
+        assert!(it.next().is_none());
     }
 }

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -2351,12 +2351,16 @@ pub fn next_dirname(path_: &[u8]) -> Option<&[u8]> {
 ///
 /// To use this, stack allocate the following struct, and then call `resolve`.
 ///
-///     let mut normalizer = PosixToWinNormalizer::default();
-///     let result = normalizer.resolve(b"C:\\dev\\bun", b"/dev/bun/test/etc.js");
+/// ```ignore
+/// let mut normalizer = PosixToWinNormalizer::default();
+/// let result = normalizer.resolve(b"C:\\dev\\bun", b"/dev/bun/test/etc.js");
+/// ```
 ///
 /// When you are certain that using the current working directory is fine, you can use
 ///
-///     let result = normalizer.resolve_cwd(b"/dev/bun/test/etc.js");
+/// ```ignore
+/// let result = normalizer.resolve_cwd(b"/dev/bun/test/etc.js");
+/// ```
 ///
 /// This API does nothing on Linux (it has a size of zero)
 pub struct PosixToWinNormalizer {

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -285,7 +285,8 @@ pub mod lib_info {
                     let pos = (*request).cache.pos_in_pending();
                     this.pending_host_cache_native.with_mut(|c| {
                         let slot = c.ptr_at(pos as usize);
-                        c.put_raw(slot);
+                        // SAFETY: `pos` was alloc'd; no other token outstanding.
+                        unsafe { c.put_raw(slot) };
                     });
                 }
                 // Drop the KeepAlive + resolver ref that `GetAddrInfoRequest.init` took.

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4237,12 +4237,9 @@ impl Resolver {
         cache_field: PendingCacheField,
     ) -> R::PendingCacheKey {
         let cache = R::pending_cache(self, cache_field);
-        debug_assert!(cache.used.is_set(index as usize));
-        // SAFETY: `used` bit is set ⇒ slot was initialized by `get_or_put_into_resolve_pending_cache`
-        // + `*Request::init`. `PendingCacheKey` is POD; reading by value then unsetting the bit
-        // hands ownership of the slot back to the HiveArray (Zig's `= undefined`).
-        let entry = unsafe { core::ptr::read(cache.ptr_at(index as usize)) };
-        cache.used.unset(index as usize);
+        // SAFETY: `used` bit is set ⇒ slot was initialized by
+        // `get_or_put_into_resolve_pending_cache` + `*Request::init`. POD; no aliases.
+        let entry = unsafe { cache.take_at(index as usize) };
         entry
     }
 
@@ -4253,24 +4250,22 @@ impl Resolver {
         field: PendingCacheField,
     ) -> get_addr_info_request::PendingCacheKey {
         let cache = self.pending_host_cache(field);
-        debug_assert!(cache.used.is_set(index as usize));
-        let entry = unsafe { core::ptr::read(cache.ptr_at(index as usize)) };
-        cache.used.unset(index as usize);
+        // SAFETY: `used` bit is set ⇒ slot was initialized by
+        // `get_or_put_into_resolve_pending_cache` + `*Request::init`. POD; no aliases.
+        let entry = unsafe { cache.take_at(index as usize) };
         entry
     }
     fn get_key_addr(&self, index: u8) -> get_host_by_addr_info_request::PendingCacheKey {
         self.pending_addr_cache_cares.with_mut(|cache| {
-            debug_assert!(cache.used.is_set(index as usize));
-            let entry = unsafe { core::ptr::read(cache.ptr_at(index as usize)) };
-            cache.used.unset(index as usize);
+            // SAFETY: `used` bit is set ⇒ slot was initialized; POD; no aliases.
+            let entry = unsafe { cache.take_at(index as usize) };
             entry
         })
     }
     fn get_key_nameinfo(&self, index: u8) -> get_name_info_request::PendingCacheKey {
         self.pending_nameinfo_cache_cares.with_mut(|cache| {
-            debug_assert!(cache.used.is_set(index as usize));
-            let entry = unsafe { core::ptr::read(cache.ptr_at(index as usize)) };
-            cache.used.unset(index as usize);
+            // SAFETY: `used` bit is set ⇒ slot was initialized; POD; no aliases.
+            let entry = unsafe { cache.take_at(index as usize) };
             entry
         })
     }
@@ -4289,13 +4284,8 @@ impl Resolver {
         // TODO(port): generic getKey over T::CACHE_FIELD
         let key = {
             let cache = self.pending_cache_for::<T>(T::CACHE_FIELD);
-            debug_assert!(cache.used.is_set(index as usize));
-            // SAFETY: `used` bit is set ⇒ slot was initialized by
-            // `get_or_put_into_resolve_pending_cache` + `*Request::init`.
-            // `PendingCacheKey` is POD; reading by value then unsetting the bit hands
-            // ownership of the slot back to the HiveArray (Zig's `= undefined`).
-            let key = unsafe { core::ptr::read(cache.ptr_at(index as usize)) };
-            cache.used.unset(index as usize);
+            // SAFETY: `used` bit is set ⇒ slot was initialized; POD; no aliases.
+            let key = unsafe { cache.take_at(index as usize) };
             key
         };
 

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4239,7 +4239,7 @@ impl Resolver {
         let cache = R::pending_cache(self, cache_field);
         // SAFETY: `used` bit is set ⇒ slot was initialized by
         // `get_or_put_into_resolve_pending_cache` + `*Request::init`. POD; no aliases.
-        let entry = unsafe { cache.take_at(index as usize) };
+        let entry = unsafe { cache.box_at(index as usize) }.into_inner();
         entry
     }
 
@@ -4252,20 +4252,20 @@ impl Resolver {
         let cache = self.pending_host_cache(field);
         // SAFETY: `used` bit is set ⇒ slot was initialized by
         // `get_or_put_into_resolve_pending_cache` + `*Request::init`. POD; no aliases.
-        let entry = unsafe { cache.take_at(index as usize) };
+        let entry = unsafe { cache.box_at(index as usize) }.into_inner();
         entry
     }
     fn get_key_addr(&self, index: u8) -> get_host_by_addr_info_request::PendingCacheKey {
         self.pending_addr_cache_cares.with_mut(|cache| {
             // SAFETY: `used` bit is set ⇒ slot was initialized; POD; no aliases.
-            let entry = unsafe { cache.take_at(index as usize) };
+            let entry = unsafe { cache.box_at(index as usize) }.into_inner();
             entry
         })
     }
     fn get_key_nameinfo(&self, index: u8) -> get_name_info_request::PendingCacheKey {
         self.pending_nameinfo_cache_cares.with_mut(|cache| {
             // SAFETY: `used` bit is set ⇒ slot was initialized; POD; no aliases.
-            let entry = unsafe { cache.take_at(index as usize) };
+            let entry = unsafe { cache.box_at(index as usize) }.into_inner();
             entry
         })
     }
@@ -4285,7 +4285,7 @@ impl Resolver {
         let key = {
             let cache = self.pending_cache_for::<T>(T::CACHE_FIELD);
             // SAFETY: `used` bit is set ⇒ slot was initialized; POD; no aliases.
-            let key = unsafe { cache.take_at(index as usize) };
+            let key = unsafe { cache.box_at(index as usize) }.into_inner();
             key
         };
 

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4237,9 +4237,10 @@ impl Resolver {
         cache_field: PendingCacheField,
     ) -> R::PendingCacheKey {
         let cache = R::pending_cache(self, cache_field);
-        // SAFETY: `used` bit is set ⇒ slot was initialized by
-        // `get_or_put_into_resolve_pending_cache` + `*Request::init`. POD; no aliases.
-        let entry = unsafe { cache.box_at(index as usize) }.into_inner();
+        let entry = cache
+            .box_at(index as usize)
+            .expect("pending DNS slot")
+            .into_inner();
         entry
     }
 
@@ -4250,22 +4251,29 @@ impl Resolver {
         field: PendingCacheField,
     ) -> get_addr_info_request::PendingCacheKey {
         let cache = self.pending_host_cache(field);
-        // SAFETY: `used` bit is set ⇒ slot was initialized by
-        // `get_or_put_into_resolve_pending_cache` + `*Request::init`. POD; no aliases.
-        let entry = unsafe { cache.box_at(index as usize) }.into_inner();
+        let entry = cache
+            .box_at(index as usize)
+            .expect("pending DNS slot")
+            .into_inner();
         entry
     }
     fn get_key_addr(&self, index: u8) -> get_host_by_addr_info_request::PendingCacheKey {
         self.pending_addr_cache_cares.with_mut(|cache| {
             // SAFETY: `used` bit is set ⇒ slot was initialized; POD; no aliases.
-            let entry = unsafe { cache.box_at(index as usize) }.into_inner();
+            let entry = cache
+                .box_at(index as usize)
+                .expect("pending DNS slot")
+                .into_inner();
             entry
         })
     }
     fn get_key_nameinfo(&self, index: u8) -> get_name_info_request::PendingCacheKey {
         self.pending_nameinfo_cache_cares.with_mut(|cache| {
             // SAFETY: `used` bit is set ⇒ slot was initialized; POD; no aliases.
-            let entry = unsafe { cache.box_at(index as usize) }.into_inner();
+            let entry = cache
+                .box_at(index as usize)
+                .expect("pending DNS slot")
+                .into_inner();
             entry
         })
     }
@@ -4285,7 +4293,10 @@ impl Resolver {
         let key = {
             let cache = self.pending_cache_for::<T>(T::CACHE_FIELD);
             // SAFETY: `used` bit is set ⇒ slot was initialized; POD; no aliases.
-            let key = unsafe { cache.box_at(index as usize) }.into_inner();
+            let key = cache
+                .box_at(index as usize)
+                .expect("pending DNS slot")
+                .into_inner();
             key
         };
 

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4237,8 +4237,8 @@ impl Resolver {
         cache_field: PendingCacheField,
     ) -> R::PendingCacheKey {
         let cache = R::pending_cache(self, cache_field);
-        let entry = cache
-            .box_at(index as usize)
+        // SAFETY: slot at `index` was alloc'd by `get_or_put_into_resolve_pending_cache`.
+        let entry = unsafe { cache.box_at(index as usize) }
             .expect("pending DNS slot")
             .into_inner();
         entry
@@ -4251,17 +4251,16 @@ impl Resolver {
         field: PendingCacheField,
     ) -> get_addr_info_request::PendingCacheKey {
         let cache = self.pending_host_cache(field);
-        let entry = cache
-            .box_at(index as usize)
+        // SAFETY: slot at `index` was alloc'd by `get_or_put_into_resolve_pending_cache`.
+        let entry = unsafe { cache.box_at(index as usize) }
             .expect("pending DNS slot")
             .into_inner();
         entry
     }
     fn get_key_addr(&self, index: u8) -> get_host_by_addr_info_request::PendingCacheKey {
         self.pending_addr_cache_cares.with_mut(|cache| {
-            // SAFETY: `used` bit is set ⇒ slot was initialized; POD; no aliases.
-            let entry = cache
-                .box_at(index as usize)
+            // SAFETY: slot at `index` was alloc'd by `get_or_put_into_resolve_pending_cache`.
+            let entry = unsafe { cache.box_at(index as usize) }
                 .expect("pending DNS slot")
                 .into_inner();
             entry
@@ -4269,9 +4268,8 @@ impl Resolver {
     }
     fn get_key_nameinfo(&self, index: u8) -> get_name_info_request::PendingCacheKey {
         self.pending_nameinfo_cache_cares.with_mut(|cache| {
-            // SAFETY: `used` bit is set ⇒ slot was initialized; POD; no aliases.
-            let entry = cache
-                .box_at(index as usize)
+            // SAFETY: slot at `index` was alloc'd by `get_or_put_into_resolve_pending_cache`.
+            let entry = unsafe { cache.box_at(index as usize) }
                 .expect("pending DNS slot")
                 .into_inner();
             entry
@@ -4292,9 +4290,8 @@ impl Resolver {
         // TODO(port): generic getKey over T::CACHE_FIELD
         let key = {
             let cache = self.pending_cache_for::<T>(T::CACHE_FIELD);
-            // SAFETY: `used` bit is set ⇒ slot was initialized; POD; no aliases.
-            let key = cache
-                .box_at(index as usize)
+            // SAFETY: slot at `index` was alloc'd by `get_or_put_into_resolve_pending_cache`.
+            let key = unsafe { cache.box_at(index as usize) }
                 .expect("pending DNS slot")
                 .into_inner();
             key

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -284,7 +284,7 @@ pub mod lib_info {
                     // POD-ness.
                     let pos = (*request).cache.pos_in_pending();
                     this.pending_host_cache_native.with_mut(|c| {
-                        let slot = c.buffer[pos as usize].as_mut_ptr();
+                        let slot = c.ptr_at(pos as usize);
                         c.put_raw(slot);
                     });
                 }
@@ -4241,7 +4241,7 @@ impl Resolver {
         // SAFETY: `used` bit is set ⇒ slot was initialized by `get_or_put_into_resolve_pending_cache`
         // + `*Request::init`. `PendingCacheKey` is POD; reading by value then unsetting the bit
         // hands ownership of the slot back to the HiveArray (Zig's `= undefined`).
-        let entry = unsafe { core::ptr::read(cache.buffer[index as usize].as_ptr()) };
+        let entry = unsafe { core::ptr::read(cache.ptr_at(index as usize)) };
         cache.used.unset(index as usize);
         entry
     }
@@ -4254,14 +4254,14 @@ impl Resolver {
     ) -> get_addr_info_request::PendingCacheKey {
         let cache = self.pending_host_cache(field);
         debug_assert!(cache.used.is_set(index as usize));
-        let entry = unsafe { core::ptr::read(cache.buffer[index as usize].as_ptr()) };
+        let entry = unsafe { core::ptr::read(cache.ptr_at(index as usize)) };
         cache.used.unset(index as usize);
         entry
     }
     fn get_key_addr(&self, index: u8) -> get_host_by_addr_info_request::PendingCacheKey {
         self.pending_addr_cache_cares.with_mut(|cache| {
             debug_assert!(cache.used.is_set(index as usize));
-            let entry = unsafe { core::ptr::read(cache.buffer[index as usize].as_ptr()) };
+            let entry = unsafe { core::ptr::read(cache.ptr_at(index as usize)) };
             cache.used.unset(index as usize);
             entry
         })
@@ -4269,7 +4269,7 @@ impl Resolver {
     fn get_key_nameinfo(&self, index: u8) -> get_name_info_request::PendingCacheKey {
         self.pending_nameinfo_cache_cares.with_mut(|cache| {
             debug_assert!(cache.used.is_set(index as usize));
-            let entry = unsafe { core::ptr::read(cache.buffer[index as usize].as_ptr()) };
+            let entry = unsafe { core::ptr::read(cache.ptr_at(index as usize)) };
             cache.used.unset(index as usize);
             entry
         })
@@ -4294,7 +4294,7 @@ impl Resolver {
             // `get_or_put_into_resolve_pending_cache` + `*Request::init`.
             // `PendingCacheKey` is POD; reading by value then unsetting the bit hands
             // ownership of the slot back to the HiveArray (Zig's `= undefined`).
-            let key = unsafe { core::ptr::read(cache.buffer[index as usize].as_ptr()) };
+            let key = unsafe { core::ptr::read(cache.ptr_at(index as usize)) };
             cache.used.unset(index as usize);
             key
         };
@@ -4612,7 +4612,7 @@ impl Resolver {
 
         while let Some(index) = inflight_iter.next() {
             // SAFETY: `used` bit is set ⇒ slot was initialized.
-            let entry = unsafe { &mut *cache.buffer[index].as_mut_ptr() };
+            let entry = unsafe { &mut *cache.ptr_at(index) };
             if R::key_hash(entry) == R::key_hash(key) && R::key_len(entry) == R::key_len(key) {
                 return LookupCacheHit::Inflight(std::ptr::from_mut(entry));
             }
@@ -4635,7 +4635,7 @@ impl Resolver {
 
         while let Some(index) = inflight_iter.next() {
             // SAFETY: `used` bit is set ⇒ slot was initialized.
-            let entry = unsafe { &mut *cache.buffer[index].as_mut_ptr() };
+            let entry = unsafe { &mut *cache.ptr_at(index) };
             if entry.hash == key.hash && entry.len == key.len {
                 return CacheHit::Inflight(std::ptr::from_mut(entry));
             }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1152,32 +1152,6 @@ unsafe fn create_node_fs(vm: *mut VirtualMachine) -> *mut c_void {
     .cast::<c_void>()
 }
 
-/// `Body.Value.HiveRef.init(body, &vm.body_value_pool)` — Spec
-/// VirtualMachine.zig:255. `body` is moved by value into the pooled slot.
-///
-/// # Safety
-/// `body` is a `*mut webcore::body::Value` the caller is donating (read-once,
-/// not dropped by the caller). Returns a `*mut webcore::body::HiveRef` erased
-/// to `*mut c_void`.
-unsafe fn init_request_body_value(_vm: *mut VirtualMachine, body: *mut c_void) -> *mut c_void {
-    use crate::webcore::body::{HiveRef, Value};
-    let state = runtime_state();
-    debug_assert!(
-        !state.is_null(),
-        "init_request_body_value before init_runtime_state"
-    );
-    // SAFETY: per fn contract — `body` points at an initialised `Body::Value`
-    // the caller hands over by move; `state` is the live per-thread box and
-    // its `body_value_pool` `Box` payload is heap-stable for the
-    // VM's lifetime (BACKREF contract on `HiveRef::allocator`).
-    let value = unsafe { core::ptr::read(body.cast::<Value>()) };
-    let pool: *mut crate::webcore::body::HiveAllocator =
-        unsafe { &raw mut *(*state).body_value_pool };
-    // Spec returns `!*HiveRef` with the only `try` site being the pool
-    // allocation; `bun.handleOom`-style crash matches Zig.
-    unsafe { HiveRef::init(value, pool) }.cast::<c_void>()
-}
-
 /// `WebCore.ObjectURLRegistry.singleton().has(specifier["blob:".len..])` —
 /// Spec VirtualMachine.zig:1760.
 fn has_blob_url(blob_id: &[u8]) -> bool {
@@ -1436,7 +1410,6 @@ pub static __BUN_RUNTIME_HOOKS: RuntimeHooks = RuntimeHooks {
     default_client_ssl_ctx,
     ssl_ctx_cache_get_or_create,
     create_node_fs,
-    init_request_body_value,
     has_blob_url,
     body_mixin_get_blob,
     process_exit,

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -182,9 +182,9 @@ pub struct RequestContext<
     pub range: RangeRequest::Raw,
 
     pub request_body_readable_stream_ref: readable_stream::Strong,
-    // TODO(b2-blocked): `WebCore::body::value::HiveRef` — webcore gates the
-    // HiveArray pool. Raw ptr to the pooled `Body::Value` slot until that lands.
-    pub request_body: Option<NonNull<body::Value>>,
+    /// Owning `+1` handle into the per-VM `Body::Value` hive pool. Shared with
+    /// `Request.body` (each holds its own `+1`). `Drop` releases the count.
+    pub request_body: Option<body::BodyHiveHandle>,
     pub request_body_buf: Vec<u8>,
     pub request_body_content_len: usize,
 
@@ -583,21 +583,14 @@ where
     /// Returns an unbounded `&'r mut` because the slot is a separate
     /// `HiveArray` allocation, **not** a sub-field of `*self`, so callers may
     /// hold it across disjoint `&self`/`&mut self` reborrows of other
-    /// `RequestContext` fields (same pattern as [`server()`]). Replaces the
-    /// per-site raw `NonNull::as_mut` deref at each state-machine site.
-    ///
-    /// # Safety (encapsulated)
-    /// While `Some`, `request_body` points to a pooled `HiveRef<Body::Value>`
-    /// slot whose lifetime is governed by the intrusive ref this context holds
-    /// (released via [`request_body_take_unref`] in `deinit()` /
-    /// `on_buffered_body_chunk` last-chunk path). The slot is single-threaded
-    /// and never aliased from outside this `RequestContext`, so forming a
-    /// unique `&mut` for the duration of the caller's use is sound.
+    /// `RequestContext` fields (same pattern as [`server()`]).
     #[inline]
     fn request_body_mut<'r>(&mut self) -> Option<&'r mut Body::Value> {
-        // SAFETY: see fn doc — pooled HiveRef slot live while `Some`,
-        // unaliased, single-threaded.
-        self.request_body.map(|mut p| unsafe { p.as_mut() })
+        // SAFETY: R-2 invariant — the slot is shared with `Request.body` but
+        // never `&mut`-borrowed concurrently (single-threaded event loop).
+        self.request_body
+            .as_ref()
+            .map(|h| unsafe { &mut (*h.as_ptr()).value })
     }
 
     /// Exclusive borrow of the heap [`ResponseStreamJSSink`] this context owns.
@@ -619,19 +612,12 @@ where
         self.sink.map(|p| unsafe { &mut *p.as_ptr() })
     }
 
-    /// Take the pooled request-body slot out of `self` and release the
-    /// intrusive ref this context held on it (returns it to the hive when
-    /// last). Mirrors the Zig `body.unref()` on `deinit` / final body chunk.
+    /// Take the pooled request-body slot out of `self`; the handle's `Drop`
+    /// releases the `+1`. Mirrors the Zig `body.unref()` on `deinit` /
+    /// final body chunk.
     #[inline]
     fn request_body_take_unref(&mut self) {
-        if let Some(mut p) = self.request_body.take() {
-            // SAFETY: pointee is the pooled `HiveRef` slot allocated by
-            // `init_request_body_value`; live until this `unref()` drops the
-            // last count. `Body::Value` reachable from `request_body` is
-            // always the `.value` field of a hive slot, satisfying `unref`'s
-            // container-of precondition.
-            let _ = unsafe { p.as_mut().unref() };
-        }
+        self.request_body.take();
     }
 
     pub fn set_signal_aborted(&mut self, reason: jsc::CommonAbortReason) {
@@ -845,11 +831,8 @@ where
             return false;
         }
         // check if the body is Locked (streaming)
-        if let Some(body) = self.request_body {
-            // Pooled HiveRef slot is live while held (see deinit()) — satisfies
-            // the `BackRef` outlives-holder invariant for this read.
-            let body = bun_ptr::BackRef::from(body);
-            if matches!(&*body, Body::Value::Locked(_)) {
+        if let Some(body) = &self.request_body {
+            if matches!(&**body, Body::Value::Locked(_)) {
                 return false;
             }
         }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -730,11 +730,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             );
 
         // Allocate the pooled body slot (ref_count = 1).
-        // SAFETY: vm backref live for the JS thread's lifetime.
-        let body_hive = crate::webcore::body::hive_alloc(
-            unsafe { &*vm_ptr },
-            crate::webcore::body::Value::Null,
-        );
+        let body_hive = crate::webcore::body::hive_alloc(crate::webcore::body::Value::Null);
         // Raw payload pointer for the deferred Locked write below.
         // SAFETY: slot stays live — both `ctx.request_body` and `Request.body` hold a +1.
         let body_value: *mut crate::webcore::body::Value =

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -729,19 +729,20 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 core::mem::size_of::<ServerRequestContext<SSL, DEBUG>>(),
             );
 
-        // Allocate the pooled body slot. `hive_alloc` is the typed front-end
-        // for the type-erased `init_request_body_value` hook (the hook lives
-        // in `bun_jsc` which cannot name `bun_runtime` types).
+        // Allocate the pooled body slot (ref_count = 1).
         // SAFETY: vm backref live for the JS thread's lifetime.
         let body_hive = crate::webcore::body::hive_alloc(
-            unsafe { &mut *vm_ptr },
+            unsafe { &*vm_ptr },
             crate::webcore::body::Value::Null,
         );
-        // SAFETY: hive_alloc returns a freshly-initialized hive slot
-        // (`ref_count = 1`); live until refcount drops to zero.
+        // Raw payload pointer for the deferred Locked write below.
+        // SAFETY: slot stays live — both `ctx.request_body` and `Request.body` hold a +1.
         let body_value: *mut crate::webcore::body::Value =
             unsafe { core::ptr::addr_of_mut!((*body_hive.as_ptr()).value) };
-        ctx_mut.request_body = core::ptr::NonNull::new(body_value);
+        // Zig: `.body = body.ref()` — bump once so the ctx and JS Request each
+        // own a +1 on the same slot (streamed bytes buffered into the ctx
+        // surface on `request.body`/`request.json()`).
+        ctx_mut.request_body = Some(body_hive.clone());
 
         let global = server.global_this();
         let signal = jsc::AbortSignal::new(global);
@@ -752,24 +753,19 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // SAFETY: `signal.ref_()` bumps the intrusive count and returns +1.
         let signal_ref =
             unsafe { jsc::AbortSignalRef::adopt(bun_opaque::opaque_deref_mut(signal).ref_()) };
-        // Zig: `.body = body.ref()` — bump once so the JS Request shares the
-        // same hive slot as `ctx.request_body` (streamed bytes buffered into
-        // the ctx surface on `request.body`/`request.json()`). Paired with
-        // `HiveRef::unref` in `Request::finalize`.
-        // SAFETY: `body_hive` is live (ref_count >= 1).
-        let body_for_req: core::ptr::NonNull<crate::webcore::body::HiveRef> =
-            unsafe { core::ptr::NonNull::from((*body_hive.as_ptr()).ref_()) };
         // PORT NOTE (ownership): `Request::new` is `bun.TrivialNew` — the heap
         // allocation is handed to the JS GC via `to_js`/`to_js_for_bake` (C++
         // wrapper finalizer frees it), or, for `CreateJsRequest::No`, retained
         // by `ctx.request_weakref` until `RequestContext::deinit` releases it.
+        // `body_hive` (the original +1) moves into the Request — paired drop in
+        // `Request::finalize`.
         let request_object: *mut crate::webcore::Request =
             bun_core::heap::into_raw(crate::webcore::Request::new(crate::webcore::Request::init(
                 ctx_mut.method,
                 AnyRequestContext::init(ctx),
                 SSL,
                 Some(signal_ref),
-                body_for_req,
+                body_hive,
             )));
         // SAFETY: freshly allocated; uniquely owned here.
         ctx_mut.request_weakref = bun_ptr::WeakPtr::init_ref(unsafe { &mut *request_object });

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -135,7 +135,7 @@ pub trait RequestCtxOps: RequestCtx {
     fn ctx_method(&self) -> http::Method;
     fn set_upgrade_context(&mut self, ctx: Option<*mut WebSocketUpgradeContext>);
     fn defer_deinit_ptr(&mut self) -> &mut Option<DeferDeinitFlag>;
-    fn set_request_body(&mut self, body: Option<NonNull<BodyValue>>);
+    fn set_request_body(&mut self, body: Option<crate::webcore::body::BodyHiveHandle>);
     fn request_body_mut(&mut self) -> Option<&mut BodyValue>;
     fn set_signal(&mut self, sig: *mut AbortSignal);
     fn set_request_weakref(&mut self, req: *mut Request);
@@ -217,14 +217,16 @@ where
         &mut self.defer_deinit_until_callback_completes
     }
     #[inline]
-    fn set_request_body(&mut self, body: Option<NonNull<BodyValue>>) {
+    fn set_request_body(&mut self, body: Option<crate::webcore::body::BodyHiveHandle>) {
         self.request_body = body
     }
     #[inline]
     fn request_body_mut(&mut self) -> Option<&mut BodyValue> {
-        // SAFETY: request_body points at a live HiveRef<Value> slot owned by the
-        // VM's hive allocator while the RequestContext holds a ref.
-        self.request_body.map(|p| unsafe { &mut *p.as_ptr() })
+        // SAFETY: R-2 invariant — slot shared with `Request.body`, never
+        // `&mut`-borrowed concurrently (single-threaded event loop).
+        self.request_body
+            .as_ref()
+            .map(|h| unsafe { &mut (*h.as_ptr()).value })
     }
     #[inline]
     fn set_signal(&mut self, sig: *mut AbortSignal) {
@@ -2529,9 +2531,8 @@ where
             Box::new(Request::init2(
                 BunString::clone_utf8(url.href),
                 headers,
-                // Zig: `bun.handleOom(this.vm.initRequestBodyValue(body))` —
-                // moves `body` into the per-VM hive pool (ref_count = 1).
-                crate::webcore::body::hive_alloc(self.vm().as_mut(), body),
+                // Moves `body` into the per-VM hive pool (ref_count = 1).
+                crate::webcore::body::hive_alloc(self.vm(), body),
                 method,
             ))
         } else if let Some(request_) = first_arg
@@ -3176,16 +3177,12 @@ where
             .jsc_vm()
             .deprecated_report_extra_memory(mem::size_of::<Ctx>());
 
-        // `vm.initRequestBodyValue(.{ .Null = {} })` — typed wrapper over the
-        // type-erased RuntimeHooks vtable. Returns `NonNull<HiveRef>` with
-        // `ref_count = 1` (held by `ctx.request_body`).
-        let body_hive = crate::webcore::body::hive_alloc(self.vm().as_mut(), BodyValue::Null);
-        // SAFETY: hive_alloc returns a freshly-initialized hive slot; live until
-        // its refcount drops to zero (released in `RequestContext::deinit` and
-        // `Request::finalize`).
-        let body_ptr: *mut BodyValue =
-            unsafe { core::ptr::addr_of_mut!((*body_hive.as_ptr()).value) };
-        ctx.set_request_body(NonNull::new(body_ptr));
+        // `vm.initRequestBodyValue(.{ .Null = {} })` — pooled body slot,
+        // ref_count = 1.
+        let body_hive = crate::webcore::body::hive_alloc(self.vm(), BodyValue::Null);
+        // Zig: `.body = body.ref()` — ctx and Request each own a +1 on the
+        // same slot. Paired drop in `RequestContext::deinit` / `Request::finalize`.
+        ctx.set_request_body(Some(body_hive.clone()));
 
         let signal = AbortSignal::new(&self.global());
         ctx.set_signal(signal);
@@ -3196,19 +3193,12 @@ where
         // copy and adopt into RAII so it pairs with `Request::Drop`'s unref.
         // SAFETY: `signal` is live; `ref_()` returns the same non-null ptr +1.
         let signal_for_req = unsafe { jsc::AbortSignalRef::adopt((*signal).ref_()) };
-        // Zig: `.body = body.ref()` — bump once so the JS Request shares the
-        // same hive slot as `ctx.request_body` (streamed bytes buffered into
-        // the ctx surface on `request.body`/`request.json()`). Paired with
-        // `HiveRef::unref` in `Request::finalize`.
-        // SAFETY: `body_hive` is live (ref_count >= 1).
-        let body_for_req: NonNull<crate::webcore::body::HiveRef> =
-            unsafe { NonNull::from((*body_hive.as_ptr()).ref_()) };
         let request_object_box = Request::new(Request::init(
             ctx.ctx_method(),
             AnyRequestContext::init(std::ptr::from_ref::<Ctx>(ctx)),
             SSL,
             Some(signal_for_req),
-            body_for_req,
+            body_hive,
         ));
         let request_object: &mut Request =
             // SAFETY: leak so the ctx (which outlives this stack frame) can
@@ -3425,12 +3415,11 @@ where
         // SAFETY: ctx_slot was just initialized by create_in.
         let ctx = unsafe { &mut *ctx_slot };
 
-        let body_hive = crate::webcore::body::hive_alloc(this.vm().as_mut(), BodyValue::Null);
-        // SAFETY: hive_alloc returns a freshly-initialized hive slot; live until
-        // its refcount drops to zero.
-        let body_ptr: *mut BodyValue =
-            unsafe { core::ptr::addr_of_mut!((*body_hive.as_ptr()).value) };
-        ctx.request_body = NonNull::new(body_ptr);
+        // Pooled body slot, ref_count = 1.
+        let body_hive = crate::webcore::body::hive_alloc(this.vm(), BodyValue::Null);
+        // Zig: `.body = body.ref()` — ctx and Request each own a +1 on the
+        // same slot. Paired drop in `RequestContext::deinit` / `Request::finalize`.
+        ctx.request_body = Some(body_hive.clone());
 
         let signal = AbortSignal::new(&this.global());
         // Zig: `ctx.signal = signal; signal.pendingActivityRef();` — the
@@ -3443,18 +3432,12 @@ where
         // adopt into RAII so it pairs with `Request::Drop`'s unref.
         // SAFETY: `signal` is live; `ref_()` returns the same non-null ptr +1.
         let signal_for_req = unsafe { jsc::AbortSignalRef::adopt((*signal).ref_()) };
-        // Zig: `.body = body.ref()` — bump once so the JS Request shares the
-        // same hive slot as `ctx.request_body`. Paired unref in
-        // `Request::finalize`.
-        // SAFETY: `body_hive` is live (ref_count >= 1).
-        let body_for_req: NonNull<crate::webcore::body::HiveRef> =
-            unsafe { NonNull::from((*body_hive.as_ptr()).ref_()) };
         let request_object_box = Request::new(Request::init(
             ctx.method,
             AnyRequestContext::init(std::ptr::from_ref(ctx)),
             SSL,
             Some(signal_for_req),
-            body_for_req,
+            body_hive,
         ));
         ctx.upgrade_context = Some(upgrade_ctx);
         let request_object: &mut Request =

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2532,7 +2532,7 @@ where
                 BunString::clone_utf8(url.href),
                 headers,
                 // Moves `body` into the per-VM hive pool (ref_count = 1).
-                crate::webcore::body::hive_alloc(self.vm(), body),
+                crate::webcore::body::hive_alloc(body),
                 method,
             ))
         } else if let Some(request_) = first_arg
@@ -3179,7 +3179,7 @@ where
 
         // `vm.initRequestBodyValue(.{ .Null = {} })` — pooled body slot,
         // ref_count = 1.
-        let body_hive = crate::webcore::body::hive_alloc(self.vm(), BodyValue::Null);
+        let body_hive = crate::webcore::body::hive_alloc(BodyValue::Null);
         // Zig: `.body = body.ref()` — ctx and Request each own a +1 on the
         // same slot. Paired drop in `RequestContext::deinit` / `Request::finalize`.
         ctx.set_request_body(Some(body_hive.clone()));
@@ -3416,7 +3416,7 @@ where
         let ctx = unsafe { &mut *ctx_slot };
 
         // Pooled body slot, ref_count = 1.
-        let body_hive = crate::webcore::body::hive_alloc(this.vm(), BodyValue::Null);
+        let body_hive = crate::webcore::body::hive_alloc(BodyValue::Null);
         // Zig: `.body = body.ref()` — ctx and Request each own a +1 on the
         // same slot. Paired drop in `RequestContext::deinit` / `Request::finalize`.
         ctx.request_body = Some(body_hive.clone());

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -555,21 +555,19 @@ const POOL_SIZE: usize = if bun_alloc::heap_breakdown::ENABLED {
 };
 pub type HiveRef = bun_collections::HiveRef<Value, POOL_SIZE>;
 pub type HiveAllocator = bun_collections::hive_array::Fallback<HiveRef, POOL_SIZE>;
+pub type BodyHiveHandle = bun_collections::HiveRefHandle<Value, POOL_SIZE>;
 
-/// Typed front-end for `VirtualMachine::init_request_body_value` (the hook is
-/// type-erased to break the `bun_jsc` → `bun_runtime` dep edge). Spec
-/// `VirtualMachine.zig:255 initRequestBodyValue` — moves `value` into a
-/// pooled `HiveRef` slot (ref_count = 1) and returns it.
-pub fn hive_alloc(vm: &mut VirtualMachine, value: Value) -> core::ptr::NonNull<HiveRef> {
-    // The hook impl (`runtime/jsc_hooks.rs`) `ptr::read`s its `*mut Value`
-    // argument; suppress the local drop so the move is one-way.
-    let mut value = core::mem::ManuallyDrop::new(value);
-    let ptr = vm
-        .init_request_body_value((&raw mut *value).cast::<core::ffi::c_void>())
-        .cast::<HiveRef>();
-    // `HiveRef::init` only fails on allocator OOM, which `handle_oom` upstream
-    // would have already aborted on; treat null as unreachable.
-    core::ptr::NonNull::new(ptr).expect("body HiveAllocator returned null")
+/// Spec `VirtualMachine.zig:255 initRequestBodyValue` — moves `value` into a
+/// pooled `HiveRef` slot and returns an owning handle (ref_count = 1).
+pub fn hive_alloc(vm: &VirtualMachine, value: Value) -> BodyHiveHandle {
+    let _ = vm;
+    let state = crate::jsc_hooks::runtime_state();
+    debug_assert!(!state.is_null(), "hive_alloc before init_runtime_state");
+    // SAFETY: `state` is the live boxed RuntimeState; `body_value_pool` is a
+    // heap-stable `Box<HiveAllocator>` for the VM lifetime.
+    let pool = unsafe { &raw const *(*state).body_value_pool };
+    // SAFETY: `pool` outlives every handle (process lifetime).
+    unsafe { BodyHiveHandle::new(value, pool) }
 }
 
 pub const HEAP_BREAKDOWN_LABEL: &str = "BodyValue";
@@ -686,37 +684,6 @@ impl ValueError {
 }
 
 impl Value {
-    /// Decrement the refcount of the enclosing pooled `HiveRef<Value>` slot.
-    ///
-    /// `RequestContext.request_body` stores `NonNull<Value>` (the pooled
-    /// payload), but the Zig field type is `?*Body.Value.HiveRef` — the slot
-    /// header carries the refcount + pool back-pointer. Recover the parent via
-    /// `offset_of!``) and forward.
-    ///
-    /// # Safety
-    /// `self` must be the `value` field of a live `HiveRef<Value, POOL_SIZE>`
-    /// produced by `HiveRef::init`.
-    pub unsafe fn unref(&mut self) -> Option<&mut Self> {
-        let parent: *mut HiveRef =
-            bun_core::from_field_ptr!(HiveRef, value, std::ptr::from_mut::<Self>(self));
-        // SAFETY: caller contract — `self` is the `.value` field of a HiveRef slot.
-        unsafe { HiveRef::unref(parent) }.map(|p| {
-            // SAFETY: `Some` ⇒ ref_count > 0 ⇒ slot still live.
-            unsafe { &mut (*p).value }
-        })
-    }
-
-    /// See [`Value::unref`] for the safety contract.
-    pub unsafe fn ref_(&mut self) -> &mut Self {
-        let parent: *mut HiveRef =
-            bun_core::from_field_ptr!(HiveRef, value, std::ptr::from_mut::<Self>(self));
-        // SAFETY: caller contract — `self` is the `.value` field of a HiveRef slot.
-        unsafe {
-            (*parent).ref_();
-            &mut (*parent).value
-        }
-    }
-
     /// Downcast a `JSValue` to the `Body.Value` it owns, if any.
     ///
     /// Port of the `Body.Value` special-case in `JSValue.as()` (JSValue.zig:449):

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -697,20 +697,24 @@ impl Value {
     /// `self` must be the `value` field of a live `HiveRef<Value, POOL_SIZE>`
     /// produced by `HiveRef::init`.
     pub unsafe fn unref(&mut self) -> Option<&mut Self> {
+        let parent: *mut HiveRef =
+            bun_core::from_field_ptr!(HiveRef, value, std::ptr::from_mut::<Self>(self));
         // SAFETY: caller contract — `self` is the `.value` field of a HiveRef slot.
-        let parent = unsafe {
-            &mut *bun_core::from_field_ptr!(HiveRef, value, std::ptr::from_mut::<Self>(self))
-        };
-        parent.unref().map(|h| &mut h.value)
+        unsafe { HiveRef::unref(parent) }.map(|p| {
+            // SAFETY: `Some` ⇒ ref_count > 0 ⇒ slot still live.
+            unsafe { &mut (*p).value }
+        })
     }
 
     /// See [`Value::unref`] for the safety contract.
     pub unsafe fn ref_(&mut self) -> &mut Self {
+        let parent: *mut HiveRef =
+            bun_core::from_field_ptr!(HiveRef, value, std::ptr::from_mut::<Self>(self));
         // SAFETY: caller contract — `self` is the `.value` field of a HiveRef slot.
-        let parent = unsafe {
-            &mut *bun_core::from_field_ptr!(HiveRef, value, std::ptr::from_mut::<Self>(self))
-        };
-        &mut parent.ref_().value
+        unsafe {
+            (*parent).ref_();
+            &mut (*parent).value
+        }
     }
 
     /// Downcast a `JSValue` to the `Body.Value` it owns, if any.

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -559,8 +559,7 @@ pub type BodyHiveHandle = bun_collections::HiveRefHandle<Value, POOL_SIZE>;
 
 /// Spec `VirtualMachine.zig:255 initRequestBodyValue` — moves `value` into a
 /// pooled `HiveRef` slot and returns an owning handle (ref_count = 1).
-pub fn hive_alloc(vm: &VirtualMachine, value: Value) -> BodyHiveHandle {
-    let _ = vm;
+pub fn hive_alloc(value: Value) -> BodyHiveHandle {
     let state = crate::jsc_hooks::runtime_state();
     debug_assert!(!state.is_null(), "hive_alloc before init_runtime_state");
     // SAFETY: `state` is the live boxed RuntimeState; `body_value_pool` is a

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -842,7 +842,8 @@ impl Request {
         // zero (drops the payload in place). `body: NonNull<_>` has no Drop,
         // so this is the only release point. Deref is centralised in
         // `body_hive()`.
-        this.body_hive().unref();
+        // SAFETY: `body` is a live +1 slot (this is its only release point).
+        unsafe { BodyHiveRef::unref(std::ptr::from_mut(this.body_hive())) };
         if this.weak_ptr_data.on_finalize() {
             // Hot path: no outstanding weak refs. Reclaim and drop the whole
             // allocation in one shot — `Box::from_raw`'s drop runs
@@ -1064,13 +1065,14 @@ impl Request {
                 req.finalize_without_deinit();
                 // `req.body` is the +1 ref this fn allocated above; deref is
                 // centralised in `body_hive()`.
-                req.body_hive().unref();
+                // SAFETY: live +1 slot.
+                unsafe { BodyHiveRef::unref(std::ptr::from_mut(req.body_hive())) };
             }
             if req.body != body {
                 // SAFETY: `body` was allocated with ref_count=1 at fn entry; if
                 // `req.body` was repointed (not currently done by any path here),
                 // release the original.
-                unsafe { (*body.as_ptr()).unref() };
+                unsafe { BodyHiveRef::unref(body.as_ptr()) };
             }
         };
 
@@ -1568,7 +1570,7 @@ impl Request {
                 // Zig: `errdefer body.unref()` — `NonNull` is `Copy`, so no
                 // RAII covers this; release the +1 we just allocated.
                 // SAFETY: `body` is a fresh +1 hive slot from `hive_alloc`.
-                unsafe { (*body.as_ptr()).unref() };
+                unsafe { BodyHiveRef::unref(body.as_ptr()) };
                 return Err(e);
             }
         };

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1021,7 +1021,7 @@ impl Request {
     ) -> JsResult<Request> {
         let mut success = false;
         // SAFETY: bun_vm() yields the live per-thread VM singleton.
-        let body = body::hive_alloc(global_this.bun_vm(), BodyValue::Null);
+        let body = body::hive_alloc(BodyValue::Null);
         // Snapshot the seed slot pointer for the repoint check below; `body`
         // (the +1) is moved into `req.body` next.
         let body_seed_ptr = body.as_ptr();
@@ -1541,7 +1541,7 @@ impl Request {
         let _ = self.ensure_url();
         let body_ = self.clone_body_value_via_cached_stream(global_this)?;
         // errdefer body_.deinit() → deleted; BodyValue: Drop frees on `?` error path
-        let body = body::hive_alloc(global_this.bun_vm(), body_);
+        let body = body::hive_alloc(body_);
         // Last fallible call. Zig hoists `url` above this with an
         // `errdefer if (!preserve_url) url.deref()`; we instead sink the url
         // computation below it so no guard is needed at all — `BunString` is

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -11,7 +11,7 @@ use super::response::HeadersRef;
 use crate::api::AnyRequestContext;
 use crate::webcore::BlobExt as _;
 use crate::webcore::blob::ZigStringBlobExt as _;
-use crate::webcore::body::{self, Body, BodyMixin, HiveRef as BodyHiveRef, Value as BodyValue};
+use crate::webcore::body::{self, Body, BodyHiveHandle, BodyMixin, Value as BodyValue};
 use crate::webcore::jsc::{
     self as jsc, CallFrame, HTTPHeaderName, JSGlobalObject, JSValue, JsError, JsRef, JsResult,
 };
@@ -32,6 +32,7 @@ use bun_jsc::StringJsc as _;
 use bun_jsc::generated::JSRequest as js_gen;
 use bun_ptr::weak_ptr::WeakPtrData;
 use bun_uws as uws;
+use core::mem::ManuallyDrop;
 
 // TODO(port): WeakRef = bun.ptr.WeakPtr(Request, "weak_ptr_data") — intrusive weak-ptr;
 // keep raw *mut Request + embedded WeakPtrData. See PORTING.md §Pointers.
@@ -93,13 +94,12 @@ pub struct Request {
     // `AbortSignalRef` wraps `NonNull<AbortSignal>` and routes Clone/Drop to
     // the C++ ref/unref.
     pub signal: JsCell<Option<AbortSignalRef>>,
-    /// Intrusive ref into the per-VM `Body::Value::HiveAllocator` pool. The
-    /// `Request` and (when served by `Bun.serve`) the `RequestContext` share
-    /// the same slot — `RequestContext.request_body` aliases
-    /// `&mut hive.value` — so streamed bytes buffered by the server surface
-    /// on `req.body`/`req.json()` without a copy. `finalize()` releases this
-    /// ref via `HiveRef::unref()`.
-    body: NonNull<BodyHiveRef>,
+    /// Owning `+1` handle into the per-VM `Body::Value` hive pool. The
+    /// `Request` and (when served by `Bun.serve`) the `RequestContext` each
+    /// hold their own `+1` on the same slot. `ManuallyDrop` because
+    /// `finalize()` decouples from `Box` and must release this handle exactly
+    /// once before `Box::from_raw().drop()` (which would otherwise re-run it).
+    body: ManuallyDrop<BodyHiveHandle>,
     js_ref: JsCell<JsRef>,
     pub method: Method,
     pub flags: Flags,
@@ -211,40 +211,22 @@ impl Request {
         self.body_value_mut()
     }
 
-    /// Exclusive borrow of the pooled `HiveRef<BodyValue>` slot this request
-    /// holds a `+1` ref on. **Single centralised `unsafe` deref** for the
-    /// set-once `body: NonNull<BodyHiveRef>` field — [`body_value`],
-    /// [`body_value_mut`], `finalize()` and the construct-cleanup path all
-    /// route through here so the `NonNull::as_ptr()` deref is audited in one
-    /// place.
-    ///
-    /// R-2: takes `&self` and projects `&mut` through the raw `NonNull`
-    /// (the hive slot is a separate heap allocation; not covered by `&self`'s
-    /// `noalias`). Single-JS-thread invariant — keep the borrow short.
-    #[inline]
-    #[allow(clippy::mut_from_ref)]
-    pub(crate) fn body_hive(&self) -> &mut BodyHiveRef {
-        // SAFETY: `body` is a +1 ref into the VM-owned hive allocator; the
-        // slot is live until `finalize()` (or the JS wrapper's GC finalizer)
-        // calls `unref()`. `Request` is `!Sync` so no concurrent `&mut` exists.
-        // The slot is a separate hive allocation (not `*self`), so the returned
-        // `&mut` does not alias `&Request`. R-2: the aliasing
-        // `RequestContext.request_body` pointer is only dereferenced while no
-        // other `&mut BodyValue` is live (single-threaded event-loop sequencing).
-        unsafe { &mut *self.body.as_ptr() }
-    }
-
     /// Zig: `this.#body.value` (immutable view).
     #[inline]
     pub(crate) fn body_value(&self) -> &BodyValue {
-        &self.body_hive().value
+        &self.body
     }
 
-    /// Zig: `&this.#body.value`. See [`body_hive`] for the R-2 invariant.
+    /// Zig: `&this.#body.value`.
+    ///
+    /// R-2: `&self` → `&mut` through the slot's raw pointer. The slot is shared
+    /// with `RequestContext.request_body` but never `&mut`-borrowed concurrently
+    /// (single-threaded event-loop sequencing). Keep the borrow short.
     #[inline]
     #[allow(clippy::mut_from_ref)]
     pub(crate) fn body_value_mut(&self) -> &mut BodyValue {
-        &mut self.body_hive().value
+        // SAFETY: see R-2 invariant above.
+        unsafe { &mut (*self.body.as_ptr()).value }
     }
 
     /// R-2: short-hand for `unsafe { self.headers.get_mut() }`. The
@@ -457,14 +439,14 @@ impl Request {
     pub fn init2(
         url: BunString,
         headers: Option<HeadersRef>,
-        body: NonNull<BodyHiveRef>,
+        body: BodyHiveHandle,
         method: Method,
     ) -> Request {
         Request {
             url: OwnedStringCell::new(url),
             headers: JsCell::new(headers),
             signal: JsCell::new(None),
-            body,
+            body: ManuallyDrop::new(body),
             js_ref: JsCell::new(JsRef::empty()),
             method,
             flags: Flags::default(),
@@ -837,13 +819,10 @@ impl Request {
         // hand ownership back to the raw pointer FIRST so a panic in the work
         // below leaks instead of Box-drop UAF-ing those weak holders.
         let this = bun_core::heap::release(self);
-        // Release the +1 hive ref handed out by `body::hive_alloc` /
-        // `HiveRef::ref_()`; slot returns to the pool when the count hits
-        // zero (drops the payload in place). `body: NonNull<_>` has no Drop,
-        // so this is the only release point. Deref is centralised in
-        // `body_hive()`.
-        // SAFETY: `body` is a live +1 slot (this is its only release point).
-        unsafe { BodyHiveRef::unref(std::ptr::from_mut(this.body_hive())) };
+        // Release the request's `+1` on the body slot. `ManuallyDrop` so the
+        // hot-path `Box::from_raw().drop()` below cannot re-run this.
+        // SAFETY: `this` is live and this is the sole release point for `body`.
+        unsafe { ManuallyDrop::drop(&mut this.body) };
         if this.weak_ptr_data.on_finalize() {
             // Hot path: no outstanding weak refs. Reclaim and drop the whole
             // allocation in one shot — `Box::from_raw`'s drop runs
@@ -1042,12 +1021,15 @@ impl Request {
     ) -> JsResult<Request> {
         let mut success = false;
         // SAFETY: bun_vm() yields the live per-thread VM singleton.
-        let body = body::hive_alloc(global_this.bun_vm().as_mut(), BodyValue::Null);
+        let body = body::hive_alloc(global_this.bun_vm(), BodyValue::Null);
+        // Snapshot the seed slot pointer for the repoint check below; `body`
+        // (the +1) is moved into `req.body` next.
+        let body_seed_ptr = body.as_ptr();
         let mut req = Request {
             url: OwnedStringCell::new(BunString::empty()),
             headers: JsCell::new(None),
             signal: JsCell::new(None),
-            body,
+            body: ManuallyDrop::new(body),
             js_ref: JsCell::new(JsRef::init_weak(this_value)),
             method: Method::GET,
             flags: Flags::default(),
@@ -1060,25 +1042,25 @@ impl Request {
         //               if (req.#body != body) { _ = body.unref(); } }`
         // PORT NOTE: reshaped for borrowck — scopeguard cannot capture `&mut req` while the
         // fn body also uses it. Cleanup is invoked at each early-return site via `bail!`.
-        let cleanup = |req: &mut Request, body: NonNull<BodyHiveRef>, success: bool| {
+        let cleanup = |req: &mut Request,
+                       body_seed_ptr: *mut crate::webcore::body::HiveRef,
+                       success: bool| {
             if !success {
                 req.finalize_without_deinit();
-                // `req.body` is the +1 ref this fn allocated above; deref is
-                // centralised in `body_hive()`.
-                // SAFETY: live +1 slot.
-                unsafe { BodyHiveRef::unref(std::ptr::from_mut(req.body_hive())) };
+                // SAFETY: `req.body` is live; this is the sole release on this path.
+                unsafe { ManuallyDrop::drop(&mut req.body) };
             }
-            if req.body != body {
-                // SAFETY: `body` was allocated with ref_count=1 at fn entry; if
-                // `req.body` was repointed (not currently done by any path here),
-                // release the original.
-                unsafe { BodyHiveRef::unref(body.as_ptr()) };
+            if req.body.as_ptr() != body_seed_ptr {
+                // `clone_into` `ptr::write`-overwrote `req.body`, orphaning the
+                // seed slot's +1. Recover and drop it.
+                // SAFETY: `body_seed_ptr` is a live +1 leaked by the ptr::write.
+                drop(unsafe { BodyHiveHandle::from_raw(body_seed_ptr) });
             }
         };
 
         macro_rules! bail {
             ($e:expr) => {{
-                cleanup(&mut req, body, success);
+                cleanup(&mut req, body_seed_ptr, success);
                 return $e;
             }};
         }
@@ -1156,7 +1138,7 @@ impl Request {
                             Err(e) => bail!(Err(e)),
                         }
                         success = true;
-                        cleanup(&mut req, body, success);
+                        cleanup(&mut req, body_seed_ptr, success);
                         return Ok(req);
                     }
 
@@ -1514,7 +1496,7 @@ impl Request {
         req.check_body_stream_ref(global_this);
         success = true;
 
-        cleanup(&mut req, body, success);
+        cleanup(&mut req, body_seed_ptr, success);
         Ok(req)
     }
 
@@ -1554,26 +1536,17 @@ impl Request {
     ) -> JsResult<()> {
         // allocator param dropped (global mimalloc)
         let _ = self.ensure_url();
-        let vm = global_this.bun_vm().as_mut();
         let body_ = self.clone_body_value_via_cached_stream(global_this)?;
         // errdefer body_.deinit() → deleted; BodyValue: Drop frees on `?` error path
-        // SAFETY: vm is the live per-thread singleton.
-        let body = body::hive_alloc(unsafe { &mut *vm }, body_);
+        let body = body::hive_alloc(global_this.bun_vm(), body_);
         // Last fallible call. Zig hoists `url` above this with an
         // `errdefer if (!preserve_url) url.deref()`; we instead sink the url
         // computation below it so no guard is needed at all — `BunString` is
         // `Copy` with no `Drop`, so an early return here leaves `req.url`
         // untouched and still owned by the caller's `finalize_without_deinit`.
-        let headers = match self.clone_headers(global_this) {
-            Ok(h) => h,
-            Err(e) => {
-                // Zig: `errdefer body.unref()` — `NonNull` is `Copy`, so no
-                // RAII covers this; release the +1 we just allocated.
-                // SAFETY: `body` is a fresh +1 hive slot from `hive_alloc`.
-                unsafe { BodyHiveRef::unref(body.as_ptr()) };
-                return Err(e);
-            }
-        };
+        // `body` (a `BodyHiveHandle`) drops on the `?` error path below,
+        // releasing its +1 — Zig's `errdefer body.unref()`.
+        let headers = self.clone_headers(global_this)?;
         // errdefer if (headers) |_h| _h.deref() → Arc drop on error path is automatic
         let url = if preserve_url {
             // Bitwise copy — the `ptr::write` below overwrites the old slot;
@@ -1588,8 +1561,8 @@ impl Request {
         // on the old `*req`. Match that with `ptr::write` so future Drop impls
         // on `JsRef` / `strong::Optional` don't fire on the caller's sentinel.
         // The old `req.body` hive ref is NOT unref'd here (Zig doesn't either):
-        // `clone()` seeds it with `NonNull::dangling()`, and `construct_into`
-        // releases its seed via the `req.body != body` arm of its `cleanup`.
+        // `clone()` seeds it with a dangling sentinel, and `construct_into`
+        // releases its seed via the ptr-equality arm of its `cleanup`.
         // `url` was bitwise-copied above (preserve_url) or is the empty
         // sentinel; remaining incoming fields are None/weak/Copy by contract.
         // SAFETY: `req` is a valid &mut, fully initialized by the caller;
@@ -1601,7 +1574,7 @@ impl Request {
                     url: OwnedStringCell::new(url),
                     headers: JsCell::new(headers),
                     signal: JsCell::new(None),
-                    body,
+                    body: ManuallyDrop::new(body),
                     js_ref: JsCell::new(JsRef::empty()),
                     method: self.method,
                     flags: self.flags,
@@ -1631,9 +1604,12 @@ impl Request {
             headers: JsCell::new(None),
             signal: JsCell::new(None),
             // `clone_into` `ptr::write`s the whole struct without dropping the
-            // sentinel; seed with a non-deref'd dangling so no hive slot is
-            // allocated for the throwaway.
-            body: NonNull::dangling(),
+            // sentinel; seed with a non-deref'd dangling handle. `ManuallyDrop`
+            // suppresses drop, so the `?` error path won't unref the dangling ptr.
+            // SAFETY: never deref'd or dropped — overwritten by `clone_into`.
+            body: ManuallyDrop::new(unsafe {
+                BodyHiveHandle::from_raw(NonNull::dangling().as_ptr())
+            }),
             js_ref: JsCell::new(JsRef::empty()),
             method: Method::GET,
             flags: Flags::default(),
@@ -1697,13 +1673,13 @@ impl Request {
         request_context: AnyRequestContext,
         https: bool,
         signal: Option<AbortSignalRef>,
-        body: NonNull<BodyHiveRef>,
+        body: BodyHiveHandle,
     ) -> Request {
         Request {
             url: OwnedStringCell::new(BunString::empty()),
             headers: JsCell::new(None),
             signal: JsCell::new(signal),
-            body,
+            body: ManuallyDrop::new(body),
             js_ref: JsCell::new(JsRef::empty()),
             method,
             flags: Flags {

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1045,12 +1045,15 @@ impl Request {
         let cleanup = |req: &mut Request,
                        body_seed_ptr: *mut crate::webcore::body::HiveRef,
                        success: bool| {
+            // Snapshot before the `!success` drop — reading a `ManuallyDrop`
+            // after `ManuallyDrop::drop()` is documented use-after-drop.
+            let req_body_ptr = req.body.as_ptr();
             if !success {
                 req.finalize_without_deinit();
                 // SAFETY: `req.body` is live; this is the sole release on this path.
                 unsafe { ManuallyDrop::drop(&mut req.body) };
             }
-            if req.body.as_ptr() != body_seed_ptr {
+            if req_body_ptr != body_seed_ptr {
                 // `clone_into` `ptr::write`-overwrote `req.body`, orphaning the
                 // seed slot's +1. Recover and drop it.
                 // SAFETY: `body_seed_ptr` is a live +1 leaked by the ptr::write.
@@ -1595,10 +1598,9 @@ impl Request {
 
     pub fn clone(&self, global_this: &JSGlobalObject) -> JsResult<Box<Request>> {
         // allocator param dropped (global mimalloc)
-        // Zig does `Request.new(undefined)` then clone_into bit-overwrites the whole
-        // struct. clone_into uses `ptr::write` (no drop glue) but does `ptr::read`
-        // `req.body` first to release the seed allocation, so seed with a valid
-        // sentinel rather than `MaybeUninit`.
+        // Zig does `Request.new(undefined)` then clone_into bit-overwrites the
+        // whole struct. clone_into `ptr::write`s the new fields over the seed
+        // without reading or dropping it.
         let mut req = Box::new(Request {
             url: OwnedStringCell::new(BunString::empty()),
             headers: JsCell::new(None),


### PR DESCRIPTION
Fixes #30719

## Miri support

Adds `bun run rust:miri` (`scripts/rust-miri.ts`), which runs `cargo miri test` over the FFI-free crate set (`bun_collections`, `bun_paths`, `bun_clap`, `bun_base64`, `bun_hash`, `bun_wyhash`, `bun_ptr`, `bun_md`, `bun_ast`, `bun_dispatch`, `bun_errno`, `bun_http_types`, `bun_resolve_builtins`, `bun_shell_parser`).

Aliasing model is `-Zmiri-tree-borrows`, not the default Stacked Borrows. Stacked Borrows pops every raw pointer derived through `&mut self` the moment a later `&mut self` is formed — that's the entire premise of the slab/pool/slot types in this codebase. Tree Borrows is the candidate replacement spec, allows that pattern, and still catches the bugs we care about (UAF, OOB, uninit, races).

## Bit-rot fixes

`cargo test` has never run on these crates. Enabling it surfaced compile errors and wrong assertions that have been there since the original port:

- `bun_collections`: dead test stub needing `generic_const_exprs`, wrong type name, ambiguous `init()`, plus a `cfg(miri)` iteration-count guard.
- `bun_paths`: `back_then_forward` expected `previous() → None` to rewind the cursor; it doesn't (matches `std.fs.path.ComponentIterator`). Plus 2 doc-comments that compiled as failing doctests.
- `bun_clap`: the `errors` test expected unrecognized long flags to error; Bun's `StreamingClap` intentionally skips them (warn + continue).
- `bun_base64`: `test_base64_url_safe_no_pad` fed unpadded input to `decoder_with_ignore`, which for `URL_SAFE_NO_PAD` is the *padded* decoder (the field is shared with `URL_SAFE`). Reworked the test helpers to feed each decoder the form it accepts; the impl is unchanged.
- `bun_ast`: 3 doc-comments compiling as failing doctests.

## HiveArray interior mutability

Tree Borrows immediately flagged `HiveArray`/`Fallback`/`HiveRef` as UB. The pool used `&mut self` receivers and handed out raw `*mut T` pointers into its internal buffer. Under `noalias`, any subsequent `&mut self` reborrow invalidates pointers derived from a prior one. This was a mechanical Zig→Rust translation: Zig's `*Self` carries no aliasing contract, but Rust's `&mut self` is `noalias`.

Fix is the `bumpalo`/`typed-arena` shape — `&self` receivers + interior mutability:

- `HiveArray::buffer` → `UnsafeCell<[MaybeUninit<T>; CAP]>`. Slot pointers come from `UnsafeCell::get()` and survive `&self` reborrows. Made private; `ptr_at()` is the typed accessor.
- `HiveBitSet::masks` → `[Cell<usize>; 32]`. Same size, same alignment, no atomics; verified identical codegen.
- All `&mut self` receivers → `&self`. `HiveSlot::write()` writes through a raw pointer.
- `HiveRef::ref_count` → `Cell<u32>`; `unref(this: *mut Self)` (not a protected `&mut self` it would then free through the pool back-pointer).
- New `HiveRefHandle<T, CAP>` smart pointer — `Clone`/`Drop` track the refcount, `into_raw()`/`from_raw()` for raw round-trips, `get_mut()` instead of `DerefMut` (a blanket `DerefMut` on a shared-ownership handle is unsound). Safe API; `unsafe` only at raw-pointer ingress.

Adds 11 tests covering the previously-untested API surface. All 13 hive tests pass under `MIRIFLAGS=-Zmiri-tree-borrows cargo miri test -p bun_collections hive_array` with no ignores.

## HiveRefHandle migration

`Request.body` and `RequestContext.request_body` migrated from raw `NonNull` + manual ref/unref to `HiveRefHandle`. `Value::ref_/unref` deleted (they recovered the parent `HiveRef` from a `*mut Value` via `offsetof`, only needed because `RequestContext` held a payload pointer). The `RuntimeHooks.init_request_body_value` vtable slot deleted: its only caller and only impl were both in `bun_runtime`. Net `unsafe` delta across the touched files: −17.

## Verification

```sh
cargo +nightly check --workspace                                # clean
cargo +nightly test -p bun_collections                          # 35 passed
MIRIFLAGS=-Zmiri-tree-borrows cargo +nightly miri test -p bun_collections hive_array  # 13 passed, 0 ignored
bun run rust:miri                                               # all 14 crates pass
```