### PR TITLE
runtime: derive Copy on DiffSegment/NPMClient (cleanup, no alloc change)

### DIFF
--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -1520,7 +1520,7 @@ impl CreateCommand {
 
         if npm_client_.is_some() && !preinstall_tasks.is_empty() {
             for task in &preinstall_tasks {
-                exec_task(task, destination, path_env, npm_client_.clone());
+                exec_task(task, destination, path_env, npm_client_);
             }
         }
 
@@ -1580,7 +1580,7 @@ impl CreateCommand {
 
         if !postinstall_tasks.is_empty() {
             for task in &postinstall_tasks {
-                exec_task(task, destination, path_env, npm_client_.clone());
+                exec_task(task, destination, path_env, npm_client_);
             }
         }
 

--- a/src/runtime/cli/which_npm_client.rs
+++ b/src/runtime/cli/which_npm_client.rs
@@ -1,4 +1,4 @@
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct NPMClient {
     // TODO(port): verify `bin` is always a static literal (no deinit in Zig source)
     pub bin: &'static [u8],

--- a/src/runtime/test_runner/diff/printDiff.rs
+++ b/src/runtime/test_runner/diff/printDiff.rs
@@ -170,7 +170,7 @@ pub fn print_diff_main(
                     });
                 }
             } else {
-                new_diff_segments.push(diff_segment.clone());
+                new_diff_segments.push(*diff_segment);
             }
         }
 
@@ -318,7 +318,7 @@ pub enum DiffSegmentMode {
 
 // TODO(port): lifetime — `removed`/`inserted` borrow from caller input and diff_match_patch output;
 // in Zig these were arena-backed slices. Revisit ownership.
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct DiffSegment<'a> {
     pub removed: &'a [u8],
     pub inserted: &'a [u8],


### PR DESCRIPTION
Adds `Copy` to 2 runtime types whose fields are all already `Copy` and which have no `Drop` impl:

- `test_runner::diff::DiffSegment<'a>` — `&'a [u8]` × 2, `DiffSegmentMode`, `usize` × 2, `bool`
- `cli::NPMClient` — `&'static [u8]`, `Tag`

`cargo check -p bun_runtime` clean.

Not included: `shell::IO::OutKind` — its `Fd` variant holds `Arc<IOWriter>`, which is not `Copy`.