### PR TITLE
NativeReadableStreamSource: allocate pull buffer via ArrayBuffer to skip slowDownAndWasteMemory

### DIFF
--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2048,7 +2048,10 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
       // subarray — on Windows that drove commit charge to tens of GB before
       // VirtualAlloc(MEM_COMMIT) failed in pas_compact_heap_reservation.
       if (!chunk || chunk.buffer.byteLength < chunkSize) {
-        this.$data = chunk = new Uint8Array(chunkSize);
+        // Wrap an ArrayBuffer so the view is born with a shared backing
+        // store; new Uint8Array(n) would start fast-path and get copied to
+        // the C heap (slowDownAndWasteMemory) on the first .buffer/.subarray.
+        this.$data = chunk = new Uint8Array(new ArrayBuffer(chunkSize));
       }
       return chunk;
     }

--- a/test/js/web/streams/streams-leak.test.ts
+++ b/test/js/web/streams/streams-leak.test.ts
@@ -50,6 +50,32 @@ test("native ReadableStream reuses the pull buffer across small reads", async ()
   for (const buf of distinctBuffers) backingBytes += buf.byteLength;
   // Pre-fix this was ~chunks.length * 256KB ≈ 25–250 MB.
   expect(backingBytes).toBeLessThan(4 * 1024 * 1024);
+
+  // #getInternalBuffer allocates the view over a pre-created ArrayBuffer
+  // of autoAllocateChunkSize so .buffer/.subarray don't have to migrate
+  // it off the fast path (slowDownAndWasteMemory). The rotate check
+  // relies on chunk.buffer.byteLength reflecting that full allocation,
+  // so any buffer shared by multiple chunks must be at least the initial
+  // autoAllocateChunkSize (256KB), and consecutive chunks within it must
+  // advance through it. (chunks[0] may be the constructor drainValue and
+  // have its own tiny buffer; skip buffers that back only one chunk.)
+  const byBuffer = new Map<ArrayBuffer, Uint8Array[]>();
+  for (const c of chunks) {
+    const arr = byBuffer.get(c.buffer) ?? [];
+    arr.push(c);
+    byBuffer.set(c.buffer, arr);
+  }
+  let sawPullBuffer = false;
+  for (const [buf, views] of byBuffer) {
+    if (views.length < 2) continue;
+    sawPullBuffer = true;
+    expect(buf.byteLength).toBeGreaterThanOrEqual(256 * 1024);
+    expect(views[0].byteOffset).toBe(0);
+    for (let i = 1; i < views.length; i++) {
+      expect(views[i].byteOffset).toBe(views[i - 1].byteOffset + views[i - 1].length);
+    }
+  }
+  expect(sawPullBuffer).toBe(true);
 });
 
 const BYTES_TO_WRITE = 500_000;


### PR DESCRIPTION
Follow-up to #30593 per https://github.com/oven-sh/bun/pull/30593#discussion_r3275000659.

`#getInternalBuffer` now reads `chunk.buffer.byteLength` on every pull, and `#handleNumberResult` calls `.subarray()` on the same view. Both paths force a `new Uint8Array(n)` — which JSC allocates in the fast-path GC heap without an `ArrayBuffer` — through `JSGenericTypedArrayView::slowDownAndWasteMemory`, copying the 256KB-2MB contents out to the C heap before the buffer has even been written to.

Allocate as `new Uint8Array(new ArrayBuffer(chunkSize))` instead so the view is born in WastefulTypedArray mode and the first `.buffer` / `.subarray` access is a no-op.

### Verification
- `test/js/web/streams/streams-leak.test.ts` — "native ReadableStream reuses the pull buffer across small reads" passes.
- `test/js/bun/spawn/spawn-streaming-stdout.test.ts` passes.