### PR TITLE
hot: reuse Bun.listen/Bun.serve listeners across --hot reloads

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6739,6 +6739,18 @@ declare module "bun" {
      * @default false
      */
     allowHalfOpen?: boolean;
+    /**
+     * Uniquely identify this listener for hot reloading.
+     *
+     * When Bun is started with the `--hot` flag, `Bun.listen()` calls that
+     * resolve to the same `id` reuse the existing listening socket (swapping
+     * handlers in place) instead of re-binding, which would fail with
+     * `EADDRINUSE`. If not provided, an id is derived from `hostname`,
+     * `port`, and `tls`. Pass `null` to opt out of hot-reload reuse.
+     *
+     * When Bun is not started with `--hot`, this value is currently unused.
+     */
+    id?: string | null;
   }
 
   interface TCPSocketConnectOptions<Data = undefined> extends SocketOptions<Data> {
@@ -6782,6 +6794,21 @@ declare module "bun" {
     tls?: TLSOptions | boolean;
   }
 
+  interface UnixSocketListenOptions<Data = undefined> extends UnixSocketOptions<Data> {
+    /**
+     * Uniquely identify this listener for hot reloading.
+     *
+     * When Bun is started with the `--hot` flag, `Bun.listen()` calls that
+     * resolve to the same `id` reuse the existing listening socket (swapping
+     * handlers in place) instead of re-binding. If not provided, an id is
+     * derived from `unix` and `tls`. Pass `null` to opt out of hot-reload
+     * reuse.
+     *
+     * When Bun is not started with `--hot`, this value is currently unused.
+     */
+    id?: string | null;
+  }
+
   interface FdSocketOptions<Data = undefined> extends SocketOptions<Data> {
     /**
      * TLS configuration with which to create the socket
@@ -6817,7 +6844,7 @@ declare module "bun" {
    *
    * @category HTTP & Networking
    */
-  function listen<Data = undefined>(options: UnixSocketOptions<Data>): UnixSocketListener<Data>;
+  function listen<Data = undefined>(options: UnixSocketListenOptions<Data>): UnixSocketListener<Data>;
 
   /**
    * @category HTTP & Networking

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -84,8 +84,7 @@ impl HotMap {
         self._map.get(key).copied()
     }
 
-    /// Returns `false` (leaving the existing entry untouched) if `key` is
-    /// already registered.
+    /// Returns `false` and keeps the existing entry if `key` is already registered.
     pub fn insert_raw(&mut self, key: &[u8], entry: HotMapEntry) -> bool {
         let gop = bun_core::handle_oom(self._map.get_or_put(key));
         if gop.found_existing {

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -84,15 +84,16 @@ impl HotMap {
         self._map.get(key).copied()
     }
 
-    /// Untyped insert — typed `insert<T>` lives in `bun_runtime` where the
-    /// `TaggedPointerUnion` payload list is named.
-    pub fn insert_raw(&mut self, key: &[u8], entry: HotMapEntry) {
+    /// Returns `false` (leaving the existing entry untouched) if `key` is
+    /// already registered.
+    pub fn insert_raw(&mut self, key: &[u8], entry: HotMapEntry) -> bool {
         let gop = bun_core::handle_oom(self._map.get_or_put(key));
         if gop.found_existing {
-            panic!("HotMap already contains key");
+            return false;
         }
         // `get_or_put` already boxed the key; the map owns its keys.
         *gop.value_ptr = entry;
+        true
     }
 
     pub fn remove(&mut self, key: &[u8]) {

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1599,13 +1599,32 @@ fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSVa
                 // SAFETY: same VM pointer; re-borrow after the earlier `vm` mut
                 // borrow was released by the `hot_map()` arm above.
                 if let Some(hot) = global_object.bun_vm().as_mut().hot_map() {
-                    hot.insert_raw(
-                        &server_ref.config.id,
-                        HotMapEntry {
-                            tag: $tag as u8,
-                            ptr: server.cast::<()>(),
-                        },
-                    );
+                    // `insert_raw` panics on a duplicate key. The lookup
+                    // above only early-returns on an `AnyServerTag` match,
+                    // so a foreign-tag entry would survive to here.
+                    // `Bun.listen` keys are namespaced
+                    // (`[tcp]-`/`[tls]-`/`[listen]-`) so this is
+                    // belt-and-suspenders for a contrived
+                    // `Bun.serve({id: "[listen]-…"})` — skip registration
+                    // rather than panicking; the tag check keeps the
+                    // entries from ever being mis-cast.
+                    if hot.get_entry(&server_ref.config.id).is_none() {
+                        hot.insert_raw(
+                            &server_ref.config.id,
+                            HotMapEntry {
+                                tag: $tag as u8,
+                                ptr: server.cast::<()>(),
+                            },
+                        );
+                    } else {
+                        // Not registered → `NewServer::stop` must not
+                        // `hot.remove` the foreign entry that *is* there.
+                        // Flip `allow_hot` so its `allow_hot && !id.is_empty()`
+                        // gate is false, but leave `config.id` intact so the
+                        // user-visible `server.id` getter still reflects what
+                        // was passed.
+                        server_ref.config.allow_hot = false;
+                    }
                 }
             }
 

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1599,30 +1599,13 @@ fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSVa
                 // SAFETY: same VM pointer; re-borrow after the earlier `vm` mut
                 // borrow was released by the `hot_map()` arm above.
                 if let Some(hot) = global_object.bun_vm().as_mut().hot_map() {
-                    // `insert_raw` panics on a duplicate key. The lookup
-                    // above only early-returns on an `AnyServerTag` match,
-                    // so a foreign-tag entry would survive to here.
-                    // `Bun.listen` keys are namespaced
-                    // (`[tcp]-`/`[tls]-`/`[listen]-`) so this is
-                    // belt-and-suspenders for a contrived
-                    // `Bun.serve({id: "[listen]-…"})` — skip registration
-                    // rather than panicking; the tag check keeps the
-                    // entries from ever being mis-cast.
-                    if hot.get_entry(&server_ref.config.id).is_none() {
-                        hot.insert_raw(
-                            &server_ref.config.id,
-                            HotMapEntry {
-                                tag: $tag as u8,
-                                ptr: server.cast::<()>(),
-                            },
-                        );
-                    } else {
-                        // Not registered → `NewServer::stop` must not
-                        // `hot.remove` the foreign entry that *is* there.
-                        // Flip `allow_hot` so its `allow_hot && !id.is_empty()`
-                        // gate is false, but leave `config.id` intact so the
-                        // user-visible `server.id` getter still reflects what
-                        // was passed.
+                    let entry = HotMapEntry {
+                        tag: $tag as u8,
+                        ptr: server.cast::<()>(),
+                    };
+                    // Key held by a non-server entry (a `Bun.listen` id):
+                    // stay unregistered so `stop()` leaves that entry alone.
+                    if !hot.insert_raw(&server_ref.config.id, entry) {
                         server_ref.config.allow_hot = false;
                     }
                 }

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1603,8 +1603,7 @@ fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSVa
                         tag: $tag as u8,
                         ptr: server.cast::<()>(),
                     };
-                    // Key held by a non-server entry (a `Bun.listen` id):
-                    // stay unregistered so `stop()` leaves that entry alone.
+                    // Key held by a `Bun.listen` entry: stay unregistered so `stop()` leaves it alone.
                     if !hot.insert_raw(&server_ref.config.id, entry) {
                         server_ref.config.allow_hot = false;
                     }

--- a/src/runtime/socket/Handlers.rs
+++ b/src/runtime/socket/Handlers.rs
@@ -412,12 +412,9 @@ impl Handlers {
         self.binary_type.set(reloaded.binary_type);
     }
 
-    /// Overwrites this cell's callbacks and binary type from `source`. Used by
-    /// `--hot` reload reuse, where the entry module already produced a fresh
-    /// `Handlers` via `SocketConfig::from_js` and we want the existing
-    /// listener (and every socket sharing its cell) to pick those callbacks
-    /// up without re-binding. Runs no user JS.
-    pub fn copy_callbacks_from(&self, global_object: &JSGlobalObject, source: &Handlers) {
+    /// Like [`apply_reload`](Self::apply_reload), but `source`'s callbacks are
+    /// already context-wrapped by `from_generated`.
+    pub(crate) fn copy_callbacks_from(&self, global_object: &JSGlobalObject, source: &Handlers) {
         self.cell
             .set_callbacks(global_object, &source.cell.callbacks());
         self.binary_type.set(source.binary_type.get());

--- a/src/runtime/socket/Handlers.rs
+++ b/src/runtime/socket/Handlers.rs
@@ -411,6 +411,17 @@ impl Handlers {
         self.cell.set_callbacks(global_object, &wrapped);
         self.binary_type.set(reloaded.binary_type);
     }
+
+    /// Overwrites this cell's callbacks and binary type from `source`. Used by
+    /// `--hot` reload reuse, where the entry module already produced a fresh
+    /// `Handlers` via `SocketConfig::from_js` and we want the existing
+    /// listener (and every socket sharing its cell) to pick those callbacks
+    /// up without re-binding. Runs no user JS.
+    pub fn copy_callbacks_from(&self, global_object: &JSGlobalObject, source: &Handlers) {
+        self.cell
+            .set_callbacks(global_object, &source.cell.callbacks());
+        self.binary_type.set(source.binary_type.get());
+    }
 }
 
 /// One in-flight dispatch into JS. Holds an `Rc` so the callbacks it is about

--- a/src/runtime/socket/Handlers.rs
+++ b/src/runtime/socket/Handlers.rs
@@ -412,8 +412,7 @@ impl Handlers {
         self.binary_type.set(reloaded.binary_type);
     }
 
-    /// Like [`apply_reload`](Self::apply_reload), but `source`'s callbacks are
-    /// already context-wrapped by `from_generated`.
+    /// [`apply_reload`](Self::apply_reload) for callbacks `from_generated` already context-wrapped.
     pub(crate) fn copy_callbacks_from(&self, global_object: &JSGlobalObject, source: &Handlers) {
         self.cell
             .set_callbacks(global_object, &source.cell.callbacks());

--- a/src/runtime/socket/JSSocketHandlers.rs
+++ b/src/runtime/socket/JSSocketHandlers.rs
@@ -136,9 +136,8 @@ impl JSSocketHandlers {
         Bun__SocketHandlers__setCallbacks(global, self.0, callbacks.as_ptr());
     }
 
-    /// Reads all callback fields out of the cell. `undefined` entries come back
-    /// as `JSValue::ZERO` (the inverse of [`set_callbacks`]).
-    pub fn callbacks(self) -> [JSValue; CALLBACK_COUNT] {
+    /// Inverse of [`set_callbacks`](Self::set_callbacks): unset fields read as `JSValue::ZERO`.
+    pub(crate) fn callbacks(self) -> [JSValue; CALLBACK_COUNT] {
         core::array::from_fn(|i| {
             let v = Bun__SocketHandlers__getField(self.0, i as u32);
             if v.is_undefined() { JSValue::ZERO } else { v }

--- a/src/runtime/socket/JSSocketHandlers.rs
+++ b/src/runtime/socket/JSSocketHandlers.rs
@@ -136,6 +136,15 @@ impl JSSocketHandlers {
         Bun__SocketHandlers__setCallbacks(global, self.0, callbacks.as_ptr());
     }
 
+    /// Reads all callback fields out of the cell. `undefined` entries come back
+    /// as `JSValue::ZERO` (the inverse of [`set_callbacks`]).
+    pub fn callbacks(self) -> [JSValue; CALLBACK_COUNT] {
+        core::array::from_fn(|i| {
+            let v = Bun__SocketHandlers__getField(self.0, i as u32);
+            if v.is_undefined() { JSValue::ZERO } else { v }
+        })
+    }
+
     /// Drops the `open` callback: a client socket clears it after its first TLS
     /// handshake so renegotiations do not fire it again.
     #[inline]

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -67,9 +67,7 @@ fn with_ssl_ctx_cache<R>(
 // `to_js(self)` impl does would invalidate that link).
 use crate::generated_classes::js_Listener;
 
-/// `HotMapEntry.tag` discriminant for `Listener`. Must not collide with
-/// `crate::server::AnyServerTag` (0..=3) — those are the `Bun.serve` server
-/// variants sharing the same hot-reload registry.
+/// `HotMapEntry.tag` for listeners; `crate::server::AnyServerTag` owns 0..=3.
 const HOT_MAP_TAG_LISTENER: u8 = 4;
 
 // R-2 (host-fn re-entrancy): every JS-exposed method takes `&self`; per-field
@@ -98,10 +96,7 @@ pub struct Listener {
     /// Reference to this listener's JS wrapper. Strong while it is listening or
     /// has connections, downgraded to weak once idle so GC can reclaim it.
     pub this_value: JsCell<JsRef>,
-    /// `--hot` registry key. Non-empty iff this listener is registered in
-    /// `VirtualMachine::hot_map()`; cleared on [`do_stop`](Self::do_stop) so a
-    /// subsequent `Bun.listen` on the same address re-binds instead of
-    /// reusing a stopped listener.
+    /// `--hot` registry key; non-empty iff registered in `VirtualMachine::hot_map()`.
     pub(crate) hot_id: JsCell<Box<[u8]>>,
 }
 
@@ -199,16 +194,8 @@ impl Listener {
         let ssl_enabled = socket_config.ssl.is_some();
         let socket_flags = socket_config.socket_flags();
 
-        // `--hot` reuse: if a previous evaluation of the entry module already
-        // has a listener bound to this address, swap its handlers in place
-        // and return the existing JS wrapper instead of re-binding (which
-        // would fail EADDRINUSE). Matches what `Bun.serve` does via
-        // `ServerConfig::compute_id`/`on_reload_from_zig`. `id: null`/`""`
-        // opts out (same as `Bun.serve`). User-supplied ids are namespaced
-        // with `[listen]-` so they can't collide with `Bun.serve`'s entries
-        // in the shared `HotMap` — a listen and a serve can never reuse
-        // each other (different tags), so sharing a key only causes
-        // whichever registers second to go untracked.
+        // `--hot`: re-evaluating the entry module must reuse the listener the
+        // previous evaluation bound, as `Bun.serve` does. `id: null`/`""` opts out.
         let hot_id: Box<[u8]> = match opts.get(global, "id")? {
             None => compute_hot_id(socket_config.hostname_or_unix.slice(), port, ssl_enabled),
             Some(id) if id.is_null() => Box::default(),
@@ -218,6 +205,7 @@ impl Listener {
                 if user.is_empty() {
                     Box::default()
                 } else {
+                    // Prefixed so a user id can never alias a `Bun.serve` key.
                     let mut buf = Vec::with_capacity(user.len() + 9);
                     buf.extend_from_slice(b"[listen]-");
                     buf.extend_from_slice(user);
@@ -229,17 +217,12 @@ impl Listener {
             if let Some(hot) = global.bun_vm().as_mut().hot_map() {
                 if let Some(entry) = hot.get_entry(&hot_id) {
                     if entry.tag == HOT_MAP_TAG_LISTENER {
-                        // SAFETY: tag matched; ptr was inserted below as
-                        // `*mut Listener` and is removed in `do_stop`/`deinit`
-                        // before the allocation is freed, so it is live here.
+                        // SAFETY: tag matched; `register_for_hot_reload` inserted a
+                        // `*mut Listener` that `do_stop`/`deinit` remove before freeing.
                         let existing: &Listener = unsafe { &*entry.ptr.cast::<Listener>() };
                         let this_ref = existing.this_value.get();
                         if this_ref.is_strong() {
                             if let Some(this_value) = this_ref.try_get() {
-                                // Write the new callbacks into the existing
-                                // listener's shared cell so every accepted
-                                // socket picks them up in place — same path as
-                                // `listener.reload()`.
                                 existing
                                     .handlers
                                     .copy_callbacks_from(global, &socket_config.handlers);
@@ -254,10 +237,7 @@ impl Listener {
                                 return Ok(this_value);
                             }
                         }
-                        // A registered listener holds `this_value` strong
-                        // while it is listening, so this branch is defensive:
-                        // a Weak JSValue may be GC-dead, so never hand it
-                        // back; close the old socket and rebind instead.
+                        // A weak `JSValue` may already be dead; release the port instead.
                         Listener::do_stop(existing, false);
                     }
                 }
@@ -676,8 +656,6 @@ impl Listener {
             ));
         }
 
-        // Register for `--hot` reuse and `--watch` fd cleanup (mirrors
-        // `NewServer::on_listen` in `runtime/server/mod.rs`).
         Listener::register_for_hot_reload(this, hot_id);
         if !ssl_enabled {
             // S008: `ListenSocket` is an `opaque_ffi!` ZST — safe deref.
@@ -1007,10 +985,6 @@ impl Listener {
             ListenerType::Uws(socket) => {
                 Self::unlink_unix_socket_path(&self);
                 if !self.ssl {
-                    // Mirror `do_stop`: drop the `--watch` registration
-                    // before closing so a later `--watch` restart doesn't
-                    // SO_LINGER-close whatever unrelated fd the OS reused
-                    // this number for.
                     // S008: `ListenSocket` is an `opaque_ffi!` ZST — safe deref.
                     let fd = bun_opaque::opaque_deref_mut(socket).fd();
                     self.handlers
@@ -1039,36 +1013,22 @@ impl Listener {
         Self::deinit(Box::into_raw(self));
     }
 
-    /// Registers `this` in `VirtualMachine::hot_map()` under `hot_id` so a
-    /// subsequent `Bun.listen` call with the same address (after a `--hot`
-    /// re-evaluation of the entry module) reuses this listener instead of
-    /// re-binding. No-op outside `--hot` (`hot_map()` returns `None`).
+    /// No-op outside `--hot` (`hot_map()` is `None`) or when the key is taken.
     fn register_for_hot_reload(this: *mut Self, hot_id: Box<[u8]>) {
         if hot_id.is_empty() {
             return;
         }
-        // SAFETY: `this` is the freshly-allocated Listener owned by the JS
-        // wrapper; single JS thread, no aliasing `&mut` outstanding.
+        // SAFETY: `this` was just allocated by `listen()`; no `&mut` outstanding.
         let this_ref = unsafe { &*this };
         let vm = this_ref.handlers.global_object.bun_vm().as_mut();
         let Some(hot) = vm.hot_map() else { return };
-        // `insert_raw` panics on a duplicate key. The lookup in `listen()`
-        // either returns early (reusable same-tag entry) or `do_stop`s the
-        // stale one (unref'd listener), and listener keys are namespaced
-        // (`[tcp]-`/`[tls]-`/`[listen]-`) so `Bun.serve` can't hold one.
-        // This check is belt-and-suspenders in case a caller somehow
-        // constructs a colliding key — skip registration rather than panic.
-        if hot.get_entry(&hot_id).is_some() {
-            return;
+        let entry = bun_jsc::rare_data::HotMapEntry {
+            tag: HOT_MAP_TAG_LISTENER,
+            ptr: this.cast::<()>(),
+        };
+        if hot.insert_raw(&hot_id, entry) {
+            this_ref.hot_id.set(hot_id);
         }
-        hot.insert_raw(
-            &hot_id,
-            bun_jsc::rare_data::HotMapEntry {
-                tag: HOT_MAP_TAG_LISTENER,
-                ptr: this.cast::<()>(),
-            },
-        );
-        this_ref.hot_id.set(hot_id);
     }
 
     fn unregister_for_hot_reload(this: &Self) {
@@ -1103,8 +1063,6 @@ impl Listener {
         // and `close_all()` can fire JS `close` handlers that re-derive
         // `&Listener` — no `&mut` may span that.
         let this_ref = unsafe { &*this };
-        // Normally cleared in `do_stop`; repeated here so no teardown path
-        // can leave a hot-map entry pointing at freed memory.
         Self::unregister_for_hot_reload(this_ref);
         this_ref.this_value.with_mut(|r| r.finalize());
         this_ref.strong_data.with_mut(|s| s.deinit());
@@ -1880,15 +1838,11 @@ pub(crate) fn js_add_server_name(global: &JSGlobalObject, frame: &CallFrame) -> 
     Err(global.throw(format_args!("Expected a Listener instance")))
 }
 
-/// `--hot` registry key for a `Bun.listen` call. Uses the *requested* address
-/// (host/port or unix path) so repeated evaluations of the same source under
-/// `--hot` produce the same key even when `port: 0` resolves to a random
-/// port. The `[tcp]`/`[tls]` prefix keeps these disjoint from `Bun.serve`'s
-/// `[http]-...` keys in the shared `HotMap` (see `ServerConfig::compute_id`).
+/// Keyed on the *requested* address so `port: 0` maps to the same entry on every
+/// reload. Prefixed to stay disjoint from `ServerConfig::compute_id` keys.
 fn compute_hot_id(hostname_or_unix: &[u8], port: Option<u16>, ssl: bool) -> Box<[u8]> {
     use std::io::Write as _;
-    // Callers that pass an fd (connect path) or an empty address would
-    // produce a non-unique key; skip hot-reload reuse for those.
+    // fd-based listeners have no address to key on.
     if hostname_or_unix.is_empty() && port.is_none() {
         return Box::default();
     }

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -67,6 +67,11 @@ fn with_ssl_ctx_cache<R>(
 // `to_js(self)` impl does would invalidate that link).
 use crate::generated_classes::js_Listener;
 
+/// `HotMapEntry.tag` discriminant for `Listener`. Must not collide with
+/// `crate::server::AnyServerTag` (0..=3) — those are the `Bun.serve` server
+/// variants sharing the same hot-reload registry.
+const HOT_MAP_TAG_LISTENER: u8 = 4;
+
 // R-2 (host-fn re-entrancy): every JS-exposed method takes `&self`; per-field
 // interior mutability via `Cell` (Copy) / `JsCell` (non-Copy). The codegen
 // shim still emits `this: &mut Listener` — `&mut T` auto-derefs to `&T`
@@ -93,6 +98,11 @@ pub struct Listener {
     /// Reference to this listener's JS wrapper. Strong while it is listening or
     /// has connections, downgraded to weak once idle so GC can reclaim it.
     pub this_value: JsCell<JsRef>,
+    /// `--hot` registry key. Non-empty iff this listener is registered in
+    /// `VirtualMachine::hot_map()`; cleared on [`do_stop`](Self::do_stop) so a
+    /// subsequent `Bun.listen` on the same address re-binds instead of
+    /// reusing a stopped listener.
+    pub(crate) hot_id: JsCell<Box<[u8]>>,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -189,6 +199,71 @@ impl Listener {
         let ssl_enabled = socket_config.ssl.is_some();
         let socket_flags = socket_config.socket_flags();
 
+        // `--hot` reuse: if a previous evaluation of the entry module already
+        // has a listener bound to this address, swap its handlers in place
+        // and return the existing JS wrapper instead of re-binding (which
+        // would fail EADDRINUSE). Matches what `Bun.serve` does via
+        // `ServerConfig::compute_id`/`on_reload_from_zig`. `id: null`/`""`
+        // opts out (same as `Bun.serve`). User-supplied ids are namespaced
+        // with `[listen]-` so they can't collide with `Bun.serve`'s entries
+        // in the shared `HotMap` — a listen and a serve can never reuse
+        // each other (different tags), so sharing a key only causes
+        // whichever registers second to go untracked.
+        let hot_id: Box<[u8]> = match opts.get(global, "id")? {
+            None => compute_hot_id(socket_config.hostname_or_unix.slice(), port, ssl_enabled),
+            Some(id) if id.is_null() => Box::default(),
+            Some(id) => {
+                let slice = id.to_slice(global)?;
+                let user = slice.slice();
+                if user.is_empty() {
+                    Box::default()
+                } else {
+                    let mut buf = Vec::with_capacity(user.len() + 9);
+                    buf.extend_from_slice(b"[listen]-");
+                    buf.extend_from_slice(user);
+                    buf.into_boxed_slice()
+                }
+            }
+        };
+        if !hot_id.is_empty() {
+            if let Some(hot) = global.bun_vm().as_mut().hot_map() {
+                if let Some(entry) = hot.get_entry(&hot_id) {
+                    if entry.tag == HOT_MAP_TAG_LISTENER {
+                        // SAFETY: tag matched; ptr was inserted below as
+                        // `*mut Listener` and is removed in `do_stop`/`deinit`
+                        // before the allocation is freed, so it is live here.
+                        let existing: &Listener = unsafe { &*entry.ptr.cast::<Listener>() };
+                        let this_ref = existing.this_value.get();
+                        if this_ref.is_strong() {
+                            if let Some(this_value) = this_ref.try_get() {
+                                // Write the new callbacks into the existing
+                                // listener's shared cell so every accepted
+                                // socket picks them up in place — same path as
+                                // `listener.reload()`.
+                                existing
+                                    .handlers
+                                    .copy_callbacks_from(global, &socket_config.handlers);
+                                let default_data = socket_config.default_data;
+                                existing.strong_data.with_mut(|s| {
+                                    if default_data.is_empty() {
+                                        s.deinit();
+                                    } else {
+                                        s.set(global, default_data);
+                                    }
+                                });
+                                return Ok(this_value);
+                            }
+                        }
+                        // A registered listener holds `this_value` strong
+                        // while it is listening, so this branch is defensive:
+                        // a Weak JSValue may be GC-dead, so never hand it
+                        // back; close the old socket and rebind instead.
+                        Listener::do_stop(existing, false);
+                    }
+                }
+            }
+        }
+
         #[cfg(windows)]
         if port.is_none() {
             // we check if the path is a named pipe otherwise we try to connect using AF_UNIX
@@ -234,6 +309,7 @@ impl Listener {
                     secure_ctx: Cell::new(None),
                     strong_data: JsCell::new(Strong::empty()),
                     this_value: JsCell::new(JsRef::empty()),
+                    hot_id: JsCell::new(Box::default()),
                 }));
                 // SAFETY: just allocated, non-null; every field touched below
                 // is `Cell`/`JsCell` or `&self`, so a shared borrow suffices.
@@ -326,6 +402,7 @@ impl Listener {
                         (),
                     ));
                 }
+                Listener::register_for_hot_reload(this, hot_id);
                 return Ok(this_value);
             }
         }
@@ -362,6 +439,7 @@ impl Listener {
             secure_ctx: Cell::new(None),
             strong_data: JsCell::new(Strong::empty()),
             this_value: JsCell::new(JsRef::empty()),
+            hot_id: JsCell::new(Box::default()),
         }));
         // SAFETY: just allocated, non-null; every field touched through this
         // borrow is `Cell`/`JsCell` or `&self`. The one plain-field write
@@ -596,6 +674,18 @@ impl Listener {
                 crate::jsc_hooks::ActiveHandle::Listener(NonNull::from(this_ref)),
                 (),
             ));
+        }
+
+        // Register for `--hot` reuse and `--watch` fd cleanup (mirrors
+        // `NewServer::on_listen` in `runtime/server/mod.rs`).
+        Listener::register_for_hot_reload(this, hot_id);
+        if !ssl_enabled {
+            // S008: `ListenSocket` is an `opaque_ffi!` ZST — safe deref.
+            let fd = bun_opaque::opaque_deref_mut(listen_socket).fd();
+            global
+                .bun_vm()
+                .as_mut()
+                .add_listening_socket_for_watch_mode(fd);
         }
 
         Ok(this_value)
@@ -844,6 +934,7 @@ impl Listener {
     }
 
     fn do_stop(this: &Self, force_close: bool) {
+        Self::unregister_for_hot_reload(this);
         if matches!(this.listener.get(), ListenerType::None) {
             return;
         }
@@ -854,8 +945,17 @@ impl Listener {
             )));
         }
 
-        if matches!(listener, ListenerType::Uws(_)) {
+        if let ListenerType::Uws(socket) = listener {
             Self::unlink_unix_socket_path(this);
+            if !this.ssl {
+                // S008: `ListenSocket` is an `opaque_ffi!` ZST — safe deref.
+                let fd = bun_opaque::opaque_deref_mut(socket).fd();
+                this.handlers
+                    .global_object
+                    .bun_vm()
+                    .as_mut()
+                    .remove_listening_socket_for_watch_mode(fd);
+            }
         }
 
         // The listener's poll_ref tracks the listening socket only; accepted
@@ -906,6 +1006,19 @@ impl Listener {
         match listener {
             ListenerType::Uws(socket) => {
                 Self::unlink_unix_socket_path(&self);
+                if !self.ssl {
+                    // Mirror `do_stop`: drop the `--watch` registration
+                    // before closing so a later `--watch` restart doesn't
+                    // SO_LINGER-close whatever unrelated fd the OS reused
+                    // this number for.
+                    // S008: `ListenSocket` is an `opaque_ffi!` ZST — safe deref.
+                    let fd = bun_opaque::opaque_deref_mut(socket).fd();
+                    self.handlers
+                        .global_object
+                        .bun_vm()
+                        .as_mut()
+                        .remove_listening_socket_for_watch_mode(fd);
+                }
                 // S008: `ListenSocket` is an `opaque_ffi!` ZST — safe deref.
                 bun_opaque::opaque_deref_mut(socket).close();
             }
@@ -924,6 +1037,49 @@ impl Listener {
         // `deinit` frees the allocation itself (`heap::take`); hand ownership
         // back so its existing raw-ptr teardown path stays intact.
         Self::deinit(Box::into_raw(self));
+    }
+
+    /// Registers `this` in `VirtualMachine::hot_map()` under `hot_id` so a
+    /// subsequent `Bun.listen` call with the same address (after a `--hot`
+    /// re-evaluation of the entry module) reuses this listener instead of
+    /// re-binding. No-op outside `--hot` (`hot_map()` returns `None`).
+    fn register_for_hot_reload(this: *mut Self, hot_id: Box<[u8]>) {
+        if hot_id.is_empty() {
+            return;
+        }
+        // SAFETY: `this` is the freshly-allocated Listener owned by the JS
+        // wrapper; single JS thread, no aliasing `&mut` outstanding.
+        let this_ref = unsafe { &*this };
+        let vm = this_ref.handlers.global_object.bun_vm().as_mut();
+        let Some(hot) = vm.hot_map() else { return };
+        // `insert_raw` panics on a duplicate key. The lookup in `listen()`
+        // either returns early (reusable same-tag entry) or `do_stop`s the
+        // stale one (unref'd listener), and listener keys are namespaced
+        // (`[tcp]-`/`[tls]-`/`[listen]-`) so `Bun.serve` can't hold one.
+        // This check is belt-and-suspenders in case a caller somehow
+        // constructs a colliding key — skip registration rather than panic.
+        if hot.get_entry(&hot_id).is_some() {
+            return;
+        }
+        hot.insert_raw(
+            &hot_id,
+            bun_jsc::rare_data::HotMapEntry {
+                tag: HOT_MAP_TAG_LISTENER,
+                ptr: this.cast::<()>(),
+            },
+        );
+        this_ref.hot_id.set(hot_id);
+    }
+
+    fn unregister_for_hot_reload(this: &Self) {
+        let hot_id = this.hot_id.with_mut(core::mem::take);
+        if hot_id.is_empty() {
+            return;
+        }
+        let vm = this.handlers.global_object.bun_vm().as_mut();
+        if let Some(hot) = vm.hot_map() {
+            hot.remove(&hot_id);
+        }
     }
 
     /// Match Node.js/libuv: unlink the unix socket file before closing the listening fd.
@@ -947,6 +1103,9 @@ impl Listener {
         // and `close_all()` can fire JS `close` handlers that re-derive
         // `&Listener` — no `&mut` may span that.
         let this_ref = unsafe { &*this };
+        // Normally cleared in `do_stop`; repeated here so no teardown path
+        // can leave a hot-map entry pointing at freed memory.
+        Self::unregister_for_hot_reload(this_ref);
         this_ref.this_value.with_mut(|r| r.finalize());
         this_ref.strong_data.with_mut(|s| s.deinit());
         this_ref.poll_ref.with_mut(|p| p.unref(bun_io::js_vm_ctx()));
@@ -1719,6 +1878,31 @@ pub(crate) fn js_add_server_name(global: &JSGlobalObject, frame: &CallFrame) -> 
         return Listener::add_server_name(this, global, hostname, tls);
     }
     Err(global.throw(format_args!("Expected a Listener instance")))
+}
+
+/// `--hot` registry key for a `Bun.listen` call. Uses the *requested* address
+/// (host/port or unix path) so repeated evaluations of the same source under
+/// `--hot` produce the same key even when `port: 0` resolves to a random
+/// port. The `[tcp]`/`[tls]` prefix keeps these disjoint from `Bun.serve`'s
+/// `[http]-...` keys in the shared `HotMap` (see `ServerConfig::compute_id`).
+fn compute_hot_id(hostname_or_unix: &[u8], port: Option<u16>, ssl: bool) -> Box<[u8]> {
+    use std::io::Write as _;
+    // Callers that pass an fd (connect path) or an empty address would
+    // produce a non-unique key; skip hot-reload reuse for those.
+    if hostname_or_unix.is_empty() && port.is_none() {
+        return Box::default();
+    }
+    let mut buf: Vec<u8> = Vec::with_capacity(hostname_or_unix.len() + 24);
+    let _ = buf.write_all(if ssl { b"[tls]-" } else { b"[tcp]-" });
+    match port {
+        Some(p) => {
+            let _ = write!(&mut buf, "tcp:{}:{}", bstr::BStr::new(hostname_or_unix), p);
+        }
+        None => {
+            let _ = write!(&mut buf, "unix:{}", bstr::BStr::new(hostname_or_unix));
+        }
+    }
+    buf.into_boxed_slice()
 }
 
 #[cfg(windows)]

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -194,8 +194,7 @@ impl Listener {
         let ssl_enabled = socket_config.ssl.is_some();
         let socket_flags = socket_config.socket_flags();
 
-        // `--hot`: re-evaluating the entry module must reuse the listener the
-        // previous evaluation bound, as `Bun.serve` does. `id: null`/`""` opts out.
+        // `--hot` reuses the listener a previous evaluation bound (as `Bun.serve` does); `id: null`/`""` opts out.
         let hot_id: Box<[u8]> = match opts.get(global, "id")? {
             None => compute_hot_id(socket_config.hostname_or_unix.slice(), port, ssl_enabled),
             Some(id) if id.is_null() => Box::default(),
@@ -1838,8 +1837,7 @@ pub(crate) fn js_add_server_name(global: &JSGlobalObject, frame: &CallFrame) -> 
     Err(global.throw(format_args!("Expected a Listener instance")))
 }
 
-/// Keyed on the *requested* address so `port: 0` maps to the same entry on every
-/// reload. Prefixed to stay disjoint from `ServerConfig::compute_id` keys.
+/// Keyed on the *requested* address so `port: 0` is stable across reloads; prefix keeps it disjoint from `ServerConfig::compute_id`.
 fn compute_hot_id(hostname_or_unix: &[u8], port: Option<u16>, ssl: bool) -> Box<[u8]> {
     use std::io::Write as _;
     // fd-based listeners have no address to key on.

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -809,6 +809,7 @@ describe("should reuse the listening socket on hot reload", () => {
               resolve(text.slice(0, nl));
               s.end();
             },
+            close: () => reject(new Error("socket closed before a full line arrived")),
             error: (_s, e) => reject(e),
             connectError: (_s, e) => reject(e),
           },

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
-import { beforeEach, expect, it } from "bun:test";
+import { beforeEach, describe, expect, it } from "bun:test";
 import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isDebug, isWindows, tmpdirSync, waitForFileToExist } from "harness";
+import { bunEnv, bunExe, isDebug, isWindows, tempDir, tmpdirSync, waitForFileToExist } from "harness";
 import { join } from "path";
 
 const timeout = isDebug ? Infinity : 10_000;
@@ -776,3 +776,158 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
   },
   longTimeout,
 );
+
+// https://github.com/oven-sh/bun/issues/26036
+// Under --hot, re-evaluating the entry module re-runs Bun.listen()/Bun.serve()
+// with the same address. The previous listener must be reused (handlers
+// swapped in place) rather than re-binding, which would fail EADDRINUSE.
+describe("should reuse the listening socket on hot reload", () => {
+  for (const [name, listen, extract] of [
+    [
+      "Bun.listen",
+      `const server = Bun.listen({
+         hostname: "127.0.0.1",
+         port: 0,
+         socket: {
+           open(s) { s.write("v" + globalThis.reloadCount + "\\n"); s.flush(); },
+           data() {},
+         },
+       });`,
+      async (port: number) => {
+        const { promise, resolve, reject } = Promise.withResolvers<string>();
+        let text = "";
+        const sock = await Bun.connect({
+          hostname: "127.0.0.1",
+          port,
+          socket: {
+            data(s, data) {
+              // TCP is a byte stream; accumulate until the newline
+              // terminator instead of assuming a single-chunk delivery.
+              text += Buffer.from(data).toString();
+              const nl = text.indexOf("\n");
+              if (nl === -1) return;
+              resolve(text.slice(0, nl));
+              s.end();
+            },
+            error: (_s, e) => reject(e),
+            connectError: (_s, e) => reject(e),
+          },
+        });
+        const result = await promise;
+        sock.end();
+        return result;
+      },
+    ],
+    [
+      "Bun.serve",
+      `const server = Bun.serve({
+         hostname: "127.0.0.1",
+         port: 0,
+         fetch() { return new Response("v" + globalThis.reloadCount); },
+       });`,
+      async (port: number) => {
+        const res = await fetch(`http://127.0.0.1:${port}/`);
+        return await res.text();
+      },
+    ],
+  ] as const) {
+    it(
+      name,
+      async () => {
+        // The hot-reload registry keys on the *requested* address, so
+        // `port: 0` matches itself across reloads and the child keeps the
+        // same resolved port. We read that port back from the first event
+        // rather than reserving one in the parent (which would be a TOCTOU
+        // race with other processes on the CI box).
+        const source = (n: number) => `
+globalThis.reloadCount = ${n};
+${listen}
+console.log(JSON.stringify({ listening: true, port: server.port, reload: globalThis.reloadCount }));
+`;
+        using dir = tempDir("hot-listen-reuse", {
+          "index.ts": source(1),
+        });
+        const entry = join(String(dir), "index.ts");
+
+        await using runner = spawn({
+          cmd: [bunExe(), "--hot", "run", entry],
+          env: bunEnv,
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "pipe",
+          stdin: "ignore",
+        });
+
+        let stderr = "";
+        const stderrDone = (async () => {
+          for await (const chunk of runner.stderr) {
+            stderr += new TextDecoder().decode(chunk);
+            // Without the fix the second evaluation fails EADDRINUSE and
+            // stdout never produces another event; bail instead of hanging
+            // until the timeout.
+            if (stderr.includes("EADDRINUSE") || stderr.includes("Failed to")) {
+              runner.kill();
+            }
+          }
+        })().catch(() => {});
+
+        const events: Array<{ listening: boolean; port: number; reload: number }> = [];
+        const responses: string[] = [];
+        let buf = "";
+        const target = 3;
+        let port = 0;
+
+        try {
+          for await (const chunk of runner.stdout) {
+            buf += new TextDecoder().decode(chunk);
+            const lines = buf.split("\n");
+            buf = lines.pop() ?? "";
+            let advanced = false;
+            for (const line of lines) {
+              if (!line.startsWith("{")) continue;
+              const ev = JSON.parse(line);
+              // File watchers can fire more than once for a single write
+              // (truncate+write); ignore repeats of the current generation
+              // so the strict-sequence assertions below aren't at the mercy
+              // of platform watcher coalescing.
+              if (events.length > 0 && events[events.length - 1].reload === ev.reload) continue;
+              events.push(ev);
+              port ||= ev.port;
+              advanced = true;
+            }
+            if (!advanced) continue;
+            if (events.length >= target) {
+              responses.push(await extract(port));
+              runner.kill();
+              break;
+            }
+            // Verify the new handlers are actually wired up (not just that
+            // listen() didn't throw), then trigger the next reload.
+            responses.push(await extract(port));
+            writeFileSync(entry, source(events.length + 1));
+          }
+        } catch (e) {
+          // runner.kill() from the stderr reader aborts this iterator; only
+          // swallow that — let real errors from JSON.parse / extract /
+          // writeFileSync surface directly.
+          if (!runner.killed) throw e;
+        }
+
+        runner.kill();
+        await runner.exited;
+        await stderrDone;
+
+        expect(stderr).not.toContain("EADDRINUSE");
+        expect(stderr).not.toContain("Failed to listen");
+        expect(stderr).not.toContain("Failed to start server");
+        expect(events).toEqual([
+          { listening: true, port, reload: 1 },
+          { listening: true, port, reload: 2 },
+          { listening: true, port, reload: 3 },
+        ]);
+        expect(responses).toEqual(["v1", "v2", "v3"]);
+      },
+      timeout,
+    );
+  }
+});


### PR DESCRIPTION
## What

Under `--hot`, re-evaluating the entry module re-runs `Bun.listen()` on an address that is still bound by the previous evaluation's listener, failing with `EADDRINUSE`:

```
error: Failed to listen at 127.0.0.1
 syscall: "listen",
   errno: 98,
 address: "127.0.0.1",
    port: 22345,
    code: "EADDRINUSE"
```

`Bun.serve` avoids this via the per-VM `HotMap`: each server registers under a computed key, and a subsequent `Bun.serve()` with the same address swaps handlers on the live server instead of re-binding. `Bun.listen` had no `HotMap` wiring at all.

(Two adjacent bugs this PR originally also fixed, `VirtualMachine::hot_map()` never lazy-initializing and `Bun.serve` inserting under the empty key because `config.id` was read after `NewServer::init()` took the config, have since landed on main via #31783. This PR now contains only the `Bun.listen` work plus hardening of the shared registry.)

## Fix

`Bun.listen` mirrors `Bun.serve`:

- Compute a `[tcp]-tcp:host:port` / `[tls]-...` / `[tcp]-unix:path` key from the *requested* address, look it up before binding, and on a match swap handlers/`data` in place on the existing listener (same swap as `listener.reload()`), returning the existing JS wrapper.
- Insert on first bind; remove on `stop()`/`deinit()`. Non-TLS listen fds are also registered for `--watch` cleanup, matching the HTTP server path.
- An `id?: string | null` option (matching `Bun.serve`) disambiguates multiple listeners on the same address; `id: null`/`""` opts out. User-supplied ids are namespaced with a `[listen]-` prefix so listener keys are structurally disjoint from `Bun.serve`'s. A listen and a serve can never reuse each other (different tags), so sharing a key would only leave whichever registers second untracked.
- `HotMap::insert_raw` now returns `bool` instead of panicking on a duplicate key. Its only two callers (`Bun.serve` and the new listener registration) skip registration on `false`; `Bun.serve` additionally flips `allow_hot` so its `stop()` does not evict the entry that is there. This covers the contrived `Bun.serve({id: "[listen]-..."})` overlap without a second lookup.
- The reuse path only returns the existing wrapper when its `JsRef` is strong (a registered listener holds it strong while listening); anything else closes the stale socket and rebinds rather than handing back a possibly dead weak value.
- Types for `id` added to `TCPSocketListenOptions` and a new `UnixSocketListenOptions`.

## Verification

New `describe("should reuse the listening socket on hot reload")` in `test/cli/hot/hot.test.ts` spawns `bun --hot` with a `Bun.listen`/`Bun.serve` fixture on `port: 0`, drives three reloads, and asserts the same resolved port is reported every time and a client connect succeeds after each reload. On the unfixed build each reload binds a different random port, so the port-stability assertion fails; with the fix all three generations reuse one socket.

Also checked manually under `--hot`: listen+serve sharing a colliding key in both orders (listener reused, server untracked and rebound, `server.id` intact, no panic), `id: null`/`""` opt-out, distinct-id isolation, `stop()`-then-relisten, and `unref()`-then-reload (same port reused).

Fixes #26036.

<details>
<summary>Rebase notes</summary>

Rebased onto main after roughly 1100 commits landed; squashed to one commit. Three textual conflicts, all resolved by keeping both sides:

- `Listener::listen` named-pipe path: main added `active_handles` registration next to where this PR adds `register_for_hot_reload`.
- `Listener::deinit`: main switched `this_ref` to a shared borrow; `unregister_for_hot_reload` takes `&Self` so it slots in unchanged.
- `hot.test.ts` imports: main added `isWindows`, this PR adds `tempDir`.

Main also changed `Listener::unref()` to keep `this_value` strong while the socket is still listening (it is downgraded in `do_stop`/`mark_inactive` instead). That makes the non-strong fallback in the reuse path purely defensive. Full `hot.test.ts` passes after the rebase.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 18 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/hot/hot.test.ts

<!-- robobun:evidence:end -->