### PR TITLE
Fix JSX transform panic when a bare `key` prop precedes `key` with a value

### DIFF
--- a/src/js_parser/parse/parse_jsx.rs
+++ b/src/js_parser/parse/parse_jsx.rs
@@ -48,8 +48,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             'parse_attributes: loop {
                 match p.lexer.token {
                     T::TIdentifier => {
-                        // PORT NOTE: `defer i += 1` inlined at each exit point of this arm
-                        // that appends to `props`.
+                        // PORT NOTE: `defer i += 1` inlined at each exit point of this arm.
                         // Parse the prop name
                         let key_range = p.lexer.range();
                         let prop_name_literal = p.lexer.identifier;
@@ -66,11 +65,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     key_range.loc,
                                     b"\"key\" prop ignored. Must be a string, number or symbol.",
                                 );
-                                // This prop is not appended to `props`, so `i` must not
-                                // advance: it tracks the index each appended prop gets in
-                                // `props`, and a later `key=...` records it as
-                                // `key_prop_i`, which is used to remove the key prop by
-                                // index during the JSX transform.
                                 continue;
                             }
 

--- a/src/js_parser/parse/parse_jsx.rs
+++ b/src/js_parser/parse/parse_jsx.rs
@@ -48,7 +48,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             'parse_attributes: loop {
                 match p.lexer.token {
                     T::TIdentifier => {
-                        // PORT NOTE: `defer i += 1` inlined at each exit point of this arm.
+                        // PORT NOTE: `defer i += 1` inlined at each exit point of this arm
+                        // that appends to `props`.
                         // Parse the prop name
                         let key_range = p.lexer.range();
                         let prop_name_literal = p.lexer.identifier;
@@ -65,7 +66,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     key_range.loc,
                                     b"\"key\" prop ignored. Must be a string, number or symbol.",
                                 );
-                                i += 1; // defer i += 1
+                                // This prop is not appended to `props`, so `i` must not
+                                // advance: it tracks the index each appended prop gets in
+                                // `props`, and a later `key=...` records it as
+                                // `key_prop_i`, which is used to remove the key prop by
+                                // index during the JSX transform.
                                 continue;
                             }
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1684,10 +1684,6 @@ console.log(<div {...obj} key="after" />);`),
   });
 
   it("JSX bare key prop followed by key with a value does not crash", async () => {
-    // A bare `key` (no value) is skipped with a warning, but it used to still advance the
-    // prop index, so a later `key=...` recorded an out-of-bounds `key_prop_index` and the
-    // automatic-runtime key extraction removed past the end of the props list. Run in a
-    // subprocess so a crash surfaces as a test failure instead of taking down the test runner.
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1683,6 +1683,38 @@ console.log(<div {...obj} key="after" />);`),
     );
   });
 
+  it("JSX bare key prop followed by key with a value does not crash", async () => {
+    // A bare `key` (no value) is skipped with a warning, but it used to still advance the
+    // prop index, so a later `key=...` recorded an out-of-bounds `key_prop_index` and the
+    // automatic-runtime key extraction removed past the end of the props list. Run in a
+    // subprocess so a crash surfaces as a test failure instead of taking down the test runner.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const t = new Bun.Transpiler({
+            loader: "jsx",
+            define: { "process.env.NODE_ENV": JSON.stringify("development") },
+            logLevel: "error",
+          });
+          process.stdout.write(t.transformSync('console.log(<div key key="duplicate"></div>);'));
+          process.stdout.write(t.transformSync('console.log(<div key className="x" key="duplicate"></div>);'));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(
+      'console.log(jsxDEV_7x81h0kn("div", {}, "duplicate", false, undefined, this));\n' +
+        'console.log(jsxDEV_7x81h0kn("div", {\n  className: "x"\n}, "duplicate", false, undefined, this));\n',
+    );
+    expect(exitCode).toBe(0);
+  });
+
   it("parses TSX arrow functions correctly", () => {
     var transpiler = new Bun.Transpiler({
       loader: "tsx",


### PR DESCRIPTION
### What does this PR do?

Fixes a panic in the JSX transform when a JSX element has a bare `key` prop (no value) followed by a `key` prop with a value:

```
panic: removal index (is 1) should be < len (is 1)
```

**Repro** (found by fuzzing, 22-byte input):

```js
new Bun.Transpiler({ loader: "jsx", target: "node", minifyWhitespace: true })
  .transformSync('<div key key=""></div>');
```

### Cause

In `parse_jsx.rs`, a bare `key` prop is skipped with a `"key" prop ignored` warning and is never appended to the props list — but the prop index counter `i` still advanced. A later `key=...` then recorded `key_prop_i = i`, which is one past the prop's actual position in the list. During the automatic-runtime JSX transform, the key extraction calls `properties.ordered_remove(key_prop_index)`, which removes past the end of the list and panics.

### Fix

Only advance the counter when a prop is actually appended to `props`, so `key_prop_index` (and `first_spread_prop_i`) always match real positions in the props list. The bare `key` keeps its existing behavior (warning + ignored), and `key="duplicate"` is extracted as the key argument as usual.

### Verification

- Before: the repro (and the new test's subprocess) panics with `removal index (is 1) should be < len (is 1)`.
- After: `<div key key="duplicate"></div>` transforms to `jsxDEV("div", {}, "duplicate", ...)`; the variant with an extra prop in between (`<div key className="x" key="duplicate">`) also transforms correctly.
- New test in `test/bundler/transpiler/transpiler.test.js` runs the transform in a subprocess (so a crash surfaces as a test failure) and asserts the exact output; it fails on the previous build and passes with this change.
- Full `test/bundler/transpiler/transpiler.test.js` suite passes (147 pass / 0 fail).
