### PR TITLE
shell: move Arc<BuiltinBlob> into stderr instead of cloning on last use

### DIFF
--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -776,7 +776,7 @@ impl Builtin {
                         me.stdout = BuiltinIO::Blob(blob.clone());
                     }
                     if redirect.stderr() {
-                        me.stderr = BuiltinIO::Blob(blob.clone());
+                        me.stderr = BuiltinIO::Blob(blob);
                     }
                 } else if let Some(blob_ref) = jsval.as_class_ref::<crate::webcore::Blob>() {
                     if (redirect.stdout() || redirect.stderr()) && !blob_ref.needs_to_read_file() {


### PR DESCRIPTION
## What

`src/runtime/shell/Builtin.rs:779` — in the `Response`/`Request` body redirect branch, the third `if` arm (`stderr`) is the last use of the local `blob: Arc<BuiltinBlob>`, so move it instead of `Arc::clone`ing.

```rust
if redirect.stderr() {
-   me.stderr = BuiltinIO::Blob(blob.clone());
+   me.stderr = BuiltinIO::Blob(blob);
}
```

## Why this is safe

The three redirect branches at :773/:776/:779 are independent `if`s (stdin/stdout/stderr can all be set), so the first two must keep `.clone()`. The stderr arm is the final use — `blob` falls out of scope immediately after the closing brace. `Arc::clone` is a pure refcount bump with no side effects, so eliminating clone-then-drop is a mechanical no-op: the same `Arc` instance reaches `me.stderr` with identical net refcount.

This also brings the body-Value branch in line with the sibling `Blob` branch at :793-797 (`theblob`), which already moves on its last arm.

Flagged by the clone tracer as `redundant_clone` (0 bytes copied — pure Arc inc/dec pair eliminated). No `unsafe`, no AtomString/GC/cross-thread concerns.

## Tests

`cargo check -p bun_bin` clean.

`bun bd test test/js/bun/shell/bunshell-instance.test.ts` and `bunshell.test.ts`: identical outcome to `origin/main` — both crash on a pre-existing `debug_assert!(atoms.capacity() == 1)` in `src/shell_parser/parse.rs:1932` (different crate, unrelated to this change; reproduces on f816284bc without this patch). 0 new failures.