### PR TITLE
fix: seal dispatch handles and reject corrupt lockfile dep ids

### DIFF
--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -629,10 +629,7 @@ bun_dispatch::link_interface! {
 }
 
 impl OutputSink {
-    pub const SYS: Self = Self {
-        kind: OutputSinkKind::Sys,
-        owner: core::ptr::null_mut(),
-    };
+    pub const SYS: Self = unsafe { Self::new(OutputSinkKind::Sys, core::ptr::null_mut::<()>()) };
 }
 
 // `bun_core` (T0) cannot name `bun_errno` (cycle). Single-variant link-interface
@@ -646,10 +643,7 @@ bun_dispatch::link_interface! {
 }
 
 impl ErrnoNames {
-    pub const SYS: Self = Self {
-        kind: ErrnoNamesKind::Sys,
-        owner: core::ptr::null_mut(),
-    };
+    pub const SYS: Self = unsafe { Self::new(ErrnoNamesKind::Sys, core::ptr::null_mut::<()>()) };
 }
 
 /// Compile-time `<tag>` → ANSI rewrite (proc-macro). Re-exported at crate root

--- a/src/dispatch/lib.rs
+++ b/src/dispatch/lib.rs
@@ -32,9 +32,17 @@
 //! ```
 //!
 //! `this` is `*mut T`; bodies run inside a macro-provided `unsafe { }` so
-//! `(*this)` derefs are bare. The validity invariant ("`owner` is a live
-//! `*mut T` matching `kind`") is established once at `unsafe fn
-//! <Iface>::new()` — that's the only `unsafe` the caller writes.
+//! `(*this)` derefs are bare. The owner invariant ("`owner` satisfies the
+//! concrete `link_impl_*!` body's assumptions for `kind`") is established once
+//! at `unsafe fn <Iface>::new()` — that's the only `unsafe` the caller writes.
+//!
+//! Handle fields are intentionally not constructible by safe code: the
+//! generated struct lives inside a private inner `mod __<Iface>_handle` with
+//! private `kind` and `owner` fields and is re-exported by type only, so the
+//! `link_interface!` invocation site (and any downstream crate) cannot forge
+//! a handle via struct literal — `let h = Shape { kind, owner: ... }` is a
+//! privacy error. The only public constructor is `unsafe fn new(kind, owner)`,
+//! which is where the caller establishes the owner invariant once.
 //!
 //! Every interface method must appear exactly once in each `link_impl_*!`
 //! call (an unknown name is a compile error from the generated macro; a
@@ -177,6 +185,7 @@ pub fn link_interface(input: TokenStream) -> TokenStream {
     // Nested in a private module so that a `link_impl_*!` in the *same* module
     // as `link_interface!` (e.g. tests, or a variant whose type lives in the
     // declaring crate) doesn't collide with the decl in the value namespace.
+    let handle_mod = format_ident!("__{}_handle", name);
     let externs_mod = format_ident!("__{}_externs", name);
     let externs = variants.iter().flat_map(|v| {
         methods.iter().map(move |m| {
@@ -299,36 +308,46 @@ pub fn link_interface(input: TokenStream) -> TokenStream {
         #[derive(Copy, Clone, PartialEq, Eq, Debug)]
         #vis enum #kind { #(#variants),* }
 
-        #[derive(Copy, Clone)]
-        #vis struct #name {
-            pub kind: #kind,
-            pub owner: *mut (),
-        }
-
-        impl #name {
-            /// SAFETY: `owner` must be a live `*mut T` where `T` is the
-            /// concrete type the `kind` variant's `link_impl_*!` was written
-            /// for, and must remain live for every dispatch through the
-            /// returned handle. This is the only place the caller writes
-            /// `unsafe` for this interface — the dispatch methods are safe
-            /// given this precondition.
-            #[inline]
-            pub unsafe fn new<T: ?Sized>(kind: #kind, owner: *mut T) -> Self {
-                Self { kind, owner: owner as *mut () }
-            }
-            #[inline]
-            pub fn is(&self, kind: #kind) -> bool { self.kind == kind }
-        }
-
         #(#sig_aliases)*
 
         #[allow(non_snake_case)]
-        mod #externs_mod {
+        mod #handle_mod {
             use super::*;
-            unsafe extern "Rust" { #(#externs)* }
+
+            #[derive(Copy, Clone)]
+            pub struct #name {
+                kind: #kind,
+                owner: *mut (),
+            }
+
+            impl #name {
+                /// SAFETY: `owner` must satisfy the concrete `kind` variant's
+                /// `link_impl_*!` bodies for every dispatch through the returned
+                /// handle. Usually this means a live `*mut T`, where `T` is the
+                /// implementation type for `kind`. Null is only valid for
+                /// implementations that never dereference `this`.
+                #[inline]
+                pub const unsafe fn new<T: ?Sized>(kind: #kind, owner: *mut T) -> Self {
+                    Self { kind, owner: owner as *mut () }
+                }
+                #[inline]
+                pub fn is(&self, kind: #kind) -> bool { self.kind == kind }
+                #[inline]
+                pub(crate) fn owner_is_null(&self) -> bool { self.owner.is_null() }
+                #[inline]
+                pub(crate) fn owner_ptr(&self) -> *mut () { self.owner }
+            }
+
+            #[allow(non_snake_case)]
+            mod #externs_mod {
+                use super::*;
+                unsafe extern "Rust" { #(#externs)* }
+            }
+
+            impl #name { #(#dispatchers)* }
         }
 
-        impl #name { #(#dispatchers)* }
+        #vis use #handle_mod::#name;
 
         // `#[macro_export]` hoists this to the *crate root* of whichever crate
         // calls `link_interface!`, regardless of the call-site module — so

--- a/src/event_loop/AnyEventLoop.rs
+++ b/src/event_loop/AnyEventLoop.rs
@@ -403,7 +403,7 @@ impl EventLoopHandle {
     #[inline]
     pub fn into_tag_ptr(self) -> (core::ffi::c_char, *mut core::ffi::c_void) {
         match self {
-            EventLoopHandle::Js { owner, .. } => (1, owner.owner.cast()),
+            EventLoopHandle::Js { owner, .. } => (1, owner.owner_ptr().cast()),
             EventLoopHandle::Mini(mini) => (2, mini.as_ptr().cast()),
         }
     }

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -168,6 +168,8 @@ pub enum SubtreeError {
     OutOfMemory,
     #[error("DependencyLoop")]
     DependencyLoop,
+    #[error("CorruptLockfile")]
+    CorruptLockfile,
 }
 
 bun_core::oom_from_alloc!(SubtreeError);
@@ -1011,20 +1013,26 @@ impl Tree {
                 .get(builder.list.items_dependencies()[self_id as usize].as_slice());
             (s.as_ptr(), s.len())
         };
-        // Keep the comparand in a register; `deps.get_unchecked` may alias `dependency`.
         let target_name_hash = dependency.name_hash;
         for i in 0..this_deps_len {
             // SAFETY: `i < this_deps_len` and `builder.list` is not mutated until after this loop
             // (see invariant above), so `this_deps_ptr[0..this_deps_len)` remains valid.
             let dep_id: DependencyID = unsafe { *this_deps_ptr.add(i) };
-            // SAFETY: `dep_id` was produced by the same lockfile that produced `deps`;
-            // Zig release builds have no bounds check here.
-            let dep = unsafe { deps.get_unchecked(dep_id as usize) };
+            // `dep_id` is deserialized from lockfile bytes (`Buffers::read_array<DependencyID>`)
+            // and so is attacker-controlled in the hostile-lockfile threat model. A `dep_id`
+            // outside `0..deps.len()` used to produce an out-of-bounds read through
+            // `get_unchecked` (Bucket 4/15 UB; audit witness EXP-007). Do not silently
+            // skip it: malformed lockfile graph data must fail closed.
+            let Some(dep) = deps.get(dep_id as usize) else {
+                return Err(SubtreeError::CorruptLockfile);
+            };
             if dep.name_hash != target_name_hash {
                 continue;
             }
 
-            let res_id = builder.resolutions[dep_id as usize];
+            let Some(&res_id) = builder.resolutions.get(dep_id as usize) else {
+                return Err(SubtreeError::CorruptLockfile);
+            };
 
             if res_id == invalid_package_id && package_id == invalid_package_id {
                 debug_assert!(dep.behavior.is_optional_peer());

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -1126,20 +1126,17 @@ impl Tree {
 
         // this dependency was not found in this tree, try hoisting or placing in the next parent
         if this.parent != INVALID_ID && this.id != hoist_root_id {
-            let id = match Tree::hoist_dependency::<false, METHOD>(
+            // `hoist_dependency::<false, _>` can return `Err(SubtreeError::CorruptLockfile)`
+            // on attacker-controlled lockfile bytes (an out-of-range `dep_id`); propagate
+            // it so corrupt input fails closed instead of reaching UB on a stale
+            // `unreachable_unchecked` invariant.
+            let id = Tree::hoist_dependency::<false, METHOD>(
                 this.parent,
                 hoist_root_id,
                 package_id,
                 input_dep_id,
                 builder,
-            ) {
-                Ok(id) => id,
-                // SAFETY: `hoist_dependency::<false, _>` never returns `Err` —
-                // the only `Err(SubtreeError::DependencyLoop)` site above is
-                // gated on `AS_DEFINED`. Avoids faulting panic-format pages on
-                // the per-dependency recursion.
-                Err(_) => unsafe { core::hint::unreachable_unchecked() },
-            };
+            )?;
             if !AS_DEFINED || !matches!(id, HoistDependencyResult::DependencyLoop) {
                 return Ok(id); // 1 or 2
             }

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -2772,6 +2772,7 @@ pub fn parse_into_binary_lockfile(
             return Err(match err {
                 tree::SubtreeError::OutOfMemory => ParseError::OutOfMemory,
                 tree::SubtreeError::DependencyLoop => ParseError::InvalidPackagesObject,
+                tree::SubtreeError::CorruptLockfile => ParseError::InvalidPackagesObject,
             });
         }
     }

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -168,6 +168,7 @@ impl From<crate::lockfile_real::tree::SubtreeError> for MigratePnpmLockfileError
         match e {
             E::OutOfMemory => Self::OutOfMemory,
             E::DependencyLoop => Self::DependencyLoop,
+            E::CorruptLockfile => Self::InvalidPnpmLockfile,
         }
     }
 }

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -115,7 +115,7 @@ pub(crate) fn call_exit_handler(
     rusage: &Rusage,
 ) {
     let Some(h) = h else { return };
-    if h.owner.is_null() {
+    if h.owner_is_null() {
         return;
     }
     h.on_process_exit(process, status, rusage);


### PR DESCRIPTION
## Summary

This PR applies two small fixes from the UB audit in #30903 and includes one one-line build unblock needed for the current local debug build.

- Seal `bun_dispatch::link_interface!` handle fields by generating the handle struct inside a private child module and re-exporting only the type. External and same-module safe code can still name/pass the handle, but cannot forge `Handle { kind, owner }`; callers must use the existing `unsafe fn new(...)` constructor boundary. A `compile_fail` doctest now locks this down.
- Reject corrupt lockfile dependency ids in `Tree::hoist_dependency`. The `dep_id` value comes from lockfile bytes; an out-of-range id now fails closed with `SubtreeError::CorruptLockfile` instead of reaching the old `get_unchecked` OOB read. The paired `resolutions` lookup is checked at the same trust boundary, and the new error is mapped through bun.lock and pnpm migration parsing as invalid lockfile data.
- Include `<cassert>` in `wtf-bindings.cpp` so the current debug build can see `assert(...)` under this clang/PCH configuration.

Refs #30903.

## Verification

- `cargo test -p bun_dispatch`
- `env CARGO_TARGET_DIR=/tmp/bun-ub-fixes-demo-3-target cargo check -p bun_install`
- `env CARGO_TARGET_DIR=/tmp/bun-ub-fixes-demo-3-target cargo check --workspace`
- `bun bd test test/js/bun/util/bun-file-exists.test.js`

I also attempted the more directly related install smoke:

- `bun bd test test/cli/install/bun-lock.test.ts -t "should convert a binary lockfile with invalid optional peers"`

That run built the debug binary after the `<cassert>` fix, but the test harness failed before exercising this change because this checkout cannot resolve `verdaccio/bin/verdaccio` from `test/harness.ts`.
