### PR TITLE
Fix quadratic blowup in Bun.markdown on unterminated inline HTML openers

### DIFF
--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -61,25 +61,6 @@ pub enum HtmlScanKind {
 
 pub const HTML_SCAN_KIND_COUNT: usize = 4;
 
-#[derive(Clone, Copy)]
-struct HtmlScanMemoEntry {
-    slice_addr: usize,
-    slice_len: usize,
-    no_terminator_from: [usize; HTML_SCAN_KIND_COUNT],
-}
-
-impl HtmlScanMemoEntry {
-    const EMPTY: HtmlScanMemoEntry = HtmlScanMemoEntry {
-        slice_addr: 0,
-        slice_len: 0,
-        no_terminator_from: [usize::MAX; HTML_SCAN_KIND_COUNT],
-    };
-
-    fn applies_to(&self, content: &[u8]) -> bool {
-        self.slice_addr == content.as_ptr() as usize && self.slice_len == content.len()
-    }
-}
-
 /// Memo of failed closing-delimiter searches in `find_html_tag`.
 ///
 /// A `<!--` / `<?` / `<!DECL` / `<![CDATA[` candidate scans forward for a
@@ -90,24 +71,30 @@ impl HtmlScanMemoEntry {
 /// rescan is quadratic on inputs with many unterminated openers in one
 /// paragraph (found by fuzzing).
 ///
-/// Entries are keyed to the content slice identity (address + length) because
-/// `find_html_tag` is also called on link-label sub-slices with their own
-/// coordinates. Two recency-ordered entries are kept so a label scan cannot
-/// evict the enclosing slice's entry (the two interleave once per link
-/// candidate, which would otherwise rescan the paragraph per link).
-/// `process_inline_content` starts each slice from an empty memo and restores
-/// the caller's memo on return, so recycled merged-line buffers and transient
-/// table-cell buffers can never alias a previous slice's entries.
+/// The memo describes one slice at a time and is keyed to that slice's
+/// identity (address + length). Every scope that scans a different slice —
+/// `process_inline_content` for each paragraph, table cell or recursively
+/// rendered link label, and `label_contains_link` for its label walk — starts
+/// from an empty memo and restores the caller's memo when it returns, so
+/// scans for different slices never evict each other's state and recycled or
+/// transient buffers can never alias a previous slice's entry.
 #[derive(Clone, Copy)]
 pub struct HtmlScanMemo {
-    /// `entries[0]` is the most recently used.
-    entries: [HtmlScanMemoEntry; 2],
+    slice_addr: usize,
+    slice_len: usize,
+    no_terminator_from: [usize; HTML_SCAN_KIND_COUNT],
 }
 
 impl HtmlScanMemo {
     pub const EMPTY: HtmlScanMemo = HtmlScanMemo {
-        entries: [HtmlScanMemoEntry::EMPTY; 2],
+        slice_addr: 0,
+        slice_len: 0,
+        no_terminator_from: [usize::MAX; HTML_SCAN_KIND_COUNT],
     };
+
+    fn applies_to(&self, content: &[u8]) -> bool {
+        self.slice_addr == content.as_ptr() as usize && self.slice_len == content.len()
+    }
 }
 
 impl Parser<'_> {
@@ -811,38 +798,20 @@ impl Parser<'_> {
         kind: HtmlScanKind,
         scan_start: usize,
     ) -> bool {
-        let mut memo = self.html_scan_memo.get();
-        let Some(idx) = memo.entries.iter().position(|e| e.applies_to(content)) else {
-            return false;
-        };
-        if idx != 0 {
-            memo.entries.swap(0, idx);
-            self.html_scan_memo.set(memo);
-        }
-        scan_start >= memo.entries[0].no_terminator_from[kind as usize]
+        let memo = self.html_scan_memo.get();
+        memo.applies_to(content) && scan_start >= memo.no_terminator_from[kind as usize]
     }
 
     /// Record that the search for `kind`'s terminator starting at `scan_start`
     /// reached the end of `content` without a match.
     fn note_unterminated_html_scan(&self, content: &[u8], kind: HtmlScanKind, scan_start: usize) {
         let mut memo = self.html_scan_memo.get();
-        match memo.entries.iter().position(|e| e.applies_to(content)) {
-            Some(idx) => {
-                if idx != 0 {
-                    memo.entries.swap(0, idx);
-                }
-            }
-            None => {
-                // Evict the least recently used entry.
-                memo.entries[1] = HtmlScanMemoEntry {
-                    slice_addr: content.as_ptr() as usize,
-                    slice_len: content.len(),
-                    no_terminator_from: [usize::MAX; HTML_SCAN_KIND_COUNT],
-                };
-                memo.entries.swap(0, 1);
-            }
+        if !memo.applies_to(content) {
+            memo = HtmlScanMemo::EMPTY;
+            memo.slice_addr = content.as_ptr() as usize;
+            memo.slice_len = content.len();
         }
-        let slot = &mut memo.entries[0].no_terminator_from[kind as usize];
+        let slot = &mut memo.no_terminator_from[kind as usize];
         *slot = (*slot).min(scan_start);
         self.html_scan_memo.set(memo);
     }

--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -61,6 +61,25 @@ pub enum HtmlScanKind {
 
 pub const HTML_SCAN_KIND_COUNT: usize = 4;
 
+#[derive(Clone, Copy)]
+struct HtmlScanMemoEntry {
+    slice_addr: usize,
+    slice_len: usize,
+    no_terminator_from: [usize; HTML_SCAN_KIND_COUNT],
+}
+
+impl HtmlScanMemoEntry {
+    const EMPTY: HtmlScanMemoEntry = HtmlScanMemoEntry {
+        slice_addr: 0,
+        slice_len: 0,
+        no_terminator_from: [usize::MAX; HTML_SCAN_KIND_COUNT],
+    };
+
+    fn applies_to(&self, content: &[u8]) -> bool {
+        self.slice_addr == content.as_ptr() as usize && self.slice_len == content.len()
+    }
+}
+
 /// Memo of failed closing-delimiter searches in `find_html_tag`.
 ///
 /// A `<!--` / `<?` / `<!DECL` / `<![CDATA[` candidate scans forward for a
@@ -71,27 +90,24 @@ pub const HTML_SCAN_KIND_COUNT: usize = 4;
 /// rescan is quadratic on inputs with many unterminated openers in one
 /// paragraph (found by fuzzing).
 ///
-/// The memo is keyed to the content slice identity (address + length) because
+/// Entries are keyed to the content slice identity (address + length) because
 /// `find_html_tag` is also called on link-label sub-slices with their own
-/// coordinates; `process_inline_content` clears it per slice so recycled
-/// merged-line buffers can never alias a previous block's entries.
+/// coordinates. Two recency-ordered entries are kept so a label scan cannot
+/// evict the enclosing slice's entry (the two interleave once per link
+/// candidate, which would otherwise rescan the paragraph per link).
+/// `process_inline_content` starts each slice from an empty memo and restores
+/// the caller's memo on return, so recycled merged-line buffers and transient
+/// table-cell buffers can never alias a previous slice's entries.
 #[derive(Clone, Copy)]
 pub struct HtmlScanMemo {
-    slice_addr: usize,
-    slice_len: usize,
-    no_terminator_from: [usize; HTML_SCAN_KIND_COUNT],
+    /// `entries[0]` is the most recently used.
+    entries: [HtmlScanMemoEntry; 2],
 }
 
 impl HtmlScanMemo {
     pub const EMPTY: HtmlScanMemo = HtmlScanMemo {
-        slice_addr: 0,
-        slice_len: 0,
-        no_terminator_from: [usize::MAX; HTML_SCAN_KIND_COUNT],
+        entries: [HtmlScanMemoEntry::EMPTY; 2],
     };
-
-    fn applies_to(&self, content: &[u8]) -> bool {
-        self.slice_addr == content.as_ptr() as usize && self.slice_len == content.len()
-    }
 }
 
 impl Parser<'_> {
@@ -149,10 +165,12 @@ impl Parser<'_> {
             return Err(parser::Error::StackOverflow);
         }
 
-        // Failed HTML terminator searches recorded for a previous slice must
-        // not leak into this one (the merged-line buffer is recycled across
-        // blocks, so a stale entry could alias a new slice of the same length).
-        self.html_scan_memo.set(HtmlScanMemo::EMPTY);
+        // Failed HTML terminator searches recorded for another slice must not
+        // leak into this one (the merged-line buffer is recycled across blocks,
+        // so a stale entry could alias a new slice of the same length). The
+        // caller's memo is restored on return so a recursive call for a link
+        // label does not throw away what the enclosing slice already learned.
+        let outer_html_scan_memo = self.html_scan_memo.replace(HtmlScanMemo::EMPTY);
 
         // Bracket-pair map for this slice: link processing looks up the ']'
         // matching a '[' here instead of rescanning the rest of the slice for
@@ -473,6 +491,9 @@ impl Parser<'_> {
         }
         // Hand the bracket-map storage back for reuse by the next block.
         self.bracket_pairs = brackets.into_storage();
+        // Restore the enclosing slice's memo (the entries built for this slice
+        // are meaningless to the caller).
+        self.html_scan_memo.set(outer_html_scan_memo);
         Ok(())
     }
 
@@ -790,20 +811,38 @@ impl Parser<'_> {
         kind: HtmlScanKind,
         scan_start: usize,
     ) -> bool {
-        let memo = self.html_scan_memo.get();
-        memo.applies_to(content) && scan_start >= memo.no_terminator_from[kind as usize]
+        let mut memo = self.html_scan_memo.get();
+        let Some(idx) = memo.entries.iter().position(|e| e.applies_to(content)) else {
+            return false;
+        };
+        if idx != 0 {
+            memo.entries.swap(0, idx);
+            self.html_scan_memo.set(memo);
+        }
+        scan_start >= memo.entries[0].no_terminator_from[kind as usize]
     }
 
     /// Record that the search for `kind`'s terminator starting at `scan_start`
     /// reached the end of `content` without a match.
     fn note_unterminated_html_scan(&self, content: &[u8], kind: HtmlScanKind, scan_start: usize) {
         let mut memo = self.html_scan_memo.get();
-        if !memo.applies_to(content) {
-            memo = HtmlScanMemo::EMPTY;
-            memo.slice_addr = content.as_ptr() as usize;
-            memo.slice_len = content.len();
+        match memo.entries.iter().position(|e| e.applies_to(content)) {
+            Some(idx) => {
+                if idx != 0 {
+                    memo.entries.swap(0, idx);
+                }
+            }
+            None => {
+                // Evict the least recently used entry.
+                memo.entries[1] = HtmlScanMemoEntry {
+                    slice_addr: content.as_ptr() as usize,
+                    slice_len: content.len(),
+                    no_terminator_from: [usize::MAX; HTML_SCAN_KIND_COUNT],
+                };
+                memo.entries.swap(0, 1);
+            }
         }
-        let slot = &mut memo.no_terminator_from[kind as usize];
+        let slot = &mut memo.entries[0].no_terminator_from[kind as usize];
         *slot = (*slot).min(scan_start);
         self.html_scan_memo.set(memo);
     }

--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -66,18 +66,20 @@ pub const HTML_SCAN_KIND_COUNT: usize = 4;
 /// A `<!--` / `<?` / `<!DECL` / `<![CDATA[` candidate scans forward for a
 /// terminator that may not exist, reaching the end of the inline slice. Once
 /// one such scan has failed from some position, any later scan of the same
-/// kind over the same slice starting at or beyond that position must fail
-/// too, so it can return immediately instead of rescanning to the end — that
-/// rescan is quadratic on inputs with many unterminated openers in one
-/// paragraph (found by fuzzing).
+/// kind starting at or beyond that position must fail too, so it can return
+/// immediately instead of rescanning to the end — that rescan is quadratic on
+/// inputs with many unterminated openers in one paragraph (found by fuzzing).
 ///
-/// The memo describes one slice at a time and is keyed to that slice's
-/// identity (address + length). Every scope that scans a different slice —
-/// `process_inline_content` for each paragraph, table cell or recursively
-/// rendered link label, and `label_contains_link` for its label walk — starts
-/// from an empty memo and restores the caller's memo when it returns, so
-/// scans for different slices never evict each other's state and recycled or
-/// transient buffers can never alias a previous slice's entry.
+/// The memo describes one slice at a time, keyed by address + length. Because
+/// `find_html_tag` is also called on link-label sub-slices of that slice (with
+/// their own coordinates), a recorded fact serves any sub-slice query by
+/// translating positions with the sub-slice's offset: "no terminator at or
+/// after position P of the paragraph" covers every later position of every
+/// label inside it. Sub-slice scans never overwrite the enclosing slice's
+/// entry (they prove nothing beyond their own extent), and
+/// `process_inline_content` starts each slice from an empty memo and restores
+/// the caller's on return, so recycled merged-line buffers and transient
+/// table-cell buffers can never alias a previous slice's entry.
 #[derive(Clone, Copy)]
 pub struct HtmlScanMemo {
     slice_addr: usize,
@@ -94,6 +96,17 @@ impl HtmlScanMemo {
 
     fn applies_to(&self, content: &[u8]) -> bool {
         self.slice_addr == content.as_ptr() as usize && self.slice_len == content.len()
+    }
+
+    /// If `content` lies within the memoized slice, returns its offset from
+    /// that slice's start (0 for the memoized slice itself).
+    fn offset_within(&self, content: &[u8]) -> Option<usize> {
+        let addr = content.as_ptr() as usize;
+        if self.slice_addr <= addr && addr + content.len() <= self.slice_addr + self.slice_len {
+            Some(addr - self.slice_addr)
+        } else {
+            None
+        }
     }
 }
 
@@ -790,8 +803,9 @@ impl Parser<'_> {
         helpers::find_entity(content, start)
     }
 
-    /// True if a previous scan over this same `content` slice already proved
-    /// there is no `kind` terminator at or after `scan_start`.
+    /// True if a previous scan already proved there is no `kind` terminator at
+    /// or after `scan_start` of `content` — either recorded for `content`
+    /// itself or for an enclosing slice that contains it.
     fn html_scan_known_unterminated(
         &self,
         content: &[u8],
@@ -799,7 +813,10 @@ impl Parser<'_> {
         scan_start: usize,
     ) -> bool {
         let memo = self.html_scan_memo.get();
-        memo.applies_to(content) && scan_start >= memo.no_terminator_from[kind as usize]
+        let Some(offset) = memo.offset_within(content) else {
+            return false;
+        };
+        offset + scan_start >= memo.no_terminator_from[kind as usize]
     }
 
     /// Record that the search for `kind`'s terminator starting at `scan_start`
@@ -807,6 +824,13 @@ impl Parser<'_> {
     fn note_unterminated_html_scan(&self, content: &[u8], kind: HtmlScanKind, scan_start: usize) {
         let mut memo = self.html_scan_memo.get();
         if !memo.applies_to(content) {
+            if memo.offset_within(content).is_some() {
+                // A sub-slice scan stops at the sub-slice's end, so it proves
+                // nothing about the rest of the enclosing slice; keep the
+                // enclosing entry (it already answers the sub-slice's later
+                // queries via offset_within).
+                return;
+            }
             memo = HtmlScanMemo::EMPTY;
             memo.slice_addr = content.as_ptr() as usize;
             memo.slice_len = content.len();

--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -46,6 +46,54 @@ impl Default for EmphDelim {
     }
 }
 
+/// Closing-delimiter kinds tracked by `HtmlScanMemo`.
+#[derive(Clone, Copy)]
+pub enum HtmlScanKind {
+    /// `<!--` … `-->`
+    Comment = 0,
+    /// `<?` … `?>`
+    ProcessingInstruction = 1,
+    /// `<!` + uppercase letter … `>`
+    Declaration = 2,
+    /// `<![CDATA[` … `]]>`
+    Cdata = 3,
+}
+
+pub const HTML_SCAN_KIND_COUNT: usize = 4;
+
+/// Memo of failed closing-delimiter searches in `find_html_tag`.
+///
+/// A `<!--` / `<?` / `<!DECL` / `<![CDATA[` candidate scans forward for a
+/// terminator that may not exist, reaching the end of the inline slice. Once
+/// one such scan has failed from some position, any later scan of the same
+/// kind over the same slice starting at or beyond that position must fail
+/// too, so it can return immediately instead of rescanning to the end — that
+/// rescan is quadratic on inputs with many unterminated openers in one
+/// paragraph (found by fuzzing).
+///
+/// The memo is keyed to the content slice identity (address + length) because
+/// `find_html_tag` is also called on link-label sub-slices with their own
+/// coordinates; `process_inline_content` clears it per slice so recycled
+/// merged-line buffers can never alias a previous block's entries.
+#[derive(Clone, Copy)]
+pub struct HtmlScanMemo {
+    slice_addr: usize,
+    slice_len: usize,
+    no_terminator_from: [usize; HTML_SCAN_KIND_COUNT],
+}
+
+impl HtmlScanMemo {
+    pub const EMPTY: HtmlScanMemo = HtmlScanMemo {
+        slice_addr: 0,
+        slice_len: 0,
+        no_terminator_from: [usize::MAX; HTML_SCAN_KIND_COUNT],
+    };
+
+    fn applies_to(&self, content: &[u8]) -> bool {
+        self.slice_addr == content.as_ptr() as usize && self.slice_len == content.len()
+    }
+}
+
 impl Parser<'_> {
     /// Merge all lines into buffer with \n between them (unmodified),
     /// then process inlines on the merged text. Hard/soft breaks are detected
@@ -100,6 +148,11 @@ impl Parser<'_> {
         if !self.stack_check.is_safe_to_recurse() {
             return Err(parser::Error::StackOverflow);
         }
+
+        // Failed HTML terminator searches recorded for a previous slice must
+        // not leak into this one (the merged-line buffer is recycled across
+        // blocks, so a stale entry could alias a new slice of the same length).
+        self.html_scan_memo.set(HtmlScanMemo::EMPTY);
 
         // Bracket-pair map for this slice: link processing looks up the ']'
         // matching a '[' here instead of rescanning the rest of the slice for
@@ -729,6 +782,32 @@ impl Parser<'_> {
         helpers::find_entity(content, start)
     }
 
+    /// True if a previous scan over this same `content` slice already proved
+    /// there is no `kind` terminator at or after `scan_start`.
+    fn html_scan_known_unterminated(
+        &self,
+        content: &[u8],
+        kind: HtmlScanKind,
+        scan_start: usize,
+    ) -> bool {
+        let memo = self.html_scan_memo.get();
+        memo.applies_to(content) && scan_start >= memo.no_terminator_from[kind as usize]
+    }
+
+    /// Record that the search for `kind`'s terminator starting at `scan_start`
+    /// reached the end of `content` without a match.
+    fn note_unterminated_html_scan(&self, content: &[u8], kind: HtmlScanKind, scan_start: usize) {
+        let mut memo = self.html_scan_memo.get();
+        if !memo.applies_to(content) {
+            memo = HtmlScanMemo::EMPTY;
+            memo.slice_addr = content.as_ptr() as usize;
+            memo.slice_len = content.len();
+        }
+        let slot = &mut memo.no_terminator_from[kind as usize];
+        *slot = (*slot).min(scan_start);
+        self.html_scan_memo.set(memo);
+    }
+
     pub fn find_html_tag(&self, content: &[u8], start: usize) -> Option<usize> {
         if start + 1 >= content.len() {
             return None;
@@ -774,12 +853,17 @@ impl Parser<'_> {
             if pos + 1 < content.len() && content[pos] == b'-' && content[pos + 1] == b'>' {
                 return Some(pos + 2);
             }
+            if self.html_scan_known_unterminated(content, HtmlScanKind::Comment, pos) {
+                return None;
+            }
+            let scan_start = pos;
             while pos + 2 < content.len() {
                 if content[pos] == b'-' && content[pos + 1] == b'-' && content[pos + 2] == b'>' {
                     return Some(pos + 3);
                 }
                 pos += 1;
             }
+            self.note_unterminated_html_scan(content, HtmlScanKind::Comment, scan_start);
             return None;
         }
 
@@ -790,12 +874,17 @@ impl Parser<'_> {
             && content[pos + 1] <= b'Z'
         {
             pos += 2;
+            if self.html_scan_known_unterminated(content, HtmlScanKind::Declaration, pos) {
+                return None;
+            }
+            let scan_start = pos;
             while pos < content.len() && content[pos] != b'>' {
                 pos += 1;
             }
             if pos < content.len() {
                 return Some(pos + 1);
             }
+            self.note_unterminated_html_scan(content, HtmlScanKind::Declaration, scan_start);
             return None;
         }
 
@@ -811,24 +900,39 @@ impl Parser<'_> {
             && content[pos + 7] == b'['
         {
             pos += 8;
+            if self.html_scan_known_unterminated(content, HtmlScanKind::Cdata, pos) {
+                return None;
+            }
+            let scan_start = pos;
             while pos + 2 < content.len() {
                 if content[pos] == b']' && content[pos + 1] == b']' && content[pos + 2] == b'>' {
                     return Some(pos + 3);
                 }
                 pos += 1;
             }
+            self.note_unterminated_html_scan(content, HtmlScanKind::Cdata, scan_start);
             return None;
         }
 
         // Processing instruction: <? ... ?>
         if c == b'?' {
             pos += 1;
+            if self.html_scan_known_unterminated(content, HtmlScanKind::ProcessingInstruction, pos)
+            {
+                return None;
+            }
+            let scan_start = pos;
             while pos + 1 < content.len() {
                 if content[pos] == b'?' && content[pos + 1] == b'>' {
                     return Some(pos + 2);
                 }
                 pos += 1;
             }
+            self.note_unterminated_html_scan(
+                content,
+                HtmlScanKind::ProcessingInstruction,
+                scan_start,
+            );
             return None;
         }
 

--- a/src/md/links.rs
+++ b/src/md/links.rs
@@ -734,13 +734,6 @@ impl Parser<'_> {
         brackets: &BracketMatches,
         base: usize,
     ) -> bool {
-        // This walk scans `label` sub-slices with find_html_tag, which keys its
-        // unterminated-scan memo by slice; give the walk its own memo and hand
-        // the enclosing slice's back afterwards so the enclosing scan does not
-        // lose what it already learned (rescanning it per link candidate is
-        // quadratic on link floods with unterminated HTML openers).
-        let outer_html_scan_memo = self.html_scan_memo.replace(inlines::HtmlScanMemo::EMPTY);
-        let mut found = false;
         let mut pos: usize = 0;
         while pos < label.len() {
             if label[pos] == b'\\' && pos + 1 < label.len() {
@@ -776,8 +769,7 @@ impl Parser<'_> {
                 // Try to find matching ] and check for link syntax
                 let inner = self.try_match_bracket_link(label, pos, brackets, base);
                 if inner.is_link && !is_inner_image {
-                    found = true;
-                    break;
+                    return true;
                 }
                 if inner.link_end > pos {
                     // Skip past entire construct (including (url) or [ref] for images)
@@ -787,8 +779,7 @@ impl Parser<'_> {
             }
             pos += 1;
         }
-        self.html_scan_memo.set(outer_html_scan_memo);
-        found
+        false
     }
 
     /// Process wiki link: [[destination]] or [[destination|label]]

--- a/src/md/links.rs
+++ b/src/md/links.rs
@@ -734,6 +734,13 @@ impl Parser<'_> {
         brackets: &BracketMatches,
         base: usize,
     ) -> bool {
+        // This walk scans `label` sub-slices with find_html_tag, which keys its
+        // unterminated-scan memo by slice; give the walk its own memo and hand
+        // the enclosing slice's back afterwards so the enclosing scan does not
+        // lose what it already learned (rescanning it per link candidate is
+        // quadratic on link floods with unterminated HTML openers).
+        let outer_html_scan_memo = self.html_scan_memo.replace(inlines::HtmlScanMemo::EMPTY);
+        let mut found = false;
         let mut pos: usize = 0;
         while pos < label.len() {
             if label[pos] == b'\\' && pos + 1 < label.len() {
@@ -769,7 +776,8 @@ impl Parser<'_> {
                 // Try to find matching ] and check for link syntax
                 let inner = self.try_match_bracket_link(label, pos, brackets, base);
                 if inner.is_link && !is_inner_image {
-                    return true;
+                    found = true;
+                    break;
                 }
                 if inner.link_end > pos {
                     // Skip past entire construct (including (url) or [ref] for images)
@@ -779,7 +787,8 @@ impl Parser<'_> {
             }
             pos += 1;
         }
-        false
+        self.html_scan_memo.set(outer_html_scan_memo);
+        found
     }
 
     /// Process wiki link: [[destination]] or [[destination|label]]

--- a/src/md/parser.rs
+++ b/src/md/parser.rs
@@ -1,5 +1,6 @@
 // Sub-modules
 
+use core::cell::Cell;
 use core::ffi::c_void;
 
 use bun_collections::bit_set::{ArrayBitSet, num_masks_for};
@@ -23,7 +24,7 @@ use crate::RenderOptions; // Zig: `root.RenderOptions` (root.zig → crate lib.r
 
 // Re-exports that Zig nested under `Parser.*` — Rust has no struct-scoped type
 // aliases, so they live at module scope as `parser::EmphDelim` etc.
-pub use super::inlines::{EmphDelim, MAX_EMPH_MATCHES};
+pub use super::inlines::{EmphDelim, HtmlScanMemo, MAX_EMPH_MATCHES};
 pub use super::ref_defs::RefDef;
 
 /// Parser context holding all state during parsing.
@@ -61,6 +62,10 @@ pub struct Parser<'a> {
     // Scratch storage recycled by compute_bracket_matches (links.rs) so inline
     // processing does not allocate a bracket-pair map per block.
     pub bracket_pairs: Vec<(OFF, OFF)>,
+    // Memo of failed closing-delimiter searches in find_html_tag (inlines.rs).
+    // Cell because find_html_tag is a &self query reached from both &self and
+    // &mut self scanners.
+    pub html_scan_memo: Cell<HtmlScanMemo>,
 
     // Number of active containers
     pub n_containers: u32,
@@ -192,6 +197,7 @@ impl<'a> Parser<'a> {
             buffer: Vec::new(),
             emph_delims: Vec::new(),
             bracket_pairs: Vec::new(),
+            html_scan_memo: Cell::new(HtmlScanMemo::EMPTY),
             n_containers: 0,
             current_block: None,
             current_block_lines: Vec::new(),

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -695,6 +695,7 @@ describe("pathological inline HTML inputs", () => {
           ["reference links between unterminated comments", "[r]: /u\\n\\n" + fill(20000, "[a][r] <!-- x "), out => out.includes('<a href="/u">') && out.includes("&lt;!-- x")],
           ["one link with a comment-flooded label", "[" + fill(40000, "<!-- x ") + "](u)", out => out.includes('<a href="u">') && out.includes("&lt;!-- x")],
           ["comment-label link before a comment-flooded label", "[<!-- a](u)[" + fill(40000, "<!-- x ") + "](v) <!-- tail", out => out.includes('<a href="v">') && out.includes("&lt;!-- tail")],
+          ["nested comment-label links", fill(20000, "[<!-- ") + "x" + fill(20000, "](u)"), out => out.includes('<a href="u">') && out.includes("[&lt;!--")],
         ];
         for (const [name, input, check] of cases) {
           const out = Bun.markdown.html(input);
@@ -752,6 +753,11 @@ describe("pathological inline HTML inputs", () => {
     );
     expect(Markdown.html("[<!-- a](u)[<!-- b](v) <!-- c\n")).toBe(
       '<p><a href="u">&lt;!-- a</a><a href="v">&lt;!-- b</a> &lt;!-- c</p>\n',
+    );
+    // Nested link candidates: only the innermost is a link (links cannot
+    // contain links), and the unterminated openers at every level stay text.
+    expect(Markdown.html("[<!-- [<!-- [<!-- x](u)](u)](u)\n")).toBe(
+      '<p>[&lt;!-- [&lt;!-- <a href="u">&lt;!-- x</a>](u)](u)</p>\n',
     );
   });
 });

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -653,3 +653,83 @@ describe("pathological bracket inputs", () => {
     expect(Markdown.html(wiki(40), { wikiLinks: true })).not.toContain('data-target="t"');
   });
 });
+
+// ============================================================================
+// Pathological inputs: unterminated inline HTML openers. Every `<!--` / `<?` /
+// `<!DECL` / `<![CDATA[` candidate used to rescan from its own position to the
+// end of the paragraph for a terminator that never appears, so a paragraph
+// with many such openers was O(n²) (found by fuzzing: a ~260 KB flood of
+// bracket runs + `<!--` spun in find_html_tag). The child process is killed
+// after 30s so a regression fails fast instead of hanging the test runner.
+// ============================================================================
+
+describe("pathological inline HTML inputs", () => {
+  async function expectRendersQuickly(script: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 30_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("DONE");
+    expect(exitCode).toBe(0);
+  }
+
+  test("unterminated inline HTML openers render in linear time", async () => {
+    await expectRendersQuickly(`
+        const fill = (n, unit) => Buffer.alloc(n * unit.length, unit).toString();
+        const cases = [
+          ["unterminated comments", fill(100000, "x <!-- y --\\n"), out => out.includes("&lt;!-- y")],
+          ["unterminated processing instructions", fill(100000, "x <? y\\n"), out => out.includes("&lt;? y")],
+          ["unterminated declarations", fill(100000, "x <!DOCTYPE y\\n"), out => out.includes("&lt;!DOCTYPE y")],
+          ["unterminated CDATA sections", fill(100000, "x <![CDATA[ y\\n"), out => out.includes("&lt;![CDATA[ y")],
+          ["bracket runs with unterminated comments", fill(20000, "[[[[[[[ foo <!-- this is a --\\n"), out => out.includes("[[[[[[[") && out.includes("&lt;!--")],
+        ];
+        for (const [name, input, check] of cases) {
+          const out = Bun.markdown.html(input);
+          if (!check(out)) throw new Error("unexpected output for " + name + ": " + JSON.stringify(out.slice(0, 200)));
+          console.log("OK " + name);
+        }
+        // The fuzzer hit this through the custom-renderer API — exercise it too.
+        if (typeof Bun.markdown.render(fill(20000, "[[[[[[[ foo <!-- this is a --\\n"), {}) !== "string") {
+          throw new Error("render() did not return a string");
+        }
+        console.log("DONE");
+      `);
+  }, 90_000);
+
+  test("unterminated inline HTML openers stay escaped text", () => {
+    expect(Markdown.html("a <!-- b\n")).toBe("<p>a &lt;!-- b</p>\n");
+    expect(Markdown.html("a <? b\n")).toBe("<p>a &lt;? b</p>\n");
+    expect(Markdown.html("a <!D b\n")).toBe("<p>a &lt;!D b</p>\n");
+    expect(Markdown.html("a <![CDATA[ b\n")).toBe("<p>a &lt;![CDATA[ b</p>\n");
+  });
+
+  test("a terminated HTML span after an unterminated opener of another kind is still recognized", () => {
+    // The failed `<?` scan must not suppress the later `<!-- c -->` comment.
+    expect(Markdown.html("a <? x y <!-- c --> d\n")).toBe("<p>a &lt;? x y <!-- c --> d</p>\n");
+    // And the other way around: a failed `<!--` scan with a later `?>`-less `<?`.
+    expect(Markdown.html("a <!-- x y <? c d\n")).toBe("<p>a &lt;!-- x y &lt;? c d</p>\n");
+  });
+
+  test("inline comments spanning multiple lines still become raw HTML", () => {
+    expect(Markdown.html("before <!-- mid\nstill comment --> after\n")).toBe(
+      "<p>before <!-- mid\nstill comment --> after</p>\n",
+    );
+    expect(Markdown.html("x <!-- y -- z <!--> w\n")).toBe("<p>x <!-- y -- z <!--> w</p>\n");
+  });
+
+  test("consecutive same-length paragraphs do not share unterminated-scan state", () => {
+    // Both paragraphs merge to 12-byte inline slices; the recycled buffer must
+    // not carry the first paragraph's failed `-->` search into the second.
+    expect(Markdown.html("a <!-- bcdef\n\na <!-- b -->\n")).toBe("<p>a &lt;!-- bcdef</p>\n<p>a <!-- b --></p>\n");
+  });
+
+  test("unterminated comment openers inside link labels keep the surrounding text literal", () => {
+    expect(Markdown.html("[t <!-- u](v) <!-- w --> q\n")).toBe("<p>[t <!-- u](v) <!-- w --> q</p>\n");
+  });
+});

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -688,6 +688,11 @@ describe("pathological inline HTML inputs", () => {
           ["unterminated declarations", fill(100000, "x <!DOCTYPE y\\n"), out => out.includes("&lt;!DOCTYPE y")],
           ["unterminated CDATA sections", fill(100000, "x <![CDATA[ y\\n"), out => out.includes("&lt;![CDATA[ y")],
           ["bracket runs with unterminated comments", fill(20000, "[[[[[[[ foo <!-- this is a --\\n"), out => out.includes("[[[[[[[") && out.includes("&lt;!--")],
+          ["inline links between unterminated comments", fill(20000, "[a](b) <!-- x "), out => out.includes('<a href="b">') && out.includes("&lt;!-- x")],
+          ["unterminated comments inside link labels", fill(20000, "[<!-- x](u) <!-- y "), out => out.includes('<a href="u">') && out.includes("&lt;!-- y")],
+          ["images between unterminated comments", fill(20000, "![a](b) <!-- x "), out => out.includes("<img") && out.includes("&lt;!-- x")],
+          ["reference links between unterminated comments", "[r]: /u\\n\\n" + fill(20000, "[a][r] <!-- x "), out => out.includes('<a href="/u">') && out.includes("&lt;!-- x")],
+          ["one link with a comment-flooded label", "[" + fill(40000, "<!-- x ") + "](u)", out => out.includes('<a href="u">') && out.includes("&lt;!-- x")],
         ];
         for (const [name, input, check] of cases) {
           const out = Bun.markdown.html(input);
@@ -731,5 +736,17 @@ describe("pathological inline HTML inputs", () => {
 
   test("unterminated comment openers inside link labels keep the surrounding text literal", () => {
     expect(Markdown.html("[t <!-- u](v) <!-- w --> q\n")).toBe("<p>[t <!-- u](v) <!-- w --> q</p>\n");
+  });
+
+  test("links and images interleaved with unterminated comment openers render unchanged", () => {
+    expect(Markdown.html("[a](b) <!-- x [a](b)\n")).toBe('<p><a href="b">a</a> &lt;!-- x <a href="b">a</a></p>\n');
+    expect(Markdown.html("[<!-- x](u) <!-- y\n")).toBe('<p><a href="u">&lt;!-- x</a> &lt;!-- y</p>\n');
+    expect(Markdown.html("![<!-- x](u) <!-- y\n")).toBe('<p><img src="u" alt="&lt;!-- x" /> &lt;!-- y</p>\n');
+    expect(Markdown.html("[r]: /u\n\n[a][r] <!-- x [a][r]\n")).toBe(
+      '<p><a href="/u">a</a> &lt;!-- x <a href="/u">a</a></p>\n',
+    );
+    expect(Markdown.html("[<!-- x <!-- x <!-- x ](u)\n")).toBe(
+      '<p><a href="u">&lt;!-- x &lt;!-- x &lt;!-- x </a></p>\n',
+    );
   });
 });

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -690,9 +690,11 @@ describe("pathological inline HTML inputs", () => {
           ["bracket runs with unterminated comments", fill(20000, "[[[[[[[ foo <!-- this is a --\\n"), out => out.includes("[[[[[[[") && out.includes("&lt;!--")],
           ["inline links between unterminated comments", fill(20000, "[a](b) <!-- x "), out => out.includes('<a href="b">') && out.includes("&lt;!-- x")],
           ["unterminated comments inside link labels", fill(20000, "[<!-- x](u) <!-- y "), out => out.includes('<a href="u">') && out.includes("&lt;!-- y")],
+          ["adjacent comment-label links between unterminated comments", fill(15000, "[<!-- a](u)[<!-- b](v) <!-- c "), out => out.includes('<a href="v">') && out.includes("&lt;!-- c")],
           ["images between unterminated comments", fill(20000, "![a](b) <!-- x "), out => out.includes("<img") && out.includes("&lt;!-- x")],
           ["reference links between unterminated comments", "[r]: /u\\n\\n" + fill(20000, "[a][r] <!-- x "), out => out.includes('<a href="/u">') && out.includes("&lt;!-- x")],
           ["one link with a comment-flooded label", "[" + fill(40000, "<!-- x ") + "](u)", out => out.includes('<a href="u">') && out.includes("&lt;!-- x")],
+          ["comment-label link before a comment-flooded label", "[<!-- a](u)[" + fill(40000, "<!-- x ") + "](v) <!-- tail", out => out.includes('<a href="v">') && out.includes("&lt;!-- tail")],
         ];
         for (const [name, input, check] of cases) {
           const out = Bun.markdown.html(input);
@@ -747,6 +749,9 @@ describe("pathological inline HTML inputs", () => {
     );
     expect(Markdown.html("[<!-- x <!-- x <!-- x ](u)\n")).toBe(
       '<p><a href="u">&lt;!-- x &lt;!-- x &lt;!-- x </a></p>\n',
+    );
+    expect(Markdown.html("[<!-- a](u)[<!-- b](v) <!-- c\n")).toBe(
+      '<p><a href="u">&lt;!-- a</a><a href="v">&lt;!-- b</a> &lt;!-- c</p>\n',
     );
   });
 });


### PR DESCRIPTION
### Problem

`Bun.markdown` is quadratic on paragraphs containing many unterminated inline HTML openers (found by parser fuzzing — a ~260 KB input of bracket runs plus repeated `foo <!-- this is a --` lines spun in `find_html_tag`):

```js
Bun.markdown.html("x <!-- y --\n".repeat(100000)); // minutes before this change
```

Measured on a debug+ASAN build (input doubled twice, 18 KB → 36 KB → 72 KB unless noted):

| input | before | after |
|---|---|---|
| unterminated `<!--` flood | 133 / 521 / 2052 ms (×3.9 per doubling) | 7 / 11 / 22 ms (×2.0) |
| unterminated `<?` flood | 73 / 281 / 1098 ms | 5 / 10 / 19 ms |
| unterminated `<!DECL` flood | 75 / 287 / 1124 ms | 5 / 10 / 20 ms |
| unterminated `<![CDATA[` flood | 139 / 539 / 2125 ms | 9 / 18 / 36 ms |
| bracket runs + unterminated `<!--` (fuzzer shape) | 73 / 263 / 993 ms | 12 / 23 / 46 ms |
| `[a](b) <!-- x` repeated (links interleaved) | 88 / 318 / 1205 ms | 16 / 32 / 66 ms |
| `[<!-- x](u) <!-- y` repeated (opener inside label) | 215 / 819 / 3201 ms | 18 / 37 / 75 ms |
| `[<!-- a](u)[<!-- b](v) <!-- c` repeated (adjacent labels) | quadratic | 33 / 66 / 136 ms |
| `[<!-- [<!-- … x](u)](u)…` (nested labels, 5–40 KB) | 18 / 55 / 202 / 760 ms | 6 / 10 / 20 / 42 ms |
| one link with a `<!--`-flooded label | quadratic | 4 / 7 / 14 ms |
| the original 260 KB fuzzer input | 1093 ms | 94 ms |

Terminated comments, unclosed quoted attributes, autolinks, and the bracket-flood family fixed in #31241 were already linear and are unchanged.

### Cause

`find_html_tag` (src/md/inlines.rs) resolves a `<!--` / `<?` / `<!` declaration / `<![CDATA[` candidate by scanning forward for its closing delimiter (`-->`, `?>`, `>`, `]]>`). When the delimiter never appears, the scan walks to the end of the inline slice and returns `None` — and the next such opener repeats the same full-length scan. The scans are repeated per pass (bracket-map builder, emphasis collection, rendering) and per link-label walk, so n openers in an n-byte paragraph cost O(n²).

### Fix

Add a small memo on the `Parser` (`HtmlScanMemo`): when a search for one of the four fixed terminators reaches the end of the slice without a match, record the scan's start position for that terminator kind. Any later scan of the same kind starting at or beyond that position must also fail, so it returns immediately.

This cannot change behavior: if a later candidate's terminator existed, the earlier failed scan would have found it (the search ranges are nested). Two details make the memo cover every scan path:

- The memo is keyed by slice identity (address + length), and a recorded fact also answers queries for any **sub-slice** of that slice by translating positions with the sub-slice's offset — `find_html_tag` runs on link-label sub-slices during `label_contains_link` and nested-link checks, and "no terminator after position P of the paragraph" covers every later position of every label inside it. Sub-slice scans never overwrite the enclosing entry.
- `process_inline_content` starts each slice from an empty memo and restores the caller's memo on return, so recursive label rendering keeps what the paragraph already learned, while recycled merged-line buffers and transient table-cell buffers can never alias a previous slice's entry.

### Tests

`test/js/bun/md/md-edge-cases.test.ts`, new "pathological inline HTML inputs" block:

- a child-process test renders 1.2 MB floods of each unterminated opener kind, the fuzzer-shaped bracket+comment pattern, link/image/reference-link interleavings, adjacent and nested comment-label links, and comment-flooded link labels with a 30 s kill switch — it times out without this change (30.0 s, killed) and completes in a few seconds with it (debug+ASAN)
- conformance tests lock in that unterminated openers still render as escaped text, a terminated construct after a failed opener of another kind is still recognized, multi-line comments still become raw HTML, consecutive same-length paragraphs don't share scan state, and links/images/nested link candidates interleaved with unterminated openers render byte-identically

Full markdown suite (CommonMark spec, GFM, edge cases — 1038 tests) and the markdown CLI entrypoint tests pass.
