### PR TITLE
blob: release the adopted WTF string ref in string-body consumers

### DIFF
--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -61,7 +61,7 @@ extern "C" int uv_tty_reset_mode(void)
 
 static void uv__tty_make_raw(struct termios* tio)
 {
-    assert(tio != NULL);
+    ASSERT(tio != NULL);
 
 #if defined __sun || defined __MVS__
     /*

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -6376,8 +6376,12 @@ impl Any {
                 Ok(str)
             }
             Any::WTFStringImpl(impl_) => {
-                let mut str =
-                    BunString::adopt_wtf_impl(core::mem::replace(impl_, core::ptr::null_mut()));
+                // Adopts a +1 WTF ref; `OwnedString` releases it on every exit
+                // path (Zig: `defer str.deref()`).
+                let mut str = OwnedString::new(BunString::adopt_wtf_impl(core::mem::replace(
+                    impl_,
+                    core::ptr::null_mut(),
+                )));
                 *self = Any::Blob(Blob::default());
                 if str.length() == 0 {
                     return Ok(JSValue::NULL);
@@ -6438,8 +6442,12 @@ impl Any {
                 Ok(owned)
             }
             Any::WTFStringImpl(impl_) => {
-                let str =
-                    BunString::adopt_wtf_impl(core::mem::replace(impl_, core::ptr::null_mut()));
+                // Adopts a +1 WTF ref; `OwnedString` releases it on scope exit
+                // (Zig: `defer str.deref()`).
+                let str = OwnedString::new(BunString::adopt_wtf_impl(core::mem::replace(
+                    impl_,
+                    core::ptr::null_mut(),
+                )));
                 *self = Any::Blob(Blob::default());
                 str.to_js(global)
             }
@@ -6480,8 +6488,13 @@ impl Any {
                 ))
             }
             Any::WTFStringImpl(impl_) => {
-                let str =
-                    BunString::adopt_wtf_impl(core::mem::replace(impl_, core::ptr::null_mut()));
+                // Adopts a +1 WTF ref; `OwnedString` releases it on scope exit,
+                // after `out_bytes` (which borrows it) is consumed below
+                // (Zig: `defer str.deref()`).
+                let str = OwnedString::new(BunString::adopt_wtf_impl(core::mem::replace(
+                    impl_,
+                    core::ptr::null_mut(),
+                )));
                 *self = Any::Blob(Blob::default());
 
                 let out_bytes = str.to_utf8_without_ref();

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -6418,7 +6418,10 @@ impl Any {
 
         if let Any::WTFStringImpl(_) = self {
             let blob = Blob::create(self.slice(), global, true);
-            *self = Any::Blob(Blob::default());
+            // `Blob::create(.., true)` copied the bytes; `Any` still owns the
+            // +1 WTF ref. `detach()` releases it and resets `*self` (the bare
+            // `*self = Any::Blob(default)` here previously leaked that ref).
+            self.detach();
             return blob;
         }
 

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1,5 +1,6 @@
 import { file, spawn, version } from "bun";
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 const bodyTypes = [
   {
@@ -668,3 +669,61 @@ function arrayBuffer(buffer: BufferSource) {
   }
   return buffer.buffer;
 }
+
+// Consuming a string body via .text()/.json()/.arrayBuffer()/.bytes() used to
+// permanently leak the whole body string (the adopted WTF::StringImpl +1 ref
+// was never released), so RSS grew *linearly and never plateaued* across
+// round-trips. The fix mirrors the Zig `defer str.deref()`. This asserts the
+// leak is bounded: after a warmup, a second equal block of round-trips must
+// not keep growing RSS (a linear leak adds ~block-size every block; a bounded
+// impl plateaus). Absolute RSS is intentionally not asserted — only growth.
+describe("string body consumption does not leak", () => {
+  // NOTE: `.text()` is intentionally excluded. It produces a large JS string
+  // as its result, and discarded large JS strings are currently not reclaimed
+  // by GC in this build independently of bodies — `Buffer.alloc(2e6).toString()`
+  // in a loop leaks identically with no Blob/Response involved. That is a
+  // separate bug from the missing body-string `deref`; mixing it in here would
+  // test the wrong thing. These four consume into a parsed value / byte buffer
+  // and measure the body-string lifetime cleanly.
+  const cases: Array<[string, "Response" | "Request", string]> = [
+    ["Response.json", "Response", "json"],
+    ["Response.arrayBuffer", "Response", "arrayBuffer"],
+    ["Response.bytes", "Response", "bytes"],
+    ["Request.json", "Request", "json"],
+  ];
+
+  for (const [name, ctor, method] of cases) {
+    test(name, async () => {
+      const makeBody = method === "json" ? `() => JSON.stringify({ k: "z".repeat(SZ) })` : `() => "z".repeat(SZ)`;
+      const make =
+        ctor === "Request"
+          ? `b => new Request("http://example.com/", { method: "POST", body: b })`
+          : `b => new Response(b)`;
+      const src = `
+        const SZ = 2_000_000, WARM = 50, BLOCK = 40;
+        const rss = () => (process.memoryUsage().rss / 1048576) | 0;
+        const body = ${makeBody};
+        const make = ${make};
+        const run = async n => { for (let i = 0; i < n; i++) await make(body())[${JSON.stringify(method)}](); };
+        await run(WARM); Bun.gc(true); const a = rss();
+        await run(BLOCK); Bun.gc(true); const b = rss();
+        await run(BLOCK); Bun.gc(true); const c = rss();
+        console.log("BLOCK1:" + (b - a) + " BLOCK2:" + (c - b));
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", src],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      const m = stdout.match(/BLOCK1:(-?\d+) BLOCK2:(-?\d+)/);
+      expect(m).not.toBeNull();
+      const block2 = Number(m![2]);
+      // Bounded: BLOCK2 ≈ 0 (plateaued). Leaking: BLOCK2 ≈ 40 × ~3 MB ≈ 100+ MB
+      // and keeps growing every block. 50 MB cleanly separates the two.
+      expect(block2).toBeLessThan(50);
+      expect(exitCode).toBe(0);
+    });
+  }
+});

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -677,7 +677,7 @@ function arrayBuffer(buffer: BufferSource) {
 // leak is bounded: after a warmup, a second equal block of round-trips must
 // not keep growing RSS (a linear leak adds ~block-size every block; a bounded
 // impl plateaus). Absolute RSS is intentionally not asserted — only growth.
-describe("string body consumption does not leak", () => {
+describe.concurrent("string body consumption does not leak", () => {
   // NOTE: `.text()` is intentionally excluded. It produces a large JS string
   // as its result, and discarded large JS strings are currently not reclaimed
   // by GC in this build independently of bodies — `Buffer.alloc(2e6).toString()`
@@ -694,7 +694,13 @@ describe("string body consumption does not leak", () => {
 
   for (const [name, ctor, method] of cases) {
     test(name, async () => {
-      const makeBody = method === "json" ? `() => JSON.stringify({ k: "z".repeat(SZ) })` : `() => "z".repeat(SZ)`;
+      // We need the *body string* to be large (that's the leaked ref) but the
+      // consumer to be cheap, so the JSON arm uses whitespace padding + a tiny
+      // value — valid JSON, ~SZ-byte body, near-free parse. `Buffer.alloc` is
+      // avoided for body construction per the note above (separate reclaim
+      // issue would pollute this measurement); `.repeat()` is also measurably
+      // faster than `Buffer.alloc(..).toString()` on this path in debug.
+      const makeBody = method === "json" ? `() => " ".repeat(SZ) + "0"` : `() => "z".repeat(SZ)`;
       const make =
         ctor === "Request"
           ? `b => new Request("http://example.com/", { method: "POST", body: b })`
@@ -716,7 +722,8 @@ describe("string body consumption does not leak", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
       const m = stdout.match(/BLOCK1:(-?\d+) BLOCK2:(-?\d+)/);
       expect(m).not.toBeNull();
       const block2 = Number(m![2]);

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1,6 +1,8 @@
 import { file, spawn, version } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, exampleSite } from "harness";
+
+const exampleServer = exampleSite("http");
 
 const bodyTypes = [
   {
@@ -208,7 +210,7 @@ for (const { body, fn } of bodyTypes) {
           {
             label: "fetch() stream",
             stream: async () => {
-              const { body } = await fetch("http://example.com/");
+              const { body } = await fetch(exampleServer.url);
               expect(body).not.toBeNull();
               return body as ReadableStream;
             },


### PR DESCRIPTION
Consuming a string body via `Response`/`Request` `.json()` / `.arrayBuffer()` / `.bytes()` permanently leaked the body string. The Zig `defer str.deref()` that releases the AnyBlob's adopted +1 WTF::StringImpl ref was dropped from the three `Any` string-body arms in the Rust port (`bun_core::String` is `Copy` with no `Drop`, so an adopted ref returned without an explicit deref leaks unconditionally).

Wrap the adopted value in the existing `OwnedString` RAII helper at all three arms (`to_json`, `to_string`, `to_array_buffer_view`) — the Rust spelling of Zig's `defer str.deref()`, covering every return path. This is the same pattern already used elsewhere in `Blob.rs`.

Verified: the finding's `new Response(JSON.stringify(...)).json()` repro went from unbounded (~400 MB, linear, never plateaus) to bounded (plateaus, matching released Bun); `.arrayBuffer()`/`.bytes()` likewise. The regression test asserts boundedness via a two-block RSS growth check (absolute RSS deliberately not asserted).

Note: `.text()` is **not** claimed fixed here and is excluded from the test. While verifying I found a *separate, unrelated* regression — discarded large JS strings are not GC-reclaimed in this build independently of bodies (`Buffer.alloc(2e6).toString()` discarded in a loop leaks identically with no Blob/Response, while released Bun reclaims it). `.text()` returns a large string so its measurement is dominated by that separate bug; conflating them would test the wrong thing. Filing that separately.