### PR TITLE
jest: don't null-deref when creating the lazy test module object fails

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1992,7 +1992,12 @@ void GlobalObject::finishCreation(VM& vm)
             JSC::JSGlobalObject* globalObject = init.owner;
 
             JSValue result = JSValue::decode(Bun__Jest__createTestModuleObject(globalObject));
-            init.set(result.toObject(globalObject));
+            if (result.isEmpty() || !result.isObject()) [[unlikely]] {
+                // Creating the test module failed and an exception is pending.
+                init.set(JSC::constructEmptyObject(globalObject));
+                return;
+            }
+            init.set(JSC::asObject(result));
         });
 
     m_testMatcherUtilsObject.initLater(

--- a/test/js/bun/test/jest-module-outside-test-runner-crash.test.ts
+++ b/test/js/bun/test/jest-module-outside-test-runner-crash.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Reduced from a Fuzzilli-generated sample: create the lazy `Bun.jest()` test
+// module and an `expect()` value outside of the test runner, poke at matchers
+// with bogus receivers, then force a full GC. None of this should crash.
+test("Bun.jest() and expect() outside of the test runner do not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const received = Bun.jest().expect();
+      const hasAssertions = received?.hasAssertions;
+      try { new hasAssertions(); } catch {}
+      const toEndWith = received.toEndWith;
+      try { toEndWith.call(toEndWith); } catch {}
+      Bun.gc(true);
+      console.log("ok");
+    `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/test/jest-module-outside-test-runner-crash.test.ts
+++ b/test/js/bun/test/jest-module-outside-test-runner-crash.test.ts
@@ -29,3 +29,32 @@ test("Bun.jest() and expect() outside of the test runner do not crash", async ()
   expect(stdout.trim()).toBe("ok");
   expect(exitCode).toBe(0);
 });
+
+// The lazy test module initializer must tolerate `Bun__Jest__createTestModuleObject`
+// failing (it returns an empty JSValue with a pending exception). Calling
+// `Bun.jest()` at maximum call depth is the historical way to make that happen.
+test("Bun.jest() does not crash when called under stack pressure", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      function F0() {
+        const v = this.constructor;
+        try { new v(); } catch {}
+        try { Bun.jest(); } catch {}
+      }
+      try { new F0(); } catch {}
+      console.log("ok:" + (typeof Bun.jest() === "object"));
+    `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("ok:true");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### What does this PR do?

Hardens the lazy `Bun.jest()` test-module initialization against a null `JSCell` dereference.

`Bun__Jest__createTestModuleObject` returns an **empty JSValue** (encoded `0`) when creating the test module fails with a pending exception. The `m_lazyTestModuleObject.initLater` callback in `ZigGlobalObject.cpp` passed that result straight to `JSValue::toObject()`. An empty JSValue passes `isCell()`, so `toObject()` ends up calling through a null `JSCell*` — a plain SIGSEGV with no diagnostics. Every failure path in `create_test_module` (Rust) / `createTestModule` (Zig spec) funnels into this: the creator maps any error to `.zero`, and the consumer never checked for it.

With this change the initializer checks the result; on failure it falls back to an empty object (keeping the `LazyProperty` contract) and lets the pending exception propagate to whichever caller triggered the initialization (`Bun.jest()` or a `bun:test` import), instead of crashing the process.

### Background

Fuzzilli flagged a flaky SIGSEGV (fingerprint `102347d77ec4776e`, no backtrace captured) on a sample whose only Bun-specific work is:

```js
const v26 = Bun.jest().expect();
const v27 = v26?.hasAssertions;
try { new v27(); } catch (e) {}
const v29 = v26.toEndWith;
try { v29.call(v29); } catch (e) {}
Bun.gc(true);
```

The exact crash did not reproduce locally after several thousand executions of the sample (fresh processes, REPRL-style repeated eval in one process, `BUN_JSC_collectContinuously=1`, CPU contention, and a 50k-iteration stress loop of the same API sequence). Auditing every native path the sample exercises turned up one guaranteed-SEGV defect — the unguarded `toObject()` above, sitting directly under the sample's `Bun.jest()` call — which this PR fixes. The happy path is unchanged.

### How did you verify your code works?

- Added `test/js/bun/test/jest-module-outside-test-runner-crash.test.ts`, which runs the reduced fuzzer sample (`Bun.jest().expect()` outside the test runner, matcher calls with bogus receivers, `Bun.gc(true)`) in a subprocess and asserts a clean exit.
- `bun bd test test/js/bun/test/jest-module-outside-test-runner-crash.test.ts`
- `bun bd test test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts test/js/bun/test/expect-stack-overflow-crash.test.ts test/js/bun/test/bun-test.test.ts test/js/bun/test/jest-hooks.test.ts test/js/bun/test/expect-extend.test.js test/js/bun/test/expect-label.test.ts` — all pass with the debug (ASAN) build.
