### PR TITLE
webcore: free Blob's owned content type on drop

### DIFF
--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -262,13 +262,14 @@ impl Blob {
         } else {
             std::ptr::from_ref::<[u8]>(b"" as &'static [u8])
         };
-        Blob {
-            size: Cell::new(size),
-            store: JsCell::new(Some(store)),
-            content_type: Cell::new(content_type),
-            global_this: Cell::new(global_this),
-            ..Default::default()
-        }
+        // PORT NOTE: spelled out via `Default::default()` + `Cell::set` —
+        // `Blob: Drop` makes functional-record-update an E0509.
+        let blob = Blob::default();
+        blob.size.set(size);
+        blob.store.set(Some(store));
+        blob.content_type.set(content_type);
+        blob.global_this.set(global_this);
+        blob
     }
 
     /// `Blob.init(bytes, allocator, globalThis)` (Blob.zig:3576). Takes
@@ -280,21 +281,19 @@ impl Blob {
         } else {
             None
         };
-        Blob {
-            size: Cell::new(size),
-            store: JsCell::new(store),
-            global_this: Cell::new(global_this),
-            ..Default::default()
-        }
+        let blob = Blob::default();
+        blob.size.set(size);
+        blob.store.set(store);
+        blob.global_this.set(global_this);
+        blob
     }
 
     /// `Blob.initEmpty(globalThis)` (Blob.zig:3660).
     #[inline]
     pub fn init_empty(global_this: &JSGlobalObject) -> Blob {
-        Blob {
-            global_this: Cell::new(global_this),
-            ..Default::default()
-        }
+        let blob = Blob::default();
+        blob.global_this.set(global_this);
+        blob
     }
 
     /// `Blob.sharedView()` (Blob.zig:3737) — borrowed view of the in-memory
@@ -337,31 +336,16 @@ impl Blob {
     ///
     /// In Zig that copy bumps **no** refcounts and is never `deinit()`ed — it
     /// just borrows `self`'s store/name/content_type for the caller's stack
-    /// frame. In Rust, both `StoreRef` and `OwnedStringCell` have drop glue,
-    /// so the only sound translation is: clone them (their `Drop` balances the
-    /// +1 at scope exit) and **alias** `content_type` as borrowed bits (a
-    /// `Copy` raw pointer with no `Drop`, so nothing runs on scope exit).
+    /// frame. In Rust every field of the copy carries its own teardown
+    /// (`StoreRef`/`OwnedStringCell` drop glue, plus `Blob`'s `Drop` for an
+    /// owned `content_type`), so the sound translation is a full [`Blob::dupe`]:
+    /// each clone/deep-copy is balanced by the drop at the caller's scope exit.
     ///
-    /// Do **not** use [`Blob::dupe`] for this — it boxes a fresh
-    /// `content_type`, which is not freed by drop glue, so it leaks when the
-    /// result is treated as a no-copy view.
+    /// Kept as a distinct named entry point so the call sites still read as
+    /// "Zig took a borrowed view here".
     #[inline]
     pub fn borrowed_view(&self) -> Blob {
-        Blob {
-            reported_estimated_size: Cell::new(self.reported_estimated_size.get()),
-            size: Cell::new(self.size.get()),
-            offset: Cell::new(self.offset.get()),
-            store: JsCell::new(self.store.get().clone()), // +1 ↔ StoreRef::drop on scope exit
-            content_type: Cell::new(self.content_type.get()), // borrowed; `self` owns it
-            content_type_allocated: Cell::new(self.content_type_allocated.get()),
-            content_type_was_set: Cell::new(self.content_type_was_set.get()),
-            charset: Cell::new(self.charset.get()),
-            is_jsdom_file: Cell::new(self.is_jsdom_file.get()),
-            ref_count: bun_ptr::RawRefCount::init(0), // setNotHeapAllocated
-            global_this: Cell::new(self.global_this.get()),
-            last_modified: Cell::new(self.last_modified.get()),
-            name: self.name.clone(), // +1 ↔ OwnedStringCell::drop on scope exit
-        }
+        self.dupe()
     }
 
     /// `Blob.dupeWithContentType()` (Blob.zig:3688). The Zig spec ignores
@@ -370,14 +354,24 @@ impl Blob {
     /// borrow path was removed because it dropped user-supplied parameters
     /// like multipart boundaries on a static-mime miss).
     pub fn dupe_with_content_type(&self, _include_content_type: bool) -> Blob {
+        // If the source's content_type is heap-allocated, a bitwise copy would
+        // alias the same allocation and `Drop` would free it twice. Take our
+        // own copy *before* constructing the duplicate so no transient `Blob`
+        // ever claims ownership of the source's allocation (Blob.zig:3700).
+        let content_type = if self.content_type_allocated.get() {
+            let copy = self.content_type_slice().to_vec().into_boxed_slice();
+            bun_core::heap::into_raw(copy).cast_const()
+        } else {
+            self.content_type.get()
+        };
         // Zig: `if (this.store != null) this.store.?.ref()` then bitwise-copy.
         // `Option<StoreRef>::clone` bumps the intrusive `Store::ref_count`.
-        let duped = Blob {
+        Blob {
             reported_estimated_size: Cell::new(self.reported_estimated_size.get()),
             size: Cell::new(self.size.get()),
             offset: Cell::new(self.offset.get()),
             store: JsCell::new(self.store.get().clone()),
-            content_type: Cell::new(self.content_type.get()),
+            content_type: Cell::new(content_type),
             content_type_allocated: Cell::new(self.content_type_allocated.get()),
             content_type_was_set: Cell::new(self.content_type_was_set.get()),
             charset: Cell::new(self.charset.get()),
@@ -386,18 +380,9 @@ impl Blob {
             global_this: Cell::new(self.global_this.get()),
             last_modified: Cell::new(self.last_modified.get()),
             name: self.name.clone(),
-        };
-        // If the source's content_type is heap-allocated, the bitwise copy
-        // above aliases the same allocation. Take our own copy so freeing one
-        // side doesn't dangle the other (Blob.zig:3700).
-        if duped.content_type_allocated.get() {
-            let copy = self.content_type_slice().to_vec().into_boxed_slice();
-            duped.content_type.set(bun_core::heap::into_raw(copy));
         }
-        duped
     }
 
-    /// `Blob.deinit()` (Blob.zig:3720). Tear down owned resources; if
     // ────────────────────────────────────────────────────────────────────
     // Data-only predicates (Blob.zig:3601-3659). LAYERING: hoisted from
     // `bun_runtime::webcore::blob::BlobExt` — these read only the `Store`
@@ -467,11 +452,14 @@ impl Blob {
         }
     }
 
+    /// `Blob.deinit()` (Blob.zig:3720). Tear down owned resources; if
     /// heap-allocated, also frees the heap box.
     ///
-    /// PORT NOTE: kept as an explicit method (not `Drop`) because `Blob` is the
-    /// `m_ctx` payload of a `.classes.ts` class — `finalize()` owns teardown,
-    /// and many call sites tear down stack copies explicitly.
+    /// PORT NOTE: kept as an explicit method because `Blob` is the `m_ctx`
+    /// payload of a `.classes.ts` class — `finalize()` owns teardown, and many
+    /// call sites tear down stack copies explicitly. `Drop` covers the same
+    /// fields for by-value drops (every step here is idempotent, so running
+    /// both is safe), but only `deinit()` frees the heap box itself.
     pub fn deinit(&mut self) {
         self.detach();
         self.name.set(bun_core::String::dead());
@@ -483,6 +471,21 @@ impl Blob {
             // `Blob::new` (`heap::alloc`).
             unsafe { drop(bun_core::heap::take(std::ptr::from_mut::<Blob>(self))) };
         }
+    }
+}
+
+/// The `store` and `name` fields already have their own drop glue
+/// (`StoreRef`/`OwnedStringCell`); `content_type` is a bare `Cell<*const [u8]>`
+/// and was the one owned resource a by-value drop leaked. Freeing it here makes
+/// every consumer that drops a `dupe()`d / `use_()`d / deserialized `Blob`
+/// without an explicit `deinit()` release the heap-allocated content type.
+///
+/// `free_content_type` only frees when `content_type_allocated` is set and
+/// resets the flag, so the existing explicit `deinit()` / `free_content_type()`
+/// call sites layered under this `Drop` cannot double-free.
+impl Drop for Blob {
+    fn drop(&mut self) {
+        self.free_content_type();
     }
 }
 

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -262,8 +262,6 @@ impl Blob {
         } else {
             std::ptr::from_ref::<[u8]>(b"" as &'static [u8])
         };
-        // PORT NOTE: spelled out via `Default::default()` + `Cell::set` —
-        // `Blob: Drop` makes functional-record-update an E0509.
         let blob = Blob::default();
         blob.size.set(size);
         blob.store.set(Some(store));
@@ -333,16 +331,6 @@ impl Blob {
 
     /// Rust spelling of Zig's raw `blob.*` bitwise copy (e.g.
     /// `PathOrBlob.fromJSNoCopy`, `var blob_internal = .{ .blob = this.* }`).
-    ///
-    /// In Zig that copy bumps **no** refcounts and is never `deinit()`ed — it
-    /// just borrows `self`'s store/name/content_type for the caller's stack
-    /// frame. In Rust every field of the copy carries its own teardown
-    /// (`StoreRef`/`OwnedStringCell` drop glue, plus `Blob`'s `Drop` for an
-    /// owned `content_type`), so the sound translation is a full [`Blob::dupe`]:
-    /// each clone/deep-copy is balanced by the drop at the caller's scope exit.
-    ///
-    /// Kept as a distinct named entry point so the call sites still read as
-    /// "Zig took a borrowed view here".
     #[inline]
     pub fn borrowed_view(&self) -> Blob {
         self.dupe()
@@ -354,10 +342,6 @@ impl Blob {
     /// borrow path was removed because it dropped user-supplied parameters
     /// like multipart boundaries on a static-mime miss).
     pub fn dupe_with_content_type(&self, _include_content_type: bool) -> Blob {
-        // If the source's content_type is heap-allocated, a bitwise copy would
-        // alias the same allocation and `Drop` would free it twice. Take our
-        // own copy *before* constructing the duplicate so no transient `Blob`
-        // ever claims ownership of the source's allocation (Blob.zig:3700).
         let content_type = if self.content_type_allocated.get() {
             let copy = self.content_type_slice().to_vec().into_boxed_slice();
             bun_core::heap::into_raw(copy).cast_const()
@@ -454,12 +438,6 @@ impl Blob {
 
     /// `Blob.deinit()` (Blob.zig:3720). Tear down owned resources; if
     /// heap-allocated, also frees the heap box.
-    ///
-    /// PORT NOTE: kept as an explicit method because `Blob` is the `m_ctx`
-    /// payload of a `.classes.ts` class — `finalize()` owns teardown, and many
-    /// call sites tear down stack copies explicitly. `Drop` covers the same
-    /// fields for by-value drops (every step here is idempotent, so running
-    /// both is safe), but only `deinit()` frees the heap box itself.
     pub fn deinit(&mut self) {
         self.detach();
         self.name.set(bun_core::String::dead());
@@ -474,15 +452,6 @@ impl Blob {
     }
 }
 
-/// The `store` and `name` fields already have their own drop glue
-/// (`StoreRef`/`OwnedStringCell`); `content_type` is a bare `Cell<*const [u8]>`
-/// and was the one owned resource a by-value drop leaked. Freeing it here makes
-/// every consumer that drops a `dupe()`d / `use_()`d / deserialized `Blob`
-/// without an explicit `deinit()` release the heap-allocated content type.
-///
-/// `free_content_type` only frees when `content_type_allocated` is set and
-/// resets the flag, so the existing explicit `deinit()` / `free_content_type()`
-/// call sites layered under this `Drop` cannot double-free.
 impl Drop for Blob {
     fn drop(&mut self) {
         self.free_content_type();

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1439,9 +1439,6 @@ mod vm_loader_ctx {
                 core::slice::from_raw_parts(v.as_ptr(), v.len())
             },
             blob_deinit(b) => {
-                // `b` was produced by `resolve_blob` (heap::into_raw of a
-                // `dupe_with_content_type` clone). `Blob`'s drop glue releases
-                // the store/name refs and the deep-copied `content_type`.
                 // SAFETY: `b` is the live boxed `Blob`; sole owner.
                 drop(bun_core::heap::take(b.cast::<Blob>()))
             },

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1440,11 +1440,9 @@ mod vm_loader_ctx {
             },
             blob_deinit(b) => {
                 // `b` was produced by `resolve_blob` (heap::into_raw of a
-                // `dupe_with_content_type` clone). `Blob`'s drop glue does not
-                // free `content_type` (raw `*const [u8]`), so the
-                // ObjectURLRegistry resolve path stranded that allocation.
+                // `dupe_with_content_type` clone). `Blob`'s drop glue releases
+                // the store/name refs and the deep-copied `content_type`.
                 // SAFETY: `b` is the live boxed `Blob`; sole owner.
-                unsafe { (*b.cast::<Blob>()).free_content_type() };
                 drop(bun_core::heap::take(b.cast::<Blob>()))
             },
         }

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -68,9 +68,10 @@ impl Drop for BlobOrStringOrBuffer {
     fn drop(&mut self) {
         match self {
             Self::Blob(blob) => {
-                // `.blob` is a raw bitwise copy of a live JS Blob — it does NOT own
-                // content_type/name. Only release the store reference.
-                // `StoreRef::drop` (via `Option::take`) calls `Store::deref()`.
+                // `.blob` is a self-owning `dupe()`: the `Box<Blob>` drop glue
+                // releases the store ref, the +1 `name`, and the deep-copied
+                // `content_type`. Taking the store first only mirrors Zig's
+                // explicit teardown order; the field drop then sees `None`.
                 let _ = blob.store.with_mut(|s| s.take());
             }
             Self::StringOrBuffer(_) => {

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1984,12 +1984,11 @@ impl PathOrBlob {
         };
         if let Some(blob) = arg.as_class_ref::<Blob>() {
             // Zig: `blob.*` — a raw bitwise copy with no ref bumps that callers
-            // never `deinit()`. `borrowed_view()` is the sound Rust spelling: it
-            // clones the `StoreRef`/`name` (whose `Drop`s balance the +1) and
-            // aliases `content_type`; `dupe()` would leak the boxed
-            // `content_type` copy. `as_class_ref` is the safe shared-borrow
-            // downcast — the JS wrapper roots the payload while `arg` is on the
-            // stack.
+            // never `deinit()`. `borrowed_view()` is the sound Rust spelling: a
+            // self-owning `dupe()` whose `StoreRef`/`name`/`content_type` are
+            // all released by drop glue at scope exit. `as_class_ref` is the
+            // safe shared-borrow downcast — the JS wrapper roots the payload
+            // while `arg` is on the stack.
             return Ok(PathOrBlob::Blob(Box::new(blob.borrowed_view())));
         }
         Err(ctx.throw_invalid_argument_type_value(

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -68,10 +68,6 @@ impl Drop for BlobOrStringOrBuffer {
     fn drop(&mut self) {
         match self {
             Self::Blob(blob) => {
-                // `.blob` is a self-owning `dupe()`: the `Box<Blob>` drop glue
-                // releases the store ref, the +1 `name`, and the deep-copied
-                // `content_type`. Taking the store first only mirrors Zig's
-                // explicit teardown order; the field drop then sees `None`.
                 let _ = blob.store.with_mut(|s| s.take());
             }
             Self::StringOrBuffer(_) => {
@@ -1984,12 +1980,6 @@ impl PathOrBlob {
             ));
         };
         if let Some(blob) = arg.as_class_ref::<Blob>() {
-            // Zig: `blob.*` — a raw bitwise copy with no ref bumps that callers
-            // never `deinit()`. `borrowed_view()` is the sound Rust spelling: a
-            // self-owning `dupe()` whose `StoreRef`/`name`/`content_type` are
-            // all released by drop glue at scope exit. `as_class_ref` is the
-            // safe shared-borrow downcast — the JS wrapper roots the payload
-            // while `arg` is on the stack.
             return Ok(PathOrBlob::Blob(Box::new(blob.borrowed_view())));
         }
         Err(ctx.throw_invalid_argument_type_value(

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -130,10 +130,6 @@ impl FileRoute {
     fn deinit(this: *mut FileRoute) {
         // SAFETY: `this` was allocated via heap::alloc in init_from_blob/from_js and the
         // intrusive ref_count has reached 0.
-        // Mirror Zig FileRoute.zig:53 `this.blob.deinit()`. `Blob`'s drop glue
-        // also releases the store/name/content_type on Box auto-drop; the
-        // explicit `deinit()` matches the Zig teardown order and is idempotent
-        // under the subsequent field drops.
         // `headers` is freed by its own Drop when the Box is dropped.
         unsafe {
             (*this).blob.deinit();

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -130,9 +130,10 @@ impl FileRoute {
     fn deinit(this: *mut FileRoute) {
         // SAFETY: `this` was allocated via heap::alloc in init_from_blob/from_js and the
         // intrusive ref_count has reached 0.
-        // Mirror Zig FileRoute.zig:53 `this.blob.deinit()` — `Blob` has no Drop,
-        // so its raw `content_type: Cell<*const [u8]>` (when
-        // `content_type_allocated`) would otherwise leak on Box auto-drop.
+        // Mirror Zig FileRoute.zig:53 `this.blob.deinit()`. `Blob`'s drop glue
+        // also releases the store/name/content_type on Box auto-drop; the
+        // explicit `deinit()` matches the Zig teardown order and is idempotent
+        // under the subsequent field drops.
         // `headers` is freed by its own Drop when the Box is dropped.
         unsafe {
             (*this).blob.deinit();

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -6501,8 +6501,9 @@ impl Any {
                     // `StoreRef` exposes interior-mutable `data_mut()` (no DerefMut).
                     let internal = s.data_mut().as_bytes_mut().to_internal_blob();
                     // PORT NOTE: Zig deref's the store; StoreRef::drop on replace handles it.
-                    // `content_type` is a raw pointer not covered by any field's
-                    // drop glue — free it explicitly.
+                    // `Blob::drop` also frees `content_type` when `*self` is replaced
+                    // below; the explicit call mirrors Zig's teardown order and is
+                    // idempotent.
                     blob.free_content_type();
                     *self = Any::InternalBlob(internal);
                     return;
@@ -6802,10 +6803,9 @@ impl Any {
     pub fn detach(&mut self) {
         match self {
             Any::Blob(b) => {
-                // `content_type` is a raw `*const [u8]` not covered by `Blob`'s drop
-                // glue; release it here so a heap-owned content_type (e.g. the
-                // `multipart/form-data; boundary=…` string from `from_dom_form_data`)
-                // doesn't leak when the AnyBlob is torn down.
+                // `Blob::drop` frees `content_type` when `*self` is overwritten
+                // below; the explicit call mirrors Zig's teardown order and is
+                // idempotent.
                 b.free_content_type();
                 b.detach();
                 *self = Any::Blob(Blob::default());

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1369,7 +1369,8 @@ impl BlobExt for Blob {
         // Zig: `var blob_internal: PathOrBlob = .{ .blob = this.* }` — a raw
         // bitwise copy with NO ref bumps; `write_file_internal` then `dupe()`s
         // its own owned `destination_blob` from it. `borrowed_view()` is the
-        // sound Rust spelling — see its doc for why `dupe()` would leak here.
+        // sound Rust spelling: a self-owning `dupe()` whose store/name/
+        // content_type are all released by drop glue at scope exit.
         let mut blob_internal = PathOrBlob::Blob(Box::new(self.borrowed_view()));
         write_file_internal(
             global_this,
@@ -2523,14 +2524,15 @@ impl BlobExt for Blob {
             unsafe { (*s.as_ptr()).is_all_ascii = Some(is_all_ascii) };
             store = Some(s);
         }
-        Blob {
-            size: Cell::new(len as SizeType),
-            store: JsCell::new(store),
-            content_type: Cell::new(std::ptr::from_ref::<[u8]>(b"" as &'static [u8])),
-            global_this: Cell::new(global_this),
-            charset: Cell::new(strings::AsciiStatus::from_bool(Some(is_all_ascii))),
-            ..Default::default()
-        }
+        // PORT NOTE: spell out via `Default::default()` + `Cell::set` —
+        // `Blob: Drop` makes functional-record-update an E0509.
+        let blob = Blob::default();
+        blob.size.set(len as SizeType);
+        blob.store.set(store);
+        blob.global_this.set(global_this);
+        blob.charset
+            .set(strings::AsciiStatus::from_bool(Some(is_all_ascii)));
+        blob
     }
 
     fn create_with_bytes_and_allocator(
@@ -2539,21 +2541,22 @@ impl BlobExt for Blob {
         was_string: bool,
     ) -> Blob {
         let len = bytes.len();
-        Blob {
-            size: Cell::new(len as SizeType),
-            store: JsCell::new(if len > 0 {
-                Some(Store::init(bytes))
-            } else {
-                None
-            }),
-            content_type: Cell::new(if was_string {
-                std::ptr::from_ref::<[u8]>(bun_http_types::MimeType::TEXT.value.as_ref())
-            } else {
-                std::ptr::from_ref::<[u8]>(b"" as &'static [u8])
-            }),
-            global_this: Cell::new(global_this),
-            ..Default::default()
+        // PORT NOTE: spell out via `Default::default()` + `Cell::set` —
+        // `Blob: Drop` makes functional-record-update an E0509.
+        let blob = Blob::default();
+        blob.size.set(len as SizeType);
+        blob.store.set(if len > 0 {
+            Some(Store::init(bytes))
+        } else {
+            None
+        });
+        if was_string {
+            blob.content_type.set(std::ptr::from_ref::<[u8]>(
+                bun_http_types::MimeType::TEXT.value.as_ref(),
+            ));
         }
+        blob.global_this.set(global_this);
+        blob
     }
 
     fn try_create(
@@ -3306,10 +3309,7 @@ impl BlobExt for Blob {
     ) -> JsResult<Blob> {
         let mut current = arg;
         if current.is_undefined_or_null() {
-            return Ok(Blob {
-                global_this: Cell::new(global),
-                ..Default::default()
-            });
+            return Ok(Blob::init_empty(global));
         }
 
         let mut top_value = current;
@@ -3322,10 +3322,7 @@ impl BlobExt for Blob {
                 let mut top_iter = jsc::JSArrayIterator::init(current, global)?;
                 might_only_be_one_thing = top_iter.len == 1;
                 if top_iter.len == 0 {
-                    return Ok(Blob {
-                        global_this: Cell::new(global),
-                        ..Default::default()
-                    });
+                    return Ok(Blob::init_empty(global));
                 }
                 if might_only_be_one_thing {
                     top_value = top_iter.next()?.unwrap();
@@ -4690,13 +4687,11 @@ pub fn write_file_with_source_destination(
         // Zig passes `destination_blob.*` / `source_blob.*` (raw struct copy,
         // +0 store ref) and `WriteFile.create` then calls `store.?.ref()`. The
         // Rust port folds that pair into RAII: callers hand over a +1 `Blob`
-        // via `borrowed_view()` (clones the `StoreRef`/`name`; `content_type`
-        // is aliased — unused by `WriteFile*`, no `Drop`) and
+        // via `borrowed_view()` (a self-owning `dupe()`) and
         // `WriteFile::create` does NOT re-bump (see PORT NOTE in
         // `write_file.rs::create_with_ctx`); the matching deref runs when
-        // `heap::take` drops the embedded `StoreRef`/`name` in `then`/`deinit`.
-        // Net ref balance is identical. `dupe()` is wrong here: it boxes a
-        // fresh `content_type`, which is not released by `Blob`'s drop glue.
+        // `heap::take` drops the embedded `StoreRef`/`name`/`content_type` in
+        // `then`/`deinit`. Net ref balance is identical.
         #[cfg(windows)]
         {
             let promise = JSPromise::create(ctx);

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1368,9 +1368,7 @@ impl BlobExt for Blob {
         }
         // Zig: `var blob_internal: PathOrBlob = .{ .blob = this.* }` — a raw
         // bitwise copy with NO ref bumps; `write_file_internal` then `dupe()`s
-        // its own owned `destination_blob` from it. `borrowed_view()` is the
-        // sound Rust spelling: a self-owning `dupe()` whose store/name/
-        // content_type are all released by drop glue at scope exit.
+        // its own owned `destination_blob` from it.
         let mut blob_internal = PathOrBlob::Blob(Box::new(self.borrowed_view()));
         write_file_internal(
             global_this,
@@ -2524,8 +2522,6 @@ impl BlobExt for Blob {
             unsafe { (*s.as_ptr()).is_all_ascii = Some(is_all_ascii) };
             store = Some(s);
         }
-        // PORT NOTE: spell out via `Default::default()` + `Cell::set` —
-        // `Blob: Drop` makes functional-record-update an E0509.
         let blob = Blob::default();
         blob.size.set(len as SizeType);
         blob.store.set(store);
@@ -2541,8 +2537,6 @@ impl BlobExt for Blob {
         was_string: bool,
     ) -> Blob {
         let len = bytes.len();
-        // PORT NOTE: spell out via `Default::default()` + `Cell::set` —
-        // `Blob: Drop` makes functional-record-update an E0509.
         let blob = Blob::default();
         blob.size.set(len as SizeType);
         blob.store.set(if len > 0 {
@@ -4685,13 +4679,7 @@ pub fn write_file_with_source_destination(
         }));
 
         // Zig passes `destination_blob.*` / `source_blob.*` (raw struct copy,
-        // +0 store ref) and `WriteFile.create` then calls `store.?.ref()`. The
-        // Rust port folds that pair into RAII: callers hand over a +1 `Blob`
-        // via `borrowed_view()` (a self-owning `dupe()`) and
-        // `WriteFile::create` does NOT re-bump (see PORT NOTE in
-        // `write_file.rs::create_with_ctx`); the matching deref runs when
-        // `heap::take` drops the embedded `StoreRef`/`name`/`content_type` in
-        // `then`/`deinit`. Net ref balance is identical.
+        // +0 store ref) and `WriteFile.create` then calls `store.?.ref()`.
         #[cfg(windows)]
         {
             let promise = JSPromise::create(ctx);
@@ -5229,10 +5217,6 @@ pub fn write_file_internal(
                             bun_core::heap::into_raw(Box::new(WriteFileWaitFromLockedValueTask {
                                 global_this: bun_ptr::BackRef::new(global_this),
                                 // Zig moves `destination_blob` by value into the task
-                                // (single store ref transfers; outer local is dead after the
-                                // early return). Take the value and leave an empty blob
-                                // behind so the residual local owns no store and no extra
-                                // +1 is taken.
                                 file_blob: core::mem::replace(
                                     &mut destination_blob,
                                     Blob::init_empty(global_this),
@@ -6501,9 +6485,6 @@ impl Any {
                     // `StoreRef` exposes interior-mutable `data_mut()` (no DerefMut).
                     let internal = s.data_mut().as_bytes_mut().to_internal_blob();
                     // PORT NOTE: Zig deref's the store; StoreRef::drop on replace handles it.
-                    // `Blob::drop` also frees `content_type` when `*self` is replaced
-                    // below; the explicit call mirrors Zig's teardown order and is
-                    // idempotent.
                     blob.free_content_type();
                     *self = Any::InternalBlob(internal);
                     return;
@@ -6803,9 +6784,6 @@ impl Any {
     pub fn detach(&mut self) {
         match self {
             Any::Blob(b) => {
-                // `Blob::drop` frees `content_type` when `*self` is overwritten
-                // below; the explicit call mirrors Zig's teardown order and is
-                // idempotent.
                 b.free_content_type();
                 b.detach();
                 *self = Any::Blob(Blob::default());

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5230,9 +5230,9 @@ pub fn write_file_internal(
                                 global_this: bun_ptr::BackRef::new(global_this),
                                 // Zig moves `destination_blob` by value into the task
                                 // (single store ref transfers; outer local is dead after the
-                                // early return). `dupe()` here would leak one StoreRef since
-                                // Blob has no Drop. Take the value and leave an empty blob
-                                // behind so the residual local owns no store.
+                                // early return). Take the value and leave an empty blob
+                                // behind so the residual local owns no store and no extra
+                                // +1 is taken.
                                 file_blob: core::mem::replace(
                                     &mut destination_blob,
                                     Blob::init_empty(global_this),

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -842,10 +842,6 @@ impl Value {
             Value::Null => Ok(JSValue::NULL),
             Value::InternalBlob(_) | Value::Blob(_) | Value::WTFStringImpl(_) => {
                 // Zig: `defer blob.detach()` — must run on every exit incl. `?` paths.
-                // `use_()` hands back a stack-owned `Blob`. `Blob::drop` also frees an
-                // owned `content_type`; the explicit `deinit()` (detach +
-                // free_content_type) mirrors Zig's teardown order and is idempotent
-                // under the guard payload's drop.
                 let blob = scopeguard::guard(self.use_(), |mut b| b.deinit());
                 blob.resolve_size();
                 let blob_size = blob.size.get();
@@ -1123,12 +1119,6 @@ impl Value {
                     Action::GetText => match new {
                         Value::WTFStringImpl(_) | Value::InternalBlob(_) /* | Value::InlineBlob(_) */ => {
                             let mut blob = new.use_as_any_blob_allow_non_utf8_string();
-                            // `to_string_transfer` moves the bytes into a JS string but
-                            // leaves the heap-owned `content_type` (from
-                            // `from_dom_form_data`) in the `Any::Blob` variant. The inner
-                            // `Blob`'s drop glue frees it; the explicit `detach()` mirrors
-                            // Zig's teardown order (same as the GetJSON / GetFormData
-                            // arms) and is idempotent.
                             let result = promise.wrap(global, |g| blob.to_string_transfer(g));
                             blob.detach();
                             result?;
@@ -1865,11 +1855,6 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
 
         let value = self.get_body_value();
         let mut blob = value.use_as_any_blob_allow_non_utf8_string();
-        // `to_string(Transfer)` moves the bytes into the JS string but leaves the
-        // heap-owned `content_type` (e.g. the `multipart/form-data; boundary=…`
-        // string from `from_dom_form_data`) in `Any::Blob`. The inner `Blob`'s
-        // drop glue frees it; the explicit `detach()` mirrors Zig's teardown
-        // order and is idempotent.
         let result = JSPromise::wrap(global_object, |g| blob.to_string(g, Lifetime::Transfer));
         blob.detach();
         Ok(result?)

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -842,12 +842,10 @@ impl Value {
             Value::Null => Ok(JSValue::NULL),
             Value::InternalBlob(_) | Value::Blob(_) | Value::WTFStringImpl(_) => {
                 // Zig: `defer blob.detach()` — must run on every exit incl. `?` paths.
-                // `use_()` hands back a stack-owned `Blob`; `Blob::detach()` only
-                // releases the store, so a heap-owned `content_type` (e.g. the
-                // `multipart/form-data; boundary=…` from `from_dom_form_data`)
-                // would leak. `deinit()` = detach + free_content_type and is a
-                // no-op on the heap-free path (`is_heap_allocated()` is false —
-                // asserted in `use_()`). Same gap exists in the Zig spec.
+                // `use_()` hands back a stack-owned `Blob`. `Blob::drop` also frees an
+                // owned `content_type`; the explicit `deinit()` (detach +
+                // free_content_type) mirrors Zig's teardown order and is idempotent
+                // under the guard payload's drop.
                 let blob = scopeguard::guard(self.use_(), |mut b| b.deinit());
                 blob.resolve_size();
                 let blob_size = blob.size.get();
@@ -1125,12 +1123,12 @@ impl Value {
                     Action::GetText => match new {
                         Value::WTFStringImpl(_) | Value::InternalBlob(_) /* | Value::InlineBlob(_) */ => {
                             let mut blob = new.use_as_any_blob_allow_non_utf8_string();
-                            // `Any` has no Drop. `to_string_transfer` moves the bytes into
-                            // a JS string but leaves the heap-owned `content_type` (from
-                            // `from_dom_form_data`) behind in the `Any::Blob` variant —
-                            // detach() (idempotent) reclaims it. Same defer is already in
-                            // the GetJSON / GetFormData arms; the Zig spec omits it here
-                            // and leaks ~80B per FormData body under ASAN.
+                            // `to_string_transfer` moves the bytes into a JS string but
+                            // leaves the heap-owned `content_type` (from
+                            // `from_dom_form_data`) in the `Any::Blob` variant. The inner
+                            // `Blob`'s drop glue frees it; the explicit `detach()` mirrors
+                            // Zig's teardown order (same as the GetJSON / GetFormData
+                            // arms) and is idempotent.
                             let result = promise.wrap(global, |g| blob.to_string_transfer(g));
                             blob.detach();
                             result?;
@@ -1867,10 +1865,11 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
 
         let value = self.get_body_value();
         let mut blob = value.use_as_any_blob_allow_non_utf8_string();
-        // `Any` has no Drop. `to_string(Transfer)` moves the bytes into the JS
-        // string but leaves the heap-owned `content_type` (e.g. the
-        // `multipart/form-data; boundary=…` string from `from_dom_form_data`)
-        // behind in `Any::Blob` — `detach()` (idempotent) reclaims it.
+        // `to_string(Transfer)` moves the bytes into the JS string but leaves the
+        // heap-owned `content_type` (e.g. the `multipart/form-data; boundary=…`
+        // string from `from_dom_form_data`) in `Any::Blob`. The inner `Blob`'s
+        // drop glue frees it; the explicit `detach()` mirrors Zig's teardown
+        // order and is idempotent.
         let result = JSPromise::wrap(global_object, |g| blob.to_string(g, Lifetime::Transfer));
         blob.detach();
         Ok(result?)

--- a/src/runtime/webcore/ByteBlobLoader.rs
+++ b/src/runtime/webcore/ByteBlobLoader.rs
@@ -254,10 +254,6 @@ impl ByteBlobLoader {
     ) -> JsResult<JSValue> {
         if let Some(mut blob) = self.to_any_blob(global) {
             let result = blob.to_promise(global, action);
-            // The inner `Blob`'s drop glue releases the store ref and the owned
-            // `content_type` filled by `to_any_blob`; the explicit `detach()`
-            // mirrors Zig's teardown order and is idempotent (same shape as the
-            // BodyMixin arms in `Body.rs`).
             blob.detach();
             return Ok(result?);
         }

--- a/src/runtime/webcore/ByteBlobLoader.rs
+++ b/src/runtime/webcore/ByteBlobLoader.rs
@@ -254,10 +254,10 @@ impl ByteBlobLoader {
     ) -> JsResult<JSValue> {
         if let Some(mut blob) = self.to_any_blob(global) {
             let result = blob.to_promise(global, action);
-            // `Any` has no `Drop` and the inner `Blob`'s `content_type` is a
-            // raw `*const [u8]` that `to_any_blob` filled via `into_raw`;
-            // release the store ref + content_type explicitly (same shape as
-            // the BodyMixin arms in `Body.rs`).
+            // The inner `Blob`'s drop glue releases the store ref and the owned
+            // `content_type` filled by `to_any_blob`; the explicit `detach()`
+            // mirrors Zig's teardown order and is idempotent (same shape as the
+            // BodyMixin arms in `Body.rs`).
             blob.detach();
             return Ok(result?);
         }

--- a/src/runtime/webcore/ObjectURLRegistry.rs
+++ b/src/runtime/webcore/ObjectURLRegistry.rs
@@ -50,12 +50,6 @@ impl Entry {
 impl Drop for Entry {
     fn drop(&mut self) {
         // Zig `Entry.deinit`: `this.blob.deinit(); bun.destroy(this);`.
-        // `Blob`'s field/struct drop glue would also release the +1 `name` ref
-        // and the heap-allocated `content_type` taken by
-        // `dupe_with_content_type`; the explicit `deinit()` matches the Zig
-        // teardown order and is idempotent under the subsequent field drops.
-        // The duped blob's `ref_count == 0`, so `deinit`'s heap-free branch is
-        // skipped.
         self.blob.deinit();
         // `bun.destroy(this)` ↔ `Box<Entry>` drop.
     }

--- a/src/runtime/webcore/ObjectURLRegistry.rs
+++ b/src/runtime/webcore/ObjectURLRegistry.rs
@@ -50,11 +50,12 @@ impl Entry {
 impl Drop for Entry {
     fn drop(&mut self) {
         // Zig `Entry.deinit`: `this.blob.deinit(); bun.destroy(this);`.
-        // `Blob` has no `Drop` impl (it's a `.classes.ts` ctx payload with an
-        // explicit `deinit()` — see webcore_types.rs PORT NOTE), so we must
-        // call it here to release the +1 `name` ref and any heap-allocated
-        // `content_type` taken by `dupe_with_content_type`. The duped blob's
-        // `ref_count == 0`, so `deinit`'s heap-free branch is skipped.
+        // `Blob`'s field/struct drop glue would also release the +1 `name` ref
+        // and the heap-allocated `content_type` taken by
+        // `dupe_with_content_type`; the explicit `deinit()` matches the Zig
+        // teardown order and is idempotent under the subsequent field drops.
+        // The duped blob's `ref_count == 0`, so `deinit`'s heap-free branch is
+        // skipped.
         self.blob.deinit();
         // `bun.destroy(this)` ↔ `Box<Entry>` drop.
     }

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -104,8 +104,10 @@ impl<'a, F: ReadFileToJs> ReadFileCompletion for NewReadFileHandler<'a, F> {
         let promise: *mut jsc::JSPromise = handler.promise.swap();
         let blob = core::mem::take(&mut handler.context);
         // `context` was populated via `this.dupe()` in doReadFile(), so it
-        // owns a store ref, a name ref, and possibly a content_type copy.
-        // (blob is dropped at end of scope — Drop handles deinit.)
+        // owns a store ref, a name ref, and possibly a deep-copied
+        // content_type. All three are released by drop glue when `blob` goes
+        // out of scope (`StoreRef`/`OwnedStringCell` field drops + `Blob`'s
+        // `Drop` freeing the owned content_type).
         let global_this = handler.global_this;
         drop(handler);
         match maybe_bytes {

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -103,11 +103,6 @@ impl<'a, F: ReadFileToJs> ReadFileCompletion for NewReadFileHandler<'a, F> {
         // Decay to a raw pointer so `handler` can be dropped before resolution.
         let promise: *mut jsc::JSPromise = handler.promise.swap();
         let blob = core::mem::take(&mut handler.context);
-        // `context` was populated via `this.dupe()` in doReadFile(), so it
-        // owns a store ref, a name ref, and possibly a deep-copied
-        // content_type. All three are released by drop glue when `blob` goes
-        // out of scope (`StoreRef`/`OwnedStringCell` field drops + `Blob`'s
-        // `Drop` freeing the owned content_type).
         let global_this = handler.global_this;
         drop(handler);
         match maybe_bytes {

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -326,20 +326,11 @@ test("dupe() preserves allocated content_type for Body clone", () => {
 });
 
 test("Bun.file(path, {type}).text() does not leak the duped content_type", async () => {
-  // Reading a file-backed Blob goes text() -> doReadFile -> Blob.dupe(),
-  // which deep-copies a heap-allocated (non-registry) content type into the
-  // read handler's context blob. That copy must be released when the handler's
-  // blob is dropped; otherwise every .text() on a typed Bun.file leaks the
-  // whole content-type allocation. A 64 KiB type makes the leak measurable in
-  // RSS: 1024 reads leak >= 64 MiB unfixed.
   using dir = tempDir("blob-text-content-type", {
     "data.txt": "hello",
   });
   const script = `
     const p = ${JSON.stringify(path.join(String(dir), "data.txt"))};
-    // Printable-ASCII non-registry type so the mime-table lookup misses and
-    // the content type is heap-allocated. Hoisted out of the loop: the source
-    // handle's own allocation happens exactly once.
     const type = "application/x-" + Buffer.alloc(64 * 1024, "a").toString();
     const file = Bun.file(p, { type });
     for (let i = 0; i < 100; i++) await file.text();
@@ -359,16 +350,11 @@ test("Bun.file(path, {type}).text() does not leak the duped content_type", async
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   const { deltaMiB } = JSON.parse(stdout);
-  // On ASAN builds LeakSanitizer (not RSS) is the regression guard: an unfixed
-  // build leaks 1024 content-type copies, LSan reports them at exit, and the
-  // exit-code assertion below fails.
   expect(deltaMiB).toBeLessThan(isASAN ? 400 : 40);
   expect(exitCode).toBe(0);
 });
 
 test("reading a file-backed Blob does not free the source's content type", async () => {
-  // The read handler's context blob owns a *deep copy* of the content type;
-  // dropping it must not free the source Blob's allocation.
   using dir = tempDir("blob-text-keeps-type", {
     "data.txt": "hello",
   });
@@ -380,10 +366,6 @@ test("reading a file-backed Blob does not free the source's content type", async
 });
 
 test("Bun.write preserves a custom content type on the destination", async () => {
-  // Bun.file(...).write() / Bun.write(Bun.file(...), ...) passes the
-  // destination blob through PathOrBlob::Blob(borrowed_view()) and dupes it
-  // again inside write_file_internal. Both copies must own (and release) their
-  // own content type without freeing the source handle's allocation.
   using dir = tempDir("blob-write-keeps-type", {});
   const customType = "application/x-custom-type-not-in-registry-write";
   const dest = Bun.file(path.join(String(dir), "out.txt"), { type: customType });

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -352,19 +352,16 @@ test("Bun.file(path, {type}).text() does not leak the duped content_type", async
   `;
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", script],
-    env: {
-      ...bunEnv,
-      // ASAN's quarantine retains freed allocations (default
-      // quarantine_size_mb=256), which would make RSS grow by the full 64 MiB
-      // even when every content-type copy is correctly freed. Disable it so
-      // the measurement reflects live memory on ASAN builds too.
-      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),
-    },
+    env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
   const { deltaMiB } = JSON.parse(stdout);
+  // On ASAN builds LeakSanitizer (not RSS) is the regression guard: an unfixed
+  // build leaks 1024 content-type copies, LSan reports them at exit, and the
+  // exit-code assertion below fails.
   expect(deltaMiB).toBeLessThan(isASAN ? 400 : 40);
   expect(exitCode).toBe(0);
 });

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, tempDir } from "harness";
 import type { BlobOptions } from "node:buffer";
 import type { BinaryLike } from "node:crypto";
 import path from "node:path";
@@ -323,6 +323,76 @@ test("dupe() preserves allocated content_type for Body clone", () => {
   const clonedType = cloned.headers.get("content-type");
   expect(originalType).toStartWith("multipart/form-data; boundary=");
   expect(clonedType).toBe(originalType);
+});
+
+test("Bun.file(path, {type}).text() does not leak the duped content_type", async () => {
+  // Reading a file-backed Blob goes text() -> doReadFile -> Blob.dupe(),
+  // which deep-copies a heap-allocated (non-registry) content type into the
+  // read handler's context blob. That copy must be released when the handler's
+  // blob is dropped; otherwise every .text() on a typed Bun.file leaks the
+  // whole content-type allocation. A 64 KiB type makes the leak measurable in
+  // RSS: 1024 reads leak >= 64 MiB unfixed.
+  using dir = tempDir("blob-text-content-type", {
+    "data.txt": "hello",
+  });
+  const script = `
+    const p = ${JSON.stringify(path.join(String(dir), "data.txt"))};
+    // Printable-ASCII non-registry type so the mime-table lookup misses and
+    // the content type is heap-allocated. Hoisted out of the loop: the source
+    // handle's own allocation happens exactly once.
+    const type = "application/x-" + Buffer.alloc(64 * 1024, "a").toString();
+    const file = Bun.file(p, { type });
+    for (let i = 0; i < 100; i++) await file.text();
+    Bun.gc(true);
+    const before = process.memoryUsage.rss();
+    for (let i = 0; i < 1024; i++) await file.text();
+    Bun.gc(true);
+    const after = process.memoryUsage.rss();
+    console.log(JSON.stringify({ deltaMiB: (after - before) / 1024 / 1024 }));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: {
+      ...bunEnv,
+      // ASAN's quarantine retains freed allocations (default
+      // quarantine_size_mb=256), which would make RSS grow by the full 64 MiB
+      // even when every content-type copy is correctly freed. Disable it so
+      // the measurement reflects live memory on ASAN builds too.
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const { deltaMiB } = JSON.parse(stdout);
+  expect(deltaMiB).toBeLessThan(isASAN ? 400 : 40);
+  expect(exitCode).toBe(0);
+});
+
+test("reading a file-backed Blob does not free the source's content type", async () => {
+  // The read handler's context blob owns a *deep copy* of the content type;
+  // dropping it must not free the source Blob's allocation.
+  using dir = tempDir("blob-text-keeps-type", {
+    "data.txt": "hello",
+  });
+  const customType = "application/x-custom-type-not-in-registry-keepme";
+  const file = Bun.file(path.join(String(dir), "data.txt"), { type: customType });
+  expect(await file.text()).toBe("hello");
+  expect(await file.text()).toBe("hello");
+  expect(file.type).toBe(customType);
+});
+
+test("Bun.write preserves a custom content type on the destination", async () => {
+  // Bun.file(...).write() / Bun.write(Bun.file(...), ...) passes the
+  // destination blob through PathOrBlob::Blob(borrowed_view()) and dupes it
+  // again inside write_file_internal. Both copies must own (and release) their
+  // own content type without freeing the source handle's allocation.
+  using dir = tempDir("blob-write-keeps-type", {});
+  const customType = "application/x-custom-type-not-in-registry-write";
+  const dest = Bun.file(path.join(String(dir), "out.txt"), { type: customType });
+  await Bun.write(dest, "data");
+  expect(await dest.text()).toBe("data");
+  expect(dest.type).toBe(customType);
 });
 
 test("Blob part's bytes survive a later part freeing it during construction", async () => {


### PR DESCRIPTION
Blob kept its content type as a raw slice pointer plus an ownership flag, with no drop glue. Consumers that drop a duplicated Blob by value (the file read handler, `PathOrBlob`, `BlobOrStringOrBuffer`, `AnyBlob`, the object-URL registry) relied on an explicit `deinit()` that several of them never call, so the heap copy made by `dupe_with_content_type` was stranded on every `Bun.file(p, { type }).text()` and similar paths.

This adds `impl Drop for Blob` that frees an owned content type, makes `borrowed_view()` return a self-owning `dupe()` instead of aliasing the source's allocation (which would double-free under the new Drop), and hoists the deep copy in `dupe_with_content_type` ahead of construction. The remaining `Blob { .., ..Default::default() }` literals are spelled out since functional-record-update is rejected for Drop types.

Adds three tests to `test/js/web/fetch/blob.test.ts`: an RSS regression test for repeated `.text()` on a file handle with a large custom type, and two behavioral tests confirming the source handle's type survives reads and `Bun.write`. Existing content-type ownership tests in that file still pass.