### PR TITLE
Fix CSS color fallback panic for system colors and currentColor in compound values

### DIFF
--- a/src/css/small_list.rs
+++ b/src/css/small_list.rs
@@ -213,7 +213,10 @@ pub mod fallbacks_gated {
                 // dummy non-alloced color to avoid deep cloning the real one since we will replace it
                 new_shadow.color = css::css_values::color::CssColor::CurrentColor;
                 new_shadow = new_shadow.deep_clone(arena);
-                new_shadow.color = shadow.color.to_rgb().unwrap();
+                new_shadow.color = shadow
+                    .color
+                    .to_rgb()
+                    .unwrap_or_else(|| shadow.color.deep_clone(arena));
                 rgb.append_assume_capacity(new_shadow);
             }
             res.append(rgb);
@@ -226,7 +229,10 @@ pub mod fallbacks_gated {
                 // dummy non-alloced color to avoid deep cloning the real one since we will replace it
                 new_shadow.color = css::css_values::color::CssColor::CurrentColor;
                 new_shadow = new_shadow.deep_clone(arena);
-                new_shadow.color = shadow.color.to_p3().unwrap();
+                new_shadow.color = shadow
+                    .color
+                    .to_p3()
+                    .unwrap_or_else(|| shadow.color.deep_clone(arena));
                 p3.append_assume_capacity(new_shadow);
             }
             res.append(p3);
@@ -234,7 +240,9 @@ pub mod fallbacks_gated {
 
         if fallbacks.contains(css::ColorFallbackKind::LAB) {
             for shadow in this.slice_mut() {
-                let out = shadow.color.to_lab().unwrap();
+                let Some(out) = shadow.color.to_lab() else {
+                    continue;
+                };
                 // old color dropped via replace
                 let _ = core::mem::replace(&mut shadow.color, out);
             }

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -560,12 +560,6 @@ impl CssColor {
     }
 
     /// Project this color into the given fallback colorspace.
-    ///
-    /// The fallback kind may have been derived from sibling colors in a compound
-    /// value (e.g. a background shorthand or a gradient stop list), so this color
-    /// itself may not be convertible (`currentColor`, system colors, or a
-    /// `light-dark()` containing one of those). Those colors need no fallback and
-    /// are returned unchanged.
     pub fn get_fallback(&self, _arena: &Arena, kind: ColorFallbackKind) -> CssColor {
         if matches!(self, CssColor::Rgba(_)) {
             return self.clone();
@@ -588,8 +582,6 @@ impl CssColor {
 
         let mut res = crate::SmallList::<CssColor, 2>::default();
 
-        // The conversions can fail for `light-dark()` values where one side is a
-        // system color or `currentColor`; in that case no fallback is added.
         if fallbacks.contains(ColorFallbackKind::RGB) {
             // PERF(port): was assume_capacity
             if let Some(rgb) = self.to_rgb() {

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -560,22 +560,23 @@ impl CssColor {
     }
 
     /// Project this color into the given fallback colorspace.
+    ///
+    /// The fallback kind may have been derived from sibling colors in a compound
+    /// value (e.g. a background shorthand or a gradient stop list), so this color
+    /// itself may not be convertible (`currentColor`, system colors, or a
+    /// `light-dark()` containing one of those). Those colors need no fallback and
+    /// are returned unchanged.
     pub fn get_fallback(&self, _arena: &Arena, kind: ColorFallbackKind) -> CssColor {
         if matches!(self, CssColor::Rgba(_)) {
             return self.clone();
         }
-        match kind.bits() {
-            x if x == ColorFallbackKind::RGB.bits() => self
-                .to_rgb()
-                .expect("infallible: fallback implies convertible"),
-            x if x == ColorFallbackKind::P3.bits() => self
-                .to_p3()
-                .expect("infallible: fallback implies convertible"),
-            x if x == ColorFallbackKind::LAB.bits() => self
-                .to_lab()
-                .expect("infallible: fallback implies convertible"),
+        let converted = match kind.bits() {
+            x if x == ColorFallbackKind::RGB.bits() => self.to_rgb(),
+            x if x == ColorFallbackKind::P3.bits() => self.to_p3(),
+            x if x == ColorFallbackKind::LAB.bits() => self.to_lab(),
             _ => unreachable!("Expected RGBA, P3, LAB fallback. This is a bug in Bun."),
-        }
+        };
+        converted.unwrap_or_else(|| self.clone())
     }
 
     pub fn get_fallbacks(
@@ -587,26 +588,26 @@ impl CssColor {
 
         let mut res = crate::SmallList::<CssColor, 2>::default();
 
+        // The conversions can fail for `light-dark()` values where one side is a
+        // system color or `currentColor`; in that case no fallback is added.
         if fallbacks.contains(ColorFallbackKind::RGB) {
             // PERF(port): was assume_capacity
-            res.append(
-                self.to_rgb()
-                    .expect("infallible: fallback implies convertible"),
-            );
+            if let Some(rgb) = self.to_rgb() {
+                res.append(rgb);
+            }
         }
 
         if fallbacks.contains(ColorFallbackKind::P3) {
             // PERF(port): was assume_capacity
-            res.append(
-                self.to_p3()
-                    .expect("infallible: fallback implies convertible"),
-            );
+            if let Some(p3) = self.to_p3() {
+                res.append(p3);
+            }
         }
 
         if fallbacks.contains(ColorFallbackKind::LAB) {
-            *self = self
-                .to_lab()
-                .expect("infallible: fallback implies convertible");
+            if let Some(lab) = self.to_lab() {
+                *self = lab;
+            }
         }
 
         res

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7528,6 +7528,126 @@ describe("css tests", () => {
       minify_test('.foo { color: "a" lab(40% 0.1 0.1) }', '.foo{color:"a" lab(40% .1 .1)}');
     });
 
+    describe("color fallbacks with system colors and currentColor", () => {
+      // System colors and currentColor can't be converted to RGB/P3/LAB. When they
+      // sit next to colors that do need fallbacks (in a background shorthand, a
+      // gradient stop list, a shadow list, or light-dark()), they must pass through
+      // unchanged instead of panicking.
+
+      // `background` is a deprecated CSS2 system color.
+      prefix_test(
+        `
+          .foo {
+            background: background linear-gradient(lch(8% 76 2), lch(51% 66 6));
+          }
+        `,
+        indoc`
+          .foo {
+            background: background linear-gradient(#41001b, #da3671);
+            background: background linear-gradient(lch(8% 76 2), lch(51% 66 6));
+          }
+        `,
+        {
+          chrome: 95 << 16,
+        },
+      );
+      prefix_test(
+        `
+          .foo {
+            background: background linear-gradient(lch(8% 76 2), lch(51% 66 6));
+          }
+        `,
+        indoc`
+          .foo {
+            background: background linear-gradient(color(display-p3 .342311 -.157987 .0918331), color(display-p3 .787212 .27046 .444387));
+            background: background linear-gradient(lch(8% 76 2), lch(51% 66 6));
+          }
+        `,
+        {
+          safari: 14 << 16,
+        },
+      );
+      prefix_test(
+        `
+          .foo {
+            background: linear-gradient(currentColor, lch(50% 50 180));
+          }
+        `,
+        indoc`
+          .foo {
+            background: linear-gradient(currentColor, #008675);
+            background: linear-gradient(currentColor, lch(50% 50 180));
+          }
+        `,
+        {
+          chrome: 95 << 16,
+        },
+      );
+      prefix_test(
+        `
+          .foo {
+            background: buttonface linear-gradient(lch(50% 50 180), canvas);
+          }
+        `,
+        indoc`
+          .foo {
+            background: buttonface linear-gradient(#008675, canvas);
+            background: buttonface linear-gradient(lch(50% 50 180), canvas);
+          }
+        `,
+        {
+          chrome: 95 << 16,
+        },
+      );
+      prefix_test(
+        `
+          .foo {
+            color: light-dark(buttonface, lch(50% 50 180));
+          }
+        `,
+        indoc`
+          .foo {
+            color: var(--buncss-light, buttonface) var(--buncss-dark, lch(50% 50 180));
+          }
+        `,
+        {
+          chrome: 95 << 16,
+        },
+      );
+      prefix_test(
+        `
+          .foo {
+            text-shadow: 0 0 currentColor, 0 0 lch(50% 50 180);
+          }
+        `,
+        indoc`
+          .foo {
+            text-shadow: 0 0, 0 0 #008675;
+            text-shadow: 0 0, 0 0 lch(50% 50 180);
+          }
+        `,
+        {
+          chrome: 95 << 16,
+        },
+      );
+      prefix_test(
+        `
+          .foo {
+            text-shadow: 0 0 currentColor, 0 0 lch(50% 50 180);
+          }
+        `,
+        indoc`
+          .foo {
+            text-shadow: 0 0, 0 0 color(display-p3 -.0472161 .537112 .461858);
+            text-shadow: 0 0, 0 0 lch(50% 50 180);
+          }
+        `,
+        {
+          safari: 14 << 16,
+        },
+      );
+    });
+
     // Deeply nested @keyframes with invalid percentages
     describe("nested keyframes", () => {
       cssTest(

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7529,12 +7529,6 @@ describe("css tests", () => {
     });
 
     describe("color fallbacks with system colors and currentColor", () => {
-      // System colors and currentColor can't be converted to RGB/P3/LAB. When they
-      // sit next to colors that do need fallbacks (in a background shorthand, a
-      // gradient stop list, a shadow list, or light-dark()), they must pass through
-      // unchanged instead of panicking.
-
-      // `background` is a deprecated CSS2 system color.
       prefix_test(
         `
           .foo {


### PR DESCRIPTION
### Problem

Found by fuzzing (`panic: infallible: fallback implies convertible`), but reachable through the public API with completely valid CSS. Any compound CSS value that mixes a color needing a browser fallback (`lch()`, `lab()`, `oklch()`, …) with a color that cannot be converted to a concrete colorspace (`currentColor` or a system color like `background`, `buttonface`, `canvas`) panics the CSS minifier whenever browser targets require color fallbacks — including the default targets used by `bun build`:

```sh
# app.css: .foo{background:background linear-gradient(lch(8% 76 2), lch(51% 66 6))}
bun build app.css
# panic: infallible: fallback implies convertible
```

(`background` is a deprecated CSS2 system color keyword, so the shorthand parses as color = system color + image = lch gradient.)

Original fuzz repro (minimized; panics when browser targets are supplied):

```sh
BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1 bun -e 'require("bun:internal-for-testing").cssInternals.minifyTest("{background:background linear-gradient(lch(8% 76 2), lch(51%66 6)", "")'
```

Other affected inputs (with browser targets that need color fallbacks):

- `background: linear-gradient(currentColor, lch(50% 50 180))` — inconvertible gradient stop
- `color: light-dark(buttonface, lch(50% 50 180))` — mixed `light-dark()`
- `text-shadow: 0 0 currentColor, 0 0 lch(50% 50 180)` — shadow list (panics with `called Option::unwrap() on a None value`)

### Cause

`CssColor::get_fallback` in `src/css/values/color.rs` assumes the requested fallback kind implies the color is convertible (`.expect("infallible: fallback implies convertible")`). That holds when the kind is derived from the color itself, but for compound values (the `background` shorthand, gradient stop lists, shadow lists, unparsed token lists) the fallback kind is computed from the **union of all colors in the value** and then applied to **every** color — including `currentColor` and system colors, whose conversions return `None`.

The same assumption exists in `CssColor::get_fallbacks` (reachable via `light-dark()` with one inconvertible side, since its possible-fallback set is the union of both sides) and in the text-shadow fallback path in `src/css/small_list.rs`, which used bare `.unwrap()`.

Upstream lightningcss has the same panic (`called Result::unwrap() on an Err value` at `src/values/color.rs:441` with the same input), so there is no upstream behavior to match here. The box-shadow handler in this codebase already handles the case gracefully (`unwrap_or_else(|| input.color.deep_clone(arena))`), so this brings the remaining paths in line with it.

### Fix

- `CssColor::get_fallback`: if the conversion to the requested colorspace isn't possible, return the color unchanged. `currentColor` and system colors are universally supported keywords and need no fallback, so the generated fallback declaration simply keeps them while sibling colors get converted.
- `CssColor::get_fallbacks`: skip fallbacks that cannot be computed (mixed `light-dark()`), instead of panicking.
- `small_list::get_fallbacks_text_shadow`: same treatment box-shadow already had — keep the original color when conversion isn't possible.

No output changes for previously working inputs; the conversions only fail for colors that previously caused the panic.

Output for the repro above is now:

```css
.foo {
  background: background linear-gradient(#41001b, #da3671);
  background: background linear-gradient(color(display-p3 .342311 -.157987 .0918331), color(display-p3 .787212 .27046 .444387));
  background: background linear-gradient(lch(8% 76 2), lch(51% 66 6));
}
```

### Verification

- New tests in `test/js/bun/css/css.test.ts` (`edge cases > color fallbacks with system colors and currentColor`) covering the background shorthand with a system color, gradients with `currentColor`/system color stops, mixed `light-dark()`, and `text-shadow` lists, with both RGB (`chrome 95`) and P3 (`safari 14`) fallback targets.
- Without the fix these tests crash with the fuzz signature; with the fix `bun bd test test/js/bun/css/css.test.ts` → 1071 pass, 0 fail.
- `color.test.ts`, `doesnt_crash.test.ts`, `css-system-color-*` regression tests, and the other CSS test files pass with the debug build.
- The original fuzz repro and `bun build` on the CSS above no longer panic.
