### PR TITLE
Bun.openInEditor: throw when no editor is detected instead of spawning an empty command

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1041,7 +1041,7 @@ pub fn open_in_editor(global_this: &JSGlobalObject, callframe: &CallFrame) -> Js
                         edit.name =
                             unsafe { bun_ptr::detach_lifetime(slot.name_storage.as_slice()) };
                         edit.detect_editor(env);
-                        editor_choice = edit.editor;
+                        editor_choice = edit.editor.filter(|e| *e != Editor::None);
                         if editor_choice.is_none() {
                             slot.name_storage = prev_storage;
                             *edit = prev;
@@ -1074,11 +1074,11 @@ pub fn open_in_editor(global_this: &JSGlobalObject, callframe: &CallFrame) -> Js
             }
         }
 
-        let editor = match editor_choice.or(edit.editor) {
+        let editor = match editor_choice.or(edit.editor).filter(|e| *e != Editor::None) {
             Some(e) => e,
             None => {
                 edit.auto_detect_editor(env);
-                match edit.editor {
+                match edit.editor.filter(|e| *e != Editor::None) {
                     Some(e) => e,
                     None => {
                         return Err(global_this.throw(format_args!("Failed to auto-detect editor")));

--- a/test/js/bun/util/open-in-editor-gc.test.ts
+++ b/test/js/bun/util/open-in-editor-gc.test.ts
@@ -3,6 +3,59 @@ import { bunEnv, bunExe, isLinux, tempDir } from "harness";
 import { existsSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 
+// When no editor can be detected (no bunfig editor, no EDITOR/VISUAL, nothing
+// in PATH), Bun.openInEditor must throw instead of spawning a detached editor
+// thread with an empty argv[0]. Repeated calls used to fork a doomed child per
+// call, which let fuzzed scripts create thousands of threads/processes and
+// stress the GC/scavenger thread-suspension signal until the process died.
+test.skipIf(!isLinux)("Bun.openInEditor throws when no editor can be found", async () => {
+  using dir = tempDir("open-in-editor-none", {
+    "empty-path/.keep": "",
+  });
+
+  const env: Record<string, string | undefined> = {
+    ...bunEnv,
+    PATH: join(String(dir), "empty-path"),
+  };
+  delete env.EDITOR;
+  delete env.VISUAL;
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      function f0(a1, a2, a3) {}
+      let threw = 0;
+      let silent = 0;
+      let lastError = "";
+      for (let i = 0; i < 50; i++) {
+        try {
+          Bun.openInEditor(i % 2 ? "foo.js" : f0);
+          silent++;
+        } catch (e) {
+          threw++;
+          lastError = e.message;
+        }
+      }
+      Bun.gc(true);
+      console.log(JSON.stringify({ threw, silent, lastError }));
+      `,
+    ],
+    env,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({ threw: 50, silent: 0, lastError: "Failed to auto-detect editor" });
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+});
+
 // On Linux, JSC uses SIGPWR to suspend/resume threads for GC and the libpas
 // scavenger. Bun.openInEditor spawns a detached thread that goes through
 // bun.spawnSync, whose signal-forwarding setup must not touch SIGPWR or the


### PR DESCRIPTION
### What does this PR do?

Fixes a Fuzzilli-found flaky crash (fingerprint `ad4892a7a5610032`, TERMSIG 30 / "Power failure" on Linux) in the `Bun.openInEditor` path — the same family as #31183.

**Root cause**

`EditorContext::detect_editor` caches "nothing found" as the sentinel `Editor::None` (with an empty binary path), but `Bun.openInEditor` only treated `Option::None` as "no editor". So when no editor is detectable (no bunfig `editor`, no `EDITOR`/`VISUAL`, nothing in `PATH` — i.e. the fuzzing container), the intended `"Failed to auto-detect editor"` error never fired. Instead, **every call** silently spawned a detached "Open Editor" thread plus a forked child with an empty `argv[0]` that can never exec.

The fuzzer sample exploits this: it recurses until stack overflow and calls `Bun.openInEditor` once per unwound frame, so a single script run creates tens of thousands of detached threads, each running the synchronous spawn machinery (process-global signal-forwarding register/unregister, vfork + wait) concurrently, followed by `Bun.gc(true)`. On Linux, JSC and the libpas scavenger suspend threads with SIGPWR during exactly this kind of thread/allocator churn (verified: forcing SIGPWR to `SIG_DFL` and running this workload dies immediately with "Power failure"), and the storm of concurrent, main-thread-only spawnSync signal bookkeeping is what lets the flaky SIGPWR termination show up. #31183 removed SIGPWR from the forwarding list; this removes the pointless spawn storm that hammers it.

**Fix**

Treat `Editor::None` as "not found" in `Bun.openInEditor`:

- no detectable editor → throws `"Failed to auto-detect editor"` instead of spawning an empty command per call
- `{ editor: "code" }` (or another known name) that isn't installed → throws `"Could not find editor \"code\""` instead of falling through to the empty spawn
- explicit absolute paths and real detected editors are unchanged

**Related (not closed by this PR):** #31194 tracks making the detached editor helper skip the foreground spawnSync signal-forwarding entirely (via a `forward_signals` spawn option). This PR only eliminates the no-editor spawn storm; when a real editor is configured, the helper thread still uses `sync::spawn` as before, so that issue remains open.

### How did you verify your code works?

- New test in `test/js/bun/util/open-in-editor-gc.test.ts` runs `Bun.openInEditor` 50× in a child bun with editor detection guaranteed to fail and asserts every call throws (fails on the previous behavior: `threw: 0, silent: 50`; passes with this change).
- Existing `Bun.openInEditor does not break GC signal handling` test (from #31183, uses an explicit editor path) still passes.
- The fuzzer's crash body now exits with a proper JS error (`Failed to auto-detect editor`) and no longer spawns any threads/processes; previously it spawned one detached thread + doomed child per unwound frame.