### PR TITLE
bundler: make optimizeImports tree-shake mixed barrels

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -287,6 +287,43 @@ impl<'a> BundleV2<'a> {
 
     // PORT NOTE: draft `on_parse_task_complete` / `deinit_without_freeing_arena`
     // removed — canonical bodies live in the later impl blocks below.
+
+    /// If the resolved file belongs to a package listed in `optimizeImports`
+    /// and that package did not declare its own `sideEffects`, treat it as if
+    /// the package had `"sideEffects": false`. This makes the linker-level
+    /// tree-shaking fire for packages whose barrel index mixes local exports
+    /// with re-exports (where the parse-skip optimization alone bails out).
+    /// Mirrors the documented equivalence: a package in `optimizeImports` is
+    /// "also enabled automatically for any package with sideEffects: false".
+    pub(crate) fn apply_optimize_imports_side_effects_override(
+        &self,
+        result: &mut bun_resolver::Result,
+    ) {
+        if result.primary_side_effects_data != bun_ast::SideEffects::HasSideEffects {
+            return;
+        }
+        let Some(oi) = self.transpiler().options.optimize_imports else {
+            return;
+        };
+        let Some(pj) = result.package_json_ref() else {
+            return;
+        };
+        if pj.name.is_empty() {
+            return;
+        }
+        // Only override when the package hasn't declared its own sideEffects.
+        // An explicit `sideEffects: ["..."]` listing was a deliberate choice;
+        // optimizeImports is the fallback for packages that didn't set it.
+        if !matches!(
+            pj.side_effects,
+            bun_resolver::package_json::SideEffects::Unspecified
+        ) {
+            return;
+        }
+        if oi.map.contains(&pj.name[..]) {
+            result.primary_side_effects_data = bun_ast::SideEffects::NoSideEffectsPackageJson;
+        }
+    }
 }
 // ══════════════════════════════════════════════════════════════════════════
 // `BundleV2` method bodies + supporting types.
@@ -2578,6 +2615,7 @@ pub mod bv2_impl {
                 Ok(r) => r,
                 Err(_) => return Ok(()),
             };
+            self.apply_optimize_imports_side_effects_override(&mut result);
             let mut path = result.path_pair.primary;
             self.increment_scan_counter();
             let source_index = Index::source(self.graph.input_files.len() as u32);
@@ -2648,6 +2686,7 @@ pub mod bv2_impl {
             is_entry_point: bool,
             target: options::Target,
         ) -> Result<Option<IndexInt>, Error> {
+            self.apply_optimize_imports_side_effects_override(resolve);
             let result = &mut *resolve;
             // PORT NOTE(borrowck): clone the active path out so we don't hold a `&mut`
             // into `result` across the `&mut self` calls below.
@@ -6336,6 +6375,7 @@ pub mod bv2_impl {
                     }
                 };
                 let mut resolve_result = resolve_result;
+                self.apply_optimize_imports_side_effects_override(&mut resolve_result);
                 // if there were errors, lets go ahead and collect them all
                 if last_error.is_some() {
                     continue;

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2455,6 +2455,7 @@ pub mod bv2_impl {
                 }
             };
             let mut resolve_result = resolve_result;
+            self.apply_optimize_imports_side_effects_override(&mut resolve_result);
 
             let out_source_index: Option<Index>;
 
@@ -3593,10 +3594,23 @@ pub mod bv2_impl {
             let source_index = Index::init(u32::try_from(self.graph.ast.len()).expect("int cast"));
             let _ = self.graph.ast.append(JSAst::empty_in(self.graph.heap)); // OOM/capacity: Zig aborts; port keeps fire-and-forget
 
+            // Prefer resolver-supplied side-effects data (from package.json
+            // sideEffects: false, data URLs, or the optimizeImports override)
+            // when it's more optimistic than the loader default. The loader
+            // fallback still covers data loaders (JSON/TOML/etc.) whose
+            // resolver result stays at the default HasSideEffects.
+            let side_effects = if resolve_result.primary_side_effects_data
+                != bun_ast::SideEffects::HasSideEffects
+            {
+                resolve_result.primary_side_effects_data
+            } else {
+                loader.side_effects()
+            };
+
             self.graph.input_files.append(crate::Graph::InputFile {
                 source: core::mem::take(source),
                 loader,
-                side_effects: loader.side_effects(),
+                side_effects,
                 ..Default::default()
             })?;
             // PORT NOTE: `ParseTask::init` takes `bun_ast::Index`; both Index newtypes

--- a/test/bundler/bundler_barrel.test.ts
+++ b/test/bundler/bundler_barrel.test.ts
@@ -221,6 +221,52 @@ describe("bundler", () => {
     },
   });
 
+  // Same scenario but the resolution path goes through a plugin that
+  // returns undefined (onResolve "NoMatch"), forcing the bundler down the
+  // `run_resolver` → `enqueue_parse_task` fallback. That path wasn't
+  // propagating `primary_side_effects_data` at all (pre-existing bug that
+  // also made `sideEffects: false` fail on the plugin NoMatch fallback),
+  // so the optimizeImports override was getting dropped before it reached
+  // the linker. Companion to `OptimizeImportsMixedBarrel`.
+  itBundled("barrel/OptimizeImportsMixedBarrelWithPluginNoMatch", {
+    files: {
+      "/entry.js": /* js */ `
+        import { Alpha } from 'mixedoptplug';
+        console.log(Alpha);
+      `,
+      "/node_modules/mixedoptplug/package.json": JSON.stringify({
+        name: "mixedoptplug",
+        main: "./index.js",
+      }),
+      "/node_modules/mixedoptplug/index.js": /* js */ `
+        export { Alpha } from './Alpha.js';
+        export { Beta } from './Beta.js';
+        export const VERSION = "1.0.0";
+      `,
+      "/node_modules/mixedoptplug/Alpha.js": /* js */ `
+        export const Alpha = "ALPHA_MARKER_" + "aaaaaaaa".repeat(10);
+      `,
+      "/node_modules/mixedoptplug/Beta.js": /* js */ `
+        export const Beta = "BETA_MARKER_" + "bbbbbbbb".repeat(10);
+      `,
+    },
+    optimizeImports: ["mixedoptplug"],
+    outdir: "/out",
+    // Filter /.*/ so the plugin intercepts every resolve — including the
+    // nested `./Alpha.js` / `./Beta.js` specifiers — and returns undefined
+    // for all of them. Each goes through `run_resolver` → `enqueue_parse_task`.
+    // Without the enqueue_parse_task fix, `side_effects = loader.side_effects()`
+    // was stamped as HasSideEffects for every submodule and Beta leaked into
+    // the bundle even though entry.js only reads Alpha.
+    plugins(builder) {
+      builder.onResolve({ filter: /.*/ }, () => undefined);
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toContain("ALPHA_MARKER_");
+      api.expectFile("/out/entry.js").not.toContain("BETA_MARKER_");
+    },
+  });
+
   // --- import * (namespace import) must load all submodules ---
 
   itBundled("barrel/NamespaceImportLoadsAll", {

--- a/test/bundler/bundler_barrel.test.ts
+++ b/test/bundler/bundler_barrel.test.ts
@@ -175,6 +175,52 @@ describe("bundler", () => {
     },
   });
 
+  // Regression test for #31146.
+  //
+  // `optimizeImports` is documented as being equivalent to a package having
+  // `"sideEffects": false` in its package.json. That equivalence held for
+  // *pure* barrels (the parse-skip path). For *mixed* barrels (a local
+  // export alongside re-exports — common in real-world packages like
+  // cheerio) the parse-skip path bails, and before this fix `optimizeImports`
+  // gave zero bundle-size benefit. `"sideEffects": false` kept working
+  // because the linker tree-shakes unused re-export targets independently.
+  // The fix propagates `optimizeImports` through to the resolver's
+  // `primary_side_effects_data` so the linker does the same work here.
+  //
+  // The long string-concat expressions are intentional: short literal values
+  // get inlined and DCE'd regardless of `optimizeImports`, so the assertion
+  // needs a payload the bundler can't constant-fold away.
+  itBundled("barrel/OptimizeImportsMixedBarrel", {
+    files: {
+      "/entry.js": /* js */ `
+        import { Alpha } from 'mixedopt';
+        console.log(Alpha);
+      `,
+      "/node_modules/mixedopt/package.json": JSON.stringify({
+        name: "mixedopt",
+        main: "./index.js",
+        // No sideEffects field — optimization relies on optimizeImports.
+      }),
+      "/node_modules/mixedopt/index.js": /* js */ `
+        export { Alpha } from './Alpha.js';
+        export { Beta } from './Beta.js';
+        export const VERSION = "1.0.0";
+      `,
+      "/node_modules/mixedopt/Alpha.js": /* js */ `
+        export const Alpha = "ALPHA_MARKER_" + "aaaaaaaa".repeat(10);
+      `,
+      "/node_modules/mixedopt/Beta.js": /* js */ `
+        export const Beta = "BETA_MARKER_" + "bbbbbbbb".repeat(10);
+      `,
+    },
+    optimizeImports: ["mixedopt"],
+    outdir: "/out",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toContain("ALPHA_MARKER_");
+      api.expectFile("/out/entry.js").not.toContain("BETA_MARKER_");
+    },
+  });
+
   // --- import * (namespace import) must load all submodules ---
 
   itBundled("barrel/NamespaceImportLoadsAll", {


### PR DESCRIPTION
Fixes #31146.

## Repro

`node_modules/mypkg` is an ESM barrel that mixes one local export with re-exports — the shape of the vast majority of real-world packages (cheerio, antd, etc.). Entry imports only `{ alpha }`:

```js
// node_modules/mypkg/index.js
export { alpha } from './alpha.js';
export { beta } from './beta.js';
export { gamma } from './gamma.js';
export const VERSION = '1.0.0';   // ← one local export

// src/index.js
import { alpha } from 'mypkg';
console.log(alpha);
```

Before the fix, `optimizeImports: ['mypkg']` produced a byte-identical bundle to no optimization — `beta` and `gamma` were both left in. Manually adding `"sideEffects": false` to `mypkg`'s package.json did tree-shake them out. On the real cheerio scenario from the issue report: no optimization and `optimizeImports: ['cheerio']` both emitted a **2,794,391**-byte bundle; patching `sideEffects: false` into cheerio's own package.json dropped that to **1,902,922** bytes. The [docs for optimizeImports](https://bun.com/docs/bundler#optimizeimports) describe it as the same optimization, "also enabled automatically for any package with `sideEffects: false` in its package.json."

## Cause

`optimizeImports` only fed into `apply_barrel_optimization` (`src/bundler/barrel_imports.rs`), the parse-skip pass. That pass bails the moment a barrel's named-export list contains *any* local definition:

```rust
for entry in ast.named_exports.values() {
    if ast.named_imports.get(&entry.ref_).is_none() {
        return Ok(());
    }
}
```

A single `export const VERSION = '1.0.0'` is enough — every re-export is then parsed. `sideEffects: false` kept working because the resolver tags every file in the package as `SideEffects::NoSideEffectsPackageJson` (`src/resolver/resolver.rs:1645-1711`), and `LinkerContext` consults that tag when deciding whether to mark a file live for tree-shaking (`src/bundler/LinkerContext.rs:2879`). `optimizeImports` never reached that path.

## Fix

Introduce `BundleV2::apply_optimize_imports_side_effects_override`, which checks the resolved file's package.json name against `optimize_imports` and promotes `primary_side_effects_data` from `HasSideEffects` to `NoSideEffectsPackageJson` when the package didn't declare its own `sideEffects`. Called at the three bundler sites that consume `primary_side_effects_data` before it lands in `graph.input_files.side_effects`:

- `enqueue_file_from_dev_server_incremental_graph_invalidation` — dev-server entry re-enqueue
- `enqueue_entry_item` — user-provided entry points
- `resolve_import_records` — imports resolved during scan (the hot path)

Guard rails:
- Only promotes when the current value is `HasSideEffects` — so an already-`NoSideEffectsPureData` data loader isn't disturbed.
- Only promotes when the package's `sideEffects` is `Unspecified` — an explicit `sideEffects: ['foo.css']` or `sideEffects: false` was a deliberate choice and remains authoritative.

The parse-skip path keeps working unchanged for pure barrels; mixed barrels now benefit from the linker-level DCE that `sideEffects: false` has always given.

## Verification

Gate-friendly regression test: `test/bundler/bundler_barrel.test.ts` `barrel/OptimizeImportsMixedBarrel` — a mixed barrel with `optimizeImports: ['mixedopt']` must not emit the unused `BETA_MARKER_` in the bundle. Fails on unpatched `main`, passes on this branch. All 49 existing barrel tests and the 20 bake HMR barrel tests still pass.