### PR TITLE
bundler: drop no-op .into()/.clone() on Copy (clippy cleanup, no alloc change)

### DIFF
--- a/src/bundler/AstBuilder.rs
+++ b/src/bundler/AstBuilder.rs
@@ -589,15 +589,12 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
         Ok(crate::BundledAst {
             parts,
             module_scope: module_scope_value,
-            symbols: bun_alloc::vec_from_iter_in(
-                core::mem::take(&mut self.symbols).into_iter(),
-                self.bump,
-            ),
+            symbols: bun_alloc::vec_from_iter_in(core::mem::take(&mut self.symbols), self.bump),
             exports_ref: Ref::NONE,
             wrapper_ref: Ref::NONE,
             module_ref: self.module_ref,
             import_records: bun_alloc::vec_from_iter_in(
-                core::mem::take(&mut self.import_records).into_iter(),
+                core::mem::take(&mut self.import_records),
                 self.bump,
             ),
             export_star_import_records: Box::default(),

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -791,7 +791,6 @@ pub mod parse_worker {
                 // `caches` is disjoint from `(*transpiler).options` reborrowed above.
                 let root: Expr = unsafe { &mut (*resolver).caches.json }
                     .parse_json(log, source, mode, true)?
-                    .map(Into::into)
                     .unwrap_or_else(|| Expr::init(E::Object::default(), Loc::EMPTY));
                 return Ok(JSAst::init(
                     js_parser::new_lazy_export_ast(
@@ -816,7 +815,7 @@ pub mod parse_worker {
                 // post-amble that flushes `temp_log`.
                 let result = (|| -> core::result::Result<JSAst<'static>, AnyError> {
                     let root: Expr =
-                        bun_parsers::toml::TOML::parse(source, &mut temp_log, bump, false)?.into();
+                        bun_parsers::toml::TOML::parse(source, &mut temp_log, bump, false)?;
                     Ok(JSAst::init(
                         js_parser::new_lazy_export_ast(
                             bump,
@@ -837,8 +836,7 @@ pub mod parse_worker {
                 let _trace = perf::trace("Bundler.ParseYAML");
                 let mut temp_log = Log::init();
                 let result = (|| -> core::result::Result<JSAst<'static>, AnyError> {
-                    let root: Expr =
-                        bun_parsers::yaml::YAML::parse(source, &mut temp_log, bump)?.into();
+                    let root: Expr = bun_parsers::yaml::YAML::parse(source, &mut temp_log, bump)?;
                     Ok(JSAst::init(
                         js_parser::new_lazy_export_ast(
                             bump,
@@ -860,7 +858,7 @@ pub mod parse_worker {
                 let mut temp_log = Log::init();
                 let result = (|| -> core::result::Result<JSAst<'static>, AnyError> {
                     let root: Expr =
-                        bun_parsers::json5::JSON5Parser::parse(source, &mut temp_log, bump)?.into();
+                        bun_parsers::json5::JSON5Parser::parse(source, &mut temp_log, bump)?;
                     Ok(JSAst::init(
                         js_parser::new_lazy_export_ast(
                             bump,
@@ -1161,7 +1159,7 @@ pub mod parse_worker {
                     b"",
                 )?
                 .unwrap();
-                ast.import_records = bun_alloc::vec_from_iter_in(import_records.into_iter(), bump);
+                ast.import_records = bun_alloc::vec_from_iter_in(import_records, bump);
 
                 // We're banning import default of html loader files for now.
                 //
@@ -1289,7 +1287,7 @@ pub mod parse_worker {
                 let mut ast = JSAst::init(lazy?.unwrap());
                 let css_ast_heap = crate::bundled_ast::CssAstRef::from_bump(bump.alloc(css_ast));
                 ast.css = Some(css_ast_heap);
-                ast.import_records = bun_alloc::vec_from_iter_in(import_records.into_iter(), bump);
+                ast.import_records = bun_alloc::vec_from_iter_in(import_records, bump);
                 return Ok(ast);
             }
             // TODO:

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2021,11 +2021,11 @@ pub mod bv2_impl {
 
             if self.transpiler.options.code_splitting {
                 for entry_point in self.graph.entry_points.iter().copied() {
-                    visitor.visit::<true>(entry_point.into(), false);
+                    visitor.visit::<true>(entry_point, false);
                 }
             } else {
                 for entry_point in self.graph.entry_points.iter().copied() {
-                    visitor.visit::<false>(entry_point.into(), false);
+                    visitor.visit::<false>(entry_point, false);
                 }
             }
 
@@ -2393,7 +2393,7 @@ pub mod bv2_impl {
                                                 bstr::BStr::new(path_to_use)
                                             ),
                                             path_to_use,
-                                            import_record.kind.into(),
+                                            import_record.kind,
                                         );
                                     } else {
                                         add_error(
@@ -2405,7 +2405,7 @@ pub mod bv2_impl {
                                                 bstr::BStr::new(path_to_use)
                                             ),
                                             path_to_use,
-                                            import_record.kind.into(),
+                                            import_record.kind,
                                         );
                                     }
                                 } else {
@@ -2418,7 +2418,7 @@ pub mod bv2_impl {
                                             bstr::BStr::new(path_to_use)
                                         ),
                                         path_to_use,
-                                        import_record.kind.into(),
+                                        import_record.kind,
                                     );
                                 }
                             }
@@ -2623,7 +2623,7 @@ pub mod bv2_impl {
                 ..Default::default()
             })?;
             // Arena-owned (Zig: `arena.create(ParseTask)`); freed on heap reset.
-            let task_val = ParseTask::init(&result, source_index.into(), self);
+            let task_val = ParseTask::init(&result, source_index, self);
             // SAFETY: arena outlives the bundle pass; reborrow `*mut` as `&mut`.
             let task: &mut ParseTask = self.arena_create(task_val);
             task.loader = Some(loader);
@@ -2740,7 +2740,7 @@ pub mod bv2_impl {
                 ..Default::default()
             })?;
             // Arena-owned (Zig: `arena.create(ParseTask)`); freed on heap reset.
-            let task_val = ParseTask::init(result, source_index.into(), self);
+            let task_val = ParseTask::init(result, source_index, self);
             // SAFETY: arena outlives the bundle pass; reborrow `*mut` as `&mut`.
             let task: &mut ParseTask = self.arena_create(task_val);
             task.loader = Some(loader);
@@ -5625,9 +5625,8 @@ pub mod bv2_impl {
             // Arena-owned (Zig allocates `chunks` from `this.arena()`); the
             // `DevServerOutput` lifetime is documented as "tied to the bundler's
             // arena". `alloc_slice_fill_iter` moves each `Chunk` into the bump.
-            let chunks: *mut [Chunk] = std::ptr::from_mut::<[Chunk]>(
-                self.arena().alloc_slice_fill_iter(chunks.into_iter()),
-            );
+            let chunks: *mut [Chunk] =
+                std::ptr::from_mut::<[Chunk]>(self.arena().alloc_slice_fill_iter(chunks));
             // SAFETY: arena outlives this fn and the `DevServerOutput` it produces.
             let chunks: &mut [Chunk] = unsafe { &mut *chunks };
 
@@ -5717,7 +5716,7 @@ pub mod bv2_impl {
             target: options::Target,
         ) -> bool {
             if let Some(plugins) = self.plugins_ref() {
-                let mut temp_path = Fs::Path::init(entry_point.into());
+                let mut temp_path = Fs::Path::init(entry_point);
                 temp_path.namespace = b"file";
                 if plugins.has_any_matches(&temp_path, false) {
                     bun_core::scoped_log!(
@@ -6367,7 +6366,7 @@ pub mod bv2_impl {
                                                     },
                                                 ),
                                                 &import_record.path.text,
-                                                import_record.kind.into(),
+                                                import_record.kind,
                                             );
                                         } else if !ctx.target.is_bun()
                                             && import_record.path.text == b"bun"
@@ -6389,7 +6388,7 @@ pub mod bv2_impl {
                                                     },
                                                 ),
                                                 &import_record.path.text,
-                                                import_record.kind.into(),
+                                                import_record.kind,
                                             );
                                         } else if !ctx.target.is_bun()
                                             && import_record.path.text.starts_with(b"bun:")
@@ -6411,7 +6410,7 @@ pub mod bv2_impl {
                                                     },
                                                 ),
                                                 &import_record.path.text,
-                                                import_record.kind.into(),
+                                                import_record.kind,
                                             );
                                         } else {
                                             add_error(
@@ -6423,7 +6422,7 @@ pub mod bv2_impl {
                                                     bstr::BStr::new(&import_record.path.text)
                                                 ),
                                                 &import_record.path.text,
-                                                import_record.kind.into(),
+                                                import_record.kind,
                                             );
                                         }
                                     } else {
@@ -6457,7 +6456,7 @@ pub mod bv2_impl {
                                                 bstr::BStr::new(specifier_to_use)
                                             ),
                                             specifier_to_use,
-                                            import_record.kind.into(),
+                                            import_record.kind,
                                         );
                                     }
                                 }
@@ -6568,7 +6567,7 @@ pub mod bv2_impl {
                                 import_record.path.is_disabled = false;
                             } else {
                                 import_record.path.text = path.text;
-                                import_record.path.pretty = rel.into();
+                                import_record.path.pretty = rel;
                                 import_record.path = path_as_static(
                                     self.path_with_pretty_initialized(path.clone(), target)
                                         .expect("oom"),
@@ -6652,7 +6651,7 @@ pub mod bv2_impl {
                     target
                 };
 
-                resolve_task.jsx = resolve_result.jsx.clone().into();
+                resolve_task.jsx = resolve_result.jsx.clone();
                 resolve_task.jsx.development = match transpiler.options.force_node_env {
                     options::ForceNodeEnv::Development => true,
                     options::ForceNodeEnv::Production => false,
@@ -6735,7 +6734,7 @@ pub mod bv2_impl {
                 if !found_existing {
                     let new_task: &mut ParseTask = value;
                     let mut new_input_file = crate::Graph::InputFile {
-                        source: bun_ast::Source::init_empty_file(&new_task.path.text[..]),
+                        source: bun_ast::Source::init_empty_file(new_task.path.text),
                         side_effects: new_task.side_effects,
                         secondary_path: if let Some(secondary_path) =
                             &new_task.secondary_path_for_commonjs_interop
@@ -6896,8 +6895,7 @@ pub mod bv2_impl {
 
                     if let Some(compare) = get_redirect_id(ctx.redirect_import_record_index) {
                         if compare == i as u32 {
-                            let _ =
-                                path_to_source_index_map.put(ctx.source_path.into(), source_index); // OOM-only Result (Zig: catch unreachable)
+                            let _ = path_to_source_index_map.put(ctx.source_path, source_index); // OOM-only Result (Zig: catch unreachable)
                         }
                     }
                 }
@@ -6925,11 +6923,7 @@ pub mod bv2_impl {
                 ..Default::default()
             });
             let mut js_parser_options = bun_js_parser::ParserOptions::init(
-                self.transpiler_for_target(target)
-                    .options
-                    .jsx
-                    .clone()
-                    .into(),
+                self.transpiler_for_target(target).options.jsx.clone(),
                 Loader::Html,
             );
             js_parser_options.bundle = true;
@@ -6994,7 +6988,7 @@ pub mod bv2_impl {
             import_record.source_index = Index::init(fake_source_index.0);
             let _ = self
                 .path_to_source_index_map(target)
-                .put(path_text.into(), fake_source_index.0); // OOM-only Result (Zig: catch unreachable)
+                .put(path_text, fake_source_index.0); // OOM-only Result (Zig: catch unreachable)
             self.graph
                 .html_imports
                 .server_source_indices

--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -600,7 +600,7 @@ impl Linker {
                         bstr::BStr::new(import_record.path.text)
                     ),
                     import_record.path.text,
-                    import_record.kind.into(),
+                    import_record.kind,
                     bun_core::err!("ModuleNotFound"),
                 );
             } else {
@@ -612,7 +612,7 @@ impl Linker {
                         bstr::BStr::new(import_record.path.text)
                     ),
                     import_record.path.text,
-                    import_record.kind.into(),
+                    import_record.kind,
                     bun_core::err!("ModuleNotFound"),
                 );
             }
@@ -625,7 +625,7 @@ impl Linker {
                     bstr::BStr::new(import_record.path.text)
                 ),
                 import_record.path.text,
-                import_record.kind.into(),
+                import_record.kind,
                 bun_core::err!("ModuleNotFound"),
             );
         }

--- a/src/bundler/linker_context/generateCodeForLazyExport.rs
+++ b/src/bundler/linker_context/generateCodeForLazyExport.rs
@@ -361,9 +361,8 @@ pub fn generate_code_for_lazy_export(
                     // PORT NOTE: Zig used an arena-backed ArrayList and moved `.items`
                     // into `E.Template`; mirror that by moving into the linker arena
                     // (freed when the linker arena drops).
-                    let parts_slice = bun_ast::StoreSlice::new_mut(
-                        arena.alloc_slice_fill_iter(template_parts.into_iter()),
-                    );
+                    let parts_slice =
+                        bun_ast::StoreSlice::new_mut(arena.alloc_slice_fill_iter(template_parts));
                     value = Expr::init(
                         E::Template {
                             tag: None,

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -1149,8 +1149,7 @@ pub fn generate_entry_point_tail_js<'a>(
                         // collected Vec into the linker arena (Zig used
                         // `c.arena().alloc`). The arena slice is also iterated
                         // below for the synthetic-default-export path.
-                        let items: &mut [bun_ast::ClauseItem] =
-                            arena.alloc_slice_fill_iter(items.into_iter());
+                        let items: &mut [bun_ast::ClauseItem] = arena.alloc_slice_fill_iter(items);
                         stmts.push(Stmt::alloc(
                             S::ExportClause {
                                 items: bun_ast::StoreSlice::new_mut(items),

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -834,35 +834,35 @@ impl ESMConditions {
         style_condition_map.reserve(defaults.len() + 2 + conditions.len());
 
         // PERF(port): was assume_capacity
-        import_condition_map.insert(b"import".as_slice().into(), ());
-        require_condition_map.insert(b"require".as_slice().into(), ());
-        style_condition_map.insert(b"style".as_slice().into(), ());
+        import_condition_map.insert(b"import".as_slice(), ());
+        require_condition_map.insert(b"require".as_slice(), ());
+        style_condition_map.insert(b"style".as_slice(), ());
 
         for condition in conditions {
-            import_condition_map.insert((*condition).into(), ());
-            require_condition_map.insert((*condition).into(), ());
-            default_condition_amp.insert((*condition).into(), ());
+            import_condition_map.insert(*condition, ());
+            require_condition_map.insert(*condition, ());
+            default_condition_amp.insert(*condition, ());
         }
 
         for default in defaults {
-            default_condition_amp.insert((*default).into(), ());
-            import_condition_map.insert((*default).into(), ());
-            require_condition_map.insert((*default).into(), ());
-            style_condition_map.insert((*default).into(), ());
+            default_condition_amp.insert(*default, ());
+            import_condition_map.insert(*default, ());
+            require_condition_map.insert(*default, ());
+            style_condition_map.insert(*default, ());
         }
 
         if allow_addons {
-            default_condition_amp.insert(b"node-addons".as_slice().into(), ());
-            import_condition_map.insert(b"node-addons".as_slice().into(), ());
-            require_condition_map.insert(b"node-addons".as_slice().into(), ());
+            default_condition_amp.insert(b"node-addons".as_slice(), ());
+            import_condition_map.insert(b"node-addons".as_slice(), ());
+            require_condition_map.insert(b"node-addons".as_slice(), ());
 
             // style is not here because you don't import N-API addons inside css files.
         }
 
-        default_condition_amp.insert(b"default".as_slice().into(), ());
-        import_condition_map.insert(b"default".as_slice().into(), ());
-        require_condition_map.insert(b"default".as_slice().into(), ());
-        style_condition_map.insert(b"default".as_slice().into(), ());
+        default_condition_amp.insert(b"default".as_slice(), ());
+        import_condition_map.insert(b"default".as_slice(), ());
+        require_condition_map.insert(b"default".as_slice(), ());
+        style_condition_map.insert(b"default".as_slice(), ());
 
         Ok(ESMConditions {
             default: default_condition_amp,
@@ -895,19 +895,19 @@ impl ESMConditions {
 
         for condition in conditions {
             // PERF(port): was assume_capacity
-            self.default.insert((*condition).into(), ());
-            self.import.insert((*condition).into(), ());
-            self.require.insert((*condition).into(), ());
-            self.style.insert((*condition).into(), ());
+            self.default.insert(*condition, ());
+            self.import.insert(*condition, ());
+            self.require.insert(*condition, ());
+            self.style.insert(*condition, ());
         }
         Ok(())
     }
 
     pub fn append(&mut self, condition: &[u8]) -> Result<(), bun_alloc::AllocError> {
-        self.default.insert(condition.into(), ());
-        self.import.insert(condition.into(), ());
-        self.require.insert(condition.into(), ());
-        self.style.insert(condition.into(), ());
+        self.default.insert(condition, ());
+        self.import.insert(condition, ());
+        self.require.insert(condition, ());
+        self.style.insert(condition, ());
         Ok(())
     }
 }

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1954,7 +1954,7 @@ fn parse_data_loader<'a>(
         // SAFETY: outer match arm guarantees one of the five.
         _ => unsafe { core::hint::unreachable_unchecked() },
     };
-    let mut expr = bun_ast::Expr::from(value_expr);
+    let mut expr = value_expr;
 
     let mut symbols: Vec<bun_ast::Symbol> = Vec::new();
 
@@ -2139,7 +2139,7 @@ fn parse_data_loader<'a>(
         }
     };
     let mut ast = bun_ast::Ast::from_parts(parts, arena);
-    ast.symbols = bun_alloc::vec_from_iter_in(symbols.into_iter(), arena);
+    ast.symbols = bun_alloc::vec_from_iter_in(symbols, arena);
 
     return Some(ParseResult {
         ast,


### PR DESCRIPTION
Mechanical cleanup via `cargo clippy --fix -p bun_bundler` for these lints:

- `clippy::useless_conversion` — `.into()` / `From::from()` / `.into_iter()` to the same type (porting cruft from the Zig→Rust translation)
- `clippy::clone_on_copy` — `.clone()` on a `Copy` type
- `clippy::map_clone` — `.map(Into::into)` on the same type
- `clippy::redundant_slicing` — `&x[..]` where `x` is already a slice

60 hits across 8 files in `src/bundler/`. Compiler-verified zero behavior change (`cargo check -p bun_bin` clean).