### PR TITLE
Throw RangeError instead of crashing when `Bun.deepMatch` recurses too deep

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1626,6 +1626,10 @@ bool Bun__deepMatch(
     // fast path for reference equality.
     if (objValue == subsetValue) return true;
     VM& vm = globalObject->vm();
+    if (!vm.isSafeToRecurse()) [[unlikely]] {
+        throwStackOverflowError(globalObject, throwScope);
+        return false;
+    }
     JSObject* obj = objValue.getObject();
     JSObject* subsetObj = subsetValue.getObject();
 

--- a/test/js/bun/bun-object/deep-match-stack-overflow.test.ts
+++ b/test/js/bun/bun-object/deep-match-stack-overflow.test.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "bun:test";
+
+function makeDeep(depth: number) {
+  const root: Record<string, unknown> = {};
+  let p = root;
+  for (let i = 0; i < depth; i++) {
+    p.c = {};
+    p = p.c as Record<string, unknown>;
+  }
+  return root;
+}
+
+test("Bun.deepMatch throws RangeError on deeply nested objects instead of crashing", () => {
+  const a = makeDeep(100000);
+  const b = makeDeep(100000);
+  expect(() => Bun.deepMatch(a, b)).toThrow(RangeError);
+});
+
+test("expect().toMatchObject() throws RangeError on deeply nested objects instead of crashing", () => {
+  const a = makeDeep(100000);
+  const b = makeDeep(100000);
+  expect(() => expect(a).toMatchObject(b)).toThrow(RangeError);
+});

--- a/test/js/bun/bun-object/deep-match-stack-overflow.test.ts
+++ b/test/js/bun/bun-object/deep-match-stack-overflow.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 function makeDeep(depth: number) {
   const root: Record<string, unknown> = {};

--- a/test/js/bun/bun-object/deep-match.spec.ts
+++ b/test/js/bun/bun-object/deep-match.spec.ts
@@ -205,20 +205,6 @@ describe("Bun.deepMatch", () => {
     // expect(Bun.deepMatch(foo, baz)).toBe(false);
   });
 
-  it("throws a RangeError for deeply nested objects instead of crashing", () => {
-    const a: Record<string, unknown> = {};
-    const b: Record<string, unknown> = {};
-    let pa = a;
-    let pb = b;
-    for (let i = 0; i < 100000; i++) {
-      pa.c = {};
-      pa = pa.c as Record<string, unknown>;
-      pb.c = {};
-      pb = pb.c as Record<string, unknown>;
-    }
-    expect(() => Bun.deepMatch(a, b)).toThrow(RangeError);
-  });
-
   describe("Invalid arguments", () => {
     it.each<TestCase>([
       [null, null],

--- a/test/js/bun/bun-object/deep-match.spec.ts
+++ b/test/js/bun/bun-object/deep-match.spec.ts
@@ -205,6 +205,20 @@ describe("Bun.deepMatch", () => {
     // expect(Bun.deepMatch(foo, baz)).toBe(false);
   });
 
+  it("throws a RangeError for deeply nested objects instead of crashing", () => {
+    const a: Record<string, unknown> = {};
+    const b: Record<string, unknown> = {};
+    let pa = a;
+    let pb = b;
+    for (let i = 0; i < 100000; i++) {
+      pa.c = {};
+      pa = pa.c as Record<string, unknown>;
+      pb.c = {};
+      pb = pb.c as Record<string, unknown>;
+    }
+    expect(() => Bun.deepMatch(a, b)).toThrow(RangeError);
+  });
+
   describe("Invalid arguments", () => {
     it.each<TestCase>([
       [null, null],


### PR DESCRIPTION
`Bun__deepMatch` recurses natively for each nested object property. With sufficiently deeply nested (non-cyclic) objects, this overflows the native stack and segfaults.

`Bun__deepEquals` already guards against this with `vm.isSafeToRecurse()`; this adds the same guard to `Bun__deepMatch` so both `Bun.deepMatch()` and `expect().toMatchObject()` throw a `RangeError: Maximum call stack size exceeded` instead of crashing.

Repro:
```js
let a = {}, b = {}, pa = a, pb = b;
for (let i = 0; i < 50000; i++) {
  pa.c = {}; pa = pa.c;
  pb.c = {}; pb = pb.c;
}
Bun.deepMatch(a, b); // previously: SIGSEGV
```

Found by Fuzzilli (fingerprint `42a736a4c6b863f7`).