### PR TITLE
process: implement process._rawDebug

### DIFF
--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -461,6 +461,18 @@ export function windowsEnv(
   });
 }
 
+export function getRawDebug() {
+  // process._rawDebug(...args) — undocumented-but-depended-on Node API used by
+  // Node's own test suite and libraries like pino/thread-stream. Behaves like
+  // `console.error(util.format(...args))` but writes synchronously to fd 2 so
+  // it works even while the event loop is blocked or during shutdown.
+  const { format } = require("node:util");
+  const { writeSync } = require("node:fs");
+  return function _rawDebug(...args) {
+    writeSync(2, format.$apply(null, args) + "\n");
+  };
+}
+
 export function getChannel() {
   const EventEmitter = require("node:events");
   const setRef = $newZigFunction("node_cluster_binding.zig", "setRef", 1);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3944,6 +3944,22 @@ static JSValue constructProcessNextTickFn(VM& vm, JSObject* processObject)
     return uncheckedDowncast<Process>(processObject)->constructNextTickFn(JSC::getVM(globalObject), globalObject);
 }
 
+static JSValue constructRawDebug(VM& vm, JSObject* processObject)
+{
+    auto* globalObject = processObject->globalObject();
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    JSC::JSFunction* getRawDebug = JSC::JSFunction::create(vm, globalObject, processObjectInternalsGetRawDebugCodeGenerator(vm), globalObject);
+    JSC::MarkedArgumentBuffer args;
+    JSC::CallData callData = JSC::getCallData(getRawDebug);
+    auto result = JSC::profiledCall(globalObject, ProfilingReason::API, getRawDebug, callData, globalObject->globalThis(), args);
+    if (auto* exception = scope.exception()) {
+        (void)scope.tryClearException();
+        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        return jsUndefined();
+    }
+    return result;
+}
+
 JSC_DEFINE_CUSTOM_GETTER(processNoDeprecation, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName name))
 {
     return JSValue::encode(jsBoolean(Bun__Node__ProcessNoDeprecation));
@@ -4271,7 +4287,7 @@ extern "C" void Process__emitErrorEvent(Zig::GlobalObject* global, EncodedJSValu
   _kill                            Process_functionReallyKill                          Function 2
   _linkedBinding                   Process_stubEmptyFunction                           Function 0
   _preload_modules                 Process_stubEmptyArray                              PropertyCallback
-  _rawDebug                        Process_stubEmptyFunction                           Function 0
+  _rawDebug                        constructRawDebug                                   PropertyCallback
   _startProfilerIdleNotifier       Process_stubEmptyFunction                           Function 0
   _stopProfilerIdleNotifier        Process_stubEmptyFunction                           Function 0
   _tickCallback                    Process_stubEmptyFunction                           Function 0

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -781,6 +781,21 @@ describe.concurrent(() => {
       expect(stderr).toBe("\n");
       expect(exitCode).toBe(0);
     });
+
+    it("returns the same function across accesses (PropertyCallback cache)", async () => {
+      // The _rawDebug accessor is wired as a PropertyCallback that lazily
+      // constructs the function once and caches it on the process object.
+      // Matches Node: `process._rawDebug === process._rawDebug` is true.
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", `console.log(process._rawDebug === process._rawDebug);`],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("true\n");
+      expect(exitCode).toBe(0);
+    });
   });
 
   it("dlopen args parsing", () => {

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -689,7 +689,6 @@ describe.concurrent(() => {
     "_debugProcess",
     "_fatalException",
     "_linkedBinding",
-    "_rawDebug",
     "_startProfilerIdleNotifier",
     "_stopProfilerIdleNotifier",
     "_tickCallback",
@@ -732,6 +731,65 @@ describe.concurrent(() => {
       expect(process[stub]).toHaveLength(0);
     });
   }
+
+  describe("process._rawDebug", () => {
+    it("writes util.format output + newline to stderr synchronously", async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", `process._rawDebug('hi', {a: 1}, [1, 2]);`],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect(stdout).toBe("");
+      expect(stderr).toBe("hi { a: 1 } [ 1, 2 ]\n");
+      expect(exitCode).toBe(0);
+    });
+
+    it("handles printf-style format specifiers via util.format", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process._rawDebug('val: %d', 42); process._rawDebug('%s: %j', 'key', {a: 1});`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe('val: 42\nkey: {"a":1}\n');
+      expect(exitCode).toBe(0);
+    });
+
+    it("fires from a beforeExit handler during normal shutdown (issue #30934)", async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", `process.on('beforeExit', () => process._rawDebug('hi'));`],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("hi\n");
+      expect(exitCode).toBe(0);
+    });
+
+    it("prints an empty line when called with no args", async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", `process._rawDebug();`],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("\n");
+      expect(exitCode).toBe(0);
+    });
+  });
 
   it("dlopen args parsing", () => {
     const notFound = join(tmpdirSync(), "not-found.so");

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -740,11 +740,7 @@ describe.concurrent(() => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stdout).toBe("");
       expect(stderr).toBe("hi { a: 1 } [ 1, 2 ]\n");
       expect(exitCode).toBe(0);
@@ -752,11 +748,7 @@ describe.concurrent(() => {
 
     it("handles printf-style format specifiers via util.format", async () => {
       await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "-e",
-          `process._rawDebug('val: %d', 42); process._rawDebug('%s: %j', 'key', {a: 1});`,
-        ],
+        cmd: [bunExe(), "-e", `process._rawDebug('val: %d', 42); process._rawDebug('%s: %j', 'key', {a: 1});`],
         env: bunEnv,
         stdout: "pipe",
         stderr: "pipe",


### PR DESCRIPTION
Fixes #30934

## Repro

```js
// repro.cjs
process.on('beforeExit', () => process._rawDebug('hi'));
```

```console
$ node repro.cjs      # stderr
hi
$ bun repro.cjs       # (nothing)
```

## Cause

`process._rawDebug` was wired to `Process_stubEmptyFunction` in the process property table in `src/jsc/bindings/BunProcess.cpp` — it returned `undefined` and never wrote anything. The `beforeExit` handler in the issue fires correctly, but its call into `_rawDebug` dropped on the floor.

Node's `process._rawDebug(...args)` is an undocumented-but-depended-on API: `util.format(...args)` written synchronously to fd 2. Used by Node's own test suite, by `pino`/`thread-stream`, and by libraries that need to log from contexts where the event loop or the normal stderr stream isn't reliable (during shutdown, from workers, etc).

## Fix

- New `getRawDebug` builtin in `src/js/builtins/ProcessObjectInternals.ts`: returns a closure that does `fs.writeSync(2, util.format(...args) + '\n')`.
- New `constructRawDebug` PropertyCallback in `BunProcess.cpp` invokes that builtin once, caches the result (matching Node's identity: `process._rawDebug === process._rawDebug`).
- Flip the `_rawDebug` row in `processObjectTable` from `Process_stubEmptyFunction` to `constructRawDebug PropertyCallback`.

Matches Node byte-for-byte on the cases the test exercises — plain args, printf-style `%d`/`%s`/`%j`, nested objects/arrays, empty call — and is synchronous (writes complete before subsequent microtasks run).

## Verification

```
git stash push -- src/
bun bd test test/js/node/process/process.test.js -t 'process._rawDebug'
  → 0 pass, 4 fail  (no output written; stub)

git stash pop
bun bd test test/js/node/process/process.test.js -t 'process._rawDebug'
  → 4 pass, 0 fail
```

Also removed `_rawDebug` from the `undefinedStubs` list in the same file since it's no longer a stub. Existing `process-onBeforeExit` tests still pass.