### PR TITLE
Fix unchecked exception in Bun.plugin target conversion

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -302,8 +302,11 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
     auto targetValue = obj->getIfPropertyExists(globalObject, Identifier::fromString(vm, "target"_s));
     RETURN_IF_EXCEPTION(throwScope, {});
     if (targetValue) {
-        if (auto* targetJSString = targetValue.toStringOrNull(globalObject)) {
+        auto* targetJSString = targetValue.toStringOrNull(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (targetJSString) {
             String targetString = targetJSString->value(globalObject);
+            RETURN_IF_EXCEPTION(throwScope, {});
             if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
                 JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
                 return {};

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -560,3 +560,17 @@ it("recursion throws stack overflow at entry point", () => {
 
   expect(result.stderr.toString()).toContain("RangeError: Maximum call stack size exceeded.");
 });
+
+it("does not crash when target property throws on string conversion", () => {
+  const badTarget = {
+    toString() {
+      return {};
+    },
+    valueOf() {
+      return {};
+    },
+  };
+  expect(() => {
+    plugin({ name: "bad-target", target: badTarget as any, setup() {} });
+  }).toThrow();
+});


### PR DESCRIPTION
## What does this PR do?

Fixes an `ExceptionScope::assertNoException()` assertion failure in debug builds when `Bun.plugin()` is called with a `target` option that throws during string conversion (e.g. an object whose `toString`/`valueOf` return non-primitives).

`toStringOrNull()` returns `nullptr` and leaves the exception pending. The previous code only checked for a non-null return and fell through to construct the builder object and call `setup()` with the exception still pending.

### Repro
```js
const badTarget = { toString: () => ({}), valueOf: () => ({}) };
Bun.plugin({ name: "x", target: badTarget, setup() {} });
```

Before:
```
ASSERTION FAILED: Unexpected exception observed
!exception()
ExceptionScope.h(61) : void JSC::ExceptionScope::assertNoException()
```

After: the `TypeError: No default value` exception is propagated to JS and can be caught.

Found by Fuzzilli. Fingerprint: `2fddca8bb30d77a3`