### PR TITLE
Fix YAML.stringify emitting invalid anchor names for keys with special characters

### DIFF
--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -270,13 +270,15 @@ impl Stringifier {
                     self.array_item_counter += 1;
                 }
                 AnchorAliasName::PropValue { prop_name, counter } => {
-                    // Property names that can't be reused as anchor names all
-                    // share the generated `value<counter>` namespace (keyed on
-                    // the empty name), so their counters can't collide.
+                    // Property names that can't be reused as anchor names fall
+                    // back to the generated `value<counter>` names. Their
+                    // counters are keyed on "value" so they share a sequence
+                    // with properties literally named "value", keeping every
+                    // emitted anchor name unique.
                     let key: &[u8] = if can_use_prop_name_as_anchor(prop_name) {
                         prop_name.byte_slice()
                     } else {
-                        b""
+                        b"value"
                     };
                     let name_entry = self.prop_names.get_or_put(key)?;
                     if name_entry.found_existing {
@@ -691,6 +693,10 @@ fn prop_value_needs_newline(value: JSValue) -> bool {
 /// encodings. Only reuse the property name when it consists entirely of
 /// unambiguously safe characters; otherwise the anchor falls back to a
 /// generated `value<counter>` name, like empty property names do.
+///
+/// Names that textually match a generated anchor name (`root<n>`, `item<n>`,
+/// `value<n>`) are also rejected so a verbatim name can never duplicate a
+/// generated one, which would make aliases resolve to the wrong node.
 fn can_use_prop_name_as_anchor(str: &BunString) -> bool {
     if str.is_empty() {
         return false;
@@ -708,7 +714,35 @@ fn can_use_prop_name_as_anchor(str: &BunString) -> bool {
         }
     }
 
-    true
+    !matches_generated_anchor_name(str)
+}
+
+/// True when `str` is one of the reserved generated-anchor prefixes followed
+/// by one or more digits (`value0`, `item12`, `root1`, ...).
+fn matches_generated_anchor_name(str: &BunString) -> bool {
+    const PREFIXES: [&[u8]; 3] = [b"value", b"item", b"root"];
+
+    'next_prefix: for prefix in PREFIXES {
+        if str.length() <= prefix.len() {
+            continue;
+        }
+
+        for (i, &byte) in prefix.iter().enumerate() {
+            if str.char_at(i) != u16::from(byte) {
+                continue 'next_prefix;
+            }
+        }
+
+        for i in prefix.len()..str.length() {
+            if !matches!(str.char_at(i), 0x30..=0x39 /* '0'..='9' */) {
+                continue 'next_prefix;
+            }
+        }
+
+        return true;
+    }
+
+    false
 }
 
 fn string_needs_quotes(str: &BunString) -> bool {

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -270,7 +270,15 @@ impl Stringifier {
                     self.array_item_counter += 1;
                 }
                 AnchorAliasName::PropValue { prop_name, counter } => {
-                    let name_entry = self.prop_names.get_or_put(prop_name.byte_slice())?;
+                    // Property names that can't be reused as anchor names all
+                    // share the generated `value<counter>` namespace (keyed on
+                    // the empty name), so their counters can't collide.
+                    let key: &[u8] = if can_use_prop_name_as_anchor(prop_name) {
+                        prop_name.byte_slice()
+                    } else {
+                        b""
+                    };
+                    let name_entry = self.prop_names.get_or_put(key)?;
                     if name_entry.found_existing {
                         *name_entry.value_ptr += 1;
                     } else {
@@ -408,7 +416,7 @@ impl Stringifier {
                     self.builder.append_usize(*counter);
                 }
                 AnchorAliasName::PropValue { prop_name, counter } => {
-                    if prop_name.length() == 0 {
+                    if !can_use_prop_name_as_anchor(prop_name) {
                         self.builder.append_latin1(b"value");
                         self.builder.append_usize(*counter);
                     } else {
@@ -672,6 +680,35 @@ impl Stringifier {
 /// Does this object property value need a newline? True for arrays and objects.
 fn prop_value_needs_newline(value: JSValue) -> bool {
     !value.is_number() && !value.is_boolean() && !value.is_null() && !value.is_string()
+}
+
+/// Can this property name be emitted verbatim as an anchor/alias name?
+///
+/// Anchor names cannot be quoted or escaped, so the name must re-parse exactly
+/// as written. YAML forbids whitespace, line breaks, and flow indicators
+/// (`,`, `[`, `]`, `{`, `}`) in anchor names; other characters (`#`, `:`,
+/// quotes, non-ASCII, ...) are ambiguous across flow/block contexts or
+/// encodings. Only reuse the property name when it consists entirely of
+/// unambiguously safe characters; otherwise the anchor falls back to a
+/// generated `value<counter>` name, like empty property names do.
+fn can_use_prop_name_as_anchor(str: &BunString) -> bool {
+    if str.is_empty() {
+        return false;
+    }
+
+    for i in 0..str.length() {
+        match str.char_at(i) {
+            0x30..=0x39 /* '0'..='9' */
+            | 0x41..=0x5a /* 'A'..='Z' */
+            | 0x61..=0x7a /* 'a'..='z' */
+            | 0x2d /* '-' */
+            | 0x2e /* '.' */
+            | 0x5f /* '_' */ => {}
+            _ => return false,
+        }
+    }
+
+    true
 }
 
 fn string_needs_quotes(str: &BunString) -> bool {

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -270,11 +270,8 @@ impl Stringifier {
                     self.array_item_counter += 1;
                 }
                 AnchorAliasName::PropValue { prop_name, counter } => {
-                    // Property names that can't be reused as anchor names fall
-                    // back to the generated `value<counter>` names. Their
-                    // counters are keyed on "value" so they share a sequence
-                    // with properties literally named "value", keeping every
-                    // emitted anchor name unique.
+                    // Unsafe names use generated `value<counter>` anchors, keyed on
+                    // "value" so the counter is shared with literal "value" properties.
                     let key: &[u8] = if can_use_prop_name_as_anchor(prop_name) {
                         prop_name.byte_slice()
                     } else {
@@ -685,18 +682,8 @@ fn prop_value_needs_newline(value: JSValue) -> bool {
 }
 
 /// Can this property name be emitted verbatim as an anchor/alias name?
-///
-/// Anchor names cannot be quoted or escaped, so the name must re-parse exactly
-/// as written. YAML forbids whitespace, line breaks, and flow indicators
-/// (`,`, `[`, `]`, `{`, `}`) in anchor names; other characters (`#`, `:`,
-/// quotes, non-ASCII, ...) are ambiguous across flow/block contexts or
-/// encodings. Only reuse the property name when it consists entirely of
-/// unambiguously safe characters; otherwise the anchor falls back to a
-/// generated `value<counter>` name, like empty property names do.
-///
-/// Names that textually match a generated anchor name (`root<n>`, `item<n>`,
-/// `value<n>`) are also rejected so a verbatim name can never duplicate a
-/// generated one, which would make aliases resolve to the wrong node.
+/// Anchor names can't be quoted or escaped, so only unambiguously safe characters
+/// are reused; anything else falls back to a generated `value<counter>` name.
 fn can_use_prop_name_as_anchor(str: &BunString) -> bool {
     if str.is_empty() {
         return false;
@@ -717,8 +704,7 @@ fn can_use_prop_name_as_anchor(str: &BunString) -> bool {
     !matches_generated_anchor_name(str)
 }
 
-/// True when `str` is one of the reserved generated-anchor prefixes followed
-/// by one or more digits (`value0`, `item12`, `root1`, ...).
+/// `value0`, `item12`, `root1`, ... — names that could duplicate a generated anchor name.
 fn matches_generated_anchor_name(str: &BunString) -> bool {
     const PREFIXES: [&[u8]; 3] = [b"value", b"item", b"root"];
 

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1,5 +1,6 @@
 import { YAML, file } from "bun";
 import { describe, expect, test } from "bun:test";
+import { isASAN, isDebug } from "harness";
 import { join } from "path";
 
 describe("Bun.YAML", () => {
@@ -1959,7 +1960,9 @@ config:
         },
       };
 
-      for (let i = 0; i < 10000; i++) {
+      // Debug/ASAN builds are much slower; keep this stress test within the default test timeout.
+      const iterations = isDebug || isASAN ? 1000 : 10000;
+      for (let i = 0; i < iterations; i++) {
         expect(YAML.stringify(config)).toBeString();
       }
     });
@@ -2042,6 +2045,58 @@ config:
         expect(parsed.a).not.toBe(parsed.c);
         expect(parsed.a.type).toBe("first");
         expect(parsed.c.type).toBe("second");
+      });
+
+      // Anchor names are derived from property names, but characters like
+      // flow indicators or whitespace are not valid in YAML anchor names,
+      // so stringify must not copy them into the anchor name verbatim.
+      test("anchors named after keys with special characters re-parse", () => {
+        const specialKeys = [
+          "\\u{10FFFF}a", // literal backslash-u-braces text, not a codepoint
+          "{",
+          "}",
+          "[",
+          "]",
+          ",",
+          "{a}",
+          "key[0]",
+          "a,b",
+          "a\\b",
+          "a b",
+          "a\tb",
+          "a\nb",
+          " ",
+          "key:with#chars",
+          "🙂emoji",
+        ];
+
+        for (const key of specialKeys) {
+          const shared = [1, 2];
+          const obj = { [key]: shared, other: shared };
+
+          for (const space of [undefined, 2]) {
+            const yaml = YAML.stringify(obj, null, space);
+            const parsed = YAML.parse(yaml);
+            expect(parsed).toEqual({ [key]: [1, 2], other: [1, 2] });
+            expect(parsed[key]).toBe(parsed.other);
+          }
+        }
+      });
+
+      test("falls back to generated anchor names for unsafe keys", () => {
+        const shared = [1, 2];
+        expect(YAML.stringify({ "a[b]": shared, other: shared })).toBe('{"a[b]": &value0 [1,2],other: *value0}');
+      });
+
+      test("round-trips parsed documents whose aliased keys contain flow indicators", () => {
+        const doc = "\\u{10FFFF}a: &x [1, 2]\nb: *x";
+        const value = YAML.parse(doc);
+        expect(value).toEqual({ "\\u{10FFFF}a": [1, 2], b: [1, 2] });
+
+        const yaml = YAML.stringify(value);
+        const reparsed = YAML.parse(yaml);
+        expect(reparsed).toEqual(value);
+        expect(reparsed["\\u{10FFFF}a"]).toBe(reparsed.b);
       });
     });
 

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -2047,9 +2047,6 @@ config:
         expect(parsed.c.type).toBe("second");
       });
 
-      // Anchor names are derived from property names, but characters like
-      // flow indicators or whitespace are not valid in YAML anchor names,
-      // so stringify must not copy them into the anchor name verbatim.
       test("anchors named after keys with special characters re-parse", () => {
         const specialKeys = [
           "\\u{10FFFF}a", // literal backslash-u-braces text, not a codepoint
@@ -2088,9 +2085,6 @@ config:
         expect(YAML.stringify({ "a[b]": shared, other: shared })).toBe('{"a[b]": &value0 [1,2],other: *value0}');
       });
 
-      // Keys that literally look like generated anchor names (value0, item0, ...)
-      // must not produce the same anchor name as a generated one, otherwise the
-      // aliases silently resolve to the wrong node after a round-trip.
       test("generated anchor names cannot collide with keys named like them", () => {
         const cases: Array<{ obj: Record<string, unknown>; expected: Record<string, unknown> }> = [];
 

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -2088,6 +2088,48 @@ config:
         expect(YAML.stringify({ "a[b]": shared, other: shared })).toBe('{"a[b]": &value0 [1,2],other: *value0}');
       });
 
+      // Keys that literally look like generated anchor names (value0, item0, ...)
+      // must not produce the same anchor name as a generated one, otherwise the
+      // aliases silently resolve to the wrong node after a round-trip.
+      test("generated anchor names cannot collide with keys named like them", () => {
+        const cases: Array<{ obj: Record<string, unknown>; expected: Record<string, unknown> }> = [];
+
+        {
+          // literal "value0" key vs generated name for an unsafe key
+          const a = [1];
+          const b = [2];
+          cases.push({
+            obj: { value0: a, "[k]": b, x: a, y: b },
+            expected: { value0: [1], "[k]": [2], x: [1], y: [2] },
+          });
+        }
+        {
+          // literal "value0" key vs generated name for an empty key
+          const a = [1];
+          const b = [2];
+          cases.push({
+            obj: { "": a, value0: b, x: a, y: b },
+            expected: { "": [1], value0: [2], x: [1], y: [2] },
+          });
+        }
+        {
+          // literal "item0" key vs array item anchor names
+          const a = [1];
+          const b = [2];
+          cases.push({
+            obj: { item0: a, list: [b, b], x: a },
+            expected: { item0: [1], list: [[2], [2]], x: [1] },
+          });
+        }
+
+        for (const { obj, expected } of cases) {
+          for (const space of [undefined, 2]) {
+            const parsed = YAML.parse(YAML.stringify(obj, null, space));
+            expect(parsed).toEqual(expected);
+          }
+        }
+      });
+
       test("round-trips parsed documents whose aliased keys contain flow indicators", () => {
         const doc = "\\u{10FFFF}a: &x [1, 2]\nb: *x";
         const value = YAML.parse(doc);


### PR DESCRIPTION
### What does this PR do?

Fixes `Bun.YAML.stringify` producing output that fails to re-parse when an anchor name is derived from a property name containing characters that are not valid in YAML anchor names (found by fuzzing).

**Repro:**

```js
const v = Bun.YAML.parse("\\u{10FFFF}a: &x [1, 2]\nb: *x"); // key is the literal text "\u{10FFFF}a"
const s = Bun.YAML.stringify(v);
// {"\u{10FFFF}a": &\u{10FFFF}a [1,2],b: *\u{10FFFF}a}
Bun.YAML.parse(s); // SyntaxError: YAML Parse error: Unexpected token
```

Any key containing `{`, `}`, `[`, `]`, `,`, whitespace, etc. triggers it when the value is a shared object/array.

**Cause:** when `stringify` detects a shared object/array it emits an anchor/alias, and the anchor name is copied verbatim from the property name the value was first seen under. YAML anchor names cannot contain whitespace, line breaks, or flow indicators (`,[]{}`) and cannot be quoted or escaped, so such names make the document unparseable (or structurally ambiguous in flow context).

**Fix** (`src/runtime/api/YAMLObject.rs`):

- A property name is only reused as an anchor name when it consists entirely of unambiguously safe characters (ASCII alphanumeric, `-`, `.`, `_`). Anything else falls back to the generated `value<n>` names, the same path empty property names already use.
- Property names that textually match a generated anchor name (`value<n>`, `item<n>`, `root<n>`) are also routed to the generated namespace, and the generated counter shares its sequence with properties literally named `value`, so the generated fallback cannot duplicate an anchor named after such a key. Pre-existing suffix-counter collisions that already exist on main (e.g. a `foo` key's dedup suffix `foo1` vs a literal `foo1` key, or an `item` key's dedup suffix vs array-item anchors) are unchanged here.

Anchor naming for ordinary keys is unchanged (`&data`, `&item1`, `&value0`, ... as before); all existing inline snapshots pass unchanged.

Also reduces the iteration count of the pre-existing "strings are properly referenced" stress test on debug/ASAN builds (10000 → 1000) so `bun bd test test/js/bun/yaml/yaml.test.ts` stays within the default per-test timeout; release builds keep the full 10000 iterations.

### How did you verify your code works?

New tests in `test/js/bun/yaml/yaml.test.ts`:

- `anchors named after keys with special characters re-parse` — round-trips objects whose shared values sit under keys containing flow indicators, whitespace, backslashes, `#`/`:`, and non-ASCII, in both minified and indented modes, asserting the output re-parses, deep-equals the input, and preserves alias identity.
- `falls back to generated anchor names for unsafe keys` — asserts the exact emitted output uses `&value0`/`*value0`.
- `generated anchor names cannot collide with keys named like them` — documents containing literal `value0`/`item0` keys alongside generated anchor names round-trip with aliases resolving to the correct nodes.
- `round-trips parsed documents whose aliased keys contain flow indicators` — the original fuzz case (parse → stringify → parse).

Without the fix these tests fail with `YAML Parse error: Unexpected token`/`Unexpected character`; with the fix the whole file passes (351 pass / 0 fail) on a debug ASAN build.
