### PR TITLE
RuntimeTranspilerStore: move printer buffer into external string instead of cloning at TranspilerJob::run

### DIFF
--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -1182,22 +1182,20 @@ impl TranspilerJob {
         }
 
         let source_code = 'brk: {
-            let written = source_code_printer.ctx.get_written();
-
             // The `Jsc` vtable bridge `put()` does not write
             // `cache.output_code` (only the `r#impl == None` fallback does,
             // and `r#impl` is `Some(Jsc)` here), so it is always `None`.
             debug_assert!(cache.output_code.is_none());
-            let result = String::clone_latin1(written);
 
-            // SAFETY: leaf scalar field read on `*vm`; see `vm` PORT NOTE above.
-            if written.len() > 1024 * 1024 * 2 || unsafe { (*vm).smol } {
-                // printer.ctx.buffer.deinit() → Drop
-                let writer = BufferWriter::init();
-                *source_code_printer = BufferPrinter::init(writer);
-                source_code_printer.ctx.append_null_byte = false;
-            }
-            // else: writeback guard already restored `printer` into the thread-local.
+            // Move the pooled printer buffer into a WTF::ExternalStringImpl
+            // instead of copying it. `get_written()` spans the whole backing
+            // `Vec`, so taking `buffer.list` hands JSC the exact bytes with a
+            // global-allocator finalizer (zero copy; ASCII output is valid
+            // Latin-1). The thread-local printer is left with a fresh empty
+            // buffer — the same end state the old >2MB/smol reset produced,
+            // applied unconditionally so it never retains a large buffer.
+            let written = core::mem::take(&mut source_code_printer.ctx.buffer.list);
+            let result = String::create_external_globally_allocated_latin1(written);
 
             // In a benchmarking loading @babel/standalone 100 times:
             //


### PR DESCRIPTION
Convert the highest-volume module-load string clone into a zero-copy move.

## Callsite
`src/jsc/RuntimeTranspilerStore.rs:1191` (`TranspilerJob::run`), the runtime ESM/CJS transpile path that produces the `source_code` handed to JSC. Previously:

```rust
let written = source_code_printer.ctx.get_written();
let result = String::clone_latin1(written);
```

`get_written()` returns `buffer.list.as_slice()` — the **whole** backing `Vec<u8>` (the printer runs with `append_null_byte = false`, so there is no sub-slice/watermark to honor). So `clone_latin1` allocated a fresh `WTFStringImpl` and memcpy'd the entire transpiled output every module load.

## Change
Move the buffer instead of copying it:

```rust
let written = core::mem::take(&mut source_code_printer.ctx.buffer.list);
let result = String::create_external_globally_allocated_latin1(written);
```

This hands the `Vec<u8>` directly to a `WTF::ExternalStringImpl` with a global-allocator finalizer — eliminating the WTF malloc, the N-byte copy, and the per-string free.

## Why it is safe
- **Encoding**: `Format::EsmAscii` output is ASCII, which is valid Latin-1, so `latin1` is the correct variant with no transcode. Byte-for-byte identical observable JS string content to the old clone.
- **Ownership / lifetime**: the `ExternalStringImpl` owns the `Vec` for the JS string's lifetime; the finalizer (`Bun::defaultAllocatorFree`) frees via the `#[global_allocator]`, which matches the `Vec` allocator under both mimalloc and ASAN/system. This exact constructor already ships in `src/runtime/webcore/encoding.rs`.
- **Cross-thread**: the result is a plain (non-atom, non-symbol) `ExternalStringImpl` with an atomic refcount — same hazard class as the `clone_latin1` output it replaces, and no `AtomString` table is touched. No new cross-thread String hazard. The clone already built its `StringImpl` off the JS thread (transpile runs on a WorkPool worker), so this does not change which thread allocates.
- **Edge cases**: empty output -> `String::EMPTY`; over-length -> `String::DEAD` with the `Vec` freed (no leak). Parity with `clone_latin1`.
- **No new `unsafe`** — `mem::take` is safe; the `unsafe` lives inside the already-vetted constructor.

The `>2MB || vm.smol` reset branch is removed: `mem::take` already leaves the thread-local printer with a fresh capacity-0 buffer unconditionally, so a large output is now moved out rather than copied-then-discarded — strictly better than the old reset.

This diverges from the Zig sibling (`RuntimeTranspilerStore.zig:592` does `bun.String.cloneLatin1`), but only as a copy->move perf change; observable semantics are preserved.

## Trade-off (benchmark before merge)
This site is a deliberate thread-local buffer **pool** (`MAX_BUFFER_CAP` 512 KB): the printer buffer was reused across transpiles so steady-state printing wrote into pre-grown capacity. After this change every transpile consumes the buffer, so the next print regrows from capacity 0 (~geometric reallocs). We remove one full N-byte clone + malloc + free per load but add the regrow cost to the print phase — net is workload-dependent. The `@babel/standalone`-x100 load path referenced in the in-code comment should be benchmarked before merge. If regrow proves costly, a follow-up `BufferWriter::with_capacity(source.len())` pre-reserve makes it strictly faster.

## Tracer
Runtime `.clone()` tracer flagged this as the highest-volume module-load clone (`clone_latin1(written)`).

## Tests
Debug build (`bun bd`) clean. With the debug build:
- `test/bundler/transpiler/runtime-transpiler.test.ts` — 13 pass / 0 fail
- `test/js/bun/resolve/concurrent-dynamic-import.test.ts`, `bun-main-entry-point.test.ts` — 4 pass / 0 fail
- End-to-end smoke: importing/executing a transpiled `.ts` module returns correct output.

No new failures vs `origin/main`.
