### PR TITLE
fix(resolver): add PermissionDenied/EPERM/EACCES to directory read error handling

### DIFF
--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -2128,7 +2128,7 @@ impl RealFS {
             // always `Some` here.
             let entries = entries.expect("caller holds entries_mutex when ENABLE_ENTRY_CACHE");
             let mut get_or_put_result = entries.get_or_put(dir)?;
-            if err == bun_core::err!("ENOENT") || err == bun_core::err!("FileNotFound") {
+            if err == bun_core::err!("ENOENT") || err == bun_core::err!("FileNotFound") || err == bun_core::err!("PermissionDenied") || err == bun_core::err!("AccessDenied") || err == bun_core::err!("EPERM") || err == bun_core::err!("EACCES") {
                 entries.mark_not_found(get_or_put_result);
                 return Ok(TEMP_ENTRIES_OPTION.with_borrow_mut(|slot| {
                     slot.write(EntriesOption::Err(dir_entry::Err {

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1127,7 +1127,7 @@ pub mod fs {
         ) -> core::result::Result<&'static mut EntriesOption, bun_core::Error> {
             if bun_core::FeatureFlags::ENABLE_ENTRY_CACHE {
                 let mut get_or_put_result = self.entries.get_or_put(dir)?;
-                if err == bun_core::err!("ENOENT") || err == bun_core::err!("FileNotFound") {
+                if err == bun_core::err!("ENOENT") || err == bun_core::err!("FileNotFound") || err == bun_core::err!("PermissionDenied") || err == bun_core::err!("AccessDenied") || err == bun_core::err!("EPERM") || err == bun_core::err!("EACCES") {
                     self.entries.mark_not_found(get_or_put_result);
                     return Ok(temp_entries_option_write(EntriesOption::Err(
                         dir_entry::Err {

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1086,7 +1086,7 @@ impl PackageJSON {
         ) {
             Ok(e) => e,
             Err(err) => {
-                if err != bun_core::err!("IsDir") {
+                if err != bun_core::err!("IsDir") && err != bun_core::err!("PermissionDenied") && err != bun_core::err!("AccessDenied") && err != bun_core::err!("EPERM") && err != bun_core::err!("EACCES") {
                     r_log.add_error_fmt(
                         None,
                         bun_ast::Loc::EMPTY,

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4376,7 +4376,11 @@ impl<'a> Resolver<'a> {
                             self.dir_cache_mut().mark_not_found(queue_top.result);
                             rfs!().entries.mark_not_found(cached_dir_entry_result);
                             if !(err == bun_core::err!("ENOENT")
-                                || err == bun_core::err!("FileNotFound"))
+                                || err == bun_core::err!("FileNotFound")
+                                || err == bun_core::err!("PermissionDenied")
+                                || err == bun_core::err!("AccessDenied")
+                                || err == bun_core::err!("EPERM")
+                                || err == bun_core::err!("EACCES"))
                             {
                                 if enable_logging {
                                     let pretty = queue_top_unsafe_path;
@@ -5587,7 +5591,11 @@ impl<'a> Resolver<'a> {
                 e if e == bun_core::err!("ENOENT")
                     || e == bun_core::err!("FileNotFound")
                     || e == bun_core::err!("ENOTDIR")
-                    || e == bun_core::err!("NotDir") => {}
+                    || e == bun_core::err!("NotDir")
+                    || e == bun_core::err!("PermissionDenied")
+                    || e == bun_core::err!("AccessDenied")
+                    || e == bun_core::err!("EPERM")
+                    || e == bun_core::err!("EACCES") => {}
                 _ => {
                     let _ = self.log_mut().add_error_fmt(
                         None,
@@ -6252,7 +6260,7 @@ impl<'a> Resolver<'a> {
                     Ok(v) => v.map(bun_core::heap::into_raw),
                     Err(err) => {
                         let pretty = tsconfigpath;
-                        if err == bun_core::err!("ENOENT") || err == bun_core::err!("FileNotFound")
+                        if err == bun_core::err!("ENOENT") || err == bun_core::err!("FileNotFound") || err == bun_core::err!("PermissionDenied") || err == bun_core::err!("AccessDenied") || err == bun_core::err!("EPERM") || err == bun_core::err!("EACCES")
                         {
                             let _ = self.log_mut().add_error_fmt(
                                 None,


### PR DESCRIPTION
On Linux with SELinux/seccomp, directory reads can return EPERM or EACCES in addition to EACCES. The resolver currently only handles ENOENT/FileNotFound/ENOTDIR/NotDir. This PR adds PermissionDenied, AccessDenied, EPERM, and EACCES to all 6 locations.