### PR TITLE
install: drop redundant Box re-allocation of INIT_CWD key

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1161,7 +1161,6 @@ fn configure_env_for_scripts_run(
 
     let init_cwd_entry = this.env_mut().map.get_or_put_without_value(b"INIT_CWD")?;
     if !init_cwd_entry.found_existing {
-        *init_cwd_entry.key_ptr = Box::<[u8]>::from(&**init_cwd_entry.key_ptr);
         *init_cwd_entry.value_ptr = dot_env::HashTableValue {
             value: Box::<[u8]>::from(strings::without_trailing_slash(
                 FileSystem::instance().top_level_dir(),


### PR DESCRIPTION
Callsite: `src/install/PackageManager.rs:1164` (`configure_env_for_scripts_run`)

Tracer: 0 hits / 0 bytes in the recorded run (path is `bun.once`-gated and only fires when `INIT_CWD` is unset and lifecycle scripts run), but it is a pure redundant alloc+copy+free every time it does fire.

#### Why this is safe

`dot_env::Map::get_or_put_without_value` wraps `StringArrayHashMap::get_or_put`, which on the miss path calls `box_key::<A>(key)` to allocate an owned `Box<[u8], Global>` before returning. So when `found_existing == false`, `key_ptr` already points at a freshly heap-owned `Box` containing `b"INIT_CWD"`. The deleted line read that box, allocated an identical `Box<[u8]>`, assigned it back, and dropped the original — same bytes, same allocator, no observable effect. The doc comment on `StringArrayHashMap::get_or_put` already calls this exact pattern out as a harmless redundancy kept so Zig-shaped call sites compile unchanged.

The original Zig (`PackageManager.zig:332`) needed the `dupe` because `std.StringArrayHashMap` stores the caller's borrowed `[]const u8` key slice; the Rust port's `K = Box<[u8]>` does not have that constraint. No `bun_core::String` / WTFStringImpl / AtomString involved, so no JS-lifetime or cross-thread concerns.

#### Tests

- `cargo check -p bun_bin` clean
- `bun bd test test/cli/install/bun-install-lifecycle-scripts.test.ts -t INIT_CWD` → 2 pass / 0 fail
- Full `bun-install-lifecycle-scripts.test.ts` → 0 new failures vs `origin/main` (3 pre-existing `bun: command not found` node-gyp shim failures reproduce identically on main)