### PR TITLE
package.json: drop empty-valued script/config entries (Zig parity)

### DIFF
--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1688,7 +1688,9 @@ impl PackageJSON {
                         // OR the value is empty (expr.zig: `key.len > 0 and
                         // value.len > 0`). An empty-valued script
                         // (`{"scripts":{"build":""}}`) must NOT become a real
-                        // (empty) script — npm/Zig report "Script not found".
+                        // (empty) script — Zig reports "Script not found".
+                        // (npm actually runs empty scripts and exits 0; we
+                        // intentionally diverge here to match released Bun.)
                         if key.is_empty() || value.is_empty() {
                             continue;
                         }

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1700,7 +1700,7 @@ impl PackageJSON {
                     // Zig returns null when the FILTERED map is empty
                     // (expr.zig: `if (count == 0) return null;`), not just when
                     // the raw object had no properties.
-                    if map.len() == 0 {
+                    if map.is_empty() {
                         return None;
                     }
                     Some(Box::new(map))

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1672,9 +1672,6 @@ impl PackageJSON {
                     let js_ast::ExprData::EObject(obj) = &prop.expr.data else {
                         return None;
                     };
-                    if obj.properties.len_u32() == 0 {
-                        return None;
-                    }
                     let mut map = StringArrayHashMap::<&'static [u8]>::default();
                     map.ensure_total_capacity(obj.properties.len_u32() as usize)
                         .ok()?;

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1687,13 +1687,24 @@ impl PackageJSON {
                         else {
                             continue;
                         };
-                        if key.is_empty() {
+                        // Zig `asPropertyStringMap` drops entries where the key
+                        // OR the value is empty (expr.zig: `key.len > 0 and
+                        // value.len > 0`). An empty-valued script
+                        // (`{"scripts":{"build":""}}`) must NOT become a real
+                        // (empty) script — npm/Zig report "Script not found".
+                        if key.is_empty() || value.is_empty() {
                             continue;
                         }
                         // SAFETY: `key`/`value` borrow `contents_static`; see SAFETY note
                         // on `contents_static` above (owned by the returned PackageJSON).
                         let value: &'static [u8] = unsafe { bun_ptr::detach_lifetime(value) };
                         map.put_assume_capacity(key, value);
+                    }
+                    // Zig returns null when the FILTERED map is empty
+                    // (expr.zig: `if (count == 0) return null;`), not just when
+                    // the raw object had no properties.
+                    if map.len() == 0 {
+                        return None;
                     }
                     Some(Box::new(map))
                 };

--- a/test/cli/run/run_command.test.ts
+++ b/test/cli/run/run_command.test.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
 import { rmSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, bunRun, isWindows } from "harness";
+import { bunEnv, bunExe, bunRun, isWindows, tempDir } from "harness";
 
 let cwd: string;
 
@@ -10,6 +10,24 @@ describe("bun", () => {
     const { exitCode, stdout, stderr } = spawnSync({
       cwd,
       cmd: [bunExe(), "run", "dev"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(stdout.toString()).toBeEmpty();
+    expect(stderr.toString()).toMatch(/Script not found/);
+    expect(exitCode).toBe(1);
+  });
+
+  test("an empty-string script value is not a runnable script", () => {
+    using dir = tempDir("empty-script", {
+      "package.json": JSON.stringify({ scripts: { build: "" } }),
+    });
+    // npm/Zig drop empty-valued script entries; an empty `build` must report
+    // "Script not found" and exit 1, not run an empty `$ ` command and exit 0.
+    const { exitCode, stdout, stderr } = spawnSync({
+      cwd: String(dir),
+      cmd: [bunExe(), "run", "build"],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",

--- a/test/cli/run/run_command.test.ts
+++ b/test/cli/run/run_command.test.ts
@@ -23,8 +23,10 @@ describe("bun", () => {
     using dir = tempDir("empty-script", {
       "package.json": JSON.stringify({ scripts: { build: "" } }),
     });
-    // npm/Zig drop empty-valued script entries; an empty `build` must report
-    // "Script not found" and exit 1, not run an empty `$ ` command and exit 0.
+    // Zig `asPropertyStringMap` drops empty-valued script entries; an empty
+    // `build` must report "Script not found" and exit 1, not run an empty
+    // `$ ` command and exit 0. (npm runs empty scripts and exits 0 — Bun
+    // intentionally diverges here to match its own prior/Zig behavior.)
     const { exitCode, stdout, stderr } = spawnSync({
       cwd: String(dir),
       cmd: [bunExe(), "run", "build"],


### PR DESCRIPTION
A package.json `scripts` (or `config`) entry with an empty-string **value** (`{"scripts":{"build":""}}` — common from scaffolding / `npm pkg set scripts.x=` / placeholder stubs) was treated as a real script. `bun run build` ran an empty shell command and exited 0; released (Zig) Bun reports `error: Script not found "build"` and exits 1. Also skewed `bun run` list counts and leaked empty `config` values as `npm_package_config_*=""` into child env.

`property_string_map` (used for both `scripts` and `config`) only skipped entries with an empty **key**, and only early-returned `None` when the raw object had zero properties. Zig's `asPropertyStringMap` drops entries where key **or value** is empty and returns null when the *filtered* map is empty.

Also `continue` on an empty value, and return `None` when the filtered map ends up empty — mirroring `expr.zig`. `bun run build` on `{"scripts":{"build":""}}` now reports "Script not found" / exit 1, matching released Bun. (npm actually runs empty scripts and exits 0 — this intentionally keeps Bun's existing behavior rather than following npm.) Regression test in `run_command.test.ts`.