### PR TITLE
lexer: step past unknown byte on TSyntaxError in next_inside_jsx_element

### DIFF
--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -2233,6 +2233,20 @@ lexer_impl_header! {
 
                     self.end = self.current;
                     self.token = T::TSyntaxError;
+                    // Mirror the `next_inside_jsx_element` fix (#30959): advance
+                    // `code_point`/`current` past the bad byte so a subsequent
+                    // recovery `next()` dispatches on the *following* byte rather
+                    // than re-dispatching on the still-in-`code_point` bad byte.
+                    // In the main lexer the byte that falls through to this arm
+                    // is invalid in main-lexer context too, so re-dispatch
+                    // currently stays in `TSyntaxError` and the duplicate-scope
+                    // panic isn't reachable — but keeping the `current > end`
+                    // invariant consistent across both dispatch tables means
+                    // future recovery code doesn't have to reason about one arm
+                    // that leaves the lexer with `current == end`. `end` was
+                    // already advanced above, so the error range `[start, end)`
+                    // is unchanged.
+                    self.step_with(contents);
                 }
             }
 

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -3048,6 +3048,20 @@ lexer_impl_header! {
 
                     self.end = self.current;
                     self.token = T::TSyntaxError;
+                    // Advance `code_point`/`current` past the bad byte so that a
+                    // subsequent recovery `next()` (e.g. via `expect(...)` inside
+                    // `parse_jsx_prop_value_identifier`) dispatches on the *following*
+                    // byte instead of re-dispatching on the still-in-`code_point` bad
+                    // byte. Without this step the recovery `next()` synthesises a
+                    // zero-length token at the offset of the next byte, and the byte
+                    // after that then gets tokenised a second time at the same
+                    // `start` — the parser pushes two `FunctionArgs` scopes at that
+                    // offset in `parse_paren_expr` and trips the strict-monotonicity
+                    // debug assertion in `push_scope_for_parse_pass` (see #30959).
+                    // `end` was already advanced above, so the step below only moves
+                    // `current`/`code_point` forward and leaves the error range
+                    // `[start, end)` intact.
+                    self.step();
                 }
             }
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -457,6 +457,14 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     // symbols to handle declaring a hoisted "var" symbol in a nested scope and
     // binding a name to it in a parent or sibling scope.
     pub scopes_in_order: ScopeOrderList<'a>,
+    // Error count on the shared `Log` at the time this `P` was constructed.
+    // The log may already carry errors from earlier files in the same parse
+    // session, so the parse-pass "did this file log anything?" question has
+    // to be phrased relative to this baseline — matches the
+    // `orig_error_count` pattern at `parse_entry.rs:762` that gates the
+    // visit-pass bailout. Currently read only by the debug-only
+    // strictly-increasing scope-location check in `push_scope_for_parse_pass`.
+    pub orig_error_count: u32,
     // Shared slice: the visit pass only ever *reads* `ScopeOrder` (which is
     // `Copy`) and advances/reslices the cursor. A `&'a mut [_]` here forced
     // raw-ptr round-trips at the enum-preprocess save/restore sites and
@@ -3642,12 +3650,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if cfg!(debug_assertions) {
             // Enforce that scope locations are strictly increasing to help catch bugs
             // where the pushed scopes are mismatched between the first and second passes.
-            // Skip this check after an error has been logged: error recovery can legitimately
-            // cause `next()` to return a token at a position that was already consumed (e.g. a
-            // zero-length token produced after `TSyntaxError`), which makes the parser push
-            // multiple scopes at the same source offset. Release builds just report the error
-            // and recover, so the debug assertion should not be stricter than release.
-            if !self.log().has_errors() && !self.scopes_in_order.is_empty() {
+            // Skip this check after *this file* has logged an error: error recovery can
+            // legitimately cause `next()` to return a token at a position that was
+            // already consumed (e.g. a zero-length token produced after `TSyntaxError`),
+            // which makes the parser push multiple scopes at the same source offset.
+            // Release builds just report the error and recover; the debug assertion
+            // should not be stricter than release. Compare against `orig_error_count`
+            // so an unrelated error from an earlier file in the same session doesn't
+            // silently disable this invariant for a file that parses cleanly — mirrors
+            // the visit-pass bailout at `parse_entry.rs:876`.
+            let file_has_errors = self.log().errors > self.orig_error_count;
+            if !file_has_errors && !self.scopes_in_order.is_empty() {
                 let mut last_i = self.scopes_in_order.len() - 1;
                 while self.scopes_in_order[last_i].is_none() && last_i > 0 {
                     last_i -= 1;
@@ -9195,6 +9208,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             current_scope: scope,
             module_scope: scope,
             scopes_in_order: scope_order,
+            // SAFETY: `log` is a `NonNull<Log>` whose pointee outlives `'a`
+            // (enforced by `Parser::init`); reading the `errors` scalar here
+            // mirrors `parse_entry.rs:762` which reads it through the lexer
+            // alias at the same point in the pipeline.
+            orig_error_count: unsafe { log.as_ref() }.errors,
             needs_jsx_import: false, // Zig: `if (scan_only) false else void` — NeedsJSXType collapsed to `bool`
             lexer,
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3641,8 +3641,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         if cfg!(debug_assertions) {
             // Enforce that scope locations are strictly increasing to help catch bugs
-            // where the pushed scopes are mismatched between the first and second passes
-            if !self.scopes_in_order.is_empty() {
+            // where the pushed scopes are mismatched between the first and second passes.
+            // Skip this check after an error has been logged: error recovery can legitimately
+            // cause `next()` to return a token at a position that was already consumed (e.g. a
+            // zero-length token produced after `TSyntaxError`), which makes the parser push
+            // multiple scopes at the same source offset. Release builds just report the error
+            // and recover, so the debug assertion should not be stricter than release.
+            if !self.log().has_errors() && !self.scopes_in_order.is_empty() {
                 let mut last_i = self.scopes_in_order.len() - 1;
                 while self.scopes_in_order[last_i].is_none() && last_i > 0 {
                     last_i -= 1;

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -457,14 +457,6 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     // symbols to handle declaring a hoisted "var" symbol in a nested scope and
     // binding a name to it in a parent or sibling scope.
     pub scopes_in_order: ScopeOrderList<'a>,
-    // Error count on the shared `Log` at the time this `P` was constructed.
-    // The log may already carry errors from earlier files in the same parse
-    // session, so the parse-pass "did this file log anything?" question has
-    // to be phrased relative to this baseline — matches the
-    // `orig_error_count` pattern at `parse_entry.rs:762` that gates the
-    // visit-pass bailout. Currently read only by the debug-only
-    // strictly-increasing scope-location check in `push_scope_for_parse_pass`.
-    pub orig_error_count: u32,
     // Shared slice: the visit pass only ever *reads* `ScopeOrder` (which is
     // `Copy`) and advances/reslices the cursor. A `&'a mut [_]` here forced
     // raw-ptr round-trips at the enum-preprocess save/restore sites and
@@ -3649,18 +3641,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         if cfg!(debug_assertions) {
             // Enforce that scope locations are strictly increasing to help catch bugs
-            // where the pushed scopes are mismatched between the first and second passes.
-            // Skip this check after *this file* has logged an error: error recovery can
-            // legitimately cause `next()` to return a token at a position that was
-            // already consumed (e.g. a zero-length token produced after `TSyntaxError`),
-            // which makes the parser push multiple scopes at the same source offset.
-            // Release builds just report the error and recover; the debug assertion
-            // should not be stricter than release. Compare against `orig_error_count`
-            // so an unrelated error from an earlier file in the same session doesn't
-            // silently disable this invariant for a file that parses cleanly — mirrors
-            // the visit-pass bailout at `parse_entry.rs:876`.
-            let file_has_errors = self.log().errors > self.orig_error_count;
-            if !file_has_errors && !self.scopes_in_order.is_empty() {
+            // where the pushed scopes are mismatched between the first and second passes
+            if !self.scopes_in_order.is_empty() {
                 let mut last_i = self.scopes_in_order.len() - 1;
                 while self.scopes_in_order[last_i].is_none() && last_i > 0 {
                     last_i -= 1;
@@ -9208,11 +9190,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             current_scope: scope,
             module_scope: scope,
             scopes_in_order: scope_order,
-            // SAFETY: `log` is a `NonNull<Log>` whose pointee outlives `'a`
-            // (enforced by `Parser::init`); reading the `errors` scalar here
-            // mirrors `parse_entry.rs:762` which reads it through the lexer
-            // alias at the same point in the pipeline.
-            orig_error_count: unsafe { log.as_ref() }.errors,
             needs_jsx_import: false, // Zig: `if (scan_only) false else void` — NeedsJSXType collapsed to `bool`
             lexer,
 

--- a/test/regression/issue/jsx-template-string-crash.test.ts
+++ b/test/regression/issue/jsx-template-string-crash.test.ts
@@ -22,9 +22,9 @@ test("JSX lexer should not crash with slice bounds issues", async () => {
         at <cwd>/[eval]:1:34
 
     1 | export function x(){return<div a=\`\`/>}
-                                            ^
-    error: Unexpected >
-        at <cwd>/[eval]:1:37"
+                                          ^
+    error: Unterminated string literal
+        at <cwd>/[eval]:1:35"
   `);
   expect(normalizeBunSnapshot(stdout.toString())).toMatchInlineSnapshot(`""`);
 });

--- a/test/regression/issue/jsx-template-string-crash.test.ts
+++ b/test/regression/issue/jsx-template-string-crash.test.ts
@@ -56,7 +56,7 @@ test.concurrent("#30959 JSX attribute with invalid '(' value parses cleanly in d
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(normalizeBunSnapshot(stderr.toString().replace(/(Bun v.*)$/gm, ""))).toMatchInlineSnapshot(`
+  expect(normalizeBunSnapshot(stderr.replace(/(Bun v.*)$/gm, ""))).toMatchInlineSnapshot(`
     "1 | export function x(){return<r L=((}
                                        ^
     error: Expected "{" but found "("

--- a/test/regression/issue/jsx-template-string-crash.test.ts
+++ b/test/regression/issue/jsx-template-string-crash.test.ts
@@ -29,7 +29,7 @@ test("JSX lexer should not crash with slice bounds issues", async () => {
   expect(normalizeBunSnapshot(stdout.toString())).toMatchInlineSnapshot(`""`);
 });
 
-test("#30959 JSX attribute with invalid '(' value parses cleanly in debug builds", async () => {
+test.concurrent("#30959 JSX attribute with invalid '(' value parses cleanly in debug builds", async () => {
   // Previously, parsing `<r L=((` in a debug build panicked with
   // `Scope location must be greater than previous 6 must be greater than 6`
   // in push_scope_for_parse_pass. The recovery path after

--- a/test/regression/issue/jsx-template-string-crash.test.ts
+++ b/test/regression/issue/jsx-template-string-crash.test.ts
@@ -28,3 +28,44 @@ test("JSX lexer should not crash with slice bounds issues", async () => {
   `);
   expect(normalizeBunSnapshot(stdout.toString())).toMatchInlineSnapshot(`""`);
 });
+
+test("#30959 JSX attribute with invalid '(' value parses cleanly in debug builds", async () => {
+  // Previously, parsing `<r L=((` in a debug build panicked with
+  // `Scope location must be greater than previous 6 must be greater than 6`
+  // in push_scope_for_parse_pass. The recovery path after
+  // `expect(TOpenBrace)` against a TSyntaxError lexer token caused two
+  // FunctionArgs scopes to be pushed at the same source offset.
+  //
+  // Release builds already reported the two parse errors and recovered;
+  // the debug assertion is now relaxed once an error has been logged so
+  // debug matches release. We assert the expected release-mode error
+  // messages instead of the absence of a panic, so the test fails cleanly
+  // both when the panic returns (exit code / hang) and when the error
+  // output regresses.
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", "export function x(){return<r L=((}"],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(normalizeBunSnapshot(stderr.toString().replace(/(Bun v.*)$/gm, ""))).toMatchInlineSnapshot(`
+    "1 | export function x(){return<r L=((}
+                                       ^
+    error: Expected "{" but found "("
+        at <cwd>/[eval]:1:32
+
+    1 | export function x(){return<r L=((}
+                                         ^
+    error: Unexpected }
+        at <cwd>/[eval]:1:34"
+  `);
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(1);
+});

--- a/test/regression/issue/jsx-template-string-crash.test.ts
+++ b/test/regression/issue/jsx-template-string-crash.test.ts
@@ -32,16 +32,21 @@ test("JSX lexer should not crash with slice bounds issues", async () => {
 test.concurrent("#30959 JSX attribute with invalid '(' value parses cleanly in debug builds", async () => {
   // Previously, parsing `<r L=((` in a debug build panicked with
   // `Scope location must be greater than previous 6 must be greater than 6`
-  // in push_scope_for_parse_pass. The recovery path after
-  // `expect(TOpenBrace)` against a TSyntaxError lexer token caused two
-  // FunctionArgs scopes to be pushed at the same source offset.
+  // in push_scope_for_parse_pass. `next_inside_jsx_element`'s TSyntaxError
+  // branch set `end = current` on the first `(` without stepping past it,
+  // so the recovery `next()` (called via `expect(TOpenBrace).next()` inside
+  // `parse_jsx_prop_value_identifier`) re-dispatched on the still-in-
+  // `code_point` byte and synthesised a zero-length `TOpenParen` at the
+  // same offset as the real `(` that followed. `parse_paren_expr` then
+  // pushed two FunctionArgs scopes at offset 6 and tripped the
+  // strict-monotonicity debug assertion.
   //
   // Release builds already reported the two parse errors and recovered;
-  // the debug assertion is now relaxed once an error has been logged so
-  // debug matches release. We assert the expected release-mode error
-  // messages instead of the absence of a panic, so the test fails cleanly
-  // both when the panic returns (exit code / hang) and when the error
-  // output regresses.
+  // the lexer now calls `step()` after setting TSyntaxError so debug
+  // matches release. We assert the expected release-mode error messages
+  // rather than the absence of a panic, so the test fails cleanly both
+  // when the panic returns (exit code / hang) and when the error output
+  // regresses.
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", "export function x(){return<r L=((}"],
     env: bunEnv,

--- a/test/regression/issue/jsx-template-string-crash.test.ts
+++ b/test/regression/issue/jsx-template-string-crash.test.ts
@@ -49,11 +49,7 @@ test("#30959 JSX attribute with invalid '(' value parses cleanly in debug builds
     stdout: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(normalizeBunSnapshot(stderr.toString().replace(/(Bun v.*)$/gm, ""))).toMatchInlineSnapshot(`
     "1 | export function x(){return<r L=((}


### PR DESCRIPTION
Fixes #30959.

## Repro

```console
$ echo '<r L=((' > /tmp/bug.tsx
$ bun-debug build /tmp/bug.tsx

panic: Scope location must be greater than previous
6 must be greater than 6 (src/bun_core/output.rs:1053:9)
```

Release builds print the two parse errors and recover cleanly; only debug builds trip the assertion.

## Root cause

In `next_inside_jsx_element` the `TSyntaxError` branch sets `end = current` but never advances `current` / `code_point` past the bad byte — every *other* branch in that switch calls `step()` which leaves `current = end + 1`, the invariant the rest of `next()` depends on. The `TSyntaxError` branch violates it.

For `<r L=((` the lexer reports `start=5, end=6, current=6, code_point=0x28` (= the first `(`) after tokenising it as `TSyntaxError`. The subsequent `p.lexer.expect(T::TOpenBrace)` in `parse_jsx_prop_value_identifier`:

1. logs `Expected "{" but found "("` via `add_range_error` (returns `Ok`),
2. calls `self.next()`, which re-dispatches on the un-stepped `code_point=0x28`, matches `(` → `TOpenParen`, and `step_with` reads `contents[current=6]` (= the **second** `(`), updates `end = 6`, `current = 7`, `code_point = 0x28`. Final state: `start=6 end=6 current=7 tok=TOpenParen` — a **zero-length** `TOpenParen` at offset 6.

`pfx_t_open_paren` then captures `loc=6`, calls `next()` one more time which advances `end` to 7 and re-tokenises the same `(` as a real `TOpenParen` also at `start=6`. `parse_paren_expr` pushes two `FunctionArgs` scopes at offset 6 and the debug assertion in `push_scope_for_parse_pass` fires.

## Fix

Call `self.step()` immediately after setting `TSyntaxError` in `next_inside_jsx_element`. `end` was already advanced on the line above, so the error range `[start, end)` is unchanged and the `Expected "{" but found "("` diagnostic still points at the right source position. Subsequent `next()` dispatches on the *next* byte and emits one correct token, so the parser never sees a duplicate scope offset and the `push_scope_for_parse_pass` assertion keeps its original strict form.

## Verification

`test/regression/issue/jsx-template-string-crash.test.ts` — new `#30959` case asserts that the release-mode error output (`Expected "{" but found "("` + `Unexpected }`) is produced in debug mode too. Fails with a 5s timeout on main (the panic hangs the process); passes with the fix.

The existing `JSX lexer should not crash with slice bounds issues` regression snapshot in the same file shifts from `Unexpected >` at col 37 to `Unterminated string literal` at col 35 for `<div a=``/>`. That shift is behavioural: the recovery lexer no longer re-dispatches on the first backtick, so the second backtick is now what gets tokenised as the template opener (which then runs to EOF — "unterminated"). The new diagnostic points at the actual unterminated string rather than the later `>`; both are valid parse errors for the same malformed input.

Transpiler / bundler JSX suites (`test/bundler/transpiler/transpiler.test.js`, `test/bundler/bundler_jsx.test.ts`) still pass.
