### PR TITLE
fetch: drop redundant Host header re-allocation in fetch_impl

### DIFF
--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -484,7 +484,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     // when ownership is moved into `FetchOptions`.
     let mut signal = SignalRef(None);
     // Custom Hostname
-    let mut hostname: Option<bun_core::ZBox> = None;
+    let mut hostname: Option<Box<[u8]>> = None;
     let mut range: Option<bun_core::ZBox> = None;
     let mut unix_socket_path: ZigStringSlice = ZigStringSlice::empty();
 
@@ -1356,7 +1356,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             // an opaque ZST FFI handle (S008) — safe `*mut → &mut` deref.
             let headers_ref = bun_opaque::opaque_deref_mut(headers_);
             if let Some(hostname_) = headers_ref.fast_get(HTTPHeaderName::Host) {
-                hostname = Some(hostname_.to_owned_slice_z());
+                hostname = Some(hostname_.to_owned_slice().into_boxed_slice());
             }
             if url.is_s3() {
                 if let Some(range_) = headers_ref.fast_get(HTTPHeaderName::Range) {
@@ -2027,7 +2027,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         signal: signal.take(),
         global_this: Some(global_this.into()),
         ssl_config: ssl_config.take(),
-        hostname: hostname.take().map(|z| Box::<[u8]>::from(z.as_bytes())),
+        hostname: hostname.take(),
         upgraded_connection,
         force_http2,
         force_http3,


### PR DESCRIPTION
**Callsite:** `src/runtime/webcore/fetch.rs:2030` — `Box::<[u8]>::from(z.as_bytes())`

**Tracer:** 0 hits / 0 bytes in the clone-tracer benchmark (the workload did not set a custom `Host` header), but this is a port-artifact double allocation on every `fetch()` that does.

### What changed

The custom-`Host` path in `fetch_impl` allocated twice:
1. `hostname_.to_owned_slice_z()` → `ZBox` (heap copy + NUL)
2. `Box::<[u8]>::from(z.as_bytes())` → fresh `Box<[u8]>` re-copying the bytes just to strip the NUL before storing in `FetchOptions::hostname: Option<Box<[u8]>>`

Zig (`fetch.zig:959,1442`) did one `toOwnedSliceZ` and passed the `[:0]u8` straight through. The Rust consumer (`FetchTasklet`, read via `as_deref()`) only needs `&[u8]` — no terminator.

Now: declare the local as `Option<Box<[u8]>>`, build it once via `ZigString::to_owned_slice().into_boxed_slice()`, and move it directly into `FetchOptions`.

### Why safe

- Plain heap bytes — no `WTFStringImpl`/`AtomString`, no per-thread atom table involved. `Box<[u8]>` drop in `clear_data()` is thread-safe.
- No GC lifetime: `FetchTasklet` owns the box until `clear_data()` (unchanged).
- `ZigString::to_owned_slice()` performs the same UTF-16/Latin-1 → UTF-8 transcoding as `to_owned_slice_z()`; only the in-len NUL push differs.
- Source `ZigString` borrows `FetchHeaders` storage, but we copy out immediately at the same point as before.
- No `unsafe` added.

### Tests

- `bun bd test test/js/bun/http/fetch-header-count-limit.test.ts` — 3 pass / 0 fail (sets `Host` on a `fetch()` request)
- `bun bd test test/js/web/fetch/fetch.test.ts` — 322 pass / 19 fail, **identical** to `origin/main` baseline in this env (root-user `chmod 0` no-ops, external-HTTPS timeouts, debug-build GC-stress timeouts). 0 new failures.
- `cargo check -p bun_bin` clean.