### PR TITLE
paths: derive Copy for fs::Path (cleanup, no alloc change)

### DIFF
--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -251,7 +251,7 @@ impl ParseTask {
             // SAFETY: lifetime erased — `ctx` outlives the ParseTask (BACKREF);
             // write provenance from the `*mut BundleV2` parameter.
             ctx: Some(unsafe { bun_ptr::ParentRef::from_raw_mut(ctx.cast::<BundleV2<'static>>()) }),
-            path: resolve_result.path_pair.primary.clone(),
+            path: resolve_result.path_pair.primary,
             contents_or_fd: ContentsOrFd::Fd {
                 dir: resolve_result.dirname_fd,
                 file: resolve_result.file_fd,
@@ -2206,7 +2206,7 @@ pub mod parse_worker {
         // path explicitly (scopeguard would alias `transpiler` access below).
         // SAFETY: `transpiler` is live; `resolver` projects a field of it.
         let resolver: *mut Resolver = unsafe { core::ptr::addr_of_mut!((*transpiler).resolver) };
-        let mut file_path = task.path.clone();
+        let mut file_path = task.path;
         let mut loader = task
             .loader
             // SAFETY: `options` is a disjoint field of the live `*transpiler`.

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6613,9 +6613,8 @@ pub mod bv2_impl {
 
                 if let Some(id) = self.path_to_source_index_map(target).get(&path.text) {
                     if self.dev_server.is_some() && loader != Loader::Html {
-                        import_record.path = self.graph.input_files.items_source()[id as usize]
-                            .path
-                            .clone();
+                        import_record.path =
+                            self.graph.input_files.items_source()[id as usize].path;
                     } else {
                         import_record.source_index = Index::init(id);
                     }
@@ -6629,12 +6628,12 @@ pub mod bv2_impl {
                 let resolve_entry = resolve_queue.get_or_put(&path.text).expect("oom");
                 if resolve_entry.found_existing {
                     import_record.path =
-                        path_as_static(unsafe { &**resolve_entry.value_ptr }.path.clone());
+                        path_as_static(unsafe { &**resolve_entry.value_ptr }.path);
                     continue;
                 }
 
                 *path = self
-                    .path_with_pretty_initialized(core::mem::take(path), target)
+                    .path_with_pretty_initialized(*path, target)
                     .expect("oom");
 
                 import_record.path = path_as_static(*path);
@@ -6667,7 +6666,7 @@ pub mod bv2_impl {
                         && !core::ptr::eq(secondary, path)
                         && !strings::eql_long(&secondary.text, &path.text, true)
                     {
-                        resolve_task.secondary_path_for_commonjs_interop = Some(secondary.clone());
+                        resolve_task.secondary_path_for_commonjs_interop = Some(*secondary);
                     }
                 }
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6498,7 +6498,7 @@ pub mod bv2_impl {
                         )
                     {
                         import_record.path =
-                            path_as_static(resolve_result.path_pair.primary.clone());
+                            path_as_static(resolve_result.path_pair.primary);
                     }
                     import_record.flags.set(
                         bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS,
@@ -6570,7 +6570,7 @@ pub mod bv2_impl {
                                 import_record.path.text = path.text;
                                 import_record.path.pretty = rel.into();
                                 import_record.path = path_as_static(
-                                    self.path_with_pretty_initialized(path.clone(), target)
+                                    self.path_with_pretty_initialized(*path, target)
                                         .expect("oom"),
                                 );
                                 if loader == Loader::Html

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5833,7 +5833,7 @@ pub mod bv2_impl {
                 self.transpiler.fs().top_level_dir,
                 bump,
             )?;
-            Ok(out.clone())
+            Ok(out)
         }
 
         #[cold]
@@ -6637,7 +6637,7 @@ pub mod bv2_impl {
                     .path_with_pretty_initialized(core::mem::take(path), target)
                     .expect("oom");
 
-                import_record.path = path_as_static(path.clone());
+                import_record.path = path_as_static(*path);
                 // key already interned by get_or_put — no key_ptr on StringHashMapGetOrPut
                 bun_core::scoped_log!(Bundle, "created ParseTask: {}", bstr::BStr::new(&path.text));
                 // Arena-owned (Zig: `arena.create(ParseTask)`).
@@ -6752,7 +6752,7 @@ pub mod bv2_impl {
 
                     new_input_file.source.index =
                         bun_ast::Index(self.graph.input_files.len() as u32);
-                    new_input_file.source.path = path_as_static(new_task.path.clone());
+                    new_input_file.source.path = path_as_static(new_task.path);
                     new_input_file.loader = loader;
                     let new_source_index: u32 = new_input_file.source.index.0;
                     new_task.source_index = bun_ast::Index(new_source_index);

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6497,8 +6497,7 @@ pub mod bv2_impl {
                             true,
                         )
                     {
-                        import_record.path =
-                            path_as_static(resolve_result.path_pair.primary);
+                        import_record.path = path_as_static(resolve_result.path_pair.primary);
                     }
                     import_record.flags.set(
                         bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6627,8 +6627,7 @@ pub mod bv2_impl {
 
                 let resolve_entry = resolve_queue.get_or_put(&path.text).expect("oom");
                 if resolve_entry.found_existing {
-                    import_record.path =
-                        path_as_static(unsafe { &**resolve_entry.value_ptr }.path);
+                    import_record.path = path_as_static(unsafe { &**resolve_entry.value_ptr }.path);
                     continue;
                 }
 

--- a/src/paths/lib.rs
+++ b/src/paths/lib.rs
@@ -831,7 +831,7 @@ pub mod fs {
     /// of this type (D090). Resolver-tier methods (`dupe_alloc`, `loader`, `hash_key`,
     /// …) live on `bun_resolver::fs::PathResolverExt`.
     #[repr(C)]
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, Copy)]
     pub struct Path<'a> {
         /// Display path — relative to cwd in the bundler; forward-slash on Windows.
         pub pretty: &'a [u8],


### PR DESCRIPTION
fs::Path<'a> fields are all `&'a [u8]` borrows + `PathName<'a>: Copy` — no owned heap. Derive Copy and drop 5 explicit `.clone()` calls in ParseTask/bundle_v2 that fire once per module (~120K calls on 20K-module bundle, ~12 MB of struct memmove). Zero runtime change (struct copy either way) but matches Zig's by-value passing.

Found via runtime clone tracer (claude/clone-tracer).