### PR TITLE
node:http2: send GOAWAY frames on stream 0

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -2381,7 +2381,7 @@ impl H2FrameParser {
 
     pub(crate) fn send_go_away(
         &self,
-        stream_identifier: u32,
+        triggering_stream_id: u32,
         rst_code: ErrorCode,
         debug_data: &[u8],
         last_stream_id: u32,
@@ -2390,7 +2390,7 @@ impl H2FrameParser {
         bun_output::scoped_log!(
             H2FrameParser,
             "HTTP_FRAME_GOAWAY {} code {} debug_data {} emitError {}",
-            stream_identifier,
+            triggering_stream_id,
             rst_code.0,
             BStr::new(debug_data),
             emit_error
@@ -2398,10 +2398,15 @@ impl H2FrameParser {
         let mut buffer = [0u8; FrameHeader::BYTE_SIZE + 8];
         let mut stream = FixedBufferStream::new(&mut buffer);
 
+        // RFC 9113 section 6.8: GOAWAY frames are always sent on stream 0. A
+        // GOAWAY with a non-zero stream identifier is itself a connection
+        // error of type PROTOCOL_ERROR. The stream that triggered the GOAWAY
+        // is only used for logging above; the last processed stream id goes in
+        // the payload below.
         let frame = FrameHeader {
             type_: FrameType::HTTP_FRAME_GOAWAY as u8,
             flags: 0,
-            stream_identifier,
+            stream_identifier: 0,
             length: u32::try_from(8 + debug_data.len()).expect("int cast"),
         };
         let _ = frame.write(&mut stream);

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1606,7 +1606,7 @@ it("http2 client receives 'goaway' when the server rejects a stream", async () =
     // The header block exceeds the server's maxHeaderListSize, so the server
     // rejects the stream; with maxSessionRejectedStreams: 0 it answers with a
     // GOAWAY carrying NGHTTP2_ENHANCE_YOUR_CALM.
-    const req = client.request({ ":path": "/", "x-filler": "a".repeat(256) });
+    const req = client.request({ ":path": "/", "x-filler": Buffer.alloc(256, "a").toString() });
     req.on("error", () => {});
     req.end();
 

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1530,6 +1530,96 @@ it("http2 session.goaway() sends custom data", async done => {
   });
 });
 
+it("http2 server sends protocol-error GOAWAY on stream 0", async () => {
+  // RFC 9113 section 6.8: GOAWAY frames MUST be sent with a stream identifier
+  // of 0 in the frame header; the last processed stream id lives in the
+  // payload. Trigger a connection-level protocol violation (a PING addressed
+  // to stream 1) from a raw socket and inspect the GOAWAY frame the server
+  // writes back.
+  const server = http2.createServer();
+  server.on("error", () => {});
+  server.on("session", session => session.on("error", () => {}));
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+
+  try {
+    const chunks = [];
+    const { promise: closed, resolve: onClose } = Promise.withResolvers();
+    const socket = net.connect(server.address().port, "127.0.0.1", () => {
+      socket.write(http2utils.kClientMagic);
+      socket.write(new http2utils.SettingsFrame().data);
+      // PING frame (type 0x6) addressed to stream 1 is a connection error.
+      socket.write(Buffer.concat([new http2utils.Frame(8, 0x6, 0, 1).data, Buffer.alloc(8)]));
+    });
+    socket.on("error", () => {});
+    socket.on("data", chunk => chunks.push(chunk));
+    socket.on("close", onClose);
+    await closed;
+
+    const data = Buffer.concat(chunks);
+    let offset = 0;
+    let goaway = null;
+    while (offset + 9 <= data.length) {
+      const length = data.readUIntBE(offset, 3);
+      const type = data.readUInt8(offset + 3);
+      if (type === 0x07) {
+        goaway = data.subarray(offset, offset + 9 + length);
+        break;
+      }
+      offset += 9 + length;
+    }
+
+    expect(goaway).not.toBeNull();
+    // Frame header stream identifier must be 0 (the connection stream).
+    expect(goaway.readUInt32BE(5) & 0x7fffffff).toBe(0);
+    // Payload: last-stream-id (no stream was ever opened) followed by the
+    // error code, which must still be PROTOCOL_ERROR.
+    expect(goaway.readUInt32BE(9) & 0x7fffffff).toBe(0);
+    expect(goaway.readUInt32BE(13)).toBe(http2.constants.NGHTTP2_PROTOCOL_ERROR);
+  } finally {
+    server.close();
+  }
+});
+
+it("http2 client receives 'goaway' when the server rejects a stream", async () => {
+  // When the server rejects a stream and gives up on the session, the GOAWAY
+  // it sends must be readable by a conforming client: the client should emit
+  // 'goaway' with the server's error code instead of treating the frame
+  // itself as a protocol error.
+  const server = http2.createServer({ maxSessionRejectedStreams: 0, settings: { maxHeaderListSize: 100 } });
+  server.on("error", () => {});
+  server.on("session", session => session.on("error", () => {}));
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+
+  try {
+    const { promise: goawayReceived, resolve: onGoaway } = Promise.withResolvers();
+    const { promise: clientClosed, resolve: onClientClose } = Promise.withResolvers();
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+    let sessionError = null;
+    client.on("error", err => {
+      sessionError = err;
+    });
+    client.on("close", onClientClose);
+    client.on("goaway", (code, lastStreamID, opaqueData) => {
+      onGoaway({ code, lastStreamID, opaqueData });
+    });
+
+    // The header block exceeds the server's maxHeaderListSize, so the server
+    // rejects the stream; with maxSessionRejectedStreams: 0 it answers with a
+    // GOAWAY carrying NGHTTP2_ENHANCE_YOUR_CALM.
+    const req = client.request({ ":path": "/", "x-filler": "a".repeat(256) });
+    req.on("error", () => {});
+    req.end();
+
+    const { code } = await goawayReceived;
+    expect(code).toBe(http2.constants.NGHTTP2_ENHANCE_YOUR_CALM);
+    expect(sessionError?.code).not.toBe("ERR_HTTP2_SESSION_ERROR");
+
+    await clientClosed;
+  } finally {
+    server.close();
+  }
+});
+
 it(
   "http2 server with minimal maxSessionMemory handles multiple requests",
   async () => {


### PR DESCRIPTION
RFC 9113 section 6.8 requires GOAWAY frames to be sent with a stream identifier of 0 in the frame header; the last processed stream id belongs in the GOAWAY payload. The node:http2 server's frame writer was putting the triggering stream's id in the frame header instead, so conforming peers (including Bun's own client) treated every server-initiated GOAWAY as a connection protocol error and never saw the real error code.

This hardcodes the GOAWAY frame header's stream identifier to 0 and keeps the triggering stream id as a diagnostics-only parameter. The payload layout (last-stream-id + error code + debug data) is unchanged.

Tests added to test/js/node/http2/node-http2.test.js: a wire-level test that parses the GOAWAY frame a server emits after a protocol violation and asserts the header stream id is 0 while the payload still carries the right error code, and an end-to-end test that a client receives the 'goaway' event with the server's error code instead of a session error. Both fail without the fix.