### PR TITLE
Don't forward SIGPWR in sync-spawn signal forwarding

### DIFF
--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -933,9 +933,12 @@ static struct sigaction previous_actions[NSIG];
     M(SIGIO);
 
 #if OS(LINUX)
+// SIGPWR is intentionally excluded: JSC's GC uses it to suspend/resume
+// threads (see WTF/wtf/posix/ThreadingPOSIX.cpp). Overriding it with an
+// SA_RESETHAND forwarder resets the disposition to SIG_DFL after the first
+// GC suspend, and the next GC SIGPWR terminates the process.
 #define FOR_EACH_LINUX_ONLY_SIGNAL(M) \
     M(SIGPOLL);                       \
-    M(SIGPWR);                        \
     M(SIGSTKFLT);
 
 #endif

--- a/test/js/bun/spawn/spawnSync-sigpwr-gc.test.ts
+++ b/test/js/bun/spawn/spawnSync-sigpwr-gc.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// On Linux, JSC's GC uses SIGPWR to suspend/resume threads for conservative
+// stack scanning. Bun.openInEditor spawns a detached thread that runs the
+// internal sync-spawn path, which installs a temporary signal-forwarding
+// handler for the signals it knows about. If SIGPWR is in that set,
+// concurrent register/unregister races on the shared previous_actions[]
+// array leave the SIGPWR disposition as SIG_DFL, and the next GC suspend
+// terminates the process with SIGPWR.
+test.skipIf(process.platform !== "linux")(
+  "sync-spawn signal forwarding does not override the GC's SIGPWR handler",
+  async () => {
+    const script = `
+      for (let i = 0; i < 100; i++) {
+        try { Bun.openInEditor("/tmp/__nonexistent__"); } catch {}
+      }
+      await Bun.sleep(200);
+      for (let g = 0; g < 100; g++) {
+        new Array(10000).fill({ x: g });
+        Bun.gc(true);
+      }
+      process.exit(0);
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      // Empty PATH / no EDITOR so auto-detect picks Editor::None and the
+      // background thread's posix_spawn fails immediately instead of
+      // launching a real editor.
+      env: { ...bunEnv, PATH: "", EDITOR: "", VISUAL: "" },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(proc.signalCode).not.toBe("SIGPWR");
+    expect(proc.signalCode).toBeNull();
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
## What does this PR do?

Removes `SIGPWR` from the set of signals that `Bun__registerSignalsForForwarding()` overrides during sync-spawn (`bun run`, `bunx`, and the background thread of `Bun.openInEditor()`).

On Linux, JSC's GC uses `SIGPWR` (via `g_wtfConfig.sigThreadSuspendResume` in `WTF/wtf/posix/ThreadingPOSIX.cpp`) to suspend and resume threads for conservative stack scanning. The sync-spawn signal-forwarding path was installing an `SA_RESETHAND` forwarder for `SIGPWR`, which breaks the GC in two ways:

1. If the GC sends `SIGPWR` while the forwarder is installed, the forwarder runs instead of WebKit's suspend handler. `SA_RESETHAND` then resets the disposition to `SIG_DFL`, and the next GC `SIGPWR` terminates the process.
2. `Bun.openInEditor()` spawns a detached thread that runs the same sync-spawn path, so concurrent `openInEditor` calls race on the process-global `previous_actions[]` array: one thread's `memset(previous_actions, 0, ...)` runs before another's restore, which then installs `SIG_DFL` for every forwarded signal — including `SIGPWR`.

Either way the next GC thread-suspend terminates the process with `SIGPWR` (`TERMSIG: 30`).

`SIGPWR` is already excluded from `process.on()` for the same reason (`BunProcess.cpp` checks `g_wtfConfig.sigThreadSuspendResume`); this excludes it from the forwarding set as well.

Found by Fuzzilli (fingerprint `66c688589d402c9f`).

## How did you verify your code works?

Added `test/js/bun/spawn/spawnSync-sigpwr-gc.test.ts` which:
- Fires 100 concurrent `Bun.openInEditor()` calls (each spawns a background thread that runs the register/unregister cycle), waits for the race to settle, then runs a GC loop.
- Before the fix: the subprocess terminates with `SIGPWR` 100% of the time on debug builds.
- After the fix: the subprocess exits cleanly with code 0.

Also verified the original fuzzer repro no longer crashes over 30 runs.
