### PR TITLE
http: accept empty pfx array in https.request

### DIFF
--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -781,7 +781,10 @@ function ClientRequest(input, options, cb) {
   }
   this.joinDuplicateHeaders = joinDuplicateHeaders;
 
-  if (options.pfx) {
+  // Match Node.js behavior in lib/internal/tls/secure-context.js: an empty
+  // pfx array is iterated zero times and silently accepted. We don't yet
+  // support real PFX content, so anything non-empty still throws.
+  if (options.pfx != null && !(Array.isArray(options.pfx) && options.pfx.length === 0)) {
     throw new Error("pfx is not supported");
   }
 

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -887,6 +887,33 @@ describe("node:http", () => {
 
       await promise;
     });
+
+    // Node's lib/internal/tls/secure-context.js iterates pfx with
+    // ArrayPrototypeForEach, so an empty array is a silent no-op. Bun used to
+    // reject any truthy `pfx`, which broke ~20 Playwright client-cert tests
+    // because Playwright's convertClientCertificatesToTLSOptions always passes
+    // `pfx: []` even when no PFX is in use.
+    it("accepts an empty pfx array", () => {
+      const req = https.request({ hostname: "127.0.0.1", port: 1, pfx: [] });
+      // Swallow the connection error so the test stays clean — we're only
+      // checking that constructing the request did not throw synchronously.
+      req.on("error", () => {});
+      req.destroy();
+    });
+
+    it("still rejects non-empty pfx values", () => {
+      // Real PFX content is not yet implemented, so non-empty inputs must keep
+      // throwing the same error until the larger feature lands.
+      expect(() => https.request({ hostname: "127.0.0.1", port: 1, pfx: "anything" })).toThrow("pfx is not supported");
+
+      expect(() => https.request({ hostname: "127.0.0.1", port: 1, pfx: Buffer.from("anything") })).toThrow(
+        "pfx is not supported",
+      );
+
+      expect(() => https.request({ hostname: "127.0.0.1", port: 1, pfx: [Buffer.from("anything")] })).toThrow(
+        "pfx is not supported",
+      );
+    });
   });
 
   describe("signal", () => {


### PR DESCRIPTION
## Summary

`https.request({ pfx: [] })` currently throws `Error: pfx is not supported` in Bun, but in Node.js an empty pfx array is a silent no-op. This breaks roughly 20 Playwright client-certificate tests because Playwright's `convertClientCertificatesToTLSOptions` unconditionally puts `pfx: []` into its TLS options object, even when no PFX is configured.

This change accepts an empty array and keeps rejecting non-empty pfx values with the same error message, since real PFX is still unimplemented.

## Node behavior

[`lib/internal/tls/secure-context.js`](https://github.com/nodejs/node/blob/main/lib/internal/tls/secure-context.js) processes pfx via `ArrayPrototypeForEach(pfx, …)`. An empty array iterates zero times, so it never triggers the `addPfx` branch and is effectively ignored. Anything else (string / Buffer / non-empty array) is treated as actual PFX content.

## Before

```js
$ bun -e 'require("https").request({ hostname: "127.0.0.1", port: 1, pfx: [] })'
error: pfx is not supported
```

## After

```js
$ bun-debug -e 'require("https").request({ hostname: "127.0.0.1", port: 1, pfx: [] })'
# (no output — request object created, then naturally errors with ECONNREFUSED on connect)

$ bun-debug -e 'require("https").request({ hostname: "127.0.0.1", port: 1, pfx: "anything" })'
error: pfx is not supported   # still rejected
```

## Test plan

- [x] Added `accepts an empty pfx array` and `still rejects non-empty pfx values` cases inside the existing `describe("https.request with custom tls options")` block in `test/js/node/http/node-http.test.ts`.
- [x] `bun bd test test/js/node/http/node-http.test.ts -t "pfx"` — both new tests pass.
- [x] `USE_SYSTEM_BUN=1 bun test test/js/node/http/node-http.test.ts -t "pfx"` — the empty-array test fails on system Bun (regression validated); the rejection test passes there too.
- [x] No new lints; touched only `src/js/node/_http_client.ts` and the test file.