### PR TITLE
Print integers in shorter scientific form when possible

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -3344,25 +3344,6 @@ pub fn itoa<T: ::itoa::Integer>(buf: &mut ItoaBuf, n: T) -> &[u8] {
     buf.format(n).as_bytes()
 }
 
-/// If `val` is exactly `10^e` for `e` in `4..=9`, return `Some(e)`; else `None`.
-///
-/// Used by `js_printer`'s non-negative-integer fast path to emit the
-/// minified-JS forms `1e4`..`1e9` (which are shorter than the full digit
-/// expansion). `e ≤ 3` is not shorter; `e ≥ 10` exceeds `u32::MAX` and is
-/// handled by the printer's f64 path.
-#[inline]
-pub const fn pow10_exp_1e4_to_1e9(val: u64) -> Option<u8> {
-    match val {
-        10_000 => Some(4),
-        100_000 => Some(5),
-        1_000_000 => Some(6),
-        10_000_000 => Some(7),
-        100_000_000 => Some(8),
-        1_000_000_000 => Some(9),
-        _ => None,
-    }
-}
-
 /// Format `value`
 /// into `buf` as base-10 ASCII and return the number of bytes written.
 /// Panics if `buf` is too small — callers size the buffer by the type's max

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -783,6 +783,43 @@ use bun_core::printer::{
 /// For support JavaScriptCore
 const ASCII_ONLY_ALWAYS_ON_UNLESS_MINIFYING: bool = true;
 
+/// Pick the shorter of decimal or `<prefix>e<exp>` scientific form for a
+/// non-negative integer. `digits` is the base-10 ASCII of the value (as
+/// produced by [`bun_core::fmt::itoa`]); `scratch` holds the scientific form
+/// and must be large enough for `digits.len() + 1` bytes (one more digit is
+/// replaced by `'e'`, and the exponent is always strictly shorter than the
+/// trailing-zero run it represents when we pick this branch). Returns a
+/// slice into `digits` or `scratch` — whichever is shorter.
+///
+/// This is the sole JS-integer formatting shortener and runs unconditionally;
+/// scientific form is a legal integer literal at every JS target we support.
+pub fn shortest_integer_form<'a>(digits: &'a [u8], scratch: &'a mut [u8]) -> &'a [u8] {
+    // Find the largest `exp` such that `val == prefix * 10^exp`.
+    let trailing_zeros = digits.iter().rev().take_while(|&&c| c == b'0').count();
+    // A lone "0" has no mantissa to strip; anything with <=2 trailing zeros
+    // can't be made shorter (`100` = `1e2`, both 3 chars).
+    if trailing_zeros < 3 || trailing_zeros == digits.len() {
+        return digits;
+    }
+    let prefix = &digits[..digits.len() - trailing_zeros];
+
+    // `<prefix>e<exp>` is `prefix.len() + 1 + exp_digits`. Shorter than
+    // `<prefix><zeros>` (prefix.len() + trailing_zeros) when
+    // `trailing_zeros > 1 + exp_digits`. For an f64-backed u52, `exp ≤ 15`.
+    let mut exp_buf = bun_core::fmt::ItoaBuf::new();
+    let exp_bytes = bun_core::fmt::itoa(&mut exp_buf, trailing_zeros as u64);
+    if exp_bytes.len() + 1 >= trailing_zeros {
+        return digits;
+    }
+
+    debug_assert!(scratch.len() >= prefix.len() + 1 + exp_bytes.len());
+    let (pre, rest) = scratch.split_at_mut(prefix.len());
+    pre.copy_from_slice(prefix);
+    rest[0] = b'e';
+    rest[1..1 + exp_bytes.len()].copy_from_slice(exp_bytes);
+    &scratch[..prefix.len() + 1 + exp_bytes.len()]
+}
+
 // Callers widen to i32 at the boundary.
 // PERF: `ascii_only` is a *runtime* arg so the large
 // callers (`write_pre_quoted_string_inner`, `estimate_length_for_utf8`) collapse to a
@@ -2622,13 +2659,10 @@ pub mod __gated_printer {
                 // However, they could also be signed or unsigned int 32 (when doing bit shifts)
                 // In this case, it's always going to unsigned since that conversion has already happened.
                 let val = float as u64;
-                if let Some(e) = bun_core::fmt::pow10_exp_1e4_to_1e9(val) {
-                    self.print(b"1e");
-                    self.print(&[b'0' + e]);
-                    return;
-                }
                 let mut buf = bun_core::fmt::ItoaBuf::new();
-                self.print(bun_core::fmt::itoa(&mut buf, val));
+                let digits = bun_core::fmt::itoa(&mut buf, val);
+                let mut sci_buf = [0u8; 24];
+                self.print(shortest_integer_form(digits, &mut sci_buf));
                 return;
             }
 

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -630,6 +630,42 @@ describe("bundler", () => {
       '+"æ"',
     ],
   });
+  // https://github.com/oven-sh/bun/issues/31074
+  // Integers with trailing zeros should print in `<prefix>e<exp>` form when
+  // shorter than the full decimal. The old integer fast path only recognised
+  // exact powers of ten (10000 → 1e4), so 160000 stayed `160000` instead of
+  // shrinking to `16e4`, and 320000000 stayed 9 chars instead of 4 (`32e7`).
+  itBundled("minify/IntegerTrailingZeroScientificNotation", {
+    files: {
+      "/entry.ts": `
+        capture(160000);
+        capture(10000);
+        capture(50000);
+        capture(2048000);
+        capture(320000000);
+        capture(1000);
+        capture(100);
+        capture(999);
+        capture(0);
+        capture(1);
+        capture(10);
+      `,
+    },
+    minifySyntax: true,
+    capture: [
+      "16e4",
+      "1e4",
+      "5e4",
+      "2048e3",
+      "32e7",
+      "1e3",
+      "100", // 3 chars == "1e2" 3 chars; keep decimal on tie
+      "999",
+      "0",
+      "1",
+      "10",
+    ],
+  });
   itBundled("minify/ImportMetaHotTreeShaking", {
     files: {
       "/entry.ts": `


### PR DESCRIPTION
Closes #31074.

## Repro

```ts
// server.ts
const server = Bun.serve({
  maxRequestBodySize: 160e3,
  port: 10000,
})
```

Before:

```console
$ bun build server.ts --target bun --format esm
var server = Bun.serve({
  maxRequestBodySize: 160000,  // 6 chars
  port: 1e4                    // 3 chars
});
```

After:

```console
$ bun build server.ts --target bun --format esm
var server = Bun.serve({
  maxRequestBodySize: 16e4,    // 4 chars
  port: 1e4
});
```

## Cause

`print_non_negative_float` in `src/js_printer/lib.rs` had a special case for **exact powers of 10** (via `pow10_exp_1e4_to_1e9` — 10000 → `1e4`, 100000 → `1e5`, …) but any other integer with a trailing-zero run fell through to a plain decimal write. So `port: 10000` correctly shrank to `1e4`, but `maxRequestBodySize: 160e3` actually **grew** by 2 chars as it was reprinted as `160000`.

Missed cases this hit in real minified output:

| Value | Old emission | Shorter form | Save |
| --- | --- | --- | --- |
| `160000` | `160000` (6) | `16e4` (4) | 2 |
| `50000` | `50000` (5) | `5e4` (3) | 2 |
| `2048000` | `2048000` (7) | `2048e3` (6) | 1 |
| `320000000` | `320000000` (9) | `32e7` (4) | 5 |

## Fix

Replaced the power-of-10 lookup with a general trailing-zero shortener: count the trailing `'0'`s on the itoa output, and if `<prefix>e<exp>` is shorter than the full decimal, emit that instead. Ties (`100` vs `1e2`) stay decimal, matching esbuild.

Round-trip safe for every u52 integer: `prefix × 10^exp` with `prefix ≤ 2^52` and `exp ≤ 15` is always exactly representable as `f64`.

## Verification

`test/bundler/bundler_minify.test.ts` — new test `minify/IntegerTrailingZeroScientificNotation` captures the emitted form of 11 values covering the bug cases, the pre-existing power-of-10 cases, edge cases (`0`, `1`, `10`, `100`, `999`), and the tie case (`100` stays `100`). Fail-before confirmed with `USE_SYSTEM_BUN=1` — all four bug values diff against main; passes on this branch.

Also re-ran `bundler_minify.test.ts` (33 pass), `bundler_edgecase.test.ts` (103 pass), `esbuild/default.test.ts` (150 pass), and `transpiler/transpiler.test.js` (114 pass) — no regressions.