### PR TITLE
Fix rare concurrent-transpile segfault: mimalloc TLS slot resurrection; restructure the AST allocators

### DIFF
--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "24f9c6b49e2e33855a7d08a9f1e07a6fccce8820";
+const MIMALLOC_COMMIT = "afb41757285694f832e7a2f164d35f5717457f96";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/src/ast/ast_memory_allocator.rs
+++ b/src/ast/ast_memory_allocator.rs
@@ -209,6 +209,17 @@ impl ASTMemoryAllocator {
         }
     }
 
+    /// Take this allocator's `AstAlloc` state without recycling it. The caller
+    /// keeps the box alive for as long as `AstVec`s allocated under this
+    /// allocator's scope are read, then drops it.
+    pub fn take_ast_state(&mut self) -> Option<Box<AstAllocState>> {
+        debug_assert!(
+            !self.ast_pushed,
+            "take_ast_state while the AstAllocState is still installed"
+        );
+        self.ast_state.take()
+    }
+
     /// Debug-only: is the installed `AST_ALLOC` state the one this allocator
     /// pushed? Only meaningful while `ast_pushed`.
     fn ast_state_is_active(&self) -> bool {

--- a/src/ast/ast_memory_allocator.rs
+++ b/src/ast/ast_memory_allocator.rs
@@ -247,7 +247,10 @@ impl ASTMemoryAllocator {
         expr::data::Store::set_memory_allocator(std::ptr::from_mut::<Self>(self));
         crate::set_data_store_override(arena);
         if !self.ast_pushed {
-            let state = self.ast_state.take().unwrap_or_else(ast_alloc::acquire_state);
+            let state = self
+                .ast_state
+                .take()
+                .unwrap_or_else(ast_alloc::acquire_state);
             self.previous_ast_state = ast_alloc::swap_state(Some(state));
             self.ast_pushed = true;
         }
@@ -351,10 +354,7 @@ impl<'a> Scope<'a> {
             Some(r) => {
                 let arena: *const Arena = &raw const r.arena;
                 // Install this allocator's `AstAlloc` state for the scope.
-                let state = r
-                    .ast_state
-                    .take()
-                    .unwrap_or_else(ast_alloc::acquire_state);
+                let state = r.ast_state.take().unwrap_or_else(ast_alloc::acquire_state);
                 self.previous_ast_state = ast_alloc::swap_state(Some(state));
                 r.ast_pushed = true;
                 (std::ptr::from_mut::<ASTMemoryAllocator>(*r), arena)

--- a/src/ast/ast_memory_allocator.rs
+++ b/src/ast/ast_memory_allocator.rs
@@ -2,6 +2,7 @@ use core::cell::Cell;
 use core::ptr;
 
 use bun_alloc::Arena;
+use bun_alloc::ast_alloc::{self, AstAllocState};
 
 use crate::expr;
 use crate::stmt;
@@ -10,9 +11,8 @@ use crate::stmt;
 // — a small inline stack buffer with heap fallback. `bun_alloc::Arena`
 // (`MimallocArena`) has no stack buffer; instead the owned arena is recycled
 // per thread via `ARENA_POOL` below so the per-module callers don't pay a fresh
-// `mi_heap_new` + first-segment page faults every file. (A real inline
-// stack-fallback would still avoid the heap entirely for small modules — left
-// for a follow-up.)
+// `mi_heap_new` + first-segment page faults every file. (The `AstAlloc` side
+// *does* have an inline buffer now — see `bun_alloc::ast_alloc::AstAllocState`.)
 
 // ── Thread-local arena pool ──────────────────────────────────────────────
 //
@@ -64,9 +64,21 @@ pub struct ASTMemoryAllocator {
     /// for the per-module callers, each of which takes a freshly-pooled (clean)
     /// arena and arms it exactly once.
     arena_dirty: bool,
+    /// The `AstAlloc` allocation state for this allocator's scope (`AstVec`
+    /// buffers: `named_exports`, `DeclList`, `PropertyList`, …). Owned here
+    /// while no scope is active; moved into the `AST_ALLOC` thread-local by
+    /// [`Self::push`] / `Scope::enter` and moved back by [`Self::pop`] /
+    /// `Scope::exit`. Lazily acquired on the first push. `None` both before
+    /// the first push and while pushed — `ast_pushed` disambiguates.
+    ast_state: Option<Box<AstAllocState>>,
+    /// `true` while `ast_state` is installed in the `AST_ALLOC` thread-local
+    /// (i.e. the box is *not* in `ast_state`).
+    ast_pushed: bool,
     previous: *mut ASTMemoryAllocator,
     previous_logger: *const Arena,
-    previous_heap: *mut bun_alloc::mimalloc::Heap,
+    /// The `AST_ALLOC` occupant displaced by [`Self::push`], restored by
+    /// [`Self::pop`].
+    previous_ast_state: Option<Box<AstAllocState>>,
 }
 
 impl Default for ASTMemoryAllocator {
@@ -74,9 +86,11 @@ impl Default for ASTMemoryAllocator {
         Self {
             arena: take_pooled_arena(),
             arena_dirty: false,
+            ast_state: None,
+            ast_pushed: false,
             previous: ptr::null_mut(),
             previous_logger: ptr::null(),
-            previous_heap: ptr::null_mut(),
+            previous_ast_state: None,
         }
     }
 }
@@ -99,6 +113,18 @@ impl Drop for ASTMemoryAllocator {
         // arena behind so the field's own `Drop` does nothing.
         let arena = core::mem::replace(&mut self.arena, Arena::borrowing_default());
         return_pooled_arena(arena);
+        // Bulk-free the `AstAlloc` state's heap and park the box in the
+        // thread-local spare slot. If the state is still installed (push
+        // without pop), leave it where it is: the thread-local owns the box,
+        // so dropping nothing here turns a scope imbalance into a leak rather
+        // than a use-after-free.
+        debug_assert!(
+            !self.ast_pushed,
+            "ASTMemoryAllocator dropped while its AstAllocState is still installed"
+        );
+        if let Some(state) = self.ast_state.take() {
+            ast_alloc::release_state(state);
+        }
     }
 }
 
@@ -122,6 +148,31 @@ impl ASTMemoryAllocator {
         Self::default()
     }
 
+    /// Bulk-free everything allocated through this allocator's `AstAlloc`
+    /// state, wherever the state currently lives (owned here, or installed in
+    /// the thread-local by a `push()` that has not been `pop()`ed — the
+    /// package manager's `MiniStore` re-arms without popping).
+    fn reset_ast_state(&mut self) {
+        if let Some(state) = self.ast_state.as_deref_mut() {
+            state.reset();
+        } else if self.ast_pushed {
+            debug_assert!(
+                self.ast_state_is_active(),
+                "ASTMemoryAllocator::reset while another AstAllocState is installed"
+            );
+            ast_alloc::reset_active_state();
+        }
+    }
+
+    /// Debug-only: is the installed `AST_ALLOC` state the one this allocator
+    /// pushed? Only meaningful while `ast_pushed`.
+    fn ast_state_is_active(&self) -> bool {
+        // While pushed the box lives in the thread-local, so the only identity
+        // we can compare against is "something is installed". A stronger check
+        // would require keeping a raw alias to the box across the move.
+        !ast_alloc::active_state_id().is_null()
+    }
+
     pub fn enter(&mut self) -> Scope<'_> {
         // Zig: this.stack_allocator = SFA{ .fallback_allocator = arena, .. };
         //      this.bump_allocator = this.stack_allocator.get();
@@ -134,12 +185,6 @@ impl ASTMemoryAllocator {
         // `RuntimeTranspilerStore::run()` calls grows unboundedly (one full
         // AST worth of nodes per import).
         //
-        // This is the `AST_HEAP` for `AstAlloc` data (`named_exports` etc.)
-        // — bulk-free-only. `9ae903e` made this `reset_retain_with_limit(8M)`
-        // but `AstAlloc` bypasses `track_alloc` (raw `mi_heap_malloc`), so
-        // the limit never trips and every previous import's AST data leaks.
-        // See `store_ast_alloc_heap::reset` for the full analysis.
-        //
         // ...but a *pristine* arena (fresh from `new()` / the thread-local
         // pool, or just `reset()`) has nothing to discard, so the
         // `mi_heap_destroy` + `mi_heap_new` round-trip is skipped in that case
@@ -147,6 +192,7 @@ impl ASTMemoryAllocator {
         // `enter()` once, and drop it).
         if self.arena_dirty {
             self.arena.reset();
+            self.reset_ast_state();
         }
         self.arena_dirty = true;
         self.previous = ptr::null_mut();
@@ -154,7 +200,8 @@ impl ASTMemoryAllocator {
             current: Some(self),
             previous: Some(stmt::data::Store::memory_allocator()),
             previous_logger: ptr::null(),
-            previous_heap: ptr::null_mut(),
+            previous_ast_state: None,
+            entered: false,
         };
         ast_scope.enter();
         ast_scope
@@ -166,6 +213,7 @@ impl ASTMemoryAllocator {
         // Skip the `mi_heap_destroy` + `mi_heap_new` when already pristine.
         if self.arena_dirty {
             self.arena.reset();
+            self.reset_ast_state();
             self.arena_dirty = false;
         }
     }
@@ -177,7 +225,14 @@ impl ASTMemoryAllocator {
     /// thread`) keep calling [`Self::reset`].
     pub fn reset_retain_with_limit(&mut self, limit: usize) {
         if self.arena_dirty {
-            self.arena.reset_retain_with_limit(limit);
+            // Mirror the arena's retain-or-recycle decision for the `AstAlloc`
+            // state: when the arena heap is retained, the previous iteration's
+            // `AstVec` buffers survive too (callers like `--define` hold
+            // `StoreRef`s across this reset); when it is recycled, they are
+            // bulk-freed alongside it.
+            if !self.arena.reset_retain_with_limit(limit) {
+                self.reset_ast_state();
+            }
             self.arena_dirty = false;
         }
     }
@@ -187,12 +242,18 @@ impl ASTMemoryAllocator {
         // directly into it across many modules with no intervening `reset()`).
         self.arena_dirty = true;
         self.previous_logger = crate::data_store_override();
-        self.previous_heap = bun_alloc::ast_alloc::thread_heap();
         let arena: *const Arena = &raw const self.arena;
         stmt::data::Store::set_memory_allocator(std::ptr::from_mut::<Self>(self));
         expr::data::Store::set_memory_allocator(std::ptr::from_mut::<Self>(self));
         crate::set_data_store_override(arena);
-        bun_alloc::ast_alloc::set_thread_heap(self.arena.heap_ptr());
+        if !self.ast_pushed {
+            let state = self.ast_state.take().unwrap_or_else(ast_alloc::acquire_state);
+            self.previous_ast_state = ast_alloc::swap_state(Some(state));
+            self.ast_pushed = true;
+        }
+        // else: already installed (`push()` without an intervening `pop()`,
+        // e.g. the package manager's `MiniStore` re-arms per workspace child).
+        // The installed state and the saved previous occupant stay as they are.
     }
 
     pub fn pop(&mut self) {
@@ -201,10 +262,20 @@ impl ASTMemoryAllocator {
         stmt::data::Store::set_memory_allocator(prev);
         expr::data::Store::set_memory_allocator(prev);
         crate::set_data_store_override(self.previous_logger);
-        bun_alloc::ast_alloc::set_thread_heap(self.previous_heap);
+        if self.ast_pushed {
+            // Take the state back from the thread-local and restore whatever
+            // was installed before `push()`. The state's contents (the AST the
+            // bundler worker just built) stay alive in the box until the owner
+            // resets or drops this allocator.
+            self.ast_state = ast_alloc::swap_state(self.previous_ast_state.take());
+            self.ast_pushed = false;
+            debug_assert!(
+                self.ast_state.is_some(),
+                "ASTMemoryAllocator::pop: the pushed AstAllocState was uninstalled by someone else"
+            );
+        }
         self.previous = ptr::null_mut();
         self.previous_logger = ptr::null();
-        self.previous_heap = ptr::null_mut();
     }
 
     #[inline]
@@ -243,7 +314,14 @@ pub struct Scope<'a> {
     current: Option<&'a mut ASTMemoryAllocator>,
     previous: Option<*mut ASTMemoryAllocator>,
     previous_logger: *const Arena,
-    previous_heap: *mut bun_alloc::mimalloc::Heap,
+    /// The `AST_ALLOC` occupant displaced by [`Self::enter`], restored by
+    /// [`Self::exit`].
+    previous_ast_state: Option<Box<AstAllocState>>,
+    /// `true` between `enter()` and the first `exit()`. Makes `exit()`
+    /// idempotent (Zig callers write `defer ast_scope.exit()` *and* the Rust
+    /// port runs it again from `Drop`) and makes dropping a never-entered
+    /// `Scope::default()` a no-op instead of clobbering the thread-locals.
+    entered: bool,
 }
 
 impl<'a> Default for Scope<'a> {
@@ -252,7 +330,8 @@ impl<'a> Default for Scope<'a> {
             current: None,
             previous: None,
             previous_logger: ptr::null(),
-            previous_heap: ptr::null_mut(),
+            previous_ast_state: None,
+            entered: false,
         }
     }
 }
@@ -262,31 +341,37 @@ impl<'a> Scope<'a> {
         debug_assert!(
             expr::data::Store::memory_allocator() == stmt::data::Store::memory_allocator()
         );
+        debug_assert!(!self.entered);
 
         self.previous = Some(expr::data::Store::memory_allocator());
         self.previous_logger = crate::data_store_override();
-        self.previous_heap = bun_alloc::ast_alloc::thread_heap();
+        self.entered = true;
 
-        let (current, arena, heap): (
-            *mut ASTMemoryAllocator,
-            *const Arena,
-            *mut bun_alloc::mimalloc::Heap,
-        ) = match &mut self.current {
+        let (current, arena): (*mut ASTMemoryAllocator, *const Arena) = match &mut self.current {
             Some(r) => {
                 let arena: *const Arena = &raw const r.arena;
-                (
-                    std::ptr::from_mut::<ASTMemoryAllocator>(*r),
-                    arena,
-                    r.arena.heap_ptr(),
-                )
+                // Install this allocator's `AstAlloc` state for the scope.
+                let state = r
+                    .ast_state
+                    .take()
+                    .unwrap_or_else(ast_alloc::acquire_state);
+                self.previous_ast_state = ast_alloc::swap_state(Some(state));
+                r.ast_pushed = true;
+                (std::ptr::from_mut::<ASTMemoryAllocator>(*r), arena)
             }
-            None => (ptr::null_mut(), ptr::null(), ptr::null_mut()),
+            None => {
+                // Block-store scope with no `ASTMemoryAllocator`: detach
+                // `AstAlloc` to the global-mimalloc fallback. Callers that
+                // want arena-lifetime `AstVec`s here install their own state
+                // (`ScopedAstAlloc` in `transpile_source_code`).
+                self.previous_ast_state = ast_alloc::swap_state(None);
+                (ptr::null_mut(), ptr::null())
+            }
         };
 
         expr::data::Store::set_memory_allocator(current);
         stmt::data::Store::set_memory_allocator(current);
         crate::set_data_store_override(arena);
-        bun_alloc::ast_alloc::set_thread_heap(heap);
 
         if current.is_null() {
             stmt::data::Store::begin();
@@ -294,30 +379,37 @@ impl<'a> Scope<'a> {
         }
     }
 
-    pub fn exit(&self) {
+    pub fn exit(&mut self) {
+        // Idempotent: Zig callers write `defer ast_scope.exit()` immediately
+        // after `enter()`, and the Rust `Drop` impl calls this again.
+        if !self.entered {
+            return;
+        }
+        self.entered = false;
         let prev = self.previous.unwrap_or(ptr::null_mut());
         expr::data::Store::set_memory_allocator(prev);
         stmt::data::Store::set_memory_allocator(prev);
         crate::set_data_store_override(self.previous_logger);
-        if !prev.is_null() {
-            // Returning into an outer `ASTMemoryAllocator` scope: its arena's
-            // `heap_ptr()` cannot have changed while it was suspended
-            // (`Store::reset` early-returns while `MEMORY_ALLOCATOR` is set,
-            // and the outer arena is only `reset()` by its own `enter()`), so
-            // the snapshot is valid.
-            bun_alloc::ast_alloc::set_thread_heap(self.previous_heap);
-        } else {
-            // Returning into the raw `Stmt.Data.Store` block-store (no
-            // `ASTMemoryAllocator` was active before this scope). The
-            // `store_ast_alloc_heap` side arena owns `AST_HEAP` there. We
-            // cannot trust `self.previous_heap`: if `enter()` ran
-            // `Store::begin()` → `store_ast_alloc_heap::reset()`, that
-            // `mi_heap_destroy`+rebuild left the snapshot dangling. And we
-            // cannot leave `AST_HEAP` as-is: when `current` was `Some`, it
-            // still points at *this* scope's arena, which the caller is about
-            // to drop. Re-read the side arena's live heap (or null if none
-            // exists yet — i.e. no block-store on this thread).
-            bun_alloc::ast_alloc::set_thread_heap(crate::store_ast_alloc_heap::current_heap());
+        // Restore the `AST_ALLOC` occupant that was displaced by `enter()`.
+        // Ownership of the displaced box travelled into `previous_ast_state`,
+        // so this is exact regardless of how the outer scope's state was
+        // reset in the meantime (the box address never changes).
+        let installed = ast_alloc::swap_state(self.previous_ast_state.take());
+        match self.current.as_deref_mut() {
+            Some(r) => {
+                debug_assert!(
+                    installed.is_some(),
+                    "ASTMemoryAllocator::Scope::exit: the installed AstAllocState was taken by someone else"
+                );
+                r.ast_state = installed;
+                r.ast_pushed = false;
+            }
+            None => {
+                // `Scope::default()` installed nothing, so nothing should come
+                // back out. (A `ScopedAstAlloc` opened inside this scope must
+                // have been dropped already — it is declared after the scope.)
+                debug_assert!(installed.is_none());
+            }
         }
     }
 }
@@ -325,8 +417,8 @@ impl<'a> Scope<'a> {
 // Zig callers write `defer ast_scope.exit()` immediately after `enter()`;
 // porting that as RAII so `let _scope = alloc.enter();` restores the previous
 // `Expr/Stmt.Data.Store.memory_allocator` on every return path. `exit()` is
-// idempotent (just rewrites the thread-locals to `previous`), so an explicit
-// `.exit()` followed by Drop is harmless.
+// idempotent (guarded by `entered`), so an explicit `.exit()` followed by Drop
+// is harmless.
 impl<'a> Drop for Scope<'a> {
     fn drop(&mut self) {
         self.exit();

--- a/src/ast/ast_memory_allocator.rs
+++ b/src/ast/ast_memory_allocator.rs
@@ -52,18 +52,11 @@ fn return_pooled_arena(arena: Arena) {
 
 pub struct ASTMemoryAllocator {
     // Zig fields `stack_arena: SFA` + `bump_std.mem.Allocator param` (the vtable into
-    // the SFA) collapse to a single bump arena. Zig's SFA *borrowed* the
-    // caller's per-job arena as its fallback; the Rust port grew an owned
-    // arena here, which doubled the `mi_heap_new`/`mi_heap_destroy` count per
-    // transpile job. [`Self::borrowing`] restores the Zig shape for callers
-    // whose arena strictly outlives this allocator; `external_arena` is null
-    // for owned instances.
+    // the SFA) collapse to a single bump arena.
     arena: Arena,
-    /// When non-null, the allocator routes every allocation to this
-    /// caller-owned arena instead of `self.arena`, and `Drop`/`reset` never
-    /// destroy or pool anything — the caller owns the arena's lifecycle. The
-    /// pointee must outlive `self` (the [`Self::borrowing`] contract; same
-    /// shape as `data_store_override`).
+    /// When non-null, allocations route to this caller-owned arena instead of
+    /// `self.arena` and `Drop`/`reset` never destroy or pool anything. Must
+    /// outlive `self` ([`Self::borrowing`] contract).
     external_arena: *const Arena,
     /// `true` once a scope on this instance armed `arena` for allocation (via
     /// [`Self::enter`] / [`Self::push`]) since the last reset. Lets
@@ -72,20 +65,15 @@ pub struct ASTMemoryAllocator {
     /// for the per-module callers, each of which takes a freshly-pooled (clean)
     /// arena and arms it exactly once.
     arena_dirty: bool,
-    /// The `AstAlloc` allocation state for this allocator's scope (`AstVec`
-    /// buffers: `named_exports`, `DeclList`, `PropertyList`, …). Owned here
-    /// while no scope is active; moved into the `AST_ALLOC` thread-local by
-    /// [`Self::push`] / `Scope::enter` and moved back by [`Self::pop`] /
-    /// `Scope::exit`. Lazily acquired on the first push. `None` both before
-    /// the first push and while pushed — `ast_pushed` disambiguates.
+    /// The `AstAlloc` state for this allocator's scope. Owned here while no
+    /// scope is active; in the `AST_ALLOC` thread-local while pushed
+    /// (`ast_pushed` disambiguates).
     ast_state: Option<Box<AstAllocState>>,
-    /// `true` while `ast_state` is installed in the `AST_ALLOC` thread-local
-    /// (i.e. the box is *not* in `ast_state`).
+    /// `true` while `ast_state` is installed in the `AST_ALLOC` thread-local.
     ast_pushed: bool,
     previous: *mut ASTMemoryAllocator,
     previous_logger: *const Arena,
-    /// The `AST_ALLOC` occupant displaced by [`Self::push`], restored by
-    /// [`Self::pop`].
+    /// The `AST_ALLOC` occupant displaced by `push()`, restored by `pop()`.
     previous_ast_state: Option<Box<AstAllocState>>,
 }
 
@@ -106,13 +94,8 @@ impl Default for ASTMemoryAllocator {
 
 impl Drop for ASTMemoryAllocator {
     fn drop(&mut self) {
-        // Park the (cursor-reset) `AstAlloc` state box in the thread-local
-        // spare slot *before* touching the arena: the state's spill pointer
-        // targets `self.arena()`'s heap, so it must be cleared before that
-        // heap can be destroyed below. If the state is still installed (push
-        // without pop), leave it where it is: the thread-local owns the box,
-        // so dropping nothing here turns a scope imbalance into a leak rather
-        // than a use-after-free.
+        // Recycle the AstAlloc state (whose spill pointer targets the arena's
+        // heap) before the arena can be reset/destroyed below.
         debug_assert!(
             !self.ast_pushed,
             "ASTMemoryAllocator dropped while its AstAllocState is still installed"
@@ -121,8 +104,7 @@ impl Drop for ASTMemoryAllocator {
             ast_alloc::release_state(state);
         }
         if !self.external_arena.is_null() {
-            // Borrowed arena: the caller owns its lifecycle; everything this
-            // allocator put in it is reclaimed when the caller resets/drops it.
+            // Borrowed arena: the caller owns its lifecycle.
             return;
         }
         // Recycle the owned arena for the next `ASTMemoryAllocator` on this
@@ -146,31 +128,18 @@ impl Drop for ASTMemoryAllocator {
 
 impl ASTMemoryAllocator {
     /// Construct with an **owned** arena (recycled via the per-thread pool).
-    ///
-    /// Zig callers wrote `var a: ASTMemoryAllocator = undefined;` then
-    /// `a.enter(arena)` (passing the fallback `std.mem.Allocator`). Callers
-    /// whose `fallback` arena strictly outlives the allocator should use
-    /// [`Self::borrowing`] instead so the job pays for one `mi_heap_t`, not
-    /// two. This constructor remains for callers that `reset()` the allocator
-    /// independently of the passed arena (the bundler worker, `BundleThread`,
-    /// the package manager's `MiniStore`).
+    /// Callers whose `fallback` arena outlives the allocator should use
+    /// [`Self::borrowing`] instead.
     pub fn new(_fallback: &Arena) -> Self {
         Self::default()
     }
 
     /// Construct an allocator that routes every allocation into `arena`
-    /// instead of owning a heap of its own. One transpile job then uses a
-    /// single `mi_heap_t` for the parser scratch, the AST node store, and the
-    /// `AstVec` spill.
-    ///
-    /// Contract: `arena` must strictly outlive the returned allocator (and
-    /// every `Scope` derived from it), and the caller — not this allocator —
-    /// is responsible for resetting/destroying it. Re-`enter()`ing a borrowing
-    /// allocator does **not** free the previous scope's data.
+    /// instead of owning a heap of its own. `arena` must outlive the returned
+    /// allocator (and every `Scope` derived from it); the caller owns its
+    /// reset/destroy.
     pub fn borrowing(arena: &Arena) -> Self {
         Self {
-            // Never allocated from and never pooled; `borrowing_default()`'s
-            // Drop is a no-op.
             arena: Arena::borrowing_default(),
             external_arena: ptr::from_ref(arena),
             arena_dirty: false,
@@ -213,9 +182,8 @@ impl ASTMemoryAllocator {
     }
 
     /// Bulk-free everything allocated through this allocator's `AstAlloc`
-    /// state, wherever the state currently lives (owned here, or installed in
-    /// the thread-local by a `push()` that has not been `pop()`ed — the
-    /// package manager's `MiniStore` re-arms without popping).
+    /// state, wherever the state currently lives (owned here, or installed by
+    /// a `push()` that has not been `pop()`ed).
     fn reset_ast_state(&mut self) {
         if let Some(state) = self.ast_state.as_deref_mut() {
             state.reset();
@@ -228,13 +196,9 @@ impl ASTMemoryAllocator {
         }
     }
 
-    /// Take this allocator's `AstAlloc` state (if any) and recycle it into the
-    /// per-thread spare slot. For owners that are arena-allocated and never
-    /// run `Drop` (the dev server's bundle-setup allocator) — without this the
-    /// 16 KB state box is stranded in the owner's bump chunk when the bundle
-    /// heap is bulk-freed. The AST-node arena is unaffected; only the `AstVec`
-    /// inline chunk is recycled, so call this only once nothing reads `AstVec`s
-    /// allocated under this allocator's scope.
+    /// Take this allocator's `AstAlloc` state (if any) and recycle it. For
+    /// owners that are arena-allocated and never run `Drop`. Call only once
+    /// nothing reads `AstVec`s allocated under this allocator's scope.
     pub fn release_ast_state(&mut self) {
         debug_assert!(
             !self.ast_pushed,
@@ -248,9 +212,6 @@ impl ASTMemoryAllocator {
     /// Debug-only: is the installed `AST_ALLOC` state the one this allocator
     /// pushed? Only meaningful while `ast_pushed`.
     fn ast_state_is_active(&self) -> bool {
-        // While pushed the box lives in the thread-local, so the only identity
-        // we can compare against is "something is installed". A stronger check
-        // would require keeping a raw alias to the box across the move.
         !ast_alloc::active_state_id().is_null()
     }
 
@@ -270,8 +231,7 @@ impl ASTMemoryAllocator {
         // pool, or just `reset()`) has nothing to discard, so the
         // `mi_heap_destroy` + `mi_heap_new` round-trip is skipped in that case
         // (the common one — per-module callers create a fresh instance,
-        // `enter()` once, and drop it). A borrowed arena is never reset here —
-        // its owner decides when its contents die.
+        // `enter()` once, and drop it). A borrowed arena is never reset here.
         if self.arena_dirty {
             self.reset_ast_state();
             if self.external_arena.is_null() {
@@ -317,13 +277,9 @@ impl ASTMemoryAllocator {
                 self.external_arena.is_null(),
                 "reset_retain_with_limit on a borrowing ASTMemoryAllocator"
             );
-            // Mirror the arena's retain-or-recycle decision for the `AstAlloc`
-            // state: when the arena heap is retained, the previous iteration's
-            // `AstVec` buffers (spill blocks in that heap *and* the inline
-            // chunk) survive too — callers like `--define` hold `StoreRef`s
-            // across this reset. When it is recycled, the spill heap is gone:
-            // null the state's pointer to it and rewind the chunk; the next
-            // `push()` re-points the spill at the fresh heap.
+            // The AstAlloc state follows the arena's retain-or-recycle
+            // decision: callers like `--define` hold `StoreRef`s across a
+            // retained reset, so only clear it when the heap is recycled.
             if !self.arena.reset_retain_with_limit(limit) {
                 self.reset_ast_state();
             }
@@ -335,27 +291,28 @@ impl ASTMemoryAllocator {
         // `push()` arms `arena` for allocation (the bundler workers allocate
         // directly into it across many modules with no intervening `reset()`).
         self.arena_dirty = true;
-        self.previous_logger = crate::data_store_override();
         let arena: *const Arena = self.arena_raw();
         stmt::data::Store::set_memory_allocator(std::ptr::from_mut::<Self>(self));
         expr::data::Store::set_memory_allocator(std::ptr::from_mut::<Self>(self));
-        crate::set_data_store_override(arena);
         let spill = self.arena().heap_ptr();
         if !self.ast_pushed {
+            // Capture the outer override only on the first (un-popped) push so
+            // a re-arming `push()` doesn't clobber the saved outer value.
+            self.previous_logger = crate::data_store_override();
+            crate::set_data_store_override(arena);
             let mut state = self
                 .ast_state
                 .take()
                 .unwrap_or_else(ast_alloc::acquire_state);
-            // `AstVec` spill allocations share this allocator's arena — one
-            // `mi_heap_t` per scope, not two.
+            // `AstVec` spill allocations share this allocator's arena.
             state.set_spill_heap(spill);
             self.previous_ast_state = ast_alloc::swap_state(Some(state));
             self.ast_pushed = true;
         } else {
-            // Already installed (`push()` without an intervening `pop()`, e.g.
-            // the package manager's `MiniStore` re-arms per workspace child).
-            // Re-point the installed state's spill at the (possibly just
-            // recycled) arena heap; the saved previous occupant stays as is.
+            // Re-arming push (no intervening `pop()`, e.g. `MiniStore`):
+            // re-publish the override and re-point the spill at the (possibly
+            // recycled) arena heap.
+            crate::set_data_store_override(arena);
             ast_alloc::set_active_spill_heap(spill);
         }
     }
@@ -367,9 +324,7 @@ impl ASTMemoryAllocator {
         expr::data::Store::set_memory_allocator(prev);
         crate::set_data_store_override(self.previous_logger);
         if self.ast_pushed {
-            // Take the state back from the thread-local and restore whatever
-            // was installed before `push()`. The state's contents (the AST the
-            // bundler worker just built) stay alive in the box until the owner
+            // Take the state back; its contents stay alive until the owner
             // resets or drops this allocator.
             self.ast_state = ast_alloc::swap_state(self.previous_ast_state.take());
             self.ast_pushed = false;
@@ -419,13 +374,10 @@ pub struct Scope<'a> {
     current: Option<&'a mut ASTMemoryAllocator>,
     previous: Option<*mut ASTMemoryAllocator>,
     previous_logger: *const Arena,
-    /// The `AST_ALLOC` occupant displaced by [`Self::enter`], restored by
-    /// [`Self::exit`].
+    /// The `AST_ALLOC` occupant displaced by `enter()`, restored by `exit()`.
     previous_ast_state: Option<Box<AstAllocState>>,
-    /// `true` between `enter()` and the first `exit()`. Makes `exit()`
-    /// idempotent (Zig callers write `defer ast_scope.exit()` *and* the Rust
-    /// port runs it again from `Drop`) and makes dropping a never-entered
-    /// `Scope::default()` a no-op instead of clobbering the thread-locals.
+    /// `true` between `enter()` and the first `exit()`; makes `exit()`
+    /// idempotent and a never-entered `Scope::default()` drop a no-op.
     entered: bool,
 }
 
@@ -454,10 +406,12 @@ impl<'a> Scope<'a> {
 
         let (current, arena): (*mut ASTMemoryAllocator, *const Arena) = match &mut self.current {
             Some(r) => {
+                debug_assert!(
+                    !r.ast_pushed,
+                    "ASTMemoryAllocator::enter while its AstAllocState is already installed (push without pop)"
+                );
                 let arena: *const Arena = r.arena_raw();
-                // Install this allocator's `AstAlloc` state for the scope.
-                // `AstVec` spill allocations share the allocator's arena — one
-                // `mi_heap_t` per scope, not two.
+                // Install this allocator's `AstAlloc` state; spill shares its arena.
                 let mut state = r.ast_state.take().unwrap_or_else(ast_alloc::acquire_state);
                 state.set_spill_heap(r.arena().heap_ptr());
                 self.previous_ast_state = ast_alloc::swap_state(Some(state));
@@ -466,9 +420,7 @@ impl<'a> Scope<'a> {
             }
             None => {
                 // Block-store scope with no `ASTMemoryAllocator`: detach
-                // `AstAlloc` to the global-mimalloc fallback. Callers that
-                // want arena-lifetime `AstVec`s here install their own state
-                // (`ScopedAstAlloc` in `transpile_source_code`).
+                // `AstAlloc` to the global-mimalloc fallback.
                 self.previous_ast_state = ast_alloc::swap_state(None);
                 (ptr::null_mut(), ptr::null())
             }
@@ -485,8 +437,6 @@ impl<'a> Scope<'a> {
     }
 
     pub fn exit(&mut self) {
-        // Idempotent: Zig callers write `defer ast_scope.exit()` immediately
-        // after `enter()`, and the Rust `Drop` impl calls this again.
         if !self.entered {
             return;
         }
@@ -495,10 +445,7 @@ impl<'a> Scope<'a> {
         expr::data::Store::set_memory_allocator(prev);
         stmt::data::Store::set_memory_allocator(prev);
         crate::set_data_store_override(self.previous_logger);
-        // Restore the `AST_ALLOC` occupant that was displaced by `enter()`.
-        // Ownership of the displaced box travelled into `previous_ast_state`,
-        // so this is exact regardless of how the outer scope's state was
-        // reset in the meantime (the box address never changes).
+        // Restore the `AST_ALLOC` occupant displaced by `enter()`.
         let installed = ast_alloc::swap_state(self.previous_ast_state.take());
         match self.current.as_deref_mut() {
             Some(r) => {
@@ -510,9 +457,7 @@ impl<'a> Scope<'a> {
                 r.ast_pushed = false;
             }
             None => {
-                // `Scope::default()` installed nothing, so nothing should come
-                // back out. (A `ScopedAstAlloc` opened inside this scope must
-                // have been dropped already — it is declared after the scope.)
+                // `Scope::default()` installed nothing, so nothing should come back out.
                 debug_assert!(installed.is_none());
             }
         }

--- a/src/ast/ast_memory_allocator.rs
+++ b/src/ast/ast_memory_allocator.rs
@@ -52,11 +52,19 @@ fn return_pooled_arena(arena: Arena) {
 
 pub struct ASTMemoryAllocator {
     // Zig fields `stack_arena: SFA` + `bump_std.mem.Allocator param` (the vtable into
-    // the SFA) collapse to a single bump arena. The `arena: std.mem.Allocator` fallback
-    // field is dropped — bumpalo uses the global arena implicitly.
-    // TODO(port): if any caller passed a non-default arena into `enter` /
-    // `init_without_stack`, that routing is lost here; revisit.
+    // the SFA) collapse to a single bump arena. Zig's SFA *borrowed* the
+    // caller's per-job arena as its fallback; the Rust port grew an owned
+    // arena here, which doubled the `mi_heap_new`/`mi_heap_destroy` count per
+    // transpile job. [`Self::borrowing`] restores the Zig shape for callers
+    // whose arena strictly outlives this allocator; `external_arena` is null
+    // for owned instances.
     arena: Arena,
+    /// When non-null, the allocator routes every allocation to this
+    /// caller-owned arena instead of `self.arena`, and `Drop`/`reset` never
+    /// destroy or pool anything — the caller owns the arena's lifecycle. The
+    /// pointee must outlive `self` (the [`Self::borrowing`] contract; same
+    /// shape as `data_store_override`).
+    external_arena: *const Arena,
     /// `true` once a scope on this instance armed `arena` for allocation (via
     /// [`Self::enter`] / [`Self::push`]) since the last reset. Lets
     /// [`Self::enter`] / [`Self::reset`] skip the `mi_heap_destroy` +
@@ -85,6 +93,7 @@ impl Default for ASTMemoryAllocator {
     fn default() -> Self {
         Self {
             arena: take_pooled_arena(),
+            external_arena: ptr::null(),
             arena_dirty: false,
             ast_state: None,
             ast_pushed: false,
@@ -97,8 +106,27 @@ impl Default for ASTMemoryAllocator {
 
 impl Drop for ASTMemoryAllocator {
     fn drop(&mut self) {
-        // Recycle the arena for the next `ASTMemoryAllocator` on this thread
-        // (see `ARENA_POOL`). Clean it first so a pooled arena is always
+        // Park the (cursor-reset) `AstAlloc` state box in the thread-local
+        // spare slot *before* touching the arena: the state's spill pointer
+        // targets `self.arena()`'s heap, so it must be cleared before that
+        // heap can be destroyed below. If the state is still installed (push
+        // without pop), leave it where it is: the thread-local owns the box,
+        // so dropping nothing here turns a scope imbalance into a leak rather
+        // than a use-after-free.
+        debug_assert!(
+            !self.ast_pushed,
+            "ASTMemoryAllocator dropped while its AstAllocState is still installed"
+        );
+        if let Some(state) = self.ast_state.take() {
+            ast_alloc::release_state(state);
+        }
+        if !self.external_arena.is_null() {
+            // Borrowed arena: the caller owns its lifecycle; everything this
+            // allocator put in it is reclaimed when the caller resets/drops it.
+            return;
+        }
+        // Recycle the owned arena for the next `ASTMemoryAllocator` on this
+        // thread (see `ARENA_POOL`). Clean it first so a pooled arena is always
         // pristine — `push()` callers (the bundler workers) allocate straight
         // into it with no intervening `reset()`. By the time this runs nothing
         // aliases `self.arena`: `enter()`'s returned `Scope` borrows `&mut
@@ -113,39 +141,75 @@ impl Drop for ASTMemoryAllocator {
         // arena behind so the field's own `Drop` does nothing.
         let arena = core::mem::replace(&mut self.arena, Arena::borrowing_default());
         return_pooled_arena(arena);
-        // Bulk-free the `AstAlloc` state's heap and park the box in the
-        // thread-local spare slot. If the state is still installed (push
-        // without pop), leave it where it is: the thread-local owns the box,
-        // so dropping nothing here turns a scope imbalance into a leak rather
-        // than a use-after-free.
-        debug_assert!(
-            !self.ast_pushed,
-            "ASTMemoryAllocator dropped while its AstAllocState is still installed"
-        );
-        if let Some(state) = self.ast_state.take() {
-            ast_alloc::release_state(state);
-        }
     }
 }
 
 impl ASTMemoryAllocator {
-    /// Construct a fresh arena.
+    /// Construct with an **owned** arena (recycled via the per-thread pool).
     ///
     /// Zig callers wrote `var a: ASTMemoryAllocator = undefined;` then
-    /// `a.enter(arena)` (passing the fallback `std.mem.Allocator`). In the
-    /// Rust port the SFA + fallback collapse to a single internal `Arena`, so
-    /// the passed arena is currently unused — kept for call-site shape compat.
-    // TODO(port): if the parser bump arena is ever routed through here instead
-    // of allocating a fresh one, thread `_fallback` into `self.arena`.
+    /// `a.enter(arena)` (passing the fallback `std.mem.Allocator`). Callers
+    /// whose `fallback` arena strictly outlives the allocator should use
+    /// [`Self::borrowing`] instead so the job pays for one `mi_heap_t`, not
+    /// two. This constructor remains for callers that `reset()` the allocator
+    /// independently of the passed arena (the bundler worker, `BundleThread`,
+    /// the package manager's `MiniStore`).
     pub fn new(_fallback: &Arena) -> Self {
-        // PERF(port): was stack-fallback — profile
         Self::default()
+    }
+
+    /// Construct an allocator that routes every allocation into `arena`
+    /// instead of owning a heap of its own. One transpile job then uses a
+    /// single `mi_heap_t` for the parser scratch, the AST node store, and the
+    /// `AstVec` spill.
+    ///
+    /// Contract: `arena` must strictly outlive the returned allocator (and
+    /// every `Scope` derived from it), and the caller — not this allocator —
+    /// is responsible for resetting/destroying it. Re-`enter()`ing a borrowing
+    /// allocator does **not** free the previous scope's data.
+    pub fn borrowing(arena: &Arena) -> Self {
+        Self {
+            // Never allocated from and never pooled; `borrowing_default()`'s
+            // Drop is a no-op.
+            arena: Arena::borrowing_default(),
+            external_arena: ptr::from_ref(arena),
+            arena_dirty: false,
+            ast_state: None,
+            ast_pushed: false,
+            previous: ptr::null_mut(),
+            previous_logger: ptr::null(),
+            previous_ast_state: None,
+        }
     }
 
     /// Zig: `var a: ASTMemoryAllocator = undefined; a.initWithoutStack(arena);`
     /// — collapsed to a constructor that returns a ready instance.
     pub fn new_without_stack(_fallback: &Arena) -> Self {
         Self::default()
+    }
+
+    /// The arena every allocation routes to: the caller-owned one for
+    /// [`Self::borrowing`] instances, else the owned pooled one.
+    #[inline]
+    fn arena(&self) -> &Arena {
+        if self.external_arena.is_null() {
+            &self.arena
+        } else {
+            // SAFETY: `borrowing()`'s contract — the pointee strictly outlives
+            // `self`.
+            unsafe { &*self.external_arena }
+        }
+    }
+
+    /// Raw pointer form of [`Self::arena`] for the `data_store_override`
+    /// thread-local (which stores `*const Arena`).
+    #[inline]
+    fn arena_raw(&self) -> *const Arena {
+        if self.external_arena.is_null() {
+            &raw const self.arena
+        } else {
+            self.external_arena
+        }
     }
 
     /// Bulk-free everything allocated through this allocator's `AstAlloc`
@@ -189,10 +253,13 @@ impl ASTMemoryAllocator {
         // pool, or just `reset()`) has nothing to discard, so the
         // `mi_heap_destroy` + `mi_heap_new` round-trip is skipped in that case
         // (the common one — per-module callers create a fresh instance,
-        // `enter()` once, and drop it).
+        // `enter()` once, and drop it). A borrowed arena is never reset here —
+        // its owner decides when its contents die.
         if self.arena_dirty {
-            self.arena.reset();
             self.reset_ast_state();
+            if self.external_arena.is_null() {
+                self.arena.reset();
+            }
         }
         self.arena_dirty = true;
         self.previous = ptr::null_mut();
@@ -212,8 +279,12 @@ impl ASTMemoryAllocator {
         // PERF(port): was stack-fallback — profile
         // Skip the `mi_heap_destroy` + `mi_heap_new` when already pristine.
         if self.arena_dirty {
-            self.arena.reset();
+            // The AST state's spill pointer targets the arena's heap; null it
+            // before that heap is destroyed.
             self.reset_ast_state();
+            if self.external_arena.is_null() {
+                self.arena.reset();
+            }
             self.arena_dirty = false;
         }
     }
@@ -225,11 +296,17 @@ impl ASTMemoryAllocator {
     /// thread`) keep calling [`Self::reset`].
     pub fn reset_retain_with_limit(&mut self, limit: usize) {
         if self.arena_dirty {
+            debug_assert!(
+                self.external_arena.is_null(),
+                "reset_retain_with_limit on a borrowing ASTMemoryAllocator"
+            );
             // Mirror the arena's retain-or-recycle decision for the `AstAlloc`
             // state: when the arena heap is retained, the previous iteration's
-            // `AstVec` buffers survive too (callers like `--define` hold
-            // `StoreRef`s across this reset); when it is recycled, they are
-            // bulk-freed alongside it.
+            // `AstVec` buffers (spill blocks in that heap *and* the inline
+            // chunk) survive too — callers like `--define` hold `StoreRef`s
+            // across this reset. When it is recycled, the spill heap is gone:
+            // null the state's pointer to it and rewind the chunk; the next
+            // `push()` re-points the spill at the fresh heap.
             if !self.arena.reset_retain_with_limit(limit) {
                 self.reset_ast_state();
             }
@@ -242,21 +319,28 @@ impl ASTMemoryAllocator {
         // directly into it across many modules with no intervening `reset()`).
         self.arena_dirty = true;
         self.previous_logger = crate::data_store_override();
-        let arena: *const Arena = &raw const self.arena;
+        let arena: *const Arena = self.arena_raw();
         stmt::data::Store::set_memory_allocator(std::ptr::from_mut::<Self>(self));
         expr::data::Store::set_memory_allocator(std::ptr::from_mut::<Self>(self));
         crate::set_data_store_override(arena);
+        let spill = self.arena().heap_ptr();
         if !self.ast_pushed {
-            let state = self
+            let mut state = self
                 .ast_state
                 .take()
                 .unwrap_or_else(ast_alloc::acquire_state);
+            // `AstVec` spill allocations share this allocator's arena — one
+            // `mi_heap_t` per scope, not two.
+            state.set_spill_heap(spill);
             self.previous_ast_state = ast_alloc::swap_state(Some(state));
             self.ast_pushed = true;
+        } else {
+            // Already installed (`push()` without an intervening `pop()`, e.g.
+            // the package manager's `MiniStore` re-arms per workspace child).
+            // Re-point the installed state's spill at the (possibly just
+            // recycled) arena heap; the saved previous occupant stays as is.
+            ast_alloc::set_active_spill_heap(spill);
         }
-        // else: already installed (`push()` without an intervening `pop()`,
-        // e.g. the package manager's `MiniStore` re-arms per workspace child).
-        // The installed state and the saved previous occupant stay as they are.
     }
 
     pub fn pop(&mut self) {
@@ -286,7 +370,7 @@ impl ASTMemoryAllocator {
         // Zig: `this.bump_allocator.create(ValueType) catch unreachable; ptr.* = value;`
         // bumpalo's `alloc` aborts on OOM, matching `catch unreachable`.
         // SAFETY: bumpalo never returns null.
-        crate::StoreRef::from_bump(self.arena.alloc(value))
+        crate::StoreRef::from_bump(self.arena().alloc(value))
     }
 
     /// Zig: `this.stack_allocator.get()` — the `std.mem.Allocator` vtable into
@@ -294,13 +378,13 @@ impl ASTMemoryAllocator {
     /// `bump_allocator` collapse to the single `Arena`, so this returns it.
     #[inline]
     pub fn stack_allocator(&self) -> &Arena {
-        &self.arena
+        self.arena()
     }
 
     /// Alias for callers that addressed the Zig `bump_allocator` field.
     #[inline]
     pub fn bump_allocator(&self) -> &Arena {
-        &self.arena
+        self.arena()
     }
 
     /// Initialize ASTMemoryAllocator as `undefined`, and call this.
@@ -309,6 +393,7 @@ impl ASTMemoryAllocator {
         // `arena`. With bumpalo there is no stack buffer either way; just (re)initialize.
         // PERF(port): was stack-fallback — profile
         self.arena = Arena::new();
+        self.external_arena = ptr::null();
         self.arena_dirty = false;
     }
 }
@@ -352,9 +437,12 @@ impl<'a> Scope<'a> {
 
         let (current, arena): (*mut ASTMemoryAllocator, *const Arena) = match &mut self.current {
             Some(r) => {
-                let arena: *const Arena = &raw const r.arena;
+                let arena: *const Arena = r.arena_raw();
                 // Install this allocator's `AstAlloc` state for the scope.
-                let state = r.ast_state.take().unwrap_or_else(ast_alloc::acquire_state);
+                // `AstVec` spill allocations share the allocator's arena — one
+                // `mi_heap_t` per scope, not two.
+                let mut state = r.ast_state.take().unwrap_or_else(ast_alloc::acquire_state);
+                state.set_spill_heap(r.arena().heap_ptr());
                 self.previous_ast_state = ast_alloc::swap_state(Some(state));
                 r.ast_pushed = true;
                 (std::ptr::from_mut::<ASTMemoryAllocator>(*r), arena)

--- a/src/ast/ast_memory_allocator.rs
+++ b/src/ast/ast_memory_allocator.rs
@@ -204,6 +204,11 @@ impl ASTMemoryAllocator {
             !self.ast_pushed,
             "release_ast_state while the AstAllocState is still installed"
         );
+        if self.ast_pushed {
+            // Still installed in the thread-local; releasing here would let the
+            // next scope reuse storage the current scope still writes to.
+            return;
+        }
         if let Some(state) = self.ast_state.take() {
             ast_alloc::release_state(state);
         }
@@ -217,6 +222,9 @@ impl ASTMemoryAllocator {
             !self.ast_pushed,
             "take_ast_state while the AstAllocState is still installed"
         );
+        if self.ast_pushed {
+            return None;
+        }
         self.ast_state.take()
     }
 

--- a/src/ast/ast_memory_allocator.rs
+++ b/src/ast/ast_memory_allocator.rs
@@ -228,6 +228,23 @@ impl ASTMemoryAllocator {
         }
     }
 
+    /// Take this allocator's `AstAlloc` state (if any) and recycle it into the
+    /// per-thread spare slot. For owners that are arena-allocated and never
+    /// run `Drop` (the dev server's bundle-setup allocator) — without this the
+    /// 16 KB state box is stranded in the owner's bump chunk when the bundle
+    /// heap is bulk-freed. The AST-node arena is unaffected; only the `AstVec`
+    /// inline chunk is recycled, so call this only once nothing reads `AstVec`s
+    /// allocated under this allocator's scope.
+    pub fn release_ast_state(&mut self) {
+        debug_assert!(
+            !self.ast_pushed,
+            "release_ast_state while the AstAllocState is still installed"
+        );
+        if let Some(state) = self.ast_state.take() {
+            ast_alloc::release_state(state);
+        }
+    }
+
     /// Debug-only: is the installed `AST_ALLOC` state the one this allocator
     /// pushed? Only meaningful while `ast_pushed`.
     fn ast_state_is_active(&self) -> bool {

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -2360,10 +2360,11 @@ impl Data {
     /// Deep-clone this subtree into `bump`.
     ///
     /// Nodes go into `bump`; embedded `AstVec`s (`items`/`properties`/…)
-    /// allocate via `AstAlloc`, which reads `thread_heap()`. If a per-parse
-    /// `ASTMemoryAllocator` scope is active that heap is `reset()` while the
-    /// cloned tree (e.g. `WorkspacePackageJSONCache`) still references the
-    /// buffers — UAF. This entry point installs a [`DetachAstHeap`] guard so
+    /// allocate via `AstAlloc`, which reads the thread's active allocation
+    /// state. If a per-parse `ASTMemoryAllocator` scope is active that state
+    /// is bulk-freed while the cloned tree (e.g. `WorkspacePackageJSONCache`)
+    /// still references the buffers — UAF. This entry point installs a
+    /// [`DetachAstHeap`] guard so
     /// those vecs land on global mimalloc. The guard is installed once here
     /// and at [`Expr::deep_clone`]; the recursive body goes through
     /// `*_no_detach` so we don't pay 3 TLS ops per node.

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -3225,84 +3225,72 @@ impl<T> Drop for DebugOnlyDisablerScope<T> {
     }
 }
 
-/// Per-thread side `MimallocArena` that backs `AstAlloc` while the bundler's
-/// `Stmt.Data.Store` / `Expr.Data.Store` block-store is active and **no**
-/// `ASTMemoryAllocator` scope is in effect. See `NewStore::reset` for the
-/// leak this closes.
+/// Per-thread side [`bun_alloc::ast_alloc::AstAllocState`] that backs
+/// `AstAlloc` while the bundler's `Stmt.Data.Store` / `Expr.Data.Store`
+/// block-store is active and **no** `ASTMemoryAllocator` scope is in effect.
+/// See `NewStore::reset` for the leak this closes.
 pub mod store_ast_alloc_heap {
     use core::cell::Cell;
     use core::ptr;
 
-    use bun_alloc::MimallocArena;
+    use bun_alloc::ast_alloc::{self, AstAllocState};
 
+    /// Address of this thread's installed side state — the "entered" flag and
+    /// the identity used to assert that `reset()`/`exit()` operate on the
+    /// state this module installed (the box itself lives in the `AST_ALLOC`
+    /// thread-local while entered, so it cannot be reached through a field
+    /// here). Null when not entered. Never dereferenced.
     #[thread_local]
-    static ARENA: Cell<*mut MimallocArena> = Cell::new(ptr::null_mut());
-
-    /// Reborrow the thread-local arena. Centralises the back-ref deref so
-    /// `enter` / `reset` / `current_heap` stay safe (mirrors
-    /// `Stmt::Data::Store::instance_mut`). `None` iff `enter()` has not run
-    /// (or `exit()` cleared it).
-    #[inline]
-    fn arena_mut<'a>() -> Option<&'a mut MimallocArena> {
-        // SAFETY: `ARENA` is thread-local; the `*mut MimallocArena` it holds is
-        // either null or a live `Box::into_raw` allocation owned by this thread
-        // and freed only by `exit()` (on this thread). No other `&`/`&mut` to
-        // the arena is reachable: this module is its sole accessor.
-        unsafe { ARENA.get().as_mut() }
-    }
+    static STATE_ID: Cell<*const AstAllocState> = Cell::new(ptr::null());
+    /// The `AST_ALLOC` occupant displaced by `enter()`, restored by `exit()`.
+    #[thread_local]
+    static PREVIOUS: Cell<Option<Box<AstAllocState>>> = Cell::new(None);
 
     pub fn enter() {
         if bun_core::getenv_z(bun_core::zstr!("BUN_DISABLE_STORE_AST_HEAP")).is_some() {
             return;
         }
-        let arena = match arena_mut() {
-            Some(a) => a,
-            None => {
-                let p = Box::into_raw(Box::new(MimallocArena::new()));
-                ARENA.set(p);
-                arena_mut().expect("just set")
-            }
-        };
-        bun_alloc::ast_alloc::set_thread_heap(arena.heap_ptr());
+        if !STATE_ID.get().is_null() {
+            // Already entered on this thread; the long-lived side state stays
+            // installed until `exit()`.
+            debug_assert!(core::ptr::eq(ast_alloc::active_state_id(), STATE_ID.get()));
+            return;
+        }
+        let state = ast_alloc::acquire_state();
+        STATE_ID.set(&raw const *state);
+        PREVIOUS.set(ast_alloc::swap_state(Some(state)));
     }
 
     pub fn reset() {
-        let Some(arena) = arena_mut() else {
+        if STATE_ID.get().is_null() {
             enter();
             return;
-        };
-        // This is the `AstAlloc` side-heap holding `Ast.named_exports`,
+        }
+        // This is the `AstAlloc` side state holding `Ast.named_exports`,
         // `AstVec` buffers, etc. — data that is intentionally NEVER `Drop`'d
         // (the whole point of routing through `AstAlloc` is bulk-free here).
-        // `9ae903e` changed this to `reset_retain_with_limit(8M)` to avoid
-        // the per-file `mi_heap_new` bitmap memset, but that is WRONG for
-        // this heap: the previous file's allocations are never individually
-        // freed, so under the limit they accumulate as unreachable garbage.
-        // With `AstAlloc` bypassing `track_alloc` (calls `mi_heap_malloc`
-        // directly via the raw `*mut mi_heap_t`) AND `heap_committed_exceeds`
-        // being unreliable on darwin (OS-backed pages not walked by
-        // `mi_heap_visit_blocks`), the limit never trips → 83→61 MB on
-        // require-cache "long export names". Zig's
-        // `arena.reset(.{.retain_with_limit=..})` is on a BUMP allocator
-        // where reset always rewinds the cursor (= bulk-free); only the
-        // backing buffer is retained. `MimallocArena` is not a bump
-        // allocator, so the only correct mapping is destroy+new.
-        arena.reset();
-        bun_alloc::ast_alloc::set_thread_heap(arena.heap_ptr());
-    }
-
-    #[inline]
-    pub fn current_heap() -> *mut bun_alloc::mimalloc::Heap {
-        arena_mut().map_or(ptr::null_mut(), |a| a.heap_ptr())
+        // The previous file's allocations are never individually freed, so the
+        // only correct per-file reclamation is a full bulk-free (destroy the
+        // spill heap, rewind the inline cursor). The call sites gate this on
+        // `memory_allocator().is_null()`, so the installed state is ours.
+        debug_assert!(
+            core::ptr::eq(ast_alloc::active_state_id(), STATE_ID.get()),
+            "store_ast_alloc_heap::reset while another AstAllocState is installed"
+        );
+        ast_alloc::reset_active_state();
     }
 
     pub fn exit() {
-        let arena = ARENA.replace(ptr::null_mut());
-        bun_alloc::ast_alloc::set_thread_heap(ptr::null_mut());
-        if !arena.is_null() {
-            // SAFETY: `arena` was `Box::into_raw`'d in `enter()` on this
-            // thread and is now being reclaimed exactly once.
-            drop(unsafe { Box::from_raw(arena) });
+        if STATE_ID.get().is_null() {
+            return;
+        }
+        debug_assert!(
+            core::ptr::eq(ast_alloc::active_state_id(), STATE_ID.get()),
+            "store_ast_alloc_heap::exit while another AstAllocState is installed"
+        );
+        STATE_ID.set(ptr::null());
+        if let Some(state) = ast_alloc::swap_state(PREVIOUS.take()) {
+            ast_alloc::release_state(state);
         }
     }
 }

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -3235,25 +3235,25 @@ pub mod store_ast_alloc_heap {
 
     use bun_alloc::ast_alloc::{self, AstAllocState};
 
-    /// Address of this thread's installed side state — the "entered" flag and
-    /// the identity used to assert that `reset()`/`exit()` operate on the
-    /// state this module installed (the box itself lives in the `AST_ALLOC`
-    /// thread-local while entered, so it cannot be reached through a field
-    /// here). Null when not entered. Never dereferenced.
+    /// Address of this thread's installed side state (the "entered" flag and
+    /// the identity check for `reset()`/`exit()`). Never dereferenced.
     #[thread_local]
     static STATE_ID: Cell<*const AstAllocState> = Cell::new(ptr::null());
     /// The `AST_ALLOC` occupant displaced by `enter()`, restored by `exit()`.
     #[thread_local]
     static PREVIOUS: Cell<Option<Box<AstAllocState>>> = Cell::new(None);
 
+    /// `true` iff the state this module installed is the one currently active
+    /// (i.e. no other scope is stacked on top of it).
+    fn owns_active_state() -> bool {
+        core::ptr::eq(ast_alloc::active_state_id(), STATE_ID.get())
+    }
+
     pub fn enter() {
         if bun_core::getenv_z(bun_core::zstr!("BUN_DISABLE_STORE_AST_HEAP")).is_some() {
             return;
         }
         if !STATE_ID.get().is_null() {
-            // Already entered on this thread; the long-lived side state stays
-            // installed until `exit()`.
-            debug_assert!(core::ptr::eq(ast_alloc::active_state_id(), STATE_ID.get()));
             return;
         }
         let state = ast_alloc::acquire_state();
@@ -3266,17 +3266,15 @@ pub mod store_ast_alloc_heap {
             enter();
             return;
         }
-        // This is the `AstAlloc` side state holding `Ast.named_exports`,
-        // `AstVec` buffers, etc. — data that is intentionally NEVER `Drop`'d
-        // (the whole point of routing through `AstAlloc` is bulk-free here).
-        // The previous file's allocations are never individually freed, so the
-        // only correct per-file reclamation is a full bulk-free (destroy the
-        // spill heap, rewind the inline cursor). The call sites gate this on
-        // `memory_allocator().is_null()`, so the installed state is ours.
-        debug_assert!(
-            core::ptr::eq(ast_alloc::active_state_id(), STATE_ID.get()),
-            "store_ast_alloc_heap::reset while another AstAllocState is installed"
-        );
+        // Skip if another scope's state is stacked on top — resetting it
+        // would free that scope's live data.
+        if !owns_active_state() {
+            debug_assert!(
+                false,
+                "store_ast_alloc_heap::reset while another AstAllocState is installed"
+            );
+            return;
+        }
         ast_alloc::reset_active_state();
     }
 
@@ -3284,10 +3282,14 @@ pub mod store_ast_alloc_heap {
         if STATE_ID.get().is_null() {
             return;
         }
-        debug_assert!(
-            core::ptr::eq(ast_alloc::active_state_id(), STATE_ID.get()),
-            "store_ast_alloc_heap::exit while another AstAllocState is installed"
-        );
+        // Skip if another scope's state is stacked on top.
+        if !owns_active_state() {
+            debug_assert!(
+                false,
+                "store_ast_alloc_heap::exit while another AstAllocState is installed"
+            );
+            return;
+        }
         STATE_ID.set(ptr::null());
         if let Some(state) = ast_alloc::swap_state(PREVIOUS.take()) {
             ast_alloc::release_state(state);

--- a/src/bun_alloc/MimallocArena.rs
+++ b/src/bun_alloc/MimallocArena.rs
@@ -239,7 +239,6 @@ impl MimallocArena {
             HEAP_DESTROY_COUNT.fetch_add(1, Ordering::Relaxed);
             HEAP_NEW_COUNT.fetch_add(1, Ordering::Relaxed);
         }
-        crate::ast_alloc::bump_invalidate_heap(self.heap_ptr());
         // SAFETY: `self.heap` was obtained from `mi_heap_new` and has not been
         // destroyed (we own it). After this call all outstanding allocations
         // are freed; replacing `self.heap` with a fresh heap restores the
@@ -588,7 +587,6 @@ impl Drop for MimallocArena {
         HEAP_DESTROY_COUNT.fetch_add(1, Ordering::Relaxed);
         // Zig: `deinit` → `mi_heap_destroy`. Destroys the heap and bulk-frees
         // every block still allocated in it without running per-block free.
-        crate::ast_alloc::bump_invalidate_heap(self.heap_ptr());
         // SAFETY: `self.heap` is a live heap obtained from `mi_heap_new` and
         // is destroyed exactly once here.
         unsafe { mimalloc::mi_heap_destroy(self.heap_ptr()) };

--- a/src/bun_alloc/ast_alloc.rs
+++ b/src/bun_alloc/ast_alloc.rs
@@ -35,68 +35,35 @@ use core::ptr::NonNull;
 
 use crate::{MimallocArena, mimalloc};
 
-// ── AstAllocState ────────────────────────────────────────────────────────────
-//
-// The parser builds thousands of tiny `AstVec`s (`ExprNodeList`, `G::DeclList`,
-// `G::PropertyList`, `ClassStaticBlock::stmts`, …). Without the bump chunk,
-// every fresh list and every growth reallocation is a `mi_heap_malloc` /
-// `mi_heap_realloc` — and the *first* allocation for a not-yet-seen size class
-// drops into mimalloc's `_mi_malloc_generic` slow path (visible in next-lint
-// profiles). Zig's parser keeps these short lists in a
-// `StackFallbackAllocator`'s inline buffer so the small case never touches the
-// allocator; this matches that by carving allocations `<= BUMP_MAX` from a
-// 16 KB buffer stored *inline* in the state.
-//
-// Lifetime / safety: the bump cursor is a field of the same struct as the
-// buffer it indexes, so it cannot outlive it. The spill heap is owned by the
-// same struct, so a block handed out by `heap_alloc` cannot outlive the state
-// either. The previous design kept the cursor in bare `#[thread_local]` statics
-// pointing into a chunk owned by a destroyable `mi_heap_t`; keeping that cursor
-// valid across heap destruction required a manual `bump_invalidate_heap()` call
-// before every `mi_heap_destroy` — a protocol that already shipped one
-// use-after-free (#53599) and was the prime suspect in the elysia
-// `bracket-pair-range` worker-heap corruption.
+// The parser builds thousands of tiny `AstVec`s; allocations `<= BUMP_MAX` are
+// carved from a 16 KB buffer stored inline in the state (mirroring Zig's
+// `StackFallbackAllocator`), so the small case never touches mimalloc. The
+// cursor, the buffer, and the spill target live in one struct, so none of them
+// can outlive the others.
 
 /// Largest allocation served from the inline bump chunk; above this, requests
-/// go straight to the state's spill heap. Covers the first few growth steps of
-/// the AST list types (e.g. a `Vec<Expr>` passes 96 / 192 / 384 bytes before
-/// mimalloc takes over) and `with_capacity` / `from_slice` for short lists.
+/// go straight to the spill heap.
 const BUMP_MAX: usize = 512;
 
-/// Inline bump chunk size. Once exhausted there is no refill — every
-/// subsequent small allocation falls through to the spill heap (matching Zig's
-/// `StackFallbackAllocator` semantics).
+/// Inline bump chunk size. No refill — once full, small allocations fall
+/// through to the spill heap.
 const BUMP_CHUNK: usize = 16 * 1024;
 
-/// Per-scope allocation state for [`AstAlloc`].
-///
-/// Owned by whichever component opened the AST allocation scope
-/// (`ASTMemoryAllocator`, the `store_ast_alloc_heap` side module, a
-/// [`ScopedAstAlloc`] guard) and moved into the [`AST_ALLOC`] thread-local
-/// while the scope is active. The owner decides when the contents are
-/// bulk-freed ([`Self::reset`] / [`release_state`]) — exactly where the
-/// backing `MimallocArena` was reset or dropped before this type existed.
+/// Per-scope allocation state for [`AstAlloc`]. Owned by whichever component
+/// opened the AST allocation scope and moved into the [`AST_ALLOC`]
+/// thread-local while the scope is active; the owner decides when the
+/// contents are bulk-freed.
 pub struct AstAllocState {
     /// Offset of the next free byte in `bump_chunk`.
     bump_cursor: usize,
-    /// Spill target for allocations that cannot be served from `bump_chunk`
-    /// (size > [`BUMP_MAX`], over-aligned, zeroed, or the chunk is full).
-    /// Set by the installing scope from its own arena via [`Self::set_spill_heap`]
-    /// — one transpile job therefore uses **one** `mi_heap_t` for everything
-    /// instead of paying a second `mi_heap_new`/`mi_heap_destroy` for the
-    /// spill. When the installer has no arena (the long-lived
-    /// `store_ast_alloc_heap` side module), it stays null and `owned_spill` is
-    /// created lazily on first use.
-    ///
-    /// Lifetime: the installer guarantees the heap outlives the installed
-    /// window and clears/replaces the pointer whenever the backing arena is
-    /// reset (`set_spill_heap` is called on every install; [`Self::reset`]
-    /// nulls it).
+    /// Spill target for allocations the chunk can't serve. Set by the
+    /// installing scope from its own arena ([`Self::set_spill_heap`]); the
+    /// installer guarantees the heap outlives the installed window. Null when
+    /// the installer has no arena — `owned_spill` is then created lazily.
     spill: *mut mimalloc::Heap,
     /// Backing storage for `spill` when no borrowed target was provided.
     owned_spill: Option<MimallocArena>,
-    /// Inline small-allocation buffer. Never initialised eagerly; carved
-    /// ranges are written by the `Vec`s that own them.
+    /// Inline small-allocation buffer.
     bump_chunk: [MaybeUninit<u8>; BUMP_CHUNK],
 }
 
@@ -105,9 +72,8 @@ impl AstAllocState {
     fn new_boxed() -> Box<Self> {
         let mut boxed = Box::<Self>::new_uninit();
         let p = boxed.as_mut_ptr();
-        // SAFETY: `p` points to a live uninitialised `Self`; the header
-        // fields are written before `assume_init`, and `bump_chunk` is
-        // `MaybeUninit` so it is allowed to stay uninitialised.
+        // SAFETY: the header fields are written before `assume_init`;
+        // `bump_chunk` is `MaybeUninit` and may stay uninitialised.
         unsafe {
             (&raw mut (*p).bump_cursor).write(0);
             (&raw mut (*p).spill).write(core::ptr::null_mut());
@@ -116,25 +82,18 @@ impl AstAllocState {
         }
     }
 
-    /// Bulk-free everything allocated through this state: drop the spill
-    /// target (destroying it only if owned) and rewind the bump cursor. Any
-    /// pointer previously returned by [`AstAlloc`] while this state was
-    /// installed is invalidated (borrowed-spill blocks are reclaimed by the
-    /// owning arena's own reset/drop).
+    /// Bulk-free everything allocated through this state. Any pointer
+    /// previously returned by [`AstAlloc`] under this state is invalidated.
     #[inline]
     pub fn reset(&mut self) {
         self.bump_cursor = 0;
         self.spill = core::ptr::null_mut();
-        // `MimallocArena::Drop` → `mi_heap_destroy` (bulk-free) — only for a
-        // lazily created owned spill.
         self.owned_spill = None;
     }
 
-    /// Point spill allocations at `heap` (the installing scope's arena) for
-    /// the duration of the install. Called by the owner on **every** install
-    /// so a reset of the backing arena between installs is picked up. Pass the
-    /// live `mi_heap_t` of an arena that strictly outlives the installed
-    /// window.
+    /// Point spill allocations at `heap` (the installing scope's arena), which
+    /// must outlive the installed window. Called on every install so an arena
+    /// reset between installs is picked up.
     #[inline]
     pub fn set_spill_heap(&mut self, heap: *mut mimalloc::Heap) {
         debug_assert!(
@@ -195,51 +154,30 @@ impl AstAllocState {
 /// The active [`AstAllocState`], or `None` when no AST scope is installed
 /// (allocations then fall back to global mimalloc).
 ///
-/// `#[thread_local]` (not `thread_local!`) so this is a bare `__thread` slot
-/// like Zig's `threadlocal var`: every `AstAlloc` allocation reads this, and
-/// the macro form's `LocalKey::__getit` wrapper showed up under
-/// `pthread_getspecific` in next-lint profiles. `#[thread_local]` statics run
-/// no destructor, but scopes are balanced, so this slot is `None` by the time
-/// a thread exits — except for process-lifetime installs (the package
-/// manager's `MiniStore`, the main thread's `store_ast_alloc_heap`), whose
-/// threads live until process exit anyway.
+/// `#[thread_local]` (not `thread_local!`): read on every `AstAlloc`
+/// allocation, so it must stay a bare `__thread` slot.
 #[thread_local]
 static AST_ALLOC: Cell<Option<Box<AstAllocState>>> = Cell::new(None);
 
 // One-slot recycler so a per-job `acquire_state`/`release_state` pair doesn't
-// pay a 16 KB global malloc each time. Holds a clean state (cursor 0, no
-// heap) — an idle worker thread therefore retains 16 KB of buffer and **zero**
-// live `mi_heap_t`s between jobs.
-//
-// Unlike `AST_ALLOC` this is the `thread_local!` macro, which registers a
-// destructor: the parked box is a global-heap allocation (only the 8-byte
-// pointer lives in TLS), so without a destructor every exiting thread that
-// ever parsed JS — e.g. a terminated Web Worker — would leak ~16 KB. The
-// `LocalKey` access overhead doesn't matter here: the slot is only touched on
-// scope entry/exit, never on the per-allocation hot path. The destructor is
-// just a `free` of the box (a released state never holds an owned spill heap),
-// so it is safe at any point during thread teardown.
+// pay a 16 KB malloc each time. Uses `thread_local!` (unlike `AST_ALLOC`) so
+// the destructor frees a parked box at thread exit; only touched on scope
+// entry/exit, never on the allocation hot path.
 std::thread_local! {
     static AST_ALLOC_SPARE: Cell<Option<Box<AstAllocState>>> = const { Cell::new(None) };
 }
 
 /// Mutable access to the installed state without moving the box out of the
 /// thread-local.
-///
-/// The unbounded lifetime is constrained by the callers: the reference is used
-/// for the duration of a single carve / `mi_heap_malloc` and is never held
-/// across [`swap_state`] / [`release_state`] / a nested `AstAlloc` call.
 #[inline(always)]
 fn active_state<'a>() -> Option<&'a mut AstAllocState> {
     // SAFETY: `AST_ALLOC` is thread-local and this module never re-enters
-    // itself while a reference returned here is live (mimalloc FFI calls do
-    // not call back into Rust), so this is the only reference to the boxed
-    // state for its lifetime.
+    // itself while the returned reference is live, so this is the only
+    // reference to the boxed state for its lifetime.
     unsafe { (*AST_ALLOC.as_ptr()).as_deref_mut() }
 }
 
 /// Take the recycled spare state for this thread, or allocate a fresh one.
-/// The returned state is clean: cursor 0, no spill heap.
 #[inline]
 pub fn acquire_state() -> Box<AstAllocState> {
     AST_ALLOC_SPARE
@@ -249,34 +187,24 @@ pub fn acquire_state() -> Box<AstAllocState> {
         .unwrap_or_else(AstAllocState::new_boxed)
 }
 
-/// Bulk-free `state`'s allocations ([`AstAllocState::reset`]) and park the
-/// clean box in the one-slot recycler for the next [`acquire_state`] on this
-/// thread. If the slot is already occupied (or the thread is tearing down and
-/// the recycler's destructor has already run) the box is freed instead.
+/// Bulk-free `state`'s allocations and park the clean box in the recycler.
+/// If the slot is occupied (or the thread is tearing down) the box is freed.
 #[inline]
 pub fn release_state(mut state: Box<AstAllocState>) {
     state.reset();
-    let displaced = AST_ALLOC_SPARE.try_with(|slot| slot.replace(Some(state)));
-    // `Err` ⇒ the TLS destructor already ran; `state` was not moved into the
-    // slot and is dropped here. `Ok(Some(_))` ⇒ the previous occupant is
-    // dropped here.
-    drop(displaced);
+    drop(AST_ALLOC_SPARE.try_with(|slot| slot.replace(Some(state))));
 }
 
-/// Replace the active allocation state, returning the previous occupant.
-///
-/// `Some(state)` installs `state`; the caller must keep the returned previous
-/// occupant and pass it back through `swap_state` when its scope exits (the
-/// `prev` chain lives on the call stack, so nested scopes restore correctly).
-/// `None` detaches to the global-mimalloc fallback.
+/// Replace the active allocation state, returning the previous occupant. The
+/// caller passes the previous occupant back when its scope exits; `None`
+/// detaches to the global-mimalloc fallback.
 #[inline]
 pub fn swap_state(state: Option<Box<AstAllocState>>) -> Option<Box<AstAllocState>> {
     AST_ALLOC.replace(state)
 }
 
-/// Address of the active state (null when none is installed). For debug
-/// assertions that a scope is uninstalling the state it installed; never
-/// dereferenced.
+/// Address of the active state (null when none is installed). Identity checks
+/// only; never dereferenced.
 #[inline]
 pub fn active_state_id() -> *const AstAllocState {
     // SAFETY: see `active_state` — shared read of the thread-local slot.
@@ -284,11 +212,8 @@ pub fn active_state_id() -> *const AstAllocState {
 }
 
 /// Bulk-free the *installed* state in place. For owners that keep their state
-/// installed across resets (the package manager's `MiniStore`, the main-thread
-/// `store_ast_alloc_heap` side module) — they cannot reach the box through
-/// their own field while it lives in the thread-local. No-op when no state is
-/// installed; the caller is responsible for ensuring the installed state is
-/// the one it owns (see [`active_state_id`]).
+/// installed across resets and so cannot reach the box through their own
+/// field. No-op when no state is installed.
 #[inline]
 pub fn reset_active_state() {
     if let Some(state) = active_state() {
@@ -296,10 +221,8 @@ pub fn reset_active_state() {
     }
 }
 
-/// [`AstAllocState::set_spill_heap`] on the *installed* state. For owners that
-/// keep their state installed across arena resets (the package manager's
-/// `MiniStore`) and need to re-point the spill at the recycled arena's new
-/// heap. No-op when no state is installed.
+/// [`AstAllocState::set_spill_heap`] on the *installed* state. No-op when no
+/// state is installed.
 #[inline]
 pub fn set_active_spill_heap(heap: *mut mimalloc::Heap) {
     if let Some(state) = active_state() {
@@ -335,20 +258,13 @@ impl Drop for DetachAstHeap {
 
 /// RAII scope that installs a fresh (or recycled) [`AstAllocState`] for its
 /// lifetime and bulk-frees everything allocated through it on drop. For
-/// callers that want arena-lifetime `AstVec`s without an `ASTMemoryAllocator`
-/// (the synchronous module-loader transpile path).
+/// callers that want arena-lifetime `AstVec`s without an `ASTMemoryAllocator`.
 pub struct ScopedAstAlloc {
     prev: Option<Box<AstAllocState>>,
 }
 impl ScopedAstAlloc {
-    /// Install a state whose spill allocations land in `spill_heap` (the
-    /// caller's arena, which must outlive this guard **and** must not be reset
-    /// while the guard is alive). The scope therefore creates no `mi_heap_t`
-    /// of its own.
-    ///
-    /// SAFETY-adjacent contract (not `unsafe` because the failure mode is the
-    /// same as every other arena-backed allocation here): `spill_heap` must be
-    /// a live `mi_heap_t` for the guard's entire lifetime.
+    /// Install a state whose spill allocations land in `spill_heap`, which
+    /// must stay live (and not be reset) for the guard's entire lifetime.
     #[inline]
     pub fn with_spill(spill_heap: *mut mimalloc::Heap) -> Self {
         let mut state = acquire_state();
@@ -364,6 +280,22 @@ impl ScopedAstAlloc {
         Self {
             prev: swap_state(Some(acquire_state())),
         }
+    }
+
+    /// Uninstall the scope's state and return it **without** bulk-freeing it,
+    /// restoring the previous occupant exactly as `drop` would. For callers
+    /// that hand the parsed AST to an async consumer: small `AstVec`s live in
+    /// the state's inline chunk, so the returned box must be kept alive until
+    /// the consumer is done with the AST.
+    #[inline]
+    pub fn take_state(self) -> Option<Box<AstAllocState>> {
+        let mut this = core::mem::ManuallyDrop::new(self);
+        let installed = swap_state(this.prev.take());
+        debug_assert!(
+            installed.is_some(),
+            "ScopedAstAlloc state was uninstalled by someone else"
+        );
+        installed
     }
 }
 impl Default for ScopedAstAlloc {

--- a/src/bun_alloc/ast_alloc.rs
+++ b/src/bun_alloc/ast_alloc.rs
@@ -296,7 +296,10 @@ impl Drop for ScopedAstAlloc {
     fn drop(&mut self) {
         match swap_state(self.prev.take()) {
             Some(state) => release_state(state),
-            None => debug_assert!(false, "ScopedAstAlloc state was uninstalled by someone else"),
+            None => debug_assert!(
+                false,
+                "ScopedAstAlloc state was uninstalled by someone else"
+            ),
         }
     }
 }

--- a/src/bun_alloc/ast_alloc.rs
+++ b/src/bun_alloc/ast_alloc.rs
@@ -164,20 +164,30 @@ impl AstAllocState {
 /// `#[thread_local]` (not `thread_local!`) so this is a bare `__thread` slot
 /// like Zig's `threadlocal var`: every `AstAlloc` allocation reads this, and
 /// the macro form's `LocalKey::__getit` wrapper showed up under
-/// `pthread_getspecific` in next-lint profiles. The destructor never runs for
-/// `#[thread_local]` statics; a state still installed at thread exit is
-/// reclaimed by the OS with the rest of the thread's pages (scopes are
-/// balanced, so this only happens for process-lifetime installs like the
-/// package manager's `MiniStore`).
+/// `pthread_getspecific` in next-lint profiles. `#[thread_local]` statics run
+/// no destructor, but scopes are balanced, so this slot is `None` by the time
+/// a thread exits — except for process-lifetime installs (the package
+/// manager's `MiniStore`, the main thread's `store_ast_alloc_heap`), whose
+/// threads live until process exit anyway.
 #[thread_local]
 static AST_ALLOC: Cell<Option<Box<AstAllocState>>> = Cell::new(None);
 
-/// One-slot recycler so a per-job `acquire_state`/`release_state` pair doesn't
-/// pay a 16 KB global malloc each time. Holds a clean state (cursor 0, no
-/// heap) — an idle worker thread therefore retains 16 KB of buffer and **zero**
-/// live `mi_heap_t`s between jobs.
-#[thread_local]
-static AST_ALLOC_SPARE: Cell<Option<Box<AstAllocState>>> = Cell::new(None);
+// One-slot recycler so a per-job `acquire_state`/`release_state` pair doesn't
+// pay a 16 KB global malloc each time. Holds a clean state (cursor 0, no
+// heap) — an idle worker thread therefore retains 16 KB of buffer and **zero**
+// live `mi_heap_t`s between jobs.
+//
+// Unlike `AST_ALLOC` this is the `thread_local!` macro, which registers a
+// destructor: the parked box is a global-heap allocation (only the 8-byte
+// pointer lives in TLS), so without a destructor every exiting thread that
+// ever parsed JS — e.g. a terminated Web Worker — would leak ~16 KB. The
+// `LocalKey` access overhead doesn't matter here: the slot is only touched on
+// scope entry/exit, never on the per-allocation hot path. The destructor is
+// just a `free` of the box (a released state never holds a spill heap), so it
+// is safe at any point during thread teardown.
+std::thread_local! {
+    static AST_ALLOC_SPARE: Cell<Option<Box<AstAllocState>>> = const { Cell::new(None) };
+}
 
 /// Mutable access to the installed state without moving the box out of the
 /// thread-local.
@@ -199,17 +209,24 @@ fn active_state<'a>() -> Option<&'a mut AstAllocState> {
 #[inline]
 pub fn acquire_state() -> Box<AstAllocState> {
     AST_ALLOC_SPARE
-        .take()
+        .try_with(Cell::take)
+        .ok()
+        .flatten()
         .unwrap_or_else(AstAllocState::new_boxed)
 }
 
 /// Bulk-free `state`'s allocations ([`AstAllocState::reset`]) and park the
 /// clean box in the one-slot recycler for the next [`acquire_state`] on this
-/// thread. If the slot is already occupied the surplus box is freed.
+/// thread. If the slot is already occupied (or the thread is tearing down and
+/// the recycler's destructor has already run) the box is freed instead.
 #[inline]
 pub fn release_state(mut state: Box<AstAllocState>) {
     state.reset();
-    drop(AST_ALLOC_SPARE.replace(Some(state)));
+    let displaced = AST_ALLOC_SPARE.try_with(|slot| slot.replace(Some(state)));
+    // `Err` ⇒ the TLS destructor already ran; `state` was not moved into the
+    // slot and is dropped here. `Ok(Some(_))` ⇒ the previous occupant is
+    // dropped here.
+    drop(displaced);
 }
 
 /// Replace the active allocation state, returning the previous occupant.

--- a/src/bun_alloc/ast_alloc.rs
+++ b/src/bun_alloc/ast_alloc.rs
@@ -9,12 +9,12 @@
 //! module in `RuntimeTranspilerStore`.
 //!
 //! `AstAlloc` is a ZST `core::alloc::Allocator` that routes `allocate`/`grow`
-//! to the *same* `mi_heap_t` the AST nodes live in (read from a thread-local
-//! set by `ASTMemoryAllocator::push`/`Scope::enter`), and makes `deallocate` a
-//! **no-op**. The buffer is reclaimed by `mi_heap_destroy` on the next
-//! `arena.reset()`, alongside the node that owns it. When no thread-local heap
-//! is set the allocator falls back to global mimalloc (`mi_malloc`), matching
-//! the pre-Strategy-B behaviour for the bundler / `Stmt.Data.Store` block-store
+//! to the thread's active [`AstAllocState`] (installed by
+//! `ASTMemoryAllocator::push`/`Scope::enter` and friends), and makes
+//! `deallocate` a **no-op**. Everything allocated through a state is bulk-freed
+//! when its owner resets or releases it. When no state is installed the
+//! allocator falls back to global mimalloc (`mi_malloc`), matching the
+//! pre-Strategy-B behaviour for the bundler / `Stmt.Data.Store` block-store
 //! path.
 //!
 //! `deallocate` being a no-op preserves the `Expr::Data::clone_in` invariant
@@ -30,260 +30,324 @@
 
 use core::alloc::{AllocError, Allocator, Layout};
 use core::cell::Cell;
+use core::mem::MaybeUninit;
 use core::ptr::NonNull;
 
-use crate::mimalloc;
+use crate::{MimallocArena, mimalloc};
 
-/// Raw `mi_heap_t*` of the active `ASTMemoryAllocator`'s `MimallocArena`,
-/// or null when no AST scope is entered. Set/cleared by
-/// `bun_ast::ASTMemoryAllocator::{push,pop}` and
-/// `ASTMemoryAllocator::Scope::{enter,exit}` (alongside the existing
-/// `Stmt/Expr.Data.Store.MEMORY_ALLOCATOR` and
-/// `bun_ast::data_store_override` thread-locals).
+// ── AstAllocState ────────────────────────────────────────────────────────────
+//
+// The parser builds thousands of tiny `AstVec`s (`ExprNodeList`, `G::DeclList`,
+// `G::PropertyList`, `ClassStaticBlock::stmts`, …). Without the bump chunk,
+// every fresh list and every growth reallocation is a `mi_heap_malloc` /
+// `mi_heap_realloc` — and the *first* allocation for a not-yet-seen size class
+// drops into mimalloc's `_mi_malloc_generic` slow path (visible in next-lint
+// profiles). Zig's parser keeps these short lists in a
+// `StackFallbackAllocator`'s inline buffer so the small case never touches the
+// allocator; this matches that by carving allocations `<= BUMP_MAX` from a
+// 16 KB buffer stored *inline* in the state.
+//
+// Lifetime / safety: the bump cursor is a field of the same struct as the
+// buffer it indexes, so it cannot outlive it. The spill heap is owned by the
+// same struct, so a block handed out by `heap_alloc` cannot outlive the state
+// either. The previous design kept the cursor in bare `#[thread_local]` statics
+// pointing into a chunk owned by a destroyable `mi_heap_t`; keeping that cursor
+// valid across heap destruction required a manual `bump_invalidate_heap()` call
+// before every `mi_heap_destroy` — a protocol that already shipped one
+// use-after-free (#53599) and was the prime suspect in the elysia
+// `bracket-pair-range` worker-heap corruption.
+
+/// Largest allocation served from the inline bump chunk; above this, requests
+/// go straight to the state's spill heap. Covers the first few growth steps of
+/// the AST list types (e.g. a `Vec<Expr>` passes 96 / 192 / 384 bytes before
+/// mimalloc takes over) and `with_capacity` / `from_slice` for short lists.
+const BUMP_MAX: usize = 512;
+
+/// Inline bump chunk size. Once exhausted there is no refill — every
+/// subsequent small allocation falls through to the spill heap (matching Zig's
+/// `StackFallbackAllocator` semantics).
+const BUMP_CHUNK: usize = 16 * 1024;
+
+/// Per-scope allocation state for [`AstAlloc`].
+///
+/// Owned by whichever component opened the AST allocation scope
+/// (`ASTMemoryAllocator`, the `store_ast_alloc_heap` side module, a
+/// [`ScopedAstAlloc`] guard) and moved into the [`AST_ALLOC`] thread-local
+/// while the scope is active. The owner decides when the contents are
+/// bulk-freed ([`Self::reset`] / [`release_state`]) — exactly where the
+/// backing `MimallocArena` was reset or dropped before this type existed.
+pub struct AstAllocState {
+    /// Offset of the next free byte in `bump_chunk`.
+    bump_cursor: usize,
+    /// Spill heap, lazily created on the first allocation that cannot be
+    /// served from `bump_chunk` (size > [`BUMP_MAX`], over-aligned, zeroed, or
+    /// the chunk is full). Scopes that never overflow the chunk never pay
+    /// `mi_heap_new`/`mi_heap_destroy` at all.
+    heap: Option<MimallocArena>,
+    /// Inline small-allocation buffer. Never initialised eagerly; carved
+    /// ranges are written by the `Vec`s that own them.
+    bump_chunk: [MaybeUninit<u8>; BUMP_CHUNK],
+}
+
+impl AstAllocState {
+    /// Allocate a clean state without materialising 16 KB on the stack.
+    fn new_boxed() -> Box<Self> {
+        let mut boxed = Box::<Self>::new_uninit();
+        let p = boxed.as_mut_ptr();
+        // SAFETY: `p` points to a live uninitialised `Self`; the two header
+        // fields are written before `assume_init`, and `bump_chunk` is
+        // `MaybeUninit` so it is allowed to stay uninitialised.
+        unsafe {
+            (&raw mut (*p).bump_cursor).write(0);
+            (&raw mut (*p).heap).write(None);
+            boxed.assume_init()
+        }
+    }
+
+    /// Bulk-free everything allocated through this state: destroy the spill
+    /// heap and rewind the bump cursor. Any pointer previously returned by
+    /// [`AstAlloc`] under this state is invalidated.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.bump_cursor = 0;
+        // `MimallocArena::Drop` → `mi_heap_destroy` (bulk-free).
+        self.heap = None;
+    }
+
+    /// Carve `size` bytes at `align` (a power of two `<= MI_MAX_ALIGN_SIZE`)
+    /// from the inline chunk. `None` when it doesn't fit — there is no refill;
+    /// the caller falls through to the spill heap.
+    #[inline]
+    fn bump_alloc(&mut self, size: usize, align: usize) -> Option<*mut u8> {
+        debug_assert!(size != 0 && size <= BUMP_MAX && align.is_power_of_two());
+        debug_assert!(align <= mimalloc::MI_MAX_ALIGN_SIZE);
+        debug_assert!(self.bump_cursor <= BUMP_CHUNK);
+        // SAFETY: `bump_cursor <= BUMP_CHUNK` (invariant: only advanced below
+        // after the bounds check), so `add` is at most one-past-the-end.
+        let cur = unsafe {
+            self.bump_chunk
+                .as_mut_ptr()
+                .cast::<u8>()
+                .add(self.bump_cursor)
+        };
+        let remaining = BUMP_CHUNK - self.bump_cursor;
+        let pad = cur.align_offset(align);
+        if pad <= remaining && size <= remaining - pad {
+            // SAFETY: `pad + size <= remaining`, so `cur + pad` and
+            // `cur + pad + size` stay within `bump_chunk` (one-past-the-end at
+            // most).
+            unsafe {
+                let aligned = cur.add(pad);
+                self.bump_cursor += pad + size;
+                Some(aligned)
+            }
+        } else {
+            None
+        }
+    }
+
+    /// The state's spill `mi_heap_t`, created on first use.
+    #[inline]
+    fn heap_ptr(&mut self) -> *mut mimalloc::Heap {
+        match &self.heap {
+            Some(heap) => heap.heap_ptr(),
+            None => self.heap.insert(MimallocArena::new()).heap_ptr(),
+        }
+    }
+}
+
+// ── Thread-local active state ────────────────────────────────────────────────
+
+/// The active [`AstAllocState`], or `None` when no AST scope is installed
+/// (allocations then fall back to global mimalloc).
 ///
 /// `#[thread_local]` (not `thread_local!`) so this is a bare `__thread` slot
 /// like Zig's `threadlocal var`: every `AstAlloc` allocation reads this, and
 /// the macro form's `LocalKey::__getit` wrapper showed up under
-/// `pthread_getspecific` in next-lint profiles. `Cell<*mut _>` has no
-/// destructor and a const initializer, so no dtor registration is needed.
+/// `pthread_getspecific` in next-lint profiles. The destructor never runs for
+/// `#[thread_local]` statics; a state still installed at thread exit is
+/// reclaimed by the OS with the rest of the thread's pages (scopes are
+/// balanced, so this only happens for process-lifetime installs like the
+/// package manager's `MiniStore`).
 #[thread_local]
-static AST_HEAP: Cell<*mut mimalloc::Heap> = Cell::new(core::ptr::null_mut());
+static AST_ALLOC: Cell<Option<Box<AstAllocState>>> = Cell::new(None);
 
-// ── Per-thread small-allocation bump arena ───────────────────────────────────
-//
-// The parser builds thousands of tiny `AstVec`s (`ExprNodeList`, `G::DeclList`,
-// `G::PropertyList`, `ClassStaticBlock::stmts`, …). Without this, every fresh
-// list and every growth reallocation is a `mi_heap_malloc` / `mi_heap_realloc`
-// on the AST heap — and the *first* allocation for a not-yet-seen size class
-// drops into mimalloc's `_mi_malloc_generic` slow path (visible in next-lint
-// profiles). Zig's parser keeps these short lists in pooled / stack-seeded
-// buffers so the small case never touches the allocator; this matches that by
-// carving allocations `<= BUMP_MAX` from a large chunk owned by the active AST
-// `mi_heap_t`. The chunk is allocated *once* (per refill), so N tiny lists cost
-// one `mi_heap_malloc` instead of N.
-//
-// Lifetime / safety: the chunk is allocated from `AST_HEAP` and is *never* freed
-// individually (consistent with `AstAlloc::deallocate` being a no-op) — it is
-// reclaimed by `mi_heap_destroy` on `MimallocArena::reset()`, alongside the AST
-// nodes whose `Vec` headers point into it. The bump cursor is invalidated
-// ([`bump_reset`]) on every [`set_thread_heap`], so it never outlives the heap
-// that owns its chunk: any `mi_heap_destroy` affecting `AST_HEAP` in a
-// well-formed call sequence is bracketed by a `set_thread_heap` (otherwise
-// `heap_alloc` itself would already use-after-free the stale `*mut mi_heap_t`).
-// This is the discipline the earlier reverted bump layer lacked — it cached the
-// `mi_heap_t*` across heap swaps, so a recycled slot (#53599) aliased a
-// destroyed heap. Here the cursor is dropped, not the heap pointer cached, so an
-// ABA on the `mi_heap_t*` value can only happen *through* a `set_thread_heap`,
-// which clears the cursor first.
-//
-// `grow` must not pass a bump-carved interior pointer to `mi_expand` (it would
-// corrupt that chunk's mimalloc bookkeeping without ever moving our cursor), so
-// the `mi_expand` fast path there is gated to `old.size() > BUMP_MAX` — a block
-// of that size necessarily came straight from `mi_heap_malloc`.
-
-/// Largest allocation served from the bump chunk; above this, requests go
-/// straight to `mi_heap_malloc`. Covers the first few growth steps of the AST
-/// list types (e.g. a `Vec<Expr>` passes 96 / 192 / 384 bytes before mimalloc
-/// takes over) and `with_capacity` / `from_slice` for short lists.
-const BUMP_MAX: usize = 512;
-
-/// Backing chunk size — comparable to a `new_store!` AST-node block; large
-/// enough that a typical module needs only a handful, all freed with the arena.
-const BUMP_CHUNK: usize = 16 * 1024;
-
-/// Next free byte of the active bump chunk, or null when none is active.
+/// One-slot recycler so a per-job `acquire_state`/`release_state` pair doesn't
+/// pay a 16 KB global malloc each time. Holds a clean state (cursor 0, no
+/// heap) — an idle worker thread therefore retains 16 KB of buffer and **zero**
+/// live `mi_heap_t`s between jobs.
 #[thread_local]
-static BUMP_CUR: Cell<*mut u8> = Cell::new(core::ptr::null_mut());
-/// One-past-the-end of the active bump chunk.
-#[thread_local]
-static BUMP_END: Cell<*mut u8> = Cell::new(core::ptr::null_mut());
-/// The `mi_heap_t*` that owns the active bump chunk (set in [`bump_refill`]).
-/// Lets [`set_thread_heap`] keep the cursor when re-entering the same heap so
-/// the bundler's per-task `push()`/`pop()` doesn't abandon a 16 KB chunk every
-/// task — that was ~70 K tasks × 16 KB ≈ 1.1 GB of mostly-empty chunks held in
-/// the never-reset worker `ast_memory_store` arenas.
-#[thread_local]
-static BUMP_HEAP: Cell<*mut mimalloc::Heap> = Cell::new(core::ptr::null_mut());
+static AST_ALLOC_SPARE: Cell<Option<Box<AstAllocState>>> = Cell::new(None);
 
-/// Drop the bump cursor (the chunk itself is owned by `BUMP_HEAP` and reclaimed
-/// by `mi_heap_destroy`).
-#[inline]
-fn bump_reset() {
-    BUMP_CUR.set(core::ptr::null_mut());
-    BUMP_END.set(core::ptr::null_mut());
-    BUMP_HEAP.set(core::ptr::null_mut());
+/// Mutable access to the installed state without moving the box out of the
+/// thread-local.
+///
+/// The unbounded lifetime is constrained by the callers: the reference is used
+/// for the duration of a single carve / `mi_heap_malloc` and is never held
+/// across [`swap_state`] / [`release_state`] / a nested `AstAlloc` call.
+#[inline(always)]
+fn active_state<'a>() -> Option<&'a mut AstAllocState> {
+    // SAFETY: `AST_ALLOC` is thread-local and this module never re-enters
+    // itself while a reference returned here is live (mimalloc FFI calls do
+    // not call back into Rust), so this is the only reference to the boxed
+    // state for its lifetime.
+    unsafe { (*AST_ALLOC.as_ptr()).as_deref_mut() }
 }
 
-/// Invalidate the bump cursor if it is backed by `heap`. Called from
-/// `MimallocArena::reset`/`Drop` immediately before `mi_heap_destroy(heap)` so
-/// a recycled `mi_heap_t*` slot can't ABA-match `BUMP_HEAP` and serve a stale
-/// (freed) chunk under [`set_thread_heap`].
+/// Take the recycled spare state for this thread, or allocate a fresh one.
+/// The returned state is clean: cursor 0, no spill heap.
 #[inline]
-pub(crate) fn bump_invalidate_heap(heap: *mut mimalloc::Heap) {
-    if BUMP_HEAP.get() == heap {
-        bump_reset();
-    }
+pub fn acquire_state() -> Box<AstAllocState> {
+    AST_ALLOC_SPARE
+        .take()
+        .unwrap_or_else(AstAllocState::new_boxed)
 }
 
-/// Carve `size` bytes at `align` (a power of two `<= MI_MAX_ALIGN_SIZE`) from
-/// the thread's bump chunk for `heap`, refilling with a fresh `mi_heap_malloc`
-/// chunk when the current one is exhausted. `None` only on allocation failure
-/// (the caller then falls back to `mi_heap_malloc` directly).
+/// Bulk-free `state`'s allocations ([`AstAllocState::reset`]) and park the
+/// clean box in the one-slot recycler for the next [`acquire_state`] on this
+/// thread. If the slot is already occupied the surplus box is freed.
 #[inline]
-fn bump_alloc(heap: *mut mimalloc::Heap, size: usize, align: usize) -> Option<*mut u8> {
-    debug_assert!(size != 0 && size <= BUMP_MAX && align.is_power_of_two());
-    debug_assert!(align <= mimalloc::MI_MAX_ALIGN_SIZE);
-    let cur = BUMP_CUR.get();
-    if !cur.is_null() {
-        // Bytes left in the active chunk; `BUMP_END >= BUMP_CUR` is the cursor
-        // invariant (set together in `bump_refill`, only ever advanced here).
-        let remaining = (BUMP_END.get() as usize).wrapping_sub(cur as usize);
-        let pad = cur.align_offset(align);
-        if pad <= remaining && size <= remaining - pad {
-            // SAFETY: `pad + size <= remaining`, so `cur + pad` and
-            // `cur + pad + size` stay within `[BUMP_CUR, BUMP_END]` — i.e. in
-            // bounds of the chunk allocation (one-past-the-end at most).
-            unsafe {
-                let aligned = cur.add(pad);
-                BUMP_CUR.set(aligned.add(size));
-                return Some(aligned);
-            }
-        }
-    }
-    bump_refill(heap, size)
+pub fn release_state(mut state: Box<AstAllocState>) {
+    state.reset();
+    drop(AST_ALLOC_SPARE.replace(Some(state)));
 }
 
-#[cold]
-#[inline(never)]
-fn bump_refill(heap: *mut mimalloc::Heap, size: usize) -> Option<*mut u8> {
-    // SAFETY: `heap` is the live AST heap — `bump_alloc`'s only caller is
-    // `heap_alloc`, which passes `AST_HEAP.get()` after a non-null check, and
-    // `set_thread_heap` keeps the bump cursor consistent with `AST_HEAP`.
-    let chunk = unsafe { mimalloc::mi_heap_malloc(heap, BUMP_CHUNK).cast::<u8>() };
-    if chunk.is_null() {
-        return None;
-    }
-    // SAFETY: `chunk` is `>= MI_MAX_ALIGN_SIZE`-aligned (mimalloc guarantee) and the
-    // caller's `align <= MI_MAX_ALIGN_SIZE`, so carving from the front already
-    // satisfies the request's alignment. `size <= BUMP_MAX < BUMP_CHUNK`, so
-    // both `add`s are in bounds.
-    unsafe {
-        BUMP_CUR.set(chunk.add(size));
-        BUMP_END.set(chunk.add(BUMP_CHUNK));
-    }
-    BUMP_HEAP.set(heap);
-    Some(chunk)
+/// Replace the active allocation state, returning the previous occupant.
+///
+/// `Some(state)` installs `state`; the caller must keep the returned previous
+/// occupant and pass it back through `swap_state` when its scope exits (the
+/// `prev` chain lives on the call stack, so nested scopes restore correctly).
+/// `None` detaches to the global-mimalloc fallback.
+#[inline]
+pub fn swap_state(state: Option<Box<AstAllocState>>) -> Option<Box<AstAllocState>> {
+    AST_ALLOC.replace(state)
 }
 
-/// Install `heap` as the thread's AST heap. Pass `null` to clear.
-/// Intended caller: `ASTMemoryAllocator` (push/pop/Scope) only.
-//
-// Also drops the small-allocation bump cursor ([`bump_reset`]): its chunk is
-// owned by the *outgoing* heap, so it must not be reused under the incoming one.
-//
-// PERF NOTE: a previous iteration also cached the resolved `mi_theap_t*` here to
-// skip mimalloc's per-call `heap → theap` TLS lookup. Reverted: `mi_theap_t*` is
-// per-OS-thread while `mi_heap_t*` is `Send`, so caching the former on a struct
-// that may move threads is a corruption footgun, and that layer also cached the
-// `mi_heap_t*` across heap swaps — a recycled slot (#53599) then aliased a
-// destroyed heap. The bump arena above avoids both: nothing per-OS-thread is
-// cached, and the cursor (not the heap pointer) is what survives, dropped on
-// every swap. Zig does not use `mi_theap_*` either. If `_mi_heap_theap` thrash
-// resurfaces in profiles, the intended fix is `mi_heap_set_default(heap)` for
-// the parse scope (mimalloc's supported "make this heap the cached one" API),
-// not manual theap caching.
+/// Address of the active state (null when none is installed). For debug
+/// assertions that a scope is uninstalling the state it installed; never
+/// dereferenced.
 #[inline]
-pub fn set_thread_heap(heap: *mut mimalloc::Heap) {
-    AST_HEAP.set(heap);
-    // Keep the cursor when re-entering the heap that owns it (the bundler's
-    // per-task `push()`/`pop()` always passes the same per-worker arena). Only
-    // discard when switching to a *different* non-null heap — the chunk then
-    // belongs to the wrong owner. Clearing to null is a no-op for the cursor
-    // (no allocs happen while `AST_HEAP` is null), so it survives the
-    // `pop()→push()` round-trip. Heap destruction must call [`bump_reset`]
-    // explicitly to defend against address reuse.
-    if !heap.is_null() && heap != BUMP_HEAP.get() {
-        bump_reset();
-    }
+pub fn active_state_id() -> *const AstAllocState {
+    // SAFETY: see `active_state` — shared read of the thread-local slot.
+    unsafe { (*AST_ALLOC.as_ptr()).as_deref() }.map_or(core::ptr::null(), core::ptr::from_ref)
 }
 
-/// Current thread's AST heap, or null if no `ASTMemoryAllocator` scope is
-/// active.
+/// Bulk-free the *installed* state in place. For owners that keep their state
+/// installed across resets (the package manager's `MiniStore`, the main-thread
+/// `store_ast_alloc_heap` side module) — they cannot reach the box through
+/// their own field while it lives in the thread-local. No-op when no state is
+/// installed; the caller is responsible for ensuring the installed state is
+/// the one it owns (see [`active_state_id`]).
 #[inline]
-pub fn thread_heap() -> *mut mimalloc::Heap {
-    AST_HEAP.get()
+pub fn reset_active_state() {
+    if let Some(state) = active_state() {
+        state.reset();
+    }
 }
 
 /// RAII guard: for its lifetime, [`AstAlloc`] allocates on **global** mimalloc
-/// instead of the per-parse [`thread_heap`]. Use when constructing
+/// instead of the active per-parse state. Use when constructing
 /// `AstVec`/`StoreRef` data that must outlive the current parse arena
 /// (e.g. `Expr::deep_clone` for `WorkspacePackageJSONCache`). Without this,
 /// the next `ASTMemoryAllocator::reset()` frees buffers the cache still holds.
 ///
-/// Restores the prior heap on drop, so it nests correctly inside an
+/// Restores the prior state on drop, so it nests correctly inside an
 /// `ASTMemoryAllocator` scope.
-pub struct DetachAstHeap(*mut mimalloc::Heap);
+pub struct DetachAstHeap(Option<Box<AstAllocState>>);
 impl DetachAstHeap {
     #[inline]
     pub fn new() -> Self {
-        let prev = thread_heap();
-        set_thread_heap(core::ptr::null_mut());
-        Self(prev)
+        Self(swap_state(None))
     }
 }
 impl Drop for DetachAstHeap {
     #[inline]
     fn drop(&mut self) {
-        set_thread_heap(self.0);
+        let displaced = swap_state(self.0.take());
+        debug_assert!(
+            displaced.is_none(),
+            "AstAlloc scope installed during a DetachAstHeap window was not uninstalled"
+        );
     }
 }
 
-/// Zero-sized `Allocator` that routes to [`thread_heap`] when set, else to
-/// global mimalloc. `deallocate` is a no-op (arena reclaims on `reset()`).
+/// RAII scope that installs a fresh (or recycled) [`AstAllocState`] for its
+/// lifetime and bulk-frees everything allocated through it on drop. For
+/// callers that want arena-lifetime `AstVec`s without an `ASTMemoryAllocator`
+/// (the synchronous module-loader transpile path).
+pub struct ScopedAstAlloc {
+    prev: Option<Box<AstAllocState>>,
+}
+impl ScopedAstAlloc {
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            prev: swap_state(Some(acquire_state())),
+        }
+    }
+}
+impl Default for ScopedAstAlloc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl Drop for ScopedAstAlloc {
+    #[inline]
+    fn drop(&mut self) {
+        match swap_state(self.prev.take()) {
+            Some(state) => release_state(state),
+            None => debug_assert!(false, "ScopedAstAlloc state was uninstalled by someone else"),
+        }
+    }
+}
+
+/// Zero-sized `Allocator` that routes to the active [`AstAllocState`] when one
+/// is installed, else to global mimalloc. `deallocate` is a no-op (the state's
+/// owner reclaims everything in bulk).
 ///
 /// Use as `Vec<T, AstAlloc>` (see [`AstVec`]). The ZST means the `Vec` stays
 /// 24 bytes — same size as `Vec<T>` — so AST node layouts are unchanged.
 #[derive(Clone, Copy, Default)]
 pub struct AstAlloc;
 
-/// `Vec` whose backing buffer lives in the thread-local AST `mi_heap_t`.
+/// `Vec` whose backing buffer lives in the thread-local AST allocation state.
 pub type AstVec<T> = Vec<T, AstAlloc>;
 
 use crate::alloc_result;
 
 #[inline(always)]
 fn heap_alloc(layout: Layout) -> *mut u8 {
-    let heap = AST_HEAP.get();
-    if heap.is_null() {
+    let Some(state) = active_state() else {
         // Global fallback (no AST scope active). `mi_malloc` tolerates
         // `size == 0` (unique non-null pointer), so no special-casing.
         return mimalloc::mi_malloc_auto_align(layout.size(), layout.align()).cast();
-    }
-    // Small, normally-aligned requests: bump-carve from a chunk owned by `heap`
-    // so a burst of tiny `AstVec`s costs one `mi_heap_malloc` instead of one
-    // per list (and stays out of `_mi_malloc_generic`). See the bump-arena doc
-    // above for the lifetime / `mi_expand` argument. Zero-size layouts and
-    // over-aligned ones (no AST list type needs `> MI_MAX_ALIGN_SIZE`) fall
-    // through to mimalloc, which handles both.
+    };
+    // Small, normally-aligned requests: carve from the state's inline chunk so
+    // a burst of tiny `AstVec`s costs zero mallocs (and stays out of
+    // `_mi_malloc_generic`). Zero-size layouts and over-aligned ones (no AST
+    // list type needs `> MI_MAX_ALIGN_SIZE`) fall through to mimalloc, which
+    // handles both.
     if layout.size() != 0
         && layout.size() <= BUMP_MAX
         && layout.align() <= mimalloc::MI_MAX_ALIGN_SIZE
     {
-        if let Some(p) = bump_alloc(heap, layout.size(), layout.align()) {
+        if let Some(p) = state.bump_alloc(layout.size(), layout.align()) {
             return p;
         }
     }
-    // SAFETY: `heap` is the live `mi_heap_t*` of this thread's
-    // `ASTMemoryAllocator` arena (the documented contract of `set_thread_heap`);
-    // the scope guarantees it is not `reset()` while active.
-    unsafe { mimalloc::mi_heap_malloc_auto_align(heap, layout.size(), layout.align()).cast() }
+    // SAFETY: `heap_ptr` returns the live spill heap owned by `state`, which
+    // is owned by the thread-local for the duration of this call.
+    unsafe {
+        mimalloc::mi_heap_malloc_auto_align(state.heap_ptr(), layout.size(), layout.align()).cast()
+    }
 }
 
 // SAFETY:
-// - `allocate`/`grow` return blocks from `mi_heap_malloc[_aligned]` (or global
-//   `mi_malloc[_aligned]` when no TL heap is set), which satisfy `layout` and
-//   are owned by `AST_HEAP` (or the global heap). Under a TL heap they are
-//   bulk-freed by `mi_heap_destroy` on `MimallocArena::reset()`.
+// - `allocate`/`grow` return blocks carved from the active state's inline
+//   chunk, from `mi_heap_malloc[_aligned]` on its spill heap, or from global
+//   `mi_malloc[_aligned]` when no state is installed; all satisfy `layout`.
+//   State-owned blocks are bulk-freed when the owner resets/releases the
+//   state.
 // - `deallocate` is a no-op (permitted: the trait only requires that memory
 //   *may* be reclaimed). This preserves the `Expr::Data::clone_in` invariant
 //   (two `Vec` headers may alias one buffer; neither frees it). Under the
@@ -291,23 +355,24 @@ fn heap_alloc(layout: Layout) -> *mut u8 {
 //   pre-Strategy-B status quo.
 // - `grow` tries `mi_expand` (extend the existing block in place — never moves
 //   it, so it stays in whatever heap owns it) *only when `old.size() > BUMP_MAX`*:
-//   a smaller block may be a bump-arena interior pointer (see `heap_alloc`), on
+//   a smaller block may be a bump-chunk interior pointer (see `heap_alloc`), on
 //   which `mi_expand` would corrupt the chunk's bookkeeping. A `> BUMP_MAX`
-//   block always came straight from `mi_heap_malloc[_aligned]`, so it is sound.
-//   Otherwise (and on `mi_expand` failure) `grow` allocates a fresh block +
-//   `memcpy` rather than `mi_realloc`: when the TL heap is *null* we cannot tell
-//   whether `ptr` is a global-fallback `mi_malloc` block head or a heap block
-//   from a since-exited AST scope on another thread (`BundleV2::clone_ast` does
-//   exactly this), so passing it to `mi_realloc` would be unsound. The old block
-//   is abandoned (same leak semantics as `deallocate` — and under a TL heap it,
-//   like every other block, is reclaimed by `mi_heap_destroy` on `reset()`).
+//   block always came straight from `mi_[heap_]malloc[_aligned]`, so it is
+//   sound. Otherwise (and on `mi_expand` failure) `grow` allocates a fresh
+//   block + `memcpy` rather than `mi_realloc`: when no state is installed we
+//   cannot tell whether `ptr` is a global-fallback `mi_malloc` block head or a
+//   bump-chunk interior pointer from a since-exited AST scope on another
+//   thread (`BundleV2::clone_ast` does exactly this), so passing it to
+//   `mi_realloc` would be unsound. The old block is abandoned (same leak
+//   semantics as `deallocate` — and under a state it, like every other block,
+//   is reclaimed when the owner resets the state).
 // - `allocate_zeroed` is `mi_*zalloc` (skips the redundant `memset` mimalloc
 //   would otherwise need over already-zero OS pages); same lifetime as
 //   `allocate`.
 // - `AstAlloc` is a ZST: every instance is trivially "the same allocator", so
 //   the "pointers may be freed by any clone" requirement is satisfied.
 // - `Send + Sync` (auto-derived for a fieldless ZST) is sound: each call reads
-//   the *calling* thread's `AST_HEAP`, and allocation is gated to that thread
+//   the *calling* thread's `AST_ALLOC`, and allocation is gated to that thread
 //   by `ASTMemoryAllocator`'s single-threaded contract (mirrored from Zig's
 //   `ThreadLock`; see `MimallocArena::assert_owning_thread`). The no-op
 //   `deallocate` removes the only cross-thread hazard a `Vec<_,A>: Send` would
@@ -322,19 +387,17 @@ unsafe impl Allocator for AstAlloc {
     fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         // `mi_*zalloc` lets mimalloc skip the `memset` for blocks carved from
         // freshly-`mmap`ed (already-zero) OS pages, which the default
-        // `allocate` + `ptr::write_bytes(0)` cannot. Same lifetime semantics as
-        // `heap_alloc` (the block is reclaimed by `mi_heap_destroy` on
-        // `MimallocArena::reset()`, or leaks under the global fallback). Mirrors
-        // `MimallocArena::allocate_zeroed`.
-        let heap = AST_HEAP.get();
-        let p: *mut u8 = if heap.is_null() {
-            mimalloc::mi_zalloc_auto_align(layout.size(), layout.align()).cast()
-        } else {
-            // SAFETY: `heap` is the live `mi_heap_t*` of this thread's AST
-            // arena (the `set_thread_heap` contract); see `heap_alloc`.
-            unsafe {
-                mimalloc::mi_heap_zalloc_auto_align(heap, layout.size(), layout.align()).cast()
-            }
+        // `allocate` + `ptr::write_bytes(0)` cannot. Never bump-carved (the
+        // chunk is uninitialised); same lifetime semantics as `heap_alloc`.
+        // Mirrors `MimallocArena::allocate_zeroed`.
+        let p: *mut u8 = match active_state() {
+            None => mimalloc::mi_zalloc_auto_align(layout.size(), layout.align()).cast(),
+            // SAFETY: `heap_ptr` returns the live spill heap owned by the
+            // installed state; see `heap_alloc`.
+            Some(state) => unsafe {
+                mimalloc::mi_heap_zalloc_auto_align(state.heap_ptr(), layout.size(), layout.align())
+                    .cast()
+            },
         };
         alloc_result(p, layout.size())
     }
@@ -342,9 +405,9 @@ unsafe impl Allocator for AstAlloc {
     #[inline]
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
         // Unconditional no-op — see SAFETY block above and the module doc's
-        // `Expr::Data::clone_in` invariant. Under a TL heap the block is
-        // reclaimed by `mi_heap_destroy` on the next `MimallocArena::reset()`;
-        // under the global fallback it leaks (cannot prove `ptr`'s provenance).
+        // `Expr::Data::clone_in` invariant. Under an installed state the block
+        // is reclaimed when the owner resets/releases the state; under the
+        // global fallback it leaks (cannot prove `ptr`'s provenance).
         let _ = (ptr, layout);
     }
 
@@ -365,11 +428,12 @@ unsafe impl Allocator for AstAlloc {
         // `mi_expand`-then-`mi_realloc`).
         //
         // Gated on:
-        //  - `old.size() > BUMP_MAX`: smaller blocks may be bump-arena interior
+        //  - `old.size() > BUMP_MAX`: smaller blocks may be bump-chunk interior
         //    pointers (see `heap_alloc`), and `mi_expand` on those would treat
-        //    the *whole chunk* as the block — corrupting both its bookkeeping
-        //    and our cursor. A `> BUMP_MAX` block always came straight from
-        //    `mi_heap_malloc[_aligned]`, so this is the only safe slice to use it.
+        //    the *whole chunk* as the block — corrupting its bookkeeping. A
+        //    `> BUMP_MAX` block always came straight from
+        //    `mi_[heap_]malloc[_aligned]`, so this is the only safe slice to
+        //    use it.
         //  - `new.align() <= old.align()`: the block was aligned for `old`,
         //    `mi_expand` cannot raise that, and for `Vec<T>` (the only `AstVec`
         //    shape) the alignment never changes across grows.
@@ -386,9 +450,9 @@ unsafe impl Allocator for AstAlloc {
             }
         }
         // Slow path: allocate-new (possibly bump-carved) + copy + abandon-old.
-        // Not `mi_realloc`: `ptr`'s provenance is unknown when the TL heap is
-        // null (see SAFETY above), and under a TL heap the old block is reclaimed
-        // by `mi_heap_destroy` anyway, so the leak is bounded by the arena.
+        // Not `mi_realloc`: `ptr` may be a bump-chunk interior pointer or a
+        // block from another scope's heap (see SAFETY above); the old block is
+        // reclaimed when its owning state is reset.
         let p = NonNull::new(heap_alloc(new)).ok_or(AllocError)?;
         // SAFETY: `p` is a fresh `new.size()`-byte block disjoint from `ptr`;
         // `old.size()` bytes at `ptr` are initialized per the `grow` contract;

--- a/src/bun_alloc/ast_alloc.rs
+++ b/src/bun_alloc/ast_alloc.rs
@@ -79,11 +79,22 @@ const BUMP_CHUNK: usize = 16 * 1024;
 pub struct AstAllocState {
     /// Offset of the next free byte in `bump_chunk`.
     bump_cursor: usize,
-    /// Spill heap, lazily created on the first allocation that cannot be
-    /// served from `bump_chunk` (size > [`BUMP_MAX`], over-aligned, zeroed, or
-    /// the chunk is full). Scopes that never overflow the chunk never pay
-    /// `mi_heap_new`/`mi_heap_destroy` at all.
-    heap: Option<MimallocArena>,
+    /// Spill target for allocations that cannot be served from `bump_chunk`
+    /// (size > [`BUMP_MAX`], over-aligned, zeroed, or the chunk is full).
+    /// Set by the installing scope from its own arena via [`Self::set_spill_heap`]
+    /// — one transpile job therefore uses **one** `mi_heap_t` for everything
+    /// instead of paying a second `mi_heap_new`/`mi_heap_destroy` for the
+    /// spill. When the installer has no arena (the long-lived
+    /// `store_ast_alloc_heap` side module), it stays null and `owned_spill` is
+    /// created lazily on first use.
+    ///
+    /// Lifetime: the installer guarantees the heap outlives the installed
+    /// window and clears/replaces the pointer whenever the backing arena is
+    /// reset (`set_spill_heap` is called on every install; [`Self::reset`]
+    /// nulls it).
+    spill: *mut mimalloc::Heap,
+    /// Backing storage for `spill` when no borrowed target was provided.
+    owned_spill: Option<MimallocArena>,
     /// Inline small-allocation buffer. Never initialised eagerly; carved
     /// ranges are written by the `Vec`s that own them.
     bump_chunk: [MaybeUninit<u8>; BUMP_CHUNK],
@@ -94,24 +105,43 @@ impl AstAllocState {
     fn new_boxed() -> Box<Self> {
         let mut boxed = Box::<Self>::new_uninit();
         let p = boxed.as_mut_ptr();
-        // SAFETY: `p` points to a live uninitialised `Self`; the two header
+        // SAFETY: `p` points to a live uninitialised `Self`; the header
         // fields are written before `assume_init`, and `bump_chunk` is
         // `MaybeUninit` so it is allowed to stay uninitialised.
         unsafe {
             (&raw mut (*p).bump_cursor).write(0);
-            (&raw mut (*p).heap).write(None);
+            (&raw mut (*p).spill).write(core::ptr::null_mut());
+            (&raw mut (*p).owned_spill).write(None);
             boxed.assume_init()
         }
     }
 
-    /// Bulk-free everything allocated through this state: destroy the spill
-    /// heap and rewind the bump cursor. Any pointer previously returned by
-    /// [`AstAlloc`] under this state is invalidated.
+    /// Bulk-free everything allocated through this state: drop the spill
+    /// target (destroying it only if owned) and rewind the bump cursor. Any
+    /// pointer previously returned by [`AstAlloc`] while this state was
+    /// installed is invalidated (borrowed-spill blocks are reclaimed by the
+    /// owning arena's own reset/drop).
     #[inline]
     pub fn reset(&mut self) {
         self.bump_cursor = 0;
-        // `MimallocArena::Drop` → `mi_heap_destroy` (bulk-free).
-        self.heap = None;
+        self.spill = core::ptr::null_mut();
+        // `MimallocArena::Drop` → `mi_heap_destroy` (bulk-free) — only for a
+        // lazily created owned spill.
+        self.owned_spill = None;
+    }
+
+    /// Point spill allocations at `heap` (the installing scope's arena) for
+    /// the duration of the install. Called by the owner on **every** install
+    /// so a reset of the backing arena between installs is picked up. Pass the
+    /// live `mi_heap_t` of an arena that strictly outlives the installed
+    /// window.
+    #[inline]
+    pub fn set_spill_heap(&mut self, heap: *mut mimalloc::Heap) {
+        debug_assert!(
+            self.owned_spill.is_none(),
+            "AstAllocState: switching an owned spill heap to a borrowed one would strand its contents"
+        );
+        self.spill = heap;
     }
 
     /// Carve `size` bytes at `align` (a power of two `<= MI_MAX_ALIGN_SIZE`)
@@ -146,13 +176,17 @@ impl AstAllocState {
         }
     }
 
-    /// The state's spill `mi_heap_t`, created on first use.
+    /// The state's spill `mi_heap_t`: the borrowed target installed by
+    /// [`Self::set_spill_heap`], or a lazily created owned heap when none was
+    /// provided.
     #[inline]
     fn heap_ptr(&mut self) -> *mut mimalloc::Heap {
-        match &self.heap {
-            Some(heap) => heap.heap_ptr(),
-            None => self.heap.insert(MimallocArena::new()).heap_ptr(),
+        if !self.spill.is_null() {
+            return self.spill;
         }
+        let heap = self.owned_spill.insert(MimallocArena::new()).heap_ptr();
+        self.spill = heap;
+        heap
     }
 }
 
@@ -183,8 +217,8 @@ static AST_ALLOC: Cell<Option<Box<AstAllocState>>> = Cell::new(None);
 // ever parsed JS — e.g. a terminated Web Worker — would leak ~16 KB. The
 // `LocalKey` access overhead doesn't matter here: the slot is only touched on
 // scope entry/exit, never on the per-allocation hot path. The destructor is
-// just a `free` of the box (a released state never holds a spill heap), so it
-// is safe at any point during thread teardown.
+// just a `free` of the box (a released state never holds an owned spill heap),
+// so it is safe at any point during thread teardown.
 std::thread_local! {
     static AST_ALLOC_SPARE: Cell<Option<Box<AstAllocState>>> = const { Cell::new(None) };
 }
@@ -262,6 +296,17 @@ pub fn reset_active_state() {
     }
 }
 
+/// [`AstAllocState::set_spill_heap`] on the *installed* state. For owners that
+/// keep their state installed across arena resets (the package manager's
+/// `MiniStore`) and need to re-point the spill at the recycled arena's new
+/// heap. No-op when no state is installed.
+#[inline]
+pub fn set_active_spill_heap(heap: *mut mimalloc::Heap) {
+    if let Some(state) = active_state() {
+        state.set_spill_heap(heap);
+    }
+}
+
 /// RAII guard: for its lifetime, [`AstAlloc`] allocates on **global** mimalloc
 /// instead of the active per-parse state. Use when constructing
 /// `AstVec`/`StoreRef` data that must outlive the current parse arena
@@ -296,6 +341,24 @@ pub struct ScopedAstAlloc {
     prev: Option<Box<AstAllocState>>,
 }
 impl ScopedAstAlloc {
+    /// Install a state whose spill allocations land in `spill_heap` (the
+    /// caller's arena, which must outlive this guard **and** must not be reset
+    /// while the guard is alive). The scope therefore creates no `mi_heap_t`
+    /// of its own.
+    ///
+    /// SAFETY-adjacent contract (not `unsafe` because the failure mode is the
+    /// same as every other arena-backed allocation here): `spill_heap` must be
+    /// a live `mi_heap_t` for the guard's entire lifetime.
+    #[inline]
+    pub fn with_spill(spill_heap: *mut mimalloc::Heap) -> Self {
+        let mut state = acquire_state();
+        state.set_spill_heap(spill_heap);
+        Self {
+            prev: swap_state(Some(state)),
+        }
+    }
+
+    /// Install a state with a lazily created owned spill heap.
     #[inline]
     pub fn new() -> Self {
         Self {

--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -8,7 +8,7 @@
 // `#[thread_local]` (vs the `thread_local!` macro) compiles to a bare
 // `__thread` slot — single `mov reg, fs:[OFFSET]` access, no `LocalKey`
 // `__getit()` wrapper, no lazy-init flag check, no dtor-registration probe.
-// Used for the per-allocation hot-path TLS in `ast_alloc::AST_ARENA`; matches
+// Used for the per-allocation hot-path TLS in `ast_alloc::AST_ALLOC`; matches
 // Zig's `threadlocal var` semantics exactly.
 #![feature(thread_local)]
 

--- a/src/bun_alloc/stack_fallback.rs
+++ b/src/bun_alloc/stack_fallback.rs
@@ -7,14 +7,14 @@
 //!
 //! ### Relationship to `AstAlloc`
 //! `StackFallback` is a **standalone** [`Allocator`]; it is **not** composed
-//! under [`crate::ast_alloc::AstAlloc`] / `AST_HEAP`. In Zig, `stackFallback`
-//! and `ASTMemoryAllocator` are orthogonal — none of the 20 `stackFallback`
+//! under [`crate::ast_alloc::AstAlloc`]. In Zig, `stackFallback` and
+//! `ASTMemoryAllocator` are orthogonal — none of the 20 `stackFallback`
 //! callsites route AST-node allocation through it (the two `js_parser` uses
-//! pass `bun.default_allocator` as fallback, not the AST arena). A bump
-//! front-end on `AST_HEAP` was previously shipped and reverted (#53599 UAF;
-//! see the `PERF NOTE` on [`crate::ast_alloc::set_thread_heap`]). Under this
-//! standalone design `AstVec<T>` stays 24 B; only vecs that explicitly want
-//! stack-first storage become `Vec<T, &StackFallback<N, A>>` (32 B).
+//! pass `bun.default_allocator` as fallback, not the AST arena). `AstAlloc`
+//! has its own inline-buffer-with-heap-fallback state
+//! ([`crate::ast_alloc::AstAllocState`]). Under this standalone design
+//! `AstVec<T>` stays 24 B; only vecs that explicitly want stack-first storage
+//! become `Vec<T, &StackFallback<N, A>>` (32 B).
 //!
 //! ### Callsite shape
 //! ```ignore
@@ -291,7 +291,8 @@ unsafe impl<const N: usize, A: Allocator> Allocator for &StackFallback<N, A> {
 // `ASTMemoryAllocator` is published into raw thread-locals and may outlive any
 // nameable `'a`, so `&'a MimallocArena` (which already implements `Allocator`)
 // cannot be used directly. The caller guarantees the pointee outlives every
-// allocation — same invariant `ast_alloc::set_thread_arena` already requires.
+// allocation — same invariant the `ast_alloc` install/uninstall protocol
+// already requires.
 //
 // `arena == null` routes to global `mi_malloc`/`mi_free`, matching
 // [`crate::ast_alloc::AstAlloc`] when no AST scope is active.

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1550,7 +1550,7 @@ impl SourceMapData {
         let _ = alloc;
         // SAFETY: sole writer to this slot (disjoint by source_index).
         // `Worker::get` (the caller) brackets this in `ast_memory_store.push()/
-        // pop()`, so `AST_HEAP` points at this worker's `MimallocArena` and the
+        // pop()`, so the active `AstAlloc` state is this worker's and the
         // `AstAlloc` route lands the SoA slab + every `columns_for_non_ascii`
         // payload there for bulk-free on `pool.deinit()`.
         unsafe {
@@ -1593,8 +1593,8 @@ impl SourceMapData {
         }
 
         let source: &Source = &parse_graph.input_files.items_source()[source_index as usize];
-        // Allocate from the worker's AST heap (`Worker::get` has set
-        // `AST_HEAP`); ~12.5% escape-expansion slack matches `quote_for_json`'s
+        // Allocate from the worker's AST allocation state (installed by
+        // `Worker::get`); ~12.5% escape-expansion slack matches `quote_for_json`'s
         // heuristic so the writer rarely reallocs. The slack is dropped with
         // the arena at bundle end, and `StringJoiner` only borrows a `&[u8]`
         // view downstream.

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -790,8 +790,8 @@ impl<'a> LinkerGraph<'a> {
     /// `append` call site; the Rust `Vec<T, &Arena>` stores it, so swap here.
     /// Zig also transfers `part.dependencies` and `symbols`; the Rust port's
     /// `DependencyList` is `Vec<_, AstAlloc>` (linker-side grows just route
-    /// through whichever thread's `AST_HEAP` is active — `AstAlloc` is a ZST,
-    /// so there is nothing to retag) and new symbols feed through
+    /// through whichever thread's `AstAlloc` state is active — `AstAlloc` is a
+    /// ZST, so there is nothing to retag) and new symbols feed through
     /// `self.symbols: symbol::Map` (global) — neither needs transfer here.
     pub fn take_ast_ownership(&mut self, heap: &'a Arena) {
         for v in self.ast.items_import_records_mut() {

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -436,14 +436,12 @@ impl<'a> Transpiler<'a> {
         // evaluation pins the store via `DisableStoreReset`, and
         // `ParseTask`/`RuntimeTranspilerStore` call this from inside an
         // `ASTMemoryAllocator::Scope` (where the block-store reset is a no-op
-        // and `AST_HEAP` belongs to that scope's arena, NOT the side-arena).
-        // If we ran `store_ast_alloc_heap::reset()` there it would (a)
-        // `mi_heap_destroy` whatever side-arena buffers earlier main-thread
-        // transpiles left and (b) clobber `AST_HEAP` to the side-arena's new
-        // heap, so subsequent `AstVec` allocations land in the side-arena
-        // instead of the active `ASTMemoryAllocator` arena and survive its
-        // `enter()` reset → cross-reset UAF (hot.test.ts "Unexpected NUL" /
-        // transpiled `:1:12` coords on aarch64).
+        // and the active `AstAlloc` state belongs to that scope, NOT the
+        // side module). If we ran `store_ast_alloc_heap::reset()` there it
+        // would bulk-free whatever side-state buffers earlier main-thread
+        // transpiles left while `--define`/install still hold `StoreRef`s
+        // into them (and the side module's debug assert that *its* state is
+        // the installed one would fire).
         if !bun_ast::stmt::data::Store::disable_reset()
             && bun_ast::stmt::data::Store::memory_allocator().is_null()
         {

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -1051,8 +1051,9 @@ pub fn initialize_mini_store() {
             // Spec checks `stack_allocator.fixed_buffer_allocator.end_index >=
             // buffer.len() - 1`; the equivalent size gate is
             // `reset_retain_with_limit` — only pay `mi_heap_destroy + mi_heap_new`
-            // once accumulated bytes exceed 8 MiB. `push()` re-publishes the
-            // (possibly unchanged) `heap_ptr()` to `AST_HEAP`.
+            // once accumulated bytes exceed 8 MiB. The `AstAlloc` state stays
+            // installed across the re-arm (`push()` without `pop()`), so
+            // `reset_retain_with_limit` resets it in place when it recycles.
             let _ = &mini_store.heap;
             mini_store
                 .memory_store

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -34,6 +34,9 @@ pub struct InitOpts<'a> {
     pub loader: bun_ast::Loader,
     pub hash: u32,
     pub arena: Box<ArenaAllocator>,
+    /// Backs `parse_result`'s small `AstVec`s (inline bump chunk); must stay
+    /// alive alongside `arena` until the module finishes loading.
+    pub ast_alloc_state: Option<Box<bun_alloc::ast_alloc::AstAllocState>>,
 }
 
 pub struct AsyncModule {
@@ -58,6 +61,8 @@ pub struct AsyncModule {
     pub hash: u32, // default = u32::MAX
     pub global_this: crate::GlobalRef,
     pub arena: Box<ArenaAllocator>,
+    /// See [`InitOpts::ast_alloc_state`].
+    pub ast_alloc_state: Option<Box<bun_alloc::ast_alloc::AstAllocState>>,
 
     // This is the specific state for making it async
     pub poll_ref: KeepAlive,
@@ -692,6 +697,7 @@ impl AsyncModule {
             // .expr_blocks = expr_blocks,
             global_this: crate::GlobalRef::new(global_object),
             arena: opts.arena,
+            ast_alloc_state: opts.ast_alloc_state,
             poll_ref: KeepAlive::default(),
             any_task: AnyTask::AnyTask::default(),
         })

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -659,15 +659,14 @@ impl TranspilerJob {
         // Zig: `var ast_scope = ast_memory_store.?.enter(allocator); defer ast_scope.exit();`
         // PORT NOTE: Zig's per-thread `ast_memory_store` was a `StackFallback
         // Allocator` that *borrowed* the per-call `arena` above as its
-        // fallback, so its allocations were bulk-freed by `arena.deinit()`. The
-        // Rust `ASTMemoryAllocator` owns its own `MimallocArena` instead (see
-        // ast_memory_allocator.rs), so it must be stack-local too — its `Drop`
-        // (via the owned `Arena` field) `mi_heap_destroy`s the AST-node heap
-        // when `run()` returns. `Scope` restores the previous
-        // `Expr/Stmt.Data.Store.memory_allocator` on Drop and runs *before*
-        // `ast_memory_store` drops (reverse declaration order), so the
-        // thread-local AST heap pointer never dangles.
-        let mut ast_memory_store = ASTMemoryAllocator::new(&arena);
+        // fallback, so its allocations were bulk-freed by `arena.deinit()`.
+        // `borrowing()` restores that shape: the AST node store and the
+        // `AstVec` spill share `arena`'s single `mi_heap_t`, all bulk-freed
+        // when `arena` drops at the end of `run()`. `arena` is declared first,
+        // so it strictly outlives `ast_memory_store` and the `Scope` (which
+        // restores the previous `Expr/Stmt.Data.Store.memory_allocator` on
+        // Drop, before `ast_memory_store` drops).
+        let mut ast_memory_store = ASTMemoryAllocator::borrowing(&arena);
         let _ast_scope = ast_memory_store.enter();
 
         let path = self.path;

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -657,15 +657,9 @@ impl TranspilerJob {
         }
 
         // Zig: `var ast_scope = ast_memory_store.?.enter(allocator); defer ast_scope.exit();`
-        // PORT NOTE: Zig's per-thread `ast_memory_store` was a `StackFallback
-        // Allocator` that *borrowed* the per-call `arena` above as its
-        // fallback, so its allocations were bulk-freed by `arena.deinit()`.
-        // `borrowing()` restores that shape: the AST node store and the
-        // `AstVec` spill share `arena`'s single `mi_heap_t`, all bulk-freed
-        // when `arena` drops at the end of `run()`. `arena` is declared first,
-        // so it strictly outlives `ast_memory_store` and the `Scope` (which
-        // restores the previous `Expr/Stmt.Data.Store.memory_allocator` on
-        // Drop, before `ast_memory_store` drops).
+        // `borrowing()` matches the Zig shape: the AST node store and the
+        // `AstVec` spill share `arena`'s heap and are bulk-freed when `arena`
+        // drops at the end of `run()`.
         let mut ast_memory_store = ASTMemoryAllocator::borrowing(&arena);
         let _ast_scope = ast_memory_store.enter();
 

--- a/src/runtime/api.rs
+++ b/src/runtime/api.rs
@@ -251,7 +251,7 @@ pub(crate) fn with_text_format_source<R>(
 
     // PERF(port): was ArenaAllocator bulk-free feeding the parser + AST stores.
     let arena = bun_alloc::Arena::new();
-    let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::new(&arena);
+    let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::borrowing(&arena);
     let _ast_scope = ast_memory_allocator.enter();
 
     let input_value = frame.argument(0);

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -792,7 +792,7 @@ impl<'a> TransformTask<'a> {
 
         // TODO(port): ASTMemoryAllocator scope — typed_arena in AST crates; here we just
         // construct one and enter it. Model as RAII guard.
-        let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::new(&arena);
+        let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::borrowing(&arena);
         let _ast_scope = ast_memory_allocator.enter();
 
         // SAFETY: `arena` outlives every use through `self.transpiler` in this fn body;
@@ -1390,7 +1390,7 @@ impl JSTranspiler {
             prev_macro_context: None,
         };
 
-        let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::new(&arena);
+        let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::borrowing(&arena);
         let _ast_scope = ast_memory_allocator.enter();
 
         let parse_result = self.get_parse_result(arena_ref, code, loader, MacroJSCtx::ZERO);
@@ -1553,7 +1553,7 @@ impl JSTranspiler {
             None
         };
 
-        let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::new(&arena);
+        let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::borrowing(&arena);
         let _ast_scope = ast_memory_allocator.enter();
 
         // PORT NOTE: spec snapshots the WHOLE `this.transpiler` by value
@@ -1772,7 +1772,7 @@ impl JSTranspiler {
             prev_macro_context: None,
         };
 
-        let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::new(&arena);
+        let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::borrowing(&arena);
         let _ast_scope = ast_memory_allocator.enter();
 
         let source = bun_ast::Source::init_path_string(loader.stdin_name(), code);

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -3210,6 +3210,22 @@ impl DevServer {
         // TODO(port): ASTMemoryAllocator scope — bake is an AST crate; arena threading required
         let ast_memory_store: *mut bun_ast::ASTMemoryAllocator =
             heap.alloc(bun_ast::ASTMemoryAllocator::default());
+        // The arena-allocated `ASTMemoryAllocator` above never runs `Drop`
+        // (its bytes are bulk-freed with the bundle heap), so the
+        // `AstAllocState` the `Scope` hands back to it on exit would be
+        // stranded — one 16 KB box per dev-server bundle. Recycle it
+        // explicitly once the scope has exited. Declared *before* `_ast_scope`
+        // so it drops after it on every return path.
+        struct ReleaseAstState(*mut bun_ast::ASTMemoryAllocator);
+        impl Drop for ReleaseAstState {
+            fn drop(&mut self) {
+                // SAFETY: `0` points at the arena-allocated allocator in
+                // `heap`, which outlives this guard; the `Scope` (declared
+                // after, dropped before) has already returned the state to it.
+                unsafe { (*self.0).release_ast_state() };
+            }
+        }
+        let _release_ast_state = ReleaseAstState(ast_memory_store);
         // SAFETY: the `ASTMemoryAllocator` lives in a bumpalo chunk owned by
         // `heap` → `bv2.graph.heap`; address is stable for the bv2 lifetime,
         // and `_ast_scope` is dropped before `bv2` at end of this fn.

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -3210,18 +3210,14 @@ impl DevServer {
         // TODO(port): ASTMemoryAllocator scope — bake is an AST crate; arena threading required
         let ast_memory_store: *mut bun_ast::ASTMemoryAllocator =
             heap.alloc(bun_ast::ASTMemoryAllocator::default());
-        // The arena-allocated `ASTMemoryAllocator` above never runs `Drop`
-        // (its bytes are bulk-freed with the bundle heap), so the
-        // `AstAllocState` the `Scope` hands back to it on exit would be
-        // stranded — one 16 KB box per dev-server bundle. Recycle it
-        // explicitly once the scope has exited. Declared *before* `_ast_scope`
-        // so it drops after it on every return path.
+        // The arena-allocated `ASTMemoryAllocator` never runs `Drop`, so
+        // recycle its `AstAllocState` once the scope exits (declared before
+        // `_ast_scope` so it drops after it).
         struct ReleaseAstState(*mut bun_ast::ASTMemoryAllocator);
         impl Drop for ReleaseAstState {
             fn drop(&mut self) {
-                // SAFETY: `0` points at the arena-allocated allocator in
-                // `heap`, which outlives this guard; the `Scope` (declared
-                // after, dropped before) has already returned the state to it.
+                // SAFETY: points at the arena-allocated allocator in `heap`,
+                // which outlives this guard; the `Scope` has already exited.
                 unsafe { (*self.0).release_ast_state() };
             }
         }

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -259,6 +259,9 @@ pub struct CurrentBundle {
     /// Owns the arena that `bv2.graph.heap` borrows (`'static` self-ref via the
     /// boxed allocation's stable address; same erasure as `bv2` above).
     pub heap: Box<bun_alloc::MimallocArena>,
+    /// Backs the small `AstVec`s built during bundle setup
+    /// (`start_async_bundle`'s AST scope); dropped with the bundle.
+    pub ast_alloc_state: Option<Box<bun_alloc::ast_alloc::AstAllocState>>,
     /// Information BundleV2 needs to finalize the bundle
     pub start_data: bundler::bundle_v2::DevServerInput,
     /// Started when the bundle was queued
@@ -3207,12 +3210,12 @@ impl DevServer {
         // borrows it (self-ref via `CurrentBundle`, see PORT NOTE on
         // `CurrentBundle.bv2`).
         let heap: Box<bun_alloc::MimallocArena> = Box::new(bun_alloc::MimallocArena::new());
-        // TODO(port): ASTMemoryAllocator scope — bake is an AST crate; arena threading required
+        // Borrows `heap` (Zig parity), so AST nodes built during bundle setup
+        // live exactly as long as the bundle. The arena-allocated allocator
+        // never runs `Drop`; the `AstAllocState` is taken into `CurrentBundle`
+        // on success and recycled by the guard below on error paths.
         let ast_memory_store: *mut bun_ast::ASTMemoryAllocator =
-            heap.alloc(bun_ast::ASTMemoryAllocator::default());
-        // The arena-allocated `ASTMemoryAllocator` never runs `Drop`, so
-        // recycle its `AstAllocState` once the scope exits (declared before
-        // `_ast_scope` so it drops after it).
+            heap.alloc(bun_ast::ASTMemoryAllocator::borrowing(&heap));
         struct ReleaseAstState(*mut bun_ast::ASTMemoryAllocator);
         impl Drop for ReleaseAstState {
             fn drop(&mut self) {
@@ -3224,8 +3227,9 @@ impl DevServer {
         let _release_ast_state = ReleaseAstState(ast_memory_store);
         // SAFETY: the `ASTMemoryAllocator` lives in a bumpalo chunk owned by
         // `heap` → `bv2.graph.heap`; address is stable for the bv2 lifetime,
-        // and `_ast_scope` is dropped before `bv2` at end of this fn.
-        let _ast_scope = unsafe { &mut *ast_memory_store }.enter();
+        // and `ast_scope` is dropped before `bv2` is moved into
+        // `current_bundle` below.
+        let ast_scope = unsafe { &mut *ast_memory_store }.enter();
 
         // Zig: `.{ .js = dev.vm.eventLoop() }` constructed an `AnyEventLoop`
         // by value; the Rust bundler instead stores
@@ -3303,9 +3307,16 @@ impl DevServer {
             bt
         })?;
         drop(entry_points);
+        // End the AST scope and move its state into the bundle so the small
+        // `AstVec`s built during setup stay alive until the bundle completes.
+        drop(ast_scope);
+        // SAFETY: `ast_memory_store` lives in `heap`; the scope above has
+        // exited, so no `&mut` to the allocator is live.
+        let ast_alloc_state = unsafe { (*ast_memory_store).take_ast_state() };
         self.current_bundle = Some(CurrentBundle {
             bv2,
             heap,
+            ast_alloc_state,
             timer,
             start_data,
             had_reload_event,

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -1199,7 +1199,7 @@ impl Framework {
         // `enter`/`exit`; the Rust port collapses that to `ASTMemoryAllocator::enter`
         // returning the RAII `Scope`, whose `Drop` runs `exit()` at end-of-fn
         // (Zig's `defer ast_scope.exit()`).
-        let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::new_without_stack(arena);
+        let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::borrowing(arena);
         let _ast_scope = ast_memory_allocator.enter();
 
         // PORT NOTE: Zig passed `out: *Transpiler` pointing at `= undefined`

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -1197,11 +1197,10 @@ impl Framework {
     ) -> Result<(), bun_core::Error> {
         // PORT NOTE: Zig built `ASTMemoryAllocator.Scope` by hand and called
         // `enter`/`exit`; the Rust port collapses that to `ASTMemoryAllocator::enter`
-        // returning the RAII `Scope`. `defer ast_scope.exit()` is the explicit
-        // exit at end-of-fn (the Scope has no Drop yet).
+        // returning the RAII `Scope`, whose `Drop` runs `exit()` at end-of-fn
+        // (Zig's `defer ast_scope.exit()`).
         let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::new_without_stack(arena);
-        let ast_scope = ast_memory_allocator.enter();
-        let _guard = scopeguard::guard(ast_scope, |s| s.exit());
+        let _ast_scope = ast_memory_allocator.enter();
 
         // PORT NOTE: Zig passed `out: *Transpiler` pointing at `= undefined`
         // memory and assigned `out.* = try Transpiler.init(...)`. In Rust the

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -228,8 +228,7 @@ impl Framework {
         use bun_options_types::schema as bun_schema;
 
         let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::new_without_stack(arena);
-        let ast_scope = ast_memory_allocator.enter();
-        let _guard = scopeguard::guard(ast_scope, |s| s.exit());
+        let _ast_scope = ast_memory_allocator.enter();
 
         let out: &mut bun_bundler::Transpiler = out.write(bun_bundler::Transpiler::init(
             arena,

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -227,7 +227,7 @@ impl Framework {
     ) -> Result<*mut bun_bundler::bake_types::Framework, bun_core::Error> {
         use bun_options_types::schema as bun_schema;
 
-        let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::new_without_stack(arena);
+        let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::borrowing(arena);
         let _ast_scope = ast_memory_allocator.enter();
 
         let out: &mut bun_bundler::Transpiler = out.write(bun_bundler::Transpiler::init(

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2069,13 +2069,10 @@ fn transpile_source_code_inner(
             unsafe { (*jsc_vm).transpiled_count += 1 };
             // Spec :122 — `Transpiler::reset_store`.
             // Inline only the block-store half and SKIP
-            // `store_ast_alloc_heap::reset()`: we bind `AST_HEAP` to
-            // `arena.heap_ptr()` below so `AstAlloc` and the parser scratch
-            // share ONE `mi_heap_t*` for this transpile. The two have
-            // identical lifetime — both reclaimed at the give-back
-            // `arena.reset_retain_with_limit` — so unifying is semantically
-            // equivalent and also drops the per-file `mi_heap_destroy`/
-            // `mi_heap_new` pair the side-arena reset paid.
+            // `store_ast_alloc_heap::reset()`: the `ScopedAstAlloc` installed
+            // below gives `AstAlloc` a per-transpile state with the same
+            // lifetime as the parser scratch arena, so the side module's
+            // long-lived state is neither needed nor touched here.
             bun_ast::Expr::data_store_reset();
             bun_ast::Stmt::data_store_reset();
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2093,12 +2093,10 @@ fn transpile_source_code_inner(
             // Stable heap address (Box interior); survives the move into
             // `arena_guard` and into the VM slot on give-back.
             let arena_ptr: *const bun_alloc::Arena = &raw const *arena;
-            // Install a per-transpile `AstAlloc` state (see the `reset_store`
-            // note above). `_ast_scope.enter()` detached `AstAlloc` to the
-            // global fallback; this gives the parser's `AstVec`s an arena that
-            // is bulk-freed when this guard drops — after `arena_guard` has
-            // run, so nothing that reads the AST outlives it.
-            let _ast_alloc_scope = bun_alloc::ast_alloc::ScopedAstAlloc::new();
+            // `mi_heap_t` of the transpile arena, captured before `arena`
+            // moves into `arena_guard`. The Box interior (and therefore the
+            // heap handle it owns) is address-stable across that move.
+            let arena_heap: *mut bun_alloc::mimalloc::Heap = arena.heap_ptr();
             let give_back_arena = true;
             // PORT NOTE: reshaped for borrowck — Zig's `defer` block becomes a
             // scopeguard so `?`-early-returns still run it.
@@ -2183,6 +2181,15 @@ fn transpile_source_code_inner(
                     // else: drop the fresh Box (spec :161-163).
                 },
             );
+            // Install a per-transpile `AstAlloc` state spilling into the
+            // transpile arena (see the `reset_store` note above) — the
+            // parser's `AstVec`s share the arena's single `mi_heap_t` and are
+            // bulk-freed with it. `_ast_scope.enter()` detached `AstAlloc` to
+            // the global fallback; this re-attaches it. Declared *after*
+            // `arena_guard` so it drops (uninstalls the state and clears its
+            // pointer into the arena's heap) before the guard can reset that
+            // heap.
+            let _ast_alloc_scope = bun_alloc::ast_alloc::ScopedAstAlloc::with_spill(arena_heap);
             // ── Watcher fd / package_json lookup ────────────────────────────
             // Spec :170-176.
             let mut fd: Option<bun_sys::Fd> = None;

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2096,23 +2096,18 @@ fn transpile_source_code_inner(
             // Stable heap address (Box interior); survives the move into
             // `arena_guard` and into the VM slot on give-back.
             let arena_ptr: *const bun_alloc::Arena = &raw const *arena;
-            // Route `AstAlloc` to `arena`'s `mi_heap_t*` (see the
-            // `reset_store` note above). `_ast_scope.enter()` already nulled
-            // `AST_HEAP`; this rebinds it to the heap that the parser scratch
-            // and printer arena allocations also use.
-            bun_alloc::ast_alloc::set_thread_heap(arena.heap_ptr());
+            // Install a per-transpile `AstAlloc` state (see the `reset_store`
+            // note above). `_ast_scope.enter()` detached `AstAlloc` to the
+            // global fallback; this gives the parser's `AstVec`s an arena that
+            // is bulk-freed when this guard drops — after `arena_guard` has
+            // run, so nothing that reads the AST outlives it.
+            let _ast_alloc_scope = bun_alloc::ast_alloc::ScopedAstAlloc::new();
             let give_back_arena = true;
             // PORT NOTE: reshaped for borrowck — Zig's `defer` block becomes a
             // scopeguard so `?`-early-returns still run it.
             let mut arena_guard = scopeguard::guard(
                 (jsc_vm, arena, give_back_arena, args.flags),
                 |(jsc_vm, mut arena, give_back, flags)| {
-                    // `AST_HEAP` was bound to `arena.heap_ptr()` for this
-                    // transpile; clear it before `reset()` (which is
-                    // `mi_heap_destroy` + `mi_heap_new`) so it never dangles.
-                    // `_ast_scope.exit()` (drops after this guard) restores
-                    // the surrounding scope's heap regardless.
-                    bun_alloc::ast_alloc::set_thread_heap(core::ptr::null_mut());
                     // SAFETY: `jsc_vm` is the live per-thread VM (closure runs
                     // on the same thread, before the hook returns).
                     let slot = unsafe { &mut (*jsc_vm).module_loader.transpile_source_code_arena };

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2067,12 +2067,9 @@ fn transpile_source_code_inner(
 
             // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
             unsafe { (*jsc_vm).transpiled_count += 1 };
-            // Spec :122 — `Transpiler::reset_store`.
-            // Inline only the block-store half and SKIP
-            // `store_ast_alloc_heap::reset()`: the `ScopedAstAlloc` installed
-            // below gives `AstAlloc` a per-transpile state with the same
-            // lifetime as the parser scratch arena, so the side module's
-            // long-lived state is neither needed nor touched here.
+            // Spec :122 — `Transpiler::reset_store`. Inline only the
+            // block-store half; `AstAlloc` gets its own per-transpile state
+            // below, so the side module's long-lived state is not touched.
             bun_ast::Expr::data_store_reset();
             bun_ast::Stmt::data_store_reset();
 
@@ -2093,9 +2090,8 @@ fn transpile_source_code_inner(
             // Stable heap address (Box interior); survives the move into
             // `arena_guard` and into the VM slot on give-back.
             let arena_ptr: *const bun_alloc::Arena = &raw const *arena;
-            // `mi_heap_t` of the transpile arena, captured before `arena`
-            // moves into `arena_guard`. The Box interior (and therefore the
-            // heap handle it owns) is address-stable across that move.
+            // Captured before `arena` moves into `arena_guard` (the Box
+            // interior is address-stable across the move).
             let arena_heap: *mut bun_alloc::mimalloc::Heap = arena.heap_ptr();
             let give_back_arena = true;
             // PORT NOTE: reshaped for borrowck — Zig's `defer` block becomes a
@@ -2181,15 +2177,13 @@ fn transpile_source_code_inner(
                     // else: drop the fresh Box (spec :161-163).
                 },
             );
-            // Install a per-transpile `AstAlloc` state spilling into the
-            // transpile arena (see the `reset_store` note above) — the
-            // parser's `AstVec`s share the arena's single `mi_heap_t` and are
-            // bulk-freed with it. `_ast_scope.enter()` detached `AstAlloc` to
-            // the global fallback; this re-attaches it. Declared *after*
-            // `arena_guard` so it drops (uninstalls the state and clears its
-            // pointer into the arena's heap) before the guard can reset that
-            // heap.
-            let _ast_alloc_scope = bun_alloc::ast_alloc::ScopedAstAlloc::with_spill(arena_heap);
+            // Per-transpile `AstAlloc` state spilling into the transpile
+            // arena. Declared after `arena_guard` so it drops before the
+            // guard can reset that heap. Small `AstVec`s live in the state's
+            // inline chunk, not the arena, so the pending-imports path must
+            // consume this scope via `take_state()` and ship the box with the
+            // arena.
+            let ast_alloc_scope = bun_alloc::ast_alloc::ScopedAstAlloc::with_spill(arena_heap);
             // ── Watcher fd / package_json lookup ────────────────────────────
             // Spec :170-176.
             let mut fd: Option<bun_sys::Fd> = None;
@@ -2890,6 +2884,9 @@ fn transpile_source_code_inner(
 
                     // Hand `arena` ownership to the queue (defuse the give-back guard).
                     let (_, arena, _, _) = scopeguard::ScopeGuard::into_inner(arena_guard);
+                    // Hand the `AstAlloc` state to the queue too: the queued
+                    // AST's small `AstVec`s live in its inline bump chunk.
+                    let ast_alloc_state = ast_alloc_scope.take_state();
                     // SAFETY: per fn contract — `jsc_vm` / `global_object` are the live
                     // per-thread VM / global; `package_json` is the opaque watcher
                     // forward-decl of `bun_resolver::package_json::PackageJSON`.
@@ -2910,6 +2907,7 @@ fn transpile_source_code_inner(
                                 referrer,
                                 hash,
                                 arena,
+                                ast_alloc_state,
                             },
                         );
                     }

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -275,7 +275,7 @@ it("process.versions", () => {
   const expectedVersions = {
     boringssl: "0c5fce43b7ed5eb6001487ee48ac65766f5ddcd1",
     libarchive: "ded82291ab41d5e355831b96b0e1ff49e24d8939",
-    mimalloc: "24f9c6b49e2e33855a7d08a9f1e07a6fccce8820",
+    mimalloc: "afb41757285694f832e7a2f164d35f5717457f96",
     picohttpparser: "066d2b1e9ab820703db0837a7255d92d30f0c9f5",
     zlib: "12731092979c6d07f42da27da673a9f6c7b13586",
     tinycc: "12882eee073cfe5c7621bcfadf679e1372d4537b",


### PR DESCRIPTION
### What does this PR do?

Fixes the rare (~1 in 20k runs) `Segmentation fault at address 0x0/0x8/0xE92` crash in heavily concurrent transpile workloads (`vendor/elysia/test/sucrose/bracket-pair-range.test.ts` in CI), and restructures the AST allocators along the way.

### The actual bug: mimalloc thread-local slot resurrection (commit `mimalloc: bump to afb41757`)

`mi_thread_locals_expand()` grows the per-thread heap→theap slot array with `mi_rezalloc` and assumes the new slots come back zeroed. `mi_rezalloc` copies `mi_usable_size(old)` bytes — the live slots **plus the uninitialized slack between the old requested size and the old bin size** — and only zeroes beyond that. Under heavy `mi_heap_new`/`mi_heap_destroy` churn that slack holds whatever the previous tenant of the recycled page wrote, so a new slot can come up as arbitrary application bytes. `_mi_thread_local_get` validates a slot only by comparing its version lane against the key's version (a small sequential counter), so a garbage lane that happens to equal a live key's version makes the adjacent garbage lane get dereferenced as a cached `mi_theap_t*` — after which mimalloc itself corrupts whatever the fake theap's page queues and stat counters point at: other threads' heap blocks, their stacks, or more of mimalloc's own metadata.

That is why the corrupting bytes in the crash dumps decode as parser records (export-clause items, object-literal properties): the recycled page's previous tenant was a destroyed per-job AST heap. Post-mortem forensics on two cores traced every downstream symptom (a corrupted parser struct on another thread's stack, garbage page queues, the `_mi_heap_theap_get_or_init` null derefs) back to a single poisoned 16-byte slot.

The bug reproduces in the mimalloc fork alone with no Bun code: a 64-thread `mi_heap_new`/`malloc`/`mi_heap_destroy` churn loop crashes 4 times in 2,000 process runs unpatched and 0 times in 2,000 with the fix. The fix and the stress test are in [`oven-sh/mimalloc@afb41757`](https://github.com/oven-sh/mimalloc/commit/afb41757285694f832e7a2f164d35f5717457f96) (`src/threadlocal.c` + `test/test-heap-churn.c`); this PR bumps `MIMALLOC_COMMIT` to it.

### AST allocator restructuring (the other three commits)

1. **`ast_alloc`: replace the bare thread-local bump cursor with an owned per-scope state.** The small-`AstVec` fast path kept its bump cursor in bare `#[thread_local]` statics pointing into a chunk owned by a destroyable `mi_heap_t`; the only thing preventing a write through a dangling cursor was a manual `bump_invalidate_heap()` call before every `mi_heap_destroy`. The cursor, the 16 KB chunk, and the spill target now live in one `AstAllocState` owned by whichever scope installed it, so none of them can outlive the others.
2. **Free the spare `AstAllocState` at thread exit** (`#[thread_local]` statics run no destructors; the parked 16 KB box is a global-heap allocation, so every terminated Web Worker that had parsed JS leaked one).
3. **One `mi_heap_t` per transpile job instead of three.** `ASTMemoryAllocator::borrowing(&arena)` routes the AST node store and the `AstVec` spill into the job's existing scratch arena (matching the original Zig `StackFallbackAllocator` design) instead of each owning a heap. Measured on the elysia workload: **530 → 114 `mi_heap_new` calls per process**. Fewer heap lifecycles also means fewer TLS key claims and a smaller heap→theap slot array — a smaller surface for the class of bug above.

### How was it verified?

- Standalone mimalloc stress test: 4 crashes / 2,000 runs unpatched → 0 / 2,000 patched.
- The elysia stress harness (16 workers × 6,000 iterations of `bracket-pair-range.test.ts` against the CI release artifact) reproduced the crash at the baseline rate (5 / 96,000) **before** the mimalloc fix; the same harness will be run against this PR's artifact.
- `cargo check` on all 10 cross-platform targets, clippy clean, the elysia test, `test/bundler/transpiler/` (one pre-existing failure that also fails on released Bun 1.4.0), and `Bun.build` smoke tests pass against the consolidated allocator.