### PR TITLE
hooks: deny direct rustfmt, point at cargo fmt --all

### DIFF
--- a/.claude/hooks/pre-bash-zig-build.js
+++ b/.claude/hooks/pre-bash-zig-build.js
@@ -74,6 +74,13 @@ if (argv0 === "zig") {
   }
 }
 
+// Disallow direct `rustfmt`: it doesn't read the workspace edition from
+// Cargo.toml the way `cargo fmt` does, so its output can disagree with CI's
+// Format job (`cargo fmt --all --check`).
+if (argv0 === "rustfmt") {
+  denyWithReason("error: Don't run `rustfmt` directly. Run `cargo fmt --all` — it's what CI checks.");
+}
+
 // Check if argv0 is timeout and the command is "bun bd"
 if (argv0 === "timeout") {
   // Find the actual command after timeout and its arguments


### PR DESCRIPTION
### What

Adds a deny rule to the PreToolUse Bash hook (`.claude/hooks/pre-bash-zig-build.js`) that intercepts `rustfmt` invocations and rejects them with a message pointing at `cargo fmt --all` instead.

### Why

CI's Format job runs `cargo fmt --all --check` (#30682). Standalone `rustfmt` doesn't read the workspace edition from `Cargo.toml` the way `cargo fmt` does — it falls back to edition 2015 — and our `rustfmt.toml` only carries the ignore list, not an `edition` override. So `rustfmt <file>` can produce output that disagrees with what CI expects, leading to a red Format job after a "formatting" commit.

### How

Same `denyWithReason` pattern the hook already uses for `zig build obj`, `bun bd` under `timeout`, etc. Matches on `argv0` after stripping inline env assignments and path prefixes, so `rustfmt`, `/path/to/rustfmt`, and `FOO=1 rustfmt` are all caught. `cargo fmt` / `cargo fmt --all` are unaffected.

```
$ echo '{"tool_name":"Bash","tool_input":{"command":"rustfmt src/foo.rs"}}' | bun .claude/hooks/pre-bash-zig-build.js
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"error: Don't run `rustfmt` directly. Run `cargo fmt --all` — it's what CI checks."}}

$ echo '{"tool_name":"Bash","tool_input":{"command":"cargo fmt --all"}}' | bun .claude/hooks/pre-bash-zig-build.js
(empty — allowed)
```