### PR TITLE
bun build: honor --outfile directory when --sourcemap is set

### DIFF
--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -697,23 +697,31 @@ impl BuildCommand {
                     || (output_files.len() == 1
                         && matches!(output_files[0].value, options::OutputFileValue::Buffer { .. }));
 
-            if output_dir.is_empty() && !outfile.is_empty() && will_be_one_file {
+            if output_dir.is_empty() && !outfile.is_empty() {
+                // --outfile with a directory component — use its dirname as
+                // the output directory regardless of how many files get
+                // emitted. Emitting a sourcemap adds a second output file,
+                // which previously dropped this fallback (via will_be_one_file)
+                // and left the files in cwd.
+                // https://github.com/oven-sh/bun/issues/30883
                 output_dir = bun_core::dirname(outfile).unwrap_or(b".");
-                if ctx.bundler_options.compile {
-                    // If the first output file happens to be a client-side chunk imported server-side
-                    // then don't rename it to something else, since an HTML
-                    // import manifest might depend on the file path being the
-                    // one we think it should be.
-                    for f in output_files.iter_mut() {
-                        if f.output_kind == options::OutputKind::EntryPoint
-                            && f.side.unwrap_or(options::Side::Server) == options::Side::Server
-                        {
-                            f.dest_path = bun_paths::basename(outfile).into();
-                            break;
+                if will_be_one_file {
+                    if ctx.bundler_options.compile {
+                        // If the first output file happens to be a client-side chunk imported server-side
+                        // then don't rename it to something else, since an HTML
+                        // import manifest might depend on the file path being the
+                        // one we think it should be.
+                        for f in output_files.iter_mut() {
+                            if f.output_kind == options::OutputKind::EntryPoint
+                                && f.side.unwrap_or(options::Side::Server) == options::Side::Server
+                            {
+                                f.dest_path = bun_paths::basename(outfile).into();
+                                break;
+                            }
                         }
+                    } else {
+                        output_files[0].dest_path = bun_paths::basename(outfile).into();
                     }
-                } else {
-                    output_files[0].dest_path = bun_paths::basename(outfile).into();
                 }
             }
 

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -352,6 +352,40 @@ test("you can use --outfile=... and --sourcemap", async () => {
   `);
 });
 
+test("--outfile subdirectory is honored with --sourcemap (#30883)", async () => {
+  // Regression: `bun build --outfile ./dist/output.js --sourcemap` used to
+  // drop the `./dist/` prefix and emit `output.js` + `output.js.map` in cwd.
+  // The dirname of `--outfile` must be used as the output directory, even
+  // when the sourcemap adds a second output file.
+  using dir = tempDir("outfile-sourcemap-subdir", {
+    "index.ts": `console.log("hello");\n`,
+  });
+  const cwd = String(dir);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "./index.ts", "--outfile", "./dist/output.js", "--sourcemap"],
+    env: bunEnv,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+
+  // Files must land in ./dist/, not cwd.
+  expect(fs.existsSync(path.join(cwd, "dist", "output.js"))).toBe(true);
+  expect(fs.existsSync(path.join(cwd, "dist", "output.js.map"))).toBe(true);
+  expect(fs.existsSync(path.join(cwd, "output.js"))).toBe(false);
+  expect(fs.existsSync(path.join(cwd, "output.js.map"))).toBe(false);
+
+  // Sourcemap link still points to the basename (relative to the JS file).
+  const outputContent = fs.readFileSync(path.join(cwd, "dist", "output.js"), "utf8");
+  expect(outputContent).toContain("//# sourceMappingURL=output.js.map");
+});
+
 test("some log cases", async () => {
   const tmpdir = tmpdirSync();
   const inputFile = path.join(tmpdir, "input.js");


### PR DESCRIPTION
Closes #30883
Closes #19729

## Repro

```console
$ mkdir repro && cd repro && echo 'console.log("hi")' > index.ts

$ bun build ./index.ts --outfile ./dist/output.js --sourcemap
Bundled 1 module in 3ms

  output.js      115 bytes  (entry point)
  output.js.map  206 bytes  (source map)

$ ls dist/
ls: cannot access 'dist/': No such file or directory

$ ls
index.ts  output.js  output.js.map
```

Without `--sourcemap` the same invocation emits `dist/output.js` correctly.

## Cause

In `src/runtime/cli/build_command.rs` the "if user set `--outfile` but no `--outdir`, treat `dirname(outfile)` as the output directory" fallback is gated on `will_be_one_file`:

```rust
let will_be_one_file =
    ctx.bundler_options.compile
        || (output_files.len() == 1
            && matches!(output_files[0].value, options::OutputFileValue::Buffer { .. }));

if output_dir.is_empty() && !outfile.is_empty() && will_be_one_file {
    output_dir = bun_core::dirname(outfile).unwrap_or(b".");
    // …also rewrite output_files[0].dest_path to basename(outfile).
}
```

`--sourcemap` adds a second `OutputFile` (the `.map`), so `output_files.len() == 2` and `will_be_one_file` becomes false. The fallback is skipped, `output_dir` stays empty, and the files land in cwd.

The existing regression test (`test/bundler/cli.test.ts:313`) didn't catch this because it passed `path.relative(tmpdir, outFile) === "out.js"` as the outfile — no directory component.

## Fix

Split the two responsibilities of that block. Always take `dirname(outfile)` as the output directory when `--outfile` is set and `--outdir` isn't — this matches the behavior of `--outfile` without `--sourcemap` and matches esbuild. Only rewrite `output_files[0].dest_path` when `will_be_one_file` is actually true (i.e., there really is one file to name).

## Verification

- New test: `--outfile subdirectory is honored with --sourcemap (#30883)` in `test/bundler/cli.test.ts`. Fails on main, passes with the fix.
- All other `--outfile` / `--outdir` / `--sourcemap` tests in `cli.test.ts` still pass.
- Manually verified: subdir outfile without sourcemap, subdir outfile with external sourcemap, absolute-path outfile with sourcemap, `--outdir` + sourcemap, and inline sourcemap to stdout all still work.
