### PR TITLE
Fix dangling PackageManager.log when JS runs during auto-install sleep_until

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -596,6 +596,13 @@ pub fn enqueue_dependency_to_root(
                 // raw `*mut` — `sleep_until`
                 // also receives this pointer, so `&mut` here would alias.
                 manager: *mut PackageManager,
+                // `sleep_until` ticks the JS event loop between polls; code
+                // run there (module transpile / nested resolve / AsyncModule)
+                // swaps `manager.log` and may restore it from a different
+                // source than the caller did, leaving it pointing at a dead
+                // stack `Log`. Snapshot the caller's log and re-assert it
+                // before every `run_tasks` so `log_mut()` never dangles.
+                log: *mut bun_ast::Log,
             }
             impl Closure {
                 fn is_done(&mut self) -> bool {
@@ -603,6 +610,7 @@ pub fn enqueue_dependency_to_root(
                     // below; `sleep_until`/`tick_raw` hold no `&mut` across
                     // this callback, so this is the unique live borrow.
                     let manager = unsafe { &mut *self.manager };
+                    manager.log = self.log;
                     if manager.pending_task_count() > 0 {
                         // All callbacks void: `VoidRunTasksCallbacks` (below)
                         // has `Ctx = ()` and every `HAS_* = false`.
@@ -639,6 +647,7 @@ pub fn enqueue_dependency_to_root(
             let mut closure = Closure {
                 err: None,
                 manager: mgr,
+                log: this.log,
             };
             // SAFETY: `mgr` derived from the live exclusive `this` borrow;
             // `sleep_until` + `tick_raw` hold no `&mut PackageManager` across

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -596,12 +596,9 @@ pub fn enqueue_dependency_to_root(
                 // raw `*mut` — `sleep_until`
                 // also receives this pointer, so `&mut` here would alias.
                 manager: *mut PackageManager,
-                // `sleep_until` ticks the JS event loop between polls; code
-                // run there (module transpile / nested resolve / AsyncModule)
-                // swaps `manager.log` and may restore it from a different
-                // source than the caller did, leaving it pointing at a dead
-                // stack `Log`. Snapshot the caller's log and re-assert it
-                // before every `run_tasks` so `log_mut()` never dangles.
+                // `sleep_until` ticks the JS event loop, and JS run there can
+                // swap `manager.log` and leave it pointing at a dead stack
+                // `Log`. `is_done` re-asserts this snapshot before each poll.
                 log: *mut bun_ast::Log,
             }
             impl Closure {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4734,8 +4734,10 @@ impl VirtualMachine {
         // so the `Option` is purely a
         // zeroed-init nicety; the `expect` is infallible.
         let old_log: NonNull<bun_ast::Log> = jsc_vm.log.expect("vm.log set in init");
+        let old_transpiler_log: *mut bun_ast::Log = jsc_vm.transpiler.log;
         let mut log = bun_ast::Log::default();
         jsc_vm.log = NonNull::new(&raw mut log);
+        jsc_vm.transpiler.log = &raw mut log;
         jsc_vm.transpiler.resolver.log = NonNull::from(&mut log);
         jsc_vm.transpiler.linker.log = &raw mut log;
         if let Some(pm) = jsc_vm.transpiler.resolver.package_manager {
@@ -4752,6 +4754,7 @@ impl VirtualMachine {
         struct RestoreLog {
             vm: bun_ptr::BackRef<VirtualMachine>,
             old_log: NonNull<bun_ast::Log>,
+            old_transpiler_log: *mut bun_ast::Log,
         }
         impl Drop for RestoreLog {
             fn drop(&mut self) {
@@ -4759,6 +4762,7 @@ impl VirtualMachine {
                 // thread); `old_log` outlives the VM (Box::leak in `init`).
                 let jsc_vm = self.vm.get().as_mut();
                 jsc_vm.log = Some(self.old_log);
+                jsc_vm.transpiler.log = self.old_transpiler_log;
                 jsc_vm.transpiler.resolver.log = self.old_log;
                 jsc_vm.transpiler.linker.log = self.old_log.as_ptr();
                 // `_resolve` may have lazily created the PM with
@@ -4776,6 +4780,7 @@ impl VirtualMachine {
         let _restore = RestoreLog {
             vm: bun_ptr::BackRef::from(NonNull::new(jsc_vm_ptr).expect("vm non-null")),
             old_log,
+            old_transpiler_log,
         };
         // Note: reshaped for borrowck — re-derive from raw so the unique
         // borrow doesn't span the guard's drop.

--- a/test/js/bun/resolve/resolve-autoinstall-log-dangling.test.ts
+++ b/test/js/bun/resolve/resolve-autoinstall-log-dangling.test.ts
@@ -57,3 +57,68 @@ test("repeated failing auto-install resolves at varying stack depth don't read a
   expect(stdout.trim()).toBe("ok");
   expect(exitCode).toBe(0);
 });
+
+// Auto-install's `sleep_until` ticks the JS event loop while waiting for the
+// manifest response. JS that runs during that tick (module transpile) swaps
+// `PackageManager.log` (and the related resolver/linker/transpiler log
+// pointers) and restores them from `transpiler.log` — which the outer resolve
+// hadn't swapped — instead of the resolve's scoped log. The next `run_tasks`
+// poll then wrote its 404 diagnostic into the VM's persistent log, which is
+// dumped to stderr at process exit. With enough interleaving across REPRL
+// iterations this escalated to `pm.log` pointing at dead stack memory (ASAN
+// stack-buffer-overflow).
+test("module transpile during auto-install's event-loop tick doesn't desync pm.log", async () => {
+  let hits = 0;
+  await using server = Bun.serve({
+    port: 0,
+    fetch() {
+      hits++;
+      return new Response("Not Found", { status: 404 });
+    },
+  });
+
+  using dir = tempDir("resolve-autoinstall-log-tick", {
+    "index.js": `
+      const Module = require("module");
+      const fs = require("fs");
+      const path = require("path");
+
+      let n = 0;
+      function load() {
+        const f = path.join(import.meta.dir, "dyn" + n++ + ".cjs");
+        fs.writeFileSync(f, "module.exports = 0;");
+        try { require(f); } catch {}
+      }
+
+      for (let i = 0; i < 20; i++) {
+        setImmediate(load);
+        setImmediate(load);
+        try {
+          Module._resolveFilename("autoinstall-missing-pkg-" + i, { filename: import.meta.path });
+        } catch {}
+      }
+
+      console.log("ok " + n);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--install=force", "index.js"],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      BUN_CONFIG_REGISTRY: server.url.href,
+      NPM_CONFIG_REGISTRY: server.url.href,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toMatch(/^ok \d+$/m);
+  expect(Number(stdout.trim().slice(3))).toBeGreaterThan(0);
+  expect(hits).toBeGreaterThan(0);
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fuzzilli found an ASAN stack-buffer-overflow in `run_tasks` -> `Log::add_msg` -> `Vec::push` during runtime auto-install.

## What happened

`enqueue_dependency_to_root` blocks in `sleep_until`. `sleep_until` ticks the JS event loop between `is_done` polls. Each poll calls `run_tasks`, which reads `manager.log` to log manifest 4xx errors.

The event loop tick can run module transpilation or `AsyncModule::resume_loading_module`. Both swap the VM's log pointers (`jsc_vm.log`, `transpiler.log`, `resolver.log`, `linker.log`, `pm.log`) and restore them on exit. They do not save from the same source:

- `resolve_maybe_needs_trailing_slash` saves `jsc_vm.log` and swaps every pointer except `transpiler.log`.
- `transpile_source_code_inner` saves `transpiler.log` and restores `pm.log` to it.
- `AsyncModule::resume_loading_module` saves `jsc_vm.log` but restores `transpiler.log` to it.

When a module transpile runs during a resolve's `sleep_until` tick, its restore sets `pm.log` to the old `transpiler.log`, not the resolve's scoped log. The 404 diagnostics from `run_tasks` then land in the wrong log. With more interleaving across calls `pm.log` ends up at a dead stack `Log`, and the next `run_tasks` poll reads it.

```
READ of size 8 at 0x7ffd98a149c0 thread T0
    #0  RawVecInner::capacity
    #1  Log::add_msg (lib.rs:2369)
    #3  Log::add_error_fmt (lib.rs:2032)
    #4  run_tasks (runTasks.rs:494)
    #5  Closure::is_done (PackageManagerEnqueue.rs:534)
    #7  AnyEventLoop::tick_raw (AnyEventLoop.rs:148)
    #8  PackageManager::sleep_until (PackageManager.rs:1063)
    #9  enqueue_dependency_to_root (PackageManagerEnqueue.rs:571)
    ...
    #18 resolve_maybe_needs_trailing_slash (VirtualMachine.rs:4259)

Address is located in stack of thread T0 in frame
    #0  to_js_host_call (host_fn.rs:677)
  [144, 152) 'scope' <== Memory access at offset 160 overflows this variable
  [176, 240) 'scope_storage'
```

## Fix

- Swap and restore `transpiler.log` with the other log pointers in `resolve_maybe_needs_trailing_slash`. It can no longer drift from `jsc_vm.log` across a resolve.
- Snapshot `pm.log` on entry to `enqueue_dependency_to_root`'s `sleep_until`. Re-assert it before each `run_tasks` poll. `run_tasks` always sees the caller's log, whatever the event loop tick did to it.

## Test

The test runs a 404 registry in the parent process on `port: 0`. The child queues `require()` calls with `setImmediate`, so they run during `sleep_until`'s event-loop tick and trigger `transpile_source_code_inner`'s log swap. Without the fix, the 404 errors land in the VM log and print to stderr at exit. With the fix, stderr is empty.

Verified on current `main` (6f27257bb2): the test fails without the source change and passes with it.
