### PR TITLE
fix(cli): parse inline values for optional short flags

### DIFF
--- a/src/clap/streaming.rs
+++ b/src/clap/streaming.rs
@@ -252,6 +252,12 @@ where
                 if next_is_eql && param.takes_value == clap::Values::None {
                     return Err(self.err(arg, Some(short), None, ArgError::DoesntTakeValue));
                 }
+                if next_is_eql {
+                    return Ok(Some(Arg {
+                        param,
+                        value: Some(&arg[next_index + 1..]),
+                    }));
+                }
                 return Ok(Some(Arg { param, value: None }));
             }
 
@@ -416,7 +422,7 @@ mod tests {
 
     #[test]
     fn short_params() {
-        let params: [clap::Param<u8>; 4] = [
+        let params: [clap::Param<u8>; 5] = [
             clap::Param {
                 id: 0,
                 names: clap::Names::short(b'a'),
@@ -439,17 +445,25 @@ mod tests {
                 takes_value: clap::Values::Many,
                 ..Default::default()
             },
+            clap::Param {
+                id: 4,
+                names: clap::Names::short(b'e'),
+                takes_value: clap::Values::OneOptional,
+                ..Default::default()
+            },
         ];
 
         let a = &params[0];
         let b = &params[1];
         let c = &params[2];
         let d = &params[3];
+        let e = &params[4];
 
         test_no_err(
             &params,
             &[
-                b"-a", b"-b", b"-ab", b"-ba", b"-c", b"0", b"-c=0", b"-ac", b"0", b"-ac=0", b"-d=0",
+                b"-a", b"-b", b"-ab", b"-ba", b"-c", b"0", b"-c=0", b"-ac", b"0", b"-ac=0",
+                b"-d=0", b"-e=1", b"-e",
             ],
             &[
                 Arg {
@@ -503,6 +517,14 @@ mod tests {
                 Arg {
                     param: d,
                     value: Some(b"0"),
+                },
+                Arg {
+                    param: e,
+                    value: Some(b"1"),
+                },
+                Arg {
+                    param: e,
+                    value: None,
                 },
             ],
         );

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -142,5 +142,29 @@ describe("bun", () => {
         fs.unlinkSync(path);
       }
     });
+
+    test("-c=path loads bunfig like --config=path, issue #21431", () => {
+      using dir = tempDir("config-short-flag-value", {
+        "custom.toml": `preload = ["./preload.ts"]`,
+        "preload.ts": `globalThis.__bunConfigLoaded = true;`,
+        "index.ts": `console.log(globalThis.__bunConfigLoaded === true ? "loaded" : "missing");`,
+      });
+
+      for (const args of [
+        ["-c=custom.toml", "index.ts"],
+        ["-c=custom.toml", "run", "index.ts"],
+        ["run", "-c=custom.toml", "index.ts"],
+      ]) {
+        const { stdout, exitCode } = Bun.spawnSync({
+          cmd: [bunExe(), ...args],
+          cwd: String(dir),
+          env: bunEnv,
+          stderr: "inherit",
+        });
+
+        expect(stdout.toString()).toBe("loaded\n");
+        expect(exitCode).toBe(0);
+      }
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes #21431.

Short optional CLI flags such as `-c=custom.toml` were parsed as bare flags before the short-option parser checked the inline `=` value. This makes the `Values::OneOptional` short-flag path return the value after `=` while preserving the existing `DoesntTakeValue` error for no-value flags like `-a=value`.

The regression test covers the reported config forms:

- `bun -c=custom.toml index.ts`
- `bun -c=custom.toml run index.ts`
- `bun run -c=custom.toml index.ts`

### How did you verify your code works?

- `USE_SYSTEM_BUN=1 bun test test/cli/bun.test.ts -t "-c=path loads bunfig"` (fails on system Bun 1.3.14 with `missing`, confirming the regression)
- `git diff --check`
- `PATH="$HOME/.cargo/bin:$PATH" SDKROOT="$(xcrun --show-sdk-path)" DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer RUSTFLAGS="-C link-arg=-isysroot -C link-arg=$(xcrun --show-sdk-path)" cargo test -p bun_clap short_params`
- `build/debug/bun-debug test test/cli/bun.test.ts -t "-c=path loads bunfig"`

Local caveat: my Homebrew LLVM 21 config points at a missing CommandLineTools `MacOSX26.sdk`, so the full `bun bd test ...` command needed local generated-build env fixes to use the installed Xcode SDK/Apple clang for host/Rust build edges. No generated files are included in this PR.

Note: I used Codex to help inspect the issue/code path and draft the tests, then reviewed the final diff and ran the listed verification commands locally.
