### PR TITLE
semver: add Bun.semver.parse() to extract version components

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4649,6 +4649,23 @@ declare module "bun" {
      * Throws an error if either version is invalid.
      */
     function order(v1: StringLike, v2: StringLike): -1 | 0 | 1;
+
+    /**
+     * Parse a semver string into its component parts.
+     *
+     * Returns `null` if the input is not a valid semver string.
+     *
+     * @example
+     * ```ts
+     * Bun.semver.parse("1.2.3-beta.1+build.42");
+     * // { major: 1, minor: 2, patch: 3, pre: "beta.1", build: "build.42" }
+     *
+     * Bun.semver.parse("not-a-version"); // null
+     * ```
+     */
+    function parse(
+      version: StringLike,
+    ): { major: number; minor: number; patch: number; pre: string | null; build: string | null } | null;
   }
 
   namespace unsafe {

--- a/src/semver_jsc/SemverObject.rs
+++ b/src/semver_jsc/SemverObject.rs
@@ -1,9 +1,9 @@
-//! `Bun.semver` — `{ satisfies, order }` host-function table.
+//! `Bun.semver` — `{ satisfies, order, parse }` host-function table.
 
 use core::cmp::Ordering;
 
 use bun_core::strings;
-use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
+use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, bun_string_jsc};
 use bun_semver::{SlicedString, Version, query};
 
 pub fn create(global: &JSGlobalObject) -> JSValue {
@@ -12,6 +12,7 @@ pub fn create(global: &JSGlobalObject) -> JSValue {
         &[
             ("satisfies", __jsc_host_satisfies, 2),
             ("order", __jsc_host_order, 2),
+            ("parse", __jsc_host_parse, 1),
         ],
     )
 }
@@ -117,6 +118,56 @@ pub fn satisfies(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue
         right.slice(),
         left.slice(),
     )))
+}
+
+#[bun_jsc::host_fn]
+pub fn parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    let arguments = frame.arguments_old::<1>();
+    let arguments = arguments.slice();
+    if arguments.is_empty() {
+        return Ok(JSValue::NULL);
+    }
+
+    let input_str = arguments[0].to_js_string(global)?;
+    let input = input_str.to_slice(global);
+    let buf = input.slice();
+
+    if !strings::is_all_ascii(buf) {
+        return Ok(JSValue::NULL);
+    }
+
+    let result = Version::parse(SlicedString::init(buf, buf));
+    if !result.valid || result.wildcard != query::token::Wildcard::None {
+        return Ok(JSValue::NULL);
+    }
+
+    let v = result.version.min();
+    let obj = JSValue::create_empty_object(global, 5);
+    obj.put(global, b"major", JSValue::js_number(v.major as f64));
+    obj.put(global, b"minor", JSValue::js_number(v.minor as f64));
+    obj.put(global, b"patch", JSValue::js_number(v.patch as f64));
+
+    if v.tag.has_pre() {
+        obj.put(
+            global,
+            b"pre",
+            bun_string_jsc::create_utf8_for_js(global, v.tag.pre.slice(buf))?,
+        );
+    } else {
+        obj.put(global, b"pre", JSValue::NULL);
+    }
+
+    if v.tag.has_build() {
+        obj.put(
+            global,
+            b"build",
+            bun_string_jsc::create_utf8_for_js(global, v.tag.build.slice(buf))?,
+        );
+    } else {
+        obj.put(global, b"build", JSValue::NULL);
+    }
+
+    Ok(obj)
 }
 
 // ported from: src/semver_jsc/SemverObject.zig

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -15,7 +15,7 @@
 // IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 import { unsortedPrereleases } from "./semver-fixture.js";
-const { satisfies, order } = Bun.semver;
+const { satisfies, order, parse } = Bun.semver;
 
 function testSatisfiesExact(left: any, right: any, expected: boolean) {
   expect(satisfies(left, right)).toBe(expected);
@@ -736,5 +736,35 @@ describe("Bun.semver.satisfies()", () => {
 
   test("pre-release snapshot", () => {
     expect(unsortedPrereleases.sort(Bun.semver.order)).toMatchSnapshot();
+  });
+});
+
+describe("Bun.semver.parse()", () => {
+  test("simple version", () => {
+    expect(parse("1.2.3")).toEqual({ major: 1, minor: 2, patch: 3, pre: null, build: null });
+  });
+
+  test("prerelease", () => {
+    expect(parse("1.2.3-beta.1")).toEqual({ major: 1, minor: 2, patch: 3, pre: "beta.1", build: null });
+  });
+
+  test("build metadata", () => {
+    expect(parse("1.2.3+build.42")).toEqual({ major: 1, minor: 2, patch: 3, pre: null, build: "build.42" });
+  });
+
+  test("prerelease + build", () => {
+    expect(parse("1.2.3-beta.1+build.42")).toEqual({ major: 1, minor: 2, patch: 3, pre: "beta.1", build: "build.42" });
+  });
+
+  test("invalid returns null", () => {
+    expect(parse("not-a-version")).toBeNull();
+    expect(parse("1.x")).toBeNull();
+    expect(parse("")).toBeNull();
+  });
+
+  test("Bun.version is parseable", () => {
+    const v = parse(Bun.version.split("-")[0]);
+    expect(v).not.toBeNull();
+    expect(v!.major).toBeGreaterThanOrEqual(0);
   });
 });


### PR DESCRIPTION
## Summary

- Add `Bun.semver.parse(version)` that returns `{ major, minor, patch, pre, build }` or `null` for invalid input
- Exposes what Bun's internal semver parser already computes — zero overhead, no new logic
- Eliminates the need to `split(".")` manually or install the `semver` npm package for version inspection

## Example

```ts
Bun.semver.parse("1.2.3-beta.1+build.42")
// { major: 1, minor: 2, patch: 3, pre: "beta.1", build: "build.42" }

Bun.semver.parse("1.x")  // null
Bun.semver.parse("not-a-version")  // null
```

## Changes

- `src/semver_jsc/SemverObject.rs` — add `parse` host function + register in table
- `packages/bun-types/bun.d.ts` — TypeScript type declaration
- `test/cli/install/semver.test.ts` — tests covering basic version, prerelease, build metadata, invalid input

## Test plan

- [ ] `bun bd test test/cli/install/semver.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)