### PR TITLE
https: make https.Server a distinct class from http.Server

### DIFF
--- a/src/js/node/https.ts
+++ b/src/js/node/https.ts
@@ -44,11 +44,21 @@ function Agent(options) {
 $toClass(Agent, "Agent", http.Agent);
 Agent.prototype.createConnection = http.createConnection;
 
+function Server(options, requestListener) {
+  if (!(this instanceof Server)) return new Server(options, requestListener);
+  http.Server.$apply(this, [options, requestListener]);
+}
+$toClass(Server, "Server", http.Server);
+
+function createServer(options, requestListener) {
+  return new Server(options, requestListener);
+}
+
 var https = {
   Agent,
   globalAgent: new Agent({ keepAlive: true, scheduling: "lifo", timeout: 5000 }),
-  Server: http.Server,
-  createServer: http.createServer,
+  Server,
+  createServer,
   get,
   request,
 };

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -982,6 +982,34 @@ describe("node:http", () => {
     });
   });
 
+  describe("Server", () => {
+    // https://github.com/oven-sh/bun/issues/31125
+    it("https.Server is a distinct class from http.Server", () => {
+      expect(http.Server).not.toBe(https.Server);
+    });
+
+    it("http.createServer() is instanceof http.Server but not https.Server", () => {
+      const server = http.createServer(() => {});
+      expect(server instanceof http.Server).toBe(true);
+      expect(server instanceof https.Server).toBe(false);
+      server.close();
+    });
+
+    it("https.createServer() is instanceof https.Server and http.Server", () => {
+      const server = https.createServer(() => {});
+      expect(server instanceof https.Server).toBe(true);
+      expect(server instanceof http.Server).toBe(true);
+      server.close();
+    });
+
+    it("new https.Server() is instanceof https.Server and http.Server", () => {
+      const server = new https.Server(() => {});
+      expect(server instanceof https.Server).toBe(true);
+      expect(server instanceof http.Server).toBe(true);
+      server.close();
+    });
+  });
+
   describe("ClientRequest.signal", () => {
     it("should attempt to make a standard GET request and abort", async () => {
       let server_port;


### PR DESCRIPTION
Closes #31125

## Repro

```js
import http from "node:http";
import https from "node:https";

const httpServer = http.createServer(() => {});

console.log("http.Server === https.Server:", http.Server === https.Server);
console.log("httpServer instanceof http.Server:", httpServer instanceof http.Server);
console.log("httpServer instanceof https.Server:", httpServer instanceof https.Server);
```

**Before:**
```
http.Server === https.Server: true
httpServer instanceof http.Server: true
httpServer instanceof https.Server: true
```

**After (matches Node.js):**
```
http.Server === https.Server: false
httpServer instanceof http.Server: true
httpServer instanceof https.Server: false
```

## Cause

`src/js/node/https.ts` exposed `http.Server` directly as `https.Server`:

```ts
var https = {
  Agent,
  globalAgent: new Agent({...}),
  Server: http.Server,            // same reference as http.Server
  createServer: http.createServer,
  ...
};
```

PR #11826 fixed this same issue for `https.Agent` but left `Server`
untouched. Libraries like `@astrojs/node` use `server instanceof https.Server`
to decide whether to print `https://` or `http://` in startup logs
(withastro/astro#16798).

## Fix

Mirror the existing `Agent` pattern in the same file: wrap `Server` in a
subclass that inherits from `http.Server` via `$toClass`, and route
`https.createServer` through it so instances are `instanceof https.Server`
(and still `instanceof http.Server` — Node's `https.Server` extends
`tls.Server` which extends `net.Server`, so a Node `https` server is also
an `http.Server`'s parent-of-parent; our wrapper preserves the subclass
relationship libraries actually check for).

## Verification

```
$ bun bd test test/js/node/http/node-http.test.ts -t Server
30 pass, 0 fail

$ USE_SYSTEM_BUN=1 bun test test/js/node/http/node-http.test.ts -t Server
28 pass, 2 fail  (the two new instanceof tests)
```

Four regression tests cover:
- `http.Server !== https.Server`
- `http.createServer()` is instanceof `http.Server` but not `https.Server`
- `https.createServer()` is instanceof both `https.Server` and `http.Server`
- `new https.Server()` is instanceof both `https.Server` and `http.Server`