### PR TITLE
fix(threading): avoid invalid Channel/FIFO read patterns

### DIFF
--- a/src/collections/linear_fifo.rs
+++ b/src/collections/linear_fifo.rs
@@ -280,9 +280,9 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
             // this copy overlaps
             let count = self.count;
             let head = self.head;
-            let buf = self.buf.as_mut_slice();
+            let buf = self.buf.as_mut_slice().as_mut_ptr();
             // SAFETY: src/dst within same allocation; ptr::copy is memmove.
-            unsafe { ptr::copy(buf.as_ptr().add(head), buf.as_mut_ptr(), count) };
+            unsafe { ptr::copy(buf.add(head), buf, count) };
             self.head = 0;
         } else {
             // Zig: `var tmp: [page_size_min / 2 / @sizeOf(T)]T = undefined;`
@@ -305,19 +305,15 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
             while self.head != 0 {
                 let n = self.head.min(tmp_len);
                 let m = buf_len - n;
-                let buf = self.buf.as_mut_slice();
+                let buf = self.buf.as_mut_slice().as_mut_ptr();
                 // SAFETY: `tmp` is disjoint from `buf`. The tmp↔buf copies move
                 // `n * size_of::<T>()` raw bytes (no `T` typed access through
                 // the 1-aligned scratch). The buf→buf shift overlaps, so use
                 // `ptr::copy` (memmove); it operates on properly-aligned `*T`.
                 unsafe {
-                    ptr::copy_nonoverlapping(buf.as_ptr().cast::<u8>(), tmp_ptr, n * t_size);
-                    ptr::copy(buf.as_ptr().add(n), buf.as_mut_ptr(), m);
-                    ptr::copy_nonoverlapping(
-                        tmp_ptr,
-                        buf.as_mut_ptr().add(m).cast::<u8>(),
-                        n * t_size,
-                    );
+                    ptr::copy_nonoverlapping(buf.cast::<u8>(), tmp_ptr, n * t_size);
+                    ptr::copy(buf.add(n), buf, m);
+                    ptr::copy_nonoverlapping(tmp_ptr, buf.add(m).cast::<u8>(), n * t_size);
                 }
                 self.head -= n;
             }
@@ -906,6 +902,24 @@ mod tests {
             let n = fifo.read(&mut read_buf);
             assert_eq!(3usize, n); // NOTE: It should be the number of items.
         }
+    }
+
+    #[test]
+    fn linear_fifo_realign_wrapped_buffer() {
+        let mut fifo = LinearFifo::<u8, StaticBuffer<u8, 8>>::init();
+
+        fifo.write(b"abcdefgh").unwrap();
+        assert_eq!(b'a', fifo.read_item().unwrap());
+        assert_eq!(b'b', fifo.read_item().unwrap());
+        assert_eq!(b'c', fifo.read_item().unwrap());
+        fifo.write(b"ijk").unwrap();
+
+        fifo.realign();
+
+        let mut result = [0u8; 8];
+        let n = fifo.read(&mut result);
+        assert_eq!(n, 8);
+        assert_eq!(&result, b"defghijk");
     }
 }
 

--- a/src/threading/channel.rs
+++ b/src/threading/channel.rs
@@ -2,7 +2,6 @@
 //   https://gist.github.com/kprotty/0d2dc3da4840341d6ff361b27bdac7dc#file-sync2-zig
 
 use core::cell::{Cell, UnsafeCell};
-use core::mem::MaybeUninit;
 
 use bun_collections::LinearFifo;
 use bun_collections::linear_fifo::{DynamicBuffer, LinearFifoBuffer, SliceBuffer, StaticBuffer};
@@ -120,25 +119,19 @@ impl<T: Copy, B: LinearFifoBuffer<T>> Channel<T, B> {
 
     // TODO(port): narrow error set
     pub fn try_read_item(&self) -> Result<Option<T>, ChannelError> {
-        let mut items: [MaybeUninit<T>; 1] = [MaybeUninit::uninit()];
-        // SAFETY: `read` only writes initialized `T` into the first `n` slots
-        // and returns `n`; we never read an uninitialized slot.
-        let slice = unsafe { &mut *items.as_mut_ptr().cast::<[T; 1]>() };
-        if self.read(slice)? != 1 {
-            return Ok(None);
-        }
-        // SAFETY: read() returned 1, so items[0] is initialized.
-        Ok(Some(unsafe { items[0].assume_init_read() }))
+        let _guard = self.mutex.lock_guard();
+        self.read_item_locked()
     }
 
     // TODO(port): narrow error set
     pub fn read_item(&self) -> Result<T, ChannelError> {
-        let mut items: [MaybeUninit<T>; 1] = [MaybeUninit::uninit()];
-        // SAFETY: see try_read_item.
-        let slice = unsafe { &mut *items.as_mut_ptr().cast::<[T; 1]>() };
-        self.read_all(slice)?;
-        // SAFETY: read_all() filled all slots.
-        Ok(unsafe { items[0].assume_init_read() })
+        let _guard = self.mutex.lock_guard();
+        loop {
+            if let Some(item) = self.read_item_locked()? {
+                return Ok(item);
+            }
+            self.getters.wait(&self.mutex);
+        }
     }
 
     // TODO(port): narrow error set
@@ -177,7 +170,7 @@ impl<T: Copy, B: LinearFifoBuffer<T>> Channel<T, B> {
                 }
                 // SAFETY: mutex is held; this &mut does not live across wait().
                 let buffer = unsafe { &mut *self.buffer.get() };
-                match buffer.write(items) {
+                match buffer.write_item(items[pushed]) {
                     Ok(()) => {}
                     Err(err) => {
                         if B::DYNAMIC {
@@ -210,25 +203,7 @@ impl<T: Copy, B: LinearFifoBuffer<T>> Channel<T, B> {
 
         let mut popped: usize = 0;
         while popped < items.len() {
-            // See write_items: re-derive UnsafeCell refs each iteration so no
-            // borrow lives across `getters.wait()` (which releases the mutex).
-            let new_item: Option<T> = 'blk: {
-                // SAFETY: mutex is held; this &mut does not live across wait().
-                let buffer = unsafe { &mut *self.buffer.get() };
-                // Buffer can contain null items but readItem will return null if the buffer is empty.
-                // we need to check if the buffer is empty before trying to read an item.
-                if buffer.readable_length() == 0 {
-                    if self.is_closed.get() {
-                        return Err(ChannelError::Closed);
-                    }
-                    break 'blk None;
-                }
-                let item = buffer.read_item();
-                self.putters.signal();
-                break 'blk item;
-            };
-
-            if let Some(item) = new_item {
+            if let Some(item) = self.read_item_locked()? {
                 items[popped] = item;
                 popped += 1;
             } else if should_block {
@@ -240,6 +215,58 @@ impl<T: Copy, B: LinearFifoBuffer<T>> Channel<T, B> {
 
         Ok(popped)
     }
+
+    fn read_item_locked(&self) -> Result<Option<T>, ChannelError> {
+        // See write_items: re-derive UnsafeCell refs for each operation so no
+        // borrow lives across `getters.wait()` (which releases the mutex).
+        // SAFETY: mutex is held by the caller; this &mut does not live across wait().
+        let buffer = unsafe { &mut *self.buffer.get() };
+        if buffer.readable_length() == 0 {
+            if self.is_closed.get() {
+                return Err(ChannelError::Closed);
+            }
+            return Ok(None);
+        }
+
+        let item = buffer
+            .read_item()
+            .expect("readable_length checked before read_item");
+        self.putters.signal();
+        Ok(Some(item))
+    }
 }
 
 // ported from: src/threading/channel.zig
+
+#[cfg(test)]
+mod tests {
+    use super::{Channel, ChannelError};
+
+    #[test]
+    fn single_item_reads_support_non_byte_payloads() {
+        let channel = Channel::<bool>::init_dynamic();
+
+        assert_eq!(channel.try_read_item(), Ok(None));
+
+        channel.write_item(true).unwrap();
+        assert_eq!(channel.try_read_item(), Ok(Some(true)));
+
+        channel.write_item(false).unwrap();
+        assert_eq!(channel.read_item(), Ok(false));
+
+        channel.close();
+        assert_eq!(channel.try_read_item(), Err(ChannelError::Closed));
+    }
+
+    #[test]
+    fn multi_item_write_appends_each_item_once() {
+        let channel = Channel::<u8>::init_dynamic();
+
+        assert_eq!(channel.write(&[1, 2, 3]), Ok(3));
+
+        let mut out = [0; 3];
+        channel.read_all(&mut out).unwrap();
+        assert_eq!(out, [1, 2, 3]);
+        assert_eq!(channel.try_read_item(), Ok(None));
+    }
+}


### PR DESCRIPTION
## What changed

This fixes the audit EXP-033 Channel single-item read shape in `bun_threading`.

`try_read_item()` and `read_item()` previously allocated `[MaybeUninit<T>; 1]`, cast that storage to `&mut [T; 1]`, and then routed through the slice-based read APIs. That fabricates a typed mutable reference before a valid `T` exists in the slot. For validity-sensitive payloads such as `bool`, the audit witness reports Miri UB while reading the uninitialized slot:

> Undefined Behavior: reading memory ... but memory is uninitialized

The single-item methods now pop directly from the locked FIFO through a shared helper, avoiding the temporary uninitialized `T` reference entirely. The helper preserves the existing empty/closed-channel behavior and still avoids holding the `UnsafeCell` buffer borrow across `Condition::wait()`.

During review, I also found a neighboring channel write bug: `write_items()` appended the entire input slice on every loop iteration while advancing `pushed` by one. That could duplicate multi-item writes (or return the wrong partial count for fixed buffers). It now writes exactly `items[pushed]` per successful iteration, matching the loop's accounting and blocking behavior.

Running the new dynamic-buffer multi-item test under Miri then exposed nearby `LinearFifo::realign` stacked-borrows issues: overlapping copies derived shared raw pointers and mutable raw pointers from the same slice. Both realign copy paths now derive source and destination from one mutable raw pointer.

## Test coverage

Added coverage for:

- `Channel<bool>` single-item reads, so the validity-sensitive payload case is exercised directly under Miri
- dynamic-buffer multi-item writes appending each item exactly once and leaving the channel empty after the expected reads
- wrapped-buffer `LinearFifo::realign`, which exercises the second raw-copy branch under Miri

## Verification

- `bun run fmt:rust`
- `env CARGO_TARGET_DIR=/tmp/bun-channel-fix-target cargo +nightly test -p bun_threading channel::tests`
- `env CARGO_TARGET_DIR=/tmp/bun-channel-fix-miri-target cargo +nightly miri test -p bun_threading channel::tests`
- `env CARGO_TARGET_DIR=/tmp/bun-channel-fix-target cargo +nightly check -p bun_threading`
- `env CARGO_TARGET_DIR=/tmp/bun-channel-fix-target cargo +nightly test -p bun_collections linear_fifo`
- `env CARGO_TARGET_DIR=/tmp/bun-channel-fix-miri-target cargo +nightly miri test -p bun_collections linear_fifo_realign_wrapped_buffer`
- `env CARGO_TARGET_DIR=/tmp/bun-channel-fix-target cargo +nightly check -p bun_collections`
- `git diff --check`
- `env CARGO_TARGET_DIR=/tmp/bun-channel-clean-target cargo +nightly check --workspace` from a clean `HEAD` snapshot

The workspace check only emitted existing warnings.
