### PR TITLE
install: drop no-op .into()/.clone() on Copy (clippy cleanup, no alloc change)

### DIFF
--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -833,7 +833,7 @@ pub fn setup_global_dir(manager: &mut PackageManager, ctx: &Command::Context) ->
         .append(result.as_bytes_with_nul())?;
     // SAFETY: `path` includes the trailing NUL (we appended `as_bytes_with_nul`)
     // and lives for program lifetime in the dirname store.
-    manager.options.bin_path = ZStr::from_slice_with_nul(&path[..]);
+    manager.options.bin_path = ZStr::from_slice_with_nul(path);
     Ok(())
 }
 

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -262,7 +262,7 @@ impl PackageManager {
                     Err(err) => {
                         Output::debug(format_args!(
                             "error getting path for cached npm path: {}",
-                            bun_core::Error::from(err).name()
+                            err.name()
                         ));
                         return None;
                     }

--- a/src/install/PackageManager/security_scanner.rs
+++ b/src/install/PackageManager/security_scanner.rs
@@ -228,7 +228,7 @@ pub fn perform_security_scan_after_resolution(
     command_ctx: CommandContext,
     original_cwd: &[u8],
 ) -> Result<Option<SecurityScanResults>, Error> {
-    let Some(security_scanner) = manager.options.security_scanner.clone() else {
+    let Some(security_scanner) = manager.options.security_scanner else {
         return Ok(None);
     };
 
@@ -289,7 +289,7 @@ pub fn perform_security_scan_for_all(
     command_ctx: CommandContext,
     original_cwd: &[u8],
 ) -> Result<Option<SecurityScanResults>, Error> {
-    let Some(security_scanner) = manager.options.security_scanner.clone() else {
+    let Some(security_scanner) = manager.options.security_scanner else {
         return Ok(None);
     };
 

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -172,7 +172,7 @@ fn update_package_json_and_install_with_manager_with_updates(
     // is taken across this borrow; `PackageJSONEditor` and `do_patch_commit` touch only
     // disjoint manager fields.
     let current_package_json: &mut MapEntry = unsafe { &mut *current_package_json_ptr };
-    let mut current_package_json_root: bun_ast::Expr = current_package_json.root.into();
+    let mut current_package_json_root: bun_ast::Expr = current_package_json.root;
     let current_package_json_indent = current_package_json.indentation;
 
     // If there originally was a newline at the end of their package.json, preserve it
@@ -489,7 +489,7 @@ fn update_package_json_and_install_with_manager_with_updates(
         if let Some(stuff) = &not_in_workspace_root {
             // PORT NOTE (layering): see `current_package_json_root` above — promote
             // T2 → T4 for `PackageJSONEditor` / `print_json`.
-            let mut root_package_json_root: bun_ast::Expr = root_package_json.root.into();
+            let mut root_package_json_root: bun_ast::Expr = root_package_json.root;
             PackageJSONEditor::edit_patched_dependencies(
                 manager,
                 &mut root_package_json_root,
@@ -563,7 +563,7 @@ fn update_package_json_and_install_with_manager_with_updates(
         let json_arena = bun_alloc::Arena::new();
         let mut new_package_json: bun_ast::Expr =
             match json::parse_package_json_utf8(&source, manager.log_mut(), &json_arena) {
-                Ok(v) => v.into(),
+                Ok(v) => v,
                 Err(err) => {
                     Output::pretty_errorln(format_args!(
                         "package.json failed to parse due to error {}",

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -419,9 +419,10 @@ fn update_package_json_and_install_with_manager_with_updates(
     // must store an *owning* copy to avoid a dangling borrow. PERF(port): one extra
     // alloc+copy vs Zig's single dupe — profile if hot.
     current_package_json.source.contents = Cow::Owned(new_package_json_source.clone());
-    // Re-parse the printed source so the cached AST (consumed by `FolderResolver`
-    // for workspace members during `install_with_manager`) reflects the new
-    // dependency list.
+    // PORT NOTE: Zig edited `current_package_json.root` in place above; the Rust
+    // port edited a promoted copy (`current_package_json_root`), so re-parse the
+    // printed source so the cached AST (consumed by `FolderResolver` for workspace
+    // members during `install_with_manager`) reflects the new dependency list.
     if let Err(err) = current_package_json.reparse_root(manager.log_mut()) {
         Output::pretty_errorln(format_args!(
             "package.json failed to parse due to error {}",

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -487,8 +487,6 @@ fn update_package_json_and_install_with_manager_with_updates(
         let root_package_json: &mut MapEntry = unsafe { &mut *root_package_json_ptr };
 
         if let Some(stuff) = &not_in_workspace_root {
-            // PORT NOTE (layering): see `current_package_json_root` above — promote
-            // T2 → T4 for `PackageJSONEditor` / `print_json`.
             let mut root_package_json_root: bun_ast::Expr = root_package_json.root;
             PackageJSONEditor::edit_patched_dependencies(
                 manager,

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -419,10 +419,9 @@ fn update_package_json_and_install_with_manager_with_updates(
     // must store an *owning* copy to avoid a dangling borrow. PERF(port): one extra
     // alloc+copy vs Zig's single dupe — profile if hot.
     current_package_json.source.contents = Cow::Owned(new_package_json_source.clone());
-    // PORT NOTE: Zig edited `current_package_json.root` in place above; we edited a
-    // promoted T4 copy (`current_package_json_root`). Re-parse the printed source so
-    // the cached T2 AST (consumed by `FolderResolver` for workspace members during
-    // `install_with_manager`) reflects the new dependency list.
+    // Re-parse the printed source so the cached AST (consumed by `FolderResolver`
+    // for workspace members during `install_with_manager`) reflects the new
+    // dependency list.
     if let Err(err) = current_package_json.reparse_root(manager.log_mut()) {
         Output::pretty_errorln(format_args!(
             "package.json failed to parse due to error {}",

--- a/src/install/auto_installer.rs
+++ b/src/install/auto_installer.rs
@@ -184,7 +184,6 @@ impl hooks::AutoInstaller for PackageManager {
         self.lockfile
             .buffers
             .legacy_package_to_dependency_id(None, package_id)
-            .map_err(Into::into)
     }
 
     fn lockfile_str<'a>(&'a self, s: &'a SemverString) -> &'a [u8] {

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -317,7 +317,7 @@ pub fn install_isolated_packages(
                 let pkg_id: PackageID = u32::try_from(pkg_idx).expect("int cast");
                 let deps = pkg_dependency_slices[pkg_id as usize];
                 for _dep_id in deps.begin()..deps.end() {
-                    let dep_id: DependencyID = u32::try_from(_dep_id).expect("int cast");
+                    let dep_id: DependencyID = _dep_id;
                     let dep = &dependencies[dep_id as usize];
                     let Some(bit) = peer_name_idx.get_index(&dep.name_hash) else {
                         continue;
@@ -350,7 +350,7 @@ pub fn install_isolated_packages(
                     scratch.copy_into(&own_peers.at(pkg_id as usize));
 
                     for _dep_id in deps.begin()..deps.end() {
-                        let dep_id: DependencyID = u32::try_from(_dep_id).expect("int cast");
+                        let dep_id: DependencyID = _dep_id;
                         let dep = &dependencies[dep_id as usize];
                         if dep.behavior.is_peer() {
                             if let Some(bit) = peer_name_idx.get_index(&dep.name_hash) {
@@ -383,7 +383,7 @@ pub fn install_isolated_packages(
 
         let mut root_declares_workspace = DynamicBitSet::init_empty(lockfile.packages.len())?;
         for _dep_idx in pkg_dependency_slices[0].begin()..pkg_dependency_slices[0].end() {
-            let dep_idx: DependencyID = u32::try_from(_dep_idx).expect("int cast");
+            let dep_idx: DependencyID = _dep_idx;
             if !dependencies[dep_idx as usize].behavior.is_workspace() {
                 continue;
             }
@@ -670,7 +670,7 @@ pub fn install_isolated_packages(
             dep_ids_sort_buf.clear();
             dep_ids_sort_buf.reserve(pkg_deps.len as usize);
             for _dep_id in pkg_deps.begin()..pkg_deps.end() {
-                let dep_id: DependencyID = u32::try_from(_dep_id).expect("int cast");
+                let dep_id: DependencyID = _dep_id;
                 dep_ids_sort_buf.push(dep_id);
                 // PERF(port): was appendAssumeCapacity — profile if hot.
             }
@@ -2089,7 +2089,7 @@ pub fn install_isolated_packages(
                 .as_deref()
                 .map(|b: &[u8]| -> &bun_core::ZStr {
                     // SAFETY: `global_store_path` was built with a trailing NUL above.
-                    bun_core::ZStr::from_slice_with_nul(&b[..])
+                    bun_core::ZStr::from_slice_with_nul(b)
                 }),
             global_store_tmp_suffix: fast_random(),
             summary: Default::default(),

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -295,7 +295,7 @@ impl Stringifier {
                     Self::write_workspace_deps(
                         writer,
                         indent,
-                        u32::try_from(workspace_pkg_id).expect("int cast"),
+                        workspace_pkg_id,
                         // SAFETY: `workspace_sort_buf` only contains pkgs whose
                         // resolution `tag == Workspace`.
                         *res.workspace(),
@@ -621,7 +621,7 @@ impl Stringifier {
                     pkg_deps_sort_buf.clear();
                     pkg_deps_sort_buf.reserve(pkg_deps_list.len as usize);
                     for pkg_dep_id in pkg_deps_list.begin()..pkg_deps_list.end() {
-                        pkg_deps_sort_buf.push(u32::try_from(pkg_dep_id).expect("int cast"));
+                        pkg_deps_sort_buf.push(pkg_dep_id);
                         // PERF(port): was assume_capacity
                     }
 
@@ -2316,8 +2316,7 @@ pub fn parse_into_binary_lockfile(
                     for _workspace_pkg_id in
                         workspace_pkgs_off..workspace_pkgs_off + workspace_pkgs_len
                     {
-                        let workspace_pkg_id: PackageID =
-                            u32::try_from(_workspace_pkg_id).expect("int cast");
+                        let workspace_pkg_id: PackageID = _workspace_pkg_id;
                         if res.eql(
                             &pkg_resolutions[workspace_pkg_id as usize],
                             lockfile.buffers.string_bytes.as_slice(),
@@ -2593,7 +2592,7 @@ pub fn parse_into_binary_lockfile(
         {
             // first the root dependencies are resolved
             for _dep_id in pkg_deps[0].begin()..pkg_deps[0].end() {
-                let dep_id: DependencyID = u32::try_from(_dep_id).expect("int cast");
+                let dep_id: DependencyID = _dep_id;
                 let dep = &mut dependencies[dep_id as usize];
 
                 let Some(&res_id) = pkg_map.get(dep.name.slice(string_buf)) else {
@@ -2636,14 +2635,14 @@ pub fn parse_into_binary_lockfile(
         if lockfile_version != Version::V0 {
             // then workspace dependencies are resolved
             for _pkg_id in workspace_pkgs_off..workspace_pkgs_off + workspace_pkgs_len {
-                let pkg_id: PackageID = u32::try_from(_pkg_id).expect("int cast");
+                let pkg_id: PackageID = _pkg_id;
                 let workspace_name = pkg_names[pkg_id as usize].slice(string_buf);
 
                 seen_deps.clear_retaining_capacity();
 
                 let deps = pkg_deps[pkg_id as usize];
                 for _dep_id in deps.begin()..deps.end() {
-                    let dep_id: DependencyID = u32::try_from(_dep_id).expect("int cast");
+                    let dep_id: DependencyID = _dep_id;
                     let dep = &mut dependencies[dep_id as usize];
                     let dep_name = dep.name.slice(string_buf);
 
@@ -2731,7 +2730,7 @@ pub fn parse_into_binary_lockfile(
             // find resolutions. iterate up to root through the pkg path.
             let deps = pkg_deps[pkg_id as usize];
             'deps: for _dep_id in deps.begin()..deps.end() {
-                let dep_id: DependencyID = u32::try_from(_dep_id).expect("int cast");
+                let dep_id: DependencyID = _dep_id;
                 let dep = &mut dependencies[dep_id as usize];
 
                 let res_id =

--- a/src/install/migration.rs
+++ b/src/install/migration.rs
@@ -690,7 +690,7 @@ pub fn migrate_npm_lockfile<'a>(
                 }
 
                 let off = this.buffers.extern_strings.len() as u32;
-                let len = u32::try_from(bin_obj.properties.len_u32() * 2).expect("int cast");
+                let len = bin_obj.properties.len_u32() * 2;
 
                 for bin_entry in bin_obj.properties.slice() {
                     let key = bin_entry

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -390,15 +390,15 @@ pub mod registry {
                             // Bearer Token
                             if segment == b"_authToken" {
                                 registry.token = value.into();
-                                url.pathname = pathname.into();
-                                url.path = pathname.into();
+                                url.pathname = pathname;
+                                url.path = pathname;
                                 break 'outer;
                             }
 
                             if segment == b"_auth" {
                                 auth = value;
-                                url.pathname = pathname.into();
-                                url.path = pathname.into();
+                                url.pathname = pathname;
+                                url.path = pathname;
                                 break 'outer;
                             }
 
@@ -427,8 +427,8 @@ pub mod registry {
                                         registry.token = value.into();
                                         pathname = &pathname[..last_slash as usize + 1];
                                         needs_normalize = true;
-                                        url.pathname = pathname.into();
-                                        url.path = pathname.into();
+                                        url.pathname = pathname;
+                                        url.path = pathname;
                                         break 'outer;
                                     }
 
@@ -436,8 +436,8 @@ pub mod registry {
                                         auth = value;
                                         pathname = &pathname[..last_slash as usize + 1];
                                         needs_normalize = true;
-                                        url.pathname = pathname.into();
-                                        url.path = pathname.into();
+                                        url.pathname = pathname;
+                                        url.path = pathname;
                                         break 'outer;
                                     }
 
@@ -445,8 +445,8 @@ pub mod registry {
                                         registry.username = value.into();
                                         pathname = &pathname[..last_slash as usize + 1];
                                         needs_normalize = true;
-                                        url.pathname = pathname.into();
-                                        url.path = pathname.into();
+                                        url.pathname = pathname;
+                                        url.path = pathname;
                                         break 'outer;
                                     }
 
@@ -454,8 +454,8 @@ pub mod registry {
                                         registry.password = value.into();
                                         pathname = &pathname[..last_slash as usize + 1];
                                         needs_normalize = true;
-                                        url.pathname = pathname.into();
-                                        url.path = pathname.into();
+                                        url.pathname = pathname;
+                                        url.path = pathname;
                                         break 'outer;
                                     }
                                 }
@@ -464,8 +464,8 @@ pub mod registry {
 
                         // PORT NOTE: reshaped for borrowck — Zig's `defer { url.pathname = pathname; url.path = pathname; }`
                         // is applied at every `break 'outer` above and once more here at fallthrough.
-                        url.pathname = pathname.into();
-                        url.path = pathname.into();
+                        url.pathname = pathname;
+                        url.path = pathname;
                     }
 
                     registry.username = env.get_auto(&registry.username).into();

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -664,7 +664,7 @@ pub fn migrate_pnpm_lockfile<'a>(
 
             let deps = lockfile.packages.items_dependencies()[pkg_id as usize];
             'next_dep: for _dep_id in deps.begin()..deps.end() {
-                let dep_id: DependencyID = u32::try_from(_dep_id).expect("int cast");
+                let dep_id: DependencyID = _dep_id;
 
                 let dep = lockfile.buffers.dependencies[dep_id as usize].clone();
 
@@ -975,7 +975,7 @@ pub fn migrate_pnpm_lockfile<'a>(
         // resolve root dependencies first
         let root_deps = lockfile.packages.items_dependencies()[0];
         for _dep_id in root_deps.begin()..root_deps.end() {
-            let dep_id: DependencyID = u32::try_from(_dep_id).expect("int cast");
+            let dep_id: DependencyID = _dep_id;
             let dep = lockfile.buffers.dependencies[dep_id as usize].clone();
             let string_buf = string_bytes!(lockfile);
 
@@ -1052,7 +1052,7 @@ pub fn migrate_pnpm_lockfile<'a>(
 
         let deps = lockfile.packages.items_dependencies()[pkg_id as usize];
         for _dep_id in deps.begin()..deps.end() {
-            let dep_id: DependencyID = u32::try_from(_dep_id).expect("int cast");
+            let dep_id: DependencyID = _dep_id;
             let dep = lockfile.buffers.dependencies[dep_id as usize].clone();
             let string_buf = string_bytes!(lockfile);
             let dep_name = dep.name.slice(string_buf);
@@ -1109,7 +1109,7 @@ pub fn migrate_pnpm_lockfile<'a>(
 
         let deps = lockfile.packages.items_dependencies()[pkg_id as usize];
         for _dep_id in deps.begin()..deps.end() {
-            let dep_id: DependencyID = u32::try_from(_dep_id).expect("int cast");
+            let dep_id: DependencyID = _dep_id;
             let dep = lockfile.buffers.dependencies[dep_id as usize].clone();
             let string_buf = string_bytes!(lockfile);
             let mut version_maybe_alias = dep.version.literal.slice(string_buf);
@@ -2076,7 +2076,7 @@ fn update_package_json_after_migration(
 
         if bun_js_printer::print_json(
             &mut package_json_writer,
-            json.into(),
+            json,
             &root_pkg_json.source,
             bun_js_printer::PrintJsonOptions {
                 indent: root_pkg_json.indentation,

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -5,12 +5,6 @@ use std::io::Write as _;
 use bun_alloc::AllocError;
 use bun_collections::StringArrayHashMap;
 
-// LAYERING: every `Expr` flowing through this file (YAML parse, package.json
-// cache, `CatalogMap::from_pnpm_lockfile`) is the T2 value-shaped tree from
-// `bun_ast::js_ast`, NOT the T4 `bun_ast::Expr`. Importing the T4
-// type here forced a deep-convert at every boundary and broke type unification
-// with `WorkspacePackageJSONCache.root`. Use the lower crate directly; the
-// only T4 hop is the final `print_json` call, which lifts via `.into()`.
 use bun_ast::{self, self as js_ast, E, Expr, ExprData, G};
 use bun_core::strings;
 use bun_semver as semver;


### PR DESCRIPTION
Mechanical clippy cleanup for the `bun_install` crate — porting cruft from the Zig→Rust translation.

**Lints applied:** `clippy::useless_conversion`, `clippy::clone_on_copy`, `clippy::redundant_slicing`, `clippy::map_clone`

**40 hits fixed** across 10 files (of 47 flagged):
- `.into()` / `From::from()` to the same type → removed
- `.clone()` on `Copy` types (`Option<&[u8]>`) → removed
- `&x[..]` on a slice → `x`
- `u32::try_from(x).expect("int cast")` where `x` is already `u32` → `x` (the `TryFrom<T> for T` impl returns `Result<T, Infallible>`, so `.expect` is dead code)
- `.map_err(Into::into)` to the same error type → removed

**Intentionally skipped:** 3 `u32::try_from(st.st_mode)` sites in `isolated_install.rs` / `isolated_install/Installer.rs` — `mode_t` is `u16` on macOS so the conversion is load-bearing there. Also skipped 4 `redundant_clone` hits (different lint, separate PR).

Compiler-verified zero behavior change. `cargo check -p bun_bin` clean.