### PR TITLE
server: borrow URL via Cow instead of to_vec() in server.fetch(string)

### DIFF
--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2480,13 +2480,16 @@ where
 
             let mut url = URL::parse(temp_url_str);
 
-            // Both branches produce a heap-owned buffer that `url.href` borrows.
-            // `bun.String.cloneUTF8(url.href)` below makes its own copy, so this
-            // buffer must be freed before we leave the block.
-            let owned_url_buf: Vec<u8> = if url.hostname.is_empty() {
-                strings::append(&self.base_url_string_for_joining, url.pathname).into_vec()
+            // `bun.String.cloneUTF8(url.href)` below makes its own copy, so the
+            // joined buffer only needs to live through this block. The else arm
+            // borrows `temp_url_str` (kept alive by `url_zig_str`) instead of
+            // duping it just to satisfy a uniform `defer free` like the Zig did.
+            let owned_url_buf: std::borrow::Cow<'_, [u8]> = if url.hostname.is_empty() {
+                std::borrow::Cow::Owned(
+                    strings::append(&self.base_url_string_for_joining, url.pathname).into_vec(),
+                )
             } else {
-                temp_url_str.to_vec()
+                std::borrow::Cow::Borrowed(temp_url_str)
             };
             url = URL::parse(&owned_url_buf);
 


### PR DESCRIPTION
**Callsite:** `src/runtime/server/server_body.rs:2489` — `temp_url_str.to_vec()` in the `server.fetch(stringUrl)` path.

**Tracer:** 0 hits / 0 bytes in the clone-tracer aggregation (this is the test-helper `server.fetch(string)` path, not the per-request hot path), so no measurable production impact — but the copy is still unnecessary and free to remove.

**What/why:** The Zig (`server.zig:1280-1285`) dupes `temp_url_str` in the hostname-present arm purely so a single `defer this.allocator.free(owned_url_buf)` can cover both arms — a Zig idiom for lacking sum-typed ownership. The Rust port carried that over as a `Vec<u8>` annotation, forcing an allocation+memcpy of the input URL whenever it already contains a hostname.

Switch to `Cow<'_, [u8]>`: the join arm stays `Owned`, the hostname-present arm `Borrowed(temp_url_str)`. `URL::parse(&owned_url_buf)` derefs either variant, and `BunString::clone_utf8(url.href)` copies out before the Cow drops.

**Lifetime safety:** `temp_url_str` borrows `url_zig_str` (`ZigString::Slice`), which is bound for the entire `is_string()` block and owns any UTF-8 conversion buffer. The underlying `JSString` is rooted on the stack via `arguments_buf`, and JSC `StringImpl` storage is non-moving, so the option-block `fast_get`/`to_slice` calls cannot invalidate it. No cross-thread, no AtomString, no GC-visible storage change. No `unsafe`.

**Tests** (`bun bd test`, vs origin/main @ f816284bcb1a):
- `test/js/bun/http/bun-server.test.ts -t fetch` — 6 pass / 0 fail
- `test/js/bun/http/bun-serve-fetch-invalid-args.test.ts` — pass
- `test/js/bun/http/leaks-test.test.ts -t "server.fetch"` — pre-existing fail on origin/main; RSS delta improves 357.9 MB → 215.6 MB with this change
- `test/js/bun/http/bun-server.test.ts` "should not use 100% CPU when websocket is idle" — pre-existing fail on origin/main, unrelated (websocket idle CPU)

0 new failures.