### PR TITLE
css: derive Copy on 10 all-Copy-field value types (cleanup, no alloc change)

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -4240,7 +4240,7 @@ impl<'a> ParserInput<'a> {
 
 /// A capture of the internal state of a `Parser` (including the position
 /// within the input), obtained from the `Parser::position` method.
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct ParserState {
     pub position: usize,
     pub current_line_start_position: usize,

--- a/src/css/lib.rs
+++ b/src/css/lib.rs
@@ -391,7 +391,7 @@ pub struct Num {
     pub int_value: Option<i32>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct Dimension {
     pub num: Num,
     /// e.g. "px"

--- a/src/css/media_query.rs
+++ b/src/css/media_query.rs
@@ -168,8 +168,8 @@ pub enum Qualifier {
 }
 
 /// A [media type](https://drafts.csswg.org/mediaqueries/#media-types).
-// Clone: bitwise OK — `Custom` borrows arena-owned parser input (non-owning).
-#[derive(Debug, Clone)]
+// Copy: bitwise OK — `Custom` borrows arena-owned parser input (non-owning).
+#[derive(Debug, Copy, Clone)]
 pub enum MediaType {
     /// `all` (default).
     All,

--- a/src/css/properties/background.rs
+++ b/src/css/properties/background.rs
@@ -547,7 +547,7 @@ impl BackgroundClip {
 }
 
 /// A value for the [aspect-ratio](https://drafts.csswg.org/css-sizing-4/#aspect-ratio) property.
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct AspectRatio {
     /// The `auto` keyword.
     pub auto: bool,

--- a/src/css/properties/display.rs
+++ b/src/css/properties/display.rs
@@ -4,7 +4,7 @@ use crate as css;
 use crate::{Parser, PrintErr, Printer, VendorPrefix};
 
 /// A value for the [display](https://drafts.csswg.org/css-display-3/#the-display-properties) property.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Display {
     /// A display keyword.
     Keyword(DisplayKeyword),

--- a/src/css/properties/font.rs
+++ b/src/css/properties/font.rs
@@ -229,7 +229,7 @@ pub enum RelativeFontSize {
 }
 
 /// A value for the [font-stretch](https://www.w3.org/TR/css-fonts-4/#font-stretch-prop) property.
-#[derive(Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum FontStretch {
     /// A font stretch keyword.
     Keyword(FontStretchKeyword),

--- a/src/css/properties/position.rs
+++ b/src/css/properties/position.rs
@@ -5,7 +5,7 @@ use crate::{Parser, PrintErr, Printer, Token, VendorPrefix};
 use bun_core::strings;
 
 /// A value for the [position](https://www.w3.org/TR/css-position-3/#position-property) property.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Position {
     /// The box is laid in the document flow.
     Static,

--- a/src/css/properties/size.rs
+++ b/src/css/properties/size.rs
@@ -340,7 +340,7 @@ impl MaxSize {
 }
 
 /// A value for the [aspect-ratio](https://drafts.csswg.org/css-sizing-4/#aspect-ratio) property.
-#[derive(Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct AspectRatio {
     /// The `auto` keyword.
     pub auto: bool,

--- a/src/css/properties/transform.rs
+++ b/src/css/properties/transform.rs
@@ -773,7 +773,7 @@ impl Translate {
 }
 
 /// A value for the [rotate](https://drafts.csswg.org/css-transforms-2/#propdef-rotate) property.
-#[derive(Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct Rotate {
     /// Rotation around the x axis.
     pub x: f32,

--- a/src/css/values/gradient.rs
+++ b/src/css/values/gradient.rs
@@ -915,7 +915,7 @@ impl WebKitGradient {
 }
 
 /// The corner payload for [`LineDirection::Corner`].
-#[derive(Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct LineDirectionCorner {
     /// A horizontal position keyword, e.g. `left` or `right`.
     pub horizontal: HorizontalPositionKeyword,


### PR DESCRIPTION
Adds `Copy` to 10 CSS types whose fields are all already `Copy` and which have no `Drop` impl:

- `css_parser::ParserState` — `usize`, `u32`, `Option<BlockType>`
- `lib::Dimension` — `Num`, `&'static [u8]`
- `media_query::MediaType` — `*const [u8]`
- `properties::background::AspectRatio` — `bool`, `Option<Ratio>`
- `properties::display::Display` — `DisplayKeyword`, `DisplayPair`
- `properties::font::FontStretch` — `FontStretchKeyword`, `Percentage`
- `properties::position::Position` — `VendorPrefix`
- `properties::size::AspectRatio` — `bool`, `Option<Ratio>`
- `properties::transform::Rotate` — `f32` × 3, `Angle`
- `values::gradient::LineDirectionCorner` — `HorizontalPositionKeyword`, `VerticalPositionKeyword`

`cargo check -p bun_css` clean; clippy `clone_on_copy` reports no redundant clones to drop.

Not included from the candidate sweep: `CachedToken` (holds `Token`, not yet `Copy`) and `Scale` (holds `NumberOrPercentage`, not yet `Copy`).