### PR TITLE
shell: only template-literal glob tokens act as pattern syntax

### DIFF
--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -471,7 +471,10 @@ fn match_brace(
                 }
             }
             b',' => {
-                if brace_depth == 1 {
+                // A comma inside a `[...]` character class is a class member,
+                // not a branch separator — same `!in_brackets` guard as the
+                // `{`/`}` arms above.
+                if brace_depth == 1 && !in_brackets {
                     if match_brace_branch(
                         state,
                         glob,

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -31,12 +31,13 @@ pub struct Expansion {
     /// boundary is hit (IFS split / glob result), it is flushed into `out`
     /// via `push_current_out`. Spec: Expansion.zig `current_out`.
     pub current_out: Vec<u8>,
-    /// Byte offsets in `current_out` written by literal `BraceBegin`/`Comma`/
-    /// `BraceEnd` atoms. Only these positions may act as brace-expansion
-    /// metacharacters in `do_brace_expand`; `{`/`,`/`}` bytes from any other
-    /// source (JS interpolation, quoted text, `$var`, command substitution)
-    /// are data and must not change the expansion structure.
-    pub brace_meta_offsets: Vec<u32>,
+    /// Byte offsets in `current_out` written by literal metacharacter atoms
+    /// (`Asterisk`/`DoubleAsterisk`/`BraceBegin`/`Comma`/`BraceEnd`). Only
+    /// these positions may act as pattern syntax in `do_brace_expand` or
+    /// `transition_to_glob_state`; metacharacter bytes from any other source
+    /// (JS interpolation, quoted text, `$var`, command substitution) are data
+    /// and must not change the expansion structure or broaden the glob.
+    pub meta_offsets: Vec<u32>,
     pub child_script: Option<NodeId>,
     /// Whether the in-flight command substitution was `"$(...)"` (no IFS
     /// splitting on its result). Only meaningful while `state == CmdSubst`.
@@ -110,7 +111,7 @@ impl Expansion {
             word_idx: 0,
             out: ExpansionOut::default(),
             current_out: Vec::new(),
-            brace_meta_offsets: Vec::new(),
+            meta_offsets: Vec::new(),
             child_script: None,
             cmd_subst_quoted: false,
             has_quoted_empty: false,
@@ -186,7 +187,7 @@ impl Expansion {
                     shell,
                     simple,
                     &mut me.current_out,
-                    &mut me.brace_meta_offsets,
+                    &mut me.meta_offsets,
                     &mut me.has_quoted_empty,
                     true,
                     event_loop,
@@ -248,11 +249,11 @@ impl Expansion {
                 // The first two arms prepend; shift the recorded brace
                 // metacharacter offsets so they keep pointing at the same
                 // bytes. The `extend_from_slice` arm only runs when
-                // `current_out` (and therefore `brace_meta_offsets`) is
+                // `current_out` (and therefore `meta_offsets`) is
                 // empty, so the shift is a no-op there.
                 let prepended = (me.current_out.len() - len_before) as u32;
                 if prepended != 0 {
-                    for off in &mut me.brace_meta_offsets {
+                    for off in &mut me.meta_offsets {
                         *off += prepended;
                     }
                 }
@@ -284,17 +285,17 @@ impl Expansion {
     /// `expand_simple_no_io`) and push each variant as a separate argv word.
     fn do_brace_expand(me: &mut Expansion) {
         use bun_shell_parser::braces;
-        // Only the `{`/`,`/`}` bytes recorded in `brace_meta_offsets` (written
+        // Only the `{`/`,`/`}` bytes recorded in `meta_offsets` (written
         // by literal BraceBegin/Comma/BraceEnd atoms) are brace-expansion
         // metacharacters. Bytes from Text/Var/cmd-subst expansion — notably JS
         // `${...}` interpolations — are data: backslash-escape them so the
         // brace lexer cannot be steered into emitting extra argv words.
+        // (`meta_offsets` also records literal `*`/`**` positions for the glob
+        // path; those are inert here since `*` is not in the escape set.)
         let mut escaped: Vec<u8> = Vec::with_capacity(me.current_out.len());
         let mut next_meta = 0usize;
         for (i, &b) in me.current_out.iter().enumerate() {
-            if next_meta < me.brace_meta_offsets.len()
-                && me.brace_meta_offsets[next_meta] as usize == i
-            {
+            if next_meta < me.meta_offsets.len() && me.meta_offsets[next_meta] as usize == i {
                 next_meta += 1;
             } else if matches!(b, b'{' | b'}' | b',' | b'\\') {
                 escaped.push(b'\\');
@@ -357,6 +358,49 @@ impl Expansion {
         }
     }
 
+    /// Build the pattern handed to the glob walker from `current_out`,
+    /// neutralizing every glob metacharacter byte that was *not* written by a
+    /// literal metacharacter atom (those positions are recorded in
+    /// `meta_offsets`). Metacharacters arriving via JS `${...}` interpolation,
+    /// `$var`, command substitution, or quoted text are data and must not be
+    /// able to broaden the match. Mirrors `do_brace_expand`'s escaping loop,
+    /// but the glob matcher has no general backslash-escape that survives
+    /// `build_pattern_components` on every platform, so each byte is wrapped
+    /// in a single-character class (`[c]`) — or a one-branch brace group for
+    /// `!` — which the matcher provably treats as that literal character.
+    /// `current_out` itself is not mutated: the no-match error message and the
+    /// assignment-position literal fallback keep using the original word.
+    fn neutralize_glob_metachars(current_out: &[u8], meta_offsets: &[u32]) -> Vec<u8> {
+        let mut pattern: Vec<u8> = Vec::with_capacity(current_out.len());
+        let mut next_meta = 0usize;
+        for (i, &b) in current_out.iter().enumerate() {
+            if next_meta < meta_offsets.len() && meta_offsets[next_meta] as usize == i {
+                next_meta += 1;
+                pattern.push(b);
+                continue;
+            }
+            match b {
+                // `[c]` is a single-character class containing only `c`.
+                b'*' | b'?' | b'[' | b']' | b'{' | b'}' | b',' => {
+                    pattern.extend_from_slice(&[b'[', b, b']']);
+                }
+                // `[!]`/`[^]` would be a negated class and a bare leading `!`
+                // flips the matcher's negation loop, so wrap `!` in a
+                // one-branch brace group whose sole branch is the literal `!`.
+                b'!' => pattern.extend_from_slice(b"{!}"),
+                // `[\\]` is a class containing an escaped `\`; the 3-byte
+                // `[\]` would mis-parse as a class containing an escaped `]`.
+                #[cfg(not(windows))]
+                b'\\' => pattern.extend_from_slice(b"[\\\\]"),
+                // On Windows `\` is a native path separator (same pass-through
+                // policy as `/`); wrapping it would let the component splitter
+                // cut the synthesized brackets apart.
+                _ => pattern.push(b),
+            }
+        }
+        pattern
+    }
+
     /// Spec: Expansion.zig `transitionToGlobState`. Kick off an off-thread
     /// glob walk for the assembled pattern in `current_out`.
     fn transition_to_glob_state(interp: &Interpreter, this: NodeId) -> Yield {
@@ -366,7 +410,7 @@ impl Expansion {
         {
             let me = interp.as_expansion_mut(this);
             me.state = ExpansionState::Glob;
-            pattern = me.current_out.clone();
+            pattern = Self::neutralize_glob_metachars(&me.current_out, &me.meta_offsets);
             cwd = me.base.shell().cwd().to_vec();
         }
         let walker = match bun_glob::BunGlobWalkerZ::init_with_cwd(
@@ -396,7 +440,7 @@ impl Expansion {
         shell: &ShellExecEnv,
         atom: &ast::SimpleAtom,
         out: &mut Vec<u8>,
-        brace_meta_offsets: &mut Vec<u32>,
+        meta_offsets: &mut Vec<u32>,
         has_quoted_empty: &mut bool,
         expand_tilde: bool,
         event_loop: EventLoopHandle,
@@ -429,18 +473,27 @@ impl Expansion {
                 // SAFETY: `command_ctx` is the live VM ctx; `vm_args_utf8` borrows it.
                 Interpreter::append_var_argv(out, *int, event_loop, command_ctx, vm_args_utf8);
             }
-            ast::SimpleAtom::Asterisk => out.push(b'*'),
-            ast::SimpleAtom::DoubleAsterisk => out.extend_from_slice(b"**"),
+            ast::SimpleAtom::Asterisk => {
+                meta_offsets.push(out.len() as u32);
+                out.push(b'*');
+            }
+            ast::SimpleAtom::DoubleAsterisk => {
+                // Both bytes must be recorded or `neutralize_glob_metachars`
+                // would wrap the second `*`, breaking `**`.
+                meta_offsets.push(out.len() as u32);
+                meta_offsets.push(out.len() as u32 + 1);
+                out.extend_from_slice(b"**");
+            }
             ast::SimpleAtom::BraceBegin => {
-                brace_meta_offsets.push(out.len() as u32);
+                meta_offsets.push(out.len() as u32);
                 out.push(b'{');
             }
             ast::SimpleAtom::BraceEnd => {
-                brace_meta_offsets.push(out.len() as u32);
+                meta_offsets.push(out.len() as u32);
                 out.push(b'}');
             }
             ast::SimpleAtom::Comma => {
-                brace_meta_offsets.push(out.len() as u32);
+                meta_offsets.push(out.len() as u32);
                 out.push(b',');
             }
             ast::SimpleAtom::Tilde => {
@@ -466,7 +519,7 @@ impl Expansion {
             me.out.bounds.push(me.out.buf.len() as u32);
         }
         me.out.buf.append(&mut me.current_out);
-        me.brace_meta_offsets.clear();
+        me.meta_offsets.clear();
     }
 
     /// Spec: Expansion.zig `postSubshellExpansion` + `convertNewlinesToSpaces`.

--- a/test/js/bun/glob/match.test.ts
+++ b/test/js/bun/glob/match.test.ts
@@ -83,6 +83,15 @@ describe("Glob.match", () => {
     expect(glob.match("src/foo/nice/bar/baz/lmao.ts")).toBeTrue();
   });
 
+  test("comma inside a bracket class inside braces is not a branch separator", () => {
+    // `[,]` is a single-character class containing a literal comma, so the
+    // group has three branches: `ts`, `[,]foo`, and nothing after — not a
+    // spurious `]foo` branch split off at the class-interior comma.
+    expect(new Glob("x.{ts,[,]foo}").match("x.,foo")).toBeTrue();
+    expect(new Glob("x.{ts,[,]foo}").match("x.]foo")).toBeFalse();
+    expect(new Glob("x.{ts,[,]foo}").match("x.ts")).toBeTrue();
+  });
+
   test("no early globstar lock-in", () => {
     // see https://github.com/oven-sh/bun/issues/14934
     expect(new Glob(`**/*abc*`).match(`a/abc`)).toBeTrue();

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -109,4 +109,21 @@ describe("brace + glob composition", () => {
     expect(words).toContain("src/a.ts");
     expect(words).toContain("lib/b.ts");
   });
+
+  test("an interpolated comma inside a brace group is one literal branch", async () => {
+    using dir = tempDir("shell-brace-glob3", {
+      "x.ts": "",
+      "x.,foo": "",
+      "x.]foo": "",
+    });
+    // `echo` rather than `ls`: the literal brace variants (`*.ts`, `*.,foo`)
+    // are also emitted as argv words and do not exist as files.
+    const out = (await $`echo *.{ts,${",foo"}}`.cwd(String(dir)).text()).trim();
+    const words = out.split(" ");
+    expect(words).toContain("x.ts");
+    // The interpolated `,foo` is matched as a single literal branch...
+    expect(words).toContain("x.,foo");
+    // ...and does not split into a spurious `]foo` branch.
+    expect(words).not.toContain("x.]foo");
+  });
 });

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -696,6 +696,75 @@ booga"
         expect(sortedShellOutput(out)).toEqual(sortedShellOutput("foo.js\nbar.js\n"));
       })
       .runAsTest("Should work with a different cwd");
+
+    describe("interpolated values cannot inject glob syntax", () => {
+      // Only `*`/`**` written literally in the template act as glob syntax.
+      // Metacharacters arriving via `${...}` interpolation are data and must
+      // match only files containing them literally.
+      TestBuilder.command`echo ${"**/"}*`
+        .ensureTempDir()
+        .file("f.txt", "f")
+        .directory("sub")
+        .file("sub/deep.txt", "deep")
+        .exitCode(1)
+        .stderr("bun: no matches found: **/*\n")
+        .runAsTest("injected ** does not recurse");
+
+      TestBuilder.command`echo a${"?"}*`
+        .ensureTempDir()
+        .file("ax.txt", "ax")
+        .exitCode(1)
+        .stderr("bun: no matches found: a?*\n")
+        .runAsTest("injected ? is literal");
+
+      TestBuilder.command`echo ${"!keep"}*`
+        .ensureTempDir()
+        .file("keep.txt", "")
+        .file("other.txt", "")
+        .file("!keep1.txt", "")
+        .stdout(out => {
+          expect(out).toContain("!keep1.txt");
+          expect(out).not.toContain("other.txt");
+          // `!keep1.txt` does not contain the substring `keep.txt`, so this
+          // asserts the un-negated `keep.txt` fixture was not matched.
+          expect(out).not.toContain("keep.txt");
+        })
+        .runAsTest("injected leading ! does not negate");
+
+      TestBuilder.command`echo a${"[bc]"}*`
+        .ensureTempDir()
+        .file("ab.txt", "")
+        .file("ac.txt", "")
+        .file("a[bc].txt", "")
+        .stdout(out => {
+          expect(out).toContain("a[bc].txt");
+          expect(out).not.toContain("ab.txt");
+          expect(out).not.toContain("ac.txt");
+        })
+        .runAsTest("injected [...] is literal");
+
+      TestBuilder.command`echo ${"foo"}*`
+        .ensureTempDir()
+        .file("foo1.txt", "")
+        .file("foo2.txt", "")
+        .file("bar.txt", "")
+        .stdout(out => {
+          expect(out).toContain("foo1.txt");
+          expect(out).toContain("foo2.txt");
+          expect(out).not.toContain("bar.txt");
+        })
+        .runAsTest("plain interpolation followed by a literal * still globs");
+
+      TestBuilder.command`echo **/*.txt`
+        .ensureTempDir()
+        .file("a.txt", "")
+        .directory("sub")
+        .file("sub/b.txt", "")
+        .stdout(out => {
+          expect(out.replaceAll("\\", "/")).toContain("sub/b.txt");
+        })
+        .runAsTest("literal ** still recurses");
+    });
   });
 
   describe("brace expansion", () => {


### PR DESCRIPTION
Bun Shell treats `${...}` interpolated values as inert single arguments. The brace-expansion path already enforces this by recording which `{`/`,`/`}` bytes came from literal template atoms and escaping the rest, but the glob path handed the assembled word to the glob walker verbatim — so glob metacharacters arriving via interpolation, `$var`, command substitution, or quoted text were interpreted as pattern syntax whenever the word also contained a literal `*`.

This extends the existing offset tracking to literal `*`/`**` atoms and neutralizes every other glob metacharacter (`* ? [ ] { } , ! \`) by wrapping it in a single-character class before the pattern reaches the walker, so it only matches itself. The original word is still used for the "no matches found" message and the assignment-position literal fallback. It also fixes `match_brace` to not treat a comma inside a `[...]` character class as a brace-branch separator (the `{`/`}` arms already had that guard), which aligns `Bun.Glob` with bash/micromatch for patterns like `{a,[,],b}`.

Note: `?`, `[...]`, and leading `!` written directly in a template literal are not tokenized by the shell lexer (only `*`, `**`, and braces are), so they are now matched literally as well — same trade-off the brace fix already made for quoted `{`/`,`/`}`.

Tests added:
- `test/js/bun/glob/match.test.ts`: comma inside a bracket class inside braces is a class member, not a branch separator.
- `test/js/bun/shell/bunshell.test.ts` ("glob expansion"): interpolated `**/`, `?`, `[...]`, and leading `!` match only files containing them literally; plain interpolation followed by a literal `*` and an all-literal `**/*.txt` still glob as before.
- `test/js/bun/shell/brace.test.ts`: an interpolated comma inside a brace+glob word is one literal branch.
