### PR TITLE
patch: don't panic applying a rename whose destination dir overflows the path buffer

### DIFF
--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -50,8 +50,6 @@ pub struct PatchFile<'a> {
 
 // Zig `deinit` only freed owned fields → Drop is automatic.
 
-// The cached absolute patch-dir path is only consumed by the Windows branches
-// below (POSIX works dirfd-relative throughout), so it is dead code on unix.
 #[cfg_attr(unix, allow(dead_code))]
 struct ApplyState {
     pathbuf: PathBuffer,
@@ -120,11 +118,6 @@ impl<'a> PatchFile<'a> {
 
                     let todir = paths::dirname_simple(to_path.as_bytes());
                     if !todir.is_empty() {
-                        // Create the destination's parent directory relative to `patch_dir`,
-                        // like the FileCreation branch below. Joining the patch dir's absolute
-                        // path with the patch-supplied dirname can exceed the fixed-size
-                        // path-join buffer (and panic); the dirfd-relative mkdir surfaces
-                        // over-long paths as a regular error instead.
                         if let sys::Result::Err(e) =
                             sys::mkdir_recursive_at_mode(patch_dir, todir, 0o755)
                         {

--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -10,7 +10,7 @@ use core::mem;
 use bun_collections::bit_set::ArrayBitSet;
 use bun_core::{PathString, strings};
 use bun_core::{ZBox, ZStr};
-use bun_paths::{self as paths, PathBuffer, platform};
+use bun_paths::{self as paths, PathBuffer};
 use bun_sys::{self as sys, Fd, FdExt};
 
 bun_core::declare_scope!(Patch, visible);
@@ -50,6 +50,9 @@ pub struct PatchFile<'a> {
 
 // Zig `deinit` only freed owned fields → Drop is automatic.
 
+// The cached absolute patch-dir path is only consumed by the Windows branches
+// below (POSIX works dirfd-relative throughout), so it is dead code on unix.
+#[cfg_attr(unix, allow(dead_code))]
 struct ApplyState {
     pathbuf: PathBuffer,
     // TODO(port): lifetime — `patch_dir_abs_path` is a self-referential slice
@@ -66,6 +69,7 @@ impl ApplyState {
         }
     }
 
+    #[cfg_attr(unix, allow(dead_code))]
     fn patch_dir_abs_path(&mut self, fd: Fd) -> sys::Result<&ZStr> {
         if let Some(len) = self.patch_dir_abs_path {
             // pathbuf[len] == 0 was written below on a previous call.
@@ -116,16 +120,13 @@ impl<'a> PatchFile<'a> {
 
                     let todir = paths::dirname_simple(to_path.as_bytes());
                     if !todir.is_empty() {
-                        let abs_patch_dir = match state.patch_dir_abs_path(patch_dir) {
-                            sys::Result::Ok(p) => p,
-                            sys::Result::Err(e) => return Some(e.without_path()),
-                        };
-                        let path_to_make = paths::resolve_path::join_z::<platform::Auto>(&[
-                            abs_patch_dir.as_bytes(),
-                            todir,
-                        ]);
+                        // Create the destination's parent directory relative to `patch_dir`,
+                        // like the FileCreation branch below. Joining the patch dir's absolute
+                        // path with the patch-supplied dirname can exceed the fixed-size
+                        // path-join buffer (and panic); the dirfd-relative mkdir surfaces
+                        // over-long paths as a regular error instead.
                         if let sys::Result::Err(e) =
-                            sys::mkdir_recursive_at_mode(Fd::cwd(), path_to_make.as_bytes(), 0o755)
+                            sys::mkdir_recursive_at_mode(patch_dir, todir, 0o755)
                         {
                             return Some(e.without_path());
                         }
@@ -245,10 +246,11 @@ impl<'a> PatchFile<'a> {
                             sys::Result::Err(e) => return Some(e.without_path()),
                         };
                         let mut buf = PathBuffer::uninit();
-                        let joined_absfilepath = paths::resolve_path::join_z_buf::<platform::Auto>(
-                            &mut buf[..],
-                            &[absfilepath.as_bytes(), filepath.as_bytes()],
-                        );
+                        let joined_absfilepath =
+                            paths::resolve_path::join_z_buf::<paths::platform::Auto>(
+                                &mut buf[..],
+                                &[absfilepath.as_bytes(), filepath.as_bytes()],
+                            );
                         let fd = match sys::open(&joined_absfilepath, sys::O::RDWR, 0) {
                             sys::Result::Err(e) => return Some(e.without_path()),
                             sys::Result::Ok(f) => f,
@@ -286,7 +288,7 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
         #[cfg(not(unix))]
         let r = {
             let p = match state.patch_dir_abs_path(patch_dir) {
-                sys::Result::Ok(p) => paths::resolve_path::join_z::<platform::Auto>(&[
+                sys::Result::Ok(p) => paths::resolve_path::join_z::<paths::platform::Auto>(&[
                     p.as_bytes(),
                     file_path.as_bytes(),
                 ]),

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -202,6 +202,41 @@ describe("apply", () => {
       ).toBe("okay!\n");
     });
 
+    // A hostile patchfile can specify a `rename to` destination whose parent
+    // directory is longer than the fixed-size path buffers; apply() must
+    // surface that as a catchable error instead of aborting the process.
+    test("to a destination dir longer than the path buffer throws instead of crashing", async () => {
+      const tempdir = tempDirWithFiles("patch-test", { "from.txt": "hello!" });
+
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `import { patchInternals } from "bun:internal-for-testing";
+           const hugeDir = Buffer.alloc(8000, "a").toString();
+           const patchfile = "rename from from.txt\\nrename to " + hugeDir + "/to.txt\\n";
+           try {
+             patchInternals.apply(patchfile, ${JSON.stringify(tempdir)});
+             console.log("no-error");
+           } catch (e) {
+             console.log("caught: " + e.code);
+           }`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      if (process.platform !== "win32") {
+        expect(stdout.trim()).toBe("caught: ENAMETOOLONG");
+      } else {
+        expect(stdout.trim()).toStartWith("caught:");
+      }
+      expect(exitCode).toBe(0);
+    });
+
     test("folders", async () => {
       const files = {
         "a/foo/hey.txt": "hello!",

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -202,9 +202,6 @@ describe("apply", () => {
       ).toBe("okay!\n");
     });
 
-    // A hostile patchfile can specify a `rename to` destination whose parent
-    // directory is longer than the fixed-size path buffers; apply() must
-    // surface that as a catchable error instead of aborting the process.
     test("to a destination dir longer than the path buffer throws instead of crashing", async () => {
       const tempdir = tempDirWithFiles("patch-test", { "from.txt": "hello!" });
 


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-found crash in patch application: applying a patchfile whose `rename to` destination has a long parent directory aborts the process with

```
panic: range end index 4107 out of range for slice of length 4094
```

#### Repro

```js
// BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1
import { patchInternals } from "bun:internal-for-testing";
const hugeDir = Buffer.alloc(8000, "a").toString();
patchInternals.apply(`rename from from.txt\nrename to ${hugeDir}/to.txt\n`, someDir);
```

The same code path runs during `bun install` when applying `patchedDependencies`, so a hostile `.patch` file can crash the install.

#### Cause

`PatchFile::apply`'s `FileRename` branch built the destination's parent directory as an **absolute** path by joining the patch dir's absolute path with the patch-supplied dirname via `resolve_path::join_z`. That join normalizes into a fixed 4096-byte thread-local buffer (`JOIN_BUF` → `join_string_buf(&buf[..4095])` → `normalize_string_node_t` writes into `buf[1..]`, i.e. 4094 bytes), so any joined path longer than that trips a slice-bounds panic — the `4107` / `4094` numbers from the fuzz report correspond exactly to a ~4081-byte dirname joined with a 26-byte patch dir path.

#### Fix

Create the destination's parent directory **relative to the patch dir fd** with `sys::mkdir_recursive_at_mode(patch_dir, todir, 0o755)`, the same way the `FileCreation` branch already does. This removes the unbounded fixed-buffer join entirely; over-long paths now surface as a regular `ENAMETOOLONG` error that `patchInternals.apply` / `bun install` report as a normal failure.

Because the cached absolute patch-dir path is now only needed by the Windows-only branches, `ApplyState`'s field/method are marked `#[cfg_attr(unix, allow(dead_code))]` and the remaining `platform::Auto` uses go through the existing `paths` alias.

#### Verification

- New test in `test/js/bun/patch/patch.test.ts` (`apply > rename > to a destination dir longer than the path buffer throws instead of crashing`) spawns a subprocess that applies such a patch: without the fix the subprocess aborts with the panic above; with the fix it throws a catchable `ENAMETOOLONG` and exits 0.
- The original fuzz input (4,158-byte patchfile with a 4,127-byte `rename to` path) now yields `ENAMETOOLONG` instead of the panic.
- All existing tests in `test/js/bun/patch/patch.test.ts` pass (23/23), including the `rename > folders` test that exercises the changed mkdir path.
