### PR TITLE
build: enable rustc parallel frontend (-Zthreads=8) for local builds

### DIFF
--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -387,6 +387,25 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
   // (flags.ts:293-301). Needed so profilers and crash backtraces walk Rust
   // frames the same as the Zig binary did.
   rustflags.push("-Cforce-frame-pointers=yes");
+  // Parallel frontend: rustc's default is single-threaded for parse / macro
+  // expansion / typeck / borrowck, so the critical-path crate (`bun_runtime`)
+  // sits on one core while the rest idle. With this, independent compiler
+  // queries run on a rayon pool and the long pole roughly halves. The pool
+  // shares cargo's jobserver, so N rustcs × 8 doesn't oversubscribe — each
+  // thread acquires a `-j` token before doing work.
+  //
+  // Why 8, not nproc: returns flatten past ~8 (the query DAG has its own
+  // serial spine — macro expansion in particular), and `-Zthreads=0` (= nproc)
+  // measured marginally *worse* on a 32-core box from sharded-lock contention.
+  // 8 is also the upstream proposal for the eventual default
+  // (rust-lang/compiler-team#681).
+  //
+  // Local-only: CI/release builds want byte-identical output across runs, and
+  // the parallel frontend can reorder diagnostics (and is still nightly
+  // `-Z`-gated). The shipped binaries stay on the serial path.
+  if (!cfg.ci) {
+    rustflags.push("-Zthreads=8");
+  }
   // rustc does not emit `.llvm_addrsig` by default on *any* target (verified
   // empirically — Linux-gnu, musl, darwin, msvc all missing it). lld's
   // `--icf=safe` (flags.ts:960) and lld-link's `/OPT:SAFEICF` (flags.ts:778)


### PR DESCRIPTION
rustc's frontend (parse, macro expansion, typeck, borrowck) is single-threaded by default — only the LLVM backend fans out via `codegen-units`. The Rust crate graph's critical path is a serial chain ending in `bun_runtime`, so during the tail of every `bun bd` one core does ~20s of work while the rest idle.

`-Zthreads=8` enables rustc's parallel-frontend query pool. It shares cargo's jobserver, so concurrent rustcs don't oversubscribe — each frontend thread acquires a `-j` token before running. Gated on `!cfg.ci` so PR/release builds keep deterministic diagnostic ordering and stay off the nightly `-Z` surface.

**Why 8 and not nproc:** scaling on `bun_runtime` (32-core box, debug, no incremental cache):

| `-Zthreads` | wall |
|---|---|
| 1 | 20.2s |
| 4 | 13.2s |
| 8 | 10.6s |
| 16 | 9.6s |
| 0 (=nproc=32) | 10.9s |

Returns flatten past 8 (macro expansion is inherently serial; the query DAG has its own critical path), and `0` is marginally worse than `8` from sharded-lock contention. 8 is also the upstream proposal for the eventual default (rust-lang/compiler-team#681), so this becomes a no-op when that lands.

Verified: flag present in `build.ninja` for local configure, absent with `--ci=true`; `bun bd --revision` works.