### PR TITLE
shell: widen brace-rollback counter to u32 to avoid debug overflow panic

### DIFF
--- a/src/shell_parser/braces.rs
+++ b/src/shell_parser/braces.rs
@@ -1370,7 +1370,12 @@ impl<const ENCODING: Encoding> NewLexer<ENCODING> {
             debug_assert!(matches!(first, Token::Open(_)));
         }
 
-        let mut braces: u8 = 0;
+        // PORT NOTE: Zig used `u8` here, which silently wraps in ReleaseFast.
+        // In Rust debug builds overflow-checks turn that wrap into a panic, so
+        // `{{{...}}}` deeper than 255 matched levels inside an unclosed outer
+        // brace aborted the process. Widened to `u32` to match the surrounding
+        // index type and also avoid the original latent wrap.
+        let mut braces: u32 = 0;
 
         self.replace_token_with_string(starting_idx);
         let mut i: u32 = starting_idx + 1;

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -84,14 +84,15 @@ describe("$.braces", () => {
     // before the first `Close`, which used to overflow a `u8` counter and
     // panic the debug build (released Bun silently wrapped).
     const depth = 300;
-    const input = "{" + "{".repeat(depth) + "x" + "}".repeat(depth);
+    const input = "{" + Buffer.alloc(depth, "{").toString() + "x" + Buffer.alloc(depth, "}").toString();
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", `import { $ } from "bun"; $.braces(${JSON.stringify(input)});`],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -1,5 +1,6 @@
 import { $ } from "bun";
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 describe("$.braces", () => {
   test("no-op", () => {
@@ -76,4 +77,22 @@ describe("$.braces", () => {
     const result = $.braces(`lol {😂,🫵,🤣}`);
     expect(result).toEqual(["lol 😂", "lol 🫵", "lol 🤣"]);
   });
+
+  test("unclosed outer with >255 matched nested pairs does not abort", async () => {
+    // Outer `{` is unmatched, but contains 300 levels of balanced `{...}`
+    // around an `x`. The rollback walk visits ≥300 consecutive `Open` tokens
+    // before the first `Close`, which used to overflow a `u8` counter and
+    // panic the debug build (released Bun silently wrapped).
+    const depth = 300;
+    const input = "{" + "{".repeat(depth) + "x" + "}".repeat(depth);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `import { $ } from "bun"; $.braces(${JSON.stringify(input)});`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  }, 30_000);
 });

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -94,5 +94,5 @@ describe("$.braces", () => {
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
-  }, 30_000);
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Fix a `u8` overflow in `NewLexer::rollback_braces` (`src/shell_parser/braces.rs`) that aborts the **debug** build of `Bun.$.braces(...)` when the input has an unclosed outer `{` wrapping ≥256 levels of balanced `{...}`.

Same shape as #31010 (semver): direct port of `var braces: u8 = 0` from the Zig original. Cargo's dev profile enables `overflow-checks` (release does not), so debug panics on the 256th `+= 1` while release wraps silently (256 → 0), matching Zig's ReleaseFast.

**Reproducer:**

```ts
import { $ } from "bun";
$.braces("{" + "{".repeat(300) + "x" + "}".repeat(300));
// debug: panic: attempt to add with overflow at src/shell_parser/braces.rs:1381
// release: exits cleanly, but the silent wrap kicks the rollback walk out of
//          "skip nested" state mid-span and converts inner `}` tokens to literal
//          `}` text — a latent Zig bug that this widening also fixes.
```

**Why nothing upstream stops it:** there is no depth cap on the input. `MAX_NESTED_BRACES = 10` only sets `SmallVec` inline capacity (heap-spills on overflow rather than rejecting), and `BunObject::braces` caps `expansion_count` *after* tokenization, which is too late.

**The fix:** widen `braces` to `u32` to match the surrounding index type `i: u32`. `braces` is only compared `> 0` / `== 0`, never stored or cast, so a wider type is strictly more correct.

```diff
- let mut braces: u8 = 0;
+ let mut braces: u32 = 0;
```

### How did you verify your code works?

Added a regression test in `test/js/bun/shell/brace.test.ts` that runs `$.braces` with 300 nested levels inside an unclosed outer brace in a subprocess (the failure is an uncatchable abort, same pattern as the #31010 test).

```
$ bun run build --asan=off test test/js/bun/shell/brace.test.ts
 13 pass
 0 fail
 16 expect() calls
```

With the `u32` change reverted, the new test fails on debug with the expected stack:

```
panic_const_add_overflow
  rollback_braces (src/shell_parser/braces.rs)
  tokenize_impl
  tokenize
  bun_object::braces
```

The pre-existing 12 brace tests continue to pass.

**Note on `--asan=off`:** the default ASan-enabled debug build crashes at startup on Darwin 25 (`AddressSanitizer: CHECK failed: sanitizer_procmaps_mac.cpp:214`) — an environmental ASan/macOS issue unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)