### PR TITLE
Reject `export` of a block-scoped function declaration instead of emitting unparseable output

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3390,11 +3390,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     let original_member_ref = value.ref_;
 
                     if self.symbols[symbol_idx].kind == js_ast::symbol::Kind::HoistedFunction {
-                        // Block-level function declarations behave like "let" in strict mode,
-                        // so they must stay scoped to the block they were declared in. This
-                        // keeps the symbol model in sync with the printed output (the printer
-                        // lowers them to a "let" inside the block), e.g. so that
-                        // "export {f}" of a block-scoped function is reported as an error.
+                        // Block-level function declarations behave like "let" in strict mode
                         if scope_strict_mode != js_ast::StrictModeKind::SloppyMode {
                             continue;
                         }
@@ -3417,9 +3413,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         //   }
                         //   f();
                         //
-                        // The two symbols share the same original name, so this form is only
-                        // printable when the renamer runs (bundling/minifying). Otherwise the
-                        // function symbol itself is hoisted below.
                         if self.will_use_renamer() {
                             // `Symbol.original_name` is an arena-owned `StoreStr` valid for 'a.
                             let original_name: &'a [u8] =

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3389,10 +3389,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     let mut is_sloppy_mode_block_level_fn_stmt = false;
                     let original_member_ref = value.ref_;
 
-                    if self.will_use_renamer()
-                        && self.symbols[symbol_idx].kind == js_ast::symbol::Kind::HoistedFunction
-                    {
-                        // Block-level function declarations behave like "let" in strict mode
+                    if self.symbols[symbol_idx].kind == js_ast::symbol::Kind::HoistedFunction {
+                        // Block-level function declarations behave like "let" in strict mode,
+                        // so they must stay scoped to the block they were declared in. This
+                        // keeps the symbol model in sync with the printed output (the printer
+                        // lowers them to a "let" inside the block), e.g. so that
+                        // "export {f}" of a block-scoped function is reported as an error.
                         if scope_strict_mode != js_ast::StrictModeKind::SloppyMode {
                             continue;
                         }
@@ -3415,20 +3417,25 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         //   }
                         //   f();
                         //
-                        // `Symbol.original_name` is an arena-owned `StoreStr` valid for 'a.
-                        let original_name: &'a [u8] =
-                            self.symbols[symbol_idx].original_name.slice();
-                        let hoisted_ref = self
-                            .new_symbol(js_ast::symbol::Kind::Hoisted, original_name)
-                            .expect("unreachable");
-                        // No live `&` borrow of `scope` exists here (the members
-                        // snapshot was taken by value); `StoreRef` `DerefMut`.
-                        VecExt::append(&mut scope.generated, hoisted_ref);
-                        self.hoisted_ref_for_sloppy_mode_block_fn
-                            .insert(value.ref_, hoisted_ref);
-                        value.ref_ = hoisted_ref;
-                        symbol_idx = hoisted_ref.inner_index() as usize;
-                        is_sloppy_mode_block_level_fn_stmt = true;
+                        // The two symbols share the same original name, so this form is only
+                        // printable when the renamer runs (bundling/minifying). Otherwise the
+                        // function symbol itself is hoisted below.
+                        if self.will_use_renamer() {
+                            // `Symbol.original_name` is an arena-owned `StoreStr` valid for 'a.
+                            let original_name: &'a [u8] =
+                                self.symbols[symbol_idx].original_name.slice();
+                            let hoisted_ref = self
+                                .new_symbol(js_ast::symbol::Kind::Hoisted, original_name)
+                                .expect("unreachable");
+                            // No live `&` borrow of `scope` exists here (the members
+                            // snapshot was taken by value); `StoreRef` `DerefMut`.
+                            VecExt::append(&mut scope.generated, hoisted_ref);
+                            self.hoisted_ref_for_sloppy_mode_block_fn
+                                .insert(value.ref_, hoisted_ref);
+                            value.ref_ = hoisted_ref;
+                            symbol_idx = hoisted_ref.inner_index() as usize;
+                            is_sloppy_mode_block_level_fn_stmt = true;
+                        }
                     }
 
                     if hash.is_none() {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3806,10 +3806,6 @@ const Layout = () => {
 });
 
 describe("export of a block-scoped function declaration", () => {
-  // In a module, a function declaration inside a block is block-scoped (modules are
-  // strict mode), so "export { name }" at module scope must be rejected up front.
-  // Previously the transpiler accepted it, lowered the function to a "let" inside the
-  // block, and still emitted the top-level export clause - output that fails to parse.
   const code = "{\n  function encrypt() {}\n}\nexport { encrypt }";
 
   function expectNotDeclaredError(loader) {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, hideFromStackTrace } from "harness";
+import { bunEnv, bunExe, hideFromStackTrace, tempDir } from "harness";
 import { join } from "path";
 
 describe("Bun.Transpiler", () => {
@@ -3802,5 +3802,72 @@ const Layout = () => {
     const result = transpiler.transformSync(code);
     expect(result).toContain("a: 1");
     expect(result).not.toContain("fn(");
+  });
+});
+
+describe("export of a block-scoped function declaration", () => {
+  // In a module, a function declaration inside a block is block-scoped (modules are
+  // strict mode), so "export { name }" at module scope must be rejected up front.
+  // Previously the transpiler accepted it, lowered the function to a "let" inside the
+  // block, and still emitted the top-level export clause - output that fails to parse.
+  const code = "{\n  function encrypt() {}\n}\nexport { encrypt }";
+
+  function expectNotDeclaredError(loader) {
+    const transpiler = new Bun.Transpiler({ loader });
+    try {
+      transpiler.transformSync(code);
+      expect.unreachable();
+    } catch (e) {
+      const error = e instanceof AggregateError ? e.errors[0] : e;
+      expect(error.message).toBe('"encrypt" is not declared in this file');
+    }
+  }
+
+  it("is a parse error for JavaScript", () => {
+    expectNotDeclaredError("js");
+  });
+
+  it("is a parse error for JSX", () => {
+    expectNotDeclaredError("jsx");
+  });
+
+  it("is stripped like a type-only export for TypeScript", () => {
+    const transpiler = new Bun.Transpiler({ loader: "ts" });
+    const out = transpiler.transformSync(code);
+    expect(out).not.toContain("export { encrypt }");
+  });
+
+  it("still allows exporting a top-level function declaration", () => {
+    const transpiler = new Bun.Transpiler({ loader: "js" });
+    const out = transpiler.transformSync("function encrypt() {}\nexport { encrypt }");
+    expect(out).toContain("export { encrypt }");
+  });
+
+  it("still allows exporting a var declared inside a block", () => {
+    const transpiler = new Bun.Transpiler({ loader: "js" });
+    const out = transpiler.transformSync("{\n  var encrypt = 1;\n}\nexport { encrypt }");
+    expect(out).toContain("export { encrypt }");
+  });
+
+  it("does not affect block-level function declarations in sloppy mode", () => {
+    const transpiler = new Bun.Transpiler({ loader: "js" });
+    const out = transpiler.transformSync("{\n  function f() {}\n}\nmodule.exports = f;");
+    expect(out).toContain("let f = function");
+    expect(out).toContain("module.exports = f");
+  });
+
+  it("reports the error when running a module with this pattern", async () => {
+    using dir = tempDir("block-scoped-fn-export", {
+      "mod.mjs": code + "\n",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "mod.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain('"encrypt" is not declared in this file');
+    expect(exitCode).toBe(1);
   });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes the transpiler accepting an `export` of a name that is only declared as a block-level function declaration, and then emitting output that fails to re-parse.

```js
// repro.mjs
{
  function encrypt() {}
}
export { encrypt }
```

```
❯ bun -e 'console.log(new Bun.Transpiler({loader:"jsx"}).transformSync("{\n  function encrypt() {}\n}\nexport { encrypt }"))'
{
  let encrypt = function() {};
}

export { encrypt };
```

Modules are strict mode, so `encrypt` is block-scoped and `export { encrypt }` references an undeclared name — the emitted code itself fails to parse (`"encrypt" is not declared in this file`), and running such a file surfaces a confusing downstream JSC error (`Exported binding 'encrypt' needs to refer to a top-level declared variable`). `bun build` already rejects this input with the proper error; only the non-bundling path (runtime transpiler / `Bun.Transpiler`) accepted it.

### Cause

`hoist_symbols` in `src/js_parser/p.rs` implements the esbuild rule "block-level function declarations behave like `let` in strict mode" (i.e. they must not be hoisted out of the block), but that check sat inside a `will_use_renamer()` gate. The gate was added in #2864 to stop the sloppy-mode Annex-B transform (`let f2 = function() {}; var f = f2;`) from emitting colliding names when the renamer doesn't run (#2862) — but it also disabled the strict-mode check. Without the renamer, the block-scoped function symbol was hoisted into the module scope, so `export { encrypt }` passed validation against a scope model that doesn't match the printed output (which keeps the declaration inside the block as a `let`).

### Fix

Apply the strict-mode check unconditionally, matching esbuild and the bundler path. Only the sloppy-mode let/var sibling transform stays behind the renamer gate, so the #2862 fix is preserved and sloppy-mode (CommonJS) behavior is unchanged.

With this change the runtime transpiler reports the same error as `bun build`:

```
❯ bun repro.mjs
4 | export { encrypt }
             ^
error: "encrypt" is not declared in this file
    at repro.mjs:4:10
```

For TypeScript inputs the unbound export name is silently stripped, consistent with how other non-local names in `export {}` clauses are treated there (they may be type-only exports).

### How did you verify your code works?

Added tests in `test/bundler/transpiler/transpiler.test.js`:

- `export` of a block-scoped function is a parse error for `js` and `jsx` loaders, and is stripped for `ts`
- running a module with this pattern reports the parser error
- exporting a top-level function declaration and a `var` declared inside a block still works
- sloppy-mode block-level function declarations are unaffected

The new tests fail on the current release build and pass with this change. The full `test/bundler/transpiler/` suite and `test/js/bun/transpiler/` pass with the change (the only failure is the pre-existing, unrelated `scope-mismatch-panic.test.ts` react resolution issue which also fails without this change).