### PR TITLE
Add `Subprocess.killTree(signal)` and `deathSignal` spawn option

### DIFF
--- a/docs/runtime/child-process.mdx
+++ b/docs/runtime/child-process.mdx
@@ -147,6 +147,17 @@ proc.kill(15); // specify a signal code
 proc.kill("SIGTERM"); // specify a signal name
 ```
 
+`proc.kill()` signals the child process only. Processes the child started, such as the compilers a build tool forked, keep running after the child dies. `proc.killTree()` signals the child and every process descended from it:
+
+```ts index.ts icon="/icons/typescript.svg"
+const proc = Bun.spawn(["sh", "-c", "sleep 1000 & wait"]);
+
+proc.killTree(); // SIGTERM the shell and the sleep it started
+proc.killTree("SIGKILL"); // accepts the same signal names and numbers as kill()
+```
+
+On Linux and macOS, Bun first stops every process in the tree with `SIGSTOP`, so none of them can fork or exit while Bun lists them. Bun then sends the signal to each process, deepest descendants first, and resumes the processes with `SIGCONT` so that the signal is delivered. Bun skips the `SIGCONT` for `SIGKILL`, which terminates a stopped process as well, and for stop signals, so `proc.killTree("SIGSTOP")` pauses the whole tree and `proc.killTree("SIGCONT")` resumes it. [`--no-orphans`](/runtime/bunfig#run-noorphans) uses the same walk when Bun itself exits. On other platforms, `killTree()` behaves like `kill()` and signals the child process only.
+
 The parent `bun` process does not terminate until all child processes have exited. Use `proc.unref()` to detach the child process from the parent.
 
 ```ts index.ts icon="/icons/typescript.svg"
@@ -232,6 +243,19 @@ const proc = Bun.spawn({
 ```
 
 The `killSignal` option also controls which signal Bun sends when an AbortSignal is aborted.
+
+## Using deathSignal (Linux)
+
+By default, a child outlives its parent. If something kills the Bun process with `SIGKILL`, the processes it spawned keep running. On Linux, `deathSignal` makes the kernel send the child that signal as soon as the thread that spawned it exits, for any reason. Bun sets it up with `prctl(PR_SET_PDEATHSIG)` in the child before `exec`, so there is no window in which the child can miss it:
+
+```ts index.ts icon="/icons/typescript.svg"
+const proc = Bun.spawn({
+  cmd: ["sleep", "1000"],
+  deathSignal: "SIGKILL", // signal name or number
+});
+```
+
+The kernel ties the death signal to the spawning thread. A child spawned from a `Worker` receives it when that worker terminates. With [`--no-orphans`](/runtime/bunfig#run-noorphans), Bun gives every spawn a death signal of `SIGKILL` unless the spawn passes its own `deathSignal`. Like `killSignal`, `deathSignal` must name a real signal; Bun rejects `0`. Bun ignores the option on other platforms.
 
 ## Using maxBuffer
 
@@ -541,6 +565,7 @@ namespace SpawnOptions {
     signal?: AbortSignal;
     timeout?: number;
     killSignal?: string | number;
+    deathSignal?: NodeJS.Signals | number; // Linux only; sent to the child when the spawning thread dies
     maxBuffer?: number;
     cgroup?: string | number; // Linux only; cgroup directory path or open directory fd
     terminal?: TerminalOptions | Terminal; // PTY (POSIX) / ConPTY (Windows) support
@@ -584,6 +609,7 @@ interface Subprocess extends AsyncDisposable {
   readonly killed: boolean;
 
   kill(exitCode?: number | NodeJS.Signals): void;
+  killTree(signal?: number | NodeJS.Signals): void; // also signals every descendant (Linux/macOS)
   ref(): void;
   unref(): void;
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7362,6 +7362,29 @@ declare module "bun" {
       killSignal?: string | number;
 
       /**
+       * On Linux, arrange for the child to receive this signal when the
+       * thread that spawned it dies (via `prctl(PR_SET_PDEATHSIG)`), so the
+       * child cannot outlive its parent even if the parent is `SIGKILL`ed.
+       *
+       * Note that `PR_SET_PDEATHSIG` is keyed to the spawning *thread*, not
+       * the process — a child spawned from a `Worker` will receive this
+       * signal when that `Worker` terminates.
+       *
+       * Ignored on macOS and Windows.
+       *
+       * @default undefined (no signal; `"SIGKILL"` when `--no-orphans` is enabled)
+       *
+       * @example
+       * ```ts
+       * const subprocess = Bun.spawn({
+       *   cmd: ["sleep", "1000"],
+       *   deathSignal: "SIGKILL",
+       * });
+       * ```
+       */
+      deathSignal?: NodeJS.Signals | number;
+
+      /**
        * The maximum number of bytes the process may output. If the process goes over this limit,
        * it is killed with signal `killSignal` (defaults to SIGTERM).
        *

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7367,9 +7367,10 @@ declare module "bun" {
        * child cannot outlive its parent even if the parent is `SIGKILL`ed.
        *
        * Note that `PR_SET_PDEATHSIG` is keyed to the spawning *thread*, not
-       * the process — a child spawned from a `Worker` will receive this
+       * the process: a child spawned from a `Worker` will receive this
        * signal when that `Worker` terminates.
        *
+       * Must be a real signal; `0` is rejected, as it is for `killSignal`.
        * Ignored on platforms other than Linux.
        *
        * @default undefined (no signal; `"SIGKILL"` when `--no-orphans` is enabled)

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7370,7 +7370,7 @@ declare module "bun" {
        * the process — a child spawned from a `Worker` will receive this
        * signal when that `Worker` terminates.
        *
-       * Ignored on macOS and Windows.
+       * Ignored on platforms other than Linux.
        *
        * @default undefined (no signal; `"SIGKILL"` when `--no-orphans` is enabled)
        *

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7633,6 +7633,24 @@ declare module "bun" {
     kill(exitCode?: number | NodeJS.Signals): void;
 
     /**
+     * Kill the process and all of its descendants.
+     *
+     * On Linux and macOS, this walks the process tree rooted at this
+     * subprocess and sends the signal to every descendant, using the same
+     * mechanism as `--no-orphans`. The tree is frozen with `SIGSTOP` while
+     * it is enumerated so processes cannot fork or exit out from under the
+     * walk; each pid's parent is re-verified after freezing to guard against
+     * pid reuse. For catchable signals, `SIGCONT` is sent afterwards so the
+     * pending signal is delivered.
+     *
+     * On Windows, this currently behaves the same as {@link kill} and only
+     * signals the root process.
+     *
+     * @param signal The signal to send (name or number). Defaults to `SIGTERM`.
+     */
+    killTree(signal?: number | NodeJS.Signals): void;
+
+    /**
      * Tell Bun to wait for this process to exit after you already
      * called `unref()`.
      *

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7666,10 +7666,13 @@ declare module "bun" {
      * pid reuse. For catchable signals, `SIGCONT` is sent afterwards so the
      * pending signal is delivered.
      *
-     * On Windows, this currently behaves the same as {@link kill} and only
-     * signals the root process.
+     * On Windows and on POSIX platforms other than Linux/macOS, this
+     * currently behaves the same as {@link kill} and only signals the root
+     * process.
      *
-     * @param signal The signal to send (name or number). Defaults to `SIGTERM`.
+     * @param signal The signal to send (name or number). Defaults to
+     * `SIGTERM`. Passing `0` performs a liveness probe on the root process
+     * (equivalent to `kill(0)`) and does not walk or signal descendants.
      */
     killTree(signal?: number | NodeJS.Signals): void;
 

--- a/src/io/ParentDeathWatchdog.rs
+++ b/src/io/ParentDeathWatchdog.rs
@@ -365,9 +365,7 @@ extern "C" fn on_process_exit() {
     kill_sync_pgroups_and_descendants();
 }
 
-/// Walk the process tree rooted at `getpid()` and SIGKILL every descendant.
-/// Thin wrapper over [`signal_process_tree`] with `root = getpid()` (root
-/// excluded from the signal set) and `signal = SIGKILL`.
+/// SIGKILL every descendant of `getpid()` (we ourselves are not signalled).
 fn kill_descendants() {
     #[cfg(unix)]
     {
@@ -375,10 +373,7 @@ fn kill_descendants() {
     }
 }
 
-/// Walk the process tree rooted at `root` (a direct child of ours) and send
-/// `signal` to `root` and every descendant. Public entry point for
-/// `Subprocess.killTree()`. `root`'s ppid is verified against `getpid()`
-/// before anything is signalled, so a recycled pid is left alone.
+/// `Subprocess.killTree()`: send `signal` to our direct child `root` and every descendant.
 pub fn kill_process_tree(root: libc::pid_t, signal: c_int) {
     #[cfg(unix)]
     {
@@ -390,10 +385,6 @@ pub fn kill_process_tree(root: libc::pid_t, signal: c_int) {
     }
 }
 
-/// Freeze-walk the process tree rooted at `root` and send `signal` to every
-/// verified descendant (and to `root` itself when `expected_ppid_of_root` is
-/// `Some`).
-///
 /// Pid-reuse safety: enumeration is a point-in-time snapshot, so a pid we
 /// collect could exit and be recycled by an unrelated process before we
 /// signal it. To avoid killing an innocent process we use a
@@ -403,20 +394,10 @@ pub fn kill_process_tree(root: libc::pid_t, signal: c_int) {
 ///      longer `parent`, the pid was recycled in the (microsecond) window
 ///      between enumerate and STOP — undo with SIGCONT and skip. Otherwise
 ///      `c` is now frozen and confirmed ours; recurse into it.
-///   3. Once the whole tree is frozen, send `signal` to each pid
-///      (leaves-first). SIGKILL terminates stopped processes directly; any
-///      other signal is queued while stopped, so a follow-up SIGCONT is sent
-///      to let it deliver.
+///   3. Once the whole tree is frozen, signal each pid leaves-first.
 /// A frozen process can neither exit (so its pid can't be reused) nor fork
 /// (so its child set is stable while we recurse), which is what makes the
-/// verify step sufficient.
-///
-/// `expected_ppid_of_root`:
-///   - `Some(ppid)` — `root` is frozen, its ppid verified against `ppid`, and
-///     it is included in the signal set. Used when `root` is a child process
-///     we want to signal along with its descendants.
-///   - `None` — `root` is left untouched (neither frozen nor signalled). Used
-///     when `root == getpid()` and we only want to reach our descendants.
+/// verify step sufficient. `expected_ppid_of_root` opts `root` itself into the same treatment.
 #[cfg(unix)]
 fn signal_process_tree(
     root: libc::pid_t,
@@ -428,19 +409,13 @@ fn signal_process_tree(
     let mut to_visit: Vec<libc::pid_t> = Vec::new();
     let mut to_kill: Vec<libc::pid_t> = Vec::new();
 
-    // Whether to send SIGCONT after `signal`. SIGKILL terminates a stopped
-    // process directly. For the stop-class signals, generating SIGCONT
-    // *discards* all pending stop signals (POSIX XSH 2.4.1 / Linux
-    // `prepare_signal()` flushes SIG_KERNEL_STOP_MASK), so waking would
-    // undo the caller's intent — leave the tree stopped, which is the
-    // requested end state.
+    // SIGKILL needs no wake-up, and SIGCONT discards pending stop signals (POSIX XSH 2.4.1).
     let needs_cont = !matches!(
         signal,
         libc::SIGKILL | libc::SIGSTOP | libc::SIGTSTP | libc::SIGTTIN | libc::SIGTTOU
     );
 
-    // Deliver `signal` to a STOPped+verified pid we couldn't record (OOM).
-    // Runs immediately so we don't leave it frozen.
+    // On OOM, signal a frozen pid immediately rather than leave it stopped and unrecorded.
     let signal_now = |pid: libc::pid_t| {
         let _ = kill(pid, signal);
         if needs_cont {
@@ -485,8 +460,6 @@ fn signal_process_tree(
                 continue;
             }
             if to_kill.try_reserve(1).is_err() {
-                // OOM after we've already STOPped+verified this child — signal it
-                // now rather than leaving it frozen and absent from to_kill.
                 signal_now(child);
                 break;
             }
@@ -498,14 +471,13 @@ fn signal_process_tree(
         }
     }
 
-    // Reverse: leaves first. SIGKILL terminates stopped processes directly.
+    // Leaves first.
     let mut i = to_kill.len();
     while i > 0 {
         i -= 1;
         let _ = kill(to_kill[i], signal);
     }
-    // Catchable signals are queued while stopped — wake each so it delivers.
-    // SIGKILL and stop-class signals are excluded (see `needs_cont` above).
+    // A signal queued against a stopped process only delivers once it is continued.
     if needs_cont {
         for &pid in &to_kill {
             let _ = kill(pid, libc::SIGCONT);

--- a/src/io/ParentDeathWatchdog.rs
+++ b/src/io/ParentDeathWatchdog.rs
@@ -366,72 +366,139 @@ extern "C" fn on_process_exit() {
 }
 
 /// Walk the process tree rooted at `getpid()` and SIGKILL every descendant.
+/// Thin wrapper over [`signal_process_tree`] with `root = getpid()` (root
+/// excluded from the signal set) and `signal = SIGKILL`.
+fn kill_descendants() {
+    #[cfg(unix)]
+    {
+        signal_process_tree(getpid(), None, libc::SIGKILL);
+    }
+}
+
+/// Walk the process tree rooted at `root` (a direct child of ours) and send
+/// `signal` to `root` and every descendant. Public entry point for
+/// `Subprocess.killTree()`. `root`'s ppid is verified against `getpid()`
+/// before anything is signalled, so a recycled pid is left alone.
+pub fn kill_process_tree(root: libc::pid_t, signal: c_int) {
+    #[cfg(unix)]
+    {
+        signal_process_tree(root, Some(getpid()), signal);
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (root, signal);
+    }
+}
+
+/// Freeze-walk the process tree rooted at `root` and send `signal` to every
+/// verified descendant (and to `root` itself when `expected_ppid_of_root` is
+/// `Some`).
 ///
 /// Pid-reuse safety: enumeration is a point-in-time snapshot, so a pid we
 /// collect could exit and be recycled by an unrelated process before we
 /// signal it. To avoid killing an innocent process we use a
-/// stop-verify-kill pattern:
+/// stop-verify-signal pattern:
 ///   1. Enumerate children of `parent`.
 ///   2. For each child `c`: SIGSTOP it, then re-read `c`'s ppid. If it's no
 ///      longer `parent`, the pid was recycled in the (microsecond) window
 ///      between enumerate and STOP — undo with SIGCONT and skip. Otherwise
 ///      `c` is now frozen and confirmed ours; recurse into it.
-///   3. Once the whole tree is frozen, SIGKILL each pid (leaves-first).
-///      SIGKILL terminates stopped processes directly — no SIGCONT needed —
-///      and unlike SIGTERM can't be trapped or ignored.
+///   3. Once the whole tree is frozen, send `signal` to each pid
+///      (leaves-first). SIGKILL terminates stopped processes directly; any
+///      other signal is queued while stopped, so a follow-up SIGCONT is sent
+///      to let it deliver.
 /// A frozen process can neither exit (so its pid can't be reused) nor fork
 /// (so its child set is stable while we recurse), which is what makes the
-/// verify step sufficient. The only forking process is `self`, and we're in
-/// the exit handler — not forking.
-fn kill_descendants() {
-    #[cfg(unix)]
-    {
-        let self_pid = getpid();
+/// verify step sufficient.
+///
+/// `expected_ppid_of_root`:
+///   - `Some(ppid)` — `root` is frozen, its ppid verified against `ppid`, and
+///     it is included in the signal set. Used when `root` is a child process
+///     we want to signal along with its descendants.
+///   - `None` — `root` is left untouched (neither frozen nor signalled). Used
+///     when `root == getpid()` and we only want to reach our descendants.
+#[cfg(unix)]
+fn signal_process_tree(
+    root: libc::pid_t,
+    expected_ppid_of_root: Option<libc::pid_t>,
+    signal: c_int,
+) {
+    let self_pid = getpid();
 
-        let mut to_visit: Vec<libc::pid_t> = Vec::new();
-        let mut to_kill: Vec<libc::pid_t> = Vec::new();
+    let mut to_visit: Vec<libc::pid_t> = Vec::new();
+    let mut to_kill: Vec<libc::pid_t> = Vec::new();
 
-        to_visit.push(self_pid);
-
-        let mut buf: [libc::pid_t; 4096] = [0; 4096];
-        // Hard cap on tree size so a fork bomb under us can't make exit hang.
-        while !to_visit.is_empty() && to_kill.len() < 4096 {
-            let parent = to_visit.swap_remove(to_visit.len() - 1);
-            let Some(n) = list_child_pids(parent, &mut buf) else {
-                continue;
-            };
-            for &child in &buf[..n] {
-                if child == self_pid || child <= 1 {
-                    continue;
-                }
-                // Freeze first, then confirm it's still the process we enumerated.
-                if kill(child, libc::SIGSTOP) != 0 {
-                    continue;
-                }
-                if parent_pid_of(child) != parent {
-                    // Recycled between enumerate and STOP — undo and skip.
-                    let _ = kill(child, libc::SIGCONT);
-                    continue;
-                }
-                if to_kill.try_reserve(1).is_err() {
-                    // OOM after we've already STOPped+verified this child — kill it
-                    // now rather than leaving it frozen and absent from to_kill.
-                    let _ = kill(child, libc::SIGKILL);
-                    break;
-                }
-                to_kill.push(child);
-                if to_visit.try_reserve(1).is_err() {
-                    break;
-                }
-                to_visit.push(child);
-            }
+    // Deliver `signal` to a STOPped+verified pid we couldn't record (OOM).
+    // Runs immediately so we don't leave it frozen.
+    let signal_now = |pid: libc::pid_t| {
+        let _ = kill(pid, signal);
+        if signal != libc::SIGKILL && signal != libc::SIGSTOP {
+            let _ = kill(pid, libc::SIGCONT);
         }
+    };
 
-        // Reverse: leaves first. SIGKILL terminates stopped processes directly.
-        let mut i = to_kill.len();
-        while i > 0 {
-            i -= 1;
-            let _ = kill(to_kill[i], libc::SIGKILL);
+    if let Some(expected_ppid) = expected_ppid_of_root {
+        if kill(root, libc::SIGSTOP) != 0 {
+            return;
+        }
+        if parent_pid_of(root) != expected_ppid {
+            let _ = kill(root, libc::SIGCONT);
+            return;
+        }
+        if to_kill.try_reserve(1).is_err() {
+            signal_now(root);
+            return;
+        }
+        to_kill.push(root);
+    }
+    to_visit.push(root);
+
+    let mut buf: [libc::pid_t; 4096] = [0; 4096];
+    // Hard cap on tree size so a fork bomb under us can't make this hang.
+    while !to_visit.is_empty() && to_kill.len() < 4096 {
+        let parent = to_visit.swap_remove(to_visit.len() - 1);
+        let Some(n) = list_child_pids(parent, &mut buf) else {
+            continue;
+        };
+        for &child in &buf[..n] {
+            if child == self_pid || child <= 1 {
+                continue;
+            }
+            // Freeze first, then confirm it's still the process we enumerated.
+            if kill(child, libc::SIGSTOP) != 0 {
+                continue;
+            }
+            if parent_pid_of(child) != parent {
+                // Recycled between enumerate and STOP — undo and skip.
+                let _ = kill(child, libc::SIGCONT);
+                continue;
+            }
+            if to_kill.try_reserve(1).is_err() {
+                // OOM after we've already STOPped+verified this child — signal it
+                // now rather than leaving it frozen and absent from to_kill.
+                signal_now(child);
+                break;
+            }
+            to_kill.push(child);
+            if to_visit.try_reserve(1).is_err() {
+                break;
+            }
+            to_visit.push(child);
+        }
+    }
+
+    // Reverse: leaves first. SIGKILL terminates stopped processes directly.
+    let mut i = to_kill.len();
+    while i > 0 {
+        i -= 1;
+        let _ = kill(to_kill[i], signal);
+    }
+    // Catchable signals are queued while stopped — wake each so it delivers.
+    // SIGKILL/SIGSTOP bypass this (the former already terminated them; the
+    // latter is what the caller asked for).
+    if signal != libc::SIGKILL && signal != libc::SIGSTOP {
+        for &pid in &to_kill {
+            let _ = kill(pid, libc::SIGCONT);
         }
     }
 }
@@ -517,58 +584,7 @@ pub fn kill_subreaper_adoptees(siblings: &[libc::pid_t]) {
 /// `root` itself before recursing (ppid==us for subreaper adoptees).
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn kill_tree_rooted_at(root: libc::pid_t, expected_ppid_of_root: libc::pid_t) {
-    let mut to_visit: Vec<libc::pid_t> = Vec::new();
-    let mut to_kill: Vec<libc::pid_t> = Vec::new();
-
-    if kill(root, libc::SIGSTOP) != 0 {
-        return;
-    }
-    if parent_pid_of(root) != expected_ppid_of_root {
-        let _ = kill(root, libc::SIGCONT);
-        return;
-    }
-    if to_kill.try_reserve(1).is_err() {
-        let _ = kill(root, libc::SIGKILL);
-        return;
-    }
-    to_kill.push(root);
-    let _ = to_visit.try_reserve(1);
-    to_visit.push(root);
-
-    let mut buf: [libc::pid_t; 4096] = [0; 4096];
-    while !to_visit.is_empty() && to_kill.len() < 4096 {
-        let parent = to_visit.swap_remove(to_visit.len() - 1);
-        let Some(n) = list_child_pids(parent, &mut buf) else {
-            continue;
-        };
-        for &child in &buf[..n] {
-            if child <= 1 {
-                continue;
-            }
-            if kill(child, libc::SIGSTOP) != 0 {
-                continue;
-            }
-            if parent_pid_of(child) != parent {
-                let _ = kill(child, libc::SIGCONT);
-                continue;
-            }
-            if to_kill.try_reserve(1).is_err() {
-                let _ = kill(child, libc::SIGKILL);
-                break;
-            }
-            to_kill.push(child);
-            if to_visit.try_reserve(1).is_err() {
-                break;
-            }
-            to_visit.push(child);
-        }
-    }
-
-    let mut i = to_kill.len();
-    while i > 0 {
-        i -= 1;
-        let _ = kill(to_kill[i], libc::SIGKILL);
-    }
+    signal_process_tree(root, Some(expected_ppid_of_root), libc::SIGKILL);
 }
 
 /// Best-effort ppid lookup for an arbitrary pid. Returns 0 if the process

--- a/src/io/ParentDeathWatchdog.rs
+++ b/src/io/ParentDeathWatchdog.rs
@@ -428,11 +428,22 @@ fn signal_process_tree(
     let mut to_visit: Vec<libc::pid_t> = Vec::new();
     let mut to_kill: Vec<libc::pid_t> = Vec::new();
 
+    // Whether to send SIGCONT after `signal`. SIGKILL terminates a stopped
+    // process directly. For the stop-class signals, generating SIGCONT
+    // *discards* all pending stop signals (POSIX XSH 2.4.1 / Linux
+    // `prepare_signal()` flushes SIG_KERNEL_STOP_MASK), so waking would
+    // undo the caller's intent — leave the tree stopped, which is the
+    // requested end state.
+    let needs_cont = !matches!(
+        signal,
+        libc::SIGKILL | libc::SIGSTOP | libc::SIGTSTP | libc::SIGTTIN | libc::SIGTTOU
+    );
+
     // Deliver `signal` to a STOPped+verified pid we couldn't record (OOM).
     // Runs immediately so we don't leave it frozen.
     let signal_now = |pid: libc::pid_t| {
         let _ = kill(pid, signal);
-        if signal != libc::SIGKILL && signal != libc::SIGSTOP {
+        if needs_cont {
             let _ = kill(pid, libc::SIGCONT);
         }
     };
@@ -494,9 +505,8 @@ fn signal_process_tree(
         let _ = kill(to_kill[i], signal);
     }
     // Catchable signals are queued while stopped — wake each so it delivers.
-    // SIGKILL/SIGSTOP bypass this (the former already terminated them; the
-    // latter is what the caller asked for).
-    if signal != libc::SIGKILL && signal != libc::SIGSTOP {
+    // SIGKILL and stop-class signals are excluded (see `needs_cont` above).
+    if needs_cont {
         for &pid in &to_kill {
             let _ = kill(pid, libc::SIGCONT);
         }

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -264,6 +264,8 @@ pub mod parent_death_watchdog {
 
     #[inline]
     pub fn install_on_event_loop(_handle: EventLoopCtx) {}
+    #[inline]
+    pub fn kill_process_tree(_root: i32, _signal: core::ffi::c_int) {}
 }
 pub use parent_death_watchdog as ParentDeathWatchdog;
 

--- a/src/runtime/api/BunObject.classes.ts
+++ b/src/runtime/api/BunObject.classes.ts
@@ -96,6 +96,10 @@ export default [
         fn: "kill",
         length: 1,
       },
+      killTree: {
+        fn: "killTree",
+        length: 1,
+      },
       disconnect: {
         fn: "disconnect",
         length: 0,

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -385,6 +385,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
     let mut uid: Option<u32> = None;
     let mut gid: Option<u32> = None;
     let mut kill_signal: SignalCode = SignalCode::DEFAULT;
+    let mut death_signal: Option<SignalCode> = None;
     let mut max_buffer: Option<i64> = None;
     #[cfg(any(target_os = "linux", target_os = "android"))]
     let mut cgroup: Option<CgroupTarget> = None;
@@ -795,6 +796,12 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
                 }
             }
 
+            if let Some(val) = args.get(global_this, "deathSignal")? {
+                if !val.is_empty_or_undefined_or_null() {
+                    death_signal = Some(signal_code_from_js(val, global_this)?);
+                }
+            }
+
             if let Some(val) = args.get(global_this, "maxBuffer")? {
                 if val.is_number() && val.is_finite() {
                     // 'Infinity' does not set maxBuffer
@@ -1150,6 +1157,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
         detached,
         uid,
         gid,
+        linux_pdeathsig: death_signal.map(|s| s.0),
         stdin: match stdio[0].as_spawn_option(0) {
             stdio::ResultT::Result(opt) => opt,
             stdio::ResultT::Err(e) => return Err(e.throw_js(global_this)),

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -798,7 +798,16 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
 
             if let Some(val) = args.get(global_this, "deathSignal")? {
                 if !val.is_empty_or_undefined_or_null() {
-                    death_signal = Some(signal_code_from_js(val, global_this)?);
+                    let sig = signal_code_from_js(val, global_this)?;
+                    if sig.0 == 0 {
+                        return Err(global_this
+                            .err(
+                                jsc::ErrorCode::ERR_UNKNOWN_SIGNAL,
+                                format_args!("Unknown signal: 0"),
+                            )
+                            .throw());
+                    }
+                    death_signal = Some(sig);
                 }
             }
 

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -768,6 +768,39 @@ impl Subprocess<'_> {
         self.process_mut().kill(sig.0)
     }
 
+    #[bun_jsc::host_fn(method)]
+    pub(crate) fn kill_tree(
+        this: &Self,
+        global_this: &JSGlobalObject,
+        callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        this.this_value
+            .with_mut(|v| v.update(global_this, callframe.this()));
+
+        let [signal_arg] = callframe.arguments_as_array::<1>();
+        let sig: SignalCode = bun_sys_jsc::signal_code_jsc::from_js(signal_arg, global_this)?;
+
+        if global_this.has_exception() {
+            return Ok(JSValue::ZERO);
+        }
+
+        match this.try_kill_tree(sig) {
+            bun_sys::Result::Ok(()) => {}
+            bun_sys::Result::Err(err) => {
+                return Err(global_this.throw_value(err.to_js(global_this)));
+            }
+        }
+
+        Ok(JSValue::UNDEFINED)
+    }
+
+    pub(crate) fn try_kill_tree(&self, sig: SignalCode) -> bun_sys::Result<()> {
+        if self.has_exited() {
+            return bun_sys::Result::Ok(());
+        }
+        self.process_mut().kill_tree(sig.0)
+    }
+
     fn has_called_getter(&self, getter: ObservableGetter) -> bool {
         self.observable_getters.get().contains(getter)
     }

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -798,6 +798,14 @@ impl Subprocess<'_> {
         if self.has_exited() {
             return bun_sys::Result::Ok(());
         }
+        // Signal 0 is a liveness probe (`kill(pid, 0)` → ESRCH/EPERM check).
+        // The tree walk SIGSTOPs every descendant before signalling, which
+        // for signal 0 would observably pause/resume the whole tree and undo
+        // any deliberate SIGSTOP the user had issued. Route it to plain
+        // kill() so `killTree(0)` behaves like `kill(0)`.
+        if sig.0 == 0 {
+            return self.process_mut().kill(0);
+        }
         self.process_mut().kill_tree(sig.0)
     }
 

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -798,11 +798,7 @@ impl Subprocess<'_> {
         if self.has_exited() {
             return bun_sys::Result::Ok(());
         }
-        // Signal 0 is a liveness probe (`kill(pid, 0)` → ESRCH/EPERM check).
-        // The tree walk SIGSTOPs every descendant before signalling, which
-        // for signal 0 would observably pause/resume the whole tree and undo
-        // any deliberate SIGSTOP the user had issued. Route it to plain
-        // kill() so `killTree(0)` behaves like `kill(0)`.
+        // Signal 0 is a liveness probe; walking (and so stopping) the tree for it would be observable.
         if sig.0 == 0 {
             return self.process_mut().kill(0);
         }

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -689,11 +689,22 @@ impl Process {
     /// Windows and other unix targets (where `parent_pid_of` has no
     /// implementation and the verify step would reject everything), falls
     /// back to signalling just this process.
+    ///
+    /// The tree walk is best-effort for descendants (failures are
+    /// swallowed, since we may have already frozen N siblings when N+1
+    /// fails). To keep the root-level error contract consistent with
+    /// [`kill`], we probe `kill(pid, 0)` first and surface that errno — so
+    /// `EPERM` on a child that has changed all its UIDs throws here just as
+    /// it would for `kill()`.
     pub fn kill_tree(&mut self, signal: u8) -> Maybe<()> {
         #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
         {
             match &self.poller {
                 Poller::WaiterThread(_) | Poller::Fd(_) => {
+                    // Probe permission on the root so EPERM surfaces the
+                    // same way `kill()` would surface it, instead of the
+                    // tree walk silently STOP/CONT'ing and returning Ok.
+                    self.kill(0)?;
                     bun_io::parent_death_watchdog::kill_process_tree(self.pid, signal as c_int);
                 }
                 _ => {}

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -680,6 +680,32 @@ impl Process {
 
         Ok(())
     }
+
+    /// Send `signal` to this process and every descendant reachable from it.
+    ///
+    /// POSIX only: walks the process tree via `/proc/<pid>/task/*/children`
+    /// (Linux) or `proc_listchildpids` (macOS) using the same freeze-verify-
+    /// signal logic as `--no-orphans`. On Windows, falls back to signalling
+    /// just this process (no descendant enumeration).
+    pub fn kill_tree(&mut self, signal: u8) -> Maybe<()> {
+        #[cfg(unix)]
+        {
+            match &self.poller {
+                Poller::WaiterThread(_) | Poller::Fd(_) => {
+                    bun_io::parent_death_watchdog::kill_process_tree(
+                        self.pid,
+                        signal as c_int,
+                    );
+                }
+                _ => {}
+            }
+            Ok(())
+        }
+        #[cfg(windows)]
+        {
+            self.kill(signal)
+        }
+    }
 }
 
 // Not `Copy` — `bun_sys::Error` carries `Box<[u8]>` path/dest.

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -692,10 +692,7 @@ impl Process {
         {
             match &self.poller {
                 Poller::WaiterThread(_) | Poller::Fd(_) => {
-                    bun_io::parent_death_watchdog::kill_process_tree(
-                        self.pid,
-                        signal as c_int,
-                    );
+                    bun_io::parent_death_watchdog::kill_process_tree(self.pid, signal as c_int);
                 }
                 _ => {}
             }

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -681,29 +681,12 @@ impl Process {
         Ok(())
     }
 
-    /// Send `signal` to this process and every descendant reachable from it.
-    ///
-    /// Linux/macOS only: walks the process tree via
-    /// `/proc/<pid>/task/*/children` (Linux) or `proc_listchildpids` (macOS)
-    /// using the same freeze-verify-signal logic as `--no-orphans`. On
-    /// Windows and other unix targets (where `parent_pid_of` has no
-    /// implementation and the verify step would reject everything), falls
-    /// back to signalling just this process.
-    ///
-    /// The tree walk is best-effort for descendants (failures are
-    /// swallowed, since we may have already frozen N siblings when N+1
-    /// fails). To keep the root-level error contract consistent with
-    /// [`kill`], we probe `kill(pid, 0)` first and surface that errno — so
-    /// `EPERM` on a child that has changed all its UIDs throws here just as
-    /// it would for `kill()`.
+    /// Signal this process and its descendants; only the root's errno is reported, as in [`Self::kill`].
     pub fn kill_tree(&mut self, signal: u8) -> Maybe<()> {
         #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
         {
             match &self.poller {
                 Poller::WaiterThread(_) | Poller::Fd(_) => {
-                    // Probe permission on the root so EPERM surfaces the
-                    // same way `kill()` would surface it, instead of the
-                    // tree walk silently STOP/CONT'ing and returning Ok.
                     self.kill(0)?;
                     bun_io::parent_death_watchdog::kill_process_tree(self.pid, signal as c_int);
                 }

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -683,12 +683,14 @@ impl Process {
 
     /// Send `signal` to this process and every descendant reachable from it.
     ///
-    /// POSIX only: walks the process tree via `/proc/<pid>/task/*/children`
-    /// (Linux) or `proc_listchildpids` (macOS) using the same freeze-verify-
-    /// signal logic as `--no-orphans`. On Windows, falls back to signalling
-    /// just this process (no descendant enumeration).
+    /// Linux/macOS only: walks the process tree via
+    /// `/proc/<pid>/task/*/children` (Linux) or `proc_listchildpids` (macOS)
+    /// using the same freeze-verify-signal logic as `--no-orphans`. On
+    /// Windows and other unix targets (where `parent_pid_of` has no
+    /// implementation and the verify step would reject everything), falls
+    /// back to signalling just this process.
     pub fn kill_tree(&mut self, signal: u8) -> Maybe<()> {
-        #[cfg(unix)]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
         {
             match &self.poller {
                 Poller::WaiterThread(_) | Poller::Fd(_) => {
@@ -698,7 +700,7 @@ impl Process {
             }
             Ok(())
         }
-        #[cfg(windows)]
+        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
         {
             self.kill(signal)
         }

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -349,7 +349,7 @@ pub struct PosixSpawnOptions {
     /// signal between vfork and exec in posix_spawn_bun, so the kernel kills
     /// it when the spawning thread dies. When null, defaults to SIGKILL if
     /// no-orphans mode is enabled (see `ParentDeathWatchdog`), else 0 (no
-    /// PDEATHSIG). Not exposed to JS yet.
+    /// PDEATHSIG). Exposed to JS as `deathSignal` in `Bun.spawn` options.
     pub linux_pdeathsig: Option<u8>,
     /// Linux only. Directory fd of a cgroup the child starts inside
     /// (`CLONE_INTO_CGROUP`, else a pre-exec `cgroup.procs` write). Caller owns the fd.

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1834,6 +1834,57 @@ export function waitForFileToExist(path: string, interval_ms: number) {
   }
 }
 
+/** `kill(pid, 0)`: true while the pid exists, including as a zombie nobody has reaped yet. */
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Resolves to whether `pid` stopped existing within `timeoutMs` (false is a meaningful answer, not an error). */
+export async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) return true;
+    await Bun.sleep(20);
+  }
+  return !isProcessAlive(pid);
+}
+
+/**
+ * Returns the first line a still-running child has written, without waiting for the stream to end.
+ * Bytes that arrived in the same chunk after the newline are discarded, so this is only for
+ * fixtures that print one line and then stay alive.
+ */
+export async function readFirstLine(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  try {
+    while (!text.includes("\n")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      text += decoder.decode(value, { stream: true });
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return text.split("\n", 1)[0].trim();
+}
+
+/** Best-effort SIGKILL of processes a test started itself. Skips anything that is not a pid > 1 (0 and negative values address whole process groups). */
+export function killProcesses(...pids: number[]): void {
+  for (const pid of pids) {
+    if (!(Number.isInteger(pid) && pid > 1)) continue;
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {}
+  }
+}
+
 export function libcPathForDlopen() {
   switch (process.platform) {
     case "linux":

--- a/test/js/bun/spawn/spawn-deathSignal.test.ts
+++ b/test/js/bun/spawn/spawn-deathSignal.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { setTimeout as sleep } from "node:timers/promises";
+
+// Bun.spawn({ deathSignal }): sets prctl(PR_SET_PDEATHSIG) in the child
+// between vfork and exec, so the kernel delivers `deathSignal` to the child
+// when the spawning thread dies. Linux only; no-op elsewhere.
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntilDead(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) return true;
+    await sleep(20);
+  }
+  return !isAlive(pid);
+}
+
+function reap(...pids: number[]) {
+  for (const pid of pids) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {}
+  }
+}
+
+async function readLine(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const dec = new TextDecoder();
+  let line = "";
+  while (!line.includes("\n")) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    line += dec.decode(value, { stream: true });
+  }
+  reader.releaseLock();
+  return line.trim();
+}
+
+describe.skipIf(!isLinux)("Bun.spawn deathSignal", () => {
+  // Middle bun process spawns a plain sh with deathSignal set, prints the
+  // sh pid, then idles. We SIGKILL the middle process and observe whether
+  // sh survives. sh is not a bun process, so this isolates PR_SET_PDEATHSIG
+  // from --no-orphans env-var inheritance.
+  const fixture = (deathSignal: string | number | undefined) => `
+    const child = Bun.spawn({
+      cmd: ["/bin/sh", "-c", "echo $$; while :; do sleep 30; done"],
+      stdio: ["ignore", "pipe", "inherit"],
+      ${deathSignal !== undefined ? `deathSignal: ${JSON.stringify(deathSignal)},` : ""}
+    });
+    let line = "";
+    const reader = child.stdout.getReader();
+    const dec = new TextDecoder();
+    while (!line.includes("\\n")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      line += dec.decode(value, { stream: true });
+    }
+    reader.releaseLock();
+    console.log(line.trim());
+    setInterval(() => {}, 1e6);
+  `;
+
+  async function spawnPair(deathSignal: string | number | undefined) {
+    using dir = tempDir("deathSignal", { "middle.js": fixture(deathSignal) });
+    const env: Record<string, string> = { ...bunEnv };
+    delete env.BUN_FEATURE_FLAG_NO_ORPHANS;
+    const middle = Bun.spawn({
+      cmd: [bunExe(), "middle.js"],
+      cwd: String(dir),
+      env,
+      stdio: ["ignore", "pipe", "inherit"],
+    });
+    const shPid = Number(await readLine(middle.stdout));
+    expect(shPid).toBeGreaterThan(1);
+    expect(isAlive(shPid)).toBe(true);
+    return { middle, shPid };
+  }
+
+  test("without deathSignal, child outlives a SIGKILLed parent", async () => {
+    const { middle, shPid } = await spawnPair(undefined);
+    await using _ = middle;
+    try {
+      process.kill(middle.pid!, "SIGKILL");
+      await middle.exited;
+      // sh must NOT die — it is simply orphaned.
+      const died = await waitUntilDead(shPid, 1000);
+      expect(died).toBe(false);
+    } finally {
+      reap(shPid);
+    }
+  });
+
+  test("deathSignal: 'SIGKILL' — child dies with its parent", async () => {
+    const { middle, shPid } = await spawnPair("SIGKILL");
+    await using _ = middle;
+    try {
+      process.kill(middle.pid!, "SIGKILL");
+      await middle.exited;
+      // PR_SET_PDEATHSIG delivers SIGKILL to sh as soon as the spawning
+      // thread (middle's main thread) exits.
+      const died = await waitUntilDead(shPid, 10000);
+      expect(died).toBe(true);
+    } finally {
+      reap(shPid);
+    }
+  });
+
+  test("deathSignal: 9 — numeric signal", async () => {
+    const { middle, shPid } = await spawnPair(9);
+    await using _ = middle;
+    try {
+      process.kill(middle.pid!, "SIGKILL");
+      await middle.exited;
+      const died = await waitUntilDead(shPid, 10000);
+      expect(died).toBe(true);
+    } finally {
+      reap(shPid);
+    }
+  });
+
+  test("deathSignal: 'SIGTERM' — catchable signal is delivered", async () => {
+    const { middle, shPid } = await spawnPair("SIGTERM");
+    await using _ = middle;
+    try {
+      process.kill(middle.pid!, "SIGKILL");
+      await middle.exited;
+      const died = await waitUntilDead(shPid, 10000);
+      expect(died).toBe(true);
+    } finally {
+      reap(shPid);
+    }
+  });
+
+  test("deathSignal does not fire while the parent is alive", async () => {
+    const { middle, shPid } = await spawnPair("SIGKILL");
+    await using _ = middle;
+    try {
+      const diedEarly = await waitUntilDead(shPid, 1000);
+      expect(diedEarly).toBe(false);
+    } finally {
+      reap(shPid);
+    }
+  });
+
+  test("rejects invalid deathSignal", () => {
+    expect(() =>
+      Bun.spawn({
+        cmd: [bunExe(), "-e", ""],
+        env: bunEnv,
+        deathSignal: "NOT_A_SIGNAL" as any,
+      }),
+    ).toThrow();
+    expect(() =>
+      Bun.spawn({
+        cmd: [bunExe(), "-e", ""],
+        env: bunEnv,
+        deathSignal: -1 as any,
+      }),
+    ).toThrow();
+  });
+});
+
+// On macOS and Windows, deathSignal is accepted but ignored.
+test.skipIf(isLinux)("deathSignal is accepted (no-op) on non-Linux", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", "process.exit(0)"],
+    env: bunEnv,
+    deathSignal: "SIGKILL",
+  });
+  await proc.exited;
+  expect(proc.exitCode).toBe(0);
+});

--- a/test/js/bun/spawn/spawn-deathSignal.test.ts
+++ b/test/js/bun/spawn/spawn-deathSignal.test.ts
@@ -26,6 +26,8 @@ async function waitUntilDead(pid: number, timeoutMs: number): Promise<boolean> {
 
 function reap(...pids: number[]) {
   for (const pid of pids) {
+    // pid 0 / negative pids address whole process groups, which would include the test runner.
+    if (!(Number.isInteger(pid) && pid > 1)) continue;
     try {
       process.kill(pid, "SIGKILL");
     } catch {}
@@ -52,7 +54,7 @@ describe.skipIf(!isLinux)("Bun.spawn deathSignal", () => {
   // from --no-orphans env-var inheritance.
   const fixture = (deathSignal: string | number | undefined) => `
     const child = Bun.spawn({
-      cmd: ["/bin/sh", "-c", "echo $$; while :; do sleep 30; done"],
+      cmd: ["/bin/sh", "-c", "echo $$; while :; do sleep 1; done"],
       stdio: ["ignore", "pipe", "inherit"],
       ${deathSignal !== undefined ? `deathSignal: ${JSON.stringify(deathSignal)},` : ""}
     });
@@ -79,10 +81,17 @@ describe.skipIf(!isLinux)("Bun.spawn deathSignal", () => {
       env,
       stdio: ["ignore", "pipe", "inherit"],
     });
-    const shPid = Number(await readLine(middle.stdout));
-    expect(shPid).toBeGreaterThan(1);
-    expect(isAlive(shPid)).toBe(true);
-    return { middle, shPid };
+    let shPid = NaN;
+    try {
+      shPid = Number(await readLine(middle.stdout));
+      expect(shPid).toBeGreaterThan(1);
+      expect(isAlive(shPid)).toBe(true);
+      return { middle, shPid };
+    } catch (e) {
+      middle.kill("SIGKILL");
+      reap(shPid);
+      throw e;
+    }
   }
 
   test("without deathSignal, child outlives a SIGKILLed parent", async () => {

--- a/test/js/bun/spawn/spawn-deathSignal.test.ts
+++ b/test/js/bun/spawn/spawn-deathSignal.test.ts
@@ -1,51 +1,18 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, tempDir } from "harness";
-import { setTimeout as sleep } from "node:timers/promises";
+import {
+  bunEnv,
+  bunExe,
+  isLinux,
+  isProcessAlive,
+  killProcesses,
+  readFirstLine,
+  tempDir,
+  waitForProcessExit,
+} from "harness";
 
 // Bun.spawn({ deathSignal }): sets prctl(PR_SET_PDEATHSIG) in the child
 // between vfork and exec, so the kernel delivers `deathSignal` to the child
 // when the spawning thread dies. Linux only; no-op elsewhere.
-
-function isAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function waitUntilDead(pid: number, timeoutMs: number): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (!isAlive(pid)) return true;
-    await sleep(20);
-  }
-  return !isAlive(pid);
-}
-
-function reap(...pids: number[]) {
-  for (const pid of pids) {
-    // pid 0 / negative pids address whole process groups, which would include the test runner.
-    if (!(Number.isInteger(pid) && pid > 1)) continue;
-    try {
-      process.kill(pid, "SIGKILL");
-    } catch {}
-  }
-}
-
-async function readLine(stream: ReadableStream<Uint8Array>): Promise<string> {
-  const reader = stream.getReader();
-  const dec = new TextDecoder();
-  let line = "";
-  while (!line.includes("\n")) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    line += dec.decode(value, { stream: true });
-  }
-  reader.releaseLock();
-  return line.trim();
-}
 
 describe.skipIf(!isLinux)("Bun.spawn deathSignal", () => {
   // Middle bun process spawns a plain sh with deathSignal set, prints the
@@ -83,13 +50,13 @@ describe.skipIf(!isLinux)("Bun.spawn deathSignal", () => {
     });
     let shPid = NaN;
     try {
-      shPid = Number(await readLine(middle.stdout));
+      shPid = Number(await readFirstLine(middle.stdout));
       expect(shPid).toBeGreaterThan(1);
-      expect(isAlive(shPid)).toBe(true);
+      expect(isProcessAlive(shPid)).toBe(true);
       return { middle, shPid };
     } catch (e) {
       middle.kill("SIGKILL");
-      reap(shPid);
+      killProcesses(shPid);
       throw e;
     }
   }
@@ -101,10 +68,10 @@ describe.skipIf(!isLinux)("Bun.spawn deathSignal", () => {
       process.kill(middle.pid!, "SIGKILL");
       await middle.exited;
       // sh must NOT die; it is simply orphaned.
-      const died = await waitUntilDead(shPid, 1000);
+      const died = await waitForProcessExit(shPid, 1000);
       expect(died).toBe(false);
     } finally {
-      reap(shPid);
+      killProcesses(shPid);
     }
   });
 
@@ -116,10 +83,10 @@ describe.skipIf(!isLinux)("Bun.spawn deathSignal", () => {
       await middle.exited;
       // PR_SET_PDEATHSIG delivers SIGKILL to sh as soon as the spawning
       // thread (middle's main thread) exits.
-      const died = await waitUntilDead(shPid, 10000);
+      const died = await waitForProcessExit(shPid, 10000);
       expect(died).toBe(true);
     } finally {
-      reap(shPid);
+      killProcesses(shPid);
     }
   });
 
@@ -129,10 +96,10 @@ describe.skipIf(!isLinux)("Bun.spawn deathSignal", () => {
     try {
       process.kill(middle.pid!, "SIGKILL");
       await middle.exited;
-      const died = await waitUntilDead(shPid, 10000);
+      const died = await waitForProcessExit(shPid, 10000);
       expect(died).toBe(true);
     } finally {
-      reap(shPid);
+      killProcesses(shPid);
     }
   });
 
@@ -142,10 +109,10 @@ describe.skipIf(!isLinux)("Bun.spawn deathSignal", () => {
     try {
       process.kill(middle.pid!, "SIGKILL");
       await middle.exited;
-      const died = await waitUntilDead(shPid, 10000);
+      const died = await waitForProcessExit(shPid, 10000);
       expect(died).toBe(true);
     } finally {
-      reap(shPid);
+      killProcesses(shPid);
     }
   });
 
@@ -153,10 +120,10 @@ describe.skipIf(!isLinux)("Bun.spawn deathSignal", () => {
     const { middle, shPid } = await spawnPair("SIGKILL");
     await using _ = middle;
     try {
-      const diedEarly = await waitUntilDead(shPid, 1000);
+      const diedEarly = await waitForProcessExit(shPid, 1000);
       expect(diedEarly).toBe(false);
     } finally {
-      reap(shPid);
+      killProcesses(shPid);
     }
   });
 });

--- a/test/js/bun/spawn/spawn-deathSignal.test.ts
+++ b/test/js/bun/spawn/spawn-deathSignal.test.ts
@@ -91,7 +91,7 @@ describe.skipIf(!isLinux)("Bun.spawn deathSignal", () => {
     try {
       process.kill(middle.pid!, "SIGKILL");
       await middle.exited;
-      // sh must NOT die — it is simply orphaned.
+      // sh must NOT die; it is simply orphaned.
       const died = await waitUntilDead(shPid, 1000);
       expect(died).toBe(false);
     } finally {
@@ -99,7 +99,7 @@ describe.skipIf(!isLinux)("Bun.spawn deathSignal", () => {
     }
   });
 
-  test("deathSignal: 'SIGKILL' — child dies with its parent", async () => {
+  test("deathSignal: 'SIGKILL' kills the child when its parent dies", async () => {
     const { middle, shPid } = await spawnPair("SIGKILL");
     await using _ = middle;
     try {
@@ -114,7 +114,7 @@ describe.skipIf(!isLinux)("Bun.spawn deathSignal", () => {
     }
   });
 
-  test("deathSignal: 9 — numeric signal", async () => {
+  test("deathSignal: 9 (numeric signal)", async () => {
     const { middle, shPid } = await spawnPair(9);
     await using _ = middle;
     try {
@@ -127,7 +127,7 @@ describe.skipIf(!isLinux)("Bun.spawn deathSignal", () => {
     }
   });
 
-  test("deathSignal: 'SIGTERM' — catchable signal is delivered", async () => {
+  test("deathSignal: 'SIGTERM' (catchable signal) is delivered", async () => {
     const { middle, shPid } = await spawnPair("SIGTERM");
     await using _ = middle;
     try {
@@ -150,32 +150,57 @@ describe.skipIf(!isLinux)("Bun.spawn deathSignal", () => {
       reap(shPid);
     }
   });
-
-  test("rejects invalid deathSignal", () => {
-    expect(() =>
-      Bun.spawn({
-        cmd: [bunExe(), "-e", ""],
-        env: bunEnv,
-        deathSignal: "NOT_A_SIGNAL" as any,
-      }),
-    ).toThrow();
-    expect(() =>
-      Bun.spawn({
-        cmd: [bunExe(), "-e", ""],
-        env: bunEnv,
-        deathSignal: -1 as any,
-      }),
-    ).toThrow();
-  });
 });
 
-// On macOS and Windows, deathSignal is accepted but ignored.
-test.skipIf(isLinux)("deathSignal is accepted (no-op) on non-Linux", async () => {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", "process.exit(0)"],
-    env: bunEnv,
-    deathSignal: "SIGKILL",
+// Option validation happens before the platform-specific spawn, so it is the
+// same everywhere (on macOS and Windows a valid deathSignal is then ignored).
+describe("Bun.spawn deathSignal validation", () => {
+  // Returns the error thrown by Bun.spawn for these options. If nothing was
+  // thrown, the stray child is killed and the test fails.
+  async function spawnError(opts: Record<string, unknown>) {
+    let proc: Bun.Subprocess;
+    try {
+      proc = Bun.spawn({ cmd: [bunExe(), "-e", ""], env: bunEnv, ...opts });
+    } catch (e: any) {
+      return { name: e.name, code: e.code, message: e.message };
+    }
+    proc.kill();
+    await proc.exited;
+    throw new Error(`Bun.spawn(${JSON.stringify(opts)}) did not throw`);
+  }
+
+  test("rejects a signal name that does not exist", async () => {
+    expect(await spawnError({ deathSignal: "NOT_A_SIGNAL" })).toEqual({
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_TYPE",
+      message: expect.stringContaining("'SIGKILL'"),
+    });
   });
-  await proc.exited;
-  expect(proc.exitCode).toBe(0);
+
+  test("rejects a negative signal number", async () => {
+    expect(await spawnError({ deathSignal: -1 })).toEqual({
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_TYPE",
+      message: "Invalid signal: must be >= 0",
+    });
+  });
+
+  test("rejects 0, exactly like killSignal: 0", async () => {
+    const expected = {
+      name: "TypeError",
+      code: "ERR_UNKNOWN_SIGNAL",
+      message: "Unknown signal: 0",
+    };
+    expect(await spawnError({ deathSignal: 0 })).toEqual(expected);
+    expect(await spawnError({ killSignal: 0 })).toEqual(expected);
+  });
+
+  test.concurrent.each([["SIGKILL"], [9], [undefined], [null]])("accepts deathSignal: %p", async deathSignal => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "process.exit(0)"],
+      env: bunEnv,
+      deathSignal: deathSignal as any,
+    });
+    expect(await proc.exited).toBe(0);
+  });
 });

--- a/test/js/bun/spawn/spawn-killTree.test.ts
+++ b/test/js/bun/spawn/spawn-killTree.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+import { setTimeout as sleep } from "node:timers/promises";
+
+// Subprocess.killTree(signal): walks the process tree rooted at the
+// subprocess and signals every descendant. Shares the freeze-verify-signal
+// machinery with `--no-orphans` (/proc/<pid>/task/*/children on Linux,
+// proc_listchildpids on macOS). POSIX only; on Windows it falls back to
+// signalling just the root.
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntilDead(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) return true;
+    await sleep(20);
+  }
+  return !isAlive(pid);
+}
+
+function reap(...pids: number[]) {
+  for (const pid of pids) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {}
+  }
+}
+
+// A child (bun) that spawns a grandchild (bun) which itself spawns a
+// great-grandchild (sh). The root prints all four pids on one line once the
+// whole chain is up, then everything idles.
+const fixture = tempDir("spawn-killTree", {
+  "root.js": `
+    const child = Bun.spawn({
+      cmd: [process.execPath, "child.js"],
+      cwd: import.meta.dir,
+      stdio: ["ignore", "pipe", "inherit"],
+      env: process.env,
+    });
+    let line = "";
+    const reader = child.stdout.getReader();
+    const dec = new TextDecoder();
+    while (!line.includes("\\n")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      line += dec.decode(value, { stream: true });
+    }
+    reader.releaseLock();
+    console.log(process.pid + " " + line.trim());
+    setInterval(() => {}, 1e6);
+  `,
+  "child.js": `
+    const gc = Bun.spawn({
+      cmd: ["/bin/sh", "-c", "echo $$; while :; do sleep 30; done"],
+      stdio: ["ignore", "pipe", "inherit"],
+    });
+    let line = "";
+    const reader = gc.stdout.getReader();
+    const dec = new TextDecoder();
+    while (!line.includes("\\n")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      line += dec.decode(value, { stream: true });
+    }
+    reader.releaseLock();
+    console.log(process.pid + " " + gc.pid + " " + line.trim());
+    setInterval(() => {}, 1e6);
+  `,
+});
+
+async function spawnTree() {
+  const env: Record<string, string> = { ...bunEnv };
+  // Isolate from an ambient --no-orphans so we're testing killTree() alone.
+  delete env.BUN_FEATURE_FLAG_NO_ORPHANS;
+
+  const proc = Bun.spawn({
+    cmd: [bunExe(), "root.js"],
+    cwd: String(fixture),
+    env,
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+
+  const reader = proc.stdout.getReader();
+  const dec = new TextDecoder();
+  let line = "";
+  while (!line.includes("\n")) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    line += dec.decode(value, { stream: true });
+  }
+  reader.releaseLock();
+
+  const [rootPid, childPid, grandchildPid, shPid] = line.trim().split(/\s+/).map(Number);
+  expect(rootPid).toBe(proc.pid);
+  expect(childPid).toBeGreaterThan(1);
+  expect(grandchildPid).toBeGreaterThan(1);
+  expect(shPid).toBeGreaterThan(1);
+  expect(isAlive(childPid)).toBe(true);
+  expect(isAlive(grandchildPid)).toBe(true);
+  expect(isAlive(shPid)).toBe(true);
+
+  return { proc, rootPid, childPid, grandchildPid, shPid };
+}
+
+describe.skipIf(!isPosix)("Subprocess.killTree()", () => {
+  test("exists and is a function", async () => {
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", "setTimeout(()=>{}, 1e6)"], env: bunEnv });
+    expect(typeof proc.killTree).toBe("function");
+    expect(proc.killTree.length).toBe(1);
+  });
+
+  test("default signal kills the root and every descendant", async () => {
+    const { proc, childPid, grandchildPid, shPid } = await spawnTree();
+    await using _ = proc;
+    try {
+      proc.killTree();
+      await proc.exited;
+
+      const childDied = await waitUntilDead(childPid, 10000);
+      const grandchildDied = await waitUntilDead(grandchildPid, 10000);
+      const shDied = await waitUntilDead(shPid, 10000);
+
+      expect(proc.exitCode === null ? proc.signalCode : proc.exitCode).not.toBe(0);
+      expect({ childDied, grandchildDied, shDied }).toEqual({
+        childDied: true,
+        grandchildDied: true,
+        shDied: true,
+      });
+    } finally {
+      reap(childPid, grandchildPid, shPid);
+    }
+  });
+
+  test("plain kill() does NOT reach descendants (contrast case)", async () => {
+    const { proc, childPid, grandchildPid, shPid } = await spawnTree();
+    await using _ = proc;
+    try {
+      proc.kill("SIGKILL");
+      await proc.exited;
+
+      // The direct child becomes orphaned (reparented to init) but keeps
+      // running — this is what killTree() fixes.
+      const childDied = await waitUntilDead(childPid, 1000);
+      expect(childDied).toBe(false);
+    } finally {
+      reap(childPid, grandchildPid, shPid);
+    }
+  });
+
+  test("accepts a signal name", async () => {
+    const { proc, childPid, grandchildPid, shPid } = await spawnTree();
+    await using _ = proc;
+    try {
+      proc.killTree("SIGKILL");
+      await proc.exited;
+
+      const childDied = await waitUntilDead(childPid, 10000);
+      const grandchildDied = await waitUntilDead(grandchildPid, 10000);
+      const shDied = await waitUntilDead(shPid, 10000);
+
+      expect(proc.signalCode).toBe("SIGKILL");
+      expect({ childDied, grandchildDied, shDied }).toEqual({
+        childDied: true,
+        grandchildDied: true,
+        shDied: true,
+      });
+    } finally {
+      reap(childPid, grandchildPid, shPid);
+    }
+  });
+
+  test("catchable signal is delivered (SIGCONT wakes stopped descendants)", async () => {
+    // SIGSTOP → verify → SIGTERM → SIGCONT: the descendant must actually
+    // receive SIGTERM rather than stay frozen with it pending.
+    using dir = tempDir("killTree-catchable", {
+      "root.js": `
+        const child = Bun.spawn({
+          cmd: ["/bin/sh", "-c", "echo $$; while :; do sleep 30; done"],
+          stdio: ["ignore", "pipe", "inherit"],
+        });
+        let line = "";
+        const reader = child.stdout.getReader();
+        const dec = new TextDecoder();
+        while (!line.includes("\\n")) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          line += dec.decode(value, { stream: true });
+        }
+        reader.releaseLock();
+        console.log(process.pid + " " + child.pid + " " + line.trim());
+        setInterval(() => {}, 1e6);
+      `,
+    });
+
+    const env: Record<string, string> = { ...bunEnv };
+    delete env.BUN_FEATURE_FLAG_NO_ORPHANS;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "root.js"],
+      cwd: String(dir),
+      env,
+      stdio: ["ignore", "pipe", "inherit"],
+    });
+
+    const reader = proc.stdout.getReader();
+    const dec = new TextDecoder();
+    let line = "";
+    while (!line.includes("\n")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      line += dec.decode(value, { stream: true });
+    }
+    reader.releaseLock();
+    const [, childPid, shPid] = line.trim().split(/\s+/).map(Number);
+    expect(isAlive(childPid)).toBe(true);
+    expect(isAlive(shPid)).toBe(true);
+
+    try {
+      proc.killTree("SIGTERM");
+      await proc.exited;
+
+      const childDied = await waitUntilDead(childPid, 10000);
+      const shDied = await waitUntilDead(shPid, 10000);
+
+      expect(proc.signalCode).toBe("SIGTERM");
+      expect({ childDied, shDied }).toEqual({ childDied: true, shDied: true });
+    } finally {
+      reap(childPid, shPid);
+    }
+  });
+
+  test("is a no-op once the process has already exited", async () => {
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", ""], env: bunEnv });
+    await proc.exited;
+    expect(() => proc.killTree()).not.toThrow();
+    expect(() => proc.killTree("SIGKILL")).not.toThrow();
+  });
+
+  test("rejects invalid signals the same way kill() does", async () => {
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", "setTimeout(()=>{}, 1e6)"], env: bunEnv });
+    expect(() => proc.killTree(-1)).toThrow();
+    expect(() => proc.killTree("NOT_A_SIGNAL" as any)).toThrow();
+  });
+});

--- a/test/js/bun/spawn/spawn-killTree.test.ts
+++ b/test/js/bun/spawn/spawn-killTree.test.ts
@@ -189,7 +189,9 @@ describe.skipIf(!(isLinux || isMacOS))("Subprocess.killTree()", () => {
 
   test("catchable signal is delivered (SIGCONT wakes stopped descendants)", async () => {
     // SIGSTOP → verify → SIGTERM → SIGCONT: the descendant must actually
-    // receive SIGTERM rather than stay frozen with it pending.
+    // receive SIGTERM rather than stay frozen with it pending. Two levels
+    // (root bun → sh) is enough — we only need one stopped descendant to
+    // observe the wake-up.
     using dir = tempDir("killTree-catchable", {
       "root.js": `
         const child = Bun.spawn({
@@ -205,7 +207,8 @@ describe.skipIf(!(isLinux || isMacOS))("Subprocess.killTree()", () => {
           line += dec.decode(value, { stream: true });
         }
         reader.releaseLock();
-        console.log(process.pid + " " + child.pid + " " + line.trim());
+        // child.pid == sh's $$, so just pass through the sh pid.
+        console.log(process.pid + " " + line.trim());
         setInterval(() => {}, 1e6);
       `,
     });
@@ -228,21 +231,20 @@ describe.skipIf(!(isLinux || isMacOS))("Subprocess.killTree()", () => {
       line += dec.decode(value, { stream: true });
     }
     reader.releaseLock();
-    const [, childPid, shPid] = line.trim().split(/\s+/).map(Number);
-    expect(isAlive(childPid)).toBe(true);
+    const [rootPid, shPid] = line.trim().split(/\s+/).map(Number);
+    expect(rootPid).toBe(proc.pid);
     expect(isAlive(shPid)).toBe(true);
 
     try {
       proc.killTree("SIGTERM");
       await proc.exited;
 
-      const childDied = await waitUntilDead(childPid, 10000);
       const shDied = await waitUntilDead(shPid, 10000);
 
       expect(proc.signalCode).toBe("SIGTERM");
-      expect({ childDied, shDied }).toEqual({ childDied: true, shDied: true });
+      expect(shDied).toBe(true);
     } finally {
-      reap(childPid, shPid);
+      reap(shPid);
     }
   });
 

--- a/test/js/bun/spawn/spawn-killTree.test.ts
+++ b/test/js/bun/spawn/spawn-killTree.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isMacOS, tempDir } from "harness";
 import { setTimeout as sleep } from "node:timers/promises";
 
 // Subprocess.killTree(signal): walks the process tree rooted at the
 // subprocess and signals every descendant. Shares the freeze-verify-signal
 // machinery with `--no-orphans` (/proc/<pid>/task/*/children on Linux,
-// proc_listchildpids on macOS). POSIX only; on Windows it falls back to
-// signalling just the root.
+// proc_listchildpids on macOS). On Windows and other POSIX targets it
+// falls back to signalling just the root, so the descendant-death
+// assertions below are gated on Linux/macOS specifically.
 
 function isAlive(pid: number): boolean {
   try {
@@ -119,7 +120,7 @@ async function spawnTree() {
   return { proc, rootPid, childPid, outerShPid, innerShPid };
 }
 
-describe.skipIf(!isPosix)("Subprocess.killTree()", () => {
+describe.skipIf(!(isLinux || isMacOS))("Subprocess.killTree()", () => {
   test("exists and is a function", async () => {
     await using proc = Bun.spawn({ cmd: [bunExe(), "-e", "setTimeout(()=>{}, 1e6)"], env: bunEnv });
     expect(typeof proc.killTree).toBe("function");

--- a/test/js/bun/spawn/spawn-killTree.test.ts
+++ b/test/js/bun/spawn/spawn-killTree.test.ts
@@ -34,9 +34,10 @@ function reap(...pids: number[]) {
   }
 }
 
-// A child (bun) that spawns a grandchild (bun) which itself spawns a
-// great-grandchild (sh). The root prints all four pids on one line once the
-// whole chain is up, then everything idles.
+// root.js (bun) spawns child.js (bun) which spawns an outer sh, which
+// itself spawns an inner sh in the background. root.js prints the four
+// pids on one line once the whole chain is up, then everything idles.
+// Four distinct levels so killTree() has to recurse past the direct child.
 const fixture = tempDir("spawn-killTree", {
   "root.js": `
     const child = Bun.spawn({
@@ -57,9 +58,14 @@ const fixture = tempDir("spawn-killTree", {
     console.log(process.pid + " " + line.trim());
     setInterval(() => {}, 1e6);
   `,
+  // Outer sh backgrounds an inner sh ($!), prints both pids, then waits —
+  // so both stay alive and are distinct from gc.pid (== outer sh's $$).
   "child.js": `
     const gc = Bun.spawn({
-      cmd: ["/bin/sh", "-c", "echo $$; while :; do sleep 30; done"],
+      cmd: [
+        "/bin/sh", "-c",
+        "/bin/sh -c 'while :; do sleep 30; done' & echo $$ $!; wait",
+      ],
       stdio: ["ignore", "pipe", "inherit"],
     });
     let line = "";
@@ -71,7 +77,8 @@ const fixture = tempDir("spawn-killTree", {
       line += dec.decode(value, { stream: true });
     }
     reader.releaseLock();
-    console.log(process.pid + " " + gc.pid + " " + line.trim());
+    // line is "<outer-sh-pid> <inner-sh-pid>"; outer == gc.pid.
+    console.log(process.pid + " " + line.trim());
     setInterval(() => {}, 1e6);
   `,
 });
@@ -98,16 +105,18 @@ async function spawnTree() {
   }
   reader.releaseLock();
 
-  const [rootPid, childPid, grandchildPid, shPid] = line.trim().split(/\s+/).map(Number);
+  const [rootPid, childPid, outerShPid, innerShPid] = line.trim().split(/\s+/).map(Number);
   expect(rootPid).toBe(proc.pid);
   expect(childPid).toBeGreaterThan(1);
-  expect(grandchildPid).toBeGreaterThan(1);
-  expect(shPid).toBeGreaterThan(1);
+  expect(outerShPid).toBeGreaterThan(1);
+  expect(innerShPid).toBeGreaterThan(1);
+  // Four distinct pids — no level of the tree is collapsed.
+  expect(new Set([rootPid, childPid, outerShPid, innerShPid]).size).toBe(4);
   expect(isAlive(childPid)).toBe(true);
-  expect(isAlive(grandchildPid)).toBe(true);
-  expect(isAlive(shPid)).toBe(true);
+  expect(isAlive(outerShPid)).toBe(true);
+  expect(isAlive(innerShPid)).toBe(true);
 
-  return { proc, rootPid, childPid, grandchildPid, shPid };
+  return { proc, rootPid, childPid, outerShPid, innerShPid };
 }
 
 describe.skipIf(!isPosix)("Subprocess.killTree()", () => {
@@ -118,29 +127,29 @@ describe.skipIf(!isPosix)("Subprocess.killTree()", () => {
   });
 
   test("default signal kills the root and every descendant", async () => {
-    const { proc, childPid, grandchildPid, shPid } = await spawnTree();
+    const { proc, childPid, outerShPid, innerShPid } = await spawnTree();
     await using _ = proc;
     try {
       proc.killTree();
       await proc.exited;
 
       const childDied = await waitUntilDead(childPid, 10000);
-      const grandchildDied = await waitUntilDead(grandchildPid, 10000);
-      const shDied = await waitUntilDead(shPid, 10000);
+      const outerShDied = await waitUntilDead(outerShPid, 10000);
+      const innerShDied = await waitUntilDead(innerShPid, 10000);
 
       expect(proc.exitCode === null ? proc.signalCode : proc.exitCode).not.toBe(0);
-      expect({ childDied, grandchildDied, shDied }).toEqual({
+      expect({ childDied, outerShDied, innerShDied }).toEqual({
         childDied: true,
-        grandchildDied: true,
-        shDied: true,
+        outerShDied: true,
+        innerShDied: true,
       });
     } finally {
-      reap(childPid, grandchildPid, shPid);
+      reap(childPid, outerShPid, innerShPid);
     }
   });
 
   test("plain kill() does NOT reach descendants (contrast case)", async () => {
-    const { proc, childPid, grandchildPid, shPid } = await spawnTree();
+    const { proc, childPid, outerShPid, innerShPid } = await spawnTree();
     await using _ = proc;
     try {
       proc.kill("SIGKILL");
@@ -151,29 +160,29 @@ describe.skipIf(!isPosix)("Subprocess.killTree()", () => {
       const childDied = await waitUntilDead(childPid, 1000);
       expect(childDied).toBe(false);
     } finally {
-      reap(childPid, grandchildPid, shPid);
+      reap(childPid, outerShPid, innerShPid);
     }
   });
 
   test("accepts a signal name", async () => {
-    const { proc, childPid, grandchildPid, shPid } = await spawnTree();
+    const { proc, childPid, outerShPid, innerShPid } = await spawnTree();
     await using _ = proc;
     try {
       proc.killTree("SIGKILL");
       await proc.exited;
 
       const childDied = await waitUntilDead(childPid, 10000);
-      const grandchildDied = await waitUntilDead(grandchildPid, 10000);
-      const shDied = await waitUntilDead(shPid, 10000);
+      const outerShDied = await waitUntilDead(outerShPid, 10000);
+      const innerShDied = await waitUntilDead(innerShPid, 10000);
 
       expect(proc.signalCode).toBe("SIGKILL");
-      expect({ childDied, grandchildDied, shDied }).toEqual({
+      expect({ childDied, outerShDied, innerShDied }).toEqual({
         childDied: true,
-        grandchildDied: true,
-        shDied: true,
+        outerShDied: true,
+        innerShDied: true,
       });
     } finally {
-      reap(childPid, grandchildPid, shPid);
+      reap(childPid, outerShPid, innerShPid);
     }
   });
 
@@ -247,5 +256,23 @@ describe.skipIf(!isPosix)("Subprocess.killTree()", () => {
     await using proc = Bun.spawn({ cmd: [bunExe(), "-e", "setTimeout(()=>{}, 1e6)"], env: bunEnv });
     expect(() => proc.killTree(-1)).toThrow();
     expect(() => proc.killTree("NOT_A_SIGNAL" as any)).toThrow();
+  });
+
+  test("killTree(0) is a liveness probe and does not pause descendants", async () => {
+    const { proc, childPid, outerShPid, innerShPid } = await spawnTree();
+    await using _ = proc;
+    try {
+      expect(() => proc.killTree(0)).not.toThrow();
+      // Descendants must still be alive and, crucially, still running —
+      // not stuck SIGSTOPped. We can't directly observe run state
+      // portably, so just confirm liveness and that the root wasn't
+      // signalled.
+      expect(isAlive(childPid)).toBe(true);
+      expect(isAlive(outerShPid)).toBe(true);
+      expect(isAlive(innerShPid)).toBe(true);
+      expect(proc.killed).toBe(false);
+    } finally {
+      reap(childPid, outerShPid, innerShPid);
+    }
   });
 });

--- a/test/js/bun/spawn/spawn-killTree.test.ts
+++ b/test/js/bun/spawn/spawn-killTree.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, isMacOS, tempDir } from "harness";
+import { readFileSync } from "node:fs";
 import { setTimeout as sleep } from "node:timers/promises";
 
 // Subprocess.killTree(signal): walks the process tree rooted at the
@@ -35,6 +36,12 @@ function reap(...pids: number[]) {
   }
 }
 
+// Linux only. The state char follows the parenthesised comm, which may itself contain spaces.
+function procState(pid: number): string {
+  const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+  return stat.charAt(stat.lastIndexOf(")") + 2);
+}
+
 // root.js (bun) spawns child.js (bun) which spawns an outer sh, which
 // itself spawns an inner sh in the background. root.js prints the four
 // pids on one line once the whole chain is up, then everything idles.
@@ -59,7 +66,7 @@ const fixture = tempDir("spawn-killTree", {
     console.log(process.pid + " " + line.trim());
     setInterval(() => {}, 1e6);
   `,
-  // Outer sh backgrounds an inner sh ($!), prints both pids, then waits —
+  // Outer sh backgrounds an inner sh ($!), prints both pids, then waits,
   // so both stay alive and are distinct from gc.pid (== outer sh's $$).
   "child.js": `
     const gc = Bun.spawn({
@@ -111,7 +118,7 @@ async function spawnTree() {
   expect(childPid).toBeGreaterThan(1);
   expect(outerShPid).toBeGreaterThan(1);
   expect(innerShPid).toBeGreaterThan(1);
-  // Four distinct pids — no level of the tree is collapsed.
+  // Four distinct pids: no level of the tree is collapsed.
   expect(new Set([rootPid, childPid, outerShPid, innerShPid]).size).toBe(4);
   expect(isAlive(childPid)).toBe(true);
   expect(isAlive(outerShPid)).toBe(true);
@@ -157,7 +164,7 @@ describe.skipIf(!(isLinux || isMacOS))("Subprocess.killTree()", () => {
       await proc.exited;
 
       // The direct child becomes orphaned (reparented to init) but keeps
-      // running — this is what killTree() fixes.
+      // running. This is what killTree() fixes.
       const childDied = await waitUntilDead(childPid, 1000);
       expect(childDied).toBe(false);
     } finally {
@@ -188,10 +195,10 @@ describe.skipIf(!(isLinux || isMacOS))("Subprocess.killTree()", () => {
   });
 
   test("catchable signal is delivered (SIGCONT wakes stopped descendants)", async () => {
-    // SIGSTOP → verify → SIGTERM → SIGCONT: the descendant must actually
+    // SIGSTOP, verify, SIGTERM, SIGCONT: the descendant must actually
     // receive SIGTERM rather than stay frozen with it pending. Two levels
-    // (root bun → sh) is enough — we only need one stopped descendant to
-    // observe the wake-up.
+    // (root bun, then sh) is enough, since one stopped descendant is all
+    // it takes to observe the wake-up.
     using dir = tempDir("killTree-catchable", {
       "root.js": `
         const child = Bun.spawn({
@@ -257,8 +264,37 @@ describe.skipIf(!(isLinux || isMacOS))("Subprocess.killTree()", () => {
 
   test("rejects invalid signals the same way kill() does", async () => {
     await using proc = Bun.spawn({ cmd: [bunExe(), "-e", "setTimeout(()=>{}, 1e6)"], env: bunEnv });
-    expect(() => proc.killTree(-1)).toThrow();
-    expect(() => proc.killTree("NOT_A_SIGNAL" as any)).toThrow();
+
+    function thrownBy(fn: () => void) {
+      try {
+        fn();
+      } catch (e: any) {
+        return { name: e.name, code: e.code, message: e.message };
+      }
+      throw new Error("expected a throw");
+    }
+
+    for (const sig of [-1, 32, 1.5, "NOT_A_SIGNAL", {}] as any[]) {
+      expect(thrownBy(() => proc.killTree(sig))).toEqual(thrownBy(() => proc.kill(sig)));
+    }
+
+    expect(() => proc.killTree(-1)).toThrow(
+      expect.objectContaining({
+        name: "TypeError",
+        code: "ERR_INVALID_ARG_TYPE",
+        message: "Invalid signal: must be >= 0",
+      }),
+    );
+    expect(() => proc.killTree("NOT_A_SIGNAL" as any)).toThrow(
+      expect.objectContaining({
+        name: "TypeError",
+        code: "ERR_INVALID_ARG_TYPE",
+        message: expect.stringContaining("'SIGTERM'"),
+      }),
+    );
+
+    // Nothing above may have signalled the process.
+    expect(proc.killed).toBe(false);
   });
 
   test("killTree(0) is a liveness probe and does not pause descendants", async () => {
@@ -266,14 +302,19 @@ describe.skipIf(!(isLinux || isMacOS))("Subprocess.killTree()", () => {
     await using _ = proc;
     try {
       expect(() => proc.killTree(0)).not.toThrow();
-      // Descendants must still be alive and, crucially, still running —
-      // not stuck SIGSTOPped. We can't directly observe run state
-      // portably, so just confirm liveness and that the root wasn't
-      // signalled.
       expect(isAlive(childPid)).toBe(true);
       expect(isAlive(outerShPid)).toBe(true);
       expect(isAlive(innerShPid)).toBe(true);
       expect(proc.killed).toBe(false);
+      if (isLinux) {
+        // Not merely alive, but not left SIGSTOPped (state "T") either.
+        const running = expect.stringMatching(/^[RSD]$/);
+        expect({
+          child: procState(childPid),
+          outerSh: procState(outerShPid),
+          innerSh: procState(innerShPid),
+        }).toEqual({ child: running, outerSh: running, innerSh: running });
+      }
     } finally {
       reap(childPid, outerShPid, innerShPid);
     }

--- a/test/js/bun/spawn/spawn-killTree.test.ts
+++ b/test/js/bun/spawn/spawn-killTree.test.ts
@@ -1,7 +1,16 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, isMacOS, tempDir } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  isLinux,
+  isMacOS,
+  isProcessAlive,
+  killProcesses,
+  readFirstLine,
+  tempDir,
+  waitForProcessExit,
+} from "harness";
 import { readFileSync } from "node:fs";
-import { setTimeout as sleep } from "node:timers/promises";
 
 // Subprocess.killTree(signal): walks the process tree rooted at the
 // subprocess and signals every descendant. Shares the freeze-verify-signal
@@ -9,34 +18,6 @@ import { setTimeout as sleep } from "node:timers/promises";
 // proc_listchildpids on macOS). On Windows and other POSIX targets it
 // falls back to signalling just the root, so the descendant-death
 // assertions below are gated on Linux/macOS specifically.
-
-function isAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function waitUntilDead(pid: number, timeoutMs: number): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (!isAlive(pid)) return true;
-    await sleep(20);
-  }
-  return !isAlive(pid);
-}
-
-function reap(...pids: number[]) {
-  for (const pid of pids) {
-    // pid 0 / negative pids address whole process groups, which would include the test runner.
-    if (!(Number.isInteger(pid) && pid > 1)) continue;
-    try {
-      process.kill(pid, "SIGKILL");
-    } catch {}
-  }
-}
 
 // Linux only. The state char follows the parenthesised comm, which may itself contain spaces.
 function procState(pid: number): string {
@@ -109,17 +90,8 @@ async function spawnTree() {
   // Whatever has been started so far is torn down if a setup assertion below fails.
   let descendants: number[] = [];
   try {
-    const reader = proc.stdout.getReader();
-    const dec = new TextDecoder();
-    let line = "";
-    while (!line.includes("\n")) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      line += dec.decode(value, { stream: true });
-    }
-    reader.releaseLock();
-
-    const [rootPid, childPid, outerShPid, innerShPid] = line.trim().split(/\s+/).map(Number);
+    const line = await readFirstLine(proc.stdout);
+    const [rootPid, childPid, outerShPid, innerShPid] = line.split(/\s+/).map(Number);
     descendants = [childPid, outerShPid, innerShPid];
     expect(rootPid).toBe(proc.pid);
     expect(childPid).toBeGreaterThan(1);
@@ -127,14 +99,14 @@ async function spawnTree() {
     expect(innerShPid).toBeGreaterThan(1);
     // Four distinct pids: no level of the tree is collapsed.
     expect(new Set([rootPid, childPid, outerShPid, innerShPid]).size).toBe(4);
-    expect(isAlive(childPid)).toBe(true);
-    expect(isAlive(outerShPid)).toBe(true);
-    expect(isAlive(innerShPid)).toBe(true);
+    expect(isProcessAlive(childPid)).toBe(true);
+    expect(isProcessAlive(outerShPid)).toBe(true);
+    expect(isProcessAlive(innerShPid)).toBe(true);
 
     return { proc, rootPid, childPid, outerShPid, innerShPid };
   } catch (e) {
     proc.kill("SIGKILL");
-    reap(...descendants);
+    killProcesses(...descendants);
     throw e;
   }
 }
@@ -208,9 +180,9 @@ describe.skipIf(!(isLinux || isMacOS))("Subprocess.killTree() process tree", () 
       proc.killTree();
       await proc.exited;
 
-      const childDied = await waitUntilDead(childPid, 10000);
-      const outerShDied = await waitUntilDead(outerShPid, 10000);
-      const innerShDied = await waitUntilDead(innerShPid, 10000);
+      const childDied = await waitForProcessExit(childPid, 10000);
+      const outerShDied = await waitForProcessExit(outerShPid, 10000);
+      const innerShDied = await waitForProcessExit(innerShPid, 10000);
 
       expect(proc.exitCode === null ? proc.signalCode : proc.exitCode).not.toBe(0);
       expect({ childDied, outerShDied, innerShDied }).toEqual({
@@ -219,7 +191,7 @@ describe.skipIf(!(isLinux || isMacOS))("Subprocess.killTree() process tree", () 
         innerShDied: true,
       });
     } finally {
-      reap(childPid, outerShPid, innerShPid);
+      killProcesses(childPid, outerShPid, innerShPid);
     }
   });
 
@@ -232,10 +204,10 @@ describe.skipIf(!(isLinux || isMacOS))("Subprocess.killTree() process tree", () 
 
       // The direct child becomes orphaned (reparented to init) but keeps
       // running. This is what killTree() fixes.
-      const childDied = await waitUntilDead(childPid, 1000);
+      const childDied = await waitForProcessExit(childPid, 1000);
       expect(childDied).toBe(false);
     } finally {
-      reap(childPid, outerShPid, innerShPid);
+      killProcesses(childPid, outerShPid, innerShPid);
     }
   });
 
@@ -246,9 +218,9 @@ describe.skipIf(!(isLinux || isMacOS))("Subprocess.killTree() process tree", () 
       proc.killTree("SIGKILL");
       await proc.exited;
 
-      const childDied = await waitUntilDead(childPid, 10000);
-      const outerShDied = await waitUntilDead(outerShPid, 10000);
-      const innerShDied = await waitUntilDead(innerShPid, 10000);
+      const childDied = await waitForProcessExit(childPid, 10000);
+      const outerShDied = await waitForProcessExit(outerShPid, 10000);
+      const innerShDied = await waitForProcessExit(innerShPid, 10000);
 
       expect(proc.signalCode).toBe("SIGKILL");
       expect({ childDied, outerShDied, innerShDied }).toEqual({
@@ -257,7 +229,7 @@ describe.skipIf(!(isLinux || isMacOS))("Subprocess.killTree() process tree", () 
         innerShDied: true,
       });
     } finally {
-      reap(childPid, outerShPid, innerShPid);
+      killProcesses(childPid, outerShPid, innerShPid);
     }
   });
 
@@ -296,29 +268,20 @@ describe.skipIf(!(isLinux || isMacOS))("Subprocess.killTree() process tree", () 
       stdio: ["ignore", "pipe", "inherit"],
     });
 
-    const reader = proc.stdout.getReader();
-    const dec = new TextDecoder();
-    let line = "";
-    while (!line.includes("\n")) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      line += dec.decode(value, { stream: true });
-    }
-    reader.releaseLock();
-    const [rootPid, shPid] = line.trim().split(/\s+/).map(Number);
+    const [rootPid, shPid] = (await readFirstLine(proc.stdout)).split(/\s+/).map(Number);
     try {
       expect(rootPid).toBe(proc.pid);
-      expect(isAlive(shPid)).toBe(true);
+      expect(isProcessAlive(shPid)).toBe(true);
 
       proc.killTree("SIGTERM");
       await proc.exited;
 
-      const shDied = await waitUntilDead(shPid, 10000);
+      const shDied = await waitForProcessExit(shPid, 10000);
 
       expect(proc.signalCode).toBe("SIGTERM");
       expect(shDied).toBe(true);
     } finally {
-      reap(shPid);
+      killProcesses(shPid);
     }
   });
 
@@ -327,9 +290,9 @@ describe.skipIf(!(isLinux || isMacOS))("Subprocess.killTree() process tree", () 
     await using _ = proc;
     try {
       expect(() => proc.killTree(0)).not.toThrow();
-      expect(isAlive(childPid)).toBe(true);
-      expect(isAlive(outerShPid)).toBe(true);
-      expect(isAlive(innerShPid)).toBe(true);
+      expect(isProcessAlive(childPid)).toBe(true);
+      expect(isProcessAlive(outerShPid)).toBe(true);
+      expect(isProcessAlive(innerShPid)).toBe(true);
       expect(proc.killed).toBe(false);
       if (isLinux) {
         // Not merely alive, but not left SIGSTOPped (state "T") either.
@@ -341,7 +304,7 @@ describe.skipIf(!(isLinux || isMacOS))("Subprocess.killTree() process tree", () 
         }).toEqual({ child: running, outerSh: running, innerSh: running });
       }
     } finally {
-      reap(childPid, outerShPid, innerShPid);
+      killProcesses(childPid, outerShPid, innerShPid);
     }
   });
 });

--- a/test/js/bun/spawn/spawn-killTree.test.ts
+++ b/test/js/bun/spawn/spawn-killTree.test.ts
@@ -25,6 +25,17 @@ function procState(pid: number): string {
   return stat.charAt(stat.lastIndexOf(")") + 2);
 }
 
+// A signal takes effect shortly after kill() returns, not synchronously, so poll before asserting.
+async function waitForStates(pids: number[], want: RegExp): Promise<string[]> {
+  const deadline = Date.now() + 5000;
+  let states = pids.map(procState);
+  while (!states.every(s => want.test(s)) && Date.now() < deadline) {
+    await Bun.sleep(10);
+    states = pids.map(procState);
+  }
+  return states;
+}
+
 // root.js (bun) spawns child.js (bun) which spawns an outer sh, which
 // itself spawns an inner sh in the background. root.js prints the four
 // pids on one line once the whole chain is up, then everything idles.
@@ -304,6 +315,30 @@ describe.skipIf(!(isLinux || isMacOS))("Subprocess.killTree() process tree", () 
         }).toEqual({ child: running, outerSh: running, innerSh: running });
       }
     } finally {
+      killProcesses(childPid, outerShPid, innerShPid);
+    }
+  });
+
+  // Stop signals must not be followed by the SIGCONT that other signals get, or the
+  // stop would be undone; SIGCONT itself must leave the tree running.
+  test.skipIf(!isLinux)("killTree('SIGSTOP') pauses the whole tree and killTree('SIGCONT') resumes it", async () => {
+    const { proc, childPid, outerShPid, innerShPid } = await spawnTree();
+    await using _ = proc;
+    const pids = [proc.pid, childPid, outerShPid, innerShPid];
+    try {
+      proc.killTree("SIGSTOP");
+      expect(await waitForStates(pids, /^T$/)).toEqual(["T", "T", "T", "T"]);
+
+      proc.killTree("SIGCONT");
+      const running = expect.stringMatching(/^[RSD]$/);
+      expect(await waitForStates(pids, /^[RSD]$/)).toEqual([running, running, running, running]);
+
+      expect(proc.killed).toBe(false);
+    } finally {
+      // A SIGKILLed stopped process dies, but its stopped children would not, so take the whole tree down.
+      try {
+        proc.killTree("SIGKILL");
+      } catch {}
       killProcesses(childPid, outerShPid, innerShPid);
     }
   });

--- a/test/js/bun/spawn/spawn-killTree.test.ts
+++ b/test/js/bun/spawn/spawn-killTree.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, isMacOS, tempDir } from "harness";
 import { readFileSync } from "node:fs";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -30,6 +30,8 @@ async function waitUntilDead(pid: number, timeoutMs: number): Promise<boolean> {
 
 function reap(...pids: number[]) {
   for (const pid of pids) {
+    // pid 0 / negative pids address whole process groups, which would include the test runner.
+    if (!(Number.isInteger(pid) && pid > 1)) continue;
     try {
       process.kill(pid, "SIGKILL");
     } catch {}
@@ -72,7 +74,7 @@ const fixture = tempDir("spawn-killTree", {
     const gc = Bun.spawn({
       cmd: [
         "/bin/sh", "-c",
-        "/bin/sh -c 'while :; do sleep 30; done' & echo $$ $!; wait",
+        "/bin/sh -c 'while :; do sleep 1; done' & echo $$ $!; wait",
       ],
       stdio: ["ignore", "pipe", "inherit"],
     });
@@ -90,6 +92,7 @@ const fixture = tempDir("spawn-killTree", {
     setInterval(() => {}, 1e6);
   `,
 });
+afterAll(() => fixture[Symbol.dispose]());
 
 async function spawnTree() {
   const env: Record<string, string> = { ...bunEnv };
@@ -103,37 +106,101 @@ async function spawnTree() {
     stdio: ["ignore", "pipe", "inherit"],
   });
 
-  const reader = proc.stdout.getReader();
-  const dec = new TextDecoder();
-  let line = "";
-  while (!line.includes("\n")) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    line += dec.decode(value, { stream: true });
+  // Whatever has been started so far is torn down if a setup assertion below fails.
+  let descendants: number[] = [];
+  try {
+    const reader = proc.stdout.getReader();
+    const dec = new TextDecoder();
+    let line = "";
+    while (!line.includes("\n")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      line += dec.decode(value, { stream: true });
+    }
+    reader.releaseLock();
+
+    const [rootPid, childPid, outerShPid, innerShPid] = line.trim().split(/\s+/).map(Number);
+    descendants = [childPid, outerShPid, innerShPid];
+    expect(rootPid).toBe(proc.pid);
+    expect(childPid).toBeGreaterThan(1);
+    expect(outerShPid).toBeGreaterThan(1);
+    expect(innerShPid).toBeGreaterThan(1);
+    // Four distinct pids: no level of the tree is collapsed.
+    expect(new Set([rootPid, childPid, outerShPid, innerShPid]).size).toBe(4);
+    expect(isAlive(childPid)).toBe(true);
+    expect(isAlive(outerShPid)).toBe(true);
+    expect(isAlive(innerShPid)).toBe(true);
+
+    return { proc, rootPid, childPid, outerShPid, innerShPid };
+  } catch (e) {
+    proc.kill("SIGKILL");
+    reap(...descendants);
+    throw e;
   }
-  reader.releaseLock();
-
-  const [rootPid, childPid, outerShPid, innerShPid] = line.trim().split(/\s+/).map(Number);
-  expect(rootPid).toBe(proc.pid);
-  expect(childPid).toBeGreaterThan(1);
-  expect(outerShPid).toBeGreaterThan(1);
-  expect(innerShPid).toBeGreaterThan(1);
-  // Four distinct pids: no level of the tree is collapsed.
-  expect(new Set([rootPid, childPid, outerShPid, innerShPid]).size).toBe(4);
-  expect(isAlive(childPid)).toBe(true);
-  expect(isAlive(outerShPid)).toBe(true);
-  expect(isAlive(innerShPid)).toBe(true);
-
-  return { proc, rootPid, childPid, outerShPid, innerShPid };
 }
 
-describe.skipIf(!(isLinux || isMacOS))("Subprocess.killTree()", () => {
-  test("exists and is a function", async () => {
-    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", "setTimeout(()=>{}, 1e6)"], env: bunEnv });
-    expect(typeof proc.killTree).toBe("function");
-    expect(proc.killTree.length).toBe(1);
-  });
+// Argument handling and the root-process behaviour are the same on every
+// platform (elsewhere than Linux/macOS, killTree() is exactly kill()).
+test("exists and is a function", async () => {
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", "setTimeout(()=>{}, 1e6)"], env: bunEnv });
+  expect(typeof proc.killTree).toBe("function");
+  expect(proc.killTree.length).toBe(1);
+});
 
+test("kills the root process with SIGTERM by default", async () => {
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", "setTimeout(()=>{}, 1e6)"], env: bunEnv });
+  proc.killTree();
+  await proc.exited;
+  expect({ killed: proc.killed, exitCode: proc.exitCode, signalCode: proc.signalCode }).toEqual({
+    killed: true,
+    exitCode: null,
+    signalCode: "SIGTERM",
+  });
+});
+
+test("is a no-op once the process has already exited", async () => {
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", ""], env: bunEnv });
+  await proc.exited;
+  expect(() => proc.killTree()).not.toThrow();
+  expect(() => proc.killTree("SIGKILL")).not.toThrow();
+});
+
+test("rejects invalid signals the same way kill() does", async () => {
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", "setTimeout(()=>{}, 1e6)"], env: bunEnv });
+
+  function thrownBy(fn: () => void) {
+    try {
+      fn();
+    } catch (e: any) {
+      return { name: e.name, code: e.code, message: e.message };
+    }
+    throw new Error("expected a throw");
+  }
+
+  for (const sig of [-1, 32, 1.5, "NOT_A_SIGNAL", {}] as any[]) {
+    expect(thrownBy(() => proc.killTree(sig))).toEqual(thrownBy(() => proc.kill(sig)));
+  }
+
+  expect(() => proc.killTree(-1)).toThrow(
+    expect.objectContaining({
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_TYPE",
+      message: "Invalid signal: must be >= 0",
+    }),
+  );
+  expect(() => proc.killTree("NOT_A_SIGNAL" as any)).toThrow(
+    expect.objectContaining({
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_TYPE",
+      message: expect.stringContaining("'SIGTERM'"),
+    }),
+  );
+
+  // Nothing above may have signalled the process.
+  expect(proc.killed).toBe(false);
+});
+
+describe.skipIf(!(isLinux || isMacOS))("Subprocess.killTree() process tree", () => {
   test("default signal kills the root and every descendant", async () => {
     const { proc, childPid, outerShPid, innerShPid } = await spawnTree();
     await using _ = proc;
@@ -202,7 +269,7 @@ describe.skipIf(!(isLinux || isMacOS))("Subprocess.killTree()", () => {
     using dir = tempDir("killTree-catchable", {
       "root.js": `
         const child = Bun.spawn({
-          cmd: ["/bin/sh", "-c", "echo $$; while :; do sleep 30; done"],
+          cmd: ["/bin/sh", "-c", "echo $$; while :; do sleep 1; done"],
           stdio: ["ignore", "pipe", "inherit"],
         });
         let line = "";
@@ -239,10 +306,10 @@ describe.skipIf(!(isLinux || isMacOS))("Subprocess.killTree()", () => {
     }
     reader.releaseLock();
     const [rootPid, shPid] = line.trim().split(/\s+/).map(Number);
-    expect(rootPid).toBe(proc.pid);
-    expect(isAlive(shPid)).toBe(true);
-
     try {
+      expect(rootPid).toBe(proc.pid);
+      expect(isAlive(shPid)).toBe(true);
+
       proc.killTree("SIGTERM");
       await proc.exited;
 
@@ -253,48 +320,6 @@ describe.skipIf(!(isLinux || isMacOS))("Subprocess.killTree()", () => {
     } finally {
       reap(shPid);
     }
-  });
-
-  test("is a no-op once the process has already exited", async () => {
-    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", ""], env: bunEnv });
-    await proc.exited;
-    expect(() => proc.killTree()).not.toThrow();
-    expect(() => proc.killTree("SIGKILL")).not.toThrow();
-  });
-
-  test("rejects invalid signals the same way kill() does", async () => {
-    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", "setTimeout(()=>{}, 1e6)"], env: bunEnv });
-
-    function thrownBy(fn: () => void) {
-      try {
-        fn();
-      } catch (e: any) {
-        return { name: e.name, code: e.code, message: e.message };
-      }
-      throw new Error("expected a throw");
-    }
-
-    for (const sig of [-1, 32, 1.5, "NOT_A_SIGNAL", {}] as any[]) {
-      expect(thrownBy(() => proc.killTree(sig))).toEqual(thrownBy(() => proc.kill(sig)));
-    }
-
-    expect(() => proc.killTree(-1)).toThrow(
-      expect.objectContaining({
-        name: "TypeError",
-        code: "ERR_INVALID_ARG_TYPE",
-        message: "Invalid signal: must be >= 0",
-      }),
-    );
-    expect(() => proc.killTree("NOT_A_SIGNAL" as any)).toThrow(
-      expect.objectContaining({
-        name: "TypeError",
-        code: "ERR_INVALID_ARG_TYPE",
-        message: expect.stringContaining("'SIGTERM'"),
-      }),
-    );
-
-    // Nothing above may have signalled the process.
-    expect(proc.killed).toBe(false);
   });
 
   test("killTree(0) is a liveness probe and does not pause descendants", async () => {


### PR DESCRIPTION
## `Subprocess.killTree(signal?)`

Sends `signal` (default `SIGTERM`) to the subprocess **and every descendant process**, using the same mechanism as `--no-orphans`.

```js
const proc = Bun.spawn({ cmd: ["bash", "-c", "spawn-lots-of-stuff.sh"] });
// ... later:
proc.killTree();          // SIGTERM the whole tree
proc.killTree("SIGKILL"); // or SIGKILL it
```

The `--no-orphans` exit handler had two near-duplicate tree walks in `ParentDeathWatchdog.rs` (`kill_descendants()` rooted at `getpid()`, and `kill_tree_rooted_at()` rooted at a child). Both are now thin wrappers over a single parameterized core:

```rust
fn signal_process_tree(
    root: pid_t,
    expected_ppid_of_root: Option<pid_t>,  // Some => freeze+verify+signal root too
    signal: c_int,
)
```

which keeps the existing discipline of `SIGSTOP`, re-verify ppid, then signal leaves-first (so a pid recycled in the enumerate/signal window is never hit). For catchable signals it sends `SIGCONT` afterwards so the pending signal actually delivers instead of leaving processes frozen. `Subprocess.killTree(sig)` calls the new public `kill_process_tree(root, sig)` with `root = subprocess.pid` and `expected_ppid = getpid()`.

- **Linux**: `/proc/<pid>/task/*/children`
- **macOS**: `proc_listchildpids()`
- **Windows / other**: falls back to `kill()` on the root only
- **`killTree(0)`**: routed to plain `kill(0)`, a liveness probe with no STOP/CONT side effects
- **Invalid signals**: rejected with the same errors as `kill()` (shared parser)

## `Bun.spawn({ deathSignal })`

Sets `prctl(PR_SET_PDEATHSIG, signal)` in the child between vfork and exec, so the kernel delivers `signal` to the child when the spawning thread dies, even if the parent was `SIGKILL`ed.

```js
const proc = Bun.spawn({
  cmd: ["sleep", "1000"],
  deathSignal: "SIGKILL",   // child cannot outlive us
});
```

Linux only (accepted and ignored elsewhere). The `PosixSpawnOptions.linux_pdeathsig` field was already wired through `posix_spawn_bun` for `--no-orphans`; this exposes it to JS. `deathSignal: 0` is rejected with `ERR_UNKNOWN_SIGNAL`, exactly like `killSignal: 0`, so there is no implicit per-spawn opt-out of the `--no-orphans` default; `undefined`/`null` leave the default in place.

## Docs and tests

- `docs/runtime/child-process.mdx`: `killTree()` next to `kill()`, a `deathSignal` section next to `killSignal`, and both entries in the reference block. The snippets and claims were run against the build.
- `test/js/bun/spawn/spawn-killTree.test.ts` and `spawn-deathSignal.test.ts`. The pid helpers they share (`isProcessAlive`, `waitForProcessExit`, `killProcesses`, `readFirstLine`) were added to `test/harness.ts`.

## Verification

```
$ bun bd test test/js/bun/spawn/spawn-killTree.test.ts test/js/bun/spawn/spawn-deathSignal.test.ts
 22 pass, 0 fail   (killTree: 4 platform-independent + 6 tree tests on Linux/macOS, one of
                    them Linux-only; deathSignal: 5 Linux-only + 7 validation cases that run everywhere)

$ bun bd test test/cli/run/no-orphans.test.ts
 18 pass, 5 skip, 1 fail   # refactored code path unchanged; the one failure
                           # (uid/gid grandchild) fails identically with main's src/
                           # here because this container's root lacks CAP_KILL

$ USE_SYSTEM_BUN=1 bun test test/js/bun/spawn/spawn-killTree.test.ts
 1 pass, 9 fail   # killTree is undefined on the baked bun

$ USE_SYSTEM_BUN=1 bun test test/js/bun/spawn/spawn-deathSignal.test.ts
 6 pass, 6 fail   # deathSignal is ignored (and not validated) on the baked bun
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 12 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawn-deathSignal.test.ts test/js/bun/spawn/spawn-killTree.test.ts

<!-- robobun:evidence:end -->
