### PR TITLE
fix(plugin): check exception when converting Bun.plugin target to string

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -302,12 +302,11 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
     auto targetValue = obj->getIfPropertyExists(globalObject, Identifier::fromString(vm, "target"_s));
     RETURN_IF_EXCEPTION(throwScope, {});
     if (targetValue) {
-        if (auto* targetJSString = targetValue.toStringOrNull(globalObject)) {
-            String targetString = targetJSString->value(globalObject);
-            if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
-                JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
-                return {};
-            }
+        String targetString = targetValue.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
+            JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
+            return {};
         }
     }
 

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -366,6 +366,33 @@ describe("errors", () => {
     }).toThrow("plugin target must be one of 'node', 'bun' or 'browser'");
   });
 
+  it("handles 'target' that throws while converting to a string", () => {
+    let setupCalled = false;
+    expect(() => {
+      plugin({
+        setup: () => {
+          setupCalled = true;
+        },
+        target: {
+          toString() {
+            throw new Error("broken target");
+          },
+        },
+      } as any);
+    }).toThrow("broken target");
+    expect(setupCalled).toBe(false);
+
+    expect(() => {
+      plugin({
+        setup: () => {
+          setupCalled = true;
+        },
+        target: Symbol("nope"),
+      } as any);
+    }).toThrow(TypeError);
+    expect(setupCalled).toBe(false);
+  });
+
   it("invalid loaders throw", () => {
     const invalidLoaders = ["blah", "blah2", "blah3", "blah4"];
     const inputs = ["body { background: red; }", "<h1>hi</h1>", '{"hi": "there"}', "hi"];


### PR DESCRIPTION
### What does this PR do?

Fixes a missing exception check in `Bun.plugin()` found by fuzzing (fingerprint `c2634e99042cf103`).

When the `target` option is converted to a string, the conversion can throw — for example an out-of-memory error while stringifying a huge typed array, or a user-provided `toString()` that throws:

```js
const v2 = new Int8Array(268435456);
Bun.plugin({ target: v2, setup: ArrayBuffer });
```

`setupBunPlugin` used `toStringOrNull()` and ignored the null/exception case, so execution continued with a pending exception and hit the exception scope assertion in debug builds:

```
ASSERTION FAILED: Unexpected exception observed on thread ...
Error Exception: Out of memory
!exception()
JavaScriptCore/ExceptionScope.h(61) : void JSC::ExceptionScope::assertNoException()
```

The conversion now uses `toWTFString()` followed by `RETURN_IF_EXCEPTION`, matching the rest of the function, so the error propagates to the caller as a normal JS exception and `setup()` is never invoked when the `target` conversion fails.

### How did you verify your code works?

- The fuzzer repro now exits with a regular `RangeError: Out of memory` instead of aborting in a debug+ASAN build.
- Added a regression test in `test/js/bun/plugin/plugins.test.ts` covering a `target` whose string conversion throws (throwing `toString()` and a `Symbol`), asserting the error is rethrown and `setup()` is not called. Ran with `bun bd test test/js/bun/plugin/plugins.test.ts`.
