### PR TITLE
resolver: restore package_manager.log after resolve to avoid dangling stack pointer

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4204,8 +4204,12 @@ impl VirtualMachine {
         let mut log = bun_ast::Log::default();
         jsc_vm.log = NonNull::new(&raw mut log);
         jsc_vm.transpiler.resolver.log = NonNull::from(&mut log);
-        // TODO(b2-cycle): `transpiler.linker.log` / `resolver.package_manager.log`
-        // — gated bundler fields.
+        jsc_vm.transpiler.linker.log = &raw mut log;
+        if let Some(pm) = jsc_vm.transpiler.resolver.package_manager {
+            // SAFETY: the `dyn AutoInstaller` is always `PackageManager`
+            // (sole impl — see `VirtualMachine::package_manager`).
+            unsafe { (*pm.cast::<bun_install::PackageManager>().as_ptr()).log = &raw mut log };
+        }
         // PORT NOTE: Zig `defer { restore old_log }` — fires on every exit
         // (including `?` from `ResolveMessage::create` below), so the VM's
         // `log` cannot be left pointing at the dropped stack `log`. Hand-roll
@@ -4223,6 +4227,17 @@ impl VirtualMachine {
                 let jsc_vm = self.vm.get().as_mut();
                 jsc_vm.log = Some(self.old_log);
                 jsc_vm.transpiler.resolver.log = self.old_log;
+                jsc_vm.transpiler.linker.log = self.old_log.as_ptr();
+                // `_resolve` may have lazily created the PM with
+                // `pm.log = resolver.log` (our stack `log`), so restore even
+                // if it was `None` when we swapped.
+                if let Some(pm) = jsc_vm.transpiler.resolver.package_manager {
+                    // SAFETY: sole `dyn AutoInstaller` impl is `PackageManager`.
+                    unsafe {
+                        (*pm.cast::<bun_install::PackageManager>().as_ptr()).log =
+                            self.old_log.as_ptr();
+                    }
+                }
             }
         }
         let _restore = RestoreLog {

--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -15,6 +15,7 @@
 #if !OS(WINDOWS)
 #include <stdatomic.h>
 
+#include <cassert>
 #include <signal.h>
 #include <termios.h>
 static int orig_termios_fd = -1;

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2157,31 +2157,18 @@ fn transpile_source_code_inner(
             let args_log_nn = core::ptr::NonNull::new(args.log).expect("args.log is non-null");
             unsafe {
                 (*jsc_vm).transpiler.log = args.log;
-                {
-                    (*jsc_vm).transpiler.resolver.log = args_log_nn;
-                }
-                // TODO(b2-blocked): `Linker` is a unit stub in `bun_bundler`
-                // — `.log` field un-gates with `linker.rs`.
-
-                {
-                    (*jsc_vm).transpiler.linker.log = args.log;
-                    if let Some(pm) = (*jsc_vm).transpiler.resolver.package_manager {
-                        // TODO(blocked_on): bun_resolver::package_json::PackageManager::log
-                        // — the resolver-side stub only exposes `lockfile`/`on_wake`.
-                        let _ = pm;
-                    }
+                (*jsc_vm).transpiler.resolver.log = args_log_nn;
+                (*jsc_vm).transpiler.linker.log = args.log;
+                if let Some(pm) = (*jsc_vm).transpiler.resolver.package_manager {
+                    (*pm.cast::<bun_install::PackageManager>().as_ptr()).log = args.log;
                 }
             }
             let _log_guard = scopeguard::guard(jsc_vm, move |jsc_vm| unsafe {
                 (*jsc_vm).transpiler.log = old_log;
-
-                {
-                    (*jsc_vm).transpiler.resolver.log = old_log_nn;
-                    (*jsc_vm).transpiler.linker.log = old_log;
-                    if let Some(pm) = (*jsc_vm).transpiler.resolver.package_manager {
-                        // TODO(blocked_on): bun_resolver::package_json::PackageManager::log
-                        let _ = pm;
-                    }
+                (*jsc_vm).transpiler.resolver.log = old_log_nn;
+                (*jsc_vm).transpiler.linker.log = old_log;
+                if let Some(pm) = (*jsc_vm).transpiler.resolver.package_manager {
+                    (*pm.cast::<bun_install::PackageManager>().as_ptr()).log = old_log;
                 }
             });
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4943,17 +4943,23 @@ unsafe fn resolve_hook(
         (*vm).log = Some(log_nn);
         (*vm).transpiler.resolver.log = log_nn;
         (*vm).transpiler.linker.log = log_nn.as_ptr();
-        // TODO(b2-cycle): `transpiler.resolver.package_manager` log swap —
-        // gated alongside the PM field (see transpile_source_code §log-swap).
+        if let Some(pm) = (*vm).transpiler.resolver.package_manager {
+            (*pm.cast::<bun_install::PackageManager>().as_ptr()).log = log_nn.as_ptr();
+        }
     }
     scopeguard::defer! {
         // SAFETY: `vm` is the live per-thread VM; restoring the log pointers
         // swapped just above so early-return paths don't leave a dangling
-        // stack pointer.
+        // stack pointer. The PM may have been lazily created inside
+        // `_resolve` with `pm.log = resolver.log` (our stack `log`), so
+        // restore it even if it was `None` at swap time.
         unsafe {
             (*vm).log = Some(old_log);
             (*vm).transpiler.resolver.log = old_log;
             (*vm).transpiler.linker.log = old_log.as_ptr();
+            if let Some(pm) = (*vm).transpiler.resolver.package_manager {
+                (*pm.cast::<bun_install::PackageManager>().as_ptr()).log = old_log.as_ptr();
+            }
         }
     }
 

--- a/test/js/bun/resolve/resolve-autoinstall-log-dangling.test.ts
+++ b/test/js/bun/resolve/resolve-autoinstall-log-dangling.test.ts
@@ -37,15 +37,14 @@ test("repeated failing auto-install resolves at varying stack depth don't read a
   `;
 
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", src],
+    // Force the auto-install path (PackageManager lazy init inside the
+    // resolver) without hitting the network — the registry hostname is
+    // unroutable, so every enqueued manifest fetch fails fast and routes
+    // through `manager.log_mut()`.
+    cmd: [bunExe(), "--install=fallback", "-e", src],
     cwd: String(dir),
     env: {
       ...bunEnv,
-      // Force the auto-install path (PackageManager lazy init inside the
-      // resolver) without hitting the network — the registry hostname is
-      // unroutable, so every enqueued manifest fetch fails fast and routes
-      // through `manager.log_mut()`.
-      BUN_CONFIG_INSTALL: "fallback",
       BUN_CONFIG_REGISTRY: "http://127.0.0.1:1",
     },
     stdout: "pipe",

--- a/test/js/bun/resolve/resolve-autoinstall-log-dangling.test.ts
+++ b/test/js/bun/resolve/resolve-autoinstall-log-dangling.test.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// When the runtime resolver's auto-install path lazily creates the
+// PackageManager, it snapshots `resolver.log` into `pm.log`. If the
+// PackageManager is created while the resolver log is pointed at a
+// stack-local `Log` inside `resolveMaybeNeedsTrailingSlash`, `pm.log` must be
+// restored to the VM log before returning, otherwise the next resolve at a
+// different stack depth dereferences dead stack memory when the HTTP task
+// fails and calls `manager.log_mut().add_error_fmt(...)`.
+test("repeated failing auto-install resolves at varying stack depth don't read a dangling pm.log", async () => {
+  // Run from an empty dir so the resolver falls through to the auto-install
+  // path instead of stopping at the repo's own node_modules.
+  using dir = tempDir("resolve-autoinstall-log", {});
+
+  const src = `
+    const realm = new ShadowRealm();
+    const variants = [
+      () => realm.importValue("pkg-not-found-a", "x"),
+      () => (() => realm.importValue("pkg-not-found-b", "x"))(),
+      () => (() => (() => realm.importValue("pkg-not-found-c", "x"))())(),
+      () => { try { return realm.importValue("pkg-not-found-d", "x"); } finally {} },
+      () => [realm.importValue("pkg-not-found-e", "x")][0],
+      () => import("pkg-not-found-f"),
+      () => (async () => realm.importValue("pkg-not-found-g", "x"))(),
+    ];
+    for (let i = 0; i < 100; i++) {
+      for (const v of variants) {
+        try {
+          const p = v();
+          if (p && p.catch) p.catch(() => {});
+        } catch {}
+      }
+    }
+    Bun.gc(true);
+    console.log("ok");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      // Force the auto-install path (PackageManager lazy init inside the
+      // resolver) without hitting the network — the registry hostname is
+      // unroutable, so every enqueued manifest fetch fails fast and routes
+      // through `manager.log_mut()`.
+      BUN_CONFIG_INSTALL: "fallback",
+      BUN_CONFIG_REGISTRY: "http://127.0.0.1:1",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/resolve/resolve-autoinstall-log-dangling.test.ts
+++ b/test/js/bun/resolve/resolve-autoinstall-log-dangling.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 // When the runtime resolver's auto-install path lazily creates the
@@ -52,11 +52,7 @@ test("repeated failing auto-install resolves at varying stack depth don't read a
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toBe("");
   expect(stdout.trim()).toBe("ok");


### PR DESCRIPTION
## What

`resolveMaybeNeedsTrailingSlash` swaps `vm.log` / `resolver.log` to a stack-local `Log` for the duration of `_resolve`, then restores them via a drop guard. The Zig original also swaps and restores `transpiler.linker.log` and `resolver.package_manager.log`; the Rust port had those behind a `TODO(b2-cycle)` and only handled `vm.log` + `resolver.log`.

When auto-install is enabled and the resolver lazily creates the `PackageManager` during `_resolve`, `Resolver::get_package_manager` seeds `pm.log` from `resolver.log` — which at that point is the **stack-local** `Log`. Because the restore guard never touched `pm.log`, it was left pointing into a dead stack frame after the function returned. The next resolve at a different stack depth that routes through the auto-install task runner dereferenced that stale pointer in `Log::add_error_fmt`, tripping ASAN's `stack-use-after-scope` (or segfaulting / executing garbage in release builds).

Stack at the fault:

```
#0  bun_ast::Log::add_formatted_msg
#1  bun_ast::Log::add_error_fmt
#2  bun_install::…::run_tasks
#7  bun_install::…::enqueue_dependency_to_root
#9  bun_resolver::Resolver::enqueue_dependency_to_resolve
#14 bun_resolver::Resolver::resolve_and_auto_install
#15 bun_jsc::VirtualMachine::_resolve
#16 bun_jsc::VirtualMachine::resolve_maybe_needs_trailing_slash::<true>
```

## Fix

Swap and restore `linker.log` and (when present) `package_manager.log` in both copies of the resolve log guard (`VirtualMachine::resolve_maybe_needs_trailing_slash` and `jsc_hooks::resolve_hook`), matching `VirtualMachine.zig`. The restore re-checks `resolver.package_manager` at drop time so a PM that was lazily created during `_resolve` is also pointed back at the VM log.

Also adds the missing `<cassert>` include in `wtf-bindings.cpp`, which stopped being pulled in transitively.

## Repro

```js
// run from an empty dir with
// BUN_CONFIG_INSTALL=fallback BUN_CONFIG_REGISTRY=http://127.0.0.1:1
const realm = new ShadowRealm();
const variants = [
  () => realm.importValue("pkg-not-found-a", "x"),
  () => (() => realm.importValue("pkg-not-found-b", "x"))(),
  () => (() => (() => realm.importValue("pkg-not-found-c", "x"))())(),
  () => import("pkg-not-found-f"),
];
for (let i = 0; i < 100; i++)
  for (const v of variants) try { v()?.catch?.(() => {}); } catch {}
```

Segfaults on `main`, clean after this change.

Fixes #14432
Fixes #22407