### PR TITLE
css: keep required grouping parens in @container conditions when minifying

### DIFF
--- a/src/css/rules/container.rs
+++ b/src/css/rules/container.rs
@@ -176,7 +176,7 @@ impl QueryCondition for StyleQuery {
     fn needs_parens(&self, parent_operator: Option<Operator>, _targets: &css::Targets) -> bool {
         match self {
             StyleQuery::Not(_) => true,
-            StyleQuery::Operation { operator, .. } => Some(*operator) == parent_operator,
+            StyleQuery::Operation { operator, .. } => Some(*operator) != parent_operator,
             StyleQuery::Feature(_) => true,
         }
     }
@@ -296,7 +296,7 @@ impl QueryCondition for ContainerCondition {
     fn needs_parens(&self, parent_operator: Option<Operator>, targets: &css::Targets) -> bool {
         match self {
             ContainerCondition::Not(_) => true,
-            ContainerCondition::Operation { operator, .. } => Some(*operator) == parent_operator,
+            ContainerCondition::Operation { operator, .. } => Some(*operator) != parent_operator,
             ContainerCondition::Feature(f) => f.needs_parens(parent_operator, targets),
             ContainerCondition::Style(_) => false,
         }

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7466,6 +7466,74 @@ describe("css tests", () => {
     minify_test("@page \\31 st{margin:1em}", "@page \\31 st{margin:1em}");
   });
 
+  describe("container", () => {
+    minify_test("@container (width > 100px) { a { color: red } }", "@container (width>100px){a{color:red}}");
+    minify_test("@container not (width > 100px) { a { color: red } }", "@container not (width>100px){a{color:red}}");
+
+    // `not` takes a single parenthesized query, so the grouping parens around
+    // a nested and/or group must survive minification for the output to parse.
+    minify_test(
+      "@container not ((width > 100px) and (height > 100px)) { a { color: red } }",
+      "@container not ((width>100px) and (height>100px)){a{color:red}}",
+    );
+    minify_test(
+      "@container not ((width > 100px) or (height > 100px)) { a { color: red } }",
+      "@container not ((width>100px) or (height>100px)){a{color:red}}",
+    );
+    minify_test(
+      "@container my-layout not ((width > 100px) and (height > 100px)) { a { color: red } }",
+      "@container my-layout not ((width>100px) and (height>100px)){a{color:red}}",
+    );
+
+    // A nested group keeps its parens when its operator differs from the
+    // parent's; a nested group with the same operator is flattened.
+    minify_test(
+      "@container ((width > 100px) or (height > 100px)) and (orientation: landscape) { a { color: red } }",
+      "@container ((width>100px) or (height>100px)) and (orientation:landscape){a{color:red}}",
+    );
+    minify_test(
+      "@container ((width > 100px) and (height > 100px)) and (orientation: landscape) { a { color: red } }",
+      "@container (width>100px) and (height>100px) and (orientation:landscape){a{color:red}}",
+    );
+
+    // The same grammar applies inside style() queries.
+    minify_test("@container style(not (--a: 1)) { a { color: red } }", "@container style(not (--a:1)){a{color:red}}");
+    minify_test(
+      "@container style(not ((--a: 1) and (--b: 2))) { a { color: red } }",
+      "@container style(not ((--a:1) and (--b:2))){a{color:red}}",
+    );
+    minify_test(
+      "@container style(not ((width: 1px) and (height: 2px))) { a { color: red } }",
+      "@container style(not ((width:1px) and (height:2px))){a{color:red}}",
+    );
+    minify_test(
+      "@container style(((--a: 1) or (--b: 2)) and (--c: 3)) { a { color: red } }",
+      "@container style(((--a:1) or (--b:2)) and (--c:3)){a{color:red}}",
+    );
+    minify_test(
+      "@container style((--a: 1) or (--b: 2)) and style(--c: 3) { a { color: red } }",
+      "@container style((--a:1) or (--b:2)) and style(--c:3){a{color:red}}",
+    );
+
+    // The minified forms parse back to themselves.
+    minify_test(
+      "@container not ((width>100px) and (height>100px)){a{color:red}}",
+      "@container not ((width>100px) and (height>100px)){a{color:red}}",
+    );
+    minify_test(
+      "@container ((width>100px) or (height>100px)) and (orientation:landscape){a{color:red}}",
+      "@container ((width>100px) or (height>100px)) and (orientation:landscape){a{color:red}}",
+    );
+    minify_test(
+      "@container style(not ((--a:1) and (--b:2))){a{color:red}}",
+      "@container style(not ((--a:1) and (--b:2))){a{color:red}}",
+    );
+    minify_test(
+      "@container style(((--a:1) or (--b:2)) and (--c:3)){a{color:red}}",
+      "@container style(((--a:1) or (--b:2)) and (--c:3)){a{color:red}}",
+    );
+  });
+
   describe("font-palette-values", () => {
     minify_test(
       "@font-palette-values --x{font-family:Foo;base-palette:2}",


### PR DESCRIPTION
### What does this PR do?

Fixes a CSS fuzzer invariant violation (`invariant:css:minified CSS does not reparse`): `@container` conditions with a nested and/or group lose the grouping parentheses the grammar requires, so Bun's own CSS parser can't read its minified output back.

**Repro:**

```bash
BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1 bun -e 'const c = require("bun:internal-for-testing").cssInternals;
const min = c.minifyTest("@container style(not ((w:)and (r:))){{c:", "");
console.log(min); // @container style(not (w:) and (r:)){{c:}}
c.minifyTest(min, "");'
# error: parsing failed: Unexpected token: and
```

`not` only takes a single parenthesized query, so `not ((a) and (b))` must keep the group — the re-printed `not (a) and (b)` is a parse error. The same happens for realistic inputs, in both size and style container queries, and also when mixing operators:

| input | minified (before this PR) | reparse |
| --- | --- | --- |
| `@container not ((width > 100px) and (height > 100px))` | `@container not (width>100px) and (height>100px)` | ❌ `Unexpected token: and` |
| `@container style(not ((width: 1px) and (height: 2px)))` | `@container style(not (width:1px) and (height:2px))` | ❌ |
| `@container ((width > 100px) or (height > 100px)) and (orientation: landscape)` | `@container (width>100px) or (height>100px) and (orientation:landscape)` | ❌ (can't mix `and`/`or` without parens) |

Any such stylesheet breaks when Bun-minified CSS is fed back through `bun build` / CSS imports, and `@media` handles all of these correctly — only `@container` is affected.

### Root cause

`needs_parens` for `ContainerCondition` and `StyleQuery` in `src/css/rules/container.rs` has the operator comparison inverted:

```rust
Operation { operator, .. } => Some(*operator) == parent_operator,
```

It adds parentheses when a nested group has the *same* operator as its parent (where they're redundant) and drops them when the operator differs or the parent is `not` (`parent_operator == None`) — exactly the positions where the grammar requires `<query-in-parens>` / `<style-in-parens>`. `MediaCondition::needs_parens` in `media_query.rs` already uses `!=`, which is why the equivalent `@media` queries roundtrip fine.

### The fix

Flip the comparison to `!=` in both `StyleQuery::needs_parens` and `ContainerCondition::needs_parens`, matching `MediaCondition` and current lightningcss. Nested groups now keep their parens under `not` and under a parent with a different operator, and same-operator nesting flattens (`((a) and (b)) and (c)` → `(a) and (b) and (c)`), which is smaller and still equivalent.

All the outputs above now match lightningcss 1.32.0 byte-for-byte, and the fuzzer input roundtrips: `@container style(not ((w:)and (r:))){{c:` → `@container style(not ((w:) and (r:))){{c:}}` → reparses to itself.

### Verification

- New `describe("container")` block in `test/js/bun/css/css.test.ts`: minification of `not`/mixed-operator/style() groups plus reparsing of the minified forms. Without the fix 12 of the 16 tests fail; with it all pass.
- `test/js/bun/css/css.test.ts` + `doesnt_crash.test.ts` + `color.test.ts` on the debug build: no new failures (the only failures are pre-existing timeouts of iteration-heavy fuzz/ANSI-color tests that also time out on unmodified main in the same environment and don't involve `@container`).
