### PR TITLE
Match V8 semantics for CallSite.getTypeName/getFunctionName/getMethodName

### DIFF
--- a/docs/runtime/debugger.mdx
+++ b/docs/runtime/debugger.mdx
@@ -263,10 +263,10 @@ The `CallSite` object has the following methods:
 | Method                     | Returns                                               |
 | -------------------------- | ----------------------------------------------------- |
 | `getThis`                  | `this` value of the function call                     |
-| `getTypeName`              | typeof `this`                                         |
+| `getTypeName`              | constructor name of the receiver, or `null`           |
 | `getFunction`              | function object                                       |
-| `getFunctionName`          | function name as a string                             |
-| `getMethodName`            | method name as a string                               |
+| `getFunctionName`          | function name, or `null` if anonymous                 |
+| `getMethodName`            | `null` (receiver not retained)                        |
 | `getFileName`              | file name or URL                                      |
 | `getLineNumber`            | line number                                           |
 | `getColumnNumber`          | column number                                         |

--- a/src/jsc/bindings/CallSitePrototype.cpp
+++ b/src/jsc/bindings/CallSitePrototype.cpp
@@ -15,6 +15,8 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/JSBoundFunction.h>
+#include <JavaScriptCore/PropertyNameArray.h>
+#include <JavaScriptCore/ProxyObject.h>
 using namespace JSC;
 
 namespace Zig {
@@ -100,11 +102,37 @@ JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetThis, (JSGlobalObject * globalObjec
     return JSC::JSValue::encode(callSite->thisValue());
 }
 
-// TODO: doesn't get class name
+// Matches V8's CallSiteInfo::GetTypeName: returns the name of the constructor
+// that produced the receiver (or its prototype's constructor), falling back to
+// @@toStringTag / [[Class]]. Returns null for strict-mode frames and for
+// null/undefined receivers, never the string "undefined" or an empty string.
 JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetTypeName, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     ENTER_PROTO_FUNC();
-    return JSC::JSValue::encode(JSC::jsTypeStringForValue(globalObject, callSite->thisValue()));
+
+    JSC::JSValue thisValue = callSite->thisValue();
+
+    // V8 returns null when the receiver can't be identified: strict-mode
+    // frames, explicit `this === null`/`undefined`, and calls on the global
+    // object.
+    if (!thisValue || thisValue.isUndefinedOrNull()) {
+        return JSC::JSValue::encode(JSC::jsNull());
+    }
+
+    JSC::JSObject* thisObject = thisValue.toObject(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (!thisObject || thisObject->isGlobalObject()) {
+        return JSC::JSValue::encode(JSC::jsNull());
+    }
+
+    // JSObject::calculatedClassName implements the V8 cascade: own
+    // constructor -> proto's constructor -> @@toStringTag -> classInfo -> "Object".
+    String className = JSObject::calculatedClassName(thisObject);
+    if (className.isEmpty()) {
+        return JSC::JSValue::encode(JSC::jsNull());
+    }
+
+    return JSC::JSValue::encode(JSC::jsString(vm, className));
 }
 
 JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetFunction, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
@@ -113,16 +141,122 @@ JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetFunction, (JSGlobalObject * globalO
     return JSC::JSValue::encode(callSite->function());
 }
 
+// V8 returns null (not "") when the frame's function has no name.
 JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetFunctionName, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     ENTER_PROTO_FUNC();
-    return JSC::JSValue::encode(callSite->functionName());
+    JSValue name = callSite->functionName();
+    if (JSC::JSString* str = dynamicDowncast<JSC::JSString>(name)) {
+        if (str->length() == 0) {
+            return JSC::JSValue::encode(JSC::jsNull());
+        }
+        return JSC::JSValue::encode(str);
+    }
+    return JSC::JSValue::encode(JSC::jsNull());
 }
 
-// TODO
+// Matches V8's CallSiteInfo::GetMethodName: walks the receiver and its
+// prototype chain looking for a property whose value is identity-equal to the
+// frame's function. Returns null if the receiver is nullish, if no matching
+// property is found, or if more than one distinct property name matches.
 JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetMethodName, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
-    return callSiteProtoFuncGetFunctionName(globalObject, callFrame);
+    ENTER_PROTO_FUNC();
+
+    JSC::JSValue thisValue = callSite->thisValue();
+    if (!thisValue || thisValue.isUndefinedOrNull()) {
+        return JSC::JSValue::encode(JSC::jsNull());
+    }
+
+    JSC::JSValue functionValue = callSite->function();
+    if (!functionValue || !functionValue.isCell()) {
+        return JSC::JSValue::encode(JSC::jsNull());
+    }
+    JSC::JSCell* functionCell = functionValue.asCell();
+
+    JSC::JSObject* thisObject = thisValue.toObject(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (!thisObject) {
+        return JSC::JSValue::encode(JSC::jsNull());
+    }
+
+    // Walk `this` and its prototype chain. Collect property names whose value
+    // is identity-equal to the frame's function. Bound functions and proxies
+    // aren't inspected (V8 gives up on them too).
+    Identifier foundName;
+    bool foundMultiple = false;
+
+    JSC::JSObject* current = thisObject;
+    // Cap the depth to avoid pathological prototype chains; 128 matches other
+    // JSC traversals and is more than any real chain.
+    constexpr unsigned maxDepth = 128;
+    for (unsigned depth = 0; current && depth < maxDepth; ++depth) {
+        if (current->type() == JSC::ProxyObjectType) {
+            break;
+        }
+
+        PropertyNameArrayBuilder properties(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
+        {
+            auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+            current->methodTable()->getOwnPropertyNames(current, globalObject, properties, DontEnumPropertiesMode::Include);
+            if (topExceptionScope.exception()) [[unlikely]] {
+                (void)topExceptionScope.tryClearException();
+                break;
+            }
+        }
+
+        for (const auto& propertyName : properties) {
+            PropertySlot slot(current, PropertySlot::InternalMethodType::VMInquiry, &vm);
+            auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+            bool hasProperty = current->methodTable()->getOwnPropertySlot(current, globalObject, propertyName, slot);
+            if (topExceptionScope.exception()) [[unlikely]] {
+                (void)topExceptionScope.tryClearException();
+                continue;
+            }
+            if (!hasProperty) {
+                continue;
+            }
+            // Only examine direct values (mirrors V8: accessor/computed props
+            // would require invoking user code).
+            if (!slot.isValue()) {
+                continue;
+            }
+            JSValue value = slot.getValue(globalObject, propertyName);
+            if (topExceptionScope.exception()) [[unlikely]] {
+                (void)topExceptionScope.tryClearException();
+                continue;
+            }
+            if (!value.isCell() || value.asCell() != functionCell) {
+                continue;
+            }
+
+            if (foundName.isNull()) {
+                foundName = propertyName;
+            } else if (foundName != propertyName) {
+                foundMultiple = true;
+                break;
+            }
+        }
+
+        if (foundMultiple) {
+            break;
+        }
+
+        if (current->structure()->typeInfo().overridesGetPrototype()) [[unlikely]] {
+            break;
+        }
+        JSValue protoValue = current->getPrototypeDirect();
+        if (!protoValue.isObject()) {
+            break;
+        }
+        current = asObject(protoValue);
+    }
+
+    if (foundName.isNull() || foundMultiple) {
+        return JSC::JSValue::encode(JSC::jsNull());
+    }
+
+    return JSC::JSValue::encode(JSC::jsString(vm, foundName.string()));
 }
 
 JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetFileName, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))

--- a/src/jsc/bindings/CallSitePrototype.cpp
+++ b/src/jsc/bindings/CallSitePrototype.cpp
@@ -15,8 +15,6 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/JSBoundFunction.h>
-#include <JavaScriptCore/PropertyNameArray.h>
-#include <JavaScriptCore/ProxyObject.h>
 using namespace JSC;
 
 namespace Zig {
@@ -155,108 +153,18 @@ JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetFunctionName, (JSGlobalObject * glo
     return JSC::JSValue::encode(JSC::jsNull());
 }
 
-// Matches V8's CallSiteInfo::GetMethodName: walks the receiver and its
-// prototype chain looking for a property whose value is identity-equal to the
-// frame's function. Returns null if the receiver is nullish, if no matching
-// property is found, or if more than one distinct property name matches.
+// V8's CallSiteInfo::GetMethodName resolves the method name by matching the
+// frame's function against the receiver's own and inherited properties. Bun's
+// captured stack frames don't retain the receiver (CallSite::thisValue() is
+// undefined for them), so the property holding the function can't be
+// identified, and we return null. This also matches what V8 returns when it
+// can't determine a method name (e.g. plain function calls). Previously this
+// delegated to getFunctionName, which reported the function's own name even
+// for non-method frames.
 JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetMethodName, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     ENTER_PROTO_FUNC();
-
-    JSC::JSValue thisValue = callSite->thisValue();
-    if (!thisValue || thisValue.isUndefinedOrNull()) {
-        return JSC::JSValue::encode(JSC::jsNull());
-    }
-
-    JSC::JSValue functionValue = callSite->function();
-    if (!functionValue || !functionValue.isCell()) {
-        return JSC::JSValue::encode(JSC::jsNull());
-    }
-    JSC::JSCell* functionCell = functionValue.asCell();
-
-    JSC::JSObject* thisObject = thisValue.toObject(globalObject);
-    RETURN_IF_EXCEPTION(scope, {});
-    if (!thisObject) {
-        return JSC::JSValue::encode(JSC::jsNull());
-    }
-
-    // Walk `this` and its prototype chain. Collect property names whose value
-    // is identity-equal to the frame's function. Bound functions and proxies
-    // aren't inspected (V8 gives up on them too).
-    Identifier foundName;
-    bool foundMultiple = false;
-
-    JSC::JSObject* current = thisObject;
-    // Cap the depth to avoid pathological prototype chains; 128 matches other
-    // JSC traversals and is more than any real chain.
-    constexpr unsigned maxDepth = 128;
-    for (unsigned depth = 0; current && depth < maxDepth; ++depth) {
-        if (current->type() == JSC::ProxyObjectType) {
-            break;
-        }
-
-        PropertyNameArrayBuilder properties(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
-        {
-            auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-            current->methodTable()->getOwnPropertyNames(current, globalObject, properties, DontEnumPropertiesMode::Include);
-            if (topExceptionScope.exception()) [[unlikely]] {
-                (void)topExceptionScope.tryClearException();
-                break;
-            }
-        }
-
-        for (const auto& propertyName : properties) {
-            PropertySlot slot(current, PropertySlot::InternalMethodType::VMInquiry, &vm);
-            auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-            bool hasProperty = current->methodTable()->getOwnPropertySlot(current, globalObject, propertyName, slot);
-            if (topExceptionScope.exception()) [[unlikely]] {
-                (void)topExceptionScope.tryClearException();
-                continue;
-            }
-            if (!hasProperty) {
-                continue;
-            }
-            // Only examine direct values (mirrors V8: accessor/computed props
-            // would require invoking user code).
-            if (!slot.isValue()) {
-                continue;
-            }
-            JSValue value = slot.getValue(globalObject, propertyName);
-            if (topExceptionScope.exception()) [[unlikely]] {
-                (void)topExceptionScope.tryClearException();
-                continue;
-            }
-            if (!value.isCell() || value.asCell() != functionCell) {
-                continue;
-            }
-
-            if (foundName.isNull()) {
-                foundName = propertyName;
-            } else if (foundName != propertyName) {
-                foundMultiple = true;
-                break;
-            }
-        }
-
-        if (foundMultiple) {
-            break;
-        }
-
-        if (current->structure()->typeInfo().overridesGetPrototype()) [[unlikely]] {
-            break;
-        }
-        JSValue protoValue = current->getPrototypeDirect();
-        if (!protoValue.isObject()) {
-            break;
-        }
-        current = asObject(protoValue);
-    }
-
-    if (foundName.isNull() || foundMultiple) {
-        return JSC::JSValue::encode(JSC::jsNull());
-    }
-
-    return JSC::JSValue::encode(JSC::jsString(vm, foundName.string()));
+    return JSC::JSValue::encode(JSC::jsNull());
 }
 
 JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetFileName, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))

--- a/src/jsc/bindings/CallSitePrototype.cpp
+++ b/src/jsc/bindings/CallSitePrototype.cpp
@@ -100,19 +100,14 @@ JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetThis, (JSGlobalObject * globalObjec
     return JSC::JSValue::encode(callSite->thisValue());
 }
 
-// Matches V8's CallSiteInfo::GetTypeName: returns the name of the constructor
-// that produced the receiver (or its prototype's constructor), falling back to
-// @@toStringTag / [[Class]]. Returns null for strict-mode frames and for
-// null/undefined receivers, never the string "undefined" or an empty string.
+// Matches V8's GetTypeName: the receiver's constructor name, else null for
+// null/undefined/global/strict receivers. Never the string "undefined" (the
+// previous typeof-based behavior that broke source-map-support formatting).
 JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetTypeName, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     ENTER_PROTO_FUNC();
 
     JSC::JSValue thisValue = callSite->thisValue();
-
-    // V8 returns null when the receiver can't be identified: strict-mode
-    // frames, explicit `this === null`/`undefined`, and calls on the global
-    // object.
     if (!thisValue || thisValue.isUndefinedOrNull()) {
         return JSC::JSValue::encode(JSC::jsNull());
     }
@@ -123,8 +118,8 @@ JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetTypeName, (JSGlobalObject * globalO
         return JSC::JSValue::encode(JSC::jsNull());
     }
 
-    // JSObject::calculatedClassName implements the V8 cascade: own
-    // constructor -> proto's constructor -> @@toStringTag -> classInfo -> "Object".
+    // calculatedClassName is V8's cascade: own/proto constructor, then
+    // @@toStringTag, then [[Class]], then "Object".
     String className = JSObject::calculatedClassName(thisObject);
     if (className.isEmpty()) {
         return JSC::JSValue::encode(JSC::jsNull());
@@ -153,14 +148,9 @@ JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetFunctionName, (JSGlobalObject * glo
     return JSC::JSValue::encode(JSC::jsNull());
 }
 
-// V8's CallSiteInfo::GetMethodName resolves the method name by matching the
-// frame's function against the receiver's own and inherited properties. Bun's
-// captured stack frames don't retain the receiver (CallSite::thisValue() is
-// undefined for them), so the property holding the function can't be
-// identified, and we return null. This also matches what V8 returns when it
-// can't determine a method name (e.g. plain function calls). Previously this
-// delegated to getFunctionName, which reported the function's own name even
-// for non-method frames.
+// V8 resolves the method name by matching the frame's function against the
+// receiver's properties, but Bun's captured frames don't retain the receiver
+// (thisValue() is undefined), so we return null as V8 does when it can't tell.
 JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetMethodName, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     ENTER_PROTO_FUNC();

--- a/src/jsc/bindings/CallSitePrototype.cpp
+++ b/src/jsc/bindings/CallSitePrototype.cpp
@@ -101,8 +101,8 @@ JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetThis, (JSGlobalObject * globalObjec
 }
 
 // Matches V8's GetTypeName: the receiver's constructor name, else null for
-// null/undefined/global/strict receivers. Never the string "undefined" (the
-// previous typeof-based behavior that broke source-map-support formatting).
+// null/undefined/global/strict receivers. Never returns the literal string
+// "undefined".
 JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetTypeName, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     ENTER_PROTO_FUNC();

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -351,11 +351,14 @@ test("sanity check", () => {
     Error.prepareStackTrace = (e, s) => {
       // getThis returns undefined in strict mode
       expect(s[0].getThis()).toBe(undefined);
-      expect(s[0].getTypeName()).toBe("undefined");
+      // getTypeName returns null when the receiver is null/undefined or strict.
+      // Matches V8 (previously Bun returned the literal string "undefined").
+      expect(s[0].getTypeName()).toBe(null);
       // getFunction returns undefined in strict mode
       expect(s[0].getFunction()).toBe(undefined);
       expect(s[0].getFunctionName()).toBe("f3");
-      expect(s[0].getMethodName()).toBe("f3");
+      // f3 is a top-level function, not a method of any object, so V8 returns null.
+      expect(s[0].getMethodName()).toBe(null);
       expect(typeof s[0].getLineNumber()).toBe("number");
       expect(typeof s[0].getColumnNumber()).toBe("number");
       expect(s[0].getFileName().includes("capture-stack-trace.test.js")).toBe(true);
@@ -463,6 +466,52 @@ test("CallFrame.p.isConstructor", () => {
     expect(s[1].isToplevel()).toBe(true);
   };
   new C();
+  Error.prepareStackTrace = prevPrepareStackTrace;
+});
+
+// Regression for https://github.com/oven-sh/bun/issues/30938
+// getTypeName/getFunctionName/getMethodName must match V8 (return null,
+// not the string "undefined" or the empty string). tap + source-map-support
+// concatenates `typeName + "."` into the formatted frame, so the old
+// behaviour rendered as `undefined.<anonymous>` in TAP error output.
+test("CallSite.p.getTypeName returns null (not 'undefined') when receiver is not an object", () => {
+  let prevPrepareStackTrace = Error.prepareStackTrace;
+  Error.prepareStackTrace = (_, s) => {
+    expect(s[0].getTypeName()).toBe(null);
+  };
+  const e = new Error();
+  Error.captureStackTrace(e);
+  e.stack;
+  Error.prepareStackTrace = prevPrepareStackTrace;
+});
+
+test("CallSite.p.getFunctionName returns null for anonymous frames", () => {
+  let prevPrepareStackTrace = Error.prepareStackTrace;
+  Error.prepareStackTrace = (_, s) => {
+    // Top frame is the anonymous arrow below.
+    expect(s[0].getFunctionName()).toBe(null);
+  };
+  (() => {
+    const e = new Error();
+    Error.captureStackTrace(e);
+    e.stack;
+  })();
+  Error.prepareStackTrace = prevPrepareStackTrace;
+});
+
+test("CallSite.p.getMethodName returns null for non-method frames", () => {
+  let prevPrepareStackTrace = Error.prepareStackTrace;
+  function topLevelFn() {
+    const e = new Error();
+    Error.captureStackTrace(e);
+    e.stack;
+  }
+  Error.prepareStackTrace = (_, s) => {
+    // topLevelFn is a plain function call — it's not stored at a property of
+    // `this`, so V8 returns null. Previously Bun delegated to getFunctionName.
+    expect(s[0].getMethodName()).toBe(null);
+  };
+  topLevelFn();
   Error.prepareStackTrace = prevPrepareStackTrace;
 });
 

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -469,11 +469,7 @@ test("CallFrame.p.isConstructor", () => {
   Error.prepareStackTrace = prevPrepareStackTrace;
 });
 
-// Regression for https://github.com/oven-sh/bun/issues/30938
-// getTypeName/getFunctionName/getMethodName must match V8 (return null,
-// not the string "undefined" or the empty string). tap + source-map-support
-// concatenates `typeName + "."` into the formatted frame, so the old
-// behaviour rendered as `undefined.<anonymous>` in TAP error output.
+// https://github.com/oven-sh/bun/issues/30938
 test("CallSite.p.getTypeName returns null (not 'undefined') when receiver is not an object", () => {
   // The assertion runs inside the prepareStackTrace hook, so require it to fire.
   expect.hasAssertions();
@@ -517,8 +513,7 @@ test("CallSite.p.getMethodName returns null for non-method frames", () => {
     e.stack;
   }
   Error.prepareStackTrace = (_, s) => {
-    // topLevelFn is a plain function call — it's not stored at a property of
-    // `this`, so V8 returns null. Previously Bun delegated to getFunctionName.
+    // topLevelFn is a plain function call, not a method, so V8 returns null.
     expect(s[0].getMethodName()).toBe(null);
   };
   try {

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -475,31 +475,41 @@ test("CallFrame.p.isConstructor", () => {
 // concatenates `typeName + "."` into the formatted frame, so the old
 // behaviour rendered as `undefined.<anonymous>` in TAP error output.
 test("CallSite.p.getTypeName returns null (not 'undefined') when receiver is not an object", () => {
+  // The assertion runs inside the prepareStackTrace hook, so require it to fire.
+  expect.hasAssertions();
   let prevPrepareStackTrace = Error.prepareStackTrace;
   Error.prepareStackTrace = (_, s) => {
     expect(s[0].getTypeName()).toBe(null);
   };
-  const e = new Error();
-  Error.captureStackTrace(e);
-  e.stack;
-  Error.prepareStackTrace = prevPrepareStackTrace;
+  try {
+    const e = new Error();
+    Error.captureStackTrace(e);
+    e.stack;
+  } finally {
+    Error.prepareStackTrace = prevPrepareStackTrace;
+  }
 });
 
 test("CallSite.p.getFunctionName returns null for anonymous frames", () => {
+  expect.hasAssertions();
   let prevPrepareStackTrace = Error.prepareStackTrace;
   Error.prepareStackTrace = (_, s) => {
     // Top frame is the anonymous arrow below.
     expect(s[0].getFunctionName()).toBe(null);
   };
-  (() => {
-    const e = new Error();
-    Error.captureStackTrace(e);
-    e.stack;
-  })();
-  Error.prepareStackTrace = prevPrepareStackTrace;
+  try {
+    (() => {
+      const e = new Error();
+      Error.captureStackTrace(e);
+      e.stack;
+    })();
+  } finally {
+    Error.prepareStackTrace = prevPrepareStackTrace;
+  }
 });
 
 test("CallSite.p.getMethodName returns null for non-method frames", () => {
+  expect.hasAssertions();
   let prevPrepareStackTrace = Error.prepareStackTrace;
   function topLevelFn() {
     const e = new Error();
@@ -511,8 +521,11 @@ test("CallSite.p.getMethodName returns null for non-method frames", () => {
     // `this`, so V8 returns null. Previously Bun delegated to getFunctionName.
     expect(s[0].getMethodName()).toBe(null);
   };
-  topLevelFn();
-  Error.prepareStackTrace = prevPrepareStackTrace;
+  try {
+    topLevelFn();
+  } finally {
+    Error.prepareStackTrace = prevPrepareStackTrace;
+  }
 });
 
 test("CallFrame.p.isNative", () => {


### PR DESCRIPTION
## Problem

Reported in #30938: `async_hooks` + `process._fatalException` + `tap` produces TAP subtest errors formatted as `undefined.<anonymous>` instead of the receiver's class name.

```
# Bun 1.3.14
stack: |
  undefined.<anonymous> (fail.cjs:29:12)
at:
  function: undefined.<anonymous>
```

```
# Node 24
stack: |
  Test.<anonymous> (fail.cjs:29:9)
at:
  function: Test.<anonymous>
```

The literal string `"undefined"` appears because `source-map-support` does `typeName + "."` when formatting method-call frames, and Bun's `CallSite.getTypeName()` was returning `typeof this` (so `"undefined"`, `"object"`, `"function"`) where V8/Node returns the receiver's constructor name — or `null` when the receiver can't be identified.

Two neighbouring methods had the same shape of mismatch:

- `getFunctionName()` returned `""` for anonymous frames where V8 returns `null`.
- `getMethodName()` delegated to `getFunctionName` (there's even a `// TODO` on it), so it reported the function's own name even for plain, non-method frames where V8 returns `null`.

## Fix

`src/jsc/bindings/CallSitePrototype.cpp`:

- `getTypeName` — null/undefined receiver → `null`; otherwise `JSObject::calculatedClassName`, which already implements V8's cascade (own `constructor` → `proto.constructor` → `@@toStringTag` → `[[Class]]` → `"Object"`). Global object → `null`.
- `getFunctionName` — empty stored name → `null`.
- `getMethodName` — `null`. V8 resolves the method name by matching the frame's function against the receiver's own/inherited properties, but Bun's captured frames don't retain the receiver (see the caveat), so the property can't be identified. `null` is also what V8 returns when it can't determine a method name, and it's strictly better than the old delegation that reported the function's own name for non-method frames.

## Caveat

Bun can't reproduce Node's `Test.<anonymous>` output because `JSC::StackFrame` doesn't persist the receiver through stack capture — by the time `Error.prepareStackTrace` runs the callframe is gone, so `CallSite.getThis()` is `undefined` for captured frames (verified across object methods, class methods, `.call(obj)`, and constructors). Consequently `getTypeName()` and `getMethodName()` return `null` in practice today; the receiver-dependent branches activate only if a future change stashes `this` on each frame.

Net effect for the issue: the TAP output goes from `undefined.<anonymous>` to `null.<anonymous>` (and `function: undefined.<anonymous>` to `function: null.<anonymous>`). Still not Node's `Test.<anonymous>`, but consistent with what V8 returns when the receiver is unavailable, and the `null` return value unblocks ecosystem libraries that guard with `typeName && typeName !== 'Object'`. Going the rest of the way needs the receiver captured on every frame — a separate, bigger change.

## Verification

`test/js/node/v8/capture-stack-trace.test.js`:

- Three new regressions pinned to #30938 assert `null` return for each method.
- Two existing sanity-check assertions were updated from the buggy values (`"undefined"`, `"f3"` for `getMethodName` of a top-level function) to the V8-correct `null` — these encoded the bug.

```
bun bd test test/js/node/v8/capture-stack-trace.test.js
 43 pass
 0 fail
```

Fail-before (`USE_SYSTEM_BUN=1`):

```
CallSite.p.getTypeName ... Expected: null / Received: "undefined"
CallSite.p.getFunctionName ... Expected: null / Received: ""
CallSite.p.getMethodName ... Expected: null / Received: "topLevelFn"
```

Related test files still green:

```
bun bd test test/js/node/v8/                                   → 46 pass
bun bd test test/regression/issue/fix-bindings-stack-trace.test.ts
         test/regression/issue/prepare-stack-trace-crash.test.ts
         test/regression/issue/circular-error-stack.test.ts
         test/regression/issue/23022-stack-trace-iterator.test.ts
         test/regression/issue/circular-error-stack-edge-cases.test.ts → 12 pass
```

Fixes #30938