### PR TITLE
Fix exponential backtracking on nested TypeScript infer constraints

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -358,6 +358,17 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
 
     pub reported_stack_overflow: core::cell::Cell<bool>,
 
+    /// Attempts to skip the constraint of an `infer` type that already backtracked,
+    /// keyed by the byte offset of the `extends` token shifted left by one, with the
+    /// low bit set when conditional types were disallowed. The outcome of such an
+    /// attempt is fully determined by that key, so a repeated attempt can return
+    /// `false` immediately instead of re-parsing the constraint. Without this memo,
+    /// every backtracked constraint gets re-parsed as the `extends` clause of a
+    /// conditional type, which re-runs the attempts nested inside it — exponential
+    /// for deeply nested `infer X extends` constraints inside template literal types
+    /// (found by fuzzing).
+    pub ts_infer_constraint_backtracks: HashMap<u64, ()>,
+
     /// When this flag is enabled, we attempt to fold all expressions that
     /// TypeScript would consider to be "constant expressions". This flag is
     /// enabled inside each enum body block since TypeScript requires numeric
@@ -9241,6 +9252,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             stack_check: bun_core::StackCheck::init(),
             parse_stmt_depth: 0,
             reported_stack_overflow: core::cell::Cell::new(false),
+            ts_infer_constraint_backtracks: Default::default(),
             arena,
             then_catch_chain: ThenCatchChain {
                 next_target: null_expr_data(),

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -366,8 +366,9 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// every backtracked constraint gets re-parsed as the `extends` clause of a
     /// conditional type, which re-runs the attempts nested inside it — exponential
     /// for deeply nested `infer X extends` constraints inside template literal types
-    /// (found by fuzzing).
-    pub ts_infer_constraint_backtracks: HashMap<u64, ()>,
+    /// (found by fuzzing). Kept sorted for binary search; stays empty (no allocation)
+    /// until a constraint attempt actually backtracks, which is rare in real code.
+    pub ts_infer_constraint_backtracks: Vec<u32>,
 
     /// When this flag is enabled, we attempt to fold all expressions that
     /// TypeScript would consider to be "constant expressions". This flag is
@@ -9252,7 +9253,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             stack_check: bun_core::StackCheck::init(),
             parse_stmt_depth: 0,
             reported_stack_overflow: core::cell::Cell::new(false),
-            ts_infer_constraint_backtracks: Default::default(),
+            ts_infer_constraint_backtracks: Vec::new(),
             arena,
             then_catch_chain: ThenCatchChain {
                 next_target: null_expr_data(),

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -1548,9 +1548,26 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         &mut self,
         flags: SkipTypeOptionsBitset,
     ) -> bool {
-        self.lexer_backtracker_bool(|p| {
+        // The outcome of this attempt depends only on the position of the `extends`
+        // token and on whether conditional types are allowed, so an attempt that
+        // already backtracked here can be skipped. Each backtracked constraint gets
+        // re-parsed by the caller as the `extends` clause of a conditional type,
+        // which repeats the attempts nested inside it; without the memo that's
+        // exponential for deeply nested `infer X extends` constraints inside
+        // template literal types (found by fuzzing).
+        let memo_key = ((self.lexer.start as u64) << 1)
+            | flags.contains(SkipTypeOptions::DisallowConditionalTypes) as u64;
+        if self.ts_infer_constraint_backtracks.contains(&memo_key) {
+            return false;
+        }
+
+        let skipped = self.lexer_backtracker_bool(|p| {
             p.skip_type_script_constraint_of_infer_type_with_backtracking(flags)
-        })
+        });
+        if !skipped {
+            self.ts_infer_constraint_backtracks.insert(memo_key, ());
+        }
+        skipped
     }
 }
 

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -1576,7 +1576,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // Re-search for the insertion point: attempts nested inside the one that
             // just failed may have added entries of their own.
             if let Err(insert_at) = self.ts_infer_constraint_backtracks.binary_search(&memo_key) {
-                self.ts_infer_constraint_backtracks.insert(insert_at, memo_key);
+                self.ts_infer_constraint_backtracks
+                    .insert(insert_at, memo_key);
             }
         }
         skipped

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -1555,9 +1555,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // which repeats the attempts nested inside it; without the memo that's
         // exponential for deeply nested `infer X extends` constraints inside
         // template literal types (found by fuzzing).
-        let memo_key = ((self.lexer.start as u64) << 1)
-            | flags.contains(SkipTypeOptions::DisallowConditionalTypes) as u64;
-        if self.ts_infer_constraint_backtracks.contains(&memo_key) {
+        //
+        // Token offsets fit in 31 bits (`Loc` is an `i32`), so the offset and the
+        // flag bit pack into a `u32`.
+        debug_assert!(self.lexer.start <= (u32::MAX >> 1) as usize);
+        let memo_key = ((self.lexer.start as u32) << 1)
+            | flags.contains(SkipTypeOptions::DisallowConditionalTypes) as u32;
+        if self
+            .ts_infer_constraint_backtracks
+            .binary_search(&memo_key)
+            .is_ok()
+        {
             return false;
         }
 
@@ -1565,7 +1573,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.skip_type_script_constraint_of_infer_type_with_backtracking(flags)
         });
         if !skipped {
-            self.ts_infer_constraint_backtracks.insert(memo_key, ());
+            // Re-search for the insertion point: attempts nested inside the one that
+            // just failed may have added entries of their own.
+            if let Err(insert_at) = self.ts_infer_constraint_backtracks.binary_search(&memo_key) {
+                self.ts_infer_constraint_backtracks.insert(insert_at, memo_key);
+            }
         }
         skipped
     }

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -288,6 +288,49 @@ describe("Bun.Transpiler", () => {
       ts.expectPrinted_("var foo: Foo extends string & infer Foo extends string ? Foo : never", "var foo");
     });
 
+    it("deeply nested infer constraints in template literal types do not hang the parser", async () => {
+      // Every `infer X extends` constraint attempt that backtracks gets re-parsed as
+      // the `extends` clause of a conditional type. Without memoizing backtracked
+      // attempts, that re-parse repeats the attempts nested inside it, so inputs that
+      // nest the pattern inside template literal types take O(2^depth) time (found by
+      // fuzzing Bun.build with a ~140-level input).
+      const fill = (n, unit) => Buffer.alloc(n * unit.length, unit).toString();
+      const depth = 128;
+      // Shape found by fuzzing: every constraint attempt fails near EOF (hard error).
+      const malformed =
+        "type LengthDown<\r\n  ? unknown extends " + fill(depth, "`${infer own extends ") + "`${infer $Rest}`\r";
+      // Valid variant: every constraint parses but is followed by "?", so every level
+      // backtracks and re-parses the constraint as part of a conditional type.
+      const valid =
+        "type X = " + fill(depth, "`${infer o extends ") + "number" + fill(depth, " ? 0 : 1}`") + ";\nexport {};\n";
+
+      using dir = tempDir("ts-infer-constraint-hang", {
+        "malformed.ts": malformed,
+        "valid.ts": valid,
+        "check.ts": `
+          const malformed = await Bun.build({ entrypoints: ["./malformed.ts"], target: "browser", throw: false });
+          if (malformed.success) throw new Error("malformed input should fail to parse");
+          const valid = await Bun.build({ entrypoints: ["./valid.ts"], target: "browser", throw: false });
+          if (!valid.success) throw new Error("valid input should build: " + valid.logs.join("\\n"));
+          console.log("DONE");
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "check.ts"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: 30_000,
+        killSignal: "SIGKILL",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toContain("DONE");
+      expect(exitCode).toBe(0);
+    }, 90_000);
+
     it.todo("instantiation expressions", async () => {
       const exp = ts.expectPrinted_;
       const err = ts.expectParseError;
@@ -569,6 +612,9 @@ function foo() {}
       exp("type Foo = {} extends (infer T extends {}) ? A<T> : never", "");
       exp("let x: A extends B<infer C extends D> ? D : never", "let x;\n");
       exp("let x: A extends B<infer C extends D ? infer C : never> ? D : never", "let x;\n");
+      exp("type Foo = `${infer T extends `${infer U extends `${infer V}`}`}`", "");
+      exp("type Foo = `${infer T extends `${infer U extends string ? 1 : 2}` ? 3 : 4}`", "");
+      exp("let x: T extends infer U extends `${infer V extends W ? 1 : 2}` ? U : never", "let x;\n");
       exp("let x: ([e1, e2, ...es]: any) => any", "let x;\n");
       exp("let x: (...[e1, e2, es]: any) => any", "let x;\n");
       exp("let x: (...[e1, e2, ...es]: any) => any", "let x;\n");


### PR DESCRIPTION
### Problem

Parser fuzzing found a 3 KB TypeScript input that keeps `Bun.build` busy in the JS lexer for 20+ seconds (hang signature `mi_heap_malloc | bun_js_parser::lexer::LexerType…`). The input nests `` `${infer own extends `${infer own extends … `` about 140 levels deep inside template literal types.

Parse time doubles per nesting level on the current release:

| nesting depth | time |
|---|---|
| 20 | 141 ms |
| 22 | 512 ms |
| 24 | 2.0 s |
| 26 | 8.0 s |
| 140 (fuzz input) | never finishes |

A fully valid variant blows up the same way:

```ts
type X = `${infer o extends `${infer o extends /* …deeper… */ ? 0 : 1}` ? 0 : 1}`;
```

(tsc parses the fuzz input in ~300 ms.)

Original fuzz repro:

```sh
bun -e 'await Bun.build({entrypoints:["./e.ts"], files:{"./e.ts": Buffer.from(Bun.gunzipSync(Buffer.from("H4sIAAAAAAACAyupLEhV8EnNSy/JcMkvz7Ph5VJQsFcozcvOA/IUUitKUvNSihUSVKoz89JSixRGBUcFh4eg/2iAjAqOCo4KjgqOCo4KjgqOCpIuqBKUWlxSm8ALAGuwGAJGDAAA", "base64"))).toString("latin1")}, target:"browser", minify:false, sourcemap:"none", throw:false})'
```

### Cause

`skip_type_script_type_with_opts` handles `infer X extends …` by trying to skip the constraint with backtracking (`try_skip_type_script_constraint_of_infer_type_with_backtracking`). The attempt backtracks when the constraint fails to parse, or when it parses but is followed by `?` in a context that allows conditional types (the `T extends infer U extends V ? A : B` ambiguity). After backtracking, the caller re-parses the same region as the `extends` clause of a conditional type.

A template literal placeholder resets the "conditional types allowed" context, so when the pattern nests inside template literal types, every level both attempts the constraint and then re-parses it as a conditional-type clause. Each level doubles the work of the level below it — O(2^depth). In the fuzz input every attempt fails near EOF (hard error); in the valid variant every attempt is followed by `?` (the soft ambiguity). Both re-lex the nested template contents over and over, which is why the profile sits in lexer allocations.

### Fix

Memoize backtracked constraint attempts on the parser (`ts_infer_constraint_backtracks`), keyed by the byte offset of the `extends` token and whether conditional types were disallowed — the only inputs that determine the attempt's outcome. A repeated attempt at a memoized position returns `false` immediately instead of re-parsing the constraint.

This cannot change what parses: a skipped attempt would have parsed the same text with the same flags, backtracked, and restored the lexer to exactly the state it is already in. Worst case drops from O(2^depth) to roughly O(depth²) token work.

### Verification

- The original 140-level fuzz input now finishes instantly on a debug+ASAN build (~0.7 s total, dominated by startup) and reports the same five diagnostics, byte for byte, that the unfixed parser reports for smaller inputs of the same shape.
- The valid 128-level variant builds successfully in the same time.
- `bun bd test test/bundler/transpiler/` — 447 pass, 0 fail.
- New test in `test/bundler/transpiler/transpiler.test.js` builds both the fuzz-shaped malformed input and the valid nested variant at depth 128 in a child process with a 30 s kill switch: it fails on the unfixed build (child killed after 30 s) and passes in ~1 s with the fix. Added conformance cases locking in that nested `infer … extends` constraints inside template literal types still parse exactly as before.
