### PR TITLE
js_parser: drop no-op .into()/.clone() on Copy (clippy cleanup, no alloc change)

### DIFF
--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -570,7 +570,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     return Some(p.new_expr(
                         E::Dot {
                             target,
-                            name: name_static.into(),
+                            name: name_static,
                             name_loc,
                             can_be_removed_if_unused: true,
                             ..Default::default()
@@ -733,7 +733,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 return Some(Expr::init(
                                     E::Dot {
                                         target: Expr::init_identifier(p.hmr_api_ref, target.loc),
-                                        name: name_static.into(),
+                                        name: name_static,
                                         name_loc,
                                         ..Default::default()
                                     },
@@ -813,7 +813,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         p.new_expr(
                             E::Dot {
                                 target: *target,
-                                name: name_static.into(),
+                                name: name_static,
                                 name_loc,
                                 ..Default::default()
                             },
@@ -823,7 +823,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         p.new_expr(
                             E::Dot {
                                 target: *target,
-                                name: name_static.into(),
+                                name: name_static,
                                 name_loc,
                                 ..Default::default()
                             },

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -729,7 +729,7 @@ pub mod defines_full_draft {
                 flags |= DefineDataFlags::METHOD_CALL_MUST_BE_REPLACED_WITH_UNDEFINED;
             }
             DefineData {
-                value: b.value.clone(),
+                value: b.value,
                 flags,
                 original_name: b.original_name.clone(),
             }

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -1948,7 +1948,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             cls_dec_args.push(p.new_expr(E::Number { value: 0.0 }, loc));
             cls_dec_args.push(p.new_expr(
                 E::EString {
-                    data: class_name_str.into(),
+                    data: class_name_str,
                     ..Default::default()
                 },
                 loc,

--- a/src/js_parser/parse/parse_suffix.rs
+++ b/src/js_parser/parse/parse_suffix.rs
@@ -253,7 +253,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     *left = p.new_expr(
                         E::Dot {
                             target,
-                            name: name.into(),
+                            name,
                             name_loc,
                             optional_chain: optional_start,
                             ..Default::default()
@@ -325,7 +325,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         *left = p.new_expr(
             E::Template {
                 tag: Some(tag),
-                head: E::TemplateContents::Raw(head.into()),
+                head: E::TemplateContents::Raw(head),
                 parts,
             },
             loc,

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -200,7 +200,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .add_range_error(
                     Some(self.source),
                     self.source.range_of_string(strict_loc.unwrap()),
-                    b"Cannot use a \"use strict\" directive in a function with a non-simple parameter list".as_slice().into(),
+                    b"Cannot use a \"use strict\" directive in a function with a non-simple parameter list".as_slice(),
                 );
         }
 


### PR DESCRIPTION
Mechanical clippy autofix for `bun_js_parser` (9 hits across 5 files):

- `clippy::useless_conversion` — `.into()` to the same type (`StoreStr` → `StoreStr`, `&[u8]` → `&[u8]`): 8 sites
- `clippy::clone_on_copy` — `.clone()` on `ExprData` (a `Copy` type): 1 site

Applied via `cargo clippy --fix -p bun_js_parser`. Compiler-verified zero behavior change; `cargo check -p bun_bin` clean.