### PR TITLE
Error instead of crashing on deeply nested TypeScript types in the transpiler

### DIFF
--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -59,6 +59,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn skip_type_script_binding(&mut self) -> Result<(), Error> {
         self.mark_type_script_only();
+        // Nested destructuring patterns in skipped type positions recurse through
+        // this function; bound it like `parse_binding` does.
+        if !self.stack_check.is_safe_to_recurse() {
+            return Err(err!("StackOverflow"));
+        }
         match self.lexer.token {
             T::TIdentifier | T::TThis => {
                 self.lexer.next()?;
@@ -235,6 +240,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         mut result: Option<&mut Metadata>,
     ) -> Result<(), Error> {
         self.mark_type_script_only();
+
+        // Deeply nested types ("[[[[...", "A<A<A<...", ...) recurse through this
+        // function, so bound it the same way `parse_expr_common` bounds expression
+        // recursion instead of overflowing the stack.
+        if !self.stack_check.is_safe_to_recurse() {
+            return Err(err!("StackOverflow"));
+        }
 
         loop {
             match self.lexer.token {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4044,6 +4044,51 @@ it("deeply nested expressions error instead of crashing the process", () => {
   expect([exitCode, signalCode ?? undefined]).toEqual([0, undefined]);
 }, 60_000);
 
+it("deeply nested TypeScript types error instead of crashing the process", () => {
+  const script = `
+    const repeat = (fill, count) => Buffer.alloc(fill.length * count, fill).toString();
+    const shapes = [
+      // TSX generic arrow function whose "extends" constraint is a deeply nested tuple type
+      { loader: "tsx", code: n => "<T extends " + repeat("[", n) + "0" + repeat("]", n) + ">(x: T) => x" },
+      // same shape nested inside array literals (matches the fuzzer-found input)
+      {
+        loader: "tsx",
+        code: n =>
+          repeat("[", 1000) + "<T extends " + repeat("[", n) + "0" + repeat("]", n) + ">(x: T) => x" + repeat("]", 1000),
+      },
+      // deeply nested tuple type in a type alias
+      { loader: "ts", code: n => "type A = " + repeat("[", n) + "0" + repeat("]", n) + ";" },
+      // deeply nested destructuring pattern in a function type's arguments
+      { loader: "ts", code: n => "type A = (" + repeat("[", n) + "a" + repeat("]", n) + ": any) => void;" },
+    ];
+    for (const { loader, code } of shapes) {
+      for (const n of [4000, 20000, 100000]) {
+        const transpiler = new Bun.Transpiler({
+          loader,
+          target: "bun",
+          minifyWhitespace: true,
+          deadCodeElimination: true,
+        });
+        try {
+          transpiler.transformSync(code(n));
+        } catch (e) {
+          if (!/Maximum call stack size exceeded|StackOverflow/.test(String(e?.message))) throw e;
+        }
+      }
+    }
+    console.log("type-depth-ok");
+  `;
+  const { stdout, exitCode, signalCode } = Bun.spawnSync({
+    cmd: [bunExe(), "-e", script],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+
+  expect(stdout.toString()).toBe("type-depth-ok\n");
+  expect([exitCode, signalCode ?? undefined]).toEqual([0, undefined]);
+}, 60_000);
+
 it("running a file with deeply nested unary operators does not crash the process", () => {
   const code = Buffer.alloc(2 * 4000, "- ").toString() + "1";
   const { exitCode, signalCode } = Bun.spawnSync({


### PR DESCRIPTION
### Problem

Parser fuzzing found a 33 KB TSX input that kills the process with a hard SIGSEGV (`sig:SIGSEGV:nostack`) instead of a JavaScript error:

```sh
bun -e 'new Bun.Transpiler({loader:"tsx", target:"bun", minifyWhitespace:true, deadCodeElimination:true}).transformSync(Buffer.from(Bun.gunzipSync(Buffer.from("H4sIAAAAAAACA+3WMYrCQBSAYWvBO7wLiAYTo3GRPYSdWAQdRBCLJIgge3fdA4g2gsj3PZjmwRQzzb9eAwDwOX5WkS5dOu3a8BjvMIzXZ/lwest4NqNR/HZ1s09dFanN3nDlLM+nZZ6Py0k5nhdFNs2KQd8PAwDIe3kv7wEAkPfyXt4DACDv5b28BwCQ98h7eQ8AIO+R9wAAyHt5L+8BAJD38l7eAwDIe3kv7+U9AIC8R97f836Xtse6SXGum6iruP4fbdccTvv4W9zXGwAA+HI3uJJ58sqBAAA=", "base64"))).toString("latin1"))'
```

The input is ~28,000 nested `[` brackets: 2,462 open an array-literal expression, then `<T extends [[[[…` makes the TSX parser skip the deeply nested tuple *type* in the generic arrow function's `extends` constraint. Reduced shapes hit the same thing:

```js
// all SIGSEGV on a debug build, and on smaller (4 MB worker) stacks in release
new Bun.Transpiler({ loader: "tsx" }).transformSync("<T extends " + "[".repeat(20000) + "0" + "]".repeat(20000) + ">(x: T) => x");
new Bun.Transpiler({ loader: "ts" }).transformSync("type A = " + "[".repeat(20000) + "0" + "]".repeat(20000) + ";");
new Bun.Transpiler({ loader: "ts" }).transformSync("type A = (" + "[".repeat(100000) + "a" + "]".repeat(100000) + ": any) => void;");
```

### Cause

`parse_expr_common`, `parse_binding`, `parse_stmt`, and (since #31242) the visit/print/DCE passes bound their recursion with `StackCheck::is_safe_to_recurse()`, but the TypeScript type-*skipping* recursion has no check at all:

- `skip_type_script_type_with_opts` recurses directly for tuple members, nested generics, object types, conditional types, etc. (`parse_skip_typescript.rs`, the `T::TOpenBracket` arm is the frame in the crash backtrace), and
- `skip_type_script_binding` recurses directly for `[`/`{` destructuring patterns inside skipped function types.

So an AST-free token skip of a deep enough type walks straight off the stack. The crash frame loops in `skip_type_script_type_with_opts → skip_type_script_type_with_opts` until the guard page is hit, which is why the crash handler prints nothing.

### Fix

Add the same guard the sibling parse functions already use to both functions: when `is_safe_to_recurse()` reports the stack is nearly exhausted, return the `StackOverflow` error, which the parse entry point already converts into a logged "Maximum call stack size exceeded" error. No behavior change for inputs that fit on the stack; the type skipper allocates no AST, so the check is the only cost per nesting level.

### Verification

- Before: the fuzz repro and the reduced shapes above exit with SIGSEGV (exit 139) on a debug/ASAN build; after: they exit cleanly (the fuzz input reports its syntax errors plus "Maximum call stack size exceeded", the valid deep shapes either transpile or throw that error).
- New test `deeply nested TypeScript types error instead of crashing the process` in `test/bundler/transpiler/transpiler.test.js` spawns a subprocess that transpiles the TSX generic-arrow shape (bare and nested inside 1,000 array literals, matching the fuzz input), the nested tuple type alias, and the nested function-type destructuring pattern at depths 4,000 / 20,000 / 100,000, and asserts the process exits 0 with no signal. It fails on the unfixed build (child dies with SIGSEGV) and passes with this change.
- `bun bd test test/bundler/transpiler/` — 430 pass, 0 fail.
