### PR TITLE
elf: pick the writable PT_LOAD that contains .bun, not the first one

### DIFF
--- a/src/exe_format/elf.rs
+++ b/src/exe_format/elf.rs
@@ -212,17 +212,28 @@ impl ElfFile {
         let ehdr = read_ehdr(&self.data);
         let bun_section = self.find_bun_section(ehdr)?;
         let bun_section_offset = bun_section.file_offset;
+        let bun_section_vaddr = bun_section.vaddr;
         let page_size = Self::page_size(ehdr);
 
         let header_size: u64 = size_of::<u64>() as u64;
         let new_content_size: u64 = header_size + payload.len() as u64;
         let aligned_new_size = align_up(new_content_size, page_size);
 
-        // Locate the writable PT_LOAD we'll extend. .bun lives in this
-        // segment already (BlobHeader is `aligned(16K)` + PROGBITS with WA
-        // flags). Growing an existing PT_LOAD is the layout a linker would
-        // naturally produce; WSL1's kernel loader rejects binaries that
-        // instead add a late PT_LOAD by repurposing PT_GNU_STACK (#29963).
+        // Locate the writable PT_LOAD we'll extend — the one that actually
+        // contains `.bun`. A template bun binary post-processed by `patchelf`
+        // (NixOS `autoPatchelfHook`, #31023) has a *second* writable PT_LOAD
+        // inserted at the front of the program header table to hold the
+        // relocated PHDR + `.interp`. That front segment is unrelated to
+        // `.bun`; extending it would produce a segment whose file/memory
+        // range overlaps the read-only and executable PT_LOADs at conflicting
+        // vaddrs and the resulting binary segfaults in the loader.
+        //
+        // Match by vaddr containment so we grow the same PT_LOAD `.bun`
+        // already lives in (BlobHeader is `aligned(16K)` + PROGBITS with WA
+        // flags, so this is always a writable PT_LOAD). Growing that
+        // PT_LOAD is the layout a linker would naturally produce; WSL1's
+        // kernel loader rejects binaries that instead add a late PT_LOAD by
+        // repurposing PT_GNU_STACK (#29963).
         let phdr_size = size_of::<Elf64_Phdr>();
         let mut rw_phdr_index: Option<usize> = None;
         let mut rw_phdr: Elf64_Phdr = Elf64_Phdr::ZEROED;
@@ -239,7 +250,10 @@ impl ElfFile {
                 max_vaddr_end = vaddr_end;
             }
 
-            if (phdr.p_flags & PF_W) != 0 && rw_phdr_index.is_none() {
+            if (phdr.p_flags & PF_W) != 0
+                && phdr.p_vaddr <= bun_section_vaddr
+                && bun_section_vaddr < vaddr_end
+            {
                 rw_phdr_index = Some(i);
                 rw_phdr = phdr;
             }
@@ -467,6 +481,7 @@ impl ElfFile {
                 if name == b".bun" {
                     return Ok(BunSectionInfo {
                         file_offset: shdr.sh_offset,
+                        vaddr: shdr.sh_addr,
                         section_index: u16::try_from(i).expect("int cast"),
                     });
                 }
@@ -499,6 +514,10 @@ impl ElfFile {
 struct BunSectionInfo {
     /// File offset of the .bun section's data (sh_offset).
     file_offset: u64,
+    /// Virtual address of the .bun section (sh_addr). Used to pick the
+    /// writable PT_LOAD that already contains .bun when multiple writable
+    /// PT_LOADs exist (e.g. patchelf'd templates; see #31023).
+    vaddr: u64,
     /// Index of the .bun section in the section header table.
     section_index: u16,
 }

--- a/src/exe_format/elf.rs
+++ b/src/exe_format/elf.rs
@@ -219,21 +219,11 @@ impl ElfFile {
         let new_content_size: u64 = header_size + payload.len() as u64;
         let aligned_new_size = align_up(new_content_size, page_size);
 
-        // Locate the writable PT_LOAD we'll extend — the one that actually
-        // contains `.bun`. A template bun binary post-processed by `patchelf`
-        // (NixOS `autoPatchelfHook`, #31023) has a *second* writable PT_LOAD
-        // inserted at the front of the program header table to hold the
-        // relocated PHDR + `.interp`. That front segment is unrelated to
-        // `.bun`; extending it would produce a segment whose file/memory
-        // range overlaps the read-only and executable PT_LOADs at conflicting
-        // vaddrs and the resulting binary segfaults in the loader.
-        //
-        // Match by vaddr containment so we grow the same PT_LOAD `.bun`
-        // already lives in (BlobHeader is `aligned(16K)` + PROGBITS with WA
-        // flags, so this is always a writable PT_LOAD). Growing that
-        // PT_LOAD is the layout a linker would naturally produce; WSL1's
-        // kernel loader rejects binaries that instead add a late PT_LOAD by
-        // repurposing PT_GNU_STACK (#29963).
+        // Extend the writable PT_LOAD that contains `.bun` (matched by vaddr,
+        // not "first writable": patchelf'd templates have an extra writable
+        // PT_LOAD holding the relocated PHDR + `.interp`, #31023). Growing an
+        // existing PT_LOAD rather than adding a late one is required by
+        // WSL1's kernel loader (#29963).
         let phdr_size = size_of::<Elf64_Phdr>();
         let mut rw_phdr_index: Option<usize> = None;
         let mut rw_phdr: Elf64_Phdr = Elf64_Phdr::ZEROED;
@@ -514,9 +504,7 @@ impl ElfFile {
 struct BunSectionInfo {
     /// File offset of the .bun section's data (sh_offset).
     file_offset: u64,
-    /// Virtual address of the .bun section (sh_addr). Used to pick the
-    /// writable PT_LOAD that already contains .bun when multiple writable
-    /// PT_LOADs exist (e.g. patchelf'd templates; see #31023).
+    /// Virtual address of the .bun section (sh_addr).
     vaddr: u64,
     /// Index of the .bun section in the section header table.
     section_index: u16,

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isArm64, isLinux, isMacOS, isMusl, isPosix, isWindows, tempDir } from "harness";
-import { chmodSync } from "node:fs";
+import { chmodSync, cpSync, existsSync } from "node:fs";
 import { join } from "path";
 
 describe("Bun.build compile", () => {
@@ -462,6 +462,166 @@ if (isLinux) {
       expect(stdout).toContain("wsl1-regression-20000");
       expect(exitCode).toBe(0);
     }, 60_000);
+
+    // Regression guard for #31023. On NixOS, `autoPatchelfHook` runs
+    // `patchelf --set-interpreter` on the installed bun binary. Patchelf
+    // inserts a *new* writable PT_LOAD at the front of the program-header
+    // table (to hold the relocated PHDR + .interp), so the template bun
+    // has TWO writable PT_LOADs. `write_bun_section` used to pick the
+    // first writable PT_LOAD and extend it — that's patchelf's small
+    // segment, unrelated to .bun — producing an output whose grown
+    // segment overlaps the read-only and executable PT_LOADs at
+    // conflicting vaddrs. The kernel ELF loader mmap'd garbage over .bun
+    // at its runtime address and the compiled binary segfaulted on exec.
+    //
+    // We simulate the NixOS layout by running `patchelf
+    // --set-interpreter` on the bun binary (exactly what
+    // autoPatchelfHook does) and then using `--compile-executable-path`
+    // to drive `bun build --compile` off it. The resulting output must
+    // (a) have the .bun section inside a writable PT_LOAD whose extent
+    // doesn't cross another PT_LOAD, and (b) actually run.
+    const patchelf = Bun.which("patchelf");
+    const ldso =
+      process.arch === "arm64"
+        ? isMusl
+          ? "/lib/ld-musl-aarch64.so.1"
+          : "/lib/ld-linux-aarch64.so.1"
+        : isMusl
+          ? "/lib/ld-musl-x86_64.so.1"
+          : "/lib64/ld-linux-x86-64.so.2";
+    test.skipIf(!patchelf || !existsSync(ldso))(
+      "compiled binary works when template bun has patchelf-inserted RW PT_LOAD (#31023)",
+      async () => {
+        using dir = tempDir("build-compile-patchelf-rw-regression", {
+          "app.js": `console.log("patchelf-regression-ok");`,
+        });
+        const cwd = String(dir);
+
+        // Copy bun and patchelf it — autoPatchelfHook's signature move.
+        // Any real interpreter works; we just need patchelf to insert its
+        // new writable PT_LOAD at the front of the phdr table.
+        const patchedBun = join(cwd, "patched-bun");
+        cpSync(bunExe(), patchedBun);
+        chmodSync(patchedBun, 0o755);
+        {
+          const r = Bun.spawnSync({
+            cmd: [patchelf!, "--set-interpreter", ldso, patchedBun],
+            stderr: "pipe",
+          });
+          expect(r.stderr.toString()).toBe("");
+          expect(r.exitCode).toBe(0);
+        }
+
+        // Sanity: the patched bun really does have two writable PT_LOADs.
+        // Otherwise the test is vacuous (it would exercise the same path
+        // as the stock-bun tests above).
+        {
+          const bytes = new Uint8Array(await Bun.file(patchedBun).arrayBuffer());
+          const view = new DataView(bytes.buffer);
+          const phoff = Number(view.getBigUint64(32, true));
+          const phentsize = view.getUint16(54, true);
+          const phnum = view.getUint16(56, true);
+          let writableLoads = 0;
+          for (let i = 0; i < phnum; i++) {
+            const off = phoff + i * phentsize;
+            const pType = view.getUint32(off, true);
+            const pFlags = view.getUint32(off + 4, true);
+            if (pType === 1 /* PT_LOAD */ && (pFlags & 2) !== 0 /* PF_W */) writableLoads++;
+          }
+          expect(writableLoads).toBeGreaterThanOrEqual(2);
+        }
+
+        // Drive bun build --compile off the patched template.
+        const outfile = join(cwd, "app-out");
+        const build = Bun.spawnSync({
+          cmd: [
+            bunExe(),
+            "build",
+            "--compile",
+            "--compile-executable-path",
+            patchedBun,
+            join(cwd, "app.js"),
+            "--outfile",
+            outfile,
+          ],
+          env: bunEnv,
+          cwd,
+          stderr: "pipe",
+          stdout: "pipe",
+        });
+        expect(build.stderr.toString()).not.toContain("error:");
+        expect(build.exitCode).toBe(0);
+
+        // Structural check on the output: the writable PT_LOAD that
+        // contains .bun must not overlap any other PT_LOAD. Before the
+        // fix, the grown front PT_LOAD extended past the R and R-E
+        // PT_LOADs, which is exactly the corruption that segfaulted.
+        const bytes = new Uint8Array(await Bun.file(outfile).arrayBuffer());
+        const view = new DataView(bytes.buffer);
+        const phoff = Number(view.getBigUint64(32, true));
+        const phentsize = view.getUint16(54, true);
+        const phnum = view.getUint16(56, true);
+        const shoff = Number(view.getBigUint64(40, true));
+        const shentsize = view.getUint16(58, true);
+        const shnum = view.getUint16(60, true);
+        const shstrndx = view.getUint16(62, true);
+        const strtabHdr = shoff + shstrndx * shentsize;
+        const strtabOff = Number(view.getBigUint64(strtabHdr + 24, true));
+        const strtabSize = Number(view.getBigUint64(strtabHdr + 32, true));
+
+        // Find .bun's vaddr.
+        const decoder = new TextDecoder();
+        let bunAddr = 0n;
+        for (let i = 0; i < shnum; i++) {
+          const hdrOff = shoff + i * shentsize;
+          const nameIdx = view.getUint32(hdrOff, true);
+          if (nameIdx >= strtabSize) continue;
+          let end = strtabOff + nameIdx;
+          while (end < bytes.length && bytes[end] !== 0) end++;
+          const name = decoder.decode(bytes.slice(strtabOff + nameIdx, end));
+          if (name === ".bun") {
+            bunAddr = view.getBigUint64(hdrOff + 16, true);
+            break;
+          }
+        }
+        expect(bunAddr).not.toBe(0n);
+
+        // Collect all PT_LOAD ranges; find the one that covers .bun and
+        // assert it doesn't overlap any of the others.
+        type LoadSeg = { vaddr: bigint; end: bigint; writable: boolean };
+        const loads: LoadSeg[] = [];
+        for (let i = 0; i < phnum; i++) {
+          const off = phoff + i * phentsize;
+          if (view.getUint32(off, true) !== 1 /* PT_LOAD */) continue;
+          const pFlags = view.getUint32(off + 4, true);
+          const pVaddr = view.getBigUint64(off + 16, true);
+          const pMemsz = view.getBigUint64(off + 40, true);
+          loads.push({ vaddr: pVaddr, end: pVaddr + pMemsz, writable: (pFlags & 2) !== 0 });
+        }
+        const bunLoadIdx = loads.findIndex(s => s.writable && s.vaddr <= bunAddr && bunAddr < s.end);
+        expect(bunLoadIdx).toBeGreaterThanOrEqual(0);
+        const bunLoad = loads[bunLoadIdx];
+        for (let i = 0; i < loads.length; i++) {
+          if (i === bunLoadIdx) continue;
+          const other = loads[i];
+          // Disjoint: either bunLoad ends before other starts, or other
+          // ends before bunLoad starts.
+          const disjoint = bunLoad.end <= other.vaddr || other.end <= bunLoad.vaddr;
+          expect(disjoint).toBe(true);
+        }
+
+        // And the binary actually runs — the ultimate behavioral check.
+        await using proc = Bun.spawn({
+          cmd: [outfile],
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stdout.trim()).toBe("patchelf-regression-ok");
+        expect(exitCode).toBe(0);
+      },
+      180_000,
+    );
   });
 }
 

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isArm64, isLinux, isMacOS, isMusl, isPosix, isWindows, tempDir } from "harness";
-import { chmodSync, cpSync, existsSync } from "node:fs";
+import { chmodSync, closeSync, cpSync, existsSync, openSync, readSync } from "node:fs";
 import { join } from "path";
 
 describe("Bun.build compile", () => {
@@ -489,7 +489,51 @@ if (isLinux) {
         : isMusl
           ? "/lib/ld-musl-x86_64.so.1"
           : "/lib64/ld-linux-x86-64.so.2";
-    test.skipIf(!patchelf || !existsSync(ldso))(
+
+    // Mirror of `hostUsesNixStoreInterpreter()` in src/exe_format/elf.rs:
+    // gate out NixOS/Guix hosts where the FHS ldso path is a stub that
+    // refuses to exec generic binaries. Without this the final
+    // `Bun.spawn({cmd:[outfile]})` check fails on a NixOS host because
+    // stub-ld rejects the compiled output, not because the fix is broken.
+    // Same pattern as the sibling patchelf tests in
+    // test/regression/issue/29290.test.ts and 24742.test.ts.
+    function readInterp(buf: Buffer): string | null {
+      if (buf.length < 64 || buf.readUInt32BE(0) !== 0x7f454c46) return null;
+      const e_phoff = Number(buf.readBigUInt64LE(32));
+      const e_phnum = buf.readUInt16LE(56);
+      for (let i = 0; i < e_phnum; i++) {
+        const ph = e_phoff + i * 56;
+        if (buf.readUInt32LE(ph) !== 3 /* PT_INTERP */) continue;
+        const p_offset = Number(buf.readBigUInt64LE(ph + 8));
+        const p_filesz = Number(buf.readBigUInt64LE(ph + 32));
+        const region = buf.subarray(p_offset, p_offset + p_filesz);
+        const nul = region.indexOf(0);
+        return region.subarray(0, nul === -1 ? region.length : nul).toString("utf8");
+      }
+      return null;
+    }
+    function hostLooksNix(): boolean {
+      if (existsSync("/etc/NIXOS")) return true;
+      if (existsSync("/gnu/store")) return true;
+      try {
+        // bun is ~1 GB in debug builds; PT_INTERP lives in the first page,
+        // so read only the leading 4 KiB.
+        const fd = openSync(bunExe(), "r");
+        try {
+          const buf = Buffer.alloc(4096);
+          const n = readSync(fd, buf, 0, 4096, 0);
+          const selfInterp = readInterp(buf.subarray(0, n));
+          if (selfInterp && (selfInterp.startsWith("/nix/store/") || selfInterp.startsWith("/gnu/store/"))) {
+            return true;
+          }
+        } finally {
+          closeSync(fd);
+        }
+      } catch {}
+      return false;
+    }
+
+    test.skipIf(!patchelf || !existsSync(ldso) || hostLooksNix())(
       "compiled binary works when template bun has patchelf-inserted RW PT_LOAD (#31023)",
       async () => {
         using dir = tempDir("build-compile-patchelf-rw-regression", {


### PR DESCRIPTION
Fixes #31023.

## Reproduction

```console
$ cp $(which bun) ./bun-patched
$ patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 ./bun-patched
$ echo "console.log('hi');" > main.ts
$ ./bun-patched build --compile main.ts --outfile main
$ ./main
Segmentation fault (core dumped)
```

This is the NixOS layout: `autoPatchelfHook` runs `patchelf --set-interpreter` on installed binaries, so every bun compiled on NixOS produced segfaulting output (linked nixpkgs PR: NixOS/nixpkgs#519796).

## Root cause

Regressed in 1.3.14 via #29967 (fix for WSL1 ENOEXEC, #29963). That PR switched from repurposing `PT_GNU_STACK` to extending an existing writable `PT_LOAD`, but picked the **first** writable `PT_LOAD` encountered in the program header table:

```rust
if (phdr.p_flags & PF_W) != 0 && rw_phdr_index.is_none() {
    rw_phdr_index = Some(i);
    rw_phdr = phdr;
}
```

On a stock bun the only writable `PT_LOAD` *is* the one containing `.bun`. On a patchelf'd bun there are **two**, because patchelf inserts a new one at the front to hold the relocated PHDR + `.interp`:

```
LOAD  vaddr=0x1fe000   filesz=0x290      RW   ← patchelf-inserted (PHDR + .interp)
LOAD  vaddr=0x200254   filesz=~32 MB     R
LOAD  vaddr=0x24c7e00  filesz=~56 MB     R E
LOAD  vaddr=0x5c95910  filesz=0x349e0    RW   ← the real RW PT_LOAD; .bun lives here
```

Picking the first one and extending it to cover `.bun` at vaddr `0x5e88000` produced a `filesz ≈ 96 MB` segment starting at `0x1fe000` — overlapping the R and R-E `PT_LOAD`s at conflicting vaddrs. The kernel loader mmap'd the new segment's file bytes over `.bun`'s runtime address and the binary segfaulted on `execve`.

## Fix

Pick the writable `PT_LOAD` by **vaddr containment of `.bun`'s `sh_addr`**, not by order:

```rust
if (phdr.p_flags & PF_W) != 0
    && phdr.p_vaddr <= bun_section_vaddr
    && bun_section_vaddr < vaddr_end
{
    rw_phdr_index = Some(i);
    rw_phdr = phdr;
}
```

On a stock bun this picks the same segment as before (only one writable PT_LOAD). On a patchelf'd bun it picks the later segment that actually contains `.bun`, so the grown segment doesn't collide with anything.

## Verification

**Before** the fix, on a `patchelf --set-interpreter`'d bun:

```
LOAD  vaddr=0x1fe000    filesz=0x51fa000  RW   ← grown to 82 MB, overlaps R/R-E
LOAD  vaddr=0x200254    filesz=~32 MB     R
LOAD  vaddr=0x21ef400   filesz=~49 MB     R E
LOAD  vaddr=0x5183c60   filesz=0xc14c0    RW
```

**After** the fix:

```
LOAD  vaddr=0x1fe000    filesz=0x2c8      RW   ← patchelf's small segment, untouched
LOAD  vaddr=0x20028c    filesz=~127 MB    R
LOAD  vaddr=0x810b600   filesz=~255 MB    R E
LOAD  vaddr=0x1805ab40  filesz=~60 MB     RW   ← grown to cover .bun at 0x18074000
```

The compiled binary runs.

## Test

`test/bundler/bun-build-compile.test.ts` gets a new entry in the existing `ELF section` describe block that:

1. `patchelf --set-interpreter`'s the bun binary (exactly what `autoPatchelfHook` does).
2. Asserts the resulting template has ≥2 writable `PT_LOAD`s (otherwise the test is vacuous).
3. Drives `bun build --compile` through `--compile-executable-path` pointing at the patched template.
4. Structural check: the writable `PT_LOAD` covering `.bun` must not overlap any other `PT_LOAD`.
5. Behavioral check: the compiled binary actually runs.

Gated on `patchelf` being available + ldso existing, same style as the existing #29290 regression test.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 9 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-compile.test.ts

<!-- robobun:evidence:end -->