### PR TITLE
Error instead of crashing on deeply nested statements in the transpiler

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -345,8 +345,10 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// out-of-line `t_*` fns; the `parse_stmt`→`t_for` cycle is only a few
     /// hundred bytes, so the 15k-level `lots-of-for-loop.js` fixture (~4 MB)
     /// never trips the 256 KB threshold on Windows' 18 MB worker stack — parse
-    /// completes, then the (uncapped) visitor/printer recurse 15k times and
-    /// hard-overflow. Same `MAX_STMT_DEPTH` rationale as `interchange/json.rs`.
+    /// would complete and hand a 15k-deep AST to the visitor/printer, whose
+    /// per-level frames are far larger (they carry their own stack checks in
+    /// `visit_and_append_stmt`/`print_stmt`, but the cap keeps the failure
+    /// deterministic). Same `MAX_STMT_DEPTH` rationale as `interchange/json.rs`.
     pub parse_stmt_depth: u32,
 
     pub reported_stack_overflow: core::cell::Cell<bool>,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3332,6 +3332,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     fn hoist_symbols(&mut self, mut scope: js_ast::StoreRef<js_ast::Scope>) {
+        // This runs before the visit pass, so it walks the scope tree at the full
+        // nesting depth the parser allowed; deep trees must error here instead of
+        // overflowing the stack.
+        if !self.stack_check.is_safe_to_recurse() || self.reported_stack_overflow.get() {
+            self.report_stack_overflow(bun_ast::Loc::EMPTY);
+            return;
+        }
+
         // `StoreRef` is the arena back-pointer with safe `Deref`/`DerefMut` —
         // scope is arena-owned and valid for the parser 'a lifetime; the visit
         // pass is single-threaded so no aliasing `&mut` is outstanding. Read the

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -338,18 +338,6 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub has_commonjs_export_names: bool,
 
     pub stack_check: bun_core::StackCheck,
-    /// Hard recursion cap for `parse_stmt`. Zig relies on `stack_check` alone,
-    /// but its `parseStmt` uses an `inline` switch that pulls every `t_*`
-    /// handler into one multi-KB frame, so 15k nested statements exhaust the
-    /// 18 MB Windows stack and trip `is_safe_to_recurse()`. Rust dispatches to
-    /// out-of-line `t_*` fns; the `parse_stmt`→`t_for` cycle is only a few
-    /// hundred bytes, so the 15k-level `lots-of-for-loop.js` fixture (~4 MB)
-    /// never trips the 256 KB threshold on Windows' 18 MB worker stack — parse
-    /// would complete and hand a 15k-deep AST to the visitor/printer, whose
-    /// per-level frames are far larger (they carry their own stack checks in
-    /// `visit_and_append_stmt`/`print_stmt`, but the cap keeps the failure
-    /// deterministic). Same `MAX_STMT_DEPTH` rationale as `interchange/json.rs`.
-    pub parse_stmt_depth: u32,
 
     pub reported_stack_overflow: core::cell::Cell<bool>,
 
@@ -9246,7 +9234,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             named_exports: Default::default(),
             log,
             stack_check: bun_core::StackCheck::init(),
-            parse_stmt_depth: 0,
             reported_stack_overflow: core::cell::Cell::new(false),
             ts_infer_constraint_backtracks: Vec::new(),
             arena,

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1897,8 +1897,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     pub fn parse_stmt(&mut self, opts: &mut ParseStatementOptions<'a>) -> Result<Stmt> {
         // PORT NOTE: Zig only checks `stack_check`; the hard cap is added so
         // Windows' 18 MB worker stack (where the small Rust `parse_stmt`→`t_*`
-        // frames never exhaust it) still throws before the uncapped visitor/
-        // printer pass hard-overflows. See `P::parse_stmt_depth` field doc.
+        // frames never exhaust it) still rejects absurd nesting deterministically
+        // instead of deferring to the visitor/printer stack checks.
+        // See `P::parse_stmt_depth` field doc.
         if self.parse_stmt_depth >= MAX_STMT_DEPTH || !self.stack_check.is_safe_to_recurse() {
             // TODO(port): bun_core::throw_stack_overflow() not yet exported; map to a SyntaxError
             // until the StackOverflow error variant lands.
@@ -1941,6 +1942,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 }
 
-/// See `P::parse_stmt_depth` — sized so the visitor/printer (larger per-level
-/// frames, no stack check) fit on the smallest 4 MB POSIX worker stack.
+/// See `P::parse_stmt_depth` — a deterministic upper bound; depths below it are
+/// still guarded by the per-level stack checks in the visitor/printer, whose
+/// frames are much larger than `parse_stmt`'s.
 const MAX_STMT_DEPTH: u32 = 1000;

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1895,22 +1895,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     pub fn parse_stmt(&mut self, opts: &mut ParseStatementOptions<'a>) -> Result<Stmt> {
-        // PORT NOTE: Zig only checks `stack_check`; the hard cap is added so
-        // Windows' 18 MB worker stack (where the small Rust `parse_stmt`→`t_*`
-        // frames never exhaust it) still rejects absurd nesting deterministically
-        // instead of deferring to the visitor/printer stack checks.
-        // See `P::parse_stmt_depth` field doc.
-        if self.parse_stmt_depth >= MAX_STMT_DEPTH || !self.stack_check.is_safe_to_recurse() {
+        if !self.stack_check.is_safe_to_recurse() {
             // TODO(port): bun_core::throw_stack_overflow() not yet exported; map to a SyntaxError
             // until the StackOverflow error variant lands.
             return Err(err!("StackOverflow"));
         }
-        self.parse_stmt_depth += 1;
 
         // Zig used `inline ... => |function| @field(@This(), @tagName(function))(...)` to dispatch
         // by token name via comptime reflection. Rust has no `@field`/`@tagName`; expand the arms.
         let loc = self.lexer.loc();
-        let result = match self.lexer.token {
+        match self.lexer.token {
             T::TSemicolon => Self::t_semicolon(self),
             T::TAt => Self::t_at(self, opts),
 
@@ -1936,13 +1930,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             T::TOpenBrace => Self::t_open_brace(self, opts, loc),
 
             _ => Self::parse_stmt_fallthrough(self, opts, loc),
-        };
-        self.parse_stmt_depth -= 1;
-        result
+        }
     }
 }
-
-/// See `P::parse_stmt_depth` — a deterministic upper bound; depths below it are
-/// still guarded by the per-level stack checks in the visitor/printer, whose
-/// frames are much larger than `parse_stmt`'s.
-const MAX_STMT_DEPTH: u32 = 1000;

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -52,6 +52,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         stmts: &mut StmtList<'a>,
         stmt: &mut Stmt,
     ) -> Result<(), Error> {
+        // Statements nest arbitrarily deep (e.g. hundreds of `{` blocks), and each
+        // level stacks a `visit_stmts` + `s_*` frame, so guard here like
+        // `visit_expr_in_out` does for expressions.
+        if !self.stack_check.is_safe_to_recurse() || self.reported_stack_overflow.get() {
+            self.report_stack_overflow(stmt.loc);
+            return Ok(());
+        }
+
         let p = self;
         // By default any statement ends the const local prefix
         let was_after_after_const_local_prefix = p.cur_scope().is_after_const_local_prefix;

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -5196,6 +5196,11 @@ pub mod __gated_printer {
         }
 
         pub fn print_stmt(&mut self, stmt: Stmt, tlmtlo: TopLevel) -> Result<(), bun_core::Error> {
+            if !self.stack_check.is_safe_to_recurse() {
+                self.stack_overflowed = true;
+                return Ok(());
+            }
+
             let prev_stmt_tag = self.prev_stmt_tag;
             // Zig: `defer { p.prev_stmt_tag = std.meta.activeTag(stmt.data); }`
             // PORT NOTE: reshaped for borrowck — scopeguard would hold `&mut self.prev_stmt_tag`

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -6657,6 +6657,13 @@ pub mod __gated_printer {
         }
 
         pub fn print_if(&mut self, s: &S::If, loc: bun_ast::Loc, tlmtlo: TopLevel) {
+            // `else if` chains recurse here directly without passing through
+            // `print_stmt`, so they need their own guard.
+            if !self.stack_check.is_safe_to_recurse() {
+                self.stack_overflowed = true;
+                return;
+            }
+
             self.print_space_before_identifier();
             self.add_source_mapping(loc);
             self.print(b"if");

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4044,6 +4044,43 @@ it("deeply nested expressions error instead of crashing the process", () => {
   expect([exitCode, signalCode ?? undefined]).toEqual([0, undefined]);
 }, 60_000);
 
+it("deeply nested statement blocks error instead of crashing the process", () => {
+  const script = `
+    const repeat = (fill, count) => Buffer.alloc(fill.length * count, fill).toString();
+    const shapes = [
+      n => repeat("{", n) + 'class Test1 { static "prop1" = 0; }' + repeat("}", n),
+      n => repeat("{", n) + "let x = 1;" + repeat("}", n),
+      n => repeat("if (x) {", n) + "y();" + repeat("}", n),
+    ];
+    const check = (transpiler, src) => {
+      try {
+        transpiler.transformSync(src);
+      } catch (e) {
+        if (!/Maximum call stack size exceeded|StackOverflow/.test(String(e?.message))) throw e;
+      }
+    };
+    for (const shape of shapes) {
+      for (const n of [600, 800, 990]) {
+        check(
+          new Bun.Transpiler({ loader: "tsx", target: "bun", minifyWhitespace: true, deadCodeElimination: true }),
+          shape(n),
+        );
+        check(new Bun.Transpiler({ loader: "js" }), shape(n));
+      }
+    }
+    console.log("depth-ok");
+  `;
+  const { stdout, exitCode, signalCode } = Bun.spawnSync({
+    cmd: [bunExe(), "-e", script],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+
+  expect(stdout.toString()).toBe("depth-ok\n");
+  expect([exitCode, signalCode ?? undefined]).toEqual([0, undefined]);
+}, 60_000);
+
 it("running a file with deeply nested unary operators does not crash the process", () => {
   const code = Buffer.alloc(2 * 4000, "- ").toString() + "1";
   const { exitCode, signalCode } = Bun.spawnSync({

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4051,6 +4051,7 @@ it("deeply nested statement blocks error instead of crashing the process", () =>
       n => repeat("{", n) + 'class Test1 { static "prop1" = 0; }' + repeat("}", n),
       n => repeat("{", n) + "let x = 1;" + repeat("}", n),
       n => repeat("if (x) {", n) + "y();" + repeat("}", n),
+      n => "if (x) { y(); }" + repeat(" else if (x) { y(); }", n),
     ];
     const check = (transpiler, src) => {
       try {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4166,7 +4166,7 @@ it("deeply nested statement blocks error instead of crashing the process", () =>
 
   expect(stdout.toString()).toBe("depth-ok\n");
   expect([exitCode, signalCode ?? undefined]).toEqual([0, undefined]);
-}, 60_000);
+});
 
 it("running a file with deeply nested unary operators does not crash the process", () => {
   const code = Buffer.alloc(2 * 4000, "- ").toString() + "1";


### PR DESCRIPTION
### Problem

Fuzzing found a second transpiler stack overflow (`sig:SIGSEGV:nostack`): ~600 nested `{` blocks crash the process.

```js
new Bun.Transpiler({ loader: "tsx", target: "bun", minifyWhitespace: true, deadCodeElimination: true })
  .transformSync("{".repeat(600) + 'class Test1 { static "prop1" = 0; }' + "}".repeat(600));
```

#31242 guarded the **expression** recursion (`visit_expr_in_out`, `print_expr`, DCE helpers), but the **statement** recursion was left unguarded. Nested blocks stay under `MAX_STMT_DEPTH` (1000) in `parse_stmt`, then the visit pass recurses through `visit_stmts → visit_and_append_stmt → s_block → visit_stmts` with no stack check — each level stacks several multi-KB frames, so a few hundred levels exhaust the thread's stack (reproduces at depth 800 on a debug build's 8 MB main stack; smaller stacks crash at 600):

```
#5  visit_stmts                 src/js_parser/visit/mod.rs:1280
#6  s_block                     src/js_parser/visit/visit_stmt.rs:1627
#7  visit_and_append_stmt       src/js_parser/visit/visit_stmt.rs:108
#8  visit_stmts                 src/js_parser/visit/mod.rs:1336
... (repeats until SIGSEGV)
```

### Fix

Guard the statement recursion the same way the expression recursion already is:

- `visit_and_append_stmt` now checks `stack_check.is_safe_to_recurse()` (plus the `reported_stack_overflow` fast-path) and reports "Maximum call stack size exceeded" instead of descending, mirroring `visit_expr_in_out`.
- `print_stmt` and `print_if` (which self-recurses for `else if` chains without passing through `print_stmt`) get the same guard `print_expr`/`print_binding` already have, so a deep AST printed on a thread with less stack headroom errors instead of overflowing.
- Removed the `MAX_STMT_DEPTH`/`parse_stmt_depth` hard cap from `parse_stmt` (review feedback): recursion depth in every phase is now governed by `StackCheck` alone, matching the Zig parser.
- Guarded `hoist_symbols` the same way: it walks the scope tree before the visit pass at the full depth the parser allowed, and was only kept safe previously by the now-removed cap (the 15k-deep `lots-of-for-loop.js` fixture overflowed it in release builds otherwise).

With this, every arbitrarily-nestable AST recursion (statements, expressions, bindings) is stack-checked in all three phases (parse, visit, print); deep inputs throw a catchable `Maximum call stack size exceeded` error.

### Verification

New test `deeply nested statement blocks error instead of crashing the process` in `test/bundler/transpiler/transpiler.test.js` transpiles nested-block and `else if`-chain shapes at depths 600/800/990 (below the parse-time cap, deep enough to overflow an unguarded visitor) in a subprocess and asserts it exits cleanly.

- Without the fix: the subprocess dies with SIGSEGV at depth 800+ (debug build), so the test fails.
- With the fix: `bun bd test test/bundler/transpiler/transpiler.test.js` → 147 pass, 0 fail; the repro above now throws `Maximum call stack size exceeded`.



