### PR TITLE
Disable libpas JIT heap on Windows ARM64

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "3167a44fb92c268c83f09b232b38a9f3e7f9655a";
+export const WEBKIT_VERSION = "autobuild-preview-pr-234-c8f7dc7f";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.


### PR DESCRIPTION
### What does this PR do?

Disables the libpas JIT heap on Windows ARM64 by pointing `WEBKIT_VERSION` at the preview build of oven-sh/WebKit#234.

Since #30705 upgraded WebKit (which pulled in upstream `af63dbd0b5d` "[libpas] Enable JIT-heap on Windows"), Windows ARM64 CI has been intermittently crashing with `illegal instruction` on DFG worker threads — observed across `test/js/node/test/parallel/*.js` and other random tests in 19+ CI builds since build 55719.

The crash is a `PAS_ASSERT` firing inside `jit_heap_try_allocate -> pas_segregated_heap_ensure_allocator_index`. On Windows ARM64, libpas's `__builtin_trap()` compiles to `brk #1`, which the OS reports as `STATUS_ILLEGAL_INSTRUCTION` rather than a breakpoint, so the assertion failure surfaces as a flaky illegal-instruction panic.

Windows x64 has not exhibited the same failure across the same range of CI builds (55400–56380, zero illegal-instruction panics), so the WebKit-side change keeps the libpas JIT heap enabled on x64 and falls back to the legacy `MetaAllocator` path on Windows ARM64 only, until the assertion can be root-caused.

### Notes

- This points at the preview build `autobuild-preview-pr-234-c8f7dc7f`. Once oven-sh/WebKit#234 merges, `WEBKIT_VERSION` should be updated to the final merge SHA.
- The rest of the upstream `af63dbd0b5d` change (the `pas_mmap_capability` -> `pas_page_flags` refactor and the executable-protection plumbing in `pas_page_malloc`) remains intact; with `ENABLE_LIBPAS_JIT_HEAP` off on ARM64, `jit_heap_config` is unused there and `pas_page_flag_executable` is never set, so those paths are inert.

### How did you verify your code works?

- oven-sh/WebKit#234 CI is green across all platforms.
- Windows ARM64 + x64 lanes in this PR's CI should be the real signal — the goal is for Windows ARM64 test runs to stop hitting the illegal-instruction panic, while x64 behavior is unchanged.
