### PR TITLE
css: fix @page selector parsing and printing so minified rules roundtrip

### DIFF
--- a/src/css/rules/page.rs
+++ b/src/css/rules/page.rs
@@ -57,8 +57,6 @@ impl PageSelector {
         loop {
             // Whitespace is not allowed between pseudo classes
             let state = input.state();
-            // Reaching the end of the prelude here (e.g. `@page:left{`) just ends the
-            // selector; it must not fail the parse.
             let is_colon = matches!(input.next_including_whitespace(), Ok(css::Token::Colon));
             if is_colon {
                 let vv = PagePseudoClass::parse(input)?;
@@ -132,8 +130,7 @@ impl PageRule {
         dest.write_str("@page")?;
         if self.selectors.len() >= 1 {
             let firstsel = &self.selectors[0];
-            // Space is only required if the first selector has a name
-            // (`@pagefoo` would tokenize as a single at-keyword).
+            // Space is only required if the first selector has a name.
             if firstsel.name.is_some() {
                 dest.write_char(b' ')?;
             }

--- a/src/css/rules/page.rs
+++ b/src/css/rules/page.rs
@@ -21,7 +21,7 @@ pub struct PageSelector {
 impl PageSelector {
     pub fn to_css(&self, dest: &mut Printer) -> core::result::Result<(), PrintErr> {
         if let Some(name) = self.name {
-            dest.write_str(name)?;
+            dest.serialize_identifier(name)?;
         }
 
         for pseudo in &self.pseudo_classes {

--- a/src/css/rules/page.rs
+++ b/src/css/rules/page.rs
@@ -57,7 +57,9 @@ impl PageSelector {
         loop {
             // Whitespace is not allowed between pseudo classes
             let state = input.state();
-            let is_colon = matches!(*input.next_including_whitespace()?, css::Token::Colon);
+            // Reaching the end of the prelude here (e.g. `@page:left{`) just ends the
+            // selector; it must not fail the parse.
+            let is_colon = matches!(input.next_including_whitespace(), Ok(css::Token::Colon));
             if is_colon {
                 let vv = PagePseudoClass::parse(input)?;
                 pseudo_classes.push(vv);
@@ -130,8 +132,9 @@ impl PageRule {
         dest.write_str("@page")?;
         if self.selectors.len() >= 1 {
             let firstsel = &self.selectors[0];
-            // Space is only required if the first selector has a name.
-            if !dest.minify && firstsel.name.is_some() {
+            // Space is only required if the first selector has a name
+            // (`@pagefoo` would tokenize as a single at-keyword).
+            if firstsel.name.is_some() {
                 dest.write_char(b' ')?;
             }
             dest.write_comma_separated(&self.selectors, |d, sel| sel.to_css(d))?;

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7454,8 +7454,6 @@ describe("css tests", () => {
     minify_test("@page :first, :blank { margin: 1em }", "@page:first,:blank{margin:1em}");
     minify_test("@page toc, index { margin: 1em }", "@page toc,index{margin:1em}");
 
-    // Minified @page rules have no whitespace between the selector and the block
-    // or after the selector-list commas; that output must reparse.
     minify_test("@page:left{margin:1em}", "@page:left{margin:1em}");
     minify_test("@page:first{margin:1em}", "@page:first{margin:1em}");
     minify_test("@page:blank:first{margin:1em}", "@page:blank:first{margin:1em}");

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7445,6 +7445,25 @@ describe("css tests", () => {
     );
   });
 
+  describe("page", () => {
+    minify_test("@page { margin: 1em }", "@page{margin:1em}");
+    minify_test("@page :left { margin: 1em }", "@page:left{margin:1em}");
+    minify_test("@page :blank:first { margin: 1em }", "@page:blank:first{margin:1em}");
+    minify_test("@page LandscapeTable { margin: 1em }", "@page LandscapeTable{margin:1em}");
+    minify_test("@page CompanyLetterHead:first { margin: 1em }", "@page CompanyLetterHead:first{margin:1em}");
+    minify_test("@page :first, :blank { margin: 1em }", "@page:first,:blank{margin:1em}");
+    minify_test("@page toc, index { margin: 1em }", "@page toc,index{margin:1em}");
+
+    // Minified @page rules have no whitespace between the selector and the block
+    // or after the selector-list commas; that output must reparse.
+    minify_test("@page:left{margin:1em}", "@page:left{margin:1em}");
+    minify_test("@page:first{margin:1em}", "@page:first{margin:1em}");
+    minify_test("@page:blank:first{margin:1em}", "@page:blank:first{margin:1em}");
+    minify_test("@page:first,:blank{margin:1em}", "@page:first,:blank{margin:1em}");
+    minify_test("@page toc,index{margin:1em}", "@page toc,index{margin:1em}");
+    minify_test("@page CompanyLetterHead:first{margin:1em}", "@page CompanyLetterHead:first{margin:1em}");
+  });
+
   describe("edge cases", () => {
     describe("invalid gradient", () => {
       cssTest(

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7453,6 +7453,8 @@ describe("css tests", () => {
     minify_test("@page CompanyLetterHead:first { margin: 1em }", "@page CompanyLetterHead:first{margin:1em}");
     minify_test("@page :first, :blank { margin: 1em }", "@page:first,:blank{margin:1em}");
     minify_test("@page toc, index { margin: 1em }", "@page toc,index{margin:1em}");
+    minify_test("@page \\31 st { margin: 1em }", "@page \\31 st{margin:1em}");
+    minify_test("@page a\\ b { margin: 1em }", "@page a\\ b{margin:1em}");
 
     minify_test("@page:left{margin:1em}", "@page:left{margin:1em}");
     minify_test("@page:first{margin:1em}", "@page:first{margin:1em}");
@@ -7461,6 +7463,7 @@ describe("css tests", () => {
     minify_test("@page:first,:blank{margin:1em}", "@page:first,:blank{margin:1em}");
     minify_test("@page toc,index{margin:1em}", "@page toc,index{margin:1em}");
     minify_test("@page CompanyLetterHead:first{margin:1em}", "@page CompanyLetterHead:first{margin:1em}");
+    minify_test("@page \\31 st{margin:1em}", "@page \\31 st{margin:1em}");
   });
 
   describe("edge cases", () => {

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7459,6 +7459,7 @@ describe("css tests", () => {
     minify_test("@page:left{margin:1em}", "@page:left{margin:1em}");
     minify_test("@page:first{margin:1em}", "@page:first{margin:1em}");
     minify_test("@page:blank:first{margin:1em}", "@page:blank:first{margin:1em}");
+    minify_test("@page LandscapeTable{margin:1em}", "@page LandscapeTable{margin:1em}");
     minify_test("@page:first,:blank{margin:1em}", "@page:first,:blank{margin:1em}");
     minify_test("@page toc,index{margin:1em}", "@page toc,index{margin:1em}");
     minify_test("@page CompanyLetterHead:first{margin:1em}", "@page CompanyLetterHead:first{margin:1em}");


### PR DESCRIPTION
### What does this PR do?

Fixes a CSS fuzzer invariant violation (`invariant:css:minified CSS does not reparse`): `@page` rules with pseudo-class selectors minify to output Bun's own CSS parser cannot read back.

**Repro:**

```bash
BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1 bun -e 'const c = require("bun:internal-for-testing").cssInternals;
const min = c.minifyTest("@page :left { margin: 1em }", ""); // "@page:left{margin:1em}"
c.minifyTest(min, "");'
# error: parsing failed: Unexpected token: :
```

The same failure hits `@page:first,:blank{…}`, `@page foo:left{…}`, and even the pretty-printed form `@page toc, index { … }` (the first selector is immediately followed by the `,` delimiter). Any such stylesheet fails `bun build` / `import "./x.css"` outright, and minified `@page` output can't be re-consumed by Bun.

A second bug in the same rule surfaced while testing: `@page foo { margin: 1em }` minifies to `@pagefoo{margin:1em}`, which tokenizes as a single unknown at-keyword — the page rule is silently lost on a second pass.

### Root cause

Both are divergences from lightningcss in `src/css/rules/page.rs`:

1. **`PageSelector::parse`** peeks for the next pseudo-class with `input.next_including_whitespace()?`. When the selector is immediately followed by the prelude delimiter (`{` or `,`) — exactly the shape the minifier emits — that call returns an end-of-input error and the `?` aborts the whole selector parse. The `@page` prelude handler swallows the error via `try_parse` and resets, leaving the unconsumed `:left` in the prelude, so `expect_exhausted` then fails with `Unexpected token: :`. lightningcss treats the error as "no more pseudo classes" (reset + break); only a space before `{` avoided the bug, which is why the pretty form parsed but its minified output didn't.

2. **`PageRule::to_css`** wrote the space after `@page` only when `!dest.minify`. The space is syntactically required whenever the first selector has a name, since `@page` + `foo` with no whitespace tokenizes as the at-keyword `@pagefoo`. lightningcss writes it unconditionally.

### The fix

`src/css/rules/page.rs`, matching lightningcss behavior:

- Treat an error from the pseudo-class peek as the end of the selector (reset + break) instead of propagating it.
- Write the space after `@page` whenever the first selector has a name, regardless of minification.
- Print the page name with `serialize_identifier` (review follow-up): the parsed name is stored decoded, so `write_str` emitted `@page \31 st` as `@page 1st{…}`, which reparses as a dimension token and fails.

### Verification

- New `describe("page")` block in `test/js/bun/css/css.test.ts` covering `@page` minification and reparsing of the minified forms (`@page:left{…}`, `@page:first,:blank{…}`, `@page toc,index{…}`, `@page LandscapeTable{…}`, `@page CompanyLetterHead:first{…}`, `@page \31 st{…}`, …). On the current release build 14/17 of these fail; with this change all pass.
- Fuzzer input roundtrips: `@page:left {` → `@page:left{}` → reparses to the same output.
- `test/js/bun/css/css.test.ts` + `test/js/bun/css/doesnt_crash.test.ts` on the debug build: 1109 pass, 67 skip, 0 fail.


