### PR TITLE
dev-server: hoist insert_stale out of debug_assert! so it runs in release

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -963,10 +963,11 @@ pub fn init(options: Options) -> JsResult<Box<DevServer>> {
     // Add react fast refresh if needed. This is the first file on the client side,
     // as it will be referred to by index.
     if let Some(rfr) = &dev.framework.react_fast_refresh {
-        debug_assert!(
-            dev.client_graph.insert_stale(&rfr.import_source, false)?
-                == incremental_graph::FileIndex::<{ bake::Side::Client }>::init(0) // Zig: react_refresh_index = .init(0)
-        );
+        // Spec (DevServer.zig:511): `bun.assert` always evaluates its argument;
+        // `debug_assert!` does not in release. Hoist the side-effecting `insert_stale`
+        // out so the refresh runtime is registered at index 0 in all builds.
+        let idx = dev.client_graph.insert_stale(&rfr.import_source, false)?;
+        debug_assert!(idx == incremental_graph::FileIndex::<{ bake::Side::Client }>::init(0)); // Zig: react_refresh_index = .init(0)
     }
 
     if !dev.frontend_only {


### PR DESCRIPTION
Fixes #30678


## Summary

The Zig spec at `DevServer.zig:511` registers the React Fast Refresh runtime as the first stale client-graph file inside an `assert`:

```zig
assert(try dev.client_graph.insertStale(rfr.import_source, false) == IncrementalGraph(.client).react_refresh_index);
```

`bun.assert` is a function — its argument is always evaluated; only the comparison is stripped in release builds. The `bun.zig` doc comment for the assert family even calls this out: *"if the compiler cannot determine that `ok` has no side effects, the argument expression may not be removed from the binary."*

The Rust port wrapped the entire expression in `debug_assert!`:

```rust
debug_assert!(
    dev.client_graph.insert_stale(&rfr.import_source, false)?
        == incremental_graph::FileIndex::<{ bake::Side::Client }>::init(0)
);
```

`debug_assert!` is a macro that wraps the **entire argument expression** in `if cfg!(debug_assertions)`. In release builds, `insert_stale` is never called, so the refresh runtime is never registered at client-graph index 0 at `DevServer` init time — the comment above the block ("This is the first file on the client side, as it will be referred to by index") describes an invariant the release build silently dropped.

## Fix

Hoist the side-effecting call out and keep the index check debug-only:

```rust
let idx = dev.client_graph.insert_stale(&rfr.import_source, false)?;
debug_assert!(idx == incremental_graph::FileIndex::<{ bake::Side::Client }>::init(0));
```

This matches how every other side-effecting `bun.assert` was ported. The same hoist pattern (with explicit comments calling out the footgun) already appears in `boringssl/lib.rs`, `FakeTimers.rs`, `node_fs.rs`, `channel.rs`, `AutoFlusher.rs`, `sha.rs`, `win_watcher.rs`, `timer/mod.rs`, `HTTPContext.rs`, `MutableString.rs`, and `immutable.rs`. This was the one site that slipped through.

## Audit

A full sweep of all `assert(...)` calls in the Zig spec with side-effecting arguments and their Rust ports found exactly one mishandled site (this one). The other 14 sites correctly hoist the side effect.

## No regression test

The change has no effect in debug builds (where `debug_assert!` already evaluates its argument), and the index-0 invariant is not currently observable from JS — `react-refresh/runtime` is also pulled into the client graph by the bundler when any module uses Fast Refresh, so the `refresh:` config line is emitted regardless. A test asserting the index-0 placement would need a release build, which the test harness can't observe, and it would pass with `USE_SYSTEM_BUN=1`. There is no JS-observable behavior change to test against.

## Verification

- `cargo check -p bun_runtime` clean
- `bun bd test test/bake/dev/react-spa.test.ts` — 6/6 pass
- `bun run build:release` + manual repro: bundle still emits `refresh:` correctly