### PR TITLE
Fix unchecked exception in `Bun.plugin` when `target` toString throws

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -304,11 +304,13 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
     if (targetValue) {
         if (auto* targetJSString = targetValue.toStringOrNull(globalObject)) {
             String targetString = targetJSString->value(globalObject);
+            RETURN_IF_EXCEPTION(throwScope, {});
             if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
                 JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
                 return {};
             }
         }
+        RETURN_IF_EXCEPTION(throwScope, {});
     }
 
     JSObject* builderObject = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 4);

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -366,6 +366,21 @@ describe("errors", () => {
     }).toThrow("plugin target must be one of 'node', 'bun' or 'browser'");
   });
 
+  it("propagates exception from 'target' toString", () => {
+    const opts = {
+      setup: () => {},
+      target: {
+        toString() {
+          throw new Error("boom");
+        },
+      },
+    };
+
+    expect(() => {
+      plugin(opts as any);
+    }).toThrow("boom");
+  });
+
   it("invalid loaders throw", () => {
     const invalidLoaders = ["blah", "blah2", "blah3", "blah4"];
     const inputs = ["body { background: red; }", "<h1>hi</h1>", '{"hi": "there"}', "hi"];


### PR DESCRIPTION
## What does this PR do?

Fixes an `assertNoException()` failure in `setupBunPlugin` found by Fuzzilli (fingerprint `e094de1fac1a5ee5`).

When `Bun.plugin({ target, setup })` is called with a `target` value whose string coercion throws (e.g. an object with a throwing `toString`), `toStringOrNull` returns `nullptr` and leaves the exception pending. The code then fell through to `constructEmptyObject`, which asserts that no exception is pending.

```js
Bun.plugin({
  setup: () => {},
  target: { toString() { throw new Error("boom"); } },
});
```

Before: `ASSERTION FAILED: !exception()` in debug builds.
After: the thrown error is propagated to the caller.

## How did you verify your code works?

- Reproduced the assertion with the fuzzer output and a minimized repro on the debug+ASAN build.
- After the fix, both reproduce cleanly as a thrown JS error.
- Added a regression test to `test/js/bun/plugin/plugins.test.ts`.