### PR TITLE
Bun__inspect: don't panic when user JS throws during error-message formatting

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -720,7 +720,14 @@ pub fn bun_inspect(global_this: &JSGlobalObject, value: JSValue) -> BunString {
     let mut array: Vec<u8> = Vec::new();
 
     let mut formatter = ConsoleObject::Formatter::new(global_this);
-    if write!(&mut array, "{}", value.to_fmt(&mut formatter)).is_err() {
+    use core::fmt::Write;
+    if write!(
+        bun_core::fmt::VecWriter(&mut array),
+        "{}",
+        value.to_fmt(&mut formatter)
+    )
+    .is_err()
+    {
         return BunString::empty();
     }
     BunString::clone_utf8(&array)

--- a/test/js/bun/cookie/cookie-expires-validation.test.ts
+++ b/test/js/bun/cookie/cookie-expires-validation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 describe("Bun.Cookie expires validation", () => {
   describe("Date objects", () => {
@@ -74,6 +75,36 @@ describe("Bun.Cookie expires validation", () => {
       expect(() => {
         new Bun.Cookie("name", "value", { expires: { time: 123456 } });
       }).toThrow();
+    });
+
+    test("throws for objects whose inspect.custom throws", async () => {
+      // Bun__inspect renders the received value into the error message; a
+      // throwing inspect.custom must surface as a JS error, not a crash.
+      // Spawn a subprocess so a regression fails cleanly instead of aborting.
+      const src = `
+        const obj = {
+          [Symbol.for("nodejs.util.inspect.custom")]() {
+            throw new Error("boom from inspect.custom");
+          },
+        };
+        try {
+          new Bun.Cookie("name", "value", { expires: obj });
+          console.log("no-throw");
+        } catch (e) {
+          console.log("threw:" + e.message);
+        }
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", src],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), stderr, exitCode }).toMatchObject({
+        stdout: "threw:boom from inspect.custom",
+        exitCode: 0,
+      });
     });
 
     test("invalid strings throw", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a panic in `Bun__inspect` (the native helper used by `JSValueToStringSafe` in `ErrorCode.cpp` to render values in messages like `ERR_INVALID_ARG_VALUE`).

When the value being rendered has a throwing `[Symbol.for("nodejs.util.inspect.custom")]` (or any user JS that throws while the console formatter walks the value), `ZigFormatter`'s `Display` impl returns `fmt::Error`. The sink was a `Vec<u8>` via `std::io::Write`, whose `write_fmt` **panics** with

> a formatting trait implementation returned an error when the underlying stream did not

because the in-memory stream never errored. The existing `.is_err()` check never saw the error — the panic happens inside `write_fmt` before it returns.

Fix: write through `core::fmt::Write` (`bun_core::fmt::VecWriter`) so the error is observable and we return an empty string as the code originally intended. The user's thrown exception then propagates normally.

### Repro (crashed before, throws cleanly after)

```js
const obj = {
  [Symbol.for("nodejs.util.inspect.custom")]() {
    throw new Error("boom");
  },
};
new Bun.Cookie("n", "v", { expires: obj });
```

## How did you verify your code works?

- Reproduced the exact Fuzzilli panic fingerprint (`panic:a formatting trait implementation returned an error when the`) with the minimal repro above; symbolicated stack confirms `std::io::default_write_fmt::<Vec<u8>>` → `bun_inspect` → `JSValueToStringSafe`.
- After the fix, the repro throws a regular JS error instead of crashing.
- Added a regression test in `test/js/bun/cookie/cookie-expires-validation.test.ts` that crashes on the baked Bun and passes with this change.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 15 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/cookie/cookie-expires-validation.test.ts
bun test v1.4.0 (f28a7bb6c)

test/js/bun/cookie/cookie-expires-validation.test.ts:
(pass) Bun.Cookie expires validation > Date objects > accepts valid Date in future [4.30ms]
(pass) Bun.Cookie expires validation > Date objects > accepts valid Date in past [2.78ms]
(pass) Bun.Cookie expires validation > Date objects > throws for invalid Date (NaN) [4.25ms]
(pass) Bun.Cookie expires validation > Number values > accepts positive integer [2.01ms]
(pass) Bun.Cookie expires validation > Number values > accepts zero [2.31ms]
(pass) Bun.Cookie expires validation > Number values > throws for NaN [2.62ms]
(pass) Bun.Cookie expires validation > Number values > throws for Infinity [2.89ms]
(pass) Bun.Cookie expires validation > Number values > throws for negative Infinity [2.94ms]
(pass) Bun.Cookie expires validation > Special values > handles undefined [1.43ms]
(pass) Bun.Cookie expires validation > Special values > handles null [1.72ms]
(pass) Bun.Cookie expires validation > Special values > t
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (b58cd4685)

test/js/bun/cookie/cookie-expires-validation.test.ts:
(pass) Bun.Cookie expires validation > Date objects > accepts valid Date in future [0.10ms]
(pass) Bun.Cookie expires validation > Date objects > accepts valid Date in past [0.04ms]
(pass) Bun.Cookie expires validation > Date objects > throws for invalid Date (NaN) [0.07ms]
(pass) Bun.Cookie expires validation > Number values > accepts positive integer [0.03ms]
(pass) Bun.Cookie expires validation > Number values > accepts zero [0.02ms]
(pass) Bun.Cookie expires validation > Number values > throws for NaN [0.03ms]
(pass) Bun.Cookie expires validation > Number values > throws for Infinity [0.02ms]
(pass) Bun.Cookie expires validation > Number values > throws for negative Infinity [0.02ms]
(pass) Bun.Cookie expires validation > Special values > handles undefined [0.03ms]
(pass) Bun.Cookie expires validation > Special values > handles null [0.02ms]
(pass) Bun.Cookie expires validation > Special values > throws for non-date objects [0.07ms]
 99 |         env: bunEnv,
100 |         stdout: "pipe",
101 |         stderr: "pipe",
102 |       });
103 |       const [stdout, stderr, exi
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/cookie/cookie-expires-validation.test.ts
bun test v1.4.0 (f28a7bb6c)

test/js/bun/cookie/cookie-expires-validation.test.ts:
(pass) Bun.Cookie expires validation > Date objects > accepts valid Date in future [4.75ms]
(pass) Bun.Cookie expires validation > Date objects > accepts valid Date in past [2.46ms]
(pass) Bun.Cookie expires validation > Date objects > throws for invalid Date (NaN) [4.23ms]
(pass) Bun.Cookie expires validation > Number values > accepts positive integer [2.03ms]
(pass) Bun.Cookie expires validation > Number values > accepts zero [2.19ms]
(pass) Bun.Cookie expires validation > Number values > throws for NaN [2.56ms]
(pass) Bun.Cookie expires validation > Number values > throws for Infinity [3.61ms]
(pass) Bun.Cookie expires validation > Number values > throws for negative Infinity [2.98ms]
(pass) Bun.Cookie expires validation > Special values > handles undefined [1.42ms]
(pass) Bun.Cookie expires validation > Special values > handles null [1.87ms]
(pass) Bun.Cookie expires validation > Special values > t
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 655ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/72] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 239 extern-C blocks audited
[1/72] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 26s
[68/72] cxx obj/codegen/ZigGeneratedClasses.cpp.o
[69/72] link bun-profile
[71/72] strip bun
[71/72] bun-profile --revision
1.4.0-canary.1+f28a7bb6c
[build] done
bun test v1.4.0-canary.1 (f28a7bb6c)

test/js/bun/cookie/cookie-expires-validation.test.ts:
(pass) Bun.Cookie expires validation > Date objects > accepts valid Date in future [0.14ms]
(pass) Bun.Cookie expires validation > Date objects > accepts valid Date in past [0.06ms]
(pass) Bun.Cookie expires valida
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/BunObject.rs                       |  9 ++++++-
 .../bun/cookie/cookie-expires-validation.test.ts   | 31 ++++++++++++++++++++++
 2 files changed, 39 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 15

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/runtime/api/BunObject.rs                              4      3     18
test/js/bun/cookie/cookie-expires-validation.test.ts      5      5     18
```

</details>

<!-- robobun:evidence:end -->