### PR TITLE
Don't panic on `export default abstract` followed by a class statement

### DIFF
--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1072,63 +1072,60 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 let name = p.lexer.identifier;
                 let expr = p.parse_expr(Level::Comma)?;
 
-                // Handle the default export of an abstract class in TypeScript
+                // Handle the default export of an abstract class in TypeScript. This
+                // only applies when "abstract" was parsed as a plain identifier
+                // expression; anything else (e.g. "export default abstract = 1") is a
+                // regular expression statement that falls through below.
                 if Self::IS_TYPESCRIPT_ENABLED
                     && is_identifier
                     && (p.lexer.token == T::TClass || opts.ts_decorators.is_some())
                     && name == b"abstract"
+                    && matches!(expr.data, js_ast::ExprData::EIdentifier(_))
                 {
-                    match &expr.data {
-                        js_ast::ExprData::EIdentifier(_) => {
-                            let mut stmt_opts = ParseStatementOptions {
-                                ts_decorators: opts.ts_decorators.take(),
-                                is_name_optional: true,
-                                ..Default::default()
-                            };
-                            let stmt: Stmt = p.parse_class_stmt(loc, &mut stmt_opts)?;
+                    let mut stmt_opts = ParseStatementOptions {
+                        ts_decorators: opts.ts_decorators.take(),
+                        is_name_optional: true,
+                        ..Default::default()
+                    };
+                    let stmt: Stmt = p.parse_class_stmt(loc, &mut stmt_opts)?;
 
-                            // Use the statement name if present, since it's a better name
-                            let default_name: LocRef = 'default_name_getter: {
-                                match &stmt.data {
-                                    // This was just a type annotation
-                                    js_ast::StmtData::STypeScript(_) => {
-                                        return Ok(stmt);
-                                    }
+                    // Use the statement name if present, since it's a better name
+                    let default_name: LocRef = 'default_name_getter: {
+                        match &stmt.data {
+                            // This was just a type annotation
+                            js_ast::StmtData::STypeScript(_) => {
+                                return Ok(stmt);
+                            }
 
-                                    js_ast::StmtData::SFunction(func_container) => {
-                                        if let Some(_name) = func_container.func.name {
-                                            break 'default_name_getter LocRef {
-                                                loc: default_loc,
-                                                ref_: _name.ref_,
-                                            };
-                                        }
-                                    }
-                                    js_ast::StmtData::SClass(class) => {
-                                        if let Some(_name) = class.class.class_name {
-                                            break 'default_name_getter LocRef {
-                                                loc: default_loc,
-                                                ref_: _name.ref_,
-                                            };
-                                        }
-                                    }
-                                    _ => {}
+                            js_ast::StmtData::SFunction(func_container) => {
+                                if let Some(_name) = func_container.func.name {
+                                    break 'default_name_getter LocRef {
+                                        loc: default_loc,
+                                        ref_: _name.ref_,
+                                    };
                                 }
+                            }
+                            js_ast::StmtData::SClass(class) => {
+                                if let Some(_name) = class.class.class_name {
+                                    break 'default_name_getter LocRef {
+                                        loc: default_loc,
+                                        ref_: _name.ref_,
+                                    };
+                                }
+                            }
+                            _ => {}
+                        }
 
-                                p.create_default_name(default_loc).expect("unreachable")
-                            };
-                            p.has_export_default = true;
-                            return Ok(p.s(
-                                S::ExportDefault {
-                                    default_name,
-                                    value: js_ast::StmtOrExpr::Stmt(stmt),
-                                },
-                                loc,
-                            ));
-                        }
-                        _ => {
-                            p.panic("internal error: unexpected", format_args!(""));
-                        }
-                    }
+                        p.create_default_name(default_loc).expect("unreachable")
+                    };
+                    p.has_export_default = true;
+                    return Ok(p.s(
+                        S::ExportDefault {
+                            default_name,
+                            value: js_ast::StmtOrExpr::Stmt(stmt),
+                        },
+                        loc,
+                    ));
                 }
 
                 p.lexer.expect_or_insert_semicolon()?;

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1072,10 +1072,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 let name = p.lexer.identifier;
                 let expr = p.parse_expr(Level::Comma)?;
 
-                // Handle the default export of an abstract class in TypeScript. This
-                // only applies when "abstract" was parsed as a plain identifier
-                // expression; anything else (e.g. "export default abstract = 1") is a
-                // regular expression statement that falls through below.
+                // Handle the default export of an abstract class in TypeScript
                 if Self::IS_TYPESCRIPT_ENABLED
                     && is_identifier
                     && (p.lexer.token == T::TClass || opts.ts_decorators.is_some())

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1125,6 +1125,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     ));
                 }
 
+                // "@decorator export default abstract = 1"
+                if opts.ts_decorators.is_some() {
+                    p.lexer.expected(T::TClass)?;
+                }
+
                 p.lexer.expect_or_insert_semicolon()?;
 
                 // Use the expression name if present, since it's a better name

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -179,13 +179,10 @@ describe("Bun.Transpiler", () => {
     it("does not crash when export default abstract is an expression followed by a class", () => {
       const exp = ts.expectPrinted_;
 
-      // "abstract" is a plain identifier expression here, not the start of an
-      // abstract class declaration, even when a class statement follows.
       exp("export default abstract = 1\nclass Foo {}", "export default abstract = 1;\n\nclass Foo {\n}");
       exp("export default abstract ?? 1\nclass Foo {}", "export default abstract ?? 1;\n\nclass Foo {\n}");
       exp("export default abstract = 1", "export default abstract = 1;\n");
 
-      // A real abstract class default export is still stripped down to a class.
       exp("export default abstract class Foo { abstract bar(): void }", "export default class Foo {\n}");
       exp("export default abstract class {}", "export default class {\n}");
     });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -176,6 +176,20 @@ describe("Bun.Transpiler", () => {
       exp("declare class Foo {}", "");
     });
 
+    it("does not crash when export default abstract is an expression followed by a class", () => {
+      const exp = ts.expectPrinted_;
+
+      // "abstract" is a plain identifier expression here, not the start of an
+      // abstract class declaration, even when a class statement follows.
+      exp("export default abstract = 1\nclass Foo {}", "export default abstract = 1;\n\nclass Foo {\n}");
+      exp("export default abstract ?? 1\nclass Foo {}", "export default abstract ?? 1;\n\nclass Foo {\n}");
+      exp("export default abstract = 1", "export default abstract = 1;\n");
+
+      // A real abstract class default export is still stripped down to a class.
+      exp("export default abstract class Foo { abstract bar(): void }", "export default class Foo {\n}");
+      exp("export default abstract class {}", "export default class {\n}");
+    });
+
     it("scope tracking stays balanced when a contextual keyword starts a larger expression", () => {
       const exp = ts.expectPrinted_;
       const err = ts.expectParseError;

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -178,6 +178,7 @@ describe("Bun.Transpiler", () => {
 
     it("does not crash when export default abstract is an expression followed by a class", () => {
       const exp = ts.expectPrinted_;
+      const err = ts.expectParseError;
 
       exp("export default abstract = 1\nclass Foo {}", "export default abstract = 1;\n\nclass Foo {\n}");
       exp("export default abstract ?? 1\nclass Foo {}", "export default abstract ?? 1;\n\nclass Foo {\n}");
@@ -185,6 +186,9 @@ describe("Bun.Transpiler", () => {
 
       exp("export default abstract class Foo { abstract bar(): void }", "export default class Foo {\n}");
       exp("export default abstract class {}", "export default class {\n}");
+
+      err("@dec export default abstract = 1", 'Expected "class" but found end of file');
+      err("@dec(() => 0) export default abstract = 1\nclass Foo {}", 'Expected "class" but found "class"');
     });
 
     it("scope tracking stays balanced when a contextual keyword starts a larger expression", () => {


### PR DESCRIPTION
### What does this PR do?

Fixes a transpiler panic (`panic: internal error: unexpected`) when a TypeScript file uses `abstract` as a plain identifier in an `export default` expression and a class statement (or leading decorators) makes the parser consider the abstract-class lookahead:

```ts
export default abstract = 1
class Foo {}
```

```
panic: internal error: unexpected
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
```

Other shapes hitting the same path (`export default abstract ?? 1`, `export default abstract.foo`, `@dec export default abstract = 1`, …) crashed the same way.

### Cause

In `parse_stmt.rs`, the `export default abstract` handling enters the abstract-class special case whenever the statement starts with the identifier `abstract` and the next token is `class` (or decorators are pending), then matches on the parsed expression: the bare-identifier arm parses the class, and **every other expression hits an unconditional `p.panic(...)`**. esbuild, which this logic comes from, instead makes the "expression is exactly the identifier `abstract`" check part of the condition, so anything else simply falls through to the regular `export default <expr>` statement.

### Fix

- Hoist the `EIdentifier` check into the `if` condition and drop the panic arm. `export default abstract = 1` now parses as a normal export-default assignment expression (matching esbuild and tsc), and the real `export default abstract class …` path is unchanged.
- When decorators are pending and the `abstract`-led statement turns out not to be an abstract class (`@dec export default abstract = 1`), report `Expected "class"` like the surrounding decorator guards instead of falling through. This avoids silently dropping the decorator and keeps the scopes recorded while parsing decorator arguments from desyncing the visit pass.

### How did you verify your code works?

- New cases in `test/bundler/transpiler/transpiler.test.js` (`does not crash when export default abstract is an expression followed by a class`). Against the unfixed build the test crashes with `panic: internal error: unexpected`; with the fix it passes.
- `bun bd test test/bundler/transpiler/transpiler.test.js` — 127 pass, 0 fail
- `bun bd test test/bundler/esbuild/ts.test.ts` — 57 pass, 0 fail
- `bun bd test test/bundler/bundler_decorator_metadata.test.ts` — 2 pass, 0 fail
