### PR TITLE
jsc: borrow remaining_buf in ArgumentsSlice::init_async instead of cloning

### DIFF
--- a/src/jsc/CallFrame.rs
+++ b/src/jsc/CallFrame.rs
@@ -290,12 +290,12 @@ impl<'a> Iterator<'a> {
 ///
 /// Prefer `Iterator` for a simpler iterator.
 pub struct ArgumentsSlice<'a> {
-    /// Backing storage for the remaining-args view. Borrowed (`init`) or
-    /// heap-owned dupe (`init_async`) — Zig's `initAsync` does
-    /// `bun.default_allocator.dupe(jsc.JSValue, slice)` so the remaining slice
-    /// survives the original CallFrame stack slot being reused before async
-    /// work consumes the arguments. A borrowed `&'a [JSValue]` here would
-    /// dangle in that case.
+    /// Backing storage for the remaining-args view. Both [`Self::init`] and
+    /// [`Self::init_async`] borrow — `all: &'a [JSValue]` already ties this
+    /// struct's lifetime to the source slice, so the heap-owned dupe Zig's
+    /// `initAsync` does buys nothing here (it could not outlive `'a`). Kept as
+    /// `Cow` so a future caller that does own its args can pass `Owned`
+    /// without changing the type.
     remaining_buf: Cow<'a, [JSValue]>,
     /// Cursor into `remaining_buf`; advances on `eat()`. Replaces Zig's
     /// `remaining.ptr += 1` reslice (which a `Cow` can't express in-place).

--- a/src/jsc/CallFrame.rs
+++ b/src/jsc/CallFrame.rs
@@ -376,9 +376,11 @@ impl<'a> ArgumentsSlice<'a> {
 
     pub fn init_async(vm: &'a VirtualMachine, slice: &'a [JSValue]) -> ArgumentsSlice<'a> {
         // Spec (CallFrame.zig:258-265): `.remaining = bun.default_allocator.dupe(jsc.JSValue, slice)`.
+        // In the Rust port `all: &'a [JSValue]` already pins the struct lifetime to `slice`, so a
+        // heap-owned dupe of `remaining` cannot outlive `slice` anyway — borrow instead of copying.
         // `all` stays borrowed (matches Zig) so `protect_eat` index math holds.
         ArgumentsSlice {
-            remaining_buf: Cow::Owned(slice.to_vec()),
+            remaining_buf: Cow::Borrowed(slice),
             remaining_start: 0,
             vm,
             all: slice,


### PR DESCRIPTION
**Callsite:** `src/jsc/CallFrame.rs:381` — `Cow::Owned(slice.to_vec())` in `ArgumentsSlice::init_async`.

**Tracer:** 0 hits / 0 bytes (dead code). `git grep` confirms `init_async` has zero callers in Rust, C++, or codegen; the Zig original `initAsync` (CallFrame.zig:258) was also already dead pre-port.

**Why the borrow is safe:** `ArgumentsSlice<'a>` stores `all: &'a [JSValue]` borrowing the same input `slice`, so the struct lifetime is pinned to `'a` regardless of whether `remaining_buf` is owned or borrowed. The heap dupe cannot make the struct outlive `slice` — the borrow checker already forbids that. `Cow::Owned(slice.to_vec())` therefore bought nothing over `Cow::Borrowed(slice)`. `init_async` also sets `will_be_async: false` (same as `init`), so it was behaviorally identical to `init` modulo the wasted allocation. JSValue is an encoded i64 — no AtomString thread-table hazard, no GC hazard (values remain reachable via `all` for `'a`).

**Tests:** `cargo check -p bun_bin --keep-going` clean. `bun bd test test/js/bun/util/inspect.test.js` (heavy `ArgumentsSlice::init` user, same struct/field) — 72 pass / 0 fail.

No `unsafe`.

Follow-up (not in this PR): `init_async` is now byte-identical to `init`; could delete it and collapse `remaining_buf: Cow<'a, [JSValue]>` → `&'a [JSValue]`, dropping the `Cow` import and the stale doc comment at L293-298.