### PR TITLE
js_parser/lexer: reject JSX numeric entities outside Unicode range

### DIFF
--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -3336,8 +3336,21 @@ lexer_impl_header! {
 
                 // PORT NOTE: std.fmt.parseInt(i32, ..) — bytes-based parser; source bytes are
                 // not guaranteed UTF-8 so we never round-trip through &str (PORTING.md §Strings).
+                // Also reject values outside the Unicode range (0..=0x10FFFF); otherwise
+                // `push_codepoint_utf16` hits `debug_assert`s in `u16_lead`/`u16_trail`
+                // (release builds would silently encode garbage surrogate pairs).
                 cursor.c = match bun_core::parse_int::<i32>(number, base) {
-                    Ok(v) => v,
+                    Ok(v) if (0..=0x10FFFF).contains(&v) => v,
+                    Ok(_) => {
+                        self.add_error(
+                            self.start,
+                            format_args!(
+                                "JSX entity escape is too big: {}",
+                                bstr::BStr::new(entity)
+                            ),
+                        );
+                        strings::UNICODE_REPLACEMENT as CodePoint
+                    }
                     Err(err) => {
                         match err {
                             strings::ParseIntError::InvalidCharacter => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1560,9 +1560,7 @@ console.log(<div {...obj} key="after" />);`),
     // lands as a negative CodePoint that must be rejected before it reaches
     // the u32 cast in push_codepoint_utf16.
     it.each(["&#7777707;", "&#x110000;", "&#2147483647;", "&#-1;"])("%s is rejected", entity => {
-      expect(() => bun.transformSync(`export var x = <div>${entity}</div>`)).toThrow(
-        /JSX entity escape is too big/,
-      );
+      expect(() => bun.transformSync(`export var x = <div>${entity}</div>`)).toThrow(/JSX entity escape is too big/);
     });
 
     // Boundary: 0x10FFFF is the maximum valid code point and must still work.

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1549,18 +1549,26 @@ console.log(<div {...obj} key="after" />);`),
   // encoded the value as a UTF-16 surrogate pair. The lexer must reject the
   // entity with the same "JSX entity escape is too big" diagnostic it emits
   // for i32-overflow, instead of forwarding an invalid code point.
-  it("rejects out-of-range numeric JSX entities without panicking", () => {
-    var bun = new Bun.Transpiler({
+  describe("rejects out-of-range numeric JSX entities without panicking", () => {
+    const bun = new Bun.Transpiler({
       loader: "jsx",
       define: { "process.env.NODE_ENV": JSON.stringify("development") },
     });
 
-    for (const entity of ["&#7777707;", "&#x110000;", "&#2147483647;"]) {
-      expect(() => bun.transformSync(`export var x = <div>${entity}</div>`)).toThrow(/JSX entity escape is too big/);
-    }
+    // Covers: the original fuzzer input (0x76B22B), max+1, i32::MAX, and the
+    // negative-i32 path — parse_int::<i32> accepts a leading '-' so `&#-1;`
+    // lands as a negative CodePoint that must be rejected before it reaches
+    // the u32 cast in push_codepoint_utf16.
+    it.each(["&#7777707;", "&#x110000;", "&#2147483647;", "&#-1;"])("%s is rejected", entity => {
+      expect(() => bun.transformSync(`export var x = <div>${entity}</div>`)).toThrow(
+        /JSX entity escape is too big/,
+      );
+    });
 
     // Boundary: 0x10FFFF is the maximum valid code point and must still work.
-    expect(bun.transformSync("export var x = <div>&#x10FFFF;</div>")).toContain("jsxDEV_");
+    it("&#x10FFFF; (max valid) still transpiles", () => {
+      expect(bun.transformSync("export var x = <div>&#x10FFFF;</div>")).toContain("jsxDEV_");
+    });
   });
 
   it("require with a dynamic non-string expression", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1543,6 +1543,28 @@ console.log(<div {...obj} key="after" />);`),
     );
   });
 
+  // https://github.com/oven-sh/bun/issues/30958
+  // A numeric JSX entity outside the Unicode range (0..=0x10FFFF) used to
+  // trip a debug_assert in u16_lead (src/bun_core/lib.rs) when the lexer
+  // encoded the value as a UTF-16 surrogate pair. The lexer must reject the
+  // entity with the same "JSX entity escape is too big" diagnostic it emits
+  // for i32-overflow, instead of forwarding an invalid code point.
+  it("rejects out-of-range numeric JSX entities without panicking", () => {
+    var bun = new Bun.Transpiler({
+      loader: "jsx",
+      define: { "process.env.NODE_ENV": JSON.stringify("development") },
+    });
+
+    for (const entity of ["&#7777707;", "&#x110000;", "&#2147483647;"]) {
+      expect(() => bun.transformSync(`export var x = <div>${entity}</div>`)).toThrow(
+        /JSX entity escape is too big/,
+      );
+    }
+
+    // Boundary: 0x10FFFF is the maximum valid code point and must still work.
+    expect(bun.transformSync("export var x = <div>&#x10FFFF;</div>")).toContain("jsxDEV_");
+  });
+
   it("require with a dynamic non-string expression", () => {
     var nodeTranspiler = new Bun.Transpiler({ platform: "node" });
     expect(nodeTranspiler.transformSync("require('hi' + bar)")).toBe('require("hi" + bar);\n');

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1556,9 +1556,7 @@ console.log(<div {...obj} key="after" />);`),
     });
 
     for (const entity of ["&#7777707;", "&#x110000;", "&#2147483647;"]) {
-      expect(() => bun.transformSync(`export var x = <div>${entity}</div>`)).toThrow(
-        /JSX entity escape is too big/,
-      );
+      expect(() => bun.transformSync(`export var x = <div>${entity}</div>`)).toThrow(/JSX entity escape is too big/);
     }
 
     // Boundary: 0x10FFFF is the maximum valid code point and must still work.


### PR DESCRIPTION
## Reproduction

```console
$ echo 'PP87JiM3Nzc3NzA3O3s=' | base64 -d > /tmp/repro.jsx   # <\xff;&#7777707;{
$ bun-debug /tmp/repro.jsx
panic: assertion failed: supplementary >= 0x10000 && supplementary <= 0x10FFFF (src/bun_core/lib.rs:1319:9)
```

Minimal JSX form:

```console
$ bun-debug -e 'const x = <div>&#7777707;</div>'
panic: assertion failed: supplementary >= 0x10000 && supplementary <= 0x10FFFF
```

`&#7777707;` decodes to 0x76B22B, well beyond the maximum valid Unicode
codepoint U+10FFFF.

## Cause

`maybe_decode_jsx_entity` (`src/js_parser/lexer.rs:3312`) parses the
numeric entity as `i32` and only errors on `InvalidCharacter` /
`Overflow` from `bun_core::parse_int`. Any value that fits in `i32` is
forwarded to `strings::push_codepoint_utf16` (called from
`decode_jsx_entities`), which calls `encode_surrogate_pair` →
`u16_lead` / `u16_trail`. Both assert `supplementary <= 0x10FFFF`
(`src/bun_core/lib.rs:1319` and `:1326`). Debug builds panic; release
builds silently encode garbage surrogate pairs (the Zig original used
`@truncate` inline and hid the problem).

## Fix

Reject values outside the Unicode range `0..=0x10FFFF` in the same
arm that handles `parse_int` success, emitting the existing
"JSX entity escape is too big" diagnostic and substituting
`UNICODE_REPLACEMENT` (U+FFFD) — matching the `Overflow` branch.

## Verification

```console
$ bun-debug -e 'const x = <div>&#7777707;</div>'
1 | const x = <div>&#7777707;</div>
                    ^
error: JSX entity escape is too big: #7777707
```

Boundary cases covered:
- `&#x10FFFF;` (max valid) — still encodes as a surrogate pair
- `&#x110000;` (max + 1) — "JSX entity escape is too big"
- `&#-1;` (negative i32) — "JSX entity escape is too big"
- `&#2147483647;` (i32::MAX) — "JSX entity escape is too big"

Test added to `test/bundler/transpiler/transpiler.test.js` alongside
the other JSX lexer tests. Without the fix the test binary panics in
`u16_lead`; with the fix each out-of-range entity throws and the
`&#x10FFFF;` boundary still compiles.

Fixes #30958