### PR TITLE
install: fail closed on unusable npm integrity (pin computed sha512; reject invalid manifest/lockfile hashes)

### DIFF
--- a/src/install/PackageManager/processDependencyList.rs
+++ b/src/install/PackageManager/processDependencyList.rs
@@ -350,8 +350,7 @@ impl PackageManager {
                     && *package_id != INVALID_PACKAGE_ID
                     && data.integrity.tag.is_supported()
                 {
-                    let meta =
-                        &mut self.lockfile.packages.items_meta_mut()[*package_id as usize];
+                    let meta = &mut self.lockfile.packages.items_meta_mut()[*package_id as usize];
                     if !meta.integrity.tag.is_supported() {
                         meta.integrity = data.integrity;
                     }

--- a/src/install/PackageManager/processDependencyList.rs
+++ b/src/install/PackageManager/processDependencyList.rs
@@ -341,19 +341,6 @@ impl PackageManager {
                     let _ = scripts;
                 }
 
-                // Persist the integrity computed during extraction (registry
-                // manifest carried no usable integrity) so the lockfile pins
-                // the tarball content.
-                if resolution.tag == ResolutionTag::Npm
-                    && *package_id != INVALID_PACKAGE_ID
-                    && data.integrity.tag.is_supported()
-                {
-                    let meta = &mut self.lockfile.packages.items_meta_mut()[*package_id as usize];
-                    if !meta.integrity.tag.is_supported() {
-                        meta.integrity = data.integrity;
-                    }
-                }
-
                 None
             }
         }

--- a/src/install/PackageManager/processDependencyList.rs
+++ b/src/install/PackageManager/processDependencyList.rs
@@ -342,10 +342,8 @@ impl PackageManager {
                 }
 
                 // Persist the integrity computed during extraction (registry
-                // manifest carried no usable integrity) so the first install's
-                // lockfile already pins the tarball content. This mirrors the
-                // `package.meta.integrity = data.integrity` write-back the
-                // Github and Local/RemoteTarball arms above perform.
+                // manifest carried no usable integrity) so the lockfile pins
+                // the tarball content.
                 if resolution.tag == ResolutionTag::Npm
                     && *package_id != INVALID_PACKAGE_ID
                     && data.integrity.tag.is_supported()

--- a/src/install/PackageManager/processDependencyList.rs
+++ b/src/install/PackageManager/processDependencyList.rs
@@ -341,6 +341,22 @@ impl PackageManager {
                     let _ = scripts;
                 }
 
+                // Persist the integrity computed during extraction (registry
+                // manifest carried no usable integrity) so the first install's
+                // lockfile already pins the tarball content. This mirrors the
+                // `package.meta.integrity = data.integrity` write-back the
+                // Github and Local/RemoteTarball arms above perform.
+                if resolution.tag == ResolutionTag::Npm
+                    && *package_id != INVALID_PACKAGE_ID
+                    && data.integrity.tag.is_supported()
+                {
+                    let meta =
+                        &mut self.lockfile.packages.items_meta_mut()[*package_id as usize];
+                    if !meta.integrity.tag.is_supported() {
+                        meta.integrity = data.integrity;
+                    }
+                }
+
                 None
             }
         }

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1143,8 +1143,8 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                 {
                     let computed = task.data_extract().integrity;
                     if computed.tag.is_supported() {
-                        let meta = &mut manager.lockfile.packages.items_meta_mut()
-                            [package_id as usize];
+                        let meta =
+                            &mut manager.lockfile.packages.items_meta_mut()[package_id as usize];
                         if !meta.integrity.tag.is_supported() {
                             meta.integrity = computed;
                             manager

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1132,6 +1132,29 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                 manager.extracted_count += 1;
                 bun_core::analytics::Features::extracted_packages_inc();
 
+                // Back-fill a registry package whose manifest or lockfile entry
+                // carried no usable integrity: the extractor hashed the bytes
+                // as they were downloaded, so pin that value now and force a
+                // lockfile save so subsequent installs verify against it. Runs
+                // here (rather than in a single callback) so the resolve phase
+                // and both hoisted/isolated install phases share one write-back.
+                if resolution.tag == bun_install::ResolutionTag::Npm
+                    && package_id != INVALID_PACKAGE_ID
+                {
+                    let computed = task.data_extract().integrity;
+                    if computed.tag.is_supported() {
+                        let meta = &mut manager.lockfile.packages.items_meta_mut()
+                            [package_id as usize];
+                        if !meta.integrity.tag.is_supported() {
+                            meta.integrity = computed;
+                            manager
+                                .options
+                                .enable
+                                .set(Enable::FORCE_SAVE_LOCKFILE, true);
+                        }
+                    }
+                }
+
                 if C::HAS_ON_EXTRACT {
                     if C::IS_PACKAGE_INSTALLER {
                         C::as_package_installer(extract_ctx).fix_cached_lockfile_package_slices();

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -211,11 +211,13 @@ impl TarballStream {
 
         // For GitHub/URL/local tarballs we need a SHA-512 to record in the
         // lockfile even when there is no expected value to verify against,
-        // matching `ExtractTarball.run`.
+        // matching `ExtractTarball.run`. npm packages get the same fallback so
+        // a registry manifest with no usable integrity still ends up pinned,
+        // unless the user opted out of integrity work with `--no-verify`.
         let compute_if_missing = matches!(
             tarball.resolution.tag,
             ResolutionTag::Github | ResolutionTag::RemoteTarball | ResolutionTag::LocalTarball
-        );
+        ) || (tarball.resolution.tag == ResolutionTag::Npm && !tarball.skip_verify);
 
         let npm_mode = tarball.resolution.tag != ResolutionTag::Github;
         let want_first_dirname = tarball.resolution.tag == ResolutionTag::Github;
@@ -1171,7 +1173,8 @@ impl TarballStream {
             };
 
             match tarball.resolution.tag {
-                ResolutionTag::Github
+                ResolutionTag::Npm
+                | ResolutionTag::Github
                 | ResolutionTag::RemoteTarball
                 | ResolutionTag::LocalTarball => {
                     if tarball.integrity.tag.is_supported() {

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -217,7 +217,8 @@ impl TarballStream {
         let compute_if_missing = matches!(
             tarball.resolution.tag,
             ResolutionTag::Github | ResolutionTag::RemoteTarball | ResolutionTag::LocalTarball
-        ) || (tarball.resolution.tag == ResolutionTag::Npm && !tarball.skip_verify);
+        ) || (tarball.resolution.tag == ResolutionTag::Npm
+            && !tarball.skip_verify);
 
         let npm_mode = tarball.resolution.tag != ResolutionTag::Github;
         let want_first_dirname = tarball.resolution.tag == ResolutionTag::Github;

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -77,6 +77,18 @@ impl ExtractTarball {
                     result.integrity = Integrity::for_bytes(bytes);
                 }
             }
+            // npm registry packages whose manifest carried no usable integrity
+            // (missing, unsupported algorithm, or malformed) would otherwise stay
+            // permanently unverified: compute and pin a SHA-512 of the downloaded
+            // tarball so subsequent installs can detect a swap. `--no-verify` is
+            // an explicit opt-out of integrity work, so it skips the fallback too.
+            ResolutionTag::Npm => {
+                if self.integrity.tag.is_supported() {
+                    result.integrity = self.integrity;
+                } else if !self.skip_verify {
+                    result.integrity = Integrity::for_bytes(bytes);
+                }
+            }
             _ => {}
         }
 

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -77,11 +77,9 @@ impl ExtractTarball {
                     result.integrity = Integrity::for_bytes(bytes);
                 }
             }
-            // npm registry packages whose manifest carried no usable integrity
-            // (missing, unsupported algorithm, or malformed) would otherwise stay
-            // permanently unverified: compute and pin a SHA-512 of the downloaded
-            // tarball so subsequent installs can detect a swap. `--no-verify` is
-            // an explicit opt-out of integrity work, so it skips the fallback too.
+            // Same fallback for npm packages whose manifest carried no usable
+            // integrity (missing, unsupported algorithm, or malformed), so they
+            // don't stay permanently unverified. `--no-verify` opts out.
             ResolutionTag::Npm => {
                 if self.integrity.tag.is_supported() {
                     result.integrity = self.integrity;

--- a/src/install/integrity.rs
+++ b/src/install/integrity.rs
@@ -287,6 +287,13 @@ impl Tag {
     pub const SHA384: Tag = Tag(3);
     /// The value is a [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) value
     pub const SHA512: Tag = Tag(4);
+    /// The registry manifest carried a non-empty `dist.integrity` that did not
+    /// parse as a supported SRI value (unknown algorithm, bad base64, or wrong
+    /// digest length). Distinguished from `UNKNOWN` so the resolve step can
+    /// refuse the version instead of treating the hash as merely absent.
+    /// Never written to disk: not `is_supported()`, so `Display` emits nothing
+    /// and `verify()` rejects it.
+    pub const INVALID: Tag = Tag(5);
 
     #[inline]
     pub fn is_supported(self) -> bool {

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -844,7 +844,22 @@ impl Package<u64> {
 
             package.meta.arch = package_version.cpu;
             package.meta.os = package_version.os;
-            package.meta.integrity = package_version.integrity;
+            package.meta.integrity = if package_version.integrity.tag
+                == crate::integrity::Tag::INVALID
+            {
+                log.add_error_fmt(
+                    None,
+                    bun_ast::Loc::EMPTY,
+                    format_args!(
+                        "Registry provided an invalid integrity hash for {}@{}",
+                        bstr::BStr::new(manifest.name()),
+                        version.fmt(&manifest.string_buf),
+                    ),
+                );
+                crate::integrity::Integrity::default()
+            } else {
+                package_version.integrity
+            };
             package
                 .meta
                 .set_has_install_script(package_version.has_install_script);

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -844,22 +844,21 @@ impl Package<u64> {
 
             package.meta.arch = package_version.cpu;
             package.meta.os = package_version.os;
-            package.meta.integrity = if package_version.integrity.tag
-                == crate::integrity::Tag::INVALID
-            {
-                log.add_error_fmt(
-                    None,
-                    bun_ast::Loc::EMPTY,
-                    format_args!(
-                        "Registry provided an invalid integrity hash for {}@{}",
-                        bstr::BStr::new(manifest.name()),
-                        version.fmt(&manifest.string_buf),
-                    ),
-                );
-                crate::integrity::Integrity::default()
-            } else {
-                package_version.integrity
-            };
+            package.meta.integrity =
+                if package_version.integrity.tag == crate::integrity::Tag::INVALID {
+                    log.add_error_fmt(
+                        None,
+                        bun_ast::Loc::EMPTY,
+                        format_args!(
+                            "Registry provided an invalid integrity hash for {}@{}",
+                            bstr::BStr::new(manifest.name()),
+                            version.fmt(&manifest.string_buf),
+                        ),
+                    );
+                    crate::integrity::Integrity::default()
+                } else {
+                    package_version.integrity
+                };
             package
                 .meta
                 .set_has_install_script(package_version.has_install_script);

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -110,6 +110,9 @@ pub enum Version {
     /// lockfile keeps loading:
     /// - an npm package resolved to a tarball URL outside the configured
     ///   registry must carry a supported integrity hash
+    /// - an npm package's integrity string, when non-empty, must parse as a
+    ///   supported SRI hash (unparseable/unknown-algorithm entries are
+    ///   rejected rather than warned-and-ignored)
     /// - a git `.bun-tag` must be a safe path/checkout component (the same
     ///   check on a `github` tag is enforced at every version, since its
     ///   download path has no checkout-time re-validation)
@@ -2622,11 +2625,19 @@ pub fn parse_into_binary_lockfile(
 
                     pkg.meta.integrity = Integrity::parse(integrity_str);
                     if !integrity_str.is_empty() && !pkg.meta.integrity.tag.is_supported() {
-                        // Surface — don't fail — for npm parity (`npm install`
-                        // proceeds on a malformed lockfile integrity, treating
-                        // it as absent). The download path still applies any
-                        // registry-supplied integrity, so this only loses the
-                        // *lockfile* pin.
+                        // A non-empty value that doesn't parse as a supported
+                        // SRI hash is refused so a tampered or unknown-algorithm
+                        // entry cannot silently disable verification. Gated to
+                        // v2+ so lockfiles written before this check keep
+                        // loading with the prior warn-and-ignore behaviour.
+                        if lockfile_version.at_least(Version::V2) {
+                            log.add_error(
+                                Some(source),
+                                item_loc(source, key_loc, i),
+                                b"Unsupported or malformed integrity hash for npm package",
+                            );
+                            return Err(ParseError::InvalidPackageInfo);
+                        }
                         log.add_warning(
                             Some(source),
                             item_loc(source, key_loc, i),
@@ -2652,6 +2663,39 @@ pub fn parse_into_binary_lockfile(
                             b"Missing integrity hash for npm package resolved to a tarball URL outside the configured registry",
                         );
                         return Err(ParseError::InvalidPackageInfo);
+                    }
+
+                    // An empty integrity string means this entry vouches for
+                    // nothing. The download path computes and back-fills a
+                    // SHA-512 once the tarball is fetched, so a non-frozen
+                    // install self-heals; under --frozen-lockfile the lockfile
+                    // cannot be updated and the unverified entry is refused.
+                    // Gated to v2+ so lockfiles written before the back-fill
+                    // existed (which always persisted `""` for a registry with
+                    // no integrity) keep loading silently.
+                    if lockfile_version.at_least(Version::V2) && integrity_str.is_empty() {
+                        let frozen = manager
+                            .as_deref()
+                            .is_some_and(|m| m.options.enable.frozen_lockfile());
+                        if frozen {
+                            log.add_error_fmt(
+                                Some(source),
+                                item_loc(source, key_loc, i),
+                                format_args!(
+                                    "Package {} has no integrity pin in the frozen lockfile",
+                                    bstr::BStr::new(name_str),
+                                ),
+                            );
+                            return Err(ParseError::InvalidPackageInfo);
+                        }
+                        log.add_warning_fmt(
+                            Some(source),
+                            item_loc(source, key_loc, i),
+                            format_args!(
+                                "Package {} has no integrity pin in the lockfile; it will be computed after download",
+                                bstr::BStr::new(name_str),
+                            ),
+                        );
                     }
                 }
                 ResolutionTag::LocalTarball | ResolutionTag::RemoteTarball => {

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -2568,16 +2568,29 @@ impl PackageManifest {
                             package_version.unpacked_size = n.value() as u32;
                         }
 
-                        if let Some(shasum_str) = dist.get(b"integrity").and_then(|v| v.as_str()) {
-                            package_version.integrity = Integrity::parse(shasum_str);
+                        let mut had_invalid_integrity = false;
+                        if let Some(sri_str) = dist.get(b"integrity").and_then(|v| v.as_str()) {
+                            package_version.integrity = Integrity::parse(sri_str);
                             if package_version.integrity.tag.is_supported() {
                                 break 'integrity;
                             }
+                            had_invalid_integrity = !sri_str.is_empty();
                         }
 
                         if let Some(shasum_str) = dist.get(b"shasum").and_then(|v| v.as_str()) {
                             package_version.integrity =
                                 Integrity::parse_sha_sum(shasum_str).unwrap_or_default();
+                            if package_version.integrity.tag.is_supported() {
+                                break 'integrity;
+                            }
+                            had_invalid_integrity |= !shasum_str.is_empty();
+                        }
+
+                        if had_invalid_integrity {
+                            package_version.integrity = Integrity {
+                                tag: crate::integrity::Tag::INVALID,
+                                ..Default::default()
+                            };
                         }
                     }
                 }

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -751,6 +751,219 @@ describe.concurrent("tarball integrity metadata forms", () => {
   });
 });
 
+describe.concurrent("npm registry without usable integrity metadata", () => {
+  function octal(n: number, width: number) {
+    return n.toString(8).padStart(width - 1, "0") + "\0";
+  }
+  function tarHeader(name: string, size: number) {
+    const buf = Buffer.alloc(512, 0);
+    buf.write(name, 0, 100, "utf8");
+    buf.write(octal(0o644, 8), 100);
+    buf.write(octal(0, 8), 108);
+    buf.write(octal(0, 8), 116);
+    buf.write(octal(size, 12), 124);
+    buf.write(octal(0, 12), 136);
+    buf.fill(" ", 148, 156);
+    buf.write("0", 156);
+    buf.write("ustar\0", 257);
+    buf.write("00", 263);
+    let sum = 0;
+    for (let i = 0; i < 512; i++) sum += buf[i];
+    buf.write(octal(sum, 8), 148);
+    return buf;
+  }
+  function pad512(len: number) {
+    return Buffer.alloc((512 - (len % 512)) % 512, 0);
+  }
+  function buildTarball(body: Buffer) {
+    const tar = Buffer.concat([
+      tarHeader("package/package.json", body.length),
+      body,
+      pad512(body.length),
+      Buffer.alloc(1024, 0),
+    ]);
+    return gzipSync(tar);
+  }
+
+  // The registry advertises an integrity value Bun cannot use (unsupported
+  // algorithm or malformed base64) — or none at all. Bun must compute and pin
+  // its own SHA-512 of the downloaded tarball so a later swap of the tarball
+  // bytes is detected. The third variant forces the streaming extractor
+  // (normally reserved for tarballs >= 2 MiB) so both extract paths are
+  // covered.
+  for (const [label, dist, extraEnv] of [
+    ["unsupported algorithm", { integrity: "md5-AAAAAAAAAAAAAAAAAAAAAA==" }, {}],
+    ["malformed base64", { integrity: "sha512-!!!" }, {}],
+    [
+      "unsupported algorithm, streaming",
+      { integrity: "md5-AAAAAAAAAAAAAAAAAAAAAA==" },
+      { BUN_INSTALL_STREAMING_MIN_SIZE: "1" },
+    ],
+  ] as const) {
+    it(`pins a computed sha512 when the manifest integrity is unparseable (${label}) and rejects a swapped tarball on reinstall`, async () => {
+      const tarballA = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
+      const tarballB = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0","swapped":true}\n'));
+
+      let tarballRequests = 0;
+      await using server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        async fetch(req) {
+          const url = new URL(req.url);
+          if (url.pathname.endsWith("/pkg")) {
+            return Response.json({
+              name: "pkg",
+              "dist-tags": { latest: "1.0.0" },
+              versions: {
+                "1.0.0": {
+                  name: "pkg",
+                  version: "1.0.0",
+                  dist: {
+                    ...dist,
+                    tarball: `http://127.0.0.1:${server.port}/pkg/-/pkg-1.0.0.tgz`,
+                  },
+                },
+              },
+            });
+          }
+          if (url.pathname.endsWith("/pkg-1.0.0.tgz")) {
+            tarballRequests++;
+            const tgz = tarballRequests <= 1 ? tarballA : tarballB;
+            return new Response(tgz, { headers: { "content-length": String(tgz.length) } });
+          }
+          return new Response("Not found", { status: 404 });
+        },
+      });
+
+      using dir = tempDir("npm-integrity-unparseable", {
+        "package.json": JSON.stringify({
+          name: "app",
+          version: "1.0.0",
+          dependencies: { pkg: "1.0.0" },
+        }),
+        "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:${server.port}/"\nlinker = "hoisted"\n`,
+      });
+      const cacheDir = join(String(dir), ".cache");
+
+      // First install: the unparseable manifest integrity must not leave the
+      // package permanently unverified — Bun computes a SHA-512 of the bytes
+      // it downloaded and records it in the lockfile.
+      {
+        await using proc = spawn({
+          cmd: [bunExe(), "install", "--save-text-lockfile"],
+          cwd: String(dir),
+          env: { ...env, ...extraEnv, BUN_INSTALL_CACHE_DIR: cacheDir },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+        expect(stderr).toContain("Saved lockfile");
+        expect(exitCode).toBe(0);
+      }
+
+      const lockContent = await file(join(String(dir), "bun.lock")).text();
+      expect(lockContent).toMatch(/"sha512-[A-Za-z0-9+/]+=*"/);
+
+      // Second install from scratch: the server now serves different bytes.
+      // The pin recorded on the first install must reject the swap.
+      await rm(join(String(dir), "node_modules"), { recursive: true, force: true });
+      await rm(cacheDir, { recursive: true, force: true });
+
+      {
+        await using proc = spawn({
+          cmd: [bunExe(), "install"],
+          cwd: String(dir),
+          env: { ...env, ...extraEnv, BUN_INSTALL_CACHE_DIR: cacheDir },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+        expect(stderr + stdout).toContain("Integrity check failed");
+        expect(stdout).not.toContain("1 package installed");
+        expect(exitCode).not.toBe(0);
+      }
+    });
+  }
+
+  it("does not re-save the lockfile on reinstall when the registry provides no integrity metadata", async () => {
+    const tarball = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
+
+    await using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      async fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname.endsWith("/pkg")) {
+          return Response.json({
+            name: "pkg",
+            "dist-tags": { latest: "1.0.0" },
+            versions: {
+              "1.0.0": {
+                name: "pkg",
+                version: "1.0.0",
+                // No dist.integrity and no dist.shasum.
+                dist: { tarball: `http://127.0.0.1:${server.port}/pkg/-/pkg-1.0.0.tgz` },
+              },
+            },
+          });
+        }
+        if (url.pathname.endsWith("/pkg-1.0.0.tgz")) {
+          return new Response(tarball, { headers: { "content-length": String(tarball.length) } });
+        }
+        return new Response("Not found", { status: 404 });
+      },
+    });
+
+    using dir = tempDir("npm-integrity-no-resave", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { pkg: "1.0.0" },
+      }),
+      "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:${server.port}/"\nlinker = "hoisted"\n`,
+    });
+    const cacheDir = join(String(dir), ".cache");
+
+    // First install: pins the computed SHA-512 into the lockfile.
+    {
+      await using proc = spawn({
+        cmd: [bunExe(), "install", "--save-text-lockfile"],
+        cwd: String(dir),
+        env: { ...env, BUN_INSTALL_CACHE_DIR: cacheDir },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("Saved lockfile");
+      expect(exitCode).toBe(0);
+    }
+
+    const lockContent = await file(join(String(dir), "bun.lock")).text();
+    expect(lockContent).toMatch(/"sha512-[A-Za-z0-9+/]+=*"/);
+
+    // Second install of the unchanged project, forcing a re-download and
+    // re-extract: the lockfile already contains the pin, so it must not be
+    // dirtied and re-saved again.
+    await rm(join(String(dir), "node_modules"), { recursive: true, force: true });
+    await rm(cacheDir, { recursive: true, force: true });
+
+    {
+      await using proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env: { ...env, BUN_INSTALL_CACHE_DIR: cacheDir },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      expect(stderr).not.toContain("Saved lockfile");
+      expect(stderr + stdout).not.toContain("Integrity check failed");
+      expect(stdout).toContain("1 package installed");
+      expect(exitCode).toBe(0);
+    }
+  });
+});
+
 describe.concurrent.each(["hoisted", "isolated"] as const)("tarball download failure (%s)", linker => {
   it("should fail (not hang) when registry returns 404 for tarball", async () => {
     await withContext({ linker }, async ctx => {

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -1,7 +1,7 @@
 import { file, spawn } from "bun";
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
-import { rm, writeFile } from "fs/promises";
 import { readFileSync, writeFileSync } from "fs";
+import { rm, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env, readdirSorted, tempDir } from "harness";
 import { createHash } from "node:crypto";
 import { gzipSync } from "node:zlib";

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -1,6 +1,7 @@
 import { file, spawn } from "bun";
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { rm, writeFile } from "fs/promises";
+import { readFileSync, writeFileSync } from "fs";
 import { bunExe, bunEnv as env, readdirSorted, tempDir } from "harness";
 import { createHash } from "node:crypto";
 import { gzipSync } from "node:zlib";
@@ -784,106 +785,221 @@ describe.concurrent("npm registry without usable integrity metadata", () => {
     ]);
     return gzipSync(tar);
   }
+  function sha512(bytes: Uint8Array) {
+    return "sha512-" + createHash("sha512").update(bytes).digest("base64");
+  }
+  function makeRegistry(state: { bytes: Buffer; dist: Record<string, string> }) {
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      async fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname.endsWith(".tgz")) {
+          return new Response(state.bytes, { headers: { "content-length": String(state.bytes.length) } });
+        }
+        return Response.json({
+          name: "pkg",
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              name: "pkg",
+              version: "1.0.0",
+              dist: { tarball: `http://127.0.0.1:${server.port}/pkg/-/pkg-1.0.0.tgz`, ...state.dist },
+            },
+          },
+        });
+      },
+    });
+    return server;
+  }
+  function projectDir(name: string, port: number) {
+    return tempDir(name, {
+      "package.json": JSON.stringify({ name: "app", version: "1.0.0", dependencies: { pkg: "1.0.0" } }),
+      "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:${port}/"\nlinker = "hoisted"\n`,
+    });
+  }
+  async function runInstall(dir: string, extra: string[] = [], extraEnv: Record<string, string> = {}) {
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--no-progress", ...extra],
+      cwd: dir,
+      env: { ...env, ...extraEnv, BUN_INSTALL_CACHE_DIR: join(dir, ".cache"), NO_COLOR: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    return { stderr, stdout, exitCode };
+  }
+  function lockfileIntegrity(dir: string) {
+    const text = readFileSync(join(dir, "bun.lock"), "utf8");
+    const m = text.match(/"pkg@1\.0\.0"[^\n]*?"((?:sha\d+-[A-Za-z0-9+/]+=*)?)"\]/);
+    return m ? m[1] : null;
+  }
 
-  // The registry advertises an integrity value Bun cannot use (unsupported
-  // algorithm or malformed base64) — or none at all. Bun must compute and pin
-  // its own SHA-512 of the downloaded tarball so a later swap of the tarball
-  // bytes is detected. The third variant forces the streaming extractor
-  // (normally reserved for tarballs >= 2 MiB) so both extract paths are
-  // covered.
-  for (const [label, dist, extraEnv] of [
-    ["unsupported algorithm", { integrity: "md5-AAAAAAAAAAAAAAAAAAAAAA==" }, {}],
-    ["malformed base64", { integrity: "sha512-!!!" }, {}],
-    [
-      "unsupported algorithm, streaming",
-      { integrity: "md5-AAAAAAAAAAAAAAAAAAAAAA==" },
-      { BUN_INSTALL_STREAMING_MIN_SIZE: "1" },
-    ],
+  // Face A: the registry advertises a non-empty integrity value that does not
+  // parse as a supported SRI hash. Installing that version must fail closed.
+  for (const [label, dist] of [
+    ["unsupported algorithm", { integrity: "md5-AAAAAAAAAAAAAAAAAAAAAA==" }],
+    ["malformed base64", { integrity: "sha512-!!!" }],
+    ["not an SRI string", { integrity: "not-an-sri-string!!!" }],
+    ["non-hex shasum", { shasum: "this-is-not-hex" }],
   ] as const) {
-    it(`pins a computed sha512 when the manifest integrity is unparseable (${label}) and rejects a swapped tarball on reinstall`, async () => {
+    it(`refuses an unparseable manifest integrity (${label})`, async () => {
+      const good = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
+      const state = { bytes: good, dist };
+      await using server = makeRegistry(state);
+      using dir = projectDir("npm-integrity-manifest-invalid", server.port);
+
+      const r = await runInstall(String(dir));
+      expect(r.stderr).toContain("Registry provided an invalid integrity hash for pkg@1.0.0");
+      expect(r.exitCode).not.toBe(0);
+    });
+  }
+
+  it("uses the legacy shasum when the SRI integrity is unparseable", async () => {
+    const good = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
+    const shasum = createHash("sha1").update(good).digest("hex");
+    const state = { bytes: good, dist: { integrity: "md5-AAAAAAAAAAAAAAAAAAAAAA==", shasum } };
+    await using server = makeRegistry(state);
+    using dir = projectDir("npm-integrity-shasum-fallback", server.port);
+
+    const r = await runInstall(String(dir));
+    expect(r.stderr).not.toContain("invalid integrity");
+    expect(lockfileIntegrity(String(dir))).toMatch(/^sha1-[A-Za-z0-9+/]+=*$/);
+    expect(r.exitCode).toBe(0);
+  });
+
+  // Face B: the registry omits both `dist.integrity` and `dist.shasum`. Bun must
+  // compute a SHA-512 of the downloaded bytes, pin it in the lockfile, and on a
+  // subsequent install reject a swapped tarball. Covers both extract paths.
+  for (const [label, extraEnv] of [
+    ["buffered", {}],
+    ["streaming", { BUN_INSTALL_STREAMING_MIN_SIZE: "1" }],
+  ] as const) {
+    it(`pins a computed sha512 when the manifest omits integrity (${label}) and rejects a swapped tarball on reinstall`, async () => {
       const tarballA = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
       const tarballB = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0","swapped":true}\n'));
 
-      let tarballRequests = 0;
-      await using server = Bun.serve({
-        port: 0,
-        hostname: "127.0.0.1",
-        async fetch(req) {
-          const url = new URL(req.url);
-          if (url.pathname.endsWith("/pkg")) {
-            return Response.json({
-              name: "pkg",
-              "dist-tags": { latest: "1.0.0" },
-              versions: {
-                "1.0.0": {
-                  name: "pkg",
-                  version: "1.0.0",
-                  dist: {
-                    ...dist,
-                    tarball: `http://127.0.0.1:${server.port}/pkg/-/pkg-1.0.0.tgz`,
-                  },
-                },
-              },
-            });
-          }
-          if (url.pathname.endsWith("/pkg-1.0.0.tgz")) {
-            tarballRequests++;
-            const tgz = tarballRequests <= 1 ? tarballA : tarballB;
-            return new Response(tgz, { headers: { "content-length": String(tgz.length) } });
-          }
-          return new Response("Not found", { status: 404 });
-        },
-      });
+      const state = { bytes: tarballA, dist: {} as Record<string, string> };
+      await using server = makeRegistry(state);
+      using dir = projectDir("npm-integrity-missing", server.port);
 
-      using dir = tempDir("npm-integrity-unparseable", {
-        "package.json": JSON.stringify({
-          name: "app",
-          version: "1.0.0",
-          dependencies: { pkg: "1.0.0" },
-        }),
-        "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:${server.port}/"\nlinker = "hoisted"\n`,
-      });
-      const cacheDir = join(String(dir), ".cache");
-
-      // First install: the unparseable manifest integrity must not leave the
-      // package permanently unverified — Bun computes a SHA-512 of the bytes
+      // First install: the absent manifest integrity must not leave the
+      // package permanently unverified; Bun computes a SHA-512 of the bytes
       // it downloaded and records it in the lockfile.
       {
-        await using proc = spawn({
-          cmd: [bunExe(), "install", "--save-text-lockfile"],
-          cwd: String(dir),
-          env: { ...env, ...extraEnv, BUN_INSTALL_CACHE_DIR: cacheDir },
-          stdout: "pipe",
-          stderr: "pipe",
-        });
-        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-        expect(stderr).toContain("Saved lockfile");
-        expect(exitCode).toBe(0);
+        const r = await runInstall(String(dir), ["--save-text-lockfile"], extraEnv);
+        expect(r.stderr).toContain("Saved lockfile");
+        expect(r.exitCode).toBe(0);
       }
 
-      const lockContent = await file(join(String(dir), "bun.lock")).text();
-      expect(lockContent).toMatch(/"sha512-[A-Za-z0-9+/]+=*"/);
+      expect(lockfileIntegrity(String(dir))).toBe(sha512(tarballA));
 
       // Second install from scratch: the server now serves different bytes.
       // The pin recorded on the first install must reject the swap.
       await rm(join(String(dir), "node_modules"), { recursive: true, force: true });
-      await rm(cacheDir, { recursive: true, force: true });
+      await rm(join(String(dir), ".cache"), { recursive: true, force: true });
+      state.bytes = tarballB;
 
       {
-        await using proc = spawn({
-          cmd: [bunExe(), "install"],
-          cwd: String(dir),
-          env: { ...env, ...extraEnv, BUN_INSTALL_CACHE_DIR: cacheDir },
-          stdout: "pipe",
-          stderr: "pipe",
-        });
-        const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
-        expect(stderr + stdout).toContain("Integrity check failed");
-        expect(stdout).not.toContain("1 package installed");
-        expect(exitCode).not.toBe(0);
+        const r = await runInstall(String(dir), [], extraEnv);
+        expect(r.stderr + r.stdout).toContain("Integrity check failed");
+        expect(r.stdout).not.toContain("1 package installed");
+        expect(r.exitCode).not.toBe(0);
       }
     });
   }
+
+  // Face C: a lockfile that already has an empty integrity for an npm package
+  // is warned about and self-heals on the next download; under --frozen-lockfile
+  // the same entry is refused.
+  it("warns on an empty npm lockfile integrity and back-fills it", async () => {
+    const good = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
+    const state = { bytes: good, dist: { integrity: sha512(good) } };
+    await using server = makeRegistry(state);
+    using dir = projectDir("npm-integrity-lockfile-empty", server.port);
+
+    {
+      const r = await runInstall(String(dir));
+      expect(r.exitCode).toBe(0);
+    }
+    const lockPath = join(String(dir), "bun.lock");
+    const lock = readFileSync(lockPath, "utf8");
+    writeFileSync(lockPath, lock.replace(/"sha\d+-[A-Za-z0-9+/]+=*"]/, '""]'));
+    await rm(join(String(dir), "node_modules"), { recursive: true, force: true });
+    await rm(join(String(dir), ".cache"), { recursive: true, force: true });
+
+    {
+      const r = await runInstall(String(dir), ["--frozen-lockfile"]);
+      expect(r.stderr).toContain("Package pkg has no integrity pin in the frozen lockfile");
+      expect(r.exitCode).not.toBe(0);
+    }
+
+    {
+      const r = await runInstall(String(dir));
+      expect(r.stderr).toContain("Package pkg has no integrity pin in the lockfile");
+      expect(r.stderr).toContain("Saved lockfile");
+      expect(lockfileIntegrity(String(dir))).toBe(sha512(good));
+      expect(r.exitCode).toBe(0);
+    }
+  });
+
+  // Face D: an unparseable / unsupported-algorithm integrity in the lockfile
+  // must be rejected, not warned-and-ignored, for a v2 lockfile.
+  it("rejects an unsupported-algorithm integrity in the lockfile", async () => {
+    const good = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
+    const state = { bytes: good, dist: { integrity: sha512(good) } };
+    await using server = makeRegistry(state);
+    using dir = projectDir("npm-integrity-lockfile-md5", server.port);
+
+    {
+      const r = await runInstall(String(dir));
+      expect(r.exitCode).toBe(0);
+    }
+    const lockPath = join(String(dir), "bun.lock");
+    const lock = readFileSync(lockPath, "utf8");
+    const tampered = lock.replace(/"sha\d+-[A-Za-z0-9+/]+=*"]/, '"md5-AAAAAAAAAAAAAAAAAAAAAA=="]');
+    expect(tampered).not.toBe(lock);
+    writeFileSync(lockPath, tampered);
+    await rm(join(String(dir), "node_modules"), { recursive: true, force: true });
+    await rm(join(String(dir), ".cache"), { recursive: true, force: true });
+
+    {
+      const r = await runInstall(String(dir), ["--frozen-lockfile"]);
+      expect(r.stderr).toContain("Unsupported or malformed integrity hash for npm package");
+      expect(r.exitCode).not.toBe(0);
+    }
+
+    // Without --frozen-lockfile the error is reported and the lockfile is
+    // discarded; re-resolving writes a verified sha512 back.
+    {
+      const r = await runInstall(String(dir));
+      expect(r.stderr).toContain("Unsupported or malformed integrity hash for npm package");
+      expect(lockfileIntegrity(String(dir))).toBe(sha512(good));
+      expect(r.exitCode).toBe(0);
+    }
+  });
+
+  it("still warns and ignores an unsupported-algorithm integrity in a v1 lockfile", async () => {
+    const good = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
+    const state = { bytes: good, dist: { integrity: sha512(good) } };
+    await using server = makeRegistry(state);
+    using dir = projectDir("npm-integrity-lockfile-md5-v1", server.port);
+
+    const lock = {
+      lockfileVersion: 1,
+      configVersion: 1,
+      workspaces: { "": { name: "app", dependencies: { pkg: "1.0.0" } } },
+      packages: {
+        pkg: ["pkg@1.0.0", "", {}, "md5-AAAAAAAAAAAAAAAAAAAAAA=="],
+      },
+    };
+    writeFileSync(join(String(dir), "bun.lock"), JSON.stringify(lock));
+
+    const r = await runInstall(String(dir));
+    expect(r.stderr).toContain("Unsupported or malformed integrity hash; ignoring");
+    expect(r.stderr).not.toContain("error:");
+    expect(r.exitCode).toBe(0);
+  });
 
   it("does not re-save the lockfile on reinstall when the registry provides no integrity metadata", async () => {
     const tarball = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));


### PR DESCRIPTION
## Problem

`bun install` integrity is fail-open when the registry's `dist.integrity` is missing or unparseable, and when a lockfile entry carries an empty or malformed hash. Four faces, all verified against 1.4.0-canary.1 (5b98630ac) and release-asan main (e532ad91f):

- **A**: registry advertises an unparseable `dist.integrity` (and no usable `shasum`): install succeeds silently, `bun.lock` records `""` for that package, no warning.
- **B**: registry omits `dist.integrity` and `dist.shasum` entirely: `bun.lock` records `""`. No hash of the downloaded bytes is computed or pinned (npm's lockfile pins a computed sha512 here).
- **C**: any lockfile entry with `""` is never verified: wipe the cache, let the registry serve different bytes for the same version, and they are linked cleanly with exit 0.
- **D**: an unsupported-algorithm (`md5-…`) or garbage integrity in the lockfile produces `warn: Unsupported or malformed integrity hash; ignoring` and proceeds unverified with exit 0.

A real sha1/sha256/sha384/sha512 in `bun.lock` is enforced correctly (swapped tarball: `error: Integrity check failed`, exit 1); the hole is only the empty/unparseable path.

## Cause

`Integrity::parse` / `Integrity::parse_entry` return `Tag::UNKNOWN` for every failure (short input, unknown algorithm via `Tag::parse`, bad base64, wrong length, decode error) and the npm manifest reader maps a garbage `dist.integrity` and a garbage/absent `dist.shasum` to `Integrity::default()` with no log line. The lockfile writer prints `Display for Integrity`, which emits nothing for `UNKNOWN`, so `""` is persisted. The compute-and-pin machinery that already exists for GitHub/remote/local tarballs (`compute_if_missing`) excludes `ResolutionTag::Npm`, so the extractor never hashes the npm bytes. At verify time, `!tag.is_supported()` short-circuits to success, and the lockfile reader only `add_warning`s on a malformed value.

## Fix

Fail closed on each face:

- **A** (`src/install/npm.rs`, `src/install/integrity.rs`, `src/install/lockfile/Package.rs`): a registry manifest whose `dist.integrity` (and `dist.shasum`) is present but unparseable now tags the version `Tag::INVALID` instead of `UNKNOWN`. `Package::from_npm` refuses that version with `error: Registry provided an invalid integrity hash for <pkg>@<ver>`. A valid `shasum` still salvages an unparseable `integrity`.
- **B** (`src/install/TarballStream.rs`, `src/install/extract_tarball.rs`, `src/install/PackageManager/runTasks.rs`): when neither field is usable, both extract paths compute SHA-512 over the downloaded bytes for `ResolutionTag::Npm` (as they already did for GitHub/remote/local tarballs). `runTasks` writes the computed hash back to `lockfile.packages[id].meta.integrity` and sets `FORCE_SAVE_LOCKFILE`, so the first install's lockfile already carries the pin and every subsequent install verifies against it. Skipped under `--no-verify`.
- **C** (`src/install/lockfile/bun.lock.rs`): at `lockfileVersion: 2`, an empty npm integrity string is refused with `error: Package <x> has no integrity pin in the frozen lockfile` under `--frozen-lockfile`, and warned about otherwise (the download path then back-fills the SHA-512 via the same write-back and re-saves). v0/v1 lockfiles, written before the back-fill existed, keep loading silently.
- **D** (`src/install/lockfile/bun.lock.rs`): at `lockfileVersion: 2`, a non-empty npm integrity string that doesn't parse as a supported SRI value is a parse error (`Unsupported or malformed integrity hash for npm package`) instead of the warn-and-ignore. v0/v1 keep the old warn.

`Tag::INVALID` is a runtime sentinel only: `is_supported()` is false for it, `Display` emits nothing, and `verify()` rejects it, so it never reaches disk.

## Verification

`test/cli/install/bun-install-tarball-integrity.test.ts` adds a `describe("npm registry without usable integrity metadata")` block with an in-process loopback registry:

- four manifest shapes that trigger `Tag::INVALID` (`md5-…`, `sha512-!!!`, `not-an-sri-string!!!`, non-hex `shasum`) each fail with the new install error;
- an unparseable `integrity` with a valid `shasum` falls through to SHA-1;
- a manifest with no integrity at all pins the computed SHA-512 (buffered and streaming extractors) and the pin rejects a swapped tarball on reinstall;
- a v2 lockfile with `""` for an npm package is refused under `--frozen-lockfile` and warned + back-filled otherwise;
- a v2 lockfile with `md5-…` for an npm package is refused; a v1 lockfile with the same entry still warns and proceeds;
- the lockfile is not re-saved on a second install when the pin is already present.

With `src/` reverted to `origin/main`, 9 of the 11 new tests fail; with this change the full file (27 tests) passes. `rust:check-all` is clean on all ten targets. Neighboring `lockfile-version-2.test.ts`, `bun-install.test.ts`, and `bun-install-retry.test.ts` are unchanged.

Fixes #19519
