### PR TITLE
Fix typo in default-trusted-dependencies.txt

### DIFF
--- a/src/install/default-trusted-dependencies.txt
+++ b/src/install/default-trusted-dependencies.txt
@@ -131,7 +131,7 @@ cldr-data
 clevertap-react-native
 clientjs
 cmark-gfm
-compresion
+compression
 contentlayer
 contextify
 cordova.plugins.diagnostic


### PR DESCRIPTION
Both `compression` and `compresion` point to the same logical packge, but `compresion` is a typo and `compression` is the canonical name 35M weekly downloads