### PR TITLE
Fix panic on anonymous export default class with an auto-accessor field

### DIFF
--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -826,8 +826,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 p.create_default_name(stmt.loc).expect("unreachable");
                         }
 
-                        // We only inject a name into classes when there is a decorator
-                        if class.class.has_decorators {
+                        // We only inject a name into classes when decorator lowering
+                        // needs one: legacy TS decorators (`has_decorators`) or
+                        // standard decorator lowering, which also covers classes with
+                        // only auto-accessor fields and no decorators.
+                        if class.class.has_decorators
+                            || class.class.should_lower_standard_decorators
+                        {
                             if class.class.class_name.is_none()
                                 || class.class.class_name.unwrap().ref_.is_none()
                             {

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -637,6 +637,98 @@ describe("ES Decorators", () => {
       expect(stdout).toBe("decorated foo\n42\n");
       expect(exitCode).toBe(0);
     });
+
+    test("export default anonymous class with auto-accessor and no decorators", async () => {
+      using dir = tempDir("es-dec-export-default-anon-accessor", {
+        "entry.js": `
+          import Cls from "./mod.js";
+          const c = new Cls();
+          console.log(c.op);
+          c.op = 42;
+          console.log(c.op);
+          const desc = Object.getOwnPropertyDescriptor(Cls.prototype, "op");
+          console.log(typeof desc.get, typeof desc.set);
+        `,
+        "mod.js": `
+          export default class {
+            accessor op;
+          }
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "entry.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(filterStderr(rawStderr)).toBe("");
+      expect(stdout).toBe("undefined\n42\nfunction function\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("export default anonymous TypeScript class with auto-accessor and no decorators", async () => {
+      using dir = tempDir("es-dec-export-default-anon-accessor-ts", {
+        "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
+        "entry.ts": `
+          import Cls from "./mod.ts";
+          const c = new Cls();
+          c.op = "hello";
+          console.log(c.op);
+        `,
+        "mod.ts": `
+          export default class {
+            accessor op: string | undefined;
+          }
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "entry.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(filterStderr(rawStderr)).toBe("");
+      expect(stdout).toBe("hello\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("Bun.build bundles export default anonymous class with auto-accessor", async () => {
+      using dir = tempDir("es-dec-build-anon-accessor", {
+        "build.js": `
+          const result = await Bun.build({
+            entrypoints: ["./mod.ts"],
+            target: "bun",
+            minify: true,
+            sourcemap: "external",
+            throw: false,
+          });
+          console.log(result.success);
+        `,
+        "mod.ts": `
+          export default class {
+            accessor op;
+          }
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(filterStderr(rawStderr)).toBe("");
+      expect(stdout).toBe("true\n");
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("anonymous class expressions with reserved-word inferred names", () => {


### PR DESCRIPTION
Fixes a fuzzer-found panic: `called 'Option::unwrap()' on a 'None' value` when transpiling or bundling an anonymous `export default class` that contains an `accessor` (auto-accessor) field and no decorators.

## Repro

```ts
// e.ts (or .js — both panic)
export default class {
  accessor op;
}
```

```
bun e.ts          # panic
bun build e.ts    # panic
Bun.build({ entrypoints: ["./e.ts"], target: "bun", minify: true, sourcemap: "external" })  # panic (original fuzz case)
```

```
panic: called `Option::unwrap()` on a `None` value
  <bun_js_parser::p::P<true, false>>::lower_impl   src/js_parser/lower/lower_decorators.rs:1062
  lower_standard_decorators_stmt → lower_class → s_export_default
```

The `minify`/`sourcemap` flags from the fuzz report are incidental — any parse of the input hits it.

## Root cause

An `accessor` field marks the class `should_lower_standard_decorators`, so `lower_class` takes the standard-decorator lowering path, which reads the class name ref unconditionally for class statements (`lower_decorators.rs:1062`).

For `export default class { ... }` the class statement is anonymous, and `s_export_default` only injected the generated `<file>_default` name when the class `has_decorators`. A class whose only reason for lowering is an auto-accessor has `has_decorators == false`, so no name was injected and the lowering unwrapped `None`.

The expression path already keys this off `should_lower_standard_decorators`; the statement path didn't.

## Fix

In `s_export_default`, inject the default name whenever the class has decorators **or** will go through standard-decorator lowering. Output now matches the already-working decorated case:

```js
var _op = new WeakMap;
var _init = __decoratorStart(undefined);
class e_default {
  constructor() { __privateAdd(this, _op, undefined); }
  get op() { return __privateGet(this, _op); }
  set op(v) { __privateSet(this, _op, v); }
}
__decoratorMetadata(_init, e_default);
let _e_default = e_default;
export { e_default as default };
```

## Verification

- New tests in `test/bundler/transpiler/es-decorators.test.ts` (runtime JS, runtime TS, and a `Bun.build` case mirroring the fuzz config) fail with the panic before the fix and pass after.
- Full `es-decorators.test.ts`, `es-decorators-esbuild.test.ts`, `decorators.test.ts`, `decorator-metadata.test.ts`, `export-default.test.js`, `bundler_decorator_metadata.test.ts`, and `transpiler.test.js` pass with the fix.
- `cargo clippy -p bun_js_parser` clean.
