### PR TITLE
transpiler: move ASCII output buffer into external string instead of cloning in TransformTask::run

### DIFF
--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -872,10 +872,22 @@ impl<'a> TransformTask<'a> {
 
         if printed > 0 {
             buffer_writer = printer.ctx;
-            // TODO(port): `buffer_writer.buffer.list.items = buffer_writer.written;` —
-            // Zig truncates the Vec's view to `written`. Map to `.truncate(written.len())` or
-            // a slice copy depending on BufferWriter shape.
-            self.output_code = BunString::clone_utf8(buffer_writer.written());
+            // `done()` sets `written_len == buffer.list.len()`, so `written()` is
+            // the whole backing buffer. Move the owned `Vec` into a
+            // WTF::ExternalStringImpl (its finalizer frees via the global
+            // allocator) instead of copying — but only for pure-ASCII output.
+            // `ascii_only == is_bun` for this print path, so non-Bun targets can
+            // emit raw UTF-8; those keep `clone_utf8`, which transcodes (an
+            // external string can't).
+            let buf_len = buffer_writer.buffer.list.len();
+            if buffer_writer.written().len() == buf_len
+                && bun_core::strings::is_all_ascii(buffer_writer.written())
+            {
+                let bytes = core::mem::take(&mut buffer_writer.buffer.list);
+                self.output_code = BunString::create_external_globally_allocated_latin1(bytes);
+            } else {
+                self.output_code = BunString::clone_utf8(buffer_writer.written());
+            }
         } else {
             self.output_code = BunString::empty();
         }


### PR DESCRIPTION
## What

In `TransformTask::run` (the async `Bun.Transpiler.transform` worker path), `src/runtime/api/JSTranspiler.rs:878`, the printed output was copied into a new `WTFStringImpl` via `BunString::clone_utf8(buffer_writer.written())`.

`buffer_writer` here is a **fresh owned local** (`BufferWriter::init` earlier in the same function), not pooled, and dropped right after. After `done()`, `written_len == buffer.list.len()`, so `written()` spans the entire backing `Vec<u8>`. For pure-ASCII output we can **move** that `Vec` into a `WTF::ExternalStringImpl` (zero-copy) rather than memcpy'ing it.

```rust
let buf_len = buffer_writer.buffer.list.len();
if buffer_writer.written().len() == buf_len
    && bun_core::strings::is_all_ascii(buffer_writer.written())
{
    let bytes = core::mem::take(&mut buffer_writer.buffer.list);
    self.output_code = BunString::create_external_globally_allocated_latin1(bytes);
} else {
    self.output_code = BunString::clone_utf8(buffer_writer.written());
}
```

## Why it's safe

- **Ownership/lifetime:** `buffer_writer` is owned by this stack frame and never reused after this point, so `mem::take`-ing its `Vec` is sound. `create_external_globally_allocated_latin1` registers a finalizer that frees the buffer via `Bun::defaultAllocatorFree`, which matches the crate `#[global_allocator]` (ASAN-safe). Spare capacity is reclaimed with the base pointer.
- **Encoding:** ASCII is **not** guaranteed. `ascii_only == is_bun` for this print path (matching `transpiler.zig`), so non-Bun targets can emit raw UTF-8 multibyte bytes. A Latin-1 external string would corrupt those, so the `is_all_ascii` guard keeps non-ASCII output on `clone_utf8`, which transcodes correctly. The `==len` guard ensures `written()` covers the whole `Vec` before moving.
- **Cross-thread:** `ExternalStringImpl` has an atomic refcount and is not an `AtomString`, so it has the same cross-thread profile as the `WTFStringImpl` it replaces — built on the worker thread, transferred to JS on the JS thread, no per-thread AtomString-table hazard.
- The JS-observable result is identical (8-bit Latin-1 for pure-ASCII output).
- No new `unsafe`.

## Tracer

Runtime clone tracer (`claude/clone-tracer`) flagged this `clone_utf8(buffer_writer.written())` call site. The async transform path copies the full transpiled output on every `transform()`.

## Tests

- `bun bd test test/bundler/transpiler/transpiler.test.js` — 114 pass, 0 fail (exercises async `.transform()`, the ASCII move path).
- `bun bd test test/js/bun/transpiler/transpiler-utf16-loader.test.ts transpiler-truncated-utf8.test.ts` — 6 pass, 0 fail (non-ASCII / `clone_utf8` fallback path).
- Manual: `await new Bun.Transpiler({loader:'ts'}).transform(...)` produces identical output for ASCII and non-ASCII (raw UTF-8 `é`/`ö` preserved, emoji escaped by the printer as before).