### PR TITLE
core/misc: derive Copy on 5 small all-Copy-field types (cleanup, no alloc change)

### DIFF
--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -452,7 +452,7 @@ pub mod zig_base64 {
     // PORT NOTE: dropped `standard_pad_char`/`standard_encoder`/`standard_decoder`
     // @compileError deprecation stubs — no Rust equivalent for use-site compile errors.
 
-    #[derive(Clone)]
+    #[derive(Copy, Clone)]
     pub struct Base64Encoder {
         pub alphabet_chars: [u8; 64],
         pub pad_char: Option<u8>,

--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -131,7 +131,7 @@ impl StoredTrace {
 }
 
 /// Zig: `WriteStackTraceLimits`. Aliased as `DumpOptions` for safety/sys callers.
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct DumpStackTraceOptions {
     pub frame_count: usize,
     pub stop_at_jsc_llint: bool,

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -1399,7 +1399,7 @@ pub struct TaskCallbackContext {
 /// lives in this crate — so callers pass the borrow directly.
 // Clone: bitwise OK — `context` is a non-owning opaque backref the runtime
 // installed; the handler fn-ptrs are POD.
-#[derive(Default, Clone)]
+#[derive(Default, Copy, Clone)]
 pub struct WakeHandler {
     pub context: Option<NonNull<c_void>>,
     /// Zig: `fn(ctx: *anyopaque, pm: *PackageManager) void`.

--- a/src/md/ansi_renderer.rs
+++ b/src/md/ansi_renderer.rs
@@ -1999,7 +1999,7 @@ impl<'a> AnsiRenderer<'a> {
 /// Tracked so a cell that wraps mid-span can re-emit the same opens
 /// on the continuation segment AND close any open OSC 8 link before
 /// the border character — `\x1b[0m` doesn't terminate OSC 8.
-#[derive(Clone, Default)]
+#[derive(Copy, Clone, Default)]
 struct CellAnsiState<'s> {
     flags: u8,
     fg: Option<&'s [u8]>,

--- a/src/md/ansi_renderer.rs
+++ b/src/md/ansi_renderer.rs
@@ -1664,7 +1664,7 @@ impl<'a> AnsiRenderer<'a> {
                         strings::wtf8_byte_sequence_length_with_invalid(rest[0]),
                     ));
                 }
-                state_at[i].push(state.clone());
+                state_at[i].push(state);
                 segments[i].push(&rest[0..cut]);
                 state.scan(&rest[0..cut]);
                 rest = &rest[cut..];
@@ -1700,7 +1700,7 @@ impl<'a> AnsiRenderer<'a> {
                     b""
                 };
                 let opens: CellAnsiState = if line < state_at[i].len() {
-                    state_at[i][line].clone()
+                    state_at[i][line]
                 } else {
                     CellAnsiState::default()
                 };

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -703,7 +703,7 @@ pub mod api {
     }
 
     /// schema.zig — peechy `struct Log` (minimal: `warnings`, `errors`, `msgs`).
-    #[derive(Clone, Debug, Default)]
+    #[derive(Copy, Clone, Debug, Default)]
     pub struct Log {
         pub warnings: u32,
         pub errors: u32,


### PR DESCRIPTION
Adds `Copy` to 5 small foundation types whose fields are all already `Copy` and which have no `Drop` impl:

- `bun_core::DumpStackTraceOptions` — `usize`, `bool` × 2, `&'static [&'static [u8]]` × 2
- `options_types::schema::Log` — `u32` × 2
- `base64::Base64Encoder` — `[u8; 64]`, `Option<u8>`
- `install_types::WakeHandler` — `Option<NonNull<c_void>>`, `Option<fn(...)>` × 2
- `md::CellAnsiState<'s>` — `u8`, `Option<&'s [u8]>` × 3

`cargo check` clean on all five crates; clippy `clone_on_copy` reports no redundant clones to drop.