### PR TITLE
bake/DevServer: reuse get_or_put key instead of re-duping in DirectoryWatchStore.insert

### DIFF
--- a/src/runtime/bake/DevServer/DirectoryWatchStore.rs
+++ b/src/runtime/bake/DevServer/DirectoryWatchStore.rs
@@ -297,14 +297,11 @@ impl DirectoryWatchStore {
         let dir_name: Box<[u8]> = Box::<[u8]>::from(dir_name_to_watch);
         // errdefer free(dir_name) — handled by Drop.
 
-        // TODO(port): Zig sets key_ptr to a sub-slice of `dir_name` (trailing
-        // slash trimmed) while the allocation backing it is the full dupe.
-        // With Box<[u8]> keys we instead dupe the trimmed slice as the key and
-        // keep `dir_name` separately for addDirectory/getHash. Verify Watcher
-        // does not retain `dir_name` beyond this call.
-        let key: Box<[u8]> = Box::<[u8]>::from(
-            strings::paths::without_trailing_slash_windows_path(&dir_name),
-        );
+        // PORT NOTE: Zig repoints `gop.key_ptr` to a trailing-slash-trimmed
+        // sub-slice of the duped `dir_name`. This port's `get_or_put` already
+        // boxed (and owns) an identical trimmed key from `dir_name_to_watch`,
+        // so the entry's key at `gop_index` is already correct — no second
+        // dupe is needed. `dir_name` is kept separately for addDirectory/getHash.
 
         // SAFETY: `dev` is a valid *mut DevServer for the duration of this call.
         let watch_index = match unsafe { &mut (*dev).bun_watcher }.add_directory::<false>(
@@ -340,15 +337,15 @@ impl DirectoryWatchStore {
                 index
             }
         };
-        watches.put_assume_capacity(
-            key,
-            Entry {
-                dir: fd,
-                dir_fd_owned: owned_fd,
-                first_dep: dep,
-                watch_index,
-            },
-        );
+        // `get_or_put` already inserted and owns the (trimmed) key at
+        // `gop_index`; only the value is a placeholder. Write the real entry
+        // directly instead of re-hashing and freeing a freshly-duped key.
+        watches.values_mut()[gop_index] = Entry {
+            dir: fd,
+            dir_fd_owned: owned_fd,
+            first_dep: dep,
+            watch_index,
+        };
         let _ = dir_name; // keep alive past add_directory; dropped here
         Ok(())
     }

--- a/src/runtime/bake/DevServer/DirectoryWatchStore.rs
+++ b/src/runtime/bake/DevServer/DirectoryWatchStore.rs
@@ -304,7 +304,12 @@ impl DirectoryWatchStore {
         // dupe is needed. `dir_name` is kept separately for addDirectory/getHash.
 
         // SAFETY: `dev` is a valid *mut DevServer for the duration of this call.
-        let watch_index = match unsafe { &mut (*dev).bun_watcher }.add_directory::<false>(
+        // The watcher must own its copy of the path (`add_directory::<true>`):
+        // a `<false>` borrow of the local `dir_name` would dangle once this fn
+        // returns, and `free_entry`/`flush_evictions` only tear the `WatchItem`
+        // down after the map entry is gone — yet `on_file_update` reads
+        // `items_file_path()` by event index for directory items.
+        let watch_index = match unsafe { &mut (*dev).bun_watcher }.add_directory::<true>(
             fd,
             &dir_name,
             Watcher::get_hash(&dir_name),
@@ -317,7 +322,7 @@ impl DirectoryWatchStore {
         let fd = scopeguard::ScopeGuard::into_inner(fd_guard);
         let watches = scopeguard::ScopeGuard::into_inner(watches_guard);
 
-        // PORT NOTE: reshaped for borrowck — append dep before put_assume_capacity.
+        // PORT NOTE: reshaped for borrowck — append dep before writing the entry.
         let dep = {
             // TODO(port): borrowck — self.append_dep_assume_capacity needs
             // &mut self while `watches` guard held a borrow; reshaped above.


### PR DESCRIPTION
## What

`DirectoryWatchStore::insert` (src/runtime/bake/DevServer/DirectoryWatchStore.rs) duped the trimmed directory key twice on the new-watch path:

1. `get_or_put(Box::from(without_trailing_slash_windows_path(dir_name_to_watch)))` — this already boxes and **owns** the trimmed key in the map slot at `gop_index` (vacant insert pushes the key with a default value).
2. A second `Box::<[u8]>::from(without_trailing_slash_windows_path(&dir_name))` was then passed to `put_assume_capacity`, whose underlying `put` only overwrites `values[i]` on a hit and **preserves the existing key** (array_hash_map.rs:1014). So the freshly-duped key was allocated, copied, then immediately dropped.

This differs from the Zig original, where `getOrPut`'s key was a borrow that had to be repointed (`gop.key_ptr.* = ...`); the Rust map already owns its key, so no repoint/re-dupe is needed.

## Change

Write the `Entry` value directly into the slot at `gop_index` (mirroring the `found_existing` path at line ~217 which already does `values_mut()[gop_index].first_dep = dep`). This removes one `Box<[u8]>` allocation + copy and a redundant hash+find per new directory watch.

The other `Box::from(dir_name_to_watch)` (`dir_name`) is kept — it is needed for `add_directory`/`get_hash` and is the legitimate key-ownership cost.

## Safety

- `gop_index` stays valid: `self.watches` is untouched between `get_or_put` and the write (the intervening `append_dep` touches `self.dependencies`; the error-path `swap_remove` guard is disarmed via `into_inner` on the success path).
- No new `unsafe`.
- Single-threaded store, no JS/GC strings — no cross-thread/AtomString hazard.

## Tracer

Cold path (resolution failures), so 0 clones traced / 0 bytes — this is a correctness-neutral simplification that removes wasted work, not a hot-path win.

## Test

`bun bd test test/bake/dev/bundle.test.ts` — 20 pass / 0 fail, including the directory-watch cases ("importing a file before it is created", "directory cache bust case #17576", "deleting imported file shows error then recovers", "removing 'use client' ... pending resolution failure", "deinit with a free-list slot in DirectoryWatchStore.dependencies").