### PR TITLE
build: enable static SQLite by default on macOS

### DIFF
--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -692,8 +692,8 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   const canary = partial.canary ?? true;
   const canaryRevision = canary ? "1" : "0";
 
-  // Static SQLite: off on Apple (uses system), on elsewhere
-  const staticSqlite = partial.staticSqlite ?? !darwin;
+  // Static SQLite: on by default (embeds 3.53.0 for consistency across platforms)
+  const staticSqlite = partial.staticSqlite ?? true;
 
   // Static libatomic: on by default. Arch/Manjaro don't ship libatomic.a —
   // those users pass --static-libatomic=off. Not auto-detected: the link


### PR DESCRIPTION
### What does this PR do?

Changes the default value of `staticSqlite` from platform-dependent (`!darwin`) to `true` on all platforms.

Previously, macOS builds dynamically loaded the system `libsqlite3.dylib` at runtime, which meant the actual SQLite version varied by OS version (e.g. 3.51.0 on Sonoma) instead of the bundled 3.53.0. This change ensures consistent SQLite 3.53.0 behavior across macOS, Linux, and Windows.

### How did you verify your code works?

- Verified that `build.ninja` includes `obj/src/jsc/bindings/sqlite/sqlite3.c.o` on macOS without passing `--static-sqlite`.
- C++ compilation of `sqlite3.c` and Rust compilation both succeed with this default.