### PR TITLE
shell: require $.raw() for unescaped template interpolation

### DIFF
--- a/docs/runtime/shell.mdx
+++ b/docs/runtime/shell.mdx
@@ -514,16 +514,18 @@ console.log($.escape('$(foo) `bar` "baz"'));
 // => \$(foo) \`bar\` \"baz\"
 ```
 
-If you do not want your string to be escaped, wrap it in a `{ raw: 'str' }` object:
+If you do not want your string to be escaped, wrap it with `$.raw()`:
 
 ```js
 import { $ } from "bun";
 
-await $`echo ${{ raw: '$(foo) `bar` "baz"' }}`;
+await $`echo ${$.raw('$(foo) `bar` "baz"')}`;
 // => bun: command not found: foo
 // => bun: command not found: bar
 // => baz
 ```
+
+Plain `{ raw: '...' }` object literals are rejected with a `TypeError`. Any attacker-shaped object — a parsed JSON body, a `qs`-parsed query string — could otherwise set a `raw` property and smuggle unescaped shell syntax into your command. Only objects returned by `$.raw()` carry the internal brand that opts out of escaping.
 
 ---
 

--- a/packages/bun-release/scripts/upload-npm.ts
+++ b/packages/bun-release/scripts/upload-npm.ts
@@ -282,7 +282,7 @@ async function test() {
     });
 
     console.log("Testing", install + " bun");
-    await $`${{ raw: install }} ./bun-${version}.tgz`;
+    await $`${Bun.$.raw(install)} ./bun-${version}.tgz`;
 
     console.log("Running " + exec + " bun");
 

--- a/packages/bun-types/shell.d.ts
+++ b/packages/bun-types/shell.d.ts
@@ -3,6 +3,11 @@ declare module "bun" {
     | { toString(): string }
     | Array<ShellExpression>
     | string
+    /**
+     * Raw, unescaped shell syntax. Only objects returned by {@link $.raw} are
+     * accepted at runtime; plain `{ raw: string }` object literals throw a
+     * `TypeError` because they could be forged by untrusted data.
+     */
     | { raw: string }
     | Subprocess<SpawnOptions.Writable, SpawnOptions.Readable, SpawnOptions.Readable>
     | SpawnOptions.Readable
@@ -42,6 +47,25 @@ declare module "bun" {
      * @param input
      */
     function escape(input: string): string;
+
+    /**
+     * Mark a string as raw shell syntax so it is interpolated without
+     * escaping. This is the only supported way to opt out of escaping:
+     * the returned object carries an internal brand that plain
+     * `{ raw: string }` object literals do not have, so untrusted data
+     * (JSON bodies, parsed query strings) cannot forge it.
+     *
+     * @param str - Raw shell syntax to splice into the command
+     *
+     * @example
+     * ```js
+     * import { $ } from "bun";
+     * await $`echo a ${$.raw("&& echo b")}`;
+     * // a
+     * // b
+     * ```
+     */
+    function raw(str: string): { raw: string };
 
     /**
      *

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -183,6 +183,7 @@ using namespace JSC;
     macro(sameSite) \
     macro(secure) \
     macro(self) \
+    macro(shellRaw) \
     macro(signal) \
     macro(sink) \
     macro(size) \

--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -342,10 +342,8 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
 
   /**
    * Returns an object that interpolates into a shell template literal as raw,
-   * unescaped shell syntax. The string is also stored under a private symbol
-   * that user code cannot read, copy, or forge -- the native side only honors
-   * that private brand, so attacker-shaped plain objects (e.g. JSON bodies or
-   * parsed query strings containing a `raw` key) cannot opt out of escaping.
+   * unescaped shell syntax. The native side only honors the private-symbol
+   * brand set here, so a plain `{ raw }` object cannot opt out of escaping.
    */
   function shellRaw(str) {
     if (typeof str !== "string") {

--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -340,6 +340,25 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     return Shell;
   }
 
+  /**
+   * Returns an object that interpolates into a shell template literal as raw,
+   * unescaped shell syntax. The string is also stored under a private symbol
+   * that user code cannot read, copy, or forge -- the native side only honors
+   * that private brand, so attacker-shaped plain objects (e.g. JSON bodies or
+   * parsed query strings containing a `raw` key) cannot opt out of escaping.
+   */
+  function shellRaw(str) {
+    if (typeof str !== "string") {
+      throw new TypeError("$.raw() expects a string");
+    }
+    // Keep a public `raw` data property for `{ raw: string }` structural
+    // typing, but splice the value stored under the private symbol so a later
+    // mutation of `.raw` cannot change what executes.
+    const obj = { raw: str };
+    $putByIdDirectPrivate(obj, "shellRaw", str);
+    return obj;
+  }
+
   Shell.prototype = ShellPrototype.prototype;
   Object.setPrototypeOf(Shell, ShellPrototype);
   Object.setPrototypeOf(BunShell, ShellPrototype.prototype);
@@ -359,6 +378,10 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     },
     ShellError: {
       value: ShellError,
+      enumerable: true,
+    },
+    raw: {
+      value: shellRaw,
       enumerable: true,
     },
   });

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5123,6 +5123,7 @@ enum class BuiltinNamesMap : uint8_t {
     type,
     signal,
     cmd,
+    shellRaw,
 };
 
 static inline const JSC::Identifier& builtinNameMap(JSC::VM& vm, unsigned char name)
@@ -5201,6 +5202,12 @@ static inline const JSC::Identifier& builtinNameMap(JSC::VM& vm, unsigned char n
     }
     case BuiltinNamesMap::cmd: {
         return clientData->builtinNames().cmdPublicName();
+    }
+    case BuiltinNamesMap::shellRaw: {
+        // Deliberately the *private* name: the brand is stored via
+        // @putByIdDirectPrivate in shell.ts and must not be forgeable from
+        // user JS through an ordinary string-keyed property.
+        return clientData->builtinNames().shellRawPrivateName();
     }
     default: {
         ASSERT_NOT_REACHED();

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5204,9 +5204,7 @@ static inline const JSC::Identifier& builtinNameMap(JSC::VM& vm, unsigned char n
         return clientData->builtinNames().cmdPublicName();
     }
     case BuiltinNamesMap::shellRaw: {
-        // Deliberately the *private* name: the brand is stored via
-        // @putByIdDirectPrivate in shell.ts and must not be forgeable from
-        // user JS through an ordinary string-keyed property.
+        // Deliberately the private name: the $.raw() brand must not be forgeable from user JS.
         return clientData->builtinNames().shellRawPrivateName();
     }
     default: {

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1322,10 +1322,8 @@ pub enum BuiltinName {
     type_,
     signal,
     cmd,
-    /// Resolves to the *private* `shellRaw` identifier on the C++ side
-    /// (`builtinNameMap` in bindings.cpp). Used as an unforgeable brand for
-    /// `Bun.$.raw()` objects; deliberately absent from `BUILTIN_NAME_MAP`
-    /// because it does not correspond to a public string-keyed property.
+    /// The *private* `shellRaw` identifier (the `Bun.$.raw()` brand).
+    /// Deliberately absent from `BUILTIN_NAME_MAP`: it has no public string key.
     shellRaw,
 }
 

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1322,6 +1322,11 @@ pub enum BuiltinName {
     type_,
     signal,
     cmd,
+    /// Resolves to the *private* `shellRaw` identifier on the C++ side
+    /// (`builtinNameMap` in bindings.cpp). Used as an unforgeable brand for
+    /// `Bun.$.raw()` objects; deliberately absent from `BUILTIN_NAME_MAP`
+    /// because it does not correspond to a public string-keyed property.
+    shellRaw,
 }
 
 #[allow(non_upper_case_globals)]

--- a/src/node-fallbacks/build-fallbacks.ts
+++ b/src/node-fallbacks/build-fallbacks.ts
@@ -24,15 +24,16 @@ for (let fileIndex = 0; fileIndex < allFiles.length; fileIndex++) {
     externals.splice(i, 1);
   }
 
-  // Build all files at once with specific options
+  // Build all files at once with specific options. Interpolating the array
+  // makes the shell escape each flag as its own word, so no raw splice is
+  // needed (and `${{ raw: ... }}` is no longer accepted).
   const externalModules = builtins
     .concat(moduleFiles.filter(f => f !== name))
-    .flatMap(b => [`--external:node:${b}`, `--external:${b}`])
-    .join(" ");
+    .flatMap(b => [`--external:node:${b}`, `--external:${b}`]);
 
   // Create the build command with all the specified options
   const buildCommand =
-    Bun.$`bun build --define=process.env.NODE_DEBUG:"false" --define=process.env.READABLE_STREAM="'enable'" --define=global:globalThis --outdir=${outdir} ${name} --minify-syntax --minify-whitespace --format=${name.includes("stream") ? "cjs" : "esm"} --target=node ${{ raw: externalModules }}`.text();
+    Bun.$`bun build --define=process.env.NODE_DEBUG:"false" --define=process.env.READABLE_STREAM="'enable'" --define=global:globalThis --outdir=${outdir} ${name} --minify-syntax --minify-whitespace --format=${name.includes("stream") ? "cjs" : "esm"} --target=node ${externalModules}`.text();
 
   commands.push(
     buildCommand.then(async text => {

--- a/src/node-fallbacks/build-fallbacks.ts
+++ b/src/node-fallbacks/build-fallbacks.ts
@@ -24,9 +24,7 @@ for (let fileIndex = 0; fileIndex < allFiles.length; fileIndex++) {
     externals.splice(i, 1);
   }
 
-  // Build all files at once with specific options. Interpolating the array
-  // makes the shell escape each flag as its own word, so no raw splice is
-  // needed (and `${{ raw: ... }}` is no longer accepted).
+  // Build all files at once with specific options
   const externalModules = builtins
     .concat(moduleFiles.filter(f => f !== name))
     .flatMap(b => [`--external:node:${b}`, `--external:${b}`]);

--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -895,10 +895,8 @@ pub fn handle_template_value(
         }
 
         if template_value.is_object() {
-            // Raw (unescaped) interpolation is gated on a private-symbol brand
-            // that only `Bun.$.raw()` (shell.ts) can set. A string-keyed `raw`
-            // property is forgeable by attacker-shaped data (JSON bodies,
-            // qs-parsed query strings), so it must not opt out of escaping.
+            // Raw (unescaped) interpolation is gated on a private-symbol brand that
+            // only `Bun.$.raw()` can set; a string-keyed `raw` property is forgeable.
             if let Some(raw_str) = template_value.fast_get(global, jsc::BuiltinName::shellRaw)? {
                 let bunstr = OwnedString::new(raw_str.to_bun_string(global)?);
 
@@ -920,9 +918,6 @@ pub fn handle_template_value(
                 return Ok(());
             }
 
-            // Legacy `{ raw: ... }` plain objects used to be spliced in
-            // unescaped. Throw an actionable error instead of either silently
-            // injecting or silently changing the semantics to escaped.
             if template_value.get_own_truthy(global, "raw")?.is_some() {
                 return Err(global
                     .err(

--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -895,8 +895,12 @@ pub fn handle_template_value(
         }
 
         if template_value.is_object() {
-            if let Some(maybe_str) = template_value.get_own_truthy(global, "raw")? {
-                let bunstr = OwnedString::new(maybe_str.to_bun_string(global)?);
+            // Raw (unescaped) interpolation is gated on a private-symbol brand
+            // that only `Bun.$.raw()` (shell.ts) can set. A string-keyed `raw`
+            // property is forgeable by attacker-shaped data (JSON bodies,
+            // qs-parsed query strings), so it must not opt out of escaping.
+            if let Some(raw_str) = template_value.fast_get(global, jsc::BuiltinName::shellRaw)? {
+                let bunstr = OwnedString::new(raw_str.to_bun_string(global)?);
 
                 // Check for null bytes in shell argument (security: prevent null byte injection)
                 if bunstr.index_of_ascii_char(0).is_some() {
@@ -914,6 +918,20 @@ pub fn handle_template_value(
                     );
                 }
                 return Ok(());
+            }
+
+            // Legacy `{ raw: ... }` plain objects used to be spliced in
+            // unescaped. Throw an actionable error instead of either silently
+            // injecting or silently changing the semantics to escaped.
+            if template_value.get_own_truthy(global, "raw")?.is_some() {
+                return Err(global
+                    .err(
+                        jsc::ErrorCode::INVALID_ARG_TYPE,
+                        format_args!(
+                            "Plain objects with a `raw` property are no longer interpolated as raw shell syntax. Use Bun.$.raw(string) to opt into unescaped interpolation."
+                        ),
+                    )
+                    .throw());
             }
         }
 

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -6,7 +6,7 @@
  */
 import { $ } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
-import { chmodSync, mkdirSync } from "fs";
+import { chmodSync, existsSync, mkdirSync } from "fs";
 import { mkdir, rm, stat } from "fs/promises";
 import { bunExe, isPosix, isWindows, runWithErrorPromise, tempDirWithFiles, tmpdirSync } from "harness";
 import { join, sep } from "path";
@@ -81,7 +81,7 @@ describe("bunshell", () => {
 
     failing_cmds.forEach(cmdstr =>
       !!cmdstr
-        ? TestBuilder.command`${{ raw: cmdstr }}`
+        ? TestBuilder.command`${$.raw(cmdstr)}`
             .exitCode(c => c !== 0)
             .stdout(() => {})
             .stderr(() => {})
@@ -172,6 +172,44 @@ describe("bunshell", () => {
     });
   });
 
+  describe("raw interpolation", () => {
+    test("JSON-shaped { raw } object throws instead of injecting", () => {
+      const dir = tempDirWithFiles("raw-inject", {});
+      const marker = join(dir, "pwned");
+      const payload = JSON.parse(`{"file": {"raw": "; touch ${JSON.stringify(marker).slice(1, -1)}"}}`);
+      expect(() => $`ls ${payload.file}`).toThrow(/\$\.raw/);
+      expect(existsSync(marker)).toBe(false);
+    });
+
+    test("plain object literal with truthy raw throws", () => {
+      expect(() => $`echo ${{ raw: "; echo injected" } as any}`).toThrow(/no longer interpolated as raw shell syntax/);
+    });
+
+    test("the brand cannot be forged by copying a branded object", () => {
+      const legit = $.raw("x");
+      expect(Object.getOwnPropertySymbols(legit)).toHaveLength(0);
+      const forged = { ...legit, raw: "; echo injected" };
+      expect(() => $`echo ${forged}`).toThrow(/no longer interpolated as raw shell syntax/);
+    });
+
+    test("null bytes still rejected on the raw path", () => {
+      expect(() => $`echo ${$.raw("a\0b")}`).toThrow(/must be a string without null bytes/);
+    });
+
+    test("$.raw rejects non-strings", () => {
+      expect(() => $.raw(123 as any)).toThrow("$.raw() expects a string");
+    });
+
+    test("$.raw interpolates unescaped shell syntax", async () => {
+      const { stdout } = await $`echo a ${$.raw("&& echo b")}`;
+      expect(stdout.toString()).toBe("a\nb\n");
+    });
+
+    test("$.raw return value exposes .raw", () => {
+      expect($.raw("x").raw).toBe("x");
+    });
+  });
+
   describe("quiet", async () => {
     test("basic", async () => {
       // Check its buffered
@@ -253,7 +291,7 @@ describe("bunshell", () => {
   describe("echo+cmdsubst edgecases", async () => {
     async function doTest(cmd: string, expected: string) {
       test(cmd, async () => {
-        const { stdout } = await $`${{ raw: cmd }}`;
+        const { stdout } = await $`${$.raw(cmd)}`;
         expect(stdout.toString()).toEqual(expected);
       });
     }
@@ -518,9 +556,9 @@ describe("bunshell", () => {
   // I'm not sure why, this isn't documented behavior, so I'm choosing to ignore it.
   describe("gnu_quote", () => {
     // An unfortunate consequence of our use of String.raw and tagged template
-    // functions for the shell make it so that we have to use { raw: string } to do
+    // functions for the shell make it so that we have to use $.raw() to do
     // backtick command substitution
-    const BACKTICK = { raw: "`" };
+    const BACKTICK = $.raw("`");
 
     // Single Quote
     TestBuilder.command`
@@ -796,7 +834,7 @@ booga"
   describe("brace expansion", () => {
     function doTest(pattern: string, expected: string) {
       test(pattern, async () => {
-        const { stdout } = await $`echo ${{ raw: pattern }} `;
+        const { stdout } = await $`echo ${$.raw(pattern)} `;
         expect(stdout.toString()).toEqual(`${expected}\n`);
       });
     }
@@ -1740,20 +1778,20 @@ fi
     .runAsTest("multi statement in all branches");
 
   ["if", "else", "elif", "then", "fi"].map(tok => {
-    TestBuilder.command`"${{ raw: tok }}"`
+    TestBuilder.command`"${$.raw(tok)}"`
       .stderr(`bun: command not found: ${tok}\n`)
       .exitCode(1)
       .runAsTest(`quoted ${tok} doesn't break`);
 
-    TestBuilder.command`echo ${{ raw: "lksdfjklsdjf" + tok }}`
+    TestBuilder.command`echo ${$.raw("lksdfjklsdjf" + tok)}`
       .stdout(`lksdfjklsdjf${tok}\n`)
       .runAsTest(`${tok} in script does not break parsing 1`);
 
-    TestBuilder.command`echo ${{ raw: "hi " + tok }}`
+    TestBuilder.command`echo ${$.raw("hi " + tok)}`
       .stdout(`hi ${tok}\n`)
       .runAsTest(`${tok} in script does not break parsing 2`);
 
-    TestBuilder.command`echo ${{ raw: tok + " hi" }}`
+    TestBuilder.command`echo ${$.raw(tok + " hi")}`
       .stdout(`${tok} hi\n`)
       .runAsTest(`${tok} in script does not break parsing 3`);
   });
@@ -1862,12 +1900,12 @@ fi
       .todo("! not supported")
       .runAsTest("execution path of if-elif-elif-else, false-false-false");
 
-    const exit = (code: number): { raw: string } => ({
-      raw:
+    const exit = (code: number): ReturnType<typeof $.raw> =>
+      $.raw(
         process.platform !== "win32"
           ? `bash -c 'exit $1' -- ${code}`
           : `BUN_DEBUG_QUIET_LOGS=1 ${BUN} -e 'process.exit(${code})'`,
-    });
+      );
 
     // test_x -e 0 'exit status of if, true-true'
     TestBuilder.command`if ${exit(0)}; then ${exit(0)}; fi`.exitCode(0).runAsTest("exit status of if, true-true");

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -64,7 +64,7 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
     TestBuilder.command /* sh */ `
     echo hi! > hello.txt
     mkdir somedir 
-    cp ${{ raw: Array(50).fill("hello.txt").join(" ") }} somedir 
+    cp ${$.raw(Array(50).fill("hello.txt").join(" "))} somedir 
     `
       .ensureTempDir()
       .exitCode(0)

--- a/test/js/bun/shell/env.positionals.test.ts
+++ b/test/js/bun/shell/env.positionals.test.ts
@@ -9,7 +9,7 @@ $.nothrow();
 describe("$ argv", async () => {
   for (let i = 0; i < process.argv.length; i++) {
     const element = process.argv[i];
-    TestBuilder.command`echo $${{ raw: i }}`
+    TestBuilder.command`echo $${$.raw(String(i))}`
       .exitCode(0)
       .stdout(process.argv[i] + "\n")
       .runAsTest(`$${i} should equal process.argv[${i}]`);

--- a/test/js/bun/shell/exec.test.ts
+++ b/test/js/bun/shell/exec.test.ts
@@ -23,7 +23,7 @@ describe("bun exec", () => {
     )
     .runAsTest("no args prints help text");
 
-  TestBuilder.command`${BUN} exec ${{ raw: Bun.$.escape(`echo 'hi "there bud"'`) }}`
+  TestBuilder.command`${BUN} exec ${$.raw(Bun.$.escape(`echo 'hi "there bud"'`))}`
     .stdout('hi "there bud"\n')
     .runAsTest("it works2");
 

--- a/test/js/bun/shell/lex.test.ts
+++ b/test/js/bun/shell/lex.test.ts
@@ -735,8 +735,8 @@ describe("lex shell", () => {
         .exitCode(1)
         .run();
 
-      await TestBuilder.command`echo hi && ${{ raw: "`echo uh oh" }}`.error("Unclosed command substitution").run();
-      await TestBuilder.command`echo hi && ${{ raw: "`echo uh oh`" }}`
+      await TestBuilder.command`echo hi && ${$.raw("`echo uh oh")}`.error("Unclosed command substitution").run();
+      await TestBuilder.command`echo hi && ${$.raw("`echo uh oh`")}`
         .stdout("hi\n")
         .stderr("bun: command not found: uh\n")
         .exitCode(1)

--- a/test/js/bun/shell/shell-blocking-pipe.test.ts
+++ b/test/js/bun/shell/shell-blocking-pipe.test.ts
@@ -9,9 +9,7 @@ import { isWindows } from "harness";
 test.skipIf(isWindows)("writing > send buffer size doesn't block the main thread", async () => {
   const expected = Buffer.alloc(1024 * 1024, "bun!").toString();
   const massiveComamnd = "echo " + expected + " | " + Bun.which("cat");
-  const pendingResult = $`${{
-    raw: massiveComamnd,
-  }}`.text();
+  const pendingResult = $`${$.raw(massiveComamnd)}`.text();
 
   // Ensure that heap snapshot works, to excercise the memoryCost & estimated fields.
   generateHeapSnapshot("v8");

--- a/test/js/bun/shell/shell-leak-args.test.ts
+++ b/test/js/bun/shell/shell-leak-args.test.ts
@@ -6,13 +6,13 @@ test("shell parsing error does not leak emmory", async () => {
   const buffer = Buffer.alloc(1024 * 1024, "A").toString();
   for (let i = 0; i < 5; i++) {
     try {
-      $`${{ raw: buffer }} <!INVALID ==== SYNTAX!>`;
+      $`${$.raw(buffer)} <!INVALID ==== SYNTAX!>`;
     } catch (e) {}
   }
   const rss = process.memoryUsage.rss();
   for (let i = 0; i < 200; i++) {
     try {
-      $`${{ raw: buffer }} <!INVALID ==== SYNTAX!>`;
+      $`${$.raw(buffer)} <!INVALID ==== SYNTAX!>`;
     } catch (e) {}
   }
   const after = process.memoryUsage.rss() / 1024 / 1024;
@@ -37,11 +37,11 @@ test("shell execution doesn't leak argv", async () => {
   const buffer = Buffer.alloc(1024 * 1024, "bun!").toString();
   const cmd = `echo ${buffer}`;
   for (let i = 0; i < 5; i++) {
-    await $`${{ raw: cmd }}`.quiet();
+    await $`${$.raw(cmd)}`.quiet();
   }
   const rss = process.memoryUsage.rss();
   for (let i = 0; i < 200; i++) {
-    await $`${{ raw: cmd }}`.quiet();
+    await $`${$.raw(cmd)}`.quiet();
   }
   const after = process.memoryUsage.rss() / 1024 / 1024;
   const before = rss / 1024 / 1024;
@@ -62,11 +62,11 @@ test("non-awaited shell command does not leak argv", async () => {
   const buffer = Buffer.alloc(1024 * 1024, "bun!").toString();
   const cmd = `echo ${buffer}`;
   for (let i = 0; i < 5; i++) {
-    $`${{ raw: cmd }}`.quiet();
+    $`${$.raw(cmd)}`.quiet();
   }
   const rss = process.memoryUsage.rss();
   for (let i = 0; i < 200; i++) {
-    $`${{ raw: cmd }}`.quiet();
+    $`${$.raw(cmd)}`.quiet();
   }
   const after = process.memoryUsage.rss() / 1024 / 1024;
   const before = rss / 1024 / 1024;

--- a/test/js/bun/shell/shell-sentinel-hardening.test.ts
+++ b/test/js/bun/shell/shell-sentinel-hardening.test.ts
@@ -35,7 +35,7 @@ describe("shell sentinel character hardening", () => {
     const testScript = [
       'import { $ } from "bun";',
       "const sentinel = String.fromCharCode(8) + '__bun_9999';",
-      "try { await $`echo hello > ${{ raw: sentinel }}`; } catch {}",
+      "try { await $`echo hello > ${$.raw(sentinel)}`; } catch {}",
       'console.log("OK");',
     ].join("\n");
 

--- a/test/js/bun/spawn/null-byte-injection.test.ts
+++ b/test/js/bun/spawn/null-byte-injection.test.ts
@@ -112,7 +112,7 @@ describe("null byte injection protection", () => {
     });
 
     test("throws error when object with raw property contains null byte", () => {
-      const raw = { raw: "test\0value" };
+      const raw = $.raw("test\0value");
       expect(() => $`echo ${raw}`).toThrow(/must be a string without null bytes/);
     });
 

--- a/test/js/bun/test/test-only.test.ts
+++ b/test/js/bun/test/test-only.test.ts
@@ -15,7 +15,7 @@ test.each(["./only-fixture-1.ts", "./only-fixture-2.ts", "./only-fixture-3.ts"])
 
 test("only resets per test", async () => {
   const files = ["./only-fixture-1.ts", "./only-fixture-2.ts", "./only-fixture-3.ts", "./only-fixture-4.ts"];
-  const result = await $.cwd(import.meta.dir)`${bunExe()} test ${{ raw: files.join(" ") }}`.env({
+  const result = await $.cwd(import.meta.dir)`${bunExe()} test ${$.raw(files.join(" "))}`.env({
     ...bunEnv,
     CI: "false",
   });

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -840,7 +840,7 @@ it("process.execArgv", async () => {
 
   for (const [cmd, execArgv, argv] of fixtures) {
     const replacedCmd = cmd.replace("index.ts", Bun.$.escape(join(__dirname, "print-process-execArgv.js")));
-    const result = await Bun.$`${bunExe()} ${{ raw: replacedCmd }}`.json();
+    const result = await Bun.$`${bunExe()} ${Bun.$.raw(replacedCmd)}`.json();
     expect(result, `bun ${cmd}`).toEqual({ execArgv, argv });
   }
 });


### PR DESCRIPTION
Interpolated objects opted out of Bun Shell's escaping whenever they had a truthy own `raw` string property, which meant any plain object shaped that way was spliced into the command as live shell syntax. This adds a `Bun.$.raw(string)` helper that brands its return value with an internal private symbol, makes the native interpolation path honor only that brand, and turns plain `{ raw: ... }` object literals into an actionable `TypeError` pointing at the new helper.

All in-repo `${{ raw: ... }}` interpolations (11 test files plus the npm release script) are migrated to `$.raw()`, the docs and `bun-types` declarations are updated, and a new `raw interpolation` describe block in `bunshell.test.ts` covers the helper's behavior, the rejection of unbranded objects, brand non-copyability via spread, the null-byte check, and the unescaped execution path.