### PR TITLE
deps: bump mimalloc to 24f9c6b4 (theap-init sentinel fix + dev3 sync)

### DIFF
--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "f15aecb94fc8096008bf87b90c53ed682026914a";
+const MIMALLOC_COMMIT = "24f9c6b49e2e33855a7d08a9f1e07a6fccce8820";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -275,7 +275,7 @@ it("process.versions", () => {
   const expectedVersions = {
     boringssl: "0c5fce43b7ed5eb6001487ee48ac65766f5ddcd1",
     libarchive: "ded82291ab41d5e355831b96b0e1ff49e24d8939",
-    mimalloc: "f15aecb94fc8096008bf87b90c53ed682026914a",
+    mimalloc: "24f9c6b49e2e33855a7d08a9f1e07a6fccce8820",
     picohttpparser: "066d2b1e9ab820703db0837a7255d92d30f0c9f5",
     zlib: "12731092979c6d07f42da27da673a9f6c7b13586",
     tinycc: "12882eee073cfe5c7621bcfadf679e1372d4537b",


### PR DESCRIPTION
Fixes a flaky segfault at `0xE89` on darwin x64 in the `RuntimeTranspilerStore` worker pool.

### What

`mi_heap_init_theap` writes a non-NULL placeholder into the per-heap TLS slot to force the slot allocation, then overwrites it with the real `mi_theap_t*` once `_mi_theap_create` returns. The placeholder was `(mi_theap_t*)1`. If anything between those two writes re-enters `mi_heap_malloc(heap, ..)` on the same thread, `_mi_heap_theap_get_or_init` reads `1` back, treats it as initialized (`!= NULL`), and `_mi_theap_cached_set` → `_mi_theap_incref` dereferences `1->memid.memkind`.

Under `-DNDEBUG` that field is at offset `0xe88`, so the fault lands at `0xE89` — exact match for the [build #56330 darwin-x64 crash](https://buildkite.com/bun/bun/builds/56330) (`heap.c:95` in the stack, with the two un-symbolicated frames being `_mi_theap_cached_set` / `_mi_theap_incref`).

### Fix (oven-sh/mimalloc@24f9c6b4)

- Use `&_mi_theap_empty_wrong` as the placeholder: `_mi_theap_incref`/`decref` no-op on it (`memid.memkind == MI_MEM_STATIC`) and `_mi_malloc_generic` already returns NULL for it, so a re-entrant allocation gets NULL instead of faulting.
- `_mi_heap_theap_get_peek` maps the placeholder to NULL so the debug invariant in `_mi_heap_theap_peek` holds and `mi_heap_init_theap` does not recurse.
- New `test/test-theap-sentinel.c` (`--prove` models the mid-init slot state and asserts `mi_heap_malloc` returns NULL gracefully; `--stress` runs the short-lived-heap thread-pool pattern). All 11 mimalloc tests pass under release / debug / debug-full.

### Also included

- upstream `dev3` @ e5047591 — issue #1287 (main thread may terminate before process), more assertions
- heap-snapshot + pprof-compatible sampling profiler + `mi-heapview` CLI (oven-sh/mimalloc fdcc84db..3e41c9f7)
- prior `dev3` sync to v3.3.2 (8e4230a9)

### Notes

`test/js/bun/util/which.test.ts` trips a `debug_assert!(atoms.capacity() == 1)` in `src/shell_parser/parse.rs:1932` on a debug build of this branch. That assertion checks an allocator-dependent capacity rounding (never a valid invariant for an arena-backed Vec); flagging here in case CI catches it on more than debug, but it's orthogonal to the placeholder fix.