### PR TITLE
Fix unchecked exception when Bun.plugin target cannot be converted to a string

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -302,12 +302,11 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
     auto targetValue = obj->getIfPropertyExists(globalObject, Identifier::fromString(vm, "target"_s));
     RETURN_IF_EXCEPTION(throwScope, {});
     if (targetValue) {
-        if (auto* targetJSString = targetValue.toStringOrNull(globalObject)) {
-            String targetString = targetJSString->value(globalObject);
-            if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
-                JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
-                return {};
-            }
+        String targetString = targetValue.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
+            JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
+            return {};
         }
     }
 

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -366,6 +366,17 @@ describe("errors", () => {
     }).toThrow("plugin target must be one of 'node', 'bun' or 'browser'");
   });
 
+  it("handles 'target' that cannot be converted to a string", () => {
+    const opts = {
+      setup: () => {},
+      target: Symbol("not a string"),
+    };
+
+    expect(() => {
+      plugin(opts as any);
+    }).toThrow("Cannot convert a symbol to a string");
+  });
+
   it("invalid loaders throw", () => {
     const invalidLoaders = ["blah", "blah2", "blah3", "blah4"];
     const inputs = ["body { background: red; }", "<h1>hi</h1>", '{"hi": "there"}', "hi"];


### PR DESCRIPTION
### What does this PR do?

Fixes an unchecked JS exception in `Bun.plugin()` (fuzzer-found, fingerprint `e72b98fc73896e0c`).

`setupBunPlugin` converted the `target` option to a string with `toStringOrNull()`. When that conversion throws (e.g. `target` is a Symbol, or an object whose `toString` returns a Symbol), the code ignored the null result and continued with the exception still pending on the throw scope, eventually invoking the plugin's `setup` callback. On debug/ASAN builds this trips `ExceptionScope::assertNoException()` and aborts:

```
ASSERTION FAILED: Unexpected exception observed on thread ...
Error Exception: Cannot convert a symbol to a string
!exception()
JavaScriptCore/ExceptionScope.h(61) : void JSC::ExceptionScope::assertNoException()
```

Repro:

```js
Bun.plugin({ target: Symbol(), setup: () => {} });
```

The conversion now uses `toWTFString()` with `RETURN_IF_EXCEPTION`, matching the rest of the file, so the exception propagates to the caller as a regular `TypeError` instead of being swallowed while execution continues.

### How did you verify your code works?

- Minimized fuzzer repro now throws `TypeError: Cannot convert a symbol to a string` instead of aborting (verified on a debug+ASAN build, including with `BUN_JSC_validateExceptionChecks=1`).
- Added a regression test in `test/js/bun/plugin/plugins.test.ts`; `bun bd test test/js/bun/plugin/plugins.test.ts` passes (30 pass, 1 todo).
