### PR TITLE
Don't forward SIGPWR in spawnSync signal handling

### DIFF
--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -933,9 +933,12 @@ static struct sigaction previous_actions[NSIG];
     M(SIGIO);
 
 #if OS(LINUX)
+// SIGPWR is intentionally excluded: JSC uses it for GC thread suspend/resume
+// (see wtf/posix/ThreadingPOSIX.cpp). Overriding it here breaks GC and the
+// SA_RESETHAND disposition leaves it at SIG_DFL after one delivery, which
+// kills the process on the next collection.
 #define FOR_EACH_LINUX_ONLY_SIGNAL(M) \
     M(SIGPOLL);                       \
-    M(SIGPWR);                        \
     M(SIGSTKFLT);
 
 #endif

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1051,14 +1051,15 @@ pub fn open_in_editor(global_this: &JSGlobalObject, callframe: &CallFrame) -> Js
                             )));
                         } else if edit.name.as_ptr() == edit.path.as_ptr() {
                             // `detect_editor` aliased `path` to `name` (absolute
-                            // editor path). Re-backing `name_storage` frees the
-                            // old buffer, so repoint both `name` and `path` at
-                            // the new storage.
-                            slot.name_storage = edit.path.to_vec();
-                            // SAFETY: see above.
-                            edit.name =
-                                unsafe { bun_ptr::detach_lifetime(slot.name_storage.as_slice()) };
-                            edit.path = edit.name;
+                            // editor path). `name` is backed by `slot.name_storage`,
+                            // which a later call may drop while the detached editor
+                            // thread is still reading argv[0]. Give `path`
+                            // process-lifetime storage, matching every other
+                            // `detect_editor` branch.
+                            edit.path = bun_resolver::fs::FileSystem::instance()
+                                .dirname_store
+                                .append_slice(edit.path)
+                                .expect("unreachable");
                         }
                     }
                 }

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1050,14 +1050,15 @@ pub fn open_in_editor(global_this: &JSGlobalObject, callframe: &CallFrame) -> Js
                                 bstr::BStr::new(sliced.slice()),
                             )));
                         } else if edit.name.as_ptr() == edit.path.as_ptr() {
-                            // detect_editor pointed `name` at `path`'s storage
-                            // (process-lifetime dirname_store); dupe into our
-                            // owned buffer so a later `path` overwrite doesn't
-                            // dangling-alias it.
+                            // `detect_editor` aliased `path` to `name` (absolute
+                            // editor path). Re-backing `name_storage` frees the
+                            // old buffer, so repoint both `name` and `path` at
+                            // the new storage.
                             slot.name_storage = edit.path.to_vec();
                             // SAFETY: see above.
                             edit.name =
                                 unsafe { bun_ptr::detach_lifetime(slot.name_storage.as_slice()) };
+                            edit.path = edit.name;
                         }
                     }
                 }

--- a/test/js/bun/util/open-in-editor-gc.test.ts
+++ b/test/js/bun/util/open-in-editor-gc.test.ts
@@ -29,8 +29,9 @@ test.skipIf(!isLinux)("Bun.openInEditor does not break GC signal handling", asyn
     `,
   });
   // Second absolute path to the same binary so alternating calls take the
-  // `!eql_long(prev_name, ...)` branch in open_in_editor.
-  const sleep2 = join(String(dir), "sleep2");
+  // `!eql_long(prev_name, ...)` branch in open_in_editor. Keep the basename
+  // `sleep` so BusyBox (Alpine) resolves the multi-call applet from argv[0].
+  const sleep2 = join(String(dir), "sleep");
   symlinkSync(sleep!, sleep2);
 
   const runs = Array.from({ length: 5 }, async () => {

--- a/test/js/bun/util/open-in-editor-gc.test.ts
+++ b/test/js/bun/util/open-in-editor-gc.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, tempDir } from "harness";
-import { existsSync } from "node:fs";
+import { existsSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
 
 // On Linux, JSC uses SIGPWR to suspend/resume threads for GC and the libpas
 // scavenger. Bun.openInEditor spawns a detached thread that goes through
@@ -12,8 +13,13 @@ test.skipIf(!isLinux)("Bun.openInEditor does not break GC signal handling", asyn
 
   using dir = tempDir("open-in-editor-gc", {
     "run.js": `
+      const a = ${JSON.stringify(sleep)};
+      const b = process.argv[2];
+      // Alternate absolute editor paths so the cached editor name_storage is
+      // replaced each call while a detached editor thread may still be
+      // reading the previous one.
       for (let i = 0; i < 8; i++) {
-        try { Bun.openInEditor("0.3", { editor: ${JSON.stringify(sleep)} }); } catch {}
+        try { Bun.openInEditor("0.3", { editor: i % 2 ? b : a }); } catch {}
       }
       // Wait for the detached editor threads to complete their register /
       // unregister cycle, then for the scavenger to fire SIGPWR.
@@ -22,10 +28,14 @@ test.skipIf(!isLinux)("Bun.openInEditor does not break GC signal handling", asyn
       console.log("alive");
     `,
   });
+  // Second absolute path to the same binary so alternating calls take the
+  // `!eql_long(prev_name, ...)` branch in open_in_editor.
+  const sleep2 = join(String(dir), "sleep2");
+  symlinkSync(sleep!, sleep2);
 
   const runs = Array.from({ length: 5 }, async () => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "run.js"],
+      cmd: [bunExe(), "run.js", sleep2],
       env: bunEnv,
       cwd: String(dir),
       stdout: "pipe",

--- a/test/js/bun/util/open-in-editor-gc.test.ts
+++ b/test/js/bun/util/open-in-editor-gc.test.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { existsSync } from "node:fs";
+
+// On Linux, JSC uses SIGPWR to suspend/resume threads for GC and the libpas
+// scavenger. Bun.openInEditor spawns a detached thread that goes through
+// bun.spawnSync, whose signal-forwarding setup must not touch SIGPWR or the
+// process is terminated the next time GC/scavenger fires.
+test.skipIf(!isLinux)("Bun.openInEditor does not break GC signal handling", async () => {
+  const sleep = ["/usr/bin/sleep", "/bin/sleep"].find(p => existsSync(p));
+  expect(sleep).toBeDefined();
+
+  using dir = tempDir("open-in-editor-gc", {
+    "run.js": `
+      for (let i = 0; i < 8; i++) {
+        try { Bun.openInEditor("0.3", { editor: ${JSON.stringify(sleep)} }); } catch {}
+      }
+      // Wait for the detached editor threads to complete their register /
+      // unregister cycle, then for the scavenger to fire SIGPWR.
+      await Bun.sleep(1000);
+      Bun.gc(true);
+      console.log("alive");
+    `,
+  });
+
+  const runs = Array.from({ length: 5 }, async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("alive");
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(0);
+  });
+
+  await Promise.all(runs);
+});

--- a/test/js/bun/util/open-in-editor-gc.test.ts
+++ b/test/js/bun/util/open-in-editor-gc.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, tempDir } from "harness";
 import { existsSync } from "node:fs";
 


### PR DESCRIPTION
On Linux, JSC uses `SIGPWR` (via `g_wtfConfig.sigThreadSuspendResume`) to suspend and resume threads for GC and the libpas scavenger.

`Bun.openInEditor` spawns a detached `std::thread` that calls `sync::spawn`, which installs a process-wide signal-forwarding handler (with `SA_RESETHAND`) over every signal in `FOR_EACH_SIGNAL` — including `SIGPWR`. With multiple concurrent `openInEditor` calls, the register/unregister paths race on the shared `previous_actions[]` array and leave `SIGPWR` at `SIG_DFL`, so the next `pthread_kill(thread, SIGPWR)` from GC or the scavenger terminates the process with "Power failure".

`SIGPWR` is not a user-facing signal in Bun and never needs forwarding to a child — drop it from the Linux-only forwarding list.

Also fixes a use-after-free in `Bun.openInEditor({ editor: "/absolute/path" })`: `detect_editor` aliases `path` to `name`, and re-backing `name_storage` freed the buffer both pointed at while only repointing `name`. The stale `path` was then handed to the spawned editor thread as argv[0].

Found by Fuzzilli (fingerprint `4e72ca85863f92fa`). Repro:

```js
for (let i = 0; i < 8; i++) {
  try { Bun.openInEditor("0.3", { editor: "/usr/bin/sleep" }); } catch {}
}
await Bun.sleep(1000);
Bun.gc(true);
console.log("alive");
```