### PR TITLE
tls: apply the server's default rejectUnauthorized to incoming connections

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -338,7 +338,9 @@ const ServerHandlers: SocketHandler<NetSocket> = {
     const _socket = new SClass({}) as NetSocket | TLSSocket;
     _socket.isServer = true;
     _socket._requestCert = requestCert;
-    _socket._rejectUnauthorized = rejectUnauthorized;
+    // The raw options object only has rejectUnauthorized when the user passed it explicitly;
+    // fall back to the server's normalized value (defaults to true for tls.Server).
+    _socket._rejectUnauthorized = rejectUnauthorized ?? self._rejectUnauthorized;
 
     _socket[kAttach](this.localPort, socket);
 
@@ -412,7 +414,10 @@ const ServerHandlers: SocketHandler<NetSocket> = {
     self.servername = socket.getServername();
     const server = self.server!;
     self.alpnProtocol = socket.alpnProtocol;
-    if (self._requestCert || self._rejectUnauthorized) {
+    // Only consult the peer-certificate verification result when a client certificate was
+    // requested; the native verifier reports a non-OK code whenever no peer certificate
+    // exists, which is the normal case for plain TLS servers.
+    if (self._requestCert) {
       if (verifyError) {
         self.authorized = false;
         self.authorizationError = verifyError.code || verifyError.message;
@@ -420,7 +425,10 @@ const ServerHandlers: SocketHandler<NetSocket> = {
         if (self._rejectUnauthorized) {
           // if we reject we still need to emit secure
           self.emit("secure", self);
-          self.destroy(verifyError);
+          // No error argument: this socket has no 'error' listener yet, so destroy(err)
+          // would surface as an uncaught exception. The failure is already reported via
+          // 'tlsClientError' and socket.authorizationError.
+          self.destroy();
           return;
         }
       } else {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -414,9 +414,8 @@ const ServerHandlers: SocketHandler<NetSocket> = {
     self.servername = socket.getServername();
     const server = self.server!;
     self.alpnProtocol = socket.alpnProtocol;
-    // Only consult the peer-certificate verification result when a client certificate was
-    // requested; the native verifier reports a non-OK code whenever no peer certificate
-    // exists, which is the normal case for plain TLS servers.
+    // The native verifier reports a non-OK code when there is no peer certificate,
+    // which is the normal case for plain TLS servers.
     if (self._requestCert) {
       if (verifyError) {
         self.authorized = false;
@@ -425,9 +424,8 @@ const ServerHandlers: SocketHandler<NetSocket> = {
         if (self._rejectUnauthorized) {
           // if we reject we still need to emit secure
           self.emit("secure", self);
-          // No error argument: this socket has no 'error' listener yet, so destroy(err)
-          // would surface as an uncaught exception. The failure is already reported via
-          // 'tlsClientError' and socket.authorizationError.
+          // No error argument: the socket has no 'error' listener yet, so destroy(err)
+          // would surface as an uncaught exception.
           self.destroy();
           return;
         }

--- a/test/js/node/tls/node-tls-cert.test.ts
+++ b/test/js/node/tls/node-tls-cert.test.ts
@@ -352,7 +352,7 @@ it("explicit rejectUnauthorized: false still admits an unverified client certifi
   client.on("error", () => {});
 
   try {
-    const serverSocket = await handledSocket;
+    const [serverSocket] = await Promise.all([handledSocket, once(client, "secureConnect")]);
     expect(serverSocket.authorized).toBe(false);
     expect(serverSocket.authorizationError).toBe("UNABLE_TO_VERIFY_LEAF_SIGNATURE");
   } finally {

--- a/test/js/node/tls/node-tls-cert.test.ts
+++ b/test/js/node/tls/node-tls-cert.test.ts
@@ -251,6 +251,116 @@ it("Fail to complete client's chain.", async () => {
   }
 });
 
+it("rejects an unverifiable client certificate by default when requestCert is true", async () => {
+  // No explicit rejectUnauthorized: the documented default is true, so a client
+  // certificate that fails CA verification must never reach the connection handler.
+  const handled: string[] = [];
+  const secureConnections: TLSSocket[] = [];
+  let clientError: any = null;
+
+  const server = tls.createServer(
+    {
+      key: serverTls.key,
+      cert: serverTls.cert,
+      ca: clientTls.ca,
+      requestCert: true,
+    },
+    socket => {
+      handled.push(socket.authorizationError as any);
+      socket.pipe(socket);
+    },
+  );
+  server.on("secureConnection", socket => secureConnections.push(socket));
+  server.on("tlsClientError", err => {
+    clientError = err;
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const port = (server.address() as AddressInfo).port;
+
+  try {
+    // Client 1: incomplete chain the server cannot verify. The server must drop it.
+    const badClient = tls.connect({
+      host: "127.0.0.1",
+      port,
+      key: clientTls.key,
+      cert: clientTls.single,
+      ca: serverTls.ca,
+      checkServerIdentity,
+      rejectUnauthorized: false,
+    });
+    badClient.on("error", () => {});
+    // The server must tear the socket down; it must never hand it to the application.
+    const outcome = await Promise.race([
+      once(badClient, "close").then(() => "closed"),
+      once(server, "secureConnection").then(() => "secureConnection"),
+    ]);
+    expect(outcome).toBe("closed");
+
+    expect(clientError?.code).toBe("UNABLE_TO_VERIFY_LEAF_SIGNATURE");
+    expect(secureConnections).toHaveLength(0);
+    expect(handled).toHaveLength(0);
+
+    // Client 2: full verifiable chain. The server must still be alive and serve it,
+    // proving the rejection above was a clean per-socket teardown.
+    const goodClient = tls.connect({
+      host: "127.0.0.1",
+      port,
+      key: clientTls.key,
+      cert: clientTls.cert,
+      ca: serverTls.ca,
+      checkServerIdentity,
+    });
+    await once(goodClient, "secureConnect");
+    const echoed = once(goodClient, "data");
+    goodClient.write("ping");
+    expect((await echoed)[0].toString()).toBe("ping");
+    goodClient.end();
+    await once(goodClient, "close");
+
+    expect(handled).toHaveLength(1);
+    expect(secureConnections).toHaveLength(1);
+  } finally {
+    server.close();
+  }
+});
+
+it("explicit rejectUnauthorized: false still admits an unverified client certificate", async () => {
+  const { promise: handledSocket, resolve: onHandledSocket } = Promise.withResolvers<TLSSocket>();
+
+  const server = tls.createServer(
+    {
+      key: serverTls.key,
+      cert: serverTls.cert,
+      ca: clientTls.ca,
+      requestCert: true,
+      rejectUnauthorized: false,
+    },
+    socket => onHandledSocket(socket),
+  );
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const port = (server.address() as AddressInfo).port;
+
+  const client = tls.connect({
+    host: "127.0.0.1",
+    port,
+    key: clientTls.key,
+    cert: clientTls.single,
+    ca: serverTls.ca,
+    checkServerIdentity,
+    rejectUnauthorized: false,
+  });
+  client.on("error", () => {});
+
+  try {
+    const serverSocket = await handledSocket;
+    expect(serverSocket.authorized).toBe(false);
+    expect(serverSocket.authorizationError).toBe("UNABLE_TO_VERIFY_LEAF_SIGNATURE");
+  } finally {
+    client.end();
+    server.close();
+  }
+});
+
 it("Fail to find CA for server.", async () => {
   try {
     await connect({


### PR DESCRIPTION
\`tls.Server\` normalizes \`rejectUnauthorized\` to its documented default on the server object, but the per-connection socket copied the raw, un-defaulted option, so the post-handshake check never enforced the default. This defaults the per-connection value from the server's normalized one, gates the peer-certificate verification result on \`requestCert\` (matching Node's \`onServerSocketSecure\`, since the native verifier reports a non-OK code whenever no peer certificate exists), and drops the error argument from the reject-path \`destroy()\` so the teardown does not surface as an uncaught exception on a listener-less socket.

Adds two tests to \`test/js/node/tls/node-tls-cert.test.ts\`: one asserting a server with \`requestCert: true\` and no explicit \`rejectUnauthorized\` tears down a connection whose client certificate cannot be verified (and still serves a subsequent verifiable client), and one asserting an explicit \`rejectUnauthorized: false\` still admits the connection with \`authorized === false\`.