### PR TITLE
 fix(fetch): remove latent cross-thread UB in FetchTasklet shutdown

### DIFF
--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -378,8 +378,12 @@ impl FetchTasklet {
         }
         let self_ = Self::from_raw_ref(this);
         if self_.javascript_vm.is_shutting_down() {
-            // SAFETY: last ref; exclusive access
-            unsafe { FetchTasklet::deinit(this) };
+            // SAFETY (Intentional Leak): We are on the background HTTP thread.
+            // During VM shutdown, the JS event loop is dead, so enqueueing a task
+            // is useless. However, calling `deinit()` synchronously from here is UB:
+            // it destroys JS-bound handles (`Response::unref` mutating `Cell<u32>`,
+            // `ReadableStream::Strong`, etc.) off the main JS thread.
+            // We explicitly abandon this allocation and let the OS reclaim it.
             return;
         }
         // this is really unlikely to happen, but can happen


### PR DESCRIPTION
### What does this PR do?
Removes a latent data race and JSC thread-safety violation in `FetchTasklet::deref_from_thread` during VM shutdown.

Currently, if `is_shutting_down()` is true, `deref_from_thread` synchronously calls `FetchTasklet::deinit(this)` on the background HTTP thread. This is Undefined Behavior because it destroys `jsc::Weak` handles and modifies single-threaded structures (`Response::unref(response)` mutates a `Cell<u32>`, and `readable_stream_ref.deinit()` drops a `ReadableStream::Strong`) off the main JS thread.

This branch is currently unreachable dead code because the JS thread leaks its initial reference when the event loop is halted during `process.exit`. However, if Bun were to implement graceful shutdown, eager GC for aborted fetches, or clean up the shutdown memory leak, the HTTP thread would become the final reference holder, triggering a guaranteed segfault.

The fix replaces the synchronous `deinit` call with an intentional leak (explicit abandonment). If the VM is shutting down, the HTTP thread will simply return and safely abandon the allocation for the OS to reclaim, avoiding the cross-thread UB.

### How did you verify your code works?
- `bun bd test test/js/web/fetch/exiting.test.ts` runs 500 concurrent fetches with process.exit(0); passes with exit code 0 and no panic
- Traced the reference lifecycle of `FetchTasklet` (initial refs, `deref_from_thread` drops, JS thread drops in `on_progress_update`) to confirm this code is currently dead but dangerous.
- Confirmed with standard JSC practices that explicitly abandoning/leaking the memory during VM shutdown is the correct and safest approach to avoid cross-thread heap corruption.
- Ensured it compiles successfully locally.