### PR TITLE
resolver: drop no-op .into()/.clone() on Copy (clippy cleanup, no alloc change)

### DIFF
--- a/src/resolver/fs/stat_hash.rs
+++ b/src/resolver/fs/stat_hash.rs
@@ -62,8 +62,8 @@ impl StatHash {
             let mtime_timespec = stat_mtime(stat);
             // Clamp negative values to 0 to avoid timestamp overflow issues on Windows
             let mtime = Timespec {
-                nsec: i64::try_from(mtime_timespec.nsec.max(0)).expect("int cast"),
-                sec: i64::try_from(mtime_timespec.sec.max(0)).expect("int cast"),
+                nsec: mtime_timespec.nsec.max(0),
+                sec: mtime_timespec.sec.max(0),
             };
             if mtime.ms() > 0 {
                 self.last_modified_buffer_len = u8::try_from(

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4340,7 +4340,6 @@ impl<'a> Resolver<'a> {
                                 iterate: true,
                             },
                         )
-                        .map_err(Into::into)
                     };
                     #[cfg(windows)]
                     let open_req: core::result::Result<FD, bun_core::Error> = {

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -65,9 +65,7 @@ impl JsonCache {
         // PORT NOTE: reshaped for borrowck — Zig `defer temp_log.appendToMaybeRecycled(log, source) catch {}`
         // runs after the `func() catch null` body; here the append is hoisted past the match.
         let result = match func(source, &mut temp_log, bump) {
-            // Lift the T2 value-subset `bun_ast::Expr` into the full
-            // `bun_ast::Expr` (src/js_parser/ast/Expr.rs `From` impl).
-            Ok(expr) => Some(bun_ast::Expr::from(expr)),
+            Ok(expr) => Some(expr),
             Err(_) => None,
         };
         let _ = temp_log.append_to_maybe_recycled(log, source);


### PR DESCRIPTION
Mechanical clippy cleanup in `src/resolver/` — removes identity conversions left over from the Zig port.

Lints: `clippy::useless_conversion` (4 hits fixed). Compiler-verified zero behavior change.

- `resolver.rs`: drop `.map_err(Into::into)` where the error is already `bun_core::Error`
- `tsconfig_json.rs`: drop `bun_ast::Expr::from(expr)` where `expr` is already `bun_ast::Expr` (and the stale comment describing it)
- `fs/stat_hash.rs`: drop `i64::try_from(..).expect()` on `Timespec` fields that are already `i64` on every platform

Left in place: the two `u32::try_from(stat.st_mode)` calls in `stat_hash.rs`. Clippy flags them on Linux where `st_mode` is `u32`, but `libc::stat::st_mode` is `u16` on macOS and `uv_stat_t::st_mode` is `u64` on Windows, so the conversion is load-bearing cross-platform.

Verified: `cargo check -p bun_bin` clean.