### PR TITLE
buffer: preserve high-bit bytes in `buf.write(str, 'ascii')`

### DIFF
--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -396,6 +396,14 @@ static JSC::EncodedJSValue writeToBuffer(JSC::JSGlobalObject* lexicalGlobalObjec
 
     size_t written = 0;
 
+    // Per Node docs, `'ascii'` on write is equivalent to `'latin1'` —
+    // verbatim byte copy, no 7-bit masking. The writeLatin1/writeUTF16
+    // ascii arm masks because the ascii *decode* path (jsBufferToStringFromBytes)
+    // reuses it; on encode we route ascii through the latin1 branch instead.
+    auto encodingForWrite = encoding == WebCore::BufferEncodingType::ascii
+        ? WebCore::BufferEncodingType::latin1
+        : encoding;
+
     switch (encoding) {
     case WebCore::BufferEncodingType::utf8:
     case WebCore::BufferEncodingType::latin1:
@@ -408,10 +416,10 @@ static JSC::EncodedJSValue writeToBuffer(JSC::JSGlobalObject* lexicalGlobalObjec
 
         if (view->is8Bit()) {
             const auto span = view->span8();
-            written = Bun__encoding__writeLatin1(span.data(), span.size(), reinterpret_cast<unsigned char*>(castedThis->vector()) + offset, length, static_cast<uint8_t>(encoding));
+            written = Bun__encoding__writeLatin1(span.data(), span.size(), reinterpret_cast<unsigned char*>(castedThis->vector()) + offset, length, static_cast<uint8_t>(encodingForWrite));
         } else {
             const auto span = view->span16();
-            written = Bun__encoding__writeUTF16(span.data(), span.size(), reinterpret_cast<unsigned char*>(castedThis->vector()) + offset, length, static_cast<uint8_t>(encoding));
+            written = Bun__encoding__writeUTF16(span.data(), span.size(), reinterpret_cast<unsigned char*>(castedThis->vector()) + offset, length, static_cast<uint8_t>(encodingForWrite));
         }
         break;
     }

--- a/src/runtime/node/buffer.rs
+++ b/src/runtime/node/buffer.rs
@@ -26,6 +26,16 @@ mod _impl {
             // SAFETY: caller guarantees buf_ptr[0..fill_length] is a valid writable buffer.
             let buf = unsafe { core::slice::from_raw_parts_mut(buf_ptr, fill_length) };
 
+            // Per Node docs, `'ascii'` on encode is equivalent to `'latin1'` (verbatim
+            // byte copy, no 7-bit masking). The shared write_u8::<Ascii> helper masks
+            // because the ascii decode path reuses it; fold ascii → latin1 here so
+            // Buffer.fill(str, 'ascii') / Buffer.alloc(n, str, 'ascii') match Node.
+            let encoding = if matches!(encoding, Encoding::Ascii) {
+                Encoding::Latin1
+            } else {
+                encoding
+            };
+
             // PORT NOTE: encoder::write_u8/write_u16 take the encoding as a const-generic
             // `u8` (stable-Rust workaround for `adt_const_params`) — `dispatch_encoding!`
             // expands the runtime `encoding` into nine monomorphized arms.

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -379,6 +379,23 @@ for (let withOverridenBufferWrite of [false, true]) {
         expect(writeTest.toString()).toBe("nodejs");
       });
 
+      // https://github.com/oven-sh/bun/issues/31083
+      // Per Node docs, `'ascii'` on write is equivalent to `'latin1'`
+      // (verbatim byte copy, not 7-bit masking).
+      it("write with 'ascii' encoding preserves high-bit bytes (Node parity)", () => {
+        const buf = Buffer.alloc(4, 0);
+        buf.write(String.fromCharCode(128), 0, "ascii");
+        buf.write(String.fromCharCode(129), 1, "ascii");
+        buf.write(String.fromCharCode(128), 2, "latin1");
+        buf.write(String.fromCharCode(129), 3, "latin1");
+        expect([buf[0], buf[1], buf[2], buf[3]]).toEqual([128, 129, 128, 129]);
+
+        // Multi-byte Latin-1 input via 'ascii' write should also copy verbatim.
+        const buf2 = Buffer.alloc(4, 0);
+        buf2.write(String.fromCharCode(128, 129, 250, 255), 0, "ascii");
+        expect([buf2[0], buf2[1], buf2[2], buf2[3]]).toEqual([128, 129, 250, 255]);
+      });
+
       it("ASCII slice", () => {
         const buf = Buffer.allocUnsafe(256);
         const str = "hello world";

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -380,9 +380,10 @@ for (let withOverridenBufferWrite of [false, true]) {
       });
 
       // https://github.com/oven-sh/bun/issues/31083
-      // Per Node docs, `'ascii'` on write is equivalent to `'latin1'`
-      // (verbatim byte copy, not 7-bit masking).
-      it("write with 'ascii' encoding preserves high-bit bytes (Node parity)", () => {
+      // Per Node docs, `'ascii'` on encode is equivalent to `'latin1'`
+      // (verbatim byte copy, not 7-bit masking). Covers write / fill / alloc.
+      it("'ascii' encoding preserves high-bit bytes on encode (Node parity)", () => {
+        // write()
         const buf = Buffer.alloc(4, 0);
         buf.write(String.fromCharCode(128), 0, "ascii");
         buf.write(String.fromCharCode(129), 1, "ascii");
@@ -390,10 +391,18 @@ for (let withOverridenBufferWrite of [false, true]) {
         buf.write(String.fromCharCode(129), 3, "latin1");
         expect([buf[0], buf[1], buf[2], buf[3]]).toEqual([128, 129, 128, 129]);
 
-        // Multi-byte Latin-1 input via 'ascii' write should also copy verbatim.
+        // write() with multi-byte Latin-1 input
         const buf2 = Buffer.alloc(4, 0);
         buf2.write(String.fromCharCode(128, 129, 250, 255), 0, "ascii");
         expect([buf2[0], buf2[1], buf2[2], buf2[3]]).toEqual([128, 129, 250, 255]);
+
+        // fill()
+        const buf3 = Buffer.alloc(4).fill(String.fromCharCode(128), "ascii");
+        expect([buf3[0], buf3[1], buf3[2], buf3[3]]).toEqual([128, 128, 128, 128]);
+
+        // alloc() with fill string
+        const buf4 = Buffer.alloc(4, String.fromCharCode(129), "ascii");
+        expect([buf4[0], buf4[1], buf4[2], buf4[3]]).toEqual([129, 129, 129, 129]);
       });
 
       it("ASCII slice", () => {


### PR DESCRIPTION
Fixes #31083.

## Repro

```js
const buf = Buffer.alloc(4, 0);
buf.write(String.fromCharCode(128), 0, 'ascii');
buf.write(String.fromCharCode(129), 1, 'ascii');
buf.write(String.fromCharCode(128), 2, 'latin1');
buf.write(String.fromCharCode(129), 3, 'latin1');
console.log(buf[0], buf[1], buf[2], buf[3]);
```

**Node 22** → `128 129 128 129`
**Bun (pre-fix)** → `0 1 128 129`

Per [Node docs](https://nodejs.org/api/buffer.html#buffers-and-character-encodings): on write, `'ascii'` is "equivalent to using `'latin1'`" — verbatim byte copy, not 7-bit masking.

## Cause

`Buffer.prototype.write(str, 'ascii')` / `Buffer.prototype.asciiWrite(str, …)` both land in `writeToBuffer` (`src/jsc/bindings/JSBuffer.cpp`), which dispatches to `Bun__encoding__writeLatin1`. That function's `Ascii` arm (`src/runtime/webcore/encoding.rs`, `write_u8::<Ascii>`) calls `copy_latin1_into_ascii`, which masks every non-pure-ASCII byte with `0x7f` (`128 & 0x7f = 0`, `129 & 0x7f = 1`).

The masking can't be removed from `write_u8::<Ascii>` outright because the ascii **decode** path (`buf.toString('ascii')` → `jsBufferToStringFromBytes`) reuses it to convert a Latin-1 input buffer into an ASCII output string — `Buffer.from("\\xa4", "binary").toString("ascii")` must still yield `"$"` for Node parity.

## Fix

In `writeToBuffer`, when the requested encoding is `ascii`, dispatch to `writeLatin1`/`writeUTF16` with encoding `latin1` instead. The encode and decode paths go their separate ways at the C++ boundary, and the shared Rust helper keeps its (documented-correct-for-decode) behaviour.

The `Buffer.from(str, 'ascii')` constructor one frame up already does this same substitution (`case ascii: // ascii is a noop for latin1`).

## Verification

- New test: `test/js/node/buffer.test.js` → `write with 'ascii' encoding preserves high-bit bytes (Node parity)` covers both Latin-1 input characters (128, 129, 250, 255) and exercises both the native `Buffer.prototype.write` path and the wrapper path that calls `.asciiWrite` directly.
- Gate: fails against the unpatched build (`0 1 128 129`), passes with the fix.
- `bun bd test test/js/node/buffer.test.js` — 464/464 pass (previously 2 fail, 462 pass — the `Buffer.from latin1 vs ascii` test which asserts both `toString('ascii')` masks AND `Buffer.from(…, 'ascii')` preserves bytes was already passing; this fix doesn't touch either path).
- `bun bd test/js/node/test/parallel/test-buffer-alloc.js`, `test-buffer-ascii.js`, `test-buffer-write.js`, `test-buffer-tostring.js` — all exit 0.
- `bun bd test test/js/node/string_decoder/string-decoder.test.js` — 84/84 pass.
