### PR TITLE
shell: wrap only component-leading `!` when neutralizing glob metachars

### DIFF
--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -367,7 +367,8 @@ impl Expansion {
     /// but the glob matcher has no general backslash-escape that survives
     /// `build_pattern_components` on every platform, so each byte is wrapped
     /// in a single-character class (`[c]`) — or a one-branch brace group for
-    /// `!` — which the matcher provably treats as that literal character.
+    /// a component-leading `!` — which the matcher provably treats as that
+    /// literal character.
     /// `current_out` itself is not mutated: the no-match error message and the
     /// assignment-position literal fallback keep using the original word.
     fn neutralize_glob_metachars(current_out: &[u8], meta_offsets: &[u32]) -> Vec<u8> {
@@ -384,10 +385,26 @@ impl Expansion {
                 b'*' | b'?' | b'[' | b']' | b'{' | b'}' | b',' => {
                     pattern.extend_from_slice(&[b'[', b, b']']);
                 }
-                // `[!]`/`[^]` would be a negated class and a bare leading `!`
-                // flips the matcher's negation loop, so wrap `!` in a
-                // one-branch brace group whose sole branch is the literal `!`.
-                b'!' => pattern.extend_from_slice(b"{!}"),
+                // `[!]`/`[^]` would be a negated class, so `!` cannot use the
+                // class wrapper. Only a `!` at the start of a path component
+                // (the same split `build_pattern_components` performs) can act
+                // as pattern syntax — the matcher's negation loop — so wrap
+                // that one in a one-branch brace group whose sole branch is
+                // the literal `!`. Every other `!` already matches literally
+                // and is emitted bare: wrapping each one costs a brace-stack
+                // slot per byte, and a run of more than 10 interpolated `!`
+                // would overflow the matcher's bounded brace stack and turn
+                // the whole word into a spurious no-match.
+                b'!' => {
+                    let starts_component = pattern
+                        .last()
+                        .is_none_or(|&prev| bun_core::path_sep::is_sep_native(prev));
+                    if starts_component {
+                        pattern.extend_from_slice(b"{!}");
+                    } else {
+                        pattern.push(b'!');
+                    }
+                }
                 // `[\\]` is a class containing an escaped `\`; the 3-byte
                 // `[\]` would mis-parse as a class containing an escaped `]`.
                 #[cfg(not(windows))]

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -769,7 +769,7 @@ booga"
       // limit (10) must still match literally: neutralizing every `!` as its
       // own `{!}` group used to overflow the brace stack and turn the whole
       // word into "no matches found".
-      const bangRun = "!".repeat(11);
+      const bangRun = Buffer.alloc(11, "!").toString();
 
       TestBuilder.command`echo prefix${bangRun}*`
         .ensureTempDir()

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -764,6 +764,32 @@ booga"
           expect(out.replaceAll("\\", "/")).toContain("sub/b.txt");
         })
         .runAsTest("literal ** still recurses");
+
+      // A run of interpolated `!` longer than the matcher's brace-nesting
+      // limit (10) must still match literally: neutralizing every `!` as its
+      // own `{!}` group used to overflow the brace stack and turn the whole
+      // word into "no matches found".
+      const bangRun = "!".repeat(11);
+
+      TestBuilder.command`echo prefix${bangRun}*`
+        .ensureTempDir()
+        .file(`prefix${bangRun}x.txt`, "")
+        .file("prefixy.txt", "")
+        .stdout(out => {
+          expect(out).toContain(`prefix${bangRun}x.txt`);
+          expect(out).not.toContain("prefixy.txt");
+        })
+        .runAsTest("long run of injected ! inside a word stays literal");
+
+      TestBuilder.command`echo ${bangRun}keep*`
+        .ensureTempDir()
+        .file(`${bangRun}keep1.txt`, "")
+        .file("keep2.txt", "")
+        .stdout(out => {
+          expect(out).toContain(`${bangRun}keep1.txt`);
+          expect(out).not.toContain("keep2.txt");
+        })
+        .runAsTest("long leading run of injected ! stays literal");
     });
   });
 


### PR DESCRIPTION
### Problem

Since #31220, glob metacharacters arriving in a shell word via `${...}` interpolation (or `$var`, command substitution, quoted text) are neutralized before the word reaches the glob walker. `!` is neutralized by wrapping it in a one-branch brace group `{!}`.

The glob matcher keeps brace state in a `BoundedArray<Brace, 10>`, and sequential brace groups occupy the stack simultaneously (a group's entry is only popped after the recursion that matches the rest of the pattern returns). A run of N interpolated `!` bytes therefore needs N brace-stack slots, and at 11+ the push fails and the whole pattern is reported as a non-match:

```js
import { $ } from "bun";
await Bun.write("prefix!!!!!!!!!!!x.txt", "");
await $`echo prefix${"!".repeat(11)}*`;
// bun: no matches found: prefix!!!!!!!!!!!*   (the file exists)
```

Before #31220 a non-leading `!` reached the matcher bare and matched literally, so this case is a regression.

### Fix

Only a `!` at the start of a path component can act as pattern syntax (the matcher's negation loop). Everywhere else the matcher already treats `!` as a literal byte — it can never be the first character of a `[...]` class either, because every `[` coming from data is itself neutralized to `[[]`.

`neutralize_glob_metachars` now wraps `!` as `{!}` only when it starts a component (the pattern is empty or the previously emitted byte is a native path separator, mirroring the split `build_pattern_components` performs) and emits every other `!` bare. A run of interpolated `!` now costs at most one brace-stack slot per component.

### Verification

Two new cases in the existing "interpolated values cannot inject glob syntax" block in `test/js/bun/shell/bunshell.test.ts`: an 11-`!` interpolated run in the middle of a word and at the start of a word must still match files containing those bytes literally.

- Without the fix both fail: `bun: no matches found: prefix!!!!!!!!!!!*` / `bun: no matches found: !!!!!!!!!!!keep*`
- With the fix they pass, alongside the rest of the glob-expansion block, `test/js/bun/shell/brace.test.ts`, and `test/js/bun/glob/{match,scan,path-length,proto}.test.ts`.