### PR TITLE
fix(plugin): propagate exception from Bun.plugin target string coercion

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -302,8 +302,11 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
     auto targetValue = obj->getIfPropertyExists(globalObject, Identifier::fromString(vm, "target"_s));
     RETURN_IF_EXCEPTION(throwScope, {});
     if (targetValue) {
-        if (auto* targetJSString = targetValue.toStringOrNull(globalObject)) {
+        auto* targetJSString = targetValue.toStringOrNull(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (targetJSString) {
             String targetString = targetJSString->value(globalObject);
+            RETURN_IF_EXCEPTION(throwScope, {});
             if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
                 JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
                 return {};

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -302,15 +302,13 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
     auto targetValue = obj->getIfPropertyExists(globalObject, Identifier::fromString(vm, "target"_s));
     RETURN_IF_EXCEPTION(throwScope, {});
     if (targetValue) {
-        auto* targetJSString = targetValue.toStringOrNull(globalObject);
+        auto* targetJSString = targetValue.toString(globalObject);
         RETURN_IF_EXCEPTION(throwScope, {});
-        if (targetJSString) {
-            String targetString = targetJSString->value(globalObject);
-            RETURN_IF_EXCEPTION(throwScope, {});
-            if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
-                JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
-                return {};
-            }
+        String targetString = targetJSString->value(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
+            JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
+            return {};
         }
     }
 

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="./plugins" />
 import { plugin } from "bun";
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, jest } from "bun:test";
 import { resolve } from "path";
 
 declare global {
@@ -367,8 +367,9 @@ describe("errors", () => {
   });
 
   it("handles a 'target' whose toString throws", () => {
+    const setup = jest.fn();
     const opts = {
-      setup: () => {},
+      setup,
       target: {
         toString() {
           throw new Error("target toString error");
@@ -379,6 +380,7 @@ describe("errors", () => {
     expect(() => {
       plugin(opts as any);
     }).toThrow("target toString error");
+    expect(setup).not.toHaveBeenCalled();
   });
 
   it("invalid loaders throw", () => {

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -366,6 +366,21 @@ describe("errors", () => {
     }).toThrow("plugin target must be one of 'node', 'bun' or 'browser'");
   });
 
+  it("handles a 'target' whose toString throws", () => {
+    const opts = {
+      setup: () => {},
+      target: {
+        toString() {
+          throw new Error("target toString error");
+        },
+      },
+    };
+
+    expect(() => {
+      plugin(opts as any);
+    }).toThrow("target toString error");
+  });
+
   it("invalid loaders throw", () => {
     const invalidLoaders = ["blah", "blah2", "blah3", "blah4"];
     const inputs = ["body { background: red; }", "<h1>hi</h1>", '{"hi": "there"}', "hi"];


### PR DESCRIPTION
### What does this PR do?

Fixes a crash (debug assertion `ExceptionScope::assertNoException`) found by fuzzing in `Bun.plugin()`.

When the `target` option is an object whose `toString()` throws, `setupBunPlugin` called `targetValue.toStringOrNull(globalObject)`, got back `nullptr`, and silently fell through with the exception still pending. It then continued building the builder object and invoked the user's `setup()` function while an exception was pending, which trips `ExceptionScope::assertNoException()` in debug builds and leaves the VM in an inconsistent exception state in release builds.

```js
Bun.plugin({
  setup() {},
  target: { toString() { throw new Error("boom"); } },
});
```

Now the exception from the string coercion of `target` is checked and propagated to the caller as a normal JS error.

### How did you verify your code works?

- Reproducer above aborts with `ASSERTION FAILED: Unexpected exception observed` before the fix and throws a catchable `Error: boom` after the fix (debug/ASAN build).
- Added a regression test in `test/js/bun/plugin/plugins.test.ts` ("handles a 'target' whose toString throws"); `bun bd test test/js/bun/plugin/plugins.test.ts` passes (30 pass, 1 todo, 0 fail).