### PR TITLE
fix(install): reject corrupt PatchedDep bool byte from hostile lockfile

### DIFF
--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1260,7 +1260,7 @@ impl<'a> PackageInstaller<'a> {
                 }
                 break 'brk (None, None, None, false);
             };
-            debug_assert!(!patchdep.patchfile_hash_is_null);
+            debug_assert!(!patchdep.patchfile_hash_is_null());
             // if (!patchdep.patchfile_hash_is_null) {
             //     this.manager.enqueuePatchTask(PatchTask.newCalcPatchHash(this, package_id, name_and_version_hash, dependency_id, url: string))
             // }

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -180,7 +180,7 @@ impl PackageManager {
                     };
                     // Zig: `defer out_name_and_version_hash.* = name_and_version_hash;`
                     // Runs on every exit path after this point.
-                    if patched_dep.patchfile_hash_is_null {
+                    if patched_dep.patchfile_hash_is_null() {
                         *out_name_and_version_hash = Some(name_and_version_hash);
                         self.set_preinstall_state(pkg.meta.id, PreinstallState::CalcPatchHash);
                         return PreinstallState::CalcPatchHash;

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -427,7 +427,7 @@ pub fn install_with_manager(
                         let mut iter = lockfile.patched_dependencies.iter();
                         while let Some((key, value)) = iter.next() {
                             let pkg_name_and_version_hash = *key;
-                            debug_assert!(value.patchfile_hash_is_null);
+                            debug_assert!(value.patchfile_hash_is_null());
                             let gop = lf.patched_dependencies.entry(pkg_name_and_version_hash);
                             // PORT NOTE: ArrayHashMap getOrPut semantics → entry API approximation
                             match gop {

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -1323,7 +1323,7 @@ fn clean_migrate_patched_dependencies_cold(
         .iter()
         .zip(old.patched_dependencies.values().iter())
     {
-        debug_assert!(!v.patchfile_hash_is_null);
+        debug_assert!(!v.patchfile_hash_is_null());
         let mut patchdep = *v;
         patchdep.path = builder
             .append::<SemverString>(patchdep.path.slice(old.buffers.string_bytes.as_slice()));
@@ -3372,7 +3372,12 @@ pub struct PatchedDep {
     /// e.g. "patches/is-even@1.0.0.patch"
     pub path: SemverString,
     _padding: [u8; 7],
-    pub patchfile_hash_is_null: bool,
+    // Stored as `u8` (not `bool`) so that every bit pattern is a valid
+    // value. The lockfile reader transmutes raw bytes into `&[PatchedDep]`
+    // (`Buffers::read_array`), and an attacker-controlled byte here would
+    // otherwise produce an invalid `bool` and immediate UB (audit witness
+    // EXP-036). Only `0` (present) and `1` (null) are accepted.
+    patchfile_hash_is_null: u8,
     /// the hash of the patch file contents
     __patchfile_hash: u64,
 }
@@ -3382,13 +3387,16 @@ impl Default for PatchedDep {
         PatchedDep {
             path: SemverString::default(),
             _padding: [0; 7],
-            patchfile_hash_is_null: true,
+            patchfile_hash_is_null: PatchedDep::PATCHFILE_HASH_NULL,
             __patchfile_hash: 0,
         }
     }
 }
 
 impl PatchedDep {
+    const PATCHFILE_HASH_PRESENT: u8 = 0;
+    const PATCHFILE_HASH_NULL: u8 = 1;
+
     /// Construct with just `path` set (Zig: `.{ .path = path }`). Exists because
     /// the explicit-padding / private-hash fields make the `..Default::default()`
     /// struct-update form unusable from sibling modules.
@@ -3398,13 +3406,31 @@ impl PatchedDep {
         this
     }
 
+    #[inline]
+    pub fn patchfile_hash_is_null(&self) -> bool {
+        debug_assert!(self.has_valid_patchfile_hash_flag());
+        self.patchfile_hash_is_null == Self::PATCHFILE_HASH_NULL
+    }
+
+    #[inline]
+    pub(crate) fn has_valid_patchfile_hash_flag(&self) -> bool {
+        matches!(
+            self.patchfile_hash_is_null,
+            Self::PATCHFILE_HASH_PRESENT | Self::PATCHFILE_HASH_NULL
+        )
+    }
+
     pub fn set_patchfile_hash(&mut self, val: Option<u64>) {
-        self.patchfile_hash_is_null = val.is_none();
+        self.patchfile_hash_is_null = if val.is_none() {
+            Self::PATCHFILE_HASH_NULL
+        } else {
+            Self::PATCHFILE_HASH_PRESENT
+        };
         self.__patchfile_hash = val.unwrap_or(0);
     }
 
     pub fn patchfile_hash(&self) -> Option<u64> {
-        if self.patchfile_hash_is_null {
+        if self.patchfile_hash_is_null() {
             None
         } else {
             Some(self.__patchfile_hash)

--- a/src/install/lockfile/bun.lockb.rs
+++ b/src/install/lockfile/bun.lockb.rs
@@ -258,7 +258,7 @@ pub fn save(
 
     if this.patched_dependencies.count() > 0 {
         for patched_dep in this.patched_dependencies.values() {
-            debug_assert!(!patched_dep.patchfile_hash_is_null);
+            debug_assert!(!patched_dep.patchfile_hash_is_null());
         }
 
         stream.write_all(&HAS_PATCHED_DEPENDENCIES_TAG.to_ne_bytes())?;
@@ -599,14 +599,19 @@ pub fn load(
 
                 // PORT NOTE: Zig: `var map = lockfile.patched_dependencies; defer lockfile.patched_dependencies = map;`
                 let map = &mut lockfile.patched_dependencies;
-
-                map.ensure_total_capacity(patched_dependencies_name_and_version_hashes.len())?;
                 let patched_dependencies_paths: Vec<PatchedDep> = buffers::read_array(stream)?;
 
-                debug_assert_eq!(
-                    patched_dependencies_name_and_version_hashes.len(),
-                    patched_dependencies_paths.len()
-                );
+                if patched_dependencies_name_and_version_hashes.len()
+                    != patched_dependencies_paths.len()
+                    || patched_dependencies_paths
+                        .iter()
+                        .any(|patched_dep| !patched_dep.has_valid_patchfile_hash_flag())
+                {
+                    return Err(bun_core::err!("CorruptLockfile"));
+                }
+
+                map.ensure_total_capacity(patched_dependencies_name_and_version_hashes.len())?;
+
                 for (name_hash, patch_path) in patched_dependencies_name_and_version_hashes
                     .iter()
                     .zip(patched_dependencies_paths.iter())

--- a/test/cli/install/bun-lockb.test.ts
+++ b/test/cli/install/bun-lockb.test.ts
@@ -1,7 +1,8 @@
 import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, expect, it } from "bun:test";
-import { copyFile, exists, open, rm, writeFile } from "fs/promises";
+import { copyFile, exists, mkdir, open, rm, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env, isWindows, runBunInstall, stderrForInstall, VerdaccioRegistry } from "harness";
+import { Buffer } from "node:buffer";
 import { join } from "path";
 
 const registry = new VerdaccioRegistry();
@@ -13,6 +14,21 @@ beforeAll(async () => {
 afterAll(() => {
   registry.stop();
 });
+
+const patchedDepPrefix = Buffer.from("\n<install.lockfile.PatchedDep> 24 sizeof, 8 alignof\n");
+const patchedDepHashIsNullOffset = 15;
+
+const noDepsPatch = /* patch */ `diff --git a/index.js b/index.js
+index 1034e955e3ad1d3c4eebdccf0b8f05e6b72fef59..9e9388fc3b7ea38889fc0f47d5cb1d7db1e4d1af 100644
+--- a/index.js
++++ b/index.js
+@@ -1,4 +1,5 @@
+ module.exports = require(\`./package.json\`);
++module.exports.patched = true;
+
+ for (const key of [\`dependencies\`, \`devDependencies\`, \`peerDependencies\`]) {
+   for (const dep of Object.keys(module.exports[key] || {})) {
+`;
 
 it("should not print anything to stderr when running bun.lockb", async () => {
   const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: false } });
@@ -80,6 +96,54 @@ it("should not print anything to stderr when running bun.lockb", async () => {
   expect(stderrOutput).toBe("");
 
   expect(await exited).toBe(0);
+});
+
+it("rejects a non-canonical PatchedDep flag in a binary lockfile", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: false } });
+
+  await mkdir(join(packageDir, "patches"));
+  await writeFile(join(packageDir, "patches/no-deps@1.0.0.patch"), noDepsPatch);
+  await writeFile(
+    packageJson,
+    JSON.stringify({
+      name: "patched-binary-lockfile-package",
+      version: "1.0.0",
+      dependencies: {
+        "no-deps": "1.0.0",
+      },
+      patchedDependencies: {
+        "no-deps@1.0.0": "patches/no-deps@1.0.0.patch",
+      },
+    }),
+  );
+
+  await runBunInstall(env, packageDir);
+
+  const lockfilePath = join(packageDir, "bun.lockb");
+  const lockfile = Buffer.from(await file(lockfilePath).arrayBuffer());
+  const prefixOffset = lockfile.indexOf(patchedDepPrefix);
+  expect(prefixOffset).toBeGreaterThanOrEqual(0);
+  expect(lockfile.indexOf(patchedDepPrefix, prefixOffset + patchedDepPrefix.length)).toBe(-1);
+
+  const patchedDepStart = Math.ceil((prefixOffset + patchedDepPrefix.length) / 8) * 8;
+  const patchedDepHashIsNullByte = patchedDepStart + patchedDepHashIsNullOffset;
+  expect(lockfile[patchedDepHashIsNullByte]).toBe(0);
+  lockfile[patchedDepHashIsNullByte] = 0xff;
+  await writeFile(lockfilePath, lockfile);
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "bun.lockb"],
+    cwd: packageDir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const stdoutOutput = await stdout.text();
+  const stderrOutput = await stderr.text();
+  expect(stdoutOutput).toBe("");
+  expect(stderrOutput).toContain("CorruptLockfile");
+  expect(await exited).not.toBe(0);
 });
 
 it("should continue using a binary lockfile if it exists", async () => {


### PR DESCRIPTION
## Summary

Closes UB audit finding **EXP-036** from #30903.

`PatchedDep.patchfile_hash_is_null: bool` was deserialized from attacker-controlled lockfile bytes via `Buffers::read_array::<PatchedDep>`, which transmutes raw bytes into `&[PatchedDep]`. A tampered byte (e.g. `0xff`) in that slot produces an invalid `bool` and **immediate UB at the slice-cast**, before any downstream read.

Audit Miri witness (Bucket 4/15 — validity invariant):

```
error: Undefined Behavior: constructing invalid value of type bool:
  encountered 0xff, but expected a boolean
```

## Fix

1. **Type change** — `patchfile_hash_is_null: bool` → `u8`. Every bit pattern is now a valid value, so `read_array::<PatchedDep>` no longer constructs an invalid `bool` during the transmute. The 24-byte struct layout (`24 sizeof, 8 alignof`, asserted in `bun.lockb.rs`) is preserved exactly: `SemverString` (8) + `_padding` (7) + flag byte (1) + `u64` hash (8).

2. **Reject, don't normalize** — the binary lockfile reader (`bun.lockb.rs`) now actively rejects non-canonical flag bytes at the trust boundary:
   - `1` = patchfile hash is null
   - `0` = patchfile hash is present
   - anything else → `Err(CorruptLockfile)` *before* reserving map capacity
   - Mismatched `keys.len() != values.len()` also rejected (used to be release-build `zip` truncation)

3. **Canonical accessor** — `fn patchfile_hash_is_null(&self) -> bool` checks `== PATCHFILE_HASH_NULL` (not `!= 0`) and `debug_assert!`s the canonical invariant, so any drift from the trust boundary trips in debug.

4. **In-repo regression test** in `test/cli/install/bun-lockb.test.ts` — builds a real `bun.lockb` with `patchedDependencies`, asserts the `PatchedDep` prefix appears exactly once, asserts the target byte starts as canonical `0`, flips it to `0xff`, and asserts `bun bun.lockb` fails with `CorruptLockfile`.

## Test plan

- [x] `cargo check -p bun_install` clean
- [x] `cargo check --workspace` clean
- [x] `bun bd test test/cli/install/bun-lockb.test.ts -t \"rejects a non-canonical PatchedDep flag in a binary lockfile\"` passes
- [x] Standalone Miri witness: pre-fix shape stops at the transmute with the audit's exact error; post-fix shape runs clean

Refs #30903.

🤖 Generated with [Claude Code](https://claude.com/claude-code)