### PR TITLE
node:zlib: defer params() and reject init() while a write is in flight

### DIFF
--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -445,9 +445,8 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
             s.set_flush(i32::try_from(flush).expect("int cast"));
         });
 
-        // Apply a params() request that arrived while the previous write was
-        // still on the threadpool. Must be a separate statement (not nested in
-        // the `with_mut` above) and must run before the task is scheduled.
+        // Must be a separate statement (not nested in the `with_mut` above)
+        // and must run before the task is scheduled.
         this.apply_pending_params();
 
         // Only create the strong handle when we have a pending write
@@ -717,8 +716,6 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         });
         let this_value = callframe.this();
 
-        // Apply a params() request that arrived while a previous async write
-        // was still on the threadpool (legacy `_processChunk` sync path).
         this.apply_pending_params();
 
         this.stream().with_mut(|s| s.do_work());
@@ -1052,8 +1049,6 @@ macro_rules! __impl_compression_stream {
             #[inline] fn pending_close(&self) -> &::core::cell::Cell<bool> { &self.pending_close }
             #[inline] fn pending_reset(&self) -> &::core::cell::Cell<bool> { &self.pending_reset }
             #[inline] fn closed(&self) -> &::core::cell::Cell<bool> { &self.closed }
-            // Inherent impls win path resolution over the trait method (same
-            // pattern as `Self::do_work(self)` on the Context above).
             #[inline] fn apply_pending_params(&self) { Self::apply_pending_params(self) }
 
             #[inline]

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -258,6 +258,15 @@ pub(crate) trait CompressionStreamImpl: Sized + Taskable + 'static {
     fn pending_reset(&self) -> &Cell<bool>;
     fn closed(&self) -> &Cell<bool>;
 
+    /// Apply a parameter change that was requested via `params()` while a
+    /// write was in flight on the threadpool.
+    ///
+    /// Call-site contract: JS thread only, after the `write_in_progress`
+    /// guard has passed and `set_buffers` has bound the new output buffer,
+    /// before any work is scheduled. No-op for stream types without a
+    /// deferrable `params()` (brotli/zstd).
+    fn apply_pending_params(&self);
+
     /// Recover `*mut Self` from the embedded `WorkPoolTask`.
     /// SAFETY: caller guarantees `task` points at the `task` field of a live `Self`.
     unsafe fn from_task(task: *mut WorkPoolTask) -> *mut Self;
@@ -435,6 +444,11 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
             s.set_buffers(in_, out);
             s.set_flush(i32::try_from(flush).expect("int cast"));
         });
+
+        // Apply a params() request that arrived while the previous write was
+        // still on the threadpool. Must be a separate statement (not nested in
+        // the `with_mut` above) and must run before the task is scheduled.
+        this.apply_pending_params();
 
         // Only create the strong handle when we have a pending write
         // And make sure to clear it when we are done.
@@ -702,6 +716,10 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
             s.set_flush(i32::try_from(flush).expect("int cast"));
         });
         let this_value = callframe.this();
+
+        // Apply a params() request that arrived while a previous async write
+        // was still on the threadpool (legacy `_processChunk` sync path).
+        this.apply_pending_params();
 
         this.stream().with_mut(|s| s.do_work());
         if Self::check_error(this, global_this, this_value) {
@@ -1034,6 +1052,9 @@ macro_rules! __impl_compression_stream {
             #[inline] fn pending_close(&self) -> &::core::cell::Cell<bool> { &self.pending_close }
             #[inline] fn pending_reset(&self) -> &::core::cell::Cell<bool> { &self.pending_reset }
             #[inline] fn closed(&self) -> &::core::cell::Cell<bool> { &self.closed }
+            // Inherent impls win path resolution over the trait method (same
+            // pattern as `Self::do_work(self)` on the Context above).
+            #[inline] fn apply_pending_params(&self) { Self::apply_pending_params(self) }
 
             #[inline]
             unsafe fn from_task(task: *mut ::bun_jsc::WorkPoolTask) -> *mut Self {

--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -186,9 +186,7 @@ mod _impl {
 
             // Re-creating the Brotli encoder/decoder while the worker thread is
             // inside BrotliEncoderCompressStream/BrotliDecoderDecompressStream
-            // would be a data race on the native state. Bun's own JS only calls
-            // init() before any write (zlib.ts), so this is only reachable by
-            // scripts poking at `_handle` directly.
+            // would be a data race on the native state.
             if self.write_in_progress.get() {
                 return Err(global_this
                     .err(

--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -184,6 +184,20 @@ mod _impl {
                     .throw());
             }
 
+            // Re-creating the Brotli encoder/decoder while the worker thread is
+            // inside BrotliEncoderCompressStream/BrotliDecoderDecompressStream
+            // would be a data race on the native state. Bun's own JS only calls
+            // init() before any write (zlib.ts), so this is only reachable by
+            // scripts poking at `_handle` directly.
+            if self.write_in_progress.get() {
+                return Err(global_this
+                    .err(
+                        ErrorCode::INVALID_STATE,
+                        format_args!("Cannot call init() while a write is in progress"),
+                    )
+                    .throw());
+            }
+
             // `flush_write_result` writes two u32s into this array, so the
             // caller-supplied array must hold at least 2 elements.
             let write_result_value = arguments.ptr[1];
@@ -274,6 +288,10 @@ mod _impl {
             // intentionally left empty
             Ok(JSValue::UNDEFINED)
         }
+
+        /// Brotli parameters are init-only and the `params()` host_fn above is
+        /// intentionally empty, so there is never anything to defer.
+        pub(crate) fn apply_pending_params(&self) {}
 
         /// `CellRefCounted::destroy` target (refcount hit zero). Runs `deinit`
         /// then frees the Box-allocated payload — matches Zig

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -140,8 +140,6 @@ mod _impl {
 
             // Re-initializing the z_stream while the worker thread is inside
             // deflate()/inflate() would be a data race on the native state.
-            // Bun's own JS only calls init() before any write (zlib.ts), so
-            // this is only reachable by scripts poking at `_handle` directly.
             if self.write_in_progress.get() {
                 return Err(global
                     .err(
@@ -236,15 +234,12 @@ mod _impl {
             let strategy =
                 validators::validate_int32(global, arguments.ptr[1], "strategy", None, None)?;
 
-            // The JS layer legitimately reaches this method while a write is in
-            // flight: writable's `clearBuffer` starts the next buffered write
-            // before `afterWrite` invokes the params flush callback
-            // (writable.ts `clearBuffer` vs `afterWrite`), so the
-            // `paramsAfterFlushCallback` in zlib.ts can land here with
-            // `write_in_progress == true`. Calling `deflateParams` now would
-            // mutate the same z_stream the worker thread is traversing inside
-            // `deflate()`, so defer the request and apply it on the JS thread
-            // at the start of the next write (see `apply_pending_params`).
+            // `paramsAfterFlushCallback` in zlib.ts can legitimately land here
+            // while a write is in flight (writable's `clearBuffer` starts the
+            // next buffered write before `afterWrite` runs the flush callback).
+            // Calling `deflateParams` now would race the worker thread inside
+            // `deflate()`, so defer it to the start of the next write
+            // (see `apply_pending_params`).
             if self.write_in_progress.get() {
                 self.pending_params.set(Some((level, strategy)));
                 return Ok(JSValue::UNDEFINED);
@@ -266,21 +261,12 @@ mod _impl {
         }
 
         /// Apply a `params()` request that was deferred because a write was in
-        /// flight when it arrived.
-        ///
-        /// Only called from `CompressionStream::write`/`write_sync` on the JS
-        /// thread, after the `write_in_progress` guard has passed and
-        /// `set_buffers` has bound the new output buffer — so no other
-        /// `&mut Context` exists, and any block flushed by `deflateParams`'s
-        /// internal `deflate(Z_BLOCK)` lands in (and is accounted against) the
-        /// new write's `avail_out`.
-        ///
-        /// The result is discarded rather than `emit_error`'d: `Z_BUF_ERROR`
+        /// flight when it arrived. Runs after `set_buffers` so the block
+        /// flushed by `deflateParams`'s internal `deflate(Z_BLOCK)` lands in
+        /// the new write's `avail_out`. The result is discarded: `Z_BUF_ERROR`
         /// already means "params silently not applied" on the immediate path,
-        /// `Z_STREAM_ERROR` is only reachable when a caller writes after the
-        /// stream finished (the write itself reports that), and `do_work()`
-        /// overwrites `Context.err` before `check_error` reads it, so a
-        /// discarded failure cannot leak into the write's error reporting.
+        /// and `do_work()` overwrites `Context.err` before `check_error` reads
+        /// it.
         pub(crate) fn apply_pending_params(&self) {
             let Some((level, strategy)) = self.pending_params.take() else {
                 return;

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -250,6 +250,11 @@ mod _impl {
                 return Ok(JSValue::UNDEFINED);
             }
 
+            // Drop any stale deferred request so it can't be re-applied by
+            // `apply_pending_params()` on the next write, overriding this
+            // newer immediate one.
+            self.pending_params.set(None);
+
             let err = self.stream.with_mut(|s| s.set_params(level, strategy));
             if err.is_error() {
                 // R-2: `&self` over `Cell`/`JsCell` fields — `emit_error` →

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -49,6 +49,11 @@ mod _impl {
         pub write_in_progress: Cell<bool>,
         pub pending_close: Cell<bool>,
         pub pending_reset: Cell<bool>,
+        /// `(level, strategy)` requested by `params()` while a write was in
+        /// flight on the threadpool. Applied on the JS thread at the start of
+        /// the next write (see `apply_pending_params`). Only ever touched from
+        /// the JS thread, so a plain `Cell` suffices.
+        pub pending_params: Cell<Option<(c_int, c_int)>>,
         pub closed: Cell<bool>,
         pub task: JsCell<WorkPoolTask>,
     }
@@ -101,6 +106,7 @@ mod _impl {
                 write_in_progress: Cell::new(false),
                 pending_close: Cell::new(false),
                 pending_reset: Cell::new(false),
+                pending_params: Cell::new(None),
                 closed: Cell::new(false),
                 task: JsCell::new(WorkPoolTask {
                     node: Default::default(),
@@ -130,6 +136,19 @@ mod _impl {
                     ),
                 )
                 .throw());
+            }
+
+            // Re-initializing the z_stream while the worker thread is inside
+            // deflate()/inflate() would be a data race on the native state.
+            // Bun's own JS only calls init() before any write (zlib.ts), so
+            // this is only reachable by scripts poking at `_handle` directly.
+            if self.write_in_progress.get() {
+                return Err(global
+                    .err(
+                        bun_jsc::ErrorCode::INVALID_STATE,
+                        format_args!("Cannot call init() while a write is in progress"),
+                    )
+                    .throw());
             }
 
             let window_bits =
@@ -217,6 +236,20 @@ mod _impl {
             let strategy =
                 validators::validate_int32(global, arguments.ptr[1], "strategy", None, None)?;
 
+            // The JS layer legitimately reaches this method while a write is in
+            // flight: writable's `clearBuffer` starts the next buffered write
+            // before `afterWrite` invokes the params flush callback
+            // (writable.ts `clearBuffer` vs `afterWrite`), so the
+            // `paramsAfterFlushCallback` in zlib.ts can land here with
+            // `write_in_progress == true`. Calling `deflateParams` now would
+            // mutate the same z_stream the worker thread is traversing inside
+            // `deflate()`, so defer the request and apply it on the JS thread
+            // at the start of the next write (see `apply_pending_params`).
+            if self.write_in_progress.get() {
+                self.pending_params.set(Some((level, strategy)));
+                return Ok(JSValue::UNDEFINED);
+            }
+
             let err = self.stream.with_mut(|s| s.set_params(level, strategy));
             if err.is_error() {
                 // R-2: `&self` over `Cell`/`JsCell` fields — `emit_error` →
@@ -225,6 +258,29 @@ mod _impl {
                 CompressionStream::<Self>::emit_error(self, global, frame.this(), err);
             }
             Ok(JSValue::UNDEFINED)
+        }
+
+        /// Apply a `params()` request that was deferred because a write was in
+        /// flight when it arrived.
+        ///
+        /// Only called from `CompressionStream::write`/`write_sync` on the JS
+        /// thread, after the `write_in_progress` guard has passed and
+        /// `set_buffers` has bound the new output buffer — so no other
+        /// `&mut Context` exists, and any block flushed by `deflateParams`'s
+        /// internal `deflate(Z_BLOCK)` lands in (and is accounted against) the
+        /// new write's `avail_out`.
+        ///
+        /// The result is discarded rather than `emit_error`'d: `Z_BUF_ERROR`
+        /// already means "params silently not applied" on the immediate path,
+        /// `Z_STREAM_ERROR` is only reachable when a caller writes after the
+        /// stream finished (the write itself reports that), and `do_work()`
+        /// overwrites `Context.err` before `check_error` reads it, so a
+        /// discarded failure cannot leak into the write's error reporting.
+        pub(crate) fn apply_pending_params(&self) {
+            let Some((level, strategy)) = self.pending_params.take() else {
+                return;
+            };
+            let _ = self.stream.with_mut(|s| s.set_params(level, strategy));
         }
 
         /// RefCount destroy callback. Invoked when `ref_count` reaches zero.

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -148,6 +148,9 @@ mod _impl {
                     )
                     .throw());
             }
+            // A deferred params() request must not outlive the stream it was
+            // aimed at and override the level/strategy established below.
+            self.pending_params.set(None);
 
             let window_bits =
                 validators::validate_int32(global, arguments.ptr[0], "windowBits", None, None)?;

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -138,6 +138,20 @@ mod _impl {
                     .throw());
             }
 
+            // Re-creating the ZSTD_CCtx/DCtx while the worker thread is inside
+            // ZSTD_compressStream2/ZSTD_decompressStream would be a data race
+            // on the native state. Bun's own JS only calls init() before any
+            // write (zlib.ts), so this is only reachable by scripts poking at
+            // `_handle` directly.
+            if self.write_in_progress.get() {
+                return Err(global
+                    .err(
+                        jsc::ErrorCode::INVALID_STATE,
+                        format_args!("Cannot call init() while a write is in progress"),
+                    )
+                    .throw());
+            }
+
             let init_params_array_value = arguments[0];
             let pledged_src_size_value = arguments[1];
             let write_state_value = arguments[2];
@@ -237,6 +251,10 @@ mod _impl {
             // intentionally left empty
             Ok(JSValue::UNDEFINED)
         }
+
+        /// Zstd parameters are init-only and the `params()` host_fn above is
+        /// intentionally empty, so there is never anything to defer.
+        pub(crate) fn apply_pending_params(&self) {}
     }
 
     // `fn deinit(this: *@This()) void` — called by RefCount when count hits 0.

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -140,9 +140,7 @@ mod _impl {
 
             // Re-creating the ZSTD_CCtx/DCtx while the worker thread is inside
             // ZSTD_compressStream2/ZSTD_decompressStream would be a data race
-            // on the native state. Bun's own JS only calls init() before any
-            // write (zlib.ts), so this is only reachable by scripts poking at
-            // `_handle` directly.
+            // on the native state.
             if self.write_in_progress.get() {
                 return Err(global
                     .err(

--- a/test/js/node/zlib/zlib-reset-race.test.ts
+++ b/test/js/node/zlib/zlib-reset-race.test.ts
@@ -95,6 +95,40 @@ const deflateFixture = /* js */ `
   }
 `;
 
+const paramsFixture = /* js */ `
+  const zlib = require("zlib");
+  const crypto = require("crypto");
+  const assert = require("assert");
+
+  const buf = crypto.randomBytes(2 * 1024 * 1024);
+
+  let remaining = 0;
+  for (let i = 0; i < 4; i++) {
+    remaining++;
+    const z = zlib.createDeflate({ chunkSize: 2 * 1024 * 1024, level: 9 });
+    const chunks = [];
+    z.on("error", err => {
+      throw err;
+    });
+    z.on("data", c => chunks.push(c));
+    z.on("end", () => {
+      assert.deepStrictEqual(zlib.inflateSync(Buffer.concat(chunks)), buf);
+      if (--remaining === 0) console.log("OK");
+    });
+    z.write(buf, () => {
+      z.end();
+    });
+    // Spin briefly so the threadpool starts deflate() before params().
+    const start = Date.now();
+    while (Date.now() - start < 10) {}
+    // Call the native handle directly, bypassing the JS-level flush queue, so
+    // the call deterministically lands while a write is in progress. Before
+    // the fix this calls deflateParams() on the z_stream while the worker
+    // thread is inside deflate() -> data race / state corruption.
+    z._handle.params(0, zlib.constants.Z_DEFAULT_STRATEGY);
+  }
+`;
+
 // These tests are intentionally sequential (not test.concurrent): each
 // subprocess launches several threadpool compression jobs at high quality
 // levels, and running three of them at once makes individual test wall
@@ -127,6 +161,13 @@ test("brotli: reset() while an async write is in flight does not use-after-free"
 
 test("deflate: reset() while an async write is in flight does not race", async () => {
   const { stdout, stderr, exitCode } = await run(deflateFixture);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+});
+
+test("deflate: params() while an async write is in flight does not race", async () => {
+  const { stdout, stderr, exitCode } = await run(paramsFixture);
   expect(stderr).toBe("");
   expect(stdout.trim()).toBe("OK");
   expect(exitCode).toBe(0);

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -736,3 +736,80 @@ describe("dictionary buffer lifetime", () => {
     expect(Buffer.concat(chunks).toString()).toBe(input.toString());
   });
 });
+
+describe("deflate params()", () => {
+  // `write(a); params(...); write(b); end()` queues chunk b behind the
+  // Z_SYNC_FLUSH that params() issues, so the writable machinery dequeues
+  // chunk b (setting write_in_progress) before the params flush callback
+  // reaches the native handle. The native params() call therefore arrives
+  // while a write is in flight and must be deferred, not raced or errored.
+  it("params() with a write queued behind the flush does not error and produces valid output", async () => {
+    const a = Buffer.alloc(4096, "a");
+    const b = Buffer.alloc(4096, "b");
+
+    const d = zlib.createDeflate({ level: 9 });
+    const errors = [];
+    const chunks = [];
+    let paramsCallbackFired = false;
+
+    d.on("error", err => errors.push(err));
+    d.on("data", c => chunks.push(c));
+    const { promise: ended, resolve: onEnd } = Promise.withResolvers();
+    d.on("end", onEnd);
+
+    d.write(a);
+    d.params(0, zlib.constants.Z_DEFAULT_STRATEGY, () => {
+      paramsCallbackFired = true;
+    });
+    d.write(b);
+    d.end();
+
+    await ended;
+
+    expect(errors).toEqual([]);
+    expect(paramsCallbackFired).toBe(true);
+    expect(zlib.inflateSync(Buffer.concat(chunks))).toEqual(Buffer.concat([a, b]));
+  });
+
+  // Same shape with a tiny chunkSize so chunk b's Z_FINISH write is reissued
+  // by processCallback (availOutAfter === 0). That reissued write() applies
+  // the deferred params against a stream that may already be in FINISH_STATE,
+  // exercising the discard-on-error branch of the deferred apply.
+  it("params() with a multi-pass finish write does not error and produces valid output", async () => {
+    const a = Buffer.alloc(4096, "a");
+    // Incompressible (xorshift32) so the Z_FINISH write needs many output
+    // chunks regardless of which compression level ends up applying.
+    const b = Buffer.alloc(8192);
+    let x = 0x12345678;
+    for (let i = 0; i < b.length; i++) {
+      x ^= x << 13;
+      x ^= x >>> 17;
+      x ^= x << 5;
+      x |= 0;
+      b[i] = x & 0xff;
+    }
+
+    const d = zlib.createDeflate({ level: 9, chunkSize: 64 });
+    const errors = [];
+    const chunks = [];
+    let paramsCallbackFired = false;
+
+    d.on("error", err => errors.push(err));
+    d.on("data", c => chunks.push(c));
+    const { promise: ended, resolve: onEnd } = Promise.withResolvers();
+    d.on("end", onEnd);
+
+    d.write(a);
+    d.params(0, zlib.constants.Z_DEFAULT_STRATEGY, () => {
+      paramsCallbackFired = true;
+    });
+    d.write(b);
+    d.end();
+
+    await ended;
+
+    expect(errors).toEqual([]);
+    expect(paramsCallbackFired).toBe(true);
+    expect(zlib.inflateSync(Buffer.concat(chunks))).toEqual(Buffer.concat([a, b]));
+  });
+});


### PR DESCRIPTION
The native `params()` and `init()` methods on the zlib/brotli/zstd handles could mutate the native compression state from the JS thread while the thread pool was still processing a write against the same state.

`params()` now defers the requested level/strategy when a write is in flight and applies it on the JS thread at the start of the next write (the JS layer legitimately reaches `params()` mid-write because the writable machinery dequeues the next buffered chunk before the params flush callback runs, so throwing is not an option there). `init()` now returns `ERR_INVALID_STATE` in that situation, which is only reachable by calling `_handle.init()` directly.

Tests added:
- `zlib-reset-race.test.ts`: `params()` issued directly against the handle while an async write is on the thread pool round-trips correctly.
- `zlib.test.js`: `write(a); params(...); write(b); end()` (and a multi-pass variant with a tiny chunkSize) completes without an error event, fires the params callback, and produces output that inflates back to the input.

`test-zlib-params.js`, `test-zlib-reset-before-write.js`, and `test-zlib-write-after-flush.js` still pass, so the existing immediate `params()` path is byte-for-byte unchanged.