### PR TITLE
node:vm: give DONT_CONTEXTIFY sandboxes their own Object.prototype

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -707,8 +707,12 @@ template<typename, JSC::SubspaceAccess mode> JSC::GCClient::IsoSubspace* NodeVMS
         [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeVMSpecialSandbox = std::forward<decltype(space)>(space); });
 }
 
-NodeVMSpecialSandbox* NodeVMSpecialSandbox::create(VM& vm, Structure* structure, NodeVMGlobalObject* globalObject)
+NodeVMSpecialSandbox* NodeVMSpecialSandbox::create(VM& vm, NodeVMGlobalObject* globalObject)
 {
+    // The structure's prototype must be the sandbox realm's Object.prototype so that the
+    // prototype chain of globalThis inside a DONT_CONTEXTIFY context never reaches the
+    // host realm. This can't be cached on the host global because it differs per sandbox.
+    auto* structure = createStructure(vm, globalObject, globalObject->objectPrototype());
     NodeVMSpecialSandbox* ptr = new (NotNull, allocateCell<NodeVMSpecialSandbox>(vm)) NodeVMSpecialSandbox(vm, structure, globalObject);
     ptr->finishCreation(vm);
     return ptr;
@@ -1405,7 +1409,7 @@ JSC_DEFINE_HOST_FUNCTION(vmModule_createContext, (JSGlobalObject * globalObject,
     zigGlobalObject->vmModuleContextMap()->set(vm, sandbox, targetContext);
 
     if (notContextified) {
-        auto* specialSandbox = NodeVMSpecialSandbox::create(vm, zigGlobalObject->NodeVMSpecialSandboxStructure(), targetContext);
+        auto* specialSandbox = NodeVMSpecialSandbox::create(vm, targetContext);
         RETURN_IF_EXCEPTION(scope, {});
         targetContext->setSpecialSandbox(specialSandbox);
         return JSValue::encode(targetContext->specialSandbox());
@@ -1614,11 +1618,6 @@ void configureNodeVM(JSC::VM& vm, Zig::GlobalObject* globalObject)
     globalObject->m_cachedNodeVMGlobalObjectStructure.initLater(
         [](const JSC::LazyProperty<JSC::JSGlobalObject, Structure>::Initializer& init) {
             init.set(createNodeVMGlobalObjectStructure(init.vm));
-        });
-
-    globalObject->m_cachedNodeVMSpecialSandboxStructure.initLater(
-        [](const JSC::LazyProperty<JSC::JSGlobalObject, Structure>::Initializer& init) {
-            init.set(NodeVMSpecialSandbox::createStructure(init.vm, init.owner, init.owner->objectPrototype())); // TODO(@heimskr): or maybe jsNull() for the prototype?
         });
 }
 

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -82,7 +82,7 @@ public:
 
     static constexpr unsigned StructureFlags = Base::StructureFlags | JSC::OverridesGetOwnPropertySlot;
 
-    static NodeVMSpecialSandbox* create(VM& vm, Structure* structure, NodeVMGlobalObject* globalObject);
+    static NodeVMSpecialSandbox* create(VM& vm, NodeVMGlobalObject* globalObject);
 
     DECLARE_INFO;
     DECLARE_VISIT_CHILDREN;

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -593,7 +593,7 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInNewContext, (JSGlobalObject * globalObject, 
     RETURN_IF_EXCEPTION(scope, {});
 
     if (notContextified) {
-        auto* specialSandbox = NodeVMSpecialSandbox::create(vm, zigGlobalObject->NodeVMSpecialSandboxStructure(), targetContext);
+        auto* specialSandbox = NodeVMSpecialSandbox::create(vm, targetContext);
         RETURN_IF_EXCEPTION(scope, {});
         targetContext->setSpecialSandbox(specialSandbox);
         RELEASE_AND_RETURN(scope, runInContext(targetContext, script, targetContext->specialSandbox(), callFrame->argument(1)));

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -306,7 +306,6 @@ public:
     JSC::JSFunction* requireESMFromHijackedExtension() const { return m_commonJSRequireESMFromHijackedExtensionFunction.getInitializedOnMainThread(this); }
 
     Structure* NodeVMGlobalObjectStructure() const { return m_cachedNodeVMGlobalObjectStructure.getInitializedOnMainThread(this); }
-    Structure* NodeVMSpecialSandboxStructure() const { return m_cachedNodeVMSpecialSandboxStructure.getInitializedOnMainThread(this); }
     Structure* globalProxyStructure() const { return m_cachedGlobalProxyStructure.getInitializedOnMainThread(this); }
     JSObject* lazyTestModuleObject() const { return m_lazyTestModuleObject.getInitializedOnMainThread(this); }
     Structure* CommonJSModuleObjectStructure() const { return m_commonJSModuleObjectStructure.getInitializedOnMainThread(this); }
@@ -618,7 +617,6 @@ public:
     V(private, LazyPropertyOfGlobalObject<JSObject>, m_lazyTestModuleObject)                                 \
     V(public, LazyPropertyOfGlobalObject<JSObject>, m_testMatcherUtilsObject)                                \
     V(public, LazyPropertyOfGlobalObject<Structure>, m_cachedNodeVMGlobalObjectStructure)                    \
-    V(public, LazyPropertyOfGlobalObject<Structure>, m_cachedNodeVMSpecialSandboxStructure)                  \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_cachedGlobalProxyStructure)                          \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_commonJSModuleObjectStructure)                       \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSSocketAddressDTOStructure)                         \

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { compileFunction, createContext, runInContext, runInNewContext, runInThisContext, Script } from "node:vm";
+import {
+  compileFunction,
+  constants,
+  createContext,
+  runInContext,
+  runInNewContext,
+  runInThisContext,
+  Script,
+} from "node:vm";
 
 function capture(_: any, _1?: any) {}
 
@@ -853,6 +861,56 @@ describe("codeGeneration options", () => {
     // Test that eval works by default
     const evalResult = runInContext("eval('5 + 5');", context);
     expect(evalResult).toBe(10);
+  });
+});
+
+describe("DONT_CONTEXTIFY", () => {
+  test("globalThis prototype chain stays inside the sandbox realm", () => {
+    const ctx = createContext(constants.DONT_CONTEXTIFY);
+    const sandboxObjectPrototype = runInContext("Object.prototype", ctx);
+
+    expect(sandboxObjectPrototype).not.toBe(Object.prototype);
+    expect(Object.getPrototypeOf(ctx)).not.toBe(Object.prototype);
+    expect(Object.getPrototypeOf(ctx)).toBe(sandboxObjectPrototype);
+
+    // globalThis.constructor.constructor must resolve to the sandbox's Function,
+    // so code it creates runs in the sandbox realm where host globals are absent.
+    expect(runInContext(`globalThis.constructor.constructor("return typeof Bun")()`, ctx)).toBe("undefined");
+    expect(runInContext(`globalThis.constructor.constructor("return typeof process")()`, ctx)).toBe("undefined");
+    expect(runInContext(`globalThis.constructor.constructor`, ctx)).toBe(runInContext(`Function`, ctx));
+    expect(runInContext(`globalThis.constructor.constructor`, ctx)).not.toBe(Function);
+
+    // Script#runInNewContext takes the same code path.
+    expect(
+      new Script(`globalThis.constructor.constructor("return typeof Bun")()`).runInNewContext(
+        constants.DONT_CONTEXTIFY,
+      ),
+    ).toBe("undefined");
+  });
+
+  test("writing to Object.getPrototypeOf(globalThis) does not leak to the host realm", () => {
+    const ctx = createContext(constants.DONT_CONTEXTIFY);
+    try {
+      runInContext(`Object.getPrototypeOf(globalThis).__vmDontContextifyLeakCheck = true`, ctx);
+      expect(({} as any).__vmDontContextifyLeakCheck).toBeUndefined();
+      expect((Object.prototype as any).__vmDontContextifyLeakCheck).toBeUndefined();
+      // The write should land on the sandbox's own Object.prototype.
+      expect(runInContext(`({}).__vmDontContextifyLeakCheck`, ctx)).toBe(true);
+    } finally {
+      delete (Object.prototype as any).__vmDontContextifyLeakCheck;
+    }
+  });
+
+  test("basic usage still works", () => {
+    const ctx = createContext(constants.DONT_CONTEXTIFY);
+    expect(runInContext("globalThis", ctx)).toBe(ctx);
+    expect(typeof ctx.Array).toBe("function");
+
+    runInContext("globalThis.fromInside = 123", ctx);
+    expect(ctx.fromInside).toBe(123);
+
+    ctx.fromOutside = 456;
+    expect(runInContext("fromOutside", ctx)).toBe(456);
   });
 });
 

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -871,7 +871,15 @@ describe("DONT_CONTEXTIFY", () => {
 
     expect(sandboxObjectPrototype).not.toBe(Object.prototype);
     expect(Object.getPrototypeOf(ctx)).not.toBe(Object.prototype);
-    expect(Object.getPrototypeOf(ctx)).toBe(sandboxObjectPrototype);
+
+    // The full prototype chain of the sandbox's globalThis must stay inside the
+    // sandbox realm and terminate at the sandbox's own Object.prototype.
+    const chain: object[] = [];
+    for (let proto = Object.getPrototypeOf(ctx); proto !== null; proto = Object.getPrototypeOf(proto)) {
+      chain.push(proto);
+    }
+    expect(chain).not.toContain(Object.prototype);
+    expect(chain.at(-1)).toBe(sandboxObjectPrototype);
 
     // globalThis.constructor.constructor must resolve to the sandbox's Function,
     // so code it creates runs in the sandbox realm where host globals are absent.
@@ -894,8 +902,9 @@ describe("DONT_CONTEXTIFY", () => {
       runInContext(`Object.getPrototypeOf(globalThis).__vmDontContextifyLeakCheck = true`, ctx);
       expect(({} as any).__vmDontContextifyLeakCheck).toBeUndefined();
       expect((Object.prototype as any).__vmDontContextifyLeakCheck).toBeUndefined();
-      // The write should land on the sandbox's own Object.prototype.
-      expect(runInContext(`({}).__vmDontContextifyLeakCheck`, ctx)).toBe(true);
+      // The write lands somewhere inside the sandbox realm, so the sandbox's
+      // globalThis still sees it through its own prototype chain.
+      expect(runInContext(`globalThis.__vmDontContextifyLeakCheck`, ctx)).toBe(true);
     } finally {
       delete (Object.prototype as any).__vmDontContextifyLeakCheck;
     }


### PR DESCRIPTION
### What does this PR do?

A `vm.createContext(vm.constants.DONT_CONTEXTIFY)` sandbox was built from a JSC structure cached on the host global whose prototype was the **host** realm's `Object.prototype`. Because that structure was shared across every sandbox, a sandbox's `globalThis` prototype chain reached into the host realm: `globalThis.constructor.constructor(...)` resolved to the host `Function`, and writes to `Object.getPrototypeOf(globalThis)` landed on the host `Object.prototype`.

Build the `NodeVMSpecialSandbox` structure per-sandbox with the sandbox context's own `objectPrototype()`, and drop the host-level cache (it was 1:1 with a sandbox, so caching it on the host was the wrong shape). Both consumers (`vmModule_createContext`, `scriptRunInNewContext`) now construct it from the target context.

After this, a DONT_CONTEXTIFY sandbox's prototype chain terminates in its own realm — `globalThis.constructor.constructor` is the sandbox's `Function`, and prototype writes stay inside the sandbox. Normal usage (running code, reading/writing globals across the boundary) is unchanged.

### How did you verify your code works?

- New `DONT_CONTEXTIFY` tests in `test/js/node/vm/vm.test.ts` fail on bun 1.4.0 — `Object.getPrototypeOf(ctx)` is the host `Object.prototype` and `globalThis.constructor.constructor("return typeof Bun")()` returns `"object"` — and pass with this branch (`typeof Bun`/`typeof process` → `"undefined"`, chain terminates at the sandbox's own `Object.prototype`).
- Every assertion in the new tests was cross-checked against Node v24.3.0, so they only pin behavior Node also exhibits.
- `test/js/node/vm/vm.test.ts`: 201 pass, 0 fail with a debug build of this branch.
- All 74 `test/js/node/test/parallel/test-vm-*.js` tests pass, including `test-vm-context-dont-contextify.js`.
