### PR TITLE
patch: don't panic on truncated ---/+++ header lines

### DIFF
--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -1283,11 +1283,18 @@ impl<'a> PatchLinesParser<'a> {
                         self.current_file_patch.before_hash = Some(hashes.0);
                         self.current_file_patch.after_hash = Some(hashes.1);
                     } else if line.starts_with(b"--- ") {
-                        self.current_file_patch.from_path =
-                            Some(strings::trim(&line[b"--- a/".len()..], WHITESPACE));
+                        // The line may be shorter than "--- a/" (e.g. a bare "--- ");
+                        // treat the missing path as empty like the JS implementation's
+                        // `line.slice("--- a/".length)`.
+                        self.current_file_patch.from_path = Some(strings::trim(
+                            line.get(b"--- a/".len()..).unwrap_or_default(),
+                            WHITESPACE,
+                        ));
                     } else if line.starts_with(b"+++ ") {
-                        self.current_file_patch.to_path =
-                            Some(strings::trim(&line[b"+++ b/".len()..], WHITESPACE));
+                        self.current_file_patch.to_path = Some(strings::trim(
+                            line.get(b"+++ b/".len()..).unwrap_or_default(),
+                            WHITESPACE,
+                        ));
                     }
                 }
                 ParserState::ParsingHunks => {

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -750,6 +750,51 @@ describe("parse", () => {
       },
     });
   });
+
+  // A `---`/`+++` header line can be shorter than "--- a/"/"+++ b/" (no path after the marker).
+  // This used to crash the parser with an out-of-bounds slice.
+  test("does not crash on truncated ---/+++ header lines", () => {
+    for (const truncated of ["+++ ", "--- ", "--- a", "+++ b"]) {
+      expect(removeCapacity(JSON.parse(parse(truncated)))).toEqual({ "parts": { "items": [] } });
+    }
+
+    // a truncated header line falls back to the paths from the `diff --git` line
+    const truncatedHeaderPatch = `diff --git a/banana.ts b/banana.ts\n--- \n+++ \n@@ -1,1 +1,1 @@\n-a\n+b\n`;
+    expect(removeCapacity(JSON.parse(parse(truncatedHeaderPatch)))).toEqual({
+      "parts": {
+        "items": [
+          {
+            "file_patch": {
+              "path": "banana.ts",
+              "hunks": {
+                "items": [
+                  {
+                    "header": { "original": { "start": 1, "len": 1 }, "patched": { "start": 1, "len": 1 } },
+                    "parts": {
+                      "items": [
+                        {
+                          "type": "deletion",
+                          "lines": { "items": ["a"] },
+                          "no_newline_at_end_of_file": false,
+                        },
+                        {
+                          "type": "insertion",
+                          "lines": { "items": ["b"] },
+                          "no_newline_at_end_of_file": false,
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+              "before_hash": null,
+              "after_hash": null,
+            },
+          },
+        ],
+      },
+    });
+  });
 });
 
 const patch = `diff --git a/banana.ts b/banana.ts\nindex 2de83dd..842652c 100644\n--- a/banana.ts\n+++ b/banana.ts\n@@ -1,5 +1,5 @@\n this\n is\n \n-a\n+\n file\n`;


### PR DESCRIPTION
### What does this PR do?

Fixes a panic in the patch file parser when a `---` or `+++` header line is truncated (no path after the marker).

**Repro (4 bytes):**

```sh
BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1 \
  bun -e 'require("bun:internal-for-testing").patchInternals.parse("+++ ")'
# panic: range start index 6 out of range for slice of length 4
```

User-facing surface: `bun pm patch` / applying a `.patch` file from `patchedDependencies` whose `---`/`+++` header line has no path after the marker.

**Cause:** `PatchLinesParser::parse` slices `line["--- a/".len()..]` (6 bytes) after only checking `starts_with("--- ")` / `starts_with("+++ ")` (4 bytes), so any matching line shorter than 6 bytes hits an out-of-bounds slice. The Zig implementation has the same unchecked slice (unchecked UB in release builds, which is why bun 1.3.14 didn't visibly panic); the JS implementation both ports mimic uses `line.slice("--- a/".length).trim()`, which saturates to `""`.

**Fix:** bounds-checked slice (`line.get(b"--- a/".len()..).unwrap_or_default()`). A missing path becomes an empty string, which `nullify_empty_strings()` already turns into `None`, so parsing degrades gracefully and falls back to the `diff --git` line paths — same behavior as the JS implementation and as released bun.

### How did you verify your code works?

- Added `parse > does not crash on truncated ---/+++ header lines` to `test/js/bun/patch/patch.test.ts`. Without the fix it crashes with the panic above; with the fix the whole file passes (21 pass / 0 fail).
- Verified the original repro (`"+++ "`, `"--- "`, `"--- a"`) no longer panics and returns `{"parts":{"items":[]}}`.
