### PR TITLE
Reject TypeScript `using` declarations in ambient contexts instead of panicking

### DIFF
--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -837,7 +837,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 opts.is_using_statement = true;
                 let decls = p.parse_and_declare_decls(js_ast::symbol::Kind::Constant, opts)?;
                 let decls_slice = bun_collections::RawSlice::new(decls.slice());
-                if !opts.is_for_loop_init {
+                if opts.is_typescript_declare {
+                    // TypeScript does not allow "using" declarations in ambient
+                    // contexts ("declare using x", "declare namespace { using x }").
+                    // Their bindings are also never declared as symbols, so
+                    // require_initializers (which looks up the binding's symbol)
+                    // must not run here.
+                    p.log().add_error(
+                        Some(p.source),
+                        token_range.loc,
+                        b"Cannot use a \"using\" declaration in an ambient context",
+                    );
+                } else if !opts.is_for_loop_init {
                     p.require_initializers(js_ast::LocalKind::KUsing, decls.slice())?;
                 }
                 return Ok(ExprOrLetStmt {
@@ -886,7 +897,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         let decls =
                             p.parse_and_declare_decls(js_ast::symbol::Kind::Constant, opts)?;
                         let decls_slice = bun_collections::RawSlice::new(decls.slice());
-                        if !opts.is_for_loop_init {
+                        if opts.is_typescript_declare {
+                            p.log().add_error(
+                                Some(p.source),
+                                token_range.loc,
+                                b"Cannot use an \"await using\" declaration in an ambient context",
+                            );
+                        } else if !opts.is_for_loop_init {
                             p.require_initializers(js_ast::LocalKind::KAwaitUsing, decls.slice())?;
                         }
                         return Ok(ExprOrLetStmt {

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -846,7 +846,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     p.log().add_error(
                         Some(p.source),
                         token_range.loc,
-                        b"Cannot use a \"using\" declaration in an ambient context",
+                        b"Cannot use \"declare\" with a \"using\" declaration",
                     );
                 } else if !opts.is_for_loop_init {
                     p.require_initializers(js_ast::LocalKind::KUsing, decls.slice())?;
@@ -901,7 +901,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             p.log().add_error(
                                 Some(p.source),
                                 token_range.loc,
-                                b"Cannot use an \"await using\" declaration in an ambient context",
+                                b"Cannot use \"declare\" with an \"await using\" declaration",
                             );
                         } else if !opts.is_for_loop_init {
                             p.require_initializers(js_ast::LocalKind::KAwaitUsing, decls.slice())?;

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1001,21 +1001,21 @@ export default class {
       );
     });
 
-    it("rejects using declarations in ambient contexts", () => {
+    it("rejects using declarations in ambient (declare) contexts", () => {
       const exp = ts.expectPrinted_;
       const err = ts.expectParseError;
 
       // These used to crash the parser with an index-out-of-bounds panic
       // because ambient ("declare") bindings are never declared as symbols.
-      err("declare await using basic;var", 'Cannot use an "await using" declaration in an ambient context');
-      err("declare using basic;var", 'Cannot use a "using" declaration in an ambient context');
-      err("declare using x", 'Cannot use a "using" declaration in an ambient context');
-      err("declare await using x", 'Cannot use an "await using" declaration in an ambient context');
-      err("declare using x = foo()", 'Cannot use a "using" declaration in an ambient context');
-      err("declare await using x = foo()", 'Cannot use an "await using" declaration in an ambient context');
-      err("declare namespace NS { using x; }", 'Cannot use a "using" declaration in an ambient context');
-      err('declare module "m" { using x; }', 'Cannot use a "using" declaration in an ambient context');
-      err("declare global { await using x; }", 'Cannot use an "await using" declaration in an ambient context');
+      err("declare await using basic;var", 'Cannot use "declare" with an "await using" declaration');
+      err("declare using basic;var", 'Cannot use "declare" with a "using" declaration');
+      err("declare using x", 'Cannot use "declare" with a "using" declaration');
+      err("declare await using x", 'Cannot use "declare" with an "await using" declaration');
+      err("declare using x = foo()", 'Cannot use "declare" with a "using" declaration');
+      err("declare await using x = foo()", 'Cannot use "declare" with an "await using" declaration');
+      err("declare namespace NS { using x; }", 'Cannot use "declare" with a "using" declaration');
+      err('declare module "m" { using x; }', 'Cannot use "declare" with a "using" declaration');
+      err("declare global { await using x; }", 'Cannot use "declare" with an "await using" declaration');
 
       // "declare" on other declarations is still erased without error
       exp("declare const x: number; var y", "var y");

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1000,6 +1000,28 @@ export default class {
         'const b = { xyz: "foo" };\n',
       );
     });
+
+    it("rejects using declarations in ambient contexts", () => {
+      const exp = ts.expectPrinted_;
+      const err = ts.expectParseError;
+
+      // These used to crash the parser with an index-out-of-bounds panic
+      // because ambient ("declare") bindings are never declared as symbols.
+      err("declare await using basic;var", 'Cannot use an "await using" declaration in an ambient context');
+      err("declare using basic;var", 'Cannot use a "using" declaration in an ambient context');
+      err("declare using x", 'Cannot use a "using" declaration in an ambient context');
+      err("declare await using x", 'Cannot use an "await using" declaration in an ambient context');
+      err("declare using x = foo()", 'Cannot use a "using" declaration in an ambient context');
+      err("declare await using x = foo()", 'Cannot use an "await using" declaration in an ambient context');
+      err("declare namespace NS { using x; }", 'Cannot use a "using" declaration in an ambient context');
+      err('declare module "m" { using x; }', 'Cannot use a "using" declaration in an ambient context');
+      err("declare global { await using x; }", 'Cannot use an "await using" declaration in an ambient context');
+
+      // "declare" on other declarations is still erased without error
+      exp("declare const x: number; var y", "var y");
+      exp("declare let x: number; var y", "var y");
+      exp("declare var x: number; var y", "var y");
+    });
   });
 
   describe("generated closures", () => {


### PR DESCRIPTION
### Problem

The TypeScript parser panicked (`index out of bounds: the len is 0 but the index is 5`) on `using` / `await using` declarations in ambient (`declare`) contexts. Found by parser fuzzing; 29-byte repro:

```js
new Bun.Transpiler({ loader: "ts" }).transformSync("declare await using basic;var")
```

Any `.ts` file containing one of these token sequences crashes `bun run` / `bun build` / `Bun.Transpiler` instead of producing a syntax error:

```ts
declare await using x;
declare using x;
declare namespace NS { using x; }
declare module "m" { using x; }
declare global { await using x; }
```

### Cause

In a `declare` context, `declare_binding` intentionally skips `declare_symbol`, so the binding's `Ref` stays as a source-contents-slice ref (inner index = name length) instead of a symbol table index. The `using` / `await using` paths in `parse_expr_or_let_stmt` then call `require_initializers`, which reads `p.symbols[ref.inner_index()]` — indexing an empty symbols table with the name length → panic. The `const` path already guards this call with `!opts.is_typescript_declare`; the `using` paths did not. (Upstream esbuild has the same crash on these inputs.)

### Fix

`using` / `await using` declarations in a `declare` context now produce a parse error instead of requiring initializers, phrased like the neighboring `export` errors:

- `Cannot use "declare" with a "using" declaration`
- `Cannot use "declare" with an "await using" declaration`

This matches TypeScript, which rejects all of these (TS1491/TS1495 for the `declare` modifier, TS1545/TS1546 for ambient blocks). Non-ambient `using` declarations and `declare const/let/var` erasure are unchanged.

### Verification

- New test `Bun.Transpiler > TypeScript > rejects using declarations in ambient (declare) contexts` in `test/bundler/transpiler/transpiler.test.js` covers the fuzz repro plus the ambient-block variants; without the fix it crashes the parser, with the fix it asserts the new error messages.
- `bun bd test test/bundler/transpiler/transpiler.test.js` → 115 pass, 0 fail
- `bun bd test test/bundler/esbuild/ts.test.ts` → 57 pass, 0 fail
- `bun bd test test/js/bun/resolve/lower-using-bun-target.test.ts` → 11 pass, 0 fail
