### PR TITLE
jsc/RuntimeTranspilerCache: drop redundant output_code Box copy in put()

### DIFF
--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -1111,7 +1111,6 @@ bun_ast::link_impl_TranspilerCacheImpl! {
                 return;
             }
             debug_assert!(this.entry.is_none());
-            this.output_code = Some(Box::<[u8]>::from(output_code_bytes));
 
             let output_code = BunString::clone_latin1(output_code_bytes);
             let result = RuntimeTranspilerCache::to_file(

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -1184,14 +1184,11 @@ impl TranspilerJob {
         let source_code = 'brk: {
             let written = source_code_printer.ctx.get_written();
 
-            // PORT NOTE: lower-tier `cache.output_code` is `Option<Box<[u8]>>`
-            // (Zig `?bun.String`). `RuntimeTranspilerCacheExt::put()` stores
-            // the printer bytes there; convert to a WTF `bun.String` for JSC.
-            let result = cache
-                .output_code
-                .take()
-                .map(|b| String::clone_latin1(&b))
-                .unwrap_or_else(|| String::clone_latin1(written));
+            // The `Jsc` vtable bridge `put()` does not write
+            // `cache.output_code` (only the `r#impl == None` fallback does,
+            // and `r#impl` is `Some(Jsc)` here), so it is always `None`.
+            debug_assert!(cache.output_code.is_none());
+            let result = String::clone_latin1(written);
 
             // SAFETY: leaf scalar field read on `*vm`; see `vm` PORT NOTE above.
             if written.len() > 1024 * 1024 * 2 || unsafe { (*vm).smol } {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3042,15 +3042,12 @@ fn transpile_source_code_inner(
                 let printer: &mut bun_js_printer::BufferPrinter =
                     unsafe { &mut *(*extra).source_code_printer };
                 let written = printer.ctx.get_written();
-                // PORT NOTE: bundler-side `cache.output_code` is
-                // `Option<Box<[u8]>>` (T6's `bun.String` wrapper lives in
-                // `bun_jsc::RuntimeTranspilerCache`); clone into a fresh
-                // `bun.String` either way. Spec :573 hands the `bun.String`
-                // straight through.
-                let source_code = match cache.output_code.take() {
-                    Some(b) => bun_core::String::clone_latin1(&b),
-                    None => bun_core::String::clone_latin1(written),
-                };
+                // The `Jsc` vtable bridge `put()` does not write
+                // `cache.output_code` (only the `r#impl == None` fallback
+                // does, and `r#impl` is `Some(Jsc)` here), so it is always
+                // `None`.
+                debug_assert!(cache.output_code.is_none());
+                let source_code = bun_core::String::clone_latin1(written);
                 if written.len() > 1024 * 1024 * 2 || unsafe { &*jsc_vm }.smol {
                     // PERF(port): spec deinits the printer buffer; Rust drops on
                     // next `reset()`. TODO(port): expose `BufferWriter::deinit`.


### PR DESCRIPTION
Clone-tracer site: `Box::<[u8]>::from(output_code_bytes)` at `src/jsc/RuntimeTranspilerCache.rs:1114` (vtable bridge `put`).

Tracer count: 0 calls / 0 bytes on the bundler-perf workload (RuntimeTranspilerStore is bypassed there). This is a per-module-on-cache-miss source-sized allocation in the runtime path, not the bundler — a clean simplification rather than a measured win for that workload.

### What / why

`put()` is called from `js_printer/lib.rs:8138` with a borrow of the thread-local `BufferPrinter` output. The deleted line copied that borrow into a `Box<[u8]>` and stored it in the lower-tier `bun_ast::RuntimeTranspilerCache.output_code`.

The only two readers of that field — `src/jsc/RuntimeTranspilerStore.rs:1190-1194` and `src/runtime/jsc_hooks.rs:3050-3053` — both do:

```rust
cache.output_code.take()
    .map(|b| String::clone_latin1(&b))
    .unwrap_or_else(|| String::clone_latin1(written))
```

where `written = source_code_printer.ctx.get_written()` is the **same buffer** `output_code_bytes` borrowed. So storing the `Box` forces an extra full-source copy that the `None` fallback already produces byte-identically.

### Why the fallback is byte-identical

Between `put()` (lib.rs:8138) and the consumer's `get_written()`, only `source_map_handler.on_source_map_chunk` and `BufferWriter::done()` run. `done()` is a no-op here (`append_newline` defaults to `false` and neither caller sets it). The buffer-mutating handler `SourceMapHandlerGetter::on_source_map_chunk` (appends `//# sourceMappingURL=…`) is selected only when `vm.debugger.is_some()`, and whenever that holds `IS_DISABLED` is forced `true` (`jsc_hooks.rs:526-533`, mirroring `VirtualMachine.zig:1379-1383`), which short-circuits `put()` at line 1110 before the deleted code. The other handler, `SavedSourceMap::on_source_map_chunk`, does not touch the printer buffer.

### Zig parity

Zig (`RuntimeTranspilerCache.zig:699-700` + `RuntimeTranspilerStore.zig:592`) did one `bun.String.cloneLatin1` in `put()` and reused it via `cache.output_code orelse cloneLatin1(written)`. The Rust tier split to `Option<Box<[u8]>>` lost that reuse and turned it into copy→store→re-clone. With this change Rust takes Zig's `orelse` arm unconditionally on the JSC path: same byte-copy count as Zig, one fewer source-sized allocation than Rust before.

No `unsafe`. No cross-thread String hazard (`clone_latin1` builds a plain WTFStringImpl on the consumer thread, identical to what the `Some` arm already did).

### Tests

```
bun bd test test/cli/run/transpiler-cache.test.ts     # 9 pass / 0 fail
bun bd test test/regression/issue/28159.test.ts       # 1 pass / 0 fail
cargo check -p bun_bin                                # clean
```