### PR TITLE
wtf-bindings: use WTF ASSERT() so debug builds compile

### DIFF
--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -61,7 +61,7 @@ extern "C" int uv_tty_reset_mode(void)
 
 static void uv__tty_make_raw(struct termios* tio)
 {
-    assert(tio != NULL);
+    ASSERT(tio != NULL);
 
 #if defined __sun || defined __MVS__
     /*

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -287,9 +287,9 @@ describe("Bun.Terminal", () => {
     // proves the file compiled.
     test.skipIf(isWindows)("setRawMode toggles on a real PTY fd", async () => {
       await using terminal = new Bun.Terminal({});
-      // ICANON is 0x2 on Linux/BSD but 0x100 on Darwin (bit 0x2 is ECHOE there,
+      // ICANON is 0x2 on Linux but 0x100 on Darwin — bit 0x2 is ECHOE there,
       // which Bun__ttySetMode mode=1 does not clear, so a flat 0x2 would fail
-      // on macOS CI). ECHO is 0x8 on every POSIX we build for.
+      // on macOS CI. ECHO is 0x8 on every POSIX we build for.
       const ICANON = process.platform === "darwin" ? 0x100 : 0x2;
       const ECHO = 0x8;
 

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -287,7 +287,10 @@ describe("Bun.Terminal", () => {
     // proves the file compiled.
     test.skipIf(isWindows)("setRawMode toggles on a real PTY fd", async () => {
       await using terminal = new Bun.Terminal({});
-      const ICANON = 0x2;
+      // ICANON is 0x2 on Linux/BSD but 0x100 on Darwin (bit 0x2 is ECHOE there,
+      // which Bun__ttySetMode mode=1 does not clear, so a flat 0x2 would fail
+      // on macOS CI). ECHO is 0x8 on every POSIX we build for.
+      const ICANON = process.platform === "darwin" ? 0x100 : 0x2;
       const ECHO = 0x8;
 
       const beforeLflag = terminal.localFlags;

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -278,6 +278,32 @@ describe("Bun.Terminal", () => {
 
       expect(() => terminal.setRawMode(true)).toThrow("Terminal is closed");
     });
+
+    // Regression for #30988: wtf-bindings.cpp used libc `assert` without
+    // including <cassert>. After the WebKit upgrade in #30705 the header
+    // stopped reaching this translation unit transitively, so debug builds
+    // failed to compile. Building and running this test file exercises
+    // Bun__ttySetMode (the same translation unit) on a real PTY fd and
+    // proves the file compiled.
+    test.skipIf(isWindows)("setRawMode toggles on a real PTY fd", async () => {
+      await using terminal = new Bun.Terminal({});
+      const ICANON = 0x2;
+      const ECHO = 0x8;
+
+      const beforeLflag = terminal.localFlags;
+      expect(beforeLflag & ICANON).not.toBe(0);
+      expect(beforeLflag & ECHO).not.toBe(0);
+
+      terminal.setRawMode(true);
+      const rawLflag = terminal.localFlags;
+      expect(rawLflag & ICANON).toBe(0);
+      expect(rawLflag & ECHO).toBe(0);
+
+      terminal.setRawMode(false);
+      const restoredLflag = terminal.localFlags;
+      expect(restoredLflag & ICANON).not.toBe(0);
+      expect(restoredLflag & ECHO).not.toBe(0);
+    });
   });
 
   describe("termios flags", () => {


### PR DESCRIPTION
Fixes #30988.

## Repro

```sh
bun install
bun bd
```

```
unified/../../../src/jsc/bindings/wtf-bindings.cpp:64:5: error: use of undeclared identifier 'assert'
   64 |     assert(tio != NULL);
      |     ^~~~~~
```

## Cause

`uv__tty_make_raw()` in `src/jsc/bindings/wtf-bindings.cpp` calls the libc `assert()` macro, but the file never includes `<cassert>` or `<assert.h>`. It was reaching `assert` transitively through a WebKit header; the WebKit upgrade in #30705 dropped that include, so on current main the unified-source unit containing `wtf-bindings.cpp` fails to compile in debug.

Release builds are unaffected because `NDEBUG` makes `assert` a no-op before name lookup, and because the unified grouping differs from debug — whichever sibling was pulling `<cassert>` in happens to still land in that bundle.

## Fix

Swap `assert(tio != NULL)` → `ASSERT(tio != NULL)`. `ASSERT` is the WTF-style assertion already used elsewhere in the same file (line 256) and defined by `<wtf/Assertions.h>`, which is already in scope via the other WTF includes. No new includes needed.

## Verification

```
# Before (at HEAD = 4c8a21b149):
$ bun bd
...
error: use of undeclared identifier 'assert'

# After:
$ bun bd
[build] done

$ bun bd test test/js/bun/terminal/terminal.test.ts -t setRawMode
 5 pass
 0 fail
```

The added test (`Bun.Terminal > setRawMode > setRawMode toggles on a real PTY fd`) exercises `Bun__ttySetMode` — the same translation unit as `uv__tty_make_raw` — against a real PTY fd and asserts `ICANON`/`ECHO` flip off and back on through a `setRawMode(true)` → `setRawMode(false)` round-trip. Proves both the file compiled and the runtime path behaves correctly.

Several open PRs (#30243, #30975, #30980, #30981) carry this one-line fix as a drive-by; none are focused on #30988. This PR is dedicated to the build break so it can land first and unblock debug builds on `main`.