### PR TITLE
blob: only re-create file-backed Blobs from in-process structured clones

### DIFF
--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -434,7 +434,7 @@ JSC_DECLARE_CUSTOM_GETTER(js${typeName}Constructor);
       `extern JSC_CALLCONV JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES ${symbolName(
         typeName,
         "onStructuredCloneDeserialize",
-      )}(JSC::JSGlobalObject*, uint8_t**, const uint8_t*);` + "\n";
+      )}(JSC::JSGlobalObject*, uint8_t**, const uint8_t*, bool);` + "\n";
   }
   if (obj.finalize) {
     externs +=
@@ -2391,9 +2391,9 @@ const JavaScriptCoreBindings = struct {
       exports.set("structuredCloneDeserialize", symbolName(typeName, "onStructuredCloneDeserialize"));
 
       output += `
-      pub fn ${symbolName(typeName, "onStructuredCloneDeserialize")}(globalObject: *jsc.JSGlobalObject, ptr: *[*]u8, end: [*]u8) callconv(jsc.conv) jsc.JSValue {
+      pub fn ${symbolName(typeName, "onStructuredCloneDeserialize")}(globalObject: *jsc.JSGlobalObject, ptr: *[*]u8, end: [*]u8, from_wire_bytes: bool) callconv(jsc.conv) jsc.JSValue {
         if (comptime Environment.enable_logs) log_zig_structured_clone_deserialize("${typeName}");
-        return @call(bun.callmod_inline, jsc.toJSHostCall, .{ globalObject, @src(), ${typeName}.onStructuredCloneDeserialize, .{globalObject, ptr, end} });
+        return @call(bun.callmod_inline, jsc.toJSHostCall, .{ globalObject, @src(), ${typeName}.onStructuredCloneDeserialize, .{globalObject, ptr, end, from_wire_bytes} });
       }
       `;
     } else {
@@ -3057,8 +3057,8 @@ function generateRust(
     }
     thunk(
       symbolName(typeName, "onStructuredCloneDeserialize"),
-      `(global: &JSGlobalObject, ptr: *mut *mut u8, end: *const u8) -> JSValue`,
-      `    host_fn::host_fn_result(global, || ${T}::on_structured_clone_deserialize(global, ptr, end))`,
+      `(global: &JSGlobalObject, ptr: *mut *mut u8, end: *const u8, from_wire_bytes: bool) -> JSValue`,
+      `    host_fn::host_fn_result(global, || ${T}::on_structured_clone_deserialize(global, ptr, end, from_wire_bytes))`,
     );
   }
 
@@ -3484,7 +3484,7 @@ class StructuredCloneableSerialize {
 
 class StructuredCloneableDeserialize {
   public:
-    static std::optional<JSC::EncodedJSValue> fromTagDeserialize(uint8_t tag, JSC::JSGlobalObject*, const uint8_t*&, const uint8_t*);
+    static std::optional<JSC::EncodedJSValue> fromTagDeserialize(uint8_t tag, JSC::JSGlobalObject*, const uint8_t*&, const uint8_t*, bool fromWireBytes);
 };
 
 }
@@ -3512,7 +3512,7 @@ function writeCppSerializers() {
   function fromTagDeserializeForEachClass(klass) {
     return `
     if (tag == ${klass.structuredClone.tag}) {
-      return ${symbolName(klass.name, "onStructuredCloneDeserialize")}(globalObject, (uint8_t**)&ptr, end);
+      return ${symbolName(klass.name, "onStructuredCloneDeserialize")}(globalObject, (uint8_t**)&ptr, end, fromWireBytes);
     }
     `;
   }
@@ -3526,7 +3526,7 @@ function writeCppSerializers() {
   `;
 
   output += `
-  std::optional<JSC::EncodedJSValue> StructuredCloneableDeserialize::fromTagDeserialize(uint8_t tag, JSC::JSGlobalObject* globalObject, const uint8_t*& ptr, const uint8_t* end)
+  std::optional<JSC::EncodedJSValue> StructuredCloneableDeserialize::fromTagDeserialize(uint8_t tag, JSC::JSGlobalObject* globalObject, const uint8_t*& ptr, const uint8_t* end, bool fromWireBytes)
   {
     ${structuredClonable.map(fromTagDeserializeForEachClass).join("\n").trim()}
     return std::nullopt;

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -2957,7 +2957,8 @@ public:
         ,
         Vector<RefPtr<WebCodecsEncodedVideoChunkStorage>>&& serializedVideoChunks, Vector<WebCodecsVideoFrameData>&& serializedVideoFrames
 #endif
-    )
+        ,
+        bool fromWireBytes)
     {
         if (!buffer.size())
             return std::make_pair(jsNull(), SerializationReturnCode::UnspecifiedError);
@@ -2979,6 +2980,7 @@ public:
             WTF::move(serializedVideoChunks), WTF::move(serializedVideoFrames)
 #endif
         );
+        deserializer.m_fromWireBytes = fromWireBytes;
         if (!deserializer.isValid())
             return std::make_pair(JSValue(), SerializationReturnCode::ValidationError);
         return deserializer.deserialize();
@@ -4782,7 +4784,7 @@ private:
         //     return JSValue();
 
         // read bun types
-        if (auto value = StructuredCloneableDeserialize::fromTagDeserialize(tag, m_lexicalGlobalObject, m_ptr, m_end)) {
+        if (auto value = StructuredCloneableDeserialize::fromTagDeserialize(tag, m_lexicalGlobalObject, m_ptr, m_end, m_fromWireBytes)) {
             JSValue deserialized = JSValue::decode(value.value());
             if (deserialized.isEmpty()) {
                 fail();
@@ -5267,6 +5269,12 @@ private:
     JSGlobalObject* const m_globalObject;
     const bool m_isDOMGlobalObject;
     // const bool m_canCreateDOMObject;
+    // True when the serialized bytes came from outside this process's
+    // serializer (bun:jsc / node:v8 deserialize(), child-process IPC).
+    // Deserializers must not mint new capabilities (file-backed Blobs)
+    // from such bytes. Default-initialized to false so the
+    // deserializeString constructor path is unaffected.
+    bool m_fromWireBytes { false };
     const uint8_t* m_ptr;
     const uint8_t* const m_end;
     unsigned m_version;
@@ -6514,7 +6522,10 @@ JSC::JSValue SerializedScriptValue::fromArrayBuffer(JSC::JSGlobalObject& domGlob
         ,
         WTF::move(m_serializedVideoChunks), WTF::move(m_serializedVideoFrames)
 #endif
-    );
+        ,
+        // The caller hands us an arbitrary ArrayBuffer (bun:jsc / node:v8
+        // deserialize()); these bytes are always treated as external.
+        /* fromWireBytes */ true);
 
     if (arrayBuffer->isShared()) {
         arrayBuffer->unpin();
@@ -6771,7 +6782,11 @@ JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, 
                                       ,
         WTF::move(m_serializedVideoChunks), WTF::move(m_serializedVideoFrames)
 #endif
-    );
+        ,
+        // false for structuredClone/postMessage/Worker (built via
+        // SerializedScriptValue::create from a live JS value); true only when
+        // this SSV was reconstituted from external bytes (createFromWireBytes).
+        m_constructedFromWireBytes);
     if (didFail)
         *didFail = result.second != SerializationReturnCode::SuccessfullyCompleted;
     // Deserialize may throw an exception. Similar to serialize (~L6240, SerializedScriptValue::create),

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -6522,7 +6522,7 @@ JSC::JSValue SerializedScriptValue::fromArrayBuffer(JSC::JSGlobalObject& domGlob
         ,
         WTF::move(m_serializedVideoChunks), WTF::move(m_serializedVideoFrames)
 #endif
-        ,
+                                                ,
         // The caller hands us an arbitrary ArrayBuffer (bun:jsc / node:v8
         // deserialize()); these bytes are always treated as external.
         /* fromWireBytes */ true);
@@ -6782,7 +6782,7 @@ JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, 
                                       ,
         WTF::move(m_serializedVideoChunks), WTF::move(m_serializedVideoFrames)
 #endif
-        ,
+                                                ,
         // false for structuredClone/postMessage/Worker (built via
         // SerializedScriptValue::create from a live JS value); true only when
         // this SSV was reconstituted from external bytes (createFromWireBytes).

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -5271,9 +5271,6 @@ private:
     // const bool m_canCreateDOMObject;
     // True when the serialized bytes came from outside this process's
     // serializer (bun:jsc / node:v8 deserialize(), child-process IPC).
-    // Deserializers must not mint new capabilities (file-backed Blobs)
-    // from such bytes. Default-initialized to false so the
-    // deserializeString constructor path is unaffected.
     bool m_fromWireBytes { false };
     const uint8_t* m_ptr;
     const uint8_t* const m_end;
@@ -6523,8 +6520,6 @@ JSC::JSValue SerializedScriptValue::fromArrayBuffer(JSC::JSGlobalObject& domGlob
         WTF::move(m_serializedVideoChunks), WTF::move(m_serializedVideoFrames)
 #endif
                                                 ,
-        // The caller hands us an arbitrary ArrayBuffer (bun:jsc / node:v8
-        // deserialize()); these bytes are always treated as external.
         /* fromWireBytes */ true);
 
     if (arrayBuffer->isShared()) {
@@ -6783,9 +6778,6 @@ JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, 
         WTF::move(m_serializedVideoChunks), WTF::move(m_serializedVideoFrames)
 #endif
                                                 ,
-        // false for structuredClone/postMessage/Worker (built via
-        // SerializedScriptValue::create from a live JS value); true only when
-        // this SSV was reconstituted from external bytes (createFromWireBytes).
         m_constructedFromWireBytes);
     if (didFail)
         *didFail = result.second != SerializationReturnCode::SuccessfullyCompleted;

--- a/src/jsc/bindings/webcore/SerializedScriptValue.h
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.h
@@ -175,7 +175,12 @@ public:
     // IDBValue writeBlobsToDiskForIndexedDBSynchronously();
     static Ref<SerializedScriptValue> createFromWireBytes(Vector<uint8_t>&& data)
     {
-        return adoptRef(*new SerializedScriptValue(WTF::move(data)));
+        auto result = adoptRef(*new SerializedScriptValue(WTF::move(data)));
+        // These bytes did not come from this process's serializer, so the
+        // deserializer must not honor tags that confer new capabilities
+        // (e.g. file-backed Blobs).
+        result->m_constructedFromWireBytes = true;
+        return result;
     }
     const Vector<uint8_t>& wireBytes() const { return m_data; }
 
@@ -285,6 +290,12 @@ private:
     String m_fastPathString;
     FastPath m_fastPath { FastPath::None };
     size_t m_memoryCost { 0 };
+
+    // True only when this SerializedScriptValue was built from raw bytes that
+    // arrived from outside this process's serializer (createFromWireBytes).
+    // The deserializer uses this to reject tags that would mint new
+    // capabilities from attacker-controlled bytes.
+    bool m_constructedFromWireBytes { false };
 
     FixedVector<SimpleInMemoryPropertyTableEntry> m_simpleInMemoryPropertyTable {};
     // m_simpleArrayElements and m_arrayButterflyData/m_arrayLength are used exclusively:

--- a/src/jsc/bindings/webcore/SerializedScriptValue.h
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.h
@@ -176,9 +176,6 @@ public:
     static Ref<SerializedScriptValue> createFromWireBytes(Vector<uint8_t>&& data)
     {
         auto result = adoptRef(*new SerializedScriptValue(WTF::move(data)));
-        // These bytes did not come from this process's serializer, so the
-        // deserializer must not honor tags that confer new capabilities
-        // (e.g. file-backed Blobs).
         result->m_constructedFromWireBytes = true;
         return result;
     }

--- a/src/runtime/node/net/BlockList.rs
+++ b/src/runtime/node/net/BlockList.rs
@@ -421,6 +421,7 @@ impl BlockList {
         global: &JSGlobalObject,
         ptr: *mut *mut u8,
         end: *const u8,
+        _from_wire_bytes: bool,
     ) -> JsResult<JSValue> {
         // SAFETY: `*ptr` and `end` bound a contiguous byte buffer owned by the
         // caller (C++ SerializedScriptValue); `end >= *ptr`. `ptr` itself is a

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -181,6 +181,7 @@ pub trait BlobExt {
         global_this: &JSGlobalObject,
         ptr: *mut *mut u8,
         end: *const u8,
+        from_wire_bytes: bool,
     ) -> JsResult<JSValue>
     where
         Self: Sized;
@@ -795,6 +796,7 @@ impl BlobExt for Blob {
         global_this: &JSGlobalObject,
         ptr: *mut *mut u8,
         end: *const u8,
+        from_wire_bytes: bool,
     ) -> JsResult<JSValue> {
         // SAFETY: codegen passes a live `*mut *mut u8` cursor (C++:
         // `(uint8_t**)&ptr`) and a one-past-the-end `*const u8`; both are
@@ -807,8 +809,17 @@ impl BlobExt for Blob {
         let mut buffer_stream =
             bun_io::FixedBufferStream::new(unsafe { bun_core::ffi::slice(*cursor, total_length) });
 
-        let result = match _on_structured_clone_deserialize(global_this, &mut buffer_stream) {
+        let result = match _on_structured_clone_deserialize(
+            global_this,
+            &mut buffer_stream,
+            from_wire_bytes,
+        ) {
             Ok(v) => v,
+            Err(e) if e == bun_core::err!("FileBlobFromExternalBytes") => {
+                return Err(global_this.throw_type_error(format_args!(
+                    "Cannot deserialize a file-backed Blob from serialized bytes; only in-process structured clone can carry file references"
+                )));
+            }
             Err(e)
                 if e == bun_core::err!("EndOfStream")
                     || e == bun_core::err!("TooSmall")
@@ -4076,6 +4087,7 @@ fn read_slice<B: AsRef<[u8]>>(
 fn _on_structured_clone_deserialize<B: AsRef<[u8]>>(
     global_this: &JSGlobalObject,
     reader: &mut bun_io::FixedBufferStream<B>,
+    from_wire_bytes: bool,
 ) -> Result<JSValue, bun_core::Error> {
     let version = reader.read_int_le::<u8>()?;
     let offset = reader.read_int_le::<u64>()?;
@@ -4132,6 +4144,15 @@ fn _on_structured_clone_deserialize<B: AsRef<[u8]>>(
         }
         store::SerializeTag::File => 'file: {
             use crate::node::types::PathOrFileDescriptorSerializeTag;
+            // A file-backed Blob record names a path, an open file descriptor,
+            // or an `s3://` URL to re-open. Honoring it for bytes that did not
+            // come from this process's serializer would mint a live read/write
+            // handle from attacker-controlled data, so reject it. In-process
+            // structured clone (postMessage, structuredClone) still carries
+            // file references.
+            if from_wire_bytes {
+                return Err(bun_core::err!("FileBlobFromExternalBytes"));
+            }
             let pathlike_tag =
                 PathOrFileDescriptorSerializeTag::from_raw(reader.read_int_le::<u8>()?)
                     .ok_or_else(|| bun_core::err!("InvalidValue"))?;

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4144,12 +4144,9 @@ fn _on_structured_clone_deserialize<B: AsRef<[u8]>>(
         }
         store::SerializeTag::File => 'file: {
             use crate::node::types::PathOrFileDescriptorSerializeTag;
-            // A file-backed Blob record names a path, an open file descriptor,
-            // or an `s3://` URL to re-open. Honoring it for bytes that did not
-            // come from this process's serializer would mint a live read/write
-            // handle from attacker-controlled data, so reject it. In-process
-            // structured clone (postMessage, structuredClone) still carries
-            // file references.
+            // Reconstituting a file-backed Blob from bytes that did not come
+            // from this process's serializer would mint a live file handle
+            // (path/fd/s3 URL) from attacker-controlled data, so reject it.
             if from_wire_bytes {
                 return Err(bun_core::err!("FileBlobFromExternalBytes"));
             }

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -102,13 +102,17 @@ impl<'a, F: ReadFileToJs> ReadFileCompletion for NewReadFileHandler<'a, F> {
         // `&mut self`, but the promise is GC-heap-owned and outlives `handler`.
         // Decay to a raw pointer so `handler` can be dropped before resolution.
         let promise: *mut jsc::JSPromise = handler.promise.swap();
-        let blob = core::mem::take(&mut handler.context);
+        let mut blob = core::mem::take(&mut handler.context);
         // `context` was populated via `this.dupe()` in doReadFile(), so it
         // owns a store ref, a name ref, and possibly a content_type copy.
-        // (blob is dropped at end of scope — Drop handles deinit.)
+        // Zig: `defer blob.deinit()`. `Blob` has no `Drop` impl (`finalize()`
+        // owns teardown for class-payload blobs), so the field drop glue
+        // releases the store ref and name but NOT the heap `content_type`
+        // copy made by `dupe_with_content_type` — that must be freed
+        // explicitly after the callback has run.
         let global_this = handler.global_this;
         drop(handler);
-        match maybe_bytes {
+        let result = match maybe_bytes {
             ReadFileResultType::Result(result) => {
                 let bytes = result.buf;
                 if blob.size.get() > 0 {
@@ -119,9 +123,9 @@ impl<'a, F: ReadFileToJs> ReadFileCompletion for NewReadFileHandler<'a, F> {
                 // `Function` into the `toJSHostCall` shape; Rust closures + the
                 // `#[track_caller]` `to_js_host_call` inside `AnyPromise::wrap`
                 // give the same source-location/exception-scope behaviour.
-                AnyPromise::Normal(promise).wrap(global_this, move |g| {
+                AnyPromise::Normal(promise).wrap(global_this, |g| {
                     F::call(&blob, g, bytes, Lifetime::Temporary)
-                })?;
+                })
             }
             ReadFileResultType::Err(err) => {
                 // SAFETY: `promise` was just swapped out of a live `Strong`
@@ -129,10 +133,11 @@ impl<'a, F: ReadFileToJs> ReadFileCompletion for NewReadFileHandler<'a, F> {
                 // `JSRef` over the ReadFile task.
                 let promise = unsafe { &mut *promise };
                 let val = err.to_error_instance_with_async_stack(global_this, promise);
-                promise.reject(global_this, Ok(val))?;
+                promise.reject(global_this, Ok(val))
             }
-        }
-        Ok(())
+        };
+        blob.deinit();
+        result
     }
 }
 

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -1,6 +1,8 @@
 import { deserialize, serialize } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN } from "harness";
+import { bunEnv, bunExe, isASAN, tempDir } from "harness";
+import { openSync } from "node:fs";
+import { join } from "node:path";
 import v8 from "node:v8";
 
 describe("structuredClone with Blob and File", () => {
@@ -510,5 +512,161 @@ describe("structuredClone with Blob and File", () => {
       // measured window still grows under bun-asan; widen the threshold there.
       expect(deltaMiB).toBeLessThan(isASAN ? 128 : 32);
     }, 30_000);
+
+    // A file-backed Blob record in the wire format names a path, an open file
+    // descriptor, or an s3:// URL to re-open. `deserialize()` accepts bytes
+    // from anywhere (a cache, an IPC peer, a client upload), so honoring that
+    // record would turn attacker-controlled bytes into a live read/write
+    // handle over any path or descriptor in the process. Only the in-process
+    // structured-clone path (structuredClone, postMessage) may carry file
+    // references; every byte-stream entry point must reject them.
+    describe("file-backed Blob payloads from external bytes", () => {
+      test("file-path Blob payload does not grant a file handle via deserialize", async () => {
+        const sentinel = "TOP-SECRET-SENTINEL-1f2e3d";
+        using dir = tempDir("blob-deser-path", {
+          "secret.txt": sentinel,
+        });
+        const secretPath = join(String(dir), "secret.txt");
+        // The serializer still emits the File/Path wire record for a
+        // path-backed Bun.file(); this is byte-for-byte what an attacker
+        // would craft by hand.
+        const payload = serialize(Bun.file(secretPath));
+
+        expect(() => deserialize(payload)).toThrow();
+        expect(() => v8.deserialize(Buffer.from(payload))).toThrow();
+
+        // The same payload handed to a *fresh* process (the cache/IPC-shaped
+        // attack) must not mint a file handle there either.
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `
+            const { deserialize } = require("bun:jsc");
+            const payload = await Bun.stdin.bytes();
+            let blob;
+            try {
+              blob = deserialize(payload);
+            } catch (e) {
+              console.log("DESERIALIZE_THREW");
+              process.exit(0);
+            }
+            console.log("DESERIALIZE_OK");
+            console.log(await blob.text());
+            `,
+          ],
+          env: bunEnv,
+          stdin: new Uint8Array(payload),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+        expect(stdout).not.toContain(sentinel);
+        expect(stdout).toContain("DESERIALIZE_THREW");
+        expect(exitCode).toBe(0);
+      });
+
+      test("fd Blob payload does not alias an open descriptor", async () => {
+        using dir = tempDir("blob-deser-fd", {
+          "fd-target.txt": "fd sentinel contents",
+        });
+        const fd = openSync(join(String(dir), "fd-target.txt"), "r");
+        const payload = serialize(Bun.file(fd));
+
+        expect(() => deserialize(payload)).toThrow();
+        expect(() => v8.deserialize(Buffer.from(payload))).toThrow();
+
+        // In a fresh process that fd number refers to a different (or no)
+        // descriptor; deserialize must refuse rather than alias it.
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `
+            const { deserialize } = require("bun:jsc");
+            const payload = await Bun.stdin.bytes();
+            try {
+              deserialize(payload);
+            } catch (e) {
+              console.log("DESERIALIZE_THREW");
+              process.exit(0);
+            }
+            console.log("DESERIALIZE_OK");
+            `,
+          ],
+          env: bunEnv,
+          stdin: new Uint8Array(payload),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+        expect(stdout).toContain("DESERIALIZE_THREW");
+        expect(exitCode).toBe(0);
+      });
+
+      test("s3 path Blob payload is rejected", () => {
+        // `Bun.file("s3://...")` uses a dedicated S3 store that serializes
+        // under the Bytes tag, so to get a File/Path record whose path is an
+        // s3:// URL we patch the path bytes of a regular file payload in
+        // place (same length, so the length prefix stays valid). This is the
+        // payload an attacker would craft to make the deserializer mint an
+        // S3-backed Blob using the process's ambient credentials.
+        using dir = tempDir("blob-deser-s3", { "abcdefgh.txt": "x" });
+        const realPath = join(String(dir), "abcdefgh.txt");
+        const payload = new Uint8Array(serialize(Bun.file(realPath)));
+
+        const pathBytes = new TextEncoder().encode(realPath);
+        const s3Url = "s3://bucket/" + "k".repeat(pathBytes.length - "s3://bucket/".length);
+        const s3Bytes = new TextEncoder().encode(s3Url);
+        expect(s3Bytes.length).toBe(pathBytes.length);
+
+        // Locate the path string inside the payload and overwrite it.
+        let at = -1;
+        outer: for (let i = 0; i + pathBytes.length <= payload.length; i++) {
+          for (let j = 0; j < pathBytes.length; j++) {
+            if (payload[i + j] !== pathBytes[j]) continue outer;
+          }
+          at = i;
+          break;
+        }
+        expect(at).toBeGreaterThanOrEqual(0);
+        payload.set(s3Bytes, at);
+
+        expect(() => deserialize(payload)).toThrow();
+        expect(() => v8.deserialize(Buffer.from(payload))).toThrow();
+      });
+
+      test("in-process structuredClone of a file-backed Blob still works", async () => {
+        const sentinel = "structured-clone-keeps-working";
+        using dir = tempDir("blob-clone-inproc", {
+          "kept.txt": sentinel,
+        });
+        const path = join(String(dir), "kept.txt");
+        const blob = Bun.file(path);
+        const clone = structuredClone(blob);
+        expect(clone.name).toBe(blob.name);
+        expect(clone.size).toBe(blob.size);
+        expect(clone.lastModified).toBe(blob.lastModified);
+        expect(await clone.text()).toBe(sentinel);
+      });
+
+      test("bytes-backed Blob and File payloads still round-trip through external bytes", async () => {
+        const blob = new Blob(["hello bytes"], { type: "application/octet-stream" });
+        const blobClone = deserialize(serialize(blob));
+        expect(blobClone).toBeInstanceOf(Blob);
+        expect(blobClone.type).toBe("application/octet-stream");
+        expect(await blobClone.text()).toBe("hello bytes");
+
+        const file = new File(["file bytes"], "n.txt", {
+          type: "application/octet-stream",
+          lastModified: 1234,
+        });
+        const fileClone = v8.deserialize(v8.serialize(file));
+        expect(fileClone).toBeInstanceOf(File);
+        expect(fileClone.name).toBe("n.txt");
+        expect(fileClone.lastModified).toBe(1234);
+        expect(await fileClone.text()).toBe("file bytes");
+      });
+    });
   });
 });

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -616,7 +616,7 @@ describe("structuredClone with Blob and File", () => {
         const payload = new Uint8Array(serialize(Bun.file(realPath)));
 
         const pathBytes = new TextEncoder().encode(realPath);
-        const s3Url = "s3://bucket/" + "k".repeat(pathBytes.length - "s3://bucket/".length);
+        const s3Url = "s3://bucket/" + Buffer.alloc(pathBytes.length - "s3://bucket/".length, "k").toString();
         const s3Bytes = new TextEncoder().encode(s3Url);
         expect(s3Bytes.length).toBe(pathBytes.length);
 

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -484,7 +484,7 @@ describe("structuredClone with Blob and File", () => {
       const payloads = cuts.map(n => full.slice(0, n));
       // All of these must hit the error path; if one accidentally succeeds
       // the test isn't measuring what it thinks it is.
-      for (const p of payloads) expect(() => deserialize(p)).toThrow();
+      for (const p of payloads) expect(() => deserialize(p)).toThrow(TypeError);
 
       const attempt = () => {
         for (const p of payloads) {
@@ -532,8 +532,8 @@ describe("structuredClone with Blob and File", () => {
         // would craft by hand.
         const payload = serialize(Bun.file(secretPath));
 
-        expect(() => deserialize(payload)).toThrow();
-        expect(() => v8.deserialize(Buffer.from(payload))).toThrow();
+        expect(() => deserialize(payload)).toThrow(TypeError);
+        expect(() => v8.deserialize(Buffer.from(payload))).toThrow(TypeError);
 
         // The same payload handed to a *fresh* process (the cache/IPC-shaped
         // attack) must not mint a file handle there either.
@@ -574,8 +574,8 @@ describe("structuredClone with Blob and File", () => {
         try {
           const payload = serialize(Bun.file(fd));
 
-          expect(() => deserialize(payload)).toThrow();
-          expect(() => v8.deserialize(Buffer.from(payload))).toThrow();
+          expect(() => deserialize(payload)).toThrow(TypeError);
+          expect(() => v8.deserialize(Buffer.from(payload))).toThrow(TypeError);
 
           // In a fresh process that fd number refers to a different (or no)
           // descriptor; deserialize must refuse rather than alias it.
@@ -636,8 +636,8 @@ describe("structuredClone with Blob and File", () => {
         expect(at).toBeGreaterThanOrEqual(0);
         payload.set(s3Bytes, at);
 
-        expect(() => deserialize(payload)).toThrow();
-        expect(() => v8.deserialize(Buffer.from(payload))).toThrow();
+        expect(() => deserialize(payload)).toThrow(TypeError);
+        expect(() => v8.deserialize(Buffer.from(payload))).toThrow(TypeError);
       });
 
       test("in-process structuredClone of a file-backed Blob still works", async () => {

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -1,7 +1,7 @@
 import { deserialize, serialize } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, tempDir } from "harness";
-import { openSync } from "node:fs";
+import { closeSync, openSync } from "node:fs";
 import { join } from "node:path";
 import v8 from "node:v8";
 
@@ -571,18 +571,19 @@ describe("structuredClone with Blob and File", () => {
           "fd-target.txt": "fd sentinel contents",
         });
         const fd = openSync(join(String(dir), "fd-target.txt"), "r");
-        const payload = serialize(Bun.file(fd));
+        try {
+          const payload = serialize(Bun.file(fd));
 
-        expect(() => deserialize(payload)).toThrow();
-        expect(() => v8.deserialize(Buffer.from(payload))).toThrow();
+          expect(() => deserialize(payload)).toThrow();
+          expect(() => v8.deserialize(Buffer.from(payload))).toThrow();
 
-        // In a fresh process that fd number refers to a different (or no)
-        // descriptor; deserialize must refuse rather than alias it.
-        await using proc = Bun.spawn({
-          cmd: [
-            bunExe(),
-            "-e",
-            `
+          // In a fresh process that fd number refers to a different (or no)
+          // descriptor; deserialize must refuse rather than alias it.
+          await using proc = Bun.spawn({
+            cmd: [
+              bunExe(),
+              "-e",
+              `
             const { deserialize } = require("bun:jsc");
             const payload = await Bun.stdin.bytes();
             try {
@@ -593,15 +594,18 @@ describe("structuredClone with Blob and File", () => {
             }
             console.log("DESERIALIZE_OK");
             `,
-          ],
-          env: bunEnv,
-          stdin: new Uint8Array(payload),
-          stdout: "pipe",
-          stderr: "pipe",
-        });
-        const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-        expect(stdout).toContain("DESERIALIZE_THREW");
-        expect(exitCode).toBe(0);
+            ],
+            env: bunEnv,
+            stdin: new Uint8Array(payload),
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+          const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+          expect(stdout).toContain("DESERIALIZE_THREW");
+          expect(exitCode).toBe(0);
+        } finally {
+          closeSync(fd);
+        }
       });
 
       test("s3 path Blob payload is rejected", () => {

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -184,20 +184,41 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
         const cloned = structuredCloneFn(blob);
         await compareBlobs(blob, cloned);
       });
+      // File-backed Blobs may only be re-created by the in-process
+      // structured-clone path. The byte-stream entry points (bun:jsc
+      // deserialize, cross-process IPC) must reject them: a file/fd record in
+      // an untrusted byte stream would otherwise mint a live handle over any
+      // path or descriptor.
       test("file from path", async () => {
         const blob = Bun.file(join(import.meta.dir, "example.txt"));
-        const cloned = structuredCloneFn(blob);
-        expect(cloned.lastModified).toBe(blob.lastModified);
-        expect(cloned.name).toBe(blob.name);
-        expect(cloned.size).toBe(blob.size);
+        if (structuredCloneFn === structuredClone) {
+          const cloned = structuredCloneFn(blob);
+          expect(cloned.lastModified).toBe(blob.lastModified);
+          expect(cloned.name).toBe(blob.name);
+          expect(cloned.size).toBe(blob.size);
+        } else if (structuredCloneFn === jscSerializeRoundtrip) {
+          expect(() => structuredCloneFn(blob)).toThrow();
+        } else {
+          // Cross-process: the child's deserialize rejects the file record,
+          // so no file-backed Blob ever comes back.
+          expect(structuredCloneFn(blob)).not.toBeInstanceOf(Blob);
+        }
       });
       test("file from fd", async () => {
         const fd = openSync(join(import.meta.dir, "example.txt"), "r");
         const blob = Bun.file(fd);
-        const cloned = structuredCloneFn(blob);
-        expect(cloned.lastModified).toBe(blob.lastModified);
-        expect(cloned.name).toBe(blob.name);
-        expect(cloned.size).toBe(blob.size);
+        if (structuredCloneFn === structuredClone) {
+          const cloned = structuredCloneFn(blob);
+          expect(cloned.lastModified).toBe(blob.lastModified);
+          expect(cloned.name).toBe(blob.name);
+          expect(cloned.size).toBe(blob.size);
+        } else if (structuredCloneFn === jscSerializeRoundtrip) {
+          expect(() => structuredCloneFn(blob)).toThrow();
+        } else {
+          // Cross-process: the child's deserialize rejects the file record,
+          // so no file-backed Blob ever comes back.
+          expect(structuredCloneFn(blob)).not.toBeInstanceOf(Blob);
+        }
       });
       describe("dom file", async () => {
         test("without lastModified", async () => {

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -210,9 +210,9 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
         } else if (structuredCloneFn === jscSerializeRoundtrip) {
           expect(() => structuredCloneFn(blob)).toThrow();
         } else {
-          // Cross-process: the child's deserialize rejects the file record,
-          // so no file-backed Blob ever comes back.
-          expect(structuredCloneFn(blob)).not.toBeInstanceOf(Blob);
+          // Cross-process: the child's deserialize must reject the file
+          // record outright (surfaced by the helper as a sentinel).
+          expect(structuredCloneFn(blob)).toBe("DESERIALIZE_THREW");
         }
       });
       test("file from fd", async () => {
@@ -226,9 +226,9 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
         } else if (structuredCloneFn === jscSerializeRoundtrip) {
           expect(() => structuredCloneFn(blob)).toThrow();
         } else {
-          // Cross-process: the child's deserialize rejects the file record,
-          // so no file-backed Blob ever comes back.
-          expect(structuredCloneFn(blob)).not.toBeInstanceOf(Blob);
+          // Cross-process: the child's deserialize must reject the file
+          // record outright (surfaced by the helper as a sentinel).
+          expect(structuredCloneFn(blob)).toBe("DESERIALIZE_THREW");
         }
       });
       describe("dom file", async () => {

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1,5 +1,5 @@
 import { deserialize, serialize } from "bun:jsc";
-import { openSync } from "fs";
+import { closeSync, openSync } from "fs";
 import { bunEnv } from "harness";
 import { bunExe } from "js/bun/shell/test_builder";
 import { join } from "path";
@@ -217,18 +217,22 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
       });
       test("file from fd", async () => {
         const fd = openSync(join(import.meta.dir, "example.txt"), "r");
-        const blob = Bun.file(fd);
-        if (structuredCloneFn === structuredClone) {
-          const cloned = structuredCloneFn(blob);
-          expect(cloned.lastModified).toBe(blob.lastModified);
-          expect(cloned.name).toBe(blob.name);
-          expect(cloned.size).toBe(blob.size);
-        } else if (structuredCloneFn === jscSerializeRoundtrip) {
-          expect(() => structuredCloneFn(blob)).toThrow();
-        } else {
-          // Cross-process: the child's deserialize must reject the file
-          // record outright (surfaced by the helper as a sentinel).
-          expect(structuredCloneFn(blob)).toBe("DESERIALIZE_THREW");
+        try {
+          const blob = Bun.file(fd);
+          if (structuredCloneFn === structuredClone) {
+            const cloned = structuredCloneFn(blob);
+            expect(cloned.lastModified).toBe(blob.lastModified);
+            expect(cloned.name).toBe(blob.name);
+            expect(cloned.size).toBe(blob.size);
+          } else if (structuredCloneFn === jscSerializeRoundtrip) {
+            expect(() => structuredCloneFn(blob)).toThrow();
+          } else {
+            // Cross-process: the child's deserialize must reject the file
+            // record outright (surfaced by the helper as a sentinel).
+            expect(structuredCloneFn(blob)).toBe("DESERIALIZE_THREW");
+          }
+        } finally {
+          closeSync(fd);
         }
       });
       describe("dom file", async () => {

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -18,7 +18,13 @@ function jscSerializeRoundtripCrossProcess(original: any) {
       "-e",
       `
     import {deserialize, serialize} from "bun:jsc";
-    const serialized = deserialize(await Bun.stdin.bytes());
+    let serialized;
+    try {
+      serialized = deserialize(await Bun.stdin.bytes());
+    } catch {
+      process.stdout.write("DESERIALIZE_THREW");
+      process.exit(0);
+    }
     const cloned = serialize(serialized);
     process.stdout.write(cloned);
     `,
@@ -28,6 +34,11 @@ function jscSerializeRoundtripCrossProcess(original: any) {
     stdout: "pipe",
     stderr: "inherit",
   });
+  if (result.stdout.toString() === "DESERIALIZE_THREW") {
+    // The child's deserialize rejected the payload (e.g. a file-backed Blob
+    // record arriving as external bytes); return a sentinel that is not a Blob.
+    return "DESERIALIZE_THREW";
+  }
   return deserialize(result.stdout);
 }
 

--- a/test/js/web/workers/structuredClone-classes.test.ts
+++ b/test/js/web/workers/structuredClone-classes.test.ts
@@ -79,7 +79,13 @@ describe("serialize & deserialize", () => {
           "-e",
           `
         import {deserialize, serialize} from "bun:jsc";
-        const serialized = deserialize(await Bun.stdin.bytes());
+        let serialized;
+        try {
+          serialized = deserialize(await Bun.stdin.bytes());
+        } catch (e) {
+          process.stdout.write("DESERIALIZE_THREW");
+          process.exit(0);
+        }
         const cloned = serialize(serialized);
         process.stdout.write(cloned);
         `,
@@ -89,6 +95,13 @@ describe("serialize & deserialize", () => {
         stdout: "pipe",
         stderr: "inherit",
       });
+      if (testType.name.startsWith("BunFile")) {
+        // A file-backed Blob record names a path to re-open; the byte-stream
+        // deserializer in the child process must reject it rather than mint a
+        // file handle from external bytes.
+        expect(result.stdout.toString()).toBe("DESERIALIZE_THREW");
+        return;
+      }
       const cloned = deserialize(result.stdout);
       testType.expectedAfterClone(original, cloned, TransferMode.no, true);
     });


### PR DESCRIPTION
Deserializing a byte stream via `bun:jsc` / `node:v8` `deserialize()` or child-process IPC no longer re-opens Blob records that reference a file path, an open file descriptor, or an `s3://` URL; those records are now rejected with a `TypeError`. Only the in-process structured-clone paths (`structuredClone`, Worker/MessagePort `postMessage`), where the value being cloned came from a live JS object in the same process, still carry file references. Bytes-backed and empty Blob/File records continue to round-trip through every entry point.

The deserializer now receives a flag describing whether the bytes were reconstituted from an external buffer (`SerializedScriptValue::fromArrayBuffer`, `createFromWireBytes`) or produced by the in-process serializer, and the Blob deserializer rejects the file store tag in the former case.

Adds tests covering path-, fd-, and s3-shaped Blob payloads through `deserialize`, `v8.deserialize`, and a child process, plus coverage that in-process `structuredClone` of `Bun.file()` and bytes-backed round-trips keep working. Updates the two existing tests that asserted the old byte-stream behavior.