### PR TITLE
Handle exception from `target` toString in `Bun.plugin`

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -304,11 +304,13 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
     if (targetValue) {
         if (auto* targetJSString = targetValue.toStringOrNull(globalObject)) {
             String targetString = targetJSString->value(globalObject);
+            RETURN_IF_EXCEPTION(throwScope, {});
             if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
                 JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
                 return {};
             }
         }
+        RETURN_IF_EXCEPTION(throwScope, {});
     }
 
     JSObject* builderObject = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 4);

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -366,6 +366,19 @@ describe("errors", () => {
     }).toThrow("plugin target must be one of 'node', 'bun' or 'browser'");
   });
 
+  it("propagates exceptions thrown from 'target' toString", () => {
+    expect(() => {
+      plugin({
+        setup: () => {},
+        target: {
+          toString() {
+            throw new Error("boom");
+          },
+        },
+      } as any);
+    }).toThrow("boom");
+  });
+
   it("invalid loaders throw", () => {
     const invalidLoaders = ["blah", "blah2", "blah3", "blah4"];
     const inputs = ["body { background: red; }", "<h1>hi</h1>", '{"hi": "there"}', "hi"];


### PR DESCRIPTION
When `Bun.plugin()` is called with a `target` value whose `toString()` throws (e.g. an object with a throwing `toString`, or anything that triggers a stack overflow during string coercion), the pending exception was not checked before proceeding to `constructEmptyObject`, tripping the `assertNoException()` assertion in debug builds.

`toStringOrNull` returns `nullptr` on exception, which caused the inner `if` body to be skipped without propagating the error.

### Repro
```js
Bun.plugin({
  target: { toString() { throw new Error("boom"); } },
  setup: () => {},
});
```

Before: `ASSERTION FAILED: !exception()` in `ExceptionScope.h`
After: `error: boom` is thrown as expected.

Found by Fuzzilli (fingerprint `3287a60078202cd7`).