### PR TITLE
fetch: move scheduled_response_buffer into ByteStream as Owned to skip per-chunk copy

### DIFF
--- a/src/runtime/webcore/ByteStream.rs
+++ b/src/runtime/webcore/ByteStream.rs
@@ -388,10 +388,14 @@ impl ByteStream {
                 self.buffer
                     .with_mut(|b| b.extend_from_slice(&temp.slice()[offset..]));
             }
-            streams::Result::OwnedAndDone(owned) | streams::Result::Owned(owned) => {
-                self.buffer
-                    .with_mut(|b| b.extend_from_slice(&owned.slice()[offset..]));
-                // Zig: `allocator.free(@constCast(base_address))` — `owned: Vec<u8>` drops here.
+            streams::Result::OwnedAndDone(mut owned) | streams::Result::Owned(mut owned) => {
+                if self.buffer.get().is_empty() {
+                    self.buffer.set(owned.move_to_list_managed());
+                    self.offset.set(self.offset.get() + offset);
+                } else {
+                    self.buffer
+                        .with_mut(|b| b.extend_from_slice(&owned.slice()[offset..]));
+                }
             }
             streams::Result::Err(err) => {
                 if self.buffer_action.get().is_some() {

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -683,16 +683,14 @@ impl FetchTasklet {
             if let Some(bytes) = readable.ptr.bytes() {
                 bytes.size_hint.set(self.get_size_hint());
                 // body can be marked as used but we still need to pipe the data
+                let chunk = core::mem::take(&mut self.scheduled_response_buffer.list);
+                buffer_reset.set(false);
                 if self.result.has_more {
-                    let chunk = self.scheduled_response_buffer.list.as_slice();
-                    bytes.on_data(Self::temporary_chunk(chunk, false))?;
+                    bytes.on_data(StreamResult::Owned(chunk))?;
                 } else {
                     self.clear_stream_cancel_handler();
                     let prev = core::mem::take(&mut self.readable_stream_ref);
-                    buffer_reset.set(false);
-
-                    let chunk = self.scheduled_response_buffer.list.as_slice();
-                    bytes.on_data(Self::temporary_chunk(chunk, true))?;
+                    bytes.on_data(StreamResult::OwnedAndDone(chunk))?;
                     drop(prev);
                 }
                 return Ok(());
@@ -709,14 +707,14 @@ impl FetchTasklet {
                     "onBodyReceived CurrentResponse BodyReadableStream"
                 );
                 if let Some(bytes) = readable.ptr.bytes() {
-                    let chunk = self.scheduled_response_buffer.list.as_slice();
-
+                    let chunk = core::mem::take(&mut self.scheduled_response_buffer.list);
+                    buffer_reset.set(false);
                     if self.result.has_more {
-                        bytes.on_data(Self::temporary_chunk(chunk, false))?;
+                        bytes.on_data(StreamResult::Owned(chunk))?;
                     } else {
                         readable.value.ensure_still_alive();
                         response.detach_readable_stream(&global_this);
-                        bytes.on_data(Self::temporary_chunk(chunk, true))?;
+                        bytes.on_data(StreamResult::OwnedAndDone(chunk))?;
                     }
 
                     return Ok(());


### PR DESCRIPTION
## What

When a `fetch()` response body is consumed via a streaming reader, `FetchTasklet::on_body_received` was wrapping `scheduled_response_buffer` as `StreamResult::Temporary`/`TemporaryAndDone` and calling `ByteStream::on_data`, which then `extend_from_slice`d the bytes into `ByteStream.buffer`. The original buffer was then `reset()` (kept capacity) by the scopeguard.

That's one full memcpy of the chunk per JS-thread drain, on top of the HTTP-thread socket→`scheduled_response_buffer` copy and the BYOB-mandated `on_pull` copy into the JS Uint8Array.

This PR `mem::take`s `scheduled_response_buffer.list` and sends it as `StreamResult::Owned`/`OwnedAndDone` instead. `ByteStream::append`'s owned arm now adopts the `Vec` directly when `buffer.is_empty()` (the steady state after `on_pull` drains via `b.clear()`), eliminating the intermediate copy.

## Safety

- `mem::take` runs on the JS thread inside `on_body_received`, called from `on_progress_update` while `self.mutex` is held; the HTTP-thread `write()` at `callback()` holds the same mutex, so there's no race on the `Vec` header.
- The taken `Vec` is moved into `ByteStream.buffer` (Rust-owned `JsCell<Vec<u8>>`); `on_pull` only `copy_from_slice`s out of it into the JS-provided BYOB view — the Rust `Vec`'s storage is never exposed to JS, so there's no Rust-mutates-while-JS-reads hazard.
- `is_empty()` adopt invariant: every path that empties `buffer` resets `offset` to 0 (`on_pull`, `default()`), so `offset.set(0 + param_offset)` matches the existing `cap == 0` arm semantics.
- No new `unsafe`.

## Trade-off

`scheduled_response_buffer` now regrows from `cap=0` each drain (1 alloc) and the prior `ByteStream.buffer` capacity is dropped on adopt (1 free). Net: **1 memcpy(N) traded for 1 alloc + 1 free**. For the 16-64 KB chunks typical here (multiple socket reads coalesce under the `has_schedule_callback` CAS), this is ~200 ns vs 2-10 µs. The `OwnedAndDone` final-chunk path is strictly net-positive since the buffer is never reused after `has_more == false`.

The pipe/proxy path (`Bun.serve` returning `fetch(url)`) goes through `on_pipe` which copies into uSockets regardless, so that path sees +1 alloc/free without saving a copy. Worth a benchmark if proxy throughput matters.

Zig sibling sends `.temporary*`; this is an intentional perf-only divergence — same bytes reach JS.

## Tests

0 new failures vs `origin/main` across `test/js/web/fetch/fetch.stream.test.ts` (109 pass), `body-stream.test.ts` (9086 pass), `body.test.ts` (346 pass), `body-async-iterator.test.ts`, `stream-fast-path.test.ts`, `test/js/web/streams/streams.test.js`, `test/js/bun/http/proxy.test.js`, `async-iterator-stream.test.ts`.