### PR TITLE
Fix quadratic hang reporting duplicate-binding parse errors in the transpiler

### DIFF
--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -2813,18 +2813,9 @@ fn clamp_error_offset(contents: &[u8], offset_loc: Loc) -> usize {
 /// against one file pays O(diagnostics × file size) just computing their
 /// positions — a few hundred KB of malformed JSONC that errors on nearly
 /// every token used to take minutes. The [`Log`] owns one of these:
-/// diagnostics for the same source resume one of a small pool of previous
-/// scans, so N diagnostics cost O(file size + N) in total. Results are
-/// identical to `Source::init_error_position`.
-///
-/// A pool (rather than a single resumable scan) is needed because diagnostic
-/// offsets are not monotonic: the JS parser lexes a whole statement (logging
-/// lexer errors at its end) before declaring its bindings, and
-/// "has already been declared" errors carry a note pointing back at the
-/// original declaration. Each of those streams is individually
-/// non-decreasing, so giving each its own cursor keeps every position
-/// computation incremental instead of falling back to a full rescan per
-/// backwards offset — which is the same quadratic cost all over again.
+/// diagnostics for the same source at non-decreasing offsets resume the
+/// previous scan, so N diagnostics cost O(file size + N) in total. Results
+/// are identical to `Source::init_error_position`.
 #[derive(Default)]
 pub struct LineColumnTracker {
     /// Identity of the tracked source (`contents` and `path.text` pointers +
@@ -2834,25 +2825,13 @@ pub struct LineColumnTracker {
     contents_len: usize,
     path_ptr: usize,
     path_len: usize,
-    /// Resumable scans, sorted by `offset` descending. A diagnostic resumes
-    /// the first cursor at or below its offset, so the cursors fan out over
-    /// the interleaved diagnostic streams (lexer high-water mark, duplicate
-    /// declarations, the notes attached to them, one spare) and each cursor
-    /// only ever moves forward. Four is enough for the streams the parsers
-    /// interleave in practice; anything below every cursor falls back to a
-    /// one-off full scan, exactly like the pre-pool behavior.
     cursors: [ScanCursor; 4],
 }
 
-/// One resumable error-position scan: the [`ErrorPositionState`] after
-/// consuming every codepoint in `contents[..offset]`, plus the cached end of
-/// the line containing `offset`.
 #[derive(Clone, Copy, Default)]
 struct ScanCursor {
     offset: usize,
     state: ErrorPositionState,
-    /// `scan_line_end` result for the line containing `offset`, if already
-    /// computed; invalidated whenever the scan crosses a line break.
     line_end: Option<usize>,
 }
 
@@ -2874,7 +2853,7 @@ impl LineColumnTracker {
         };
     }
 
-    /// [`Source::init_error_position`], resuming from a previous call's
+    /// [`Source::init_error_position`], resuming from the previous call's
     /// offset when possible instead of rescanning from the start.
     pub fn error_position(&mut self, source: &Source, offset_loc: Loc) -> ErrorPosition {
         debug_assert!(!offset_loc.is_empty());
@@ -2885,22 +2864,11 @@ impl LineColumnTracker {
             self.reset_for(source);
         }
 
-        // Serve offsets that land inside a multi-byte codepoint with a
-        // one-off full scan, leaving the cursors untouched: resuming from
-        // mid-codepoint would decode the tail bytes differently than a fresh
-        // scan does.
         if offset < contents.len() && contents[offset] & 0xC0 == 0x80 {
             return source.init_error_position(offset_loc);
         }
 
-        // Resume the furthest-advanced cursor that is still at or below
-        // `offset`. The cursors are sorted by offset descending, and
-        // advancing the chosen one cannot overtake the cursors before it, so
-        // the order is preserved.
         let Some(index) = self.cursors.iter().position(|c| c.offset <= offset) else {
-            // Below every cursor: serve with a one-off full scan, leaving the
-            // cursors untouched — moving one backwards would lose forward
-            // progress.
             return source.init_error_position(offset_loc);
         };
         let cursor = &mut self.cursors[index];
@@ -3716,11 +3684,6 @@ mod line_column_tracker_tests {
 
     #[test]
     fn line_column_tracker_interleaved_diagnostic_streams_match_full_scan() {
-        // The JS parser's duplicate-binding pattern: per statement, a lexer
-        // error at the end of the statement, then for every duplicate an
-        // error at the duplicate plus a note at the first declaration. The
-        // offsets jump backwards between those streams but each stream is
-        // individually non-decreasing.
         let statement = b"try {} catch ([a,a,a,a,a,a,a,a,a,a,a,a, `]) {}\n";
         let mut contents = Vec::new();
         for _ in 0..12 {

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -2813,9 +2813,18 @@ fn clamp_error_offset(contents: &[u8], offset_loc: Loc) -> usize {
 /// against one file pays O(diagnostics × file size) just computing their
 /// positions — a few hundred KB of malformed JSONC that errors on nearly
 /// every token used to take minutes. The [`Log`] owns one of these:
-/// diagnostics for the same source at non-decreasing offsets resume the
-/// previous scan, so N diagnostics cost O(file size + N) in total. Results
-/// are identical to `Source::init_error_position`.
+/// diagnostics for the same source resume one of a small pool of previous
+/// scans, so N diagnostics cost O(file size + N) in total. Results are
+/// identical to `Source::init_error_position`.
+///
+/// A pool (rather than a single resumable scan) is needed because diagnostic
+/// offsets are not monotonic: the JS parser lexes a whole statement (logging
+/// lexer errors at its end) before declaring its bindings, and
+/// "has already been declared" errors carry a note pointing back at the
+/// original declaration. Each of those streams is individually
+/// non-decreasing, so giving each its own cursor keeps every position
+/// computation incremental instead of falling back to a full rescan per
+/// backwards offset — which is the same quadratic cost all over again.
 #[derive(Default)]
 pub struct LineColumnTracker {
     /// Identity of the tracked source (`contents` and `path.text` pointers +
@@ -2825,7 +2834,21 @@ pub struct LineColumnTracker {
     contents_len: usize,
     path_ptr: usize,
     path_len: usize,
-    /// Scanner state after consuming every codepoint in `contents[..offset]`.
+    /// Resumable scans, sorted by `offset` descending. A diagnostic resumes
+    /// the first cursor at or below its offset, so the cursors fan out over
+    /// the interleaved diagnostic streams (lexer high-water mark, duplicate
+    /// declarations, the notes attached to them, one spare) and each cursor
+    /// only ever moves forward. Four is enough for the streams the parsers
+    /// interleave in practice; anything below every cursor falls back to a
+    /// one-off full scan, exactly like the pre-pool behavior.
+    cursors: [ScanCursor; 4],
+}
+
+/// One resumable error-position scan: the [`ErrorPositionState`] after
+/// consuming every codepoint in `contents[..offset]`, plus the cached end of
+/// the line containing `offset`.
+#[derive(Clone, Copy, Default)]
+struct ScanCursor {
     offset: usize,
     state: ErrorPositionState,
     /// `scan_line_end` result for the line containing `offset`, if already
@@ -2851,7 +2874,7 @@ impl LineColumnTracker {
         };
     }
 
-    /// [`Source::init_error_position`], resuming from the previous call's
+    /// [`Source::init_error_position`], resuming from a previous call's
     /// offset when possible instead of rescanning from the start.
     pub fn error_position(&mut self, source: &Source, offset_loc: Loc) -> ErrorPosition {
         debug_assert!(!offset_loc.is_empty());
@@ -2862,30 +2885,41 @@ impl LineColumnTracker {
             self.reset_for(source);
         }
 
-        // Serve out-of-order offsets (e.g. notes pointing at earlier ranges)
-        // and offsets inside a multi-byte codepoint with a one-off full scan,
-        // leaving the resumable state untouched: going backwards would lose
-        // forward progress, and resuming mid-codepoint would decode the tail
-        // bytes differently than a fresh scan does.
-        if offset < self.offset || (offset < contents.len() && contents[offset] & 0xC0 == 0x80) {
+        // Serve offsets that land inside a multi-byte codepoint with a
+        // one-off full scan, leaving the cursors untouched: resuming from
+        // mid-codepoint would decode the tail bytes differently than a fresh
+        // scan does.
+        if offset < contents.len() && contents[offset] & 0xC0 == 0x80 {
             return source.init_error_position(offset_loc);
         }
 
-        if self.state.advance(contents, self.offset, offset) {
-            self.line_end = None;
-        }
-        self.offset = offset;
+        // Resume the furthest-advanced cursor that is still at or below
+        // `offset`. The cursors are sorted by offset descending, and
+        // advancing the chosen one cannot overtake the cursors before it, so
+        // the order is preserved.
+        let Some(index) = self.cursors.iter().position(|c| c.offset <= offset) else {
+            // Below every cursor: serve with a one-off full scan, leaving the
+            // cursors untouched — moving one backwards would lose forward
+            // progress.
+            return source.init_error_position(offset_loc);
+        };
+        let cursor = &mut self.cursors[index];
 
-        let line_end = match self.line_end {
+        if cursor.state.advance(contents, cursor.offset, offset) {
+            cursor.line_end = None;
+        }
+        cursor.offset = offset;
+
+        let line_end = match cursor.line_end {
             Some(line_end) => line_end,
             None => {
                 let line_end = scan_line_end(contents, offset);
-                self.line_end = Some(line_end);
+                cursor.line_end = Some(line_end);
                 line_end
             }
         };
 
-        self.state.to_error_position(line_end)
+        cursor.state.to_error_position(line_end)
     }
 }
 
@@ -3677,6 +3711,54 @@ mod line_column_tracker_tests {
         ];
         for contents in corpus {
             check_corpus_entry(contents);
+        }
+    }
+
+    #[test]
+    fn line_column_tracker_interleaved_diagnostic_streams_match_full_scan() {
+        // The JS parser's duplicate-binding pattern: per statement, a lexer
+        // error at the end of the statement, then for every duplicate an
+        // error at the duplicate plus a note at the first declaration. The
+        // offsets jump backwards between those streams but each stream is
+        // individually non-decreasing.
+        let statement = b"try {} catch ([a,a,a,a,a,a,a,a,a,a,a,a, `]) {}\n";
+        let mut contents = Vec::new();
+        for _ in 0..12 {
+            contents.extend_from_slice(statement);
+        }
+        let source = Source::init_path_string(b"tracker-test.js" as &[u8], contents.as_slice());
+
+        let mut offsets = Vec::new();
+        for statement_index in 0..12usize {
+            let start = statement_index * statement.len();
+            let first_binding = start + 15;
+            offsets.push(start + statement.len() - 6);
+            for duplicate in 1..12usize {
+                offsets.push(first_binding);
+                offsets.push(first_binding + duplicate * 2);
+            }
+        }
+
+        let mut tracker = LineColumnTracker::default();
+        for offset in offsets {
+            let loc = usize2loc(offset);
+            let expected = source.init_error_position(loc);
+            let got = tracker.error_position(&source, loc);
+            assert_eq!(
+                (
+                    expected.line_start,
+                    expected.line_end,
+                    expected.line_count,
+                    expected.column_count
+                ),
+                (
+                    got.line_start,
+                    got.line_end,
+                    got.line_count,
+                    got.column_count
+                ),
+                "interleaved scan diverged at offset {offset}"
+            );
         }
     }
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4499,12 +4499,6 @@ describe("numeric property keys that overflow to Infinity", () => {
 });
 
 describe("parse error flood", () => {
-  // A parse that reports many diagnostics against one file used to recompute
-  // each diagnostic's line/column by rescanning the source from byte 0
-  // whenever the offset jumped backwards (duplicate-declaration errors and the
-  // notes they attach always point behind the lexer's position), making error
-  // reporting quadratic in input size: a few hundred KB of duplicate catch
-  // bindings took minutes.
   it("reports duplicate-binding floods in linear time", async () => {
     await using proc = Bun.spawn({
       cmd: [
@@ -4532,12 +4526,7 @@ describe("parse error flood", () => {
             console.log("OK " + label);
           };
           const bindings = Buffer.alloc(420, "a,").toString();
-          // The template literal swallows the next line, so the lexer logs an
-          // error at the end of the statement before the ~200 duplicate "a"
-          // bindings are declared; every duplicate then logs an error plus a
-          // note at an offset behind the lexer's position.
           check("template catch flood", "try {} catch ([" + bindings + "a, \`]) {}\\n", 800);
-          // Plain duplicate catch bindings: only the notes point backwards.
           check("duplicate catch flood", "try {} catch ([" + bindings + "a]) {}\\n", 400);
           console.log("DONE");
         `,
@@ -4545,9 +4534,6 @@ describe("parse error flood", () => {
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
-      // Generous kill switch: with incremental error positions both checks
-      // finish in a few seconds even in debug+ASAN builds, while the quadratic
-      // rescan took minutes for the first one alone.
       timeout: 60_000,
       killSignal: "SIGKILL",
     });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4497,3 +4497,65 @@ describe("numeric property keys that overflow to Infinity", () => {
     expect(new Function(`${out}; return result;`)()).toEqual(["object", "destructured", "method", "static"]);
   });
 });
+
+describe("parse error flood", () => {
+  // A parse that reports many diagnostics against one file used to recompute
+  // each diagnostic's line/column by rescanning the source from byte 0
+  // whenever the offset jumped backwards (duplicate-declaration errors and the
+  // notes they attach always point behind the lexer's position), making error
+  // reporting quadratic in input size: a few hundred KB of duplicate catch
+  // bindings took minutes.
+  it("reports duplicate-binding floods in linear time", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const transpiler = new Bun.Transpiler({
+            loader: "js",
+            target: "browser",
+            minifyWhitespace: true,
+            deadCodeElimination: true,
+          });
+          const check = (label, statement, repeats) => {
+            const input = Buffer.alloc(statement.length * repeats, statement).toString();
+            let threw;
+            try {
+              transpiler.transformSync(input);
+            } catch (e) {
+              threw = e;
+            }
+            if (threw?.name !== "AggregateError") throw new Error("expected AggregateError, got " + threw);
+            if (!threw.errors.some(e => String(e.message).includes("has already been declared"))) {
+              throw new Error("expected duplicate-declaration errors");
+            }
+            console.log("OK " + label);
+          };
+          const bindings = Buffer.alloc(420, "a,").toString();
+          // The template literal swallows the next line, so the lexer logs an
+          // error at the end of the statement before the ~200 duplicate "a"
+          // bindings are declared; every duplicate then logs an error plus a
+          // note at an offset behind the lexer's position.
+          check("template catch flood", "try {} catch ([" + bindings + "a, \`]) {}\\n", 800);
+          // Plain duplicate catch bindings: only the notes point backwards.
+          check("duplicate catch flood", "try {} catch ([" + bindings + "a]) {}\\n", 400);
+          console.log("DONE");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      // Generous kill switch: with incremental error positions both checks
+      // finish in a few seconds even in debug+ASAN builds, while the quadratic
+      // rescan took minutes for the first one alone.
+      timeout: 60_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("OK template catch flood");
+    expect(stdout).toContain("OK duplicate catch flood");
+    expect(stdout).toContain("DONE");
+    expect(exitCode).toBe(0);
+  }, 90_000);
+});


### PR DESCRIPTION
### Problem

Fuzzing found a hang in the JS parser's error-position tracking: a ~9 KB input full of parse errors keeps `Bun.Transpiler.transformSync` busy for 20+ seconds, sampled spinning in `ErrorPositionState::advance` ← `LineColumnTracker::error_position` — the same line/column computation that previously hung `Bun.JSONC.parse`, now reached through the transpiler.

The input shape is lines of

```js
try {} catch ([a,a,a,/* ~200 more */,a, `]) {}
```

where every `a` after the first is a duplicate catch binding and the backtick starts a template literal that swallows the next line.

Synthetic reproduction (debug build, before this change):

```js
const stmt = "try {} catch ([" + "a,".repeat(210) + "a, `]) {}\n";
new Bun.Transpiler({ loader: "js" }).transformSync(stmt.repeat(168)); // 75 KB → 15.5 s
```

9 KB → 0.35 s · 19 KB → 1.1 s · 37 KB → 4.0 s · 75 KB → 15.5 s — doubling the input quadruples the time.

### Cause

`Log` computes diagnostic line/columns through a single resumable scan (`LineColumnTracker`); any diagnostic whose offset is **behind** the previous one falls back to a full rescan of the source from byte 0.

For this input that fallback is the common case, not the exception:

1. The parser lexes the whole `catch ([...])` binding first. The template literal produces an "Expected identifier" error at the **end** of the statement, advancing the tracker there.
2. `declare_binding` then declares the ~200 `a`s and logs one "has already been declared" error per duplicate — plus a note pointing at the first `a`. Both locations are behind the tracker, so **every** duplicate pays two O(offset) rescans ⇒ O(duplicates × file size).

Even without the template literal, the notes alone (always pointing back at the original declaration) make the pattern quadratic.

### Fix

Generalize the tracker's single resumable scan into a small pool of four cursors, kept sorted by offset. A diagnostic resumes the furthest-advanced cursor at or below its offset, so the interleaved diagnostic streams the parsers actually produce (lexer high-water mark, duplicate-declaration errors, the notes attached to them) each stay incremental; each cursor only ever moves forward. Offsets below every cursor and offsets inside a multi-byte codepoint keep the existing one-off full-scan fallback, so results remain bit-identical to `Source::init_error_position`.

No caps or truncation of diagnostics anywhere; diagnostic output is unchanged.

### Measurements (debug + ASAN build)

| input | before | after |
|---|---|---|
| original 9 KB fuzz repro | 0.39 s | 0.14 s |
| 75 KB duplicate-catch flood | 15.5 s | 0.54 s |
| 356 KB duplicate-catch flood | > 5 min (extrapolated ~6 min) | 2.6 s |

Scaling is now linear (2× input ⇒ ~2× time).

### Tests

- `src/ast/lib.rs`: new differential unit test driving the tracker with the parser's interleaved ordering (lexer error at end of statement, then duplicate/note pairs) against from-scratch `init_error_position`; existing forward/backwards/strided differential tests still pass.
- `test/bundler/transpiler/transpiler.test.js`: new "parse error flood" test spawns a child with a 60 s kill switch (same pattern as the `Bun.JSONC.parse` pathological test) that transpiles a 356 KB duplicate-catch-binding flood and a plain duplicate-binding flood, expecting the usual `AggregateError`. Fails without the fix (child killed at 60 s), passes in ~6 s with it.
- `bun bd test test/bundler/transpiler/transpiler.test.js` (169 tests), `test/js/bun/jsonc/jsonc.test.ts`, `test/bundler/transpiler/runtime-transpiler.test.ts`, `test/js/bun/resolve/resolve-error.test.ts`, `test/js/bun/resolve/build-error.test.ts`, `test/js/bun/resolve/toml/crash/toml-crash.test.ts` — all green locally.
