### PR TITLE
Fixes: EINVAL: Failed to replace old lockfile with new lockfile on disk

### DIFF
--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -4863,10 +4863,8 @@ pub fn move_opened_file_at(
                 )
             };
             if src == win32::INVALID_HANDLE_VALUE {
-                return bun_sys::Result::errno(
-                    win32::NTSTATUS(kernel32::GetLastError()),
-                    bun_sys::Tag::NtSetInformationFile,
-                );
+                let e = SystemErrno::init(kernel32::GetLastError() as i64).unwrap_or(SystemErrno::EUNKNOWN);
+                return bun_sys::Result::errno(e, bun_sys::Tag::NtSetInformationFile);
             }
 
             // Reuse buf for dst path. Mirrors FileRenameInformationEx:
@@ -4908,12 +4906,9 @@ pub fn move_opened_file_at(
                 )
             };
             if dst == win32::INVALID_HANDLE_VALUE {
-                let err = kernel32::GetLastError();
+                let e = SystemErrno::init(kernel32::GetLastError() as i64).unwrap_or(SystemErrno::EUNKNOWN);
                 let _ = unsafe { externs::CloseHandle(src) };
-                return bun_sys::Result::errno(
-                    win32::NTSTATUS(err),
-                    bun_sys::Tag::NtSetInformationFile,
-                );
+                return bun_sys::Result::errno(e, bun_sys::Tag::NtSetInformationFile);
             }
             let mut copy_ok = true;
             let mut last_err: u32 = 0;
@@ -4944,10 +4939,8 @@ pub fn move_opened_file_at(
             if copy_ok {
                 bun_sys::Result::success()
             } else {
-                bun_sys::Result::errno(
-                    win32::NTSTATUS(last_err),
-                    bun_sys::Tag::NtSetInformationFile,
-                )
+                let e = SystemErrno::init(last_err as i64).unwrap_or(SystemErrno::EUNKNOWN);
+                bun_sys::Result::errno(e, bun_sys::Tag::NtSetInformationFile)
             }
         } else {
             bun_sys::Result::errno(fallback_rc, bun_sys::Tag::NtSetInformationFile)

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -4828,14 +4828,11 @@ pub fn move_opened_file_at(
         if fallback_rc == win32::ntstatus::SUCCESS {
             bun_sys::Result::success()
         } else if fallback_rc == win32::ntstatus::INVALID_PARAMETER {
-            // Both FileRenameInformationEx and FileRenameInformation rejected — a filter
-            // driver (e.g. BFS-filterdriver) is blocking NtSetInformationFile entirely.
-            // MoveFileExW uses the same kernel path so would also fail; skip it and
-            // copy the content directly using the already-open src_fd handle instead.
-            // Bun unlinks the temp file after this function returns regardless.
-            // src_fd may have been opened write-only; open a fresh read handle by path.
-            // Use a single heap-allocated pool buffer (64 KB) to avoid stack overflow.
-            // src path is resolved first, handle opened, then buffer reused for dst.
+            // Filter driver blocks all NtSetInformationFile renames (MoveFileExW
+            // uses the same path and would also fail). Copy content instead:
+            // open a fresh read handle (src_fd may be write-only) and write to
+            // the destination directly. Bun unlinks the temp file on return.
+            // Single pool buffer (64 KB heap) reused for src then dst path.
             let mut buf = bun_paths::w_path_buffer_pool::get();
             let buf_len = buf.len() as u32;
 
@@ -4852,8 +4849,7 @@ pub fn move_opened_file_at(
             let _ = unsafe { kernel32::GetFileSizeEx(src_fd.native(), &mut src_size) };
             bun_sys::syslog!("moveOpenedFileAt src_fd size={}", src_size);
 
-            // FILE_FLAG_DELETE_ON_CLOSE: mark temp file for deletion so it is
-            // removed when all handles (including bun's src_fd) are closed.
+            // FILE_FLAG_DELETE_ON_CLOSE: temp file deleted when bun closes src_fd.
             const FILE_FLAG_DELETE_ON_CLOSE: u32 = 0x0400_0000;
             let src = unsafe {
                 externs::CreateFileW(
@@ -4873,18 +4869,31 @@ pub fn move_opened_file_at(
                 );
             }
 
-            // Reuse buf for the destination path now that src handle is open.
-            let dir_len = unsafe {
-                externs::GetFinalPathNameByHandleW(new_dir_fd.native(), buf.as_mut_ptr(), buf_len, 0)
-            } as usize;
-            if dir_len == 0 || dir_len + 1 + new_file_name.len() + 1 > buf.len() {
-                let _ = unsafe { externs::CloseHandle(src) };
-                return bun_sys::Result::errno(fallback_rc, bun_sys::Tag::NtSetInformationFile);
+            // Reuse buf for dst path. Mirrors FileRenameInformationEx:
+            // absolute new_file_name used as-is; relative resolved via new_dir_fd.
+            let dst_name_len;
+            if bun_paths::is_absolute_windows_wtf16(new_file_name) {
+                if new_file_name.len() + 1 > buf.len() {
+                    let _ = unsafe { externs::CloseHandle(src) };
+                    return bun_sys::Result::errno(fallback_rc, bun_sys::Tag::NtSetInformationFile);
+                }
+                buf[..new_file_name.len()].copy_from_slice(new_file_name);
+                buf[new_file_name.len()] = 0;
+                dst_name_len = new_file_name.len();
+            } else {
+                let dir_len = unsafe {
+                    externs::GetFinalPathNameByHandleW(new_dir_fd.native(), buf.as_mut_ptr(), buf_len, 0)
+                } as usize;
+                if dir_len == 0 || dir_len + 1 + new_file_name.len() + 1 > buf.len() {
+                    let _ = unsafe { externs::CloseHandle(src) };
+                    return bun_sys::Result::errno(fallback_rc, bun_sys::Tag::NtSetInformationFile);
+                }
+                buf[dir_len] = b'\\' as u16;
+                buf[dir_len + 1..dir_len + 1 + new_file_name.len()].copy_from_slice(new_file_name);
+                buf[dir_len + 1 + new_file_name.len()] = 0;
+                dst_name_len = dir_len + 1 + new_file_name.len();
             }
-            buf[dir_len] = b'\\' as u16;
-            buf[dir_len + 1..dir_len + 1 + new_file_name.len()].copy_from_slice(new_file_name);
-            buf[dir_len + 1 + new_file_name.len()] = 0;
-            bun_sys::syslog!("moveOpenedFileAt copy fallback dst='{}'", bun_core::fmt::utf16(&buf[..dir_len + 1 + new_file_name.len()]));
+            bun_sys::syslog!("moveOpenedFileAt copy fallback dst='{}'", bun_core::fmt::utf16(&buf[..dst_name_len]));
 
             let dst_disposition = if replace_if_exists { win32::CREATE_ALWAYS } else { win32::CREATE_NEW };
             let dst = unsafe {
@@ -4909,10 +4918,10 @@ pub fn move_opened_file_at(
             let mut copy_ok = true;
             let mut last_err: u32 = 0;
             let mut total_copied: u64 = 0;
-            let mut buf = [0u8; 4096];
+            let mut copy_buf = [0u8; 4096];
             loop {
                 let mut nr = 0u32;
-                let read_ok = unsafe { kernel32::ReadFile(src, buf.as_mut_ptr(), buf.len() as u32, &mut nr, ptr::null_mut()) };
+                let read_ok = unsafe { kernel32::ReadFile(src, copy_buf.as_mut_ptr(), copy_buf.len() as u32, &mut nr, ptr::null_mut()) };
                 if read_ok == 0 {
                     last_err = kernel32::GetLastError();
                     copy_ok = false;
@@ -4922,7 +4931,7 @@ pub fn move_opened_file_at(
                     break; // EOF
                 }
                 let mut nw = 0u32;
-                if unsafe { kernel32::WriteFile(dst, buf.as_ptr(), nr, &mut nw, ptr::null_mut()) } == 0 || nw != nr {
+                if unsafe { kernel32::WriteFile(dst, copy_buf.as_ptr(), nr, &mut nw, ptr::null_mut()) } == 0 || nw != nr {
                     last_err = kernel32::GetLastError();
                     copy_ok = false;
                     break;

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -4834,30 +4834,30 @@ pub fn move_opened_file_at(
             // copy the content directly using the already-open src_fd handle instead.
             // Bun unlinks the temp file after this function returns regardless.
             // src_fd may have been opened write-only; open a fresh read handle by path.
-            const BUF: usize = win32::PATH_MAX_WIDE as usize + 1;
-            let mut src_buf = [0u16; BUF];
-            let mut dst_buf = [0u16; BUF];
+            // Use a single heap-allocated pool buffer (64 KB) to avoid stack overflow.
+            // src path is resolved first, handle opened, then buffer reused for dst.
+            let mut buf = bun_paths::w_path_buffer_pool::get();
+            let buf_len = buf.len() as u32;
+
             // VOLUME_NAME_DOS | FILE_NAME_NORMALIZED = 0x0
             let src_len = unsafe {
-                externs::GetFinalPathNameByHandleW(src_fd.native(), src_buf.as_mut_ptr(), BUF as u32, 0)
+                externs::GetFinalPathNameByHandleW(src_fd.native(), buf.as_mut_ptr(), buf_len, 0)
             } as usize;
-            let dir_len = unsafe {
-                externs::GetFinalPathNameByHandleW(new_dir_fd.native(), dst_buf.as_mut_ptr(), BUF as u32, 0)
-            } as usize;
-            if src_len == 0 || dir_len == 0 || dir_len + 1 + new_file_name.len() + 1 > BUF {
+            if src_len == 0 || src_len >= buf.len() {
                 return bun_sys::Result::errno(fallback_rc, bun_sys::Tag::NtSetInformationFile);
             }
-            src_buf[src_len] = 0;
-            dst_buf[dir_len] = b'\\' as u16;
-            dst_buf[dir_len + 1..dir_len + 1 + new_file_name.len()].copy_from_slice(new_file_name);
-            dst_buf[dir_len + 1 + new_file_name.len()] = 0;
+            buf[src_len] = 0;
+            bun_sys::syslog!("moveOpenedFileAt copy fallback src='{}'", bun_core::fmt::utf16(&buf[..src_len]));
+            let mut src_size: i64 = 0;
+            let _ = unsafe { kernel32::GetFileSizeEx(src_fd.native(), &mut src_size) };
+            bun_sys::syslog!("moveOpenedFileAt src_fd size={}", src_size);
 
             // FILE_FLAG_DELETE_ON_CLOSE: mark temp file for deletion so it is
             // removed when all handles (including bun's src_fd) are closed.
             const FILE_FLAG_DELETE_ON_CLOSE: u32 = 0x0400_0000;
             let src = unsafe {
                 externs::CreateFileW(
-                    src_buf.as_ptr(),
+                    buf.as_ptr(),
                     win32::GENERIC_READ,
                     win32::FILE_SHARE_READ | win32::FILE_SHARE_WRITE | win32::FILE_SHARE_DELETE,
                     ptr::null_mut(),
@@ -4866,27 +4866,34 @@ pub fn move_opened_file_at(
                     ptr::null_mut(),
                 )
             };
-            bun_sys::syslog!(
-                "moveOpenedFileAt copy fallback src='{}' dst='{}'",
-                bun_core::fmt::utf16(&src_buf[..src_len]),
-                bun_core::fmt::utf16(&dst_buf[..dir_len + 1 + new_file_name.len()]),
-            );
-            let mut src_size: i64 = 0;
-            let _ = unsafe { kernel32::GetFileSizeEx(src_fd.native(), &mut src_size) };
-            bun_sys::syslog!("moveOpenedFileAt src_fd size={}", src_size);
             if src == win32::INVALID_HANDLE_VALUE {
                 return bun_sys::Result::errno(
                     win32::NTSTATUS(kernel32::GetLastError()),
                     bun_sys::Tag::NtSetInformationFile,
                 );
             }
+
+            // Reuse buf for the destination path now that src handle is open.
+            let dir_len = unsafe {
+                externs::GetFinalPathNameByHandleW(new_dir_fd.native(), buf.as_mut_ptr(), buf_len, 0)
+            } as usize;
+            if dir_len == 0 || dir_len + 1 + new_file_name.len() + 1 > buf.len() {
+                let _ = unsafe { externs::CloseHandle(src) };
+                return bun_sys::Result::errno(fallback_rc, bun_sys::Tag::NtSetInformationFile);
+            }
+            buf[dir_len] = b'\\' as u16;
+            buf[dir_len + 1..dir_len + 1 + new_file_name.len()].copy_from_slice(new_file_name);
+            buf[dir_len + 1 + new_file_name.len()] = 0;
+            bun_sys::syslog!("moveOpenedFileAt copy fallback dst='{}'", bun_core::fmt::utf16(&buf[..dir_len + 1 + new_file_name.len()]));
+
+            let dst_disposition = if replace_if_exists { win32::CREATE_ALWAYS } else { win32::CREATE_NEW };
             let dst = unsafe {
                 externs::CreateFileW(
-                    dst_buf.as_ptr(),
+                    buf.as_ptr(),
                     win32::GENERIC_WRITE,
                     win32::FILE_SHARE_READ | win32::FILE_SHARE_WRITE | win32::FILE_SHARE_DELETE,
                     ptr::null_mut(),
-                    win32::CREATE_ALWAYS,
+                    dst_disposition,
                     win32::FILE_ATTRIBUTE_NORMAL,
                     ptr::null_mut(),
                 )
@@ -4900,15 +4907,23 @@ pub fn move_opened_file_at(
                 );
             }
             let mut copy_ok = true;
+            let mut last_err: u32 = 0;
             let mut total_copied: u64 = 0;
             let mut buf = [0u8; 4096];
             loop {
                 let mut nr = 0u32;
-                if unsafe { kernel32::ReadFile(src, buf.as_mut_ptr(), buf.len() as u32, &mut nr, ptr::null_mut()) } == 0 || nr == 0 {
+                let read_ok = unsafe { kernel32::ReadFile(src, buf.as_mut_ptr(), buf.len() as u32, &mut nr, ptr::null_mut()) };
+                if read_ok == 0 {
+                    last_err = kernel32::GetLastError();
+                    copy_ok = false;
                     break;
+                }
+                if nr == 0 {
+                    break; // EOF
                 }
                 let mut nw = 0u32;
                 if unsafe { kernel32::WriteFile(dst, buf.as_ptr(), nr, &mut nw, ptr::null_mut()) } == 0 || nw != nr {
+                    last_err = kernel32::GetLastError();
                     copy_ok = false;
                     break;
                 }
@@ -4921,7 +4936,7 @@ pub fn move_opened_file_at(
                 bun_sys::Result::success()
             } else {
                 bun_sys::Result::errno(
-                    win32::NTSTATUS(kernel32::GetLastError()),
+                    win32::NTSTATUS(last_err),
                     bun_sys::Tag::NtSetInformationFile,
                 )
             }

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -4768,6 +4768,166 @@ pub fn move_opened_file_at(
 
     if rc == win32::ntstatus::SUCCESS {
         bun_sys::Result::success()
+    } else if rc == win32::ntstatus::INVALID_PARAMETER {
+        // INVALID_PARAMETER means the filesystem or a filter driver does not support
+        // FileRenameInformationEx (e.g. FILE_RENAME_POSIX_SEMANTICS /
+        // FILE_RENAME_IGNORE_READONLY_ATTRIBUTE rejected). Fall back to the non-Ex
+        // FileRenameInformation class, which lacks POSIX semantics but works on all
+        // NTFS configurations. Mirrors the FileDispositionInformationEx →
+        // FileDispositionInformation fallback in the deletion path.
+        #[repr(C)]
+        struct FileRenameInformation {
+            replace_if_exists: BOOLEAN,
+            root_directory: HANDLE,
+            file_name_length: ULONG,
+            file_name: [u16; 1],
+        }
+        // SAFETY: rename_info_buf is #[repr(align(8))] which satisfies
+        // FileRenameInformation's alignment (largest field is HANDLE, 8-byte aligned).
+        // ptr::write initializes without dropping prior (uninit) contents.
+        let fallback_info: *mut FileRenameInformation = rename_info_buf.as_mut_ptr().cast();
+        unsafe {
+            ptr::write(
+                fallback_info,
+                FileRenameInformation {
+                    replace_if_exists: if replace_if_exists { 1 } else { 0 },
+                    root_directory: if bun_paths::is_absolute_windows_wtf16(new_file_name) {
+                        ptr::null_mut()
+                    } else {
+                        new_dir_fd.native()
+                    },
+                    file_name_length: u32::try_from(new_file_name.len() * 2).expect("int cast"),
+                    file_name: [0; 1],
+                },
+            );
+            ptr::copy_nonoverlapping(
+                new_file_name.as_ptr(),
+                ptr::addr_of_mut!((*fallback_info).file_name).cast::<u16>(),
+                new_file_name.len(),
+            );
+        }
+        let fallback_len =
+            size_of::<FileRenameInformation>() - size_of::<u16>() + new_file_name.len() * 2;
+        let fallback_rc = unsafe {
+            ntdll::NtSetInformationFile(
+                src_fd.native(),
+                &mut io_status_block,
+                fallback_info.cast::<c_void>(),
+                u32::try_from(fallback_len).expect("int cast"),
+                win32::FileInformationClass::FileRenameInformation,
+            )
+        };
+        bun_sys::syslog!(
+            "moveOpenedFileAt fallback({} ->> {} '{}', {}) = {:?}",
+            src_fd,
+            new_dir_fd,
+            bun_core::fmt::utf16(new_file_name),
+            if replace_if_exists { "replace_if_exists" } else { "no flag" },
+            fallback_rc
+        );
+        if fallback_rc == win32::ntstatus::SUCCESS {
+            bun_sys::Result::success()
+        } else if fallback_rc == win32::ntstatus::INVALID_PARAMETER {
+            // Both FileRenameInformationEx and FileRenameInformation rejected — a filter
+            // driver (e.g. BFS-filterdriver) is blocking NtSetInformationFile entirely.
+            // MoveFileExW uses the same kernel path so would also fail; skip it and
+            // copy the content directly using the already-open src_fd handle instead.
+            // Bun unlinks the temp file after this function returns regardless.
+            // src_fd may have been opened write-only; open a fresh read handle by path.
+            const BUF: usize = win32::PATH_MAX_WIDE as usize + 1;
+            let mut src_buf = [0u16; BUF];
+            let mut dst_buf = [0u16; BUF];
+            // VOLUME_NAME_DOS | FILE_NAME_NORMALIZED = 0x0
+            let src_len = unsafe {
+                externs::GetFinalPathNameByHandleW(src_fd.native(), src_buf.as_mut_ptr(), BUF as u32, 0)
+            } as usize;
+            let dir_len = unsafe {
+                externs::GetFinalPathNameByHandleW(new_dir_fd.native(), dst_buf.as_mut_ptr(), BUF as u32, 0)
+            } as usize;
+            if src_len == 0 || dir_len == 0 || dir_len + 1 + new_file_name.len() + 1 > BUF {
+                return bun_sys::Result::errno(fallback_rc, bun_sys::Tag::NtSetInformationFile);
+            }
+            src_buf[src_len] = 0;
+            dst_buf[dir_len] = b'\\' as u16;
+            dst_buf[dir_len + 1..dir_len + 1 + new_file_name.len()].copy_from_slice(new_file_name);
+            dst_buf[dir_len + 1 + new_file_name.len()] = 0;
+
+            // FILE_FLAG_DELETE_ON_CLOSE: mark temp file for deletion so it is
+            // removed when all handles (including bun's src_fd) are closed.
+            const FILE_FLAG_DELETE_ON_CLOSE: u32 = 0x0400_0000;
+            let src = unsafe {
+                externs::CreateFileW(
+                    src_buf.as_ptr(),
+                    win32::GENERIC_READ,
+                    win32::FILE_SHARE_READ | win32::FILE_SHARE_WRITE | win32::FILE_SHARE_DELETE,
+                    ptr::null_mut(),
+                    win32::OPEN_EXISTING,
+                    win32::FILE_ATTRIBUTE_NORMAL | FILE_FLAG_DELETE_ON_CLOSE,
+                    ptr::null_mut(),
+                )
+            };
+            bun_sys::syslog!(
+                "moveOpenedFileAt copy fallback src='{}' dst='{}'",
+                bun_core::fmt::utf16(&src_buf[..src_len]),
+                bun_core::fmt::utf16(&dst_buf[..dir_len + 1 + new_file_name.len()]),
+            );
+            let mut src_size: i64 = 0;
+            let _ = unsafe { kernel32::GetFileSizeEx(src_fd.native(), &mut src_size) };
+            bun_sys::syslog!("moveOpenedFileAt src_fd size={}", src_size);
+            if src == win32::INVALID_HANDLE_VALUE {
+                return bun_sys::Result::errno(
+                    win32::NTSTATUS(kernel32::GetLastError()),
+                    bun_sys::Tag::NtSetInformationFile,
+                );
+            }
+            let dst = unsafe {
+                externs::CreateFileW(
+                    dst_buf.as_ptr(),
+                    win32::GENERIC_WRITE,
+                    win32::FILE_SHARE_READ | win32::FILE_SHARE_WRITE | win32::FILE_SHARE_DELETE,
+                    ptr::null_mut(),
+                    win32::CREATE_ALWAYS,
+                    win32::FILE_ATTRIBUTE_NORMAL,
+                    ptr::null_mut(),
+                )
+            };
+            if dst == win32::INVALID_HANDLE_VALUE {
+                let err = kernel32::GetLastError();
+                let _ = unsafe { externs::CloseHandle(src) };
+                return bun_sys::Result::errno(
+                    win32::NTSTATUS(err),
+                    bun_sys::Tag::NtSetInformationFile,
+                );
+            }
+            let mut copy_ok = true;
+            let mut total_copied: u64 = 0;
+            let mut buf = [0u8; 4096];
+            loop {
+                let mut nr = 0u32;
+                if unsafe { kernel32::ReadFile(src, buf.as_mut_ptr(), buf.len() as u32, &mut nr, ptr::null_mut()) } == 0 || nr == 0 {
+                    break;
+                }
+                let mut nw = 0u32;
+                if unsafe { kernel32::WriteFile(dst, buf.as_ptr(), nr, &mut nw, ptr::null_mut()) } == 0 || nw != nr {
+                    copy_ok = false;
+                    break;
+                }
+                total_copied += nw as u64;
+            }
+            let _ = unsafe { externs::CloseHandle(src) };
+            let _ = unsafe { externs::CloseHandle(dst) };
+            bun_sys::syslog!("moveOpenedFileAt copy fallback = {} ({} bytes)", copy_ok, total_copied);
+            if copy_ok {
+                bun_sys::Result::success()
+            } else {
+                bun_sys::Result::errno(
+                    win32::NTSTATUS(kernel32::GetLastError()),
+                    bun_sys::Tag::NtSetInformationFile,
+                )
+            }
+        } else {
+            bun_sys::Result::errno(fallback_rc, bun_sys::Tag::NtSetInformationFile)
+        }
     } else {
         bun_sys::Result::errno(rc, bun_sys::Tag::NtSetInformationFile)
     }


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/oven-sh/bun/issues/10169

On Windows 11 24H2, the built-in bfs filter driver rejects all NtSetInformationFile rename operations with STATUS_INVALID_PARAMETER, causing: **EINVAL: Failed to replace old lockfile with new lockfile on disk**



  Fix: two-level fallback in move_opened_file_at:

  1. FileRenameInformation (non-Ex) - retry without POSIX flags when Ex returns INVALID_PARAMETER. Atomic rename, works for drivers that only block POSIX
  semantics.
  2. Copy-content - when both NtSetInformationFile calls fail, resolve handles to paths via GetFinalPathNameByHandleW, open fresh read handle with FILE_FLAG_DELETE_ON_CLOSE (so temp file is cleaned up when bun closes its handle), and copy with ReadFile/WriteFile/CreateFileW.

  Tested on Windows 11 24H2 with bfs filter driver active.

### How did you verify your code works?

I rebuilt bun on windows, and ran bun-debug install with success.

Before: 
<img width="635" height="68" alt="image" src="https://github.com/user-attachments/assets/c8bb04e1-cccf-4039-8f80-356a685ba7e5" />

After:
<img width="999" height="193" alt="image" src="https://github.com/user-attachments/assets/ae4c67a5-0058-4096-a93c-aafc85f0c5f5" />



