### PR TITLE
process: implement process.initgroups

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3143,25 +3143,39 @@ JSC_DEFINE_HOST_FUNCTION(Process_functioninitgroups, (JSGlobalObject * globalObj
         auto str = userValue.getString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
         auto utf8 = str.utf8();
-        auto len = utf8.length();
-        if (len >= sizeof(usernameBuf)) {
+        struct passwd pwd;
+        struct passwd* pp = nullptr;
+        char buf[8192];
+        if (getpwnam_r(utf8.data(), &pwd, buf, sizeof(buf), &pp) == 0 && pp != nullptr) {
+            size_t len = strlen(pp->pw_name);
+            if (len >= sizeof(usernameBuf)) {
+                auto message = makeString("User identifier does not exist: "_s, str);
+                scope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_UNKNOWN_CREDENTIAL, message));
+                return {};
+            }
+            memcpy(usernameBuf, pp->pw_name, len + 1);
+            username = usernameBuf;
+        } else {
             auto message = makeString("User identifier does not exist: "_s, str);
             scope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_UNKNOWN_CREDENTIAL, message));
             return {};
         }
-        memcpy(usernameBuf, utf8.data(), len + 1);
-        username = usernameBuf;
     } else if (userValue.isNumber()) {
         uint32_t uid = 0;
         Bun::V::validateInteger(scope, globalObject, userValue, "user"_s, jsNumber(0), jsNumber(std::pow(2, 31) - 1), &uid);
         RETURN_IF_EXCEPTION(scope, {});
 
-        struct passwd pwd;
-        struct passwd* pp = nullptr;
-        char buf[8192];
-        if (getpwuid_r(static_cast<uid_t>(uid), &pwd, buf, sizeof(buf), &pp) == 0 && pp != nullptr) {
-            auto len = strlen(pp->pw_name);
-            memcpy(usernameBuf, pp->pw_name, len + 1);
+        struct passwd pwd2;
+        struct passwd* pp2 = nullptr;
+        char buf2[8192];
+        if (getpwuid_r(static_cast<uid_t>(uid), &pwd2, buf2, sizeof(buf2), &pp2) == 0 && pp2 != nullptr) {
+            size_t len = strlen(pp2->pw_name);
+            if (len >= sizeof(usernameBuf)) {
+                auto message = makeString("User identifier does not exist: "_s, String::number(uid));
+                scope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_UNKNOWN_CREDENTIAL, message));
+                return {};
+            }
+            memcpy(usernameBuf, pp2->pw_name, len + 1);
             username = usernameBuf;
         } else {
             auto message = makeString("User identifier does not exist: "_s, String::number(uid));

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3127,6 +3127,73 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionsetgroups, (JSGlobalObject * globalObje
     return JSValue::encode(jsNumber(result));
 }
 
+JSC_DEFINE_HOST_FUNCTION(Process_functioninitgroups, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto userValue = callFrame->argument(0);
+    auto extraGroupValue = callFrame->argument(1);
+
+    // Resolve user argument to a username string (initgroups() requires const char*)
+    char usernameBuf[8192];
+    const char* username = nullptr;
+
+    if (userValue.isString()) {
+        auto str = userValue.getString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        auto utf8 = str.utf8();
+        auto len = utf8.length();
+        if (len >= sizeof(usernameBuf)) {
+            auto message = makeString("User identifier does not exist: "_s, str);
+            scope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_UNKNOWN_CREDENTIAL, message));
+            return {};
+        }
+        memcpy(usernameBuf, utf8.data(), len + 1);
+        username = usernameBuf;
+    } else if (userValue.isNumber()) {
+        uint32_t uid = 0;
+        Bun::V::validateInteger(scope, globalObject, userValue, "user"_s, jsNumber(0), jsNumber(std::pow(2, 31) - 1), &uid);
+        RETURN_IF_EXCEPTION(scope, {});
+
+        struct passwd pwd;
+        struct passwd* pp = nullptr;
+        char buf[8192];
+        if (getpwuid_r(static_cast<uid_t>(uid), &pwd, buf, sizeof(buf), &pp) == 0 && pp != nullptr) {
+            auto len = strlen(pp->pw_name);
+            memcpy(usernameBuf, pp->pw_name, len + 1);
+            username = usernameBuf;
+        } else {
+            auto message = makeString("User identifier does not exist: "_s, String::number(uid));
+            scope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_UNKNOWN_CREDENTIAL, message));
+            return {};
+        }
+    } else {
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "user"_s, "string or number"_s, userValue);
+    }
+
+    // Resolve extraGroup to a gid_t using the existing maybe_gid_by_name helper
+    if (!extraGroupValue.isNumber() && !extraGroupValue.isString()) {
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "extraGroup"_s, "string or number"_s, extraGroupValue);
+    }
+    uint32_t gid = 0;
+    auto is_number = extraGroupValue.isNumber();
+    extraGroupValue = maybe_gid_by_name(scope, globalObject, extraGroupValue);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (is_number) Bun::V::validateInteger(scope, globalObject, extraGroupValue, "extraGroup"_s, jsNumber(0), jsNumber(std::pow(2, 31) - 1), &gid);
+    if (!is_number) gid = extraGroupValue.toUInt32(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    // Call POSIX initgroups(username, gid) -- exactly 2 arguments per POSIX spec
+    errno = 0;
+    if (initgroups(username, static_cast<gid_t>(gid)) != 0) {
+        throwSystemError(scope, globalObject, "initgroups"_s, errno);
+        return {};
+    }
+
+    return JSValue::encode(jsUndefined());
+}
+
 #endif
 
 JSC_DEFINE_HOST_FUNCTION(Process_functionAssert, (JSGlobalObject * globalObject, CallFrame* callFrame))
@@ -4343,6 +4410,7 @@ extern "C" void Process__emitErrorEvent(Zig::GlobalObject* global, EncodedJSValu
   getgid                           Process_functiongetgid                              Function 0
   getgroups                        Process_functiongetgroups                           Function 0
   getuid                           Process_functiongetuid                              Function 0
+  initgroups                       Process_functioninitgroups                          Function 2
 
   setegid                          Process_functionsetegid                             Function 1
   seteuid                          Process_functionseteuid                             Function 1

--- a/test/js/node/process/process-initgroups.test.js
+++ b/test/js/node/process/process-initgroups.test.js
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+
+// process.initgroups is only available on non-Windows POSIX systems
+const isWindows = process.platform === "win32";
+
+describe("process.initgroups", () => {
+  it("is undefined on Windows, a function on POSIX", () => {
+    if (isWindows) {
+      expect(process.initgroups).toBeUndefined();
+    } else {
+      expect(typeof process.initgroups).toBe("function");
+    }
+  });
+
+  if (!isWindows) {
+    it("has length 2", () => {
+      expect(process.initgroups.length).toBe(2);
+    });
+
+    it("throws ERR_INVALID_ARG_TYPE when user argument is missing", () => {
+      expect(() => process.initgroups()).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" })
+      );
+    });
+
+    it("throws ERR_INVALID_ARG_TYPE when user is null", () => {
+      expect(() => process.initgroups(null, 0)).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" })
+      );
+    });
+
+    it("throws ERR_INVALID_ARG_TYPE when user is a boolean", () => {
+      expect(() => process.initgroups(true, 0)).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" })
+      );
+    });
+
+    it("throws ERR_INVALID_ARG_TYPE when extraGroup argument is missing", () => {
+      expect(() => process.initgroups("root")).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" })
+      );
+    });
+
+    it("throws ERR_INVALID_ARG_TYPE when extraGroup is null", () => {
+      expect(() => process.initgroups("root", null)).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" })
+      );
+    });
+
+    it("throws ERR_UNKNOWN_CREDENTIAL for a non-existent string username", () => {
+      expect(() => process.initgroups("__bun_nonexistent_user_12345__", 0)).toThrow(
+        expect.objectContaining({ code: "ERR_UNKNOWN_CREDENTIAL" })
+      );
+    });
+
+    it("throws ERR_UNKNOWN_CREDENTIAL for a non-existent numeric UID", () => {
+      // UID 2147483647 is extremely unlikely to exist
+      expect(() => process.initgroups(2147483647, 0)).toThrow(
+        expect.objectContaining({ code: "ERR_UNKNOWN_CREDENTIAL" })
+      );
+    });
+
+    it("succeeds or throws EPERM when called with current user (requires root to fully succeed)", () => {
+      try {
+        const uid = process.getuid();
+        const gid = process.getgid();
+        process.initgroups(uid, gid);
+        // If we reach here, it succeeded (we are root or have capability)
+      } catch (err) {
+        // EPERM is expected when not running as root
+        if (err.code !== "EPERM") {
+          throw err;
+        }
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Implements `process.initgroups(user, extraGroup)` to close #23891.

`process.initgroups` was undefined in Bun while Node.js exposes it as a standard POSIX API for setting the supplementary group access list of the process.

## Implementation

- Added `Process_functioninitgroups` in `src/jsc/bindings/BunProcess.cpp`, guarded by the existing non-Windows `#if !OS(WINDOWS)` block (consistent with `getgroups`/`setgroups`).
- The `user` argument accepts either a **string** (username) or a **number** (UID). When a UID is given, it is resolved to a username via `getpwuid_r()` (required by POSIX `initgroups()`).
- The `extraGroup` argument accepts either a **string** (group name resolved via `maybe_gid_by_name()`) or a **number** (GID).
- Numeric arguments are validated with `validateInteger()` for consistent error behaviour.
- All exception paths use `RETURN_IF_EXCEPTION` after every potentially-throwing call.
- Returns `undefined` on success, throws a system error (`EPERM`, `ERR_UNKNOWN_CREDENTIAL`, etc.) on failure.
- Added a test file at `test/js/node/process/process-initgroups.test.js`.

## Testing

```bash
bun test test/js/node/process/process-initgroups.test.js
```

> Tests that verify argument validation run without root. The integration test that actually calls `initgroups()` catches `EPERM` when not root.

## Notes

- This is a POSIX-only API. `process.initgroups` is not exposed on Windows, consistent with Node.js behaviour.
- Multiple previous PRs (#25312, #26578, #27902, #29362) attempted this fix but have not been merged. This implementation addresses the issues raised in code reviews of those PRs (correct 2-arg POSIX call, proper exception propagation, integer validation).

---

> This fix was contributed with AI assistance by SwarmFix (sulphur-swarm).

Closes #23891