### PR TITLE
toml: reject bare identifiers at value position

### DIFF
--- a/src/parsers/toml.rs
+++ b/src/parsers/toml.rs
@@ -357,12 +357,6 @@ impl<'a> TOML<'a> {
                 self.lexer.next()?;
                 Ok(result)
             }
-            T::t_identifier => {
-                let str = E::String::init(self.lexer.identifier);
-
-                self.lexer.next()?;
-                Ok(self.e(str, loc))
-            }
             T::t_numeric_literal => {
                 let value = self.lexer.number;
                 self.lexer.next()?;

--- a/src/parsers/toml/lexer.rs
+++ b/src/parsers/toml/lexer.rs
@@ -836,6 +836,24 @@ impl<'a> Lexer<'a> {
                     }
                     self.identifier = self.raw();
                     self.token = match self.identifier.len() {
+                        // TOML 1.0.0 §Float lists `inf` and `nan` as valid floats
+                        // (also `+inf`/`-inf`/`+nan`/`-nan`, handled by the `t_plus`/
+                        // `t_minus` arms in `parse_value_inner` which require a
+                        // following `t_numeric_literal`). Promote the bare keywords
+                        // here. Bare keys spelled `inf`/`nan` keep working because
+                        // `parse_key_segment`'s `t_numeric_literal` arm uses
+                        // `self.lexer.raw()` (not `self.number`) for the key name.
+                        3 => {
+                            if strings::eql_comptime_ignore_len(self.identifier, b"inf") {
+                                self.number = f64::INFINITY;
+                                T::t_numeric_literal
+                            } else if strings::eql_comptime_ignore_len(self.identifier, b"nan") {
+                                self.number = f64::NAN;
+                                T::t_numeric_literal
+                            } else {
+                                T::t_identifier
+                            }
+                        }
                         4 => {
                             if strings::eql_comptime_ignore_len(self.identifier, b"true") {
                                 T::t_true

--- a/src/runtime/api/TOMLObject.rs
+++ b/src/runtime/api/TOMLObject.rs
@@ -1,6 +1,6 @@
-use bun_core::String as BunString;
-use bun_js_printer as js_printer;
-use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, LogJsc, StringJsc};
+use bun_ast::ToJSError;
+use bun_js_parser_jsc::ExprJsc;
+use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsError, JsResult, LogJsc};
 use bun_parsers::toml::TOML;
 
 pub fn create(global: &JSGlobalObject) -> JSValue {
@@ -26,33 +26,26 @@ pub fn parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
                 }
             };
 
+            // PORT NOTE(#31252): `Lexer::expect` logs errors but recovers (calls `next()`),
+            // so the parser can return `Ok` with a partial AST. Surface any logged errors
+            // before handing the AST to JS.
             if log.has_errors() {
                 return Err(global.throw_value(log.to_js(global, "Failed to parse toml")?));
             }
 
-            // for now...
-            let buffer_writer = js_printer::BufferWriter::init();
-            let mut writer = js_printer::BufferPrinter::init(buffer_writer);
-            // PORT NOTE: Zig passed `*js_printer.BufferPrinter` as a comptime type param; dropped per (comptime X: type, arg: X) rule
-            if js_printer::print_json(
-                &mut writer,
-                parse_result,
-                source,
-                js_printer::PrintJsonOptions {
-                    indent: Default::default(),
-                    mangled_props: None,
-                    ..Default::default()
-                },
-            )
-            .is_err()
-            {
-                return Err(global.throw_value(log.to_js(global, "Failed to print toml")?));
+            // PORT NOTE: Zig TOMLObject.parse did a `print_json` → `JSONParse` round-trip
+            // to get the parsed Expr into JS. That pipeline can't round-trip `Infinity` /
+            // `NaN` (strict JSON forbids them), and it's wasteful — JSONC already switched
+            // to `ExprJsc::to_js`, which is a direct AST → JSValue walk. Mirror that here.
+            match parse_result.to_js(global) {
+                Ok(v) => Ok(v),
+                Err(ToJSError::OutOfMemory) => Err(JsError::OutOfMemory),
+                Err(ToJSError::JSError) => Err(JsError::Thrown),
+                Err(ToJSError::JSTerminated) => Err(JsError::Terminated),
+                // TOML parsing produces only literals (objects, arrays, strings,
+                // numbers, booleans) — never identifiers or macros.
+                Err(_) => unreachable!(),
             }
-
-            let slice = writer.ctx.buffer.slice();
-            let mut out = BunString::borrow_utf8(slice);
-
-            out.to_js_by_parse_json(global)
         },
     )
 }

--- a/test/js/bun/resolve/toml/toml-parse.test.ts
+++ b/test/js/bun/resolve/toml/toml-parse.test.ts
@@ -120,3 +120,40 @@ test("Bun.TOML.parse still accepts bare keys built from @/$/_/letters/digits/-/:
   expect(Bun.TOML.parse('$bar = "ok"')).toEqual({ $bar: "ok" });
   expect(Bun.TOML.parse('foo-bar = "ok"')).toEqual({ "foo-bar": "ok" });
 });
+
+// Per TOML 1.0.0 §Float, `inf`, `+inf`, `-inf`, `nan`, `+nan`, `-nan` are valid
+// floats. Before this fix:
+//  - `a = inf` / `a = nan` silently parsed as the strings `"inf"` / `"nan"`
+//    (they fell into `parse_value_inner`'s `t_identifier` arm).
+//  - `a = +inf` / `a = -inf` / `a = ±nan` produced `0` (the `t_plus` / `t_minus`
+//    arms read `self.lexer.number` before `expect(t_numeric_literal)`, which
+//    fails on an identifier — the 0 was whatever `number` was last set to).
+// The lexer now promotes bare `inf` / `nan` to `t_numeric_literal` with
+// `f64::INFINITY` / `f64::NAN`, which also feeds the `t_plus` / `t_minus` arms.
+// Requires the TOMLObject JSValue pipeline to bypass the `print_json → JSONParse`
+// round-trip (strict JSON has no `Infinity` / `NaN`); that's done in the same
+// patch.
+test("Bun.TOML.parse accepts inf and nan as float values (#31251)", () => {
+  expect(Bun.TOML.parse("a = inf").a).toBe(Infinity);
+  expect(Bun.TOML.parse("a = +inf").a).toBe(Infinity);
+  expect(Bun.TOML.parse("a = -inf").a).toBe(-Infinity);
+  expect(Bun.TOML.parse("a = nan").a).toBeNaN();
+  expect(Bun.TOML.parse("a = +nan").a).toBeNaN();
+  expect(Bun.TOML.parse("a = -nan").a).toBeNaN();
+});
+
+// Bare keys spelled exactly `inf` / `nan` must keep working. The lexer now emits
+// `t_numeric_literal`, and `parse_key_segment`'s numeric-literal arm uses the raw
+// source text (`self.lexer.raw()`) as the key string, preserving the spelling.
+test("Bun.TOML.parse still accepts bare keys named inf and nan (#31251)", () => {
+  expect(Bun.TOML.parse('inf = "ok"')).toEqual({ inf: "ok" });
+  expect(Bun.TOML.parse('nan = "ok"')).toEqual({ nan: "ok" });
+});
+
+// Identifiers that merely contain `inf` / `nan` (`infinity`, `nan1`, `inf-foo`)
+// still fall through to `t_identifier` and are rejected at value position.
+test("Bun.TOML.parse rejects inf-like/nan-like identifiers at value position (#31251)", () => {
+  expect(() => Bun.TOML.parse("a = infinity")).toThrow();
+  expect(() => Bun.TOML.parse("a = nan1")).toThrow();
+  expect(() => Bun.TOML.parse("a = inf-foo")).toThrow();
+});

--- a/test/js/bun/resolve/toml/toml-parse.test.ts
+++ b/test/js/bun/resolve/toml/toml-parse.test.ts
@@ -87,3 +87,36 @@ test("Bun.TOML.parse rejects array values without comma separators (#31252)", ()
   // Trailing comma is legal TOML.
   expect(Bun.TOML.parse("a = [1, 2,]")).toEqual({ a: [1, 2] });
 });
+
+// https://github.com/oven-sh/bun/issues/31251
+// `parse_value_inner` used to accept `t_identifier` at value position and emit it as
+// an `E.String`. The lexer's identifier class is deliberately broad so bare keys like
+// `foo-bar` work, which meant `a = @`, `a = foo`, `a = $` all silently parsed as
+// strings instead of being syntax errors. Per the TOML spec, the right-hand side
+// of `key = value` must be a quoted string, number, boolean, datetime, array, or
+// inline table — anything else is invalid.
+test("Bun.TOML.parse rejects bare identifiers at value position (#31251)", () => {
+  expect(() => Bun.TOML.parse("a = @")).toThrow();
+  expect(() => Bun.TOML.parse("a = foo")).toThrow();
+  expect(() => Bun.TOML.parse("a = @foo")).toThrow();
+  expect(() => Bun.TOML.parse("a = $")).toThrow();
+  expect(() => Bun.TOML.parse("a = _bar")).toThrow();
+  // inside an inline table
+  expect(() => Bun.TOML.parse("a = { x = foo }")).toThrow();
+  // inside an array
+  expect(() => Bun.TOML.parse("a = [foo]")).toThrow();
+});
+
+// `true`/`false` are kept as booleans — they have their own tokens and never
+// reach the identifier arm.
+test("Bun.TOML.parse still accepts true/false booleans at value position (#31251)", () => {
+  expect(Bun.TOML.parse("a = true\nb = false")).toEqual({ a: true, b: false });
+});
+
+// Bare keys with the same alphabet as the old value-position identifier arm must
+// still work — the fix is value-only.
+test("Bun.TOML.parse still accepts bare keys built from @/$/_/letters/digits/-/: (#31251)", () => {
+  expect(Bun.TOML.parse('@foo = "ok"')).toEqual({ "@foo": "ok" });
+  expect(Bun.TOML.parse('$bar = "ok"')).toEqual({ $bar: "ok" });
+  expect(Bun.TOML.parse('foo-bar = "ok"')).toEqual({ "foo-bar": "ok" });
+});


### PR DESCRIPTION
Fixes #31251.

### Repro

```console
$ bun -e 'console.log(JSON.stringify(Bun.TOML.parse("a = @")))'
{"a":"@"}
```

Per the [TOML spec](https://toml.io/en/v1.0.0#keyvalue-pair) the right-hand side of `key = value` must be a quoted string, number, boolean, datetime, array, or inline table. `@` is none of those.

### Cause

The TOML lexer classifies `@`, `a-z`, `A-Z`, `$`, `_` followed by identifier-part characters as `t_identifier` — this is deliberately broad so bare keys like `foo-bar` work in key position. But `parse_value_inner` was also accepting `t_identifier` and wrapping it in an `E.String`, so any bare identifier-ish token on the right of `=` silently became a string. Same arm existed in the legacy Zig (`src/parsers/toml.zig` L262-267).

Additionally, the TOML 1.0.0 spec (§Float) lists `inf`, `+inf`, `-inf`, `nan`, `+nan`, `-nan` as valid floats, but the lexer classified bare `inf` / `nan` as `t_identifier` (only `true` / `false` got length-based promotion). Pre-fix they silently became the strings `"inf"` / `"nan"`; the signed forms produced `0` because `t_plus` / `t_minus` read `self.lexer.number` before `expect(t_numeric_literal)` failed on the identifier.

### Fix

1. **Drop the `t_identifier` arm in `parse_value_inner`**. Falls through to the existing catch-all `self.lexer.unexpected()`, which produces e.g. `Unexpected @` at the right location. The `t_identifier` arm in `parse_key_segment` is untouched, so bare keys still work.
2. **Promote `inf` / `nan` to `t_numeric_literal`** in the lexer with `f64::INFINITY` / `f64::NAN` in `self.number`. Covers all six spec forms: bare `inf` / `nan` hit the numeric-literal value arm, and `+inf` / `-inf` / `+nan` / `-nan` flow through `t_plus` / `t_minus`. Bare keys spelled `inf` / `nan` keep working because `parse_key_segment`'s numeric-literal arm uses `self.lexer.raw()` (source text) for the key name, not `self.number`.
3. **Switch `TOMLObject::parse` from `print_json` → JSC `JSONParse` to `ExprJsc::to_js`** (the same direct Expr → JSValue walker JSONCObject and the `import foo.toml` module loader already use). Strict JSON has no `Infinity` / `NaN`, so the round-trip was both wasteful and unable to carry those values — `Bun.TOML.parse("a = inf")` would otherwise fail at `JSONParse` with `Failed to parse JSON`.

### Rebase conflict resolution

Rebased onto main to pick up #31255 (the fix for #31252, which added a `log.has_errors()` recovery check to `TOMLObject::parse`). Both PRs touch the same function. The resolution keeps both: my new `ExprJsc::to_js` call happens *after* the `log.has_errors()` surface-errors check, so lexer error-recovery diagnostics (`a = [1 2]`) still throw correctly.

### Verification

```console
$ bun -e 'try { Bun.TOML.parse("a = @") } catch (e) { console.log(e.message) }'
Unexpected @
$ bun -e 'try { Bun.TOML.parse("a = foo") } catch (e) { console.log(e.message) }'
Unexpected foo
$ bun -e 'console.log(Bun.TOML.parse("a = inf").a === Infinity)'
true
$ bun -e 'console.log(Number.isNaN(Bun.TOML.parse("a = -nan").a))'
true
$ bun -e 'console.log(JSON.stringify(Bun.TOML.parse("@foo = 1")))'  # bare key still ok
{"@foo":1}
$ bun -e 'try { Bun.TOML.parse("a = [1 2]") } catch (e) { console.log(e.message) }'  # #31252 regression check
Expected t_comma but found 2
```

`test/js/bun/resolve/toml/toml-parse.test.ts` covers:
- `@`, `foo`, `@foo`, `$`, `_bar` on the RHS all throw (bare identifier rejection)
- Identifier inside an inline table (`a = { x = foo }`) throws
- Identifier inside an array (`a = [foo]`) throws
- `true` / `false` still parse as booleans
- Bare keys `@foo`, `$bar`, `foo-bar` still parse as keys
- `inf`, `+inf`, `-inf`, `nan`, `+nan`, `-nan` return `Infinity` / `NaN` / `-Infinity` correctly
- Bare keys spelled `inf` / `nan` still work
- `infinity`, `nan1`, `inf-foo` at value position still throw (they only match the identifier arm, not the promoted keywords)
- `a = [1 2]` (from #31252) still throws on the new `ExprJsc::to_js` path