### PR TITLE
Don't forward SIGPWR in spawnSync signal handling on Linux

### DIFF
--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -933,9 +933,11 @@ static struct sigaction previous_actions[NSIG];
     M(SIGIO);
 
 #if OS(LINUX)
+// SIGPWR is intentionally excluded: JSC uses it for GC thread suspend/resume
+// on Linux (see WTF ThreadingPOSIX.cpp), so replacing its handler here would
+// break the collector and can terminate the process with signal 30.
 #define FOR_EACH_LINUX_ONLY_SIGNAL(M) \
     M(SIGPOLL);                       \
-    M(SIGPWR);                        \
     M(SIGSTKFLT);
 
 #endif

--- a/test/js/bun/util/openInEditor-gc.test.ts
+++ b/test/js/bun/util/openInEditor-gc.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Bun.openInEditor spawns a detached thread that runs sync::spawn, which
+// installs signal-forwarding handlers. On Linux the forwarding list used to
+// include SIGPWR, which JSC uses for GC thread suspend/resume. Overlapping
+// register/unregister calls from multiple editor threads could leave the
+// SIGPWR disposition at SIG_DFL, so the next GC-driven SIGPWR killed the
+// process with signal 30.
+test.skipIf(process.platform !== "linux")(
+  "Bun.openInEditor does not clobber the GC thread-suspend signal handler",
+  async () => {
+    const script = `
+      for (let i = 0; i < 30; i++) {
+        try { Bun.openInEditor("/tmp/bun-open-in-editor-gc-" + i); } catch {}
+      }
+      await Bun.sleep(50);
+      for (let i = 0; i < 100; i++) {
+        new Uint8Array(10000);
+        Bun.gc(true);
+      }
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, PATH: "/nonexistent" },
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    const exitCode = await proc.exited;
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
Fuzzilli found a flaky crash (fingerprint `5b0730bc208b3b6c`) where the process is terminated by signal 30 (SIGPWR).

## Root cause

On Linux, JavaScriptCore uses **SIGPWR** for GC thread suspend/resume (see `WTF/wtf/posix/ThreadingPOSIX.cpp` under `USE(BUN_JSC_ADDITIONS)` — upstream uses SIGUSR1, Bun switched to SIGPWR so npm packages can intercept SIGUSR1).

The `bun.spawnSync` signal-forwarding list in `c-bindings.cpp` was copied from npm's list and includes SIGPWR. `Bun__registerSignalsForForwarding()` therefore replaces JSC's SIGPWR handler with a forwarding handler marked `SA_RESETHAND`, and `Bun__unregisterSignalsForForwarding()` restores the previous handler from a process-global `previous_actions[]` array.

`Bun.openInEditor()` spawns a detached background thread which calls `sync::spawn` → `Bun__registerSignalsForForwarding` / `Bun__unregisterSignalsForForwarding`. Multiple concurrent editor threads race on `previous_actions[]`:

1. Thread A: register → saves JSC handler, installs forwarder
2. Thread B: register → saves **forwarder** as "previous", installs forwarder
3. Thread A: unregister → restores forwarder, then `memset`s `previous_actions` to zero
4. Thread B: unregister → restores **zeroed** struct = `SIG_DFL`

After the race settles, SIGPWR is left at `SIG_DFL`. The next time GC sends SIGPWR to suspend a thread, the process dies with signal 30.

Even without the overlap race, temporarily replacing JSC's SIGPWR handler while JS is running concurrently is unsafe: a concurrent GC that fires during the window hits the wrong handler and never posts the suspend semaphore.

## Fix

Remove SIGPWR from `FOR_EACH_LINUX_ONLY_SIGNAL`. It's an obscure "power failure" signal that supervisors don't send to `bun run`, and JSC has explicitly reserved it for GC on Linux.

## Repro

Before the fix, this dies with SIGPWR 100/100 on a debug build:

```js
for (let i = 0; i < 30; i++) {
  try { Bun.openInEditor("/tmp/x" + i); } catch {}
}
await Bun.sleep(50);
for (let i = 0; i < 200; i++) {
  new Uint8Array(10000);
  Bun.gc(true);
}
```

After: 0/100.