### PR TITLE
module_loader: set has_loaded on every transpile_source_code return path

### DIFF
--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2067,22 +2067,11 @@ fn transpile_source_code_inner(
             let (main, main_hash) = unsafe { ((*jsc_vm).main(), (*jsc_vm).main_hash) };
             let is_main = main.len() == path.text.len() && main_hash == hash && main == path.text;
 
-            // Spec :545-549 — `defer { if (is_main) jsc_vm.has_loaded = true }`.
-            // Hoisted to a scopeguard at the top of the JS-like arm so it runs
-            // on every return path. The Zig spec registers the `defer` *after*
-            // the cache-hit / already_bundled / disable_transpiling early
-            // returns (:417-466), so a transpiler-cache hit on the entry file
-            // would leave `has_loaded == false` and the concurrent-transpiler
-            // gate in `transpile_file` would route every child import through
-            // the synchronous fallback. Hoisting matches the intent (entry
-            // transpiled ⇒ concurrent loader unlocked) on all paths.
             let _has_loaded_guard = scopeguard::guard((), {
                 let jsc_vm = jsc_vm;
                 move |_| {
                     if is_main {
-                        // SAFETY: per fn contract — `jsc_vm` is the live
-                        // per-thread VM; this guard runs on the same thread
-                        // before the hook returns.
+                        // SAFETY: per fn contract.
                         unsafe { (*jsc_vm).has_loaded = true };
                     }
                 }
@@ -2973,8 +2962,6 @@ fn transpile_source_code_inner(
                         )?;
                     }
                 }
-
-                // (`has_loaded = true` is set by `_has_loaded_guard` above.)
 
                 // Spec :553-558 — watcher path uses ref-counted source.
                 // TODO(b2-blocked): `VirtualMachine::ref_counted_resolved_source`.

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2067,6 +2067,27 @@ fn transpile_source_code_inner(
             let (main, main_hash) = unsafe { ((*jsc_vm).main(), (*jsc_vm).main_hash) };
             let is_main = main.len() == path.text.len() && main_hash == hash && main == path.text;
 
+            // Spec :545-549 — `defer { if (is_main) jsc_vm.has_loaded = true }`.
+            // Hoisted to a scopeguard at the top of the JS-like arm so it runs
+            // on every return path. The Zig spec registers the `defer` *after*
+            // the cache-hit / already_bundled / disable_transpiling early
+            // returns (:417-466), so a transpiler-cache hit on the entry file
+            // would leave `has_loaded == false` and the concurrent-transpiler
+            // gate in `transpile_file` would route every child import through
+            // the synchronous fallback. Hoisting matches the intent (entry
+            // transpiled ⇒ concurrent loader unlocked) on all paths.
+            let _has_loaded_guard = scopeguard::guard((), {
+                let jsc_vm = jsc_vm;
+                move |_| {
+                    if is_main {
+                        // SAFETY: per fn contract — `jsc_vm` is the live
+                        // per-thread VM; this guard runs on the same thread
+                        // before the hook returns.
+                        unsafe { (*jsc_vm).has_loaded = true };
+                    }
+                }
+            });
+
             // ── Arena take/give-back ────────────────────────────────────────
             // Spec :128-165. Reuse the per-VM arena when free; allocate a
             // fresh boxed one otherwise. `give_back_arena` is cleared on the
@@ -2953,9 +2974,7 @@ fn transpile_source_code_inner(
                     }
                 }
 
-                if is_main {
-                    unsafe { (*jsc_vm).has_loaded = true };
-                }
+                // (`has_loaded = true` is set by `_has_loaded_guard` above.)
 
                 // Spec :553-558 — watcher path uses ref-counted source.
                 // TODO(b2-blocked): `VirtualMachine::ref_counted_resolved_source`.

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -176,6 +176,28 @@ describe("transpiler cache", () => {
       chmodSync(join(cache_dir), "777");
     }
   });
+  test("unknown-extension child import still uses file loader after entry cache hit", () => {
+    // Entry is large enough to cache; second run serves it from the cache and
+    // returns early out of transpile_source_code before the print path. The
+    // child's extension is not in the loader map, so loader selection in
+    // transpile_file falls through to the has_loaded gate — which must pick
+    // the file loader (path string) on the cache-hit run just like the first.
+    const pad = Buffer.alloc(50 * 1024, "*").toString();
+    writeFileSync(
+      join(temp_dir, "entry.js"),
+      `/*${pad}*/\nimport x from "./data.unknownext";\nconsole.log(typeof x === "string" && x.endsWith("data.unknownext") ? "file-loader" : "wrong:" + JSON.stringify(x));\n`,
+    );
+    writeFileSync(join(temp_dir, "data.unknownext"), `export default 42;\n`);
+
+    const a = bunRun(join(temp_dir, "entry.js"), env);
+    expect(a.stdout).toBe("file-loader");
+    expect(existsSync(cache_dir)).toBeTrue();
+    expect(newCacheCount()).toBe(1);
+
+    const b = bunRun(join(temp_dir, "entry.js"), env);
+    expect(b.stdout).toBe("file-loader");
+    expect(newCacheCount()).toBe(0);
+  });
   test("does not inline process.env", () => {
     writeFileSync(
       join(temp_dir, "a.js"),


### PR DESCRIPTION
## What

Hoist `has_loaded = true` to a scopeguard at the top of the JS-like arm in `transpile_source_code_inner`, so it runs on every return path instead of only the fall-through print path.

## What happened in Zig

`ModuleLoader.zig:545-549` registers `defer { if (is_main) jsc_vm.has_loaded = true }` — but the `defer` is registered *after* the RuntimeTranspilerCache / `already_bundled` / `disable_transpiling` early returns at `:417-466`. So if the entry file takes one of those early returns, the `defer` never registers and `has_loaded` stays `false`.

## What it fixes

The concurrent-transpiler gate in `transpile_file` requires `has_loaded || is_in_preload`. When the entry file is served from the runtime transpiler cache, `has_loaded` was never set, so every direct child import of the entry fell through to the synchronous transpile path instead of being dispatched to the work pool.

There is also a user-visible effect: the synchronous-loader fallback in `transpile_file` picks `Loader::File` for an unknown-extension ESM child only when `has_loaded || is_in_preload`, otherwise it falls back to `Loader::Tsx`. So on a cache-hit run, `import x from "./data.unknownext"` would execute the file contents as TSX instead of yielding the path string. Covered by a new case in `test/cli/run/transpiler-cache.test.ts`.
