### PR TITLE
semver: widen comparator counter to u32 to avoid debug overflow panic

### DIFF
--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -61,7 +61,7 @@ extern "C" int uv_tty_reset_mode(void)
 
 static void uv__tty_make_raw(struct termios* tio)
 {
-    assert(tio != NULL);
+    ASSERT(tio != NULL);
 
 #if defined __sun || defined __MVS__
     /*

--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -722,10 +722,6 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
     let mut token = Token::default();
     let mut prev_token = Token::default();
 
-    // u32, not u8: a range with >=256 `||`/whitespace comparators overflows a
-    // u8 on the 256th increment. Zig's ReleaseFast wrapped (256 -> 0) silently;
-    // Rust's debug profile has overflow-checks and would panic+abort. `count`
-    // is only ever compared `== 0`, so the wider type is strictly more correct.
     let mut count: u32 = 0;
     let mut skip_round;
     let mut is_or = false;

--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -722,7 +722,11 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
     let mut token = Token::default();
     let mut prev_token = Token::default();
 
-    let mut count: u8 = 0;
+    // u32, not u8: a range with >=256 `||`/whitespace comparators overflows a
+    // u8 on the 256th increment. Zig's ReleaseFast wrapped (256 -> 0) silently;
+    // Rust's debug profile has overflow-checks and would panic+abort. `count`
+    // is only ever compared `== 0`, so the wider type is strictly more correct.
+    let mut count: u32 = 0;
     let mut skip_round;
     let mut is_or = false;
 

--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -722,7 +722,7 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
     let mut token = Token::default();
     let mut prev_token = Token::default();
 
-    let mut count: u32 = 0;
+    let mut count: u8 = 0;
     let mut skip_round;
     let mut is_or = false;
 

--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -722,7 +722,7 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
     let mut token = Token::default();
     let mut prev_token = Token::default();
 
-    let mut count: u8 = 0;
+    let mut count: u32 = 0;
     let mut skip_round;
     let mut is_or = false;
 

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -749,7 +749,7 @@ test("a version range with >=256 || comparators does not abort", async () => {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toBe("true");
   if (exitCode !== 0) expect(stderr).toBe("");
+  expect(stdout).toBe("true");
   expect(exitCode).toBe(0);
 }, 30_000);

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -227,7 +227,7 @@ describe("Bun.semver.satisfies()", () => {
       }
     }
     Bun.gc(true);
-  });
+  }, 30_000);
 
   test("exact versions", () => {
     testSatisfiesExact("1.2.3", "1.2.3", true);
@@ -752,4 +752,4 @@ test("a version range with >=256 || comparators does not abort", async () => {
   expect(stdout).toBe("true");
   if (exitCode !== 0) expect(stderr).toBe("");
   expect(exitCode).toBe(0);
-});
+}, 30_000);

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -748,7 +748,8 @@ test("a version range with >=256 || comparators does not abort", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).toBe("true");
+  if (exitCode !== 0) expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -749,8 +749,6 @@ test("a version range with >=256 || comparators does not abort", async () => {
     stderr: "pipe",
   });
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-  // The 256th comparator overflowed a u8 counter -> panic+abort (exit 133) in
-  // debug builds. Fixed: a wider counter parses it fine, like released Bun.
   expect(stdout).toBe("true");
   expect(exitCode).toBe(0);
 });

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -14,6 +14,7 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 // IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+import { bunEnv, bunExe } from "harness";
 import { unsortedPrereleases } from "./semver-fixture.js";
 const { satisfies, order } = Bun.semver;
 
@@ -737,4 +738,19 @@ describe("Bun.semver.satisfies()", () => {
   test("pre-release snapshot", () => {
     expect(unsortedPrereleases.sort(Bun.semver.order)).toMatchSnapshot();
   });
+});
+
+test("a version range with >=256 || comparators does not abort", async () => {
+  const range = Array(300).fill("1.0.0").join(" || ");
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `process.stdout.write(String(Bun.semver.satisfies("1.0.0", ${JSON.stringify(range)})))`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  // The 256th comparator overflowed a u8 counter -> panic+abort (exit 133) in
+  // debug builds. Fixed: a wider counter parses it fine, like released Bun.
+  expect(stdout).toBe("true");
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
A version range with >=256 `||`/whitespace-separated comparators panicked the **debug** build (`attempt to add with overflow`, exit 133) where released Bun fails gracefully. Debug-only: Cargo's dev profile enables `overflow-checks`; the release profile doesn't, so release wrapped (256 -> 0) exactly like Zig's ReleaseFast.

`SemverQuery::parse` used `let mut count: u8 = 0;` with `count += 1;` — the 256th increment overflows. `count` is only ever compared `== 0`, never stored or cast, so a wider type is strictly more correct (it also avoids Zig's silent u8 wrap, which was a latent bug that merely didn't crash).

Widen `count` to `u32`. Regression test (`Bun.semver.satisfies` with 300 `||` comparators, run in a subprocess since the failure was an uncatchable abort) passes on the debug build and matches released Bun.

---

Also carried:
- `wtf-bindings.cpp`: `assert` → `ASSERT` — identical to #30992; the WebKit upgrade in #30705 dropped the transitive `<cassert>` include, so debug builds currently fail to compile on `main`. Needed here so the regression test can run under `bun bd`.
- 30s timeout on the pre-existing `failures does not cause weird memory issues` test (1e5 iterations) and the new subprocess test — both exceed the 5s default under debug+ASAN.

### Verification

```
$ bun bd test test/cli/install/semver.test.ts
 23 pass  0 fail
$ ./build/release/bun test test/cli/install/semver.test.ts
 23 pass  0 fail
```

With the `u32` change reverted, the new test fails on debug with `panic: attempt to add with overflow (src/semver/SemverQuery.rs:981)` on stderr and exit 132.
