### PR TITLE
[tracking] Zig/C++ fork: Rust→Zig port progress

### DIFF
--- a/src/install/PackageManager/PackageJSONEditor.zig
+++ b/src/install/PackageManager/PackageJSONEditor.zig
@@ -459,7 +459,9 @@ pub fn edit(
                                 }
                                 break;
                             } else {
-                                if (request.version.tag == .github or request.version.tag == .git) {
+                                if (request.e_string == null and !request.is_aliased and
+                                    (request.version.tag == .github or request.version.tag == .git or request.version.tag == .tarball or request.version.tag == .folder or request.version.tag == .symlink))
+                                {
                                     for (query.expr.data.e_object.properties.slice()) |item| {
                                         if (item.value) |v| {
                                             const url = request.version.literal.slice(request.version_buf);

--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -436,7 +436,9 @@ EventEmitterPrototype.eventNames = function eventNames() {
 
 EventEmitterPrototype[kCapture] = false;
 
-function once(emitter, type, options = kEmptyObject) {
+// `async` so validation/already-aborted `throw`s surface as rejected
+// promise instead of synchronous throw — matches Node's `events.once`.
+async function once(emitter, type, options = kEmptyObject) {
   validateObject(options, "options");
   var signal = options?.signal;
   validateAbortSignal(signal, "options.signal");

--- a/src/js_parser/ast/parseProperty.zig
+++ b/src/js_parser/ast/parseProperty.zig
@@ -318,7 +318,7 @@ pub fn ParseProperty(
                                         },
                                     }
                                 }
-                            } else if (p.lexer.token == .t_open_brace and strings.eqlComptime(name, "static")) {
+                            } else if (opts.is_class and p.lexer.token == .t_open_brace and strings.eqlComptime(name, "static")) {
                                 const loc = p.lexer.loc();
                                 try p.lexer.next();
 

--- a/src/js_parser/lexer.zig
+++ b/src/js_parser/lexer.zig
@@ -1778,6 +1778,7 @@ fn NewLexer_(
 
                         lexer.end = lexer.current;
                         lexer.token = T.t_syntax_error;
+                        lexer.step();
                     },
                 }
 
@@ -2318,6 +2319,7 @@ fn NewLexer_(
 
                         lexer.end = lexer.current;
                         lexer.token = .t_syntax_error;
+                        lexer.step();
                     },
                 }
 

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -302,4 +302,24 @@ describe("bundler", () => {
       },
     ],
   });
+  // A non-ASCII basename char must collapse to a single "_" in the generated
+  // CommonJS wrapper symbol, not one "_" per UTF-8 byte. Regressed in the
+  // Rust port; Zig's identifier formatter already decodes multi-byte codepoints.
+  itBundled("naming/NonAsciiSourceFilenameSymbol", {
+    files: {
+      "/entry.js": /* js */ `
+        const u = require("./café-utils.js");
+        console.log(u.hi);
+      `,
+      "/café-utils.js": /* js */ `
+        module.exports = { hi: 1 };
+      `,
+    },
+    target: "bun",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("require_caf_utils");
+      api.expectFile("/out.js").not.toContain("require_caf__utils");
+    },
+    run: { stdout: "1" },
+  });
 });

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2323,6 +2323,142 @@ it("should add local tarball dependency", async () => {
     await access(join(package_dir, "bun.lockb")));
 });
 
+it("should not add duplicate package.json entries when installing the same local folder twice (#30933)", async () => {
+  setHandler(dummyRegistry([]));
+  await writeFile(
+    join(add_dir, "package.json"),
+    JSON.stringify({
+      name: "myproject",
+      version: "1.0.0",
+      bin: { myproject: "./index.js" },
+    }),
+  );
+  await writeFile(join(add_dir, "index.js"), 'console.log("hi")');
+
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "host",
+      version: "0.0.1",
+    }),
+  );
+
+  const local_path = resolve(add_dir);
+  const stored_path = local_path.replace(/\\/g, "/");
+
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "add", local_path],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    const out = await stdout.text();
+    expect(out).toContain("installed myproject@");
+    expect(await exited).toBe(0);
+  }
+
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "add", local_path],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    const out = await stdout.text();
+    expect(out).toContain("installed myproject@");
+    expect(await exited).toBe(0);
+  }
+
+  const raw = await file(join(package_dir, "package.json")).text();
+  expect(raw.match(/"myproject"\s*:/g) ?? []).toHaveLength(1);
+  expect(JSON.parse(raw)).toStrictEqual({
+    name: "host",
+    version: "0.0.1",
+    dependencies: {
+      myproject: stored_path,
+    },
+  });
+});
+
+it("should not add duplicate package.json entries when installing the same tarball URL twice (#30499)", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response(Bun.file(join(__dirname, "baz-0.0.3.tgz")));
+    },
+  });
+  const tarball_url = `${server.url.href.replace(/\/+$/, "")}/baz-0.0.3.tgz`;
+  setHandler(dummyRegistry([]));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+    }),
+  );
+
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "add", tarball_url],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).toContain("Saved lockfile");
+    const out = await stdout.text();
+    expect(out).toContain("installed baz@");
+    expect(await exited).toBe(0);
+  }
+  expect(await file(join(package_dir, "package.json")).json()).toStrictEqual({
+    name: "foo",
+    version: "0.0.1",
+    dependencies: {
+      baz: tarball_url,
+    },
+  });
+
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "add", tarball_url],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    const out = await stdout.text();
+    expect(out).toContain("installed baz@");
+    expect(await exited).toBe(0);
+  }
+
+  const raw = await file(join(package_dir, "package.json")).text();
+  expect(raw.match(/"baz"\s*:/g) ?? []).toHaveLength(1);
+  expect(JSON.parse(raw)).toStrictEqual({
+    name: "foo",
+    version: "0.0.1",
+    dependencies: {
+      baz: tarball_url,
+    },
+  });
+});
+
 it("should add multiple dependencies specified on command line", async () => {
   expect(check_npm_auth_type.check).toBe(true);
   using server = Bun.serve({

--- a/test/cli/install/bun-lockb.test.ts
+++ b/test/cli/install/bun-lockb.test.ts
@@ -1,7 +1,7 @@
 import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, expect, it } from "bun:test";
-import { copyFile, exists, open, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, isWindows, runBunInstall, VerdaccioRegistry } from "harness";
+import { copyFile, exists, open, rm, writeFile } from "fs/promises";
+import { bunExe, bunEnv as env, isWindows, runBunInstall, stderrForInstall, VerdaccioRegistry } from "harness";
 import { join } from "path";
 
 const registry = new VerdaccioRegistry();
@@ -113,4 +113,65 @@ it("should continue using a binary lockfile if it exists", async () => {
   expect(await exists(join(packageDir, "bun.lock"))).toBe(false);
   const thirdLockfile = await file(join(packageDir, "bun.lockb")).text();
   expect(thirdLockfile).not.toBe(secondLockfile);
+});
+
+it("recovers from a corrupted binary lockfile instead of panicking", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: false } });
+
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "corrupt-lockb",
+      version: "1.0.0",
+      dependencies: {
+        "no-deps": "1.0.0",
+        "a-dep": "1.0.1",
+      },
+    }),
+  );
+
+  // Generate a valid bun.lockb against the local registry.
+  await runBunInstall(env, packageDir);
+  const lockbPath = join(packageDir, "bun.lockb");
+  expect(await exists(lockbPath)).toBe(true);
+
+  // Corrupt `meta[1].id` to an out-of-range value. Packages are stored
+  // SoA; the `meta` column sits after name (8), name_hash (8), resolution
+  // (72 for format v3, 64 for v2), dependencies (8) and resolutions (8)
+  // per package, and `id` is at +8 within each 88-byte Meta.
+  const lockb = Buffer.from(await file(lockbPath).arrayBuffer());
+  const fmt = lockb.readUInt32LE(42);
+  const N = Number(lockb.readBigUInt64LE(86));
+  const begin = Number(lockb.readBigUInt64LE(110));
+  const resolutionSize = fmt === 2 ? 64 : 72;
+  const metaStart = begin + N * (8 + 8 + resolutionSize + 8 + 8);
+  expect(N).toBeGreaterThan(1);
+  // Sanity: in a well-formed lockfile meta[i].id == i.
+  expect(lockb.readUInt32LE(metaStart + 0 * 88 + 8)).toBe(0);
+  expect(lockb.readUInt32LE(metaStart + 1 * 88 + 8)).toBe(1);
+  lockb.writeUInt32LE(0x7fffffff, metaStart + 1 * 88 + 8);
+  await write(lockbPath, lockb);
+
+  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install", "--no-progress"],
+    cwd: packageDir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [out, rawErr, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+  const err = stderrForInstall(rawErr);
+
+  // The garbage `meta.id` deserialized from the corrupt lockfile used to
+  // panic_bounds_check in Package::clone. Released Bun tolerates it: it
+  // re-resolves and completes the install. The fix matches that.
+  expect(err).toContain("Ignoring lockfile");
+  expect(err).not.toContain("error:");
+  expect(out).toContain("no-deps@1.0.0");
+  expect(out).toContain("a-dep@1.0.1");
+  expect(code).toBe(0);
+  expect(await exists(join(packageDir, "node_modules", "no-deps"))).toBe(true);
+  expect(await exists(join(packageDir, "node_modules", "a-dep"))).toBe(true);
 });

--- a/test/js/bun/resolve/resolve-autoinstall-log-dangling.test.ts
+++ b/test/js/bun/resolve/resolve-autoinstall-log-dangling.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// When the runtime resolver's auto-install path lazily creates the
+// PackageManager, it snapshots `resolver.log` into `pm.log`. If the
+// PackageManager is created while the resolver log is pointed at a
+// stack-local `Log` inside `resolveMaybeNeedsTrailingSlash`, `pm.log` must be
+// restored to the VM log before returning, otherwise the next resolve at a
+// different stack depth dereferences dead stack memory when the HTTP task
+// fails and calls `manager.log.add_error_fmt(...)`.
+//
+// The Zig original already swaps and restores `linker.log` and
+// `package_manager.log`; this test guards against regression.
+test("repeated failing auto-install resolves at varying stack depth don't read a dangling pm.log", async () => {
+  using dir = tempDir("resolve-autoinstall-log", {});
+
+  const src = `
+    const realm = new ShadowRealm();
+    const variants = [
+      () => realm.importValue("pkg-not-found-a", "x"),
+      () => (() => realm.importValue("pkg-not-found-b", "x"))(),
+      () => (() => (() => realm.importValue("pkg-not-found-c", "x"))())(),
+      () => { try { return realm.importValue("pkg-not-found-d", "x"); } finally {} },
+      () => [realm.importValue("pkg-not-found-e", "x")][0],
+      () => import("pkg-not-found-f"),
+      () => (async () => realm.importValue("pkg-not-found-g", "x"))(),
+    ];
+    for (let i = 0; i < 100; i++) {
+      for (const v of variants) {
+        try {
+          const p = v();
+          if (p && p.catch) p.catch(() => {});
+        } catch {}
+      }
+    }
+    Bun.gc(true);
+    console.log("ok");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--install=fallback", "-e", src],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      BUN_CONFIG_REGISTRY: "http://127.0.0.1:1",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -1,5 +1,6 @@
 import { $ } from "bun";
 import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
 
 describe("$.braces", () => {
   test("no-op", () => {
@@ -75,5 +76,31 @@ describe("$.braces", () => {
   test("unicode", () => {
     const result = $.braces(`lol {😂,🫵,🤣}`);
     expect(result).toEqual(["lol 😂", "lol 🫵", "lol 🤣"]);
+  });
+});
+
+describe("brace + glob composition", () => {
+  test("src/*.{ts,tsx} globs after brace expansion", async () => {
+    using dir = tempDir("shell-brace-glob", {
+      "src/app.ts": "",
+      "src/util.tsx": "",
+    });
+    const out = (await $`echo src/*.{ts,tsx}`.cwd(String(dir)).text()).trim().replaceAll("\\", "/");
+    const words = out.split(" ");
+    expect(words).toContain("src/app.ts");
+    expect(words).toContain("src/util.tsx");
+    expect(words).toContain("src/*.ts");
+    expect(words).toContain("src/*.tsx");
+  });
+
+  test("{src,lib}/*.ts composes a brace prefix with a glob", async () => {
+    using dir = tempDir("shell-brace-glob2", {
+      "src/a.ts": "",
+      "lib/b.ts": "",
+    });
+    const out = (await $`echo {src,lib}/*.ts`.cwd(String(dir)).text()).trim().replaceAll("\\", "/");
+    const words = out.split(" ");
+    expect(words).toContain("src/a.ts");
+    expect(words).toContain("lib/b.ts");
   });
 });

--- a/test/js/bun/spawn/spawn-kill-signal.test.ts
+++ b/test/js/bun/spawn/spawn-kill-signal.test.ts
@@ -50,4 +50,35 @@ describe("subprocess.kill", () => {
       });
     }
   });
+
+  test("invalid signal name lists the valid signal names", async () => {
+    const proc = Bun.spawn({
+      cmd: [shellExe(), "-c", "sleep 1000"],
+      stdio: ["inherit", "inherit", "inherit"],
+    });
+
+    let err: any;
+    try {
+      proc.kill("SIGGOD");
+    } catch (e) {
+      err = e;
+    }
+
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
+    // The message must enumerate the real signal names, not a static
+    // "the SignalCode names" placeholder (regressed in the Rust port;
+    // Zig already builds the list at comptime).
+    expect(err.message).toContain("'SIGHUP'");
+    expect(err.message).toContain("'SIGTERM'");
+    expect(err.message).toContain("'SIGKILL'");
+    expect(err.message).toContain("or 'SIGSYS'");
+    expect(err.message).not.toContain("the SignalCode names");
+
+    const { promise, resolve, reject } = Promise.withResolvers();
+    proc.exited.then(resolve, reject);
+    proc.kill();
+    await promise;
+    expect(proc.signalCode).toBe("SIGTERM");
+  });
 });

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -268,3 +268,13 @@ it.skipIf(!isPosix)("does not leak native FileSink when a pending write fails (E
   // more than that indicates a native leak.
   expect(fileSinkInternals.liveCount()).toBeLessThanOrEqual(baseline + 1);
 });
+
+it("start() without path/fd on an already-open writer does not crash", async () => {
+  const path = join(tmpdirSync(), "filesink-restart.txt");
+  const writer = Bun.file(path).writer();
+  expect(() => writer.start({})).not.toThrow();
+  expect(() => writer.start({ highWaterMark: 1024 })).not.toThrow();
+  writer.write("hello");
+  await writer.end();
+  expect(await Bun.file(path).text()).toBe("hello");
+});

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -65,6 +65,36 @@ describe("node:events", () => {
     await promise;
     expect(emitter.listenerCount("hey")).toBe(0);
   });
+
+  // `events.once()` is an `async function` in Node: a bad `options`, a bad
+  // `options.signal`, or an already-aborted signal must produce a *rejected
+  // promise*, never a synchronous throw.
+  test("once is an async function", () => {
+    expect(EventEmitter.once.constructor.name).toBe("AsyncFunction");
+  });
+
+  test("once with already-aborted signal rejects (not a synchronous throw)", async () => {
+    const ee = new EventEmitter();
+    const p = EventEmitter.once(ee, "foo", { signal: AbortSignal.abort() });
+    expect(p).toBeInstanceOf(Promise);
+    await expect(p).rejects.toMatchObject({ name: "AbortError", code: "ABORT_ERR" });
+  });
+
+  test("once with invalid options.signal rejects (not a synchronous throw)", async () => {
+    for (const signal of [1, {}, "hi", null, false]) {
+      const ee = new EventEmitter();
+      const p = EventEmitter.once(ee, "foo", { signal } as any);
+      expect(p).toBeInstanceOf(Promise);
+      await expect(p).rejects.toMatchObject({ code: "ERR_INVALID_ARG_TYPE" });
+    }
+  });
+
+  test("once with non-object options rejects (not a synchronous throw)", async () => {
+    const ee = new EventEmitter();
+    const p = EventEmitter.once(ee, "foo", "hi" as any);
+    expect(p).toBeInstanceOf(Promise);
+    await expect(p).rejects.toMatchObject({ code: "ERR_INVALID_ARG_TYPE" });
+  });
 });
 
 describe("EventEmitter", () => {

--- a/test/js/node/fs/fs-readfile-fifo-fixture.js
+++ b/test/js/node/fs/fs-readfile-fifo-fixture.js
@@ -1,0 +1,31 @@
+// Spawned by fs.test.ts. Reads a FIFO whose content (>256 KB) far exceeds the
+// 0-byte size `fstat` reports for a pipe. The "stat size is wrong" grow path in
+// readFileSync reset buf.items.len = total before each reserve so growth is
+// incremental. Prints a parseable line so the parent can assert.
+const fs = require("fs");
+const cp = require("child_process");
+const path = require("path");
+
+const dir = process.argv[2];
+const fifo = path.join(dir, "thefifo");
+try {
+  fs.unlinkSync(fifo);
+} catch {}
+cp.execFileSync("mkfifo", [fifo]);
+if (!fs.statSync(fifo).isFIFO()) throw new Error(`not a FIFO: ${fifo}`);
+
+const SIZE = 400 * 1024;
+cp.spawn(
+  process.execPath,
+  [
+    "-e",
+    `const fs=require("fs");const fd=fs.openSync(process.argv[1],"w");` +
+      `const b=Buffer.alloc(${SIZE},0x61);let o=0;` +
+      `while(o<b.length){o+=fs.writeSync(fd,b,o,Math.min(16384,b.length-o))}fs.closeSync(fd);`,
+    fifo,
+  ],
+  { stdio: "inherit" },
+);
+
+const data = fs.readFileSync(fifo);
+process.stdout.write(`len=${data.length} allA=${data.every(x => x === 0x61)}`);

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3968,3 +3968,26 @@ describe("synchronous I/O string flags", () => {
     expect(buf.toString("utf8", 0, bytesRead)).toBe("hello");
   });
 });
+
+// POSIX-only: readFileSync on a FIFO whose fstat size is 0 but actual
+// content >256 KB. Zig resets buf.items.len = total before each reserve,
+// so growth is incremental; the test guard is that it returns promptly
+// instead of ballooning RSS.
+if (isPosix) {
+  describe("readFileSync on a FIFO larger than the stat size", () => {
+    it("does not balloon the read buffer", async () => {
+      using dir = tempDir("fs-readfile-fifo", {});
+      const fixture = join(import.meta.path, "../fs-readfile-fifo-fixture.js");
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), fixture, String(dir)],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("len=409600 allA=true");
+      expect(exitCode).toBe(0);
+    });
+  });
+}

--- a/test/regression/issue/30963.test.ts
+++ b/test/regression/issue/30963.test.ts
@@ -1,0 +1,37 @@
+// https://github.com/oven-sh/bun/issues/30963
+//
+// Parsing `[{static{}` (a `static { ... }` block inside an object literal
+// instead of a class body) tripped a debug_assert in the object-literal
+// parser: the class-static-block branch in `parseProperty.zig` fired on
+// identifier + `{` alone, without checking that the enclosing context was
+// actually a class, and returned a property with neither key nor
+// value, violating the assertion in the caller.
+//
+// Run the parse in a subprocess so a reintroduction (debug-build abort)
+// doesn't tear down the in-process test runner.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test.concurrent.each(["[{static{}", "({static{}})", "({static{};})", "({static{},})"])(
+  "`static { ... }` in an object-literal position (%s) is a syntax error, not a parser crash",
+  async source => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 10_000,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Before the fix, the debug build aborted inside the
+    // parser. After the fix the parser emits the
+    // normal user-facing syntax error.
+    expect(stderr).toContain('Expected "}" but found "{"');
+    expect(proc.signalCode).toBeNull();
+    expect(stdout).toBe("");
+    expect(exitCode).not.toBe(0);
+  },
+);

--- a/test/regression/issue/jsx-template-string-crash.test.ts
+++ b/test/regression/issue/jsx-template-string-crash.test.ts
@@ -17,14 +17,49 @@ test("JSX lexer should not crash with slice bounds issues", async () => {
   expect(exitCode).toBe(1);
   expect(normalizeBunSnapshot(stderr.toString().replace(/(Bun v.*)$/gm, ""))).toMatchInlineSnapshot(`
     "1 | export function x(){return<div a=\`\`/>}
-                                         ^
-    error: Expected "{" but found "\`"
+                                          ^
+    error: Expecting Unicode escape sequence \\uXXXX
         at <cwd>/[eval]:1:34
 
     1 | export function x(){return<div a=\`\`/>}
                                             ^
-    error: Unexpected >
-        at <cwd>/[eval]:1:37"
+    error: Expected "{" but found "\`"
+        at <cwd>/[eval]:1:34
+
+    1 | export function x(){return<div a=\`\`/>}
+                                          ^
+    error: Unterminated string literal
+        at <cwd>/[eval]:1:35"
   `);
   expect(normalizeBunSnapshot(stdout.toString())).toMatchInlineSnapshot(`""`);
+});
+
+test.concurrent("#30959 JSX attribute with invalid '(' value parses cleanly in debug builds", async () => {
+  // Previously, parsing `<r L=((` in a debug build panicked with
+  // `Scope location must be greater than previous 6 must be greater than 6`
+  // in push_scope_for_parse_pass. `nextInsideJSXElement`'s syntax-error
+  // branch set `end = current` on the first `(` without stepping past it,
+  // causing re-dispatch on the same byte and duplicate scope offsets.
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", "export function x(){return<r L=((}"],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(normalizeBunSnapshot(stderr.replace(/(Bun v.*)$/gm, ""))).toMatchInlineSnapshot(`
+    "1 | export function x(){return<r L=((}
+                                       ^
+    error: Expected "{" but found "("
+        at <cwd>/[eval]:1:32
+
+    1 | export function x(){return<r L=((}
+                                         ^
+    error: Unexpected }
+        at <cwd>/[eval]:1:34"
+  `);
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(1);
 });


### PR DESCRIPTION
Tracking PR for the Zig/C++ fork of Bun. Starting from `b8ecc78b0` (last pure Zig, May 13 2026), porting meaningful fixes from the 104 post-rewrite Rust commits.

## Ported (11/104)

### Code fixes (3)
- dc1b3a51f lexer: step past bad byte in JSX element (#30969)
- 2f5048ada parser: gate class-static-block on is_class (#30967)
- 0a850b13b events: once() async function (#30984)

### Regression tests (8)
- 1293c9d82 install: duplicate package.json entries (#30935)
- 57810893c install: corrupt lockfile recovery (#31008)
- 0b128a3a9 resolver: dangling pm.log (#31020)
- 13b178c69 node:fs: FIFO buffer growth (#31005)
- d3a3ad593 tests: bundler naming, shell brace+glob, kill signal, filesink

### Skipped (~93)
- ~70 Rust-only (derive Copy, clippy, cfg, cargo fmt, Box/Arc/Cow)
- ~20 regressions introduced by Rust port (Zig already correct)
- ~3 new features not in Zig scope