### PR TITLE
bake: borrow CSS key instead of boxing in tailwind plugin hack map

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -395,7 +395,7 @@ pub struct DevServer {
     /// The Plugin API is missing a way to attach filesystem watchers (addWatchFile)
     /// This special case makes `bun-plugin-tailwind` work, which is a requirement
     /// to ship initial incremental bundling support for HTML files.
-    pub has_tailwind_plugin_hack: Option<ArrayHashMap<Box<[u8]>, ()>>,
+    pub has_tailwind_plugin_hack: Option<bun_collections::StringArrayHashMap<()>>,
 
     // These values are handles to the functions in `hmr-runtime-server.ts`.
     // For type definitions, see `./bake.private.d.ts`
@@ -4019,11 +4019,9 @@ pub fn finalize_bundle(
 
         if let Some(map) = &mut dev.has_tailwind_plugin_hack {
             if looks_like_tailwind {
-                // PORT NOTE: `get_or_put` consumes the key by value; on miss the key
-                // already lives in the map so the explicit `*key_ptr =` is redundant.
-                let _ = map.get_or_put(Box::from(key))?;
+                let _ = map.get_or_put(key)?;
             } else {
-                let _ = map.swap_remove(&Box::<[u8]>::from(key));
+                let _ = map.swap_remove(key);
             }
         }
 


### PR DESCRIPTION
## What

`DevServer.has_tailwind_plugin_hack` was typed `ArrayHashMap<Box<[u8]>, ()>`. The generic `ArrayHashMap` methods force owned keys:

- `get_or_put(Box::from(key))` allocates a `Box<[u8]>` even when the key is already present (the alloc is dropped on a hit).
- `swap_remove(&Box::<[u8]>::from(key))` allocates a `Box<[u8]>` solely so it can take a `&Box<[u8]>` — always wasted.

Both fire on **every CSS chunk** when a `bun-plugin-tailwind` user edits CSS (the `receive_chunk` CSS path in `finalizeBundle`).

## Fix

Switch the field to `bun_collections::StringArrayHashMap<()>`, which is the `[]const u8`-keyed wrapper. Its `get_or_put(&[u8])` boxes only on an insert miss, and `swap_remove(&[u8])` does no allocation. The per-chunk `key: &[u8]` (borrowed from `ctx.sources`) is now passed by reference.

This matches:
- the sibling fields `barrel_files_with_deferrals` / `barrel_needed_exports` on the same struct, which already use `StringArrayHashMap`;
- the Zig original `DevServer.zig` (`bun.StringArrayHashMapUnmanaged(void)`), which dupes only on insert-miss and uses `fetchSwapRemove(key)` with a borrowed slice (zero alloc).

## Tracer

The clone tracer recorded 0 hits for this site because `bun-plugin-tailwind` was inactive in the traced workload; the allocations are on the CSS-edit hot path for tailwind users, not the steady state.

## Safety

- `key` is `&'a [u8]` from `ctx.sources`; the borrow keeps it usable for the later `insert_css_file_on_server(..., key)` call.
- The map is `DevServer`-owned and single-threaded — no AtomString / GC / cross-thread hazard.
- Other usages stay valid under the new type: `.is_some()`, `.keys()` (via Deref), the `w!(None)` writer, the `Default::default()` constructor.
- No new `unsafe`.

## Test

`cargo check -p bun_bin --keep-going`: clean (0 errors).
`bun bd test test/bake/dev/css.test.ts`: 11 pass / 2 fail. The 2 failures (`DEV:css-13` and one other) are pre-existing on `origin/main` — verified identical by reverting the change and re-running. 0 new failures.