### PR TITLE
cli: add `--check` flag to syntax-check a file without executing

### DIFF
--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -472,6 +472,7 @@ _bun_run_completion() {
         '--cwd[Absolute path to resolve files & entry points from. This just changes the process cwd]:cwd' \
         '--config[Config file to load bun from (e.g. -c bunfig.toml]: :->config' \
         '-c[Config file to load bun from (e.g. -c bunfig.toml]: :->config' \
+        '--check[Check the syntax of the entry point without executing it]' \
         '--env-file[Load environment variables from the specified file(s)]:env-file' \
         '--extension-order[Defaults to: .tsx,.ts,.jsx,.js,.json]:extension-order' \
         '--jsx-factory[Changes the function called when compiling JSX elements using the classic JSX runtime]:jsx-factory' \

--- a/docs/snippets/cli/run.mdx
+++ b/docs/snippets/cli/run.mdx
@@ -22,6 +22,11 @@ bun run <file or script>
   Evaluate argument as a script and print the result. Alias: <code>-p</code>
 </ParamField>
 
+<ParamField path="--check" type="boolean">
+  Check the syntax of the entry point without executing it. With no file (or <code>-</code>), reads from stdin.
+  Equivalent to <code>node --check</code>
+</ParamField>
+
 <ParamField path="--help" type="boolean">
   Display this menu and exit. Alias: <code>-h</code>
 </ParamField>

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -544,6 +544,8 @@ pub struct RuntimeOptions {
     pub redis_preconnect: bool,
     pub sql_preconnect: bool,
     pub eval: Eval,
+    /// `--check`: parse the entry point and exit without executing.
+    pub syntax_check: bool,
     pub preconnect: Vec<Box<[u8]>>,
     pub experimental_http2_fetch: bool,
     pub experimental_http3_fetch: bool,
@@ -615,6 +617,7 @@ impl Default for RuntimeOptions {
             redis_preconnect: false,
             sql_preconnect: false,
             eval: Eval::default(),
+            syntax_check: false,
             preconnect: Vec::new(),
             experimental_http2_fetch: false,
             experimental_http3_fetch: false,

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -229,6 +229,9 @@ const RUNTIME_PARAMS_: &[ParamType] = &[
         "-p, --print <STR>                 Evaluate argument as a script and print the result"
     ),
     parse_param!(
+        "--check                           Check the syntax of the entry point without executing it"
+    ),
+    parse_param!(
         "--prefer-offline                  Skip staleness checks for packages in the Bun runtime and resolve from disk"
     ),
     parse_param!(
@@ -1204,6 +1207,13 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
             ctx.runtime_options.eval.eval_and_print = true;
         } else if let Some(script) = args.option(b"--eval") {
             ctx.runtime_options.eval.script = script.into();
+        }
+        ctx.runtime_options.syntax_check = args.flag(b"--check");
+        if ctx.runtime_options.syntax_check
+            && (args.option(b"--eval").is_some() || args.option(b"--print").is_some())
+        {
+            Output::err_generic("either --check or --eval can be used, not both", ());
+            Global::exit(9);
         }
         ctx.runtime_options.if_present = args.flag(b"--if-present");
         ctx.runtime_options.smol = args.flag(b"--smol");

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1433,6 +1433,10 @@ pub mod command {
         };
         ctx.args.target = Some(bun_options_types::schema::api::Target::Bun);
 
+        if ctx.runtime_options.syntax_check {
+            return run_command::RunCommand::exec_check(ctx);
+        }
+
         if ctx.parallel || ctx.sequential {
             // Result<Infallible, _>: if this returns at all, it's Err.
             let Err(err) = super::multi_run::run(ctx);

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -2857,6 +2857,104 @@ impl RunCommand {
         Self::exec_eval(ctx)
     }
 
+    /// `bun --check <file>` / `node --check` — parse the entry point and exit
+    /// 0 on success, or print syntax errors and exit 1. Never boots the JS VM.
+    #[cold]
+    #[inline(never)]
+    pub(crate) fn exec_check(ctx: &mut ContextData) -> crate::Result<()> {
+        bun_ast::initialize_store();
+        let arena = runner_arena();
+
+        let mut positionals: &[Box<[u8]>] = &ctx.positionals[..];
+        // `bun run --check <file>` leaves "run" in positionals[0]; strip it
+        // (but not under node emulation, where positionals[0] is the script).
+        if !crate::cli::PRETEND_TO_BE_NODE.load(::core::sync::atomic::Ordering::Relaxed)
+            && !positionals.is_empty()
+            && positionals[0].as_ref() == b"run"
+        {
+            positionals = &positionals[1..];
+        }
+
+        let entry = positionals.first().filter(|e| e.as_ref() != b"-");
+        let (path, contents): (Box<[u8]>, Vec<u8>) = if let Some(entry) = entry {
+            let entry: Box<[u8]> = entry.clone();
+            // Cursor-read (not pread-based `read_from`) so pipes passed as
+            // paths (process substitution, FIFOs) work like `node --check`.
+            match sys::File::openat(Fd::cwd(), &entry, sys::O::RDONLY, 0).and_then(|f| {
+                let mut bytes = Vec::new();
+                f.read_to_end_into(&mut bytes).map(|_| bytes)
+            }) {
+                Ok(bytes) => (entry, bytes),
+                Err(err) => {
+                    if ctx.runtime_options.if_present && err.get_errno() == sys::E::ENOENT {
+                        Output::flush();
+                        Global::exit(0);
+                    }
+                    let verb: &[u8] = if err.get_errno() == sys::E::ENOENT {
+                        b"find module"
+                    } else {
+                        b"read"
+                    };
+                    pretty_errorln!(
+                        "<r><red>error<r><d>:<r> Cannot {} {} ({})",
+                        bstr::BStr::new(verb),
+                        bun_core::fmt::quote(&entry),
+                        bstr::BStr::new(err.name()),
+                    );
+                    Global::exit(1);
+                }
+            }
+        } else {
+            let mut bytes = Vec::new();
+            match sys::File::stdin().read_to_end_into(&mut bytes) {
+                Ok(_) => (Box::from(&b"[stdin]"[..]), bytes),
+                Err(err) => {
+                    pretty_errorln!(
+                        "<r><red>error<r><d>:<r> Failed to read stdin ({})",
+                        bstr::BStr::new(err.name()),
+                    );
+                    Global::exit(1);
+                }
+            }
+        };
+
+        let ext = paths::extension(&path);
+        let user_loader = ctx.args.loaders.as_ref().and_then(|m| {
+            m.extensions
+                .iter()
+                .position(|e| strings::eql(e, ext))
+                .map(|i| <Loader as bun_options_types::LoaderExt>::from_api(m.loaders[i]))
+        });
+        let loader = user_loader
+            .or_else(|| bun_bundler::options::DEFAULT_LOADERS.get(ext).copied())
+            .filter(|l| l.is_javascript_like())
+            .unwrap_or(Loader::Tsx);
+
+        let source = bun_ast::Source::init_path_string(&*path, &*contents);
+        let define = bun_js_parser::Define::default();
+        let mut opts =
+            bun_js_parser::ParserOptions::init(bun_options_types::jsx::Pragma::default(), loader);
+        opts.features.top_level_await = true;
+
+        // SAFETY: `ctx.log` is the process-lifetime CLI log set in
+        // `Command::start`; no other borrow is live here.
+        let log: &mut bun_ast::Log = unsafe { ctx.log() };
+        let had_error = match bun_js_parser::Parser::init(opts, log, &source, &define, arena) {
+            Ok(parser) => parser.parse().is_err(),
+            Err(_) => true,
+        };
+
+        // SAFETY: see above; the parser's `&mut Log` borrow has ended.
+        let log: &mut bun_ast::Log = unsafe { ctx.log() };
+        if had_error || log.has_errors() {
+            let _ = log.print(std::ptr::from_mut(Output::error_writer()));
+            Output::flush();
+            Global::exit(1);
+        }
+        Output::flush();
+        Global::exit(0);
+    }
+
     /// Synthetic `cwd/[eval]`
     /// entry point + boot. `Arguments::parse` has already stashed the script
     /// in `ctx.runtime_options.eval.script`. Public so `Command::start` can
@@ -2896,6 +2994,10 @@ impl RunCommand {
         // their own `.env.{mode}` resolution (Vite etc.) don't see pre-populated
         // values. Explicit `--env-file` is still honored. #6338
         ctx.args.disable_default_env_files = true;
+
+        if ctx.runtime_options.syntax_check {
+            return Self::exec_check(ctx);
+        }
 
         // `node --interactive [-e code]`: same gate as AutoCommand — a script
         // positional wins, and `-p` currently bypasses the REPL (see mod.rs).

--- a/test/cli/run/check.test.ts
+++ b/test/cli/run/check.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+describe.concurrent("bun --check", () => {
+  test("exits 0 and produces no output for a syntactically valid file", async () => {
+    using dir = tempDir("check-valid", {
+      "ok.js": `const x = 1;\nconsole.log("SHOULD NOT RUN");\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--check", "ok.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // The script must not execute.
+    expect(stdout).not.toContain("SHOULD NOT RUN");
+    expect(stdout).toBe("");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("exits 1 and reports a syntax error for an invalid file", async () => {
+    using dir = tempDir("check-invalid", {
+      "bad.js": `const x = ;\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--check", "bad.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("error");
+    expect(stderr).toContain("bad.js");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test("does not execute the file", async () => {
+    using dir = tempDir("check-noexec", {
+      "side-effect.js": `
+        import fs from "node:fs";
+        fs.writeFileSync("ran.txt", "1");
+        process.exit(42);
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--check", "side-effect.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("");
+    expect(await Bun.file(`${dir}/ran.txt`).exists()).toBe(false);
+    expect(exitCode).toBe(0);
+  });
+
+  test("accepts TypeScript syntax in .ts files", async () => {
+    using dir = tempDir("check-ts", {
+      "ok.ts": `interface Foo { x: number }\nconst y: Foo = { x: 1 };\nexport { y };\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--check", "ok.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("honors --loader overrides", async () => {
+    // TS syntax in a .js file: fails by default, passes with -l .js:ts.
+    using dir = tempDir("check-loader", {
+      "script.js": `interface Foo { x: number }\n`,
+    });
+    {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--check", "script.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("error");
+      expect(stdout).toBe("");
+      expect(exitCode).toBe(1);
+    }
+    {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--check", "-l", ".js:ts", "script.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("");
+      expect(exitCode).toBe(0);
+    }
+  });
+
+  test("accepts ESM import/export syntax", async () => {
+    using dir = tempDir("check-esm", {
+      "esm.mjs": `import foo from "bar";\nexport const x = 1;\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--check", "esm.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("accepts top-level await", async () => {
+    using dir = tempDir("check-tla", {
+      "tla.js": `const x = await Promise.resolve(1);\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--check", "tla.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("reads from stdin when no file is given", async () => {
+    {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--check"],
+        env: bunEnv,
+        stdin: new Blob(["let x = 1;\n"]),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("");
+      expect(exitCode).toBe(0);
+    }
+    {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--check"],
+        env: bunEnv,
+        stdin: new Blob(["const x = ;\n"]),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("error");
+      expect(stderr).toContain("[stdin]");
+      expect(stdout).toBe("");
+      expect(exitCode).toBe(1);
+    }
+  });
+
+  test("reads from stdin when the positional is `-`", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--check", "-"],
+      env: bunEnv,
+      stdin: new Blob(["let x = 1;\n"]),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  // Process substitution hands bun a pipe via a /dev/fd path; POSIX shells only.
+  test.skipIf(isWindows)("reads a pipe passed as a path (process substitution)", async () => {
+    await using proc = Bun.spawn({
+      cmd: ["bash", "-c", `${JSON.stringify(bunExe())} --check <(echo "let x = 1;")`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("exits 1 when the file does not exist", async () => {
+    using dir = tempDir("check-missing", {});
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--check", "nope.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("error");
+    expect(stderr).toContain("nope.js");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test("exits 0 when the file does not exist and --if-present is set", async () => {
+    using dir = tempDir("check-if-present", {});
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--check", "--if-present", "nope.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test.each(["-e", "--eval", "-p", "--print"])("rejects combining --check with %s", async flag => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--check", flag, "1 + 1"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr.toLowerCase()).toContain("either --check or --eval");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(9);
+  });
+
+  test("works via `bun run --check <file>`", async () => {
+    using dir = tempDir("check-run", {
+      "bad.js": `function f( {\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--check", "bad.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("error");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+});

--- a/test/cli/run/check.test.ts
+++ b/test/cli/run/check.test.ts
@@ -263,4 +263,44 @@ describe.concurrent("bun --check", () => {
     expect(stdout).toBe("");
     expect(exitCode).toBe(1);
   });
+
+  test("works as `node --check <file>` (argv0 emulation) without executing", async () => {
+    using dir = tempDir("check-as-node", {
+      "script.js": `require("fs").writeFileSync("ran.txt", "1");\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--check", "script.js"],
+      argv0: "node",
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("");
+    expect(await Bun.file(`${dir}/ran.txt`).exists()).toBe(false);
+    expect(exitCode).toBe(0);
+  });
+
+  test("`node --check run` checks a file literally named `run`", async () => {
+    // Under node emulation positionals[0] is the script, so the `run`
+    // subcommand strip must not apply.
+    using dir = tempDir("check-as-node-run", {
+      run: `const x = ;\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--check", "run"],
+      argv0: "node",
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("error");
+    expect(stderr).toContain("run");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
 });


### PR DESCRIPTION
## What

Adds `bun --check <file>`, equivalent to Node's `node --check` / `node -c`: parse the entry point for syntax errors and exit without ever executing it.

```sh
$ bun --check ok.js
$ echo $?
0

$ bun --check bad.js
1 | const x = ;
              ^
error: Unexpected ;
    at bad.js:1:11
$ echo $?
1
```

## Behavior

- `bun --check <file>` — parses `<file>`; exits 0 silently on success, prints the syntax error and exits 1 on failure.
- `bun --check` with no file — reads from stdin (like `node --check`).
- `bun run --check <file>` — same.
- Works with JS, TS, JSX and TSX (loader is picked from the file extension, defaulting to TSX).
- Top-level `await` and ESM `import`/`export` are accepted.
- Never boots the JS VM or resolves imports — it only parses.
- `--check` combined with `--eval`/`--print` is rejected with `either --check or --eval can be used, not both` and exit code 9, matching Node.

The short `-c` spelling is **not** provided because `-c` is already `--config` in Bun.

## How

- New `syntax_check: bool` on `RuntimeOptions`, populated from a `--check` entry in `RUNTIME_PARAMS_`.
- `RunCommand::exec_check()` reads the file (or stdin via a streaming `read()` loop — `pread` fails on pipes), picks a loader from the extension, and runs `bun_js_parser::Parser` directly against an empty `Define`. If the parse errors or the log has errors, it prints them and exits 1; otherwise exits 0.
- Wired into `exec_auto_or_run` (for `bun` / `bun run`) and `exec_as_if_node` (for `bun`-as-`node`) before VM boot.

Rebased onto main several times; conflicts were always adjacent-insertion in `run_command.rs` (most recently main's `disable_default_env_files` line in `exec_as_if_node`, kept alongside the `--check` early return). `exec_check` is `pub(crate)` to satisfy main's `-D unreachable-pub`. An earlier `wtf-bindings.cpp` assert fix was dropped because main fixed it independently.

## Tests

`test/cli/run/check.test.ts` covers: valid/invalid files, no-execute guarantee, TS syntax, ESM syntax, top-level await, stdin, missing file, `--eval` conflict, and `bun run --check`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 16 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/check.test.ts

<!-- robobun:evidence:end -->