### PR TITLE
Add typed callback registration for uws, libuv, and the work pool

### DIFF
--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -30,6 +30,11 @@
 
 pub mod stub_event_loop;
 
+// Typed owning wrapper for libuv handles (Windows-only, like the raw
+// `bun_libuv_sys` bindings it wraps).
+#[cfg(windows)]
+pub mod uv_handle;
+
 #[cfg(windows)]
 pub mod windows_event_loop;
 

--- a/src/io/uv_handle.rs
+++ b/src/io/uv_handle.rs
@@ -77,6 +77,19 @@ pub trait UvCallback<H> {
 ///   wrapper's `(H, T)`.
 /// * [`close`](Self::close) (and `Drop`) is the teardown half: the slot is
 ///   freed by the `uv_close` callback, never while libuv still references it.
+///
+/// # Non-re-entrancy contract
+///
+/// Owning a `UvHandle<H, T>` asserts that no borrow returned by
+/// [`data`](Self::data) / [`data_mut`](Self::data_mut) /
+/// [`handle_mut`](Self::handle_mut) is held across a call that can dispatch
+/// this handle's callbacks (`uv_run` / `Loop::tick`). The event trampoline
+/// materialises `&mut T` from the slot back-pointer; a wrapper-side borrow
+/// live at that moment would alias it. This is the same contract every libuv
+/// userdata consumer (and `ExtSlot<T>` on the uWS side) relies on: the loop
+/// is only driven from the event-loop driver, with no handle borrows on the
+/// stack. Consumers that need to reach the userdata *during* a callback get
+/// it from the callback's own `&mut T` parameter, not from the wrapper.
 pub struct UvHandle<H: RawUvHandle + bun_core::Zeroable, T> {
     /// Owned heap slot. Held as a raw pointer (not `Box`) because libuv keeps
     /// an aliasing `*mut H` into the same allocation from `uv_*_init` until

--- a/src/io/uv_handle.rs
+++ b/src/io/uv_handle.rs
@@ -1,0 +1,239 @@
+//! Typed registration/recovery pairing for libuv handles: an owning wrapper
+//! around a heap-allocated `uv_*_t` plus its userdata, whose `extern "C"`
+//! callback trampolines are generated once per `(handle, userdata)` pair.
+//!
+//! The libuv callback shape is "store a `T` behind the handle's `void* data`
+//! word, get the handle back in an `extern "C"` callback, cast `data` to
+//! `&mut T`". Every consumer used to restate the "this `void*` is really my
+//! struct" invariant at both the registration site and inside each callback.
+//! [`UvHandle<H, T>`] carries that invariant in its type parameters: the
+//! allocation, the `data` stamp, the callback, and the `uv_close`-time
+//! reclamation are all monomorphised over the same `(H, T)`, so a wrong-type
+//! recovery is unrepresentable.
+//!
+//! The remaining `unsafe` for this callback shape is the pair of trampolines
+//! (`event` and `on_close`) plus the `uv_close` FFI call that arms the second
+//! one.
+//!
+//! Bounded cost: each callback dispatch re-reads the `data` word and panics
+//! if it is null (a callback fired on a handle that was never
+//! [`arm`](UvHandle::arm)ed) instead of dereferencing it.
+
+use core::ptr::NonNull;
+
+use bun_sys::windows::libuv as uv;
+use bun_sys::windows::libuv::UvHandle as RawUvHandle;
+
+/// One heap allocation holding the libuv handle and its typed userdata. The
+/// handle's `data` word points back at the whole `Slot` so the trampolines
+/// recover it with full-allocation provenance regardless of which (possibly
+/// field-narrowed) handle pointer libuv hands them.
+#[repr(C)]
+struct Slot<H, T> {
+    handle: H,
+    data: T,
+}
+
+/// The callback half of a [`UvHandle<H, T>`] registration. Implemented by a
+/// (typically zero-sized) marker type; `Data` must equal the wrapper's `T`
+/// for [`UvHandle::arm`] to accept it, which is what makes a wrong-type
+/// recovery a compile error:
+///
+/// ```compile_fail
+/// use bun_io::uv_handle::{UvCallback, UvHandle};
+/// use bun_sys::windows::libuv as uv;
+///
+/// struct Tick;
+/// impl UvCallback<uv::Timer> for Tick {
+///     type Data = u32;
+///     fn on_event(_data: &mut u32, _handle: &mut uv::Timer) {}
+/// }
+///
+/// // The handle owns a `String`, but `Tick` recovers a `u32`:
+/// // error[E0271]: type mismatch resolving `<Tick as UvCallback<Timer>>::Data == String`
+/// let mut h: UvHandle<uv::Timer, String> = UvHandle::new(String::new());
+/// let _ = h.arm::<Tick>();
+/// ```
+pub trait UvCallback<H> {
+    /// The userdata type this callback recovers. Must match the `T` of the
+    /// [`UvHandle<H, T>`] it is armed on.
+    type Data;
+
+    /// The handler body. `data` and `handle` are disjoint borrows of the same
+    /// heap allocation, so the handler can both mutate its state and re-arm /
+    /// stop the handle.
+    fn on_event(data: &mut Self::Data, handle: &mut H);
+}
+
+/// Owning wrapper for a heap-allocated libuv handle and its typed userdata.
+///
+/// * [`new`](Self::new) allocates the slot with the handle zeroed (libuv
+///   requires `memset(0)` before `uv_*_init`).
+/// * [`handle_mut`](Self::handle_mut) exposes the raw handle for the
+///   per-type `uv_*_init` / `uv_*_start` calls. The handle's `data` word is
+///   reserved for the wrapper's back-pointer; do not overwrite it.
+/// * [`arm`](Self::arm) is the registration half: it stamps the back-pointer
+///   and yields the `extern "C"` trampoline monomorphised over this
+///   wrapper's `(H, T)`.
+/// * [`close`](Self::close) (and `Drop`) is the teardown half: the slot is
+///   freed by the `uv_close` callback, never while libuv still references it.
+pub struct UvHandle<H: RawUvHandle + bun_core::Zeroable, T> {
+    /// Owned heap slot. Held as a raw pointer (not `Box`) because libuv keeps
+    /// an aliasing `*mut H` into the same allocation from `uv_*_init` until
+    /// the `uv_close` callback fires; ownership is only re-materialised as a
+    /// `Box` inside `on_close` once libuv has dropped its reference.
+    slot: NonNull<Slot<H, T>>,
+}
+
+impl<H: RawUvHandle + bun_core::Zeroable, T> UvHandle<H, T> {
+    /// Heap-allocate a zeroed `H` alongside `data`. The handle is **not**
+    /// initialised; call the per-type `uv_*_init` through
+    /// [`handle_mut`](Self::handle_mut) before arming/starting it.
+    pub fn new(data: T) -> Self {
+        let slot = Box::new(Slot {
+            // `H: Zeroable` asserts the all-zero bit pattern is a valid `H`
+            // (libuv expects callers to `memset(0)` before `uv_*_init`).
+            handle: bun_core::ffi::zeroed(),
+            data,
+        });
+        Self {
+            slot: NonNull::from(Box::leak(slot)),
+        }
+    }
+
+    /// The raw handle, for `uv_*_init` / `uv_*_start` / `uv_*_stop` calls.
+    #[inline]
+    pub fn handle_mut(&mut self) -> &mut H {
+        &mut self.slot_mut().handle
+    }
+
+    /// Shared access to the userdata.
+    #[inline]
+    pub fn data(&self) -> &T {
+        &self.slot_ref().data
+    }
+
+    /// Exclusive access to the userdata.
+    #[inline]
+    pub fn data_mut(&mut self) -> &mut T {
+        &mut self.slot_mut().data
+    }
+
+    /// The registration half of the pairing: stamp the handle's `data` word
+    /// with the back-pointer to this wrapper's slot and return the
+    /// `extern "C"` trampoline for `C`, monomorphised over this wrapper's
+    /// `(H, T)`. Pass the result to the per-type `uv_*_start` alongside
+    /// [`handle_mut`](Self::handle_mut).
+    ///
+    /// Call this **after** the per-type `uv_*_init` (some init wrappers zero
+    /// the whole struct, which would wipe an earlier stamp).
+    ///
+    /// Taking `&mut self` ties the requested trampoline to an actual
+    /// allocation of the same `(H, T)`; the `Data = T` bound is what rejects
+    /// a callback that would recover a different userdata type.
+    #[inline]
+    pub fn arm<C: UvCallback<H, Data = T>>(&mut self) -> unsafe extern "C" fn(*mut H) {
+        let back = self.slot.as_ptr();
+        self.slot_mut().handle.set_data(back.cast());
+        Self::event::<C>
+    }
+
+    /// The libuv event trampoline for this `(H, T, C)`.
+    ///
+    /// This is the single recovery `unsafe` for the libuv callback shape.
+    unsafe extern "C" fn event<C: UvCallback<H, Data = T>>(handle: *mut H) {
+        // SAFETY: type-pairing proof. This trampoline is only obtainable from
+        // `UvHandle::<H, T>::arm`, which requires a live `&mut UvHandle<H, T>`
+        // and stamps the handle's `data` word with the back-pointer to that
+        // wrapper's `Slot<H, T>` before returning it — so the `data` word read
+        // here is either that back-pointer (carrying whole-`Slot` provenance,
+        // preserved through the store/load) or null if the handle was never
+        // armed, which the `expect` turns into a panic instead of a deref.
+        // The slot stays allocated until the `uv_close` callback fires
+        // (`close`/`Drop` never free it directly), and libuv dispatches
+        // callbacks on the single loop thread, so no other Rust borrow of the
+        // slot is live here.
+        let slot = unsafe {
+            let data = (*handle.cast::<uv::uv_handle_t>()).data;
+            NonNull::new(data.cast::<Slot<H, T>>())
+                .expect("UvHandle callback fired on a handle that was never armed")
+                .as_mut()
+        };
+        C::on_event(&mut slot.data, &mut slot.handle);
+    }
+
+    /// The `uv_close` trampoline: reclaims the `Box<Slot<H, T>>` once libuv
+    /// guarantees it will never touch the handle again.
+    unsafe extern "C" fn on_close(handle: *mut uv::uv_handle_t) {
+        // SAFETY: this trampoline is only ever installed by `Drop` below,
+        // which re-stamps the `data` word with the wrapper's own slot pointer
+        // and then relinquishes the wrapper without freeing. libuv invokes
+        // the close callback exactly once, after which it holds no reference
+        // to the handle, so re-materialising and dropping the `Box` here is
+        // the sole free of the allocation.
+        let slot = unsafe {
+            let data = (*handle).data;
+            Box::from_raw(data.cast::<Slot<H, T>>())
+        };
+        drop(slot);
+    }
+
+    /// Hand the handle to `uv_close`; the slot is freed by the `uv_close`
+    /// trampoline on the next loop turn. Equivalent to `drop(self)` —
+    /// provided so teardown reads as an action at call sites.
+    #[inline]
+    pub fn close(self) {
+        drop(self);
+    }
+
+    /// Reborrow the owned slot. Centralises the aliasing argument the
+    /// accessors share instead of repeating it per field.
+    #[inline(always)]
+    fn slot_ref(&self) -> &Slot<H, T> {
+        // SAFETY: `self.slot` is the wrapper's owned allocation, live from
+        // `new` until the close trampoline reclaims it (which can only happen
+        // after the wrapper — and therefore every borrow derived from it — is
+        // gone). The wrapper is `!Send`/`!Sync` and libuv only mutates the
+        // handle from inside `uv_run` on the loop thread, never concurrently
+        // with Rust code holding this borrow.
+        unsafe { self.slot.as_ref() }
+    }
+
+    /// Exclusive reborrow of the owned slot. See [`Self::slot_ref`].
+    #[inline(always)]
+    fn slot_mut(&mut self) -> &mut Slot<H, T> {
+        // SAFETY: as `slot_ref`, plus `&mut self` guarantees no other borrow
+        // derived from the wrapper is live.
+        unsafe { self.slot.as_mut() }
+    }
+}
+
+impl<H: RawUvHandle + bun_core::Zeroable, T> Drop for UvHandle<H, T> {
+    fn drop(&mut self) {
+        let back = self.slot.as_ptr();
+        let slot = self.slot_mut();
+        // `uv_*_init` stamps `handle.type` with a non-zero `uv_handle_type`;
+        // a still-zeroed type means libuv has never seen this handle, so
+        // there is nothing to close and the slot can be freed directly.
+        // SAFETY: `as_handle` is the `UvHandle` trait's prefix cast over the
+        // slot's own live `handle` field; reading the POD `type_` field
+        // through it is in-bounds.
+        let initialised = unsafe { (*slot.handle.as_handle()).type_ } != uv::HandleType::Unknown;
+        if initialised {
+            // Transfer ownership of the slot to the close callback through
+            // the `data` word (re-stamped here in case the handle was never
+            // armed). `uv_close` aborts on a second close, but `self.slot` is
+            // unique to this wrapper and `Drop` runs at most once.
+            slot.handle.set_data(back.cast());
+            // SAFETY: the handle was initialised on a loop (checked above) and
+            // is not yet closing (this is the only place the wrapper closes
+            // it); `on_close::<H, T>` frees the matching `Slot<H, T>` via the
+            // `data` word stamped above.
+            unsafe { uv::uv_close(slot.handle.as_handle_mut(), Some(Self::on_close)) };
+        } else {
+            // SAFETY: libuv never saw the handle, so the wrapper is the sole
+            // owner of the allocation `new` leaked; reclaim and drop it.
+            drop(unsafe { Box::from_raw(back) });
+        }
+    }
+}

--- a/src/threading/lib.rs
+++ b/src/threading/lib.rs
@@ -12,6 +12,7 @@ pub mod mutex;
 pub mod reset_event;
 #[path = "RwLock.rs"]
 pub mod rwlock;
+pub mod scheduled_task;
 #[path = "Semaphore.rs"]
 pub mod semaphore;
 #[path = "ThreadPool.rs"]
@@ -36,6 +37,7 @@ pub use guarded::{Guarded, GuardedBy, GuardedLock};
 pub use mutex::{Mutex, MutexGuard};
 pub use reset_event::ResetEvent;
 pub use rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+pub use scheduled_task::{ScheduledContext, ScheduledTask};
 pub use semaphore::Semaphore;
 /// `parking_lot::Once` parity. Bun has no custom `Once` (Zig also uses
 /// `std.once` directly), and `std::sync::Once` has no poisoning concern, so

--- a/src/threading/scheduled_task.rs
+++ b/src/threading/scheduled_task.rs
@@ -1,0 +1,189 @@
+//! Typed registration/recovery pairing for the work pool: Box in, `&mut C` in
+//! the callback, Box out.
+//!
+//! The raw [`Task`] callback shape is `unsafe fn(*mut Task)` — every consumer
+//! used to `Box::into_raw` its own struct, stash the resulting pointer in the
+//! pool, and `Box::from_raw` + `container_of` it back inside the callback,
+//! restating the "this pointer is really a `MyTask`" invariant at both ends.
+//! [`ScheduledTask<C>`] carries that invariant in its type parameter instead:
+//! [`ScheduledTask::new`] is the only place the trampoline is installed and
+//! [`ScheduledTask::schedule`] is the only place the allocation is leaked, so
+//! the `*mut Task` the pool hands back to the trampoline is a
+//! `ScheduledTask<C>` for the same `C` by construction.
+//!
+//! The single remaining `unsafe` for this callback shape is the trampoline.
+
+use crate::thread_pool::{Node, Task};
+use crate::work_pool::WorkPool;
+
+/// A unit of work the pool runs with exclusive access to `&mut self`.
+///
+/// The wrapper (not the implementor) owns the intrusive [`Task`] plumbing, so
+/// implementors are plain structs with no `#[repr(C)]` / field-offset
+/// obligations.
+///
+/// `Send + 'static` because the context is moved to an arbitrary worker
+/// thread and outlives the scheduling scope. A non-`Send` context is a
+/// compile error at the [`ScheduledTask::new`] call site:
+///
+/// ```compile_fail
+/// use bun_threading::scheduled_task::{ScheduledContext, ScheduledTask};
+///
+/// struct NotSend(*mut u8);
+/// impl ScheduledContext for NotSend {
+///     fn run(&mut self) {}
+/// }
+/// // error[E0277]: `*mut u8` cannot be sent between threads safely
+/// let _ = ScheduledTask::new(NotSend(core::ptr::null_mut()));
+/// ```
+pub trait ScheduledContext: Send + Sized + 'static {
+    /// Runs on a worker thread. The trampoline recovers the heap allocation
+    /// and lends the context out as `&mut C` for the duration of the call.
+    fn run(&mut self);
+
+    /// Receives the heap allocation back after [`run`](Self::run) returns,
+    /// still on the worker thread. The default drops it (fire-and-forget);
+    /// override to hand the box onward, e.g. to an event-loop completion
+    /// queue.
+    fn finish(task: Box<ScheduledTask<Self>>) {
+        drop(task);
+    }
+}
+
+/// Owning pair of an intrusive work-pool [`Task`] and its typed context.
+///
+/// `#[repr(C)]` with `task` first so the `*mut Task` the pool threads through
+/// its intrusive queue is the same address as the `ScheduledTask<C>`
+/// allocation — the trampoline's container-of is a pointer cast.
+#[repr(C)]
+pub struct ScheduledTask<C: ScheduledContext> {
+    task: Task,
+    context: C,
+}
+
+impl<C: ScheduledContext> ScheduledTask<C> {
+    /// Heap-allocate a task around `context` with the typed trampoline
+    /// pre-installed. This is the registration half of the pairing: the only
+    /// callback ever stored in this `Task` is `Self::trampoline`, which
+    /// recovers the same `ScheduledTask<C>`.
+    pub fn new(context: C) -> Box<Self> {
+        Box::new(Self {
+            task: Task {
+                node: Node::default(),
+                callback: Self::trampoline,
+            },
+            context,
+        })
+    }
+
+    /// Shared access to the context before scheduling / after recovery.
+    #[inline]
+    pub fn context(&self) -> &C {
+        &self.context
+    }
+
+    /// Exclusive access to the context before scheduling / after recovery.
+    #[inline]
+    pub fn context_mut(&mut self) -> &mut C {
+        &mut self.context
+    }
+
+    /// Unwrap the context (e.g. out of the box recovered by
+    /// [`ScheduledContext::finish`]; `Box<Self>` auto-derefs and frees the
+    /// allocation).
+    #[inline]
+    pub fn into_context(self) -> C {
+        self.context
+    }
+
+    /// Box in: hand the allocation to the global [`WorkPool`]. Ownership
+    /// returns to Rust inside [`Self::trampoline`], which gives it back to
+    /// [`ScheduledContext::finish`].
+    pub fn schedule(self: Box<Self>) {
+        WorkPool::schedule(Self::into_task_ptr(self));
+    }
+
+    /// `Box::new` + [`schedule`](Self::schedule) for contexts built inline at
+    /// the call site.
+    #[inline]
+    pub fn schedule_new(context: C) {
+        Self::new(context).schedule();
+    }
+
+    /// Leak the box into the intrusive `*mut Task` the pool links into its
+    /// queue. Private: pairing with [`Self::trampoline`] is what makes the
+    /// recovery sound, so no other callback may ever see this pointer.
+    fn into_task_ptr(self: Box<Self>) -> *mut Task {
+        const { assert!(core::mem::offset_of!(Self, task) == 0) };
+        Box::into_raw(self).cast::<Task>()
+    }
+
+    /// The work-pool trampoline for this `C`: Box out, `&mut C` for the
+    /// handler, Box handed to [`ScheduledContext::finish`].
+    ///
+    /// This is the single `unsafe` for the work-pool callback shape.
+    unsafe fn trampoline(task: *mut Task) {
+        const { assert!(core::mem::offset_of!(Self, task) == 0) };
+        // SAFETY: type-pairing proof. `Self::trampoline` is private and only
+        // ever installed by `Self::new`, and the resulting `Box<Self>` is only
+        // ever leaked into the pool by `Self::into_task_ptr` (also private).
+        // The pool invokes `task.callback` exactly once with the same `*mut
+        // Task` it was given, so `task` is the (offset-0) `task` field of a
+        // live, uniquely-owned `ScheduledTask<C>` heap allocation for this
+        // exact `C`. Reclaiming the `Box` here is therefore sound and cannot
+        // double-free.
+        let mut this: Box<Self> = unsafe { Box::from_raw(task.cast::<Self>()) };
+        this.context.run();
+        C::finish(this);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+
+    struct Ctx {
+        runs: u32,
+        done: mpsc::Sender<u32>,
+    }
+
+    impl ScheduledContext for Ctx {
+        fn run(&mut self) {
+            self.runs += 1;
+        }
+
+        fn finish(task: Box<ScheduledTask<Self>>) {
+            // Box out: the same allocation `schedule` leaked comes back here
+            // with the mutation `run` made through `&mut self` visible.
+            let ctx = task.into_context();
+            ctx.done.send(ctx.runs).expect("test receiver alive");
+        }
+    }
+
+    /// Example adoption: schedule onto the real global pool. Cannot run under
+    /// Miri (the pool's futex park path is a foreign syscall).
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn round_trips_through_the_pool() {
+        let (tx, rx) = mpsc::channel();
+        ScheduledTask::schedule_new(Ctx { runs: 0, done: tx });
+        assert_eq!(rx.recv().expect("task ran"), 1);
+    }
+
+    /// Drive the trampoline directly (no pool, no FFI) so the Box-in →
+    /// `&mut C` → Box-out round trip is observable single-threaded — and so
+    /// Miri can check the recovery for aliasing/UAF.
+    #[test]
+    fn trampoline_recovers_the_same_allocation() {
+        let (tx, rx) = mpsc::channel();
+        let task =
+            ScheduledTask::<Ctx>::into_task_ptr(ScheduledTask::new(Ctx { runs: 0, done: tx }));
+        // SAFETY: `task` came from `into_task_ptr` on a `ScheduledTask<Ctx>`
+        // and is invoked exactly once, exactly as the pool would.
+        unsafe { ((*task).callback)(task) };
+        // `run` executed on this thread, mutated the context through `&mut C`,
+        // and `finish` observed that mutation in the recovered Box.
+        assert_eq!(rx.recv().expect("finish ran"), 1);
+    }
+}

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -36,6 +36,8 @@ pub use bun_uws_sys::response::State;
 pub use bun_uws_sys::{h3 as H3, quic, udp, vtable};
 pub type Socket = us_socket_t;
 
+pub mod shared_handler;
+
 // Upward refs into `bun_runtime` (higher tier) — kept as empty namespace stubs.
 // TODO(port): bun_runtime::socket::{uws_dispatch, windows_named_pipe, upgraded_duplex}
 pub mod dispatch {}

--- a/src/uws/shared_handler.rs
+++ b/src/uws/shared_handler.rs
@@ -1,0 +1,263 @@
+//! Typed `&self` callback registration for uWS socket handlers.
+//!
+//! The uWS callback shape is "store `T` behind the socket's ext word, get the
+//! word back in an `extern "C"` callback, cast it to a Rust borrow". The
+//! existing [`bun_uws_sys::vtable::Handler`] + [`ExtSlot<T>`] pairing already
+//! makes registration and recovery agree on `T`, but its recovery
+//! ([`ExtSlot::owner_mut`]) hands the handler `&mut T` — an exclusivity claim
+//! the handler bodies do not actually need and that re-entrant uWS dispatch
+//! (a handler calling back into uWS on the same socket) can violate.
+//!
+//! [`SharedHandler`] is the `&T` variant: registration is the [`vtable`] you
+//! pass to the socket group, recovery is the one trampoline in
+//! `Shared::owner`, and the handler bodies are safe `fn(&self, ...)` methods.
+//! Mutation goes through the owner's interior-mutability cells.
+//!
+//! The single `unsafe` for this callback shape is `Shared::owner`.
+
+use core::ffi::{c_int, c_void};
+use core::marker::PhantomData;
+
+use bun_uws_sys::socket_group::VTable;
+use bun_uws_sys::thunk::ExtSlot;
+use bun_uws_sys::vtable::Handler;
+use bun_uws_sys::{ConnectingSocket, us_bun_verify_error_t, us_socket_t};
+
+/// A uWS socket handler whose callbacks receive `&self` recovered from the
+/// socket's [`ExtSlot<Self>`] ext word.
+///
+/// Set the `HAS_ON_*` const for each callback you implement; the vtable slot
+/// for every other callback is left null so uWS never dispatches it (the
+/// default bodies are `unreachable!()`).
+///
+/// Each callback may also fire before the owner has been stamped into the
+/// freshly-`calloc`'d ext slot (the connect/accept window); the dispatch
+/// adapter skips the handler call in that case, matching the existing
+/// `ExtSlot::owner_mut` consumers.
+///
+/// A handler body must not free its own allocation mid-call (e.g. by dropping
+/// the last refcount on itself) — the `&self` receiver is live for the whole
+/// callback. Owners that can die during dispatch must keep using the
+/// raw-pointer handler family instead.
+pub trait SharedHandler: Sized + 'static {
+    const HAS_ON_OPEN: bool = false;
+    const HAS_ON_DATA: bool = false;
+    const HAS_ON_FD: bool = false;
+    const HAS_ON_WRITABLE: bool = false;
+    const HAS_ON_CLOSE: bool = false;
+    const HAS_ON_TIMEOUT: bool = false;
+    const HAS_ON_LONG_TIMEOUT: bool = false;
+    const HAS_ON_END: bool = false;
+    const HAS_ON_CONNECT_ERROR: bool = false;
+    const HAS_ON_CONNECTING_ERROR: bool = false;
+    const HAS_ON_HANDSHAKE: bool = false;
+
+    fn on_open(&self, _s: *mut us_socket_t, _is_client: bool, _ip: &[u8]) {
+        unreachable!()
+    }
+    fn on_data(&self, _s: *mut us_socket_t, _data: &[u8]) {
+        unreachable!()
+    }
+    fn on_fd(&self, _s: *mut us_socket_t, _fd: c_int) {
+        unreachable!()
+    }
+    fn on_writable(&self, _s: *mut us_socket_t) {
+        unreachable!()
+    }
+    fn on_close(&self, _s: *mut us_socket_t, _code: i32, _reason: Option<*mut c_void>) {
+        unreachable!()
+    }
+    fn on_timeout(&self, _s: *mut us_socket_t) {
+        unreachable!()
+    }
+    fn on_long_timeout(&self, _s: *mut us_socket_t) {
+        unreachable!()
+    }
+    fn on_end(&self, _s: *mut us_socket_t) {
+        unreachable!()
+    }
+    fn on_connect_error(&self, _s: *mut us_socket_t, _code: i32) {
+        unreachable!()
+    }
+    /// Fired while the socket is still a `us_connecting_socket_t` (DNS /
+    /// happy-eyeballs failure before any concrete socket exists).
+    fn on_connecting_error(&self, _c: *mut ConnectingSocket, _code: i32) {
+        unreachable!()
+    }
+    fn on_handshake(&self, _s: *mut us_socket_t, _ok: bool, _err: us_bun_verify_error_t) {
+        unreachable!()
+    }
+}
+
+/// Dispatch adapter: implements the `_sys` [`Handler`] for any
+/// [`SharedHandler`], pinning `Ext = ExtSlot<H>` so the socket-group vtable's
+/// trampolines recover exactly `&H`.
+///
+/// The pairing is carried by the type parameter: the `Ext` associated type of
+/// `Shared<H>` is `ExtSlot<H>`, so its dispatch methods cannot be handed the
+/// ext slot of a socket registered for a different owner type:
+///
+/// ```compile_fail
+/// use bun_uws::shared_handler::{Shared, SharedHandler};
+///
+/// struct A;
+/// impl SharedHandler for A {}
+/// struct B;
+/// impl SharedHandler for B {}
+///
+/// fn wrong(ext: &mut bun_uws_sys::thunk::ExtSlot<B>) {
+///     // error[E0308]: expected `ExtSlot<A>`, found `ExtSlot<B>`
+///     <Shared<A> as bun_uws_sys::vtable::Handler>::on_data(ext, core::ptr::null_mut(), &[]);
+/// }
+/// ```
+pub struct Shared<H>(PhantomData<H>);
+
+impl<H: SharedHandler> Shared<H> {
+    /// The uWS callback-shape trampoline: recover `&H` from the ext slot the
+    /// socket was registered with, or `None` for the calloc'd-but-not-yet-
+    /// stamped window during connect/accept.
+    ///
+    /// The returned borrow is tied to the ext borrow, which the `_sys`
+    /// trampoline layer bounds to the duration of the C callback.
+    #[inline(always)]
+    fn owner<'a>(ext: &'a ExtSlot<H>) -> Option<&'a H> {
+        // SAFETY: type-pairing proof. `ext` is the `ExtSlot<H>` the
+        // `vtable::Trampolines<Shared<H>>` layer materialised from the ext
+        // storage of a socket whose group was built from `vtable::<H>()` —
+        // `Handler::Ext = ExtSlot<H>` is what sized and typed that storage, so
+        // the word it holds is either `None` (calloc zero) or the `NonNull<H>`
+        // the owner stamped at registration. The pointee outlives the socket
+        // (it owns it), and a *shared* borrow is formed, so concurrent `&H`
+        // from re-entrant dispatch on the same socket cannot conflict; `H`
+        // mutation goes through interior-mutability cells.
+        ext.get().map(|p| unsafe { p.as_ref() })
+    }
+}
+
+impl<H: SharedHandler> Handler for Shared<H> {
+    type Ext = ExtSlot<H>;
+
+    const HAS_ON_OPEN: bool = H::HAS_ON_OPEN;
+    const HAS_ON_DATA: bool = H::HAS_ON_DATA;
+    const HAS_ON_FD: bool = H::HAS_ON_FD;
+    const HAS_ON_WRITABLE: bool = H::HAS_ON_WRITABLE;
+    const HAS_ON_CLOSE: bool = H::HAS_ON_CLOSE;
+    const HAS_ON_TIMEOUT: bool = H::HAS_ON_TIMEOUT;
+    const HAS_ON_LONG_TIMEOUT: bool = H::HAS_ON_LONG_TIMEOUT;
+    const HAS_ON_END: bool = H::HAS_ON_END;
+    const HAS_ON_CONNECT_ERROR: bool = H::HAS_ON_CONNECT_ERROR;
+    const HAS_ON_CONNECTING_ERROR: bool = H::HAS_ON_CONNECTING_ERROR;
+    const HAS_ON_HANDSHAKE: bool = H::HAS_ON_HANDSHAKE;
+
+    fn on_open(ext: &mut Self::Ext, s: *mut us_socket_t, is_client: bool, ip: &[u8]) {
+        if let Some(h) = Self::owner(ext) {
+            h.on_open(s, is_client, ip);
+        }
+    }
+    fn on_data(ext: &mut Self::Ext, s: *mut us_socket_t, data: &[u8]) {
+        if let Some(h) = Self::owner(ext) {
+            h.on_data(s, data);
+        }
+    }
+    fn on_fd(ext: &mut Self::Ext, s: *mut us_socket_t, fd: c_int) {
+        if let Some(h) = Self::owner(ext) {
+            h.on_fd(s, fd);
+        }
+    }
+    fn on_writable(ext: &mut Self::Ext, s: *mut us_socket_t) {
+        if let Some(h) = Self::owner(ext) {
+            h.on_writable(s);
+        }
+    }
+    fn on_close(ext: &mut Self::Ext, s: *mut us_socket_t, code: i32, reason: Option<*mut c_void>) {
+        if let Some(h) = Self::owner(ext) {
+            h.on_close(s, code, reason);
+        }
+    }
+    fn on_timeout(ext: &mut Self::Ext, s: *mut us_socket_t) {
+        if let Some(h) = Self::owner(ext) {
+            h.on_timeout(s);
+        }
+    }
+    fn on_long_timeout(ext: &mut Self::Ext, s: *mut us_socket_t) {
+        if let Some(h) = Self::owner(ext) {
+            h.on_long_timeout(s);
+        }
+    }
+    fn on_end(ext: &mut Self::Ext, s: *mut us_socket_t) {
+        if let Some(h) = Self::owner(ext) {
+            h.on_end(s);
+        }
+    }
+    fn on_connect_error(ext: &mut Self::Ext, s: *mut us_socket_t, code: i32) {
+        if let Some(h) = Self::owner(ext) {
+            h.on_connect_error(s, code);
+        }
+    }
+    fn on_connecting_error(c: *mut ConnectingSocket, code: i32) {
+        // The connecting-socket callback carries no pre-recovered ext; read
+        // the same `ExtSlot<H>` word off the connecting socket's ext storage
+        // (sized for it by the same registration) and recover `&H` through
+        // the one trampoline above.
+        if let Some(h) = Self::owner(ConnectingSocket::opaque_mut(c).ext::<ExtSlot<H>>()) {
+            h.on_connecting_error(c, code);
+        }
+    }
+    fn on_handshake(
+        ext: &mut Self::Ext,
+        s: *mut us_socket_t,
+        ok: bool,
+        err: us_bun_verify_error_t,
+    ) {
+        if let Some(h) = Self::owner(ext) {
+            h.on_handshake(s, ok, err);
+        }
+    }
+}
+
+/// The registration half of the pairing: a `&'static VTable` whose entries
+/// are the `extern "C"` trampolines for `Shared<H>`. Install it on a socket
+/// group whose ext storage is sized for `ExtSlot<H>` and stamped with the
+/// owning `NonNull<H>`; every callback then recovers `&H` through
+/// `Shared::owner`.
+pub fn vtable<H: SharedHandler>() -> &'static VTable {
+    bun_uws_sys::vtable::make::<Shared<H>>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::cell::Cell;
+
+    /// Example adoption: a handler with interior-mutability state and `&self`
+    /// callback bodies. Only the callbacks it declares get a vtable slot.
+    struct Sample {
+        bytes: Cell<usize>,
+    }
+
+    impl SharedHandler for Sample {
+        const HAS_ON_DATA: bool = true;
+        const HAS_ON_CLOSE: bool = true;
+
+        fn on_data(&self, _s: *mut us_socket_t, data: &[u8]) {
+            self.bytes.set(self.bytes.get() + data.len());
+        }
+        fn on_close(&self, _s: *mut us_socket_t, _code: i32, _reason: Option<*mut c_void>) {}
+    }
+
+    #[test]
+    fn vtable_populates_only_declared_slots() {
+        let vt = vtable::<Sample>();
+        assert!(vt.on_data.is_some());
+        assert!(vt.on_close.is_some());
+        assert!(vt.on_open.is_none());
+        assert!(vt.on_writable.is_none());
+        assert!(vt.on_timeout.is_none());
+        assert!(vt.on_long_timeout.is_none());
+        assert!(vt.on_end.is_none());
+        assert!(vt.on_connect_error.is_none());
+        assert!(vt.on_connecting_error.is_none());
+        assert!(vt.on_handshake.is_none());
+        assert!(vt.on_fd.is_none());
+    }
+}


### PR DESCRIPTION
## What

Adds one typed registration/recovery API per C-callback shape, so the "store `T` as `void*` userdata, cast it back in the `extern "C"` callback" pattern carries its type-pairing proof in a generic signature instead of restating it at every call site. New code only — no callers are migrated.

### `bun_uws::shared_handler` (new module in `src/uws/`)

`SharedHandler` + `Shared<H>`: a `vtable::Handler` adapter over `ExtSlot<H>` whose recovery hands the handler `&H` (shared) instead of `&mut H`, so handler bodies are safe `fn(&self, ...)` and re-entrant uWS dispatch on the same socket cannot create overlapping exclusive borrows of the owner. (The `&mut ExtSlot<H>` over the 8-byte ext word that the `_sys` trampoline layer forms per callback is inherited from the existing `vtable::Handler` signature and is unchanged here.) `shared_handler::vtable::<H>()` is the registration half; `Shared::owner` is the single recovery `unsafe`. A `compile_fail` doctest shows that `Shared<A>`'s dispatch cannot be handed an `ExtSlot<B>`.

### `bun_io::uv_handle` (new module in `src/io/`, Windows-only)

`UvHandle<H, T>`: an owning wrapper for a heap-allocated libuv handle plus its userdata in one `#[repr(C)]` slot. `arm::<C>()` stamps the handle's `data` word with the slot back-pointer and returns the `extern "C"` trampoline monomorphised over the same `(H, T)`; `UvCallback<H, Data = T>` is the bound that makes a wrong-type recovery a compile error (demonstrated with a `compile_fail` doctest). Teardown goes through `uv_close` and the close trampoline reclaims the `Box`, so the slot is never freed while libuv still references it.

### `bun_threading::scheduled_task` (new module in `src/threading/`)

`ScheduledTask<C>`: Box in (`schedule` leaks the allocation into the work pool), `&mut C` in the callback (`ScheduledContext::run`), Box out (`ScheduledContext::finish` receives the recovered allocation). The trampoline is private and only installable by `ScheduledTask::<C>::new`, so the `*mut Task` the pool hands back is a `ScheduledTask<C>` for the same `C` by construction. A `compile_fail` doctest shows a non-`Send` context is rejected.

## Unsafe accounting

Before: 487 `unsafe` sites across `src/uws/`, `src/io/`, `src/threading/` (`rg -o -e 'unsafe \{' -e 'unsafe fn' -e 'unsafe extern' -e 'unsafe impl' -e 'unsafe trait'`). After: 502. The +15 are all in the new modules (this project adds the shared trampolines; the P5-* projects spend them by deleting per-call-site unsafe):

- `shared_handler.rs`: 1 — the `&H` recovery in `Shared::owner`. Meets the "trampoline is the only unsafe block" bar exactly.
- `scheduled_task.rs`: 3 — the `unsafe fn` trampoline declaration (required by the `Task.callback` field type), its `Box::from_raw` body, and one block in a `#[test]` that drives the trampoline directly.
- `uv_handle.rs`: 10 — the two trampolines (`event`, `on_close`) and their recovery blocks, the `uv_close` FFI call, the owned-slot reborrows (`slot_ref`/`slot_mut`), and the two `Drop` paths (read `type_` to decide close-vs-free, `Box::from_raw` for the never-initialised case). More than "just the trampoline", but each block is the wrapper's own allocation or an FFI call; none is a userdata type-pun.

## Named cost

`UvHandle`'s event trampoline re-reads the handle's `data` word and panics if it is null (a callback fired on a handle that was never `arm`ed) instead of dereferencing it: one branch per callback dispatch.

## Tests / Miri

- `cargo miri test -p bun_threading -- scheduled_task` and `cargo miri test -p bun_uws -- shared_handler` pass (unit tests + the `compile_fail` doctests). The pool round-trip test is `#[cfg_attr(miri, ignore)]` (the futex park path is a foreign syscall). Neither crate is added to the `MIRI_CRATES` allowlist because their other tests do call FFI.
- `bun_io::uv_handle` is `#[cfg(windows)]`; it is covered by `cargo check`/`clippy` for `x86_64-pc-windows-msvc` but its doctest cannot be executed on a non-Windows host.
- `bun bd` compiles and the debug build passes a smoke test. No existing callers changed, so no existing test coverage is affected.

## Sites left unsafe

None converted, none left — this is the Wave-0 "new code only" project that the P5-* migrations build on.
