### PR TITLE
toml: surface logged errors on Bun.TOML.parse

### DIFF
--- a/src/runtime/api/TOMLObject.rs
+++ b/src/runtime/api/TOMLObject.rs
@@ -26,6 +26,15 @@ pub fn parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
                 }
             };
 
+            // The TOML lexer's `expect` logs mismatches via `add_range_error`
+            // and falls through to `next()` for error recovery, so the parser
+            // can return `Ok` with a partial AST even after reporting an
+            // error (e.g. a missing comma in `[1 2]`). Surface any such
+            // diagnostics here instead of silently accepting the partial AST.
+            if log.has_errors() {
+                return Err(global.throw_value(log.to_js(global, "Failed to parse toml")?));
+            }
+
             // for now...
             let buffer_writer = js_printer::BufferWriter::init();
             let mut writer = js_printer::BufferPrinter::init(buffer_writer);

--- a/src/runtime/api/TOMLObject.rs
+++ b/src/runtime/api/TOMLObject.rs
@@ -26,11 +26,6 @@ pub fn parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
                 }
             };
 
-            // The TOML lexer's `expect` logs mismatches via `add_range_error`
-            // and falls through to `next()` for error recovery, so the parser
-            // can return `Ok` with a partial AST even after reporting an
-            // error (e.g. a missing comma in `[1 2]`). Surface any such
-            // diagnostics here instead of silently accepting the partial AST.
             if log.has_errors() {
                 return Err(global.throw_value(log.to_js(global, "Failed to parse toml")?));
             }

--- a/test/js/bun/resolve/toml/toml-parse.test.ts
+++ b/test/js/bun/resolve/toml/toml-parse.test.ts
@@ -67,3 +67,23 @@ test("Bun.TOML.parse normalizes literal CRLF to LF in multiline basic strings", 
   const input = 'k = """a\r\nb\\tc"""';
   expect(Bun.TOML.parse(input).k).toBe("a\nb\tc");
 });
+
+// https://github.com/oven-sh/bun/issues/31252
+// `Lexer::expect` in the TOML lexer logs a mismatch via `add_range_error` and
+// then falls through to `next()` for error recovery, so the parser returned
+// `Ok` with a partial AST for inputs like `[1 2]` and `[1 2 3]`. The JS entry
+// point only inspected the `Result`, so the logged diagnostic was discarded
+// and bogus values like `{"a":[1]}` / `{"a":[1,3]}` leaked out. The entry
+// point now also checks `log.has_errors()` on the Ok path.
+test("Bun.TOML.parse rejects array values without comma separators (#31252)", () => {
+  expect(() => Bun.TOML.parse("a = [1 2]")).toThrow();
+  expect(() => Bun.TOML.parse("a = [1 2 3]")).toThrow();
+  expect(() => Bun.TOML.parse("a = [1, 2 3]")).toThrow();
+  expect(() => Bun.TOML.parse('a = ["x" "y"]')).toThrow();
+
+  // Valid comma-separated arrays still parse.
+  expect(Bun.TOML.parse("a = [1, 2]")).toEqual({ a: [1, 2] });
+  expect(Bun.TOML.parse("a = [1, 2, 3]")).toEqual({ a: [1, 2, 3] });
+  // Trailing comma is legal TOML.
+  expect(Bun.TOML.parse("a = [1, 2,]")).toEqual({ a: [1, 2] });
+});


### PR DESCRIPTION
Fixes #31252.

## Repro

```console
$ bun -e 'console.log(JSON.stringify(Bun.TOML.parse("a = [1 2]")))'
{"a":[1]}
```

Per the [TOML spec](https://toml.io/en/v1.0.0#array) array values must be comma-separated. `[1 2]` (and `[1 2 3]`, `[1, 2 3]`, `[\"x\" \"y\"]`) should be rejected as syntax errors.

## Cause

The TOML lexer's `expect` (`src/parsers/toml/lexer.rs`) does:

```rust
pub fn expect(&mut self, token: T) -> Result<(), Error> {
    if self.token != token {
        self.expected(token)?;   // logs "Expected X but found Y" on self.log
    }
    self.next()                  // still advances past the wrong token
}
```

`expected` → `expected_string` → `add_range_error` **logs** the error to `self.log` but returns `Ok(())`, so `expect(T::t_comma)` on a non-comma records a diagnostic and then happily eats the token. This is the shared "log + recover" pattern across js/json/toml lexers and is not unique to TOML.

Flow for `[1 2]`:
1. `[` consumed, `1` pushed.
2. Current token `2` (not `]`) with array length 1 → `parse_maybe_trailing_comma(t_close_bracket)`.
3. `expect(t_comma)` logs the error, then `next()` advances past `2` → current token is `]`.
4. `parse_maybe_trailing_comma` sees the closer → returns `Ok(false)`, loop breaks.
5. `expect(t_close_bracket)` succeeds. `TOML::parse` returns `Ok` with `[1]`.

`TOMLObject::parse` (`src/runtime/api/TOMLObject.rs`) then only inspected the `Result`, so the logged diagnostic was discarded and the partial AST leaked out as `{"a":[1]}`.

## Fix

Scoped to the JS-visible entry point: check `log.has_errors()` on the `Ok` path in `TOMLObject::parse` and throw if any diagnostics were recorded. The lexer's "log + recover" behaviour is preserved for other TOML consumers (bundler loader, `bunfig.toml` parser) that may want to continue on soft errors.

## Verification

```console
$ bun -e 'try { Bun.TOML.parse("a = [1 2]") } catch (e) { console.log(e.message) }'
Expected t_comma but found 2
$ bun -e 'console.log(JSON.stringify(Bun.TOML.parse("a = [1, 2]")))'
{"a":[1,2]}
$ bun -e 'console.log(JSON.stringify(Bun.TOML.parse("a = [1, 2,]")))'
{"a":[1,2]}
```

`test/js/bun/resolve/toml/toml-parse.test.ts` covers:
- `[1 2]`, `[1 2 3]`, `[1, 2 3]`, `[\"x\" \"y\"]` all throw
- `[1, 2]`, `[1, 2, 3]`, `[1, 2,]` (trailing comma) still parse

```
$ bun bd test test/js/bun/resolve/toml/toml-parse.test.ts
 8 pass, 0 fail
```

Gate: the new `#31252` test fails on baked bun (`expect(() => Bun.TOML.parse("a = [1 2]")).toThrow()` receives `{a: [1]}` instead of a throw) and passes with this change.