### PR TITLE
server: don't send a fallback content-type on detached responses

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3403,7 +3403,7 @@ where
             // do not insert the content type if it is the fallback value
             // we may not know the content-type when streaming
             && (!self.blob.is_detached()
-                || content_type.value.as_ptr() != bun_http_types::MimeType::OTHER.value.as_ptr())
+                || content_type.category != bun_http_types::MimeType::Category::Other)
             && !content_type
                 .value
                 .iter()

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3403,7 +3403,11 @@ where
             // do not insert the content type if it is the fallback value
             // we may not know the content-type when streaming
             && (!self.blob.is_detached()
-                || content_type.category != bun_http_types::MimeType::Category::Other)
+                // Zig: `content_type.value.ptr != MimeType.other.value.ptr`. A Rust `const` has
+                // no stable address, so compare the bytes. `MimeType::init` maps unrecognized
+                // top-level types (e.g. `multipart/*`) to `Category::Other` while preserving the
+                // caller's value — hence category alone would over-suppress here.
+                || content_type.value.as_ref() != bun_http_types::MimeType::OTHER.value.as_ref())
             && !content_type
                 .value
                 .iter()

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1367,6 +1367,39 @@ it("request body and signal life cycle", async () => {
   }
 }, 30_000);
 
+describe("does not send a spurious content-type for empty/redirect/204/untyped-stream responses", () => {
+  const cases: Array<[string, () => Response]> = [
+    ["new Response()", () => new Response()],
+    ["Response.redirect()", () => Response.redirect("http://example.com/", 302)],
+    ["new Response(null, { status: 204 })", () => new Response(null, { status: 204 })],
+    ["new Response(null, { status: 302 })", () => new Response(null, { status: 302, headers: { location: "/x" } })],
+    [
+      "untyped ReadableStream",
+      () =>
+        new Response(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(new TextEncoder().encode("hi"));
+              c.close();
+            },
+          }),
+        ),
+    ],
+  ];
+  for (const [name, make] of cases) {
+    it(name, async () => {
+      using server = Bun.serve({ port: 0, fetch: () => make() });
+      const res = await fetch(server.url, { redirect: "manual" });
+      const contentType = res.headers.get("content-type");
+      await res.text().catch(() => {});
+      // Zig sends no content-type here; the Rust port wrote a spurious
+      // application/octet-stream because a `const` pointer-identity sentinel
+      // never matched the fallback MimeType.
+      expect(contentType).toBeNull();
+    });
+  }
+});
+
 it("propagates content-type from a Bun.file()'s file path in fetch()", async () => {
   const body = Bun.file(import.meta.dir + "/fetch.js.txt");
   const bodyText = await body.text();

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1367,11 +1367,15 @@ it("request body and signal life cycle", async () => {
   }
 }, 30_000);
 
-describe("does not send a spurious content-type for empty/redirect/204/untyped-stream responses", () => {
-  const cases: Array<[string, () => Response]> = [
+describe("content-type on detached/empty responses", () => {
+  // Zig sends no content-type here; the Rust port wrote a spurious
+  // application/octet-stream because a `const` pointer-identity sentinel
+  // never matched the fallback MimeType.
+  const suppressed: Array<[string, () => Response]> = [
     ["new Response()", () => new Response()],
     ["Response.redirect()", () => Response.redirect("http://example.com/", 302)],
     ["new Response(null, { status: 204 })", () => new Response(null, { status: 204 })],
+    ["new Response(null, { status: 304 })", () => new Response(null, { status: 304 })],
     ["new Response(null, { status: 302 })", () => new Response(null, { status: 302, headers: { location: "/x" } })],
     [
       "untyped ReadableStream",
@@ -1386,16 +1390,44 @@ describe("does not send a spurious content-type for empty/redirect/204/untyped-s
         ),
     ],
   ];
-  for (const [name, make] of cases) {
-    it(name, async () => {
+  for (const [name, make] of suppressed) {
+    it(`no spurious content-type for ${name}`, async () => {
       using server = Bun.serve({ port: 0, fetch: () => make() });
       const res = await fetch(server.url, { redirect: "manual" });
       const contentType = res.headers.get("content-type");
       await res.text().catch(() => {});
-      // Zig sends no content-type here; the Rust port wrote a spurious
-      // application/octet-stream because a `const` pointer-identity sentinel
-      // never matched the fallback MimeType.
       expect(contentType).toBeNull();
+    });
+  }
+
+  // An explicit content-type whose top-level category Bun doesn't recognize
+  // (MimeType::init falls through to Category::Other) must still be sent on
+  // an empty body — suppression targets the application/octet-stream
+  // *fallback*, not every Category::Other.
+  const preserved: Array<[string, () => Response, string]> = [
+    [
+      "empty Blob with multipart/form-data",
+      () => new Response(new Blob([], { type: "multipart/form-data" })),
+      "multipart/form-data",
+    ],
+    [
+      "empty Blob with model/gltf-binary",
+      () => new Response(new Blob([], { type: "model/gltf-binary" })),
+      "model/gltf-binary",
+    ],
+    [
+      "empty body with multipart/form-data header",
+      () => new Response(null, { headers: { "content-type": "multipart/form-data" } }),
+      "multipart/form-data",
+    ],
+  ];
+  for (const [name, make, expected] of preserved) {
+    it(`preserves explicit ${name}`, async () => {
+      using server = Bun.serve({ port: 0, fetch: () => make() });
+      const res = await fetch(server.url);
+      const contentType = res.headers.get("content-type");
+      await res.text().catch(() => {});
+      expect(contentType).toBe(expected);
     });
   }
 });


### PR DESCRIPTION
`new Response()`, `Response.redirect()`, `new Response(null, { status: 204/302/304 })`, and untyped streamed responses got a spurious `content-type: application/octet-stream`. Released Bun sends no content-type. This is non-conforming on 204/304 and can make a browser download a streamed HTML page instead of rendering it.

The suppression check ported Zig's comptime pointer-identity sentinel literally: `content_type.value.as_ptr() != MimeType::OTHER.value.as_ptr()`. Zig's `MimeType.other` is one comptime constant with a stable address, so the sentinel reliably means "this is the fallback → suppress". A Rust `const` has no stable address — the two `as_ptr()` evaluations differ, so the `!=` was always true and suppression never fired.

Compare the value bytes instead (`content_type.value.as_ref() != MimeType::OTHER.value.as_ref()`). `MimeType::init` returns the `OTHER` constant for `application/octet-stream`, so this matches Zig exactly (including the explicit-octet-stream-on-detached case) with no `const`-address fragility. Comparing by `Category::Other` alone would over-suppress: `MimeType::init` also maps unrecognized top-level types (`multipart/*`, `model/*`, `message/*`) to `Category::Other` while preserving the caller's value, so an explicit `multipart/form-data` on an empty Blob would be dropped.

Regression tests in `serve.test.ts` cover both directions: empty/redirect/204/302/304/untyped-stream → no content-type; empty Blob with `multipart/form-data` / `model/gltf-binary` → content-type preserved.
