### PR TITLE
perf: React SSR / Bun.serve hot-path optimizations

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1150,6 +1150,19 @@ impl JSValue {
             .get(global, property)?
             .filter(|v| !v.is_empty_or_undefined_or_null() && !(v.is_string() && !v.to_boolean())))
     }
+    /// JSValue.zig:1649 `getTruthyComptime` — `fast_get` (precached `JSC::Identifier`,
+    /// no StringImpl alloc / atom-table probe) followed by the same `truthyPropertyValue`
+    /// filter as `get_truthy`. Use this when the property name is a `BuiltinName`.
+    pub fn fast_get_truthy(
+        self,
+        global: &JSGlobalObject,
+        builtin_name: BuiltinName,
+    ) -> JsResult<Option<JSValue>> {
+        // JSValue.zig:1625 truthyPropertyValue: filters undef/null AND empty strings.
+        Ok(self
+            .fast_get(global, builtin_name)?
+            .filter(|v| !v.is_empty_or_undefined_or_null() && !(v.is_string() && !v.to_boolean())))
+    }
     /// JSValue.zig:1866 `getBooleanLoose` — missing/undefined → `None`; otherwise
     /// truthy-coerce the property value (never throws on the coercion itself).
     pub fn get_boolean_loose(

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -151,7 +151,7 @@ namespace Bun {
 
 // Use a JSString* here to avoid unnecessarily joining the rope string.
 // If we're only getting the length property, it won't join the rope string.
-std::optional<double> byteLength(JSC::JSString* str, JSC::JSGlobalObject* lexicalGlobalObject, WebCore::BufferEncodingType encoding)
+std::optional<size_t> byteLength(JSC::JSString* str, JSC::JSGlobalObject* lexicalGlobalObject, WebCore::BufferEncodingType encoding)
 {
     if (str->length() == 0)
         return 0;
@@ -197,7 +197,7 @@ std::optional<double> byteLength(JSC::JSString* str, JSC::JSGlobalObject* lexica
         }
 
         // https://github.com/nodejs/node/blob/e676942f814915b2d24fc899bb42dc71ae6c8226/lib/buffer.js#L579
-        return static_cast<double>((length * 3) >> 2);
+        return static_cast<size_t>((length * 3) >> 2);
     }
 
     case WebCore::BufferEncodingType::hex: {

--- a/src/jsc/bindings/JSBuffer.h
+++ b/src/jsc/bindings/JSBuffer.h
@@ -37,7 +37,7 @@ extern "C" bool JSBuffer__isBuffer(JSC::JSGlobalObject*, JSC::EncodedJSValue);
 
 namespace Bun {
 
-std::optional<size_t> byteLength(JSC::JSString* str, WebCore::BufferEncodingType encoding);
+std::optional<size_t> byteLength(JSC::JSString* str, JSC::JSGlobalObject* lexicalGlobalObject, WebCore::BufferEncodingType encoding);
 
 namespace Buffer {
 

--- a/src/jsc/bindings/JSBuffer.h
+++ b/src/jsc/bindings/JSBuffer.h
@@ -37,7 +37,7 @@ extern "C" bool JSBuffer__isBuffer(JSC::JSGlobalObject*, JSC::EncodedJSValue);
 
 namespace Bun {
 
-std::optional<double> byteLength(JSC::JSString* str, WebCore::BufferEncodingType encoding);
+std::optional<size_t> byteLength(JSC::JSString* str, WebCore::BufferEncodingType encoding);
 
 namespace Buffer {
 

--- a/src/jsc/bindings/webcore/FetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/FetchHeaders.cpp
@@ -43,6 +43,18 @@ static void removePrivilegedNoCORSRequestHeaders(HTTPHeaderMap& headers)
     headers.remove(HTTPHeaderName::Range);
 }
 
+// String::trim takes a function pointer and dispatches through
+// StringImpl::trimMatchedCharacters, which is an indirect call per probed
+// character. Header values are almost always already free of leading/trailing
+// HTTP whitespace, so do a cheap inline check on the first/last code unit and
+// only fall back to the real trim when something actually needs stripping.
+static inline String trimHTTPSpaceIfNeeded(const String& value)
+{
+    if (value.isEmpty() || (!isHTTPSpace(value[0]) && !isHTTPSpace(value[value.length() - 1])))
+        return value;
+    return value.trim(isHTTPSpace);
+}
+
 static ExceptionOr<bool> canWriteHeader(const HTTPHeaderName name, const String& value, const String& combinedValue, FetchHeaders::Guard guard)
 {
     ASSERT(value.isEmpty() || (!isHTTPSpace(value[0]) && !isHTTPSpace(value[value.length() - 1])));
@@ -67,7 +79,7 @@ static ExceptionOr<bool> canWriteHeader(const String& name, const String& value,
 
 static ExceptionOr<void> appendToHeaderMap(const String& name, const String& value, HTTPHeaderMap& headers, FetchHeaders::Guard guard)
 {
-    String normalizedValue = value.trim(isHTTPSpace);
+    String normalizedValue = trimHTTPSpaceIfNeeded(value);
     String combinedValue = normalizedValue;
     HTTPHeaderName headerName;
     if (findHTTPHeaderName(name, headerName)) {
@@ -121,7 +133,7 @@ static ExceptionOr<void> appendToHeaderMap(const String& name, const String& val
 
 static ExceptionOr<void> appendToHeaderMap(const HTTPHeaderMap::HTTPHeaderMapConstIterator::KeyValue& header, HTTPHeaderMap& headers, FetchHeaders::Guard guard)
 {
-    String normalizedValue = header.value.trim(isHTTPSpace);
+    String normalizedValue = trimHTTPSpaceIfNeeded(header.value);
     auto canWriteResult = canWriteHeader(header.key, normalizedValue, header.value, guard);
     if (canWriteResult.hasException())
         return canWriteResult.releaseException();
@@ -253,7 +265,7 @@ ExceptionOr<bool> FetchHeaders::has(const StringView name) const
 
 ExceptionOr<void> FetchHeaders::set(const HTTPHeaderName name, const String& value)
 {
-    String normalizedValue = value.trim(isHTTPSpace);
+    String normalizedValue = trimHTTPSpaceIfNeeded(value);
     auto canWriteResult = canWriteHeader(name, normalizedValue, normalizedValue, m_guard);
     if (canWriteResult.hasException())
         return canWriteResult.releaseException();
@@ -271,7 +283,7 @@ ExceptionOr<void> FetchHeaders::set(const HTTPHeaderName name, const String& val
 
 ExceptionOr<void> FetchHeaders::set(const String& name, const String& value)
 {
-    String normalizedValue = value.trim(isHTTPSpace);
+    String normalizedValue = trimHTTPSpaceIfNeeded(value);
     auto canWriteResult = canWriteHeader(name, normalizedValue, normalizedValue, m_guard);
     if (canWriteResult.hasException())
         return canWriteResult.releaseException();
@@ -290,7 +302,7 @@ ExceptionOr<void> FetchHeaders::set(const String& name, const String& value)
 void FetchHeaders::filterAndFill(const HTTPHeaderMap& headers, Guard guard)
 {
     for (auto& header : headers) {
-        String normalizedValue = header.value.trim(isHTTPSpace);
+        String normalizedValue = trimHTTPSpaceIfNeeded(header.value);
         auto canWriteResult = canWriteHeader(header.key, normalizedValue, header.value, guard);
         if (canWriteResult.hasException())
             continue;

--- a/src/jsc/bindings/webcore/FetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/FetchHeaders.cpp
@@ -55,6 +55,18 @@ static inline String trimHTTPSpaceIfNeeded(const String& value)
     return value.trim(isHTTPSpace);
 }
 
+// Like trimHTTPSpaceIfNeeded, but avoids the ref-count round-trip on the
+// returned String in the common no-trim case by aliasing the input. When a trim
+// is actually needed, the trimmed result is parked in `storage` (which must
+// outlive the returned reference) and a reference to it is returned.
+static inline const String& trimHTTPSpaceIfNeeded(const String& value, String& storage)
+{
+    if (value.isEmpty() || (!isHTTPSpace(value[0]) && !isHTTPSpace(value[value.length() - 1])))
+        return value;
+    storage = value.trim(isHTTPSpace);
+    return storage;
+}
+
 static ExceptionOr<bool> canWriteHeader(const HTTPHeaderName name, const String& value, const String& combinedValue, FetchHeaders::Guard guard)
 {
     ASSERT(value.isEmpty() || (!isHTTPSpace(value[0]) && !isHTTPSpace(value[value.length() - 1])));
@@ -79,8 +91,14 @@ static ExceptionOr<bool> canWriteHeader(const String& name, const String& value,
 
 static ExceptionOr<void> appendToHeaderMap(const String& name, const String& value, HTTPHeaderMap& headers, FetchHeaders::Guard guard)
 {
-    String normalizedValue = trimHTTPSpaceIfNeeded(value);
-    String combinedValue = normalizedValue;
+    // The common path here is a brand-new header with no leading/trailing HTTP
+    // whitespace. Avoid taking ownership (and the atomic ref-count round-trip
+    // that comes with it) of the value String unless we actually have to trim
+    // or merge with an existing header.
+    String trimStorage;
+    const String& normalizedValue = trimHTTPSpaceIfNeeded(value, trimStorage);
+    String combinedTemp;
+    const String* valueToSet = &normalizedValue;
     HTTPHeaderName headerName;
     if (findHTTPHeaderName(name, headerName)) {
         auto index = headers.indexOf(headerName);
@@ -89,14 +107,15 @@ static ExceptionOr<void> appendToHeaderMap(const String& name, const String& val
             if (index.isValid()) {
                 auto existing = headers.getIndex(index);
                 if (headerName == HTTPHeaderName::Cookie) {
-                    combinedValue = makeString(existing, "; "_s, normalizedValue);
+                    combinedTemp = makeString(existing, "; "_s, normalizedValue);
                 } else {
-                    combinedValue = makeString(existing, ", "_s, normalizedValue);
+                    combinedTemp = makeString(existing, ", "_s, normalizedValue);
                 }
+                valueToSet = &combinedTemp;
             }
         }
 
-        auto canWriteResult = canWriteHeader(headerName, normalizedValue, combinedValue, guard);
+        auto canWriteResult = canWriteHeader(headerName, normalizedValue, *valueToSet, guard);
 
         if (canWriteResult.hasException())
             return canWriteResult.releaseException();
@@ -104,8 +123,8 @@ static ExceptionOr<void> appendToHeaderMap(const String& name, const String& val
             return {};
 
         if (headerName != HTTPHeaderName::SetCookie) {
-            if (!headers.setIndex(index, combinedValue))
-                headers.set(headerName, combinedValue);
+            if (!headers.setIndex(index, *valueToSet))
+                headers.set(headerName, *valueToSet);
         } else {
             headers.add(headerName, normalizedValue);
         }
@@ -114,16 +133,17 @@ static ExceptionOr<void> appendToHeaderMap(const String& name, const String& val
     }
     auto index = headers.indexOf(name);
     if (index.isValid()) {
-        combinedValue = makeString(headers.getIndex(index), ", "_s, normalizedValue);
+        combinedTemp = makeString(headers.getIndex(index), ", "_s, normalizedValue);
+        valueToSet = &combinedTemp;
     }
-    auto canWriteResult = canWriteHeader(name, normalizedValue, combinedValue, guard);
+    auto canWriteResult = canWriteHeader(name, normalizedValue, *valueToSet, guard);
     if (canWriteResult.hasException())
         return canWriteResult.releaseException();
     if (!canWriteResult.releaseReturnValue())
         return {};
 
-    if (!headers.setIndex(index, combinedValue))
-        headers.set(name, combinedValue);
+    if (!headers.setIndex(index, *valueToSet))
+        headers.set(name, *valueToSet);
 
     // if (guard == FetchHeaders::Guard::RequestNoCors)
     //     removePrivilegedNoCORSRequestHeaders(headers);
@@ -133,7 +153,8 @@ static ExceptionOr<void> appendToHeaderMap(const String& name, const String& val
 
 static ExceptionOr<void> appendToHeaderMap(const HTTPHeaderMap::HTTPHeaderMapConstIterator::KeyValue& header, HTTPHeaderMap& headers, FetchHeaders::Guard guard)
 {
-    String normalizedValue = trimHTTPSpaceIfNeeded(header.value);
+    String trimStorage;
+    const String& normalizedValue = trimHTTPSpaceIfNeeded(header.value, trimStorage);
     auto canWriteResult = canWriteHeader(header.key, normalizedValue, header.value, guard);
     if (canWriteResult.hasException())
         return canWriteResult.releaseException();

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.h
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.h
@@ -67,7 +67,7 @@ public:
         bool operator==(const UncommonHeader &other) const { return key == other.key && value == other.value; }
     };
 
-    typedef Vector<CommonHeader, 0, CrashOnOverflow, 6> CommonHeadersVector;
+    typedef Vector<CommonHeader, 2, CrashOnOverflow, 6> CommonHeadersVector;
     typedef Vector<UncommonHeader, 0, CrashOnOverflow, 0> UncommonHeadersVector;
 
     class HTTPHeaderMapConstIterator {

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -720,12 +720,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         let ctx: *mut ServerRequestContext<SSL, DEBUG> = ctx_slot;
         let ctx_mut = unsafe { &mut *ctx };
 
-        // Note: the context lives in a pre-allocated `HiveArray::Fallback`
-        // slot that is recycled per request, not freshly heap-allocated, so
-        // we deliberately do NOT report it as extra GC memory here. Doing so
-        // per request hits `Heap::deprecatedReportExtraMemorySlowCase` (and
-        // `collectIfNecessaryOrDefer`) on every request and inflates the
-        // GC heuristic for memory that isn't actually growing.
+        // Don't report extra GC memory here: ctx lives in a recycled pool
+        // slot, not a fresh heap allocation, and reporting it per request
+        // hits the slow GC heuristic path on every request.
 
         // Allocate the pooled body slot. `hive_alloc` is the typed front-end
         // for the type-erased `init_request_body_value` hook (the hook lives

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -720,14 +720,12 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         let ctx: *mut ServerRequestContext<SSL, DEBUG> = ctx_slot;
         let ctx_mut = unsafe { &mut *ctx };
 
-        // `VirtualMachine::jsc_vm()` is the safe accessor for the JSC VM
-        // (set in VM init; valid for the JS thread's lifetime).
-        server
-            .vm()
-            .jsc_vm()
-            .deprecated_report_extra_memory(
-                core::mem::size_of::<ServerRequestContext<SSL, DEBUG>>(),
-            );
+        // Note: the context lives in a pre-allocated `HiveArray::Fallback`
+        // slot that is recycled per request, not freshly heap-allocated, so
+        // we deliberately do NOT report it as extra GC memory here. Doing so
+        // per request hits `Heap::deprecatedReportExtraMemorySlowCase` (and
+        // `collectIfNecessaryOrDefer`) on every request and inflates the
+        // GC heuristic for memory that isn't actually growing.
 
         // Allocate the pooled body slot. `hive_alloc` is the typed front-end
         // for the type-erased `init_request_body_value` hook (the hook lives

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3170,11 +3170,13 @@ where
         };
         // SAFETY: ctx_slot was just initialized by create_in.
         let ctx = unsafe { &mut *ctx_slot };
-        // `VirtualMachine::jsc_vm()` is the safe accessor for the JSC VM
-        // owned by the per-thread VirtualMachine.
-        self.vm_ref()
-            .jsc_vm()
-            .deprecated_report_extra_memory(mem::size_of::<Ctx>());
+
+        // Note: the context lives in a pre-allocated `HiveArray::Fallback`
+        // slot that is recycled per request, not freshly heap-allocated, so
+        // we deliberately do NOT report it as extra GC memory here. Doing so
+        // per request hits `Heap::deprecatedReportExtraMemorySlowCase` (and
+        // `collectIfNecessaryOrDefer`) on every request and inflates the
+        // GC heuristic for memory that isn't actually growing.
 
         // `vm.initRequestBodyValue(.{ .Null = {} })` — typed wrapper over the
         // type-erased RuntimeHooks vtable. Returns `NonNull<HiveRef>` with

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3171,12 +3171,8 @@ where
         // SAFETY: ctx_slot was just initialized by create_in.
         let ctx = unsafe { &mut *ctx_slot };
 
-        // Note: the context lives in a pre-allocated `HiveArray::Fallback`
-        // slot that is recycled per request, not freshly heap-allocated, so
-        // we deliberately do NOT report it as extra GC memory here. Doing so
-        // per request hits `Heap::deprecatedReportExtraMemorySlowCase` (and
-        // `collectIfNecessaryOrDefer`) on every request and inflates the
-        // GC heuristic for memory that isn't actually growing.
+        // Don't report extra GC memory here: ctx is a recycled pool slot,
+        // not a fresh heap allocation (see NewServer::on_request).
 
         // `vm.initRequestBodyValue(.{ .Null = {} })` — typed wrapper over the
         // type-erased RuntimeHooks vtable. Returns `NonNull<HiveRef>` with

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1335,7 +1335,7 @@ impl Request {
             }
 
             if !fields.contains(Fields::Signal) {
-                match value.get_truthy(global_this, b"signal") {
+                match value.fast_get_truthy(global_this, bun_jsc::BuiltinName::signal) {
                     Ok(Some(signal_)) => {
                         fields.insert(Fields::Signal);
                         if let Some(signal) = AbortSignal::ref_from_js(signal_) {

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -1460,11 +1460,15 @@ impl Init {
             return Err(JsError::Thrown);
         }
 
-        if let Some(status_text) = response_init.fast_get_truthy(global_this, BuiltinName::statusText)? {
+        if let Some(status_text) =
+            response_init.fast_get_truthy(global_this, BuiltinName::statusText)?
+        {
             result.status_text = OwnedString::new(status_text.to_bun_string(global_this)?);
         }
 
-        if let Some(method_value) = response_init.fast_get_truthy(global_this, BuiltinName::method)? {
+        if let Some(method_value) =
+            response_init.fast_get_truthy(global_this, BuiltinName::method)?
+        {
             if let Some(method) = bun_http_jsc::method_jsc::from_js(global_this, method_value)? {
                 result.method = method;
             }

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -1460,11 +1460,11 @@ impl Init {
             return Err(JsError::Thrown);
         }
 
-        if let Some(status_text) = response_init.get_truthy(global_this, b"statusText")? {
+        if let Some(status_text) = response_init.fast_get_truthy(global_this, BuiltinName::statusText)? {
             result.status_text = OwnedString::new(status_text.to_bun_string(global_this)?);
         }
 
-        if let Some(method_value) = response_init.get_truthy(global_this, b"method")? {
+        if let Some(method_value) = response_init.fast_get_truthy(global_this, BuiltinName::method)? {
             if let Some(method) = bun_http_jsc::method_jsc::from_js(global_this, method_value)? {
                 result.method = method;
             }

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -879,17 +879,14 @@ impl<T: JsSinkType + JsSinkAbi> JSSink<T> {
             return Err(global.throw_value(err));
         }
 
-        let args_list = frame.arguments_old::<4>();
-        let args = args_list.slice();
-
-        if args.is_empty() {
+        if frame.arguments_count() == 0 {
             return Err(global.throw_value(global.to_type_error(
                 bun_jsc::ErrorCode::MISSING_ARGS,
                 format_args!("write() expects a string, ArrayBufferView, or ArrayBuffer"),
             )));
         }
 
-        let arg = args[0];
+        let arg = frame.argument(0);
         arg.ensure_still_alive();
         let _keep = bun_jsc::EnsureStillAlive(arg);
 

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1882,10 +1882,11 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
 
     fn register_auto_flusher(&mut self) {
         let Some(res) = self.any_res() else { return };
+        // Match streams.zig:1231 — reset per-enqueue so a long stream of
+        // sub-highWaterMark writes between auto-flushes still bumps the idle
+        // timeout.
+        res.reset_timeout();
         if !self.auto_flusher.registered.get() {
-            // Reset the idle timeout once on registration; the pending flush
-            // resets it again so per-chunk resets are redundant FFI hops.
-            res.reset_timeout();
             let vm = self.global_this().bun_vm();
             AutoFlusher::register_deferred_microtask_with_type_unchecked::<Self>(self, vm);
         }

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -903,9 +903,7 @@ impl StreamResult {
                 ArrayBuffer::create::<{ JSType::Uint8Array }>(global_this, temp.slice())
             }
             StreamResult::IntoArray(array) => Ok(JSValue::from(array.len)),
-            StreamResult::IntoArrayAndDone(array) => {
-                Ok(JSValue::from(array.len))
-            }
+            StreamResult::IntoArrayAndDone(array) => Ok(JSValue::from(array.len)),
             StreamResult::Pending(pending) => {
                 // SAFETY: pending is a valid borrowed pointer per BORROW_PARAM classification
                 let promise = unsafe { &mut **pending }.promise(global_this);

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -106,7 +106,7 @@ impl Start {
     pub fn to_js(self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
         match self {
             Start::Empty | Start::Ready => Ok(JSValue::UNDEFINED),
-            Start::ChunkSize(chunk) => Ok(JSValue::js_number(chunk as f64)),
+            Start::ChunkSize(chunk) => Ok(JSValue::js_number_from_uint64(chunk)),
             Start::Err(err) => Err(err.throw(global_this)),
             Start::OwnedAndDone(mut list) => {
                 // PORT NOTE: Zig captures `|list|` by bitwise copy with no destructor and
@@ -594,12 +594,12 @@ impl Writable {
             Writable::Err(err) => {
                 JSPromise::rejected_promise(global_this, err.to_js(global_this)).to_js()
             }
-            Writable::Owned(len) => JSValue::js_number(len as f64),
-            Writable::OwnedAndDone(len) => JSValue::js_number(len as f64),
-            Writable::TemporaryAndDone(len) => JSValue::js_number(len as f64),
-            Writable::Temporary(len) => JSValue::js_number(len as f64),
-            Writable::IntoArray(len) => JSValue::js_number(len as f64),
-            Writable::IntoArrayAndDone(len) => JSValue::js_number(len as f64),
+            Writable::Owned(len) => JSValue::js_number_from_uint64(len),
+            Writable::OwnedAndDone(len) => JSValue::js_number_from_uint64(len),
+            Writable::TemporaryAndDone(len) => JSValue::js_number_from_uint64(len),
+            Writable::Temporary(len) => JSValue::js_number_from_uint64(len),
+            Writable::IntoArray(len) => JSValue::js_number_from_uint64(len),
+            Writable::IntoArrayAndDone(len) => JSValue::js_number_from_uint64(len),
             // false == controller.close()
             // undefined == noop, but we probably won't send it
             Writable::Done => JSValue::TRUE,
@@ -1563,7 +1563,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
 
     fn flush_from_js_no_wait(&mut self) -> bun_sys::Result<JSValue> {
         bun_core::scoped_log!(HTTPServerWritableLog, "flushFromJSNoWait");
-        bun_sys::Result::Ok(JSValue::js_number(self.flush_no_wait() as f64))
+        bun_sys::Result::Ok(JSValue::js_number_from_uint64(self.flush_no_wait() as u64))
     }
 
     pub fn flush_no_wait(&mut self) -> usize {
@@ -1613,7 +1613,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             if self.send_readable(0) {
                 return bun_sys::Result::Ok(JSPromise::resolved_promise_value(
                     global_this,
-                    JSValue::js_number(slice_len as f64),
+                    JSValue::js_number_from_uint64(slice_len as u64),
                 ));
             }
         }
@@ -1819,7 +1819,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         bun_core::scoped_log!(HTTPServerWritableLog, "endFromJS()");
 
         if self.requested_end {
-            return bun_sys::Result::Ok(JSValue::js_number(0.0));
+            return bun_sys::Result::Ok(JSValue::js_number_from_int32(0));
         }
 
         if self.done || self.res.is_none() || self.any_res().unwrap().has_responded() {
@@ -1827,7 +1827,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             self.signal.close(None);
             self.mark_done();
             self.finalize();
-            return bun_sys::Result::Ok(JSValue::js_number(0.0));
+            return bun_sys::Result::Ok(JSValue::js_number_from_int32(0));
         }
 
         self.requested_end = true;
@@ -1854,7 +1854,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         self.signal.close(None);
         self.finalize();
 
-        bun_sys::Result::Ok(JSValue::js_number(self.wrote as f64))
+        bun_sys::Result::Ok(JSValue::js_number_from_uint64(self.wrote))
     }
 
     pub fn sink(&mut self) -> Sink<'_> {

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1884,9 +1884,12 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
 
     fn register_auto_flusher(&mut self) {
         let Some(res) = self.any_res() else { return };
-        // if we enqueue data we should reset the timeout
-        res.reset_timeout();
         if !self.auto_flusher.registered.get() {
+            // if we enqueue data we should reset the timeout. Once the
+            // auto-flusher is registered, the pending flush (or the eventual
+            // res.write()/res.end()) resets it again, so there's no need to
+            // pay the FFI hop on every buffered chunk in the same drain.
+            res.reset_timeout();
             let vm = self.global_this().bun_vm();
             AutoFlusher::register_deferred_microtask_with_type_unchecked::<Self>(self, vm);
         }

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -106,7 +106,7 @@ impl Start {
     pub fn to_js(self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
         match self {
             Start::Empty | Start::Ready => Ok(JSValue::UNDEFINED),
-            Start::ChunkSize(chunk) => Ok(JSValue::js_number_from_uint64(chunk)),
+            Start::ChunkSize(chunk) => Ok(JSValue::from(chunk)),
             Start::Err(err) => Err(err.throw(global_this)),
             Start::OwnedAndDone(mut list) => {
                 // PORT NOTE: Zig captures `|list|` by bitwise copy with no destructor and
@@ -594,12 +594,12 @@ impl Writable {
             Writable::Err(err) => {
                 JSPromise::rejected_promise(global_this, err.to_js(global_this)).to_js()
             }
-            Writable::Owned(len) => JSValue::js_number_from_uint64(len),
-            Writable::OwnedAndDone(len) => JSValue::js_number_from_uint64(len),
-            Writable::TemporaryAndDone(len) => JSValue::js_number_from_uint64(len),
-            Writable::Temporary(len) => JSValue::js_number_from_uint64(len),
-            Writable::IntoArray(len) => JSValue::js_number_from_uint64(len),
-            Writable::IntoArrayAndDone(len) => JSValue::js_number_from_uint64(len),
+            Writable::Owned(len) => JSValue::from(len),
+            Writable::OwnedAndDone(len) => JSValue::from(len),
+            Writable::TemporaryAndDone(len) => JSValue::from(len),
+            Writable::Temporary(len) => JSValue::from(len),
+            Writable::IntoArray(len) => JSValue::from(len),
+            Writable::IntoArrayAndDone(len) => JSValue::from(len),
             // false == controller.close()
             // undefined == noop, but we probably won't send it
             Writable::Done => JSValue::TRUE,
@@ -902,9 +902,9 @@ impl StreamResult {
                 // back to ArrayBuffer::create (copies) until the no-init path lands.
                 ArrayBuffer::create::<{ JSType::Uint8Array }>(global_this, temp.slice())
             }
-            StreamResult::IntoArray(array) => Ok(JSValue::js_number_from_uint64(array.len as u64)),
+            StreamResult::IntoArray(array) => Ok(JSValue::from(array.len)),
             StreamResult::IntoArrayAndDone(array) => {
-                Ok(JSValue::js_number_from_uint64(array.len as u64))
+                Ok(JSValue::from(array.len))
             }
             StreamResult::Pending(pending) => {
                 // SAFETY: pending is a valid borrowed pointer per BORROW_PARAM classification
@@ -1563,7 +1563,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
 
     fn flush_from_js_no_wait(&mut self) -> bun_sys::Result<JSValue> {
         bun_core::scoped_log!(HTTPServerWritableLog, "flushFromJSNoWait");
-        bun_sys::Result::Ok(JSValue::js_number_from_uint64(self.flush_no_wait() as u64))
+        bun_sys::Result::Ok(JSValue::from(self.flush_no_wait()))
     }
 
     pub fn flush_no_wait(&mut self) -> usize {
@@ -1603,7 +1603,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         if self.buffer.len() == 0 || self.done {
             return bun_sys::Result::Ok(JSPromise::resolved_promise_value(
                 global_this,
-                JSValue::js_number_from_int32(0),
+                JSValue::from(0i32),
             ));
         }
 
@@ -1613,7 +1613,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             if self.send_readable(0) {
                 return bun_sys::Result::Ok(JSPromise::resolved_promise_value(
                     global_this,
-                    JSValue::js_number_from_uint64(slice_len as u64),
+                    JSValue::from(slice_len),
                 ));
             }
         }
@@ -1819,7 +1819,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         bun_core::scoped_log!(HTTPServerWritableLog, "endFromJS()");
 
         if self.requested_end {
-            return bun_sys::Result::Ok(JSValue::js_number_from_int32(0));
+            return bun_sys::Result::Ok(JSValue::from(0i32));
         }
 
         if self.done || self.res.is_none() || self.any_res().unwrap().has_responded() {
@@ -1827,7 +1827,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             self.signal.close(None);
             self.mark_done();
             self.finalize();
-            return bun_sys::Result::Ok(JSValue::js_number_from_int32(0));
+            return bun_sys::Result::Ok(JSValue::from(0i32));
         }
 
         self.requested_end = true;
@@ -1854,7 +1854,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         self.signal.close(None);
         self.finalize();
 
-        bun_sys::Result::Ok(JSValue::js_number_from_uint64(self.wrote))
+        bun_sys::Result::Ok(JSValue::from(self.wrote))
     }
 
     pub fn sink(&mut self) -> Sink<'_> {
@@ -1885,10 +1885,8 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
     fn register_auto_flusher(&mut self) {
         let Some(res) = self.any_res() else { return };
         if !self.auto_flusher.registered.get() {
-            // if we enqueue data we should reset the timeout. Once the
-            // auto-flusher is registered, the pending flush (or the eventual
-            // res.write()/res.end()) resets it again, so there's no need to
-            // pay the FFI hop on every buffered chunk in the same drain.
+            // Reset the idle timeout once on registration; the pending flush
+            // resets it again so per-chunk resets are redundant FFI hops.
             res.reset_timeout();
             let vm = self.global_this().bun_vm();
             AutoFlusher::register_deferred_microtask_with_type_unchecked::<Self>(self, vm);


### PR DESCRIPTION
Iterative perf work targeting `Bun.serve()` request handling, response body streaming, and `Response` construction, profiled on `react-dom/server.bun`'s `renderToReadableStream` benchmark with `NODE_ENV=production`.

Each change was profiled with `perf` + LLVM symbolication under `oha` load, adversarially reviewed, then verified with `cargo check` and a quick subset of `serve`/`streams`/`response`/`escapeHTML` tests.

This is a rolling branch — more commits will be pushed as additional optimizations are validated. Marking as draft until benchmarks settle.

No `unsafe` is added.