### PR TITLE
shell: address recursive rm deletions relative to open parent directory fds

### DIFF
--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -1265,9 +1265,9 @@ impl ShellRmTask {
                     }
                     return Err(self.error_with_path(&e, path.as_bytes()));
                 }
-                E::ENOTDIR => {
-                    // The entry the parent classified as a directory is no
-                    // longer one.
+                // ENOTDIR (Linux) or ELOOP/EMLINK (macOS/BSD): the entry the
+                // parent classified as a directory is no longer one.
+                E::ENOTDIR | E::ELOOP | E::EMLINK => {
                     let mut dummy = DummyRemoveFile;
                     #[cfg(unix)]
                     {

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -1107,7 +1107,17 @@ impl ShellRmTask {
                 });
             }
             let flags = bun_sys::O::DIRECTORY | bun_sys::O::RDONLY | bun_sys::O::NOFOLLOW;
-            let fd = shell_openat(self.cwd, (*parent).path.as_zstr(), flags, 0)?;
+            let fd = match shell_openat(self.cwd, (*parent).path.as_zstr(), flags, 0) {
+                Ok(fd) => fd,
+                // The path no longer leads to a directory we can verify:
+                // O_NOFOLLOW|O_DIRECTORY on a final component swapped for a
+                // symlink yields ENOTDIR (Linux) or ELOOP/EMLINK (macOS/BSD).
+                // Same condition as the dev/ino mismatch below.
+                Err(e) if matches!(e.get_errno(), E::ELOOP | E::EMLINK | E::ENOTDIR) => {
+                    return Err(bun_sys::Error::from_code(E::ENOENT, bun_sys::Tag::open));
+                }
+                Err(e) => return Err(e),
+            };
             let guard = VerifiedParentFd { fd, owned: true };
             let actual = FileId::from_stat(&bun_sys::fstat(fd)?);
             if (*parent).dir_id != Some(actual) {
@@ -1493,7 +1503,7 @@ impl ShellRmTask {
                     }
                     Err(self.error_with_path(&e, path.as_bytes()))
                 }
-                _ => Err(e),
+                _ => Err(self.error_with_path(&e, path.as_bytes())),
             },
         }
     }

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -1490,6 +1490,33 @@ impl ShellRmTask {
                     }
                     Err(self.error_with_path(&e, path.as_bytes()))
                 }
+                // The directory was replaced by a non-directory after
+                // iteration; unlink the replacement through the verified
+                // parent like `remove_entry_dir_after_children` does.
+                #[cfg(unix)]
+                E::ENOTDIR => {
+                    let parent = match self.open_verified_parent(dir_task) {
+                        Ok(p) => p,
+                        Err(pe) => {
+                            if self.opts.force && pe.get_errno() == E::ENOENT {
+                                return self.verbose_deleted(dir_task, path.as_bytes());
+                            }
+                            return Err(self.error_with_path(&pe, path.as_bytes()));
+                        }
+                    };
+                    // SAFETY: `dir_task` is live and owned by this thread;
+                    // `name` is read-only after construction.
+                    let name = unsafe { (*dir_task).name.as_zstr() };
+                    match bun_sys::unlinkat_with_flags(parent.fd, name, 0) {
+                        Ok(()) => self.verbose_deleted(dir_task, path.as_bytes()),
+                        Err(ue) => {
+                            if self.opts.force && ue.get_errno() == E::ENOENT {
+                                return self.verbose_deleted(dir_task, path.as_bytes());
+                            }
+                            Err(self.error_with_path(&ue, path.as_bytes()))
+                        }
+                    }
+                }
                 _ => Err(self.error_with_path(&e, path.as_bytes())),
             },
         }

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -1133,8 +1133,6 @@ impl ShellRmTask {
     /// Remove the (now empty) directory `dir_task` describes by unlinking its
     /// single-component name from a freshly opened, identity-verified parent
     /// directory fd, so no intermediate path component is re-resolved.
-    /// Returns the raw syscall result; callers keep their existing
-    /// ENOENT/`--force`/ENOTDIR handling.
     #[cfg(unix)]
     fn rmdir_self(&self, dir_task: *mut DirTask) -> bun_sys::Maybe<()> {
         let parent = self.open_verified_parent(dir_task)?;
@@ -1226,10 +1224,8 @@ impl ShellRmTask {
                         }
                         E::ENOTDIR => {
                             state.treat_as_dir = false;
-                            // `-d` without `-r` is root-only (children are
-                            // only created under `-r`), so the user-supplied
-                            // operand relative to the shell cwd is the trust
-                            // anchor.
+                            // `-d` without `-r` is root-only, so `name` is
+                            // the full operand relative to the shell cwd.
                             self.remove_entry_file(
                                 dir_task,
                                 dirfd,
@@ -1271,8 +1267,7 @@ impl ShellRmTask {
                 }
                 E::ENOTDIR => {
                     // The entry the parent classified as a directory is no
-                    // longer one; unlink it relative to its (verified)
-                    // parent directory instead of re-resolving the full path.
+                    // longer one.
                     let mut dummy = DummyRemoveFile;
                     #[cfg(unix)]
                     {
@@ -1323,11 +1318,9 @@ impl ShellRmTask {
             }
         });
 
-        // Confirm the directory we just opened by (multi-component, freshly
-        // re-resolved) path is the one the parent task discovered through its
-        // own open fd. A mismatch means some component of the path was
-        // replaced while this task was queued — fail closed instead of
-        // descending into whatever is reachable there now.
+        // Confirm the directory we just opened by path is the one the parent
+        // task discovered through its own open fd; on a mismatch fail closed
+        // instead of descending into whatever is reachable there now.
         #[cfg(unix)]
         {
             let actual = match bun_sys::fstat(fd) {
@@ -1429,9 +1422,6 @@ impl ShellRmTask {
                     let joined = self.buf_join(buf, &[path.as_bytes(), name]);
                     ZBox::from_bytes(joined.as_bytes())
                 };
-                // Unlink the entry through the already-open directory fd and
-                // its single-component name so no intermediate path component
-                // is re-resolved; the joined path is only for display.
                 #[cfg(unix)]
                 self.remove_entry_file(
                     dir_task,
@@ -1487,9 +1477,6 @@ impl ShellRmTask {
             }
         }
 
-        // No pending children: remove the directory itself by unlinking its
-        // single-component name from its identity-verified parent fd instead
-        // of re-resolving the full path from the cwd.
         #[cfg(unix)]
         let rmdir_result = self.rmdir_self(dir_task);
         #[cfg(not(unix))]
@@ -1514,9 +1501,6 @@ impl ShellRmTask {
     fn remove_entry_dir_after_children(&self, dir_task: *mut DirTask) -> bun_sys::Maybe<bool> {
         // SAFETY: `dir_task` is live; this thread owns it.
         let (path, is_abs) = unsafe { ((*dir_task).path.as_zstr(), (*dir_task).is_absolute) };
-        // Address the directory as a single component relative to a freshly
-        // opened, identity-verified parent fd so no intermediate path
-        // component is re-resolved by the deletion syscalls below.
         #[cfg(unix)]
         let parent = match self.open_verified_parent(dir_task) {
             Ok(p) => p,
@@ -1619,7 +1603,6 @@ impl ShellRmTask {
                         let expected_id = match bun_sys::lstatat(dirfd, name) {
                             Ok(st) => FileId::from_stat(&st),
                             Err(e2) => {
-                                // The entry vanished after the unlink attempt.
                                 if self.opts.force && e2.get_errno() == E::ENOENT {
                                     return self.verbose_deleted(parent_dir_task, path.as_bytes());
                                 }
@@ -1673,10 +1656,6 @@ impl ShellRmTask {
                                     E::ENOTEMPTY => {
                                         #[cfg(unix)]
                                         {
-                                            // Capture the directory's identity
-                                            // through `dirfd` before handing it
-                                            // off so the enqueued child task can
-                                            // verify its own re-open by path.
                                             let expected_id = match bun_sys::lstatat(dirfd, name) {
                                                 Ok(st) => FileId::from_stat(&st),
                                                 Err(e3) => {

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -652,13 +652,6 @@ pub enum EntryKindHint {
     File,
 }
 
-/// Identity of a directory entry captured through its parent's already-open
-/// fd at discovery time and re-checked after a task re-opens that entry by
-/// its full path. The recursive walk hands multi-component relative paths to
-/// asynchronous child tasks; if any intermediate component is replaced (e.g.
-/// by a symlink) between discovery and the child's open, the re-open lands on
-/// a different inode and the comparison fails, so the deletion never follows
-/// the replacement out of the tree being removed.
 #[cfg(unix)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 struct FileId {
@@ -668,9 +661,6 @@ struct FileId {
 
 #[cfg(unix)]
 impl FileId {
-    // `st_dev`/`st_ino` widths vary across libc targets (e.g. `dev_t` is
-    // `i32` on Darwin, `u64` on Linux); widen both to a fixed type for
-    // comparison.
     #[allow(clippy::unnecessary_cast)]
     fn from_stat(st: &bun_sys::Stat) -> FileId {
         FileId {
@@ -680,9 +670,6 @@ impl FileId {
     }
 }
 
-/// Directory fd handed out by [`ShellRmTask::open_verified_parent`]. The
-/// shell cwd (root case) is borrowed and must not be closed; a re-opened
-/// parent directory is owned and closed on drop.
 #[cfg(unix)]
 struct VerifiedParentFd {
     fd: bun_sys::Fd,
@@ -742,23 +729,9 @@ pub struct ShellRmTask {
 pub struct DirTask {
     pub task_manager: *mut ShellRmTask,
     pub parent_task: *mut DirTask,
-    /// Full joined path of this entry. Used for error messages, verbose
-    /// output, and the by-path re-open in `remove_entry_dir` (whose result is
-    /// then identity-checked against `dir_id`); deletion syscalls address the
-    /// entry as `name` relative to an open parent directory fd instead.
     pub path: ZBox,
-    /// The single path component of this entry inside its parent directory.
-    /// For the root DirTask this is the full user-supplied operand, because
-    /// its parent fd is the shell cwd.
     #[cfg(unix)]
     name: ZBox,
-    /// Identity of the directory this task is expected to operate on. For
-    /// children: recorded by the parent via `lstatat` on its open fd at
-    /// discovery and confirmed by `fstat` after this task re-opens the
-    /// directory by path. For the root: `None` until its own open succeeds
-    /// (the user-supplied operand relative to the shell cwd is the trust
-    /// anchor). Written before the task is scheduled (or before any child is
-    /// scheduled), so the work-pool enqueue is the synchronization edge.
     #[cfg(unix)]
     dir_id: Option<FileId>,
     pub is_absolute: bool,
@@ -922,9 +895,7 @@ impl ShellRmTask {
     }
 
     /// Spec: rm.zig `enqueue` — joins `name` onto `parent_dir.path` and spawns
-    /// a child DirTask. `name` is the single path component of the entry
-    /// inside `parent_dir`; `expected_id` is its identity as observed through
-    /// `parent_dir`'s open fd.
+    /// a child DirTask.
     fn enqueue(
         &self,
         parent_dir: *mut DirTask,
@@ -1076,13 +1047,6 @@ impl ShellRmTask {
         e.with_path(path)
     }
 
-    /// Open `dir_task`'s parent directory and confirm it is still the
-    /// directory recorded when the parent task opened itself, so that a
-    /// deletion addressed as `unlinkat(parent_fd, name)` cannot be redirected
-    /// by a path component swapped in after validation. The returned fd is a
-    /// stack-local RAII value — it is never stored in a DirTask, so peak fd
-    /// usage stays bounded by worker-pool concurrency rather than by the
-    /// number of pending interior directories.
     #[cfg(unix)]
     fn open_verified_parent(&self, dir_task: *mut DirTask) -> bun_sys::Maybe<VerifiedParentFd> {
         // SAFETY: `dir_task` is live and owned by the calling worker thread;
@@ -1092,15 +1056,10 @@ impl ShellRmTask {
         // the chain of work-pool enqueues makes them visible here.
         unsafe {
             let mut parent = (*dir_task).parent_task;
-            // A DirTask re-enqueued by `RemoveFileParent::on_dir_not_empty`
-            // describes the same directory as its protocol parent; its
-            // filesystem parent is the first ancestor with a different path.
             while !parent.is_null() && (*parent).path.as_bytes() == (*dir_task).path.as_bytes() {
                 parent = (*parent).parent_task;
             }
             if parent.is_null() {
-                // The root entry is addressed by the user-supplied operand
-                // relative to the shell cwd; that pair is the trust anchor.
                 return Ok(VerifiedParentFd {
                     fd: self.cwd,
                     owned: false,
@@ -1109,10 +1068,6 @@ impl ShellRmTask {
             let flags = bun_sys::O::DIRECTORY | bun_sys::O::RDONLY | bun_sys::O::NOFOLLOW;
             let fd = match shell_openat(self.cwd, (*parent).path.as_zstr(), flags, 0) {
                 Ok(fd) => fd,
-                // The path no longer leads to a directory we can verify:
-                // O_NOFOLLOW|O_DIRECTORY on a final component swapped for a
-                // symlink yields ENOTDIR (Linux) or ELOOP/EMLINK (macOS/BSD).
-                // Same condition as the dev/ino mismatch below.
                 Err(e) if matches!(e.get_errno(), E::ELOOP | E::EMLINK | E::ENOTDIR) => {
                     return Err(bun_sys::Error::from_code(E::ENOENT, bun_sys::Tag::open));
                 }
@@ -1121,18 +1076,12 @@ impl ShellRmTask {
             let guard = VerifiedParentFd { fd, owned: true };
             let actual = FileId::from_stat(&bun_sys::fstat(fd)?);
             if (*parent).dir_id != Some(actual) {
-                // The path no longer leads to the directory we validated;
-                // report the entry as gone rather than deleting through
-                // whatever is there now.
                 return Err(bun_sys::Error::from_code(E::ENOENT, bun_sys::Tag::open));
             }
             Ok(guard)
         }
     }
 
-    /// Remove the (now empty) directory `dir_task` describes by unlinking its
-    /// single-component name from a freshly opened, identity-verified parent
-    /// directory fd, so no intermediate path component is re-resolved.
     #[cfg(unix)]
     fn rmdir_self(&self, dir_task: *mut DirTask) -> bun_sys::Maybe<()> {
         let parent = self.open_verified_parent(dir_task)?;
@@ -1168,8 +1117,6 @@ impl ShellRmTask {
                     child_of_dir: false,
                     need_to_wait_out: Some(&mut waiting),
                 };
-                // Root entry: the user-supplied operand relative to the shell
-                // cwd is the trust anchor, so `name` is the full path.
                 self.remove_entry_file(
                     dir_task,
                     self.cwd,
@@ -1224,8 +1171,6 @@ impl ShellRmTask {
                         }
                         E::ENOTDIR => {
                             state.treat_as_dir = false;
-                            // `-d` without `-r` is root-only, so `name` is
-                            // the full operand relative to the shell cwd.
                             self.remove_entry_file(
                                 dir_task,
                                 dirfd,
@@ -1265,8 +1210,6 @@ impl ShellRmTask {
                     }
                     return Err(self.error_with_path(&e, path.as_bytes()));
                 }
-                // ENOTDIR (Linux) or ELOOP/EMLINK (macOS/BSD): the entry the
-                // parent classified as a directory is no longer one.
                 E::ENOTDIR | E::ELOOP | E::EMLINK => {
                     let mut dummy = DummyRemoveFile;
                     #[cfg(unix)]
@@ -1318,9 +1261,6 @@ impl ShellRmTask {
             }
         });
 
-        // Confirm the directory we just opened by path is the one the parent
-        // task discovered through its own open fd; on a mismatch fail closed
-        // instead of descending into whatever is reachable there now.
         #[cfg(unix)]
         {
             let actual = match bun_sys::fstat(fd) {
@@ -1341,9 +1281,6 @@ impl ShellRmTask {
                     ));
                 }
                 _ => {
-                    // Root (no recorded identity) or a match: record the
-                    // opened directory's identity so this task's children can
-                    // verify their own parent re-open against it.
                     // SAFETY: `dir_task` is live; this thread owns its
                     // non-atomic fields (no child has been enqueued yet).
                     unsafe { (*dir_task).dir_id = Some(actual) };
@@ -1378,12 +1315,6 @@ impl ShellRmTask {
             i += 1;
             let mut treat_as_file = true;
             if current.kind == bun_sys::EntryKind::Directory {
-                // Record the entry's identity through the already-open parent
-                // fd so the child task can confirm that its own re-open by
-                // path landed on the same directory. AT_SYMLINK_NOFOLLOW
-                // means a symlink swapped in before this point records the
-                // link's own identity, which the child's O_NOFOLLOW open can
-                // never match.
                 #[cfg(unix)]
                 match bun_sys::lstatat(fd, current.name.as_zstr()) {
                     Ok(st) => {
@@ -1396,9 +1327,6 @@ impl ShellRmTask {
                         );
                         treat_as_file = false;
                     }
-                    // The entry vanished between readdir and here; fall
-                    // through to the unlink path so the existing
-                    // ENOENT/`--force` handling reports it.
                     Err(_) => {}
                 }
                 #[cfg(not(unix))]
@@ -1490,9 +1418,6 @@ impl ShellRmTask {
                     }
                     Err(self.error_with_path(&e, path.as_bytes()))
                 }
-                // The directory was replaced by a non-directory after
-                // iteration; unlink the replacement through the verified
-                // parent like `remove_entry_dir_after_children` does.
                 #[cfg(unix)]
                 E::ENOTDIR => {
                     let parent = match self.open_verified_parent(dir_task) {
@@ -1595,12 +1520,6 @@ impl ShellRmTask {
     }
 
     /// Spec: rm.zig `removeEntryFile`.
-    ///
-    /// The entry is addressed as `name` relative to `dirfd` — for entries
-    /// discovered while iterating a directory that is the iteration fd plus
-    /// the single dirent component, so no intermediate path component is ever
-    /// re-resolved. `path` is the full joined path and is used only for error
-    /// messages and verbose output.
     #[allow(clippy::too_many_arguments)]
     fn remove_entry_file<V: RemoveFileHandler>(
         &self,
@@ -1624,9 +1543,6 @@ impl ShellRmTask {
                 E::EISDIR => {
                     #[cfg(unix)]
                     {
-                        // Capture the directory's identity through `dirfd`
-                        // before handing it off so the enqueued child task
-                        // can verify its own re-open by path.
                         let expected_id = match bun_sys::lstatat(dirfd, name) {
                             Ok(st) => FileId::from_stat(&st),
                             Err(e2) => {
@@ -1724,8 +1640,7 @@ impl ShellRmTask {
                         }
                         // We don't know if it was an actual permissions error
                         // or it was a directory so we need to try to delete it
-                        // as a directory. This is only reachable for the root
-                        // operand (children are only iterated under `-r`).
+                        // as a directory.
                         #[cfg(unix)]
                         {
                             let expected_id = match bun_sys::lstatat(dirfd, name) {
@@ -2058,11 +1973,6 @@ fn dir_task_run_from_main_thread_mini(this: *mut DirTask, _: *mut ()) {
 // ── RemoveFileHandler — Zig `vtable: anytype` lowered to a trait ───────────
 
 trait RemoveFileHandler {
-    /// `name` is the entry's single path component relative to the directory
-    /// fd the failed unlink was issued against, and `expected_id` is its
-    /// identity captured through that fd; together they let the
-    /// `child_of_dir` arms stamp the DirTask they enqueue so its re-open by
-    /// path can be verified.
     #[allow(clippy::too_many_arguments)]
     fn on_is_dir(
         &mut self,

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -652,6 +652,52 @@ pub enum EntryKindHint {
     File,
 }
 
+/// Identity of a directory entry captured through its parent's already-open
+/// fd at discovery time and re-checked after a task re-opens that entry by
+/// its full path. The recursive walk hands multi-component relative paths to
+/// asynchronous child tasks; if any intermediate component is replaced (e.g.
+/// by a symlink) between discovery and the child's open, the re-open lands on
+/// a different inode and the comparison fails, so the deletion never follows
+/// the replacement out of the tree being removed.
+#[cfg(unix)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct FileId {
+    dev: u64,
+    ino: u64,
+}
+
+#[cfg(unix)]
+impl FileId {
+    // `st_dev`/`st_ino` widths vary across libc targets (e.g. `dev_t` is
+    // `i32` on Darwin, `u64` on Linux); widen both to a fixed type for
+    // comparison.
+    #[allow(clippy::unnecessary_cast)]
+    fn from_stat(st: &bun_sys::Stat) -> FileId {
+        FileId {
+            dev: st.st_dev as u64,
+            ino: st.st_ino as u64,
+        }
+    }
+}
+
+/// Directory fd handed out by [`ShellRmTask::open_verified_parent`]. The
+/// shell cwd (root case) is borrowed and must not be closed; a re-opened
+/// parent directory is owned and closed on drop.
+#[cfg(unix)]
+struct VerifiedParentFd {
+    fd: bun_sys::Fd,
+    owned: bool,
+}
+
+#[cfg(unix)]
+impl Drop for VerifiedParentFd {
+    fn drop(&mut self) {
+        if self.owned {
+            self.fd.close();
+        }
+    }
+}
+
 /// Spec: rm.zig `ShellRmTask`. One per filepath argument; owns the root
 /// [`DirTask`] and tracks the cross-thread error state.
 pub struct ShellRmTask {
@@ -696,7 +742,25 @@ pub struct ShellRmTask {
 pub struct DirTask {
     pub task_manager: *mut ShellRmTask,
     pub parent_task: *mut DirTask,
+    /// Full joined path of this entry. Used for error messages, verbose
+    /// output, and the by-path re-open in `remove_entry_dir` (whose result is
+    /// then identity-checked against `dir_id`); deletion syscalls address the
+    /// entry as `name` relative to an open parent directory fd instead.
     pub path: ZBox,
+    /// The single path component of this entry inside its parent directory.
+    /// For the root DirTask this is the full user-supplied operand, because
+    /// its parent fd is the shell cwd.
+    #[cfg(unix)]
+    name: ZBox,
+    /// Identity of the directory this task is expected to operate on. For
+    /// children: recorded by the parent via `lstatat` on its open fd at
+    /// discovery and confirmed by `fstat` after this task re-opens the
+    /// directory by path. For the root: `None` until its own open succeeds
+    /// (the user-supplied operand relative to the shell cwd is the trust
+    /// anchor). Written before the task is scheduled (or before any child is
+    /// scheduled), so the work-pool enqueue is the synchronization edge.
+    #[cfg(unix)]
+    dir_id: Option<FileId>,
     pub is_absolute: bool,
     pub subtask_count: AtomicUsize,
     pub need_to_wait: AtomicBool,
@@ -740,6 +804,10 @@ impl ShellRmTask {
             task_manager: core::ptr::null_mut(),
             parent_task: core::ptr::null_mut(),
             path: ZBox::from_bytes(root_path),
+            #[cfg(unix)]
+            name: ZBox::from_bytes(root_path),
+            #[cfg(unix)]
+            dir_id: None,
             is_absolute: false,
             subtask_count: AtomicUsize::new(1),
             need_to_wait: AtomicBool::new(false),
@@ -853,26 +921,45 @@ impl ShellRmTask {
         self.error_signal.get()
     }
 
-    /// Spec: rm.zig `enqueue` — joins `path` onto `parent_dir.path` and spawns
-    /// a child DirTask.
+    /// Spec: rm.zig `enqueue` — joins `name` onto `parent_dir.path` and spawns
+    /// a child DirTask. `name` is the single path component of the entry
+    /// inside `parent_dir`; `expected_id` is its identity as observed through
+    /// `parent_dir`'s open fd.
     fn enqueue(
         &self,
         parent_dir: *mut DirTask,
-        path: &[u8],
+        name: &[u8],
         is_absolute: bool,
         kind_hint: EntryKindHint,
+        #[cfg(unix)] expected_id: FileId,
     ) {
         if self.error_signal().load(Ordering::SeqCst) {
             return;
         }
         // SAFETY: `parent_dir` is live for the duration of its run_from_thread_pool_impl.
         let parent_path = unsafe { (*parent_dir).path.as_bytes() };
-        let new_path = self.join(&[parent_path, path], is_absolute);
+        let new_path = self.join(&[parent_path, name], is_absolute);
+        #[cfg(unix)]
+        self.enqueue_no_join(
+            parent_dir,
+            new_path,
+            ZBox::from_bytes(name),
+            kind_hint,
+            expected_id,
+        );
+        #[cfg(not(unix))]
         self.enqueue_no_join(parent_dir, new_path, kind_hint);
     }
 
     /// Spec: rm.zig `enqueueNoJoin`. Takes ownership of `path`.
-    fn enqueue_no_join(&self, parent: *mut DirTask, path: ZBox, kind_hint: EntryKindHint) {
+    fn enqueue_no_join(
+        &self,
+        parent: *mut DirTask,
+        path: ZBox,
+        #[cfg(unix)] name: ZBox,
+        kind_hint: EntryKindHint,
+        #[cfg(unix)] expected_id: FileId,
+    ) {
         if self.error_signal().load(Ordering::SeqCst) {
             return;
         }
@@ -884,6 +971,10 @@ impl ShellRmTask {
             task_manager,
             parent_task: parent,
             path,
+            #[cfg(unix)]
+            name,
+            #[cfg(unix)]
+            dir_id: Some(expected_id),
             is_absolute: false,
             subtask_count: AtomicUsize::new(1),
             need_to_wait: AtomicBool::new(false),
@@ -985,6 +1076,64 @@ impl ShellRmTask {
         e.with_path(path)
     }
 
+    /// Open `dir_task`'s parent directory and confirm it is still the
+    /// directory recorded when the parent task opened itself, so that a
+    /// deletion addressed as `unlinkat(parent_fd, name)` cannot be redirected
+    /// by a path component swapped in after validation. The returned fd is a
+    /// stack-local RAII value — it is never stored in a DirTask, so peak fd
+    /// usage stays bounded by worker-pool concurrency rather than by the
+    /// number of pending interior directories.
+    #[cfg(unix)]
+    fn open_verified_parent(&self, dir_task: *mut DirTask) -> bun_sys::Maybe<VerifiedParentFd> {
+        // SAFETY: `dir_task` is live and owned by the calling worker thread;
+        // every ancestor DirTask is kept alive by the `subtask_count`
+        // protocol until this task completes. Ancestor `path` / `dir_id`
+        // fields are written before the corresponding child is scheduled, so
+        // the chain of work-pool enqueues makes them visible here.
+        unsafe {
+            let mut parent = (*dir_task).parent_task;
+            // A DirTask re-enqueued by `RemoveFileParent::on_dir_not_empty`
+            // describes the same directory as its protocol parent; its
+            // filesystem parent is the first ancestor with a different path.
+            while !parent.is_null() && (*parent).path.as_bytes() == (*dir_task).path.as_bytes() {
+                parent = (*parent).parent_task;
+            }
+            if parent.is_null() {
+                // The root entry is addressed by the user-supplied operand
+                // relative to the shell cwd; that pair is the trust anchor.
+                return Ok(VerifiedParentFd {
+                    fd: self.cwd,
+                    owned: false,
+                });
+            }
+            let flags = bun_sys::O::DIRECTORY | bun_sys::O::RDONLY | bun_sys::O::NOFOLLOW;
+            let fd = shell_openat(self.cwd, (*parent).path.as_zstr(), flags, 0)?;
+            let guard = VerifiedParentFd { fd, owned: true };
+            let actual = FileId::from_stat(&bun_sys::fstat(fd)?);
+            if (*parent).dir_id != Some(actual) {
+                // The path no longer leads to the directory we validated;
+                // report the entry as gone rather than deleting through
+                // whatever is there now.
+                return Err(bun_sys::Error::from_code(E::ENOENT, bun_sys::Tag::open));
+            }
+            Ok(guard)
+        }
+    }
+
+    /// Remove the (now empty) directory `dir_task` describes by unlinking its
+    /// single-component name from a freshly opened, identity-verified parent
+    /// directory fd, so no intermediate path component is re-resolved.
+    /// Returns the raw syscall result; callers keep their existing
+    /// ENOENT/`--force`/ENOTDIR handling.
+    #[cfg(unix)]
+    fn rmdir_self(&self, dir_task: *mut DirTask) -> bun_sys::Maybe<()> {
+        let parent = self.open_verified_parent(dir_task)?;
+        // SAFETY: `dir_task` is live and owned by this thread; `name` is
+        // read-only after construction.
+        let name = unsafe { (*dir_task).name.as_zstr() };
+        bun_sys::unlinkat_with_flags(parent.fd, name, bun_sys::AT_REMOVEDIR)
+    }
+
     /// Spec: rm.zig `removeEntry`.
     ///
     /// Returns `Ok(true)` when [`remove_entry_dir`] published
@@ -1011,7 +1160,17 @@ impl ShellRmTask {
                     child_of_dir: false,
                     need_to_wait_out: Some(&mut waiting),
                 };
-                self.remove_entry_file(dir_task, path, is_absolute, &mut buf, &mut vtable)?;
+                // Root entry: the user-supplied operand relative to the shell
+                // cwd is the trust anchor, so `name` is the full path.
+                self.remove_entry_file(
+                    dir_task,
+                    self.cwd,
+                    path,
+                    path,
+                    is_absolute,
+                    &mut buf,
+                    &mut vtable,
+                )?;
             }
             EntryKindHint::Dir => {
                 self.remove_entry_dir(dir_task, is_absolute, &mut buf, &mut waiting)?;
@@ -1057,7 +1216,19 @@ impl ShellRmTask {
                         }
                         E::ENOTDIR => {
                             state.treat_as_dir = false;
-                            self.remove_entry_file(dir_task, path, is_absolute, buf, &mut state)?;
+                            // `-d` without `-r` is root-only (children are
+                            // only created under `-r`), so the user-supplied
+                            // operand relative to the shell cwd is the trust
+                            // anchor.
+                            self.remove_entry_file(
+                                dir_task,
+                                dirfd,
+                                path,
+                                path,
+                                is_absolute,
+                                buf,
+                                &mut state,
+                            )?;
                             if !state.treat_as_dir {
                                 return Ok(());
                             }
@@ -1089,8 +1260,46 @@ impl ShellRmTask {
                     return Err(self.error_with_path(&e, path.as_bytes()));
                 }
                 E::ENOTDIR => {
+                    // The entry the parent classified as a directory is no
+                    // longer one; unlink it relative to its (verified)
+                    // parent directory instead of re-resolving the full path.
                     let mut dummy = DummyRemoveFile;
-                    return self.remove_entry_file(dir_task, path, is_absolute, buf, &mut dummy);
+                    #[cfg(unix)]
+                    {
+                        let parent = match self.open_verified_parent(dir_task) {
+                            Ok(p) => p,
+                            Err(pe) => {
+                                if self.opts.force && pe.get_errno() == E::ENOENT {
+                                    return self.verbose_deleted(dir_task, path.as_bytes());
+                                }
+                                return Err(self.error_with_path(&pe, path.as_bytes()));
+                            }
+                        };
+                        // SAFETY: `dir_task` is live and owned by this
+                        // thread; `name` is read-only after construction.
+                        let name = unsafe { (*dir_task).name.as_zstr() };
+                        return self.remove_entry_file(
+                            dir_task,
+                            parent.fd,
+                            name,
+                            path,
+                            is_absolute,
+                            buf,
+                            &mut dummy,
+                        );
+                    }
+                    #[cfg(not(unix))]
+                    {
+                        return self.remove_entry_file(
+                            dir_task,
+                            self.cwd,
+                            path,
+                            path,
+                            is_absolute,
+                            buf,
+                            &mut dummy,
+                        );
+                    }
                 }
                 _ => return Err(self.error_with_path(&e, path.as_bytes())),
             },
@@ -1103,6 +1312,41 @@ impl ShellRmTask {
                 fd.close();
             }
         });
+
+        // Confirm the directory we just opened by (multi-component, freshly
+        // re-resolved) path is the one the parent task discovered through its
+        // own open fd. A mismatch means some component of the path was
+        // replaced while this task was queued — fail closed instead of
+        // descending into whatever is reachable there now.
+        #[cfg(unix)]
+        {
+            let actual = match bun_sys::fstat(fd) {
+                Ok(st) => FileId::from_stat(&st),
+                Err(e) => return Err(self.error_with_path(&e, path.as_bytes())),
+            };
+            // SAFETY: `dir_task` is live; this thread owns its non-atomic
+            // fields (no child has been enqueued yet).
+            let recorded = unsafe { (*dir_task).dir_id };
+            match recorded {
+                Some(expected) if expected != actual => {
+                    if self.opts.force {
+                        return self.verbose_deleted(dir_task, path.as_bytes());
+                    }
+                    return Err(self.error_with_path(
+                        &bun_sys::Error::from_code(E::ENOENT, bun_sys::Tag::open),
+                        path.as_bytes(),
+                    ));
+                }
+                _ => {
+                    // Root (no recorded identity) or a match: record the
+                    // opened directory's identity so this task's children can
+                    // verify their own parent re-open against it.
+                    // SAFETY: `dir_task` is live; this thread owns its
+                    // non-atomic fields (no child has been enqueued yet).
+                    unsafe { (*dir_task).dir_id = Some(actual) };
+                }
+            }
+        }
 
         if self.error_signal().load(Ordering::SeqCst) {
             return Ok(());
@@ -1129,33 +1373,75 @@ impl ShellRmTask {
                 return Ok(());
             }
             i += 1;
-            match current.kind {
-                bun_sys::EntryKind::Directory => {
+            let mut treat_as_file = true;
+            if current.kind == bun_sys::EntryKind::Directory {
+                // Record the entry's identity through the already-open parent
+                // fd so the child task can confirm that its own re-open by
+                // path landed on the same directory. AT_SYMLINK_NOFOLLOW
+                // means a symlink swapped in before this point records the
+                // link's own identity, which the child's O_NOFOLLOW open can
+                // never match.
+                #[cfg(unix)]
+                match bun_sys::lstatat(fd, current.name.as_zstr()) {
+                    Ok(st) => {
+                        self.enqueue(
+                            dir_task,
+                            current.name.slice_u8(),
+                            is_absolute,
+                            EntryKindHint::Dir,
+                            FileId::from_stat(&st),
+                        );
+                        treat_as_file = false;
+                    }
+                    // The entry vanished between readdir and here; fall
+                    // through to the unlink path so the existing
+                    // ENOENT/`--force` handling reports it.
+                    Err(_) => {}
+                }
+                #[cfg(not(unix))]
+                {
                     self.enqueue(
                         dir_task,
                         current.name.slice_u8(),
                         is_absolute,
                         EntryKindHint::Dir,
                     );
+                    treat_as_file = false;
                 }
-                _ => {
-                    let name = current.name.slice_u8();
-                    // PORT NOTE: reshaped for borrowck — Zig passed both the
-                    // joined slice (borrowing `buf`) and `buf` itself to
-                    // `removeEntryFile`. Copy the join into an owned ZBox so
-                    // `buf` is free to be re-borrowed by the vtable callback.
-                    let file_path = {
-                        let joined = self.buf_join(buf, &[path.as_bytes(), name]);
-                        ZBox::from_bytes(joined.as_bytes())
-                    };
-                    self.remove_entry_file(
-                        dir_task,
-                        file_path.as_zstr(),
-                        is_absolute,
-                        buf,
-                        &mut child_vtable,
-                    )?;
-                }
+            }
+            if treat_as_file {
+                let name = current.name.slice_u8();
+                // PORT NOTE: reshaped for borrowck — Zig passed both the
+                // joined slice (borrowing `buf`) and `buf` itself to
+                // `removeEntryFile`. Copy the join into an owned ZBox so
+                // `buf` is free to be re-borrowed by the vtable callback.
+                let file_path = {
+                    let joined = self.buf_join(buf, &[path.as_bytes(), name]);
+                    ZBox::from_bytes(joined.as_bytes())
+                };
+                // Unlink the entry through the already-open directory fd and
+                // its single-component name so no intermediate path component
+                // is re-resolved; the joined path is only for display.
+                #[cfg(unix)]
+                self.remove_entry_file(
+                    dir_task,
+                    fd,
+                    current.name.as_zstr(),
+                    file_path.as_zstr(),
+                    is_absolute,
+                    buf,
+                    &mut child_vtable,
+                )?;
+                #[cfg(not(unix))]
+                self.remove_entry_file(
+                    dir_task,
+                    self.cwd,
+                    file_path.as_zstr(),
+                    file_path.as_zstr(),
+                    is_absolute,
+                    buf,
+                    &mut child_vtable,
+                )?;
             }
         }
 
@@ -1191,7 +1477,14 @@ impl ShellRmTask {
             }
         }
 
-        match bun_sys::unlinkat_with_flags(self.cwd, path, bun_sys::AT_REMOVEDIR) {
+        // No pending children: remove the directory itself by unlinking its
+        // single-component name from its identity-verified parent fd instead
+        // of re-resolving the full path from the cwd.
+        #[cfg(unix)]
+        let rmdir_result = self.rmdir_self(dir_task);
+        #[cfg(not(unix))]
+        let rmdir_result = bun_sys::unlinkat_with_flags(self.cwd, path, bun_sys::AT_REMOVEDIR);
+        match rmdir_result {
             Ok(()) => self.verbose_deleted(dir_task, path.as_bytes()),
             Err(e) => match e.get_errno() {
                 E::ENOENT => {
@@ -1209,9 +1502,31 @@ impl ShellRmTask {
     /// directory was deleted (or force-ignored), `Ok(false)` if a subtask was
     /// enqueued and the caller should not run `post_run` yet.
     fn remove_entry_dir_after_children(&self, dir_task: *mut DirTask) -> bun_sys::Maybe<bool> {
-        let dirfd = self.cwd;
         // SAFETY: `dir_task` is live; this thread owns it.
         let (path, is_abs) = unsafe { ((*dir_task).path.as_zstr(), (*dir_task).is_absolute) };
+        // Address the directory as a single component relative to a freshly
+        // opened, identity-verified parent fd so no intermediate path
+        // component is re-resolved by the deletion syscalls below.
+        #[cfg(unix)]
+        let parent = match self.open_verified_parent(dir_task) {
+            Ok(p) => p,
+            Err(e) => {
+                if self.opts.force && e.get_errno() == E::ENOENT {
+                    let _ = self.verbose_deleted(dir_task, path.as_bytes());
+                    return Ok(true);
+                }
+                return Err(self.error_with_path(&e, path.as_bytes()));
+            }
+        };
+        #[cfg(unix)]
+        let dirfd = parent.fd;
+        // SAFETY: `dir_task` is live; `name` is read-only after construction.
+        #[cfg(unix)]
+        let name = unsafe { (*dir_task).name.as_zstr() };
+        #[cfg(not(unix))]
+        let dirfd = self.cwd;
+        #[cfg(not(unix))]
+        let name = path;
         let mut state = RemoveFileParent {
             treat_as_dir: true,
             #[cfg(not(any(target_os = "linux", target_os = "android")))]
@@ -1220,7 +1535,11 @@ impl ShellRmTask {
         };
         loop {
             if state.treat_as_dir {
-                match bun_sys::rmdirat(dirfd, path) {
+                #[cfg(unix)]
+                let rmdir_result = bun_sys::unlinkat_with_flags(dirfd, name, bun_sys::AT_REMOVEDIR);
+                #[cfg(not(unix))]
+                let rmdir_result = bun_sys::rmdirat(dirfd, path);
+                match rmdir_result {
                     Ok(()) => {
                         let _ = self.verbose_deleted(dir_task, path.as_bytes());
                         return Ok(true);
@@ -1242,7 +1561,7 @@ impl ShellRmTask {
                 }
             } else {
                 let mut buf = bun_paths::PathBuffer::uninit();
-                self.remove_entry_file(dir_task, path, is_abs, &mut buf, &mut state)?;
+                self.remove_entry_file(dir_task, dirfd, name, path, is_abs, &mut buf, &mut state)?;
                 if state.enqueued {
                     return Ok(false);
                 }
@@ -1255,16 +1574,24 @@ impl ShellRmTask {
     }
 
     /// Spec: rm.zig `removeEntryFile`.
+    ///
+    /// The entry is addressed as `name` relative to `dirfd` — for entries
+    /// discovered while iterating a directory that is the iteration fd plus
+    /// the single dirent component, so no intermediate path component is ever
+    /// re-resolved. `path` is the full joined path and is used only for error
+    /// messages and verbose output.
+    #[allow(clippy::too_many_arguments)]
     fn remove_entry_file<V: RemoveFileHandler>(
         &self,
         parent_dir_task: *mut DirTask,
+        dirfd: bun_sys::Fd,
+        name: &ZStr,
         path: &ZStr,
         is_absolute: bool,
         buf: &mut bun_paths::PathBuffer,
         vtable: &mut V,
     ) -> bun_sys::Maybe<()> {
-        let dirfd = self.cwd;
-        match bun_sys::unlinkat_with_flags(dirfd, path, 0) {
+        match bun_sys::unlinkat_with_flags(dirfd, name, 0) {
             Ok(()) => self.verbose_deleted(parent_dir_task, path.as_bytes()),
             Err(e) => match e.get_errno() {
                 E::ENOENT => {
@@ -1273,7 +1600,34 @@ impl ShellRmTask {
                     }
                     Err(self.error_with_path(&e, path.as_bytes()))
                 }
-                E::EISDIR => vtable.on_is_dir(parent_dir_task, path, is_absolute, buf),
+                E::EISDIR => {
+                    #[cfg(unix)]
+                    {
+                        // Capture the directory's identity through `dirfd`
+                        // before handing it off so the enqueued child task
+                        // can verify its own re-open by path.
+                        let expected_id = match bun_sys::lstatat(dirfd, name) {
+                            Ok(st) => FileId::from_stat(&st),
+                            Err(e2) => {
+                                // The entry vanished after the unlink attempt.
+                                if self.opts.force && e2.get_errno() == E::ENOENT {
+                                    return self.verbose_deleted(parent_dir_task, path.as_bytes());
+                                }
+                                return Err(self.error_with_path(&e2, path.as_bytes()));
+                            }
+                        };
+                        return vtable.on_is_dir(
+                            parent_dir_task,
+                            path,
+                            name,
+                            expected_id,
+                            is_absolute,
+                            buf,
+                        );
+                    }
+                    #[cfg(not(unix))]
+                    vtable.on_is_dir(parent_dir_task, path, is_absolute, buf)
+                }
                 // This might happen if the file is actually a directory.
                 E::EPERM => {
                     // Non-Linux POSIX systems and Windows return EPERM when
@@ -1298,20 +1652,54 @@ impl ShellRmTask {
                         // so we don't need to call `stat` to check that.
                         if self.opts.recursive || self.opts.remove_empty_dirs {
                             return match bun_sys::unlinkat_with_flags(
-                                self.cwd,
-                                path,
+                                dirfd,
+                                name,
                                 bun_sys::AT_REMOVEDIR,
                             ) {
                                 // it was empty, we saved a syscall
                                 Ok(()) => self.verbose_deleted(parent_dir_task, path.as_bytes()),
                                 Err(e2) => match e2.get_errno() {
                                     // not empty, process directory as we would normally
-                                    E::ENOTEMPTY => vtable.on_dir_not_empty(
-                                        parent_dir_task,
-                                        path,
-                                        is_absolute,
-                                        buf,
-                                    ),
+                                    E::ENOTEMPTY => {
+                                        #[cfg(unix)]
+                                        {
+                                            // Capture the directory's identity
+                                            // through `dirfd` before handing it
+                                            // off so the enqueued child task can
+                                            // verify its own re-open by path.
+                                            let expected_id = match bun_sys::lstatat(dirfd, name) {
+                                                Ok(st) => FileId::from_stat(&st),
+                                                Err(e3) => {
+                                                    if self.opts.force
+                                                        && e3.get_errno() == E::ENOENT
+                                                    {
+                                                        return self.verbose_deleted(
+                                                            parent_dir_task,
+                                                            path.as_bytes(),
+                                                        );
+                                                    }
+                                                    return Err(
+                                                        self.error_with_path(&e3, path.as_bytes())
+                                                    );
+                                                }
+                                            };
+                                            return vtable.on_dir_not_empty(
+                                                parent_dir_task,
+                                                path,
+                                                name,
+                                                expected_id,
+                                                is_absolute,
+                                                buf,
+                                            );
+                                        }
+                                        #[cfg(not(unix))]
+                                        vtable.on_dir_not_empty(
+                                            parent_dir_task,
+                                            path,
+                                            is_absolute,
+                                            buf,
+                                        )
+                                    }
                                     // actually a file, the error is a permissions error
                                     E::ENOTDIR => Err(self.error_with_path(&e, path.as_bytes())),
                                     _ => Err(self.error_with_path(&e2, path.as_bytes())),
@@ -1320,7 +1708,30 @@ impl ShellRmTask {
                         }
                         // We don't know if it was an actual permissions error
                         // or it was a directory so we need to try to delete it
-                        // as a directory.
+                        // as a directory. This is only reachable for the root
+                        // operand (children are only iterated under `-r`).
+                        #[cfg(unix)]
+                        {
+                            let expected_id = match bun_sys::lstatat(dirfd, name) {
+                                Ok(st) => FileId::from_stat(&st),
+                                Err(e3) => {
+                                    if self.opts.force && e3.get_errno() == E::ENOENT {
+                                        return self
+                                            .verbose_deleted(parent_dir_task, path.as_bytes());
+                                    }
+                                    return Err(self.error_with_path(&e3, path.as_bytes()));
+                                }
+                            };
+                            return vtable.on_is_dir(
+                                parent_dir_task,
+                                path,
+                                name,
+                                expected_id,
+                                is_absolute,
+                                buf,
+                            );
+                        }
+                        #[cfg(not(unix))]
                         return vtable.on_is_dir(parent_dir_task, path, is_absolute, buf);
                     }
                     #[cfg(not(any(
@@ -1631,18 +2042,29 @@ fn dir_task_run_from_main_thread_mini(this: *mut DirTask, _: *mut ()) {
 // ── RemoveFileHandler — Zig `vtable: anytype` lowered to a trait ───────────
 
 trait RemoveFileHandler {
+    /// `name` is the entry's single path component relative to the directory
+    /// fd the failed unlink was issued against, and `expected_id` is its
+    /// identity captured through that fd; together they let the
+    /// `child_of_dir` arms stamp the DirTask they enqueue so its re-open by
+    /// path can be verified.
+    #[allow(clippy::too_many_arguments)]
     fn on_is_dir(
         &mut self,
         parent_dir_task: *mut DirTask,
         path: &ZStr,
+        #[cfg(unix)] name: &ZStr,
+        #[cfg(unix)] expected_id: FileId,
         is_absolute: bool,
         buf: &mut bun_paths::PathBuffer,
     ) -> bun_sys::Maybe<()>;
     #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    #[allow(clippy::too_many_arguments)]
     fn on_dir_not_empty(
         &mut self,
         parent_dir_task: *mut DirTask,
         path: &ZStr,
+        #[cfg(unix)] name: &ZStr,
+        #[cfg(unix)] expected_id: FileId,
         is_absolute: bool,
         buf: &mut bun_paths::PathBuffer,
     ) -> bun_sys::Maybe<()>;
@@ -1654,6 +2076,8 @@ impl RemoveFileHandler for DummyRemoveFile {
         &mut self,
         _: *mut DirTask,
         _: &ZStr,
+        #[cfg(unix)] _: &ZStr,
+        #[cfg(unix)] _: FileId,
         _: bool,
         _: &mut bun_paths::PathBuffer,
     ) -> bun_sys::Maybe<()> {
@@ -1664,6 +2088,8 @@ impl RemoveFileHandler for DummyRemoveFile {
         &mut self,
         _: *mut DirTask,
         _: &ZStr,
+        #[cfg(unix)] _: &ZStr,
+        #[cfg(unix)] _: FileId,
         _: bool,
         _: &mut bun_paths::PathBuffer,
     ) -> bun_sys::Maybe<()> {
@@ -1686,10 +2112,21 @@ impl RemoveFileHandler for RemoveFileVTable<'_> {
         &mut self,
         parent: *mut DirTask,
         path: &ZStr,
+        #[cfg(unix)] name: &ZStr,
+        #[cfg(unix)] expected_id: FileId,
         is_absolute: bool,
         buf: &mut bun_paths::PathBuffer,
     ) -> bun_sys::Maybe<()> {
         if self.child_of_dir {
+            #[cfg(unix)]
+            self.task.enqueue_no_join(
+                parent,
+                ZBox::from_bytes(path.as_bytes()),
+                ZBox::from_bytes(name.as_bytes()),
+                EntryKindHint::Dir,
+                expected_id,
+            );
+            #[cfg(not(unix))]
             self.task.enqueue_no_join(
                 parent,
                 ZBox::from_bytes(path.as_bytes()),
@@ -1710,10 +2147,21 @@ impl RemoveFileHandler for RemoveFileVTable<'_> {
         &mut self,
         parent: *mut DirTask,
         path: &ZStr,
+        #[cfg(unix)] name: &ZStr,
+        #[cfg(unix)] expected_id: FileId,
         is_absolute: bool,
         buf: &mut bun_paths::PathBuffer,
     ) -> bun_sys::Maybe<()> {
         if self.child_of_dir {
+            #[cfg(unix)]
+            self.task.enqueue_no_join(
+                parent,
+                ZBox::from_bytes(path.as_bytes()),
+                ZBox::from_bytes(name.as_bytes()),
+                EntryKindHint::Dir,
+                expected_id,
+            );
+            #[cfg(not(unix))]
             self.task.enqueue_no_join(
                 parent,
                 ZBox::from_bytes(path.as_bytes()),
@@ -1741,6 +2189,8 @@ impl RemoveFileHandler for RemoveFileParent {
         &mut self,
         _: *mut DirTask,
         _: &ZStr,
+        #[cfg(unix)] _: &ZStr,
+        #[cfg(unix)] _: FileId,
         _: bool,
         _: &mut bun_paths::PathBuffer,
     ) -> bun_sys::Maybe<()> {
@@ -1752,6 +2202,8 @@ impl RemoveFileHandler for RemoveFileParent {
         &mut self,
         parent: *mut DirTask,
         path: &ZStr,
+        #[cfg(unix)] name: &ZStr,
+        #[cfg(unix)] expected_id: FileId,
         _: bool,
         _: &mut bun_paths::PathBuffer,
     ) -> bun_sys::Maybe<()> {
@@ -1760,6 +2212,15 @@ impl RemoveFileHandler for RemoveFileParent {
             // SAFETY: `parent` is a live DirTask; `task_manager` is live until
             // `pending_main_callbacks` hits 0.
             let task = unsafe { &*(*parent).task_manager };
+            #[cfg(unix)]
+            task.enqueue_no_join(
+                parent,
+                ZBox::from_bytes(path.as_bytes()),
+                ZBox::from_bytes(name.as_bytes()),
+                EntryKindHint::Dir,
+                expected_id,
+            );
+            #[cfg(not(unix))]
             task.enqueue_no_join(
                 parent,
                 ZBox::from_bytes(path.as_bytes()),

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -224,22 +224,6 @@ test.skipIf(process.platform === "win32")(
   },
 );
 
-// The walker hands multi-component relative paths to asynchronous worker
-// tasks ("target/sub/inner/f.txt") and each deletion syscall must not
-// re-resolve that path from the original cwd. If an *intermediate* component
-// ("sub") is replaced by a symlink after the walker has already opened and
-// validated it, a path-based deletion of anything below it follows the link
-// and lands outside the tree being removed. The extra "inner" nesting level
-// is what makes the swapped component intermediate rather than final — the
-// final-component case is covered by the test above.
-//
-// To make the race land reliably, "sub" contains a sacrificial "canary.txt"
-// that the walker unlinks inline while iterating "sub". Once the canary is
-// gone, "sub" has been opened and "inner" has been (or is about to be) handed
-// to another worker as the multi-component path "target/sub/inner" — swapping
-// "sub" at that point cannot interfere with "sub"'s own open, but every
-// subsequent path-based deletion below it resolves through the symlink into
-// the victim, which holds entries with the same names.
 test.skipIf(process.platform === "win32")(
   "recursive rm does not unlink files through a swapped intermediate path component",
   async () => {
@@ -262,11 +246,6 @@ test.skipIf(process.platform === "win32")(
       const entry = path.join(target, "sub");
       const canary = path.join(entry, "canary.txt");
 
-      // Start the recursive delete on the worker pool. The worker threads
-      // make progress concurrently with this (synchronous) JS code: wait
-      // until the walker has opened "sub" and unlinked the canary, then swap
-      // "sub" for a symlink to the victim while the deletion of
-      // "target/sub/inner/*" is still pending.
       const running = $`rm -rf ${target}`.nothrow().quiet().run();
       const deadline = Date.now() + 10_000;
       while (existsSync(canary) && Date.now() < deadline) {}
@@ -274,16 +253,9 @@ test.skipIf(process.platform === "win32")(
         renameSync(entry, path.join(root, "stash", "sub"));
         symlinkSync(victimDir, entry);
         swapped++;
-      } catch {
-        // The walker already deleted the whole subtree; nothing to race.
-      }
+      } catch {}
       const result = await running;
 
-      // A swapped-out component means the entry is already gone from the
-      // tree being removed; under -f that is not an error. One benign
-      // exception: if the symlink lands only after the walker has already
-      // emptied "target", the re-created "sub" entry correctly fails the
-      // final rmdir of the root operand with ENOTEMPTY.
       const stderrText = result.stderr.toString();
       if (stderrText === `rm: ${target}: Directory not empty\n`) {
         expect(result.exitCode).toBe(1);
@@ -292,24 +264,15 @@ test.skipIf(process.platform === "win32")(
         expect(result.exitCode).toBe(0);
       }
 
-      // Every victim file shares its basename with a file the walker was
-      // told to delete; none of them may be reachable through the swapped
-      // component.
       for (let j = 0; j < FILLER; j++) {
         expect(existsSync(path.join(victimDir, "inner", `f${j}.txt`))).toBeTrue();
       }
       expect(existsSync(victimDir)).toBeTrue();
     }
-    // If no swap ever landed while the walker was mid-flight, the loop above
-    // exercised nothing and the canary probe is broken.
     expect(swapped).toBeGreaterThan(0);
   },
 );
 
-// Same shape as the test above, but the leaves are empty directories so the
-// racing deletion is the rmdir each worker issues for a directory it has
-// finished with. That rmdir must also be addressed relative to a validated
-// parent directory fd rather than re-resolving the full multi-component path.
 test.skipIf(process.platform === "win32")(
   "recursive rm does not rmdir through a swapped intermediate path component",
   async () => {
@@ -339,16 +302,9 @@ test.skipIf(process.platform === "win32")(
         renameSync(entry, path.join(root, "stash", "sub"));
         symlinkSync(victimDir, entry);
         swapped++;
-      } catch {
-        // The walker already deleted the whole subtree; nothing to race.
-      }
+      } catch {}
       const result = await running;
 
-      // A swapped-out component means the entry is already gone from the
-      // tree being removed; under -f that is not an error. One benign
-      // exception: if the symlink lands only after the walker has already
-      // emptied "target", the re-created "sub" entry correctly fails the
-      // final rmdir of the root operand with ENOTEMPTY.
       const stderrText = result.stderr.toString();
       if (stderrText === `rm: ${target}: Directory not empty\n`) {
         expect(result.exitCode).toBe(1);
@@ -357,9 +313,6 @@ test.skipIf(process.platform === "win32")(
         expect(result.exitCode).toBe(0);
       }
 
-      // Every victim leaf directory shares its name with one the walker was
-      // told to remove; none of them may be reachable through the swapped
-      // component.
       for (let j = 0; j < FILLER; j++) {
         expect(existsSync(path.join(victimDir, "inner", `leaf${j}`))).toBeTrue();
       }

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -223,3 +223,124 @@ test.skipIf(process.platform === "win32")(
     }
   },
 );
+
+// The walker hands multi-component relative paths to asynchronous worker
+// tasks ("target/sub/inner/f.txt") and each deletion syscall must not
+// re-resolve that path from the original cwd. If an *intermediate* component
+// ("sub") is replaced by a symlink after the walker has already opened and
+// validated it, a path-based deletion of anything below it follows the link
+// and lands outside the tree being removed. The extra "inner" nesting level
+// is what makes the swapped component intermediate rather than final — the
+// final-component case is covered by the test above.
+//
+// To make the race land reliably, "sub" contains a sacrificial "canary.txt"
+// that the walker unlinks inline while iterating "sub". Once the canary is
+// gone, "sub" has been opened and "inner" has been (or is about to be) handed
+// to another worker as the multi-component path "target/sub/inner" — swapping
+// "sub" at that point cannot interfere with "sub"'s own open, but every
+// subsequent path-based deletion below it resolves through the symlink into
+// the victim, which holds entries with the same names.
+test.skipIf(process.platform === "win32")(
+  "recursive rm does not unlink files through a swapped intermediate path component",
+  async () => {
+    const FILLER = 128;
+    const ITERATIONS = 5;
+
+    let swapped = 0;
+    for (let iter = 0; iter < ITERATIONS; iter++) {
+      const files: Record<string, string> = {
+        "stash/.keep": "",
+        "target/sub/canary.txt": "",
+      };
+      for (let j = 0; j < FILLER; j++) {
+        files[`victim/inner/f${j}.txt`] = "important";
+        files[`target/sub/inner/f${j}.txt`] = "";
+      }
+      const root = tempDirWithFiles(`rm-swap-mid-${iter}`, files);
+      const victimDir = path.join(root, "victim");
+      const target = path.join(root, "target");
+      const entry = path.join(target, "sub");
+      const canary = path.join(entry, "canary.txt");
+
+      // Start the recursive delete on the worker pool. The worker threads
+      // make progress concurrently with this (synchronous) JS code: wait
+      // until the walker has opened "sub" and unlinked the canary, then swap
+      // "sub" for a symlink to the victim while the deletion of
+      // "target/sub/inner/*" is still pending.
+      const running = $`rm -rf ${target}`.nothrow().quiet().run();
+      const deadline = Date.now() + 10_000;
+      while (existsSync(canary) && Date.now() < deadline) {}
+      try {
+        renameSync(entry, path.join(root, "stash", "sub"));
+        symlinkSync(victimDir, entry);
+        swapped++;
+      } catch {
+        // The walker already deleted the whole subtree; nothing to race.
+      }
+      await running;
+
+      // Every victim file shares its basename with a file the walker was
+      // told to delete; none of them may be reachable through the swapped
+      // component.
+      for (let j = 0; j < FILLER; j++) {
+        expect(existsSync(path.join(victimDir, "inner", `f${j}.txt`))).toBeTrue();
+      }
+      expect(existsSync(victimDir)).toBeTrue();
+    }
+    // If no swap ever landed while the walker was mid-flight, the loop above
+    // exercised nothing and the canary probe is broken.
+    expect(swapped).toBeGreaterThan(0);
+  },
+  60_000,
+);
+
+// Same shape as the test above, but the leaves are empty directories so the
+// racing deletion is the rmdir each worker issues for a directory it has
+// finished with. That rmdir must also be addressed relative to a validated
+// parent directory fd rather than re-resolving the full multi-component path.
+test.skipIf(process.platform === "win32")(
+  "recursive rm does not rmdir through a swapped intermediate path component",
+  async () => {
+    const FILLER = 64;
+    const ITERATIONS = 5;
+
+    let swapped = 0;
+    for (let iter = 0; iter < ITERATIONS; iter++) {
+      const files: import("harness").DirectoryTree = {
+        "stash/.keep": "",
+        "target/sub/canary.txt": "",
+      };
+      for (let j = 0; j < FILLER; j++) {
+        files[`victim/inner/leaf${j}`] = {};
+        files[`target/sub/inner/leaf${j}`] = {};
+      }
+      const root = tempDirWithFiles(`rm-swap-rmdir-${iter}`, files);
+      const victimDir = path.join(root, "victim");
+      const target = path.join(root, "target");
+      const entry = path.join(target, "sub");
+      const canary = path.join(entry, "canary.txt");
+
+      const running = $`rm -rf ${target}`.nothrow().quiet().run();
+      const deadline = Date.now() + 10_000;
+      while (existsSync(canary) && Date.now() < deadline) {}
+      try {
+        renameSync(entry, path.join(root, "stash", "sub"));
+        symlinkSync(victimDir, entry);
+        swapped++;
+      } catch {
+        // The walker already deleted the whole subtree; nothing to race.
+      }
+      await running;
+
+      // Every victim leaf directory shares its name with one the walker was
+      // told to remove; none of them may be reachable through the swapped
+      // component.
+      for (let j = 0; j < FILLER; j++) {
+        expect(existsSync(path.join(victimDir, "inner", `leaf${j}`))).toBeTrue();
+      }
+      expect(existsSync(victimDir)).toBeTrue();
+    }
+    expect(swapped).toBeGreaterThan(0);
+  },
+  60_000,
+);

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -277,7 +277,12 @@ test.skipIf(process.platform === "win32")(
       } catch {
         // The walker already deleted the whole subtree; nothing to race.
       }
-      await running;
+      const result = await running;
+
+      // A swapped-out component means the entry is already gone from the
+      // tree being removed; under -f that is not an error.
+      expect(result.stderr.toString()).toBe("");
+      expect(result.exitCode).toBe(0);
 
       // Every victim file shares its basename with a file the walker was
       // told to delete; none of them may be reachable through the swapped
@@ -329,7 +334,12 @@ test.skipIf(process.platform === "win32")(
       } catch {
         // The walker already deleted the whole subtree; nothing to race.
       }
-      await running;
+      const result = await running;
+
+      // A swapped-out component means the entry is already gone from the
+      // tree being removed; under -f that is not an error.
+      expect(result.stderr.toString()).toBe("");
+      expect(result.exitCode).toBe(0);
 
       // Every victim leaf directory shares its name with one the walker was
       // told to remove; none of them may be reachable through the swapped

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -291,7 +291,6 @@ test.skipIf(process.platform === "win32")(
     // exercised nothing and the canary probe is broken.
     expect(swapped).toBeGreaterThan(0);
   },
-  60_000,
 );
 
 // Same shape as the test above, but the leaves are empty directories so the
@@ -342,5 +341,4 @@ test.skipIf(process.platform === "win32")(
     }
     expect(swapped).toBeGreaterThan(0);
   },
-  60_000,
 );

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -280,9 +280,17 @@ test.skipIf(process.platform === "win32")(
       const result = await running;
 
       // A swapped-out component means the entry is already gone from the
-      // tree being removed; under -f that is not an error.
-      expect(result.stderr.toString()).toBe("");
-      expect(result.exitCode).toBe(0);
+      // tree being removed; under -f that is not an error. One benign
+      // exception: if the symlink lands only after the walker has already
+      // emptied "target", the re-created "sub" entry correctly fails the
+      // final rmdir of the root operand with ENOTEMPTY.
+      const stderrText = result.stderr.toString();
+      if (stderrText === `rm: ${target}: Directory not empty\n`) {
+        expect(result.exitCode).toBe(1);
+      } else {
+        expect(stderrText).toBe("");
+        expect(result.exitCode).toBe(0);
+      }
 
       // Every victim file shares its basename with a file the walker was
       // told to delete; none of them may be reachable through the swapped
@@ -337,9 +345,17 @@ test.skipIf(process.platform === "win32")(
       const result = await running;
 
       // A swapped-out component means the entry is already gone from the
-      // tree being removed; under -f that is not an error.
-      expect(result.stderr.toString()).toBe("");
-      expect(result.exitCode).toBe(0);
+      // tree being removed; under -f that is not an error. One benign
+      // exception: if the symlink lands only after the walker has already
+      // emptied "target", the re-created "sub" entry correctly fails the
+      // final rmdir of the root operand with ENOTEMPTY.
+      const stderrText = result.stderr.toString();
+      if (stderrText === `rm: ${target}: Directory not empty\n`) {
+        expect(result.exitCode).toBe(1);
+      } else {
+        expect(stderrText).toBe("");
+        expect(result.exitCode).toBe(0);
+      }
 
       // Every victim leaf directory shares its name with one the walker was
       // told to remove; none of them may be reachable through the swapped


### PR DESCRIPTION
Recursive `rm` in the Bun shell issued every unlink and rmdir against the original cwd fd with the full multi-component relative path accumulated during traversal, so the kernel re-resolved every intermediate component on each deletion syscall. This change unlinks file entries through the already-open parent directory fd plus the single entry name, records each discovered subdirectory's dev/ino identity through that fd and re-checks it after the child task re-opens the directory by path, and performs each directory's final rmdir as `unlinkat(parent_fd, name, AT_REMOVEDIR)` against a freshly opened, identity-verified parent. Display paths for errors and `-v` output are unchanged, and the identity verification is POSIX-only (Windows keeps the existing cwd-relative form).

Adds two tests to `test/js/bun/shell/commands/rm.test.ts` that rename an already-traversed directory out from under the walker and replace it with a symlink while deletions beneath it are still in flight, asserting the link target's contents survive. The existing recursive/verbose/node_modules/fd-leak rm tests pass unchanged.