### PR TITLE
install: borrow trustedDependencies array instead of to_vec in PackageJSONEditor::edit

### DIFF
--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -584,7 +584,8 @@ pub fn edit(
                             if let bun_ast::ExprData::EString(s) = &item.data {
                                 if s.eql_bytes(trusted_package_name) {
                                     // PORT NOTE: reshaped for borrowck — drop return value (was allocator.free)
-                                    let _ = manager.trusted_deps_to_add_to_package_json.swap_remove(i);
+                                    let _ =
+                                        manager.trusted_deps_to_add_to_package_json.swap_remove(i);
                                     break;
                                 }
                             }

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -572,31 +572,22 @@ pub fn edit(
     // 3. There is a "dependencies" (or equivalent list), and the package name exists in multiple lists
     // Try to use the existing spot in the dependencies list if possible
     {
-        let original_trusted_dependencies: Vec<Expr> = 'brk: {
-            if !options.add_trusted_dependencies {
-                break 'brk Vec::new();
-            }
-            if let Some(query) = current_package_json.as_property(TRUSTED_DEPENDENCIES_STRING) {
-                if let bun_ast::ExprData::EArray(arr) = &query.expr.data {
-                    // not modifying
-                    break 'brk arr.items.slice().to_vec();
-                }
-            }
-            Vec::new()
-        };
-
         if options.add_trusted_dependencies {
-            // Iterate backwards to avoid index issues when removing items
-            let mut i: usize = manager.trusted_deps_to_add_to_package_json.len();
-            while i > 0 {
-                i -= 1;
-                let trusted_package_name = &manager.trusted_deps_to_add_to_package_json[i];
-                for item in original_trusted_dependencies.iter() {
-                    if let bun_ast::ExprData::EString(s) = &item.data {
-                        if s.eql_bytes(trusted_package_name) {
-                            // PORT NOTE: reshaped for borrowck — drop return value (was allocator.free)
-                            let _ = manager.trusted_deps_to_add_to_package_json.swap_remove(i);
-                            break;
+            if let Some(query) = current_package_json.as_property(TRUSTED_DEPENDENCIES_STRING) {
+                if let bun_ast::ExprData::EArray(arr) = query.expr.data {
+                    // Iterate backwards to avoid index issues when removing items
+                    let mut i: usize = manager.trusted_deps_to_add_to_package_json.len();
+                    while i > 0 {
+                        i -= 1;
+                        let trusted_package_name = &manager.trusted_deps_to_add_to_package_json[i];
+                        for item in arr.items.slice() {
+                            if let bun_ast::ExprData::EString(s) = &item.data {
+                                if s.eql_bytes(trusted_package_name) {
+                                    // PORT NOTE: reshaped for borrowck — drop return value (was allocator.free)
+                                    let _ = manager.trusted_deps_to_add_to_package_json.swap_remove(i);
+                                    break;
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
**Callsite:** `src/install/PackageManager/PackageJSONEditor.rs:582` (`arr.items.slice().to_vec()`)

**Tracer:** 0 hits / 0 bytes (cold path: `bun add --trust` with a pre-existing `trustedDependencies` array). This is a port-correctness cleanup rather than a hot-path win.

**What changed**

The Zig original (`PackageJSONEditor.zig:384`) does `break :brk query.expr.data.e_array.*` — a shallow struct copy that shares the same arena-backed items slice with no heap allocation. The Rust port introduced `.to_vec()` purely as a borrowck workaround: `as_property` returns `Query` by value, so binding `&query.expr.data` ties the slice lifetime to the `query` local, which cannot escape the labelled block.

`original_trusted_dependencies` was read exactly once (the dedup loop immediately following) and only when `options.add_trusted_dependencies` is true. This change merges the lookup into that consumer block and binds `arr` as `StoreRef<E::Array>` by value (which is `Copy`, see `src/ast/nodes.rs`), so `arr.items.slice()` borrows the arena-backed slice directly for the whole loop — no `Vec`, no `unsafe`.

**Why the borrow is safe**

- `StoreRef<E::Array>` is `Copy` and points into `manager.ast_arena`, which is not reset during `edit()`.
- `arr` does not borrow `manager` or `current_package_json` (`Query` is returned by value), so the existing disjoint `&manager.ast_arena` / `&mut manager.trusted_deps_to_add_to_package_json` accesses are unaffected.
- When `trustedDependencies` is absent or not an array, the original code ran the while-loop against an empty `Vec` (inner `for` never matches → no removals); skipping the loop entirely is semantically identical.
- No new `unsafe` (contrast lines 129/794 which use `detach_lifetime` for the same shape).

**Tests**

```
bun bd test test/cli/install/bun-install-lifecycle-scripts.test.ts -t "trust"
52 pass / 0 fail
```

A sibling site at `edit_trusted_dependencies` (~line 105) has the identical anti-pattern and could get the same treatment in a follow-up.