### PR TITLE
css: fix quadratic minify time on stylesheets with many duplicate rules

### DIFF
--- a/src/css/properties/properties_generated.rs
+++ b/src/css/properties/properties_generated.rs
@@ -7393,7 +7393,10 @@ impl Property {
                 css::generic::eql(&a.0, &b.0) && a.1 == b.1
             }
             (Property::ColorScheme(a), Property::ColorScheme(b)) => css::generic::eql(a, b),
-            (Property::All(_), Property::All(_)) => true,
+            // PORT NOTE: the Zig spec compares only the tag here (`.all => true`),
+            // but `eql` must be value equality — `all: unset` and `all: revert`
+            // are different declarations. Compare the CSS-wide keyword payload.
+            (Property::All(a), Property::All(b)) => a == b,
             (Property::Unparsed(a), Property::Unparsed(b)) => a.eql(b),
             (Property::Custom(a), Property::Custom(b)) => a.eql(b),
             _ => false,

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -930,6 +930,32 @@ impl StyleRuleKeyMap {
 
 // ─── merge_style_rules ─────────────────────────────────────────────────────
 
+/// Remove declarations from `existing` that are exactly duplicated (same
+/// property, equal value) by a declaration in `incoming`.
+///
+/// Used when merging same-selector rules: the incoming declarations are
+/// appended *after* the existing ones, so dropping the earlier identical copy
+/// cannot change the cascade in any browser. It does, however, keep the merged
+/// block from growing by one copy per duplicated source rule — without this,
+/// every merge re-minifies an ever-growing declaration list and minifying a
+/// stylesheet made of thousands of identical rules becomes quadratic.
+fn remove_duplicate_declarations<'a, 'b>(
+    existing: &mut css::DeclarationList<'a>,
+    incoming: &css::DeclarationList<'b>,
+) {
+    if existing.is_empty() || incoming.is_empty() {
+        return;
+    }
+    let mut i = 0;
+    while i < existing.len() {
+        if incoming.iter().any(|new| new.eql(&existing[i])) {
+            existing.remove(i);
+        } else {
+            i += 1;
+        }
+    }
+}
+
 /// Merge `sty` into `last_style_rule` if their selectors/declarations allow.
 /// Returns `true` if merged (caller should drop `sty`).
 pub fn merge_style_rules<R>(
@@ -947,6 +973,14 @@ pub fn merge_style_rules<R>(
         && last_style_rule.rules.v.is_empty()
         && (!context.css_modules || sty.loc.source_index == last_style_rule.loc.source_index)
     {
+        remove_duplicate_declarations(
+            &mut last_style_rule.declarations.declarations,
+            &sty.declarations.declarations,
+        );
+        remove_duplicate_declarations(
+            &mut last_style_rule.declarations.important_declarations,
+            &sty.declarations.important_declarations,
+        );
         last_style_rule
             .declarations
             .declarations

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { describe, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import "harness";
 import { join } from "path";
 import {
@@ -7443,6 +7443,41 @@ describe("css tests", () => {
         `,
       { chrome: Some(90 << 16) },
     );
+  });
+
+  describe("duplicate rule merging", () => {
+    // When same-selector rules are merged, a declaration that is exactly
+    // duplicated by a later one is dropped. Previously every duplicated rule
+    // re-added its declarations to the merged rule and the whole (ever-growing)
+    // list was re-minified, so stylesheets made of thousands of identical rules
+    // minified in quadratic time — a ~30 KB input of repeated
+    // `.foo { color-scheme: only foo dark bar; }` rules tripped the CSS
+    // fuzzer's hang detector.
+    minify_test(".foo { color-scheme: dark; } .foo { color-scheme: dark; }", ".foo{color-scheme:dark}");
+    minify_test(
+      ".foo { color-scheme: only foo dark bar; } .foo { color-scheme: only foo dark bar; }",
+      ".foo{color-scheme:dark only}",
+    );
+    minify_test(".foo { --x: 1; } .foo { --x: 1; } .foo { --x: 1; }", ".foo{--x:1}");
+    minify_test(
+      ".foo { color-scheme: dark !important; } .foo { color-scheme: dark !important; }",
+      ".foo{color-scheme:dark!important}",
+    );
+    // Only exact duplicates collapse; differing values keep their cascade order
+    // so fallback declarations survive.
+    minify_test(
+      ".foo { unknown-prop: a; } .foo { unknown-prop: b; } .foo { unknown-prop: a; }",
+      ".foo{unknown-prop:b;unknown-prop:a}",
+    );
+    minify_test(".foo { unknown-prop: a; } .foo { unknown-prop: b; }", ".foo{unknown-prop:a;unknown-prop:b}");
+
+    test("minifying thousands of identical rules stays fast", () => {
+      // Same shape as the fuzzer input that hit the hang detector: one rule
+      // repeated until the stylesheet is tens of kilobytes.
+      const rule = ".foo { color-scheme: only foo dark bar; }\n";
+      const source = Buffer.alloc(rule.length * 1000, rule).toString();
+      expect(minify_test_with_options(source, "")).toEqual(".foo{color-scheme:dark only}");
+    });
   });
 
   describe("page", () => {

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7470,6 +7470,10 @@ describe("css tests", () => {
       ".foo{unknown-prop:b;unknown-prop:a}",
     );
     minify_test(".foo { unknown-prop: a; } .foo { unknown-prop: b; }", ".foo{unknown-prop:a;unknown-prop:b}");
+    // Different `all:` CSS-wide keywords are not duplicates of each other — the
+    // earlier declaration is a fallback for browsers without `revert` support.
+    minify_test(".foo { all: unset; } .foo { all: revert; }", ".foo{all:unset;all:revert}");
+    minify_test(".foo { all: unset; } .foo { all: unset; }", ".foo{all:unset}");
 
     test("minifying thousands of identical rules stays fast", () => {
       // Same shape as the fuzzer input that hit the hang detector: one rule


### PR DESCRIPTION
### What does this PR do?

Fixes a CSS minifier hang found by fuzzing: a ~30 KB stylesheet consisting of one rule repeated hundreds of times (`.foo { color-scheme: only foo dark bar; }` × 733) makes CSS minification take quadratic time — long enough to trip the fuzzer's hang detector, which sampled the process spinning in `drop_in_place<bun_css::properties::Property>`.

The same input through the bundler is far worse than through the test harness, because default browser targets make every duplicated `color-scheme` declaration expand into extra custom-property polyfills that are re-cloned and re-dropped on every merge:

```bash
bun -e 'require("fs").writeFileSync("dup.css", ".foo { color-scheme: only foo dark bar; }\n".repeat(1000))'
bun build dup.css --outdir out        # 43 KB input, ~40 s before this change (release build)
# 2000 rules (86 KB): does not finish within 2 minutes
```

Any stylesheet reachable from `bun build`, an `import "./x.css"`, or the dev server is an entry point, so a generated/concatenated CSS file with many repeated rules can effectively DoS the bundler. (`--minify` is not required; the bundler always runs the minify pass on CSS.)

### Root cause

`CssRuleList::minify` merges adjacent style rules with identical selectors by appending the incoming rule's declarations to the accumulated rule and re-minifying the whole merged block (`merge_style_rules` in `src/css/rules/mod.rs`). That is only linear if duplicate declarations collapse during re-minification — but they don't: the `color-scheme` handler pushes the declaration (plus its `--buncss-light`/`--buncss-dark` polyfill vars when targets are set) on every pass, and properties without a dedicated handler are appended as-is. With n identical source rules, the k-th merge re-processes k declarations, so the whole pass is O(n²) Property clones and drops — which is exactly where the fuzzer's stack samples landed.

Upstream lightningcss 1.30.2 is quadratic on this exact input too (1000 rules → 139 ms, 2000 → 575 ms, 4000 → 2.4 s, 8000 → 10.3 s via the npm package), so there is no upstream fix to port.

### The fix

In the same-selector merge branch, before appending the incoming declarations, drop any declaration in the accumulated rule that is exactly duplicated (same property, equal value via `Property::eql`) by an incoming declaration. The incoming copy is appended right after and sits later in the block, so the computed style is unchanged in every browser: whatever declaration a given browser used before is still the last one it understands. Declarations with the *same property but different values* (fallback patterns) are left alone and keep their cascade order.

With exact duplicates collapsing, the merged block stays bounded and repeated rules minify in linear time. Output also improves: n identical `.foo { color-scheme: …; }` rules now minify to a single `.foo{color-scheme:dark only}` instead of one rule containing n duplicate declarations.

Measurements for the 733-rule / 30 KB fuzz input (debug ASAN build): 745 ms → 46 ms, and scaling is now linear (6000 rules: 378 ms; previously ~4.3× per doubling). Through the bundler: `bun build` on 1000 duplicated rules went from ~40 s (release, before) to 0.36 s (debug, after); 8000 rules complete in ~1 s.

Follow-up from review: `Property::eql`'s arm for the `all` shorthand ignored its `CSSWideKeyword` payload (`all: unset` and `all: revert` compared equal). Nothing constructs `Property::All` from parsed CSS today (`all` currently falls back to the unknown-property representation, so the dedup was not affected in practice), but the dedup relies on `eql` being value equality, so the arm now compares the keyword and tests cover `all: unset` + `all: revert` fallbacks surviving the merge.

### Verification

- New `duplicate rule merging` tests in `test/js/bun/css/css.test.ts`: identical-rule dedup for `color-scheme`, a custom property, and `!important` declarations; the exact fuzz shape at 1000 repetitions; and guards that differing values keep their cascade order. Six of the seven fail on an unfixed build (duplicates pile up in the output).
- Existing suites pass with the fix: `test/js/bun/css/css.test.ts` (1062), `color.test.ts` + `doesnt_crash.test.ts` + `small-list-grow.test.ts` + `nested-function-backtracking.test.ts` (982 — the only failure is the pre-existing `fuzz ansi256` debug-ASAN timeout, which never touches CSS), `test/bundler/css/` (166), `test/bundler/esbuild/css.test.ts` + CSS regression tests (56).

