### PR TITLE
parser: gate class-static-block branch on is_class

### DIFF
--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -504,7 +504,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     }
                                 }
                             }
-                        } else if p.lexer.token == T::TOpenBrace && name == b"static" {
+                        } else if opts.is_class
+                            && p.lexer.token == T::TOpenBrace
+                            && name == b"static"
+                        {
                             let loc = p.lexer.loc();
                             p.lexer.next()?;
 

--- a/src/js_parser/parse/parse_property.zig
+++ b/src/js_parser/parse/parse_property.zig
@@ -318,7 +318,7 @@ pub fn ParseProperty(
                                         },
                                     }
                                 }
-                            } else if (p.lexer.token == .t_open_brace and strings.eqlComptime(name, "static")) {
+                            } else if (opts.is_class and p.lexer.token == .t_open_brace and strings.eqlComptime(name, "static")) {
                                 const loc = p.lexer.loc();
                                 try p.lexer.next();
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2398,22 +2398,6 @@ class Foo {
     expectParseError("x: { class Foo { static { break x } } }", 'There is no containing label named "x"');
     expectParseError("x: { class Foo { static { continue x } } }", 'There is no containing label named "x"');
 
-    // `static { ... }` is only a class static block inside a class body.
-    // In an object literal it must be treated as an ordinary identifier so
-    // that the trailing `{` produces a syntax error rather than a parser
-    // assertion failure. https://github.com/oven-sh/bun/issues/30963
-    for (const code of ["[{static{}", "({static{}})", "({static{};})", "({static{},})"]) {
-      let threw = false;
-      try {
-        transpiler.transformSync(code, "js");
-      } catch (e) {
-        threw = true;
-        const messages = e instanceof AggregateError ? e.errors.map(x => x.message) : [e.message];
-        expect(messages.some(m => m.includes('Expected "}" but found "{"'))).toBe(true);
-      }
-      expect(threw).toBe(true);
-    }
-
     expectParseError("class Foo { get #x() { this.#x = 1 } }", 'Writing to getter-only property "#x" will throw');
     expectParseError("class Foo { get #x() { this.#x += 1 } }", 'Writing to getter-only property "#x" will throw');
     expectParseError("class Foo { set #x(x) { this.#x } }", 'Reading from setter-only property "#x" will throw');

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2398,6 +2398,22 @@ class Foo {
     expectParseError("x: { class Foo { static { break x } } }", 'There is no containing label named "x"');
     expectParseError("x: { class Foo { static { continue x } } }", 'There is no containing label named "x"');
 
+    // `static { ... }` is only a class static block inside a class body.
+    // In an object literal it must be treated as an ordinary identifier so
+    // that the trailing `{` produces a syntax error rather than a parser
+    // assertion failure. https://github.com/oven-sh/bun/issues/30963
+    for (const code of ["[{static{}", "({static{}})", "({static{};})", "({static{},})"]) {
+      let threw = false;
+      try {
+        transpiler.transformSync(code, "js");
+      } catch (e) {
+        threw = true;
+        const messages = e instanceof AggregateError ? e.errors.map(x => x.message) : [e.message];
+        expect(messages.some(m => m.includes('Expected "}" but found "{"'))).toBe(true);
+      }
+      expect(threw).toBe(true);
+    }
+
     expectParseError("class Foo { get #x() { this.#x = 1 } }", 'Writing to getter-only property "#x" will throw');
     expectParseError("class Foo { get #x() { this.#x += 1 } }", 'Writing to getter-only property "#x" will throw');
     expectParseError("class Foo { set #x(x) { this.#x } }", 'Reading from setter-only property "#x" will throw');

--- a/test/regression/issue/30963.test.ts
+++ b/test/regression/issue/30963.test.ts
@@ -35,11 +35,7 @@ for (const source of ["[{static{}", "({static{}})", "({static{};})", "({static{}
       // a clean `signalCode` rather than a bun-test runner timeout.
       timeout: 10_000,
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     // Before the fix, the debug build aborted with SIGILL inside the
     // parser and never reached the syntax-error reporter — stderr carried

--- a/test/regression/issue/30963.test.ts
+++ b/test/regression/issue/30963.test.ts
@@ -1,0 +1,55 @@
+// https://github.com/oven-sh/bun/issues/30963
+//
+// Parsing `[{static{}` (a `static { ... }` block inside an object literal
+// instead of a class body) tripped a debug_assert in the object-literal
+// parser: the class-static-block branch in `parse_property.rs` fired on
+// identifier + `{` alone, without checking that the enclosing context was
+// actually a class, and returned a `Property` with neither `key` nor
+// `value`. That violated the `prop.key.is_some() || prop.value.is_some()`
+// invariant asserted at `parse_prefix.rs:870`, aborting the debug process
+// with SIGILL. Release builds masked it because the assert is gated on
+// `cfg!(debug_assertions)`, so the malformed AST fell through to the
+// existing `expect(TCloseBrace)` error path and a user-facing syntax error
+// was emitted anyway.
+//
+// The Zig sibling had the same un-gated branch; both are now gated on
+// `opts.is_class`. Outside a class body `static` is now parsed as an
+// ordinary identifier and the trailing `{` produces a normal syntax error.
+//
+// Run the parse in a subprocess so a reintroduction (debug-build SIGILL)
+// doesn't tear down the in-process test runner.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+for (const source of ["[{static{}", "({static{}})", "({static{};})", "({static{},})"]) {
+  test(`\`static { ... }\` in an object-literal position is a syntax error, not a parser crash (${source})`, async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      // Bound the subprocess: without the fix, the debug build panics
+      // (SIGILL) and should exit immediately; if it somehow hangs, we want
+      // a clean `signalCode` rather than a bun-test runner timeout.
+      timeout: 10_000,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    // Before the fix, the debug build aborted with SIGILL inside the
+    // parser and never reached the syntax-error reporter — stderr carried
+    // `panic: assertion failed: prop.key.is_some() || prop.value.is_some()`
+    // and `signalCode === "SIGILL"`. After the fix the parser emits the
+    // normal user-facing syntax error and the process exits cleanly with
+    // a non-zero code.
+    expect(stderr).toContain('Expected "}" but found "{"');
+    expect(proc.signalCode).toBeNull();
+    expect(stdout).toBe("");
+    expect(exitCode).not.toBe(0);
+  }, 30_000);
+}

--- a/test/regression/issue/30963.test.ts
+++ b/test/regression/issue/30963.test.ts
@@ -19,33 +19,36 @@
 // Run the parse in a subprocess so a reintroduction (debug-build SIGILL)
 // doesn't tear down the in-process test runner.
 
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-for (const source of ["[{static{}", "({static{}})", "({static{};})", "({static{},})"]) {
-  test(`\`static { ... }\` in an object-literal position is a syntax error, not a parser crash (${source})`, async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", source],
-      env: bunEnv,
-      stdin: "ignore",
-      stdout: "pipe",
-      stderr: "pipe",
-      // Bound the subprocess: without the fix, the debug build panics
-      // (SIGILL) and should exit immediately; if it somehow hangs, we want
-      // a clean `signalCode` rather than a bun-test runner timeout.
-      timeout: 10_000,
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+describe.each(["[{static{}", "({static{}})", "({static{};})", "({static{},})"])(
+  "`static { ... }` in an object-literal position (%s)",
+  source => {
+    test("is a syntax error, not a parser crash", async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", source],
+        env: bunEnv,
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+        // Bound the subprocess: without the fix, the debug build panics
+        // (SIGILL) and should exit immediately; if it somehow hangs, we want
+        // a clean `signalCode` rather than a bun-test runner timeout.
+        timeout: 10_000,
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // Before the fix, the debug build aborted with SIGILL inside the
-    // parser and never reached the syntax-error reporter — stderr carried
-    // `panic: assertion failed: prop.key.is_some() || prop.value.is_some()`
-    // and `signalCode === "SIGILL"`. After the fix the parser emits the
-    // normal user-facing syntax error and the process exits cleanly with
-    // a non-zero code.
-    expect(stderr).toContain('Expected "}" but found "{"');
-    expect(proc.signalCode).toBeNull();
-    expect(stdout).toBe("");
-    expect(exitCode).not.toBe(0);
-  }, 30_000);
-}
+      // Before the fix, the debug build aborted with SIGILL inside the
+      // parser and never reached the syntax-error reporter — stderr carried
+      // `panic: assertion failed: prop.key.is_some() || prop.value.is_some()`
+      // and `signalCode === "SIGILL"`. After the fix the parser emits the
+      // normal user-facing syntax error and the process exits cleanly with
+      // a non-zero code.
+      expect(stderr).toContain('Expected "}" but found "{"');
+      expect(proc.signalCode).toBeNull();
+      expect(stdout).toBe("");
+      expect(exitCode).not.toBe(0);
+    }, 30_000);
+  },
+);

--- a/test/regression/issue/30963.test.ts
+++ b/test/regression/issue/30963.test.ts
@@ -19,36 +19,34 @@
 // Run the parse in a subprocess so a reintroduction (debug-build SIGILL)
 // doesn't tear down the in-process test runner.
 
-import { describe, expect, test } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-describe.each(["[{static{}", "({static{}})", "({static{};})", "({static{},})"])(
-  "`static { ... }` in an object-literal position (%s)",
-  source => {
-    test("is a syntax error, not a parser crash", async () => {
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "-e", source],
-        env: bunEnv,
-        stdin: "ignore",
-        stdout: "pipe",
-        stderr: "pipe",
-        // Bound the subprocess: without the fix, the debug build panics
-        // (SIGILL) and should exit immediately; if it somehow hangs, we want
-        // a clean `signalCode` rather than a bun-test runner timeout.
-        timeout: 10_000,
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+test.concurrent.each(["[{static{}", "({static{}})", "({static{};})", "({static{},})"])(
+  "`static { ... }` in an object-literal position (%s) is a syntax error, not a parser crash",
+  async source => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      // Bound the subprocess: without the fix, the debug build panics
+      // (SIGILL) and should exit immediately; if it somehow hangs, we want
+      // a clean `signalCode` rather than a bun-test runner timeout.
+      timeout: 10_000,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      // Before the fix, the debug build aborted with SIGILL inside the
-      // parser and never reached the syntax-error reporter — stderr carried
-      // `panic: assertion failed: prop.key.is_some() || prop.value.is_some()`
-      // and `signalCode === "SIGILL"`. After the fix the parser emits the
-      // normal user-facing syntax error and the process exits cleanly with
-      // a non-zero code.
-      expect(stderr).toContain('Expected "}" but found "{"');
-      expect(proc.signalCode).toBeNull();
-      expect(stdout).toBe("");
-      expect(exitCode).not.toBe(0);
-    }, 30_000);
+    // Before the fix, the debug build aborted with SIGILL inside the
+    // parser and never reached the syntax-error reporter — stderr carried
+    // `panic: assertion failed: prop.key.is_some() || prop.value.is_some()`
+    // and `signalCode === "SIGILL"`. After the fix the parser emits the
+    // normal user-facing syntax error and the process exits cleanly with
+    // a non-zero code.
+    expect(stderr).toContain('Expected "}" but found "{"');
+    expect(proc.signalCode).toBeNull();
+    expect(stdout).toBe("");
+    expect(exitCode).not.toBe(0);
   },
 );


### PR DESCRIPTION
Fixes #30963.

### Reproduction

```console
$ echo '[{static{}' > /tmp/repro.js
$ bun-debug /tmp/repro.js
panic: assertion failed: prop.key.is_some() || prop.value.is_some() (src/js_parser/parse/parse_prefix.rs:870:25)
```

Release builds correctly emit a user-facing syntax error; only the debug
assertion fires, because the assertion is gated on `cfg!(debug_assertions)`.

### Cause

`src/js_parser/parse/parse_property.rs` at the `static { ... }` branch
entered the class-static-block path purely on identifier + `{`, without
checking whether the enclosing context was a class body:

```rust
} else if p.lexer.token == T::TOpenBrace && name == b"static" {
    // ... parse statements until `}` ...
    return Ok(Some(G::Property {
        kind: PropertyKind::ClassStaticBlock,
        class_static_block: Some(js_ast::StoreRef::from_bump(block)),
        ..Default::default()   // key = None, value = None
    }));
}
```

Every sibling branch in the same match (`PStatic`, `PDeclare`,
`PAbstract`, `PAccessor`, `PPrivate/PProtected/PPublic/POverride/PReadonly`)
already gates on `opts.is_class`; this one was the only exception. When
invoked from the object-literal path (`parse_prefix.rs::pfx_t_open_brace`),
`opts.is_class` is `false` and the returned property had neither `key` nor
`value`, tripping the `debug_assert` in the caller.

### Fix

Add `opts.is_class &&` to the condition so `static { ... }` is only parsed
as a class static block inside a class body. Outside a class body `static`
now falls through to ordinary identifier handling and the trailing `{`
produces a syntax error, matching release-mode behavior.

The Zig sibling (`parse_property.zig`) had the same un-gated branch; it's
updated in lockstep to keep the porting reference aligned.

### Test

`test/bundler/transpiler/transpiler.test.js` — added four malformed
object-literal cases (`[{static{}`, `({static{}})`, `({static{};})`,
`({static{},})`) alongside the existing "class static blocks" suite, each
asserting a `SyntaxError` with `Expected "}" but found "{"`.

### Verification

- `bun bd test test/bundler/transpiler/transpiler.test.js -t "class static blocks"` — 1 pass, 24 expect() calls (130 filtered).
- With the fix stashed, the same test panics at the original assertion site → confirms the test exercises the fix.
- `bun bd test test/cli/run/syntax.test.ts` — 590 pass; valid `class A{static{}}` still works.
- Full `transpiler.test.js` — 109 pass, 0 fail.