### PR TITLE
spawn: don't forward SIGPWR on Linux

### DIFF
--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -933,9 +933,11 @@ static struct sigaction previous_actions[NSIG];
     M(SIGIO);
 
 #if OS(LINUX)
+// SIGPWR is intentionally excluded: JSC uses it for GC thread suspend/resume
+// on Linux (see WTF/wtf/posix/ThreadingPOSIX.cpp). Replacing that handler here
+// makes the next GC-sent SIGPWR terminate the process.
 #define FOR_EACH_LINUX_ONLY_SIGNAL(M) \
     M(SIGPOLL);                       \
-    M(SIGPWR);                        \
     M(SIGSTKFLT);
 
 #endif

--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -61,7 +61,7 @@ extern "C" int uv_tty_reset_mode(void)
 
 static void uv__tty_make_raw(struct termios* tio)
 {
-    assert(tio != NULL);
+    ASSERT(tio != NULL);
 
 #if defined __sun || defined __MVS__
     /*

--- a/test/js/bun/spawn/spawnSync.test.ts
+++ b/test/js/bun/spawn/spawnSync.test.ts
@@ -40,4 +40,31 @@ describe("spawnSync", () => {
   it.skipIf(!isPosix)("should use spawnSync optimizations when possible", () => {
     expect([join(import.meta.dir, "spawnSync-counters-fixture.ts")]).toRun();
   });
+
+  // On Linux, JSC uses SIGPWR to suspend/resume threads for GC. The spawnSync
+  // signal-forwarding table used to include SIGPWR, so a GC that fired while
+  // (or after) spawnSync ran would terminate the process with signal 30.
+  it.skipIf(process.platform !== "linux")("does not clobber the GC thread-suspend signal handler", () => {
+    const result = Bun.spawnSync({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          for (let i = 0; i < 50; i++) {
+            Bun.spawnSync({ cmd: ["true"] });
+            Bun.gc(true);
+          }
+          for (let i = 0; i < 50; i++) {
+            Bun.spawnSync({ cmd: ["true"] });
+          }
+          Bun.gc(true);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+    expect(result.signalCode).toBeFalsy();
+    expect(result.exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
On Linux, JSC uses `SIGPWR` to suspend/resume mutator threads for GC (see `WTF/wtf/posix/ThreadingPOSIX.cpp`):

```cpp
g_wtfConfig.sigThreadSuspendResume = SIGPWR;
```

`Bun__registerSignalsForForwarding()` was installing a `SA_RESETHAND` forwarding handler for `SIGPWR`, replacing JSC's `signalHandlerSuspendResume` process-wide for the duration of each `sync::spawn()`.

When multiple threads call `sync::spawn()` concurrently (e.g. via `Bun.openInEditor`, which spawns a detached thread per call that runs `sync::spawn` for the editor process), the register/unregister pair races on the global `previous_actions[]` array: one thread's unregister `memset`s the saved handler to zero, so the next thread's unregister restores `SIG_DFL` for `SIGPWR`. The next GC-sent `SIGPWR` then terminates the process with signal 30.

The signal list was copied from npm, which runs on Node.js and has no special use for `SIGPWR`. Bun does, so drop `SIGPWR` from the Linux forwarding list — there is no legitimate use case for forwarding a power-failure signal to a child script anyway.

### Repro

```js
for (let i = 0; i < 2100; i++) {
  Bun.openInEditor(Int16Array);
}
```

Before: process killed by `SIGPWR` (exit 158) during or after cleanup.
After: exits cleanly.

Also replaces a stray lowercase `assert()` in `wtf-bindings.cpp` with WTF's `ASSERT` so the file compiles standalone in a unified build (pre-existing break exposed when the PCH is regenerated).

Found by Fuzzilli. Fingerprint `0166e0b96fc64e94`.