### PR TITLE
parser: fix "Scope mismatch while visiting" panic from decorators on dropped class members

### DIFF
--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -212,7 +212,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             // Parse decorators for this property
             let first_decorator_loc = p.lexer.loc();
-            let decorators_scope_index = p.scopes_in_order.len();
+            let property_scope_index = p.scopes_in_order.len();
             if opts.allow_ts_decorators {
                 opts.ts_decorators = p.parse_type_script_decorators()?;
                 opts.has_class_decorators = class_opts.ts_decorators.len() > 0;
@@ -246,12 +246,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
 
                 has_decorators = has_decorators || opts.has_argument_decorators;
-            } else if opts.ts_decorators.len() > 0 {
+            } else {
                 // The property was dropped (e.g. a TypeScript overload signature or
-                // abstract method), which drops its decorators too. Discard any scopes
-                // recorded while parsing them or the visit pass will hit a scope order
-                // mismatch.
-                p.discard_scopes_up_to(decorators_scope_index);
+                // abstract method), which drops its decorators and computed key too.
+                // Discard any scopes recorded while parsing them or the visit pass
+                // will hit a scope order mismatch.
+                p.discard_scopes_up_to(property_scope_index);
             }
         }
 

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -212,6 +212,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             // Parse decorators for this property
             let first_decorator_loc = p.lexer.loc();
+            let decorators_scope_index = p.scopes_in_order.len();
             if opts.allow_ts_decorators {
                 opts.ts_decorators = p.parse_type_script_decorators()?;
                 opts.has_class_decorators = class_opts.ts_decorators.len() > 0;
@@ -245,6 +246,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
 
                 has_decorators = has_decorators || opts.has_argument_decorators;
+            } else if opts.ts_decorators.len() > 0 {
+                // The property was dropped (e.g. a TypeScript overload signature or
+                // abstract method), which drops its decorators too. Discard any scopes
+                // recorded while parsing them or the visit pass will hit a scope order
+                // mismatch.
+                p.discard_scopes_up_to(decorators_scope_index);
             }
         }
 

--- a/test/bundler/transpiler/scope-mismatch-panic.test.ts
+++ b/test/bundler/transpiler/scope-mismatch-panic.test.ts
@@ -147,12 +147,12 @@ describe("TypeScript 'declare' statements discard scopes of dropped statements",
   });
 });
 
-describe("decorators on dropped TypeScript class members discard scopes", () => {
-  // Decorators are parsed before the class member they decorate. When the member is
-  // then dropped (an overload signature, abstract/declare method, or index signature),
-  // its decorators are dropped too. Scopes recorded while parsing those decorators
-  // (e.g. arrow functions) used to be left behind, so visiting a later scope of a
-  // different kind hit "Scope mismatch while visiting".
+describe("dropped TypeScript class members discard scopes", () => {
+  // Decorators and computed keys are parsed before the parser knows whether the class
+  // member they belong to will be kept. When the member is then dropped (an overload
+  // signature, abstract/declare method, or index signature), they are dropped too.
+  // Scopes recorded while parsing them (e.g. arrow functions) used to be left behind,
+  // so visiting a later scope of a different kind hit "Scope mismatch while visiting".
   const cases: [name: string, source: string, expected: string[]][] = [
     [
       "arrow decorator on a method overload signature plus an arrow parameter decorator",
@@ -183,6 +183,11 @@ describe("decorators on dropped TypeScript class members discard scopes", () => 
       "arrow decorator on a method overload signature followed by a function after the class",
       "class C { @((td) => { })oo(): oo; }\nfunction f() { { let x; } }",
       ["class C", "function f"],
+    ],
+    [
+      "arrow function in the computed key of a method overload signature",
+      "class C { [((x) => x)('foo')](): void; h() { { let x; } } }",
+      ["class C"],
     ],
   ];
 

--- a/test/bundler/transpiler/scope-mismatch-panic.test.ts
+++ b/test/bundler/transpiler/scope-mismatch-panic.test.ts
@@ -146,3 +146,64 @@ describe("TypeScript 'declare' statements discard scopes of dropped statements",
     expect(exitCode).toBe(0);
   });
 });
+
+describe("decorators on dropped TypeScript class members discard scopes", () => {
+  // Decorators are parsed before the class member they decorate. When the member is
+  // then dropped (an overload signature, abstract/declare method, or index signature),
+  // its decorators are dropped too. Scopes recorded while parsing those decorators
+  // (e.g. arrow functions) used to be left behind, so visiting a later scope of a
+  // different kind hit "Scope mismatch while visiting".
+  const cases: [name: string, source: string, expected: string[]][] = [
+    [
+      "arrow decorator on a method overload signature plus an arrow parameter decorator",
+      "class C {\r@((td) => { })oo(): oo;\n h(@(() => {})ny) {}}",
+      ["class C"],
+    ],
+    [
+      "arrow decorator on a method overload signature followed by a nested block",
+      "class C { @((td) => { })oo(): oo; h() { { let x; } } }",
+      ["class C"],
+    ],
+    [
+      "arrow decorator on an abstract method",
+      "abstract class C { @((td) => { })abstract oo(): void; h() { { let x; } } }",
+      ["class C"],
+    ],
+    [
+      "arrow decorator on a declare method",
+      "class C { @((td) => { })declare oo(): void;\n h() { { let x; } } }",
+      ["class C"],
+    ],
+    [
+      "arrow decorator on an index signature",
+      "class C { @((td) => { })[key: string]: any;\n h() { { let x; } } }",
+      ["class C"],
+    ],
+    [
+      "arrow decorator on a method overload signature followed by a function after the class",
+      "class C { @((td) => { })oo(): oo; }\nfunction f() { { let x; } }",
+      ["class C", "function f"],
+    ],
+  ];
+
+  test.concurrent.each(cases)("%s", async (_name, source, expected) => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.stdout.write(new Bun.Transpiler({ loader: "tsx" }).transformSync(${JSON.stringify(source)}))`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    for (const substring of expected) {
+      expect(stdout).toContain(substring);
+    }
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Repro

Found by parser fuzzing on `1.4.0-canary.1`. Minimized (55 bytes):

```ts
class C {
@((td) => { })oo(): oo;
 h(@(() => {})ny) {}}
```

```
bun -e 'new Bun.Transpiler({loader:"tsx", target:"bun", minifyWhitespace:true}).transformSync(atob("Y2xhc3MgQyB7DUAoKHRkKSA9PiB7IH0pb28oKTogb287CiBoKEAoKCkgPT4ge30pbnkpIHt9fQ=="))'
panic: Scope mismatch while visiting
```

The same panic is reachable whenever a scope-creating decorator — or computed key — sits on a class member that the parser drops, followed by any later scope of a different kind:

```ts
class C { @((td) => { })oo(): oo; h() { { let x; } } }
abstract class C { @((td) => { })abstract oo(): void; h() { { let x; } } }
class C { @((td) => { })declare oo(): void;
 h() { { let x; } } }
class C { @((td) => { })[key: string]: any;
 h() { { let x; } } }
class C { @((td) => { })oo(): oo; }
function f() { { let x; } }
class C { [((x) => x)('foo')](): void; h() { { let x; } } }
```

The Zig parser has the same structure, so this is a faithfully-ported long-standing bug rather than a port regression — same family as #31231 (dropped `declare` statements).

### Cause

In `parse_class`, decorators for each property are parsed (in the class-body scope) *before* `parse_property` decides whether the member is kept, and a computed key is parsed before the member's own function scope is pushed. When the member turns out to be dropped — a TypeScript overload signature (method with no body), an abstract/`declare` method, or an index signature — `parse_property` returns `None` and only discards the scopes it pushed itself (the method's `FunctionArgs` scope). Scopes recorded while parsing the member's decorators or computed key (the arrow functions above) stay in `scopes_in_order` even though those expressions are dropped from the AST and never visited.

The visit pass then consumes those orphaned entries for the *next* scope it pushes. In release builds only the scope kind is checked, so the panic fires once a scope of a different kind lines up against the leftover entry — here the arrow in `h`'s parameter decorator (`FunctionArgs` vs the orphaned arrow-body `FunctionBody` entry). Debug builds also check the location, so any later scope trips it.

### Fix

`src/js_parser/parse/mod.rs` (`parse_class`): record `scopes_in_order.len()` before parsing a property's decorators, and when `parse_property` drops the member, call `discard_scopes_up_to()` so everything recorded for the dropped member (decorators and computed key) is discarded with it. This is the same pattern the statement-level decorator path already uses for `@decorator declare class Foo {}` (`DeferredTsDecorators::scope_index`).

Output for kept members is unchanged; the discard only runs on members the parser already drops.

### Verification

- Added 7 cases to `test/bundler/transpiler/scope-mismatch-panic.test.ts` (overload signature, abstract method, declare method, index signature, computed key, plus the original fuzz input). All 7 panic with "Scope mismatch while visiting" before the fix and pass with it; the 8 existing cases in that file still pass.
- The original fuzz input now transpiles cleanly (`class C{h(ny){}}` plus decorator metadata preamble).
- No regressions: `decorators.test.ts`, `decorator-metadata.test.ts`, `es-decorators.test.ts`, `es-decorators-esbuild.test.ts` (206 pass), `test/bundler/esbuild/ts.test.ts` + `test/bundler/transpiler/transpiler.test.js` (203 pass, 0 fail).
- `cargo check -p bun_js_parser` and `cargo clippy -p bun_js_parser` are clean.
