### PR TITLE
Fix `await using` expression printing `using` as `await`

### DIFF
--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -919,7 +919,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             decls: decls_slice,
                         });
                     }
-                    let r = p.store_name_in_ref(raw)?;
+                    let r = p.store_name_in_ref(raw2)?;
                     break 'value p.new_expr(
                         E::Identifier {
                             ref_: r,

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3824,6 +3824,29 @@ console.log("boop");
     expectCapturePrintedSnapshot(`for await (await using a of b) { c(a); a(c) }`);
   });
 
+  it("await of the identifier 'using' is not an await using declaration", () => {
+    // "await using" only starts a declaration when followed by an identifier on
+    // the same line. Otherwise it's an "await" expression of the identifier "using".
+    expectPrinted_(
+      "async function f() { await using instanceof o }",
+      "async function f() {\n  await using instanceof o;\n}",
+    );
+    expectPrinted_("async function f() { await using }", "async function f() {\n  await using;\n}");
+    expectPrinted_(
+      "async function f() { await using\n x = 1 }",
+      "async function f() {\n  await using;\n  x = 1;\n}",
+    );
+    expectPrinted_(
+      "async function f() { await using.foo() }",
+      "async function f() {\n  await using.foo();\n}",
+    );
+    expectPrinted_(
+      "async function f() { for (await using instanceof o;;); }",
+      "async function f() {\n  for (await using instanceof o;; )\n    ;\n}",
+    );
+    expectBunPrinted_("await using instanceof o", "await using instanceof o");
+  });
+
   it("using top level", () => {
     expectPrintedSnapshot(`
       using a = b;

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3832,14 +3832,8 @@ console.log("boop");
       "async function f() {\n  await using instanceof o;\n}",
     );
     expectPrinted_("async function f() { await using }", "async function f() {\n  await using;\n}");
-    expectPrinted_(
-      "async function f() { await using\n x = 1 }",
-      "async function f() {\n  await using;\n  x = 1;\n}",
-    );
-    expectPrinted_(
-      "async function f() { await using.foo() }",
-      "async function f() {\n  await using.foo();\n}",
-    );
+    expectPrinted_("async function f() { await using\n x = 1 }", "async function f() {\n  await using;\n  x = 1;\n}");
+    expectPrinted_("async function f() { await using.foo() }", "async function f() {\n  await using.foo();\n}");
     expectPrinted_(
       "async function f() { for (await using instanceof o;;); }",
       "async function f() {\n  for (await using instanceof o;; )\n    ;\n}",


### PR DESCRIPTION
### Problem

Found by the transpiler fuzzer (printed output does not reparse):

```js
new Bun.Transpiler({ loader: "jsx", target: "bun", minifyWhitespace: true })
  .transformSync("async function f(){await using instanceof o}")
// => "async function f(){await await instanceof o}"   (does not reparse: "Unexpected instanceof")
```

`await using` only starts an `await using` declaration when it is followed by an identifier on the same line. Otherwise it is an `await` expression whose operand is the identifier `using` — e.g. `await using instanceof o`, `await using.foo()`, `await using` followed by a newline. In that fallback path the parser printed the operand as `await`, producing invalid output like `await await instanceof o`.

### Cause

In `parse_expr_or_let_stmt` (`src/js_parser/parse/mod.rs`), the fallback that builds the `E::Identifier` for `using` called `store_name_in_ref(raw)`, where `raw` is the raw text of the *first* token (`"await"`). The identifier therefore got the name `await`. The correct name is `raw2`, the raw text of the `using` token.

### Fix

Pass `raw2` (`"using"`) to `store_name_in_ref`, matching what the normal identifier-expression path would have stored.

### Verification

- `bun bd test test/bundler/transpiler/transpiler.test.js` — 147 pass, 0 fail.
- New test `await of the identifier 'using' is not an await using declaration` covers `instanceof`, bare `await using`, ASI via newline, member access, for-loop init, and top-level await; it fails without the src change and passes with it.
- `await using x = y`, `using x = y`, and `for (await using a of b)` declarations still parse and lower through `__using`/`__callDispose` as before.