### PR TITLE
install: drop dead Patch.path field, make Patch Copy

### DIFF
--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -48,8 +48,8 @@ pub struct PackageInstall<'a> {
     pub lockfile: &'a Lockfile,
 }
 
+#[derive(Clone, Copy)]
 pub struct Patch {
-    pub path: Box<[u8]>,
     pub contents_hash: u64,
 }
 
@@ -892,17 +892,11 @@ impl<'a> PackageInstall<'a> {
             _ => self.verify_package_json_name_and_version(root_node_modules_dir, resolution.tag),
         };
 
-        if let Some(patch) = &self.patch {
+        if let Some(patch) = self.patch {
             if !verified {
                 return false;
             }
-            // TODO(port): borrowck — patch borrowed from self while calling &mut self method.
-            // Clone the small Patch fields or restructure.
-            let patch_copy = Patch {
-                path: patch.path.clone(),
-                contents_hash: patch.contents_hash,
-            };
-            return self.verify_patch_hash(&patch_copy, root_node_modules_dir);
+            return self.verify_patch_hash(&patch, root_node_modules_dir);
         }
         verified
     }

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1290,9 +1290,8 @@ impl<'a> PackageInstaller<'a> {
             destination_dir_subpath_buf: unsafe { (*subpath_buf_ptr).as_mut_slice() },
             // PORT NOTE: zig `arena: this.lockfile.allocator` dropped — global mimalloc.
             package_name: pkg_name,
-            patch: patch_patch.map(|p| package_install::Patch {
+            patch: patch_patch.map(|_| package_install::Patch {
                 contents_hash: patch_contents_hash.unwrap(),
-                path: Box::<[u8]>::from(p),
             }),
             package_version,
             node_modules: node_modules_ref.get(),


### PR DESCRIPTION
### What

Removes the `path: Box<[u8]>` field from `package_install::Patch` and derives `Copy` on the now-8-byte struct.

**Call site:** `src/install/PackageInstaller.rs:1295` (`Box::<[u8]>::from(p)`) plus the secondary `.clone()` at `src/install/PackageInstall.rs:902`.

**Tracer count:** 0 / 0 bytes (patched-deps path, not hit in the trace run) — but the field is dead regardless of count.

### Why this is safe

- The Zig original stored `path: string`, a free borrow into the lockfile string buffer. The Rust port boxed it solely for borrowck, then cloned it again in the `patch_copy` workaround so `&mut self` could be re-borrowed.
- No reader exists. The only consumers of `Patch` are:
  - `verify_patch_hash` — reads `.contents_hash` only (matches Zig `verifyPatchHash`).
  - `self.patch.is_none()` at PackageInstall.rs:2406.
  - `installer.patch.as_ref().map(|p| p.contents_hash)` at PackageInstaller.rs:1573.
- `rg "patch.path" src/install/*.zig` → none. The Zig field was already dead.
- `patch_patch: Option<&[u8]>` is kept as the `Some`/`None` discriminant so behavior is bit-for-bit identical.
- No cross-thread, GC, or arena hazard — pure dead-field removal. No `unsafe` added.

With `path` gone, `Patch` is `{ contents_hash: u64 }` and can be `Copy`, which deletes the `TODO(port): borrowck` clone-and-reborrow dance at the verify call site.

### Tests

```
bun bd test test/cli/install/bun-lock.test.ts
 9 pass / 0 fail   (includes the patchedDependencies fixture → exercises Patch construction + verify_patch_hash)

bun bd test test/cli/install/bun-install-retry.test.ts
 1 pass / 0 fail
```

`test/cli/install/bun-install-patch.test.ts` currently panics on origin/main (`f816284bc`) at `src/shell_parser/parse.rs:1932` (`debug_assert!(atoms.capacity() == 1)`) before any install code runs — reproduces with `bun bd -e 'await Bun.$`echo hi`'` on a clean main checkout, unrelated to this change.