### PR TITLE
webcore: hand ByteStream accumulator to JS as Owned in on_pull

### DIFF
--- a/src/runtime/webcore/ByteStream.rs
+++ b/src/runtime/webcore/ByteStream.rs
@@ -421,6 +421,16 @@ impl ByteStream {
 
         if !self.buffer.get().is_empty() {
             debug_assert!(self.value().is_empty()); // == .zero
+
+            if self.offset.get() == 0 {
+                let owned = self.buffer.replace(Vec::new());
+                if self.has_received_last_chunk.get() {
+                    self.done.set(true);
+                    return streams::Result::OwnedAndDone(owned);
+                }
+                return streams::Result::Owned(owned);
+            }
+
             // R-2: confine the `&mut Vec<u8>` to a `with_mut` so no `JsCell`
             // borrow escapes the copy. The result tuple drives the rest.
             let (to_write, remaining_in_buffer_len) = self.buffer.with_mut(|b| {


### PR DESCRIPTION
### What

`ByteStream::on_pull` (src/runtime/webcore/ByteStream.rs:422) currently memcpys the accumulated `self.buffer` into the JS-provided BYOB view and returns `IntoArray(len)`. When `offset == 0`, the entire Vec is being copied out only to be `clear()`ed.

This change moves the Vec to JS instead: `self.buffer.replace(Vec::new())` → `streams::Result::Owned` / `OwnedAndDone`. The bytes reach JS via `ArrayBuffer::from_bytes` + `MarkedArrayBuffer_deallocator` (zero-copy ownership transfer), and `#handleArrayBufferViewResult` enqueues the result while returning the original `view`, so `$data` stays full-size and `#getInternalBuffer` reuses it on subsequent pulls.

### When it fires

- First `pull()` with pre-buffered data (`$data` falsy + buffer non-empty).
- Accumulator larger than the ~528 KB view: instead of N×IntoArray copies + N fresh `Uint8Array` view allocations across N pulls, one `Owned(buf)` is emitted.

The common steady-state buffered path already goes through `drain()` (called before `pull()` whenever `$data` is truthy), which was already doing this same zero-copy move; this brings `on_pull` to parity.

### Safety

- `JsCell::replace` hands sole ownership of the bytes to the returned Vec; the `ByteStream` is left with a fresh empty Vec. `on_data`/`append` are main-thread-only and see `cap==0` next time. JSC frees via `MarkedArrayBuffer_deallocator`. No new `unsafe`.
- `offset > 0` keeps the existing `IntoArray` memcpy so the already-delivered prefix is never re-exposed (offset is only set by the `Owned`-with-offset overflow path in `append()`).
- User-visible semantics (bytes delivered, done timing) preserved. When the accumulator exceeds the view size the reader now gets one large `Uint8Array` instead of view-sized slices over N reads — spec-compliant for the default reader and matches existing `on_start` / `drain()` behavior.

### Tests

`fetch.stream.test.ts` + `body-stream.test.ts` + `client-fetch.test.ts`: **9224 pass / 0 fail**.

`streams.test.js`, `test/js/web/streams/`, `test/js/bun/io/`, `fetch.test.ts`: identical pass/fail to `origin/main` (pre-existing debug-build timeouts only).