### PR TITLE
refactor: fix non-idiomatic boolean comparisons from Zig port

### DIFF
--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -1454,7 +1454,7 @@ fn get_bundled_deps(
                 let Some(b) = bundled_deps.as_bool() else {
                     return Ok(Some(Vec::new()));
                 };
-                if !b == true {
+                if !b {
                     return Ok(Some(Vec::new()));
                 }
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2301,7 +2301,7 @@ impl BlobExt for Blob {
                 if let store::Data::File(file) =
                     &self.store().expect("infallible: store present").data
                 {
-                    if file.seekable.unwrap_or(true) == false && file.max_size == MAX_SIZE {
+                    if !file.seekable.unwrap_or(true) && file.max_size == MAX_SIZE {
                         return JSValue::js_number(f64::INFINITY);
                     }
                 }


### PR DESCRIPTION
## Summary

- Fix two non-idiomatic boolean comparison patterns left over from the Zig-to-Rust port:
  - `Blob.rs:2304`: `file.seekable.unwrap_or(true) == false` → `!file.seekable.unwrap_or(true)`
  - `pack_command.rs:1457`: `!b == true` → `!b`
- Similar in spirit to #30867 (remove unsafe for static strings) — mechanical cleanup of port artifacts

## Test plan

- [ ] No behavioral change — purely cosmetic refactor
- [ ] Existing tests should continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)