### PR TITLE
lexer: point caret at the backslash for out-of-range \u{...}

### DIFF
--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -841,10 +841,13 @@ lexer_impl_header! {
                                     self.syntax_error()?;
                                 }
 
+                                // `iter.i` is the byte offset of `{` inside `text`;
+                                // back up past `\` and `u` only. `width3` is the
+                                // width of `{` itself, which `iter.i` already points
+                                // at — subtracting it lands one character too early.
                                 let hex_start = (iter.i as usize)
                                     .saturating_sub(width as usize)
-                                    .saturating_sub(width2 as usize)
-                                    .saturating_sub(width3 as usize);
+                                    .saturating_sub(width2 as usize);
                                 let mut is_first = true;
                                 let mut is_out_of_range = false;
                                 'variable_length: loop {
@@ -2783,8 +2786,12 @@ lexer_impl_header! {
                 debug_assert!(self.temp_buffer_u16.is_empty());
                 let mut tmp = core::mem::take(&mut self.temp_buffer_u16);
                 tmp.reserve(self.string_literal_raw_content.len());
+                // `string_literal_raw_content` starts one byte after the opening
+                // quote/backtick (see `base` in `parse_string_literal`); pass the
+                // content-start offset so `start + iter.i` inside the decoder
+                // lines up with absolute positions in the source.
                 let res = self.decode_escape_sequences(
-                    self.string_literal_start,
+                    self.string_literal_start + 1,
                     self.string_literal_raw_content,
                     &mut tmp,
                 );

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -768,10 +768,14 @@ lexer_impl_header! {
 
                             iter.c = i32::try_from(value).expect("int cast");
                             if is_bad {
+                                // `octal_start` is text-relative like `iter.i`;
+                                // map back to absolute source position the same
+                                // way every sibling error path does (e.g.
+                                // `start + hex_start` in the `\u{}` branch).
                                 self.add_range_error(
                                     Range {
                                         loc: Loc {
-                                            start: i32::try_from(octal_start).expect("int cast"),
+                                            start: i32::try_from(start + octal_start).expect("int cast"),
                                         },
                                         len: i32::try_from(
                                             iter.i as usize - octal_start,

--- a/test/regression/issue/invalid-escape-sequences.test.ts
+++ b/test/regression/issue/invalid-escape-sequences.test.ts
@@ -269,7 +269,8 @@ describe("out-of-range \\u{...} caret points at the backslash (#31134)", () => {
       cwd: String(dir),
     });
 
-    expect(exitCode).toBe(1);
+    // Check stderr first so a location/caret mismatch surfaces directly
+    // instead of getting hidden behind a bare exitCode assertion.
     const err = stderr.toString();
     expect(err).toContain("Unicode escape sequence is out of range");
     // Reported error location: `:1:<col>` — 1-indexed byte column of the `\`.
@@ -287,5 +288,6 @@ describe("out-of-range \\u{...} caret points at the backslash (#31134)", () => {
     const backslashIdx = sourceLine.indexOf("\\u{110000}");
     expect(backslashIdx).toBeGreaterThanOrEqual(0);
     expect(caretLine[backslashIdx]).toBe("^");
+    expect(exitCode).toBe(1);
   });
 });

--- a/test/regression/issue/invalid-escape-sequences.test.ts
+++ b/test/regression/issue/invalid-escape-sequences.test.ts
@@ -243,23 +243,33 @@ test("Valid unicode escapes in identifiers should work", async () => {
 });
 
 // https://github.com/oven-sh/bun/issues/31134
-// Out-of-range `\u{...}` inside a template/string literal reported a caret
-// location two columns left of the backslash (one column when the escape
-// immediately followed the opening quote, because the computation clamped).
-// `hex_start` over-subtracted by the width of `{`, and the string-path caller
-// passed the opening-quote offset where the decoder expects the content-start
-// offset. Pin the caret to the `\` byte in each quote style.
-describe("out-of-range \\u{...} caret points at the backslash (#31134)", () => {
+// Invalid escape-sequence diagnostics in `decode_escape_sequences` reported
+// caret locations at text-relative offsets instead of absolute source
+// positions, landing the caret several columns left of the backslash (or on
+// an unrelated earlier line/character). Two kinds of bugs fed into this:
+//   1. `hex_start` in the `\u{...}` branch over-subtracted by the width of
+//      `{`, and the string-path caller passed the opening-quote offset
+//      where the decoder expects the content-start offset.
+//   2. The legacy-octal `\0`..`\7` + `8`/`9` branch built `Range.loc.start`
+//      from `octal_start` alone, ignoring the absolute `start` argument that
+//      every sibling error path adds.
+// Pin the caret under the `\` for every affected escape and quote style.
+describe("invalid-escape caret points at the backslash (#31134)", () => {
   const cases = [
-    { name: "backtick with prefix", source: "`aaaaa\\u{110000}`", expectCol: 7 },
-    { name: "backtick without prefix", source: "`\\u{110000}`", expectCol: 2 },
-    { name: "double-quote with prefix", source: 'var a = "aaaaa\\u{110000}";', expectCol: 15 },
-    { name: "double-quote without prefix", source: 'var a = "\\u{110000}";', expectCol: 10 },
-    { name: "single-quote with prefix", source: "var a = 'aaaaa\\u{110000}';", expectCol: 15 },
-    { name: "identifier with prefix", source: "var ab\\u{110000} = 1;", expectCol: 7 },
+    // `\u{...}` out-of-range:
+    { name: "\\u{} backtick with prefix", source: "`aaaaa\\u{110000}`", msg: "Unicode escape sequence is out of range", pattern: "\\u{110000}", expectCol: 7 },
+    { name: "\\u{} backtick without prefix", source: "`\\u{110000}`", msg: "Unicode escape sequence is out of range", pattern: "\\u{110000}", expectCol: 2 },
+    { name: '\\u{} double-quote with prefix', source: 'var a = "aaaaa\\u{110000}";', msg: "Unicode escape sequence is out of range", pattern: "\\u{110000}", expectCol: 15 },
+    { name: '\\u{} double-quote without prefix', source: 'var a = "\\u{110000}";', msg: "Unicode escape sequence is out of range", pattern: "\\u{110000}", expectCol: 10 },
+    { name: "\\u{} single-quote with prefix", source: "var a = 'aaaaa\\u{110000}';", msg: "Unicode escape sequence is out of range", pattern: "\\u{110000}", expectCol: 15 },
+    { name: "\\u{} identifier with prefix", source: "var ab\\u{110000} = 1;", msg: "Unicode escape sequence is out of range", pattern: "\\u{110000}", expectCol: 7 },
+    // Legacy-octal `\08`/`\09`:
+    { name: '\\08 double-quote with prefix', source: 'var a = "aaaaa\\08";', msg: "Invalid legacy octal literal", pattern: "\\08", expectCol: 15 },
+    { name: '\\08 double-quote without prefix', source: 'var a = "\\08";', msg: "Invalid legacy octal literal", pattern: "\\08", expectCol: 10 },
+    { name: "\\09 single-quote with prefix", source: "var a = 'aaaaa\\09';", msg: "Invalid legacy octal literal", pattern: "\\09", expectCol: 15 },
   ];
 
-  test.each(cases)("$name → column $expectCol", ({ source, expectCol }) => {
+  test.each(cases)("$name → column $expectCol", ({ source, msg, pattern, expectCol }) => {
     using dir = tempDir("caret-pos", { "test.js": source });
     const { stderr, exitCode } = Bun.spawnSync({
       cmd: [bunExe(), join(dir, "test.js")],
@@ -272,7 +282,7 @@ describe("out-of-range \\u{...} caret points at the backslash (#31134)", () => {
     // Check stderr first so a location/caret mismatch surfaces directly
     // instead of getting hidden behind a bare exitCode assertion.
     const err = stderr.toString();
-    expect(err).toContain("Unicode escape sequence is out of range");
+    expect(err).toContain(msg);
     // Reported error location: `:1:<col>` — 1-indexed byte column of the `\`.
     expect(err).toContain(`:1:${expectCol}`);
     // The caret line (second printed line) should place `^` directly under
@@ -285,7 +295,7 @@ describe("out-of-range \\u{...} caret points at the backslash (#31134)", () => {
     // `1 | ` (or similar) prefix is identical on both lines, so column
     // alignment carries through. The backslash in `sourceLine` must sit
     // above the `^` in `caretLine`.
-    const backslashIdx = sourceLine.indexOf("\\u{110000}");
+    const backslashIdx = sourceLine.indexOf(pattern);
     expect(backslashIdx).toBeGreaterThanOrEqual(0);
     expect(caretLine[backslashIdx]).toBe("^");
     expect(exitCode).toBe(1);

--- a/test/regression/issue/invalid-escape-sequences.test.ts
+++ b/test/regression/issue/invalid-escape-sequences.test.ts
@@ -257,16 +257,70 @@ test("Valid unicode escapes in identifiers should work", async () => {
 describe("invalid-escape caret points at the backslash (#31134)", () => {
   const cases = [
     // `\u{...}` out-of-range:
-    { name: "\\u{} backtick with prefix", source: "`aaaaa\\u{110000}`", msg: "Unicode escape sequence is out of range", pattern: "\\u{110000}", expectCol: 7 },
-    { name: "\\u{} backtick without prefix", source: "`\\u{110000}`", msg: "Unicode escape sequence is out of range", pattern: "\\u{110000}", expectCol: 2 },
-    { name: '\\u{} double-quote with prefix', source: 'var a = "aaaaa\\u{110000}";', msg: "Unicode escape sequence is out of range", pattern: "\\u{110000}", expectCol: 15 },
-    { name: '\\u{} double-quote without prefix', source: 'var a = "\\u{110000}";', msg: "Unicode escape sequence is out of range", pattern: "\\u{110000}", expectCol: 10 },
-    { name: "\\u{} single-quote with prefix", source: "var a = 'aaaaa\\u{110000}';", msg: "Unicode escape sequence is out of range", pattern: "\\u{110000}", expectCol: 15 },
-    { name: "\\u{} identifier with prefix", source: "var ab\\u{110000} = 1;", msg: "Unicode escape sequence is out of range", pattern: "\\u{110000}", expectCol: 7 },
+    {
+      name: "\\u{} backtick with prefix",
+      source: "`aaaaa\\u{110000}`",
+      msg: "Unicode escape sequence is out of range",
+      pattern: "\\u{110000}",
+      expectCol: 7,
+    },
+    {
+      name: "\\u{} backtick without prefix",
+      source: "`\\u{110000}`",
+      msg: "Unicode escape sequence is out of range",
+      pattern: "\\u{110000}",
+      expectCol: 2,
+    },
+    {
+      name: "\\u{} double-quote with prefix",
+      source: 'var a = "aaaaa\\u{110000}";',
+      msg: "Unicode escape sequence is out of range",
+      pattern: "\\u{110000}",
+      expectCol: 15,
+    },
+    {
+      name: "\\u{} double-quote without prefix",
+      source: 'var a = "\\u{110000}";',
+      msg: "Unicode escape sequence is out of range",
+      pattern: "\\u{110000}",
+      expectCol: 10,
+    },
+    {
+      name: "\\u{} single-quote with prefix",
+      source: "var a = 'aaaaa\\u{110000}';",
+      msg: "Unicode escape sequence is out of range",
+      pattern: "\\u{110000}",
+      expectCol: 15,
+    },
+    {
+      name: "\\u{} identifier with prefix",
+      source: "var ab\\u{110000} = 1;",
+      msg: "Unicode escape sequence is out of range",
+      pattern: "\\u{110000}",
+      expectCol: 7,
+    },
     // Legacy-octal `\08`/`\09`:
-    { name: '\\08 double-quote with prefix', source: 'var a = "aaaaa\\08";', msg: "Invalid legacy octal literal", pattern: "\\08", expectCol: 15 },
-    { name: '\\08 double-quote without prefix', source: 'var a = "\\08";', msg: "Invalid legacy octal literal", pattern: "\\08", expectCol: 10 },
-    { name: "\\09 single-quote with prefix", source: "var a = 'aaaaa\\09';", msg: "Invalid legacy octal literal", pattern: "\\09", expectCol: 15 },
+    {
+      name: "\\08 double-quote with prefix",
+      source: 'var a = "aaaaa\\08";',
+      msg: "Invalid legacy octal literal",
+      pattern: "\\08",
+      expectCol: 15,
+    },
+    {
+      name: "\\08 double-quote without prefix",
+      source: 'var a = "\\08";',
+      msg: "Invalid legacy octal literal",
+      pattern: "\\08",
+      expectCol: 10,
+    },
+    {
+      name: "\\09 single-quote with prefix",
+      source: "var a = 'aaaaa\\09';",
+      msg: "Invalid legacy octal literal",
+      pattern: "\\09",
+      expectCol: 15,
+    },
   ];
 
   test.each(cases)("$name → column $expectCol", ({ source, msg, pattern, expectCol }) => {

--- a/test/regression/issue/invalid-escape-sequences.test.ts
+++ b/test/regression/issue/invalid-escape-sequences.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
@@ -240,4 +240,52 @@ test("Valid unicode escapes in identifiers should work", async () => {
     expect(exitCode).toBe(0);
     expect(stdout.toString()).toBe("2\n");
   }
+});
+
+// https://github.com/oven-sh/bun/issues/31134
+// Out-of-range `\u{...}` inside a template/string literal reported a caret
+// location two columns left of the backslash (one column when the escape
+// immediately followed the opening quote, because the computation clamped).
+// `hex_start` over-subtracted by the width of `{`, and the string-path caller
+// passed the opening-quote offset where the decoder expects the content-start
+// offset. Pin the caret to the `\` byte in each quote style.
+describe("out-of-range \\u{...} caret points at the backslash (#31134)", () => {
+  const cases = [
+    { name: "backtick with prefix", source: "`aaaaa\\u{110000}`", expectCol: 7 },
+    { name: "backtick without prefix", source: "`\\u{110000}`", expectCol: 2 },
+    { name: "double-quote with prefix", source: 'var a = "aaaaa\\u{110000}";', expectCol: 15 },
+    { name: "double-quote without prefix", source: 'var a = "\\u{110000}";', expectCol: 10 },
+    { name: "single-quote with prefix", source: "var a = 'aaaaa\\u{110000}';", expectCol: 15 },
+    { name: "identifier with prefix", source: "var ab\\u{110000} = 1;", expectCol: 7 },
+  ];
+
+  test.each(cases)("$name → column $expectCol", ({ source, expectCol }) => {
+    using dir = tempDir("caret-pos", { "test.js": source });
+    const { stderr, exitCode } = Bun.spawnSync({
+      cmd: [bunExe(), join(dir, "test.js")],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+      cwd: String(dir),
+    });
+
+    expect(exitCode).toBe(1);
+    const err = stderr.toString();
+    expect(err).toContain("Unicode escape sequence is out of range");
+    // Reported error location: `:1:<col>` — 1-indexed byte column of the `\`.
+    expect(err).toContain(`:1:${expectCol}`);
+    // The caret line (second printed line) should place `^` directly under
+    // the backslash in the source line above it.
+    const lines = err.split("\n");
+    const sourceLineIdx = lines.findIndex(l => l.includes(source));
+    expect(sourceLineIdx).toBeGreaterThanOrEqual(0);
+    const sourceLine = lines[sourceLineIdx];
+    const caretLine = lines[sourceLineIdx + 1];
+    // `1 | ` (or similar) prefix is identical on both lines, so column
+    // alignment carries through. The backslash in `sourceLine` must sit
+    // above the `^` in `caretLine`.
+    const backslashIdx = sourceLine.indexOf("\\u{110000}");
+    expect(backslashIdx).toBeGreaterThanOrEqual(0);
+    expect(caretLine[backslashIdx]).toBe("^");
+  });
 });


### PR DESCRIPTION
Fixes #31134.

## Reproduction

```console
$ echo "\`aaaaa\u{110000}\`" > /tmp/repro.js
$ bun /tmp/repro.js
1 | \`aaaaa\u{110000}\`
        ^
error: Unicode escape sequence is out of range
    at /tmp/repro.js:1:5
```

The caret lands on the 4th `a` instead of the `\` at column 7.

## Cause

Two off-by-ones in `decode_escape_sequences` (`src/js_parser/lexer.rs`) combine in the variable-length `\u{...}` branch:

1. `hex_start = iter.i − width − width2 − width3` rolls `iter.i` back past the width of `{` — but the cursor is already AT the `{`, so only the widths of `\` and `u` should be subtracted. `width3` over-rolls by one.
2. The string-literal caller passes `string_literal_start` (the opening-quote offset) as the function's `start`, but `string_literal_raw_content` begins one byte after the quote (see `base` in `parse_string_literal`). The decoder computes absolute positions as `start + iter.i`, so every reported location is one byte left of where it should be.

For `` `aaaaa\u{110000}` `` the two bugs compounded: the caret landed 2 columns left of the `\`. For `` `\u{110000}` `` the first-bug clamp to 0 hid the off-by-one — the caret landed on the backtick (still wrong, just less visibly).

## Fix

- Drop the `.saturating_sub(width3 as usize)` from `hex_start`.
- Pass `string_literal_start + 1` to `decode_escape_sequences` so its `start + iter.i` lands on absolute source positions.

## Verification

```console
$ bun /tmp/repro.js
1 | \`aaaaa\u{110000}\`
          ^
error: Unicode escape sequence is out of range
    at /tmp/repro.js:1:7
```

Regression test in `test/regression/issue/invalid-escape-sequences.test.ts` covers six inputs (backtick / single-quote / double-quote each with and without leading content, plus an identifier-escape sanity check). Each asserts both the reported `:1:col` location AND that the printed `^` sits exactly under the `\` in the source line. All 6 fail under `USE_SYSTEM_BUN=1` (pre-fix) and pass under the debug build.