### PR TITLE
FileSystemRouter: keep the percent-decoded path buffer alive for the matched route

### DIFF
--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -1,7 +1,7 @@
 import { FileSystemRouter } from "bun";
 import { expect, it } from "bun:test";
 import fs, { mkdirSync, rmSync } from "fs";
-import { bunEnv, bunExe, isASAN, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
 import path, { dirname } from "path";
 
 function createTree(basedir: string, paths: string[]) {
@@ -522,8 +522,9 @@ it("MatchedRoute.params does not leak", async () => {
     const growthMB = (process.memoryUsage.rss() - before) / 1024 / 1024;
     console.error("RSS growth: " + growthMB.toFixed(2) + "MB");
     // ASAN's quarantine retains freed allocations (default 256 MB) so RSS
-    // deltas run far higher under bun-asan; widen the threshold there.
-    if (growthMB > ${isASAN ? 400 : 20}) throw new Error("leaked " + growthMB.toFixed(2) + "MB");
+    // deltas run far higher under ASAN. Debug builds enable ASAN by default,
+    // so treat them the same; the non-ASAN bound guards the actual leak.
+    if (growthMB > ${isASAN || isDebug ? 400 : 20}) throw new Error("leaked " + growthMB.toFixed(2) + "MB");
   `;
 
   await using proc = Bun.spawn({


### PR DESCRIPTION
`Bun.FileSystemRouter.prototype.match(url)` percent-decodes the path into a buffer owned by a stack-local `URLPath`, then borrows slices of it for the returned route's `.pathname`/`.query`/`.params`. That `URLPath` was dropped when `match()` returned, freeing the buffer while the `MatchedRoute` still pointed into it — so reading `.query`/`.pathname`/`.params` on any URL containing a `%` read freed memory. Plain URLs were unaffected.

Move the decoded buffer into `MatchedRoute` (a new `Option<Box<[u8]>>` field), freed once on finalize. Moving the `Box` doesn't move the heap bytes, so the already-captured slices stay valid.

The original Zig kept this buffer in a threadlocal; the Rust port switched to a per-`URLPath` heap buffer — sounder, but the owner has to travel with the slices. This also closes the threadlocal's latent stale-data window.

Adds percent-encoded query + dynamic-param regression tests.


---

Verification: on a pre-fix ASAN debug build, the new percent-encoding tests abort with `heap-use-after-free` (the freed decode buffer is read via `Scanner::init`); with the fix, the full `filesystem_router.test.ts` suite passes under the ASAN debug build.

Also included: the pre-existing `MatchedRoute.params does not leak` RSS bound now applies its wide ASAN threshold to debug builds too (debug builds enable ASAN by default, and its quarantine inflates RSS), and the new tests use `tempDir` from the test harness.
