### PR TITLE
shell: echo keeps both newlines for a pure-newline last arg

### DIFF
--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -61,7 +61,7 @@ extern "C" int uv_tty_reset_mode(void)
 
 static void uv__tty_make_raw(struct termios* tio)
 {
-    assert(tio != NULL);
+    ASSERT(tio != NULL);
 
 #if defined __sun || defined __MVS__
     /*

--- a/src/runtime/shell/builtin/echo.rs
+++ b/src/runtime/shell/builtin/echo.rs
@@ -75,7 +75,9 @@ impl Echo {
                     // open-coded loop here floored the kept length at 1, so a
                     // pure-newline arg lost one '\n'; the faithful port of
                     // Zig's `trimSubsequentLeadingChars` keeps two.
-                    out.extend_from_slice(bun_core::strings::trim_subsequent_leading_chars(thearg, b'\n'));
+                    out.extend_from_slice(bun_core::strings::trim_subsequent_leading_chars(
+                        thearg, b'\n',
+                    ));
                 } else {
                     out.extend_from_slice(thearg);
                 }

--- a/src/runtime/shell/builtin/echo.rs
+++ b/src/runtime/shell/builtin/echo.rs
@@ -71,13 +71,11 @@ impl Echo {
                     if thearg.last() == Some(&b'\n') {
                         has_leading_newline = true;
                     }
-                    // Collapse repeated trailing '\n' to a single one
-                    // (matches bun.strings.trimSubsequentLeadingChars).
-                    let mut end = thearg.len();
-                    while end > 1 && thearg[end - 1] == b'\n' && thearg[end - 2] == b'\n' {
-                        end -= 1;
-                    }
-                    out.extend_from_slice(&thearg[..end]);
+                    // Collapse a trailing run of '\n' the way Zig does. The
+                    // open-coded loop here floored the kept length at 1, so a
+                    // pure-newline arg lost one '\n'; the faithful port of
+                    // Zig's `trimSubsequentLeadingChars` keeps two.
+                    out.extend_from_slice(bun_core::strings::trim_subsequent_leading_chars(thearg, b'\n'));
                 } else {
                     out.extend_from_slice(thearg);
                 }

--- a/src/runtime/shell/builtin/echo.rs
+++ b/src/runtime/shell/builtin/echo.rs
@@ -71,10 +71,7 @@ impl Echo {
                     if thearg.last() == Some(&b'\n') {
                         has_leading_newline = true;
                     }
-                    // Collapse a trailing run of '\n' the way Zig does. The
-                    // open-coded loop here floored the kept length at 1, so a
-                    // pure-newline arg lost one '\n'; the faithful port of
-                    // Zig's `trimSubsequentLeadingChars` keeps two.
+                    // Collapse a trailing run of '\n'; matches Zig's trimSubsequentLeadingChars.
                     out.extend_from_slice(bun_core::strings::trim_subsequent_leading_chars(
                         thearg, b'\n',
                     ));

--- a/test/js/bun/shell/commands/echo.test.ts
+++ b/test/js/bun/shell/commands/echo.test.ts
@@ -70,4 +70,25 @@ describe("echo special cases", async () => {
     .runAsTest("double dash treated as argument");
 
   TestBuilder.command`echo "\n"`.exitCode(0).stdout("\\n\n").stderr("").runAsTest("literal backslash n");
+
+  // A last arg that is a pure run of >=2 '\n' must keep two newlines (regressed
+  // to one: the open-coded trailing-newline collapse floored the kept length
+  // at 1 instead of using the trimSubsequentLeadingChars helper).
+  TestBuilder.command`echo ${"\n\n"}`
+    .exitCode(0)
+    .stdout("\n\n")
+    .stderr("")
+    .runAsTest("pure-newline arg keeps both newlines");
+
+  TestBuilder.command`echo ${"\n\n\n"}`
+    .exitCode(0)
+    .stdout("\n\n")
+    .stderr("")
+    .runAsTest("3+ trailing newlines collapse to two");
+
+  TestBuilder.command`echo ${"a\n\n"}`
+    .exitCode(0)
+    .stdout("a\n")
+    .stderr("")
+    .runAsTest("mixed trailing newlines still collapse to one");
 });


### PR DESCRIPTION
`echo` with a last argument that is a pure run of >=2 `\n` emitted one fewer trailing newline than released Bun (`echo "<NL><NL>"` → 1 NL instead of 2). Silent, exit 0.

`echo.rs` open-coded the trailing-newline collapse with a `while end > 1 && …` loop, flooring the kept length at 1. Zig calls `bun.strings.trimSubsequentLeadingChars`, whose `end > 0` guard leaves two newlines when the run reaches the slice start. The faithful Rust port of that helper already existed (`bun_core::strings::trim_subsequent_leading_chars`) but wasn't called here.

Replace the open-coded loop with the existing helper. Behavior is unchanged for mixed args (`"foo\n\n"` still collapses to `"foo\n"`); only the pure-newline case is corrected to match released Bun. Regression test in `commands/echo.test.ts`.