### PR TITLE
install: move catalog_dep.version instead of cloning in enqueue_dependency

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -763,7 +763,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                         .catalogs
                         .get(&this.lockfile, *dependency.version.catalog(), name)
                 {
-                    let v = catalog_dep.version.clone();
+                    let v = catalog_dep.version;
                     (name, name_hash) = update_name_and_name_hash_from_version_replacement(
                         &this.lockfile,
                         name,


### PR DESCRIPTION
Drops a redundant `.clone()` flagged by clippy `redundant_clone` at `src/install/PackageManager/PackageManagerEnqueue.rs:766`.

## Why this is safe

- `CatalogMap::get` (src/install/lockfile/CatalogMap.rs:48-69) returns `Option<Dependency>` **by value** — it already `.cloned()` out of the map internally, so `catalog_dep` is fully owned here.
- After line 766, `catalog_dep` is never read again; it just falls out of scope.
- `Dependency` (src/install_types/resolver_hooks.rs:534) has a custom `Clone` but **no `Drop`**, so a partial move of `catalog_dep.version` is legal.
- `DependencyVersion::clone` (resolver_hooks.rs:467) has no side effects. For `tag == Npm` it heap-allocates a `semver::query::Group` via `NpmInfo::clone`, which the matching `Drop` then immediately frees when `catalog_dep` goes out of scope — pure alloc/free churn.
- No cross-thread / WTFStringImpl / AtomString concerns: the strings inside `DependencyVersion` are `SemverString` (a `Copy` buffer-index handle), not refcounted JSC strings.

## Tracer

Runtime count: 0 / 0 bytes (catalog path was cold in the traced workload), but the lint is compiler-proven.

## Tests

```
bun bd test test/cli/install/catalogs.test.ts
 6 pass
 0 fail
 3 snapshots, 101 expect() calls
```

No `unsafe` added.

An identical redundant clone exists at line 745 (the `new.catalog()` branch); left for a separate shard to avoid merge conflicts.