### PR TITLE
Don't emit reserved words as class names when lowering decorated anonymous class expressions

### DIFF
--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -6,8 +6,9 @@ use bun_alloc::ArenaVecExt as _;
 
 use bun_collections::{HashMap, VecExt};
 
+use crate::lexer as js_lexer;
 use crate::p::P;
-use crate::parser::{ARGUMENTS_STR as arguments_str, Ref};
+use crate::parser::{ARGUMENTS_STR as arguments_str, Ref, is_eval_or_arguments};
 use bun_ast::g::{DeclList, Property, PropertyKind};
 use bun_ast::{self as js_ast, B, E, Expr, ExprNodeList, Flags, G, S, Stmt};
 
@@ -119,6 +120,21 @@ fn class_copy(c: &G::Class) -> G::Class {
         has_decorators: c.has_decorators,
         should_lower_standard_decorators: c.should_lower_standard_decorators,
     }
+}
+
+/// Whether a context-inferred name (`export default` → "default", object
+/// property keys, assignment targets) can be attached to a lowered anonymous
+/// class expression as its syntactic binding name. Class bodies are always
+/// strict mode code and the output may be a module, so reserved words
+/// ("default", "let", "await", …), `eval`/`arguments`, and non-identifier
+/// strings would turn `_class = class <name> {}` into a syntax error.
+#[inline]
+fn can_be_class_binding_name(name: &[u8]) -> bool {
+    js_lexer::is_identifier(name)
+        && js_lexer::keyword(name).is_none()
+        && !js_lexer::is_strict_mode_reserved_word(name)
+        && name != b"await"
+        && !is_eval_or_arguments(name)
 }
 
 // ── impl P ───────────────────────────────────────────────────────────────────
@@ -1030,7 +1046,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 class_name_ref = ecr;
                 class_name_loc = loc;
                 expr_class_is_anonymous = true;
-                if let Some(name) = name_from_context {
+                if let Some(name) = name_from_context
+                    && can_be_class_binding_name(name)
+                {
                     class.class_name = Some(js_ast::LocRef {
                         ref_: Some(p.new_sym(js_ast::symbol::Kind::Other, name)),
                         loc,

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -557,6 +557,108 @@ describe("ES Decorators", () => {
       expect(stdout).toBe("named\n");
       expect(exitCode).toBe(0);
     });
+
+    test("export default anonymous decorated class expression", async () => {
+      using dir = tempDir("es-dec-export-default-anon-expr", {
+        "entry.js": `
+          import Cls from "./mod.js";
+          console.log(Cls.name);
+          console.log(globalThis.decoratorContextName);
+        `,
+        "mod.js": `
+          function dec(cls, ctx) { globalThis.decoratorContextName = ctx.name; }
+          export default (@dec class {});
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "entry.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(filterStderr(rawStderr)).toBe("");
+      expect(stdout).toBe("default\ndefault\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("export default anonymous class with class decorator", async () => {
+      using dir = tempDir("es-dec-export-default-anon-dec", {
+        "entry.js": `
+          import Cls from "./mod.js";
+          console.log(Cls.name);
+          console.log(globalThis.decoratorContextName);
+        `,
+        "mod.js": `
+          function dec(cls, ctx) { globalThis.decoratorContextName = ctx.name; }
+          export default @dec class {}
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "entry.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(filterStderr(rawStderr)).toBe("");
+      expect(stdout).toBe("default\ndefault\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("export default anonymous class expression with method decorator", async () => {
+      using dir = tempDir("es-dec-export-default-anon-method", {
+        "entry.js": `
+          import Cls from "./mod.js";
+          const c = new Cls();
+          console.log(c.foo());
+        `,
+        "mod.js": `
+          function dec(fn, ctx) { console.log("decorated", ctx.name); return fn; }
+          export default (class {
+            @dec foo() { return 42; }
+          });
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "entry.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(filterStderr(rawStderr)).toBe("");
+      expect(stdout).toBe("decorated foo\n42\n");
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  describe("anonymous class expressions with reserved-word inferred names", () => {
+    test("decorated anonymous class as value of a reserved-word object key", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(cls, ctx) { console.log("ctx.name:", ctx.name); }
+        const obj = { default: (@dec class {}) };
+        console.log(obj.default.name);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("ctx.name: default\ndefault\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("Bun.Transpiler output for decorated anonymous default export reparses", () => {
+      const transpiler = new Bun.Transpiler({ loader: "ts", target: "node", deadCodeElimination: true });
+      const output = transpiler.transformSync("export default(@c class{})");
+      // "default" is a keyword, so it must not be printed as the class binding name
+      expect(output).not.toContain("class default");
+      // the lowered output must still be valid syntax
+      expect(() => new Bun.Transpiler({ loader: "js" }).transformSync(output)).not.toThrow();
+    });
   });
 
   describe("accessor with TypeScript annotations", () => {


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-found invariant violation (`printed output does not reparse`) in the standard (TC39) decorator lowering: decorating an anonymous class expression whose inferred name is a reserved word produced syntactically invalid output.

```ts
export default (@dec class {})
```

was lowered to

```js
export default (_dec = [dec], _init = __decoratorStart(undefined), _class = class default {
}, _class = __decorateElement(_init, 0, "default", _dec, _class), ...);
```

`class default {}` is a syntax error, so:

- `Bun.Transpiler` / `bun build --target=node|browser` emitted output that fails to parse
- running a plain `.js` module containing `export default (@dec class {})` (or `export default @dec class {}`) failed at runtime with `SyntaxError: Unexpected keyword 'default'`

The same thing happened for any other context-inferred name that can't be a binding identifier, e.g. `{ default: (@dec class {}) }`, `{ "foo bar!": (@dec class {}) }`, `{ 0: (@dec class {}) }`, `{ eval: (@dec class {}) }`.

### How did we fix it?

When the lowering rewrites an anonymous decorated class expression, it attaches the context-inferred name (from `export default`, object property keys, assignment targets, …) as the class's syntactic binding name so `Class.name` survives the rewrite. That is only legal when the name is a valid strict-mode binding identifier (class bodies are always strict and the output may be a module).

`lower_impl` now only attaches the name when it passes that check (valid identifier, not a keyword, not strict-mode reserved, not `await`/`eval`/`arguments`); otherwise the class expression stays anonymous — the same shape esbuild emits. The decorator context `name` string and the `__name` call inside `__decorateElement` are unchanged, so `ctx.name` and `Class.name` still evaluate to `"default"` for a decorated anonymous default export. Valid inferred names (`let x = (@dec class {})` → `class x {}`) are unaffected.

### How did you verify your code works?

Repro (before): `bun -e 'new Bun.Transpiler({loader:"ts", target:"node", deadCodeElimination:true}).transformSync("export default(@c class{})")'` emitted `_class = class default {}`; running a `.js` module with `export default (@dec class {})` threw `SyntaxError: Unexpected keyword 'default'`.

Added tests to `test/bundler/transpiler/es-decorators.test.ts`:

- `export default (@dec class {})` and `export default @dec class {}` run, `Class.name` and `ctx.name` are `"default"`
- `export default (class { @dec foo() {} })` (elements-only decoration) runs
- `{ default: (@dec class {}) }` runs with correct name
- `Bun.Transpiler` output for the fuzz repro contains no `class default` and reparses

All 5 fail on bun without this change (SyntaxError / invalid output) and pass with it; the rest of `es-decorators.test.ts`, `es-decorators-esbuild.test.ts`, `decorators.test.ts`, `decorator-metadata.test.ts`, and `bundler_decorator_metadata.test.ts` (180 tests) pass.
