### PR TITLE
Fix FileSink.start() crash when called without path/fd on an open writer

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1565,6 +1565,7 @@ impl BlobExt for Blob {
                 let stream_start = streams::Start::FileSink(streams::FileSinkOptions {
                     input_path,
                     chunk_size: 0,
+                    ..Default::default()
                 });
 
                 // SAFETY: `init` returns a freshly-allocated +1 *mut FileSink.
@@ -1928,6 +1929,7 @@ impl BlobExt for Blob {
                 streams::Start::FileSink(streams::FileSinkOptions {
                     chunk_size: 0,
                     input_path: webcore::PathOrFileDescriptor::Fd(Fd::INVALID),
+                    ..Default::default()
                 })
             };
             if let streams::Start::FileSink(ref mut opts) = stream_start {
@@ -1936,6 +1938,7 @@ impl BlobExt for Blob {
                 stream_start = streams::Start::FileSink(streams::FileSinkOptions {
                     chunk_size: 0,
                     input_path,
+                    ..Default::default()
                 });
             }
 

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -850,33 +850,9 @@ impl FileSink {
     pub fn start(&self, stream_start: streams::Start) -> sys::Result<()> {
         match stream_start {
             streams::Start::FileSink(ref file)
-                if !matches!(
-                    file.input_path,
-                    crate::webcore::PathOrFileDescriptor::Fd(Fd::INVALID)
-                ) =>
+                if !matches!(file.input_path, PathOrFileDescriptor::Fd(Fd::INVALID)) =>
             {
-                // PORT NOTE: `streams::FileSinkOptions` mirrors `file_sink::Options`
-                // but is a distinct draft type; bridge by-field until streams.rs
-                // aliases to this module's `Options`.
-                let opts = Options {
-                    chunk_size: file.chunk_size as webcore::BlobSizeType,
-                    input_path: match &file.input_path {
-                        crate::webcore::PathOrFileDescriptor::Fd(fd) => {
-                            PathOrFileDescriptor::Fd(*fd)
-                        }
-                        crate::webcore::PathOrFileDescriptor::Path(p) => {
-                            // `ZigStringSlice` is non-`Clone` (owns/WTF-refs its
-                            // bytes); borrow the bytes for the duration of
-                            // `setup(&opts)` — `stream_start` (and thus `p`)
-                            // outlives `opts` within this match arm.
-                            PathOrFileDescriptor::Path(
-                                bun_core::zig_string::Slice::from_utf8_never_free(p.slice()),
-                            )
-                        }
-                    },
-                    ..Options::default()
-                };
-                match self.setup(&opts) {
+                match self.setup(file) {
                     sys::Result::Err(err) => {
                         return sys::Result::Err(err);
                     }

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -849,7 +849,12 @@ impl FileSink {
 
     pub fn start(&self, stream_start: streams::Start) -> sys::Result<()> {
         match stream_start {
-            streams::Start::FileSink(ref file) => {
+            streams::Start::FileSink(ref file)
+                if !matches!(
+                    file.input_path,
+                    crate::webcore::PathOrFileDescriptor::Fd(Fd::INVALID)
+                ) =>
+            {
                 // PORT NOTE: `streams::FileSinkOptions` mirrors `file_sink::Options`
                 // but is a distinct draft type; bridge by-field until streams.rs
                 // aliases to this module's `Options`.

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -49,22 +49,8 @@ pub mod result {
 // Start
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Options payload for the `Start::FileSink` variant. Mirrors
-/// `jsc.WebCore.FileSink.Options` (path-or-fd + chunk size).
-// TODO(port): once `crate::webcore::file_sink::Options` is exported, alias to it.
-pub struct FileSinkOptions {
-    pub chunk_size: BlobSizeType,
-    pub input_path: crate::webcore::PathOrFileDescriptor,
-}
-
-impl Default for FileSinkOptions {
-    fn default() -> Self {
-        Self {
-            chunk_size: 0,
-            input_path: crate::webcore::PathOrFileDescriptor::Fd(Fd::INVALID),
-        }
-    }
-}
+/// Options payload for the `Start::FileSink` variant.
+pub type FileSinkOptions = crate::webcore::file_sink::Options;
 
 pub enum Start {
     Empty,
@@ -253,6 +239,7 @@ impl Start {
                             // folded into the owning `ZigStringSlice`.
                             path.to_slice(global_this)?,
                         ),
+                        ..Default::default()
                     }));
                 } else if let Some(fd_value) = value.get_truthy(global_this, b"fd")? {
                     if !fd_value.is_any_int() {
@@ -268,6 +255,7 @@ impl Start {
                         return Ok(Start::FileSink(FileSinkOptions {
                             chunk_size,
                             input_path: crate::webcore::PathOrFileDescriptor::Fd(fd),
+                            ..Default::default()
                         }));
                     } else {
                         return Ok(Start::Err(SysError {
@@ -281,6 +269,7 @@ impl Start {
                 return Ok(Start::FileSink(FileSinkOptions {
                     input_path: crate::webcore::PathOrFileDescriptor::Fd(Fd::INVALID),
                     chunk_size,
+                    ..Default::default()
                 }));
             }
             StartTag::NetworkSink

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -268,3 +268,13 @@ it.skipIf(!isPosix)("does not leak native FileSink when a pending write fails (E
   // more than that indicates a native leak.
   expect(fileSinkInternals.liveCount()).toBeLessThanOrEqual(baseline + 1);
 });
+
+it("start() without path/fd on an already-open writer does not crash", async () => {
+  const path = join(tmpdirSync(), "filesink-restart.txt");
+  const writer = Bun.file(path).writer();
+  expect(() => writer.start({})).not.toThrow();
+  expect(() => writer.start({ highWaterMark: 1024 })).not.toThrow();
+  writer.write("hello");
+  await writer.end();
+  expect(await Bun.file(path).text()).toBe("hello");
+});


### PR DESCRIPTION
## What

Fixes a debug assertion failure (`fd != Fd::INVALID` in `src/sys/Error.rs`) when calling `.start()` on a `FileSink` created by `Bun.file(path).writer()` with an options object that does not include a `path` or `fd` property.

```js
const writer = Bun.file("/tmp/out.txt").writer();
writer.start({}); // panic: assertion failed: fd != Fd::INVALID
```

## Why

`Start::from_js_with_tag::<FileSink>` returns `Start::FileSink { input_path: Fd(Fd::INVALID), .. }` when the options object has neither `path` nor `fd`. `FileSink::start()` then unconditionally called `setup()`, which called `dup_with_flags(Fd::INVALID, 0)`. The `fcntl` fails with `EBADF`, and when building the error via `.with_fd(Fd::INVALID)` we hit the debug assertion.

In `Blob::get_writer` the invalid-fd placeholder is always overwritten with the real file path/fd before `start()` is called, but the JS-exposed `.start()` has no such override.

## How

Add a match guard in `FileSink::start()` to skip `setup()` when the incoming `input_path` is the invalid-fd placeholder — the writer is already configured, so we only update `done`/`started`/`signal` state as before. Calls with a real `path` or `fd` still re-run `setup()`.

Found by Fuzzilli.