### PR TITLE
macros: free per-thread SOURCE_CODE_PRINTER on bundler worker teardown

### DIFF
--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -306,6 +306,7 @@ pub fn __bun_macro_context_deinit(data: *mut core::ffi::c_void) {
     // `MacroMap` and, if a macro was invoked, runs `MimallocArena::drop`
     // (→ `mi_heap_destroy`) on the lazily-created `bump`.
     drop(unsafe { Box::<MacroContext>::from_raw(data.cast::<MacroContext>()) });
+    bun_jsc::virtual_machine::drop_source_code_printer_if_macro_owned();
 }
 
 #[unsafe(no_mangle)]

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -427,8 +427,8 @@ impl Macro {
         hash: i32,
     ) -> Result<Macro, Error> {
         // TODO(port): narrow error set
-        let vm: *mut VirtualMachine = if VirtualMachine::is_loaded() {
-            VirtualMachine::get_mut_ptr()
+        let (vm, is_new_vm): (*mut VirtualMachine, bool) = if VirtualMachine::is_loaded() {
+            (VirtualMachine::get_mut_ptr(), false)
         } else {
             // PORT NOTE: Zig saved/restored `resolver.opts.transform_options`
             // across this block because `VirtualMachine.init` (via
@@ -451,20 +451,21 @@ impl Macro {
                 is_main_thread: false,
                 ..Default::default()
             })?;
-
-            // SAFETY: `_vm` is the freshly-allocated per-thread VM.
-            unsafe {
-                (*_vm).enable_macro_mode();
-                (*(*_vm).event_loop()).ensure_waker();
-                (*_vm).transpiler.configure_defines()?;
-            }
-            _vm
+            (_vm, true)
         };
 
+        // Covers `configure_defines` (new-VM path) and `load_macro_entry_point`
+        // (which runs the macro module's top-level JS via `wait_for_promise`) so
+        // a top-level `Bun.Transpiler#transformSync` doesn't see
+        // `macro_guard_depth == 0` and free the printer mid-init. Drops on every
+        // exit (success, `?`, Rejected) so depth/state can't leak; the caller's
+        // own `MacroModeGuard` re-enables for the actual macro call.
+        let _init_guard = MacroModeGuard::new(vm);
         // SAFETY: `vm` is the per-thread VM; uniquely accessed here.
-        unsafe {
-            (*vm).enable_macro_mode();
-            (*(*vm).event_loop()).ensure_waker();
+        unsafe { (*(*vm).event_loop()).ensure_waker() };
+        if is_new_vm {
+            // SAFETY: `vm` is the freshly-allocated per-thread VM.
+            unsafe { (*vm).transpiler.configure_defines()? };
         }
 
         // SAFETY: `vm` is the per-thread VM; uniquely accessed here.
@@ -482,7 +483,6 @@ impl Macro {
             // is a live promise cell.
             unsafe {
                 (*vm).unhandled_rejection(&*(*vm).global, result, (*loaded_result).to_js());
-                (*vm).disable_macro_mode();
             }
             return Err(err!("MacroLoadError"));
         }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3026,10 +3026,28 @@ fn drop_source_code_printer() {
 /// on threads where the runtime VM had already initialized the printer (e.g. an
 /// inline `Bun.build()` macro on the JS thread), so subsequent module loads
 /// keep their printer.
+///
+/// Also a no-op while a [`MacroModeGuard`] is still active on this thread:
+/// `__bun_macro_context_deinit` can fire *inside* the guard scope (e.g. a
+/// macro that calls `new Bun.Transpiler().transformSync(...)` —
+/// `TranspilerStateGuard::drop` deinits the nested `MacroContext`), and freeing
+/// here would panic the next module fetch at
+/// `SOURCE_CODE_PRINTER.get().expect(...)` with no intervening
+/// `enable_macro_mode()`. The outermost guard's `disable_macro_mode()` clears
+/// `macro_mode`, after which `Worker::deinit` (or the next per-job deinit)
+/// reaches the free.
 pub fn drop_source_code_printer_if_macro_owned() {
-    if SOURCE_CODE_PRINTER_FROM_MACRO.get() {
-        drop_source_code_printer();
+    if !SOURCE_CODE_PRINTER_FROM_MACRO.get() {
+        return;
     }
+    if let Some(vm) = VM.get() {
+        // SAFETY: `VM` is this thread's per-JS-thread VM singleton; we only
+        // read the `macro_mode` flag and never alias `&mut`.
+        if unsafe { (*vm).macro_mode } {
+            return;
+        }
+    }
+    drop_source_code_printer();
 }
 
 fn normalize_source(source: &[u8]) -> &[u8] {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1147,6 +1147,9 @@ impl VirtualMachine {
             self.macro_event_loop.virtual_machine = NonNull::new(std::ptr::from_mut(self));
             self.macro_event_loop.global = NonNull::new(self.global);
             self.macro_event_loop.concurrent_tasks = Default::default();
+            if SOURCE_CODE_PRINTER.get().is_none() {
+                SOURCE_CODE_PRINTER_FROM_MACRO.set(true);
+            }
             ensure_source_code_printer();
         }
         self.transpiler.options.target = bun_ast::Target::BunMacro;
@@ -2948,6 +2951,16 @@ pub struct ResolveFunctionResult {
 pub static SOURCE_CODE_PRINTER: Cell<Option<NonNull<bun_js_printer::BufferPrinter>>> =
     Cell::new(None);
 
+/// `true` when [`enable_macro_mode`](VirtualMachine::enable_macro_mode) was the
+/// first allocator of [`SOURCE_CODE_PRINTER`] on this thread (i.e. a bundler
+/// worker thread running a macro, where no runtime VM had called
+/// [`VirtualMachine::load_extra_env_and_source_code_printer`] beforehand).
+/// Lets `__bun_macro_context_deinit` free the printer on worker teardown
+/// without touching the runtime VM's printer when an inline `Bun.build()`
+/// macro ran on the JS thread.
+#[thread_local]
+static SOURCE_CODE_PRINTER_FROM_MACRO: Cell<bool> = Cell::new(false);
+
 /// Spec VirtualMachine.zig:1712 `normalizeSpecifierForResolution`.
 fn normalize_specifier_for_resolution<'a>(
     specifier_: &'a [u8],
@@ -2984,6 +2997,32 @@ fn ensure_source_code_printer() {
         let mut printer = Box::new(bun_js_printer::BufferPrinter::init(writer));
         printer.ctx.append_null_byte = false;
         SOURCE_CODE_PRINTER.set(NonNull::new(bun_core::heap::into_raw(printer)));
+    }
+}
+
+/// Free this thread's [`SOURCE_CODE_PRINTER`] Box (if any).
+fn drop_source_code_printer() {
+    if let Some(printer) = SOURCE_CODE_PRINTER.take() {
+        // SAFETY: `printer` was produced by `heap::into_raw` in
+        // `ensure_source_code_printer` and is exclusively owned by this thread.
+        drop(unsafe { bun_core::heap::take(printer.as_ptr()) });
+    }
+    SOURCE_CODE_PRINTER_FROM_MACRO.set(false);
+}
+
+/// Free this thread's [`SOURCE_CODE_PRINTER`] Box only if
+/// [`enable_macro_mode`](VirtualMachine::enable_macro_mode) allocated it.
+/// Called from `js_parser_jsc::Macro::__bun_macro_context_deinit` on bundler
+/// worker teardown — the macro VM never reaches `VirtualMachine::deinit`, so
+/// the box would otherwise leak when the worker thread's TLS block is torn down
+/// before LSan scans (issue 03830 on debian-13-asan after the
+/// `leak:bun_js_parser_jsc::Macro` suppression was removed in #30875). A no-op
+/// on threads where the runtime VM had already initialized the printer (e.g. an
+/// inline `Bun.build()` macro on the JS thread), so subsequent module loads
+/// keep their printer.
+pub fn drop_source_code_printer_if_macro_owned() {
+    if SOURCE_CODE_PRINTER_FROM_MACRO.get() {
+        drop_source_code_printer();
     }
 }
 
@@ -4377,15 +4416,7 @@ impl VirtualMachine {
         // is the deinit body; take()+drop runs it without dropping `self`.
         drop(core::mem::take(&mut self.auto_killer));
 
-        // PORT NOTE: Zig frees the thread-local `source_code_printer` static
-        // in `deinit`; here it's `SOURCE_CODE_PRINTER` (boxed via
-        // `ensure_source_code_printer`).
-        if let Some(printer) = SOURCE_CODE_PRINTER.take() {
-            // SAFETY: `printer` was produced by `heap::alloc` in
-            // `ensure_source_code_printer` and is exclusively owned by this
-            // thread's VM.
-            drop(unsafe { bun_core::heap::take(printer.as_ptr()) });
-        }
+        drop_source_code_printer();
 
         // PORT NOTE: `SavedSourceMap`'s `Drop` is the Zig `deinit()`; it frees
         // each stored map and `deinit()`s the sibling `saved_source_map_table`.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -240,6 +240,15 @@ pub struct VirtualMachine {
     // TODO(b2-cycle): `MacroEntryPoint` from `bun_bundler::entry_points` (gated).
     pub macro_entry_points: bun_collections::ArrayHashMap<i32, *mut c_void>,
     pub macro_mode: bool,
+    /// Depth of live [`MacroModeGuard`]s on this thread. Distinct from
+    /// `macro_mode` (which is a non-reentrant bool toggled by
+    /// `enable_/disable_macro_mode` and read by the resolve/transpile path):
+    /// `macro_mode` can be cleared by an inner guard's drop while an outer
+    /// guard is still on the stack, or left stuck `true` on `Macro::init`'s
+    /// `?` error path before any guard exists. The depth is the precise "a
+    /// guard is on the stack" signal that
+    /// [`drop_source_code_printer_if_macro_owned`] needs.
+    pub macro_guard_depth: u32,
     pub no_macros: bool,
     pub auto_killer: ProcessAutoKiller::ProcessAutoKiller,
 
@@ -587,7 +596,9 @@ impl MacroModeGuard {
     #[inline]
     pub fn new(vm: *mut VirtualMachine) -> Self {
         let vm = bun_ptr::BackRef::from(NonNull::new(vm).expect("vm non-null"));
-        vm.get().as_mut().enable_macro_mode();
+        let vm_mut = vm.get().as_mut();
+        vm_mut.enable_macro_mode();
+        vm_mut.macro_guard_depth += 1;
         Self { vm }
     }
 }
@@ -595,7 +606,9 @@ impl Drop for MacroModeGuard {
     #[inline]
     fn drop(&mut self) {
         // Per `new` contract — `vm` outlives the guard (BackRef invariant).
-        self.vm.get().as_mut().disable_macro_mode();
+        let vm_mut = self.vm.get().as_mut();
+        vm_mut.macro_guard_depth = vm_mut.macro_guard_depth.saturating_sub(1);
+        vm_mut.disable_macro_mode();
     }
 }
 
@@ -3033,17 +3046,19 @@ fn drop_source_code_printer() {
 /// `TranspilerStateGuard::drop` deinits the nested `MacroContext`), and freeing
 /// here would panic the next module fetch at
 /// `SOURCE_CODE_PRINTER.get().expect(...)` with no intervening
-/// `enable_macro_mode()`. The outermost guard's `disable_macro_mode()` clears
-/// `macro_mode`, after which `Worker::deinit` (or the next per-job deinit)
-/// reaches the free.
+/// `enable_macro_mode()`. Gated on `macro_guard_depth` (not `macro_mode`): an
+/// inner guard's drop unconditionally clears `macro_mode` while the outer guard
+/// is still on the stack, and `Macro::init`'s `?` error path can leave
+/// `macro_mode` stuck `true` before any guard exists — the depth counter is
+/// nonzero exactly while a guard is on the stack.
 pub fn drop_source_code_printer_if_macro_owned() {
     if !SOURCE_CODE_PRINTER_FROM_MACRO.get() {
         return;
     }
     if let Some(vm) = VM.get() {
         // SAFETY: `VM` is this thread's per-JS-thread VM singleton; we only
-        // read the `macro_mode` flag and never alias `&mut`.
-        if unsafe { (*vm).macro_mode } {
+        // read the depth counter and never alias `&mut`.
+        if unsafe { (*vm).macro_guard_depth } > 0 {
             return;
         }
     }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -240,14 +240,12 @@ pub struct VirtualMachine {
     // TODO(b2-cycle): `MacroEntryPoint` from `bun_bundler::entry_points` (gated).
     pub macro_entry_points: bun_collections::ArrayHashMap<i32, *mut c_void>,
     pub macro_mode: bool,
-    /// Depth of live [`MacroModeGuard`]s on this thread. Distinct from
-    /// `macro_mode` (which is a non-reentrant bool toggled by
-    /// `enable_/disable_macro_mode` and read by the resolve/transpile path):
-    /// `macro_mode` can be cleared by an inner guard's drop while an outer
-    /// guard is still on the stack, or left stuck `true` on `Macro::init`'s
-    /// `?` error path before any guard exists. The depth is the precise "a
-    /// guard is on the stack" signal that
-    /// [`drop_source_code_printer_if_macro_owned`] needs.
+    /// Depth of live [`MacroModeGuard`]s on this thread. Nonzero exactly while
+    /// macro JS may be executing — both `MacroContext::call` and `Macro::init`
+    /// (whose `load_macro_entry_point` runs the macro module's top-level via
+    /// `wait_for_promise`) hold a guard. `enable_/disable_macro_mode` are gated
+    /// on the 0↔1 transition so the guard is reentrant; this is the signal
+    /// [`drop_source_code_printer_if_macro_owned`] uses.
     pub macro_guard_depth: u32,
     pub no_macros: bool,
     pub auto_killer: ProcessAutoKiller::ProcessAutoKiller,
@@ -2979,13 +2977,13 @@ pub struct ResolveFunctionResult {
 pub static SOURCE_CODE_PRINTER: Cell<Option<NonNull<bun_js_printer::BufferPrinter>>> =
     Cell::new(None);
 
-/// `true` when [`enable_macro_mode`](VirtualMachine::enable_macro_mode) was the
-/// first allocator of [`SOURCE_CODE_PRINTER`] on this thread (i.e. a bundler
-/// worker thread running a macro, where no runtime VM had called
-/// [`VirtualMachine::load_extra_env_and_source_code_printer`] beforehand).
-/// Lets `__bun_macro_context_deinit` free the printer on worker teardown
-/// without touching the runtime VM's printer when an inline `Bun.build()`
-/// macro ran on the JS thread.
+/// `true` when [`enable_macro_mode`](VirtualMachine::enable_macro_mode)
+/// allocated [`SOURCE_CODE_PRINTER`] on this thread and no runtime VM has since
+/// claimed it via [`VirtualMachine::load_extra_env_and_source_code_printer`]
+/// (i.e. a bundler worker thread running a macro). Lets
+/// `__bun_macro_context_deinit` free the printer on worker teardown without
+/// touching the runtime VM's printer when an inline `Bun.build()` macro ran on
+/// the JS thread.
 #[thread_local]
 static SOURCE_CODE_PRINTER_FROM_MACRO: Cell<bool> = Cell::new(false);
 
@@ -3055,11 +3053,9 @@ fn drop_source_code_printer() {
 /// `TranspilerStateGuard::drop` deinits the nested `MacroContext`), and freeing
 /// here would panic the next module fetch at
 /// `SOURCE_CODE_PRINTER.get().expect(...)` with no intervening
-/// `enable_macro_mode()`. Gated on `macro_guard_depth` (not `macro_mode`): an
-/// inner guard's drop unconditionally clears `macro_mode` while the outer guard
-/// is still on the stack, and `Macro::init`'s `?` error path can leave
-/// `macro_mode` stuck `true` before any guard exists — the depth counter is
-/// nonzero exactly while a guard is on the stack.
+/// `enable_macro_mode()`. Gated on `macro_guard_depth`: nonzero exactly while a
+/// guard is on the stack (both `MacroContext::call` and `Macro::init` hold one,
+/// so the macro module's top-level is covered too).
 pub fn drop_source_code_printer_if_macro_owned() {
     if !SOURCE_CODE_PRINTER_FROM_MACRO.get() {
         return;
@@ -3238,6 +3234,9 @@ impl VirtualMachine {
         let map = &mut *env.map;
 
         ensure_source_code_printer();
+        // The runtime VM owns the printer from here on — even if a macro had
+        // allocated it first, `__bun_macro_context_deinit` must not free it.
+        SOURCE_CODE_PRINTER_FROM_MACRO.set(false);
 
         if map.get(b"BUN_SHOW_BUN_STACKFRAMES").is_some() {
             self.hide_bun_stackframes = false;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -597,8 +597,15 @@ impl MacroModeGuard {
     pub fn new(vm: *mut VirtualMachine) -> Self {
         let vm = bun_ptr::BackRef::from(NonNull::new(vm).expect("vm non-null"));
         let vm_mut = vm.get().as_mut();
-        vm_mut.enable_macro_mode();
+        // Reentrant: only the outermost guard flips the VM into macro mode and
+        // back; inner guards (e.g. a macro that calls
+        // `Bun.Transpiler#transformSync` which itself enters a guard) just bump
+        // the depth so their `Drop` doesn't reset `macro_mode`/`event_loop`/
+        // `transpiler.target`/`transpiler_store.enabled` underneath the outer.
         vm_mut.macro_guard_depth += 1;
+        if vm_mut.macro_guard_depth == 1 {
+            vm_mut.enable_macro_mode();
+        }
         Self { vm }
     }
 }
@@ -608,7 +615,9 @@ impl Drop for MacroModeGuard {
         // Per `new` contract — `vm` outlives the guard (BackRef invariant).
         let vm_mut = self.vm.get().as_mut();
         vm_mut.macro_guard_depth = vm_mut.macro_guard_depth.saturating_sub(1);
-        vm_mut.disable_macro_mode();
+        if vm_mut.macro_guard_depth == 0 {
+            vm_mut.disable_macro_mode();
+        }
     }
 }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1147,11 +1147,17 @@ impl VirtualMachine {
             self.macro_event_loop.virtual_machine = NonNull::new(std::ptr::from_mut(self));
             self.macro_event_loop.global = NonNull::new(self.global);
             self.macro_event_loop.concurrent_tasks = Default::default();
-            if SOURCE_CODE_PRINTER.get().is_none() {
-                SOURCE_CODE_PRINTER_FROM_MACRO.set(true);
-            }
-            ensure_source_code_printer();
         }
+        // Idempotent; outside the `has_enabled_macro_mode` guard because
+        // `__bun_macro_context_deinit` runs per-job (RuntimeTranspilerStore
+        // scopeguard, JSTranspiler TransformTask, bundler `Worker::deinit`) and
+        // frees the printer while this VM survives with the flag still set —
+        // the next macro on the same pool thread would otherwise skip re-init
+        // and panic at `SOURCE_CODE_PRINTER.get().expect(...)`.
+        if SOURCE_CODE_PRINTER.get().is_none() {
+            SOURCE_CODE_PRINTER_FROM_MACRO.set(true);
+        }
+        ensure_source_code_printer();
         self.transpiler.options.target = bun_ast::Target::BunMacro;
         self.transpiler
             .resolver

--- a/test/regression/issue/03830.test.ts
+++ b/test/regression/issue/03830.test.ts
@@ -1,26 +1,21 @@
 import { describe, expect, it } from "bun:test";
-import { mkdirSync, realpathSync, rmSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { realpathSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 describe("issue/03830", () => {
+  // First test stays sequential: `toMatchSnapshot()` is not supported in
+  // concurrent tests (Bun's test runner rejects it). The second test has no
+  // snapshot matcher, so it runs `.concurrent` per test/CLAUDE.md.
   it("macros should not lead to seg faults under any given input", async () => {
     // this test code follows the same structure as and
     // is based on the code for testing issue 4893
 
-    let testDir = tmpdirSync();
-
-    // Clean up from prior runs if necessary
-    rmSync(testDir, { recursive: true, force: true });
-
-    // Create a directory with our test file
-    mkdirSync(testDir, { recursive: true });
-    writeFileSync(join(testDir, "macro.ts"), "export function fn(str) { return str; }");
-    writeFileSync(
-      join(testDir, "index.ts"),
-      "import { fn } from './macro' assert { type: 'macro' };\nfn(`©${Number(0)}`);",
-    );
-    testDir = realpathSync(testDir);
+    using dir = tempDir("issue-03830", {
+      "macro.ts": "export function fn(str) { return str; }",
+      "index.ts": "import { fn } from './macro' assert { type: 'macro' };\nfn(`©${Number(0)}`);",
+    });
+    const testDir = realpathSync(dir);
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "build", "--minify", join(testDir, "index.ts")],
@@ -35,28 +30,21 @@ describe("issue/03830", () => {
     expect(exitCode).toBe(1);
   });
 
-  it("nested Bun.Transpiler in a macro then import() does not free the printer", async () => {
+  it.concurrent("nested Bun.Transpiler in a macro then import() does not free the printer", async () => {
     // The macro's Bun.Transpiler#transformSync drops a nested MacroContext via
     // TranspilerStateGuard, which calls __bun_macro_context_deinit. On a
     // bundler-worker thread the macro was the first SOURCE_CODE_PRINTER
     // allocator; freeing it here would panic the subsequent module fetch.
-    let testDir = tmpdirSync();
-    rmSync(testDir, { recursive: true, force: true });
-    mkdirSync(testDir, { recursive: true });
-    writeFileSync(join(testDir, "helper.ts"), "export const value = 42;");
-    writeFileSync(
-      join(testDir, "macro.ts"),
-      `export async function nested() {
+    using dir = tempDir("issue-03830-nested", {
+      "helper.ts": "export const value = 42;",
+      "macro.ts": `export async function nested() {
   new Bun.Transpiler().transformSync("const a = 1;");
   const mod = await import("./helper.ts");
   return mod.value;
 }`,
-    );
-    writeFileSync(
-      join(testDir, "index.ts"),
-      "import { nested } from './macro.ts' with { type: 'macro' };\nconsole.log(nested());",
-    );
-    testDir = realpathSync(testDir);
+      "index.ts": "import { nested } from './macro.ts' with { type: 'macro' };\nconsole.log(nested());",
+    });
+    const testDir = realpathSync(dir);
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "build", "--target=bun", join(testDir, "index.ts")],

--- a/test/regression/issue/03830.test.ts
+++ b/test/regression/issue/03830.test.ts
@@ -30,18 +30,31 @@ describe("issue/03830", () => {
     expect(exitCode).toBe(1);
   });
 
-  it.concurrent("nested Bun.Transpiler in a macro then import() does not free the printer", async () => {
-    // The macro's Bun.Transpiler#transformSync drops a nested MacroContext via
+  it.concurrent.each([
+    // [name, where transformSync+import() runs in macro.ts]
+    ["inside the exported macro fn", "fn-body"],
+    // Macro::init runs the module's top-level via wait_for_promise BEFORE the
+    // caller's MacroModeGuard exists — Macro::init holds its own guard so
+    // depth > 0 here too.
+    ["at macro-module top level (during Macro::init)", "top-level"],
+  ])("nested Bun.Transpiler %s then import() does not free the printer", async (_, where) => {
+    // Bun.Transpiler#transformSync drops a nested MacroContext via
     // TranspilerStateGuard, which calls __bun_macro_context_deinit. On a
     // bundler-worker thread the macro was the first SOURCE_CODE_PRINTER
     // allocator; freeing it here would panic the subsequent module fetch.
-    using dir = tempDir("issue-03830-nested", {
-      "helper.ts": "export const value = 42;",
-      "macro.ts": `export async function nested() {
+    const macroTs =
+      where === "top-level"
+        ? `new Bun.Transpiler().transformSync("const a = 1;");
+const mod = await import("./helper.ts");
+export function nested() { return mod.value; }`
+        : `export async function nested() {
   new Bun.Transpiler().transformSync("const a = 1;");
   const mod = await import("./helper.ts");
   return mod.value;
-}`,
+}`;
+    using dir = tempDir("issue-03830-nested", {
+      "helper.ts": "export const value = 42;",
+      "macro.ts": macroTs,
       "index.ts": "import { nested } from './macro.ts' with { type: 'macro' };\nconsole.log(nested());",
     });
     const testDir = realpathSync(dir);

--- a/test/regression/issue/03830.test.ts
+++ b/test/regression/issue/03830.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, realpathSync, rmSync, writeFileSync } from "fs";
 import { bunEnv, bunExe, tmpdirSync } from "harness";
 import { join } from "path";
 
-describe.concurrent("issue/03830", () => {
+describe("issue/03830", () => {
   it("macros should not lead to seg faults under any given input", async () => {
     // this test code follows the same structure as and
     // is based on the code for testing issue 4893
@@ -33,5 +33,42 @@ describe.concurrent("issue/03830", () => {
 
     expect(stderr.trim().replaceAll(testDir, "[dir]").replaceAll("\\", "/")).toMatchSnapshot();
     expect(exitCode).toBe(1);
+  });
+
+  it("nested Bun.Transpiler in a macro then import() does not free the printer", async () => {
+    // The macro's Bun.Transpiler#transformSync drops a nested MacroContext via
+    // TranspilerStateGuard, which calls __bun_macro_context_deinit. On a
+    // bundler-worker thread the macro was the first SOURCE_CODE_PRINTER
+    // allocator; freeing it here would panic the subsequent module fetch.
+    let testDir = tmpdirSync();
+    rmSync(testDir, { recursive: true, force: true });
+    mkdirSync(testDir, { recursive: true });
+    writeFileSync(join(testDir, "helper.ts"), "export const value = 42;");
+    writeFileSync(
+      join(testDir, "macro.ts"),
+      `export async function nested() {
+  new Bun.Transpiler().transformSync("const a = 1;");
+  const mod = await import("./helper.ts");
+  return mod.value;
+}`,
+    );
+    writeFileSync(
+      join(testDir, "index.ts"),
+      "import { nested } from './macro.ts' with { type: 'macro' };\nconsole.log(nested());",
+    );
+    testDir = realpathSync(testDir);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--target=bun", join(testDir, "index.ts")],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr.trim()).toBe("");
+    expect(stdout).toContain("console.log(42)");
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
Fixes flaky `test/regression/issue/03830.test.ts` on `:debian: 13 x64-asan` (showing as `[new]` on PRs branched from `f816284bcb1a`).

**Root cause:** `enable_macro_mode()` lazily `Box::new`'s a `BufferPrinter` into the `#[thread_local]` `SOURCE_CODE_PRINTER` on whichever bundler worker thread first runs a macro (via `Macro::init` → `VirtualMachine::init` → `enable_macro_mode`). The only free site was `VirtualMachine::deinit`, which the macro VM never reaches (per-worker VM dealloc is intentionally unimplemented). When the worker thread's TLS block is torn down before LSan scans (timing-dependent — debian-13's glibc thread teardown ordering vs Amazon Linux), the 72-byte box is reported.

This was always a leak; #30875 unmasked it by removing the `leak:bun_js_parser_jsc::Macro` suppression. Not a #30971 regression.

**Fix:** `__bun_macro_context_deinit` already runs on the worker's own thread during `Worker::deinit` and frees the `MacroContext` box (the LSan report showing only 72 B confirms it runs — the much-larger `MacroContext`/`MacroMap`/`bump` arena don't leak). Have it also free the printer when macro mode allocated it. Gated via a `SOURCE_CODE_PRINTER_FROM_MACRO` thread-local so an inline `Bun.build()` macro on the JS thread leaves the runtime VM's printer intact for subsequent module loads.

**Tests (debug+ASAN, all 0 fail):**
- `test/regression/issue/03830.test.ts` — 1 pass
- `test/regression/issue/04893.test.ts` — pass
- `test/bundler/transpiler/macro-test.test.ts` — 10 pass
- `test/bundler/bun-build-api.test.ts` — 45 pass / 1 skip / 1 todo (covers `Bun.build()` + macros + subsequent imports)