### PR TITLE
Pass --lto-O3/--lto-CGO3 to ld64.lld on darwin LTO links

### DIFF
--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -721,9 +721,23 @@ export const linkerFlags: Flag[] = [
     // CMake implicitly forwarded CMAKE_CXX_FLAGS (incl. -O2) to the link line;
     // we must do so explicitly. Dropping this cost ~5 MB of .text on linux-x64
     // (less unrolling/inlining in JSC — measurable in Yarr, DFG, BuiltinNames).
+    // ELF only: the driver forwards this to lld as -plugin-opt=O2. The Darwin
+    // driver forwards no opt-level flag at all — see the next entry.
     flag: "-O2",
-    when: c => c.unix && c.lto && c.release && !c.smol,
-    desc: "LTO codegen at -O2",
+    when: c => c.unix && !c.darwin && c.lto && c.release && !c.smol,
+    desc: "LTO codegen at -O2 (ELF: forwarded to lld as -plugin-opt=O2)",
+  },
+  {
+    // The Darwin driver drops a bare -O at link time (`clang++ -### …` shows
+    // no opt-level flag reaching the linker), so Mach-O LTO would codegen at
+    // ld64.lld's built-in defaults: --lto-O2 for the IR pipeline and
+    // --lto-CGO2 (CodeGenOptLevel::Default) for instruction selection —
+    // inline threshold 225 and default isel, while the per-TU build codegens
+    // everything at -O3 + CodeGenOptLevel::Aggressive (threshold 275). Pass
+    // ld64.lld's own options so LTO codegen matches the compile side.
+    flag: ["-Wl,--lto-O3", "-Wl,--lto-CGO3"],
+    when: c => c.darwin && c.lto && c.release && !c.smol,
+    desc: "LTO codegen at -O3 + aggressive isel (Darwin driver forwards no -O to ld64.lld)",
   },
   {
     flag: "-Os",

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -735,8 +735,12 @@ export const linkerFlags: Flag[] = [
     // inline threshold 225 and default isel, while the per-TU build codegens
     // everything at -O3 + CodeGenOptLevel::Aggressive (threshold 275). Pass
     // ld64.lld's own options so LTO codegen matches the compile side.
+    // Cross links only: --lto-O/--lto-CGO are lld-specific, and only the
+    // darwin cross link uses lld's Mach-O port (ld64.lld). Native darwin
+    // links go through Apple's ld, which rejects unknown double-dash options,
+    // so they keep the driver's default LTO codegen level.
     flag: ["-Wl,--lto-O3", "-Wl,--lto-CGO3"],
-    when: c => c.darwin && c.lto && c.release && !c.smol,
+    when: c => c.darwin && c.crossTarget !== undefined && c.lto && c.release && !c.smol,
     desc: "LTO codegen at -O3 + aggressive isel (Darwin driver forwards no -O to ld64.lld)",
   },
   {


### PR DESCRIPTION
Fixes #31342 (follow-up to #31303).

### Problem

The LTO link line passes `-O2` on all unix targets. On ELF that works — clang's driver forwards it to the linker as `-plugin-opt=O2` — but the **Darwin driver forwards no opt-level flag to the linker at all**, so the flag is silently dropped and Mach-O LTO codegen runs at ld64.lld's built-in defaults: `--lto-O2` for the IR pipeline and `--lto-CGO2` (`CodeGenOptLevel::Default`) for instruction selection, while the per-TU build codegens everything at `-O3` + `CodeGenOptLevel::Aggressive` (inline threshold 225 vs 275, less aggressive isel/scheduling).

Verified with `clang++ -###` (LLVM 21):

```
# ELF: -O2 at link time reaches the linker
$ clang++ -### --target=x86_64-linux-gnu -fuse-ld=lld -flto=full -O2 a.o -o a.out
  ... "-plugin-opt=O2" ...

# Darwin: no opt-level flag reaches the linker at all
$ clang++ -### --target=arm64-apple-macos13.0 -flto=full -O2 a.o -o a.out
  ... (no -plugin-opt / --lto-O / -O anywhere on the ld invocation)

# Darwin: -Wl, passes ld64.lld's own options through verbatim
$ clang++ -### --target=arm64-apple-macos13.0 -flto=full -Wl,--lto-O3 -Wl,--lto-CGO3 a.o -o a.out
  ... "--lto-O3" "--lto-CGO3" ...
```

### Fix

Split the `LTO codegen at -O2` entry in `scripts/build/flags.ts`:

- ELF (`c.unix && !c.darwin`) keeps `-O2` exactly as before (dropping it previously cost ~5 MB of .text on linux-x64).
- darwin **cross** LTO release links (`c.darwin && c.crossTarget !== undefined`) get `-Wl,--lto-O3 -Wl,--lto-CGO3` instead, so ld64.lld's LTO codegen matches the compile-side `-O3` + aggressive isel.

`--lto-O`/`--lto-CGO` are lld-specific, and only the darwin cross link (added by #31303) uses lld's Mach-O port — native darwin links go through Apple's ld, which rejects unknown double-dash options. So the entry is gated on `crossTarget` and native darwin LTO links keep the driver default, which is the same effective behavior they had with the dropped `-O2`. On main the darwin-cross config doesn't resolve yet, so the entry goes live when #31303 lands; the ELF split stands on its own.

The smol `-Os` entry is left untouched per the issue scope.

### Verification

- `bunx tsc --noEmit -p scripts/build/tsconfig.json` passes.
- `bun scripts/build.ts --configure-only --profile=btg` (linux LTO release): the generated link line still contains exactly one bare `-O2` and no `--lto-O*` — ELF output unchanged.
- Evaluating the `linkerFlags` table against mock configs:

  | config | opt-level link flags |
  | --- | --- |
  | darwin cross + lto + release | `-Wl,--lto-O3 -Wl,--lto-CGO3` |
  | darwin native + lto + release | (none — was a dropped `-O2` before) |
  | darwin native + lto + smol | `-Os` (unchanged) |
  | darwin non-LTO release | (none, unchanged) |
  | linux + lto + release | `-O2` (unchanged) |

- `ld64.lld --help` (LLVM 21) confirms both options: `--lto-O<opt-level>` and `--lto-CGO<cgopt-level>`, default 2.

### Not done here

- The before/after HTTP plaintext A/B on an M-series Mac needs real Apple Silicon hardware (the darwin-cross LTO artifact comes from the #31303 lanes), so that measurement is left to the #31303 benchmarking runs.
- `test/internal/macos-cross-config.test.ts` (added by #31303, not on main yet) pins the darwin cross link flags; it will need to expect `-Wl,--lto-O3 -Wl,--lto-CGO3` instead of `-O2` when that PR rebases onto this.
- The `Bun.stringWidth` regression is unrelated (SLP vectorizer is off in ld64.lld's LTO pipeline at every `--lto-O` level), tracked separately in #31343.
