### PR TITLE
docs: update discord.js API docs link to discord.js.org/docs

### DIFF
--- a/docs/guides/ecosystem/discordjs.mdx
+++ b/docs/guides/ecosystem/discordjs.mdx
@@ -77,7 +77,7 @@ Ready! Logged in as my-bot#1234
 
 ---
 
-You're up and running with a bare-bones Discord.js bot! This is a basic guide to setting up your bot with Bun; we recommend the [official discord.js docs](https://discordjs.guide/) for complete information on the `discord.js` API.
+You're up and running with a bare-bones Discord.js bot! This is a basic guide to setting up your bot with Bun; we recommend the [official discord.js docs](https://discord.js.org/docs) for complete information on the `discord.js` API.
 
 ---
 


### PR DESCRIPTION
Closes #31186.

The "official discord.js docs" link on the Discord.js guide pointed at `discordjs.guide/` — the original community tutorial site, which has since been rebranded as the legacy guide. The API reference now lives at `discord.js.org/docs`.

### Change

`docs/guides/ecosystem/discordjs.mdx` line 80: update the "official discord.js docs" link from `https://discordjs.guide/` to `https://discord.js.org/docs`.

The line 25 deep-link into `discordjs.guide/legacy/preparations/app-setup` stays — that's the step-by-step bot-portal setup walkthrough (still hosted at the rebranded legacy URL), which the new API-reference site doesn't replace.