### PR TITLE
shell: emit one argv word per brace variant, including empties

### DIFF
--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -341,9 +341,20 @@ impl Expansion {
 
         // Spec lines 268-279: push each variant as its own word. The Zig
         // version NUL-terminated then `out.pushResult`; the NodeId port
-        // records word boundaries via `bounds` instead.
-        for s in expanded {
-            if !me.out.buf.is_empty() {
+        // records word boundaries via `bounds` instead. A boundary is needed
+        // before every variant except the very first word in `out`, including
+        // empty (leading) variants — checking `!buf.is_empty()` per-iteration
+        // collapsed a run of empty variants (`{,,,}` produced 1 word instead
+        // of 4) because an empty variant never advances `buf`.
+        //
+        // `had_prior_word` is `!buf.is_empty()` alone: at this point `bounds`
+        // non-empty implies `buf` non-empty (every prior bounds-push gated on
+        // it and `buf` only grows), and `has_quoted_empty` tracks an empty
+        // prefix of the *current* word, not a separate prior word — folding
+        // it in would over-count `""{,a}`.
+        let had_prior_word = !me.out.buf.is_empty();
+        for (i, s) in expanded.into_iter().enumerate() {
+            if had_prior_word || i > 0 {
                 me.out.bounds.push(me.out.buf.len() as u32);
             }
             me.out.buf.extend_from_slice(&s);

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -165,3 +165,30 @@ console.log(JSON.stringify(Bun.$.braces("echo {a,b}")));`,
     expect(exitCode).toBe(0);
   });
 });
+
+// A brace expansion whose leading variants are empty must still emit one argv
+// word per variant. The shell collapsed a run of empty variants (`{,,,}` ->
+// 1 word instead of 4) because the word-boundary check used "buffer non-empty"
+// as a proxy for "a prior word exists", which is false when prior variants are
+// empty.
+describe("brace expansion emits one argv word per variant (including empty)", () => {
+  const cases: Array<[string, string]> = [
+    ["{,,,}", "[][][][]"],
+    ["{,a,b}", "[][a][b]"],
+    ["{,a}", "[][a]"],
+    ["{a,,b}", "[a][][b]"],
+    ["{a,b,}", "[a][b][]"],
+    ["x{,,}", "[x][x][x]"],
+    ["{,}y", "[y][y]"],
+    // A quoted-empty prefix is part of the *same* compound word, not a prior
+    // word in the output — `""{,a}` is 2 words, not 3.
+    ['""{,a}', "[][a]"],
+    ['""{,,}', "[][][]"],
+  ];
+  for (const [pattern, expected] of cases) {
+    test(pattern, async () => {
+      const out = await $`printf "[%s]" ${{ raw: pattern }}`.text();
+      expect(out).toBe(expected);
+    });
+  }
+});


### PR DESCRIPTION
A brace expansion whose leading variants are empty collapsed them into one argv word: `{,,,}` produced 1 word instead of 4 (`printf "[%s]" {,,,}` → `[]` instead of `[][][][]`), `{,a,b}` → `a b` instead of ` a b`, etc. Silent wrong argv, exit 0.

`do_brace_expand` records word boundaries in a `buf`/`bounds` model and pushed a boundary only `if !me.out.buf.is_empty()` — using "buffer non-empty" as a proxy for "a prior word exists". That proxy is false when prior variants are empty (an empty variant never advances `buf`), so a leading run of empty variants never recorded boundaries and collapsed to one word.

Mirror Zig's per-variant `out.pushResult`: push a boundary before every variant except the very first word in `out`, tracked with an explicit index plus a `had_prior_word` snapshot (`!out.buf.is_empty()` taken once before the loop — at that point `bounds` non-empty already implies `buf` non-empty, and `has_quoted_empty` belongs to the current compound word so must not count as a prior word; a `""{,a}` guard test pins that). Regression tests in `brace.test.ts`. (Note: the same per-iteration `!buf.is_empty()` proxy also appears at the `push_current_out` and glob-result sites — same latent class, left for a separate audit to keep this change scoped.)
