### PR TITLE
parser: fix "Scope mismatch while visiting" panic from dropped TypeScript `declare` statements

### DIFF
--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1795,15 +1795,27 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 if p.lexer.is_contextual_keyword(b"global") {
                     p.lexer.next()?;
                     p.lexer.expect(T::TOpenBrace)?;
+                    let scope_index = p.scopes_in_order.len();
                     let _ = p.parse_stmts_up_to(T::TCloseBrace, opts)?;
                     p.lexer.next()?;
+                    // The statements inside are dropped, so discard any scopes they
+                    // recorded or the visit pass will hit a scope order mismatch.
+                    p.discard_scopes_up_to(scope_index);
                     return Ok(Some(p.s(S::TypeScript {}, loc)));
                 }
 
                 // "declare const x: any"
+                let scope_index = p.scopes_in_order.len();
                 let stmt = p.parse_stmt(opts)?;
                 if let Some(decs) = &opts.ts_decorators {
                     p.discard_scopes_up_to(decs.scope_index);
+                } else {
+                    // The statement is dropped below (or reduced to just its bindings
+                    // for "export declare var" inside a namespace), so discard any
+                    // scopes it recorded or the visit pass will hit a scope order
+                    // mismatch (e.g. "declare foo: bar" parses a labeled statement
+                    // that records a Label scope).
+                    p.discard_scopes_up_to(scope_index);
                 }
 
                 // Unlike almost all uses of "declare", statements that use

--- a/test/bundler/transpiler/scope-mismatch-panic.test.ts
+++ b/test/bundler/transpiler/scope-mismatch-panic.test.ts
@@ -125,7 +125,7 @@ describe("TypeScript 'declare' statements discard scopes of dropped statements",
     ],
   ];
 
-  test.each(cases)("%s", async (_name, source, expected) => {
+  test.concurrent.each(cases)("%s", async (_name, source, expected) => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),

--- a/test/bundler/transpiler/scope-mismatch-panic.test.ts
+++ b/test/bundler/transpiler/scope-mismatch-panic.test.ts
@@ -96,3 +96,57 @@ const fn = () => {
     expect(exitCode).not.toBe(0);
   });
 });
+
+describe("TypeScript 'declare' statements discard scopes of dropped statements", () => {
+  // Each of these parses a statement after "declare" that records scopes during the
+  // parse pass and is then dropped. The recorded scopes used to be left behind, so
+  // visiting the following class statement hit "Scope mismatch while visiting".
+  const cases: [name: string, source: string, expected: string[]][] = [
+    [
+      "declare module with an invalid name followed by a class",
+      "declare module : es2015\nclass Foo {}\n",
+      ["class Foo"],
+    ],
+    [
+      "declare followed by a labeled statement and a class",
+      "declare foo: bar\nclass Foo {}\n",
+      ["class Foo"],
+    ],
+    [
+      "declare const with an arrow function initializer followed by a class",
+      "declare const x = () => {};\nclass Foo {}\n",
+      ["class Foo"],
+    ],
+    [
+      "declare global containing nested blocks followed by a class",
+      "declare global { if (1) { let x = 1 } }\nclass Foo {}\n",
+      ["class Foo"],
+    ],
+    [
+      "export declare with an initializer inside a namespace",
+      "namespace ns { export declare const x = () => {}; export function y() { return x } }\nclass Foo {}\n",
+      ["function y", "class Foo"],
+    ],
+  ];
+
+  test.each(cases)("%s", async (_name, source, expected) => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.stdout.write(new Bun.Transpiler({ loader: "tsx" }).transformSync(${JSON.stringify(source)}))`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    for (const substring of expected) {
+      expect(stdout).toContain(substring);
+    }
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/bundler/transpiler/scope-mismatch-panic.test.ts
+++ b/test/bundler/transpiler/scope-mismatch-panic.test.ts
@@ -107,11 +107,7 @@ describe("TypeScript 'declare' statements discard scopes of dropped statements",
       "declare module : es2015\nclass Foo {}\n",
       ["class Foo"],
     ],
-    [
-      "declare followed by a labeled statement and a class",
-      "declare foo: bar\nclass Foo {}\n",
-      ["class Foo"],
-    ],
+    ["declare followed by a labeled statement and a class", "declare foo: bar\nclass Foo {}\n", ["class Foo"]],
     [
       "declare const with an arrow function initializer followed by a class",
       "declare const x = () => {};\nclass Foo {}\n",


### PR DESCRIPTION
### Repro

Found by parser fuzzing. Minimized:

```ts
declare module : es2015
class Foo {}
```

```
bun -e 'new Bun.Transpiler({loader:"tsx"}).transformSync("declare module : es2015\nclass Foo {}\n")'
panic: Scope mismatch while visiting
```

Reproduces on 1.3.14 and current canary, so it is a faithful port of the pre-existing parser behavior rather than a regression.

The same panic is reachable through several other shapes of `declare`:

```ts
declare foo: bar
class Foo {}
```

```ts
declare const x = () => {};
class Foo {}
```

```ts
declare global { if (1) { let x = 1 } }
class Foo {}
```

(esbuild 0.21.5 panics on the `declare global` variant too, with its equivalent "Expected scope ... found scope" internal error.)

### Cause

`declare module : es2015` never reaches the namespace parser — after `declare`, the guard for `module`/`namespace` requires an identifier or string literal as the name, so `module : es2015` falls through and is parsed as a **labeled statement**, which pushes (and records) a `Label` scope.

The `declare` branch in `parse_stmt.rs` then throws the parsed statement away and returns a bare TypeScript no-op, but the scopes recorded while parsing it stay in `scopes_in_order`. When the visit pass later pushes the scope for the next scope-creating statement (the `class`), the recorded order no longer lines up and the parser panics with "Scope mismatch while visiting".

The same leak exists for:
- any dropped `declare <stmt>` whose parse recorded scopes (labeled statements, blocks, `if`, arrow-function initializers on `declare const`, …)
- the statements inside `declare global { ... }`, which are parsed and discarded without discarding their scopes
- `export declare var/let/const` inside a namespace, which is reduced to just its bindings (initializer scopes are dropped)

### Fix

In the `declare` branch (`src/js_parser/parse/parse_stmt.rs`), record `scopes_in_order.len()` before parsing the declared statement and call `discard_scopes_up_to()` afterwards — the same thing the decorator path in that branch already does. Same treatment for the `declare global { ... }` body.

This only removes scope records for statements the parser drops anyway, so output for valid `declare` code is unchanged.

### Verification

- Added 5 cases to `test/bundler/transpiler/scope-mismatch-panic.test.ts`; all 5 panic with "Scope mismatch while visiting" before the fix and pass with it.
- The original 431-byte fuzz input transpiles cleanly with the fix.
- `bun bd test test/bundler/esbuild/ts.test.ts` (57 pass) and `test/bundler/transpiler/transpiler.test.js` (114 pass) are clean, so existing `declare`/namespace behavior is unchanged.
