### PR TITLE
test runner: preserve top-level await across --isolate / --parallel preload

### DIFF
--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -40,7 +40,10 @@ bun_core::declare_scope!(cache, visible);
 /// Version 19: Sourcemap blob is InternalSourceMap (varint stream + sync points), not VLQ.
 /// Version 20: InternalSourceMap stream is bit-packed windows.
 /// Version 21: ModuleInfo records a phase byte per requested module (`import defer`).
-const EXPECTED_VERSION: u32 = 21;
+/// Version 22: Serialize `has_tla` in the cached ESM record flags byte. Entries
+/// written before #30888 carried `has_tla=false` for every module; the cache-HIT
+/// path reinstates the bug for any previously-cached TLA module (#30887).
+const EXPECTED_VERSION: u32 = 22;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -1133,6 +1133,15 @@ impl TranspilerJob {
             } else {
                 None
             };
+        // Spec ModuleLoader.zig:523 — propagate top-level-await to the cached
+        // module record. Without this, modules cached via the isolation source
+        // provider (used under --isolate / --parallel) are reported to JSC as
+        // having no TLA, so the module's evaluation promise resolves before the
+        // top-level-await actually completes — causing the caller's
+        // `wait_for_promise` on the preload to return early.
+        if let Some(mi) = module_info.as_deref_mut() {
+            mi.flags.has_tla = !parse_result.ast.top_level_await_keyword.is_empty();
+        }
         // PORT NOTE: derive `*mut` from a `&mut` borrow (not `&x as *const _ as
         // *mut _`, which is Stacked-Borrows UB). The `&mut` borrow ends when the
         // closure returns; the raw pointer stays valid until `module_info` is

--- a/test/regression/issue/30887.test.ts
+++ b/test/regression/issue/30887.test.ts
@@ -3,6 +3,8 @@ import { bunEnv, bunExe, tempDir } from "harness";
 import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+// https://github.com/oven-sh/bun/issues/30887
+//
 // Under `--parallel` / `--isolate`, `bun test` reads transpiled preloads from
 // the isolation source provider cache. That path dropped the `has_tla` flag
 // on the cached module record, so JSC treated TLA preloads as having none

--- a/test/regression/issue/30887.test.ts
+++ b/test/regression/issue/30887.test.ts
@@ -92,7 +92,15 @@ preload = ["./preload.ts"]
   });
 
   const cachePath = join(String(dir), ".bun-cache");
-  const extraEnv = { BUN_RUNTIME_TRANSPILER_CACHE_PATH: cachePath };
+  // `BUN_DEBUG_ENABLE_RESTORE_FROM_TRANSPILER_CACHE=1` is required on debug
+  // builds so `RuntimeTranspilerCache::get()` actually returns the loaded
+  // entry instead of discarding it; without it the cache-HIT branch in
+  // `RuntimeTranspilerStore` is never taken (precedent:
+  // `test/cli/run/transpiler-cache.test.ts`).
+  const extraEnv = {
+    BUN_RUNTIME_TRANSPILER_CACHE_PATH: cachePath,
+    BUN_DEBUG_ENABLE_RESTORE_FROM_TRANSPILER_CACHE: "1",
+  };
 
   // First run populates the cache.
   const first = await runTest(String(dir), ["--isolate"], extraEnv);
@@ -138,7 +146,10 @@ preload = ["./preload.ts"]
   });
 
   const cachePath = join(String(dir), ".bun-cache");
-  const extraEnv = { BUN_RUNTIME_TRANSPILER_CACHE_PATH: cachePath };
+  const extraEnv = {
+    BUN_RUNTIME_TRANSPILER_CACHE_PATH: cachePath,
+    BUN_DEBUG_ENABLE_RESTORE_FROM_TRANSPILER_CACHE: "1",
+  };
 
   // First run populates the cache (so the filename and path layout exist).
   const first = await runTest(String(dir), ["--isolate"], extraEnv);
@@ -146,20 +157,27 @@ preload = ["./preload.ts"]
   expect(first.exitCode).toBe(0);
 
   // Locate the written `.pile` file(s) (covers `.debug.pile` on debug builds
-  // and `.pile` on release builds) and rewrite the 4-byte LE cache_version
-  // header to 20 — the previous `EXPECTED_VERSION`. A binary that still has
-  // `EXPECTED_VERSION == 20` would accept this stale entry verbatim; the
-  // fix in this PR bumps to 21, so the decode must fail and the file must
-  // be re-transpiled (and rewritten with version=21).
+  // and `.pile` on release builds). Read the current cache version from the
+  // first file, then downgrade every entry's 4-byte LE version header to
+  // `current - 1`. A binary that reverted the #30888 bump (back to 20)
+  // would accept a `has_tla=false` entry verbatim; the fix requires the
+  // decode to fail and the file to be re-transpiled and rewritten at the
+  // current version. Reading the current version from the file (rather
+  // than hardcoding 21) means this test doesn't need editing on every
+  // future `EXPECTED_VERSION` bump — it still fails iff the version is
+  // ever reverted to ≤ 20.
   const entries = readdirSync(cachePath).filter(n => n.endsWith(".pile"));
   expect(entries.length).toBeGreaterThan(0);
+  const firstBytes = readFileSync(join(cachePath, entries[0]));
+  expect(firstBytes.length).toBeGreaterThan(4);
+  const currentVersion = firstBytes.readUInt32LE(0);
+  // Guard against an accidental revert of the #30888 bump (20 → 21).
+  expect(currentVersion).toBeGreaterThan(20);
   for (const name of entries) {
     const p = join(cachePath, name);
     const bytes = readFileSync(p);
-    expect(bytes.length).toBeGreaterThan(4);
-    // Sanity check: the version we just wrote should be the current one (21).
-    expect(bytes.readUInt32LE(0)).toBe(21);
-    bytes.writeUInt32LE(20, 0);
+    expect(bytes.readUInt32LE(0)).toBe(currentVersion);
+    bytes.writeUInt32LE(currentVersion - 1, 0);
     writeFileSync(p, bytes);
   }
 
@@ -169,10 +187,10 @@ preload = ["./preload.ts"]
   expect(second.stderr).toContain("0 fail");
   expect(second.exitCode).toBe(0);
 
-  // The cache file must now carry the bumped version byte, proving the
+  // The cache file must now carry the current version byte, proving the
   // decode path rejected the stale header and forced a rewrite.
   for (const name of entries) {
     const bytes = readFileSync(join(cachePath, name));
-    expect(bytes.readUInt32LE(0)).toBe(21);
+    expect(bytes.readUInt32LE(0)).toBe(currentVersion);
   }
 });

--- a/test/regression/issue/30887.test.ts
+++ b/test/regression/issue/30887.test.ts
@@ -20,11 +20,7 @@ async function runTest(cwd: string, extraArgs: string[]) {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   return { stdout, stderr, exitCode };
 }

--- a/test/regression/issue/30887.test.ts
+++ b/test/regression/issue/30887.test.ts
@@ -1,4 +1,6 @@
 import { expect, test } from "bun:test";
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 // Under `--parallel` / `--isolate`, `bun test` reads transpiled preloads from
@@ -9,12 +11,14 @@ import { bunEnv, bunExe, tempDir } from "harness";
 // then happened *after* the test file started running.
 //
 // These tests assert that the preload's top-level await is awaited to
-// completion before the test file runs, across all three modes.
+// completion before the test file runs, across all three modes, and that
+// the on-disk runtime transpiler cache survives a round-trip with TLA
+// intact.
 
-async function runTest(cwd: string, extraArgs: string[]) {
+async function runTest(cwd: string, extraArgs: string[], extraEnv?: Record<string, string>) {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "test", ...extraArgs],
-    env: bunEnv,
+    env: { ...bunEnv, ...extraEnv },
     cwd,
     stdout: "pipe",
     stderr: "pipe",
@@ -49,9 +53,128 @@ preload = ["./preload.ts"]
     `,
   });
 
-  const { stdout, stderr, exitCode } = await runTest(String(dir), flags);
+  const { stderr, exitCode } = await runTest(String(dir), flags);
 
   expect(stderr).toContain("1 pass");
   expect(stderr).toContain("0 fail");
   expect(exitCode).toBe(0);
+});
+
+// Runtime transpiler cache round-trip: a ≥4 KiB preload with top-level-await
+// is cached on the first run, then read back from the on-disk cache on the
+// second run. The cache-HIT path deserializes `module_info` straight from the
+// stored `esm_record` without touching the AST, so if the serializer or the
+// cache version doesn't preserve the `has_tla` flag, the second run will
+// fail exactly like the original #30887 repro.
+test("async preload survives runtime transpiler cache round-trip (--isolate)", async () => {
+  // Pad the preload past MINIMUM_CACHE_SIZE (4 KiB). Declared variables are
+  // enough — we just need byte-length, not any particular JS behavior.
+  const padding =
+    "\n" + Array.from({ length: 400 }, (_, i) => `const pad_${i} = ${i};`).join("\n");
+
+  using dir = tempDir("bun-test-30887-cache-", {
+    "preload.ts": `
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      Bun.env.MY_ENV = "MUST_NOT_BE_UNDEFINED";
+      ${padding}
+    `,
+    "my.test.ts": `
+      import { test, expect } from "bun:test";
+      test("MY_ENV must not be undefined", () => {
+        expect(Bun.env.MY_ENV).toBe("MUST_NOT_BE_UNDEFINED");
+      });
+    `,
+    "bunfig.toml": `
+[test]
+preload = ["./preload.ts"]
+    `,
+  });
+
+  const cachePath = join(String(dir), ".bun-cache");
+  const extraEnv = { BUN_RUNTIME_TRANSPILER_CACHE_PATH: cachePath };
+
+  // First run populates the cache.
+  const first = await runTest(String(dir), ["--isolate"], extraEnv);
+  expect(first.stderr).toContain("1 pass");
+  expect(first.stderr).toContain("0 fail");
+  expect(first.exitCode).toBe(0);
+
+  // Second run reads from the cache. The cache-HIT branch builds
+  // `module_info` via `create_from_cached_record`, never touching the AST —
+  // so `has_tla` here comes entirely from the serialized bytes.
+  const second = await runTest(String(dir), ["--isolate"], extraEnv);
+  expect(second.stderr).toContain("1 pass");
+  expect(second.stderr).toContain("0 fail");
+  expect(second.exitCode).toBe(0);
+});
+
+// On-disk cache entries written before #30888 have `has_tla=false` baked
+// into their serialized ESM record; without bumping `EXPECTED_VERSION`, the
+// post-fix binary would happily read them back and reinstate the original
+// bug. Simulate the stale-entry scenario by populating the cache, rewriting
+// the 4-byte LE version header to the prior version (20), and asserting the
+// next run overwrites it with the current version rather than silently
+// accepting the stale entry.
+test("stale transpiler cache entries are rejected (version bump)", async () => {
+  const padding =
+    "\n" + Array.from({ length: 400 }, (_, i) => `const pad_${i} = ${i};`).join("\n");
+
+  using dir = tempDir("bun-test-30887-stale-", {
+    "preload.ts": `
+      await Promise.resolve();
+      Bun.env.MY_ENV = "MUST_NOT_BE_UNDEFINED";
+      ${padding}
+    `,
+    "my.test.ts": `
+      import { test, expect } from "bun:test";
+      test("MY_ENV must not be undefined", () => {
+        expect(Bun.env.MY_ENV).toBe("MUST_NOT_BE_UNDEFINED");
+      });
+    `,
+    "bunfig.toml": `
+[test]
+preload = ["./preload.ts"]
+    `,
+  });
+
+  const cachePath = join(String(dir), ".bun-cache");
+  const extraEnv = { BUN_RUNTIME_TRANSPILER_CACHE_PATH: cachePath };
+
+  // First run populates the cache (so the filename and path layout exist).
+  const first = await runTest(String(dir), ["--isolate"], extraEnv);
+  expect(first.stderr).toContain("1 pass");
+  expect(first.exitCode).toBe(0);
+
+  // Locate the written `.pile` file(s) (covers `.debug.pile` on debug builds
+  // and `.pile` on release builds) and rewrite the 4-byte LE cache_version
+  // header to 20 — the previous `EXPECTED_VERSION`. A binary that still has
+  // `EXPECTED_VERSION == 20` would accept this stale entry verbatim; the
+  // fix in this PR bumps to 21, so the decode must fail and the file must
+  // be re-transpiled (and rewritten with version=21).
+  const entries = readdirSync(cachePath).filter(n => n.endsWith(".pile"));
+  expect(entries.length).toBeGreaterThan(0);
+  for (const name of entries) {
+    const p = join(cachePath, name);
+    const bytes = readFileSync(p);
+    expect(bytes.length).toBeGreaterThan(4);
+    // Sanity check: the version we just wrote should be the current one (21).
+    expect(bytes.readUInt32LE(0)).toBe(21);
+    bytes.writeUInt32LE(20, 0);
+    writeFileSync(p, bytes);
+  }
+
+  // Second run must reject the stale entry, re-transpile, and overwrite.
+  const second = await runTest(String(dir), ["--isolate"], extraEnv);
+  expect(second.stderr).toContain("1 pass");
+  expect(second.stderr).toContain("0 fail");
+  expect(second.exitCode).toBe(0);
+
+  // The cache file must now carry the bumped version byte, proving the
+  // decode path rejected the stale header and forced a rewrite.
+  for (const name of entries) {
+    const bytes = readFileSync(join(cachePath, name));
+    expect(bytes.readUInt32LE(0)).toBe(21);
+  }
 });

--- a/test/regression/issue/30887.test.ts
+++ b/test/regression/issue/30887.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Under `--parallel` / `--isolate`, `bun test` reads transpiled preloads from
+// the isolation source provider cache. That path dropped the `has_tla` flag
+// on the cached module record, so JSC treated TLA preloads as having none
+// and let their evaluation promise resolve before the top-level-await
+// actually completed. The preload's side effects (like `Bun.env.X = ...`)
+// then happened *after* the test file started running.
+//
+// These tests assert that the preload's top-level await is awaited to
+// completion before the test file runs, across all three modes.
+
+async function runTest(cwd: string, extraArgs: string[]) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", ...extraArgs],
+    env: bunEnv,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  return { stdout, stderr, exitCode };
+}
+
+test.concurrent.each([
+  ["sequential (default)", []],
+  ["--isolate", ["--isolate"]],
+  ["--parallel", ["--parallel"]],
+])("async preload is awaited before tests run (%s)", async (_name, flags) => {
+  using dir = tempDir("bun-test-30887-", {
+    "preload.ts": `
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      Bun.env.MY_ENV = "MUST_NOT_BE_UNDEFINED";
+    `,
+    "my.test.ts": `
+      import { test, expect } from "bun:test";
+      test("MY_ENV must not be undefined", () => {
+        expect(Bun.env.MY_ENV).toBe("MUST_NOT_BE_UNDEFINED");
+      });
+    `,
+    "bunfig.toml": `
+[test]
+preload = ["./preload.ts"]
+    `,
+  });
+
+  const { stdout, stderr, exitCode } = await runTest(String(dir), flags);
+
+  expect(stderr).toContain("1 pass");
+  expect(stderr).toContain("0 fail");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/30887.test.ts
+++ b/test/regression/issue/30887.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { bunEnv, bunExe, tempDir } from "harness";
 
 // Under `--parallel` / `--isolate`, `bun test` reads transpiled preloads from
 // the isolation source provider cache. That path dropped the `has_tla` flag
@@ -69,8 +69,7 @@ preload = ["./preload.ts"]
 test("async preload survives runtime transpiler cache round-trip (--isolate)", async () => {
   // Pad the preload past MINIMUM_CACHE_SIZE (4 KiB). Declared variables are
   // enough — we just need byte-length, not any particular JS behavior.
-  const padding =
-    "\n" + Array.from({ length: 400 }, (_, i) => `const pad_${i} = ${i};`).join("\n");
+  const padding = "\n" + Array.from({ length: 400 }, (_, i) => `const pad_${i} = ${i};`).join("\n");
 
   using dir = tempDir("bun-test-30887-cache-", {
     "preload.ts": `
@@ -118,8 +117,7 @@ preload = ["./preload.ts"]
 // next run overwrites it with the current version rather than silently
 // accepting the stale entry.
 test("stale transpiler cache entries are rejected (version bump)", async () => {
-  const padding =
-    "\n" + Array.from({ length: 400 }, (_, i) => `const pad_${i} = ${i};`).join("\n");
+  const padding = "\n" + Array.from({ length: 400 }, (_, i) => `const pad_${i} = ${i};`).join("\n");
 
   using dir = tempDir("bun-test-30887-stale-", {
     "preload.ts": `


### PR DESCRIPTION
Fixes #30887.

## Repro

```ts
// preload.ts
await Bun.sleep(2000)
Bun.env.MY_ENV = 'MUST_NOT_BE_UNDEFINED'
```

```ts
// my.test.ts
import { test, expect } from 'bun:test'
test('MY_ENV must not be undefined', () => {
    expect(Bun.env.MY_ENV).toBeDefined()
})
```

```toml
# bunfig.toml
[test]
preload = ["./preload.ts"]
```

Before:

```console
$ bun test --parallel    # or --isolate
... 1 fail, completed in ~26ms (sleep was skipped)
$ bun test               # no flags
... 1 pass, completed in ~2s (correct)
```

After, all three modes pass in ~2s.

## Cause

Runtime transpilation caches the parsed module record in the isolation
source provider cache when `test_isolation_enabled` is on (used under
`--isolate` and `--parallel`). `ModuleLoader.zig:523` sets
`module_info.flags.has_tla` from
`parse_result.ast.top_level_await_keyword` before handing the record
off to JSC — the Rust port in `RuntimeTranspilerStore.rs` was missing
this line.

With `has_tla = false`, JSC reports the preload module's evaluation
promise as fulfilled before the top-level await has actually run to
completion. `loadPreloads`'s `wait_for_promise` returns early, and
the test file starts executing before the preload's side effects (env
var assignment, module initialization, etc.) have happened.

Without the isolation source provider cache
(`BUN_FEATURE_FLAG_DISABLE_ISOLATION_SOURCE_CACHE=1`) the bug
disappears, which pinpointed the cache path.

## Fix

Set `module_info.flags.has_tla` from
`parse_result.ast.top_level_await_keyword` right after the
`module_info` is created, matching the Zig spec.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/regression/issue/30887.test.ts`:
  `--isolate` and `--parallel` fail as expected (sequential still
  passes — that path doesn't use the isolation source cache).
- `bun bd test test/regression/issue/30887.test.ts`: all 3 pass.
- Related test suites still pass: `test/config/bunfig/preload.test.ts`
  (18 pass / 0 fail), `test/js/bun/test/expect-extend-preload.test.ts`,
  `test/regression/issue/12782.test.ts`, `test/js/bun/test/bun_test.test.ts`.