### PR TITLE
node/types: avoid intermediate Vec in digest('base64') encode

### DIFF
--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -839,12 +839,14 @@ impl Encoding {
         // const-generic arithmetic in array lengths, so we heap-allocate.
         match self {
             Self::Base64 => {
-                let mut base64_buf =
-                    vec![0u8; bun_core::base64::standard_encoder_calc_size(max_size * 4)];
-                let encoded_len = bun_core::base64::encode(&mut base64_buf, input);
+                let encoded_len = bun_core::base64::encode_len(input);
                 let (mut encoded, bytes) =
                     bun_core::String::create_uninitialized_latin1(encoded_len);
-                bytes.copy_from_slice(&base64_buf[..encoded_len]);
+                if encoded.is_dead() {
+                    return encoded.transfer_to_js(global_object);
+                }
+                let n = bun_core::base64::encode(bytes, input);
+                debug_assert_eq!(n, encoded_len);
                 encoded.transfer_to_js(global_object)
             }
             Self::Base64url => {


### PR DESCRIPTION
Clone-tracer shard **nodetypes** — 1 site.

### types-846 — `String::create_uninit_latin1` @ `src/runtime/node/types.rs:846`
`Encoding::Base64` arm of `encode_with_max_size`. Traced **2050 hits @ ~44 B avg** (SHA-256 digests via `hash.digest('base64')` from CryptoHasher / csrf / webcore Crypto callers).

The WTF Latin-1 allocation is the JS result and is unavoidable. What was avoidable: the intermediate `vec![0u8; calc_size(max_size*4)]` (~344 B for `EVP_MAX_MD_SIZE` callers) plus the `copy_from_slice` into the WTF buffer. Padded base64 length is exact (`encode_len` = `((n+2)/3)*4`), so size the WTF buffer up-front and let simdutf encode straight into it — same shape the Hex arm already uses. Adds the matching `is_dead()` OOM guard so simdutf never writes into a zero-length slice on WTF OOM.

**Net:** −1 heap alloc (~344 B), −1 memcpy per `digest('base64')` call. The traced `create_uninit_latin1` remains (it is the destination).

**Safety:** `bun_core::base64::encode` writes exactly `encode_len(input)` bytes for the standard padded alphabet (util.rs:4032-4035 / simdutf binary_to_base64); guarded by `debug_assert_eq!`. No new `unsafe`. No cross-thread hazard — created and transferred on the JS thread in the same call. Zig (types.zig:462-466) also did stack-buffer→memcpy→WTF, so this is an improvement over Zig, not a divergence.

### Non-fixes
- **types-860** (Hex arm): already encodes directly into the WTF buffer — necessary as-is.

### Tests
`bun bd test` — 935 pass / 0 fail across `test/js/node/crypto/crypto.test.ts`, `node-crypto.test.js`, `test/js/bun/util/bun-cryptohasher.test.ts`, `csrf.test.ts` (build `3f6187862`).