### PR TITLE
shell_parser: drop stale capacity==1 debug_assert in parse_atom

### DIFF
--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1915,10 +1915,7 @@ impl<'bump> Parser<'bump> {
 
         Ok(match atoms.len() {
             0 => None,
-            1 => {
-                debug_assert!(atoms.capacity() == 1);
-                Some(ast::Atom::new_simple(atoms.into_iter().next().unwrap()))
-            }
+            1 => Some(ast::Atom::new_simple(atoms.into_iter().next().unwrap())),
             _ => Some(ast::Atom::Compound(ast::CompoundAtom {
                 atoms: atoms.into_bump_slice(),
                 brace_expansion_hint: has_brace_open && has_brace_close && has_comma,

--- a/test/js/bun/shell/parse.test.ts
+++ b/test/js/bun/shell/parse.test.ts
@@ -59,6 +59,42 @@ describe("parse shell", () => {
     expect(result).toEqual(expected);
   });
 
+  test("single atom", () => {
+    expect(JSON.parse(parse`ls`)).toEqual({
+      stmts: [
+        {
+          exprs: [
+            {
+              cmd: {
+                assigns: [],
+                name_and_args: [{ simple: { Text: "ls" } }],
+                redirect: redirect({}),
+                redirect_file: null,
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(JSON.parse(parse`echo ~`)).toEqual({
+      stmts: [
+        {
+          exprs: [
+            {
+              cmd: {
+                assigns: [],
+                name_and_args: [{ simple: { Text: "echo" } }, { simple: { tilde: {} } }],
+                redirect: redirect({}),
+                redirect_file: null,
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   test("compound atom", () => {
     const expected = {
       stmts: [


### PR DESCRIPTION
Fuzzilli found a debug-build panic in the shell parser:

```
panic: assertion failed: atoms.capacity() == 1 (src/shell_parser/parse.rs:1932:17)
```

Minimal repro (debug build):
```js
await Bun.$`echo hello`;
```

### Root cause

`parse_atom` creates its atom list with `ArenaVec::with_capacity_in(1, ..)` and, when exactly one atom was pushed, asserts `atoms.capacity() == 1`. In the Zig original this verified the `std.heap.stackFallback(@sizeOf(SimpleAtom))` slot was sufficient and no heap allocation occurred.

Since 303cd282b5, `ArenaVec` is `BabyVec`, whose `with_capacity_in` routes through `grow_to`:
```rust
let new_cap = (self.cap as usize * 2).max(at_least).max(4);
```
so the initial capacity is always 4. The assertion therefore fires on every single-atom token in debug builds — i.e. on essentially any `Bun.$` invocation.

### Fix

Remove the assertion. There is no stack fallback in the Rust port, so the check guards no invariant; the `len() == 1` match arm already establishes the only property the code relies on.

Covered by the existing `test/js/bun/shell/parse.test.ts` (`parse\`echo foo\`` et al.), which crashed under `bun-debug` before this change and passes after.