### PR TITLE
install/npm: move single-use Range<usize> instead of cloning in PackageManifest::parse

### DIFF
--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -3259,7 +3259,7 @@ impl PackageManifest {
         );
         result.pkg.releases.values = PackageVersionList::init(
             &versioned_packages,
-            &versioned_packages[all_versioned_package_releases_range.clone()],
+            &versioned_packages[all_versioned_package_releases_range],
         );
 
         result.pkg.prereleases.keys = VersionSlice::init(
@@ -3268,7 +3268,7 @@ impl PackageManifest {
         );
         result.pkg.prereleases.values = PackageVersionList::init(
             &versioned_packages,
-            &versioned_packages[all_versioned_package_prereleases_range.clone()],
+            &versioned_packages[all_versioned_package_prereleases_range],
         );
 
         let max_versions_count = all_release_versions_range


### PR DESCRIPTION
Part of the clone-reduction sweep (clippy::redundant_clone hits surfaced by the runtime clone tracer).

#### What

`all_versioned_package_releases_range` (declared npm.rs:2374) and `all_versioned_package_prereleases_range` (declared npm.rs:2376) are each `Range<usize>` locals consumed **exactly once** — as the slice index at npm.rs:3262 / npm.rs:3271 respectively. `Range<usize>` is `!Copy`, so the Zig→Rust porter added `.clone()` defensively, but since this is the sole/last use the value can simply be moved into `Index<Range<usize>>`.

The adjacent `all_release_versions_range.clone()` / `all_prerelease_versions_range.clone()` (npm.rs:3258/3267) are **kept** — those ranges are reused immediately after for `.len()` (npm.rs:3274/3276).

#### Why it's safe

- `Range::clone` has no side effects; move vs clone of two `usize`s is semantically identical.
- No thread/GC/String hazards: pure stack-local `Range<usize>` consumed by a slice index on a local `Vec` borrow within the same function scope.
- No `unsafe` added.

#### Perf

Tracer: 0 calls / 0 bytes (this is `Range<usize>`, not a `String`/`WTFStringImpl` allocator). Pure lint hygiene — silences `clippy::redundant_clone`.

#### Tests

- `cargo check -p bun_bin --keep-going` — clean
- `bun bd test test/cli/install/bun-add.test.ts` — **54 pass / 0 fail** (exercises the npm manifest version-list parsing path)