### PR TITLE
install: make `--cwd` chdir idempotent across re-parses

### DIFF
--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -1559,10 +1559,10 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
         // cwd and hit ENOENT (or walk into a wrong absolute path). After the
         // first successful chdir the process cwd IS the requested target, so
         // the subsequent parse can safely skip.
-        static CWD_APPLIED: std::sync::atomic::AtomicBool =
-            std::sync::atomic::AtomicBool::new(false);
+        static CWD_APPLIED: core::sync::atomic::AtomicBool =
+            core::sync::atomic::AtomicBool::new(false);
         if let Some(cwd_) = args.option(b"--cwd") {
-            if !CWD_APPLIED.load(std::sync::atomic::Ordering::Relaxed) {
+            if !CWD_APPLIED.load(core::sync::atomic::Ordering::Relaxed) {
                 let mut buf = PathBuffer::uninit();
                 let mut buf2 = PathBuffer::uninit();
 
@@ -1593,7 +1593,7 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
                     );
                     Global::crash();
                 }
-                CWD_APPLIED.store(true, std::sync::atomic::Ordering::Relaxed);
+                CWD_APPLIED.store(true, core::sync::atomic::Ordering::Relaxed);
             }
         }
 

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -1546,36 +1546,48 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
             cli.concurrent_scripts = strings::parse_int::<usize>(concurrency, 10).ok();
         }
 
+        // Only apply `--cwd` once per process. Some subcommands (e.g.
+        // `bun update [-i]`) re-enter `parse` after the first call already
+        // moved the process into the target directory; a second `chdir` with
+        // the same relative path would resolve against the already-changed
+        // cwd and hit ENOENT (or walk into a wrong absolute path). After the
+        // first successful chdir the process cwd IS the requested target, so
+        // the subsequent parse can safely skip.
+        static CWD_APPLIED: std::sync::atomic::AtomicBool =
+            std::sync::atomic::AtomicBool::new(false);
         if let Some(cwd_) = args.option(b"--cwd") {
-            let mut buf = PathBuffer::uninit();
-            let mut buf2 = PathBuffer::uninit();
+            if !CWD_APPLIED.load(std::sync::atomic::Ordering::Relaxed) {
+                let mut buf = PathBuffer::uninit();
+                let mut buf2 = PathBuffer::uninit();
 
-            let final_path: &mut bun_core::ZStr = if !cwd_.is_empty() && cwd_[0] == b'.' {
-                let cwd_len = bun_sys::getcwd(&mut buf[..])?;
-                let cwd = &buf[..cwd_len];
-                let parts: [&[u8]; 1] = [cwd_];
-                let len = Path::resolve_path::join_abs_string_buf::<Path::platform::Auto>(
-                    cwd,
-                    &mut buf2[..],
-                    &parts,
-                )
-                .len();
-                buf2[len] = 0;
-                bun_core::ZStr::from_buf_mut(&mut buf2[..], len)
-            } else {
-                buf[..cwd_.len()].copy_from_slice(cwd_);
-                buf[cwd_.len()] = 0;
-                bun_core::ZStr::from_buf_mut(&mut buf[..], cwd_.len())
-            };
-            if let Err(err) = bun_sys::chdir(final_path) {
-                Output::err_generic(
-                    "failed to change directory to \"{}\": {}\n",
-                    (
-                        bstr::BStr::new(final_path.as_bytes()),
-                        bstr::BStr::new(err.name()),
-                    ),
-                );
-                Global::crash();
+                let final_path: &mut bun_core::ZStr = if !cwd_.is_empty() && cwd_[0] == b'.' {
+                    let cwd_len = bun_sys::getcwd(&mut buf[..])?;
+                    let cwd = &buf[..cwd_len];
+                    let parts: [&[u8]; 1] = [cwd_];
+                    let len = Path::resolve_path::join_abs_string_buf::<Path::platform::Auto>(
+                        cwd,
+                        &mut buf2[..],
+                        &parts,
+                    )
+                    .len();
+                    buf2[len] = 0;
+                    bun_core::ZStr::from_buf_mut(&mut buf2[..], len)
+                } else {
+                    buf[..cwd_.len()].copy_from_slice(cwd_);
+                    buf[cwd_.len()] = 0;
+                    bun_core::ZStr::from_buf_mut(&mut buf[..], cwd_.len())
+                };
+                if let Err(err) = bun_sys::chdir(final_path) {
+                    Output::err_generic(
+                        "failed to change directory to \"{}\": {}\n",
+                        (
+                            bstr::BStr::new(final_path.as_bytes()),
+                            bstr::BStr::new(err.name()),
+                        ),
+                    );
+                    Global::crash();
+                }
+                CWD_APPLIED.store(true, std::sync::atomic::Ordering::Relaxed);
             }
         }
 

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -1203,8 +1203,11 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
         // `args` must stay alive for the program duration —
         // `cli` stores slices into it. Park the parsed `Args` in a process-global
         // `OnceLock` so outer slice borrows (`positionals()`, `options()`) are
-        // `'static`; inner `&[u8]` are argv-backed and already `'static`. CLI args
-        // are parsed exactly once per process.
+        // `'static`; inner `&[u8]` are argv-backed and already `'static`. A few
+        // subcommands (e.g. `bun update [-i]`) re-enter `parse` with the same
+        // argv + same `Subcommand`, so the cell may already be populated on
+        // subsequent calls; the first parse's `Args` is canonical and is what
+        // survives for the program duration.
         static PARSED_ARGS: OnceLock<clap::Args<clap::Help>> = OnceLock::new();
         let args: &'static clap::Args<clap::Help> = match clap::parse::<clap::Help>(
             params,
@@ -1215,7 +1218,10 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
             },
         ) {
             Ok(a) => {
-                // `set` only fails on second call; CLI parse runs once.
+                // On re-entry (e.g. `bun update` calls `parse` twice) `set`
+                // returns `Err(a)`; drop the fresh parse and fall through to
+                // the cached first one — argv is identical so the two are
+                // equivalent.
                 let _ = PARSED_ARGS.set(a);
                 PARSED_ARGS.get().unwrap()
             }

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -1203,11 +1203,9 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
         // `args` must stay alive for the program duration —
         // `cli` stores slices into it. Park the parsed `Args` in a process-global
         // `OnceLock` so outer slice borrows (`positionals()`, `options()`) are
-        // `'static`; inner `&[u8]` are argv-backed and already `'static`. A few
-        // subcommands (e.g. `bun update [-i]`) re-enter `parse` with the same
-        // argv + same `Subcommand`, so the cell may already be populated on
-        // subsequent calls; the first parse's `Args` is canonical and is what
-        // survives for the program duration.
+        // `'static`; inner `&[u8]` are argv-backed and already `'static`.
+        // Some subcommands (e.g. `bun update [-i]`) re-enter `parse` with the
+        // same argv; the first parse's `Args` is canonical.
         static PARSED_ARGS: OnceLock<clap::Args<clap::Help>> = OnceLock::new();
         let args: &'static clap::Args<clap::Help> = match clap::parse::<clap::Help>(
             params,
@@ -1218,10 +1216,7 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
             },
         ) {
             Ok(a) => {
-                // On re-entry (e.g. `bun update` calls `parse` twice) `set`
-                // returns `Err(a)`; drop the fresh parse and fall through to
-                // the cached first one — argv is identical so the two are
-                // equivalent.
+                // On re-entry `set` fails; reuse the cached first parse.
                 let _ = PARSED_ARGS.set(a);
                 PARSED_ARGS.get().unwrap()
             }
@@ -1552,13 +1547,9 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
             cli.concurrent_scripts = strings::parse_int::<usize>(concurrency, 10).ok();
         }
 
-        // Only apply `--cwd` once per process. Some subcommands (e.g.
-        // `bun update [-i]`) re-enter `parse` after the first call already
-        // moved the process into the target directory; a second `chdir` with
-        // the same relative path would resolve against the already-changed
-        // cwd and hit ENOENT (or walk into a wrong absolute path). After the
-        // first successful chdir the process cwd IS the requested target, so
-        // the subsequent parse can safely skip.
+        // Apply `--cwd` only on the first parse: `bun update [-i]` re-enters
+        // `parse`, and a second relative `chdir` would resolve from the
+        // already-changed cwd and hit ENOENT (#31152).
         static CWD_APPLIED: core::sync::atomic::AtomicBool =
             core::sync::atomic::AtomicBool::new(false);
         if let Some(cwd_) = args.option(b"--cwd") {

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -1207,6 +1207,7 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
         // Some subcommands (e.g. `bun update [-i]`) re-enter `parse` with the
         // same argv; the first parse's `Args` is canonical.
         static PARSED_ARGS: OnceLock<clap::Args<clap::Help>> = OnceLock::new();
+        let first_parse;
         let args: &'static clap::Args<clap::Help> = match clap::parse::<clap::Help>(
             params,
             clap::ParseOptions {
@@ -1216,8 +1217,9 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
             },
         ) {
             Ok(a) => {
-                // On re-entry `set` fails; reuse the cached first parse.
-                let _ = PARSED_ARGS.set(a);
+                // `set` succeeds only on the first parse; on re-entry reuse
+                // the cached one.
+                first_parse = PARSED_ARGS.set(a).is_ok();
                 PARSED_ARGS.get().unwrap()
             }
             Err(err) => {
@@ -1547,13 +1549,10 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
             cli.concurrent_scripts = strings::parse_int::<usize>(concurrency, 10).ok();
         }
 
-        // Apply `--cwd` only on the first parse: `bun update [-i]` re-enters
-        // `parse`, and a second relative `chdir` would resolve from the
-        // already-changed cwd and hit ENOENT (#31152).
-        static CWD_APPLIED: core::sync::atomic::AtomicBool =
-            core::sync::atomic::AtomicBool::new(false);
         if let Some(cwd_) = args.option(b"--cwd") {
-            if !CWD_APPLIED.load(core::sync::atomic::Ordering::Relaxed) {
+            // A re-entrant parse already chdir'd; a second relative `chdir`
+            // would resolve from the changed cwd and hit ENOENT (#31152).
+            if first_parse {
                 let mut buf = PathBuffer::uninit();
                 let mut buf2 = PathBuffer::uninit();
 
@@ -1584,7 +1583,6 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
                     );
                     Global::crash();
                 }
-                CWD_APPLIED.store(true, core::sync::atomic::Ordering::Relaxed);
             }
         }
 

--- a/test/regression/issue/31152.test.ts
+++ b/test/regression/issue/31152.test.ts
@@ -1,0 +1,87 @@
+// https://github.com/oven-sh/bun/issues/31152
+//
+// `bun --cwd=<relative-dir> update [-i]` double-chdir'd into the target
+// directory because `UpdateCommand` parsed `--cwd` once itself and then
+// re-entered a helper that parsed `--cwd` again — the second relative
+// `chdir` ran from inside the already-resolved dir and hit ENOENT.
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test.concurrent("bun --cwd=<relative> update succeeds in a workspace child", async () => {
+  using dir = tempDir("issue-31152-update", {
+    "package.json": JSON.stringify({
+      name: "root",
+      private: true,
+      workspaces: ["apps/*"],
+    }),
+    "apps/web/package.json": JSON.stringify({
+      name: "web",
+      version: "1.0.0",
+    }),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--cwd=apps/web", "update"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).not.toContain("failed to change directory");
+  expect(stderr).not.toContain("ENOENT");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("bun --cwd=<relative> update -i succeeds in a workspace child", async () => {
+  using dir = tempDir("issue-31152-update-i", {
+    "package.json": JSON.stringify({
+      name: "root",
+      private: true,
+      workspaces: ["apps/*"],
+    }),
+    "apps/web/package.json": JSON.stringify({
+      name: "web",
+      version: "1.0.0",
+    }),
+  });
+
+  // `update -i` needs a lockfile, otherwise it crashes with "missing
+  // lockfile" regardless of the cwd bug. Generate one first with a normal
+  // install — zero deps, no network.
+  await using install = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(await install.exited).toBe(0);
+
+  // No deps to update → the interactive command prints "All packages are up
+  // to date!" and exits without ever entering the prompt. That's enough to
+  // exercise the double-parse path; we don't need a TTY or npm traffic.
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--cwd=apps/web", "update", "-i"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).not.toContain("failed to change directory");
+  expect(stderr).not.toContain("ENOENT");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/31152.test.ts
+++ b/test/regression/issue/31152.test.ts
@@ -4,7 +4,7 @@
 // directory because `UpdateCommand` parsed `--cwd` once itself and then
 // re-entered a helper that parsed `--cwd` again — the second relative
 // `chdir` ran from inside the already-resolved dir and hit ENOENT.
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 test.concurrent("bun --cwd=<relative> update succeeds in a workspace child", async () => {
@@ -28,11 +28,7 @@ test.concurrent("bun --cwd=<relative> update succeeds in a workspace child", asy
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).not.toContain("failed to change directory");
   expect(stderr).not.toContain("ENOENT");
@@ -75,11 +71,7 @@ test.concurrent("bun --cwd=<relative> update -i succeeds in a workspace child", 
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).not.toContain("failed to change directory");
   expect(stderr).not.toContain("ENOENT");

--- a/test/regression/issue/31152.test.ts
+++ b/test/regression/issue/31152.test.ts
@@ -50,7 +50,8 @@ test.concurrent("bun --cwd=<relative> update -i succeeds in a workspace child", 
 
   // `update -i` needs a lockfile, otherwise it crashes with "missing
   // lockfile" regardless of the cwd bug. Generate one first with a normal
-  // install — zero deps, no network.
+  // install — zero deps, no network. Drain stderr so a future install
+  // regression surfaces in the CI log instead of being swallowed.
   await using install = Bun.spawn({
     cmd: [bunExe(), "install"],
     env: bunEnv,
@@ -58,7 +59,13 @@ test.concurrent("bun --cwd=<relative> update -i succeeds in a workspace child", 
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(await install.exited).toBe(0);
+  const [, installStderr, installExit] = await Promise.all([
+    install.stdout.text(),
+    install.stderr.text(),
+    install.exited,
+  ]);
+  expect(installStderr).not.toContain("error:");
+  expect(installExit).toBe(0);
 
   // No deps to update → the interactive command prints "All packages are up
   // to date!" and exits without ever entering the prompt. That's enough to


### PR DESCRIPTION
Fixes #31152.

## Repro

```console
$ mkdir -p /tmp/repro/apps/web
$ echo '{"name":"root","private":true,"workspaces":["apps/*"]}' > /tmp/repro/package.json
$ echo '{"name":"web","version":"1.0.0"}' > /tmp/repro/apps/web/package.json
$ cd /tmp/repro
$ bun --cwd=apps/web update -i
bun update --interactive v1.4.0-canary.1 (184d0371a)
error: failed to change directory to "apps/web": ENOENT
```

Absolute `--cwd=/tmp/repro/apps/web` worked; `bun --cwd=apps/web add <pkg>` also worked.

## Cause

`UpdateCommand::exec` calls `CommandLineArguments::parse` once to branch on `cli.interactive`, then re-enters either `UpdateInteractiveCommand::exec` or `update_package_json_and_install`, both of which call `parse` again. Each `parse` applied `--cwd` via `chdir`. With a relative `--cwd=apps/web`, the first `chdir("apps/web")` succeeds and moves the process into `/tmp/repro/apps/web`; the second `chdir("apps/web")` resolves against the new cwd, looks for `/tmp/repro/apps/web/apps/web`, and hits ENOENT.

`bun add` didn't hit this because `AddCommand::exec` dispatches straight into the helper, so only one `parse` call. Absolute `--cwd` didn't hit it either because absolute `chdir` is idempotent.

## Fix

Run the `chdir` only on the first parse. `parse` already parks the parsed `Args` in a process-global `OnceLock` (`PARSED_ARGS`), and `OnceLock::set` returns `Ok` exactly once per process, so the first-parse signal is derived from `PARSED_ARGS.set(a).is_ok()` rather than a second static. On re-entry the process cwd is already the requested target, so skipping is correct: argv is process-global, so a re-entrant parse always carries the same `--cwd` value.

<details>
<summary>Earlier iteration</summary>

The first version gated the chdir on a separate `CWD_APPLIED: AtomicBool`. Review pointed out that this duplicated the first-parse signal `PARSED_ARGS.set` already produces, so the static was removed in favor of deriving the signal.

</details>

## Verification

`test/regression/issue/31152.test.ts` covers both `bun --cwd=apps/web update` and `bun --cwd=apps/web update -i`.

```
$ bun bd test test/regression/issue/31152.test.ts
 2 pass / 0 fail

$ USE_SYSTEM_BUN=1 bun test test/regression/issue/31152.test.ts
 0 pass / 2 fail   # both hit "failed to change directory to \"apps/web\": ENOENT"
```

Existing `bun-install.test.ts` `--cwd` test and `bun-update.test.ts` / `update_interactive_install.test.ts` pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 8 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/31152.test.ts"
bun test v1.4.0 (a9fec1ea4)

test/regression/issue/31152.test.ts:
28 |     stderr: "pipe",
29 |   });
30 | 
31 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
32 | 
33 |   expect(stderr).not.toContain("failed to change directory");
                          ^
error: expect(received).not.toContain(expected)

Expected to not contain: "failed to change directory"
Received: "error: failed to change directory to \"apps/web\": ENOENT\n"

      at <anonymous> (/workspace/bun/test/regression/issue/31152.test.ts:33:22)
(fail) bun --cwd=<relative> update succeeds in a workspace child [186.03ms]
78 |     stderr: "pipe",
79 |   });
80 | 
81 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
82 | 
83 |   expect(stderr).not.toContain("failed to change directory");
                          ^
error: expect(received).not.toContain(expected)

Expected to not contain: "failed to change direc
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (eabb96de7)

test/regression/issue/31152.test.ts:
28 |     stderr: "pipe",
29 |   });
30 | 
31 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
32 | 
33 |   expect(stderr).not.toContain("failed to change directory");
                          ^
error: expect(received).not.toContain(expected)

Expected to not contain: "failed to change directory"
Received: "error: failed to change directory to \"apps/web\": ENOENT\n"

      at <anonymous> (/workspace/bun/test/regression/issue/31152.test.ts:33:22)
(fail) bun --cwd=<relative> update succeeds in a workspace child [7.60ms]
78 |     stderr: "pipe",
79 |   });
80 | 
81 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
82 | 
83 |   expect(stderr).not.toContain("failed to change directory");
                          ^
error: expect(received).not.toContain(expected)

Expected to not contain: "failed to change directory"
Received: "error: failed to change directory to \"apps/web\": ENOENT\n"

      at <anonymous> (/workspace/bun/test/regression/issue/31152.test.ts:83:22)
(fail
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/31152.test.ts"
bun test v1.4.0 (a9fec1ea4)

test/regression/issue/31152.test.ts:
(pass) bun --cwd=<relative> update succeeds in a workspace child [194.98ms]
(pass) bun --cwd=<relative> update -i succeeds in a workspace child [310.08ms]

 2 pass
 0 fail
 8 expect() calls
Ran 2 tests across 1 file. [2.81s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 718ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/227] fetch lsquic
[lsquic] up to date
[2/158] fetch hdrhistogram
[hdrhistogram] up to date
[3/155] fetch WebKit (prebuilt)
[WebKit] up to date
[4/155] fetch lolhtml
[lolhtml] up to date
[5/155] cc obj/vendor/tinycc/tccasm.c.o
[6/155] cc obj/vendor/tinycc/tccelf.c.o
[7/155] cc obj/vendor/tinycc/x86_64-link.c.o
[8/155] cc obj/vendor/tinycc/tccrun.c.o
[9/155] cc obj/vendor/tinycc/i386-asm.c.o
[10/155] cc obj/vendor/tinycc/libtcc.c.o
[11/155] cc obj/vendor/tinycc/tccdbg.c.o
[12/155] cc obj/vendor/tinycc/tccpp.c.o
[13/155] cc obj/vendor/tinycc/tccgen.c.o
[14/155] cc obj/vendor/tinycc/x86_64-gen.c.o
[15/155] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[16/155] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[17/155] cc obj/packages/bun-usockets/src/socket.c.o
[18/155] cc obj/packages/bun-usockets/src/loop.c.o
[19/155] cc obj/packages/bun-usockets/src/node_quic_shim.c.o
[20/155] cc obj/packages/bun-usockets/src/fault_inject.c.o
[21/155] cc obj/packages/bun-usockets/src/quic.c.o
[22/155] cc o
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/PackageManager/CommandLineArguments.rs | 73 +++++++++---------
 test/regression/issue/31152.test.ts                | 86 ++++++++++++++++++++++
 2 files changed, 126 insertions(+), 33 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 8

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/install/PackageManager/CommandLineArguments.rs     11     12     11
test/regression/issue/31152.test.ts                     2      3     11
```

</details>

**root cause** · written by the author bot

The interactive update command parses command line arguments twice in the same process, and each parse applied the relative `--cwd` path with a chdir, so the second pass resolved the path against the already changed working directory and failed with ENOENT. The fix gates the chdir on the first successful insertion of the parsed arguments into the process-wide OnceLock cache, making the cwd change idempotent across re-parses. A regression test verifies that `bun --cwd=apps/web update` and `bun --cwd=apps/web update -i` run from a workspace root exit cleanly without directory errors.

<!-- robobun:evidence:end -->