### PR TITLE
FileSink: mark sink done when end() fails during flush

### DIFF
--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -99,6 +99,9 @@ pub trait PosixPipeWriter {
         write_fn: fn(Fd, &[u8]) -> sys::Result<usize>,
     ) -> WriteResult {
         let fd = self.get_fd();
+        if fd == Fd::INVALID {
+            return WriteResult::Done(0);
+        }
 
         let mut offset: usize = 0;
 

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1240,7 +1240,8 @@ impl FileSink {
                 sys::Result::Ok(())
             }
             WriteResult::Err(e) => {
-                self.writer.with_mut(|w| w.close());
+                self.done.set(true);
+                self.writer.with_mut(|w| w.end());
                 sys::Result::Err(e)
             }
             WriteResult::Pending(written) => {
@@ -1354,7 +1355,8 @@ impl FileSink {
                 sys::Result::Ok(JSValue::js_number(written as f64))
             }
             WriteResult::Err(err) => {
-                self.writer.with_mut(|w| w.close());
+                self.done.set(true);
+                self.writer.with_mut(|w| w.end());
                 sys::Result::Err(err)
             }
             WriteResult::Pending(pending_written) => {

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -278,3 +278,33 @@ it("start() without path/fd on an already-open writer does not crash", async () 
   await writer.end();
   expect(await Bun.file(path).text()).toBe("hello");
 });
+
+it.skipIf(!isPosix)("writing after end() fails during flush does not crash", async () => {
+  const dir = tmpdirSync();
+  const target = join(dir, "ro.txt");
+  fs.writeFileSync(target, "");
+  const writer = Bun.file(target).writer();
+  // Re-point the writer at a read-only fd so the buffered flush in end() fails.
+  const fd = fs.openSync(target, "r");
+  try {
+    writer.start({ fd });
+  } finally {
+    fs.closeSync(fd);
+  }
+  writer.write("x");
+  let endErr: unknown;
+  try {
+    await writer.end();
+  } catch (e) {
+    endErr = e;
+  }
+  expect(endErr).toBeDefined();
+  // Previously this would attempt to write to an invalid fd and crash with a
+  // debug assertion; now it should behave as if the sink is closed.
+  expect(() => writer.write("y")).not.toThrow();
+  expect(() => writer.start({})).not.toThrow();
+  expect(() => writer.write("z")).not.toThrow();
+  expect(() => writer.flush()).not.toThrow();
+  await Promise.resolve(writer.end()).catch(() => {});
+  await 1;
+});


### PR DESCRIPTION
When `FileSink::end()`/`end_from_js()` hit a write error while flushing buffered data, they closed the writer's handle via `writer.close()` but left both `FileSink.done` and `writer.is_done` unset. A subsequent `write()`/`flush()` (including the deferred auto-flusher microtask, or after `start({})` reset `done`) would then attempt to write to `Fd::INVALID`, tripping a debug assertion (`fd != Fd::INVALID` in `sys::Error::with_fd`, or the rustix fd validity assert depending on the write path taken).

### Fix

- In the `WriteResult::Err` arm of `FileSink::end` and `FileSink::end_from_js`, set `self.done = true` and call `writer.end()` (which sets `is_done` before closing) instead of `writer.close()`. This matches the other arms which all leave the writer in a terminal state.
- Defensively, `PosixPipeWriter::try_write_with_write_fn` now returns `Done(0)` when the handle has no fd instead of issuing a syscall on fd `-1`.

### Repro

```js
const w = Bun.file(path).writer();
w.start({ fd: readOnlyFd }); // dup a read-only fd into the writer
w.write("x");
try { await w.end(); } catch {} // flush -> write() fails -> handle closed
w.write("y");                  // previously: writes to Fd::INVALID
w.flush();                      // debug assertion
```

Found by Fuzzilli.