### PR TITLE
mysql: consume 4 bytes for INT24/MEDIUMINT binary field

### DIFF
--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -6,6 +6,7 @@
 #include <wtf/dtoa.h>
 #include <wtf/NumberOfCores.h>
 #include <atomic>
+#include <cassert>
 
 #include "wtf/SIMDUTF.h"
 #if OS(WINDOWS)

--- a/src/sql/mysql/protocol/NewReader.rs
+++ b/src/sql/mysql/protocol/NewReader.rs
@@ -88,16 +88,21 @@ impl<C: ReaderContext> NewReader<C> {
         Ok(I::from_ne_slice(&data.slice()[..I::SIZE]))
     }
 
-    /// Zig `reader.int(u24)` — read 3 little-endian bytes, zero-extend to u32.
+    /// Zig `reader.int(u24)`. MySQL's binary result-row protocol transmits
+    /// `MYSQL_TYPE_INT24` as a fixed 4-byte field; Zig consumes `@sizeOf(u24)`
+    /// (== 4, ABI size rounds 24 bits up to 4-byte alignment) and decodes the
+    /// low 3 bytes. Consuming only 3 leaves the cursor 1 byte behind and
+    /// corrupts every subsequent column.
     pub fn int_u24(self) -> Result<u32, AnyMySQLError> {
-        let data = self.read(3)?;
+        let data = self.read(4)?;
         let s = data.slice();
         Ok(u32::from_le_bytes([s[0], s[1], s[2], 0]))
     }
 
-    /// Zig `reader.int(i24)` — read 3 little-endian bytes, sign-extend to i32.
+    /// Zig `reader.int(i24)` — consume 4 bytes (see [`Self::int_u24`]), decode
+    /// the low 3 little-endian bytes and sign-extend to i32.
     pub fn int_i24(self) -> Result<i32, AnyMySQLError> {
-        let data = self.read(3)?;
+        let data = self.read(4)?;
         let s = data.slice();
         let u = u32::from_le_bytes([s[0], s[1], s[2], 0]);
         // sign-extend 24 -> 32

--- a/src/sql_jsc/mysql/protocol/DecodeBinaryValue.rs
+++ b/src/sql_jsc/mysql/protocol/DecodeBinaryValue.rs
@@ -77,8 +77,10 @@ pub fn decode_binary_value<Context: ReaderContext>(
         }
         FieldType::MYSQL_TYPE_INT24 => {
             if raw {
-                let data = reader.read(3)?;
-                return Ok(SQLDataCell::raw(Some(&data)));
+                // Binary protocol sends INT24 as a fixed 4-byte field; consume
+                // all 4 to keep the cursor aligned and return only the low 3.
+                let data = reader.read(4)?;
+                return Ok(SQLDataCell::raw(Some(&data.substring(0, 3))));
             }
             if unsigned {
                 return Ok(SQLDataCell {

--- a/test/js/sql/sql-mysql-mediumint.test.ts
+++ b/test/js/sql/sql-mysql-mediumint.test.ts
@@ -1,0 +1,230 @@
+// MySQL's binary result-row protocol transmits MYSQL_TYPE_INT24 (MEDIUMINT) as
+// a fixed 4-byte field. The decoder used to consume only 3, leaving the cursor
+// 1 byte behind and corrupting every column that follows (or hanging on a
+// length-prefixed column like VARCHAR).
+//
+// Uses a minimal mock MySQL server so the test runs without Docker.
+
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import { once } from "events";
+import net from "net";
+
+// --- MySQL wire format helpers ---------------------------------------------
+
+function u16le(n: number): Buffer {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff]);
+}
+function u24le(n: number): Buffer {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff]);
+}
+function u32le(n: number): Buffer {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >>> 24) & 0xff]);
+}
+function i64le(n: bigint): Buffer {
+  const b = Buffer.alloc(8);
+  b.writeBigInt64LE(n);
+  return b;
+}
+function f64le(n: number): Buffer {
+  const b = Buffer.alloc(8);
+  b.writeDoubleLE(n);
+  return b;
+}
+function packet(seq: number, payload: Buffer): Buffer {
+  return Buffer.concat([u24le(payload.length), Buffer.from([seq]), payload]);
+}
+function lenenc(n: number): Buffer {
+  if (n < 0xfb) return Buffer.from([n]);
+  if (n < 0xffff) return Buffer.concat([Buffer.from([0xfc]), u16le(n)]);
+  throw new Error("lenenc: not needed for this test");
+}
+function lenencStr(s: string): Buffer {
+  const buf = Buffer.from(s, "utf-8");
+  return Buffer.concat([lenenc(buf.length), buf]);
+}
+
+// --- Capability flags ------------------------------------------------------
+
+const CLIENT_PROTOCOL_41 = 1 << 9;
+const CLIENT_SECURE_CONNECTION = 1 << 15;
+const CLIENT_PLUGIN_AUTH = 1 << 19;
+const CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA = 1 << 21;
+const CLIENT_DEPRECATE_EOF = 1 << 24;
+const SERVER_CAPS =
+  CLIENT_PROTOCOL_41 |
+  CLIENT_SECURE_CONNECTION |
+  CLIENT_PLUGIN_AUTH |
+  CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA |
+  CLIENT_DEPRECATE_EOF;
+
+// MYSQL_TYPE_* values. From src/sql/mysql/mysql_types.rs.
+const MYSQL_TYPE_LONG = 0x03;
+const MYSQL_TYPE_DOUBLE = 0x05;
+const MYSQL_TYPE_LONGLONG = 0x08;
+const MYSQL_TYPE_INT24 = 0x09;
+const MYSQL_TYPE_VAR_STRING = 0xfd;
+
+const UNSIGNED_FLAG = 1 << 5;
+
+// --- Packet builders -------------------------------------------------------
+
+function handshakeV10(): Buffer {
+  const authData1 = Buffer.alloc(8, 0x61);
+  const authData2 = Buffer.alloc(13, 0x62);
+  authData2[12] = 0;
+  return packet(
+    0,
+    Buffer.concat([
+      Buffer.from([10]),
+      Buffer.from("mock-5.7.0\0"),
+      u32le(1),
+      authData1,
+      Buffer.from([0]),
+      u16le(SERVER_CAPS & 0xffff),
+      Buffer.from([0x2d]),
+      u16le(0x0002),
+      u16le((SERVER_CAPS >>> 16) & 0xffff),
+      Buffer.from([21]),
+      Buffer.alloc(10, 0),
+      authData2,
+      Buffer.from("mysql_native_password\0"),
+    ]),
+  );
+}
+
+function okPacket(seq: number, header = 0x00): Buffer {
+  return packet(seq, Buffer.from([header, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
+}
+
+function columnDef(name: string, type: number, flags = 0): Buffer {
+  return Buffer.concat([
+    lenencStr("def"),
+    lenencStr(""),
+    lenencStr("t"),
+    lenencStr("t"),
+    lenencStr(name),
+    lenencStr(name),
+    Buffer.from([0x0c]),
+    u16le(33),
+    u32le(1024),
+    Buffer.from([type]),
+    u16le(flags),
+    Buffer.from([0]),
+    Buffer.from([0, 0]),
+  ]);
+}
+
+const columns = [
+  columnDef("id", MYSQL_TYPE_LONG),
+  columnDef("uviews", MYSQL_TYPE_INT24, UNSIGNED_FLAG),
+  columnDef("sviews", MYSQL_TYPE_INT24),
+  columnDef("balance", MYSQL_TYPE_LONGLONG),
+  columnDef("ratio", MYSQL_TYPE_DOUBLE),
+  columnDef("name", MYSQL_TYPE_VAR_STRING),
+];
+
+function stmtPrepareOK(startSeq: number, stmtId: number): Buffer {
+  const packets: Buffer[] = [];
+  let seq = startSeq;
+  packets.push(
+    packet(
+      seq++,
+      Buffer.concat([
+        Buffer.from([0x00]),
+        u32le(stmtId),
+        u16le(columns.length),
+        u16le(0), // num_params
+        Buffer.from([0x00]),
+        u16le(0),
+      ]),
+    ),
+  );
+  for (const c of columns) packets.push(packet(seq++, c));
+  return Buffer.concat(packets);
+}
+
+function binaryResultSet(startSeq: number): Buffer {
+  const packets: Buffer[] = [];
+  let seq = startSeq;
+  packets.push(packet(seq++, Buffer.from([columns.length])));
+  for (const c of columns) packets.push(packet(seq++, c));
+  // Binary row: 0x00 header, NULL bitmap ((6+7+2)/8 = 1 byte), then values.
+  // MEDIUMINT is transmitted as a fixed 4-byte field — the decoder must
+  // consume all 4 or the cursor desyncs into the following columns.
+  packets.push(
+    packet(
+      seq++,
+      Buffer.concat([
+        Buffer.from([0x00]), // row header
+        Buffer.from([0x00]), // null bitmap: nothing null
+        u32le(1), // id INT
+        u32le(100), // uviews MEDIUMINT UNSIGNED → 64 00 00 00
+        u32le(0xffffffce), // sviews MEDIUMINT (-50) → ce ff ff ff
+        i64le(5000n), // balance BIGINT
+        f64le(3.5), // ratio DOUBLE
+        lenencStr("alice"), // name VARCHAR
+      ]),
+    ),
+  );
+  packets.push(packet(seq++, Buffer.from([0xfe, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00])));
+  return Buffer.concat(packets);
+}
+
+function startMockServer() {
+  const server = net.createServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let authed = false;
+    let stmtId = 0;
+    socket.write(handshakeV10());
+    socket.on("data", chunk => {
+      buffered = Buffer.concat([buffered, chunk]);
+      while (buffered.length >= 4) {
+        const len = buffered[0] | (buffered[1] << 8) | (buffered[2] << 16);
+        if (buffered.length < 4 + len) break;
+        const seq = buffered[3];
+        const payload = buffered.subarray(4, 4 + len);
+        buffered = buffered.subarray(4 + len);
+        if (!authed) {
+          authed = true;
+          socket.write(okPacket(seq + 1));
+          continue;
+        }
+        const cmd = payload[0];
+        if (cmd === 0x16 /* COM_STMT_PREPARE */) {
+          socket.write(stmtPrepareOK(seq + 1, ++stmtId));
+        } else if (cmd === 0x17 /* COM_STMT_EXECUTE */) {
+          socket.write(binaryResultSet(seq + 1));
+        } else if (cmd === 0x03 /* COM_QUERY */) {
+          socket.write(okPacket(seq + 1));
+        } else if (cmd === 0x19 /* COM_STMT_CLOSE */) {
+          // no response expected
+        } else {
+          socket.end();
+        }
+      }
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  return server;
+}
+
+test("MEDIUMINT before other columns is read as 4 bytes (binary protocol)", async () => {
+  const server = startMockServer();
+  await once(server, "listening");
+  const { port } = server.address() as net.AddressInfo;
+  try {
+    await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
+
+    const [row] = await sql`SELECT id, uviews, sviews, balance, ratio, name FROM t`;
+    expect(row).toEqual({ id: 1, uviews: 100, sviews: -50, balance: 5000, ratio: 3.5, name: "alice" });
+
+    const [rawRow] = await sql`SELECT id, uviews, sviews, balance, ratio, name FROM t`.raw();
+    expect(rawRow).toHaveLength(6);
+    expect(rawRow[1]).toEqual(new Uint8Array([0x64, 0x00, 0x00])); // 100
+    expect(rawRow[2]).toEqual(new Uint8Array([0xce, 0xff, 0xff])); // -50 as i24 LE
+    expect(Buffer.from(rawRow[5]).toString("utf-8")).toBe("alice");
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+});

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -84,10 +84,16 @@ if (isDockerEnabled()) {
           await using db = new SQL({ ...getOptions(), max: 1, idleTimeout: 5 });
           using sql = await db.reserve();
           const t = "mi_" + randomUUIDv7("hex").replaceAll("-", "");
-          await sql`CREATE TEMPORARY TABLE ${sql(t)} (id INT PRIMARY KEY, uviews MEDIUMINT, sviews MEDIUMINT, balance BIGINT, ratio DOUBLE, name VARCHAR(64))`;
+          await sql`CREATE TEMPORARY TABLE ${sql(t)} (id INT PRIMARY KEY, uviews MEDIUMINT UNSIGNED, sviews MEDIUMINT, balance BIGINT, ratio DOUBLE, name VARCHAR(64))`;
           await sql`INSERT INTO ${sql(t)} VALUES (1, 100, -50, 5000, 3.5, ${"alice"})`;
           const [row] = await sql`SELECT id, uviews, sviews, balance, ratio, name FROM ${sql(t)} WHERE id = ${1}`;
           expect(row).toEqual({ id: 1, uviews: 100, sviews: -50, balance: 5000, ratio: 3.5, name: "alice" });
+          // `.raw()` takes a separate branch that must also consume 4 bytes.
+          const [rawRow] =
+            await sql`SELECT id, uviews, sviews, balance, ratio, name FROM ${sql(t)} WHERE id = ${1}`.raw();
+          expect(rawRow).toHaveLength(6);
+          expect(rawRow[2]).toEqual(new Uint8Array([0xce, 0xff, 0xff])); // -50 as i24 LE
+          expect(Buffer.from(rawRow[5]).toString("utf-8")).toBe("alice");
         });
         describe("should work with more than the max inline capacity", () => {
           for (let size of [50, 60, 62, 64, 70, 100]) {

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -76,6 +76,19 @@ if (isDockerEnabled()) {
             await sql`UPDATE ${sql(random_name)} SET name = "test2" WHERE id = ${lastInsertRowid}`;
           expect(affectedRows).toBe(1);
         });
+        test("MEDIUMINT not in the last column reads following columns correctly", async () => {
+          // MySQL's binary protocol sends MYSQL_TYPE_INT24 as a fixed 4-byte
+          // field. Reading only 3 left the cursor 1 byte behind, silently
+          // corrupting every following column (and hanging forever if a
+          // length-prefixed column like VARCHAR followed).
+          await using db = new SQL({ ...getOptions(), max: 1, idleTimeout: 5 });
+          using sql = await db.reserve();
+          const t = "mi_" + randomUUIDv7("hex").replaceAll("-", "");
+          await sql`CREATE TEMPORARY TABLE ${sql(t)} (id INT PRIMARY KEY, uviews MEDIUMINT, sviews MEDIUMINT, balance BIGINT, ratio DOUBLE, name VARCHAR(64))`;
+          await sql`INSERT INTO ${sql(t)} VALUES (1, 100, -50, 5000, 3.5, ${"alice"})`;
+          const [row] = await sql`SELECT id, uviews, sviews, balance, ratio, name FROM ${sql(t)} WHERE id = ${1}`;
+          expect(row).toEqual({ id: 1, uviews: 100, sviews: -50, balance: 5000, ratio: 3.5, name: "alice" });
+        });
         describe("should work with more than the max inline capacity", () => {
           for (let size of [50, 60, 62, 64, 70, 100]) {
             for (let duplicated of [true, false]) {


### PR DESCRIPTION
Any `Bun.SQL` MySQL/MariaDB query selecting a `MEDIUMINT` column that is **not** the last column silently returned corrupted values for every following column. If a length-prefixed column (VARCHAR/TEXT/JSON/BLOB) followed the MEDIUMINT, the connection hung forever (promise never resolves). Tagged-template queries always use the binary protocol, so this is data corruption on a basic, common MySQL read path.

`NewReader::int_u24`/`int_i24` did `self.read(3)` — consuming only 3 bytes. MySQL's binary result-row protocol transmits `MYSQL_TYPE_INT24` as a fixed **4-byte** field. Zig's generic `int(Int)` does `read(@sizeOf(Int))`, and `@sizeOf(u24) == 4` in Zig (ABI size rounds 24 bits up to 4-byte alignment), so Zig consumes 4 bytes and decodes the low 3. The porter misread `@sizeOf` as the 3-byte natural width.

Consume 4 bytes (decode the low 3, unchanged), mirroring Zig's `read(@sizeOf(u24))`; fix the misleading doc comments.

Verified end-to-end against a local MariaDB: `SELECT id, uviews MEDIUMINT, sviews MEDIUMINT, balance BIGINT, ratio DOUBLE, name VARCHAR` now returns the exact row byte-identical to released Bun (was `balance` corrupted / VARCHAR hang). Regression test added to the container MySQL suite.