### PR TITLE
Track ld64.lld's missing LTO SLP vectorization in workarounds.ts

### DIFF
--- a/scripts/build/workarounds.ts
+++ b/scripts/build/workarounds.ts
@@ -172,6 +172,35 @@ export const workarounds: Workaround[] = [
       `(options.detached block), replace the local 0x80 with libc::POSIX_SPAWN_SETSID, ` +
       `drop the explanatory comments, and delete this entry.`,
   },
+  {
+    id: "ld64-lld-lto-no-slp-vectorization",
+    issue: "https://github.com/llvm/llvm-project/pull/182748",
+    description:
+      "lld/MachO/LTO.cpp never set PTO.SLPVectorization (the ELF/COFF ports do), so ld64.lld's " +
+      "LTO pipeline skips the SLP vectorizer at every --lto-O level and straight-line code that " +
+      "counts on SLP autovectorization stays scalar in darwin LTO links (oven-sh/bun#31343 — " +
+      "Bun.stringWidth's ASCII kernel ~2x slower). Accepted rather than patched: no custom lld " +
+      "is carried; the hot kernels are moving to explicit SIMD intrinsics instead.",
+    // Exercised by any Mach-O LTO link (darwin release CI cross builds, local --lto darwin builds).
+    applies: cfg => cfg.darwin && cfg.lto,
+    expectedToBeFixed: cfg => {
+      // Fix merged to LLVM main on 2026-02-23, after release/22.x branched —
+      // LLVM 23 is the first release train that ships it. Lower the threshold
+      // to the exact 22.1.x if a backport lands. Check whichever lld actually
+      // performs the Mach-O LTO link: rust-lld (rustc's bundled LLVM) when the
+      // cross-language-LTO swap in resolveConfig() fired, clang's ld64.lld
+      // otherwise. No link-flag change is needed once the fix is present:
+      // ld64.lld defaults to --lto-O2 and the fix enables SLP at --lto-O >= 2,
+      // mirroring ELF.
+      const FIXED_IN_LLVM = "23.0.0";
+      const linkerLlvm = cfg.ld === cfg.rustLld ? cfg.rustLlvmVersion : cfg.clangVersion;
+      return linkerLlvm !== undefined && satisfiesRange(linkerLlvm, `>=${FIXED_IN_LLVM}`);
+    },
+    cleanup:
+      `Nothing to revert in the build — the gap was accepted, not patched around. Re-run the ` +
+      `bitcode replay from oven-sh/bun#31343 (or benchmark Bun.stringWidth's ASCII path on a ` +
+      `darwin LTO build) to confirm ld64.lld now runs the SLP vectorizer, then delete this entry.`,
+  },
 ];
 
 /**

--- a/scripts/build/workarounds.ts
+++ b/scripts/build/workarounds.ts
@@ -181,15 +181,21 @@ export const workarounds: Workaround[] = [
       "counts on SLP autovectorization stays scalar in darwin LTO links (oven-sh/bun#31343 — " +
       "Bun.stringWidth's ASCII kernel ~2x slower). Accepted rather than patched: no custom lld " +
       "is carried; the hot kernels are moving to explicit SIMD intrinsics instead.",
-    // Exercised by any Mach-O LTO link (darwin release CI cross builds, local --lto darwin builds).
+    // The links that hit this are the darwin LTO cross builds (#31303), which
+    // run the Mach-O link through the ld64.lld flavor of whichever lld
+    // resolveConfig() picked as cfg.ld. Native darwin links don't consume
+    // cfg.ld (clang drives Apple's ld there), so a trip on a local native
+    // --lto build is just the reminder firing early — harmless by design.
     applies: cfg => cfg.darwin && cfg.lto,
     expectedToBeFixed: cfg => {
       // Fix merged to LLVM main on 2026-02-23, after release/22.x branched —
-      // LLVM 23 is the first release train that ships it. Lower the threshold
-      // to the exact 22.1.x if a backport lands. Check whichever lld actually
-      // performs the Mach-O LTO link: rust-lld (rustc's bundled LLVM) when the
-      // cross-language-LTO swap in resolveConfig() fired, clang's ld64.lld
-      // otherwise. No link-flag change is needed once the fix is present:
+      // LLVM 23 is the first release train that ships it; lower the threshold
+      // to the exact 22.1.x if a backport lands. Key on the lld resolveConfig()
+      // selected: rust-lld when the cross-language-LTO swap fired (the normal
+      // case on the LTO cross lanes — rustc's LLVM reaches 23 long before our
+      // pinned clang does), clang's ld64.lld otherwise. Keying on clangVersion
+      // alone would keep this entry silent after the lld doing the Mach-O LTO
+      // already has the fix. No link-flag change is needed once it ships:
       // ld64.lld defaults to --lto-O2 and the fix enables SLP at --lto-O >= 2,
       // mirroring ELF.
       const FIXED_IN_LLVM = "23.0.0";


### PR DESCRIPTION
Closes #31343 (follow-up to #31303).

### Upstream status

The one-line fix is already merged on llvm-project `main`: [llvm/llvm-project#182748](https://github.com/llvm/llvm-project/pull/182748) (merged 2026-02-23) adds `PTO.LoopVectorization` / `PTO.SLPVectorization = OptLevel > 1` to `lld/MachO/LTO.cpp::createConfig()`, mirroring the ELF/COFF ports. It landed **after** `release/22.x` branched (`llvmorg-23-init`, 2026-01-13), so LLVM 23 is the first release train that ships it — `llvmorg-21.1.8` and `llvmorg-22.1.0`…`22.1.6` all lack the line. That covers both llds we can link with today (Homebrew/apt clang 21.1.x, rust-lld from the pinned nightly at LLVM 22.1.x), so nothing to upstream and no released toolchain to pick up yet.

### What this does

Takes the "accept the gap" option from the issue and adds the self-obsoleting tracking entry to `scripts/build/workarounds.ts` (`ld64-lld-lto-no-slp-vectorization`):

- **`applies`** — darwin + LTO, the only configs where a Mach-O LTO link happens (the cross-compile release lanes from #31303; the native darwin lanes are non-LTO).
- **`expectedToBeFixed`** — trips once the lld that actually performs the Mach-O LTO link has LLVM ≥ 23: rust-lld's bundled LLVM when the cross-language-LTO swap in `resolveConfig()` selected it (today's case), clang's otherwise. The comment notes to lower the threshold to the exact 22.1.x if a `release/22.x` backport lands, and that no link-flag change is needed once the fix is present (ld64.lld defaults to `--lto-O2`; the fix enables SLP at `--lto-O ≥ 2`, same gate as ELF).
- **`cleanup`** — nothing to revert in the build; re-run the bitcode replay from #31343 (or benchmark `Bun.stringWidth`'s ASCII path on a darwin LTO build) to confirm SLP now runs, then delete the entry.

No custom/patched lld is carried — the only code that regresses is scalar code relying on SLP to become SIMD, and those kernels are being moved to explicit intrinsics separately (the `PERF(port)` TODOs in `visible.rs`).

The entry is appended at the end of the array so it doesn't collide with the entries #31303 inserts mid-array.

### Verification

- `bunx tsc --noEmit -p scripts/build/tsconfig.json` — clean.
- `bun scripts/build.ts --configure-only` (Linux) — configure succeeds, behavior unchanged (`applies` is false off-darwin).
- Predicate matrix against synthetic configs: no-op for linux-LTO and darwin-non-LTO; applies-but-not-tripped for today's toolchains (rust-lld 22.1.x / clang 21.1.x, including a hypothetical 22.1.9); trips once the linking lld reaches LLVM 23 via either a rustc nightly bump (swap on) or a clang bump (swap off); falls back to `clangVersion` when rust-lld isn't found.
- Prettier: already conformant.


### CI note

The red on CI is unrelated to the diff (build-script-only; it's a no-op off darwin+LTO and doesn't change any compile/link flags, so the tested binaries are identical to main's):

- **Build 57569** (same content): only failures were `darwin-14/26-aarch64-test-bun` expiring at 0s waiting for a macOS agent. All builds and the darwin-x64 test suite passed.
- **Build 57620** (comment-only delta): the vendored `libspng` dep fetch failed transiently on `linux-aarch64-musl-build-cpp` (same pinned commit fetched fine on every other lane and on the previous run), which cascades into that lane's downstream steps; and the `darwin-14-x64-test-bun` lane hit known-flaky runtime tests (`fetch-leak` RSS threshold, 60s `backpressure` timeout, `expect.assertions` counting) that passed on the previous run of this same diff.

I've used my one CI re-roll and won't push further retrigger commits — a Buildkite-side retry of the two failed jobs should clear it.
