### PR TITLE
Fix unchecked exception when Bun.plugin target fails string conversion

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -302,8 +302,11 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
     auto targetValue = obj->getIfPropertyExists(globalObject, Identifier::fromString(vm, "target"_s));
     RETURN_IF_EXCEPTION(throwScope, {});
     if (targetValue) {
-        if (auto* targetJSString = targetValue.toStringOrNull(globalObject)) {
+        auto* targetJSString = targetValue.toStringOrNull(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (targetJSString) {
             String targetString = targetJSString->value(globalObject);
+            RETURN_IF_EXCEPTION(throwScope, {});
             if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
                 JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
                 return {};

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -366,6 +366,21 @@ describe("errors", () => {
     }).toThrow("plugin target must be one of 'node', 'bun' or 'browser'");
   });
 
+  it("handles 'target' that throws while converting to a string", () => {
+    const opts = {
+      setup: () => {},
+      target: {
+        toString() {
+          throw new TypeError("invalid target");
+        },
+      },
+    };
+
+    expect(() => {
+      plugin(opts as any);
+    }).toThrow("invalid target");
+  });
+
   it("invalid loaders throw", () => {
     const invalidLoaders = ["blah", "blah2", "blah3", "blah4"];
     const inputs = ["body { background: red; }", "<h1>hi</h1>", '{"hi": "there"}', "hi"];


### PR DESCRIPTION
### What does this PR do?

Fixes a crash (assertion failure in debug builds: `ASSERTION FAILED: Unexpected exception observed ... !exception()` in `ExceptionScope::assertNoException`) found by fuzzing, fingerprint `f5eeed969723f716`.

In `Bun.plugin()` (`setupBunPlugin` in `src/jsc/bindings/BunPlugin.cpp`), the `target` option is converted to a string with `toStringOrNull()`. If that conversion throws (e.g. `target` is an object whose `toString` throws), the pending exception was never checked: the code silently fell through and went on to invoke the plugin's `setup()` callback with an exception still pending on the VM, tripping the exception-scope assertion (abort) in debug/ASAN builds.

This adds the missing `RETURN_IF_EXCEPTION` checks after the string conversion so the exception propagates to the caller as a normal JS error.

Repro that previously aborted:

```js
const v2 = {};
v2.target = v2;
Object.defineProperty(v2, "setup", { value: ArrayBuffer });
v2.__proto__ = Float32Array;
Bun.plugin(v2);
```

### How did you verify your code works?

- The fuzzer repro now exits with a regular `TypeError` instead of aborting.
- Added a regression test in `test/js/bun/plugin/plugins.test.ts` (`handles 'target' that throws while converting to a string`) which aborts on a debug build without the fix and passes with it.
- `bun bd test test/js/bun/plugin/plugins.test.ts` passes (30 pass, 1 todo).
