### PR TITLE
install: borrow node_path instead of double-boxing in configure_env_for_scripts_run

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1195,10 +1195,9 @@ fn configure_env_for_scripts_run(
     {
         let mut node_path = PathBuffer::uninit();
         if let Some(node_path_z) = this.env_mut().get_node_path(paths_fs, &mut node_path) {
-            let node_path_owned: Box<[u8]> = Box::<[u8]>::from(node_path_z.as_ref());
             let _ = this
                 .env_mut()
-                .load_node_js_config(paths_fs, &node_path_owned)?;
+                .load_node_js_config(paths_fs, node_path_z.as_ref())?;
         } else {
             'brk: {
                 let current_path = this.env().get(b"PATH").unwrap_or(b"");


### PR DESCRIPTION
## What

Drop the redundant `Box::<[u8]>::from(node_path_z.as_ref())` at `src/install/PackageManager.rs:1198` and pass the borrowed slice directly to `load_node_js_config`.

## Why

The Zig original (`PackageManager.zig:357`) had to `default_allocator.dupe` before calling `loadNodeJSConfig` because that function stored the passed slice directly into a global. The Rust port moved that ownership-taking *inside* `load_node_js_config` — `src/dotenv/env_loader.rs:520` already does `Box::from(override_node)` when non-empty — so the caller-side Box is a leftover that heap-allocs, passes a borrow of it, and gets immediately re-boxed by the callee.

The else-branch at line 1213 already passes a borrowed `bun_path: &[u8]` without boxing, which is the same pattern.

## Safety

`get_node_path<'b>(&mut self, fs, buf: &'b mut PathBuffer) -> Option<&'b ZStr>` ties the return lifetime only to the stack `PathBuffer`, not to `self`. The `&mut self` borrow on `env_mut()` ends after the scrutinee evaluates (the body already calls `this.env_mut()` again, proving this), and the local `node_path` buffer is untouched in the body. `load_node_js_config` copies into its own `Box` + `map.put` (which dupes), so the stack buffer can safely die after the call returns.

No cross-thread, no JS, no GC, no `unsafe`.

## Tracer

Clone tracer: 0 hits / 0 bytes (cold path — only reached when `bun install` runs lifecycle scripts with `node` on PATH). Fix is one line with no signature changes.

## Tests

`bun bd test test/cli/install/bun-install-lifecycle-scripts.test.ts`: 100 pass / 3 fail. The 3 failures (`ensureTempNodeGypScript works` ×2, `node -p should work in postinstall scripts`) are pre-existing on `origin/main` in this environment (`bun: command not found` in PATH-stripped subprocess) and exercise the *else* branch, which is untouched. **0 new failures.**

`cargo check -p bun_bin --keep-going`: clean.