### PR TITLE
test: pipeline the http2 maxSessionMemory test and scale it down on debug builds

### DIFF
--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1,4 +1,4 @@
-import { bunEnv, bunExe, isASAN, isCI, nodeExe } from "harness";
+import { bunEnv, bunExe, isASAN, isCI, isDebug, nodeExe } from "harness";
 import { createTest } from "node-harness";
 import fs from "node:fs";
 import http2 from "node:http2";
@@ -1800,50 +1800,67 @@ it(
   async () => {
     const server = http2.createServer({ maxSessionMemory: 1 });
 
-    return await new Promise(resolve => {
-      server.on("session", session => {
-        session.on("stream", stream => {
-          stream.on("end", function () {
-            this.respond(
-              {
-                ":status": 200,
-              },
-              {
-                endStream: true,
-              },
-            );
-          });
-          stream.resume();
+    server.on("session", session => {
+      session.on("stream", stream => {
+        stream.on("end", function () {
+          this.respond(
+            {
+              ":status": 200,
+            },
+            {
+              endStream: true,
+            },
+          );
         });
-      });
-
-      server.listen(0, () => {
-        const port = server.address().port;
-        const client = http2.connect(`http://localhost:${port}`);
-
-        function next(i) {
-          if (i === 10000) {
-            client.close();
-            server.close();
-            resolve();
-            return;
-          }
-
-          const stream = client.request({ ":method": "POST" });
-
-          stream.on("response", function (headers) {
-            expect(headers[":status"]).toBe(200);
-
-            this.on("close", () => next(i + 1));
-          });
-
-          stream.end();
-        }
-
-        // Start the sequence with the first request
-        next(0);
+        stream.resume();
       });
     });
+
+    await new Promise(resolve => server.listen(0, resolve));
+    const port = server.address().port;
+    const client = http2.connect(`http://localhost:${port}`);
+
+    // A session-level failure (e.g. GOAWAY with ENHANCE_YOUR_CALM) should fail
+    // the test immediately instead of hanging until the timeout.
+    let sessionError = null;
+    client.on("error", err => {
+      sessionError = err;
+    });
+
+    try {
+      // Debug builds spend several milliseconds of CPU per request, so scale
+      // the total down there. Pipeline the requests in batches of 50 (well
+      // under the advertised maxConcurrentStreams of 100) so the test is
+      // bounded by TOTAL / BATCH round trips instead of TOTAL sequential ones.
+      const TOTAL = isDebug ? 1_000 : 10_000;
+      const BATCH = 50;
+      let ok = 0;
+
+      for (let sent = 0; sent < TOTAL; sent += BATCH) {
+        if (sessionError) throw sessionError;
+        await Promise.all(
+          Array.from(
+            { length: Math.min(BATCH, TOTAL - sent) },
+            () =>
+              new Promise((resolve, reject) => {
+                const stream = client.request({ ":method": "POST" });
+                stream.on("error", reject);
+                stream.on("response", headers => {
+                  if (headers[":status"] === 200) ok++;
+                });
+                stream.on("close", resolve);
+                stream.end();
+              }),
+          ),
+        );
+      }
+
+      if (sessionError) throw sessionError;
+      expect(ok).toBe(TOTAL);
+    } finally {
+      client.close();
+      server.close();
+    }
   },
   15_000 * ASAN_MULTIPLIER,
 );


### PR DESCRIPTION
The "http2 server with minimal maxSessionMemory handles multiple requests" test in `test/js/node/http2/node-http2.test.js` issued 10,000 strictly sequential HTTP/2 round trips, which cannot finish inside its 15s timeout on an unoptimized build (it reliably times out partway through), so it shows up as a false failure on every local debug run of the file.

This sends the requests in concurrent batches of 50 (well under the advertised `maxConcurrentStreams` of 100), reduces the total to 1,000 on debug builds via the `isDebug` harness export while keeping 10,000 on release builds, and adds stream/session `error` handlers so a spurious stream rejection or a session-level GOAWAY fails the test immediately instead of hanging until the timeout. What the test verifies is unchanged: a session created with `maxSessionMemory: 1` must serve every request with a 200 and reject none of them.

No native code changes; the test passes on both debug and release builds (including with the system Bun). On a debug build the test now completes in a few seconds instead of timing out.