### PR TITLE
install: support certfile and keyfile from .npmrc for client TLS auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,6 @@ test/integration/bun-types/fixture/bun.lock
 src/runtime/bake/generated.ts
 /target/
 *.heapsnapshot
+.zed/
+.opencode/
+.tool-versions

--- a/docs/pm/npmrc.mdx
+++ b/docs/pm/npmrc.mdx
@@ -195,6 +195,10 @@ These options can be combined with other authentication options like `_authToken
 //my-registry.example.com/:_authToken=${NPM_TOKEN}
 ```
 
+**Supported formats:** Certificate and key files must be in PEM format, the default and most common format. DER format is not supported.
+
+**Security note:** Protect your `keyfile` (and any private keys) with appropriate filesystem permissions. Restrict access to the owner only (e.g., `chmod 600`), validate file ownership, avoid storing keys in version control, and prefer secure stores or OS keyrings when possible.
+
 ### `omit` and `include`: Control dependency types
 
 Control which dependency types are installed:

--- a/docs/pm/npmrc.mdx
+++ b/docs/pm/npmrc.mdx
@@ -73,6 +73,8 @@ The following options are supported:
 - `_password` (base64 encoded password)
 - `_auth` (base64 encoded username:password, e.g. `btoa(username + ":" + password)`)
 - `email`
+- `certfile` (path to client certificate file for mutual TLS authentication)
+- `keyfile` (path to client private key file for mutual TLS authentication)
 
 The equivalent `bunfig.toml` option is to add a key in [`install.scopes`](/runtime/bunfig#install-registry):
 
@@ -173,6 +175,24 @@ ca[]="-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
 
 # or specify a path to a CA file
 cafile=/path/to/ca-bundle.crt
+```
+
+### `certfile` and `keyfile`: Client certificate authentication
+
+Configure client certificate and private key for mutual TLS authentication with a registry. This is useful for registries that require client certificates for authentication, such as private corporate registries.
+
+```ini .npmrc icon="npm"
+//my-registry.example.com/:certfile=/path/to/client-cert.pem
+//my-registry.example.com/:keyfile=/path/to/client-key.pem
+```
+
+These options can be combined with other authentication options like `_authToken`:
+
+```ini .npmrc icon="npm"
+@myorg:registry=https://my-registry.example.com/
+//my-registry.example.com/:certfile=/path/to/client-cert.pem
+//my-registry.example.com/:keyfile=/path/to/client-key.pem
+//my-registry.example.com/:_authToken=${NPM_TOKEN}
 ```
 
 ### `omit` and `include`: Control dependency types

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -575,6 +575,7 @@ impl<'a> AsyncHTTP<'a> {
         http_proxy: Option<URL<'a>>,
         hostname: Option<&'a [u8]>,
         redirect_type: FetchRedirect,
+        tls_props: Option<SSLConfigSharedPtr>,
     ) -> AsyncHTTP<'a> {
         Self::init(
             method,
@@ -589,6 +590,7 @@ impl<'a> AsyncHTTP<'a> {
             Options {
                 http_proxy,
                 hostname,
+                tls_props,
                 ..Options::default()
             },
         )

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -1673,22 +1673,6 @@ mod draft {
                     //
                     // Scoped registries are set like this:
                     // - @myorg:registry=https://somewhere-else.com/myorg
-                    let conf_item: &ConfigItem = &conf_item_;
-                    match conf_item.optname {
-                        ConfigOpt::Certfile | ConfigOpt::Keyfile => {
-                            iter.log.add_warning_fmt(
-                            Some(source),
-                            iter.config.properties.at(iter.prop_idx - 1).key.as_ref().unwrap().loc,
-                            format_args!(
-                                "The following .npmrc registry option was not applied:\n\n  <b>{}<r>\n\nBecause we currently don't support the <b>{}<r> option.",
-                                conf_item,
-                                <&'static str>::from(conf_item.optname),
-                            ),
-                        );
-                            continue;
-                        }
-                        _ => {}
-                    }
                     if let Some(x) = conf_item_.dupe()? {
                         configs.push(x);
                     }
@@ -1717,6 +1701,8 @@ mod draft {
                                     .as_bytes(),
                             ),
                             email: Box::default(),
+                            certfile: Box::default(),
+                            keyfile: Box::default(),
                         });
                         install.default_registry.as_mut().unwrap()
                     };
@@ -1745,7 +1731,16 @@ mod draft {
                                 v.email = x;
                             }
                         }
-                        ConfigOpt::Certfile | ConfigOpt::Keyfile => unreachable!(),
+                        ConfigOpt::Certfile => {
+                            if let Some(x) = conf_item.dupe_value_decoded(log, source)? {
+                                v.certfile = x;
+                            }
+                        }
+                        ConfigOpt::Keyfile => {
+                            if let Some(x) = conf_item.dupe_value_decoded(log, source)? {
+                                v.keyfile = x;
+                            }
+                        }
                     }
                 }
 
@@ -1797,7 +1792,16 @@ mod draft {
                                     v.email = x;
                                 }
                             }
-                            ConfigOpt::Certfile | ConfigOpt::Keyfile => unreachable!(),
+                            ConfigOpt::Certfile => {
+                                if let Some(x) = conf_item.dupe_value_decoded(log, source)? {
+                                    v.certfile = x;
+                                }
+                            }
+                            ConfigOpt::Keyfile => {
+                                if let Some(x) = conf_item.dupe_value_decoded(log, source)? {
+                                    v.keyfile = x;
+                                }
+                            }
                         }
                         // We have to keep going as it could match multiple scopes
                         continue;

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -11,6 +11,28 @@ use bun_ast::{Loc, Log, Source};
 
 type OOM<T> = Result<T, AllocError>;
 
+/// Resolve `value` (a certfile/keyfile path) relative to the `.npmrc` directory.
+/// If `value` is already absolute, return it unchanged.
+pub(crate) fn resolve_relative_npmrc_path(npmrc_path: &[u8], value: Box<[u8]>) -> Box<[u8]> {
+    if value.is_empty() {
+        return value;
+    }
+    // Absolute on POSIX starts with `/`; on Windows starts with a drive letter + colon
+    if value[0] == b'/' || (value.len() > 2 && value[1] == b':') {
+        return value;
+    }
+    match bun_core::dirname(npmrc_path) {
+        Some(dir) => {
+            let mut resolved = Vec::with_capacity(dir.len() + 1 + value.len());
+            resolved.extend_from_slice(dir);
+            resolved.push(b'/');
+            resolved.extend_from_slice(&value);
+            resolved.into_boxed_slice()
+        }
+        None => value,
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // Options
 // ──────────────────────────────────────────────────────────────────────────
@@ -251,7 +273,7 @@ mod draft {
 
     use super::{
         ConfigItem, ConfigOpt, IniOption, NODE_LINKER_MAP, NodeLinker, Options, is_quoted,
-        next_dot, should_skip_line,
+        next_dot, resolve_relative_npmrc_path, should_skip_line,
     };
 
     type OOM<T> = Result<T, AllocError>;
@@ -1733,12 +1755,12 @@ mod draft {
                         }
                         ConfigOpt::Certfile => {
                             if let Some(x) = conf_item.dupe_value_decoded(log, source)? {
-                                v.certfile = x;
+                                v.certfile = resolve_relative_npmrc_path(npmrc_path.as_bytes(), x);
                             }
                         }
                         ConfigOpt::Keyfile => {
                             if let Some(x) = conf_item.dupe_value_decoded(log, source)? {
-                                v.keyfile = x;
+                                v.keyfile = resolve_relative_npmrc_path(npmrc_path.as_bytes(), x);
                             }
                         }
                     }
@@ -1794,12 +1816,12 @@ mod draft {
                             }
                             ConfigOpt::Certfile => {
                                 if let Some(x) = conf_item.dupe_value_decoded(log, source)? {
-                                    v.certfile = x;
+                                    v.certfile = resolve_relative_npmrc_path(npmrc_path.as_bytes(), x);
                                 }
                             }
                             ConfigOpt::Keyfile => {
                                 if let Some(x) = conf_item.dupe_value_decoded(log, source)? {
-                                    v.keyfile = x;
+                                    v.keyfile = resolve_relative_npmrc_path(npmrc_path.as_bytes(), x);
                                 }
                             }
                         }

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -833,7 +833,17 @@ impl NetworkTask {
         // the identical pattern in `for_manifest` above.
         let url = URL::parse(unsafe { bun_ptr::detach_lifetime(&self.url_buf) });
 
-        let tls_props = npm::registry::registry_tls_config(scope);
+        let tls_props = {
+            let registry = scope.url.url();
+            if url.protocol == registry.protocol
+                && url.hostname == registry.hostname
+                && url.get_port_auto() == registry.get_port_auto()
+            {
+                npm::registry::registry_tls_config(scope)
+            } else {
+                None
+            }
+        };
 
         let mut http_options = AsyncHTTPOptions {
             http_proxy: pm.http_proxy(&url),

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -629,6 +629,7 @@ impl NetworkTask {
         // `headers_buf` / `last_modified` now alias.
         let _ = ManuallyDrop::new(core::mem::take(&mut header_builder.content));
         let completion_callback = self.get_completion_callback();
+        let tls_props = npm::registry::registry_tls_config(scope);
         // TODO(port): narrow error set
         // PORT NOTE: MaybeUninit overwrite — see field doc; old slot value is
         // either uninitialized (fresh hive slot) or a stale bitwise copy from
@@ -644,6 +645,7 @@ impl NetworkTask {
             http::FetchRedirect::Follow,
             AsyncHTTPOptions {
                 http_proxy,
+                tls_props,
                 ..Default::default()
             },
         ));
@@ -831,8 +833,11 @@ impl NetworkTask {
         // the identical pattern in `for_manifest` above.
         let url = URL::parse(unsafe { bun_ptr::detach_lifetime(&self.url_buf) });
 
+        let tls_props = npm::registry::registry_tls_config(scope);
+
         let mut http_options = AsyncHTTPOptions {
             http_proxy: pm.http_proxy(&url),
+            tls_props,
             ..Default::default()
         };
 

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -6,7 +6,7 @@ use crate::bun_schema::api;
 use bun_alloc::AllocError;
 use bun_collections::{HashMap, StringSet};
 use bun_core::{Error, Global, Output, err, fmt as bun_fmt};
-use bun_core::{MutableString, strings};
+use bun_core::{MutableString, strings, dupe_z};
 use bun_dotenv::Loader as DotEnv;
 use bun_http::{self as http, AsyncHTTP, HeaderBuilder};
 use bun_picohttp as picohttp;
@@ -153,6 +153,8 @@ pub fn whoami(manager: &mut PackageManager) -> Result<Vec<u8>, WhoamiError> {
     // `&[]` when unallocated, matching the previous `None => b""` arm).
     let header_buf: &[u8] = headers.content.written_slice();
 
+    let tls_props = registry::registry_tls_config(registry);
+
     let mut req = AsyncHTTP::init_sync(
         http::Method::GET,
         url,
@@ -163,6 +165,7 @@ pub fn whoami(manager: &mut PackageManager) -> Result<Vec<u8>, WhoamiError> {
         None,
         None,
         http::FetchRedirect::Follow,
+        tls_props,
     );
 
     let res = match req.send_sync() {
@@ -308,6 +311,10 @@ pub mod registry {
 
         // username and password combo, `user:pass`
         pub user: Box<[u8]>,
+
+        // client TLS certificate paths for registry authentication
+        pub certfile: Box<[u8]>,
+        pub keyfile: Box<[u8]>,
     }
 
     impl Scope {
@@ -511,11 +518,32 @@ pub mod registry {
                 token: registry.token,
                 auth,
                 user,
+                certfile: registry.certfile,
+                keyfile: registry.keyfile,
             })
         }
     }
 
-    // TODO(port): Zig used `IdentityContext(u64)` hasher; std HashMap is fine for now.
+// TODO(port): Zig used `IdentityContext(u64)` hasher; std HashMap is fine for now.
+
+    pub fn registry_tls_config(registry: &Scope) -> Option<http::ssl_config::SharedPtr> {
+        let certfile = &registry.certfile;
+        let keyfile = &registry.keyfile;
+
+        if certfile.is_empty() && keyfile.is_empty() {
+            return None;
+        }
+
+        let mut config = http::ssl_config::SSLConfig::default();
+        if !certfile.is_empty() {
+            config.cert_file_name = dupe_z(certfile);
+        }
+        if !keyfile.is_empty() {
+            config.key_file_name = dupe_z(keyfile);
+        }
+        Some(http::ssl_config::SharedPtr::new(config))
+    }
+
     pub type Map = HashMap<u64, Scope>;
 
     pub(crate) enum PackageVersionResponse {
@@ -3427,3 +3455,48 @@ impl PackageManifest {
 }
 
 // ported from: src/install/npm.zig
+
+#[cfg(test)]
+mod tests {
+    use super::registry::{registry_tls_config, Scope};
+
+    #[test]
+    fn test_registry_tls_config_empty() {
+        let scope = Scope::default();
+        assert!(registry_tls_config(&scope).is_none());
+    }
+
+    #[test]
+    fn test_registry_tls_config_certfile_only() {
+        let mut scope = Scope::default();
+        scope.certfile = Box::from(&b"/path/to/cert.pem"[..]);
+        let result = registry_tls_config(&scope);
+        assert!(result.is_some());
+        let config = result.unwrap();
+        assert!(!config.cert_file_name.is_null());
+        assert!(config.key_file_name.is_null());
+    }
+
+    #[test]
+    fn test_registry_tls_config_keyfile_only() {
+        let mut scope = Scope::default();
+        scope.keyfile = Box::from(&b"/path/to/key.pem"[..]);
+        let result = registry_tls_config(&scope);
+        assert!(result.is_some());
+        let config = result.unwrap();
+        assert!(config.cert_file_name.is_null());
+        assert!(!config.key_file_name.is_null());
+    }
+
+    #[test]
+    fn test_registry_tls_config_both() {
+        let mut scope = Scope::default();
+        scope.certfile = Box::from(&b"/path/to/cert.pem"[..]);
+        scope.keyfile = Box::from(&b"/path/to/key.pem"[..]);
+        let result = registry_tls_config(&scope);
+        assert!(result.is_some());
+        let config = result.unwrap();
+        assert!(!config.cert_file_name.is_null());
+        assert!(!config.key_file_name.is_null());
+    }
+}

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -493,6 +493,9 @@ pub mod registry {
 
             registry.token = env.get_auto(&registry.token).into();
 
+            registry.certfile = env.get_auto(&registry.certfile).into();
+            registry.keyfile = env.get_auto(&registry.keyfile).into();
+
             // Copy `auth`/`user` into owned buffers now so the borrows of
             // `registry_url` / `output_buf_owned` are released before
             // `registry_url` is moved into `final_href` below.

--- a/src/install_jsc/ini_jsc.rs
+++ b/src/install_jsc/ini_jsc.rs
@@ -122,10 +122,14 @@ impl IniTestingAPIs {
             default_registry_username,
             default_registry_password,
             default_registry_email,
+            default_registry_certfile,
+            default_registry_keyfile,
         ) = 'brk: {
             let Some(default_registry) = install.default_registry.as_ref() else {
                 break 'brk (
                     BunString::static_(Registry::DEFAULT_URL),
+                    BunString::empty(),
+                    BunString::empty(),
                     BunString::empty(),
                     BunString::empty(),
                     BunString::empty(),
@@ -139,6 +143,8 @@ impl IniTestingAPIs {
                 BunString::from_bytes(&default_registry.username),
                 BunString::from_bytes(&default_registry.password),
                 BunString::from_bytes(&default_registry.email),
+                BunString::from_bytes(&default_registry.certfile),
+                BunString::from_bytes(&default_registry.keyfile),
             )
         };
         // `defer { *.deref() }` deleted — bun_core::String impls Drop.
@@ -154,9 +160,11 @@ impl IniTestingAPIs {
             default_registry_username: BunString,
             default_registry_password: BunString,
             default_registry_email: BunString,
+            default_registry_certfile: BunString,
+            default_registry_keyfile: BunString,
         }
         impl bun_jsc::js_object::PojoFields for Pojo {
-            const FIELD_COUNT: usize = 5;
+            const FIELD_COUNT: usize = 7;
             fn put_fields(
                 &self,
                 global: &JSGlobalObject,
@@ -182,6 +190,14 @@ impl IniTestingAPIs {
                     b"default_registry_email",
                     self.default_registry_email.to_js(global)?,
                 )?;
+                put(
+                    b"default_registry_certfile",
+                    self.default_registry_certfile.to_js(global)?,
+                )?;
+                put(
+                    b"default_registry_keyfile",
+                    self.default_registry_keyfile.to_js(global)?,
+                )?;
                 Ok(())
             }
         }
@@ -191,6 +207,8 @@ impl IniTestingAPIs {
             default_registry_username,
             default_registry_password,
             default_registry_email,
+            default_registry_certfile,
+            default_registry_keyfile,
         };
         Ok(bun_jsc::JSObject::create(&pojo, global)?.to_js())
     }

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -231,6 +231,10 @@ pub mod api {
         pub token: Box<[u8]>,
         /// email
         pub email: Box<[u8]>,
+        /// path to certificate file for client TLS authentication
+        pub certfile: Box<[u8]>,
+        /// path to key file for client TLS authentication
+        pub keyfile: Box<[u8]>,
     }
 
     impl NpmRegistry {

--- a/src/runtime/cli/audit_command.rs
+++ b/src/runtime/cli/audit_command.rs
@@ -8,6 +8,7 @@ use bun_core::{Global, Output, pretty, prettyln};
 use bun_core::{MutableString, strings};
 use bun_http::{self as http, HeaderBuilder};
 use bun_install::lockfile::package::PackageColumns as _;
+use bun_install::npm::registry::registry_tls_config;
 use bun_install::package_manager_real::command_line_arguments::AuditLevel;
 use bun_install::resolution::Tag as ResolutionTag;
 use bun_install::{CommandLineArguments, PackageManager, Subcommand};
@@ -488,6 +489,7 @@ fn send_audit_request(
     let url = URL::parse(&url_str);
 
     let http_proxy = pm.http_proxy(&url);
+    let tls_props = registry_tls_config(&pm.options.scope);
 
     // PORT NOTE: Zig passed `headers.content.ptr.?[0..headers.content.len]`.
     let headers_buf: &[u8] = headers.content.written_slice();
@@ -506,6 +508,7 @@ fn send_audit_request(
         http_proxy,
         None,
         http::FetchRedirect::Follow,
+        tls_props,
     );
     let res = match req.send_sync() {
         Ok(r) => r,

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -2333,6 +2333,7 @@ impl Example {
             http_proxy,
             None,
             HTTP::FetchRedirect::Follow,
+            None,
         ));
         async_http.client.progress_node = Some(core::ptr::NonNull::from(&mut *progress));
         async_http.client.flags.reject_unauthorized = env_loader.get_tls_reject_unauthorized();
@@ -2435,6 +2436,7 @@ impl Example {
                 http_proxy,
                 None,
                 HTTP::FetchRedirect::Follow,
+                None,
             ));
         async_http.client.progress_node = Some(core::ptr::NonNull::from(&mut *progress));
         async_http.client.flags.reject_unauthorized = env_loader.get_tls_reject_unauthorized();
@@ -2533,6 +2535,7 @@ impl Example {
             http_proxy,
             None,
             HTTP::FetchRedirect::Follow,
+            None,
         );
         async_http.client.progress_node = Some(core::ptr::NonNull::from(&mut *progress));
         async_http.client.flags.reject_unauthorized = env_loader.get_tls_reject_unauthorized();
@@ -2580,6 +2583,7 @@ impl Example {
             http_proxy,
             None,
             HTTP::FetchRedirect::Follow,
+            None,
         ));
         async_http.client.flags.reject_unauthorized = env_loader.get_tls_reject_unauthorized();
 

--- a/src/runtime/cli/pm_view_command.rs
+++ b/src/runtime/cli/pm_view_command.rs
@@ -8,7 +8,7 @@ use bun_core::{Global, Output, prettyln};
 use bun_http as http;
 use bun_install::PackageManager;
 use bun_install::dependency;
-use bun_install::npm::{self, PackageManifest};
+use bun_install::npm::{self, registry::registry_tls_config, PackageManifest};
 use bun_js_parser as ast;
 use bun_js_printer as JSPrinter;
 use bun_parsers::json as JSON;
@@ -123,6 +123,7 @@ pub(crate) fn view(
     let mut response_buf = MutableString::init(2048)?;
     let header_buf: &[u8] = headers.content.written_slice();
     let http_proxy = manager.http_proxy(&url);
+    let tls_props = registry_tls_config(&scope);
     let mut req = http::AsyncHTTP::init_sync(
         http::Method::GET,
         url,
@@ -133,6 +134,7 @@ pub(crate) fn view(
         http_proxy,
         None,
         http::FetchRedirect::Follow,
+        tls_props,
     );
     req.client.flags.reject_unauthorized = manager.tls_reject_unauthorized();
 

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -11,6 +11,7 @@ use bun_core::{ZStr, strings};
 use bun_dotenv as dotenv;
 use bun_http as http;
 use bun_install::lockfile::{LoadResult, LoadStep};
+use bun_install::npm::registry::registry_tls_config;
 use bun_install::{self as install, Lockfile, Npm, PackageManager, Subcommand};
 use bun_libarchive::lib::{Archive, ArchiveIterator, IteratorResult as ArchiveIterResult};
 use bun_parsers::json as json_mod;
@@ -857,6 +858,7 @@ impl PublishCommand {
             None,
             None,
             http::FetchRedirect::Follow,
+            registry_tls_config(registry),
         );
 
         let Ok(res) = req.send_sync() else {
@@ -983,6 +985,7 @@ impl PublishCommand {
             None,
             None,
             http::FetchRedirect::Follow,
+            registry_tls_config(registry),
         );
 
         let res = match req.send_sync() {
@@ -1080,6 +1083,7 @@ impl PublishCommand {
                     None,
                     None,
                     http::FetchRedirect::Follow,
+                    registry_tls_config(registry),
                 );
 
                 let otp_res = match otp_req.send_sync() {
@@ -1305,6 +1309,7 @@ impl PublishCommand {
                         None,
                         None,
                         http::FetchRedirect::Follow,
+                        registry_tls_config(registry),
                     );
 
                     let res = match req.send_sync() {

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -283,6 +283,7 @@ impl UpgradeCommand {
             http_proxy,
             None,
             HTTP::FetchRedirect::Follow,
+            None,
         ));
         async_http.client.flags.reject_unauthorized = env_loader.get_tls_reject_unauthorized();
 
@@ -682,6 +683,7 @@ impl UpgradeCommand {
                 http_proxy,
                 None,
                 HTTP::FetchRedirect::Follow,
+                None,
             ));
             // `progress` is leaked; AsyncHTTP holds a NonNull into it.
             async_http.client.progress_node =

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1589,6 +1589,7 @@ pub(crate) fn download_to_path(
                 http_proxy,
                 None,
                 bun_http::FetchRedirect::Follow,
+                None,
             ));
             async_http.client.progress_node =
                 core::ptr::NonNull::new(core::ptr::from_mut(progress));

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -1774,3 +1774,40 @@ impl<'a> Scanner<'a> {
 }
 
 // ported from: src/url/url.zig
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_host_vs_hostname_with_explicit_port() {
+        let url = URL::parse(b"https://registry.example.com:443/pkg");
+        assert_eq!(url.hostname, b"registry.example.com");
+        assert_eq!(url.host, b"registry.example.com:443");
+        assert_eq!(url.get_port_auto(), 443);
+    }
+
+    #[test]
+    fn test_host_vs_hostname_without_port() {
+        let url = URL::parse(b"https://registry.example.com/pkg");
+        assert_eq!(url.hostname, b"registry.example.com");
+        assert_eq!(url.host, b"registry.example.com");
+        assert_eq!(url.get_port_auto(), 443);
+    }
+
+    #[test]
+    fn test_same_origin_hostname_plus_port_matches() {
+        let explicit = URL::parse(b"https://registry.example.com:443/pkg-1.0.0.tgz");
+        let implicit = URL::parse(b"https://registry.example.com/pkg");
+        assert!(explicit.protocol == implicit.protocol);
+        assert!(explicit.hostname == implicit.hostname);
+        assert!(explicit.get_port_auto() == implicit.get_port_auto());
+    }
+
+    #[test]
+    fn test_same_origin_host_mismatch_with_explicit_port() {
+        let explicit = URL::parse(b"https://registry.example.com:443/pkg-1.0.0.tgz");
+        let implicit = URL::parse(b"https://registry.example.com/pkg");
+        assert_ne!(explicit.host, implicit.host);
+    }
+}

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -533,4 +533,13 @@ registry=https://my-registry.example.com/
     expect(result.default_registry_certfile).toEqual("/path/to/cert.pem");
     expect(result.default_registry_keyfile).toEqual("");
   });
+
+  test("keyfile without certfile is parsed", () => {
+    const ini = `
+//registry.npmjs.org/:keyfile=/path/to/key.pem
+`;
+    const result = loadNpmrc(ini);
+    expect(result.default_registry_certfile).toEqual("");
+    expect(result.default_registry_keyfile).toEqual("/path/to/key.pem");
+  });
 });

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -493,4 +493,44 @@ registry=https://somehost.com/org1/npm/registry/
     // Should be empty since there's no matching token for /org1/npm/registry/
     expect(result.default_registry_token).toBe("");
   });
+
+  test("certfile and keyfile are parsed for default registry", () => {
+    const ini = `
+//registry.npmjs.org/:certfile=/path/to/cert.pem
+//registry.npmjs.org/:keyfile=/path/to/key.pem
+`;
+    const result = loadNpmrc(ini);
+    expect(result.default_registry_certfile).toEqual("/path/to/cert.pem");
+    expect(result.default_registry_keyfile).toEqual("/path/to/key.pem");
+  });
+
+  test("certfile and keyfile are empty by default", () => {
+    const ini = ``;
+    const result = loadNpmrc(ini);
+    expect(result.default_registry_certfile).toEqual("");
+    expect(result.default_registry_keyfile).toEqual("");
+  });
+
+  test("certfile and keyfile work with custom registry", () => {
+    const ini = `
+registry=https://my-registry.example.com/
+//my-registry.example.com/:certfile=/etc/ssl/client-cert.pem
+//my-registry.example.com/:keyfile=/etc/ssl/client-key.pem
+//my-registry.example.com/:_authToken=my-token
+`;
+    const result = loadNpmrc(ini);
+    expect(result.default_registry_url).toEqual("https://my-registry.example.com/");
+    expect(result.default_registry_certfile).toEqual("/etc/ssl/client-cert.pem");
+    expect(result.default_registry_keyfile).toEqual("/etc/ssl/client-key.pem");
+    expect(result.default_registry_token).toEqual("my-token");
+  });
+
+  test("certfile without keyfile is parsed", () => {
+    const ini = `
+//registry.npmjs.org/:certfile=/path/to/cert.pem
+`;
+    const result = loadNpmrc(ini);
+    expect(result.default_registry_certfile).toEqual("/path/to/cert.pem");
+    expect(result.default_registry_keyfile).toEqual("");
+  });
 });


### PR DESCRIPTION
## Summary

Bun now reads `certfile` and `keyfile` options from `.npmrc` and uses them to configure client certificate authentication when connecting to npm registries over HTTPS (mutual TLS / mTLS).

Previously these options were parsed but silently ignored with a warning. Now they are passed through to the HTTP client's SSL configuration.

### Supported syntax (matches [npm docs](https://docs.npmjs.com/cli/v10/configuring-npm/npmrc#auth-related-configuration))

```ini
//registry.example.com/:certfile=/path/to/cert.pem
//registry.example.com/:keyfile=/path/to/key.pem
```

Per-scope:
```ini
@myorg:registry=https://registry.example.com/
//registry.example.com/:certfile=/path/to/cert.pem
//registry.example.com/:keyfile=/path/to/key.pem
//registry.example.com/:_authToken=${NPM_TOKEN}
```

## Changes

### Data structures
- `NpmRegistry` (`options_types/schema.rs`) — added `certfile`, `keyfile` fields
- `Scope` (`install/npm.rs`) — added `certfile`, `keyfile` fields, transferred from `NpmRegistry` in `from_api`

### Parser
- `ini/lib.rs` — removed "we currently don't support" warning, added `Certfile`/`Keyfile` handling for both default and scoped registries

### HTTP client
- `AsyncHTTP::init_sync` — added `tls_props` parameter
- `registry::registry_tls_config()` — public helper that creates `SSLConfig` from certfile/keyfile paths

### CLI commands with TLS from registry
- `pm_view_command.rs` — `registry_tls_config(&scope)`
- `audit_command.rs` — `registry_tls_config(&pm.options.scope)`
- `publish_command.rs` — `registry_tls_config(registry)` (4 calls)
- `npm.rs` whoami — `registry::registry_tls_config(registry)`
- `NetworkTask.rs` — `registry_tls_config(scope)` in `for_manifest` and `for_tarball`

### CLI commands with `None` (not npm registry)
- `upgrade_command.rs`, `create_command.rs`, `StandaloneModuleGraph.rs`

### Tests
- Rust unit tests for `registry_tls_config` (empty, certfile-only, keyfile-only, both)
- TS tests for `loadNpmrc` certfile/keyfile parsing (4 tests)
- `loadNpmrc` test API (`ini_jsc.rs`) extended with certfile/keyfile fields

### Docs
- `docs/pm/npmrc.mdx` — new section for `certfile` and `keyfile` with examples

## Test plan
- [x] `cargo check -p bun_bin` passes
- [ ] `bun bd test test/cli/install/npmrc.test.ts` (requires verdaccio)