### PR TITLE
bake: derive Copy on EncodedPattern/ServerComponents/ReactFastRefresh (cleanup, no alloc change)

### DIFF
--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -254,8 +254,8 @@ impl FrameworkRouter {
 
 /// Route patterns are serialized in a stable byte format so it can be treated
 /// as a string, while easily decodable as []Part.
-// Clone: bitwise OK — `data` borrows from `pattern_string_arena`; the arena owns it.
-#[derive(Clone)]
+// Copy: bitwise OK — `data` borrows from `pattern_string_arena`; the arena owns it.
+#[derive(Copy, Clone)]
 pub struct EncodedPattern {
     // ARENA: backed by `pattern_string_arena` (arena owns the bytes; outlives
     // every `EncodedPattern` — see `RawSlice` invariant in `bun_ptr`).

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -1367,7 +1367,7 @@ pub enum BuiltInModule {
     Code(&'static [u8]),
 }
 
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct ServerComponents {
     pub separate_ssr_graph: bool,
     pub server_runtime_import: &'static [u8],
@@ -1389,7 +1389,7 @@ impl Default for ServerComponents {
     }
 }
 
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct ReactFastRefresh {
     pub import_source: &'static [u8],
 }


### PR DESCRIPTION
Adds `Copy` to 3 bake types whose fields are all already `Copy` and which have no `Drop` impl:

- `FrameworkRouter::EncodedPattern` — `bun_ptr::RawSlice<u8>` (arena-borrowed)
- `bake_body::ServerComponents` — `bool`, `&'static [u8]` × 4
- `bake_body::ReactFastRefresh` — `&'static [u8]`

`cargo check -p bun_runtime` clean.

Not included: `FileSystemRouterType` holds `framework_router::Style`, whose `JavascriptDefined` arm carries a `jsc::Strong` with `Drop`, so it cannot be `Copy`.