### PR TITLE
parser: fix scope underflow panic when a TS contextual keyword starts a larger expression

### DIFF
--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1687,17 +1687,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 if p.lexer.token == T::TColon && !opts.has_decorators() {
                     return Self::parse_labeled_stmt(p, opts, loc, expr.loc, ident.ref_);
                 }
-            }
 
-            if Self::IS_TYPESCRIPT_ENABLED {
-                if let Some(ts_stmt) = js_lexer::TypescriptStmtKeyword::from_bytes(name) {
-                    // Hand the cold TS-keyword statement forms (`type`/`interface`/`namespace`/
-                    // `module`/`abstract`/`global`/`declare`) to an out-of-line helper so the
-                    // common `SExpr` fall-through keeps a small stack frame.
-                    if let Some(stmt) =
-                        Self::parse_stmt_fallthrough_ts_keyword(p, opts, loc, ts_stmt)?
-                    {
-                        return Ok(stmt);
+                // The TS contextual statement keywords only apply when the parsed
+                // expression is still just the bare identifier. If the identifier was
+                // consumed as part of a larger expression (e.g. "declare = () => {}"),
+                // it must be kept as a regular expression statement; replacing it with
+                // a TS no-op would orphan any scopes recorded while parsing it and
+                // desync the visit pass.
+                if Self::IS_TYPESCRIPT_ENABLED {
+                    if let Some(ts_stmt) = js_lexer::TypescriptStmtKeyword::from_bytes(name) {
+                        // Hand the cold TS-keyword statement forms (`type`/`interface`/`namespace`/
+                        // `module`/`abstract`/`global`/`declare`) to an out-of-line helper so the
+                        // common `SExpr` fall-through keeps a small stack frame.
+                        if let Some(stmt) =
+                            Self::parse_stmt_fallthrough_ts_keyword(p, opts, loc, ts_stmt)?
+                        {
+                            return Ok(stmt);
+                        }
                     }
                 }
             }

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1688,12 +1688,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     return Self::parse_labeled_stmt(p, opts, loc, expr.loc, ident.ref_);
                 }
 
-                // The TS contextual statement keywords only apply when the parsed
-                // expression is still just the bare identifier. If the identifier was
-                // consumed as part of a larger expression (e.g. "declare = () => {}"),
-                // it must be kept as a regular expression statement; replacing it with
-                // a TS no-op would orphan any scopes recorded while parsing it and
-                // desync the visit pass.
                 if Self::IS_TYPESCRIPT_ENABLED {
                     if let Some(ts_stmt) = js_lexer::TypescriptStmtKeyword::from_bytes(name) {
                         // Hand the cold TS-keyword statement forms (`type`/`interface`/`namespace`/

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -156,8 +156,6 @@ describe("Bun.Transpiler", () => {
     it("contextual keywords used as plain identifiers keep their statements", () => {
       const exp = ts.expectPrinted_;
 
-      // A TS contextual statement keyword that is only the start of a larger
-      // expression must be treated as a regular identifier, not as a modifier.
       exp("declare = t => 0;", "declare = (t) => 0;\n");
       exp("declare = (...t) => R;", "declare = (...t) => R;\n");
       exp("declare.foo = 1;", "declare.foo = 1;\n");
@@ -172,7 +170,6 @@ describe("Bun.Transpiler", () => {
         "abstract = () => {};\n\nclass Foo {\n  m() {\n    return 1;\n  }\n}",
       );
 
-      // Actual ambient declarations are still erased.
       exp("declare const x: number", "");
       exp("declare let x: number", "");
       exp("declare function f(): void", "");
@@ -183,18 +180,11 @@ describe("Bun.Transpiler", () => {
       const exp = ts.expectPrinted_;
       const err = ts.expectParseError;
 
-      // Fuzz-found crash: the whole `declare = <arrow>` assignment used to be
-      // replaced with a TS no-op, orphaning the arrow function's scopes and
-      // panicking in the visit pass once later statements pushed nested scopes.
       exp("declare = (...t) => R;e((a) => {(u=> uge);\r\n})", "declare = (...t) => R;\ne((a) => {});\n");
       exp("declare = t => 0; () => () => 0", "declare = (t) => 0;\n");
       exp("declare = function () {}; () => () => 0", "declare = function() {};\n");
       exp("declare = t => 0; function f() { () => 0; }\nf();", "declare = (t) => 0;\nfunction f() {}\nf();\n");
 
-      // The same scope desync used to panic through the other contextual
-      // keywords when the token after the parsed expression happened to satisfy
-      // their lookahead (a class for `abstract`, an identifier for
-      // `type`/`namespace`/`module`).
       exp(
         "abstract = (t) => 0\nclass Foo { m() { return () => () => 0 } }",
         "abstract = (t) => 0;\n\nclass Foo {\n  m() {\n    return () => () => 0;\n  }\n}",

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -186,16 +186,10 @@ describe("Bun.Transpiler", () => {
       // Fuzz-found crash: the whole `declare = <arrow>` assignment used to be
       // replaced with a TS no-op, orphaning the arrow function's scopes and
       // panicking in the visit pass once later statements pushed nested scopes.
-      exp(
-        "declare = (...t) => R;e((a) => {(u=> uge);\r\n})",
-        "declare = (...t) => R;\ne((a) => {});\n",
-      );
+      exp("declare = (...t) => R;e((a) => {(u=> uge);\r\n})", "declare = (...t) => R;\ne((a) => {});\n");
       exp("declare = t => 0; () => () => 0", "declare = (t) => 0;\n");
       exp("declare = function () {}; () => () => 0", "declare = function() {};\n");
-      exp(
-        "declare = t => 0; function f() { () => 0; }\nf();",
-        "declare = (t) => 0;\nfunction f() {}\nf();\n",
-      );
+      exp("declare = t => 0; function f() { () => 0; }\nf();", "declare = (t) => 0;\nfunction f() {}\nf();\n");
 
       // The same scope desync used to panic through the other contextual
       // keywords when the token after the parsed expression happened to satisfy

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -153,6 +153,63 @@ describe("Bun.Transpiler", () => {
       );
     });
 
+    it("contextual keywords used as plain identifiers keep their statements", () => {
+      const exp = ts.expectPrinted_;
+
+      // A TS contextual statement keyword that is only the start of a larger
+      // expression must be treated as a regular identifier, not as a modifier.
+      exp("declare = t => 0;", "declare = (t) => 0;\n");
+      exp("declare = (...t) => R;", "declare = (...t) => R;\n");
+      exp("declare.foo = 1;", "declare.foo = 1;\n");
+      exp("interface = t => 0;", "interface = (t) => 0;\n");
+      exp("type = t => 0;", "type = (t) => 0;\n");
+      exp("namespace = t => 0;", "namespace = (t) => 0;\n");
+      exp("module = t => 0;", "module = (t) => 0;\n");
+      exp("abstract = t => 0;", "abstract = (t) => 0;\n");
+      exp("global = t => 0;", "global = (t) => 0;\n");
+      exp(
+        "abstract = () => {}\nclass Foo { m() { return 1 } }",
+        "abstract = () => {};\n\nclass Foo {\n  m() {\n    return 1;\n  }\n}",
+      );
+
+      // Actual ambient declarations are still erased.
+      exp("declare const x: number", "");
+      exp("declare let x: number", "");
+      exp("declare function f(): void", "");
+      exp("declare class Foo {}", "");
+    });
+
+    it("scope tracking stays balanced when a contextual keyword starts a larger expression", () => {
+      const exp = ts.expectPrinted_;
+      const err = ts.expectParseError;
+
+      // Fuzz-found crash: the whole `declare = <arrow>` assignment used to be
+      // replaced with a TS no-op, orphaning the arrow function's scopes and
+      // panicking in the visit pass once later statements pushed nested scopes.
+      exp(
+        "declare = (...t) => R;e((a) => {(u=> uge);\r\n})",
+        "declare = (...t) => R;\ne((a) => {});\n",
+      );
+      exp("declare = t => 0; () => () => 0", "declare = (t) => 0;\n");
+      exp("declare = function () {}; () => () => 0", "declare = function() {};\n");
+      exp(
+        "declare = t => 0; function f() { () => 0; }\nf();",
+        "declare = (t) => 0;\nfunction f() {}\nf();\n",
+      );
+
+      // The same scope desync used to panic through the other contextual
+      // keywords when the token after the parsed expression happened to satisfy
+      // their lookahead (a class for `abstract`, an identifier for
+      // `type`/`namespace`/`module`).
+      exp(
+        "abstract = (t) => 0\nclass Foo { m() { return () => () => 0 } }",
+        "abstract = (t) => 0;\n\nclass Foo {\n  m() {\n    return () => () => 0;\n  }\n}",
+      );
+      err("type = (t) => 0 Foo = number; () => () => 0", 'Expected ";" but found "Foo"');
+      err("namespace = (t) => 0 Foo { () => () => 0 }", 'Expected ";" but found "Foo"');
+      err("module = (t) => 0 Foo { () => () => 0 }", 'Expected ";" but found "Foo"');
+    });
+
     it("should parse empty type parameters", () => {
       const exp = ts.expectPrinted_;
       const err = ts.expectParseError;


### PR DESCRIPTION
### Repro

Found by parser fuzzing (46 bytes):

```ts
bun -e 'new Bun.Transpiler({ loader: "ts" }).transformSync("declare = (...t) => R;e((a) => {(u=> uge);\r\n})")'
panic: Internal error: attempted to call popScope() on the topmost scope
```

Minimized:

```ts
declare = t => 0; () => () => 0
```

The same desync is reachable through the other TS contextual statement keywords, including from valid TypeScript:

```ts
abstract = () => {}
class Foo { m() { return () => () => 0 } }   // panic: Scope mismatch while visiting

type = (t) => 0 Foo = number; () => () => 0  // panic: popScope() on the topmost scope
namespace = (t) => 0 Foo { () => () => 0 }   // panic: Scope mismatch while visiting
```

Reproduces on 1.3.x and current canary; it is a faithful port of the pre-existing Zig parser behavior rather than a Rust-port regression.

### Cause

In `parse_stmt_fallthrough` (`src/js_parser/parse/parse_stmt.rs`), the TS contextual-keyword handling (`type`/`interface`/`namespace`/`module`/`abstract`/`global`/`declare`) ran whenever the statement *began* with that identifier token. esbuild additionally requires that the parsed expression is still exactly that bare identifier; the port lost that nesting.

So for `declare = (...t) => R`, the whole assignment is parsed first (recording the arrow function's scopes in `scopes_in_order`), and then the `declare` branch throws the expression away and emits a TS no-op. The orphaned scope records no longer line up with the AST, so the visit pass enters a scope whose parent chain is shallower than expected — `pop_scope()` walks off the module scope in release builds (`popScope() on the topmost scope`), or the order sanity-check fires in debug builds (`Scope mismatch while visiting`). The statement was also silently dropped from the output (`declare = t => 0;` → ``), and `interface = t => 0` produced a bogus parse error.

### Fix

Move the TS keyword handling inside the `ExprData::EIdentifier` check, matching esbuild's structure. If the keyword identifier was consumed as part of a larger expression, we now fall through to the normal `SExpr` path:

- `declare = t => 0;`, `abstract = () => {}` etc. are preserved as expression statements (same output as esbuild/tsc), so no scopes are orphaned.
- Invalid suffix forms like `type = (t) => 0 Foo` now produce the normal `Expected ";" but found "Foo"` parse error (same as esbuild) instead of panicking.
- Real ambient declarations (`declare const x: number`, `declare function f(): void`, `interface Foo {}`, `namespace Foo {}`, …) still parse through the keyword path because the expression is the bare identifier there — no behavior change.

Related open PRs in this area, both complementary rather than overlapping in coverage:
- #30008 gates the `declare`/`interface` arms on the same bare-identifier condition and additionally refines ASI/decorator/lookahead handling for the *bare*-identifier forms (`declare()` wrapped by its caller, `declare\nfoo()`, `@dec declare()`, `export default interface\nFoo {}`). It does not gate `type`/`namespace`/`module`/`abstract`, so the panics above through those keywords remain without this change. Whichever lands second needs a trivial rebase of the caller hunk.
- #31231 discards the scopes of statements that a *real* ambient `declare` parses and then drops (`declare foo: bar`, `declare global { ... }`), which this change does not address.

### Verification

New tests in `test/bundler/transpiler/transpiler.test.js` (`Bun.Transpiler > TypeScript`):

- `contextual keywords used as plain identifiers keep their statements` — asserts `declare = t => 0;`, `declare.foo = 1;`, `interface = t => 0;`, `abstract = () => {}\nclass Foo { ... }`, etc. survive transpilation, and that real ambient `declare` forms are still erased.
- `scope tracking stays balanced when a contextual keyword starts a larger expression` — the original fuzz input plus the minimized `declare`/`abstract`/`type`/`namespace`/`module` variants; each one panics without the fix.

```
USE_SYSTEM_BUN=1 bun test test/bundler/transpiler/transpiler.test.js -t "contextual"   # assertion failure + popScope panic (bug)
bun bd test test/bundler/transpiler/transpiler.test.js                                 # 116 pass, 0 fail
bun bd test test/bundler/esbuild/ts.test.ts                                            # 57 pass, 0 fail
bun bd test test/bundler/transpiler/scope-mismatch-panic.test.ts                       # 3 pass, 0 fail
```
