### PR TITLE
css: cap `&` parent-selector expansion when compiling nesting for older targets

### DIFF
--- a/src/css/error.rs
+++ b/src/css/error.rs
@@ -234,6 +234,9 @@ pub enum PrinterErrorKind {
     invalid_composes_selector,
     /// The CSS modules pattern must end with `[local]` for use in CSS grid.
     invalid_css_modules_pattern_in_grid,
+    /// Substituting parent selectors for `&` while compiling CSS nesting for
+    /// the configured targets exceeded the expansion limit.
+    maximum_nesting_expansion,
     no_import_records,
 }
 
@@ -255,6 +258,9 @@ impl fmt::Display for PrinterErrorKind {
             Self::invalid_css_modules_pattern_in_grid => {
                 f.write_str("CSS modules pattern must end with '[local]' when used in CSS grid")
             }
+            Self::maximum_nesting_expansion => f.write_str(
+                "Maximum nesting expansion exceeded when compiling CSS nesting for the configured targets",
+            ),
             Self::no_import_records => f.write_str("No import records found"),
         }
     }

--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -144,6 +144,13 @@ pub struct Printer<'a> {
     // TODO(port): lifetime — ctx is set to a stack-local during with_context() and restored
     // after; `&'a StyleContext<'a>` will not borrow-check there. May need raw `*const StyleContext`.
     pub ctx: Option<&'a css::StyleContext<'a>>,
+    /// Number of parent-selector substitutions performed for `&` while
+    /// serializing the current rule prelude with compiled nesting (targets
+    /// without CSS nesting support). Reset per prelude in
+    /// `StyleRule::to_css_base` and bounded in `serialize::serialize_nesting`
+    /// so deeply nested rules with multiple `&` references per level cannot
+    /// expand exponentially.
+    pub nesting_expansions: u32,
     pub scratchbuf: BumpVec<'a, u8>,
     pub error_kind: Option<css::PrinterError>,
     pub import_info: Option<ImportInfo<'a>>,
@@ -310,6 +317,7 @@ impl<'a> Printer<'a> {
             in_calc: false,
             css_module: None,
             ctx: None,
+            nesting_expansions: 0,
             error_kind: None,
         }
     }

--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -146,10 +146,10 @@ pub struct Printer<'a> {
     pub ctx: Option<&'a css::StyleContext<'a>>,
     /// Number of parent-selector substitutions performed for `&` while
     /// serializing the current rule prelude with compiled nesting (targets
-    /// without CSS nesting support). Reset per prelude in
-    /// `StyleRule::to_css_base` and bounded in `serialize::serialize_nesting`
-    /// so deeply nested rules with multiple `&` references per level cannot
-    /// expand exponentially.
+    /// without CSS nesting support). Reset per prelude (in
+    /// `StyleRule::to_css_base` and `ScopeRule::to_css`) and bounded in
+    /// `serialize::serialize_nesting` so deeply nested rules with multiple
+    /// `&` references per level cannot expand exponentially.
     pub nesting_expansions: u32,
     pub scratchbuf: BumpVec<'a, u8>,
     pub error_kind: Option<css::PrinterError>,

--- a/src/css/rules/scope.rs
+++ b/src/css/rules/scope.rs
@@ -26,6 +26,10 @@ impl<R> ScopeRule<R> {
 
         dest.write_str("@scope")?;
         dest.whitespace()?;
+        // The scope preludes get their own budget for `&` substitutions when
+        // compiling nesting, like style rule preludes do (see
+        // `serialize::serialize_nesting`).
+        dest.nesting_expansions = 0;
         if let Some(scope_start) = &self.scope_start {
             dest.write_char(b'(')?;
             // scope_start.to_css(dest)?;

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -122,6 +122,9 @@ impl<R> StyleRule<R> {
             // PORT NOTE: `dest.context()` borrows `dest`; copy the (Copy) raw
             // ctx field out so it doesn't conflict with the `&mut *dest` below.
             let ctx = dest.ctx;
+            // Each rule prelude gets its own budget for `&` substitutions when
+            // compiling nesting (see `serialize::serialize_nesting`).
+            dest.nesting_expansions = 0;
             selector::serialize::serialize_selector_list(
                 self.selectors.v.slice(),
                 dest,

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -1361,12 +1361,33 @@ pub mod serialize {
         Ok(())
     }
 
+    /// Maximum number of parent-selector substitutions allowed while
+    /// serializing a single rule prelude with compiled nesting.
+    ///
+    /// When the targets don't support CSS nesting, every `&` is replaced with
+    /// the parent selector, which may itself contain `&` referring to the
+    /// grandparent, and so on. A selector with multiple `&` references per
+    /// nesting level therefore expands to (references per level)^depth copies
+    /// of its ancestors, so a few KB of deeply nested input can print
+    /// gigabytes of output. Real-world nesting needs at most a handful of
+    /// substitutions per rule; anything past this limit is a runaway
+    /// expansion, so bail out with an error instead of allocating without
+    /// bound.
+    const MAX_NESTING_EXPANSIONS: u32 = 65_536;
+
     pub fn serialize_nesting(
         dest: &mut Printer,
         context: Option<&StyleContext>,
         first: bool,
     ) -> Result<(), PrintErr> {
         if let Some(ctx) = context {
+            dest.nesting_expansions += 1;
+            if dest.nesting_expansions > MAX_NESTING_EXPANSIONS {
+                return dest.new_error(
+                    crate::error::PrinterErrorKind::maximum_nesting_expansion,
+                    None,
+                );
+            }
             // If there's only one simple selector, just serialize it directly.
             // Otherwise, use an :is() pseudo class.
             // Type selectors are only allowed at the start of a compound selector,

--- a/test/js/bun/css/nested-selector-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-expansion.test.ts
@@ -72,12 +72,15 @@ async function runMinifyTest(depth: number, withTargets: boolean) {
   return { stdout, stderr, exitCode, signalCode: proc.signalCode };
 }
 
-test.concurrent("deeply nested `&` selectors error out instead of expanding without bound when compiling nesting", async () => {
-  const { stdout, stderr, signalCode } = await runMinifyTest(24, true);
-  expect(stderr).toBe("");
-  expect(signalCode).toBeNull(); // not killed by the kill switch
-  expect(stdout).toContain("ERR Maximum nesting expansion exceeded");
-});
+test.concurrent(
+  "deeply nested `&` selectors error out instead of expanding without bound when compiling nesting",
+  async () => {
+    const { stdout, stderr, signalCode } = await runMinifyTest(24, true);
+    expect(stderr).toBe("");
+    expect(signalCode).toBeNull(); // not killed by the kill switch
+    expect(stdout).toContain("ERR Maximum nesting expansion exceeded");
+  },
+);
 
 test.concurrent("deeply nested `&` selectors still minify when nesting is preserved (no targets)", async () => {
   const { stdout, stderr, signalCode } = await runMinifyTest(24, false);

--- a/test/js/bun/css/nested-selector-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-expansion.test.ts
@@ -72,14 +72,14 @@ async function runMinifyTest(depth: number, withTargets: boolean) {
   return { stdout, stderr, exitCode, signalCode: proc.signalCode };
 }
 
-test("deeply nested `&` selectors error out instead of expanding without bound when compiling nesting", async () => {
+test.concurrent("deeply nested `&` selectors error out instead of expanding without bound when compiling nesting", async () => {
   const { stdout, stderr, signalCode } = await runMinifyTest(24, true);
   expect(stderr).toBe("");
   expect(signalCode).toBeNull(); // not killed by the kill switch
   expect(stdout).toContain("ERR Maximum nesting expansion exceeded");
 });
 
-test("deeply nested `&` selectors still minify when nesting is preserved (no targets)", async () => {
+test.concurrent("deeply nested `&` selectors still minify when nesting is preserved (no targets)", async () => {
   const { stdout, stderr, signalCode } = await runMinifyTest(24, false);
   expect(stderr).toBe("");
   expect(signalCode).toBeNull();
@@ -87,7 +87,7 @@ test("deeply nested `&` selectors still minify when nesting is preserved (no tar
   expect(stdout).toStartWith("OK ");
 });
 
-test("ordinary nested CSS still compiles for older targets", async () => {
+test.concurrent("ordinary nested CSS still compiles for older targets", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -114,7 +114,7 @@ test("ordinary nested CSS still compiles for older targets", async () => {
   expect(exitCode).toBe(0);
 });
 
-test("bun build does not hang on deeply nested `&` selectors with the default browser target", async () => {
+test.concurrent("bun build does not hang on deeply nested `&` selectors with the default browser target", async () => {
   using dir = tempDir("css-nested-selector-expansion", {
     "explode.css": explodingNestedCss(24),
   });

--- a/test/js/bun/css/nested-selector-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-expansion.test.ts
@@ -1,0 +1,136 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import path from "node:path";
+
+// Regression test for unbounded memory growth when compiling CSS nesting for
+// targets that don't support it (found by CSS fuzzing).
+//
+// When the browser targets lack native nesting support, every `&` in a nested
+// rule's selector is replaced with the parent selector at print time. The
+// parent selector itself may contain `&` referring to the grandparent, so a
+// selector with multiple `&` references per nesting level expands to
+// (references per level)^depth copies of its ancestors. A ~3 KB stylesheet
+// with ~20 nesting levels of `&:is(.bar, &.baz)` makes the printer allocate an
+// effectively unbounded output buffer: `bun build` (whose default browser
+// target predates CSS nesting) and `minifyTest` with explicit targets both
+// spin forever while memory grows.
+//
+// The serializer now budgets the number of `&` substitutions per rule prelude
+// and reports "Maximum nesting expansion exceeded" instead of expanding
+// without bound. Preserving nesting (no targets) and ordinary nested CSS with
+// old targets are unaffected.
+
+/** Deeply nested rules where each level references the parent twice (`&` appears twice per selector). */
+function explodingNestedCss(depth: number): string {
+  let css = "";
+  for (let i = 0; i < depth; i++) {
+    css += "&:is(.bar, &.baz) { color: red; }\n";
+    css += "&:is(.bar, &.baz) { colo\n"; // unclosed block, same shape as the fuzz input
+  }
+  css += "&:is(.bar, &.baz) { color: red; }\n";
+  css += "}";
+  return css;
+}
+
+const minifyTestScript = `
+  const { cssInternals } = require("bun:internal-for-testing");
+  const depth = parseInt(process.env.NESTED_CSS_DEPTH, 10);
+  const targets = process.env.NESTED_CSS_TARGETS === "1" ? { safari: 13 << 16 } : undefined;
+  let css = "";
+  for (let i = 0; i < depth; i++) {
+    css += "&:is(.bar, &.baz) { color: red; }\\n";
+    css += "&:is(.bar, &.baz) { colo\\n";
+  }
+  css += "&:is(.bar, &.baz) { color: red; }\\n";
+  css += "}";
+  try {
+    const out = targets ? cssInternals.minifyTest(css, "", targets) : cssInternals.minifyTest(css, "");
+    console.log("OK " + out.length);
+  } catch (err) {
+    console.log("ERR " + err.message);
+  }
+`;
+
+async function runMinifyTest(depth: number, withTargets: boolean) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", minifyTestScript],
+    env: {
+      ...bunEnv,
+      BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1",
+      NESTED_CSS_DEPTH: String(depth),
+      NESTED_CSS_TARGETS: withTargets ? "1" : "0",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+    // Kill switch: before the fix these spins were unbounded. Let the child be
+    // killed so a regression fails the assertions below instead of hanging the
+    // test runner and exhausting memory.
+    timeout: 20_000,
+    killSignal: "SIGKILL",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode, signalCode: proc.signalCode };
+}
+
+test("deeply nested `&` selectors error out instead of expanding without bound when compiling nesting", async () => {
+  const { stdout, stderr, signalCode } = await runMinifyTest(24, true);
+  expect(stderr).toBe("");
+  expect(signalCode).toBeNull(); // not killed by the kill switch
+  expect(stdout).toContain("ERR Maximum nesting expansion exceeded");
+});
+
+test("deeply nested `&` selectors still minify when nesting is preserved (no targets)", async () => {
+  const { stdout, stderr, signalCode } = await runMinifyTest(24, false);
+  expect(stderr).toBe("");
+  expect(signalCode).toBeNull();
+  // Without targets the nesting is preserved, so the output stays small.
+  expect(stdout).toStartWith("OK ");
+});
+
+test("ordinary nested CSS still compiles for older targets", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const { cssInternals } = require("bun:internal-for-testing");
+        // 8 levels deep, one parent reference per level: well within the budget.
+        let css = ".a { color: red; ";
+        for (let i = 0; i < 8; i++) css += "&:hover .b" + i + " { color: blue; ";
+        css += "}".repeat(9);
+        console.log(cssInternals.minifyTest(css, "", { safari: 13 << 16 }));
+      `,
+    ],
+    env: { ...bunEnv, BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 20_000,
+    killSignal: "SIGKILL",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  // The innermost rule's `&` chain is fully expanded.
+  expect(stdout).toContain(".a:hover .b0:hover .b1:hover .b2:hover .b3:hover .b4:hover .b5:hover .b6:hover .b7");
+  expect(exitCode).toBe(0);
+});
+
+test("bun build does not hang on deeply nested `&` selectors with the default browser target", async () => {
+  using dir = tempDir("css-nested-selector-expansion", {
+    "explode.css": explodingNestedCss(24),
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", path.join(String(dir), "explode.css"), "--outdir", path.join(String(dir), "out")],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    // Kill switch: before the fix this build spun forever while allocating.
+    timeout: 20_000,
+    killSignal: "SIGKILL",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // The build must terminate on its own (the printer reports an error for the
+  // runaway rule) instead of being killed by the 20s kill switch.
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).not.toBeNull();
+});

--- a/test/js/bun/css/nested-selector-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-expansion.test.ts
@@ -75,19 +75,21 @@ async function runMinifyTest(depth: number, withTargets: boolean) {
 test.concurrent(
   "deeply nested `&` selectors error out instead of expanding without bound when compiling nesting",
   async () => {
-    const { stdout, stderr, signalCode } = await runMinifyTest(24, true);
+    const { stdout, stderr, signalCode, exitCode } = await runMinifyTest(24, true);
     expect(stderr).toBe("");
     expect(signalCode).toBeNull(); // not killed by the kill switch
     expect(stdout).toContain("ERR Maximum nesting expansion exceeded");
+    expect(exitCode).toBe(0);
   },
 );
 
 test.concurrent("deeply nested `&` selectors still minify when nesting is preserved (no targets)", async () => {
-  const { stdout, stderr, signalCode } = await runMinifyTest(24, false);
+  const { stdout, stderr, signalCode, exitCode } = await runMinifyTest(24, false);
   expect(stderr).toBe("");
   expect(signalCode).toBeNull();
   // Without targets the nesting is preserved, so the output stays small.
   expect(stdout).toStartWith("OK ");
+  expect(exitCode).toBe(0);
 });
 
 test.concurrent("ordinary nested CSS still compiles for older targets", async () => {


### PR DESCRIPTION
### What does this PR do?

Fixes a hang with unbounded memory growth in the CSS printer, found by CSS fuzzing (signature `hang:css:…alloc::raw_vec::RawVecInner::finish_grow…` — the printer keeps reallocating an ever-growing output buffer; the follow-up OOM reports are the same mechanism hitting the allocator limit).

The fuzzer's ~2.8 KB input is ~21 nesting levels of

```css
&:is(.bar, &.baz) { color: red; }
&:is(.bar, &.baz) { colo   /* unclosed block -> everything below nests one level deeper */
```

The published repro calls `minifyTest(input, "")` with **no targets** and does not hang (nesting is preserved, 1.5 KB output). The same input hangs as soon as CSS nesting is compiled away, which is what the real entry points do:

```sh
# default --target=browser lowers nesting (safari14/chrome87/edge88/firefox78 defaults)
bun build explode.css --outdir out      # never returns, memory grows until OOM
```

or `minifyTest(input, "", { safari: 13 << 16 })`. Upstream lightningcss 1.32.0 hangs on the same input with the same targets, so there is no upstream fix to port.

### Cause

When targets lack nesting support, `serialize_nesting` replaces each `&` with the parent selector (`StyleContext` chain). The parent's selector may itself contain `&` referring to the grandparent, so a selector with k `&` references per level expands to ~k^depth copies of its ancestors. With this input the printed output grows ~4× per nesting level: depth 6 → 1 MB, depth 8 → 17 MB, depth 10 → 274 MB, depth 21 → effectively unbounded. The work and the output are inherently exponential — the process isn't stuck, it's printing a stylesheet that would be terabytes.

### Fix

`Printer` now tracks the number of parent-selector substitutions performed for the current rule prelude (reset in `StyleRule::to_css_base`, counted in `serialize_nesting`). Past 65,536 substitutions for a single prelude the printer reports a new `PrinterErrorKind::maximum_nesting_expansion` ("Maximum nesting expansion exceeded when compiling CSS nesting for the configured targets") instead of allocating without bound.

Real-world nesting needs at most a handful of substitutions per rule (depth × `&`-per-level), so the budget is far beyond anything legitimate; only runaway expansions hit it. Behavior is unchanged for:

* stylesheets where nesting is preserved (no targets / modern targets) — the fuzz input still minifies to the same 1.5 KB,
* ordinary nested CSS compiled for older targets (e.g. 8 levels of `&:hover` still expands fully),
* everything in the existing CSS suites (see below).

With the budget, `bun build` on the hostile input terminates in milliseconds-to-seconds instead of hanging. Note the bundler currently maps *any* CSS printer error to an empty chunk rather than a build diagnostic (pre-existing, same as the Zig implementation); surfacing printer errors as build errors is a separate follow-up.

Related: #31270 fixes a different exponential blowup from the same fuzzing campaign (duplicate re-serialization across vendor-prefix passes). The two mechanisms are independent — that fix does not bound this input (no prefixed selectors here), and this budget resets per prelude so it does not bound that one — the fixes are complementary and touch adjacent code.

### Verification

* New `test/js/bun/css/nested-selector-expansion.test.ts`:
  * deeply nested `&:is(.bar, &.baz)` with targets now errors with "Maximum nesting expansion exceeded" instead of hanging (spawned with a 20 s kill switch so a regression fails instead of hanging the runner),
  * the same input with nesting preserved (no targets) still minifies,
  * ordinary 8-level nesting still compiles fully for older targets,
  * `bun build` with the default browser target terminates on its own.
  * Without the fix, the first and last test fail (child killed by the kill switch); with the fix all four pass.
* Existing suites with the fix (debug build): `test/js/bun/css/css.test.ts` (1049 pass), `test/js/bun/css/` nested-function-backtracking / small-list-grow / doesnt_crash / css-modules (all pass), `test/bundler/css/` (166 pass). The only failure seen locally is the pre-existing `fuzz ansi256` 16.7M-iteration timeout on debug ASAN builds (color integer math, unrelated to this change).
* `cargo clippy -p bun_css` is clean.
