### PR TITLE
Fix crash when constructing a mock function that returns a primitive

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -852,6 +852,19 @@ static EncodedJSValue jsMockFunctionCallOrConstruct(JSGlobalObject* lexicalGloba
         }
         thisValue = JSC::constructEmptyObject(globalObject, prototype);
         RETURN_IF_EXCEPTION(scope, {});
+
+        if (auto* instances = fn->instances.get()) {
+            instances->push(globalObject, thisValue);
+            RETURN_IF_EXCEPTION(scope, {});
+        } else {
+            JSC::ObjectInitializationScope object(vm);
+            instances = JSC::JSArray::tryCreateUninitializedRestricted(
+                object,
+                globalObject->arrayStructureForIndexingTypeDuringAllocation(JSC::ArrayWithContiguous),
+                1);
+            instances->initializeIndex(object, 0, thisValue);
+            fn->instances.set(vm, fn, instances);
+        }
     }
 
     auto encodeReturn = [&](JSValue value) -> EncodedJSValue {

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -86,6 +86,7 @@ inline To tryJSDynamicCast(JSC::WriteBarrier<WriteBarrierT>& from)
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionCall);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionConstruct);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetter_mockGetLastCall);
@@ -462,7 +463,7 @@ public:
     }
 
     JSMockFunction(JSC::VM& vm, JSC::Structure* structure, CallbackKind wrapKind)
-        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
+        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionConstruct)
     {
         initMock();
     }
@@ -826,7 +827,7 @@ static JSValue createMockResult(JSC::VM& vm, Zig::GlobalObject* globalObject, co
     return result;
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+static EncodedJSValue jsMockFunctionCallOrConstruct(JSGlobalObject* lexicalGlobalObject, CallFrame* callframe, bool isConstructCall)
 {
     Zig::GlobalObject* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
@@ -839,6 +840,26 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
 
     JSC::ArgList args = JSC::ArgList(callframe);
     JSValue thisValue = callframe->thisValue();
+
+    if (isConstructCall) {
+        JSValue newTarget = callframe->newTarget();
+        JSObject* prototype = globalObject->objectPrototype();
+        if (newTarget && newTarget.isObject()) {
+            JSValue prototypeValue = asObject(newTarget)->get(globalObject, vm.propertyNames->prototype);
+            RETURN_IF_EXCEPTION(scope, {});
+            if (prototypeValue.isObject())
+                prototype = asObject(prototypeValue);
+        }
+        thisValue = JSC::constructEmptyObject(globalObject, prototype);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
+    auto encodeReturn = [&](JSValue value) -> EncodedJSValue {
+        if (isConstructCall && !value.isObject())
+            return JSValue::encode(thisValue);
+        return JSValue::encode(value);
+    };
+
     JSC::JSArray* argumentsArray = nullptr;
     {
         JSC::ObjectInitializationScope object(vm);
@@ -954,22 +975,22 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
                 fn->returnValues.set(vm, fn, returnValuesArray);
             }
 
-            return JSValue::encode(returnValue);
+            return encodeReturn(returnValue);
         }
         case JSMockImplementation::Kind::ReturnValue: {
             JSValue returnValue = impl->underlyingValue.get();
             setReturnValue(createMockResult(vm, globalObject, "return"_s, returnValue));
-            return JSValue::encode(returnValue);
+            return encodeReturn(returnValue);
         }
         case JSMockImplementation::Kind::ReturnThis: {
             setReturnValue(createMockResult(vm, globalObject, "return"_s, thisValue));
-            return JSValue::encode(thisValue);
+            return encodeReturn(thisValue);
         }
         case JSMockImplementation::Kind::RejectedValue: {
             JSValue rejectedPromise = JSC::JSPromise::rejectedPromise(globalObject, impl->underlyingValue.get());
             RETURN_IF_EXCEPTION(scope, {});
             setReturnValue(createMockResult(vm, globalObject, "return"_s, rejectedPromise));
-            return JSValue::encode(rejectedPromise);
+            return encodeReturn(rejectedPromise);
         }
         default: {
             RELEASE_ASSERT_NOT_REACHED();
@@ -978,7 +999,17 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     }
 
     setReturnValue(createMockResult(vm, globalObject, "return"_s, jsUndefined()));
-    return JSValue::encode(jsUndefined());
+    return encodeReturn(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    return jsMockFunctionCallOrConstruct(lexicalGlobalObject, callframe, false);
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    return jsMockFunctionCallOrConstruct(lexicalGlobalObject, callframe, true);
 }
 
 void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -794,6 +794,57 @@ describe("mock()", () => {
 
     expect(bar()()).toBe(true);
   });
+
+  describe("as constructor", () => {
+    test("returns an object when the implementation returns a primitive", () => {
+      const fn = jest.fn(function () {
+        this.x = 1;
+        return "primitive";
+      });
+      expect(fn.call({})).toBe("primitive");
+      const instance = new fn();
+      expect(typeof instance).toBe("object");
+      expect(instance.x).toBe(1);
+      expect(typeof Reflect.construct(fn, [])).toBe("object");
+    });
+
+    test("returns the implementation's return value when it is an object", () => {
+      const obj = { custom: true };
+      const fn = jest.fn(() => obj);
+      expect(new fn()).toBe(obj);
+      expect(Reflect.construct(fn, [])).toBe(obj);
+    });
+
+    test("works with no implementation", () => {
+      const fn = jest.fn();
+      expect(typeof new fn()).toBe("object");
+      expect(typeof Reflect.construct(fn, [])).toBe("object");
+    });
+
+    test("works with mockReturnValue", () => {
+      const fn = jest.fn().mockReturnValue(42);
+      expect(fn()).toBe(42);
+      expect(typeof new fn()).toBe("object");
+      expect(typeof Reflect.construct(fn, [])).toBe("object");
+    });
+
+    test("sets the prototype from new.target", () => {
+      class Base {}
+      const fn = jest.fn(() => undefined);
+      expect(Reflect.construct(fn, [], Base)).toBeInstanceOf(Base);
+    });
+
+    if (isBun) {
+      test("no crash when implementation returns a non-object cell", () => {
+        for (const impl of [Symbol, BigInt, () => "str", () => 1n]) {
+          const fn = jest.fn(impl);
+          expect(typeof Reflect.construct(fn, [1])).toBe("object");
+          expect(typeof new fn(1)).toBe("object");
+        }
+        Bun.gc(true);
+      });
+    }
+  });
 });
 
 describe("spyOn", () => {

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -808,6 +808,18 @@ describe("mock()", () => {
       expect(typeof Reflect.construct(fn, [])).toBe("object");
     });
 
+    test("records instances and results", () => {
+      const fn = jest.fn(function () {
+        this.x = 1;
+        return "primitive";
+      });
+      const instance = new fn();
+      expect(fn.mock.instances).toHaveLength(1);
+      expect(fn.mock.instances[0]).toBe(instance);
+      expect(fn.mock.contexts[0]).toBe(instance);
+      expect(fn.mock.results[0]).toEqual({ type: "return", value: "primitive" });
+    });
+
     test("returns the implementation's return value when it is an object", () => {
       const obj = { custom: true };
       const fn = jest.fn(() => obj);


### PR DESCRIPTION
## What

Fixes a debug assertion (`cell->isObjectSlow()` in `JSObject.h:1345`) when a `jest.fn()` / `mock()` is invoked as a constructor and its implementation returns a non-object value.

```js
const fn = mock(Symbol);
Reflect.construct(fn, []); // ASSERTION FAILED: cell->isObjectSlow()
```

Also affected: `mock(() => "str")`, `mock(BigInt)`, `mock().mockReturnValue(42)`, and `mock()` with no implementation — any construct path whose result isn't an object.

## Why

`jsMockFunctionCall` was registered as both the `[[Call]]` and `[[Construct]]` native for `JSMockFunction`. Native constructors must return an object; the mock was returning whatever its implementation returned (or `jsUndefined()`). `Reflect.construct` then calls `asObject()` on the result and asserts. In release builds this doesn't crash but `new fn()` incorrectly returns primitives.

Since `CallFrame::newTarget()` is just an alias for `thisValue()`, a single shared native can't distinguish call from construct, so the handler is split into separate `jsMockFunctionCall` and `jsMockFunctionConstruct` entry points.

The construct path now:
- allocates a fresh `this` object using `new.target.prototype`
- passes it as `this` to the implementation
- returns it whenever the implementation's result is not an object

This matches ordinary JS `[[Construct]]` semantics (`function F() { return "x"; } new F()` → the created object) and how Jest's mock constructor behaves.

Found by Fuzzilli.