### PR TITLE
install: move catalog_dep.version instead of cloning in enqueue override path

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -742,7 +742,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                             .catalogs
                             .get(&this.lockfile, *new.catalog(), name)
                     {
-                        let v = catalog_dep.version.clone();
+                        let v = catalog_dep.version;
                         (name, name_hash) = update_name_and_name_hash_from_version_replacement(
                             &this.lockfile,
                             name,


### PR DESCRIPTION
### What

`src/install/PackageManager/PackageManagerEnqueue.rs:745` — in the catalog-override branch of `enqueue_dependency_with_main_and_success_fn`, replace `catalog_dep.version.clone()` with a partial move of `catalog_dep.version`.

### Why this is safe

- `CatalogMap::get` (`src/install/lockfile/CatalogMap.rs:48`) returns `Option<Dependency>` **by value**, so `catalog_dep` is an owned local that is dropped at the end of the block. Only its `.version` field is read.
- `Dependency` (`src/install_types/resolver_hooks.rs:534`) has no `Drop` impl, so a partial move of one field is legal.
- `DependencyVersion::clone` deep-clones the boxed `NpmInfo` when `tag == Npm`, and its `Drop` frees it; clone-then-immediately-drop-original is pure alloc/free churn with no observable side effect.
- Matches the Zig sibling exactly (`src/install/PackageManager/PackageManagerEnqueue.zig:495-497`): `break :version catalog_dep.version` with no clone.
- No thread/JS/GC concerns: `DependencyVersion` holds only `SemverString` lockfile-buffer offsets (Copy) plus an optional arena `NpmInfo`; nothing crosses to JSC.

### Tracer

Clone tracer (claude/clone-tracer): 0 hits / 0 bytes — catalog-override path was not exercised in the traced workload, but the redundancy is compiler-proven (clippy `redundant_clone`).

### Tests

```
bun bd test test/cli/install/catalogs.test.ts
 6 pass
 0 fail
 3 snapshots, 101 expect() calls
```

`cargo check -p bun_bin --keep-going`: clean (warnings only, all pre-existing).

No `unsafe` added.

Note: an identical redundant clone exists at line 766 (the non-override catalog branch) — left for a sibling shard.