### PR TITLE
util: make styleText color-aware and validate options (Node parity)

### DIFF
--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -3,7 +3,7 @@ const types = require("node:util/types");
 /** @type {import('node-inspect-extracted')} */
 const utl = require("internal/util/inspect");
 const { promisify } = require("internal/promisify");
-const { validateString, validateOneOf, validateBoolean } = require("internal/validators");
+const { validateString, validateOneOf, validateBoolean, validateObject } = require("internal/validators");
 const { MIMEType, MIMEParams } = require("internal/util/mime");
 const { deprecate } = require("internal/util/deprecate");
 
@@ -60,21 +60,53 @@ function emitWarningIfNeeded(set) {
   }
 }
 
-function debuglog(set) {
-  set = set.toUpperCase();
+function debuglogImpl(enabled, set) {
   if (!debugs[set]) {
-    if (debugEnvRegex.test(set)) {
-      var pid = process.pid;
+    let impl;
+    if (enabled) {
+      const pid = process.pid;
       emitWarningIfNeeded(set);
-      debugs[set] = function () {
-        var msg = format.$apply(cjs_exports, arguments);
+      impl = function debug() {
+        const msg = format.$apply(cjs_exports, arguments);
         console.error("%s %d: %s", set, pid, msg);
       };
     } else {
-      debugs[set] = function () {};
+      impl = function debug() {};
     }
+    Object.defineProperty(impl, "enabled", {
+      __proto__: null,
+      value: enabled,
+      configurable: true,
+      enumerable: true,
+    });
+    debugs[set] = impl;
   }
   return debugs[set];
+}
+
+function debuglog(set, cb) {
+  set = set.toUpperCase();
+  const enabled = debugEnvRegex.test(set);
+  // The implementation is created eagerly so that the NODE_DEBUG=http warning
+  // is emitted when node:http requires this, the way node:_http_client does.
+  const impl = debuglogImpl(enabled, set);
+  let notified = false;
+  const logger = function debuglogWrapper() {
+    if (!notified) {
+      notified = true;
+      if (typeof cb === "function") cb(impl);
+    }
+    return impl.$apply(undefined, arguments);
+  };
+  Object.defineProperty(logger, "enabled", {
+    __proto__: null,
+    get() {
+      return enabled;
+    },
+    configurable: true,
+    enumerable: true,
+  });
+  return logger;
 }
 
 function isBoolean(arg) {
@@ -213,19 +245,33 @@ var toUSVString = input => {
   return (input + "").toWellFormed();
 };
 
-function styleText(format, text, { validateStream = true, stream = process.stdout } = {}) {
+// internal/streams/utils pulls in the whole stream machinery and
+// internal/util/colors requires node:tty, so neither loads until a caller
+// actually asks styleText to look at a stream.
+let lazyStreamUtils;
+let lazyUtilColors;
+
+// The options are read the way node's lib/util.js reads them today, so that
+// `{ stream: null }` falls back to process.stdout rather than throwing.
+function styleText(format, text, options) {
+  const validateStream = options?.validateStream ?? true;
+
   validateString(text, "text");
+  if (options !== undefined) {
+    validateObject(options, "options");
+  }
   validateBoolean(validateStream, "options.validateStream");
 
   let skipColorize;
   if (validateStream) {
+    const stream = options?.stream ?? process.stdout;
+    lazyStreamUtils ??= require("internal/streams/utils");
+    const { isReadableStream, isWritableStream, isNodeStream } = lazyStreamUtils;
     if (!isReadableStream(stream) && !isWritableStream(stream) && !isNodeStream(stream)) {
       throw $ERR_INVALID_ARG_TYPE("stream", ["ReadableStream", "WritableStream", "Stream"], stream);
     }
 
-    // Lazy to avoid a require cycle (colors -> tty -> ... -> util).
     lazyUtilColors ??= require("internal/util/colors");
-    // If the stream is falsy or should not be colorized, skip colorizing.
     skipColorize = !lazyUtilColors.shouldColorize(stream);
   }
 

--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -213,30 +213,68 @@ var toUSVString = input => {
   return (input + "").toWellFormed();
 };
 
-function styleText(format, text) {
+function styleText(format, text, { validateStream = true, stream = process.stdout } = {}) {
   validateString(text, "text");
+  validateBoolean(validateStream, "options.validateStream");
 
-  if ($isJSArray(format)) {
-    let left = "";
-    let right = "";
-    for (const key of format) {
-      const formatCodes = inspect.colors[key];
-      if (formatCodes == null) {
-        validateOneOf(key, "format", ObjectKeys(inspect.colors));
-      }
-      left += `\u001b[${formatCodes[0]}m`;
-      right = `\u001b[${formatCodes[1]}m${right}`;
+  let skipColorize;
+  if (validateStream) {
+    if (!isReadableStream(stream) && !isWritableStream(stream) && !isNodeStream(stream)) {
+      throw $ERR_INVALID_ARG_TYPE("stream", ["ReadableStream", "WritableStream", "Stream"], stream);
     }
 
-    return `${left}${text}${right}`;
+    // Lazy to avoid a require cycle (colors -> tty -> ... -> util).
+    lazyUtilColors ??= require("internal/util/colors");
+    // If the stream is falsy or should not be colorized, skip colorizing.
+    skipColorize = !lazyUtilColors.shouldColorize(stream);
   }
 
-  let formatCodes = inspect.colors[format];
+  const formatArray = $isJSArray(format) ? format : [format];
 
-  if (formatCodes == null) {
-    validateOneOf(format, "format", ObjectKeys(inspect.colors));
+  const codes: [number, number][] = [];
+  for (const key of formatArray) {
+    if (key === "none") continue;
+    const formatCodes = inspect.colors[key];
+    // If the format is not a valid style, throw an error.
+    if (formatCodes == null) {
+      validateOneOf(key, "format", ObjectKeys(inspect.colors));
+    }
+    if (skipColorize) continue;
+    codes.push(formatCodes);
   }
-  return `\u001b[${formatCodes[0]}m${text}\u001b[${formatCodes[1]}m`;
+
+  if (skipColorize) {
+    return text;
+  }
+
+  let openCodes = "";
+  for (let i = 0; i < codes.length; i++) {
+    openCodes += `\u001b[${codes[i][0]}m`;
+  }
+
+  // Process the text to handle nested styles: reapply the style after any
+  // matching reset code that is not at the very end of the string.
+  let processedText = text;
+  for (let i = 0; i < codes.length; i++) {
+    const code = codes[i];
+    processedText = processedText.replace(new RegExp(`\\u001b\\[${code[1]}m`, "g"), (match, offset) => {
+      if (offset + match.length < processedText.length) {
+        if (code[0] === inspect.colors.dim[0] || code[0] === inspect.colors.bold[0]) {
+          // Dim and bold are not mutually exclusive, so reapply.
+          return `${match}\u001b[${code[0]}m`;
+        }
+        return `\u001b[${code[0]}m`;
+      }
+      return match;
+    });
+  }
+
+  let closeCodes = "";
+  for (let i = codes.length - 1; i >= 0; i--) {
+    closeCodes += `\u001b[${codes[i][1]}m`;
+  }
+
+  return `${openCodes}${processedText}${closeCodes}`;
 }
 
 function getSystemErrorName(err: any) {

--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -6,6 +6,7 @@
 #include <wtf/dtoa.h>
 #include <wtf/NumberOfCores.h>
 #include <atomic>
+#include <cassert>
 
 #include "wtf/SIMDUTF.h"
 #if OS(WINDOWS)

--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -6,7 +6,6 @@
 #include <wtf/dtoa.h>
 #include <wtf/NumberOfCores.h>
 #include <atomic>
-#include <cassert>
 
 #include "wtf/SIMDUTF.h"
 #if OS(WINDOWS)

--- a/test/js/node/test/parallel/test-util-styletext.js
+++ b/test/js/node/test/parallel/test-util-styletext.js
@@ -1,7 +1,12 @@
 'use strict';
-require('../common');
-const assert = require('assert');
-const util = require('util');
+
+const common = require('../common');
+const assert = require('node:assert');
+const util = require('node:util');
+const { WriteStream } = require('node:tty');
+
+const styled = '\u001b[31mtest\u001b[39m';
+const noChange = 'test';
 
 [
   undefined,
@@ -17,12 +22,12 @@ const util = require('util');
     util.styleText(invalidOption, 'test');
   }, {
     code: 'ERR_INVALID_ARG_VALUE',
-  });
+  }, invalidOption);
   assert.throws(() => {
     util.styleText('red', invalidOption);
   }, {
     code: 'ERR_INVALID_ARG_TYPE'
-  });
+  }, invalidOption);
 });
 
 assert.throws(() => {
@@ -31,13 +36,188 @@ assert.throws(() => {
   code: 'ERR_INVALID_ARG_VALUE',
 });
 
-assert.strictEqual(util.styleText('red', 'test'), '\u001b[31mtest\u001b[39m');
+assert.strictEqual(
+  util.styleText('red', 'test', { validateStream: false }),
+  '\u001b[31mtest\u001b[39m',
+);
 
-assert.strictEqual(util.styleText(['bold', 'red'], 'test'), '\u001b[1m\u001b[31mtest\u001b[39m\u001b[22m');
-assert.strictEqual(util.styleText(['bold', 'red'], 'test'), util.styleText('bold', util.styleText('red', 'test')));
+assert.strictEqual(
+  util.styleText('gray', 'test', { validateStream: false }),
+  '\u001b[90mtest\u001b[39m',
+);
+
+assert.strictEqual(
+  util.styleText('grey', 'test', { validateStream: false }),
+  '\u001b[90mtest\u001b[39m',
+);
+
+assert.strictEqual(
+  util.styleText(['bold', 'red'], 'test', { validateStream: false }),
+  '\u001b[1m\u001b[31mtest\u001b[39m\u001b[22m',
+);
+
+assert.strictEqual(
+  util.styleText('red',
+                 'A' + util.styleText('blue', 'B', { validateStream: false }) + 'C',
+                 { validateStream: false }),
+  '\u001b[31mA\u001b[34mB\u001b[31mC\u001b[39m'
+);
+
+assert.strictEqual(
+  util.styleText('red',
+                 'red' +
+    util.styleText('blue', 'blue', { validateStream: false }) +
+    'red' +
+    util.styleText('blue', 'blue', { validateStream: false }) +
+    'red',
+                 { validateStream: false }
+  ),
+  '\x1B[31mred\x1B[34mblue\x1B[31mred\x1B[34mblue\x1B[31mred\x1B[39m'
+);
+
+assert.strictEqual(
+  util.styleText('red',
+                 'red' +
+    util.styleText('blue', 'blue', { validateStream: false }) +
+    'red' +
+    util.styleText('red', 'red', { validateStream: false }) +
+    'red' +
+    util.styleText('blue', 'blue', { validateStream: false }),
+                 { validateStream: false }
+  ),
+  '\x1b[31mred\x1b[34mblue\x1b[31mred\x1b[31mred\x1b[31mred\x1b[34mblue\x1b[39m\x1b[39m'
+);
+
+assert.strictEqual(
+  util.styleText('red',
+                 'A' + util.styleText(['bgRed', 'blue'], 'B', { validateStream: false }) +
+    'C', { validateStream: false }),
+  '\x1B[31mA\x1B[41m\x1B[34mB\x1B[31m\x1B[49mC\x1B[39m'
+);
+
+assert.strictEqual(
+  util.styleText('dim',
+                 'dim' +
+    util.styleText('bold', 'bold', { validateStream: false }) +
+  'dim', { validateStream: false }),
+  '\x1B[2mdim\x1B[1mbold\x1B[22m\x1B[2mdim\x1B[22m'
+);
+
+assert.strictEqual(
+  util.styleText('blue',
+                 'blue' +
+    util.styleText('red',
+                   'red' +
+      util.styleText('green', 'green', { validateStream: false }) +
+      'red', { validateStream: false }) +
+    'blue', { validateStream: false }),
+  '\x1B[34mblue\x1B[31mred\x1B[32mgreen\x1B[31mred\x1B[34mblue\x1B[39m'
+);
+
+assert.strictEqual(
+  util.styleText(
+    'red',
+    'red' +
+    util.styleText(
+      'blue',
+      'blue' + util.styleText('red', 'red', {
+        validateStream: false,
+      }) + 'blue',
+      {
+        validateStream: false,
+      }
+    ) + 'red', {
+      validateStream: false,
+    }
+  ),
+  '\x1b[31mred\x1b[34mblue\x1b[31mred\x1b[34mblue\x1b[31mred\x1b[39m'
+);
+
+assert.strictEqual(
+  util.styleText(['bold', 'red'], 'test', { validateStream: false }),
+  util.styleText(
+    'bold',
+    util.styleText('red', 'test', { validateStream: false }),
+    { validateStream: false },
+  ),
+);
 
 assert.throws(() => {
   util.styleText(['invalid'], 'text');
 }, {
   code: 'ERR_INVALID_ARG_VALUE',
 });
+
+assert.throws(() => {
+  util.styleText('red', 'text', { stream: {} });
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
+
+// Color aliases should be accepted (e.g. 'grey' is an alias for 'gray')
+// See https://github.com/nodejs/node/issues/62177
+assert.strictEqual(
+  util.styleText('grey', 'test', { validateStream: false }),
+  util.styleText('gray', 'test', { validateStream: false }),
+);
+assert.strictEqual(
+  util.styleText('bgGrey', 'test', { validateStream: false }),
+  util.styleText('bgGray', 'test', { validateStream: false }),
+);
+assert.strictEqual(
+  util.styleText('blackBright', 'test', { validateStream: false }),
+  util.styleText('gray', 'test', { validateStream: false }),
+);
+assert.strictEqual(
+  util.styleText('faint', 'test', { validateStream: false }),
+  util.styleText('dim', 'test', { validateStream: false }),
+);
+assert.strictEqual(
+  util.styleText(['grey', 'bold'], 'test', { validateStream: false }),
+  util.styleText(['gray', 'bold'], 'test', { validateStream: false }),
+);
+
+// does not throw
+util.styleText('red', 'text', { stream: {}, validateStream: false });
+
+assert.strictEqual(
+  util.styleText('red', 'test', { validateStream: false }),
+  styled,
+);
+
+assert.strictEqual(util.styleText('none', 'test'), 'test');
+
+const fd = common.getTTYfd();
+if (fd !== -1) {
+  const writeStream = new WriteStream(fd);
+
+  const originalEnv = process.env;
+  [
+    { isTTY: true, env: {}, expected: styled },
+    { isTTY: false, env: {}, expected: noChange },
+    { isTTY: true, env: { NODE_DISABLE_COLORS: '1' }, expected: noChange },
+    { isTTY: true, env: { NO_COLOR: '1' }, expected: noChange },
+    { isTTY: true, env: { FORCE_COLOR: '1' }, expected: styled },
+    { isTTY: true, env: { FORCE_COLOR: '1', NODE_DISABLE_COLORS: '1' }, expected: styled },
+    { isTTY: false, env: { FORCE_COLOR: '1', NO_COLOR: '1', NODE_DISABLE_COLORS: '1' }, expected: styled },
+    { isTTY: true, env: { FORCE_COLOR: '1', NO_COLOR: '1', NODE_DISABLE_COLORS: '1' }, expected: styled },
+  ].forEach((testCase) => {
+    writeStream.isTTY = testCase.isTTY;
+    process.env = {
+      ...process.env,
+      ...testCase.env
+    };
+    {
+      const output = util.styleText('red', 'test', { stream: writeStream });
+      assert.strictEqual(output, testCase.expected);
+    }
+    {
+      // Check that when passing an array of styles, the output behaves the same
+      const output = util.styleText(['red'], 'test', { stream: writeStream });
+      assert.strictEqual(output, testCase.expected);
+    }
+    process.env = originalEnv;
+  });
+} else {
+  common.skip('Could not create TTY fd');
+}

--- a/test/js/node/test/parallel/test-util-styletext.js
+++ b/test/js/node/test/parallel/test-util-styletext.js
@@ -1,4 +1,8 @@
 'use strict';
+// ci sets FORCE_COLOR/NO_COLOR, which makes the test fail in both node and bun
+delete process.env["FORCE_COLOR"];
+delete process.env["NO_COLOR"];
+delete process.env["NODE_DISABLE_COLORS"];
 
 const common = require('../common');
 const assert = require('node:assert');
@@ -189,7 +193,13 @@ assert.strictEqual(util.styleText('none', 'test'), 'test');
 
 const fd = common.getTTYfd();
 if (fd !== -1) {
-  const writeStream = new WriteStream(fd);
+  let writeStream;
+  try {
+    writeStream = new WriteStream(fd);
+  } catch {
+    // e.g. EINVAL from kqueue on /dev/tty on macOS
+    common.skip('Could not create TTY WriteStream');
+  }
 
   const originalEnv = process.env;
   [

--- a/test/js/node/test/parallel/test-util-styletext.js
+++ b/test/js/node/test/parallel/test-util-styletext.js
@@ -196,8 +196,10 @@ if (fd !== -1) {
   let writeStream;
   try {
     writeStream = new WriteStream(fd);
-  } catch {
-    // e.g. EINVAL from kqueue on /dev/tty on macOS
+  } catch (err) {
+    // getTTYfd() falls back to a read-only /dev/tty when no stdio fd is a tty,
+    // and bun cannot poll that fd for writability (EINVAL from kqueue).
+    if (err.code !== 'EINVAL') throw err;
     common.skip('Could not create TTY WriteStream');
   }
 

--- a/test/js/node/util/debuglog.test.ts
+++ b/test/js/node/util/debuglog.test.ts
@@ -1,0 +1,100 @@
+// https://nodejs.org/api/util.html#utildebuglogsection-callback
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import util from "node:util";
+
+async function run(script: string, nodeDebug?: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    // Always set the key so an ambient NODE_DEBUG cannot leak into the child.
+    env: { ...bunEnv, NODE_DEBUG: nodeDebug },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("util.debuglog", () => {
+  // The value of `enabled` depends on this process's NODE_DEBUG, so the true and
+  // false cases live in the subprocess tests below.
+  test("returns a function exposing an enumerable `enabled` boolean", () => {
+    const log = util.debuglog("some-section");
+    expect(typeof log).toBe("function");
+    expect(typeof log.enabled).toBe("boolean");
+    expect(Object.keys(log)).toEqual(["enabled"]);
+  });
+
+  test("util.debug is util.debuglog", () => {
+    expect(util.debug).toBe(util.debuglog);
+  });
+
+  test.concurrent("a disabled section writes nothing", async () => {
+    const result = await run(`require("util").debuglog("quiet")("hello");`);
+    expect(result).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+  });
+
+  test.concurrent("an enabled section writes SECTION pid: message to stderr", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `const log = require("util").debuglog("noisy");
+       process.stdout.write(String(log.enabled));
+       log("hello %s", "world");`,
+      "noisy",
+    );
+    expect(stdout).toBe("true");
+    expect(stderr.trim()).toMatch(/^NOISY \d+: hello world$/);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("enabled reflects NODE_DEBUG", async () => {
+    const script = `const util = require("util");
+      process.stdout.write(JSON.stringify([util.debuglog("a").enabled, util.debuglog("b").enabled]));`;
+    const results = await Promise.all([run(script, "a"), run(script, "b"), run(script, "a,b"), run(script)]);
+    expect(results.map(r => r.stdout)).toEqual(["[true,false]", "[false,true]", "[true,true]", "[false,false]"]);
+  });
+
+  test.concurrent("section matching is case-insensitive and supports wildcards", async () => {
+    const script = `const util = require("util");
+      process.stdout.write(JSON.stringify([util.debuglog("FOO").enabled, util.debuglog("foobar").enabled]));`;
+    const results = await Promise.all([run(script, "foo"), run(script, "foo*")]);
+    expect(results.map(r => r.stdout)).toEqual(["[true,false]", "[true,true]"]);
+  });
+
+  test.concurrent("the callback runs once, on the first call, with the logging function", async () => {
+    const { stdout, exitCode } = await run(
+      `const util = require("util");
+       const seen = [];
+       const log = util.debuglog("cb", fn => seen.push(typeof fn));
+       const beforeFirstCall = seen.length;
+       log("one");
+       log("two");
+       process.stdout.write(JSON.stringify({ beforeFirstCall, seen }));`,
+      "cb",
+    );
+    expect(stdout).toBe(`{"beforeFirstCall":0,"seen":["function"]}`);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("the logging function handed to the callback also reports enabled", async () => {
+    const { stdout } = await run(
+      `const util = require("util");
+       let enabled;
+       util.debuglog("cb2", fn => { enabled = fn.enabled; })("x");
+       process.stdout.write(String(enabled));`,
+      "cb2",
+    );
+    expect(stdout).toBe("true");
+  });
+
+  test.concurrent("a non-function callback is ignored", async () => {
+    const result = await run(`require("util").debuglog("ignored", 42)("x");`, "ignored");
+    expect(result.stderr.trim()).toMatch(/^IGNORED \d+: x$/);
+    expect(result.exitCode).toBe(0);
+  });
+
+  test.concurrent("NODE_DEBUG=http warns that it can expose sensitive data", async () => {
+    const { stderr, exitCode } = await run(`require("util").debuglog("http");`, "http");
+    expect(stderr).toContain("can expose sensitive data");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/util/style-text.test.ts
+++ b/test/js/node/util/style-text.test.ts
@@ -1,0 +1,185 @@
+// Bun-side coverage of util.styleText. The node-parity assertions live in
+// styletext.test.ts (which also runs under node) and in the ported
+// test/js/node/test/parallel/test-util-styletext.js.
+// https://nodejs.org/api/util.html#utilstyletextformat-text-options
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { Writable } from "node:stream";
+import util from "node:util";
+
+// styleText only emits escape codes when the target stream can show them, so
+// every in-process case has to name a stream or opt out of the check. The
+// default-stream behavior is covered by subprocesses further down.
+const raw = { validateStream: false } as const;
+
+function colorCapableStream() {
+  const stream: any = new Writable();
+  stream.isTTY = true;
+  stream.getColorDepth = () => 24;
+  return stream;
+}
+
+// FORCE_COLOR short-circuits the stream check, so the in-process cases below
+// would answer to the ambient environment rather than to the stream they pass.
+const ambientForceColor = process.env.FORCE_COLOR;
+beforeAll(() => {
+  delete process.env.FORCE_COLOR;
+});
+afterAll(() => {
+  if (ambientForceColor !== undefined) process.env.FORCE_COLOR = ambientForceColor;
+});
+
+describe("util.styleText", () => {
+  test("wraps the text in the format's open and close codes", () => {
+    expect(util.styleText("red", "test", raw)).toBe("\u001b[31mtest\u001b[39m");
+    expect(util.styleText("bold", "test", raw)).toBe("\u001b[1mtest\u001b[22m");
+  });
+
+  test("applies an array of formats from the outside in", () => {
+    expect(util.styleText(["bold", "red"], "test", raw)).toBe("\u001b[1m\u001b[31mtest\u001b[39m\u001b[22m");
+    expect(util.styleText(["bold", "red"], "test", raw)).toBe(
+      util.styleText("bold", util.styleText("red", "test", raw), raw),
+    );
+  });
+
+  test("accepts the color aliases", () => {
+    expect(util.styleText("grey", "t", raw)).toBe(util.styleText("gray", "t", raw));
+    expect(util.styleText("bgGrey", "t", raw)).toBe(util.styleText("bgGray", "t", raw));
+    expect(util.styleText("blackBright", "t", raw)).toBe(util.styleText("gray", "t", raw));
+    expect(util.styleText("faint", "t", raw)).toBe(util.styleText("dim", "t", raw));
+  });
+
+  test("the 'none' format leaves the text untouched", () => {
+    expect(util.styleText("none", "test")).toBe("test");
+    expect(util.styleText(["none"], "test", raw)).toBe("test");
+    expect(util.styleText(["none", "red"], "test", raw)).toBe("\u001b[31mtest\u001b[39m");
+  });
+
+  test("rejects an unknown format", () => {
+    expect(() => util.styleText("invalid", "text")).toThrowWithCode(TypeError, "ERR_INVALID_ARG_VALUE");
+    expect(() => util.styleText(["invalid"], "text")).toThrowWithCode(TypeError, "ERR_INVALID_ARG_VALUE");
+    expect(() => util.styleText(["red", "invalid"], "text")).toThrowWithCode(TypeError, "ERR_INVALID_ARG_VALUE");
+  });
+
+  test.each([undefined, null, false, 5n, 5, Symbol("s"), () => {}, {}])("rejects %p as a format", invalid => {
+    expect(() => util.styleText(invalid as any, "test")).toThrowWithCode(TypeError, "ERR_INVALID_ARG_VALUE");
+  });
+
+  test.each([undefined, null, false, 5n, 5, Symbol("s"), () => {}, {}])("rejects %p as text", invalid => {
+    expect(() => util.styleText("red", invalid as any)).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+  });
+
+  test("validates the options object", () => {
+    expect(() => util.styleText("red", "x", 5 as any)).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+    expect(() => util.styleText("red", "x", null as any)).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+    expect(() => util.styleText("red", "x", { validateStream: "yes" } as any)).toThrowWithCode(
+      TypeError,
+      "ERR_INVALID_ARG_TYPE",
+    );
+  });
+
+  describe("options.stream", () => {
+    test("colorizes when the stream supports colors", () => {
+      expect(util.styleText("red", "x", { stream: colorCapableStream() })).toBe("\u001b[31mx\u001b[39m");
+      expect(util.styleText(["red"], "x", { stream: colorCapableStream() })).toBe("\u001b[31mx\u001b[39m");
+    });
+
+    test("leaves the text alone when the stream is not a TTY", () => {
+      expect(util.styleText("red", "x", { stream: new Writable() })).toBe("x");
+    });
+
+    // https://github.com/oven-sh/bun/issues/25736
+    test("honors a bare isTTY flag on a stream with no getColorDepth", () => {
+      const tty: any = new Writable();
+      tty.isTTY = true;
+      const notTty: any = new Writable();
+      notTty.isTTY = false;
+      expect(util.styleText("bgYellow", "TTY", { stream: tty })).toBe("\u001b[43mTTY\u001b[49m");
+      expect(util.styleText("bgYellow", "No TTY", { stream: notTty })).toBe("No TTY");
+    });
+
+    test("accepts web streams", () => {
+      expect(util.styleText("red", "x", { stream: new WritableStream() as any })).toBe("x");
+      expect(util.styleText("red", "x", { stream: new ReadableStream() as any })).toBe("x");
+    });
+
+    test("rejects anything that is not a stream", () => {
+      expect(() => util.styleText("red", "x", { stream: {} as any })).toThrowWithCode(
+        TypeError,
+        "ERR_INVALID_ARG_TYPE",
+      );
+      expect(() => util.styleText("red", "x", { stream: 1 as any })).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+    });
+
+    test("skips the stream check entirely when validateStream is false", () => {
+      expect(util.styleText("red", "x", { stream: {} as any, validateStream: false })).toBe("\u001b[31mx\u001b[39m");
+    });
+  });
+
+  // The enclosing color resumes after a nested styleText closes, rather than the
+  // nested reset leaving the rest of the string unstyled.
+  test("restores the outer format after a nested one closes", () => {
+    const nested = "A" + util.styleText("blue", "B", raw) + "C";
+    expect(util.styleText("red", nested, raw)).toBe("\u001b[31mA\u001b[34mB\u001b[31mC\u001b[39m");
+  });
+
+  // https://github.com/oven-sh/bun/issues/20129
+  describe("the color environment variables", () => {
+    // A stream that claims to be a TTY and defers to the real color detection,
+    // so the env vars are the only thing deciding the outcome.
+    const script = `
+      const { Writable } = require("node:stream");
+      const stream = new Writable();
+      stream.isTTY = true;
+      stream.getColorDepth = require("node:tty").WriteStream.prototype.getColorDepth;
+      process.stdout.write(JSON.stringify(require("util").styleText("cyan", "hi", { stream })));
+    `;
+    const cleared = { ...bunEnv, NO_COLOR: undefined, FORCE_COLOR: undefined, NODE_DISABLE_COLORS: undefined };
+    const colorized = JSON.stringify("\u001b[36mhi\u001b[39m");
+
+    test.concurrent.each([
+      ["NO_COLOR", { NO_COLOR: "1" }, `"hi"`],
+      ["NODE_DISABLE_COLORS", { NODE_DISABLE_COLORS: "1" }, `"hi"`],
+      ["FORCE_COLOR", { FORCE_COLOR: "1" }, colorized],
+    ])("%s decides whether a TTY stream gets colors", async (_name, env, expected) => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: { ...cleared, ...env },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr: stderr.trim(), exitCode }).toEqual({ stdout: expected, stderr: "", exitCode: 0 });
+    });
+  });
+
+  describe("the default stream is process.stdout", () => {
+    const script = `process.stdout.write(JSON.stringify(require("util").styleText("red", "test")));`;
+
+    test.concurrent("a piped stdout gets no escape codes", async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr: stderr.trim(), exitCode }).toEqual({ stdout: `"test"`, stderr: "", exitCode: 0 });
+    });
+
+    test.concurrent("FORCE_COLOR turns the codes back on", async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: { ...bunEnv, FORCE_COLOR: "1", NO_COLOR: undefined },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr: stderr.trim(), exitCode }).toEqual({
+        stdout: JSON.stringify("\u001b[31mtest\u001b[39m"),
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+  });
+});

--- a/test/js/node/util/styletext.test.ts
+++ b/test/js/node/util/styletext.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Runs under `bun test` and (via node:test/node:assert) under
+ * `node --experimental-strip-types --test`. Green under Node proves the
+ * assertions encode real Node v22 behaviour, so a green run under Bun means
+ * Bun matches Node.
+ *
+ * Node v22 made `util.styleText` colour-aware and option-validating. Bun's
+ * port took only `(format, text)`: it always emitted ANSI (corrupting piped /
+ * redirected logs, ignoring `NO_COLOR`), silently ignored `stream` /
+ * `validateStream`, and wrongly threw on the valid `'none'` format.
+ */
+import assert from "node:assert";
+import { PassThrough } from "node:stream";
+import { test } from "node:test";
+import { styleText } from "node:util";
+
+test("styleText does not colourize a non-TTY stream", () => {
+  assert.strictEqual(styleText("red", "x", { stream: new PassThrough() }), "x");
+  assert.strictEqual(styleText(["bold", "red"], "x", { stream: new PassThrough() }), "x");
+});
+
+test("styleText with validateStream:false always colourizes", () => {
+  assert.strictEqual(styleText("red", "x", { validateStream: false }), "\u001b[31mx\u001b[39m");
+  assert.strictEqual(
+    styleText(["bold", "red"], "test", { validateStream: false }),
+    "\u001b[1m\u001b[31mtest\u001b[39m\u001b[22m",
+  );
+});
+
+test("styleText skips the 'none' format instead of throwing", () => {
+  assert.strictEqual(styleText(["red", "none"], "x", { validateStream: false }), "\u001b[31mx\u001b[39m");
+  assert.strictEqual(styleText("none", "x", { validateStream: false }), "x");
+  assert.strictEqual(styleText(["red", "none"], "x", { stream: new PassThrough() }), "x");
+});
+
+test("styleText reapplies the style after a nested reset", () => {
+  assert.strictEqual(
+    styleText("red", "a\u001b[39mb", { validateStream: false }),
+    "\u001b[31ma\u001b[31mb\u001b[39m",
+  );
+});
+
+test("styleText validates options.validateStream", () => {
+  assert.throws(() => styleText("red", "x", { validateStream: "x" }), { code: "ERR_INVALID_ARG_TYPE" });
+});
+
+test("styleText validates the stream option", () => {
+  for (const stream of [123, {}, "nope", Symbol()]) {
+    assert.throws(() => styleText("red", "x", { stream }), { code: "ERR_INVALID_ARG_TYPE" });
+  }
+});
+
+test("styleText still validates format and text", () => {
+  assert.throws(() => styleText("invalid", "x", { validateStream: false }), { code: "ERR_INVALID_ARG_VALUE" });
+  assert.throws(() => styleText("red", 123, { validateStream: false }), { code: "ERR_INVALID_ARG_TYPE" });
+});

--- a/test/js/node/util/styletext.test.ts
+++ b/test/js/node/util/styletext.test.ts
@@ -34,10 +34,7 @@ test("styleText skips the 'none' format instead of throwing", () => {
 });
 
 test("styleText reapplies the style after a nested reset", () => {
-  assert.strictEqual(
-    styleText("red", "a\u001b[39mb", { validateStream: false }),
-    "\u001b[31ma\u001b[31mb\u001b[39m",
-  );
+  assert.strictEqual(styleText("red", "a\u001b[39mb", { validateStream: false }), "\u001b[31ma\u001b[31mb\u001b[39m");
 });
 
 test("styleText validates options.validateStream", () => {

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -342,9 +342,11 @@ describe("util", () => {
   });
 
   it("multiplecolors", () => {
-    expect(util.styleText(["bold", "red"], "test")).toBe("\u001b[1m\u001b[31mtest\u001b[39m\u001b[22m");
-    expect(util.styleText("bold", "test")).toBe("\u001b[1mtest\u001b[22m");
-    expect(util.styleText("red", "test")).toBe("\u001b[31mtest\u001b[39m");
+    expect(util.styleText(["bold", "red"], "test", { validateStream: false })).toBe(
+      "\u001b[1m\u001b[31mtest\u001b[39m\u001b[22m",
+    );
+    expect(util.styleText("bold", "test", { validateStream: false })).toBe("\u001b[1mtest\u001b[22m");
+    expect(util.styleText("red", "test", { validateStream: false })).toBe("\u001b[31mtest\u001b[39m");
   });
 
   it("styleText", () => {
@@ -376,7 +378,7 @@ describe("util", () => {
       },
     );
 
-    assert.strictEqual(util.styleText("red", "test"), "\u001b[31mtest\u001b[39m");
+    assert.strictEqual(util.styleText("red", "test", { validateStream: false }), "\u001b[31mtest\u001b[39m");
   });
 
   describe("getSystemErrorName", () => {


### PR DESCRIPTION
Fixes #25736
Fixes #20129

Node v22 made `util.styleText` color-aware and option-validating. Bun's port took only `(format, text)` and diverged from Node:

- always emitted ANSI even when the target stream isn't a TTY → corrupted piped/redirected/CI logs and ignored `NO_COLOR`
- silently ignored the `stream` and `validateStream` options (no `ERR_INVALID_ARG_TYPE`)
- threw `ERR_INVALID_ARG_VALUE` on the valid `'none'` format
- no nested-style reset reapplication

Port the full Node v22.20 `styleText`: `{ validateStream, stream }` options, stream-type validation, `shouldColorize` (already present in `internal/util/colors`, exact Node match), `'none'` skip, and the nested-reset handling.

Refreshed the stale vendored `test-util-styletext.js` from upstream Node. The new `styletext.test.ts` is `node:test`/`node:assert` so it runs under both `bun test` and `node --experimental-strip-types --test`: green under Node, fails under released Bun, green with this fix.

---

_Rebased onto main and extended by @robobun at @alii's request, superseding #33327._

**styleText option reading.** Switched from destructuring defaults to the way node's current `lib/util.js` reads them:

```js
const validateStream = options?.validateStream ?? true;
const stream = options?.stream ?? process.stdout;
```

so `{ stream: null }` falls back to `process.stdout` instead of throwing (`node -e 'require("util").styleText("red","x",{stream:null})'` returns `"x"`), and `validateObject(options)` turns a non-object `options` into `ERR_INVALID_ARG_TYPE` rather than a bare destructuring `TypeError`. The two internal requires are memoized per `src/js/CLAUDE.md`.

**debuglog.** Folded in from #33327, which closing would otherwise drop. `util.debuglog("x").enabled` was `undefined` and the documented callback argument was ignored. The per-section implementation is still created eagerly so `NODE_DEBUG=http` keeps emitting its sensitive-data warning when `node:http` loads, which `test-http-debug.js` depends on. Happy to split this back out if you would rather keep the PR to `styleText`.

**Tests.** `styletext.test.ts` (runs under node too) is untouched. `style-text.test.ts` adds the Bun-side coverage: the bare-`isTTY` repro from #25736, the `NO_COLOR` / `NODE_DISABLE_COLORS` / `FORCE_COLOR` matrix from #20129 as subprocesses against a TTY-claiming stream, `options` validation, the color aliases, and the default-stream behavior with piped stdout. `debuglog.test.ts` covers `enabled`, `NODE_DEBUG` matching (lists, wildcards, case), the stderr output shape, the callback, and the http warning. Both files pass with `NODE_DEBUG='*'` or `FORCE_COLOR=1` exported.

```
bun bd test test/js/node/util/                          575 pass (2 pre-existing debug-build timeouts in parseArgs)
bun bd test/js/node/test/parallel/test-util-styletext.js  pass
bun bd test/js/node/test/parallel/test-http-debug.js       pass
```
