### PR TITLE
css: reject `*` local names in attribute selectors instead of panicking

### DIFF
--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -4121,7 +4121,9 @@ fn parse_qualified_name_eplicit_namespace_helper<Impl: BunSelectorImpl>(
     let t = input.next_including_whitespace()?.clone();
     match &t {
         Token::Ident(local_name) => return Ok(OptionalQName::Some(namespace, Some(*local_name))),
-        Token::Delim(c) if *c == b'*' as u32 => {
+        // `*` is only a valid local name outside of attribute selectors;
+        // `[ns|*]` must fall through to the `InvalidQualNameInAttr` error below.
+        Token::Delim(c) if *c == b'*' as u32 && !in_attr_selector => {
             return Ok(OptionalQName::Some(namespace, None));
         }
         _ => {}

--- a/test/js/bun/css/attr-selector-namespace-star.test.ts
+++ b/test/js/bun/css/attr-selector-namespace-star.test.ts
@@ -1,0 +1,48 @@
+import { cssInternals } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+const { minifyTest } = cssInternals;
+
+// A `*` local name inside an attribute selector (e.g. `[|*`, `[*|*]`, `[ns|*]`) used to hit
+// `unreachable!()` in the selector parser instead of being rejected as an invalid qualified name
+// (found by fuzzing `[|*`).
+
+test("`*` local name in an attribute selector is a parse error, not a panic", () => {
+  expect(() => minifyTest("[|*] {color: red}", "")).toThrow("Invalid qualified name in attribute selector");
+  expect(() => minifyTest("[*|*] {color: red}", "")).toThrow("Invalid qualified name in attribute selector");
+  expect(() => minifyTest("@namespace svg url(http://www.w3.org/2000/svg); [svg|*] {color: red}", "")).toThrow(
+    "Invalid qualified name in attribute selector",
+  );
+
+  // Namespace prefixes in attribute selectors and `*` local names outside of them still parse.
+  expect(minifyTest("[*|attr] {color: red}", "[*|attr]{color:red}")).toBe("[*|attr]{color:red}");
+  expect(minifyTest("[|attr] {color: red}", "[attr]{color:red}")).toBe("[attr]{color:red}");
+  expect(minifyTest("*|* {color: red}", "*|*{color:red}")).toBe("*|*{color:red}");
+});
+
+test("fuzzer-minimized input: unterminated `[|*` attribute selector", async () => {
+  // Run in a child process so a crash doesn't take down the test runner.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `try {
+        require("bun:internal-for-testing").cssInternals.minifyTest("[|*", "");
+        console.log("no error");
+      } catch (e) {
+        console.log("error: " + e.message);
+      }`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The unterminated rule is skipped once the selector is rejected, so the surfaced error is EOF.
+  expect(stdout.trim()).toBe("error: parsing failed: Unexpected end of input");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### What

Fuzzer-found panic: a 3-byte CSS input `[|*` crashes the selector parser with `panic: internal error: entered unreachable code`.

```sh
BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1 bun -e 'require("bun:internal-for-testing").cssInternals.minifyTest("[|*", "")'
```

Any attribute selector whose qualified name ends in `*` reproduces it: `[|*]`, `[*|*]`, `[ns|*]` (with `@namespace ns`), regardless of how the stylesheet is fed to the CSS parser.

### Cause

`parse_qualified_name_eplicit_namespace_helper` in `src/css/selectors/parser.rs` accepted `*` as a local name unconditionally:

```rust
Token::Delim(c) if *c == b'*' as u32 => {
    return Ok(OptionalQName::Some(namespace, None));
}
```

The upstream `selectors` crate guards this arm with `!in_attr_selector`, because attribute selectors must have an identifier local name — there is no universal attribute selector. Without the guard, `parse_attribute_selector` receives a qualified name with no local name and hits `unreachable!()` (`ln.unwrap_or_else(|| unreachable!())`).

### Fix

Restore the `!in_attr_selector` guard on the `*` arm, so `[|*`, `[*|*]`, `[ns|*]` fall through to the existing `InvalidQualNameInAttr` parse error ("Invalid qualified name in attribute selector: *") instead of panicking. Element selectors like `*|*` and valid attribute selectors like `[*|attr]` / `[|attr]` are unaffected.

### Verification

- New test `test/js/bun/css/attr-selector-namespace-star.test.ts` panics the test runner without the fix and passes with it (covers the exact fuzzer input in a child process, the bracketed/namespaced variants, and the still-valid forms).
- `test/js/bun/css/css.test.ts`, `doesnt_crash.test.ts`, `nth-anplusb-ident.test.ts` pass with the change.
