### PR TITLE
perf: remove redundant clones in ESM package maps

### DIFF
--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1969,13 +1969,13 @@ impl Entry {
         matches!(&self.data, EntryData::Map(m) if !m.list.is_empty() && strings::starts_with_char(&m.list[0].key, b'.'))
     }
 
-    pub fn value_for_key(&self, key_: &[u8]) -> Option<Entry> {
+    pub fn value_for_key(&self, key_: &[u8]) -> Option<&Entry> {
         match &self.data {
             EntryData::Map(m) => {
                 // TODO(port): bun_collections::MultiArrayList column accessor; Vec placeholder.
                 for entry in m.list.iter() {
                     if strings::eql(&entry.key, key_) {
-                        return Some(entry.value.clone());
+                        return Some(&entry.value);
                     }
                 }
 
@@ -1990,7 +1990,7 @@ pub type ConditionsMap = StringArrayHashMap<()>;
 
 pub struct ESModule<'a> {
     pub debug_logs: Option<&'a mut resolver::DebugLogs>,
-    pub conditions: ConditionsMap,
+    pub conditions: &'a ConditionsMap,
     // allocator dropped — global mimalloc
     pub module_type: &'a mut ModuleType,
 }
@@ -2487,27 +2487,19 @@ impl<'a> ESModule<'a> {
         }
 
         if subpath == b"." {
-            let mut main_export = Entry {
-                data: EntryData::Null,
-                first_token: bun_ast::Range::NONE,
+            let main_export: Option<&Entry> = match &exports.data {
+                EntryData::String(_) | EntryData::Array(_) => Some(exports),
+                EntryData::Map(_) if !exports.keys_start_with_dot() => Some(exports),
+                EntryData::Map(_) => exports.value_for_key(b"."),
+                _ => None,
             };
-            let cond = match &exports.data {
-                EntryData::String(_) | EntryData::Array(_) => true,
-                EntryData::Map(_) => !exports.keys_start_with_dot(),
-                _ => false,
-            };
-            if cond {
-                main_export = exports.clone();
-            } else if matches!(exports.data, EntryData::Map(_)) {
-                if let Some(value) = exports.value_for_key(b".") {
-                    main_export = value;
-                }
-            }
 
-            if !matches!(main_export.data, EntryData::Null) {
-                let result = self.resolve_target::<false>(package_url, &main_export, b"", false);
-                if result.status != Status::Null && result.status != Status::Undefined {
-                    return result;
+            if let Some(main_export) = main_export {
+                if !matches!(main_export.data, EntryData::Null) {
+                    let result = self.resolve_target::<false>(package_url, main_export, b"", false);
+                    if result.status != Status::Null && result.status != Status::Undefined {
+                        return result;
+                    }
                 }
             }
         } else if matches!(exports.data, EntryData::Map(_)) && exports.keys_start_with_dot() {
@@ -2566,7 +2558,7 @@ impl<'a> ESModule<'a> {
                     log.add_note_fmt(format_args!("Found \"{}\"", bstr::BStr::new(match_key)));
                 }
 
-                return self.resolve_target::<false>(package_url, &target, b"", is_imports);
+                return self.resolve_target::<false>(package_url, target, b"", is_imports);
             }
         }
 

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2747,7 +2747,6 @@ impl<'a> Resolver<'a> {
 
                         if let Some(package_json) = pkg_dir_info.package_json() {
                             if let Some(exports_map) = package_json.exports.as_ref() {
-                                // The condition set is determined by the kind of import
                                 let mut module_type = package_json.module_type;
                                 // PORT NOTE: reshaped for borrowck — Zig held a single `ESModule`
                                 // with a raw `*DebugLogs` across both `resolve` calls and the
@@ -2756,15 +2755,6 @@ impl<'a> Resolver<'a> {
                                 // `&mut self` call is aliased-&mut UB. Build a fresh short-lived
                                 // `ESModule` per `resolve` call so its borrow ends before
                                 // `self.handle_esm_resolution` re-borrows `self`.
-                                let conditions = match kind {
-                                    ast::ImportKind::Require | ast::ImportKind::RequireResolve => {
-                                        self.opts.conditions.require.clone().expect("oom")
-                                    }
-                                    ast::ImportKind::At | ast::ImportKind::AtConditional => {
-                                        self.opts.conditions.style.clone().expect("oom")
-                                    }
-                                    _ => self.opts.conditions.import.clone().expect("oom"),
-                                };
 
                                 // Resolve against the path "/", then join it with the absolute
                                 // directory path. This is done because ESM package resolution uses
@@ -2773,9 +2763,18 @@ impl<'a> Resolver<'a> {
                                 // paths. We also want to avoid any "%" characters in the absolute
                                 // directory path accidentally being interpreted as URL escapes.
                                 {
-                                    // PERF(port): extra conditions clone vs Zig — profile if hot.
                                     let esm_resolution = ESModule {
-                                        conditions: conditions.clone().expect("oom"),
+                                        conditions: match kind {
+                                            ast::ImportKind::Require
+                                            | ast::ImportKind::RequireResolve => {
+                                                &self.opts.conditions.require
+                                            }
+                                            ast::ImportKind::At
+                                            | ast::ImportKind::AtConditional => {
+                                                &self.opts.conditions.style
+                                            }
+                                            _ => &self.opts.conditions.import,
+                                        },
                                         debug_logs: self.debug_logs.as_mut(),
                                         module_type: &mut module_type,
                                     }
@@ -2819,7 +2818,17 @@ impl<'a> Resolver<'a> {
                                 let extname = bun_paths::extension(esm.subpath);
                                 if extname == b".js" && esm.subpath.len() > 3 {
                                     let esm_resolution = ESModule {
-                                        conditions,
+                                        conditions: match kind {
+                                            ast::ImportKind::Require
+                                            | ast::ImportKind::RequireResolve => {
+                                                &self.opts.conditions.require
+                                            }
+                                            ast::ImportKind::At
+                                            | ast::ImportKind::AtConditional => {
+                                                &self.opts.conditions.style
+                                            }
+                                            _ => &self.opts.conditions.import,
+                                        },
                                         debug_logs: self.debug_logs.as_mut(),
                                         module_type: &mut module_type,
                                     }
@@ -3200,16 +3209,7 @@ impl<'a> Resolver<'a> {
                             let mut module_type = options::ModuleType::Unknown;
                             if let Some(package_json) = pkg_dir_info.package_json() {
                                 if let Some(exports_map) = package_json.exports.as_ref() {
-                                    // The condition set is determined by the kind of import
                                     // PORT NOTE: reshaped for borrowck — see identical note above.
-                                    let conditions = match kind {
-                                        ast::ImportKind::Require
-                                        | ast::ImportKind::RequireResolve => {
-                                            self.opts.conditions.require.clone().expect("oom")
-                                        }
-                                        _ => self.opts.conditions.import.clone().expect("oom"),
-                                    };
-
                                     // Resolve against the path "/", then join it with the absolute
                                     // directory path. This is done because ESM package resolution uses
                                     // URLs while our path resolution uses file system paths. We don't
@@ -3217,9 +3217,14 @@ impl<'a> Resolver<'a> {
                                     // paths. We also want to avoid any "%" characters in the absolute
                                     // directory path accidentally being interpreted as URL escapes.
                                     {
-                                        // PERF(port): extra conditions clone vs Zig — profile if hot.
                                         let esm_resolution = ESModule {
-                                            conditions: conditions.clone().expect("oom"),
+                                            conditions: match kind {
+                                                ast::ImportKind::Require
+                                                | ast::ImportKind::RequireResolve => {
+                                                    &self.opts.conditions.require
+                                                }
+                                                _ => &self.opts.conditions.import,
+                                            },
                                             debug_logs: self.debug_logs.as_mut(),
                                             module_type: &mut module_type,
                                         }
@@ -3249,7 +3254,13 @@ impl<'a> Resolver<'a> {
                                     let extname = bun_paths::extension(esm.subpath);
                                     if extname == b".js" && esm.subpath.len() > 3 {
                                         let esm_resolution = ESModule {
-                                            conditions,
+                                            conditions: match kind {
+                                                ast::ImportKind::Require
+                                                | ast::ImportKind::RequireResolve => {
+                                                    &self.opts.conditions.require
+                                                }
+                                                _ => &self.opts.conditions.import,
+                                            },
                                             debug_logs: self.debug_logs.as_mut(),
                                             module_type: &mut module_type,
                                         }
@@ -4825,9 +4836,9 @@ impl<'a> Resolver<'a> {
         let esm_resolution = ESModule {
             conditions: match kind {
                 ast::ImportKind::Require | ast::ImportKind::RequireResolve => {
-                    self.opts.conditions.require.clone().expect("oom")
+                    &self.opts.conditions.require
                 }
-                _ => self.opts.conditions.import.clone().expect("oom"),
+                _ => &self.opts.conditions.import,
             },
             debug_logs: self.debug_logs.as_mut(),
             module_type: &mut module_type,

--- a/test/bundler/esbuild/css.test.ts
+++ b/test/bundler/esbuild/css.test.ts
@@ -92,6 +92,28 @@ describe("bundler", () => {
     },
   });
 
+  itBundled("css/CSSAtImportPackageExportsStyleCondition", {
+    files: {
+      "/entry.css": `@import "pkg";`,
+      "/node_modules/pkg/package.json": JSON.stringify({
+        exports: {
+          style: "./style.css",
+          import: "./wrong.js",
+          default: "./default.css",
+        },
+      }),
+      "/node_modules/pkg/style.css": `.from-style { color: green }`,
+      "/node_modules/pkg/default.css": `.from-default { color: red }`,
+      "/node_modules/pkg/wrong.js": `export default "wrong";`,
+    },
+    outfile: "/out.css",
+    onAfterBundle(api) {
+      api.expectFile("/out.css").toContain(".from-style");
+      api.expectFile("/out.css").not.toContain(".from-default");
+      api.expectFile("/out.css").not.toContain("wrong");
+    },
+  });
+
   itBundled("css/CSSAtImportDiamond", {
     // GENERATED
     files: {


### PR DESCRIPTION
### What does this PR do?

Makes ESM package map resolution faster by removing clones left over from the Rust port.

The resolver was cloning the active `ConditionsMap` when constructing `ESModule`, then cloning the matched `Entry` when reading from package `exports` or `imports`. This changes both paths to borrow from the existing resolver and package JSON data instead.

Resolution behavior stays the same for package `exports`, package `imports`, and CSS `@import` package resolution.

I timed the changed resolver paths with `hyperfine`:

| case | before | after | change |
| --- | ---: | ---: | ---: |
| package root conditions | 92.4 ms ± 1.2 | 79.8 ms ± 1.2 | 1.16x faster |
| exact exports/imports lookup | 141.2 ms ± 2.0 | 124.9 ms ± 1.9 | 1.13x faster |

### How did you verify your code works?

- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p bun_resolver --target x86_64-pc-windows-msvc`
- `bun bd test test/bundler/esbuild/css.test.ts test/bundler/esbuild/packagejson.test.ts test/js/bun/resolve/import-custom-condition.test.ts`
- Release build benchmarks with `hyperfine`
