### PR TITLE
fix(bun_core): remove ArrayLike set_len_and_slice

### DIFF
--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -113,9 +113,10 @@ pub trait ArrayLike {
 
     fn ensure_unused_capacity(&mut self, additional: usize);
     fn append_assume_capacity(&mut self, elem: Self::Elem);
-    /// Set `len` to `n` (caller has already reserved) and return the now-live
-    /// slice for bulk memcpy. Mirrors the Zig `map.items.len = n; slice = map.items`.
-    fn set_len_and_slice(&mut self, n: usize) -> &mut [Self::Elem];
+    /// Append all elements from `items`.
+    fn extend_from_slice(&mut self, items: &[Self::Elem])
+    where
+        Self::Elem: Copy;
 }
 
 pub type Of<A> = <A as ArrayLike>::Elem;
@@ -156,17 +157,11 @@ where
 
     // TODO(port): the Zig MultiArrayList arm (`@hasField(Array, "bytes")`)
     // appended element-by-element because SoA storage cannot be memcpy'd as one
-    // block. The trait impl for `MultiArrayList<T>` must override
-    // `set_len_and_slice` to panic and instead route through
-    // `append_assume_capacity`. For now we take the memcpy path and rely on the
-    // impl to do the right thing.
+    // block. A future trait impl for `MultiArrayList<T>` can implement
+    // `extend_from_slice` with repeated `append_assume_capacity` calls.
 
     map.ensure_unused_capacity(default.len());
-
-    let slice = map.set_len_and_slice(default.len());
-
-    // Zig: `@memcpy(out[0..in.len], in)` over `sliceAsBytes`
-    slice.copy_from_slice(default);
+    map.extend_from_slice(default);
 
     map
 }
@@ -282,13 +277,11 @@ impl<T> ArrayLike for Vec<T> {
         // PERF(port): was appendAssumeCapacity
         self.push(elem);
     }
-    fn set_len_and_slice(&mut self, n: usize) -> &mut [T] {
-        debug_assert!(self.capacity() >= n);
-        // SAFETY: capacity reserved above; caller immediately memcpy-fills [0..n].
-        // Matches Zig `map.items.len = default.len; slice = map.items;` which
-        // also exposes uninitialized memory until the subsequent @memcpy.
-        unsafe { self.set_len(n) };
-        self.as_mut_slice()
+    fn extend_from_slice(&mut self, items: &[T])
+    where
+        T: Copy,
+    {
+        Vec::extend_from_slice(self, items);
     }
 }
 


### PR DESCRIPTION
## Summary

This fixes audit finding EXP-078 by removing `ArrayLike::set_len_and_slice`, the helper that exposed a typed mutable slice over newly-live `Vec` capacity.

The old `Vec<T>` implementation called `set_len(n)` and returned `&mut [T]` before the new elements were initialized. Safe Rust could call it on `Vec<bool>` and read from the returned slice, exposing uninitialized memory through a safe public trait method.

## Changes

- Remove `ArrayLike::set_len_and_slice`
- Add a safe `ArrayLike::extend_from_slice` method instead
- Change `from_slice` to initialize through `extend_from_slice`, not by raising length first
- Implement the Vec path with `Vec::extend_from_slice`, so initialization happens through Vec's safe API

This is slightly stronger than just marking the old helper unsafe: no typed slice over spare capacity escapes at all.

## Audit context

The audit witness `experiments/EXP-078-bun-core-crate/` imports the real `bun_core::util::ArrayLike`, calls the actual old `Vec<bool>` implementation, and Miri reports an uninitialized read through the returned slice.

I checked for duplicate work before opening this PR. No existing PR targets EXP-078, `ArrayLike`, or `set_len_and_slice`. The open `bun_core` util split PR (#31202) preserves the same old helper shape, so this fix is still incremental rather than duplicative.

## Verification

- `bun run fmt:rust`
- `cargo check -p bun_core`
- `cargo check --workspace`
- `bun bd test test/cli/run/run_command.test.ts -t "should error with missing script"`
- External old-API smoke at `/tmp/exp-078-old-api-check`: calling `values.set_len_and_slice(1)` now fails with `E0599`

Note: I also tried `cargo test -p bun_core`, but the standalone test binary does not link in this checkout due pre-existing external Bun dispatch and simdutf symbols.