### PR TITLE
Print Infinity and negative numeric property keys as computed properties

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -4664,6 +4664,15 @@ pub mod __gated_printer {
             self.prev_reg_exp_end = self.writer.written();
         }
 
+        /// Whether a number used as a non-computed property name must be printed as a
+        /// computed property instead, because `print_number` would render it as
+        /// something that is not a valid property name (e.g. "-1", "1/0", "1 / 0").
+        pub fn number_property_key_must_be_computed(&self, value: f64) -> bool {
+            value.is_sign_negative()
+                || (value == f64::INFINITY
+                    && (self.options.minify_syntax || !self.options.has_run_symbol_renamer))
+        }
+
         pub fn print_property(&mut self, item_in: &G::Property) {
             // PORT NOTE: Zig took G.Property by value (Copy in Zig). Rust's
             // G::Property isn't `Copy`, so take a borrow and shallow-copy the
@@ -4788,6 +4797,16 @@ pub mod __gated_printer {
             }
 
             let key = item.key.expect("infallible: prop has key");
+
+            // Automatically print numbers that would cause a syntax error as computed properties
+            if !IS_JSON
+                && !item.flags.contains(js_ast::flags::Property::IsComputed)
+                && matches!(&key.data, ExprData::ENumber(e) if self.number_property_key_must_be_computed(e.value))
+            {
+                // "{ -1: 0 }" must be printed as "{ [-1]: 0 }"
+                // "{ 1/0: 0 }" must be printed as "{ [1/0]: 0 }"
+                set_flag(&mut item.flags, js_ast::flags::Property::IsComputed, true);
+            }
 
             if !IS_JSON && item.flags.contains(js_ast::flags::Property::IsComputed) {
                 self.print(b"[");
@@ -5061,7 +5080,15 @@ pub mod __gated_printer {
                             if property.flags.contains(js_ast::flags::Property::IsSpread) {
                                 self.print(b"...");
                             } else {
-                                if property.flags.contains(js_ast::flags::Property::IsComputed) {
+                                // Automatically print numbers that would cause a syntax error as computed properties
+                                let key_must_be_computed = matches!(
+                                    &property.key.data,
+                                    ExprData::ENumber(e) if self.number_property_key_must_be_computed(e.value)
+                                );
+
+                                if property.flags.contains(js_ast::flags::Property::IsComputed)
+                                    || key_must_be_computed
+                                {
                                     self.print(b"[");
                                     self.print_expr(property.key, Level::Comma, ExprFlag::none());
                                     self.print(b"]:");

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -272,6 +272,30 @@ describe("bundler", () => {
     minifySyntax: true,
     minifyWhitespace: true,
   });
+  // Numeric property names that would be printed as "1/0" (Infinity) or "-1" (inlined const
+  // enums) are not valid syntax in property-name position and must become computed properties.
+  itBundled("minify/NumericPropertyKeysPrintedAsComputed", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { E } from "./enum";
+        const obj = { 1e999: "inf", [E.Negative]: "neg" };
+        const { 1e999: destructured } = obj;
+        class C {
+          1e999() { return "method"; }
+          static 1e999 = "static";
+        }
+        console.log(JSON.stringify([obj[Infinity], obj[-1], destructured, new C()[Infinity](), C[Infinity]]));
+      `,
+      "enum.ts": /* ts */ `
+        export const enum E { Negative = -1 }
+      `,
+    },
+    minifySyntax: true,
+    minifyWhitespace: true,
+    run: {
+      stdout: '["inf","neg","inf","method","static"]',
+    },
+  });
   itBundled("minify/InlineArraySpread", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -274,6 +274,7 @@ describe("bundler", () => {
   });
   // Numeric property names that would be printed as "1/0" (Infinity) or "-1" (inlined const
   // enums) are not valid syntax in property-name position and must become computed properties.
+  // The negative const enum key case is https://github.com/oven-sh/bun/issues/14687
   itBundled("minify/NumericPropertyKeysPrintedAsComputed", {
     files: {
       "/entry.ts": /* ts */ `

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4366,3 +4366,48 @@ describe("minifyWhitespace keeps the space before keyword operators", () => {
     expect(minifier.transformSync("1 in y")).toBe("1 in y;");
   });
 });
+
+// A numeric literal property name like `1e999` overflows to the number Infinity, which the
+// printer emits as "1/0" / "1 / 0". That is not valid syntax in property-name position, so such
+// keys must be printed as computed properties instead.
+describe("numeric property keys that overflow to Infinity", () => {
+  const minifier = new Bun.Transpiler({ loader: "ts", minifyWhitespace: true });
+  const plain = new Bun.Transpiler({ loader: "ts" });
+
+  it("are printed as computed properties when minifying whitespace", () => {
+    expect(minifier.transformSync("x = { 1e999: 1 };")).toBe("x={[1/0]:1};");
+    expect(minifier.transformSync("x = { 1e999() {} };")).toBe("x={[1/0](){}};");
+    expect(minifier.transformSync("x = { get 1e999() {} };")).toBe("x={get[1/0](){}};");
+    expect(minifier.transformSync("x = { set 1e999(v) {} };")).toBe("x={set[1/0](v){}};");
+    expect(minifier.transformSync("x = class { 1e999() {} };")).toBe("x=class{[1/0](){}};");
+    expect(minifier.transformSync("x = class { static 1e999() {} };")).toBe("x=class{static[1/0](){}};");
+    expect(minifier.transformSync("x = class { 1e999 = 1 };")).toBe("x=class{[1/0]=1};");
+    expect(minifier.transformSync("x = class { static 1e999 = 1 };")).toBe("x=class{static[1/0]=1};");
+    expect(minifier.transformSync("const { 1e999: y } = x;")).toBe("const{[1/0]:y}=x;");
+    expect(minifier.transformSync("({ 1e999: x.y } = z);")).toBe("({[1/0]:x.y}=z);");
+  });
+
+  it("are printed as computed properties without minification", () => {
+    expect(plain.transformSync("x = { 1e999: 1 };")).toBe("x = { [1 / 0]: 1 };\n");
+    expect(plain.transformSync("x = class { 1e999() {} };")).toBe("x = class {\n  [1 / 0]() {}\n};\n");
+    expect(plain.transformSync("const { 1e999: y } = x;")).toBe("const { [1 / 0]: y } = x;\n");
+  });
+
+  it("handles a method name with hundreds of digits", () => {
+    const digits = Buffer.alloc(325, "9").toString();
+    expect(minifier.transformSync(`(class { ${digits}() {} });`)).toBe("(class{[1/0](){}});");
+  });
+
+  it("still refers to the same property at runtime", () => {
+    const out = minifier.transformSync(`
+      const obj = { 1e999: "object" };
+      const { 1e999: destructured } = { 1e999: "destructured" };
+      class C {
+        1e999() { return "method"; }
+        static 1e999 = "static";
+      }
+      var result = [obj[Infinity], destructured, new C()[Infinity](), C[Infinity]];
+    `);
+    expect(new Function(`${out}; return result;`)()).toEqual(["object", "destructured", "method", "static"]);
+  });
+});


### PR DESCRIPTION
### Problem

Fuzzer-found invariant violation: `printed output does not reparse (loader=ts)`.

```js
new Bun.Transpiler({ loader: "ts", minifyWhitespace: true })
  .transformSync("(class {999…(325 digits)…999() {}})")
// => (class{1/0(){}});   ← syntax error
```

A numeric property name that overflows to `Infinity` (a few hundred digits, or just `1e999`) is printed by `print_number` as `1/0` / `1 / 0`, which is not valid syntax in property-name position. The same happens for:

- object literal properties, methods, getters/setters: `x={1/0:1}`, `x={get 1/0(){}}`
- class methods and fields: `class{1/0(){}}`, `class{static 1/0=1}`
- destructuring patterns: `const{1/0:x}=obj`
- negative keys produced by cross-module `const enum` inlining with `--minify`: `{-1:1,1/0:2}`

None of these reparse, so `bun build --minify` output can be unparseable.

### Fix

In `src/js_printer/lib.rs`, when a non-computed property key is an `ENumber` whose printed form would not be a valid property name (sign bit set, or `+Infinity` in the configurations where `print_number` emits `1/0`), print it as a computed property instead:

- `print_property` (object literals, classes) — mirrors esbuild's `printProperty` ("Automatically print numbers that would cause a syntax error as computed properties").
- `print_binding` (destructuring object patterns) — same check; esbuild's `printBinding` lacks it and has the same bug with `--minify`, so this goes one step further.

Output now matches esbuild: `(class{[1/0](){}})`, `{[-1]:1,[1/0]:2}`, `const{[1/0]:x}=obj`. Semantics are unchanged since `[1/0]`/`[-1]` evaluate to the same property keys (`"Infinity"`, `"-1"`).

### Verification

- `test/bundler/transpiler/transpiler.test.js` — new `describe("numeric property keys that overflow to Infinity")`: exact printed output with and without `minifyWhitespace` for object/class/destructuring positions, the original 325-digit fuzz input, and a runtime check that the minified output evaluates and the key is still `"Infinity"`.
- `test/bundler/bundler_minify.test.ts` — new `itBundled("minify/NumericPropertyKeysPrintedAsComputed")`: bundles `1e999` keys plus an imported `const enum { Negative = -1 }` used as a computed key, and runs the output.

Both tests fail on current canary (`(class{1/0(){}})`, bundle fails to parse) and pass with this change; the full files pass with the debug build (150 + 33 tests, 0 fail).


### Linked issue

Fixes #14687 — the negative-key half of this change is exactly that report (imported `const enum` member `-1` used as an object key with `minify: true`). Verified with the issue's repro:

```js
// before: var e={-1:"foo",1:"bar"};export{e as FooRecord};   ← syntax error
// after:  var e={[-1]:"foo",1:"bar"};export{e as FooRecord};
```
