### PR TITLE
install: verify cached npm packages against the lockfile integrity

### DIFF
--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -2388,13 +2388,9 @@ impl<'a> PackageInstall<'a> {
         match state {
             crate::PreinstallState::Done => false,
             _ => 'brk: {
-                // Shared-cache npm entries are keyed only by name@version, so a
-                // bare existence probe would accept a folder produced from a
-                // different tarball (e.g. by another project's install). When
-                // this lockfile carries an integrity for the package, require
-                // the cache folder's recorded integrity to match before
-                // treating it as present; otherwise report it missing so it is
-                // re-downloaded, re-verified, and replaced.
+                // Shared-cache npm entries are keyed only by name@version; require
+                // the folder's recorded integrity to match this lockfile's before
+                // treating it as present.
                 let expected = self.lockfile.packages.items_meta()[package_id as usize].integrity;
                 let npm_integrity_check_needed = resolution_tag == resolution::Tag::Npm
                     && manager.options.do_.verify_integrity()
@@ -2464,9 +2460,6 @@ impl<'a> PackageInstall<'a> {
                 // SAFETY: NUL written above.
                 let subpath =
                     ZStr::from_buf(&join_buf[..], cache_dir_subpath_without_patch_hash.len());
-                // The non-patched base folder is the same shared name@version
-                // cache slot; apply the same integrity gate before its
-                // contents are copied out and patched.
                 let exists = sys::directory_exists_at(self.cache_dir, subpath).unwrap_or(false)
                     && (!npm_integrity_check_needed
                         || crate::package_manager::cached_folder_integrity_matches(
@@ -2488,11 +2481,8 @@ impl<'a> PackageInstall<'a> {
         package_id: PackageID,
     ) -> bool {
         // The patched cache folder is keyed by the patch file's content hash
-        // on top of name@version — nothing that pins the base tarball it was
-        // built from — so it gets the same integrity gate as the base folder
-        // before its contents are linked into node_modules. On mismatch (or a
-        // missing record) report it missing so the patch is re-applied on top
-        // of a verified base.
+        // on top of name@version — nothing pins the base tarball it was built
+        // from — so it gets the same integrity gate as the base folder.
         let expected = self.lockfile.packages.items_meta()[package_id as usize].integrity;
         let resolution_tag = self.lockfile.packages.items_resolution()[package_id as usize].tag;
         let npm_integrity_check_needed = resolution_tag == resolution::Tag::Npm

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -2487,8 +2487,26 @@ impl<'a> PackageInstall<'a> {
         manager: &mut PackageManager,
         package_id: PackageID,
     ) -> bool {
+        // The patched cache folder is keyed by the patch file's content hash
+        // on top of name@version — nothing that pins the base tarball it was
+        // built from — so it gets the same integrity gate as the base folder
+        // before its contents are linked into node_modules. On mismatch (or a
+        // missing record) report it missing so the patch is re-applied on top
+        // of a verified base.
+        let expected = self.lockfile.packages.items_meta()[package_id as usize].integrity;
+        let resolution_tag = self.lockfile.packages.items_resolution()[package_id as usize].tag;
+        let npm_integrity_check_needed = resolution_tag == resolution::Tag::Npm
+            && manager.options.do_.verify_integrity()
+            && expected.tag.is_supported();
         let exists =
             sys::directory_exists_at(self.cache_dir, self.cache_dir_subpath).unwrap_or(false);
+        let exists = exists
+            && (!npm_integrity_check_needed
+                || crate::package_manager::cached_folder_integrity_matches(
+                    self.cache_dir,
+                    strings::without_trailing_slash(self.cache_dir_subpath.as_bytes()),
+                    &expected,
+                ));
         if exists {
             manager.set_preinstall_state(package_id, crate::PreinstallState::Done);
         }

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -14,6 +14,7 @@ use bun_threading::thread_pool::{Batch, Node as ThreadPoolNode};
 use bun_threading::work_pool::Task as WorkPoolTask;
 use bun_threading::{ThreadPool, WaitGroup};
 
+use crate::lockfile::package::PackageColumns as _;
 use crate::package_installer::NodeModulesFolder;
 use crate::{
     BuntagHashBuf, Lockfile, Npm, PackageID, PackageManager, Repository, Resolution,
@@ -2387,6 +2388,18 @@ impl<'a> PackageInstall<'a> {
         match state {
             crate::PreinstallState::Done => false,
             _ => 'brk: {
+                // Shared-cache npm entries are keyed only by name@version, so a
+                // bare existence probe would accept a folder produced from a
+                // different tarball (e.g. by another project's install). When
+                // this lockfile carries an integrity for the package, require
+                // the cache folder's recorded integrity to match before
+                // treating it as present; otherwise report it missing so it is
+                // re-downloaded, re-verified, and replaced.
+                let expected = self.lockfile.packages.items_meta()[package_id as usize].integrity;
+                let npm_integrity_check_needed = resolution_tag == resolution::Tag::Npm
+                    && manager.options.do_.verify_integrity()
+                    && expected.tag.is_supported();
+
                 if self.patch.is_none() {
                     let exists = match resolution_tag {
                         resolution::Tag::Npm => 'package_json_exists: {
@@ -2424,6 +2437,13 @@ impl<'a> PackageInstall<'a> {
                         _ => sys::directory_exists_at(self.cache_dir, self.cache_dir_subpath)
                             .unwrap_or(false),
                     };
+                    let exists = exists
+                        && (!npm_integrity_check_needed
+                            || crate::package_manager::cached_folder_integrity_matches(
+                                self.cache_dir,
+                                strings::without_trailing_slash(self.cache_dir_subpath.as_bytes()),
+                                &expected,
+                            ));
                     if exists {
                         manager.set_preinstall_state(package_id, crate::PreinstallState::Done);
                     }
@@ -2444,7 +2464,16 @@ impl<'a> PackageInstall<'a> {
                 // SAFETY: NUL written above.
                 let subpath =
                     ZStr::from_buf(&join_buf[..], cache_dir_subpath_without_patch_hash.len());
-                let exists = sys::directory_exists_at(self.cache_dir, subpath).unwrap_or(false);
+                // The non-patched base folder is the same shared name@version
+                // cache slot; apply the same integrity gate before its
+                // contents are copied out and patched.
+                let exists = sys::directory_exists_at(self.cache_dir, subpath).unwrap_or(false)
+                    && (!npm_integrity_check_needed
+                        || crate::package_manager::cached_folder_integrity_matches(
+                            self.cache_dir,
+                            cache_dir_subpath_without_patch_hash,
+                            &expected,
+                        ));
                 if exists {
                     manager.set_preinstall_state(package_id, crate::PreinstallState::Done);
                 }

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -243,8 +243,9 @@ pub use super::package_installer::PackageInstaller;
 pub use self::package_manager_directories as directories;
 use directories::attempt_to_create_package_json_and_open;
 pub use directories::{
-    attempt_to_create_package_json, cached_git_folder_name, cached_git_folder_name_print,
-    cached_git_folder_name_print_auto, cached_github_folder_name, cached_github_folder_name_print,
+    attempt_to_create_package_json, cache_integrity_sidecar_name, cached_folder_integrity_matches,
+    cached_git_folder_name, cached_git_folder_name_print, cached_git_folder_name_print_auto,
+    cached_github_folder_name, cached_github_folder_name_print,
     cached_github_folder_name_print_auto, cached_npm_package_folder_name,
     cached_npm_package_folder_name_print, cached_npm_package_folder_print_basename,
     cached_tarball_folder_name, cached_tarball_folder_name_print, compute_cache_dir_and_subpath,

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -9,6 +9,7 @@ use crate::repository::Repository;
 use bun_core::ZStr;
 use bun_core::{Error, Global, Output, ZBox, env_var, fmt as bun_fmt};
 use bun_dotenv::Loader as DotEnvLoader;
+use bun_install::integrity::Integrity;
 use bun_install::lockfile::{Format as LockfileFormat, LoadResult, Lockfile};
 use bun_install::resolution::Tag as ResolutionTag;
 use bun_install::{PackageID, Resolution};
@@ -827,6 +828,45 @@ pub fn cached_tarball_folder_name(
 
 pub fn is_folder_in_cache(this: &mut PackageManager, folder_path: &ZStr) -> bool {
     sys::directory_exists_at(get_cache_directory(this), folder_path).unwrap_or(false)
+}
+
+/// Suffix appended to a cache folder name to form the name of the sidecar file
+/// that records the integrity the folder's source tarball was verified
+/// against. Cache folder names always end in `@@@<digits>` (the cache version)
+/// or `_patch_hash=<hex>`, never `.integrity`, so the sidecar can never
+/// collide with a real cache folder.
+pub const CACHE_INTEGRITY_SIDECAR_SUFFIX: &[u8] = b".integrity";
+
+/// Writes `<folder_path>.integrity\0` into `buf` and returns it as a `ZStr`
+/// borrowing from `buf`.
+pub fn cache_integrity_sidecar_name<'a>(buf: &'a mut PathBuffer, folder_path: &[u8]) -> &'a ZStr {
+    let len = folder_path.len() + CACHE_INTEGRITY_SIDECAR_SUFFIX.len();
+    buf[..folder_path.len()].copy_from_slice(folder_path);
+    buf[folder_path.len()..len].copy_from_slice(CACHE_INTEGRITY_SIDECAR_SUFFIX);
+    buf[len] = 0;
+    ZStr::from_buf(&buf[..], len)
+}
+
+/// Returns true iff the cache folder's integrity sidecar exists, parses, and
+/// matches `expected`. Any open/read/parse failure — including a missing
+/// sidecar (an entry written before sidecars existed, or whose write was
+/// interrupted) — is reported as a mismatch so the caller treats the entry as
+/// a cache miss and re-downloads + re-verifies the package instead of trusting
+/// a folder whose provenance is unknown.
+pub fn cached_folder_integrity_matches(
+    cache_dir: Fd,
+    folder_path: &[u8],
+    expected: &Integrity,
+) -> bool {
+    if !expected.tag.is_supported() {
+        return false;
+    }
+    let mut sidecar_buf = PathBuffer::uninit();
+    let sidecar = cache_integrity_sidecar_name(&mut sidecar_buf, folder_path);
+    let Ok(bytes) = File::read_from(cache_dir, sidecar.as_bytes()) else {
+        return false;
+    };
+    Integrity::parse(&bytes).eql_supported(expected)
 }
 
 // ─────────────────────────── global directories ───────────────────────────────

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -830,11 +830,9 @@ pub fn is_folder_in_cache(this: &mut PackageManager, folder_path: &ZStr) -> bool
     sys::directory_exists_at(get_cache_directory(this), folder_path).unwrap_or(false)
 }
 
-/// Suffix appended to a cache folder name to form the name of the sidecar file
-/// that records the integrity the folder's source tarball was verified
-/// against. Cache folder names always end in `@@@<digits>` (the cache version)
-/// or `_patch_hash=<hex>`, never `.integrity`, so the sidecar can never
-/// collide with a real cache folder.
+/// Suffix forming the name of the sidecar file that records the integrity a
+/// cache folder's source tarball was verified against. Folder names never end
+/// in `.integrity`, so the sidecar cannot collide with a real cache folder.
 pub const CACHE_INTEGRITY_SIDECAR_SUFFIX: &[u8] = b".integrity";
 
 /// Writes `<folder_path>.integrity\0` into `buf` and returns it as a `ZStr`
@@ -848,11 +846,8 @@ pub fn cache_integrity_sidecar_name<'a>(buf: &'a mut PathBuffer, folder_path: &[
 }
 
 /// Returns true iff the cache folder's integrity sidecar exists, parses, and
-/// matches `expected`. Any open/read/parse failure — including a missing
-/// sidecar (an entry written before sidecars existed, or whose write was
-/// interrupted) — is reported as a mismatch so the caller treats the entry as
-/// a cache miss and re-downloads + re-verifies the package instead of trusting
-/// a folder whose provenance is unknown.
+/// matches `expected`. Any failure (including a missing sidecar) is reported
+/// as a mismatch so the caller treats the entry as a cache miss.
 pub fn cached_folder_integrity_matches(
     cache_dir: Fd,
     folder_path: &[u8],

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -225,25 +225,16 @@ impl PackageManager {
                     return PreinstallState::Extract;
                 }
 
-                // The cache is shared across every project on the machine, and
-                // its npm entries are keyed only by name@version. A bare
-                // existence check would let any previously cached folder stand
-                // in for this lockfile's package even if it was produced from
-                // a different tarball. Require the folder's recorded integrity
-                // to match this lockfile's expected integrity before treating
-                // it as a hit; on mismatch (or a missing/unreadable record)
-                // fall through to Extract, which re-downloads, re-verifies,
-                // and replaces the folder.
+                // The shared cache keys npm entries by name@version only; require
+                // the folder's recorded integrity to match this lockfile's before
+                // treating it as a hit. On mismatch, fall through to Extract.
                 let expected = pkg.meta.integrity;
                 let npm_integrity_check_needed = pkg.resolution.tag == ResolutionTag::Npm
                     && self.options.do_.verify_integrity()
                     && expected.tag.is_supported();
 
-                // Patched cache folders are keyed by the patch file's content
-                // hash on top of name@version — still nothing that pins the
-                // base tarball they were built from — so they get the same
-                // gate. Their sidecar is written when the patch is applied
-                // (see `PatchTask::apply`).
+                // Patched cache folders get the same gate; their sidecar is
+                // written when the patch is applied (see `PatchTask::apply`).
                 if directories::is_folder_in_cache(self, folder_path)
                     && (!npm_integrity_check_needed
                         || directories::cached_folder_integrity_matches(
@@ -274,9 +265,6 @@ impl PackageManager {
                         });
                     // Zig: `allocator.dupeZ(u8, folder_path[..idx])` — owned NUL-terminated copy.
                     let non_patched_path = ZBox::from_bytes(&folder_path.as_bytes()[..idx]);
-                    // The non-patched base folder is the same shared
-                    // name@version cache slot, so it gets the same integrity
-                    // gate before its contents are copied out and patched.
                     if directories::is_folder_in_cache(self, &non_patched_path)
                         && (!npm_integrity_check_needed
                             || directories::cached_folder_integrity_matches(

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -225,7 +225,29 @@ impl PackageManager {
                     return PreinstallState::Extract;
                 }
 
-                if directories::is_folder_in_cache(self, folder_path) {
+                // The cache is shared across every project on the machine, and
+                // its npm entries are keyed only by name@version. A bare
+                // existence check would let any previously cached folder stand
+                // in for this lockfile's package even if it was produced from
+                // a different tarball. Require the folder's recorded integrity
+                // to match this lockfile's expected integrity before treating
+                // it as a hit; on mismatch (or a missing/unreadable record)
+                // fall through to Extract, which re-downloads, re-verifies,
+                // and replaces the folder.
+                let expected = pkg.meta.integrity;
+                let npm_integrity_check_needed = pkg.resolution.tag == ResolutionTag::Npm
+                    && self.options.do_.verify_integrity()
+                    && expected.tag.is_supported();
+
+                if directories::is_folder_in_cache(self, folder_path)
+                    && (patch_hash.is_some()
+                        || !npm_integrity_check_needed
+                        || directories::cached_folder_integrity_matches(
+                            directories::get_cache_directory(self),
+                            folder_path.as_bytes(),
+                            &expected,
+                        ))
+                {
                     self.set_preinstall_state(pkg.meta.id, PreinstallState::Done);
                     return PreinstallState::Done;
                 }
@@ -248,7 +270,17 @@ impl PackageManager {
                         });
                     // Zig: `allocator.dupeZ(u8, folder_path[..idx])` — owned NUL-terminated copy.
                     let non_patched_path = ZBox::from_bytes(&folder_path.as_bytes()[..idx]);
-                    if directories::is_folder_in_cache(self, &non_patched_path) {
+                    // The non-patched base folder is the same shared
+                    // name@version cache slot, so it gets the same integrity
+                    // gate before its contents are copied out and patched.
+                    if directories::is_folder_in_cache(self, &non_patched_path)
+                        && (!npm_integrity_check_needed
+                            || directories::cached_folder_integrity_matches(
+                                directories::get_cache_directory(self),
+                                non_patched_path.as_bytes(),
+                                &expected,
+                            ))
+                    {
                         self.set_preinstall_state(pkg.meta.id, PreinstallState::ApplyPatch);
                         // yay step 1 is already done for us
                         return PreinstallState::ApplyPatch;

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -239,9 +239,13 @@ impl PackageManager {
                     && self.options.do_.verify_integrity()
                     && expected.tag.is_supported();
 
+                // Patched cache folders are keyed by the patch file's content
+                // hash on top of name@version — still nothing that pins the
+                // base tarball they were built from — so they get the same
+                // gate. Their sidecar is written when the patch is applied
+                // (see `PatchTask::apply`).
                 if directories::is_folder_in_cache(self, folder_path)
-                    && (patch_hash.is_some()
-                        || !npm_integrity_check_needed
+                    && (!npm_integrity_check_needed
                         || directories::cached_folder_integrity_matches(
                             directories::get_cache_directory(self),
                             folder_path.as_bytes(),

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -523,11 +523,14 @@ impl ExtractTarball {
 
             // The cache folder is about to be replaced, so any existing
             // integrity sidecar describes bytes that are going away. Remove it
-            // *before* the rename: every failure or interruption from here on
-            // then leaves at worst a folder without a sidecar (which readers
-            // treat as a cache miss), never a folder paired with a sidecar its
-            // contents were not verified against. If the stale sidecar cannot
-            // be removed, abort before touching the folder.
+            // *before* the rename: if this process then fails or is
+            // interrupted at any point, it leaves at worst a folder without a
+            // sidecar (which readers treat as a cache miss), never the stale
+            // sidecar paired with the new folder. (Two installs racing on the
+            // same slot can still interleave their unlink/rename/write
+            // sequences — see the note at the sidecar write below.) If the
+            // stale sidecar cannot be removed, abort before touching the
+            // folder.
             let mut sidecar_name_buf = PathBuffer::uninit();
             let sidecar_name =
                 directories::cache_integrity_sidecar_name(&mut sidecar_name_buf, folder_name);
@@ -539,11 +542,10 @@ impl ExtractTarball {
                         None,
                         bun_ast::Loc::EMPTY,
                         format_args!(
-                            "moving \"{}\" to cache dir failed: {}\n  From: {}\n    To: {}",
+                            "removing stale integrity sidecar for \"{}\" failed: {}\n  Path: {}",
                             bun_fmt::s(name),
                             err,
-                            bun_fmt::s(tmpname.as_bytes()),
-                            bun_fmt::s(folder_name),
+                            bun_fmt::s(sidecar_name.as_bytes()),
                         ),
                     );
                     return Err(bun_core::err!("InstallFailed"));
@@ -728,10 +730,23 @@ impl ExtractTarball {
             // later installs can require their own lockfile's integrity to
             // match before trusting this folder. Only written when the bytes
             // were actually verified (same precondition as `run`'s integrity
-            // check above), so the sidecar value is always the true hash of
-            // the bytes that produced the folder. A failed write is ignored:
-            // a folder without a sidecar is never trusted by the read side, so
-            // the worst case is one redundant re-download on the next install.
+            // check above). A failed write is ignored: a folder without a
+            // sidecar is never trusted by the read side, so the worst case is
+            // one redundant re-download on the next install.
+            //
+            // The unlink → rename → write sequence is not atomic across
+            // processes. Two installs racing on this slot with different
+            // integrities can leave one install's folder paired with the
+            // other's sidecar. That is accepted rather than closed here: the
+            // folder is still the verified output of one of the racing
+            // installs (never bytes nobody verified), a reader that trusts
+            // the mismatched pair gets exactly what the pre-sidecar cache
+            // handed out unconditionally, and the slot heals on the next
+            // install whose integrity disagrees with the sidecar. Actually
+            // closing the race needs the cache folder keyed by integrity or a
+            // cross-process lock held from extract through link — reordering
+            // the writes here cannot do it, because readers re-resolve the
+            // folder by name after checking the sidecar anyway.
             if !self.skip_verify && self.integrity.tag.is_supported() {
                 let mut integrity_str: [u8; 128] = [0u8; 128];
                 let mut cursor = std::io::Cursor::new(&mut integrity_str[..]);

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -521,16 +521,10 @@ impl ExtractTarball {
             }
             let cache_dir = Dir::borrow(&self.cache_dir);
 
-            // The cache folder is about to be replaced, so any existing
-            // integrity sidecar describes bytes that are going away. Remove it
-            // *before* the rename: if this process then fails or is
-            // interrupted at any point, it leaves at worst a folder without a
-            // sidecar (which readers treat as a cache miss), never the stale
-            // sidecar paired with the new folder. (Two installs racing on the
-            // same slot can still interleave their unlink/rename/write
-            // sequences — see the note at the sidecar write below.) If the
-            // stale sidecar cannot be removed, abort before touching the
-            // folder.
+            // Remove any stale integrity sidecar *before* the rename: an
+            // interruption after this point then leaves at worst a folder
+            // without a sidecar (a cache miss to readers), never a stale
+            // sidecar paired with the new folder.
             let mut sidecar_name_buf = PathBuffer::uninit();
             let sidecar_name =
                 directories::cache_integrity_sidecar_name(&mut sidecar_name_buf, folder_name);
@@ -727,26 +721,12 @@ impl ExtractTarball {
             }
 
             // Record the integrity the tarball bytes were verified against so
-            // later installs can require their own lockfile's integrity to
-            // match before trusting this folder. Only written when the bytes
-            // were actually verified (same precondition as `run`'s integrity
-            // check above). A failed write is ignored: a folder without a
-            // sidecar is never trusted by the read side, so the worst case is
-            // one redundant re-download on the next install.
-            //
-            // The unlink → rename → write sequence is not atomic across
-            // processes. Two installs racing on this slot with different
-            // integrities can leave one install's folder paired with the
-            // other's sidecar. That is accepted rather than closed here: the
-            // folder is still the verified output of one of the racing
-            // installs (never bytes nobody verified), a reader that trusts
-            // the mismatched pair gets exactly what the pre-sidecar cache
-            // handed out unconditionally, and the slot heals on the next
-            // install whose integrity disagrees with the sidecar. Actually
-            // closing the race needs the cache folder keyed by integrity or a
-            // cross-process lock held from extract through link — reordering
-            // the writes here cannot do it, because readers re-resolve the
-            // folder by name after checking the sidecar anyway.
+            // later installs can check it against their own lockfile. A failed
+            // write is ignored: a folder without a sidecar is never trusted,
+            // so the worst case is one redundant re-download. Two installs
+            // racing on this slot can pair one's folder with the other's
+            // sidecar; the slot heals on the next install whose integrity
+            // disagrees.
             if !self.skip_verify && self.integrity.tag.is_supported() {
                 let mut integrity_str: [u8; 128] = [0u8; 128];
                 let mut cursor = std::io::Cursor::new(&mut integrity_str[..]);

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -1,5 +1,6 @@
 use core::cell::RefCell;
 use core::fmt;
+use std::io::Write as _;
 
 use bun_core::fmt::s;
 use bun_core::{Output, fmt as bun_fmt};
@@ -520,6 +521,35 @@ impl ExtractTarball {
             }
             let cache_dir = Dir::borrow(&self.cache_dir);
 
+            // The cache folder is about to be replaced, so any existing
+            // integrity sidecar describes bytes that are going away. Remove it
+            // *before* the rename: every failure or interruption from here on
+            // then leaves at worst a folder without a sidecar (which readers
+            // treat as a cache miss), never a folder paired with a sidecar its
+            // contents were not verified against. If the stale sidecar cannot
+            // be removed, abort before touching the folder.
+            let mut sidecar_name_buf = PathBuffer::uninit();
+            let sidecar_name =
+                directories::cache_integrity_sidecar_name(&mut sidecar_name_buf, folder_name);
+            match sys::unlinkat(cache_dir.fd(), sidecar_name) {
+                Ok(()) => {}
+                Err(err) if err.get_errno() == bun_sys::E::ENOENT => {}
+                Err(err) => {
+                    log.add_error_fmt(
+                        None,
+                        bun_ast::Loc::EMPTY,
+                        format_args!(
+                            "moving \"{}\" to cache dir failed: {}\n  From: {}\n    To: {}",
+                            bun_fmt::s(name),
+                            err,
+                            bun_fmt::s(tmpname.as_bytes()),
+                            bun_fmt::s(folder_name),
+                        ),
+                    );
+                    return Err(bun_core::err!("InstallFailed"));
+                }
+            }
+
             // e.g. @next
             // if it's a namespace package, we need to make sure the @name folder exists
             let create_subdir = basename.len() != name.len() && !self.resolution.tag.is_git();
@@ -691,6 +721,24 @@ impl ExtractTarball {
                         ),
                     );
                     return Err(bun_core::err!("InstallFailed"));
+                }
+            }
+
+            // Record the integrity the tarball bytes were verified against so
+            // later installs can require their own lockfile's integrity to
+            // match before trusting this folder. Only written when the bytes
+            // were actually verified (same precondition as `run`'s integrity
+            // check above), so the sidecar value is always the true hash of
+            // the bytes that produced the folder. A failed write is ignored:
+            // a folder without a sidecar is never trusted by the read side, so
+            // the worst case is one redundant re-download on the next install.
+            if !self.skip_verify && self.integrity.tag.is_supported() {
+                let mut integrity_str: [u8; 128] = [0u8; 128];
+                let mut cursor = std::io::Cursor::new(&mut integrity_str[..]);
+                if write!(cursor, "{}", self.integrity).is_ok() {
+                    let len = cursor.position() as usize;
+                    let _ =
+                        sys::File::write_file(cache_dir.fd(), sidecar_name, &integrity_str[..len]);
                 }
             }
 

--- a/src/install/integrity.rs
+++ b/src/install/integrity.rs
@@ -159,9 +159,8 @@ impl Integrity {
     }
 
     /// Strict equality between two parsed integrity values. `UNKNOWN` never
-    /// equals anything — including another `UNKNOWN` — so an unparseable or
-    /// missing value can never satisfy a comparison against a real digest.
-    /// Intentionally not a `PartialEq` impl to keep that asymmetry explicit.
+    /// equals anything — including another `UNKNOWN` — which is why this is
+    /// deliberately not a `PartialEq` impl.
     pub fn eql_supported(&self, other: &Integrity) -> bool {
         self.tag == other.tag
             && self.tag.is_supported()

--- a/src/install/integrity.rs
+++ b/src/install/integrity.rs
@@ -158,6 +158,16 @@ impl Integrity {
         &self.value[0..self.tag.digest_len()]
     }
 
+    /// Strict equality between two parsed integrity values. `UNKNOWN` never
+    /// equals anything — including another `UNKNOWN` — so an unparseable or
+    /// missing value can never satisfy a comparison against a real digest.
+    /// Intentionally not a `PartialEq` impl to keep that asymmetry explicit.
+    pub fn eql_supported(&self, other: &Integrity) -> bool {
+        self.tag == other.tag
+            && self.tag.is_supported()
+            && strings::eql_long(self.slice(), other.slice(), true)
+    }
+
     /// Compute a sha512 integrity hash from raw bytes (e.g. a downloaded tarball).
     pub fn for_bytes(bytes: &[u8]) -> Integrity {
         const LEN: usize = SHA512_DIGEST_LEN;

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2413,11 +2413,7 @@ pub(crate) fn install_isolated_packages(
                                         // The shared cache keys npm entries by
                                         // name@version only; require the
                                         // folder's recorded integrity to match
-                                        // this lockfile's expected integrity
-                                        // before linking its contents into the
-                                        // store. On mismatch, treat it as
-                                        // missing so it is re-downloaded,
-                                        // re-verified, and replaced.
+                                        // before trusting it.
                                         let expected = pkg_metas[pkg_id as usize].integrity;
                                         exists
                                             && (!installer.manager().options.do_.verify_integrity()

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2011,6 +2011,7 @@ pub(crate) fn install_isolated_packages(
         let pkg_names = pkgs.items_name();
         let pkg_name_hashes = pkgs.items_name_hash();
         let pkg_resolutions = pkgs.items_resolution();
+        let pkg_metas = pkgs.items_meta();
 
         let mut seen_entry_ids: HashMap<store::entry::Id, ()> = HashMap::default();
         seen_entry_ids.reserve(store.entries.len());
@@ -2409,7 +2410,23 @@ pub(crate) fn install_isolated_packages(
                                             pkg_cache_dir_subpath.slice_z(),
                                         );
                                         pkg_cache_dir_subpath.set_length(cache_dir_path_save);
+                                        // The shared cache keys npm entries by
+                                        // name@version only; require the
+                                        // folder's recorded integrity to match
+                                        // this lockfile's expected integrity
+                                        // before linking its contents into the
+                                        // store. On mismatch, treat it as
+                                        // missing so it is re-downloaded,
+                                        // re-verified, and replaced.
+                                        let expected = pkg_metas[pkg_id as usize].integrity;
                                         exists
+                                            && (!installer.manager().options.do_.verify_integrity()
+                                                || !expected.tag.is_supported()
+                                                || package_manager::cached_folder_integrity_matches(
+                                                    cache_dir,
+                                                    pkg_cache_dir_subpath.slice(),
+                                                    &expected,
+                                                ))
                                     }
                                     _ => sys::directory_exists_at(
                                         cache_dir,

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -688,11 +688,8 @@ impl PatchTask {
                 let mut cursor = std::io::Cursor::new(&mut integrity_str[..]);
                 if write!(cursor, "{}", meta.integrity).is_ok() {
                     let len = cursor.position() as usize;
-                    let _ = sys::File::write_file(
-                        patch.cache_dir,
-                        sidecar_name,
-                        &integrity_str[..len],
-                    );
+                    let _ =
+                        sys::File::write_file(patch.cache_dir, sidecar_name, &integrity_str[..len]);
                 }
             }
         }

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -622,14 +622,10 @@ impl PatchTask {
 
         let cache_dir_subpath_z: &ZStr = patch.cache_dir_subpath.as_zstr();
 
-        // The patched cache folder is about to be replaced, so any existing
-        // integrity sidecar describes contents that are going away. Remove it
-        // *before* the rename: if this process then fails or is interrupted at
-        // any point, it leaves at worst a folder without a sidecar (which
-        // readers treat as a cache miss), never the stale sidecar paired with
-        // the new folder. (Two installs racing on the same slot can still
-        // interleave their unlink/rename/write sequences — see the note at the
-        // sidecar write in `extract_tarball.rs`.)
+        // Remove any stale integrity sidecar *before* the rename: an
+        // interruption after this point then leaves at worst a folder without
+        // a sidecar (a cache miss to readers), never a stale sidecar paired
+        // with the new folder.
         let mut sidecar_name_buf = PathBuffer::uninit();
         let sidecar_name = package_manager::cache_integrity_sidecar_name(
             &mut sidecar_name_buf,
@@ -671,13 +667,9 @@ impl PatchTask {
         }
 
         // Record the integrity of the base tarball this patched folder was
-        // built from so later installs can require their own lockfile's
-        // expected integrity to match before trusting it (the folder name only
-        // encodes the patch file's content hash). Only written when the base
-        // contents were actually verified against that integrity — the same
-        // gate the read side applies. A failed write is ignored: a folder
-        // without a sidecar is never trusted, so the worst case is one
-        // redundant re-patch on the next install.
+        // built from (the folder name only encodes the patch file's content
+        // hash). A failed write is ignored: a folder without a sidecar is
+        // never trusted, so the worst case is one redundant re-patch.
         {
             let manager = self.manager.get();
             let meta = &manager.lockfile.packages.items_meta()[patch.pkg_id as usize];

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -624,10 +624,12 @@ impl PatchTask {
 
         // The patched cache folder is about to be replaced, so any existing
         // integrity sidecar describes contents that are going away. Remove it
-        // *before* the rename: every failure or interruption from here on then
-        // leaves at worst a folder without a sidecar (which readers treat as a
-        // cache miss), never a folder paired with a sidecar its contents were
-        // not built from.
+        // *before* the rename: if this process then fails or is interrupted at
+        // any point, it leaves at worst a folder without a sidecar (which
+        // readers treat as a cache miss), never the stale sidecar paired with
+        // the new folder. (Two installs racing on the same slot can still
+        // interleave their unlink/rename/write sequences — see the note at the
+        // sidecar write in `extract_tarball.rs`.)
         let mut sidecar_name_buf = PathBuffer::uninit();
         let sidecar_name = package_manager::cache_integrity_sidecar_name(
             &mut sidecar_name_buf,
@@ -639,8 +641,8 @@ impl PatchTask {
             Err(e) => {
                 log.add_error_fmt_opts(
                     format_args!(
-                        "replacing patched package in cache dir: {}",
-                        e.with_path(cache_dir_subpath_z.as_bytes())
+                        "removing stale integrity sidecar for patched package: {}",
+                        e.with_path(sidecar_name.as_bytes())
                     ),
                     Default::default(),
                 );

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -621,6 +621,33 @@ impl PatchTask {
         );
 
         let cache_dir_subpath_z: &ZStr = patch.cache_dir_subpath.as_zstr();
+
+        // The patched cache folder is about to be replaced, so any existing
+        // integrity sidecar describes contents that are going away. Remove it
+        // *before* the rename: every failure or interruption from here on then
+        // leaves at worst a folder without a sidecar (which readers treat as a
+        // cache miss), never a folder paired with a sidecar its contents were
+        // not built from.
+        let mut sidecar_name_buf = PathBuffer::uninit();
+        let sidecar_name = package_manager::cache_integrity_sidecar_name(
+            &mut sidecar_name_buf,
+            cache_dir_subpath_z.as_bytes(),
+        );
+        match sys::unlinkat(patch.cache_dir, sidecar_name) {
+            Ok(()) => {}
+            Err(e) if e.get_errno() == sys::Errno::ENOENT => {}
+            Err(e) => {
+                log.add_error_fmt_opts(
+                    format_args!(
+                        "replacing patched package in cache dir: {}",
+                        e.with_path(cache_dir_subpath_z.as_bytes())
+                    ),
+                    Default::default(),
+                );
+                return Ok(());
+            }
+        }
+
         if let Err(e) = sys::renameat_concurrently(
             system_tmpdir,
             path_in_tmpdir,
@@ -639,6 +666,35 @@ impl PatchTask {
                 Default::default(),
             );
             return Ok(());
+        }
+
+        // Record the integrity of the base tarball this patched folder was
+        // built from so later installs can require their own lockfile's
+        // expected integrity to match before trusting it (the folder name only
+        // encodes the patch file's content hash). Only written when the base
+        // contents were actually verified against that integrity — the same
+        // gate the read side applies. A failed write is ignored: a folder
+        // without a sidecar is never trusted, so the worst case is one
+        // redundant re-patch on the next install.
+        {
+            let manager = self.manager.get();
+            let meta = &manager.lockfile.packages.items_meta()[patch.pkg_id as usize];
+            if resolution_tag == crate::resolution::Tag::Npm
+                && manager.options.do_.verify_integrity()
+                && meta.integrity.tag.is_supported()
+            {
+                use std::io::Write as _;
+                let mut integrity_str: [u8; 128] = [0u8; 128];
+                let mut cursor = std::io::Cursor::new(&mut integrity_str[..]);
+                if write!(cursor, "{}", meta.integrity).is_ok() {
+                    let len = cursor.position() as usize;
+                    let _ = sys::File::write_file(
+                        patch.cache_dir,
+                        sidecar_name,
+                        &integrity_str[..len],
+                    );
+                }
+            }
         }
         Ok(())
     }

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -814,8 +814,8 @@ describe.concurrent("npm cache integrity sidecar", () => {
       {
         const { stderr, exitCode } = await install(String(projectA), String(cache));
         expect(stderr).not.toContain("Integrity check failed");
-        expect(await installedIndexJs(String(projectA))).toContain("EVIL");
         expect(exitCode).toBe(0);
+        expect(await installedIndexJs(String(projectA))).toContain("EVIL");
       }
       expect(state.tarballRequests).toBe(1);
 
@@ -826,8 +826,8 @@ describe.concurrent("npm cache integrity sidecar", () => {
       {
         const { stderr, exitCode } = await install(String(projectB), String(cache));
         expect(stderr).not.toContain("Integrity check failed");
-        expect(await installedIndexJs(String(projectB))).toContain("GOOD");
         expect(exitCode).toBe(0);
+        expect(await installedIndexJs(String(projectB))).toContain("GOOD");
       }
       expect(state.tarballRequests).toBe(2);
 
@@ -850,8 +850,8 @@ describe.concurrent("npm cache integrity sidecar", () => {
       state.current = good;
       {
         const { exitCode } = await install(String(project), String(cache));
-        expect(await installedIndexJs(String(project))).toContain("GOOD");
         expect(exitCode).toBe(0);
+        expect(await installedIndexJs(String(project))).toContain("GOOD");
       }
       expect(state.tarballRequests).toBe(1);
 
@@ -868,8 +868,8 @@ describe.concurrent("npm cache integrity sidecar", () => {
 
       {
         const { exitCode } = await install(String(project), String(cache));
-        expect(await installedIndexJs(String(project))).toContain("GOOD");
         expect(exitCode).toBe(0);
+        expect(await installedIndexJs(String(project))).toContain("GOOD");
       }
       expect(state.tarballRequests).toBe(2);
     });
@@ -886,16 +886,16 @@ describe.concurrent("npm cache integrity sidecar", () => {
     state.current = good;
     {
       const { exitCode } = await install(String(projectA), String(cache));
-      expect(await installedIndexJs(String(projectA))).toContain("GOOD");
       expect(exitCode).toBe(0);
+      expect(await installedIndexJs(String(projectA))).toContain("GOOD");
     }
     expect(state.tarballRequests).toBe(1);
 
     // Same package, same integrity, shared cache: no second download.
     {
       const { exitCode } = await install(String(projectB), String(cache));
-      expect(await installedIndexJs(String(projectB))).toContain("GOOD");
       expect(exitCode).toBe(0);
+      expect(await installedIndexJs(String(projectB))).toContain("GOOD");
     }
     expect(state.tarballRequests).toBe(1);
   });
@@ -922,8 +922,8 @@ describe.concurrent("npm cache integrity sidecar", () => {
 
     {
       const { exitCode } = await install(String(projectB), String(cache));
-      expect(await installedIndexJs(String(projectB))).toContain("GOOD");
       expect(exitCode).toBe(0);
+      expect(await installedIndexJs(String(projectB))).toContain("GOOD");
     }
     expect(state.tarballRequests).toBe(2);
     expect(await findSidecars(String(cache))).toHaveLength(1);

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -39,6 +39,43 @@ async function withContext(
 // Default context options for most tests
 const defaultOpts = { linker: "hoisted" as const };
 
+// ── minimal in-memory .tgz builder ──────────────────────────────────────────
+// Used by tests that need to serve two different tarballs for the same
+// name@version (something the on-disk fixtures can't express).
+function octal(n: number, width: number) {
+  return n.toString(8).padStart(width - 1, "0") + "\0";
+}
+function tarHeader(name: string, size: number) {
+  const buf = Buffer.alloc(512, 0);
+  buf.write(name, 0, 100, "utf8");
+  buf.write(octal(0o644, 8), 100);
+  buf.write(octal(0, 8), 108);
+  buf.write(octal(0, 8), 116);
+  buf.write(octal(size, 12), 124);
+  buf.write(octal(0, 12), 136);
+  buf.fill(" ", 148, 156);
+  buf.write("0", 156);
+  buf.write("ustar\0", 257);
+  buf.write("00", 263);
+  let sum = 0;
+  for (let i = 0; i < 512; i++) sum += buf[i];
+  buf.write(octal(sum, 8), 148);
+  return buf;
+}
+function pad512(len: number) {
+  return Buffer.alloc((512 - (len % 512)) % 512, 0);
+}
+function buildTarball(files: Record<string, string>) {
+  const parts: Buffer[] = [];
+  for (const [name, contents] of Object.entries(files)) {
+    const body = Buffer.from(contents);
+    parts.push(tarHeader(`package/${name}`, body.length), body, pad512(body.length));
+  }
+  parts.push(Buffer.alloc(1024, 0));
+  const tgz = gzipSync(Buffer.concat(parts));
+  return { tgz, integrity: "sha512-" + createHash("sha512").update(tgz).digest("base64") };
+}
+
 describe.concurrent("tarball integrity", () => {
   it("should store integrity hash for tarball URL in text lockfile", async () => {
     await withContext(defaultOpts, async ctx => {
@@ -506,42 +543,8 @@ describe.concurrent.each(["hoisted", "isolated"] as const)("tarball integrity mi
   // callback is the void `onPackageDownloadError = {}` — i.e. the branch the
   // fix in runTasks.zig now cleans up.
   it("should fail (not hang) when tarball bytes don't match manifest SHA-512", { timeout: 60_000 }, async () => {
-    function octal(n: number, width: number) {
-      return n.toString(8).padStart(width - 1, "0") + "\0";
-    }
-    function tarHeader(name: string, size: number) {
-      const buf = Buffer.alloc(512, 0);
-      buf.write(name, 0, 100, "utf8");
-      buf.write(octal(0o644, 8), 100);
-      buf.write(octal(0, 8), 108);
-      buf.write(octal(0, 8), 116);
-      buf.write(octal(size, 12), 124);
-      buf.write(octal(0, 12), 136);
-      buf.fill(" ", 148, 156);
-      buf.write("0", 156);
-      buf.write("ustar\0", 257);
-      buf.write("00", 263);
-      let sum = 0;
-      for (let i = 0; i < 512; i++) sum += buf[i];
-      buf.write(octal(sum, 8), 148);
-      return buf;
-    }
-    function pad512(len: number) {
-      return Buffer.alloc((512 - (len % 512)) % 512, 0);
-    }
-    function buildTarball(body: Buffer) {
-      const tar = Buffer.concat([
-        tarHeader("package/package.json", body.length),
-        body,
-        pad512(body.length),
-        Buffer.alloc(1024, 0),
-      ]);
-      const tgz = gzipSync(tar);
-      return { tgz, integrity: "sha512-" + createHash("sha512").update(tgz).digest("base64") };
-    }
-
-    const real = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
-    const lie = buildTarball(Buffer.from('{"name":"other","version":"9.9.9"}\n'));
+    const real = buildTarball({ "package.json": '{"name":"pkg","version":"1.0.0"}\n' });
+    const lie = buildTarball({ "package.json": '{"name":"other","version":"9.9.9"}\n' });
 
     // Custom server instead of the dummy registry — we need to advertise an
     // integrity hash that deliberately does not match the served bytes, which
@@ -700,5 +703,229 @@ describe.concurrent.each(["hoisted", "isolated"] as const)("tarball download fai
         expect(exitCode).not.toBe(0);
       }
     });
+  });
+});
+
+// The shared package cache (`BUN_INSTALL_CACHE_DIR`) keys npm entries by
+// name@version. Each extracted entry records the integrity its tarball was
+// verified against in a `<folder>.integrity` sidecar, and a project whose
+// lockfile expects a different integrity must not reuse the entry — it must
+// re-download and re-verify. These tests share one cache directory across two
+// project directories to exercise that boundary.
+describe.concurrent("npm cache integrity sidecar", () => {
+  const evil = buildTarball({
+    "package.json": '{"name":"pkg","version":"1.0.0","main":"index.js"}\n',
+    "index.js": 'module.exports = "EVIL";\n',
+  });
+  const good = buildTarball({
+    "package.json": '{"name":"pkg","version":"1.0.0","main":"index.js"}\n',
+    "index.js": 'module.exports = "GOOD";\n',
+  });
+
+  function makeRegistry() {
+    const state = {
+      current: good,
+      tarballRequests: 0,
+    };
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      async fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname.endsWith("/pkg")) {
+          return Response.json({
+            name: "pkg",
+            "dist-tags": { latest: "1.0.0" },
+            versions: {
+              "1.0.0": {
+                name: "pkg",
+                version: "1.0.0",
+                dist: {
+                  integrity: state.current.integrity,
+                  tarball: `http://127.0.0.1:${server.port}/pkg/-/pkg-1.0.0.tgz`,
+                },
+              },
+            },
+          });
+        }
+        if (url.pathname.endsWith("/pkg-1.0.0.tgz")) {
+          state.tarballRequests++;
+          return new Response(state.current.tgz, {
+            headers: { "content-length": String(state.current.tgz.length) },
+          });
+        }
+        return new Response("Not found", { status: 404 });
+      },
+    });
+    return { server, state };
+  }
+
+  function projectFiles(registryUrl: string, linker: "hoisted" | "isolated") {
+    return {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { pkg: "1.0.0" },
+      }),
+      "bunfig.toml": `[install]\nregistry = "${registryUrl}"\nlinker = "${linker}"\n`,
+    };
+  }
+
+  // `--no-cache` disables only the *manifest* disk cache (which would
+  // otherwise hand the second project the first project's metadata for up to
+  // 5 minutes); the extracted-package cache under BUN_INSTALL_CACHE_DIR — the
+  // thing under test — is unaffected by it.
+  async function install(cwd: string, cacheDir: string) {
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--no-cache"],
+      cwd,
+      env: { ...env, BUN_INSTALL_CACHE_DIR: cacheDir },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    return { stderr, stdout, exitCode };
+  }
+
+  async function installedIndexJs(projectDir: string) {
+    return await file(join(projectDir, "node_modules", "pkg", "index.js")).text();
+  }
+
+  async function findSidecars(cacheDir: string) {
+    const found: string[] = [];
+    for await (const entry of new Bun.Glob("**/*.integrity").scan({ cwd: cacheDir, onlyFiles: true })) {
+      found.push(join(cacheDir, entry));
+    }
+    return found.sort();
+  }
+
+  for (const linker of ["hoisted", "isolated"] as const) {
+    it(`a cache entry from one project is not reused by a project expecting a different integrity (${linker})`, async () => {
+      const { server, state } = makeRegistry();
+      await using _server = server;
+      const registryUrl = `http://127.0.0.1:${server.port}/`;
+      using projectA = tempDir(`cache-integrity-a-${linker}`, projectFiles(registryUrl, linker));
+      using projectB = tempDir(`cache-integrity-b-${linker}`, projectFiles(registryUrl, linker));
+      using cache = tempDir(`cache-integrity-cache-${linker}`, {});
+
+      // Project A installs while the registry maps pkg@1.0.0 to the "evil"
+      // tarball, populating the shared cache slot for pkg@1.0.0.
+      state.current = evil;
+      {
+        const { stderr, exitCode } = await install(String(projectA), String(cache));
+        expect(stderr).not.toContain("Integrity check failed");
+        expect(await installedIndexJs(String(projectA))).toContain("EVIL");
+        expect(exitCode).toBe(0);
+      }
+      expect(state.tarballRequests).toBe(1);
+
+      // Project B resolves the same name@version but its manifest (and
+      // therefore its lockfile) carries the "good" integrity. The existing
+      // cache folder must not be reused as-is.
+      state.current = good;
+      {
+        const { stderr, exitCode } = await install(String(projectB), String(cache));
+        expect(stderr).not.toContain("Integrity check failed");
+        expect(await installedIndexJs(String(projectB))).toContain("GOOD");
+        expect(exitCode).toBe(0);
+      }
+      expect(state.tarballRequests).toBe(2);
+
+      // The cache slot now belongs to the "good" tarball: exactly one sidecar,
+      // containing the good integrity (replaced, not appended to).
+      const sidecars = await findSidecars(String(cache));
+      expect(sidecars).toHaveLength(1);
+      expect(await file(sidecars[0]).text()).toBe(good.integrity);
+    });
+  }
+
+  for (const linker of ["hoisted", "isolated"] as const) {
+    it(`install-phase cache check with an existing lockfile rejects a tampered entry (${linker})`, async () => {
+      const { server, state } = makeRegistry();
+      await using _server = server;
+      const registryUrl = `http://127.0.0.1:${server.port}/`;
+      using project = tempDir(`cache-integrity-install-phase-${linker}`, projectFiles(registryUrl, linker));
+      using cache = tempDir(`cache-integrity-install-phase-cache-${linker}`, {});
+
+      state.current = good;
+      {
+        const { exitCode } = await install(String(project), String(cache));
+        expect(await installedIndexJs(String(project))).toContain("GOOD");
+        expect(exitCode).toBe(0);
+      }
+      expect(state.tarballRequests).toBe(1);
+
+      // Tamper with the cache folder out-of-band and remove its sidecar, then
+      // reinstall with the lockfile present and node_modules removed. The
+      // resolve phase is a no-op, so the install-phase cache probe is the only
+      // gate. Without a sidecar the entry must be treated as a miss.
+      const sidecars = await findSidecars(String(cache));
+      expect(sidecars).toHaveLength(1);
+      const cacheFolder = sidecars[0].slice(0, -".integrity".length);
+      await writeFile(join(cacheFolder, "index.js"), 'module.exports = "TAMPERED";\n');
+      await rm(sidecars[0]);
+      await rm(join(String(project), "node_modules"), { recursive: true, force: true });
+
+      {
+        const { exitCode } = await install(String(project), String(cache));
+        expect(await installedIndexJs(String(project))).toContain("GOOD");
+        expect(exitCode).toBe(0);
+      }
+      expect(state.tarballRequests).toBe(2);
+    });
+  }
+
+  it("matching integrity still hits the cache without re-downloading", async () => {
+    const { server, state } = makeRegistry();
+    await using _server = server;
+    const registryUrl = `http://127.0.0.1:${server.port}/`;
+    using projectA = tempDir("cache-integrity-hit-a", projectFiles(registryUrl, "hoisted"));
+    using projectB = tempDir("cache-integrity-hit-b", projectFiles(registryUrl, "hoisted"));
+    using cache = tempDir("cache-integrity-hit-cache", {});
+
+    state.current = good;
+    {
+      const { exitCode } = await install(String(projectA), String(cache));
+      expect(await installedIndexJs(String(projectA))).toContain("GOOD");
+      expect(exitCode).toBe(0);
+    }
+    expect(state.tarballRequests).toBe(1);
+
+    // Same package, same integrity, shared cache: no second download.
+    {
+      const { exitCode } = await install(String(projectB), String(cache));
+      expect(await installedIndexJs(String(projectB))).toContain("GOOD");
+      expect(exitCode).toBe(0);
+    }
+    expect(state.tarballRequests).toBe(1);
+  });
+
+  it("a cache entry without a sidecar degrades to a re-download, not an error", async () => {
+    const { server, state } = makeRegistry();
+    await using _server = server;
+    const registryUrl = `http://127.0.0.1:${server.port}/`;
+    using projectA = tempDir("cache-integrity-missing-a", projectFiles(registryUrl, "hoisted"));
+    using projectB = tempDir("cache-integrity-missing-b", projectFiles(registryUrl, "hoisted"));
+    using cache = tempDir("cache-integrity-missing-cache", {});
+
+    state.current = good;
+    {
+      const { exitCode } = await install(String(projectA), String(cache));
+      expect(exitCode).toBe(0);
+    }
+    expect(state.tarballRequests).toBe(1);
+
+    // Simulate a cache populated before sidecars existed.
+    const sidecars = await findSidecars(String(cache));
+    expect(sidecars).toHaveLength(1);
+    await rm(sidecars[0]);
+
+    {
+      const { exitCode } = await install(String(projectB), String(cache));
+      expect(await installedIndexJs(String(projectB))).toContain("GOOD");
+      expect(exitCode).toBe(0);
+    }
+    expect(state.tarballRequests).toBe(2);
+    expect(await findSidecars(String(cache))).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Extracted npm cache entries now record the integrity their tarball was verified against in a `<folder>.integrity` sidecar file written after the folder is renamed into the cache. Cache hits for npm packages require that recorded value to match the consuming lockfile's integrity before the entry is reused; on a mismatch (or a missing/unreadable record) the package is re-downloaded, re-verified, and the cache entry replaced. The check is applied at the resolve-phase preinstall gate, the hoisted and isolated install-phase probes, and the non-patched base lookup for patched dependencies; git/GitHub/tarball-URL slots are keyed by URL/committish and are unchanged.

Entries written by older versions have no sidecar and degrade to a one-time re-download on the next install that reaches them.

Adds tests covering: two projects with different integrities for the same name@version sharing one cache (hoisted and isolated), the warm-lockfile install-phase probe, the cache-hit fast path (no extra download when the integrity matches), and the missing-sidecar migration path.