### PR TITLE
fs: fix fd leak in ReadStream._destroy for { start, autoClose } (dead kReadStreamFastPath branch)

### DIFF
--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -35,11 +35,6 @@ type FD = number;
 
 const { validateInteger, validateInt32, validateFunction } = require("internal/validators");
 
-// Bun supports a fast path for `createReadStream("path.txt")` with `.pipe(res)`,
-// where the entire stream implementation can be bypassed, effectively making it
-// `new Response(Bun.file("path.txt"))`.
-// This makes an idomatic Node.js pattern much faster.
-const kReadStreamFastPath = Symbol("kReadStreamFastPath");
 const kIsPerformingIO = Symbol("kIsPerformingIO");
 const kIoDone = Symbol("kIoDone");
 // Bun supports a fast path for `createWriteStream("path.txt")` where instead of
@@ -142,7 +137,7 @@ function ReadStream(this: FSStream, path, options): void {
   // Only buffers are supported.
   options.decodeStrings = true;
 
-  let { fd, autoClose, fs: customFs, start, end = Infinity, encoding } = options;
+  let { fd, autoClose, fs: customFs, start, end = Infinity } = options;
 
   if (fd == null) {
     this[kFs] = customFs || fs;
@@ -207,13 +202,6 @@ function ReadStream(this: FSStream, path, options): void {
     }
   }
 
-  this[kReadStreamFastPath] =
-    start === 0 &&
-    end === Infinity &&
-    autoClose &&
-    !customFs &&
-    // is it an encoding which we don't need to decode?
-    (encoding === "buffer" || encoding === "binary" || encoding == null || encoding === "utf-8" || encoding === "utf8");
   Readable.$call(this, options);
   return this as unknown as void;
 }
@@ -351,9 +339,7 @@ readStreamPrototype._destroy = function (this: FSStream, err, cb) {
   // running in a thread pool. Therefore, file descriptors are not safe
   // to close while used in a pending read or write operation. Wait for
   // any pending IO (kIsPerformingIO) to complete (kIoDone).
-  if (this[kReadStreamFastPath]) {
-    this.once(kReadStreamFastPath, er => close(this, err || er, cb));
-  } else if (this[kIsPerformingIO]) {
+  if (this[kIsPerformingIO]) {
     this.once(kIoDone, er => close(this, err || er, cb));
   } else {
     close(this, err, cb);
@@ -400,13 +386,6 @@ function closeAfterSync(stream, err, cb) {
   });
   stream.fd = null;
 }
-
-ReadStream.prototype.pipe = function (this: FSStream, dest, pipeOpts) {
-  // Fast path for streaming files:
-  // if (this[kReadStreamFastPath]) {
-  // }
-  return Readable.prototype.pipe.$call(this, dest, pipeOpts);
-};
 
 function WriteStream(this: FSStream, path: string | null, options?: any): void {
   if (!(this instanceof WriteStream)) {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2274,14 +2274,13 @@ describe("createReadStream", () => {
     expect(caught?.code).toBe("ERR_STREAM_PREMATURE_CLOSE");
   });
 
-  // Regression: _destroy used to register `once(kReadStreamFastPath, ...)` for an
-  // event that is never emitted when { start, autoClose } were both truthy, so
-  // 'close' never fired and the fd was leaked.
+  // https://github.com/oven-sh/bun/pull/30920
   it("emits 'close' and releases fd with { start: 0, autoClose: true }", async () => {
     const stream = createReadStream(join(import.meta.dir, "readFileSync.txt"), { start: 0, autoClose: true });
-    const { promise, resolve } = Promise.withResolvers<void>();
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
 
     stream.on("data", () => {});
+    stream.on("error", reject);
     stream.on("close", () => resolve());
 
     await promise;

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2253,6 +2253,42 @@ describe("createReadStream", () => {
     },
     { timeout: 100 },
   );
+
+  // https://github.com/oven-sh/bun/issues/30919
+  it("async iterator rejects with ERR_STREAM_PREMATURE_CLOSE when destroy() is called during iteration", async () => {
+    const stream = createReadStream(join(import.meta.dir, "readFileSync.txt"));
+
+    let chunks = 0;
+    let caught: any = undefined;
+    try {
+      for await (const _ of stream) {
+        chunks++;
+        stream.destroy();
+      }
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(chunks).toBe(1);
+    expect(caught).toBeDefined();
+    expect(caught?.code).toBe("ERR_STREAM_PREMATURE_CLOSE");
+  });
+
+  // Regression: _destroy used to register `once(kReadStreamFastPath, ...)` for an
+  // event that is never emitted when { start, autoClose } were both truthy, so
+  // 'close' never fired and the fd was leaked.
+  it("emits 'close' and releases fd with { start: 0, autoClose: true }", async () => {
+    const stream = createReadStream(join(import.meta.dir, "readFileSync.txt"), { start: 0, autoClose: true });
+    const { promise, resolve } = Promise.withResolvers<void>();
+
+    stream.on("data", () => {});
+    stream.on("close", () => resolve());
+
+    await promise;
+    expect(stream.destroyed).toBe(true);
+    expect(stream.closed).toBe(true);
+    expect(stream.fd).toBeNull();
+  });
 });
 
 describe("fs.WriteStream", () => {


### PR DESCRIPTION
Fixes #30919.

## Status after rebase onto main

Main's #31826 ("sync the stream suite to Node v26.3.0") independently fixed the original #30919 async-iterator bug by restoring the `kIsPerformingIO`/`kIoDone` pattern in `ReadStream._read` (the in-flight read callback now returns early when `this.destroyed`, so `push(null)` can't mark the readable side ended and suppress `ERR_STREAM_PREMATURE_CLOSE`). This PR was rebased onto that; the now-redundant `_read` guard was dropped.

What remains is an adjacent bug #31826 left in place, plus the regression tests.

## Remaining fix: fd leak in `_destroy`

`ReadStream.prototype._destroy` still had:

```js
if (this[kReadStreamFastPath]) {
  this.once(kReadStreamFastPath, er => close(this, err || er, cb));
} else if (this[kIsPerformingIO]) {
  this.once(kIoDone, er => close(this, err || er, cb));
} else {
  close(this, err, cb);
}
```

`kReadStreamFastPath` is set true in the constructor for `{ start: 0, autoClose: true }` (both documented `fs` options) but is **never emitted anywhere**. So for such streams `_destroy` registers a one-shot listener that never fires: the destroy callback never runs, `'close'` is never emitted, and the fd leaks.

```js
const { createReadStream } = require("fs");
const s = createReadStream(__filename, { start: 0, autoClose: true });
s.on("data", () => {});
s.on("close", () => console.log("close"));     // Node: fires. Bun: never fires.
setTimeout(() => console.log(s.closed, s.fd), 500); // Node: true null. Bun: false <fd>.
```

The fix removes the dead `kReadStreamFastPath` branch so destroy falls through to the `kIsPerformingIO`/`kIoDone` path (waits for an in-flight thread-pool read) or closes immediately, matching the common `createReadStream(path)` path. The now-unused `kReadStreamFastPath` symbol, its constructor assignment, the orphaned `encoding` destructure, and the no-op `pipe` override (which only referenced it in a comment) are removed too. `kIsPerformingIO`/`kIoDone` from #31826 are left intact.

## Tests

`test/js/node/fs/fs.test.ts`, `createReadStream` describe block:

- `async iterator rejects with ERR_STREAM_PREMATURE_CLOSE when destroy() is called during iteration` — the #30919 regression test. Passes on current main (fixed by #31826); kept to lock the behavior in.
- `emits 'close' and releases fd with { start: 0, autoClose: true }` — the fd-leak regression test. Times out (no `'close'`) on current main, passes with this fix.

## Verification

```
# fd-leak test against main (src/ stashed): FAIL (times out, no 'close')
# fd-leak test with fix:                    PASS
# async-iterator test both ways:            PASS (already fixed upstream)
```

Upstream `test-fs-read-stream*` parallel tests still pass locally.