### PR TITLE
Replace HiveArrayFallback's uninit-pointer API with safe construction

### DIFF
--- a/src/collections/hive_array.rs
+++ b/src/collections/hive_array.rs
@@ -260,9 +260,9 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
     /// The slot at `index`, if occupied, must hold a fully-initialized `T`,
     /// and no other live access path ([`HiveSlot`], [`HiveBox`], `*mut T`) to
     /// it may exist. The bitset check cannot prove this: [`claim`](Self::claim)
-    /// and the deprecated [`get`](Self::get) family set the `used` bit *before*
-    /// the slot is written, so safe code holding a claim token can have an
-    /// occupied-but-uninit slot. Pools that only use [`alloc`](Self::alloc)/
+    /// sets the `used` bit *before* the slot is written, so safe code holding
+    /// a claim token can have an occupied-but-uninit slot. Pools that only
+    /// use [`alloc`](Self::alloc)/
     /// [`get_init`](Self::get_init) (which write before returning) trivially
     /// satisfy this.
     #[inline]
@@ -275,24 +275,6 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
             slot: unsafe { NonNull::new_unchecked(self.ptr_at(index)) },
             owner: self,
         })
-    }
-
-    /// Claim a slot and return a raw pointer to its **uninitialized** storage.
-    ///
-    /// Prefer [`get_init`](Self::get_init) / [`emplace`](Self::emplace) /
-    /// [`claim`](Self::claim), which encode the "a `used` slot is always
-    /// fully initialized" invariant in the type system. This entry point
-    /// hands out `*mut T` to garbage; forming `&mut T` over it is instant UB
-    /// when `T` has niche-bearing fields, and an early return between `get()`
-    /// and the caller's `ptr::write` leaves the slot claimed-but-uninit so a
-    /// later [`put`](Self::put) drops garbage.
-    #[deprecated = "returns *mut T to uninitialized memory; use get_init / emplace / claim"]
-    pub fn get(&self) -> Option<*mut T> {
-        let index = self.used.find_first_unset()?;
-        self.used.set(index);
-        let ret = self.ptr_at(index);
-        asan::unpoison(ret.cast(), size_of::<T>());
-        Some(ret)
     }
 
     /// One-shot claim + write. Preferred entry point — no uninit window.
@@ -392,9 +374,11 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
     ///
     /// # Safety
     /// If `value` points into this hive, it must point to a fully-initialized
-    /// `T` previously obtained via [`get`](Self::get) and written by the
-    /// caller. The slot is dropped in place; passing a moved-from or
-    /// uninitialized slot is UB for `T` with drop glue.
+    /// `T` previously obtained via [`get_init`](Self::get_init) /
+    /// [`emplace`](Self::emplace), or via [`claim`](Self::claim) followed by
+    /// [`HiveSlot::write`] / [`HiveSlot::assume_init`]. The slot is dropped in
+    /// place; passing a moved-from or uninitialized slot is UB for `T` with
+    /// drop glue.
     pub unsafe fn put(&self, value: *mut T) -> bool {
         let Some(index) = self.index_of(value) else {
             return false;
@@ -425,7 +409,7 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
 
 /// Linear reservation token for a claimed-but-uninitialized hive slot.
 ///
-/// `HiveArray` slots are `[MaybeUninit<T>; CAP]`. The legacy [`HiveArray::get`]
+/// `HiveArray` slots are `[MaybeUninit<T>; CAP]`. The legacy `get()`
 /// contract was two-phase — claim a `*mut T` to garbage, then `ptr::write` it
 /// — which opened three UB hazards in the gap: (H1) early-return / `?` / panic
 /// leaves the slot claimed-uninit so a later `put()` drops garbage; (H2)
@@ -499,6 +483,27 @@ impl<'h, T, const CAPACITY: usize> HiveSlot<'h, T, CAPACITY> {
     pub unsafe fn assume_init(self) -> NonNull<T> {
         let this = ManuallyDrop::new(self);
         this.slot.cast::<T>()
+    }
+
+    /// Consume the token into an owned, lifetime-erased [`HiveOwned`] handle.
+    /// The slot stays claimed (the token's `Drop` does not run); recycle later
+    /// via [`Fallback::put`] / [`Fallback::put_raw`].
+    ///
+    /// `HiveOwned` does not deref by itself, so this does not require the slot
+    /// to already be initialized — that obligation moves to the first
+    /// [`HiveOwned::as_ref`] / [`HiveOwned::as_mut`].
+    ///
+    /// # Safety
+    /// The slot must be fully initialized before any call to
+    /// [`HiveOwned::as_ref`] / [`HiveOwned::as_mut`] on the returned handle.
+    /// Initialize through [`addr`](Self::addr) / [`as_uninit`](Self::as_uninit)
+    /// before calling `into_owned`, or through [`HiveOwned::as_ptr`] after.
+    /// ([`write`](Self::write) is not a valid precursor — it consumes the token
+    /// and already returns the committed `NonNull<T>` directly.)
+    #[inline]
+    pub unsafe fn into_owned(self) -> HiveOwned<T> {
+        let this = ManuallyDrop::new(self);
+        HiveOwned(this.slot.cast::<T>())
     }
 }
 
@@ -589,12 +594,90 @@ impl<T, const CAPACITY: usize> Drop for HiveBox<'_, T, CAPACITY> {
     }
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// HiveOwned
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Owned, lifetime-erased handle to a fully-initialized pool slot.
+///
+/// Constructible only from a real pool claim (no public `new`), so safe code
+/// cannot manufacture one from a dangling pointer. Move-only — there is exactly
+/// one per claimed slot, so aliasing two of them is a compile error.
+///
+/// Unlike [`HiveSlot`], this does not borrow the pool; it can be stored in
+/// long-lived structs (e.g. a `Task` that outlives the claiming scope). The
+/// trade-off: it does not track recycling. Dereferencing after the slot has
+/// been [`Fallback::put`] is UB — that contract lives on
+/// [`as_ref`](Self::as_ref) / [`as_mut`](Self::as_mut).
+///
+/// There is no `Drop`: dropping a `HiveOwned` is a no-op (the slot stays
+/// claimed). Recycling is the explicit [`Fallback::put`] step, matching the
+/// existing pool protocol.
+#[must_use = "dropping a HiveOwned without put() leaks the pool slot"]
+pub struct HiveOwned<T>(NonNull<T>);
+
+impl<T> HiveOwned<T> {
+    /// Stable address of the slot. Safe — returning a raw pointer is safe;
+    /// dereferencing it isn't.
+    #[inline]
+    pub fn as_ptr(&self) -> *mut T {
+        self.0.as_ptr()
+    }
+
+    /// Borrow the slot's contents for the lifetime of `&self`.
+    ///
+    /// # Safety
+    /// The slot must be fully initialized and must not have been returned to
+    /// the pool via [`Fallback::put`] / [`Fallback::put_raw`].
+    #[inline]
+    pub unsafe fn as_ref(&self) -> &T {
+        // SAFETY: caller contract — slot is initialized and not recycled.
+        unsafe { self.0.as_ref() }
+    }
+
+    /// Mutably borrow the slot's contents for the lifetime of `&mut self`.
+    ///
+    /// # Safety
+    /// The slot must be fully initialized and must not have been returned to
+    /// the pool via [`Fallback::put`] / [`Fallback::put_raw`]. No other
+    /// reference into the slot may be live for the duration of the borrow.
+    #[inline]
+    pub unsafe fn as_mut(&mut self) -> &mut T {
+        // SAFETY: caller contract — slot is initialized, not recycled, and
+        // not aliased. `&mut self` prevents forming two `&mut T` from the
+        // same handle.
+        unsafe { self.0.as_mut() }
+    }
+
+    /// Re-seal a pool-slot pointer that round-tripped through an intrusive
+    /// queue (`bun_threading::UnboundedQueue`). The queue stores raw `*mut`
+    /// links inside the element, so the `HiveOwned` token cannot survive
+    /// transit; `push_owned` consumes it, and the drain side reconstructs it
+    /// here.
+    ///
+    /// `#[doc(hidden)]` — this is the queue's private back-door, not general
+    /// API. It must have exactly one caller per push/pop boundary; everything
+    /// else should hold a real `HiveOwned` from [`Fallback::get_owned`] /
+    /// [`HiveSlot::into_owned`].
+    ///
+    /// # Safety
+    /// `ptr` must be the unique owner of a claimed pool slot — i.e. it was
+    /// previously the inner pointer of a [`HiveOwned`] that was relinquished
+    /// to an intrusive queue (or otherwise not yet `put()` back), and no other
+    /// live `HiveOwned` references the same slot.
+    #[doc(hidden)]
+    #[inline]
+    pub unsafe fn from_raw_for_queue(ptr: *mut T) -> Self {
+        Self(NonNull::new(ptr).expect("queue node is non-null"))
+    }
+}
+
 // PORT NOTE: In Zig this was the nested type `HiveArray(T, capacity).Fallback`.
 // Rust cannot nest a generic struct that captures outer generics, so it lives at
 // module scope with the same parameters. The Zig field
 // `hive: if (capacity > 0) Self else void` is always materialized here; the
 // `CAPACITY > 0` checks below preserve the original gating.
-// PERF(port): zero-capacity case carried a zero-size hive in Zig — profile in Phase B.
+// PERF(port): zero-capacity case carried a zero-size hive in Zig.
 pub struct Fallback<T, const CAPACITY: usize> {
     pub hive: HiveArray<T, CAPACITY>,
     // PORT NOTE: `std.mem.Allocator param` dropped — global mimalloc.
@@ -648,38 +731,18 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
         NonNull::from(Box::leak(unsafe { boxed.assume_init() }))
     }
 
-    /// See [`HiveArray::get`] — same UB hazards, plus the heap path leaks a
-    /// `Box<MaybeUninit<T>>` if the caller early-returns before `ptr::write`.
-    #[deprecated = "returns *mut T to uninitialized memory; use get_init / emplace / claim"]
-    pub fn get(&self) -> *mut T {
-        // Forget the token so its `Drop` does not release the slot — legacy
-        // callers expect the slot to remain claimed until their later `put()`.
-        ManuallyDrop::new(self.claim()).addr().as_ptr()
-    }
-
-    #[deprecated = "returns *mut T to uninitialized memory; use get_init / emplace / claim"]
-    pub fn get_and_see_if_new(&self, new: &mut bool) -> *mut T {
-        if CAPACITY > 0 {
-            #[allow(deprecated)]
-            if let Some(value) = self.hive.get() {
-                *new = false;
-                return value;
-            }
-        }
-
-        bun_core::heap::into_raw(Box::<T>::new_uninit()).cast::<T>()
-    }
-
-    #[deprecated = "returns *mut T to uninitialized memory; use get_init / emplace / claim"]
-    pub fn try_get(&self) -> *mut T {
-        ManuallyDrop::new(self.claim()).addr().as_ptr()
-    }
-
     /// One-shot claim + write. Preferred entry point — no uninit window.
     /// Infallible: spills to a heap `Box<T>` when the inline hive is full.
     #[inline]
     pub fn get_init(&self, value: T) -> NonNull<T> {
         self.claim().write(value)
+    }
+
+    /// Claim, write, and return a lifetime-erased owned handle. The slot stays
+    /// claimed; recycle later via [`put`](Self::put). See [`HiveOwned`].
+    #[inline]
+    pub fn get_owned(&self, value: T) -> HiveOwned<T> {
+        HiveOwned(self.get_init(value))
     }
 
     /// See [`HiveArray::emplace`]. Infallible (heap fallback).
@@ -714,10 +777,9 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
     ///
     /// # Safety
     /// `value` must have been obtained from this `Fallback` (via `get_init` /
-    /// `emplace` / `claim().write()` / the deprecated `get` family) and not
-    /// yet returned. The contained `T` is **not** dropped — caller must have
-    /// already moved out / destructured anything with drop glue, or `T` must
-    /// be POD.
+    /// `emplace` / `claim().write()`) and not yet returned. The contained `T`
+    /// is **not** dropped — caller must have already moved out / destructured
+    /// anything with drop glue, or `T` must be POD.
     pub unsafe fn put_raw(&self, value: *mut T) {
         if CAPACITY > 0 {
             // SAFETY: caller contract (this fn is `unsafe`).
@@ -725,10 +787,10 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
                 return;
             }
         }
-        // SAFETY: caller contract — `value` is a heap slot from `claim()` /
-        // `get()`; it was allocated as `Box<MaybeUninit<T>>` (same layout as
-        // `Box<T>`). Reclaiming as `MaybeUninit<T>` deallocates without
-        // running `T::drop`.
+        // SAFETY: caller contract — `value` is a heap slot from `claim()`; it
+        // was allocated as `Box<MaybeUninit<T>>` (same layout as `Box<T>`).
+        // Reclaiming as `MaybeUninit<T>` deallocates without running
+        // `T::drop`.
         drop(unsafe { Box::from_raw(value.cast::<MaybeUninit<T>>()) });
     }
 
@@ -746,9 +808,11 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
     ///
     /// # Safety
     /// `value` must point to a fully-initialized `T` previously obtained from
-    /// [`get`](Self::get) / [`get_and_see_if_new`](Self::get_and_see_if_new) /
-    /// [`try_get`](Self::try_get) on this `Fallback` and subsequently written
-    /// by the caller.
+    /// [`get_init`](Self::get_init), [`emplace`](Self::emplace), or from
+    /// [`claim`](Self::claim) after consuming the [`HiveSlot`] via
+    /// [`HiveSlot::write`] / [`HiveSlot::assume_init`], on this `Fallback`
+    /// and not yet returned. A claimed-but-uninitialized slot must not be
+    /// passed here.
     pub unsafe fn put(&self, value: *mut T) {
         if CAPACITY > 0 {
             // SAFETY: caller contract — `value` is fully initialized.
@@ -757,9 +821,10 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
             }
         }
 
-        // SAFETY: `value` was produced by the heap-fallback path of `claim()` /
-        // `get()` (it is not in the hive), and the caller has since fully
-        // initialized it. `destroy` reconstructs the `Box<T>` and runs `T::drop`.
+        // SAFETY: `value` was produced by the heap-spill path in `claim()`
+        // (it is not in the inline hive) and the caller has since fully
+        // initialized it. `destroy` reconstructs the `Box<T>` and runs
+        // `T::drop`.
         unsafe { bun_core::heap::destroy(value) };
     }
 }
@@ -935,7 +1000,6 @@ impl<T, const CAP: usize> Drop for HiveRefHandle<T, CAP> {
 }
 
 #[cfg(test)]
-#[allow(deprecated)]
 mod tests {
     use super::*;
 
@@ -950,37 +1014,33 @@ mod tests {
         let a = HiveArray::<Int, SIZE>::init();
 
         {
-            let b = a.get().unwrap();
-            // SAFETY: `b` points into `a.buffer` and was just unpoisoned by `get()`.
-            unsafe { *b = 0 };
-            assert!(a.get().unwrap() != b);
+            let b = a.get_init(0).unwrap().as_ptr();
+            assert!(a.get_init(0).unwrap().as_ptr() != b);
             assert_eq!(a.index_of(b), Some(0));
             // SAFETY: `b` is a fully-initialized hive slot.
             assert!(unsafe { a.put(b) });
-            assert!(a.get().unwrap() == b);
-            let c = a.get().unwrap();
-            // SAFETY: `c` points into `a.buffer` and was just unpoisoned by `get()`.
-            unsafe { *c = 123 };
+            assert!(a.get_init(0).unwrap().as_ptr() == b);
+            let _c = a.get_init(123).unwrap().as_ptr();
             let mut d: Int = 12345;
             // SAFETY: `&mut d` is foreign — `put` returns `false` and drops nothing.
             assert!(unsafe { a.put(&mut d) } == false);
             assert!(a.r#in(&d) == false);
         }
 
+        // `Int` has no drop glue, so resetting the bitset directly is a safe
+        // way to release every slot at once without `put`-ing them one by one.
         let mut a = a;
         a.used = HiveBitSet::init_empty();
         {
             for i in 0..SIZE {
-                let b = a.get().unwrap();
-                // SAFETY: `b` points into `a.buffer` and was just unpoisoned by `get()`.
-                unsafe { *b = 0 };
+                let b = a.get_init(0).unwrap().as_ptr();
                 assert_eq!(a.index_of(b), Some(u32::try_from(i).expect("int cast")));
                 // SAFETY: `b` is a fully-initialized hive slot.
                 assert!(unsafe { a.put(b) });
-                assert!(a.get().unwrap() == b);
+                assert!(a.get_init(0).unwrap().as_ptr() == b);
             }
             for _ in 0..SIZE {
-                assert!(a.get().is_none());
+                assert!(a.claim().is_none());
             }
         }
     }
@@ -1184,43 +1244,6 @@ mod tests {
         // SAFETY: `inline` is a live initialized slot from `f`.
         unsafe { f.put(inline.as_ptr()) };
         assert!(!f.hive.used.is_set(0));
-    }
-
-    #[test]
-    fn fallback_deprecated_get_apis() {
-        const CAP: usize = 1;
-        let f = Fallback::<u64, CAP>::init();
-
-        // get() / try_get(): inline first, heap after the hive fills.
-        let p0 = f.get();
-        assert!(f.r#in(p0));
-        let p1 = f.try_get();
-        assert!(!f.r#in(p1));
-        // SAFETY: caller owns the uninitialized slots and writes before reading.
-        unsafe {
-            p0.write(11);
-            p1.write(22);
-            assert_eq!(*p0, 11);
-            assert_eq!(*p1, 22);
-            f.put(p0);
-            f.put(p1);
-        }
-
-        // get_and_see_if_new(): caller pre-inits to true; flipped false on
-        // an inline (recycled) hit, left true when a fresh heap box is made.
-        let mut new = true;
-        let p0 = f.get_and_see_if_new(&mut new);
-        assert!(!new);
-        let mut new = true;
-        let p1 = f.get_and_see_if_new(&mut new);
-        assert!(new);
-        // SAFETY: same as above.
-        unsafe {
-            p0.write(33);
-            p1.write(44);
-            f.put_raw(p0);
-            f.put_raw(p1);
-        }
     }
 
     #[test]
@@ -1486,6 +1509,42 @@ mod tests {
         // SAFETY: stale/OOB indices are caught at runtime — `None`, not UB.
         assert!(unsafe { pool.box_at(i0) }.is_none());
         assert!(unsafe { pool.box_at(999) }.is_none());
+    }
+
+    #[test]
+    fn hive_owned_lifecycle() {
+        let mut f = Fallback::<u64, 4>::init();
+
+        // get_owned: claim + write + lifetime-erase in one shot.
+        let mut owned = f.get_owned(7u64);
+        assert!(f.hive.used.is_set(0));
+        // SAFETY: `get_owned` initialized the slot; not yet recycled.
+        assert_eq!(unsafe { *owned.as_ref() }, 7);
+        // SAFETY: same slot, sole `HiveOwned`, not recycled.
+        unsafe { *owned.as_mut() = 9 };
+
+        // Move it (compile-time check that it's not implicitly `Copy`).
+        let moved = owned;
+        // SAFETY: still initialized, slot still claimed.
+        assert_eq!(unsafe { *moved.as_ref() }, 9);
+
+        // No `Drop` on `HiveOwned` — recycle through the explicit put().
+        // SAFETY: slot is fully initialized; `as_ptr()` is the pool address.
+        unsafe { f.put(moved.as_ptr()) };
+        assert!(!f.hive.used.is_set(0));
+
+        // claim → into_owned → placement-init → as_ref: the deferred-init path.
+        let slot = f.claim();
+        // SAFETY: slot will be initialized through `as_ptr()` before any deref.
+        let owned = unsafe { slot.into_owned() };
+        assert!(f.hive.used.is_set(0));
+        // SAFETY: `owned` points at a freshly claimed inline slot.
+        unsafe { owned.as_ptr().write(42) };
+        // SAFETY: just initialized, slot still claimed.
+        assert_eq!(unsafe { *owned.as_ref() }, 42);
+        // SAFETY: slot is fully initialized.
+        unsafe { f.put(owned.as_ptr()) };
+        assert!(!f.hive.used.is_set(0));
     }
 }
 

--- a/src/collections/lib.rs
+++ b/src/collections/lib.rs
@@ -41,7 +41,7 @@ pub use static_hash_map::StaticHashMap;
 
 pub use bounded_array::BoundedArray;
 pub use hive_array::{
-    Fallback as HiveArrayFallback, HiveArray, HiveBox, HiveRef, HiveRefHandle, HiveSlot,
+    Fallback as HiveArrayFallback, HiveArray, HiveBox, HiveOwned, HiveRef, HiveRefHandle, HiveSlot,
 };
 pub use linear_fifo::{LinearFifo, LinearFifoBufferType};
 pub use multi_array_list::MultiArrayList;

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -48,7 +48,7 @@ pub struct NetworkTask {
     //
     // PORT NOTE: `MaybeUninit` because the slot comes from `HiveArrayFallback`
     // as *uninitialized* memory (often zero-page on first mmap, but not
-    // guaranteed — `get()`'s heap fallback is `Box::new_uninit()`) and is
+    // guaranteed — `claim()`'s heap fallback is `Box::new_uninit()`) and is
     // overwritten by plain `=` in `for_manifest`/`for_tarball`. Zig has no
     // destructors so the `= undefined` field was simply overwritten;
     // `MaybeUninit<T>` is the spec-correct mapping for that semantic — unlike
@@ -87,10 +87,9 @@ pub struct NetworkTask {
     pub tarball_stream: Option<Box<TarballStream>>,
     /// Extract `Task` pre-created on the main thread so the HTTP thread can
     /// schedule it on the worker pool as soon as the first body chunk arrives.
-    // PORT NOTE: `'static` matches `PreallocatedTaskStore =
-    // HiveArrayFallback<Task<'static>, 64>` which this slot is borrowed from
-    // and returned to (`discard_unused_streaming_state`).
-    pub streaming_extract_task: *mut Task<'static>,
+    /// Pool slot borrowed from `PreallocatedTaskStore` and returned to it
+    /// (`discard_unused_streaming_state`).
+    pub streaming_extract_task: *mut Task,
     /// Set by the HTTP thread the first time it commits this request to
     /// the streaming path. Once true, `notify` never pushes this task to
     /// `async_network_task_queue` — the extract Task published by
@@ -858,9 +857,9 @@ impl NetworkTask {
         if !self.streaming_extract_task.is_null() {
             // ARENA: returned to `preallocated_resolve_tasks` pool, not freed.
             // SAFETY: `streaming_extract_task` was obtained from this same
-            // `preallocated_resolve_tasks` pool via `get()` and is not aliased
-            // (cleared immediately below); `put()` runs `Task::drop` on the
-            // slot — the Task was fully initialized via
+            // `preallocated_resolve_tasks` pool via `get_init()` and is not
+            // aliased (cleared immediately below); `put()` runs `Task::drop` on
+            // the slot — the Task was fully initialized via
             // `enqueue::create_extract_task_for_streaming` so this is sound.
             unsafe {
                 manager
@@ -886,11 +885,11 @@ impl NetworkTask {
     /// `network_task.* = .{ .task_id = …, .callback = undefined, .allocator = …,
     /// .package_manager = …, .apply_patch_task = … }` — a full struct overwrite
     /// that resets every other field to its struct default. The slot may be
-    /// uninitialized heap memory (from `HiveArrayFallback::get()`'s
-    /// `Box::new_uninit()` fallback) or stale (reused hive slot whose prior
-    /// contents ARE now dropped on `put` since 1e76047), so each field is
-    /// written via `addr_of_mut!().write()` without dropping the previous
-    /// value — the slot is freshly poisoned/uninit from `get()`.
+    /// uninitialized heap memory (`HiveArrayFallback::claim()` spills to a
+    /// `Box::new_uninit()` allocation when the inline hive is full) or stale
+    /// (reused hive slot whose prior contents ARE now dropped on `put` since
+    /// 1e76047), so each field is written via `addr_of_mut!().write()` without
+    /// dropping the previous value — the slot is freshly poisoned/uninit.
     ///
     /// Fields that are `= undefined` in Zig (`unsafe_http_client`, `callback`,
     /// `request_buffer`, `response_buffer`) are written here with drop-safe
@@ -902,8 +901,9 @@ impl NetworkTask {
     ///
     /// # Safety
     /// `slot` must be the unique handle to a `HiveArrayFallback<NetworkTask>`
-    /// slot returned by `get()`; its prior contents are treated as garbage
-    /// (matches Zig — no destructors run).
+    /// slot freshly vended by `claim()` (typically wrapped in a `HiveOwned`);
+    /// its prior contents are treated as garbage (matches Zig — no destructors
+    /// run).
     pub unsafe fn write_init(
         slot: *mut NetworkTask,
         task_id: crate::package_manager_task::Id,

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -317,9 +317,9 @@ pub type TaskCallbackList = Vec<TaskCallbackContext>;
 pub type TaskDependencyQueue =
     HashMap<Task::Id, TaskCallbackList /* , IdentityContext<Task::Id>, 80 */>;
 
-type PreallocatedTaskStore = HiveArrayFallback<Task::Task<'static>, 64>;
+type PreallocatedTaskStore = HiveArrayFallback<Task::Task, 64>;
 type PreallocatedNetworkTasks = HiveArrayFallback<NetworkTask, 128>;
-type ResolveTaskQueue = UnboundedQueue<Task::Task<'static> /* , .next */>;
+type ResolveTaskQueue = UnboundedQueue<Task::Task /* , .next */>;
 
 type RepositoryMap = HashMap<Task::Id, Fd /* , IdentityContext<Task::Id>, 80 */>;
 /// Zig: `FolderResolution.Map` (resolvers/folder_resolver.zig) =

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1,9 +1,11 @@
 use crate::lockfile::package::PackageColumns as _;
 use bun_ptr::detach_lifetime;
 use core::mem::ManuallyDrop;
+use core::ptr::NonNull;
 use core::sync::atomic::Ordering;
 
 use crate::bun_fs::FileSystem;
+use bun_collections::HiveOwned;
 use bun_core::{Output, fmt as bun_fmt};
 use bun_core::{StringOrTinyString, strings};
 use bun_paths::{self as Path, PathBuffer};
@@ -252,7 +254,7 @@ pub fn enqueue_tarball_for_reading(
     }
 
     task_queue.value_ptr.push(task_context);
-    // PERF(port): was assume-capacity append via ArrayList — profile in Phase B
+    // PERF(port): was assume-capacity append via ArrayList — profile if hot.
 
     if task_queue.found_existing {
         return;
@@ -353,33 +355,31 @@ pub fn enqueue_parse_npm_package(
     this: &mut PackageManager,
     task_id: Task::Id,
     name: StringOrTinyString,
-    network_task: *mut NetworkTask,
+    network_task: HiveOwned<NetworkTask>,
 ) -> *mut ThreadPool::Task {
-    let task = this.preallocated_resolve_tasks.get();
-    // SAFETY: task is a freshly acquired slot from the preallocated pool; we own the write.
-    unsafe {
-        task.write(Task::Task {
-            package_manager: Some(bun_ptr::ParentRef::from_raw_mut(std::ptr::from_mut::<
-                PackageManager,
-            >(this))),
-            log: bun_ast::Log::init(),
-            tag: crate::package_manager_task::Tag::PackageManifest,
-            request: crate::package_manager_task::Request {
-                package_manifest: ManuallyDrop::new(
-                    crate::package_manager_task::PackageManifestRequest {
-                        // SAFETY: `network_task` is a freshly-vended pool slot; the
-                        // `'static` reborrow matches the `Task<'static>` slot lifetime.
-                        network: &mut *network_task,
-                        name,
-                    },
-                ),
-            },
-            id: task_id,
-            // TODO(port): `data: undefined` — Task::data left uninitialized in Zig
-            ..Task::uninit()
-        });
-        &raw mut (*task).threadpool_task
-    }
+    // Build the `Task` value first (uses `this` freely), then claim+init the
+    // pool slot. `value` owns no borrow of `this` — the back-pointer is a raw
+    // `*mut` — so `get_init`'s `&mut this.preallocated_resolve_tasks` does not
+    // conflict, and there is no uninitialized-slot window.
+    let value = Task::Task {
+        package_manager: Some(bun_ptr::ParentRef::from(NonNull::from(&mut *this))),
+        log: bun_ast::Log::init(),
+        tag: crate::package_manager_task::Tag::PackageManifest,
+        request: crate::package_manager_task::Request {
+            package_manifest: ManuallyDrop::new(
+                crate::package_manager_task::PackageManifestRequest {
+                    network: network_task,
+                    name,
+                },
+            ),
+        },
+        id: task_id,
+        // TODO(port): `data: undefined` — Task::data left uninitialized in Zig
+        ..Task::uninit()
+    };
+    let task = this.preallocated_resolve_tasks.get_init(value).as_ptr();
+    // SAFETY: `task` points at the freshly initialized pool slot.
+    unsafe { &raw mut (*task).threadpool_task }
 }
 
 pub fn enqueue_package_for_download(
@@ -608,7 +608,7 @@ pub fn enqueue_network_task(this: &mut PackageManager, task: *mut NetworkTask) {
         this.flush_network_queue();
     }
 
-    // PERF(port): was writeItemAssumeCapacity — profile in Phase B
+    // PERF(port): was writeItemAssumeCapacity — profile if hot.
     this.network_task_fifo.write_item_assume_capacity(task);
 }
 
@@ -624,7 +624,7 @@ pub fn enqueue_patch_task(this: &mut PackageManager, task: *mut PatchTask) {
         this.flush_patch_task_queue();
     }
 
-    // PERF(port): was writeItemAssumeCapacity — profile in Phase B
+    // PERF(port): was writeItemAssumeCapacity — profile if hot.
     this.patch_task_fifo.write_item_assume_capacity(task);
 }
 
@@ -643,7 +643,7 @@ pub fn enqueue_patch_task_pre(this: &mut PackageManager, task: *mut PatchTask) {
         this.flush_patch_task_queue();
     }
 
-    // PERF(port): was writeItemAssumeCapacity — profile in Phase B
+    // PERF(port): was writeItemAssumeCapacity — profile if hot.
     this.patch_task_fifo.write_item_assume_capacity(task);
     let _ = this.pending_pre_calc_hashes.fetch_add(1, Ordering::Relaxed);
 }
@@ -657,7 +657,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
     dependency: &Dependency,
     resolution: PackageID,
     install_peer: bool,
-    // PERF(port): was comptime monomorphization (successFn/failFn) — profile in Phase B
+    // PERF(port): was comptime monomorphization (successFn/failFn) — profile if hot.
     success_fn: SuccessFn,
     fail_fn: Option<FailFn>,
     // Zig: `comptime if (successFn == assignRootResolution)`. The Zig check is a
@@ -1159,18 +1159,19 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                 // `name_str` lifetime-detached above, `this`
                                 // is free to reborrow `&mut`.
                                 let network_task = this.get_network_task();
+                                let net_ptr = network_task.as_ptr();
                                 // SAFETY: `network_task` is the unique handle to a
                                 // freshly-vended pool slot. Zig's `network_task.* = .{ ... }`
                                 // resets every defaulted field; `write_init` mirrors that
                                 // (callback is `= undefined` and overwritten by `for_manifest`).
                                 unsafe {
-                                    NetworkTask::write_init(network_task, task_id, this_ptr, None);
+                                    NetworkTask::write_init(net_ptr, task_id, this_ptr, None);
                                 }
 
                                 let scope = this.scope_for_package_name(name_str);
-                                // SAFETY: network_task points to a valid initialized NetworkTask slot
+                                // SAFETY: `net_ptr` points to a valid initialized NetworkTask slot
                                 unsafe {
-                                    (*network_task).for_manifest(
+                                    (*net_ptr).for_manifest(
                                         name_str,
                                         scope,
                                         loaded_manifest.as_ref(),
@@ -1178,7 +1179,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                         needs_extended_manifest,
                                     )?;
                                 }
-                                enqueue_network_task(this, network_task);
+                                enqueue_network_task(this, net_ptr);
                             }
                         } else {
                             this.peer_dependencies.write_item(id)?;
@@ -1654,45 +1655,41 @@ pub fn enqueue_dependency_with_main_and_success_fn(
 fn init_extract_task(
     this: &mut PackageManager,
     tarball: &ExtractTarball,
-    network_task: *mut NetworkTask,
-) -> *mut Task::Task<'static> {
-    let task = this.preallocated_resolve_tasks.get();
-    // SAFETY: task is a freshly acquired uninitialized slot from the preallocated
-    // pool; we own the write. `ptr::write` (no drop of prior value) matches Zig's
-    // `task.* = Task{...}` semantics on uninit memory.
-    unsafe {
-        task.write(Task::Task {
-            package_manager: Some(bun_ptr::ParentRef::from_raw_mut(std::ptr::from_mut::<
-                PackageManager,
-            >(this))),
-            log: bun_ast::Log::init(),
-            tag: crate::package_manager_task::Tag::Extract,
-            request: crate::package_manager_task::Request {
-                extract: ManuallyDrop::new(crate::package_manager_task::ExtractRequest {
-                    // SAFETY: `network_task` is a freshly-vended pool slot; the
-                    // `'static` reborrow matches the `Task<'static>` slot lifetime.
-                    network: &mut *network_task,
-                    tarball: ExtractTarball {
-                        skip_verify: !this
-                            .options
-                            .do_
-                            .contains(crate::package_manager_real::options::Do::VERIFY_INTEGRITY),
-                        ..*tarball
-                    },
-                }),
-            },
-            id: (*network_task).task_id,
-            // TODO(port): `data: undefined`
-            ..Task::uninit()
-        });
-        task
-    }
+    network: HiveOwned<NetworkTask>,
+) -> *mut Task::Task {
+    // SAFETY: `network` is a freshly-vended `preallocated_network_tasks` pool
+    // slot; the slot is fully initialized and outlives this `Task`.
+    let task_id = unsafe { network.as_ref() }.task_id;
+    // Build the `Task` value first (uses `this` freely), then claim+init the
+    // pool slot — `value` owns no borrow of `this`, so `get_init`'s
+    // `&mut this.preallocated_resolve_tasks` does not conflict.
+    let value = Task::Task {
+        package_manager: Some(bun_ptr::ParentRef::from(NonNull::from(&mut *this))),
+        log: bun_ast::Log::init(),
+        tag: crate::package_manager_task::Tag::Extract,
+        request: crate::package_manager_task::Request {
+            extract: ManuallyDrop::new(crate::package_manager_task::ExtractRequest {
+                network,
+                tarball: ExtractTarball {
+                    skip_verify: !this
+                        .options
+                        .do_
+                        .contains(crate::package_manager_real::options::Do::VERIFY_INTEGRITY),
+                    ..*tarball
+                },
+            }),
+        },
+        id: task_id,
+        // TODO(port): `data: undefined`
+        ..Task::uninit()
+    };
+    this.preallocated_resolve_tasks.get_init(value).as_ptr()
 }
 
 pub fn enqueue_extract_npm_package(
     this: &mut PackageManager,
     tarball: &ExtractTarball,
-    network_task: *mut NetworkTask,
+    network_task: HiveOwned<NetworkTask>,
 ) -> *mut ThreadPool::Task {
     // SAFETY: init_extract_task returns a valid *mut Task
     unsafe { &raw mut (*init_extract_task(this, tarball, network_task)).threadpool_task }
@@ -1706,8 +1703,8 @@ pub fn enqueue_extract_npm_package(
 pub fn create_extract_task_for_streaming(
     this: &mut PackageManager,
     tarball: &ExtractTarball,
-    network_task: *mut NetworkTask,
-) -> *mut Task::Task<'static> {
+    network_task: HiveOwned<NetworkTask>,
+) -> *mut Task::Task {
     init_extract_task(this, tarball, network_task)
 }
 
@@ -1800,74 +1797,74 @@ pub fn enqueue_git_checkout(
     // if patched then we need to do apply step after network task is done
     patch_name_and_version_hash: Option<u64>,
 ) -> *mut ThreadPool::Task {
-    let task = this.preallocated_resolve_tasks.get();
-    // SAFETY: task is a freshly acquired uninitialized slot from the preallocated
-    // pool; we own the write. `ptr::write` (no drop of prior value) matches Zig's
-    // `task.* = Task{...}` semantics on uninit memory.
-    unsafe {
-        task.write(Task::Task {
-            package_manager: Some(bun_ptr::ParentRef::from_raw_mut(std::ptr::from_mut::<
-                PackageManager,
-            >(this))),
-            log: bun_ast::Log::init(),
-            tag: crate::package_manager_task::Tag::GitCheckout,
-            request: crate::package_manager_task::Request {
-                git_checkout: ManuallyDrop::new(crate::package_manager_task::GitCheckoutRequest {
-                    repo_dir: dir,
-                    resolution,
-                    dependency_id,
-                    name: StringOrTinyString::init_append_if_needed(
-                        name,
-                        &mut crate::network_task::filename_store_appender(),
-                    )
-                    .expect("unreachable"),
-                    url: StringOrTinyString::init_append_if_needed(
-                        // `resolution.tag == Git` for the git-checkout path.
-                        this.lockfile.str(&resolution.git().repo),
-                        &mut crate::network_task::filename_store_appender(),
-                    )
-                    .expect("unreachable"),
-                    resolved: StringOrTinyString::init_append_if_needed(
-                        resolved,
-                        &mut crate::network_task::filename_store_appender(),
-                    )
-                    .expect("unreachable"),
-                    env: crate::repository::SharedEnv::get(this.env_mut()),
-                }),
-            },
-            apply_patch_task: if let Some(h) = patch_name_and_version_hash {
-                let dep_name_hash =
-                    this.lockfile.buffers.dependencies[dependency_id as usize].name_hash;
-                let pkg_id = match this
-                    .lockfile
-                    .package_index
-                    .get(&dep_name_hash)
-                    .unwrap_or_else(|| panic!("Package not found"))
-                {
-                    PackageIndexEntry::Id(p) => *p,
-                    PackageIndexEntry::Ids(ps) => ps[0], // TODO is this correct
-                };
-                let patch_hash = this
-                    .lockfile
-                    .patched_dependencies
-                    .get(&h)
-                    .unwrap()
-                    .patchfile_hash()
-                    .unwrap();
-                let pt = PatchTask::new_apply_patch_hash(this, pkg_id, patch_hash, h);
-                // SAFETY: `pt` is fresh from `heap::alloc`; reclaim ownership.
-                let mut pt = bun_core::heap::take(pt);
-                pt.callback.apply_mut().task_id = Some(task_id);
-                Some(pt)
-            } else {
-                None
-            },
-            id: task_id,
-            // TODO(port): `data: undefined`
-            ..Task::uninit()
-        });
-        &raw mut (*task).threadpool_task
-    }
+    // Build the `Task` value first (uses `this` freely — `this.lockfile`,
+    // `this.env_mut()`, …), then claim+init the pool slot. `value` owns no
+    // borrow of `this` (back-pointer is a `ParentRef`, not a Rust borrow), so
+    // `get_init`'s `&mut this.preallocated_resolve_tasks` does not conflict.
+    // `..Task::uninit()` leaves `data` undefined per the Zig contract (written
+    // before read by the task callback).
+    let value = Task::Task {
+        package_manager: Some(bun_ptr::ParentRef::from(NonNull::from(&mut *this))),
+        log: bun_ast::Log::init(),
+        tag: crate::package_manager_task::Tag::GitCheckout,
+        request: crate::package_manager_task::Request {
+            git_checkout: ManuallyDrop::new(crate::package_manager_task::GitCheckoutRequest {
+                repo_dir: dir,
+                resolution,
+                dependency_id,
+                name: StringOrTinyString::init_append_if_needed(
+                    name,
+                    &mut crate::network_task::filename_store_appender(),
+                )
+                .expect("unreachable"),
+                url: StringOrTinyString::init_append_if_needed(
+                    // `resolution.tag == Git` for the git-checkout path.
+                    this.lockfile.str(&resolution.git().repo),
+                    &mut crate::network_task::filename_store_appender(),
+                )
+                .expect("unreachable"),
+                resolved: StringOrTinyString::init_append_if_needed(
+                    resolved,
+                    &mut crate::network_task::filename_store_appender(),
+                )
+                .expect("unreachable"),
+                env: crate::repository::SharedEnv::get(this.env_mut()),
+            }),
+        },
+        apply_patch_task: if let Some(h) = patch_name_and_version_hash {
+            let dep_name_hash =
+                this.lockfile.buffers.dependencies[dependency_id as usize].name_hash;
+            let pkg_id = match this
+                .lockfile
+                .package_index
+                .get(&dep_name_hash)
+                .unwrap_or_else(|| panic!("Package not found"))
+            {
+                PackageIndexEntry::Id(p) => *p,
+                PackageIndexEntry::Ids(ps) => ps[0], // TODO is this correct
+            };
+            let patch_hash = this
+                .lockfile
+                .patched_dependencies
+                .get(&h)
+                .unwrap()
+                .patchfile_hash()
+                .unwrap();
+            let pt = PatchTask::new_apply_patch_hash(this, pkg_id, patch_hash, h);
+            // SAFETY: `pt` is fresh from `heap::alloc`; reclaim ownership.
+            let mut pt = unsafe { bun_core::heap::take(pt) };
+            pt.callback.apply_mut().task_id = Some(task_id);
+            Some(pt)
+        } else {
+            None
+        },
+        id: task_id,
+        // TODO(port): `data: undefined`
+        ..Task::uninit()
+    };
+    let task = this.preallocated_resolve_tasks.get_init(value).as_ptr();
+    // SAFETY: `task` points at the freshly initialized pool slot.
+    unsafe { &raw mut (*task).threadpool_task }
 }
 
 fn enqueue_local_tarball(
@@ -2025,7 +2022,7 @@ fn get_or_put_resolved_package_with_find_result(
     manifest: &Npm::PackageManifest,
     find_result: Npm::FindResult,
     install_peer: bool,
-    // PERF(port): was comptime monomorphization — profile in Phase B
+    // PERF(port): was comptime monomorphization — profile if hot.
     success_fn: SuccessFn,
 ) -> Result<Option<ResolvedPackageResult>, bun_core::Error> {
     // TODO(port): narrow error set
@@ -2230,7 +2227,7 @@ fn get_or_put_resolved_package(
     dependency_id: DependencyID,
     resolution: PackageID,
     install_peer: bool,
-    // PERF(port): was comptime monomorphization — profile in Phase B
+    // PERF(port): was comptime monomorphization — profile if hot.
     success_fn: SuccessFn,
 ) -> Result<Option<ResolvedPackageResult>, bun_core::Error> {
     // TODO(port): narrow error set
@@ -2965,7 +2962,7 @@ impl PackageManager {
         &mut self,
         task_id: Task::Id,
         name: StringOrTinyString,
-        network_task: *mut NetworkTask,
+        network_task: HiveOwned<NetworkTask>,
     ) -> *mut ThreadPool::Task {
         enqueue_parse_npm_package(self, task_id, name, network_task)
     }
@@ -2974,7 +2971,7 @@ impl PackageManager {
     pub fn enqueue_extract_npm_package(
         &mut self,
         tarball: &ExtractTarball,
-        network_task: *mut NetworkTask,
+        network_task: HiveOwned<NetworkTask>,
     ) -> *mut ThreadPool::Task {
         enqueue_extract_npm_package(self, tarball, network_task)
     }
@@ -2983,8 +2980,8 @@ impl PackageManager {
     pub fn create_extract_task_for_streaming(
         &mut self,
         tarball: &ExtractTarball,
-        network_task: *mut NetworkTask,
-    ) -> *mut Task::Task<'static> {
+        network_task: HiveOwned<NetworkTask>,
+    ) -> *mut Task::Task {
         create_extract_task_for_streaming(self, tarball, network_task)
     }
 

--- a/src/install/PackageManager/PopulateManifestCache.rs
+++ b/src/install/PackageManager/PopulateManifestCache.rs
@@ -74,9 +74,10 @@ fn start_manifest_task(
     // TODO(port): lifetime — BACKREF.
     let manager_backref: *mut PackageManager = manager;
 
-    // Take the pool slot as a raw pointer so borrowck releases `manager` for the
-    // `enqueue_network_task` tail.
-    let net_ptr: *mut NetworkTask = run_tasks::get_network_task(manager);
+    // Take the pool slot as a sealed handle, then a raw pointer so borrowck
+    // releases `manager` for the `enqueue_network_task` tail.
+    let net_owned = run_tasks::get_network_task(manager);
+    let net_ptr: *mut NetworkTask = net_owned.as_ptr();
     // Zig: `task.* = .{ .package_manager = manager, .callback = undefined,
     //                   .task_id = task_id, .allocator = manager.allocator };`
     // — full struct overwrite that resets every other field to its struct

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -47,11 +47,11 @@ use crate::isolated_install::store as Store;
 // and branches on `@TypeOf(callbacks.onExtract) != void`, `Ctx == *PackageInstaller`,
 // etc. Rust models this as a single trait with associated consts gating the
 // optional hooks (default-unreachable bodies), plus associated-const tags for
-// the `Ctx` identity checks. Phase B should revisit whether the call sites can
+// the `Ctx` identity checks. TODO(refactor): revisit whether the call sites can
 // be split into 2–3 concrete impls instead of const-gated branches.
 //
 // TODO(port): callbacks trait — comptime duck-typing reshape; verify against
-// the three call sites (`PackageInstaller`, `Store.Installer`, void) in Phase B.
+// the three call sites (`PackageInstaller`, `Store.Installer`, void).
 pub trait RunTasksCallbacks {
     /// Mirrors `Ctx` (the `extract_ctx` value type).
     type Ctx;
@@ -346,11 +346,21 @@ pub fn run_tasks<C: RunTasksCallbacks>(
     let network_tasks_batch = manager.async_network_task_queue.pop_batch();
     let mut network_tasks_iter = network_tasks_batch.iterator();
     loop {
-        let task_ptr = network_tasks_iter.next();
-        if task_ptr.is_null() {
+        // SAFETY: the only producer for `async_network_task_queue` is
+        // `NetworkTask::notify` (HTTP-thread completion callback). Every node it
+        // pushes was vended from `manager.preallocated_network_tasks` at enqueue
+        // time and the `HiveOwned` token was relinquished at HTTP-schedule time;
+        // the slot stays claimed (not `put()`) until a later resolve-task pass.
+        // `next_owned()` re-seals exclusive ownership on the main thread.
+        let Some(task_owned) = (unsafe { network_tasks_iter.next_owned() }) else {
             break;
-        }
-        // SAFETY: `next()` returned non-null; node is exclusively owned by this batch.
+        };
+        // Raw alias for ergonomic field access while `task_owned` carries the
+        // ownership token. `HiveOwned` does not deref by itself, so `task` and
+        // `task_owned` are not Rust-level aliases; `task_owned` is moved into
+        // `Task.network` (or dropped, no-op) before the slot is touched again.
+        let task_ptr = task_owned.as_ptr();
+        // SAFETY: `task_owned` is the sole live handle to this pool slot.
         let task = unsafe { &mut *task_ptr };
         if cfg!(debug_assertions) {
             debug_assert!(manager.pending_task_count() > 0);
@@ -621,8 +631,14 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                 .expect("unreachable");
                 // PORT NOTE: reshaped for borrowck — split the nested `&mut
                 // manager` borrows (`task_batch.push` vs. `enqueue_*`).
-                let queued =
-                    enqueue::enqueue_parse_npm_package(manager, task.task_id, name_tiny, task_ptr);
+                // `task_owned` carries pool-slot ownership from the queue
+                // drain into `Task.network` — see `next_owned()` at loop top.
+                let queued = enqueue::enqueue_parse_npm_package(
+                    manager,
+                    task.task_id,
+                    name_tiny,
+                    task_owned,
+                );
                 manager.task_batch.push(ThreadPoolBatch::from(queued));
             }
             NetworkTaskCallback::Extract(extract) => {
@@ -908,7 +924,9 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                 }
 
                 // PORT NOTE: reshaped for borrowck — split nested `&mut manager`.
-                let queued = enqueue::enqueue_extract_npm_package(manager, &*extract, task_ptr);
+                // `task_owned` carries pool-slot ownership from the queue
+                // drain into `Task.network` — see `next_owned()` at loop top.
+                let queued = enqueue::enqueue_extract_npm_package(manager, &*extract, task_owned);
                 manager.task_batch.push(ThreadPoolBatch::from(queued));
             }
             _ => unreachable!(),
@@ -928,7 +946,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
         // Zig: `defer manager.preallocated_resolve_tasks.put(task);`
         // PORT NOTE: raw-ptr capture — borrowck would reject overlapping `&mut`
         // with the loop body. Guard runs on every `continue`/`?`/fallthrough.
-        // Phase B: have the iterator yield a pool guard that puts back on Drop.
+        // TODO(refactor): have the iterator yield a pool guard that puts back on Drop.
         // SAFETY: `task_ptr` non-null per loop guard; node exclusively owned by this batch.
         let task = unsafe { &mut *task_ptr };
         // The per-iteration scopeguards capture the function-scope provenance
@@ -959,13 +977,9 @@ pub fn run_tasks<C: RunTasksCallbacks>(
         match task.tag {
             Task::Tag::PackageManifest => {
                 // Zig: `defer manager.preallocated_network_tasks.put(task.request.package_manifest.network);`
-                // PORT NOTE: capture the `*mut NetworkTask` up front — the
-                // `&'a mut NetworkTask` field can't be moved out through
-                // `ManuallyDrop`'s immutable `Deref` inside the defer body.
-                let net_ptr: *mut NetworkTask = {
-                    let req = task.request_package_manifest_mut();
-                    &raw mut *req.network
-                };
+                // Capture the pool-slot pointer up front so the `defer!` body
+                // doesn't need to project through the union.
+                let net_ptr: *mut NetworkTask = task.request_package_manifest().network.as_ptr();
                 scopeguard::defer! {
                     // SAFETY: see the put-task `defer!` above — `manager_ptr` is the
                     // function-scope provenance root; `net_ptr` is the network task
@@ -990,8 +1004,9 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             extract_ctx,
                             name,
                             err,
-                            // SAFETY: same active-arm read as `req` above.
-                            unsafe { &(*req.network).url_buf },
+                            // SAFETY: same active-arm read as `req` above;
+                            // `network` is a live pool slot (see `defer!`).
+                            unsafe { &req.network.as_ref().url_buf },
                         );
                     } else {
                         bun_ast::add_error_pretty!(
@@ -1040,12 +1055,10 @@ pub fn run_tasks<C: RunTasksCallbacks>(
             }
             Task::Tag::Extract | Task::Tag::LocalTarball => {
                 // Zig: `defer { switch (task.tag) { .extract => preallocated_network_tasks.put(...), else => {} } }`
-                // PORT NOTE: capture the `*mut NetworkTask` up front (only for the
-                // Extract arm) so the defer body need not move the `&mut` out
-                // through `ManuallyDrop`'s immutable `Deref`.
+                // Capture the pool-slot pointer up front (only for the Extract
+                // arm) so the `defer!` body doesn't need to project through the union.
                 let net_ptr: *mut NetworkTask = if task.tag == Task::Tag::Extract {
-                    let req = task.request_extract_mut();
-                    &raw mut *req.network
+                    task.request_extract().network.as_ptr()
                 } else {
                     core::ptr::null_mut()
                 };
@@ -1094,7 +1107,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         // SAFETY: `task.tag` selects the active union arm.
                         let fail_url: &[u8] = match task.tag {
                             Task::Tag::Extract => unsafe {
-                                &(*task.request.extract.network).url_buf
+                                &task.request.extract.network.as_ref().url_buf
                             },
                             Task::Tag::LocalTarball => unsafe {
                                 task.request.local_tarball.tarball.url.slice()
@@ -1704,8 +1717,17 @@ pub fn drain_dependency_list(this: &mut PackageManager) {
     let _ = schedule_tasks(this);
 }
 
-pub fn get_network_task(this: &mut PackageManager) -> *mut NetworkTask {
-    this.preallocated_network_tasks.get()
+// Vends an *uninitialized* pool slot as a sealed [`HiveOwned`] handle. Callers
+// placement-init it via `NetworkTask::write_init(handle.as_ptr(), …)` before
+// any deref (args differ per caller, so the init cannot be hoisted here).
+// `into_owned` consumes the `HiveSlot` token so its `Drop` does not recycle the
+// slot — it stays claimed and is returned to the pool later via the existing
+// `NetworkTask` `put` path, exactly as before.
+pub fn get_network_task(this: &mut PackageManager) -> bun_collections::HiveOwned<NetworkTask> {
+    let slot = this.preallocated_network_tasks.claim();
+    // SAFETY: callers placement-init via `NetworkTask::write_init` before any
+    // call to `as_ref`/`as_mut` on the returned handle (see `into_owned` docs).
+    unsafe { slot.into_owned() }
 }
 
 pub fn alloc_github_url(this: &PackageManager, repository: &Repository) -> Vec<u8> {
@@ -1808,15 +1830,18 @@ pub fn generate_network_task_for_tarball<'a>(
     // back-pointer (TODO(port): lifetime — BACKREF).
     let this_backref: *mut PackageManager = this;
 
-    // Take the pool slot as a raw pointer so borrowck releases `this` for the
-    // streaming-setup tail. Reborrowed `&mut` per-statement below.
-    let net_ptr: *mut NetworkTask = get_network_task(this);
+    // Take the pool slot as a sealed handle, then a raw pointer so borrowck
+    // releases `this` for the streaming-setup tail. Reborrowed `&mut`
+    // per-statement below.
+    let net_owned = get_network_task(this);
+    let net_ptr: *mut NetworkTask = net_owned.as_ptr();
     // Zig: `network_task.* = .{ .task_id, .callback = undefined, .allocator,
     // .package_manager, .apply_patch_task }` — full struct overwrite that resets
     // every other field (`retried`, `response`, `streaming_committed`,
     // `tarball_stream`, `streaming_extract_task`, `next`, `url_buf`,
     // `signal_store`) to its struct default. The slot may be uninitialized
-    // (`HiveArrayFallback::get()` heap fallback) or stale (reused hive slot).
+    // (`HiveArrayFallback::claim()` heap-spilled a `Box::new_uninit()` slot
+    // when the inline hive was full) or stale (reused hive slot).
     // SAFETY: `net_ptr` is the unique handle to a freshly-vended pool slot; no
     // other alias exists until we return it.
     unsafe { NetworkTask::write_init(net_ptr, task_id, this_backref, apply_patch_task) };
@@ -1866,8 +1891,8 @@ pub fn generate_network_task_for_tarball<'a>(
         // every other `this` field these calls touch (resolve-task pool,
         // allocator, options) and the network-task pool is never reallocated
         // or `put()` here, so we reborrow `*net_ptr` per-statement alongside
-        // `this`. Phase B: have `get_network_task` return a pool index so this
-        // intrusive-pointer pattern goes away.
+        // `this`. TODO(refactor): have `get_network_task` return a pool index
+        // so this intrusive-pointer pattern goes away.
         // SAFETY: see disjointness note above.
         let tarball_ref = unsafe {
             let NetworkTaskCallback::Extract(t) = &(*net_ptr).callback else {
@@ -1875,7 +1900,12 @@ pub fn generate_network_task_for_tarball<'a>(
             };
             t
         };
-        let extract_task = enqueue::create_extract_task_for_streaming(this, tarball_ref, net_ptr);
+        // `create_extract_task_for_streaming` consumes the `HiveOwned` (it is
+        // moved into `Task.network`); the streaming-state writes below go
+        // through the `net_ptr` raw alias, which stays valid (the slot is not
+        // recycled here). This is the documented "secondary use through
+        // `as_ptr()`" pattern — exactly one `HiveOwned` exists.
+        let extract_task = enqueue::create_extract_task_for_streaming(this, tarball_ref, net_owned);
         unsafe {
             (*net_ptr).streaming_extract_task = extract_task;
             (*net_ptr).tarball_stream = Some(bun_core::heap::take(TarballStream::init(
@@ -1925,7 +1955,7 @@ impl PackageManager {
         is_network_task_required(self, task_id)
     }
     #[inline]
-    pub fn get_network_task(&mut self) -> *mut NetworkTask {
+    pub fn get_network_task(&mut self) -> bun_collections::HiveOwned<NetworkTask> {
         get_network_task(self)
     }
     #[inline]

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -4,6 +4,7 @@
 use core::mem::ManuallyDrop;
 
 use bun_ast::{Loc, Log};
+use bun_collections::HiveOwned;
 use bun_core::Output;
 use bun_core::StringOrTinyString;
 use bun_semver as semver;
@@ -20,14 +21,9 @@ use crate::{
 use bun_dotenv as dot_env;
 
 /// File-level struct in Zig (`@This()` == `Task`).
-///
-/// `'a` is forced by LIFETIMES.tsv (BORROW_PARAM on `Request::*.network`).
-/// // TODO(port): lifetime — Task lives in an intrusive cross-thread queue
-/// (`next`, `package_manager` BACKREF). A `&'a mut NetworkTask` cannot soundly
-/// cross that boundary; Phase B should likely demote to `*mut NetworkTask`.
-pub struct Task<'a> {
+pub struct Task {
     pub tag: Tag,
-    pub request: Request<'a>,
+    pub request: Request,
     pub data: Data,
     /// default: `Status::Waiting`
     pub status: Status,
@@ -44,7 +40,7 @@ pub struct Task<'a> {
     pub apply_patch_task: Option<Box<PatchTask>>,
     /// INTRUSIVE — `bun.UnboundedQueue(Task, .next)`
     /// default: null
-    pub next: bun_threading::Link<Task<'a>>,
+    pub next: bun_threading::Link<Task>,
 }
 
 /// Zig: struct field defaults (`status = .waiting`, `threadpool_task = .{ .callback = &callback }`,
@@ -53,7 +49,7 @@ pub struct Task<'a> {
 /// the task is observed. Exposed as a module-level fn so call sites that import this
 /// module as `Task` can write `..Task::uninit()` in struct-update position.
 #[inline]
-pub fn uninit() -> Task<'static> {
+pub fn uninit() -> Task {
     Task {
         // Overwritten by every caller; zero/garbage matches Zig `undefined`.
         // SAFETY: untagged unions of `ManuallyDrop<_>` — any bit pattern is
@@ -83,7 +79,7 @@ pub fn uninit() -> Task<'static> {
 
 // SAFETY: `next` is the sole intrusive link for `UnboundedQueue<Task>`;
 // `link()` always projects to it. Mirrors Zig's `@field(item, "next")`.
-unsafe impl<'a> bun_threading::Linked for Task<'a> {
+unsafe impl bun_threading::Linked for Task {
     #[inline]
     unsafe fn link(item: *mut Self) -> *const bun_threading::Link<Self> {
         // SAFETY: `item` is valid and properly aligned per `UnboundedQueue` contract.
@@ -165,7 +161,7 @@ impl Id {
     }
 }
 
-impl<'a> Task<'a> {
+impl Task {
     // ── Tag-checked projectors for the untagged `Request`/`Data` unions ────
     // `Task.tag` is the single discriminant for both; every variant payload is
     // POD or `ManuallyDrop`-wrapped (no drop on overwrite), so reading the
@@ -173,11 +169,11 @@ impl<'a> Task<'a> {
     // `as *const $Ty` cast unwraps `ManuallyDrop<$Ty>` (`repr(transparent)`).
     bun_core::extern_union_accessors! {
         tag: tag as Tag, value: request;
-        PackageManifest => request_package_manifest @ package_manifest: PackageManifestRequest<'a>, mut request_package_manifest_mut;
-        Extract         => request_extract          @ extract:          ExtractRequest<'a>,         mut request_extract_mut;
-        GitClone        => request_git_clone        @ git_clone:        GitCloneRequest,            mut request_git_clone_mut;
-        GitCheckout     => request_git_checkout     @ git_checkout:     GitCheckoutRequest,         mut request_git_checkout_mut;
-        LocalTarball    => request_local_tarball    @ local_tarball:    LocalTarballRequest,        mut request_local_tarball_mut;
+        PackageManifest => request_package_manifest @ package_manifest: PackageManifestRequest, mut request_package_manifest_mut;
+        Extract         => request_extract          @ extract:          ExtractRequest,         mut request_extract_mut;
+        GitClone        => request_git_clone        @ git_clone:        GitCloneRequest,        mut request_git_clone_mut;
+        GitCheckout     => request_git_checkout     @ git_checkout:     GitCheckoutRequest,     mut request_git_checkout_mut;
+        LocalTarball    => request_local_tarball    @ local_tarball:    LocalTarballRequest,    mut request_local_tarball_mut;
     }
 
     bun_core::extern_union_accessors! {
@@ -209,15 +205,15 @@ impl<'a> Task<'a> {
     }
 }
 
-impl<'a> Task<'a> {
+impl Task {
     pub fn callback(task: *mut thread_pool::Task) {
         Output::Source::configure_thread();
 
         // SAFETY: `task` points to the `threadpool_task` field of a `Task`
         // (this is the only place this `thread_pool::Task` callback is registered).
-        let this: *mut Task<'a> = unsafe { bun_core::from_field_ptr!(Task, threadpool_task, task) };
+        let this: *mut Task = unsafe { bun_core::from_field_ptr!(Task, threadpool_task, task) };
         // SAFETY: exclusive access — task runs on exactly one worker thread
-        let this: &mut Task<'a> = unsafe { &mut *this };
+        let this: &mut Task = unsafe { &mut *this };
         // BACKREF (LIFETIMES.tsv:598) — `package_manager` outlives every task it
         // owns. The `ParentRef` is `Copy` and gives safe `Deref` for the
         // shared-read sites below; `manager` is kept as a raw `*mut` for the
@@ -244,7 +240,12 @@ impl<'a> Task<'a> {
                     // PORT NOTE: split-borrow `manifest.network` so the mutable
                     // `response_buffer` borrow doesn't overlap the immutable
                     // `response`/`callback` reads below.
-                    let network = &mut *manifest.network;
+                    // SAFETY: `network` is a `preallocated_network_tasks` pool
+                    // slot owned exclusively by this resolve task until the
+                    // run-tasks loop returns it (`put()` in the `defer!` blocks
+                    // in runTasks.rs); the pool outlives the task. Single
+                    // accessor while the task runs on the worker thread.
+                    let network = unsafe { manifest.network.as_mut() };
                     // Zig: `defer body.deinit()` — take ownership so the
                     // multi-MB manifest buffer drops on every exit of this arm
                     // instead of staying live on the NetworkTask until recycle.
@@ -362,7 +363,10 @@ impl<'a> Task<'a> {
                     let extract = unsafe { &mut *this.request.extract };
                     // Zig: `defer buffer.deinit()` — take ownership so the
                     // tarball body drops on every exit of this arm.
-                    let mut buffer = core::mem::take(&mut extract.network.response_buffer);
+                    // SAFETY: see `manifest.network` note above — pool-owned
+                    // `NetworkTask` slot, sole accessor while this task runs.
+                    let mut buffer =
+                        core::mem::take(&mut unsafe { extract.network.as_mut() }.response_buffer);
 
                     let result = match extract.tarball.run(&mut this.log, buffer.slice()) {
                         Ok(v) => v,
@@ -550,14 +554,10 @@ impl<'a> Task<'a> {
                 }
             }
         }
-        // SAFETY: `Task<'a>` is layout-identical for all `'a` (the lifetime is
-        // a phantom on `&mut NetworkTask` borrows that the queue never reads
-        // through); erasing to `'static` matches Zig's lifetime-less queue.
-        // `UnboundedQueue::push` takes `&self` (lock-free), so reach it via a
-        // shared raw deref — no `&mut PackageManager` is formed.
+        // SAFETY: `UnboundedQueue::push` takes `&self` (lock-free), so reach it
+        // via a shared raw deref — no `&mut PackageManager` is formed.
         unsafe {
-            (*core::ptr::addr_of!((*manager).resolve_tasks))
-                .push(std::ptr::from_mut::<Task<'a>>(this).cast::<Task<'static>>());
+            (*core::ptr::addr_of!((*manager).resolve_tasks)).push(std::ptr::from_mut::<Task>(this));
             PackageManager::wake_raw(manager);
         }
 
@@ -630,27 +630,30 @@ pub union Data {
 }
 
 /// Bare Zig `union` (untagged). Discriminated externally by `Task.tag`.
-pub union Request<'a> {
+pub union Request {
     /// package name
     // todo: Registry URL
-    pub package_manifest: ManuallyDrop<PackageManifestRequest<'a>>,
-    pub extract: ManuallyDrop<ExtractRequest<'a>>,
+    pub package_manifest: ManuallyDrop<PackageManifestRequest>,
+    pub extract: ManuallyDrop<ExtractRequest>,
     pub git_clone: ManuallyDrop<GitCloneRequest>,
     pub git_checkout: ManuallyDrop<GitCheckoutRequest>,
     pub local_tarball: ManuallyDrop<LocalTarballRequest>,
 }
 
-pub struct PackageManifestRequest<'a> {
+pub struct PackageManifestRequest {
     pub name: StringOrTinyString,
-    // BORROW_PARAM per LIFETIMES.tsv
-    // TODO(port): lifetime — see note on `Task<'a>`; likely `*mut NetworkTask` in Phase B.
-    pub network: &'a mut NetworkTask,
+    /// `PackageManager.preallocated_network_tasks` pool slot vended at enqueue
+    /// time and returned to the pool after this task is processed. Outlives the
+    /// `Task` by pool contract — Zig: `*NetworkTask`. `HiveOwned` is sealed and
+    /// move-only, so safe code cannot construct this from a dangling pointer or
+    /// alias it across two `Task`s; use-after-`put` remains an `unsafe`
+    /// contract on the deref methods.
+    pub network: HiveOwned<NetworkTask>,
 }
 
-pub struct ExtractRequest<'a> {
-    // BORROW_PARAM per LIFETIMES.tsv
-    // TODO(port): lifetime — see note on `Task<'a>`; likely `*mut NetworkTask` in Phase B.
-    pub network: &'a mut NetworkTask,
+pub struct ExtractRequest {
+    /// See `PackageManifestRequest::network` — same pool-slot contract.
+    pub network: HiveOwned<NetworkTask>,
     pub tarball: ExtractTarball,
 }
 

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -37,9 +37,7 @@ use crate::integrity::{self, Integrity};
 use crate::package_manager_real::PackageManager;
 
 // `crate::Task` is a `()` stub; the real Task lives in `package_manager_task`.
-// `'static` is sound here because we only ever hold raw `*mut Task` and never
-// materialise a `&'static` borrow of the inner `Request` lifetime.
-type Task = crate::package_manager_task::Task<'static>;
+type Task = crate::package_manager_task::Task;
 
 bun_output::declare_scope!(TarballStream, hidden);
 
@@ -968,7 +966,8 @@ impl TarballStream {
             // leaves `tarball_stream = None` so `HiveArray::put`'s
             // `drop_in_place<NetworkTask>` (1e76047) does not double-free a
             // dangling Box. Before 1e76047 the dangling `Some` was harmless
-            // (overwritten on next `get()`); now it use-after-frees.
+            // (overwritten the next time the slot was vended from the pool);
+            // now it use-after-frees.
             debug_assert!(
                 (*network).tarball_stream.as_deref().map(|s| s as *const _)
                     == Some(this as *const _),

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -350,7 +350,7 @@ pub type PackageManagerEnableStub = package_manager_real::package_manager_option
 pub type PublishConfigStub = package_manager_real::package_manager_options::PublishConfig;
 pub type AsyncNetworkTaskQueueStub = package_manager_real::AsyncNetworkTaskQueue;
 pub type PreallocatedResolveTasksStub =
-    bun_collections::HiveArrayFallback<package_manager_task::Task<'static>, 64>;
+    bun_collections::HiveArrayFallback<package_manager_task::Task, 64>;
 pub use package_manager_real::package_manager_options::{Access, AuthType};
 
 /// Port of the anonymous `comptime callbacks: anytype` struct passed to

--- a/src/io/windows_event_loop.rs
+++ b/src/io/windows_event_loop.rs
@@ -88,20 +88,16 @@ impl FilePoll {
         flags: FlagsStruct,
         owner: Owner,
     ) -> *mut FilePoll {
+        // Build the value, then claim+init the slot in one shot — no
+        // uninitialized-slot window (mirrors the posix `Store::get_init` path).
+        let value = FilePoll {
+            fd,
+            flags,
+            owner,
+            next_to_free: ptr::null_mut(),
+        };
         // Crate-private backref-deref accessor — single live `&mut Store` borrow.
-        let poll = vm.file_polls_mut().get();
-        // SAFETY: `get()` returns a valid, uniquely-owned, *uninitialized* slot from the
-        // HiveArray pool. We must not materialize `&mut FilePoll` (validity invariant
-        // requires initialized memory); write the whole value through the raw pointer.
-        unsafe {
-            poll.write(FilePoll {
-                fd,
-                flags,
-                owner,
-                next_to_free: ptr::null_mut(),
-            });
-        }
-        poll
+        vm.file_polls_mut().get_init(value).as_ptr()
     }
 
     // PORT NOTE: not `impl Drop` — FilePoll lives in a HiveArray pool slot, not a Box;
@@ -289,8 +285,8 @@ impl Store {
         }
     }
 
-    pub fn get(&mut self) -> *mut FilePoll {
-        self.hive.get()
+    pub fn get_init(&mut self, value: FilePoll) -> ptr::NonNull<FilePoll> {
+        self.hive.get_init(value)
     }
 
     pub fn process_deferred_frees(&mut self) {

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -22,7 +22,7 @@ use enum_map::EnumMap;
 /// arena) or duped into the renamer's `bumpalo::Bump` arena. `StoreStr` is the
 /// arena-backed lifetime-erased slice wrapper that centralises the raw deref
 /// (one `unsafe` in `StoreStr::slice`), so the renamer's name-table reads stay
-/// safe. Phase B may later thread `'bump` and rewrite to `&'bump [u8]`.
+/// safe. TODO(refactor): could thread `'bump` and rewrite to `&'bump [u8]`.
 type NameStr = bun_ast::StoreStr;
 
 #[inline]
@@ -754,20 +754,19 @@ impl NumberRenamer {
         parent: Option<bun_ptr::ParentRef<NumberScope>>,
         sorted: &mut Vec<u32>,
     ) {
-        let s: *mut NumberScope = self.number_scope_pool.get();
-        // SAFETY: `s` is a valid pool slot (HiveArrayFallback::get never returns null).
-        unsafe {
-            s.write(NumberScope {
+        let s: *mut NumberScope = self
+            .number_scope_pool
+            .get_init(NumberScope {
                 parent,
                 name_counts: NameCountMap::default(),
-            });
-        }
+            })
+            .as_ptr();
 
         self.assign_names_recursive_with_number_scope(s, scope, source_index, sorted);
 
         // PORT NOTE: Zig `defer { s.deinit(); pool.put(s) }` — fn is infallible,
         // so no scopeguard needed; cleanup runs unconditionally below.
-        // SAFETY: s came from number_scope_pool.get() and was initialized above;
+        // SAFETY: s came from number_scope_pool.get_init() (fully initialized);
         // `put` drops `name_counts` in place before recycling the slot.
         unsafe { self.number_scope_pool.put(s) };
     }
@@ -819,13 +818,12 @@ impl NumberRenamer {
         loop {
             let symbol_count = scope.members.count() + scope.generated.len_u32() as usize;
             if symbol_count > 0 {
-                let new_child_scope: *mut NumberScope = self.number_scope_pool.get();
-                // SAFETY: `new_child_scope` is a valid pool slot.
-                unsafe {
-                    new_child_scope.write(NumberScope {
-                        // `s` is non-null (either `initial_scope` or a fresh
-                        // pool slot from a prior iteration); the new child
-                        // outlives this `ParentRef` only until `put()` below.
+                // `s` is non-null (either `initial_scope` or a fresh pool slot
+                // from a prior iteration); the new child outlives this
+                // `ParentRef` only until `put()` below.
+                let new_child_scope: *mut NumberScope = self
+                    .number_scope_pool
+                    .get_init(NumberScope {
                         parent: Some(bun_ptr::ParentRef::from(
                             core::ptr::NonNull::new(s).expect("number_scope non-null"),
                         )),
@@ -840,8 +838,8 @@ impl NumberRenamer {
                             symbol_count,
                             Default::default(),
                         ),
-                    });
-                }
+                    })
+                    .as_ptr();
                 s = new_child_scope;
 
                 // SAFETY: s is a valid pool slot just initialized above
@@ -876,8 +874,8 @@ impl NumberRenamer {
             let parent = unsafe { (*s).parent }
                 .map(|p| p.as_mut_ptr())
                 .unwrap_or(initial_scope);
-            // SAFETY: `s` came from `number_scope_pool.get()` in the loop above
-            // and was fully initialized; `put` drops `name_counts` in place
+            // SAFETY: `s` came from `number_scope_pool.get_init()` in the loop
+            // above (fully initialized); `put` drops `name_counts` in place
             // before recycling/freeing the slot.
             unsafe { self.number_scope_pool.put(s) };
             s = parent;

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -464,7 +464,7 @@ impl SettingsPayloadUnit {
 }
 
 // packed struct(u336) — 7 × (u16 type + u32 value) = 42 bytes
-// TODO(port): #[repr(C, packed)] for wire layout; verify byteSwapAllFields equivalence in Phase B
+// TODO(port): #[repr(C, packed)] for wire layout; verify byteSwapAllFields equivalence.
 #[repr(C, packed)]
 #[derive(Clone, Copy)]
 pub struct FullSettingsPayload {
@@ -638,7 +638,7 @@ const SINGLE_VALUE_HEADERS_LEN: usize = 40;
 /// for duplicate detection — the concrete numeric value has no other meaning.
 ///
 /// PERF(port): Zig used `ComptimeStringMap.indexOf`, which compiles to a
-/// length-gated switch. The Phase-A draft used a `phf::Map` but, because phf
+/// length-gated switch. An earlier draft used a `phf::Map` but, because phf
 /// does not expose stable indices, had to fall back to a *linear*
 /// `.entries().position()` scan — 40 slice compares per header per HTTP/2
 /// request. The hand-rolled match below restores the Zig dispatch shape: one
@@ -1248,9 +1248,7 @@ thread_local! {
 }
 
 // R-2 (host-fn re-entrancy): every JS-exposed method takes `&self`; per-field
-// interior mutability via `Cell` (Copy) / `JsCell` (non-Copy). The codegen
-// shim still emits `this: &mut H2FrameParser` until Phase 1 lands —
-// `&mut T` auto-derefs to `&T` so the impls below compile against either.
+// interior mutability via `Cell` (Copy) / `JsCell` (non-Copy).
 #[bun_jsc::JsClass]
 #[derive(bun_ptr::RefCounted)]
 #[ref_count(destroy = Self::deinit_raw)]
@@ -7372,12 +7370,7 @@ impl H2FrameParser {
         let this: *mut H2FrameParser = if ENABLE_ALLOCATOR_POOL {
             POOL.with_borrow_mut(|pool| {
                 let pool = pool.get_or_insert_with(|| Box::new(H2FrameParserHiveAllocator::init()));
-                let slot = pool.try_get();
-                // SAFETY: `slot` is a freshly-claimed, uninitialised `*mut H2FrameParser`
-                // (HiveArray slot or fallback `Box<MaybeUninit<_>>`); `write` moves
-                // `init` in without dropping prior contents.
-                unsafe { slot.write(init) };
-                slot
+                pool.get_init(init).as_ptr()
             })
         } else {
             bun_core::heap::into_raw(Box::new(init))

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -2094,106 +2094,134 @@ impl DevServer {
         req: ReqOrSaved,
         resp: AnyResponse,
     ) -> Result<(), bun_core::Error> {
-        let deferred_ptr = self.deferred_request_pool.get();
-        // SAFETY: HiveArrayFallback::get returns an exclusively-owned, live node ptr
-        // (heap-allocates on overflow; never null).
-        let deferred = unsafe { &mut *deferred_ptr };
-        // Precompute the data slot pointer (used inside the initializer for
-        // abort-callback registration) before borrowing `deferred.data` for `.write()`.
-        let deferred_data_ptr: *mut c_void = deferred.data.as_mut_ptr().cast::<c_void>();
-        debug_log!("DeferredRequest(0x{:x}).init", deferred_data_ptr as usize);
-
         let method = match &req {
             // SAFETY: r is a uws Request ptr valid for the duration of the handler callback
             ReqOrSaved::Req(r) => Method::which(unsafe { &**r }.method()).unwrap_or(Method::GET),
             ReqOrSaved::Saved(saved) => unsafe { (*saved.request).method },
             _ => unreachable!(),
         };
+        // Back-pointer captured before the pool borrow; raw, no live borrow.
+        let dev_ptr: *const DevServer = std::ptr::from_ref(self);
 
-        deferred.data.write(DeferredRequest {
-            route_bundle_index,
-            dev: std::ptr::from_ref(self),
-            referenced_by_devserver: true,
-            weakly_referenced_by_requestcontext: false,
-            handler: match kind {
-                deferred_request::HandlerKind::BundledHtmlPage => 'brk: {
-                    // PORT NOTE: `on_aborted<U: 'static>` rejects `DeferredRequest`;
-                    // erase to `c_void` and cast back inside the trampoline.
-                    resp.on_aborted(
-                        |p: *mut c_void, r: AnyResponse| {
-                            // SAFETY: p is the &mut deferred.data registered below; lifetime erased
-                            unsafe { &mut *p.cast::<DeferredRequest>() }.on_abort(r)
-                        },
-                        deferred_data_ptr,
-                    );
-                    break 'brk Handler::BundledHtmlPage(ResponseAndMethod {
-                        response: resp,
-                        method,
-                    });
-                }
-                deferred_request::HandlerKind::ServerHandler => 'brk: {
-                    let server_handler: SavedRequest = match req {
-                        ReqOrSaved::Req(r) => {
-                            let global = self.vm().global();
-                            match self
-                                .server
-                                .as_ref()
-                                .unwrap()
-                                .prepare_and_save_js_request_context(
-                                    // SAFETY: r is the live µWS request for this handler frame.
-                                    unsafe { &mut *r },
-                                    resp,
-                                    global,
-                                    Some(method),
-                                )? {
-                                Some(saved) => saved,
-                                // Zig: `catch return` — abort the deferral on failure.
-                                None => {
-                                    // SAFETY: `deferred_ptr` is a hive slot from
-                                    // `get()` above; `deferred.data.write()` has
-                                    // not run on this branch (we're still inside
-                                    // the struct-literal initializer), so the slot
-                                    // does not satisfy `put()`'s "fully-initialized
-                                    // T" contract. `put_raw` recycles/frees without
-                                    // `drop_in_place`, matching Zig's `pool.put`
-                                    // (no destructor).
-                                    unsafe { self.deferred_request_pool.put_raw(deferred_ptr) };
-                                    return Ok(());
-                                }
-                            }
+        // Phase 1 — fallible, `self`-reentrant work runs *before* a slot is
+        // claimed. The old code claimed first and recycled via `put_raw` on the
+        // `None` path (and *leaked* the slot on the `?`-error path); resolving
+        // the handler first means the early-return paths have no slot at all.
+        enum HandlerInput {
+            BundledHtmlPage,
+            ServerHandler(SavedRequest),
+        }
+        let handler_input = match kind {
+            deferred_request::HandlerKind::BundledHtmlPage => HandlerInput::BundledHtmlPage,
+            deferred_request::HandlerKind::ServerHandler => {
+                let server_handler: SavedRequest = match req {
+                    ReqOrSaved::Req(r) => {
+                        let global = self.vm().global();
+                        match self
+                            .server
+                            .as_ref()
+                            .unwrap()
+                            .prepare_and_save_js_request_context(
+                                // SAFETY: r is the live µWS request for this handler frame.
+                                unsafe { &mut *r },
+                                resp,
+                                global,
+                                Some(method),
+                            )? {
+                            Some(saved) => saved,
+                            // Zig: `catch return` — abort the deferral on failure.
+                            None => return Ok(()),
                         }
-                        ReqOrSaved::Saved(saved) => saved,
-                        _ => unreachable!(),
-                    };
-                    server_handler.ctx.ref_();
-                    server_handler.ctx.set_additional_on_abort_callback(Some(
-                        crate::server::any_request_context::AdditionalOnAbortCallback {
-                            cb: {
-                                fn cb(ptr: *mut c_void) {
-                                    DeferredRequest::on_abort_wrapper(ptr)
-                                }
-                                cb
-                            },
-                            // SAFETY: deferred.data is a live field of a HiveArray-owned node
-                            data: unsafe { ::core::ptr::NonNull::new_unchecked(deferred_data_ptr) },
-                            deref_fn: {
-                                fn deref_fn(ptr: *mut c_void) {
-                                    // SAFETY: ptr is &mut DeferredRequest from above
-                                    let self_: &mut DeferredRequest =
-                                        unsafe { &mut *ptr.cast::<DeferredRequest>() };
-                                    self_.weak_deref();
-                                }
-                                deref_fn
-                            },
-                        },
-                    ));
-                    break 'brk Handler::ServerHandler(server_handler);
-                }
-            },
-        });
+                    }
+                    ReqOrSaved::Saved(saved) => saved,
+                    _ => unreachable!(),
+                };
+                HandlerInput::ServerHandler(server_handler)
+            }
+        };
 
-        // SAFETY: `deferred.data` was just initialized above.
-        let deferred_data = unsafe { deferred.data.assume_init_mut() };
+        // Phase 2 — infallible, no `self` access (the back-pointer is the
+        // precomputed raw `dev_ptr`). `claim()` reserves a stable slot; the
+        // `HiveSlot` token's `Drop` would recycle it without `T::drop` if we
+        // returned early here (we never do — kept as the correctness net).
+        let slot = self.deferred_request_pool.claim();
+        let deferred_ptr: *mut deferred_request::Node = slot.addr().as_ptr();
+        // SAFETY: `slot` is a freshly-claimed, exclusively-owned `Node`. Write
+        // `.next` (prepend overwrites it on success) and take the stable
+        // address of `.data` for the self-referential abort registration.
+        let deferred_data_ptr: *mut c_void = unsafe {
+            std::ptr::addr_of_mut!((*deferred_ptr).next).write(std::ptr::null_mut());
+            std::ptr::addr_of_mut!((*deferred_ptr).data)
+                .cast::<DeferredRequest>()
+                .cast::<c_void>()
+        };
+        debug_log!("DeferredRequest(0x{:x}).init", deferred_data_ptr as usize);
+
+        let handler = match handler_input {
+            HandlerInput::BundledHtmlPage => {
+                // PORT NOTE: `on_aborted<U: 'static>` rejects `DeferredRequest`;
+                // erase to `c_void` and cast back inside the trampoline.
+                resp.on_aborted(
+                    |p: *mut c_void, r: AnyResponse| {
+                        // SAFETY: p is the &mut deferred.data registered here; lifetime erased
+                        unsafe { &mut *p.cast::<DeferredRequest>() }.on_abort(r)
+                    },
+                    deferred_data_ptr,
+                );
+                Handler::BundledHtmlPage(ResponseAndMethod {
+                    response: resp,
+                    method,
+                })
+            }
+            HandlerInput::ServerHandler(server_handler) => {
+                server_handler.ctx.ref_();
+                server_handler.ctx.set_additional_on_abort_callback(Some(
+                    crate::server::any_request_context::AdditionalOnAbortCallback {
+                        cb: {
+                            fn cb(ptr: *mut c_void) {
+                                DeferredRequest::on_abort_wrapper(ptr)
+                            }
+                            cb
+                        },
+                        // SAFETY: deferred.data is a live field of a HiveArray-owned node
+                        data: unsafe { ::core::ptr::NonNull::new_unchecked(deferred_data_ptr) },
+                        deref_fn: {
+                            fn deref_fn(ptr: *mut c_void) {
+                                // SAFETY: ptr is &mut DeferredRequest from above
+                                let self_: &mut DeferredRequest =
+                                    unsafe { &mut *ptr.cast::<DeferredRequest>() };
+                                self_.weak_deref();
+                            }
+                            deref_fn
+                        },
+                    },
+                ));
+                Handler::ServerHandler(server_handler)
+            }
+        };
+
+        // SAFETY: place the fully-formed value into the slot's `data` field
+        // (raw `ptr::write` — no drop of the prior uninitialized bytes).
+        unsafe {
+            std::ptr::addr_of_mut!((*deferred_ptr).data)
+                .cast::<DeferredRequest>()
+                .write(DeferredRequest {
+                    route_bundle_index,
+                    dev: dev_ptr,
+                    referenced_by_devserver: true,
+                    weakly_referenced_by_requestcontext: false,
+                    handler,
+                });
+        }
+        // SAFETY: both `Node` fields (`next`, `data`) are now initialized;
+        // `assume_init` returns the now-live node pointer and consumes the
+        // token so its `Drop` does not recycle the in-use slot.
+        let deferred_ptr = unsafe { slot.assume_init() }.as_ptr();
+
+        // SAFETY: `.data` initialized just above; `deferred_data_ptr` is its
+        // stable address.
+        let deferred_data: &mut DeferredRequest =
+            unsafe { &mut *deferred_data_ptr.cast::<DeferredRequest>() };
         if matches!(deferred_data.handler, Handler::ServerHandler(_)) {
             deferred_data.weak_ref();
         }
@@ -3534,7 +3562,7 @@ impl DevServer {
         Ok(arr)
     }
 
-    // PERF(port): was comptime monomorphization (`comptime goal: TraceImportGoal`) — profile in Phase B
+    // PERF(port): was comptime monomorphization (`comptime goal: TraceImportGoal`) — profile if hot.
     fn trace_all_route_imports(
         &mut self,
         route_bundle: &RouteBundle,
@@ -3701,7 +3729,7 @@ pub fn finalize_bundle(
     let had_sent_hmr_event = ::core::cell::Cell::new(false);
 
     // TODO(port): the giant `defer` block at the start of finalizeBundle has been
-    // moved into a scopeguard. Phase B must verify ordering relative to ?-returns.
+    // moved into a scopeguard. Verify ordering relative to ?-returns.
     // PORT NOTE: erase `dev`/`bv2` to raw pointers inside the guard so the
     // long-lived closure capture doesn't lock borrowck for the entire fn body
     // (Zig `defer` had no aliasing analysis).
@@ -5406,8 +5434,8 @@ impl DevServer {
 }
 
 // PORT NOTE: FileKind/ChunkKind/TraceImportGoal/IncrementalResult/GraphTraceState
-// are defined once in `crate::bake::dev_server` and re-exported here so the
-// Phase-A draft body and the keystone struct module agree on identity.
+// are defined once in `crate::bake::dev_server` and re-exported here so this
+// module and the keystone struct module agree on identity.
 pub use crate::bake::dev_server::FileKind;
 
 pub use crate::bake::dev_server::IncrementalResult;
@@ -5871,7 +5899,7 @@ mod c {
     }
 }
 
-// PERF(port): was comptime monomorphization (`comptime n: comptime_int, bits: [n]*DynamicBitSetUnmanaged`) — profile in Phase B
+// PERF(port): was comptime monomorphization (`comptime n: comptime_int, bits: [n]*DynamicBitSetUnmanaged`) — profile if hot.
 fn mark_all_route_children(
     router: &FrameworkRouter,
     bits: &mut [&mut DynamicBitSet],
@@ -6270,7 +6298,7 @@ fn dump_state_due_to_crash(dev: &mut DevServer) -> Result<(), bun_core::Error> {
 
     // TODO(port): comptime brk: { @setEvalBranchQuota; @embedFile; lastIndexOf }
     const VISUALIZER: &[u8] = include_bytes!("incremental_visualizer.html");
-    // TODO(port): const split at compile time — Phase B
+    // TODO(perf): split the embedded file at compile time instead of at runtime.
     let i = strings::last_index_of(VISUALIZER, b"<script>").unwrap() + b"<script>".len();
     let (start, end) = (&VISUALIZER[..i], &VISUALIZER[i..]);
 
@@ -6318,9 +6346,6 @@ impl RouteIndexAndRecurseFlag {
         (self.0 >> 31) != 0
     }
 }
-// TODO(port): Zig field-init `.{ .route_index = .., .should_recurse_when_visiting = .. }`
-// is used throughout; Phase B should add a `new()` and update callsites.
-
 /// Bake needs to specify which graph (client/server/ssr) each entry point is.
 #[derive(Default)]
 pub struct EntryPointList {
@@ -7058,7 +7083,7 @@ fn extract_pathname_from_url(url: &[u8]) -> &[u8] {
     pathname
 }
 
-// Type aliases referenced throughout (Phase B will resolve to real paths)
+// Type aliases referenced throughout.
 use crate::bake::dev_server::incremental_graph;
 use crate::bake::dev_server::route_bundle;
 use crate::bake::dev_server::serialized_failure;

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -112,19 +112,29 @@ pub type ResponseStream<const SSL_ENABLED: bool, const HTTP3: bool> =
 pub type ResponseStreamJSSink<const SSL_ENABLED: bool, const HTTP3: bool> =
     crate::webcore::streams::HTTPServerWritableJSSink<SSL_ENABLED, HTTP3>;
 
-/// This pre-allocates up to 2,048 RequestContext structs.
-/// It costs about 655,632 bytes.
+/// Inline capacity of the per-server `RequestContext` pool. Cast sites that
+/// reinterpret a `RequestContextStackAllocator<…>` pointer for a different
+/// `Ctx` monomorphization (server_body.rs) name this constant rather than
+/// hardcoding the literal — the layout of `Fallback` depends on it, so a
+/// mismatch is a silent OOB.
 // TODO(port): bun.HiveArray(RequestContext, if (bun.heap_breakdown.enabled) 0 else 2048).Fallback
+pub const REQUEST_CONTEXT_POOL_CAPACITY: usize = 2048;
+
+/// This pre-allocates up to [`REQUEST_CONTEXT_POOL_CAPACITY`] (2,048)
+/// RequestContext structs. It costs about 655,632 bytes.
 pub type RequestContextStackAllocator<
     ThisServer,
     const SSL: bool,
     const DBG: bool,
     const H3: bool,
-> = bun_collections::hive_array::Fallback<RequestContext<ThisServer, SSL, DBG, H3>, 2048>;
+> = bun_collections::hive_array::Fallback<
+    RequestContext<ThisServer, SSL, DBG, H3>,
+    REQUEST_CONTEXT_POOL_CAPACITY,
+>;
 
 thread_local! {
-    // TODO(port): Zig `pub threadlocal var pool: ?*RequestContextStackAllocator = null;` is
-    // per-monomorphization. Rust thread_local! cannot be generic; Phase B: move into ThisServer
+    // TODO(refactor): Zig `pub threadlocal var pool: ?*RequestContextStackAllocator = null;` is
+    // per-monomorphization. Rust thread_local! cannot be generic; move into ThisServer
     // or use a per-instantiation static via macro.
     static POOL: core::cell::Cell<*mut c_void> = const { core::cell::Cell::new(core::ptr::null_mut()) };
 }
@@ -164,7 +174,7 @@ pub struct RequestContext<
     /// We can only safely free once the request body promise is finalized
     /// and the response is rejected
     // TODO(port): bare JSValue heap field — kept alive via manual protect()/unprotect()
-    // (response_protected flag); revisit bun_jsc::Strong in Phase B.
+    // (response_protected flag); revisit whether bun_jsc::Strong fits here.
     pub response_jsvalue: JSValue,
     pub ref_count: u8,
 
@@ -325,7 +335,7 @@ unsafe fn as_response(value: JSValue) -> Option<&'static mut Response> {
 // ─── sibling-subtree shims ───────────────────────────────────────────────────
 // These forward to methods that exist in webcore/ but are currently inside
 // impl blocks that fail to compile (codegen gc-slot stubs, opaque AbortSignal,
-// duplicate InternalJSEventCallback). Adapt on this side per phase-d rules.
+// duplicate InternalJSEventCallback). Adapt on this side.
 mod shim {
     use super::*;
 
@@ -1017,7 +1027,7 @@ where
     pub fn render_default_error(
         &mut self,
         // TODO(port): arena_allocator param dropped; this is a non-AST crate, allocations use global mimalloc.
-        // PERF(port): was arena bulk-free — profile in Phase B
+        // PERF(port): was arena bulk-free — profile if hot.
         log: &mut bun_ast::Log,
         err: bun_core::Error,
         exceptions: &[Api::JsException],
@@ -1276,51 +1286,53 @@ where
         }
     }
 
-    // TODO(port): in-place init — `this` is a pre-allocated slot in a HiveArray pool.
-    pub fn create(
-        this: &mut core::mem::MaybeUninit<Self>,
-        server: *const ThisServer,
+    /// Build a fully-initialized `RequestContext` by value. The pool slot is
+    /// claimed and written via the safe `Fallback::get_init`; no caller forms
+    /// `&mut`/`*mut` over uninitialized storage.
+    ///
+    /// `server` is `NonNull` — every dispatch path constructs from a live
+    /// `&Self::Server` (or its registered raw user-data pointer), so the
+    /// constructor never sees null. The field stays `Option` because
+    /// [`Self::deinit`] `take()`s it to mark the slot as torn down before pool
+    /// recycle.
+    pub fn new(
+        server: NonNull<ThisServer>,
         req: *mut Req<SSL_ENABLED, HTTP3>,
         resp: uws::AnyResponse,
         should_deinit_context: Option<DeferDeinitFlag>,
         method: Option<Method>,
-    ) {
+    ) -> Self {
         let resolved_method = method
             .or_else(|| Method::which(Self::req_method(req)))
             .unwrap_or(Method::GET);
-        // SAFETY: writing to MaybeUninit slot
-        unsafe {
-            this.as_mut_ptr().write(Self {
-                resp: Some(resp),
-                req: Some(req),
-                method: resolved_method,
-                server: NonNull::new(server.cast_mut()).map(bun_ptr::BackRef::from),
-                defer_deinit_until_callback_completes: should_deinit_context,
-                range: RangeRequest::raw_from_request(&Self::any_request(req)),
-                request_weakref: request::WeakRef::EMPTY,
-                signal: None,
-                cookies: None,
-                flags: Flags::<DEBUG_MODE>::default(),
-                upgrade_context: None,
-                response_jsvalue: JSValue::ZERO,
-                ref_count: 1,
-                response_weakref: response::WeakRef::EMPTY,
-                blob: AnyBlob::Blob(Blob::default()),
-                sendfile: SendfileContext::default(),
-                request_body_readable_stream_ref: readable_stream::Strong::default(),
-                request_body: None,
-                request_body_buf: Vec::new(),
-                request_body_content_len: 0,
-                sink: None,
-                byte_stream: None,
-                response_body_readable_stream_ref: readable_stream::Strong::default(),
-                pathname: BunString::empty(),
-                response_buf_owned: Vec::new(),
-                additional_on_abort: None,
-            });
+        Self {
+            resp: Some(resp),
+            req: Some(req),
+            method: resolved_method,
+            server: Some(bun_ptr::BackRef::from(server)),
+            defer_deinit_until_callback_completes: should_deinit_context,
+            range: RangeRequest::raw_from_request(&Self::any_request(req)),
+            request_weakref: request::WeakRef::EMPTY,
+            signal: None,
+            cookies: None,
+            flags: Flags::<DEBUG_MODE>::default(),
+            upgrade_context: None,
+            response_jsvalue: JSValue::ZERO,
+            ref_count: 1,
+            response_weakref: response::WeakRef::EMPTY,
+            blob: AnyBlob::Blob(Blob::default()),
+            sendfile: SendfileContext::default(),
+            request_body_readable_stream_ref: readable_stream::Strong::default(),
+            request_body: None,
+            request_body_buf: Vec::new(),
+            request_body_content_len: 0,
+            sink: None,
+            byte_stream: None,
+            response_body_readable_stream_ref: readable_stream::Strong::default(),
+            pathname: BunString::empty(),
+            response_buf_owned: Vec::new(),
+            additional_on_abort: None,
         }
-
-        ctx_log!("create<d> ({:p})<r>", this.as_ptr());
     }
 
     pub fn on_timeout(this: *mut Self, _resp: uws::AnyResponse) {
@@ -3174,7 +3186,7 @@ where
         // the single audited `&mut VirtualMachine` accessor.
         let vm = server.vm().as_mut();
         if DEBUG_MODE {
-            // PERF(port): was arena bulk-free — profile in Phase B
+            // PERF(port): was arena bulk-free — profile if hot.
             let mut exception_list_upstream: jsc::ExceptionList = Vec::new();
             let prev_exception_list = vm.on_unhandled_rejection_exception_list;
             vm.on_unhandled_rejection_exception_list =

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1,10 +1,10 @@
 //! Port of src/runtime/server/server.zig
 //!
-//! cycle-5: un-gated `NewServer` struct + lifecycle skeleton (start/stop/listen),
-//! `AnyServer` dispatch, `AnyRoute`, and the per-file submodules. JS callback
+//! `NewServer` struct + lifecycle skeleton (start/stop/listen), `AnyServer`
+//! dispatch, `AnyRoute`, and the per-file submodules are wired. JS callback
 //! bodies (`on_request`, `on_upgrade`, `from_js`, …) and methods that need
 //! `bun_uws` write/close surface stay ``-gated inside each file.
-//! The full Phase-A draft of every gated body is preserved in `server_body.rs`.
+//! The full draft of every gated body is preserved in `server_body.rs`.
 
 use bun_collections::{ByteVecExt, VecExt};
 use core::ffi::{c_char, c_int, c_void};
@@ -700,24 +700,26 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             );
         }
 
-        // SAFETY: `request_pool` points at a process-static (or
-        // server-owned) `HiveArray::Fallback`; valid for the server's lifetime.
-        let ctx_slot = unsafe { (*server.request_pool).try_get() };
-        // SAFETY: `try_get` hands out an uninitialized slot; `create()` fully
-        // initializes it via `MaybeUninit::write`.
-        let ctx_uninit = unsafe {
-            &mut *ctx_slot.cast::<core::mem::MaybeUninit<ServerRequestContext<SSL, DEBUG>>>()
+        // `request_pool`'s element is layout-identical to `ServerRequestContext`
+        // across the `H3` const; `<*mut _>::cast()` is safe. Construction is the
+        // safe `Fallback::get_init` (claim + `MaybeUninit::write`); only the
+        // server-owned-pool deref is unsafe.
+        let pool: *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, false> =
+            server.request_pool.cast();
+        // SAFETY: `pool` points at a process-static (or server-owned) Fallback
+        // valid for the server's lifetime.
+        let ctx: *mut ServerRequestContext<SSL, DEBUG> = unsafe {
+            (*pool)
+                .get_init(ServerRequestContext::<SSL, DEBUG>::new(
+                    core::ptr::NonNull::from(&*server),
+                    std::ptr::from_mut::<uws_sys::Request>(req).cast::<c_void>(),
+                    any_response_from::<SSL>(resp),
+                    should_deinit_context,
+                    method,
+                ))
+                .as_ptr()
         };
-        ServerRequestContext::<SSL, DEBUG>::create(
-            ctx_uninit,
-            this,
-            std::ptr::from_mut::<uws_sys::Request>(req).cast::<c_void>(),
-            any_response_from::<SSL>(resp),
-            should_deinit_context,
-            method,
-        );
-        // SAFETY: fully initialized by `create()`.
-        let ctx: *mut ServerRequestContext<SSL, DEBUG> = ctx_slot;
+        bun_output::scoped_log!(server_body::RequestContext, "create<d> ({:p})<r>", ctx);
         let ctx_mut = unsafe { &mut *ctx };
 
         // `VirtualMachine::jsc_vm()` is the safe accessor for the JSC VM

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -114,14 +114,13 @@ where
 #[allow(clippy::too_many_arguments)]
 pub trait RequestCtxOps: RequestCtx {
     type Server;
-    fn create_in(
-        slot: *mut Self,
-        server: *const Self::Server,
+    fn create(
+        server: NonNull<Self::Server>,
         req: &mut Self::Req,
         resp: &mut Self::Resp,
         should_deinit_context: Option<DeferDeinitFlag>,
         method: Option<http::Method>,
-    );
+    ) -> Self;
     fn on_response(
         &mut self,
         server: &Self::Server,
@@ -163,26 +162,21 @@ where
 {
     type Server = ThisServer;
     #[inline]
-    fn create_in(
-        slot: *mut Self,
-        server: *const ThisServer,
+    fn create(
+        server: NonNull<ThisServer>,
         req: &mut Self::Req,
         resp: &mut Self::Resp,
         should_deinit_context: Option<DeferDeinitFlag>,
         method: Option<http::Method>,
-    ) {
-        // SAFETY: `slot` points at a fresh HiveArray pool entry; treat as
-        // MaybeUninit for in-place construction.
-        let slot = unsafe { &mut *slot.cast::<core::mem::MaybeUninit<Self>>() };
+    ) -> Self {
         let any_resp = RespLike::to_any_response(resp);
-        Self::create(
-            slot,
+        Self::new(
             server,
             std::ptr::from_mut(req).cast(),
             any_resp,
             should_deinit_context,
             method,
-        );
+        )
     }
     #[inline]
     fn on_response(&mut self, server: &ThisServer, rq: JSValue, rv: JSValue) {
@@ -973,7 +967,7 @@ pub enum ServePluginsState {
         promise: jsc::JSPromiseStrong,
         html_bundle_routes: Vec<*mut html_bundle::Route>,
         // TODO(port): LIFETIMES.tsv classifies this BORROW_PARAM → Option<&'a DevServer>;
-        // threading <'a> through ServePluginsState/ServePlugins deferred to Phase B.
+        // threading <'a> through ServePluginsState/ServePlugins not yet done.
         dev_server: Option<NonNull<DevServer>>,
     },
     Loaded(Box<JSBundler::Plugin>),
@@ -1377,7 +1371,7 @@ pub enum PluginsResult<'a> {
 // `CreateJsRequest`, `PreparedRequest`, `SavedRequest`, `SavedRequestUnion`,
 // `ServerAllConnectionsClosedTask`, `AnyServer` and the four type aliases are
 // defined once in `super` (mod.rs). This file contributes additional inherent
-// methods on the same type — there is no separate Phase-A struct.
+// methods on the same type — there is no separate struct here.
 pub use super::{
     AnyServer, AnyServerTag, CreateJsRequest, DebugHTTPSServer, DebugHTTPServer, HTTPSServer,
     HTTPServer, NewServer, PreparedRequest, SavedRequest, SavedRequestUnion,
@@ -3126,50 +3120,41 @@ where
             );
         }
 
-        let self_ptr: *const Self = self;
-        // SAFETY: both allocators hand out `*mut RequestContext<_, SSL, DEBUG, _>`; the
-        // const-bool H3 parameter only affects associated consts/types, not layout, so
-        // reinterpreting the slot pointer as the caller's `Ctx` monomorphization is sound.
-        //
-        // `claim()` reserves the slot as a `HiveSlot`; `create_in` does
-        // `MaybeUninit::write` placement-new through the slot's stable
-        // address, after which `assume_init()` consumes the token.
-        // `RequestContext` carries the heaviest drop glue in the codebase, so
-        // a panic inside `create_in` (or `to_any_response`) now releases the
-        // slot via `HiveSlot::drop` without running `RequestContext::drop` on
-        // garbage.
-        let ctx_slot: *mut Ctx = unsafe {
-            if Ctx::IS_H3 {
-                debug_assert!(
-                    !self.h3_request_pool.is_null(),
-                    "H3 request dispatched but h3_request_pool was never allocated (listen() H3 path not taken)"
-                );
-                let slot = (*self.h3_request_pool).claim();
-                Ctx::create_in(
-                    slot.addr().as_ptr().cast(),
-                    self_ptr,
-                    req,
-                    resp,
-                    should_deinit_context,
-                    method,
-                );
-                // SAFETY: `create_in` fully initialized the slot via `MaybeUninit::write`.
-                slot.assume_init().as_ptr().cast()
-            } else {
-                let slot = (*self.request_pool).claim();
-                Ctx::create_in(
-                    slot.addr().as_ptr().cast(),
-                    self_ptr,
-                    req,
-                    resp,
-                    should_deinit_context,
-                    method,
-                );
-                // SAFETY: `create_in` fully initialized the slot via `MaybeUninit::write`.
-                slot.assume_init().as_ptr().cast()
-            }
+        let self_ptr: NonNull<Self> = NonNull::from(&*self);
+        // Both pools are layout-identical across the `H3` const (it only affects
+        // associated consts/types, not layout), so the server-owned pool pointer
+        // can be reinterpreted to `Ctx`'s monomorphization with a safe
+        // `<*mut _>::cast()`. Construction is the safe `Fallback::get_init`
+        // (claim + `MaybeUninit::write`): no caller forms `&mut`/`*mut` over
+        // uninitialized storage, and a panic in `Ctx::create` cannot leave a
+        // half-initialized `RequestContext` (its drop glue is the heaviest in
+        // the codebase). The only `unsafe` is the server-owned-pool deref.
+        let pool: *mut bun_collections::hive_array::Fallback<
+            Ctx,
+            { super::request_context::REQUEST_CONTEXT_POOL_CAPACITY },
+        > = if Ctx::IS_H3 {
+            debug_assert!(
+                !self.h3_request_pool.is_null(),
+                "H3 request dispatched but h3_request_pool was never allocated (listen() H3 path not taken)"
+            );
+            self.h3_request_pool.cast()
+        } else {
+            self.request_pool.cast()
         };
-        // SAFETY: ctx_slot was just initialized by create_in.
+        // SAFETY: `pool` is the live, server-owned request-context pool.
+        let ctx_slot: *mut Ctx = unsafe {
+            (*pool)
+                .get_init(Ctx::create(
+                    self_ptr,
+                    req,
+                    resp,
+                    should_deinit_context,
+                    method,
+                ))
+                .as_ptr()
+        };
+        ctx_log!("create<d> ({:p})<r>", ctx_slot);
+        // SAFETY: `ctx_slot` points at the freshly initialized pool slot.
         let ctx = unsafe { &mut *ctx_slot };
         // `VirtualMachine::jsc_vm()` is the safe accessor for the JSC VM
         // owned by the per-thread VirtualMachine.
@@ -3401,19 +3386,29 @@ where
         }
         this.pending_requests += 1;
         req.set_yield(false);
-        // SAFETY: pointer is non-null and owns a fresh pool slot.
-        let ctx_slot = unsafe { (*this.request_pool).get() };
         let should_deinit_context = core::cell::Cell::new(false);
-        <ServerRequestContext<SSL, DEBUG> as RequestCtxOps>::create_in(
-            ctx_slot,
-            self_ptr,
-            req,
-            resp,
-            Some(bun_ptr::BackRef::new(&should_deinit_context)),
-            None,
-        );
-        // SAFETY: ctx_slot was just initialized by create_in.
-        let ctx = unsafe { &mut *ctx_slot };
+        // `request_pool`'s element is layout-identical to `ServerRequestContext`
+        // across the `H3` const; `<*mut _>::cast()` is safe. Construction is the
+        // safe `Fallback::get_init`; only the server-owned-pool deref is unsafe.
+        let pool: *mut super::request_context::RequestContextStackAllocator<
+            Self,
+            SSL,
+            DEBUG,
+            false,
+        > = this.request_pool.cast();
+        // SAFETY: `pool` is non-null and valid for the server lifetime.
+        let ctx = unsafe {
+            &mut *(*pool)
+                .get_init(<ServerRequestContext<SSL, DEBUG> as RequestCtxOps>::create(
+                    NonNull::from(&*this),
+                    req,
+                    resp,
+                    Some(bun_ptr::BackRef::new(&should_deinit_context)),
+                    None,
+                ))
+                .as_ptr()
+        };
+        ctx_log!("create<d> ({:p})<r>", ctx);
 
         // Pooled body slot, ref_count = 1.
         let body_hive = crate::webcore::body::hive_alloc(BodyValue::Null);

--- a/src/threading/unbounded_queue.rs
+++ b/src/threading/unbounded_queue.rs
@@ -167,6 +167,30 @@ impl<T: Node> BatchIterator<T> {
         self.batch.count -= 1;
         front
     }
+
+    /// Like [`next`](Self::next), but re-seals the node into a pool-owned
+    /// [`HiveOwned`](bun_collections::HiveOwned) handle. Pairs with
+    /// [`UnboundedQueue::push_owned`] on the producer side.
+    ///
+    /// # Safety
+    /// Every node in this batch's queue must be the exclusive owner of a
+    /// claimed pool slot whose [`HiveOwned`](bun_collections::HiveOwned) token
+    /// was relinquished at push time — i.e. the queue is only ever fed via
+    /// [`UnboundedQueue::push_owned`] (or pointers carrying the equivalent
+    /// ownership claim, e.g. a callback handed an `as_ptr()` of a relinquished
+    /// `HiveOwned`). The caller takes ownership: the returned handle is the
+    /// sole live `HiveOwned` for that slot.
+    #[inline]
+    pub unsafe fn next_owned(&mut self) -> Option<bun_collections::HiveOwned<T>> {
+        let node = self.next();
+        if node.is_null() {
+            return None;
+        }
+        // SAFETY: `node` came from this batch, which was populated by the
+        // queue's push path. Caller contract (above) guarantees every such node
+        // is a claimed pool slot with no other live `HiveOwned`.
+        Some(unsafe { bun_collections::HiveOwned::from_raw_for_queue(node) })
+    }
 }
 
 impl<T: Node> Batch<T> {
@@ -238,6 +262,19 @@ impl<T: Node> UnboundedQueue<T> {
 
     pub fn push(&self, item: *mut T) {
         self.push_batch(item, item);
+    }
+
+    /// Push a pool-owned slot. The queue takes ownership while in transit —
+    /// the seal is re-opened by [`BatchIterator::next_owned`] on drain.
+    ///
+    /// Zero-cost: `as_ptr()` + `forget()` + intrusive [`push`](Self::push).
+    /// `HiveOwned` has no `Drop`, so `forget` is purely documentation that the
+    /// queue, not the caller, is the owner from here on.
+    #[inline]
+    pub fn push_owned(&self, item: bun_collections::HiveOwned<T>) {
+        let ptr = item.as_ptr();
+        core::mem::forget(item);
+        self.push(ptr);
     }
 
     pub fn push_batch(&self, first: *mut T, last: *mut T) {


### PR DESCRIPTION
## What

Deletes `HiveArrayFallback::{get, try_get, get_and_see_if_new}` — they return a raw `*mut T` to uninitialized pool memory, which is an unsound shape: forming `&mut T` over the uninit slot is immediate UB for any `T` with niche-bearing fields, and an early return between `get()` and the caller's `ptr::write` leaves the slot claimed-but-uninit so a later `put()` drops garbage.

Every caller is migrated to the safe entry points (`get_init` / `claim()`) that encode "a used slot is always fully initialized" in the type system:

- **renamer / h2_frame_parser / windows_event_loop**: `pool.get()` + `ptr::write(value)` → `pool.get_init(value)`. The Windows path mirrors the posix event loop, which already used safe construction.
- **install enqueue**: build the `Task` value first (owns no borrow of `this`), then `get_init` — removes the borrow conflict the uninit-slot pattern was working around.
- **`get_network_task`**: `claim()` + `forget` — the slot stays claimed for the existing `put()` path, but no uninit `*mut T` escapes the pool's deprecated API. Documented as the one remaining "uninit pointer across a boundary" site.
- **server request context**: invert `RequestContext::create(*mut Self)` to `::new() -> Self` and `RequestCtxOps::create_in` to `::create() -> Self`; call sites use safe `Fallback::get_init`. The constructor already built the literal by value and `ptr::write`'d it — `get_init` does exactly that, with no `unsafe` at the call site.
- **DevServer::defer_request**: restructure into a fallible/`self`-reentrant phase (runs before any slot is claimed — early returns no longer have a slot to recycle) and an infallible placement-init phase via `claim()`. Also closes a latent slot leak: the old code only recycled the slot on the explicit `None` branch, not on the `?`-error path.

The remaining hive APIs are `get_init`, `emplace`, `claim()`, `put`, `put_raw` — all encode the initialization invariant, none hand out uninit pointers.

## Verification

- `cargo check --workspace` clean (the deleted methods have zero remaining callers)
- `bun run rust:check-all` (all 6 target triples — the Windows path is cfg-gated)
- `bun bd test` on serve.test.ts, bake/dev-and-prod, http2, bundler_minify, bun-install
- 2 separate bughunt sweeps found no logic or memory-safety regressions