### PR TITLE
Fix over-deref of `Blob.name` in `borrowed_view()`

### DIFF
--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -335,14 +335,14 @@ impl Blob {
     ///
     /// In Zig that copy bumps **no** refcounts and is never `deinit()`ed — it
     /// just borrows `self`'s store/name/content_type for the caller's stack
-    /// frame. In Rust, `StoreRef` has drop glue, so the only sound translation
-    /// is: clone the `StoreRef` (its `Drop` balances the +1 at scope exit) and
-    /// **alias** `name`/`content_type` as borrowed bits (both are `Copy` raw
-    /// data with no `Drop`, so nothing runs on scope exit).
+    /// frame. In Rust, both `StoreRef` and `OwnedStringCell` have drop glue,
+    /// so the only sound translation is: clone them (their `Drop` balances the
+    /// +1 at scope exit) and **alias** `content_type` as borrowed bits (a
+    /// `Copy` raw pointer with no `Drop`, so nothing runs on scope exit).
     ///
-    /// Do **not** use [`Blob::dupe`] for this — it `dupe_ref()`s `name` and
-    /// boxes a fresh `content_type`, neither of which is freed by drop glue,
-    /// so both leak when the result is treated as a no-copy view.
+    /// Do **not** use [`Blob::dupe`] for this — it boxes a fresh
+    /// `content_type`, which is not freed by drop glue, so it leaks when the
+    /// result is treated as a no-copy view.
     #[inline]
     pub fn borrowed_view(&self) -> Blob {
         Blob {
@@ -358,7 +358,7 @@ impl Blob {
             ref_count: bun_ptr::RawRefCount::init(0), // setNotHeapAllocated
             global_this: Cell::new(self.global_this.get()),
             last_modified: Cell::new(self.last_modified.get()),
-            name: bun_core::OwnedStringCell::new(self.name.get()), // borrowed; no dupe_ref
+            name: self.name.clone(), // +1 ↔ OwnedStringCell::drop on scope exit
         }
     }
 

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1900,9 +1900,9 @@ impl PathOrBlob {
         if let Some(blob) = arg.as_class_ref::<Blob>() {
             // Zig: `blob.*` — a raw bitwise copy with no ref bumps that callers
             // never `deinit()`. `borrowed_view()` is the sound Rust spelling: it
-            // clones only the `StoreRef` (whose `Drop` balances the +1) and
-            // aliases `name`/`content_type`; `dupe()` would leak both since
-            // `Blob` has no `Drop`. `as_class_ref` is the safe shared-borrow
+            // clones the `StoreRef`/`name` (whose `Drop`s balance the +1) and
+            // aliases `content_type`; `dupe()` would leak the boxed
+            // `content_type` copy. `as_class_ref` is the safe shared-borrow
             // downcast — the JS wrapper roots the payload while `arg` is on the
             // stack.
             return Ok(PathOrBlob::Blob(blob.borrowed_view()));

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4499,14 +4499,13 @@ pub fn write_file_with_source_destination(
         // Zig passes `destination_blob.*` / `source_blob.*` (raw struct copy,
         // +0 store ref) and `WriteFile.create` then calls `store.?.ref()`. The
         // Rust port folds that pair into RAII: callers hand over a +1 `Blob`
-        // via `borrowed_view()` (clones only the `StoreRef`; `name` /
-        // `content_type` are aliased — unused by `WriteFile*`, no `Drop`) and
+        // via `borrowed_view()` (clones the `StoreRef`/`name`; `content_type`
+        // is aliased — unused by `WriteFile*`, no `Drop`) and
         // `WriteFile::create` does NOT re-bump (see PORT NOTE in
         // `write_file.rs::create_with_ctx`); the matching deref runs when
-        // `heap::take` drops the embedded `StoreRef` in `then`/`deinit`.
-        // Net store ref balance is identical. `dupe()` is wrong here: it
-        // `dupe_ref()`s `name` and boxes a fresh `content_type`, neither of
-        // which is released by `Blob`'s (nonexistent) drop glue.
+        // `heap::take` drops the embedded `StoreRef`/`name` in `then`/`deinit`.
+        // Net ref balance is identical. `dupe()` is wrong here: it boxes a
+        // fresh `content_type`, which is not released by `Blob`'s drop glue.
         #[cfg(windows)]
         {
             let promise = JSPromise::create(ctx);

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -542,4 +542,56 @@ const IS_UV_FS_COPYFILE_DISABLED =
       expect(await exited).toBe(0);
     }, 10000);
   }
+
+  it("BunFile.name survives multiple file.write() calls + GC", async () => {
+    using dir = tempDir("bun-file-name-write-gc", {});
+    const filePath = join(String(dir), "out.txt");
+
+    const f = Bun.file(filePath);
+    expect(f.name).toBe(filePath);
+
+    await f.write("a");
+    await f.write("b");
+    await f.write("c");
+    await f.write("d");
+    Bun.gc(true);
+
+    expect(f.name).toBe(filePath);
+    expect(await f.text()).toBe("d");
+  });
+
+  it("BunFile.name survives multiple Bun.write() calls + GC", async () => {
+    using dir = tempDir("bun-file-name-bunwrite-gc", {});
+    const filePath = join(String(dir), "out.txt");
+
+    const f = Bun.file(filePath);
+    expect(f.name).toBe(filePath);
+
+    await Bun.write(f, "a");
+    await Bun.write(f, "b");
+    await Bun.write(f, "c");
+    await Bun.write(f, "d");
+    Bun.gc(true);
+
+    expect(f.name).toBe(filePath);
+    expect(await f.text()).toBe("d");
+  });
+
+  it("BunFile.name survives concurrent write() calls + GC", async () => {
+    using dir = tempDir("bun-file-name-concurrent-write-gc", {});
+    const filePath = join(String(dir), "out.txt");
+
+    const f = Bun.file(filePath);
+    f.name;
+
+    const writes = [];
+    for (let i = 0; i < 8; i++) {
+      writes.push(f.write("x").catch(() => {}));
+    }
+    Bun.gc(true);
+    await Promise.all(writes);
+    Bun.gc(true);
+
+    expect(f.name).toBe(filePath);
+  });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes a SIGFPE crash that occurs when writing to a `BunFile` multiple times after reading its `.name` property, followed by a GC.

```js
const f = Bun.file("/tmp/test.txt");
f.name;
f.write("a").catch(() => {});
f.write("b").catch(() => {});
Bun.gc(true); // SIGFPE
```

### Root cause

`Blob::borrowed_view()` constructed its `name` field via `OwnedStringCell::new(self.name.get())`, which copies the `String` value **without** bumping its refcount. The surrounding doc comment assumed `name` was `Copy` raw data with no `Drop`, but `OwnedStringCell` **does** implement `Drop` (it `deref()`s the inner `String`).

So every time a `borrowed_view()` was dropped — which happens in `BunFile.prototype.write()`, `Bun.write(file, ...)`, and `WriteFile::create` via `PathOrBlob::Blob(...)` — the original Blob's `name` `StringImpl` was deref'd without a matching ref.

After two writes to a `BunFile` whose `.name` had been materialized, the `StringImpl` refcount hit 0 while the cached `JSString` in `JSBlob::m_name` still pointed at it. The next GC then hit `StringImpl::costDuringGC()` → `divideRoundedUp(len, refCount())` with `refCount() == 0` → SIGFPE.

### Fix

Clone the `OwnedStringCell` (which `dupe_ref()`s, balanced by its `Drop`), same as the `store` field already does.

## How did you verify your code works?

Added regression tests to `test/js/bun/io/bun-write.test.js` covering `file.write()`, `Bun.write(file, ...)`, and concurrent writes followed by GC. All crash on the unfixed binary and pass with the fix.

Found by Fuzzilli (fingerprint `db407a6431bfbfa7`).