### PR TITLE
install/npm: drop redundant Range<usize>.clone() in manifest parse

### DIFF
--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -3259,7 +3259,7 @@ impl PackageManifest {
         );
         result.pkg.releases.values = PackageVersionList::init(
             &versioned_packages,
-            &versioned_packages[all_versioned_package_releases_range.clone()],
+            &versioned_packages[all_versioned_package_releases_range],
         );
 
         result.pkg.prereleases.keys = VersionSlice::init(
@@ -3268,7 +3268,7 @@ impl PackageManifest {
         );
         result.pkg.prereleases.values = PackageVersionList::init(
             &versioned_packages,
-            &versioned_packages[all_versioned_package_prereleases_range.clone()],
+            &versioned_packages[all_versioned_package_prereleases_range],
         );
 
         let max_versions_count = all_release_versions_range


### PR DESCRIPTION
## What

Removes two redundant `.clone()` calls on `Range<usize>` at `src/install/npm.rs:3262` and `:3271` (`PackageManifest::parse`).

## Why safe

- `all_versioned_package_releases_range` (defined at npm.rs:2374 as `0..release_versions_len`) and `all_versioned_package_prereleases_range` (npm.rs:2376) are each used **exactly once** — here, to slice `versioned_packages[..]`. Indexing consumes the range by value, and there are no later uses, so the clone is dead (clippy::redundant_clone).
- `Range<usize>::clone()` is a trivial two-`usize` bitwise copy with no allocation or side effects; the move is semantically identical. Clone tracer recorded **0 clones / 0 bytes** at this site, confirming no allocation.
- The neighboring `all_release_versions_range.clone()` (3258) and `all_prerelease_versions_range.clone()` (3267) are left as-is — those *are* reused below for `.len()` at 3274–3276.
- Pure stack data inside the manifest parser; no thread/GC/String concerns. No `unsafe`.

## Tests

`bun bd test test/cli/install/bun-info.test.ts`: 18 pass / 1 fail (timeout in `bun pm view (alias) > should handle scoped packages`) — same result on clean `origin/main`, **0 new failures**.

`cargo check -p bun_bin`: clean.