### PR TITLE
csrf: add sessionId option to bind tokens to a principal

### DIFF
--- a/docs/runtime/csrf.mdx
+++ b/docs/runtime/csrf.mdx
@@ -145,11 +145,7 @@ const server = Bun.serve({
         const formData = await req.formData();
         const csrfToken = formData.get("_csrf");
 
-        if (
-          !sessionId ||
-          typeof csrfToken !== "string" ||
-          !Bun.CSRF.verify(csrfToken, { secret: SECRET, sessionId })
-        ) {
+        if (!sessionId || typeof csrfToken !== "string" || !Bun.CSRF.verify(csrfToken, { secret: SECRET, sessionId })) {
           return new Response("Invalid CSRF token", { status: 403 });
         }
 

--- a/docs/runtime/csrf.mdx
+++ b/docs/runtime/csrf.mdx
@@ -108,15 +108,26 @@ A typical pattern is to generate a token when rendering a form, embed it in a hi
 ```ts title="server.ts" icon="/icons/typescript.svg"
 const SECRET = process.env.CSRF_SECRET || "my-secret";
 
-// Resolve the requester's session identifier (e.g. from a session cookie).
-function getSessionId(req: Request): string {
-  return req.headers.get("cookie")?.match(/session=([^;]+)/)?.[1] ?? "anonymous";
+// Resolve the requester's session identifier from a session cookie. Returns
+// null when the visitor has no session yet — never fall back to a shared
+// placeholder, or every session-less visitor would share one token binding.
+function getSessionId(req: Request): string | null {
+  return req.headers.get("cookie")?.match(/session=([^;]+)/)?.[1] ?? null;
 }
 
 const server = Bun.serve({
   routes: {
     "/form": req => {
-      const token = Bun.CSRF.generate(SECRET, { sessionId: getSessionId(req) });
+      // Create a per-visitor session before issuing the form so the token is
+      // bound to this visitor and no one else.
+      let sessionId = getSessionId(req);
+      const headers = new Headers({ "Content-Type": "text/html" });
+      if (!sessionId) {
+        sessionId = crypto.randomUUID();
+        headers.append("Set-Cookie", `session=${sessionId}; HttpOnly; SameSite=Lax; Path=/`);
+      }
+
+      const token = Bun.CSRF.generate(SECRET, { sessionId });
 
       return new Response(
         `<form method="POST" action="/submit">
@@ -124,18 +135,20 @@ const server = Bun.serve({
           <input type="text" name="message" />
           <button type="submit">Send</button>
         </form>`,
-        { headers: { "Content-Type": "text/html" } },
+        { headers },
       );
     },
 
     "/submit": {
       POST: async req => {
+        const sessionId = getSessionId(req);
         const formData = await req.formData();
         const csrfToken = formData.get("_csrf");
 
         if (
+          !sessionId ||
           typeof csrfToken !== "string" ||
-          !Bun.CSRF.verify(csrfToken, { secret: SECRET, sessionId: getSessionId(req) })
+          !Bun.CSRF.verify(csrfToken, { secret: SECRET, sessionId })
         ) {
           return new Response("Invalid CSRF token", { status: 403 });
         }

--- a/docs/runtime/csrf.mdx
+++ b/docs/runtime/csrf.mdx
@@ -6,13 +6,20 @@ description: Generate and verify CSRF tokens with Bun's built-in API
 Bun provides a built-in API for generating and verifying [CSRF (Cross-Site Request Forgery)](https://owasp.org/www-community/attacks/csrf) tokens through `Bun.CSRF`. Tokens are signed with HMAC and include expiration timestamps to limit the token validity window.
 
 ```ts title="csrf.ts" icon="/icons/typescript.svg"
-// Generate a token
-const token = Bun.CSRF.generate("my-secret");
+// Generate a token bound to the requester's session
+const token = Bun.CSRF.generate("my-secret", { sessionId: "user-session-id" });
 
 // Verify it
-const isValid = Bun.CSRF.verify(token, { secret: "my-secret" });
+const isValid = Bun.CSRF.verify(token, { secret: "my-secret", sessionId: "user-session-id" });
 console.log(isValid); // true
 ```
+
+<Callout type="warning">
+  Always pass a `sessionId` (the requester's session identifier or user ID) to both `generate()` and `verify()`. Without
+  it, a token is only bound to the secret — any token the server has ever issued validates for every user, so an
+  attacker can obtain a token in their own session and replay it in a forged cross-site request from a victim's
+  browser.
+</Callout>
 
 ---
 
@@ -29,23 +36,26 @@ const token = Bun.CSRF.generate("my-secret-key");
 - `secret` (string, optional) — The secret key used to sign the token. If not provided, Bun generates a random in-memory default secret (unique per thread).
 - `options` (object, optional):
 
-| Option      | Type     | Default       | Description                                                                                            |
-| ----------- | -------- | ------------- | ------------------------------------------------------------------------------------------------------ |
-| `expiresIn` | `number` | `86400000`    | Milliseconds until the token expires. Defaults to 24 hours.                                            |
-| `encoding`  | `string` | `"base64url"` | Token encoding format: `"base64"`, `"base64url"`, or `"hex"`.                                          |
-| `algorithm` | `string` | `"sha256"`    | HMAC algorithm: `"sha256"`, `"sha384"`, `"sha512"`, `"sha512-256"`, `"blake2b256"`, or `"blake2b512"`. |
+| Option      | Type     | Default       | Description                                                                                                                                              |
+| ----------- | -------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `expiresIn` | `number` | `86400000`    | Milliseconds until the token expires. Defaults to 24 hours.                                                                                              |
+| `encoding`  | `string` | `"base64url"` | Token encoding format: `"base64"`, `"base64url"`, or `"hex"`.                                                                                            |
+| `algorithm` | `string` | `"sha256"`    | HMAC algorithm: `"sha256"`, `"sha384"`, `"sha512"`, `"sha512-256"`, `"blake2b256"`, or `"blake2b512"`.                                                   |
+| `sessionId` | `string` | (none)        | Binds the token to the requesting principal (session ID, user ID, or equivalent). The token will only verify when the same `sessionId` is passed to `verify()`. |
 
 **Returns:** `string` — the encoded token.
 
 ```ts title="generate-options.ts" icon="/icons/typescript.svg"
-// Token that expires in 1 hour, encoded as hex
+// Token bound to the requester's session that expires in 1 hour, encoded as hex
 const token = Bun.CSRF.generate("my-secret", {
+  sessionId: "user-session-id",
   expiresIn: 60 * 60 * 1000,
   encoding: "hex",
 });
 
 // Using a different algorithm
 const token2 = Bun.CSRF.generate("my-secret", {
+  sessionId: "user-session-id",
   algorithm: "sha512",
 });
 ```
@@ -65,25 +75,27 @@ const isValid = Bun.CSRF.verify(token, { secret: "my-secret-key" });
 - `token` (string, required) — The token to verify.
 - `options` (object, optional):
 
-| Option      | Type     | Default       | Description                                                                                          |
-| ----------- | -------- | ------------- | ---------------------------------------------------------------------------------------------------- |
-| `secret`    | `string` | (auto)        | The secret used to sign the token. If not provided, uses the same in-memory default as `generate()`. |
-| `maxAge`    | `number` | `86400000`    | Maximum token age in milliseconds, independent of the token's own `expiresIn`.                       |
-| `encoding`  | `string` | `"base64url"` | Must match the encoding used during `generate()`.                                                    |
-| `algorithm` | `string` | `"sha256"`    | Must match the algorithm used during `generate()`.                                                   |
+| Option      | Type     | Default       | Description                                                                                                                              |
+| ----------- | -------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `secret`    | `string` | (auto)        | The secret used to sign the token. If not provided, uses the same in-memory default as `generate()`.                                     |
+| `maxAge`    | `number` | `86400000`    | Maximum token age in milliseconds, independent of the token's own `expiresIn`.                                                           |
+| `encoding`  | `string` | `"base64url"` | Must match the encoding used during `generate()`.                                                                                        |
+| `algorithm` | `string` | `"sha256"`    | Must match the algorithm used during `generate()`.                                                                                       |
+| `sessionId` | `string` | (none)        | Must match the `sessionId` used during `generate()`. A token bound to one principal fails verification for any other principal, and a token generated without a `sessionId` fails verification when one is supplied. |
 
 **Returns:** `boolean`
 
 ```ts title="verify-options.ts" icon="/icons/typescript.svg"
-// Verify a hex-encoded token
-const isValid = Bun.CSRF.verify(hexToken, {
+// Verify a token bound to the requester's session
+const isValid = Bun.CSRF.verify(token, {
   secret: "my-secret",
-  encoding: "hex",
+  sessionId: "user-session-id",
 });
 
 // Enforce a shorter max age than what the token was generated with
 const isValid2 = Bun.CSRF.verify(token, {
   secret: "my-secret",
+  sessionId: "user-session-id",
   maxAge: 60 * 1000, // reject tokens older than 1 minute
 });
 ```
@@ -92,15 +104,20 @@ const isValid2 = Bun.CSRF.verify(token, {
 
 ## Using with `Bun.serve()`
 
-A typical pattern is to generate a token when rendering a form, embed it in a hidden field, and verify it when the form is submitted.
+A typical pattern is to generate a token when rendering a form, embed it in a hidden field, and verify it when the form is submitted. Pass the requester's session identifier as `sessionId` to both calls so the token only works for the user it was issued to.
 
 ```ts title="server.ts" icon="/icons/typescript.svg"
 const SECRET = process.env.CSRF_SECRET || "my-secret";
 
+// Resolve the requester's session identifier (e.g. from a session cookie).
+function getSessionId(req: Request): string {
+  return req.headers.get("cookie")?.match(/session=([^;]+)/)?.[1] ?? "anonymous";
+}
+
 const server = Bun.serve({
   routes: {
-    "/form": () => {
-      const token = Bun.CSRF.generate(SECRET);
+    "/form": req => {
+      const token = Bun.CSRF.generate(SECRET, { sessionId: getSessionId(req) });
 
       return new Response(
         `<form method="POST" action="/submit">
@@ -117,7 +134,10 @@ const server = Bun.serve({
         const formData = await req.formData();
         const csrfToken = formData.get("_csrf");
 
-        if (typeof csrfToken !== "string" || !Bun.CSRF.verify(csrfToken, { secret: SECRET })) {
+        if (
+          typeof csrfToken !== "string" ||
+          !Bun.CSRF.verify(csrfToken, { secret: SECRET, sessionId: getSessionId(req) })
+        ) {
           return new Response("Invalid CSRF token", { status: 403 });
         }
 
@@ -155,6 +175,7 @@ interface CSRFGenerateOptions {
   expiresIn?: number;
   encoding?: "base64" | "base64url" | "hex";
   algorithm?: CSRFAlgorithm;
+  sessionId?: string;
 }
 
 interface CSRFVerifyOptions {
@@ -162,6 +183,7 @@ interface CSRFVerifyOptions {
   encoding?: "base64" | "base64url" | "hex";
   algorithm?: CSRFAlgorithm;
   maxAge?: number;
+  sessionId?: string;
 }
 
 namespace Bun.CSRF {

--- a/docs/runtime/csrf.mdx
+++ b/docs/runtime/csrf.mdx
@@ -112,7 +112,7 @@ const SECRET = process.env.CSRF_SECRET || "my-secret";
 // null when the visitor has no session yet — never fall back to a shared
 // placeholder, or every session-less visitor would share one token binding.
 function getSessionId(req: Request): string | null {
-  return req.headers.get("cookie")?.match(/session=([^;]+)/)?.[1] ?? null;
+  return req.headers.get("cookie")?.match(/(?:^|;\s*)session=([^;]+)/)?.[1] ?? null;
 }
 
 const server = Bun.serve({

--- a/docs/runtime/csrf.mdx
+++ b/docs/runtime/csrf.mdx
@@ -17,8 +17,7 @@ console.log(isValid); // true
 <Callout type="warning">
   Always pass a `sessionId` (the requester's session identifier or user ID) to both `generate()` and `verify()`. Without
   it, a token is only bound to the secret — any token the server has ever issued validates for every user, so an
-  attacker can obtain a token in their own session and replay it in a forged cross-site request from a victim's
-  browser.
+  attacker can obtain a token in their own session and replay it in a forged cross-site request from a victim's browser.
 </Callout>
 
 ---
@@ -36,11 +35,11 @@ const token = Bun.CSRF.generate("my-secret-key");
 - `secret` (string, optional) — The secret key used to sign the token. If not provided, Bun generates a random in-memory default secret (unique per thread).
 - `options` (object, optional):
 
-| Option      | Type     | Default       | Description                                                                                                                                              |
-| ----------- | -------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `expiresIn` | `number` | `86400000`    | Milliseconds until the token expires. Defaults to 24 hours.                                                                                              |
-| `encoding`  | `string` | `"base64url"` | Token encoding format: `"base64"`, `"base64url"`, or `"hex"`.                                                                                            |
-| `algorithm` | `string` | `"sha256"`    | HMAC algorithm: `"sha256"`, `"sha384"`, `"sha512"`, `"sha512-256"`, `"blake2b256"`, or `"blake2b512"`.                                                   |
+| Option      | Type     | Default       | Description                                                                                                                                                     |
+| ----------- | -------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `expiresIn` | `number` | `86400000`    | Milliseconds until the token expires. Defaults to 24 hours.                                                                                                     |
+| `encoding`  | `string` | `"base64url"` | Token encoding format: `"base64"`, `"base64url"`, or `"hex"`.                                                                                                   |
+| `algorithm` | `string` | `"sha256"`    | HMAC algorithm: `"sha256"`, `"sha384"`, `"sha512"`, `"sha512-256"`, `"blake2b256"`, or `"blake2b512"`.                                                          |
 | `sessionId` | `string` | (none)        | Binds the token to the requesting principal (session ID, user ID, or equivalent). The token will only verify when the same `sessionId` is passed to `verify()`. |
 
 **Returns:** `string` — the encoded token.
@@ -75,12 +74,12 @@ const isValid = Bun.CSRF.verify(token, { secret: "my-secret-key" });
 - `token` (string, required) — The token to verify.
 - `options` (object, optional):
 
-| Option      | Type     | Default       | Description                                                                                                                              |
-| ----------- | -------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `secret`    | `string` | (auto)        | The secret used to sign the token. If not provided, uses the same in-memory default as `generate()`.                                     |
-| `maxAge`    | `number` | `86400000`    | Maximum token age in milliseconds, independent of the token's own `expiresIn`.                                                           |
-| `encoding`  | `string` | `"base64url"` | Must match the encoding used during `generate()`.                                                                                        |
-| `algorithm` | `string` | `"sha256"`    | Must match the algorithm used during `generate()`.                                                                                       |
+| Option      | Type     | Default       | Description                                                                                                                                                                                                          |
+| ----------- | -------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `secret`    | `string` | (auto)        | The secret used to sign the token. If not provided, uses the same in-memory default as `generate()`.                                                                                                                 |
+| `maxAge`    | `number` | `86400000`    | Maximum token age in milliseconds, independent of the token's own `expiresIn`.                                                                                                                                       |
+| `encoding`  | `string` | `"base64url"` | Must match the encoding used during `generate()`.                                                                                                                                                                    |
+| `algorithm` | `string` | `"sha256"`    | Must match the algorithm used during `generate()`.                                                                                                                                                                   |
 | `sessionId` | `string` | (none)        | Must match the `sessionId` used during `generate()`. A token bound to one principal fails verification for any other principal, and a token generated without a `sessionId` fails verification when one is supplied. |
 
 **Returns:** `boolean`

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2239,6 +2239,14 @@ declare module "bun" {
      * @default "sha256"
      */
     algorithm?: CSRFAlgorithm;
+
+    /**
+     * Binds the token to the requesting principal (session ID, user ID, or
+     * equivalent). A token generated with a `sessionId` only verifies when the
+     * same `sessionId` is supplied to `verify()`. Without it, any token issued
+     * under the same secret validates for every user.
+     */
+    sessionId?: string;
   }
 
   interface CSRFVerifyOptions {
@@ -2264,6 +2272,14 @@ declare module "bun" {
      * @default 24 * 60 * 60 * 1000 (24 hours)
      */
     maxAge?: number;
+
+    /**
+     * The principal (session ID, user ID, or equivalent) the token must be
+     * bound to. A token generated with a `sessionId` only verifies when the
+     * same `sessionId` is supplied here; a token generated without one only
+     * verifies when this option is omitted.
+     */
+    sessionId?: string;
   }
 
   /**

--- a/src/csrf/lib.rs
+++ b/src/csrf/lib.rs
@@ -35,6 +35,9 @@ bun_core::named_error_set!(Error);
 pub struct GenerateOptions<'a> {
     /// Secret key to use for signing
     pub secret: &'a [u8],
+    /// Per-principal associated data mixed into the HMAC; an empty slice
+    /// means the token is not bound to any principal
+    pub session_id: &'a [u8],
     /// How long the token should be valid (in milliseconds)
     pub expires_in_ms: u64, // = DEFAULT_EXPIRATION_MS
     /// Format to encode the token in
@@ -50,6 +53,9 @@ pub struct VerifyOptions<'a> {
     pub token: &'a [u8],
     /// Secret key used to sign the token
     pub secret: &'a [u8],
+    /// Per-principal associated data mixed into the HMAC; an empty slice
+    /// means the token is not bound to any principal
+    pub session_id: &'a [u8],
     /// Maximum age of the token in milliseconds
     pub max_age_ms: u64, // = DEFAULT_EXPIRATION_MS
     /// Encoding to use for the token
@@ -106,14 +112,25 @@ pub fn generate<'a>(
     payload_buf[8..24].copy_from_slice(&nonce);
     payload_buf[24..32].copy_from_slice(&expires_in_bytes);
 
-    // Sign the payload
+    // Sign the payload. When a session id is provided, it is mixed into the
+    // HMAC input as associated data (`payload || session_id`) but never
+    // written to the token, so the token only verifies for that principal.
+    // The fixed 32-byte payload prefix keeps the concatenation unambiguous.
     let mut digest_buf = [0u8; boring::EVP_MAX_MD_SIZE as usize];
-    let digest = match hmac::generate(
-        options.secret,
-        &payload_buf,
-        options.algorithm,
-        &mut digest_buf,
-    ) {
+    let digest = if options.session_id.is_empty() {
+        hmac::generate(
+            options.secret,
+            &payload_buf,
+            options.algorithm,
+            &mut digest_buf,
+        )
+    } else {
+        let mut msg = Vec::with_capacity(payload_buf.len() + options.session_id.len());
+        msg.extend_from_slice(&payload_buf);
+        msg.extend_from_slice(options.session_id);
+        hmac::generate(options.secret, &msg, options.algorithm, &mut digest_buf)
+    };
+    let digest = match digest {
         Some(d) => d,
         None => return Err(Error::TokenCreationFailed),
     };
@@ -232,14 +249,24 @@ pub fn verify(options: &VerifyOptions<'_>) -> bool {
     let payload = &decoded[0..32]; // timestamp + nonce + expires_in
     let received_signature = &decoded[32..];
 
-    // Verify the signature
+    // Verify the signature. The session id (if any) is appended to the
+    // payload exactly as in `generate`, so a token bound to one principal
+    // fails verification for any other principal or for no principal.
     let mut expected_signature = [0u8; boring::EVP_MAX_MD_SIZE as usize];
-    let signature = match hmac::generate(
-        options.secret,
-        payload,
-        options.algorithm,
-        &mut expected_signature,
-    ) {
+    let signature = if options.session_id.is_empty() {
+        hmac::generate(
+            options.secret,
+            payload,
+            options.algorithm,
+            &mut expected_signature,
+        )
+    } else {
+        let mut msg = Vec::with_capacity(payload.len() + options.session_id.len());
+        msg.extend_from_slice(payload);
+        msg.extend_from_slice(options.session_id);
+        hmac::generate(options.secret, &msg, options.algorithm, &mut expected_signature)
+    };
+    let signature = match signature {
         Some(s) => s,
         None => return false,
     };

--- a/src/csrf/lib.rs
+++ b/src/csrf/lib.rs
@@ -264,7 +264,12 @@ pub fn verify(options: &VerifyOptions<'_>) -> bool {
         let mut msg = Vec::with_capacity(payload.len() + options.session_id.len());
         msg.extend_from_slice(payload);
         msg.extend_from_slice(options.session_id);
-        hmac::generate(options.secret, &msg, options.algorithm, &mut expected_signature)
+        hmac::generate(
+            options.secret,
+            &msg,
+            options.algorithm,
+            &mut expected_signature,
+        )
     };
     let signature = match signature {
         Some(s) => s,

--- a/src/csrf/lib.rs
+++ b/src/csrf/lib.rs
@@ -112,10 +112,9 @@ pub fn generate<'a>(
     payload_buf[8..24].copy_from_slice(&nonce);
     payload_buf[24..32].copy_from_slice(&expires_in_bytes);
 
-    // Sign the payload. When a session id is provided, it is mixed into the
-    // HMAC input as associated data (`payload || session_id`) but never
-    // written to the token, so the token only verifies for that principal.
-    // The fixed 32-byte payload prefix keeps the concatenation unambiguous.
+    // Sign the payload. A session id is mixed into the HMAC input as
+    // `payload || session_id` but never written to the token; the fixed
+    // 32-byte payload prefix keeps the concatenation unambiguous.
     let mut digest_buf = [0u8; boring::EVP_MAX_MD_SIZE as usize];
     let digest = if options.session_id.is_empty() {
         hmac::generate(
@@ -249,9 +248,7 @@ pub fn verify(options: &VerifyOptions<'_>) -> bool {
     let payload = &decoded[0..32]; // timestamp + nonce + expires_in
     let received_signature = &decoded[32..];
 
-    // Verify the signature. The session id (if any) is appended to the
-    // payload exactly as in `generate`, so a token bound to one principal
-    // fails verification for any other principal or for no principal.
+    // Verify the signature
     let mut expected_signature = [0u8; boring::EVP_MAX_MD_SIZE as usize];
     let signature = if options.session_id.is_empty() {
         hmac::generate(

--- a/src/runtime/api/csrf_jsc.rs
+++ b/src/runtime/api/csrf_jsc.rs
@@ -100,6 +100,7 @@ pub fn csrf__generate(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JS
     let mut expires_in: u64 = csrf::DEFAULT_EXPIRATION_MS;
     let mut encoding: csrf::TokenFormat = csrf::TokenFormat::Base64Url;
     let mut algorithm: EvpAlgorithm = csrf::DEFAULT_ALGORITHM;
+    let mut session_id: Option<ZigStringSlice> = None;
 
     // Check if we have options object
     if args.len() > 1 && args[1].is_object() {
@@ -108,6 +109,16 @@ pub fn csrf__generate(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JS
         // Extract expiresIn (optional)
         if let Some(expires_in_js) = get_optional_int_u64(options_value, global, "expiresIn")? {
             expires_in = expires_in_js;
+        }
+
+        // Extract sessionId (optional)
+        if let Some(session_id_slice) = get_optional_slice(options_value, global, b"sessionId")? {
+            if session_id_slice.slice().is_empty() {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "sessionId must be a non-empty string"
+                )));
+            }
+            session_id = Some(session_id_slice);
         }
 
         // Extract encoding (optional)
@@ -174,6 +185,7 @@ pub fn csrf__generate(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JS
                 // on the JS thread so the VM singleton is exclusively reachable here.
                 None => global.bun_vm().as_mut().rare_data().default_csrf_secret(),
             },
+            session_id: session_id.as_ref().map(|s| s.slice()).unwrap_or(b""),
             expires_in_ms: expires_in,
             encoding,
             algorithm,
@@ -233,6 +245,7 @@ pub fn csrf__verify(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
     // `defer if (secret) |s| s.deinit();` — handled by Drop
     let mut max_age: u64 = csrf::DEFAULT_EXPIRATION_MS;
     let mut encoding: csrf::TokenFormat = csrf::TokenFormat::Base64Url;
+    let mut session_id: Option<ZigStringSlice> = None;
 
     let mut algorithm: EvpAlgorithm = csrf::DEFAULT_ALGORITHM;
 
@@ -247,6 +260,16 @@ pub fn csrf__verify(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
                     .throw_invalid_arguments(format_args!("Secret must be a non-empty string")));
             }
             secret = Some(secret_slice);
+        }
+
+        // Extract sessionId (optional)
+        if let Some(session_id_slice) = get_optional_slice(options_value, global, b"sessionId")? {
+            if session_id_slice.slice().is_empty() {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "sessionId must be a non-empty string"
+                )));
+            }
+            session_id = Some(session_id_slice);
         }
 
         // Extract maxAge (optional)
@@ -313,6 +336,7 @@ pub fn csrf__verify(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
             // on the JS thread so the VM singleton is exclusively reachable here.
             None => global.bun_vm().as_mut().rare_data().default_csrf_secret(),
         },
+        session_id: session_id.as_ref().map(|s| s.slice()).unwrap_or(b""),
         max_age_ms: max_age,
         encoding,
         algorithm,

--- a/test/js/bun/util/csrf.test.ts
+++ b/test/js/bun/util/csrf.test.ts
@@ -131,6 +131,35 @@ describe("Bun.CSRF", () => {
     expect(CSRF.verify(token)).toBe(true);
   });
 
+  test("token bound to a sessionId verifies for the same sessionId", () => {
+    const token = CSRF.generate(secret, { sessionId: "user-session-1" });
+    expect(CSRF.verify(token, { secret, sessionId: "user-session-1" })).toBe(true);
+  });
+
+  test("token bound to a sessionId does not verify for a different sessionId", () => {
+    const token = CSRF.generate(secret, { sessionId: "attacker-session" });
+    expect(CSRF.verify(token, { secret, sessionId: "victim-session" })).toBe(false);
+  });
+
+  test("sessionId binding is fail-closed in both directions", () => {
+    // A token bound to a session does not verify without one.
+    const boundToken = CSRF.generate(secret, { sessionId: "user-session-1" });
+    expect(CSRF.verify(boundToken, { secret })).toBe(false);
+
+    // A token generated without a session does not verify with one.
+    const unboundToken = CSRF.generate(secret);
+    expect(CSRF.verify(unboundToken, { secret, sessionId: "user-session-1" })).toBe(false);
+  });
+
+  test("sessionId composes with encoding and algorithm options", () => {
+    const sessionId = "user-session-1";
+    const token = CSRF.generate(secret, { sessionId, encoding: "hex", algorithm: "sha512" });
+    expect(CSRF.verify(token, { secret, sessionId, encoding: "hex", algorithm: "sha512" })).toBe(true);
+    expect(CSRF.verify(token, { secret, sessionId: "other-session", encoding: "hex", algorithm: "sha512" })).toBe(
+      false,
+    );
+  });
+
   test("error handling", () => {
     // Empty token
     expect(() => CSRF.verify("", { secret })).toThrow();
@@ -140,6 +169,19 @@ describe("Bun.CSRF", () => {
 
     // Empty secret for verification
     expect(() => CSRF.verify("some-token", { secret: "" })).toThrow();
+
+    // Empty sessionId for generation
+    expect(() => CSRF.generate(secret, { sessionId: "" })).toThrow();
+
+    // Empty sessionId for verification
+    const token = CSRF.generate(secret);
+    expect(() => CSRF.verify(token, { secret, sessionId: "" })).toThrow();
+
+    // Non-string sessionId
+    // @ts-expect-error - testing invalid input
+    expect(() => CSRF.generate(secret, { sessionId: 123 })).toThrow();
+    // @ts-expect-error - testing invalid input
+    expect(() => CSRF.verify(token, { secret, sessionId: 123 })).toThrow();
   });
 
   test("handle bad decoding", () => {


### PR DESCRIPTION
Adds an optional `sessionId` option to `Bun.CSRF.generate()` and `Bun.CSRF.verify()`. When provided, it is mixed into the HMAC input as associated data (it is never embedded in the token itself), so a token generated for one session only verifies when the same `sessionId` is supplied to `verify()` — and fails closed in both directions if the option is supplied on only one side. Tokens generated without a `sessionId` are byte-for-byte identical to before, so existing callers are unaffected.

Adds tests covering same-session round-trip, cross-session rejection, fail-closed behavior in both directions, composition with the `encoding`/`algorithm` options, and argument validation. Updates the TypeScript definitions and the CSRF docs to demonstrate session binding.