### PR TITLE
fix(CryptoHasher): don't crash on non-latin1 algorithm names

### DIFF
--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -897,7 +897,7 @@ impl CryptoHasherZig {
     ) -> JsResult<Option<JSValue>> {
         macro_rules! arm {
             ($name:literal, $ty:ty, $g:expr, $alg:expr, $in:expr, $out:expr) => {
-                if $alg.slice() == $name {
+                if $alg.eql_comptime($name) {
                     return Ok(Some(Self::hash_by_name_inner::<$ty>($g, $in, $out)?));
                 }
             };
@@ -1010,7 +1010,7 @@ impl CryptoHasherZig {
     fn constructor(algorithm: &ZigString) -> Option<Box<CryptoHasher>> {
         macro_rules! arm {
             ($name:literal, $ty:ty, $alg:expr) => {
-                if $alg.slice() == $name {
+                if $alg.eql_comptime($name) {
                     return Some(CryptoHasher::new(CryptoHasher::Zig(JsCell::new(
                         CryptoHasherZig {
                             algorithm: <$ty as ZigHashAlgo>::ALGORITHM,

--- a/test/js/bun/util/bun-cryptohasher.test.ts
+++ b/test/js/bun/util/bun-cryptohasher.test.ts
@@ -15,6 +15,16 @@ test("CryptoHasher update should throw when no parameter/null/undefined is passe
   // @ts-expect-error
   expect(() => new Bun.CryptoHasher("sha1").update(null)).toThrow();
 });
+test("CryptoHasher throws on non-latin1 algorithm names instead of crashing", () => {
+  // @ts-expect-error
+  expect(() => Bun.CryptoHasher.hash("🚀", "hello")).toThrow(/Unsupported algorithm/);
+  // @ts-expect-error
+  expect(() => Bun.CryptoHasher.hash("sha3-256\u{1F680}", "hello", "hex")).toThrow(/Unsupported algorithm/);
+  // @ts-expect-error
+  expect(() => new Bun.CryptoHasher("🚀")).toThrow(/Unsupported algorithm/);
+  // @ts-expect-error
+  expect(() => new Bun.CryptoHasher("ünïcode")).toThrow(/Unsupported algorithm/);
+});
 
 describe("HMAC", () => {
   const hashes = {


### PR DESCRIPTION
### What does this PR do?

Fixes a crash (debug assertion failure) found by fuzzing:

```
panic: ZigString::slice() on UTF-16 string; use to_slice() (src/bun_alloc/lib.rs)
```

`CryptoHasherZig::hash_by_name` and `CryptoHasherZig::constructor` compare the user-supplied algorithm name against the Zig-backed algorithm table (`sha3-*`, `shake*`, `blake2s256`) using `ZigString::slice()`, which asserts the string is 8-bit. Any algorithm name that JSC stores as UTF-16 (i.e. containing non-latin1 characters) reaches that assert and aborts the process:

```js
Bun.CryptoHasher.hash("🚀", "hello");  // panic
new Bun.CryptoHasher("🚀");            // panic
```

This PR switches both comparisons to the encoding-aware `ZigString::eql_comptime`, so UTF-16 algorithm names are compared correctly and unknown names fall through to the existing `Unsupported algorithm` JS error:

```js
Bun.CryptoHasher.hash("🚀", "hello");
// error: Unsupported algorithm "🚀"
```

### How did you verify your code works?

- Added a regression test to `test/js/bun/util/bun-cryptohasher.test.ts`; it aborts with the panic above on an unpatched debug build and passes with this change.
- `bun bd test test/js/bun/util/bun-cryptohasher.test.ts` — 397 pass, 0 fail.
