### PR TITLE
Fix unchecked exception when Bun.plugin target coercion throws

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -304,11 +304,13 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
     if (targetValue) {
         if (auto* targetJSString = targetValue.toStringOrNull(globalObject)) {
             String targetString = targetJSString->value(globalObject);
+            RETURN_IF_EXCEPTION(throwScope, {});
             if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
                 JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
                 return {};
             }
         }
+        RETURN_IF_EXCEPTION(throwScope, {});
     }
 
     JSObject* builderObject = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 4);

--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -1,5 +1,6 @@
 #include "root.h"
 #include "wtf-bindings.h"
+#include <cassert>
 #include <wtf/StackBounds.h>
 #include <wtf/StackCheck.h>
 #include <wtf/StackTrace.h>

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -366,6 +366,21 @@ describe("errors", () => {
     }).toThrow("plugin target must be one of 'node', 'bun' or 'browser'");
   });
 
+  it("propagates exception thrown while coercing 'target' to string", () => {
+    const opts = {
+      setup: () => {},
+      target: {
+        toString() {
+          return {};
+        },
+      },
+    };
+
+    expect(() => {
+      plugin(opts as any);
+    }).toThrow(TypeError);
+  });
+
   it("invalid loaders throw", () => {
     const invalidLoaders = ["blah", "blah2", "blah3", "blah4"];
     const inputs = ["body { background: red; }", "<h1>hi</h1>", '{"hi": "there"}', "hi"];


### PR DESCRIPTION
Fuzzer found a debug assertion failure in `Bun.plugin()`.

## Repro

```js
Bun.plugin({
  target: { toString() { return {}; } },
  setup() {},
});
```

```
ASSERTION FAILED: Unexpected exception observed
Error Exception: No default value
!exception()
ExceptionScope.h(61) : void JSC::ExceptionScope::assertNoException()
```

## Cause

`setupBunPlugin()` calls `targetValue.toStringOrNull(globalObject)` to coerce the `target` option to a string. When coercion throws (e.g. `toString()` returns an object, producing a "No default value" TypeError), `toStringOrNull` returns `nullptr` and the `if` body is skipped — but the pending exception is never checked before continuing to `constructEmptyObject()`, which asserts.

## Fix

Add `RETURN_IF_EXCEPTION` after the `toStringOrNull` path (and after `value(globalObject)` for rope resolution).

Also adds a missing `<cassert>` include in `wtf-bindings.cpp` that was relying on transitive includes from other files in its unified-build source group.

Fingerprint: `0462f40eaa1971c9`