### PR TITLE
parser: reject for-in/for-of head declarations with invalid initializers

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4586,7 +4586,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             0 => {}
             1 => {
                 if let Some(value) = &decls[0].value {
-                    if is_var {
+                    if is_var && matches!(decls[0].binding.data, js_ast::b::B::BIdentifier(_)) {
                         // This is a weird special case. Initializers are allowed in "var"
                         // statements with identifier bindings.
                         return Ok(());

--- a/src/js_parser/p.zig
+++ b/src/js_parser/p.zig
@@ -3106,7 +3106,7 @@ pub fn NewParser_(
                 0 => {},
                 1 => {
                     if (decls[0].value) |value| {
-                        if (is_var) {
+                        if (is_var and decls[0].binding.data == .b_identifier) {
 
                             // This is a weird special case. Initializers are allowed in "var"
                             // statements with identifier bindings.

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -588,6 +588,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     match res.stmt_or_expr {
                         js_ast::StmtOrExpr::Stmt(stmt) => {
                             bad_let_range = None;
+                            // Keep the "let"/"using" declarations visible to the for-in/for-of
+                            // checks below ("forbid_initializers"), like the "var"/"const" arms.
+                            decls_ptr = bun_ast::StoreSlice::new(res.decls.slice());
                             init_ = Some(stmt);
                         }
                         js_ast::StmtOrExpr::Expr(expr) => {

--- a/src/js_parser/parse/parse_stmt.zig
+++ b/src/js_parser/parse/parse_stmt.zig
@@ -830,6 +830,9 @@ pub fn ParseStmt(
                     switch (res.stmt_or_expr) {
                         .stmt => |stmt| {
                             bad_let_range = null;
+                            // Keep the "let"/"using" declarations visible to the for-in/for-of
+                            // checks below ("forbidInitializers"), like the "var"/"const" cases.
+                            decls = .fromOwnedSlice(res.decls);
                             init_ = stmt;
                         },
                         .expr => |expr| {

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1166,8 +1166,8 @@ pub struct ExprOrLetStmt {
     // PORT NOTE: Zig writes `.decls = decls.slice()` borrowing the heap buffer
     // that was just moved into `S::Local`. The buffer pointer is stable across
     // the move, but borrowck can't see that — store as `RawSlice` to record the
-    // outlives-holder invariant without a per-site unsafe cast. (Neither caller
-    // currently reads this field, matching parseStmt.zig:829-836.)
+    // outlives-holder invariant without a per-site unsafe cast. Read by the
+    // for-loop parser so for-in/for-of heads can validate "let"/"using" decls.
     pub decls: bun_collections::RawSlice<G::Decl>,
 }
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2192,6 +2192,36 @@ console.log(resolve.length)
       expectParseError("for ([...a, b] of c) {}", 'Unexpected "," after rest pattern');
     });
 
+    it("for-in and for-of loop initializers", () => {
+      // Annex B: a plain identifier "var" binding may keep its initializer in a sloppy-mode for-in
+      expectPrintedNoTrim("for (var x = 1 in y) ;", "x = 1;\nfor (x in y)\n  ;\nvar x;\n");
+
+      // A destructuring binding can never have an initializer in a for-in/for-of head
+      expectParseError("for (var [a] = 1 in y) ;", "for-in loop variables cannot have an initializer");
+      expectParseError("for (var {a} = 1 in y) ;", "for-in loop variables cannot have an initializer");
+      expectParseError("for (var [a] = 1 of y) ;", "for-of loop variables cannot have an initializer");
+      expectParseError("for (var {a} = 1 of y) ;", "for-of loop variables cannot have an initializer");
+
+      // "let" and "const" bindings can never have an initializer in a for-in/for-of head
+      expectParseError("for (let x = 1 in y) ;", "for-in loop variables cannot have an initializer");
+      expectParseError("for (let x = 1 of y) ;", "for-of loop variables cannot have an initializer");
+      expectParseError("for (let [a] = 1 in y) ;", "for-in loop variables cannot have an initializer");
+      expectParseError("for (let {a} = 1 of y) ;", "for-of loop variables cannot have an initializer");
+      expectParseError("for (const x = 1 in y) ;", "for-in loop variables cannot have an initializer");
+      expectParseError("for (const x = 1 of y) ;", "for-of loop variables cannot have an initializer");
+
+      // for-in/for-of heads must have exactly one declaration
+      expectParseError("for (var x, y in z) ;", "for-in loops must have a single declaration");
+      expectParseError("for (let x, y in z) ;", "for-in loops must have a single declaration");
+      expectParseError("for (let x, y of z) ;", "for-of loops must have a single declaration");
+
+      // Declarations without an initializer are still allowed
+      expectPrintedNoTrim("for (var x in y) ;", "for (x in y)\n  ;\nvar x;\n");
+      expectPrintedNoTrim("for (var [a] in y) ;", "for ([a] in y)\n  ;\nvar a;\n");
+      expectPrintedNoTrim("for (let [a] of y) ;", "for (let [a] of y)\n  ;\n");
+      expectPrintedNoTrim("for (const {a} of y) ;", "for (const { a } of y)\n  ;\n");
+    });
+
     it("regexp", () => {
       expectPrinted("/x/g", "/x/g");
       expectPrinted("/x/i", "/x/i");


### PR DESCRIPTION
### Reproduction

Found by parser fuzzing — the transpiler accepts a for-in head that is a SyntaxError per spec, and its own output cannot be re-parsed:

```console
$ bun -e 'console.log(new Bun.Transpiler({loader:"js"}).transformSync("for (var [a] = 5e-324 in {});"))'
for ([a] = 0.000000…0005 in {})
  ;
var a;
```

V8/JSC/esbuild all reject the input (`for-in loop variable declaration may not have an initializer`); Bun accepted it and emitted `[a] = … in {}` as a for-in target, which is an invalid assignment target everywhere (including Bun itself). The same hole existed for `let`:

```js
for (let x = 1 in y) ;     // accepted, printed verbatim → invalid output
for (let [a] = 1 of y) ;   // accepted
for (let x, y in z) ;      // accepted
```

### Cause

Two gaps in the for-in/for-of head validation in `src/js_parser`:

1. `forbid_initializers` (`p.rs`) implements the Annex B special case — a sloppy-mode `var` may keep its initializer — but didn't check that the binding is a plain identifier, unlike esbuild's `forbidInitializers`. Destructuring `var` bindings with initializers slipped through.
2. The for-head parser (`parse/parse_stmt.rs`) only tracked decls from the `var`/`const` arms. The decls returned by `parse_expr_or_let_stmt` (for `let`/`using` heads) were never handed to `forbid_initializers`, so `let` declarations in a for-in/for-of head were never validated (initializers and multi-declaration heads both slipped through). The `ExprOrLetStmt.decls` field already existed for this purpose but was unread.

### Fix

- `forbid_initializers` only allows the var-with-initializer special case when the binding is a `B::BIdentifier`, matching esbuild.
- The for-head parser threads `res.decls` from `parse_expr_or_let_stmt` into the existing for-in/for-of checks, so `let`/`using` declarations are validated like `var`/`const`.
- The Zig porting references (`p.zig`, `parse/parse_stmt.zig`) are updated in lockstep.

Still accepted (unchanged): `for (var x = 1 in y)` (Annex B), `for (var [a] in y)`, `for (let [a] of y)`, `for (using x of y)`, `for (await using x of y)`, and the TypeScript `for (var x = Array < number > in y)` case covered by existing tests.

Not touched here: the `5e-324` → 320-character decimal expansion in the repro output is a separate, pre-existing printer behavior (the non-integer float path prints shortest-digits decimal form without exponent notation; the output is valid and round-trips). It's already tracked by a `TODO(port)` in `src/js_printer/lib.rs`.

### Test

`test/bundler/transpiler/transpiler.test.js` → `parser > for-in and for-of loop initializers`: asserts parse errors for destructuring/`let`/`const` initializers and multi-declaration heads in for-in/for-of, and asserts the still-valid forms keep their current output. The test fails on an unmodified build (the invalid forms are accepted) and passes with this change.

### Verification

- `bun bd test test/bundler/transpiler/transpiler.test.js` — 115 pass, 0 fail
- `bun bd test test/bundler/esbuild/default.test.ts` — 150 pass, 0 fail (includes the var-relocation fixtures using `for (var i = 1 in {})`)
- `bun bd test test/bundler/esbuild/ts.test.ts` — 57 pass, 0 fail
- `bun bd test test/bundler/transpiler/runtime-transpiler.test.ts` — 13 pass, 0 fail
- `bun bd test test/cli/run/syntax.test.ts` — 590 pass, 0 fail
- `bun bd test test/js/bun/resolve/lower-using-bun-target.test.ts` — 11 pass, 0 fail
- `cargo check -p bun_js_parser`, `cargo fmt --check`, prettier — clean
