### PR TITLE
Implement dynamic `import.defer()` (TC39 Stage 3)

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -2411,6 +2411,12 @@ pub struct Import {
     pub expr: ExprNodeIndex,
     pub options: ExprNodeIndex,
     pub import_record_index: u32,
+    /// True for `import.defer(...)` — the dynamic form of the TC39
+    /// "Deferred Module Evaluation" proposal. The module graph is fetched
+    /// and linked, but evaluation is deferred until a property of the
+    /// returned namespace is accessed.
+    /// https://tc39.es/proposal-defer-import-eval/
+    pub phase_defer: bool,
     // TODO:
     // Comments inside "import()" expressions have special meaning for Webpack.
     // Preserving comments inside these expressions makes it possible to use

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -2411,11 +2411,7 @@ pub struct Import {
     pub expr: ExprNodeIndex,
     pub options: ExprNodeIndex,
     pub import_record_index: u32,
-    /// True for `import.defer(...)` — the dynamic form of the TC39
-    /// "Deferred Module Evaluation" proposal. The module graph is fetched
-    /// and linked, but evaluation is deferred until a property of the
-    /// returned namespace is accessed.
-    /// https://tc39.es/proposal-defer-import-eval/
+    /// `import.defer(...)` (https://tc39.es/proposal-defer-import-eval/)
     pub phase_defer: bool,
     // TODO:
     // Comments inside "import()" expressions have special meaning for Webpack.

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -2123,6 +2123,7 @@ impl Data {
                     expr: el.expr.deep_clone_no_detach(bump)?,
                     options: el.options.deep_clone_no_detach(bump)?,
                     import_record_index: el.import_record_index,
+                    phase_defer: el.phase_defer,
                 });
                 Ok(Data::EImport(StoreRef::from_bump(item)))
             }

--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -84,10 +84,7 @@ bitflags::bitflags! {
         const WRAP_WITH_TO_ESM = 1 << 13;
         const WRAP_WITH_TO_COMMONJS = 1 << 14;
 
-        /// "import defer * as ns from 'path'" (kind `Stmt`, requires
-        /// `CONTAINS_IMPORT_STAR`) or "import.defer('path')" (kind `Dynamic`)
-        /// — defer evaluation of the imported module until a property on the
-        /// namespace object is accessed.
+        /// `import defer * as ns from 'path'` (requires `CONTAINS_IMPORT_STAR`) or `import.defer('path')`.
         const PHASE_DEFER = 1 << 15;
     }
 }

--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -84,9 +84,10 @@ bitflags::bitflags! {
         const WRAP_WITH_TO_ESM = 1 << 13;
         const WRAP_WITH_TO_COMMONJS = 1 << 14;
 
-        /// "import defer * as ns from 'path'" — defer evaluation of the
-        /// imported module until a property on the namespace object is
-        /// accessed. Requires `CONTAINS_IMPORT_STAR`.
+        /// "import defer * as ns from 'path'" (kind `Stmt`, requires
+        /// `CONTAINS_IMPORT_STAR`) or "import.defer('path')" (kind `Dynamic`)
+        /// — defer evaluation of the imported module until a property on the
+        /// namespace object is accessed.
         const PHASE_DEFER = 1 << 15;
     }
 }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -998,6 +998,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     (state.is_await_target && self.fn_or_arrow_data_visit.try_body_count != 0)
                         || state.is_then_catch_target,
                 );
+            self.import_records.items_mut()[import_record_index as usize]
+                .flags
+                .set(bun_ast::ImportRecordFlags::PHASE_DEFER, state.phase_defer);
             self.import_records_for_current_part
                 .push(import_record_index);
 
@@ -1006,6 +1009,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     expr: arg,
                     import_record_index,
                     options: state.import_options,
+                    phase_defer: state.phase_defer,
                 },
                 state.loc,
             );
@@ -1029,6 +1033,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 expr: arg,
                 options: state.import_options,
                 import_record_index: u32::MAX,
+                phase_defer: state.phase_defer,
             },
             state.loc,
         )

--- a/src/js_parser/parse/parse_import_export.rs
+++ b/src/js_parser/parse/parse_import_export.rs
@@ -35,7 +35,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 p.lexer.next()?;
                 phase_defer = true;
             } else {
-                p.lexer.expected_string(b"\"meta\"")?;
+                p.lexer.expected_string(b"\"meta\" or \"defer\"")?;
             }
         }
 

--- a/src/js_parser/parse/parse_import_export.rs
+++ b/src/js_parser/parse/parse_import_export.rs
@@ -16,22 +16,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         level: Level,
     ) -> Result<Expr, Error> {
         let p = self;
-        // "import.defer(...)" — the dynamic form of the TC39 "Deferred Module
-        // Evaluation" proposal. Unlike "import.meta" it is a dynamic import,
-        // so it does not mark the file as ESM.
         let mut phase_defer = false;
         // Parse an "import.meta" expression
         if p.lexer.token == T::TDot {
             p.lexer.next()?;
             if p.lexer.is_contextual_keyword(b"meta") {
+                // Only `import.meta` implies ESM; `import.defer()` is a dynamic import.
                 p.esm_import_keyword = js_lexer::range_of_identifier(p.source, loc);
                 p.lexer.next()?;
                 p.has_import_meta = true;
                 return Ok(p.new_expr(E::ImportMeta {}, loc));
             } else if p.lexer.is_contextual_keyword(b"defer") {
-                // ImportCall : `import` `.` `defer` `(` AssignmentExpression `,`? `)`
-                // `is_contextual_keyword` compares the raw token, so an escaped
-                // `def\u0065r` falls through to the error branch instead.
                 p.lexer.next()?;
                 phase_defer = true;
             } else {

--- a/src/js_parser/parse/parse_import_export.rs
+++ b/src/js_parser/parse/parse_import_export.rs
@@ -16,14 +16,24 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         level: Level,
     ) -> Result<Expr, Error> {
         let p = self;
+        // "import.defer(...)" — the dynamic form of the TC39 "Deferred Module
+        // Evaluation" proposal. Unlike "import.meta" it is a dynamic import,
+        // so it does not mark the file as ESM.
+        let mut phase_defer = false;
         // Parse an "import.meta" expression
         if p.lexer.token == T::TDot {
-            p.esm_import_keyword = js_lexer::range_of_identifier(p.source, loc);
             p.lexer.next()?;
             if p.lexer.is_contextual_keyword(b"meta") {
+                p.esm_import_keyword = js_lexer::range_of_identifier(p.source, loc);
                 p.lexer.next()?;
                 p.has_import_meta = true;
                 return Ok(p.new_expr(E::ImportMeta {}, loc));
+            } else if p.lexer.is_contextual_keyword(b"defer") {
+                // ImportCall : `import` `.` `defer` `(` AssignmentExpression `,`? `)`
+                // `is_contextual_keyword` compares the raw token, so an escaped
+                // `def\u0065r` falls through to the error branch instead.
+                p.lexer.next()?;
+                phase_defer = true;
             } else {
                 p.lexer.expected_string(b"\"meta\"")?;
             }
@@ -87,11 +97,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             if let Some(slice) = slice_opt {
                 let import_record_index =
                     p.add_import_record(bun_ast::ImportKind::Dynamic, value.loc, slice);
+                p.import_records.items_mut()[import_record_index as usize]
+                    .flags
+                    .set(bun_ast::ImportRecordFlags::PHASE_DEFER, phase_defer);
                 return Ok(p.new_expr(
                     E::Import {
                         expr: value,
                         import_record_index,
                         options: import_options,
+                        phase_defer,
                     },
                     loc,
                 ));
@@ -106,6 +120,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // .leading_interior_comments = comments,
                 import_record_index: u32::MAX,
                 options: import_options,
+                phase_defer,
             },
             loc,
         ))

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -693,6 +693,8 @@ pub struct TransposeState {
     pub(crate) import_record_tag: Option<bun_ast::ImportRecordTag>,
     pub(crate) import_loader: Option<bun_ast::Loader>,
     pub(crate) import_options: Expr,
+    /// True when transposing an `import.defer(...)` expression.
+    pub(crate) phase_defer: bool,
 }
 
 impl Default for TransposeState {
@@ -705,6 +707,7 @@ impl Default for TransposeState {
             import_record_tag: None,
             import_loader: None,
             import_options: Expr::EMPTY,
+            phase_defer: false,
         }
     }
 }

--- a/src/js_parser/repl_transforms.rs
+++ b/src/js_parser/repl_transforms.rs
@@ -269,6 +269,7 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                     //   import X from 'mod'      -> var X = (await import('mod')).default
                     //   import { a, b } from 'mod' -> var {a, b} = await import('mod')
                     //   import * as X from 'mod'   -> var X = await import('mod')
+                    //   import defer * as X from 'mod' -> var X = await import.defer('mod')
                     //   import 'mod'              -> await import('mod')
                     let path_str: &'static [u8] = self.import_records.items()
                         [import_data.import_record_index as usize]
@@ -286,6 +287,7 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                             expr: str_expr,
                             options: Expr::EMPTY,
                             import_record_index: u32::MAX,
+                            phase_defer: import_data.phase_defer,
                         },
                         stmt.loc,
                     );

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1828,6 +1828,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 import_options: e_.options,
                 loc: e_.expr.loc,
                 import_loader: e_.import_record_loader(),
+                phase_defer: e_.phase_defer,
                 ..Default::default()
             };
 

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2703,13 +2703,8 @@ pub(crate) mod __gated_printer {
 
             // Allow it to fail at runtime, if it should
             if module_type != bundle_opts::Format::InternalBakeDev {
+                // The `__toESM` `.then()` below would touch the namespace immediately, defeating the defer.
                 if record.flags.contains(ImportRecordFlags::PHASE_DEFER) && !wrap_with_to_esm {
-                    // `import.defer(...)` — keep the defer phase so the engine
-                    // defers evaluation of the imported module. When the record
-                    // needs the `__toESM` interop wrapper (cross-chunk CommonJS
-                    // target), the `.then((m)=>__toESM(m.default))` below would
-                    // touch the namespace immediately and defeat the defer, so
-                    // degrade to a regular dynamic import instead.
                     self.print(b"import.defer(");
                 } else {
                     self.print(b"import(");

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2703,9 +2703,13 @@ pub(crate) mod __gated_printer {
 
             // Allow it to fail at runtime, if it should
             if module_type != bundle_opts::Format::InternalBakeDev {
-                if record.flags.contains(ImportRecordFlags::PHASE_DEFER) {
+                if record.flags.contains(ImportRecordFlags::PHASE_DEFER) && !wrap_with_to_esm {
                     // `import.defer(...)` — keep the defer phase so the engine
-                    // defers evaluation of the imported module.
+                    // defers evaluation of the imported module. When the record
+                    // needs the `__toESM` interop wrapper (cross-chunk CommonJS
+                    // target), the `.then((m)=>__toESM(m.default))` below would
+                    // touch the namespace immediately and defeat the defer, so
+                    // degrade to a regular dynamic import instead.
                     self.print(b"import.defer(");
                 } else {
                     self.print(b"import(");

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2703,7 +2703,13 @@ pub(crate) mod __gated_printer {
 
             // Allow it to fail at runtime, if it should
             if module_type != bundle_opts::Format::InternalBakeDev {
-                self.print(b"import(");
+                if record.flags.contains(ImportRecordFlags::PHASE_DEFER) {
+                    // `import.defer(...)` — keep the defer phase so the engine
+                    // defers evaluation of the imported module.
+                    self.print(b"import.defer(");
+                } else {
+                    self.print(b"import(");
+                }
                 self.print_import_record_path(record);
             } else {
                 self.print_symbol(self.options.hmr_ref);
@@ -3365,6 +3371,8 @@ pub(crate) mod __gated_printer {
                         if self.options.module_type == bundle_opts::Format::InternalBakeDev {
                             self.print_symbol(self.options.hmr_ref);
                             self.print(b".dynamicImport(");
+                        } else if e.phase_defer {
+                            self.print(b"import.defer(");
                         } else {
                             self.print(b"import(");
                         }

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -276,7 +276,7 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
     return function;
 }
 
-JSPromise* importModule(JSGlobalObject* globalObject, JSString* moduleName, RefPtr<JSC::ScriptFetchParameters> parameters, const SourceOrigin& sourceOrigin)
+JSPromise* importModule(JSGlobalObject* globalObject, JSString* moduleName, RefPtr<JSC::ScriptFetchParameters> parameters, const SourceOrigin& sourceOrigin, bool deferred)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -303,7 +303,7 @@ JSPromise* importModule(JSGlobalObject* globalObject, JSString* moduleName, RefP
     if (isUseMainContextDefaultLoaderConstant(globalObject, dynamicImportCallback)) {
         auto defer = fetcher->temporarilyUseDefaultLoader();
         Zig::GlobalObject* zigGlobalObject = defaultGlobalObject(globalObject);
-        RELEASE_AND_RETURN(scope, zigGlobalObject->moduleLoaderImportModule(zigGlobalObject, zigGlobalObject->moduleLoader(), moduleName, WTF::move(parameters), sourceOrigin, false));
+        RELEASE_AND_RETURN(scope, zigGlobalObject->moduleLoaderImportModule(zigGlobalObject, zigGlobalObject->moduleLoader(), moduleName, WTF::move(parameters), sourceOrigin, deferred));
     } else if (!dynamicImportCallback || !dynamicImportCallback.isCallable()) {
         throwException(globalObject, scope, createError(globalObject, ErrorCode::ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING, "A dynamic import callback was not specified."_s));
         return nullptr;
@@ -1656,12 +1656,11 @@ static JSPromise* moduleLoaderImportModuleInner(NodeVMGlobalObject* globalObject
 
 JSPromise* NodeVMGlobalObject::moduleLoaderImportModule(JSGlobalObject* globalObject, JSC::JSModuleLoader* moduleLoader, JSC::JSString* moduleName, RefPtr<JSC::ScriptFetchParameters> parameters, const JSC::SourceOrigin& sourceOrigin, bool deferred)
 {
-    UNUSED_PARAM(deferred);
     auto* nodeVmGlobalObject = static_cast<NodeVMGlobalObject*>(globalObject);
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSPromise* result = NodeVM::importModule(nodeVmGlobalObject, moduleName, parameters, sourceOrigin);
+    JSPromise* result = NodeVM::importModule(nodeVmGlobalObject, moduleName, parameters, sourceOrigin, deferred);
     // importModule runs the user's dynamic-import callback, which can throw
     // and leave a null result; surface that as a rejected promise instead of
     // falling through with the exception pending.
@@ -1673,6 +1672,9 @@ JSPromise* NodeVMGlobalObject::moduleLoaderImportModule(JSGlobalObject* globalOb
         return result;
     }
 
+    // The `importModuleDynamically` callback API has no notion of an import
+    // phase, so a deferred import resolved through it behaves like a regular
+    // dynamic import.
     RELEASE_AND_RETURN(scope, moduleLoaderImportModuleInner(nodeVmGlobalObject, moduleLoader, moduleName, WTF::move(parameters), sourceOrigin));
 }
 

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1672,9 +1672,7 @@ JSPromise* NodeVMGlobalObject::moduleLoaderImportModule(JSGlobalObject* globalOb
         return result;
     }
 
-    // The `importModuleDynamically` callback API has no notion of an import
-    // phase, so a deferred import resolved through it behaves like a regular
-    // dynamic import.
+    // importModuleDynamically callbacks have no import phase, so `deferred` stops here.
     RELEASE_AND_RETURN(scope, moduleLoaderImportModuleInner(nodeVmGlobalObject, moduleLoader, moduleName, WTF::move(parameters), sourceOrigin));
 }
 

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -40,7 +40,7 @@ NodeVMGlobalObject* getGlobalObjectFromContext(JSGlobalObject* globalObject, JSV
 JSC::EncodedJSValue INVALID_ARG_VALUE_VM_VARIATION(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, WTF::ASCIILiteral name, JSC::JSValue value);
 // For vm.compileFunction we need to return an anonymous function expression. This code is adapted from/inspired by JSC::constructFunction, which is used for function declarations.
 JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, const ArgList& args, const SourceOrigin& sourceOrigin, CompileFunctionOptions&& options, JSC::SourceTaintedOrigin sourceTaintOrigin, JSC::JSScope* scope);
-JSPromise* importModule(JSGlobalObject* globalObject, JSString* moduleNameValue, RefPtr<JSC::ScriptFetchParameters> parameters, const SourceOrigin& sourceOrigin);
+JSPromise* importModule(JSGlobalObject* globalObject, JSString* moduleNameValue, RefPtr<JSC::ScriptFetchParameters> parameters, const SourceOrigin& sourceOrigin, bool deferred);
 bool isContext(JSC::JSGlobalObject* globalObject, JSValue);
 bool getContextArg(JSC::JSGlobalObject* globalObject, JSValue& contextArg);
 bool isUseMainContextDefaultLoaderConstant(JSC::JSGlobalObject* globalObject, JSValue value);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3659,8 +3659,7 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
 
     // The C++ module loader now extracts `with.type` into a
     // ScriptFetchParameters before calling this hook, so `parameters` is
-    // already the parsed RefPtr (or null). Just forward it, along with the
-    // defer phase of `import.defer(...)`.
+    // already the parsed RefPtr (or null). Just forward it.
     auto result = JSC::importModule(globalObject, resolvedIdentifier,
         JSC::Identifier(), WTF::move(parameters), nullptr, deferred, referrerAsyncOrder);
     if (scope.exception()) [[unlikely]] {

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3559,14 +3559,13 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
     const SourceOrigin& sourceOrigin,
     bool deferred)
 {
-    UNUSED_PARAM(deferred);
     auto* globalObject = static_cast<Zig::GlobalObject*>(jsGlobalObject);
 
     VM& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     {
-        JSC::JSPromise* result = NodeVM::importModule(globalObject, moduleNameValue, parameters, sourceOrigin);
+        JSC::JSPromise* result = NodeVM::importModule(globalObject, moduleNameValue, parameters, sourceOrigin, deferred);
         RETURN_IF_EXCEPTION(scope, nullptr);
         if (result) {
             return result;
@@ -3602,7 +3601,7 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
         if (auto resolution = globalObject->onLoadPlugins.resolveVirtualModule(moduleName, sourceURL.protocolIsFile() ? sourceOriginStringHolder : String())) {
             resolvedIdentifier = JSC::Identifier::fromString(vm, resolution.value());
 
-            auto result = JSC::importModule(globalObject, resolvedIdentifier, JSC::Identifier(), parameters, nullptr, /* deferred */ false, referrerAsyncOrder);
+            auto result = JSC::importModule(globalObject, resolvedIdentifier, JSC::Identifier(), parameters, nullptr, deferred, referrerAsyncOrder);
             if (scope.exception()) [[unlikely]] {
                 return JSC::JSPromise::rejectedPromiseWithCaughtException(globalObject, scope);
             }
@@ -3660,9 +3659,10 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
 
     // The C++ module loader now extracts `with.type` into a
     // ScriptFetchParameters before calling this hook, so `parameters` is
-    // already the parsed RefPtr (or null). Just forward it.
+    // already the parsed RefPtr (or null). Just forward it, along with the
+    // defer phase of `import.defer(...)`.
     auto result = JSC::importModule(globalObject, resolvedIdentifier,
-        JSC::Identifier(), WTF::move(parameters), nullptr, /* deferred */ false, referrerAsyncOrder);
+        JSC::Identifier(), WTF::move(parameters), nullptr, deferred, referrerAsyncOrder);
     if (scope.exception()) [[unlikely]] {
         return JSC::JSPromise::rejectedPromiseWithCaughtException(globalObject, scope);
     }

--- a/src/react_compiler/codegen.rs
+++ b/src/react_compiler/codegen.rs
@@ -1892,6 +1892,7 @@ fn codegen_base_instruction_value(
                         expr: it.next().unwrap_or(orig.expr),
                         options: it.next().unwrap_or(Expr::EMPTY),
                         import_record_index: orig.import_record_index,
+                        phase_defer: orig.phase_defer,
                     },
                     loc,
                 ));

--- a/src/runtime/bake/BakeGlobalObject.cpp
+++ b/src/runtime/bake/BakeGlobalObject.cpp
@@ -21,12 +21,11 @@ bakeModuleLoaderImportModule(JSC::JSGlobalObject* global,
     const JSC::SourceOrigin& sourceOrigin,
     bool deferred)
 {
-    UNUSED_PARAM(deferred);
     WTF::String keyString = moduleNameValue->getString(global);
     if (keyString.startsWith("bake:/"_s)) {
         auto& vm = JSC::getVM(global);
         return JSC::importModule(global, JSC::Identifier::fromString(vm, keyString),
-            JSC::Identifier(), WTF::move(parameters), nullptr);
+            JSC::Identifier(), WTF::move(parameters), nullptr, deferred);
     }
 
     if (!sourceOrigin.isNull() && sourceOrigin.string().startsWith("bake:/"_s)) {
@@ -46,11 +45,11 @@ bakeModuleLoaderImportModule(JSC::JSGlobalObject* global,
         RETURN_IF_EXCEPTION(scope, nullptr);
 
         return JSC::importModule(global, JSC::Identifier::fromString(vm, result.toWTFString()),
-            JSC::Identifier(), WTF::move(parameters), nullptr);
+            JSC::Identifier(), WTF::move(parameters), nullptr, deferred);
     }
 
     // TODO: make static cast instead of jscast
-    return uncheckedDowncast<Zig::GlobalObject>(global)->moduleLoaderImportModule(global, moduleLoader, moduleNameValue, WTF::move(parameters), sourceOrigin, false);
+    return uncheckedDowncast<Zig::GlobalObject>(global)->moduleLoaderImportModule(global, moduleLoader, moduleNameValue, WTF::move(parameters), sourceOrigin, deferred);
 }
 
 JSC::Identifier bakeModuleLoaderResolve(JSC::JSGlobalObject* jsGlobal,

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3266,6 +3266,34 @@ describe("bundler", () => {
       expect(out).toContain("import.defer(name)");
     },
   });
+  // With code splitting, a deferred dynamic import of a CommonJS module needs
+  // the `__toESM` interop wrapper, whose `.then((m) => __toESM(m.default))`
+  // callback touches the namespace immediately. Emitting `import.defer()`
+  // there would be pointless (it would be defeated on the same line), so the
+  // defer phase is dropped and a regular dynamic import is emitted.
+  itBundled("edgecase/DynamicImportDeferSplittingCommonJS", {
+    files: {
+      "/entry.js": /* js */ `
+        const ns = await import.defer("./dep.cjs");
+        console.log("value:", ns.default.value);
+      `,
+      "/dep.cjs": /* js */ `
+        module.exports = { value: 7 };
+      `,
+    },
+    splitting: true,
+    outdir: "/out",
+    target: "bun",
+    onAfterBundle(api) {
+      const out = api.readFile("/out/entry.js");
+      expect(out).toContain("__toESM(");
+      expect(out).not.toContain("import.defer(");
+    },
+    run: {
+      file: "/out/entry.js",
+      stdout: "value: 7",
+    },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3223,6 +3223,49 @@ describe("bundler", () => {
       api.expectFile("/out.js").toContain("var arguments = 1;");
     },
   });
+  // Dynamic `import.defer()` (TC39 deferred module evaluation). When the
+  // target module is inlined into the bundle, the defer phase is dropped —
+  // same documented limitation as static `import defer` — and it behaves
+  // like a regular dynamic import.
+  itBundled("edgecase/DynamicImportDeferBundled", {
+    files: {
+      "/entry.js": /* js */ `
+        const ns = await import.defer("./dep.js");
+        console.log("after import");
+        console.log("value:", ns.value);
+      `,
+      "/dep.js": /* js */ `
+        console.log("dep evaluated");
+        export const value = 42;
+      `,
+    },
+    target: "bun",
+    run: {
+      stdout: "dep evaluated\nafter import\nvalue: 42",
+    },
+  });
+  // When the target stays external, the defer phase must be preserved in the
+  // emitted code so the runtime can still defer evaluation.
+  itBundled("edgecase/DynamicImportDeferExternal", {
+    files: {
+      "/entry.js": /* js */ `
+        export async function load() {
+          const ns = await import.defer("x-external");
+          return ns.value;
+        }
+        export function loadComputed(name) {
+          return import.defer(name);
+        }
+      `,
+    },
+    external: ["x-external"],
+    target: "bun",
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toContain('import.defer("x-external")');
+      expect(out).toContain("import.defer(name)");
+    },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/js/bun/resolve/import-defer.test.ts
+++ b/test/js/bun/resolve/import-defer.test.ts
@@ -665,8 +665,8 @@ describe.concurrent("dynamic import.defer()", () => {
       const { exitCode, stderr } = await run({
         "main.js": `const x = import.defer; console.log(x);`,
       });
-      expect(exitCode).not.toBe(0);
       expect(stderr.toLowerCase()).toContain("error");
+      expect(exitCode).not.toBe(0);
     });
 
     test("'defer' with an escape sequence is not the phase keyword", async () => {
@@ -674,8 +674,8 @@ describe.concurrent("dynamic import.defer()", () => {
         "main.js": `import.def\\u0065r("./dep.js");`,
         "dep.js": `export const x = 1;`,
       });
-      expect(exitCode).not.toBe(0);
       expect(stderr.toLowerCase()).toContain("error");
+      expect(exitCode).not.toBe(0);
     });
 
     test("other identifiers after 'import.' are still rejected", async () => {
@@ -683,8 +683,8 @@ describe.concurrent("dynamic import.defer()", () => {
         "main.js": `import.source("./dep.js");`,
         "dep.js": `export const x = 1;`,
       });
-      expect(exitCode).not.toBe(0);
       expect(stderr.toLowerCase()).toContain("error");
+      expect(exitCode).not.toBe(0);
     });
   });
 });

--- a/test/js/bun/resolve/import-defer.test.ts
+++ b/test/js/bun/resolve/import-defer.test.ts
@@ -401,12 +401,7 @@ describe.concurrent("dynamic import.defer()", () => {
       `,
     });
     expect(stderr).toBe("");
-    expect(stdout.split("\n").filter(Boolean)).toEqual([
-      "before access",
-      "dep evaluated",
-      "value: 42",
-      "add: 3",
-    ]);
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["before access", "dep evaluated", "value: 42", "add: 3"]);
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/bun/resolve/import-defer.test.ts
+++ b/test/js/bun/resolve/import-defer.test.ts
@@ -382,3 +382,314 @@ describe.concurrent("import defer", () => {
     });
   });
 });
+
+// TC39 proposal-defer-import-eval (Stage 3) — dynamic `import.defer(...)`
+// https://tc39.es/proposal-defer-import-eval/#sec-import-call-runtime-semantics-evaluation
+describe.concurrent("dynamic import.defer()", () => {
+  test("defers module evaluation until a property is accessed", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "main.js": `
+        const ns = await import.defer("./dep.js");
+        console.log("before access");
+        console.log("value:", ns.value);
+        console.log("add:", ns.add(1, 2));
+      `,
+      "dep.js": `
+        console.log("dep evaluated");
+        export const value = 42;
+        export function add(a, b) { return a + b; }
+      `,
+    });
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual([
+      "before access",
+      "dep evaluated",
+      "value: 42",
+      "add: 3",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("module is never evaluated if the namespace is never accessed", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "main.js": `
+        await import.defer("./dep.js");
+        console.log("done");
+      `,
+      "dep.js": `
+        console.log("dep evaluated");
+        export const value = 1;
+      `,
+    });
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["done"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("resolves to a 'Deferred Module' namespace", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "main.js": `
+        const ns = await import.defer("./dep.js");
+        console.log(ns[Symbol.toStringTag]);
+        console.log("---");
+        console.log(ns.value);
+      `,
+      "dep.js": `
+        console.log("dep evaluated");
+        export const value = 7;
+      `,
+    });
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["Deferred Module", "---", "dep evaluated", "7"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("returns the same namespace object as a static 'import defer'", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "main.js": `
+        import defer * as stat from "./dep.js";
+        const dyn = await import.defer("./dep.js");
+        console.log("same:", dyn === stat);
+        console.log("value:", dyn.value);
+      `,
+      "dep.js": `
+        console.log("dep evaluated");
+        export const value = 3;
+      `,
+    });
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["same: true", "dep evaluated", "value: 3"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("evaluation error surfaces at property access, not at import time", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "main.js": `
+        const ns = await import.defer("./throws.js");
+        console.log("imported ok");
+        for (let i = 0; i < 2; i++) {
+          try {
+            void ns.value;
+            console.log("unreachable");
+          } catch (e) {
+            console.log("caught:", e.message);
+          }
+        }
+      `,
+      "throws.js": `
+        throw new Error("boom");
+        export const value = 1;
+      `,
+    });
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["imported ok", "caught: boom", "caught: boom"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("rejects when the module cannot be resolved", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "main.js": `
+        import.defer("./does-not-exist.js").then(
+          () => console.log("unreachable"),
+          () => console.log("rejected"),
+        );
+      `,
+    });
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["rejected"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("evaluates async transitive dependencies eagerly, defers the rest", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "main.js": `
+        const ns = await import.defer("./dep.js");
+        console.log("main after import");
+        console.log("value:", ns.value);
+      `,
+      "dep.js": `
+        import { ready } from "./tla.js";
+        console.log("dep evaluated");
+        export const value = ready;
+      `,
+      "tla.js": `
+        console.log("tla start");
+        await Promise.resolve();
+        console.log("tla done");
+        export const ready = "ok";
+      `,
+    });
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual([
+      "tla start",
+      "tla done",
+      "main after import",
+      "dep evaluated",
+      "value: ok",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("a deferred module that itself uses top-level await is evaluated during the import", async () => {
+    // GatherAsynchronousTransitiveDependencies includes the root module when
+    // it has top-level await, so it can never be left for (impossible)
+    // synchronous evaluation later.
+    const { stdout, stderr, exitCode } = await run({
+      "main.js": `
+        const ns = await import.defer("./tla.js");
+        console.log("main after import");
+        console.log("value:", ns.ready);
+      `,
+      "tla.js": `
+        console.log("tla start");
+        await Promise.resolve();
+        console.log("tla done");
+        export const ready = "ok";
+      `,
+    });
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["tla start", "tla done", "main after import", "value: ok"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("works with a runtime-computed specifier", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "main.js": `
+        const parts = ["./dep", ".js"];
+        const ns = await import.defer(parts.join(""));
+        console.log("before access");
+        console.log("value:", ns.value);
+      `,
+      "dep.js": `
+        console.log("dep evaluated");
+        export const value = 42;
+      `,
+    });
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["before access", "dep evaluated", "value: 42"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("works from a CommonJS module", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      {
+        "main.cjs": `
+          module.exports.loaded = true;
+          (async () => {
+            const ns = await import.defer("./dep.js");
+            console.log("before access");
+            console.log("value:", ns.value);
+          })();
+        `,
+        "dep.js": `
+          console.log("dep evaluated");
+          export const value = 42;
+        `,
+      },
+      "main.cjs",
+    );
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["before access", "dep evaluated", "value: 42"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("importing a CommonJS module evaluates it at import time (host-defined)", async () => {
+    // CommonJS modules are executed by the host while building their ESM
+    // wrapper record, so there is nothing left to defer — the namespace is
+    // usable but the module body has already run by the time the promise
+    // resolves. Deferral only applies to ES module evaluation.
+    const { stdout, stderr, exitCode } = await run({
+      "main.js": `
+        const ns = await import.defer("./dep.cjs");
+        console.log("after import");
+        console.log("value:", ns.default.value);
+      `,
+      "dep.cjs": `
+        console.log("cjs evaluated");
+        module.exports = { value: 7 };
+      `,
+    });
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["cjs evaluated", "after import", "value: 7"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("import.defer() with import attributes", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "main.js": `
+        const ns = await import.defer("./data.json", { with: { type: "json" } });
+        console.log("loaded");
+        console.log(ns.default.hello);
+      `,
+      "data.json": JSON.stringify({ hello: "world" }),
+    });
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["loaded", "world"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("works in .ts files", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      {
+        "main.ts": `
+          const ns = await import.defer("./dep.ts");
+          console.log("before access");
+          console.log(ns.value);
+        `,
+        "dep.ts": `
+          console.log("dep evaluated");
+          export const value: number = 9;
+        `,
+      },
+      "main.ts",
+    );
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["before access", "dep evaluated", "9"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("Bun.Transpiler preserves import.defer() in output", () => {
+    const out = new Bun.Transpiler({ loader: "js" }).transformSync(`const p = import.defer("./x");\n`);
+    expect(out).toContain(`import.defer("./x")`);
+  });
+
+  test("Bun.Transpiler preserves import.defer() with a non-literal specifier", () => {
+    const out = new Bun.Transpiler({ loader: "js" }).transformSync(
+      `export function load(name) { return import.defer(name); }\n`,
+    );
+    expect(out).toContain("import.defer(name)");
+  });
+
+  test("Bun.Transpiler.scanImports reports import.defer() as a dynamic import", () => {
+    const scanned = new Bun.Transpiler({ loader: "js" }).scanImports(`import.defer("./x");`);
+    expect(scanned).toEqual([{ kind: "dynamic-import", path: "./x" }]);
+  });
+
+  describe("syntax errors", () => {
+    test("'import.defer' without a call is a syntax error", async () => {
+      const { exitCode, stderr } = await run({
+        "main.js": `const x = import.defer; console.log(x);`,
+      });
+      expect(exitCode).not.toBe(0);
+      expect(stderr.toLowerCase()).toContain("error");
+    });
+
+    test("'defer' with an escape sequence is not the phase keyword", async () => {
+      const { exitCode, stderr } = await run({
+        "main.js": `import.def\\u0065r("./dep.js");`,
+        "dep.js": `export const x = 1;`,
+      });
+      expect(exitCode).not.toBe(0);
+      expect(stderr.toLowerCase()).toContain("error");
+    });
+
+    test("other identifiers after 'import.' are still rejected", async () => {
+      const { exitCode, stderr } = await run({
+        "main.js": `import.source("./dep.js");`,
+        "dep.js": `export const x = 1;`,
+      });
+      expect(exitCode).not.toBe(0);
+      expect(stderr.toLowerCase()).toContain("error");
+    });
+  });
+});


### PR DESCRIPTION
Implements the dynamic form of the Stage 3 [Deferred Module Evaluation](https://github.com/tc39/proposal-defer-import-eval) proposal, completing the feature started in #30975 (static `import defer`):

```js
const ns = await import.defer("./mod.js");
// mod.js is fetched and linked, but NOT evaluated.

console.log("before");
console.log(ns.value);   // <-- mod.js evaluates here, synchronously
```

Bun's pinned WebKit already ships the engine side (upstream [WebKit/WebKit#64907](https://github.com/WebKit/WebKit/pull/64907)): the JSC parser accepts `import.defer(...)` under `useImportDefer` (which Bun enables), and the `moduleLoaderImportModule` host hook carries a trailing `bool deferred`. Bun previously rejected the syntax in its own transpiler and ignored that flag.

### What changed

**Parser / AST** — `src/js_parser/parse/parse_import_export.rs`, `src/ast/e.rs`, `src/js_parser/{parser,p,visit/visit_expr,repl_transforms}.rs`
- `import.` now accepts the contextual keyword `defer` followed by the usual `( specifier [, options] )` arguments. The check compares the raw token, so `import.def\u0065r(...)` stays a syntax error; other identifiers after `import.` still error.
- Unlike `import.meta`, `import.defer()` does not mark the file as ESM (it is valid in CommonJS, like `import()`).
- New `E::Import.phase_defer`, threaded through import transposition (`TransposeState.phase_defer`), and `ImportRecordFlags::PHASE_DEFER` is now also set on `ImportKind::Dynamic` records.
- REPL static-import lowering now maps `import defer * as X from 'mod'` → `await import.defer('mod')`.

**Printer** — `src/js_printer/lib.rs`
- External records and non-literal specifiers print `import.defer(...)`, so JSC's own parser sees the phase during bytecode generation.
- When the bundler inlines the target module, the call degrades to a regular dynamic import (`Promise.resolve().then(...)`) — the same documented limitation as static `import defer`. The bake dev server's `hmr.dynamicImport` path is likewise unchanged.

**Runtime** — `src/jsc/bindings/ZigGlobalObject.cpp`, `src/runtime/bake/BakeGlobalObject.cpp`, `src/jsc/bindings/NodeVM.{h,cpp}`
- `moduleLoaderImportModule` forwards the `deferred` flag into `JSC::importModule(...)` instead of dropping it, for the main global, Bake global, plugin virtual modules, and the node:vm `USE_MAIN_CONTEXT_DEFAULT_LOADER` path. JSC then links the graph, eagerly evaluates only the async transitive dependencies, and resolves the promise with the deferred namespace (`ensureDeferredNamespaceEvaluation` handles later property access).
- node:vm `importModuleDynamically` callbacks have no phase parameter (same as Node), so deferred imports resolved through a user callback behave like regular dynamic imports.

### Semantics covered by tests (`test/js/bun/resolve/import-defer.test.ts`, 19 new cases)

- Evaluation deferred until first non-symbol property access; never evaluated if never accessed
- `ns[Symbol.toStringTag] === "Deferred Module"`
- `import.defer()` and static `import defer` of the same module yield the same namespace object
- Throwing module: the import promise resolves; the error is thrown at property access, every time
- Resolution failures reject the promise
- Async transitive dependencies are evaluated during the import; a deferred module that itself uses TLA is evaluated during the import
- Runtime-computed specifiers, import attributes, `.ts` files, CommonJS callers, CommonJS targets (host-defined eager evaluation)
- `Bun.Transpiler` round-trips `import.defer(...)` and `scanImports` reports it as `dynamic-import`
- Syntax errors: `import.defer` without a call, escaped `def\u0065r`, `import.source(...)`

Bundler coverage (`test/bundler/bundler_edgecase.test.ts`): inlined targets degrade gracefully and run; `--external` targets keep `import.defer(...)` in the output.

### Verification

- `bun bd test test/js/bun/resolve/import-defer.test.ts` — 39 pass (20 existing static + 19 new)
- `bun bd test test/bundler/bundler_edgecase.test.ts -t DynamicImportDefer` — 2 pass
- New tests fail on `USE_SYSTEM_BUN=1` (1.4.0 rejects the syntax with `Expected "meta" but found "defer"`)
- No regressions: `transpiler.test.js`, `vm.test.ts`, `repl-transform.test.ts`, `concurrent-dynamic-import`, `dynamic-import-tla-cycle`, `import-meta`, `import-query` all pass

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 17 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->