### PR TITLE
Bind Promise.all in primordials so SafePromiseAll works as a free function

### DIFF
--- a/src/js/internal/fs/cp.ts
+++ b/src/js/internal/fs/cp.ts
@@ -18,7 +18,7 @@ const { chmod, copyFile, lstat, mkdir, opendir, readlink, stat, symlink, unlink,
 const { dirname, isAbsolute, join, parse, resolve } = require("node:path");
 
 const PromisePrototypeThen = $Promise.prototype.$then;
-const PromiseReject = Promise.$reject;
+const PromiseReject = Promise.$reject.bind(Promise);
 
 async function checkPaths(src, dest, opts) {
   if (opts.filter && !(await opts.filter(src, dest))) {

--- a/src/js/internal/primordials.js
+++ b/src/js/internal/primordials.js
@@ -93,7 +93,7 @@ const arrayToSafePromiseIterable = (promises, mapFn) =>
         new Promise((a, b) => PromisePrototypeThen.$call(mapFn == null ? promise : mapFn(promise, i), a, b)),
     ),
   );
-const PromiseAll = Promise.all;
+const PromiseAll = Promise.all.bind(Promise);
 const PromiseResolve = Promise.$resolve.bind(Promise);
 const SafePromiseAll = (promises, mapFn) => PromiseAll(arrayToSafePromiseIterable(promises, mapFn));
 // Shared scheduler for SafePromiseAllReturnVoid/ReturnArrayLike: `returnVal`

--- a/src/js/node/readline.ts
+++ b/src/js/node/readline.ts
@@ -43,7 +43,7 @@ const {
 
 const internalGetStringWidth = $newCppFunction("stringWidth.cpp", "jsFunctionBunStringWidth", 1);
 
-const PromiseReject = Promise.$reject;
+const PromiseReject = Promise.$reject.bind(Promise);
 
 var isWritable;
 

--- a/test/js/node/readline/readline_promises.node.test.ts
+++ b/test/js/node/readline/readline_promises.node.test.ts
@@ -70,6 +70,26 @@ describe("readline/promises.createInterface()", () => {
     assert.strictEqual(closed, true);
   });
 
+  // https://github.com/oven-sh/bun/issues/30939
+  // rl.question() with a pre-aborted signal used to throw "TypeError: |this|
+  // is not an object" because PromiseReject was captured as an unbound
+  // Promise.$reject reference. The rejection must carry the AbortError, not
+  // a TypeError masking it.
+  it("question() with pre-aborted signal rejects with AbortError", async () => {
+    const fi = new FakeInput();
+    // @ts-ignore
+    const rl = new readlinePromises.Interface({ input: fi, output: fi });
+    const ac = new AbortController();
+    ac.abort();
+    // @ts-ignore
+    const result = await rl.question("x", { signal: ac.signal }).then(
+      () => ({ ok: true }),
+      err => ({ name: err?.name, message: err?.message }),
+    );
+    rl.close();
+    expect(result).toEqual({ name: "AbortError", message: "The operation was aborted." });
+  });
+
   it("should support Symbol.dispose as alias for close()", () => {
     const fi = new FakeInput();
     let closed = false;

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -386,6 +386,31 @@ it("Readable.fromWeb", async () => {
   expect(Buffer.concat(chunks).toString()).toBe("Hello World!\n");
 });
 
+// https://github.com/oven-sh/bun/issues/30939
+// Multiple queued writes on a Transform.fromWeb stream trigger _writev, which
+// internally calls SafePromiseAll. Promise.all must be bound in primordials;
+// otherwise this throws "TypeError: |this| is not an object".
+it("Transform.fromWeb _writev does not throw on buffered writes", async () => {
+  const s = Transform.fromWeb(new TransformStream());
+  const chunks = [];
+  s.on("data", chunk => chunks.push(chunk));
+  const { promise, resolve, reject } = Promise.withResolvers();
+  s.on("end", resolve);
+  s.on("error", reject);
+
+  // Five synchronous writes force the writable side to queue and coalesce
+  // into a single _writev call.
+  s.write(Buffer.from("hello"));
+  s.write(Buffer.from("hello"));
+  s.write(Buffer.from("hello"));
+  s.write(Buffer.from("hello"));
+  s.write(Buffer.from("hello"));
+  s.end();
+
+  await promise;
+  expect(Buffer.concat(chunks).toString()).toBe("hellohellohellohellohello");
+});
+
 it("#9242.5 Stream has constructor", () => {
   const s = new Stream({});
   expect(s.constructor).toBe(Stream);


### PR DESCRIPTION
### Repro

```js
const { TransformStream } = require('stream/web');
const { Transform } = require('stream');
const s = Transform.fromWeb(new TransformStream());
s.pipe(process.stderr);
s.write(Buffer.from('hello'));
s.write(Buffer.from('hello'));
s.write(Buffer.from('hello'));
s.end();
```

Bun threw `TypeError: |this| is not an object` inside `internal:webstreams_adapters`.

### Cause

`src/js/internal/primordials.js` captured `Promise.all` unbound:

```js
const PromiseAll = Promise.all;
```

`SafePromiseAll` calls `PromiseAll(...)` as a free function — so its `this` is `undefined`, and `Promise.all`'s internal `NewPromiseCapability(this, …)` throws.

Consumers: the `Transform.fromWeb` / `Duplex.fromWeb` `_writev` path and `closeWriter/closeReader` in `webstreams_adapters.ts` (lines 323, 621, 721). The 5-sync-write repro forces the writable side to queue and coalesce into a single `_writev` call.

### Fix

Bind it to `Promise`, matching the existing pattern on the next line for `PromiseResolve`:

```diff
-const PromiseAll = Promise.all;
+const PromiseAll = Promise.all.bind(Promise);
 const PromiseResolve = Promise.$resolve.bind(Promise);
```

### Verification

```
USE_SYSTEM_BUN=1 bun test test/js/node/stream/node-stream.test.js -t "Transform.fromWeb _writev"  → FAIL (TypeError)
bun bd test test/js/node/stream/node-stream.test.js -t "Transform.fromWeb _writev"               → PASS
bun bd test test/js/node/stream/node-stream.test.js                                               → 37 pass, 0 fail
```

Fixes #30939