### PR TITLE
socket: don't assert in Handlers::unprotect when never protected

### DIFF
--- a/src/runtime/socket/Handlers.rs
+++ b/src/runtime/socket/Handlers.rs
@@ -392,7 +392,11 @@ impl Handlers {
 
         #[cfg(debug_assertions)]
         {
-            debug_assert!(self.protection_count > 0);
+            // `Drop` runs even on the early-error returns in `from_generated`
+            // (before `protect()`); nothing to unprotect in that case.
+            if self.protection_count == 0 {
+                return;
+            }
             self.protection_count -= 1;
         }
         self.on_open.unprotect();

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -821,6 +821,27 @@ it("should throw on empty unix path from truthy non-string value", () => {
   expect(() => Bun.connect({ unix: [] as any, socket })).toThrow("SocketOptions.unix must be a string");
 });
 
+it("should throw when socket handlers have no data or drain callback", () => {
+  // Handlers validation fails before protect() is called; Drop must not
+  // assert on an unprotected Handlers.
+  expect(() => Bun.listen({ hostname: "localhost", port: 0, socket: {} as any })).toThrow(
+    'Expected at least "data" or "drain" callback',
+  );
+  expect(() => Bun.connect({ hostname: "localhost", port: 0, socket: {} as any })).toThrow(
+    'Expected at least "data" or "drain" callback',
+  );
+});
+
+it("should throw when a socket handler is not a function", () => {
+  const socket = { open() {}, close: "not a function" } as any;
+  expect(() => Bun.listen({ hostname: "localhost", port: 0, socket })).toThrow(
+    'Expected "onClose" callback to be a function',
+  );
+  expect(() => Bun.connect({ hostname: "localhost", port: 0, socket })).toThrow(
+    'Expected "onClose" callback to be a function',
+  );
+});
+
 it("reading .listener on a closed client socket does not use-after-free handlers", async () => {
   // Client-mode Handlers is heap-allocated per-connect and freed in
   // markInactive once the socket closes. `socket.listener` read


### PR DESCRIPTION
Fuzzilli found a debug-assertion crash in `Bun.listen`/`Bun.connect` when the `socket` handlers object fails validation.

## Repro

```js
Bun.listen({ socket: {} });
```

```
panic: assertion failed: self.protection_count > 0 (src/runtime/socket/Handlers.rs:395:13)
```

## Root cause

`Handlers::from_generated` returns early with an error when the socket handlers object has no `data`/`drain` callback or contains a non-callable handler. At that point `protect()` has not been called, so `protection_count` is still 0.

In the Zig original, the stack `result` is simply abandoned on the early error return. In Rust, `Drop for Handlers` runs → `unprotect()` → `debug_assert!(self.protection_count > 0)` fails.

Release builds were unaffected: the assertion is `#[cfg(debug_assertions)]`-only, and `JSValue::unprotect()` on `ZERO` / unprotected cells is a no-op on the C++ side.

## Fix

Skip the unprotect body when `protection_count == 0` in debug builds. There is nothing to unprotect, and `Drop` can only run once so the double-unprotect case the assertion guarded against cannot arise.