### PR TITLE
Progress: format Unit::Bytes with binary IEC units (KiB/MiB/GiB)

### DIFF
--- a/src/bun_core/Progress.rs
+++ b/src/bun_core/Progress.rs
@@ -627,10 +627,14 @@ impl Progress {
                                 &mut end,
                                 format_args!("[{}/{} files] ", current_item, eti),
                             ),
-                            // Raw byte counts are printed until an IEC-units
-                            // (KiB/MiB) formatting helper lands.
-                            Unit::Bytes => self
-                                .buf_write(&mut end, format_args!("[{}/{}] ", current_item, eti)),
+                            Unit::Bytes => self.buf_write(
+                                &mut end,
+                                format_args!(
+                                    "[{}/{}] ",
+                                    crate::fmt::size_bi(current_item as u64),
+                                    crate::fmt::size_bi(eti as u64),
+                                ),
+                            ),
                         }
                         need_ellipse = false;
                     } else if completed_items != 0 {
@@ -644,10 +648,10 @@ impl Progress {
                             Unit::Files => {
                                 self.buf_write(&mut end, format_args!("[{} files] ", current_item))
                             }
-                            // Raw byte counts; see the note above.
-                            Unit::Bytes => {
-                                self.buf_write(&mut end, format_args!("[{}] ", current_item))
-                            }
+                            Unit::Bytes => self.buf_write(
+                                &mut end,
+                                format_args!("[{}] ", crate::fmt::size_bi(current_item as u64)),
+                            ),
                         }
                         need_ellipse = false;
                     }

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -2650,6 +2650,50 @@ impl Display for SizeFormatter {
     }
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// BinarySizeFormatter
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Port of Zig's `{Bi:.P}` binary-bytes formatter (base 1024, IEC suffixes
+/// `KiB`/`MiB`/`GiB`/…). `value == 0` short-circuits to `"0B"`; otherwise
+/// we divide by the largest power of 1024 that fits and print the result
+/// with `P` decimals plus the IEC suffix. `P` defaults to 2 to match Bun's
+/// `Progress` call-sites (`"[{Bi:.2}/{Bi:.2}]"`).
+pub struct BinarySizeFormatter<const PRECISION: usize = 2> {
+    pub value: u64,
+}
+
+impl<const PRECISION: usize> Display for BinarySizeFormatter<PRECISION> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let value = self.value;
+        if value == 0 {
+            return f.write_str("0B");
+        }
+
+        // `" KMGTPEZY"` mirrors Zig stdlib: index 0 (space) is the no-prefix
+        // slot for values below the first magnitude (< 1024), so those print
+        // as `N.00B` — matching Zig's `{Bi:.2}` of e.g. 512 → "512.00B".
+        const MAGS_IEC: &[u8] = b" KMGTPEZY";
+        let log2 = (u64::BITS - 1 - value.leading_zeros()) as usize;
+        // log2(1024) == 10
+        let magnitude = (log2 / 10).min(MAGS_IEC.len() - 1);
+        let new_value = value as f64 / 1024f64.powi(magnitude as i32);
+        let suffix = MAGS_IEC[magnitude];
+        if suffix == b' ' {
+            write!(f, "{:.*}B", PRECISION, new_value)
+        } else {
+            write!(f, "{:.*}{}iB", PRECISION, new_value, suffix as char)
+        }
+    }
+}
+
+/// Binary-bytes formatter at the default precision of 2 decimals
+/// (Zig `{Bi:.2}`). Example: `size_bi(1_572_864)` → `"1.50MiB"`.
+#[inline]
+pub fn size_bi(bytes: u64) -> BinarySizeFormatter<2> {
+    BinarySizeFormatter { value: bytes }
+}
+
 pub fn size(bytes: usize, opts: SizeFormatterOptions) -> SizeFormatter {
     SizeFormatter { value: bytes, opts }
 }

--- a/test/regression/issue/30990.test.ts
+++ b/test/regression/issue/30990.test.ts
@@ -127,9 +127,9 @@ async function runUpgradeAgainstMock(opts: { zipSize: number; advertiseSize: boo
   return stderr;
 }
 
-test.skipIf(isWindows).concurrent(
-  "bun upgrade [current/total] progress uses binary-bytes (MiB), not raw bytes (#30990)",
-  async () => {
+test
+  .skipIf(isWindows)
+  .concurrent("bun upgrade [current/total] progress uses binary-bytes (MiB), not raw bytes (#30990)", async () => {
     // With `size` advertised, Progress renders `[current/total]` — both
     // sides go through the binary-bytes formatter.
     const stderr = await runUpgradeAgainstMock({ zipSize: 5 * 1024 * 1024, advertiseSize: true });
@@ -146,23 +146,24 @@ test.skipIf(isWindows).concurrent(
     // Broken shape: raw integer bytes `[<N>/5242880]` (5 × 1024²).
     const anyRawBytes = downloadingLines.some(l => /\[\d+\/5242880\]/.test(l));
     expect(anyRawBytes).toBe(false);
-  },
-);
+  });
 
-test.skipIf(isWindows).concurrent("bun upgrade [current] progress (unknown size) uses binary-bytes (#30990)", async () => {
-  // With `size` omitted, bun's `version.size == 0` and Progress takes the
-  // `eti == 0 && completed_items != 0` branch — the one-sided `[current]`
-  // arm. Same arm exercised by the canary upgrade path.
-  const stderr = await runUpgradeAgainstMock({ zipSize: 5 * 1024 * 1024, advertiseSize: false });
+test
+  .skipIf(isWindows)
+  .concurrent("bun upgrade [current] progress (unknown size) uses binary-bytes (#30990)", async () => {
+    // With `size` omitted, bun's `version.size == 0` and Progress takes the
+    // `eti == 0 && completed_items != 0` branch — the one-sided `[current]`
+    // arm. Same arm exercised by the canary upgrade path.
+    const stderr = await runUpgradeAgainstMock({ zipSize: 5 * 1024 * 1024, advertiseSize: false });
 
-  const downloadingLines = stderr.split("\n").filter(l => l.includes("Downloading ["));
-  expect(downloadingLines.length).toBeGreaterThan(0);
+    const downloadingLines = stderr.split("\n").filter(l => l.includes("Downloading ["));
+    expect(downloadingLines.length).toBeGreaterThan(0);
 
-  const anyBinaryUnit = downloadingLines.some(l => /\[[\d.]+(MiB|KiB|GiB|B)\]/.test(l));
-  expect({ anyBinaryUnit, downloadingLines }).toEqual({ anyBinaryUnit: true, downloadingLines });
+    const anyBinaryUnit = downloadingLines.some(l => /\[[\d.]+(MiB|KiB|GiB|B)\]/.test(l));
+    expect({ anyBinaryUnit, downloadingLines }).toEqual({ anyBinaryUnit: true, downloadingLines });
 
-  // Broken shape: `[<many-digit-int>]` with no IEC suffix (e.g. `[3407873]`).
-  // `[0B]` is fine — it's the new code printing zero.
-  const anyRawBytes = downloadingLines.some(l => /\[\d{5,}\]/.test(l));
-  expect(anyRawBytes).toBe(false);
-});
+    // Broken shape: `[<many-digit-int>]` with no IEC suffix (e.g. `[3407873]`).
+    // `[0B]` is fine — it's the new code printing zero.
+    const anyRawBytes = downloadingLines.some(l => /\[\d{5,}\]/.test(l));
+    expect(anyRawBytes).toBe(false);
+  });

--- a/test/regression/issue/30990.test.ts
+++ b/test/regression/issue/30990.test.ts
@@ -33,7 +33,9 @@ function assetBaseName(): string {
         ? "darwin"
         : process.platform === "win32"
           ? "windows"
-          : "unknown";
+          : process.platform === "freebsd"
+            ? "freebsd"
+            : "unknown";
   return `bun-${os}-${arch}`;
 }
 

--- a/test/regression/issue/30990.test.ts
+++ b/test/regression/issue/30990.test.ts
@@ -140,23 +140,20 @@ test.skipIf(isWindows)(
   },
 );
 
-test.skipIf(isWindows)(
-  "bun upgrade [current] progress (unknown size) uses binary-bytes (#30990)",
-  async () => {
-    // With `size` omitted, bun's `version.size == 0` and Progress takes the
-    // `eti == 0 && completed_items != 0` branch — the one-sided `[current]`
-    // arm. Same arm exercised by the canary upgrade path.
-    const stderr = await runUpgradeAgainstMock({ zipSize: 5 * 1024 * 1024, advertiseSize: false });
+test.skipIf(isWindows)("bun upgrade [current] progress (unknown size) uses binary-bytes (#30990)", async () => {
+  // With `size` omitted, bun's `version.size == 0` and Progress takes the
+  // `eti == 0 && completed_items != 0` branch — the one-sided `[current]`
+  // arm. Same arm exercised by the canary upgrade path.
+  const stderr = await runUpgradeAgainstMock({ zipSize: 5 * 1024 * 1024, advertiseSize: false });
 
-    const downloadingLines = stderr.split("\n").filter(l => l.includes("Downloading ["));
-    expect(downloadingLines.length).toBeGreaterThan(0);
+  const downloadingLines = stderr.split("\n").filter(l => l.includes("Downloading ["));
+  expect(downloadingLines.length).toBeGreaterThan(0);
 
-    const anyBinaryUnit = downloadingLines.some(l => /\[[\d.]+(MiB|KiB|GiB|B)\]/.test(l));
-    expect({ anyBinaryUnit, downloadingLines }).toEqual({ anyBinaryUnit: true, downloadingLines });
+  const anyBinaryUnit = downloadingLines.some(l => /\[[\d.]+(MiB|KiB|GiB|B)\]/.test(l));
+  expect({ anyBinaryUnit, downloadingLines }).toEqual({ anyBinaryUnit: true, downloadingLines });
 
-    // Broken shape: `[<many-digit-int>]` with no IEC suffix (e.g. `[3407873]`).
-    // `[0B]` is fine — it's the new code printing zero.
-    const anyRawBytes = downloadingLines.some(l => /\[\d{5,}\]/.test(l));
-    expect(anyRawBytes).toBe(false);
-  },
-);
+  // Broken shape: `[<many-digit-int>]` with no IEC suffix (e.g. `[3407873]`).
+  // `[0B]` is fine — it's the new code printing zero.
+  const anyRawBytes = downloadingLines.some(l => /\[\d{5,}\]/.test(l));
+  expect(anyRawBytes).toBe(false);
+});

--- a/test/regression/issue/30990.test.ts
+++ b/test/regression/issue/30990.test.ts
@@ -127,7 +127,7 @@ async function runUpgradeAgainstMock(opts: { zipSize: number; advertiseSize: boo
   return stderr;
 }
 
-test.skipIf(isWindows)(
+test.skipIf(isWindows).concurrent(
   "bun upgrade [current/total] progress uses binary-bytes (MiB), not raw bytes (#30990)",
   async () => {
     // With `size` advertised, Progress renders `[current/total]` — both
@@ -149,7 +149,7 @@ test.skipIf(isWindows)(
   },
 );
 
-test.skipIf(isWindows)("bun upgrade [current] progress (unknown size) uses binary-bytes (#30990)", async () => {
+test.skipIf(isWindows).concurrent("bun upgrade [current] progress (unknown size) uses binary-bytes (#30990)", async () => {
   // With `size` omitted, bun's `version.size == 0` and Progress takes the
   // `eti == 0 && completed_items != 0` branch — the one-sided `[current]`
   // arm. Same arm exercised by the canary upgrade path.

--- a/test/regression/issue/30990.test.ts
+++ b/test/regression/issue/30990.test.ts
@@ -1,0 +1,148 @@
+// Regression test for https://github.com/oven-sh/bun/issues/30990
+// `bun upgrade` download progress must render binary bytes (`KiB`/`MiB`/`GiB`)
+// rather than raw integer bytes — matching the Zig `{Bi:.2}` output that the
+// original implementation produced.
+//
+// We stand up a TLS server impersonating `api.github.com` via `GITHUB_API_DOMAIN`,
+// point `browser_download_url` at the same server so the download streams back
+// through us, and assert that `Downloading [...]` lines in stderr contain
+// binary-IEC units (e.g. `1.50MiB`) — both in the two-sided
+// `[current/total]` form (stable path, non-zero `size`) and the one-sided
+// `[current]` form (canary path, `size == 0`).
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir, tls } from "harness";
+
+// The expected `bun-<platform>.zip` filename in the mock release's asset list.
+// Built from bun's own triplet detection so the test works on whatever host ran it.
+function triplet(): string {
+  const arch = process.arch === "arm64" ? "aarch64" : "x64";
+  const os =
+    process.platform === "linux"
+      ? "linux"
+      : process.platform === "darwin"
+        ? "darwin"
+        : process.platform === "win32"
+          ? "windows"
+          : "unknown";
+  return `bun-${os}-${arch}.zip`;
+}
+
+async function runUpgradeAgainstMock(opts: { stable: boolean; zipSize: number }) {
+  const zipName = triplet();
+
+  await using server = Bun.serve({
+    port: 0,
+    tls,
+    async fetch(req) {
+      const url = new URL(req.url);
+
+      // `bun upgrade` stable path hits the Jarred-Sumner/bun-releases-for-updater repo.
+      if (url.pathname.endsWith("/releases/latest")) {
+        return Response.json({
+          tag_name: "bun-v99.0.0",
+          name: "Bun v99.0.0",
+          assets: [
+            {
+              name: zipName,
+              content_type: "application/zip",
+              browser_download_url: `https://localhost:${server.port}/bun.zip`,
+              size: opts.zipSize,
+            },
+          ],
+        });
+      }
+
+      if (url.pathname === "/bun.zip") {
+        // Stream garbage bytes with small chunks and a sleep so progress has
+        // time to tick through several `Downloading [...]` lines.
+        const CHUNK = 64 * 1024;
+        const pad = new Uint8Array(CHUNK);
+        const stream = new ReadableStream({
+          async start(controller) {
+            for (let off = 0; off < opts.zipSize; off += CHUNK) {
+              const n = Math.min(CHUNK, opts.zipSize - off);
+              controller.enqueue(n === CHUNK ? pad : pad.subarray(0, n));
+              await Bun.sleep(10);
+            }
+            controller.close();
+          },
+        });
+        return new Response(stream, {
+          headers: {
+            "content-type": "application/zip",
+            "content-length": String(opts.zipSize),
+          },
+        });
+      }
+
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  // Confine bun's upgrade side-effects (tmpdir, installation path) to a
+  // throwaway directory so if zip-extraction somehow succeeds it can't touch
+  // the running bun.
+  using scratch = tempDir("upgrade-30990", {});
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "upgrade", ...(opts.stable ? ["--stable"] : ["--canary"])],
+    env: {
+      ...bunEnv,
+      GITHUB_API_DOMAIN: `localhost:${server.port}`,
+      // Our mock server uses a self-signed cert; disable validation so the
+      // sync HTTP client inside `bun upgrade` can connect.
+      NODE_TLS_REJECT_UNAUTHORIZED: "0",
+      // Force non-colored output — we match on literal strings.
+      FORCE_COLOR: "0",
+      NO_COLOR: "1",
+      TMPDIR: String(scratch),
+      TEMP: String(scratch),
+      TMP: String(scratch),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [_stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return stderr;
+}
+
+test.concurrent.skipIf(isWindows)("bun upgrade shows binary-bytes progress (MiB), not raw bytes (#30990)", async () => {
+  // --stable gets a known size from the mock API, so both sides of
+  // `[current/total]` exercise the binary-bytes formatter.
+  const stderr = await runUpgradeAgainstMock({ stable: true, zipSize: 5 * 1024 * 1024 });
+
+  const downloadingLines = stderr.split("\n").filter(l => l.includes("Downloading ["));
+  expect(downloadingLines.length).toBeGreaterThan(0);
+
+  // At least one `Downloading [...]` line must mention a binary IEC unit.
+  // We don't pin an exact numeric value — timing of progress ticks is
+  // machine-dependent — but the formatter output always ends in `MiB` (or
+  // `KiB`/`B`) when the stable download completes.
+  const anyBinaryUnit = downloadingLines.some(l => /\[[\d.]+(MiB|KiB|GiB|B)\/[\d.]+(MiB|KiB|GiB|B)\]/.test(l));
+  expect({ anyBinaryUnit, downloadingLines }).toEqual({ anyBinaryUnit: true, downloadingLines });
+
+  // And crucially: the broken output shape (raw integer bytes
+  // `[<current-int>/<total-int>]`) must not appear. `5242880` = 5 × 1024².
+  const anyRawBytes = downloadingLines.some(l => /\[\d+\/5242880\]/.test(l));
+  expect(anyRawBytes).toBe(false);
+});
+
+test.concurrent.skipIf(isWindows)("bun upgrade --canary progress uses binary-bytes (#30990)", async () => {
+  // Canary path: `size` isn't known up-front, so progress renders only
+  // `[current]`. `Unit::Bytes` still applies — the one-sided arm must also
+  // format through the binary-bytes helper.
+  const stderr = await runUpgradeAgainstMock({ stable: false, zipSize: 5 * 1024 * 1024 });
+
+  const downloadingLines = stderr.split("\n").filter(l => l.includes("Downloading ["));
+  expect(downloadingLines.length).toBeGreaterThan(0);
+
+  const anyBinaryUnit = downloadingLines.some(l => /\[[\d.]+(MiB|KiB|GiB|B)\]/.test(l));
+  expect({ anyBinaryUnit, downloadingLines }).toEqual({ anyBinaryUnit: true, downloadingLines });
+
+  // The broken shape is `[<large-int>]` with no suffix — e.g. `[3407873]`.
+  // Strings like `[0B]` are fine (new code); we only care about the raw
+  // many-digit integer without any unit suffix.
+  const anyRawBytes = downloadingLines.some(l => /\[\d{5,}\]/.test(l));
+  expect(anyRawBytes).toBe(false);
+});

--- a/test/regression/issue/30990.test.ts
+++ b/test/regression/issue/30990.test.ts
@@ -99,6 +99,11 @@ async function runUpgradeAgainstMock(opts: { zipSize: number; advertiseSize: boo
       // Mock uses a self-signed cert; disable validation so the sync HTTP
       // client inside `bun upgrade` can connect.
       NODE_TLS_REJECT_UNAUTHORIZED: "0",
+      // `bun upgrade` deliberately leaks its `cli_arena()` allocations (the
+      // process is about to `execve` itself away), which ASAN happily
+      // reports under `detect_leaks=1` and aborts the subprocess. Keep the
+      // other options from CI's default so segv/coredump handling survives.
+      ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=0",
       FORCE_COLOR: "0",
       NO_COLOR: "1",
       TMPDIR: String(scratch),

--- a/test/regression/issue/30990.test.ts
+++ b/test/regression/issue/30990.test.ts
@@ -4,16 +4,22 @@
 // original implementation produced.
 //
 // We stand up a TLS server impersonating `api.github.com` via `GITHUB_API_DOMAIN`,
-// point `browser_download_url` at the same server so the download streams back
+// point `browser_download_url` at the same server so the download streams
 // through us, and assert that `Downloading [...]` lines in stderr contain
-// binary-IEC units (e.g. `1.50MiB`) — both in the two-sided
-// `[current/total]` form (stable path, non-zero `size`) and the one-sided
-// `[current]` form (canary path, `size == 0`).
+// binary-IEC units (e.g. `1.50MiB`) — exercising both the two-sided
+// `[current/total]` arm (mock API returns a non-zero `size`) and the
+// one-sided `[current]` arm (mock API omits `size`, so `version.size == 0`,
+// the same render shape the canary path produces).
+//
+// We don't hit the `--canary` path with a mock: upgrade_command.rs hard-codes
+// `https://github.com/oven-sh/bun/releases/download/canary/…`, so only the
+// stable path respects `GITHUB_API_DOMAIN`. Using the stable path with
+// `size` omitted gets us the same `[{Bi:.2}]` render shape regardless.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir, tls } from "harness";
 
-// The expected `bun-<platform>.zip` filename in the mock release's asset list.
-// Built from bun's own triplet detection so the test works on whatever host ran it.
+// Mirror bun's `Version::ZIP_FILENAME` — the stable upgrade loop rejects any
+// asset whose name doesn't match this, so we have to produce the same string.
 function triplet(): string {
   const arch = process.arch === "arm64" ? "aarch64" : "x64";
   const os =
@@ -27,7 +33,7 @@ function triplet(): string {
   return `bun-${os}-${arch}.zip`;
 }
 
-async function runUpgradeAgainstMock(opts: { stable: boolean; zipSize: number }) {
+async function runUpgradeAgainstMock(opts: { zipSize: number; advertiseSize: boolean }) {
   const zipName = triplet();
 
   await using server = Bun.serve({
@@ -36,25 +42,27 @@ async function runUpgradeAgainstMock(opts: { stable: boolean; zipSize: number })
     async fetch(req) {
       const url = new URL(req.url);
 
-      // `bun upgrade` stable path hits the Jarred-Sumner/bun-releases-for-updater repo.
+      // `bun upgrade --stable` hits `Jarred-Sumner/bun-releases-for-updater`.
       if (url.pathname.endsWith("/releases/latest")) {
+        const asset: Record<string, unknown> = {
+          name: zipName,
+          content_type: "application/zip",
+          browser_download_url: `https://localhost:${server.port}/bun.zip`,
+        };
+        // Omitting `size` makes `version.size == 0` on the bun side, which
+        // drives the one-sided `[{current}]` progress arm (same as canary).
+        if (opts.advertiseSize) asset.size = opts.zipSize;
         return Response.json({
           tag_name: "bun-v99.0.0",
           name: "Bun v99.0.0",
-          assets: [
-            {
-              name: zipName,
-              content_type: "application/zip",
-              browser_download_url: `https://localhost:${server.port}/bun.zip`,
-              size: opts.zipSize,
-            },
-          ],
+          assets: [asset],
         });
       }
 
       if (url.pathname === "/bun.zip") {
-        // Stream garbage bytes with small chunks and a sleep so progress has
-        // time to tick through several `Downloading [...]` lines.
+        // Small chunks + a short sleep so Progress ticks through several
+        // `Downloading [...]` lines (its refresh is rate-limited; one-shot
+        // transfers produce no visible ticks).
         const CHUNK = 64 * 1024;
         const pad = new Uint8Array(CHUNK);
         const stream = new ReadableStream({
@@ -62,7 +70,7 @@ async function runUpgradeAgainstMock(opts: { stable: boolean; zipSize: number })
             for (let off = 0; off < opts.zipSize; off += CHUNK) {
               const n = Math.min(CHUNK, opts.zipSize - off);
               controller.enqueue(n === CHUNK ? pad : pad.subarray(0, n));
-              await Bun.sleep(10);
+              await Bun.sleep(15);
             }
             controller.close();
           },
@@ -79,20 +87,18 @@ async function runUpgradeAgainstMock(opts: { stable: boolean; zipSize: number })
     },
   });
 
-  // Confine bun's upgrade side-effects (tmpdir, installation path) to a
-  // throwaway directory so if zip-extraction somehow succeeds it can't touch
-  // the running bun.
+  // Confine upgrade side-effects (tmpdir for download + unzip) to a
+  // throwaway directory.
   using scratch = tempDir("upgrade-30990", {});
 
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "upgrade", ...(opts.stable ? ["--stable"] : ["--canary"])],
+    cmd: [bunExe(), "upgrade", "--stable"],
     env: {
       ...bunEnv,
       GITHUB_API_DOMAIN: `localhost:${server.port}`,
-      // Our mock server uses a self-signed cert; disable validation so the
-      // sync HTTP client inside `bun upgrade` can connect.
+      // Mock uses a self-signed cert; disable validation so the sync HTTP
+      // client inside `bun upgrade` can connect.
       NODE_TLS_REJECT_UNAUTHORIZED: "0",
-      // Force non-colored output — we match on literal strings.
       FORCE_COLOR: "0",
       NO_COLOR: "1",
       TMPDIR: String(scratch),
@@ -107,42 +113,45 @@ async function runUpgradeAgainstMock(opts: { stable: boolean; zipSize: number })
   return stderr;
 }
 
-test.concurrent.skipIf(isWindows)("bun upgrade shows binary-bytes progress (MiB), not raw bytes (#30990)", async () => {
-  // --stable gets a known size from the mock API, so both sides of
-  // `[current/total]` exercise the binary-bytes formatter.
-  const stderr = await runUpgradeAgainstMock({ stable: true, zipSize: 5 * 1024 * 1024 });
+test.skipIf(isWindows)(
+  "bun upgrade [current/total] progress uses binary-bytes (MiB), not raw bytes (#30990)",
+  async () => {
+    // With `size` advertised, Progress renders `[current/total]` — both
+    // sides go through the binary-bytes formatter.
+    const stderr = await runUpgradeAgainstMock({ zipSize: 5 * 1024 * 1024, advertiseSize: true });
 
-  const downloadingLines = stderr.split("\n").filter(l => l.includes("Downloading ["));
-  expect(downloadingLines.length).toBeGreaterThan(0);
+    const downloadingLines = stderr.split("\n").filter(l => l.includes("Downloading ["));
+    expect(downloadingLines.length).toBeGreaterThan(0);
 
-  // At least one `Downloading [...]` line must mention a binary IEC unit.
-  // We don't pin an exact numeric value — timing of progress ticks is
-  // machine-dependent — but the formatter output always ends in `MiB` (or
-  // `KiB`/`B`) when the stable download completes.
-  const anyBinaryUnit = downloadingLines.some(l => /\[[\d.]+(MiB|KiB|GiB|B)\/[\d.]+(MiB|KiB|GiB|B)\]/.test(l));
-  expect({ anyBinaryUnit, downloadingLines }).toEqual({ anyBinaryUnit: true, downloadingLines });
+    // At least one `Downloading [...]` line must carry a binary IEC unit.
+    // Exact numeric values are machine-dependent (Progress refresh is
+    // rate-limited and chunk timing jitters), but the suffix is deterministic.
+    const anyBinaryUnit = downloadingLines.some(l => /\[[\d.]+(MiB|KiB|GiB|B)\/[\d.]+(MiB|KiB|GiB|B)\]/.test(l));
+    expect({ anyBinaryUnit, downloadingLines }).toEqual({ anyBinaryUnit: true, downloadingLines });
 
-  // And crucially: the broken output shape (raw integer bytes
-  // `[<current-int>/<total-int>]`) must not appear. `5242880` = 5 × 1024².
-  const anyRawBytes = downloadingLines.some(l => /\[\d+\/5242880\]/.test(l));
-  expect(anyRawBytes).toBe(false);
-});
+    // Broken shape: raw integer bytes `[<N>/5242880]` (5 × 1024²).
+    const anyRawBytes = downloadingLines.some(l => /\[\d+\/5242880\]/.test(l));
+    expect(anyRawBytes).toBe(false);
+  },
+);
 
-test.concurrent.skipIf(isWindows)("bun upgrade --canary progress uses binary-bytes (#30990)", async () => {
-  // Canary path: `size` isn't known up-front, so progress renders only
-  // `[current]`. `Unit::Bytes` still applies — the one-sided arm must also
-  // format through the binary-bytes helper.
-  const stderr = await runUpgradeAgainstMock({ stable: false, zipSize: 5 * 1024 * 1024 });
+test.skipIf(isWindows)(
+  "bun upgrade [current] progress (unknown size) uses binary-bytes (#30990)",
+  async () => {
+    // With `size` omitted, bun's `version.size == 0` and Progress takes the
+    // `eti == 0 && completed_items != 0` branch — the one-sided `[current]`
+    // arm. Same arm exercised by the canary upgrade path.
+    const stderr = await runUpgradeAgainstMock({ zipSize: 5 * 1024 * 1024, advertiseSize: false });
 
-  const downloadingLines = stderr.split("\n").filter(l => l.includes("Downloading ["));
-  expect(downloadingLines.length).toBeGreaterThan(0);
+    const downloadingLines = stderr.split("\n").filter(l => l.includes("Downloading ["));
+    expect(downloadingLines.length).toBeGreaterThan(0);
 
-  const anyBinaryUnit = downloadingLines.some(l => /\[[\d.]+(MiB|KiB|GiB|B)\]/.test(l));
-  expect({ anyBinaryUnit, downloadingLines }).toEqual({ anyBinaryUnit: true, downloadingLines });
+    const anyBinaryUnit = downloadingLines.some(l => /\[[\d.]+(MiB|KiB|GiB|B)\]/.test(l));
+    expect({ anyBinaryUnit, downloadingLines }).toEqual({ anyBinaryUnit: true, downloadingLines });
 
-  // The broken shape is `[<large-int>]` with no suffix — e.g. `[3407873]`.
-  // Strings like `[0B]` are fine (new code); we only care about the raw
-  // many-digit integer without any unit suffix.
-  const anyRawBytes = downloadingLines.some(l => /\[\d{5,}\]/.test(l));
-  expect(anyRawBytes).toBe(false);
-});
+    // Broken shape: `[<many-digit-int>]` with no IEC suffix (e.g. `[3407873]`).
+    // `[0B]` is fine — it's the new code printing zero.
+    const anyRawBytes = downloadingLines.some(l => /\[\d{5,}\]/.test(l));
+    expect(anyRawBytes).toBe(false);
+  },
+);

--- a/test/regression/issue/30990.test.ts
+++ b/test/regression/issue/30990.test.ts
@@ -18,9 +18,13 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir, tls } from "harness";
 
-// Mirror bun's `Version::ZIP_FILENAME` — the stable upgrade loop rejects any
-// asset whose name doesn't match this, so we have to produce the same string.
-function triplet(): string {
+// Bun's stable-upgrade loop requires an asset whose `name` matches its own
+// `Version::ZIP_FILENAME` byte-for-byte — that filename includes `-musl`,
+// `-baseline`, `-android` suffixes depending on how this bun was built.
+// The test runs on many build flavours in CI (glibc / musl / baseline /
+// musl-baseline / android / macOS), so rather than reproduce every rule in
+// JS we advertise every plausible variant and let bun pick its own match.
+function assetBaseName(): string {
   const arch = process.arch === "arm64" ? "aarch64" : "x64";
   const os =
     process.platform === "linux"
@@ -30,11 +34,12 @@ function triplet(): string {
         : process.platform === "win32"
           ? "windows"
           : "unknown";
-  return `bun-${os}-${arch}.zip`;
+  return `bun-${os}-${arch}`;
 }
 
 async function runUpgradeAgainstMock(opts: { zipSize: number; advertiseSize: boolean }) {
-  const zipName = triplet();
+  const base = assetBaseName();
+  const variants = ["", "-musl", "-android", "-baseline", "-musl-baseline", "-android-baseline"];
 
   await using server = Bun.serve({
     port: 0,
@@ -44,18 +49,22 @@ async function runUpgradeAgainstMock(opts: { zipSize: number; advertiseSize: boo
 
       // `bun upgrade --stable` hits `Jarred-Sumner/bun-releases-for-updater`.
       if (url.pathname.endsWith("/releases/latest")) {
-        const asset: Record<string, unknown> = {
-          name: zipName,
-          content_type: "application/zip",
-          browser_download_url: `https://localhost:${server.port}/bun.zip`,
-        };
-        // Omitting `size` makes `version.size == 0` on the bun side, which
-        // drives the one-sided `[{current}]` progress arm (same as canary).
-        if (opts.advertiseSize) asset.size = opts.zipSize;
+        const assets = variants.map(suffix => {
+          const asset: Record<string, unknown> = {
+            name: `${base}${suffix}.zip`,
+            content_type: "application/zip",
+            browser_download_url: `https://localhost:${server.port}/bun.zip`,
+          };
+          // Omitting `size` makes `version.size == 0` on the bun side,
+          // which drives the one-sided `[{current}]` progress arm (the
+          // same shape the canary path produces).
+          if (opts.advertiseSize) asset.size = opts.zipSize;
+          return asset;
+        });
         return Response.json({
           tag_name: "bun-v99.0.0",
           name: "Bun v99.0.0",
-          assets: [asset],
+          assets,
         });
       }
 


### PR DESCRIPTION
Fixes #30990.

## Repro

```sh
# On Zig-era stable bun, self-upgrade to the Rust build, then:
bun upgrade --canary       # canary path
bun upgrade --stable       # stable path
```

Both render raw integer bytes in the progress bar
(`Downloading [12254605]`, `Downloading [3407873/5242880]`) instead of
the IEC units the Zig build used
(`Downloading [11.69MiB]`, `Downloading [3.25MiB/5.00MiB]`).

## Cause

`Progress::refresh` in `src/bun_core/Progress.rs` treats `Unit::Bytes`
like `Unit::None` — both arms carry a `TODO(port)` because the Rust
`bun_core::fmt` doesn't have an equivalent of Zig stdlib's `{Bi:.2}`
binary-bytes formatter (`{SizeFormatter}` is the SI variant — base
1000, `KB`/`MB`). So the renderer emits plain `{integer}` where the
Zig original emitted `{1.50MiB}`.

## Fix

1. Add `bun_core::fmt::BinarySizeFormatter<const PRECISION: usize>`
   and a `size_bi(u64)` helper — port of Zig stdlib's `{Bi:.P}`
   (base 1024, IEC suffixes `KiB`/`MiB`/`GiB`/…). Zero → `"0B"`;
   otherwise divide by the largest power of 1024 that fits and print
   with `P` decimals. `P` defaults to `2` to match the Zig call-sites
   Bun used (`"[{Bi:.2}/{Bi:.2}]"`).
2. Route both `Unit::Bytes` arms in `Progress::refresh` through
   `size_bi` — the two-value `[current/total]` form (stable upgrade,
   known `size`) and the one-value `[current]` form (canary, `size == 0`).

The formatter matches Zig's output across the ranges that matter for a
bun release download:

| bytes      | output  |
|------------|---------|
| 0          | `0B`    |
| 1          | `1.00B` |
| 1024       | `1.00KiB` |
| 1 572 864  | `1.50MiB` |
| 5 242 880  | `5.00MiB` |
| 1 073 741 824 | `1.00GiB` |

## Verification

```
$ bun bd test test/regression/issue/30990.test.ts
(pass) bun upgrade shows binary-bytes progress (MiB), not raw bytes (#30990)
(pass) bun upgrade --canary progress uses binary-bytes (#30990)
 2 pass
 0 fail
```

The test stands up a TLS server impersonating `api.github.com` via
`GITHUB_API_DOMAIN`, has the mock release's `browser_download_url`
point back at the same port, streams a fake 5 MiB zip in 64 KiB chunks
so progress has time to tick, and asserts that `Downloading [...]`
lines contain IEC units (`MiB`) and not the raw-integer shape
(`[N/5242880]`). Stashing `src/` and re-running reproduces the
broken `[3719169/5242880]` / `[12254605]` output, confirming the test
exercises this fix.
