### PR TITLE
sys: drop with_fd debug assertion on Fd::INVALID

### DIFF
--- a/src/sys/Error.rs
+++ b/src/sys/Error.rs
@@ -211,7 +211,6 @@ impl Error {
 
     #[inline]
     pub fn with_fd(&self, fd: Fd) -> Error {
-        debug_assert!(fd != Fd::INVALID);
         Error {
             errno: self.errno,
             syscall: self.syscall,
@@ -581,5 +580,17 @@ impl ReturnCodeExt for crate::windows::libuv::ReturnCodeI64 {
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_fd_accepts_invalid() {
+        let err = Error::from_code(E::EBADF, Tag::fcntl).with_fd(Fd::INVALID);
+        assert_eq!(err.fd, Fd::INVALID);
+        assert_eq!(fd_unwrap_valid(err.fd), None);
     }
 }

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -279,11 +279,11 @@ it("start() without path/fd on an already-open writer does not crash", async () 
   expect(await Bun.file(path).text()).toBe("hello");
 });
 
-it("start() with arbitrary objects does not hit the invalid-fd debug assertion", async () => {
-  // Fuzzilli drove FileSink.start() with the Bun global and other objects that have
-  // no path/fd, routing Fd::INVALID into sys::dup → Error::with_fd. The placeholder fd
-  // should be treated as "no fd attached" rather than asserting in debug builds.
-  // Run in a subprocess so a debug assertion (which aborts the process) fails the test.
+it("start() with arbitrary objects does not crash", async () => {
+  // Fuzzilli hit the with_fd(Fd::INVALID) debug assertion via FileSink.start() under
+  // REPRL state that doesn't reproduce standalone; the #30953 guard now short-circuits
+  // these args before setup(). Keep as smoke coverage for start() with arbitrary
+  // objects; the direct with_fd regression guard is the unit test in src/sys/Error.rs.
   const path = join(tmpdirSync(), "filesink-start-args.txt");
   await using proc = Bun.spawn({
     cmd: [

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -300,7 +300,7 @@ it("start() with arbitrary objects does not hit the invalid-fd debug assertion",
       `,
     ],
     env: bunEnv,
-    stdout: "pipe",
+    stdout: "ignore",
     stderr: "pipe",
   });
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -279,6 +279,37 @@ it("start() without path/fd on an already-open writer does not crash", async () 
   expect(await Bun.file(path).text()).toBe("hello");
 });
 
+it("start() with arbitrary objects does not hit the invalid-fd debug assertion", async () => {
+  // Fuzzilli drove FileSink.start() with the Bun global and other objects that have
+  // no path/fd, routing Fd::INVALID into sys::dup → Error::with_fd. The placeholder fd
+  // should be treated as "no fd attached" rather than asserting in debug builds.
+  // Run in a subprocess so a debug assertion (which aborts the process) fails the test.
+  const path = join(tmpdirSync(), "filesink-start-args.txt");
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const writer = Bun.file(${JSON.stringify(path)}).writer();
+        for (const arg of [Bun, globalThis, Set, class extends Buffer {}, { fd: undefined }, { path: undefined }, []]) {
+          try { writer.start(arg); } catch {}
+        }
+        Bun.gc(true);
+        writer.write("ok");
+        await writer.end();
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("panic");
+  expect(stderr).not.toContain("Fd::INVALID");
+  expect(exitCode).toBe(0);
+  expect(await Bun.file(path).text()).toBe("ok");
+});
+
 it.skipIf(!isPosix)("writing after end() fails during flush does not crash", async () => {
   const dir = tmpdirSync();
   const target = join(dir, "ro.txt");

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -304,10 +304,9 @@ it("start() with arbitrary objects does not hit the invalid-fd debug assertion",
     stderr: "pipe",
   });
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-  expect(stderr).not.toContain("panic");
-  expect(stderr).not.toContain("Fd::INVALID");
-  expect(exitCode).toBe(0);
+  expect(stderr).toBe("");
   expect(await Bun.file(path).text()).toBe("ok");
+  expect(exitCode).toBe(0);
 });
 
 it.skipIf(!isPosix)("writing after end() fails during flush does not crash", async () => {


### PR DESCRIPTION
## What

Remove the `debug_assert!(fd != Fd::INVALID)` from `sys::Error::with_fd`.

## Why

Fuzzilli hit this panic again (after #30953 fixed one instance in `FileSink::start`) via a REPRL sequence that doesn't reproduce standalone:

```
panic: assertion failed: fd != Fd::INVALID (src/sys/Error.rs:230:9)
```

`Error.fd` already defaults to `Fd::INVALID`, and `to_system_error()` / `Display` treat that as "no fd attached" via `fd_unwrap_valid()`. So `with_fd(Fd::INVALID)` is a no-op — the assertion just converts a correctly-handled case into a debug-build crash.

User-reachable inputs can route the invalid-fd sentinel into any of the ~40 syscall wrappers that tag their error via `.with_fd(fd)` (`dup`, `fcntl`, `close`, `read`/`write`, …), e.g. through `PathOrFileDescriptor::Fd(Fd::INVALID)` placeholders in `FileSink` / `Blob` option parsing or prototype pollution across REPRL iterations. #30953 guarded one such path; rather than keep playing whack-a-mole, drop the assertion so these surface as the proper `EBADF` JS error.

Release builds are unchanged (the assertion was debug-only).

Found by Fuzzilli.