### PR TITLE
Handle exceptions from require.cache / Module.wrapper lazy builtins

### DIFF
--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -730,7 +730,11 @@ JSC_DEFINE_CUSTOM_GETTER(nodeModuleWrapper,
 
     NakedPtr<JSC::Exception> returnedException = nullptr;
     auto result = JSC::profiledCall(global, JSC::ProfilingReason::API, cb, callData, JSC::jsUndefined(), args, returnedException);
-    ASSERT(!returnedException);
+    if (returnedException) [[unlikely]] {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        throwException(global, scope, returnedException.get());
+        return {};
+    }
     ASSERT(result.isCell());
     return JSC::JSValue::encode(result);
 }
@@ -1110,8 +1114,11 @@ void addNodeModuleConstructorProperties(JSC::VM& vm,
 
             NakedPtr<JSC::Exception> returnedException = nullptr;
             auto result = JSC::profiledCall(globalObject, ProfilingReason::API, function, JSC::getCallData(function), globalObject, ArgList(), returnedException);
-            ASSERT(!returnedException);
-            init.set(result.toObject(globalObject));
+            if (returnedException || !result.isObject()) [[unlikely]] {
+                init.set(JSC::constructEmptyObject(vm, globalObject->nullPrototypeObjectStructure()));
+                return;
+            }
+            init.set(result.getObject());
         });
 
     globalObject->m_lazyRequireExtensionsObject.initLater(

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -251,4 +251,52 @@ describe.concurrent("node-module-module", () => {
    ./k.cjs (seen)`);
     expect(await proc.exited).toBe(0);
   });
+
+  test.each(["Map", "Proxy", "Symbol"])(
+    "require.cache / Module._cache does not crash when %s has been overwritten",
+    async ctor => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `globalThis.${ctor} = undefined;
+           const c1 = require.cache;
+           const c2 = require("module")._cache;
+           if (typeof c1 !== "object" || c1 === null) throw new Error("require.cache");
+           if (typeof c2 !== "object" || c2 === null) throw new Error("Module._cache");
+           console.log("ok");`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("ASSERTION FAILED");
+      expect(stdout.trim()).toBe("ok");
+      expect(exitCode).toBe(0);
+    },
+  );
+
+  test("Module.wrapper throws instead of crashing when Proxy has been overwritten", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `globalThis.Proxy = undefined;
+         try {
+           require("module").wrapper;
+           console.log("no-throw");
+         } catch (e) {
+           console.log("threw", e instanceof TypeError);
+         }`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("ASSERTION FAILED");
+    expect(stdout.trim()).toBe("threw true");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -268,10 +268,9 @@ describe.concurrent("node-module-module", () => {
         ],
         env: bunEnv,
         stdout: "pipe",
-        stderr: "pipe",
+        stderr: "inherit",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).not.toContain("ASSERTION FAILED");
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
       expect(stdout.trim()).toBe("ok");
       expect(exitCode).toBe(0);
     },
@@ -292,10 +291,9 @@ describe.concurrent("node-module-module", () => {
       ],
       env: bunEnv,
       stdout: "pipe",
-      stderr: "pipe",
+      stderr: "inherit",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).not.toContain("ASSERTION FAILED");
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
     expect(stdout.trim()).toBe("threw true");
     expect(exitCode).toBe(0);
   });


### PR DESCRIPTION
Fuzzilli found a flaky assertion failure at `NodeModuleModule.cpp:1113`:

```
ASSERTION FAILED: !returnedException
unified/../../../src/jsc/modules/NodeModuleModule.cpp(1113) : auto Bun::addNodeModuleConstructorProperties(...)::(anonymous class)::operator()(...) const
```

## What

The builtins backing `require.cache` (`createRequireCache`) and `Module.wrapper` (`getWrapperArrayProxy`) use `new Map`, `new Proxy` and `Symbol.for`, which go through the global object and can throw if those constructors have been overwritten (or under memory pressure, which is what Fuzzilli hit). Both C++ call sites asserted that no exception was returned, aborting the process in debug builds.

Deterministic repro:
```js
Map = undefined;
require.cache; // ASSERTION FAILED: !returnedException
```

## How

- **`m_lazyRequireCacheObject` initializer**: fall back to a plain null-prototype object when the builtin throws. We don't rethrow here because the `LazyProperty` initializer must always call `init.set()` (`callFunc` has a `RELEASE_ASSERT` on it), and one caller (`getModuleCacheObject`) is a static hash table `PropertyCallback` where `JSObject::get` asserts if a slot is returned with a pending exception. `profiledCall(..., NakedPtr<Exception>&)` already clears the VM's pending exception, so no extra catch scope is needed.
- **`nodeModuleWrapper` custom getter**: rethrow the exception as a normal JS `TypeError` (custom accessors are allowed to throw).

Also replaced the `result.toObject(globalObject)` call with a direct `result.getObject()` after verifying `result.isObject()`, avoiding an unchecked throw scope on that path.