### PR TITLE
install: compare trusted dependency names, not just truncated hashes

### DIFF
--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -105,7 +105,12 @@ pub struct PackageInstaller<'a> {
     pub tree_ids_to_trees_the_id_depends_on: bun_collections::DynamicBitSetList,
     pub pending_lifecycle_scripts: Vec<PendingLifecycleScript>,
 
-    pub trusted_dependencies_from_update_requests: ArrayHashMap<TruncatedPackageNameHash, ()>,
+    /// Keyed by truncated name hash; the value is the exact alias bytes the
+    /// hash was computed from. Lookups must compare the name so a
+    /// hash-colliding alias can't be trusted (or written back to
+    /// package.json/the lockfile) through `--trust`.
+    pub trusted_dependencies_from_update_requests:
+        ArrayHashMap<TruncatedPackageNameHash, Box<[u8]>>,
 
     /// uses same ids as lockfile.trees
     pub trees: Box<[TreeContext]>,
@@ -1772,7 +1777,8 @@ impl<'a> PackageInstaller<'a> {
                     let (is_trusted, is_trusted_through_update_request) = 'brk: {
                         if self
                             .trusted_dependencies_from_update_requests
-                            .contains(&truncated_dep_name_hash)
+                            .get(&truncated_dep_name_hash)
+                            .is_some_and(|n| **n == *alias.slice(string_buf!()))
                         {
                             break 'brk (true, true);
                         }
@@ -1849,7 +1855,10 @@ impl<'a> PackageInstaller<'a> {
                                         .trusted_dependencies
                                         .as_mut()
                                         .unwrap()
-                                        .put(truncated_dep_name_hash, ())
+                                        .put(
+                                            truncated_dep_name_hash,
+                                            Box::<[u8]>::from(alias.slice(string_buf!())),
+                                        )
                                         .unwrap_or_oom();
                                 }
                             }
@@ -2077,19 +2086,22 @@ impl<'a> PackageInstaller<'a> {
                 // trusted through a --trust dependency. need to enqueue scripts, write to package.json, and add to lockfile
                 if self
                     .trusted_dependencies_from_update_requests
-                    .contains(&truncated_dep_name_hash)
+                    .get(&truncated_dep_name_hash)
+                    .is_some_and(|n| **n == *alias.slice(string_buf!()))
                 {
                     break 'brk (true, true, true);
                 }
 
-                if let Some(should_add_to_lockfile) = self
+                if let Some(added) = self
                     .manager()
                     .summary
                     .added_trusted_dependencies
                     .get(&truncated_dep_name_hash)
                 {
                     // is a new trusted dependency. need to enqueue scripts and maybe add to lockfile
-                    break 'brk (true, false, *should_add_to_lockfile);
+                    if *added.name == *alias.slice(string_buf!()) {
+                        break 'brk (true, false, added.add_to_lockfile);
+                    }
                 }
                 break 'brk (false, false, false);
             };
@@ -2154,7 +2166,10 @@ impl<'a> PackageInstaller<'a> {
                                 .trusted_dependencies
                                 .as_mut()
                                 .unwrap()
-                                .put(truncated_dep_name_hash, ())
+                                .put(
+                                    truncated_dep_name_hash,
+                                    Box::<[u8]>::from(alias.slice(string_buf!())),
+                                )
                                 .unwrap_or_oom();
                         }
                     }

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -105,10 +105,8 @@ pub struct PackageInstaller<'a> {
     pub tree_ids_to_trees_the_id_depends_on: bun_collections::DynamicBitSetList,
     pub pending_lifecycle_scripts: Vec<PendingLifecycleScript>,
 
-    /// Keyed by truncated name hash; the value is the exact alias bytes the
-    /// hash was computed from. Lookups must compare the name so a
-    /// hash-colliding alias can't be trusted (or written back to
-    /// package.json/the lockfile) through `--trust`.
+    /// Value is the alias bytes the key hash was computed from; lookups must
+    /// compare it since truncated hashes can collide.
     pub trusted_dependencies_from_update_requests:
         ArrayHashMap<TruncatedPackageNameHash, Box<[u8]>>,
 

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -566,8 +566,7 @@ fn add_dependencies_to_set(
         let dep = &lockfile.buffers.dependencies[dep_id as usize];
         let entry = handle_oom(names.get_or_put(dep.name_hash as TruncatedPackageNameHash));
         if !entry.found_existing {
-            *entry.value_ptr =
-                Box::from(dep.name.slice(lockfile.buffers.string_bytes.as_slice()));
+            *entry.value_ptr = Box::from(dep.name.slice(lockfile.buffers.string_bytes.as_slice()));
             let dependency_slice = lockfile.packages.items_dependencies()[package_id as usize];
             add_dependencies_to_set(names, lockfile, dependency_slice);
         }

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -499,11 +499,15 @@ impl PackageManager {
         Ok(())
     }
 
+    /// Returns a map keyed by truncated name hash whose value is the exact
+    /// alias bytes the hash was computed from. Callers must compare the name
+    /// before trusting an entry: the truncated hash alone is not a sufficient
+    /// identity check.
     pub fn find_trusted_dependencies_from_update_requests(
         &mut self,
-    ) -> ArrayHashMap<TruncatedPackageNameHash, ()> {
+    ) -> ArrayHashMap<TruncatedPackageNameHash, Box<[u8]>> {
         // find all deps originating from --trust packages from cli
-        let mut set: ArrayHashMap<TruncatedPackageNameHash, ()> = ArrayHashMap::default();
+        let mut set: ArrayHashMap<TruncatedPackageNameHash, Box<[u8]>> = ArrayHashMap::default();
         if self.options.do_.trust_dependencies_from_args() && self.lockfile.packages.len() > 0 {
             let root_id = self
                 .root_package_id
@@ -524,6 +528,11 @@ impl PackageManager {
                             set.get_or_put(root_dep.name_hash as TruncatedPackageNameHash),
                         );
                         if !entry.found_existing {
+                            *entry.value_ptr = Box::from(
+                                root_dep
+                                    .name
+                                    .slice(self.lockfile.buffers.string_bytes.as_slice()),
+                            );
                             let dependency_slice =
                                 self.lockfile.packages.items_dependencies()[package_id as usize];
                             add_dependencies_to_set(&mut set, &self.lockfile, dependency_slice);
@@ -540,7 +549,7 @@ impl PackageManager {
 }
 
 fn add_dependencies_to_set(
-    names: &mut ArrayHashMap<TruncatedPackageNameHash, ()>,
+    names: &mut ArrayHashMap<TruncatedPackageNameHash, Box<[u8]>>,
     lockfile: &Lockfile,
     dependencies_slice: lockfile::DependencySlice,
 ) {
@@ -557,6 +566,8 @@ fn add_dependencies_to_set(
         let dep = &lockfile.buffers.dependencies[dep_id as usize];
         let entry = handle_oom(names.get_or_put(dep.name_hash as TruncatedPackageNameHash));
         if !entry.found_existing {
+            *entry.value_ptr =
+                Box::from(dep.name.slice(lockfile.buffers.string_bytes.as_slice()));
             let dependency_slice = lockfile.packages.items_dependencies()[package_id as usize];
             add_dependencies_to_set(names, lockfile, dependency_slice);
         }
@@ -643,7 +654,7 @@ pub fn spawn_package_lifecycle_scripts(
 #[inline]
 pub fn find_trusted_dependencies_from_update_requests(
     this: &mut PackageManager,
-) -> ArrayHashMap<TruncatedPackageNameHash, ()> {
+) -> ArrayHashMap<TruncatedPackageNameHash, Box<[u8]>> {
     this.find_trusted_dependencies_from_update_requests()
 }
 

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -499,10 +499,6 @@ impl PackageManager {
         Ok(())
     }
 
-    /// Returns a map keyed by truncated name hash whose value is the exact
-    /// alias bytes the hash was computed from. Callers must compare the name
-    /// before trusting an entry: the truncated hash alone is not a sufficient
-    /// identity check.
     pub fn find_trusted_dependencies_from_update_requests(
         &mut self,
     ) -> ArrayHashMap<TruncatedPackageNameHash, Box<[u8]>> {

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -1310,7 +1310,8 @@ pub fn install_isolated_packages(
                                     pkg_names[pkg_id as usize].slice(string_buf),
                                     pkg_res,
                                 ) || trusted_from_update
-                                    .contains(&(dep_name_hash as crate::TruncatedPackageNameHash))
+                                    .get(&(dep_name_hash as crate::TruncatedPackageNameHash))
+                                    .is_some_and(|n| **n == *dep_name)
                                 {
                                     break 'eligible false;
                                 }

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -108,10 +108,9 @@ pub struct Installer<'a> {
     /// round-trip via `Method::from_u8` at the load sites below.
     pub supported_backend: AtomicU8,
 
-    /// Keyed by truncated name hash; the value is the exact alias bytes the
-    /// hash was computed from. Lookups must compare the name so a
-    /// hash-colliding alias can't be trusted through `--trust`. Built before
-    /// tasks spawn and only read concurrently afterwards.
+    /// Value is the alias bytes the key hash was computed from; lookups must
+    /// compare it since truncated hashes can collide. Built before tasks
+    /// spawn and only read concurrently afterwards.
     pub trusted_dependencies_from_update_requests:
         ArrayHashMap<TruncatedPackageNameHash, Box<[u8]>>,
 

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -108,7 +108,12 @@ pub struct Installer<'a> {
     /// round-trip via `Method::from_u8` at the load sites below.
     pub supported_backend: AtomicU8,
 
-    pub trusted_dependencies_from_update_requests: ArrayHashMap<TruncatedPackageNameHash, ()>,
+    /// Keyed by truncated name hash; the value is the exact alias bytes the
+    /// hash was computed from. Lookups must compare the name so a
+    /// hash-colliding alias can't be trusted through `--trust`. Built before
+    /// tasks spawn and only read concurrently afterwards.
+    pub trusted_dependencies_from_update_requests:
+        ArrayHashMap<TruncatedPackageNameHash, Box<[u8]>>,
 
     /// Absolute path to the global virtual store (`<cache_dir>/links`). When
     /// non-null, npm/git/tarball entries are materialized once into this
@@ -1628,7 +1633,8 @@ impl Task {
                     let (is_trusted, is_trusted_through_update_request) = 'brk: {
                         if installer
                             .trusted_dependencies_from_update_requests
-                            .contains_key(&truncated_dep_name_hash)
+                            .get(&truncated_dep_name_hash)
+                            .is_some_and(|n| **n == *dep.name.slice(string_buf))
                         {
                             break 'brk (true, true);
                         }
@@ -1737,10 +1743,10 @@ impl Task {
                                 if trusted.is_none() {
                                     *trusted = Some(Default::default());
                                 }
-                                trusted
-                                    .as_mut()
-                                    .unwrap()
-                                    .insert(truncated_dep_name_hash, ());
+                                trusted.as_mut().unwrap().insert(
+                                    truncated_dep_name_hash,
+                                    Box::from(dep.name.slice(string_buf)),
+                                );
                             }
 
                             if first_index != 0 {

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -111,12 +111,9 @@ pub type StringBuffer = Vec<u8>;
 pub type ExternalStringBuffer = Vec<ExternalString>;
 
 pub type NameHashMap = ArrayHashMap<PackageNameHash, SemverString, ArrayIdentityContextU64>;
-/// Trusted-dependency entries keyed by the truncated 32-bit name hash. The
-/// value is the exact byte string the key hash was computed from; lookups must
-/// compare it so a different name whose truncated hash happens to collide with
-/// a trusted entry is not treated as trusted. An empty value is the legacy
-/// `bun.lockb` sentinel ("name unknown, hash-only match") and is only ever
-/// produced by the binary-lockfile loader, which does not store names.
+/// Value is the exact byte string the key hash was computed from; lookups must
+/// compare it since truncated hashes can collide. An empty value is the legacy
+/// `bun.lockb` sentinel ("name unknown, hash-only match").
 pub type TrustedDependenciesSet =
     ArrayHashMap<TruncatedPackageNameHash, Box<[u8]>, ArrayIdentityContext>;
 pub type VersionHashMap = ArrayHashMap<PackageNameHash, Semver::Version, ArrayIdentityContextU64>;
@@ -3364,10 +3361,8 @@ impl Lockfile {
     ) -> bool {
         if let Some(trusted_dependencies) = &self.trusted_dependencies {
             let hash = SemverStringBuilder::string_hash(alias) as u32;
-            // The truncated hash is only a bucket index; require the stored
-            // name to match so a colliding name can't inherit trust. The empty
-            // value is the legacy bun.lockb sentinel (no name stored) and
-            // keeps matching by hash alone.
+            // Empty value = legacy bun.lockb sentinel (no name stored);
+            // match by hash alone.
             return match trusted_dependencies.get(&hash) {
                 Some(name) => name.is_empty() || **name == *alias,
                 None => false,

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -111,7 +111,14 @@ pub type StringBuffer = Vec<u8>;
 pub type ExternalStringBuffer = Vec<ExternalString>;
 
 pub type NameHashMap = ArrayHashMap<PackageNameHash, SemverString, ArrayIdentityContextU64>;
-pub type TrustedDependenciesSet = ArrayHashMap<TruncatedPackageNameHash, (), ArrayIdentityContext>;
+/// Trusted-dependency entries keyed by the truncated 32-bit name hash. The
+/// value is the exact byte string the key hash was computed from; lookups must
+/// compare it so a different name whose truncated hash happens to collide with
+/// a trusted entry is not treated as trusted. An empty value is the legacy
+/// `bun.lockb` sentinel ("name unknown, hash-only match") and is only ever
+/// produced by the binary-lockfile loader, which does not store names.
+pub type TrustedDependenciesSet =
+    ArrayHashMap<TruncatedPackageNameHash, Box<[u8]>, ArrayIdentityContext>;
 pub type VersionHashMap = ArrayHashMap<PackageNameHash, Semver::Version, ArrayIdentityContextU64>;
 pub type PatchedDependenciesMap =
     ArrayHashMap<PackageNameAndVersionHash, PatchedDep, ArrayIdentityContextU64>;
@@ -3357,7 +3364,14 @@ impl Lockfile {
     ) -> bool {
         if let Some(trusted_dependencies) = &self.trusted_dependencies {
             let hash = SemverStringBuilder::string_hash(alias) as u32;
-            return trusted_dependencies.contains(&hash);
+            // The truncated hash is only a bucket index; require the stored
+            // name to match so a colliding name can't inherit trust. The empty
+            // value is the legacy bun.lockb sentinel (no name stored) and
+            // keeps matching by hash alone.
+            return match trusted_dependencies.get(&hash) {
+                Some(name) => name.is_empty() || **name == *alias,
+                None => false,
+            };
         }
 
         // Only allow default trusted dependencies for npm packages. Check the

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1269,13 +1269,14 @@ impl Diff {
                     // stored names to match (empty = legacy bun.lockb
                     // hash-only sentinel) so replacing a trusted name with a
                     // colliding one is still reported as an add + remove.
-                    let already_trusted = from_trusted_dependencies
-                        .get(&to_trusted)
-                        .is_some_and(|from_name| {
-                            from_name.is_empty()
-                                || to_name.is_empty()
-                                || **from_name == **to_name
-                        });
+                    let already_trusted =
+                        from_trusted_dependencies
+                            .get(&to_trusted)
+                            .is_some_and(|from_name| {
+                                from_name.is_empty()
+                                    || to_name.is_empty()
+                                    || **from_name == **to_name
+                            });
                     if !already_trusted {
                         summary.added_trusted_dependencies.put(
                             to_trusted,
@@ -1289,13 +1290,14 @@ impl Diff {
 
                 // removed
                 for (&from_trusted, from_name) in from_trusted_dependencies.iter() {
-                    let still_trusted = to_trusted_dependencies
-                        .get(&from_trusted)
-                        .is_some_and(|to_name| {
-                            from_name.is_empty()
-                                || to_name.is_empty()
-                                || **to_name == **from_name
-                        });
+                    let still_trusted =
+                        to_trusted_dependencies
+                            .get(&from_trusted)
+                            .is_some_and(|to_name| {
+                                from_name.is_empty()
+                                    || to_name.is_empty()
+                                    || **to_name == **from_name
+                            });
                     if !still_trusted {
                         summary
                             .removed_trusted_dependencies

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -987,8 +987,7 @@ pub enum DiffOp {
 }
 
 /// A trusted dependency newly added by the current diff. `name` is the exact
-/// byte string the truncated key hash was computed from; consumers must
-/// compare it before granting trust so a hash-colliding alias can't match.
+/// byte string the truncated key hash was computed from.
 pub struct AddedTrustedDependency {
     /// Whether this dependency should be added to lockfile trusted
     /// dependencies. It is false when the new trusted dependency is coming
@@ -1265,10 +1264,7 @@ impl Diff {
             ) {
                 // added
                 for (&to_trusted, to_name) in to_trusted_dependencies.iter() {
-                    // The truncated hash is only a bucket index; require the
-                    // stored names to match (empty = legacy bun.lockb
-                    // hash-only sentinel) so replacing a trusted name with a
-                    // colliding one is still reported as an add + remove.
+                    // Empty name = legacy bun.lockb hash-only sentinel.
                     let already_trusted =
                         from_trusted_dependencies
                             .get(&to_trusted)

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1265,7 +1265,18 @@ impl Diff {
             ) {
                 // added
                 for (&to_trusted, to_name) in to_trusted_dependencies.iter() {
-                    if !from_trusted_dependencies.contains(&to_trusted) {
+                    // The truncated hash is only a bucket index; require the
+                    // stored names to match (empty = legacy bun.lockb
+                    // hash-only sentinel) so replacing a trusted name with a
+                    // colliding one is still reported as an add + remove.
+                    let already_trusted = from_trusted_dependencies
+                        .get(&to_trusted)
+                        .is_some_and(|from_name| {
+                            from_name.is_empty()
+                                || to_name.is_empty()
+                                || **from_name == **to_name
+                        });
+                    if !already_trusted {
                         summary.added_trusted_dependencies.put(
                             to_trusted,
                             AddedTrustedDependency {
@@ -1278,7 +1289,14 @@ impl Diff {
 
                 // removed
                 for (&from_trusted, from_name) in from_trusted_dependencies.iter() {
-                    if !to_trusted_dependencies.contains(&from_trusted) {
+                    let still_trusted = to_trusted_dependencies
+                        .get(&from_trusted)
+                        .is_some_and(|to_name| {
+                            from_name.is_empty()
+                                || to_name.is_empty()
+                                || **to_name == **from_name
+                        });
+                    if !still_trusted {
                         summary
                             .removed_trusted_dependencies
                             .put(from_trusted, from_name.clone())?;

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -986,6 +986,17 @@ pub enum DiffOp {
     Link,
 }
 
+/// A trusted dependency newly added by the current diff. `name` is the exact
+/// byte string the truncated key hash was computed from; consumers must
+/// compare it before granting trust so a hash-colliding alias can't match.
+pub struct AddedTrustedDependency {
+    /// Whether this dependency should be added to lockfile trusted
+    /// dependencies. It is false when the new trusted dependency is coming
+    /// from the default list.
+    pub add_to_lockfile: bool,
+    pub name: Box<[u8]>,
+}
+
 #[derive(Default)]
 pub struct DiffSummary {
     pub add: u32,
@@ -994,10 +1005,8 @@ pub struct DiffSummary {
     pub overrides_changed: bool,
     pub catalogs_changed: bool,
 
-    /// bool for if this dependency should be added to lockfile trusted dependencies.
-    /// it is false when the new trusted dependency is coming from the default list.
     pub added_trusted_dependencies:
-        ArrayHashMap<TruncatedPackageNameHash, bool, ArrayIdentityContext>,
+        ArrayHashMap<TruncatedPackageNameHash, AddedTrustedDependency, ArrayIdentityContext>,
     pub removed_trusted_dependencies: TrustedDependenciesSet,
 
     pub patched_dependencies_changed: bool,
@@ -1255,16 +1264,24 @@ impl Diff {
                 to_lockfile.trusted_dependencies.as_ref(),
             ) {
                 // added
-                for &to_trusted in to_trusted_dependencies.keys() {
+                for (&to_trusted, to_name) in to_trusted_dependencies.iter() {
                     if !from_trusted_dependencies.contains(&to_trusted) {
-                        summary.added_trusted_dependencies.put(to_trusted, true)?;
+                        summary.added_trusted_dependencies.put(
+                            to_trusted,
+                            AddedTrustedDependency {
+                                add_to_lockfile: true,
+                                name: to_name.clone(),
+                            },
+                        )?;
                     }
                 }
 
                 // removed
-                for &from_trusted in from_trusted_dependencies.keys() {
+                for (&from_trusted, from_name) in from_trusted_dependencies.iter() {
                     if !to_trusted_dependencies.contains(&from_trusted) {
-                        summary.removed_trusted_dependencies.put(from_trusted, ())?;
+                        summary
+                            .removed_trusted_dependencies
+                            .put(from_trusted, from_name.clone())?;
                     }
                 }
 
@@ -1283,16 +1300,22 @@ impl Diff {
                     {
                         // although this is a new trusted dependency, it is from the default
                         // list so it shouldn't be added to the lockfile
-                        summary
-                            .added_trusted_dependencies
-                            .put(entry.hash as TruncatedPackageNameHash, false)?;
+                        summary.added_trusted_dependencies.put(
+                            entry.hash as TruncatedPackageNameHash,
+                            AddedTrustedDependency {
+                                add_to_lockfile: false,
+                                name: Box::from(entry.key),
+                            },
+                        )?;
                     }
                 }
 
                 // removed
-                for &from_trusted in from_trusted_dependencies.keys() {
+                for (&from_trusted, from_name) in from_trusted_dependencies.iter() {
                     if !default_trusted_dependencies::has_with_hash(u64::from(from_trusted)) {
-                        summary.removed_trusted_dependencies.put(from_trusted, ())?;
+                        summary
+                            .removed_trusted_dependencies
+                            .put(from_trusted, from_name.clone())?;
                     }
                 }
 
@@ -1306,8 +1329,14 @@ impl Diff {
             ) {
                 // add all to trusted dependencies, even if they exist in default because they weren't in the
                 // lockfile originally
-                for &to_trusted in to_trusted_dependencies.keys() {
-                    summary.added_trusted_dependencies.put(to_trusted, true)?;
+                for (&to_trusted, to_name) in to_trusted_dependencies.iter() {
+                    summary.added_trusted_dependencies.put(
+                        to_trusted,
+                        AddedTrustedDependency {
+                            add_to_lockfile: true,
+                            name: to_name.clone(),
+                        },
+                    )?;
                 }
 
                 {
@@ -2468,7 +2497,7 @@ impl Package<u64> {
                                 .put_assume_capacity(
                                     semver::string::Builder::string_hash(name)
                                         as TruncatedPackageNameHash,
-                                    (),
+                                    Box::<[u8]>::from(name),
                                 );
                         }
                     }
@@ -2766,7 +2795,11 @@ impl Package<u64> {
         // PERF(port): was `inline for` — profile if hot.
         for group in &dependency_groups {
             if group.behavior.is_workspace() {
-                let mut seen_workspace_names = TrustedDependenciesSet::default();
+                let mut seen_workspace_names: ArrayHashMap<
+                    TruncatedPackageNameHash,
+                    (),
+                    ArrayIdentityContext,
+                > = ArrayHashMap::default();
                 // defer seen_workspace_names.deinit(allocator); — Drop handles it
                 for (entry, path_) in workspace_names
                     .values()

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -387,15 +387,9 @@ impl Stringifier {
                         if let Some(trusted_name) =
                             trusted_dependencies.get(&(dep.name_hash as TruncatedPackageNameHash))
                         {
-                            // Only persist the entry under this dependency's name when
-                            // the stored name matches; a truncated-hash collision must
-                            // not launder a different alias into the lockfile. The
-                            // `is_empty()` arm exists for entries loaded from a legacy
-                            // bun.lockb (no name stored): it persists that hash-only
-                            // grant under the colliding graph dep's name when migrating
-                            // bun.lockb -> bun.lock, preserving today's migration
-                            // behavior so existing binary-lockfile projects don't
-                            // silently lose trusted entries.
+                            // The `is_empty()` arm keeps hash-only entries from a
+                            // legacy bun.lockb (no name stored) when migrating to
+                            // bun.lock.
                             if trusted_name.is_empty() || **trusted_name == *dep.name.slice(buf) {
                                 found_trusted_dependencies.insert(dep.name_hash, dep.name);
                             }
@@ -1552,11 +1546,8 @@ pub fn parse_into_binary_lockfile(
                 log.add_error(Some(source), dep.loc, b"Expected a string");
                 return Err(ParseError::InvalidTrustedDependenciesSet);
             };
-            // Store the exact bytes the hash is computed from so trust lookups
-            // can confirm the name instead of relying on the truncated hash
-            // alone. JSON-parsed strings are always UTF-8; the UTF-16 arm is
-            // kept for the unreachable branch (transcode so the stored name
-            // and the hash agree).
+            // JSON-parsed strings are always UTF-8; the UTF-16 arm is kept for
+            // the unreachable branch so the stored name and the hash agree.
             let name: Box<[u8]> = if s.is_utf8() {
                 Box::from(s.slice8())
             } else {

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -384,10 +384,21 @@ impl Stringifier {
 
                     // intentionally not checking default trusted dependencies
                     if let Some(trusted_dependencies) = &lockfile.trusted_dependencies {
-                        if trusted_dependencies
-                            .contains(&(dep.name_hash as TruncatedPackageNameHash))
+                        if let Some(trusted_name) =
+                            trusted_dependencies.get(&(dep.name_hash as TruncatedPackageNameHash))
                         {
-                            found_trusted_dependencies.insert(dep.name_hash, dep.name);
+                            // Only persist the entry under this dependency's name when
+                            // the stored name matches; a truncated-hash collision must
+                            // not launder a different alias into the lockfile. The
+                            // `is_empty()` arm exists for entries loaded from a legacy
+                            // bun.lockb (no name stored): it persists that hash-only
+                            // grant under the colliding graph dep's name when migrating
+                            // bun.lockb -> bun.lock, preserving today's migration
+                            // behavior so existing binary-lockfile projects don't
+                            // silently lose trusted entries.
+                            if trusted_name.is_empty() || **trusted_name == *dep.name.slice(buf) {
+                                found_trusted_dependencies.insert(dep.name_hash, dep.name);
+                            }
                         }
                     }
                 }
@@ -1537,14 +1548,28 @@ pub fn parse_into_binary_lockfile(
             .items
             .slice()
         {
-            if !dep.is_string() {
+            let ExprData::EString(s) = &dep.data else {
                 log.add_error(Some(source), dep.loc, b"Expected a string");
                 return Err(ParseError::InvalidTrustedDependenciesSet);
+            };
+            // Store the exact bytes the hash is computed from so trust lookups
+            // can confirm the name instead of relying on the truncated hash
+            // alone. JSON-parsed strings are always UTF-8; keep the UTF-16
+            // fallback from `as_string_hash_utf8` for the unreachable branch
+            // (transcode so the stored name and the hash agree).
+            if s.is_utf8() {
+                let name = s.slice8();
+                let name_hash: TruncatedPackageNameHash =
+                    StringBuilder::string_hash(name) as TruncatedPackageNameHash;
+                trusted_dependencies.insert(name_hash, Box::from(name));
+            } else {
+                debug_assert!(false, "trustedDependencies: UTF-16 EString from JSON parser");
+                let bump = bun_alloc::Arena::new();
+                let name = s.string(&bump)?;
+                let name_hash: TruncatedPackageNameHash =
+                    StringBuilder::string_hash(name) as TruncatedPackageNameHash;
+                trusted_dependencies.insert(name_hash, Box::from(name));
             }
-            let name_hash: TruncatedPackageNameHash =
-                dep.as_string_hash_utf8(StringBuilder::string_hash)?
-                    .unwrap() as TruncatedPackageNameHash;
-            trusted_dependencies.insert(name_hash, ());
         }
 
         lockfile.trusted_dependencies = Some(trusted_dependencies);

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -1563,7 +1563,10 @@ pub fn parse_into_binary_lockfile(
                     StringBuilder::string_hash(name) as TruncatedPackageNameHash;
                 trusted_dependencies.insert(name_hash, Box::from(name));
             } else {
-                debug_assert!(false, "trustedDependencies: UTF-16 EString from JSON parser");
+                debug_assert!(
+                    false,
+                    "trustedDependencies: UTF-16 EString from JSON parser"
+                );
                 let bump = bun_alloc::Arena::new();
                 let name = s.string(&bump)?;
                 let name_hash: TruncatedPackageNameHash =

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -1554,25 +1554,21 @@ pub fn parse_into_binary_lockfile(
             };
             // Store the exact bytes the hash is computed from so trust lookups
             // can confirm the name instead of relying on the truncated hash
-            // alone. JSON-parsed strings are always UTF-8; keep the UTF-16
-            // fallback from `as_string_hash_utf8` for the unreachable branch
-            // (transcode so the stored name and the hash agree).
-            if s.is_utf8() {
-                let name = s.slice8();
-                let name_hash: TruncatedPackageNameHash =
-                    StringBuilder::string_hash(name) as TruncatedPackageNameHash;
-                trusted_dependencies.insert(name_hash, Box::from(name));
+            // alone. JSON-parsed strings are always UTF-8; the UTF-16 arm is
+            // kept for the unreachable branch (transcode so the stored name
+            // and the hash agree).
+            let name: Box<[u8]> = if s.is_utf8() {
+                Box::from(s.slice8())
             } else {
                 debug_assert!(
                     false,
                     "trustedDependencies: UTF-16 EString from JSON parser"
                 );
-                let bump = bun_alloc::Arena::new();
-                let name = s.string(&bump)?;
-                let name_hash: TruncatedPackageNameHash =
-                    StringBuilder::string_hash(name) as TruncatedPackageNameHash;
-                trusted_dependencies.insert(name_hash, Box::from(name));
-            }
+                strings::to_utf8_alloc(s.slice16()).into_boxed_slice()
+            };
+            let name_hash: TruncatedPackageNameHash =
+                StringBuilder::string_hash(&name) as TruncatedPackageNameHash;
+            trusted_dependencies.insert(name_hash, name);
         }
 
         lockfile.trusted_dependencies = Some(trusted_dependencies);

--- a/src/install/lockfile/bun.lockb.rs
+++ b/src/install/lockfile/bun.lockb.rs
@@ -521,15 +521,12 @@ pub fn load(
                 lockfile.trusted_dependencies = Some(Default::default());
                 let td = lockfile.trusted_dependencies.as_mut().unwrap();
                 td.ensure_total_capacity(trusted_dependencies_hashes.len())?;
-
-                // SAFETY: capacity reserved above; keys are fully overwritten
-                // by `copy_from_slice` before `re_index` reads them; value type
-                // is `()` so its column needs no init.
-                unsafe {
-                    td.set_entries_len(trusted_dependencies_hashes.len());
+                // The binary lockfile only stores the truncated hashes, not the
+                // names they were computed from. The empty value is the
+                // "name unknown, hash-only match" sentinel.
+                for &hash in &trusted_dependencies_hashes {
+                    td.put_assume_capacity(hash, Box::<[u8]>::default());
                 }
-                td.keys_mut().copy_from_slice(&trusted_dependencies_hashes);
-                td.re_index()?;
             } else if next_num == HAS_EMPTY_TRUSTED_DEPENDENCIES_TAG {
                 // trusted dependencies exists in package.json but is an empty array.
                 lockfile.trusted_dependencies = Some(Default::default());

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -637,7 +637,7 @@ impl TrustCommand {
                     .put(
                         bun_semver::string::Builder::string_hash(name)
                             as install::TruncatedPackageNameHash,
-                        (),
+                        Box::<[u8]>::from(&**name),
                     )?;
             }
         }

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -1991,6 +1991,100 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       expect(await exists(join(packageDir, "node_modules", "esbuild", "postinstall-ran.txt"))).toBeTrue();
     });
 
+    test("trustedDependencies entry must match by name, not truncated hash", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
+      const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
+
+      // Trusted-dependency lookups are keyed by `Wyhash11::hash(0, name) as u32`
+      // (the legacy 32-byte-round wyhash used by `String.Builder.string_hash`,
+      // NOT `Bun.hash.wyhash`). These two distinct names share the truncated
+      // 32-bit hash 0x6c4a82d1; they were found by an offline birthday search
+      // over `pkg-<base36>` candidates against that exact hash function.
+      const trustedName = "pkg-xjd";
+      const colliderName = "pkg-ztd";
+
+      const colliderPath = join(packageDir, "collider");
+      await mkdir(colliderPath, { recursive: true });
+      await writeFile(
+        join(colliderPath, "package.json"),
+        JSON.stringify({
+          name: colliderName,
+          version: "1.0.0",
+          scripts: {
+            postinstall: `${bunExe()} -e "require('fs').writeFileSync('postinstall-ran.txt', 'ran')"`,
+          },
+        }),
+      );
+
+      await writeFile(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          version: "1.0.0",
+          dependencies: {
+            [colliderName]: "file:./collider",
+          },
+          // Trusts a *different* name whose truncated hash collides with the
+          // collider's. The collider's postinstall must NOT run.
+          trustedDependencies: [trustedName],
+        }),
+      );
+
+      let { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env: testEnv,
+      });
+
+      let err = await stderr.text();
+      let out = await stdout.text();
+      expect(err).toContain("Saved lockfile");
+      expect(err).not.toContain("error:");
+      expect(out).toContain("Blocked 1 postinstall");
+      expect(await exited).toBe(0);
+
+      expect(await exists(join(packageDir, "node_modules", colliderName))).toBeTrue();
+      expect(await exists(join(packageDir, "node_modules", colliderName, "postinstall-ran.txt"))).toBeFalse();
+
+      // Trusting the collider by its exact name still grants trust to the same
+      // package. Start from a clean slate so this is a plain install with a
+      // matching trustedDependencies entry.
+      await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+      await rm(join(packageDir, "bun.lock"), { force: true });
+      await writeFile(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          version: "1.0.0",
+          dependencies: {
+            [colliderName]: "file:./collider",
+          },
+          trustedDependencies: [colliderName],
+        }),
+      );
+
+      ({ stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env: testEnv,
+      }));
+
+      err = await stderr.text();
+      out = await stdout.text();
+      expect(err).not.toContain("error:");
+      expect(out).not.toContain("Blocked");
+      expect(await exited).toBe(0);
+
+      expect(await exists(join(packageDir, "node_modules", colliderName, "postinstall-ran.txt"))).toBeTrue();
+    });
+
     test("will run default trustedDependencies after install that didn't include them", async () => {
       using ctx = await setupTest();
       const { packageDir, packageJson, env } = ctx;
@@ -2134,6 +2228,75 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           await exists(join(packageDir, "node_modules", "pkg1", "node_modules", "uses-what-bin", "what-bin.txt")),
         ).toBeTrue();
       });
+
+      test("must not trust a truncated-hash collision in the trusted subtree", async () => {
+        using ctx = await setupTest();
+        const { packageDir, packageJson, env } = ctx;
+        const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
+
+        // `--trust` collects the trusted subtree into a set keyed by
+        // `Wyhash11::hash(0, name) as u32` (the legacy 32-byte-round wyhash
+        // used by `String.Builder.string_hash`). "pkg-jodsufb" was found by an
+        // offline targeted search over `pkg-<base36>` candidates so that its
+        // truncated hash equals hash32("uses-what-bin") == 0x9f4d06e5.
+        const colliderName = "pkg-jodsufb";
+
+        const colliderPath = join(packageDir, "collider2");
+        await mkdir(colliderPath, { recursive: true });
+        await writeFile(
+          join(colliderPath, "package.json"),
+          JSON.stringify({
+            name: colliderName,
+            version: "1.0.0",
+            scripts: {
+              postinstall: `${bunExe()} -e "require('fs').writeFileSync('postinstall-ran.txt', 'ran')"`,
+            },
+          }),
+        );
+
+        await writeFile(
+          packageJson,
+          JSON.stringify({
+            name: "foo",
+            dependencies: {
+              [colliderName]: "file:./collider2",
+            },
+          }),
+        );
+
+        const { stdout, stderr, exited } = spawn({
+          cmd: [bunExe(), "i", "--trust", "uses-what-bin@1.0.0"],
+          cwd: packageDir,
+          stdout: "pipe",
+          stderr: "pipe",
+          stdin: "ignore",
+          env: testEnv,
+        });
+
+        const err = await stderr.text();
+        const out = await stdout.text();
+        expect(err).toContain("Saved lockfile");
+        expect(err).not.toContain("error:");
+        expect(await exited).toBe(0);
+
+        // The package that was actually trusted ran its scripts...
+        expect(await exists(join(packageDir, "node_modules", "uses-what-bin", "what-bin.txt"))).toBeTrue();
+        // ...the hash-colliding package did not.
+        expect(await exists(join(packageDir, "node_modules", colliderName, "postinstall-ran.txt"))).toBeFalse();
+
+        // Only the name passed to --trust is written back to package.json.
+        const pkgJson = await file(packageJson).json();
+        expect(pkgJson.trustedDependencies).toEqual(["uses-what-bin"]);
+
+        // The colliding alias is not persisted into the lockfile's
+        // trustedDependencies either.
+        const lockfile = await file(join(packageDir, "bun.lock")).text();
+        const trusted = lockfile.match(/"trustedDependencies":\s*\[([^\]]*)\]/);
+        expect(trusted).not.toBeNull();
+        expect(trusted![1]).toContain('"uses-what-bin"');
+        expect(trusted![1]).not.toContain(colliderName);
+      });
+
       const trustTests = [
         {
           label: "only name",


### PR DESCRIPTION
Trusted-dependency membership checks (`trustedDependencies`, the `--trust` subtree, and the install diff summary) keyed only on a truncated 32-bit name hash. This change stores the exact name each entry was registered under as the map value and requires it to match at every lookup, mirroring what the default trusted-dependencies list already does. Entries loaded from a legacy binary `bun.lockb` have no stored name and keep matching by hash alone, so existing projects are unaffected.

Adds two tests to `bun-install-lifecycle-scripts.test.ts` using precomputed truncated-hash collisions: one for a `trustedDependencies` entry whose hash collides with a different dependency's name, and one for a `--trust` install with a colliding sibling dependency. Both verify the colliding package's scripts stay blocked and that only the intended name is written back to package.json and bun.lock.