### PR TITLE
patch: propagate thrown errors from patchInternals.apply argument parsing

### DIFF
--- a/src/patch_jsc/testing.rs
+++ b/src/patch_jsc/testing.rs
@@ -61,10 +61,7 @@ impl TestingAPIs {
     }
 
     pub fn apply(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        let args = match Self::parse_apply_args(global, frame) {
-            Err(e) => return Ok(e),
-            Ok(a) => a,
-        };
+        let args = Self::parse_apply_args(global, frame)?;
 
         // TODO(port): lifetime — `PatchFile<'a>` borrows its source bytes, so the Zig
         // `ApplyArgs { patchfile, patchfile_txt }` pair is self-referential in Rust.
@@ -117,27 +114,19 @@ impl TestingAPIs {
         Ok(js)
     }
 
-    pub fn parse_apply_args(
-        global: &JSGlobalObject,
-        frame: &CallFrame,
-    ) -> Result<ApplyArgs, JSValue> {
-        // TODO(port): Zig return type was `bun.jsc.Node.Maybe(ApplyArgs, jsc.JSValue)`; mapped to plain Result.
+    pub fn parse_apply_args(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<ApplyArgs> {
         let arguments_ = frame.arguments_old::<2>();
         // SAFETY: `bun_vm()` never returns null for a Bun-owned global; the VM
         // outlives this call frame.
         let mut arguments = ArgumentsSlice::init(global.bun_vm(), arguments_.slice());
 
         let Some(patchfile_js) = arguments.next_eat() else {
-            let _ = global.throw(format_args!("apply: expected at least 1 argument, got 0"));
-            return Err(JSValue::UNDEFINED);
+            return Err(global.throw(format_args!("apply: expected at least 1 argument, got 0")));
         };
 
         let dir_fd = if let Some(dir_js) = arguments.next_eat() {
-            let Ok(bunstr) = dir_js.to_bun_string(global) else {
-                return Err(JSValue::UNDEFINED);
-            };
             // +1 ref from `to_bun_string`; release via `OwnedString` drop (Zig: `defer bunstr.deref()`).
-            let bunstr = OwnedString::new(bunstr);
+            let bunstr = OwnedString::new(dir_js.to_bun_string(global)?);
             let path = bunstr.to_owned_slice_z();
 
             match bun_sys::open(
@@ -147,8 +136,7 @@ impl TestingAPIs {
             ) {
                 Err(e) => {
                     let js_err = SysErrorJsc::to_js(&e.with_path(path.as_bytes()), global);
-                    let _ = global.throw_value(js_err);
-                    return Err(JSValue::UNDEFINED);
+                    return Err(global.throw_value(js_err));
                 }
                 Ok(fd) => fd,
             }
@@ -156,8 +144,14 @@ impl TestingAPIs {
             Fd::cwd()
         };
 
-        let Ok(patchfile_bunstr) = patchfile_js.to_bun_string(global) else {
-            return Err(JSValue::UNDEFINED);
+        let patchfile_bunstr = match patchfile_js.to_bun_string(global) {
+            Ok(bunstr) => bunstr,
+            Err(e) => {
+                if Fd::cwd() != dir_fd {
+                    dir_fd.close();
+                }
+                return Err(e);
+            }
         };
         // +1 ref from `to_bun_string`; release via `OwnedString` drop (Zig:
         // `defer patchfile_bunstr.deref()`). `to_utf8()` takes its own ref, so
@@ -177,8 +171,7 @@ impl TestingAPIs {
             }
 
             drop(patchfile_src);
-            let _ = global.throw_error(e.into(), "failed to parse patchfile");
-            return Err(JSValue::UNDEFINED);
+            return Err(global.throw_error(e.into(), "failed to parse patchfile"));
         }
 
         Ok(ApplyArgs {

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -484,21 +484,24 @@ describe("apply", () => {
       cmd: [
         bunExe(),
         "-e",
-        `const { patchInternals } = require("bun:internal-for-testing");
+        `import { patchInternals } from "bun:internal-for-testing";
          try { patchInternals.apply("@@"); console.log("no-error"); } catch (e) { console.log("invalid-patchfile: " + e.message); }
          try { patchInternals.apply(); console.log("no-error"); } catch (e) { console.log("missing-argument: " + e.message); }
-         try { patchInternals.apply("@@", "bun-patch-test-nonexistent-dir"); console.log("no-error"); } catch (e) { console.log("bad-dir: " + e.code); }`,
+         try { patchInternals.apply("@@", "bun-patch-test-nonexistent-dir"); console.log("no-error"); } catch (e) { console.log("bad-dir: " + e.code); }
+         try { patchInternals.apply({ toString() { throw new Error("coerce-fail"); } }, process.cwd()); console.log("no-error"); } catch (e) { console.log("bad-patchfile-arg: " + e.message); }`,
       ],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
 
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
     expect(stdout.trim().split("\n")).toEqual([
       "invalid-patchfile: bad_header_line failed to parse patchfile",
       "missing-argument: apply: expected at least 1 argument, got 0",
       "bad-dir: ENOENT",
+      "bad-patchfile-arg: coerce-fail",
     ]);
     expect(exitCode).toBe(0);
   });

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -2,7 +2,7 @@ import { $ } from "bun";
 import { patchInternals } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import fs from "fs/promises";
-import { tempDirWithFiles as __tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDirWithFiles as __tempDirWithFiles } from "harness";
 import { join as __join } from "node:path";
 const { parse, apply, makeDiff } = patchInternals;
 
@@ -473,6 +473,34 @@ describe("apply", () => {
 
   describe("No newline at end of file", () => {
     // TODO: simple, multiline, multiple hunks
+  });
+
+  // Each of these hits an error path in `parse_apply_args`. The native code must
+  // surface the failure as a catchable JS exception; it used to return a normal
+  // value while the exception was still pending, which aborts debug/ASAN builds
+  // with "Unexpected exception observed" (releaseAssertNoException).
+  test("invalid arguments throw a catchable error", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { patchInternals } = require("bun:internal-for-testing");
+         try { patchInternals.apply("@@"); console.log("no-error"); } catch (e) { console.log("invalid-patchfile: " + e.message); }
+         try { patchInternals.apply(); console.log("no-error"); } catch (e) { console.log("missing-argument: " + e.message); }
+         try { patchInternals.apply("@@", "bun-patch-test-nonexistent-dir"); console.log("no-error"); } catch (e) { console.log("bad-dir: " + e.code); }`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout.trim().split("\n")).toEqual([
+      "invalid-patchfile: bad_header_line failed to parse patchfile",
+      "missing-argument: apply: expected at least 1 argument, got 0",
+      "bad-dir: ENOENT",
+    ]);
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -2,7 +2,7 @@ import { $ } from "bun";
 import { patchInternals } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import fs from "fs/promises";
-import { bunEnv, bunExe, tempDirWithFiles as __tempDirWithFiles } from "harness";
+import { tempDirWithFiles as __tempDirWithFiles, bunEnv, bunExe } from "harness";
 import { join as __join } from "node:path";
 const { parse, apply, makeDiff } = patchInternals;
 


### PR DESCRIPTION
### What does this PR do?

Fixes a bun-fuzz crash in the `patch` testing bindings (`sig:SIGABRT:nostack`, Bun `1.4.0-canary.1+4df6154f0`):

```
ASSERTION FAILED: Unexpected exception observed on thread ...
Error Exception: bad_header_line failed to parse patchfile
!exception()
JavaScriptCore/ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
```

**Repro** (the fuzz report's minimized input, but via `apply` — the `"failed to parse patchfile"` message in the report only exists on the `apply` path, and `.parse("@@")` does not abort):

```sh
BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1 \
  bun -e 'require("bun:internal-for-testing").patchInternals.apply("@@")'
# debug/ASAN/assert builds: SIGABRT with the assertion above
```

### Cause

`TestingAPIs::parse_apply_args` (`src/patch_jsc/testing.rs`) throws the JS exception (`global.throw(...)` / `throw_value(...)` / `throw_error(...)`) but then discards the resulting `JsError` and returns `Err(JSValue::UNDEFINED)`. `apply()` turned that into `return Ok(e)` — i.e. the host function returned a normal `undefined` value **while the exception was still pending**. The host-function glue asserts no exception is pending when a function returns a value, so assert-enabled builds abort with `releaseAssertNoException`. Every error path in the helper had the same flaw (invalid patchfile, missing argument, directory that fails to open, argument-to-string failures).

On release builds the pending exception still happened to propagate, which is why this only surfaced on the fuzzer's assert-enabled canary.

### Fix

- `parse_apply_args` now returns `JsResult<ApplyArgs>` and returns the real `JsError` produced by the throw on every error path.
- `apply()` propagates it with `?` instead of returning the smuggled `JSValue` as a success value.
- While restructuring the error paths: the opened directory fd is now closed when converting the patchfile argument to a string fails (previously leaked on that path).

### How did you verify your code works?

Added `apply > invalid arguments throw a catchable error` to `test/js/bun/patch/patch.test.ts`. It spawns a child `bun -e` that calls `patchInternals.apply` with an invalid patchfile, with no arguments, and with a nonexistent directory, and expects each to surface as a catchable JS error with a clean exit.

- Without the fix (debug/ASAN build): the child aborts with the exact assertion from the fuzz report and the test fails.
- With the fix: the whole `patch.test.ts` file passes (22 pass / 0 fail), and the repro above no longer aborts (`try/catch` sees `bad_header_line failed to parse patchfile`).

`cargo check -p bun_patch_jsc` and `cargo clippy -p bun_patch_jsc` are clean.
