### PR TITLE
bun test: scope mock.module() to the test file that registered it

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -260,6 +260,12 @@ pub struct VirtualMachine {
 
     /// Used by bun:test to set global hooks for beforeAll, beforeEach, etc.
     pub is_in_preload: bool,
+    /// True while `bun test` executes a hook that was *registered* during
+    /// `--preload` (e.g. a preload script's `beforeAll`). `mock.module()`
+    /// treats such hooks like preload top-level code: mocks they install are
+    /// process-lifetime, not per-test-file. Set/cleared by the test runner's
+    /// entry lifecycle (`Execution::on_entry_started/_completed`).
+    pub is_in_preload_hook: bool,
     pub has_patched_run_main: bool,
 
     pub transpiler_store: crate::runtime_transpiler_store::RuntimeTranspilerStore,

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -149,7 +149,7 @@ static EncodedJSValue jsFunctionAppendVirtualModulePluginBody(JSC::JSGlobalObjec
     // `Bun.plugin({ module })` virtual modules persist across per-file
     // `bun test` teardown — they're process-level plugin registrations,
     // not test-local mocks.
-    global->onLoadPlugins.addModuleMock(vm, moduleId, uncheckedDowncast<JSC::JSObject>(functionValue), /*persistent=*/ true);
+    global->onLoadPlugins.addModuleMock(vm, moduleId, uncheckedDowncast<JSC::JSObject>(functionValue), /*persistent=*/true);
 
     auto* requireMap = global->requireMap();
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -150,7 +150,7 @@ static EncodedJSValue jsFunctionAppendVirtualModulePluginBody(JSC::JSGlobalObjec
     // `Bun.plugin({ module })` virtual modules persist across per-file
     // `bun test` teardown — they're process-level plugin registrations,
     // not test-local mocks.
-    global->onLoadPlugins.addModuleMock(vm, moduleId, uncheckedDowncast<JSC::JSObject>(functionValue), /*persistent=*/true, /*mockBorn=*/false);
+    global->onLoadPlugins.addModuleMock(vm, moduleId, uncheckedDowncast<JSC::JSObject>(functionValue), /*persistent=*/true, /*mockBorn=*/false, /*cjsEntryPreExisted=*/false);
 
     auto* requireMap = global->requireMap();
     RETURN_IF_EXCEPTION(scope, {});
@@ -396,7 +396,7 @@ JSC::JSObject* BunPlugin::Group::find(JSC::JSGlobalObject* globalObject, String&
     return nullptr;
 }
 
-void BunPlugin::OnLoad::addModuleMock(JSC::VM& vm, const String& path, JSC::JSObject* mockObject, bool persistent, bool mockBorn)
+void BunPlugin::OnLoad::addModuleMock(JSC::VM& vm, const String& path, JSC::JSObject* mockObject, bool persistent, bool mockBorn, bool cjsEntryPreExisted)
 {
     Zig::GlobalObject* globalObject = defaultGlobalObject(mockObject->globalObject());
     auto& onLoad = globalObject->onLoadPlugins;
@@ -453,6 +453,7 @@ void BunPlugin::OnLoad::addModuleMock(JSC::VM& vm, const String& path, JSC::JSOb
             record.displacedEntry = std::move(displacedEntry);
             record.displacedWasPersistent = displacedWasPersistent;
             record.wasMockBorn = mockBorn;
+            record.cjsEntryPreExisted = cjsEntryPreExisted;
             onLoad.transientMockRecords->set(path, std::move(record));
         }
     }
@@ -795,7 +796,11 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
 
     // No loaded-and-linked namespace at install time means any module record
     // this path acquires afterwards was materialized from the mock factory.
-    globalObject->onLoadPlugins.addModuleMock(vm, specifier, mock, persistent, /*mockBorn=*/!mockedNamespace);
+    // A require-cache entry kept in place (exports replaced above) means its
+    // first requirer predates the mock and captured real values.
+    globalObject->onLoadPlugins.addModuleMock(vm, specifier, mock, persistent,
+        /*mockBorn=*/!mockedNamespace,
+        /*cjsEntryPreExisted=*/entryValue && !removeFromCJS);
 
     // Attach the ESM teardown snapshot (if any) to the freshly-created
     // transient record. `addModuleMock` already set up the record slot;
@@ -1198,12 +1203,19 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
             mod = mod->m_parent.get();
         }
     };
-    auto poisonRequireMapEntry = [&](JSC::JSString* pathString) {
+    // `walkParents` is false when the require-cache entry predates the mock
+    // install: its `m_parent` chain required the module before the mock and
+    // captured real values, so evicting it would only re-run pre-mock side
+    // effects (e.g. preload setup). Post-mock requirers of the kept entry
+    // still get evicted through their own `m_children` edges.
+    auto poisonRequireMapEntry = [&](JSC::JSString* pathString, bool walkParents) {
         JSC::JSValue cached = requireMap->get(global, pathString);
         if (scope.clearExceptionExceptTermination() && cached && cached.isCell()) {
             poisonedCJSModules.add(cached.asCell());
-            if (auto* mod = dynamicDowncast<Bun::JSCommonJSModule>(cached)) {
-                poisonModuleAndParents(mod->m_parent.get());
+            if (walkParents) {
+                if (auto* mod = dynamicDowncast<Bun::JSCommonJSModule>(cached)) {
+                    poisonModuleAndParents(mod->m_parent.get());
+                }
             }
         }
     };
@@ -1249,7 +1261,7 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
             // replay, so always drop the require-cache entry — the next
             // `require()` misses and re-runs the restored (preload) factory.
             auto* pathString = JSC::jsString(vm, path);
-            poisonRequireMapEntry(pathString);
+            poisonRequireMapEntry(pathString, !record.cjsEntryPreExisted);
             requireMap->remove(global, pathString);
             if (!scope.clearExceptionExceptTermination()) {
                 break;
@@ -1282,7 +1294,7 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
                 moduleLoader->removeEntry(ident);
             }
             auto* pathString = JSC::jsString(vm, path);
-            poisonRequireMapEntry(pathString);
+            poisonRequireMapEntry(pathString, !record.cjsEntryPreExisted);
             requireMap->remove(global, pathString);
             if (!scope.clearExceptionExceptTermination()) {
                 break;
@@ -1328,9 +1340,11 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
                 // A dependent that was also `require()`d has a require-map
                 // entry wrapping the same (now-evicted) module; drop and
                 // poison it so the CJS walk below catches its own consumers.
+                // Dependents were loaded under the mock, so their requirers
+                // captured tainted values: walk their parent chains.
                 for (auto& ident : dependentKeys) {
                     auto* keyString = JSC::jsString(vm, ident.string());
-                    poisonRequireMapEntry(keyString);
+                    poisonRequireMapEntry(keyString, /*walkParents=*/true);
                     requireMap->remove(global, keyString);
                     if (!scope.clearExceptionExceptTermination()) {
                         break;

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -1203,19 +1203,17 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
             mod = mod->m_parent.get();
         }
     };
-    // `walkParents` is false when the require-cache entry predates the mock
-    // install: its `m_parent` chain required the module before the mock and
-    // captured real values, so evicting it would only re-run pre-mock side
-    // effects (e.g. preload setup). Post-mock requirers of the kept entry
-    // still get evicted through their own `m_children` edges.
-    auto poisonRequireMapEntry = [&](JSC::JSString* pathString, bool walkParents) {
+    // Callers skip this entirely when the require-cache entry predates the
+    // mock install: pre-mock requirers captured real values, and both the
+    // `m_parent` back-edge and `m_children` edges point at the same kept
+    // cell for pre- and post-mock requirers alike, so poisoning it would
+    // re-run pre-mock side effects (e.g. preload setup) on every file.
+    auto poisonRequireMapEntry = [&](JSC::JSString* pathString) {
         JSC::JSValue cached = requireMap->get(global, pathString);
         if (scope.clearExceptionExceptTermination() && cached && cached.isCell()) {
             poisonedCJSModules.add(cached.asCell());
-            if (walkParents) {
-                if (auto* mod = dynamicDowncast<Bun::JSCommonJSModule>(cached)) {
-                    poisonModuleAndParents(mod->m_parent.get());
-                }
+            if (auto* mod = dynamicDowncast<Bun::JSCommonJSModule>(cached)) {
+                poisonModuleAndParents(mod->m_parent.get());
             }
         }
     };
@@ -1261,7 +1259,9 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
             // replay, so always drop the require-cache entry — the next
             // `require()` misses and re-runs the restored (preload) factory.
             auto* pathString = JSC::jsString(vm, path);
-            poisonRequireMapEntry(pathString, !record.cjsEntryPreExisted);
+            if (!record.cjsEntryPreExisted) {
+                poisonRequireMapEntry(pathString);
+            }
             requireMap->remove(global, pathString);
             if (!scope.clearExceptionExceptTermination()) {
                 break;
@@ -1281,12 +1281,15 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
             if (virtualModules) {
                 virtualModules->remove(path);
             }
-            // Evict caches only when there's no persistent replacement —
-            // otherwise the next import should go straight back to the
-            // (restored) preload mock.
-            auto ident = record.wasMockBorn ? collectMockBornRecord(path)
-                                            : JSC::Identifier::fromString(vm, path);
-            {
+            // Mock-born: the registry record was materialized from the mock
+            // factory — evict it so the next import re-executes the real
+            // source (its importers are evicted transitively below).
+            // Otherwise step 1 restored the record's env slots in place, so
+            // keep the entry: cached re-exporters bind through it, and a
+            // later file's mock.module() must find it to override those
+            // bindings again.
+            if (record.wasMockBorn) {
+                auto ident = collectMockBornRecord(path);
                 // JSModuleLoader::visitChildrenImpl iterates the registry maps
                 // on the GC thread under cellLock(); take the same lock so
                 // the removal can't race it.
@@ -1294,7 +1297,9 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
                 moduleLoader->removeEntry(ident);
             }
             auto* pathString = JSC::jsString(vm, path);
-            poisonRequireMapEntry(pathString, !record.cjsEntryPreExisted);
+            if (!record.cjsEntryPreExisted) {
+                poisonRequireMapEntry(pathString);
+            }
             requireMap->remove(global, pathString);
             if (!scope.clearExceptionExceptTermination()) {
                 break;
@@ -1344,7 +1349,7 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
                 // captured tainted values: walk their parent chains.
                 for (auto& ident : dependentKeys) {
                     auto* keyString = JSC::jsString(vm, ident.string());
-                    poisonRequireMapEntry(keyString, /*walkParents=*/true);
+                    poisonRequireMapEntry(keyString);
                     requireMap->remove(global, keyString);
                     if (!scope.clearExceptionExceptTermination()) {
                         break;

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -150,7 +150,7 @@ static EncodedJSValue jsFunctionAppendVirtualModulePluginBody(JSC::JSGlobalObjec
     // `Bun.plugin({ module })` virtual modules persist across per-file
     // `bun test` teardown — they're process-level plugin registrations,
     // not test-local mocks.
-    global->onLoadPlugins.addModuleMock(vm, moduleId, uncheckedDowncast<JSC::JSObject>(functionValue), /*persistent=*/true);
+    global->onLoadPlugins.addModuleMock(vm, moduleId, uncheckedDowncast<JSC::JSObject>(functionValue), /*persistent=*/true, /*mockBorn=*/false);
 
     auto* requireMap = global->requireMap();
     RETURN_IF_EXCEPTION(scope, {});
@@ -396,7 +396,7 @@ JSC::JSObject* BunPlugin::Group::find(JSC::JSGlobalObject* globalObject, String&
     return nullptr;
 }
 
-void BunPlugin::OnLoad::addModuleMock(JSC::VM& vm, const String& path, JSC::JSObject* mockObject, bool persistent)
+void BunPlugin::OnLoad::addModuleMock(JSC::VM& vm, const String& path, JSC::JSObject* mockObject, bool persistent, bool mockBorn)
 {
     Zig::GlobalObject* globalObject = defaultGlobalObject(mockObject->globalObject());
     auto& onLoad = globalObject->onLoadPlugins;
@@ -452,6 +452,7 @@ void BunPlugin::OnLoad::addModuleMock(JSC::VM& vm, const String& path, JSC::JSOb
             InstalledMockRecord record;
             record.displacedEntry = std::move(displacedEntry);
             record.displacedWasPersistent = displacedWasPersistent;
+            record.wasMockBorn = mockBorn;
             onLoad.transientMockRecords->set(path, std::move(record));
         }
     }
@@ -792,7 +793,9 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
         RETURN_IF_EXCEPTION(scope, {});
     }
 
-    globalObject->onLoadPlugins.addModuleMock(vm, specifier, mock, persistent);
+    // No loaded-and-linked namespace at install time means any module record
+    // this path acquires afterwards was materialized from the mock factory.
+    globalObject->onLoadPlugins.addModuleMock(vm, specifier, mock, persistent, /*mockBorn=*/!mockedNamespace);
 
     // Attach the ESM teardown snapshot (if any) to the freshly-created
     // transient record. `addModuleMock` already set up the record slot;
@@ -801,7 +804,11 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
     if (!persistent && mockedNamespace) {
         auto& onLoad = globalObject->onLoadPlugins;
         if (onLoad.transientMockRecords) {
-            if (auto it = onLoad.transientMockRecords->find(specifier); it != onLoad.transientMockRecords->end()) {
+            // Skip records whose first install was mock-born: the namespace a
+            // later re-mock finds was itself materialized from a mock factory,
+            // so "originals" snapshotted from it are mock values. Leaving the
+            // record snapshot-free keeps teardown on the eviction path.
+            if (auto it = onLoad.transientMockRecords->find(specifier); it != onLoad.transientMockRecords->end() && !it->value.wasMockBorn) {
                 if (!it->value.esmNamespace) {
                     it->value.esmNamespace = JSC::Strong<JSC::JSModuleNamespaceObject> { vm, mockedNamespace };
                 }
@@ -1249,11 +1256,11 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
             }
             // ESM: with a snapshot, step 1 already restored the cached
             // record's environment to the values it held before this
-            // install (the preload mock's values), so keep it. Without a
-            // snapshot, any registry record was materialized from the
-            // transient factory after install — evict it so the next import
+            // install (the preload mock's values), so keep it. Mock-born:
+            // any registry record was materialized from the transient
+            // factory after install — evict it so the next import
             // re-resolves through the restored preload shim.
-            if (!record.esmNamespace) {
+            if (record.wasMockBorn) {
                 auto ident = collectMockBornRecord(path);
                 WTF::Locker locker { moduleLoader->cellLock() };
                 moduleLoader->removeEntry(ident);
@@ -1265,8 +1272,8 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
             // Evict caches only when there's no persistent replacement —
             // otherwise the next import should go straight back to the
             // (restored) preload mock.
-            auto ident = record.esmNamespace ? JSC::Identifier::fromString(vm, path)
-                                             : collectMockBornRecord(path);
+            auto ident = record.wasMockBorn ? collectMockBornRecord(path)
+                                            : JSC::Identifier::fromString(vm, path);
             {
                 // JSModuleLoader::visitChildrenImpl iterates the registry maps
                 // on the GC thread under cellLock(); take the same lock so

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -801,12 +801,27 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
         auto& onLoad = globalObject->onLoadPlugins;
         if (onLoad.transientMockRecords) {
             if (auto it = onLoad.transientMockRecords->find(specifier); it != onLoad.transientMockRecords->end()) {
-                // Keep the first snapshot we took — it reflects the *real*
-                // module's values. Re-mocking the same path during the same
-                // file would snapshot the prior mock's values instead.
-                if (it->value.esmOriginals.isEmpty()) {
+                if (!it->value.esmNamespace) {
                     it->value.esmNamespace = JSC::Strong<JSC::JSModuleNamespaceObject> { vm, mockedNamespace };
-                    it->value.esmOriginals = std::move(esmOriginals);
+                }
+                // Merge per export name, keeping the first snapshot of each:
+                // it reflects the value the name held before any mock in this
+                // file touched it. A later mock of the same path may override
+                // a *different* export set (first `{a}`, then `{b}`) — `b`'s
+                // original comes from the second call's snapshot, while a
+                // re-snapshot of `a` would capture the first mock's value and
+                // must be ignored.
+                for (auto& pair : esmOriginals) {
+                    bool alreadyRecorded = false;
+                    for (const auto& existing : it->value.esmOriginals) {
+                        if (existing.first == pair.first) {
+                            alreadyRecorded = true;
+                            break;
+                        }
+                    }
+                    if (!alreadyRecorded) {
+                        it->value.esmOriginals.append(std::move(pair));
+                    }
                 }
             }
         }
@@ -1103,7 +1118,10 @@ BUN_DEFINE_HOST_FUNCTION(jsFunctionBunPluginClear, (JSC::JSGlobalObject * global
 ///   transient mock shadowed one, or removes the `virtualModules` slot
 ///   entirely if there was nothing to restore,
 /// - evicts the ESM registry entry and CJS require-cache entry for fully
-///   removed mocks, so the next import re-executes the real source.
+///   removed mocks, so the next import re-executes the real source,
+/// - transitively evicts cached modules that imported a module materialized
+///   from a transient mock factory (their bindings chain into environment
+///   slots that never held real values).
 ///
 /// Persistent mocks (paths currently in `persistentMockPaths`) are left
 /// untouched. Called from Rust's per-file teardown in `bun test`.
@@ -1127,6 +1145,23 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
     auto* moduleLoader = global->moduleLoader();
     auto* requireMap = global->requireMap();
     auto* virtualModules = onLoad.virtualModules;
+
+    // Module records that were materialized *from* a transient mock factory
+    // (install saw no registry entry, so there were no original values to
+    // snapshot — the record's environment was born holding mock values).
+    // Evicting only such a record is not enough: cached importers hold live
+    // bindings into its environment slots, so they (and their importers) are
+    // evicted transitively below.
+    WTF::HashSet<JSC::AbstractModuleRecord*> mockBornRecords;
+    auto collectMockBornRecord = [&](const WTF::String& path) {
+        auto ident = JSC::Identifier::fromString(vm, path);
+        if (auto* regEntry = moduleLoader->registryEntry(ident)) {
+            if (auto* rec = regEntry->record()) {
+                mockBornRecords.add(rec);
+            }
+        }
+        return ident;
+    };
 
     for (auto& entry : *records) {
         const auto& path = entry.key;
@@ -1164,13 +1199,26 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
                 }
                 onLoad.persistentMockPaths->add(path);
             }
-            // A restored persistent mock should still shadow the real module
-            // — don't evict the ESM registry entry in that case. The
-            // displaced mock doesn't re-apply its `overrideExportValue`
-            // patches, but since the preload mock's values are what the
-            // ESM registry entry already held before *this* transient
-            // install (we restored them in step 1), the next import hits
-            // the shim and re-evaluates the preload factory cleanly.
+            // Install wrote the transient mock's exports in place into any
+            // cached `JSCommonJSModule` and there is no CJS snapshot to
+            // replay, so always drop the require-cache entry — the next
+            // `require()` misses and re-runs the restored (preload) factory.
+            auto* pathString = JSC::jsString(vm, path);
+            requireMap->remove(global, pathString);
+            if (!scope.clearExceptionExceptTermination()) {
+                break;
+            }
+            // ESM: with a snapshot, step 1 already restored the cached
+            // record's environment to the values it held before this
+            // install (the preload mock's values), so keep it. Without a
+            // snapshot, any registry record was materialized from the
+            // transient factory after install — evict it so the next import
+            // re-resolves through the restored preload shim.
+            if (!record.esmNamespace) {
+                auto ident = collectMockBornRecord(path);
+                WTF::Locker locker { moduleLoader->cellLock() };
+                moduleLoader->removeEntry(ident);
+            }
         } else {
             if (virtualModules) {
                 virtualModules->remove(path);
@@ -1178,7 +1226,8 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
             // Evict caches only when there's no persistent replacement —
             // otherwise the next import should go straight back to the
             // (restored) preload mock.
-            auto ident = JSC::Identifier::fromString(vm, path);
+            auto ident = record.esmNamespace ? JSC::Identifier::fromString(vm, path)
+                                             : collectMockBornRecord(path);
             {
                 // JSModuleLoader::visitChildrenImpl iterates the registry maps
                 // on the GC thread under cellLock(); take the same lock so
@@ -1190,6 +1239,49 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
             requireMap->remove(global, pathString);
             if (!scope.clearExceptionExceptTermination()) {
                 break;
+            }
+        }
+    }
+
+    // Transitively evict cached modules whose dependency graph reaches a
+    // mock-born record. Their import bindings chain into environment slots
+    // that never held real values, so unlike the snapshot/restore path there
+    // is nothing to revert in place — they must re-import. Reads of the
+    // registry don't race the GC marker (it only iterates under its own
+    // lock and never mutates); removals are deferred past each pass because
+    // `removeEntry` invalidates iteration, and they take `cellLock()` like
+    // every other registry mutation.
+    if (!mockBornRecords.isEmpty()) {
+        bool changed = true;
+        while (changed) {
+            changed = false;
+            WTF::Vector<JSC::Identifier> dependentKeys;
+            for (auto& [key, entryBarrier] : moduleLoader->moduleMap()) {
+                if (!key.first) {
+                    continue;
+                }
+                auto* regEntry = entryBarrier.get();
+                if (!regEntry) {
+                    continue;
+                }
+                auto* rec = regEntry->record();
+                if (!rec || mockBornRecords.contains(rec)) {
+                    continue;
+                }
+                for (auto& [requestKey, loaded] : rec->loadedModules()) {
+                    if (loaded.m_module && mockBornRecords.contains(loaded.m_module.get())) {
+                        dependentKeys.append(JSC::Identifier::fromUid(vm, key.first));
+                        mockBornRecords.add(rec);
+                        changed = true;
+                        break;
+                    }
+                }
+            }
+            if (!dependentKeys.isEmpty()) {
+                WTF::Locker locker { moduleLoader->cellLock() };
+                for (auto& ident : dependentKeys) {
+                    moduleLoader->removeEntry(ident);
+                }
             }
         }
     }

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -38,6 +38,7 @@
 namespace Zig {
 
 extern "C" void Bun__onDidAppendPlugin(void* bunVM, JSGlobalObject* globalObject);
+extern "C" bool Bun__VirtualMachine__isInPreload(void* bunVM);
 using OnAppendPluginCallback = void (*)(void*, JSGlobalObject* globalObject);
 
 static bool isValidNamespaceString(String& namespaceString)
@@ -145,12 +146,10 @@ static EncodedJSValue jsFunctionAppendVirtualModulePluginBody(JSC::JSGlobalObjec
 
     Zig::GlobalObject* global = defaultGlobalObject(globalObject);
 
-    if (global->onLoadPlugins.virtualModules == nullptr) {
-        global->onLoadPlugins.virtualModules = new BunPlugin::VirtualModuleMap;
-    }
-    auto* virtualModules = global->onLoadPlugins.virtualModules;
-
-    virtualModules->set(moduleId, JSC::Strong<JSC::JSObject> { vm, uncheckedDowncast<JSC::JSObject>(functionValue) });
+    // `Bun.plugin({ module })` virtual modules persist across per-file
+    // `bun test` teardown — they're process-level plugin registrations,
+    // not test-local mocks.
+    global->onLoadPlugins.addModuleMock(vm, moduleId, uncheckedDowncast<JSC::JSObject>(functionValue), /*persistent=*/ true);
 
     auto* requireMap = global->requireMap();
     RETURN_IF_EXCEPTION(scope, {});
@@ -396,7 +395,7 @@ JSC::JSObject* BunPlugin::Group::find(JSC::JSGlobalObject* globalObject, String&
     return nullptr;
 }
 
-void BunPlugin::OnLoad::addModuleMock(JSC::VM& vm, const String& path, JSC::JSObject* mockObject)
+void BunPlugin::OnLoad::addModuleMock(JSC::VM& vm, const String& path, JSC::JSObject* mockObject, bool persistent)
 {
     Zig::GlobalObject* globalObject = defaultGlobalObject(mockObject->globalObject());
 
@@ -406,6 +405,13 @@ void BunPlugin::OnLoad::addModuleMock(JSC::VM& vm, const String& path, JSC::JSOb
     auto* virtualModules = globalObject->onLoadPlugins.virtualModules;
 
     virtualModules->set(path, JSC::Strong<JSC::JSObject> { vm, mockObject });
+
+    if (persistent) {
+        if (globalObject->onLoadPlugins.persistentMockPaths == nullptr) {
+            globalObject->onLoadPlugins.persistentMockPaths = new BunPlugin::PersistentMockPathSet;
+        }
+        globalObject->onLoadPlugins.persistentMockPaths->add(path);
+    }
 }
 
 class JSModuleMock final : public JSC::JSNonFinalObject {
@@ -711,7 +717,11 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
         RETURN_IF_EXCEPTION(scope, {});
     }
 
-    globalObject->onLoadPlugins.addModuleMock(vm, specifier, mock);
+    // Mocks installed during `--preload` persist across `bun test`'s per-file
+    // teardown; a mock installed while running a test file is scoped to that
+    // file (cleared by `BunPlugin__clearTransientModuleMocks`).
+    bool persistent = Bun__VirtualMachine__isInPreload(globalObject->bunVM());
+    globalObject->onLoadPlugins.addModuleMock(vm, specifier, mock, persistent);
 
     return JSValue::encode(jsUndefined());
 }
@@ -986,8 +996,89 @@ BUN_DEFINE_HOST_FUNCTION(jsFunctionBunPluginClear, (JSC::JSGlobalObject * global
 
     delete global->onLoadPlugins.virtualModules;
     global->onLoadPlugins.virtualModules = nullptr;
+    global->onLoadPlugins.mustDoExpensiveRelativeLookup = false;
+
+    delete global->onLoadPlugins.persistentMockPaths;
+    global->onLoadPlugins.persistentMockPaths = nullptr;
 
     return JSC::JSValue::encode(JSC::jsUndefined());
+}
+
+/// Clears all per-test-file `mock.module(...)` registrations and evicts the
+/// module loader / require cache entries for their paths, so the next test
+/// file sees the real modules. Preload-installed mocks (paths in
+/// `persistentMockPaths`) and `Bun.plugin({ module })` registrations are
+/// preserved. Called from Rust's per-file teardown in `bun test`.
+extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
+{
+    auto& onLoad = global->onLoadPlugins;
+    if (onLoad.virtualModules == nullptr) {
+        return;
+    }
+
+    auto& virtualModules = *onLoad.virtualModules;
+    const auto* persistent = onLoad.persistentMockPaths;
+
+    // Two-pass: collect transient paths first, then mutate the map and evict
+    // module-loader / require-map entries. `WTF::HashMap` iteration can alias
+    // with mutation and the eviction callbacks may run arbitrary JS.
+    WTF::Vector<WTF::String> transientPaths;
+    for (const auto& entry : virtualModules) {
+        if (persistent && persistent->contains(entry.key)) {
+            continue;
+        }
+        // Only clear `JSModuleMock` entries — `Bun.plugin({ module })`
+        // callbacks also live in this map and are always persistent.
+        if (!dynamicDowncast<Zig::JSModuleMock>(entry.value.get())) {
+            continue;
+        }
+        transientPaths.append(entry.key);
+    }
+
+    if (transientPaths.isEmpty()) {
+        return;
+    }
+
+    auto& vm = JSC::getVM(global);
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto* moduleLoader = global->moduleLoader();
+    auto* requireMap = global->requireMap();
+
+    for (const auto& path : transientPaths) {
+        virtualModules.remove(path);
+
+        // Drop the ESM registry entry so the next import re-executes the
+        // real source. `mock.module`'s install path mutates
+        // `JSModuleNamespaceObject::overrideExportValue`; without this
+        // eviction a sibling file that already imported the module would
+        // still see the mocked namespace after we removed the virtual-module
+        // shim.
+        auto ident = JSC::Identifier::fromString(vm, path);
+        moduleLoader->removeEntry(ident);
+
+        // CJS path — `globalObject->requireMap()` keys by specifier string.
+        auto* pathString = JSC::jsString(vm, path);
+        requireMap->remove(global, pathString);
+
+        // Swallow any non-termination exception; this runs during
+        // test-runner teardown where the reporter has already consumed
+        // results and has no scope to surface an exception through.
+        if (!scope.clearExceptionExceptTermination()) {
+            break;
+        }
+    }
+
+    // `mustDoExpensiveRelativeLookup` is set when a `file:` URL or
+    // unresolvable relative specifier is mocked (see lines ~555, ~583). If
+    // no virtual modules remain, drop the flag — `moduleLoaderResolve`
+    // asserts `!mustDoExpensiveRelativeLookup` when `hasVirtualModules()`
+    // is false (ZigGlobalObject.cpp:3393). If persistent entries still
+    // exist, leave it alone: we don't know which ones need the flag.
+    if (virtualModules.isEmpty()) {
+        delete onLoad.virtualModules;
+        onLoad.virtualModules = nullptr;
+        onLoad.mustDoExpensiveRelativeLookup = false;
+    }
 }
 
 BUN_DEFINE_HOST_FUNCTION(jsFunctionBunPlugin, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -12,6 +12,7 @@
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/JSMap.h>
 #include <JavaScriptCore/JSMapInlines.h>
+#include <JavaScriptCore/JSMapIterator.h>
 #include <JavaScriptCore/JSModuleLoader.h>
 #include <JavaScriptCore/ModuleRegistryEntry.h>
 #include <JavaScriptCore/CyclicModuleRecord.h>
@@ -1163,6 +1164,37 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
         return ident;
     };
 
+    // CJS modules whose cached exports came from a transient mock: the
+    // require-map values of every evicted transient path, plus (transitively)
+    // any cached module whose `m_children` reaches one. A CJS consumer copies
+    // values out of the mocked module at require time, so unlike ESM there is
+    // no binding to restore — the consumer itself must re-run.
+    WTF::HashSet<JSC::JSCell*> poisonedCJSModules;
+    // Require-map keys (filenames) queued for eviction by the CJS walk.
+    WTF::Vector<JSC::JSValue> cjsKeysToEvict;
+    // Poison a cached CJS module and walk its `m_parent` chain: the *first*
+    // requirer of an ESM(-mocked) module gets no `m_children` edge (the
+    // namespace early-return in `overridableRequire` skips the recording
+    // call), but module creation recorded the requirer as the parent.
+    auto poisonModuleAndParents = [&](Bun::JSCommonJSModule* mod) {
+        while (mod && !poisonedCJSModules.contains(mod)) {
+            poisonedCJSModules.add(mod);
+            if (JSC::JSValue filename = mod->filename(); filename && filename.isString()) {
+                cjsKeysToEvict.append(filename);
+            }
+            mod = mod->m_parent.get();
+        }
+    };
+    auto poisonRequireMapEntry = [&](JSC::JSString* pathString) {
+        JSC::JSValue cached = requireMap->get(global, pathString);
+        if (scope.clearExceptionExceptTermination() && cached && cached.isCell()) {
+            poisonedCJSModules.add(cached.asCell());
+            if (auto* mod = dynamicDowncast<Bun::JSCommonJSModule>(cached)) {
+                poisonModuleAndParents(mod->m_parent.get());
+            }
+        }
+    };
+
     for (auto& entry : *records) {
         const auto& path = entry.key;
         auto& record = entry.value;
@@ -1204,6 +1236,7 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
             // replay, so always drop the require-cache entry — the next
             // `require()` misses and re-runs the restored (preload) factory.
             auto* pathString = JSC::jsString(vm, path);
+            poisonRequireMapEntry(pathString);
             requireMap->remove(global, pathString);
             if (!scope.clearExceptionExceptTermination()) {
                 break;
@@ -1236,6 +1269,7 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
                 moduleLoader->removeEntry(ident);
             }
             auto* pathString = JSC::jsString(vm, path);
+            poisonRequireMapEntry(pathString);
             requireMap->remove(global, pathString);
             if (!scope.clearExceptionExceptTermination()) {
                 break;
@@ -1278,10 +1312,78 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
                 }
             }
             if (!dependentKeys.isEmpty()) {
+                // A dependent that was also `require()`d has a require-map
+                // entry wrapping the same (now-evicted) module; drop and
+                // poison it so the CJS walk below catches its own consumers.
+                for (auto& ident : dependentKeys) {
+                    auto* keyString = JSC::jsString(vm, ident.string());
+                    poisonRequireMapEntry(keyString);
+                    requireMap->remove(global, keyString);
+                    if (!scope.clearExceptionExceptTermination()) {
+                        break;
+                    }
+                }
                 WTF::Locker locker { moduleLoader->cellLock() };
                 for (auto& ident : dependentKeys) {
                     moduleLoader->removeEntry(ident);
                 }
+            }
+        }
+    }
+
+    // Transitively evict CJS consumers of poisoned modules. Two edge kinds
+    // link a consumer to what it required: `m_children` (recorded for
+    // second-and-later requirers and for plain-CJS first requires) and the
+    // dep's `m_parent` back-edge (first requirer — the only edge when the
+    // require resolved to an ESM/mocked namespace). A consumer copies values
+    // out at require time, so there is nothing to restore in place — it must
+    // re-run. Pure-CJS consumers never appear in the ESM registry, hence the
+    // separate walk over the require map. Keys are collected per pass and
+    // removed afterwards to keep iteration and mutation separate.
+    if (!poisonedCJSModules.isEmpty()) {
+        bool changed = true;
+        while (changed || !cjsKeysToEvict.isEmpty()) {
+            changed = false;
+            auto* iter = JSC::JSMapIterator::create(vm, global->mapIteratorStructure(), requireMap, JSC::IterationKind::Entries);
+            if (!scope.clearExceptionExceptTermination() || !iter) {
+                break;
+            }
+            JSC::JSValue key;
+            JSC::JSValue value;
+            while (iter->nextKeyValue(global, key, value)) {
+                auto* mod = dynamicDowncast<Bun::JSCommonJSModule>(value);
+                if (!mod || poisonedCJSModules.contains(mod)) {
+                    continue;
+                }
+                for (const auto& childBarrier : mod->m_children) {
+                    JSC::JSValue child = childBarrier.get();
+                    if (child && child.isCell() && poisonedCJSModules.contains(child.asCell())) {
+                        cjsKeysToEvict.append(key);
+                        poisonedCJSModules.add(mod);
+                        poisonModuleAndParents(mod->m_parent.get());
+                        changed = true;
+                        break;
+                    }
+                }
+            }
+            if (!scope.clearExceptionExceptTermination()) {
+                break;
+            }
+            auto keys = std::exchange(cjsKeysToEvict, {});
+            for (auto& depKey : keys) {
+                requireMap->remove(global, depKey);
+                if (!scope.clearExceptionExceptTermination()) {
+                    break;
+                }
+                // Drop any same-path ESM wrapper record so `import` of this
+                // consumer re-evaluates as well.
+                auto keyStr = depKey.toWTFString(global);
+                if (!scope.clearExceptionExceptTermination()) {
+                    break;
+                }
+                auto ident = JSC::Identifier::fromString(vm, keyStr);
+                WTF::Locker locker { moduleLoader->cellLock() };
+                moduleLoader->removeEntry(ident);
             }
         }
     }

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -1179,7 +1179,13 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
             // otherwise the next import should go straight back to the
             // (restored) preload mock.
             auto ident = JSC::Identifier::fromString(vm, path);
-            moduleLoader->removeEntry(ident);
+            {
+                // JSModuleLoader::visitChildrenImpl iterates the registry maps
+                // on the GC thread under cellLock(); take the same lock so
+                // the removal can't race it.
+                WTF::Locker locker { moduleLoader->cellLock() };
+                moduleLoader->removeEntry(ident);
+            }
             auto* pathString = JSC::jsString(vm, path);
             requireMap->remove(global, pathString);
             if (!scope.clearExceptionExceptTermination()) {

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -1171,7 +1171,13 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
     // no binding to restore — the consumer itself must re-run.
     WTF::HashSet<JSC::JSCell*> poisonedCJSModules;
     // Require-map keys (filenames) queued for eviction by the CJS walk.
-    WTF::Vector<JSC::JSValue> cjsKeysToEvict;
+    // MarkedArgumentBuffer, not a plain Vector: these JSValues are held
+    // across allocating calls (jsString, JSMapIterator::create, map
+    // mutations), and heap-backed storage is invisible to the conservative
+    // scanner — an eviction below can sever a queued string's last other
+    // root before its turn comes.
+    JSC::MarkedArgumentBuffer cjsKeysToEvict;
+    size_t cjsKeysDrained = 0;
     // Poison a cached CJS module and walk its `m_parent` chain: the *first*
     // requirer of an ESM(-mocked) module gets no `m_children` edge (the
     // namespace early-return in `overridableRequire` skips the recording
@@ -1340,9 +1346,9 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
     // re-run. Pure-CJS consumers never appear in the ESM registry, hence the
     // separate walk over the require map. Keys are collected per pass and
     // removed afterwards to keep iteration and mutation separate.
-    if (!poisonedCJSModules.isEmpty()) {
+    if (!poisonedCJSModules.isEmpty() && !cjsKeysToEvict.hasOverflowed()) {
         bool changed = true;
-        while (changed || !cjsKeysToEvict.isEmpty()) {
+        while (changed || cjsKeysDrained < cjsKeysToEvict.size()) {
             changed = false;
             auto* iter = JSC::JSMapIterator::create(vm, global->mapIteratorStructure(), requireMap, JSC::IterationKind::Entries);
             if (!scope.clearExceptionExceptTermination() || !iter) {
@@ -1366,11 +1372,12 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
                     }
                 }
             }
-            if (!scope.clearExceptionExceptTermination()) {
+            if (!scope.clearExceptionExceptTermination() || cjsKeysToEvict.hasOverflowed()) {
                 break;
             }
-            auto keys = std::exchange(cjsKeysToEvict, {});
-            for (auto& depKey : keys) {
+            size_t drainEnd = cjsKeysToEvict.size();
+            for (size_t i = cjsKeysDrained; i < drainEnd; ++i) {
+                JSC::JSValue depKey = cjsKeysToEvict.at(i);
                 requireMap->remove(global, depKey);
                 if (!scope.clearExceptionExceptTermination()) {
                     break;
@@ -1385,6 +1392,7 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
                 WTF::Locker locker { moduleLoader->cellLock() };
                 moduleLoader->removeEntry(ident);
             }
+            cjsKeysDrained = drainEnd;
         }
     }
 

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -398,19 +398,61 @@ JSC::JSObject* BunPlugin::Group::find(JSC::JSGlobalObject* globalObject, String&
 void BunPlugin::OnLoad::addModuleMock(JSC::VM& vm, const String& path, JSC::JSObject* mockObject, bool persistent)
 {
     Zig::GlobalObject* globalObject = defaultGlobalObject(mockObject->globalObject());
+    auto& onLoad = globalObject->onLoadPlugins;
 
-    if (globalObject->onLoadPlugins.virtualModules == nullptr) {
-        globalObject->onLoadPlugins.virtualModules = new BunPlugin::VirtualModuleMap;
+    if (onLoad.virtualModules == nullptr) {
+        onLoad.virtualModules = new BunPlugin::VirtualModuleMap;
     }
-    auto* virtualModules = globalObject->onLoadPlugins.virtualModules;
+    auto* virtualModules = onLoad.virtualModules;
+
+    // Capture the displaced entry *before* overwriting so transient teardown
+    // can restore the preload / `Bun.plugin` mock this call is shadowing.
+    JSC::Strong<JSC::JSObject> displacedEntry;
+    bool displacedWasPersistent = false;
+    if (auto existing = virtualModules->get(path)) {
+        displacedEntry = JSC::Strong<JSC::JSObject> { vm, existing.get() };
+        displacedWasPersistent = onLoad.persistentMockPaths && onLoad.persistentMockPaths->contains(path);
+    }
 
     virtualModules->set(path, JSC::Strong<JSC::JSObject> { vm, mockObject });
 
     if (persistent) {
-        if (globalObject->onLoadPlugins.persistentMockPaths == nullptr) {
-            globalObject->onLoadPlugins.persistentMockPaths = new BunPlugin::PersistentMockPathSet;
+        if (onLoad.persistentMockPaths == nullptr) {
+            onLoad.persistentMockPaths = new BunPlugin::PersistentMockPathSet;
         }
-        globalObject->onLoadPlugins.persistentMockPaths->add(path);
+        onLoad.persistentMockPaths->add(path);
+        // A persistent install clears any stale transient record for this
+        // path — the persistent entry now owns the slot and teardown must
+        // not evict it.
+        if (onLoad.transientMockRecords) {
+            onLoad.transientMockRecords->remove(path);
+        }
+    } else {
+        // Transient install: track what we displaced so teardown can put it
+        // back. Demote the path from `persistentMockPaths` — the current
+        // value in `virtualModules` is the transient mock and is not itself
+        // persistent. `displacedWasPersistent` remembers that the prior
+        // owner was persistent so teardown can re-promote the path when it
+        // restores the displaced entry.
+        if (onLoad.persistentMockPaths) {
+            onLoad.persistentMockPaths->remove(path);
+        }
+        if (onLoad.transientMockRecords == nullptr) {
+            onLoad.transientMockRecords = new BunPlugin::InstalledMocksMap;
+        }
+        // If this is the *first* transient install for this path in the
+        // current test file, record displacement state. If this overwrites
+        // a previous transient install (test file mocks the same path
+        // twice), keep the original displacement + the original ESM
+        // snapshot we already took — re-snapshotting would capture the
+        // previous mock's values, not the real module's.
+        auto it = onLoad.transientMockRecords->find(path);
+        if (it == onLoad.transientMockRecords->end()) {
+            InstalledMockRecord record;
+            record.displacedEntry = std::move(displacedEntry);
+            record.displacedWasPersistent = displacedWasPersistent;
+            onLoad.transientMockRecords->set(path, std::move(record));
+        }
     }
 }
 
@@ -637,6 +679,19 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
     bool removeFromESM = false;
     bool removeFromCJS = false;
 
+    // Mocks installed while `--preload` is executing persist across `bun test`
+    // per-file teardown; mocks installed by a test file are transient. We need
+    // the flag here (not only inside `addModuleMock`) so we know whether to
+    // capture the original ESM namespace values for teardown-time restore.
+    const bool persistent = Bun__VirtualMachine__isInPreload(globalObject->bunVM());
+
+    // Snapshot of the module-environment values the mock is about to overwrite.
+    // Populated only for transient mocks against already-loaded ESM modules;
+    // replayed by `BunPlugin__clearTransientModuleMocks` so re-exporters that
+    // bind through this module's environment slots revert to the real values.
+    JSC::JSModuleNamespaceObject* mockedNamespace = nullptr;
+    WTF::Vector<std::pair<JSC::Identifier, JSC::Strong<JSC::Unknown>>> esmOriginals;
+
     auto specifierIdent = JSC::Identifier::fromString(vm, specifierString->value(globalObject));
     RETURN_IF_EXCEPTION(scope, {});
     if (auto* entry = globalObject->moduleLoader()->registryEntry(specifierIdent)) {
@@ -659,6 +714,23 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
                         RETURN_IF_EXCEPTION(scope, {});
                         auto* object = exportsValue.getObject();
                         removeFromESM = false;
+                        if (!persistent) {
+                            mockedNamespace = moduleNamespaceObject;
+                        }
+
+                        auto snapshotAndOverride = [&](JSC::Identifier name, JSValue value) -> bool {
+                            if (!persistent) {
+                                auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+                                JSValue original = moduleNamespaceObject->get(globalObject, name);
+                                if (scope.exception()) [[unlikely]] {
+                                    (void)scope.tryClearException();
+                                    original = jsUndefined();
+                                }
+                                esmOriginals.append({ name, JSC::Strong<JSC::Unknown> { vm, original } });
+                            }
+                            moduleNamespaceObject->overrideExportValue(globalObject, name, value);
+                            return !scope.exception();
+                        };
 
                         if (object) {
                             JSC::PropertyNameArrayBuilder names(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
@@ -673,14 +745,16 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
                                     (void)scope.tryClearException();
                                     value = jsUndefined();
                                 }
-                                moduleNamespaceObject->overrideExportValue(globalObject, name, value);
-                                RETURN_IF_EXCEPTION(scope, {});
+                                if (!snapshotAndOverride(name, value)) {
+                                    RETURN_IF_EXCEPTION(scope, {});
+                                }
                             }
 
                         } else {
                             // if it's not an object, I guess we just set the default export?
-                            moduleNamespaceObject->overrideExportValue(globalObject, vm.propertyNames->defaultKeyword, exportsValue);
-                            RETURN_IF_EXCEPTION(scope, {});
+                            if (!snapshotAndOverride(vm.propertyNames->defaultKeyword, exportsValue)) {
+                                RETURN_IF_EXCEPTION(scope, {});
+                            }
                         }
 
                         // TODO: do we need to handle intermediate loading state here?
@@ -717,11 +791,26 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
         RETURN_IF_EXCEPTION(scope, {});
     }
 
-    // Mocks installed during `--preload` persist across `bun test`'s per-file
-    // teardown; a mock installed while running a test file is scoped to that
-    // file (cleared by `BunPlugin__clearTransientModuleMocks`).
-    bool persistent = Bun__VirtualMachine__isInPreload(globalObject->bunVM());
     globalObject->onLoadPlugins.addModuleMock(vm, specifier, mock, persistent);
+
+    // Attach the ESM teardown snapshot (if any) to the freshly-created
+    // transient record. `addModuleMock` already set up the record slot;
+    // filling in the namespace + originals here keeps the data-collection
+    // logic local to the overrideExportValue loop above.
+    if (!persistent && mockedNamespace) {
+        auto& onLoad = globalObject->onLoadPlugins;
+        if (onLoad.transientMockRecords) {
+            if (auto it = onLoad.transientMockRecords->find(specifier); it != onLoad.transientMockRecords->end()) {
+                // Keep the first snapshot we took — it reflects the *real*
+                // module's values. Re-mocking the same path during the same
+                // file would snapshot the prior mock's values instead.
+                if (it->value.esmOriginals.isEmpty()) {
+                    it->value.esmNamespace = JSC::Strong<JSC::JSModuleNamespaceObject> { vm, mockedNamespace };
+                    it->value.esmOriginals = std::move(esmOriginals);
+                }
+            }
+        }
+    }
 
     return JSValue::encode(jsUndefined());
 }
@@ -1001,70 +1090,101 @@ BUN_DEFINE_HOST_FUNCTION(jsFunctionBunPluginClear, (JSC::JSGlobalObject * global
     delete global->onLoadPlugins.persistentMockPaths;
     global->onLoadPlugins.persistentMockPaths = nullptr;
 
+    delete global->onLoadPlugins.transientMockRecords;
+    global->onLoadPlugins.transientMockRecords = nullptr;
+
     return JSC::JSValue::encode(JSC::jsUndefined());
 }
 
-/// Clears all per-test-file `mock.module(...)` registrations and evicts the
-/// module loader / require cache entries for their paths, so the next test
-/// file sees the real modules. Preload-installed mocks (paths in
-/// `persistentMockPaths`) and `Bun.plugin({ module })` registrations are
-/// preserved. Called from Rust's per-file teardown in `bun test`.
+/// Clears per-test-file `mock.module(...)` registrations:
+/// - restores the ESM module-environment values the mock overrode (so cached
+///   re-exporters that bind through the same slot see the real value again),
+/// - restores the displaced preload / `Bun.plugin({ module })` entry if the
+///   transient mock shadowed one, or removes the `virtualModules` slot
+///   entirely if there was nothing to restore,
+/// - evicts the ESM registry entry and CJS require-cache entry for fully
+///   removed mocks, so the next import re-executes the real source.
+///
+/// Persistent mocks (paths currently in `persistentMockPaths`) are left
+/// untouched. Called from Rust's per-file teardown in `bun test`.
 extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
 {
     auto& onLoad = global->onLoadPlugins;
-    if (onLoad.virtualModules == nullptr) {
+    auto* transientRecords = onLoad.transientMockRecords;
+    if (transientRecords == nullptr || transientRecords->isEmpty()) {
         return;
     }
 
-    auto& virtualModules = *onLoad.virtualModules;
-    const auto* persistent = onLoad.persistentMockPaths;
-
-    // Two-pass: collect transient paths first, then mutate the map and evict
-    // module-loader / require-map entries. `WTF::HashMap` iteration can alias
-    // with mutation and the eviction callbacks may run arbitrary JS.
-    WTF::Vector<WTF::String> transientPaths;
-    for (const auto& entry : virtualModules) {
-        if (persistent && persistent->contains(entry.key)) {
-            continue;
-        }
-        // Only clear `JSModuleMock` entries — `Bun.plugin({ module })`
-        // callbacks also live in this map and are always persistent.
-        if (!dynamicDowncast<Zig::JSModuleMock>(entry.value.get())) {
-            continue;
-        }
-        transientPaths.append(entry.key);
-    }
-
-    if (transientPaths.isEmpty()) {
-        return;
-    }
+    // Take ownership of the map so iteration doesn't alias with re-entry
+    // from any JS the restore path might invoke (overrideExportValue,
+    // requireMap::remove). A fresh empty map covers the tail case of a JS
+    // callback that itself calls mock.module() during teardown.
+    std::unique_ptr<Zig::BunPlugin::InstalledMocksMap> records { transientRecords };
+    onLoad.transientMockRecords = nullptr;
 
     auto& vm = JSC::getVM(global);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto* moduleLoader = global->moduleLoader();
     auto* requireMap = global->requireMap();
+    auto* virtualModules = onLoad.virtualModules;
 
-    for (const auto& path : transientPaths) {
-        virtualModules.remove(path);
+    for (auto& entry : *records) {
+        const auto& path = entry.key;
+        auto& record = entry.value;
 
-        // Drop the ESM registry entry so the next import re-executes the
-        // real source. `mock.module`'s install path mutates
-        // `JSModuleNamespaceObject::overrideExportValue`; without this
-        // eviction a sibling file that already imported the module would
-        // still see the mocked namespace after we removed the virtual-module
-        // shim.
-        auto ident = JSC::Identifier::fromString(vm, path);
-        moduleLoader->removeEntry(ident);
+        // Skip paths that were re-installed as persistent after this
+        // transient record was created. `addModuleMock(persistent=true)`
+        // already cleared the path from `transientMockRecords`, but guard
+        // again — the map could have been mutated by a re-entry.
+        if (onLoad.persistentMockPaths && onLoad.persistentMockPaths->contains(path)
+            && !record.displacedWasPersistent) {
+            continue;
+        }
 
-        // CJS path — `globalObject->requireMap()` keys by specifier string.
-        auto* pathString = JSC::jsString(vm, path);
-        requireMap->remove(global, pathString);
-
-        // Swallow any non-termination exception; this runs during
-        // test-runner teardown where the reporter has already consumed
-        // results and has no scope to surface an exception through.
+        // 1. Revert the module-environment slots we wrote into at install.
+        //    Covers transitive re-exporters that bind through the same slot.
+        if (auto* ns = record.esmNamespace.get()) {
+            for (auto& [name, strong] : record.esmOriginals) {
+                ns->overrideExportValue(global, name, strong.get());
+                if (!scope.clearExceptionExceptTermination()) {
+                    break;
+                }
+            }
+        }
         if (!scope.clearExceptionExceptTermination()) {
             break;
+        }
+
+        // 2. Restore or remove the `virtualModules` slot.
+        if (record.displacedEntry && virtualModules) {
+            virtualModules->set(path, std::move(record.displacedEntry));
+            if (record.displacedWasPersistent) {
+                if (onLoad.persistentMockPaths == nullptr) {
+                    onLoad.persistentMockPaths = new Zig::BunPlugin::PersistentMockPathSet;
+                }
+                onLoad.persistentMockPaths->add(path);
+            }
+            // A restored persistent mock should still shadow the real module
+            // — don't evict the ESM registry entry in that case. The
+            // displaced mock doesn't re-apply its `overrideExportValue`
+            // patches, but since the preload mock's values are what the
+            // ESM registry entry already held before *this* transient
+            // install (we restored them in step 1), the next import hits
+            // the shim and re-evaluates the preload factory cleanly.
+        } else {
+            if (virtualModules) {
+                virtualModules->remove(path);
+            }
+            // Evict caches only when there's no persistent replacement —
+            // otherwise the next import should go straight back to the
+            // (restored) preload mock.
+            auto ident = JSC::Identifier::fromString(vm, path);
+            moduleLoader->removeEntry(ident);
+            auto* pathString = JSC::jsString(vm, path);
+            requireMap->remove(global, pathString);
+            if (!scope.clearExceptionExceptTermination()) {
+                break;
+            }
         }
     }
 
@@ -1074,7 +1194,7 @@ extern "C" void BunPlugin__clearTransientModuleMocks(Zig::GlobalObject* global)
     // asserts `!mustDoExpensiveRelativeLookup` when `hasVirtualModules()`
     // is false (ZigGlobalObject.cpp:3393). If persistent entries still
     // exist, leave it alone: we don't know which ones need the flag.
-    if (virtualModules.isEmpty()) {
+    if (virtualModules && virtualModules->isEmpty()) {
         delete onLoad.virtualModules;
         onLoad.virtualModules = nullptr;
         onLoad.mustDoExpensiveRelativeLookup = false;

--- a/src/jsc/bindings/BunPlugin.h
+++ b/src/jsc/bindings/BunPlugin.h
@@ -2,9 +2,12 @@
 
 #include "root.h"
 #include "headers-handwritten.h"
+#include <JavaScriptCore/Identifier.h>
 #include <JavaScriptCore/JSGlobalObject.h>
+#include <JavaScriptCore/JSModuleNamespaceObject.h>
 #include <JavaScriptCore/Strong.h>
 #include <wtf/HashSet.h>
+#include <wtf/Vector.h>
 #include "helpers.h"
 
 BUN_DECLARE_HOST_FUNCTION(jsFunctionBunPlugin);
@@ -18,6 +21,30 @@ class BunPlugin {
 public:
     using VirtualModuleMap = WTF::UncheckedKeyHashMap<String, JSC::Strong<JSC::JSObject>>;
     using PersistentMockPathSet = WTF::HashSet<String>;
+
+    /// Per-module state captured when `mock.module(path, ...)` installs a
+    /// transient mock over an already-loaded module. Lets per-file teardown
+    /// restore both the virtual-module registry slot and the module
+    /// environment's export bindings so sibling files see the original module
+    /// — even when cached intermediate re-exporters hold live bindings into
+    /// the mocked module's environment slots.
+    struct InstalledMockRecord {
+        /// Entry in `virtualModules[path]` at install time. `nullptr` if the
+        /// path was not previously mocked; otherwise the mock installed by
+        /// `--preload` or `Bun.plugin({ module })` that this transient mock
+        /// displaced.
+        JSC::Strong<JSC::JSObject> displacedEntry;
+        /// Whether the displaced entry lived in `persistentMockPaths`. Drives
+        /// whether teardown re-adds the path to that set.
+        bool displacedWasPersistent { false };
+        /// ESM namespace of the already-loaded module and the original value
+        /// of each exported name the mock overrode. Replayed via
+        /// `overrideExportValue` at teardown so re-exporters that bind
+        /// through the same module environment slot revert to the real value.
+        JSC::Strong<JSC::JSModuleNamespaceObject> esmNamespace;
+        WTF::Vector<std::pair<JSC::Identifier, JSC::Strong<JSC::Unknown>>> esmOriginals;
+    };
+    using InstalledMocksMap = WTF::UncheckedKeyHashMap<String, InstalledMockRecord>;
 
     // This is a list of pairs of regexps and functions to match against
     class Group {
@@ -77,6 +104,10 @@ public:
         /// `bun test`; transient entries added by a test file's top-level code
         /// or during a running test are cleared between files.
         PersistentMockPathSet* _Nullable persistentMockPaths = nullptr;
+        /// Teardown state for transient mocks: each entry records what the
+        /// mock displaced and what environment values it overrode so
+        /// `BunPlugin__clearTransientModuleMocks` can restore them.
+        InstalledMocksMap* _Nullable transientMockRecords = nullptr;
         bool mustDoExpensiveRelativeLookup = false;
         JSC::EncodedJSValue run(JSC::JSGlobalObject* globalObject, BunString* namespaceString, BunString* path);
 
@@ -93,6 +124,9 @@ public:
             }
             if (persistentMockPaths) {
                 delete persistentMockPaths;
+            }
+            if (transientMockRecords) {
+                delete transientMockRecords;
             }
         }
     };

--- a/src/jsc/bindings/BunPlugin.h
+++ b/src/jsc/bindings/BunPlugin.h
@@ -4,6 +4,7 @@
 #include "headers-handwritten.h"
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/Strong.h>
+#include <wtf/HashSet.h>
 #include "helpers.h"
 
 BUN_DECLARE_HOST_FUNCTION(jsFunctionBunPlugin);
@@ -16,6 +17,7 @@ using namespace JSC;
 class BunPlugin {
 public:
     using VirtualModuleMap = WTF::UncheckedKeyHashMap<String, JSC::Strong<JSC::JSObject>>;
+    using PersistentMockPathSet = WTF::HashSet<String>;
 
     // This is a list of pairs of regexps and functions to match against
     class Group {
@@ -70,12 +72,17 @@ public:
         }
 
         VirtualModuleMap* _Nullable virtualModules = nullptr;
+        /// Paths of `mock.module()` entries installed during `--preload` or
+        /// `Bun.plugin({ module })`. These survive per-test-file teardown in
+        /// `bun test`; transient entries added by a test file's top-level code
+        /// or during a running test are cleared between files.
+        PersistentMockPathSet* _Nullable persistentMockPaths = nullptr;
         bool mustDoExpensiveRelativeLookup = false;
         JSC::EncodedJSValue run(JSC::JSGlobalObject* globalObject, BunString* namespaceString, BunString* path);
 
         bool hasVirtualModules() const { return virtualModules != nullptr; }
 
-        void addModuleMock(JSC::VM& vm, const String& path, JSC::JSObject* mock);
+        void addModuleMock(JSC::VM& vm, const String& path, JSC::JSObject* mock, bool persistent);
 
         std::optional<String> resolveVirtualModule(const String& path, const String& from);
 
@@ -83,6 +90,9 @@ public:
         {
             if (virtualModules) {
                 delete virtualModules;
+            }
+            if (persistentMockPaths) {
+                delete persistentMockPaths;
             }
         }
     };

--- a/src/jsc/bindings/BunPlugin.h
+++ b/src/jsc/bindings/BunPlugin.h
@@ -49,6 +49,11 @@ public:
         /// originals to restore and must be evicted transitively — even if a
         /// later re-mock found a loaded (mock-born) namespace to snapshot.
         bool wasMockBorn { false };
+        /// True when the path already had a require-cache entry at the first
+        /// transient install (install replaced its exports object in place).
+        /// That entry's `m_parent` chain required the module *before* the
+        /// mock and captured real values, so teardown must not evict it.
+        bool cjsEntryPreExisted { false };
     };
     using InstalledMocksMap = WTF::UncheckedKeyHashMap<String, InstalledMockRecord>;
 
@@ -119,7 +124,7 @@ public:
 
         bool hasVirtualModules() const { return virtualModules != nullptr; }
 
-        void addModuleMock(JSC::VM& vm, const String& path, JSC::JSObject* mock, bool persistent, bool mockBorn);
+        void addModuleMock(JSC::VM& vm, const String& path, JSC::JSObject* mock, bool persistent, bool mockBorn, bool cjsEntryPreExisted);
 
         std::optional<String> resolveVirtualModule(const String& path, const String& from);
 

--- a/src/jsc/bindings/BunPlugin.h
+++ b/src/jsc/bindings/BunPlugin.h
@@ -43,6 +43,12 @@ public:
         /// through the same module environment slot revert to the real value.
         JSC::Strong<JSC::JSModuleNamespaceObject> esmNamespace;
         WTF::Vector<std::pair<JSC::Identifier, JSC::Strong<JSC::Unknown>>> esmOriginals;
+        /// True when the first transient mock for this path installed before
+        /// the module was ever loaded, so any module record for the path was
+        /// materialized from a mock factory. Such records have no real
+        /// originals to restore and must be evicted transitively — even if a
+        /// later re-mock found a loaded (mock-born) namespace to snapshot.
+        bool wasMockBorn { false };
     };
     using InstalledMocksMap = WTF::UncheckedKeyHashMap<String, InstalledMockRecord>;
 
@@ -113,7 +119,7 @@ public:
 
         bool hasVirtualModules() const { return virtualModules != nullptr; }
 
-        void addModuleMock(JSC::VM& vm, const String& path, JSC::JSObject* mock, bool persistent);
+        void addModuleMock(JSC::VM& vm, const String& path, JSC::JSObject* mock, bool persistent, bool mockBorn);
 
         std::optional<String> resolveVirtualModule(const String& path, const String& from);
 

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -31,6 +31,11 @@ pub fn script_execution_status(this: &VirtualMachine) -> i32 {
     this.script_execution_status() as i32
 }
 
+// HOST_EXPORT(Bun__VirtualMachine__isInPreload, c)
+pub fn is_in_preload(this: &VirtualMachine) -> bool {
+    this.is_in_preload
+}
+
 // HOST_EXPORT(Bun__getVM, c)
 pub fn get_vm() -> *mut VirtualMachine {
     VirtualMachine::get_mut_ptr()

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -33,7 +33,10 @@ pub fn script_execution_status(this: &VirtualMachine) -> i32 {
 
 // HOST_EXPORT(Bun__VirtualMachine__isInPreload, c)
 pub fn is_in_preload(this: &VirtualMachine) -> bool {
-    this.is_in_preload
+    // Hooks registered during `--preload` (e.g. a preload `beforeAll`) run
+    // later, during a test file's execution phase, but mocks they install
+    // must be process-lifetime like preload top-level code.
+    this.is_in_preload || this.is_in_preload_hook
 }
 
 // HOST_EXPORT(Bun__getVM, c)

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -520,7 +520,7 @@ impl Execution {
         if let Some(entry_ptr) = sequence.active_entry {
             // SAFETY: arena-owned entry, alive for lifetime of BunTest
             let entry = unsafe { entry_ptr.as_ref() };
-            Execution::on_entry_completed(entry_ptr);
+            Execution::on_entry_completed(entry_ptr, sequence.test_entry.is_none());
 
             sequence.executing = false;
             if sequence.maybe_skip {
@@ -625,7 +625,7 @@ impl Execution {
         }
     }
 
-    fn on_entry_started(entry: &mut ExecutionEntry) {
+    fn on_entry_started(entry: &mut ExecutionEntry, in_hooks_only_sequence: bool) {
         if entry.callback.is_none() {
             return;
         }
@@ -639,23 +639,27 @@ impl Execution {
             entry.timespec = Timespec::EPOCH;
         }
 
-        // A hook registered during `--preload` (e.g. a preload script's
-        // `beforeAll`) executes here, after `loadPreloads()` cleared
-        // `vm.is_in_preload`. Flag its whole execution window — including
-        // async continuations, since the entry stays active until its promise
-        // settles — so `mock.module()` inside it installs process-lifetime
-        // mocks like preload top-level code. Only hooks can carry
-        // `AddedInPhase::Preload` (`test()` is rejected during preload), and
-        // jest ordering runs tests only after `beforeAll` hooks settle, so no
-        // test callback can observe the flag.
-        if entry.added_in_phase == AddedInPhase::Preload {
+        // A `beforeAll`/`afterAll` registered during `--preload` executes
+        // here, after `loadPreloads()` cleared `vm.is_in_preload`. Flag its
+        // whole execution window — including async continuations, since the
+        // entry stays active until its promise settles — so `mock.module()`
+        // inside it installs process-lifetime mocks like preload top-level
+        // code. Restricted to hooks-only sequences (`test_entry == None`):
+        // those run in their own group that settles before any test group
+        // starts, so no concurrently-scheduled test body can observe the
+        // VM-global flag. Preload `beforeEach`/`afterEach` clones live
+        // inside test sequences and *do* interleave with sibling tests under
+        // `test.concurrent`; they stay transient — they re-run before every
+        // test in every file, so reinstalling per file is the correct
+        // per-file behavior anyway.
+        if entry.added_in_phase == AddedInPhase::Preload && in_hooks_only_sequence {
             VirtualMachine::get().as_mut().is_in_preload_hook = true;
         }
     }
 
-    fn on_entry_completed(entry: NonNull<ExecutionEntry>) {
+    fn on_entry_completed(entry: NonNull<ExecutionEntry>, in_hooks_only_sequence: bool) {
         // SAFETY: arena-owned entry, alive for the lifetime of BunTest.
-        if unsafe { entry.as_ref() }.added_in_phase == AddedInPhase::Preload {
+        if unsafe { entry.as_ref() }.added_in_phase == AddedInPhase::Preload && in_hooks_only_sequence {
             VirtualMachine::get().as_mut().is_in_preload_hook = false;
         }
     }
@@ -1023,7 +1027,7 @@ fn step_sequence_one(
     if Some(next_item_ptr) == sequence.first_entry {
         Execution::on_sequence_started(sequence);
     }
-    Execution::on_entry_started(next_item);
+    Execution::on_entry_started(next_item, sequence.test_entry.is_none());
 
     if let Some(cb) = next_item.callback.as_ref() {
         group_log::log(format_args!("runSequence queued callback"));

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -638,9 +638,27 @@ impl Execution {
             group_log::log(format_args!("-> entry.timeout: 0"));
             entry.timespec = Timespec::EPOCH;
         }
+
+        // A hook registered during `--preload` (e.g. a preload script's
+        // `beforeAll`) executes here, after `loadPreloads()` cleared
+        // `vm.is_in_preload`. Flag its whole execution window — including
+        // async continuations, since the entry stays active until its promise
+        // settles — so `mock.module()` inside it installs process-lifetime
+        // mocks like preload top-level code. Only hooks can carry
+        // `AddedInPhase::Preload` (`test()` is rejected during preload), and
+        // jest ordering runs tests only after `beforeAll` hooks settle, so no
+        // test callback can observe the flag.
+        if entry.added_in_phase == AddedInPhase::Preload {
+            VirtualMachine::get().as_mut().is_in_preload_hook = true;
+        }
     }
 
-    fn on_entry_completed(_entry: NonNull<ExecutionEntry>) {}
+    fn on_entry_completed(entry: NonNull<ExecutionEntry>) {
+        // SAFETY: arena-owned entry, alive for the lifetime of BunTest.
+        if unsafe { entry.as_ref() }.added_in_phase == AddedInPhase::Preload {
+            VirtualMachine::get().as_mut().is_in_preload_hook = false;
+        }
+    }
 
     fn on_sequence_completed(buntest: NonNull<BunTest>, sequence: &mut ExecutionSequence) {
         let elapsed_ns: u64 = if sequence.started_at.eql(&Timespec::EPOCH) {

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -14,6 +14,13 @@ use crate::cli::test_command::CommandLineReporter;
 use super::execution::TimespecExt as _;
 
 bun_core::declare_scope!(bun_test_group, hidden);
+
+unsafe extern "C" {
+    /// C++ side in `src/jsc/bindings/BunPlugin.cpp` — removes `mock.module()`
+    /// entries whose path is not in `persistentMockPaths`, and evicts the
+    /// ESM registry / CJS require cache for each removed path.
+    safe fn BunPlugin__clearTransientModuleMocks(global: &JSGlobalObject);
+}
 // Callers use `group_log!` / `group_begin!` / `group_end!` below.
 /// Thin macro over `debug::group::begin()` so call sites stay `group_begin!()`.
 macro_rules! group_begin {
@@ -547,6 +554,20 @@ impl BunTestRoot {
             active.get().reporter = None;
         }
         self.active_file = None; // drops the Rc (deinit)
+
+        // Clear `mock.module(...)` entries installed by this file's top-level
+        // code or tests so the next file starts from the real modules.
+        // Preload-installed mocks are preserved (see
+        // `BunPlugin::OnLoad::persistentMockPaths`). Under `--isolate` the
+        // whole global is swapped out by `swap_global_for_test_isolation`
+        // immediately after this, making the call redundant but cheap.
+        let vm = VirtualMachine::get();
+        if !vm.is_shutting_down() {
+            // Single-threaded; the C++ side casts to `Zig::GlobalObject*`
+            // and touches only `onLoadPlugins`, `moduleLoader()`, and
+            // `requireMap()` — all stable for the VM lifetime.
+            BunPlugin__clearTransientModuleMocks(vm.global());
+        }
     }
 
     pub fn get_active_file_unless_in_preload(&mut self, vm: &VirtualMachine) -> Option<&mut BunTest> {

--- a/test/regression/issue/31316.test.ts
+++ b/test/regression/issue/31316.test.ts
@@ -7,7 +7,7 @@
 //
 // Per-file scoping matches Vitest and Jest semantics and removes the need to
 // spawn one process per file for correctness under `bun test`.
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 test("mock.module does not leak into sibling test files", async () => {

--- a/test/regression/issue/31316.test.ts
+++ b/test/regression/issue/31316.test.ts
@@ -1,0 +1,115 @@
+// https://github.com/oven-sh/bun/issues/31316
+//
+// `mock.module()` mutated a process-global registry on the `ZigGlobalObject`
+// that was never reset between test files. Running two test files in the
+// same `bun test` process leaked a partial mock from the first file into the
+// second — which broke ESM binding to the dropped exports.
+//
+// Per-file scoping matches Vitest and Jest semantics and removes the need to
+// spawn one process per file for correctness under `bun test`.
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("mock.module does not leak into sibling test files", async () => {
+  using dir = tempDir("issue-31316", {
+    "dep.ts": `
+      export const a = "REAL_A";
+      export const b = "REAL_B";
+    `,
+    "a.test.ts": `
+      import { mock, it, expect } from "bun:test";
+      mock.module("./dep", () => ({ a: "MOCK_A" }));
+      import { a } from "./dep";
+      it("A sees mock", () => {
+        expect(a).toBe("MOCK_A");
+      });
+    `,
+    "b.test.ts": `
+      import { it, expect } from "bun:test";
+      import { a, b } from "./dep";
+      it("B sees real", () => {
+        expect(a).toBe("REAL_A");
+        expect(b).toBe("REAL_B");
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "a.test.ts", "b.test.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("2 pass");
+  expect(stderr).toContain("0 fail");
+  expect(exitCode).toBe(0);
+});
+
+test("mock.module still persists within its own file", async () => {
+  // Regression guard: the per-file cleanup should run at file boundaries,
+  // not between individual tests in the same file.
+  using dir = tempDir("issue-31316-same-file", {
+    "dep.ts": `export const v = "REAL";`,
+    "same.test.ts": `
+      import { mock, it, expect } from "bun:test";
+      mock.module("./dep", () => ({ v: "MOCK" }));
+      import { v } from "./dep";
+      it("first", () => { expect(v).toBe("MOCK"); });
+      it("second (same file)", () => { expect(v).toBe("MOCK"); });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "same.test.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("2 pass");
+  expect(stderr).toContain("0 fail");
+  expect(exitCode).toBe(0);
+});
+
+test("preload-installed mock.module persists across files", async () => {
+  // `mock.module()` from a `--preload` script is process-lifetime, not
+  // per-test-file. The per-file cleanup must leave it alone.
+  using dir = tempDir("issue-31316-preload", {
+    "dep.ts": `export const v = "REAL";`,
+    "preload.ts": `
+      import { mock } from "bun:test";
+      mock.module("./dep", () => ({ v: "PRELOAD_MOCK" }));
+    `,
+    "one.test.ts": `
+      import { it, expect } from "bun:test";
+      import { v } from "./dep";
+      it("one", () => { expect(v).toBe("PRELOAD_MOCK"); });
+    `,
+    "two.test.ts": `
+      import { it, expect } from "bun:test";
+      import { v } from "./dep";
+      it("two", () => { expect(v).toBe("PRELOAD_MOCK"); });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--preload", "./preload.ts", "one.test.ts", "two.test.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("2 pass");
+  expect(stderr).toContain("0 fail");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/31316.test.ts
+++ b/test/regression/issue/31316.test.ts
@@ -7,108 +7,192 @@
 //
 // Per-file scoping matches Vitest and Jest semantics and removes the need to
 // spawn one process per file for correctness under `bun test`.
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-test("mock.module does not leak into sibling test files", async () => {
-  using dir = tempDir("issue-31316", {
-    "dep.ts": `
-      export const a = "REAL_A";
-      export const b = "REAL_B";
-    `,
-    "a.test.ts": `
-      import { mock, it, expect } from "bun:test";
-      mock.module("./dep", () => ({ a: "MOCK_A" }));
-      import { a } from "./dep";
-      it("A sees mock", () => {
-        expect(a).toBe("MOCK_A");
-      });
-    `,
-    "b.test.ts": `
-      import { it, expect } from "bun:test";
-      import { a, b } from "./dep";
-      it("B sees real", () => {
-        expect(a).toBe("REAL_A");
-        expect(b).toBe("REAL_B");
-      });
-    `,
+describe.concurrent("mock.module per-file scoping", () => {
+  test("mock.module does not leak into sibling test files", async () => {
+    using dir = tempDir("issue-31316", {
+      "dep.ts": `
+        export const a = "REAL_A";
+        export const b = "REAL_B";
+      `,
+      "a.test.ts": `
+        import { mock, it, expect } from "bun:test";
+        mock.module("./dep", () => ({ a: "MOCK_A" }));
+        import { a } from "./dep";
+        it("A sees mock", () => {
+          expect(a).toBe("MOCK_A");
+        });
+      `,
+      "b.test.ts": `
+        import { it, expect } from "bun:test";
+        import { a, b } from "./dep";
+        it("B sees real", () => {
+          expect(a).toBe("REAL_A");
+          expect(b).toBe("REAL_B");
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "a.test.ts", "b.test.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // `bun test` writes pass/fail counts to stderr; stdout is captured so it
+    // surfaces in failure logs alongside stderr.
+    expect(stderr + stdout).toContain("2 pass");
+    expect(stderr + stdout).toContain("0 fail");
+    expect(exitCode).toBe(0);
   });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "test", "a.test.ts", "b.test.ts"],
-    cwd: String(dir),
-    env: bunEnv,
-    stderr: "pipe",
-    stdout: "pipe",
+  test("mock.module still persists within its own file", async () => {
+    // Regression guard: the per-file cleanup should run at file boundaries,
+    // not between individual tests in the same file.
+    using dir = tempDir("issue-31316-same-file", {
+      "dep.ts": `export const v = "REAL";`,
+      "same.test.ts": `
+        import { mock, it, expect } from "bun:test";
+        mock.module("./dep", () => ({ v: "MOCK" }));
+        import { v } from "./dep";
+        it("first", () => { expect(v).toBe("MOCK"); });
+        it("second (same file)", () => { expect(v).toBe("MOCK"); });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "same.test.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr + stdout).toContain("2 pass");
+    expect(stderr + stdout).toContain("0 fail");
+    expect(exitCode).toBe(0);
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  // `bun test` writes pass/fail counts to stderr; stdout is captured so it
-  // surfaces in failure logs alongside stderr.
-  expect(stderr + stdout).toContain("2 pass");
-  expect(stderr + stdout).toContain("0 fail");
-  expect(exitCode).toBe(0);
-});
+  test("preload-installed mock.module persists across files", async () => {
+    // `mock.module()` from a `--preload` script is process-lifetime, not
+    // per-test-file. The per-file cleanup must leave it alone.
+    using dir = tempDir("issue-31316-preload", {
+      "dep.ts": `export const v = "REAL";`,
+      "preload.ts": `
+        import { mock } from "bun:test";
+        mock.module("./dep", () => ({ v: "PRELOAD_MOCK" }));
+      `,
+      "one.test.ts": `
+        import { it, expect } from "bun:test";
+        import { v } from "./dep";
+        it("one", () => { expect(v).toBe("PRELOAD_MOCK"); });
+      `,
+      "two.test.ts": `
+        import { it, expect } from "bun:test";
+        import { v } from "./dep";
+        it("two", () => { expect(v).toBe("PRELOAD_MOCK"); });
+      `,
+    });
 
-test("mock.module still persists within its own file", async () => {
-  // Regression guard: the per-file cleanup should run at file boundaries,
-  // not between individual tests in the same file.
-  using dir = tempDir("issue-31316-same-file", {
-    "dep.ts": `export const v = "REAL";`,
-    "same.test.ts": `
-      import { mock, it, expect } from "bun:test";
-      mock.module("./dep", () => ({ v: "MOCK" }));
-      import { v } from "./dep";
-      it("first", () => { expect(v).toBe("MOCK"); });
-      it("second (same file)", () => { expect(v).toBe("MOCK"); });
-    `,
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--preload", "./preload.ts", "one.test.ts", "two.test.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr + stdout).toContain("2 pass");
+    expect(stderr + stdout).toContain("0 fail");
+    expect(exitCode).toBe(0);
   });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "test", "same.test.ts"],
-    cwd: String(dir),
-    env: bunEnv,
-    stderr: "pipe",
-    stdout: "pipe",
+  test("transient mock is cleared through a re-export barrel", async () => {
+    // `mock.module('./dep', ...)` writes into `./dep`'s module environment
+    // via `overrideExportValue`. A cached intermediate `./consumer` that
+    // re-exports from `./dep` binds through that same env slot, so if we
+    // only evict `./dep` the re-exporter still observes the mocked value in
+    // the next file. Per-file teardown now restores the env slot *before*
+    // evicting so re-exporters revert to the real module.
+    using dir = tempDir("issue-31316-reexport", {
+      "dep.ts": `export const v = "REAL";`,
+      "consumer.ts": `export { v } from "./dep";`,
+      "a.test.ts": `
+        import { mock, it, expect } from "bun:test";
+        import { v } from "./consumer";
+        mock.module("./dep", () => ({ v: "MOCK_A" }));
+        it("A sees the mock through consumer", () => {
+          expect(v).toBe("MOCK_A");
+        });
+      `,
+      "b.test.ts": `
+        import { it, expect } from "bun:test";
+        import { v } from "./consumer";
+        it("B sees real through consumer", () => {
+          expect(v).toBe("REAL");
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "a.test.ts", "b.test.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr + stdout).toContain("2 pass");
+    expect(stderr + stdout).toContain("0 fail");
+    expect(exitCode).toBe(0);
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr + stdout).toContain("2 pass");
-  expect(stderr + stdout).toContain("0 fail");
-  expect(exitCode).toBe(0);
-});
+  test("test-file mock that shadows a preload mock restores the preload mock", async () => {
+    // When a test file re-mocks the same path a `--preload` already mocked,
+    // teardown must restore the preload's mock — not leak the test file's
+    // mock into siblings.
+    using dir = tempDir("issue-31316-preload-shadow", {
+      "dep.ts": `export const v = "REAL";`,
+      "preload.ts": `
+        import { mock } from "bun:test";
+        mock.module("./dep", () => ({ v: "PRELOAD" }));
+      `,
+      "a.test.ts": `
+        import { mock, it, expect } from "bun:test";
+        mock.module("./dep", () => ({ v: "A_MOCK" }));
+        import { v } from "./dep";
+        it("A sees its own mock", () => {
+          expect(v).toBe("A_MOCK");
+        });
+      `,
+      "b.test.ts": `
+        import { it, expect } from "bun:test";
+        import { v } from "./dep";
+        it("B sees the preload mock, not A's", () => {
+          expect(v).toBe("PRELOAD");
+        });
+      `,
+    });
 
-test("preload-installed mock.module persists across files", async () => {
-  // `mock.module()` from a `--preload` script is process-lifetime, not
-  // per-test-file. The per-file cleanup must leave it alone.
-  using dir = tempDir("issue-31316-preload", {
-    "dep.ts": `export const v = "REAL";`,
-    "preload.ts": `
-      import { mock } from "bun:test";
-      mock.module("./dep", () => ({ v: "PRELOAD_MOCK" }));
-    `,
-    "one.test.ts": `
-      import { it, expect } from "bun:test";
-      import { v } from "./dep";
-      it("one", () => { expect(v).toBe("PRELOAD_MOCK"); });
-    `,
-    "two.test.ts": `
-      import { it, expect } from "bun:test";
-      import { v } from "./dep";
-      it("two", () => { expect(v).toBe("PRELOAD_MOCK"); });
-    `,
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--preload", "./preload.ts", "a.test.ts", "b.test.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr + stdout).toContain("2 pass");
+    expect(stderr + stdout).toContain("0 fail");
+    expect(exitCode).toBe(0);
   });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "test", "--preload", "./preload.ts", "one.test.ts", "two.test.ts"],
-    cwd: String(dir),
-    env: bunEnv,
-    stderr: "pipe",
-    stdout: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr + stdout).toContain("2 pass");
-  expect(stderr + stdout).toContain("0 fail");
-  expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/31316.test.ts
+++ b/test/regression/issue/31316.test.ts
@@ -42,10 +42,15 @@ test("mock.module does not leak into sibling test files", async () => {
     stdout: "pipe",
   });
 
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-
-  expect(stderr).toContain("2 pass");
-  expect(stderr).toContain("0 fail");
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  // `bun test` writes pass/fail counts to stderr; stdout is captured so it
+  // surfaces in failure logs alongside stderr.
+  expect(stderr + stdout).toContain("2 pass");
+  expect(stderr + stdout).toContain("0 fail");
   expect(exitCode).toBe(0);
 });
 
@@ -71,10 +76,13 @@ test("mock.module still persists within its own file", async () => {
     stdout: "pipe",
   });
 
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-
-  expect(stderr).toContain("2 pass");
-  expect(stderr).toContain("0 fail");
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  expect(stderr + stdout).toContain("2 pass");
+  expect(stderr + stdout).toContain("0 fail");
   expect(exitCode).toBe(0);
 });
 
@@ -107,9 +115,12 @@ test("preload-installed mock.module persists across files", async () => {
     stdout: "pipe",
   });
 
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-
-  expect(stderr).toContain("2 pass");
-  expect(stderr).toContain("0 fail");
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  expect(stderr + stdout).toContain("2 pass");
+  expect(stderr + stdout).toContain("0 fail");
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/31316.test.ts
+++ b/test/regression/issue/31316.test.ts
@@ -195,4 +195,211 @@ describe.concurrent("mock.module per-file scoping", () => {
     expect(stderr + stdout).toContain("0 fail");
     expect(exitCode).toBe(0);
   });
+
+  test("mock.module inside a preload beforeAll persists across files", async () => {
+    // A hook registered during --preload runs once, during the first file's
+    // execution phase (after vm.is_in_preload is cleared). Mocks it installs
+    // must still be process-lifetime: the hook never re-runs for later files.
+    using dir = tempDir("issue-31316-preload-hook", {
+      "dep.ts": `export const v = "REAL";`,
+      "preload.ts": `
+        import { beforeAll, mock } from "bun:test";
+        beforeAll(async () => {
+          await Promise.resolve();
+          mock.module("./dep", () => ({ v: "PRELOAD_HOOK" }));
+        });
+      `,
+      "one.test.ts": `
+        import { it, expect } from "bun:test";
+        it("one", async () => {
+          const { v } = await import("./dep");
+          expect(v).toBe("PRELOAD_HOOK");
+        });
+      `,
+      "two.test.ts": `
+        import { it, expect } from "bun:test";
+        import { v } from "./dep";
+        it("two", () => { expect(v).toBe("PRELOAD_HOOK"); });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--preload", "./preload.ts", "one.test.ts", "two.test.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr + stdout).toContain("2 pass");
+    expect(stderr + stdout).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("mock installed before first load is cleared through a dynamically imported barrel", async () => {
+    // When mock.module() runs before ./dep was ever loaded, a later dynamic
+    // import materializes ./dep's module record *from the mock factory* —
+    // there are no original env values to restore. The cached barrel binding
+    // into that record must be evicted transitively.
+    using dir = tempDir("issue-31316-mock-born", {
+      "dep.ts": `export const v = "REAL";`,
+      "consumer.ts": `export { v } from "./dep";`,
+      "a.test.ts": `
+        import { mock, it, expect } from "bun:test";
+        mock.module("./dep", () => ({ v: "MOCK_A" }));
+        it("A sees mock through dynamically imported consumer", async () => {
+          const { v } = await import("./consumer");
+          expect(v).toBe("MOCK_A");
+        });
+      `,
+      "b.test.ts": `
+        import { it, expect } from "bun:test";
+        import { v } from "./consumer";
+        it("B sees real through consumer", () => {
+          expect(v).toBe("REAL");
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "a.test.ts", "b.test.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr + stdout).toContain("2 pass");
+    expect(stderr + stdout).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("require() of a preload-shadowed path sees the preload mock in the next file", async () => {
+    // Install writes the transient mock's exports in place into the cached
+    // CJS module; teardown must drop that require-cache entry so the next
+    // file's require() re-runs the restored preload factory.
+    using dir = tempDir("issue-31316-preload-shadow-cjs", {
+      "dep.ts": `export const v = "REAL";`,
+      "preload.ts": `
+        import { mock } from "bun:test";
+        mock.module("./dep", () => ({ v: "PRELOAD" }));
+      `,
+      "a.test.ts": `
+        import { mock, it, expect } from "bun:test";
+        const before = require("./dep");
+        mock.module("./dep", () => ({ v: "A_MOCK" }));
+        it("A sees its own mock via require", () => {
+          expect(before.v).toBe("A_MOCK");
+          expect(require("./dep").v).toBe("A_MOCK");
+        });
+      `,
+      "b.test.ts": `
+        import { it, expect } from "bun:test";
+        it("B sees the preload mock via require", () => {
+          expect(require("./dep").v).toBe("PRELOAD");
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--preload", "./preload.ts", "a.test.ts", "b.test.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr + stdout).toContain("2 pass");
+    expect(stderr + stdout).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("re-mocking the same path with disjoint exports restores both through a barrel", async () => {
+    // The first mock overrides `a`, the second overrides `b`. Teardown must
+    // restore each export from the snapshot taken the first time *that name*
+    // was overridden, not discard the second snapshot wholesale.
+    using dir = tempDir("issue-31316-disjoint-remock", {
+      "dep.ts": `
+        export const a = "REAL_A";
+        export const b = "REAL_B";
+      `,
+      "consumer.ts": `export { a, b } from "./dep";`,
+      "a.test.ts": `
+        import { mock, it, expect } from "bun:test";
+        import { a, b } from "./consumer";
+        mock.module("./dep", () => ({ a: "M1" }));
+        mock.module("./dep", () => ({ b: "M2" }));
+        it("A sees both mocks", () => {
+          expect(a).toBe("M1");
+          expect(b).toBe("M2");
+        });
+      `,
+      "b.test.ts": `
+        import { it, expect } from "bun:test";
+        import { a, b } from "./consumer";
+        it("B sees both real values through consumer", () => {
+          expect(a).toBe("REAL_A");
+          expect(b).toBe("REAL_B");
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "a.test.ts", "b.test.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr + stdout).toContain("2 pass");
+    expect(stderr + stdout).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("preload-shadowing mock installed before first load is cleared on teardown", async () => {
+    // Preload mocks ./dep; the test file re-mocks it before anything loaded
+    // it, then dynamically imports it (materializing the record from the
+    // transient factory). Teardown must evict that record so the next file
+    // resolves through the restored preload shim.
+    using dir = tempDir("issue-31316-preload-shadow-dynamic", {
+      "dep.ts": `export const v = "REAL";`,
+      "preload.ts": `
+        import { mock } from "bun:test";
+        mock.module("./dep", () => ({ v: "PRELOAD" }));
+      `,
+      "a.test.ts": `
+        import { mock, it, expect } from "bun:test";
+        mock.module("./dep", () => ({ v: "A_MOCK" }));
+        it("A sees its own mock via dynamic import", async () => {
+          const { v } = await import("./dep");
+          expect(v).toBe("A_MOCK");
+        });
+      `,
+      "b.test.ts": `
+        import { it, expect } from "bun:test";
+        import { v } from "./dep";
+        it("B sees the preload mock", () => {
+          expect(v).toBe("PRELOAD");
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--preload", "./preload.ts", "a.test.ts", "b.test.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr + stdout).toContain("2 pass");
+    expect(stderr + stdout).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/regression/issue/31316.test.ts
+++ b/test/regression/issue/31316.test.ts
@@ -402,4 +402,86 @@ describe.concurrent("mock.module per-file scoping", () => {
     expect(stderr + stdout).toContain("0 fail");
     expect(exitCode).toBe(0);
   });
+
+  test("CJS consumer that captured a mock-born value is re-run in the next file", async () => {
+    // A pure-CJS consumer copies values out of the mocked module at require
+    // time and never appears in the ESM registry, so clearing the mock can't
+    // restore it in place — teardown must evict it from the require cache so
+    // the next file's require() re-runs it against the real module.
+    using dir = tempDir("issue-31316-cjs-capture", {
+      "dep.ts": `export const v = "REAL";`,
+      "consumer.cjs": `module.exports.v = require("./dep").v;`,
+      "a.test.ts": `
+        import { mock, it, expect } from "bun:test";
+        mock.module("./dep", () => ({ v: "MOCK_A" }));
+        it("A sees the captured mock value", () => {
+          expect(require("./consumer.cjs").v).toBe("MOCK_A");
+        });
+      `,
+      "b.test.ts": `
+        import { it, expect } from "bun:test";
+        it("B sees the captured real value", () => {
+          expect(require("./consumer.cjs").v).toBe("REAL");
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "a.test.ts", "b.test.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr + stdout).toContain("2 pass");
+    expect(stderr + stdout).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("mock.module inside a preload beforeEach is scoped per file", async () => {
+    // Per-test hooks registered in preload run inside test sequences and can
+    // interleave with concurrent test bodies, so their mocks are transient —
+    // they re-run before every test anyway. Observable contract: the next
+    // file's *top-level import* binds the real module (a persistent mock
+    // would shim it at import time), and the re-run hook re-installs the
+    // mock before the test body executes.
+    using dir = tempDir("issue-31316-preload-each", {
+      "dep.ts": `export const v = "REAL";`,
+      "preload.ts": `
+        import { beforeEach, mock } from "bun:test";
+        beforeEach(() => {
+          mock.module("./dep", () => ({ v: "EACH_MOCK" }));
+        });
+      `,
+      "a.test.ts": `
+        import { it, expect } from "bun:test";
+        import { v } from "./dep";
+        it("a", () => { expect(v).toBe("EACH_MOCK"); });
+      `,
+      "b.test.ts": `
+        import { it, expect } from "bun:test";
+        import { v } from "./dep";
+        const atImportTime = v;
+        it("b", () => {
+          expect(atImportTime).toBe("REAL");
+          expect(v).toBe("EACH_MOCK");
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--preload", "./preload.ts", "a.test.ts", "b.test.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr + stdout).toContain("2 pass");
+    expect(stderr + stdout).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/regression/issue/31316.test.ts
+++ b/test/regression/issue/31316.test.ts
@@ -42,11 +42,7 @@ test("mock.module does not leak into sibling test files", async () => {
     stdout: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   // `bun test` writes pass/fail counts to stderr; stdout is captured so it
   // surfaces in failure logs alongside stderr.
   expect(stderr + stdout).toContain("2 pass");
@@ -76,11 +72,7 @@ test("mock.module still persists within its own file", async () => {
     stdout: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr + stdout).toContain("2 pass");
   expect(stderr + stdout).toContain("0 fail");
   expect(exitCode).toBe(0);
@@ -115,11 +107,7 @@ test("preload-installed mock.module persists across files", async () => {
     stdout: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr + stdout).toContain("2 pass");
   expect(stderr + stdout).toContain("0 fail");
   expect(exitCode).toBe(0);

--- a/test/regression/issue/31316.test.ts
+++ b/test/regression/issue/31316.test.ts
@@ -484,4 +484,47 @@ describe.concurrent("mock.module per-file scoping", () => {
     expect(stderr + stdout).toContain("0 fail");
     expect(exitCode).toBe(0);
   });
+
+  test("re-mocking a mock-born path still evicts its cached importers", async () => {
+    // The first mock installs before ./dep is loaded (mock-born); a dynamic
+    // import materializes dep from the factory; a second mock then finds the
+    // mock-born registry entry. Snapshotting that entry would record the
+    // first mock's values as "originals" and suppress the transitive
+    // eviction, leaking M1 into the next file through the cached barrel.
+    using dir = tempDir("issue-31316-remock-born", {
+      "dep.ts": `export const v = "REAL";`,
+      "consumer.ts": `export { v } from "./dep";`,
+      "a.test.ts": `
+        import { mock, it, expect } from "bun:test";
+        mock.module("./dep", () => ({ v: "M1" }));
+        it("a", async () => {
+          const { v } = await import("./consumer");
+          expect(v).toBe("M1");
+          mock.module("./dep", () => ({ v: "M2" }));
+          const { v: v2 } = await import("./consumer");
+          expect(v2).toBe("M2");
+        });
+      `,
+      "b.test.ts": `
+        import { it, expect } from "bun:test";
+        import { v } from "./consumer";
+        it("b sees real through consumer", () => {
+          expect(v).toBe("REAL");
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "a.test.ts", "b.test.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr + stdout).toContain("2 pass");
+    expect(stderr + stdout).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/regression/issue/31316.test.ts
+++ b/test/regression/issue/31316.test.ts
@@ -572,4 +572,87 @@ describe.concurrent("mock.module per-file scoping", () => {
     expect(stderr + stdout).toContain("0 fail");
     expect(exitCode).toBe(0);
   });
+
+  test("mocking a plain-CJS dep that was require-cached before the mock keeps pre-mock requirers cached", async () => {
+    // Same as above but the mocked dep is plain CJS, so the pre-mock
+    // requirer holds an m_children edge to the kept cache entry (not just
+    // the m_parent back-edge). Teardown must not poison the kept entry, or
+    // the transitive CJS walk evicts and re-runs the preload requirer.
+    using dir = tempDir("issue-31316-premock-cjs", {
+      "config.cjs": `module.exports = { key: "REAL" };`,
+      "service.cjs": `
+        const { key } = require("./config.cjs");
+        console.log("service evaluated");
+        module.exports = { key };
+      `,
+      "preload.ts": `require("./service.cjs");`,
+      "a.test.ts": `
+        import { mock, it, expect } from "bun:test";
+        mock.module("./config.cjs", () => ({ key: "MOCK" }));
+        it("a sees mock", () => {
+          expect(require("./config.cjs").key).toBe("MOCK");
+        });
+      `,
+      "b.test.ts": `
+        import { it, expect } from "bun:test";
+        it("b gets the cached service", () => {
+          expect(require("./service.cjs").key).toBe("REAL");
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--preload", "./preload.ts", "a.test.ts", "b.test.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.split("service evaluated").length - 1).toBe(1);
+    expect(stderr + stdout).toContain("2 pass");
+    expect(stderr + stdout).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("a later file can re-mock a path a previous file mocked through a shared barrel", async () => {
+    // Teardown restores dep's env slots in place, so the registry entry is
+    // fully correct and must stay reachable: evicting it orphans the record
+    // that the cached barrel still binds through, so the next file's
+    // mock.module() finds no registry entry and never overrides the slots.
+    using dir = tempDir("issue-31316-remock-barrel", {
+      "dep.ts": `export const v = "REAL";`,
+      "consumer.ts": `export { v } from "./dep";`,
+      "a.test.ts": `
+        import { mock, it, expect } from "bun:test";
+        import { v } from "./consumer";
+        mock.module("./dep", () => ({ v: "A" }));
+        it("a sees its own mock", () => {
+          expect(v).toBe("A");
+        });
+      `,
+      "b.test.ts": `
+        import { mock, it, expect } from "bun:test";
+        import { v } from "./consumer";
+        mock.module("./dep", () => ({ v: "B" }));
+        it("b sees its own mock", () => {
+          expect(v).toBe("B");
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "a.test.ts", "b.test.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr + stdout).toContain("2 pass");
+    expect(stderr + stdout).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/regression/issue/31316.test.ts
+++ b/test/regression/issue/31316.test.ts
@@ -527,4 +527,49 @@ describe.concurrent("mock.module per-file scoping", () => {
     expect(stderr + stdout).toContain("0 fail");
     expect(exitCode).toBe(0);
   });
+
+  test("mocking a dep that was require-cached before the mock keeps pre-mock requirers cached", async () => {
+    // service.cjs required ./config during --preload and captured the real
+    // value; a later transient mock of ./config replaces the cache entry's
+    // exports object in place, so service's captured values stay correct.
+    // Teardown must not evict service (and its ancestors) through config's
+    // m_parent back-edge — that re-runs preload side effects every file.
+    using dir = tempDir("issue-31316-premock-parent", {
+      "config.ts": `export const key = "REAL";`,
+      "service.cjs": `
+        const { key } = require("./config");
+        console.log("service evaluated");
+        module.exports = { key };
+      `,
+      "preload.ts": `require("./service.cjs");`,
+      "a.test.ts": `
+        import { mock, it, expect } from "bun:test";
+        import { key } from "./config";
+        mock.module("./config", () => ({ key: "MOCK" }));
+        it("a sees mock", () => {
+          expect(key).toBe("MOCK");
+        });
+      `,
+      "b.test.ts": `
+        import { it, expect } from "bun:test";
+        it("b gets the cached service", () => {
+          expect(require("./service.cjs").key).toBe("REAL");
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--preload", "./preload.ts", "a.test.ts", "b.test.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.split("service evaluated").length - 1).toBe(1);
+    expect(stderr + stdout).toContain("2 pass");
+    expect(stderr + stdout).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
Fixes #31316.

### Repro

```ts
// dep.ts
export const a = "REAL_A";
export const b = "REAL_B";

// a.test.ts
import { mock, it, expect } from "bun:test";
mock.module("./dep", () => ({ a: "MOCK_A" }));  // partial mock, drops b
import { a } from "./dep";
it("A sees mock", () => { expect(a).toBe("MOCK_A"); });

// b.test.ts
import { it, expect } from "bun:test";
import { a, b } from "./dep";  // never mocked here
it("B sees real", () => { expect(a).toBe("REAL_A"); expect(b).toBe("REAL_B"); });
```

`bun test a.test.ts b.test.ts` before this change:

```
Expected: "REAL_A"
Received: "MOCK_A"
1 pass
1 fail
```

### Cause

`mock.module()` stores the mock factory in `ZigGlobalObject::onLoadPlugins.virtualModules` — a process-global map whose lifetime is the VM's. Without `--isolate` that map is shared across every test file, so a partial mock installed at one file's top level replaces the module for every subsequent import in the same process, and ESM static bindings to exports the factory dropped bind against the mocked namespace.

`mock.restore()` / `jest.restoreAllMocks()` only walk `activeSpies`/`activeMocks` — module mocks aren't tracked there, so those calls never clear them.

### Fix

Per-file teardown (`BunTestRoot::exit_file`) calls a new `BunPlugin__clearTransientModuleMocks`. It walks `virtualModules`, removes each `JSModuleMock` entry, and evicts the matching ESM registry (`moduleLoader()->removeEntry`) and CJS require-map entries so the next file's imports re-execute the real source.

To keep preload mocks (`mock.module(...)` called from a `--preload` script) and `Bun.plugin({module})` registrations intact, `addModuleMock` now takes a `bool persistent` flag. Paths installed while `vm.is_in_preload` is true, or through `Bun.plugin({module})`, are tracked in a parallel `persistentMockPaths` set that the sweep skips.

Under `--isolate` the global object is swapped per file by `swap_global_for_test_isolation`, so the new call is redundant but harmless — both modes now share a single teardown path.

### Verification

`bun bd test test/regression/issue/31316.test.ts` covers all three expectations:

- mocks from one file don't leak into a sibling file,
- mocks still apply within the file that registered them,
- `--preload` mocks survive across files.

`bun bd test test/js/bun/test/mock/` — 19 pass, 1 todo, 0 fail.
`bun bd test test/js/bun/plugin/plugins.test.ts` — 29 pass, 1 todo, 0 fail.

### Review follow-ups

- A test-file mock that shadows a `--preload` mock is restored on teardown (the preload mock, not the test file's override, is what sibling files see).
- Transient mocks snapshot the original ESM namespace values at install and replay them on teardown, so cached re-export barrels bound through the same module environment slot revert to the real module.
- Regression test now covers five scenarios (sibling isolation, intra-file persistence, preload persistence, re-export barrel, preload shadow) under `describe.concurrent`.

### Second review round (56016758bc)

- `mock.module()` inside a hook registered during `--preload` (e.g. a preload `beforeAll`) now installs process-lifetime mocks: the test runner flags the execution window of preload-phase entries (including async continuations) and the preload check ORs that flag in.
- The displaced-preload restore branch evicts the CJS require-cache entry (install had overwritten the cached module's exports in place) and, when there was no env snapshot, the ESM registry entry.
- Env snapshots merge per export name, so re-mocking a path with a disjoint export set still restores names only the second mock touched.
- Teardown transitively evicts cached modules whose dependency graph reaches a module record materialized from a transient mock factory (mock installed before its target was ever loaded, then dynamically imported).

Each has a dedicated regression test; all ten fail without the corresponding fix and pass with it.

### Third review round (34ae55a761)

- The transitive-eviction pass covers CJS: ESM dependents also drop their require-cache entry, and a fixed-point walk over the require map evicts CJS consumers of mock-born modules (via `m_children` edges plus the dependency's `m_parent` back-edge for first requirers of ESM/mocked namespaces).
- The preload-hook flag is scoped to hooks-only sequences (`beforeAll`/`afterAll`), so it cannot race concurrent test bodies; preload `beforeEach`/`afterEach` mocks are per-file by design (they re-run before every test).

Twelve regression tests total; each fails without its fix.

### Fourth review round (4b7d8d0782)

- `InstalledMockRecord` now tracks `wasMockBorn` from the first transient install. Re-mocking a path whose first mock installed before the module ever loaded no longer snapshots the first mock's values as "originals" (they came from a mock-born namespace), so teardown stays on the transitive-eviction path and cached re-exporters revert to the real module. Thirteenth regression test covers it.

Known limitations, acknowledged in review as follow-ups (both are narrow and neither is a regression vs. the pre-PR behavior, which leaked everything):

- A persistent install (preload hook or `Bun.plugin({module})`) over a path the current file already transiently mocked discards that record's env snapshot, so export names only the transient mock touched are not restored.
- The CJS transitive walk reads the native `m_children` vector; a consumer whose `module.children` was read or assigned before teardown (reifying the vector into a JS array) is invisible to the walk unless caught by the `m_parent` back-edge.

### Fifth review round (bce632e99f)

- The teardown `m_parent` walk no longer evicts pre-mock CJS requirers. When the mocked path's require-cache entry predates the mock (e.g. created during preload), install replaced its exports object in place, so the entry's first requirer captured real values; evicting it re-ran preload side effects on every file boundary. `InstalledMockRecord` records `cjsEntryPreExisted` and teardown skips the parent walk for those records, while post-mock requirers of the kept entry are still evicted through their own `m_children` edges. Fourteenth regression test covers it (preload-required service stays cached, evaluated exactly once).

### Sixth review round (6c4cd2aa07)

- Non-mock-born records no longer evict the module registry entry at teardown. Step 1 restores the record's env slots in place, so the entry is fully correct; evicting it orphaned the record cached barrels bind through, and a later file re-mocking the same path found no registry entry and never overrode those bindings. Regression test: two files mock the same dep through a shared barrel, each sees its own mock.
- Records whose require-cache entry predates the mock skip the CJS poison entirely (the fifth-round fix only skipped the `m_parent` walk). For a plain-CJS dep, the pre-mock requirer holds an `m_children` edge to the same kept cell as post-mock requirers, so poisoning the cell still re-ran preload side effects. Regression test: plain-CJS variant of the preload-service test.

Additional known limitation, accepted in review: a CJS consumer that requires a path *after* a mock replaced a pre-existing cache entry's exports in place keeps its captured mock values into the next file (pre- and post-mock requirers of the kept cell are indistinguishable; this matches pre-PR behavior for that case).

### Rebase note (2)

Rebased onto current main (91675d0baf). One trivial conflict in `src/jsc/virtual_machine_exports.rs`: main added `Bun__VM__scriptExecutionStatus` adjacent to this PR's `Bun__VirtualMachine__isInPreload` export; kept both. All 12 regression tests plus the mock, plugin, and concurrent-GC suites pass on the rebased branch (the two `fs.watch` failures in `isolation.test.ts` are container EMFILE limits — identical against a main-src build).

### Rebase note

Rebased onto main after #31407 (hold `cellLock()` when removing module registry entries). The teardown path's `moduleLoader()->removeEntry()` now takes the loader's `cellLock()` to match, so the eviction can't race the concurrent GC marker. Verified against main's `esm-registry-concurrent-gc.test.ts`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 10 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/31316.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (bce632e99)

test/regression/issue/31316.test.ts:
(pass) mock.module per-file scoping > mock.module still persists within its own file [535.48ms]
44 |     });
45 | 
46 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
47 |     // `bun test` writes pass/fail counts to stderr; stdout is captured so it
48 |     // surfaces in failure logs alongside stderr.
49 |     expect(stderr + stdout).toContain("2 pass");
                                 ^
error: expect(received).toContain(expected)

Expected to contain: "2 pass"
Received: "\na.test.ts:\n(pass) A sees mock [1.84ms]\n\nb.test.ts:\n1 | \n2 |         import { it, expect } from \"bun:test\";\n3 |         import { a, b 
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (e66647845)

test/regression/issue/31316.test.ts:
(pass) mock.module per-file scoping > mock.module does not leak into sibling test files [20.50ms]
(pass) mock.module per-file scoping > mock.module still persists within its own file [18.95ms]
(pass) mock.module per-file scoping > preload-installed mock.module persists across files [18.04ms]
(pass) mock.module per-file scoping > test-file mock that shadows a preload mock restores the preload mock [16.33ms]
(pass) mock.module per-file scoping > mock.module inside a preload beforeAll persists across files [16.94ms]
(pass) mock.module per-file scoping > transient mock is cleared through a re-export barrel [18.68ms]
(pass) mock.module per-file scoping > mock installed before first load is cleared through a dynamically imported barrel [15.96ms]
(pass) mock.module per-file scoping > re-mocking the same path with disjoint exports restores both through a barrel [16.19ms]
(pass) mock.module per-file scoping > require() of a preload-shadowed path sees the preload mock in the next file [17.58ms]
(pass) mock.module per-file scoping > preload-shadowing mock installed before first load is cleared on teardo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/31316.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (bce632e99)

test/regression/issue/31316.test.ts:
(pass) mock.module per-file scoping > mock.module still persists within its own file [526.27ms]
(pass) mock.module per-file scoping > test-file mock that shadows a preload mock restores the preload mock [500.14ms]
(pass) mock.module per-file scoping > mock.module does not leak into sibling test files [625.56ms]
(pass) mock.module per-file scoping > transient mock is cleared through a re-export barrel [563.55ms]
(pass) mock.module per-file scoping > preload-installed mock.module persists across files [604.77ms]
(pass) mock.module per-file scoping > mock.module inside a preload beforeAll persists across files [494.04ms]
(pass) mock.module per-file scoping > require() of a preload-sh
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 677ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/119] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 243 extern-C blocks audited
[2/119] gen cpp.rs (cppbind)
[2/119] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_paths v0.0.0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs            |   6 +
 src/jsc/bindings/BunPlugin.cpp       | 470 +++++++++++++++++++++++++++-
 src/jsc/bindings/BunPlugin.h         |  57 +++-
 src/jsc/virtual_machine_exports.rs   |   8 +
 src/runtime/test_runner/Execution.rs |  30 +-
 src/runtime/test_runner/bun_test.rs  |  21 ++
 test/regression/issue/31316.test.ts  | 575 +++++++++++++++++++++++++++++++++++
 7 files changed, 1147 insertions(+), 20 deletions(-)
```

</details>

**gate history** · 4 passed · 1 rejected · iteration 10

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/jsc/VirtualMachine.rs                 3      1     25
src/jsc/bindings/BunPlugin.cpp           28     38     25
src/jsc/bindings/BunPlugin.h              5      9     25
src/jsc/virtual_machine_exports.rs        2      2     26
src/runtime/test_runner/Execution.rs      1      1     26
src/runtime/test_runner/bun_test.rs       5      6     25
test/regression/issue/31316.test.ts       4      6     25
```

</details>

**root cause** · written by the author bot

The bug was that `mock.module()` wrote into a process-global mock registry that was never torn down at test file boundaries, so a mock installed in one file remained active for every subsequent file in the same `bun test` process, leaking overridden exports and dropping non-mocked bindings. The fix tracks each transiently installed mock per test file and, at the file boundary, restores the original module state, reverting ESM environment slot bindings, evicting mock-born require cache entries and their dependents so they reload against the real module, and reinstating any preload-installed …

<!-- robobun:evidence:end -->


