### PR TITLE
bootstrap.ps1: rebuild PATH from registry before installing packages

### DIFF
--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -731,6 +731,14 @@ function Disable-Power-Management {
 # Main
 # ============================================================================
 
+# Rebuild $env:Path from the Machine/User registry values before installing
+# anything. In Windows containers the image config's PATH replaces the
+# registry PATH for every process (e.g. the bun-development-docker-image
+# build sets ENV PATH without the Windows system directories), which breaks
+# the Scoop installer's robocopy prerequisite check and lookups of system
+# tools like tar, reg, and powercfg.
+Refresh-Path
+
 if ($Optimize) {
   Optimize-System
 }


### PR DESCRIPTION
### What does this PR do?

Makes `scripts/bootstrap.ps1` rebuild `$env:Path` from the Machine/User registry values (via the existing `Refresh-Path` helper) before it starts installing packages.

### Why

The daily Windows build of [bun-development-docker-image](https://github.com/oven-sh/bun-development-docker-image) has failed on every run since 2026-02-17 ([latest failure](https://github.com/oven-sh/bun-development-docker-image/actions/runs/26337614553)). The bootstrap stage dies immediately at:

```
Installing Scoop...
Initializing...
Scoop requires 'C:\Windows\System32\Robocopy.exe' to work. Please make sure 'C:\Windows\System32' is in your PATH.
Abort.
```

so nothing gets installed and the image build fails at the following `vs_installer.exe` step.

In Windows containers, a `PATH` set in the image config replaces the registry PATH for every process, and that Dockerfile's `ENV PATH` ends up without the Windows system directories (its `${PATH}` expansion is empty because servercore doesn't define PATH in its image config). The pre-Scoop, chocolatey-based bootstrap never needed anything from `System32` by name, so this only started failing when #26746 switched the script to Scoop, whose installer hard-requires `robocopy` on PATH. `tar` (used by `Install-NodeJs`), `reg`, `attrib`, and `powercfg` have the same dependency on the system directories.

Calling `Refresh-Path` up front rebuilds the process PATH from the registry (which always contains `C:\Windows\System32` etc.), so the script works regardless of how stripped the caller's PATH is. On Azure VM image bakes and developer machines this is a no-op — the process PATH already mirrors the registry values there.

The `# Version:` header is intentionally not bumped: existing CI VM images don't need a rebake for this, and the docker image workflow keys its cache off a hash of the whole file, so it picks the change up automatically.

Companion fix on the docker image side: oven-sh/bun-development-docker-image#15 lists the system directories explicitly in the Dockerfile's `ENV PATH`. Either change alone unbreaks the image build (the Dockerfile runs `git pull` and executes this script from `main`), but the script shouldn't silently fall over when the process PATH is incomplete.

### How did you verify your code works?

The change only touches the Windows bootstrap script (not buildable/testable from the JS/Zig test suite). Verification is the next scheduled "Daily Windows Docker Build" run (or a manual `workflow_dispatch`) once this is on `main` — that workflow pulls `scripts/bootstrap.ps1` from `main` and has reproduced the failure daily for three months, always aborting at the Scoop robocopy check that this removes the precondition for.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->