### PR TITLE
Blob.writer(): force sync mode on stdout/stderr (POSIX)

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1831,6 +1831,25 @@ impl BlobExt for Blob {
 
         #[cfg(not(windows))]
         {
+            let is_stdout_or_stderr = 'brk: {
+                let PathOrFileDescriptor::Fd(fd) = &store.data.as_file().pathlike else {
+                    break 'brk false;
+                };
+                if let Some(rare) = global_this.bun_vm().rare_data.as_ref() {
+                    let store_ptr = store.as_ptr().cast::<c_void>();
+                    if rare.stdout_store.map(|p| p.as_ptr()) == Some(store_ptr) {
+                        break 'brk true;
+                    }
+                    if rare.stderr_store.map(|p| p.as_ptr()) == Some(store_ptr) {
+                        break 'brk true;
+                    }
+                }
+                matches!(
+                    fd.stdio_tag(),
+                    Some(bun_core::Stdio::StdOut) | Some(bun_core::Stdio::StdErr)
+                )
+            };
+
             let sink = webcore::FileSink::init(
                 bun_sys::Fd::INVALID,
                 jsc::EventLoopHandle::init(
@@ -1843,6 +1862,12 @@ impl BlobExt for Blob {
                 ),
             );
             // `to_js` takes its own per-wrapper +1; init's ref drops at scope end.
+
+            if is_stdout_or_stderr {
+                // Same as the Windows arm and `process.stdout`/`process.stderr`.
+                sink.force_sync.set(true);
+            }
+
             let input_path: webcore::PathOrFileDescriptor = match &store.data.as_file().pathlike {
                 PathOrFileDescriptor::Fd(fd) => webcore::PathOrFileDescriptor::Fd(*fd),
                 PathOrFileDescriptor::Path(p) => webcore::PathOrFileDescriptor::Path(

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -603,7 +603,7 @@ it("start() with a path/fd getter that closes the writer throws instead of crash
 // only flushed them via a deferred task, so a large write through a *second*
 // sink on the same fd reached the kernel first. Windows already forced stdout/
 // stderr sinks into sync mode; POSIX now does the same.
-describe("stdout/stderr sinks write synchronously", () => {
+describe.concurrent("stdout/stderr sinks write synchronously", () => {
   // A small write followed by a large write through separate FileSink
   // instances on fd 1/2 must appear in program order. Before the fix the
   // 4-byte write was buffered until the deferred auto-flush ran, landing

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -598,6 +598,48 @@ it("start() with a path/fd getter that closes the writer throws instead of crash
   expect(exitCode).toBe(0);
 });
 
+// https://github.com/oven-sh/bun/issues/11553
+// On POSIX, a FileSink on stdout/stderr buffered small writes (< page size) and
+// only flushed them via a deferred task, so a large write through a *second*
+// sink on the same fd reached the kernel first. Windows already forced stdout/
+// stderr sinks into sync mode; POSIX now does the same.
+describe("stdout/stderr sinks write synchronously", () => {
+  // A small write followed by a large write through separate FileSink
+  // instances on fd 1/2 must appear in program order. Before the fix the
+  // 4-byte write was buffered until the deferred auto-flush ran, landing
+  // after the 64 KiB body.
+  for (const expr of ["Bun.file(1)", "Bun.stdout", "Bun.file(2)", "Bun.stderr"] as const) {
+    it(`${expr}.writer()`, async () => {
+      const isStderr = expr.includes("2") || expr.includes("stderr");
+      const src = `
+        const header = Uint8Array.of(0xde, 0xad, 0xbe, 0xef);
+        const body = new Uint8Array(64 * 1024).fill(0x2e);
+        ${expr}.writer().write(header);
+        ${expr}.writer().write(body);
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", src],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdoutBuf, stderrBuf, exitCode] = await Promise.all([
+        new Response(proc.stdout).arrayBuffer(),
+        new Response(proc.stderr).arrayBuffer(),
+        proc.exited,
+      ]);
+      const stdout = new Uint8Array(stdoutBuf);
+      const stderr = new Uint8Array(stderrBuf);
+      const out = isStderr ? stderr : stdout;
+      expect(out.length).toBe(4 + 64 * 1024);
+      expect(Array.from(out.subarray(0, 4))).toEqual([0xde, 0xad, 0xbe, 0xef]);
+      expect(Array.from(out.subarray(-4))).toEqual([0x2e, 0x2e, 0x2e, 0x2e]);
+      expect((isStderr ? stdout : stderr).length).toBe(0);
+      expect(exitCode).toBe(0);
+    });
+  }
+});
+
 it.skipIf(!isPosix)("writing after end() fails during flush does not crash", async () => {
   const dir = tmpdirSync();
   const target = join(dir, "ro.txt");


### PR DESCRIPTION
> **Draft: needs a direction decision.** Rebased onto current main; the diff still applies and still fixes the repro below, but it now regresses two POSIX tests added in #38641 (details under "Conflict with current main"). The approach needs a maintainer call before this can proceed.

### Problem

- Two independent sinks on the same stdio fd write out of program order on POSIX:

  ```js
  Bun.file(1).writer().write(Uint8Array.of(0xde, 0xad, 0xbe, 0xef)); // 4 bytes
  Bun.file(1).writer().write(new Uint8Array(64 * 1024));             // 64 KiB
  ```

  The 64 KiB body reaches fd 1 first; the 4-byte header lands after it. Still reproduces on current main (verified at 23d535a7).
- Cause: each `.writer()` call creates a fresh `FileSink`. `PosixStreamingWriter::write` buffers anything below `CHUNK_SIZE` and leaves it for the deferred auto-flush task, while a write at or above `CHUNK_SIZE` goes straight to the fd (`src/io/PipeWriter.rs`, `should_buffer`). Sink A's bytes sit in A's buffer while sink B's bytes hit the kernel.
- This is the write half of #11553 (the Native Messaging host does exactly this, one `Bun.file(1).writer()` per chunk). The stdin half of that issue no longer reproduces.

### Fix (as currently written)

- POSIX arm of `Blob::get_writer` (`src/runtime/webcore/Blob.rs`): when the Blob is fd 1/2 or the `Bun.stdout`/`Bun.stderr` store singleton, set `force_sync` on the new sink before `start()`. This is the same predicate the Windows arm already uses to call `start_sync`, and the same flag `process.stdout`/`process.stderr` set via `Bun__ForceFileSinkToBeSynchronousForProcessObjectStdio`.
- `FileSink::setup` passes it to `open_for_writing`, which clears `O_NONBLOCK` on the dup'd fd and sets `writer.force_sync`, so every `write()` is an immediate `write(2)`.
- Test: `test/js/bun/util/filesink.test.ts`, "stdout/stderr sinks write synchronously" (4 cases: `Bun.file(1)`, `Bun.stdout`, `Bun.file(2)`, `Bun.stderr`). Fails on main, passes with the fix.

### Conflict with current main

#38641 added tests pinning `Bun.stdout.writer()` on POSIX as buffered and non-blocking. With this diff applied on top of main, two of them break:

- "a flush() that could not drain keeps the process alive until it does": **hangs**. `force_sync` clears `O_NONBLOCK` on the shared open file description, so `write()` to a socket whose send buffer is full blocks the main thread, and the timer that drains it never runs. That is a real regression, not a test-shape issue.
- "a flush() that fails with EPIPE emits 'beforeExit' once": EPIPE now throws from `write()` instead of `flush()`.

Both pass on clean main. So main has, since this PR was opened, committed to buffered/non-blocking semantics for stdio sinks on POSIX (#33538, #35278, #35344, #35365, #36250, #38641 all build on that path), and forcing sync mode cuts against it. It would also turn the correct usage (one cached writer, many small `write()` calls) into one syscall per write.

Options I see, none of which I think should be picked unilaterally:

1. Drop this PR and treat a per-call `.writer()` that is never flushed as misuse. `await Bun.write(Bun.stdout, x)`, `process.stdout.write`, and a single cached writer all produce correct output today. The remaining inconsistency would then be the Windows arm (sync) vs POSIX (buffered), plus docs (#11712 is the open docs issue from the same reporter).
2. Share one underlying `FileSink` per stdio fd across `.writer()` calls, so there is a single ordered buffer. Fixes ordering and keeps buffered/non-blocking semantics, but is a lifecycle/design change (`end()`/`close()` on one handle, per-call `highWaterMark`, refcounting), not a bug fix.
3. Stdio sinks attempt the non-blocking `write(2)` eagerly and only park on EAGAIN/partial. Fixes ordering and the backpressure test, but EPIPE would surface from `write()` unless errors are deferred to `flush()`, and it adds a syscall per `write()` for the normal single-writer case.

### Background

- `FileSink` is the native object behind `Bun.file(...).writer()`: a buffered writer over one fd. `write()` appends to an in-memory buffer; data reaches the fd on `flush()`, `end()`, when the buffer passes a size threshold, or from a deferred auto-flush task the event loop runs after the current macrotask.
- `force_sync` is a `FileSink`/`PosixStreamingWriter` flag that disables that buffering and makes the fd blocking. Bun already sets it for `process.stdout`/`process.stderr` (Node semantics: stdio writes are synchronous for files and, on Linux, pipes) and, on Windows, for any `.writer()` on fd 1/2.
- `rare_data.stdout_store`/`stderr_store` are the singleton `Blob.Store`s behind `Bun.stdout`/`Bun.stderr`; comparing store pointers is how both arms recognise those objects. `fd.stdio_tag()` covers `Bun.file(1)`/`Bun.file(2)`.

<details>
<summary>Original PR description (before the rebase)</summary>

## Repro

```js
Bun.file(1).writer().write(Uint8Array.of(0, 0, 16, 0));     // 4 bytes
Bun.file(1).writer().write(new Uint8Array(64 * 1024));      // 64 KiB
```

```sh
$ bun repro.js | od -An -tx1 | head -1
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
#                                         ^^^^^^^ 4-byte header ends up *after* the 64 KiB body
```

In the Native Messaging host from #11553 this surfaces as the 4-byte length prefix landing after the 1 MiB JSON payload, so the reader interprets the first 4 bytes of `[null,null,...` as the message length (`0x6c756e5b` = 1819635291) and blows up on `ArrayBuffer.resize`.

## Cause

Each `.writer()` call allocates a fresh `FileSink`. On POSIX its `PosixStreamingWriter` buffers writes below `page_size` and only flushes them from a deferred auto-flush task; writes ≥ `page_size` bypass the buffer and hit the fd immediately. So the 4-byte write sits in sink A's buffer while the 64 KiB write through sink B reaches the kernel first, then sink A's deferred flush appends the header at the end.

The Windows arm of `Blob::get_writer` already detects stdout/stderr (via the `rare_data` singleton store or `fd.stdio_tag()`) and starts the sink with `start_sync`. `process.stdout`/`process.stderr` get the same treatment on POSIX via `Bun__ForceFileSinkToBeSynchronousForProcessObjectStdio`. Only the POSIX arm of `Blob::get_writer` was missing it.

## Fix

Mirror the Windows check on POSIX: when the Blob is backed by fd 1/2 or by the `Bun.stdout`/`Bun.stderr` store singleton, set `force_sync` on the new `FileSink` before `start()`. `FileSink::setup` propagates that to `open_for_writing`, which clears `O_NONBLOCK` on the dup'd fd and sets `writer.force_sync`, so every `.write()` goes straight to the fd in program order.

The stdin-read side of #11553 (`Bun.stdin.stream()` hanging at 983036 of 1048576 bytes) no longer reproduces on main — `Bun.stdin.stream()` delivers all bytes in order.

## Verification

New tests in `test/js/bun/util/filesink.test.ts` spawn a subprocess that writes a 4-byte header and a 64 KiB body through two independent sinks on each of `Bun.file(1)`, `Bun.stdout`, `Bun.file(2)`, `Bun.stderr`, and assert the header arrives first.

| | `bun bd` without fix | `bun bd` with fix |
|-|-|-|
| `Bun.file(1).writer()` | fail | pass |
| `Bun.stdout.writer()` | fail | pass |
| `Bun.file(2).writer()` | fail | pass |
| `Bun.stderr.writer()` | fail | pass |

Full `filesink.test.ts` (46 tests), `process-stdio.test.ts`, `child-process-stdio.test.js`, and `console-log.test.ts` pass unchanged.

Fixes #11553

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 7 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/util/filesink.test.ts

<!-- robobun:evidence:end -->