### PR TITLE
jsc_hooks: move owned source bytes into a JSC external string instead of cloning

### DIFF
--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1931,6 +1931,29 @@ fn create_if_different(s: &bun_core::String, other: &[u8]) -> bun_core::String {
     bun_core::String::clone_utf8(other)
 }
 
+/// Hand the runtime-transpiler raw source bytes to JSC. When the backing is a
+/// heap-owned `Vec` that spans the whole `contents` slice and is pure ASCII
+/// (Latin-1 == UTF-8), move it into a `WTF::ExternalStringImpl` (zero copy —
+/// JSC frees it via the global allocator). Otherwise clone: `Arena` backings
+/// are recycled with the per-call arena right after this hook returns,
+/// `SharedBuffer`/`External` bytes are borrowed, and non-ASCII UTF-8 must be
+/// transcoded (an external Latin-1 string cannot).
+fn source_code_from_backing(
+    backing: bun_resolver::cache::Contents,
+    contents: &[u8],
+) -> bun_core::String {
+    if let bun_resolver::cache::Contents::Owned(bytes) = backing {
+        if bytes.len() == contents.len()
+            && core::ptr::eq(bytes.as_ptr(), contents.as_ptr())
+            && bun_core::strings::first_non_ascii(&bytes).is_none()
+        {
+            return bun_core::String::create_external_globally_allocated_latin1(bytes);
+        }
+        return bun_core::String::clone_utf8(contents);
+    }
+    bun_core::String::clone_utf8(contents)
+}
+
 /// `ModuleLoader.transpileSourceCode(...)` — the runtime-transpiler path.
 /// Port of `src/jsc/ModuleLoader.zig:85-826`: read file → `Transpiler::parse`
 /// → `js_printer::print` → `ResolvedSource`.
@@ -2592,7 +2615,10 @@ fn transpile_source_code_inner(
                 // Spec :343-351 — raw JSON: hand the source bytes straight to JSC.
                 if loader == L::Json {
                     return Ok(OwnedResolvedSource::new(ResolvedSource {
-                        source_code: bun_core::String::clone_utf8(&source.contents),
+                        source_code: source_code_from_backing(
+                            core::mem::take(&mut parse_result.source_contents_backing),
+                            &source.contents,
+                        ),
                         specifier: input_specifier.dupe_ref(),
                         source_url: create_if_different(input_specifier, path.text),
                         tag: ResolvedSourceTag::JsonForObjectLoader,
@@ -2602,24 +2628,17 @@ fn transpile_source_code_inner(
 
                 // Spec :353-364 — disable_transpiling: return raw source.
                 if disable_transpilying {
-                    let source_code = match args.flags {
-                        FetchFlags::PrintSourceAndClone => {
-                            bun_core::String::clone_utf8(&source.contents)
-                        }
-                        FetchFlags::PrintSource => {
-                            // PORT NOTE: spec ModuleLoader.zig:358 borrows
-                            // (`bun.String.init`) because the bytes live in the
-                            // per-call arena, which is intentionally not reset
-                            // for `.print_source` (ModuleLoader.zig:151). The
-                            // Rust port stores file contents in a Drop-carrying
-                            // `source_contents_backing` on `parse_result`, so a
-                            // borrow would dangle once `parse_result` drops on
-                            // return. Clone instead — matches the
-                            // `PrintSourceAndClone` arm.
-                            bun_core::String::clone_utf8(&source.contents)
-                        }
-                        FetchFlags::Transpile => unreachable!(),
-                    };
+                    debug_assert!(!matches!(args.flags, FetchFlags::Transpile));
+                    // Spec ModuleLoader.zig:358 borrows the per-call-arena bytes
+                    // for `.print_source`; the Rust port owns the backing in
+                    // `source_contents_backing`. Move a heap-owned `Vec` into a
+                    // JSC external string (zero copy) and clone the recycled
+                    // arena / borrowed shared-buffer backings (see
+                    // `source_code_from_backing`).
+                    let source_code = source_code_from_backing(
+                        core::mem::take(&mut parse_result.source_contents_backing),
+                        &source.contents,
+                    );
                     return Ok(OwnedResolvedSource::new(ResolvedSource {
                         source_code,
                         specifier: input_specifier.dupe_ref(),

--- a/test/js/node/string-module.test.js
+++ b/test/js/node/string-module.test.js
@@ -17,3 +17,17 @@ test("should import and execute ES module from string (base64)", async () => {
 test("should throw when importing malformed string (base64)", async () => {
   expect(() => import("data:text/javascript;base64,asdasdasd")).toThrowError("Base64DecodeError");
 });
+
+test("should import JSON module from data: URL (ascii)", async () => {
+  const json = await import("data:application/json," + encodeURIComponent('{"hello":"world","n":1,"arr":[1,2,3]}'), {
+    with: { type: "json" },
+  }).then(m => m.default);
+  expect(json).toEqual({ hello: "world", n: 1, arr: [1, 2, 3] });
+});
+
+test("should import JSON module from data: URL (non-ascii)", async () => {
+  const json = await import("data:application/json," + encodeURIComponent('{"k":"vål","snowman":"☃"}'), {
+    with: { type: "json" },
+  }).then(m => m.default);
+  expect(json).toEqual({ k: "vål", snowman: "☃" });
+});


### PR DESCRIPTION
## What

The runtime-transpiler module-loader hook (`transpile_source_code_inner` in `src/runtime/jsc_hooks.rs`) handed raw module source to JSC via `bun_core::String::clone_utf8(&source.contents)` on two paths:

- the JSON object-loader path (`loader == L::Json`, `jsc_hooks.rs:2595`)
- the `disable_transpiling` print-source path (`jsc_hooks.rs:2605-2622`)

Both copied every source byte into a fresh `WTFStringImpl`.

This adds a `source_code_from_backing()` helper that avoids the copy when the source backing is heap-owned and ASCII, and routes both sites through it.

## How it's safe

`parse_result.source_contents_backing` is a provenance-tagged `bun_resolver::cache::Contents`. The helper only moves the bytes when:

1. the backing is `Contents::Owned(Vec<u8>)` — the tag *is* the ownership proof; `Arena`/`SharedBuffer`/`External` never enter the move path,
2. the slice handed to JSC spans the whole `Vec` (`ptr` + `len` equality — belt-and-suspenders; always true for the `RETURN_FILE_ONLY` arm), and
3. the bytes are pure ASCII (`first_non_ascii` is `None`), so Latin-1 == UTF-8.

In that case the `Vec` is moved into a `WTF::ExternalStringImpl` via `create_external_globally_allocated_latin1` (already production-used in `encoding.rs`), which JSC frees through `Bun::defaultAllocatorFree` — matching the `#[global_allocator]` under both ASAN (`::free`) and non-ASAN (`mi_free`). `ExternalStringImpl` is non-atom, so there is no cross-thread / per-thread AtomString-table hazard (same property as `clone_utf8`).

Every other backing still clones, by necessity:

- `Arena` bytes are bulk-reclaimed by `mi_heap_destroy` when the per-call arena is recycled right after the hook returns — handing them to JSC's finalizer would double-free.
- `SharedBuffer`/`External` bytes are borrowed.
- non-ASCII UTF-8 must be transcoded (an external Latin-1 string cannot represent it).

`core::mem::take(&mut parse_result.source_contents_backing)` leaves `Contents::Empty` (no-op `Drop`), and all three sites `return` immediately, so `source.contents` (a `Cow::Borrowed` view) is never read after the move. The `&mut source_contents_backing` / `&source.contents` disjoint-field borrow mirrors the committed precedent at `jsc_hooks.rs:2685` (`mem::take(&mut parse_result.already_bundled)` then `&source.contents`).

This matches Zig semantics: `ModuleLoader.zig:346` clones the JSON path and `:358` borrows the per-call-arena bytes for print-source; the external-move is identical string content and closer to Zig's zero-copy intent.

The `disable_transpiling` match is also collapsed — its two non-`unreachable` arms (`PrintSource` / `PrintSourceAndClone`) were identical clones — into one helper call, with a `debug_assert` preserving the `Transpile`-is-unreachable invariant.

## Impact

Narrow and honest: the win lands on `data:`-URL JSON modules (decoded into a global-allocator `Vec`) and default-allocator reads. Disk JSON / print-source still clone because their bytes live in the recycled arena (the deliberate arena-reclaim design at `resolver/lib.rs:2139-2150`). The runtime clone tracer recorded this site at 0 hits, so this is a structural cleanup + zero-copy on the owned sub-case rather than a hot-path fix. No new `unsafe`.

## Tests

- Added `data:`-URL JSON module-load tests in `test/js/node/string-module.test.js`: ASCII (exercises the move-into-external path) and non-ASCII (exercises the `clone_utf8` transcode fallback).
- `bun bd test test/js/node/string-module.test.js` → 5 pass / 0 fail.
- Existing JSON/data-URL loader tests pass (`jsonc`, `json5`, `import-defer`, `import-query`, etc.).
- The two `load-same-js-file-a-lot.test.ts` timeouts are pre-existing debug-build timeouts (verified failing identically on a clean baseline build); they load `.js` via the untouched transpile path.
