### PR TITLE
openInEditor: spawn the editor without spawnSync's signal forwarding

### DIFF
--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4648,6 +4648,59 @@ enum StdinBehavior {
     Ignore,
 }
 
+#[cfg(target_os = "macos")]
+unsafe extern "C" {
+    /// `<spawn.h>` extension the `libc` crate does not bind: keeps `fd` open in
+    /// the child when `POSIX_SPAWN_CLOEXEC_DEFAULT` closes everything else.
+    fn posix_spawn_file_actions_addinherit_np(
+        actions: *mut libc::posix_spawn_file_actions_t,
+        fd: core::ffi::c_int,
+    ) -> core::ffi::c_int;
+    /// src/jsc/bindings/spawn.cpp: default dispositions for every signal and an
+    /// empty signal mask, the same reset `bun_spawn_sys` applies.
+    fn posix_spawnattr_reset_signals(attr: *mut libc::posix_spawnattr_t) -> core::ffi::c_int;
+}
+
+/// Owns an initialized `posix_spawnattr_t` + `posix_spawn_file_actions_t`
+/// pair and destroys both on every exit path of the macOS spawn arm.
+#[cfg(target_os = "macos")]
+struct DarwinSpawnSetup {
+    attr: libc::posix_spawnattr_t,
+    actions: libc::posix_spawn_file_actions_t,
+}
+
+#[cfg(target_os = "macos")]
+impl DarwinSpawnSetup {
+    fn init() -> crate::CrateResult<Self> {
+        let mut attr: libc::posix_spawnattr_t = core::ptr::null_mut();
+        // SAFETY: `attr` is a valid out-pointer; on success it holds an
+        // initialized attribute object that `Drop` destroys.
+        if unsafe { libc::posix_spawnattr_init(&raw mut attr) } != 0 {
+            return Err(crate::CrateError::Unexpected);
+        }
+        let mut actions: libc::posix_spawn_file_actions_t = core::ptr::null_mut();
+        // SAFETY: `actions` is a valid out-pointer, initialized on success.
+        if unsafe { libc::posix_spawn_file_actions_init(&raw mut actions) } != 0 {
+            // SAFETY: `attr` was initialized above and no `Self` owns it yet.
+            unsafe { libc::posix_spawnattr_destroy(&raw mut attr) };
+            return Err(crate::CrateError::Unexpected);
+        }
+        Ok(Self { attr, actions })
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Drop for DarwinSpawnSetup {
+    fn drop(&mut self) {
+        // SAFETY: both objects were initialized in `init` and are destroyed
+        // exactly once, here.
+        unsafe {
+            libc::posix_spawnattr_destroy(&raw mut self.attr);
+            libc::posix_spawn_file_actions_destroy(&raw mut self.actions);
+        }
+    }
+}
+
 /// Spawn argv, inherit stdout/stderr, **ignore stdin** (fd 0 ← /dev/null),
 /// wait.
 pub fn spawn_sync_inherit_no_stdin(argv: &[impl AsRef<[u8]>]) -> crate::CrateResult<SpawnStatus> {
@@ -4671,7 +4724,10 @@ fn spawn_sync_inherit_impl(
     // SAFETY: argv strings are owned `ZBox`es (NUL-terminated) kept alive in
     // `cargs` for the duration of the spawn; `ptrs`/`environ` are null-
     // terminated `*const c_char` arrays as required by `posix_spawn_bun` /
-    // `posix_spawnp`. `waitpid` is passed a valid `&mut c_int` out-param.
+    // `posix_spawnp`. On Darwin the attr/file-actions objects handed to
+    // `posix_spawnp` and its `add*`/`setflags` helpers stay initialized inside
+    // `DarwinSpawnSetup` until after the spawn call. `waitpid` is passed a
+    // valid `&mut c_int` out-param.
     unsafe {
         let cargs: Vec<ZBox> = argv
             .iter()
@@ -4748,42 +4804,46 @@ fn spawn_sync_inherit_impl(
         // for the non-PTY inherit case. PTY spawns go through spawn_sys.
         #[cfg(target_os = "macos")]
         let pid: libc::pid_t = {
-            // StdinBehavior::Ignore → file action opening /dev/null onto fd 0;
-            // stdout/stderr stay inherited.
-            let mut actions: libc::posix_spawn_file_actions_t = core::ptr::null_mut();
-            let actions_ptr: *const libc::posix_spawn_file_actions_t =
-                if stdin == StdinBehavior::Ignore {
-                    let rc = libc::posix_spawn_file_actions_init(&raw mut actions);
-                    if rc != 0 {
-                        return Err(crate::CrateError::Unexpected);
-                    }
-                    let rc = libc::posix_spawn_file_actions_addopen(
-                        &raw mut actions,
-                        0,
-                        c"/dev/null".as_ptr(),
-                        libc::O_RDONLY,
-                        0,
-                    );
-                    if rc != 0 {
-                        libc::posix_spawn_file_actions_destroy(&raw mut actions);
-                        return Err(crate::CrateError::Unexpected);
-                    }
-                    &raw const actions
-                } else {
-                    core::ptr::null()
-                };
+            // Same child setup as the Linux arm gets from posix_spawn_bun: every
+            // signal back to its default disposition (Bun ignores SIGPIPE
+            // process-wide), and only the stdio named in the file actions
+            // survives the exec. Without POSIX_SPAWN_CLOEXEC_DEFAULT the child
+            // would inherit every descriptor Bun opened without CLOEXEC.
+            let mut setup = DarwinSpawnSetup::init()?;
+            let flags = libc::POSIX_SPAWN_SETSIGDEF
+                | libc::POSIX_SPAWN_SETSIGMASK
+                | libc::POSIX_SPAWN_CLOEXEC_DEFAULT;
+            let stdin_rc = match stdin {
+                StdinBehavior::Inherit => {
+                    posix_spawn_file_actions_addinherit_np(&raw mut setup.actions, 0)
+                }
+                StdinBehavior::Ignore => libc::posix_spawn_file_actions_addopen(
+                    &raw mut setup.actions,
+                    0,
+                    c"/dev/null".as_ptr(),
+                    libc::O_RDONLY,
+                    0,
+                ),
+            };
+            // `flags` is 0x400c; `posix_spawnattr_setflags` takes a `short` on Darwin.
+            if libc::posix_spawnattr_setflags(&raw mut setup.attr, flags as core::ffi::c_short) != 0
+                || posix_spawnattr_reset_signals(&raw mut setup.attr) != 0
+                || stdin_rc != 0
+                || posix_spawn_file_actions_addinherit_np(&raw mut setup.actions, 1) != 0
+                || posix_spawn_file_actions_addinherit_np(&raw mut setup.actions, 2) != 0
+            {
+                return Err(crate::CrateError::Unexpected);
+            }
             let mut pid: libc::pid_t = 0;
             let rc = libc::posix_spawnp(
                 &raw mut pid,
                 ptrs[0],
-                actions_ptr,
-                core::ptr::null(),
+                &raw const setup.actions,
+                &raw const setup.attr,
                 ptrs.as_ptr().cast::<*mut core::ffi::c_char>(),
                 environ.cast::<*mut core::ffi::c_char>(),
             );
-            if !actions_ptr.is_null() {
-                libc::posix_spawn_file_actions_destroy(&raw mut actions);
-            }
+            drop(setup);
             if rc != 0 {
                 return Err(crate::CrateError::Unexpected);
             }

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4650,19 +4650,14 @@ enum StdinBehavior {
 
 #[cfg(target_os = "macos")]
 unsafe extern "C" {
-    /// `<spawn.h>` extension the `libc` crate does not bind: keeps `fd` open in
-    /// the child when `POSIX_SPAWN_CLOEXEC_DEFAULT` closes everything else.
     fn posix_spawn_file_actions_addinherit_np(
         actions: *mut libc::posix_spawn_file_actions_t,
         fd: core::ffi::c_int,
     ) -> core::ffi::c_int;
-    /// src/jsc/bindings/spawn.cpp: default dispositions for every signal and an
-    /// empty signal mask, the same reset `bun_spawn_sys` applies.
+    // Implemented in src/jsc/bindings/spawn.cpp.
     fn posix_spawnattr_reset_signals(attr: *mut libc::posix_spawnattr_t) -> core::ffi::c_int;
 }
 
-/// Owns an initialized `posix_spawnattr_t` + `posix_spawn_file_actions_t`
-/// pair and destroys both on every exit path of the macOS spawn arm.
 #[cfg(target_os = "macos")]
 struct DarwinSpawnSetup {
     attr: libc::posix_spawnattr_t,
@@ -4724,10 +4719,7 @@ fn spawn_sync_inherit_impl(
     // SAFETY: argv strings are owned `ZBox`es (NUL-terminated) kept alive in
     // `cargs` for the duration of the spawn; `ptrs`/`environ` are null-
     // terminated `*const c_char` arrays as required by `posix_spawn_bun` /
-    // `posix_spawnp`. On Darwin the attr/file-actions objects handed to
-    // `posix_spawnp` and its `add*`/`setflags` helpers stay initialized inside
-    // `DarwinSpawnSetup` until after the spawn call. `waitpid` is passed a
-    // valid `&mut c_int` out-param.
+    // `posix_spawnp`. `waitpid` is passed a valid `&mut c_int` out-param.
     unsafe {
         let cargs: Vec<ZBox> = argv
             .iter()
@@ -4804,11 +4796,7 @@ fn spawn_sync_inherit_impl(
         // for the non-PTY inherit case. PTY spawns go through spawn_sys.
         #[cfg(target_os = "macos")]
         let pid: libc::pid_t = {
-            // Same child setup as the Linux arm gets from posix_spawn_bun: every
-            // signal back to its default disposition (Bun ignores SIGPIPE
-            // process-wide), and only the stdio named in the file actions
-            // survives the exec. Without POSIX_SPAWN_CLOEXEC_DEFAULT the child
-            // would inherit every descriptor Bun opened without CLOEXEC.
+            // Same child scrub as posix_spawn_bun on Linux: default signals, only fds 0-2.
             let mut setup = DarwinSpawnSetup::init()?;
             let flags = libc::POSIX_SPAWN_SETSIGDEF
                 | libc::POSIX_SPAWN_SETSIGMASK

--- a/src/runtime/cli/open.rs
+++ b/src/runtime/cli/open.rs
@@ -7,8 +7,6 @@ use bun_paths::{self, MAX_PATH_BYTES, PathBuffer};
 use bun_resolver::fs as Fs;
 use bun_which::which;
 
-use crate::api::bun::process::sync;
-
 // ──────────────────────────────────────────────────────────────────────────
 
 #[cfg(target_os = "macos")]
@@ -401,33 +399,7 @@ fn auto_close(spawned: *mut SpawnedEditorContext) {
         argv[j] = unsafe { bun_core::ffi::slice(p, l) };
     }
 
-    // FIXME(windows-leak): the sync::spawn path
-    // requires a `WindowsOptions.loop_`; `MiniEventLoop::init_global` heap-allocates a
-    // MiniEventLoop + uv_loop_t into a thread-local that is NEVER torn down. Because this
-    // runs on a fresh detached std::thread per `Editor::open()` call, every editor-open on
-    // Windows leaks one MiniEventLoop + uv_loop_t (+ DotEnv Loader/Map if env was null).
-    // Proper fix needs either (a) a MiniEventLoop teardown helper (none exists today), or
-    // (b) plumbing the caller's existing EventLoopHandle through SpawnedEditorContext
-    // (signature change to Editor::open + callers). Both are out-of-scope for this file.
-    let owned_argv: Vec<Box<[u8]>> = argv[0..spawned.argc]
-        .iter()
-        .map(|s| s.to_vec().into_boxed_slice())
-        .collect();
-    let _ = sync::spawn(&sync::Options {
-        argv: owned_argv,
-        envp: None,
-        stderr: sync::SyncStdio::Inherit,
-        stdout: sync::SyncStdio::Inherit,
-        stdin: sync::SyncStdio::Inherit,
-        #[cfg(windows)]
-        windows: crate::api::bun::process::WindowsOptions {
-            loop_: bun_jsc::EventLoopHandle::init_mini(bun_event_loop::MiniEventLoop::init_global(
-                None, None,
-            )),
-            ..Default::default()
-        },
-        ..Default::default()
-    });
+    let _ = bun_core::spawn_sync_inherit(&argv[0..spawned.argc]);
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/test/js/bun/util/open-in-editor-gc.test.ts
+++ b/test/js/bun/util/open-in-editor-gc.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
 import { chmodSync, existsSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 
@@ -103,9 +103,10 @@ test.skipIf(!isLinux)("Bun.openInEditor survives re-entrant calls from option ge
 });
 
 // On Linux, JSC uses SIGPWR to suspend/resume threads for GC and the libpas
-// scavenger. Bun.openInEditor spawns a detached thread that goes through
-// bun.spawnSync, whose signal-forwarding setup must not touch SIGPWR or the
-// process is terminated the next time GC/scavenger fires.
+// scavenger. Bun.openInEditor runs its editor spawn on a detached thread;
+// that spawn must not disturb process-wide signal handling (it used to go
+// through bun.spawnSync's signal forwarding) or the process is terminated
+// the next time GC/scavenger fires.
 test.skipIf(!isLinux)("Bun.openInEditor does not break GC signal handling", async () => {
   const sleep = ["/usr/bin/sleep", "/bin/sleep"].find(p => existsSync(p));
   expect(sleep).toBeDefined();
@@ -151,4 +152,153 @@ test.skipIf(!isLinux)("Bun.openInEditor does not break GC signal handling", asyn
   });
 
   await Promise.all(runs);
+});
+
+// The editor thread used to go through bun.spawnSync, which installs the
+// process-wide signal-forwarding handlers meant for `bun run` (they redirect
+// SIGINT/SIGTERM/SIGUSR2/... to the child) for as long as the editor runs,
+// while the user's program keeps running on the main thread. The fixtures
+// below open a fake editor that records its pid in the "file" it is asked to
+// open and then stays alive until the test kills it, so the assertions run
+// while the editor is definitely up.
+const fakeEditorFiles = {
+  // Bun.openInEditor(file, { editor }) runs `editor file`; after the exec the
+  // sleep keeps the shell's pid, so the recorded pid is the one to kill.
+  "fake-editor.sh": '#!/bin/sh\necho $$ > "$1"\nexec sleep 30\n',
+  "wait-for-editor.js": `
+    import { readFileSync } from "node:fs";
+    export async function waitForEditorPid(pidFile) {
+      for (;;) {
+        let text = "";
+        try { text = readFileSync(pidFile, "utf8"); } catch {}
+        if (/^\\d+\\n$/.test(text)) return Number(text);
+        await Bun.sleep(5);
+      }
+    }
+  `,
+};
+
+// https://github.com/oven-sh/bun/issues/31194
+test.concurrent.skipIf(!isLinux)("Bun.openInEditor does not change the process's signal dispositions", async () => {
+  using dir = tempDir("open-in-editor-sigcgt", {
+    ...fakeEditorFiles,
+    "run.js": `
+      import { readFileSync } from "node:fs";
+      import { waitForEditorPid } from "./wait-for-editor.js";
+      // SigCgt is the bitmask of signals this process has a handler for.
+      const caught = () => readFileSync("/proc/self/status", "utf8").match(/^SigCgt:\\s*([0-9a-f]+)/m)[1];
+      const [editor, pidFile] = process.argv.slice(2);
+
+      const before = caught();
+      Bun.openInEditor(pidFile, { editor });
+      const pid = await waitForEditorPid(pidFile);
+      const during = caught();
+      process.kill(pid, "SIGTERM");
+      console.log(JSON.stringify({ before, during }));
+    `,
+  });
+  const editor = join(String(dir), "fake-editor.sh");
+  chmodSync(editor, 0o755);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run.js", editor, join(String(dir), "editor.pid")],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const { before, during } = JSON.parse(stdout);
+  const changed = BigInt("0x" + before) ^ BigInt("0x" + during);
+  const changedSignals = Array.from({ length: 64 }, (_, i) => i + 1).filter(sig => changed & (1n << BigInt(sig - 1)));
+  expect(changedSignals).toEqual([]);
+  expect(exitCode).toBe(0);
+});
+
+// https://github.com/oven-sh/bun/issues/31194
+test.concurrent.skipIf(isWindows)(
+  "a process.on signal handler still runs while an editor opened by Bun.openInEditor is up",
+  async () => {
+    using dir = tempDir("open-in-editor-signal-handler", {
+      ...fakeEditorFiles,
+      "run.js": `
+      import { waitForEditorPid } from "./wait-for-editor.js";
+      const [editor, pidFile] = process.argv.slice(2);
+      const alive = pid => { try { process.kill(pid, 0); return true; } catch { return false; } };
+
+      const handled = new Promise(resolve => process.on("SIGUSR2", () => resolve("handler ran")));
+      Bun.openInEditor(pidFile, { editor });
+      const pid = await waitForEditorPid(pidFile);
+
+      process.kill(process.pid, "SIGUSR2");
+      // Forwarding would deliver the signal to the editor instead, and sleep
+      // dies from SIGUSR2; otherwise our handler runs. Wait for either.
+      const forwarded = (async () => {
+        while (alive(pid)) await Bun.sleep(5);
+        return "signal was forwarded to the editor";
+      })();
+      const outcome = await Promise.race([handled, forwarded]);
+      if (alive(pid)) process.kill(pid, "SIGTERM");
+      console.log(outcome);
+    `,
+    });
+    const editor = join(String(dir), "fake-editor.sh");
+    chmodSync(editor, 0o755);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run.js", editor, join(String(dir), "editor.pid")],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("handler ran\n");
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(0);
+  },
+);
+
+// Terminal editors are opened through `xdg-open` on Linux, with the editor
+// binary as the first argument and the file as the last. The opener is a bare
+// name, so the editor spawn has to look it up on PATH; the spawnSync path
+// exec'd it relative to cwd and silently failed.
+test.concurrent.skipIf(!isLinux)("Bun.openInEditor finds the xdg-open opener on PATH", async () => {
+  using dir = tempDir("open-in-editor-opener", {
+    // Records the editor binary into the file argument; never runs the editor.
+    "bin/xdg-open": '#!/bin/sh\nfor file; do :; done\necho "opened $1" > "$file"\n',
+    // Only its basename matters: it selects the vim (opener-based) argv shape.
+    "vim": "",
+    "run.js": `
+      import { readFileSync } from "node:fs";
+      const [editor, marker] = process.argv.slice(2);
+      Bun.openInEditor(marker, { editor });
+      for (;;) {
+        let text = "";
+        try { text = readFileSync(marker, "utf8"); } catch {}
+        if (text.endsWith("\\n")) break;
+        await Bun.sleep(5);
+      }
+      process.stdout.write(readFileSync(marker, "utf8"));
+    `,
+  });
+  chmodSync(join(String(dir), "bin", "xdg-open"), 0o755);
+  const editor = join(String(dir), "vim");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run.js", editor, join(String(dir), "opened.txt")],
+    env: { ...bunEnv, PATH: `${join(String(dir), "bin")}:${bunEnv.PATH}` },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe(`opened ${editor}\n`);
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/util/open-in-editor-gc.test.ts
+++ b/test/js/bun/util/open-in-editor-gc.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
-import { chmodSync, existsSync, symlinkSync } from "node:fs";
+import { chmodSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 
 // Both ways of naming an editor (EDITOR in the environment, the `editor`
@@ -102,41 +102,37 @@ test.skipIf(!isLinux)("Bun.openInEditor survives re-entrant calls from option ge
   expect(exitCode).toBe(0);
 });
 
-// On Linux, JSC uses SIGPWR to suspend/resume threads for GC and the libpas
-// scavenger. Bun.openInEditor runs its editor spawn on a detached thread;
-// that spawn must not disturb process-wide signal handling (it used to go
-// through bun.spawnSync's signal forwarding) or the process is terminated
-// the next time GC/scavenger fires.
-test.skipIf(!isLinux)("Bun.openInEditor does not break GC signal handling", async () => {
-  const sleep = ["/usr/bin/sleep", "/bin/sleep"].find(p => existsSync(p));
-  expect(sleep).toBeDefined();
-
+// Each Bun.openInEditor call hands its argv to a detached thread. Alternating
+// between two absolute editor paths replaces the cached editor name on every
+// call while earlier threads may still be reading theirs, and the forced GC
+// afterwards suspends whatever threads are still around. Every editor must
+// actually run and the process must come out alive.
+test.concurrent.skipIf(isWindows)("alternating editors on live editor threads, then GC", async () => {
   using dir = tempDir("open-in-editor-gc", {
+    "fake-editor.sh": '#!/bin/sh\necho opened > "$1"\n',
     "run.js": `
-      const a = ${JSON.stringify(sleep)};
-      const b = process.argv[2];
-      // Alternate absolute editor paths so the cached editor name_storage is
-      // replaced each call while a detached editor thread may still be
-      // reading the previous one.
+      import { existsSync } from "node:fs";
+      const editors = process.argv.slice(2);
+      const markers = [];
       for (let i = 0; i < 8; i++) {
-        try { Bun.openInEditor("0.3", { editor: i % 2 ? b : a }); } catch {}
+        markers.push(\`opened-\${process.pid}-\${i}\`);
+        Bun.openInEditor(markers[i], { editor: editors[i % 2] });
       }
-      // Wait for the detached editor threads to complete their register /
-      // unregister cycle, then for the scavenger to fire SIGPWR.
-      await Bun.sleep(1000);
+      while (!markers.every(m => existsSync(m))) await Bun.sleep(5);
       Bun.gc(true);
       console.log("alive");
     `,
   });
-  // Second absolute path to the same binary so alternating calls take the
-  // `!eql_long(prev_name, ...)` branch in open_in_editor. Keep the basename
-  // `sleep` so BusyBox (Alpine) resolves the multi-call applet from argv[0].
-  const sleep2 = join(String(dir), "sleep");
-  symlinkSync(sleep!, sleep2);
+  const editor = join(String(dir), "fake-editor.sh");
+  chmodSync(editor, 0o755);
+  // Second absolute path to the same script, so consecutive calls take the
+  // name-replacing branch of openInEditor.
+  const editor2 = join(String(dir), "fake-editor-2.sh");
+  symlinkSync(editor, editor2);
 
   const runs = Array.from({ length: 5 }, async () => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "run.js", sleep2],
+      cmd: [bunExe(), "run.js", editor, editor2],
       env: bunEnv,
       cwd: String(dir),
       stdout: "pipe",
@@ -146,7 +142,7 @@ test.skipIf(!isLinux)("Bun.openInEditor does not break GC signal handling", asyn
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("alive");
+    expect(stdout).toBe("alive\n");
     expect(proc.signalCode).toBeNull();
     expect(exitCode).toBe(0);
   });
@@ -302,3 +298,54 @@ test.concurrent.skipIf(!isLinux)("Bun.openInEditor finds the xdg-open opener on 
   expect(stdout).toBe(`opened ${editor}\n`);
   expect(exitCode).toBe(0);
 });
+
+// The editor must start with only stdio open. fs.openSync() descriptors are
+// not close-on-exec, so a spawn that does not scrub the fd table (macOS
+// posix_spawn without POSIX_SPAWN_CLOEXEC_DEFAULT) hands them to the editor.
+// The "editor" here is bun itself running probe.js, which checks whether the
+// parent's descriptor number still refers to the sentinel file.
+test.concurrent.skipIf(isWindows)(
+  "Bun.openInEditor does not pass the process's file descriptors to the editor",
+  async () => {
+    using dir = tempDir("open-in-editor-fds", {
+      "sentinel.txt": "sentinel",
+      "run.js": `
+      import { openSync, readFileSync, writeFileSync } from "node:fs";
+      const fd = openSync("sentinel.txt", "r");
+      writeFileSync(
+        "probe.js",
+        \`
+          import { fstatSync, statSync, writeFileSync } from "node:fs";
+          const sentinel = statSync("sentinel.txt");
+          let inherited = false;
+          try {
+            const got = fstatSync(\${fd});
+            inherited = got.ino === sentinel.ino && got.dev === sentinel.dev;
+          } catch {}
+          writeFileSync("result.txt", inherited ? "fd \${fd} inherited\\\\n" : "fd \${fd} not inherited\\\\n");
+        \`,
+      );
+      Bun.openInEditor(\`\${process.cwd()}/probe.js\`, { editor: process.execPath });
+      let result = "";
+      while (!result.endsWith("\\n")) {
+        try { result = readFileSync("result.txt", "utf8"); } catch {}
+        if (!result.endsWith("\\n")) await Bun.sleep(5);
+      }
+      process.stdout.write(result.replace(/\\d+/, "N"));
+    `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("fd N not inherited\n");
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
### Problem
- `Bun.openInEditor()` installs `spawnSync`'s signal forwarding for as long as the editor runs (#31194). While an editor is open, SIGINT/SIGTERM/SIGHUP/SIGUSR2/... sent to the process are redirected to the editor instead of reaching the program's own handlers: a `process.on("SIGUSR2")` listener never runs, the editor gets the signal. Two overlapping opens additionally race on the shared `previous_actions[]` table: the second registration saves the forwarding handler as the "previous" disposition, so after both editors exit the forwarded signals are left at SIG_DFL, wiping the program's handlers.
- Cause: `auto_close()` in `src/runtime/cli/open.rs`, which runs on a detached thread per open, called `process::sync::spawn()`. That is the foreground `spawnSync` behind `bun run`; `spawn_posix()` (`src/spawn/process.rs`) unconditionally registers the forwarding handlers (`Bun__registerSignalsForForwarding`, `c-bindings.cpp`, whose comment says it is only ever used on the main thread) and restores them when the child exits. The Zig implementation used a plain `std.process.Child` spawn here; the Rust port switched it to `sync::spawn`.
- Same call also exec'd the `xdg-open` opener used for vim/emacs/neovim on Linux relative to cwd (the sync spawn path does no PATH lookup), so that spawn silently failed, and on Windows it allocated a `MiniEventLoop` per open that was never torn down.

### Fix
- `auto_close()` uses `bun_core::spawn_sync_inherit()`: spawn with inherited stdio, wait, nothing else. It touches no process-wide state, resolves a bare argv[0] on PATH, and needs no event loop on Windows, so the FIXME block goes away with the `sync::spawn` call.
- This is the right layer: the forwarding exists so a foreground `bun run` child sees the terminal's signals. An editor launched from inside a running program is not that case, so the editor thread should not be on that code path at all, rather than that path growing an opt-out for one caller (the approach in #31195).
- `spawn_sync_inherit()`'s macOS arm (`src/bun_core/util.rs`) was a bare `posix_spawnp` with no attributes, so unlike its Linux arm (which goes through `posix_spawn_bun` and scrubs the child) it handed the editor every descriptor Bun had opened without CLOEXEC (`fs.openSync` fds, for example) and Bun's ignored signals. Switching the editor onto the helper would have regressed that on macOS relative to the `sync::spawn` path, so the helper now sets `POSIX_SPAWN_CLOEXEC_DEFAULT` and the same signal reset `bun_spawn_sys` uses, inheriting only fds 0-2 (or `/dev/null` on 0). This also applies to the helper's existing callers (`bun init`, `bun publish`, the URL opener). Cross-checked with `cargo check -p bun_core --target aarch64-apple-darwin`; the runtime behavior is covered by the fd test below on the macOS lanes.
- Verified with `bun bd test test/js/bun/util/open-in-editor-gc.test.ts` (6 tests, repeated runs clean). The three forwarding tests keep a fake editor alive while asserting; on unmodified main all three fail (`SigCgt` gains the 14 forwarded signals `[1,2,3,5,6,12,14,15,16,24,25,26,29,31]`, the SIGUSR2 listener is bypassed and the editor dies from the forwarded signal, and the opener is never spawned); with the fix everything passes.
  - `Bun.openInEditor does not change the process's signal dispositions` (Linux): `SigCgt` from `/proc/self/status` is identical before and while the editor is up.
  - `a process.on signal handler still runs while an editor ... is up` (POSIX): the listener runs; the alternative outcome (editor killed by the forwarded signal) is detected explicitly so the failure is immediate rather than a timeout.
  - `Bun.openInEditor finds the xdg-open opener on PATH` (Linux): a fake `xdg-open` on PATH records that it was invoked.
  - `Bun.openInEditor does not pass the process's file descriptors to the editor` (POSIX): bun itself is used as the editor and checks whether the parent's `fs.openSync` descriptor number still refers to the sentinel file. Passes on Linux with or without this PR (the Linux spawner always scrubbed); on macOS it fails without the `util.rs` change and passes with it.
  - `alternating editors on live editor threads, then GC` (POSIX) replaces the old timed "does not break GC signal handling" test. That test was written for #31183's SIGPWR exclusion in the forwarding list, which the editor path no longer reaches, so it passed both with and without this change and its 1 s sleep no longer had a reason; the replacement keeps what it still covered (the editor name being replaced while earlier threads are live, then a forced GC) and waits for every editor to have run instead of sleeping. The SIGPWR exclusion itself is unchanged and still applies to the remaining `sync::spawn` callers; it just has no test driving it from `openInEditor` any more.
- The no-editor call storm test from the first version of this PR was dropped: since #37210 those calls throw before spawning, so it no longer exercised anything.

### Background
- `spawnSync` signal forwarding: when `bun run`/`bunx` run a script as a child, Bun installs handlers for npm's signal list that `kill()` the current child (`Bun__currentSyncPID`) and restores the previous dispositions afterwards. The saved dispositions live in one global array, so it is only correct for one foreground child at a time on the main thread.
- `Bun.openInEditor()` builds the editor argv and hands it to a detached thread (`auto_close`) that spawns the editor and waits for it to exit, while JS continues on the main thread.
- `bun_core::spawn_sync_inherit()` is the minimal spawn+wait helper already used by `bun init`, `bun publish` and the URL opener in `cli/mod.rs` (`posix_spawn` with PATH lookup on POSIX, `CreateProcessW` via `std::process::Command` on Windows).
- `SigCgt` in `/proc/<pid>/status` is the bitmask of signals the process currently has a handler installed for, which makes "did anything touch the dispositions" directly observable.

### Related
- Consolidates the three open fixes for #31194: #31299 (same code change; its dispositions test is folded in here) and #31195 by @fallintoplace (adds a `forward_signals` option to the sync spawn options instead; its signal-listener scenario is folded in here, credited in the commit).
- #30956 separately hardens the register/unregister pair itself for the remaining main-thread users; independent of this change.

Fixes #31194

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 10 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/open-in-editor-gc.test.ts

<!-- robobun:evidence:end -->
