### PR TITLE
spawn: don't forward SIGPWR — it's JSC's GC suspend/resume signal on Linux

### DIFF
--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -933,9 +933,12 @@ static struct sigaction previous_actions[NSIG];
     M(SIGIO);
 
 #if OS(LINUX)
+// SIGPWR is intentionally excluded: JSC's GC uses it (see wtf/posix/ThreadingPOSIX.cpp,
+// g_wtfConfig.sigThreadSuspendResume) to suspend/resume threads for conservative stack
+// scanning. Replacing that handler here would break the suspend protocol and, via
+// SA_RESETHAND, revert SIGPWR to SIG_DFL so the next GC suspend terminates the process.
 #define FOR_EACH_LINUX_ONLY_SIGNAL(M) \
     M(SIGPOLL);                       \
-    M(SIGPWR);                        \
     M(SIGSTKFLT);
 
 #endif

--- a/test/js/bun/util/openInEditor.test.ts
+++ b/test/js/bun/util/openInEditor.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDirWithFiles } from "harness";
+import { chmodSync } from "node:fs";
+import { join } from "node:path";
+
+// On Linux, JSC's GC uses SIGPWR to suspend/resume threads for conservative
+// stack scanning. Bun.openInEditor spawns the editor via the sync spawn path,
+// which installs signal-forwarding handlers for the duration of the spawn. If
+// SIGPWR is in that set, a concurrent GC's pthread_kill(SIGPWR) goes to the
+// forwarding handler instead of the suspend/resume handler, which either
+// deadlocks the GC (the semaphore is never posted) or, because the forwarding
+// handler uses SA_RESETHAND, resets SIGPWR to SIG_DFL so the next GC suspend
+// terminates the process with signal 30.
+test.skipIf(!isLinux)("Bun.openInEditor does not hijack the GC suspend/resume signal", async () => {
+  const dir = tempDirWithFiles("open-in-editor-gc", {
+    // The short sleep keeps the signal-forwarding window open long enough to
+    // overlap a GC on the main thread.
+    "code": "#!/bin/sh\nsleep 0.01\nexit 0\n",
+    "repro.js": `
+      for (let i = 0; i < 200; i++) {
+        try { Bun.openInEditor("/tmp/whatever", 1); } catch {}
+        Bun.gc(true);
+      }
+      console.log("survived");
+    `,
+  });
+  chmodSync(join(dir, "code"), 0o755);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(dir, "repro.js")],
+    env: {
+      ...bunEnv,
+      PATH: `${dir}:${bunEnv.PATH ?? process.env.PATH}`,
+      EDITOR: undefined,
+      VISUAL: undefined,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(proc.signalCode).toBeNull();
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("survived");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fuzzilli found a flaky crash (fingerprint `8f15ef1fddf992a0`) where Bun terminates with `TERMSIG: 30` (SIGPWR) on Linux.

## Root cause

`Bun__registerSignalsForForwarding()` installs a forwarding signal handler (with `SA_RESETHAND`) for a set of signals while a synchronous child process runs, so e.g. a `SIGINT` sent to `bun run` reaches the script. On Linux that set was copied from npm and included `SIGPWR`.

Bun's JSC build uses `SIGPWR` as the thread suspend/resume signal for GC conservative stack scanning (see `wtf/posix/ThreadingPOSIX.cpp`, `g_wtfConfig.sigThreadSuspendResume` — Bun switched from the upstream default `SIGUSR1` so npm packages can use `SIGUSR1`).

`Bun.openInEditor` launches the editor by calling `sync::spawn` on a detached thread, which hits `Bun__registerSignalsForForwarding()`. If the GC runs on the JS thread while that forwarding window is open:

1. `Thread::suspend()` sends `SIGPWR` via `pthread_kill` to the JS thread.
2. The forwarding handler runs instead of `signalHandlerSuspendResume`, so the suspend/resume semaphore is never posted → the GC spins or deadlocks.
3. `SA_RESETHAND` resets `SIGPWR` to `SIG_DFL`.
4. The next `SIGPWR` (either the GC retry in the suspend loop or the resume) terminates the process with signal 30.

## Repro

Before this change, with a `code` stub on `PATH`:

```js
for (let i = 0; i < 200; i++) {
  try { Bun.openInEditor("/tmp/whatever", 1); } catch {}
  Bun.gc(true);
}
```

hangs or dies with `Power failure` 15/15 runs under the debug build; 0/15 after.

## Fix

Drop `SIGPWR` from `FOR_EACH_LINUX_ONLY_SIGNAL`. There is no reason to forward a power-failure signal to a child script, and Bun must never replace this handler while JSC is live.

Adds a Linux-only regression test that puts a stub editor on `PATH`, interleaves `Bun.openInEditor` with `Bun.gc(true)`, and asserts the process exits cleanly.