### PR TITLE
Report duplicate declarations for import bindings kept in TypeScript output

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -432,6 +432,13 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub enclosing_class_keyword: bun_ast::Range,
     pub import_items_for_namespace: HashMap<Ref, ImportItemForNamespaceMap>,
     pub is_import_item: RefMap,
+    /// Import bindings whose name was re-declared by a later declaration in the
+    /// same scope. TypeScript allows the collision because the import may be
+    /// type-only and elided (see `Scope::can_merge_symbol_kinds`), but if the
+    /// import binding survives import elision it would be printed next to the
+    /// other declaration, so `ImportScanner::scan` reports a duplicate
+    /// declaration error using the re-declaration's location stored here.
+    pub redeclared_import_bindings: HashMap<Ref, bun_ast::Loc>,
     pub named_imports: NamedImportsType<'a>,
     pub named_exports: bun_ast::ast_result::NamedExports,
     pub import_namespace_cc_map: Map<ImportNamespaceCallOrConstruct, bool>,
@@ -4989,6 +4996,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         if kind.is_function() && self.symbols[symbol_idx].kind.is_function() {
                             self.symbols[symbol_idx].remove_overwritten_function_declaration = true;
                         }
+
+                        // In TypeScript, an import binding may be silently re-declared
+                        // because the import might be type-only and elided (see
+                        // `Scope::can_merge_symbol_kinds`). Remember the collision so
+                        // `ImportScanner::scan` can report a duplicate declaration error
+                        // if the import binding is actually kept in the output.
+                        if TYPESCRIPT
+                            && self.symbols[symbol_idx].kind == js_ast::symbol::Kind::Import
+                        {
+                            self.redeclared_import_bindings.insert(existing.ref_, loc);
+                        }
                     }
                     MR::BecomePrivateGetSetPair => {
                         ref_ = existing.ref_;
@@ -9301,6 +9319,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             enclosing_class_keyword: bun_ast::Range::NONE,
             import_items_for_namespace: Default::default(),
             is_import_item: Default::default(),
+            redeclared_import_bindings: Default::default(),
             import_namespace_cc_map: Default::default(),
             scope_order_to_visit: &[],
             module_scope_directive_loc: bun_ast::Loc::default(),

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -432,12 +432,8 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub enclosing_class_keyword: bun_ast::Range,
     pub import_items_for_namespace: HashMap<Ref, ImportItemForNamespaceMap>,
     pub is_import_item: RefMap,
-    /// Import bindings whose name was re-declared by a later declaration in the
-    /// same scope. TypeScript allows the collision because the import may be
-    /// type-only and elided (see `Scope::can_merge_symbol_kinds`), but if the
-    /// import binding survives import elision it would be printed next to the
-    /// other declaration, so `ImportScanner::scan` reports a duplicate
-    /// declaration error using the re-declaration's location stored here.
+    /// Import bindings replaced by a later declaration (allowed in TS since the
+    /// import may be type-only), mapped to the replacing declaration's location.
     pub redeclared_import_bindings: HashMap<Ref, bun_ast::Loc>,
     pub named_imports: NamedImportsType<'a>,
     pub named_exports: bun_ast::ast_result::NamedExports,
@@ -4997,11 +4993,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             self.symbols[symbol_idx].remove_overwritten_function_declaration = true;
                         }
 
-                        // In TypeScript, an import binding may be silently re-declared
-                        // because the import might be type-only and elided (see
-                        // `Scope::can_merge_symbol_kinds`). Remember the collision so
-                        // `ImportScanner::scan` can report a duplicate declaration error
-                        // if the import binding is actually kept in the output.
                         if TYPESCRIPT
                             && self.symbols[symbol_idx].kind == js_ast::symbol::Kind::Import
                         {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -432,9 +432,6 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub enclosing_class_keyword: bun_ast::Range,
     pub import_items_for_namespace: HashMap<Ref, ImportItemForNamespaceMap>,
     pub is_import_item: RefMap,
-    /// Import bindings replaced by a later declaration (allowed in TS since the
-    /// import may be type-only), mapped to the replacing declaration's location.
-    pub redeclared_import_bindings: HashMap<Ref, bun_ast::Loc>,
     pub named_imports: NamedImportsType<'a>,
     pub named_exports: bun_ast::ast_result::NamedExports,
     pub import_namespace_cc_map: Map<ImportNamespaceCallOrConstruct, bool>,
@@ -4992,12 +4989,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         if kind.is_function() && self.symbols[symbol_idx].kind.is_function() {
                             self.symbols[symbol_idx].remove_overwritten_function_declaration = true;
                         }
-
-                        if TYPESCRIPT
-                            && self.symbols[symbol_idx].kind == js_ast::symbol::Kind::Import
-                        {
-                            self.redeclared_import_bindings.insert(existing.ref_, loc);
-                        }
                     }
                     MR::BecomePrivateGetSetPair => {
                         ref_ = existing.ref_;
@@ -9310,7 +9301,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             enclosing_class_keyword: bun_ast::Range::NONE,
             import_items_for_namespace: Default::default(),
             is_import_item: Default::default(),
-            redeclared_import_bindings: Default::default(),
             import_namespace_cc_map: Default::default(),
             scope_order_to_visit: &[],
             module_scope_directive_loc: bun_ast::Loc::default(),

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -322,6 +322,44 @@ impl<'a> ImportScanner<'a> {
                         st.star_name_loc = None;
                     }
 
+                    // In TypeScript, a later declaration is allowed to re-declare the
+                    // name of an import binding on the assumption that the import is
+                    // type-only and will be elided (see `Scope::can_merge_symbol_kinds`).
+                    // Any such import binding that is still around at this point will be
+                    // printed next to the other declaration, so report the duplicate
+                    // declaration instead of emitting output that fails to re-parse.
+                    if is_typescript_enabled && !p.redeclared_import_bindings.is_empty() {
+                        let default_binding = st
+                            .default_name
+                            .map(|name| (name.ref_.expect("infallible: ref bound"), name.loc));
+                        let star_binding = st.star_name_loc.map(|loc| (st.namespace_ref, loc));
+                        let item_bindings = st.items.slice().iter().map(|item| {
+                            (item.name.ref_.expect("infallible: ref bound"), item.name.loc)
+                        });
+
+                        for (name_ref, import_loc) in default_binding
+                            .into_iter()
+                            .chain(star_binding)
+                            .chain(item_bindings)
+                        {
+                            // `remove` so a second scan pass doesn't report it again.
+                            if let Some(redeclared_loc) =
+                                p.redeclared_import_bindings.remove(&name_ref)
+                            {
+                                // SAFETY: arena-owned slice valid for 'p.
+                                let name = p.symbols[name_ref.inner_index() as usize]
+                                    .original_name
+                                    .slice();
+                                p.log().add_symbol_already_declared_error(
+                                    p.source,
+                                    name,
+                                    redeclared_loc,
+                                    import_loc,
+                                );
+                            }
+                        }
+                    }
+
                     if st.default_name.is_some() {
                         record!()
                             .flags

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -322,12 +322,7 @@ impl<'a> ImportScanner<'a> {
                         st.star_name_loc = None;
                     }
 
-                    // In TypeScript, a later declaration is allowed to re-declare the
-                    // name of an import binding on the assumption that the import is
-                    // type-only and will be elided (see `Scope::can_merge_symbol_kinds`).
-                    // Any such import binding that is still around at this point will be
-                    // printed next to the other declaration, so report the duplicate
-                    // declaration instead of emitting output that fails to re-parse.
+                    // Report import bindings that were re-declared but not elided.
                     if is_typescript_enabled && !p.redeclared_import_bindings.is_empty() {
                         let default_binding = st
                             .default_name

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -349,10 +349,7 @@ impl<'a> ImportScanner<'a> {
                             if let Some(member) = member {
                                 if !member.ref_.eql(name_ref) {
                                     p.log().add_symbol_already_declared_error(
-                                        p.source,
-                                        name,
-                                        member.loc,
-                                        import_loc,
+                                        p.source, name, member.loc, import_loc,
                                     );
                                 }
                             }

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -334,7 +334,10 @@ impl<'a> ImportScanner<'a> {
                             .map(|name| (name.ref_.expect("infallible: ref bound"), name.loc));
                         let star_binding = st.star_name_loc.map(|loc| (st.namespace_ref, loc));
                         let item_bindings = st.items.slice().iter().map(|item| {
-                            (item.name.ref_.expect("infallible: ref bound"), item.name.loc)
+                            (
+                                item.name.ref_.expect("infallible: ref bound"),
+                                item.name.loc,
+                            )
                         });
 
                         for (name_ref, import_loc) in default_binding

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -339,15 +339,22 @@ impl<'a> ImportScanner<'a> {
                             .chain(star_binding)
                             .chain(item_bindings)
                         {
+                            // Only report source-level re-declarations: `ReplaceWithNew`
+                            // links the import to the symbol that took over the scope
+                            // member, while generated symbols (e.g. JSX runtime imports)
+                            // link the other way.
+                            let symbol = &p.symbols[name_ref.inner_index() as usize];
+                            let link = symbol.link.get();
+                            if !link.is_valid() {
+                                continue;
+                            }
                             // SAFETY: arena-owned slice valid for 'p.
-                            let name = p.symbols[name_ref.inner_index() as usize]
-                                .original_name
-                                .slice();
+                            let name = symbol.original_name.slice();
                             let member = p
                                 .module_scope()
                                 .get_member_with_hash(name, js_ast::Scope::get_member_hash(name));
                             if let Some(member) = member {
-                                if !member.ref_.eql(name_ref) {
+                                if member.ref_.eql(link) {
                                     p.log().add_symbol_already_declared_error(
                                         p.source, name, member.loc, import_loc,
                                     );

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -322,8 +322,7 @@ impl<'a> ImportScanner<'a> {
                         st.star_name_loc = None;
                     }
 
-                    // Report import bindings that were re-declared but not elided.
-                    if is_typescript_enabled && !p.redeclared_import_bindings.is_empty() {
+                    if is_typescript_enabled {
                         let default_binding = st
                             .default_name
                             .map(|name| (name.ref_.expect("infallible: ref bound"), name.loc));
@@ -340,20 +339,22 @@ impl<'a> ImportScanner<'a> {
                             .chain(star_binding)
                             .chain(item_bindings)
                         {
-                            // `remove` so a second scan pass doesn't report it again.
-                            if let Some(redeclared_loc) =
-                                p.redeclared_import_bindings.remove(&name_ref)
-                            {
-                                // SAFETY: arena-owned slice valid for 'p.
-                                let name = p.symbols[name_ref.inner_index() as usize]
-                                    .original_name
-                                    .slice();
-                                p.log().add_symbol_already_declared_error(
-                                    p.source,
-                                    name,
-                                    redeclared_loc,
-                                    import_loc,
-                                );
+                            // SAFETY: arena-owned slice valid for 'p.
+                            let name = p.symbols[name_ref.inner_index() as usize]
+                                .original_name
+                                .slice();
+                            let member = p
+                                .module_scope()
+                                .get_member_with_hash(name, js_ast::Scope::get_member_hash(name));
+                            if let Some(member) = member {
+                                if !member.ref_.eql(name_ref) {
+                                    p.log().add_symbol_already_declared_error(
+                                        p.source,
+                                        name,
+                                        member.loc,
+                                        import_loc,
+                                    );
+                                }
                             }
                         }
                     }

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -344,9 +344,17 @@ impl<'a> ImportScanner<'a> {
                             // member, while generated symbols (e.g. JSX runtime imports)
                             // link the other way.
                             let symbol = &p.symbols[name_ref.inner_index() as usize];
-                            let link = symbol.link.get();
+                            let mut link = symbol.link.get();
                             if !link.is_valid() {
                                 continue;
+                            }
+                            // Follow the chain of replacements to the live symbol.
+                            loop {
+                                let next = p.symbols[link.inner_index() as usize].link.get();
+                                if !next.is_valid() {
+                                    break;
+                                }
+                                link = next;
                             }
                             // SAFETY: arena-owned slice valid for 'p.
                             let name = symbol.original_name.slice();

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -193,13 +193,13 @@ describe("bundler", () => {
         import { Fragment } from 'react'
         const F = Fragment
         const el = <>hi</>
-        print([typeof F, el.type !== F])
+        print([typeof F, typeof el])
       `,
       ...helpers,
     },
     target: "bun",
-    devStdout: `["symbol",true]`,
-    prodStdout: `["symbol",true]`,
+    devStdout: `["symbol","object"]`,
+    prodStdout: `["symbol","object"]`,
   });
   itBundledDevAndProd("jsx/ImportSource", {
     prodTodo: true,

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -184,6 +184,22 @@ describe("bundler", () => {
       {"$$typeof":"Symbol(jsx)","type":"Symbol("jsx.fragment")","key":"null","ref":"null","props":{"children":"Fragment"},"_owner":"null"}
     `,
   });
+  // A used `Fragment` import must not be reported as a duplicate of the
+  // auto-imported JSX `Fragment` helper that shares its name at module scope.
+  itBundledDevAndProd("jsx/AutomaticFragmentNamedImport", {
+    files: {
+      "/index.tsx": /* tsx */ `
+        import { print } from 'bun-test-helpers'
+        import { Fragment } from 'react'
+        const el = <>hi</>
+        print([typeof Fragment, el.type !== Fragment])
+      `,
+      ...helpers,
+    },
+    target: "bun",
+    devStdout: `["symbol",true]`,
+    prodStdout: `["symbol",true]`,
+  });
   itBundledDevAndProd("jsx/ImportSource", {
     prodTodo: true,
     files: {

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -191,8 +191,9 @@ describe("bundler", () => {
       "/index.tsx": /* tsx */ `
         import { print } from 'bun-test-helpers'
         import { Fragment } from 'react'
+        const F = Fragment
         const el = <>hi</>
-        print([typeof Fragment, el.type !== Fragment])
+        print([typeof F, el.type !== F])
       `,
       ...helpers,
     },

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -936,6 +936,7 @@ class Test extends Bar {
       err('import * as Foo from "./x";\nclass Foo {}', '"Foo" has already been declared');
       err('import { Foo } from "./x";\nfunction Foo() {}', '"Foo" has already been declared');
       err('import { Foo } from "./x";\nvar Foo = 1;', '"Foo" has already been declared');
+      err('import { Foo } from "./x";\nvar Foo = 1;\nvar Foo = 2;', '"Foo" has already been declared');
       err('import { Foo } from "./x";\nlet Foo = 1;', '"Foo" has already been declared');
       err('import { Foo } from "./x";\nenum Foo {}', '"Foo" has already been declared');
       err('import { Foo } from "./x";\nimport Foo = require("./y");', '"Foo" has already been declared');

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -939,6 +939,7 @@ class Test extends Bar {
       err('import { Foo } from "./x";\nlet Foo = 1;', '"Foo" has already been declared');
       err('import { Foo } from "./x";\nenum Foo {}', '"Foo" has already been declared');
       err('import { Foo } from "./x";\nimport Foo = require("./y");', '"Foo" has already been declared');
+      err('import { Foo } from "./x";\nimport Foo = Bar.Baz;', '"Foo" has already been declared');
       err('import { Foo, Foo } from "./x";', '"Foo" has already been declared');
     });
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -927,6 +927,49 @@ class Test extends Bar {
       ts.expectPrinted_("export import Foo = Baz.Bar;", "export const Foo = Baz.Bar");
     });
 
+    it("re-declaring an import binding that is kept in the output is an error", () => {
+      const err = ts.expectParseError;
+
+      // TypeScript allows another declaration to take over the name of an
+      // import binding because the import may be type-only. These imports are
+      // not elided (trimUnusedImports defaults to false for Bun.Transpiler),
+      // so printing them would produce output that fails to re-parse. They
+      // must error instead.
+      err('import{Observable}from""\nimport{Observable} from "x"', '"Observable" has already been declared');
+      err('import { Foo } from "./x";\nexport class Foo {}', '"Foo" has already been declared');
+      err('import Foo from "./x";\nclass Foo {}', '"Foo" has already been declared');
+      err('import * as Foo from "./x";\nclass Foo {}', '"Foo" has already been declared');
+      err('import { Foo } from "./x";\nfunction Foo() {}', '"Foo" has already been declared');
+      err('import { Foo } from "./x";\nvar Foo = 1;', '"Foo" has already been declared');
+      err('import { Foo } from "./x";\nlet Foo = 1;', '"Foo" has already been declared');
+      err('import { Foo } from "./x";\nenum Foo {}', '"Foo" has already been declared');
+      err('import { Foo } from "./x";\nimport Foo = require("./y");', '"Foo" has already been declared');
+      err('import { Foo, Foo } from "./x";', '"Foo" has already been declared');
+    });
+
+    it("re-declaring an elided import binding is allowed", () => {
+      const exp = ts.expectPrinted_;
+
+      // Type-only imports and declarations that emit no code don't conflict
+      // with anything in the output, so they are still allowed to collide.
+      exp('import type { Foo } from "./x";\nclass Foo {}', "class Foo {\n}");
+      exp(
+        'import { type Foo, Bar } from "./x";\nclass Foo {}\nconsole.log(Bar);',
+        'import { Bar } from "./x";\n\nclass Foo {\n}\nconsole.log(Bar);\n',
+      );
+      exp('import { Foo } from "./x";\ndeclare class Foo {}\nnew Foo();', 'import { Foo } from "./x";\nnew Foo;\n');
+      exp('import { foo } from "./x";\nfunction foo(): void;', 'import { foo } from "./x";\n');
+
+      // When unused imports are trimmed (the default for the runtime and the
+      // bundler), the re-declared import is elided and there is no error.
+      const trimming = new Bun.Transpiler({ loader: "ts", trimUnusedImports: true });
+      expect(trimming.transformSync('import { Foo } from "./x";\nexport class Foo {}')).toBe("export class Foo {\n}\n");
+      expect(trimming.transformSync('import{Observable}from""\nimport{Observable} from "x"')).toBe("");
+      expect(trimming.transformSync('import { Foo } from "./x";\nnamespace Foo { export const x = 1 }')).toBe(
+        "var Foo;\n((Foo) => {\n  Foo.x = 1;\n})(Foo ||= {});\n",
+      );
+    });
+
     it("export = {foo: 123}", () => {
       ts.expectPrinted_("export = {foo: 123}", "module.exports = { foo: 123 }");
     });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -930,11 +930,6 @@ class Test extends Bar {
     it("re-declaring an import binding that is kept in the output is an error", () => {
       const err = ts.expectParseError;
 
-      // TypeScript allows another declaration to take over the name of an
-      // import binding because the import may be type-only. These imports are
-      // not elided (trimUnusedImports defaults to false for Bun.Transpiler),
-      // so printing them would produce output that fails to re-parse. They
-      // must error instead.
       err('import{Observable}from""\nimport{Observable} from "x"', '"Observable" has already been declared');
       err('import { Foo } from "./x";\nexport class Foo {}', '"Foo" has already been declared');
       err('import Foo from "./x";\nclass Foo {}', '"Foo" has already been declared');
@@ -950,8 +945,6 @@ class Test extends Bar {
     it("re-declaring an elided import binding is allowed", () => {
       const exp = ts.expectPrinted_;
 
-      // Type-only imports and declarations that emit no code don't conflict
-      // with anything in the output, so they are still allowed to collide.
       exp('import type { Foo } from "./x";\nclass Foo {}', "class Foo {\n}");
       exp(
         'import { type Foo, Bar } from "./x";\nclass Foo {}\nconsole.log(Bar);',
@@ -960,8 +953,6 @@ class Test extends Bar {
       exp('import { Foo } from "./x";\ndeclare class Foo {}\nnew Foo();', 'import { Foo } from "./x";\nnew Foo;\n');
       exp('import { foo } from "./x";\nfunction foo(): void;', 'import { foo } from "./x";\n');
 
-      // When unused imports are trimmed (the default for the runtime and the
-      // bundler), the re-declared import is elided and there is no error.
       const trimming = new Bun.Transpiler({ loader: "ts", trimUnusedImports: true });
       expect(trimming.transformSync('import { Foo } from "./x";\nexport class Foo {}')).toBe("export class Foo {\n}\n");
       expect(trimming.transformSync('import{Observable}from""\nimport{Observable} from "x"')).toBe("");


### PR DESCRIPTION
### What

Parser fuzzing found two inputs where the transpiler's own output fails to re-parse (both are duplicate-binding early errors per spec, and errors in `tsc`):

```js
// 1. the same name imported twice
new Bun.Transpiler({ loader: "tsx" }).transformSync(`import{Observable}from""\nimport{Observable} from "x"`);
// succeeded, emitted both imports; re-parsing the output fails with
// error: "Observable" has already been declared

// 2. an import colliding with a class declaration
new Bun.Transpiler({ loader: "ts" }).transformSync(`import { Foo } from ".";export class Foo {}`);
// succeeded, emitted both the import and the class
```

### Cause

`Scope::can_merge_symbol_kinds` deliberately lets any later declaration take over the name of an import binding when TypeScript is enabled (the import may be type-only, e.g. `import type`-less interface imports, namespace declaration merging). That lenience is only sound when the shadowed import is later elided as unused. The runtime and the bundler always trim unused imports for TS, but `Bun.Transpiler` defaults to keeping them, so the shadowed import binding was printed right next to the declaration that replaced it — output that declares the same name twice.

### Fix

In `ImportScanner::scan` (src/js_parser/scan/scan_imports.rs), after unused-import elision (which runs post-visit, once use counts are known), each import binding still in the statement whose symbol was replaced (its `link` is set by `ReplaceWithNew`) is checked against the module scope's member for that name; when the member points at the final symbol in that chain of replacements, it's reported as `"X" has already been declared` at the re-declaration (the member's location) with a note at the import. Compiler-generated symbols that reuse a name (the JSX runtime auto-imports in bundle mode) don't set that link, so they can't trip the check. No parser state is added, `declare_symbol` is untouched, and non-TypeScript files are unaffected.

So the error fires when a re-declared import binding is kept in the output, and the existing lenience is preserved whenever the import is actually elided:

| input (ts/tsx) | before | after |
| --- | --- | --- |
| `import{Observable}from""` + `import{Observable} from "x"` (imports kept) | emits invalid output | error: already declared |
| `import { Foo } from "."; export class Foo {}` (imports kept) | emits invalid output | error: already declared |
| same inputs with `trimUnusedImports: true` (runtime/bundler default for TS) | shadowed import elided | unchanged |
| `import type { Foo } from "x"; class Foo {}` | import erased, `class Foo {}` | unchanged |
| `import { type Foo, Bar } from "x"; class Foo {}` | type specifier erased | unchanged |
| `import { Foo } from "x"; declare class Foo {}` / interface / overload-only signatures | import kept, no conflict emitted | unchanged |
| `import { Foo } from "x"; namespace Foo {}` at runtime (valid TS declaration merging) | import elided, namespace emitted | unchanged |
| `import { Foo } from "x"; import Foo = Bar.Baz` (unused, imports kept) | import-equals dropped by its own elision, import emitted | error: already declared (tsc rejects this input too) |
| plain JS loaders | already errored | unchanged |

`Bun.Transpiler.scan()` with a TS loader now also reports the error for these inputs (it already did for JS loaders); `scanImports()` is unchanged.

### Verification

- `bun bd test test/bundler/transpiler/transpiler.test.js` — new tests `re-declaring an import binding that is kept in the output is an error` / `re-declaring an elided import binding is allowed` pass; the error-case test fails on a build without the fix.
- Full `test/bundler/transpiler/`, `test/js/bun/transpiler/`, `test/bundler/esbuild/ts.test.ts`, `test/bundler/esbuild/importstar_ts.test.ts`, and `test/js/bun/resolve/import-defer.test.ts` pass.
- Runtime and `bun build` behavior on the repro files is unchanged (shadowed imports still elided there).




