### PR TITLE
Shrink the footprint on OS memory-pressure notifications (opt-in)

### DIFF
--- a/src/analytics/lib.rs
+++ b/src/analytics/lib.rs
@@ -299,6 +299,7 @@ pub mod features {
         58 => (xml_parse, "xml_parse", core = XML_PARSE),
         /// A standalone executable whose embedded bytecode was produced on a different os/arch/libc than the one running it.
         59 => (cross_compiled_bytecode, "cross_compiled_bytecode"),
+        60 => (memory_pressure, "memory_pressure"),
     }
 
     // C++ declares these as `extern "C" size_t Bun__...;` and

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -240,6 +240,8 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_IPV4, "BUN_FEATURE_FLAG_DISABLE_IPV4", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_IPV6, "BUN_FEATURE_FLAG_DISABLE_IPV6", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_MEMFD, "BUN_FEATURE_FLAG_DISABLE_MEMFD", {});
+    // Shrink the footprint on OS memory pressure; see `bun_runtime::node::memory_pressure`.
+    new_feature_flag!(pub BUN_FEATURE_FLAG_EXPERIMENTAL_MEMORY_PRESSURE_HANDLER, "BUN_FEATURE_FLAG_EXPERIMENTAL_MEMORY_PRESSURE_HANDLER", {});
     // The RedisClient supports auto-pipelining by default. This flag disables that behavior.
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_REDIS_AUTO_PIPELINING, "BUN_FEATURE_FLAG_DISABLE_REDIS_AUTO_PIPELINING", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_RWF_NONBLOCK, "BUN_FEATURE_FLAG_DISABLE_RWF_NONBLOCK", {});

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2417,6 +2417,8 @@ unsafe extern "Rust" {
     /// `RuntimeHooks` is an immutable POD of fn-ptrs with a single definition;
     /// reading it has no precondition beyond the link succeeding → `safe static`.
     safe static __BUN_RUNTIME_HOOKS: RuntimeHooks;
+    /// Defined in `bun_runtime::node::memory_pressure`; no-op unless its feature flag is set.
+    safe fn __bun_memory_pressure_arm_handler(global: &JSGlobalObject);
 }
 
 #[inline]
@@ -2691,6 +2693,8 @@ impl VirtualMachine {
         if opts.is_main_thread {
             // SAFETY: `vm` is the freshly-initialised per-thread VM singleton.
             bun_io::ParentDeathWatchdog::install_on_event_loop(unsafe { Self::event_loop_ctx(vm) });
+            // Registers on the same loop, so the same ordering applies.
+            __bun_memory_pressure_arm_handler(JSGlobalObject::opaque_ref(global));
         }
 
         if opts.smol {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1742,6 +1742,9 @@ fn stop_active_handles(vm: &mut VirtualMachine, reason: StopReason) -> SweepResu
         return SweepResult::Idle;
     }
     let mut result = SweepResult::Idle;
+    if reason == StopReason::VmTeardown {
+        crate::node::memory_pressure::stop_for_vm_teardown(vm.global());
+    }
     // Fake-timer state lives in the per-thread `timer::All`, not the JS
     // global, so a file that leaves it active routes every later file's
     // `setTimeout` into the never-driven fake heap. Leave the heap itself

--- a/src/runtime/node/memory_pressure.rs
+++ b/src/runtime/node/memory_pressure.rs
@@ -24,7 +24,14 @@
 //! Armed lazily on the first listener and disarmed on the last removal via
 //! `onDidChangeListeners` in `BunProcess.cpp`, matching how signal handlers
 //! are wired. The watcher does not keep the event loop alive.
+//!
+//! `BUN_FEATURE_FLAG_EXPERIMENTAL_MEMORY_PRESSURE_HANDLER=1` arms the watcher
+//! at startup, independent of listeners, and has each notification
+//! `shrink_footprint` before the event is emitted.
 
+use core::sync::atomic::Ordering;
+
+use bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_EXPERIMENTAL_MEMORY_PRESSURE_HANDLER;
 use bun_event_loop::ConcurrentTask::{Task, task_tag};
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use bun_jsc::ArrayBuffer;
@@ -33,6 +40,8 @@ use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 #[cfg(not(windows))]
 use core::ptr::NonNull;
+
+bun_core::define_scoped_log!(log, MemoryPressure, hidden);
 
 /// Pressure level passed to JS. Values are the `NOTE_MEMORYSTATUS_PRESSURE_*`
 /// bits on macOS so the kqueue dispatch can pass `fflags` through unchanged.
@@ -45,6 +54,11 @@ unsafe extern "C" {
     fn Process__emitMemoryPressureEvent(global: *mut JSGlobalObject, level: i32);
 }
 
+#[inline]
+fn handler_enabled() -> bool {
+    BUN_FEATURE_FLAG_EXPERIMENTAL_MEMORY_PRESSURE_HANDLER.get() == Some(true)
+}
+
 /// `run_task` target for `task_tag::MemoryPressureTask`. `lvl` is the packed
 /// task payload (macOS kevent `fflags`, or `level::CRITICAL` elsewhere).
 pub(crate) fn emit(global: &JSGlobalObject, lvl: i32) {
@@ -54,8 +68,25 @@ pub(crate) fn emit(global: &JSGlobalObject, lvl: i32) {
     } else {
         level::WARNING
     };
+    if handler_enabled() {
+        shrink_footprint(global, lvl == level::CRITICAL);
+    }
     // SAFETY: FFI; `global` is the live per-thread global.
     unsafe { Process__emitMemoryPressureEvent(core::ptr::from_ref(global).cast_mut(), lvl) };
+}
+
+/// JS thread: sync GC now, then JSC's `shrinkFootprintWhenIdle` (JIT code and
+/// fastMalloc free memory, deferred until no JS is on the stack), then mimalloc.
+fn shrink_footprint(global: &JSGlobalObject, critical: bool) {
+    log!(
+        "memory pressure ({}); shrinking footprint",
+        if critical { "critical" } else { "warning" }
+    );
+    bun_analytics::features::memory_pressure.fetch_add(1, Ordering::Relaxed);
+    let vm = global.vm();
+    let _ = vm.run_gc(true);
+    vm.shrink_footprint();
+    bun_core::Global::mimalloc_cleanup(critical);
 }
 
 /// The queued form of a pressure notification: `Task::ptr` packs the level,
@@ -425,8 +456,42 @@ pub(crate) extern "C" fn Bun__MemoryPressure__install(global: &JSGlobalObject) {
     windows::install(global);
 }
 
+/// Link-time extern called by `bun_jsc::VirtualMachine::init` for the main thread.
+#[unsafe(no_mangle)]
+fn __bun_memory_pressure_arm_handler(global: &JSGlobalObject) {
+    if !handler_enabled() {
+        return;
+    }
+    log!("handler enabled; arming the OS watch at startup");
+    Bun__MemoryPressure__install(global);
+}
+
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn Bun__MemoryPressure__uninstall(global: &JSGlobalObject) {
+    // The handler keeps the watch until the VM is torn down.
+    if handler_enabled() {
+        return;
+    }
+    uninstall(global);
+}
+
+/// Stop phase of VM teardown: release the watch however it was armed (a
+/// listener still registered at exit, or the handler flag).
+pub(crate) fn stop_for_vm_teardown(global: &JSGlobalObject) {
+    // Peek without `rare_data()`, which would allocate RareData for a VM
+    // that never had any just to find the slot empty.
+    let armed = global
+        .bun_vm()
+        .as_mut()
+        .rare_data
+        .as_deref_mut()
+        .is_some_and(|rare| rare.memory_pressure_watcher_slot().is_some());
+    if armed {
+        uninstall(global);
+    }
+}
+
+fn uninstall(global: &JSGlobalObject) {
     #[cfg(not(windows))]
     posix::uninstall(global);
     #[cfg(windows)]

--- a/test/js/node/process/process-memory-pressure.test.ts
+++ b/test/js/node/process/process-memory-pressure.test.ts
@@ -9,10 +9,10 @@ import { closeSync, constants, openSync, readFileSync, writeSync } from "node:fs
 // The one test that arms a real PSI trigger first checks that this process
 // is allowed to create one, and is skipped otherwise.
 
-async function run(src: string) {
+async function run(src: string, env: Record<string, string | undefined> = bunEnv) {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", src],
-    env: bunEnv,
+    env,
     stderr: "pipe",
     stdout: "pipe",
   });
@@ -182,6 +182,61 @@ describe.concurrent("process.on('memoryPressure')", () => {
       process.stdout.write("done ");
     `);
     expect(stdout).toBe("done exit");
+    expect(exitCode).toBe(0);
+  });
+});
+
+// BUN_FEATURE_FLAG_EXPERIMENTAL_MEMORY_PRESSURE_HANDLER makes Bun itself react
+// to the notification (sync GC + JSC shrinkFootprint + mi_collect) before the
+// JS event is emitted, and keeps the OS watch armed for the whole process.
+describe.concurrent("BUN_FEATURE_FLAG_EXPERIMENTAL_MEMORY_PRESSURE_HANDLER", () => {
+  const handlerEnv = { ...bunEnv, BUN_FEATURE_FLAG_EXPERIMENTAL_MEMORY_PRESSURE_HANDLER: "1" };
+
+  test("a notification collects garbage before listeners run", async () => {
+    // The WeakRef referent is the deterministic signal that a full
+    // synchronous collection ran inside emit(): by the time the listener is
+    // called it must already be gone. Heap-size deltas are too noisy to
+    // assert on. Don't deref() before the notification: per spec that would
+    // add the referent to [[KeptAlive]] for the rest of this job.
+    const { stdout, stderr, exitCode } = await run(
+      /* js */ `
+        const { emitMemoryPressure } = require("bun:internal-for-testing");
+        function makeRef() { return new WeakRef({ sentinel: true }); }
+        const ref = makeRef();
+        const seen = [];
+        process.on("memoryPressure", level => seen.push({ level, collected: ref.deref() === undefined }));
+        emitMemoryPressure("critical");
+        process.stdout.write(JSON.stringify(seen));
+      `,
+      handlerEnv,
+    );
+    expect({ stdout, stderr: stderr.trim() }).toEqual({
+      stdout: JSON.stringify([{ level: "critical", collected: true }]),
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("the watch is armed at startup and outlives the last listener", async () => {
+    // exitCode 0 with the watch still armed doubles as the keep-alive check:
+    // the child ends when the script does, so the watch is not ref'ing the loop.
+    const { stdout, stderr, exitCode } = await run(
+      /* js */ `
+        const { isMemoryPressureWatcherInstalled } = require("bun:internal-for-testing");
+        const installed = [isMemoryPressureWatcherInstalled()]; // armed by the flag, no listener needed
+        const h = () => {};
+        process.on("memoryPressure", h);
+        installed.push(isMemoryPressureWatcherInstalled());
+        process.off("memoryPressure", h);
+        installed.push(isMemoryPressureWatcherInstalled()); // removing the last listener must not disarm it
+        process.stdout.write(JSON.stringify(installed));
+      `,
+      handlerEnv,
+    );
+    expect({ stdout, stderr: stderr.trim() }).toEqual({
+      stdout: JSON.stringify([true, true, true]),
+      stderr: "",
+    });
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- `process.on("memoryPressure")` (#32594) tells JS about an OS low-memory notification, but Bun itself does nothing with it: the JSC heap, JIT code and mimalloc's free segments stay resident until the next ordinary collection, which in a container commonly arrives after the OOM kill.
- The watch is also only armed while a JS listener exists, so there is no way to have Bun react in an app that never subscribes.

### Fix
- `src/runtime/node/memory_pressure.rs`: behind `BUN_FEATURE_FLAG_EXPERIMENTAL_MEMORY_PRESSURE_HANDLER=1`, `emit()` first calls `shrink_footprint()` (sync `VM::run_gc`, `VM::shrink_footprint`, `mi_collect`, bump `analytics.features.memory_pressure`) and then emits the event as before. The OS backends are the existing ones; this PR adds none.
- Same flag: `__bun_memory_pressure_arm_handler` arms the main thread's watch from `VirtualMachine::init` (next to `ParentDeathWatchdog`, same loop-ordering requirement), and `Bun__MemoryPressure__uninstall` keeps it armed when the last listener is removed.
- The watch is now also released in the stop phase of VM teardown (`stop_active_handles`, `VmTeardown` only). Before, only the last listener's removal freed it, so under `BUN_DESTRUCT_VM_ON_EXIT` a listener still registered at exit (and, with the flag, every process) left the watcher allocation behind; the ASAN lane reported it as a leak on the first push of this shape, and the listener-at-exit case reproduces locally on main too.
- `analytics`: new `memory_pressure` feature counter, so a later crash report carries `memory_pressure(N)`.
- Default off: the behaviour can be measured before it becomes the default.
- Verified: `test/js/node/process/process-memory-pressure.test.ts` (2 new tests; a `WeakRef` referent is gone by the time the listener runs, and `isMemoryPressureWatcherInstalled()` is `[true, true, true]` across startup / add / remove). Both fail on a build without this change (`collected: false`, `[false, true, false]`). With `BUN_DESTRUCT_VM_ON_EXIT=1` and `detect_leaks=1` (the ASAN lane's setup) the whole file is leak-clean; before the teardown release, 4 of its 7 tests leaked the watcher locally. `bun run rust:clippy` clean, `bun run rust:check-all` 12/12, `test/internal/source-lints/vm-thread-door.test.ts` unchanged.

### Background
- `VM::shrink_footprint` is JSC's `shrinkFootprintWhenIdle()`: it deletes all JIT code, runs another full collection and releases fastMalloc free memory, either immediately (no JS on the stack) or when the current entry scope pops. The explicit `run_gc(true)` before it reclaims JS objects right away regardless.
- `mi_collect(force)` walks mimalloc's thread heaps and returns fully free segments to the OS; it is what makes the RSS drop visible to the kernel rather than only to the allocator.
- `__bun_*` functions are `#[no_mangle]` Rust-ABI symbols defined in `bun_runtime` and declared `extern "Rust"` in `bun_jsc`, the existing way the lower-tier crate reaches runtime code at link time (see `__bun_stdio_blob_store_deinit`).

<details>
<summary>History: originally a port of #30403</summary>

This PR started as a Rust port of #30403 (a standalone watcher with its own PSI thread, libdispatch source and Win32 wait, ~1050 lines). While it was open, #32594 landed equivalent detection backends on main, integrated with `FilePoll` and the VM teardown door, so the PR was re-scoped to only the response half on top of them. The earlier review threads (EINTR handling, libdispatch barrier, Windows handle teardown) all concern code that no longer exists in this PR.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 7 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/process/process-memory-pressure.test.ts

<!-- robobun:evidence:end -->