### PR TITLE
test: relax the timing-dependent chunk-count assertion in streams-leak.test.ts

### DIFF
--- a/test/js/web/streams/streams-leak.test.ts
+++ b/test/js/web/streams/streams-leak.test.ts
@@ -34,14 +34,15 @@ test("native ReadableStream reuses the pull buffer across small reads", async ()
   const chunks: Uint8Array[] = [];
   for await (const chunk of resp.body!) chunks.push(chunk);
 
-  // This is only a loose guard against a vacuous single-chunk pass. The
-  // number of client-side reads depends entirely on how the 1000 tiny
+  // The number of client-side reads depends entirely on how the 1000 tiny
   // writes coalesce in the socket under load (observed as low as 17 on
   // loaded CI machines), so don't assert a specific count here. The real
   // regression guards are the distinct-buffer-count and backing-bytes
   // assertions below, which detect the pre-fix one-256KB-buffer-per-chunk
   // behavior at any chunk count >= 8 without depending on the exact count.
-  expect(chunks.length).toBeGreaterThan(2);
+  // Require at least that many chunks so a passing run is guaranteed to
+  // have actually exercised those assertions.
+  expect(chunks.length).toBeGreaterThan(7);
 
   // Consecutive small reads should land in the same backing buffer (the
   // tail subarray is reused until a read fills it). 2KB of ~few-byte

--- a/test/js/web/streams/streams-leak.test.ts
+++ b/test/js/web/streams/streams-leak.test.ts
@@ -34,9 +34,14 @@ test("native ReadableStream reuses the pull buffer across small reads", async ()
   const chunks: Uint8Array[] = [];
   for await (const chunk of resp.body!) chunks.push(chunk);
 
-  // Some chunks coalesce on the wire; we just need a meaningful sample
-  // of small reads through the native pull path.
-  expect(chunks.length).toBeGreaterThan(20);
+  // This is only a loose guard against a vacuous single-chunk pass. The
+  // number of client-side reads depends entirely on how the 1000 tiny
+  // writes coalesce in the socket under load (observed as low as 17 on
+  // loaded CI machines), so don't assert a specific count here. The real
+  // regression guards are the distinct-buffer-count and backing-bytes
+  // assertions below, which detect the pre-fix one-256KB-buffer-per-chunk
+  // behavior at any chunk count >= 8 without depending on the exact count.
+  expect(chunks.length).toBeGreaterThan(2);
 
   // Consecutive small reads should land in the same backing buffer (the
   // tail subarray is reused until a read fills it). 2KB of ~few-byte


### PR DESCRIPTION
The pull-buffer reuse test asserts `chunks.length > 20`, but the number of reads the client observes depends entirely on how the 1000 tiny server writes coalesce in the socket under load — on busy machines it drops to 17–18 and the test fails on a precondition unrelated to the property it verifies. This lowers the precondition to a loose guard against a vacuous single-chunk pass and updates the comment to point at the distinct-buffer-count and backing-bytes assertions as the real regression checks.

No new test — the deliverable is the repaired assertion. Verified the modified test passes 10/10 consecutive runs, and that with the buffer-rotation condition in `#getInternalBuffer` temporarily reverted to its pre-fix form the test still fails on `distinctBuffers.size` (837 vs < 8), so the relaxed precondition does not weaken its detection power.