### PR TITLE
docs: clarify trustedDependencies replaces the default allow list

### DIFF
--- a/docs/pm/lifecycle.mdx
+++ b/docs/pm/lifecycle.mdx
@@ -63,7 +63,7 @@ Defining `trustedDependencies` in `package.json` **replaces** the default list r
 | `trustedDependencies: ["pkg-a", ...]` | **Only** the listed packages. The default list is ignored.   |
 | `trustedDependencies: []`             | **No** packages, including none from the default list.       |
 
-Set `trustedDependencies: []` when you want to opt out of the default allow list entirely without passing `--ignore-scripts` on every install. To trust a specific subset of packages, list them explicitly — you do not need to re-list entries from the default list for packages you already depend on.
+Set `trustedDependencies: []` when you want to opt out of the default allow list entirely without passing `--ignore-scripts` on every install. If you define `trustedDependencies` with an explicit list, include any packages from the [default list](https://github.com/oven-sh/bun/blob/main/src/install/default-trusted-dependencies.txt) whose lifecycle scripts you still need (for example, `sharp` or `esbuild`) — they are no longer trusted implicitly.
 
 ---
 

--- a/docs/pm/lifecycle.mdx
+++ b/docs/pm/lifecycle.mdx
@@ -53,6 +53,18 @@ The top 500 npm packages with lifecycle scripts are allowed by default. You can 
   packages from spoofing trusted package names through local file paths or git repositories.
 </Note>
 
+### Behavior of the `trustedDependencies` field
+
+Defining `trustedDependencies` in `package.json` **replaces** the default list rather than extending it. Exactly one of three modes applies per project:
+
+| `package.json`                        | Packages allowed to run lifecycle scripts                    |
+| ------------------------------------- | ------------------------------------------------------------ |
+| `trustedDependencies` omitted         | The ~500 packages in Bun's built-in list (npm sources only). |
+| `trustedDependencies: ["pkg-a", ...]` | **Only** the listed packages. The default list is ignored.   |
+| `trustedDependencies: []`             | **No** packages, including none from the default list.       |
+
+Set `trustedDependencies: []` when you want to opt out of the default allow list entirely without passing `--ignore-scripts` on every install. To trust a specific subset of packages, list them explicitly — you do not need to re-list entries from the default list for packages you already depend on.
+
 ---
 
 ## `--ignore-scripts`

--- a/docs/pm/lifecycle.mdx
+++ b/docs/pm/lifecycle.mdx
@@ -44,7 +44,7 @@ Instead of executing arbitrary scripts, Bun uses a "default-secure" approach. Yo
 
 Once added to `trustedDependencies`, install/re-install the package. Bun will read this field and run lifecycle scripts for `my-trusted-package`.
 
-The top 500 npm packages with lifecycle scripts are allowed by default. You can see the full list [here](https://github.com/oven-sh/bun/blob/main/src/install/default-trusted-dependencies.txt).
+A curated list of popular npm packages with lifecycle scripts is allowed by default. You can see the full list [here](https://github.com/oven-sh/bun/blob/main/src/install/default-trusted-dependencies.txt).
 
 <Note>
   The default trusted dependencies list only applies to packages installed from npm. For packages from other sources
@@ -59,7 +59,7 @@ Defining `trustedDependencies` in `package.json` **replaces** the default list r
 
 | `package.json`                        | Packages allowed to run lifecycle scripts                    |
 | ------------------------------------- | ------------------------------------------------------------ |
-| `trustedDependencies` omitted         | The ~500 packages in Bun's built-in list (npm sources only). |
+| `trustedDependencies` omitted         | The packages in Bun's built-in list (npm sources only).      |
 | `trustedDependencies: ["pkg-a", ...]` | **Only** the listed packages. The default list is ignored.   |
 | `trustedDependencies: []`             | **No** packages, including none from the default list.       |
 

--- a/docs/pm/lifecycle.mdx
+++ b/docs/pm/lifecycle.mdx
@@ -57,11 +57,11 @@ A curated list of popular npm packages with lifecycle scripts is allowed by defa
 
 Defining `trustedDependencies` in `package.json` **replaces** the default list rather than extending it. Exactly one of three modes applies per project:
 
-| `package.json`                        | Packages allowed to run lifecycle scripts                    |
-| ------------------------------------- | ------------------------------------------------------------ |
-| `trustedDependencies` omitted         | The packages in Bun's built-in list (npm sources only).      |
-| `trustedDependencies: ["pkg-a", ...]` | **Only** the listed packages. The default list is ignored.   |
-| `trustedDependencies: []`             | **No** packages, including none from the default list.       |
+| `package.json`                        | Packages allowed to run lifecycle scripts                  |
+| ------------------------------------- | ---------------------------------------------------------- |
+| `trustedDependencies` omitted         | The packages in Bun's built-in list (npm sources only).    |
+| `trustedDependencies: ["pkg-a", ...]` | **Only** the listed packages. The default list is ignored. |
+| `trustedDependencies: []`             | **No** packages, including none from the default list.     |
 
 Set `trustedDependencies: []` when you want to opt out of the default allow list entirely without passing `--ignore-scripts` on every install. If you define `trustedDependencies` with an explicit list, include any packages from the [default list](https://github.com/oven-sh/bun/blob/main/src/install/default-trusted-dependencies.txt) whose lifecycle scripts you still need (for example, `sharp` or `esbuild`) — they are no longer trusted implicitly.
 


### PR DESCRIPTION
## What

Closes #31026.

The `trustedDependencies` docs at `docs/pm/lifecycle.mdx` don't explain what happens when the field is set to an empty array. Users reasonably assume `"trustedDependencies": []` would add nothing on top of the default top-500 list — but it actually disables the default list entirely.

## Behavior (verified against source)

From `Lockfile.hasTrustedDependency` in `src/install/lockfile.zig:2126`:

```zig
pub fn hasTrustedDependency(this: *const Lockfile, name: []const u8, resolution: *const Resolution) bool {
    if (this.trusted_dependencies) |trusted_dependencies| {
        const hash = @as(u32, @truncate(String.Builder.stringHash(name)));
        return trusted_dependencies.contains(hash);
    }
    // Only allow default trusted dependencies for npm packages
    return resolution.tag == .npm and default_trusted_dependencies.has(name);
}
```

The parser (`src/install/lockfile/Package.zig:1556`) initialises `lockfile.trusted_dependencies` to a non-null empty map the moment the `trustedDependencies` key is present — even if the array is empty. So the fallback to the default list is only reached when the key is **absent** from `package.json`. Three cases:

| `package.json` | Trusted packages |
|---|---|
| key omitted | the ~500 built-in defaults (npm sources only) |
| `["pkg"]` | only `pkg` — default list ignored |
| `[]` | nothing — default list ignored |

## Change

Adds a short subsection + table to `docs/pm/lifecycle.mdx` covering all three cases, and notes that the field **replaces** rather than extends the default list. Docs-only, no code changes.