### PR TITLE
Parenthesize `async` when it starts a for-of loop initializer

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1524,6 +1524,7 @@ pub enum ExprFlag {
     ForbidIn,
     HasNonOptionalChainParent,
     ExprResultIsUnused,
+    IsFollowedByOf,
 }
 
 pub type ExprFlagSet = enumset::EnumSet<ExprFlag>;
@@ -1545,6 +1546,10 @@ impl ExprFlag {
     #[inline]
     pub fn expr_result_is_unused() -> ExprFlagSet {
         ExprFlag::ExprResultIsUnused.into()
+    }
+    #[inline]
+    pub fn is_followed_by_of() -> ExprFlagSet {
+        ExprFlag::IsFollowedByOf.into()
     }
 }
 
@@ -4255,7 +4260,12 @@ pub mod __gated_printer {
                 }
                 ExprData::EIdentifier(e) => {
                     let name = self.name_for_symbol(e.ref_);
-                    let wrap = self.writer.written() == self.for_of_init_start && name == b"let";
+                    // A for-of loop initializer must not start with the token "let" and
+                    // must not be the exact token sequence "async of" (e.g. the escaped
+                    // identifier in "for (\u0061sync of []) ;"), so wrap in parentheses.
+                    let wrap = self.writer.written() == self.for_of_init_start
+                        && (name == b"let"
+                            || (name == b"async" && flags.contains(ExprFlag::IsFollowedByOf)));
 
                     if wrap {
                         self.print(b"(");
@@ -5808,7 +5818,7 @@ pub mod __gated_printer {
                     self.print(b"for");
                     self.print_space();
                     self.print(b"(");
-                    self.print_for_loop_init(s.init);
+                    self.print_for_loop_init(s.init, ExprFlag::none());
                     self.print_space();
                     self.print_space_before_identifier();
                     self.print(b"in");
@@ -5828,7 +5838,7 @@ pub mod __gated_printer {
                     self.print_space();
                     self.print(b"(");
                     self.for_of_init_start = self.writer.written();
-                    self.print_for_loop_init(s.init);
+                    self.print_for_loop_init(s.init, ExprFlag::is_followed_by_of());
                     self.print_space();
                     self.print_space_before_identifier();
                     self.print(b"of");
@@ -5914,7 +5924,7 @@ pub mod __gated_printer {
                     self.print(b"(");
 
                     if let Some(init_) = &s.init {
-                        self.print_for_loop_init(*init_);
+                        self.print_for_loop_init(*init_, ExprFlag::none());
                     }
 
                     self.print(b";");
@@ -6601,13 +6611,13 @@ pub mod __gated_printer {
             self.print(b", enumerable: true, configurable: true})");
         }
 
-        pub fn print_for_loop_init(&mut self, init_st: Stmt) {
+        pub fn print_for_loop_init(&mut self, init_st: Stmt, extra_flags: ExprFlagSet) {
             match &init_st.data {
                 StmtData::SExpr(s) => {
                     self.print_expr(
                         s.value,
                         Level::Lowest,
-                        ExprFlag::ForbidIn | ExprFlag::ExprResultIsUnused,
+                        ExprFlag::ForbidIn | ExprFlag::ExprResultIsUnused | extra_flags,
                     );
                 }
                 StmtData::SLocal(s) => {

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -3823,6 +3823,8 @@ pub mod __gated_printer {
                         flags.remove(ExprFlag::HasNonOptionalChainParent);
                     }
 
+                    // The index target is not directly followed by `of`.
+                    flags.remove(ExprFlag::IsFollowedByOf);
                     self.print_expr(e.target, Level::Postfix, flags);
 
                     let is_optional_chain_start =

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2052,6 +2052,29 @@ console.log(<div {...obj} key="after" />);`),
       expectParseError("await -x ** 0", "Unexpected **");
     });
 
+    it("for-of loop variable named async", () => {
+      // "\u0061sync" is the identifier `async`, which is legal as a for-of loop
+      // variable, but printing it as the raw token sequence `async of` is a
+      // syntax error, so the printer must parenthesize it.
+      expectPrinted_("for (\\u0061sync of [7]);", "for ((async) of [7])\n  ;\n");
+      expectPrinted_("for ((async) of [7]);", "for ((async) of [7])\n  ;\n");
+      expectPrinted_(
+        "async function f() { for await (\\u0061sync of [7]); }",
+        "async function f() {\n  for await ((async) of [7])\n    ;\n}",
+      );
+
+      // The same identifier needs no parentheses when it is not directly followed by `of`
+      expectPrinted_("for (async.x of [7]);", "for (async.x of [7])\n  ;\n");
+      expectPrinted_("for (x[\\u0061sync] of [7]);", "for (x[async] of [7])\n  ;\n");
+      expectPrinted_("for (\\u0061sync in x);", "for (async in x)\n  ;\n");
+
+      // `let` as a for-of loop variable keeps its parentheses too
+      expectPrinted_("for ((let) of [7]);", "for ((let) of [7])\n  ;\n");
+
+      // The keyword spelling is a syntax error, which is why the parentheses matter
+      expect(() => parsed("for (async of [7]);", false, false)).toThrow();
+    });
+
     it("await", () => {
       expectPrinted("await x", "await x");
       expectPrinted("await +x", "await +x");

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2065,6 +2065,7 @@ console.log(<div {...obj} key="after" />);`),
 
       // The same identifier needs no parentheses when it is not directly followed by `of`
       expectPrinted_("for (async.x of [7]);", "for (async.x of [7])\n  ;\n");
+      expectPrinted_("for (\\u0061sync[0] of [7]);", "for (async[0] of [7])\n  ;\n");
       expectPrinted_("for (x[\\u0061sync] of [7]);", "for (x[async] of [7])\n  ;\n");
       expectPrinted_("for (\\u0061sync in x);", "for (async in x)\n  ;\n");
 


### PR DESCRIPTION
### What does this PR do?

Fixes a printer bug found by fuzzing (invariant: printed output must reparse):

```js
new Bun.Transpiler({ loader: "tsx", target: "bun" }).transformSync("for (\\u0061sync of [7]);")
// before: "for (async of [7])\n  ;\n"   ← not valid JS, Bun (and JSC) cannot reparse it
// after:  "for ((async) of [7])\n  ;\n" ← reparses and runs
```

`\u0061sync` is a legal identifier spelling of `async` and is valid as a for-of loop variable, but the for-of grammar has the restriction `[lookahead ∉ { let, async of }]`, so the *token sequence* `async of` may not start the initializer. The printer emitted the identifier as a bare `async`, producing output that neither Bun's parser nor JSC accepts.

### Cause

`src/js_printer/lib.rs` only parenthesized `let` at the start of a for-of initializer (`for ((let) of x)`), not `async`.

### Fix

Add an `IsFollowedByOf` expr flag that `SForOf` passes into `print_for_loop_init`. When an identifier named `async` is printed at the very start of a for-of initializer and is directly followed by `of`, it is wrapped in parentheses — mirroring the existing `let` handling and esbuild's behavior.

- `for (async.x of y)`, `for (async[0] of y)`, `for (x[async] of y)`, `for (async in x)` are unchanged (no parens needed).
- `for await (\u0061sync of x)` is also wrapped: Bun's parser (and JSC) reject the bare spelling there as well.

### Verification

- New test in `test/bundler/transpiler/transpiler.test.js` (`for-of loop variable named async`): fails on bun without this change, passes with it.
- Full `test/bundler/transpiler/transpiler.test.js` passes with the debug build (147 pass / 0 fail).
- Runtime check: `let \u0061sync; for (\u0061sync of [7, 8]) log.push(async * 2)` executes correctly with the debug build.

