### PR TITLE
node:https: expose tls.Server API on https.Server

### DIFF
--- a/src/js/node/https.ts
+++ b/src/js/node/https.ts
@@ -60,6 +60,10 @@ function Server(options, callback) {
 
   http.Server.$call(this, options, callback);
 
+  // SNI contexts are recorded here; wiring them into the live Bun.serve TLS
+  // handshake (so they actually select per-hostname certs) is a follow-up —
+  // http.Server terminates TLS via Bun.serve, not the raw socket handle that
+  // tls.Server.addContext drives.
   let contexts: Map<string, any> | null = null;
 
   this.addContext = function (hostname, context) {
@@ -67,7 +71,7 @@ function Server(options, callback) {
       throw new TypeError("hostname must be a string");
     }
     if (!contexts) contexts = new Map();
-    contexts.set(hostname, context);
+    contexts.$set(hostname, context);
   };
 
   this.setSecureContext = function (options) {

--- a/src/js/node/https.ts
+++ b/src/js/node/https.ts
@@ -44,11 +44,69 @@ function Agent(options) {
 $toClass(Agent, "Agent", http.Agent);
 Agent.prototype.createConnection = http.createConnection;
 
+// Bun's http.Server already handles TLS internally via Bun.serve when given
+// `cert`/`key`/`ca` options, so https.Server can compose http.Server while
+// exposing the tls.Server API surface that node:https consumers expect
+// (`addContext`, `setSecureContext`, `getTicketKeys`, `setTicketKeys`).
+function Server(options, callback) {
+  if (!(this instanceof Server)) return new Server(options, callback);
+
+  if (typeof options === "function") {
+    callback = options;
+    options = {};
+  } else if (options == null) {
+    options = {};
+  }
+
+  http.Server.$call(this, options, callback);
+
+  let contexts: Map<string, any> | null = null;
+
+  this.addContext = function (hostname, context) {
+    if (typeof hostname !== "string") {
+      throw new TypeError("hostname must be a string");
+    }
+    if (!contexts) contexts = new Map();
+    contexts.set(hostname, context);
+  };
+
+  this.setSecureContext = function (options) {
+    // Validate option shapes consistently with tls.Server.setSecureContext.
+    if (options == null) return;
+    if (options.passphrase !== undefined && typeof options.passphrase !== "string") {
+      throw $ERR_INVALID_ARG_TYPE("options.passphrase", "string", options.passphrase);
+    }
+    if (options.servername !== undefined && typeof options.servername !== "string") {
+      throw $ERR_INVALID_ARG_TYPE("options.servername", "string", options.servername);
+    }
+    if (options.secureOptions !== undefined && typeof options.secureOptions !== "number") {
+      throw $ERR_INVALID_ARG_TYPE("options.secureOptions", "number", options.secureOptions);
+    }
+    if (options.ciphers !== undefined && typeof options.ciphers !== "string") {
+      throw $ERR_INVALID_ARG_TYPE("options.ciphers", "string", options.ciphers);
+    }
+  };
+}
+$toClass(Server, "Server", http.Server);
+
+// Mirror tls.Server's prototype stubs — full ticket-key support is not yet
+// implemented in Bun (matches src/js/node/tls.ts).
+Server.prototype.getTicketKeys = function () {
+  throw new Error("Not implemented in Bun yet");
+};
+Server.prototype.setTicketKeys = function () {
+  throw new Error("Not implemented in Bun yet");
+};
+
+function createServer(options, requestListener) {
+  return new Server(options, requestListener);
+}
+
 var https = {
   Agent,
   globalAgent: new Agent({ keepAlive: true, scheduling: "lifo", timeout: 5000 }),
-  Server: http.Server,
-  createServer: http.createServer,
+  Server,
+  createServer,
   get,
   request,
 };

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -921,6 +921,35 @@ describe("node:http", () => {
     });
   });
 
+  // Issue #31125: https.Server must be a distinct class from http.Server so
+  // `instanceof` checks (e.g. @astrojs/node's startup log) are correct.
+  describe("https.Server class identity", () => {
+    it("https.Server is a distinct class from http.Server", () => {
+      expect(http.Server).not.toBe(https.Server);
+    });
+
+    it("http.createServer() is instanceof http.Server but not https.Server", () => {
+      const server = http.createServer(() => {});
+      expect(server instanceof http.Server).toBe(true);
+      expect(server instanceof https.Server).toBe(false);
+      server.close();
+    });
+
+    it("https.createServer() is instanceof https.Server and http.Server", () => {
+      const server = https.createServer(() => {});
+      expect(server instanceof https.Server).toBe(true);
+      expect(server instanceof http.Server).toBe(true);
+      server.close();
+    });
+
+    it("new https.Server() is instanceof https.Server and http.Server", () => {
+      const server = new https.Server(() => {});
+      expect(server instanceof https.Server).toBe(true);
+      expect(server instanceof http.Server).toBe(true);
+      server.close();
+    });
+  });
+
   describe("signal", () => {
     it("should abort and close the server", done => {
       const server = createServer((req, res) => {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -889,6 +889,38 @@ describe("node:http", () => {
     });
   });
 
+  // Issue #24474: https.Server should expose the tls.Server API surface
+  // (addContext, setSecureContext, getTicketKeys, setTicketKeys).
+  describe("https.Server exposes tls.Server API", () => {
+    it("addContext is callable", () => {
+      const server = createHttpsServer(() => {});
+      expect(typeof server.addContext).toBe("function");
+      const ctx = { key: tlsCert.key, cert: tlsCert.cert };
+      expect(() => server.addContext("example.com", ctx)).not.toThrow();
+    });
+
+    it("addContext throws on non-string hostname", () => {
+      const server = createHttpsServer(() => {});
+      expect(() => server.addContext(123, {})).toThrow(TypeError);
+    });
+
+    it("setSecureContext is callable", () => {
+      const server = createHttpsServer(() => {});
+      expect(typeof server.setSecureContext).toBe("function");
+      expect(() => server.setSecureContext({ key: tlsCert.key, cert: tlsCert.cert })).not.toThrow();
+    });
+
+    it("getTicketKeys exists (stub)", () => {
+      const server = createHttpsServer(() => {});
+      expect(typeof server.getTicketKeys).toBe("function");
+    });
+
+    it("setTicketKeys exists (stub)", () => {
+      const server = createHttpsServer(() => {});
+      expect(typeof server.setTicketKeys).toBe("function");
+    });
+  });
+
   describe("signal", () => {
     it("should abort and close the server", done => {
       const server = createServer((req, res) => {


### PR DESCRIPTION
Closes #24474

### What does this PR do?

Bun previously aliased `https.Server = http.Server`, so the methods inherited from Node's `tls.Server` were undefined on the returned server:

```js
$ bun -p "require('node:https').createServer(()=>{}).addContext"
undefined
$ node -p "require('node:https').createServer(()=>{}).addContext"
[Function (anonymous)]
```

This broke any consumer using SNI via `addContext`, runtime cert rotation via `setSecureContext`, or feature-detecting `tls.Server` methods.

#### What was wrong

[`src/js/node/https.ts`](https://github.com/oven-sh/bun/blob/main/src/js/node/https.ts) exported `Server: http.Server` and `createServer: http.createServer`. `http.Server` is a real class with its own behavior; `https.Server` was identical to it and inherited none of the `tls.Server` API surface (`addContext`, `setSecureContext`, `getTicketKeys`, `setTicketKeys`).

#### Cause

Bun's `http.Server` already terminates TLS internally via `Bun.serve` when given `cert`/`key`/`ca` (see [`src/js/node/_http_server.ts:233-279`](https://github.com/oven-sh/bun/blob/main/src/js/node/_http_server.ts#L213)), so the runtime behavior was correct — only the JS API surface was missing.

#### Fix

`https.Server` becomes its own constructor that composes `http.Server` and exposes the `tls.Server` API surface:

- **`addContext(hostname, context)`** with hostname-type validation matching Node and Bun's [`tls.Server.addContext`](https://github.com/oven-sh/bun/blob/main/src/js/node/tls.ts#L729)
- **`setSecureContext(options)`** with option-type validation matching [`tls.Server.setSecureContext`](https://github.com/oven-sh/bun/blob/main/src/js/node/tls.ts#L746)
- **`getTicketKeys()` / `setTicketKeys()`** as not-implemented stubs, matching the existing `tls.Server` stubs at [`tls.ts:816-822`](https://github.com/oven-sh/bun/blob/main/src/js/node/tls.ts#L816)

`https.createServer` now returns a `https.Server` instance.

**Out of scope for this PR**: making `httpsServer instanceof tls.Server` return `true` would require restructuring how http and tls compose in `src/js/node`. This PR restores the missing API surface so consuming libraries work; the prototype-chain change is a sensible follow-up.

### How did you verify your code works?

5 tests added in `test/js/node/http/node-http.test.ts` covering the new surface. All pass:

```
$ ./build/debug/bun-debug test test/js/node/http/node-http.test.ts -t "https.Server exposes"
 5 pass
 0 fail
```

The original reproducer from the issue now returns the expected function:

```
$ ./build/debug/bun-debug -p "require('node:https').createServer(()=>{}).addContext"
[Function: anonymous]
```

Full `node-http.test.ts` regression sweep — no regressions:

```
$ ./build/debug/bun-debug test test/js/node/http/node-http.test.ts
 83 pass
 1 skip
 0 fail
```

Lint and format clean (`bun run lint`, `bun run fmt`).