### PR TITLE
shell_parser: derive Copy on SrcAscii/Script/CompoundAtom (cleanup, no alloc change)

### DIFF
--- a/src/shell_parser/braces.rs
+++ b/src/shell_parser/braces.rs
@@ -30,8 +30,8 @@ pub enum StringEncoding {
 
 // ─── SrcAscii ──────────────────────────────────────────────────────────────
 
-// Clone: bitwise OK — `bytes` borrows caller-owned input (BACKREF, non-owning).
-#[derive(Clone)]
+// Copy: bitwise OK — `bytes` borrows caller-owned input (BACKREF, non-owning).
+#[derive(Copy, Clone)]
 struct SrcAscii {
     bytes: *const [u8], // PORT NOTE: raw slice ptr — Zig held a borrowed `[]const u8`; lifetime erased (BACKREF).
     i: usize,

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -74,7 +74,7 @@ pub mod ast {
     // port uses `&'arena [T]` so the whole tree is `Clone`/`Copy`-able like
     // Zig — required by `Atom::merge` and `SmolList::init_with_slice`.
 
-    #[derive(Clone)]
+    #[derive(Copy, Clone)]
     pub struct Script<'arena> {
         pub stmts: &'arena [Stmt<'arena>],
     }
@@ -940,7 +940,7 @@ pub mod ast {
         }
     }
 
-    #[derive(Clone)]
+    #[derive(Copy, Clone)]
     pub struct CompoundAtom<'arena> {
         pub atoms: &'arena [SimpleAtom<'arena>],
         pub brace_expansion_hint: bool,


### PR DESCRIPTION
Adds `Copy` to 3 shell-parser types whose fields are all already `Copy` and which have no `Drop` impl:

- `braces::SrcAscii` — `*const [u8]`, `usize`
- `parse::Script<'arena>` — `&'arena [Stmt]`
- `parse::CompoundAtom<'arena>` — `&'arena [SimpleAtom]`, `bool`, `bool`

The doc comment above `Script` already notes the tree is meant to be `Copy`-able like the Zig original.

`cargo check -p bun_shell_parser` clean; clippy `clone_on_copy` reports no redundant clones to drop.