### PR TITLE
Reduce node-http-backpressure test peak memory

### DIFF
--- a/test/js/node/http/node-http-backpressure.test.ts
+++ b/test/js/node/http/node-http-backpressure.test.ts
@@ -10,8 +10,38 @@ import http from "node:http";
 import type { AddressInfo } from "node:net";
 
 describe("backpressure", () => {
-  // INT_MAX is the maximum we can sent to the socket in one call
-  const TwoGBPayload = Buffer.allocUnsafe(1024 * 1024 * 1024 * 2);
+  // Writes `total` bytes to `res` in `chunk`-sized pieces, waiting for "drain"
+  // whenever a write reports backpressure, then ends the response. Reusing one
+  // chunk buffer keeps the test's peak memory small (the previous version held
+  // a single 2 GB payload plus the server's queued copy, which pushed peak RSS
+  // past 4.5 GB and intermittently got OOM-killed on 8 GB CI runners).
+  async function writeBytes(res: http.ServerResponse, total: number, chunk: Buffer) {
+    let remaining = total;
+    while (remaining > 0) {
+      const slice = remaining >= chunk.byteLength ? chunk : chunk.subarray(0, remaining);
+      remaining -= slice.byteLength;
+      if (!res.write(slice)) {
+        await once(res, "drain");
+      }
+    }
+    res.end();
+  }
+
+  async function countResponseBytes(port: number): Promise<number> {
+    const response = await fetch(`http://localhost:${port}/`);
+    const reader = (response.body as ReadableStream<Uint8Array>).getReader();
+    let totalBytes = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+
+      if (value) {
+        totalBytes += value.byteLength;
+      }
+      if (done) break;
+    }
+    return totalBytes;
+  }
+
   it("should handle backpressure", async () => {
     await using server = http.createServer((req, res) => {
       res.writeHead(200, {
@@ -34,65 +64,46 @@ describe("backpressure", () => {
     const bytes = await fetch(`http://localhost:${PORT}/`).then(res => res.arrayBuffer());
     expect(bytes.byteLength).toBe(1024 * 1024 * 3);
   });
+
   it("should handle backpressure with INT_MAX bytes", async () => {
+    const totalSize = 1024 * 1024 * 1024 * 2; // 2^31, one past INT_MAX
+    const chunk = Buffer.alloc(64 * 1024 * 1024, "a");
     await using server = http.createServer((req, res) => {
       res.writeHead(200, {
         "Content-Type": "application/octet-stream",
         "Transfer-Encoding": "chunked",
       });
 
-      res.write(TwoGBPayload, () => {
-        res.end();
-      });
+      writeBytes(res, totalSize, chunk);
     });
 
     await once(server.listen(0), "listening");
 
     const PORT = (server.address() as AddressInfo).port;
-    const response = await fetch(`http://localhost:${PORT}/`);
-    const reader = (response.body as ReadableStream<Uint8Array>).getReader();
-    let totalBytes = 0;
-    while (true) {
-      const { done, value } = await reader.read();
+    const totalBytes = await countResponseBytes(PORT);
 
-      if (value) {
-        totalBytes += value.byteLength;
-      }
-      if (done) break;
-    }
-
-    expect(totalBytes).toBe(TwoGBPayload.byteLength);
+    expect(totalBytes).toBe(totalSize);
   }, 30_000);
 
   it("should handle backpressure with more than INT_MAX bytes", async () => {
     // enough to fill the socket buffer
     const smallPayloadSize = 1024 * 1024;
+    const totalSize = 1024 * 1024 * 1024 * 2; // 2^31, one past INT_MAX
+    const chunk = Buffer.alloc(64 * 1024 * 1024, "a");
     await using server = http.createServer((req, res) => {
       res.writeHead(200, {
         "Content-Type": "application/octet-stream",
         "Transfer-Encoding": "chunked",
       });
       res.write(Buffer.alloc(smallPayloadSize, "a"));
-      res.write(TwoGBPayload, () => {
-        res.end();
-      });
+      writeBytes(res, totalSize, chunk);
     });
 
     await once(server.listen(0), "listening");
 
     const PORT = (server.address() as AddressInfo).port;
-    const response = await fetch(`http://localhost:${PORT}/`);
-    const reader = (response.body as ReadableStream<Uint8Array>).getReader();
-    let totalBytes = 0;
-    while (true) {
-      const { done, value } = await reader.read();
+    const totalBytes = await countResponseBytes(PORT);
 
-      if (value) {
-        totalBytes += value.byteLength;
-      }
-      if (done) break;
-    }
-
-    expect(totalBytes).toBe(TwoGBPayload.byteLength + smallPayloadSize);
+    expect(totalBytes).toBe(totalSize + smallPayloadSize);
   }, 30_000);
 });


### PR DESCRIPTION
`test/js/node/http/node-http-backpressure.test.ts` allocates a single 2 GB payload at module scope and passes it to one `res.write()` call in two tests. Between the payload itself and the server's queued copy of the unsent portion, the file peaks at **~4.6 GB RSS**, which is uncomfortably close to the 8 GB Linux x64 CI runners — it has been intermittently (and recently, consistently) OOM-SIGKILLed there.

This reworks the two heavy cases to stream the same totals (2^31 and 2^31 + 1 MB bytes) through a reused 64 MB chunk, honoring backpressure (`res.write()` return value + `drain`), with the client still streaming and counting bytes.

Measured with the `bun-linux-x64-profile` binary from main build 56749:

| | peak RSS | wall time |
|---|---|---|
| before | 4,635,092 KB (~4.4 GiB) | 16.0 s |
| after | 1,029,296 KB (~1.0 GiB) | 2.9 s |

Coverage note: the aggregate >INT_MAX-bytes-with-backpressure path (chunked transfer, drain handling, byte-count integrity) is preserved; what changes is that the payload is no longer handed to `res.write()` as one single ≥2 GB buffer in those two tests.

All APIs used remain Node-compatible per the file's header requirement.
