### PR TITLE
http2: route ERR_HTTP2_PUSH_DISABLED through pushStream callback

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2466,8 +2466,20 @@ class ServerHttp2Stream extends Http2Stream {
   constructor(streamId, session, headers) {
     super(streamId, session, headers);
   }
-  pushStream() {
-    throw $ERR_HTTP2_PUSH_DISABLED();
+  pushStream(headers, options, callback) {
+    // Argument shuffle: pushStream(headers, callback) is valid.
+    if (typeof options === "function") {
+      callback = options;
+      options = undefined;
+    }
+    validateFunction(callback, "callback");
+    // Bun does not currently implement sending PUSH_PROMISE frames. Node
+    // throws ERR_HTTP2_PUSH_DISABLED synchronously only when the peer
+    // explicitly disabled push; otherwise runtime errors are delivered via
+    // the error-first callback on the next tick. Route the "not supported"
+    // case through the callback so user code written against Node's
+    // callback contract doesn't crash inside the 'stream' event handler.
+    process.nextTick(callback, $ERR_HTTP2_PUSH_DISABLED());
   }
 
   respondWithFile(path, headers, options) {

--- a/test/regression/issue/30942.test.ts
+++ b/test/regression/issue/30942.test.ts
@@ -1,0 +1,216 @@
+// https://github.com/oven-sh/bun/issues/30942
+//
+// `ServerHttp2Stream.pushStream` used to throw `ERR_HTTP2_PUSH_DISABLED`
+// synchronously from inside the 'stream' event handler, which killed user
+// code following Node's `(err, pushStream) => {}` callback pattern. Node
+// routes the same error through the callback instead (async). The stub
+// now matches that contract so callers can observe the error and recover
+// until real PUSH_PROMISE support lands (see #28713).
+
+import { expect, test } from "bun:test";
+import http2 from "node:http2";
+
+test("pushStream delivers ERR_HTTP2_PUSH_DISABLED through the callback, not a sync throw", async () => {
+  const server = http2.createServer();
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+  server.on("stream", stream => {
+    try {
+      stream.pushStream({ ":path": "/x.js" }, (err, pushStream) => {
+        try {
+          expect(err).toBeInstanceOf(Error);
+          expect((err as any).code).toBe("ERR_HTTP2_PUSH_DISABLED");
+          expect(err!.message).toBe("HTTP/2 client has disabled push streams");
+          expect(pushStream).toBeUndefined();
+          stream.respond({ ":status": 200 });
+          stream.end("ok");
+        } catch (e) {
+          reject(e);
+        }
+      });
+    } catch (e) {
+      reject(new Error(`pushStream threw synchronously: ${(e as any)?.code ?? (e as Error).message}`));
+    }
+  });
+
+  server.listen(0, () => {
+    const port = (server.address() as any).port;
+    const client = http2.connect(`http://localhost:${port}`);
+    const req = client.request({ ":path": "/" });
+    let body = "";
+    req.setEncoding("utf8");
+    req.on("data", chunk => {
+      body += chunk;
+    });
+    req.on("end", () => {
+      try {
+        expect(body).toBe("ok");
+        resolve();
+      } catch (e) {
+        reject(e);
+      } finally {
+        client.close();
+        server.close();
+      }
+    });
+    req.on("error", reject);
+    req.end();
+  });
+
+  await promise;
+});
+
+test("pushStream callback fires asynchronously (next tick), not synchronously", async () => {
+  const server = http2.createServer();
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+  server.on("stream", stream => {
+    let callbackInvoked = false;
+    try {
+      stream.pushStream({ ":path": "/x.js" }, err => {
+        callbackInvoked = true;
+        try {
+          expect((err as any)?.code).toBe("ERR_HTTP2_PUSH_DISABLED");
+        } catch (e) {
+          reject(e);
+        }
+      });
+      if (callbackInvoked) {
+        reject(new Error("pushStream callback fired synchronously"));
+        return;
+      }
+    } catch (e) {
+      reject(new Error(`pushStream threw synchronously: ${(e as any)?.code ?? (e as Error).message}`));
+      return;
+    }
+    stream.respond({ ":status": 200 });
+    stream.end("ok");
+  });
+
+  server.listen(0, () => {
+    const port = (server.address() as any).port;
+    const client = http2.connect(`http://localhost:${port}`);
+    const req = client.request({ ":path": "/" });
+    req.resume();
+    req.on("end", () => {
+      client.close();
+      server.close();
+      resolve();
+    });
+    req.on("error", reject);
+    req.end();
+  });
+
+  await promise;
+});
+
+test("pushStream accepts the (headers, callback) shape with options omitted", async () => {
+  const server = http2.createServer();
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+  server.on("stream", stream => {
+    try {
+      stream.pushStream({ ":path": "/x.js" }, (err, pushStream) => {
+        try {
+          expect((err as any)?.code).toBe("ERR_HTTP2_PUSH_DISABLED");
+          expect(pushStream).toBeUndefined();
+        } catch (e) {
+          reject(e);
+        }
+      });
+      stream.respond({ ":status": 200 });
+      stream.end("ok");
+    } catch (e) {
+      reject(e);
+    }
+  });
+
+  server.listen(0, () => {
+    const port = (server.address() as any).port;
+    const client = http2.connect(`http://localhost:${port}`);
+    const req = client.request({ ":path": "/" });
+    req.resume();
+    req.on("end", () => {
+      client.close();
+      server.close();
+      resolve();
+    });
+    req.on("error", reject);
+    req.end();
+  });
+
+  await promise;
+});
+
+test("pushStream rejects a non-function callback synchronously (ERR_INVALID_ARG_TYPE)", async () => {
+  const server = http2.createServer();
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+  server.on("stream", stream => {
+    try {
+      expect(() => (stream as any).pushStream({ ":path": "/x.js" }, "not-a-function")).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+      );
+      expect(() => (stream as any).pushStream({ ":path": "/x.js" })).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+      );
+      stream.respond({ ":status": 200 });
+      stream.end("ok");
+      resolve();
+    } catch (e) {
+      reject(e);
+    }
+  });
+
+  server.listen(0, () => {
+    const port = (server.address() as any).port;
+    const client = http2.connect(`http://localhost:${port}`);
+    const req = client.request({ ":path": "/" });
+    req.resume();
+    req.on("end", () => {
+      client.close();
+      server.close();
+    });
+    req.on("error", () => {});
+    req.end();
+  });
+
+  await promise;
+});
+
+test("Http2ServerResponse.createPushResponse delivers the error via its callback", async () => {
+  const server = http2.createServer((req, res) => {
+    res.createPushResponse({ ":path": "/x.js" }, (err, pushRes) => {
+      expect((err as any)?.code).toBe("ERR_HTTP2_PUSH_DISABLED");
+      expect(pushRes).toBeUndefined();
+      res.end("ok");
+    });
+  });
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+  server.listen(0, () => {
+    const port = (server.address() as any).port;
+    const client = http2.connect(`http://localhost:${port}`);
+    const req = client.request({ ":path": "/" });
+    let body = "";
+    req.setEncoding("utf8");
+    req.on("data", chunk => {
+      body += chunk;
+    });
+    req.on("end", () => {
+      try {
+        expect(body).toBe("ok");
+        resolve();
+      } catch (e) {
+        reject(e);
+      } finally {
+        client.close();
+        server.close();
+      }
+    });
+    req.on("error", reject);
+    req.end();
+  });
+
+  await promise;
+});


### PR DESCRIPTION
Fixes #30942.

## Repro

```js
// server.cjs
const http2 = require("http2");
const server = http2.createServer();
server.on("stream", (stream) => {
  stream.pushStream({ ":path": "/x.js" }, (err, pushStream) => {
    if (err) { console.log("push error:", err.message); return; }
    pushStream.respond({ ":status": 200 });
    pushStream.end("console.log(1)");
  });
  stream.respond({ ":status": 200 });
  stream.end("ok");
});
server.listen(3000);
```

```js
// client.cjs — default http2.connect has push enabled
const c = require("http2").connect("http://localhost:3000");
const req = c.request({ ":path": "/" });
req.on("data", () => {});
req.on("end", () => { console.log("done"); c.close(); });
req.end();
```

Before: Bun crashes out of the `'stream'` handler with a synchronous
`ERR_HTTP2_PUSH_DISABLED` throw. Node routes the error through the
`(err, pushStream)` callback (when push is disabled) or actually sends
the `PUSH_PROMISE` frame (when push is allowed — which is the default
client setting), so the same code prints `done` on Node.

## Cause

`ServerHttp2Stream.pushStream` in `src/js/node/http2.ts` was a stub:

```ts
pushStream() {
  throw $ERR_HTTP2_PUSH_DISABLED();
}
```

It ignored the callback argument entirely and threw synchronously. Any
user code following the Node-style error-first callback pattern died
inside the event handler before it could read `err`.

## Fix

Match Node's callback contract while push-promise sending stays
unimplemented in Bun:

- Accept `(headers, options, callback)` and the 2-arg `(headers, callback)`
  form.
- `validateFunction(callback, "callback")` so bad callback types still
  throw `ERR_INVALID_ARG_TYPE` synchronously (what Node does).
- Deliver `ERR_HTTP2_PUSH_DISABLED` via `process.nextTick(callback, err)`
  instead of throwing, so user code can observe the error and continue.

`Http2ServerResponse.createPushResponse` already calls `pushStream` with
an error-first callback and propagates `err` — so this change also
unbreaks `res.createPushResponse(headers, cb)`.

Once full PUSH_PROMISE support lands (see #28713), the stub disappears
and real success paths run through the same callback. This change is a
stopgap so the reporter's code stops crashing in the meantime.

## Verification

Five new tests in `test/js/node/http2/node-http2.test.js` cover:
- pushStream does not throw synchronously; body round-trips as "ok"
- error is delivered asynchronously, not synchronously, from the callback
- `(headers, callback)` shape (options omitted) is accepted
- non-function callback synchronously throws `ERR_INVALID_ARG_TYPE`
- `response.createPushResponse` delivers the error via its callback

Gate:

```
git stash push -- src/
bun bd test test/js/node/http2/node-http2.test.js -t "createPushResponse|pushStream"
  → 5 fail (sync throw out of 'stream' handler)
git stash pop
bun bd test test/js/node/http2/node-http2.test.js -t "createPushResponse|pushStream"
  → 5 pass
```

Full `node-http2.test.js` suite: 249 pass, 6 skip, 1 pre-existing timeout
(`http2 server with minimal maxSessionMemory handles multiple requests` —
fails on `main` too in this container, unrelated to this PR).
