### PR TITLE
Fix panic on unterminated template literal after TypeScript type arguments

### DIFF
--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -266,7 +266,6 @@ pub struct LexerSnapshot<'a> {
     pub current: usize,
     pub start: usize,
     pub end: usize,
-    pub did_panic: bool,
     pub approximate_newline_count: usize,
     pub previous_backslash_quote_in_jsx: Range,
     pub token: T,
@@ -347,7 +346,6 @@ pub struct LexerType<
     pub current: usize,
     pub start: usize,
     pub end: usize,
-    pub did_panic: bool,
     pub approximate_newline_count: usize,
     pub previous_backslash_quote_in_jsx: Range,
     pub token: T,
@@ -529,7 +527,6 @@ lexer_impl_header! {
             current: self.current,
             start: self.start,
             end: self.end,
-            did_panic: self.did_panic,
             approximate_newline_count: self.approximate_newline_count,
             previous_backslash_quote_in_jsx: self.previous_backslash_quote_in_jsx,
             token: self.token,
@@ -570,7 +567,6 @@ lexer_impl_header! {
         self.current = original.current;
         self.start = original.start;
         self.end = original.end;
-        self.did_panic = original.did_panic;
         self.approximate_newline_count = original.approximate_newline_count;
         self.previous_backslash_quote_in_jsx = original.previous_backslash_quote_in_jsx;
         self.token = original.token;
@@ -2284,7 +2280,6 @@ lexer_impl_header! {
             }
         };
 
-        self.did_panic = true;
         self.add_range_error(
             self.range(),
             format_args!("Unexpected {}", bstr::BStr::new(found)),
@@ -2716,7 +2711,6 @@ lexer_impl_header! {
             current: 0,
             start: 0,
             end: 0,
-            did_panic: false,
             approximate_newline_count: 0,
             previous_backslash_quote_in_jsx: Range::NONE,
             token: T::TEndOfFile,

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -1418,11 +1418,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         match func(self) {
             Ok(_) => {}
             Err(_) => {
-                // Backtrack on *any* error, not just an explicit `Backtrack`: errors raised
-                // while the log is disabled (e.g. an unterminated template literal hitting
-                // EOF mid-scan) are suppressed, so the lexer must be restored rather than
-                // left on a half-scanned token. Normal parsing then re-encounters and
-                // reports the error.
                 backtrack = true;
             }
         }
@@ -1451,7 +1446,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let result = match func(self) {
             Ok(r) => r,
             Err(_) => {
-                // See `lexer_backtracker_bool`: restore the lexer on any error.
                 backtrack = true;
                 SkipTypeParameterResult::DidNotSkipAnything
             }
@@ -1479,7 +1473,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         match func(self) {
             Ok(_) => {}
             Err(_) => {
-                // See `lexer_backtracker_bool`: restore the lexer on any error.
                 backtrack = true;
             }
         }

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -1417,10 +1417,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut backtrack = false;
         match func(self) {
             Ok(_) => {}
-            Err(e) => {
-                if e == err!("Backtrack") || self.lexer.did_panic {
-                    backtrack = true;
-                }
+            Err(_) => {
+                // Backtrack on *any* error, not just an explicit `Backtrack`: errors raised
+                // while the log is disabled (e.g. an unterminated template literal hitting
+                // EOF mid-scan) are suppressed, so the lexer must be restored rather than
+                // left on a half-scanned token. Normal parsing then re-encounters and
+                // reports the error.
+                backtrack = true;
             }
         }
 
@@ -1447,10 +1450,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut backtrack = false;
         let result = match func(self) {
             Ok(r) => r,
-            Err(e) => {
-                if e == err!("Backtrack") || self.lexer.did_panic {
-                    backtrack = true;
-                }
+            Err(_) => {
+                // See `lexer_backtracker_bool`: restore the lexer on any error.
+                backtrack = true;
                 SkipTypeParameterResult::DidNotSkipAnything
             }
         };
@@ -1468,8 +1470,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     where
         F: FnOnce(&mut Self) -> Result<bool, Error>,
     {
-        // PORT NOTE: matches Zig `lexerBacktrackerWithArgs` — does NOT check `did_panic` on
-        // non-Backtrack errors (unlike `lexerBacktracker`).
         self.mark_type_script_only();
         let old_lexer = self.lexer.snapshot();
         let old_log_disabled = self.lexer.is_log_disabled;
@@ -1478,10 +1478,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut backtrack = false;
         match func(self) {
             Ok(_) => {}
-            Err(e) => {
-                if e == err!("Backtrack") {
-                    backtrack = true;
-                }
+            Err(_) => {
+                // See `lexer_backtracker_bool`: restore the lexer on any error.
+                backtrack = true;
             }
         }
 

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -1459,33 +1459,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         result
     }
 
-    #[inline]
-    fn lexer_backtracker_with_args_bool<F>(&mut self, func: F) -> bool
-    where
-        F: FnOnce(&mut Self) -> Result<bool, Error>,
-    {
-        self.mark_type_script_only();
-        let old_lexer = self.lexer.snapshot();
-        let old_log_disabled = self.lexer.is_log_disabled;
-        self.lexer.is_log_disabled = true;
-
-        let mut backtrack = false;
-        match func(self) {
-            Ok(_) => {}
-            Err(_) => {
-                backtrack = true;
-            }
-        }
-
-        if backtrack {
-            self.lexer.restore(&old_lexer);
-        }
-        self.lexer.is_log_disabled = old_log_disabled;
-
-        // FnReturnType == anyerror!bool path: returns true on success, false on backtrack.
-        !backtrack
-    }
-
     pub fn skip_type_script_type_parameters_then_open_paren_with_backtracking(
         &mut self,
     ) -> Result<SkipTypeParameterResult, Error> {
@@ -1575,7 +1548,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         &mut self,
         flags: SkipTypeOptionsBitset,
     ) -> bool {
-        self.lexer_backtracker_with_args_bool(|p| {
+        self.lexer_backtracker_bool(|p| {
             p.skip_type_script_constraint_of_infer_type_with_backtracking(flags)
         })
     }

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -163,6 +163,21 @@ describe("Bun.Transpiler", () => {
       err("const x: Foo<> = {}", "Unexpected >");
     });
 
+    it("does not crash on an unterminated template literal after type arguments", () => {
+      const exp = ts.expectPrinted_;
+      const err = ts.expectParseError;
+
+      // An unterminated template literal reached while speculatively parsing `<T>`
+      // as type arguments must be reported as a parse error, not crash the parser.
+      err("new C<T>\n`", "Unterminated string literal");
+      err("new C<T>`", "Unterminated string literal");
+      err("f<T>`", "Unterminated string literal");
+
+      // Terminated tagged templates after type arguments still transpile.
+      exp("new C<T>`ok`", "new C`ok`;\n");
+      exp("f<T>`ok`", "f`ok`;\n");
+    });
+
     it("should parse infer extends ternary correctly #9959", () => {
       ts.expectPrinted_("type Foo<T> = T extends infer U ? U : never;", "");
       ts.expectPrinted_("var foo: Foo extends string | infer Foo extends string ? Foo : never", "var foo");

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -166,14 +166,9 @@ describe("Bun.Transpiler", () => {
     it("does not crash on an unterminated template literal after type arguments", () => {
       const exp = ts.expectPrinted_;
       const err = ts.expectParseError;
-
-      // An unterminated template literal reached while speculatively parsing `<T>`
-      // as type arguments must be reported as a parse error, not crash the parser.
       err("new C<T>\n`", "Unterminated string literal");
       err("new C<T>`", "Unterminated string literal");
       err("f<T>`", "Unterminated string literal");
-
-      // Terminated tagged templates after type arguments still transpile.
       exp("new C<T>`ok`", "new C`ok`;\n");
       exp("f<T>`ok`", "f`ok`;\n");
     });


### PR DESCRIPTION
## Reproduction

```console
$ bun -e 'new Bun.Transpiler({ loader: "ts" }).transformSync("new C<T>\n`")'
panic: slice index starts at 10 but ends at 9
```

Also crashes for `new C<T>` + backtick without the newline, and for plain call targets (`f<T>` + backtick). Both pieces are required: TypeScript type arguments followed by an unterminated template literal.

## Cause

When the parser sees `C<T>` it speculatively parses `<T>` as TypeScript type arguments with the lexer log disabled, via the backtracking helpers in `src/js_parser/parse/parse_skip_typescript.rs`.

1. `skip_type_script_type_arguments` consumes `<T>` and its trailing `expect_greater_than` advances the lexer, which scans the backtick.
2. The template literal hits EOF, so the lexer reports "Unterminated string literal" via `add_default_error` — suppressed because the log is disabled — and returns a plain `SyntaxError`.
3. `lexer_backtracker_bool` only restored the lexer snapshot for an explicit `Backtrack` error or when `lexer.did_panic` was set. A plain `SyntaxError` matched neither, so the error was swallowed, the lexer was **not** restored, and the helper reported the type arguments as successfully skipped.
4. The suffix loop then treats the half-scanned token (`start = 9`, `end = 10`, no closing backtick) as a tagged template and `raw_template_contents()` slices `contents[start + 1 .. end - 1]` = `contents[10..9]` → panic.

## Fix

Restore the lexer snapshot on **any** error during the speculative parse (all three backtracking helpers), not just `Backtrack`/`did_panic`. Errors raised while the log is disabled are suppressed, so the lexer must never be left mid-token; after backtracking, normal parsing re-scans the template and reports the real "Unterminated string literal" syntax error. This matches the original esbuild behavior, where any lexer panic during backtracking restores the saved lexer state.

Related: #30894 fixes a different trigger of the same panicking slice (JSX error recovery) by clamping in `raw_template_contents`. That clamp alone would not be enough here — with the swallowed error this input would silently transpile instead of reporting the syntax error, which is why this fixes the backtracking path itself.

## Verification

```console
$ bun-debug -e 'new Bun.Transpiler({ loader: "ts" }).transformSync("new C<T>\n`")'
error: Unterminated string literal
```

New test in `test/bundler/transpiler/transpiler.test.js` ("does not crash on an unterminated template literal after type arguments") covers the three crashing inputs plus terminated tagged templates after type arguments, which still transpile unchanged. Without the fix the test binary panics with the slice-index message; with the fix the whole file passes (115 pass / 0 fail).
