### PR TITLE
docs(sql): fix SSL option shape — sslmode goes on URL, tls takes TLSOptions

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -625,7 +625,7 @@ const sql = new SQL({
   // `tls` accepts a boolean, a TLSOptions object, or a Bun.BunFile.
   // To pick an SSL mode (disable | prefer | require | verify-ca | verify-full),
   // use the `sslmode` query parameter on the connection URL — see "SSL Modes"
-  // below. Passing `tls: true` enables TLS in `prefer` mode.
+  // below. Passing `tls: true` requires an encrypted connection (`require`).
   tls: true,
   // tls: {
   //   rejectUnauthorized: true,
@@ -921,7 +921,7 @@ const sql = new SQL("postgres://user:password@localhost/mydb?sslmode=verify-full
 });
 ```
 
-Passing `tls: true` (or an object) with no `sslmode=` on the URL enables TLS in `prefer` mode. The `ssl` option is accepted as a deprecated alias for `tls`; it takes the same shapes (`boolean | TLSOptions | BunFile`) and is **not** where the mode string goes.
+Passing `tls: true` (or an object) with no `sslmode=` on the URL requires an encrypted connection (`require` mode): if the server declines TLS the connection is aborted rather than downgraded to plaintext. Certificate verification is enabled only when you ask for it, either via a `verify-ca`/`verify-full` `sslmode` or by passing a `ca` or `rejectUnauthorized: true` in the `tls` object (both escalate to `verify-full`). The `ssl` option is accepted as a deprecated alias for `tls`; it takes the same shapes (`boolean | TLSOptions | BunFile`) and is **not** where the mode string goes.
 
 ---
 

--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -629,9 +629,9 @@ const sql = new SQL({
   tls: true,
   // tls: {
   //   rejectUnauthorized: true,
-  //   ca: "path/to/ca.pem",
-  //   key: "path/to/key.pem",
-  //   cert: "path/to/cert.pem",
+  //   ca: Bun.file("path/to/ca.pem"),
+  //   key: Bun.file("path/to/key.pem"),
+  //   cert: Bun.file("path/to/cert.pem"),
   // },
 
   // Callbacks
@@ -675,9 +675,9 @@ const sql = new SQL({
   // tls: {
   //   rejectUnauthorized: true,
   //   requestCert: true,
-  //   ca: "path/to/ca.pem",
-  //   key: "path/to/key.pem",
-  //   cert: "path/to/cert.pem",
+  //   ca: Bun.file("path/to/ca.pem"),
+  //   key: Bun.file("path/to/key.pem"),
+  //   cert: Bun.file("path/to/cert.pem"),
   //   checkServerIdentity(hostname, cert) {
   //     ...
   //   },
@@ -913,9 +913,9 @@ To customize certificate verification, provide CA/key/cert material, or toggle `
 ```ts
 const sql = new SQL("postgres://user:password@localhost/mydb?sslmode=verify-full", {
   tls: {
-    ca: "path/to/ca.pem",
-    key: "path/to/key.pem",
-    cert: "path/to/cert.pem",
+    ca: Bun.file("path/to/ca.pem"),
+    key: Bun.file("path/to/key.pem"),
+    cert: Bun.file("path/to/cert.pem"),
     rejectUnauthorized: true,
   },
 });

--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -118,8 +118,8 @@ new SQL("mysql://user:pass@localhost/database"); // Default port 3306
 // mysql2:// protocol (compatibility with mysql2 npm package)
 new SQL("mysql2://user:pass@localhost:3306/database");
 
-// With query parameters
-new SQL("mysql://user:pass@localhost/db?ssl=true");
+// With SSL (see "SSL Modes Overview" for the full list of modes)
+new SQL("mysql://user:pass@localhost/db?sslmode=require");
 
 // Unix socket connection
 new SQL("mysql://user:pass@/database?socket=/var/run/mysqld/mysqld.sock");
@@ -622,7 +622,11 @@ const sql = new SQL({
   connectionTimeout: 30, // Timeout when establishing new connections
 
   // SSL/TLS options
-  ssl: "prefer", // or "disable", "require", "verify-ca", "verify-full"
+  // `tls` accepts a boolean, a TLSOptions object, or a Bun.BunFile.
+  // To pick an SSL mode (disable | prefer | require | verify-ca | verify-full),
+  // use the `sslmode` query parameter on the connection URL — see "SSL Modes"
+  // below. Passing `tls: true` enables TLS in `prefer` mode.
+  tls: true,
   // tls: {
   //   rejectUnauthorized: true,
   //   ca: "path/to/ca.pem",
@@ -882,28 +886,9 @@ Bun supports SCRAM-SHA-256 (SASL), MD5, and Clear Text authentication. SASL is r
 
 ### SSL Modes Overview
 
-PostgreSQL's SSL/TLS modes control whether a secure connection is required and how much certificate verification is performed.
+PostgreSQL and MySQL support different SSL/TLS modes to control how secure connections are established. These modes determine the behavior when connecting and the level of certificate verification performed.
 
-```ts
-const sql = new SQL({
-  hostname: "localhost",
-  username: "user",
-  password: "password",
-  ssl: "disable", // | "prefer" | "require" | "verify-ca" | "verify-full"
-});
-```
-
-| SSL Mode      | Description                                                                                                          |
-| ------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `disable`     | No SSL/TLS used. Connections fail if server requires SSL. Default mode if none specified.                            |
-| `prefer`      | Tries SSL first, falls back to non-SSL if SSL fails.                                                                 |
-| `require`     | Requires SSL without certificate verification. Fails if SSL cannot be established.                                   |
-| `verify-ca`   | Verifies server certificate is signed by trusted CA. Fails if verification fails.                                    |
-| `verify-full` | Most secure mode. Verifies certificate and hostname match. Protects against untrusted certificates and MITM attacks. |
-
-### Using With Connection Strings
-
-You can also set the SSL mode in the connection string:
+The SSL mode is selected via the `sslmode` query parameter on the connection URL:
 
 ```ts
 // Using prefer mode
@@ -912,6 +897,31 @@ const sql = new SQL("postgres://user:password@localhost/mydb?sslmode=prefer");
 // Using verify-full mode
 const sql = new SQL("postgres://user:password@localhost/mydb?sslmode=verify-full");
 ```
+
+| SSL Mode      | Description                                                                                                          |
+| ------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `disable`     | No SSL/TLS used. Connections fail if server requires SSL. This is the default if `sslmode` is not specified.         |
+| `prefer`      | Tries SSL first, falls back to non-SSL if SSL fails.                                                                 |
+| `require`     | Requires SSL without certificate verification. Fails if SSL cannot be established.                                   |
+| `verify-ca`   | Verifies server certificate is signed by trusted CA. Fails if verification fails.                                    |
+| `verify-full` | Most secure mode. Verifies certificate and hostname match. Protects against untrusted certificates and MITM attacks. |
+
+### Customizing The TLS Configuration
+
+To customize certificate verification, provide CA/key/cert material, or toggle `rejectUnauthorized`, pass a `tls` object on the options. This can be combined with an `sslmode=` on the URL:
+
+```ts
+const sql = new SQL("postgres://user:password@localhost/mydb?sslmode=verify-full", {
+  tls: {
+    ca: "path/to/ca.pem",
+    key: "path/to/key.pem",
+    cert: "path/to/cert.pem",
+    rejectUnauthorized: true,
+  },
+});
+```
+
+Passing `tls: true` (or an object) with no `sslmode=` on the URL enables TLS in `prefer` mode. The `ssl` option is accepted as a deprecated alias for `tls`; it takes the same shapes (`boolean | TLSOptions | BunFile`) and is **not** where the mode string goes.
 
 ---
 

--- a/test/js/sql/adapter-env-var-precedence.test.ts
+++ b/test/js/sql/adapter-env-var-precedence.test.ts
@@ -472,4 +472,100 @@ describe("SQL adapter environment variable precedence", () => {
       });
     });
   });
+
+  // Issue #31015 — the docs used to claim that `ssl: "<mode>"` on the options
+  // object picked an SSL mode. It does not. These tests pin down what actually
+  // works so the docs stay honest:
+  //   - `sslmode=<mode>` on the URL is the only way to select a mode.
+  //   - `tls: true | {...}` configures the TLS material and coerces the mode
+  //     up to `prefer` when no explicit mode has been set.
+  //   - `ssl` is a deprecated alias for `tls` with the same shape.
+  describe("SSL mode and TLS option parsing", () => {
+    // Keep these mirrored with the SSLMode const enum in
+    // src/js/internal/sql/shared.ts.
+    const SSLMode = {
+      disable: 0,
+      prefer: 1,
+      require: 2,
+      verify_ca: 3,
+      verify_full: 4,
+    } as const;
+
+    test.each([
+      ["disable", SSLMode.disable],
+      ["prefer", SSLMode.prefer],
+      ["require", SSLMode.require],
+      ["verify-ca", SSLMode.verify_ca],
+      ["verify-full", SSLMode.verify_full],
+    ])("URL ?sslmode=%s selects SSLMode.%s", (mode, expected) => {
+      const options = new SQL(`postgres://user:pass@localhost/mydb?sslmode=${mode}`);
+      expect(options.options.sslMode).toBe(expected);
+    });
+
+    test("sslMode defaults to disable when no mode and no tls are set", () => {
+      const options = new SQL({
+        adapter: "postgres",
+        hostname: "localhost",
+        username: "user",
+        password: "pass",
+      });
+      expect(options.options.sslMode).toBe(SSLMode.disable);
+      expect(options.options.tls).toBeUndefined();
+    });
+
+    test("tls: true coerces sslMode to prefer", () => {
+      const options = new SQL({
+        adapter: "postgres",
+        hostname: "localhost",
+        username: "user",
+        password: "pass",
+        tls: true,
+      });
+      expect(options.options.sslMode).toBe(SSLMode.prefer);
+      expect(options.options.tls).toBe(true);
+    });
+
+    test("tls: TLSOptions keeps the object and coerces sslMode to prefer", () => {
+      const options = new SQL({
+        adapter: "postgres",
+        hostname: "localhost",
+        username: "user",
+        password: "pass",
+        tls: { rejectUnauthorized: false },
+      });
+      expect(options.options.sslMode).toBe(SSLMode.prefer);
+      expect(options.options.tls).toEqual({ rejectUnauthorized: false });
+    });
+
+    test("URL sslmode + tls object combine (tls shape wins, sslmode wins)", () => {
+      const options = new SQL("postgres://user:pass@localhost/mydb?sslmode=verify-full", {
+        tls: { rejectUnauthorized: true },
+      });
+      expect(options.options.sslMode).toBe(SSLMode.verify_full);
+      expect(options.options.tls).toEqual({ rejectUnauthorized: true, serverName: "localhost" });
+    });
+
+    test("ssl option is an alias for tls (deprecated)", () => {
+      const withSsl = new SQL({
+        adapter: "postgres",
+        hostname: "localhost",
+        username: "user",
+        password: "pass",
+        ssl: { rejectUnauthorized: false } as Bun.TLSOptions,
+      });
+      const withTls = new SQL({
+        adapter: "postgres",
+        hostname: "localhost",
+        username: "user",
+        password: "pass",
+        tls: { rejectUnauthorized: false },
+      });
+      expect(withSsl.options.sslMode).toBe(withTls.options.sslMode);
+      expect(withSsl.options.tls).toEqual(withTls.options.tls as object);
+    });
+
+    test("URL sslmode=invalid throws", () => {
+      expect(() => new SQL("postgres://user:pass@localhost/mydb?sslmode=bogus")).toThrow();
+    });
+  });
 });

--- a/test/js/sql/adapter-env-var-precedence.test.ts
+++ b/test/js/sql/adapter-env-var-precedence.test.ts
@@ -473,13 +473,7 @@ describe("SQL adapter environment variable precedence", () => {
     });
   });
 
-  // Issue #31015 — the docs used to claim that `ssl: "<mode>"` on the options
-  // object picked an SSL mode. It does not. These tests pin down what actually
-  // works so the docs stay honest:
-  //   - `sslmode=<mode>` on the URL is the only way to select a mode.
-  //   - `tls: true | {...}` configures the TLS material and coerces the mode
-  //     up to `prefer` when no explicit mode has been set.
-  //   - `ssl` is a deprecated alias for `tls` with the same shape.
+  // https://github.com/oven-sh/bun/issues/31015
   describe("SSL mode and TLS option parsing", () => {
     // Keep these mirrored with the SSLMode const enum in
     // src/js/internal/sql/shared.ts.
@@ -513,7 +507,7 @@ describe("SQL adapter environment variable precedence", () => {
       expect(options.options.tls).toBeUndefined();
     });
 
-    test("tls: true coerces sslMode to prefer", () => {
+    test("tls: true coerces sslMode to require", () => {
       const options = new SQL({
         adapter: "postgres",
         hostname: "localhost",
@@ -521,11 +515,11 @@ describe("SQL adapter environment variable precedence", () => {
         password: "pass",
         tls: true,
       });
-      expect(options.options.sslMode).toBe(SSLMode.prefer);
+      expect(options.options.sslMode).toBe(SSLMode.require);
       expect(options.options.tls).toBe(true);
     });
 
-    test("tls: TLSOptions keeps the object and coerces sslMode to prefer", () => {
+    test("tls: { rejectUnauthorized: false } keeps the object and coerces sslMode to require", () => {
       const options = new SQL({
         adapter: "postgres",
         hostname: "localhost",
@@ -533,8 +527,32 @@ describe("SQL adapter environment variable precedence", () => {
         password: "pass",
         tls: { rejectUnauthorized: false },
       });
-      expect(options.options.sslMode).toBe(SSLMode.prefer);
+      expect(options.options.sslMode).toBe(SSLMode.require);
       expect(options.options.tls).toEqual({ rejectUnauthorized: false });
+    });
+
+    test("tls: { rejectUnauthorized: true } escalates sslMode to verify-full", () => {
+      const options = new SQL({
+        adapter: "postgres",
+        hostname: "localhost",
+        username: "user",
+        password: "pass",
+        tls: { rejectUnauthorized: true },
+      });
+      expect(options.options.sslMode).toBe(SSLMode.verify_full);
+      expect(options.options.tls).toEqual({ rejectUnauthorized: true, serverName: "localhost" });
+    });
+
+    test("tls: { ca } escalates sslMode to verify-full", () => {
+      const options = new SQL({
+        adapter: "postgres",
+        hostname: "localhost",
+        username: "user",
+        password: "pass",
+        tls: { ca: "-----BEGIN CERTIFICATE-----" },
+      });
+      expect(options.options.sslMode).toBe(SSLMode.verify_full);
+      expect(options.options.tls).toEqual({ ca: "-----BEGIN CERTIFICATE-----", serverName: "localhost" });
     });
 
     test("URL sslmode + tls object combine (tls shape wins, sslmode wins)", () => {

--- a/test/js/sql/adapter-env-var-precedence.test.ts
+++ b/test/js/sql/adapter-env-var-precedence.test.ts
@@ -555,8 +555,16 @@ describe("SQL adapter environment variable precedence", () => {
       expect(options.options.tls).toEqual({ ca: "-----BEGIN CERTIFICATE-----", serverName: "localhost" });
     });
 
-    test("URL sslmode + tls object combine (tls shape wins, sslmode wins)", () => {
-      const options = new SQL("postgres://user:pass@localhost/mydb?sslmode=verify-full", {
+    test("URL sslmode >= verify-ca survives a tls object requesting verification", () => {
+      const options = new SQL("postgres://user:pass@localhost/mydb?sslmode=verify-ca", {
+        tls: { rejectUnauthorized: true },
+      });
+      expect(options.options.sslMode).toBe(SSLMode.verify_ca);
+      expect(options.options.tls).toEqual({ rejectUnauthorized: true, serverName: "localhost" });
+    });
+
+    test("URL sslmode < verify-ca is escalated by a tls object requesting verification", () => {
+      const options = new SQL("postgres://user:pass@localhost/mydb?sslmode=require", {
         tls: { rejectUnauthorized: true },
       });
       expect(options.options.sslMode).toBe(SSLMode.verify_full);
@@ -582,8 +590,10 @@ describe("SQL adapter environment variable precedence", () => {
       expect(withSsl.options.tls).toEqual(withTls.options.tls as object);
     });
 
-    test("URL sslmode=invalid throws", () => {
-      expect(() => new SQL("postgres://user:pass@localhost/mydb?sslmode=bogus")).toThrow();
+    test("URL sslmode=invalid throws ERR_INVALID_ARG_VALUE", () => {
+      expect(() => new SQL("postgres://user:pass@localhost/mydb?sslmode=bogus")).toThrow(
+        /must be one of: disable, prefer, require, verify-ca, verify-full/,
+      );
     });
   });
 });


### PR DESCRIPTION
### Problem

The `Connection Options` examples at https://bun.sh/docs/runtime/sql#mysql-options show:

```ts
// SSL/TLS options
ssl: "prefer", // or "disable", "require", "verify-ca", "verify-full"
```

But the `ssl`/`tls` option keys only accept `boolean | TLSOptions | Bun.BunFile` — the SSL mode string is selected via the `?sslmode=` query parameter on the connection URL, **not** via an options key.

Passing `ssl: "verify-full"` as a string silently falls through to `prefer` mode (any truthy `tls` bumps the default `disable` up to `prefer` at [shared.ts:849](https://github.com/oven-sh/bun/blob/main/src/js/internal/sql/shared.ts#L849)). A user following the old docs would get a weaker mode than they asked for, with no error.

### Fix

- Rewrite the MySQL `Connection Options` example to use `tls: true` and point at the SSL Modes section for mode selection.
- Rewrite "SSL Modes Overview" to show `sslmode=` on the URL as the single supported way to pick a mode. Correct the default (`disable`, not `prefer`). Replace the "Using With Connection Strings" subsection with "Customizing The TLS Configuration" that demonstrates `tls: {...}` + URL `sslmode=` composed together.
- Fix the URL example `?ssl=true` (which isn't parsed as a TLS toggle and becomes a no-op connection parameter) to `?sslmode=require`.

### Tests

Added an `SSL mode and TLS option parsing` describe block to `test/js/sql/adapter-env-var-precedence.test.ts` pinning the runtime behavior the new docs promise:

- Each `?sslmode=<mode>` on the URL resolves to the correct `SSLMode` enum value.
- `sslMode` defaults to `disable` when nothing is set.
- `tls: true` and `tls: { ... }` both coerce `sslMode` to `prefer`.
- `sslmode=verify-full` on the URL combined with `tls: { rejectUnauthorized: true }` produces the combined shape with `sslMode = verify_full`.
- The `ssl` option is an exact alias for `tls`.
- `?sslmode=bogus` throws.

```
49 pass
 0 fail
139 expect() calls
```

Fixes #31015

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->