### PR TITLE
path.win32.resolve: preserve resolvedDevice when falling back to cwd

### DIFF
--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -3134,9 +3134,14 @@ pub fn resolve_windows_t<'a, T: PathCharCwd>(
                 path_ptr = buf2.as_ptr();
                 path_len = ep_len;
             } else {
-                // cwd is limited to MAX_PATH_BYTES.
-                cwd_len = get_cwd_t(&mut tmp_buf[..])?.len();
-                path_ptr = tmp_buf.as_ptr();
+                // cwd is limited to MAX_PATH_BYTES. Write past the
+                // `resolved_device_len` bytes that back `resolvedDevice` so
+                // `tmp_buf[0..resolved_device_len]` survives — the final write
+                // at the bottom of this function reads the device back from
+                // there.
+                cwd_len = get_cwd_t(&mut tmp_buf[resolved_device_len..])?.len();
+                // SAFETY: offsetting within the live `tmp_buf` array.
+                path_ptr = unsafe { tmp_buf.as_ptr().add(resolved_device_len) };
                 path_len = cwd_len;
                 // We must set envPath here so that it doesn't hit the null check just below.
                 env_path_len = Some(cwd_len);
@@ -3150,8 +3155,12 @@ pub fn resolve_windows_t<'a, T: PathCharCwd>(
             //     (StringPrototypeToLowerCase(StringPrototypeSlice(path, 0, 2)) !==
             //     StringPrototypeToLowerCase(resolvedDevice) &&
             //     StringPrototypeCharCodeAt(path, 2) === CHAR_BACKWARD_SLASH)) {
+            // JS reads `path[2]` via `charCodeAt`, which returns NaN past the
+            // end — guard the length here so a short cwd (e.g. `/`) doesn't
+            // panic the Rust indexer.
             if env_path_len.is_none()
-                || (path!()[2] == T::from_u8(CHAR_BACKWARD_SLASH)
+                || (path_len >= 3
+                    && path!()[2] == T::from_u8(CHAR_BACKWARD_SLASH)
                     && !eql_ignore_case_t(&path!()[0..2], &tmp_buf[0..resolved_device_len]))
             {
                 // Translated from the following JS code:

--- a/test/js/node/path/resolve.test.js
+++ b/test/js/node/path/resolve.test.js
@@ -144,7 +144,10 @@ describe("path.resolve", () => {
     });
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
+    // ASAN/debug builds print a "WARNING: ASAN interferes..." line on stderr
+    // at startup — filter it out before asserting stderr is clean.
+    const stderrLines = stderr.split("\n").filter(l => l && !l.startsWith("WARNING: ASAN interferes"));
+    expect(stderrLines).toEqual([]);
     expect(exitCode).toBe(0);
 
     // Node on POSIX normalises the cwd to the win32 form — slashes become

--- a/test/js/node/path/resolve.test.js
+++ b/test/js/node/path/resolve.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isWindows } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import assert from "node:assert";
 // import child from "node:child_process";
 import path from "node:path";
@@ -118,6 +118,48 @@ describe("path.resolve", () => {
     expect(() => {
       return path.posix.resolve(undefined, "/hi");
     }).not.toThrow();
+  });
+
+  // https://github.com/oven-sh/bun/issues/31182
+  test.skipIf(isWindows)("win32.resolve with a drive letter from POSIX cwd", async () => {
+    using dir = tempDir("path-resolve-31182", {});
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const path = require("node:path");
+         const out = {
+           cResolve: path.win32.resolve("C:"),
+           cNs: path.win32.toNamespacedPath("C:"),
+           dResolve: path.win32.resolve("D:"),
+           dNs: path.win32.toNamespacedPath("D:"),
+           cTail: path.win32.resolve("C:", "sub", "file.txt"),
+           cSlash: path.win32.resolve("C:/"),
+         };
+         process.stdout.write(JSON.stringify(out));`,
+      ],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    // Node on POSIX normalises the cwd to the win32 form — slashes become
+    // backslashes — and the drive-letter argument prefixes the resulting
+    // path. The previous bug emitted `/<first-two-chars-of-cwd>\<tail>`.
+    const posixCwd = String(dir);
+    const cwdTail = posixCwd.replace(/\//g, "\\");
+    expect(JSON.parse(stdout)).toEqual({
+      cResolve: `C:${cwdTail}`,
+      cNs: `\\\\?\\C:${cwdTail}`,
+      dResolve: `D:${cwdTail}`,
+      dNs: `\\\\?\\D:${cwdTail}`,
+      cTail: `C:${cwdTail}\\sub\\file.txt`,
+      cSlash: "C:\\",
+    });
   });
 
   test("very long paths", () => {


### PR DESCRIPTION
Fixes #31182.

## Repro

```sh
cd /tmp && bun -e 'const path = require("node:path");
console.log(path.win32.resolve("C:"));
console.log(path.win32.toNamespacedPath("C:"));
console.log(path.win32.resolve("D:"));
console.log(path.win32.toNamespacedPath("D:"));'
```

**Before (Bun on Linux):**
```
/t\tmp
/t\tmp
/t\tmp
/t\tmp
```

**Node / Bun after fix:**
```
C:\tmp
\\?\C:\tmp
D:\tmp
\\?\D:\tmp
```

## Cause

`resolve_windows_t` in `src/runtime/node/path.rs` stores the resolved drive
("C:", etc.) in `tmp_buf[0..resolved_device_len]`. When the reverse loop
reaches the trailing iteration (`i == -1`, `resolved_device_len > 0`), it
tries `process.env[\`=${resolvedDevice}\`]` on Windows and falls back to
`process.cwd()` otherwise.

The fallback wrote the cwd into `tmp_buf` starting at offset 0, which
clobbers the bytes backing `resolvedDevice`. The final write at the bottom
of the function then reads the mangled device back out. On Linux with cwd
`/tmp`, the prefix `C:` became `/t` and the tail normalised to `\tmp`,
producing `/t\tmp`.

The Windows path happened to work because either (a) `getenv("=X:")` hits
a drive-specific cwd and the env branch stores the path in `buf2` instead,
or (b) the cwd's drive matches `resolvedDevice` so the clobber is a no-op.
The POSIX path always takes the fallback.

## Fix

Write the cwd into `tmp_buf[resolved_device_len..]` so the device prefix
survives. Also guard the `path[2] == '\\'` check with `path_len >= 3` —
JS `charCodeAt` returns NaN past the end, but the Rust indexer panics, and
a short cwd like `/` (len 1) could otherwise OOB.

`toNamespacedPath` composes over `resolve`, so it's fixed transitively.

## Verification

- `bun bd test test/js/node/path/resolve.test.js` – new test passes.
- `USE_SYSTEM_BUN=1 bun test test/js/node/path/resolve.test.js` – new test
  fails with the exact `/t\tmp\...` output.
- Full `test/js/node/path/` suite: 121 pass, 0 fail.
- `cargo check -p bun_runtime` and `cargo check --target x86_64-pc-windows-msvc -p bun_runtime` clean.