### PR TITLE
fix(baby_vec): with_capacity_in respects exact capacity

### DIFF
--- a/src/bun_alloc/baby_vec.rs
+++ b/src/bun_alloc/baby_vec.rs
@@ -53,7 +53,7 @@ impl<'a, T> BabyVec<'a, T> {
     pub fn with_capacity_in(cap: usize, alloc: &'a MimallocArena) -> Self {
         let mut v = Self::new_in(alloc);
         if cap > 0 {
-            v.grow_to(cap);
+            v.grow_exact(cap);
         }
         v
     }


### PR DESCRIPTION
fix with_capacity_in uses grow_exact to respect requested capacity

### What does this PR do?
grow_to enforces a minimum of 4, so with_capacity_in(1) was silently allocating capacity=4. Switch to grow_exact to match Vec::with_capacity semantics.

Fixes debug_assert!(atoms.capacity() == 1) panic in shell parser on debug builds.

### How did you verify your code works?
Rebuilt on windows.

Before:
<img width="642" height="605" alt="image" src="https://github.com/user-attachments/assets/cb371a7e-f242-445a-bcb0-16576fd7c6a9" />

After:
<img width="464" height="74" alt="image" src="https://github.com/user-attachments/assets/965c7322-ce08-4f79-8c14-aa9f0f33f8ed" />
