### PR TITLE
fix(socket): don't unprotect never-protected handlers on socket config validation errors

### DIFF
--- a/src/runtime/socket/Handlers.rs
+++ b/src/runtime/socket/Handlers.rs
@@ -288,16 +288,51 @@ impl Handlers {
         generated: &GeneratedSocketConfigHandlers,
         is_server: bool,
     ) -> JsResult<Handlers> {
+        // Validate the callbacks before constructing `Handlers` so the error
+        // paths never drop (and thus `unprotect`) a value that was never
+        // `protect`ed.
+        // inline for (callback_fields) |field| { ... @field(generated, field) ... }
+        macro_rules! callback {
+            ($field:ident, $name:literal) => {{
+                let value = generated.$field;
+                if value.is_undefined_or_null() {
+                    JSValue::ZERO
+                } else if !value.is_callable() {
+                    return Err(global_object.throw_invalid_arguments(format_args!(
+                        "Expected \"{}\" callback to be a function",
+                        $name
+                    )));
+                } else {
+                    value
+                }
+            }};
+        }
+        let on_open = callback!(on_open, "onOpen");
+        let on_close = callback!(on_close, "onClose");
+        let on_data = callback!(on_data, "onData");
+        let on_writable = callback!(on_writable, "onWritable");
+        let on_timeout = callback!(on_timeout, "onTimeout");
+        let on_connect_error = callback!(on_connect_error, "onConnectError");
+        let on_end = callback!(on_end, "onEnd");
+        let on_error = callback!(on_error, "onError");
+        let on_handshake = callback!(on_handshake, "onHandshake");
+
+        if on_data.is_empty() && on_writable.is_empty() {
+            return Err(global_object.throw_invalid_arguments(format_args!(
+                "Expected at least \"data\" or \"drain\" callback"
+            )));
+        }
+
         let mut result = Handlers {
-            on_open: JSValue::ZERO,
-            on_close: JSValue::ZERO,
-            on_data: JSValue::ZERO,
-            on_writable: JSValue::ZERO,
-            on_timeout: JSValue::ZERO,
-            on_connect_error: JSValue::ZERO,
-            on_end: JSValue::ZERO,
-            on_error: JSValue::ZERO,
-            on_handshake: JSValue::ZERO,
+            on_open,
+            on_close,
+            on_data,
+            on_writable,
+            on_timeout,
+            on_connect_error,
+            on_end,
+            on_error,
+            on_handshake,
             binary_type: match generated.binary_type {
                 GeneratedBinaryType::Arraybuffer => BinaryType::ArrayBuffer,
                 GeneratedBinaryType::Buffer => BinaryType::Buffer,
@@ -317,37 +352,6 @@ impl Handlers {
             #[cfg(debug_assertions)]
             protection_count: 0,
         };
-
-        // inline for (callback_fields) |field| { ... @field(generated, field) ... }
-        macro_rules! assign_callback {
-            ($field:ident, $name:literal) => {{
-                let value = generated.$field;
-                if value.is_undefined_or_null() {
-                } else if !value.is_callable() {
-                    return Err(global_object.throw_invalid_arguments(format_args!(
-                        "Expected \"{}\" callback to be a function",
-                        $name
-                    )));
-                } else {
-                    result.$field = value;
-                }
-            }};
-        }
-        assign_callback!(on_open, "onOpen");
-        assign_callback!(on_close, "onClose");
-        assign_callback!(on_data, "onData");
-        assign_callback!(on_writable, "onWritable");
-        assign_callback!(on_timeout, "onTimeout");
-        assign_callback!(on_connect_error, "onConnectError");
-        assign_callback!(on_end, "onEnd");
-        assign_callback!(on_error, "onError");
-        assign_callback!(on_handshake, "onHandshake");
-
-        if result.on_data.is_empty() && result.on_writable.is_empty() {
-            return Err(global_object.throw_invalid_arguments(format_args!(
-                "Expected at least \"data\" or \"drain\" callback"
-            )));
-        }
         result.with_async_context_if_needed(global_object);
         result.protect();
         Ok(result)

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -821,6 +821,21 @@ it("should throw on empty unix path from truthy non-string value", () => {
   expect(() => Bun.connect({ unix: [] as any, socket })).toThrow("SocketOptions.unix must be a string");
 });
 
+it("should throw on invalid socket handlers, not crash", () => {
+  expect(() => Bun.connect({ hostname: "localhost", port: 0, socket: {} as any })).toThrow(
+    'Expected at least "data" or "drain" callback',
+  );
+  expect(() => Bun.listen({ hostname: "localhost", port: 0, socket: {} as any })).toThrow(
+    'Expected at least "data" or "drain" callback',
+  );
+  expect(() => Bun.connect({ hostname: "localhost", port: 0, socket: { data: 123 } as any })).toThrow(
+    'Expected "onData" callback to be a function',
+  );
+  expect(() => Bun.listen({ hostname: "localhost", port: 0, socket: { data() {}, drain: 1 } as any })).toThrow(
+    'Expected "onWritable" callback to be a function',
+  );
+});
+
 it("reading .listener on a closed client socket does not use-after-free handlers", async () => {
   // Client-mode Handlers is heap-allocated per-connect and freed in
   // markInactive once the socket closes. `socket.listener` read


### PR DESCRIPTION
### What does this PR do?

Fixes a crash found by fuzzing (`panic: assertion failed: self.protection_count > 0`).

`Bun.connect()` / `Bun.listen()` with an invalid `socket` handlers object — e.g. missing both `data` and `drain`, or a non-callable callback — aborted debug/assert builds instead of throwing:

```js
Bun.connect({ socket: {} });
// panic: assertion failed: self.protection_count > 0
//   Handlers::unprotect (src/runtime/socket/Handlers.rs:363)
//   <Handlers as Drop>::drop
//   Handlers::from_generated
//   SocketConfig::from_generated
//   Listener::connect_inner
```

`Handlers::from_generated` constructed the `Handlers` value first and validated the callbacks afterwards, returning `Err` before `protect()` was ever called. On that early return the partially-built value is dropped, and `Drop for Handlers` unconditionally calls `unprotect()`:

- In debug/CI-assert builds, `debug_assert!(self.protection_count > 0)` fires and the process aborts.
- In release builds it calls `JSValue::unprotect()` on callbacks that were never protected, which can release a protection legitimately held elsewhere on the same function objects.

The Zig reference (`Handlers.zig`) never deinits the partially-built struct on these error paths; the Rust port's `Drop` introduced the imbalance.

This change validates the callbacks (and the data/drain requirement) before constructing the `Handlers` value, so a `Handlers` only ever exists in its `protect()`ed state and every drop stays balanced. Error messages and validation order are unchanged.

### How did you verify your code works?

- Minimized fuzzer repro (`Bun.connect({ socket: {} })`, also with a circular `tls` object + `Bun.gc(true)`) panicked before the fix and now throws the expected `Expected at least "data" or "drain" callback` error / exits cleanly with a debug build.
- Added tests in `test/js/bun/net/socket.test.ts` covering missing and non-callable handlers for both `Bun.connect` and `Bun.listen`; they pass with `bun bd test`.
- Ran the full `test/js/bun/net/socket.test.ts` suite with the debug build: same pass/fail set as the unmodified baked Bun in this environment (remaining failures are pre-existing local `ECONNREFUSED` issues unrelated to this change).