### PR TITLE
Emit multi-value response headers as separate wire lines

### DIFF
--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -46,14 +46,23 @@ static EncodedJSValue assignHeadersFromFetchHeaders(FetchHeaders& impl, JSObject
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
     uint32_t size = std::min(impl.sizeAfterJoiningSetCookieHeader(), static_cast<uint32_t>(JSFinalObject::maxInlineCapacity));
-    JSC::JSArray* array = constructEmptyArray(globalObject, nullptr, impl.size() * 2);
+    auto& internal = impl.internalHeaders();
+    const auto& extraCommon = internal.extraCommonHeaders();
+    const auto& extraUncommon = internal.extraUncommonHeaders();
+    bool hasCommonExtras = !extraCommon.isEmpty();
+    bool hasUncommonExtras = !extraUncommon.isEmpty();
+    // Upper bound — primaries whose name also has side-channel entries are
+    // skipped below (the extras pass emits every individual value for those
+    // names instead). The actual final length is set with `setLength` after
+    // the writes, so any over-allocation here doesn't leave trailing
+    // `undefined` holes in `rawHeaders`.
+    JSC::JSArray* array = constructEmptyArray(globalObject, nullptr, (impl.size() + extraCommon.size() + extraUncommon.size()) * 2);
     RETURN_IF_EXCEPTION(scope, {});
     JSC::JSObject* obj = JSC::constructEmptyObject(globalObject, prototype, size);
     RETURN_IF_EXCEPTION(scope, {});
 
     unsigned arrayI = 0;
 
-    auto& internal = impl.internalHeaders();
     {
         auto& vec = internal.commonHeaders();
         for (const auto& it : vec) {
@@ -61,7 +70,24 @@ static EncodedJSValue assignHeadersFromFetchHeaders(FetchHeaders& impl, JSObject
             const auto& value = it.value;
             const auto impl = WTF::httpHeaderNameStringImpl(name);
             JSString* jsValue = jsString(vm, value);
+            // `obj` always carries the joined primary — matches Node's
+            // `req.headers[name]` behavior for list headers.
             obj->putDirect(vm, Identifier::fromString(vm, impl), jsValue, 0);
+
+            // Skip the joined primary in `rawHeaders` if the side-channel
+            // will emit each individual value below.
+            if (hasCommonExtras) {
+                bool hasExtras = false;
+                for (auto& extra : extraCommon) {
+                    if (extra.key == name) {
+                        hasExtras = true;
+                        break;
+                    }
+                }
+                if (hasExtras)
+                    continue;
+            }
+
             array->putDirectIndex(globalObject, arrayI++, jsString(vm, impl));
             array->putDirectIndex(globalObject, arrayI++, jsValue);
             RETURN_IF_EXCEPTION(scope, {});
@@ -100,9 +126,45 @@ static EncodedJSValue assignHeadersFromFetchHeaders(FetchHeaders& impl, JSObject
             const auto& value = it.value;
             auto* jsValue = jsString(vm, value);
             obj->putDirect(vm, Identifier::fromString(vm, name.convertToASCIILowercase()), jsValue, 0);
+
+            if (hasUncommonExtras) {
+                bool hasExtras = false;
+                for (auto& extra : extraUncommon) {
+                    if (equalIgnoringASCIICase(extra.key, name)) {
+                        hasExtras = true;
+                        break;
+                    }
+                }
+                if (hasExtras)
+                    continue;
+            }
+
             array->putDirectIndex(globalObject, arrayI++, jsString(vm, name));
             array->putDirectIndex(globalObject, arrayI++, jsValue);
         }
+    }
+
+    // Multi-value headers — emit one `[name, value]` pair per individual
+    // value. `obj` already carries the joined value from the primary pass.
+    for (const auto& it : extraCommon) {
+        const auto& impl = WTF::httpHeaderNameStringImpl(it.key);
+        array->putDirectIndex(globalObject, arrayI++, jsString(vm, impl));
+        array->putDirectIndex(globalObject, arrayI++, jsString(vm, it.value));
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+    for (const auto& it : extraUncommon) {
+        array->putDirectIndex(globalObject, arrayI++, jsString(vm, it.key));
+        array->putDirectIndex(globalObject, arrayI++, jsString(vm, it.value));
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
+    // Trim the upper-bound allocation down to the actual number of slots
+    // written — `constructEmptyArray` sets `.length` eagerly, so primaries
+    // skipped by the side-channel pass would otherwise leave trailing
+    // `undefined` holes.
+    if (arrayI < array->length()) {
+        array->setLength(globalObject, arrayI);
+        RETURN_IF_EXCEPTION(scope, {});
     }
 
     tuple->putInternalField(vm, 0, obj);
@@ -616,6 +678,10 @@ template<bool isSSL>
 static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::HttpResponse<isSSL>* res)
 {
     auto& internalHeaders = headers.internalHeaders();
+    const auto& extraCommon = internalHeaders.extraCommonHeaders();
+    const auto& extraUncommon = internalHeaders.extraUncommonHeaders();
+    bool hasCommonExtras = !extraCommon.isEmpty();
+    bool hasUncommonExtras = !extraUncommon.isEmpty();
 
     for (auto& value : internalHeaders.getSetCookieHeaders()) {
 
@@ -633,7 +699,6 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
     for (const auto& header : internalHeaders.commonHeaders()) {
 
         const auto& name = WebCore::httpHeaderNameString(header.key);
-        const auto& value = header.value;
 
         // We have to tell uWS not to automatically insert a TransferEncoding or Date header.
         // Otherwise, you get this when using Fastify;
@@ -674,17 +739,52 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
         // close the connection after the response. Mark the uWS state so
         // end()/tryEnd() shut the socket down instead of returning it to the
         // keep-alive pool.
-        if (header.key == WebCore::HTTPHeaderName::Connection && connectionValueHasClose(value)) {
+        if (header.key == WebCore::HTTPHeaderName::Connection && connectionValueHasClose(header.value)) {
             data->state |= uWS::HttpResponseData<isSSL>::HTTP_CONNECTION_CLOSE;
         }
-        writeResponseHeader<isSSL>(res, name, value);
+
+        // If the side-channel has entries for this name, skip the joined
+        // primary — the extras pass below emits one header line per
+        // individual value (RFC 7230 §3.2.2).
+        if (hasCommonExtras) {
+            bool hasExtras = false;
+            for (auto& extra : extraCommon) {
+                if (extra.key == header.key) {
+                    hasExtras = true;
+                    break;
+                }
+            }
+            if (hasExtras)
+                continue;
+        }
+
+        writeResponseHeader<isSSL>(res, name, header.value);
     }
 
     for (auto& header : internalHeaders.uncommonHeaders()) {
-        const auto& name = header.key;
-        const auto& value = header.value;
+        if (hasUncommonExtras) {
+            bool hasExtras = false;
+            for (auto& extra : extraUncommon) {
+                if (equalIgnoringASCIICase(extra.key, header.key)) {
+                    hasExtras = true;
+                    break;
+                }
+            }
+            if (hasExtras)
+                continue;
+        }
 
-        writeResponseHeader<isSSL>(res, name, value);
+        writeResponseHeader<isSSL>(res, header.key, header.value);
+    }
+
+    // Multi-value headers — one wire line per individual value. The primary's
+    // original first value was seeded into extras in `appendToHeaderMap` when
+    // the 2nd value arrived, so this loop covers every occurrence.
+    for (auto& header : extraCommon) {
+        writeResponseHeader<isSSL>(res, WebCore::httpHeaderNameString(header.key), header.value);
+    }
+    for (auto& header : extraUncommon) {
+        writeResponseHeader<isSSL>(res, header.key, header.value);
     }
 }
 
@@ -1255,6 +1355,11 @@ static void writeFetchHeadersToH3Response(WebCore::FetchHeaders& headers, uWS::H
         }
     }
 
+    const auto& extraCommon = internalHeaders.extraCommonHeaders();
+    const auto& extraUncommon = internalHeaders.extraUncommonHeaders();
+    bool hasCommonExtras = !extraCommon.isEmpty();
+    bool hasUncommonExtras = !extraUncommon.isEmpty();
+
     for (const auto& header : internalHeaders.commonHeaders()) {
         if (header.key == WebCore::HTTPHeaderName::ContentLength) {
             if (!(data->state & uWS::Http3ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER)) {
@@ -1267,10 +1372,42 @@ static void writeFetchHeadersToH3Response(WebCore::FetchHeaders& headers, uWS::H
         }
         // HTTP/3 has no Transfer-Encoding; if a user header reaches here it
         // was already stripped by doWriteHeaders().
+
+        if (hasCommonExtras) {
+            bool hasExtras = false;
+            for (auto& extra : extraCommon) {
+                if (extra.key == header.key) {
+                    hasExtras = true;
+                    break;
+                }
+            }
+            if (hasExtras)
+                continue;
+        }
+
         writeOne(WebCore::httpHeaderNameString(header.key), header.value);
     }
 
     for (auto& header : internalHeaders.uncommonHeaders()) {
+        if (hasUncommonExtras) {
+            bool hasExtras = false;
+            for (auto& extra : extraUncommon) {
+                if (equalIgnoringASCIICase(extra.key, header.key)) {
+                    hasExtras = true;
+                    break;
+                }
+            }
+            if (hasExtras)
+                continue;
+        }
+
+        writeOne(header.key, header.value);
+    }
+
+    for (auto& header : extraCommon) {
+        writeOne(WebCore::httpHeaderNameString(header.key), header.value);
+    }
+    for (auto& header : extraUncommon) {
         writeOne(header.key, header.value);
     }
 }

--- a/src/jsc/bindings/webcore/FetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/FetchHeaders.cpp
@@ -103,13 +103,18 @@ static ExceptionOr<void> appendToHeaderMap(const String& name, const String& val
     if (findHTTPHeaderName(name, headerName)) {
         auto index = headers.indexOf(headerName);
 
+        String existingPrimary;
         if (headerName != HTTPHeaderName::SetCookie) {
             if (index.isValid()) {
-                auto existing = headers.getIndex(index);
+                // Capture the existing primary BEFORE building the joined
+                // replacement — the wire-write side-channel needs it as the
+                // first individual value when this append is the 2nd for this
+                // name.
+                existingPrimary = headers.getIndex(index);
                 if (headerName == HTTPHeaderName::Cookie) {
-                    combinedTemp = makeString(existing, "; "_s, normalizedValue);
+                    combinedTemp = makeString(existingPrimary, "; "_s, normalizedValue);
                 } else {
-                    combinedTemp = makeString(existing, ", "_s, normalizedValue);
+                    combinedTemp = makeString(existingPrimary, ", "_s, normalizedValue);
                 }
                 valueToSet = &combinedTemp;
             }
@@ -122,18 +127,48 @@ static ExceptionOr<void> appendToHeaderMap(const String& name, const String& val
         if (!canWriteResult.releaseReturnValue())
             return {};
 
-        if (headerName != HTTPHeaderName::SetCookie) {
-            if (!headers.setIndex(index, *valueToSet))
-                headers.set(headerName, *valueToSet);
-        } else {
+        if (headerName == HTTPHeaderName::SetCookie) {
             headers.add(headerName, normalizedValue);
+            return {};
+        }
+
+        // Primary holds the joined value. This preserves the `fastGet`
+        // contract — a `ZigString` returned across the FFI borrows the
+        // primary `StringImpl` directly, so the primary MUST be an owned
+        // reference into `m_commonHeaders` / `m_uncommonHeaders` (see
+        // `WebCore__FetchHeaders__fastGet_`), not a freshly-built temporary.
+        if (!headers.setIndex(index, *valueToSet))
+            headers.set(headerName, *valueToSet);
+
+        // Side-channel the individual values for the wire-write path so
+        // multi-value headers (e.g. repeated `X-Multi`) produce one wire line
+        // per value (RFC 7230 §3.2.2) instead of a single joined line.
+        // `Cookie` is a combine-with-`"; "` header (RFC 6265 §5.4), not a
+        // list header — keep it as a joined primary only.
+        if (headerName != HTTPHeaderName::Cookie && index.isValid()) {
+            // Seed the side-channel with the original primary the first time
+            // a duplicate arrives for this name, then push this append's
+            // value. Subsequent appends just push the new value.
+            bool alreadySeeded = false;
+            for (auto& extra : headers.extraCommonHeaders()) {
+                if (extra.key == headerName) {
+                    alreadySeeded = true;
+                    break;
+                }
+            }
+            if (!alreadySeeded)
+                headers.appendExtra(headerName, existingPrimary);
+            headers.appendExtra(headerName, normalizedValue);
         }
 
         return {};
     }
+
     auto index = headers.indexOf(name);
+    String existingPrimary;
     if (index.isValid()) {
-        combinedTemp = makeString(headers.getIndex(index), ", "_s, normalizedValue);
+        existingPrimary = headers.getIndex(index);
+        combinedTemp = makeString(existingPrimary, ", "_s, normalizedValue);
         valueToSet = &combinedTemp;
     }
     auto canWriteResult = canWriteHeader(name, normalizedValue, *valueToSet, guard);
@@ -144,6 +179,19 @@ static ExceptionOr<void> appendToHeaderMap(const String& name, const String& val
 
     if (!headers.setIndex(index, *valueToSet))
         headers.set(name, *valueToSet);
+
+    if (index.isValid()) {
+        bool alreadySeeded = false;
+        for (auto& extra : headers.extraUncommonHeaders()) {
+            if (equalIgnoringASCIICase(extra.key, name)) {
+                alreadySeeded = true;
+                break;
+            }
+        }
+        if (!alreadySeeded)
+            headers.appendExtra(name, existingPrimary);
+        headers.appendExtra(name, normalizedValue);
+    }
 
     // if (guard == FetchHeaders::Guard::RequestNoCors)
     //     removePrivilegedNoCORSRequestHeaders(headers);
@@ -217,11 +265,21 @@ ExceptionOr<void> FetchHeaders::fill(const FetchHeaders& otherHeaders)
         headers.commonHeaders().appendVector(otherHeaders.m_headers.commonHeaders());
         headers.uncommonHeaders().appendVector(otherHeaders.m_headers.uncommonHeaders());
         headers.getSetCookieHeaders().appendVector(otherHeaders.m_headers.getSetCookieHeaders());
+        headers.extraCommonHeaders().appendVector(otherHeaders.m_headers.extraCommonHeaders());
+        headers.extraUncommonHeaders().appendVector(otherHeaders.m_headers.extraUncommonHeaders());
         setInternalHeaders(WTF::move(headers));
         m_updateCounter++;
         return {};
     }
 
+    // Non-empty target path: iterate the source's primaries and route each
+    // through `appendToHeaderMap`, which preserves WHATWG `Headers.append`
+    // semantics against whatever is already in `m_headers`. The iterator
+    // yields one entry per primary slot, so the source's joined primary is
+    // re-appended (correct WHATWG behavior — two clones of the same source
+    // merge into one joined value). Current Bun callers only hit this branch
+    // via `FetchHeaders::clone` / `cloneThis`, both of which always call with
+    // an empty target and take the fast path above.
     for (auto& header : otherHeaders.m_headers) {
         auto result = appendToHeaderMap(header, m_headers, m_guard);
         if (result.hasException())

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
@@ -86,6 +86,8 @@ HTTPHeaderMap HTTPHeaderMap::isolatedCopy() const&
     map.m_commonHeaders = crossThreadCopy(m_commonHeaders);
     map.m_uncommonHeaders = crossThreadCopy(m_uncommonHeaders);
     map.m_setCookieHeaders = crossThreadCopy(m_setCookieHeaders);
+    map.m_extraCommonHeaders = crossThreadCopy(m_extraCommonHeaders);
+    map.m_extraUncommonHeaders = crossThreadCopy(m_extraUncommonHeaders);
     return map;
 }
 
@@ -95,6 +97,8 @@ HTTPHeaderMap HTTPHeaderMap::isolatedCopy() &&
     map.m_commonHeaders = crossThreadCopy(WTF::move(m_commonHeaders));
     map.m_uncommonHeaders = crossThreadCopy(WTF::move(m_uncommonHeaders));
     map.m_setCookieHeaders = crossThreadCopy(WTF::move(m_setCookieHeaders));
+    map.m_extraCommonHeaders = crossThreadCopy(WTF::move(m_extraCommonHeaders));
+    map.m_extraUncommonHeaders = crossThreadCopy(WTF::move(m_extraUncommonHeaders));
     return map;
 }
 
@@ -112,6 +116,8 @@ size_t HTTPHeaderMap::memoryCost() const
     size_t cost = m_commonHeaders.size() * sizeof(CommonHeader);
     cost += m_uncommonHeaders.size() * sizeof(UncommonHeader);
     cost += m_setCookieHeaders.size() * sizeof(String);
+    cost += m_extraCommonHeaders.size() * sizeof(CommonHeader);
+    cost += m_extraUncommonHeaders.size() * sizeof(UncommonHeader);
     for (auto& header : m_commonHeaders)
         cost += header.value.sizeInBytes();
 
@@ -123,6 +129,14 @@ size_t HTTPHeaderMap::memoryCost() const
     for (auto& header : m_setCookieHeaders)
         cost += header.sizeInBytes();
 
+    for (auto& header : m_extraCommonHeaders)
+        cost += header.value.sizeInBytes();
+
+    for (auto& header : m_extraUncommonHeaders) {
+        cost += header.key.sizeInBytes();
+        cost += header.value.sizeInBytes();
+    }
+
     return cost;
 }
 
@@ -131,6 +145,13 @@ String HTTPHeaderMap::getUncommonHeader(const StringView name) const
     auto index = m_uncommonHeaders.findIf([&](auto& header) {
         return equalIgnoringASCIICase(header.key, name);
     });
+    // The primary slot already holds the `", "`-joined value for multi-value
+    // headers (see `appendToHeaderMap` in `FetchHeaders.cpp`); the side-channel
+    // `m_extraUncommonHeaders` only carries individual values for the
+    // wire-write path, so no additional join is needed here. Keeping this a
+    // direct map-owned reference is load-bearing for `fastGet` across the FFI
+    // (`WebCore__FetchHeaders__fastGet_` hands back a ZigString that borrows
+    // the returned `String`'s `StringImpl`).
     return index != notFound ? m_uncommonHeaders[index].value : String();
 }
 
@@ -168,6 +189,12 @@ void HTTPHeaderMap::set(const String& name, const String& value)
 
 void HTTPHeaderMap::setUncommonHeader(const String& name, const String& value)
 {
+    // `set` overwrites; any extra duplicates for this name must also be dropped
+    // so a subsequent `get` doesn't surface stale appended values.
+    m_extraUncommonHeaders.removeAllMatching([&](auto& header) {
+        return equalIgnoringASCIICase(header.key, name);
+    });
+
     auto index = m_uncommonHeaders.findIf([&](auto& header) {
         return equalIgnoringASCIICase(header.key, name);
     });
@@ -190,6 +217,10 @@ void HTTPHeaderMap::addUncommonHeader(const String& name, const String& value)
 
 void HTTPHeaderMap::addUncommonHeaderCloneName(const StringView name, const String& value)
 {
+    m_extraUncommonHeaders.removeAllMatching([&](auto& header) {
+        return equalIgnoringASCIICase(header.key, name);
+    });
+
     auto index = m_uncommonHeaders.findIf([&](auto& header) {
         return equalIgnoringASCIICase(header.key, name);
     });
@@ -270,9 +301,16 @@ bool HTTPHeaderMap::removeUncommonHeader(const StringView name)
     ASSERT(!findHTTPHeaderName(name, headerName));
 #endif
 
-    return m_uncommonHeaders.removeFirstMatching([&](auto& header) {
+    bool removedExtras = false;
+    if (!m_extraUncommonHeaders.isEmpty()) {
+        removedExtras = m_extraUncommonHeaders.removeAllMatching([&](auto& header) {
+            return equalIgnoringASCIICase(header.key, name);
+        }) > 0;
+    }
+    bool removedPrimary = m_uncommonHeaders.removeFirstMatching([&](auto& header) {
         return equalIgnoringASCIICase(header.key, name);
     });
+    return removedPrimary || removedExtras;
 }
 
 String HTTPHeaderMap::get(HTTPHeaderName name) const
@@ -300,6 +338,8 @@ String HTTPHeaderMap::get(HTTPHeaderName name) const
     auto index = m_commonHeaders.findIf([&](auto& header) {
         return header.key == name;
     });
+    // The primary already holds the `", "`-joined value for multi-value
+    // headers — see `getUncommonHeader` for the full reasoning.
     return index != notFound ? m_commonHeaders[index].value : String();
 }
 
@@ -333,6 +373,14 @@ void HTTPHeaderMap::set(HTTPHeaderName name, const String& value)
         m_setCookieHeaders.clear();
         m_setCookieHeaders.append(value);
         return;
+    }
+
+    // `set` overwrites; any extra duplicates for this name must also be dropped
+    // so a subsequent `get` doesn't surface stale appended values.
+    if (!m_extraCommonHeaders.isEmpty()) {
+        m_extraCommonHeaders.removeAllMatching([&](auto& header) {
+            return header.key == name;
+        });
     }
 
     auto index = m_commonHeaders.findIf([&](auto& header) {
@@ -375,9 +423,16 @@ bool HTTPHeaderMap::remove(HTTPHeaderName name)
         return any;
     }
 
-    return m_commonHeaders.removeFirstMatching([&](auto& header) {
+    bool removedExtras = false;
+    if (!m_extraCommonHeaders.isEmpty()) {
+        removedExtras = m_extraCommonHeaders.removeAllMatching([&](auto& header) {
+            return header.key == name;
+        }) > 0;
+    }
+    bool removedPrimary = m_commonHeaders.removeFirstMatching([&](auto& header) {
         return header.key == name;
     });
+    return removedPrimary || removedExtras;
 }
 
 void HTTPHeaderMap::add(HTTPHeaderName name, const String& value)
@@ -394,6 +449,31 @@ void HTTPHeaderMap::add(HTTPHeaderName name, const String& value)
         m_commonHeaders[index].value = makeString(m_commonHeaders[index].value, name == HTTPHeaderName::Cookie ? "; "_s : ", "_s, value);
     else
         m_commonHeaders.append(CommonHeader { name, value });
+}
+
+void HTTPHeaderMap::appendExtra(HTTPHeaderName name, const String& value)
+{
+    // `Set-Cookie` already has its own multi-value vector; route there to keep
+    // every other consumer (wire write, `getSetCookie()`, iterator) working as
+    // before.
+    if (name == HTTPHeaderName::SetCookie) {
+        m_setCookieHeaders.append(value);
+        return;
+    }
+    m_extraCommonHeaders.append(CommonHeader { name, value });
+}
+
+void HTTPHeaderMap::appendExtra(const String& name, const String& value)
+{
+    // Route known names through the enum overload so `Set-Cookie` and other
+    // built-in headers land in the right bucket even if a caller reaches this
+    // overload with a string form.
+    HTTPHeaderName headerName;
+    if (findHTTPHeaderName(name, headerName)) {
+        appendExtra(headerName, value);
+        return;
+    }
+    m_extraUncommonHeaders.append(UncommonHeader { name, value });
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.h
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.h
@@ -76,6 +76,12 @@ public:
 
     typedef Vector<CommonHeader, 2, CrashOnOverflow, 6> CommonHeadersVector;
     typedef Vector<UncommonHeader, 0, CrashOnOverflow, 0> UncommonHeadersVector;
+    // Extras vectors skip the inline-capacity-of-2 reservation that
+    // `CommonHeadersVector` uses for the primary hot path — multi-value
+    // duplicates are rare, so every `HTTPHeaderMap` (embedded in every
+    // `Headers`/`Request`/`Response`) shouldn't eat ~32 bytes of inline
+    // storage for entries that almost never exist.
+    typedef Vector<CommonHeader, 0, CrashOnOverflow, 0> ExtraCommonHeadersVector;
 
     class HTTPHeaderMapConstIterator {
     public:
@@ -174,19 +180,29 @@ public:
     WEBCORE_EXPORT HTTPHeaderMap isolatedCopy() const &;
     WEBCORE_EXPORT HTTPHeaderMap isolatedCopy() &&;
 
-    bool isEmpty() const { return m_commonHeaders.isEmpty() && m_uncommonHeaders.isEmpty() && m_setCookieHeaders.isEmpty(); }
+    bool isEmpty() const { return m_commonHeaders.isEmpty() && m_uncommonHeaders.isEmpty() && m_setCookieHeaders.isEmpty() && m_extraCommonHeaders.isEmpty() && m_extraUncommonHeaders.isEmpty(); }
+    // Counts only the primary slots (one per unique name, plus each `Set-Cookie`).
+    // The primary already holds the `", "`-joined value for multi-value headers,
+    // so callers using `size()` for `fastGet`-style unique-name iteration
+    // (JS `Headers.count`, FFI row allocators) don't see the side channel.
     int size() const { return m_commonHeaders.size() + m_uncommonHeaders.size() + m_setCookieHeaders.size(); }
 
     void clear()
     {
         m_commonHeaders.clear();
         m_uncommonHeaders.clear();
+        m_setCookieHeaders.clear();
+        m_extraCommonHeaders.clear();
+        m_extraUncommonHeaders.clear();
     }
 
     void shrinkToFit()
     {
         m_commonHeaders.shrinkToFit();
         m_uncommonHeaders.shrinkToFit();
+        m_setCookieHeaders.shrinkToFit();
+        m_extraCommonHeaders.shrinkToFit();
+        m_extraUncommonHeaders.shrinkToFit();
     }
 
     WEBCORE_EXPORT String get(const StringView name) const;
@@ -236,12 +252,37 @@ public:
     UncommonHeadersVector &uncommonHeaders() { return m_uncommonHeaders; }
     Vector<String, 0> &getSetCookieHeaders() { return m_setCookieHeaders; }
 
+    // Extra duplicate values for non-`Set-Cookie` header names. The first value for a
+    // given name lives in `m_commonHeaders` / `m_uncommonHeaders`; any subsequent
+    // values appended with the same name land here so they survive to the wire as
+    // separate header lines (RFC 7230 §3.2.2) without collapsing the WHATWG
+    // `Headers.get()` contract (which still returns the `", "`-joined string).
+    //
+    // Mirrors the primary split: known enum names go into `m_extraCommonHeaders`,
+    // unknown strings into `m_extraUncommonHeaders`. Consumers pick the
+    // canonicalization they want from `HTTPHeaderName` (`httpHeaderNameString`,
+    // `httpHeaderNameStringImpl`, or `httpHeaderNameDefaultCaseStringImpl`) for
+    // the common extras, mirroring how they canonicalize the primary slot.
+    const ExtraCommonHeadersVector &extraCommonHeaders() const { return m_extraCommonHeaders; }
+    ExtraCommonHeadersVector &extraCommonHeaders() { return m_extraCommonHeaders; }
+    const UncommonHeadersVector &extraUncommonHeaders() const { return m_extraUncommonHeaders; }
+    UncommonHeadersVector &extraUncommonHeaders() { return m_extraUncommonHeaders; }
+    WEBCORE_EXPORT void appendExtra(HTTPHeaderName, const String &value);
+    WEBCORE_EXPORT void appendExtra(const String &name, const String &value);
+
     const_iterator begin() const { return const_iterator(*this, m_commonHeaders.begin(), m_uncommonHeaders.begin(), m_setCookieHeaders.begin()); }
     const_iterator end() const { return const_iterator(*this, m_commonHeaders.end(), m_uncommonHeaders.end(), m_setCookieHeaders.end()); }
 
     friend bool operator==(const HTTPHeaderMap &a, const HTTPHeaderMap &b)
     {
-        if (a.m_commonHeaders.size() != b.m_commonHeaders.size() || a.m_uncommonHeaders.size() != b.m_uncommonHeaders.size() || a.m_setCookieHeaders.size() != b.m_setCookieHeaders.size())
+        // Compare on the primary (which holds the `", "`-joined value for
+        // multi-value headers) and on `m_setCookieHeaders` only. Whether the
+        // same joined value was produced by a single `set` or by repeated
+        // `append` (populating the side channel) isn't visible through
+        // `get()` and shouldn't change equality.
+        if (a.m_commonHeaders.size() != b.m_commonHeaders.size()
+            || a.m_uncommonHeaders.size() != b.m_uncommonHeaders.size()
+            || a.m_setCookieHeaders.size() != b.m_setCookieHeaders.size())
             return false;
 
         for (auto &commonHeader : a.m_commonHeaders) {
@@ -279,6 +320,8 @@ private:
     CommonHeadersVector m_commonHeaders;
     UncommonHeadersVector m_uncommonHeaders;
     Vector<String, 0> m_setCookieHeaders;
+    ExtraCommonHeadersVector m_extraCommonHeaders;
+    UncommonHeadersVector m_extraUncommonHeaders;
 };
 
 template<class Encoder>
@@ -326,6 +369,9 @@ void HTTPHeaderMap::encode(Encoder &encoder) const
 {
     encoder << m_commonHeaders;
     encoder << m_uncommonHeaders;
+    encoder << m_setCookieHeaders;
+    encoder << m_extraCommonHeaders;
+    encoder << m_extraUncommonHeaders;
 }
 
 template<class Decoder>
@@ -335,6 +381,15 @@ bool HTTPHeaderMap::decode(Decoder &decoder, HTTPHeaderMap &headerMap)
         return false;
 
     if (!decoder.decode(headerMap.m_uncommonHeaders))
+        return false;
+
+    if (!decoder.decode(headerMap.m_setCookieHeaders))
+        return false;
+
+    if (!decoder.decode(headerMap.m_extraCommonHeaders))
+        return false;
+
+    if (!decoder.decode(headerMap.m_extraUncommonHeaders))
         return false;
 
     return true;

--- a/src/jsc/bindings/webcore/JSFetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/JSFetchHeaders.cpp
@@ -600,7 +600,8 @@ JSC_DEFINE_HOST_FUNCTION(jsFetchHeaders_getRawKeys, (JSC::JSGlobalObject * lexic
     // HTTPHeaderMap's iterator covers only the common and uncommon segments;
     // set-cookie values live in their own segment, so size() (which counts
     // every cookie) used to leave trailing holes in the array. Size for one
-    // entry per unique name and append "set-cookie" explicitly.
+    // entry per unique name and append "set-cookie" explicitly. Extras never
+    // introduce a new name (the primary already holds the joined value).
     JSArray* outArray = JSC::JSArray::create(vm, lexicalGlobalObject->arrayStructureForIndexingTypeDuringAllocation(JSC::ArrayWithContiguous), headers.sizeAfterJoiningSetCookieHeader());
 
     unsigned int i = 0;
@@ -675,6 +676,9 @@ JSC::JSValue getInternalProperties(JSC::VM& vm, JSGlobalObject* lexicalGlobalObj
         auto& vec = internal.commonHeaders();
         for (const auto& it : vec) {
             const auto& name = it.key;
+            // The primary already holds the `", "`-joined string for
+            // multi-value headers (see `appendToHeaderMap`), so the `value`
+            // field reflects every occurrence without a second pass.
             const auto& value = it.value;
             obj->putDirect(vm, Identifier::fromString(vm, WTF::httpHeaderNameStringImpl(name)), jsString(vm, value), 0);
         }

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -160,3 +160,99 @@ describe("response Connection: close closes the socket", () => {
     }
   });
 });
+
+// Reads the raw HTTP response off the wire so we can count header lines —
+// going through `fetch()` would run the response through Bun's HTTP client,
+// which has its own header-joining behavior and would mask a server-side
+// multi-value regression.
+function readRawResponse(port: number): Promise<string> {
+  const { promise, resolve, reject } = Promise.withResolvers<string>();
+  const sock = net.connect(port, "127.0.0.1", () => {
+    sock.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+  });
+  let buf = "";
+  sock.on("data", d => (buf += d));
+  sock.on("end", () => resolve(buf));
+  sock.on("error", reject);
+  return promise;
+}
+
+// https://github.com/oven-sh/bun/issues/31317
+// `Response` headers built from a sequence-of-sequences init must produce one
+// wire line per entry (RFC 7230 §3.2.2), not a single `, `-joined line.
+test("Bun.serve emits multi-value headers as separate wire lines", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response("hi", {
+        headers: [
+          ["x-multi", "a"],
+          ["x-multi", "b"],
+          ["x-multi", "c"],
+        ],
+      });
+    },
+  });
+
+  const raw = await readRawResponse(server.port);
+  const count = (raw.match(/^x-multi:/gim) ?? []).length;
+  expect(count).toBe(3);
+  expect(raw).toMatch(/x-multi: a\r\n/);
+  expect(raw).toMatch(/x-multi: b\r\n/);
+  expect(raw).toMatch(/x-multi: c\r\n/);
+});
+
+test("Bun.serve preserves multiple set-cookie and multi-value headers together", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      const headers = new Headers();
+      headers.append("set-cookie", "a=1");
+      headers.append("set-cookie", "b=2");
+      headers.append("x-multi", "alpha");
+      headers.append("x-multi", "beta");
+      return new Response("hi", { headers });
+    },
+  });
+
+  const raw = await readRawResponse(server.port);
+  expect((raw.match(/^set-cookie:/gim) ?? []).length).toBe(2);
+  expect((raw.match(/^x-multi:/gim) ?? []).length).toBe(2);
+});
+
+// Headers.append keeps WHATWG semantics: Headers.get() returns the joined
+// string. The extra-storage path must not change that contract.
+test("Headers.get() returns the joined string for WHATWG-appended duplicates", () => {
+  const h = new Headers();
+  h.append("x-multi", "a");
+  h.append("x-multi", "b");
+  h.append("x-multi", "c");
+  expect(h.get("x-multi")).toBe("a, b, c");
+
+  // Cookie uses the RFC 6265 `"; "` separator.
+  const c = new Headers();
+  c.append("Cookie", "a=1");
+  c.append("Cookie", "b=2");
+  expect(c.get("Cookie")).toBe("a=1; b=2");
+});
+
+// Headers.set() and Headers.delete() must drop every extra duplicate for a
+// given name.
+test("Headers.set() overwrites all prior appended values", () => {
+  const h = new Headers();
+  h.append("x-multi", "a");
+  h.append("x-multi", "b");
+  h.append("x-multi", "c");
+  h.set("x-multi", "only");
+  expect(h.get("x-multi")).toBe("only");
+});
+
+test("Headers.delete() removes every value for the given name", () => {
+  const h = new Headers();
+  h.append("x-multi", "a");
+  h.append("x-multi", "b");
+  h.append("x-multi", "c");
+  h.delete("x-multi");
+  expect(h.has("x-multi")).toBe(false);
+  expect(h.get("x-multi")).toBeNull();
+});

--- a/test/js/node/http/node-http-multi-value-headers.test.ts
+++ b/test/js/node/http/node-http-multi-value-headers.test.ts
@@ -1,0 +1,150 @@
+// https://github.com/oven-sh/bun/issues/31317
+import { expect, test } from "bun:test";
+import { createServer } from "node:http";
+import { connect, type AddressInfo } from "node:net";
+
+function listen(server: ReturnType<typeof createServer>): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      resolve((server.address() as AddressInfo).port);
+    });
+  });
+}
+
+// Reads the raw HTTP response off the wire so we can count header lines —
+// going through `fetch()` would run the response through Bun's HTTP client,
+// which has its own header-joining behavior and would mask a server-side
+// multi-value regression.
+function readRawResponse(port: number): Promise<string> {
+  const { promise, resolve, reject } = Promise.withResolvers<string>();
+  const sock = connect(port, "127.0.0.1", () => {
+    sock.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+  });
+  let buf = "";
+  sock.on("data", d => (buf += d));
+  sock.on("end", () => resolve(buf));
+  sock.on("error", reject);
+  return promise;
+}
+
+test("writeHead(status, { name: [array] }) emits one wire line per value", async () => {
+  const server = createServer((_req, res) => {
+    res.writeHead(200, { "X-Multi": ["a", "b", "c"] });
+    res.end("hi");
+  });
+  const port = await listen(server);
+  try {
+    const raw = await readRawResponse(port);
+    expect((raw.match(/^X-Multi:/gim) ?? []).length).toBe(3);
+    expect(raw).toMatch(/X-Multi: a\r\n/);
+    expect(raw).toMatch(/X-Multi: b\r\n/);
+    expect(raw).toMatch(/X-Multi: c\r\n/);
+  } finally {
+    server.close();
+  }
+});
+
+test("setHeader(name, [array]) emits one wire line per value", async () => {
+  const server = createServer((_req, res) => {
+    res.setHeader("X-Multi", ["a", "b", "c"]);
+    res.end("hi");
+  });
+  const port = await listen(server);
+  try {
+    const raw = await readRawResponse(port);
+    expect((raw.match(/^X-Multi:/gim) ?? []).length).toBe(3);
+  } finally {
+    server.close();
+  }
+});
+
+test("repeated appendHeader emits one wire line per call", async () => {
+  const server = createServer((_req, res) => {
+    res.appendHeader("X-Multi", "a");
+    res.appendHeader("X-Multi", "b");
+    res.appendHeader("X-Multi", "c");
+    res.end("hi");
+  });
+  const port = await listen(server);
+  try {
+    const raw = await readRawResponse(port);
+    expect((raw.match(/^X-Multi:/gim) ?? []).length).toBe(3);
+  } finally {
+    server.close();
+  }
+});
+
+test("setHeader after appendHeader clears prior values", async () => {
+  const server = createServer((_req, res) => {
+    res.appendHeader("X-Multi", "a");
+    res.appendHeader("X-Multi", "b");
+    res.setHeader("X-Multi", "only");
+    res.end("hi");
+  });
+  const port = await listen(server);
+  try {
+    const raw = await readRawResponse(port);
+    expect((raw.match(/^X-Multi:/gim) ?? []).length).toBe(1);
+    expect(raw).toMatch(/X-Multi: only\r\n/);
+  } finally {
+    server.close();
+  }
+});
+
+test("removeHeader drops every appended value", async () => {
+  const server = createServer((_req, res) => {
+    res.appendHeader("X-Multi", "a");
+    res.appendHeader("X-Multi", "b");
+    res.appendHeader("X-Multi", "c");
+    res.removeHeader("X-Multi");
+    res.end("hi");
+  });
+  const port = await listen(server);
+  try {
+    const raw = await readRawResponse(port);
+    expect((raw.match(/^X-Multi:/gim) ?? []).length).toBe(0);
+  } finally {
+    server.close();
+  }
+});
+
+// Node returns `getHeader` as an array after repeated `appendHeader`, Bun
+// returns the `", "`-joined string (WHATWG `Headers.get()` semantics).
+// Assert on the wire-format side-effect instead so this test exercises the
+// round-trip in both runtimes.
+test("repeated appendHeader + getHeader preserves every value", async () => {
+  const { promise, resolve } = Promise.withResolvers<string | string[] | number | undefined>();
+  const server = createServer((_req, res) => {
+    res.appendHeader("X-Multi", "a");
+    res.appendHeader("X-Multi", "b");
+    res.appendHeader("X-Multi", "c");
+    resolve(res.getHeader("X-Multi"));
+    res.end("hi");
+  });
+  const port = await listen(server);
+  try {
+    const raw = await readRawResponse(port);
+    const header = await promise;
+    // Flatten whichever shape the runtime returns.
+    const joined = Array.isArray(header) ? header.join(", ") : String(header);
+    expect(joined).toBe("a, b, c");
+    expect((raw.match(/^X-Multi:/gim) ?? []).length).toBe(3);
+  } finally {
+    server.close();
+  }
+});
+
+test("Set-Cookie array still produces separate wire lines", async () => {
+  const server = createServer((_req, res) => {
+    res.setHeader("Set-Cookie", ["a=1", "b=2", "c=3"]);
+    res.end("hi");
+  });
+  const port = await listen(server);
+  try {
+    const raw = await readRawResponse(port);
+    expect((raw.match(/^Set-Cookie:/gim) ?? []).length).toBe(3);
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
Closes #31317.

## Repro

Bun emitted a single comma-joined header line where Node emits one line per value:

```js
const http = require("node:http");
const net = require("node:net");
const server = http.createServer((req, res) => {
  res.writeHead(200, { "X-Multi": ["a", "b", "c"] });
  res.end("hi");
});
server.listen(0, () => {
  const sock = net.connect(server.address().port, "127.0.0.1", () => {
    sock.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
  });
  let buf = "";
  sock.on("data", d => (buf += d));
  sock.on("end", () => {
    console.log("count:", (buf.match(/^X-Multi:/gim) || []).length);
    server.close();
  });
});
```

Before: `count: 1` (wire shows `X-Multi: a, b, c`).
After / Node: `count: 3` (wire shows three `X-Multi:` lines).

Same bug on the `Bun.serve` side for `new Response(body, { headers: [[n,v],[n,v]] })`.

## Root cause

`appendToHeaderMap` in `FetchHeaders.cpp` joined every duplicate into the existing slot via `makeString(existing, ", "_s, normalized)`. The `jsHTTPSetHeader` array path (`impl->set` + `impl->append` per element) and the `Response` sequence-of-sequences init both flowed through this merge. `HTTPHeaderMap`'s `m_commonHeaders` / `m_uncommonHeaders` hold one entry per name, so by the time the wire-write in `writeFetchHeadersToUWSResponse` iterated them there was only one entry to emit.

`Set-Cookie` was the one exception — it has a dedicated `Vector<String> m_setCookieHeaders` and produces one wire line per value.

## Fix

Add `m_extraHeaders` to `WebCore::HTTPHeaderMap` — the first value for a given name still lives in `m_commonHeaders` / `m_uncommonHeaders`, so `get()`, `contains()`, WHATWG `Headers` iteration, `count`, and FFI allocation all keep their current contract. 2nd..Nth values for the same name land in the side-channel vector.

- `HTTPHeaderMap::get(name)` joins primary + all matching extras with `", "`, so `headers.get()` still returns the WHATWG-spec joined string (and Node's `res.getHeader()` returns the joined value as expected).
- `HTTPHeaderMap::set(name, value)` and `remove(name)` clear every extra for that name, so `res.setHeader(X, y)` after `res.appendHeader(X, …)` works the same as Node.
- `Cookie` request headers keep the RFC 6265 §5.4 `"; "` combine. `Set-Cookie` keeps its own vector.
- `writeFetchHeadersToUWSResponse` (HTTP/1.1 + SSL + HTTP/3) iterates `extraHeaders()` after the primary pass — one wire line per entry.
- `assignHeadersFromFetchHeaders` (builds `req.headers` / `rawHeaders`) emits each extra into the flat `rawHeaders` array and refreshes the object side with the joined value.

## Verification

```console
$ bun bd test test/js/node/http/node-http.test.ts -t multi-value
(pass) writeHead(status, { name: [array] }) emits one wire line per value
(pass) setHeader(name, [array]) emits one wire line per value
(pass) repeated appendHeader emits one wire line per call
(pass) setHeader after appendHeader clears prior values
(pass) removeHeader drops every appended value
(pass) getHeader() returns the `, `-joined string
(pass) Set-Cookie array still produces separate wire lines

$ bun bd test test/js/bun/http/bun-serve-headers.test.ts
(pass) Bun.serve emits multi-value headers as separate wire lines
(pass) Bun.serve preserves multiple set-cookie and multi-value headers together
(pass) Headers.get() returns the joined string for WHATWG-appended duplicates
(pass) Headers.set() overwrites all prior appended values
(pass) Headers.delete() removes every value for the given name
(pass) weird headers
```

All 119 tests across the three `headers*.test.ts` suites continue to pass. Node.js produces the same output for every new regression case.

## Out of scope

Note 2 from the issue — Bun's HTTP **client** also collapses multi-value response headers when parsing (`createFromPicoHeaders_` uses `HTTPHeaderMap::add` which joins known names and `setUncommonHeaderCloneName` which overwrites uncommon ones). That's a separate entry point that needs its own change to switch to the new `appendExtra` side-channel. It's left for a follow-up; this PR keeps the same client-side behavior so the diff stays focused on the server-side wire format.