### PR TITLE
dns: match Node's getaddrinfo error shape (errno/hostname/message/name)

### DIFF
--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -530,8 +530,8 @@ function ClientRequest(input, options, cb) {
       // Don't need to bother with lookup if it's already an IP address or no lookup function is provided.
       if (RegExpPrototypeExec.$call(INVALID_HOST_CHAR_REGEX, host) !== null) {
         const error = new Error(`getaddrinfo ENOTFOUND ${host}`);
-        error.name = "DNSException";
         error.code = "ENOTFOUND";
+        error.errno = -3008; // libuv UV_EAI_NONAME
         error.syscall = "getaddrinfo";
         error.hostname = host;
         process.nextTick((self, err) => self.emit("error", err), this, error);
@@ -552,17 +552,20 @@ function ClientRequest(input, options, cb) {
 
         let candidates = results.sort((a, b) => b.family - a.family); // prefer IPv6
 
-        const fail = (message, name, code, syscall) => {
+        // `error.name` inherits "Error" from Error.prototype (like Node's dns
+        // errors), so don't set it as an own property.
+        const fail = (message, code, syscall, errno?, hostname?) => {
           const error = new Error(message);
-          error.name = name;
           error.code = code;
           error.syscall = syscall;
+          if (errno !== undefined) error.errno = errno;
+          if (hostname !== undefined) error.hostname = hostname;
           if (!!$debug) globalReportError(error);
           process.nextTick((self, err) => self.emit("error", err), this, error);
         };
 
         if (candidates.length === 0) {
-          fail("No records found", "DNSException", "ENOTFOUND", "getaddrinfo");
+          fail(`getaddrinfo ENOTFOUND ${host}`, "ENOTFOUND", "getaddrinfo", -3008, host);
           return;
         }
 
@@ -584,7 +587,7 @@ function ClientRequest(input, options, cb) {
         const iterate = () => {
           if (candidates.length === 0) {
             // If we get to this point, it means that none of the addresses could be connected to.
-            fail(`connect ECONNREFUSED ${host}:${port}`, "Error", "ECONNREFUSED", "connect");
+            fail(`connect ECONNREFUSED ${host}:${port}`, "ECONNREFUSED", "connect");
             return;
           }
 

--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -305,7 +305,7 @@ function lookup(hostname, options, callback) {
   dns
     .lookup(hostname, options)
     .then(res => {
-      throwIfEmpty(res);
+      throwIfEmpty(res, hostname);
 
       if (options.order == "ipv4first") {
         res.sort((a, b) => a.family - b.family);
@@ -669,21 +669,21 @@ const mapLookupAll = res => {
   return { address, family };
 };
 
-function throwIfEmpty(res) {
+function throwIfEmpty(res, hostname) {
   if (res.length === 0) {
-    const err = new Error("No records found");
-    err.name = "DNSException";
-    err.code = "ENODATA";
-    // Hardcoded errno
-    err.errno = 1;
+    const err = new Error(`getaddrinfo ENOTFOUND ${hostname}`);
+    // libuv UV_EAI_NONAME
+    err.errno = -3008;
+    err.code = "ENOTFOUND";
     err.syscall = "getaddrinfo";
+    err.hostname = hostname;
     throw err;
   }
 }
 Object.defineProperty(throwIfEmpty, "name", { value: "::bunternal::" });
 
-const promisifyLookup = order => res => {
-  throwIfEmpty(res);
+const promisifyLookup = (order, hostname) => res => {
+  throwIfEmpty(res, hostname);
   if (order == "ipv4first") {
     res.sort((a, b) => a.family - b.family);
   } else if (order == "ipv6first") {
@@ -693,8 +693,8 @@ const promisifyLookup = order => res => {
   return { address, family };
 };
 
-const promisifyLookupAll = order => res => {
-  throwIfEmpty(res);
+const promisifyLookupAll = (order, hostname) => res => {
+  throwIfEmpty(res, hostname);
   if (order == "ipv4first") {
     res.sort((a, b) => a.family - b.family);
   } else if (order == "ipv6first") {
@@ -753,9 +753,9 @@ const promises = {
     }
 
     if (options.all) {
-      return translateErrorCode(dns.lookup(hostname, options).then(promisifyLookupAll(options.order)));
+      return translateErrorCode(dns.lookup(hostname, options).then(promisifyLookupAll(options.order, hostname)));
     }
-    return translateErrorCode(dns.lookup(hostname, options).then(promisifyLookup(options.order)));
+    return translateErrorCode(dns.lookup(hostname, options).then(promisifyLookup(options.order, hostname)));
   },
 
   lookupService(address, port) {

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -659,6 +659,46 @@ pub(crate) struct ErrorDeferred {
     pub promise: bun_jsc::JSPromiseStrong,
 }
 
+/// Node's `getaddrinfo` errors carry libuv's negative `EAI_*` errno
+/// (`err.errno`), not the positive c-ares enum value. `c_ares::Error::init_eai`
+/// collapses `EAI_NONAME`/`EAI_NODATA` into `ENOTFOUND`, so NXDOMAIN reports
+/// `UV_EAI_NONAME` (-3008) — matching Node for the common case.
+fn getaddrinfo_uv_errno(e: c_ares::Error) -> i32 {
+    // libuv `uv/errno.h` EAI_* codes. Platform-invariant ABI constants;
+    // `bun_libuv_sys` only re-exports them on Windows (its `libuv` module is
+    // `#![cfg(windows)]`), so inline the small subset we need — mirroring how
+    // `bun_libuv_sys/lib.rs` inlines its own non-Windows errno subset.
+    const UV_EAI_AGAIN: i32 = -3001;
+    const UV_EAI_BADFLAGS: i32 = -3002;
+    const UV_EAI_CANCELED: i32 = -3003;
+    const UV_EAI_FAIL: i32 = -3004;
+    const UV_EAI_FAMILY: i32 = -3005;
+    const UV_EAI_MEMORY: i32 = -3006;
+    const UV_EAI_NODATA: i32 = -3007;
+    const UV_EAI_NONAME: i32 = -3008;
+    const UV_EAI_SERVICE: i32 = -3010;
+    const UV_EAI_SOCKTYPE: i32 = -3011;
+    const UV_EAI_BADHINTS: i32 = -3013;
+    match e {
+        c_ares::Error::ENODATA => UV_EAI_NODATA,
+        // `c_ares::Error::code()` aliases ENOTFOUND/ENONAME/EBADNAME to
+        // "DNS_ENOTFOUND"; keep errno in lockstep with code/message.
+        c_ares::Error::ENOTFOUND | c_ares::Error::ENONAME | c_ares::Error::EBADNAME => {
+            UV_EAI_NONAME
+        }
+        c_ares::Error::EBADFAMILY => UV_EAI_FAMILY,
+        c_ares::Error::EBADFLAGS => UV_EAI_BADFLAGS,
+        c_ares::Error::EBADHINTS => UV_EAI_BADHINTS,
+        c_ares::Error::ENOMEM => UV_EAI_MEMORY,
+        c_ares::Error::ESERVICE => UV_EAI_SERVICE,
+        c_ares::Error::ECONNREFUSED => UV_EAI_SOCKTYPE,
+        c_ares::Error::ETIMEOUT => UV_EAI_AGAIN,
+        c_ares::Error::ECANCELLED => UV_EAI_CANCELED,
+        c_ares::Error::EBADSTR => UV_EAI_BADHINTS,
+        _ => UV_EAI_FAIL,
+    }
+}
+
 impl ErrorDeferred {
     pub(crate) fn init(
         errno: c_ares::Error,
@@ -691,8 +731,16 @@ impl ErrorDeferred {
                 BStr::new(&code[4..])
             ))
         };
+        // Node reports libuv's negative EAI errno for getaddrinfo/getnameinfo
+        // (both go through uv); the c-ares query paths (resolve*/reverse) keep
+        // the raw c-ares value.
+        let errno = if self.syscall == b"getaddrinfo" || self.syscall == b"getnameinfo" {
+            getaddrinfo_uv_errno(self.errno)
+        } else {
+            self.errno as i32
+        };
         let system_error = SystemError {
-            errno: self.errno as i32,
+            errno,
             code: bstr::String::static_(code),
             message,
             syscall: bstr::String::clone_utf8(self.syscall),
@@ -700,13 +748,11 @@ impl ErrorDeferred {
             ..Default::default()
         };
 
+        // Node's DNS errors are plain `Error` instances — `err.name` is
+        // inherited from `Error.prototype.name`, not an own property.
+        // `to_error_instance*` already uses `ErrorType::Error`, so no `.put` needed.
         let instance =
             system_error.to_error_instance_with_async_stack(global_this, self.promise.get());
-        instance.put(
-            global_this,
-            b"name",
-            bstr::String::static_(b"DNSException").to_js(global_this)?,
-        );
 
         // `self` (and thus self.promise / self.hostname) drops at scope exit — matches
         // Zig's `defer this.deinit()`; hostname was `take()`n above to avoid double-deref.
@@ -769,7 +815,7 @@ pub(crate) fn error_to_js_with_syscall(
     syscall: &'static [u8],
 ) -> JsResult<JSValue> {
     let code = this.code();
-    let instance = SystemError {
+    Ok(SystemError {
         errno: this as i32,
         code: bstr::String::static_(&code[4..]),
         syscall: bstr::String::static_(syscall),
@@ -780,13 +826,7 @@ pub(crate) fn error_to_js_with_syscall(
         )),
         ..Default::default()
     }
-    .to_error_instance(global_this);
-    instance.put(
-        global_this,
-        b"name",
-        bstr::String::static_(b"DNSException").to_js(global_this)?,
-    );
-    Ok(instance)
+    .to_error_instance(global_this))
 }
 
 pub(crate) fn error_to_js_with_syscall_and_hostname(
@@ -796,7 +836,7 @@ pub(crate) fn error_to_js_with_syscall_and_hostname(
     hostname: &[u8],
 ) -> JsResult<JSValue> {
     let code = this.code();
-    let instance = SystemError {
+    Ok(SystemError {
         errno: this as i32,
         code: bstr::String::static_(&code[4..]),
         message: bstr::String::create_format(format_args!(
@@ -809,13 +849,7 @@ pub(crate) fn error_to_js_with_syscall_and_hostname(
         hostname: bstr::String::clone_utf8(hostname),
         ..Default::default()
     }
-    .to_error_instance(global_this);
-    instance.put(
-        global_this,
-        b"name",
-        bstr::String::static_(b"DNSException").to_js(global_this)?,
-    );
-    Ok(instance)
+    .to_error_instance(global_this))
 }
 
 // ── canonicalizeIP host fn ─────────────────────────────────────────────────

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -200,7 +200,11 @@ pub(super) mod lib_info {
             this.get_or_put_into_pending_cache(&key, PendingCacheField::PendingHostCacheNative);
 
         if let CacheHit::Inflight(inflight) = cache {
-            let dns_lookup = DNSLookup::init(this.as_ctx_ptr(), global_this);
+            let dns_lookup = DNSLookup::init(
+                this.as_ctx_ptr(),
+                global_this,
+                Box::<[u8]>::from(&*query.name),
+            );
             // SAFETY: inflight points into resolver's HiveArray buffer
             unsafe { (*inflight).append(dns_lookup) };
             // SAFETY: `dns_lookup` was just heap-allocated by `DNSLookup::init`.
@@ -329,7 +333,11 @@ pub(super) mod lib_c {
         let cache =
             this.get_or_put_into_pending_cache(&key, PendingCacheField::PendingHostCacheNative);
         if let CacheHit::Inflight(inflight) = cache {
-            let dns_lookup = DNSLookup::init(this.as_ctx_ptr(), global_this);
+            let dns_lookup = DNSLookup::init(
+                this.as_ctx_ptr(),
+                global_this,
+                Box::<[u8]>::from(&*query_init.name),
+            );
             // SAFETY: inflight points into resolver's pending-cache HiveArray slot.
             unsafe { (*inflight).append(dns_lookup) };
             // SAFETY: dns_lookup just heap-allocated; owned by the inflight list.
@@ -426,7 +434,11 @@ pub(super) mod lib_uv_backend {
         let cache =
             this.get_or_put_into_pending_cache(&key, PendingCacheField::PendingHostCacheNative);
         if let CacheHit::Inflight(inflight) = cache {
-            let dns_lookup = DNSLookup::init(this.as_ctx_ptr(), global_this);
+            let dns_lookup = DNSLookup::init(
+                this.as_ctx_ptr(),
+                global_this,
+                Box::<[u8]>::from(&*query.name),
+            );
             unsafe { (*inflight).append(dns_lookup) };
             return Ok(unsafe { (*dns_lookup).promise.value() });
         }
@@ -477,7 +489,7 @@ pub(super) mod lib_uv_backend {
                 // (e.g. UV_EINVAL from the 256-byte IDNA buffer for long hostnames,
                 // or UV_ENOMEM). Route the error through the same path the async
                 // completion would have taken so the pending-cache slot is released
-                // and the promise is rejected with a DNSException.
+                // and the promise is rejected with a Node-shaped error.
                 if let Some(resolver) = (*request).resolver_for_caching {
                     if (*request).cache.pending_cache() {
                         (*resolver).drain_pending_host_native(
@@ -1401,6 +1413,7 @@ impl GetAddrInfoRequest {
                 poll_ref,
                 allocated: false,
                 next: None,
+                name: Box::<[u8]>::from(&*query.name),
             },
             tail: ptr::null_mut(),
             // Zig: `task: bun.ThreadPool.Task = undefined`. The callback is
@@ -1963,6 +1976,9 @@ pub struct DNSLookup {
     pub allocated: bool,
     pub next: Option<NonNull<DNSLookup>>, // INTRUSIVE
     pub poll_ref: KeepAlive,
+    /// Queried hostname, kept so getaddrinfo failures can build a Node-shaped
+    /// error (`err.hostname` / `"getaddrinfo ENOTFOUND <name>"`).
+    pub name: Box<[u8]>,
 }
 
 impl DNSLookup {
@@ -1979,7 +1995,11 @@ impl DNSLookup {
         self.global_this.get()
     }
 
-    pub(crate) fn init(resolver: *mut Resolver, global_this: &JSGlobalObject) -> *mut Self {
+    pub(crate) fn init(
+        resolver: *mut Resolver,
+        global_this: &JSGlobalObject,
+        name: Box<[u8]>,
+    ) -> *mut Self {
         bun_output::scoped_log!(DNSLookup, "init");
 
         let mut poll_ref = KeepAlive::init();
@@ -1993,6 +2013,7 @@ impl DNSLookup {
             promise: JSPromiseStrong::init(global_this),
             allocated: true,
             next: None,
+            name,
         }))
     }
 
@@ -2021,8 +2042,13 @@ impl DNSLookup {
         // SAFETY: caller contract — `this` is live; JSGlobalObject outlives the request.
         unsafe {
             if let Some(err) = c_ares::Error::init_eai(status) {
-                error_to_deferred(err, b"getaddrinfo", None, &mut (*this).promise)
-                    .reject_later((*this).global_this());
+                error_to_deferred(
+                    err,
+                    b"getaddrinfo",
+                    Some(&(*this).name),
+                    &mut (*this).promise,
+                )
+                .reject_later((*this).global_this());
                 Self::destroy(this);
                 return;
             }
@@ -2052,8 +2078,13 @@ impl DNSLookup {
         unsafe {
             let global_this = (*this).global_this();
             if let Some(err) = err_ {
-                error_to_deferred(err, b"getaddrinfo", None, &mut (*this).promise)
-                    .reject_later(global_this);
+                error_to_deferred(
+                    err,
+                    b"getaddrinfo",
+                    Some(&(*this).name),
+                    &mut (*this).promise,
+                )
+                .reject_later(global_this);
                 Self::destroy(this);
                 return;
             }
@@ -2063,7 +2094,7 @@ impl DNSLookup {
                 error_to_deferred(
                     c_ares::Error::ENOTFOUND,
                     b"getaddrinfo",
-                    None,
+                    Some(&(*this).name),
                     &mut (*this).promise,
                 )
                 .reject_later(global_this);
@@ -5510,7 +5541,11 @@ impl Resolver {
         let cache =
             self.get_or_put_into_pending_cache(&key, PendingCacheField::PendingHostCacheCares);
         if let CacheHit::Inflight(inflight) = cache {
-            let dns_lookup = DNSLookup::init(self.as_ctx_ptr(), global_this);
+            let dns_lookup = DNSLookup::init(
+                self.as_ctx_ptr(),
+                global_this,
+                Box::<[u8]>::from(&*query.name),
+            );
             // SAFETY: `inflight` points into the resolver's pending-cache HiveArray slot.
             unsafe { (*inflight).append(dns_lookup) };
             // SAFETY: `dns_lookup` was just heap-allocated; owned by the inflight list.

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -100,7 +100,7 @@ describe("dns", () => {
       // @ts-expect-error
       expect(dns.lookup(hostname, { backend })).rejects.toMatchObject({
         code: "DNS_ENOTFOUND",
-        name: "DNSException",
+        name: "Error",
       });
     });
 
@@ -108,7 +108,7 @@ describe("dns", () => {
       // @ts-expect-error
       expect(dns.lookup(hostname, { backend })).rejects.toMatchObject({
         code: expect.stringMatching(/^DNS_ENOTFOUND|DNS_ESERVFAIL|DNS_ENOTIMP$/),
-        name: "DNSException",
+        name: "Error",
       });
     });
   });
@@ -122,7 +122,7 @@ describe("dns", () => {
     const long = Buffer.alloc(100_000, "a").toString();
     // @ts-expect-error
     await expect(dns.lookup(long, { backend })).rejects.toMatchObject({
-      name: "DNSException",
+      name: "Error",
       code: "DNS_ENOTFOUND",
       syscall: "getaddrinfo",
     });

--- a/test/js/node/dns/lookup-error.test.ts
+++ b/test/js/node/dns/lookup-error.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Runs under `bun test` and (via node:test/node:assert) under
+ * `node --experimental-strip-types --test`. Green under Node proves the
+ * assertions encode real Node behaviour, so a green run under Bun means Bun
+ * matches Node.
+ *
+ * Bun's `dns.lookup` (getaddrinfo) error object diverged from Node:
+ *   - `errno`    was the positive c-ares enum value (4) instead of libuv's
+ *                negative `UV_EAI_NONAME` (-3008)
+ *   - `hostname` was `undefined` instead of the queried name
+ *   - `message`  was `"getaddrinfo ENOTFOUND"` (no hostname suffix)
+ *   - `name`     was `"DNSException"` instead of `"Error"`
+ * `.invalid` is reserved (RFC 6761) and always fails to resolve.
+ */
+import assert from "node:assert";
+import dns from "node:dns";
+import dnsPromises from "node:dns/promises";
+import { test } from "node:test";
+
+const HOST = "this-name-does-not-exist.invalid";
+
+function lookupError(host: string, opts?: object): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const cb = (err: any, address: unknown) =>
+      err ? resolve(err) : reject(new Error(`expected lookup to fail, resolved to ${address}`));
+    if (opts) dns.lookup(host, opts, cb);
+    else dns.lookup(host, cb);
+  });
+}
+
+function assertNodeShape(err: any, host: string) {
+  assert.strictEqual(err.code, "ENOTFOUND");
+  assert.strictEqual(err.syscall, "getaddrinfo");
+  assert.strictEqual(err.hostname, host);
+  assert.strictEqual(err.name, "Error");
+  // libuv UV_EAI_NONAME (-3008); tolerate UV_EAI_NODATA (-3007) since
+  // c-ares collapses both into ENOTFOUND.
+  assert.ok([-3008, -3007].includes(err.errno), `expected libuv EAI errno, got ${err.errno}`);
+}
+
+test("dns.lookup failure has a Node-shaped error", async () => {
+  const err = await lookupError(HOST);
+  assertNodeShape(err, HOST);
+  assert.strictEqual(err.message, `getaddrinfo ENOTFOUND ${HOST}`);
+});
+
+test("dns.lookup({ all: true }) failure has a Node-shaped error", async () => {
+  const err = await lookupError(HOST, { all: true });
+  assertNodeShape(err, HOST);
+  assert.strictEqual(err.message, `getaddrinfo ENOTFOUND ${HOST}`);
+});
+
+test("dnsPromises.lookup failure has a Node-shaped error", async () => {
+  await assert.rejects(dnsPromises.lookup(HOST), (err: any) => {
+    assertNodeShape(err, HOST);
+    assert.strictEqual(err.message, `getaddrinfo ENOTFOUND ${HOST}`);
+    return true;
+  });
+});


### PR DESCRIPTION
`dns.lookup` (getaddrinfo) failures produced an error object that diverged from Node on four fields:

- `errno` was the positive c-ares enum value (`4`) instead of libuv's negative `UV_EAI_NONAME` (`-3008`)
- `hostname` was `undefined` instead of the queried name
- `message` was `"getaddrinfo ENOTFOUND"` (no hostname suffix)
- `name` was `"DNSException"` instead of `"Error"`

Thread the queried name onto the `DNSLookup` node so every getaddrinfo failure path can build the Node-shaped error (this also fixes `message`, same root cause). Map the c-ares error to libuv's negative `EAI_*` errno for the getaddrinfo syscall, and use `name: "Error"` like Node (also corrects resolve*/reverse, which Node likewise reports as `Error`).

Pre-existing (Zig 1.3.14 has the same bug), so the test lives in the dns module. It's `node:test`/`node:assert` and runs under both `bun test` and `node --experimental-strip-types --test`: green under Node, fails under released Bun, green with this fix. `dns.lookup` output is now byte-identical to Node; `node-dns.test.js` (66) and vendored `test-dns-lookup.js`/`test-dns.js` still pass.