### PR TITLE
Only reconstruct file-backed Blobs from in-process structured clone

### DIFF
--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -434,7 +434,7 @@ JSC_DECLARE_CUSTOM_GETTER(js${typeName}Constructor);
       `extern JSC_CALLCONV JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES ${symbolName(
         typeName,
         "onStructuredCloneDeserialize",
-      )}(JSC::JSGlobalObject*, uint8_t**, const uint8_t*);` + "\n";
+      )}(JSC::JSGlobalObject*, uint8_t**, const uint8_t*, bool);` + "\n";
   }
   if (obj.finalize) {
     externs +=
@@ -2391,9 +2391,9 @@ const JavaScriptCoreBindings = struct {
       exports.set("structuredCloneDeserialize", symbolName(typeName, "onStructuredCloneDeserialize"));
 
       output += `
-      pub fn ${symbolName(typeName, "onStructuredCloneDeserialize")}(globalObject: *jsc.JSGlobalObject, ptr: *[*]u8, end: [*]u8) callconv(jsc.conv) jsc.JSValue {
+      pub fn ${symbolName(typeName, "onStructuredCloneDeserialize")}(globalObject: *jsc.JSGlobalObject, ptr: *[*]u8, end: [*]u8, isFromUntrustedBytes: bool) callconv(jsc.conv) jsc.JSValue {
         if (comptime Environment.enable_logs) log_zig_structured_clone_deserialize("${typeName}");
-        return @call(bun.callmod_inline, jsc.toJSHostCall, .{ globalObject, @src(), ${typeName}.onStructuredCloneDeserialize, .{globalObject, ptr, end} });
+        return @call(bun.callmod_inline, jsc.toJSHostCall, .{ globalObject, @src(), ${typeName}.onStructuredCloneDeserialize, .{globalObject, ptr, end, isFromUntrustedBytes} });
       }
       `;
     } else {
@@ -3057,8 +3057,8 @@ function generateRust(
     }
     thunk(
       symbolName(typeName, "onStructuredCloneDeserialize"),
-      `(global: &JSGlobalObject, ptr: *mut *mut u8, end: *const u8) -> JSValue`,
-      `    host_fn::host_fn_result(global, || ${T}::on_structured_clone_deserialize(global, ptr, end))`,
+      `(global: &JSGlobalObject, ptr: *mut *mut u8, end: *const u8, is_from_untrusted_bytes: bool) -> JSValue`,
+      `    host_fn::host_fn_result(global, || ${T}::on_structured_clone_deserialize(global, ptr, end, is_from_untrusted_bytes))`,
     );
   }
 
@@ -3484,7 +3484,7 @@ class StructuredCloneableSerialize {
 
 class StructuredCloneableDeserialize {
   public:
-    static std::optional<JSC::EncodedJSValue> fromTagDeserialize(uint8_t tag, JSC::JSGlobalObject*, const uint8_t*&, const uint8_t*);
+    static std::optional<JSC::EncodedJSValue> fromTagDeserialize(uint8_t tag, JSC::JSGlobalObject*, const uint8_t*&, const uint8_t*, bool isFromUntrustedBytes);
 };
 
 }
@@ -3512,7 +3512,7 @@ function writeCppSerializers() {
   function fromTagDeserializeForEachClass(klass) {
     return `
     if (tag == ${klass.structuredClone.tag}) {
-      return ${symbolName(klass.name, "onStructuredCloneDeserialize")}(globalObject, (uint8_t**)&ptr, end);
+      return ${symbolName(klass.name, "onStructuredCloneDeserialize")}(globalObject, (uint8_t**)&ptr, end, isFromUntrustedBytes);
     }
     `;
   }
@@ -3526,7 +3526,7 @@ function writeCppSerializers() {
   `;
 
   output += `
-  std::optional<JSC::EncodedJSValue> StructuredCloneableDeserialize::fromTagDeserialize(uint8_t tag, JSC::JSGlobalObject* globalObject, const uint8_t*& ptr, const uint8_t* end)
+  std::optional<JSC::EncodedJSValue> StructuredCloneableDeserialize::fromTagDeserialize(uint8_t tag, JSC::JSGlobalObject* globalObject, const uint8_t*& ptr, const uint8_t* end, bool isFromUntrustedBytes)
   {
     ${structuredClonable.map(fromTagDeserializeForEachClass).join("\n").trim()}
     return std::nullopt;

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -6542,7 +6542,7 @@ JSC::JSValue SerializedScriptValue::fromArrayBuffer(JSC::JSGlobalObject& domGlob
         ,
         WTF::move(m_serializedVideoChunks), WTF::move(m_serializedVideoFrames)
 #endif
-        ,
+                                                ,
         // The ArrayBuffer's contents are arbitrary bytes supplied by JS
         // (bun:jsc / node:v8 deserialize()); never treat them as having been
         // produced by an in-process create().
@@ -6803,7 +6803,7 @@ JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, 
                                       ,
         WTF::move(m_serializedVideoChunks), WTF::move(m_serializedVideoFrames)
 #endif
-        ,
+                                                ,
         // False for postMessage / structuredClone / MessagePort / Worker
         // (bytes produced by an in-process create()); true only for values
         // built by createFromWireBytes (IPC).

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -5290,7 +5290,6 @@ private:
     JSGlobalObject* const m_globalObject;
     const bool m_isDOMGlobalObject;
     // const bool m_canCreateDOMObject;
-    // Set by the static deserialize() entry point right after construction.
     // True when the wire bytes were supplied by the caller as a raw buffer
     // (bun:jsc / node:v8 deserialize(), IPC) rather than produced by an
     // in-process SerializedScriptValue::create().
@@ -6543,9 +6542,6 @@ JSC::JSValue SerializedScriptValue::fromArrayBuffer(JSC::JSGlobalObject& domGlob
         WTF::move(m_serializedVideoChunks), WTF::move(m_serializedVideoFrames)
 #endif
                                                 ,
-        // The ArrayBuffer's contents are arbitrary bytes supplied by JS
-        // (bun:jsc / node:v8 deserialize()); never treat them as having been
-        // produced by an in-process create().
         /* isFromUntrustedBytes */ true);
 
     if (arrayBuffer->isShared()) {
@@ -6804,9 +6800,6 @@ JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, 
         WTF::move(m_serializedVideoChunks), WTF::move(m_serializedVideoFrames)
 #endif
                                                 ,
-        // False for postMessage / structuredClone / MessagePort / Worker
-        // (bytes produced by an in-process create()); true only for values
-        // built by createFromWireBytes (IPC).
         m_isFromUntrustedBytes);
     if (didFail)
         *didFail = result.second != SerializationReturnCode::SuccessfullyCompleted;

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -2961,7 +2961,8 @@ public:
         ,
         Vector<RefPtr<WebCodecsEncodedVideoChunkStorage>>&& serializedVideoChunks, Vector<WebCodecsVideoFrameData>&& serializedVideoFrames
 #endif
-    )
+        ,
+        bool isFromUntrustedBytes)
     {
         if (!buffer.size())
             return std::make_pair(jsNull(), SerializationReturnCode::UnspecifiedError);
@@ -2983,6 +2984,7 @@ public:
             WTF::move(serializedVideoChunks), WTF::move(serializedVideoFrames)
 #endif
         );
+        deserializer.m_isFromUntrustedBytes = isFromUntrustedBytes;
         if (!deserializer.isValid())
             return std::make_pair(JSValue(), SerializationReturnCode::ValidationError);
         return deserializer.deserialize();
@@ -4803,7 +4805,7 @@ private:
         //     return JSValue();
 
         // read bun types
-        if (auto value = StructuredCloneableDeserialize::fromTagDeserialize(tag, m_lexicalGlobalObject, m_ptr, m_end)) {
+        if (auto value = StructuredCloneableDeserialize::fromTagDeserialize(tag, m_lexicalGlobalObject, m_ptr, m_end, m_isFromUntrustedBytes)) {
             JSValue deserialized = JSValue::decode(value.value());
             if (deserialized.isEmpty()) {
                 fail();
@@ -5288,6 +5290,11 @@ private:
     JSGlobalObject* const m_globalObject;
     const bool m_isDOMGlobalObject;
     // const bool m_canCreateDOMObject;
+    // Set by the static deserialize() entry point right after construction.
+    // True when the wire bytes were supplied by the caller as a raw buffer
+    // (bun:jsc / node:v8 deserialize(), IPC) rather than produced by an
+    // in-process SerializedScriptValue::create().
+    bool m_isFromUntrustedBytes { false };
     const uint8_t* m_ptr;
     const uint8_t* const m_end;
     unsigned m_version;
@@ -6535,7 +6542,11 @@ JSC::JSValue SerializedScriptValue::fromArrayBuffer(JSC::JSGlobalObject& domGlob
         ,
         WTF::move(m_serializedVideoChunks), WTF::move(m_serializedVideoFrames)
 #endif
-    );
+        ,
+        // The ArrayBuffer's contents are arbitrary bytes supplied by JS
+        // (bun:jsc / node:v8 deserialize()); never treat them as having been
+        // produced by an in-process create().
+        /* isFromUntrustedBytes */ true);
 
     if (arrayBuffer->isShared()) {
         arrayBuffer->unpin();
@@ -6792,7 +6803,11 @@ JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, 
                                       ,
         WTF::move(m_serializedVideoChunks), WTF::move(m_serializedVideoFrames)
 #endif
-    );
+        ,
+        // False for postMessage / structuredClone / MessagePort / Worker
+        // (bytes produced by an in-process create()); true only for values
+        // built by createFromWireBytes (IPC).
+        m_isFromUntrustedBytes);
     if (didFail)
         *didFail = result.second != SerializationReturnCode::SuccessfullyCompleted;
     // Deserialize may throw an exception. Similar to serialize (~L6240, SerializedScriptValue::create),

--- a/src/jsc/bindings/webcore/SerializedScriptValue.h
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.h
@@ -175,7 +175,13 @@ public:
     // IDBValue writeBlobsToDiskForIndexedDBSynchronously();
     static Ref<SerializedScriptValue> createFromWireBytes(Vector<uint8_t>&& data)
     {
-        return adoptRef(*new SerializedScriptValue(WTF::move(data)));
+        // Bytes handed to us as a raw buffer (IPC, user-supplied ArrayBuffers)
+        // did not come from an in-process create(); mark them so deserialization
+        // can refuse to materialize objects that grant ambient authority (e.g.
+        // path/fd-backed Blobs).
+        auto value = adoptRef(*new SerializedScriptValue(WTF::move(data)));
+        value->m_isFromUntrustedBytes = true;
+        return value;
     }
     const Vector<uint8_t>& wireBytes() const { return m_data; }
 
@@ -285,6 +291,12 @@ private:
     String m_fastPathString;
     FastPath m_fastPath { FastPath::None };
     size_t m_memoryCost { 0 };
+
+    // True when this value was reconstituted from a caller-supplied byte buffer
+    // (createFromWireBytes) rather than produced by an in-process create().
+    // Deserialization uses this to reject tags that would mint capabilities
+    // (file paths / file descriptors) straight out of the wire bytes.
+    bool m_isFromUntrustedBytes { false };
 
     FixedVector<SimpleInMemoryPropertyTableEntry> m_simpleInMemoryPropertyTable {};
     // m_simpleArrayElements and m_arrayButterflyData/m_arrayLength are used exclusively:

--- a/src/jsc/bindings/webcore/SerializedScriptValue.h
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.h
@@ -175,10 +175,6 @@ public:
     // IDBValue writeBlobsToDiskForIndexedDBSynchronously();
     static Ref<SerializedScriptValue> createFromWireBytes(Vector<uint8_t>&& data)
     {
-        // Bytes handed to us as a raw buffer (IPC, user-supplied ArrayBuffers)
-        // did not come from an in-process create(); mark them so deserialization
-        // can refuse to materialize objects that grant ambient authority (e.g.
-        // path/fd-backed Blobs).
         auto value = adoptRef(*new SerializedScriptValue(WTF::move(data)));
         value->m_isFromUntrustedBytes = true;
         return value;

--- a/src/runtime/node/net/BlockList.rs
+++ b/src/runtime/node/net/BlockList.rs
@@ -421,6 +421,10 @@ impl BlockList {
         global: &JSGlobalObject,
         ptr: *mut *mut u8,
         end: *const u8,
+        // BlockList already validates wire bytes against the process-local
+        // `SERIALIZED_REFS` registry plus a per-instance nonce below, which
+        // rejects any payload that was not produced by this process.
+        _is_from_untrusted_bytes: bool,
     ) -> JsResult<JSValue> {
         // SAFETY: `*ptr` and `end` bound a contiguous byte buffer owned by the
         // caller (C++ SerializedScriptValue); `end >= *ptr`. `ptr` itself is a

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4270,12 +4270,9 @@ fn _on_structured_clone_deserialize<B: AsRef<[u8]>>(
         store::SerializeTag::File => 'file: {
             use crate::node::types::PathOrFileDescriptorSerializeTag;
 
-            // A path- or fd-backed Blob materialized from raw wire bytes would
-            // hand the supplier of those bytes a handle to an arbitrary file
-            // path, an arbitrary open descriptor, or an `s3://` credential
-            // scope. Only bytes produced by an in-process serialize (postMessage,
-            // structuredClone, BroadcastChannel) may reconstruct one; reject the
-            // whole arm for buffers that arrived from JS or the wire.
+            // A path/fd-backed Blob reconstructed from caller-supplied bytes would
+            // grant access to an arbitrary file path, open descriptor, or `s3://`
+            // credential scope; only in-process serialized bytes may rebuild one.
             if is_from_untrusted_bytes {
                 return Err(bun_core::err!("UntrustedFileBlob"));
             }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -181,6 +181,7 @@ pub trait BlobExt {
         global_this: &JSGlobalObject,
         ptr: *mut *mut u8,
         end: *const u8,
+        is_from_untrusted_bytes: bool,
     ) -> JsResult<JSValue>
     where
         Self: Sized;
@@ -815,6 +816,7 @@ impl BlobExt for Blob {
         global_this: &JSGlobalObject,
         ptr: *mut *mut u8,
         end: *const u8,
+        is_from_untrusted_bytes: bool,
     ) -> JsResult<JSValue> {
         // SAFETY: codegen passes a live `*mut *mut u8` cursor (C++:
         // `(uint8_t**)&ptr`) and a one-past-the-end `*const u8`; both are
@@ -827,8 +829,17 @@ impl BlobExt for Blob {
         let mut buffer_stream =
             bun_io::FixedBufferStream::new(unsafe { bun_core::ffi::slice(*cursor, total_length) });
 
-        let result = match _on_structured_clone_deserialize(global_this, &mut buffer_stream) {
+        let result = match _on_structured_clone_deserialize(
+            global_this,
+            &mut buffer_stream,
+            is_from_untrusted_bytes,
+        ) {
             Ok(v) => v,
+            Err(e) if e == bun_core::err!("UntrustedFileBlob") => {
+                return Err(global_this.throw(format_args!(
+                    "Cannot deserialize a file-backed Blob from serialized bytes; file references can only be cloned in-process via structuredClone or postMessage"
+                )));
+            }
             Err(e)
                 if e == bun_core::err!("EndOfStream")
                     || e == bun_core::err!("TooSmall")
@@ -4201,6 +4212,7 @@ fn read_slice<B: AsRef<[u8]>>(
 fn _on_structured_clone_deserialize<B: AsRef<[u8]>>(
     global_this: &JSGlobalObject,
     reader: &mut bun_io::FixedBufferStream<B>,
+    is_from_untrusted_bytes: bool,
 ) -> Result<JSValue, bun_core::Error> {
     let version = reader.read_int_le::<u8>()?;
     let offset = reader.read_int_le::<u64>()?;
@@ -4257,6 +4269,17 @@ fn _on_structured_clone_deserialize<B: AsRef<[u8]>>(
         }
         store::SerializeTag::File => 'file: {
             use crate::node::types::PathOrFileDescriptorSerializeTag;
+
+            // A path- or fd-backed Blob materialized from raw wire bytes would
+            // hand the supplier of those bytes a handle to an arbitrary file
+            // path, an arbitrary open descriptor, or an `s3://` credential
+            // scope. Only bytes produced by an in-process serialize (postMessage,
+            // structuredClone, BroadcastChannel) may reconstruct one; reject the
+            // whole arm for buffers that arrived from JS or the wire.
+            if is_from_untrusted_bytes {
+                return Err(bun_core::err!("UntrustedFileBlob"));
+            }
+
             let pathlike_tag =
                 PathOrFileDescriptorSerializeTag::from_raw(reader.read_int_le::<u8>()?)
                     .ok_or_else(|| bun_core::err!("InvalidValue"))?;

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -1,6 +1,8 @@
 import { deserialize, serialize } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN } from "harness";
+import { bunEnv, bunExe, isASAN, tempDir } from "harness";
+import { openSync } from "node:fs";
+import { join } from "node:path";
 import v8 from "node:v8";
 
 describe("structuredClone with Blob and File", () => {
@@ -575,5 +577,78 @@ describe("structuredClone with Blob and File", () => {
       // measured window still grows under bun-asan; widen the threshold there.
       expect(deltaMiB).toBeLessThan(isASAN ? 128 : 32);
     }, 30_000);
+
+    // The Blob wire format's File store variant carries either a raw path
+    // string or a raw file descriptor number. Honoring either from a
+    // caller-supplied byte buffer (bun:jsc deserialize, node:v8 deserialize,
+    // IPC) hands whoever crafted the buffer a live handle to an arbitrary
+    // file or an arbitrary open descriptor. Deserializing those tags is only
+    // allowed for byte streams produced by an in-process serialize
+    // (structuredClone / postMessage); raw buffers must be rejected.
+    describe("file-backed stores in caller-supplied buffers", () => {
+      const deserializers: [string, (payload: ArrayBuffer | Uint8Array) => any][] = [
+        ["bun:jsc deserialize", payload => deserialize(payload)],
+        ["node:v8 deserialize", payload => v8.deserialize(Buffer.from(payload as ArrayBuffer))],
+      ];
+
+      test("wire bytes naming a file path do not mint a readable file handle", async () => {
+        using dir = tempDir("blob-deser-path", {
+          "secret.txt": "this is the secret file contents",
+        });
+        const secretPath = join(String(dir), "secret.txt");
+        // Serializing a path-backed Blob is still allowed; only reconstructing
+        // one from the resulting raw bytes is not.
+        const payload = serialize(Bun.file(secretPath));
+        for (const [, de] of deserializers) {
+          expect(() => de(payload)).toThrow();
+        }
+      });
+
+      test("wire bytes naming a file descriptor are rejected", () => {
+        using dir = tempDir("blob-deser-fd", {
+          "fd.txt": "fd-backed contents",
+        });
+        const fd = openSync(join(String(dir), "fd.txt"), "r");
+        const payload = serialize(Bun.file(fd));
+        for (const [, de] of deserializers) {
+          expect(() => de(payload)).toThrow();
+        }
+      });
+
+      test("wire bytes naming an s3:// path are rejected", () => {
+        // Patch the serialized path in-place to an `s3://` URL of the same
+        // length; an honored payload would mint an S3-credential-backed blob.
+        const placeholder = "/tmp/aaaaaaaaaa";
+        const s3Path = "s3://bucket/key";
+        expect(s3Path.length).toBe(placeholder.length);
+        const payload = new Uint8Array(serialize(Bun.file(placeholder)));
+        const needle = Buffer.from(placeholder);
+        const index = Buffer.from(payload).indexOf(needle);
+        expect(index).toBeGreaterThan(-1);
+        payload.set(Buffer.from(s3Path), index);
+        for (const [, de] of deserializers) {
+          expect(() => de(payload)).toThrow();
+        }
+      });
+
+      test("bytes-backed Blob and File still round-trip through deserialize", async () => {
+        const blob = deserialize(serialize(new Blob(["hello"], { type: "text/plain" })));
+        expect(blob).toBeInstanceOf(Blob);
+        expect(await blob.text()).toBe("hello");
+
+        const file = v8.deserialize(v8.serialize(new File(["x"], "a.txt")));
+        expect(file).toBeInstanceOf(File);
+        expect(file.name).toBe("a.txt");
+        expect(await file.text()).toBe("x");
+      });
+
+      test("structuredClone of Bun.file still yields a readable file-backed blob", async () => {
+        using dir = tempDir("blob-clone-path", {
+          "data.txt": "in-process clone keeps the file reference",
+        });
+        const cloned = structuredClone(Bun.file(join(String(dir), "data.txt")));
+        expect(await cloned.text()).toBe("in-process clone keeps the file reference");
+      });
+    });
   });
 });

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -1,7 +1,7 @@
 import { deserialize, serialize } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, tempDir } from "harness";
-import { openSync } from "node:fs";
+import { closeSync, openSync } from "node:fs";
 import { join } from "node:path";
 import v8 from "node:v8";
 
@@ -609,9 +609,13 @@ describe("structuredClone with Blob and File", () => {
           "fd.txt": "fd-backed contents",
         });
         const fd = openSync(join(String(dir), "fd.txt"), "r");
-        const payload = serialize(Bun.file(fd));
-        for (const [, de] of deserializers) {
-          expect(() => de(payload)).toThrow();
+        try {
+          const payload = serialize(Bun.file(fd));
+          for (const [, de] of deserializers) {
+            expect(() => de(payload)).toThrow();
+          }
+        } finally {
+          closeSync(fd);
         }
       });
 

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -9,7 +9,7 @@ function jscSerializeRoundtrip(value: any) {
   return cloned;
 }
 
-function jscSerializeRoundtripCrossProcess(original: any) {
+function jscSerializeRoundtripCrossProcess(original: any, stderr: "inherit" | "ignore" = "inherit") {
   const serialized = serialize(original);
 
   const result = Bun.spawnSync({
@@ -26,7 +26,7 @@ function jscSerializeRoundtripCrossProcess(original: any) {
     env: bunEnv,
     stdin: serialized,
     stdout: "pipe",
-    stderr: "inherit",
+    stderr,
   });
   return deserialize(result.stdout);
 }
@@ -218,15 +218,16 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
       } else {
         // Cross-process: the child process's deserialize() rejects the
         // payload and exits without writing anything back, so the round trip
-        // never yields a file-backed Blob.
+        // never yields a file-backed Blob. The child's uncaught error is
+        // expected here, so its stderr is not echoed into the test runner's.
         test("file from path is rejected", () => {
           const blob = Bun.file(join(import.meta.dir, "example.txt"));
-          expect(structuredCloneFn(blob)).not.toBeInstanceOf(Blob);
+          expect(jscSerializeRoundtripCrossProcess(blob, "ignore")).not.toBeInstanceOf(Blob);
         });
         test("file from fd is rejected", () => {
           const fd = openSync(join(import.meta.dir, "example.txt"), "r");
           const blob = Bun.file(fd);
-          expect(structuredCloneFn(blob)).not.toBeInstanceOf(Blob);
+          expect(jscSerializeRoundtripCrossProcess(blob, "ignore")).not.toBeInstanceOf(Blob);
         });
       }
       describe("dom file", async () => {

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -184,21 +184,51 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
         const cloned = structuredCloneFn(blob);
         await compareBlobs(blob, cloned);
       });
-      test("file from path", async () => {
-        const blob = Bun.file(join(import.meta.dir, "example.txt"));
-        const cloned = structuredCloneFn(blob);
-        expect(cloned.lastModified).toBe(blob.lastModified);
-        expect(cloned.name).toBe(blob.name);
-        expect(cloned.size).toBe(blob.size);
-      });
-      test("file from fd", async () => {
-        const fd = openSync(join(import.meta.dir, "example.txt"), "r");
-        const blob = Bun.file(fd);
-        const cloned = structuredCloneFn(blob);
-        expect(cloned.lastModified).toBe(blob.lastModified);
-        expect(cloned.name).toBe(blob.name);
-        expect(cloned.size).toBe(blob.size);
-      });
+      // Path/fd-backed Blobs only round-trip through the in-process
+      // structuredClone path. The two bun:jsc serialize/deserialize variants
+      // hand the deserializer a raw byte buffer, and reconstructing a file
+      // handle from caller-supplied bytes is rejected (the path/fd embedded in
+      // the payload cannot be trusted).
+      if (structuredCloneFn === structuredClone) {
+        test("file from path", async () => {
+          const blob = Bun.file(join(import.meta.dir, "example.txt"));
+          const cloned = structuredCloneFn(blob);
+          expect(cloned.lastModified).toBe(blob.lastModified);
+          expect(cloned.name).toBe(blob.name);
+          expect(cloned.size).toBe(blob.size);
+        });
+        test("file from fd", async () => {
+          const fd = openSync(join(import.meta.dir, "example.txt"), "r");
+          const blob = Bun.file(fd);
+          const cloned = structuredCloneFn(blob);
+          expect(cloned.lastModified).toBe(blob.lastModified);
+          expect(cloned.name).toBe(blob.name);
+          expect(cloned.size).toBe(blob.size);
+        });
+      } else if (structuredCloneFn === jscSerializeRoundtrip) {
+        test("file from path is rejected", () => {
+          const blob = Bun.file(join(import.meta.dir, "example.txt"));
+          expect(() => structuredCloneFn(blob)).toThrow();
+        });
+        test("file from fd is rejected", () => {
+          const fd = openSync(join(import.meta.dir, "example.txt"), "r");
+          const blob = Bun.file(fd);
+          expect(() => structuredCloneFn(blob)).toThrow();
+        });
+      } else {
+        // Cross-process: the child process's deserialize() rejects the
+        // payload and exits without writing anything back, so the round trip
+        // never yields a file-backed Blob.
+        test("file from path is rejected", () => {
+          const blob = Bun.file(join(import.meta.dir, "example.txt"));
+          expect(structuredCloneFn(blob)).not.toBeInstanceOf(Blob);
+        });
+        test("file from fd is rejected", () => {
+          const fd = openSync(join(import.meta.dir, "example.txt"), "r");
+          const blob = Bun.file(fd);
+          expect(structuredCloneFn(blob)).not.toBeInstanceOf(Blob);
+        });
+      }
       describe("dom file", async () => {
         test("without lastModified", async () => {
           const file = new File(["hi"], "example.txt", { type: "text/plain" });

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1,5 +1,5 @@
 import { deserialize, serialize } from "bun:jsc";
-import { openSync } from "fs";
+import { closeSync, openSync } from "fs";
 import { bunEnv } from "harness";
 import { bunExe } from "js/bun/shell/test_builder";
 import { join } from "path";
@@ -199,11 +199,15 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
         });
         test("file from fd", async () => {
           const fd = openSync(join(import.meta.dir, "example.txt"), "r");
-          const blob = Bun.file(fd);
-          const cloned = structuredCloneFn(blob);
-          expect(cloned.lastModified).toBe(blob.lastModified);
-          expect(cloned.name).toBe(blob.name);
-          expect(cloned.size).toBe(blob.size);
+          try {
+            const blob = Bun.file(fd);
+            const cloned = structuredCloneFn(blob);
+            expect(cloned.lastModified).toBe(blob.lastModified);
+            expect(cloned.name).toBe(blob.name);
+            expect(cloned.size).toBe(blob.size);
+          } finally {
+            closeSync(fd);
+          }
         });
       } else if (structuredCloneFn === jscSerializeRoundtrip) {
         test("file from path is rejected", () => {
@@ -212,8 +216,12 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
         });
         test("file from fd is rejected", () => {
           const fd = openSync(join(import.meta.dir, "example.txt"), "r");
-          const blob = Bun.file(fd);
-          expect(() => structuredCloneFn(blob)).toThrow();
+          try {
+            const blob = Bun.file(fd);
+            expect(() => structuredCloneFn(blob)).toThrow();
+          } finally {
+            closeSync(fd);
+          }
         });
       } else {
         // Cross-process: the child process's deserialize() rejects the
@@ -226,8 +234,12 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
         });
         test("file from fd is rejected", () => {
           const fd = openSync(join(import.meta.dir, "example.txt"), "r");
-          const blob = Bun.file(fd);
-          expect(jscSerializeRoundtripCrossProcess(blob, "ignore")).not.toBeInstanceOf(Blob);
+          try {
+            const blob = Bun.file(fd);
+            expect(jscSerializeRoundtripCrossProcess(blob, "ignore")).not.toBeInstanceOf(Blob);
+          } finally {
+            closeSync(fd);
+          }
         });
       }
       describe("dom file", async () => {

--- a/test/js/web/workers/structuredClone-classes.test.ts
+++ b/test/js/web/workers/structuredClone-classes.test.ts
@@ -95,7 +95,10 @@ describe("serialize & deserialize", () => {
         env: bunEnv,
         stdin: serialized,
         stdout: "pipe",
-        stderr: "inherit",
+        // Test types that declare expectedAfterWireBytesRoundtrip expect the
+        // child's deserialize() to die with an uncaught error; don't echo that
+        // expected failure into the test runner's stderr.
+        stderr: "expectedAfterWireBytesRoundtrip" in testType ? "ignore" : "inherit",
       });
       const cloned = result.stdout.length > 0 ? deserialize(result.stdout) : undefined;
       if ("expectedAfterWireBytesRoundtrip" in testType) {

--- a/test/js/web/workers/structuredClone-classes.test.ts
+++ b/test/js/web/workers/structuredClone-classes.test.ts
@@ -29,6 +29,14 @@ const testTypes = [
     name: "BunFile (cloneable, non-transferable)",
     createValue: () => Bun.file(import.meta.filename),
     isTransferable: false,
+    // A path-backed BunFile cannot be reconstructed from a raw byte buffer:
+    // the deserializer rejects file-backed stores whose bytes were supplied by
+    // the caller (they would mint a handle to an arbitrary path/fd). The child
+    // process's deserialize() throws, so the wire round trip yields nothing.
+    expectedAfterWireBytesRoundtrip: (original: any, cloned: any) => {
+      expect(original).toBeInstanceOf(Blob);
+      expect(cloned).not.toBeInstanceOf(Blob);
+    },
     expectedAfterClone: (original: any, cloned: any, isTransfer: TransferMode, isStorage: boolean) => {
       expect(original).toBeInstanceOf(Blob);
       expect(original.name).toEqual(import.meta.filename);
@@ -89,8 +97,12 @@ describe("serialize & deserialize", () => {
         stdout: "pipe",
         stderr: "inherit",
       });
-      const cloned = deserialize(result.stdout);
-      testType.expectedAfterClone(original, cloned, TransferMode.no, true);
+      const cloned = result.stdout.length > 0 ? deserialize(result.stdout) : undefined;
+      if ("expectedAfterWireBytesRoundtrip" in testType) {
+        testType.expectedAfterWireBytesRoundtrip(original, cloned);
+      } else {
+        testType.expectedAfterClone(original, cloned, TransferMode.no, true);
+      }
     });
   }
 });


### PR DESCRIPTION
The structured-clone deserializer reconstructs a path- or fd-backed Blob by reading the path/descriptor straight out of the serialized payload. That is fine when the bytes were produced by an in-process serialize (structuredClone, postMessage, BroadcastChannel), but `bun:jsc` / `node:v8` `deserialize()` and IPC operate on caller-supplied buffers, where the embedded path or descriptor cannot be assumed to refer to something the caller should be handed a handle to.

This threads an is-from-raw-bytes flag from the three deserialize entry points through `CloneDeserializer` and the generated `fromTagDeserialize` dispatch into the Blob deserializer, which now rejects the file store variant for raw buffers. Bytes-backed Blobs and Files still round-trip through `deserialize()`, and in-process clones of `Bun.file()` are unchanged.

Tests: new cases in `test/js/web/structured-clone-blob-file.test.ts` covering the rejected path/fd/s3 payloads and the still-working bytes-backed and in-process round trips; the `bun:jsc` round-trip variants of the existing "file from path"/"file from fd" cases now assert the rejection.