### PR TITLE
Upgrade WebKit to 39d4ce1f12ea

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-236-e54e803f";
+export const WEBKIT_VERSION = "autobuild-preview-pr-236-d0bc4acd";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "3167a44fb92c268c83f09b232b38a9f3e7f9655a";
+export const WEBKIT_VERSION = "autobuild-preview-pr-236-e54e803f";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-236-d0bc4acd";
+export const WEBKIT_VERSION = "0d85951a31d3d04684e3e598589de065378c2c59";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/JSType.rs
+++ b/src/jsc/JSType.rs
@@ -126,11 +126,7 @@ impl JSType {
     /// ```
     pub const HeapBigInt: JSType = JSType(3);
 
-    /// Heap-allocated double values (new in recent WebKit).
-    pub const HeapDouble: JSType = JSType(4);
 
-    /// Heap-allocated int32 values (new in recent WebKit).
-    pub const HeapInt32: JSType = JSType(5);
 
     /// JavaScript Symbol primitive - unique identifiers.
     /// ```js
@@ -138,7 +134,7 @@ impl JSType {
     /// Symbol('description')
     /// Symbol.for('key')
     /// ```
-    pub const Symbol: JSType = JSType(6);
+    pub const Symbol: JSType = JSType(4);
 
     /// Accessor property descriptor containing getter and/or setter functions.
     /// ```js
@@ -147,7 +143,7 @@ impl JSType {
     ///   set(v) { this._value = v; }
     /// })
     /// ```
-    pub const GetterSetter: JSType = JSType(7);
+    pub const GetterSetter: JSType = JSType(5);
 
     /// Custom native getter/setter implementation for built-in properties.
     /// ```js
@@ -155,10 +151,10 @@ impl JSType {
     /// const arr = [1, 2, 3];
     /// arr.length; // uses CustomGetterSetter
     /// ```
-    pub const CustomGetterSetter: JSType = JSType(8);
+    pub const CustomGetterSetter: JSType = JSType(6);
 
     /// Wrapper for native API values exposed to JavaScript.
-    pub const APIValueWrapper: JSType = JSType(9);
+    pub const APIValueWrapper: JSType = JSType(7);
 
     /// Compiled native code executable for built-in functions.
     /// ```js
@@ -166,90 +162,90 @@ impl JSType {
     /// parseInt("42")
     /// Array.from([1, 2, 3])
     /// ```
-    pub const NativeExecutable: JSType = JSType(10);
+    pub const NativeExecutable: JSType = JSType(8);
 
     /// Compiled executable for top-level program code.
-    pub const ProgramExecutable: JSType = JSType(11);
+    pub const ProgramExecutable: JSType = JSType(9);
 
     /// Compiled executable for ES6 module code.
-    pub const ModuleProgramExecutable: JSType = JSType(12);
+    pub const ModuleProgramExecutable: JSType = JSType(10);
 
     /// Compiled executable for eval() expressions.
     /// ```js
     /// eval('var x = 42; console.log(x);')
     /// ```
-    pub const EvalExecutable: JSType = JSType(13);
+    pub const EvalExecutable: JSType = JSType(11);
 
     /// Compiled executable for function bodies.
     /// ```js
     /// function foo() { return 42; }
     /// const bar = () => 123
     /// ```
-    pub const FunctionExecutable: JSType = JSType(14);
+    pub const FunctionExecutable: JSType = JSType(12);
 
-    pub const UnlinkedFunctionExecutable: JSType = JSType(15);
-    pub const UnlinkedProgramCodeBlock: JSType = JSType(16);
-    pub const UnlinkedModuleProgramCodeBlock: JSType = JSType(17);
-    pub const UnlinkedEvalCodeBlock: JSType = JSType(18);
-    pub const UnlinkedFunctionCodeBlock: JSType = JSType(19);
+    pub const UnlinkedFunctionExecutable: JSType = JSType(13);
+    pub const UnlinkedProgramCodeBlock: JSType = JSType(14);
+    pub const UnlinkedModuleProgramCodeBlock: JSType = JSType(15);
+    pub const UnlinkedEvalCodeBlock: JSType = JSType(16);
+    pub const UnlinkedFunctionCodeBlock: JSType = JSType(17);
 
     /// Compiled bytecode block ready for execution.
-    pub const CodeBlock: JSType = JSType(20);
+    pub const CodeBlock: JSType = JSType(18);
 
-    pub const JSCellButterfly: JSType = JSType(21);
-    pub const JSSourceCode: JSType = JSType(22);
+    pub const JSCellButterfly: JSType = JSType(19);
+    pub const JSSourceCode: JSType = JSType(20);
 
     /// Slim promise reaction (no rejection handler / context payload).
     /// Internal object used in the promise resolution mechanism.
-    pub const SlimPromiseReaction: JSType = JSType(23);
+    pub const SlimPromiseReaction: JSType = JSType(21);
 
     /// Full promise reaction (carries onFulfilled/onRejected and async context).
     /// Internal object used in the promise resolution mechanism.
-    pub const FullPromiseReaction: JSType = JSType(24);
+    pub const FullPromiseReaction: JSType = JSType(22);
 
     /// Context object for Promise.all() operations.
     /// Internal object used to track the state of Promise.all() resolution.
     /// Note: Moved before ObjectType in recent WebKit.
-    pub const PromiseAllContext: JSType = JSType(25);
+    pub const PromiseAllContext: JSType = JSType(23);
 
     /// Global context for Promise.all() (new in recent WebKit).
-    pub const PromiseAllGlobalContext: JSType = JSType(26);
+    pub const PromiseAllGlobalContext: JSType = JSType(24);
 
     /// Streaming WebAssembly compile/instantiate context (new in WebKit).
-    pub const WebAssemblyStreamingContext: JSType = JSType(27);
+    pub const WebAssemblyStreamingContext: JSType = JSType(25);
 
     /// Microtask dispatcher for promise/microtask queue management.
-    pub const JSMicrotaskDispatcher: JSType = JSType(28);
+    pub const JSMicrotaskDispatcher: JSType = JSType(26);
 
     /// Module loader registry entry (new C++ module loader).
-    pub const ModuleRegistryEntry: JSType = JSType(29);
+    pub const ModuleRegistryEntry: JSType = JSType(27);
 
     /// Module loading context (new C++ module loader).
-    pub const ModuleLoadingContext: JSType = JSType(30);
+    pub const ModuleLoadingContext: JSType = JSType(28);
 
     /// Module loader payload (new C++ module loader).
-    pub const ModuleLoaderPayload: JSType = JSType(31);
+    pub const ModuleLoaderPayload: JSType = JSType(29);
 
     /// Module graph loading state (new C++ module loader).
-    pub const ModuleGraphLoadingState: JSType = JSType(32);
+    pub const ModuleGraphLoadingState: JSType = JSType(30);
 
     /// JSModuleLoader cell type (new C++ module loader).
-    pub const JSModuleLoader: JSType = JSType(33);
+    pub const JSModuleLoader: JSType = JSType(31);
 
     /// Base JavaScript object type.
     /// ```js
     /// {}
     /// new Object()
     /// ```
-    pub const Object: JSType = JSType(34);
+    pub const Object: JSType = JSType(32);
 
     /// Optimized object type for object literals with fixed properties.
     /// ```js
     /// { a: 1, b: 2 }
     /// ```
-    pub const FinalObject: JSType = JSType(35);
+    pub const FinalObject: JSType = JSType(33);
 
-    pub const JSCallee: JSType = JSType(36);
+    pub const JSCallee: JSType = JSType(34);
 
     /// JavaScript function object created from JavaScript source code.
     /// ```js
@@ -259,7 +255,7 @@ impl JSType {
     ///   method() {}
     /// }
     /// ```
-    pub const JSFunction: JSType = JSType(37);
+    pub const JSFunction: JSType = JSType(35);
 
     /// Built-in function implemented in native code.
     /// ```js
@@ -268,23 +264,23 @@ impl JSType {
     /// parseInt
     /// console.log
     /// ```
-    pub const InternalFunction: JSType = JSType(38);
+    pub const InternalFunction: JSType = JSType(36);
 
-    pub const NullSetterFunction: JSType = JSType(39);
+    pub const NullSetterFunction: JSType = JSType(37);
 
     /// Boxed Boolean object.
     /// ```js
     /// new Boolean(true)
     /// new Boolean(false)
     /// ```
-    pub const BooleanObject: JSType = JSType(40);
+    pub const BooleanObject: JSType = JSType(38);
 
     /// Boxed Number object.
     /// ```js
     /// new Number(42)
     /// new Number(3.14)
     /// ```
-    pub const NumberObject: JSType = JSType(41);
+    pub const NumberObject: JSType = JSType(39);
 
     /// JavaScript Error object and its subclasses.
     /// ```js
@@ -292,9 +288,9 @@ impl JSType {
     /// new TypeError()
     /// throw new RangeError()
     /// ```
-    pub const ErrorInstance: JSType = JSType(42);
+    pub const ErrorInstance: JSType = JSType(40);
 
-    pub const GlobalProxy: JSType = JSType(43);
+    pub const GlobalProxy: JSType = JSType(41);
 
     /// Arguments object for function parameters.
     /// ```js
@@ -303,10 +299,10 @@ impl JSType {
     ///   console.log(arguments.length);
     /// }
     /// ```
-    pub const DirectArguments: JSType = JSType(44);
+    pub const DirectArguments: JSType = JSType(42);
 
-    pub const ScopedArguments: JSType = JSType(45);
-    pub const ClonedArguments: JSType = JSType(46);
+    pub const ScopedArguments: JSType = JSType(43);
+    pub const ClonedArguments: JSType = JSType(44);
 
     /// JavaScript Array object.
     /// ```js
@@ -315,94 +311,94 @@ impl JSType {
     /// new Array(10)
     /// Array.from(iterable)
     /// ```
-    pub const Array: JSType = JSType(47);
+    pub const Array: JSType = JSType(45);
 
     /// Array subclass created through class extension.
     /// ```js
     /// class MyArray extends Array {}
     /// const arr = new MyArray();
     /// ```
-    pub const DerivedArray: JSType = JSType(48);
+    pub const DerivedArray: JSType = JSType(46);
 
     /// ArrayBuffer for binary data storage.
     /// ```js
     /// new ArrayBuffer(1024)
     /// ```
-    pub const ArrayBuffer: JSType = JSType(49);
+    pub const ArrayBuffer: JSType = JSType(47);
 
     /// Typed array for 8-bit signed integers.
     /// ```js
     /// new Int8Array(buffer)
     /// new Int8Array([1, -1, 127])
     /// ```
-    pub const Int8Array: JSType = JSType(50);
+    pub const Int8Array: JSType = JSType(48);
 
     /// Typed array for 8-bit unsigned integers.
     /// ```js
     /// new Uint8Array(buffer)
     /// new Uint8Array([0, 255])
     /// ```
-    pub const Uint8Array: JSType = JSType(51);
+    pub const Uint8Array: JSType = JSType(49);
 
     /// Typed array for 8-bit unsigned integers with clamping.
     /// ```js
     /// new Uint8ClampedArray([0, 300]) // 300 becomes 255
     /// ```
-    pub const Uint8ClampedArray: JSType = JSType(52);
+    pub const Uint8ClampedArray: JSType = JSType(50);
 
     /// Typed array for 16-bit signed integers.
     /// ```js
     /// new Int16Array(buffer)
     /// ```
-    pub const Int16Array: JSType = JSType(53);
+    pub const Int16Array: JSType = JSType(51);
 
     /// Typed array for 16-bit unsigned integers.
     /// ```js
     /// new Uint16Array(buffer)
     /// ```
-    pub const Uint16Array: JSType = JSType(54);
+    pub const Uint16Array: JSType = JSType(52);
 
     /// Typed array for 32-bit signed integers.
     /// ```js
     /// new Int32Array(buffer)
     /// ```
-    pub const Int32Array: JSType = JSType(55);
+    pub const Int32Array: JSType = JSType(53);
 
     /// Typed array for 32-bit unsigned integers.
     /// ```js
     /// new Uint32Array(buffer)
     /// ```
-    pub const Uint32Array: JSType = JSType(56);
+    pub const Uint32Array: JSType = JSType(54);
 
     /// Typed array for 16-bit floating point numbers.
     /// ```js
     /// new Float16Array(buffer)
     /// ```
-    pub const Float16Array: JSType = JSType(57);
+    pub const Float16Array: JSType = JSType(55);
 
     /// Typed array for 32-bit floating point numbers.
     /// ```js
     /// new Float32Array(buffer)
     /// ```
-    pub const Float32Array: JSType = JSType(58);
+    pub const Float32Array: JSType = JSType(56);
 
     /// Typed array for 64-bit floating point numbers.
     /// ```js
     /// new Float64Array(buffer)
     /// ```
-    pub const Float64Array: JSType = JSType(59);
+    pub const Float64Array: JSType = JSType(57);
 
     /// Typed array for 64-bit signed BigInt values.
     /// ```js
     /// new BigInt64Array([123n, -456n])
     /// ```
-    pub const BigInt64Array: JSType = JSType(60);
+    pub const BigInt64Array: JSType = JSType(58);
 
     /// Typed array for 64-bit unsigned BigInt values.
     /// ```js
     /// new BigUint64Array([123n, 456n])
     /// ```
-    pub const BigUint64Array: JSType = JSType(61);
+    pub const BigUint64Array: JSType = JSType(59);
 
     /// DataView for flexible binary data access.
     /// ```js
@@ -410,7 +406,7 @@ impl JSType {
     /// view.getInt32(0)
     /// view.setFloat64(8, 3.14)
     /// ```
-    pub const DataView: JSType = JSType(62);
+    pub const DataView: JSType = JSType(60);
 
     /// Global object containing all global variables and functions.
     /// ```js
@@ -418,12 +414,12 @@ impl JSType {
     /// window // in browsers
     /// global // in Node.js
     /// ```
-    pub const GlobalObject: JSType = JSType(63);
+    pub const GlobalObject: JSType = JSType(61);
 
-    pub const GlobalLexicalEnvironment: JSType = JSType(64);
-    pub const LexicalEnvironment: JSType = JSType(65);
-    pub const ModuleEnvironment: JSType = JSType(66);
-    pub const StrictEvalActivation: JSType = JSType(67);
+    pub const GlobalLexicalEnvironment: JSType = JSType(62);
+    pub const LexicalEnvironment: JSType = JSType(63);
+    pub const ModuleEnvironment: JSType = JSType(64);
+    pub const StrictEvalActivation: JSType = JSType(65);
 
     /// Scope object for with statements.
     /// ```js
@@ -431,19 +427,19 @@ impl JSType {
     ///   prop; // looks up prop in obj first
     /// }
     /// ```
-    pub const WithScope: JSType = JSType(68);
+    pub const WithScope: JSType = JSType(66);
 
-    pub const AsyncDisposableStack: JSType = JSType(69);
-    pub const DisposableStack: JSType = JSType(70);
+    pub const AsyncDisposableStack: JSType = JSType(67);
+    pub const DisposableStack: JSType = JSType(68);
 
     /// Namespace object for ES6 modules.
     /// ```js
     /// import * as ns from 'module';
     /// ns.exportedFunction()
     /// ```
-    pub const ModuleNamespaceObject: JSType = JSType(71);
+    pub const ModuleNamespaceObject: JSType = JSType(69);
 
-    pub const ShadowRealm: JSType = JSType(72);
+    pub const ShadowRealm: JSType = JSType(70);
 
     /// Regular expression object.
     /// ```js
@@ -451,7 +447,7 @@ impl JSType {
     /// new RegExp('pattern', 'flags')
     /// /abc/gi
     /// ```
-    pub const RegExpObject: JSType = JSType(73);
+    pub const RegExpObject: JSType = JSType(71);
 
     /// JavaScript Date object for date/time operations.
     /// ```js
@@ -459,7 +455,7 @@ impl JSType {
     /// new Date('2023-01-01')
     /// Date.now()
     /// ```
-    pub const JSDate: JSType = JSType(74);
+    pub const JSDate: JSType = JSType(72);
 
     /// Proxy object that intercepts operations on another object.
     /// ```js
@@ -467,7 +463,7 @@ impl JSType {
     ///   get(obj, prop) { return obj[prop]; }
     /// })
     /// ```
-    pub const ProxyObject: JSType = JSType(75);
+    pub const ProxyObject: JSType = JSType(73);
 
     /// Generator object created by generator functions.
     /// ```js
@@ -475,7 +471,10 @@ impl JSType {
     /// const g = gen();
     /// g.next()
     /// ```
-    pub const Generator: JSType = JSType(76);
+    pub const Generator: JSType = JSType(74);
+
+    /// Async function generator object (split from JSGenerator in WebKit ~May 2026 to shrink sizeof(JSGenerator)).
+    pub const AsyncFunctionGenerator: JSType = JSType(75);
 
     /// Async generator object for asynchronous iteration.
     /// ```js
@@ -483,17 +482,17 @@ impl JSType {
     ///   yield await promise;
     /// }
     /// ```
-    pub const AsyncGenerator: JSType = JSType(77);
+    pub const AsyncGenerator: JSType = JSType(76);
 
     /// Iterator for Array objects.
     /// ```js
     /// [1,2,3][Symbol.iterator]()
     /// for (const x of array) {}
     /// ```
-    pub const JSArrayIterator: JSType = JSType(78);
+    pub const JSArrayIterator: JSType = JSType(77);
 
-    pub const Iterator: JSType = JSType(79);
-    pub const IteratorHelper: JSType = JSType(80);
+    pub const Iterator: JSType = JSType(78);
+    pub const IteratorHelper: JSType = JSType(79);
 
     /// Iterator for Map objects.
     /// ```js
@@ -502,32 +501,32 @@ impl JSType {
     /// map.entries()
     /// for (const [k,v] of map) {}
     /// ```
-    pub const MapIterator: JSType = JSType(81);
+    pub const MapIterator: JSType = JSType(80);
 
     /// Iterator for Set objects.
     /// ```js
     /// set.values()
     /// for (const value of set) {}
     /// ```
-    pub const SetIterator: JSType = JSType(82);
+    pub const SetIterator: JSType = JSType(81);
 
     /// Iterator for String objects.
     /// ```js
     /// 'hello'[Symbol.iterator]()
     /// for (const char of string) {}
     /// ```
-    pub const StringIterator: JSType = JSType(83);
+    pub const StringIterator: JSType = JSType(82);
 
-    pub const WrapForValidIterator: JSType = JSType(84);
+    pub const WrapForValidIterator: JSType = JSType(83);
 
     /// Iterator for RegExp string matching.
     /// ```js
     /// 'abc'.matchAll(/./g)
     /// for (const match of string.matchAll(regex)) {}
     /// ```
-    pub const RegExpStringIterator: JSType = JSType(85);
+    pub const RegExpStringIterator: JSType = JSType(84);
 
-    pub const AsyncFromSyncIterator: JSType = JSType(86);
+    pub const AsyncFromSyncIterator: JSType = JSType(85);
 
     /// JavaScript Promise object for asynchronous operations.
     /// ```js
@@ -535,7 +534,7 @@ impl JSType {
     /// Promise.resolve(42)
     /// async function foo() { await promise; }
     /// ```
-    pub const JSPromise: JSType = JSType(87);
+    pub const JSPromise: JSType = JSType(86);
 
     /// JavaScript Map object for key-value storage.
     /// ```js
@@ -543,7 +542,7 @@ impl JSType {
     /// map.set(key, value)
     /// map.get(key)
     /// ```
-    pub const Map: JSType = JSType(88);
+    pub const Map: JSType = JSType(87);
 
     /// JavaScript Set object for unique value storage.
     /// ```js
@@ -551,34 +550,34 @@ impl JSType {
     /// set.add(value)
     /// set.has(value)
     /// ```
-    pub const Set: JSType = JSType(89);
+    pub const Set: JSType = JSType(88);
 
     /// WeakMap for weak key-value references.
     /// ```js
     /// new WeakMap()
     /// weakMap.set(object, value)
     /// ```
-    pub const WeakMap: JSType = JSType(90);
+    pub const WeakMap: JSType = JSType(89);
 
     /// WeakSet for weak value references.
     /// ```js
     /// new WeakSet()
     /// weakSet.add(object)
     /// ```
-    pub const WeakSet: JSType = JSType(91);
+    pub const WeakSet: JSType = JSType(90);
 
-    pub const WebAssemblyModule: JSType = JSType(92);
-    pub const WebAssemblyInstance: JSType = JSType(93);
-    pub const WebAssemblyGCObject: JSType = JSType(94);
+    pub const WebAssemblyModule: JSType = JSType(91);
+    pub const WebAssemblyInstance: JSType = JSType(92);
+    pub const WebAssemblyGCObject: JSType = JSType(93);
 
     /// Boxed String object.
     /// ```js
     /// new String("hello")
     /// ```
-    pub const StringObject: JSType = JSType(95);
+    pub const StringObject: JSType = JSType(94);
 
-    pub const DerivedStringObject: JSType = JSType(96);
-    pub const InternalFieldTuple: JSType = JSType(97);
+    pub const DerivedStringObject: JSType = JSType(95);
+    pub const InternalFieldTuple: JSType = JSType(96);
 
     pub const MaxJS: JSType = JSType(0b11111111);
     pub const Event: JSType = JSType(0b11101111);

--- a/src/jsc/JSType.rs
+++ b/src/jsc/JSType.rs
@@ -126,8 +126,6 @@ impl JSType {
     /// ```
     pub const HeapBigInt: JSType = JSType(3);
 
-
-
     /// JavaScript Symbol primitive - unique identifiers.
     /// ```js
     /// Symbol()

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -311,8 +311,7 @@ void JSValueToStringSafe(JSC::JSGlobalObject* globalObject, WTF::StringBuilder& 
     }
     case JSC::JSType::SymbolType: {
         auto symbol = uncheckedDowncast<Symbol>(cell);
-        auto result = symbol->description();
-        if (!result.isEmpty()) {
+        if (!symbol->uid().isNullSymbol() && !symbol->uid().isEmpty()) {
             builder.append(symbol->tryGetDescriptiveString().value_or(String()));
         } else {
             builder.append(globalObject->vm().smallStrings.symbolString());

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -274,7 +274,7 @@ JSPromise* importModule(JSGlobalObject* globalObject, JSString* moduleName, RefP
     if (isUseMainContextDefaultLoaderConstant(globalObject, dynamicImportCallback)) {
         auto defer = fetcher->temporarilyUseDefaultLoader();
         Zig::GlobalObject* zigGlobalObject = defaultGlobalObject(globalObject);
-        RELEASE_AND_RETURN(scope, zigGlobalObject->moduleLoaderImportModule(zigGlobalObject, zigGlobalObject->moduleLoader(), moduleName, WTF::move(parameters), sourceOrigin));
+        RELEASE_AND_RETURN(scope, zigGlobalObject->moduleLoaderImportModule(zigGlobalObject, zigGlobalObject->moduleLoader(), moduleName, WTF::move(parameters), sourceOrigin, false));
     } else if (!dynamicImportCallback || !dynamicImportCallback.isCallable()) {
         throwException(globalObject, scope, createError(globalObject, ErrorCode::ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING, "A dynamic import callback was not specified."_s));
         return nullptr;
@@ -1472,8 +1472,9 @@ static JSPromise* moduleLoaderImportModuleInner(NodeVMGlobalObject* globalObject
     return promise;
 }
 
-JSPromise* NodeVMGlobalObject::moduleLoaderImportModule(JSGlobalObject* globalObject, JSC::JSModuleLoader* moduleLoader, JSC::JSString* moduleName, RefPtr<JSC::ScriptFetchParameters> parameters, const JSC::SourceOrigin& sourceOrigin)
+JSPromise* NodeVMGlobalObject::moduleLoaderImportModule(JSGlobalObject* globalObject, JSC::JSModuleLoader* moduleLoader, JSC::JSString* moduleName, RefPtr<JSC::ScriptFetchParameters> parameters, const JSC::SourceOrigin& sourceOrigin, bool deferred)
 {
+    UNUSED_PARAM(deferred);
     auto* nodeVmGlobalObject = static_cast<NodeVMGlobalObject*>(globalObject);
 
     if (JSPromise* result = NodeVM::importModule(nodeVmGlobalObject, moduleName, parameters, sourceOrigin)) {

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -136,7 +136,7 @@ public:
     static void getOwnPropertyNames(JSObject*, JSGlobalObject*, JSC::PropertyNameArrayBuilder&, JSC::DontEnumPropertiesMode);
     static bool defineOwnProperty(JSObject* object, JSGlobalObject* globalObject, PropertyName propertyName, const PropertyDescriptor& descriptor, bool shouldThrow);
     static bool deleteProperty(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, JSC::DeletePropertySlot& slot);
-    static JSC::JSPromise* moduleLoaderImportModule(JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSString* moduleNameValue, RefPtr<JSC::ScriptFetchParameters> parameters, const JSC::SourceOrigin&);
+    static JSC::JSPromise* moduleLoaderImportModule(JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSString* moduleNameValue, RefPtr<JSC::ScriptFetchParameters> parameters, const JSC::SourceOrigin&, bool deferred);
 
 private:
     // The contextified object that acts as the global proxy

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -804,10 +804,11 @@ void exceptionFromString(ZigException& except, JSC::JSValue value, JSC::JSGlobal
         switch (type) {
         case JSC::SymbolType: {
             auto* symbol = asSymbol(cell);
-            if (symbol->description().isEmpty()) {
+            auto& uid = symbol->uid();
+            if (uid.isNullSymbol() || uid.isEmpty()) {
                 except.message = BunStringEmpty;
             } else {
-                except.message = Bun::toStringRef(symbol->description());
+                except.message = Bun::toStringRef(static_cast<WTF::StringImpl*>(&uid));
             }
             return;
         }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3435,8 +3435,10 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
     JSModuleLoader*,
     JSString* moduleNameValue,
     RefPtr<JSC::ScriptFetchParameters> parameters,
-    const SourceOrigin& sourceOrigin)
+    const SourceOrigin& sourceOrigin,
+    bool deferred)
 {
+    UNUSED_PARAM(deferred);
     auto* globalObject = static_cast<Zig::GlobalObject*>(jsGlobalObject);
 
     VM& vm = JSC::getVM(globalObject);

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -196,7 +196,7 @@ public:
 
     static void reportUncaughtExceptionAtEventLoop(JSGlobalObject*, JSC::Exception*);
     static JSGlobalObject* deriveShadowRealmGlobalObject(JSGlobalObject* globalObject);
-    static JSC::JSPromise* moduleLoaderImportModule(JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSString* moduleNameValue, RefPtr<JSC::ScriptFetchParameters>, const JSC::SourceOrigin&);
+    static JSC::JSPromise* moduleLoaderImportModule(JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSString* moduleNameValue, RefPtr<JSC::ScriptFetchParameters>, const JSC::SourceOrigin&, bool deferred);
     static JSC::Identifier moduleLoaderResolve(JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSValue key, JSC::JSValue referrer, RefPtr<JSC::ScriptFetcher>, bool useImportMap);
     static JSC::JSPromise* moduleLoaderFetch(JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSValue key, RefPtr<JSC::ScriptFetchParameters>, RefPtr<JSC::ScriptFetcher>);
     static JSC::JSObject* moduleLoaderCreateImportMetaProperties(JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSValue key, JSC::JSModuleRecord*, RefPtr<JSC::ScriptFetcher>);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2294,6 +2294,16 @@ static void collectAsyncStackFramesFromPromise(JSC::VM& vm, JSC::JSCell* owner, 
             case JSC::JSPromise::InlineReactionKind::InternalMicrotask: {
                 if (auto* generator = unwrapGeneratorFromContext(p->inlineReactionContext()))
                     return generator;
+                // No generator in the context. For the resolve-with-promise fast
+                // path (`return promise` without await inside an async function),
+                // the reaction's cell payload is the outer promise being resolved —
+                // follow it to the next promise in the chain. Combinator reactions
+                // store a JSPromiseCombinatorsGlobalContext there, so the downcast
+                // fails and we stop, as before.
+                if (auto* next = dynamicDowncast<JSC::JSPromise>(p->payloadCell())) {
+                    p = next;
+                    continue;
+                }
                 return nullptr;
             }
             case JSC::JSPromise::InlineReactionKind::FulfillHandler:

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -140,6 +140,7 @@
 
 #include "AsyncContextFrame.h"
 #include "JavaScriptCore/InternalFieldTuple.h"
+#include "JavaScriptCore/JSAsyncFunctionGenerator.h"
 #include "JavaScriptCore/JSGenerator.h"
 #include "JavaScriptCore/JSPromiseReaction.h"
 #include "JavaScriptCore/FunctionExecutable.h"
@@ -2264,11 +2265,11 @@ static void collectAsyncStackFramesFromPromise(JSC::VM& vm, JSC::JSCell* owner, 
         return *out != nullptr;
     };
 
-    auto unwrapGeneratorFromContext = [&](JSC::JSValue context) -> JSC::JSGenerator* {
+    auto unwrapGeneratorFromContext = [&](JSC::JSValue context) -> JSC::JSAsyncFunctionGenerator* {
         JSC::InternalFieldTuple* tuple = nullptr;
         if (dynamicCastValue(context, &tuple))
             context = tuple->getInternalField(0);
-        JSC::JSGenerator* generator = nullptr;
+        JSC::JSAsyncFunctionGenerator* generator = nullptr;
         dynamicCastValue(context, &generator);
         return generator;
     };
@@ -2285,7 +2286,7 @@ static void collectAsyncStackFramesFromPromise(JSC::VM& vm, JSC::JSCell* owner, 
     //    payloadCell() and the handler in m_slot.
     //  - As a heap-allocated JSPromiseReaction list once a second handler is
     //    attached, headed at payloadCell().
-    auto getAwaitingGenerator = [&](JSC::JSPromise* p) -> JSC::JSGenerator* {
+    auto getAwaitingGenerator = [&](JSC::JSPromise* p) -> JSC::JSAsyncFunctionGenerator* {
         for (unsigned hops = 0; p && hops < 32; hops++) {
             if (p->status() != JSC::JSPromise::Status::Pending)
                 return nullptr;
@@ -2316,9 +2317,9 @@ static void collectAsyncStackFramesFromPromise(JSC::VM& vm, JSC::JSCell* owner, 
         return nullptr;
     };
 
-    auto computeBytecodeIndex = [&](JSC::CodeBlock* codeBlock, JSC::JSGenerator* generator) -> JSC::BytecodeIndex {
+    auto computeBytecodeIndex = [&](JSC::CodeBlock* codeBlock, JSC::JSAsyncFunctionGenerator* generator) -> JSC::BytecodeIndex {
         JSC::BytecodeIndex bytecodeIndex(0);
-        JSC::JSValue stateValue = generator->internalField(JSC::JSGenerator::Field::State).get();
+        JSC::JSValue stateValue = generator->internalField(JSC::JSAsyncFunctionGenerator::Field::State).get();
         if (stateValue.isInt32()) {
             int32_t state = stateValue.asInt32();
             size_t numberOfJumpTables = codeBlock->numberOfUnlinkedSwitchJumpTables();
@@ -2333,7 +2334,7 @@ static void collectAsyncStackFramesFromPromise(JSC::VM& vm, JSC::JSCell* owner, 
         return bytecodeIndex;
     };
 
-    auto appendFrame = [&](JSC::JSGenerator* generator) {
+    auto appendFrame = [&](JSC::JSAsyncFunctionGenerator* generator) {
         JSC::JSFunction* asyncFunction = nullptr;
         if (!dynamicCastValue(generator->next(), &asyncFunction))
             return;
@@ -2350,7 +2351,7 @@ static void collectAsyncStackFramesFromPromise(JSC::VM& vm, JSC::JSCell* owner, 
         }
     };
 
-    JSC::JSGenerator* gen = getAwaitingGenerator(promise);
+    JSC::JSAsyncFunctionGenerator* gen = getAwaitingGenerator(promise);
     while (gen && results.size() < maxStackSize) {
         appendFrame(gen);
         JSC::JSPromise* returnPromise = nullptr;
@@ -4577,9 +4578,9 @@ void JSC__JSValue__getSymbolDescription(JSC::EncodedJSValue symbolValue_, JSC::J
 
     JSC::Symbol* symbol = JSC::asSymbol(symbolValue);
 
-    auto result = symbol->description();
-    if (!result.isEmpty()) {
-        *arg2 = Zig::toZigString(result);
+    auto& uid = symbol->uid();
+    if (!uid.isNullSymbol() && !uid.isEmpty()) {
+        *arg2 = Zig::toZigString(static_cast<WTF::StringImpl&>(uid));
     } else {
         *arg2 = ZigStringEmpty;
     }

--- a/src/runtime/bake/BakeGlobalObject.cpp
+++ b/src/runtime/bake/BakeGlobalObject.cpp
@@ -18,8 +18,10 @@ JSC::JSPromise*
 bakeModuleLoaderImportModule(JSC::JSGlobalObject* global,
     JSC::JSModuleLoader* moduleLoader, JSC::JSString* moduleNameValue,
     RefPtr<JSC::ScriptFetchParameters> parameters,
-    const JSC::SourceOrigin& sourceOrigin)
+    const JSC::SourceOrigin& sourceOrigin,
+    bool deferred)
 {
+    UNUSED_PARAM(deferred);
     WTF::String keyString = moduleNameValue->getString(global);
     if (keyString.startsWith("bake:/"_s)) {
         auto& vm = JSC::getVM(global);
@@ -49,7 +51,7 @@ bakeModuleLoaderImportModule(JSC::JSGlobalObject* global,
 
     // TODO: make static cast instead of jscast
     // Use Zig::GlobalObject's function
-    return uncheckedDowncast<Zig::GlobalObject>(global)->moduleLoaderImportModule(global, moduleLoader, moduleNameValue, WTF::move(parameters), sourceOrigin);
+    return uncheckedDowncast<Zig::GlobalObject>(global)->moduleLoaderImportModule(global, moduleLoader, moduleNameValue, WTF::move(parameters), sourceOrigin, false);
 }
 
 JSC::Identifier bakeModuleLoaderResolve(JSC::JSGlobalObject* jsGlobal,


### PR DESCRIPTION
Upgrades Bun's WebKit fork to upstream `39d4ce1f12ea` (~422 upstream commits since `49d2e914a4cc`). Fork PR: oven-sh/WebKit#236.

> **Note:** `WEBKIT_VERSION` currently points at the **preview build** (`autobuild-preview-pr-236-e54e803f`). After oven-sh/WebKit#236 is merged, this should be updated to the merge-commit autobuild before this PR is merged.

# WebKit Upgrade: `49d2e914a4cc` → `39d4ce1f12ea`

~422 upstream commits total; ~80 touch `Source/JavaScriptCore`, `Source/WTF`, or `Source/bmalloc`.

## ⚠️ Embedder-facing API / ABI changes

These directly affect Bun's bindings and were resolved during the merge.

- **`JSType` enum changed** — `HeapDoubleType` and `HeapInt32Type` removed; `JSAsyncFunctionGeneratorType` added after `JSGeneratorType`; constant `LastMaybeFalsyCellPrimitive` renamed to `LastValueCompareCellType`. Every JSType value after `HeapBigIntType` shifts down by 2, and every value after `JSGeneratorType` shifts up by 1. Bun's mirror of this enum in `src/jsc/bindings/JSType.zig` (and any consumers) must be regenerated/checked.
- **`JSGenerator` split into `JSGenerator` + `JSAsyncFunctionGenerator`** (`e0704d3127d5`, bug 314933). `sizeof(JSGenerator)` shrinks 64 → 48 bytes by moving the `Context` internal field into the new `JSAsyncFunctionGenerator` class. Async functions now drive a `JSAsyncFunctionGenerator`, not a plain `JSGenerator`. Anything that downcasts the async function generator must use the new type.
- **`JSPromise::performPromiseThenWithInternalMicrotask` signature changed** (`8f742098b444`, bug 314788). Fourth parameter was `JSValue promise`, now `JSCell* cell`. Pass `nullptr` where `jsUndefined()` was passed before. `setInlineMicrotaskReaction` also gained the `JSCell*` parameter; the inline reaction now stores a separate cell payload alongside the context, so a single `JSPromise` can carry an inlined `InternalMicrotask` reaction plus a result-promise cell without allocating a `JSPromiseReaction`.
- **`JSModuleLoader::loadModule` now takes `OptionSet<ModuleLoadFlag>`** instead of separate `bool evaluate, bool dynamic, bool useImportMap` parameters (`7f062965e945`, bug 314794). New flag `ModuleLoadFlag::Deferred` added for `import.defer()`. `ModuleLoadingContext::create` likewise switched to the OptionSet.
- **`globalObjectMethodTable()->moduleLoaderImportModule` gained a trailing `bool deferred` parameter** (`7f062965e945`). Bun's `JSGlobalObject` method table override must accept and (for now, can ignore) it.
- **`JSHeapInt32` / `JSHeapDouble` removed** (`3bb4fc93fb37`, bug 314894). These were the experimental 32-bit-JSValues "compressed heap" boxing types; the headers, IsoSubspaces, and includes are gone.
- **`Symbol::toString(JSGlobalObject*)` added** (`5e57a5812ef4`, bug 314842). Caches the descriptive string on the `Symbol` object. `stringConstructor()` now calls it instead of building the string inline.
- **`AbstractModuleRecord::ImportEntries` / `ExportEntries` switched to `WTF::OrderedHashMap`** (`4d67159942bc`, bug 314961). Was `UncheckedKeyHashMap`. Iteration order is now insertion order; module-binding error messages are deterministic.

### `JSType.h` diff

```diff
@@ -31,10 +31,12 @@ namespace JSC {
     macro(CellType, SpecCellOther) \
     macro(StructureType, SpecCellOther) \
+    \
+    /* These JSCells require non-pointer-comparison identity check */ \
+    /* (e.g. String value comparison). Keep in sync with LastValueCompareCellType. */ \
     macro(StringType, SpecString) \
     macro(HeapBigIntType, SpecHeapBigInt) \
-    macro(HeapDoubleType, SpecCellOther) \
-    macro(HeapInt32Type, SpecCellOther) \
+    \
     macro(SymbolType, SpecSymbol) \
@@ -133,6 +135,7 @@ namespace JSC {
     macro(JSGeneratorType, SpecObjectOther) \
+    macro(JSAsyncFunctionGeneratorType, SpecObjectOther) \
     macro(JSAsyncGeneratorType, SpecObjectOther) \
@@ -168,7 +171,7 @@ enum JSType : uint8_t {
-static constexpr uint32_t LastMaybeFalsyCellPrimitive = HeapBigIntType;
+static constexpr uint32_t LastValueCompareCellType = HeapBigIntType;
```

## Promise / async-function fast path work

A coordinated batch of patches replacing JS-builtin promise plumbing with C++ `InternalMicrotask` plumbing and removing per-`await`/per-element allocations. Combined effect: large reductions in object allocation and promise-resolution latency.

- `8f742098b444` — Inlined `InternalMicrotask` reaction: a pending `JSPromise` can carry a single `InternalMicrotask` reaction (task id + context + cell) directly in its `m_packed` / `m_slot` fields instead of allocating a `JSSlimPromiseReaction`.
- `c3276f48dfd6` — Optimize the initial `then` call path for plain promises.
- `cdf77b6570ff` — Cache `isDefinitelyNonThenable` result on `Structure`; avoids re-walking the prototype chain for the same shape.
- `b1a624172673` — Inline allocation for `Promise.resolve()` of a non-thenable object.
- `c71210975aaf` — Avoid creating both first resolving functions when only one is needed in `Promise.all` / `Promise.any`.
- `0f6a35669fa8` — Avoid per-element `JSPromiseCombinatorsContext` allocation in promise combinators.
- `4ed24b821a12` — Skip intermediate promise allocation for non-thenable elements in `Promise` combinators.
- `e0704d3127d5` — `JSGenerator` shrink + `JSAsyncFunctionGenerator` split (see above).

## DFG / FTL / JIT

- `b07dca9615f1` — `GetByStatus::computeFor` should not walk the proto chain for direct property access (bug 309519).
- `fb8bfead603e` — Fix incorrect side-effect modeling for `Spread(SetObjectUse)` in the DFG abstract interpreter (bug 315132).
- `c415e39f485b` — Introduce private tmp mechanism in DFG `ByteCodeParser` (bug 315173).
- `1aeca6948c89` — DFG abstract interpreter misclassifies `ArraySortCompact` result as `SpecObjectOther` (bug 315143).
- `227528432e5f` — Collect profiles from Baseline JIT compiler when transitioning LLInt → Baseline (bug 315183).
- `7429d22f2bfd` — Fix DFG CPS validation for inlined sort comparator (bug 315144).
- `d53865edf63b` — Add new `DateNow` DFG node (bug 315065).
- `596590000220` — Implement DFG / FTL `ArrayUnshift` (bug 315068).
- `dfe5dc6ed106` — Implement `ArrayShift` DFG node (bug 314926).
- `953bc0380f0b` — Add missing `ExitOK` after constant folding `then` (bug 315042).
- `4d1b8f9f75bb` — Add `StringSubstr` DFG node (bug 314921).
- `67969621f703` — Inline `String#startsWith` / `String#endsWith` with constant search string in DFG/FTL (bug 314517).
- `ce3942e437cb` — Extend megamorphic ByVal IC with symbols (bug 314890).
- `8f52a29461ca` — Optimize `===` (`stricteq`) with non-String / non-HeapBigInt cells; uses the new `LastValueCompareCellType` boundary (bug 314855).
- `59a20ddcb9ca` — Use scratch buffer for `ObjectDefinePropertyFromFields` (bug 315074).

## Runtime / interpreter

- `1440f8619f82` — Implement `String#match` in C++ (bug 314466).
- `f9477aedc258` — Compare 8-bit strings a word at a time in `Array#indexOf` / `Array#includes` (bug 314877).
- `a3aa7524f30f` — Use `truncateDoubleToInt32`/`64()` in more round-trip double-to-int checks (bug 314884). Touches `TypedArrayAdaptors.h`.
- `8608a8ac3b20` — Fix test262 failure in `TypedArray/constructor-buffer-sequence.js` (bug 313927).
- `918d694777b9` — Fix / update iterator return function call's arguments (bug 315095).
- `72272dcc4feb` — `ScopedArgumentsTable` `ScopeOffset` buffer should allocate from `fastMalloc` (bug 315082).
- `83e85f875a70` — Simplify bytecode writer (bug 314878). `InstructionStream.h` now includes `<wtf/UnalignedAccess.h>` directly.
- `3c73fbe0cf5d` — Shard `JSTypedArrayViewPrototype` host functions across `@no-unify` translation units (bug 313968).

## Modules

- `7f062965e945` — Implement dynamic `import.defer()` semantics (bug 314794). See API changes above.
- `4d67159942bc` — Use `OrderedHashMap` for module `ImportEntries` / `ExportEntries` so error reporting is deterministic (bug 314961).

## Temporal

- `7f9fbe74e492` — Fix `fractionToDouble` for large denominators; consolidate `ZonedDateTime` diff (bug 314848).
- `20ca333f3a4d` — Add duration rounding, calendar field resolution, and date-time difference algorithms (bug 314765).

## Wasm

- `ca0c6bb18657` — JS wrappers for Wasm Tables created lazily (bug 314958).
- `29ac32293df6` — Build JS wrappers and `JSToWasmCallee`s lazily (bug 314910).
- `280445b02587` — Address an unexpected safer-cpp failure in `WasmConstExprGenerator.cpp`.

## WTF / build infrastructure

- `368c0bec7652` — Introduce `WTF::toArray()` to work around `std::to_array()` not being detected as `NODELETE` by static analysis (bug 313933). Many files migrated by `97bbefac03a5`.
- `097a8276c97a` — Simplify `WTF::Variant` (build-speed work, bug 315055).
- `912cfd18d9b4` — `[Win]` `OSAllocator::tryProtect` fails when memory spans multiple reserved regions (bug 315080).
- `b15055c7b0ed` — Update / fix Lock/Condition performance test binaries (bug 315171).
- `6cfb79671c10` — `[CMake]` Touching a WTF `.cpp` no longer triggers an 11-second LLInt rebuild (bug 315226).
- `5780e754ea9b` — `[CMake]` Standardize `-Wunsafe-buffer-usage` flags (bug 314991).
- `13415f9ed9f3` — Remove `-fsafe-buffer-usage-suggestions` (bug 314917).
- `99f0b44bc5ce` — `[CMake]` Fix some Linux builds with precompiled headers (bug 314763).
- `c1f868200266` / `f31bec07e0e3` / `67ab82bd25dc` — Swift-in-WTF interop work (parts 4), with one revert/reland cycle (bug 314469 / 315224 / 315166).
- `f1e8bc403871` / `286cd2780073` — WTF module-verification fixes for some configurations (bugs 314977, 314858).
- `94043d8f9138` / `b035254290ed` — Suppress new Clang-22 `-Wunsafe-buffer-usage` warnings on GTK/WPE.
- `e6f4d3c2b495` — Adopt `ReducedResolutionSeconds` more widely (bug 314722).
- `dc311bb8313d` — `[Win]` Enable `MemoryPressureHandlerWin` and implement a low-memory watcher (bug 297533).

## Cleanup / removal

- `3bb4fc93fb37` — Remove `JSHeapInt32` / `JSHeapDouble` (experimental 32-bit-JSValues boxing). Drops two `JSType` enum values and two IsoSubspaces.
- `85bcefbc014c` — Fix a few more missing includes (bug 314821).
- `85015722cb65` — Fix a stray `-Wunsafe-buffer-usage` pragma that accidentally disabled the check (bug 314771).

## Not relevant to Bun's `JSCOnly` build

- `b958a2407b33` — Order files for WebCore/JSC on macOS framework builds.
- `2bfe8aece710` — Site Isolation Web Inspector network ID changes (mostly WebCore/WebKit2).
- `8e1c6277f598` / `6c766638e894` / `f34545487d2f` — Threaded time-based animations toggling.
- `f3d2e2f2ea01` — GTK/WPE skia compositor default.
- `02ee8d8ba70b`, `79003b865f9f`, `8f1f5a27db3d`, `56a1500e4215`, `761dfab7357a`, `d47452669e1a`, `3784776034f9`, `39d4ce1f12ea` — Cocoa/visionOS/sandbox/HDR/AVCapture/MTE platform work.
- `5a256540dbde`, `17c8e7383a38`, `fb6c928ed4b3`, `3ab6c7c73f9a`, `3cef60980461` — iOS/watchOS/tvOS SDK build fixes and reverts.
