### PR TITLE
Fix CSS angle serialization hang on huge radian values

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -6838,6 +6838,15 @@ pub fn fract(val: f32) -> f32 {
 
 pub fn f32_length_with_5_digits(n_input: f32) -> usize {
     let mut n = (n_input * 100000.0).round();
+
+    // Huge values (>= ~3.4e33) overflow to infinity when scaled, and infinity
+    // never drops below 1.0 no matter how many times it is divided by 10, so
+    // the loop below would spin forever. Treat non-finite values as longer
+    // than any finite representation.
+    if !n.is_finite() {
+        return usize::MAX;
+    }
+
     let mut count: usize = 0;
     let mut i: usize = 0;
 

--- a/test/js/bun/css/angle-serialization-hang.test.ts
+++ b/test/js/bun/css/angle-serialization-hang.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test for an infinite loop in angle serialization.
+//
+// `Angle::to_css` decides whether to print a `rad` value as `deg` by comparing
+// the printed lengths of both forms via `f32_length_with_5_digits`, which
+// scales the value by 100000 and repeatedly divides by 10. For huge radian
+// values (>= ~3.4e33), values near f32::MAX, or an infinity produced by
+// `calc(infinity * 1rad)` or by the rad->deg conversion overflowing, the
+// scaled value becomes infinity and dividing by 10 never makes progress, so
+// serialization spun forever inside `fmodf`.
+//
+// The child process is given a kill switch so a regression fails the
+// assertions below instead of hanging the test runner forever.
+
+const cases: [css: string, expected: string][] = [
+  // Fuzzer repros: huge radian values in a known property, an unknown
+  // property (token list path), and an unparsed/invalid declaration.
+  [
+    "a { rotate: 99999999999999999999999999999999999999999999999999rad }",
+    "a{rotate:3.40282e38rad}",
+  ],
+  ["a { ro: 1.3157e308rad }", "a{ro:3.40282e38rad}"],
+  [
+    "a { rotate: 0.0000000000000000000000000000000000000\t00000000000000000000000000000000000200000000000000000000000000000001rad }",
+    "a{rotate:0 2e+32rad}",
+  ],
+  // Other paths that serialize an Angle: transform functions and filters.
+  ["a { transform: rotate(3.3e33rad) }", "a{transform:rotate(3.3e+33rad)}"],
+  ["a { filter: hue-rotate(1e50rad) }", "a{filter:hue-rotate(3.40282e38rad)}"],
+  // calc() can produce a real infinity.
+  ["a { rotate: calc(infinity * 1rad) }", "a{rotate:3.40282e38rad}"],
+  // Sanity check: small radian values still switch to degrees when shorter.
+  ["a { transform: rotate(0.017453293rad) }", "a{transform:rotate(1deg)}"],
+];
+
+test("huge and non-finite radian angle values serialize instead of hanging", async () => {
+  const script = `
+    const { minifyTest } = require("bun:internal-for-testing").cssInternals;
+    const inputs = ${JSON.stringify(cases.map(([css]) => css))};
+    console.log(JSON.stringify(inputs.map(css => minifyTest(css, ""))));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    // Kill switch: before the fix, serializing the first input spun forever.
+    timeout: 20_000,
+    killSignal: "SIGKILL",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  expect(JSON.parse(stdout)).toEqual(cases.map(([, expected]) => expected));
+});

--- a/test/js/bun/css/angle-serialization-hang.test.ts
+++ b/test/js/bun/css/angle-serialization-hang.test.ts
@@ -52,6 +52,6 @@ test("huge and non-finite radian angle values serialize instead of hanging", asy
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toBe("");
-  expect(exitCode).toBe(0);
   expect(JSON.parse(stdout)).toEqual(cases.map(([, expected]) => expected));
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/css/angle-serialization-hang.test.ts
+++ b/test/js/bun/css/angle-serialization-hang.test.ts
@@ -17,10 +17,7 @@ import { bunEnv, bunExe } from "harness";
 const cases: [css: string, expected: string][] = [
   // Fuzzer repros: huge radian values in a known property, an unknown
   // property (token list path), and an unparsed/invalid declaration.
-  [
-    "a { rotate: 99999999999999999999999999999999999999999999999999rad }",
-    "a{rotate:3.40282e38rad}",
-  ],
+  ["a { rotate: 99999999999999999999999999999999999999999999999999rad }", "a{rotate:3.40282e38rad}"],
   ["a { ro: 1.3157e308rad }", "a{ro:3.40282e38rad}"],
   [
     "a { rotate: 0.0000000000000000000000000000000000000\t00000000000000000000000000000000000200000000000000000000000000000001rad }",


### PR DESCRIPTION
### What does this PR do?

Fixes a hang (infinite loop) found by fuzzing: the CSS minifier/printer never terminates when serializing a radian `<angle>` whose value is huge or non-finite.

```sh
# spins forever in fmodf before this change
bun build --minify ./repro.css   # repro.css: a { rotate: 1e50rad }
```

Other affected inputs: `a { ro: 1.3157e308rad }` (unknown-property token list), `transform: rotate(3.3e33rad)`, `filter: hue-rotate(1e50rad)`, and `rotate: calc(infinity * 1rad)`.

### Cause

`Angle::to_css` decides whether a `rad` value prints shorter as `deg` by comparing both forms with `f32_length_with_5_digits()` (`src/css/css_parser.rs`). That helper computes `n = (value * 100000.0).round()` and then loops `while n >= 1.0 { n % 10.0; n /= 10.0; }`.

For radian values ≥ ~3.4e33 — or an infinity coming from `calc(infinity * 1rad)` or from the rad→deg conversion overflowing — `value * 100000.0` overflows `f32` to `+inf`. `inf / 10.0` is still `inf`, so the loop never makes progress and the process spins forever inside `fmodf`.

### Fix

Bail out of `f32_length_with_5_digits` when the scaled value is not finite, returning `usize::MAX` ("longer than any finite representation"). The comparison in `Angle::to_css` then keeps the authored `rad` unit, and serialization proceeds through the existing path that already clamps infinities to `3.40282e38` (same as huge `deg` values, e.g. `rotate: 1e50deg` → `rotate:3.40282e38deg`).

Output after the fix:

| input | output |
| --- | --- |
| `rotate: 1e50rad` | `rotate:3.40282e38rad` |
| `ro: 1.3157e308rad` | `ro:3.40282e38rad` |
| `transform: rotate(3.3e33rad)` | `transform:rotate(3.3e+33rad)` |
| `filter: hue-rotate(1e50rad)` | `filter:hue-rotate(3.40282e38rad)` |
| `rotate: calc(infinity * 1rad)` | `rotate:3.40282e38rad` |
| `transform: rotate(0.017453293rad)` | `transform:rotate(1deg)` (unchanged) |

### How did you verify your code works?

- New test `test/js/bun/css/angle-serialization-hang.test.ts` minifies the fuzzer repros plus the other affected paths in a child process with a kill switch. It fails (child killed / test timeout) on bun without the fix and passes with it.
- Existing CSS suites (`css.test.ts`, `color.test.ts`, `nested-function-backtracking.test.ts`, `doesnt_crash.test.ts`) pass with the change: 2036 pass; the only failure is the pre-existing `fuzz ansi256` slowness in debug builds, which is unrelated to this change.
