### PR TITLE
subprocess: list valid signal names in kill() error

### DIFF
--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1592,11 +1592,25 @@ impl FromJsEnum for bun_sys::SignalCode {
         s.deref();
         match hit {
             Some(code) => Ok(code),
-            // Zig builds the `'SIGHUP', 'SIGINT' or ...` list at comptime; at
-            // 31 variants the runtime port keeps the message terse.
-            None => Err(global.throw_invalid_arguments(format_args!(
-                "{property_name} must be one of the SignalCode names"
-            ))),
+            None => {
+                // Mirror Zig's comptime `toEnumFromMap` list
+                // (`'SIGHUP', 'SIGINT', … or 'SIGSYS'`), built from the
+                // canonical signal X-macro so names are never re-spelled.
+                let names = &bun_core::SIGNAL_NAMES[1..];
+                let mut one_of = std::string::String::from("'");
+                for (i, entry) in names.iter().enumerate() {
+                    one_of.push_str(entry);
+                    one_of.push('\'');
+                    if i < names.len() - 2 {
+                        one_of.push_str(", '");
+                    } else if i == names.len() - 2 {
+                        one_of.push_str(" or '");
+                    }
+                }
+                Err(global.throw_invalid_arguments(format_args!(
+                    "{property_name} must be one of {one_of}"
+                )))
+            }
         }
     }
 }

--- a/test/js/bun/spawn/spawn-kill-signal.test.ts
+++ b/test/js/bun/spawn/spawn-kill-signal.test.ts
@@ -49,5 +49,37 @@ describe("subprocess.kill", () => {
         expect(proc.signalCode).toBe("SIGTERM");
       });
     }
+
+    test("invalid signal name lists the valid signal names", async () => {
+      const proc = Bun.spawn({
+        cmd: [shellExe(), "-c", "sleep 1000"],
+        stdio: ["inherit", "inherit", "inherit"],
+      });
+
+      let err: any;
+      try {
+        proc.kill("SIGGOD");
+      } catch (e) {
+        err = e;
+      }
+
+      expect(err).toBeInstanceOf(TypeError);
+      expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
+      // The message must enumerate the real signal names, not a static
+      // "the SignalCode names" placeholder (regressed in the Rust port).
+      expect(err.message).toContain("'SIGHUP'");
+      expect(err.message).toContain("'SIGTERM'");
+      expect(err.message).toContain("'SIGKILL'");
+      expect(err.message).toContain("or 'SIGSYS'");
+      expect(err.message).not.toContain("the SignalCode names");
+
+      const { promise, resolve, reject } = Promise.withResolvers();
+      proc.exited.then(resolve, reject);
+      proc.kill();
+      await promise;
+
+      expect(proc.exitCode).toBe(null);
+      expect(proc.signalCode).toBe("SIGTERM");
+    });
   });
 });


### PR DESCRIPTION
`subprocess.kill("BADSIGNAL")` lost its useful error message in the Rust port: it emitted the static placeholder `signal must be one of the SignalCode names` (naming zero actual signals) instead of the full list released Bun produces.

Build the list from the canonical signal X-macro (matching Zig's comptime `toEnumFromMap`), so the message is byte-for-byte identical to released Bun again: `signal must be one of 'SIGHUP', 'SIGINT', … or 'SIGSYS'`. `code`/`name` were already correct.