### PR TITLE
encoding: fix Vec<u8>->Vec<u16> layout UB in fs.readFile utf16le path

### DIFF
--- a/src/runtime/webcore/encoding.rs
+++ b/src/runtime/webcore/encoding.rs
@@ -295,19 +295,19 @@ pub fn to_bun_string_from_owned_slice(input: Vec<u8>, encoding: Encoding) -> Bun
                 return BunString::empty();
             }
 
-            // TODO(port): Zig reinterpreted the owned u8 allocation as []u16 (with @alignCast)
-            // and handed it to createExternalGloballyAllocated(.utf16, ...). Reinterpreting a
-            // Vec<u8> as Vec<u16> is not generally sound in Rust (alignment + allocator layout).
-            // TODO(refactor): route through a bun_core::String API that accepts raw (ptr,len,cap) bytes.
-            // SAFETY: input.as_ptr() is at least 1-aligned; Zig asserted u16 alignment via @alignCast.
-            let as_u16 = unsafe {
-                let mut input = core::mem::ManuallyDrop::new(input);
-                Vec::from_raw_parts(
-                    input.as_mut_ptr().cast::<u16>(),
-                    usable_len / 2,
-                    input.capacity() / 2,
-                )
-            };
+            // Allocate a fresh u16-aligned Vec and copy the bytes. The Zig
+            // original reinterpreted the owned `[]u8` as `[]u16` (with
+            // `@alignCast`), but the equivalent in Rust — rebuilding a
+            // `Vec<u16>` from a `Vec<u8>`'s raw parts — violates `Vec`'s
+            // Layout contract: alloc happened with align 1, but the eventual
+            // dealloc as `Vec<u16>` uses align 2. mimalloc gives us aligned
+            // pointers in practice, so this didn't crash, but it's UB on
+            // paper and an allocator change could surface it. Mirrors
+            // `construct_from_u16`'s utf16le arm, which fixed the symmetric
+            // Zig pattern for the same reason.
+            let mut as_u16 = vec![0u16; usable_len / 2];
+            let dst: &mut [u8] = bytemuck::cast_slice_mut(&mut as_u16);
+            dst.copy_from_slice(&input[..usable_len]);
             create_external_globally_allocated_utf16(as_u16)
         }
 


### PR DESCRIPTION
## Summary

Fixes a `Vec` allocator-layout UB in `to_bun_string_from_owned_slice`'s `Ucs2`/`Utf16le` arm — the sole code path for `fs.readFile(path, { encoding: "utf16le" | "ucs2" })`.

## What was wrong

The arm took an owned `Vec<u8>` and rebuilt it as a `Vec<u16>` via `Vec::from_raw_parts(ptr.cast::<u16>(), len/2, cap/2)`, then handed that to WebKit's external-string deallocator. This is a direct port of the Zig original's `@alignCast(bytesAsSlice(u16, …))`, but Rust's `Vec` is stricter:

- `Vec::from_raw_parts` requires that `T`'s alignment equal the alignment of the original allocation. `Vec<u8>` allocates with `Layout` align 1; reclaiming as `Vec<u16>` makes the eventual `dealloc` use align 2.
- Per `alloc::alloc::dealloc`'s safety contract, the `Layout` used to free must match the one used to allocate. Mismatched `align` is UB.

The `TODO(port)` comment above the code already called this out:

> Reinterpreting a `Vec<u8>` as `Vec<u16>` is not generally sound in Rust (alignment + allocator layout).

### Why it never crashed

mimalloc gives us over-aligned (>= 8 byte) pointers, so the layout mismatch is benign in practice on the allocator we ship. Miri would flag it, and a future allocator change would surface it as either a crash on free or silent heap corruption.

## The fix

Mirror the already-merged solution in `construct_from_u16`'s utf16le arm (same file). That arm had the symmetric `Vec<u16>` -> `Vec<u8>` reinterpret problem when porting from Zig, and the porter resolved it the same way — comment from `encoding.rs:786-789`:

> The Zig original allocated u16-aligned then reinterpreted the Vec header to u8, which is allocator-layout-dependent in Rust; a fresh u8 Vec sidesteps that…

Same shape here, opposite direction: allocate a fresh `Vec<u16>` and copy the input bytes into it via `bytemuck::cast_slice_mut`. Sound by construction — the `Vec` is allocated and freed with the same `Layout`.

```diff
- // TODO(port): Zig reinterpreted the owned u8 allocation as []u16 ...
- let as_u16 = unsafe {
-     let mut input = core::mem::ManuallyDrop::new(input);
-     Vec::from_raw_parts(
-         input.as_mut_ptr().cast::<u16>(),
-         usable_len / 2,
-         input.capacity() / 2,
-     )
- };
+ let mut as_u16 = vec![0u16; usable_len / 2];
+ let dst: &mut [u8] = bytemuck::cast_slice_mut(&mut as_u16);
+ dst.copy_from_slice(&input[..usable_len]);
  create_external_globally_allocated_utf16(as_u16)
```

## Tradeoff

One extra `usable_len`-byte `memcpy` on the `fs.readFile(path, "utf16le"|"ucs2")` hot path. For typical file sizes (KB-MB) this is negligible. The zero-copy path can be restored later by adding a `bun_core::String` constructor that accepts `(ptr, len, cap, dtor)` — exactly what the original `TODO(refactor)` suggested.

## Sole caller

`src/runtime/node/node_fs.rs:7071` — the `fs.readFile(path, { encoding })` return-as-string path, when the encoding is `utf16le` or `ucs2` (Latin-1/UTF-8 paths take separate arms and aren't affected).

## Test plan

- [x] `bun bd test test/regression/issue/utf16-encoding-crash.test.ts` — `fs.readFileSync(path, "utf16le")` plus `"ucs2"`, including a 256 KB + 1 byte case that hits the dynamic-allocation branch
- [x] `bun bd test test/js/node/buffer-utf16.test.ts` — `Buffer.from(str, "utf-16le")` roundtrip

```
$ bun bd --asan=off test test/regression/issue/utf16-encoding-crash.test.ts test/js/node/buffer-utf16.test.ts
 3 pass
 0 fail
 9 expect() calls
```

No new tests added — this is a soundness fix, not a behavior fix. The existing tests already exercise the relevant code path (`fs.readFile` with `utf16le`/`ucs2` encodings, including the >256 KB dynamic-allocation branch); their pre/post-fix behavior is identical, as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)