### PR TITLE
Fix minified output dropping the space before `in`/`instanceof` after a leading single-byte operand

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2228,7 +2228,10 @@ pub mod __gated_printer {
 
         #[inline]
         pub fn print_space_before_identifier(&mut self) {
-            if self.writer.written() > 0
+            // `writer.written()` starts at -1, so `>= 0` means "at least one byte has
+            // been written". Using `> 0` here would skip the space when exactly one
+            // byte precedes a keyword (e.g. `x instanceof y` minified to `xinstanceof y`).
+            if self.writer.written() >= 0
                 && (lexer::is_identifier_continue(self.writer.prev_char() as i32)
                     || self.writer.written() == self.prev_reg_exp_end)
             {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3970,3 +3970,19 @@ describe("export of a block-scoped function declaration", () => {
     expect(exitCode).toBe(1);
   });
 });
+
+describe("minifyWhitespace keeps the space before keyword operators", () => {
+  const minifier = new Bun.Transpiler({ loader: "js", minifyWhitespace: true });
+
+  it("between a single-character identifier and 'instanceof'", () => {
+    expect(minifier.transformSync("x instanceof y")).toBe("x instanceof y;");
+  });
+
+  it("between a single-character identifier and 'in'", () => {
+    expect(minifier.transformSync("x in y")).toBe("x in y;");
+  });
+
+  it("between a numeric literal and 'in'", () => {
+    expect(minifier.transformSync("1 in y")).toBe("1 in y;");
+  });
+});


### PR DESCRIPTION
Fixes a fuzzer-reported invariant violation: `printed output does not reparse (loader=js)`.

## Repro

```js
new Bun.Transpiler({ loader: "js", minifyWhitespace: true }).transformSync("x instanceof y")
// => "xinstanceof y;"   (does not reparse: Expected ";" but found "y")
```

Same failure through the bundler: `bun build --minify-whitespace` on a file containing only `x instanceof y` emits `xinstanceof y;`. Also affects `x in y` → `xin y;` and `1 in y` → `1in y;` (a numeric literal immediately followed by an identifier is a syntax error).

The trigger is a **single-byte operand at the very start of the output** followed by a keyword binary operator. With two or more preceding bytes (`xx instanceof y`, `a;x instanceof y`) the space is emitted correctly. This is not a regression from the Rust port — bun 1.2.23 prints the same broken output.

## Cause

`print_space_before_identifier()` in `src/js_printer/lib.rs` is responsible for inserting the separating space before keywords when `minifyWhitespace` suppresses the normal one:

```rust
if self.writer.written() > 0
    && (lexer::is_identifier_continue(self.writer.prev_char() as i32) || ...)
```

The writer's `written` counter is initialized to `-1`, so after printing one byte it is `0` and the `> 0` guard rejects it. The guard's intent (inherited from esbuild's `len(p.js) > 0`) is "something has already been written" — under the `-1`-based counter that is `>= 0`, not `> 0`. So the space between `x` and `instanceof` was skipped exactly when `x` was the first byte of the output.

## Fix

Change the guard to `self.writer.written() >= 0` and document the `-1`-based counter so the off-by-one doesn't get reintroduced. The change can only *add* a space in a case that previously fused two tokens; all snapshot/position comparisons elsewhere in the printer compare `written()` against other `written()` snapshots and are unaffected.

## Verification

- New tests in `test/bundler/transpiler/transpiler.test.js` (`minifyWhitespace keeps the space before keyword operators`): all three fail on the current build (`xinstanceof y;`, `xin y;`, `1in y;`) and pass with the fix.
- Original fuzz repro now prints `x instanceof y;`, which reparses.
- No regressions: `test/bundler/transpiler/transpiler.test.js` (129 pass), `test/bundler/bundler_minify.test.ts` (32 pass), `test/bundler/bundler_minify_symbol_for.test.ts` (9 pass), `test/bundler/esbuild/default.test.ts` (150 pass) all green with the debug build.
