### PR TITLE
repl: stop rewriting top-level `this` to `exports`

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5660,6 +5660,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // oroigianlly was !=- modepassthrough
         if !self.fn_only_data_visit.is_this_nested {
+            // In the REPL, top-level `this` must evaluate to the global object
+            // (matching Node's `> this` and `deno repl > this`). The REPL wraps
+            // user input in an arrow IIFE that has no `exports` binding, so the
+            // CommonJS substitution below would emit a reference to an
+            // undefined `exports`. Leaving `E::This` in place lets the arrow
+            // inherit `this` from the enclosing (global) scope at runtime.
+            if self.options.repl_mode {
+                return None;
+            }
             if self.has_es_module_syntax && self.commonjs_named_exports.count() == 0 {
                 // In an ES6 module, "this" is supposed to be undefined. Instead of
                 // doing this at runtime using "fn.call(undefined)", we do it at

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -922,10 +922,7 @@ describe.concurrent("Bun REPL", () => {
     });
 
     test("top-level `this` evaluates to globalThis (issue #31225)", async () => {
-      const { stdout, stderr, exitCode } = await runReplWith([
-        "-e",
-        "console.log(typeof this, this === globalThis)",
-      ]);
+      const { stdout, stderr, exitCode } = await runReplWith(["-e", "console.log(typeof this, this === globalThis)"]);
       expect(stderr).toBe("");
       expect(stdout).toBe("object true\n");
       expect(exitCode).toBe(0);
@@ -933,10 +930,7 @@ describe.concurrent("Bun REPL", () => {
 
     test("member access on top-level `this` hits the global (issue #31225)", async () => {
       // `Math` lives on the global, so `this.Math` should be the same object.
-      const { stdout, stderr, exitCode } = await runReplWith([
-        "-e",
-        "console.log(this.Math === Math)",
-      ]);
+      const { stdout, stderr, exitCode } = await runReplWith(["-e", "console.log(this.Math === Math)"]);
       expect(stderr).toBe("");
       expect(stdout).toBe("true\n");
       expect(exitCode).toBe(0);

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -909,6 +909,38 @@ describe.concurrent("Bun REPL", () => {
       expect(stdout).toBe("string string\n");
       expect(exitCode).toBe(0);
     });
+
+    // https://github.com/oven-sh/bun/issues/31225
+    test("bare top-level `this` does not throw (issue #31225)", async () => {
+      // Before the fix this threw `ReferenceError: exports is not defined`
+      // because the parser rewrote top-level `this` to `exports`, and the REPL
+      // IIFE has no `exports` binding.
+      const { stdout, stderr, exitCode } = await runReplWith(["-e", "this"]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("");
+      expect(exitCode).toBe(0);
+    });
+
+    test("top-level `this` evaluates to globalThis (issue #31225)", async () => {
+      const { stdout, stderr, exitCode } = await runReplWith([
+        "-e",
+        "console.log(typeof this, this === globalThis)",
+      ]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("object true\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("member access on top-level `this` hits the global (issue #31225)", async () => {
+      // `Math` lives on the global, so `this.Math` should be the same object.
+      const { stdout, stderr, exitCode } = await runReplWith([
+        "-e",
+        "console.log(this.Math === Math)",
+      ]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("true\n");
+      expect(exitCode).toBe(0);
+    });
   });
 });
 

--- a/test/js/bun/transpiler/repl-transform.test.ts
+++ b/test/js/bun/transpiler/repl-transform.test.ts
@@ -55,6 +55,23 @@ describe("Bun.Transpiler replMode", () => {
       expect(result).toContain("var Bar");
       expect(result).toContain("async");
     });
+
+    // https://github.com/oven-sh/bun/issues/31225
+    test("top-level `this` is preserved (not rewritten to `exports`)", () => {
+      const result = transpiler.transformSync("this");
+      // In REPL mode, top-level `this` must survive the visit pass so the
+      // surrounding arrow IIFE inherits `this` from the global scope.
+      // Before the fix, it was rewritten to `exports`, which isn't bound in
+      // the IIFE and blew up with `ReferenceError: exports is not defined`.
+      expect(result).toContain("this");
+      expect(result).not.toContain("exports");
+    });
+
+    test("`this` inside a nested call is preserved", () => {
+      const result = transpiler.transformSync("console.log(this)");
+      expect(result).toContain("console.log(this)");
+      expect(result).not.toContain("console.log(exports)");
+    });
   });
 
   describe("REPL session with node:vm", () => {


### PR DESCRIPTION
## What

`bun repl -e "this"` (and any REPL expression that reads top-level `this`) throws `ReferenceError: exports is not defined`:

```
$ bun repl -e "this"
1 | (() => {
2 |   return {
3 |     __proto__: null,
ReferenceError: exports is not defined
      at <anonymous> ([eval]:4:19)
      at [eval]:6:3
```

Node and Deno both return the global object for top-level `this` in their REPLs; Bun should match.

## Root cause

The parser rewrites top-level `this` to `exports` for CommonJS (`value_for_this` in `src/js_parser/p.rs`). That substitution assumes the code will be wrapped in a CJS wrapper function that binds `exports`.

The REPL wraps input in a plain arrow IIFE (`apply_repl_transforms` in `src/js_parser/repl_transforms.rs`):

```js
(() => {
  return {
    __proto__: null,
    value: exports   // ← emitted by value_for_this, but there is no `exports` binding
  };
})();
```

Neither the IIFE nor the REPL evaluator binds `exports`, so JSC throws.

## Fix

Skip the CJS `this` → `exports` substitution when `opts.repl_mode` is set. Leaving `E::This` in place means the printer emits literal `this`, and the arrow IIFE inherits `this` from the enclosing scope — which is the global object in the REPL.

```rust
if !self.fn_only_data_visit.is_this_nested {
    if self.options.repl_mode {
        return None; // preserve `this`; arrow IIFE delegates to enclosing scope
    }
    // ... existing ESM / CJS branches unchanged
}
```

The ESM branch (`this` → `undefined`) and the CJS branch (`this` → `exports`) are untouched outside REPL mode.

## Verification

After the fix, matching Node / Deno:

```
$ bun repl -e "console.log(typeof this, this === globalThis)"
object true
$ bun repl -e "console.log(this.Math === Math)"
true
```

Tests in `test/js/bun/repl/repl.test.ts`:
- bare `this` no longer throws (original repro)
- `this === globalThis` is `true`
- `this.Math === Math` is `true`

Tests in `test/js/bun/transpiler/repl-transform.test.ts`:
- `Bun.Transpiler({ replMode: true }).transformSync("this")` preserves `this` (does not emit `exports`)
- Same for `console.log(this)`

All 108 existing REPL tests and 34 existing transpiler REPL-mode tests still pass; the CJS `this.foo = ...` and ESM `typeof this === "object"` paths outside the REPL are unchanged.

Fixes #31225