### PR TITLE
worker: discard async write completions against a shutting-down VM

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4751,6 +4751,7 @@ pub fn write_file_with_source_destination(
                 source_blob.borrowed_view(),
                 write_file_promise,
                 WriteFilePromise::run,
+                WriteFilePromise::discard,
                 options.mkdirp_if_not_exists.unwrap_or(true),
             ) {
                 Err(write_file_mod::WriteFileWindowsError::WriteFileWindowsDeinitialized) => {}

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -438,6 +438,21 @@ impl FileSink {
 
             (*this).run_pending_later.has.set(false);
 
+            if (*this).js_vm().is_some_and(|vm| vm.is_shutting_down()) {
+                // JSC HandleSet and JSGlobalObject are freed by the time
+                // this fires on Windows Loop::shutdown's final uv_run;
+                // neutralize every field that would touch them.
+                (*this).pending.with_mut(|p| p.discard());
+                (*this).signal.with_mut(|s| s.clear());
+                (*this).auto_flusher.with_mut(|a| a.registered.set(false));
+                #[allow(clippy::mem_forget)]
+                {
+                    core::mem::forget((*this).js_sink_ref.replace(Default::default()));
+                    core::mem::forget((*this).readable_stream.replace(Default::default()));
+                }
+                return;
+            }
+
             let _entered = (*this).event_loop().entered();
             // SAFETY(JsCell): `WritablePending::run` resolves a JSPromise which may
             // re-enter JS, but no other path holds a borrow of `self.pending` for
@@ -1305,7 +1320,11 @@ impl FileSink {
         #[cfg(windows)]
         self_.magic.set(FILESINK_DEAD);
         // pending/readable_stream/js_sink_ref are dropped by Box drop below.
-        if let Some(global) = self_.js_global() {
+        // `registered` gate skips `bun_vm()` when the JSC global may be freed
+        // (worker-shutdown discard path, #31224).
+        if self_.auto_flusher.get().registered.get()
+            && let Some(global) = self_.js_global()
+        {
             // SAFETY: `bun_vm()` is non-null when `js_global()` returned Some.
             let vm = global.bun_vm().as_mut();
             AutoFlusher::unregister_deferred_microtask_with_type::<Self>(self_, vm);

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -33,6 +33,13 @@ pub enum WriteFileResultType {
 pub type WriteFileOnWriteFileCallback =
     fn(ctx: *mut c_void, count: WriteFileResultType) -> Result<(), JsTerminated>;
 
+/// Frees the `ctx` passed alongside `WriteFileOnWriteFileCallback` without
+/// resolving the promise. Called on the worker-shutdown discard path.
+///
+/// # Safety
+/// Must match the concrete `ctx` type `on_complete_callback` was paired with.
+pub type WriteFileOnDiscardCallback = unsafe fn(ctx: *mut c_void);
+
 pub type WriteFileTask = bun_jsc::work_task::WorkTask<WriteFile>;
 
 // `WorkTaskContext` fixes `run`/`then` to take `*mut Self`; the trait method
@@ -619,6 +626,7 @@ mod windows_impl {
         pub file_blob: Blob,
         pub bytes_blob: Blob,
         pub on_complete_callback: WriteFileOnWriteFileCallback,
+        pub on_complete_discard: WriteFileOnDiscardCallback,
         pub on_complete_ctx: *mut c_void,
         pub mkdirp_if_not_exists: bool,
         pub uv_bufs: [uv::uv_buf_t; 1],
@@ -661,6 +669,7 @@ mod windows_impl {
             event_loop: *mut EventLoop,
             on_write_file_context: *mut c_void,
             on_complete_callback: WriteFileOnWriteFileCallback,
+            on_complete_discard: WriteFileOnDiscardCallback,
             mkdirp_if_not_exists: bool,
         ) -> Result<*mut WriteFileWindows, WriteFileWindowsError> {
             let mkdirp = mkdirp_if_not_exists
@@ -678,6 +687,7 @@ mod windows_impl {
                 bytes_blob,
                 on_complete_ctx: on_write_file_context,
                 on_complete_callback,
+                on_complete_discard,
                 mkdirp_if_not_exists: mkdirp,
                 io_request: bun_core::ffi::zeroed::<uv::fs_t>(),
                 uv_bufs: [uv::uv_buf_t {
@@ -1083,6 +1093,25 @@ mod windows_impl {
         /// `this` must point to a live `WriteFileWindows` allocated via [`Self::new`].
         /// On return, `*this` has been freed and must not be accessed again.
         pub unsafe fn on_finish(this: *mut Self) -> WriteFileWindowsError {
+            // SAFETY: caller contract — `this` is live; `event_loop` is the
+            // VM-owned EventLoop with process lifetime.
+            let is_shutting_down = unsafe {
+                (*(*this).event_loop)
+                    .virtual_machine
+                    .is_some_and(|vm| vm.as_ref().is_shutting_down())
+            };
+            if is_shutting_down {
+                // SAFETY: caller contract — `this` is live.
+                let (discard, ctx) =
+                    unsafe { ((*this).on_complete_discard, (*this).on_complete_ctx) };
+                // SAFETY: caller contract — `this` is live; consumed here.
+                unsafe { Self::deinit(this) };
+                // SAFETY: `ctx` is the boxed handler paired with `discard`
+                // at `create_with_ctx`; `discard` consumes it.
+                unsafe { discard(ctx) };
+                return WriteFileWindowsError::WriteFileWindowsDeinitialized;
+            }
+
             // SAFETY: VM-owned EventLoop lives for process lifetime; the guard
             // forms short-lived `&mut` only at the enter/exit call sites (see
             // EventLoopEnterGuard docs) so it does not alias `*this`.
@@ -1264,6 +1293,7 @@ mod windows_impl {
             bytes_blob: Blob,
             context: *mut C,
             callback: WriteFileOnWriteFileCallback,
+            discard: WriteFileOnDiscardCallback,
             mkdirp_if_not_exists: bool,
         ) -> Result<*mut WriteFileWindows, WriteFileWindowsError> {
             // see `WriteFile::create` — caller supplies an erased
@@ -1274,6 +1304,7 @@ mod windows_impl {
                 event_loop,
                 context.cast::<c_void>(),
                 callback,
+                discard,
                 mkdirp_if_not_exists,
             )
         }
@@ -1317,6 +1348,22 @@ impl WriteFilePromise {
             }
         }
         Ok(())
+    }
+
+    /// Frees the boxed handler on the shutdown path. Forgets the
+    /// `JSPromiseStrong` because the JSC `HandleSet` is already gone.
+    ///
+    /// # Safety
+    /// `handler` must be a Box-allocated `WriteFilePromise`. Consumed.
+    pub unsafe fn discard(handler: *mut c_void) {
+        // SAFETY: caller contract — boxed `WriteFilePromise`; consumed here.
+        unsafe {
+            let mut boxed = bun_core::heap::take(handler.cast::<Self>());
+            // SAFETY: intentional leak — see fn doc.
+            #[allow(clippy::mem_forget)]
+            core::mem::forget(core::mem::take(&mut boxed.promise));
+            drop(boxed);
+        }
     }
 }
 

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -531,6 +531,24 @@ impl WritablePending {
             WritableFuture::None => {}
         }
     }
+
+    /// Drop the pending future without resolving the promise. Forgets the
+    /// `Promise` variant's `JSPromiseStrong` because the JSC `HandleSet` is
+    /// already freed when this runs on the Windows worker-shutdown path.
+    pub fn discard(&mut self) {
+        if self.state != PendingState::Pending {
+            return;
+        }
+        self.state = PendingState::Used;
+        self.result = Writable::Done;
+        let taken = core::mem::replace(&mut self.future, WritableFuture::None);
+        match &taken {
+            // SAFETY: intentional leak — see fn doc.
+            #[allow(clippy::mem_forget)]
+            WritableFuture::Promise { .. } => core::mem::forget(taken),
+            WritableFuture::Handler(_) | WritableFuture::None => drop(taken),
+        }
+    }
 }
 
 impl Writable {

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isWindows } from "harness";
 
 // Worker VM startup/teardown is much slower under debug and/or ASAN; these
 // tests spawn many workers, so scale iteration counts and timeouts down.
@@ -115,6 +115,48 @@ test(
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(stdout).toBe("");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);
+
+// Regression: #31224. Windows worker scheduling Bun.write then exit(0) used
+// to crash in JSNextTickQueue::drain from the uv_fs_write completion firing
+// after the worker's JSC VM was torn down.
+test.skipIf(!isWindows)(
+  "worker that schedules Bun.write to stdout then exits does not crash",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const workers = [];
+        for (let i = 0; i < ${perRound}; i++) {
+          workers.push(new Worker("data:text/javascript," + encodeURIComponent(\`
+            Bun.write(Bun.stdout, new Uint8Array(512 * 1024).fill(120)).then(() => {
+              console.error("stdout write microtask ran after worker shutdown");
+              process.exit(42);
+            });
+            process.exit(0);
+          \`)));
+        }
+        const codes = await Promise.all(workers.map(w => new Promise(r => {
+          w.addEventListener("close", e => r(e.code ?? e.exitCode ?? 0), { once: true });
+        })));
+        for (const c of codes) if (c !== 0) { console.error("bad exit", c); process.exit(1); }
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    // Drain stdout concurrently — the workers write ~`perRound * 512 KiB` to it
+    // and the child blocks on pipe backpressure if we never read it.
+    const [_stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("stdout write microtask ran after worker shutdown");
+    expect(stderr).not.toContain("bad exit");
     expect(exitCode).toBe(0);
   },
   timeout,


### PR DESCRIPTION
Fixes #31224.

## Repro

On Windows, this reliably crashes the subprocess with a segfault at a small address:

```js
const w = new Worker("data:text/javascript," + encodeURIComponent(`
  Bun.write(Bun.stdout, new Uint8Array(512 * 1024).fill(120)).then(() => {
    console.error("stdout write microtask ran after worker shutdown");
    process.exit(42);
  });
  process.exit(0);
`));
await new Promise(r => w.addEventListener("close", r, { once: true }));
```

The reporter's crash report from Bun `v1.3.14` on Windows x64 shows the same chain from a pipe-backed FileSink:

```
JSC::Interpreter::executeCallImpl
Bun::JSNextTickQueue::drain
Zig::GlobalObject::drainMicrotasks
event_loop.zig:exit
FileSink.zig:onWrite
PipeWriter.zig:onWriteComplete
uv__process_pipe_write_req
uv_run
web_worker.zig:shutdown/spin/threadMain
```

## Cause

`WebWorker::shutdown` flips `vm.is_shutting_down = true`, runs user exit handlers, closes embedded socket groups, tears down JSC, then — on Windows only — calls `libuv::Loop::shutdown()` which walks open handles, closes them, and runs one final `uv_run(loop, .default)` to flush close callbacks.

That last `uv_run` also fires any pending `uv_fs_write` and pipe-write completions that happen to land in the window. Without a shutdown check those completions ran their JS-thread callback, which entered the event loop and resolved/rejected a JSPromise. The RAII exit on the event-loop scope called `drain_microtasks`, which invoked the JSC interpreter against a global whose heap was in the process of being reclaimed.

Two completion paths hit this:

1. `WriteFileWindows::on_finish` — the async `Bun.write(Bun.stdout, Uint8Array)` path on Windows. Its `WriteFilePromise::run` resolves the promise and drains microtasks.
2. `FileSink::run_pending` — the pipe/FileSink writer path. Its `event_loop().entered()` guard triggers microtask drain on `Drop`.

## Fix

Check `VirtualMachine::is_shutting_down()` before entering the event loop and discard the pending operation instead.

- `FileSink::run_pending` — if the owning VM's `is_shutting_down` is true, call a new `WritablePending::discard()` (mark pending `Used`, clear `result` and `future` without touching the JSPromise) and release the JS-sink ref. Skip the `event_loop().entered()` RAII guard entirely so no `drain_microtasks` runs.
- `WriteFileWindows::on_finish` — read `(*event_loop).virtual_machine.is_some_and(|vm| vm.as_ref().is_shutting_down())`. When true, call a new `WriteFilePromise::discard()` (reclaim the boxed handler and release its `JSPromiseStrong` slot without dispatching JS), then `Self::deinit`, and return `WriteFileWindowsDeinitialized` without entering the loop.

Normal (non-shutdown) completions keep the existing behavior: enter the event loop, resolve/reject the promise, let the RAII guard drain microtasks.

POSIX uses a threadpool `WorkTask` whose completion is queued onto the event loop's concurrent task queue. That queue is not dispatched past worker shutdown, so the hazard is unreachable on non-Windows.

## Verification

`test/js/web/workers/worker-terminate-lifetime.test.ts` gets a new Windows-only case that spawns a batch of workers each running the repro above and asserts every worker closes with exit code 0 and never prints the "microtask ran after worker shutdown" sentinel. On Linux the crash path doesn't exist (see above) so the case is `skipIf(!isWindows)`.

Existing worker / FileSink / Bun.write suites continue to pass:

- `test/js/web/workers/worker-terminate-lifetime.test.ts`: 3 pass + 1 skip
- `test/js/bun/util/filesink.test.ts`: 42 pass
- `test/js/bun/bun-object/write.spec.ts`: 23 pass