### PR TITLE
Fix unreachable-code panic in semver range parser on dangling '-' chunks

### DIFF
--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -1018,6 +1018,14 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                 }
 
                 i += second_parsed.len as usize + 1;
+            } else if token.tag == TokenTag::None {
+                // No pending comparator token for this chunk, so skip it instead of
+                // emitting a comparator. This covers a leading "--foo" (treat "--foo"
+                // the same as "-foo", example: foo/bar@1.2.3@--canary.24) as well as
+                // a dangling "-" after a skipped tag, like "1 || - foo".
+                is_or = false;
+                token.wildcard = Wildcard::None;
+                continue;
             } else if count == 0 && token.tag == TokenTag::Version {
                 match parse_result.wildcard {
                     Wildcard::None => {
@@ -1028,14 +1036,6 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                     }
                 }
             } else if count == 0 {
-                // From a semver perspective, treat "--foo" the same as "-foo"
-                // example: foo/bar@1.2.3@--canary.24
-                //                         ^
-                if token.tag == TokenTag::None {
-                    is_or = false;
-                    token.wildcard = Wildcard::None;
-                    continue;
-                }
                 list.and_range(&token.to_range(&parse_result.version))?;
             } else if is_or {
                 list.or_range(&token.to_range(&parse_result.version))?;

--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -1020,10 +1020,11 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                 i += second_parsed.len as usize + 1;
             } else if token.tag == TokenTag::None {
                 // No pending comparator token for this chunk, so skip it instead of
-                // emitting a comparator. This covers a leading "--foo" (treat "--foo"
-                // the same as "-foo", example: foo/bar@1.2.3@--canary.24) as well as
-                // a dangling "-" after a skipped tag, like "1 || - foo".
-                is_or = false;
+                // emitting a comparator, the same way skipped tags like "boop" in
+                // "1.0.0 || boop" are ignored (any pending "||" is preserved). This
+                // covers a leading "--foo" (treat "--foo" the same as "-foo", example:
+                // foo/bar@1.2.3@--canary.24) as well as a dangling "-" after a skipped
+                // tag, like "1 || - foo".
                 token.wildcard = Wildcard::None;
                 continue;
             } else if count == 0 && token.tag == TokenTag::Version {

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -766,6 +766,8 @@ test("a range with a dangling '-' after a skipped tag does not crash the parser"
     ["1.0.0", "1 || -"],
     ["2.0.0", "1 || -"],
     ["1.0.0", "1 a - b"],
+    // the skipped "-q" chunk must not swallow the "||", so "^2" still matches
+    ["2.5.0", "^1 || -q ^2"],
   ];
   await using proc = Bun.spawn({
     cmd: [
@@ -779,6 +781,6 @@ test("a range with a dangling '-' after a skipped tag does not crash the parser"
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   if (exitCode !== 0) expect(stderr).toBe("");
-  expect(JSON.parse(stdout)).toEqual([true, true, false, true, false, true]);
+  expect(JSON.parse(stdout)).toEqual([true, true, false, true, false, true, true]);
   expect(exitCode).toBe(0);
-}, 30_000);
+});

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -753,3 +753,32 @@ test("a version range with >=256 || comparators does not abort", async () => {
   expect(stdout).toBe("true");
   expect(exitCode).toBe(0);
 }, 30_000);
+
+test("a range with a dangling '-' after a skipped tag does not crash the parser", async () => {
+  // Found by fuzzing: a "-" that follows a skipped garbage token (or "||") used to
+  // reach `unreachable!()` in the range parser once at least one comparator had
+  // already been parsed, crashing the process.
+  const fuzzed = "> > > > > > > `{" + "`${".repeat(34) + "- - - 1e-323-alpha.1";
+  const cases = [
+    ["", fuzzed],
+    ["1.0.0", fuzzed],
+    ["", "1 || -"],
+    ["1.0.0", "1 || -"],
+    ["2.0.0", "1 || -"],
+    ["1.0.0", "1 a - b"],
+  ];
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `process.stdout.write(JSON.stringify(${JSON.stringify(cases)}.map(([version, range]) => Bun.semver.satisfies(version, range))))`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual([true, true, false, true, false, true]);
+  expect(exitCode).toBe(0);
+}, 30_000);


### PR DESCRIPTION
### Problem

`Bun.semver.satisfies()` panics with `internal error: entered unreachable code` and crashes the process on certain malformed range strings (found by parser fuzzing):

```js
Bun.semver.satisfies("", atob("PiA+ID4gPiA+ID4gPiBge2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Ake2Akey0gLSAtIDFlLTMyMy1hbHBoYS4x"))
```

Minimized repro:

```js
Bun.semver.satisfies("1.0.0", "1 || -")   // panic
Bun.semver.satisfies("1.0.0", "1 a - b")  // panic
```

The empty first argument in the original report is incidental — any version string that isn't rejected earlier (e.g. `"1.2.3"` or `""`) reaches the same panic, because the crash is in range parsing, not in the comparison. The same `Query::parse` path is used by `bun install`'s resolver, so a malformed range in a dependency specifier could hit it too.

### Cause

In `src/semver/SemverQuery.rs` `parse()`, a garbage token (or `||`) resets the pending token tag to `TokenTag::None` and skips the round. If the next chunk starts with `-` (the `-` arm doesn't set a tag and doesn't skip the round) and the hyphen-range lookahead fails, the parser emits a comparator via `Token::to_range()` with the tag still `None`. `to_range()`'s `TokenTag::None` arm is `unreachable!()`.

The `count == 0` branch already guarded against this (leading `--foo` handling) and skipped the chunk, but the `count > 0` branches (`or_range`/`and_range`) did not, so the invariant only held for the first chunk.

### Fix

Hoist the `token.tag == TokenTag::None` check out of the `count == 0` branch so it applies to every chunk: when there is no pending comparator token, skip the chunk instead of emitting a comparator. This matches how the parser already ignores garbage chunks like `"1 || boop"`, and makes the `TokenTag::None => unreachable!()` arm genuinely unreachable (all `to_range()` call sites now guarantee a real tag).

### Verification

New test in `test/cli/install/semver.test.ts` runs the fuzzed range plus minimized variants in a subprocess and checks the results:

- without the fix: the subprocess panics with `internal error: entered unreachable code` → test fails
- with the fix: `bun bd test test/cli/install/semver.test.ts` → 24 pass, 0 fail

The fuzzed range evaluates to `true` against `""`/`"1.0.0"` because the parser is intentionally lenient with garbage comparators (same as the existing behavior for `Bun.semver.satisfies("1.0.0", "garbage")`); `"1 || -"` keeps the valid `1` comparator and ignores the dangling `-` chunk, matching how `"1 || boop"` is handled today.
