### PR TITLE
spawn: do not forward SIGPWR on Linux

### DIFF
--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -933,9 +933,11 @@ static struct sigaction previous_actions[NSIG];
     M(SIGIO);
 
 #if OS(LINUX)
+// SIGPWR is intentionally omitted: JavaScriptCore uses it to suspend and
+// resume threads for garbage collection (see ThreadingPOSIX.cpp). Replacing
+// that handler here would break GC and terminate the process with SIGPWR.
 #define FOR_EACH_LINUX_ONLY_SIGNAL(M) \
     M(SIGPOLL);                       \
-    M(SIGPWR);                        \
     M(SIGSTKFLT);
 
 #endif

--- a/test/js/bun/util/open-in-editor-gc.test.ts
+++ b/test/js/bun/util/open-in-editor-gc.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux } from "harness";
+
+// On Linux, JavaScriptCore uses SIGPWR to suspend and resume threads during
+// garbage collection. Bun.openInEditor() spawns the editor via bun.spawnSync
+// on a detached background thread, which installs signal-forwarding handlers
+// for the duration of the spawn. Those handlers must not replace JSC's SIGPWR
+// handler, otherwise a concurrent GC will terminate the process with SIGPWR.
+test.skipIf(!isLinux)("Bun.openInEditor concurrent with GC does not terminate the process with SIGPWR", () => {
+  const script = `
+    for (let k = 0; k < 50; k++) {
+      try { Bun.openInEditor("foo" + k); } catch {}
+    }
+    for (let i = 0; i < 200; i++) Bun.gc(true);
+  `;
+  const { exitCode, signalCode } = Bun.spawnSync({
+    cmd: [bunExe(), "-e", script],
+    env: { ...bunEnv, EDITOR: undefined, VISUAL: undefined },
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  expect(signalCode).toBeUndefined();
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What does this PR do?

On Linux, JavaScriptCore uses `SIGPWR` to suspend and resume threads during garbage collection (see [`ThreadingPOSIX.cpp`](https://github.com/oven-sh/bun/blob/main/vendor/WebKit/Source/WTF/wtf/posix/ThreadingPOSIX.cpp#L188)).

`Bun__registerSignalsForForwarding()` (used by `bun.spawnSync` to forward signals like `SIGINT`/`SIGTERM` to child scripts) was installing a forwarding handler with `SA_RESETHAND` over the GC's `SIGPWR` handler. When a concurrent GC sent `SIGPWR` to a JS thread during the register/unregister window:

1. the forwarding handler ran instead of JSC's suspend handler,
2. `SA_RESETHAND` reset the disposition to `SIG_DFL`,
3. the next `SIGPWR` (GC resume, or next suspend) terminated the process with "Power failure".

`Bun.openInEditor()` triggers this reliably because it runs `bun.spawnSync` on a **detached background thread** while the JS thread continues executing (and potentially running `Bun.gc(true)`), so the GC's `pthread_kill(thread, SIGPWR)` races the background thread's `sigaction()` calls.

## How did you verify your code works?

Minimal repro (crashes 100% before, 0% after in debug builds):

```js
for (let k = 0; k < 50; k++) {
  try { Bun.openInEditor("foo" + k); } catch {}
}
for (let i = 0; i < 200; i++) Bun.gc(true);
```

Before:
```
$ bun-debug repro.js
Power failure
exit=158  (128 + SIGPWR)
```

After: exits 0.

Added a regression test at `test/js/bun/util/open-in-editor-gc.test.ts`.

Fuzzer fingerprint: `fe0542d56ab690b0`