### PR TITLE
css: bound selector expansion when compiling nesting for older targets

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -2667,10 +2667,9 @@ mod stylesheet_impl {
             if self.rules.minify(&mut minify_ctx, false).is_err() {
                 // Minify errors report the rich error out-of-band through the
                 // context (the in-band error is just a tag).
-                let err = minify_ctx
-                    .err
-                    .take()
-                    .expect("CssRuleList::minify returned an error without setting MinifyContext::err");
+                let err = minify_ctx.err.take().expect(
+                    "CssRuleList::minify returned an error without setting MinifyContext::err",
+                );
                 return Err(self.minify_error_with_location(err));
             }
 

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -2665,10 +2665,48 @@ mod stylesheet_impl {
             };
 
             if self.rules.minify(&mut minify_ctx, false).is_err() {
-                panic!("TODO: Handle");
+                // Minify errors report the rich error out-of-band through the
+                // context (the in-band error is just a tag).
+                let err = minify_ctx
+                    .err
+                    .take()
+                    .expect("CssRuleList::minify returned an error without setting MinifyContext::err");
+                return Err(self.minify_error_with_location(err));
+            }
+
+            // When CSS nesting is compiled away, the printer substitutes `&` with
+            // the parent selector list, so the printed size of a nested rule is
+            // the product of the selector list lengths along its nesting chain —
+            // exponential in the nesting depth. Reject rules whose expansion would
+            // be unreasonably large before attempting to print them.
+            if options
+                .targets
+                .should_compile_same(compat::Feature::Nesting)
+                && let Some(loc) = css_rules::exceeds_nesting_expansion_limit(&self.rules, false, 1)
+            {
+                return Err(self.minify_error_with_location(MinifyError {
+                    kind: MinifyErrorKind::nesting_expansion_limit_exceeded,
+                    loc,
+                }));
             }
 
             Ok(())
+        }
+
+        /// Attaches the filename for `err.loc`'s source index so the error can
+        /// be reported with a proper location.
+        fn minify_error_with_location(&self, err: MinifyError) -> Err<MinifyErrorKind> {
+            Err {
+                kind: err.kind,
+                loc: self
+                    .sources
+                    .get(err.loc.source_index as usize)
+                    .map(|filename| ErrorLocation {
+                        filename: std::ptr::from_ref::<[u8]>(&**filename),
+                        line: err.loc.line,
+                        column: err.loc.column,
+                    }),
+            }
         }
 
         pub fn to_css_with_writer<'a>(

--- a/src/css/error.rs
+++ b/src/css/error.rs
@@ -502,6 +502,9 @@ pub enum MinifyErrorKind {
         /// The source location of the `@custom-media` rule with unsupported boolean logic.
         custom_media_loc: Location,
     },
+    /// Compiling CSS nesting for the configured browser targets would expand a
+    /// rule into more selector combinations than the allowed maximum.
+    nesting_expansion_limit_exceeded,
 }
 
 impl fmt::Display for MinifyErrorKind {
@@ -517,6 +520,11 @@ impl fmt::Display for MinifyErrorKind {
                 f,
                 "Unsupported boolean logic in custom media rule at line {}, column {}",
                 custom_media_loc.line, custom_media_loc.column,
+            ),
+            Self::nesting_expansion_limit_exceeded => write!(
+                f,
+                "Compiling CSS nesting for the configured browser targets would expand this rule into more than {} selector combinations. Reduce the number of selectors in nested selector lists, or target browsers that support CSS nesting.",
+                crate::rules::MAX_NESTING_EXPANSION,
             ),
         }
     }

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -663,6 +663,110 @@ impl<R> CssRuleList<R> {
 // ── `.style` arm body — preserved verbatim port, gated on StyleRule
 // behavior + selector helpers + DeclarationBlock::deep_clone. ──
 
+/// Maximum number of selector combinations a single style rule may expand into
+/// when CSS nesting is compiled away for the configured browser targets.
+///
+/// Compiling nesting multiplies selectors: every selector of a nested rule is
+/// combined with every selector of every ancestor rule, either by splitting
+/// rules during minification (`minify_style_arm`) or by substituting `&` with
+/// `:is(...)` while printing. The expansion is the product of the selector
+/// list lengths along the nesting chain, which grows exponentially with the
+/// nesting depth — ~1KB of adversarial CSS (26 nested two-selector lists) asks
+/// for 2^26 combinations and exhausts memory. Real-world stylesheets stay far
+/// below this limit.
+pub const MAX_NESTING_EXPANSION: usize = 65536;
+
+/// Counts the rules in `list`, including nested rules, returning early once
+/// the count exceeds `cap`. When the true count is `<= cap` the result is
+/// exact; otherwise it is some value `> cap`.
+fn count_rules_capped<R>(list: &CssRuleList<R>, cap: usize) -> usize {
+    let mut count: usize = 0;
+    for rule in list.v.iter() {
+        count += 1;
+        let nested: Option<&CssRuleList<R>> = match rule {
+            CssRule::Media(r) => Some(&r.rules),
+            CssRule::Supports(r) => Some(&r.rules),
+            CssRule::LayerBlock(r) => Some(&r.rules),
+            CssRule::MozDocument(r) => Some(&r.rules),
+            CssRule::Container(r) => Some(&r.rules),
+            CssRule::Scope(r) => Some(&r.rules),
+            CssRule::StartingStyle(r) => Some(&r.rules),
+            CssRule::Style(r) => Some(&r.rules),
+            CssRule::Nesting(r) => Some(&r.style.rules),
+            _ => None,
+        };
+        if let Some(nested) = nested {
+            count = count.saturating_add(count_rules_capped(nested, cap.saturating_sub(count)));
+        }
+        if count > cap {
+            return count;
+        }
+    }
+    count
+}
+
+/// Returns the location of the first nested style rule whose selectors would
+/// expand into more than [`MAX_NESTING_EXPANSION`] combinations when CSS
+/// nesting is compiled away (the printer substitutes `&` with the parent
+/// selector list, so the printed size of a nested rule is the product of the
+/// selector list lengths along its nesting chain).
+///
+/// `inside_style_rule` is whether `list` is nested within a style rule, and
+/// `ancestor_product` is the product of the selector list lengths of the
+/// enclosing style rules.
+pub(crate) fn exceeds_nesting_expansion_limit<R>(
+    list: &CssRuleList<R>,
+    inside_style_rule: bool,
+    ancestor_product: usize,
+) -> Option<Location> {
+    fn check_style_rule<R>(
+        sty: &style::StyleRule<R>,
+        inside_style_rule: bool,
+        ancestor_product: usize,
+    ) -> Result<Option<(usize, &CssRuleList<R>)>, Location> {
+        let own_len = (sty.selectors.v.len() as usize).max(1);
+        let product = ancestor_product.saturating_mul(own_len);
+        if inside_style_rule && product > MAX_NESTING_EXPANSION {
+            return Err(sty.loc);
+        }
+        if sty.rules.v.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some((product, &sty.rules)))
+        }
+    }
+
+    for rule in list.v.iter() {
+        let nested: Option<(&CssRuleList<R>, bool, usize)> = match rule {
+            CssRule::Style(sty) => match check_style_rule(sty, inside_style_rule, ancestor_product)
+            {
+                Ok(nested) => nested.map(|(product, rules)| (rules, true, product)),
+                Err(loc) => return Some(loc),
+            },
+            CssRule::Nesting(r) => {
+                match check_style_rule(&r.style, inside_style_rule, ancestor_product) {
+                    Ok(nested) => nested.map(|(product, rules)| (rules, true, product)),
+                    Err(loc) => return Some(loc),
+                }
+            }
+            CssRule::Media(r) => Some((&r.rules, inside_style_rule, ancestor_product)),
+            CssRule::Supports(r) => Some((&r.rules, inside_style_rule, ancestor_product)),
+            CssRule::LayerBlock(r) => Some((&r.rules, inside_style_rule, ancestor_product)),
+            CssRule::MozDocument(r) => Some((&r.rules, inside_style_rule, ancestor_product)),
+            CssRule::Container(r) => Some((&r.rules, inside_style_rule, ancestor_product)),
+            CssRule::Scope(r) => Some((&r.rules, inside_style_rule, ancestor_product)),
+            CssRule::StartingStyle(r) => Some((&r.rules, inside_style_rule, ancestor_product)),
+            _ => None,
+        };
+        if let Some((rules, inside, product)) = nested {
+            if let Some(loc) = exceeds_nesting_expansion_limit(rules, inside, product) {
+                return Some(loc);
+            }
+        }
+    }
+    None
+}
+
 fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
     rule: &mut CssRule<R>,
     rules: &mut Vec<CssRule<R>>,
@@ -721,6 +825,23 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
     } else {
         SmallList::default()
     };
+
+    // Each incompatible selector below clones this rule's entire nested subtree.
+    // Nested rules were minified (and possibly split the same way) first, so the
+    // subtree doubles at every nesting level whose selector list is incompatible
+    // — the total is the product of the selector list lengths along the nesting
+    // chain, which is exponential in the nesting depth. Bound the expansion and
+    // report an error instead of exhausting memory on adversarial input.
+    if incompatible.len() > 0 && !sty.rules.v.is_empty() {
+        let subtree_rules = count_rules_capped(&sty.rules, MAX_NESTING_EXPANSION);
+        if (incompatible.len() as usize).saturating_mul(subtree_rules) > MAX_NESTING_EXPANSION {
+            context.err = Some(css::error::MinifyError {
+                kind: css::error::MinifyErrorKind::nesting_expansion_limit_exceeded,
+                loc: sty.loc,
+            });
+            return Err(MinifyErr::minify_err);
+        }
+    }
 
     sty.update_prefix(context);
 

--- a/src/css_jsc/error_jsc.rs
+++ b/src/css_jsc/error_jsc.rs
@@ -17,9 +17,11 @@ where
     T: Display,
 {
     let str = BunString::create_format(format_args!("{}", this.kind));
-    // `defer str.deref()` — `bun_core::String` is `Copy` and has no `Drop`, so deref explicitly.
+    // `bun_string_jsc::to_error_instance` consumes the caller's reference
+    // (it derefs internally), so do not deref again here — the string impl is
+    // shared with the JS error's message and an extra deref frees it while
+    // still referenced.
     let js = bun_jsc::bun_string_jsc::to_error_instance(&str, global_this);
-    str.deref();
     Ok(js)
 }
 

--- a/test/js/bun/css/nesting-expansion-limit.test.ts
+++ b/test/js/bun/css/nesting-expansion-limit.test.ts
@@ -1,0 +1,96 @@
+import { cssInternals } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import path from "node:path";
+
+const { minifyTest } = cssInternals;
+
+// Regression test for unbounded memory growth when compiling CSS nesting away
+// for older browser targets.
+//
+// Compiling nesting multiplies selectors: every selector of a nested rule is
+// combined with every selector of every ancestor rule, either by splitting
+// rules apart during minification (targets without `:is()` support, which
+// includes `bun build`'s default browser targets) or by substituting `&` with
+// `:is(<parent list>)` while printing (targets with `:is()` but without CSS
+// nesting). The expansion is the product of the selector list lengths along
+// the nesting chain, so ~1KB of adversarial CSS — 26 nested two-selector
+// `::part()` lists — demanded 2^26 selector combinations and grew past 4GB of
+// memory. Such rules are now rejected with an error once they exceed 65536
+// combinations instead of exhausting memory.
+
+const EXPANSION_ERROR = "selector combinations";
+
+// Two selectors per nesting level; `::part()` cannot be wrapped in `:is()`, so
+// downleveling must combine every parent selector with every child selector.
+function nestedPartLists(depth: number): string {
+  return ".foo::part(header), .foo::part(body) {\n".repeat(depth) + "display: none\n}";
+}
+
+async function buildCSS(name: string, css: string) {
+  using dir = tempDir("css-nesting-expansion-limit", { [name]: css });
+  const outdir = path.join(String(dir), "out");
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", path.join(String(dir), name), "--outdir", outdir],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    // Kill switch: before the fix this build allocated gigabytes while
+    // expanding 2^26 selector combinations. Let the child terminate itself so
+    // a regression fails the assertions below instead of exhausting memory.
+    timeout: 15_000,
+    killSignal: "SIGKILL",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+test("nested multi-selector lists error instead of exhausting memory when splitting for old targets", () => {
+  // chrome 87 has no `:is()` support, so every nested rule is split into one
+  // rule per selector, cloning its nested subtree each time: 2^19 rules.
+  expect(() => minifyTest(nestedPartLists(19), "", { chrome: 87 << 16 })).toThrow(EXPANSION_ERROR);
+});
+
+test("nested multi-selector lists error instead of exhausting memory when compiling nesting with :is()", () => {
+  // chrome 100 supports `:is()` but not CSS nesting, so `&` is substituted
+  // with `:is(<parent list>)` at print time, doubling the output per level.
+  expect(() => minifyTest(nestedPartLists(18), "", { chrome: 100 << 16 })).toThrow(EXPANSION_ERROR);
+});
+
+test("bun build rejects exponential nesting expansion instead of running out of memory", async () => {
+  // The fuzzer-reported input: 26 nested two-selector `::part()` lists (~1KB)
+  // built with bun build's default browser targets.
+  const { stderr, exitCode } = await buildCSS("part-nesting.css", nestedPartLists(26));
+  expect(stderr).toContain(EXPANSION_ERROR);
+  expect(exitCode).toBe(1);
+});
+
+test("shallow nested multi-selector lists still expand for old targets", () => {
+  const output = minifyTest(nestedPartLists(3), "", { chrome: 87 << 16 });
+  // The cartesian product is still produced when it is small.
+  expect(output).toContain(".foo::part(header) .foo::part(header)");
+  expect(output).toContain(".foo::part(body) .foo::part(body)");
+  expect(output).toContain("display:none");
+});
+
+test("deep nesting with single-selector lists does not hit the limit", () => {
+  // The expansion is the product of selector list lengths, so single-selector
+  // lists stay linear no matter how deep they nest.
+  const input = ".foo::part(header) {\n".repeat(40) + "display: none\n}";
+  const output = minifyTest(input, "", { chrome: 87 << 16 });
+  expect(output).toContain("display:none");
+});
+
+test("deeply nested multi-selector lists are fine when no targets are configured", () => {
+  // Without browser targets nothing is downleveled, so nesting is preserved
+  // as written and no expansion takes place.
+  const output = minifyTest(nestedPartLists(26), "", "");
+  expect(output).toContain("&");
+  expect(output).toContain("display:none");
+});
+
+test("deeply nested multi-selector lists are fine when targets support CSS nesting", () => {
+  const output = minifyTest(nestedPartLists(26), "", { chrome: 130 << 16 });
+  expect(output).toContain("display:none");
+});


### PR DESCRIPTION
### What does this PR do?

Fixes unbounded memory growth (4 GB+ RSS from ~1 KB of CSS) when compiling CSS nesting away for older browser targets, found by CSS fuzzing (signature `oom:css:mi_page_free_list_extend|mi_page_extend_free…`).

The fuzzer's minimized input is 26 nested levels of

```css
.foo::part(header), .foo::part(body) {
```

The published repro calls `minifyTest(input, "")` with **no targets** and does not blow up (nesting is preserved, ~1 KB output). The same input exhausts memory as soon as CSS nesting is compiled away, which is what the real entry points do:

```sh
# default --target=browser lowers nesting (safari14/chrome87/edge88/firefox78 defaults)
bun build part-nesting.css --outdir out    # n=20 already writes a 0.4 GB file; n=26 grows past 4 GB
```

or `minifyTest(input, "", { chrome: 87 << 16 })` / `{ chrome: 100 << 16 }`. Upstream lightningcss 1.32.0 produces the same exponential output for the same input and targets, so there is no upstream fix to port.

### Cause

Compiling nesting away multiplies selectors: every selector of a nested rule ends up combined with every selector of every ancestor rule, so the expansion is the **product of the selector list lengths along the nesting chain** — 2^26 combinations for this input. That product is realized through two independent paths:

1. **Minify-time splitting** (`minify_style_arm`): when the targets lack `:is()` support (the default browser targets include chrome 87), every nested rule's `&`-selectors are "incompatible", so the rule is split into one rule per selector and its **entire nested subtree is deep-cloned per selector**. Nested rules are minified bottom-up, so the subtree doubles at every level — 2^26 rule clones in the arena before anything is printed. This is what the fuzzer's OOM actually is.
2. **Print-time `&` substitution** (`serialize_nesting`): with targets that have `:is()` but not nesting (chrome 88–119), rules are not split, but the printer substitutes `&` with `:is(<parent list>)`, and the parent's serialization contains its own already-expanded `&` — the printed text doubles per level.

### Fix

Add `MAX_NESTING_EXPANSION = 65536` (combinations per style rule) and report a CSS minify error instead of exhausting memory:

* `minify_style_arm` checks `incompatible selectors × nested subtree size` before cloning the subtree (bounds path 1 regardless of which selector feature made the list incompatible).
* After minification, `StyleSheet::minify` walks the remaining rule tree and rejects any nested rule whose chain product exceeds the limit when nesting will be compiled at print time (bounds path 2 before the printer does the work).

Real-world stylesheets stay orders of magnitude below the limit (the entire expansion of one source rule would already be several MB of output at the threshold); only runaway expansions hit it. Behavior is unchanged for stylesheets with no targets, targets that support nesting natively, single-selector nesting of any depth, and every existing CSS test.

Supporting changes required to surface the error:

* `StyleSheet::minify` previously hit `panic!("TODO: Handle")` for any minify error; it now returns the error with the offending rule's filename/line/column, so `bun build` prints a proper diagnostic:
  ```
  error: Compiling CSS nesting for the configured browser targets would expand this rule into more than 65536 selector combinations. Reduce the number of selectors in nested selector lists, or target browsers that support CSS nesting.
      at part-nesting.css:11:1
  ```
* `css_jsc/error_jsc.rs::to_error_instance` deref'd the message string once too often (`bun_string_jsc::to_error_instance` already consumes the reference), freeing the JS error's message while still referenced. This was latent because no CSS minify error could previously reach JS; with the new error path it corrupted memory (libpas "Alloc bit not set" / `spansOverlap` assertions on debug builds).

Related: #31276 caps the printer-side `&`-substitution count for a different fuzz finding (`&:is(.bar, &.baz)` nesting — single-selector lists with multiple `&` per selector, which the list-length product here intentionally does not flag), and #31270 fixes duplicate re-serialization across vendor-prefix passes. The mechanisms are independent: neither of those bounds the minify-time subtree cloning that OOMs this input under `bun build`'s default targets, and this change does not bound theirs — the fixes are complementary and touch adjacent code.

### Verification

New `test/js/bun/css/nesting-expansion-limit.test.ts`:

* the nested `::part()` input errors with the new message for chrome 87 (split path) and chrome 100 (`:is()` path) instead of expanding,
* `bun build` on the 26-level fuzzer input with default targets exits with the error in ~2 s (spawned with a kill switch so a regression fails instead of OOMing the runner),
* shallow multi-selector nesting still expands fully for old targets, deep single-selector nesting still compiles, and the original no-targets repro plus modern-target builds are unchanged.

Without the fix the first three tests fail (no error is raised; the build is killed by the watchdog); with it all seven pass.

Existing suites on the debug build: `test/js/bun/css/` css / color / css-modules / small-list-grow / nested-function-backtracking / doesnt_crash (2091 pass), `test/bundler/css/` (166 pass), `test/bundler/esbuild/css.test.ts` + CSS regression tests (56 pass). The only failure is the pre-existing `fuzz ansi256` debug-ASAN timeout (color integer math, unrelated). `cargo clippy -p bun_css` is clean.
