### PR TITLE
Fix crash when constructing jest.fn() via Reflect.construct

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -86,6 +86,7 @@ inline To tryJSDynamicCast(JSC::WriteBarrier<WriteBarrierT>& from)
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionCall);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionConstruct);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetter_mockGetLastCall);
@@ -462,7 +463,7 @@ public:
     }
 
     JSMockFunction(JSC::VM& vm, JSC::Structure* structure, CallbackKind wrapKind)
-        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
+        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionConstruct)
     {
         initMock();
     }
@@ -826,7 +827,7 @@ static JSValue createMockResult(JSC::VM& vm, Zig::GlobalObject* globalObject, co
     return result;
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+static JSC::EncodedJSValue jsMockFunctionCallOrConstruct(JSGlobalObject* lexicalGlobalObject, CallFrame* callframe, bool isConstruct)
 {
     Zig::GlobalObject* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
@@ -839,6 +840,14 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
 
     JSC::ArgList args = JSC::ArgList(callframe);
     JSValue thisValue = callframe->thisValue();
+    if (isConstruct) {
+        thisValue = JSC::constructEmptyObject(globalObject);
+    }
+    auto encodeReturn = [&](JSValue returnValue) -> JSC::EncodedJSValue {
+        if (isConstruct && !returnValue.isObject()) [[unlikely]]
+            return JSValue::encode(thisValue);
+        return JSValue::encode(returnValue);
+    };
     JSC::JSArray* argumentsArray = nullptr;
     {
         JSC::ObjectInitializationScope object(vm);
@@ -954,16 +963,16 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
                 fn->returnValues.set(vm, fn, returnValuesArray);
             }
 
-            return JSValue::encode(returnValue);
+            return encodeReturn(returnValue);
         }
         case JSMockImplementation::Kind::ReturnValue: {
             JSValue returnValue = impl->underlyingValue.get();
             setReturnValue(createMockResult(vm, globalObject, "return"_s, returnValue));
-            return JSValue::encode(returnValue);
+            return encodeReturn(returnValue);
         }
         case JSMockImplementation::Kind::ReturnThis: {
             setReturnValue(createMockResult(vm, globalObject, "return"_s, thisValue));
-            return JSValue::encode(thisValue);
+            return encodeReturn(thisValue);
         }
         case JSMockImplementation::Kind::RejectedValue: {
             JSValue rejectedPromise = JSC::JSPromise::rejectedPromise(globalObject, impl->underlyingValue.get());
@@ -978,7 +987,17 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     }
 
     setReturnValue(createMockResult(vm, globalObject, "return"_s, jsUndefined()));
-    return JSValue::encode(jsUndefined());
+    return encodeReturn(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    return jsMockFunctionCallOrConstruct(lexicalGlobalObject, callframe, false);
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    return jsMockFunctionCallOrConstruct(lexicalGlobalObject, callframe, true);
 }
 
 void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)

--- a/test/js/bun/test/mock-fn-construct.test.ts
+++ b/test/js/bun/test/mock-fn-construct.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, jest, spyOn, test } from "bun:test";
+
+describe("Reflect.construct on mock functions", () => {
+  test("jest.fn() with no implementation", () => {
+    const fn = jest.fn();
+    const result = Reflect.construct(fn, []);
+    expect(typeof result).toBe("object");
+    expect(result).not.toBe(fn);
+  });
+
+  test("jest.fn() with implementation returning a primitive", () => {
+    const fn = jest.fn(() => 42);
+    const result = Reflect.construct(fn, []);
+    expect(typeof result).toBe("object");
+  });
+
+  test("jest.fn() with implementation returning an object", () => {
+    const obj = { a: 1 };
+    const fn = jest.fn(() => obj);
+    const result = Reflect.construct(fn, []);
+    expect(result).toBe(obj);
+  });
+
+  test("jest.fn().mockReturnValue(primitive)", () => {
+    const fn = jest.fn().mockReturnValue(42);
+    const result = Reflect.construct(fn, []);
+    expect(typeof result).toBe("object");
+  });
+
+  test("jest.fn().mockReturnThis()", () => {
+    const fn = jest.fn().mockReturnThis();
+    const result = Reflect.construct(fn, []);
+    expect(typeof result).toBe("object");
+  });
+
+  test("spyOn an undefined property", () => {
+    const obj: Record<string, unknown> = {};
+    const spy = spyOn(obj, "x" as never);
+    const result = Reflect.construct(spy, []);
+    expect(typeof result).toBe("object");
+  });
+
+  test("with explicit newTarget", () => {
+    const fn = jest.fn();
+    const result = Reflect.construct(fn, [], function () {});
+    expect(typeof result).toBe("object");
+  });
+
+  test("implementation receives constructed this", () => {
+    const fn = jest.fn(function (this: { x: number }) {
+      this.x = 1;
+    });
+    const result = Reflect.construct(fn, []);
+    expect(result).toEqual({ x: 1 });
+  });
+
+  test("new on jest.fn() returns an object", () => {
+    const fn = jest.fn();
+    const result = new (fn as any)();
+    expect(typeof result).toBe("object");
+    expect(result).not.toBe(fn);
+  });
+
+  test("regular call preserves this", () => {
+    const fn = jest.fn(function (this: unknown) {
+      return this;
+    });
+    const obj = { fn };
+    expect(obj.fn()).toBe(obj);
+    expect(fn.call(123 as any)).toBe(123);
+  });
+});


### PR DESCRIPTION
## What

Fixes an assertion failure (`cell->isObjectSlow()` in `JSObject.h`) when a mock function is invoked as a constructor through `Reflect.construct` (or any native-construct path).

```js
const fn = jest.fn();
Reflect.construct(fn, []); // crashed in debug builds
```

## Why

`JSMockFunction` registered the same native function for both `[[Call]]` and `[[Construct]]`. When invoked as a native constructor, JSC's `Interpreter::executeConstruct` unconditionally wraps the result with `asObject()`, which asserts the value is an object. A mock with no implementation (or one returning a primitive / `mockReturnValue(primitive)`) returned `undefined` or a primitive, tripping the assertion.

The `new fn()` bytecode path happened not to assert, but still returned `undefined`, which is also wrong per `[[Construct]]` semantics.

## How

Split the call/construct entry points. In the construct path, allocate a fresh `this` object up front, pass it to the implementation as `this`, and return it when the mock's result is not an object — matching ordinary `[[Construct]]` semantics and Jest's behavior.

Found by Fuzzilli.