### PR TITLE
test_runner: move RefDataValue instead of cloning at callTestCallback pending-promise path

### DIFF
--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1247,7 +1247,7 @@ impl BunTest {
                             // `dcb_ref_value.dupe()` — bump 1→2.
                             unsafe { bun_ptr::IntrusiveRc::init_ref(dcb_ref_value.as_ptr()) }
                         } else {
-                            Self::ref_(&this_strong, cfg_data.clone())
+                            Self::ref_(&this_strong, cfg_data)
                         };
                         // Track the `+1` handed to `Promise.then()` in case the promise never settles.
                         let raw_ref: *mut RefData = bun_ptr::IntrusiveRc::into_raw(this_ref);


### PR DESCRIPTION
Callsite: `src/runtime/test_runner/bun_test.rs:1250` (`callTestCallback`, `PromiseStatus::Pending` arm, no-done-callback `else` branch).

Tracer: 0 hits / 0 bytes (cold path — test callback returns a still-pending promise with no `done` arg). Hygiene only; flagged by clippy `redundant_clone`.

**Why moving is safe**
- `RefDataValue` is `#[derive(Clone)]` over `NonNull` / `usize` / `Option<EntryData>` (comment at :1420 confirms bitwise Clone, no side effects — not an Rc).
- The sibling `if let Some(dcb_ref_value)` branch does not touch `cfg_data`.
- After the `let this_ref = …;` binding, the `Pending` arm runs straight to `return None;` without reading `cfg_data` again, so the original was always dropped unused.
- borrowck accepts the move; no `unsafe`, no String/AtomString/thread-crossing involved.

**Tests** (`bun bd test`, debug build `1.4.0-debug+f816284bc`)
- `test/cli/test/bun-test.test.ts` — 70 pass, 6 todo, 0 fail
- `test/cli/test/test-timeout-behavior.test.ts` — 2 pass, 0 fail