### PR TITLE
jsc: derive Copy on RuntimeTranspilerCache::Metadata (cleanup, no alloc change)

### DIFF
--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -79,7 +79,9 @@ impl Encoding {
     pub const LATIN1: Encoding = Encoding(3);
 }
 
-#[derive(Clone, PartialEq, Eq)]
+// Copy is intentional despite the ~120-byte size: Metadata is the
+// fixed-layout cache-entry header passed by value through encode/decode/verify.
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Metadata {
     pub cache_version: u32,
     pub output_encoding: Encoding,


### PR DESCRIPTION
Adds `Copy` to `RuntimeTranspilerCache::Metadata`. All fields are already `Copy` (`u32`, `u64` × 12, `Encoding`, `ModuleType`); no `Drop` impl.

The struct is ~120 bytes; `Copy` is intentional — it is the fixed-layout cache-entry header passed by value through encode/decode/verify.

`cargo check -p bun_jsc` clean.