### PR TITLE
RacyCell: replace the unconditional Sync impl with an owner-thread runtime check

### DIFF
--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -646,9 +646,12 @@ pub mod windows_stdio {
         #[cfg(debug_assertions)]
         fd_internals::WINDOWS_CACHED_FD_SET.store(true, Ordering::Relaxed);
 
-        // SAFETY: BUFFERED_STDIN is a static initialized at startup before use.
+        // SAFETY: BUFFERED_STDIN is a static initialized at startup before
+        // use; this single-threaded startup write happens-before any reader.
+        // Unsync — readers (`prompt()`) may later run on any thread (see
+        // `buffered_stdin`).
         unsafe {
-            (*BUFFERED_STDIN.get()).fd = Fd::stdin();
+            (*BUFFERED_STDIN.get_unsync()).fd = Fd::stdin();
         }
 
         // https://learn.microsoft.com/en-us/windows/console/setconsoleoutputcp
@@ -2941,11 +2944,18 @@ pub fn stdin_reader() -> StdinReader {
 /// `&mut` at the use site. Matches the other self-ref escapes in this module
 /// (`writer()`, `error_writer()`, …).
 ///
-/// SAFETY: the static is single-threaded by construction (only ever touched
-/// from the main JS/CLI thread while blocked on user input).
+/// SAFETY: the static is single-threaded *by convention* (touched from the
+/// main JS/CLI thread while blocked on user input), but `prompt()` is exposed
+/// on `Worker` global scopes too, so the pointer can be requested from more
+/// than one thread. Unsync — concurrent `prompt()` calls already interleave
+/// reads of this one shared buffer (a pre-existing race documented in the
+/// RacyCell audit); the owner check would turn that into a panic on a path
+/// that is expected to "work".
 #[inline]
 pub fn buffered_stdin() -> *mut BufferedStdin {
-    BUFFERED_STDIN.get()
+    // SAFETY: see the doc comment above — only the address is produced here;
+    // the caller's deref carries the aliasing obligation.
+    unsafe { BUFFERED_STDIN.get_unsync() }
     // TODO(port): self-ref pointer escape — see error_writer()
 }
 

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -275,7 +275,10 @@ thread_local! {
 }
 
 // These are not threadlocal so we avoid opening stdout/stderr for every thread
-// Guarded by STDOUT_STREAM_SET (write-once at startup before threads).
+// Guarded by STDOUT_STREAM_SET (write-once at startup before threads). Read
+// from every spawned thread in `configure_thread`, so all access is via the
+// `*_unsync` accessors with the spawn happens-before edge as the SAFETY
+// argument.
 static STDERR_STREAM: crate::RacyCell<StreamType> = crate::RacyCell::new(StreamType::ZEROED);
 static STDOUT_STREAM: crate::RacyCell<StreamType> = crate::RacyCell::new(StreamType::ZEROED);
 static STDOUT_STREAM_SET: AtomicBool = AtomicBool::new(false);
@@ -414,9 +417,11 @@ impl Source {
             return;
         }
         debug_assert!(STDOUT_STREAM_SET.load(Ordering::Relaxed));
-        // SAFETY: STDOUT_STREAM/STDERR_STREAM are write-once before any thread calls this.
+        // SAFETY: STDOUT_STREAM/STDERR_STREAM are write-once before any thread
+        // calls this (thread spawn is the happens-before edge); read-only here.
+        // Unsync because every spawned thread runs this.
         SOURCE.with_borrow_mut(|s| unsafe {
-            Source::init(s, STDOUT_STREAM.read(), STDERR_STREAM.read())
+            Source::init(s, STDOUT_STREAM.read_unsync(), STDERR_STREAM.read_unsync())
         });
         crate::StackCheck::configure_thread();
     }
@@ -442,9 +447,11 @@ impl Source {
             return;
         }
         debug_assert!(STDOUT_STREAM_SET.load(Ordering::Relaxed));
-        // SAFETY: STDOUT_STREAM/STDERR_STREAM are write-once before any thread calls this.
+        // SAFETY: STDOUT_STREAM/STDERR_STREAM are write-once before any thread
+        // calls this (thread spawn is the happens-before edge); read-only here.
+        // Unsync because every spawned thread runs this.
         SOURCE.with_borrow_mut(|s| unsafe {
-            Source::init(s, STDOUT_STREAM.read(), STDERR_STREAM.read())
+            Source::init(s, STDOUT_STREAM.read_unsync(), STDERR_STREAM.read_unsync())
         });
         // Intentionally NOT calling `crate::StackCheck::configure_thread()`.
     }
@@ -531,10 +538,13 @@ impl Source {
                     .store(enable_color.unwrap_or(is_stderr_tty), Ordering::Relaxed);
             }
 
-            // SAFETY: write-once init guarded by STDOUT_STREAM_SET above.
+            // SAFETY: write-once init guarded by STDOUT_STREAM_SET above,
+            // during single-threaded startup before any thread that calls
+            // `configure_thread` is spawned. Unsync because the readers in
+            // `configure_thread` run on every spawned thread.
             unsafe {
-                STDOUT_STREAM.write(stdout);
-                STDERR_STREAM.write(stderr);
+                STDOUT_STREAM.write_unsync(stdout);
+                STDERR_STREAM.write_unsync(stderr);
             }
         }
     }
@@ -2172,7 +2182,9 @@ pub fn _scoped_use_ansi() -> bool {
     ENABLE_ANSI_COLORS_STDOUT.load(Ordering::Relaxed) && SOURCE_SET.get() && {
         // SAFETY: `SCOPED_FILE_WRITER` is `QuietWriter::ZEROED` until startup
         // init; `QuietWriter` is Copy POD so reading it is always sound.
-        let sw = unsafe { scoped_debug_writer::SCOPED_FILE_WRITER.read() };
+        // Unsync because scoped logging may run on any thread; the write-once
+        // init happens before worker threads spawn.
+        let sw = unsafe { scoped_debug_writer::SCOPED_FILE_WRITER.read_unsync() };
         sw.context_handle() == raw_writer().handle()
     }
 }
@@ -2720,19 +2732,21 @@ pub fn init_scoped_debug_writer_at_startup() {
             // `create_file` above already opens for writing with truncate, so the explicit
             // `fd.truncate(0)` from Zig is a no-op here until the vtable entry lands.
             let _ = &fd; // windows
-            // SAFETY: single-threaded startup.
+            // SAFETY: single-threaded startup, before any reader thread is
+            // spawned (unsync because readers may later be on any thread).
             unsafe {
                 scoped_debug_writer::SCOPED_FILE_WRITER
-                    .write(output_sink().quiet_writer_from_fd(fd));
+                    .write_unsync(output_sink().quiet_writer_from_fd(fd));
             }
             return;
         }
     }
 
-    // SAFETY: single-threaded startup.
+    // SAFETY: single-threaded startup, before any reader thread is spawned
+    // (unsync because readers may later be on any thread).
     unsafe {
         scoped_debug_writer::SCOPED_FILE_WRITER
-            .write(output_sink().quiet_writer_from_fd(SOURCE.with_borrow(|s| s.raw_stream).0));
+            .write_unsync(output_sink().quiet_writer_from_fd(SOURCE.with_borrow(|s| s.raw_stream).0));
     }
 }
 
@@ -2746,8 +2760,9 @@ fn scoped_writer() -> QuietWriter {
     if !Environment::ENABLE_LOGS {
         unreachable!("scopedWriter() should only be called in debug mode");
     }
-    // SAFETY: initialized in init_scoped_debug_writer_at_startup; QuietWriter is Copy POD.
-    unsafe { scoped_debug_writer::SCOPED_FILE_WRITER.read() }
+    // SAFETY: initialized in init_scoped_debug_writer_at_startup; QuietWriter
+    // is Copy POD. Unsync because scoped logging may run on any thread.
+    unsafe { scoped_debug_writer::SCOPED_FILE_WRITER.read_unsync() }
 }
 
 /// Print a red error message with "error: " as the prefix. For custom prefixes see `err()`

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -2745,8 +2745,9 @@ pub fn init_scoped_debug_writer_at_startup() {
     // SAFETY: single-threaded startup, before any reader thread is spawned
     // (unsync because readers may later be on any thread).
     unsafe {
-        scoped_debug_writer::SCOPED_FILE_WRITER
-            .write_unsync(output_sink().quiet_writer_from_fd(SOURCE.with_borrow(|s| s.raw_stream).0));
+        scoped_debug_writer::SCOPED_FILE_WRITER.write_unsync(
+            output_sink().quiet_writer_from_fd(SOURCE.with_borrow(|s| s.raw_stream).0),
+        );
     }
 }
 

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -2293,72 +2293,236 @@ impl Version {
 }
 
 // ─── RacyCell ─────────────────────────────────────────────────────────────
-/// Stable equivalent of `core::cell::SyncUnsafeCell<T>` (nightly-only as of
-/// 1.79). A `static`-safe interior-mutability cell with **no** synchronization.
+/// A `static`-safe interior-mutability cell whose **safe** accessors are
+/// confined to a single owning thread, checked at runtime in release builds.
 ///
 /// This exists to replace `static mut` (banned per docs/PORTING.md §Global
 /// mutable state). Unlike `static mut`, taking `&RACY` does not assert
 /// uniqueness; callers stay in raw-ptr land via `.get()` and only deref for
 /// the duration of a single statement.
 ///
-/// **Invariant the caller upholds:** all access is either single-threaded
-/// (e.g. HTTP-thread-only buffers, main-thread-only CLI state) or externally
-/// synchronized. For anything actually shared across threads, use
-/// `Atomic*` / `OnceLock` / `Mutex` instead — `RacyCell` is the last resort
-/// for scratch buffers and FFI-shaped globals where the Zig already proved
-/// thread-affinity.
-#[repr(transparent)]
-pub struct RacyCell<T: ?Sized>(core::cell::Cell<T>);
-// SAFETY: by construction, callers promise external synchronization or
-// single-thread access. Unlike std's nightly `SyncUnsafeCell` (which gates
-// `Sync` on `T: Sync`), this impl is intentionally unconditional: many
-// payloads ported from `static mut` are `!Sync` only by auto-trait inference
-// (raw pointers, `MaybeUninit<T>` over FFI handles) yet are sound to share
-// because all access is single-threaded or externally synchronized — the
-// exact contract `static mut` already imposed. **Do not** wrap *payloads*
-// whose `!Sync` is load-bearing (`Cell<U>`, `Rc<U>`, `RefCell<U>`); use
-// `thread_local!` or a real lock for those. (The inner storage here is
-// `Cell<T>` purely so `read`/`write` bodies are safe code — the cross-thread
-// hazard is fully accounted for by this `unsafe impl Sync`.)
+/// The first thread to call [`get`](Self::get) / [`read`](Self::read) /
+/// [`write`](Self::write) becomes the owner; any later call from a different
+/// thread panics — in release builds too. That check is what makes the
+/// `unsafe impl Sync` below sound: a `&RacyCell<T>` may be reachable from any
+/// thread, but only the owning thread can ever obtain a payload pointer
+/// through the checked accessors, so a cross-thread data race is downgraded
+/// to a deterministic panic.
+///
+/// State that genuinely crosses threads must use `Atomic*` / `OnceLock` /
+/// `Mutex` / [`AtomicCell`](crate::AtomicCell) — or, where the
+/// synchronization is external and cannot be expressed in the type system,
+/// the `unsafe` [`get_unsync`](Self::get_unsync) escape hatch, whose call
+/// site documents the happens-before edge.
+///
+/// Cost of the checked accessors: one TLS read + one relaxed atomic load +
+/// compare per access (plus a one-time CAS on the first access).
+pub struct RacyCell<T: ?Sized> {
+    /// OS thread id of the owning thread. `0` = not yet claimed (kernel TIDs,
+    /// `pthread_threadid_np` ids and Win32 thread ids are all nonzero — see
+    /// [`crate::thread_id`]).
+    owner: core::sync::atomic::AtomicU64,
+    value: core::cell::UnsafeCell<T>,
+}
+// SAFETY: the payload is only reachable through (a) the checked accessors,
+// which panic unless the calling thread is the unique owner — so safe code
+// can never observe the payload from two threads — or (b) the `*_unsync`
+// accessors, which are `unsafe fn`s whose callers assert external
+// synchronization. Sharing `&RacyCell<T>` across threads therefore cannot
+// cause a data race without an `unsafe` block taking responsibility for it.
 unsafe impl<T: ?Sized> Sync for RacyCell<T> {}
-// SAFETY: `RacyCell<T>` owns a `T` by value via `Cell<T>`; sending the cell to
-// another thread is sound exactly when sending `T` itself is (`T: Send`).
+// SAFETY: `RacyCell<T>` owns a `T` by value; sending the cell to another
+// thread is sound exactly when sending `T` itself is (`T: Send`). `owner` is
+// an atomic and carries no thread affinity of its own.
 unsafe impl<T: ?Sized + Send> Send for RacyCell<T> {}
 
 impl<T> RacyCell<T> {
     #[inline]
     pub const fn new(value: T) -> Self {
-        Self(core::cell::Cell::new(value))
+        Self {
+            owner: core::sync::atomic::AtomicU64::new(0),
+            value: core::cell::UnsafeCell::new(value),
+        }
     }
-    /// Raw pointer to the contained value. Never produces a reference; callers
-    /// deref per-access (`unsafe { *X.get() }` / `unsafe { (*X.get()).field }`).
-    #[inline]
-    pub const fn get(&self) -> *mut T {
-        self.0.as_ptr()
-    }
-    /// Convenience: read a `Copy` value. Single load, no aliasing assertion.
+    /// Convenience: read a `Copy` value (owner-thread checked).
     ///
     /// # Safety
-    /// Caller guarantees no concurrent writer on another thread.
+    /// No `&mut T` derived from [`get`](Self::get) / [`get_unsync`](Self::get_unsync)
+    /// may be live across this call.
     #[inline]
     pub unsafe fn read(&self) -> T
     where
         T: Copy,
     {
-        self.0.get()
+        // SAFETY: `get()` confines access to the owning thread; the caller
+        // upholds the no-live-`&mut` contract above.
+        unsafe { *self.get() }
     }
-    /// Convenience: overwrite the value.
+    /// Convenience: overwrite the value (owner-thread checked). Drops the
+    /// previous value in place.
     ///
     /// # Safety
-    /// Caller guarantees no concurrent reader/writer on another thread.
+    /// No reference to the payload derived from [`get`](Self::get) /
+    /// [`get_unsync`](Self::get_unsync) may be live across this call.
     #[inline]
     pub unsafe fn write(&self, value: T) {
-        self.0.set(value)
+        // SAFETY: `get()` confines access to the owning thread; the caller
+        // upholds the no-live-reference contract above.
+        unsafe { *self.get() = value }
+    }
+    /// [`read`](Self::read) without the owner-thread check.
+    ///
+    /// # Safety
+    /// As [`get_unsync`](Self::get_unsync), plus the [`read`](Self::read)
+    /// aliasing contract: the caller guarantees a happens-before edge with
+    /// every writer and no live `&mut` to the payload.
+    #[inline]
+    pub unsafe fn read_unsync(&self) -> T
+    where
+        T: Copy,
+    {
+        // SAFETY: caller contract above.
+        unsafe { *self.get_unsync() }
+    }
+    /// [`write`](Self::write) without the owner-thread check.
+    ///
+    /// # Safety
+    /// As [`get_unsync`](Self::get_unsync), plus the [`write`](Self::write)
+    /// aliasing contract: the caller guarantees a happens-before edge with
+    /// every other reader/writer and no live reference to the payload.
+    #[inline]
+    pub unsafe fn write_unsync(&self, value: T) {
+        // SAFETY: caller contract above.
+        unsafe { *self.get_unsync() = value }
+    }
+}
+impl<T: ?Sized> RacyCell<T> {
+    /// Raw pointer to the contained value, restricted to the owning thread
+    /// (the first thread to call a checked accessor; any other thread
+    /// panics). Never produces a reference; callers deref per-access
+    /// (`unsafe { *X.get() }` / `unsafe { (*X.get()).field }`).
+    #[inline]
+    pub fn get(&self) -> *mut T {
+        self.check_owner();
+        self.value.get()
+    }
+    /// Raw pointer to the contained value with **no** thread check.
+    ///
+    /// # Safety
+    /// The caller guarantees that every access to the payload (through this
+    /// pointer or any other) is externally synchronized: either the value is
+    /// written before other threads can reach it and only read afterwards
+    /// (happens-before via thread spawn / `Once` / lock release), or all
+    /// access is serialized by a lock the caller holds, or the payload bytes
+    /// are never accessed from Rust at all (FFI-owned storage).
+    #[inline]
+    pub unsafe fn get_unsync(&self) -> *mut T {
+        self.value.get()
+    }
+    #[inline]
+    fn check_owner(&self) {
+        let me = crate::thread_id::current() as u64;
+        if self.owner.load(core::sync::atomic::Ordering::Relaxed) != me {
+            self.claim_slow(me);
+        }
+    }
+    /// Claim ownership for `me`, or panic if another thread already owns the
+    /// cell. The total modification order on `owner` guarantees exactly one
+    /// CAS succeeds, so at most one thread ever gets a payload pointer from
+    /// the checked accessors. `Relaxed` suffices: the latch publishes no
+    /// data — it only elects the single thread allowed past the check.
+    #[cold]
+    #[inline(never)]
+    fn claim_slow(&self, me: u64) {
+        match self.owner.compare_exchange(
+            0,
+            me,
+            core::sync::atomic::Ordering::Relaxed,
+            core::sync::atomic::Ordering::Relaxed,
+        ) {
+            Ok(_) => {}
+            Err(owner) => panic!(
+                "RacyCell: accessed from thread {me}, but thread {owner} owns it. \
+                 Cross-thread state needs an atomic, a lock, or `get_unsync` with \
+                 documented external synchronization."
+            ),
+        }
     }
 }
 impl<T: Default> Default for RacyCell<T> {
     fn default() -> Self {
         Self::new(T::default())
+    }
+}
+
+#[cfg(test)]
+mod racy_cell_tests {
+    use super::RacyCell;
+
+    #[test]
+    fn same_thread_get_read_write() {
+        static CELL: RacyCell<u32> = RacyCell::new(7);
+        assert_eq!(unsafe { CELL.read() }, 7);
+        unsafe { CELL.write(9) };
+        assert_eq!(unsafe { *CELL.get() }, 9);
+        // Repeated access from the owner thread keeps working.
+        assert_eq!(unsafe { CELL.read() }, 9);
+    }
+
+    #[test]
+    fn cross_thread_checked_access_panics() {
+        static CELL: RacyCell<u32> = RacyCell::new(0);
+        // Claim from this thread.
+        let _ = CELL.get();
+        let panicked = std::thread::spawn(|| {
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let _ = CELL.get();
+            }))
+            .is_err()
+        })
+        .join()
+        .unwrap();
+        assert!(panicked, "second thread must not pass the owner check");
+        // The owning thread is unaffected.
+        assert_eq!(unsafe { CELL.read() }, 0);
+    }
+
+    #[test]
+    fn cross_thread_unsync_access_is_not_checked() {
+        static CELL: RacyCell<u32> = RacyCell::new(41);
+        // SAFETY: written below before the reader thread is spawned
+        // (happens-before via `thread::spawn`), then only read.
+        unsafe { CELL.write_unsync(42) };
+        let v = std::thread::spawn(|| {
+            // SAFETY: see above — spawn establishes the happens-before edge.
+            unsafe { CELL.read_unsync() }
+        })
+        .join()
+        .unwrap();
+        assert_eq!(v, 42);
+    }
+
+    #[test]
+    fn first_accessor_becomes_owner_regardless_of_thread() {
+        static CELL: RacyCell<u32> = RacyCell::new(1);
+        // A spawned thread claims first; the spawning thread is then locked out.
+        std::thread::spawn(|| {
+            let _ = CELL.get();
+        })
+        .join()
+        .unwrap();
+        assert!(
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| { CELL.get() })).is_err()
+        );
+    }
+
+    #[test]
+    fn default_and_new_are_unclaimed() {
+        let a: RacyCell<i64> = RacyCell::default();
+        assert_eq!(unsafe { a.read() }, 0);
+        let b = RacyCell::new(5_i64);
+        unsafe { b.write(6) };
+        assert_eq!(unsafe { b.read() }, 6);
     }
 }
 
@@ -4308,16 +4472,19 @@ fn argv_view_init() {
         set_bun_options_argc(view.len() - original_len);
     }
     let view: &'static [&'static ZStr] = ARGV_VIEW.get_or_init(move || view);
-    // SAFETY: single-threaded lazy init guarded by Once.
-    unsafe { ARGV.write(view) };
+    // SAFETY: lazy init guarded by `ARGV_INIT` (the `Once` establishes the
+    // happens-before edge for every reader in `argv_view`); no reader runs
+    // until `call_once` returns. Unsync because readers may be on any thread.
+    unsafe { ARGV.write_unsync(view) };
 }
 
 #[inline]
 fn argv_view() -> &'static [&'static ZStr] {
     ARGV_INIT.call_once(argv_view_init);
     // SAFETY: ARGV is a Copy fat-pointer; only mutated via `set_argv` during
-    // single-threaded startup or by the Once above.
-    unsafe { ARGV.read() }
+    // single-threaded startup or by the Once above, which both happen-before
+    // this read. Unsync because `argv()` is called from any thread.
+    unsafe { ARGV.read_unsync() }
 }
 
 #[derive(Clone, Copy)]
@@ -4583,8 +4750,9 @@ pub fn append_options_env<A: OptionsEnvArg>(env: &[u8], args: &mut Vec<A>) {
 pub unsafe fn set_argv(v: &'static [&'static ZStr]) {
     // Prevent the lazy OS-argv init from later clobbering a manually-set view.
     ARGV_INIT.call_once(|| {});
-    // SAFETY: see fn doc — single-threaded startup.
-    unsafe { ARGV.write(v) };
+    // SAFETY: see fn doc — single-threaded startup, before any cross-thread
+    // reader exists. Unsync because readers may later be on any thread.
+    unsafe { ARGV.write_unsync(v) };
 }
 
 /// Park an owned argv `Vec` in process-static storage and return the

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -2441,6 +2441,12 @@ impl<T: ?Sized> RacyCell<T> {
             core::sync::atomic::Ordering::Relaxed,
         ) {
             Ok(_) => {}
+            // Unreachable today (`check_owner` only calls this after the
+            // fast-path load saw `owner != me`, and only thread `me` ever
+            // stores `me`), but kept so the claim is idempotent if this is
+            // ever reached with the owner already set to the caller — same
+            // shape as `ThreadCell::claim`.
+            Err(prev) if prev == me => {}
             Err(owner) => panic!(
                 "RacyCell: accessed from thread {me}, but thread {owner} owns it. \
                  Cross-thread state needs an atomic, a lock, or `get_unsync` with \

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -2511,9 +2511,7 @@ mod racy_cell_tests {
         })
         .join()
         .unwrap();
-        assert!(
-            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| { CELL.get() })).is_err()
-        );
+        assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| { CELL.get() })).is_err());
     }
 
     #[test]

--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -140,8 +140,9 @@ mod io_thread_pool {
                     // `REF_COUNT` above pairs with the Release store after init,
                     // so the pointee is fully written before any deref. Unsync —
                     // `acquire()` runs on multiple threads under MUTEX/REF_COUNT.
-                    return NonNull::new(unsafe { THREAD_POOL.get_unsync() }
-                        .cast::<ThreadPoolLib::ThreadPool>())
+                    return NonNull::new(
+                        unsafe { THREAD_POOL.get_unsync() }.cast::<ThreadPoolLib::ThreadPool>(),
+                    )
                     .expect("UnsafeCell::get is non-null");
                 }
                 Err(actual) => count = actual,

--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -136,8 +136,13 @@ mod io_thread_pool {
                 Ok(_) => {
                     // REF_COUNT != 0 ⇒ THREAD_POOL is initialized (set under MUTEX below).
                     // `UnsafeCell::get` never returns null.
-                    return NonNull::new(THREAD_POOL.get().cast::<ThreadPoolLib::ThreadPool>())
-                        .expect("UnsafeCell::get is non-null");
+                    // SAFETY: only the address is produced; the Acquire load of
+                    // `REF_COUNT` above pairs with the Release store after init,
+                    // so the pointee is fully written before any deref. Unsync —
+                    // `acquire()` runs on multiple threads under MUTEX/REF_COUNT.
+                    return NonNull::new(unsafe { THREAD_POOL.get_unsync() }
+                        .cast::<ThreadPoolLib::ThreadPool>())
+                    .expect("UnsafeCell::get is non-null");
                 }
                 Err(actual) => count = actual,
             }
@@ -148,9 +153,10 @@ mod io_thread_pool {
         // Relaxed because the store we care about (the one that stores 1 to
         // indicate the thread pool is initialized) is guarded by the mutex.
         if REF_COUNT.load(Ordering::Relaxed) == 0 {
-            // SAFETY: we hold MUTEX and REF_COUNT == 0, so no other thread is reading THREAD_POOL.
+            // SAFETY: we hold MUTEX and REF_COUNT == 0, so no other thread is
+            // reading THREAD_POOL (unsync — the mutex is the synchronization).
             unsafe {
-                (*THREAD_POOL.get()).write(ThreadPoolLib::ThreadPool::init(
+                (*THREAD_POOL.get_unsync()).write(ThreadPoolLib::ThreadPool::init(
                     ThreadPoolLib::Config {
                         max_threads: u32::from(bun_core::get_thread_count().clamp(2, 4)),
                         // Use a much smaller stack size for the IO thread pool
@@ -166,7 +172,9 @@ mod io_thread_pool {
             // (the racing acquirer's reference isn't counted). Mirrored.
         }
         // Just initialized (or observed initialized) above. `UnsafeCell::get` never returns null.
-        NonNull::new(THREAD_POOL.get().cast::<ThreadPoolLib::ThreadPool>())
+        // SAFETY: only the address is produced; init above happened under MUTEX
+        // which we still hold. Unsync — `acquire()` runs on multiple threads.
+        NonNull::new(unsafe { THREAD_POOL.get_unsync() }.cast::<ThreadPoolLib::ThreadPool>())
             .expect("UnsafeCell::get is non-null")
     }
 
@@ -196,9 +204,10 @@ mod io_thread_pool {
         if REF_COUNT.load(Ordering::Relaxed) != 0 {
             return false;
         }
-        // SAFETY: we hold MUTEX, REF_COUNT == 0, and we previously CAS'd from 1 ⇒ initialized.
+        // SAFETY: we hold MUTEX, REF_COUNT == 0, and we previously CAS'd from 1
+        // ⇒ initialized (unsync — the mutex is the synchronization).
         unsafe {
-            (*THREAD_POOL.get()).assume_init_drop();
+            (*THREAD_POOL.get_unsync()).assume_init_drop();
         }
         // PORT NOTE: Zig source falls off the end of a `bool`-returning fn here
         // (`thread_pool = undefined;` is the last statement). Assuming `true`.

--- a/src/collections/bit_set.rs
+++ b/src/collections/bit_set.rs
@@ -810,8 +810,11 @@ static EMPTY_MASKS_DATA: bun_core::RacyCell<[usize; 2]> = bun_core::RacyCell::ne
 #[inline(always)]
 fn empty_masks_ptr() -> *mut usize {
     // SAFETY: pointer arithmetic into a static array; index 1 is in-bounds.
-    // The `*mut` is never written through while pointing at this static.
-    unsafe { EMPTY_MASKS_DATA.get().cast::<usize>().add(1) }
+    // The `*mut` is never written through while pointing at this static (see
+    // the comment above), so handing the address to any thread is sound —
+    // hence `get_unsync` (a `Default::default()` bit set may be constructed
+    // on any thread).
+    unsafe { EMPTY_MASKS_DATA.get_unsync().cast::<usize>().add(1) }
 }
 
 impl Default for DynamicBitSetUnmanaged {

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -333,8 +333,10 @@ pub mod debug {
     pub fn get_self_debug_info() -> Result<*mut SelfInfo, Error> {
         // SAFETY: Zig's `var self_debug_info: ?SelfInfo = null` is also a plain
         // mutable global; this is debug-only and invoked from a stopped process.
+        // Unsync: the accessing thread is whichever thread crashed, and the
+        // crash handler's `panicking` latch already serializes entry.
         unsafe {
-            let slot = &mut *SELF_DEBUG_INFO.get();
+            let slot = &mut *SELF_DEBUG_INFO.get_unsync();
             if let Some(info) = slot {
                 return Ok(std::ptr::from_mut(info));
             }
@@ -1696,8 +1698,12 @@ mod draft {
                 let stack = libc::stack_t {
                     ss_flags: 0,
                     ss_size: 512 * 1024,
-                    // SAFETY: SIGALTSTACK is a process-lifetime static byte buffer; the kernel only writes to it during signal delivery (no Rust aliasing)
-                    ss_sp: SIGALTSTACK.get().cast(),
+                    // SAFETY: SIGALTSTACK is a process-lifetime static byte
+                    // buffer; only the address is taken here and the kernel
+                    // alone writes the bytes during signal delivery (Rust
+                    // never reads or writes them), so no synchronization is
+                    // required.
+                    ss_sp: unsafe { SIGALTSTACK.get_unsync() }.cast(),
                 };
 
                 // SAFETY: stack points to a valid static buffer

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -554,9 +554,12 @@ impl HardLinkWindowsInstallTask {
         // process-wide `PackageManager` singleton and never changes.
         static INITIALIZED: core::sync::atomic::AtomicBool =
             core::sync::atomic::AtomicBool::new(false);
+        // (Unsync: written here on the install main thread, read from worker
+        // threads in `run_from_thread_pool`; the thread-pool schedule is the
+        // publication edge as described above.)
         unsafe {
             if INITIALIZED.swap(true, Ordering::Relaxed) {
-                let q = (*HARDLINK_QUEUE.get()).assume_init_ref();
+                let q = (*HARDLINK_QUEUE.get_unsync()).assume_init_ref();
                 *q.errored_task.lock() = None;
                 debug_assert_eq!(
                     q.thread_pool as *const ThreadPool,
@@ -564,13 +567,13 @@ impl HardLinkWindowsInstallTask {
                     "PackageManager singleton changed between install batches",
                 );
             } else {
-                (*HARDLINK_QUEUE.get()).write(HardLinkQueue {
+                (*HARDLINK_QUEUE.get_unsync()).write(HardLinkQueue {
                     thread_pool: &PackageManager::get().thread_pool,
                     errored_task: bun_threading::Guarded::new(None),
                     wait_group: WaitGroup::init(),
                 });
             }
-            (*HARDLINK_QUEUE.get()).assume_init_ref()
+            (*HARDLINK_QUEUE.get_unsync()).assume_init_ref()
         }
     }
 
@@ -599,8 +602,11 @@ impl HardLinkWindowsInstallTask {
     fn run_from_thread_pool(task: *mut WorkPoolTask) {
         // SAFETY: task points to the `task` field of a HardLinkWindowsInstallTask.
         let self_: *mut Self = unsafe { bun_core::from_field_ptr!(Self, task, task) };
-        // SAFETY: HARDLINK_QUEUE initialized by init_queue() before scheduling.
-        let queue = unsafe { (*HARDLINK_QUEUE.get()).assume_init_ref() };
+        // SAFETY: HARDLINK_QUEUE initialized by init_queue() before scheduling;
+        // the thread-pool task queue's Release/Acquire publishes that write to
+        // this worker thread (unsync — read from a different thread than the
+        // writer).
+        let queue = unsafe { (*HARDLINK_QUEUE.get_unsync()).assume_init_ref() };
         scopeguard::defer! { queue.complete_one(); }
 
         // SAFETY: self_ is valid until we reclaim the Box below.

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -248,9 +248,11 @@ impl SharedEnv {
         // SAFETY: `SHARED_ENV` is only initialised from the main install thread
         // during enqueue (single-threaded at that point in Zig too). Once
         // `env` is `Some` it is never reassigned, so the returned `&'static`
-        // remains valid for the program lifetime.
+        // remains valid for the program lifetime. Unsync: the lazily-written
+        // map is read again through this accessor from git task threads; the
+        // task-queue enqueue/dequeue is the happens-before edge for the write.
         unsafe {
-            let this = &mut *SHARED_ENV.get();
+            let this = &mut *SHARED_ENV.get_unsync();
             if this.env.is_none() {
                 // Note: currently if the user sets this to some value that causes
                 // a prompt for a password, the stdout of the prompt will be masked

--- a/src/install/windows-shim/main.rs
+++ b/src/install/windows-shim/main.rs
@@ -199,43 +199,48 @@ pub mod bun_core {
     // Re-export under the path the shared source uses (`bun_core::w!`).
     pub use crate::w_lit as w;
     /// Mirrors `bun_core::RacyCell` (src/bun_core/util.rs) — `static`-safe
-    /// interior-mutability cell with no synchronization. The shim is
-    /// single-threaded (Zig built it `single_threaded = true`), so the
-    /// unconditional `Sync` is trivially upheld.
-    ///
-    /// Internally backed by `Cell<T>` (not `UnsafeCell<T>`): `Cell` is
-    /// `#[repr(transparent)]` over `UnsafeCell` with identical `Send`/`!Sync`
-    /// auto-traits, but gives `.get()/.set()` for `T: Copy` without a raw
-    /// deref. The only remaining `unsafe` is the `impl Sync` below — the
-    /// irreducible single-thread invariant.
+    /// interior-mutability cell. The shim is single-threaded (Zig built it
+    /// `single_threaded = true`) and a freestanding ntdll-only PE, so the
+    /// owner-thread runtime check the real `RacyCell` performs is neither
+    /// available nor needed here: no second thread ever exists, so the `Sync`
+    /// impl is never exercised across threads, and every payload access goes
+    /// through `unsafe` (a raw-pointer deref via `get()`, or the `unsafe fn`
+    /// `read`/`write`) — no combination of safe calls can touch the payload.
     #[repr(transparent)]
-    pub struct RacyCell<T: ?Sized>(core::cell::Cell<T>);
-    // SAFETY: standalone shim is single-threaded.
+    pub struct RacyCell<T: ?Sized>(core::cell::UnsafeCell<T>);
+    // SAFETY: the standalone shim never spawns a thread, so `&RacyCell<T>` is
+    // never shared across threads; all payload access requires `unsafe`.
     unsafe impl<T: ?Sized> Sync for RacyCell<T> {}
     impl<T> RacyCell<T> {
         #[inline]
         pub const fn new(value: T) -> Self {
-            Self(core::cell::Cell::new(value))
+            Self(core::cell::UnsafeCell::new(value))
         }
         #[inline]
         pub const fn get(&self) -> *mut T {
-            self.0.as_ptr()
+            self.0.get()
         }
-        /// Body is safe `Cell::get()`; the single-thread invariant is
-        /// discharged by the `Sync` impl above, not by the caller.
-        /// `bun_shim_impl.rs` only uses `.new()`/`.get()`, so signature
-        /// parity with `bun_core::RacyCell::read` is unneeded here.
+        /// `bun_shim_impl.rs` only uses `.new()`/`.get()`; `read`/`write`
+        /// exist for signature parity with `bun_core::RacyCell`.
+        ///
+        /// # Safety
+        /// No live `&mut T` derived from [`get`](Self::get) across this call.
         #[inline]
-        pub fn read(&self) -> T
+        pub unsafe fn read(&self) -> T
         where
             T: Copy,
         {
-            self.0.get()
+            // SAFETY: caller contract; the shim is single-threaded.
+            unsafe { *self.0.get() }
         }
-        /// Body is safe `Cell::set()`; see [`Self::read`].
+        /// See [`Self::read`].
+        ///
+        /// # Safety
+        /// No live reference to the payload across this call.
         #[inline]
-        pub fn write(&self, value: T) {
-            self.0.set(value)
+        pub unsafe fn write(&self, value: T) {
+            // SAFETY: caller contract; the shim is single-threaded.
+            unsafe { *self.0.get() = value }
         }
     }
 

--- a/src/io/source.rs
+++ b/src/io/source.rs
@@ -454,7 +454,11 @@ pub mod stdin_tty {
 
     #[inline]
     pub fn value() -> *mut uv::uv_tty_t {
-        DATA.get().cast::<uv::uv_tty_t>()
+        // SAFETY: only the address is produced here. The single write into the
+        // storage (`uv_tty_init` in `get_stdin_tty`) is serialized by `LOCK` +
+        // `INITIALIZED`; afterwards the bytes are owned by uv on the loop
+        // thread. Callers like `is_stdin_tty` only compare the address.
+        unsafe { DATA.get_unsync() }.cast::<uv::uv_tty_t>()
     }
 
     pub fn is_stdin_tty(tty: *const Tty) -> bool {

--- a/src/jsc/FFI.rs
+++ b/src/jsc/FFI.rs
@@ -51,20 +51,28 @@ impl union_EncodedJSValue {
 
 // PORTING.md §Global mutable state: never mutated → would be `const`, but kept
 // as `#[no_mangle] static` to preserve the exported symbol for TinyCC-compiled
-// FFI stubs. `RacyCell` is `repr(transparent)` so the symbol's bytes are
-// identical to a bare `EncodedJSValue`; the wrapper only satisfies `Sync`
-// (the union contains `*mut c_void`).
+// FFI stubs. `ImmutableJSValue` is `repr(transparent)` so the symbol's bytes
+// are identical to a bare `EncodedJSValue`; the wrapper only satisfies `Sync`
+// (the union contains `*mut c_void`, which is `!Sync` by auto-trait only).
+#[repr(transparent)]
+pub struct ImmutableJSValue(EncodedJSValue);
+// SAFETY: the payload is never mutated after static initialization (Rust has
+// no accessor for it; only the linker symbol is consumed, by TinyCC-compiled
+// read-only stubs), so sharing `&ImmutableJSValue` across threads is a shared
+// reference to plain immutable POD.
+unsafe impl Sync for ImmutableJSValue {}
+
 #[unsafe(no_mangle)]
-pub static ValueUndefined: bun_core::RacyCell<EncodedJSValue> =
-    bun_core::RacyCell::new(EncodedJSValue {
-        as_int64: (2 | 8) as i64,
-    });
+pub static ValueUndefined: ImmutableJSValue = ImmutableJSValue(EncodedJSValue {
+    as_int64: (2 | 8) as i64,
+});
 
 pub const TRUE_I64: i64 = ((2 | 4) | 1) as i64;
 
 #[unsafe(no_mangle)]
-pub static ValueTrue: bun_core::RacyCell<EncodedJSValue> =
-    bun_core::RacyCell::new(EncodedJSValue { as_int64: TRUE_I64 });
+pub static ValueTrue: ImmutableJSValue = ImmutableJSValue(EncodedJSValue {
+    as_int64: TRUE_I64,
+});
 
 pub type JSContext = *mut c_void;
 

--- a/src/jsc/FFI.rs
+++ b/src/jsc/FFI.rs
@@ -70,9 +70,7 @@ pub static ValueUndefined: ImmutableJSValue = ImmutableJSValue(EncodedJSValue {
 pub const TRUE_I64: i64 = ((2 | 4) | 1) as i64;
 
 #[unsafe(no_mangle)]
-pub static ValueTrue: ImmutableJSValue = ImmutableJSValue(EncodedJSValue {
-    as_int64: TRUE_I64,
-});
+pub static ValueTrue: ImmutableJSValue = ImmutableJSValue(EncodedJSValue { as_int64: TRUE_I64 });
 
 pub type JSContext = *mut c_void;
 

--- a/src/parsers/json.rs
+++ b/src/parsers/json.rs
@@ -846,15 +846,23 @@ static EMPTY_STRING: bun_core::RacyCell<E::String> = bun_core::RacyCell::new(E::
 fn empty_string_data() -> js_ast::expr::Data {
     // EMPTY_STRING is a never-mutated static; `StoreRef::from_raw` checks
     // non-null and the static trivially outlives any Store reset.
-    js_ast::expr::Data::EString(js_ast::StoreRef::from_raw(EMPTY_STRING.get()))
+    // SAFETY: only the address is taken and the pointee is never written
+    // through (see the comment above the statics), so handing the pointer to
+    // any parser thread is sound — hence `get_unsync`.
+    let ptr = unsafe { EMPTY_STRING.get_unsync() };
+    js_ast::expr::Data::EString(js_ast::StoreRef::from_raw(ptr))
 }
 #[inline]
 fn empty_object_data() -> js_ast::expr::Data {
-    js_ast::expr::Data::EObject(js_ast::StoreRef::from_raw(EMPTY_OBJECT.get()))
+    // SAFETY: as `empty_string_data` — address-only, never written through.
+    let ptr = unsafe { EMPTY_OBJECT.get_unsync() };
+    js_ast::expr::Data::EObject(js_ast::StoreRef::from_raw(ptr))
 }
 #[inline]
 fn empty_array_data() -> js_ast::expr::Data {
-    js_ast::expr::Data::EArray(js_ast::StoreRef::from_raw(EMPTY_ARRAY.get()))
+    // SAFETY: as `empty_string_data` — address-only, never written through.
+    let ptr = unsafe { EMPTY_ARRAY.get_unsync() };
+    js_ast::expr::Data::EArray(js_ast::StoreRef::from_raw(ptr))
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/perf/hw_timer.rs
+++ b/src/perf/hw_timer.rs
@@ -74,7 +74,8 @@ pub fn now_ns() -> u64 {
         CALIBRATE_ONCE.call_once(calibrate);
         // SAFETY: CALIBRATION is only mutated inside `CALIBRATE_ONCE.call_once(calibrate)`;
         // `Once` establishes happens-before, so this read observes the fully-initialized value.
-        let cal = unsafe { CALIBRATION.read() };
+        // Unsync — `now_ns()` is called from any thread.
+        let cal = unsafe { CALIBRATION.read_unsync() };
         if cal.mult != 0 {
             let ticks = read_counter().wrapping_sub(cal.start_counter);
             // u64×u64→u128 widening mul + shift: 2 insns on x64 (`mul`+`shrd`),
@@ -122,9 +123,10 @@ fn calibrate() {
     }
     let start_ns = os_monotonic_ns();
     // SAFETY: only ever invoked via `CALIBRATE_ONCE.call_once`, which guarantees
-    // exclusive access during this write and happens-before for subsequent readers.
+    // exclusive access during this write and happens-before for subsequent readers
+    // (which may be on any thread, hence unsync).
     unsafe {
-        CALIBRATION.write(Calibration {
+        CALIBRATION.write_unsync(Calibration {
             start_counter: read_counter(),
             start_ns,
             mult: u64::try_from(

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -208,7 +208,9 @@ pub mod fs {
 
     // Global mutable singleton; Zig used `var instance: FileSystem = undefined`.
     // `RacyCell` is the alias-safe static cell — `init()` is the only writer,
-    // serialized at startup; readers go through `instance()`.
+    // serialized at startup; readers go through `instance()`. All access is
+    // via `get_unsync` because readers run on resolver worker threads; the
+    // `INSTANCE_LOADED` Release/Acquire pair publishes the one-time write.
     pub static INSTANCE: bun_core::RacyCell<core::mem::MaybeUninit<FileSystem>> =
         bun_core::RacyCell::new(core::mem::MaybeUninit::uninit());
     pub static INSTANCE_LOADED: AtomicBool = AtomicBool::new(false);
@@ -256,8 +258,10 @@ pub mod fs {
 
         #[inline]
         pub fn instance() -> &'static mut FileSystem {
-            // SAFETY: caller guarantees init() was called (matches Zig global singleton).
-            unsafe { (*INSTANCE.get()).assume_init_mut() }
+            // SAFETY: caller guarantees init() was called (matches Zig global
+            // singleton). Unsync — the singleton is written once at startup
+            // and reached from resolver worker threads afterwards.
+            unsafe { (*INSTANCE.get_unsync()).assume_init_mut() }
         }
 
         /// Shared-ref accessor for the process-lifetime singleton. Prefer this
@@ -277,7 +281,8 @@ pub mod fs {
             // SAFETY: `INSTANCE` is written exactly once by `init()` during
             // single-threaded startup (Release-paired with the Acquire above)
             // and never freed; shared `&` aliases freely across threads.
-            unsafe { (*INSTANCE.get()).assume_init_ref() }
+            // Unsync — readers are on resolver worker threads.
+            unsafe { (*INSTANCE.get_unsync()).assume_init_ref() }
         }
 
         /// Port of `FileSystem.init` (fs.zig:90-108). First call writes the
@@ -303,7 +308,7 @@ pub mod fs {
             // `Transpiler::init` before any worker spawn.
             unsafe {
                 if INSTANCE_LOADED.load(Ordering::Acquire) && !FORCE {
-                    return Ok((*INSTANCE.get()).as_mut_ptr());
+                    return Ok((*INSTANCE.get_unsync()).as_mut_ptr());
                 }
             }
             let cwd: &'static [u8] = match top_level_dir {
@@ -331,7 +336,7 @@ pub mod fs {
             bun_paths::fs::FileSystem::init(cwd);
             // SAFETY: see above.
             unsafe {
-                (*INSTANCE.get()).write(FileSystem {
+                (*INSTANCE.get_unsync()).write(FileSystem {
                     top_level_dir: cwd,
                     top_level_dir_buf: bun_paths::PathBuffer::uninit(),
                     fs: Implementation::init(cwd),
@@ -343,7 +348,7 @@ pub mod fs {
                 // touch the singleton so it's initialized before any resolver
                 // worker hits it.
                 let _ = dir_entry::EntryStore::instance();
-                Ok((*INSTANCE.get()).as_mut_ptr())
+                Ok((*INSTANCE.get_unsync()).as_mut_ptr())
             }
         }
 

--- a/src/resolver/node_fallbacks.rs
+++ b/src/resolver/node_fallbacks.rs
@@ -118,10 +118,11 @@ fn init_modules() {
 
     let mut m = bun_collections::StringHashMap::<FallbackModule>::default();
     // SAFETY: `init_modules` runs exactly once under `Once::call_once`; no other
-    // thread observes `MODULES`/`MAP` until this returns.
+    // thread observes `MODULES`/`MAP` until this returns. Unsync — the `Once`
+    // is the happens-before edge for readers on other resolver threads.
     unsafe {
-        *MODULES.get() = Some(modules);
-        let modules_ref: &'static [FallbackEntry] = (*MODULES.get()).as_deref().unwrap();
+        *MODULES.get_unsync() = Some(modules);
+        let modules_ref: &'static [FallbackEntry] = (*MODULES.get_unsync()).as_deref().unwrap();
         for (name, pkg, path, code) in modules_ref.iter() {
             m.put_assume_capacity(
                 name,
@@ -132,7 +133,7 @@ fn init_modules() {
                 },
             );
         }
-        *MAP.get() = Some(m);
+        *MAP.get_unsync() = Some(m);
     }
 }
 
@@ -140,7 +141,9 @@ fn init_modules() {
 pub fn map() -> &'static bun_collections::StringHashMap<FallbackModule> {
     INIT.call_once(init_modules);
     // SAFETY: `INIT` guarantees `MAP` is `Some` and never written again.
-    unsafe { (*MAP.get()).as_ref().unwrap() }
+    // Unsync — `map()` is called from any resolver thread; the `Once` is the
+    // happens-before edge with the single write above.
+    unsafe { (*MAP.get_unsync()).as_ref().unwrap() }
 }
 
 pub fn contents_from_path(path: &[u8]) -> Option<&'static [u8]> {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4037,8 +4037,10 @@ impl<'a> Resolver<'a> {
             return &[];
         }
         // SAFETY: BIN_FOLDERS protected by BIN_FOLDERS_LOCK at write sites;
-        // `BIN_FOLDERS_LOADED` (acquire) guarantees init.
-        unsafe { (*BIN_FOLDERS.get()).assume_init_ref().const_slice() }
+        // `BIN_FOLDERS_LOADED` (acquire) guarantees init. Unsync — readers and
+        // writers are on different resolver threads; the lock + acquire flag
+        // are the synchronization.
+        unsafe { (*BIN_FOLDERS.get_unsync()).assume_init_ref().const_slice() }
     }
 
     pub fn parse_package_json<const ALLOW_DEPENDENCIES: bool>(
@@ -6078,7 +6080,7 @@ impl<'a> Resolver<'a> {
                         // SAFETY: BIN_FOLDERS guarded by BIN_FOLDERS_LOCK below
                         if !BIN_FOLDERS_LOADED.load(core::sync::atomic::Ordering::Acquire) {
                             // SAFETY: callers hold RESOLVER_MUTEX; first init.
-                            unsafe { (*BIN_FOLDERS.get()).write(BinFolderArray::default()) };
+                            unsafe { (*BIN_FOLDERS.get_unsync()).write(BinFolderArray::default()) };
                             BIN_FOLDERS_LOADED.store(true, core::sync::atomic::Ordering::Release);
                         }
 
@@ -6099,7 +6101,7 @@ impl<'a> Resolver<'a> {
                         // SAFETY: BIN_FOLDERS guarded by BIN_FOLDERS_LOCK acquired above.
                         unsafe {
                             for existing_folder in
-                                (*BIN_FOLDERS.get()).assume_init_ref().const_slice()
+                                (*BIN_FOLDERS.get_unsync()).assume_init_ref().const_slice()
                             {
                                 if *existing_folder == bin_path {
                                     break 'append_bin_dir;
@@ -6110,7 +6112,7 @@ impl<'a> Resolver<'a> {
                             else {
                                 break 'append_bin_dir;
                             };
-                            let _ = (*BIN_FOLDERS.get()).assume_init_mut().append(stored);
+                            let _ = (*BIN_FOLDERS.get_unsync()).assume_init_mut().append(stored);
                         }
                     }
                 }
@@ -6124,7 +6126,7 @@ impl<'a> Resolver<'a> {
                             // SAFETY: BIN_FOLDERS_LOADED is single-thread init-once; protected by RESOLVER_MUTEX held by callers.
                             if !BIN_FOLDERS_LOADED.load(core::sync::atomic::Ordering::Acquire) {
                                 // SAFETY: callers hold RESOLVER_MUTEX; first init.
-                                unsafe { (*BIN_FOLDERS.get()).write(BinFolderArray::default()) };
+                                unsafe { (*BIN_FOLDERS.get_unsync()).write(BinFolderArray::default()) };
                                 BIN_FOLDERS_LOADED
                                     .store(true, core::sync::atomic::Ordering::Release);
                             }
@@ -6143,7 +6145,7 @@ impl<'a> Resolver<'a> {
                             // SAFETY: BIN_FOLDERS guarded by BIN_FOLDERS_LOCK acquired above.
                             unsafe {
                                 for existing_folder in
-                                    (*BIN_FOLDERS.get()).assume_init_ref().const_slice()
+                                    (*BIN_FOLDERS.get_unsync()).assume_init_ref().const_slice()
                                 {
                                     if *existing_folder == bin_path {
                                         break 'append_bin_dir;
@@ -6154,7 +6156,7 @@ impl<'a> Resolver<'a> {
                                 else {
                                     break 'append_bin_dir;
                                 };
-                                let _ = (*BIN_FOLDERS.get()).assume_init_mut().append(stored);
+                                let _ = (*BIN_FOLDERS.get_unsync()).assume_init_mut().append(stored);
                             }
                         }
                     }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6126,7 +6126,9 @@ impl<'a> Resolver<'a> {
                             // SAFETY: BIN_FOLDERS_LOADED is single-thread init-once; protected by RESOLVER_MUTEX held by callers.
                             if !BIN_FOLDERS_LOADED.load(core::sync::atomic::Ordering::Acquire) {
                                 // SAFETY: callers hold RESOLVER_MUTEX; first init.
-                                unsafe { (*BIN_FOLDERS.get_unsync()).write(BinFolderArray::default()) };
+                                unsafe {
+                                    (*BIN_FOLDERS.get_unsync()).write(BinFolderArray::default())
+                                };
                                 BIN_FOLDERS_LOADED
                                     .store(true, core::sync::atomic::Ordering::Release);
                             }
@@ -6156,7 +6158,8 @@ impl<'a> Resolver<'a> {
                                 else {
                                     break 'append_bin_dir;
                                 };
-                                let _ = (*BIN_FOLDERS.get_unsync()).assume_init_mut().append(stored);
+                                let _ =
+                                    (*BIN_FOLDERS.get_unsync()).assume_init_mut().append(stored);
                             }
                         }
                     }

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -32,9 +32,10 @@ use crate::cli::which_npm_client::NPMClient;
 #[path = "create/SourceFileProjectGenerator.rs"]
 pub mod SourceFileProjectGenerator;
 
-// PORTING.md §Global mutable state: single-thread CLI scratch buffer →
-// RacyCell. Touched on the main thread for `--open` *and* the spawned git
-// thread (sequenced — git thread writes after main is done with it).
+// PORTING.md §Global mutable state: CLI scratch buffer → RacyCell. Touched on
+// the spawned git thread (`GitHandler::run`) *and* the main thread (`--open`),
+// sequenced by the git thread join — so access goes through `get_unsync`, not
+// the owner-checked `get`.
 static BUN_PATH_BUF: bun_core::RacyCell<PathBuffer> = bun_core::RacyCell::new(PathBuffer::ZEROED);
 
 // PORT NOTE: bun.OSPathLiteral — `bun_paths` does not (yet) export an
@@ -1618,8 +1619,11 @@ impl CreateCommand {
         Output::flush();
 
         if create_options.open {
-            // SAFETY: single-threaded CLI access to module-level static path buffer
-            let bun_path_buf = unsafe { &mut *BUN_PATH_BUF.get() };
+            // SAFETY: module-level static path buffer. Unsync: `GitHandler::run`
+            // also writes this buffer from the spawned git thread, but that
+            // thread is joined (in `GitHandler::wait`) before this block runs,
+            // so the accesses are sequenced by the join.
+            let bun_path_buf = unsafe { &mut *BUN_PATH_BUF.get_unsync() };
             if let Some(bin) = which(bun_path_buf, path_env, destination, b"bun") {
                 let argv: [&[u8]; 1] = [bin.as_bytes()];
                 // Zig used `std.process.Child`; PORTING.md bans std::process — route through
@@ -2854,10 +2858,11 @@ impl GitHandler {
         //   Time (mean ± σ):     306.7 ms ±   6.1 ms    [User: 31.7 ms, System: 269.8 ms]
         //   Range (min … max):   299.5 ms … 318.8 ms    10 runs
 
-        // SAFETY: single-threaded CLI access to module-level static path buffer (note: this fn
-        // may run on the git thread; BUN_PATH_BUF is also touched on main thread for `--open`.
-        // The two uses are sequenced — git runs before `--open` block. Matches Zig.)
-        let bun_path_buf = unsafe { &mut *BUN_PATH_BUF.get() };
+        // SAFETY: module-level static path buffer. Unsync: this fn may run on
+        // the git thread; BUN_PATH_BUF is also touched on the main thread for
+        // `--open`. The two uses are sequenced — the git thread is joined
+        // before the `--open` block runs. Matches Zig.
+        let bun_path_buf = unsafe { &mut *BUN_PATH_BUF.get_unsync() };
         // Zig used `std.process.Child` (no libuv). The Rust port routes through
         // `bun.spawnSync`, which on Windows drives `uv_spawn` and needs a uv loop. This fn
         // runs on the dedicated git thread (see `GitHandler::spawn`), so use the

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -1496,9 +1496,12 @@ pub mod upgrade_js_bindings {
             match sys::windows::Win32Error::from_nt_status(rc) {
                 sys::windows::Win32Error::SUCCESS => {
                     // Zig: `bun.FD.fromNative(fd)` — system-kind handle on Windows.
-                    // SAFETY: test-only helper; access is single-threaded (JS thread).
+                    // SAFETY: test-only helper; effectively single-threaded.
+                    // Unsync because the matching close may run on a different
+                    // VM thread (see the static's comment); the JS calls are
+                    // sequenced by the test harness.
                     unsafe {
-                        TEMPDIR_FD.write(Some(sys::Fd::from_system(fd)));
+                        TEMPDIR_FD.write_unsync(Some(sys::Fd::from_system(fd)));
                     }
                 }
                 _ => {}
@@ -1520,10 +1523,12 @@ pub mod upgrade_js_bindings {
         #[cfg(windows)]
         {
             use bun_sys::FdExt as _;
-            // SAFETY: test-only helper; access is single-threaded (JS thread).
-            // Consume (`take`) the stored fd so a repeat call cannot
+            // SAFETY: test-only helper; effectively single-threaded. Unsync
+            // because open/close may run on different VM threads (see the
+            // static's comment); the JS calls are sequenced by the test
+            // harness. Consume (`take`) the stored fd so a repeat call cannot
             // `CloseHandle` a stale, possibly-reissued HANDLE value.
-            if let Some(fd) = unsafe { core::mem::take(&mut *TEMPDIR_FD.get()) } {
+            if let Some(fd) = unsafe { core::mem::take(&mut *TEMPDIR_FD.get_unsync()) } {
                 fd.close();
             }
 

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -109,14 +109,26 @@ struct Offsets {
     js_cell_offset_of_type: u32,
 }
 
+/// Storage for an extern static whose bytes are written by foreign code.
+/// `#[repr(transparent)]` over `UnsafeCell<Offsets>` so the extern layout is
+/// identical to the C++ `Bun__FFI__offsets` definition while still telling
+/// the optimizer the bytes may change behind Rust's back (a plain non-`mut`
+/// extern static would assert immutability, which is UB once C++ writes it).
+#[repr(transparent)]
+struct ForeignOffsets(core::cell::UnsafeCell<Offsets>);
+// SAFETY: the payload is written exactly once by C++
+// (`Bun__FFI__ensureOffsetsAreLoaded`, gated behind a `Once` in
+// `Offsets::get`) before any Rust read; Rust never writes it. Every access
+// already requires `unsafe` (extern static + raw deref).
+unsafe impl Sync for ForeignOffsets {}
+
 // TODO(port): move to <area>_sys
 unsafe extern "C" {
     // Written once by C++ before any Rust read. C++ mutates these bytes, so a
     // plain non-`mut` extern static would assert immutability to the optimizer
-    // (UB). `RacyCell<T>` is `#[repr(transparent)]` over `UnsafeCell<T>`, so
-    // the extern layout is identical to `Offsets`.
+    // (UB). See `ForeignOffsets`.
     #[link_name = "Bun__FFI__offsets"]
-    static BUN_FFI_OFFSETS: bun_core::RacyCell<Offsets>;
+    static BUN_FFI_OFFSETS: ForeignOffsets;
     #[link_name = "Bun__FFI__ensureOffsetsAreLoaded"]
     fn bun_ffi_ensure_offsets_are_loaded();
 }
@@ -189,8 +201,9 @@ impl Offsets {
     pub fn get() -> &'static Offsets {
         static ONCE: Once = Once::new();
         ONCE.call_once(Self::load_once);
-        // SAFETY: BUN_FFI_OFFSETS is initialized by load_once and never mutated after
-        unsafe { &*BUN_FFI_OFFSETS.get() }
+        // SAFETY: BUN_FFI_OFFSETS is initialized by load_once (under the
+        // `Once`, which is the happens-before edge) and never mutated after.
+        unsafe { &*BUN_FFI_OFFSETS.0.get() }
     }
 }
 

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -305,13 +305,21 @@ pub mod Jest {
     // Zig `pub var runner: ?*TestRunner = null`.
     // PORTING.md §Global mutable state: JS-VM-thread-only singleton; RacyCell
     // over `Option<NonNull<_>>` so direct `.read()` projections in
-    // `snapshot.rs` etc. keep their shape.
+    // `snapshot.rs` etc. keep their shape. The reads below are `read_unsync`
+    // because `runner()` is reachable from non-test VM threads (e.g.
+    // `console_on_before_print` on a `Worker` thread); on those threads it
+    // returns the main test thread's pointer (or `None` outside `bun test`),
+    // matching Zig's unguarded global. See the multi-thread findings in the
+    // RacyCell audit.
     pub static RUNNER: bun_core::RacyCell<Option<NonNull<TestRunner<'static>>>> =
         bun_core::RacyCell::new(None);
 
     pub fn runner() -> Option<&'static mut TestRunner<'static>> {
-        // SAFETY: single-threaded JS VM; matches Zig's unguarded global access.
-        unsafe { RUNNER.read().map(|p| &mut *p.as_ptr()) }
+        // SAFETY: matches Zig's unguarded global access; the pointer is only
+        // ever installed/cleared by the test runner on its own thread, and a
+        // `Copy` `Option<NonNull>` read cannot tear. See `RUNNER`'s comment
+        // for why this is unsync.
+        unsafe { RUNNER.read_unsync().map(|p| &mut *p.as_ptr()) }
     }
 
     /// Raw-pointer accessor for callers that must not materialise
@@ -319,8 +327,8 @@ pub mod Jest {
     /// `&BunTestRoot`, `&mut BunTest`) is already live — see
     /// `BunTestRoot::on_before_print` / `BunTest::enter_file`.
     pub fn runner_ptr() -> Option<NonNull<TestRunner<'static>>> {
-        // SAFETY: single-threaded JS VM; matches Zig's unguarded global access.
-        unsafe { RUNNER.read() }
+        // SAFETY: see `runner()` above.
+        unsafe { RUNNER.read_unsync() }
     }
 
     #[unsafe(no_mangle)]


### PR DESCRIPTION
## What

`unsafe impl<T: ?Sized> Sync for RacyCell<T>` made any payload shareable across threads while the single-thread contract lived only in comments. A `static` RacyCell reachable from a worker thread was one (already-required) `unsafe` deref away from a silent data race, and nothing checked the comment.

`RacyCell<T>` is now `{ owner: AtomicU64, value: UnsafeCell<T> }`:

- **Checked accessors** (`get` / `read` / `write`): the first thread to call one claims the cell; any later call from a different thread panics — **in release builds too**. The `unsafe impl Sync` is now justified by this runtime check: safe code can never observe the payload from two threads.
- **Unchecked accessors** (`unsafe fn get_unsync` / `read_unsync` / `write_unsync`): for state whose synchronization is external and can't be expressed in the type system (write-once-before-thread-spawn, `Once`-published, mutex-guarded, address-only). Each call site documents its happens-before edge under the existing `// SAFETY:` comment.

Every `RacyCell` static in the tree was audited and classified (table below). The two layout-sensitive FFI statics get dedicated `#[repr(transparent)]` wrapper types because `RacyCell` is no longer `repr(transparent)`.

## Named cost

- One TLS read + one `Relaxed` atomic load + compare per checked access (plus a one-time CAS on the first access). The unchecked accessors are zero-cost.
- 8 bytes (`AtomicU64`) per `RacyCell` static.
- Cross-thread access to a thread-confined static is now a deterministic panic instead of UB. This is the intended behavior change.

## Audit

### Kept on the checked accessors (thread-confined; the comment is now enforced)

| Static | File | Owning thread |
|---|---|---|
| `TEMP_HOSTNAME`, `SOCKET_ASYNC_HTTP_ABORT_TRACKER`, `SHARED_REQUEST_HEADERS_BUF`, `SHARED_RESPONSE_HEADERS_BUF`, `SINGLE_PACKET_SMALL_BUFFER` | `http/lib.rs` | HTTP client thread |
| `CACHE` | `http/h3_client/AltSvc.rs` | HTTP client thread |
| `CUSTOM_SSL_CONTEXT_MAP` | `http/HTTPThread.rs` | HTTP client thread |
| `WTF8_ENV_BUF`, `ORIG_ENVIRON` | `sys/windows/env.rs` | startup, write-only |
| `FAILURE_REASON_DATA` | `install/windows-shim/bun_shim_impl.rs` | bunx fast-path / standalone shim |
| `ARENA` (`install_runner_arena`) | `install/lib.rs` | CLI dispatch thread |
| `CWD_BUF`, `ROOT_PACKAGE_JSON_PATH_BUF`, `ROOT_PACKAGE_JSON_PATH` | `install/PackageManager.rs` | install main thread |
| `HANDLES_BEFORE` | `resolver/fs.rs` | startup |
| `RUNNER` (the `.write()` in test_command.rs / `.read()` in snapshot.rs) | `runtime/test_runner/jest.rs` | test-runner thread |
| `HOME_DIR_BUF`, `URL_`, `APP_NAME_BUF`, `GITHUB_REPOSITORY_URL_BUF`, `NPM_REGISTRY_URL_BUF`, `THREAD` | `runtime/cli/create_command.rs` | main CLI thread |
| `ARENA` (`exec_arena`) | `runtime/cli/exec_command.rs` | CLI dispatch thread |
| `CLI_ARENA`, `CMD`, `LOG_`, `CONTEXT_DATA` | `runtime/cli/mod.rs` | main CLI thread |
| `WORKER_FRAME`, `WORKER_CMDS` | `runtime/cli/test/parallel/runner.rs` | worker-process main thread |
| `PREV_INT`, `PREV_TERM` | `runtime/cli/test/parallel/Coordinator.rs` | coordinator main thread |
| `SHELL_BUF`, `RUN`, `DIRECT_LAUNCH_BUFFER`, `ENVIRONMENT_BUFFER` | `runtime/cli/run_command.rs` | main CLI thread |
| `LIB_DIR_Z` | `runtime/ffi/mod.rs` | (no readers or writers exist) |
| `CHILD_SINGLETON` | `runtime/node/node_cluster_binding.rs` | main VM thread (cluster-child IPC) |
| `INSTANCE` | `io/ParentDeathWatchdog.rs` | event-loop install path (ZST) |

These need no call-site changes; the existing `unsafe { *X.get() }` shapes are unchanged and the "X-thread-only" comment is now a checked invariant.

### Moved to the `unsafe` `*_unsync` accessors (genuinely cross-thread; left unsafe, listed per rule)

| Static | File | Why it crosses threads / what synchronizes it |
|---|---|---|
| `ARGV` | `bun_core/util.rs` | written under a `Once` / during startup, read from any thread via `argv()` |
| `STDOUT_STREAM`, `STDERR_STREAM` | `bun_core/output.rs` | write-once at startup, read by every spawned thread in `configure_thread` |
| `BUFFERED_STDIN` | `bun_core/output.rs` | `prompt()` is exposed on `Worker` global scopes, so the shared stdin buffer is reachable from more than one thread (see findings) |
| `SCOPED_FILE_WRITER` | `bun_core/output.rs` | write-once at startup, read by debug logging on any thread |
| `EMPTY_MASKS_DATA` | `collections/bit_set.rs` | never written through; address taken from any thread |
| `SELF_DEBUG_INFO` | `crash_handler/lib.rs` | accessed by whichever thread crashes; serialized by the `panicking` latch |
| `SIGALTSTACK` | `crash_handler/lib.rs` | address-only; the kernel writes the bytes during signal delivery |
| `HARDLINK_QUEUE` | `install/PackageInstall.rs` | written on the install main thread, read by thread-pool workers (publication via the task queue) |
| `SHARED_ENV` | `install/repository.rs` | lazily written during enqueue, re-read from git task threads |
| `THREAD_POOL` | `bundler/ThreadPool.rs` | mutex + refcount guarded init/drop, address handed to multiple threads |
| `EMPTY_OBJECT/ARRAY/STRING` | `parsers/json.rs` | never written through; address taken from parser worker threads |
| `CALIBRATION` | `perf/hw_timer.rs` | `Once`-published, read by `now_ns()` on any thread |
| `INSTANCE` (FileSystem) | `resolver/lib.rs` | init at startup, read from resolver/bundler worker threads |
| `MODULES`, `MAP` | `resolver/node_fallbacks.rs` | `Once`-published, read from resolver threads |
| `BIN_FOLDERS` | `resolver/resolver.rs` | lock-guarded writes, flag-guarded reads from resolver threads |
| `DATA` (stdin tty) | `io/source.rs` | lock-guarded init; address compared from any thread; bytes owned by libuv |
| `BUN_PATH_BUF` | `runtime/cli/create_command.rs` | written on the spawned git thread *and* the main thread, sequenced by the join |
| `TEMPDIR_FD` | `runtime/cli/upgrade_command.rs` | open/close may run on different VM threads (test-only helper) |
| `RUNNER` (the reads in `Jest::runner()` / `runner_ptr()`) | `runtime/test_runner/jest.rs` | reachable from non-test VM threads (see findings) |

### Replaced with a dedicated wrapper type (layout-sensitive FFI)

| Static | File | New type |
|---|---|---|
| `ValueUndefined`, `ValueTrue` | `jsc/FFI.rs` | `#[repr(transparent)] ImmutableJSValue` — never mutated, no interior mutability at all; `unsafe impl Sync` over immutable POD |
| `Bun__FFI__offsets` extern static | `runtime/ffi/ffi_body.rs` | `#[repr(transparent)] ForeignOffsets(UnsafeCell<Offsets>)` — written once by C++ before any Rust read; every access is already `unsafe` |

### Left as-is

- `install/windows-shim/main.rs` has its own minimal `RacyCell` copy for the standalone (freestanding, ntdll-only, single-threaded) `bun_shim_impl.exe` build. There is no thread-id API available there and no second thread ever exists, so the `Sync` impl is never exercised across threads. Its `read`/`write` are now `unsafe fn` so every payload access requires `unsafe`; `get()` already only returns a raw pointer.

## Multi-thread findings (pre-existing races surfaced by the audit)

1. **`Jest::RUNNER` is reachable from `Worker` threads.** `console_on_before_print` (invoked by every `console.log`) calls `Jest::runner()`, which returns `&'static mut TestRunner` derived from the main test thread's pointer. A `Worker` that logs during `bun test` gets an aliasing `&mut` to the test runner state on a different thread. The owner check caught this immediately in a smoke test (worker `console.log` panicked); the reads in `runner()`/`runner_ptr()` are now `read_unsync` to preserve current behavior, but the underlying cross-thread `&mut TestRunner` is a real bug that needs a JS-thread-affinity guard or a `None` fast-path for non-owner threads.
2. **`BIN_FOLDERS` reads race its writes.** `bin_dirs()` reads `const_slice()` after an `Acquire` flag load but without taking `BIN_FOLDERS_LOCK`, while `append()` mutates the array under the lock on another resolver thread. A reader can observe a torn length/contents pair.
3. **`BUFFERED_STDIN` is reachable from `Worker` threads.** `prompt()` is exposed on `Worker` global scopes and reads the single process-global 4 KiB buffered-stdin struct. `prompt()` on the main thread followed by `prompt()` in a `Worker` hands two threads a `&mut` to the same buffer (concurrent calls would interleave reads and corrupt the buffer state). The owner check caught this in a smoke test; `buffered_stdin()` is `get_unsync` to preserve the existing behavior.
4. **`THREAD_POOL` refcount**: the pre-existing PORT NOTE in `acquire()` already documents that a racing acquirer's reference is not counted (mirrored from Zig). Not introduced or fixed here.

## Before/after unsafe count

`rg -o -e 'unsafe \{' -e 'unsafe fn' -e 'unsafe extern' -e 'unsafe impl' -e 'unsafe trait' <touched files> | wc -l`: **1048 → 1080**.

The count goes *up* because the fix converts wrongly-safe surface into correctly-`unsafe` surface and adds checked machinery: 3 new `unsafe fn` accessors + their internal blocks, 2 new narrowly-scoped `unsafe impl Sync` wrappers for the FFI statics, the windows-shim `read`/`write` becoming `unsafe fn`, ~7 call sites that previously called the safe `get()` outside any `unsafe` block and now call `unsafe { get_unsync() }`, and the new `#[test]`s. The deliverable is not a lower token count — it is that no safe call path can reach an unsynchronized payload.

## Tests / Miri

- New `#[test]`s in `bun_core::util::racy_cell_tests` cover same-thread access, cross-thread panic, the unsync escape hatch, and first-accessor-claims semantics. They type-check (`cargo check -p bun_core --all-targets`) but `bun_core`'s test target does not link standalone (it depends on FFI symbols supplied by higher-tier crates), and `bun_core` is not in the Miri allowlist for the same reason — so, like the existing `atomic_cell.rs` tests, they do not run in CI. Miri does not cover this crate.
- `bun bd` builds; smoke-tested `bun run`, `Bun.serve` + `fetch`, `Worker` + `console.log` from a worker, `bun install`, `bun build`, and `bun test` (with snapshots and an in-test `Worker`).
- `bun bd test test/js/web/workers/worker.test.ts` and `test/js/web/fetch/fetch.test.ts` show the same pass/fail set as the unmodified main build (the failures in both are pre-existing/network-dependent).
- `bun run rust:check-all`: 10/10 targets pass.
