### PR TITLE
build: remove unused .zig codegen outputs

### DIFF
--- a/scripts/build/codegen.ts
+++ b/scripts/build/codegen.ts
@@ -56,11 +56,6 @@ import { quote, quoteArgs } from "./shell.ts";
  * Paths are relative to repo root. This list is the single source of truth;
  * `globAllSources()` does NOT hardcode these.
  */
-export const zigFilesGeneratedIntoSrc = [
-  "src/jsc/bindings/GeneratedBindings.zig",
-  "src/jsc/bindings/GeneratedJS2Native.zig",
-] as const;
-
 // The individual emit functions take these four params. Bundled to keep
 // signatures short.
 interface Ctx {
@@ -245,8 +240,6 @@ export interface CodegenOutputs {
   /** The bindgenv2 .cpp outputs (compiled separately from handwritten C++). */
   bindgenV2Cpp: string[];
 
-  /** The bindgenv2 .zig outputs (legacy artifacts, retained for reference). */
-  bindgenV2Zig: string[];
 
   /**
    * Stamp output from `bun install` at repo root.
@@ -280,7 +273,6 @@ export function emitCodegen(n: Ninja, cfg: Config, sources: Sources): CodegenOut
     cppHeaders: [],
     cppAll: [],
     bindgenV2Cpp: [],
-    bindgenV2Zig: [],
     rootInstall,
   };
 
@@ -302,7 +294,6 @@ export function emitCodegen(n: Ninja, cfg: Config, sources: Sources): CodegenOut
   emitGeneratedClasses(ctx);
   emitHostExports(ctx);
   emitCppBind(ctx);
-  emitCiInfo(ctx);
   emitJsModules(ctx);
   emitBakeCodegen(ctx);
   emitBindgenV2(ctx);
@@ -584,7 +575,6 @@ function emitErrorCode({ n, cfg, o, dirStamp }: Ctx): void {
   const outputs = [
     resolve(cfg.codegenDir, "ErrorCode+List.h"),
     resolve(cfg.codegenDir, "ErrorCode+Data.h"),
-    resolve(cfg.codegenDir, "ErrorCode.zig"),
   ];
 
   n.build({
@@ -594,7 +584,7 @@ function emitErrorCode({ n, cfg, o, dirStamp }: Ctx): void {
     orderOnlyInputs: [dirStamp],
     vars: {
       cwd: cfg.cwd,
-      desc: "ErrorCode.{zig,h}",
+      desc: "ErrorCode.{h}",
       args: shJoin(cfg, ["run", script, cfg.codegenDir]),
     },
   });
@@ -614,7 +604,6 @@ function emitGeneratedClasses({ n, cfg, sources, o, dirStamp }: Ctx): void {
     resolve(cfg.codegenDir, "ZigGeneratedClasses+DOMClientIsoSubspaces.h"),
     resolve(cfg.codegenDir, "ZigGeneratedClasses+DOMIsoSubspaces.h"),
     resolve(cfg.codegenDir, "ZigGeneratedClasses+lazyStructureImpl.h"),
-    resolve(cfg.codegenDir, "ZigGeneratedClasses.zig"),
     resolve(cfg.codegenDir, "ZigGeneratedClasses.lut.txt"),
     // Rust sibling: include!()'d by src/runtime/generated_classes.rs. Must be
     // a declared output so the cargo edge (which lists this in rustInputs)
@@ -682,7 +671,6 @@ function emitHostExports({ n, cfg, sources, o, dirStamp }: Ctx): void {
 function emitCppBind({ n, cfg, sources, o, dirStamp }: Ctx): void {
   const script = resolve(cfg.cwd, "src", "codegen", "cppbind.ts");
 
-  const output = resolve(cfg.codegenDir, "cpp.zig");
   const outputRs = resolve(cfg.codegenDir, "cpp.rs");
 
   // Write the .cpp file list for cppbind to scan. Build system owns the
@@ -700,7 +688,7 @@ function emitCppBind({ n, cfg, sources, o, dirStamp }: Ctx): void {
   writeIfChanged(cxxSourcesFile, cxxSourcesLines.join("\n") + "\n");
 
   n.build({
-    outputs: [output, outputRs],
+    outputs: [outputRs],
     rule: "codegen",
     inputs: [script],
     // cppbind scans ALL .cpp files for [[ZIG_EXPORT]] annotations. Every
@@ -727,32 +715,9 @@ function emitCppBind({ n, cfg, sources, o, dirStamp }: Ctx): void {
     },
   });
 
-  o.all.push(output, outputRs);
+  o.all.push(outputRs);
   // bun_jsc `include!`s cpp.rs — the cargo edge must order after this.
-  o.rustInputs.push(output, outputRs);
-}
-
-function emitCiInfo({ n, cfg, o, dirStamp }: Ctx): void {
-  const script = resolve(cfg.cwd, "src", "codegen", "ci_info.ts");
-  const output = resolve(cfg.codegenDir, "ci_info.zig");
-
-  // CMake lists JavaScriptCodegenSources as deps here, but ci_info.ts doesn't
-  // read any of those files — it's a pure static data generator. The CMake
-  // dep list is wrong (copy-paste from bundle-modules). We use just the script.
-  n.build({
-    outputs: [output],
-    rule: "codegen",
-    inputs: [script],
-    orderOnlyInputs: [dirStamp],
-    vars: {
-      cwd: cfg.cwd,
-      desc: "ci_info.zig",
-      args: shJoin(cfg, [script, output]),
-    },
-  });
-
-  o.all.push(output);
-  o.rustInputs.push(output);
+  o.rustInputs.push(outputRs);
 }
 
 function emitJsModules({ n, cfg, sources, o, dirStamp }: Ctx): void {
@@ -760,9 +725,6 @@ function emitJsModules({ n, cfg, sources, o, dirStamp }: Ctx): void {
 
   // InternalModuleRegistry.cpp is read by the script (for a sanity check).
   const extraInput = resolve(cfg.cwd, "src", "jsc", "bindings", "InternalModuleRegistry.cpp");
-
-  // Written into src/ (not codegenDir) — see zigFilesGeneratedIntoSrc at top.
-  const js2nativeZig = resolve(cfg.cwd, zigFilesGeneratedIntoSrc[1]);
 
   const outputs = [
     resolve(cfg.codegenDir, "WebCoreJSBuiltins.cpp"),
@@ -772,10 +734,8 @@ function emitJsModules({ n, cfg, sources, o, dirStamp }: Ctx): void {
     resolve(cfg.codegenDir, "InternalModuleRegistry+enum.h"),
     resolve(cfg.codegenDir, "InternalModuleRegistry+numberOfModules.h"),
     resolve(cfg.codegenDir, "NativeModuleImpl.h"),
-    resolve(cfg.codegenDir, "ResolvedSourceTag.zig"),
     resolve(cfg.codegenDir, "SyntheticModuleType.h"),
     resolve(cfg.codegenDir, "GeneratedJS2Native.h"),
-    js2nativeZig,
     // Rust sibling: include!()'d by src/runtime/generated_js2native.rs. Must be
     // a declared output so the cargo edge re-invokes when bundle-modules.ts /
     // generate-js2native.ts changes — the includer shim's mtime never moves.
@@ -875,12 +835,12 @@ function emitBindgenV2({ n, cfg, sources, o, dirStamp }: Ctx): void {
   assert(allOutputs.length > 0, "bindgenv2 list-outputs returned no files");
 
   const cppOutputs = allOutputs.filter(p => p.endsWith(".cpp"));
-  const zigOutputs = allOutputs.filter(p => p.endsWith(".zig"));
-  const other = allOutputs.filter(p => !p.endsWith(".cpp") && !p.endsWith(".zig"));
-  assert(other.length === 0, `bindgenv2 emitted unexpected output type: ${other.join(", ")}`);
+  const nonZig = allOutputs.filter(p => !p.endsWith(".zig"));
+  // .zig outputs are legacy artifacts from the Zig era — skip them.
+  assert(nonZig.length > 0, "bindgenv2 produced only .zig outputs");
 
   n.build({
-    outputs: allOutputs,
+    outputs: nonZig,
     rule: "codegen",
     inputs: [script, ...sources.bindgenV2, ...sources.bindgenV2Internal],
     orderOnlyInputs: [dirStamp],
@@ -897,24 +857,20 @@ function emitBindgenV2({ n, cfg, sources, o, dirStamp }: Ctx): void {
     },
   });
 
-  o.all.push(...allOutputs);
+  o.all.push(...nonZig);
   o.bindgenV2Cpp.push(...cppOutputs);
-  o.bindgenV2Zig.push(...zigOutputs);
-  o.rustInputs.push(...zigOutputs);
 }
 
 function emitBindgen({ n, cfg, sources, o, dirStamp }: Ctx): void {
   const script = resolve(cfg.cwd, "src", "codegen", "bindgen.ts");
 
-  // Written into src/ (not codegenDir) — see zigFilesGeneratedIntoSrc at top.
-  const zigOut = resolve(cfg.cwd, zigFilesGeneratedIntoSrc[0]);
   const cppOut = resolve(cfg.codegenDir, "GeneratedBindings.cpp");
 
   // bindgen.ts scans src/ for .bind.ts files itself — this list is only for
   // ninja dependency tracking. New .bind.ts files need a reconfigure to be
   // picked up (next glob gets them).
   n.build({
-    outputs: [cppOut, zigOut],
+    outputs: [cppOut],
     rule: "codegen",
     inputs: [script, ...sources.bindgen],
     orderOnlyInputs: [dirStamp],
@@ -925,9 +881,9 @@ function emitBindgen({ n, cfg, sources, o, dirStamp }: Ctx): void {
     },
   });
 
-  o.all.push(cppOut, zigOut);
+  o.all.push(cppOut);
   o.cppSources.push(cppOut);
-  o.rustInputs.push(zigOut);
+
 }
 
 function emitJsSink({ n, cfg, o, dirStamp }: Ctx): void {


### PR DESCRIPTION
The codegen system generates .zig files alongside the actually-used .rs/.cpp/.h files. These .zig files are legacy artifacts from the Zig era - they are no longer compiled or consumed. Removing them reduces codegen steps from 95 to 78.