### PR TITLE
shell: move Arc<IOWriter> into stderr redirect slot instead of cloning

### DIFF
--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -704,7 +704,7 @@ impl Builtin {
                 if redirect.stderr() {
                     let me = Self::of_mut(interp, cmd);
                     me.stderr = BuiltinIO::Fd(OutFd {
-                        writer: redirect_writer.clone(),
+                        writer: redirect_writer,
                         captured: None,
                     });
                 }

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -691,8 +691,6 @@ impl Builtin {
                     evtloop,
                 );
                 redirect_writer.set_interp(interp_ptr);
-                // `defer redirect_writer.deref()` — `redirect_writer: Arc` drops
-                // here; each assigned slot holds its own clone.
 
                 if redirect.stdout() {
                     let me = Self::of_mut(interp, cmd);


### PR DESCRIPTION
Drops a redundant `Arc::clone` flagged by `clippy::redundant_clone` at `src/runtime/shell/Builtin.rs:707`.

In the builtin file-redirect setup (`ast::Redirect::File`), `redirect_writer: Arc<IOWriter>` is created via `IOWriter::init` and then assigned to `me.stdout` (if `redirect.stdout()`) and/or `me.stderr` (if `redirect.stderr()`). The stderr branch is the last possible use of the local — the original `Arc` drops unconditionally at the end of the match arm — so cloning into stderr and then dropping the original is one atomic incr/decr pair for nothing. Moving the `Arc` yields identical net refcounts in all four stdout/stderr truth-table cases (matches the Zig `defer redirect_writer.deref()` + per-slot `.ref()` pattern noted in the adjacent comment). The stdout clone at L700 must stay because `redirect_writer` may still be needed for stderr.

No `String`/`AtomString`/JS-GC involvement — shell-internal `std::sync::Arc` plumbing only.

**Tracer**: clippy-only finding (0 runtime hits / 0 bytes — the `&>` builtin redirect path was not exercised in the trace workload).

**Verification**:
- `cargo check -p bun_bin --keep-going` — clean.
- Shell test suites (`test/js/bun/shell/bunshell.test.ts`, `commands/echo.test.ts`, `file-io.test.ts`) currently panic on `origin/main` at `src/shell_parser/parse.rs:1932` (`debug_assert!(atoms.capacity() == 1)`) before reaching any builtin code; confirmed identical with and without this change via `git stash` — 0 new failures.