### PR TITLE
css: don't panic on out-of-range @font-palette-values palette indices

### DIFF
--- a/src/css/rules/font_palette_values.rs
+++ b/src/css/rules/font_palette_values.rs
@@ -144,19 +144,18 @@ impl OverrideColors {
     pub fn parse(input: &mut css::Parser) -> css::Result<OverrideColors> {
         use crate::css_values::number::CSSIntegerFns;
         let index = CSSIntegerFns::parse(input)?;
-        if index < 0 {
+        // Palette entry indices are stored as u16; reject negatives and values
+        // that don't fit instead of panicking on the cast.
+        let Ok(index) = u16::try_from(index) else {
             return Err(input.new_custom_error(css::ParserError::invalid_value));
-        }
+        };
 
         let color = CssColor::parse(input)?;
         if matches!(color, CssColor::CurrentColor) {
             return Err(input.new_custom_error(css::ParserError::invalid_value));
         }
 
-        Ok(OverrideColors {
-            index: u16::try_from(index).expect("int cast"),
-            color,
-        })
+        Ok(OverrideColors { index, color })
     }
 
     pub fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
@@ -196,10 +195,12 @@ impl BasePalette {
     pub fn parse(input: &mut css::Parser) -> css::Result<BasePalette> {
         use crate::css_values::number::CSSIntegerFns;
         if let Ok(i) = input.try_parse(CSSIntegerFns::parse) {
-            if i < 0 {
+            // Palette indices are stored as u16; reject negatives and values
+            // that don't fit instead of panicking on the cast.
+            let Ok(i) = u16::try_from(i) else {
                 return Err(input.new_custom_error(css::ParserError::invalid_value));
-            }
-            return Ok(BasePalette::Integer(u16::try_from(i).expect("int cast")));
+            };
+            return Ok(BasePalette::Integer(i));
         }
 
         let location = input.current_source_location();

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7466,6 +7466,34 @@ describe("css tests", () => {
     minify_test("@page \\31 st{margin:1em}", "@page \\31 st{margin:1em}");
   });
 
+  describe("font-palette-values", () => {
+    minify_test(
+      "@font-palette-values --x{font-family:Foo;base-palette:2}",
+      "@font-palette-values --x{font-family:Foo;base-palette:2}",
+    );
+    minify_test("@font-palette-values --x{base-palette:light}", "@font-palette-values --x{base-palette:light}");
+    minify_test("@font-palette-values --x{base-palette:65535}", "@font-palette-values --x{base-palette:65535}");
+    minify_test(
+      "@font-palette-values --x{override-colors:0 red,1 #00f}",
+      "@font-palette-values --x{override-colors:0 red,1 #00f}",
+    );
+
+    // Out-of-range palette indices don't fit the internal u16 storage; they
+    // must be preserved as unknown declarations instead of panicking.
+    minify_test("@font-palette-values --x{base-palette:99999}", "@font-palette-values --x{base-palette:99999}");
+    minify_test("@font-palette-values --x{base-palette:-1}", "@font-palette-values --x{base-palette:-1}");
+    minify_test(
+      "@font-palette-values --x{override-colors:99999 red}",
+      "@font-palette-values --x{override-colors:99999 red}",
+    );
+    minify_test(
+      "@font-palette-values --x{override-colors:-1 red}",
+      "@font-palette-values --x{override-colors:-1 red}",
+    );
+    // Fuzzer-minimized input: unterminated block with an overflowing index.
+    minify_test("@font-palette-values --{base-palette:99999", "@font-palette-values --{base-palette:99999}");
+  });
+
   describe("edge cases", () => {
     describe("invalid gradient", () => {
       cssTest(

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7486,10 +7486,7 @@ describe("css tests", () => {
       "@font-palette-values --x{override-colors:99999 red}",
       "@font-palette-values --x{override-colors:99999 red}",
     );
-    minify_test(
-      "@font-palette-values --x{override-colors:-1 red}",
-      "@font-palette-values --x{override-colors:-1 red}",
-    );
+    minify_test("@font-palette-values --x{override-colors:-1 red}", "@font-palette-values --x{override-colors:-1 red}");
     // Fuzzer-minimized input: unterminated block with an overflowing index.
     minify_test("@font-palette-values --{base-palette:99999", "@font-palette-values --{base-palette:99999}");
   });


### PR DESCRIPTION
Fixes a panic found by CSS fuzzing.

### Repro

```sh
BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1 bun -e 'require("bun:internal-for-testing").cssInternals.minifyTest("@font-palette-values --{base-palette:99999", "")'
```

```
panic: int cast: TryFromIntError(PosOverflow)
```

Any stylesheet containing `@font-palette-values` with an integer above 65535 hits it, e.g. `@font-palette-values --x { base-palette: 99999 }`, so `Bun.build`/the CSS bundler can be crashed by plain CSS input.

### Cause

`BasePalette` and `OverrideColors` in `src/css/rules/font_palette_values.rs` store the palette index as `u16`, but parse it as a CSS `<integer>` (i32) and convert with `u16::try_from(..).expect("int cast")`. Values that don't fit in `u16` (negative values were already rejected) panic on the cast. The same cast exists in both the `base-palette` and `override-colors` parsers.

### Fix

Treat out-of-range indices the same way negatives are already handled: return `ParserError::invalid_value`, which makes the declaration fall back to the unknown-property path and be preserved verbatim instead of crashing:

```
@font-palette-values --x{base-palette:99999}  ->  @font-palette-values --x{base-palette:99999}
```

In-range values are unaffected.

### Verification

- New tests in `test/js/bun/css/css.test.ts` (`font-palette-values` block) cover in-range values, out-of-range/negative `base-palette` and `override-colors` indices, and the fuzzer-minimized unterminated input. Without the fix they reproduce the panic; with the fix the whole file passes (1058 pass / 0 fail).
- `cargo check -p bun_css` and `cargo clippy -p bun_css` are clean.
