### PR TITLE
lsan: fix leaks behind BunString::toWTFString / ZigString__toErrorInstance / WTF::fastMalloc suppressions

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -893,11 +893,12 @@ pub mod bv2_impl {
                     is_server_side: bool,
                 ) {
                     let _tracer = bun_core::perf::trace("JSBundler.matchOnLoad");
-                    let mut namespace_string = bun_core::OwnedString::new(if namespace.is_empty() {
-                        BunString::static_(b"file")
-                    } else {
-                        BunString::clone_utf8(namespace)
-                    });
+                    let mut namespace_string =
+                        bun_core::OwnedString::new(if namespace.is_empty() {
+                            BunString::static_(b"file")
+                        } else {
+                            BunString::clone_utf8(namespace)
+                        });
                     let mut path_string = bun_core::OwnedString::new(BunString::clone_utf8(path));
                     JSBundlerPlugin__matchOnLoad(
                         self,
@@ -918,12 +919,13 @@ pub mod bv2_impl {
                     import_record_kind: ImportKind,
                 ) {
                     let _tracer = bun_core::perf::trace("JSBundler.matchOnResolve");
-                    let mut namespace_string =
-                        bun_core::OwnedString::new(if namespace.is_empty() || namespace == b"file" {
+                    let mut namespace_string = bun_core::OwnedString::new(
+                        if namespace.is_empty() || namespace == b"file" {
                             BunString::static_(b"file")
                         } else {
                             BunString::clone_utf8(namespace)
-                        });
+                        },
+                    );
                     let mut path_string = bun_core::OwnedString::new(BunString::clone_utf8(path));
                     let mut importer_string =
                         bun_core::OwnedString::new(BunString::clone_utf8(importer));

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -783,8 +783,8 @@ pub mod bv2_impl {
                 #[link_name = "JSBundlerPlugin__anyMatches"]
                 safe fn JSBundlerPlugin__anyMatches(
                     this: &Plugin,
-                    namespace: &BunString,
-                    path: &BunString,
+                    namespace: &mut BunString,
+                    path: &mut BunString,
                     is_on_load: bool,
                 ) -> bool;
                 // `context` is an opaque cookie C++ round-trips back to a Rust
@@ -875,13 +875,13 @@ pub mod bv2_impl {
                     path: &crate::ungate_support::bun_fs::Path,
                     is_on_load: bool,
                 ) -> bool {
-                    let namespace_string = bun_core::OwnedString::new(if path.is_file() {
+                    let mut namespace_string = if path.is_file() {
                         BunString::empty()
                     } else {
                         BunString::clone_utf8(path.namespace)
-                    });
-                    let path_string = bun_core::OwnedString::new(BunString::clone_utf8(path.text));
-                    JSBundlerPlugin__anyMatches(self, &namespace_string, &path_string, is_on_load)
+                    };
+                    let mut path_string = BunString::clone_utf8(path.text);
+                    JSBundlerPlugin__anyMatches(self, &mut namespace_string, &mut path_string, is_on_load)
                 }
 
                 pub fn match_on_load(
@@ -893,13 +893,12 @@ pub mod bv2_impl {
                     is_server_side: bool,
                 ) {
                     let _tracer = bun_core::perf::trace("JSBundler.matchOnLoad");
-                    let mut namespace_string =
-                        bun_core::OwnedString::new(if namespace.is_empty() {
-                            BunString::static_(b"file")
-                        } else {
-                            BunString::clone_utf8(namespace)
-                        });
-                    let mut path_string = bun_core::OwnedString::new(BunString::clone_utf8(path));
+                    let mut namespace_string = if namespace.is_empty() {
+                        BunString::static_(b"file")
+                    } else {
+                        BunString::clone_utf8(namespace)
+                    };
+                    let mut path_string = BunString::clone_utf8(path);
                     JSBundlerPlugin__matchOnLoad(
                         self,
                         &mut namespace_string,
@@ -919,16 +918,13 @@ pub mod bv2_impl {
                     import_record_kind: ImportKind,
                 ) {
                     let _tracer = bun_core::perf::trace("JSBundler.matchOnResolve");
-                    let mut namespace_string = bun_core::OwnedString::new(
-                        if namespace.is_empty() || namespace == b"file" {
-                            BunString::static_(b"file")
-                        } else {
-                            BunString::clone_utf8(namespace)
-                        },
-                    );
-                    let mut path_string = bun_core::OwnedString::new(BunString::clone_utf8(path));
-                    let mut importer_string =
-                        bun_core::OwnedString::new(BunString::clone_utf8(importer));
+                    let mut namespace_string = if namespace.is_empty() || namespace == b"file" {
+                        BunString::static_(b"file")
+                    } else {
+                        BunString::clone_utf8(namespace)
+                    };
+                    let mut path_string = BunString::clone_utf8(path);
+                    let mut importer_string = BunString::clone_utf8(importer);
                     JSBundlerPlugin__matchOnResolve(
                         self,
                         &mut namespace_string,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -893,12 +893,11 @@ pub mod bv2_impl {
                     is_server_side: bool,
                 ) {
                     let _tracer = bun_core::perf::trace("JSBundler.matchOnLoad");
-                    let mut namespace_string =
-                        bun_core::OwnedString::new(if namespace.is_empty() {
-                            BunString::static_(b"file")
-                        } else {
-                            BunString::clone_utf8(namespace)
-                        });
+                    let mut namespace_string = bun_core::OwnedString::new(if namespace.is_empty() {
+                        BunString::static_(b"file")
+                    } else {
+                        BunString::clone_utf8(namespace)
+                    });
                     let mut path_string = bun_core::OwnedString::new(BunString::clone_utf8(path));
                     JSBundlerPlugin__matchOnLoad(
                         self,
@@ -920,8 +919,8 @@ pub mod bv2_impl {
                 ) {
                     let _tracer = bun_core::perf::trace("JSBundler.matchOnResolve");
                     let mut namespace_string =
-                        bun_core::OwnedString::new(if namespace == b"file" {
-                            BunString::empty()
+                        bun_core::OwnedString::new(if namespace.is_empty() || namespace == b"file" {
+                            BunString::static_(b"file")
                         } else {
                             BunString::clone_utf8(namespace)
                         });

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -881,7 +881,12 @@ pub mod bv2_impl {
                         BunString::clone_utf8(path.namespace)
                     };
                     let mut path_string = BunString::clone_utf8(path.text);
-                    JSBundlerPlugin__anyMatches(self, &mut namespace_string, &mut path_string, is_on_load)
+                    JSBundlerPlugin__anyMatches(
+                        self,
+                        &mut namespace_string,
+                        &mut path_string,
+                        is_on_load,
+                    )
                 }
 
                 pub fn match_on_load(

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -793,8 +793,8 @@ pub mod bv2_impl {
                 #[link_name = "JSBundlerPlugin__matchOnLoad"]
                 safe fn JSBundlerPlugin__matchOnLoad(
                     this: &mut Plugin,
-                    namespace_string: &BunString,
-                    path: &BunString,
+                    namespace_string: &mut BunString,
+                    path: &mut BunString,
                     context: *mut core::ffi::c_void,
                     default_loader: u8,
                     is_server_side: bool,
@@ -802,9 +802,9 @@ pub mod bv2_impl {
                 #[link_name = "JSBundlerPlugin__matchOnResolve"]
                 safe fn JSBundlerPlugin__matchOnResolve(
                     this: &mut Plugin,
-                    namespace_string: &BunString,
-                    path: &BunString,
-                    importer: &BunString,
+                    namespace_string: &mut BunString,
+                    path: &mut BunString,
+                    importer: &mut BunString,
                     context: *mut core::ffi::c_void,
                     kind: u8,
                 );
@@ -875,13 +875,12 @@ pub mod bv2_impl {
                     path: &crate::ungate_support::bun_fs::Path,
                     is_on_load: bool,
                 ) -> bool {
-                    let namespace_string = if path.is_file() {
+                    let namespace_string = bun_core::OwnedString::new(if path.is_file() {
                         BunString::empty()
                     } else {
                         BunString::clone_utf8(path.namespace)
-                    };
-                    let path_string = BunString::clone_utf8(path.text);
-                    // namespace_string/path_string deref on Drop
+                    });
+                    let path_string = bun_core::OwnedString::new(BunString::clone_utf8(path.text));
                     JSBundlerPlugin__anyMatches(self, &namespace_string, &path_string, is_on_load)
                 }
 
@@ -894,16 +893,16 @@ pub mod bv2_impl {
                     is_server_side: bool,
                 ) {
                     let _tracer = bun_core::perf::trace("JSBundler.matchOnLoad");
-                    let namespace_string = if namespace.is_empty() {
+                    let mut namespace_string = bun_core::OwnedString::new(if namespace.is_empty() {
                         BunString::static_(b"file")
                     } else {
                         BunString::clone_utf8(namespace)
-                    };
-                    let path_string = BunString::clone_utf8(path);
+                    });
+                    let mut path_string = bun_core::OwnedString::new(BunString::clone_utf8(path));
                     JSBundlerPlugin__matchOnLoad(
                         self,
-                        &namespace_string,
-                        &path_string,
+                        &mut namespace_string,
+                        &mut path_string,
                         context,
                         default_loader as u8,
                         is_server_side,
@@ -919,18 +918,18 @@ pub mod bv2_impl {
                     import_record_kind: ImportKind,
                 ) {
                     let _tracer = bun_core::perf::trace("JSBundler.matchOnResolve");
-                    let namespace_string = if namespace == b"file" {
+                    let mut namespace_string = bun_core::OwnedString::new(if namespace == b"file" {
                         BunString::empty()
                     } else {
                         BunString::clone_utf8(namespace)
-                    };
-                    let path_string = BunString::clone_utf8(path);
-                    let importer_string = BunString::clone_utf8(importer);
+                    });
+                    let mut path_string = bun_core::OwnedString::new(BunString::clone_utf8(path));
+                    let mut importer_string = bun_core::OwnedString::new(BunString::clone_utf8(importer));
                     JSBundlerPlugin__matchOnResolve(
                         self,
-                        &namespace_string,
-                        &path_string,
-                        &importer_string,
+                        &mut namespace_string,
+                        &mut path_string,
+                        &mut importer_string,
                         context,
                         import_record_kind as u8,
                     );

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -893,11 +893,12 @@ pub mod bv2_impl {
                     is_server_side: bool,
                 ) {
                     let _tracer = bun_core::perf::trace("JSBundler.matchOnLoad");
-                    let mut namespace_string = bun_core::OwnedString::new(if namespace.is_empty() {
-                        BunString::static_(b"file")
-                    } else {
-                        BunString::clone_utf8(namespace)
-                    });
+                    let mut namespace_string =
+                        bun_core::OwnedString::new(if namespace.is_empty() {
+                            BunString::static_(b"file")
+                        } else {
+                            BunString::clone_utf8(namespace)
+                        });
                     let mut path_string = bun_core::OwnedString::new(BunString::clone_utf8(path));
                     JSBundlerPlugin__matchOnLoad(
                         self,
@@ -918,13 +919,15 @@ pub mod bv2_impl {
                     import_record_kind: ImportKind,
                 ) {
                     let _tracer = bun_core::perf::trace("JSBundler.matchOnResolve");
-                    let mut namespace_string = bun_core::OwnedString::new(if namespace == b"file" {
-                        BunString::empty()
-                    } else {
-                        BunString::clone_utf8(namespace)
-                    });
+                    let mut namespace_string =
+                        bun_core::OwnedString::new(if namespace == b"file" {
+                            BunString::empty()
+                        } else {
+                            BunString::clone_utf8(namespace)
+                        });
                     let mut path_string = bun_core::OwnedString::new(BunString::clone_utf8(path));
-                    let mut importer_string = bun_core::OwnedString::new(BunString::clone_utf8(importer));
+                    let mut importer_string =
+                        bun_core::OwnedString::new(BunString::clone_utf8(importer));
                     JSBundlerPlugin__matchOnResolve(
                         self,
                         &mut namespace_string,

--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -112,37 +112,42 @@ extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue BunString__createUT
     return JSValue::encode(jsString(vm, WTF::move(str)));
 }
 
-extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue BunString__transferToJS(BunString* bunString, JSC::JSGlobalObject* globalObject)
+JSC::JSValue BunString::transferToJS(JSC::JSGlobalObject* globalObject)
 {
     auto& vm = JSC::getVM(globalObject);
 
-    if (bunString->tag == BunStringTag::Empty) [[unlikely]] {
-        return JSValue::encode(JSC::jsEmptyString(vm));
+    if (this->tag == BunStringTag::Empty) [[unlikely]] {
+        return JSC::jsEmptyString(vm);
     }
 
-    if (bunString->tag == BunStringTag::Dead) [[unlikely]] {
+    if (this->tag == BunStringTag::Dead) [[unlikely]] {
         auto scope = DECLARE_THROW_SCOPE(vm);
-        return Bun::ERR::STRING_TOO_LONG(scope, globalObject);
+        return JSValue::decode(Bun::ERR::STRING_TOO_LONG(scope, globalObject));
     }
 
-    if (bunString->tag == BunStringTag::WTFStringImpl) [[likely]] {
+    if (this->tag == BunStringTag::WTFStringImpl) [[likely]] {
 #if ASSERT_ENABLED
-        unsigned refCount = bunString->impl.wtf->refCount();
-        ASSERT(refCount > 0 && !bunString->impl.wtf->isEmpty());
+        unsigned refCount = this->impl.wtf->refCount();
+        ASSERT(refCount > 0 && !this->impl.wtf->isEmpty());
 #endif
-        auto str = bunString->toWTFString();
+        auto str = this->toWTFString();
 #if ASSERT_ENABLED
-        unsigned newRefCount = bunString->impl.wtf->refCount();
+        unsigned newRefCount = this->impl.wtf->refCount();
         ASSERT(newRefCount == refCount + 1);
 #endif
-        bunString->impl.wtf->deref();
-        *bunString = { .tag = BunStringTag::Dead };
-        return JSValue::encode(jsString(vm, WTF::move(str)));
+        this->impl.wtf->deref();
+        *this = { .tag = BunStringTag::Dead };
+        return jsString(vm, WTF::move(str));
     }
 
-    WTF::String str = bunString->toWTFString();
-    *bunString = { .tag = BunStringTag::Dead };
-    return JSValue::encode(jsString(vm, WTF::move(str)));
+    WTF::String str = this->toWTFString();
+    *this = { .tag = BunStringTag::Dead };
+    return jsString(vm, WTF::move(str));
+}
+
+extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue BunString__transferToJS(BunString* bunString, JSC::JSGlobalObject* globalObject)
+{
+    return JSValue::encode(bunString->transferToJS(globalObject));
 }
 
 // int64_t max to say "not a number"

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -77,14 +77,14 @@ void BundlerPlugin::NamespaceList::append(JSC::VM& vm, JSC::RegExp* filter, Stri
     nsGroup->append(WTF::move(filter_regexp));
 }
 
-static bool anyMatchesForNamespace(JSC::VM& vm, BundlerPlugin::NamespaceList& list, const BunString* namespaceStr, const BunString* path)
+static bool anyMatchesForNamespace(JSC::VM& vm, BundlerPlugin::NamespaceList& list, BunString* namespaceStr, BunString* path)
 {
+    auto namespaceString = namespaceStr ? namespaceStr->transferToWTFString() : String();
+    auto pathString = path->transferToWTFString();
 
     if (list.fileNamespace.isEmpty() && list.namespaces.isEmpty())
         return false;
 
-    // Avoid unnecessary string copies
-    auto namespaceString = namespaceStr ? namespaceStr->toWTFString(BunString::ZeroCopy) : String();
     unsigned index = 0;
     auto* group = list.group(namespaceString, index);
     if (group == nullptr) {
@@ -92,7 +92,6 @@ static bool anyMatchesForNamespace(JSC::VM& vm, BundlerPlugin::NamespaceList& li
     }
 
     auto& filters = *group;
-    auto pathString = path->toWTFString(BunString::ZeroCopy);
 
     for (auto& filter : filters) {
         if (filter.match(vm, pathString)) {
@@ -102,7 +101,7 @@ static bool anyMatchesForNamespace(JSC::VM& vm, BundlerPlugin::NamespaceList& li
 
     return false;
 }
-bool BundlerPlugin::anyMatchesCrossThread(JSC::VM& vm, const BunString* namespaceStr, const BunString* path, bool isOnLoad)
+bool BundlerPlugin::anyMatchesCrossThread(JSC::VM& vm, BunString* namespaceStr, BunString* path, bool isOnLoad)
 {
     if (isOnLoad) {
         return anyMatchesForNamespace(vm, this->onLoad, namespaceStr, path);
@@ -506,7 +505,7 @@ void JSBundlerPlugin::finishCreation(JSC::VM& vm)
     reifyStaticProperties(vm, JSBundlerPlugin::info(), JSBundlerPluginHashTable, *this);
 }
 
-extern "C" bool JSBundlerPlugin__anyMatches(Bun::JSBundlerPlugin* pluginObject, const BunString* namespaceString, const BunString* path, bool isOnLoad)
+extern "C" bool JSBundlerPlugin__anyMatches(Bun::JSBundlerPlugin* pluginObject, BunString* namespaceString, BunString* path, bool isOnLoad)
 {
     return pluginObject->plugin.anyMatchesCrossThread(pluginObject->vm(), namespaceString, path, isOnLoad);
 }

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -514,8 +514,6 @@ extern "C" bool JSBundlerPlugin__anyMatches(Bun::JSBundlerPlugin* pluginObject, 
 extern "C" void JSBundlerPlugin__matchOnLoad(Bun::JSBundlerPlugin* plugin, BunString* namespaceString, BunString* path, void* context, uint8_t defaultLoaderId, bool isServerSide)
 {
     JSC::JSGlobalObject* globalObject = plugin->globalObject();
-    WTF::String namespaceStringStr = namespaceString ? namespaceString->transferToWTFString() : WTF::String();
-    WTF::String pathStr = path ? path->transferToWTFString() : WTF::String();
 
     JSFunction* function = plugin->onLoadFunction.get(plugin);
     if (!function) [[unlikely]]
@@ -529,8 +527,10 @@ extern "C" void JSBundlerPlugin__matchOnLoad(Bun::JSBundlerPlugin* plugin, BunSt
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(plugin->vm());
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(WRAP_BUNDLER_PLUGIN(context));
-    arguments.append(JSC::jsString(plugin->vm(), pathStr));
-    arguments.append(JSC::jsString(plugin->vm(), namespaceStringStr));
+    arguments.append(path->transferToJS(globalObject));
+    RETURN_IF_EXCEPTION(scope, void());
+    arguments.append(namespaceString->transferToJS(globalObject));
+    RETURN_IF_EXCEPTION(scope, void());
     arguments.append(JSC::jsNumber(defaultLoaderId));
     arguments.append(JSC::jsBoolean(isServerSide));
 
@@ -553,13 +553,6 @@ extern "C" void JSBundlerPlugin__matchOnLoad(Bun::JSBundlerPlugin* plugin, BunSt
 extern "C" void JSBundlerPlugin__matchOnResolve(Bun::JSBundlerPlugin* plugin, BunString* namespaceString, BunString* path, BunString* importer, void* context, uint8_t kindId)
 {
     JSC::JSGlobalObject* globalObject = plugin->globalObject();
-    WTF::String namespaceStringStr = namespaceString ? namespaceString->transferToWTFString() : WTF::String("file"_s);
-    if (namespaceStringStr.length() == 0) {
-        namespaceStringStr = WTF::String("file"_s);
-    }
-    WTF::String pathStr = path ? path->transferToWTFString() : WTF::String();
-    WTF::String importerStr = importer ? importer->transferToWTFString() : WTF::String();
-    auto& vm = JSC::getVM(globalObject);
 
     JSFunction* function = plugin->onResolveFunction.get(plugin);
     if (!function) [[unlikely]]
@@ -570,11 +563,14 @@ extern "C" void JSBundlerPlugin__matchOnResolve(Bun::JSBundlerPlugin* plugin, Bu
     if (callData.type == JSC::CallData::Type::None) [[unlikely]]
         return;
 
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(plugin->vm());
     JSC::MarkedArgumentBuffer arguments;
-    arguments.append(JSC::jsString(vm, pathStr));
-    arguments.append(JSC::jsString(vm, namespaceStringStr));
-    arguments.append(JSC::jsString(vm, importerStr));
+    arguments.append(path->transferToJS(globalObject));
+    RETURN_IF_EXCEPTION(scope, void());
+    arguments.append(namespaceString->transferToJS(globalObject));
+    RETURN_IF_EXCEPTION(scope, void());
+    arguments.append(importer->transferToJS(globalObject));
+    RETURN_IF_EXCEPTION(scope, void());
     arguments.append(WRAP_BUNDLER_PLUGIN(context));
     arguments.append(JSC::jsNumber(kindId));
 

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -511,11 +511,11 @@ extern "C" bool JSBundlerPlugin__anyMatches(Bun::JSBundlerPlugin* pluginObject, 
     return pluginObject->plugin.anyMatchesCrossThread(pluginObject->vm(), namespaceString, path, isOnLoad);
 }
 
-extern "C" void JSBundlerPlugin__matchOnLoad(Bun::JSBundlerPlugin* plugin, const BunString* namespaceString, const BunString* path, void* context, uint8_t defaultLoaderId, bool isServerSide)
+extern "C" void JSBundlerPlugin__matchOnLoad(Bun::JSBundlerPlugin* plugin, BunString* namespaceString, BunString* path, void* context, uint8_t defaultLoaderId, bool isServerSide)
 {
     JSC::JSGlobalObject* globalObject = plugin->globalObject();
-    WTF::String namespaceStringStr = namespaceString ? namespaceString->toWTFString(BunString::ZeroCopy) : WTF::String();
-    WTF::String pathStr = path ? path->toWTFString(BunString::ZeroCopy) : WTF::String();
+    WTF::String namespaceStringStr = namespaceString ? namespaceString->transferToWTFString() : WTF::String();
+    WTF::String pathStr = path ? path->transferToWTFString() : WTF::String();
 
     JSFunction* function = plugin->onLoadFunction.get(plugin);
     if (!function) [[unlikely]]
@@ -550,15 +550,15 @@ extern "C" void JSBundlerPlugin__matchOnLoad(Bun::JSBundlerPlugin* plugin, const
     }
 }
 
-extern "C" void JSBundlerPlugin__matchOnResolve(Bun::JSBundlerPlugin* plugin, const BunString* namespaceString, const BunString* path, const BunString* importer, void* context, uint8_t kindId)
+extern "C" void JSBundlerPlugin__matchOnResolve(Bun::JSBundlerPlugin* plugin, BunString* namespaceString, BunString* path, BunString* importer, void* context, uint8_t kindId)
 {
     JSC::JSGlobalObject* globalObject = plugin->globalObject();
-    WTF::String namespaceStringStr = namespaceString ? namespaceString->toWTFString(BunString::ZeroCopy) : WTF::String("file"_s);
+    WTF::String namespaceStringStr = namespaceString ? namespaceString->transferToWTFString() : WTF::String("file"_s);
     if (namespaceStringStr.length() == 0) {
         namespaceStringStr = WTF::String("file"_s);
     }
-    WTF::String pathStr = path ? path->toWTFString(BunString::ZeroCopy) : WTF::String();
-    WTF::String importerStr = importer ? importer->toWTFString(BunString::ZeroCopy) : WTF::String();
+    WTF::String pathStr = path ? path->transferToWTFString() : WTF::String();
+    WTF::String importerStr = importer ? importer->transferToWTFString() : WTF::String();
     auto& vm = JSC::getVM(globalObject);
 
     JSFunction* function = plugin->onResolveFunction.get(plugin);

--- a/src/jsc/bindings/JSBundlerPlugin.h
+++ b/src/jsc/bindings/JSBundlerPlugin.h
@@ -118,7 +118,7 @@ public:
     };
 
 public:
-    bool anyMatchesCrossThread(JSC::VM&, const BunString* namespaceStr, const BunString* path, bool isOnLoad);
+    bool anyMatchesCrossThread(JSC::VM&, BunString* namespaceStr, BunString* path, bool isOnLoad);
     void tombstone() { tombstoned = true; }
 
     BundlerPlugin(void* config, BunPluginTarget target, JSBundlerPluginAddErrorCallback addError, JSBundlerPluginOnLoadAsyncCallback onLoadAsync, JSBundlerPluginOnResolveAsyncCallback onResolveAsync)

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -83,6 +83,10 @@ typedef struct BunString {
 
     WTF::String transferToWTFString();
 
+    // Consumes this BunString and returns a JS string value. Leaves *this Dead
+    // so a Rust-side OwnedString::Drop deref becomes a no-op.
+    JSC::JSValue transferToJS(JSC::JSGlobalObject* globalObject);
+
     // This one usually will clone the raw bytes.
     WTF::String toWTFString() const;
 

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -608,11 +608,12 @@ extern "C" void WebWorker__fireEarlyMessages(Worker* worker, Zig::GlobalObject* 
     worker->fireEarlyMessages(globalObject);
 }
 
-extern "C" void WebWorker__dispatchError(Zig::GlobalObject* globalObject, Worker* worker, BunString message, JSC::EncodedJSValue errorValue)
+extern "C" void WebWorker__dispatchError(Zig::GlobalObject* globalObject, Worker* worker, BunString* message, JSC::EncodedJSValue errorValue)
 {
     JSValue error = JSC::JSValue::decode(errorValue);
+    WTF::String messageStr = message->transferToWTFString();
     ErrorEvent::Init init;
-    init.message = message.toWTFString(BunString::ZeroCopy).isolatedCopy();
+    init.message = messageStr.isolatedCopy();
     init.error = error;
     init.cancelable = false;
     init.bubbles = false;
@@ -620,11 +621,11 @@ extern "C" void WebWorker__dispatchError(Zig::GlobalObject* globalObject, Worker
     globalObject->globalEventScope->dispatchEvent(ErrorEvent::create(eventNames().errorEvent, init, EventIsTrusted::Yes));
     switch (worker->options().kind) {
     case WorkerOptions::Kind::Web:
-        return worker->dispatchErrorWithMessage(message.toWTFString(BunString::ZeroCopy));
+        return worker->dispatchErrorWithMessage(WTF::move(messageStr));
     case WorkerOptions::Kind::Node:
         if (!worker->dispatchErrorWithValue(globalObject, error)) {
             // If serialization threw an error, use the string instead
-            worker->dispatchErrorWithMessage(message.toWTFString(BunString::ZeroCopy));
+            worker->dispatchErrorWithMessage(WTF::move(messageStr));
         }
         return;
     }

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -225,7 +225,7 @@ unsafe extern "C" {
     safe fn WebWorker__dispatchError(
         global: &JSGlobalObject,
         cpp_worker: *mut c_void,
-        message: BunString,
+        message: &mut BunString,
         err: JSValue,
     );
 }
@@ -1432,11 +1432,10 @@ impl WebWorker {
             Err(JsError::OutOfMemory) => bun_core::out_of_memory(),
             Err(JsError::Thrown | JsError::Terminated) => panic!("unhandled exception"),
         };
-        // RAII: Zig's `defer str.deref()` — released on scope exit.
-        scopeguard::defer! { str.deref(); }
+        let mut str = bun_core::OwnedString::new(str);
         let dispatch = jsc::host_fn::from_js_host_call_generic(global, || {
             // `cpp_worker` is the opaque C++-owned handle; `str` reffed for the call.
-            WebWorker__dispatchError(global, self.cpp_worker, str, err)
+            WebWorker__dispatchError(global, self.cpp_worker, &mut str, err)
         });
         if let Err(e) = dispatch {
             // Spec web_worker.zig:810 — `.asException(..).?`: `take_exception`
@@ -1514,14 +1513,10 @@ fn on_unhandled_rejection(
     // (declares + checks a TopExceptionScope around the FFI call, same as
     // `flush_logs` above) and discard any actual exception: we are already the
     // last-resort error handler and about to arm termination.
+    let mut error_message = bun_core::OwnedString::new(BunString::clone_utf8(&array));
     if jsc::host_fn::from_js_host_call_generic(global_object, || {
         // `cpp_worker` is the opaque C++-owned handle round-tripped via `safe fn`.
-        WebWorker__dispatchError(
-            global_object,
-            worker.cpp_worker,
-            BunString::clone_utf8(&array),
-            error_instance,
-        );
+        WebWorker__dispatchError(global_object, worker.cpp_worker, &mut error_message, error_instance);
     })
     .is_err()
     {

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1516,7 +1516,12 @@ fn on_unhandled_rejection(
     let mut error_message = bun_core::OwnedString::new(BunString::clone_utf8(&array));
     if jsc::host_fn::from_js_host_call_generic(global_object, || {
         // `cpp_worker` is the opaque C++-owned handle round-tripped via `safe fn`.
-        WebWorker__dispatchError(global_object, worker.cpp_worker, &mut error_message, error_instance);
+        WebWorker__dispatchError(
+            global_object,
+            worker.cpp_worker,
+            &mut error_message,
+            error_instance,
+        );
     })
     .is_err()
     {

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -950,7 +950,7 @@ pub fn download_stream(
         ctx: *mut c_void,
     ),
     callback_context: *mut c_void,
-) {
+) -> *mut S3HttpDownloadStreamingTask {
     let range: Option<Vec<u8>> = 'brk: {
         if let Some(size_) = size {
             let mut end = offset + size_;
@@ -998,7 +998,7 @@ pub fn download_stream(
                 }),
                 callback_context,
             );
-            return;
+            return core::ptr::null_mut();
         }
     };
 
@@ -1106,6 +1106,7 @@ pub fn download_stream(
     let mut batch = bun_threading::thread_pool::Batch::default();
     http.schedule(&mut batch);
     bun_http::HTTPThread::schedule(batch);
+    task_ptr
 }
 
 /// returns a readable stream that reads from the s3 path
@@ -1122,6 +1123,10 @@ pub fn readable_stream(
         pub readable_stream_ref: ReadableStreamStrong,
         pub path: Box<[u8]>,
         pub global: GlobalRef, // JSC_BORROW
+        /// Non-owning. The task frees itself on the main thread once `has_more == false`,
+        /// which first drops this wrapper (clearing `cancel_handler`), so this pointer is
+        /// never observed dangling from `on_stream_cancelled`.
+        pub task: *mut S3HttpDownloadStreamingTask,
     }
 
     impl S3DownloadStreamWrapper {
@@ -1199,6 +1204,20 @@ pub fn readable_stream(
             // When the download finishes (has_more == false), deinit() will
             // clean up the remaining resources.
             self_.readable_stream_ref.deinit();
+            // Abort the in-flight HTTP request so the HTTP thread delivers a final
+            // callback with `has_more == false`, which frees the task and this wrapper.
+            // Without this, a server that never sends the terminal chunk would leak both.
+            let task = core::mem::replace(&mut self_.task, core::ptr::null_mut());
+            if !task.is_null() {
+                // SAFETY: task is live until its own `on_response` frees it on this thread,
+                // which has not happened yet (it would have dropped this wrapper first).
+                unsafe {
+                    (*task)
+                        .signal_store
+                        .aborted
+                        .store(true, core::sync::atomic::Ordering::Relaxed);
+                }
+            }
         }
 
         pub fn opaque_callback(
@@ -1249,6 +1268,7 @@ pub fn readable_stream(
         ),
         path: Box::<[u8]>::from(path),
         global: global_static,
+        task: core::ptr::null_mut(),
     });
 
     reader_mut
@@ -1256,7 +1276,7 @@ pub fn readable_stream(
         .set(Some(S3DownloadStreamWrapper::on_stream_cancelled));
     reader_mut.cancel_ctx.set(Some(wrapper.cast::<c_void>()));
 
-    download_stream(
+    let task = download_stream(
         this,
         path,
         offset,
@@ -1266,6 +1286,12 @@ pub fn readable_stream(
         S3DownloadStreamWrapper::opaque_callback,
         wrapper.cast::<c_void>(),
     );
+    if !task.is_null() {
+        // SAFETY: on the success path `download_stream` only schedules work onto the HTTP
+        // thread; the wrapper is freed via `opaque_callback` on this (main) thread, which
+        // cannot run until we return to the event loop, so `wrapper` is still live here.
+        unsafe { (*wrapper).task = task };
+    }
     Ok(readable_value)
 }
 

--- a/test/bundler/bundler_defer.test.ts
+++ b/test/bundler/bundler_defer.test.ts
@@ -643,6 +643,16 @@ warn: (msg: string) => console.warn(\`[WARN] \${msg}\`)
       Bun.gc(true);
       await Bun.sleep(10);
     }
+    if (onFinalizeCallCount < 3) {
+      const { heapStats } = require("bun:jsc");
+      const stats = heapStats();
+      console.error(
+        `onFinalizeCallCount=${onFinalizeCallCount} ` +
+          `BundlerPlugin alive=${stats.objectTypeCounts.BundlerPlugin ?? 0} ` +
+          `protected=${JSON.stringify(stats.protectedObjectTypeCounts)} ` +
+          `protectedCount=${stats.protectedObjectCount}`,
+      );
+    }
     expect(onFinalizeCallCount).toBe(3);
   });
 });

--- a/test/leaksan.supp
+++ b/test/leaksan.supp
@@ -7,7 +7,6 @@ leak:JSC::Identifier::fromString
 leak:jsc.JSGlobalObject.JSGlobalObject.create
 leak:Zig__GlobalObject__create
 leak:_objc_msgSend_uncached
-leak:WTF::fastMalloc
 leak:WTF::AutomaticThread::start
 leak:Bun__transpileFile
 leak:WTF::SymbolRegistry::symbolForKey

--- a/test/leaksan.supp
+++ b/test/leaksan.supp
@@ -47,12 +47,10 @@ leak:Bun__Path__resolve
 leak:Zig::GlobalObject::moduleLoaderImportModule
 leak:bake.FrameworkRouter.JSFrameworkRouter.getFileIdForRouter
 leak:runtime.webcore.Blob.findOrCreateFileFromPath__anon
-leak:BunString::toWTFString(BunString::ZeroCopyTag)
 leak:runtime.node.node_fs_binding.Bindings(.mkdtemp).runSync
 leak:jsc.ModuleLoader.fetchBuiltinModule
 leak:boringssl.boringssl.checkX509ServerIdentity
 leak:cli.pack_command.bindings.jsReadTarball
-leak:ZigString__toErrorInstance
 leak:JSC::moduleLoaderModuleDeclarationInstantiation
 leak:JSC::arrayProtoFuncSort
 leak:bindgen_Fmt_jsFmtString


### PR DESCRIPTION
Removes three LSan suppressions and fixes the leaks they were hiding (plus one S3 leak surfaced by CI along the way).

### Dropped suppressions

- `BunString::toWTFString(BunString::ZeroCopyTag)`
- `ZigString__toErrorInstance`
- `WTF::fastMalloc` — this one was masking essentially every JSC-side allocation; with VM teardown running `lastChanceToFinalize` it suppresses almost nothing anymore

### `BunString` ownership transfer at the bundler-plugin / worker FFI boundary

`JSBundlerPlugin__matchOnLoad` / `matchOnResolve` / `anyMatches` and the second `WebWorker__dispatchError` call site never released the `+1` from `bun_core::String::clone_utf8` (`bun_core::String` is `Copy` with no `Drop`; one site even had a wrong "deref on Drop" comment).

- Adds `BunString::transferToJS()` as a method (the existing extern `BunString__transferToJS` now wraps it).
- C++ side now consumes its `BunString*` arguments: `matchOnLoad`/`matchOnResolve` go straight to `transferToJS()` so the impl moves directly into the resulting `jsString`; `anyMatches` and `WebWorker__dispatchError` use `transferToWTFString()`.
- Rust callers pass `&mut` and let C++ consume. (`OwnedString` wrappers were tried but shifted stack layout enough that JSC's conservative root scan kept the `JSBundlerPlugin` cell alive on Windows, breaking `bundler_defer`'s FinalizationRegistry check — so the bundler callers stay wrapper-free.)
- The `"file"` defaulting for an empty resolve namespace moves to the Rust caller.

### S3: abort the HTTP request when a download stream is cancelled

`S3DownloadStreamWrapper::on_stream_cancelled` released the ReadableStream strong ref but never told the HTTP thread to stop, so against a server that never sends the terminal chunk the `S3HttpDownloadStreamingTask` box (and the wrapper itself) leaked at process exit. Now sets the task's `signal_store.aborted` so the HTTP thread delivers a final `has_more==false` callback and both free normally.

### Diagnostic

`bundler_defer.test.ts` now prints `heapStats()` (BundlerPlugin alive count + protected types) when the FinalizationRegistry assertion would fail, so any future regression shows whether `unprotect()` ran.