### PR TITLE
fetch: avoid WTFStringImpl clone for canonical statusText

### DIFF
--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1562,7 +1562,16 @@ impl FetchTasklet {
         // atom strings live in a per-thread table — deref'ing them off-thread
         // trips the `wasRemoved` RELEASE_ASSERT in AtomStringImpl::remove().
         // Plain WTFStringImpl refcounts are atomic, so clone_utf8 is safe.
-        let status_text = BunString::clone_utf8(&http_response.status);
+        // Fast path: when the wire reason phrase matches the canonical text for
+        // this status code, store a StaticZigString (deref is a no-op, so still
+        // safe to drop off-thread) and skip the WTF allocation entirely.
+        let status_text = match crate::server::http_status_text::get(status_code)
+            .map(|t| &t[4..])
+            .filter(|canon| *canon == http_response.status)
+        {
+            Some(canon) => BunString::static_(canon),
+            None => BunString::clone_utf8(&http_response.status),
+        };
         let url = BunString::clone_utf8(metadata.url.slice());
         let redirected = self.result.redirected;
         Response::init(


### PR DESCRIPTION
Part of the clone-tracer sweep.

### `src/runtime/webcore/fetch/FetchTasklet.rs:1565` — `String::clone_utf8(http_response.status)`

Tracer: **5947 calls / 14290 bytes** (≈ 2.4 B avg — overwhelmingly the literal `"OK"`).

`FetchTasklet::to_response` allocated a fresh `WTFStringImpl` for every response reason phrase. The Zig original used `createAtomIfPossible` here; the Rust port switched to `clone_utf8` to avoid the off-thread `AtomStringImpl::remove` crash when a `Response` is dropped from the HTTP thread during VM shutdown.

**Fix:** look up the canonical reason phrase via `http_status_text::get(code)` (the same table `Bun.serve` uses to write the status line). When the wire bytes match, store `BunString::static_(canon)` (`Tag::StaticZigString`). Otherwise fall back to `clone_utf8` so custom/non-standard reason phrases are preserved verbatim.

**Why safe off-thread:** `String::deref()` is a no-op for non-`WTFStringImpl` tags, so dropping a `StaticZigString` from the HTTP thread touches no atom table. The atom only materializes inside `BunString__toJS` → `Zig::toStringStatic` when JS reads `response.statusText` on the JS thread, owned by the resulting `JSString` cell. `Init::clone()` on a `StaticZigString` falls through to `clone_utf8(self.byte_slice())` — a plain non-atom `WTFStringImpl` on the JS thread, same safety profile as today.

**HTTP/2** (empty reason phrase): filter fails, `clone_utf8(b"")` → `String::EMPTY` (already zero-alloc).

No new `unsafe`. `response.statusText` remains byte-identical to what the server sent.

---

Non-fixes from this shard: `fetchtasklet-hdr-a` (defer), `fetchtasklet-1228` / `request-url` / `server-570` (necessary).