### PR TITLE
shell: glob brace-expanded patterns instead of dropping the glob

### DIFF
--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -61,7 +61,7 @@ extern "C" int uv_tty_reset_mode(void)
 
 static void uv__tty_make_raw(struct termios* tio)
 {
-    assert(tio != NULL);
+    ASSERT(tio != NULL);
 
 #if defined __sun || defined __MVS__
     /*

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -142,6 +142,13 @@ impl Expansion {
                 }
                 ExpansionState::BraceExpand => {
                     Self::do_brace_expand(me);
+                    // brace + glob composes: after pushing the literal brace
+                    // variants, glob the original pattern (Zig re-enters the
+                    // `.glob` state). The normal glob path likewise calls
+                    // `transition_to_glob_state` directly (see below).
+                    if matches!(me.state, ExpansionState::Glob) {
+                        return Self::transition_to_glob_state(interp, this);
+                    }
                     continue;
                 }
                 ExpansionState::Done | ExpansionState::Err(_) => break,
@@ -292,7 +299,6 @@ impl Expansion {
         // Spec lines 268-279: push each variant as its own word. The Zig
         // version NUL-terminated then `out.pushResult`; the NodeId port
         // records word boundaries via `bounds` instead.
-        me.current_out.clear();
         for s in expanded {
             if !me.out.buf.is_empty() {
                 me.out.bounds.push(me.out.buf.len() as u32);
@@ -302,15 +308,16 @@ impl Expansion {
 
         let node = me.node;
         let atom = node.get();
-        me.state = if atom.has_glob_expansion() {
-            // Spec: brace+glob composes — re-enter via the glob arm. The
-            // NodeId port currently routes glob through `current_out`, so
-            // brace-produced multi-word + glob is left as a TODO (matches the
-            // Zig "weird behaviour" note above the spec).
-            ExpansionState::Done
+        if atom.has_glob_expansion() {
+            // brace + glob composes (Zig re-enters the `.glob` state). Keep
+            // `current_out` (the original pattern, e.g. `src/*.{ts,tsx}`) so
+            // the glob walker brace-expands and globs it; its matches are
+            // appended after the literal brace variants already pushed above.
+            me.state = ExpansionState::Glob;
         } else {
-            ExpansionState::Done
-        };
+            me.current_out.clear();
+            me.state = ExpansionState::Done;
+        }
     }
 
     /// Spec: Expansion.zig `transitionToGlobState`. Kick off an off-thread

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -1,5 +1,6 @@
 import { $ } from "bun";
 import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
 
 describe("$.braces", () => {
   test("no-op", () => {
@@ -75,5 +76,33 @@ describe("$.braces", () => {
   test("unicode", () => {
     const result = $.braces(`lol {😂,🫵,🤣}`);
     expect(result).toEqual(["lol 😂", "lol 🫵", "lol 🤣"]);
+  });
+});
+
+// A shell word combining brace + glob (`src/*.{ts,tsx}`, `{src,lib}/*.ts`) was
+// brace-expanded but the resulting `*` patterns were never globbed (the
+// brace-expand state always transitioned to Done instead of re-entering glob).
+describe("brace + glob composition", () => {
+  test("src/*.{ts,tsx} globs after brace expansion", async () => {
+    using dir = tempDir("shell-brace-glob", {
+      "src/app.ts": "",
+      "src/util.tsx": "",
+    });
+    const out = (await $`echo src/*.{ts,tsx}`.cwd(String(dir)).text()).trim();
+    // Zig composes both the literal brace variants and the glob matches.
+    expect(out).toContain("src/app.ts");
+    expect(out).toContain("src/util.tsx");
+    expect(out).toContain("src/*.ts");
+    expect(out).toContain("src/*.tsx");
+  });
+
+  test("{src,lib}/*.ts composes a brace prefix with a glob", async () => {
+    using dir = tempDir("shell-brace-glob2", {
+      "src/a.ts": "",
+      "lib/b.ts": "",
+    });
+    const out = (await $`echo {src,lib}/*.ts`.cwd(String(dir)).text()).trim();
+    expect(out).toContain("src/a.ts");
+    expect(out).toContain("lib/b.ts");
   });
 });

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -88,12 +88,15 @@ describe("brace + glob composition", () => {
       "src/app.ts": "",
       "src/util.tsx": "",
     });
-    const out = (await $`echo src/*.{ts,tsx}`.cwd(String(dir)).text()).trim();
+    // The glob walker joins matched paths with the native separator on
+    // Windows, so normalize before asserting.
+    const out = (await $`echo src/*.{ts,tsx}`.cwd(String(dir)).text()).trim().replaceAll("\\", "/");
+    const words = out.split(" ");
     // Zig composes both the literal brace variants and the glob matches.
-    expect(out).toContain("src/app.ts");
-    expect(out).toContain("src/util.tsx");
-    expect(out).toContain("src/*.ts");
-    expect(out).toContain("src/*.tsx");
+    expect(words).toContain("src/app.ts");
+    expect(words).toContain("src/util.tsx");
+    expect(words).toContain("src/*.ts");
+    expect(words).toContain("src/*.tsx");
   });
 
   test("{src,lib}/*.ts composes a brace prefix with a glob", async () => {
@@ -101,8 +104,9 @@ describe("brace + glob composition", () => {
       "src/a.ts": "",
       "lib/b.ts": "",
     });
-    const out = (await $`echo {src,lib}/*.ts`.cwd(String(dir)).text()).trim();
-    expect(out).toContain("src/a.ts");
-    expect(out).toContain("lib/b.ts");
+    const out = (await $`echo {src,lib}/*.ts`.cwd(String(dir)).text()).trim().replaceAll("\\", "/");
+    const words = out.split(" ");
+    expect(words).toContain("src/a.ts");
+    expect(words).toContain("lib/b.ts");
   });
 });


### PR DESCRIPTION
A shell word combining brace + glob (`src/*.{ts,tsx}`, `{src,lib}/*.ts`, `rm -rf {dist,build}/*.js`) was brace-expanded but the resulting `*` patterns were never globbed. Silent, exit 0. Affects `Bun.$`, `--shell=bun`, bunfig `shell="bun"`, and Windows `bun run`.

`do_brace_expand` ended with `me.state = if has_glob_expansion() { Done } else { Done }` — both arms `Done`, the glob check a dead no-op (an in-source TODO admitted it). It also cleared `current_out`, which Zig keeps. Zig re-enters the `.glob` state after brace expansion, so the original pattern (e.g. `src/*.{ts,tsx}`) is globbed (the glob walker brace-expands and globs it) and its matches are appended after the literal brace variants.

When `has_glob_expansion()`, keep `current_out` and set state to `Glob`; the `BraceExpand` arm then dispatches `transition_to_glob_state` (the same call the normal glob path makes). Output is now byte-identical to released Bun: `echo src/*.{ts,tsx}` → `src/*.ts src/*.tsx src/app.ts src/util.tsx`. Regression test in `brace.test.ts` with a temp fixture.