### PR TITLE
resolver: avoid unconditional deep clone of exports Entry in visit()

### DIFF
--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1855,20 +1855,21 @@ impl<'a> Visitor<'a> {
                     }
 
                     let value = self.visit(prop.value.expect("infallible: prop has value"));
-                    map_data.push(MapEntry {
-                        key: key.clone(),
-                        key_range,
-                        value: value.clone(),
-                    });
 
                     // safe to use "/" on windows. exports in package.json does not use "\\"
                     if strings::ends_with(&key, b"/") || strings::contains_char(&key, b'*') {
                         expansion_keys.push(MapEntry {
-                            value,
-                            key,
+                            value: value.clone(),
+                            key: key.clone(),
                             key_range,
                         });
                     }
+
+                    map_data.push(MapEntry {
+                        key,
+                        key_range,
+                        value,
+                    });
                 }
 
                 // this leaks a lil, but it's fine.


### PR DESCRIPTION
package.json exports-map `visit()` (EObject arm) deep-cloned each `Entry` (recursive `Box<[Entry]>` tree) before deciding whether to keep it. Borrow first, clone only when retained. ~193 recursive clones / ~8 KB on the rolldown 20K bundle.

Found via runtime clone tracer (claude/clone-tracer).