### PR TITLE
install: borrow trustedDependencies arena slice instead of to_vec

### DIFF
--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -99,18 +99,18 @@ pub fn edit_trusted_dependencies(
 ) -> Result<(), bun_alloc::AllocError> {
     let mut len = names_to_add.len();
 
-    let original_trusted_dependencies: Vec<Expr> = 'brk: {
-        if let Some(query) = package_json.as_property(TRUSTED_DEPENDENCIES_STRING) {
-            if let bun_ast::ExprData::EArray(arr) = &query.expr.data {
-                break 'brk arr.items.slice().to_vec();
-            }
+    let mut trusted_dependencies: &[Expr] = &[];
+    if let Some(query) = package_json.as_property(TRUSTED_DEPENDENCIES_STRING) {
+        if let bun_ast::ExprData::EArray(arr) = &query.expr.data {
+            // SAFETY: `arr` is a `StoreRef` into the AST arena which outlives
+            // this function; lifetime erased per the parser's `Str` convention.
+            trusted_dependencies = unsafe { bun_ptr::detach_lifetime(arr.items.slice()) };
         }
-        Vec::new()
-    };
+    }
 
     for i in 0..names_to_add.len() {
         let name = &names_to_add[i];
-        for item in original_trusted_dependencies.iter() {
+        for item in trusted_dependencies.iter() {
             if let bun_ast::ExprData::EString(s) = &item.data {
                 if s.eql_bytes(name) {
                     names_to_add.swap(i, len - 1);
@@ -118,15 +118,6 @@ pub fn edit_trusted_dependencies(
                     break;
                 }
             }
-        }
-    }
-
-    let mut trusted_dependencies: &[Expr] = &[];
-    if let Some(query) = package_json.as_property(TRUSTED_DEPENDENCIES_STRING) {
-        if let bun_ast::ExprData::EArray(arr) = &query.expr.data {
-            // SAFETY: `arr` is a `StoreRef` into the AST arena which outlives
-            // this function; lifetime erased per the parser's `Str` convention.
-            trusted_dependencies = unsafe { bun_ptr::detach_lifetime(arr.items.slice()) };
         }
     }
 


### PR DESCRIPTION
## What

`edit_trusted_dependencies` (src/install/PackageManager/PackageJSONEditor.rs:102-131) computed `original_trusted_dependencies` via `arr.items.slice().to_vec()` — a fresh `Vec<Expr>` + memcpy of every existing `trustedDependencies` entry — then nine lines later fetched the **same** arena slice again as `trusted_dependencies: &[Expr]` via the existing `detach_lifetime` borrow.

Zig (PackageJSONEditor.zig:54-61) does `break :brk query.expr.data.e_array.*`, a shallow bitwise struct copy whose `items` is just ptr+len into the AST arena. No allocation.

This PR hoists the existing `trusted_dependencies` borrow above the de-dup loop and iterates it there, dropping the `Vec` allocation, the memcpy, and the redundant second `as_property` lookup.

## Why it's safe

- No new `unsafe`. Reuses the pre-existing `detach_lifetime` borrow with its existing SAFETY comment (`arr` is a `StoreRef` into `manager.ast_arena`, which outlives the whole edit).
- `package_json` is not mutated between the two original lookups, so the slice is identical.
- `trusted_dependencies` is read-only afterwards (`.iter()`, `.len()`, `copy_from_slice`); sharing with the de-dup loop is fine.
- The lifetime-erased `&'static [Expr]` does not borrow-conflict with `names_to_add.swap()` in the loop.
- Pure CLI-side AST editing on the install thread; no JS/WTFString/cross-thread hazards.

## Tracer

Runtime clone tracer: `to_vec` at PackageJSONEditor.rs:105 — 0 hits / 0 bytes in the recorded workload (workload didn't exercise `bun pm trust` with a pre-populated `trustedDependencies`), but the codepath is real for any project with existing trusted deps.

## Tests

`bun bd test test/cli/install/bun-install-lifecycle-scripts.test.ts`
- 99 pass / 4 fail with change; baseline origin/main 100 pass / 3 fail
- 3 shared failures are env-only (`node: command not found`, `bun: command not found` in stripped-PATH tests)
- the +1 was `does not use 100% cpu > install` CPU-threshold flake (794988 > 750000); re-run in isolation with the change: **4 pass / 0 fail**
- `-t "trust"` filter (52 tests covering `pm trust` / `trustedDependencies` editing): **52 pass / 0 fail**

Net: 0 new failures.