### PR TITLE
toml: restrict bare keys and values to the TOML 1.0.0 spec

### DIFF
--- a/src/parsers/toml.rs
+++ b/src/parsers/toml.rs
@@ -340,10 +340,11 @@ impl<'a> TOML<'a> {
                 Ok(result)
             }
             T::t_identifier => {
-                let str = E::String::init(self.lexer.identifier);
-
-                self.lexer.next()?;
-                Ok(self.e(str, loc))
+                // Per TOML 1.0.0, values must be quoted strings, booleans,
+                // numbers, dates/times, or inf/nan. Bare identifiers are not
+                // values — `true`/`false` have their own token kinds above.
+                self.lexer.expected_string(b"value")?;
+                Err(bun_core::err!("SyntaxError"))
             }
             T::t_numeric_literal => {
                 let value = self.lexer.number;

--- a/src/parsers/toml.rs
+++ b/src/parsers/toml.rs
@@ -342,7 +342,9 @@ impl<'a> TOML<'a> {
             T::t_identifier => {
                 // Per TOML 1.0.0, values must be quoted strings, booleans,
                 // numbers, dates/times, or inf/nan. Bare identifiers are not
-                // values — `true`/`false` have their own token kinds above.
+                // values — `true`/`false`/`inf`/`nan` have their own token
+                // kinds above (the lexer rewrites `inf` / `nan` into
+                // `t_numeric_literal` with `f64::INFINITY` / `f64::NAN`).
                 self.lexer.expected_string(b"value")?;
                 Err(bun_core::err!("SyntaxError"))
             }

--- a/src/parsers/toml/lexer.rs
+++ b/src/parsers/toml/lexer.rs
@@ -1314,7 +1314,6 @@ pub(crate) fn is_identifier_part(code_point: CodePoint) -> bool {
     // The `(0..=127)` bound is required for the byte cast above to be sound.
 }
 
-
 #[inline]
 fn float64(num: CodePoint) -> f64 {
     num as f64

--- a/src/parsers/toml/lexer.rs
+++ b/src/parsers/toml/lexer.rs
@@ -825,10 +825,8 @@ impl<'a> Lexer<'a> {
                     self.parse_numeric_literal_or_dot()?;
                 }
 
-                c if c == '@' as CodePoint
-                    || ('a' as CodePoint..='z' as CodePoint).contains(&c)
+                c if ('a' as CodePoint..='z' as CodePoint).contains(&c)
                     || ('A' as CodePoint..='Z' as CodePoint).contains(&c)
-                    || c == '$' as CodePoint
                     || c == '_' as CodePoint =>
                 {
                     self.step();
@@ -1184,17 +1182,31 @@ impl<'a> Lexer<'a> {
     pub fn unexpected(&mut self) -> Result<(), Error> {
         let found: &[u8] = 'finder: {
             self.start = self.start.min(self.end);
+            let contents = &self.source.contents;
 
-            if self.start == self.source.contents.len() {
+            if self.start == contents.len() {
                 break 'finder b"end of file";
             } else {
-                break 'finder self.raw();
+                // `self.end` still points at the first byte of the current
+                // codepoint (set by `next_codepoint` in the preceding `step()`);
+                // the character itself hasn't been consumed, so advance `end`
+                // past the codepoint so the reported slice includes the
+                // offending character instead of an empty range.
+                let cp_width = strings::wtf8_byte_sequence_length_with_invalid(
+                    contents[self.start],
+                ) as usize;
+                self.end = (self.start + cp_width).min(contents.len());
+                break 'finder &contents[self.start..self.end];
             }
         };
 
         // Compute the range before borrowing `found` from source.
         let range = self.range();
-        self.add_range_error(range, format_args!("Unexpected {}", bstr::BStr::new(found)))
+        self.add_range_error(range, format_args!("Unexpected {}", bstr::BStr::new(found)))?;
+        // `add_range_error` only logs and returns `Ok(())`; abort the lex so
+        // the top-level parser loop doesn't observe a synthetic `t_end_of_file`
+        // after an invalid character and silently treat the source as empty.
+        Err(Error::SyntaxError)
     }
 
     pub fn expected_string(&mut self, text: &[u8]) -> Result<(), Error> {
@@ -1270,17 +1282,20 @@ impl<'a> Lexer<'a> {
 }
 
 pub(crate) fn is_identifier_part(code_point: CodePoint) -> bool {
+    // TOML 1.0.0 bare keys: [A-Za-z0-9_-]+. Everything else (including `@`,
+    // `$`, `:`) must be a quoted key. `true`/`false` keywords share this
+    // tokenizer but only match on exact spelling, so no other characters
+    // need to be admitted here.
     matches!(code_point as u32 as u8 as char,
         '0'..='9'
         | 'a'..='z'
         | 'A'..='Z'
-        | '$'
         | '_'
         | '-'
-        | ':'
     ) && (0..=127).contains(&code_point)
     // The `(0..=127)` bound is required for the byte cast above to be sound.
 }
+
 
 #[inline]
 fn float64(num: CodePoint) -> f64 {

--- a/src/parsers/toml/lexer.rs
+++ b/src/parsers/toml/lexer.rs
@@ -834,10 +834,24 @@ impl<'a> Lexer<'a> {
                         self.step();
                     }
                     self.identifier = self.raw();
-                    self.token = KEYWORDS
-                        .get(self.identifier)
-                        .copied()
-                        .unwrap_or(T::t_identifier);
+                    // TOML 1.0.0 float values: `inf` and `nan` become numeric
+                    // literals (they need `self.number` set, which the static
+                    // KEYWORDS map can't express). The signed forms `+inf` /
+                    // `-inf` / `+nan` / `-nan` are handled by the existing
+                    // `t_plus` / `t_minus` arms in the parser, which consume a
+                    // following `t_numeric_literal`.
+                    self.token = if self.identifier == b"inf" {
+                        self.number = f64::INFINITY;
+                        T::t_numeric_literal
+                    } else if self.identifier == b"nan" {
+                        self.number = f64::NAN;
+                        T::t_numeric_literal
+                    } else {
+                        KEYWORDS
+                            .get(self.identifier)
+                            .copied()
+                            .unwrap_or(T::t_identifier)
+                    };
                 }
 
                 _ => self.unexpected()?,

--- a/src/parsers/toml/lexer.rs
+++ b/src/parsers/toml/lexer.rs
@@ -1192,9 +1192,8 @@ impl<'a> Lexer<'a> {
                 // the character itself hasn't been consumed, so advance `end`
                 // past the codepoint so the reported slice includes the
                 // offending character instead of an empty range.
-                let cp_width = strings::wtf8_byte_sequence_length_with_invalid(
-                    contents[self.start],
-                ) as usize;
+                let cp_width =
+                    strings::wtf8_byte_sequence_length_with_invalid(contents[self.start]) as usize;
                 self.end = (self.start + cp_width).min(contents.len());
                 break 'finder &contents[self.start..self.end];
             }

--- a/src/parsers/toml/lexer.rs
+++ b/src/parsers/toml/lexer.rs
@@ -1200,15 +1200,20 @@ impl<'a> Lexer<'a> {
 
             if self.start == contents.len() {
                 break 'finder b"end of file";
-            } else {
-                // `self.end` still points at the first byte of the current
-                // codepoint (set by `next_codepoint` in the preceding `step()`);
-                // the character itself hasn't been consumed, so advance `end`
-                // past the codepoint so the reported slice includes the
-                // offending character instead of an empty range.
+            } else if self.start == self.end {
+                // Called from `next()`'s `_` arm: the bad character hasn't been
+                // consumed yet (`self.start = self.end` at the top of `next()`
+                // and no `step()` ran). Advance `end` past the codepoint so the
+                // reported slice includes the offending character instead of
+                // an empty range.
                 let cp_width =
                     strings::wtf8_byte_sequence_length_with_invalid(contents[self.start]) as usize;
                 self.end = (self.start + cp_width).min(contents.len());
+                break 'finder &contents[self.start..self.end];
+            } else {
+                // Called from the parser with a full token already lexed
+                // (e.g. `parse_value_inner`'s `_` arm); `start..end` already
+                // spans the token's bytes — don't truncate it.
                 break 'finder &contents[self.start..self.end];
             }
         };

--- a/src/runtime/api/TOMLObject.rs
+++ b/src/runtime/api/TOMLObject.rs
@@ -1,6 +1,6 @@
 use bun_ast::{E, Expr, expr::Data as ExprData};
 use bun_collections::VecExt;
-use bun_core::{String as BunString, ZigString};
+use bun_core::{StackCheck, String as BunString, ZigString};
 use bun_jsc::{self as jsc, CallFrame, JSGlobalObject, JSValue, JsResult, LogJsc, StringJsc};
 use bun_parsers::toml::TOML;
 
@@ -38,7 +38,8 @@ pub fn parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
             // `print_json` + `JSON.parse` — JSON rejects `Infinity`/`NaN` /
             // overflowed float literals, so the printed form of a TOML float
             // like `1e999` or `inf` couldn't re-parse.
-            expr_to_js(parse_result, global)
+            let stack_check = StackCheck::init();
+            expr_to_js(parse_result, global, &stack_check)
         },
     )
 }
@@ -53,7 +54,19 @@ fn estring_to_js(str: &E::EString, global: &JSGlobalObject) -> JsResult<JSValue>
     }
 }
 
-fn expr_to_js(expr: Expr, global: &JSGlobalObject) -> JsResult<JSValue> {
+fn expr_to_js(
+    expr: Expr,
+    global: &JSGlobalObject,
+    stack_check: &StackCheck,
+) -> JsResult<JSValue> {
+    // Match `YAMLObject::ParserCtx::to_js` — the TOML parser bounds admitted
+    // depth via its own `StackCheck`, but this walker starts from the same
+    // stack position after all parser frames unwind, so a separately guarded
+    // recursion here is the defense-in-depth the YAML walker documents.
+    if !stack_check.is_safe_to_recurse() {
+        return Err(global.throw_stack_overflow());
+    }
+
     match expr.data {
         ExprData::ENull(_) => Ok(JSValue::NULL),
         ExprData::EBoolean(boolean) => Ok(JSValue::from(boolean.value)),
@@ -62,25 +75,32 @@ fn expr_to_js(expr: Expr, global: &JSGlobalObject) -> JsResult<JSValue> {
         ExprData::EArray(arr) => {
             let items = arr.slice();
             let js_arr = JSValue::create_empty_array(global, items.len())?;
-            // `gcProtect` the under-construction array: the recursive
-            // `expr_to_js` and `put_index` calls can allocate and trigger GC,
-            // and `js_arr` is only reachable through this Rust local (which
-            // the JSC collector does not scan). RAII guard unprotects on exit.
+            // `gcProtect` the under-construction array: belt-and-suspenders on
+            // the conservative stack scan, matching `expr_jsc::array_to_js`.
+            // The recursive `expr_to_js` and `put_index` calls can allocate
+            // and trigger GC; the RAII guard unprotects on scope exit.
             let _guard = js_arr.protected();
             for (i, item) in items.iter().enumerate() {
-                js_arr.put_index(global, i as u32, expr_to_js(*item, global)?)?;
+                js_arr.put_index(global, i as u32, expr_to_js(*item, global, stack_check)?)?;
             }
             Ok(js_arr)
         }
         ExprData::EObject(obj) => {
             let js_obj = JSValue::create_empty_object(global, obj.properties.len_u32() as usize);
-            // Same GC-root concern as the array branch above.
+            // Same GC-root rationale as the array branch above.
             let _guard = js_obj.protected();
             for prop in obj.properties.slice() {
+                // Compute the key and its BunString first so that the only
+                // live JSValue between `value` creation and the put is `value`
+                // itself — matches `expr_jsc::object_to_js`'s ordering.
                 let key_expr = prop.key.expect("infallible: prop has key");
-                let value = expr_to_js(prop.value.expect("infallible: prop has value"), global)?;
-                let key_js = expr_to_js(key_expr, global)?;
+                let key_js = expr_to_js(key_expr, global, stack_check)?;
                 let key_str = bun_core::OwnedString::new(key_js.to_bun_string(global)?);
+                let value = expr_to_js(
+                    prop.value.expect("infallible: prop has value"),
+                    global,
+                    stack_check,
+                )?;
                 js_obj.put_may_be_index(global, &key_str, value)?;
             }
             Ok(js_obj)

--- a/src/runtime/api/TOMLObject.rs
+++ b/src/runtime/api/TOMLObject.rs
@@ -38,8 +38,7 @@ pub fn parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
             // `print_json` + `JSON.parse` — JSON rejects `Infinity`/`NaN` /
             // overflowed float literals, so the printed form of a TOML float
             // like `1e999` or `inf` couldn't re-parse.
-            let stack_check = StackCheck::init();
-            expr_to_js(parse_result, global, &stack_check)
+            expr_to_js(parse_result, global, StackCheck::init())
         },
     )
 }
@@ -54,7 +53,7 @@ fn estring_to_js(str: &E::EString, global: &JSGlobalObject) -> JsResult<JSValue>
     }
 }
 
-fn expr_to_js(expr: Expr, global: &JSGlobalObject, stack_check: &StackCheck) -> JsResult<JSValue> {
+fn expr_to_js(expr: Expr, global: &JSGlobalObject, stack_check: StackCheck) -> JsResult<JSValue> {
     // Match `YAMLObject::ParserCtx::to_js` — the TOML parser bounds admitted
     // depth via its own `StackCheck`, but this walker starts from the same
     // stack position after all parser frames unwind, so a separately guarded

--- a/src/runtime/api/TOMLObject.rs
+++ b/src/runtime/api/TOMLObject.rs
@@ -60,12 +60,22 @@ fn expr_to_js(expr: Expr, global: &JSGlobalObject) -> JsResult<JSValue> {
         ExprData::ENumber(number) => Ok(JSValue::js_number(number.value)),
         ExprData::EString(str) => estring_to_js(str.get(), global),
         ExprData::EArray(arr) => {
-            JSValue::create_array_from_iter(global, arr.slice().iter(), |item| {
-                expr_to_js(*item, global)
-            })
+            let items = arr.slice();
+            let js_arr = JSValue::create_empty_array(global, items.len())?;
+            // `gcProtect` the under-construction array: the recursive
+            // `expr_to_js` and `put_index` calls can allocate and trigger GC,
+            // and `js_arr` is only reachable through this Rust local (which
+            // the JSC collector does not scan). RAII guard unprotects on exit.
+            let _guard = js_arr.protected();
+            for (i, item) in items.iter().enumerate() {
+                js_arr.put_index(global, i as u32, expr_to_js(*item, global)?)?;
+            }
+            Ok(js_arr)
         }
         ExprData::EObject(obj) => {
             let js_obj = JSValue::create_empty_object(global, obj.properties.len_u32() as usize);
+            // Same GC-root concern as the array branch above.
+            let _guard = js_obj.protected();
             for prop in obj.properties.slice() {
                 let key_expr = prop.key.expect("infallible: prop has key");
                 let value = expr_to_js(prop.value.expect("infallible: prop has value"), global)?;

--- a/src/runtime/api/TOMLObject.rs
+++ b/src/runtime/api/TOMLObject.rs
@@ -54,11 +54,7 @@ fn estring_to_js(str: &E::EString, global: &JSGlobalObject) -> JsResult<JSValue>
     }
 }
 
-fn expr_to_js(
-    expr: Expr,
-    global: &JSGlobalObject,
-    stack_check: &StackCheck,
-) -> JsResult<JSValue> {
+fn expr_to_js(expr: Expr, global: &JSGlobalObject, stack_check: &StackCheck) -> JsResult<JSValue> {
     // Match `YAMLObject::ParserCtx::to_js` — the TOML parser bounds admitted
     // depth via its own `StackCheck`, but this walker starts from the same
     // stack position after all parser frames unwind, so a separately guarded

--- a/src/runtime/api/TOMLObject.rs
+++ b/src/runtime/api/TOMLObject.rs
@@ -1,6 +1,7 @@
-use bun_core::String as BunString;
-use bun_js_printer as js_printer;
-use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, LogJsc, StringJsc};
+use bun_ast::{E, Expr, expr::Data as ExprData};
+use bun_collections::VecExt;
+use bun_core::{String as BunString, ZigString};
+use bun_jsc::{self as jsc, CallFrame, JSGlobalObject, JSValue, JsResult, LogJsc, StringJsc};
 use bun_parsers::toml::TOML;
 
 pub(crate) fn create(global: &JSGlobalObject) -> JSValue {
@@ -26,32 +27,56 @@ pub fn parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
                 }
             };
 
+            // `TOML::parse` may have returned `Ok` with a partial AST after
+            // logging recoverable errors (e.g. `[1 2]` via `expect` — #31252).
+            // Surface those before converting to JS.
             if log.has_errors() {
                 return Err(global.throw_value(log.to_js(global, "Failed to parse toml")?));
             }
 
-            // for now...
-            let buffer_writer = js_printer::BufferWriter::init();
-            let mut writer = js_printer::BufferPrinter::init(buffer_writer);
-            if js_printer::print_json(
-                &mut writer,
-                parse_result,
-                source,
-                js_printer::PrintJsonOptions {
-                    indent: Default::default(),
-                    mangled_props: None,
-                    ..Default::default()
-                },
-            )
-            .is_err()
-            {
-                return Err(global.throw_value(log.to_js(global, "Failed to print toml")?));
-            }
-
-            let slice = writer.ctx.buffer.slice();
-            let mut out = BunString::borrow_utf8(slice);
-
-            out.to_js_by_parse_json(global)
+            // Walk the AST directly instead of round-tripping through
+            // `print_json` + `JSON.parse` — JSON rejects `Infinity`/`NaN` /
+            // overflowed float literals, so the printed form of a TOML float
+            // like `1e999` or `inf` couldn't re-parse.
+            expr_to_js(parse_result, global)
         },
     )
 }
+
+fn estring_to_js(str: &E::EString, global: &JSGlobalObject) -> JsResult<JSValue> {
+    if str.is_utf16 {
+        let zig = ZigString::init_utf16(str.slice16());
+        let bun_s = BunString::init(zig);
+        bun_s.to_js(global)
+    } else {
+        jsc::bun_string_jsc::create_utf8_for_js(global, str.slice8())
+    }
+}
+
+fn expr_to_js(expr: Expr, global: &JSGlobalObject) -> JsResult<JSValue> {
+    match expr.data {
+        ExprData::ENull(_) => Ok(JSValue::NULL),
+        ExprData::EBoolean(boolean) => Ok(JSValue::from(boolean.value)),
+        ExprData::ENumber(number) => Ok(JSValue::js_number(number.value)),
+        ExprData::EString(str) => estring_to_js(str.get(), global),
+        ExprData::EArray(arr) => {
+            JSValue::create_array_from_iter(global, arr.slice().iter(), |item| {
+                expr_to_js(*item, global)
+            })
+        }
+        ExprData::EObject(obj) => {
+            let js_obj = JSValue::create_empty_object(global, obj.properties.len_u32() as usize);
+            for prop in obj.properties.slice() {
+                let key_expr = prop.key.expect("infallible: prop has key");
+                let value = expr_to_js(prop.value.expect("infallible: prop has value"), global)?;
+                let key_js = expr_to_js(key_expr, global)?;
+                let key_str = bun_core::OwnedString::new(key_js.to_bun_string(global)?);
+                js_obj.put_may_be_index(global, &key_str, value)?;
+            }
+            Ok(js_obj)
+        }
+        _ => Ok(JSValue::UNDEFINED),
+    }
+}
+
+// ported from: src/runtime/api/TOMLObject.zig

--- a/test/js/bun/resolve/toml/toml-parse.test.ts
+++ b/test/js/bun/resolve/toml/toml-parse.test.ts
@@ -125,6 +125,19 @@ test("Bun.TOML.parse still accepts true/false as bare values (#31250)", () => {
   expect(Bun.TOML.parse("a = true\nb = false")).toEqual({ a: true, b: false });
 });
 
+test("Bun.TOML.parse still accepts inf/nan as bare values (#31250)", () => {
+  // TOML 1.0.0 float values: `inf`, `+inf`, `-inf`, `nan`, `+nan`, `-nan`.
+  // These share the identifier tokenizer but the lexer emits them as numeric
+  // literals, so the parser's `t_identifier` rejection doesn't swallow them.
+  const out = Bun.TOML.parse("a = inf\nb = -inf\nc = +inf\nd = nan\ne = -nan\nf = +nan");
+  expect(out.a).toBe(Infinity);
+  expect(out.b).toBe(-Infinity);
+  expect(out.c).toBe(Infinity);
+  expect(out.d).toBeNaN();
+  expect(out.e).toBeNaN();
+  expect(out.f).toBeNaN();
+});
+
 test("Bun.TOML.parse still accepts quoted @-keys (#31250)", () => {
   // Fixture-style keys like `"@mybigcompany"` must still work — only bare
   // (unquoted) `@` is being rejected.

--- a/test/js/bun/resolve/toml/toml-parse.test.ts
+++ b/test/js/bun/resolve/toml/toml-parse.test.ts
@@ -87,3 +87,48 @@ test("Bun.TOML.parse rejects array values without comma separators (#31252)", ()
   // Trailing comma is legal TOML.
   expect(Bun.TOML.parse("a = [1, 2,]")).toEqual({ a: [1, 2] });
 });
+
+// https://github.com/oven-sh/bun/issues/31250
+// The lexer's identifier-start set included `@` and `$`, so both were accepted as
+// the start of a bare key AND as a bare (unquoted) value — `a = @` returned
+// `{ a: "@" }`. Per TOML 1.0.0, bare keys are `[A-Za-z0-9_-]+`, and unquoted
+// values are restricted to `true`/`false`, numbers, dates, and `inf`/`nan`. The
+// parser also accepted any `t_identifier` as a string value, so even `a = foo`
+// parsed as `{ a: "foo" }` on an unpatched build.
+test("Bun.TOML.parse rejects bare @ as a value (#31250)", () => {
+  expect(() => Bun.TOML.parse("a = @")).toThrow();
+  expect(() => Bun.TOML.parse("a = @foo")).toThrow();
+});
+
+test("Bun.TOML.parse rejects bare $ as a value (#31250)", () => {
+  expect(() => Bun.TOML.parse("a = $bar")).toThrow();
+});
+
+test("Bun.TOML.parse rejects @ as the start of a bare key (#31250)", () => {
+  expect(() => Bun.TOML.parse("@a = 1")).toThrow();
+});
+
+test("Bun.TOML.parse rejects $ as the start of a bare key (#31250)", () => {
+  expect(() => Bun.TOML.parse("$a = 1")).toThrow();
+});
+
+test("Bun.TOML.parse rejects an unquoted identifier as a value (#31250)", () => {
+  // Bare identifiers other than `true`/`false`/`inf`/`nan` are not valid values
+  // per the TOML spec; they must be quoted.
+  expect(() => Bun.TOML.parse("a = foo")).toThrow();
+  expect(() => Bun.TOML.parse("a = hello")).toThrow();
+});
+
+test("Bun.TOML.parse still accepts true/false as bare values (#31250)", () => {
+  // Guard against the identifier-rejection going too far and eating the
+  // `true`/`false` keywords, which share the lexer's identifier tokenizer.
+  expect(Bun.TOML.parse("a = true\nb = false")).toEqual({ a: true, b: false });
+});
+
+test("Bun.TOML.parse still accepts quoted @-keys (#31250)", () => {
+  // Fixture-style keys like `"@mybigcompany"` must still work — only bare
+  // (unquoted) `@` is being rejected.
+  expect(Bun.TOML.parse(`"@mybigcompany" = { url = "foo" }`)).toEqual({
+    "@mybigcompany": { url: "foo" },
+  });
+});


### PR DESCRIPTION
Fixes #31250.

## Repro

```console
$ bun -e 'console.log(JSON.stringify(Bun.TOML.parse("a = @")))'
{"a":"@"}
$ bun -e 'console.log(JSON.stringify(Bun.TOML.parse("a = @foo")))'
{"a":"@foo"}
$ bun -e 'console.log(JSON.stringify(Bun.TOML.parse("@a = 1")))'
{"@a":1}
$ bun -e 'console.log(JSON.stringify(Bun.TOML.parse("a = $bar")))'
{"a":"$bar"}
$ bun -e 'console.log(JSON.stringify(Bun.TOML.parse("a = foo")))'
{"a":"foo"}
```

Per the [TOML 1.0.0 spec](https://toml.io/en/v1.0.0):
- Bare keys are `[A-Za-z0-9_-]+` only — `@` and `$` must be quoted.
- Unquoted values are limited to `true`/`false`, numbers, dates/times, and `inf`/`nan`. Bare identifiers are not values.

All the above should be syntax errors.

## Cause

Two bugs, one in the lexer and one in the parser.

**Lexer** (`src/parsers/toml/lexer.rs`): the identifier-start set included `@` and `$`, so they became the leading byte of a `t_identifier` token and were accepted as bare keys. `is_identifier_part` also included `$` and `:`, carried over from the pre-port Zig.

**Parser** (`src/parsers/toml.rs`): `parse_value_inner` had a `T::t_identifier =>` arm that wrapped the raw identifier bytes in an `E::String`. Any identifier-shaped token on the right of `=` silently became a string value. `true`/`false` have their own token kinds (`t_true`/`t_false`), so they come through separate arms and aren't affected.

There was also a downstream bug making invalid input look like an empty document: `Lexer::unexpected()` called `add_range_error` (which only logs to `self.log` and returns `Ok(())`) and then the caller hit the `return Ok(())` at the bottom of `next()`, leaving `self.token = T::t_end_of_file`. The parser loop saw EOF and returned an empty object instead of surfacing the error. Visible for any invalid starting char:

```console
$ bun -e 'try { console.log(Bun.TOML.parse("~")); } catch (e) { console.log("ERR:", e.message) }'
{}
```

## Fix

- Remove `@` and `$` from the identifier-start set in `Lexer::next` and `$`/`:` from `is_identifier_part`. `is_latin1_identifier` tightened to match.
- `Lexer::unexpected()`: advance `self.end` past the offending codepoint (`wtf8_byte_sequence_length_with_invalid` on the lead byte) so the reported slice shows the bad character, then return `Err(SyntaxError)` to abort the lex.
- Drop the `T::t_identifier` arm in `parse_value_inner`. It now produces `Expected value but found <ident>` via `expected_string(b"value")`.

## Verification

```console
$ bun -e 'try { Bun.TOML.parse("a = @") } catch (e) { console.log(e.message) }'
Unexpected @
$ bun -e 'try { Bun.TOML.parse("@a = 1") } catch (e) { console.log(e.message) }'
Unexpected @
$ bun -e 'try { Bun.TOML.parse("a = foo") } catch (e) { console.log(e.message) }'
Expected value but found foo
$ bun -e 'try { Bun.TOML.parse("~") } catch (e) { console.log(e.message) }'
Unexpected ~

# Regression guards — valid TOML still parses:
$ bun -e 'console.log(JSON.stringify(Bun.TOML.parse("a = true\nb = false")))'
{"a":true,"b":false}
$ bun -e 'console.log(JSON.stringify(Bun.TOML.parse(`"@mybigcompany" = { url = "foo" }`)))'
{"@mybigcompany":{"url":"foo"}}
```

`test/js/bun/resolve/toml/toml-parse.test.ts` covers:
- `a = @`, `a = @foo`, `a = $bar`, `a = foo`, `a = hello` all throw
- `@a = 1`, `$a = 1` (bare key) both throw
- `a = true\nb = false` still parses as booleans
- `"@mybigcompany" = { url = "foo" }` still parses (quoted keys unchanged)

Gate: the five new tests fail against stashed `src/` and pass against the patched tree. The existing 9 TOML tests all continue to pass.

## Related

There's an overlapping PR #31253 (for the sibling issue #31251, which is the same first example as here). #31253 takes a narrower approach — it only drops the `t_identifier` arm in `parse_value_inner` and leaves the lexer identifier-start set alone, so `@a = 1` still parses as `{ "@a": 1 }` under that PR. This PR also addresses the bare-key case that #31250 explicitly calls out, plus the silent-empty-object behavior for invalid starting characters.
