### PR TITLE
bundler: spell out elided Graph<'_> lifetimes

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -542,7 +542,7 @@ impl IntermediateOutput {
     pub fn code<'d>(
         &mut self,
         allocator_to_use: Option<&DynAlloc>,
-        parse_graph: &Graph,
+        parse_graph: &Graph<'_>,
         linker_graph: &LinkerGraph<'_>,
         import_prefix: &[u8],
         // PORT NOTE: Zig passed `*Chunk` / `[]Chunk` (freely aliased — `chunk`
@@ -593,7 +593,7 @@ impl IntermediateOutput {
     pub fn code_standalone<'d>(
         &mut self,
         allocator_to_use: Option<&DynAlloc>,
-        parse_graph: &Graph,
+        parse_graph: &Graph<'_>,
         linker_graph: &LinkerGraph<'_>,
         import_prefix: &[u8],
         // See `code()` PORT NOTE — `chunk` aliases `chunks[i]`; body is read-only.
@@ -638,7 +638,7 @@ impl IntermediateOutput {
     pub fn code_with_source_map_shifts<const ENABLE_SOURCE_MAP_SHIFTS: bool>(
         &mut self,
         allocator_to_use: Option<&DynAlloc>,
-        graph: &Graph,
+        graph: &Graph<'_>,
         linker_graph: &LinkerGraph<'_>,
         import_prefix: &[u8],
         // See `code()` PORT NOTE — `chunk` aliases `chunks[i]`; body is read-only.

--- a/src/bundler/HTMLImportManifest.rs
+++ b/src/bundler/HTMLImportManifest.rs
@@ -133,7 +133,7 @@ fn write_entry_item<W: Write + ?Sized>(
 // Extremely unfortunate, but necessary due to E.String not accepting pre-escaped input and this happening at the very end.
 pub fn write_escaped_json<W: Write + ?Sized>(
     index: u32,
-    graph: &Graph,
+    graph: &Graph<'_>,
     linker_graph: &LinkerGraph<'_>,
     chunks: &[Chunk],
     writer: &mut W,
@@ -177,7 +177,7 @@ impl<'a> HTMLImportManifest<'a> {
 
 pub fn write<W: Write + ?Sized>(
     index: u32,
-    graph: &Graph,
+    graph: &Graph<'_>,
     linker_graph: &LinkerGraph<'_>,
     chunks: &[Chunk],
     writer: &mut W,

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -291,7 +291,7 @@ impl<'a> LinkerContext<'a> {
     /// `generate_isolated_hash`) must continue to deref the raw
     /// `self.parse_graph` field directly.
     #[inline]
-    pub fn parse_graph(&self) -> &Graph {
+    pub fn parse_graph(&self) -> &Graph<'a> {
         debug_assert!(
             !self.parse_graph.is_null(),
             "LinkerContext.parse_graph accessed before load()"

--- a/src/bundler/ungate_support.rs
+++ b/src/bundler/ungate_support.rs
@@ -546,7 +546,7 @@ pub mod html_import_manifest {
     /// slice in place so it can recover `pos = before_len - cursor.len()`.
     pub fn write_escaped_json(
         index: u32,
-        graph: &Graph,
+        graph: &Graph<'_>,
         linker_graph: &LinkerGraph<'_>,
         chunks: &[Chunk],
         w: &mut &mut [u8],


### PR DESCRIPTION
## Summary
- `LinkerContext::parse_graph()` → `&Graph<'a>` to match `parse_graph_mut()`
- `Chunk.rs` / `HTMLImportManifest.rs` / `ungate_support.rs` `&Graph` params → `&Graph<'_>` to match the adjacent `&LinkerGraph<'_>` updated in #30900

Silences the `mismatched_lifetime_syntaxes` warnings introduced when `Graph` became `Graph<'a>`. No behavior change.