### PR TITLE
node:zlib: pin _writeState buffer so transfer() can't free it mid-work

### DIFF
--- a/src/runtime/api/zlib.classes.ts
+++ b/src/runtime/api/zlib.classes.ts
@@ -10,7 +10,7 @@ function generate(name: string) {
     estimatedSize: true,
     klass: {},
     JSType: "0b11101110",
-    values: ["writeCallback", "errorCallback", "dictionary", "pendingInput", "pendingOutput"],
+    values: ["writeCallback", "errorCallback", "dictionary", "pendingInput", "pendingOutput", "writeState"],
 
     proto: {
       init: { fn: "init" },

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -250,9 +250,6 @@ pub(crate) trait CompressionStreamImpl: Sized + Taskable + 'static {
     fn pending_close(&self) -> &Cell<bool>;
     fn pending_reset(&self) -> &Cell<bool>;
     fn closed(&self) -> &Cell<bool>;
-    /// The `_writeState` `Uint32Array` pinned in `init()` so `transfer()` can't
-    /// free the backing store under the cached `write_result` pointer.
-    fn pinned_write_state(&self) -> &Cell<JSValue>;
 
     /// Recover `*mut Self` from the embedded `WorkPoolTask`.
     /// SAFETY: caller guarantees `task` points at the `task` field of a live `Self`.
@@ -755,10 +752,6 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         this.closed().set(true);
         this.this_value().with_mut(|v| v.deinit());
         this.stream().with_mut(|s| s.close());
-        let pinned = this.pinned_write_state().replace(JSValue::ZERO);
-        if !pinned.is_empty() {
-            pinned.unpin_array_buffer();
-        }
     }
 
     pub(crate) fn set_on_error(
@@ -1008,7 +1001,7 @@ macro_rules! __impl_compression_stream {
         /// `generate-classes.ts` for the `values:` list in `zlib.classes.ts`.
         #[allow(unused)]
         pub(crate) mod js {
-            ::bun_jsc::codegen_cached_accessors!($type_name; writeCallback, errorCallback, dictionary, pendingInput, pendingOutput);
+            ::bun_jsc::codegen_cached_accessors!($type_name; writeCallback, errorCallback, dictionary, pendingInput, pendingOutput, writeState);
         }
 
         impl $crate::node::node_zlib_binding::CompressionContext for $ctx {
@@ -1034,7 +1027,6 @@ macro_rules! __impl_compression_stream {
             #[inline] fn pending_close(&self) -> &::core::cell::Cell<bool> { &self.pending_close }
             #[inline] fn pending_reset(&self) -> &::core::cell::Cell<bool> { &self.pending_reset }
             #[inline] fn closed(&self) -> &::core::cell::Cell<bool> { &self.closed }
-            #[inline] fn pinned_write_state(&self) -> &::core::cell::Cell<::bun_jsc::JSValue> { &self.pinned_write_state }
 
             #[inline]
             unsafe fn from_task(task: *mut ::bun_jsc::WorkPoolTask) -> *mut Self {

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -237,8 +237,9 @@ pub(crate) trait CompressionStreamImpl: Sized + Taskable + 'static {
         };
         // SAFETY: `write_result` points at a 2-element `u32[]` owned by JS
         // (set in each impl's `init()`); both indices are in-bounds and the
-        // backing buffer is kept alive by `this._writeState` /
-        // `_handle[owner_symbol]`.
+        // backing buffer is both pinned (so `.transfer()` can't free it) and
+        // held in the wrapper's GC-visited `writeState` slot (so it can't be
+        // collected) for the handle's lifetime — see each `init()`.
         let (r1, r0) = unsafe { (&mut *write_result.add(1), &mut *write_result) };
         self.stream().with_mut(|s| s.update_write_result(r1, r0));
     }

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -250,6 +250,9 @@ pub(crate) trait CompressionStreamImpl: Sized + Taskable + 'static {
     fn pending_close(&self) -> &Cell<bool>;
     fn pending_reset(&self) -> &Cell<bool>;
     fn closed(&self) -> &Cell<bool>;
+    /// The `_writeState` `Uint32Array` pinned in `init()` so `transfer()` can't
+    /// free the backing store under the cached `write_result` pointer.
+    fn pinned_write_state(&self) -> &Cell<JSValue>;
 
     /// Recover `*mut Self` from the embedded `WorkPoolTask`.
     /// SAFETY: caller guarantees `task` points at the `task` field of a live `Self`.
@@ -752,6 +755,10 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         this.closed().set(true);
         this.this_value().with_mut(|v| v.deinit());
         this.stream().with_mut(|s| s.close());
+        let pinned = this.pinned_write_state().replace(JSValue::ZERO);
+        if !pinned.is_empty() {
+            pinned.unpin_array_buffer();
+        }
     }
 
     pub(crate) fn set_on_error(
@@ -1027,6 +1034,7 @@ macro_rules! __impl_compression_stream {
             #[inline] fn pending_close(&self) -> &::core::cell::Cell<bool> { &self.pending_close }
             #[inline] fn pending_reset(&self) -> &::core::cell::Cell<bool> { &self.pending_reset }
             #[inline] fn closed(&self) -> &::core::cell::Cell<bool> { &self.closed }
+            #[inline] fn pinned_write_state(&self) -> &::core::cell::Cell<::bun_jsc::JSValue> { &self.pinned_write_state }
 
             #[inline]
             unsafe fn from_task(task: *mut ::bun_jsc::WorkPoolTask) -> *mut Self {

--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -245,8 +245,7 @@ mod _impl {
             // under the raw pointer cached below (written through on every
             // async-write completion by `flush_write_result`). Pinning a small
             // FastTypedArray relocates its storage, so read the pointer *after*.
-            let Some(mut write_result_buf) =
-                write_result_value.as_pinned_arraybuffer(global_this)
+            let Some(mut write_result_buf) = write_result_value.as_pinned_arraybuffer(global_this)
             else {
                 return Err(global_this.throw_out_of_memory());
             };

--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -86,9 +86,8 @@ mod _impl {
         pub global_this: bun_ptr::BackRef<JSGlobalObject>,
         pub stream: JsCell<Context>,
         /// Points into a JS `Uint32Array` (`this._writeState`). Kept alive because
-        /// the JS object is tied to the native handle as `_handle[owner_symbol]`.
+        /// `init()` stores the view in the wrapper's GC-visited `writeState` slot.
         pub write_result: Cell<Option<*mut u32>>,
-        pub pinned_write_state: Cell<JSValue>,
         pub poll_ref: JsCell<CountedKeepAlive>,
         // TODO(port): Strong on m_ctx self-ref → JsRef per PORTING.md §JSC (Strong back-ref to own wrapper leaks)
         pub this_value: JsCell<StrongOptional>, // Strong.Optional — empty-initialised
@@ -147,7 +146,6 @@ mod _impl {
                 global_this: bun_ptr::BackRef::new(global_this),
                 stream: JsCell::new(stream),
                 write_result: Cell::new(None),
-                pinned_write_state: Cell::new(JSValue::ZERO),
                 poll_ref: JsCell::new(CountedKeepAlive::default()),
                 this_value: JsCell::new(StrongOptional::empty()),
                 write_in_progress: Cell::new(false),
@@ -245,11 +243,14 @@ mod _impl {
             // under the raw pointer cached below (written through on every
             // async-write completion by `flush_write_result`). Pinning a small
             // FastTypedArray relocates its storage, so read the pointer *after*.
+            // The GC-visited `writeState` slot (zlib.classes.ts `values:`) keeps
+            // the view alive for the wrapper's lifetime — the pin only blocks
+            // detach, not collection — so the cached pointer can never dangle.
             let Some(mut write_result_buf) = write_result_value.as_pinned_arraybuffer(global_this)
             else {
                 return Err(global_this.throw_out_of_memory());
             };
-            self.pinned_write_state.set(write_result_value);
+            js::write_state_set_cached(this_value, global_this, write_result_value);
             self.write_result
                 .set(Some(write_result_buf.as_u32().as_mut_ptr()));
 

--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -88,6 +88,7 @@ mod _impl {
         /// Points into a JS `Uint32Array` (`this._writeState`). Kept alive because
         /// the JS object is tied to the native handle as `_handle[owner_symbol]`.
         pub write_result: Cell<Option<*mut u32>>,
+        pub pinned_write_state: Cell<JSValue>,
         pub poll_ref: JsCell<CountedKeepAlive>,
         // TODO(port): Strong on m_ctx self-ref → JsRef per PORTING.md §JSC (Strong back-ref to own wrapper leaks)
         pub this_value: JsCell<StrongOptional>, // Strong.Optional — empty-initialised
@@ -146,6 +147,7 @@ mod _impl {
                 global_this: bun_ptr::BackRef::new(global_this),
                 stream: JsCell::new(stream),
                 write_result: Cell::new(None),
+                pinned_write_state: Cell::new(JSValue::ZERO),
                 poll_ref: JsCell::new(CountedKeepAlive::default()),
                 this_value: JsCell::new(StrongOptional::empty()),
                 write_in_progress: Cell::new(false),
@@ -217,7 +219,6 @@ mod _impl {
                     )
                     .throw());
             }
-            let write_result = write_result_slice.as_mut_ptr();
             let write_callback =
                 validators::validate_function(global_this, "writeCallback", arguments.ptr[2])?;
 
@@ -240,7 +241,18 @@ mod _impl {
                 ));
             }
 
-            self.write_result.set(Some(write_result));
+            // Pin the `_writeState` backing store so `transfer()` can't free it
+            // under the raw pointer cached below (written through on every
+            // async-write completion by `flush_write_result`). Pinning a small
+            // FastTypedArray relocates its storage, so read the pointer *after*.
+            let Some(mut write_result_buf) =
+                write_result_value.as_pinned_arraybuffer(global_this)
+            else {
+                return Err(global_this.throw_out_of_memory());
+            };
+            self.pinned_write_state.set(write_result_value);
+            self.write_result
+                .set(Some(write_result_buf.as_u32().as_mut_ptr()));
 
             js::write_callback_set_cached(
                 this_value,

--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -188,11 +188,10 @@ mod _impl {
                     .throw());
             }
 
-            // this does not get gc'd because it is stored in the JS object's
-            // `this._writeState`. and the JS object is tied to the native handle
-            // as `_handle[owner_symbol]`.
             // `flush_write_result` writes two u32s through this pointer, so the
-            // caller-supplied array must hold at least 2 elements.
+            // caller-supplied array must hold at least 2 elements. The backing
+            // store is pinned and rooted (GC-visited `writeState` slot) below,
+            // so the cached pointer can't dangle.
             let write_result_value = arguments.ptr[1];
             let Some(mut write_result_buf) = write_result_value.as_array_buffer(global_this) else {
                 return Err(global_this.throw_invalid_argument_type_value(

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -45,7 +45,6 @@ mod _impl {
         pub global_this: bun_ptr::BackRef<JSGlobalObject>,
         pub stream: JsCell<Context>,
         pub write_result: Cell<Option<*mut u32>>,
-        pub pinned_write_state: Cell<JSValue>,
         pub poll_ref: JsCell<CountedKeepAlive>,
         pub this_value: JsCell<StrongOptional>, // jsc.Strong.Optional
         pub write_in_progress: Cell<bool>,
@@ -99,7 +98,6 @@ mod _impl {
                 global_this: bun_ptr::BackRef::new(global),
                 stream: JsCell::new(stream),
                 write_result: Cell::new(None),
-                pinned_write_state: Cell::new(JSValue::ZERO),
                 poll_ref: JsCell::new(CountedKeepAlive::default()),
                 this_value: JsCell::new(StrongOptional::empty()),
                 write_in_progress: Cell::new(false),
@@ -196,11 +194,14 @@ mod _impl {
             // under the raw pointer cached below (written through on every
             // async-write completion by `flush_write_result`). Pinning a small
             // FastTypedArray relocates its storage, so read the pointer *after*.
+            // The GC-visited `writeState` slot (zlib.classes.ts `values:`) keeps
+            // the view alive for the wrapper's lifetime — the pin only blocks
+            // detach, not collection — so the cached pointer can never dangle.
             let Some(mut write_result_buf) = write_result_value.as_pinned_arraybuffer(global)
             else {
                 return Err(global.throw_out_of_memory());
             };
-            self.pinned_write_state.set(write_result_value);
+            js::write_state_set_cached(this_value, global, write_result_value);
             self.write_result
                 .set(Some(write_result_buf.as_u32().as_mut_ptr()));
             js::write_callback_set_cached(

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -196,7 +196,8 @@ mod _impl {
             // under the raw pointer cached below (written through on every
             // async-write completion by `flush_write_result`). Pinning a small
             // FastTypedArray relocates its storage, so read the pointer *after*.
-            let Some(mut write_result_buf) = write_result_value.as_pinned_arraybuffer(global) else {
+            let Some(mut write_result_buf) = write_result_value.as_pinned_arraybuffer(global)
+            else {
                 return Err(global.throw_out_of_memory());
             };
             self.pinned_write_state.set(write_result_value);

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -45,6 +45,7 @@ mod _impl {
         pub global_this: bun_ptr::BackRef<JSGlobalObject>,
         pub stream: JsCell<Context>,
         pub write_result: Cell<Option<*mut u32>>,
+        pub pinned_write_state: Cell<JSValue>,
         pub poll_ref: JsCell<CountedKeepAlive>,
         pub this_value: JsCell<StrongOptional>, // jsc.Strong.Optional
         pub write_in_progress: Cell<bool>,
@@ -98,6 +99,7 @@ mod _impl {
                 global_this: bun_ptr::BackRef::new(global),
                 stream: JsCell::new(stream),
                 write_result: Cell::new(None),
+                pinned_write_state: Cell::new(JSValue::ZERO),
                 poll_ref: JsCell::new(CountedKeepAlive::default()),
                 this_value: JsCell::new(StrongOptional::empty()),
                 write_in_progress: Cell::new(false),
@@ -168,7 +170,6 @@ mod _impl {
                     )
                     .throw());
             }
-            let write_result = write_result_slice.as_mut_ptr();
             let write_callback =
                 validators::validate_function(global, "writeCallback", arguments.ptr[5])?;
             // Bind the ArrayBuffer view to a local so the borrowed byte_slice() outlives
@@ -191,7 +192,16 @@ mod _impl {
                 Some(dictionary_buf.byte_slice())
             };
 
-            self.write_result.set(Some(write_result));
+            // Pin the `_writeState` backing store so `transfer()` can't free it
+            // under the raw pointer cached below (written through on every
+            // async-write completion by `flush_write_result`). Pinning a small
+            // FastTypedArray relocates its storage, so read the pointer *after*.
+            let Some(mut write_result_buf) = write_result_value.as_pinned_arraybuffer(global) else {
+                return Err(global.throw_out_of_memory());
+            };
+            self.pinned_write_state.set(write_result_value);
+            self.write_result
+                .set(Some(write_result_buf.as_u32().as_mut_ptr()));
             js::write_callback_set_cached(
                 this_value,
                 global,

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -141,9 +141,10 @@ mod _impl {
                 validators::validate_int32(global, arguments.ptr[2], "memLevel", None, None)?;
             let strategy =
                 validators::validate_int32(global, arguments.ptr[3], "strategy", None, None)?;
-            // this does not get gc'd because it is stored in the JS object's `this._writeState`. and the JS object is tied to the native handle as `_handle[owner_symbol]`.
             // `flush_write_result` writes two u32s through this pointer, so the
-            // caller-supplied array must hold at least 2 elements.
+            // caller-supplied array must hold at least 2 elements. The backing
+            // store is pinned and rooted (GC-visited `writeState` slot) below,
+            // so the cached pointer can't dangle.
             let write_result_value = arguments.ptr[4];
             let Some(mut write_result_buf) = write_result_value.as_array_buffer(global) else {
                 return Err(global.throw_invalid_argument_type_value(

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -181,7 +181,8 @@ mod _impl {
                 return Err(global.throw_out_of_memory());
             };
             self.pinned_write_state.set(write_state_value);
-            self.write_result.set(Some(write_state.as_u32().as_mut_ptr()));
+            self.write_result
+                .set(Some(write_state.as_u32().as_mut_ptr()));
 
             let write_js_callback =
                 validators::validate_function(global, "processCallback", process_callback_value)?;

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -44,7 +44,6 @@ mod _impl {
         pub stream: JsCell<Context>,
         // LIFETIMES.tsv: BORROW_PARAM → Option<*mut u32> (points into JS Uint32Array backing store)
         pub write_result: Cell<Option<*mut u32>>,
-        pub pinned_write_state: Cell<JSValue>,
         pub poll_ref: JsCell<CountedKeepAlive>,
         pub this_value: JsCell<StrongOptional>, // jsc.Strong.Optional
         pub write_in_progress: Cell<bool>,
@@ -103,7 +102,6 @@ mod _impl {
                 global_this: bun_ptr::BackRef::new(global),
                 stream: JsCell::new(stream),
                 write_result: Cell::new(None),
-                pinned_write_state: Cell::new(JSValue::ZERO),
                 poll_ref: JsCell::new(CountedKeepAlive::default()),
                 this_value: JsCell::new(StrongOptional::empty()),
                 write_in_progress: Cell::new(false),
@@ -173,17 +171,6 @@ mod _impl {
                     )
                     .throw());
             }
-            // Pin the `_writeState` backing store so `transfer()` can't free it
-            // under the raw pointer cached below (written through on every
-            // async-write completion by `flush_write_result`). Pinning a small
-            // FastTypedArray relocates its storage, so read the pointer *after*.
-            let Some(mut write_state) = write_state_value.as_pinned_arraybuffer(global) else {
-                return Err(global.throw_out_of_memory());
-            };
-            self.pinned_write_state.set(write_state_value);
-            self.write_result
-                .set(Some(write_state.as_u32().as_mut_ptr()));
-
             let write_js_callback =
                 validators::validate_function(global, "processCallback", process_callback_value)?;
             // js.writeCallbackSetCached — codegen'd cached-property setter on the C++ wrapper.
@@ -202,6 +189,22 @@ mod _impl {
                     false,
                 )?);
             }
+
+            // Pin the `_writeState` backing store so `transfer()` can't free it
+            // under the raw pointer cached below (written through on every
+            // async-write completion by `flush_write_result`). Pinning a small
+            // FastTypedArray relocates its storage, so read the pointer *after*.
+            // The GC-visited `writeState` slot (zlib.classes.ts `values:`) keeps
+            // the view alive for the wrapper's lifetime — the pin only blocks
+            // detach, not collection — so the cached pointer can never dangle.
+            // Placed after the argument validators (mirroring NativeZlib and
+            // NativeBrotli) so their error paths leave nothing pinned.
+            let Some(mut write_state) = write_state_value.as_pinned_arraybuffer(global) else {
+                return Err(global.throw_out_of_memory());
+            };
+            js::write_state_set_cached(this_value, global, write_state_value);
+            self.write_result
+                .set(Some(write_state.as_u32().as_mut_ptr()));
 
             let err = self.stream.with_mut(|s| s.init(pledged_src_size));
             if err.is_error() {

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -44,6 +44,7 @@ mod _impl {
         pub stream: JsCell<Context>,
         // LIFETIMES.tsv: BORROW_PARAM → Option<*mut u32> (points into JS Uint32Array backing store)
         pub write_result: Cell<Option<*mut u32>>,
+        pub pinned_write_state: Cell<JSValue>,
         pub poll_ref: JsCell<CountedKeepAlive>,
         pub this_value: JsCell<StrongOptional>, // jsc.Strong.Optional
         pub write_in_progress: Cell<bool>,
@@ -102,6 +103,7 @@ mod _impl {
                 global_this: bun_ptr::BackRef::new(global),
                 stream: JsCell::new(stream),
                 write_result: Cell::new(None),
+                pinned_write_state: Cell::new(JSValue::ZERO),
                 poll_ref: JsCell::new(CountedKeepAlive::default()),
                 this_value: JsCell::new(StrongOptional::empty()),
                 write_in_progress: Cell::new(false),
@@ -171,7 +173,15 @@ mod _impl {
                     )
                     .throw());
             }
-            self.write_result.set(Some(write_state_slice.as_mut_ptr()));
+            // Pin the `_writeState` backing store so `transfer()` can't free it
+            // under the raw pointer cached below (written through on every
+            // async-write completion by `flush_write_result`). Pinning a small
+            // FastTypedArray relocates its storage, so read the pointer *after*.
+            let Some(mut write_state) = write_state_value.as_pinned_arraybuffer(global) else {
+                return Err(global.throw_out_of_memory());
+            };
+            self.pinned_write_state.set(write_state_value);
+            self.write_result.set(Some(write_state.as_u32().as_mut_ptr()));
 
             let write_js_callback =
                 validators::validate_function(global, "processCallback", process_callback_value)?;

--- a/test/js/node/zlib/zlib-writestate-transfer.test.js
+++ b/test/js/node/zlib/zlib-writestate-transfer.test.js
@@ -11,7 +11,7 @@ import { bunEnv, bunExe } from "harness";
 describe("_writeState buffer lifetime", () => {
   // Run in a subprocess because an unpinned build corrupts stream bookkeeping
   // (or faults) rather than throwing.
-  it.each([
+  it.concurrent.each([
     ["Inflate", "deflateSync", "createInflate"],
     ["BrotliDecompress", "brotliCompressSync", "createBrotliDecompress"],
     ["ZstdDecompress", "zstdCompressSync", "createZstdDecompress"],

--- a/test/js/node/zlib/zlib-writestate-transfer.test.js
+++ b/test/js/node/zlib/zlib-writestate-transfer.test.js
@@ -1,0 +1,46 @@
+// The native zlib/brotli/zstd handle caches a raw pointer into `_writeState`'s
+// backing store at init() and writes two u32s through it on every async-write
+// completion. Detaching that backing store while a write is in flight must not
+// leave the native side writing through a stale pointer — the buffer is pinned
+// (and kept in a GC-visited slot) for the handle's lifetime so transfer()
+// becomes a copy and the stream still produces correct output.
+
+import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+describe("_writeState buffer lifetime", () => {
+  // Run in a subprocess because an unpinned build corrupts stream bookkeeping
+  // (or faults) rather than throwing.
+  it.each([
+    ["Inflate", "deflateSync", "createInflate"],
+    ["BrotliDecompress", "brotliCompressSync", "createBrotliDecompress"],
+    ["ZstdDecompress", "zstdCompressSync", "createZstdDecompress"],
+  ])("%s decompresses correctly when _writeState.buffer is transferred mid-write", async (_, compress, create) => {
+    const script = `
+      const z = require("zlib");
+      const raw = Buffer.alloc(65536, 0x41);
+      const d = z.${compress}(raw);
+      const s = z.${create}({ chunkSize: 65536 });
+      const out = [];
+      s.on("error", e => { console.log("err:" + e.message); process.exit(1); });
+      s.on("data", c => out.push(c));
+      s.on("end", () => {
+        const r = Buffer.concat(out);
+        if (r.length === 65536 && r.equals(raw)) console.log("OK");
+        else console.log("BAD len=" + r.length);
+      });
+      s.write(d);
+      s._writeState.buffer.transfer(0);
+      s.end();
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("OK");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -1,6 +1,6 @@
 import { deflateSync, gunzipSync, gzipSync, inflateSync } from "bun";
 import { describe, expect, it } from "bun:test";
-import { tmpdirSync } from "harness";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
 import * as buffer from "node:buffer";
 import * as fs from "node:fs";
 import { resolve } from "node:path";
@@ -734,5 +734,47 @@ describe("dictionary buffer lifetime", () => {
     await promise;
 
     expect(Buffer.concat(chunks).toString()).toBe(input.toString());
+  });
+});
+
+describe("_writeState buffer lifetime", () => {
+  // The native handle caches a raw pointer into `_writeState`'s backing store
+  // at init() and writes two u32s through it on every async-write completion.
+  // Detaching that backing store while a write is in flight must not leave the
+  // native side writing through a stale pointer — the buffer is pinned for the
+  // handle's lifetime so transfer() becomes a copy and the stream still
+  // produces correct output. Run in a subprocess because an unpinned build
+  // corrupts stream bookkeeping (or faults) rather than throwing.
+  it.each([
+    ["Inflate", "deflateSync", "createInflate"],
+    ["BrotliDecompress", "brotliCompressSync", "createBrotliDecompress"],
+    ["ZstdDecompress", "zstdCompressSync", "createZstdDecompress"],
+  ])("%s decompresses correctly when _writeState.buffer is transferred mid-write", async (_, compress, create) => {
+    const script = `
+      const z = require("zlib");
+      const raw = Buffer.alloc(65536, 0x41);
+      const d = z.${compress}(raw);
+      const s = z.${create}({ chunkSize: 65536 });
+      const out = [];
+      s.on("error", e => { console.log("err:" + e.message); process.exit(1); });
+      s.on("data", c => out.push(c));
+      s.on("end", () => {
+        const r = Buffer.concat(out);
+        if (r.length === 65536 && r.equals(raw)) console.log("OK");
+        else console.log("BAD len=" + r.length);
+      });
+      s.write(d);
+      s._writeState.buffer.transfer(0);
+      s.end();
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("OK");
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -1,6 +1,6 @@
 import { deflateSync, gunzipSync, gzipSync, inflateSync } from "bun";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { tmpdirSync } from "harness";
 import * as buffer from "node:buffer";
 import * as fs from "node:fs";
 import { resolve } from "node:path";
@@ -734,47 +734,5 @@ describe("dictionary buffer lifetime", () => {
     await promise;
 
     expect(Buffer.concat(chunks).toString()).toBe(input.toString());
-  });
-});
-
-describe("_writeState buffer lifetime", () => {
-  // The native handle caches a raw pointer into `_writeState`'s backing store
-  // at init() and writes two u32s through it on every async-write completion.
-  // Detaching that backing store while a write is in flight must not leave the
-  // native side writing through a stale pointer — the buffer is pinned for the
-  // handle's lifetime so transfer() becomes a copy and the stream still
-  // produces correct output. Run in a subprocess because an unpinned build
-  // corrupts stream bookkeeping (or faults) rather than throwing.
-  it.each([
-    ["Inflate", "deflateSync", "createInflate"],
-    ["BrotliDecompress", "brotliCompressSync", "createBrotliDecompress"],
-    ["ZstdDecompress", "zstdCompressSync", "createZstdDecompress"],
-  ])("%s decompresses correctly when _writeState.buffer is transferred mid-write", async (_, compress, create) => {
-    const script = `
-      const z = require("zlib");
-      const raw = Buffer.alloc(65536, 0x41);
-      const d = z.${compress}(raw);
-      const s = z.${create}({ chunkSize: 65536 });
-      const out = [];
-      s.on("error", e => { console.log("err:" + e.message); process.exit(1); });
-      s.on("data", c => out.push(c));
-      s.on("end", () => {
-        const r = Buffer.concat(out);
-        if (r.length === 65536 && r.equals(raw)) console.log("OK");
-        else console.log("BAD len=" + r.length);
-      });
-      s.write(d);
-      s._writeState.buffer.transfer(0);
-      s.end();
-    `;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: bunEnv,
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("OK");
-    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
Narrowed from the original scope. main's hardening rounds independently fixed the primary `write()` in/out ArrayBuffer UAF (now pinned via `as_pinned_arraybuffer`), and the `dictionary` is now copied (`to_vec`) rather than borrowed — so both are already safe on main.

The one gap left is `_writeState`. Its backing pointer (`write_result`) is cached once in `init()` and written (2×u32) by `flush_write_result` after each async write, but main only validates the buffer — it never pins it. So `stream._writeState.buffer.transfer(0)` still frees the storage under the cached pointer (debug: assertion/UAF; release: silent corruption).

Pin `_writeState` in `init()` using the same `as_pinned_arraybuffer` idiom main already uses for the in/out buffers, reading the pointer *after* the pin (pinning relocates a small FastTypedArray), and store the view in a GC-visited `writeState` cached value (zlib.classes.ts) so it stays alive for the wrapper's lifetime — the pin blocks detach, the slot blocks collection, so the cached pointer can never dangle and no unpin bookkeeping is needed. Adds `_writeState`-detach regression tests for inflate/brotli/zstd in `test/js/node/zlib/zlib-writestate-transfer.test.js`, alongside the other focused zlib lifetime tests.


