### PR TITLE
Fix quadratic blowup in Bun.markdown on unclosed link brackets

### DIFF
--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -103,8 +103,10 @@ impl Parser<'_> {
 
         // Bracket-pair map for this slice: link processing looks up the ']'
         // matching a '[' here instead of rescanning the rest of the slice for
-        // every opener.
-        let brackets = self.compute_bracket_matches(content);
+        // every opener. The backing storage is recycled via self.bracket_pairs
+        // (recursive calls for link labels simply build their own small map).
+        let bracket_storage = core::mem::take(&mut self.bracket_pairs);
+        let brackets = self.compute_bracket_matches(content, bracket_storage);
 
         // Phase 1: Collect and resolve emphasis delimiters
         self.collect_emphasis_delimiters(content, &brackets);
@@ -416,6 +418,8 @@ impl Parser<'_> {
         if text_start < content.len() {
             self.emit_text(TextType::Normal, &content[text_start..])?;
         }
+        // Hand the bracket-map storage back for reuse by the next block.
+        self.bracket_pairs = brackets.into_storage();
         Ok(())
     }
 

--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -1,5 +1,6 @@
 use crate::autolinks::{find_permissive_autolink, is_emph_boundary_resolved};
 use crate::helpers;
+use crate::links::BracketMatches;
 use crate::parser::{self, Parser};
 use crate::types::{OFF, SpanType, TextType, VerbatimLine};
 
@@ -100,8 +101,13 @@ impl Parser<'_> {
             return Err(parser::Error::StackOverflow);
         }
 
+        // Bracket-pair map for this slice: link processing looks up the ']'
+        // matching a '[' here instead of rescanning the rest of the slice for
+        // every opener.
+        let brackets = self.compute_bracket_matches(content);
+
         // Phase 1: Collect and resolve emphasis delimiters
-        self.collect_emphasis_delimiters(content);
+        self.collect_emphasis_delimiters(content, &brackets);
         self.resolve_emphasis_delimiters();
 
         // Copy resolved delimiters locally (recursive calls may modify emph_delims)
@@ -298,7 +304,7 @@ impl Parser<'_> {
                 if i > text_start {
                     self.emit_text(TextType::Normal, &content[text_start..i])?;
                 }
-                if let Some(end_pos) = self.process_link(content, i, base_off, false)? {
+                if let Some(end_pos) = self.process_link(content, i, base_off, false, &brackets)? {
                     i = end_pos;
                 } else {
                     self.emit_text(TextType::Normal, b"[")?;
@@ -313,7 +319,9 @@ impl Parser<'_> {
                 if i > text_start {
                     self.emit_text(TextType::Normal, &content[text_start..i])?;
                 }
-                if let Some(end_pos) = self.process_link(content, i + 1, base_off, true)? {
+                if let Some(end_pos) =
+                    self.process_link(content, i + 1, base_off, true, &brackets)?
+                {
                     i = end_pos;
                 } else {
                     self.emit_text(TextType::Normal, b"!")?;
@@ -489,7 +497,7 @@ impl Parser<'_> {
     }
 
     /// Collect emphasis delimiter runs from content, skipping code spans and HTML tags.
-    pub fn collect_emphasis_delimiters(&mut self, content: &[u8]) {
+    pub fn collect_emphasis_delimiters(&mut self, content: &[u8], brackets: &BracketMatches) {
         self.emph_delims.clear();
         let mut i: usize = 0;
         while i < content.len() {
@@ -527,13 +535,13 @@ impl Parser<'_> {
             if c == b'[' || (c == b'!' && i + 1 < content.len() && content[i + 1] == b'[') {
                 let is_img = c == b'!';
                 let bracket_start = if is_img { i + 1 } else { i };
-                let link_result = self.try_match_bracket_link(content, bracket_start);
+                let link_result = self.try_match_bracket_link(content, bracket_start, brackets, 0);
                 if link_result.is_link {
                     // Link nesting prohibition: links cannot contain other links (CommonMark §6.7)
                     // Images CAN contain links in alt text, so only check for non-images
                     if !is_img {
                         let label = &content[bracket_start + 1..link_result.label_end];
-                        if self.label_contains_link(label) {
+                        if self.label_contains_link(label, brackets, bracket_start + 1) {
                             // Label contains inner links — this can't form a link
                             i += 1;
                             continue;

--- a/src/md/links.rs
+++ b/src/md/links.rs
@@ -9,6 +9,19 @@ type Span = SpanType;
 type SpanAttrs<'a> = SpanDetail<'a>;
 type Off = OFF;
 
+/// Maximum parenthesis nesting depth inside a bare inline-link destination.
+/// CommonMark allows implementations to impose such a limit ("at least three
+/// levels of nesting should be supported"); cmark and commonmark.js both use
+/// 32. Without a cap, an unclosed destination is rescanned for every candidate
+/// link, which is quadratic on inputs like `"[a](b"` repeated.
+const MAX_LINK_DEST_PAREN_DEPTH: u32 = 32;
+
+/// Maximum `[`/`]` nesting depth inside a wiki link. Bounds the forward scan
+/// for the closing `]]`, which is otherwise rescanned to the end of the line
+/// for every `[[` candidate (quadratic on inputs like `"[".repeat(n)` when
+/// wiki links are enabled, e.g. via `Bun.markdown.ansi`).
+const MAX_WIKI_BRACKET_DEPTH: u32 = 32;
+
 /// Result of `try_match_bracket_link` — Zig anonymous return struct.
 pub struct BracketLinkMatch {
     pub is_link: bool,
@@ -22,16 +35,137 @@ pub struct Autolink {
     pub is_email: bool,
 }
 
+/// Result of matching a `[` against its closing `]`.
+struct BracketScan {
+    /// Position of the matching `]`.
+    close: usize,
+    /// Whether another `[` opener was seen between the two.
+    has_inner_bracket: bool,
+}
+
+enum BracketLookup {
+    /// Opener was seen by the single-pass builder and has a matching `]`.
+    Matched(usize),
+    /// Opener was seen by the single-pass builder and has no matching `]`.
+    Unmatched,
+    /// Opener is unknown to the map (tokenization divergence, e.g. the caller
+    /// skipped a permissive autolink the builder tokenized through).
+    Unknown,
+}
+
+/// Bracket-pair map for one inline content slice, built in a single pass so
+/// link processing can find the `]` matching a given `[` without rescanning
+/// the rest of the slice for every opener — that rescan is quadratic on
+/// inputs like `"[".repeat(n)`.
+pub struct BracketMatches {
+    /// `(open, close)` position of every `[` seen outside code spans, HTML
+    /// tags/autolinks and backslash escapes, ordered by `open`.
+    /// `close == UNMATCHED` marks an opener with no matching `]`.
+    pairs: Vec<(usize, usize)>,
+}
+
+impl BracketMatches {
+    const UNMATCHED: usize = usize::MAX;
+
+    fn get(&self, open: usize) -> BracketLookup {
+        match self.pairs.binary_search_by_key(&open, |&(o, _)| o) {
+            Ok(idx) => {
+                let close = self.pairs[idx].1;
+                if close == Self::UNMATCHED {
+                    BracketLookup::Unmatched
+                } else {
+                    BracketLookup::Matched(close)
+                }
+            }
+            Err(_) => BracketLookup::Unknown,
+        }
+    }
+
+    /// Whether any `[` opener was seen strictly between `lo` and `hi`.
+    fn has_opener_between(&self, lo: usize, hi: usize) -> bool {
+        let idx = self.pairs.partition_point(|&(o, _)| o <= lo);
+        idx < self.pairs.len() && self.pairs[idx].0 < hi
+    }
+}
+
 impl Parser<'_> {
-    pub fn process_link(
-        &mut self,
+    /// Build the bracket-pair map for `content` in a single pass, using the
+    /// same tokenization as the matching scan (code spans, HTML tags,
+    /// autolinks and backslash escapes hide brackets).
+    pub fn compute_bracket_matches(&self, content: &[u8]) -> BracketMatches {
+        let mut pairs: Vec<(usize, usize)> = Vec::new();
+        if bun_core::strings::index_of_char(content, b'[').is_none() {
+            return BracketMatches { pairs };
+        }
+        let mut stack: Vec<usize> = Vec::new();
+        let mut pos: usize = 0;
+        while pos < content.len() {
+            let c = content[pos];
+            if c == b'\\' && pos + 1 < content.len() {
+                pos += 2;
+                continue;
+            }
+            // Skip code spans — they take precedence over brackets (CommonMark §6.3)
+            if c == b'`' {
+                let count = inlines::count_backticks(content, pos);
+                if let Some(end_pos) = self.find_code_span_end(content, pos + count, count) {
+                    pos = end_pos + count;
+                } else {
+                    pos += count;
+                }
+                continue;
+            }
+            // Skip HTML tags and autolinks — they take precedence over brackets
+            if c == b'<' && !self.flags.no_html_spans {
+                if let Some(tag_end) = self.find_html_tag(content, pos) {
+                    pos = tag_end;
+                    continue;
+                }
+                if let Some(autolink) = self.find_autolink(content, pos) {
+                    pos = autolink.end_pos;
+                    continue;
+                }
+            }
+            if c == b'[' {
+                stack.push(pairs.len());
+                pairs.push((pos, BracketMatches::UNMATCHED));
+            } else if c == b']' {
+                if let Some(idx) = stack.pop() {
+                    pairs[idx].1 = pos;
+                }
+            }
+            pos += 1;
+        }
+        BracketMatches { pairs }
+    }
+
+    /// Find the `]` matching the `[` at `start` in `content`. `base` is the
+    /// offset of `content` within the slice `brackets` was built for (non-zero
+    /// when `content` is a link-label sub-slice). Falls back to a forward scan
+    /// when the opener is unknown to the map.
+    fn match_bracket(
+        &self,
         content: &[u8],
         start: usize,
-        _base_off: Off,
-        is_image: bool,
-    ) -> Result<Option<usize>, parser::Error> {
-        // start points at '['
-        // Find matching ']', skipping code spans and HTML tags (which take precedence)
+        brackets: &BracketMatches,
+        base: usize,
+    ) -> Option<BracketScan> {
+        match brackets.get(base + start) {
+            BracketLookup::Matched(close) if close > base && close - base < content.len() => {
+                Some(BracketScan {
+                    close: close - base,
+                    has_inner_bracket: brackets.has_opener_between(base + start, close),
+                })
+            }
+            BracketLookup::Unmatched => None,
+            _ => self.scan_bracket_close(content, start),
+        }
+    }
+
+    /// Forward scan for the `]` matching the `[` at `start`, skipping code
+    /// spans, HTML tags/autolinks and backslash escapes. Only used when the
+    /// opener is missing from the precomputed bracket map.
+    fn scan_bracket_close(&self, content: &[u8], start: usize) -> Option<BracketScan> {
         let mut pos = start + 1;
         let mut bracket_depth: u32 = 1;
         let mut has_inner_bracket = false;
@@ -45,8 +179,10 @@ impl Parser<'_> {
                 let count = inlines::count_backticks(content, pos);
                 if let Some(end_pos) = self.find_code_span_end(content, pos + count, count) {
                     pos = end_pos + count;
-                    continue;
+                } else {
+                    pos += count;
                 }
+                continue;
             }
             // Skip HTML tags and autolinks — they take precedence over brackets
             if content[pos] == b'<' && !self.flags.no_html_spans {
@@ -70,14 +206,32 @@ impl Parser<'_> {
                 pos += 1;
             }
         }
-
         if bracket_depth != 0 {
-            return Ok(None);
+            return None;
         }
+        Some(BracketScan {
+            close: pos,
+            has_inner_bracket,
+        })
+    }
 
-        let label_end = pos;
+    pub fn process_link(
+        &mut self,
+        content: &[u8],
+        start: usize,
+        _base_off: Off,
+        is_image: bool,
+        brackets: &BracketMatches,
+    ) -> Result<Option<usize>, parser::Error> {
+        // start points at '['
+        // Find matching ']', skipping code spans and HTML tags (which take precedence)
+        let Some(bracket) = self.match_bracket(content, start, brackets, 0) else {
+            return Ok(None);
+        };
+        let has_inner_bracket = bracket.has_inner_bracket;
+        let label_end = bracket.close;
         let label = &content[start + 1..label_end];
-        pos += 1; // skip ']'
+        let mut pos = label_end + 1; // skip ']'
 
         // Inline link: [text](url "title")
         if pos < content.len() && content[pos] == b'(' {
@@ -96,12 +250,12 @@ impl Parser<'_> {
             let dest_end;
 
             if pos < content.len() && content[pos] == b'<' {
-                // Angle-bracket destination (no newlines allowed)
+                // Angle-bracket destination (no newlines or unescaped '<' allowed)
                 dest_start = pos + 1;
                 pos += 1;
                 let mut angle_valid = true;
                 while pos < content.len() && content[pos] != b'>' {
-                    if content[pos] == b'\n' || content[pos] == b'\r' {
+                    if content[pos] == b'\n' || content[pos] == b'\r' || content[pos] == b'<' {
                         angle_valid = false;
                         break;
                     }
@@ -119,11 +273,14 @@ impl Parser<'_> {
                     pos += 1; // skip >
                 }
             } else {
-                // Bare destination — balance parentheses
+                // Bare destination — balance parentheses (nesting depth is capped)
                 let mut paren_depth: u32 = 0;
                 while pos < content.len() && !helpers::is_whitespace(content[pos]) {
                     if content[pos] == b'(' {
                         paren_depth += 1;
+                        if paren_depth > MAX_LINK_DEST_PAREN_DEPTH {
+                            break;
+                        }
                     } else if content[pos] == b')' {
                         if paren_depth == 0 {
                             break;
@@ -158,18 +315,29 @@ impl Parser<'_> {
                 } else {
                     content[pos]
                 };
+                let title_open = pos;
                 pos += 1;
                 let title_start = pos;
+                let mut title_valid = true;
                 while pos < content.len() && content[pos] != close_char {
                     if content[pos] == b'\\' && pos + 1 < content.len() {
                         pos += 2;
-                    } else {
-                        pos += 1;
+                        continue;
                     }
+                    // A ()-delimited title may not contain an unescaped '('
+                    if close_char == b')' && content[pos] == b'(' {
+                        title_valid = false;
+                        break;
+                    }
+                    pos += 1;
                 }
-                title = &content[title_start..pos];
-                if pos < content.len() {
-                    pos += 1; // skip closing quote
+                if title_valid {
+                    title = &content[title_start..pos];
+                    if pos < content.len() {
+                        pos += 1; // skip closing quote
+                    }
+                } else {
+                    pos = title_open;
                 }
             }
 
@@ -188,7 +356,10 @@ impl Parser<'_> {
                 let dest = &content[dest_start..dest_end];
 
                 // Link nesting prohibition: links cannot contain other links (CommonMark §6.7)
-                if !is_image && has_inner_bracket && self.label_contains_link(label) {
+                if !is_image
+                    && has_inner_bracket
+                    && self.label_contains_link(label, brackets, start + 1)
+                {
                     return Ok(None);
                 }
 
@@ -254,7 +425,10 @@ impl Parser<'_> {
                     let dest: Box<[u8]> = Box::from(&ref_def.dest[..]);
                     let title: Box<[u8]> = Box::from(&ref_def.title[..]);
                     // Link nesting prohibition
-                    if !is_image && has_inner_bracket && self.label_contains_link(label) {
+                    if !is_image
+                        && has_inner_bracket
+                        && self.label_contains_link(label, brackets, start + 1)
+                    {
                         return Ok(None);
                     }
                     self.render_ref_link(label, &dest, &title, is_image)?;
@@ -277,7 +451,10 @@ impl Parser<'_> {
                 let dest: Box<[u8]> = Box::from(&ref_def.dest[..]);
                 let title: Box<[u8]> = Box::from(&ref_def.title[..]);
                 // Link nesting prohibition
-                if !is_image && has_inner_bracket && self.label_contains_link(label) {
+                if !is_image
+                    && has_inner_bracket
+                    && self.label_contains_link(label, brackets, start + 1)
+                {
                     return Ok(None);
                 }
                 self.render_ref_link(label, &dest, &title, is_image)?;
@@ -290,51 +467,24 @@ impl Parser<'_> {
 
     /// Try to match a bracket pair starting at `start` and check if it forms a link.
     /// Returns whether it's a link, where the label ends, and the full link end position.
-    pub fn try_match_bracket_link(&mut self, content: &[u8], start: usize) -> BracketLinkMatch {
-        let mut pos = start + 1;
-        let mut depth: u32 = 1;
-        while pos < content.len() && depth > 0 {
-            if content[pos] == b'\\' && pos + 1 < content.len() {
-                pos += 2;
-                continue;
-            }
-            if content[pos] == b'`' {
-                let count = inlines::count_backticks(content, pos);
-                if let Some(end_pos) = self.find_code_span_end(content, pos + count, count) {
-                    pos = end_pos + count;
-                    continue;
-                }
-            }
-            if content[pos] == b'<' && !self.flags.no_html_spans {
-                if let Some(tag_end) = self.find_html_tag(content, pos) {
-                    pos = tag_end;
-                    continue;
-                }
-                if let Some(al) = self.find_autolink(content, pos) {
-                    pos = al.end_pos;
-                    continue;
-                }
-            }
-            if content[pos] == b'[' {
-                depth += 1;
-            }
-            if content[pos] == b']' {
-                depth -= 1;
-            }
-            if depth > 0 {
-                pos += 1;
-            }
-        }
-        if depth != 0 {
+    /// `base` is the offset of `content` within the slice `brackets` was built for.
+    pub fn try_match_bracket_link(
+        &mut self,
+        content: &[u8],
+        start: usize,
+        brackets: &BracketMatches,
+        base: usize,
+    ) -> BracketLinkMatch {
+        let Some(bracket) = self.match_bracket(content, start, brackets, base) else {
             return BracketLinkMatch {
                 is_link: false,
                 label_end: 0,
                 link_end: 0,
             };
-        }
+        };
 
-        let label_end = pos;
-        pos += 1; // skip ]
+        let label_end = bracket.close;
+        let pos = label_end + 1; // skip ]
 
         if pos >= content.len() {
             // Shortcut reference check
@@ -359,7 +509,11 @@ impl Parser<'_> {
             // Parse dest
             if p < content.len() && content[p] == b'<' {
                 p += 1;
-                while p < content.len() && content[p] != b'>' && content[p] != b'\n' {
+                while p < content.len()
+                    && content[p] != b'>'
+                    && content[p] != b'\n'
+                    && content[p] != b'<'
+                {
                     if content[p] == b'\\' && p + 1 < content.len() {
                         p += 2;
                     } else {
@@ -380,6 +534,9 @@ impl Parser<'_> {
                 while p < content.len() && !helpers::is_whitespace(content[p]) {
                     if content[p] == b'(' {
                         paren_depth += 1;
+                        if paren_depth > MAX_LINK_DEST_PAREN_DEPTH {
+                            break;
+                        }
                     } else if content[p] == b')' {
                         if paren_depth == 0 {
                             break;
@@ -404,16 +561,27 @@ impl Parser<'_> {
                 && (content[p] == b'"' || content[p] == b'\'' || content[p] == b'(')
             {
                 let close_ch: u8 = if content[p] == b'(' { b')' } else { content[p] };
+                let title_open = p;
                 p += 1;
+                let mut title_valid = true;
                 while p < content.len() && content[p] != close_ch {
                     if content[p] == b'\\' && p + 1 < content.len() {
                         p += 2;
-                    } else {
+                        continue;
+                    }
+                    // A ()-delimited title may not contain an unescaped '('
+                    if close_ch == b')' && content[p] == b'(' {
+                        title_valid = false;
+                        break;
+                    }
+                    p += 1;
+                }
+                if title_valid {
+                    if p < content.len() {
                         p += 1;
                     }
-                }
-                if p < content.len() {
-                    p += 1;
+                } else {
+                    p = title_open;
                 }
             }
             // Skip whitespace
@@ -479,7 +647,13 @@ impl Parser<'_> {
 
     /// Check if a link label contains an inner link construct.
     /// Used to enforce the "links cannot contain other links" rule (CommonMark §6.7).
-    pub fn label_contains_link(&mut self, label: &[u8]) -> bool {
+    /// `base` is the offset of `label` within the slice `brackets` was built for.
+    pub fn label_contains_link(
+        &mut self,
+        label: &[u8],
+        brackets: &BracketMatches,
+        base: usize,
+    ) -> bool {
         let mut pos: usize = 0;
         while pos < label.len() {
             if label[pos] == b'\\' && pos + 1 < label.len() {
@@ -509,7 +683,7 @@ impl Parser<'_> {
                 // Skip images (![...]) — images are allowed inside links
                 let is_inner_image = pos > 0 && label[pos - 1] == b'!';
                 // Try to find matching ] and check for link syntax
-                let inner = self.try_match_bracket_link(label, pos);
+                let inner = self.try_match_bracket_link(label, pos, brackets, base);
                 if inner.is_link && !is_inner_image {
                     return true;
                 }
@@ -544,6 +718,9 @@ impl Parser<'_> {
             }
             if content[pos] == b'[' {
                 bracket_depth += 1;
+                if bracket_depth > MAX_WIKI_BRACKET_DEPTH {
+                    return Ok(None);
+                }
             } else if content[pos] == b']' {
                 if bracket_depth > 0 {
                     bracket_depth -= 1;

--- a/src/md/links.rs
+++ b/src/md/links.rs
@@ -745,8 +745,12 @@ impl Parser<'_> {
                 let count = inlines::count_backticks(label, pos);
                 if let Some(end_pos) = self.find_code_span_end(label, pos + count, count) {
                     pos = end_pos + count;
-                    continue;
+                } else {
+                    // No closer: skip the whole run so it isn't re-counted per
+                    // backtick (quadratic on long unclosed runs in a label).
+                    pos += count;
                 }
+                continue;
             }
             // Skip HTML tags and autolinks
             if label[pos] == b'<' && !self.flags.no_html_spans {

--- a/src/md/links.rs
+++ b/src/md/links.rs
@@ -35,6 +35,13 @@ pub struct Autolink {
     pub is_email: bool,
 }
 
+/// Characters that can affect bracket matching: the brackets themselves,
+/// backslash escapes, code spans, and (unless HTML spans are disabled) HTML
+/// tags/autolinks. Used to SIMD-skip runs of ordinary text while building the
+/// bracket-pair map.
+const BRACKET_SCAN_CHARS: &[u8] = b"[]\\`<";
+const BRACKET_SCAN_CHARS_NO_HTML: &[u8] = b"[]\\`";
+
 /// Result of matching a `[` against its closing `]`.
 struct BracketScan {
     /// Position of the matching `]`.
@@ -56,25 +63,37 @@ enum BracketLookup {
 /// Bracket-pair map for one inline content slice, built in a single pass so
 /// link processing can find the `]` matching a given `[` without rescanning
 /// the rest of the slice for every opener — that rescan is quadratic on
-/// inputs like `"[".repeat(n)`.
+/// inputs like `"[".repeat(n)`. The backing vec is recycled through
+/// `Parser.bracket_pairs`, so steady-state rendering does not allocate here.
 pub struct BracketMatches {
     /// `(open, close)` position of every `[` seen outside code spans, HTML
     /// tags/autolinks and backslash escapes, ordered by `open`.
     /// `close == UNMATCHED` marks an opener with no matching `]`.
-    pairs: Vec<(usize, usize)>,
+    pairs: Vec<(OFF, OFF)>,
+    /// The slice contains no `]` at all, so every opener is unmatched and
+    /// `pairs` was left empty.
+    no_closers: bool,
 }
 
 impl BracketMatches {
-    const UNMATCHED: usize = usize::MAX;
+    const UNMATCHED: OFF = OFF::MAX;
+
+    /// Hand the backing storage back for reuse by the next inline slice.
+    pub(crate) fn into_storage(self) -> Vec<(OFF, OFF)> {
+        self.pairs
+    }
 
     fn get(&self, open: usize) -> BracketLookup {
-        match self.pairs.binary_search_by_key(&open, |&(o, _)| o) {
+        if self.no_closers {
+            return BracketLookup::Unmatched;
+        }
+        match self.pairs.binary_search_by_key(&(open as OFF), |&(o, _)| o) {
             Ok(idx) => {
                 let close = self.pairs[idx].1;
                 if close == Self::UNMATCHED {
                     BracketLookup::Unmatched
                 } else {
-                    BracketLookup::Matched(close)
+                    BracketLookup::Matched(close as usize)
                 }
             }
             Err(_) => BracketLookup::Unknown,
@@ -83,60 +102,107 @@ impl BracketMatches {
 
     /// Whether any `[` opener was seen strictly between `lo` and `hi`.
     fn has_opener_between(&self, lo: usize, hi: usize) -> bool {
-        let idx = self.pairs.partition_point(|&(o, _)| o <= lo);
-        idx < self.pairs.len() && self.pairs[idx].0 < hi
+        let idx = self.pairs.partition_point(|&(o, _)| (o as usize) <= lo);
+        idx < self.pairs.len() && (self.pairs[idx].0 as usize) < hi
     }
 }
 
 impl Parser<'_> {
     /// Build the bracket-pair map for `content` in a single pass, using the
     /// same tokenization as the matching scan (code spans, HTML tags,
-    /// autolinks and backslash escapes hide brackets).
-    pub fn compute_bracket_matches(&self, content: &[u8]) -> BracketMatches {
-        let mut pairs: Vec<(usize, usize)> = Vec::new();
-        if bun_core::strings::index_of_char(content, b'[').is_none() {
-            return BracketMatches { pairs };
+    /// autolinks and backslash escapes hide brackets). `storage` is the
+    /// recycled backing vec from `Parser.bracket_pairs`.
+    pub fn compute_bracket_matches(
+        &self,
+        content: &[u8],
+        mut storage: Vec<(OFF, OFF)>,
+    ) -> BracketMatches {
+        storage.clear();
+        debug_assert!(content.len() <= OFF::MAX as usize);
+
+        // No '[' means nothing will ever be looked up; no ']' means every
+        // opener is trivially unmatched (e.g. "[".repeat(n)) — skip the walk.
+        if bun_core::immutable::index_of_char(content, b'[').is_none() {
+            return BracketMatches {
+                pairs: storage,
+                no_closers: false,
+            };
         }
-        let mut stack: Vec<usize> = Vec::new();
+        if bun_core::immutable::index_of_char(content, b']').is_none() {
+            return BracketMatches {
+                pairs: storage,
+                no_closers: true,
+            };
+        }
+
+        let scan_chars: &'static [u8] = if self.flags.no_html_spans {
+            BRACKET_SCAN_CHARS_NO_HTML
+        } else {
+            BRACKET_SCAN_CHARS
+        };
+
+        // While an opener is still unmatched, its `close` slot holds the index
+        // of the previous unmatched opener — a stack threaded through the vec
+        // itself, so no separate stack allocation is needed. Whatever is left
+        // on that stack at the end is rewritten to UNMATCHED.
+        let mut top: OFF = BracketMatches::UNMATCHED;
         let mut pos: usize = 0;
         while pos < content.len() {
-            let c = content[pos];
-            if c == b'\\' && pos + 1 < content.len() {
-                pos += 2;
-                continue;
-            }
-            // Skip code spans — they take precedence over brackets (CommonMark §6.3)
-            if c == b'`' {
-                let count = inlines::count_backticks(content, pos);
-                if let Some(end_pos) = self.find_code_span_end(content, pos + count, count) {
-                    pos = end_pos + count;
-                } else {
-                    pos += count;
+            match content[pos] {
+                b'\\' => pos += 2,
+                // Code spans take precedence over brackets (CommonMark §6.3)
+                b'`' => {
+                    let count = inlines::count_backticks(content, pos);
+                    if let Some(end_pos) = self.find_code_span_end(content, pos + count, count) {
+                        pos = end_pos + count;
+                    } else {
+                        pos += count;
+                    }
                 }
-                continue;
-            }
-            // Skip HTML tags and autolinks — they take precedence over brackets
-            if c == b'<' && !self.flags.no_html_spans {
-                if let Some(tag_end) = self.find_html_tag(content, pos) {
-                    pos = tag_end;
-                    continue;
+                // HTML tags and autolinks take precedence over brackets
+                b'<' if !self.flags.no_html_spans => {
+                    if let Some(tag_end) = self.find_html_tag(content, pos) {
+                        pos = tag_end;
+                    } else if let Some(autolink) = self.find_autolink(content, pos) {
+                        pos = autolink.end_pos;
+                    } else {
+                        pos += 1;
+                    }
                 }
-                if let Some(autolink) = self.find_autolink(content, pos) {
-                    pos = autolink.end_pos;
-                    continue;
+                b'[' => {
+                    let idx = storage.len() as OFF;
+                    storage.push((pos as OFF, top));
+                    top = idx;
+                    pos += 1;
                 }
-            }
-            if c == b'[' {
-                stack.push(pairs.len());
-                pairs.push((pos, BracketMatches::UNMATCHED));
-            } else if c == b']' {
-                if let Some(idx) = stack.pop() {
-                    pairs[idx].1 = pos;
+                b']' => {
+                    if top != BracketMatches::UNMATCHED {
+                        let idx = top as usize;
+                        top = storage[idx].1;
+                        storage[idx].1 = pos as OFF;
+                    }
+                    pos += 1;
                 }
+                // Ordinary text: SIMD-jump to the next character that can
+                // affect bracket matching.
+                _ => match bun_core::immutable::index_of_any(&content[pos..], scan_chars) {
+                    Some(rel) => pos += rel as usize,
+                    None => break,
+                },
             }
-            pos += 1;
         }
-        BracketMatches { pairs }
+
+        // Openers still on the threaded stack have no matching ']'.
+        while top != BracketMatches::UNMATCHED {
+            let idx = top as usize;
+            top = storage[idx].1;
+            storage[idx].1 = BracketMatches::UNMATCHED;
+        }
+
+        BracketMatches {
+            pairs: storage,
+            no_closers: false,
+        }
     }
 
     /// Find the `]` matching the `[` at `start` in `content`. `base` is the

--- a/src/md/links.rs
+++ b/src/md/links.rs
@@ -314,6 +314,7 @@ impl Parser<'_> {
             // Parse destination
             let mut dest_start = pos;
             let dest_end;
+            let mut dest_valid = true;
 
             if pos < content.len() && content[pos] == b'<' {
                 // Angle-bracket destination (no newlines or unescaped '<' allowed)
@@ -345,6 +346,7 @@ impl Parser<'_> {
                     if content[pos] == b'(' {
                         paren_depth += 1;
                         if paren_depth > MAX_LINK_DEST_PAREN_DEPTH {
+                            dest_valid = false;
                             break;
                         }
                     } else if content[pos] == b')' {
@@ -360,6 +362,14 @@ impl Parser<'_> {
                     }
                 }
                 dest_end = pos;
+            }
+
+            if !dest_valid {
+                // Destination exceeded the paren-nesting cap: not an inline
+                // link (cmark rejects it too). Skip the title and ')' checks —
+                // the offending '(' must not be reparsed as a title opener —
+                // but keep the reference/shortcut fallback below reachable.
+                pos = content.len();
             }
 
             // Skip whitespace (including newlines)
@@ -601,6 +611,10 @@ impl Parser<'_> {
                     if content[p] == b'(' {
                         paren_depth += 1;
                         if paren_depth > MAX_LINK_DEST_PAREN_DEPTH {
+                            // Not an inline link; skip the title/')' checks but
+                            // keep the reference/shortcut fallback reachable
+                            // (mirrors process_link).
+                            p = content.len();
                             break;
                         }
                     } else if content[p] == b')' {

--- a/src/md/parser.rs
+++ b/src/md/parser.rs
@@ -58,6 +58,9 @@ pub struct Parser<'a> {
     pub block_bytes: Vec<u8>,
     pub buffer: Vec<u8>,
     pub emph_delims: Vec<EmphDelim>,
+    // Scratch storage recycled by compute_bracket_matches (links.rs) so inline
+    // processing does not allocate a bracket-pair map per block.
+    pub bracket_pairs: Vec<(OFF, OFF)>,
 
     // Number of active containers
     pub n_containers: u32,
@@ -188,6 +191,7 @@ impl<'a> Parser<'a> {
             block_bytes: Vec::new(),
             buffer: Vec::new(),
             emph_delims: Vec::new(),
+            bracket_pairs: Vec::new(),
             n_containers: 0,
             current_block: None,
             current_block_lines: Vec::new(),

--- a/src/md/ref_defs.rs
+++ b/src/md/ref_defs.rs
@@ -7,6 +7,10 @@ use crate::parser::{BlockHeader, Parser};
 use crate::types::{self, VerbatimLine};
 use crate::unicode;
 
+/// Maximum raw length of a link label (CommonMark: "a link label can have at
+/// most 999 characters inside the square brackets").
+pub const MAX_LINK_LABEL_LEN: usize = 999;
+
 pub struct RefDef {
     pub label: Box<[u8]>, // normalized label
     pub dest: Box<[u8]>,  // raw destination (slice of source)
@@ -87,7 +91,12 @@ impl Parser<'_> {
     // PORT NOTE: returns `Option<&RefDef>` instead of by-value copy; Zig RefDef was
     // three borrowed slices (Copy), Rust RefDef owns its buffers.
     pub fn lookup_ref_def(&mut self, raw_label: &[u8]) -> Option<&RefDef> {
-        if raw_label.is_empty() {
+        if raw_label.is_empty() || self.ref_defs.is_empty() {
+            return None;
+        }
+        // Labels longer than the spec cap can never match a stored definition
+        // (parse_ref_def enforces the same limit), so skip normalizing them.
+        if raw_label.len() > MAX_LINK_LABEL_LEN {
             return None;
         }
         let normalized = self.normalize_label(raw_label);
@@ -127,7 +136,7 @@ impl Parser<'_> {
                 p += 1;
                 label_len += 1;
             }
-            if label_len > 999 {
+            if label_len > MAX_LINK_LABEL_LEN {
                 return None; // label too long
             }
         }

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import { renderToString } from "react-dom/server";
 
 const Markdown = Bun.markdown;
@@ -525,5 +526,116 @@ code
       { headings: { ids: true } },
     );
     expect(ids).toEqual(["a", "a-1", "a-2"]);
+  });
+});
+
+// ============================================================================
+// Pathological inputs: the CommonMark unclosed/nested bracket family
+// (cmark's test/pathological_tests.py). These were O(n²) — a ~100 KB flood of
+// "[" took minutes — because every link candidate rescanned the rest of the
+// paragraph for its closing "]". Rendering now happens in linear time; the
+// child process is killed after 30s so a regression fails fast instead of
+// hanging the test runner.
+// ============================================================================
+
+describe("pathological bracket inputs", () => {
+  async function expectRendersQuickly(script: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 30_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("DONE");
+    expect(exitCode).toBe(0);
+  }
+
+  test("bracket floods render in linear time (html)", async () => {
+    await expectRendersQuickly(`
+        const fill = (n, unit) => Buffer.alloc(n * unit.length, unit).toString();
+        const cases = [
+          ["unclosed brackets", fill(120000, "["), out => out.length > 120000 && out.includes("[[[[[[[[")],
+          ["balanced nested brackets", fill(60000, "[") + fill(60000, "]"), out => out.includes("[[[") && out.includes("]]]")],
+          ["blockquote bracket flood", fill(8, "> ") + fill(100000, "["), out => out.includes("<blockquote>") && out.includes("[[[")],
+          ["paren + bracket flood", fill(75000, "(") + fill(75000, "["), out => out.includes("(((") && out.includes("[[[")],
+          ["unclosed inline destination", fill(50000, "[a](b"), out => out.includes("[a](b")],
+          ["unclosed angle destination", fill(50000, "[a](<b"), out => out.length > 100000],
+          ["unclosed paren title", fill(50000, "[ (]("), out => out.includes("[ (](")],
+          ["bracket then backtick flood", "[" + fill(100000, "\`"), out => out.length > 100000],
+          ["empty label unclosed destination", fill(50000, "[]("), out => out.includes("[](")],
+          ["ref def then nested brackets", "[x]: /url\\n\\n" + fill(60000, "[") + fill(60000, "]"), out => out.includes("[[[") && out.includes("]]]")],
+        ];
+        for (const [name, input, check] of cases) {
+          const out = Bun.markdown.html(input);
+          if (!check(out)) throw new Error("unexpected output for " + name + ": " + JSON.stringify(out.slice(0, 200)));
+          console.log("OK " + name);
+        }
+        console.log("DONE");
+      `);
+  }, 90_000);
+
+  test("bracket floods render in linear time (ansi, wiki links enabled)", async () => {
+    await expectRendersQuickly(`
+        const fill = (n, unit) => Buffer.alloc(n * unit.length, unit).toString();
+        {
+          const out = Bun.markdown.ansi(fill(100000, "["), { colors: false });
+          if (out.length < 100000) throw new Error("unexpected ansi output length " + out.length);
+          console.log("OK ansi unclosed brackets");
+        }
+        {
+          const out = Bun.markdown.ansi(fill(30000, "[[a|"), { colors: false });
+          if (out.length < 100000) throw new Error("unexpected ansi wiki output length " + out.length);
+          console.log("OK ansi wiki-link flood");
+        }
+        console.log("DONE");
+      `);
+  }, 90_000);
+
+  test("long link text is still a link", () => {
+    const text = Buffer.alloc(10_000, "x").toString();
+    const html = Markdown.html(`[${text}](/url)\n`);
+    expect(html).toContain('<a href="/url">');
+    expect(html).toContain(text);
+  });
+
+  test("link destination parenthesis nesting is capped at 32 (cmark parity)", () => {
+    const nest = (n: number) => "[a](" + "(".repeat(n) + "b" + ")".repeat(n) + ")\n";
+    expect(Markdown.html(nest(3))).toContain("<a href=");
+    expect(Markdown.html(nest(32))).toContain("<a href=");
+    // Beyond the cap the candidate is not a link, matching cmark/commonmark.js.
+    const over = Markdown.html(nest(40));
+    expect(over).not.toContain("<a href=");
+    expect(over).toContain("[a](");
+  });
+
+  test("angle-bracket destination may not contain an unescaped '<'", () => {
+    expect(Markdown.html("[a](<b<c>)\n")).not.toContain("<a href=");
+    expect(Markdown.html("[a](<b\\<c>)\n")).toContain('<a href="b%3Cc"');
+  });
+
+  test("()-delimited title may not contain an unescaped '('", () => {
+    expect(Markdown.html("[a](/url (tit(le))\n")).not.toContain("<a href=");
+    expect(Markdown.html("[a](/url (title))\n")).toContain('title="title"');
+    expect(Markdown.html('[a](/url "tit(le")\n')).toContain('title="tit(le"');
+  });
+
+  test("reference labels longer than 999 characters are not reference links", () => {
+    const label999 = Buffer.alloc(999, "y").toString();
+    const label1000 = Buffer.alloc(1000, "y").toString();
+    expect(Markdown.html(`[${label999}]: /url\n\n[${label999}]\n`)).toContain('<a href="/url">');
+    expect(Markdown.html(`[${label1000}]: /url\n\n[${label1000}]\n`)).not.toContain("<a href=");
+  });
+
+  test("wiki link bracket nesting is capped", () => {
+    const wiki = (depth: number) => "[[t|" + "[".repeat(depth) + "x" + "]".repeat(depth) + "]]\n";
+    // Within the cap the whole construct is one wiki link targeting "t".
+    expect(Markdown.html(wiki(3), { wikiLinks: true })).toContain('data-target="t"');
+    expect(Markdown.html(wiki(30), { wikiLinks: true })).toContain('data-target="t"');
+    // Past the cap the outer candidate is rejected.
+    expect(Markdown.html(wiki(40), { wikiLinks: true })).not.toContain('data-target="t"');
   });
 });

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -610,6 +610,10 @@ describe("pathological bracket inputs", () => {
     const over = Markdown.html(nest(40));
     expect(over).not.toContain("<a href=");
     expect(over).toContain("[a](");
+    // The 33rd '(' must not be reparsed as a ()-title opener either.
+    const overflowIntoTitle = Markdown.html("[a](" + "(".repeat(33) + "))\n");
+    expect(overflowIntoTitle).not.toContain("<a href=");
+    expect(overflowIntoTitle).toContain("[a](");
   });
 
   test("angle-bracket destination may not contain an unescaped '<'", () => {

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -566,6 +566,7 @@ describe("pathological bracket inputs", () => {
           ["unclosed angle destination", fill(50000, "[a](<b"), out => out.length > 100000],
           ["unclosed paren title", fill(50000, "[ (]("), out => out.includes("[ (](")],
           ["bracket then backtick flood", "[" + fill(100000, "\`"), out => out.length > 100000],
+          ["unclosed backticks inside link label", "[" + fill(150000, "\`") + "[a](u)](v)", out => out.includes("<a href=") && out.length > 150000],
           ["empty label unclosed destination", fill(50000, "[]("), out => out.includes("[](")],
           ["ref def then nested brackets", "[x]: /url\\n\\n" + fill(60000, "[") + fill(60000, "]"), out => out.includes("[[[") && out.includes("]]]")],
         ];
@@ -600,6 +601,15 @@ describe("pathological bracket inputs", () => {
     const html = Markdown.html(`[${text}](/url)\n`);
     expect(html).toContain('<a href="/url">');
     expect(html).toContain(text);
+  });
+
+  test("bracket inside a code span in a link label is not an inner link", () => {
+    // The unclosed ``-run is literal; the single backticks form a code span
+    // covering [a](u), so the outer construct is a link (code spans bind
+    // tighter than links).
+    const html = Markdown.html("[``x`[a](u)`](v)\n");
+    expect(html).toContain('<a href="v">');
+    expect(html).toContain("<code>[a](u)</code>");
   });
 
   test("link destination parenthesis nesting is capped at 32 (cmark parity)", () => {


### PR DESCRIPTION
### Problem

`Bun.markdown.html()` / `.ansi()` / `.react()` are quadratic on inputs with many unclosed or nested link brackets (found by parser fuzzing):

```
bun -e 'console.time("md"); Bun.markdown.html("[".repeat(40000)); console.timeEnd("md")'
```

5,000 `[` → ~95 ms · 10,000 → ~333 ms · 20,000 → ~1,280 ms · 40,000 → ~5,069 ms — doubling the input quadruples the time, and a 255 KB flood doesn't finish in 15+ seconds (`.ansi()` takes minutes). The same blowup exists for `(((([[[[…`, `> > > > [[[[…`, `[[[[…]]]]`, and the cmark pathological `[a](b…`, `[a](<b…`, `[ (](…`, `[](…`, and `[` + backtick-flood families. Anything rendering untrusted markdown (READMEs, chat messages, comments) is exposed to a trivially craftable DoS payload.

### Cause

The inline parser resolved every `[` candidate by scanning forward from that opener to find its matching `]` (`process_link`, `try_match_bracket_link` in `src/md/links.rs`), and it does this twice per paragraph (emphasis collection + rendering). n unclosed openers × O(n) scan each = O(n²). Several secondary per-candidate scans compound the same family:

- reference lookups normalized an O(n)-long label for every bracket (`[[[[…]]]]`)
- unclosed bare/angle destinations and `(…)` titles were rescanned to the end of the input per candidate (`[a](b`, `[a](<b`, `[ (](` repeated)
- unclosed backtick runs inside the bracket scan were re-measured once per backtick (`[` + `` ` ``×n)
- with wiki links enabled (always on for `.ansi()`), every `[[` candidate rescanned to the end of the line looking for `]]`

### Fix

- **Bracket-pair map**: one pass per inline slice records every `[` (outside code spans, HTML tags/autolinks, and escapes) together with its `]`; link processing looks the match up instead of rescanning. The map's backing vec lives on the `Parser` and is recycled across slices, the open-bracket stack is threaded through the pair entries themselves, and the builder SIMD-jumps between `[ ] \ ` <` (`bun_core::immutable::index_of_any` / `index_of_char`) instead of walking every byte — so typical documents do not allocate here and barely touch the text. Slices with no `]` at all (the literal `"[".repeat(n)` payload) skip the build entirely after two SIMD scans. The old forward scan remains only as a fallback for openers the map doesn't know about.
- **Reference lookups** (`lookup_ref_def`): return early when there are no definitions or the label exceeds the spec's 999-character link-label cap (the same cap `parse_ref_def` already applies when storing definitions).
- **Bare destinations**: cap parenthesis nesting at 32, matching cmark and commonmark.js (the spec explicitly allows implementations to impose this limit).
- **Angle destinations**: stop at an unescaped `<` (per spec) instead of scanning to the end of the input.
- **`(…)`-delimited titles**: reject an unescaped `(` (per spec) instead of scanning for the next `)` anywhere in the input.
- **Wiki links**: cap `[`/`]` nesting at 32 so the `]]` scan is bounded.

Visible behavior changes are limited to the spec-aligned edge cases above (>32-deep parens in a destination, unescaped `<` in an angle destination, unescaped `(` in a paren title, >32-deep brackets inside a wiki link) — each now matches cmark/commonmark.js or the spec wording. A 30K-case differential fuzz over bracket/paren/backtick/quote-heavy inputs renders byte-identically before/after, and the full markdown suite (CommonMark spec, GFM extensions, edge cases — 1030 tests) passes.

### Measurements

| input | before (1.4.0 release) | after (debug + ASAN build) |
|---|---|---|
| `"[".repeat(40000)` → `.html()` | 5.0 s | 23 ms |
| `"[".repeat(255000)` → `.html()` | minutes | 161 ms |
| `"[".repeat(1_000_000)` → `.html()` | — | 750 ms |
| `"[".repeat(255000)` → `.ansi()` | minutes | 377 ms |

Every previously-quadratic pattern in the set above now scales linearly (×2 input → ×~2 time); release numbers are another order of magnitude lower than the debug/ASAN column.

Not addressed here: `.ansi()` has a much milder, pre-existing superlinear cost on very long single lines of plain text (no brackets involved) coming from the terminal word-wrapper; it is unrelated to this family and orders of magnitude smaller.

### Tests

`test/js/bun/md/md-edge-cases.test.ts` (new "pathological bracket inputs" block):

- two child-process tests render the pathological corpus — unclosed/nested/blockquoted bracket floods, unclosed inline/angle destinations, unclosed paren titles, bracket + backtick flood, ref-def variant, plus `.ansi()` with the wiki-link flood — with a 30 s kill switch, so the old code fails fast instead of hanging the runner
- conformance tests lock in that long link text still renders as a link, destination paren nesting works at 3/32 deep and stops past the cap, unescaped `<` / `(` invalidate angle destinations / paren titles, 999-character reference labels still resolve while 1000-character ones don't, and wiki-link nesting is capped
