### PR TITLE
node:http2: reassemble HEADERS+CONTINUATION before HPACK decoding

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3914,6 +3914,16 @@ class ClientHttp2Session extends Http2Session {
         headers = { ...headers };
       }
 
+      // Evaluate user-supplied option getters now, before any header block is
+      // encoded (Node does the same). A getter that re-entrantly calls
+      // request() would otherwise run between the native parser encoding this
+      // request's header block and writing it to the socket, emitting header
+      // blocks on the wire in a different order than they were encoded and
+      // desynchronizing the peer's HPACK dynamic table.
+      if ($isObject(options)) {
+        options = { ...options };
+      }
+
       const sensitives = headers[sensitiveHeaders];
       delete headers[sensitiveHeaders];
       const sensitiveNames = {};

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3914,12 +3914,9 @@ class ClientHttp2Session extends Http2Session {
         headers = { ...headers };
       }
 
-      // Evaluate user-supplied option getters now, before any header block is
-      // encoded (Node does the same). A getter that re-entrantly calls
-      // request() would otherwise run between the native parser encoding this
-      // request's header block and writing it to the socket, emitting header
-      // blocks on the wire in a different order than they were encoded and
-      // desynchronizing the peer's HPACK dynamic table.
+      // Copy options so user-supplied getters run now, before the header block
+      // is encoded — a getter that re-entrantly calls request() would otherwise
+      // reorder header blocks on the wire (Node does the same).
       if ($isObject(options)) {
         options = { ...options };
       }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1274,6 +1274,11 @@ pub struct H2FrameParser {
     out_standing_pings: Cell<u64>,
     max_send_header_block_length: Cell<u32>,
     last_stream_id: Cell<u32>,
+    // Non-zero while a HEADERS frame without END_HEADERS is awaiting its
+    // CONTINUATION frames; holds the stream id whose header block is being
+    // reassembled. RFC 9113 §4.3: any other frame on the connection during
+    // that window is a connection error.
+    expecting_continuation: Cell<u32>,
     is_server: Cell<bool>,
     preface_received_len: Cell<u8>,
     // we buffer requests until we get the first settings ACK
@@ -1408,6 +1413,11 @@ pub struct Stream {
     is_waiting_more_headers: bool,
     header_block_size: usize,
     header_block_count: usize,
+    // RFC 9113 §4.3: a header block split across HEADERS + CONTINUATION frames
+    // must be reassembled and HPACK-decoded as a single unit once END_HEADERS
+    // arrives. Bounded to one in-flight block per connection (see
+    // `expecting_continuation`) and capped at `max_header_list_size` bytes.
+    pending_header_block: Vec<u8>,
     padding: Option<u8>,
     padding_strategy: PaddingStrategy,
     rst_code: u32,
@@ -1962,6 +1972,7 @@ impl Stream {
             is_waiting_more_headers: false,
             header_block_size: 0,
             header_block_count: 0,
+            pending_header_block: Vec::new(),
             padding: None,
             padding_strategy,
             rst_code: 0,
@@ -3253,10 +3264,30 @@ impl H2FrameParser {
 
         let mut sensitive_headers: JSValue = JSValue::UNDEFINED;
 
-        loop {
+        // Stream-level limit violations seen mid-decode. The loop must consume
+        // the whole block regardless: the HPACK dynamic table is
+        // connection-scoped, so abandoning the block midway would desync it
+        // for every other stream. The rejection is applied once after the loop.
+        let mut rejected = false;
+
+        while offset < payload.len() {
             let header = match self.decode(&payload[offset..]) {
                 Ok(h) => h,
-                Err(_) => break,
+                Err(_) => {
+                    // RFC 9113 §4.3: a decoding error in a complete header
+                    // block is a connection error of type COMPRESSION_ERROR —
+                    // the connection-scoped dynamic table can no longer be
+                    // trusted, and a partially decoded header list must not be
+                    // delivered as if it were complete.
+                    self.send_go_away(
+                        stream_id,
+                        ErrorCode::COMPRESSION_ERROR,
+                        b"Invalid HPACK header block",
+                        self.last_stream_id.get(),
+                        true,
+                    );
+                    return Ok(self.streams.get().get(&stream_id).copied());
+                }
             };
             offset += header.next;
             bun_output::scoped_log!(
@@ -3280,39 +3311,18 @@ impl H2FrameParser {
             // Size = name length + value length + HPACK entry overhead per header
             stream.header_block_size +=
                 header.name.len() + header.value.len() + HPACK_ENTRY_OVERHEAD;
-
-            // Check against maxHeaderListSize setting
-            if stream.header_block_size > self.local_settings.get().max_header_list_size as usize {
-                self.rejected_streams.set(self.rejected_streams.get() + 1);
-                if self.max_rejected_streams.get() <= self.rejected_streams.get() {
-                    self.send_go_away(
-                        stream_id,
-                        ErrorCode::ENHANCE_YOUR_CALM,
-                        b"ENHANCE_YOUR_CALM",
-                        self.last_stream_id.get(),
-                        true,
-                    );
-                } else {
-                    self.end_stream(stream, ErrorCode::ENHANCE_YOUR_CALM);
-                }
-                return Ok(self.streams.get().get(&stream_id).copied());
-            }
-
             stream.header_block_count += 1;
-            if (self.max_header_list_pairs.get() as usize) < stream.header_block_count {
-                self.rejected_streams.set(self.rejected_streams.get() + 1);
-                if self.max_rejected_streams.get() <= self.rejected_streams.get() {
-                    self.send_go_away(
-                        stream_id,
-                        ErrorCode::ENHANCE_YOUR_CALM,
-                        b"ENHANCE_YOUR_CALM",
-                        self.last_stream_id.get(),
-                        true,
-                    );
-                } else {
-                    self.end_stream(stream, ErrorCode::ENHANCE_YOUR_CALM);
-                }
-                return Ok(self.streams.get().get(&stream_id).copied());
+
+            // Check against maxHeaderListSize / maxHeaderListPairs. Once a
+            // limit is exceeded stop collecting headers but keep decoding the
+            // rest of the block so the dynamic table stays consistent.
+            if rejected
+                || stream.header_block_size
+                    > self.local_settings.get().max_header_list_size as usize
+                || (self.max_header_list_pairs.get() as usize) < stream.header_block_count
+            {
+                rejected = true;
+                continue;
             }
 
             if let Some(js_header_name) =
@@ -3350,10 +3360,22 @@ impl H2FrameParser {
                 js_header_name.ensure_still_alive();
                 js_header_value.ensure_still_alive();
             }
+        }
 
-            if offset >= payload.len() {
-                break;
+        if rejected {
+            self.rejected_streams.set(self.rejected_streams.get() + 1);
+            if self.max_rejected_streams.get() <= self.rejected_streams.get() {
+                self.send_go_away(
+                    stream_id,
+                    ErrorCode::ENHANCE_YOUR_CALM,
+                    b"ENHANCE_YOUR_CALM",
+                    self.last_stream_id.get(),
+                    true,
+                );
+            } else {
+                self.end_stream(stream, ErrorCode::ENHANCE_YOUR_CALM);
             }
+            return Ok(self.streams.get().get(&stream_id).copied());
         }
 
         self.dispatch_with_3_extra(
@@ -4023,20 +4045,70 @@ impl H2FrameParser {
             let payload = content.data();
             let end = content.end;
             self.read_buffer.with_mut(|rb| rb.reset());
-            stream = match self.decode_header_block(payload, stream, frame.flags)? {
+            if stream.pending_header_block.len() + payload.len()
+                > self.local_settings.get().max_header_list_size as usize
+            {
+                // The compressed block already exceeds the header list limit
+                // (HPACK never expands a header list when encoding it, so the
+                // decoded size check would reject it too). Reject the whole
+                // connection rather than leaving the stream waiting on more
+                // fragments for an emptied buffer.
+                self.send_go_away(
+                    frame.stream_identifier,
+                    ErrorCode::ENHANCE_YOUR_CALM,
+                    b"ENHANCE_YOUR_CALM",
+                    self.last_stream_id.get(),
+                    true,
+                );
+                return Ok(end);
+            }
+            stream.pending_header_block.extend_from_slice(payload);
+            if frame.flags & HeadersFrameFlags::END_HEADERS as u8 == 0 {
+                // keep buffering until END_HEADERS arrives
+                return Ok(end);
+            }
+            stream.is_waiting_more_headers = false;
+            self.expecting_continuation.set(0);
+            // RFC 9113 §4.3: decode the reassembled block as a single unit.
+            // Take ownership of the buffer first so re-entrant parser calls
+            // from the onStreamHeaders dispatch cannot alias or free the
+            // bytes being decoded.
+            let block = core::mem::take(&mut stream.pending_header_block);
+            stream = match self.decode_header_block(&block, stream, frame.flags)? {
                 // SAFETY: s is *mut Stream from self.streams (heap::alloc); valid while the map entry exists
                 Some(s) => unsafe { &mut *s },
                 None => return Ok(end),
             };
-            // END_STREAM (end_after_headers) was already finalized by
-            // handle_headers_frame; only track END_HEADERS here.
-            stream.is_waiting_more_headers =
-                frame.flags & HeadersFrameFlags::END_HEADERS as u8 == 0;
+            // END_STREAM finalization was deferred by handle_headers_frame
+            // until the complete header block had been dispatched.
+            if stream.end_after_headers {
+                self.finish_headers_end_stream(stream);
+            }
             return Ok(end);
         }
 
         // needs more data
         Ok(data.len())
+    }
+
+    /// Finalize a stream whose HEADERS frame carried END_STREAM, after the
+    /// complete header block has been decoded and dispatched.
+    fn finish_headers_end_stream(&self, stream: &mut Stream) {
+        let identifier = stream.get_identifier();
+        identifier.ensure_still_alive();
+
+        // no more continuation headers we can call it closed
+        if stream.state == StreamState::HALF_CLOSED_LOCAL {
+            stream.state = StreamState::CLOSED;
+            stream.free_resources::<false>(self);
+        } else {
+            stream.state = StreamState::HALF_CLOSED_REMOTE;
+        }
+        self.dispatch_with_extra(
+            JSH2FrameParser::Gc::onStreamEnd,
+            identifier,
+            JSValue::js_number(stream.state as u8 as f64),
+        );
     }
 
     pub(crate) fn handle_headers_frame(
@@ -4139,33 +4211,42 @@ impl H2FrameParser {
             stream.end_after_headers = frame.flags & HeadersFrameFlags::END_STREAM as u8 != 0;
             stream.header_block_size = 0;
             stream.header_block_count = 0;
+            stream.pending_header_block.clear();
+            stream.is_waiting_more_headers =
+                frame.flags & HeadersFrameFlags::END_HEADERS as u8 == 0;
+            if stream.is_waiting_more_headers {
+                // RFC 9113 §4.3: the header block is only complete once
+                // END_HEADERS arrives. Buffer this fragment and decode the
+                // concatenated block in handle_continuation_frame; the
+                // END_STREAM finalization is deferred with it so the JS event
+                // order stays onStreamHeaders -> onStreamEnd.
+                let fragment = &payload[offset..end];
+                if fragment.len() > self.local_settings.get().max_header_list_size as usize {
+                    // The compressed block already exceeds the header list
+                    // limit (HPACK never expands a header list when encoding
+                    // it, so the decoded size check would reject it too).
+                    // Reject the whole connection rather than leaving a
+                    // partially buffered block behind.
+                    self.send_go_away(
+                        frame.stream_identifier,
+                        ErrorCode::ENHANCE_YOUR_CALM,
+                        b"ENHANCE_YOUR_CALM",
+                        self.last_stream_id.get(),
+                        true,
+                    );
+                    return Ok(end_);
+                }
+                stream.pending_header_block.extend_from_slice(fragment);
+                self.expecting_continuation.set(frame.stream_identifier);
+                return Ok(end_);
+            }
             stream = match self.decode_header_block(&payload[offset..end], stream, frame.flags)? {
                 // SAFETY: s is *mut Stream from self.streams (heap::alloc); valid while the map entry exists
                 Some(s) => unsafe { &mut *s },
                 None => return Ok(end_),
             };
-            stream.is_waiting_more_headers =
-                frame.flags & HeadersFrameFlags::END_HEADERS as u8 == 0;
             if stream.end_after_headers {
-                let identifier = stream.get_identifier();
-                identifier.ensure_still_alive();
-
-                if stream.is_waiting_more_headers {
-                    stream.state = StreamState::HALF_CLOSED_REMOTE;
-                } else {
-                    // no more continuation headers we can call it closed
-                    if stream.state == StreamState::HALF_CLOSED_LOCAL {
-                        stream.state = StreamState::CLOSED;
-                        stream.free_resources::<false>(self);
-                    } else {
-                        stream.state = StreamState::HALF_CLOSED_REMOTE;
-                    }
-                }
-                self.dispatch_with_extra(
-                    JSH2FrameParser::Gc::onStreamEnd,
-                    identifier,
-                    JSValue::js_number(stream.state as u8 as f64),
-                );
+                self.finish_headers_end_stream(stream);
             }
             return Ok(end_);
         }
@@ -4614,6 +4695,26 @@ impl H2FrameParser {
         stream: Option<*mut Stream>,
         add: usize,
     ) -> JsResult<usize> {
+        // RFC 9113 §4.3 / §6.10: once a HEADERS frame without END_HEADERS has
+        // been received, the only frame permitted on the connection is a
+        // CONTINUATION frame for that same stream until the header block is
+        // complete. This also bounds reassembly to a single in-flight header
+        // block per connection. The check uses only the frame header so it is
+        // stable across partial-frame re-dispatches of the same frame.
+        let expecting = self.expecting_continuation.get();
+        if expecting != 0
+            && (header.type_ != FrameType::HTTP_FRAME_CONTINUATION as u8
+                || header.stream_identifier != expecting)
+        {
+            self.send_go_away(
+                header.stream_identifier,
+                ErrorCode::PROTOCOL_ERROR,
+                b"Expected CONTINUATION frame",
+                self.last_stream_id.get(),
+                true,
+            );
+            return Ok(bytes.len() + add);
+        }
         Ok(match header.type_ {
             x if x == FrameType::HTTP_FRAME_SETTINGS as u8 => {
                 self.handle_settings_frame(header, bytes) + add
@@ -7359,6 +7460,7 @@ impl H2FrameParser {
             out_standing_pings: Cell::new(0),
             max_send_header_block_length: Cell::new(0),
             last_stream_id: Cell::new(0),
+            expecting_continuation: Cell::new(0),
             is_server: Cell::new(false),
             preface_received_len: Cell::new(0),
             write_buffer: JsCell::new(Vec::<u8>::default()),

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -4043,9 +4043,9 @@ impl H2FrameParser {
             if stream.pending_header_block.len() + payload.len()
                 > self.local_settings.get().max_header_list_size as usize
             {
-                // The compressed block already exceeds the header list limit;
-                // HPACK never expands a header list, so the decoded size check
-                // would reject it too.
+                // Cap the buffered compressed block at max_header_list_size as a
+                // DoS bound; the decoded list size is checked separately in
+                // decode_header_block.
                 self.send_go_away(
                     frame.stream_identifier,
                     ErrorCode::ENHANCE_YOUR_CALM,
@@ -4214,9 +4214,9 @@ impl H2FrameParser {
                 // the JS event order stays onStreamHeaders -> onStreamEnd.
                 let fragment = &payload[offset..end];
                 if fragment.len() > self.local_settings.get().max_header_list_size as usize {
-                    // The compressed block already exceeds the header list limit;
-                    // HPACK never expands a header list, so the decoded size
-                    // check would reject it too.
+                    // Cap the buffered compressed block at max_header_list_size
+                    // as a DoS bound; the decoded list size is checked separately
+                    // in decode_header_block.
                     self.send_go_away(
                         frame.stream_identifier,
                         ErrorCode::ENHANCE_YOUR_CALM,

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1274,10 +1274,8 @@ pub struct H2FrameParser {
     out_standing_pings: Cell<u64>,
     max_send_header_block_length: Cell<u32>,
     last_stream_id: Cell<u32>,
-    // Non-zero while a HEADERS frame without END_HEADERS is awaiting its
-    // CONTINUATION frames; holds the stream id whose header block is being
-    // reassembled. RFC 9113 §4.3: any other frame on the connection during
-    // that window is a connection error.
+    // Stream id whose header block is awaiting CONTINUATION frames
+    // (RFC 9113 §4.3); 0 when none.
     expecting_continuation: Cell<u32>,
     is_server: Cell<bool>,
     preface_received_len: Cell<u8>,
@@ -1413,15 +1411,11 @@ pub struct Stream {
     is_waiting_more_headers: bool,
     header_block_size: usize,
     header_block_count: usize,
-    // RFC 9113 §4.3: a header block split across HEADERS + CONTINUATION frames
-    // must be reassembled and HPACK-decoded as a single unit once END_HEADERS
-    // arrives. Bounded to one in-flight block per connection (see
-    // `expecting_continuation`) and capped at `max_header_list_size` bytes.
+    // Header block fragments buffered across HEADERS + CONTINUATION until
+    // END_HEADERS arrives (RFC 9113 §4.3); capped at `max_header_list_size`.
     pending_header_block: Vec<u8>,
-    // Flags from the HEADERS frame that started `pending_header_block`.
-    // CONTINUATION frames only define END_HEADERS, so the original flags
-    // (END_STREAM, PADDED, PRIORITY) must be preserved for the
-    // onStreamHeaders dispatch once the block is reassembled.
+    // Flags from the HEADERS frame that started `pending_header_block`;
+    // CONTINUATION frames only carry END_HEADERS.
     pending_header_flags: u8,
     padding: Option<u8>,
     padding_strategy: PaddingStrategy,
@@ -3280,11 +3274,8 @@ impl H2FrameParser {
             let header = match self.decode(&payload[offset..]) {
                 Ok(h) => h,
                 Err(_) => {
-                    // RFC 9113 §4.3: a decoding error in a complete header
-                    // block is a connection error of type COMPRESSION_ERROR —
-                    // the connection-scoped dynamic table can no longer be
-                    // trusted, and a partially decoded header list must not be
-                    // delivered as if it were complete.
+                    // RFC 9113 §4.3: a decoding error in a header block is a
+                    // connection error of type COMPRESSION_ERROR.
                     self.send_go_away(
                         stream_id,
                         ErrorCode::COMPRESSION_ERROR,
@@ -3319,9 +3310,7 @@ impl H2FrameParser {
                 header.name.len() + header.value.len() + HPACK_ENTRY_OVERHEAD;
             stream.header_block_count += 1;
 
-            // Check against maxHeaderListSize / maxHeaderListPairs. Once a
-            // limit is exceeded stop collecting headers but keep decoding the
-            // rest of the block so the dynamic table stays consistent.
+            // Check against maxHeaderListSize / maxHeaderListPairs.
             if rejected
                 || stream.header_block_size
                     > self.local_settings.get().max_header_list_size as usize
@@ -4054,11 +4043,9 @@ impl H2FrameParser {
             if stream.pending_header_block.len() + payload.len()
                 > self.local_settings.get().max_header_list_size as usize
             {
-                // The compressed block already exceeds the header list limit
-                // (HPACK never expands a header list when encoding it, so the
-                // decoded size check would reject it too). Reject the whole
-                // connection rather than leaving the stream waiting on more
-                // fragments for an emptied buffer.
+                // The compressed block already exceeds the header list limit;
+                // HPACK never expands a header list, so the decoded size check
+                // would reject it too.
                 self.send_go_away(
                     frame.stream_identifier,
                     ErrorCode::ENHANCE_YOUR_CALM,
@@ -4075,10 +4062,8 @@ impl H2FrameParser {
             }
             stream.is_waiting_more_headers = false;
             self.expecting_continuation.set(0);
-            // RFC 9113 §4.3: decode the reassembled block as a single unit.
-            // Take ownership of the buffer first so re-entrant parser calls
-            // from the onStreamHeaders dispatch cannot alias or free the
-            // bytes being decoded.
+            // Take ownership of the buffer so re-entrant parser calls from the
+            // onStreamHeaders dispatch can't alias or free the bytes being decoded.
             let block = core::mem::take(&mut stream.pending_header_block);
             // Report the original HEADERS frame's flags (plus END_HEADERS now
             // that the block is complete), not the CONTINUATION frame's.
@@ -4224,18 +4209,14 @@ impl H2FrameParser {
             stream.is_waiting_more_headers =
                 frame.flags & HeadersFrameFlags::END_HEADERS as u8 == 0;
             if stream.is_waiting_more_headers {
-                // RFC 9113 §4.3: the header block is only complete once
-                // END_HEADERS arrives. Buffer this fragment and decode the
-                // concatenated block in handle_continuation_frame; the
-                // END_STREAM finalization is deferred with it so the JS event
-                // order stays onStreamHeaders -> onStreamEnd.
+                // Buffer fragments until END_HEADERS (RFC 9113 §4.3); the block is
+                // decoded and END_STREAM finalized in handle_continuation_frame so
+                // the JS event order stays onStreamHeaders -> onStreamEnd.
                 let fragment = &payload[offset..end];
                 if fragment.len() > self.local_settings.get().max_header_list_size as usize {
-                    // The compressed block already exceeds the header list
-                    // limit (HPACK never expands a header list when encoding
-                    // it, so the decoded size check would reject it too).
-                    // Reject the whole connection rather than leaving a
-                    // partially buffered block behind.
+                    // The compressed block already exceeds the header list limit;
+                    // HPACK never expands a header list, so the decoded size
+                    // check would reject it too.
                     self.send_go_away(
                         frame.stream_identifier,
                         ErrorCode::ENHANCE_YOUR_CALM,
@@ -4714,10 +4695,7 @@ impl H2FrameParser {
     ) -> JsResult<usize> {
         // RFC 9113 §4.3 / §6.10: once a HEADERS frame without END_HEADERS has
         // been received, the only frame permitted on the connection is a
-        // CONTINUATION frame for that same stream until the header block is
-        // complete. This also bounds reassembly to a single in-flight header
-        // block per connection. The check uses only the frame header so it is
-        // stable across partial-frame re-dispatches of the same frame.
+        // CONTINUATION for that same stream until the header block is complete.
         let expecting = self.expecting_continuation.get();
         if expecting != 0
             && (header.type_ != FrameType::HTTP_FRAME_CONTINUATION as u8

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1418,6 +1418,11 @@ pub struct Stream {
     // arrives. Bounded to one in-flight block per connection (see
     // `expecting_continuation`) and capped at `max_header_list_size` bytes.
     pending_header_block: Vec<u8>,
+    // Flags from the HEADERS frame that started `pending_header_block`.
+    // CONTINUATION frames only define END_HEADERS, so the original flags
+    // (END_STREAM, PADDED, PRIORITY) must be preserved for the
+    // onStreamHeaders dispatch once the block is reassembled.
+    pending_header_flags: u8,
     padding: Option<u8>,
     padding_strategy: PaddingStrategy,
     rst_code: u32,
@@ -1973,6 +1978,7 @@ impl Stream {
             header_block_size: 0,
             header_block_count: 0,
             pending_header_block: Vec::new(),
+            pending_header_flags: 0,
             padding: None,
             padding_strategy,
             rst_code: 0,
@@ -3286,7 +3292,7 @@ impl H2FrameParser {
                         self.last_stream_id.get(),
                         true,
                     );
-                    return Ok(self.streams.get().get(&stream_id).copied());
+                    return Ok(None);
                 }
             };
             offset += header.next;
@@ -3375,7 +3381,7 @@ impl H2FrameParser {
             } else {
                 self.end_stream(stream, ErrorCode::ENHANCE_YOUR_CALM);
             }
-            return Ok(self.streams.get().get(&stream_id).copied());
+            return Ok(None);
         }
 
         self.dispatch_with_3_extra(
@@ -4074,7 +4080,11 @@ impl H2FrameParser {
             // from the onStreamHeaders dispatch cannot alias or free the
             // bytes being decoded.
             let block = core::mem::take(&mut stream.pending_header_block);
-            stream = match self.decode_header_block(&block, stream, frame.flags)? {
+            // Report the original HEADERS frame's flags (plus END_HEADERS now
+            // that the block is complete), not the CONTINUATION frame's.
+            let block_flags =
+                stream.pending_header_flags | HeadersFrameFlags::END_HEADERS as u8;
+            stream = match self.decode_header_block(&block, stream, block_flags)? {
                 // SAFETY: s is *mut Stream from self.streams (heap::alloc); valid while the map entry exists
                 Some(s) => unsafe { &mut *s },
                 None => return Ok(end),
@@ -4237,6 +4247,7 @@ impl H2FrameParser {
                     return Ok(end_);
                 }
                 stream.pending_header_block.extend_from_slice(fragment);
+                stream.pending_header_flags = frame.flags;
                 self.expecting_continuation.set(frame.stream_identifier);
                 return Ok(end_);
             }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -4088,6 +4088,13 @@ impl H2FrameParser {
     /// Finalize a stream whose HEADERS frame carried END_STREAM, after the
     /// complete header block has been decoded and dispatched.
     fn finish_headers_end_stream(&self, stream: &mut Stream) {
+        // The stream can be reset (req.close(), AbortSignal) between the
+        // HEADERS fragment and the CONTINUATION that completes the block;
+        // don't regress a CLOSED stream or dispatch onStreamEnd after
+        // onStreamError.
+        if stream.state == StreamState::CLOSED {
+            return;
+        }
         let identifier = stream.get_identifier();
         identifier.ensure_still_alive();
 

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -3310,7 +3310,7 @@ impl H2FrameParser {
                     self.last_stream_id.get(),
                     true,
                 );
-                return Ok(self.streams.get().get(&stream_id).copied());
+                return Ok(None);
             }
 
             // RFC 7540 Section 6.5.2: Calculate header list size
@@ -4540,6 +4540,13 @@ impl H2FrameParser {
             return Some(stream);
         }
         if frame_type != FrameType::HTTP_FRAME_HEADERS as u8 || !self.is_server.get() {
+            return None;
+        }
+        // RFC 9113 §4.3: while a header block is mid-reassembly the only legal
+        // frame is a CONTINUATION for that stream, and dispatch_frame will
+        // reject this one. Don't allocate stream state, bump last_stream_id,
+        // or fire onStreamStart for a frame that is about to be rejected.
+        if self.expecting_continuation.get() != 0 {
             return None;
         }
         // Client-initiated streams must use odd identifiers (RFC 9113 §5.1.1).

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -4082,8 +4082,7 @@ impl H2FrameParser {
             let block = core::mem::take(&mut stream.pending_header_block);
             // Report the original HEADERS frame's flags (plus END_HEADERS now
             // that the block is complete), not the CONTINUATION frame's.
-            let block_flags =
-                stream.pending_header_flags | HeadersFrameFlags::END_HEADERS as u8;
+            let block_flags = stream.pending_header_flags | HeadersFrameFlags::END_HEADERS as u8;
             stream = match self.decode_header_block(&block, stream, block_flags)? {
                 // SAFETY: s is *mut Stream from self.streams (heap::alloc); valid while the map entry exists
                 Some(s) => unsafe { &mut *s },

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1319,6 +1319,181 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           }
         });
 
+        it("reassembles a header block split mid-instruction across HEADERS + CONTINUATION", async () => {
+          const { promise: waitToWrite, resolve: allowWrite } = Promise.withResolvers();
+          const { promise: serverListening, resolve: serverResolve } = Promise.withResolvers();
+          const block = http2utils.kFakeResponseHeaders;
+          const server = net.createServer(async socket => {
+            socket.on("error", () => {});
+            const settings = new http2utils.SettingsFrame(true);
+            socket.write(settings.data);
+            await waitToWrite;
+
+            // Split the HPACK block 2 bytes into the cache-control literal so
+            // neither fragment is independently decodable.
+            const headersFrame = new http2utils.HeadersFrame(1, block.subarray(0, 7), 0, /* EOH */ false, false);
+            socket.write(headersFrame.data);
+            const continuationFrame = new http2utils.ContinuationFrame(1, block.subarray(7), 0, false);
+            socket.write(continuationFrame.data);
+          });
+          server.listen(0, "127.0.0.1", () => serverResolve());
+          await serverListening;
+
+          const url = `http://127.0.0.1:${server.address().port}`;
+          const client = http2.connect(url);
+          try {
+            const { promise, resolve, reject } = Promise.withResolvers();
+            client.on("error", reject);
+            let sawTrailers = false;
+            client.on("connect", () => {
+              const req = client.request({ ":path": "/" });
+              req.on("error", reject);
+              req.on("trailers", () => {
+                sawTrailers = true;
+              });
+              req.on("response", headers => {
+                queueMicrotask(() => resolve(headers));
+              });
+              req.end();
+              allowWrite();
+            });
+            const headers = await promise;
+            expect(headers[":status"]).toBe(302);
+            expect(headers["cache-control"]).toBe("private");
+            expect(headers["date"]).toBe("Mon, 21 Oct 2013 20:13:21 GMT");
+            expect(headers["location"]).toBe("https://www.example.com");
+            expect(sawTrailers).toBe(false);
+          } finally {
+            client.destroy();
+            server.close();
+          }
+        });
+
+        it("treats an HPACK decode error in a complete header block as COMPRESSION_ERROR", async () => {
+          const { promise: waitToWrite, resolve: allowWrite } = Promise.withResolvers();
+          const { promise: serverListening, resolve: serverResolve } = Promise.withResolvers();
+          const block = http2utils.kFakeResponseHeaders;
+          const server = net.createServer(async socket => {
+            socket.on("error", () => {});
+            const settings = new http2utils.SettingsFrame(true);
+            socket.write(settings.data);
+            await waitToWrite;
+
+            // END_HEADERS is set, so this truncated block is "complete" and
+            // must fail HPACK decoding as a connection error.
+            const headersFrame = new http2utils.HeadersFrame(1, block.subarray(0, 7), 0, /* EOH */ true, false);
+            socket.write(headersFrame.data);
+          });
+          server.listen(0, "127.0.0.1", () => serverResolve());
+          await serverListening;
+
+          const url = `http://127.0.0.1:${server.address().port}`;
+          try {
+            const { promise, resolve } = Promise.withResolvers();
+            const client = http2.connect(url);
+            client.on("error", resolve);
+            client.on("connect", () => {
+              const req = client.request({ ":path": "/" });
+              req.on("error", () => {});
+              req.on("response", headers => resolve({ response: headers }));
+              req.end();
+              allowWrite();
+            });
+            const result = await promise;
+            expect(result).toBeDefined();
+            expect(result.code).toBe("ERR_HTTP2_SESSION_ERROR");
+            expect(result.message).toBe("Session closed with error code NGHTTP2_COMPRESSION_ERROR");
+          } finally {
+            server.close();
+          }
+        });
+
+        it("rejects a non-CONTINUATION frame while a header block is being reassembled", async () => {
+          const { promise: waitToWrite, resolve: allowWrite } = Promise.withResolvers();
+          const { promise: serverListening, resolve: serverResolve } = Promise.withResolvers();
+          const block = http2utils.kFakeResponseHeaders;
+          const server = net.createServer(async socket => {
+            socket.on("error", () => {});
+            const settings = new http2utils.SettingsFrame(true);
+            socket.write(settings.data);
+            await waitToWrite;
+
+            // RFC 9113 4.3: only CONTINUATION frames for the same stream may
+            // follow a HEADERS frame without END_HEADERS.
+            const headersFrame = new http2utils.HeadersFrame(1, block.subarray(0, 7), 0, /* EOH */ false, false);
+            socket.write(headersFrame.data);
+            socket.write(new http2utils.PingFrame(false).data);
+          });
+          server.listen(0, "127.0.0.1", () => serverResolve());
+          await serverListening;
+
+          const url = `http://127.0.0.1:${server.address().port}`;
+          try {
+            const { promise, resolve } = Promise.withResolvers();
+            const client = http2.connect(url);
+            client.on("error", resolve);
+            // If the interleaved PING is accepted the session pings back and no
+            // error ever fires; surface that as a failure instead of hanging.
+            client.on("ping", () => resolve({ ping: true }));
+            client.on("connect", () => {
+              const req = client.request({ ":path": "/" });
+              req.on("error", () => {});
+              req.on("response", headers => resolve({ response: headers }));
+              req.end();
+              allowWrite();
+            });
+            const result = await promise;
+            expect(result).toBeDefined();
+            expect(result.code).toBe("ERR_HTTP2_SESSION_ERROR");
+            expect(result.message).toBe("Session closed with error code NGHTTP2_PROTOCOL_ERROR");
+          } finally {
+            server.close();
+          }
+        });
+
+        it("rejects a header block whose compressed size exceeds maxHeaderListSize", async () => {
+          const { promise: waitToWrite, resolve: allowWrite } = Promise.withResolvers();
+          const { promise: serverListening, resolve: serverResolve } = Promise.withResolvers();
+          const server = net.createServer(async socket => {
+            socket.on("error", () => {});
+            const settings = new http2utils.SettingsFrame(true);
+            socket.write(settings.data);
+            await waitToWrite;
+
+            // 5 x 16384 = 81920 compressed bytes > the default 65535
+            // maxHeaderListSize; the connection must be torn down before the
+            // block is ever decoded.
+            const chunk = Buffer.alloc(16384, 0x41);
+            socket.write(Buffer.concat([new http2utils.HeadersFrame(1, chunk, 0, /* EOH */ false, false).data]));
+            for (let i = 0; i < 4; i++) {
+              // raw CONTINUATION frame without END_HEADERS
+              socket.write(Buffer.concat([new http2utils.Frame(chunk.byteLength, 9, 0, 1).data, chunk]));
+            }
+          });
+          server.listen(0, "127.0.0.1", () => serverResolve());
+          await serverListening;
+
+          const url = `http://127.0.0.1:${server.address().port}`;
+          try {
+            const { promise, resolve } = Promise.withResolvers();
+            const client = http2.connect(url);
+            client.on("error", resolve);
+            client.on("connect", () => {
+              const req = client.request({ ":path": "/" });
+              req.on("error", () => {});
+              req.on("response", headers => resolve({ response: headers }));
+              req.end();
+              allowWrite();
+            });
+            const result = await promise;
+            expect(result).toBeDefined();
+            expect(result.code).toBe("ERR_HTTP2_SESSION_ERROR");
+            expect(result.message).toBe("Session closed with error code NGHTTP2_ENHANCE_YOUR_CALM");
+          } finally {
+            server.close();
+          }
+        });
+
         it("should handle bad PRIOTITY_FRAME server frame size", async () => {
           const { promise: waitToWrite, resolve: allowWrite } = Promise.withResolvers();
           const { promise: serverListening, resolve: serverResolve } = Promise.withResolvers();


### PR DESCRIPTION
The node:http2 frame parser decoded each HEADERS and CONTINUATION fragment independently and silently truncated the header list when an HPACK instruction straddled a fragment boundary, which also left the connection-scoped dynamic table out of sync. Fragments are now buffered per stream and decoded once when END_HEADERS arrives; a decode failure on a complete block tears down the connection with COMPRESSION_ERROR, any non-CONTINUATION frame interleaved into an unfinished header block is a PROTOCOL_ERROR, and the buffered compressed block is capped at maxHeaderListSize. The header list size/count limits now finish consuming the block before rejecting it so the dynamic table stays consistent.

`request()` now also spreads its options object before the header block is encoded (matching Node), so a user-supplied option getter that re-entrantly calls `request()` can no longer reorder header blocks on the wire relative to the order they were encoded.

Adds four raw-frame tests to test/js/node/http2/node-http2.test.js covering reassembly of a block split mid-instruction, decode failure of a complete block, an interleaved frame during reassembly, and an oversized compressed block. The existing CONTINUATION suite (150/300-header send and receive, large trailers, padding sweep) passes unchanged.