### PR TITLE
css: bound selector-list expansion when compiling nesting for older targets

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -2662,10 +2662,32 @@ mod stylesheet_impl {
                 css_modules: self.options.css_modules.is_some(),
                 extra,
                 err: None,
+                selector_expansion_multiplier: 1,
+                selector_expansion_total: 0,
             };
 
             if self.rules.minify(&mut minify_ctx, false).is_err() {
-                panic!("TODO: Handle");
+                // Rule-level minify signals failure with the unit `MinifyErr`
+                // and records the diagnostic out-of-band on the context.
+                debug_assert!(minify_ctx.err.is_some());
+                let e = minify_ctx
+                    .err
+                    .take()
+                    .expect("MinifyContext.err must be set when rule minification fails");
+                let filename: &[u8] = self
+                    .sources
+                    .get(e.loc.source_index as usize)
+                    .map(|source| &**source)
+                    .unwrap_or(self.options.filename);
+                let minify_error = Err {
+                    kind: e.kind,
+                    loc: Some(ErrorLocation {
+                        filename,
+                        line: e.loc.line,
+                        column: e.loc.column,
+                    }),
+                };
+                return Err(minify_error);
             }
 
             Ok(())

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -2670,10 +2670,10 @@ mod stylesheet_impl {
                 // Rule-level minify signals failure with the unit `MinifyErr`
                 // and records the diagnostic out-of-band on the context.
                 debug_assert!(minify_ctx.err.is_some());
-                let e = minify_ctx
-                    .err
-                    .take()
-                    .expect("MinifyContext.err must be set when rule minification fails");
+                let e = minify_ctx.err.take().unwrap_or_else(|| MinifyError {
+                    kind: MinifyErrorKind::unknown,
+                    loc: crate::Location::default(),
+                });
                 let filename: &[u8] = self
                     .sources
                     .get(e.loc.source_index as usize)

--- a/src/css/error.rs
+++ b/src/css/error.rs
@@ -505,6 +505,10 @@ pub enum MinifyErrorKind {
     /// Compiling nested rules for the configured browser targets would expand to
     /// more than [`crate::css_rules::MAX_SELECTOR_EXPANSION`] selectors.
     selector_expansion_limit_exceeded,
+    /// Rule minification failed without recording a more specific diagnostic on
+    /// `MinifyContext::err`. Defensive fallback — every failing path is expected
+    /// to record one before returning an error.
+    unknown,
 }
 
 impl fmt::Display for MinifyErrorKind {
@@ -526,6 +530,7 @@ impl fmt::Display for MinifyErrorKind {
                 "Nested CSS rules expand to more than {} selectors when compiled for the configured browser targets. Reduce the nesting depth or the number of selectors per rule, or target browsers that support CSS nesting.",
                 crate::css_rules::MAX_SELECTOR_EXPANSION,
             ),
+            Self::unknown => write!(f, "CSS minification failed"),
         }
     }
 }

--- a/src/css/error.rs
+++ b/src/css/error.rs
@@ -502,6 +502,9 @@ pub enum MinifyErrorKind {
         /// The source location of the `@custom-media` rule with unsupported boolean logic.
         custom_media_loc: Location,
     },
+    /// Compiling nested rules for the configured browser targets would expand to
+    /// more than [`crate::css_rules::MAX_SELECTOR_EXPANSION`] selectors.
+    selector_expansion_limit_exceeded,
 }
 
 impl fmt::Display for MinifyErrorKind {
@@ -517,6 +520,11 @@ impl fmt::Display for MinifyErrorKind {
                 f,
                 "Unsupported boolean logic in custom media rule at line {}, column {}",
                 custom_media_loc.line, custom_media_loc.column,
+            ),
+            Self::selector_expansion_limit_exceeded => write!(
+                f,
+                "Nested CSS rules expand to more than {} selectors when compiled for the configured browser targets. Reduce the nesting depth or the number of selectors per rule, or target browsers that support CSS nesting.",
+                crate::css_rules::MAX_SELECTOR_EXPANSION,
             ),
         }
     }

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -1021,6 +1021,20 @@ pub struct StyleContext<'a> {
     pub parent: Option<&'a StyleContext<'a>>,
 }
 
+/// Upper bound on the number of selectors that compiling nested rules away for
+/// the configured targets may expand a stylesheet into.
+///
+/// When the targets don't support CSS nesting (or a rule's selectors need to be
+/// split for compatibility), every nesting level multiplies the parent
+/// selector list into its nested rules. That expansion is exponential in the
+/// nesting depth, so a few hundred bytes of adversarial input (e.g. 20+ levels
+/// of two-selector rules) would otherwise balloon into gigabytes of cloned
+/// rules and output. Real-world stylesheets stay far below this limit — 65,536
+/// expanded selectors already corresponds to megabytes of output — so exceeding
+/// it is reported as a `selector_expansion_limit_exceeded` minify error
+/// instead.
+pub const MAX_SELECTOR_EXPANSION: u32 = 65_536;
+
 /// Per-stylesheet minification state threaded through `CssRuleList::minify`
 /// and every leaf rule's `minify`.
 ///
@@ -1051,6 +1065,13 @@ pub struct MinifyContext<'a, 'bump> {
     pub css_modules: bool,
     /// First minification error encountered (Zig surfaced this out-of-band).
     pub err: Option<css::error::MinifyError>,
+    /// How many copies of the current rule's selectors compiling the enclosing
+    /// nesting for the targets will produce — the product of the enclosing
+    /// style rules' selector-list lengths. `1` at the top level.
+    pub selector_expansion_multiplier: u32,
+    /// Running total of selectors that compiling nested rules for the targets
+    /// will expand to, checked against [`MAX_SELECTOR_EXPANSION`].
+    pub selector_expansion_total: u32,
 }
 
 // ported from: src/css/rules/rules.zig

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -321,12 +321,24 @@ impl<R> StyleRule<R> {
             // When the targets require compiling nesting away (or splitting
             // this rule's selectors for compatibility), each of this rule's
             // selectors multiplies the expansion of every nested rule.
+            //
+            // Mirrors the selector-compatibility branch in `minify_style_arm`
+            // (rules/mod.rs): an incompatible selector list is either collapsed
+            // into a single `:is()` selector (nothing cloned) or partitioned
+            // into one cloned rule per selector (fan-out = selector count).
+            // Only the partition case multiplies on its own — but the `:is()`
+            // wrap keeps one `&` reference per original selector, so when
+            // nesting is compiled away the printed output still fans out per
+            // selector, which is why the nesting branch bumps unconditionally.
             let saved_expansion_multiplier = context.selector_expansion_multiplier;
-            if context.targets.should_compile_same(css::Feature::Nesting)
-                || (self.selectors.v.len() > 1
-                    && context.targets.should_compile_selectors()
-                    && !self.is_compatible(context.targets))
-            {
+            let selectors_incompatible = self.selectors.v.len() > 1
+                && context.targets.should_compile_selectors()
+                && !self.is_compatible(context.targets);
+            let splits_selectors = selectors_incompatible
+                && !(context.targets.is_compatible(css::Feature::IsSelector)
+                    && !self.selectors.any_has_pseudo_element()
+                    && self.selectors.specifities_all_equal());
+            if context.targets.should_compile_same(css::Feature::Nesting) || splits_selectors {
                 context.selector_expansion_multiplier = context
                     .selector_expansion_multiplier
                     .saturating_mul(self.selectors.v.len().max(1));

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -269,6 +269,27 @@ impl<R> StyleRule<R> {
             }
         }
 
+        // Compiling the enclosing nesting away for the targets repeats this
+        // rule's selectors once per combination of the enclosing style rules'
+        // selectors. That expansion is multiplicative across nesting levels,
+        // so bound it — otherwise a few hundred bytes of deeply nested
+        // multi-selector rules expand into gigabytes of cloned rules and
+        // output. See `css_rules::MAX_SELECTOR_EXPANSION`.
+        if context.selector_expansion_multiplier > 1 {
+            context.selector_expansion_total = context.selector_expansion_total.saturating_add(
+                context
+                    .selector_expansion_multiplier
+                    .saturating_mul(self.selectors.v.len().max(1)),
+            );
+            if context.selector_expansion_total > super::MAX_SELECTOR_EXPANSION {
+                context.err = Some(crate::error::MinifyError {
+                    kind: crate::error::MinifyErrorKind::selector_expansion_limit_exceeded,
+                    loc: self.loc,
+                });
+                return Err(MinifyErr::minify_err);
+            }
+        }
+
         // TODO: this
         // let pure_css_modules = context.pure_css_modules;
         // if context.pure_css_modules {
@@ -297,6 +318,20 @@ impl<R> StyleRule<R> {
         context.handler_context.context = DeclarationContext::None;
 
         if self.rules.v.len() > 0 {
+            // When the targets require compiling nesting away (or splitting
+            // this rule's selectors for compatibility), each of this rule's
+            // selectors multiplies the expansion of every nested rule.
+            let saved_expansion_multiplier = context.selector_expansion_multiplier;
+            if context.targets.should_compile_same(css::Feature::Nesting)
+                || (self.selectors.v.len() > 1
+                    && context.targets.should_compile_selectors()
+                    && !self.is_compatible(context.targets))
+            {
+                context.selector_expansion_multiplier = context
+                    .selector_expansion_multiplier
+                    .saturating_mul(self.selectors.v.len().max(1));
+            }
+
             let mut handler_context = context.handler_context.child(DeclarationContext::StyleRule);
             core::mem::swap::<PropertyHandlerContext<'_>>(
                 &mut context.handler_context,
@@ -307,6 +342,7 @@ impl<R> StyleRule<R> {
                 &mut context.handler_context,
                 &mut handler_context,
             );
+            context.selector_expansion_multiplier = saved_expansion_multiplier;
             if unused && self.rules.v.len() == 0 {
                 return Ok(true);
             }

--- a/src/css_jsc/error_jsc.rs
+++ b/src/css_jsc/error_jsc.rs
@@ -17,9 +17,10 @@ where
     T: Display,
 {
     let str = BunString::create_format(format_args!("{}", this.kind));
-    // `defer str.deref()` — `bun_core::String` is `Copy` and has no `Drop`, so deref explicitly.
+    // `to_error_instance` consumes the caller's reference (it derefs the string
+    // itself), so the `+1` from `create_format` must not be dropped again here —
+    // an extra deref frees the WTFStringImpl while the error still uses it.
     let js = bun_jsc::bun_string_jsc::to_error_instance(&str, global_this);
-    str.deref();
     Ok(js)
 }
 

--- a/test/js/bun/css/nested-selector-list-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-list-expansion.test.ts
@@ -105,4 +105,6 @@ test("bun build reports an error instead of exploding on deeply nested multi-sel
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
   expect(stderr).toContain(LIMIT_ERROR);
   expect(exitCode).toBe(1);
+  // The build must fail before emitting the (multi-megabyte) expanded output.
+  expect(await Bun.file(`${dir}/out/input.css`).exists()).toBe(false);
 });

--- a/test/js/bun/css/nested-selector-list-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-list-expansion.test.ts
@@ -1,0 +1,87 @@
+import { cssInternals } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Regression test for exponential selector expansion when compiling CSS
+// nesting for browser targets that don't support it.
+//
+// When nesting has to be compiled away, every nesting level multiplies the
+// parent selector list into its nested rules, and selectors the targets don't
+// support are additionally split into one cloned rule (including a deep clone
+// of all nested rules) per selector. A ~900 byte stylesheet with 23 levels of
+// two-selector nested rules therefore expanded into gigabytes of cloned rules
+// and output, OOMing the bundler — found by fuzzing, and reachable with a
+// plain `bun build` since the default bundler targets predate `:is()` and
+// native nesting. The minifier now bounds the expansion and reports an error.
+
+const { minifyTest } = cssInternals;
+
+const LIMIT_ERROR = "Nested CSS rules expand to more than";
+
+/** `depth` nested copies of a two-selector rule, innermost holding `color: red`. */
+function nestedRules(selectors: string, depth: number): string {
+  return `${selectors} {\n`.repeat(depth) + "color: red;\n" + "}\n".repeat(depth);
+}
+
+// Targets that support neither `:is()` nor CSS nesting.
+const OLD_TARGETS = { chrome: 80 << 16 };
+// Targets that support CSS nesting natively, so nothing needs to be expanded.
+const MODERN_TARGETS = { chrome: 130 << 16 };
+
+test("deeply nested multi-selector rules error instead of exploding when compiled for old targets", () => {
+  const src = nestedRules("co :is(.bar), .bar :is(.baz)", 17);
+  expect(() => minifyTest(src, "", OLD_TARGETS)).toThrow(LIMIT_ERROR);
+});
+
+test("deeply nested ::part() selector lists error instead of exploding when compiled for old targets", () => {
+  // ::part() can never be wrapped in :is(), so each selector is split into its
+  // own rule with a clone of every nested rule — the other shape of the same
+  // exponential blowup.
+  const src = nestedRules("x::part(a), y::part(b)", 17);
+  expect(() => minifyTest(src, "", OLD_TARGETS)).toThrow(LIMIT_ERROR);
+});
+
+test("nested rules below the expansion limit still compile for old targets", () => {
+  const src = nestedRules("co :is(.bar), .bar :is(.baz)", 8);
+  const out = minifyTest(src, "", OLD_TARGETS);
+  expect(out).toContain("color:red");
+  expect(out.length).toBeLessThan(100_000);
+});
+
+test("the fuzzer reproduction still minifies when no targets are configured", () => {
+  // 924-byte minimized fuzzer input: 23 unclosed nested rules. Without browser
+  // targets nothing is expanded, so this stays linear.
+  const src = "        co :is(.bar), .bar :is(.baz) {\n".repeat(23) + "        color: red;\n      }";
+  const out = minifyTest(src, "");
+  expect(out).toContain("color:red");
+  expect(out.length).toBeLessThan(10_000);
+});
+
+test("deep nesting is preserved as-is for targets that support CSS nesting", () => {
+  const src = nestedRules("co :is(.bar), .bar :is(.baz)", 23);
+  const out = minifyTest(src, "", MODERN_TARGETS);
+  expect(out).toContain("color:red");
+  expect(out.length).toBeLessThan(10_000);
+});
+
+test("bun build reports an error instead of exploding on deeply nested multi-selector css", async () => {
+  using dir = tempDir("css-nested-selector-expansion", {
+    "input.css": nestedRules("co :is(.bar), .bar :is(.baz)", 17),
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "input.css", "--outdir", "out", "--minify"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    // Kill switch: before the fix this build produced tens of megabytes of
+    // output (and at slightly larger depths, gigabytes). Let the child
+    // terminate itself so a regression fails the assertions below instead of
+    // hanging the runner.
+    timeout: 20_000,
+    killSignal: "SIGKILL",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain(LIMIT_ERROR);
+  expect(exitCode).toBe(1);
+});

--- a/test/js/bun/css/nested-selector-list-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-list-expansion.test.ts
@@ -64,6 +64,27 @@ test("deep nesting is preserved as-is for targets that support CSS nesting", () 
   expect(out.length).toBeLessThan(10_000);
 });
 
+// `:user-valid` is treated as unsupported for every target, but the lists below
+// have no pseudo-elements and equal specificity, so the minifier collapses each
+// list into a single `:is(& .a:user-valid, & .b:user-valid)` selector instead
+// of splitting it into cloned rules.
+
+test("incompatible selector lists that collapse into :is() don't hit the limit when nesting is preserved", () => {
+  // Nothing is cloned and nesting stays native, so the output is linear and no
+  // limit applies — even though a per-level multiplier would naively reach 2^20.
+  const src = nestedRules(".a:user-valid, .b:user-valid", 20);
+  const out = minifyTest(src, "", MODERN_TARGETS);
+  expect(out).toContain("color:red");
+  expect(out.length).toBeLessThan(100_000);
+});
+
+test("collapsed :is() lists still hit the limit when nesting has to be compiled away", () => {
+  // The :is() wrap keeps one `&` per original selector, so compiling nesting
+  // away still doubles the printed selector per level (~34 MB at this depth).
+  const src = nestedRules(".a:user-valid, .b:user-valid", 20);
+  expect(() => minifyTest(src, "", { chrome: 100 << 16 })).toThrow(LIMIT_ERROR);
+});
+
 test("bun build reports an error instead of exploding on deeply nested multi-selector css", async () => {
   using dir = tempDir("css-nested-selector-expansion", {
     "input.css": nestedRules("co :is(.bar), .bar :is(.baz)", 17),


### PR DESCRIPTION
### What does this PR do?

Fixes an OOM found by CSS fuzzing (signature `oom:css:__rust_alloc|alloc::vec::spec_from_iter_nested…`): a 924-byte stylesheet of 23 unclosed nested rules, each with a two-selector list,

```css
co :is(.bar), .bar :is(.baz) {
co :is(.bar), .bar :is(.baz) {
… ×23 …
color: red;
}
```

makes the CSS minifier allocate 4+ GB. The published repro calls `minifyTest(input, "")` with **no targets** and stays linear (534 bytes of output) — the blowup needs browser targets that force `:is()`/nesting to be compiled away, which is what the real entry points use:

```sh
# default --target=browser targets are edge88/firefox78/chrome87/safari14 (no :is(), no native nesting)
bun build input.css --outdir out --minify    # 18 levels → 24 MB output; 23 levels → multi-GB RSS
```

or `minifyTest(input, "", { chrome: 80 << 16 })`. The `::part()` OOM from the same fuzzing campaign is the identical path (`::part()` can never be wrapped in `:is()`).

### Cause

Two multiplicative behaviors combine in `minify_style_arm` (`src/css/rules/mod.rs`) / `StyleRule::minify` when nesting has to be compiled for the targets:

1. Selectors the targets don't support can't stay in the same rule (one unsupported selector would make browsers drop the whole list), so each incompatible selector is split into its own rule — **including a `deep_clone` of the entire, already-expanded nested-rule subtree** (`rules: sty.rules.deep_clone(...)`). That clone's `Vec::from_iter` is the allocation stack in the fuzz signature.
2. Every nesting level's selector list multiplies into the level below.

With two incompatible selectors at each of 23 levels the minified tree holds ~2²³ style-rule structures before anything is printed → multi-GB RSS from a sub-KB input. Upstream lightningcss behaves the same way (inherited, like the backtracking issue in #31243), so there is no upstream fix to port.

### Fix

`MinifyContext` now tracks the expansion:

* `selector_expansion_multiplier` — product of the enclosing style rules' selector-list lengths, bumped only when the targets force nesting to be compiled (or the rule's selectors to be split for compatibility),
* `selector_expansion_total` — running total of selectors that expansion will produce.

Past `MAX_SELECTOR_EXPANSION` (65,536) minify stops with a new `MinifyErrorKind::selector_expansion_limit_exceeded` error instead of materializing the explosion:

```
error: Nested CSS rules expand to more than 65536 selectors when compiled for the configured browser targets. Reduce the nesting depth or the number of selectors per rule, or target browsers that support CSS nesting.
```

The check runs before descending into nested rules, so nothing exponential is allocated on the error path. Real-world stylesheets don't get anywhere near the limit (65,536 expanded selectors is already megabytes of output); stylesheets below it, stylesheets minified without browser targets, and targets that support native nesting are unaffected.

Two pieces of plumbing so the error actually reaches users:

* `StyleSheet::minify` previously hit `panic!("TODO: Handle")` when rule minification failed (the path was unreachable until now). It now returns the recorded `MinifyError` with its source location; the bundler (`ParseTask`) reports it as a build error and `cssInternals.minifyTest` throws it.
* `css_jsc/error_jsc.rs::to_error_instance` deref'd the message string after calling `bun_string_jsc::to_error_instance`, which already consumes the caller's reference. The over-deref freed the `WTFStringImpl` while the JS error still referenced it and crashed debug builds (libpas "Alloc bit not set" / ASAN) the first time a CSS minify error was actually thrown.

### Relationship to other open fuzz fixes

Same fuzzing campaign, different mechanisms, complementary fixes:

* #31276 caps the **printer-side** `&` parent-selector substitution fan-out (a single selector with multiple `&` references per level — no selector-list splitting involved). It doesn't bound this report, because here the OOM happens in minify's `deep_clone` before printing starts; and this PR doesn't bound that one, because a single selector per level keeps the multiplier at 1.
* #31270 removes duplicate re-serialization across vendor-prefix passes.

Overlap is only textual (adjacent code in `style.rs`/`error.rs`; the test file here is named `nested-selector-list-expansion.test.ts` to avoid colliding with #31276's).

### Verification

New `test/js/bun/css/nested-selector-list-expansion.test.ts`:

* 17 levels of `co :is(.bar), .bar :is(.baz)` with `{ chrome: 80 << 16 }` now throws the limit error (previously ~2¹⁸ cloned rules),
* same for the `::part()` shape,
* `bun build --minify` with default targets reports the error and exits 1 (previously 12+ MB of output at this depth, OOM at the fuzzer's depth),
* below-limit nesting still compiles for old targets, the original fuzzer repro with no targets still minifies to the same small output, and deep nesting is preserved untouched for targets that support CSS nesting.

Without the fix 3/6 tests fail; with it 6/6 pass.

Existing suites on the fixed debug (ASAN) build: `css.test.ts` + `nested-function-backtracking.test.ts` (1054 pass / 0 fail), `doesnt_crash.test.ts` (60 pass), `color.test.ts` + `small-list-grow.test.ts` (917 pass; the only failure is the pre-existing `fuzz ansi256` debug-ASAN timeout also noted in #31243), `test/bundler/css/` (166 pass).
