### PR TITLE
lints: enable four clippy unsafe/cast hygiene checks (warn-only)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,6 +203,22 @@ ptr_cast_constness = "warn"
 ref_as_ptr = "warn"
 borrow_as_ptr = "warn"
 
+# ── Unsafe hygiene (warn-only) ─────────────────────────────────────────────
+# Surface but do not gate. `WarningsAsErrors` is not set workspace-wide, so
+# these stay warnings; promotion to `deny` (workspace or per-crate via
+# `#![deny(...)]`) is a separate decision.
+#
+# `undocumented_unsafe_blocks` and `multiple_unsafe_ops_per_block` are
+# `clippy::restriction` lints — opt-in by design. Enabled here because the
+# recent leak-fix / RAII-handle PR sequence (BunString #31029, File/Dir
+# #30878, mimalloc theap-init, per-thread printer #31069) points in the same
+# direction; this lets the residue be visible per-file without forcing an
+# upfront sweep.
+undocumented_unsafe_blocks = "warn"
+multiple_unsafe_ops_per_block = "warn"
+transmute_ptr_to_ptr = "warn"
+cast_ptr_alignment = "warn"
+
 [workspace.dependencies]
 rust-argon2 = "3.0"
 bcrypt = "0.19"


### PR DESCRIPTION
Adds four `warn`-level lints to `[workspace.lints.clippy]`:

```toml
undocumented_unsafe_blocks    = "warn"
multiple_unsafe_ops_per_block = "warn"
transmute_ptr_to_ptr          = "warn"
cast_ptr_alignment            = "warn"
```

Warn-only — workspace-level `WarningsAsErrors` is not set, so this cannot fail CI. Complements the four `ptr_as_ptr` / `ptr_cast_constness` / `ref_as_ptr` / `borrow_as_ptr` already in the section.

Per-lint rationale:

- **`undocumented_unsafe_blocks`** — `unsafe { … }` blocks without a `// SAFETY:` comment in the lint's lookback. Workspace has roughly 1,335 such sites across ~288 files. Aggregate `unsafe {` vs `// SAFETY:` counts about 1:1 workspace-wide, but the per-file distribution is uneven. Concentrated where unsafe lives: syscall wrappers, JSC callbacks, c-ares DNS, uws handlers, allocator. Top files: `src/sys/lib.rs` (~120), `src/runtime/api/cron.rs` (~85), `src/runtime/dns_jsc/dns.rs` (~65), `src/runtime/jsc_hooks.rs` (~40), `src/runtime/socket/uws_handlers.rs` (~30).

- **`multiple_unsafe_ops_per_block`** — blocks with 2+ unsafe ops grouped without separation. Workspace has roughly 4,800. Review-clarity concern (each op should be individually justified), not the same as the annotation concern. Doesn't force a split — warn is informational.

- **`transmute_ptr_to_ptr`** — adjacent to the existing `ptr_as_ptr` family. Catches the legacy `transmute::<*const X, *const Y>(...)` form where `.cast::<T>()` is clearer and provenance-preserving under strict provenance.

- **`cast_ptr_alignment`** — `as *const T` where `T` has alignment > 1 and the source pointer might be misaligned.

`undocumented_unsafe_blocks` and `multiple_unsafe_ops_per_block` are `clippy::restriction` lints — opt-in by design. Enabled at `warn` because the recent leak-fix / RAII-handle work (#31029 BunString, #30878 File/Dir, #31069 per-thread printer, mimalloc theap-init series) points the same direction, and warn-level lets the residue be visible without forcing an upfront cleanup PR.

At `deny`, `undocumented_unsafe_blocks` would flag the ~1,335 sites above — not realistic in a single PR. Per-crate `#![deny(clippy::undocumented_unsafe_blocks)]` is the natural follow-up when individual crates reach 0 residue.

Test plan:
- [x] `cargo metadata --no-deps --format-version 1 --offline` parses cleanly
- [ ] Reviewer: `cargo clippy --workspace --no-deps` produces warnings on the hotspots above without erroring (workspace warn level, not deny)