### PR TITLE
server: drop host snapshot Vec in H3 request URL assembly

### DIFF
--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3216,20 +3216,23 @@ where
                 ))
             }));
             // PORT NOTE: `ReqLike::{url,header}` both borrow `&mut req`; the
-            // returned slices alias the same uWS-owned header buffer. Snapshot
-            // `host` into an owned buffer first so the second borrow for `url`
-            // is unconflicted.
-            let host: Option<Vec<u8>> = ReqLike::header(req, b"host").map(|h| h.to_vec());
+            // returned slices alias the same uWS-owned header buffer. Format
+            // the `https://{host}` prefix while `host` is borrowed so the
+            // second `&mut req` borrow for `url` is unconflicted.
+            let prefix: Option<Vec<u8>> = ReqLike::header(req, b"host").map(|host| {
+                let fmt = bun_fmt::HostFormatter {
+                    is_https: true,
+                    host,
+                    port: None,
+                };
+                let mut s = Vec::new();
+                write!(&mut s, "https://{}", fmt).ok();
+                s
+            });
             let path = ReqLike::url(req);
             if !path.is_empty() && path[0] == b'/' {
-                if let Some(host) = host.as_deref() {
-                    let fmt = bun_fmt::HostFormatter {
-                        is_https: true,
-                        host,
-                        port: None,
-                    };
-                    let mut s = Vec::new();
-                    write!(&mut s, "https://{}{}", fmt, BStr::new(path)).ok();
+                if let Some(mut s) = prefix {
+                    s.extend_from_slice(path);
                     request_object.url.set(BunString::clone_utf8(&s));
                 } else {
                     request_object.url.set(BunString::clone_utf8(path));


### PR DESCRIPTION
### What

`src/runtime/server/server_body.rs:3222` (H3 `on_request`): the borrowck workaround copied `req.header("host")` into a `Vec<u8>` so a second `&mut req` borrow for `req.url()` could happen, then formatted both into a *second* `Vec` for the full URL.

Now: write `https://{host}` into the format buffer while `host` is borrowed, drop the borrow, borrow `url()`, append. One `Vec` per request instead of two.

### Why this is safe

- Output is byte-identical for every `(host?, path)` combination — `write!(.., "https://{}{}", fmt, path)` == `write!(.., "https://{}", fmt)` then `extend_from_slice(path)`.
- The Zig sibling (`src/runtime/server/server.zig:2513-2523`) holds both slices simultaneously with no copy; this just narrows the gap.
- No lifetime hazard: the `host` borrow ends inside the `.map()` closure before `ReqLike::url(req)` re-borrows; `clone_utf8` copies into a fresh `WTFStringImpl` before the `Vec` drops. JS-thread-local, no GC interaction.
- No `unsafe` added.

### Tracer

Flagged by the runtime clone tracer as a `.to_vec()` borrowck workaround. Count 0 / 0 bytes in the trace (HTTP/3 not exercised), so kept the change minimal and local rather than relaxing `h3::Request::{url,header}` to `&self` (the deeper fix — `Http3Request::{getFullUrl,getHeader}` are pure reads — but cascades through `ReqLike` and both impls).

### Tests

`bun bd test test/js/bun/http/serve-http3.test.ts` — 45 pass / 0 fail (covers `req.url` over H3 incl. before/after-await stability).