### PR TITLE
install: run the exit-time cache cleanup only on its owning thread

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -816,6 +816,15 @@ mod holder {
     pub(super) static INITIALIZED: core::sync::atomic::AtomicBool =
         core::sync::atomic::AtomicBool::new(false);
 
+    // Thread that ran `allocate_package_manager()` (the main CLI thread).
+    // `deinit_caches_at_exit` runs on whichever thread calls `Global::exit`
+    // first (e.g. the HTTP thread's on_init_error path). The cached
+    // `MapEntry.json_arena` heaps are `mi_heap_new`'d on this thread and
+    // `mi_heap_destroy` from any other thread is UB, so the exit callback
+    // must no-op unless it runs here.
+    pub(super) static OWNER_THREAD: bun_core::thread_id::AtomicThreadId =
+        bun_core::thread_id::AtomicThreadId::new(bun_core::thread_id::INVALID);
+
     // Process-lifetime env storage for `init()`. `dot_env::Loader<'a>` borrows `&'a mut Map`,
     // so the pair is self-referential and cannot live in `OnceLock<T>` (which only yields `&T`).
     // Mirrors Zig's `ctx.allocator.create(dot_env::Map)` / `create(dot_env::Loader)` — owned by
@@ -1414,6 +1423,10 @@ pub(crate) fn allocate_package_manager() {
     let ptr =
         bun_core::heap::into_raw(Box::<PackageManager>::new_uninit()).cast::<PackageManager>();
     holder::RAW_PTR.store(ptr, core::sync::atomic::Ordering::Release);
+    holder::OWNER_THREAD.store(
+        bun_core::thread_id::current(),
+        core::sync::atomic::Ordering::Release,
+    );
     bun_core::add_exit_callback(deinit_caches_at_exit);
 }
 
@@ -1421,11 +1434,24 @@ extern "C" fn deinit_caches_at_exit() {
     if !holder::INITIALIZED.load(core::sync::atomic::Ordering::Acquire) {
         return;
     }
+    // This exit callback runs on whichever thread called `Global::exit` first
+    // (quick_exit/atexit run handlers on the calling thread). `deinit_caches()`
+    // drops `MapEntry.json_arena` mimalloc heaps created on the owning thread;
+    // `mi_heap_destroy` from another thread is UB (and forming `&mut
+    // PackageManager` here would alias the main thread's live borrow). The
+    // process is exiting -- skip the free and let the OS reclaim it.
+    if bun_core::thread_id::current()
+        != holder::OWNER_THREAD.load(core::sync::atomic::Ordering::Acquire)
+    {
+        return;
+    }
     let ptr = get();
     if ptr.is_null() {
         return;
     }
-    // SAFETY: `deinit_caches()` only touches main-thread-owned fields.
+    // SAFETY: the owner-thread gate above guarantees this runs on the thread
+    // that allocated the singleton and owns the cached arenas, so
+    // `deinit_caches()` only touches state owned by the current thread.
     unsafe { (*ptr).deinit_caches() };
 }
 

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -296,6 +296,91 @@ describe("certificate authority", () => {
     expect(err).toContain(`HTTPThread: could not find CA file: '${join(packageDir, "does-not-exist")}'`);
     expect(await exited).toBe(1);
   });
+
+  test("cafile from bunfig does not exist in a workspace", async () => {
+    await Promise.all([
+      write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+          dependencies: {
+            "no-deps": "1.1.1",
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "a", "package.json"),
+        JSON.stringify({
+          name: "a",
+          version: "1.0.0",
+        }),
+      ),
+      write(
+        join(packageDir, "bunfig.toml"),
+        `
+      [install]
+      cache = false
+      registry = "http://localhost:${port}/"
+      cafile = "does-not-exist"`,
+      ),
+    ]);
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: join(packageDir, "packages", "a"),
+      stderr: "pipe",
+      stdout: "pipe",
+      env,
+    });
+
+    const out = await stdout.text();
+    expect(out).not.toContain("no-deps");
+    const err = await stderr.text();
+    expect(err).toContain(
+      `HTTPThread: could not find CA file: '${join(packageDir, "packages", "a", "does-not-exist")}'`,
+    );
+    expect(await exited).toBe(1);
+  });
+
+  test("install from workspace member directory still succeeds", async () => {
+    await Promise.all([
+      write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+          dependencies: {
+            "no-deps": "1.0.0",
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "a", "package.json"),
+        JSON.stringify({
+          name: "a",
+          version: "1.0.0",
+        }),
+      ),
+    ]);
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: join(packageDir, "packages", "a"),
+      stderr: "pipe",
+      stdout: "pipe",
+      env,
+    });
+
+    await stdout.text();
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(await exists(join(packageDir, "node_modules", "no-deps", "package.json"))).toBe(true);
+    expect(await exited).toBe(0);
+  });
+
   test("invalid cafile", async () => {
     await Promise.all([
       write(


### PR DESCRIPTION
### What does this PR do?

The package manager registers an exit callback (`deinit_caches_at_exit`) that frees the workspace `package.json` cache. That callback runs on whichever thread triggers process exit — for example the HTTP client thread when it fails to initialize — but the cached arenas are created and owned by the main CLI thread. This change records the owning thread when the singleton is allocated and makes the exit callback a no-op on any other thread, letting the OS reclaim the memory at process exit instead.

### How did you verify your code works?

Added two tests to `test/cli/install/bun-install-registry.test.ts`:
- `bun install` from a workspace member directory with a bunfig `cafile` that does not exist exits with code 1 and the expected error message.
- `bun install` from a workspace member directory without a `cafile` still installs successfully.

Ran the `certificate authority` suite and the new tests against the debug build.
