### PR TITLE
css: don't duplicate vendor-prefixed nested rules per ancestor prefix pass

### DIFF
--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -133,6 +133,13 @@ pub struct Printer<'a> {
     pub minify: bool,
     pub targets: Targets,
     pub vendor_prefix: css::VendorPrefix,
+    /// True while nested rules are being re-serialized for a non-final vendor
+    /// prefix pass of an ancestor style rule (when nesting is compiled away).
+    /// Nested style rules that carry their own vendor prefixes override
+    /// `vendor_prefix`, so their output is identical in every ancestor pass;
+    /// they are skipped while this is set and emitted once in the final pass,
+    /// keeping the output linear in nesting depth instead of exponential.
+    pub skip_prefixed_nested_rules: bool,
     pub in_calc: bool,
     pub css_module: Option<css::CssModule<'a>>,
     pub dependencies: Option<BumpVec<'a, css::Dependency>>,
@@ -307,6 +314,7 @@ impl<'a> Printer<'a> {
             line: 0,
             col: 0,
             vendor_prefix: css::VendorPrefix::default(),
+            skip_prefixed_nested_rules: false,
             in_calc: false,
             css_module: None,
             ctx: None,

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -460,6 +460,21 @@ impl<R> media::MediaRule<R> {
     }
 }
 
+impl<R> CssRule<R> {
+    /// Whether this rule is skipped while `Printer::skip_prefixed_nested_rules`
+    /// is set (a non-final vendor prefix pass of an ancestor style rule) and
+    /// emitted only in the ancestor's final pass: a style rule with its own
+    /// vendor prefixes overrides `Printer::vendor_prefix`, so its output is
+    /// identical in every ancestor pass.
+    pub(crate) fn is_deferred_to_final_prefix_pass(&self) -> bool {
+        match self {
+            CssRule::Style(style) => !style.vendor_prefix.is_empty(),
+            CssRule::Nesting(nesting) => !nesting.style.vendor_prefix.is_empty(),
+            _ => false,
+        }
+    }
+}
+
 // ─── CssRuleList::{to_css,minify,deep_clone} ──────────────────────────────
 
 impl<R> CssRuleList<R> {
@@ -477,13 +492,7 @@ impl<R> CssRuleList<R> {
             // their own vendor prefixes: they override `dest.vendor_prefix`,
             // so this pass would emit an exact duplicate of what the final
             // pass emits.
-            if dest.skip_prefixed_nested_rules
-                && match rule {
-                    CssRule::Style(style) => !style.vendor_prefix.is_empty(),
-                    CssRule::Nesting(nesting) => !nesting.style.vendor_prefix.is_empty(),
-                    _ => false,
-                }
-            {
+            if dest.skip_prefixed_nested_rules && rule.is_deferred_to_final_prefix_pass() {
                 continue;
             }
 

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -472,6 +472,21 @@ impl<R> CssRuleList<R> {
                 continue;
             }
 
+            // While re-serializing nested rules for a non-final vendor prefix
+            // pass of an ancestor style rule, skip style rules that carry
+            // their own vendor prefixes: they override `dest.vendor_prefix`,
+            // so this pass would emit an exact duplicate of what the final
+            // pass emits.
+            if dest.skip_prefixed_nested_rules
+                && match rule {
+                    CssRule::Style(style) => !style.vendor_prefix.is_empty(),
+                    CssRule::Nesting(nesting) => !nesting.style.vendor_prefix.is_empty(),
+                    _ => false,
+                }
+            {
+                continue;
+            }
+
             // Skip @import rules if collecting dependencies.
             if let CssRule::Import(import_rule) = rule
                 && dest.remove_imports

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -76,14 +76,16 @@ impl<R> StyleRule<R> {
 impl<R> StyleRule<R> {
     pub fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
         if self.vendor_prefix.is_empty() {
-            self.to_css_base(dest)?;
+            self.to_css_base(dest, true)?;
         } else {
             let mut first_rule = true;
+            let mut remaining_prefixes = self.vendor_prefix;
             // `inline for (css.VendorPrefix.FIELDS) |field|` — iterate the bool fields of the
             // packed struct in declared order. In Rust the bitflags type exposes the same
             // ordered single-bit table directly.
             for &prefix in VendorPrefix::FIELDS {
                 if self.vendor_prefix.contains(prefix) {
+                    remaining_prefixes.remove(prefix);
                     if first_rule {
                         first_rule = false;
                     } else {
@@ -94,7 +96,7 @@ impl<R> StyleRule<R> {
                     }
 
                     dest.vendor_prefix = prefix;
-                    self.to_css_base(dest)?;
+                    self.to_css_base(dest, remaining_prefixes.is_empty())?;
                 }
             }
 
@@ -103,7 +105,7 @@ impl<R> StyleRule<R> {
         Ok(())
     }
 
-    fn to_css_base(&self, dest: &mut Printer) -> Result<(), PrintErr> {
+    fn to_css_base(&self, dest: &mut Printer, is_final_prefix_pass: bool) -> Result<(), PrintErr> {
         use css::error::PrinterErrorKind;
         use css::properties::Property;
 
@@ -224,10 +226,22 @@ impl<R> StyleRule<R> {
         } else {
             helpers_end(dest, has_declarations)?;
             helpers_newline(self, dest, supports_nesting, len)?;
+            // This rule is serialized once per vendor prefix, and each pass
+            // re-serializes the nested rules. Nested style rules that carry
+            // their own vendor prefixes override `dest.vendor_prefix`, so they
+            // produce identical output in every pass; mark non-final passes so
+            // they are skipped and emitted only in the final pass. Otherwise
+            // they would be duplicated once per ancestor prefix, which grows
+            // exponentially with nesting depth.
+            let saved_skip = dest.skip_prefixed_nested_rules;
+            dest.skip_prefixed_nested_rules = saved_skip || !is_final_prefix_pass;
             // Zig: dest.withContext(&this.selectors, this, struct { fn toCss(...) }.toCss)
             // Rust `with_context` keeps the (closure-data, fn) split so the
             // `Printer` reborrow lives only inside `func`.
-            dest.with_context(&self.selectors, &self.rules, |rules, d| rules.to_css(d))?;
+            let result =
+                dest.with_context(&self.selectors, &self.rules, |rules, d| rules.to_css(d));
+            dest.skip_prefixed_nested_rules = saved_skip;
+            result?;
         }
         Ok(())
     }

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -1,5 +1,5 @@
 use crate as css;
-use crate::css_rules::{CssRuleList, Location, MinifyContext};
+use crate::css_rules::{CssRule, CssRuleList, Location, MinifyContext};
 use crate::declaration::DeclarationBlock;
 use crate::error::MinifyErr;
 use crate::selectors::selector;
@@ -230,8 +230,6 @@ impl<R> StyleRule<R> {
             self.rules.to_css(dest)?;
             helpers_end(dest, has_declarations)?;
         } else {
-            helpers_end(dest, has_declarations)?;
-            helpers_newline(self, dest, supports_nesting, len)?;
             // This rule is serialized once per vendor prefix, and each pass
             // re-serializes the nested rules. Nested style rules that carry
             // their own vendor prefixes override `dest.vendor_prefix`, so they
@@ -240,7 +238,20 @@ impl<R> StyleRule<R> {
             // they would be duplicated once per ancestor prefix, which grows
             // exponentially with nesting depth.
             let saved_skip = dest.skip_prefixed_nested_rules;
-            dest.skip_prefixed_nested_rules = saved_skip || !is_final_prefix_pass;
+            let skip_prefixed_nested = saved_skip || !is_final_prefix_pass;
+            // Whether any nested rule is emitted in this pass; if not, don't
+            // write the separator between the declarations and the nested
+            // rules (nothing would follow it).
+            let has_nested_output = !skip_prefixed_nested
+                || self.rules.v.iter().any(|rule| {
+                    !matches!(rule, CssRule::Ignored) && !rule.is_deferred_to_final_prefix_pass()
+                });
+
+            helpers_end(dest, has_declarations)?;
+            if has_nested_output {
+                helpers_newline(self, dest, supports_nesting, len)?;
+            }
+            dest.skip_prefixed_nested_rules = skip_prefixed_nested;
             // Zig: dest.withContext(&this.selectors, this, struct { fn toCss(...) }.toCss)
             // Rust `with_context` keeps the (closure-data, fn) split so the
             // `Printer` reborrow lives only inside `func`.

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -86,9 +86,7 @@ impl<R> StyleRule<R> {
             for &prefix in VendorPrefix::FIELDS {
                 if self.vendor_prefix.contains(prefix) {
                     remaining_prefixes.remove(prefix);
-                    if first_rule {
-                        first_rule = false;
-                    } else {
+                    if !first_rule {
                         if !dest.minify {
                             dest.write_char(b'\n')?; // no indent
                         }
@@ -96,7 +94,15 @@ impl<R> StyleRule<R> {
                     }
 
                     dest.vendor_prefix = prefix;
+                    let (line, col) = (dest.line, dest.col);
                     self.to_css_base(dest, remaining_prefixes.is_empty())?;
+                    // A non-final pass emits nothing when the rule has no
+                    // declarations of its own and all of its nested rules are
+                    // deferred to the final pass; don't write a separator
+                    // after such a pass.
+                    if dest.line != line || dest.col != col {
+                        first_rule = false;
+                    }
                 }
             }
 

--- a/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
+++ b/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
@@ -18,7 +18,7 @@ import path from "node:path";
 // the final prefix pass of their ancestor, so the output stays linear in
 // nesting depth.
 
-const { minifyTest } = cssInternals;
+const { minifyTest, prefixTest } = cssInternals;
 
 // Safari 8: `:fullscreen` requires the `-webkit-` prefix and CSS nesting is
 // unsupported, so nesting gets compiled away and selectors get prefixed.
@@ -64,6 +64,16 @@ test("unprefixed nested rules still expand once per ancestor prefix pass", () =>
   expect(output).toBe(":-webkit-full-screen div{color:red}:fullscreen div{color:red}");
 });
 
+test("pretty-printed output has no dangling separators around skipped passes", () => {
+  // Non-minified output: a non-final prefix pass of the outer rule emits
+  // nothing (its only nested rule is prefixed and deferred to the final
+  // pass), so no blank-line separator may be emitted for it either.
+  const output = prefixTest(nestedFullscreen(2, "color: red;"), "", safari8);
+  expect(output).toBe(
+    ":-webkit-full-screen :-webkit-full-screen {\n  color: red;\n}\n\n:fullscreen :fullscreen {\n  color: red;\n}\n",
+  );
+});
+
 test("bun build --target=browser does not blow up on deeply nested prefixed selectors", async () => {
   // Mirrors the fuzzer input: deeply nested `:fullscreen` blocks. The default
   // browser targets (safari 14) require the `-webkit-` prefix for
@@ -95,4 +105,4 @@ test("bun build --target=browser does not blow up on deeply nested prefixed sele
   expect(output.length).toBeLessThan(10_000);
   expect(output).toContain(Array(depth).fill(":-webkit-full-screen").join(" "));
   expect(output).toContain(Array(depth).fill(":fullscreen").join(" "));
-}, 120_000);
+});

--- a/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
+++ b/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
@@ -1,0 +1,98 @@
+import { cssInternals } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import path from "node:path";
+
+// Regression test for exponential output when nested rules are re-serialized
+// once per vendor prefix.
+//
+// When CSS nesting is compiled away for older targets, a style rule whose
+// selector needs vendor prefixes (e.g. `:fullscreen` -> `:-webkit-full-screen`
+// + `:fullscreen`) is serialized once per prefix, and each pass re-serialized
+// *all* of its nested rules. A nested rule that has its own vendor prefixes
+// overrides the printer's prefix, so those re-serializations were exact
+// duplicates — output doubled per nesting level. A ~5 KB stylesheet with a few
+// dozen nested `:fullscreen` levels made the printer allocate gigabytes.
+//
+// Nested rules that carry their own vendor prefixes are now only emitted in
+// the final prefix pass of their ancestor, so the output stays linear in
+// nesting depth.
+
+const { minifyTest } = cssInternals;
+
+// Safari 8: `:fullscreen` requires the `-webkit-` prefix and CSS nesting is
+// unsupported, so nesting gets compiled away and selectors get prefixed.
+const safari8 = { safari: 8 << 16 };
+
+function nestedFullscreen(depth: number, innermost: string): string {
+  let css = "";
+  for (let i = 0; i < depth; i++) {
+    css += ":fullscreen {\n";
+  }
+  css += innermost + "\n";
+  css += "}\n".repeat(depth);
+  return css;
+}
+
+test("prefixed nested rules are not duplicated per ancestor prefix pass", () => {
+  const output = minifyTest(nestedFullscreen(3, "color: red;"), "", safari8);
+  // One rule per prefix variant — not one per combination of ancestor passes.
+  expect(output).toBe(
+    ":-webkit-full-screen :-webkit-full-screen :-webkit-full-screen{color:red}" +
+      ":fullscreen :fullscreen :fullscreen{color:red}",
+  );
+});
+
+test("output stays linear in nesting depth with prefixed nested selectors", () => {
+  const depth = 16;
+  const output = minifyTest(nestedFullscreen(depth, "color: red;"), "", safari8);
+  // Before the fix this was ~2^(depth-1) copies of each rule (tens of MB at
+  // depth 16, gigabytes at the ~28 levels the fuzzer used). Fixed output is
+  // two rules, one per prefix variant.
+  expect(output.length).toBeLessThan(10_000);
+  expect(output).toBe(
+    `${Array(depth).fill(":-webkit-full-screen").join(" ")}{color:red}` +
+      `${Array(depth).fill(":fullscreen").join(" ")}{color:red}`,
+  );
+});
+
+test("unprefixed nested rules still expand once per ancestor prefix pass", () => {
+  // A nested rule without its own vendor prefixes depends on the ancestor's
+  // current prefix pass (its `&` expansion uses it), so it must still be
+  // emitted in every pass.
+  const output = minifyTest(":fullscreen { div { color: red } }", "", safari8);
+  expect(output).toBe(":-webkit-full-screen div{color:red}:fullscreen div{color:red}");
+});
+
+test("bun build --target=browser does not blow up on deeply nested prefixed selectors", async () => {
+  // Mirrors the fuzzer input: deeply nested `:fullscreen` blocks. The default
+  // browser targets (safari 14) require the `-webkit-` prefix for
+  // `:fullscreen` and don't support CSS nesting, so this hits the same path.
+  const depth = 16;
+  using dir = tempDir("css-nested-vendor-prefix", {
+    "app.css": nestedFullscreen(depth, "color: red;"),
+  });
+  const outdir = path.join(String(dir), "out");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", path.join(String(dir), "app.css"), "--target=browser", "--minify", "--outdir", outdir],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    // Before the fix this build tried to materialize an exponentially sized
+    // stylesheet; make a regression fail the assertions below instead of
+    // hanging or OOMing the test runner.
+    timeout: 60_000,
+    killSignal: "SIGKILL",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect({ exitCode, stderr: stderr.includes("error") ? stderr : "" }).toEqual({ exitCode: 0, stderr: "" });
+
+  const output = await Bun.file(path.join(outdir, "app.css")).text();
+  // Two rules (one per prefix variant), each `depth` selectors long.
+  expect(output.length).toBeLessThan(10_000);
+  expect(output).toContain(Array(depth).fill(":-webkit-full-screen").join(" "));
+  expect(output).toContain(Array(depth).fill(":fullscreen").join(" "));
+}, 120_000);

--- a/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
+++ b/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
@@ -74,6 +74,19 @@ test("pretty-printed output has no dangling separators around skipped passes", (
   );
 });
 
+test("pretty-printed output has no dangling separators when the rule has declarations", () => {
+  // The non-final pass prints the rule's own declaration block but defers its
+  // prefixed nested rule to the final pass, so the separator between the
+  // declarations and the nested rules must not be emitted for that pass.
+  const output = prefixTest(":fullscreen { color: green; :fullscreen { color: red } }", "", safari8);
+  expect(output).toBe(
+    ":-webkit-full-screen {\n  color: green;\n}\n\n" +
+      ":fullscreen {\n  color: green;\n}\n\n" +
+      ":-webkit-full-screen :-webkit-full-screen {\n  color: red;\n}\n\n" +
+      ":fullscreen :fullscreen {\n  color: red;\n}\n",
+  );
+});
+
 test("bun build --target=browser does not blow up on deeply nested prefixed selectors", async () => {
   // Mirrors the fuzzer input: deeply nested `:fullscreen` blocks. The default
   // browser targets (safari 14) require the `-webkit-` prefix for


### PR DESCRIPTION
### What does this PR do?

Fixes an OOM found by fuzzing in the CSS printer: a ~4.8 KB stylesheet of deeply nested `:fullscreen` blocks makes re-serialization allocate multiple gigabytes when browser targets are set (including the bundler's **default** `--target=browser` targets).

```sh
# before: >4 GB RSS, aborts with "memory allocation of ... failed"
# after:  1.9 KB output file
bun build app.css --target=browser --minify
```

where `app.css` is ~28 levels of nested `:fullscreen { ... }` rules (fuzzer signature `oom:css:…serialize_selector|…serialize_nesting|…serialize_selector|…serialize_selector_list|…StyleRule::to_css_base`).

### Cause

When CSS nesting is compiled away for older targets, `StyleRule::to_css` serializes the rule once per vendor prefix (`:fullscreen` → `:-webkit-full-screen` + `:fullscreen` for e.g. Safari 14), and **each prefix pass re-serializes all nested rules**. A nested rule that has its own vendor prefixes immediately overrides `dest.vendor_prefix` with its own prefix loop, so its output is byte-for-byte identical in every ancestor pass — each nesting level doubles the output. At 28 levels that's 2²⁷ copies of the leaf rules → OOM. (The re-serialized copies are exact duplicates; with one prefixed selector per level only two distinct rules ever exist.)

### Fix

Track the vendor-prefix pass in `StyleRule::to_css` and, while re-serializing nested rules for a **non-final** pass, skip nested style rules that carry their own vendor prefixes (`Printer.skip_prefixed_nested_rules`). They are emitted exactly once, in the ancestor's final pass. Nested rules **without** their own prefixes still print in every pass, because their `&` expansion depends on the current prefix.

Output is semantically unchanged — the same set of rules is emitted, just without the exact duplicates — and grows linearly with nesting depth instead of exponentially.

### Verification

- New test `test/js/bun/css/nested-vendor-prefix-duplication.test.ts`:
  - exact minified output for 3 nested prefixed levels (no duplicates)
  - depth-16 output stays linear (was ~18 MB before, 2 rules after)
  - unprefixed nested rules still expand once per ancestor prefix pass (behavior preserved)
  - `bun build --target=browser --minify` on the nested input produces a small file
  - fails on the unfixed build (3/4 tests), passes with the fix
- Original fuzzer input: `minifyTest(input, "", {safari: 8<<16})` now returns 1,892 bytes (previously aborted >4 GB); the no-targets repro output is byte-identical before/after.
- `test/js/bun/css/` (2018 tests) and `test/bundler/css/` + `test/bundler/esbuild/css.test.ts` (219 tests) pass with the fix.
