### PR TITLE
install: allow dev security scanner under `--production`

### DIFF
--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -576,6 +576,54 @@ pub fn is_filtered_dependency_or_workspace(
     lockfile: &Lockfile,
     resolutions: &[PackageID],
 ) -> bool {
+    is_filtered_dependency_or_workspace_inner(
+        dep_id,
+        parent_pkg_id,
+        workspace_filters,
+        install_root_dependencies,
+        manager,
+        lockfile,
+        resolutions,
+        false,
+    )
+}
+
+/// Hard-constraint filter for dependencies explicitly listed in
+/// `packages_to_install` (currently the security-scanner bootstrap install).
+/// Skips the `dep.behavior.is_enabled(dep_features)` check so that a dev-only
+/// scanner still installs under `--production`; disabled/bundled/workspace
+/// filters still apply.
+pub fn is_filtered_dependency_or_workspace_requested(
+    dep_id: DependencyID,
+    parent_pkg_id: PackageID,
+    workspace_filters: &[WorkspaceFilter],
+    install_root_dependencies: bool,
+    manager: &PackageManager,
+    lockfile: &Lockfile,
+    resolutions: &[PackageID],
+) -> bool {
+    is_filtered_dependency_or_workspace_inner(
+        dep_id,
+        parent_pkg_id,
+        workspace_filters,
+        install_root_dependencies,
+        manager,
+        lockfile,
+        resolutions,
+        true,
+    )
+}
+
+fn is_filtered_dependency_or_workspace_inner(
+    dep_id: DependencyID,
+    parent_pkg_id: PackageID,
+    workspace_filters: &[WorkspaceFilter],
+    install_root_dependencies: bool,
+    manager: &PackageManager,
+    lockfile: &Lockfile,
+    resolutions: &[PackageID],
+    skip_feature_filter: bool,
+) -> bool {
     let pkg_id = resolutions[dep_id as usize];
     if (pkg_id as usize) >= lockfile.packages.len() {
         let dep = &lockfile.buffers.dependencies.as_slice()[dep_id as usize];
@@ -622,15 +670,17 @@ pub fn is_filtered_dependency_or_workspace(
         return true;
     }
 
-    let dep_features = match parent_res.tag {
-        crate::resolution::Tag::Root
-        | crate::resolution::Tag::Workspace
-        | crate::resolution::Tag::Folder => manager.options.local_package_features,
-        _ => manager.options.remote_package_features,
-    };
+    if !skip_feature_filter {
+        let dep_features = match parent_res.tag {
+            crate::resolution::Tag::Root
+            | crate::resolution::Tag::Workspace
+            | crate::resolution::Tag::Folder => manager.options.local_package_features,
+            _ => manager.options.remote_package_features,
+        };
 
-    if !dep.behavior.is_enabled(dep_features) {
-        return true;
+        if !dep.behavior.is_enabled(dep_features) {
+            return true;
+        }
     }
 
     // Filtering only applies to the root package dependencies. Also
@@ -779,15 +829,42 @@ impl Tree {
 
             // filter out disabled dependencies
             if METHOD == BuilderMethod::Filter {
-                if is_filtered_dependency_or_workspace(
-                    dep_id,
-                    parent_pkg_id,
-                    builder.workspace_filters,
-                    builder.install_root_dependencies,
-                    builder.manager.expect("manager set when METHOD == Filter"),
-                    lockfile,
-                    &*builder.resolutions,
-                ) {
+                // A non-None `packages_to_install` is the security-scanner
+                // bootstrap install — narrow to exactly those root-parent
+                // pkgs and skip dev-dependency feature filtering so a dev
+                // scanner still installs under `--production` (issue #31028).
+                let is_requested_install = match builder.packages_to_install {
+                    Some(packages_to_install) if parent_pkg_id == 0 => {
+                        if !packages_to_install.contains(&pkg_id) {
+                            continue;
+                        }
+                        true
+                    }
+                    _ => false,
+                };
+
+                let filtered = if is_requested_install {
+                    is_filtered_dependency_or_workspace_requested(
+                        dep_id,
+                        parent_pkg_id,
+                        builder.workspace_filters,
+                        builder.install_root_dependencies,
+                        builder.manager.expect("manager set when METHOD == Filter"),
+                        lockfile,
+                        &*builder.resolutions,
+                    )
+                } else {
+                    is_filtered_dependency_or_workspace(
+                        dep_id,
+                        parent_pkg_id,
+                        builder.workspace_filters,
+                        builder.install_root_dependencies,
+                        builder.manager.expect("manager set when METHOD == Filter"),
+                        lockfile,
+                        &*builder.resolutions,
+                    )
+                };
+                if filtered {
                     continue;
                 }
 
@@ -795,22 +872,6 @@ impl Tree {
                 // their chance to resolve.
                 if pkg_id == invalid_package_id {
                     continue;
-                }
-
-                if let Some(packages_to_install) = builder.packages_to_install {
-                    if parent_pkg_id == 0 {
-                        let mut found = false;
-                        for &package_to_install in packages_to_install {
-                            if pkg_id == package_to_install {
-                                found = true;
-                                break;
-                            }
-                        }
-
-                        if !found {
-                            continue;
-                        }
-                    }
                 }
             }
 

--- a/test/cli/install/bun-install-security-scanner-production.test.ts
+++ b/test/cli/install/bun-install-security-scanner-production.test.ts
@@ -1,0 +1,121 @@
+// Regression coverage for https://github.com/oven-sh/bun/issues/31028
+//
+// When the security scanner is configured as a `devDependencies` entry and
+// `bun install --production` is run, the lockfile filter treats the scanner
+// as a filtered-out dev-only package. That left the partial install of the
+// scanner with an empty tree and `bun install` failed with
+// "no packages were installed during security scanner installation".
+//
+// These tests use the existing `test-security-scanner-1.0.0-clean.tgz`
+// served via the SimpleRegistry fixture: the scanner is a real `devDependencies`
+// entry and must install + run under `--production`.
+
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { join } from "node:path";
+import { startRegistry, stopRegistry } from "./simple-dummy-registry";
+
+let registryUrl: string;
+
+beforeAll(async () => {
+  registryUrl = await startRegistry(false);
+});
+
+afterAll(() => {
+  stopRegistry();
+});
+
+async function writeFixture(options: { production: boolean; frozenLockfile: boolean }) {
+  const dir = tempDirWithFiles("install-security-production-31028", {
+    "package.json": JSON.stringify({
+      name: "test-app",
+      version: "1.0.0",
+      dependencies: {
+        "left-pad": "1.3.0",
+      },
+      devDependencies: {
+        "test-security-scanner": "1.0.0",
+      },
+    }),
+  });
+
+  // First pass: no scanner so we can produce the lockfile cleanly. We do this
+  // without --production so devDependencies appear in the lockfile just like
+  // they would in a developer's local checkout.
+  await Bun.write(
+    join(dir, "bunfig.toml"),
+    `[install]
+cache.disable = true
+registry = "${registryUrl}/"`,
+  );
+
+  await using initProc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [initOut, initErr, initCode] = await Promise.all([
+    initProc.stdout.text(),
+    initProc.stderr.text(),
+    initProc.exited,
+  ]);
+  if (initCode !== 0) {
+    throw new Error(`initial install failed (${initCode}):\n${initOut}\n${initErr}`);
+  }
+
+  // Rewrite bunfig with the scanner configured — mirrors the user's bunfig.
+  await Bun.write(
+    join(dir, "bunfig.toml"),
+    `[install]
+cache.disable = true
+registry = "${registryUrl}/"
+
+[install.security]
+scanner = "test-security-scanner"`,
+  );
+
+  // Drop node_modules so the install actually has to resolve + install.
+  await Bun.$`rm -rf ${join(dir, "node_modules")}`.quiet();
+
+  const args = ["install"];
+  if (options.frozenLockfile) args.push("--frozen-lockfile");
+  if (options.production) args.push("--production");
+
+  await using runProc = Bun.spawn({
+    cmd: [bunExe(), ...args],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    runProc.stdout.text(),
+    runProc.stderr.text(),
+    runProc.exited,
+  ]);
+
+  return { dir, stdout, stderr, exitCode, combined: stdout + stderr };
+}
+
+test("install --production with npm security scanner in devDependencies installs the scanner and completes", async () => {
+  const { combined, exitCode } = await writeFixture({ production: true, frozenLockfile: false });
+
+  expect(combined).not.toContain("no packages were installed during security scanner installation");
+  expect(combined).toContain("Attempting to install security scanner from npm");
+  expect(combined).toContain("Security scanner installed successfully");
+  expect(combined).toContain("SCANNER_RAN");
+  expect(exitCode).toBe(0);
+});
+
+test("install --frozen-lockfile --production with npm security scanner in devDependencies installs the scanner and completes", async () => {
+  const { combined, exitCode } = await writeFixture({ production: true, frozenLockfile: true });
+
+  expect(combined).not.toContain("no packages were installed during security scanner installation");
+  expect(combined).toContain("Attempting to install security scanner from npm");
+  expect(combined).toContain("Security scanner installed successfully");
+  expect(combined).toContain("SCANNER_RAN");
+  expect(exitCode).toBe(0);
+});

--- a/test/cli/install/bun-install-security-scanner-production.test.ts
+++ b/test/cli/install/bun-install-security-scanner-production.test.ts
@@ -99,22 +99,28 @@ scanner = "test-security-scanner"`,
   return { dir, stdout, stderr, exitCode, combined: stdout + stderr };
 }
 
-test("install --production with npm security scanner in devDependencies installs the scanner and completes", async () => {
-  const { combined, exitCode } = await writeFixture({ production: true, frozenLockfile: false });
+test.concurrent(
+  "install --production with npm security scanner in devDependencies installs the scanner and completes",
+  async () => {
+    const { combined, exitCode } = await writeFixture({ production: true, frozenLockfile: false });
 
-  expect(combined).not.toContain("no packages were installed during security scanner installation");
-  expect(combined).toContain("Attempting to install security scanner from npm");
-  expect(combined).toContain("Security scanner installed successfully");
-  expect(combined).toContain("SCANNER_RAN");
-  expect(exitCode).toBe(0);
-});
+    expect(combined).not.toContain("no packages were installed during security scanner installation");
+    expect(combined).toContain("Attempting to install security scanner from npm");
+    expect(combined).toContain("Security scanner installed successfully");
+    expect(combined).toContain("SCANNER_RAN");
+    expect(exitCode).toBe(0);
+  },
+);
 
-test("install --frozen-lockfile --production with npm security scanner in devDependencies installs the scanner and completes", async () => {
-  const { combined, exitCode } = await writeFixture({ production: true, frozenLockfile: true });
+test.concurrent(
+  "install --frozen-lockfile --production with npm security scanner in devDependencies installs the scanner and completes",
+  async () => {
+    const { combined, exitCode } = await writeFixture({ production: true, frozenLockfile: true });
 
-  expect(combined).not.toContain("no packages were installed during security scanner installation");
-  expect(combined).toContain("Attempting to install security scanner from npm");
-  expect(combined).toContain("Security scanner installed successfully");
-  expect(combined).toContain("SCANNER_RAN");
-  expect(exitCode).toBe(0);
-});
+    expect(combined).not.toContain("no packages were installed during security scanner installation");
+    expect(combined).toContain("Attempting to install security scanner from npm");
+    expect(combined).toContain("Security scanner installed successfully");
+    expect(combined).toContain("SCANNER_RAN");
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/cli/install/bun-install-security-scanner-production.test.ts
+++ b/test/cli/install/bun-install-security-scanner-production.test.ts
@@ -10,10 +10,13 @@
 // served via the SimpleRegistry fixture: the scanner is a real `devDependencies`
 // entry and must install + run under `--production`.
 
-import { afterAll, beforeAll, expect, test } from "bun:test";
+import { afterAll, beforeAll, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { startRegistry, stopRegistry } from "./simple-dummy-registry";
+
+setDefaultTimeout(1000 * 60 * 5);
 
 let registryUrl: string;
 
@@ -77,7 +80,7 @@ scanner = "test-security-scanner"`,
   );
 
   // Drop node_modules so the install actually has to resolve + install.
-  await Bun.$`rm -rf ${join(dir, "node_modules")}`.quiet();
+  rmSync(join(dir, "node_modules"), { recursive: true, force: true });
 
   const args = ["install"];
   if (options.frozenLockfile) args.push("--frozen-lockfile");

--- a/test/cli/install/bun-install-security-scanner-production.test.ts
+++ b/test/cli/install/bun-install-security-scanner-production.test.ts
@@ -91,11 +91,7 @@ scanner = "test-security-scanner"`,
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    runProc.stdout.text(),
-    runProc.stderr.text(),
-    runProc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([runProc.stdout.text(), runProc.stderr.text(), runProc.exited]);
 
   return { dir, stdout, stderr, exitCode, combined: stdout + stderr };
 }


### PR DESCRIPTION
Fixes #31028

## Repro

```jsonc
// package.json
{
  "dependencies": { "is-number": "^7.0.0" },
  "devDependencies": { "@socketsecurity/bun-security-scanner": "*" }
}
```

```toml
# bunfig.toml
[install.security]
scanner = "@socketsecurity/bun-security-scanner"
```

`bun install` once, delete `node_modules`, then `bun install --frozen-lockfile --production`:

```
Attempting to install security scanner from npm...
error: no packages were installed during security scanner installation
```

## Cause

On the scanner's partial install, `do_partial_install_of_security_scanner` passes the scanner's pkg id via `packages_to_install` and calls `Lockfile::filter`. In the hoist tree builder (`src/install/lockfile/Tree.rs`) the order was:

1. `is_filtered_dependency_or_workspace` — rejects the scanner because it is a `devDependencies` entry and `--production` flipped `local_package_features.dev_dependencies = false`.
2. `packages_to_install` narrow — never reached.

So the tree ends up empty, the installer reports `success=0, fail=0, skipped=0`, and the partial install raises `NoPackagesInstalled`.

## Fix

Check `packages_to_install` first. When the current dep is the one we're bootstrapping (root parent + pkg id listed), run a variant of the filter that keeps the hard constraints (cpu/os `is_disabled`, `is_bundled`, workspace filters) and skips the `dep.behavior.is_enabled(dep_features)` gate. `packages_to_install` is only set by the security-scanner bootstrap path today, so other installs are unaffected.

## Verification

`test/cli/install/bun-install-security-scanner-production.test.ts` covers `--production` and `--frozen-lockfile --production` with a `devDependencies` scanner served from the local fixture registry; both fail on `main` with the issue's error message and pass here.