### PR TITLE
Fix out-of-bounds read in eql_case_insensitive_ascii when the input is longer than the comparand

### DIFF
--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1440,15 +1440,9 @@ pub(crate) mod strings_impl {
     }
     /// Zig: `strings.eqlCaseInsensitiveASCII` (src/string/immutable.zig).
     /// Spec-faithful port: defers to libc `strncasecmp`/`_strnicmp` for the
-    /// hot path (CSS parser, HTTP header matching). `strncasecmp` compares up
-    /// to `a.len()` bytes of both buffers, so `b` must be at least as long as
-    /// `a`. Zig's comparands are NUL-terminated literals, which made
-    /// `strncasecmp` stop at `b`'s sentinel and report a mismatch when `a` was
-    /// longer; Rust slices carry no terminator, so reject that case up front
-    /// instead of reading past `b` (e.g. the CSS An+B parser comparing an
-    /// arbitrary ident against `b"n"`). Callers are still expected to pass
-    /// non-empty slices (mirrors Zig's `bun.unsafeAssert`; see the
-    /// `debug_assert`s below).
+    /// hot path (CSS parser, HTTP header matching). Unlike Zig's NUL-terminated
+    /// literals, Rust slices have no terminator, so a `b` shorter than `a` is
+    /// rejected instead of read past.
     #[inline]
     pub fn eql_case_insensitive_ascii(a: &[u8], b: &[u8], check_len: bool) -> bool {
         if check_len {
@@ -1465,8 +1459,7 @@ pub(crate) mod strings_impl {
         debug_assert!(!b.is_empty());
         debug_assert!(!a.is_empty());
 
-        // SAFETY: `a.len() <= b.len()` here, and strncasecmp reads at most
-        // `a.len()` bytes from each buffer, so both reads stay in bounds.
+        // SAFETY: a.len() <= b.len() here; strncasecmp reads at most a.len() bytes from each.
         #[cfg(not(windows))]
         unsafe {
             libc::strncasecmp(a.as_ptr().cast(), b.as_ptr().cast(), a.len()) == 0

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1446,7 +1446,9 @@ pub(crate) mod strings_impl {
     /// `strncasecmp` stop at `b`'s sentinel and report a mismatch when `a` was
     /// longer; Rust slices carry no terminator, so reject that case up front
     /// instead of reading past `b` (e.g. the CSS An+B parser comparing an
-    /// arbitrary ident against `b"n"`).
+    /// arbitrary ident against `b"n"`). Callers are still expected to pass
+    /// non-empty slices (mirrors Zig's `bun.unsafeAssert`; see the
+    /// `debug_assert`s below).
     #[inline]
     pub fn eql_case_insensitive_ascii(a: &[u8], b: &[u8], check_len: bool) -> bool {
         if check_len {

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1440,9 +1440,13 @@ pub(crate) mod strings_impl {
     }
     /// Zig: `strings.eqlCaseInsensitiveASCII` (src/string/immutable.zig).
     /// Spec-faithful port: defers to libc `strncasecmp`/`_strnicmp` for the
-    /// hot path (CSS parser, HTTP header matching). When `check_len` is false
-    /// the caller guarantees `a.len() <= b.len()` and both are non-empty
-    /// (matches Zig's `bun.unsafeAssert`).
+    /// hot path (CSS parser, HTTP header matching). `strncasecmp` compares up
+    /// to `a.len()` bytes of both buffers, so `b` must be at least as long as
+    /// `a`. Zig's comparands are NUL-terminated literals, which made
+    /// `strncasecmp` stop at `b`'s sentinel and report a mismatch when `a` was
+    /// longer; Rust slices carry no terminator, so reject that case up front
+    /// instead of reading past `b` (e.g. the CSS An+B parser comparing an
+    /// arbitrary ident against `b"n"`).
     #[inline]
     pub fn eql_case_insensitive_ascii(a: &[u8], b: &[u8], check_len: bool) -> bool {
         if check_len {
@@ -1452,12 +1456,15 @@ pub(crate) mod strings_impl {
             if a.is_empty() {
                 return true;
             }
+        } else if b.len() < a.len() {
+            return false;
         }
 
         debug_assert!(!b.is_empty());
         debug_assert!(!a.is_empty());
 
-        // SAFETY: a and b are non-empty; strncasecmp reads up to a.len() bytes from each.
+        // SAFETY: `a.len() <= b.len()` here, and strncasecmp reads at most
+        // `a.len()` bytes from each buffer, so both reads stay in bounds.
         #[cfg(not(windows))]
         unsafe {
             libc::strncasecmp(a.as_ptr().cast(), b.as_ptr().cast(), a.len()) == 0

--- a/test/js/bun/css/nth-anplusb-ident.test.ts
+++ b/test/js/bun/css/nth-anplusb-ident.test.ts
@@ -4,18 +4,10 @@ import { bunEnv, bunExe } from "harness";
 
 const { minifyTest } = cssInternals;
 
-// Regression test for an out-of-bounds read in the An+B (`:nth-child()`)
-// parser. The `<ident>` branch compares the user-supplied ident against the
-// keywords "even" / "odd" / "n" / "-n" / "n-" / "-n-" with a case-insensitive
-// helper backed by `strncasecmp(a, b, a.len)`. When the ident is longer than
-// the keyword (e.g. `Nn` vs `n`) the comparison read past the end of the
-// keyword literal, which AddressSanitizer reports as a global-buffer-overflow.
-// Found by fuzzing with the minimized input `:nth-child(Nn`.
+// An+B idents longer than the keyword literals ("n", "n-", ...) used to make the
+// case-insensitive comparison read past the keyword (found by fuzzing `:nth-child(Nn`).
 
 test("An+B idents longer than the keyword literals parse deterministically", () => {
-  // `n-<digits>` idents start with the same bytes as the "n" / "n-" keywords
-  // but are longer than both; they must fall through to the `<ident> =
-  // n-<digits>` production instead of reading past the keyword literals.
   expect(minifyTest(":nth-child(n-3) {width: 20px}", ":nth-child(n-3){width:20px}")).toBe(
     ":nth-child(n-3){width:20px}",
   );
@@ -25,16 +17,12 @@ test("An+B idents longer than the keyword literals parse deterministically", () 
   expect(minifyTest(":nth-last-child(n- 42) {width: 20px}", ":nth-last-child(n-42){width:20px}")).toBe(
     ":nth-last-child(n-42){width:20px}",
   );
-  // Still matches the keywords exactly (case-insensitively).
   expect(minifyTest(":nth-child(N) {width: 20px}", ":nth-child(n){width:20px}")).toBe(":nth-child(n){width:20px}");
-  // An ident that starts like a keyword but is not a valid An+B is a parse
-  // error, not a crash.
   expect(() => minifyTest(":nth-child(NN) {width: 20px}", "")).toThrow("Unexpected token");
 });
 
 test("fuzzer-minimized input: unterminated :nth-child( with an `Nn` ident", async () => {
-  // Exact fuzz input. Run in a child process so a crash in the parser shows up
-  // as a failed assertion here instead of killing the test runner.
+  // Run in a child process so a crash doesn't take down the test runner.
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),

--- a/test/js/bun/css/nth-anplusb-ident.test.ts
+++ b/test/js/bun/css/nth-anplusb-ident.test.ts
@@ -54,5 +54,6 @@ test("fuzzer-minimized input: unterminated :nth-child( with an `Nn` ident", asyn
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout.trim()).toBe("error: parsing failed: Unexpected end of input");
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/css/nth-anplusb-ident.test.ts
+++ b/test/js/bun/css/nth-anplusb-ident.test.ts
@@ -1,0 +1,58 @@
+import { cssInternals } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+const { minifyTest } = cssInternals;
+
+// Regression test for an out-of-bounds read in the An+B (`:nth-child()`)
+// parser. The `<ident>` branch compares the user-supplied ident against the
+// keywords "even" / "odd" / "n" / "-n" / "n-" / "-n-" with a case-insensitive
+// helper backed by `strncasecmp(a, b, a.len)`. When the ident is longer than
+// the keyword (e.g. `Nn` vs `n`) the comparison read past the end of the
+// keyword literal, which AddressSanitizer reports as a global-buffer-overflow.
+// Found by fuzzing with the minimized input `:nth-child(Nn`.
+
+test("An+B idents longer than the keyword literals parse deterministically", () => {
+  // `n-<digits>` idents start with the same bytes as the "n" / "n-" keywords
+  // but are longer than both; they must fall through to the `<ident> =
+  // n-<digits>` production instead of reading past the keyword literals.
+  expect(minifyTest(":nth-child(n-3) {width: 20px}", ":nth-child(n-3){width:20px}")).toBe(
+    ":nth-child(n-3){width:20px}",
+  );
+  expect(minifyTest(":nth-child(N-3) {width: 20px}", ":nth-child(n-3){width:20px}")).toBe(
+    ":nth-child(n-3){width:20px}",
+  );
+  expect(minifyTest(":nth-last-child(n- 42) {width: 20px}", ":nth-last-child(n-42){width:20px}")).toBe(
+    ":nth-last-child(n-42){width:20px}",
+  );
+  // Still matches the keywords exactly (case-insensitively).
+  expect(minifyTest(":nth-child(N) {width: 20px}", ":nth-child(n){width:20px}")).toBe(":nth-child(n){width:20px}");
+  // An ident that starts like a keyword but is not a valid An+B is a parse
+  // error, not a crash.
+  expect(() => minifyTest(":nth-child(NN) {width: 20px}", "")).toThrow("Unexpected token");
+});
+
+test("fuzzer-minimized input: unterminated :nth-child( with an `Nn` ident", async () => {
+  // Exact fuzz input. Run in a child process so a crash in the parser shows up
+  // as a failed assertion here instead of killing the test runner.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `try {
+        require("bun:internal-for-testing").cssInternals.minifyTest(":nth-child(Nn", "");
+        console.log("no error");
+      } catch (e) {
+        console.log("error: " + e.message);
+      }`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("error: parsing failed: Unexpected end of input");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### What does this PR do?

Fixes an ASAN `global-buffer-overflow` found by fuzzing the CSS parser:

```
asan:global-buffer-overflow:strncasecmp|eql_case_insensitive_ascii|eql_case_insensitive_ascii|bun_core::string::immutable::eql_case_insensitive_ascii_ignore_length
```

**Repro**

```sh
BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1 bun -e 'require("bun:internal-for-testing").cssInternals.minifyTest(":nth-child(Nn", "")'
```

```
==ERROR: AddressSanitizer: global-buffer-overflow READ of size 2 ...
    #0 strncasecmp
    #1 bun_core::strings_impl::eql_case_insensitive_ascii src/bun_core/lib.rs
    #2 bun_core::string::immutable::eql_case_insensitive_ascii_ignore_length src/bun_core/string/immutable.rs
    #3 bun_css::css_parser::nth::parse_nth src/css/css_parser.rs
    #4 bun_css::selectors::parser::parse_nth_pseudo_class src/css/selectors/parser.rs
```

**Cause**

`strings_impl::eql_case_insensitive_ascii(a, b, check_len)` defers to `strncasecmp(a, b, a.len())`, which reads up to `a.len()` bytes from *both* buffers. The Zig original (`strings.eqlCaseInsensitiveASCII`) compared against NUL-terminated comptime literals, so `strncasecmp` stopped at the sentinel and reported a mismatch whenever `a` was longer than `b`. Rust byte-string literals carry no terminator, so the An+B parser's ident branch (`parse_nth`), which compares an arbitrary user ident against the keywords `"even" / "odd" / "n" / "-n" / "n-" / "-n-"` with the ignore-length variant, reads past the end of the keyword literal as soon as the ident is longer than the keyword and shares its prefix (`Nn` vs `n`, `n-3` vs `n`, …). Besides the OOB read, the comparison result depended on whatever byte happens to follow the literal in rodata.

**Fix**

Reject `b.len() < a.len()` up front in `eql_case_insensitive_ascii` before calling `strncasecmp` — the same result the NUL sentinel produced in Zig, so observable behavior is unchanged for every in-bounds input (all other callers of the ignore-length variant already pass equal-length slices). `strncasecmp` now only ever reads within both slices.

**Verification**

- `bun bd test test/js/bun/css/nth-anplusb-ident.test.ts` without the fix (src/ stashed): aborts with the ASAN global-buffer-overflow above.
- With the fix: passes. The new test covers valid `n-<digits>` idents that are longer than the `n`/`n-` keywords (`:nth-child(n-3)`, `:nth-child(N-3)`, `:nth-last-child(n- 42)`), keyword case-insensitivity (`:nth-child(N)`), an invalid ident (`:nth-child(NN)` → parse error), and the exact fuzzer-minimized input run in a subprocess.
- `bun bd test test/js/bun/css/css.test.ts`: 1032 pass, 0 fail (no behavior change for the existing suite).
- A second fuzz report hits the same overflow through `Bun.build` with a CSS entrypoint containing `:nth-child(Nn`; that path goes through the same `parse_nth` comparison and is covered by this fix (`Bun.build` now reports a parse error instead of aborting).
- The `build-rust` CI failures on this PR (unused label / unnecessary `unsafe` warnings in `src/spawn`, `src/install`, `src/crash_handler`, `src/runtime/ffi`, `src/runtime/dns_jsc`) are present on current `main` commits that don't include this change and come from files this PR doesn't touch.
