### PR TITLE
moduleloader: avoid redundant String::clone_latin1 of transpiled output

### DIFF
--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -1113,7 +1113,10 @@ bun_ast::link_impl_TranspilerCacheImpl! {
             debug_assert!(this.entry.is_none());
             this.output_code = Some(Box::<[u8]>::from(output_code_bytes));
 
-            let output_code = BunString::clone_latin1(output_code_bytes);
+            // Borrowed Latin-1 view: `to_file` only reads `byte_slice()` + the encoding
+            // tag (unmarked 8-bit ZigString -> Encoding::LATIN1, same as clone_latin1),
+            // and `output_code_bytes` outlives the synchronous `to_file` call.
+            let output_code = BunString::ascii(output_code_bytes);
             let result = RuntimeTranspilerCache::to_file(
                 this.input_byte_length.unwrap(),
                 this.input_hash.unwrap(),
@@ -1123,7 +1126,6 @@ bun_ast::link_impl_TranspilerCacheImpl! {
                 &output_code,
                 this.exports_kind,
             );
-            output_code.deref();
             if let Err(err) = result {
                 bun_core::scoped_log!(cache, "put() = {}", err.name());
             }


### PR DESCRIPTION
RuntimeTranspilerCache vtable `put()` cloned the printer output into a fresh `WTFStringImpl` (`BunString::clone_latin1`, ~30 KB/module) only to hand it to the synchronous `to_file()` writer which reads `byte_slice()` + the encoding tag and returns. `BunString::ascii(output_code_bytes)` borrows the same slice with the same Latin-1 encoding tag, dropping the per-cache-miss allocation (tracer: 34 calls / 1,027,215 bytes on the runtime test workload).

Originally also adopted `cache.output_code` zero-copy at `RuntimeTranspilerStore.rs:1193` and `jsc_hooks.rs:3051`, but #31054 deleted the only writer of `output_code` on the JSC path, making those arms unreachable — those two commits dropped.