### PR TITLE
feat(shell): add head, tail, printenv, and realpath builtins

### DIFF
--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -210,6 +210,10 @@ shell_builtins! {
         Cp       => (cp::Cp,            "cp",       b"usage: cp [-R [-H | -L | -P]] [-fi | -n] [-aclpsvXx] source_file target_file\n       cp [-R [-H | -L | -P]] [-fi | -n] [-aclpsvXx] source_file ... target_directory\n"),
         Seq      => (seq::Seq,          "seq",      b"usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last\n"),
         Yes      => (yes::Yes,          "yes",      b"usage: yes [expletive]\n"),
+        Head     => (head::Head,        "head",     b"usage: head [-n count] [file ...]\n"),
+        Tail     => (tail::Tail,        "tail",     b"usage: tail [-n count] [file ...]\n"),
+        Printenv => (printenv::Printenv, "printenv", b"usage: printenv [-0] [name ...]\n"),
+        Realpath => (realpath::Realpath, "realpath", b"usage: realpath [file ...]\n"),
     }
     posix_disabled: [Cat, Cp]
 }

--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -32,6 +32,8 @@ pub struct ChildPtr {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum ReaderTag {
     Cat,
+    Head,
+    Tail,
 }
 
 /// Spec: IOReader.zig `Readers = SmolList(ChildPtr, 4)`.
@@ -448,6 +450,12 @@ fn dispatch_read_chunk(
         ReaderTag::Cat => {
             crate::shell::builtins::cat::Cat::on_io_reader_chunk(interp, child.node, chunk, remove)
         }
+        ReaderTag::Head => {
+            crate::shell::builtins::head::Head::on_io_reader_chunk(interp, child.node, chunk, remove)
+        }
+        ReaderTag::Tail => {
+            crate::shell::builtins::tail::Tail::on_io_reader_chunk(interp, child.node, chunk, remove)
+        }
     }
 }
 
@@ -464,6 +472,12 @@ fn dispatch_reader_done(
         ReaderTag::Cat => {
             crate::shell::builtins::cat::Cat::on_io_reader_done(interp, child.node, err)
         }
+        ReaderTag::Head => {
+            crate::shell::builtins::head::Head::on_io_reader_done(interp, child.node, err)
+        }
+        ReaderTag::Tail => {
+            crate::shell::builtins::tail::Tail::on_io_reader_done(interp, child.node, err)
+        }
     }
 }
 
@@ -472,6 +486,18 @@ pub fn on_read_chunk(interp: &Interpreter, child: ChildPtr, chunk: &[u8]) -> Yie
     let mut remove = false;
     match child.tag {
         ReaderTag::Cat => crate::shell::builtins::cat::Cat::on_io_reader_chunk(
+            interp,
+            child.node,
+            chunk,
+            &mut remove,
+        ),
+        ReaderTag::Head => crate::shell::builtins::head::Head::on_io_reader_chunk(
+            interp,
+            child.node,
+            chunk,
+            &mut remove,
+        ),
+        ReaderTag::Tail => crate::shell::builtins::tail::Tail::on_io_reader_chunk(
             interp,
             child.node,
             chunk,
@@ -488,6 +514,12 @@ pub fn on_reader_done(
     match child.tag {
         ReaderTag::Cat => {
             crate::shell::builtins::cat::Cat::on_io_reader_done(interp, child.node, err)
+        }
+        ReaderTag::Head => {
+            crate::shell::builtins::head::Head::on_io_reader_done(interp, child.node, err)
+        }
+        ReaderTag::Tail => {
+            crate::shell::builtins::tail::Tail::on_io_reader_done(interp, child.node, err)
         }
     }
 }

--- a/src/runtime/shell/builtin/head.rs
+++ b/src/runtime/shell/builtin/head.rs
@@ -1,0 +1,356 @@
+use std::sync::Arc;
+
+use bun_ptr::AsCtxPtr;
+
+use crate::shell::ExitCode;
+use crate::shell::builtin::{Builtin, BuiltinInput, BuiltinState, IoKind, Kind};
+use crate::shell::interpreter::{Interpreter, NodeId, shell_openat};
+use crate::shell::io_reader::{ChildPtr as ReaderChildPtr, IOReader, ReaderTag};
+use crate::shell::io_writer::{ChildPtr, WriterTag};
+use crate::shell::yield_::Yield;
+
+#[derive(Default)]
+pub struct Head {
+    pub lines: usize,
+    pub state: HeadState,
+}
+
+#[derive(Default)]
+pub enum HeadState {
+    #[default]
+    Idle,
+    ExecStdin {
+        collected: Vec<u8>,
+        in_done: bool,
+    },
+    ExecFilepathArgs {
+        args_start: usize,
+        idx: usize,
+        reader: Option<Arc<IOReader>>,
+        collected: Vec<u8>,
+        in_done: bool,
+    },
+    WaitingWriteErr,
+    WaitingWriteOut,
+    Done,
+}
+
+impl Head {
+    pub fn start(interp: &Interpreter, cmd: NodeId) -> Yield {
+        let argc = Builtin::of(interp, cmd).args_slice().len();
+
+        // Manual arg parsing for -n <count>.
+        let mut lines: usize = 10;
+        let mut filepath_start: Option<usize> = None;
+        let mut idx = 0usize;
+        while idx < argc {
+            let arg = Builtin::of(interp, cmd).arg_bytes(idx);
+            if arg == b"--" {
+                filepath_start = Some(idx + 1);
+                break;
+            }
+            if arg == b"-n" {
+                idx += 1;
+                if idx >= argc {
+                    return Self::fail(interp, cmd, b"head: option requires an argument -- n\n");
+                }
+                let val = Builtin::of(interp, cmd).arg_bytes(idx);
+                match parse_usize(val) {
+                    Some(n) => lines = n,
+                    None => {
+                        return Self::fail(interp, cmd, b"head: invalid number of lines\n");
+                    }
+                }
+                idx += 1;
+                continue;
+            }
+            if arg.starts_with(b"-n") && arg.len() > 2 {
+                match parse_usize(&arg[2..]) {
+                    Some(n) => lines = n,
+                    None => {
+                        return Self::fail(interp, cmd, b"head: invalid number of lines\n");
+                    }
+                }
+                idx += 1;
+                continue;
+            }
+            if arg.starts_with(b"--lines=") && arg.len() > 8 {
+                match parse_usize(&arg[8..]) {
+                    Some(n) => lines = n,
+                    None => {
+                        return Self::fail(interp, cmd, b"head: invalid number of lines\n");
+                    }
+                }
+                idx += 1;
+                continue;
+            }
+            // Not a flag — first positional arg.
+            if arg.starts_with(b"-") && arg.len() > 1 {
+                // Check for -<number> shorthand (e.g. head -5).
+                if let Some(n) = parse_usize(&arg[1..]) {
+                    lines = n;
+                    idx += 1;
+                    continue;
+                }
+                return Self::fail(interp, cmd, b"head: invalid option\n");
+            }
+            filepath_start = Some(idx);
+            break;
+        }
+
+        Self::state_mut(interp, cmd).lines = lines;
+
+        let has_files = filepath_start.is_some() && filepath_start.unwrap() < argc;
+
+        Self::state_mut(interp, cmd).state = if has_files {
+            HeadState::ExecFilepathArgs {
+                args_start: filepath_start.unwrap(),
+                idx: 0,
+                reader: None,
+                collected: Vec::new(),
+                in_done: false,
+            }
+        } else {
+            HeadState::ExecStdin {
+                collected: Vec::new(),
+                in_done: false,
+            }
+        };
+
+        Self::next(interp, cmd)
+    }
+
+    pub fn next(interp: &Interpreter, cmd: NodeId) -> Yield {
+        enum Branch {
+            Stdin,
+            FileArg { args_start: usize, idx: usize },
+            WaitingErr,
+            WaitingOut,
+            Done,
+        }
+        let branch = match &Self::state_mut(interp, cmd).state {
+            HeadState::Idle => panic!("Invalid state"),
+            HeadState::ExecStdin { .. } => Branch::Stdin,
+            HeadState::ExecFilepathArgs {
+                args_start, idx, ..
+            } => Branch::FileArg {
+                args_start: *args_start,
+                idx: *idx,
+            },
+            HeadState::WaitingWriteErr => Branch::WaitingErr,
+            HeadState::WaitingWriteOut => Branch::WaitingOut,
+            HeadState::Done => Branch::Done,
+        };
+        match branch {
+            Branch::Stdin => {
+                let stdin_needs_io = Builtin::of(interp, cmd).stdin.needs_io();
+                if !stdin_needs_io {
+                    let buf = Builtin::read_stdin_no_io(interp, cmd).to_vec();
+                    let n = Self::state_mut(interp, cmd).lines;
+                    let output = first_n_lines(&buf, n);
+                    return Self::write_output(interp, cmd, output);
+                }
+                let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
+                let reader = match &Builtin::of(interp, cmd).stdin {
+                    BuiltinInput::Fd(r) => r.clone(),
+                    _ => unreachable!("needs_io() returned true"),
+                };
+                reader.set_interp(interp_ptr);
+                reader.add_reader(ReaderChildPtr {
+                    node: cmd,
+                    tag: ReaderTag::Head,
+                });
+                reader.start()
+            }
+            Branch::FileArg { args_start, idx } => {
+                let argc = Builtin::of(interp, cmd).args_slice().len();
+                let n_files = argc - args_start;
+                if idx >= n_files {
+                    if let HeadState::ExecFilepathArgs { reader, .. } =
+                        &mut Self::state_mut(interp, cmd).state
+                    {
+                        *reader = None;
+                    }
+                    return Builtin::done(interp, cmd, 0);
+                }
+                if let HeadState::ExecFilepathArgs { reader, .. } =
+                    &mut Self::state_mut(interp, cmd).state
+                {
+                    *reader = None;
+                }
+
+                let path = Builtin::of(interp, cmd).arg_zstr(args_start + idx);
+
+                if let HeadState::ExecFilepathArgs { idx: i, .. } =
+                    &mut Self::state_mut(interp, cmd).state
+                {
+                    *i += 1;
+                }
+
+                let dir = Builtin::cwd(interp, cmd);
+                let fd = match shell_openat(dir, path, bun_sys::O::RDONLY, 0) {
+                    Ok(fd) => fd,
+                    Err(e) => {
+                        let buf =
+                            Builtin::task_error_to_string(interp, cmd, Kind::Head, &e).to_vec();
+                        return Self::write_failing_error(interp, cmd, &buf, 1);
+                    }
+                };
+
+                let evtloop = Builtin::event_loop(interp, cmd);
+                let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
+                let reader = IOReader::init(fd, evtloop);
+                reader.set_interp(interp_ptr);
+                if let HeadState::ExecFilepathArgs {
+                    reader: slot,
+                    in_done,
+                    collected,
+                    ..
+                } = &mut Self::state_mut(interp, cmd).state
+                {
+                    *in_done = false;
+                    collected.clear();
+                    *slot = Some(reader.clone());
+                }
+                reader.add_reader(ReaderChildPtr {
+                    node: cmd,
+                    tag: ReaderTag::Head,
+                });
+                reader.start()
+            }
+            Branch::WaitingErr => Yield::failed(),
+            Branch::WaitingOut => Yield::suspended(),
+            Branch::Done => Builtin::done(interp, cmd, 0),
+        }
+    }
+
+    fn fail(interp: &Interpreter, cmd: NodeId, msg: &[u8]) -> Yield {
+        Self::state_mut(interp, cmd).state = HeadState::WaitingWriteErr;
+        Builtin::write_failing_error(interp, cmd, msg, 1)
+    }
+
+    fn write_failing_error(
+        interp: &Interpreter,
+        cmd: NodeId,
+        buf: &[u8],
+        exit_code: ExitCode,
+    ) -> Yield {
+        if let Some(safeguard) = Builtin::of(interp, cmd).stderr.needs_io() {
+            Self::state_mut(interp, cmd).state = HeadState::WaitingWriteErr;
+            let child = ChildPtr::new(cmd, WriterTag::Builtin);
+            return Builtin::of_mut(interp, cmd)
+                .stderr
+                .enqueue(child, buf, safeguard);
+        }
+        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, buf);
+        Builtin::done(interp, cmd, exit_code)
+    }
+
+    fn write_output(interp: &Interpreter, cmd: NodeId, output: Vec<u8>) -> Yield {
+        if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
+            Self::state_mut(interp, cmd).state = HeadState::WaitingWriteOut;
+            let child = ChildPtr::new(cmd, WriterTag::Builtin);
+            return Builtin::of_mut(interp, cmd)
+                .stdout
+                .enqueue(child, &output, safeguard);
+        }
+        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &output);
+        Builtin::done(interp, cmd, 0)
+    }
+
+    pub fn on_io_writer_chunk(
+        interp: &Interpreter,
+        cmd: NodeId,
+        _: usize,
+        err: Option<bun_sys::SystemError>,
+    ) -> Yield {
+        if err.is_some() {
+            return Builtin::done(interp, cmd, 1);
+        }
+        match &Self::state_mut(interp, cmd).state {
+            HeadState::WaitingWriteErr => Builtin::done(interp, cmd, 1),
+            HeadState::WaitingWriteOut => {
+                Self::state_mut(interp, cmd).state = HeadState::Done;
+                Builtin::done(interp, cmd, 0)
+            }
+            _ => Builtin::done(interp, cmd, 0),
+        }
+    }
+
+    /// Called by IOReader when a chunk of data is available.
+    pub fn on_io_reader_chunk(
+        interp: &Interpreter,
+        cmd: NodeId,
+        chunk: &[u8],
+        remove: &mut bool,
+    ) -> Yield {
+        *remove = false;
+        let n = Self::state_mut(interp, cmd).lines;
+
+        match &mut Self::state_mut(interp, cmd).state {
+            HeadState::ExecStdin { collected, .. }
+            | HeadState::ExecFilepathArgs { collected, .. } => {
+                collected.extend_from_slice(chunk);
+                // Check if we have enough lines to stop reading early.
+                let line_count = collected.iter().filter(|&&b| b == b'\n').count();
+                if line_count >= n {
+                    *remove = true;
+                }
+            }
+            _ => panic!("Invalid state"),
+        }
+        Yield::done()
+    }
+
+    /// Called by IOReader when all data has been read.
+    pub fn on_io_reader_done(
+        interp: &Interpreter,
+        cmd: NodeId,
+        err: Option<bun_sys::SystemError>,
+    ) -> Yield {
+        if let Some(e) = err {
+            let errno = e.get_errno() as ExitCode;
+            e.deref();
+            return Builtin::done(interp, cmd, errno);
+        }
+
+        let n = Self::state_mut(interp, cmd).lines;
+
+        let output = match &mut Self::state_mut(interp, cmd).state {
+            HeadState::ExecStdin { collected, in_done, .. } => {
+                *in_done = true;
+                first_n_lines(collected, n)
+            }
+            HeadState::ExecFilepathArgs { collected, in_done, .. } => {
+                *in_done = true;
+                first_n_lines(collected, n)
+            }
+            _ => return Builtin::done(interp, cmd, 0),
+        };
+
+        Self::write_output(interp, cmd, output)
+    }
+}
+
+/// Extract the first `n` lines from `data`.
+fn first_n_lines(data: &[u8], n: usize) -> Vec<u8> {
+    if n == 0 {
+        return Vec::new();
+    }
+    let mut count = 0;
+    for (i, &byte) in data.iter().enumerate() {
+        if byte == b'\n' {
+            count += 1;
+            if count >= n {
+                return data[..=i].to_vec();
+            }
+        }
+    }
+    // Fewer than n lines — return everything.
+    data.to_vec()
+}
+
+fn parse_usize(bytes: &[u8]) -> Option<usize> {
+    let s = core::str::from_utf8(bytes).ok()?;
+    s.parse().ok()
+}

--- a/src/runtime/shell/builtin/head.rs
+++ b/src/runtime/shell/builtin/head.rs
@@ -255,7 +255,28 @@ impl Head {
                 .enqueue(child, &output, safeguard);
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &output);
-        Builtin::done(interp, cmd, 0)
+        // For multi-file mode, advance to the next file.
+        Self::advance_or_done(interp, cmd)
+    }
+
+    /// If processing file arguments, advance to the next file. Otherwise done.
+    fn advance_or_done(interp: &Interpreter, cmd: NodeId) -> Yield {
+        let is_file_args = matches!(
+            &Self::state_mut(interp, cmd).state,
+            HeadState::ExecFilepathArgs { .. } | HeadState::WaitingWriteOut
+        );
+        if is_file_args {
+            // Reset state for next file iteration.
+            if let HeadState::ExecFilepathArgs { collected, in_done, .. } =
+                &mut Self::state_mut(interp, cmd).state
+            {
+                collected.clear();
+                *in_done = false;
+            }
+            Self::next(interp, cmd)
+        } else {
+            Builtin::done(interp, cmd, 0)
+        }
     }
 
     pub fn on_io_writer_chunk(
@@ -269,10 +290,7 @@ impl Head {
         }
         match &Self::state_mut(interp, cmd).state {
             HeadState::WaitingWriteErr => Builtin::done(interp, cmd, 1),
-            HeadState::WaitingWriteOut => {
-                Self::state_mut(interp, cmd).state = HeadState::Done;
-                Builtin::done(interp, cmd, 0)
-            }
+            HeadState::WaitingWriteOut => Self::advance_or_done(interp, cmd),
             _ => Builtin::done(interp, cmd, 0),
         }
     }

--- a/src/runtime/shell/builtin/head.rs
+++ b/src/runtime/shell/builtin/head.rs
@@ -13,6 +13,13 @@ use crate::shell::yield_::Yield;
 pub struct Head {
     pub lines: usize,
     pub state: HeadState,
+    /// Saved file-args context for resuming after async write.
+    pub file_args: Option<FileArgsCtx>,
+}
+
+pub struct FileArgsCtx {
+    pub args_start: usize,
+    pub idx: usize,
 }
 
 #[derive(Default)]
@@ -247,6 +254,17 @@ impl Head {
     }
 
     fn write_output(interp: &Interpreter, cmd: NodeId, output: Vec<u8>) -> Yield {
+        // Save file-args context before transitioning to WaitingWriteOut
+        // so on_io_writer_chunk can restore and advance to the next file.
+        if let HeadState::ExecFilepathArgs { args_start, idx, .. } =
+            &Self::state_mut(interp, cmd).state
+        {
+            Self::state_mut(interp, cmd).file_args = Some(FileArgsCtx {
+                args_start: *args_start,
+                idx: *idx,
+            });
+        }
+
         if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
             Self::state_mut(interp, cmd).state = HeadState::WaitingWriteOut;
             let child = ChildPtr::new(cmd, WriterTag::Builtin);
@@ -255,24 +273,17 @@ impl Head {
                 .enqueue(child, &output, safeguard);
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &output);
-        // For multi-file mode, advance to the next file.
-        Self::advance_or_done(interp, cmd)
-    }
 
-    /// If processing file arguments, advance to the next file. Otherwise done.
-    fn advance_or_done(interp: &Interpreter, cmd: NodeId) -> Yield {
-        let is_file_args = matches!(
-            &Self::state_mut(interp, cmd).state,
-            HeadState::ExecFilepathArgs { .. } | HeadState::WaitingWriteOut
-        );
-        if is_file_args {
-            // Reset state for next file iteration.
-            if let HeadState::ExecFilepathArgs { collected, in_done, .. } =
-                &mut Self::state_mut(interp, cmd).state
-            {
-                collected.clear();
-                *in_done = false;
-            }
+        // For multi-file mode, advance to the next file.
+        if Self::state_mut(interp, cmd).file_args.is_some() {
+            let ctx = Self::state_mut(interp, cmd).file_args.take().unwrap();
+            Self::state_mut(interp, cmd).state = HeadState::ExecFilepathArgs {
+                args_start: ctx.args_start,
+                idx: ctx.idx,
+                reader: None,
+                collected: Vec::new(),
+                in_done: false,
+            };
             Self::next(interp, cmd)
         } else {
             Builtin::done(interp, cmd, 0)
@@ -290,7 +301,22 @@ impl Head {
         }
         match &Self::state_mut(interp, cmd).state {
             HeadState::WaitingWriteErr => Builtin::done(interp, cmd, 1),
-            HeadState::WaitingWriteOut => Self::advance_or_done(interp, cmd),
+            HeadState::WaitingWriteOut => {
+                // Restore file-args context and advance to next file.
+                if let Some(ctx) = Self::state_mut(interp, cmd).file_args.take() {
+                    Self::state_mut(interp, cmd).state = HeadState::ExecFilepathArgs {
+                        args_start: ctx.args_start,
+                        idx: ctx.idx,
+                        reader: None,
+                        collected: Vec::new(),
+                        in_done: false,
+                    };
+                    Self::next(interp, cmd)
+                } else {
+                    Self::state_mut(interp, cmd).state = HeadState::Done;
+                    Builtin::done(interp, cmd, 0)
+                }
+            }
             _ => Builtin::done(interp, cmd, 0),
         }
     }

--- a/src/runtime/shell/builtin/printenv.rs
+++ b/src/runtime/shell/builtin/printenv.rs
@@ -1,0 +1,115 @@
+use crate::shell::builtin::{Builtin, BuiltinState, IoKind};
+use crate::shell::env_str::EnvStr;
+use crate::shell::interpreter::{Interpreter, NodeId};
+use crate::shell::io_writer::{ChildPtr, WriterTag};
+use crate::shell::yield_::Yield;
+
+#[derive(Default)]
+pub struct Printenv {
+    state: State,
+    buf: Vec<u8>,
+}
+
+#[derive(Default)]
+enum State {
+    #[default]
+    Idle,
+    WaitingIo,
+    Err,
+    Done,
+}
+
+impl Printenv {
+    pub fn start(interp: &Interpreter, cmd: NodeId) -> Yield {
+        let argc = Builtin::of(interp, cmd).args_slice().len();
+
+        // Parse flags — printenv supports -0 / --null (NUL terminator)
+        let mut null_terminate = false;
+        let mut args_start = 0usize;
+        for i in 0..argc {
+            let arg = Builtin::of(interp, cmd).arg_bytes(i);
+            if arg == b"-0" || arg == b"--null" {
+                null_terminate = true;
+                args_start = i + 1;
+            } else if arg == b"--" {
+                args_start = i + 1;
+                break;
+            } else if arg.starts_with(b"-") && arg.len() > 1 {
+                let msg = b"printenv: invalid option\n";
+                let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, msg);
+                return Builtin::done(interp, cmd, 1);
+            } else {
+                args_start = i;
+                break;
+            }
+        }
+
+        let terminator: u8 = if null_terminate { 0 } else { b'\n' };
+        let shell = Builtin::shell(interp, cmd);
+
+        let mut buf = Vec::new();
+        let mut exit_code: u8 = 0;
+
+        if args_start >= argc {
+            // No arguments: print all exported environment variables.
+            // POSIX printenv shows the export environment.
+            for (key, value) in shell.export_env.iter() {
+                buf.extend_from_slice(key.slice());
+                buf.push(b'=');
+                buf.extend_from_slice(value.slice());
+                buf.push(terminator);
+            }
+        } else {
+            // Print specific variable values.
+            for i in args_start..argc {
+                let name = Builtin::of(interp, cmd).arg_bytes(i);
+                let key = EnvStr::init_slice(name);
+                // Check shell_env first (locals), then export_env.
+                let value = shell.shell_env.get(key).or_else(|| {
+                    let key2 = EnvStr::init_slice(name);
+                    shell.export_env.get(key2)
+                });
+                if let Some(val) = value {
+                    buf.extend_from_slice(val.slice());
+                    buf.push(terminator);
+                    val.deref();
+                } else {
+                    exit_code = 1;
+                }
+            }
+        }
+
+        if buf.is_empty() {
+            Self::state_mut(interp, cmd).state = State::Done;
+            return Builtin::done(interp, cmd, exit_code);
+        }
+
+        Self::state_mut(interp, cmd).buf = buf;
+        if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
+            Self::state_mut(interp, cmd).state = State::WaitingIo;
+            let buf_clone = Self::state_mut(interp, cmd).buf.clone();
+            let child = ChildPtr::new(cmd, WriterTag::Builtin);
+            return Builtin::of_mut(interp, cmd)
+                .stdout
+                .enqueue(child, &buf_clone, safeguard);
+        }
+        let out = Self::state_mut(interp, cmd).buf.clone();
+        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &out);
+        Self::state_mut(interp, cmd).state = State::Done;
+        Builtin::done(interp, cmd, exit_code)
+    }
+
+    pub fn on_io_writer_chunk(
+        interp: &Interpreter,
+        cmd: NodeId,
+        _: usize,
+        err: Option<bun_sys::SystemError>,
+    ) -> Yield {
+        if err.is_some() {
+            Self::state_mut(interp, cmd).state = State::Err;
+            return Builtin::done(interp, cmd, 1);
+        }
+        Self::state_mut(interp, cmd).state = State::Done;
+        Builtin::done(interp, cmd, 0)
+    }
+}

--- a/src/runtime/shell/builtin/printenv.rs
+++ b/src/runtime/shell/builtin/printenv.rs
@@ -15,7 +15,7 @@ enum State {
     #[default]
     Idle,
     WaitingIo,
-    Err,
+    WaitingErr,
     Done,
 }
 
@@ -36,6 +36,13 @@ impl Printenv {
                 break;
             } else if arg.starts_with(b"-") && arg.len() > 1 {
                 let msg = b"printenv: invalid option\n";
+                if let Some(safeguard) = Builtin::of(interp, cmd).stderr.needs_io() {
+                    Self::state_mut(interp, cmd).state = State::WaitingErr;
+                    let child = ChildPtr::new(cmd, WriterTag::Builtin);
+                    return Builtin::of_mut(interp, cmd)
+                        .stderr
+                        .enqueue(child, msg, safeguard);
+                }
                 let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, msg);
                 return Builtin::done(interp, cmd, 1);
             } else {
@@ -84,6 +91,9 @@ impl Printenv {
             return Builtin::done(interp, cmd, exit_code);
         }
 
+        // Stash exit_code so on_io_writer_chunk can recover it.
+        Builtin::of_mut(interp, cmd).exit_code = Some(exit_code);
+
         Self::state_mut(interp, cmd).buf = buf;
         if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
             Self::state_mut(interp, cmd).state = State::WaitingIo;
@@ -106,10 +116,15 @@ impl Printenv {
         err: Option<bun_sys::SystemError>,
     ) -> Yield {
         if err.is_some() {
-            Self::state_mut(interp, cmd).state = State::Err;
             return Builtin::done(interp, cmd, 1);
         }
-        Self::state_mut(interp, cmd).state = State::Done;
-        Builtin::done(interp, cmd, 0)
+        match &Self::state_mut(interp, cmd).state {
+            State::WaitingErr => Builtin::done(interp, cmd, 1),
+            _ => {
+                Self::state_mut(interp, cmd).state = State::Done;
+                let exit_code = Builtin::of(interp, cmd).exit_code.unwrap_or(0);
+                Builtin::done(interp, cmd, exit_code)
+            }
+        }
     }
 }

--- a/src/runtime/shell/builtin/realpath.rs
+++ b/src/runtime/shell/builtin/realpath.rs
@@ -1,0 +1,124 @@
+use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
+use crate::shell::interpreter::{Interpreter, NodeId};
+use crate::shell::io_writer::{ChildPtr, WriterTag};
+use crate::shell::yield_::Yield;
+
+#[derive(Default)]
+pub struct Realpath {
+    state: State,
+    buf: Vec<u8>,
+}
+
+#[derive(Default)]
+enum State {
+    #[default]
+    Idle,
+    Err,
+    Done,
+}
+
+impl Realpath {
+    pub fn start(interp: &Interpreter, cmd: NodeId) -> Yield {
+        let argc = Builtin::of(interp, cmd).args_slice().len();
+        if argc == 0 {
+            return Self::fail(interp, cmd, Kind::Realpath.usage_string());
+        }
+
+        let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io();
+        let mut out = Vec::new();
+        let mut exit_code: u8 = 0;
+
+        for i in 0..argc {
+            let path_bytes = Builtin::of(interp, cmd).arg_bytes(i);
+
+            // Build an absolute path by joining the shell's CWD with the
+            // argument when the argument is relative. `bun_sys::realpath`
+            // resolves against the *process* CWD which may differ from the
+            // shell's `cd`-tracked CWD.
+            let mut path_buf = bun_paths::path_buffer_pool::get();
+            let abs_path = if bun_paths::Platform::Auto.is_absolute(path_bytes) {
+                path_bytes
+            } else {
+                let cwd = Builtin::shell(interp, cmd).cwd();
+                let len = cwd.len();
+                path_buf[..len].copy_from_slice(cwd);
+                // Ensure separator between CWD and the relative path.
+                let sep_len = if len > 0 && path_buf[len - 1] != b'/' && path_buf[len - 1] != b'\\' {
+                    path_buf[len] = b'/';
+                    1
+                } else {
+                    0
+                };
+                let rel_len = path_bytes.len();
+                path_buf[len + sep_len..len + sep_len + rel_len].copy_from_slice(path_bytes);
+                path_buf[len + sep_len + rel_len] = 0;
+                &path_buf[..len + sep_len + rel_len]
+            };
+
+            // Build a NUL-terminated version for the syscall.
+            let mut resolve_buf = bun_paths::path_buffer_pool::get();
+            let mut zpath_buf = bun_paths::path_buffer_pool::get();
+            let zpath_len = abs_path.len();
+            zpath_buf[..zpath_len].copy_from_slice(abs_path);
+            zpath_buf[zpath_len] = 0;
+            let zpath = unsafe { bun_core::ZStr::from_ptr(zpath_buf.0.as_ptr().cast()) };
+
+            match bun_sys::realpath(zpath, &mut resolve_buf) {
+                Ok(resolved) => {
+                    out.extend_from_slice(resolved);
+                    out.push(b'\n');
+                }
+                Err(_) => {
+                    // Write error for this specific path, continue processing
+                    // remaining arguments (matching GNU coreutils behavior).
+                    let mut err_msg = Vec::new();
+                    err_msg.extend_from_slice(b"realpath: ");
+                    err_msg.extend_from_slice(path_bytes);
+                    err_msg.extend_from_slice(b": No such file or directory\n");
+                    let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, &err_msg);
+                    exit_code = 1;
+                }
+            }
+        }
+
+        if out.is_empty() {
+            Self::state_mut(interp, cmd).state = State::Done;
+            return Builtin::done(interp, cmd, exit_code);
+        }
+
+        Self::state_mut(interp, cmd).state = State::Done;
+        if let Some(safeguard) = stdout_needs_io {
+            Self::state_mut(interp, cmd).buf = out;
+            let owned = Self::state_mut(interp, cmd).buf.clone();
+            let child = ChildPtr::new(cmd, WriterTag::Builtin);
+            return Builtin::of_mut(interp, cmd)
+                .stdout
+                .enqueue(child, &owned, safeguard);
+        }
+        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &out);
+        Builtin::done(interp, cmd, exit_code)
+    }
+
+    fn fail(interp: &Interpreter, cmd: NodeId, msg: &[u8]) -> Yield {
+        Self::state_mut(interp, cmd).state = State::Err;
+        Builtin::write_failing_error(interp, cmd, msg, 1)
+    }
+
+    pub fn on_io_writer_chunk(
+        interp: &Interpreter,
+        cmd: NodeId,
+        _: usize,
+        err: Option<bun_sys::SystemError>,
+    ) -> Yield {
+        if err.is_some() {
+            Self::state_mut(interp, cmd).state = State::Err;
+            return Builtin::done(interp, cmd, 1);
+        }
+        let exit = match Self::state_mut(interp, cmd).state {
+            State::Done => 0,
+            State::Err => 1,
+            State::Idle => unreachable!("Realpath.onIOWriterChunk: idle"),
+        };
+        Builtin::done(interp, cmd, exit)
+    }
+}

--- a/src/runtime/shell/builtin/realpath.rs
+++ b/src/runtime/shell/builtin/realpath.rs
@@ -86,6 +86,8 @@ impl Realpath {
         }
 
         Self::state_mut(interp, cmd).state = State::Done;
+        // Stash exit_code so on_io_writer_chunk can recover it.
+        Builtin::of_mut(interp, cmd).exit_code = Some(exit_code);
         if let Some(safeguard) = stdout_needs_io {
             let child = ChildPtr::new(cmd, WriterTag::Builtin);
             Self::state_mut(interp, cmd).buf = out;
@@ -114,7 +116,7 @@ impl Realpath {
             return Builtin::done(interp, cmd, 1);
         }
         let exit = match Self::state_mut(interp, cmd).state {
-            State::Done => 0,
+            State::Done => Builtin::of(interp, cmd).exit_code.unwrap_or(0),
             State::Err => 1,
             State::Idle => unreachable!("Realpath.onIOWriterChunk: idle"),
         };

--- a/src/runtime/shell/builtin/realpath.rs
+++ b/src/runtime/shell/builtin/realpath.rs
@@ -51,7 +51,6 @@ impl Realpath {
                 };
                 let rel_len = path_bytes.len();
                 path_buf[len + sep_len..len + sep_len + rel_len].copy_from_slice(path_bytes);
-                path_buf[len + sep_len + rel_len] = 0;
                 &path_buf[..len + sep_len + rel_len]
             };
 
@@ -88,12 +87,12 @@ impl Realpath {
 
         Self::state_mut(interp, cmd).state = State::Done;
         if let Some(safeguard) = stdout_needs_io {
-            Self::state_mut(interp, cmd).buf = out;
-            let owned = Self::state_mut(interp, cmd).buf.clone();
             let child = ChildPtr::new(cmd, WriterTag::Builtin);
+            Self::state_mut(interp, cmd).buf = out;
+            let buf_ref = Self::state_mut(interp, cmd).buf.clone();
             return Builtin::of_mut(interp, cmd)
                 .stdout
-                .enqueue(child, &owned, safeguard);
+                .enqueue(child, &buf_ref, safeguard);
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &out);
         Builtin::done(interp, cmd, exit_code)

--- a/src/runtime/shell/builtin/tail.rs
+++ b/src/runtime/shell/builtin/tail.rs
@@ -1,0 +1,354 @@
+use std::sync::Arc;
+
+use bun_ptr::AsCtxPtr;
+
+use crate::shell::ExitCode;
+use crate::shell::builtin::{Builtin, BuiltinInput, BuiltinState, IoKind, Kind};
+use crate::shell::interpreter::{Interpreter, NodeId, shell_openat};
+use crate::shell::io_reader::{ChildPtr as ReaderChildPtr, IOReader, ReaderTag};
+use crate::shell::io_writer::{ChildPtr, WriterTag};
+use crate::shell::yield_::Yield;
+
+#[derive(Default)]
+pub struct Tail {
+    pub lines: usize,
+    pub state: TailState,
+}
+
+#[derive(Default)]
+pub enum TailState {
+    #[default]
+    Idle,
+    ExecStdin {
+        collected: Vec<u8>,
+        in_done: bool,
+    },
+    ExecFilepathArgs {
+        args_start: usize,
+        idx: usize,
+        reader: Option<Arc<IOReader>>,
+        collected: Vec<u8>,
+        in_done: bool,
+    },
+    WaitingWriteErr,
+    WaitingWriteOut,
+    Done,
+}
+
+impl Tail {
+    pub fn start(interp: &Interpreter, cmd: NodeId) -> Yield {
+        let argc = Builtin::of(interp, cmd).args_slice().len();
+
+        let mut lines: usize = 10;
+        let mut filepath_start: Option<usize> = None;
+        let mut idx = 0usize;
+        while idx < argc {
+            let arg = Builtin::of(interp, cmd).arg_bytes(idx);
+            if arg == b"--" {
+                filepath_start = Some(idx + 1);
+                break;
+            }
+            if arg == b"-n" {
+                idx += 1;
+                if idx >= argc {
+                    return Self::fail(interp, cmd, b"tail: option requires an argument -- n\n");
+                }
+                let val = Builtin::of(interp, cmd).arg_bytes(idx);
+                match parse_usize(val) {
+                    Some(n) => lines = n,
+                    None => {
+                        return Self::fail(interp, cmd, b"tail: invalid number of lines\n");
+                    }
+                }
+                idx += 1;
+                continue;
+            }
+            if arg.starts_with(b"-n") && arg.len() > 2 {
+                match parse_usize(&arg[2..]) {
+                    Some(n) => lines = n,
+                    None => {
+                        return Self::fail(interp, cmd, b"tail: invalid number of lines\n");
+                    }
+                }
+                idx += 1;
+                continue;
+            }
+            if arg.starts_with(b"--lines=") && arg.len() > 8 {
+                match parse_usize(&arg[8..]) {
+                    Some(n) => lines = n,
+                    None => {
+                        return Self::fail(interp, cmd, b"tail: invalid number of lines\n");
+                    }
+                }
+                idx += 1;
+                continue;
+            }
+            if arg.starts_with(b"-") && arg.len() > 1 {
+                if let Some(n) = parse_usize(&arg[1..]) {
+                    lines = n;
+                    idx += 1;
+                    continue;
+                }
+                return Self::fail(interp, cmd, b"tail: invalid option\n");
+            }
+            filepath_start = Some(idx);
+            break;
+        }
+
+        Self::state_mut(interp, cmd).lines = lines;
+
+        let has_files = filepath_start.is_some() && filepath_start.unwrap() < argc;
+
+        Self::state_mut(interp, cmd).state = if has_files {
+            TailState::ExecFilepathArgs {
+                args_start: filepath_start.unwrap(),
+                idx: 0,
+                reader: None,
+                collected: Vec::new(),
+                in_done: false,
+            }
+        } else {
+            TailState::ExecStdin {
+                collected: Vec::new(),
+                in_done: false,
+            }
+        };
+
+        Self::next(interp, cmd)
+    }
+
+    pub fn next(interp: &Interpreter, cmd: NodeId) -> Yield {
+        enum Branch {
+            Stdin,
+            FileArg { args_start: usize, idx: usize },
+            WaitingErr,
+            WaitingOut,
+            Done,
+        }
+        let branch = match &Self::state_mut(interp, cmd).state {
+            TailState::Idle => panic!("Invalid state"),
+            TailState::ExecStdin { .. } => Branch::Stdin,
+            TailState::ExecFilepathArgs {
+                args_start, idx, ..
+            } => Branch::FileArg {
+                args_start: *args_start,
+                idx: *idx,
+            },
+            TailState::WaitingWriteErr => Branch::WaitingErr,
+            TailState::WaitingWriteOut => Branch::WaitingOut,
+            TailState::Done => Branch::Done,
+        };
+        match branch {
+            Branch::Stdin => {
+                let stdin_needs_io = Builtin::of(interp, cmd).stdin.needs_io();
+                if !stdin_needs_io {
+                    let buf = Builtin::read_stdin_no_io(interp, cmd).to_vec();
+                    let n = Self::state_mut(interp, cmd).lines;
+                    let output = last_n_lines(&buf, n);
+                    return Self::write_output(interp, cmd, output);
+                }
+                let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
+                let reader = match &Builtin::of(interp, cmd).stdin {
+                    BuiltinInput::Fd(r) => r.clone(),
+                    _ => unreachable!("needs_io() returned true"),
+                };
+                reader.set_interp(interp_ptr);
+                reader.add_reader(ReaderChildPtr {
+                    node: cmd,
+                    tag: ReaderTag::Tail,
+                });
+                reader.start()
+            }
+            Branch::FileArg { args_start, idx } => {
+                let argc = Builtin::of(interp, cmd).args_slice().len();
+                let n_files = argc - args_start;
+                if idx >= n_files {
+                    if let TailState::ExecFilepathArgs { reader, .. } =
+                        &mut Self::state_mut(interp, cmd).state
+                    {
+                        *reader = None;
+                    }
+                    return Builtin::done(interp, cmd, 0);
+                }
+                if let TailState::ExecFilepathArgs { reader, .. } =
+                    &mut Self::state_mut(interp, cmd).state
+                {
+                    *reader = None;
+                }
+
+                let path = Builtin::of(interp, cmd).arg_zstr(args_start + idx);
+
+                if let TailState::ExecFilepathArgs { idx: i, .. } =
+                    &mut Self::state_mut(interp, cmd).state
+                {
+                    *i += 1;
+                }
+
+                let dir = Builtin::cwd(interp, cmd);
+                let fd = match shell_openat(dir, path, bun_sys::O::RDONLY, 0) {
+                    Ok(fd) => fd,
+                    Err(e) => {
+                        let buf =
+                            Builtin::task_error_to_string(interp, cmd, Kind::Tail, &e).to_vec();
+                        return Self::write_failing_error(interp, cmd, &buf, 1);
+                    }
+                };
+
+                let evtloop = Builtin::event_loop(interp, cmd);
+                let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
+                let reader = IOReader::init(fd, evtloop);
+                reader.set_interp(interp_ptr);
+                if let TailState::ExecFilepathArgs {
+                    reader: slot,
+                    in_done,
+                    collected,
+                    ..
+                } = &mut Self::state_mut(interp, cmd).state
+                {
+                    *in_done = false;
+                    collected.clear();
+                    *slot = Some(reader.clone());
+                }
+                reader.add_reader(ReaderChildPtr {
+                    node: cmd,
+                    tag: ReaderTag::Tail,
+                });
+                reader.start()
+            }
+            Branch::WaitingErr => Yield::failed(),
+            Branch::WaitingOut => Yield::suspended(),
+            Branch::Done => Builtin::done(interp, cmd, 0),
+        }
+    }
+
+    fn fail(interp: &Interpreter, cmd: NodeId, msg: &[u8]) -> Yield {
+        Self::state_mut(interp, cmd).state = TailState::WaitingWriteErr;
+        Builtin::write_failing_error(interp, cmd, msg, 1)
+    }
+
+    fn write_failing_error(
+        interp: &Interpreter,
+        cmd: NodeId,
+        buf: &[u8],
+        exit_code: ExitCode,
+    ) -> Yield {
+        if let Some(safeguard) = Builtin::of(interp, cmd).stderr.needs_io() {
+            Self::state_mut(interp, cmd).state = TailState::WaitingWriteErr;
+            let child = ChildPtr::new(cmd, WriterTag::Builtin);
+            return Builtin::of_mut(interp, cmd)
+                .stderr
+                .enqueue(child, buf, safeguard);
+        }
+        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, buf);
+        Builtin::done(interp, cmd, exit_code)
+    }
+
+    fn write_output(interp: &Interpreter, cmd: NodeId, output: Vec<u8>) -> Yield {
+        if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
+            Self::state_mut(interp, cmd).state = TailState::WaitingWriteOut;
+            let child = ChildPtr::new(cmd, WriterTag::Builtin);
+            return Builtin::of_mut(interp, cmd)
+                .stdout
+                .enqueue(child, &output, safeguard);
+        }
+        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &output);
+        Builtin::done(interp, cmd, 0)
+    }
+
+    pub fn on_io_writer_chunk(
+        interp: &Interpreter,
+        cmd: NodeId,
+        _: usize,
+        err: Option<bun_sys::SystemError>,
+    ) -> Yield {
+        if err.is_some() {
+            return Builtin::done(interp, cmd, 1);
+        }
+        match &Self::state_mut(interp, cmd).state {
+            TailState::WaitingWriteErr => Builtin::done(interp, cmd, 1),
+            TailState::WaitingWriteOut => {
+                Self::state_mut(interp, cmd).state = TailState::Done;
+                Builtin::done(interp, cmd, 0)
+            }
+            _ => Builtin::done(interp, cmd, 0),
+        }
+    }
+
+    pub fn on_io_reader_chunk(
+        interp: &Interpreter,
+        cmd: NodeId,
+        chunk: &[u8],
+        remove: &mut bool,
+    ) -> Yield {
+        *remove = false;
+        // For tail we must collect all data since we need the last N lines.
+        match &mut Self::state_mut(interp, cmd).state {
+            TailState::ExecStdin { collected, .. }
+            | TailState::ExecFilepathArgs { collected, .. } => {
+                collected.extend_from_slice(chunk);
+            }
+            _ => panic!("Invalid state"),
+        }
+        Yield::done()
+    }
+
+    pub fn on_io_reader_done(
+        interp: &Interpreter,
+        cmd: NodeId,
+        err: Option<bun_sys::SystemError>,
+    ) -> Yield {
+        if let Some(e) = err {
+            let errno = e.get_errno() as ExitCode;
+            e.deref();
+            return Builtin::done(interp, cmd, errno);
+        }
+
+        let n = Self::state_mut(interp, cmd).lines;
+
+        let output = match &mut Self::state_mut(interp, cmd).state {
+            TailState::ExecStdin { collected, in_done, .. } => {
+                *in_done = true;
+                last_n_lines(collected, n)
+            }
+            TailState::ExecFilepathArgs { collected, in_done, .. } => {
+                *in_done = true;
+                last_n_lines(collected, n)
+            }
+            _ => return Builtin::done(interp, cmd, 0),
+        };
+
+        Self::write_output(interp, cmd, output)
+    }
+}
+
+/// Extract the last `n` lines from `data`.
+fn last_n_lines(data: &[u8], n: usize) -> Vec<u8> {
+    if n == 0 || data.is_empty() {
+        return Vec::new();
+    }
+
+    let mut count = 0;
+    // If data ends with a newline, don't count it as starting a new line.
+    let search_end = if data.last() == Some(&b'\n') {
+        data.len() - 1
+    } else {
+        data.len()
+    };
+
+    for i in (0..search_end).rev() {
+        if data[i] == b'\n' {
+            count += 1;
+            if count >= n {
+                return data[i + 1..].to_vec();
+            }
+        }
+    }
+
+    // Fewer than n lines — return everything.
+    data.to_vec()
+}
+
+fn parse_usize(bytes: &[u8]) -> Option<usize> {
+    let s = core::str::from_utf8(bytes).ok()?;
+    s.parse().ok()
+}

--- a/src/runtime/shell/builtin/tail.rs
+++ b/src/runtime/shell/builtin/tail.rs
@@ -13,6 +13,13 @@ use crate::shell::yield_::Yield;
 pub struct Tail {
     pub lines: usize,
     pub state: TailState,
+    /// Saved file-args context for resuming after async write.
+    pub file_args: Option<FileArgsCtx>,
+}
+
+pub struct FileArgsCtx {
+    pub args_start: usize,
+    pub idx: usize,
 }
 
 #[derive(Default)]
@@ -244,6 +251,16 @@ impl Tail {
     }
 
     fn write_output(interp: &Interpreter, cmd: NodeId, output: Vec<u8>) -> Yield {
+        // Save file-args context before transitioning state.
+        if let TailState::ExecFilepathArgs { args_start, idx, .. } =
+            &Self::state_mut(interp, cmd).state
+        {
+            Self::state_mut(interp, cmd).file_args = Some(FileArgsCtx {
+                args_start: *args_start,
+                idx: *idx,
+            });
+        }
+
         if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
             Self::state_mut(interp, cmd).state = TailState::WaitingWriteOut;
             let child = ChildPtr::new(cmd, WriterTag::Builtin);
@@ -252,21 +269,16 @@ impl Tail {
                 .enqueue(child, &output, safeguard);
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &output);
-        Self::advance_or_done(interp, cmd)
-    }
 
-    fn advance_or_done(interp: &Interpreter, cmd: NodeId) -> Yield {
-        let is_file_args = matches!(
-            &Self::state_mut(interp, cmd).state,
-            TailState::ExecFilepathArgs { .. } | TailState::WaitingWriteOut
-        );
-        if is_file_args {
-            if let TailState::ExecFilepathArgs { collected, in_done, .. } =
-                &mut Self::state_mut(interp, cmd).state
-            {
-                collected.clear();
-                *in_done = false;
-            }
+        if Self::state_mut(interp, cmd).file_args.is_some() {
+            let ctx = Self::state_mut(interp, cmd).file_args.take().unwrap();
+            Self::state_mut(interp, cmd).state = TailState::ExecFilepathArgs {
+                args_start: ctx.args_start,
+                idx: ctx.idx,
+                reader: None,
+                collected: Vec::new(),
+                in_done: false,
+            };
             Self::next(interp, cmd)
         } else {
             Builtin::done(interp, cmd, 0)
@@ -284,7 +296,21 @@ impl Tail {
         }
         match &Self::state_mut(interp, cmd).state {
             TailState::WaitingWriteErr => Builtin::done(interp, cmd, 1),
-            TailState::WaitingWriteOut => Self::advance_or_done(interp, cmd),
+            TailState::WaitingWriteOut => {
+                if let Some(ctx) = Self::state_mut(interp, cmd).file_args.take() {
+                    Self::state_mut(interp, cmd).state = TailState::ExecFilepathArgs {
+                        args_start: ctx.args_start,
+                        idx: ctx.idx,
+                        reader: None,
+                        collected: Vec::new(),
+                        in_done: false,
+                    };
+                    Self::next(interp, cmd)
+                } else {
+                    Self::state_mut(interp, cmd).state = TailState::Done;
+                    Builtin::done(interp, cmd, 0)
+                }
+            }
             _ => Builtin::done(interp, cmd, 0),
         }
     }

--- a/src/runtime/shell/builtin/tail.rs
+++ b/src/runtime/shell/builtin/tail.rs
@@ -252,7 +252,25 @@ impl Tail {
                 .enqueue(child, &output, safeguard);
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &output);
-        Builtin::done(interp, cmd, 0)
+        Self::advance_or_done(interp, cmd)
+    }
+
+    fn advance_or_done(interp: &Interpreter, cmd: NodeId) -> Yield {
+        let is_file_args = matches!(
+            &Self::state_mut(interp, cmd).state,
+            TailState::ExecFilepathArgs { .. } | TailState::WaitingWriteOut
+        );
+        if is_file_args {
+            if let TailState::ExecFilepathArgs { collected, in_done, .. } =
+                &mut Self::state_mut(interp, cmd).state
+            {
+                collected.clear();
+                *in_done = false;
+            }
+            Self::next(interp, cmd)
+        } else {
+            Builtin::done(interp, cmd, 0)
+        }
     }
 
     pub fn on_io_writer_chunk(
@@ -266,10 +284,7 @@ impl Tail {
         }
         match &Self::state_mut(interp, cmd).state {
             TailState::WaitingWriteErr => Builtin::done(interp, cmd, 1),
-            TailState::WaitingWriteOut => {
-                Self::state_mut(interp, cmd).state = TailState::Done;
-                Builtin::done(interp, cmd, 0)
-            }
+            TailState::WaitingWriteOut => Self::advance_or_done(interp, cmd),
             _ => Builtin::done(interp, cmd, 0),
         }
     }

--- a/src/runtime/shell/mod.rs
+++ b/src/runtime/shell/mod.rs
@@ -117,6 +117,14 @@ pub mod builtins {
     pub mod which;
     #[path = "yes.rs"]
     pub mod yes;
+    #[path = "head.rs"]
+    pub mod head;
+    #[path = "tail.rs"]
+    pub mod tail;
+    #[path = "printenv.rs"]
+    pub mod printenv;
+    #[path = "realpath.rs"]
+    pub mod realpath;
 }
 
 // ─── re-exports ──────────────────────────────────────────────────────────────

--- a/test/js/bun/shell/commands/head.test.ts
+++ b/test/js/bun/shell/commands/head.test.ts
@@ -40,7 +40,7 @@ describe("head", async () => {
     .runAsTest("-nN combined");
 });
 
-describe("head without stdout", async () => {
+describe("head in command substitution", async () => {
   TestBuilder.command`echo $(echo -e "line1\nline2\nline3" | head -n 1)`
     .exitCode(0)
     .stdout("line1\n")

--- a/test/js/bun/shell/commands/head.test.ts
+++ b/test/js/bun/shell/commands/head.test.ts
@@ -1,0 +1,49 @@
+import { describe } from "bun:test";
+import { createTestBuilder } from "../test_builder";
+const TestBuilder = createTestBuilder(import.meta.path);
+
+describe("head", async () => {
+  TestBuilder.command`echo -e "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11\nline12" | head`
+    .exitCode(0)
+    .stdout("line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n")
+    .stderr("")
+    .runAsTest("default 10 lines from pipe");
+
+  TestBuilder.command`echo -e "line1\nline2\nline3\nline4\nline5" | head -n 3`
+    .exitCode(0)
+    .stdout("line1\nline2\nline3\n")
+    .stderr("")
+    .runAsTest("-n flag limits lines");
+
+  TestBuilder.command`echo -e "line1\nline2\nline3" | head -n 10`
+    .exitCode(0)
+    .stdout("line1\nline2\nline3\n")
+    .stderr("")
+    .runAsTest("fewer lines than requested");
+
+  TestBuilder.command`echo -e "line1\nline2\nline3" | head -n 0`
+    .exitCode(0)
+    .stdout("")
+    .stderr("")
+    .runAsTest("-n 0 outputs nothing");
+
+  TestBuilder.command`echo -e "line1\nline2\nline3\nline4\nline5" | head -3`
+    .exitCode(0)
+    .stdout("line1\nline2\nline3\n")
+    .stderr("")
+    .runAsTest("-N shorthand");
+
+  TestBuilder.command`echo -e "line1\nline2\nline3\nline4\nline5" | head -n2`
+    .exitCode(0)
+    .stdout("line1\nline2\n")
+    .stderr("")
+    .runAsTest("-nN combined");
+});
+
+describe("head without stdout", async () => {
+  TestBuilder.command`echo $(echo -e "line1\nline2\nline3" | head -n 1)`
+    .exitCode(0)
+    .stdout("line1\n")
+    .stderr("")
+    .runAsTest("head in command substitution");
+});

--- a/test/js/bun/shell/commands/printenv.test.ts
+++ b/test/js/bun/shell/commands/printenv.test.ts
@@ -1,0 +1,37 @@
+import { describe } from "bun:test";
+import { createTestBuilder } from "../test_builder";
+const TestBuilder = createTestBuilder(import.meta.path);
+
+describe("printenv", async () => {
+  TestBuilder.command`FOO=bar printenv FOO`
+    .exitCode(0)
+    .stdout("bar\n")
+    .stderr("")
+    .runAsTest("prints specific variable");
+
+  TestBuilder.command`printenv NONEXISTENT_VAR_12345`
+    .exitCode(1)
+    .stdout("")
+    .stderr("")
+    .runAsTest("exits 1 for missing variable");
+
+  TestBuilder.command`FOO=hello BAR=world printenv FOO BAR`
+    .exitCode(0)
+    .stdout("hello\nworld\n")
+    .stderr("")
+    .runAsTest("prints multiple variables");
+
+  TestBuilder.command`export MY_TEST_VAR=exported; printenv MY_TEST_VAR`
+    .exitCode(0)
+    .stdout("exported\n")
+    .stderr("")
+    .runAsTest("prints exported variable");
+});
+
+describe("printenv without stdout", async () => {
+  TestBuilder.command`FOO=test123 echo $(printenv FOO)`
+    .exitCode(0)
+    .stdout("test123\n")
+    .stderr("")
+    .runAsTest("printenv in command substitution");
+});

--- a/test/js/bun/shell/commands/realpath.test.ts
+++ b/test/js/bun/shell/commands/realpath.test.ts
@@ -1,0 +1,42 @@
+import { describe } from "bun:test";
+import { createTestBuilder } from "../test_builder";
+const TestBuilder = createTestBuilder(import.meta.path);
+
+describe("realpath", async () => {
+  TestBuilder.command`realpath .`
+    .exitCode(0)
+    .stdout((stdout) => {
+      // Should output an absolute path ending with newline
+      const trimmed = stdout.trim();
+      if (trimmed.length === 0) throw new Error("Expected non-empty output");
+      if (process.platform === "win32") {
+        // Windows absolute paths start with a drive letter
+        if (!/^[A-Za-z]:/.test(trimmed)) throw new Error("Expected absolute path on Windows");
+      } else {
+        if (!trimmed.startsWith("/")) throw new Error("Expected absolute path");
+      }
+    })
+    .stderr("")
+    .runAsTest("resolves current directory");
+
+  TestBuilder.command`realpath`
+    .exitCode(1)
+    .stdout("")
+    .runAsTest("shows usage with no args");
+
+  TestBuilder.command`realpath /nonexistent_path_12345`
+    .exitCode(1)
+    .stdout("")
+    .runAsTest("errors on nonexistent path");
+});
+
+describe("realpath without stdout", async () => {
+  TestBuilder.command`echo $(realpath .)`
+    .exitCode(0)
+    .stdout((stdout) => {
+      const trimmed = stdout.trim();
+      if (trimmed.length === 0) throw new Error("Expected non-empty output");
+    })
+    .stderr("")
+    .runAsTest("realpath in command substitution");
+});

--- a/test/js/bun/shell/commands/realpath.test.ts
+++ b/test/js/bun/shell/commands/realpath.test.ts
@@ -22,15 +22,21 @@ describe("realpath", async () => {
   TestBuilder.command`realpath`
     .exitCode(1)
     .stdout("")
+    .stderr((stderr) => {
+      if (!stderr.includes("usage:")) throw new Error("Expected usage message on stderr");
+    })
     .runAsTest("shows usage with no args");
 
   TestBuilder.command`realpath /nonexistent_path_12345`
     .exitCode(1)
     .stdout("")
+    .stderr((stderr) => {
+      if (!stderr.includes("realpath:")) throw new Error("Expected error message on stderr");
+    })
     .runAsTest("errors on nonexistent path");
 });
 
-describe("realpath without stdout", async () => {
+describe("realpath in command substitution", async () => {
   TestBuilder.command`echo $(realpath .)`
     .exitCode(0)
     .stdout((stdout) => {

--- a/test/js/bun/shell/commands/tail.test.ts
+++ b/test/js/bun/shell/commands/tail.test.ts
@@ -40,7 +40,7 @@ describe("tail", async () => {
     .runAsTest("-nN combined");
 });
 
-describe("tail without stdout", async () => {
+describe("tail in command substitution", async () => {
   TestBuilder.command`echo $(echo -e "line1\nline2\nline3" | tail -n 1)`
     .exitCode(0)
     .stdout("line3\n")

--- a/test/js/bun/shell/commands/tail.test.ts
+++ b/test/js/bun/shell/commands/tail.test.ts
@@ -1,0 +1,49 @@
+import { describe } from "bun:test";
+import { createTestBuilder } from "../test_builder";
+const TestBuilder = createTestBuilder(import.meta.path);
+
+describe("tail", async () => {
+  TestBuilder.command`echo -e "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11\nline12" | tail`
+    .exitCode(0)
+    .stdout("line3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11\nline12\n")
+    .stderr("")
+    .runAsTest("default 10 lines from pipe");
+
+  TestBuilder.command`echo -e "line1\nline2\nline3\nline4\nline5" | tail -n 3`
+    .exitCode(0)
+    .stdout("line3\nline4\nline5\n")
+    .stderr("")
+    .runAsTest("-n flag limits lines");
+
+  TestBuilder.command`echo -e "line1\nline2\nline3" | tail -n 10`
+    .exitCode(0)
+    .stdout("line1\nline2\nline3\n")
+    .stderr("")
+    .runAsTest("fewer lines than requested");
+
+  TestBuilder.command`echo -e "line1\nline2\nline3" | tail -n 0`
+    .exitCode(0)
+    .stdout("")
+    .stderr("")
+    .runAsTest("-n 0 outputs nothing");
+
+  TestBuilder.command`echo -e "line1\nline2\nline3\nline4\nline5" | tail -n 1`
+    .exitCode(0)
+    .stdout("line5\n")
+    .stderr("")
+    .runAsTest("-n 1 outputs last line");
+
+  TestBuilder.command`echo -e "line1\nline2\nline3\nline4\nline5" | tail -n2`
+    .exitCode(0)
+    .stdout("line4\nline5\n")
+    .stderr("")
+    .runAsTest("-nN combined");
+});
+
+describe("tail without stdout", async () => {
+  TestBuilder.command`echo $(echo -e "line1\nline2\nline3" | tail -n 1)`
+    .exitCode(0)
+    .stdout("line3\n")
+    .stderr("")
+    .runAsTest("tail in command substitution");
+});


### PR DESCRIPTION
## Summary

- Implement four new shell builtin commands from the [#9716 tracking checklist](https://github.com/oven-sh/bun/issues/9716):
  - **`head [-n count] [file ...]`** — output first N lines (default 10), supports piped stdin via IOReader
  - **`tail [-n count] [file ...]`** — output last N lines (default 10), supports piped stdin via IOReader
  - **`printenv [-0|--null] [name ...]`** — print environment variables (export env by default, or specific named vars)
  - **`realpath [file ...]`** — resolve paths to absolute canonical form using `bun_sys::realpath`, handles shell CWD correctly for relative paths
- All four follow the existing builtin patterns (`Builtin.rs` macro, `BuiltinState` trait, borrowck-safe state machines)
- `head` and `tail` add `ReaderTag::Head` / `ReaderTag::Tail` to `IOReader.rs` for async pipe/stdin reading
- Especially valuable on Windows where system equivalents may not exist

## Test plan

- [ ] `bun bd test test/js/bun/shell/commands/head.test.ts` — default 10 lines, `-n` flag, `-N` shorthand, fewer-than-N, pipe input, command substitution
- [ ] `bun bd test test/js/bun/shell/commands/tail.test.ts` — default 10 lines, `-n` flag, last-1-line, fewer-than-N, pipe input, command substitution
- [ ] `bun bd test test/js/bun/shell/commands/printenv.test.ts` — specific variable, missing variable (exit 1), multiple variables, exported variable, command substitution
- [ ] `bun bd test test/js/bun/shell/commands/realpath.test.ts` — current directory, no-args usage error, nonexistent path error, command substitution

🤖 Generated with [Claude Code](https://claude.com/claude-code)