### PR TITLE
Fix worker teardown crash from missing dupeRef on synthetic-module specifiers

### DIFF
--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3375,8 +3375,10 @@ fn get_hardcoded_module(
             use bun_jsc::resolved_source::Tag;
             Some(OwnedResolvedSource::new(ResolvedSource {
                 source_code: bun_core::String::clone_utf8(&ep.contents),
-                specifier: *specifier,
-                source_url: *specifier,
+                // +1 each: ~SourceProvider() derefs `specifier` and
+                // `source_url` once all uses are done (see ZigSourceProvider.cpp).
+                specifier: specifier.dupe_ref(),
+                source_url: specifier.dupe_ref(),
                 tag: Tag::Esm,
                 source_code_needs_deref: true,
                 ..ResolvedSource::default()
@@ -3402,8 +3404,9 @@ fn get_hardcoded_module(
             {
                 return Some(OwnedResolvedSource::new(ResolvedSource {
                     source_code: bun_core::String::init(bun_ast::runtime::Runtime::source_code()),
-                    specifier: *specifier,
-                    source_url: *specifier,
+                    // +1 each: ~SourceProvider() derefs both.
+                    specifier: specifier.dupe_ref(),
+                    source_url: specifier.dupe_ref(),
                     ..ResolvedSource::default()
                 }));
             }
@@ -3475,7 +3478,8 @@ unsafe fn fetch_builtin_module(
             unsafe {
                 *out = ErrorableResolvedSource::ok(ResolvedSource {
                     source_code: bun_core::String::clone_utf8(&(*entry).source.contents),
-                    specifier: *specifier,
+                    // +1 each: ~SourceProvider() derefs both.
+                    specifier: specifier.dupe_ref(),
                     source_url: specifier.dupe_ref(),
                     ..ResolvedSource::default()
                 });
@@ -3521,7 +3525,8 @@ export default db;
                 unsafe {
                     *out = ErrorableResolvedSource::ok(ResolvedSource {
                         source_code: bun_core::String::static_(SQLITE_MODULE_SOURCE_STANDALONE),
-                        specifier: *specifier,
+                        // +1 each: ~SourceProvider() derefs both.
+                        specifier: specifier.dupe_ref(),
                         source_url: specifier.dupe_ref(),
                         source_code_needs_deref: false,
                         ..ResolvedSource::default()
@@ -3539,7 +3544,8 @@ export default db;
             unsafe {
                 *out = ErrorableResolvedSource::ok(ResolvedSource {
                     source_code: file.to_wtf_string(),
-                    specifier: *specifier,
+                    // +1 each: ~SourceProvider() derefs both.
+                    specifier: specifier.dupe_ref(),
                     source_url: specifier.dupe_ref(),
                     bytecode_origin_path: if !file.bytecode_origin_path.is_empty() {
                         bun_core::String::from_bytes(file.bytecode_origin_path)


### PR DESCRIPTION
## Summary
- `~SourceProvider()` derefs `m_resolvedSource.specifier` and `.source_url` (introduced in c713ab53130b to fix a leak), which requires every `ResolvedSource` producer to hand those `BunString`s in as +1.
- The synthetic-module paths in `jsc_hooks.rs` (`bun:main`, `bun:wrap`, `macro:`, standalone-graph, embedded sqlite) stored a bitwise copy of the borrowed specifier (`*specifier`) with no extra ref, so the destructor over-derefs. The atom impl frees while a `JSString` in the worker heap still references it, and once that slot is reused, `Heap::lastChanceToFinalize` trips `RELEASE_ASSERT(wasRemoved)` in `AtomStringImpl::remove` during worker VM teardown — symptom is a SIGABRT on a random atom string.
- Fix: `specifier.dupe_ref()` for both `specifier` and `source_url` on the paths whose `ResolvedSource` flows into `Zig::SourceProvider::create()`, matching `RuntimeTranspilerStore::run_from_js_thread`.

## Test plan
- [x] `test/js/node/test/parallel/test-worker-console-listeners.js` — 480/480 clean (was ~5/240 SIGABRT) with `BUN_DESTRUCT_VM_ON_EXIT=1` under 8× parallel debug-build loop
- [x] `test/js/node/test/parallel/test-crypto-worker-thread.js` — 400/400 clean under the same harness
- [x] Diagnostic heap walk before `~VM` confirms worker heaps no longer hold a `bun:main` `JSString` whose `StringImpl` is absent from the worker's atom table (`foreign=1` → `foreign=0`)