### PR TITLE
bun:test: fix SIGSEGV when constructing an expect.extend() matcher

### DIFF
--- a/src/jsc/bindings/JSWrappingFunction.cpp
+++ b/src/jsc/bindings/JSWrappingFunction.cpp
@@ -29,7 +29,9 @@ JS_EXPORT_PRIVATE JSWrappingFunction* JSWrappingFunction::create(
 
     auto nameStr = symbolName->tag == BunStringTag::Empty ? WTF::emptyString() : symbolName->toWTFString();
     auto name = Identifier::fromString(vm, nameStr);
-    NativeExecutable* executable = vm.getHostFunction(functionPointer, ImplementationVisibility::Public, nullptr, nameStr);
+    // Pass callHostFunctionAsConstructor so `new` on the wrapper throws a
+    // TypeError instead of jumping to a null native constructor.
+    NativeExecutable* executable = vm.getHostFunction(functionPointer, ImplementationVisibility::Public, callHostFunctionAsConstructor, nameStr);
 
     // Structure* structure = globalObject->FFIFunctionStructure();
     Structure* structure = JSWrappingFunction::createStructure(vm, globalObject, globalObject->objectPrototype());

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1762,7 +1762,11 @@ JSC_DEFINE_HOST_FUNCTION(jsBunPokePromiseAsHandled, (JSGlobalObject*, CallFrame*
 extern "C" JSC::EncodedJSValue Bun__Jest__createTestModuleObject(JSC::JSGlobalObject*);
 extern "C" JSC::EncodedJSValue Bun__Jest__testModuleObject(Zig::GlobalObject* globalObject)
 {
-    return JSValue::encode(globalObject->lazyTestModuleObject());
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSC::JSObject* object = globalObject->lazyTestModuleObject();
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(object);
 }
 
 extern "C" napi_env ZigGlobalObject__makeNapiEnvForFFI(Zig::GlobalObject* globalObject)
@@ -1992,7 +1996,14 @@ void GlobalObject::finishCreation(VM& vm)
             JSC::JSGlobalObject* globalObject = init.owner;
 
             JSValue result = JSValue::decode(Bun__Jest__createTestModuleObject(globalObject));
-            init.set(result.toObject(globalObject));
+            JSObject* object = result.isEmpty() ? nullptr : result.getObject();
+            if (!object) [[unlikely]] {
+                // Creation failed and left an exception pending; cache a plain
+                // object so the LazyProperty stays valid instead of crashing on
+                // an empty JSValue.
+                object = JSC::constructEmptyObject(globalObject);
+            }
+            init.set(object);
         });
 
     m_testMatcherUtilsObject.initLater(

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -365,16 +365,13 @@ pub mod Jest {
         )?;
         module.put(global_object, b"describe", describe_scope_functions);
 
-        let xdescribe_scope_functions = match create_bound(
+        let xdescribe_scope_functions = create_bound(
             global_object,
             ScopeKind::Describe,
             JSValue::ZERO,
             BaseScopeCfg { self_mode: ScopeMode::Skip, ..Default::default() },
             scope_strings::XDESCRIBE(),
-        ) {
-            Ok(v) => v,
-            Err(_) => return Ok(JSValue::ZERO),
-        };
+        )?;
         module.put(global_object, b"xdescribe", xdescribe_scope_functions);
 
         // `#[bun_jsc::host_fn]` emits a `__jsc_host_{name}` shim with the raw
@@ -497,7 +494,7 @@ pub mod Jest {
             }
         }
 
-        Ok(Bun__Jest__testModuleObject(global_object))
+        jsc::from_js_host_call(global_object, || Bun__Jest__testModuleObject(global_object))
     }
 
     #[bun_jsc::host_fn]

--- a/test/js/bun/test/bun-test.test.ts
+++ b/test/js/bun/test/bun-test.test.ts
@@ -19,18 +19,20 @@ test("Bun.jest() expect statics do not crash on misuse", async () => {
     cmd: [
       bunExe(),
       "-e",
-      `
-      const jestExpect = Bun.jest().expect;
-      try { jestExpect.extend(); } catch {}
-      const arrayContaining = jestExpect.arrayContaining;
-      try { new arrayContaining(); } catch (e) { if (!(e instanceof TypeError)) throw e; }
-      Bun.gc(true);
-    `,
+      `const jestExpect = Bun.jest().expect;
+try { jestExpect.extend(); } catch {}
+const arrayContaining = jestExpect.arrayContaining;
+try { new arrayContaining(); } catch (e) { if (!(e instanceof TypeError)) throw e; }
+Bun.gc(true);
+console.log("OK");`,
     ],
     env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
   });
 
-  const exitCode = await proc.exited;
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  expect(stdout).toBe("OK\n");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/test/bun-test.test.ts
+++ b/test/js/bun/test/bun-test.test.ts
@@ -13,13 +13,18 @@ test("expect().not.not", () => {
 });
 
 // Fuzzer-found crash: Bun.jest() without an active test runner, followed by
-// misuse of the expect statics, must not crash the process.
+// misuse of the expect statics, must not crash the process. In particular,
+// `new` on a matcher registered via expect.extend() used to jump to a null
+// native constructor and SIGSEGV.
 test("Bun.jest() expect statics do not crash on misuse", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
       `const jestExpect = Bun.jest().expect;
+jestExpect.extend({ customMatcher() { return { pass: true, message: () => "" }; } });
+try { new jestExpect.customMatcher(); } catch (e) { if (!(e instanceof TypeError)) throw e; }
+try { new (jestExpect(1).customMatcher)(); } catch (e) { if (!(e instanceof TypeError)) throw e; }
 try { jestExpect.extend(); } catch {}
 const arrayContaining = jestExpect.arrayContaining;
 try { new arrayContaining(); } catch (e) { if (!(e instanceof TypeError)) throw e; }

--- a/test/js/bun/test/bun-test.test.ts
+++ b/test/js/bun/test/bun-test.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 test("Bun.version", () => {
   expect(process.versions.bun).toBe(Bun.version);
@@ -9,4 +10,27 @@ test("expect().not.not", () => {
   // bun supports this but jest doesn't
   expect(1).not.not.toBe(1);
   expect(1).not.not.not.toBe(2);
+});
+
+// Fuzzer-found crash: Bun.jest() without an active test runner, followed by
+// misuse of the expect statics, must not crash the process.
+test("Bun.jest() expect statics do not crash on misuse", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const jestExpect = Bun.jest().expect;
+      try { jestExpect.extend(); } catch {}
+      const arrayContaining = jestExpect.arrayContaining;
+      try { new arrayContaining(); } catch (e) { if (!(e instanceof TypeError)) throw e; }
+      Bun.gc(true);
+    `,
+    ],
+    env: bunEnv,
+  });
+
+  const exitCode = await proc.exited;
+
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-reported SIGSEGV (fingerprint `a8d2694be898a53f`) in the `Bun.jest()` / `expect` statics area. The reported reproducer exercises `Bun.jest().expect`, `expect.extend()`, and `new` on an expect static:

```js
const v2 = Bun.jest().expect;
try { v2.extend(); } catch (e) {}
const t6 = v2.arrayContaining;
new t6();
Bun.gc(true);
```

**Root cause (primary fix):** matchers registered through `expect.extend()` are wrapped in `JSWrappingFunction`. `JSWrappingFunction::create` passed `nullptr` as the native constructor to `VM::getHostFunction`. JSC only treats `callHostFunctionAsConstructor` as "not constructible", so the wrapper was considered constructible with a null native constructor — `new expect.someCustomMatcher()` jumps straight to address 0:

```
Thread 1 received signal SIGSEGV, Segmentation fault.
#0  0x0000000000000000 in ?? ()
#3  llint_op_construct ()
```

Deterministic repro (crashes on current main, raw SIGSEGV with no output — matching the fuzzer's crash signature):

```js
const e = Bun.jest().expect;
e.extend({ myMatcher() { return { pass: true, message: () => "" }; } });
new e.myMatcher();
```

The fix passes `callHostFunctionAsConstructor` so `new` on a wrapped matcher throws `TypeError: function is not a constructor` like other native functions.

**Secondary hardening (same area):** if `Bun__Jest__createTestModuleObject` ever fails it returns an empty `JSValue`, and the `m_lazyTestModuleObject` initializer called `toObject()` on it — a null-cell dereference. The initializer now falls back to a plain object, `Bun__Jest__testModuleObject` surfaces the pending exception, `Bun.jest()` maps it to a thrown JS error, and the `xdescribe` arm of `create_test_module` propagates its error instead of returning an empty value as success.

### How did you verify your code works?

- `new (expect.extend-registered matcher)()` segfaults on the baked build and throws a `TypeError` with this change.
- Regression test added to `test/js/bun/test/bun-test.test.ts`: it spawns a subprocess that registers a custom matcher, constructs it (plus the original fuzzer shape: `extend()` with no args, `new expect.arrayContaining`), runs `Bun.gc(true)`, and asserts a clean exit. The test fails on the baked build (`USE_SYSTEM_BUN=1`) with the subprocess dying from SIGSEGV, and passes with this change.
- `bun bd test` on `bun-test.test.ts`, `expect-extend.test.js`, `jest-extended.test.js`, `expect-extend-asymmetric-match-throw.test.ts`, `expect-extend-preload.test.ts`, `describe.test.ts`, `jest-each.test.ts`, `expect-symbol-toPrimitive-crash.test.ts` — all pass.
