### PR TITLE
css: move ParserState into error closure instead of cloning

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -3265,10 +3265,9 @@ where
                 parse_qualified_rule(&start, self.input, self.parser, delimiters)
             } else {
                 let token = tok.clone();
-                let start_clone = start.clone();
                 self.input
                     .parse_until_after(Delimiters::SEMICOLON, move |_i| {
-                        Err(start_clone
+                        Err(start
                             .source_location()
                             .new_unexpected_token_error(token))
                     })

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -3267,9 +3267,7 @@ where
                 let token = tok.clone();
                 self.input
                     .parse_until_after(Delimiters::SEMICOLON, move |_i| {
-                        Err(start
-                            .source_location()
-                            .new_unexpected_token_error(token))
+                        Err(start.source_location().new_unexpected_token_error(token))
                     })
             };
 


### PR DESCRIPTION
## What

Removes a redundant `.clone()` of `ParserState` at `src/css/css_parser.rs:3268` (`RuleBodyIterator::next`, else-branch where `parse_qualified` is false).

## Why it's safe

- `start` is an **owned** `ParserState` returned by-value from `self.input.state()` at line 3205. It is a `#[derive(Clone)]` POD struct (`usize`/`u32`/`Option<BlockType>`, all `Copy`-eligible fields) with no heap allocations, refcounts, or side-effecting `Clone`.
- In the else-branch, `start` is not used after being captured by the `move` closure — the function returns `Some(result)` immediately. The if-branch only borrows `&start`, so moving in the else-branch is fine.
- Matches the Zig sibling (`css_parser.zig:3669`), which passes `start` directly into the closure struct without an extra copy.
- No `String`/`AtomString`/GC/thread involvement.

## Tracer

Flagged by `clippy::redundant_clone` via the clone-tracer sweep (count: 0 / 0 bytes — stack-only POD, not heap-allocating, but still a dead clone).

## Tests

- `cargo check -p bun_bin --keep-going`: clean (no new errors/warnings)
- `bun bd test test/js/bun/css/css.test.ts`: **1032 pass, 0 fail**
- `bun bd test test/js/bun/css/doesnt_crash.test.ts`: **60 pass, 0 fail**

No `unsafe` added.