### PR TITLE
fix(bun:test): constructing a mock whose implementation returns a primitive now yields an object

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -86,6 +86,7 @@ inline To tryJSDynamicCast(JSC::WriteBarrier<WriteBarrierT>& from)
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionCall);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionConstruct);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetter_mockGetLastCall);
@@ -462,7 +463,7 @@ public:
     }
 
     JSMockFunction(JSC::VM& vm, JSC::Structure* structure, CallbackKind wrapKind)
-        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
+        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionConstruct)
     {
         initMock();
     }
@@ -979,6 +980,34 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
 
     setReturnValue(createMockResult(vm, globalObject, "return"_s, jsUndefined()));
     return JSValue::encode(jsUndefined());
+}
+
+// A native constructor must return an object, but a mock implementation can produce any value.
+// Follow ordinary [[Construct]] semantics: if the implementation does not return an object,
+// return a fresh object created from newTarget's prototype instead.
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * globalObject, CallFrame* callframe))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue returnValue = JSValue::decode(jsMockFunctionCall(globalObject, callframe));
+    RETURN_IF_EXCEPTION(scope, {});
+
+    if (returnValue && returnValue.isObject()) {
+        return JSValue::encode(returnValue);
+    }
+
+    JSValue newTarget = callframe->newTarget();
+    JSValue prototype = jsUndefined();
+    if (newTarget && newTarget.isObject()) {
+        prototype = asObject(newTarget)->get(globalObject, vm.propertyNames->prototype);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
+    JSObject* thisObject = prototype.isObject()
+        ? JSC::constructEmptyObject(globalObject, asObject(prototype))
+        : JSC::constructEmptyObject(globalObject);
+    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject));
 }
 
 void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -794,6 +794,22 @@ describe("mock()", () => {
 
     expect(bar()()).toBe(true);
   });
+
+  test("constructing a mock returns an object even when the implementation returns a primitive", () => {
+    const fn = jest.fn();
+    expect(typeof new fn()).toBe("object");
+    expect(typeof Reflect.construct(fn, [])).toBe("object");
+
+    const returnsPrimitive = jest.fn().mockReturnValue(42);
+    expect(typeof new returnsPrimitive()).toBe("object");
+    expect(typeof Reflect.construct(returnsPrimitive, [])).toBe("object");
+    expect(returnsPrimitive).toHaveBeenCalledTimes(2);
+
+    const instance = { a: 1 };
+    const returnsObject = jest.fn(() => instance);
+    expect(new returnsObject()).toBe(instance);
+    expect(Reflect.construct(returnsObject, [])).toBe(instance);
+  });
 });
 
 describe("spyOn", () => {
@@ -1010,6 +1026,14 @@ describe("spyOn", () => {
       expect(arr[14]).toBe(original);
       expect(arr[14]()).toBe(456);
       expect(fn).not.toHaveBeenCalled();
+    });
+
+    test("constructing a spy on a missing property does not crash", () => {
+      const target = {};
+      const spy = spyOn(target, "doesNotExist");
+      expect(typeof Reflect.construct(spy, [])).toBe("object");
+      expect(spy).toHaveBeenCalledTimes(1);
+      spy.mockRestore();
     });
   }
 


### PR DESCRIPTION
### Problem

`JSMockFunction` registered `jsMockFunctionCall` as both its **call** and **construct** callback. A native construct callback must return a `JSObject` — `Interpreter::executeConstruct` calls `asObject()` on the result unconditionally — but a mock's implementation can produce any value: `undefined` for a bare `jest.fn()` or a spy on a missing property, or any primitive via `mockReturnValue(...)`.

Constructing such a mock through a path that goes via `JSC::construct()` (`Reflect.construct`, Proxy construct, `super()`) hits `ASSERTION FAILED: isCell()` in debug builds and reinterprets the primitive's bits as an object pointer in release builds. Found by fuzzing (fingerprint `JSCJSValue.h(1043)`):

```js
import { jest } from "bun:test";
const spy = jest.spyOn(someObject, "missingProperty");
Reflect.construct(spy, []); // ASSERTION FAILED: isCell()
```

Through the bytecode `new mock()` path the primitive silently escaped to JS instead, so `new (jest.fn())()` evaluated to `undefined`, which also diverges from Jest.

### Fix

Give `JSMockFunction` a dedicated construct callback. It runs the existing mock logic (calls are still recorded, results still tracked) and, when the implementation result is not an object, follows ordinary `[[Construct]]` semantics: return a fresh object created from `newTarget.prototype`, falling back to `Object.prototype`. Implementations that return an object keep returning that object. This matches Jest, where mocks are plain JS functions and `new mock()` yields an instance when the implementation returns a primitive.

### Tests

Added to `test/js/bun/test/mock-fn.test.js` (file is runnable under Jest/Vitest/Bun; the new assertions match Jest behavior):
- constructing `jest.fn()` / `jest.fn().mockReturnValue(42)` via `new` and `Reflect.construct` returns an object, and the calls are recorded
- constructing a mock whose implementation returns an object still returns that object
- (Bun-only) constructing a spy on a missing property no longer crashes

Before this change the new tests fail with `Received: "undefined"` on release builds and crash with the `isCell()` assertion on debug builds; the original fuzzer reproducer now exits cleanly.