### PR TITLE
css: drop no-op .into()/.clone() on Copy (clippy cleanup, no alloc change)

### DIFF
--- a/src/css/properties/align.rs
+++ b/src/css/properties/align.rs
@@ -840,8 +840,8 @@ impl PlaceContent {
                 }
                 AlignContent::ContentPosition(pos) => {
                     JustifyContent::ContentPosition(JustifyContentContentPosition {
-                        overflow: pos.overflow.clone(),
-                        value: pos.value.clone(),
+                        overflow: pos.overflow,
+                        value: pos.value,
                     })
                 }
             },

--- a/src/css/properties/custom.rs
+++ b/src/css/properties/custom.rs
@@ -1138,7 +1138,7 @@ impl EnvironmentVariable {
 
     pub fn get_fallback(&self, bump: &Arena, kind: ColorFallbackKind) -> Self {
         EnvironmentVariable {
-            name: self.name.clone(),
+            name: self.name,
             indices: self.indices.clone(),
             fallback: self
                 .fallback
@@ -1367,7 +1367,7 @@ impl Clone for TokenOrValue {
             TokenOrValue::Time(v) => TokenOrValue::Time(*v),
             TokenOrValue::Resolution(v) => TokenOrValue::Resolution(*v),
             TokenOrValue::DashedIdent(v) => TokenOrValue::DashedIdent(*v),
-            TokenOrValue::AnimationName(v) => TokenOrValue::AnimationName(v.clone()),
+            TokenOrValue::AnimationName(v) => TokenOrValue::AnimationName(*v),
         }
     }
 }

--- a/src/css/properties/transform.rs
+++ b/src/css/properties/transform.rs
@@ -761,7 +761,7 @@ impl Translate {
             Translate::Xyz { x, y, z } => Transform::Translate3d {
                 x: x.clone(),
                 y: y.clone(),
-                z: z.clone(),
+                z: *z,
             },
         }
     }

--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -4046,8 +4046,8 @@ pub fn parse_qualified_name<Impl: BunSelectorImpl>(
             };
             if n {
                 let prefix: Impl::NamespacePrefix = Ident { v: value };
-                let result: Option<Impl::NamespaceUrl> = parser
-                    .namespace_for_prefix(Ident { v: value });
+                let result: Option<Impl::NamespaceUrl> =
+                    parser.namespace_for_prefix(Ident { v: value });
                 let url: Impl::NamespaceUrl = match result {
                     Some(url) => url,
                     None => {

--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -195,7 +195,7 @@ pub mod attrs {
         pub fn deep_clone(&self) -> Self {
             // `NamespaceUrl = &'static [u8]` (arena-backed) — identity copy.
             Self {
-                prefix: self.prefix.clone(),
+                prefix: self.prefix,
                 url: self.url,
             }
         }
@@ -270,8 +270,8 @@ pub mod attrs {
         pub fn deep_clone(&self) -> Self {
             Self {
                 namespace: self.namespace.as_ref().map(|n| n.deep_clone()),
-                local_name: self.local_name.clone(),
-                local_name_lower: self.local_name_lower.clone(),
+                local_name: self.local_name,
+                local_name_lower: self.local_name_lower,
                 operation: self.operation.deep_clone(),
                 never_matches: self.never_matches,
             }
@@ -2263,19 +2263,19 @@ impl<Impl: BunSelectorImpl> GenericComponent<Impl> {
             C::ExplicitNoNamespace => C::ExplicitNoNamespace,
             C::DefaultNamespace(u) => C::DefaultNamespace(*u),
             C::Namespace { prefix, url } => C::Namespace {
-                prefix: prefix.clone(),
+                prefix: *prefix,
                 url: *url,
             },
             C::ExplicitUniversalType => C::ExplicitUniversalType,
             C::LocalName(ln) => C::LocalName(ln.deep_clone()),
-            C::Id(i) => C::Id(i.clone()),
-            C::Class(i) => C::Class(i.clone()),
+            C::Id(i) => C::Id(*i),
+            C::Class(i) => C::Class(*i),
             C::AttributeInNoNamespaceExists {
                 local_name,
                 local_name_lower,
             } => C::AttributeInNoNamespaceExists {
-                local_name: local_name.clone(),
-                local_name_lower: local_name_lower.clone(),
+                local_name: *local_name,
+                local_name_lower: *local_name_lower,
             },
             C::AttributeInNoNamespace {
                 local_name,
@@ -2284,9 +2284,9 @@ impl<Impl: BunSelectorImpl> GenericComponent<Impl> {
                 case_sensitivity,
                 never_matches,
             } => C::AttributeInNoNamespace {
-                local_name: local_name.clone(),
+                local_name: *local_name,
                 operator: *operator,
-                value: value.clone(),
+                value: *value,
                 case_sensitivity: *case_sensitivity,
                 never_matches: *never_matches,
             },
@@ -2307,7 +2307,7 @@ impl<Impl: BunSelectorImpl> GenericComponent<Impl> {
                 vendor_prefix,
                 selectors,
             } => C::Any {
-                vendor_prefix: vendor_prefix.clone(),
+                vendor_prefix: *vendor_prefix,
                 selectors: deep_clone_selector_slice(selectors),
             },
             C::Has(s) => C::Has(deep_clone_selector_slice(s)),
@@ -3450,14 +3450,14 @@ pub fn parse_one_simple_selector<Impl: BunSelectorImpl>(
                                 // PERF(port): was arena ArrayList with capacity 1 — profile if hot.
                                 let mut result: Vec<Impl::Identifier> = Vec::with_capacity(1);
 
-                                result.push(Impl::Identifier::from(Ident {
+                                result.push(Ident {
                                     v: input2.expect_ident()?,
-                                }));
+                                });
 
                                 while !input2.is_exhausted() {
-                                    result.push(Impl::Identifier::from(Ident {
+                                    result.push(Ident {
                                         v: input2.expect_ident()?,
-                                    }));
+                                    });
                                 }
 
                                 Ok(result.into_boxed_slice())
@@ -3596,22 +3596,20 @@ pub fn parse_attribute_selector<Impl: BunSelectorImpl>(
                 if let Some(ns) = namespace {
                     let x = attrs::AttrSelectorWithOptionalNamespace::<Impl> {
                         namespace: Some(ns),
-                        local_name: Ident { v: local_name }.into(),
+                        local_name: Ident { v: local_name },
                         local_name_lower: Ident {
                             v: local_name_lower,
-                        }
-                        .into(),
+                        },
                         never_matches: false,
                         operation: attrs::ParsedAttrSelectorOperation::Exists,
                     };
                     return Ok(GenericComponent::AttributeOther(Box::new(x)));
                 } else {
                     return Ok(GenericComponent::AttributeInNoNamespaceExists {
-                        local_name: Ident { v: local_name }.into(),
+                        local_name: Ident { v: local_name },
                         local_name_lower: Ident {
                             v: local_name_lower,
-                        }
-                        .into(),
+                        },
                     });
                 }
             }
@@ -3711,7 +3709,7 @@ pub fn parse_attribute_selector<Impl: BunSelectorImpl>(
         )))
     } else {
         Ok(GenericComponent::AttributeInNoNamespace {
-            local_name: Ident { v: local_name }.into(),
+            local_name: Ident { v: local_name },
             operator,
             value,
             case_sensitivity,
@@ -3797,7 +3795,7 @@ pub fn parse_functional_pseudo_class<Impl: BunSelectorImpl>(
 
     let result = parser.parse_non_ts_functional_pseudo_class(name, input)?;
 
-    Ok(GenericComponent::NonTsPseudoClass(result.into()))
+    Ok(GenericComponent::NonTsPseudoClass(result))
     // TODO(port): `Impl::NonTSPseudoClass` is `PseudoClass` for the concrete impl;
     // generic path would need a `From` bound.
 }
@@ -3861,7 +3859,7 @@ pub fn parse_simple_pseudo_class<Impl: BunSelectorImpl>(
         ));
     }
 
-    Ok(GenericComponent::NonTsPseudoClass(pseudo_class.into()))
+    Ok(GenericComponent::NonTsPseudoClass(pseudo_class))
 }
 
 pub fn parse_nth_pseudo_class<Impl: BunSelectorImpl>(
@@ -4047,10 +4045,9 @@ pub fn parse_qualified_name<Impl: BunSelectorImpl>(
                 false
             };
             if n {
-                let prefix: Impl::NamespacePrefix = Ident { v: value }.into();
+                let prefix: Impl::NamespacePrefix = Ident { v: value };
                 let result: Option<Impl::NamespaceUrl> = parser
-                    .namespace_for_prefix(Ident { v: value })
-                    .map(Into::into);
+                    .namespace_for_prefix(Ident { v: value });
                 let url: Impl::NamespaceUrl = match result {
                     Some(url) => url,
                     None => {
@@ -4093,7 +4090,7 @@ pub fn parse_qualified_name<Impl: BunSelectorImpl>(
                     }
                 }
                 // PORT NOTE: reshaped for borrowck — clone token before reset.
-                let result_cloned = result.map(|t| t.clone());
+                let result_cloned = result.cloned();
                 input.reset(&after_star);
                 if in_attr_selector {
                     match result_cloned {
@@ -4177,8 +4174,8 @@ impl<Impl: BunSelectorImpl> LocalName<Impl> {
     }
     pub fn deep_clone(&self) -> Self {
         Self {
-            name: self.name.clone(),
-            lower_name: self.lower_name.clone(),
+            name: self.name,
+            lower_name: self.lower_name,
         }
     }
 }

--- a/src/css/values/gradient.rs
+++ b/src/css/values/gradient.rs
@@ -631,7 +631,7 @@ impl ConicGradient {
             .collect();
 
         ConicGradient {
-            angle: self.angle.clone(),
+            angle: self.angle,
             position: self.position.deep_clone(bump),
             items,
         }
@@ -643,7 +643,7 @@ impl ConicGradient {
             items.push(in_.deep_clone(bump));
         }
         ConicGradient {
-            angle: self.angle.clone(),
+            angle: self.angle,
             position: self.position.deep_clone(bump),
             items,
         }
@@ -1209,7 +1209,7 @@ impl<S: GradientSideKeyword> WebKitGradientPointComponent<S> {
                 if s.offset.is_some() {
                     None
                 } else {
-                    Some(WebKitGradientPointComponent::Side(s.side.clone()))
+                    Some(WebKitGradientPointComponent::Side(s.side))
                 }
             }
         }


### PR DESCRIPTION
Mechanical clippy autofix for the `bun_css` crate — porting cruft from the Zig→Rust translation where types that became `Copy` were still being `.clone()`d, or already-typed values were going through no-op `.into()`.

Lints applied (33 fixes, 5 files):
- `clippy::clone_on_copy` — `.clone()` on `Copy` types (`Ident`, `Angle`, `VendorPrefix`, `LengthValue`, `ContentPosition`, etc.)
- `clippy::useless_conversion` — `.into()` / `From` to the same type (`Ident`, `PseudoClass`, `&[u8]`)
- `clippy::map_clone` — `.map(|t| t.clone())` → `.cloned()`

Compiler-verified zero behavior change. `cargo check -p bun_bin` clean.