### PR TITLE
parser: clamp raw_template_contents span after error recovery

### DIFF
--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -3509,12 +3509,23 @@ lexer_impl_header! {
 
         let mut text: &[u8] = b"";
 
+        // Error-recovery guard: the `(start, end)` span can be shorter than a
+        // well-formed template literal when this is reached after an upstream
+        // error (e.g. JSX's `expected(TGreaterThan)` logs a diagnostic but
+        // returns `Ok`, so `parse_suffix` can land here with a malformed span).
+        // Without the checks below, `end - 1` / `end - 2` underflow and the
+        // slice indexing panics. The error has already been logged; returning
+        // empty raw contents lets recovery continue.
         match self.token {
             T::TNoSubstitutionTemplateLiteral | T::TTemplateTail => {
-                text = &self.contents[self.start + 1..self.end - 1];
+                if self.end >= self.start + 2 {
+                    text = &self.contents[self.start + 1..self.end - 1];
+                }
             }
             T::TTemplateMiddle | T::TTemplateHead => {
-                text = &self.contents[self.start + 1..self.end - 2];
+                if self.end >= self.start + 3 {
+                    text = &self.contents[self.start + 1..self.end - 2];
+                }
             }
             _ => {}
         }

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4624,8 +4624,22 @@ describe("malformed JSX followed by template literal (issue #30892)", () => {
     ["<y/```", "jsx"],
     ["<y/`${1}`", "jsx"],
     ["<y/``", "tsx"],
-  ])("reports a parse error for %j (%s loader) instead of panicking", (code, loader) => {
+  ])("surfaces the JSX parse diagnostic for %j (%s loader) instead of panicking", (code, loader) => {
     const transpiler = new Bun.Transpiler({ loader });
-    expect(() => transpiler.transformSync(code)).toThrow(/Expected|error/i);
+    let caught;
+    try {
+      transpiler.transformSync(code);
+    } catch (e) {
+      caught = e;
+    }
+    // Must throw (not panic, not return silently).
+    expect(caught).toBeDefined();
+    // The first diagnostic logged by JSX error recovery is the missing `>`
+    // after the self-closing `/`. Inputs that produce a single error throw
+    // that message directly; inputs that accumulate multiple errors throw
+    // a "Parse error" wrapper but still expose the JSX diagnostic in
+    // `err.errors[0].message`.
+    const firstMessage = caught.errors?.[0]?.message ?? caught.message;
+    expect(firstMessage).toBe('Expected ">" but found "`"');
   });
 });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4611,3 +4611,21 @@ describe("parse error flood", () => {
     expect(exitCode).toBe(0);
   }, 90_000);
 });
+
+describe("malformed JSX followed by template literal (issue #30892)", () => {
+  // The JSX parser's `expected(>)` call logs a diagnostic but does not abort.
+  // When the recovery path then re-lexes the trailing backticks as a template
+  // literal, the span is too short and `raw_template_contents` used to
+  // underflow its slice and panic with
+  // "slice index starts at 5 but ends at 4".
+  it.each([
+    ["<y/``", "jsx"],
+    ["<y/`x`", "jsx"],
+    ["<y/```", "jsx"],
+    ["<y/`${1}`", "jsx"],
+    ["<y/``", "tsx"],
+  ])("reports a parse error for %j (%s loader) instead of panicking", (code, loader) => {
+    const transpiler = new Bun.Transpiler({ loader });
+    expect(() => transpiler.transformSync(code)).toThrow(/Expected|error/i);
+  });
+});


### PR DESCRIPTION
## Reproduction

```console
$ printf '<y/``' > /tmp/repro.js
$ bun-debug /tmp/repro.js
panic: slice index starts at 5 but ends at 4 (src/js_parser/lexer.rs:3463:38)
```

## Cause

For input `<y/\`\``:

1. `pfx_t_less_than` takes the JSX branch and enters `parse_jsx_element`.
2. The JSX lexer eats `<y/`, then `next_inside_jsx_element` reads the first backtick. Backtick is not a valid JSX token, so the catch-all arm sets `token = TSyntaxError` and `end = current` without stepping past the backtick.
3. `parse_jsx_element`'s self-closing branch calls `p.lexer.expected(T::TGreaterThan)?`. `expected` routes through `add_range_error`, which **logs the error and returns `Ok(())`** (see `ast/lexer_log.rs:70`) instead of propagating. The JSX parse happily returns a `JSXElement` for the malformed tag.
4. Back in `pfx_t_less_than`, `p.lexer.next()?` runs. `next()` sees `code_point = 0x60` (still the backtick) and dispatches to `parse_string_literal::<0x60>`, setting `token = TNoSubstitutionTemplateLiteral`. After stepping past the second backtick and hitting EOF, the final span is `start = 4`, `end = 5`.
5. `parse_suffix` sees the template token and calls `raw_template_contents`, which indexes `contents[start + 1..end - 1]` = `contents[5..4]`. Panic.

`raw_template_contents` assumes the span is a well-formed template literal of at least two backticks (`end >= start + 2` for `TNoSubstitution` / `TTemplateTail`; `end >= start + 3` for `TTemplateHead` / `TTemplateMiddle`). Error recovery violates that invariant.

## Fix

Guard both match arms so a span shorter than a well-formed literal returns empty raw contents. The error has already been logged upstream, so the parse continues naturally and surfaces a user-facing `Expected ">" but found \`` error.

## Verification

```console
$ bun-debug /tmp/repro.js
1 | <y/``
       ^
error: Expected ">" but found "\`"
    at /tmp/repro.js:1:4
```

Test added to `test/bundler/transpiler/transpiler.test.js` covers five malformed-JSX variants (`<y/\`\``, `<y/\`x\``, `<y/\`\`\``, `<y/\`${1}\`` under `jsx`, plus the base case under `tsx`). Without the fix, the test binary panics with the same slice-index message; with the fix, each input throws a parse error and exits cleanly.

Fixes #30892