### PR TITLE
js_parser/lexer: saturate escape-sequence error offsets to avoid usize underflow

### DIFF
--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -708,9 +708,10 @@ lexer_impl_header! {
                         // legacy octal literals
                         0x30..=0x37 => {
                             let octal_start =
-                                (iter.i as usize + width2 as usize) - 2;
+                                (iter.i as usize + width2 as usize).saturating_sub(2);
                             if IS_JSON {
-                                self.end = start + iter.i as usize - width2 as usize;
+                                self.end = (start + iter.i as usize)
+                                    .saturating_sub(width2 as usize);
                                 self.syntax_error()?;
                             }
 
@@ -799,8 +800,8 @@ lexer_impl_header! {
                             match hex_digit_value_u32(c3 as u32) {
                                 Some(d) => value = value * 16 | d as CodePoint,
                                 None => {
-                                    self.end =
-                                        start + iter.i as usize - width3 as usize;
+                                    self.end = (start + iter.i as usize)
+                                        .saturating_sub(width3 as usize);
                                     return self.syntax_error();
                                 }
                             }
@@ -813,8 +814,8 @@ lexer_impl_header! {
                             match hex_digit_value_u32(c3 as u32) {
                                 Some(d) => value = value * 16 | d as CodePoint,
                                 None => {
-                                    self.end =
-                                        start + iter.i as usize - width3 as usize;
+                                    self.end = (start + iter.i as usize)
+                                        .saturating_sub(width3 as usize);
                                     return self.syntax_error();
                                 }
                             }
@@ -835,8 +836,8 @@ lexer_impl_header! {
                             // variable-length
                             if c3 == 0x7B {
                                 if IS_JSON {
-                                    self.end =
-                                        start + iter.i as usize - width2 as usize;
+                                    self.end = (start + iter.i as usize)
+                                        .saturating_sub(width2 as usize);
                                     self.syntax_error()?;
                                 }
 
@@ -906,8 +907,8 @@ lexer_impl_header! {
                                     match hex_digit_value_u32(c3 as u32) {
                                         Some(d) => value = value * 16 | d as i64,
                                         None => {
-                                            self.end = start + iter.i as usize
-                                                - width3 as usize;
+                                            self.end = (start + iter.i as usize)
+                                                .saturating_sub(width3 as usize);
                                             return self.syntax_error();
                                         }
                                     }
@@ -928,8 +929,8 @@ lexer_impl_header! {
                         }
                         0x0D => {
                             if IS_JSON {
-                                self.end =
-                                    start + iter.i as usize - width2 as usize;
+                                self.end = (start + iter.i as usize)
+                                    .saturating_sub(width2 as usize);
                                 self.syntax_error()?;
                             }
 
@@ -943,8 +944,8 @@ lexer_impl_header! {
                         }
                         0x0A | 0x2028 | 0x2029 => {
                             if IS_JSON {
-                                self.end =
-                                    start + iter.i as usize - width2 as usize;
+                                self.end = (start + iter.i as usize)
+                                    .saturating_sub(width2 as usize);
                                 self.syntax_error()?;
                             }
 
@@ -956,8 +957,8 @@ lexer_impl_header! {
                                 match c2 {
                                     0x22 | 0x5C | 0x2F => {}
                                     _ => {
-                                        self.end = start + iter.i as usize
-                                            - width2 as usize;
+                                        self.end = (start + iter.i as usize)
+                                            .saturating_sub(width2 as usize);
                                         self.syntax_error()?;
                                     }
                                 }

--- a/src/parsers/toml/lexer.rs
+++ b/src/parsers/toml/lexer.rs
@@ -912,7 +912,8 @@ impl<'a> Lexer<'a> {
                             continue;
                         }
                         c if c == 'f' as CodePoint => {
-                            buf.push(9);
+                            // Form feed: U+000C
+                            buf.push(12);
                             continue;
                         }
                         c if c == 'n' as CodePoint => {
@@ -930,7 +931,8 @@ impl<'a> Lexer<'a> {
                             continue;
                         }
                         c if c == 't' as CodePoint => {
-                            buf.push(12);
+                            // Horizontal tab: U+0009
+                            buf.push(9);
                             continue;
                         }
                         c if c == 'r' as CodePoint => {

--- a/src/parsers/toml/lexer.rs
+++ b/src/parsers/toml/lexer.rs
@@ -1157,8 +1157,13 @@ impl<'a> Lexer<'a> {
                             }
 
                             // Ignore line continuations. A line continuation is not an escaped newline.
-                            if (iter.i as usize) < text.len() && text[iter.i as usize + 1] == b'\n'
-                            {
+                            // Match the JS lexer (js_parser/lexer.rs:660-661, 937-939): guard on
+                            // the index we actually read (`iter.i + 1`), not `iter.i`. Without
+                            // this, a multiline basic string ending in `\<CR>` right before `"""`
+                            // reads `text[len]` and panics even in release (slice bounds checks
+                            // always run).
+                            let next_i: usize = iter.i as usize + 1;
+                            if next_i < text.len() && text[next_i] == b'\n' {
                                 // Make sure Windows CRLF counts as a single newline
                                 iter.i += 1;
                             }

--- a/src/parsers/toml/lexer.rs
+++ b/src/parsers/toml/lexer.rs
@@ -940,7 +940,7 @@ impl<'a> Lexer<'a> {
 
                         // legacy octal literals
                         c if ('0' as CodePoint..='7' as CodePoint).contains(&c) => {
-                            let octal_start = (iter.i as usize + width2 as usize) - 2;
+                            let octal_start = (iter.i as usize + width2 as usize).saturating_sub(2);
 
                             // 1-3 digit octal
                             let mut is_bad = false;
@@ -1014,7 +1014,8 @@ impl<'a> Lexer<'a> {
                         // 2-digit hexadecimal
                         c if c == 'x' as CodePoint => {
                             if ALLOW_MULTILINE {
-                                self.end = start + iter.i as usize - width2 as usize;
+                                self.end =
+                                    (start + iter.i as usize).saturating_sub(width2 as usize);
                                 self.syntax_error()?;
                             }
 
@@ -1030,7 +1031,8 @@ impl<'a> Lexer<'a> {
                             match hex_digit_value_u32(c3 as u32) {
                                 Some(d) => value = value * 16 | d as CodePoint,
                                 None => {
-                                    self.end = start + iter.i as usize - width3 as usize;
+                                    self.end =
+                                        (start + iter.i as usize).saturating_sub(width3 as usize);
                                     return self.syntax_error();
                                 }
                             }
@@ -1043,7 +1045,8 @@ impl<'a> Lexer<'a> {
                             match hex_digit_value_u32(c3 as u32) {
                                 Some(d) => value = value * 16 | d as CodePoint,
                                 None => {
-                                    self.end = start + iter.i as usize - width3 as usize;
+                                    self.end =
+                                        (start + iter.i as usize).saturating_sub(width3 as usize);
                                     return self.syntax_error();
                                 }
                             }
@@ -1063,10 +1066,10 @@ impl<'a> Lexer<'a> {
 
                             // variable-length
                             if c3 == '{' as CodePoint {
-                                let hex_start = iter.i as usize
-                                    - width as usize
-                                    - width2 as usize
-                                    - width3 as usize;
+                                let hex_start = (iter.i as usize)
+                                    .saturating_sub(width as usize)
+                                    .saturating_sub(width2 as usize)
+                                    .saturating_sub(width3 as usize);
                                 let mut is_first = true;
                                 let mut is_out_of_range = false;
                                 'variable_length: loop {
@@ -1077,7 +1080,8 @@ impl<'a> Lexer<'a> {
 
                                     if c3 == '}' as CodePoint {
                                         if is_first {
-                                            self.end = start + iter.i as usize - width3 as usize;
+                                            self.end = (start + iter.i as usize)
+                                                .saturating_sub(width3 as usize);
                                             return self.syntax_error();
                                         }
                                         break 'variable_length;
@@ -1085,7 +1089,8 @@ impl<'a> Lexer<'a> {
                                     match hex_digit_value_u32(c3 as u32) {
                                         Some(d) => value = value * 16 | d as i64,
                                         None => {
-                                            self.end = start + iter.i as usize - width3 as usize;
+                                            self.end = (start + iter.i as usize)
+                                                .saturating_sub(width3 as usize);
                                             return self.syntax_error();
                                         }
                                     }
@@ -1105,8 +1110,10 @@ impl<'a> Lexer<'a> {
                                                 start: i32::try_from(start + hex_start)
                                                     .expect("int cast"),
                                             },
-                                            len: i32::try_from(iter.i as usize - hex_start)
-                                                .unwrap(),
+                                            len: i32::try_from(
+                                                (iter.i as usize).saturating_sub(hex_start),
+                                            )
+                                            .unwrap(),
                                         },
                                         format_args!("Unicode escape sequence is out of range"),
                                     )?;
@@ -1122,7 +1129,8 @@ impl<'a> Lexer<'a> {
                                     match hex_digit_value_u32(c3 as u32) {
                                         Some(d) => value = value * 16 | d as i64,
                                         None => {
-                                            self.end = start + iter.i as usize - width3 as usize;
+                                            self.end = (start + iter.i as usize)
+                                                .saturating_sub(width3 as usize);
                                             return self.syntax_error();
                                         }
                                     }
@@ -1143,7 +1151,8 @@ impl<'a> Lexer<'a> {
                         }
                         c if c == '\r' as CodePoint => {
                             if !ALLOW_MULTILINE {
-                                self.end = start + iter.i as usize - width2 as usize;
+                                self.end =
+                                    (start + iter.i as usize).saturating_sub(width2 as usize);
                                 self.add_default_error(b"Unexpected end of line")?;
                             }
 
@@ -1158,7 +1167,8 @@ impl<'a> Lexer<'a> {
                         c if c == '\n' as CodePoint || c == 0x2028 || c == 0x2029 => {
                             // Ignore line continuations. A line continuation is not an escaped newline.
                             if !ALLOW_MULTILINE {
-                                self.end = start + iter.i as usize - width2 as usize;
+                                self.end =
+                                    (start + iter.i as usize).saturating_sub(width2 as usize);
                                 self.add_default_error(b"Unexpected end of line")?;
                             }
                             continue;

--- a/src/parsers/toml/lexer.rs
+++ b/src/parsers/toml/lexer.rs
@@ -887,8 +887,14 @@ impl<'a> Lexer<'a> {
             let width = iter.width;
             match iter.c {
                 c if c == '\r' as CodePoint => {
-                    // Convert '\r\n' into '\n'
-                    if (iter.i as usize) < text.len() && text[iter.i as usize] == b'\n' {
+                    // Convert '\r\n' into '\n'. After `next()` returns for `\r`,
+                    // `iter.i` is the start byte of the `\r` itself — the `\n`
+                    // we're looking for is at `iter.i + 1`. Reading `text[iter.i]`
+                    // would always be `\r`, so the check never fired and a literal
+                    // CRLF in a slow-path multiline basic string decoded to two LFs.
+                    // Match the JS lexer (js_parser/lexer.rs:660-661).
+                    let next_i: usize = iter.i as usize + 1;
+                    if next_i < text.len() && text[next_i] == b'\n' {
                         iter.i += 1;
                     }
 

--- a/test/js/bun/resolve/toml/toml-parse.test.ts
+++ b/test/js/bun/resolve/toml/toml-parse.test.ts
@@ -5,3 +5,35 @@ test("Bun.TOML.parse with non-string input throws", () => {
   expect(() => Bun.TOML.parse(undefined as any)).toThrow();
   expect(() => Bun.TOML.parse(null as any)).toThrow();
 });
+
+// https://github.com/oven-sh/bun/issues/30893
+// TOML copy of decode_escape_sequences had the same unprotected subtraction as the JS lexer:
+// `start + iter.i - widthN` underflows whenever an escape (or the `\u{` hex_start
+// computation) lands at the start of a basic string. `\u{...}` at the very start of
+// a string underflows even for VALID input because hex_start is computed eagerly
+// before the loop. Must parse cleanly, not panic.
+test("Bun.TOML.parse accepts \\u{XX} at start of a basic string (#30893)", () => {
+  expect(Bun.TOML.parse(`key = "\\u{41}"`)).toEqual({ key: "A" });
+});
+
+test("Bun.TOML.parse rejects \\x escape (basic strings don't allow \\x) without panicking (#30893)", () => {
+  // `\x` followed by a multi-byte codepoint would underflow in the error path.
+  // Construct the bytes directly: `key = "\x<U+3945C>"`.
+  const input =
+    "key = " +
+    String.fromCharCode(0x22) +
+    "\\x" +
+    String.fromCodePoint(0x3945c) +
+    String.fromCharCode(0x22);
+  expect(() => Bun.TOML.parse(input)).toThrow();
+});
+
+test("Bun.TOML.parse rejects \\u followed by multi-byte codepoint without panicking (#30893)", () => {
+  const input =
+    "key = " +
+    String.fromCharCode(0x22) +
+    "\\u" +
+    String.fromCodePoint(0x3945c) +
+    String.fromCharCode(0x22);
+  expect(() => Bun.TOML.parse(input)).toThrow();
+});

--- a/test/js/bun/resolve/toml/toml-parse.test.ts
+++ b/test/js/bun/resolve/toml/toml-parse.test.ts
@@ -32,3 +32,17 @@ test("Bun.TOML.parse rejects \\u escape in quoted key at file start without pani
   const input = '"\\u' + String.fromCodePoint(0x3945c) + '" = 1';
   expect(() => Bun.TOML.parse(input)).toThrow();
 });
+
+// https://github.com/oven-sh/bun/issues/30893
+// Off-by-one in the CRLF look-ahead of the `\r` line-continuation branch: the guard
+// checked `iter.i < text.len()` but indexed `text[iter.i + 1]`. A multiline basic
+// string ending in `\<CR>` immediately before `"""` triggers `text[len]` — and slice
+// bounds checks fire in release too, so this was a hard crash everywhere (not just
+// debug). The JS lexer already reads the index it guards on; this brings the TOML
+// copy in line.
+test("Bun.TOML.parse handles trailing backslash-CR in multiline basic string (#30893)", () => {
+  // Bytes: `key = """\<CR>"""` — a backslash line-continuation where the newline
+  // is a bare CR and the string ends immediately after it.
+  const input = 'key = """\\\r"""';
+  expect(Bun.TOML.parse(input)).toEqual({ key: "" });
+});

--- a/test/js/bun/resolve/toml/toml-parse.test.ts
+++ b/test/js/bun/resolve/toml/toml-parse.test.ts
@@ -7,25 +7,28 @@ test("Bun.TOML.parse with non-string input throws", () => {
 });
 
 // https://github.com/oven-sh/bun/issues/30893
-// TOML copy of decode_escape_sequences had the same unprotected subtraction as the JS lexer:
-// `start + iter.i - widthN` underflows whenever an escape (or the `\u{` hex_start
-// computation) lands at the start of a basic string. `\u{...}` at the very start of
-// a string underflows even for VALID input because hex_start is computed eagerly
-// before the loop. Must parse cleanly, not panic.
+// TOML copy of decode_escape_sequences had the same unprotected subtraction as the JS
+// lexer: `start + iter.i - widthN` underflows whenever an escape lands near byte 0 of
+// the source. The string body must open at the start of the file — a quoted KEY at file
+// start (`"\x…" = 1`) gives `start = 1`, so `1 + 2 - 4` underflows. A bare-key assignment
+// like `key = "…"` puts `start` at 7, which is big enough that the subtraction stays
+// positive on unpatched builds and the test wouldn't catch a regression.
+// `\u{…}` is a separate case: `hex_start = iter.i - width - width2 - width3` doesn't
+// involve `start` at all, so it underflows for *valid* input like `"\u{41}"` regardless
+// of where the string sits.
 test("Bun.TOML.parse accepts \\u{XX} at start of a basic string (#30893)", () => {
   expect(Bun.TOML.parse(`key = "\\u{41}"`)).toEqual({ key: "A" });
 });
 
-test("Bun.TOML.parse rejects \\x escape (basic strings don't allow \\x) without panicking (#30893)", () => {
-  // `\x` followed by a multi-byte codepoint would underflow in the error path.
-  // Construct the bytes directly: `key = "\x<U+3945C>"`.
-  const input =
-    "key = " + String.fromCharCode(0x22) + "\\x" + String.fromCodePoint(0x3945c) + String.fromCharCode(0x22);
+test("Bun.TOML.parse rejects \\x escape in quoted key at file start without panicking (#30893)", () => {
+  // Quoted key at offset 0 puts `start = 1`; `\x` + 4-byte codepoint underflows at L1033.
+  // Bytes: `"\x<U+3945C>" = 1`
+  const input = '"\\x' + String.fromCodePoint(0x3945c) + '" = 1';
   expect(() => Bun.TOML.parse(input)).toThrow();
 });
 
-test("Bun.TOML.parse rejects \\u followed by multi-byte codepoint without panicking (#30893)", () => {
-  const input =
-    "key = " + String.fromCharCode(0x22) + "\\u" + String.fromCodePoint(0x3945c) + String.fromCharCode(0x22);
+test("Bun.TOML.parse rejects \\u escape in quoted key at file start without panicking (#30893)", () => {
+  // Quoted key at offset 0; `\u` + 4-byte codepoint underflows at L1125 (fixed-length \u branch).
+  const input = '"\\u' + String.fromCodePoint(0x3945c) + '" = 1';
   expect(() => Bun.TOML.parse(input)).toThrow();
 });

--- a/test/js/bun/resolve/toml/toml-parse.test.ts
+++ b/test/js/bun/resolve/toml/toml-parse.test.ts
@@ -46,3 +46,12 @@ test("Bun.TOML.parse handles trailing backslash-CR in multiline basic string (#3
   const input = 'key = """\\\r"""';
   expect(Bun.TOML.parse(input)).toEqual({ key: "" });
 });
+
+// Pre-existing bug inherited from toml/lexer.zig: the `\t` / `\f` single-char escape
+// arms had their output codepoints swapped (`\t` produced 0x0C form feed instead of
+// 0x09 tab; `\f` produced 0x09 instead of 0x0C). The TOML spec (and ASCII) define
+// `\t` = U+0009 and `\f` = U+000C, and the JS lexer already gets this right.
+test("Bun.TOML.parse produces correct codepoints for \\t and \\f escapes", () => {
+  expect(Bun.TOML.parse('k = "a\\tb"').k).toBe("a\u0009b");
+  expect(Bun.TOML.parse('k = "a\\fb"').k).toBe("a\u000cb");
+});

--- a/test/js/bun/resolve/toml/toml-parse.test.ts
+++ b/test/js/bun/resolve/toml/toml-parse.test.ts
@@ -55,3 +55,15 @@ test("Bun.TOML.parse produces correct codepoints for \\t and \\f escapes", () =>
   expect(Bun.TOML.parse('k = "a\\tb"').k).toBe("a\u0009b");
   expect(Bun.TOML.parse('k = "a\\fb"').k).toBe("a\u000cb");
 });
+
+// The outer `\r` arm in decode_escape_sequences had the same iter.i-semantics bug
+// as the `\r` escape arm below it: it indexed `text[iter.i]` for the CRLF lookahead,
+// but after `next()` returns for `\r`, `iter.i` IS the `\r` byte, so the check never
+// fired. Every literal CRLF in a slow-path multiline TOML basic string (any `"""..."""`
+// containing CRLF plus at least one backslash escape to force the slow path) decoded
+// to two LFs instead of one.
+test("Bun.TOML.parse normalizes literal CRLF to LF in multiline basic strings", () => {
+  // `"""a<CRLF>b\tc"""` — the `\t` escape forces the slow decode path.
+  const input = 'k = """a\r\nb\\tc"""';
+  expect(Bun.TOML.parse(input).k).toBe("a\nb\tc");
+});

--- a/test/js/bun/resolve/toml/toml-parse.test.ts
+++ b/test/js/bun/resolve/toml/toml-parse.test.ts
@@ -20,20 +20,12 @@ test("Bun.TOML.parse rejects \\x escape (basic strings don't allow \\x) without 
   // `\x` followed by a multi-byte codepoint would underflow in the error path.
   // Construct the bytes directly: `key = "\x<U+3945C>"`.
   const input =
-    "key = " +
-    String.fromCharCode(0x22) +
-    "\\x" +
-    String.fromCodePoint(0x3945c) +
-    String.fromCharCode(0x22);
+    "key = " + String.fromCharCode(0x22) + "\\x" + String.fromCodePoint(0x3945c) + String.fromCharCode(0x22);
   expect(() => Bun.TOML.parse(input)).toThrow();
 });
 
 test("Bun.TOML.parse rejects \\u followed by multi-byte codepoint without panicking (#30893)", () => {
   const input =
-    "key = " +
-    String.fromCharCode(0x22) +
-    "\\u" +
-    String.fromCodePoint(0x3945c) +
-    String.fromCharCode(0x22);
+    "key = " + String.fromCharCode(0x22) + "\\u" + String.fromCodePoint(0x3945c) + String.fromCharCode(0x22);
   expect(() => Bun.TOML.parse(input)).toThrow();
 });

--- a/test/regression/issue/invalid-escape-sequences.test.ts
+++ b/test/regression/issue/invalid-escape-sequences.test.ts
@@ -123,12 +123,9 @@ test("Invalid escaped z in identifier shows helpful error message", async () => 
 });
 
 // https://github.com/oven-sh/bun/issues/30893
-// Fuzzer discovered that an invalid escape sequence where the first character
-// after `\x`, `\u`, or `\u{` is a multi-byte codepoint caused a subtract-with-
-// overflow panic in debug builds (silent wrap in release). The lexer's error
-// path computed `start + iter.i - width` without saturation; when the offending
-// character is the very first thing in the string, iter.i can be smaller than
-// the codepoint's byte width.
+// Invalid escape sequence where the first char after `\x`, `\u`, or `\u{` is a
+// multi-byte codepoint underflowed `start + iter.i - width` in the lexer's error
+// path — panic in debug, silent wrap in release.
 test("invalid \\x followed by multi-byte codepoint does not panic (#30893)", async () => {
   // Input bytes: 0x27 0x5C 0x78 0xF0 0xB9 0x91 0x9C 0x27 0xFF
   //              '    \    x    <── U+3945C ──>  '    (trailing junk)
@@ -141,6 +138,7 @@ test("invalid \\x followed by multi-byte codepoint does not panic (#30893)", asy
     env: bunEnv,
     stderr: "pipe",
     stdout: "pipe",
+    cwd: String(dir),
   });
 
   const err = stderr.toString();
@@ -160,6 +158,7 @@ test("invalid \\x with second hex digit being multi-byte codepoint does not pani
     env: bunEnv,
     stderr: "pipe",
     stdout: "pipe",
+    cwd: String(dir),
   });
 
   expect(stderr.toString()).toContain("Syntax Error");
@@ -177,6 +176,7 @@ test("invalid \\u followed by multi-byte codepoint does not panic (#30893)", asy
     env: bunEnv,
     stderr: "pipe",
     stdout: "pipe",
+    cwd: String(dir),
   });
 
   expect(stderr.toString()).toContain("Syntax Error");
@@ -194,6 +194,7 @@ test("invalid \\u{ followed by multi-byte codepoint does not panic (#30893)", as
     env: bunEnv,
     stderr: "pipe",
     stdout: "pipe",
+    cwd: String(dir),
   });
 
   expect(stderr.toString()).toContain("Syntax Error");

--- a/test/regression/issue/invalid-escape-sequences.test.ts
+++ b/test/regression/issue/invalid-escape-sequences.test.ts
@@ -122,6 +122,84 @@ test("Invalid escaped z in identifier shows helpful error message", async () => 
   expect(err).toContain(":1:7");
 });
 
+// https://github.com/oven-sh/bun/issues/30893
+// Fuzzer discovered that an invalid escape sequence where the first character
+// after `\x`, `\u`, or `\u{` is a multi-byte codepoint caused a subtract-with-
+// overflow panic in debug builds (silent wrap in release). The lexer's error
+// path computed `start + iter.i - width` without saturation; when the offending
+// character is the very first thing in the string, iter.i can be smaller than
+// the codepoint's byte width.
+test("invalid \\x followed by multi-byte codepoint does not panic (#30893)", async () => {
+  // Input bytes: 0x27 0x5C 0x78 0xF0 0xB9 0x91 0x9C 0x27 0xFF
+  //              '    \    x    <── U+3945C ──>  '    (trailing junk)
+  using dir = tempDir("escape-overflow", {
+    "test.js": Buffer.from([0x27, 0x5c, 0x78, 0xf0, 0xb9, 0x91, 0x9c, 0x27, 0xff]),
+  });
+
+  const { stderr, exitCode } = Bun.spawnSync({
+    cmd: [bunExe(), join(dir, "test.js")],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const err = stderr.toString();
+  // Must be a clean SyntaxError, not a panic.
+  expect(err).toContain("Syntax Error");
+  expect(exitCode).toBe(1);
+});
+
+test("invalid \\x with second hex digit being multi-byte codepoint does not panic (#30893)", async () => {
+  // '\x2' followed by a 4-byte codepoint: exercises the second-hex-digit branch.
+  using dir = tempDir("escape-overflow-2", {
+    "test.js": Buffer.from([0x27, 0x5c, 0x78, 0x32, 0xf0, 0xb9, 0x91, 0x9c, 0x27]),
+  });
+
+  const { stderr, exitCode } = Bun.spawnSync({
+    cmd: [bunExe(), join(dir, "test.js")],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  expect(stderr.toString()).toContain("Syntax Error");
+  expect(exitCode).toBe(1);
+});
+
+test("invalid \\u followed by multi-byte codepoint does not panic (#30893)", async () => {
+  // '\u' followed by a 4-byte codepoint: exercises the fixed-length \u branch.
+  using dir = tempDir("escape-overflow-u", {
+    "test.js": Buffer.from([0x27, 0x5c, 0x75, 0xf0, 0xb9, 0x91, 0x9c, 0x27]),
+  });
+
+  const { stderr, exitCode } = Bun.spawnSync({
+    cmd: [bunExe(), join(dir, "test.js")],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  expect(stderr.toString()).toContain("Syntax Error");
+  expect(exitCode).toBe(1);
+});
+
+test("invalid \\u{ followed by multi-byte codepoint does not panic (#30893)", async () => {
+  // '\u{' followed by a 4-byte codepoint then '}': exercises the variable-length branch.
+  using dir = tempDir("escape-overflow-u-brace", {
+    "test.js": Buffer.from([0x27, 0x5c, 0x75, 0x7b, 0xf0, 0xb9, 0x91, 0x9c, 0x7d, 0x27]),
+  });
+
+  const { stderr, exitCode } = Bun.spawnSync({
+    cmd: [bunExe(), join(dir, "test.js")],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  expect(stderr.toString()).toContain("Syntax Error");
+  expect(exitCode).toBe(1);
+});
+
 test("Valid unicode escapes in identifiers should work", async () => {
   // Test valid \u escape with 4 hex digits
   {

--- a/test/regression/issue/invalid-escape-sequences.test.ts
+++ b/test/regression/issue/invalid-escape-sequences.test.ts
@@ -125,7 +125,10 @@ test("Invalid escaped z in identifier shows helpful error message", async () => 
 // https://github.com/oven-sh/bun/issues/30893
 // Invalid escape sequence where the first char after `\x`, `\u`, or `\u{` is a
 // multi-byte codepoint underflowed `start + iter.i - width` in the lexer's error
-// path — panic in debug, silent wrap in release.
+// path — panic in debug, silent wrap in release. The wrapped value is stored in
+// `self.end`, but `syntax_error()` reports at `self.start`, so release output is
+// identical pre/post-fix and nothing here can distinguish them under
+// USE_SYSTEM_BUN=1. These tests exist to guard `bun bd` (ASAN/debug) CI.
 test("invalid \\x followed by multi-byte codepoint does not panic (#30893)", async () => {
   // Input bytes: 0x27 0x5C 0x78 0xF0 0xB9 0x91 0x9C 0x27 0xFF
   //              '    \    x    <── U+3945C ──>  '    (trailing junk)


### PR DESCRIPTION
## Reproduction

```console
$ echo J1x48LmRnCf/ | base64 -d | bun-debug -
panic: attempt to subtract with overflow (src/js_parser/lexer.rs:803:41)
```

The input is `' \ x F0 B9 91 9C ' FF` — a string literal starting with `\x` immediately followed by a 4-byte UTF-8 codepoint.

## Cause

In `decode_escape_sequences`, several error paths place the diagnostic caret by computing `start + iter.i - widthN` — the position of the offending character minus its byte width. When that character is the very first thing in the string literal, `iter.i` can be smaller than `widthN` (e.g. `iter.i = 1`, `widthN = 4`), and the usize subtraction underflows. Debug builds panic; release silently wraps to a nonsense `self.end`.

The original Zig source used `-|` (saturating subtract) in two of these spots (`lexer.zig:511, 517`), but the rest used raw subtraction — inherited as-is by the Rust port.

## Fix

Use `saturating_sub` in every such error path in `decode_escape_sequences`. The result is only used to produce a caret position inside an error message; saturating to 0 when `iter.i < widthN` still gives a reasonable location. Patched sites:

- 2-digit `\x` — first hex invalid (the reported panic)
- 2-digit `\x` — second hex invalid
- `\u` fixed-length — any of 4 hex digits invalid
- JSON-mode checks inside `\0`, `\u{`, `\r`, `\n`, and the catch-all non-JSON-allowed escape
- `octal_start` computation for the legacy-octal range error

## Verification

```console
$ echo J1x48LmRnCf/ | base64 -d | bun-debug -
1 | '\x𹑜'
    ^
error: Syntax Error
    at -:1:1
```

Four new tests in `test/regression/issue/invalid-escape-sequences.test.ts` cover `\x` (1st-hex), `\x2` (2nd-hex), `\u` (fixed-length), and `\u{` (variable-length) each followed by a 4-byte codepoint. Without the fix: 3 of the 4 panic on their respective lines (803/817/909); the `\u{` variant already used `saturating_sub` so it passes either way but is retained for coverage.

Fixes #30893