### PR TITLE
Add an install function to the undici module

### DIFF
--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -501,5 +501,19 @@ const moduleExports = {
   WebSocket,
 };
 
+function install() {
+  globalThis.fetch = fetch;
+  globalThis.Headers = Headers;
+  globalThis.Response = Response;
+  globalThis.Request = Request;
+  globalThis.FormData = FormData;
+  globalThis.WebSocket = WebSocket;
+  globalThis.CloseEvent = CloseEvent;
+  globalThis.ErrorEvent = ErrorEvent;
+  globalThis.MessageEvent = MessageEvent;
+  globalThis.EventSource = EventSource;
+}
+
+moduleExports.install = install;
 moduleExports.default = moduleExports;
 export default moduleExports;


### PR DESCRIPTION
### What does this PR do?

Previously, `bunx --bun @earendil-works/pi-coding-agent` would fail with a syntax error saying the export named 'install' could not be found.
This PR ports over https://github.com/nodejs/undici/blob/main/index.js#L223 to the third party undici module.

### How did you verify your code works?

```
bun run build
./build/debug/bun-debug x --bun @earendil-works/pi-coding-agent
```