### PR TITLE
fix(jsc): fix data race on VirtualMachine::is_shutting_down 

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6,6 +6,7 @@
 use core::cell::Cell;
 use core::ffi::{c_char, c_int, c_void};
 use core::ptr::NonNull;
+use core::sync::atomic::{AtomicBool, Ordering};
 
 use bun_bundler::Transpiler;
 use bun_io as Async;
@@ -207,7 +208,7 @@ pub struct VirtualMachine {
     pub hide_bun_stackframes: bool,
 
     pub is_printing_plugin: bool,
-    pub is_shutting_down: bool,
+    pub is_shutting_down: AtomicBool,
     pub plugin_runner: Option<crate::plugin_runner::PluginRunner>,
     pub is_main_thread: bool,
     pub exit_handler: ExitHandler,
@@ -981,13 +982,13 @@ impl VirtualMachine {
     }
 
     pub fn is_shutting_down(&self) -> bool {
-        self.is_shutting_down
+        self.is_shutting_down.load(Ordering::Acquire)
     }
 
     /// Port of `VirtualMachine.scriptExecutionStatus` (VirtualMachine.zig:885).
     /// Exported to C++ as `Bun__VM__scriptExecutionStatus` via virtual_machine_exports.rs.
     pub fn script_execution_status(&self) -> crate::ScriptExecutionStatus {
-        if self.is_shutting_down {
+        if self.is_shutting_down.load(Ordering::Acquire) {
             return crate::ScriptExecutionStatus::Stopped;
         }
 
@@ -1485,7 +1486,7 @@ impl VirtualMachine {
         }
 
         ExitHandler::dispatch_on_exit(self);
-        self.is_shutting_down = true;
+        self.is_shutting_down.store(true, Ordering::Release);
 
         // Make sure we run new cleanup hooks introduced by running cleanup
         // hooks.

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1238,7 +1238,7 @@ impl WebWorker {
             // clear it so process.on('exit') handlers can run. teardownJSCVM
             // re-sets it for the JSC VM teardown.
             vm.jsc_vm().clear_has_termination_request();
-            vm.is_shutting_down = true;
+            vm.is_shutting_down.store(true, Ordering::Release);
             vm.on_exit();
             if let Some(hooks) = runtime_hooks() {
                 (hooks.cron_clear_all_teardown)(vm);

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -5,6 +5,7 @@ use crate::cli::test::changed_files_filter as ChangedFilesFilter;
 use crate::cli::test::parallel_runner as ParallelRunner;
 use crate::cli::test::scanner::{self, Scanner};
 use bun_collections::{ArrayHashMap, BoundedArray, StringHashMap};
+use core::sync::atomic::Ordering;
 use bun_core::{self as bun, Global, Output, env_var, fmt as bun_fmt};
 use bun_core::{err_generic, pretty_error, pretty_errorln};
 use bun_dotenv as DotEnv;
@@ -2398,7 +2399,7 @@ impl TestCommand {
                                 );
                             }
                             vm.exit_handler.exit_code = 1;
-                            vm.is_shutting_down = true;
+                            vm.is_shutting_down.store(true, Ordering::Release);
                             let vm_ptr: *mut VirtualMachine = vm;
                             vm.run_with_api_lock(|| unsafe { (*vm_ptr).global_exit() });
                         }
@@ -2493,7 +2494,7 @@ impl TestCommand {
                         );
                     }
                     vm.exit_handler.exit_code = 1;
-                    vm.is_shutting_down = true;
+                    vm.is_shutting_down.store(true, Ordering::Release);
                     let vm_ptr: *mut VirtualMachine = vm;
                     vm.run_with_api_lock(|| unsafe { (*vm_ptr).global_exit() });
                 }
@@ -3025,7 +3026,7 @@ impl TestCommand {
         } else if reporter.jest.unhandled_errors_between_tests > 0 {
             vm.exit_handler.exit_code = 1;
         }
-        vm.is_shutting_down = true;
+        vm.is_shutting_down.store(true, Ordering::Release);
         {
             let vm_ptr: *mut VirtualMachine = vm;
             vm.run_with_api_lock(|| unsafe { (*vm_ptr).global_exit() });
@@ -3256,7 +3257,7 @@ impl TestCommand {
                         reporter.write_junit_report_if_needed();
 
                         vm.exit_handler.exit_code = 1;
-                        vm.is_shutting_down = true;
+                        vm.is_shutting_down.store(true, Ordering::Release);
                         // SAFETY: global_exit diverges; raw-ptr reborrow mirrors Zig
                         // runWithAPILock(*VM, vm, globalExit).
                         let vm_ptr = std::ptr::from_mut::<VirtualMachine>(vm);


### PR DESCRIPTION
### What does this PR do?
Fixes a data race on `VirtualMachine::is_shutting_down`.

`is_shutting_down` was a plain `bool`, written from the main JS thread and read from the HTTP background thread via `&'static VirtualMachine`. Under the Rust memory model this is undefined behavior. On ARM, the write may never propagate to the reading core without an atomic barrier, causing the HTTP thread to operate on JSC state (`global_this`, `JSPromiseStrong`) after the VM has begun destructing in `global_exit()`.

The fix changes the field to `AtomicBool`:
- **Reads**: `load(Ordering::Acquire)` guarantees that seeing `true` synchronizes-with the release store, making all prior teardown writes visible
- **Writes**: `store(true, Ordering::Release)`  prevents reordering of cleanup hooks past the flag

### How did you verify your code works?
- Build succeeds (`bun run build`) with no new warnings
- `bun bd test test/js/bun/http/serve.test.ts -t "should work"` — 11 pass, 0 fail