### PR TITLE
fix(bun-types): flatten WebSocketOptionsProtocolsOrProtocol to fix excess-property check with headers

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3089,7 +3089,7 @@ declare module "bun" {
       algorithm: "argon2id" | "argon2d" | "argon2i";
 
       /**
-       * Memory cost, which defines the memory usage, given in kibibytes.
+       * Memory cost, which defines the memory usage, given in kibibytes. Minimum 8.
        */
       memoryCost?: number;
       /**
@@ -4693,6 +4693,20 @@ declare module "bun" {
      * Dump the mimalloc heap to the console
      */
     function mimallocDump(): void;
+
+    /**
+     * Accurate per-process memory footprint in bytes.
+     *
+     * Unlike `process.memoryUsage.rss()`, this excludes pages already
+     * returned to the OS that the kernel keeps mapped lazily (Darwin's
+     * `MADV_FREE_REUSABLE`), so leak tests are platform-comparable.
+     *
+     * Backed by `task_info(TASK_VM_INFO).phys_footprint` on Darwin, `Pss:`
+     * from `/proc/self/smaps_rollup` on Linux, and `PrivateUsage` on Windows.
+     * Returns `undefined` on platforms with no accurate accessor; callers
+     * should fall back: `Bun.unsafe.memoryFootprint() ?? process.memoryUsage.rss()`.
+     */
+    function memoryFootprint(): number | undefined;
   }
 
   type DigestEncoding = "utf8" | "ucs2" | "utf16le" | "latin1" | "ascii" | "base64" | "base64url" | "hex";

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3089,7 +3089,7 @@ declare module "bun" {
       algorithm: "argon2id" | "argon2d" | "argon2i";
 
       /**
-       * Memory cost, which defines the memory usage, given in kibibytes. Minimum 8.
+       * Memory cost, which defines the memory usage, given in kibibytes.
        */
       memoryCost?: number;
       /**
@@ -4169,19 +4169,20 @@ declare module "bun" {
     compact?: boolean;
   }
 
-  type WebSocketOptionsProtocolsOrProtocol =
-    | {
-        /**
-         * Protocols to use for the WebSocket connection
-         */
-        protocols?: string | string[];
-      }
-    | {
-        /**
-         * Protocol to use for the WebSocket connection
-         */
-        protocol?: string;
-      };
+  // Flat type (was a union) to avoid TypeScript's excess-property check flagging
+  // `headers` as unknown when checking object literals against Bun.WebSocketOptions.
+  // TypeScript separately checks each member of a union inside an intersection, and
+  // `headers` (from WebSocketOptionsHeaders) is not present in either union branch.
+  type WebSocketOptionsProtocolsOrProtocol = {
+    /**
+     * Protocols to use for the WebSocket connection
+     */
+    protocols?: string | string[];
+    /**
+     * Protocol to use for the WebSocket connection
+     */
+    protocol?: string;
+  };
 
   type WebSocketOptionsTLS = {
     /**
@@ -4692,20 +4693,6 @@ declare module "bun" {
      * Dump the mimalloc heap to the console
      */
     function mimallocDump(): void;
-
-    /**
-     * Accurate per-process memory footprint in bytes.
-     *
-     * Unlike `process.memoryUsage.rss()`, this excludes pages already
-     * returned to the OS that the kernel keeps mapped lazily (Darwin's
-     * `MADV_FREE_REUSABLE`), so leak tests are platform-comparable.
-     *
-     * Backed by `task_info(TASK_VM_INFO).phys_footprint` on Darwin, `Pss:`
-     * from `/proc/self/smaps_rollup` on Linux, and `PrivateUsage` on Windows.
-     * Returns `undefined` on platforms with no accurate accessor; callers
-     * should fall back: `Bun.unsafe.memoryFootprint() ?? process.memoryUsage.rss()`.
-     */
-    function memoryFootprint(): number | undefined;
   }
 
   type DigestEncoding = "utf8" | "ucs2" | "utf16le" | "latin1" | "ascii" | "base64" | "base64url" | "hex";

--- a/packages/bun-types/websocket-options-test.ts
+++ b/packages/bun-types/websocket-options-test.ts
@@ -1,0 +1,22 @@
+// Type-level regression test for WebSocket options excess-property check.
+// Verifies that object literals with `headers` compile when combined with
+// `protocol`, `protocols`, or neither — without TS2353.
+// Regression: https://github.com/oven-sh/bun/pull/31205
+
+declare const url: string;
+declare const wsHeaders: Record<string, string>;
+
+// Headers only — must compile
+const _ws1 = new WebSocket(url, { headers: wsHeaders });
+
+// headers + protocol — must compile (was rejected before flatten)
+const _ws2 = new WebSocket(url, { protocol: "vite-hmr", headers: wsHeaders });
+
+// headers + protocols array — must compile (was rejected before flatten)
+const _ws3 = new WebSocket(url, { protocols: ["a", "b"], headers: wsHeaders });
+
+// No options — must still compile
+const _ws4 = new WebSocket(url);
+
+// Legacy string protocol form — must still compile
+const _ws5 = new WebSocket(url, "vite-hmr");


### PR DESCRIPTION
## Problem

When calling `new WebSocket(url, { headers })`, TypeScript raises:

```
error TS2353: Object literal may only specify known properties, and 'headers' does not exist in type '{ protocols?: string | string[] }'.
```

**Root cause:** `Bun.WebSocketOptions` is defined as:

```typescript
type WebSocketOptions = WebSocketOptionsProtocolsOrProtocol & WebSocketOptionsTLS & WebSocketOptionsHeaders;
```

Where `WebSocketOptionsProtocolsOrProtocol` is a union:

```typescript
type WebSocketOptionsProtocolsOrProtocol =
  | { protocols?: string | string[] }
  | { protocol?: string };
```

TypeScript performs excess-property checking **against each member of a union independently** when checking object literals. The property `headers` (from `WebSocketOptionsHeaders`) is not declared in either branch, so TypeScript flags it as an excess property — even though `headers` is valid in the full intersection `Bun.WebSocketOptions`.

## Fix

Flatten `WebSocketOptionsProtocolsOrProtocol` from a union to a flat object type:

```typescript
// Before (union):
type WebSocketOptionsProtocolsOrProtocol =
  | { protocols?: string | string[] }
  | { protocol?: string };

// After (flat):
type WebSocketOptionsProtocolsOrProtocol = {
  protocols?: string | string[];
  protocol?: string;
};
```

Non-breaking: both properties remain optional. No runtime change.

## Type-level test

Added `packages/bun-types/websocket-options-test.ts` covering all three forms that were broken:

```typescript
// All three must compile without TS2353:
const _ws1 = new WebSocket(url, { headers: wsHeaders });
const _ws2 = new WebSocket(url, { protocol: "vite-hmr", headers: wsHeaders });
const _ws3 = new WebSocket(url, { protocols: ["a", "b"], headers: wsHeaders });
```

## Note on lib.dom.d.ts

This fix applies when Bun types are used **without** `lib.dom.d.ts` (e.g., `lib: ["ES2022"]`). When DOM types are also loaded, `UseLibDomIfAvailable` falls back to the DOM `WebSocket` constructor (no Bun-specific options) — that is a separate, pre-existing limitation documented in the `UseLibDomIfAvailable` comment.