### PR TITLE
perf: bundler & transpiler hot-path optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1205,6 +1205,7 @@ dependencies = [
  "bun_ptr",
  "bun_sourcemap",
  "bun_sys",
+ "bun_wyhash",
  "bytemuck",
  "const_format",
  "enum-map",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,6 +1152,7 @@ dependencies = [
  "phf 0.11.3",
  "regex",
  "scopeguard",
+ "smallvec",
  "strum",
  "typed-arena",
 ]

--- a/bench/bundle/index10.ts
+++ b/bench/bundle/index10.ts
@@ -1,0 +1,10 @@
+export * as Three1 from 'three-1';
+export * as Three2 from 'three-2';
+export * as Three3 from 'three-3';
+export * as Three4 from 'three-4';
+export * as Three5 from 'three-5';
+export * as Three6 from 'three-6';
+export * as Three7 from 'three-7';
+export * as Three8 from 'three-8';
+export * as Three9 from 'three-9';
+export * as Three10 from 'three-10';

--- a/src/ast/char_freq.rs
+++ b/src/ast/char_freq.rs
@@ -187,10 +187,16 @@ fn scan_small(out: &mut Buffer, text: &[u8], delta: i32) {
     // RMWs in the loop. The Rust field is naturally aligned, so operate on `out` directly
     // (same treatment as `scan_big`).
     for &c in text {
+        // Indices follow `NameMinifier::DEFAULT_TAIL` order
+        // (`a-zA-Z0-9_$` → 0..63), matching `scan_big` which writes digits
+        // at `out[52 + i]`. The Zig original (`char_freq.zig:79`) used `53`,
+        // which shifted `'0'` to 53 and made `'9'` collide with `'_'` at 62,
+        // leaving slot 52 cold for `<32`-byte inputs and slightly skewing
+        // minified-name ranking when digits/underscores appear.
         let i: usize = match c {
             b'a'..=b'z' => c as usize - b'a' as usize,
             b'A'..=b'Z' => c as usize - (b'A' as usize - 26),
-            b'0'..=b'9' => c as usize + (53 - b'0' as usize),
+            b'0'..=b'9' => c as usize + (52 - b'0' as usize),
             b'_' => 62,
             b'$' => 63,
             _ => continue,

--- a/src/ast/char_freq.rs
+++ b/src/ast/char_freq.rs
@@ -183,8 +183,9 @@ fn scan_big(out: &mut Buffer, text: &[u8], delta: i32) {
 }
 
 fn scan_small(out: &mut Buffer, text: &[u8], delta: i32) {
-    let mut freqs: [i32; CHAR_FREQ_COUNT] = *out;
-
+    // PORT NOTE: Zig copied `out.*` into a stack local to avoid unaligned (`align(1)`)
+    // RMWs in the loop. The Rust field is naturally aligned, so operate on `out` directly
+    // (same treatment as `scan_big`).
     for &c in text {
         let i: usize = match c {
             b'a'..=b'z' => c as usize - b'a' as usize,
@@ -194,10 +195,8 @@ fn scan_small(out: &mut Buffer, text: &[u8], delta: i32) {
             b'$' => 63,
             _ => continue,
         };
-        freqs[i] += delta;
+        out[i] += delta;
     }
-
-    *out = freqs;
 }
 
 // ported from: src/js_parser/ast/CharFreq.zig

--- a/src/ast/scope.rs
+++ b/src/ast/scope.rs
@@ -93,26 +93,30 @@ impl Default for Scope {
 pub type NestedScopeMap = ArrayHashMap<u32, Vec<StoreRef<Scope>>>;
 
 impl Scope {
-    // PERF(port): the parser's hot path computes the wyhash once and reuses it
-    // for lookup+insert; `StringHashMap`'s current `std::HashMap` backing
-    // ignores the precomputed hash (see `get_adapted` doc), so the rehash
-    // avoidance is lost until that map moves onto a wyhash-backed table.
+    // Must agree with `StringHashMap`'s `BuildHasher` (`bun_wyhash::BuildHasher`,
+    // i.e. `BuildHasherDefault<OneShotHasher>`) so the precomputed hash can be
+    // fed to `get_hashed` without a rehash per scope level. If the map's hasher
+    // ever changes, this must change with it (the debug_assert below catches it).
     pub fn get_member_hash(name: &[u8]) -> u64 {
-        bun_collections::string_hash_map::hash(name)
+        bun_wyhash::auto_hash::<[u8]>(name)
     }
     pub fn get_member_with_hash(&self, name: &[u8], hash_value: u64) -> Option<Member> {
-        let hashed = bun_collections::string_hash_map::Prehashed {
-            value: hash_value,
-            input: name,
-        };
-        self.members.get_adapted(name, &hashed).copied()
+        debug_assert_eq!(
+            self.members.hash_key(name),
+            hash_value,
+            "Scope::get_member_hash diverged from StringHashMap's BuildHasher"
+        );
+        self.members.get_hashed(hash_value, name).copied()
     }
     pub fn get_or_put_member_with_hash(
         &mut self,
         name: &[u8],
         hash_value: u64,
     ) -> bun_collections::array_hash_map::StringHashMapGetOrPut<'_, Member> {
-        let _ = hash_value; // PERF(port): see `StringHashMap::get_adapted` note.
+        // PERF(port): `get_or_put_borrowed` doesn't accept a precomputed hash;
+        // this path is once-per-declared-symbol (not per-scope-per-identifier),
+        // so the redundant rehash is left as-is.
+        let _ = hash_value;
         // SAFETY: `name` is always a slice into either the source-file contents
         // or the lexer string-table (the only producers of identifier text in
         // the parser). Both outlive the `AstAlloc` arena that owns this

--- a/src/bun_core/string/StringJoiner.rs
+++ b/src/bun_core/string/StringJoiner.rs
@@ -1,7 +1,6 @@
 //! Rope-like data structure for joining many small strings into one big string.
-//! Implemented as a linked list of potentially-owned slices and a length.
-
-use core::ptr::{self, NonNull};
+//! Implemented as a flat `Vec` of potentially-owned slices plus a running
+//! length, so the join-time output buffer can be sized exactly once.
 
 use crate::RawSlice;
 use crate::string::strings;
@@ -9,20 +8,22 @@ use bun_alloc::AllocError;
 
 // PORT NOTE: Zig's `std.mem.Allocator` param field dropped — global mimalloc is used for
 // node and duplicated-string allocations.
-// PERF(port): Zig recommended a stack-fallback allocator here — profile if it shows up on a hot path.
 pub struct StringJoiner {
     /// Total length of all nodes
     pub len: usize,
 
-    pub head: Option<Box<Node>>,
-    pub tail: Option<NonNull<Node>>,
+    /// Slices in insertion order. Stored flat instead of as a singly-linked
+    /// list so a join with N pieces does ~log₂N Vec reallocs instead of N
+    /// `Box<Node>` allocations and N pointer-chasing dereferences on drain.
+    nodes: Vec<Node>,
 
     /// Avoid an extra pass over the list when joining
     pub watcher: Watcher,
 }
 
-// SAFETY: raw pointers in `tail`/`Node` are interior to the singly-linked
-// chain uniquely owned by this struct; no aliasing escapes. Zig original is
+// SAFETY: `nodes` holds `RawSlice<u8>` raw fat pointers which alias
+// caller-owned (`owns_slice = false`) or joiner-owned (`owns_slice = true`)
+// storage; no aliasing escapes `&mut self` methods. The Zig original is
 // passed across bundler worker threads (see Chunk.IntermediateOutput).
 unsafe impl Send for StringJoiner {}
 unsafe impl Sync for StringJoiner {}
@@ -31,17 +32,16 @@ impl Default for StringJoiner {
     fn default() -> Self {
         Self {
             len: 0,
-            head: None,
-            tail: None,
+            nodes: Vec::new(),
             watcher: Watcher::default(),
         }
     }
 }
 
-pub struct Node {
+struct Node {
     /// Replaces Zig's `NullableAllocator`: when `true`, `slice` was heap-allocated by
-    /// this joiner (via `push_cloned`) and is freed on node drop; when `false`, `slice`
-    /// is borrowed and the caller guarantees it outlives `done()`.
+    /// this joiner (via `push_owned`/`push_cloned`) and is freed on node drop;
+    /// when `false`, `slice` is borrowed and the caller guarantees it outlives `done()`.
     owns_slice: bool,
     // TODO(port): lifetime — borrowed slices must outlive `done()`; the port avoids
     // struct lifetime params, so this is stored as a typed raw fat pointer.
@@ -49,51 +49,21 @@ pub struct Node {
     // raw deref at every read site; the backing storage outlives the node by
     // either ownership (`owns_slice`) or caller contract.
     slice: RawSlice<u8>,
-    next: *mut Node,
 }
 
 impl Node {
-    fn init(slice: RawSlice<u8>, owns_slice: bool) -> Box<Node> {
-        // bun.handleOom(joiner_alloc.create(Node)) → Box::new (aborts on OOM)
-        Box::new(Node {
-            owns_slice,
-            slice,
-            next: ptr::null_mut(),
-        })
-    }
-
     #[inline]
     fn slice(&self) -> &[u8] {
         self.slice.slice()
     }
 }
 
-// SAFETY: `Node` is a plain linked-list node; raw pointers are uniquely owned
-// through the chain rooted at `StringJoiner.head` and never shared aliased
-// across threads concurrently. The Zig original moves these between bundler
-// worker threads freely.
+// SAFETY: `Node` is a plain (slice, ownership-bit) record; the `RawSlice` raw
+// pointer is uniquely owned (or borrowed under caller contract) through the
+// `Vec` rooted at `StringJoiner.nodes` and never shared aliased across threads
+// concurrently. The Zig original moves these between bundler worker threads.
 unsafe impl Send for Node {}
 unsafe impl Sync for Node {}
-
-impl Node {
-    /// Consume the singly-linked chain rooted at `head`, yielding each node's
-    /// slice in insertion order to `sink`, then dropping the node (which frees
-    /// an owned slice if any). Centralises the
-    /// `while !cur.is_null() { read; advance; free }` walk that `done`,
-    /// `done_with_end`, and `Drop` previously open-coded.
-    fn drain_chain(head: Box<Node>, mut sink: impl FnMut(&[u8])) {
-        let mut current: *mut Node = crate::heap::into_raw(head);
-        while !current.is_null() {
-            // SAFETY: `current` walks a chain of `Box`-allocated nodes
-            // uniquely owned by the caller (handed in via `head`); each is
-            // reclaimed exactly once here and never touched again.
-            let node = unsafe { crate::heap::take(current) };
-            current = node.next;
-            sink(node.slice());
-            // `drop(node)` runs `Node::drop`, freeing `slice` when owned.
-        }
-    }
-}
 
 impl Drop for Node {
     fn drop(&mut self) {
@@ -157,35 +127,23 @@ impl StringJoiner {
         }
         self.len += data_slice.len();
 
-        let new_tail = Node::init(data, owned);
+        self.watcher.estimated_count += (self.watcher.input.len() > 0
+            && strings::index_of(data_slice, self.watcher.input).is_some())
+            as u32;
+        self.watcher.needs_newline = data_slice[data_slice.len() - 1] != b'\n';
 
-        if !data_slice.is_empty() {
-            self.watcher.estimated_count += (self.watcher.input.len() > 0
-                && strings::index_of(data_slice, self.watcher.input).is_some())
-                as u32;
-            self.watcher.needs_newline = data_slice[data_slice.len() - 1] != b'\n';
-        }
-
-        let new_tail_nn = crate::heap::into_raw_nn(new_tail);
-        if let Some(current_tail) = self.tail {
-            // SAFETY: `tail` always points to the last node in the chain owned via `head`.
-            unsafe { (*current_tail.as_ptr()).next = new_tail_nn.as_ptr() };
-        } else {
-            debug_assert!(self.head.is_none());
-            // SAFETY: new_tail_nn just came from heap::into_raw_nn above.
-            self.head = Some(unsafe { crate::heap::take(new_tail_nn.as_ptr()) });
-        }
-        self.tail = Some(new_tail_nn);
+        self.nodes.push(Node {
+            owns_slice: owned,
+            slice: data,
+        });
     }
 
     /// This deinits the string joiner on success, the new string is owned by the caller.
     pub fn done(&mut self) -> Result<Box<[u8]>, AllocError> {
-        let Some(head) = self.head.take() else {
-            debug_assert!(self.tail.is_none());
+        if self.nodes.is_empty() {
             debug_assert!(self.len == 0);
             return Ok(Box::default());
-        };
-        self.tail = None;
+        }
         let len = self.len;
         self.len = 0;
 
@@ -194,38 +152,38 @@ impl StringJoiner {
         // (each push is a `memcpy` into spare capacity), and since the final
         // `len == capacity` the `into_boxed_slice` is a no-realloc move.
         let mut out = Vec::<u8>::with_capacity(len);
-        Node::drain_chain(head, |s| out.extend_from_slice(s));
+        for node in self.nodes.drain(..) {
+            out.extend_from_slice(node.slice());
+            // `drop(node)` runs `Node::drop`, freeing `slice` when owned.
+        }
         debug_assert_eq!(out.len(), len);
         Ok(out.into_boxed_slice())
     }
 
     /// Same as `.done`, but appends extra slice `end`
     pub fn done_with_end(&mut self, end: &[u8]) -> Result<Box<[u8]>, AllocError> {
-        let Some(head) = self.head.take() else {
-            debug_assert!(self.tail.is_none());
+        if self.nodes.is_empty() {
             debug_assert!(self.len == 0);
-
             if !end.is_empty() {
                 return Ok(Box::from(end));
             }
-
             return Ok(Box::default());
-        };
-        self.tail = None;
+        }
         let len = self.len;
         self.len = 0;
 
         let mut out = Vec::<u8>::with_capacity(len + end.len());
-        Node::drain_chain(head, |s| out.extend_from_slice(s));
+        for node in self.nodes.drain(..) {
+            out.extend_from_slice(node.slice());
+        }
         debug_assert_eq!(out.len(), len);
         out.extend_from_slice(end);
         Ok(out.into_boxed_slice())
     }
 
     pub fn last_byte(&self) -> u8 {
-        let Some(tail) = self.tail else { return 0 };
-        // SAFETY: `tail` points to the last node owned via `head`.
-        let slice = unsafe { (*tail.as_ptr()).slice() };
+        let Some(tail) = self.nodes.last() else { return 0 };
+        let slice = tail.slice();
         debug_assert!(!slice.is_empty());
         slice[slice.len() - 1]
     }
@@ -237,16 +195,9 @@ impl StringJoiner {
         }
     }
 
-    /// Walk the node chain yielding each node's slice in insertion order.
-    /// Mirrors Zig's `var el = joiner.head; while (el) |e| : (el = e.next) ...`.
-    pub fn node_slices(&self) -> NodeSlices<'_> {
-        NodeSlices {
-            cur: match &self.head {
-                Some(h) => &raw const **h,
-                None => ptr::null(),
-            },
-            _joiner: core::marker::PhantomData,
-        }
+    /// Iterate each node's slice in insertion order without consuming.
+    pub fn node_slices(&self) -> impl Iterator<Item = &[u8]> {
+        self.nodes.iter().map(Node::slice)
     }
 
     pub fn contains(&self, slice: &[u8]) -> bool {
@@ -255,36 +206,7 @@ impl StringJoiner {
     }
 }
 
-/// Borrowing iterator over a `StringJoiner`'s node slices.
-pub struct NodeSlices<'a> {
-    cur: *const Node,
-    _joiner: core::marker::PhantomData<&'a StringJoiner>,
-}
-
-impl<'a> Iterator for NodeSlices<'a> {
-    type Item = &'a [u8];
-    fn next(&mut self) -> Option<&'a [u8]> {
-        if self.cur.is_null() {
-            return None;
-        }
-        // SAFETY: `cur` walks the live node chain owned by the borrowed
-        // `StringJoiner`; nodes are not freed while the borrow is held.
-        let node = unsafe { &*self.cur };
-        self.cur = node.next;
-        Some(node.slice())
-    }
-}
-
-impl Drop for StringJoiner {
-    fn drop(&mut self) {
-        let Some(head) = self.head.take() else {
-            debug_assert!(self.tail.is_none());
-            debug_assert!(self.len == 0);
-            return;
-        };
-        self.tail = None;
-        Node::drain_chain(head, |_| {});
-    }
-}
+// `Drop` for `StringJoiner` is implicit: `Vec<Node>::drop` runs `Node::drop`
+// for each element, which frees joiner-owned slices.
 
 // ported from: src/string/StringJoiner.zig

--- a/src/bun_core/string/StringJoiner.rs
+++ b/src/bun_core/string/StringJoiner.rs
@@ -182,7 +182,9 @@ impl StringJoiner {
     }
 
     pub fn last_byte(&self) -> u8 {
-        let Some(tail) = self.nodes.last() else { return 0 };
+        let Some(tail) = self.nodes.last() else {
+            return 0;
+        };
         let slice = tail.slice();
         debug_assert!(!slice.is_empty());
         slice[slice.len() - 1]

--- a/src/bun_core/string/identifier.rs
+++ b/src/bun_core/string/identifier.rs
@@ -2,7 +2,8 @@ pub fn is_identifier_start(codepoint: i32) -> bool {
     match codepoint {
         // 'a'..='z' | 'A'..='Z' | '_' | '$'
         0x61..=0x7A | 0x41..=0x5A | 0x5F | 0x24 => true,
-        i32::MIN..=0 | 0x10FFFF..=i32::MAX => false,
+        // ASCII non-identifier bytes (punctuation, control chars) skip the table lookup.
+        i32::MIN..=0x7F | 0x10FFFF..=i32::MAX => false,
         _ => is_id_start_es_next(u32::try_from(codepoint).expect("int cast")),
     }
 }
@@ -11,7 +12,8 @@ pub fn is_identifier_part(codepoint: i32) -> bool {
     match codepoint {
         // 'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '$'
         0x61..=0x7A | 0x41..=0x5A | 0x30..=0x39 | 0x5F | 0x24 => true,
-        i32::MIN..=0 | 0x10FFFF..=i32::MAX => false,
+        // ASCII non-identifier bytes (punctuation, control chars) skip the table lookup.
+        i32::MIN..=0x7F | 0x10FFFF..=i32::MAX => false,
         _ => is_id_continue_es_next(u32::try_from(codepoint).expect("int cast")),
     }
 }

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1262,7 +1262,11 @@ impl<'a> LinkerContext<'a> {
                 .extend_from_slice(&done[mapping_start..mapping_end]);
             pieces.suffix.extend_from_slice(&done[mapping_end..]);
         } else {
-            pieces.prefix.extend_from_slice(&done);
+            // No shifts → `finalize()` returns `prefix` verbatim. Move the
+            // joined buffer instead of allocating a fresh `Vec` and memcpying
+            // it; for the bundled three.js x100 case the source map JSON is
+            // ~300 MB, so this alloc+copy was ~20% of the build.
+            pieces.prefix = done.into_vec();
         }
 
         Ok(pieces)

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1552,7 +1552,7 @@ impl SourceMapData {
                 .graph
                 .files
                 .slice()
-                .items_raw::<"quoted_source_contents", Option<Box<[u8]>>>()
+                .items_raw::<"quoted_source_contents", Option<Vec<u8>>>()
                 .add(source_index as usize)
         };
         *quoted_source_contents = None;
@@ -1567,7 +1567,12 @@ impl SourceMapData {
         let source: &Source = &parse_graph.input_files.items_source()[source_index as usize];
         let mut mutable = MutableString::init_empty();
         js_printer::quote_for_json(&source.contents, &mut mutable, false).expect("OOM");
-        *quoted_source_contents = Some(mutable.to_default_owned());
+        // Move the Vec out without `into_boxed_slice()`. The quote buffer is
+        // intentionally over-reserved (escape-expansion slack), so shrinking
+        // to `Box<[u8]>` would realloc and memcpy ~1.5 MB per file. The slack
+        // is dropped when the bundle finishes, and the `StringJoiner`
+        // downstream only borrows a `&[u8]` view.
+        *quoted_source_contents = Some(core::mem::take(&mut mutable.list));
     }
 }
 

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -877,7 +877,7 @@ pub struct File {
     pub entry_point_chunk_index: u32,
 
     pub line_offset_table: bun_sourcemap::line_offset_table::List,
-    pub quoted_source_contents: Option<Box<[u8]>>,
+    pub quoted_source_contents: Option<Vec<u8>>,
 }
 
 impl File {
@@ -916,7 +916,7 @@ bun_collections::multi_array_columns! {
         entry_point_kind: EntryPoint::Kind,
         entry_point_chunk_index: u32,
         line_offset_table: bun_sourcemap::line_offset_table::List,
-        quoted_source_contents: Option<Box<[u8]>>,
+        quoted_source_contents: Option<Vec<u8>>,
     }
 }
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3861,21 +3861,6 @@ pub mod bv2_impl {
             source_code_size: &mut u64,
             fetcher: Option<&DependenciesScanner>,
         ) -> Result<BuildResult, Error> {
-            // Defer mimalloc page purge for the duration of the bundle.
-            // The default 10ms purge delay causes madvise(MADV_DONTNEED)/munmap
-            // mid-bundle, which forces freshly-recycled pages to fault back in
-            // and triggers cross-CPU TLB shootdowns under the parser/printer
-            // thread pool. A one-shot CLI build exits right after, so deferring
-            // purges only costs RSS for the lifetime of the process; for
-            // `--watch` the guard restores the default once the initial build
-            // returns so the long-lived watcher still releases memory.
-            let _purge_delay_guard = {
-                use bun_alloc::mimalloc::{Option as MiOption, mi_option_get, mi_option_set};
-                let prev = mi_option_get(MiOption::purge_delay);
-                mi_option_set(MiOption::purge_delay, -1);
-                scopeguard::guard(prev, |prev| mi_option_set(MiOption::purge_delay, prev))
-            };
-
             let mut this = BundleV2::init(
                 transpiler,
                 None,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3861,6 +3861,21 @@ pub mod bv2_impl {
             source_code_size: &mut u64,
             fetcher: Option<&DependenciesScanner>,
         ) -> Result<BuildResult, Error> {
+            // Defer mimalloc page purge for the duration of the bundle.
+            // The default 10ms purge delay causes madvise(MADV_DONTNEED)/munmap
+            // mid-bundle, which forces freshly-recycled pages to fault back in
+            // and triggers cross-CPU TLB shootdowns under the parser/printer
+            // thread pool. A one-shot CLI build exits right after, so deferring
+            // purges only costs RSS for the lifetime of the process; for
+            // `--watch` the guard restores the default once the initial build
+            // returns so the long-lived watcher still releases memory.
+            let _purge_delay_guard = {
+                use bun_alloc::mimalloc::{Option as MiOption, mi_option_get, mi_option_set};
+                let prev = mi_option_get(MiOption::purge_delay);
+                mi_option_set(MiOption::purge_delay, -1);
+                scopeguard::guard(prev, |prev| mi_option_set(MiOption::purge_delay, prev))
+            };
+
             let mut this = BundleV2::init(
                 transpiler,
                 None,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4881,8 +4881,11 @@ pub mod bv2_impl {
                     drop(q.take());
                 }
                 for t in self.linker.graph.files.items_line_offset_table_mut() {
-                    // `LineOffsetTable::List` is itself a `MultiArrayList`; its
-                    // own elements are POD-ish, so `Drop` (slab free) suffices.
+                    // `LineOffsetTable::List` is a `MultiArrayList` whose
+                    // `columns_for_non_ascii: Box<[i32]>` rows are heap-owning.
+                    // `MultiArrayList::Drop` is slab-only, so drain rows first
+                    // or every per-line non-ASCII column table leaks per call.
+                    t.drop_elements();
                     *t = Default::default();
                 }
 

--- a/src/collections/array_hash_map.rs
+++ b/src/collections/array_hash_map.rs
@@ -1929,13 +1929,11 @@ impl<V, A: Allocator + HashbrownAllocator + Clone + Default> StringHashMap<V, A>
 
     /// Zig `getAdapted` — look up by `key` using `adapter` for hash/eql.
     ///
-    /// PERF(port): the underlying `std::HashMap` cannot be queried with an
-    /// external u64 hash (it uses its own `BuildHasher`), so the adapter's
-    /// precomputed hash is ignored and the lookup falls back to the normal
-    /// `get(key)` path. Correctness is preserved (`adapter.eql` is byte
-    /// equality for all current adapters); only the rehash-avoidance is lost.
-    /// Restore once `StringHashMap` is moved off `std::HashMap` onto a
-    /// wyhash-backed table that accepts a raw u64.
+    /// The adapter's precomputed hash is ignored; the lookup falls back to the
+    /// normal `get(key)` path (correctness is preserved — `adapter.eql` is byte
+    /// equality for all current adapters). Callers that already hold a hash
+    /// computed with [`hash_key`] should use [`get_hashed`] instead to skip the
+    /// rehash.
     #[inline]
     pub fn get_adapted<C>(&self, key: &[u8], _adapter: &C) -> Option<&V> {
         self.inner.get(key)

--- a/src/collections/array_hash_map.rs
+++ b/src/collections/array_hash_map.rs
@@ -1939,7 +1939,7 @@ impl<V, A: Allocator + HashbrownAllocator + Clone + Default> StringHashMap<V, A>
         self.inner.get(key)
     }
 
-    /// See `get_adapted` for the PERF(port) caveat.
+    /// See [`get_adapted`] — same precomputed-hash caveat applies.
     #[inline]
     pub fn contains_adapted<C>(&self, key: &[u8], _adapter: &C) -> bool {
         self.inner.contains_key(key)
@@ -1960,8 +1960,9 @@ impl<V: Default, A: Allocator + HashbrownAllocator + Clone + Default> StringHash
     /// allocations + double-hashes per file. Route through a single `entry()`
     /// match; the `Box` is still allocated upfront (std `HashMap::entry`
     /// requires the owned key) but on hit it is dropped without a second
-    /// probe. Full prehash reuse needs a `raw_entry`-style API — tracked in
-    /// the `get_adapted` PERF note above.
+    /// probe. Full prehash reuse needs a `raw_entry`-style API; see
+    /// [`get_hashed`] / [`put_static_key_hashed`] for the existing single-hash
+    /// entry points.
     pub fn get_or_put(&mut self, key: &[u8]) -> Result<StringHashMapGetOrPut<'_, V>, AllocError> {
         Ok(self.get_or_put_context_adapted(key, ()))
     }

--- a/src/collections/multi_array_list.rs
+++ b/src/collections/multi_array_list.rs
@@ -1279,7 +1279,7 @@ impl<T, A: Allocator> Drop for MultiArrayList<T, A> {
         // element destructors here would double-free that side.
         //
         // For lists that *do* uniquely own heap-backed columns (e.g.
-        // `LineOffsetTable.columns_for_non_ascii: Vec<i32>`), call
+        // `LineOffsetTable.columns_for_non_ascii: Box<[i32]>`), call
         // [`MultiArrayList::drop_elements`] before letting this run, or the
         // column payloads leak.
         self.free_allocated_bytes();

--- a/src/js_parser/Cargo.toml
+++ b/src/js_parser/Cargo.toml
@@ -16,6 +16,7 @@ strum.workspace = true
 phf.workspace = true
 bstr.workspace = true
 scopeguard.workspace = true
+smallvec.workspace = true
 const_format.workspace = true
 enum-map.workspace = true
 enumset.workspace = true

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -2484,6 +2484,12 @@ lexer_impl_header! {
     }
 
     /// This scans a "// comment" in a single pass over the input.
+    ///
+    /// PERF: outlined for the same reason as `scan_multi_line_comment_body` —
+    /// keep the SIMD newline scan, arena allocation, and pragma scanning out of
+    /// `next()`'s hot ASCII arms. `#[inline(never)]` (not `#[cold]`) because
+    /// `//` comments are common enough that we don't want the branch pessimized.
+    #[inline(never)]
     fn scan_single_line_comment(&mut self) {
         // PERF: keep the source slice register-resident — see `next_codepoint_with`.
         let contents: &[u8] = self.contents;

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1768,12 +1768,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 debug_assert!(self.symbols.len() > ref_.inner_index() as usize);
             }
             self.symbols[ref_.inner_index() as usize].use_count_estimate += 1;
-            let result = self.symbol_uses.get_or_put(ref_).expect("unreachable");
-            if !result.found_existing {
-                *result.value_ptr = js_ast::symbol::Use { count_estimate: 1 };
-            } else {
-                result.value_ptr.count_estimate += 1;
-            }
+            // `get_or_put` zero-initializes the slot on insert (`Use::default()`),
+            // so the Zig `found_existing` branch is unnecessary here.
+            self.symbol_uses
+                .get_or_put(ref_)
+                .expect("unreachable")
+                .value_ptr
+                .count_estimate += 1;
         }
 
         // The correctness of TypeScript-to-JavaScript conversion relies on accurate

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -353,7 +353,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.allow_in = true;
         // TODO(port): errdefer — restore `p.allow_in = old_allow_in` on error path
 
-        let mut args = BumpVec::<Expr>::new_in(p.arena);
+        let mut args: smallvec::SmallVec<[Expr; 4]> = smallvec::SmallVec::new();
         p.lexer.expect(T::TOpenParen)?;
 
         while p.lexer.token != T::TCloseParen {
@@ -377,7 +377,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.lexer.expect(T::TCloseParen)?;
         p.allow_in = old_allow_in;
         Ok(ExprListLoc {
-            list: ExprNodeList::from_bump_vec(args),
+            list: ExprNodeList::from_arena_slice(&args),
             loc: close_paren_loc,
         })
     }
@@ -1253,7 +1253,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         opts: &mut ParseStatementOptions<'a>,
     ) -> Result<G::DeclList, Error> {
         let p = self;
-        let mut decls = BumpVec::<G::Decl>::new_in(p.arena);
+        let mut decls: smallvec::SmallVec<[G::Decl; 4]> = smallvec::SmallVec::new();
 
         loop {
             // Forbid "let let" and "const let" but not "var let"
@@ -1306,7 +1306,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.lexer.next()?;
         }
 
-        Ok(G::DeclList::from_bump_vec(decls))
+        Ok(G::DeclList::from_arena_slice(&decls))
     }
 
     pub fn parse_path(&mut self) -> Result<ParsedPath<'a>, Error> {

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -739,7 +739,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let loc = p.lexer.loc();
         p.lexer.next()?;
         let mut is_single_line = !p.lexer.has_newline_before;
-        let mut items: bun_alloc::ArenaVec<'_, Expr> = bun_alloc::ArenaVec::new_in(p.arena);
+        let mut items: smallvec::SmallVec<[Expr; 8]> = smallvec::SmallVec::new();
         let mut self_errors = DeferredErrors::default();
         let mut comma_after_spread = bun_ast::Loc::default();
 
@@ -815,7 +815,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // In this case, we can't distinguish between the two yet
             self_errors.merge_into(errors.unwrap());
         }
-        let items_list = ExprNodeList::from_bump_vec(items);
+        let items_list = ExprNodeList::from_arena_slice(&items);
         Ok(p.new_expr(
             E::Array {
                 items: items_list,

--- a/src/js_parser/scan/scan_symbols.rs
+++ b/src/js_parser/scan/scan_symbols.rs
@@ -66,33 +66,38 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
 
                 // Is the symbol a member of this scope's TypeScript namespace?
-                if let Some(mut ts_namespace) = scope.ts_namespace {
-                    let ts = &*ts_namespace;
-                    let exported: &js_ast::TSNamespaceMemberMap = &ts.exported_members;
-                    if let Some(member) = exported.get(name) {
-                        if member.data.is_enum() == ts.is_enum_scope {
-                            declare_loc = member.loc;
-                            // If this is an identifier from a sibling TypeScript namespace, then we're
-                            // going to have to generate a property access instead of a simple reference.
-                            // Lazily-generate an identifier that represents this property access.
-                            // PORT NOTE: reshaped for borrowck — Zig's getOrPut returns key/value
-                            // pointers while we also call self.new_symbol (&mut self). Split into
-                            // get-then-insert so the &mut self borrow does not overlap the map borrow.
-                            if let Some(existing) = ts.property_accesses.get(name) {
-                                break 'brk *existing;
+                // `scope.ts_namespace` is only assigned behind `IS_TYPESCRIPT_ENABLED`
+                // guards, so the probe is dead for JS inputs — gate it so the
+                // load+branch fold away in the `TYPESCRIPT == false` monomorphization.
+                if Self::IS_TYPESCRIPT_ENABLED {
+                    if let Some(mut ts_namespace) = scope.ts_namespace {
+                        let ts = &*ts_namespace;
+                        let exported: &js_ast::TSNamespaceMemberMap = &ts.exported_members;
+                        if let Some(member) = exported.get(name) {
+                            if member.data.is_enum() == ts.is_enum_scope {
+                                declare_loc = member.loc;
+                                // If this is an identifier from a sibling TypeScript namespace, then we're
+                                // going to have to generate a property access instead of a simple reference.
+                                // Lazily-generate an identifier that represents this property access.
+                                // PORT NOTE: reshaped for borrowck — Zig's getOrPut returns key/value
+                                // pointers while we also call self.new_symbol (&mut self). Split into
+                                // get-then-insert so the &mut self borrow does not overlap the map borrow.
+                                if let Some(existing) = ts.property_accesses.get(name) {
+                                    break 'brk *existing;
+                                }
+                                let arg_ref = ts.arg_ref;
+                                let new_ref = self.new_symbol(js_ast::symbol::Kind::Other, name)?;
+                                // Re-borrow ts_namespace mutably after &mut self.
+                                let ts_mut = &mut *ts_namespace;
+                                ts_mut.property_accesses.insert(name, new_ref);
+                                self.symbols[new_ref.inner_index() as usize].namespace_alias =
+                                    Some(js_ast::NamespaceAlias {
+                                        namespace_ref: arg_ref,
+                                        alias: js_ast::StoreStr::new(name),
+                                        ..Default::default()
+                                    });
+                                break 'brk new_ref;
                             }
-                            let arg_ref = ts.arg_ref;
-                            let new_ref = self.new_symbol(js_ast::symbol::Kind::Other, name)?;
-                            // Re-borrow ts_namespace mutably after &mut self.
-                            let ts_mut = &mut *ts_namespace;
-                            ts_mut.property_accesses.insert(name, new_ref);
-                            self.symbols[new_ref.inner_index() as usize].namespace_alias =
-                                Some(js_ast::NamespaceAlias {
-                                    namespace_ref: arg_ref,
-                                    alias: js_ast::StoreStr::new(name),
-                                    ..Default::default()
-                                });
-                            break 'brk new_ref;
                         }
                     }
                 }

--- a/src/js_printer/Cargo.toml
+++ b/src/js_printer/Cargo.toml
@@ -26,6 +26,7 @@ bun_alloc.workspace = true
 bun_core.workspace = true
 bun_ptr.workspace = true
 bun_collections.workspace = true
+bun_wyhash.workspace = true
 bun_crash_handler.workspace = true
 bun_io.workspace = true
 bun_ast.workspace = true

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -8042,9 +8042,9 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
                 // `MultiArrayList::Drop` only frees the column buffer — it does
                 // NOT drop column elements (Zig allocated these into the arena
                 // so it didn't matter there). The per-row `columns_for_non_ascii`
-                // Vec<i32>s live on the global heap in the Rust port; drain them
+                // Box<[i32]>s live on the global heap in the Rust port; drain them
                 // before dropping the SoA storage to avoid leaking them.
-                for v in tables.items_mut::<"columns_for_non_ascii", Vec<i32>>() {
+                for v in tables.items_mut::<"columns_for_non_ascii", Box<[i32]>>() {
                     core::mem::take(v);
                 }
                 unsafe { core::mem::ManuallyDrop::drop(tables) };
@@ -8419,8 +8419,8 @@ pub fn print_common_js<
                 // dropped exactly once here.
                 let tables = unsafe { &mut *p };
                 // `MultiArrayList::Drop` does not drop column elements; drain
-                // the global-heap Vec<i32>s before dropping the SoA storage.
-                for v in tables.items_mut::<"columns_for_non_ascii", Vec<i32>>() {
+                // the global-heap Box<[i32]>s before dropping the SoA storage.
+                for v in tables.items_mut::<"columns_for_non_ascii", Box<[i32]>>() {
                     core::mem::take(v);
                 }
                 unsafe { core::mem::ManuallyDrop::drop(tables) };

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1137,11 +1137,14 @@ pub fn quote_for_json(
     // Zig: `comptime ascii_only: bool`. We now thread `ascii_only` at runtime so
     // the heavy escaper isn't monomorphized per ascii_only/quote-char combo.
     //
-    // Heuristic reservation (~6% slack) instead of `estimate_length_for_utf8`,
+    // Heuristic reservation (~12.5% slack) instead of `estimate_length_for_utf8`,
     // which would do a full SIMD scan + per-escape rune decode over `text` just
     // to size the buffer — the same work `write_pre_quoted_string_inner` repeats
-    // immediately below. The writer grows on demand if this under-shoots.
-    bytes.grow_if_needed(text.len() + (text.len() >> 4) + 8)?;
+    // immediately below. Tab-indented JS (e.g. three.js) has ~9.4% of bytes
+    // needing 2-byte escapes (tabs + newlines + quotes/backslashes), so 6.25%
+    // slack would under-shoot and force a 2x doubling memcpy of the whole
+    // source. The writer still grows on demand if this under-shoots.
+    bytes.grow_if_needed(text.len() + (text.len() >> 3) + 8)?;
     bytes.append_char(b'"')?;
     write_pre_quoted_string_inner::<_, { Encoding::Utf8 }>(text, bytes, b'"', ascii_only, true)?;
     bytes.append_char(b'"').expect("unreachable");

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -7875,7 +7875,8 @@ pub fn get_source_map_builder<const IS_BUN_PLATFORM: bool>(
     // `data` directly; the prepend-count (Lazy) path writes through
     // `internal` and would just waste the reservation.
     if builder.source_map.ctx.internal.is_none() {
-        let hint = (source.contents.len() / 4).max(tree.approximate_newline_count.saturating_mul(4));
+        let hint =
+            (source.contents.len() / 4).max(tree.approximate_newline_count.saturating_mul(4));
         let _ = builder.source_map.ctx.data.grow_if_needed(hint);
     }
     builder

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1011,11 +1011,8 @@ where
                         strings::index_of_needs_escape_for_java_script_string(remain, quote_char)
                     {
                         let j = j as usize;
-                        let text_chunk = &text[i..i + clamped_width];
-                        writer.write_all(text_chunk)?;
-                        i += clamped_width;
-                        writer.write_all(&remain[..j])?;
-                        i += j;
+                        writer.write_all(&text[i..i + clamped_width + j])?;
+                        i += clamped_width + j;
                     } else {
                         writer.write_all(&text[i..])?;
                         i = n;

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1136,7 +1136,12 @@ pub fn quote_for_json(
 ) -> Result<(), bun_core::Error> {
     // Zig: `comptime ascii_only: bool`. We now thread `ascii_only` at runtime so
     // the heavy escaper isn't monomorphized per ascii_only/quote-char combo.
-    bytes.grow_if_needed(estimate_length_for_utf8(text, ascii_only, b'"'))?;
+    //
+    // Heuristic reservation (~6% slack) instead of `estimate_length_for_utf8`,
+    // which would do a full SIMD scan + per-escape rune decode over `text` just
+    // to size the buffer — the same work `write_pre_quoted_string_inner` repeats
+    // immediately below. The writer grows on demand if this under-shoots.
+    bytes.grow_if_needed(text.len() + (text.len() >> 4) + 8)?;
     bytes.append_char(b'"')?;
     write_pre_quoted_string_inner::<_, { Encoding::Utf8 }>(text, bytes, b'"', ascii_only, true)?;
     bytes.append_char(b'"').expect("unreachable");

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -7867,6 +7867,17 @@ pub fn get_source_map_builder<const IS_BUN_PLATFORM: bool>(
             i32::try_from(tree.approximate_newline_count).expect("int cast"),
         );
     }
+    // Pre-size the VLQ mappings buffer. With `--minify` we emit roughly one
+    // mapping per token; growing from 0 by doubling means ~16 reallocs and
+    // O(n) memmoves on a large module. The estimate is intentionally
+    // conservative — undershooting still saves the early small reallocs and
+    // the buffer doubles from there. Only the bundler/external path uses
+    // `data` directly; the prepend-count (Lazy) path writes through
+    // `internal` and would just waste the reservation.
+    if builder.source_map.ctx.internal.is_none() {
+        let hint = (source.contents.len() / 4).max(tree.approximate_newline_count.saturating_mul(4));
+        let _ = builder.source_map.ctx.data.grow_if_needed(hint);
+    }
     builder
 }
 

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -1031,9 +1031,17 @@ impl NumberScope {
         // "name" is called "name2"
         if !collided && !normalized {
             debug_assert!(strings::eql_long(name, input_name, true));
-            self.name_counts
-                .put_no_clobber(input_name, 1)
-                .expect("unreachable");
+            debug_assert!(self.name_counts.get(input_name).is_none());
+            // SAFETY: `input_name` is `symbol.original_name.slice()` — an
+            // AST-arena slice. The AST arena (and the `ManuallyDrop<symbol::Map>`
+            // view the renamer holds over it) strictly outlives every
+            // `NumberScope` allocated from `NumberRenamer::number_scope_pool`,
+            // so the borrowed key remains valid for the map's lifetime. Zig
+            // stored the slice by value (`putNoClobber(allocator, input_name,
+            // 1)`); the Rust port previously heap-boxed a copy, which showed
+            // up as one `mi_malloc` + `mi_free` per assigned symbol in
+            // non-minify builds.
+            unsafe { self.name_counts.put_borrowed(input_name, 1) }.expect("unreachable");
             return UnusedName::NoCollision;
         }
         debug_assert!(!strings::eql_long(name, input_name, true));
@@ -1042,9 +1050,12 @@ impl NumberScope {
         let duped: &[u8] = arena.alloc_slice_copy(name);
         let name: NameStr = bun_ast::StoreStr::new(duped);
 
-        self.name_counts
-            .put_no_clobber(duped, 1)
-            .expect("unreachable");
+        debug_assert!(self.name_counts.get(duped).is_none());
+        // SAFETY: `duped` was just bump-allocated from the renamer's `arena:
+        // Bump`, which lives as long as `NumberRenamer` and is only reset on
+        // `Drop` — strictly after every `NumberScope` (and its `name_counts`)
+        // has been returned to the pool and dropped.
+        unsafe { self.name_counts.put_borrowed(duped, 1) }.expect("unreachable");
         UnusedName::Renamed(name)
     }
 }

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -938,21 +938,32 @@ impl NumberScope {
         // gate on that too and fall through to the full normalizer when it
         // would apply.
         let owned_name;
+        let normalized;
         let mut name: &[u8] = if is_simple_ascii_identifier(input_name)
             && !bun_ast::lexer_tables::is_strict_mode_reserved_word(input_name)
         {
+            normalized = false;
             input_name
         } else {
+            normalized = true;
             owned_name = MutableString::ensure_valid_identifier(input_name).expect("unreachable");
             &owned_name
         };
         // PORT NOTE: hoisted from inside the match arm so `name` (which may borrow
-        // it) stays valid through the trailing `eql_long`/dupe.
+        // it) stays valid through the trailing dupe.
         let mut mutable_name = MutableString::init_empty();
+        // True iff a "name2"/"name3" suffix was appended below (i.e. `name` was
+        // reassigned to `mutable_name.slice()`). `!collided && !normalized` is
+        // equivalent to the old `strings::eql_long(name, input_name, true)`
+        // check — `name` is only ever bytewise-equal to `input_name` when both
+        // are false — without re-comparing 5–20 identifier bytes per symbol on
+        // the hot no-collision path.
+        let mut collided = false;
 
         match NameUse::find(self, name) {
             NameUse::Unused => {}
             use_ => {
+                collided = true;
                 let mut tries: u32 = if matches!(use_, NameUse::Used) {
                     1
                 } else {
@@ -1018,12 +1029,14 @@ impl NumberScope {
 
         // Each name starts off with a count of 1 so that the first collision with
         // "name" is called "name2"
-        if strings::eql_long(name, input_name, true) {
+        if !collided && !normalized {
+            debug_assert!(strings::eql_long(name, input_name, true));
             self.name_counts
                 .put_no_clobber(input_name, 1)
                 .expect("unreachable");
             return UnusedName::NoCollision;
         }
+        debug_assert!(!strings::eql_long(name, input_name, true));
 
         // Zig: `allocator.dupe(u8, name)` — allocate into the renamer arena.
         let duped: &[u8] = arena.alloc_slice_copy(name);

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -1118,9 +1118,15 @@ impl NumberScope {
         }
 
         // Each name starts off with a count of 1 so that the first collision with
-        // "name" is called "name2"
-        if !collided && !normalized {
-            debug_assert!(strings::eql_long(name, input_name, true));
+        // "name" is called "name2".
+        //
+        // `name` may still equal `input_name` bytewise even when `normalized`
+        // is true: `ensure_valid_identifier` returns the input bytes unchanged
+        // for an identifier whose first codepoint is a non-ASCII ID_Start
+        // (e.g. `é`, `π`), since only `is_simple_ascii_identifier` is
+        // ASCII-restricted. The hot ASCII path skips the byte compare via
+        // `!normalized`; the rare non-ASCII path falls back to it.
+        if !collided && (!normalized || strings::eql_long(name, input_name, true)) {
             // `input_name` is `Symbol::original_name.slice()` — an AST-arena
             // slice that outlives the renamer (see [`NameKey`] doc). No copy.
             let prev = self
@@ -1129,7 +1135,6 @@ impl NumberScope {
             debug_assert!(prev.is_none(), "put_no_clobber: key already present");
             return UnusedName::NoCollision;
         }
-        debug_assert!(!strings::eql_long(name, input_name, true));
 
         // Zig: `allocator.dupe(u8, name)` — allocate into the renamer arena.
         let duped: &[u8] = arena.alloc_slice_copy(name);

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -722,8 +722,9 @@ impl NumberRenamer {
         // reserved-name keys can be duped into it: `root_names` owns its keys
         // as `Box<[u8]>` and is dropped at the end of this function, while
         // `NameKey` is a lifetime-erased borrow that must outlive `root`.
-        // Reserved names are a small fixed set (~50 keywords/globals), so this
-        // one-time copy is negligible.
+        // The set is bounded by the unique unbound/must-not-be-renamed globals
+        // across the chunk (typically a few hundred names), and this copy
+        // happens once per chunk vs. the millions of per-symbol ops below.
         let arena = Bump::new();
         let mut root = NumberScope::default();
         root.name_counts.reserve(root_names.len());

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -1031,17 +1031,9 @@ impl NumberScope {
         // "name" is called "name2"
         if !collided && !normalized {
             debug_assert!(strings::eql_long(name, input_name, true));
-            debug_assert!(self.name_counts.get(input_name).is_none());
-            // SAFETY: `input_name` is `symbol.original_name.slice()` — an
-            // AST-arena slice. The AST arena (and the `ManuallyDrop<symbol::Map>`
-            // view the renamer holds over it) strictly outlives every
-            // `NumberScope` allocated from `NumberRenamer::number_scope_pool`,
-            // so the borrowed key remains valid for the map's lifetime. Zig
-            // stored the slice by value (`putNoClobber(allocator, input_name,
-            // 1)`); the Rust port previously heap-boxed a copy, which showed
-            // up as one `mi_malloc` + `mi_free` per assigned symbol in
-            // non-minify builds.
-            unsafe { self.name_counts.put_borrowed(input_name, 1) }.expect("unreachable");
+            self.name_counts
+                .put_no_clobber(input_name, 1)
+                .expect("unreachable");
             return UnusedName::NoCollision;
         }
         debug_assert!(!strings::eql_long(name, input_name, true));
@@ -1050,12 +1042,9 @@ impl NumberScope {
         let duped: &[u8] = arena.alloc_slice_copy(name);
         let name: NameStr = bun_ast::StoreStr::new(duped);
 
-        debug_assert!(self.name_counts.get(duped).is_none());
-        // SAFETY: `duped` was just bump-allocated from the renamer's `arena:
-        // Bump`, which lives as long as `NumberRenamer` and is only reset on
-        // `Drop` — strictly after every `NumberScope` (and its `name_counts`)
-        // has been returned to the pool and dropped.
-        unsafe { self.name_counts.put_borrowed(duped, 1) }.expect("unreachable");
+        self.name_counts
+            .put_no_clobber(duped, 1)
+            .expect("unreachable");
         UnusedName::Renamed(name)
     }
 }

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -39,6 +39,62 @@ const SLOT_NAMESPACES: [SlotNamespace; 4] = [
     SlotNamespace::MangledProp,
 ];
 
+/// Lifetime-erased name slice used as the key in `NumberScope::name_counts`.
+///
+/// `NumberScope` lives in a `HiveArrayFallback` pool inside `NumberRenamer`,
+/// alongside the renamer's `arena: Bump`. A `&'a [u8]` key would make
+/// `NumberScope<'a>` self-referential to its own owner, so the renamer (like
+/// the rest of the AST layer) carries name slices as the lifetime-erased
+/// [`bun_ast::StoreStr`] and re-borrows on read. Every key inserted here points
+/// either at `Symbol::original_name` (an AST-arena slice that strictly outlives
+/// the renamer) or at bytes bump-allocated from the renamer's own `arena: Bump`,
+/// which is only reset on `NumberRenamer::Drop` after every `NumberScope` is
+/// returned to the pool — so the borrow contract documented on `StoreStr::slice`
+/// is always satisfied.
+///
+/// Replaces the previous `StringHashMap<u32>` (whose `put_no_clobber` heap-boxed
+/// a `Box<[u8]>` copy of the key) with a `Copy` 16-byte key that needs no
+/// allocation on insert and no free on the per-scope drop in the renamer's
+/// pool walkback. Same shape as Zig's `StringHashMapUnmanaged([]const u8, u32)`.
+#[derive(Clone, Copy)]
+pub struct NameKey(NameStr);
+
+impl NameKey {
+    #[inline]
+    fn as_bytes(&self) -> &[u8] {
+        self.0.slice()
+    }
+}
+
+impl core::hash::Hash for NameKey {
+    #[inline]
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        // Must match `<[u8] as Hash>::hash` so `Borrow<[u8]>` lookups agree.
+        self.as_bytes().hash(state);
+    }
+}
+
+impl PartialEq for NameKey {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.as_bytes() == other.as_bytes()
+    }
+}
+impl Eq for NameKey {}
+
+impl core::borrow::Borrow<[u8]> for NameKey {
+    #[inline]
+    fn borrow(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+/// Per-`NumberScope` map of assigned names → next collision counter.
+/// `bun_wyhash::BuildHasher` matches `StringHashMap` so the renamer keeps its
+/// existing hash quality; `NameKey` is a `Copy` lifetime-erased slice so insert
+/// never heap-allocates a key copy and drop never frees one.
+pub type NameCountMap = bun_collections::hashbrown::HashMap<NameKey, u32, bun_wyhash::BuildHasher>;
+
 pub struct NoOpRenamer<'a> {
     // PORT NOTE: Zig `Symbol.Map` is a non-owning `BabyList(BabyList(Symbol))`
     // slice header passed by value (renamer.zig:2,126,452 — no `deinit` ever
@@ -662,8 +718,20 @@ impl NumberRenamer {
         // PERF(port): HiveArray.Fallback was bound to arena.arena() in Zig
         let number_scope_pool = HiveArrayFallback::<NumberScope, 128>::init();
 
+        // The arena is created here (before `root.name_counts`) so the
+        // reserved-name keys can be duped into it: `root_names` owns its keys
+        // as `Box<[u8]>` and is dropped at the end of this function, while
+        // `NameKey` is a lifetime-erased borrow that must outlive `root`.
+        // Reserved names are a small fixed set (~50 keywords/globals), so this
+        // one-time copy is negligible.
+        let arena = Bump::new();
         let mut root = NumberScope::default();
-        root.name_counts = root_names;
+        root.name_counts.reserve(root_names.len());
+        for (key, &value) in root_names.iter() {
+            let duped = arena.alloc_slice_copy(&**key);
+            root.name_counts
+                .insert(NameKey(NameStr::new(duped)), value);
+        }
 
         // TODO(b2-blocked): bun_core::env_var::BUN_DUMP_SYMBOLS — typed accessor
         // not yet declared upstream; debug-only `symbols.dump()` call elided.
@@ -675,7 +743,7 @@ impl NumberRenamer {
             names,
             number_scope_pool,
             root,
-            arena: Bump::new(),
+            arena,
         }))
     }
 
@@ -691,7 +759,7 @@ impl NumberRenamer {
         unsafe {
             s.write(NumberScope {
                 parent,
-                name_counts: StringHashMap::default(),
+                name_counts: NameCountMap::default(),
             });
         }
 
@@ -762,13 +830,16 @@ impl NumberRenamer {
                             core::ptr::NonNull::new(s).expect("number_scope non-null"),
                         )),
                         // Pre-size to the AST scope's symbol count so the
-                        // per-name `put_no_clobber` path doesn't realloc the
-                        // table 0→4→8→… as names are assigned. Most scopes
-                        // assign every member exactly once, so this is the
-                        // exact final size; symbols skipped by `assign_name`
+                        // per-name insert path doesn't realloc the table
+                        // 0→4→8→… as names are assigned. Most scopes assign
+                        // every member exactly once, so this is the exact
+                        // final size; symbols skipped by `assign_name`
                         // (already renamed, non-default namespace) just leave
                         // a little slack.
-                        name_counts: StringHashMap::with_capacity(symbol_count),
+                        name_counts: NameCountMap::with_capacity_and_hasher(
+                            symbol_count,
+                            Default::default(),
+                        ),
                     });
                 }
                 s = new_child_scope;
@@ -867,7 +938,7 @@ pub struct NumberScope {
     /// outlive this child (children are `put()` back before their parent), so
     /// `ParentRef::get()` is sound without per-site `unsafe`.
     pub parent: Option<bun_ptr::ParentRef<NumberScope>>,
-    pub name_counts: StringHashMap<u32>,
+    pub name_counts: NameCountMap,
 }
 
 pub enum NameUse {
@@ -882,10 +953,21 @@ impl NameUse {
         #[cfg(debug_assertions)]
         debug_assert!(js_lexer::is_identifier(name));
 
-        // avoid rehashing the same string over for each scope
-        let ctx = bun_collections::StringHashMapContext::pre(name);
+        // Hash `name` once and probe each scope in the parent chain with the
+        // same precomputed hash via hashbrown's raw-entry API; the previous
+        // `get_adapted`/`contains_adapted` calls re-hashed `name` per scope.
+        let hash = {
+            use core::hash::{BuildHasher, Hash, Hasher};
+            let mut state = <bun_wyhash::BuildHasher as Default>::default().build_hasher();
+            name.hash(&mut state);
+            state.finish()
+        };
 
-        if let Some(&count) = this.name_counts.get_adapted(name, &ctx) {
+        if let Some((_, &count)) = this
+            .name_counts
+            .raw_entry()
+            .from_hash(hash, |k| k.as_bytes() == name)
+        {
             return NameUse::SameScope(count);
         }
 
@@ -894,7 +976,12 @@ impl NameUse {
         while let Some(scope) = s {
             // `ParentRef<NumberScope>: Deref` — safe backref deref under the
             // parent-outlives-child invariant documented on the field.
-            if scope.name_counts.contains_adapted(name, &ctx) {
+            if scope
+                .name_counts
+                .raw_entry()
+                .from_hash(hash, |k| k.as_bytes() == name)
+                .is_some()
+            {
                 return NameUse::Used;
             }
             s = scope.parent;
@@ -1001,12 +1088,11 @@ impl NumberScope {
                 match NameUse::find(self, mutable_name.slice()) {
                     NameUse::Unused => {
                         if matches!(use_, NameUse::SameScope(_)) {
-                            // PORT NOTE: `StringHashMap::get_or_put` owns a boxed
-                            // copy of `prefix` on insert, so the Zig key-dupe dance
-                            // is unnecessary here.
-                            let existing =
-                                self.name_counts.get_or_put(prefix).expect("unreachable");
-                            *existing.value_ptr = tries;
+                            // `prefix` may borrow the local `owned_name`; if a
+                            // new entry is needed, dupe into the renamer arena
+                            // so the `NameKey` outlives this function. Mirrors
+                            // Zig's conditional `allocator.dupe(u8, prefix)`.
+                            *self.entry_or_arena_dup(prefix, arena) = tries;
                         }
                         name = mutable_name.slice();
                     }
@@ -1019,10 +1105,7 @@ impl NumberScope {
                         match NameUse::find(self, mutable_name.slice()) {
                             NameUse::Unused => {
                                 if matches!(cur_use, NameUse::SameScope(_)) {
-                                    // PORT NOTE: as above — map owns its key copy.
-                                    let existing =
-                                        self.name_counts.get_or_put(prefix).expect("unreachable");
-                                    *existing.value_ptr = tries;
+                                    *self.entry_or_arena_dup(prefix, arena) = tries;
                                 }
 
                                 name = mutable_name.slice();
@@ -1039,9 +1122,12 @@ impl NumberScope {
         // "name" is called "name2"
         if !collided && !normalized {
             debug_assert!(strings::eql_long(name, input_name, true));
-            self.name_counts
-                .put_no_clobber(input_name, 1)
-                .expect("unreachable");
+            // `input_name` is `Symbol::original_name.slice()` — an AST-arena
+            // slice that outlives the renamer (see [`NameKey`] doc). No copy.
+            let prev = self
+                .name_counts
+                .insert(NameKey(NameStr::new(input_name)), 1);
+            debug_assert!(prev.is_none(), "put_no_clobber: key already present");
             return UnusedName::NoCollision;
         }
         debug_assert!(!strings::eql_long(name, input_name, true));
@@ -1050,10 +1136,27 @@ impl NumberScope {
         let duped: &[u8] = arena.alloc_slice_copy(name);
         let name: NameStr = bun_ast::StoreStr::new(duped);
 
-        self.name_counts
-            .put_no_clobber(duped, 1)
-            .expect("unreachable");
+        // `duped` is bump-allocated from the renamer's `arena: Bump`, which
+        // outlives every `NumberScope` (see [`NameKey`] doc). No copy.
+        let prev = self.name_counts.insert(NameKey(name), 1);
+        debug_assert!(prev.is_none(), "put_no_clobber: key already present");
         UnusedName::Renamed(name)
+    }
+
+    /// `name_counts.entry(prefix).or_insert(0)` with a vacant-only arena dup:
+    /// when the key is already present we mutate it in place; when it is not,
+    /// the bytes are bump-allocated into `arena` so the resulting [`NameKey`]
+    /// outlives the renamer. Mirrors Zig's `getOrPut` + conditional
+    /// `allocator.dupe(u8, prefix)` shape.
+    fn entry_or_arena_dup(&mut self, prefix: &[u8], arena: &Bump) -> &mut u32 {
+        use bun_collections::hashbrown::hash_map::RawEntryMut;
+        match self.name_counts.raw_entry_mut().from_key(prefix) {
+            RawEntryMut::Occupied(o) => o.into_mut(),
+            RawEntryMut::Vacant(v) => {
+                let duped = arena.alloc_slice_copy(prefix);
+                v.insert(NameKey(NameStr::new(duped)), 0).1
+            }
+        }
     }
 }
 

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -1047,11 +1047,10 @@ impl NumberScope {
         // it) stays valid through the trailing dupe.
         let mut mutable_name = MutableString::init_empty();
         // True iff a "name2"/"name3" suffix was appended below (i.e. `name` was
-        // reassigned to `mutable_name.slice()`). `!collided && !normalized` is
-        // equivalent to the old `strings::eql_long(name, input_name, true)`
-        // check — `name` is only ever bytewise-equal to `input_name` when both
-        // are false — without re-comparing 5–20 identifier bytes per symbol on
-        // the hot no-collision path.
+        // reassigned to `mutable_name.slice()`). On the hot ASCII path
+        // `!collided && !normalized` implies `name == input_name` so the tail
+        // check skips the byte compare; the rare `normalized` path still
+        // compares (see the comment at the tail).
         let mut collided = false;
 
         match NameUse::find(self, name) {

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -729,8 +729,7 @@ impl NumberRenamer {
         root.name_counts.reserve(root_names.len());
         for (key, &value) in root_names.iter() {
             let duped = arena.alloc_slice_copy(&**key);
-            root.name_counts
-                .insert(NameKey(NameStr::new(duped)), value);
+            root.name_counts.insert(NameKey(NameStr::new(duped)), value);
         }
 
         // TODO(b2-blocked): bun_core::env_var::BUN_DUMP_SYMBOLS — typed accessor

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -749,7 +749,8 @@ impl NumberRenamer {
         // TODO(port): defer cleanup of `s` if s != initial_scope — handled at end
 
         loop {
-            if scope.members.count() > 0 || scope.generated.len_u32() > 0 {
+            let symbol_count = scope.members.count() + scope.generated.len_u32() as usize;
+            if symbol_count > 0 {
                 let new_child_scope: *mut NumberScope = self.number_scope_pool.get();
                 // SAFETY: `new_child_scope` is a valid pool slot.
                 unsafe {
@@ -760,7 +761,14 @@ impl NumberRenamer {
                         parent: Some(bun_ptr::ParentRef::from(
                             core::ptr::NonNull::new(s).expect("number_scope non-null"),
                         )),
-                        name_counts: StringHashMap::default(),
+                        // Pre-size to the AST scope's symbol count so the
+                        // per-name `put_no_clobber` path doesn't realloc the
+                        // table 0→4→8→… as names are assigned. Most scopes
+                        // assign every member exactly once, so this is the
+                        // exact final size; symbols skipped by `assign_name`
+                        // (already renamed, non-default namespace) just leave
+                        // a little slack.
+                        name_counts: StringHashMap::with_capacity(symbol_count),
                     });
                 }
                 s = new_child_scope;

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -3895,7 +3895,7 @@ pub fn finalize_bundle(
                     code: compile_result.code().to_vec().into_boxed_slice(),
                     source_map: Some(incremental_graph::ReceiveChunkSourceMap {
                         chunk: source_map,
-                        escaped_source: quoted_contents.clone(),
+                        escaped_source: quoted_contents.clone().map(Vec::into_boxed_slice),
                     }),
                 },
                 false,
@@ -3907,7 +3907,7 @@ pub fn finalize_bundle(
                     code: compile_result.code().to_vec().into_boxed_slice(),
                     source_map: Some(incremental_graph::ReceiveChunkSourceMap {
                         chunk: source_map,
-                        escaped_source: quoted_contents.clone(),
+                        escaped_source: quoted_contents.clone().map(Vec::into_boxed_slice),
                     }),
                 },
                 graph == bake::Graph::Ssr,

--- a/src/sourcemap/Chunk.rs
+++ b/src/sourcemap/Chunk.rs
@@ -485,7 +485,17 @@ impl NewBuilder<VLQSourceMap> {
     #[inline]
     pub fn update_generated_line_and_column(&mut self, output: &[u8]) {
         let slice = &output[self.last_generated_update as usize..];
-        if strings::index_of_newline_or_non_ascii(slice, 0).is_none() {
+        // The window between consecutive mappings is usually a handful of bytes
+        // (one token, often less under --minify). Below the narrowest highway
+        // lane width the SIMD body never runs and the FFI dispatch is pure
+        // overhead, so scan inline. Predicate matches
+        // `IndexOfNewlineOrNonASCIIImpl`'s scalar tail (`> 127 || < 0x20`).
+        let pure_ascii = if slice.len() < 16 {
+            !slice.iter().any(|&b| b > 127 || b < 0x20)
+        } else {
+            strings::index_of_newline_or_non_ascii(slice, 0).is_none()
+        };
+        if pure_ascii {
             debug_assert!(slice.len() <= i32::MAX as usize);
             self.generated_column += slice.len() as i32;
             self.last_generated_update = output.len() as u32;

--- a/src/sourcemap/Chunk.rs
+++ b/src/sourcemap/Chunk.rs
@@ -706,10 +706,15 @@ impl NewBuilder<VLQSourceMap> {
         // `items::<>` is a single `base + CONST*cap` pointer add.
         let mut original_column = loc.start - byte_offsets[idx] as i32;
         {
+            // `first_non_ascii` is `i32::MAX as u32` for ASCII-only lines, so the
+            // comparison below is false and the `columns_for_non_ascii` SoA column
+            // (the largest, ~24 B/line) is never touched on the hot ASCII path.
             let first_non_ascii = list.items::<"byte_offset_to_first_non_ascii", u32>()[idx];
-            let cols = &list.items::<"columns_for_non_ascii", Vec<i32>>()[idx];
-            if !cols.is_empty() && original_column >= first_non_ascii as i32 {
-                original_column = cols[(original_column as u32 - first_non_ascii) as usize];
+            if original_column >= first_non_ascii as i32 {
+                let cols = &list.items::<"columns_for_non_ascii", Vec<i32>>()[idx];
+                if !cols.is_empty() {
+                    original_column = cols[(original_column as u32 - first_non_ascii) as usize];
+                }
             }
         }
 

--- a/src/sourcemap/Chunk.rs
+++ b/src/sourcemap/Chunk.rs
@@ -392,7 +392,7 @@ impl<T: SourceMapFormatCtx + Default> Default for NewBuilder<T> {
 }
 
 /// A uniquely-owned [`line_offset_table::List`] whose per-row
-/// `columns_for_non_ascii: Vec<i32>` payloads are drained on drop.
+/// `columns_for_non_ascii: Box<[i32]>` payloads are drained on drop.
 ///
 /// `MultiArrayList::Drop` is **slab-only** — it frees the SoA buffer but never
 /// runs column destructors (a bitwise `clone` can alias two lists onto the same
@@ -406,7 +406,7 @@ pub struct OwnedLineOffsetTables(pub line_offset_table::List);
 
 impl Drop for OwnedLineOffsetTables {
     fn drop(&mut self) {
-        // Run every row's destructors (drops the `columns_for_non_ascii` Vecs);
+        // Run every row's destructors (drops the `columns_for_non_ascii` boxes);
         // the `MultiArrayList::Drop` that follows then frees the SoA slab.
         self.0.drop_elements();
     }
@@ -711,7 +711,7 @@ impl NewBuilder<VLQSourceMap> {
             // (the largest, ~24 B/line) is never touched on the hot ASCII path.
             let first_non_ascii = list.items::<"byte_offset_to_first_non_ascii", u32>()[idx];
             if original_column >= first_non_ascii as i32 {
-                let cols = &list.items::<"columns_for_non_ascii", Vec<i32>>()[idx];
+                let cols = &list.items::<"columns_for_non_ascii", Box<[i32]>>()[idx];
                 if !cols.is_empty() {
                     original_column = cols[(original_column as u32 - first_non_ascii) as usize];
                 }

--- a/src/sourcemap/Chunk.rs
+++ b/src/sourcemap/Chunk.rs
@@ -708,7 +708,7 @@ impl NewBuilder<VLQSourceMap> {
         {
             // `first_non_ascii` is `i32::MAX as u32` for ASCII-only lines, so the
             // comparison below is false and the `columns_for_non_ascii` SoA column
-            // (the largest, ~24 B/line) is never touched on the hot ASCII path.
+            // (the largest, ~16 B/line) is never touched on the hot ASCII path.
             let first_non_ascii = list.items::<"byte_offset_to_first_non_ascii", u32>()[idx];
             if original_column >= first_non_ascii as i32 {
                 let cols = &list.items::<"columns_for_non_ascii", Box<[i32]>>()[idx];

--- a/src/sourcemap/LineOffsetTable.rs
+++ b/src/sourcemap/LineOffsetTable.rs
@@ -18,7 +18,7 @@ use smallvec::SmallVec;
 /// as an optimization.
 #[derive(Default)]
 pub struct LineOffsetTable {
-    pub columns_for_non_ascii: Vec<i32>,
+    pub columns_for_non_ascii: Box<[i32]>,
     /// Byte offset of the first non-ASCII byte on this line, or `i32::MAX as u32`
     /// when the line is entirely ASCII (so no `columns_for_non_ascii` table exists).
     /// The sentinel can't be `0` because a line can legitimately start with a
@@ -255,10 +255,10 @@ impl LineOffsetTable {
                     // spilled → moves the heap buffer (no alloc). `mem::take` re-primes a fresh
                     // inline scratch with zero allocation. ASCII-only lines (almost all of them)
                     // store an inline `Vec::new()` and keep the scratch untouched.
-                    let owned = if columns_for_non_ascii.is_empty() {
-                        Vec::new()
+                    let owned: Box<[i32]> = if columns_for_non_ascii.is_empty() {
+                        Box::default()
                     } else {
-                        mem::take(&mut columns_for_non_ascii).into_vec()
+                        mem::take(&mut columns_for_non_ascii).into_vec().into_boxed_slice()
                     };
 
                     list.append(LineOffsetTable {
@@ -292,10 +292,10 @@ impl LineOffsetTable {
             columns_for_non_ascii.extend(core::iter::repeat_n(column, need));
         }
         {
-            let owned = if columns_for_non_ascii.is_empty() {
-                Vec::new()
+            let owned: Box<[i32]> = if columns_for_non_ascii.is_empty() {
+                Box::default()
             } else {
-                columns_for_non_ascii.into_vec()
+                columns_for_non_ascii.into_vec().into_boxed_slice()
             };
             list.append(LineOffsetTable {
                 byte_offset_to_start_of_line: line_byte_offset,

--- a/src/sourcemap/LineOffsetTable.rs
+++ b/src/sourcemap/LineOffsetTable.rs
@@ -19,6 +19,12 @@ use smallvec::SmallVec;
 #[derive(Default)]
 pub struct LineOffsetTable {
     pub columns_for_non_ascii: Vec<i32>,
+    /// Byte offset of the first non-ASCII byte on this line, or `i32::MAX as u32`
+    /// when the line is entirely ASCII (so no `columns_for_non_ascii` table exists).
+    /// The sentinel can't be `0` because a line can legitimately start with a
+    /// non-ASCII byte at offset 0. `i32::MAX` lets `add_source_mapping` skip the
+    /// `columns_for_non_ascii` SoA load on the (overwhelmingly common) ASCII path
+    /// with a single column comparison.
     pub byte_offset_to_first_non_ascii: u32,
     pub byte_offset_to_start_of_line: u32,
 }
@@ -150,7 +156,7 @@ impl LineOffsetTable {
         // Preallocate the top-level table using the approximate line count from the lexer
         list.ensure_unused_capacity(approximate_line_count.max(1) as usize)?;
         let mut column: i32 = 0;
-        let mut byte_offset_to_first_non_ascii: u32 = 0;
+        let mut byte_offset_to_first_non_ascii: u32 = i32::MAX as u32;
         let mut column_byte_offset: u32 = 0;
         let mut line_byte_offset: u32 = 0;
 
@@ -262,7 +268,7 @@ impl LineOffsetTable {
                     })?;
 
                     column = 0;
-                    byte_offset_to_first_non_ascii = 0;
+                    byte_offset_to_first_non_ascii = i32::MAX as u32;
                     column_byte_offset = 0;
                     line_byte_offset = 0;
                 }

--- a/src/sourcemap/LineOffsetTable.rs
+++ b/src/sourcemap/LineOffsetTable.rs
@@ -304,7 +304,14 @@ impl LineOffsetTable {
             })?;
         }
 
-        if list.capacity() > list.len() {
+        // `shrink_and_free` has no realloc-in-place fast path — it always does a fresh
+        // aligned_alloc + full SoA row copy + free. `grow_capacity` overshoots a single
+        // bulk reservation by at most ~50%, so when the lexer's line-count hint was
+        // roughly right (the common case) the slack isn't worth a multi-MB memcpy.
+        // Only trim when capacity exceeds 1.5x length, which catches pathological
+        // mismatches (wrong loader, wildly off hint) while skipping the routine ~20%
+        // overshoot.
+        if list.capacity() > list.len() + (list.len() >> 1) {
             list.shrink_and_free(list.len());
         }
         Ok(list)

--- a/src/sourcemap/LineOffsetTable.rs
+++ b/src/sourcemap/LineOffsetTable.rs
@@ -252,9 +252,9 @@ impl LineOffsetTable {
                     // Zig used a stack-fallback allocator and duped onto `allocator` only when
                     // stack-owned, then reset the fixed buffer. `SmallVec::into_vec()` is the
                     // exact equivalent: inline → one alloc sized to content (Zig's `dupe`),
-                    // spilled → moves the heap buffer (no alloc). `mem::take` re-primes a fresh
-                    // inline scratch with zero allocation. ASCII-only lines (almost all of them)
-                    // store an inline `Vec::new()` and keep the scratch untouched.
+                    // spilled → `into_boxed_slice()` shrink-reallocs when cap > len. `mem::take`
+                    // re-primes a fresh inline scratch with zero allocation. ASCII-only lines
+                    // (almost all of them) store `Box::default()` and keep the scratch untouched.
                     let owned: Box<[i32]> = if columns_for_non_ascii.is_empty() {
                         Box::default()
                     } else {

--- a/src/sourcemap/lib.rs
+++ b/src/sourcemap/lib.rs
@@ -962,6 +962,13 @@ impl SourceMapPieces {
         &mut self,
         shifts_: &[SourceMapShifts],
     ) -> Result<Box<[u8]>, bun_alloc::AllocError> {
+        // Nothing to splice: avoid re-joining (and re-allocating) the entire
+        // source-map JSON when there are no mappings or suffix to merge in.
+        if self.mappings.is_empty() && self.suffix.is_empty() {
+            debug_assert!(self.prefix.first() == Some(&b'{')); // invalid json
+            return Ok(core::mem::take(&mut self.prefix).into_boxed_slice());
+        }
+
         let mut shifts = shifts_;
         let mut start_of_run: usize = 0;
         let mut current: usize = 0;


### PR DESCRIPTION
Iterative perf work targeting the JS/TS parser, printer, and bundler hot paths, profiled on the three.js x100 bundle benchmark with `--minify --sourcemap=external`.

Each change was profiled with `perf` + LLVM symbolication, adversarially reviewed, then verified with `cargo check` and a quick subset of `bundler_*` tests.

This is a rolling branch — more commits will be pushed as additional optimizations are validated. Marking as draft until benchmarks settle.

No `unsafe` is added.