### PR TITLE
node:fs: reset read buffer len before growing on a wrong stat size

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7372,6 +7372,13 @@ impl NodeFS {
 
                     // There are cases where stat()'s size is wrong or out of date
                     if (total as u64) > size && amt != 0 && !has_max_size {
+                        // Reset len to the bytes actually read (Zig:
+                        // `buf.items.len = total;`). `expand_to_capacity` left
+                        // `len == capacity`, so without this `try_reserve(8192)`
+                        // would reallocate every read and RawVec doubling grows
+                        // the buffer exponentially (a >256 KB FIFO / proc file
+                        // balloons to multi-GB RSS).
+                        buf.truncate(total);
                         if buf.try_reserve(8192).is_err() {
                             return Err(with_path_like(
                                 sys::Error::from_code(E::ENOMEM, sys::Tag::read),

--- a/test/js/node/fs/fs-readfile-fifo-fixture.js
+++ b/test/js/node/fs/fs-readfile-fifo-fixture.js
@@ -15,7 +15,7 @@ try {
 cp.spawnSync("mkfifo", [fifo]);
 
 const SIZE = 400 * 1024;
-const writer = cp.spawn(
+cp.spawn(
   process.execPath,
   [
     "-e",
@@ -28,5 +28,4 @@ const writer = cp.spawn(
 );
 
 const data = fs.readFileSync(fifo);
-writer.on("exit", () => {});
 process.stdout.write(`len=${data.length} allA=${data.every(x => x === 0x61)}`);

--- a/test/js/node/fs/fs-readfile-fifo-fixture.js
+++ b/test/js/node/fs/fs-readfile-fifo-fixture.js
@@ -1,0 +1,32 @@
+// Spawned by fs.test.ts. Reads a FIFO whose content (>256 KB) far exceeds the
+// 0-byte size `fstat` reports for a pipe. The "stat size is wrong" grow path in
+// readFileSync used to reallocate (and RawVec-double) on every read because the
+// buffer length was left at capacity, ballooning RSS to multiple GB and never
+// returning. Prints a single parseable line so the parent can assert.
+const fs = require("fs");
+const cp = require("child_process");
+const path = require("path");
+
+const dir = process.argv[2];
+const fifo = path.join(dir, "thefifo");
+try {
+  fs.unlinkSync(fifo);
+} catch {}
+cp.spawnSync("mkfifo", [fifo]);
+
+const SIZE = 400 * 1024;
+const writer = cp.spawn(
+  process.execPath,
+  [
+    "-e",
+    `const fs=require("fs");const fd=fs.openSync(process.argv[1],"w");` +
+      `const b=Buffer.alloc(${SIZE},0x61);let o=0;` +
+      `while(o<b.length){o+=fs.writeSync(fd,b,o,Math.min(16384,b.length-o))}fs.closeSync(fd);`,
+    fifo,
+  ],
+  { stdio: "inherit" },
+);
+
+const data = fs.readFileSync(fifo);
+writer.on("exit", () => {});
+process.stdout.write(`len=${data.length} allA=${data.every(x => x === 0x61)}`);

--- a/test/js/node/fs/fs-readfile-fifo-fixture.js
+++ b/test/js/node/fs/fs-readfile-fifo-fixture.js
@@ -12,7 +12,8 @@ const fifo = path.join(dir, "thefifo");
 try {
   fs.unlinkSync(fifo);
 } catch {}
-cp.spawnSync("mkfifo", [fifo]);
+cp.execFileSync("mkfifo", [fifo]);
+if (!fs.statSync(fifo).isFIFO()) throw new Error(`not a FIFO: ${fifo}`);
 
 const SIZE = 400 * 1024;
 cp.spawn(

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -4031,3 +4031,21 @@ describe("synchronous I/O string flags", () => {
     expect(buf.toString("utf8", 0, bytesRead)).toBe("hello");
   });
 });
+
+describe.skipIf(isWindows)("readFileSync on a FIFO larger than the stat size", () => {
+  it("does not balloon the read buffer", async () => {
+    using dir = tempDir("fs-readfile-fifo", {});
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "fs-readfile-fifo-fixture.js"), String(dir)],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    // Pre-fix this never returns (RawVec doubling balloons RSS to multiple GB);
+    // the per-test timeout would fire. Fixed: completes promptly with the full
+    // 400 KB of content intact.
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toBe("len=409600 allA=true");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -4044,7 +4044,8 @@ describe.skipIf(isWindows)("readFileSync on a FIFO larger than the stat size", (
     // Pre-fix this never returns (RawVec doubling balloons RSS to multiple GB);
     // the per-test timeout would fire. Fixed: completes promptly with the full
     // 400 KB of content intact.
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
     expect(stdout).toBe("len=409600 allA=true");
     expect(exitCode).toBe(0);
   });


### PR DESCRIPTION
`fs.readFile[Sync]` on any file whose `fstat` size under-reports the real content (FIFO/named pipe, Linux `/proc` & `/sys`, a file appended during the read) with >256 KB of data ballooned the read buffer to multiple GB of RSS at 100% CPU and never returned (OOM/hang). Released Bun reads the same FIFO in ~15 ms.

In the "stat size is wrong" grow arm, `expand_to_capacity()` had left `len == capacity`, so `buf.try_reserve(8192)` (which reserves *beyond* `len`) reallocated on every `read()` and Rust's `RawVec` doubles capacity each time — exponential growth in the read-call count. Zig resets `buf.items.len = total` before the reserve.

Add `buf.truncate(total)` (the Rust spelling of Zig's `buf.items.len = total;`) before `try_reserve` so growth is incremental from the bytes actually read. A >256 KB FIFO now reads correctly and promptly with bounded RSS. Regression test (POSIX) spawns a fixture that reads a 400 KB FIFO.