### PR TITLE
fix(install): guard against overlong PAX paths in tarball extraction

### DIFF
--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -756,6 +756,15 @@ impl TarballStream {
         let rest: &[OSPathChar] = tokenize_rest_after_first(&pathname[..]);
 
         let mut norm_buf = OSPathBuffer::uninit();
+        // `normalize_buf_t` writes into a fixed-size OSPathBuffer and assumes the
+        // caller provides enough space. Tarballs can contain arbitrarily long PAX
+        // paths, so reject entries that cannot fit including the trailing sentinel.
+        if rest.len() >= norm_buf.len() {
+            self.phase = Phase::WantData;
+            self.out_fd = None;
+            return Ok(());
+        }
+
         let normalized =
             resolve_path::normalize_buf_t::<OSPathChar, platform::Auto>(rest, &mut norm_buf[..]);
         let norm_len = normalized.len();

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -1777,6 +1777,13 @@ impl Archiver {
                     // at its original `.len()`; therefore `remaining[remaining.len()] == 0`.
                     let pathname: &[OSPathChar] = remaining;
 
+                    // `normalize_buf_t` writes into a fixed-size OSPathBuffer and assumes the
+                    // caller provides enough space. Tarballs can contain arbitrarily long PAX
+                    // paths, so reject entries that cannot fit including the trailing sentinel.
+                    if pathname.len() >= normalized_buf.len() {
+                        continue 'loop_;
+                    }
+
                     let normalized = bun_paths::resolve_path::normalize_buf_t::<
                         OSPathChar,
                         bun_paths::platform::Auto,
@@ -1788,6 +1795,16 @@ impl Archiver {
                     // TODO(port): Zig had `[:0]OSPathChar` here; the NUL is at path.len()
                     if path.is_empty() || (path.len() == 1 && path[0] == b'.' as OSPathChar) {
                         continue;
+                    }
+
+                    // `normalize_buf_t` collapses interior `..` but leaves a leading `..` on
+                    // relative input. Reject those so extraction cannot escape `dir`.
+                    if path.len() >= 2
+                        && path[0] == b'.' as OSPathChar
+                        && path[1] == b'.' as OSPathChar
+                        && (path.len() == 2 || path[2] == bun_paths::SEP as OSPathChar)
+                    {
+                        continue 'loop_;
                     }
 
                     // Skip entries whose normalized path is absolute on Windows.

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -18,6 +18,7 @@ import {
   toHaveBins,
 } from "harness";
 import { join, resolve, sep } from "path";
+import { gzipSync } from "zlib";
 import {
   createTestContext,
   destroyTestContext,
@@ -66,7 +67,71 @@ async function withContext(
 // Default context options for most tests
 const defaultOpts = { linker: "hoisted" as const };
 
+function tarHeader(name: string, size: number, type = "0") {
+  const header = Buffer.alloc(512, 0);
+  header.write(name, 0, Math.min(Buffer.byteLength(name), 100), "utf8");
+  header.write("0000644\0", 100, 8, "ascii");
+  header.write("0000000\0", 108, 8, "ascii");
+  header.write("0000000\0", 116, 8, "ascii");
+  header.write(size.toString(8).padStart(11, "0") + "\0", 124, 12, "ascii");
+  header.write("00000000000\0", 136, 12, "ascii");
+  header.fill(" ", 148, 156);
+  header.write(type, 156, 1, "ascii");
+  header.write("ustar\0", 257, 6, "ascii");
+  header.write("00", 263, 2, "ascii");
+
+  let checksum = 0;
+  for (const byte of header) checksum += byte;
+  header.write(checksum.toString(8).padStart(6, "0") + "\0 ", 148, 8, "ascii");
+  return header;
+}
+
+function tarEntry(name: string, body: string | Buffer, type = "0") {
+  const contents = Buffer.isBuffer(body) ? body : Buffer.from(body);
+  const padding = Buffer.alloc((512 - (contents.length % 512)) % 512);
+  return Buffer.concat([tarHeader(name, contents.length, type), contents, padding]);
+}
+
+function paxEntry(path: string) {
+  const body = ` path=${path}\n`;
+  let digits = 1;
+  while (true) {
+    const length = digits + Buffer.byteLength(body);
+    const nextDigits = String(length).length;
+    if (nextDigits === digits) return Buffer.from(`${length}${body}`);
+    digits = nextDigits;
+  }
+}
+
 describe.concurrent("bun-install", () => {
+  it("does not crash extracting npm tarballs with overlong PAX paths", async () => {
+    const package_dir = tempDir("bun-install-long-pax-path", {
+      "package.json": JSON.stringify({ dependencies: { x: "file:./pkg.tgz" } }),
+    });
+
+    const tarball = gzipSync(
+      Buffer.concat([
+        tarEntry("PaxHeader", paxEntry(`package/${Buffer.alloc(5000, "a").toString()}`), "x"),
+        tarEntry("package/short", "x"),
+        tarEntry("package/package.json", JSON.stringify({ name: "x", version: "1.0.0" })),
+        Buffer.alloc(1024),
+      ]),
+    );
+    await writeFile(join(package_dir, "pkg.tgz"), tarball);
+
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--no-progress"],
+      cwd: package_dir,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const err = await new Response(stderr).text();
+    expect(err).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+  });
+
   for (let input of ["abcdef", "65537", "-1"]) {
     it(`bun install --network-concurrency=${input} fails`, async () => {
       await withContext(defaultOpts, async ctx => {


### PR DESCRIPTION
## Summary

Fixes a crash in `bun install` when extracting a malicious npm tarball containing an overlong PAX pathname.

`normalizeBufT` writes into a fixed-size `OSPathBuffer` (4096 bytes on macOS) and assumes callers provide enough space. A tarball can provide an arbitrarily long PAX `path`, causing extraction to write past the buffer and crash with a bus error. In local testing with Bun 1.3.12, the fault address was attacker-controlled-looking (`0x6161616161616161`).

This PR adds bounds checks before `normalizeBufT` in both extraction paths:

- `Archiver.extractToDir` buffered extraction
- `TarballStream` streaming extraction

It also adds leading `..` rejection to the buffered extraction path to match the existing `TarballStream.beginEntry` traversal guard.

## Security impact

Crash-only / denial of service. This does not claim RCE.

Requirements:

- User runs `bun install` on a project depending on a malicious npm package tarball
- The tarball contains a PAX `path` longer than `OSPathBuffer`

## Test

Added a regression test that generates a gzipped tarball with a 5000-byte PAX pathname and verifies `bun install` exits successfully without printing the crash banner.

## Validation

- `git diff --check` passed for touched files
- Zig files were formatted with `zig fmt --stdin`
- Rust files were formatted with the repo's pinned toolchain: `rustup run nightly-2026-05-06 cargo fmt`
- TypeScript test file passes Prettier formatting

I also attempted `bun bd`, but current `main` failed in an unrelated subsystem before reaching these files:

```text
error: No matching export in "hmr-module.ts" for import "emitEvent"
    at src/runtime/bake/hmr-runtime-client.ts:18:3
```
