### PR TITLE
node:http: preserve header name case in `req.rawHeaders`; add `req.headersDistinct`

### DIFF
--- a/packages/bun-uws/src/BloomFilter.h
+++ b/packages/bun-uws/src/BloomFilter.h
@@ -38,12 +38,20 @@ private:
         uint32_t val;
     };
 
+    /* Lowercase an ASCII uppercase letter; other bytes pass through unchanged.
+     * Header lookups pass lowercase names (`getHeader("host")`); since RFC 7230
+     * header names are case-insensitive, normalize to lowercase on add and
+     * mightHave so mixed-case keys hash to the same features. */
+    static inline unsigned char toLower(unsigned char c) {
+        return (unsigned char) (c | ((unsigned char) (c - 'A') < 26 ? 0x20 : 0));
+    }
+
     ScrambleArea getFeatures(std::string_view key) {
         ScrambleArea s;
-        s.p[0] = reinterpret_cast<const unsigned char&>(key[0]);
-        s.p[1] = reinterpret_cast<const unsigned char&>(key[key.length() - 1]);
-        s.p[2] = reinterpret_cast<const unsigned char&>(key[key.length() - 2]);
-        s.p[3] = reinterpret_cast<const unsigned char&>(key[key.length() >> 1]);
+        s.p[0] = toLower(reinterpret_cast<const unsigned char&>(key[0]));
+        s.p[1] = toLower(reinterpret_cast<const unsigned char&>(key[key.length() - 1]));
+        s.p[2] = toLower(reinterpret_cast<const unsigned char&>(key[key.length() - 2]));
+        s.p[3] = toLower(reinterpret_cast<const unsigned char&>(key[key.length() >> 1]));
         return s;
     }
 

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -227,7 +227,7 @@ namespace uWS
             {
                 for (Header *h = headers; (++h)->key.length();)
                 {
-                    if (h->key.length() == lowerCasedHeader.length() && !strncmp(h->key.data(), lowerCasedHeader.data(), lowerCasedHeader.length()))
+                    if (h->key.length() == lowerCasedHeader.length() && !strncasecmp(h->key.data(), lowerCasedHeader.data(), lowerCasedHeader.length()))
                     {
                         return h->value;
                     }
@@ -251,7 +251,7 @@ namespace uWS
             }
 
             for (Header *h = headers; (++h)->key.length();) {
-                if (h->key.length() == 17 && !strncmp(h->key.data(), "transfer-encoding", 17)) {
+                if (h->key.length() == 17 && !strncasecmp(h->key.data(), "transfer-encoding", 17)) {
                     // Parse comma-separated values, ensuring "chunked" is last if present
                     const auto value = h->value;
                     size_t pos = 0;
@@ -467,13 +467,12 @@ namespace uWS
                 | (c == '*') | (c == '!')) || ((c >= 48) & (c <= 57)) || ((c <= 39) & (c >= 35));
         }
 
-        static inline bool isFieldNameByteFastLowercased(unsigned char &in) {
+        static inline bool isFieldNameByte(unsigned char in) {
             /* Most common is lowercase alpha and hyphen */
             if (((in >= 97) & (in <= 122)) | (in == '-')) [[likely]] {
                 return true;
             /* Second is upper case alpha */
             } else if ((in >= 65) & (in <= 90)) [[unlikely]] {
-                in |= 32;
                 return true;
             /* These are rarely used but still valid */
             } else if (isUnlikelyFieldNameByte(in)) [[unlikely]] {
@@ -482,14 +481,13 @@ namespace uWS
             return false;
         }
 
+        /* Walks the field name without mutating it. The original case is
+         * preserved for req.rawHeaders (Node.js compatibility); downstream
+         * header matching is case-insensitive. */
         static inline char *consumeFieldName(char *p) {
             /* Best case fast path (particularly useful with clang) */
             while (true) {
-                while ((*p >= 65) & (*p <= 90)) [[likely]] {
-                    *p |= 32;
-                    p++;
-                }
-                while (((*p >= 97) & (*p <= 122))) [[likely]] {
+                while (((*p >= 65) & (*p <= 90)) | ((*p >= 97) & (*p <= 122))) [[likely]] {
                     p++;
                 }
                 if (*p == ':') {
@@ -497,14 +495,14 @@ namespace uWS
                 }
                 if (*p == '-') {
                     p++;
-                } else if (!((*p >= 65) & (*p <= 90))) {
+                } else {
                     /* Exit fast path parsing */
                     break;
                 }
             }
 
             /* Generic */
-            while (isFieldNameByteFastLowercased(*(unsigned char *)p)) {
+            while (isFieldNameByte(*(unsigned char *)p)) {
                 p++;
             }
             return p;
@@ -759,7 +757,7 @@ namespace uWS
             headers++;
 
             for (unsigned int i = 1; i < UWS_HTTP_MAX_HEADERS_COUNT - 1; i++) {
-                /* Lower case and consume the field name */
+                /* Consume the field name (case-preserving; downstream lookups compare case-insensitively) */
                 preliminaryKey = postPaddedBuffer;
                 postPaddedBuffer = consumeFieldName(postPaddedBuffer);
                 headers->key = std::string_view(preliminaryKey, (size_t) (postPaddedBuffer - preliminaryKey));
@@ -909,7 +907,7 @@ namespace uWS
             std::string_view contentLengthString;
             if (req->bf.mightHave("content-length")) {
                 for (HttpRequest::Header *h = req->headers; (++h)->key.length(); ) {
-                    if (h->key.length() == 14 && !strncmp(h->key.data(), "content-length", 14)) {
+                    if (h->key.length() == 14 && !strncasecmp(h->key.data(), "content-length", 14)) {
                         if (contentLengthString.data() == nullptr) {
                             if (h->value.length() == 0) {
                                 return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_INVALID_CONTENT_LENGTH);

--- a/src/js/node/_http_incoming.ts
+++ b/src/js/node/_http_incoming.ts
@@ -396,6 +396,50 @@ const IncomingMessagePrototype = {
   set trailers(value) {
     // noop
   },
+  get headersDistinct() {
+    // https://nodejs.org/api/http.html#messageheadersdistinct
+    // Parallel to `req.headers`, but every value is an array so multi-value
+    // headers (set-cookie, proxy-authenticate, ...) aren't lossy.
+    //
+    // Null-prototype is deliberate: the lookup below does `out[key]` against
+    // untrusted header names, and field-names like `constructor` or `toString`
+    // are valid RFC 9110 tokens. With `Object.prototype` those reach `Object`
+    // methods, making the `else existing.push(...)` branch throw. Node has the
+    // same hazard; we take the safer deviation.
+    const rawHeaders = this.rawHeaders;
+    const out = { __proto__: null };
+    if ($isJSArray(rawHeaders)) {
+      for (let i = 0, n = rawHeaders.length; i + 1 < n; i += 2) {
+        const key = String(rawHeaders[i]).toLowerCase();
+        const value = String(rawHeaders[i + 1]);
+        const existing = out[key];
+        if (existing === undefined) {
+          out[key] = [value];
+        } else {
+          existing.push(value);
+        }
+      }
+    }
+    // Memoize through the setter so `req.headersDistinct === req.headersDistinct`
+    // and user mutations persist across reads, matching Node's lazy-cached getter.
+    this.headersDistinct = out;
+    return out;
+  },
+  set headersDistinct(value) {
+    $Object.defineProperty(this, "headersDistinct", {
+      __proto__: null,
+      value,
+      configurable: true,
+      enumerable: true,
+      writable: true,
+    });
+  },
+  get trailersDistinct() {
+    return kEmptyObject;
+  },
+  set trailersDistinct(value) {
+    // noop
+  },
   setTimeout(msecs, callback) {
     void this.take;
     const req = this[kHandle] || this[webRequestOrResponse];

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -215,8 +215,6 @@ static void assignHeadersFromUWebSocketsForCall(uWS::HttpRequest* request, JSVal
         JSString* jsValue = jsString(vm, value);
 
         Identifier nameIdentifier;
-        // The uWS parser preserves the original case of the header name in `pair.first`.
-        // `req.rawHeaders` keeps the wire case, `req.headers` is keyed by lowercase name.
         WTF::String originalCasedNameString = nameView.toString();
         JSString* originalCasedNameJSString = jsString(vm, originalCasedNameString);
         WTF::String lowercasedName;

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -197,12 +197,13 @@ static void assignHeadersFromUWebSocketsForCall(uWS::HttpRequest* request, JSVal
     JSC::JSObject* headersObject = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), JSFinalObject::defaultInlineCapacity);
     RETURN_IF_EXCEPTION(scope, void());
     JSC::JSArray* setCookiesHeaderArray = nullptr;
-    JSC::JSString* setCookiesHeaderString = nullptr;
     MarkedArgumentBuffer arrayValues;
     HTTPHeaderIdentifiers& identifiers = WebCore::clientData(vm)->httpHeaderIdentifiers();
 
     for (auto it = request->begin(); it != request->end(); ++it) {
         auto pair = *it;
+        // The uWS parser preserves the original case of the header name in `pair.first`;
+        // `req.rawHeaders` keeps the wire case, `req.headers` is keyed lowercase.
         StringView nameView = StringView(std::span { reinterpret_cast<const Latin1Character*>(pair.first.data()), pair.first.length() });
         std::span<Latin1Character> data;
         auto value = String::createUninitialized(pair.second.length(), data);
@@ -214,7 +215,10 @@ static void assignHeadersFromUWebSocketsForCall(uWS::HttpRequest* request, JSVal
         JSString* jsValue = jsString(vm, value);
 
         Identifier nameIdentifier;
-        JSString* nameString = nullptr;
+        // The uWS parser preserves the original case of the header name in `pair.first`.
+        // `req.rawHeaders` keeps the wire case, `req.headers` is keyed by lowercase name.
+        WTF::String originalCasedNameString = nameView.toString();
+        JSString* originalCasedNameJSString = jsString(vm, originalCasedNameString);
         WTF::String lowercasedName;
         // `findHTTPHeaderName` only writes `name` when it returns true, so the
         // SetCookie check must be gated on a successful lookup rather than on the
@@ -224,13 +228,10 @@ static void assignHeadersFromUWebSocketsForCall(uWS::HttpRequest* request, JSVal
         bool isSetCookie = false;
 
         if (knownHeader) {
-            nameString = identifiers.stringFor(globalObject, name);
             nameIdentifier = identifiers.identifierFor(vm, name);
             isSetCookie = name == WebCore::HTTPHeaderName::SetCookie;
         } else {
-            WTF::String wtfString = nameView.toString();
-            nameString = jsString(vm, wtfString);
-            lowercasedName = wtfString.convertToASCIILowercase();
+            lowercasedName = originalCasedNameString.convertToASCIILowercase();
             nameIdentifier = Identifier::fromString(vm, lowercasedName);
         }
 
@@ -238,11 +239,10 @@ static void assignHeadersFromUWebSocketsForCall(uWS::HttpRequest* request, JSVal
             if (!setCookiesHeaderArray) {
                 setCookiesHeaderArray = constructEmptyArray(globalObject, nullptr);
                 RETURN_IF_EXCEPTION(scope, );
-                setCookiesHeaderString = nameString;
                 headersObject->putDirect(vm, nameIdentifier, setCookiesHeaderArray, 0);
                 RETURN_IF_EXCEPTION(scope, void());
             }
-            arrayValues.append(setCookiesHeaderString);
+            arrayValues.append(originalCasedNameJSString);
             arrayValues.append(jsValue);
             setCookiesHeaderArray->push(globalObject, jsValue);
             RETURN_IF_EXCEPTION(scope, void());
@@ -280,7 +280,7 @@ static void assignHeadersFromUWebSocketsForCall(uWS::HttpRequest* request, JSVal
                 }
             }
             RETURN_IF_EXCEPTION(scope, void());
-            arrayValues.append(nameString);
+            arrayValues.append(originalCasedNameJSString);
             arrayValues.append(jsValue);
             RETURN_IF_EXCEPTION(scope, void());
         }
@@ -419,12 +419,14 @@ static EncodedJSValue assignHeadersFromUWebSockets(uWS::HttpRequest* request, JS
     JSC::JSArray* array = constructEmptyArray(globalObject, nullptr, size * 2);
     RETURN_IF_EXCEPTION(scope, {});
     JSC::JSArray* setCookiesHeaderArray = nullptr;
-    JSC::JSString* setCookiesHeaderString = nullptr;
 
     unsigned i = 0;
 
     for (auto it = request->begin(); it != request->end(); ++it) {
         auto pair = *it;
+        // The uWS parser preserves the original case of the header name in `pair.first`.
+        // `req.rawHeaders` is specified (Node docs) to preserve the on-the-wire case, while
+        // `req.headers` is keyed by lowercase name.
         StringView nameView = StringView(std::span { reinterpret_cast<const Latin1Character*>(pair.first.data()), pair.first.length() });
         std::span<Latin1Character> data;
         auto value = String::tryCreateUninitialized(pair.second.length(), data);
@@ -436,18 +438,16 @@ static EncodedJSValue assignHeadersFromUWebSockets(uWS::HttpRequest* request, JS
             memcpy(data.data(), pair.second.data(), pair.second.length());
 
         HTTPHeaderName name;
-        WTF::String nameString;
+        WTF::String originalCasedNameString = nameView.toString();
         WTF::String lowercasedNameString;
         bool knownHeader = WebCore::findHTTPHeaderName(nameView, name);
         bool isSetCookie = false;
 
         if (knownHeader) {
-            nameString = WTF::httpHeaderNameStringImpl(name);
-            lowercasedNameString = nameString;
+            lowercasedNameString = WTF::httpHeaderNameStringImpl(name);
             isSetCookie = name == WebCore::HTTPHeaderName::SetCookie;
         } else {
-            nameString = nameView.toString();
-            lowercasedNameString = nameString.convertToASCIILowercase();
+            lowercasedNameString = originalCasedNameString.convertToASCIILowercase();
         }
 
         JSString* jsValue = jsString(vm, value);
@@ -456,11 +456,10 @@ static EncodedJSValue assignHeadersFromUWebSockets(uWS::HttpRequest* request, JS
             if (!setCookiesHeaderArray) {
                 setCookiesHeaderArray = constructEmptyArray(globalObject, nullptr);
                 RETURN_IF_EXCEPTION(scope, {});
-                setCookiesHeaderString = jsString(vm, nameString);
                 headersObject->putDirect(vm, Identifier::fromString(vm, lowercasedNameString), setCookiesHeaderArray, 0);
                 RETURN_IF_EXCEPTION(scope, {});
             }
-            array->putDirectIndex(globalObject, i++, setCookiesHeaderString);
+            array->putDirectIndex(globalObject, i++, jsString(vm, originalCasedNameString));
             array->putDirectIndex(globalObject, i++, jsValue);
             setCookiesHeaderArray->push(globalObject, jsValue);
             RETURN_IF_EXCEPTION(scope, {});
@@ -499,7 +498,8 @@ static EncodedJSValue assignHeadersFromUWebSockets(uWS::HttpRequest* request, JS
                 }
             }
             RETURN_IF_EXCEPTION(scope, {});
-            array->putDirectIndex(globalObject, i++, jsString(vm, nameString));
+            // rawHeaders keeps the original wire case of the name.
+            array->putDirectIndex(globalObject, i++, jsString(vm, originalCasedNameString));
             array->putDirectIndex(globalObject, i++, jsValue);
             RETURN_IF_EXCEPTION(scope, {});
         }

--- a/test/js/node/http/node-http-incoming-headers.test.ts
+++ b/test/js/node/http/node-http-incoming-headers.test.ts
@@ -1,0 +1,114 @@
+// node:http IncomingMessage header-view coverage:
+//   - rawHeaders preserves the on-the-wire case of header names (Node docs:
+//     "Header names are not lowercased, and duplicates are not merged").
+//   - headersDistinct is a per-lowercase-name array dictionary parallel to
+//     `headers`, lazily cached on first access.
+//
+// https://github.com/oven-sh/bun/issues/31318 (and #20433 / #24268)
+import { describe, expect, it } from "bun:test";
+import * as http from "node:http";
+import * as net from "node:net";
+
+describe("IncomingMessage header views", () => {
+  async function receiveRequest(payload: string) {
+    const { promise, resolve, reject } = Promise.withResolvers<http.IncomingMessage>();
+    const server = http.createServer(req => {
+      resolve(req);
+      // Don't respond — the test only inspects headers and ends the socket itself
+      // so the server can be closed cleanly.
+    });
+    server.on("clientError", () => {});
+    await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
+    try {
+      const port = (server.address() as net.AddressInfo).port;
+      const client = net.connect(port, "127.0.0.1", () => {
+        client.write(payload);
+      });
+      client.on("error", reject);
+      client.on("data", () => {});
+      const req = await promise;
+      client.destroy();
+      return req;
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  }
+
+  it("rawHeaders preserves the on-the-wire case", async () => {
+    const req = await receiveRequest(
+      "GET / HTTP/1.1\r\n" +
+        "Host: x\r\n" +
+        "X-Mixed-CASE: alpha\r\n" +
+        "x-LOWER-mixed: beta\r\n" +
+        "Connection: close\r\n\r\n",
+    );
+
+    expect(req.rawHeaders).toEqual([
+      "Host",
+      "x",
+      "X-Mixed-CASE",
+      "alpha",
+      "x-LOWER-mixed",
+      "beta",
+      "Connection",
+      "close",
+    ]);
+    expect(req.headers).toEqual({
+      host: "x",
+      "x-mixed-case": "alpha",
+      "x-lower-mixed": "beta",
+      connection: "close",
+    });
+  });
+
+  it("headersDistinct groups every value by lowercase name", async () => {
+    const req = await receiveRequest(
+      "GET / HTTP/1.1\r\n" +
+        "Host: x\r\n" +
+        "Set-Cookie: a=1\r\n" +
+        "set-COOKIE: b=2\r\n" +
+        "X-Dup: one\r\n" +
+        "X-Dup: two\r\n" +
+        "Connection: close\r\n\r\n",
+    );
+
+    // Every occurrence keeps its original case, in arrival order.
+    expect(req.rawHeaders).toEqual([
+      "Host",
+      "x",
+      "Set-Cookie",
+      "a=1",
+      "set-COOKIE",
+      "b=2",
+      "X-Dup",
+      "one",
+      "X-Dup",
+      "two",
+      "Connection",
+      "close",
+    ]);
+
+    expect((req as any).headersDistinct).toEqual({
+      host: ["x"],
+      "set-cookie": ["a=1", "b=2"],
+      "x-dup": ["one", "two"],
+      connection: ["close"],
+    });
+
+    // set-cookie remains an array in `req.headers` regardless of incoming case.
+    expect(req.headers["set-cookie"]).toEqual(["a=1", "b=2"]);
+  });
+
+  it("headersDistinct is lazily cached on first access (identity + mutation persistence)", async () => {
+    const req = await receiveRequest(
+      "GET / HTTP/1.1\r\n" + "Host: x\r\n" + "X-Foo: bar\r\n" + "Connection: close\r\n\r\n",
+    );
+
+    const a = (req as any).headersDistinct;
+    const b = (req as any).headersDistinct;
+    expect(a).toBe(b); // identity-equal, matches Node's cached behavior.
+
+    a["x-added"] = ["baz"];
+    expect((req as any).headersDistinct["x-added"]).toEqual(["baz"]);
+  });
+});


### PR DESCRIPTION
Fixes #31318. Also fixes #20433 (same root cause, re-filed with a server-side repro) and #24268 (`req.headersDistinct` missing).

## Findings

1. `req.rawHeaders` was returning lowercased names. Node docs: *"Header names are not lowercased, and duplicates are not merged."*
2. `req.headersDistinct` was `undefined`.

## Repro (server-side, raw socket — bypasses any client lowercasing)

```js
const http = require('node:http'), net = require('node:net');
http.createServer((req, res) => {
  console.log('rawHeaders:', JSON.stringify(req.rawHeaders));
  console.log('headersDistinct:', JSON.stringify(req.headersDistinct));
  res.end();
}).listen(0, function () {
  const s = net.connect(this.address().port, '127.0.0.1', () => s.write(
    'GET / HTTP/1.1\r\nHost: x\r\nX-Mixed-CASE: alpha\r\nConnection: close\r\n\r\n'));
  s.on('end', () => this.close()).on('data', () => {});
});
```

Before:
```
rawHeaders: ["host","x","x-mixed-case","alpha","connection","close"]
headersDistinct: undefined
```

After (matches Node 24):
```
rawHeaders: ["Host","x","X-Mixed-CASE","alpha","Connection","close"]
headersDistinct: {"host":["x"],"x-mixed-case":["alpha"],"connection":["close"]}
```

## Root cause

`packages/bun-uws/src/HttpParser.h`'s `consumeFieldName` lowercased field-name bytes in place during parse (`*p |= 32`). By the time `assignHeadersFromUWebSockets` read them via `request->begin()`, the original case was gone, and the same already-lowercased bytes got pushed into `rawHeaders`.

`headersDistinct` was simply not implemented.

## Fix

- **`packages/bun-uws/src/HttpParser.h`** — `consumeFieldName` now walks the field name without mutating it. Downstream matchers that previously relied on lowercased bytes are switched to case-insensitive compares: `HttpRequest::getHeader`, the transfer-encoding / content-length scans, and the BloomFilter (lowercase-normalize on add and `mightHave` so mixed-case keys hash to the same features).
- **`src/jsc/bindings/NodeHTTP.cpp`** — `assignHeadersFromUWebSockets` and `assignHeadersFromUWebSocketsForCall` push the original-case name into the `rawHeaders` array and continue to key `req.headers` by the lowercase canonical form (`WTF::httpHeaderNameStringImpl` for known names, `convertToASCIILowercase()` for the rest).
- **`src/js/node/_http_incoming.ts`** — add lazy `headersDistinct` / `trailersDistinct` getters that re-group `rawHeaders` into a per-lowercase-name array dictionary, matching the Node docs.

## Verification

Regression test: `test/regression/issue/31318.test.ts` covers both findings, including mixed-case `Set-Cookie` duplication and arbitrary-name duplicates.

Node.js-compat HTTP tests (`test/js/node/http/`) still pass modulo pre-existing failures unrelated to this diff (network-dependent proxy and IPv6 tests fail the same way on the baked bun). Transfer-Encoding / Content-Length smuggling tests in `node-http.test.ts` all pass — these exercise the new case-insensitive lookup path.

Related: #27234 adds `headersDistinct` but not the rawHeaders case fix; this PR supersedes it for #31318.