### PR TITLE
Collapse ThreadPool::init dead generic and fix cpuid cfg gate

### DIFF
--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -205,14 +205,8 @@ impl ThreadPool {
     /// resolve without a separate module path.
     pub type Worker = Worker;
 
-    // PORT NOTE: generic over `V2` because, during the phased port,
-    // `bundle_v2.rs` carried a second `BundleV2` definition inside the gated
-    // `bv2_impl` draft module and both called `ThreadPool::init`. The backref
-    // is stored as a type-erased raw pointer (`.cast()`) regardless, so the
-    // monomorphised body is identical. Collapses to `&BundleV2<'_>` once
-    // `bv2_impl` is dropped.
-    pub fn init<V2>(
-        v2: &V2,
+    pub fn init(
+        v2: &BundleV2<'_>,
         // `Option<NonNull<_>>` (not `Option<&mut _>`): callers pass the
         // process-wide `WorkPool` singleton (`OnceLock`-backed, shared across
         // worker threads). Materializing `&mut` from that provenance is UB
@@ -247,7 +241,10 @@ impl ThreadPool {
         Ok(this)
     }
 
-    pub fn init_with_pool<V2>(v2: &V2, worker_pool: *mut ThreadPoolLib::ThreadPool) -> ThreadPool {
+    pub fn init_with_pool(
+        v2: &BundleV2<'_>,
+        worker_pool: *mut ThreadPoolLib::ThreadPool,
+    ) -> ThreadPool {
         ThreadPool {
             worker_pool,
             io_pool: if Self::uses_io_pool() {
@@ -256,7 +253,7 @@ impl ThreadPool {
                 None
             },
             // BACKREF: lifetime erased behind the raw pointer.
-            v2: std::ptr::from_ref::<V2>(v2).cast(),
+            v2: std::ptr::from_ref(v2).cast::<BundleV2<'static>>(),
             worker_pool_is_owned: false,
             workers_assignments: bun_threading::Guarded::new(ArrayHashMap::default()),
         }

--- a/src/perf/hw_timer.rs
+++ b/src/perf/hw_timer.rs
@@ -209,7 +209,10 @@ fn read_frequency() -> u64 {
     compile_error!("hw_timer::read_frequency: unsupported target");
 }
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(
+    target_arch = "x86_64",
+    not(any(target_os = "macos", target_os = "freebsd"))
+))]
 struct CpuidResult {
     eax: u32,
     ebx: u32,
@@ -217,7 +220,10 @@ struct CpuidResult {
     edx: u32,
 }
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(
+    target_arch = "x86_64",
+    not(any(target_os = "macos", target_os = "freebsd"))
+))]
 #[inline]
 fn cpuid(leaf: u32, subleaf: u32) -> CpuidResult {
     // PORT NOTE: Rust inline asm reserves `rbx` (LLVM PIC base), so we use the


### PR DESCRIPTION
**ThreadPool::init dead generic.** `bundler::ThreadPool::init` (and its helper `init_with_pool`) were generic over `V2` because, during the phased Zig→Rust port, `bundle_v2.rs` carried two `BundleV2` definitions — the canonical one plus a `bv2_impl` draft module — and both needed to call `init`. The PORT NOTE on the function explicitly said it should collapse to `&BundleV2<'_>` once `bv2_impl` was dropped. That module is gone (`grep -rn "struct BundleV2" src/bundler/` finds exactly one definition, `bundle_v2.rs:75`), so this collapses the generic, names the concrete type, and drops the now-stale PORT NOTE. The body was already storing a type-erased raw pointer, so the monomorphised code is identical.

**cpuid cfg-gate mismatch.** `perf/hw_timer.rs` defines `struct CpuidResult` and `fn cpuid()` under `#[cfg(target_arch = "x86_64")]`, but their only callers live inside a `#[cfg(not(any(target_os = "macos", target_os = "freebsd")))]` block (macOS/FreeBSD read the boot-time TSC frequency from `sysctl` instead of probing CPUID). On `x86_64-apple-darwin` and `x86_64-unknown-freebsd` the helpers were therefore compiled with no callers, producing `never constructed` / `never used` warnings. The cfg gates now mirror the callers' conditions.

Verified with `cargo check --workspace --keep-going` (clean), `bun run rust:check-all` (10/10 targets), and `cargo fmt -p bun_bundler -p bun_perf --check`. Confirmed the dead-code warnings on `x86_64-apple-darwin` are present without this change and gone with it. File set is disjoint from #30879.