### PR TITLE
test: forward keep-alive requests in proxy.test.ts's mock proxy

### DIFF
--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -313,27 +313,29 @@ test("non-TLS origin redirect through HTTPS proxy forwards every hop through the
     },
   });
 
-  const response = await fetch(`${server.url.origin}/bunbun`, {
-    proxy: proxy.url,
-    tls: {
-      rejectUnauthorized: false,
-    },
-  });
-  expect(response.status).toBe(200);
-  expect(await response.text()).toBe("BUN!");
+  try {
+    const response = await fetch(`${server.url.origin}/bunbun`, {
+      proxy: proxy.url,
+      tls: {
+        rejectUnauthorized: false,
+      },
+    });
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("BUN!");
 
-  // Every redirect hop must have been forwarded through the proxy as its own
-  // absolute-form request — none dropped, none bypassing the proxy, and no
-  // CONNECT fallback.
-  expect(proxy.log).toEqual([
-    `GET localhost:${server.port}/bunbun`,
-    `GET localhost:${server.port}/bun`,
-    `GET localhost:${server.port}/`,
-  ]);
-
-  // Not awaited: the client's pooled keep-alive connection keeps the server's
-  // close event from firing (matches the afterAll teardown above).
-  proxy.server.close();
+    // Every redirect hop must have been forwarded through the proxy as its own
+    // absolute-form request — none dropped, none bypassing the proxy, and no
+    // CONNECT fallback.
+    expect(proxy.log).toEqual([
+      `GET localhost:${server.port}/bunbun`,
+      `GET localhost:${server.port}/bun`,
+      `GET localhost:${server.port}/`,
+    ]);
+  } finally {
+    // Not awaited: the client's pooled keep-alive connection keeps the server's
+    // close event from firing (matches the afterAll teardown above).
+    proxy.server.close();
+  }
 });
 
 test("unsupported protocol", async () => {

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -16,47 +16,104 @@ async function createProxyServer(is_tls: boolean) {
   }
   const log: Array<string> = [];
   serverArgs.push((clientSocket: net.Socket | tls.TLSSocket) => {
+    // ignore client errors (can happen because of happy eye balls and now we error on write when not connected for node.js compatibility)
+    clientSocket.on("error", () => {});
+
     clientSocket.once("data", data => {
       const request = data.toString();
       const [method, path] = request.split(" ");
-      let host: string;
-      let port: number | string = 0;
-      let request_path = "";
-      if (path.indexOf("http") !== -1) {
-        const url = new URL(path);
-        host = url.hostname;
-        port = url.port;
-        request_path = url.pathname + (url.search || "");
-      } else {
-        // Extract the host and port from the CONNECT request
-        [host, port] = path.split(":");
-      }
-      const destinationPort = Number.parseInt((port || (method === "CONNECT" ? "443" : "80")).toString(), 10);
-      const destinationHost = host || "";
-      log.push(`${method} ${host}:${port}${request_path}`);
 
-      // Establish a connection to the destination server
-      const serverSocket = net.connect(destinationPort, destinationHost, () => {
-        if (method === "CONNECT") {
+      if (path.indexOf("http") === -1) {
+        // Extract the host and port from the CONNECT request
+        const [host, port] = path.split(":");
+        const destinationPort = Number.parseInt((port || "443").toString(), 10);
+        const destinationHost = host || "";
+        log.push(`${method} ${host}:${port}`);
+
+        // Establish a connection to the destination server
+        const serverSocket = net.connect(destinationPort, destinationHost, () => {
           // 220 OK with host so the client knows the connection was successful
           clientSocket.write("HTTP/1.1 200 OK\r\nHost: localhost\r\n\r\n");
 
           // Pipe data between client and server
           clientSocket.pipe(serverSocket);
           serverSocket.pipe(clientSocket);
-        } else {
-          serverSocket.write(`${method} ${request_path} HTTP/1.1\r\n`);
-          // Send the request to the destination server
-          serverSocket.write(data.slice(request.indexOf("\r\n") + 2));
-          serverSocket.pipe(clientSocket);
-        }
-      });
-      // ignore client errors (can happen because of happy eye balls and now we error on write when not connected for node.js compatibility)
-      clientSocket.on("error", () => {});
+        });
+        serverSocket.on("error", () => {
+          clientSocket.end();
+        });
+        return;
+      }
 
-      serverSocket.on("error", err => {
-        clientSocket.end();
-      });
+      // Absolute-form (non-tunneled) proxying. The client negotiates
+      // keep-alive on the proxy connection, so after a redirect the next
+      // request arrives on this same socket — forward every request that
+      // shows up, not just the first one. The reused proxy connection is
+      // keyed only by the proxy address, so consecutive requests may also
+      // target different origins; keep one upstream per destination at a
+      // time and reconnect when it changes.
+      let upstream: net.Socket | undefined;
+      let upstreamKey = "";
+      let upstreamConnected = false;
+      let pending: Buffer[] = [];
+
+      const forward = (chunk: Buffer) => {
+        const text = chunk.toString();
+        const eol = text.indexOf("\r\n");
+        const parts = eol === -1 ? [] : text.slice(0, eol).split(" ");
+
+        if (parts.length === 3 && parts[1].startsWith("http")) {
+          // A new absolute-form request line: rewrite it to origin form and
+          // forward it to the destination it names.
+          const url = new URL(parts[1]);
+          const request_path = url.pathname + (url.search || "");
+          log.push(`${parts[0]} ${url.hostname}:${url.port}${request_path}`);
+
+          const key = `${url.hostname}:${url.port}`;
+          if (upstream === undefined || upstreamKey !== key) {
+            // First request on this connection, or the reused proxy
+            // connection switched targets.
+            if (upstream !== undefined) {
+              upstream.unpipe(clientSocket);
+              upstream.destroy();
+            }
+            upstreamKey = key;
+            upstreamConnected = false;
+            pending = [];
+            const destinationPort = Number.parseInt((url.port || "80").toString(), 10);
+            const serverSocket = net.connect(destinationPort, url.hostname, () => {
+              upstreamConnected = true;
+              for (const buffered of pending) serverSocket.write(buffered);
+              pending = [];
+              serverSocket.pipe(clientSocket);
+            });
+            serverSocket.on("error", () => {
+              clientSocket.end();
+            });
+            upstream = serverSocket;
+          }
+
+          const head = Buffer.from(`${parts[0]} ${request_path} HTTP/1.1\r\n`);
+          // Send the rest of the request to the destination server
+          const rest = chunk.slice(text.indexOf("\r\n") + 2);
+          if (upstreamConnected) {
+            upstream.write(head);
+            upstream.write(rest);
+          } else {
+            pending.push(head, rest);
+          }
+        } else if (upstream !== undefined) {
+          // Continuation of the previous request's body.
+          if (upstreamConnected) {
+            upstream.write(chunk);
+          } else {
+            pending.push(chunk);
+          }
+        }
+      };
+
+      forward(data);
+      clientSocket.on("data", forward);
     });
   });
   // Create a server to listen for incoming HTTPS connections
@@ -238,6 +295,46 @@ for (const server_tls of [false, true]) {
     });
   });
 }
+
+test("non-TLS origin redirect through HTTPS proxy forwards every hop through the proxy", async () => {
+  // Dedicated proxy instance so its log is not polluted by the concurrent
+  // tests that share httpsProxyServer.
+  const proxy = await createProxyServer(true);
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      if (req.url.endsWith("/bunbun")) {
+        return Response.redirect("/bun", 302);
+      }
+      if (req.url.endsWith("/bun")) {
+        return Response.redirect("/", 302);
+      }
+      return new Response("BUN!", { status: 200 });
+    },
+  });
+
+  const response = await fetch(`${server.url.origin}/bunbun`, {
+    proxy: proxy.url,
+    tls: {
+      rejectUnauthorized: false,
+    },
+  });
+  expect(response.status).toBe(200);
+  expect(await response.text()).toBe("BUN!");
+
+  // Every redirect hop must have been forwarded through the proxy as its own
+  // absolute-form request — none dropped, none bypassing the proxy, and no
+  // CONNECT fallback.
+  expect(proxy.log).toEqual([
+    `GET localhost:${server.port}/bunbun`,
+    `GET localhost:${server.port}/bun`,
+    `GET localhost:${server.port}/`,
+  ]);
+
+  // Not awaited: the client's pooled keep-alive connection keeps the server's
+  // close event from firing (matches the afterAll teardown above).
+  proxy.server.close();
+});
 
 test("unsupported protocol", async () => {
   expect(


### PR DESCRIPTION
The mock proxy fixture in `test/js/bun/http/proxy.test.ts` only serviced the first request on each client connection when proxying plain-HTTP origins (its non-CONNECT branch used a single `once("data")` forward with no persistent client-to-upstream path). fetch correctly reuses the keep-alive proxy connection after a 302, so the second absolute-form request was never read and the three "proxy can handle redirects with non-TLS server" tests timed out on every build.

This restructures the fixture's absolute-form branch to forward every request that arrives on the persistent proxy connection, rewriting each absolute-form request line to origin form and reconnecting the upstream when the destination changes. The CONNECT branch is unchanged. Adds a test that drives a 3-hop redirect chain against a plain-HTTP origin through a dedicated HTTPS proxy and asserts the proxy observes each hop as its own forwarded request.

The three previously timing-out tests now pass; the rest of the file is unaffected (the one remaining failure in the file, `non-200 CONNECT response from proxy is surfaced...`, fails identically before and after this change and does not use this fixture).