### PR TITLE
docs(watch-mode): point to built-in HMR instead of Vite

### DIFF
--- a/docs/runtime/watch-mode.mdx
+++ b/docs/runtime/watch-mode.mdx
@@ -91,8 +91,9 @@ Use `bun --hot` to enable hot reloading when executing code with Bun. Unlike `--
 <Note>
   Bun's `--hot` is not the same as hot reloading in the browser. Many frameworks provide a "hot reloading" experience,
   where you can edit & save your frontend code (say, a React component) and see the changes reflected in the browser
-  without refreshing the page. Bun's `--hot` is the server-side equivalent of this experience. To get hot reloading in
-  the browser, use a framework like [Vite](https://vite.dev).
+  without refreshing the page. Bun's `--hot` is the server-side equivalent of this experience. For browser HMR, use
+  Bun's full-stack development server, which supports Hot Module Replacement out of the box. See [Hot
+  reloading](/bundler/hot-reloading).
 </Note>
 
 ```bash terminal icon="terminal"
@@ -146,7 +147,7 @@ Bun.serve({
 ```
 
 <Note>
-Support for Vite's `import.meta.hot` is planned, to enable better lifecycle management for hot reloading and to align with the ecosystem.
+For client-side hot reloading with `import.meta.hot` (modeled after Vite's HMR API), use Bun's full-stack development server. See [Hot reloading](/bundler/hot-reloading).
 
 </Note>
 


### PR DESCRIPTION
Fixes #30911.

## Problem

`docs/runtime/watch-mode.mdx` has two notes that predate Bun's full-stack dev server and contradict `docs/bundler/hot-reloading.mdx`:

1. **Line 92** (under `--hot` mode) tells readers "To get hot reloading in the browser, use a framework like [Vite](https://vite.dev)."
2. **Line 146** promises `import.meta.hot` "in a future version of Bun".

Both are stale. Browser HMR and the full `import.meta.hot` API (`accept`, `data`, `dispose`, `prune`, `on`/`off`) already ship — see `docs/bundler/hot-reloading.mdx` and the `development.hmr` option on `Bun.serve`.

## Fix

- Replace the "use Vite" sentence with a pointer to [/bundler/hot-reloading](https://bun.com/docs/bundler/hot-reloading) explaining that Bun's full-stack dev server supports HMR out of the box.
- Rewrite the "future version" note into a cross-link to the same page, since `import.meta.hot` already exists.

Docs-only, no code or test changes.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->