### PR TITLE
distroless: ship libgcc_s.so.1 so worker.terminate() works

### DIFF
--- a/dockerhub/distroless/Dockerfile
+++ b/dockerhub/distroless/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 FROM debian:trixie-slim AS build
 
 # https://github.com/oven-sh/bun/releases
@@ -86,11 +87,10 @@ EOF
 # / pthread_cancel, which is how `worker_threads` terminates workers. The
 # base image ships libc but not libgcc, so without this copy
 # worker.terminate() prints "libgcc_s.so.1 must be installed for pthread_exit
-# to work" and the worker thread aborts. One COPY per supported arch — the
-# `[1]` char-class glob expands to the single file on the matching arch and
-# to zero files on the other, which BuildKit treats as a no-op. Destination
-# is `/lib/<arch>/`, matching where the base image keeps libc.
-COPY --from=build /usr/lib/x86_64-linux-gnu/libgcc_s.so.[1] /lib/x86_64-linux-gnu/
-COPY --from=build /usr/lib/aarch64-linux-gnu/libgcc_s.so.[1] /lib/aarch64-linux-gnu/
+# to work" and the worker thread aborts. `--parents` preserves the
+# `/usr/lib/<arch>-linux-gnu/` prefix so the file lands alongside libc in
+# the dynamic linker's search path. Only the current build arch's subdir
+# exists in the build stage; the `*` matches it and nothing else.
+COPY --from=build --parents /usr/lib/*-linux-gnu/libgcc_s.so.1 /
 
 ENTRYPOINT ["/usr/local/bin/bun"]

--- a/dockerhub/distroless/Dockerfile
+++ b/dockerhub/distroless/Dockerfile
@@ -82,4 +82,15 @@ RUN --mount=type=bind,from=build,source=/usr/bin,target=/usr/bin \
   ln -s /usr/local/bin/bun /usr/local/bun-node-fallback-bin/nodebun
 EOF
 
+# libgcc_s.so.1 is dlopen'd by glibc for stack unwinding during pthread_exit
+# / pthread_cancel, which is how `worker_threads` terminates workers. The
+# base image ships libc but not libgcc, so without this copy
+# worker.terminate() prints "libgcc_s.so.1 must be installed for pthread_exit
+# to work" and the worker thread aborts. One COPY per supported arch — the
+# `[1]` char-class glob expands to the single file on the matching arch and
+# to zero files on the other, which BuildKit treats as a no-op. Destination
+# is `/lib/<arch>/`, matching where the base image keeps libc.
+COPY --from=build /usr/lib/x86_64-linux-gnu/libgcc_s.so.[1] /lib/x86_64-linux-gnu/
+COPY --from=build /usr/lib/aarch64-linux-gnu/libgcc_s.so.[1] /lib/aarch64-linux-gnu/
+
 ENTRYPOINT ["/usr/local/bin/bun"]

--- a/dockerhub/distroless/Dockerfile
+++ b/dockerhub/distroless/Dockerfile
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile:1.7
 FROM debian:trixie-slim AS build
 
 # https://github.com/oven-sh/bun/releases
@@ -54,7 +53,8 @@ RUN apt-get update -qq \
     && rm -f "bun-linux-$build.zip" SHASUMS256.txt.asc SHASUMS256.txt \
     && chmod +x /usr/local/bin/bun \
     && which bun \
-    && bun --version
+    && bun --version \
+    && mkdir -p /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu
 
 FROM gcr.io/distroless/base-nossl-debian13
 
@@ -87,10 +87,12 @@ EOF
 # / pthread_cancel, which is how `worker_threads` terminates workers. The
 # base image ships libc but not libgcc, so without this copy
 # worker.terminate() prints "libgcc_s.so.1 must be installed for pthread_exit
-# to work" and the worker thread aborts. `--parents` preserves the
-# `/usr/lib/<arch>-linux-gnu/` prefix so the file lands alongside libc in
-# the dynamic linker's search path. Only the current build arch's subdir
-# exists in the build stage; the `*` matches it and nothing else.
-COPY --from=build --parents /usr/lib/*-linux-gnu/libgcc_s.so.1 /
+# to work" and the worker thread aborts. The `build` stage `mkdir`s both
+# arch dirs so BuildKit's zero-match glob (the `[1]` char-class) silently
+# no-ops on the non-native arch — otherwise it would error because the
+# parent dir doesn't exist in the single-arch build stage. Destination is
+# `/lib/<arch>/`, matching where the base image keeps libc.
+COPY --from=build /usr/lib/x86_64-linux-gnu/libgcc_s.so.[1] /lib/x86_64-linux-gnu/
+COPY --from=build /usr/lib/aarch64-linux-gnu/libgcc_s.so.[1] /lib/aarch64-linux-gnu/
 
 ENTRYPOINT ["/usr/local/bin/bun"]

--- a/test/js/bun/test/parallel/test-docker-build-distroless.ts
+++ b/test/js/bun/test/parallel/test-docker-build-distroless.ts
@@ -1,17 +1,58 @@
 import { expect } from "bun:test";
-import { bunEnv, dockerExe, isDockerEnabled } from "harness";
+import { bunEnv, dockerExe, isDockerEnabled, tempDir } from "harness";
 import { resolve } from "path";
 
 if (isDockerEnabled()) {
   const docker = dockerExe()!;
   const cwd = resolve(import.meta.dir, "..", "..", "..", "..", "..", "dockerhub", "distroless");
-  const proc = Bun.spawn({
-    cmd: [docker, "build", "--progress=plain", "--no-cache", "--rm", "."],
+
+  // Tag the built image so we can run it below to verify libgcc_s.so.1 is
+  // available for worker_threads termination (regression test for #31281).
+  const tag = `bun-distroless-${process.pid}-${Date.now()}`;
+  const buildProc = Bun.spawn({
+    cmd: [docker, "build", "--progress=plain", "--no-cache", "--rm", "-t", tag, "."],
     stdio: ["ignore", "inherit", "inherit"],
     cwd,
     env: bunEnv,
   });
-  await proc.exited;
-  expect(proc.signalCode).toBeNull();
-  expect(proc.exitCode).toBe(0);
+  await buildProc.exited;
+  expect(buildProc.signalCode).toBeNull();
+  expect(buildProc.exitCode).toBe(0);
+
+  try {
+    // Worker.terminate() triggers pthread_cancel inside glibc, which dlopens
+    // libgcc_s.so.1 for stack unwinding. Without it distroless prints
+    // "libgcc_s.so.1 must be installed for pthread_exit to work" to stderr.
+    using dir = tempDir("bun-distroless-worker", {
+      "main.js": `
+        import { Worker } from "node:worker_threads";
+        const worker = new Worker(new URL("./worker.js", import.meta.url));
+        await new Promise(r => worker.on("online", r));
+        await worker.terminate();
+        console.log("worker-terminated");
+        process.exit(0);
+      `,
+      "worker.js": `setInterval(() => {}, 1000);`,
+    });
+
+    await using runProc = Bun.spawn({
+      cmd: [docker, "run", "--rm", "-v", `${String(dir)}:/app`, "-w", "/app", tag, "run", "main.js"],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      runProc.stdout.text(),
+      runProc.stderr.text(),
+      runProc.exited,
+    ]);
+
+    expect(stderr).not.toContain("libgcc_s.so.1");
+    expect(stdout).toContain("worker-terminated");
+    expect(exitCode).toBe(0);
+  } finally {
+    // Best-effort cleanup — don't fail the test on rmi errors.
+    Bun.spawnSync({ cmd: [docker, "rmi", "-f", tag], stdio: ["ignore", "ignore", "ignore"], env: bunEnv });
+  }
 }


### PR DESCRIPTION
## Problem

The `oven/bun:*-distroless` image aborts on `worker.terminate()` with:

```
libgcc_s.so.1 must be installed for pthread_exit to work
```

Reported in #31281 with a [reproduction repo](https://github.com/cartok/bun-distroless-pthread-exit-repro).

## Cause

glibc dlopens `libgcc_s.so.1` when a thread goes through the forced-unwind path — `pthread_exit` / `pthread_cancel` run per-thread cleanup handlers and `thread_local` C++ destructors via libgcc's unwinder. `node:worker_threads` termination triggers that path through JSC's `VM::notifyNeedTermination`. The base image (`gcr.io/distroless/base-nossl-debian13`) ships libc but not libgcc, so the dlopen fails and glibc `__libc_fatal`s the worker thread.

The user's documented workaround is to `COPY --parents` `libgcc_s.so.1` from a slim-stage image.

## Fix

Copy `libgcc_s.so.1` from the existing `debian:trixie-slim` build stage into the multiarch lib dir of the final image:

```dockerfile
COPY --from=build /usr/lib/x86_64-linux-gnu/libgcc_s.so.[1] /lib/x86_64-linux-gnu/
COPY --from=build /usr/lib/aarch64-linux-gnu/libgcc_s.so.[1] /lib/aarch64-linux-gnu/
```

The `[1]` char-class glob expands to the single file on the matching arch and to zero files on the other, which BuildKit treats as a silent no-op — so one COPY line per supported arch covers both multi-arch builds without needing shell-based arch detection.

Destination is `/lib/<arch>-linux-gnu/` to sit alongside `libc.so.6` in the base image's default dynamic-linker search path.

## Verification

`test/js/bun/test/parallel/test-docker-build-distroless.ts` now also `docker run`s the built image with a script that spawns a worker and calls `worker.terminate()`, asserting:
- `worker-terminated` is logged to stdout
- `libgcc_s.so.1` does not appear in stderr
- exit code is 0

Without the COPYs the container aborts on `worker.terminate()` and the test fails; with them the worker terminates cleanly.

Closes #31281