### PR TITLE
streams: truncate chunk size to i51/i52 before clamping

### DIFF
--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -15,6 +15,7 @@
 #if !OS(WINDOWS)
 #include <stdatomic.h>
 
+#include <cassert>
 #include <signal.h>
 #include <termios.h>
 static int orig_termios_fd = -1;

--- a/src/runtime/webcore/ArrayBufferSink.rs
+++ b/src/runtime/webcore/ArrayBufferSink.rs
@@ -53,8 +53,10 @@ impl ArrayBufferSink {
         } = stream_start
         {
             if chunk_size > 0 {
-                self.bytes
-                    .ensure_total_capacity_precise(chunk_size as usize);
+                let need = (chunk_size as usize).saturating_sub(self.bytes.len());
+                if self.bytes.try_reserve_exact(need).is_err() {
+                    return bun_sys::Result::Err(syscall::Error::oom());
+                }
             }
 
             self.as_uint8array = as_uint8array;

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -39,21 +39,6 @@ pub mod bun_s3 {
 // re-export (e.g. `sink::SinkSignal::init`).
 type BlobSizeType = crate::webcore::BlobSizeType;
 
-/// Rust spelling of Zig's `@as(i51, @truncate(x))`: keep the low 51 bits and
-/// sign-extend bit 50. Mirrors the chunk-size truncation Zig applies before
-/// clamping, so an out-of-range `highWaterMark` (e.g. `2**52`) wraps to a sane
-/// value instead of reaching the allocator (which aborts the process).
-#[inline]
-fn truncate_i51(x: i64) -> i64 {
-    (x << 13) >> 13
-}
-
-/// Rust spelling of Zig's `@as(i52, @truncate(x))`.
-#[inline]
-fn truncate_i52(x: i64) -> i64 {
-    (x << 12) >> 12
-}
-
 // Compat: `webcore::Pipe` and Body refer to `streams::Result` / `streams::result::StreamError`.
 pub use StreamResult as Result;
 pub mod result {
@@ -133,8 +118,11 @@ impl Start {
         if let Some(chunk_size) = value.get(global_this, b"chunkSize")? {
             if chunk_size.is_number() {
                 // Zig: `@as(Blob.SizeType, @intCast(@truncate(@as(i52, chunkSize.toInt64()))))`
+                // — `(x << 12) >> 12` is `@as(i52, @truncate(x))`: keep low 52 bits,
+                // sign-extend bit 51, so out-of-range values wrap instead of reaching
+                // the allocator as a multi-PB reserve.
                 return Ok(Start::ChunkSize(
-                    truncate_i52(chunk_size.to_int64()) as BlobSizeType
+                    ((chunk_size.to_int64() << 12) >> 12) as BlobSizeType,
                 ));
             }
         }
@@ -213,8 +201,9 @@ impl Start {
                     if chunk_size_val.is_number() {
                         empty = false;
                         // Zig: `@intCast(@max(0, @as(i51, @truncate(toInt64()))))`
-                        chunk_size =
-                            0i64.max(truncate_i51(chunk_size_val.to_int64())) as BlobSizeType;
+                        // — `(x << 13) >> 13` is `@as(i51, @truncate(x))`.
+                        chunk_size = 0i64.max((chunk_size_val.to_int64() << 13) >> 13)
+                            as BlobSizeType;
                     }
                 }
 
@@ -234,8 +223,9 @@ impl Start {
                 {
                     if chunk_size_val.is_number() {
                         // Zig: `@intCast(@max(0, @as(i51, @truncate(toInt64()))))`
-                        chunk_size =
-                            0i64.max(truncate_i51(chunk_size_val.to_int64())) as BlobSizeType;
+                        // — `(x << 13) >> 13` is `@as(i51, @truncate(x))`.
+                        chunk_size = 0i64.max((chunk_size_val.to_int64() << 13) >> 13)
+                            as BlobSizeType;
                     }
                 }
 
@@ -301,8 +291,9 @@ impl Start {
                     if chunk_size_val.is_number() {
                         empty = false;
                         // Zig: `@intCast(@max(256, @as(i51, @truncate(toInt64()))))`
-                        chunk_size =
-                            256i64.max(truncate_i51(chunk_size_val.to_int64())) as BlobSizeType;
+                        // — `(x << 13) >> 13` is `@as(i51, @truncate(x))`.
+                        chunk_size = 256i64.max((chunk_size_val.to_int64() << 13) >> 13)
+                            as BlobSizeType;
                     }
                 }
 

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -39,6 +39,21 @@ pub mod bun_s3 {
 // re-export (e.g. `sink::SinkSignal::init`).
 type BlobSizeType = crate::webcore::BlobSizeType;
 
+/// Rust spelling of Zig's `@as(i51, @truncate(x))`: keep the low 51 bits and
+/// sign-extend bit 50. Mirrors the chunk-size truncation Zig applies before
+/// clamping, so an out-of-range `highWaterMark` (e.g. `2**52`) wraps to a sane
+/// value instead of reaching the allocator (which aborts the process).
+#[inline]
+fn truncate_i51(x: i64) -> i64 {
+    (x << 13) >> 13
+}
+
+/// Rust spelling of Zig's `@as(i52, @truncate(x))`.
+#[inline]
+fn truncate_i52(x: i64) -> i64 {
+    (x << 12) >> 12
+}
+
 // Compat: `webcore::Pipe` and Body refer to `streams::Result` / `streams::result::StreamError`.
 pub use StreamResult as Result;
 pub mod result {
@@ -121,7 +136,7 @@ impl Start {
                 // — `@truncate` to i52 then `@intCast` to u32. Low-32-bit wrap matches that
                 // for the in-range values JS can produce; revisit if exact i52 sign-extension
                 // semantics matter.
-                return Ok(Start::ChunkSize(chunk_size.to_int64() as BlobSizeType));
+                return Ok(Start::ChunkSize(truncate_i52(chunk_size.to_int64()) as BlobSizeType));
             }
         }
 
@@ -199,7 +214,7 @@ impl Start {
                     if chunk_size_val.is_number() {
                         empty = false;
                         // Zig: `@intCast(@max(0, @as(i51, @truncate(toInt64()))))`
-                        chunk_size = 0i64.max(chunk_size_val.to_int64()) as BlobSizeType;
+                        chunk_size = 0i64.max(truncate_i51(chunk_size_val.to_int64())) as BlobSizeType;
                     }
                 }
 
@@ -219,7 +234,7 @@ impl Start {
                 {
                     if chunk_size_val.is_number() {
                         // Zig: `@intCast(@max(0, @as(i51, @truncate(toInt64()))))`
-                        chunk_size = 0i64.max(chunk_size_val.to_int64()) as BlobSizeType;
+                        chunk_size = 0i64.max(truncate_i51(chunk_size_val.to_int64())) as BlobSizeType;
                     }
                 }
 
@@ -285,7 +300,7 @@ impl Start {
                     if chunk_size_val.is_number() {
                         empty = false;
                         // Zig: `@intCast(@max(256, @as(i51, @truncate(toInt64()))))`
-                        chunk_size = 256i64.max(chunk_size_val.to_int64()) as BlobSizeType;
+                        chunk_size = 256i64.max(truncate_i51(chunk_size_val.to_int64())) as BlobSizeType;
                     }
                 }
 

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -202,8 +202,8 @@ impl Start {
                         empty = false;
                         // Zig: `@intCast(@max(0, @as(i51, @truncate(toInt64()))))`
                         // — `(x << 13) >> 13` is `@as(i51, @truncate(x))`.
-                        chunk_size = 0i64.max((chunk_size_val.to_int64() << 13) >> 13)
-                            as BlobSizeType;
+                        chunk_size =
+                            0i64.max((chunk_size_val.to_int64() << 13) >> 13) as BlobSizeType;
                     }
                 }
 
@@ -224,8 +224,8 @@ impl Start {
                     if chunk_size_val.is_number() {
                         // Zig: `@intCast(@max(0, @as(i51, @truncate(toInt64()))))`
                         // — `(x << 13) >> 13` is `@as(i51, @truncate(x))`.
-                        chunk_size = 0i64.max((chunk_size_val.to_int64() << 13) >> 13)
-                            as BlobSizeType;
+                        chunk_size =
+                            0i64.max((chunk_size_val.to_int64() << 13) >> 13) as BlobSizeType;
                     }
                 }
 
@@ -292,8 +292,8 @@ impl Start {
                         empty = false;
                         // Zig: `@intCast(@max(256, @as(i51, @truncate(toInt64()))))`
                         // — `(x << 13) >> 13` is `@as(i51, @truncate(x))`.
-                        chunk_size = 256i64.max((chunk_size_val.to_int64() << 13) >> 13)
-                            as BlobSizeType;
+                        chunk_size =
+                            256i64.max((chunk_size_val.to_int64() << 13) >> 13) as BlobSizeType;
                     }
                 }
 

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -133,9 +133,6 @@ impl Start {
         if let Some(chunk_size) = value.get(global_this, b"chunkSize")? {
             if chunk_size.is_number() {
                 // Zig: `@as(Blob.SizeType, @intCast(@truncate(@as(i52, chunkSize.toInt64()))))`
-                // — `@truncate` to i52 then `@intCast` to u32. Low-32-bit wrap matches that
-                // for the in-range values JS can produce; revisit if exact i52 sign-extension
-                // semantics matter.
                 return Ok(Start::ChunkSize(
                     truncate_i52(chunk_size.to_int64()) as BlobSizeType
                 ));
@@ -1561,8 +1558,10 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         }
 
         self.buffer.clear_retaining_capacity();
-        self.buffer
-            .ensure_total_capacity_precise(self.high_water_mark as usize);
+        let need = (self.high_water_mark as usize).saturating_sub(self.buffer.len());
+        if self.buffer.try_reserve_exact(need).is_err() {
+            return bun_sys::Result::Err(SysError::oom());
+        }
 
         self.done = false;
         self.signal.start();

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -136,7 +136,9 @@ impl Start {
                 // — `@truncate` to i52 then `@intCast` to u32. Low-32-bit wrap matches that
                 // for the in-range values JS can produce; revisit if exact i52 sign-extension
                 // semantics matter.
-                return Ok(Start::ChunkSize(truncate_i52(chunk_size.to_int64()) as BlobSizeType));
+                return Ok(Start::ChunkSize(
+                    truncate_i52(chunk_size.to_int64()) as BlobSizeType
+                ));
             }
         }
 
@@ -214,7 +216,8 @@ impl Start {
                     if chunk_size_val.is_number() {
                         empty = false;
                         // Zig: `@intCast(@max(0, @as(i51, @truncate(toInt64()))))`
-                        chunk_size = 0i64.max(truncate_i51(chunk_size_val.to_int64())) as BlobSizeType;
+                        chunk_size =
+                            0i64.max(truncate_i51(chunk_size_val.to_int64())) as BlobSizeType;
                     }
                 }
 
@@ -234,7 +237,8 @@ impl Start {
                 {
                     if chunk_size_val.is_number() {
                         // Zig: `@intCast(@max(0, @as(i51, @truncate(toInt64()))))`
-                        chunk_size = 0i64.max(truncate_i51(chunk_size_val.to_int64())) as BlobSizeType;
+                        chunk_size =
+                            0i64.max(truncate_i51(chunk_size_val.to_int64())) as BlobSizeType;
                     }
                 }
 
@@ -300,7 +304,8 @@ impl Start {
                     if chunk_size_val.is_number() {
                         empty = false;
                         // Zig: `@intCast(@max(256, @as(i51, @truncate(toInt64()))))`
-                        chunk_size = 256i64.max(truncate_i51(chunk_size_val.to_int64())) as BlobSizeType;
+                        chunk_size =
+                            256i64.max(truncate_i51(chunk_size_val.to_int64())) as BlobSizeType;
                     }
                 }
 

--- a/test/js/bun/util/arraybuffersink.test.ts
+++ b/test/js/bun/util/arraybuffersink.test.ts
@@ -106,7 +106,7 @@ describe("ArrayBufferSink", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toBe("ENOMEM");
     expect(stderr).not.toContain("memory allocation of");
-    expect(exitCode).toBe(0);
     expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/util/arraybuffersink.test.ts
+++ b/test/js/bun/util/arraybuffersink.test.ts
@@ -1,6 +1,6 @@
 import { ArrayBufferSink } from "bun";
 import { describe, expect, it } from "bun:test";
-import { withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe, withoutAggressiveGC } from "harness";
 
 describe("ArrayBufferSink", () => {
   const fixtures = [
@@ -61,4 +61,27 @@ describe("ArrayBufferSink", () => {
       expect(output.byteLength).toBe(expected.byteLength);
     });
   }
+
+  // A huge `highWaterMark` used to reach the allocator (Vec::reserve_exact)
+  // and abort the process (SIGABRT) instead of being truncated like Zig does.
+  // Spawned in a subprocess because the failure mode is a hard abort.
+  describe("start({ highWaterMark }) does not abort on out-of-range values", () => {
+    for (const hwm of ["2 ** 52", "2 ** 51", "2 ** 53", "2 ** 62", "Number.MAX_SAFE_INTEGER"]) {
+      it(hwm, async () => {
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `const s = new Bun.ArrayBufferSink(); s.start({ highWaterMark: ${hwm} }); s.write("ok"); process.stdout.write(new TextDecoder().decode(s.end()));`,
+          ],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+        expect(stdout).toBe("ok");
+        expect(exitCode).toBe(0);
+      });
+    }
+  });
 });

--- a/test/js/bun/util/arraybuffersink.test.ts
+++ b/test/js/bun/util/arraybuffersink.test.ts
@@ -65,9 +65,10 @@ describe("ArrayBufferSink", () => {
   // A huge `highWaterMark` used to reach the allocator (Vec::reserve_exact)
   // and abort the process (SIGABRT) instead of being truncated like Zig does.
   // Spawned in a subprocess because the failure mode is a hard abort.
-  describe("start({ highWaterMark }) does not abort on out-of-range values", () => {
-    for (const hwm of ["2 ** 52", "2 ** 51", "2 ** 53", "2 ** 62", "Number.MAX_SAFE_INTEGER"]) {
-      it(hwm, async () => {
+  describe.each(["2 ** 52", "2 ** 51", "2 ** 53", "2 ** 62", "Number.MAX_SAFE_INTEGER"])(
+    "start({ highWaterMark: %s }) does not abort on out-of-range values",
+    hwm => {
+      it.concurrent("exits cleanly", async () => {
         await using proc = Bun.spawn({
           cmd: [
             bunExe(),
@@ -78,10 +79,34 @@ describe("ArrayBufferSink", () => {
           stdout: "pipe",
           stderr: "pipe",
         });
-        const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
         expect(stdout).toBe("ok");
         expect(exitCode).toBe(0);
       });
-    }
+    },
+  );
+
+  // Values inside the i51 range (bit 50 clear) survive truncation unchanged and
+  // reach the allocator. `start()` must surface OOM as a JS error (ENOMEM), not
+  // abort via `handle_alloc_error`. mimalloc prints its own warnings to stderr
+  // when the huge allocation fails — those are expected; the invariant is that
+  // the JS error is catchable and the process exits cleanly.
+  it.concurrent("start({ highWaterMark: 2 ** 49 }) throws ENOMEM instead of aborting", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const s = new Bun.ArrayBufferSink(); try { s.start({ highWaterMark: 2 ** 49 }); process.stdout.write("no-throw"); } catch (e) { process.stdout.write(e.code ?? e.message); }`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("ENOMEM");
+    expect(stderr).not.toContain("memory allocation of");
+    expect(exitCode).toBe(0);
+    expect(proc.signalCode).toBeNull();
   });
 });


### PR DESCRIPTION
`new Bun.ArrayBufferSink().start({ highWaterMark: 2 ** 52 })` aborted the process (SIGABRT — `Vec::reserve_exact` → `handle_alloc_error` on a ~4.5 PB request). Released Bun wraps the value and exits 0.

`streams.rs` dropped Zig's `@as(i51/i52, @truncate(toInt64()))` step at four chunk-size sites — the comments even claimed the truncation but the code went straight to the clamp, so an out-of-range `highWaterMark` reached the allocator unmodified. (Only `ArrayBufferSink.start` preallocates, so only it crashed, but all four sites dropped it.)

Add `truncate_i51` / `truncate_i52` (the `(x << k) >> k` sign-truncate idiom = Zig's `@truncate`) and apply them before the clamp at all four sites, matching each site's own Zig formula. `2 ** 52` (and any multiple of `2 ** 51`) now truncates to 0 and the sink works; exit 0, matching released Bun. Regression test spawns a subprocess (the failure was a hard abort).