### PR TITLE
runtime: drop no-op .into()/.clone() on Copy (clippy cleanup, no alloc change)

### DIFF
--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1138,7 +1138,7 @@ pub mod js_bundler {
             if let Some(compile) = CompileOptions::from_js(
                 global_this,
                 config,
-                this.compile.as_ref().map(|c| c.compile_target.clone()),
+                this.compile.as_ref().map(|c| c.compile_target),
             )? {
                 this.compile = Some(compile);
             }

--- a/src/runtime/api/JSONCObject.rs
+++ b/src/runtime/api/JSONCObject.rs
@@ -28,11 +28,6 @@ pub fn parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
                 }
             };
 
-            // `ExprJsc::to_js` (bun_js_parser_jsc) drops the allocator param — Rust port
-            // threads the arena via the AST nodes themselves. `parse_ts_config` returns
-            // the cycle-broken `bun_ast::Expr`; lift it into the full
-            // `bun_ast::Expr` (From impl in ast/Expr.rs) so `ExprJsc` applies.
-            let parse_result: bun_ast::Expr = parse_result;
             match parse_result.to_js(global) {
                 Ok(v) => Ok(v),
                 Err(ToJSError::OutOfMemory) => Err(JsError::OutOfMemory),

--- a/src/runtime/api/JSONCObject.rs
+++ b/src/runtime/api/JSONCObject.rs
@@ -32,7 +32,7 @@ pub fn parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
             // threads the arena via the AST nodes themselves. `parse_ts_config` returns
             // the cycle-broken `bun_ast::Expr`; lift it into the full
             // `bun_ast::Expr` (From impl in ast/Expr.rs) so `ExprJsc` applies.
-            let parse_result: bun_ast::Expr = parse_result.into();
+            let parse_result: bun_ast::Expr = parse_result;
             match parse_result.to_js(global) {
                 Ok(v) => Ok(v),
                 Err(ToJSError::OutOfMemory) => Err(JsError::OutOfMemory),

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -809,8 +809,7 @@ impl<'a> TransformTask<'a> {
 
         let jsx = match self.tsconfig {
             Some(ts) => ts
-                .merge_jsx(self.transpiler.options.jsx.clone().into())
-                .into(),
+                .merge_jsx(self.transpiler.options.jsx.clone()),
             None => self.transpiler.options.jsx.clone(),
         };
 
@@ -1292,8 +1291,7 @@ impl JSTranspiler {
 
         let jsx = match config.tsconfig.as_deref() {
             Some(ts) => ts
-                .merge_jsx(self.transpiler.get().options.jsx.clone().into())
-                .into(),
+                .merge_jsx(self.transpiler.get().options.jsx.clone()),
             None => self.transpiler.get().options.jsx.clone(),
         };
 
@@ -1772,12 +1770,11 @@ impl JSTranspiler {
         let source = bun_ast::Source::init_path_string(loader.stdin_name(), code);
         let jsx = match self.config.get().tsconfig.as_deref() {
             Some(ts) => ts
-                .merge_jsx(self.transpiler.get().options.jsx.clone().into())
-                .into(),
+                .merge_jsx(self.transpiler.get().options.jsx.clone()),
             None => self.transpiler.get().options.jsx.clone(),
         };
 
-        let mut opts = bun_js_parser::ParserOptions::init(jsx.into(), loader);
+        let mut opts = bun_js_parser::ParserOptions::init(jsx, loader);
         // SAFETY: see `transpiler_mut`. The `&mut Transpiler` is reborrowed
         // disjointly for `macro_context` (stored in `opts`) and `options.define`
         // (raw-addr read) below; both end when `opts` is consumed by `scan()`.

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -808,8 +808,7 @@ impl<'a> TransformTask<'a> {
         // self.log.msgs.allocator = bun.default_allocator → no-op
 
         let jsx = match self.tsconfig {
-            Some(ts) => ts
-                .merge_jsx(self.transpiler.options.jsx.clone()),
+            Some(ts) => ts.merge_jsx(self.transpiler.options.jsx.clone()),
             None => self.transpiler.options.jsx.clone(),
         };
 
@@ -1290,8 +1289,7 @@ impl JSTranspiler {
             arena.alloc(bun_ast::Source::init_path_string(name, processed_code));
 
         let jsx = match config.tsconfig.as_deref() {
-            Some(ts) => ts
-                .merge_jsx(self.transpiler.get().options.jsx.clone()),
+            Some(ts) => ts.merge_jsx(self.transpiler.get().options.jsx.clone()),
             None => self.transpiler.get().options.jsx.clone(),
         };
 
@@ -1769,8 +1767,7 @@ impl JSTranspiler {
 
         let source = bun_ast::Source::init_path_string(loader.stdin_name(), code);
         let jsx = match self.config.get().tsconfig.as_deref() {
-            Some(ts) => ts
-                .merge_jsx(self.transpiler.get().options.jsx.clone()),
+            Some(ts) => ts.merge_jsx(self.transpiler.get().options.jsx.clone()),
             None => self.transpiler.get().options.jsx.clone(),
         };
 

--- a/src/runtime/api/MarkdownObject.rs
+++ b/src/runtime/api/MarkdownObject.rs
@@ -1250,7 +1250,7 @@ impl<'a> JsCallbackRenderer<'a> {
                 data: self.stack.last().unwrap().data,
                 flags: self.stack.last().unwrap().flags,
                 child_index: self.stack.last().unwrap().child_index,
-                detail: self.stack.last().unwrap().detail.clone(),
+                detail: self.stack.last().unwrap().detail,
             }
         } else {
             CallbackStackEntry::default()
@@ -1288,7 +1288,7 @@ impl<'a> JsCallbackRenderer<'a> {
 
         let callback = self.get_span_callback(span_type);
         let detail = if self.stack.len() > 1 {
-            self.stack.last().unwrap().detail.clone()
+            self.stack.last().unwrap().detail
         } else {
             md::SpanDetail::default()
         };

--- a/src/runtime/api/TOMLObject.rs
+++ b/src/runtime/api/TOMLObject.rs
@@ -32,7 +32,7 @@ pub fn parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
             // PORT NOTE: Zig passed `*js_printer.BufferPrinter` as a comptime type param; dropped per (comptime X: type, arg: X) rule
             if let Err(_) = js_printer::print_json(
                 &mut writer,
-                parse_result.into(),
+                parse_result,
                 source,
                 js_printer::PrintJsonOptions {
                     indent: Default::default(),

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -952,7 +952,7 @@ pub fn spawn_maybe_sync<const IS_SYNC: bool>(
                     }
                     break 'brk fd;
                 } else {
-                    break 'brk i32::try_from(ipc_channel + 3).expect("int cast");
+                    break 'brk ipc_channel + 3;
                 }
             };
 

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -82,7 +82,7 @@ fn eat_zig_string(iter: &mut ArgumentsSlice<'_>, global: &JSGlobalObject) -> JsR
     if value.is_undefined_or_null() {
         return Err(global.throw_invalid_arguments(format_args!("Expected string")));
     }
-    Ok(ZigString::from(value.get_zig_string(global)?))
+    Ok(value.get_zig_string(global)?)
 }
 
 /// `wrapInstanceMethod` arm for `jsc.JSValue` (required) — eat next arg or

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -883,8 +883,6 @@ pub fn init(options: Options) -> JsResult<Box<DevServer>> {
         let mut h = Wyhash::init(128);
 
         if cfg!(debug_assertions) {
-            // PORT NOTE: `sys::stat` returns `Maybe<Stat>` (no `unwrap_or_else`);
-            // go through `Result` for the panic-on-error path.
             let stat = match sys::stat(
                 bun_core::self_exe_path()
                     .unwrap_or_else(|e| Output::panic(format_args!("unhandled {}", e))),

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -885,10 +885,10 @@ pub fn init(options: Options) -> JsResult<Box<DevServer>> {
         if cfg!(debug_assertions) {
             // PORT NOTE: `sys::stat` returns `Maybe<Stat>` (no `unwrap_or_else`);
             // go through `Result` for the panic-on-error path.
-            let stat = match ::core::result::Result::from(sys::stat(
+            let stat = match sys::stat(
                 bun_core::self_exe_path()
                     .unwrap_or_else(|e| Output::panic(format_args!("unhandled {}", e))),
-            )) {
+            ) {
                 Ok(s) => s,
                 Err(e) => Output::panic(format_args!("unhandled {}", e)),
             };
@@ -4100,7 +4100,7 @@ pub fn finalize_bundle(
 
         chunk
             .entry_point
-            .set_entry_point_id(u32::try_from(route_bundle_index.get()).expect("int cast"));
+            .set_entry_point_id(route_bundle_index.get());
     }
 
     // Zig: `var gts = try dev.initGraphTraceState(...); ctx.gts = &gts;` — sized AFTER
@@ -5150,7 +5150,7 @@ impl DevServer {
             // Found a matching route, bundle it and handle the request
             match ensure_route_is_bundled(self, rbi, &mut ctx) {
                 Ok(()) => {}
-                Err(jsc::JsError::OutOfMemory) => return Err(bun_core::err!(OutOfMemory).into()),
+                Err(jsc::JsError::OutOfMemory) => return Err(bun_core::err!(OutOfMemory)),
                 Err(e @ (jsc::JsError::Thrown | jsc::JsError::Terminated)) => {
                     self.vm().global().report_active_exception_as_unhandled(e);
                 }
@@ -6233,7 +6233,7 @@ fn from_opaque_file_id<const SIDE: bake::Side>(
         debug_assert!(SIDE == safe.side());
         return incremental_graph::FileIndex::<SIDE>::init(safe.index());
     }
-    incremental_graph::FileIndex::<SIDE>::init(u32::try_from(id.get()).expect("int cast"))
+    incremental_graph::FileIndex::<SIDE>::init(id.get())
 }
 
 impl DevServer {

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -1013,7 +1013,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                     EdgeAttachmentMode::Css,
                 )?;
                 if result == EdgeAttachmentResult::Continue && src.is_valid() {
-                    queue.push(src.into());
+                    queue.push(src);
                 }
             }
         }

--- a/src/runtime/bake/dev_server/serialized_failure.rs
+++ b/src/runtime/bake/dev_server/serialized_failure.rs
@@ -260,7 +260,7 @@ fn write_log_data(data: &bun_ast::Data, w: &mut Writer) {
         }
         debug_assert!(loc.column >= 0); // zero based and not negative
 
-        _ = w.write_int_le::<i32>(i32::try_from(loc.line).expect("int cast"));
+        _ = w.write_int_le::<i32>(loc.line);
         _ = w.write_int_le::<u32>(u32::try_from(loc.column).expect("int cast"));
         _ = w.write_int_le::<u32>(u32::try_from(loc.length).expect("int cast"));
 

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -293,10 +293,7 @@ pub fn write_sourcemap_to_disk(
 
     let mut key = Vec::with_capacity(6 + without_prefix.len());
     write!(&mut key, "bake:/{}", BStr::new(without_prefix)).expect("infallible: in-memory write");
-    source_maps.put(
-        &key,
-        OutputFileIndex::init(source_map_index),
-    )?;
+    source_maps.put(&key, OutputFileIndex::init(source_map_index))?;
     Ok(())
 }
 

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -295,7 +295,7 @@ pub fn write_sourcemap_to_disk(
     write!(&mut key, "bake:/{}", BStr::new(without_prefix)).expect("infallible: in-memory write");
     source_maps.put(
         &key,
-        OutputFileIndex::init(u32::try_from(source_map_index).expect("int cast")),
+        OutputFileIndex::init(source_map_index),
     )?;
     Ok(())
 }
@@ -832,7 +832,7 @@ pub fn build_with_vm(
         };
         let any_client_chunks = bundled_outputs_list.iter().any(|file| {
             file.side == Some(bun_bundler::options::Side::Client)
-                && &file.src_path.text[..] != b"bun-framework-react/client.tsx"
+                && file.src_path.text != b"bun-framework-react/client.tsx"
         });
         if any_client_chunks {
             let runtime_file: &OutputFile = &bundled_outputs_list[runtime_file_index as usize];
@@ -1676,7 +1676,7 @@ impl PerThread {
             self.loaded_files.set(id.get() as usize);
             self.all_server_files.as_ref().unwrap().get().put_index(
                 global,
-                u32::try_from(id.get()).expect("int cast"),
+                id.get(),
                 self.module_keys[id.get() as usize].to_js(global)?,
             )?;
         }

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -602,11 +602,11 @@ impl BunxCommand {
         // BUT: Skip this transformation if --package was explicitly specified
         if opts.specified_package.is_none() {
             if update_request.name == b"tsc" {
-                update_request.name = b"typescript".as_slice().into();
+                update_request.name = b"typescript".as_slice();
             } else if update_request.name == b"claude" {
                 // The npm package "claude" is an unrelated squatter with no bin;
                 // `bunx claude` is much more likely to mean the actual CLI.
-                update_request.name = b"@anthropic-ai/claude-code".as_slice().into();
+                update_request.name = b"@anthropic-ai/claude-code".as_slice();
             }
         }
 
@@ -636,7 +636,7 @@ impl BunxCommand {
                 .slice(update_request.version_buf())
         } else if let Some(index) = strings::last_index_of_char(&update_request.name, b'/') {
             initial_bin_name_is_a_guess = true;
-            &update_request.name[usize::try_from(index + 1).expect("int cast")..]
+            &update_request.name[index + 1..]
         } else {
             &update_request.name
         };

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -942,7 +942,7 @@ impl CreateCommand {
                             > 0
                         {
                             has_dependencies = true;
-                            dev_dependencies = Some(q.expr.into());
+                            dev_dependencies = Some(q.expr);
 
                             // has_bun_framework_next = has_bun_framework_next or property.hasAnyPropertyNamed(&.{"bun-framework-next"});
                             // has_react = has_react or property.hasAnyPropertyNamed(&.{ "react", "react-dom", "react-relay", "@emotion/react" });
@@ -977,7 +977,7 @@ impl CreateCommand {
                             > 0
                         {
                             has_dependencies = true;
-                            dependencies = Some(q.expr.into());
+                            dependencies = Some(q.expr);
 
                             // if (property.asProperty("next")) |next_q| {
                             //     is_nextjs = true;
@@ -1454,7 +1454,7 @@ impl CreateCommand {
 
                 if let Err(err) = JSPrinter::print_json(
                     &mut package_json_writer,
-                    package_json_expr.into(),
+                    package_json_expr,
                     &source,
                     JSPrinter::PrintJsonOptions {
                         mangled_props: None,

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -842,7 +842,7 @@ pub fn run_scripts_with_filter(
             let interned: &'static [u8] = crate::cli::cli_dupe(&copy_script);
             let combined_len = interned.len() - 1;
             // SAFETY: interned[combined_len] == 0 (copied from `copy_script`).
-            let combined = ZStr::from_buf(&interned[..], combined_len);
+            let combined = ZStr::from_buf(interned, combined_len);
 
             let dep_source_buf = pkgjson.dependencies.source_buf;
             let deps: Vec<Box<[u8]>> = pkgjson

--- a/src/runtime/cli/init_command.rs
+++ b/src/runtime/cli/init_command.rs
@@ -482,11 +482,6 @@ impl InitCommand {
                     package_json_contents.list.as_slice(),
                 );
                 let mut log = bun_ast::Log::init();
-                // PORT NOTE: bun_parsers::json builds the T2
-                // (bun_ast::js_ast) value tree to avoid a T2->T4 dep
-                // cycle; lift to the full T4 (bun_js_parser) tree here so
-                // the rest of exec can use E::Object::{put,put_string,
-                // get_or_put_object,...} which only exist at T4.
                 let package_json_expr: bun_ast::Expr =
                     match json::parse_package_json_utf8(&source, &mut log, &bump) {
                         Ok(e) => e,

--- a/src/runtime/cli/init_command.rs
+++ b/src/runtime/cli/init_command.rs
@@ -489,7 +489,7 @@ impl InitCommand {
                 // get_or_put_object,...} which only exist at T4.
                 let package_json_expr: bun_ast::Expr =
                     match json::parse_package_json_utf8(&source, &mut log, &bump) {
-                        Ok(e) => bun_ast::Expr::from(e),
+                        Ok(e) => e,
                         Err(_) => {
                             package_json_file = None;
                             break 'process_package_json;

--- a/src/runtime/cli/install_completions_command.rs
+++ b/src/runtime/cli/install_completions_command.rs
@@ -663,12 +663,7 @@ impl InstallCompletionsCommand {
                 let input_size = end_pos.max(64 * 1024);
 
                 // defer dot_zshrc.close() — handled by Drop
-                let mut buf: Vec<u8> = vec![
-                    0u8;
-                    input_size
-                        + completions_path.len() * 4
-                        + 96
-                ];
+                let mut buf: Vec<u8> = vec![0u8; input_size + completions_path.len() * 4 + 96];
 
                 let Ok(read) = dot_zshrc.pread_all(&mut buf, 0) else {
                     break 'brk true;

--- a/src/runtime/cli/install_completions_command.rs
+++ b/src/runtime/cli/install_completions_command.rs
@@ -665,7 +665,7 @@ impl InstallCompletionsCommand {
                 // defer dot_zshrc.close() — handled by Drop
                 let mut buf: Vec<u8> = vec![
                     0u8;
-                    usize::try_from(input_size).expect("int cast")
+                    input_size
                         + completions_path.len() * 4
                         + 96
                 ];

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -2923,11 +2923,8 @@ pub fn pack<const FOR_PUBLISH: bool>(
     };
 
     let normalized_pkg_info: Option<Box<[u8]>> = if FOR_PUBLISH {
-        // `normalized_package` operates on the full T4 `bun_ast::Expr`
-        // (it injects new properties before printing); lift the T2 value-subset
-        // root via the `From` impl. The mutated tree is consumed inside
-        // `normalized_package` (it prints the JSON itself), so the lifted copy
-        // doesn't need to flow back into `json.root`.
+        // The mutated tree is consumed inside `normalized_package` (it prints
+        // the JSON itself), so the copy doesn't need to flow back into `json.root`.
         let mut root_full = json.root;
         Some(Publish::PublishCommand::normalized_package(
             manager,
@@ -3564,8 +3561,6 @@ fn edit_root_package_json(
 
     let written = match js_printer::print_json(
         &mut package_json_writer,
-        // `print_json` is monomorphized over the full T4 `Expr`; lift the T2
-        // value-subset root (lossless — every T2 variant maps 1:1).
         json.root,
         // shouldn't be used
         &json.source,

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -2928,7 +2928,7 @@ pub fn pack<const FOR_PUBLISH: bool>(
         // root via the `From` impl. The mutated tree is consumed inside
         // `normalized_package` (it prints the JSON itself), so the lifted copy
         // doesn't need to flow back into `json.root`.
-        let mut root_full = bun_ast::Expr::from(json.root);
+        let mut root_full = json.root;
         Some(Publish::PublishCommand::normalized_package(
             manager,
             &package_name,
@@ -3297,7 +3297,7 @@ fn add_archive_entry(
     if is_package_bin(bins, filename.as_bytes()) {
         perm |= 0o111;
     }
-    entry.set_perm(u32::try_from(perm).expect("int cast"));
+    entry.set_perm(perm);
 
     // '1985-10-26T08:15:00.000Z'
     // https://github.com/npm/cli/blob/ec105f400281a5bfd17885de1ea3d54d0c231b27/node_modules/pacote/lib/util/tar-create-options.js#L28
@@ -3566,7 +3566,7 @@ fn edit_root_package_json(
         &mut package_json_writer,
         // `print_json` is monomorphized over the full T4 `Expr`; lift the T2
         // value-subset root (lossless — every T2 variant maps 1:1).
-        bun_ast::Expr::from(json.root),
+        json.root,
         // shouldn't be used
         &json.source,
         js_printer::PrintJsonOptions {

--- a/src/runtime/cli/pm_pkg_command.rs
+++ b/src/runtime/cli/pm_pkg_command.rs
@@ -178,7 +178,7 @@ impl PmPkgCommand {
         };
 
         Ok(PackageJson {
-            root: result.root.into(),
+            root: result.root,
             contents,
             source,
             indentation: result.indentation,
@@ -791,7 +791,7 @@ impl PmPkgCommand {
             if let Ok(json_expr) =
                 json::parse_package_json_utf8(&temp_source, &mut temp_log, dummy_bump())
             {
-                return Ok(json_expr.into());
+                return Ok(json_expr);
             } else {
                 let data: &[u8] = dummy_bump().alloc_slice_copy(value);
                 return Ok(Expr::init(E::String::init(data), Loc::EMPTY));

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -568,7 +568,7 @@ impl TrustCommand {
             unsafe { ctx.log_mut() },
             &bump,
         ) {
-            Ok(v) => v.into(),
+            Ok(v) => v,
             Err(err) => {
                 let _ = ctx
                     .log_ref()

--- a/src/runtime/cli/pm_version_command.rs
+++ b/src/runtime/cli/pm_version_command.rs
@@ -209,7 +209,7 @@ impl PmVersionCommand {
 
             if let Err(err) = JSPrinter::print_json(
                 &mut package_json_writer,
-                bun_ast::Expr::from(json),
+                json,
                 &package_json_source,
                 JSPrinter::PrintJsonOptions {
                     indent: printer_indent,

--- a/src/runtime/cli/pm_view_command.rs
+++ b/src/runtime/cli/pm_view_command.rs
@@ -61,7 +61,6 @@ pub fn view(
                 let Ok(pkg_json) = JSON::parse::<false>(source, &mut pkg_log, &bump) else {
                     break 'from_package_json;
                 };
-                let pkg_json: ast::Expr = pkg_json;
                 if let Some(name) = pkg_json.get_string_cloned(&bump, b"name").ok().flatten() {
                     if !name.is_empty() {
                         break 'brk name;

--- a/src/runtime/cli/pm_view_command.rs
+++ b/src/runtime/cli/pm_view_command.rs
@@ -61,7 +61,7 @@ pub fn view(
                 let Ok(pkg_json) = JSON::parse::<false>(source, &mut pkg_log, &bump) else {
                     break 'from_package_json;
                 };
-                let pkg_json: ast::Expr = pkg_json.into();
+                let pkg_json: ast::Expr = pkg_json;
                 if let Some(name) = pkg_json.get_string_cloned(&bump, b"name").ok().flatten() {
                     if !name.is_empty() {
                         break 'brk name;
@@ -152,7 +152,7 @@ pub fn view(
     let mut log = bun_ast::Log::init();
     let source = &bun_ast::Source::init_path_string(b"view.json", response_buf.list.as_slice());
     let json: ast::Expr = match JSON::parse_utf8(source, &mut log, &bump) {
-        Ok(j) => j.into(),
+        Ok(j) => j,
         Err(err) => {
             Output::err(err, "failed to parse response body as JSON", ());
             Global::crash();

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -411,7 +411,7 @@ impl<'a, const DIRECTORY_PUBLISH: bool> Context<'a, DIRECTORY_PUBLISH> {
         // `WorkspacePackageJSONCache::get_with_path` applies before stashing
         // `MapEntry.root`. The thread-local `data::Store` has already been
         // initialised by `PackageManager::init`.
-        let mut json: Expr = Expr::from(json);
+        let mut json: Expr = json;
         let normalized_pkg_info = PublishCommand::normalized_package(
             manager,
             &package_name,
@@ -1855,7 +1855,7 @@ impl PublishCommand {
                             // Dupe into the process-lifetime CLI arena (bytes flow into long-lived `E::String` nodes).
                             let interned: &'static [u8] = crate::cli::cli_dupe(&join);
                             // SAFETY: NUL terminator at interned[join_len] (copied from `join`).
-                            let join_z = ZStr::from_buf(&interned[..], join_len);
+                            let join_z = ZStr::from_buf(interned, join_len);
                             let name_slice_start = join_len - name.len();
                             // SAFETY: name is the trailing segment of `interned`, NUL-terminated
                             let name_z = unsafe {

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -404,14 +404,7 @@ impl<'a, const DIRECTORY_PUBLISH: bool> Context<'a, DIRECTORY_PUBLISH> {
         sha512.r#final(&mut integrity);
         drop(sha512);
 
-        // `json_mod::parse_package_json_utf8` returns the value-shaped
-        // `bun_ast::Expr`; `normalized_package` (and `print_json`)
-        // operate on the full parser-shaped `bun_ast::Expr`. Lift via the
-        // documented `From<bun_ast::Expr>` bridge — same conversion
-        // `WorkspacePackageJSONCache::get_with_path` applies before stashing
-        // `MapEntry.root`. The thread-local `data::Store` has already been
-        // initialised by `PackageManager::init`.
-        let mut json: Expr = json;
+        let mut json = json;
         let normalized_pkg_info = PublishCommand::normalized_package(
             manager,
             &package_name,

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -1784,7 +1784,7 @@ impl<'a> Repl<'a> {
 
         // Set up parser options with repl_mode enabled
         let mut opts = bun_js_parser::ParserOptions::init(
-            vm.transpiler.options.jsx.clone().into(),
+            vm.transpiler.options.jsx.clone(),
             bun_ast::Loader::Tsx,
         );
         opts.repl_mode = true;

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1207,13 +1207,11 @@ impl CommandLineReporter {
                     let needed_name =
                         unsafe { (*needed_scope).base.name.as_deref() }.unwrap_or(b"");
                     if !strings::eql(&suite_info.name, needed_name) {
-                        suites_to_close = current_suite_depth
-                            - u32::try_from(suite_index).unwrap();
+                        suites_to_close = current_suite_depth - u32::try_from(suite_index).unwrap();
                         break;
                     }
                 } else {
-                    suites_to_close = current_suite_depth
-                        - u32::try_from(suite_index).unwrap();
+                    suites_to_close = current_suite_depth - u32::try_from(suite_index).unwrap();
                     break;
                 }
                 suite_index += 1;

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1207,12 +1207,12 @@ impl CommandLineReporter {
                     let needed_name =
                         unsafe { (*needed_scope).base.name.as_deref() }.unwrap_or(b"");
                     if !strings::eql(&suite_info.name, needed_name) {
-                        suites_to_close = u32::try_from(current_suite_depth).unwrap()
+                        suites_to_close = current_suite_depth
                             - u32::try_from(suite_index).unwrap();
                         break;
                     }
                 } else {
-                    suites_to_close = u32::try_from(current_suite_depth).unwrap()
+                    suites_to_close = current_suite_depth
                         - u32::try_from(suite_index).unwrap();
                     break;
                 }

--- a/src/runtime/cli/unlink_command.rs
+++ b/src/runtime/cli/unlink_command.rs
@@ -207,7 +207,7 @@ fn unlink(ctx: &mut ContextData) -> Result<(), bun_core::Error> {
                 // `package.bin` is the inline stub `bin::Bin` (struct `Value`);
                 // project to the real union-`Value` shape via the
                 // `From<bin::Bin> for bin_real::Bin` bridge in `bun_install::lib`.
-                bin: bin::Bin::from(package.bin),
+                bin: package.bin,
                 node_modules_path: &mut node_modules_path,
                 global_bin_path: manager.options.bin_path,
                 package_name: strings::StringOrTinyString::init(name),

--- a/src/runtime/cli/unlink_command.rs
+++ b/src/runtime/cli/unlink_command.rs
@@ -204,9 +204,6 @@ fn unlink(ctx: &mut ContextData) -> Result<(), bun_core::Error> {
             let mut bin_linker = bin::Linker {
                 target_node_modules_path: &raw const target_node_modules_path,
                 target_package_name: strings::StringOrTinyString::init(name),
-                // `package.bin` is the inline stub `bin::Bin` (struct `Value`);
-                // project to the real union-`Value` shape via the
-                // `From<bin::Bin> for bin_real::Bin` bridge in `bun_install::lib`.
                 bin: package.bin,
                 node_modules_path: &mut node_modules_path,
                 global_bin_path: manager.options.bin_path,

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -207,7 +207,7 @@ impl UpdateInteractiveCommand {
         // re-read — only `source.contents` is written back below.
         if let Err(err) = js_printer::print_json(
             &mut package_json_writer,
-            package_json.root.into(),
+            package_json.root,
             &package_json.source,
             PrintJsonOptions {
                 indent: package_json.indentation,

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -98,7 +98,8 @@ pub fn hostent_with_ttls_to_js_response(
             // so build a sockaddr_in/in6 on the stack and copy through that.
             let addr_string = {
                 // h_addrtype is c_short on Windows, c_int on POSIX; widen for the compare.
-                let address = if hostent.h_addrtype == c_ares::AF::INET6 {
+                #[allow(clippy::useless_conversion)]
+                let address = if i32::from(hostent.h_addrtype) == c_ares::AF::INET6 {
                     // SAFETY: addr points to ≥16 bytes for AF_INET6.
                     let bytes: [u8; 16] = unsafe { *(addr as *const [u8; 16]) };
                     let mut sa6: super::netc::sockaddr_in6 = bun_core::ffi::zeroed();

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -98,7 +98,7 @@ pub fn hostent_with_ttls_to_js_response(
             // so build a sockaddr_in/in6 on the stack and copy through that.
             let addr_string = {
                 // h_addrtype is c_short on Windows, c_int on POSIX; widen for the compare.
-                let address = if i32::from(hostent.h_addrtype) == c_ares::AF::INET6 {
+                let address = if hostent.h_addrtype == c_ares::AF::INET6 {
                     // SAFETY: addr points to ≥16 bytes for AF_INET6.
                     let bytes: [u8; 16] = unsafe { *(addr as *const [u8; 16]) };
                     let mut sa6: super::netc::sockaddr_in6 = bun_core::ffi::zeroed();

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4939,7 +4939,7 @@ unsafe fn resolve_hook(
             specifier_utf8.slice(),
             source_utf8.slice(),
             bun_core::err!("NameTooLong"),
-            import_kind.into(),
+            import_kind,
         );
         let msg = bun_ast::Msg {
             data: bun_ast::range_data(None, bun_ast::Range::NONE, printed),
@@ -5081,13 +5081,13 @@ unsafe fn resolve_hook(
                 specifier_utf8.slice(),
                 source_utf8.slice(),
                 err,
-                import_kind.into(),
+                import_kind,
             );
             bun_ast::Msg {
                 data: bun_ast::range_data(None, bun_ast::Range::NONE, printed.clone()),
                 metadata: bun_ast::Metadata::Resolve(bun_ast::MetadataResolve {
                     specifier: bun_ast::BabyString::r#in(&printed, specifier_utf8.slice()),
-                    import_kind: import_kind.into(),
+                    import_kind: import_kind,
                     err,
                 }),
                 ..Default::default()

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -5087,7 +5087,7 @@ unsafe fn resolve_hook(
                 data: bun_ast::range_data(None, bun_ast::Range::NONE, printed.clone()),
                 metadata: bun_ast::Metadata::Resolve(bun_ast::MetadataResolve {
                     specifier: bun_ast::BabyString::r#in(&printed, specifier_utf8.slice()),
-                    import_kind: import_kind,
+                    import_kind,
                     err,
                 }),
                 ..Default::default()

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -2965,7 +2965,7 @@ pub mod args {
                     ctx,
                     arguments.next().unwrap_or(JSValue::js_number(0.0)),
                     "len",
-                    Some(i64::from(i52::MIN)),
+                    Some(i52::MIN),
                     Some(BLOB_SIZE_MAX as i64),
                 )?
                 .max(0),

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1084,7 +1084,7 @@ impl PathLikeExt for PathLike {
         if !FORCE {
             if sliced[sliced.len() - 1] == 0 {
                 // SAFETY: last byte is NUL.
-                return ZStr::from_slice_with_nul(&sliced[..]);
+                return ZStr::from_slice_with_nul(sliced);
             }
         }
 

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1665,7 +1665,7 @@ where
         if topic_value.is_undefined_or_null() {
             return Err(global.throw_invalid_arguments(format_args!("Expected string")));
         }
-        let topic = ZigString::from(topic_value.get_zig_string(global)?);
+        let topic = topic_value.get_zig_string(global)?;
         // jsc.JSValue
         let message_value = iter
             .next_eat()

--- a/src/runtime/socket/WindowsNamedPipeContext.rs
+++ b/src/runtime/socket/WindowsNamedPipeContext.rs
@@ -430,7 +430,7 @@ impl WindowsNamedPipeContext {
         if path[path.len() - 1] == 0 {
             // is already null terminated
             // SAFETY: path[path.len()-1] == 0 checked above
-            let slice_z = ZStr::from_slice_with_nul(&path[..]);
+            let slice_z = ZStr::from_slice_with_nul(path);
             named_pipe.connect(slice_z, ssl_config, owned_ctx)?;
         } else {
             let mut path_buf = PathBuffer::uninit();

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -496,7 +496,7 @@ pub fn get_tls_finished_message(
         return Ok(JSValue::UNDEFINED);
     }
 
-    let buffer_size = usize::try_from(size).expect("int cast");
+    let buffer_size = size;
     let buffer = JSValue::create_buffer_from_length(global, buffer_size)?;
     let buffer_ptr = buffer.as_array_buffer(global).unwrap().ptr.cast::<c_void>();
 
@@ -684,7 +684,7 @@ pub fn get_tls_peer_finished_message(
         return Ok(JSValue::UNDEFINED);
     }
 
-    let buffer_size = usize::try_from(size).expect("int cast");
+    let buffer_size = size;
     let buffer = JSValue::create_buffer_from_length(global, buffer_size)?;
     let buffer_ptr = buffer.as_array_buffer(global).unwrap().ptr.cast::<c_void>();
 

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -492,12 +492,14 @@ impl<'a> Snapshots<'a> {
                     ils.line,
                     ils.col
                 );
+                // c_ulong is u32 on Windows (LLP64); widen explicitly.
+                #[allow(clippy::useless_conversion)]
                 let Some(byte_offset_add) = bun_ast::Source::line_col_to_byte_offset(
                     &file_text[last_byte..],
-                    last_line,
-                    last_col,
-                    ils.line,
-                    ils.col,
+                    u64::from(last_line),
+                    u64::from(last_col),
+                    u64::from(ils.line),
+                    u64::from(ils.col),
                 ) else {
                     bun_core::scoped_log!(inline_snapshot, "-> Could not find byte");
                     log.add_error_fmt(

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -217,7 +217,7 @@ impl<'a> Snapshots<'a> {
         // duration of the runner. Per `VirtualMachine::get` doc, callers form a short-lived borrow.
         let vm = VirtualMachine::get().as_mut();
         let opts = js_parser::ParserOptions::init(
-            vm.transpiler.options.jsx.clone().into(),
+            vm.transpiler.options.jsx.clone(),
             bun_ast::Loader::Js,
         );
         // PERF(port): Zig used `this.allocator` (default_allocator). Thread a per-call arena
@@ -494,10 +494,10 @@ impl<'a> Snapshots<'a> {
                 );
                 let Some(byte_offset_add) = bun_ast::Source::line_col_to_byte_offset(
                     &file_text[last_byte..],
-                    u64::from(last_line),
-                    u64::from(last_col),
-                    u64::from(ils.line),
-                    u64::from(ils.col),
+                    last_line,
+                    last_col,
+                    ils.line,
+                    ils.col,
                 ) else {
                     bun_core::scoped_log!(inline_snapshot, "-> Could not find byte");
                     log.add_error_fmt(
@@ -572,7 +572,7 @@ impl<'a> Snapshots<'a> {
                     // PORT NOTE: `ParserOptions` isn't `Clone`; rebuild per-iteration
                     // (Zig passed by value-copy).
                     let opts = js_parser::ParserOptions::init(
-                        vm.transpiler.options.jsx.clone().into(),
+                        vm.transpiler.options.jsx.clone(),
                         bun_ast::Loader::Js,
                     );
                     // PORT NOTE: `P::init` takes an out-param (Zig:

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -686,7 +686,7 @@ impl BlobExt for Blob {
         writer: &mut W,
     ) -> Result<(), bun_core::Error> {
         writer.write_int_le::<u8>(SERIALIZATION_VERSION)?;
-        writer.write_int_le::<u64>(u64::try_from(self.offset.get()).expect("int cast"))?;
+        writer.write_int_le::<u64>(self.offset.get())?;
 
         let ct = self.content_type_slice();
         writer.write_int_le::<u32>(ct.len() as u32)?;


### PR DESCRIPTION
Mechanical clippy cleanup in `src/runtime/` — porting cruft from the Zig→Rust rewrite where intermediate types changed and the conversion became identity.

**Lints applied** (all compiler-verified zero behavior change):
- `clippy::useless_conversion` — `.into()` / `T::from()` / `T::try_from()` to the same type
- `clippy::clone_on_copy` — `.clone()` on a `Copy` type
- `clippy::redundant_slicing` — `&x[..]` where `x` is already a slice

65 of the 70 in-scope hits fixed. The 5 remaining `useless_conversion` sites wrap libc `stat` fields / `pid` whose width differs across targets, so the `try_from` is only redundant on Linux — left those alone.

`cargo check -p bun_bin` clean.