### PR TITLE
bake/DevServer: fix dangling watch path in live DirectoryWatchStore::insert

### DIFF
--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -1420,18 +1420,18 @@ impl DirectoryWatchStore {
             }
         });
 
-        let dir_name: Box<[u8]> = Box::<[u8]>::from(dir_name_to_watch);
-        // errdefer free(dir_name) — handled by Drop.
-
-        // PORT NOTE: Zig sets `key_ptr` to a sub-slice of `dir_name` (trailing
-        // slash trimmed) sharing its allocation. `StringArrayHashMap` already
-        // boxed the trimmed key on insert above, so the reassignment is a
-        // no-op here; `dir_name` is kept solely for `add_directory`/`get_hash`.
-
-        let watch_index = match self.dev_bun_watcher().add_directory::<false>(
+        // `add_directory::<true>` so the `WatchItem` owns its path: the watcher
+        // retains the path until eviction runs (deferred onto `evict_list` and
+        // drained later in `flush_evictions`), but `dir_name_to_watch` is a
+        // transient `dirname()` view of a thread-local path buffer. A borrowed
+        // (`::<false>`) `Cow` would dangle once `insert` returns — well before
+        // the watcher reads it on a file event. Owning the copy also lets the
+        // map keep its own boxed key independently, so no extra intermediate
+        // `Box` is needed here.
+        let watch_index = match self.dev_bun_watcher().add_directory::<true>(
             fd,
-            &dir_name,
-            bun_watcher::Watcher::get_hash(&dir_name),
+            dir_name_to_watch,
+            bun_watcher::Watcher::get_hash(dir_name_to_watch),
         ) {
             Err(_) => return Err(DirectoryWatchInsertError::Ignore),
             Ok(id) => id,
@@ -1452,7 +1452,6 @@ impl DirectoryWatchStore {
             first_dep: dep,
             watch_index,
         };
-        let _ = dir_name; // keep alive past add_directory; dropped here
         Ok(())
     }
 


### PR DESCRIPTION
## Real use-after-free in the dev server's directory watcher

The live `DirectoryWatchStore` (`dev_server/mod.rs:998`, the one `DevServer.directory_watchers` actually uses) registered each watch with `add_directory::<false>`, which stores `Cow::Borrowed(detach_lifetime(file_path))` in the `WatchItem`. The borrowed bytes came from a local `dir_name: Box<[u8]>` that's dropped when `insert()` returns — but the `WatchItem` lives until eviction is actually drained later in `flush_evictions` (`remove_at_index` only *queues* onto `evict_list`). `on_file_update` reads the path for directory items in that window → reads freed memory.

The `::<false>` contract documents that the path must be process-lifetime (FileSystem-interned); here it's a transient `dirname()` view of a thread-local path buffer, which violates that.

### Fix
`add_directory::<true>` so the `WatchItem` owns its path (`Cow::Owned`), independent of any local. Pass `dir_name_to_watch` directly and drop the now-redundant intermediate `Box` — the map keeps its own boxed key. Net allocation count unchanged (watcher-owned copy replaces the intermediate Box), UAF removed.

### Notes
- Found via review of the clone-reduction PRs #31098/#31099, which fixed this in `DevServer/DirectoryWatchStore.rs` — but that file is mounted as `directory_watch_store_body` and has **zero usages** (dead draft port). Those PRs are closed; this fixes the live struct.
- `cargo check -p bun_bin` clean; `test/bake/dev/bundle.test.ts` 20 pass / 0 fail (incl. the DirectoryWatchStore deinit + free-list-slot repros).