### PR TITLE
css: fix exponential backtracking on deeply nested function values

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -405,8 +405,11 @@ pub trait DeriveValueType {
 
 // ───────────────────────── core parse helpers ─────────────────────────
 
+/// Skips to the end of the current block. Returns `true` if the matching
+/// closing token was found, `false` if the end of input was reached first
+/// (the block is unclosed).
 #[cold]
-fn consume_until_end_of_block(block_type: BlockType, tokenizer: &mut Tokenizer) {
+fn consume_until_end_of_block(block_type: BlockType, tokenizer: &mut Tokenizer) -> bool {
     // PERF(port): was SmallList<BlockType, 16> + appendAssumeCapacity — Vec is
     // fine for the cold path.
     let mut stack: Vec<BlockType> = Vec::with_capacity(16);
@@ -417,7 +420,7 @@ fn consume_until_end_of_block(block_type: BlockType, tokenizer: &mut Tokenizer) 
             if *stack.last().unwrap() == b {
                 let _ = stack.pop();
                 if stack.is_empty() {
-                    return;
+                    return true;
                 }
             }
         }
@@ -425,6 +428,7 @@ fn consume_until_end_of_block(block_type: BlockType, tokenizer: &mut Tokenizer) 
             stack.push(bt);
         }
     }
+    false
 }
 
 fn parse_at_rule<P: AtRuleParser>(
@@ -636,6 +640,25 @@ pub fn parse_until_after<T, C>(
 
 const MAX_NESTING_DEPTH: u32 = 512;
 
+/// Records that the block whose content starts at `start_position` failed to
+/// parse and turned out to be unclosed: the end of input was reached without
+/// ever finding its closing token. See `ParserInput::unclosed_block_at_eof`.
+#[cold]
+fn record_unclosed_block_at_eof(parser: &mut Parser, start_position: usize) {
+    debug_assert!(parser.input.tokenizer.is_eof());
+    let eof_state = parser.input.tokenizer.state();
+    let entry = parser
+        .input
+        .unclosed_block_at_eof
+        .get_or_insert(UnclosedBlockAtEof {
+            start_position,
+            eof_state,
+        });
+    if start_position < entry.start_position {
+        entry.start_position = start_position;
+    }
+}
+
 fn parse_nested_block<T>(
     parser: &mut Parser,
     parsefn: impl FnOnce(&mut Parser) -> CssResult<T>,
@@ -648,11 +671,29 @@ fn parse_nested_block<T>(
         )
     });
 
+    let start_position = parser.input.tokenizer.get_position();
+    // If a block at or before this position already failed to parse and was
+    // found to be unclosed at the end of input, this block lies inside that
+    // truncated suffix and extends to the end of input as well. Re-parsing it
+    // can only fail again, so skip straight to the end of input. Without this,
+    // backtracking callers (e.g. `Calc::parse` followed by `V::parse`, or the
+    // token-list color fallbacks) re-parse the unclosed suffix once per
+    // alternative per nesting level, which is exponential in the nesting depth.
+    if let Some(unclosed) = parser.input.unclosed_block_at_eof {
+        if start_position >= unclosed.start_position {
+            parser.input.tokenizer.reset(&unclosed.eof_state);
+            return Err(parser.new_error(BasicParseErrorKind::end_of_input));
+        }
+    }
+
     parser.input.nesting_depth += 1;
     if parser.input.nesting_depth > MAX_NESTING_DEPTH {
         parser.input.nesting_depth -= 1;
         let err = parser.new_custom_error(ParserError::maximum_nesting_depth);
-        consume_until_end_of_block(block_type, &mut parser.input.tokenizer);
+        let found_close = consume_until_end_of_block(block_type, &mut parser.input.tokenizer);
+        if !found_close {
+            record_unclosed_block_at_eof(parser, start_position);
+        }
         return Err(err);
     }
 
@@ -672,7 +713,10 @@ fn parse_nested_block<T>(
         consume_until_end_of_block(block_type2, &mut parser.input.tokenizer);
     }
     parser.stop_before = saved_stop_before;
-    consume_until_end_of_block(block_type, &mut parser.input.tokenizer);
+    let found_close = consume_until_end_of_block(block_type, &mut parser.input.tokenizer);
+    if result.is_err() && !found_close {
+        record_unclosed_block_at_eof(parser, start_position);
+    }
     parser.input.nesting_depth -= 1;
     result
 }
@@ -4213,6 +4257,25 @@ pub struct ParserInput<'a> {
     pub tokenizer: Tokenizer<'a>,
     pub cached_token: Option<CachedToken>,
     pub nesting_depth: u32,
+    /// Set once a nested block fails to parse and the end of input is reached
+    /// without ever finding its closing token, i.e. the stylesheet is
+    /// truncated somewhere inside that block. Everything from
+    /// `start_position` to the end of input is inside the unclosed block, so
+    /// re-parsing any block in that range can only fail the same way again.
+    /// `parse_nested_block` uses this to fail such attempts immediately
+    /// instead of re-scanning (and re-recursing through) the truncated
+    /// suffix once per backtracking alternative per nesting level.
+    unclosed_block_at_eof: Option<UnclosedBlockAtEof>,
+}
+
+/// See `ParserInput::unclosed_block_at_eof`.
+#[derive(Copy, Clone)]
+struct UnclosedBlockAtEof {
+    /// Position of the first token inside the earliest known unclosed block.
+    start_position: usize,
+    /// Tokenizer state at the end of input, captured when the unclosed block
+    /// was discovered.
+    eof_state: ParserState,
 }
 
 impl<'a> ParserInput<'a> {
@@ -4229,6 +4292,7 @@ impl<'a> ParserInput<'a> {
             tokenizer: Tokenizer::init_with_arena(code, arena),
             cached_token: None,
             nesting_depth: 0,
+            unclosed_block_at_eof: None,
         }
     }
 }

--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -662,8 +662,8 @@ impl<V: CalcValue> Calc<V> {
         parse_ident: F,
     ) -> CssResult<Self> {
         // Parse nested calc() and other math functions.
-        if let Ok(calc) = input.try_parse(Self::parse) {
-            match calc {
+        match input.try_parse(Self::parse) {
+            Ok(calc) => match calc {
                 Calc::Function(f) => {
                     return match *f {
                         MathFunction::Calc(c) => Ok(c),
@@ -671,6 +671,23 @@ impl<V: CalcValue> Calc<V> {
                     };
                 }
                 other => return Ok(other),
+            },
+            Err(e) => {
+                // A math function token can only be parsed by `Self::parse`.
+                // If that failed, none of the alternatives below can succeed
+                // either, so return the error rather than falling through:
+                // `V::parse` would re-enter the same nested block through
+                // `Calc::parse` again, which makes deeply nested invalid
+                // arguments exponentially slow to reject.
+                let start = input.state();
+                let is_math_function = matches!(
+                    input.next(),
+                    Ok(css::Token::Function(name)) if CalcUnit::get_any_case(name).is_some()
+                );
+                input.reset(&start);
+                if is_math_function {
+                    return Err(e);
+                }
             }
         }
 

--- a/test/js/bun/css/nested-function-backtracking.test.ts
+++ b/test/js/bun/css/nested-function-backtracking.test.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import path from "node:path";
+
+// Regression test for exponential backtracking in the CSS parser on deeply
+// nested function values.
+//
+// For every nested `calc(`/`rgb(`/... level, the value parser tried one
+// alternative that descended into the block and failed, then another
+// alternative that descended into the very same block again (`Calc::parse`
+// followed by `V::parse`, or the token-list color fallbacks). Each unclosed or
+// invalid nesting level therefore doubled the work: 50 nested unclosed
+// `calc(` levels — a 661-byte stylesheet — kept `bun build` spinning forever
+// while allocating unboundedly.
+//
+// The parser now remembers when a nested block failed to parse and turned out
+// to be unclosed at the end of input (re-parsing the truncated suffix can only
+// fail again), and a math function whose arguments failed to parse is no
+// longer re-parsed through the value fallback, so these inputs are rejected
+// (or parsed) in linear time.
+
+async function buildCSS(name: string, css: string) {
+  using dir = tempDir("css-nested-function-backtracking", { [name]: css });
+  const outdir = path.join(String(dir), "out");
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", path.join(String(dir), name), "--outdir", outdir],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    // Kill switch: before the fix these builds spun forever. Let the child
+    // terminate itself so a regression fails the assertions below instead of
+    // leaving a runaway `bun build` process behind.
+    timeout: 20_000,
+    killSignal: "SIGKILL",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  let output = "";
+  try {
+    output = await Bun.file(path.join(outdir, name)).text();
+  } catch {}
+  return { stdout, stderr, exitCode, output };
+}
+
+test("unclosed nested calc() values error out instead of hanging", async () => {
+  const { stderr, exitCode } = await buildCSS("unclosed-calc.css", ".b{height:" + "calc(100vh - ".repeat(50) + "}");
+  expect(stderr).toContain("Unexpected end of input");
+  expect(exitCode).toBe(1);
+});
+
+test("unclosed nested color function values error out instead of hanging", async () => {
+  const { stderr, exitCode } = await buildCSS("unclosed-rgb.css", ".b{color:" + "rgb(1 2 3 / ".repeat(50) + "}");
+  expect(stderr).toContain("Unexpected end of input");
+  expect(exitCode).toBe(1);
+});
+
+test("deeply nested balanced-but-invalid calc() is handled without hanging", async () => {
+  // Balanced parentheses, but the innermost value is not valid in calc(), so
+  // the math-function parse fails at every nesting level. This exercises the
+  // non-EOF half of the fix: the failed math function must not be re-parsed
+  // through the value fallback at each level.
+  const { stderr, exitCode, output } = await buildCSS(
+    "balanced-invalid-calc.css",
+    ".b{height:" + "calc(1px + ".repeat(50) + "@" + ")".repeat(50) + "}",
+  );
+  // The declaration is preserved as an unparsed value, same as before.
+  expect(output).toContain("calc(");
+  expect({ exitCode, stderr }).toMatchObject({ exitCode: 0 });
+});
+
+test("deeply nested valid calc() still parses and folds", async () => {
+  const { stderr, exitCode, output } = await buildCSS(
+    "balanced-valid-calc.css",
+    ".b{height:" + "calc(1px + ".repeat(50) + "2px" + ")".repeat(50) + "}",
+  );
+  expect(output).toContain("height: 52px");
+  expect({ exitCode, stderr }).toMatchObject({ exitCode: 0 });
+});
+
+test("stylesheets truncated inside an otherwise-valid value still parse", async () => {
+  // Blocks left open at the end of input are implicitly closed when their
+  // contents parse fine; that behavior must survive the fast-fail path.
+  const { stderr, exitCode, output } = await buildCSS("truncated-valid.css", ".a{color:red;width:calc(100% - 5px");
+  expect(output).toContain("color: red");
+  expect(output).toContain("calc(100% - 5px)");
+  expect({ exitCode, stderr }).toMatchObject({ exitCode: 0 });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes an infinite hang (exponential parse time + unbounded allocation) in the CSS parser on deeply nested function values, found by parser fuzzing.

**Repro:**

```bash
bun -e 'require("fs").writeFileSync("hang.css", ".b{height:" + "calc(100vh - ".repeat(50) + "}")'
bun build hang.css --outdir out   # never returns, memory grows toward the worker limit
```

Same result with 50 unclosed `rgb(1 2 3 /` levels, and with balanced-but-invalid nesting such as `"calc(1px + ".repeat(50) + "@" + ")".repeat(50)`. Any CSS reachable from `bun build`, an `import "./x.css"`, or the dev server is an entry point, so a stylesheet truncated mid-`calc()` DoSes the bundler.

### Root cause

Parse time doubles with every nesting level (measured: depth 16 → 53 ms, 18 → 192 ms, 20 → 749 ms, 22 → 3 s, 24 → 12 s, 26 → 47 s; depth 50 is effectively forever). For each nested `calc(`/`rgb(` level, the value parser tries one alternative that descends into the block and fails, backtracks via `try_parse`, then tries another alternative that descends into the **same** block again:

* `Calc::parse_value` tries `Calc::parse`, and on failure falls through to `V::parse`, which re-enters the same block through `Calc::parse` again (`src/css/values/calc.rs`).
* The token-list parser tries the color fallbacks (`CssColor::parse`, `UnresolvedColor::parse`) and then the raw-function fallback, each descending into the same block (`src/css/properties/custom.rs`).

Two full descents per nesting level is O(2^N). This is inherited from lightningcss — upstream lightningcss 1.32.0 hangs on the exact same input — so there is no upstream fix to port.

### The fix

1. **`css_parser.rs`** — `parse_nested_block` now records (on the `ParserInput`) when a nested block fails to parse and the end of input is reached without ever finding its closing token, i.e. the stylesheet is truncated inside that block. Everything from that position to EOF is inside the unclosed block, so re-parsing any block in that range can only fail again; later attempts fail immediately instead of re-scanning the truncated suffix. Truncated garbage is now rejected with a single `Unexpected end of input` error in linear time, which also bounds memory.

2. **`values/calc.rs`** — when the next token is a math-function token and `Calc::parse` already failed, `parse_value` returns that error instead of falling through to `V::parse` (which could only re-enter the same block via `Calc::parse`). This covers the balanced-but-invalid variant, which never reaches EOF. The existing `MAX_NESTING_DEPTH = 512` limit stays as the depth backstop.

### Behavior notes

* Valid stylesheets are unaffected (the guard only engages after a nested block parse fails with the block unclosed at EOF). Deeply nested *valid* `calc()` still parses and constant-folds (50 levels → `52px`, matching lightningcss).
* Truncated-but-parseable input is unchanged: missing trailing `}`s, `.a{color:red;width:calc(100% - 5px` (implicitly closed), truncated custom properties like `--x:calc(100vh - ` all produce the same output as before.
* The one intentional change: a stylesheet truncated at EOF inside a value whose tail *fails* a typed parse (e.g. `.b{height:calc(100vh - ` or `--x:rgb(1 2 3 / var(--y`) now reports `error: Unexpected end of input` instead of being leniently preserved after (potentially exponential) re-parsing. Known-property cases in this shape already errored before; custom-property cases previously limped through.

### Verification

* New test `test/js/bun/css/nested-function-backtracking.test.ts`: the two unclosed repros (calc/rgb ×50), the balanced-but-invalid variant, deep valid calc folding, and a truncated-but-valid stylesheet. The hang cases spawn `bun build` with a 20 s kill switch, so on an unfixed build they fail instead of hanging the runner; on the fixed debug build each completes in well under a second.
* Existing suites pass with the fix: `test/js/bun/css/css.test.ts` (1032), `test/js/bun/css/color.test.ts` + `css-modules.test.ts` (917), `test/bundler/css/` incl. WPT color tests + `doesnt_crash.test.ts` (226). The only failure seen locally is the pre-existing `fuzz ansi256` 16.7M-iteration timeout on debug ASAN builds (integer path, never touches the CSS parser).
* `test/bake/dev/css.test.ts`: `css-6`/`css-13` fail with `assertion failed: !chunk.content.is_css()` on debug builds **with or without** this change (verified by rebuilding from a clean tree) — pre-existing debug-only dev-server issue around unresolved CSS imports, unrelated to this fix.