### PR TITLE
install: reuse existing folder/tarball entry in package.json

### DIFF
--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -720,8 +720,22 @@ pub fn edit(
                                 }
                                 break;
                             } else {
-                                if request.version.tag == dependency::Tag::Github
-                                    || request.version.tag == dependency::Tag::Git
+                                // For non-aliased positionals where `get_name()` returns the
+                                // version literal (path/URL) rather than the resolved package
+                                // name — github/git/tarball URLs and local folder/tarball
+                                // paths — fall back to matching by the stored value so a
+                                // re-run doesn't append a duplicate `"<name>": "<literal>"`
+                                // key. Skipped when the user wrote `alias@url`: that form is
+                                // an explicit request to key by `alias`, so consolidating into
+                                // an existing entry under a different name would silently drop
+                                // the alias. `e_string.is_none()` guards so a match in an
+                                // earlier dependency list isn't re-counted across iterations.
+                                if request.e_string.is_none()
+                                    && !request.is_aliased
+                                    && (request.version.tag == dependency::Tag::Github
+                                        || request.version.tag == dependency::Tag::Git
+                                        || request.version.tag == dependency::Tag::Tarball
+                                        || request.version.tag == dependency::Tag::Folder)
                                 {
                                     for item in query
                                         .expr

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -722,7 +722,7 @@ pub fn edit(
                             } else {
                                 // For non-aliased positionals where `get_name()` returns the
                                 // version literal (path/URL) rather than the resolved package
-                                // name — github/git/tarball URLs and local folder/tarball
+                                // name — github/git/tarball URLs and local folder/tarball/link
                                 // paths — fall back to matching by the stored value so a
                                 // re-run doesn't append a duplicate `"<name>": "<literal>"`
                                 // key. Skipped when the user wrote `alias@url`: that form is
@@ -735,7 +735,8 @@ pub fn edit(
                                     && (request.version.tag == dependency::Tag::Github
                                         || request.version.tag == dependency::Tag::Git
                                         || request.version.tag == dependency::Tag::Tarball
-                                        || request.version.tag == dependency::Tag::Folder)
+                                        || request.version.tag == dependency::Tag::Folder
+                                        || request.version.tag == dependency::Tag::Symlink)
                                 {
                                     for item in query
                                         .expr

--- a/src/install/PackageManager/PackageJSONEditor.zig
+++ b/src/install/PackageManager/PackageJSONEditor.zig
@@ -459,7 +459,9 @@ pub fn edit(
                                 }
                                 break;
                             } else {
-                                if (request.version.tag == .github or request.version.tag == .git) {
+                                if (request.e_string == null and !request.is_aliased and
+                                    (request.version.tag == .github or request.version.tag == .git or request.version.tag == .tarball or request.version.tag == .folder))
+                                {
                                     for (query.expr.data.e_object.properties.slice()) |item| {
                                         if (item.value) |v| {
                                             const url = request.version.literal.slice(request.version_buf);

--- a/src/install/PackageManager/PackageJSONEditor.zig
+++ b/src/install/PackageManager/PackageJSONEditor.zig
@@ -460,7 +460,7 @@ pub fn edit(
                                 break;
                             } else {
                                 if (request.e_string == null and !request.is_aliased and
-                                    (request.version.tag == .github or request.version.tag == .git or request.version.tag == .tarball or request.version.tag == .folder))
+                                    (request.version.tag == .github or request.version.tag == .git or request.version.tag == .tarball or request.version.tag == .folder or request.version.tag == .symlink))
                                 {
                                     for (query.expr.data.e_object.properties.slice()) |item| {
                                         if (item.value) |v| {

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2351,7 +2351,7 @@ it("should not add duplicate package.json entries when installing the same local
 
   // 1st run — clean, adds one entry keyed by the resolved package name.
   {
-    const { stderr, exited } = spawn({
+    const { stdout, stderr, exited } = spawn({
       cmd: [bunExe(), "add", local_path],
       cwd: package_dir,
       stdout: "pipe",
@@ -2362,12 +2362,14 @@ it("should not add duplicate package.json entries when installing the same local
     const err = await stderr.text();
     expect(err).not.toContain("error:");
     expect(err).toContain("Saved lockfile");
+    const out = await stdout.text();
+    expect(out).toContain("installed myproject@");
     expect(await exited).toBe(0);
   }
 
   // 2nd run with the same path — must reuse the existing "myproject" key, not append a duplicate.
   {
-    const { stderr, exited } = spawn({
+    const { stdout, stderr, exited } = spawn({
       cmd: [bunExe(), "add", local_path],
       cwd: package_dir,
       stdout: "pipe",
@@ -2377,6 +2379,8 @@ it("should not add duplicate package.json entries when installing the same local
     });
     const err = await stderr.text();
     expect(err).not.toContain("error:");
+    const out = await stdout.text();
+    expect(out).toContain("installed myproject@");
     expect(await exited).toBe(0);
   }
 
@@ -2411,7 +2415,7 @@ it("should not add duplicate package.json entries when installing the same tarba
 
   // First install — key should be the package name from the tarball ("baz").
   {
-    const { stderr, exited } = spawn({
+    const { stdout, stderr, exited } = spawn({
       cmd: [bunExe(), "add", tarball_url],
       cwd: package_dir,
       stdout: "pipe",
@@ -2419,7 +2423,10 @@ it("should not add duplicate package.json entries when installing the same tarba
       stderr: "pipe",
       env,
     });
-    expect(await stderr.text()).toContain("Saved lockfile");
+    const err = await stderr.text();
+    expect(err).toContain("Saved lockfile");
+    const out = await stdout.text();
+    expect(out).toContain("installed baz@");
     expect(await exited).toBe(0);
   }
   expect(await file(join(package_dir, "package.json")).json()).toStrictEqual({
@@ -2432,7 +2439,7 @@ it("should not add duplicate package.json entries when installing the same tarba
 
   // Second install with the same URL — must not duplicate the "baz" key.
   {
-    const { stderr, exited } = spawn({
+    const { stdout, stderr, exited } = spawn({
       cmd: [bunExe(), "add", tarball_url],
       cwd: package_dir,
       stdout: "pipe",
@@ -2442,6 +2449,8 @@ it("should not add duplicate package.json entries when installing the same tarba
     });
     const err = await stderr.text();
     expect(err).not.toContain("error:");
+    const out = await stdout.text();
+    expect(out).toContain("installed baz@");
     expect(await exited).toBe(0);
   }
 

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2347,7 +2347,10 @@ it("should not add duplicate package.json entries when installing the same local
   );
 
   // The positional is the absolute path; parse_with_optional_tag will tag this as `.folder`.
+  // `bun add` normalises backslashes to forward slashes before writing package.json,
+  // so the stored literal uses `/` on Windows too.
   const local_path = resolve(dep_dir);
+  const stored_path = local_path.replace(/\\/g, "/");
 
   // 1st run — clean, adds one entry keyed by the resolved package name.
   {
@@ -2391,7 +2394,7 @@ it("should not add duplicate package.json entries when installing the same local
     name: "host",
     version: "0.0.1",
     dependencies: {
-      myproject: local_path,
+      myproject: stored_path,
     },
   });
 });

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2325,18 +2325,16 @@ it("should add local tarball dependency", async () => {
 
 it("should not add duplicate package.json entries when installing the same local folder twice (#30933)", async () => {
   setHandler(dummyRegistry([]));
-  // A local dependency to install — uses a sibling dir so the path survives `bun add`.
-  const dep_dir = join(package_dir, "..", "myproject");
-  await mkdir(dep_dir, { recursive: true });
+  // `add_dir` is a fresh tmpdir created in beforeEach; use it as the local dep source.
   await writeFile(
-    join(dep_dir, "package.json"),
+    join(add_dir, "package.json"),
     JSON.stringify({
       name: "myproject",
       version: "1.0.0",
       bin: { myproject: "./index.js" },
     }),
   );
-  await writeFile(join(dep_dir, "index.js"), 'console.log("hi")');
+  await writeFile(join(add_dir, "index.js"), 'console.log("hi")');
 
   await writeFile(
     join(package_dir, "package.json"),
@@ -2349,7 +2347,7 @@ it("should not add duplicate package.json entries when installing the same local
   // The positional is the absolute path; parse_with_optional_tag will tag this as `.folder`.
   // `bun add` normalises backslashes to forward slashes before writing package.json,
   // so the stored literal uses `/` on Windows too.
-  const local_path = resolve(dep_dir);
+  const local_path = resolve(add_dir);
   const stored_path = local_path.replace(/\\/g, "/");
 
   // 1st run — clean, adds one entry keyed by the resolved package name.
@@ -2382,6 +2380,8 @@ it("should not add duplicate package.json entries when installing the same local
     });
     const err = await stderr.text();
     expect(err).not.toContain("error:");
+    // The meta-hash didn't change, but `bun add` re-saves every time.
+    expect(err).toContain("Saved lockfile");
     const out = await stdout.text();
     expect(out).toContain("installed myproject@");
     expect(await exited).toBe(0);
@@ -2452,6 +2452,8 @@ it("should not add duplicate package.json entries when installing the same tarba
     });
     const err = await stderr.text();
     expect(err).not.toContain("error:");
+    // The meta-hash didn't change, but `bun add` re-saves every time.
+    expect(err).toContain("Saved lockfile");
     const out = await stdout.text();
     expect(out).toContain("installed baz@");
     expect(await exited).toBe(0);

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2323,6 +2323,139 @@ it("should add local tarball dependency", async () => {
     await access(join(package_dir, "bun.lockb")));
 });
 
+it("should not add duplicate package.json entries when installing the same local folder twice (#30933)", async () => {
+  setHandler(dummyRegistry([]));
+  // A local dependency to install — uses a sibling dir so the path survives `bun add`.
+  const dep_dir = join(package_dir, "..", "myproject");
+  await mkdir(dep_dir, { recursive: true });
+  await writeFile(
+    join(dep_dir, "package.json"),
+    JSON.stringify({
+      name: "myproject",
+      version: "1.0.0",
+      bin: { myproject: "./index.js" },
+    }),
+  );
+  await writeFile(join(dep_dir, "index.js"), 'console.log("hi")');
+
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "host",
+      version: "0.0.1",
+    }),
+  );
+
+  // The positional is the absolute path; parse_with_optional_tag will tag this as `.folder`.
+  const local_path = resolve(dep_dir);
+
+  // 1st run — clean, adds one entry keyed by the resolved package name.
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "add", local_path],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+  }
+
+  // 2nd run with the same path — must reuse the existing "myproject" key, not append a duplicate.
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "add", local_path],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  // `JSON.parse` collapses duplicate keys — inspect the raw text to prove de-duplication.
+  const raw = await file(join(package_dir, "package.json")).text();
+  expect(raw.match(/"myproject"\s*:/g) ?? []).toHaveLength(1);
+  expect(JSON.parse(raw)).toStrictEqual({
+    name: "host",
+    version: "0.0.1",
+    dependencies: {
+      myproject: local_path,
+    },
+  });
+});
+
+it("should not add duplicate package.json entries when installing the same tarball URL twice (#30499)", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response(Bun.file(join(__dirname, "baz-0.0.3.tgz")));
+    },
+  });
+  const tarball_url = `${server.url.href.replace(/\/+$/, "")}/baz-0.0.3.tgz`;
+  setHandler(dummyRegistry([]));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+    }),
+  );
+
+  // First install — key should be the package name from the tarball ("baz").
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "add", tarball_url],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    expect(await stderr.text()).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+  }
+  expect(await file(join(package_dir, "package.json")).json()).toStrictEqual({
+    name: "foo",
+    version: "0.0.1",
+    dependencies: {
+      baz: tarball_url,
+    },
+  });
+
+  // Second install with the same URL — must not duplicate the "baz" key.
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "add", tarball_url],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  const raw = await file(join(package_dir, "package.json")).text();
+  expect(raw.match(/"baz"\s*:/g) ?? []).toHaveLength(1);
+  expect(JSON.parse(raw)).toStrictEqual({
+    name: "foo",
+    version: "0.0.1",
+    dependencies: {
+      baz: tarball_url,
+    },
+  });
+});
+
 it("should add multiple dependencies specified on command line", async () => {
   expect(check_npm_auth_type.check).toBe(true);
   using server = Bun.serve({


### PR DESCRIPTION
Fixes #30933 (and finishes #30499, which was never ported to the Rust `PackageJSONEditor`).

## Repro

```sh
mkdir /tmp/myproject && cd /tmp/myproject
cat > package.json <<'JSON'
{ "name": "myproject", "version": "1.0.0", "bin": { "myproject": "./index.js" } }
JSON
echo 'console.log("hi")' > index.js

export BUN_INSTALL_GLOBAL_DIR=/tmp/g BUN_INSTALL_BIN=/tmp/b
mkdir -p \"\$BUN_INSTALL_GLOBAL_DIR\" \"\$BUN_INSTALL_BIN\"

bun add -g /tmp/myproject   # 1st — clean
bun add -g /tmp/myproject   # 2nd — duplicates

cat /tmp/g/package.json
# {
#   \"dependencies\": {
#     \"myproject\": \"/tmp/myproject\",
#     \"myproject\": \"/tmp/myproject\"   <- dup
#   }
# }
```

Enough repeat runs make the lockfile unparseable:

```
error: Duplicate package path
    at bun.lock:XXX:5
InvalidPackageKey: failed to parse lockfile: 'bun.lock'
```

Also reproduces without `-g` — any \`bun add <local-path>\` run twice
duplicates the entry. It's the folder-install code path, not the
global-install code path, that's broken. The same shape also regresses
\`bun add <tarball-url>\` (previously fixed in #30499 for the Zig file,
which is no longer compiled after the Rust port).

## Cause

\`PackageJSONEditor::edit\`'s initial name-match phase looks up the
existing entry by \`UpdateRequest::get_name()\`. For a non-aliased
folder/path/tarball positional, \`get_name()\` returns the version
literal (the path/URL the user typed), not the resolved package name,
so \`query.expr.as_property(name)\` never finds the existing
\`\"<pkg-name>\"\` key and the code falls through to the append path.

The fallback URL-value-match loop below only fired for \`Tag::Github\` /
\`Tag::Git\`, so \`.folder\` and \`.tarball\` both fell through to the
append path. \`get_resolved_name(lockfile)\` then returned the real
package name (\`\"myproject\"\`) which was written as a *second* key next
to the existing \`\"myproject\": \"/tmp/myproject\"\` entry — producing
two keys with the same name.

## Fix

Extend the fallback URL/path-match loop to also match on \`.tarball\`
and \`.folder\`, skip it when the user wrote \`alias@url\` (that form is
an explicit request to key by \`alias\`, so consolidating into an
existing entry under a different name would silently drop the alias),
and guard on \`request.e_string.is_none()\` so a match in an earlier
dependency list (e.g. \`dependencies\`) isn't re-counted when the
outer loop continues to the remaining lists (\`devDependencies\`, etc.).

The \`.zig\` sibling is kept aligned as a porting reference (it is no
longer compiled — CLAUDE.md: \"not compiled, not shipped\").

## Verification

Two regression tests added in \`test/cli/install/bun-add.test.ts\`:

- \`should not add duplicate package.json entries when installing the same local folder twice (#30933)\` — this issue.
- \`should not add duplicate package.json entries when installing the same tarball URL twice (#30499)\` — re-port of the test dropped during the Rust rewrite.

Gate:

- \`USE_SYSTEM_BUN=1 bun test test/cli/install/bun-add.test.ts -t '30933|30499'\` — both fail on the duplicate \`\"<name>\":\` key.
- \`bun bd test test/cli/install/bun-add.test.ts -t '30933|30499'\` — both pass with the fix.

Existing tests that exercise the same fallback still pass:

- \`should add local tarball dependency\` ✅
- \`should add dependency without duplication\` ✅
- \`should add aliased dependency (npm)\` ✅

Supersedes #30500 (which targeted the \`.zig\` file only).