### PR TITLE
tls: defer upgraded-duplex teardown to the owning context's close task

### DIFF
--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -154,10 +154,11 @@ impl UpgradedDuplex {
         // `deinit_in_next_tick()`; the next-tick Close task drops the
         // `DuplexUpgradeContext`, whose `Drop for UpgradedDuplex` runs
         // `teardown()` once no SSLWrapper frame is live. Until then every
-        // re-entry is inert: `closed_notified` is already set (gates
-        // `handle_traffic` / the data, write and close callbacks),
-        // `sent_ssl_shutdown` short-circuits `shutdown()`, and the
-        // `DuplexUpgradeContext` already nulled its `tls`.
+        // re-entry is inert: `closed_notified` is already set (it gates
+        // `handle_traffic` and every data/write/handshake/close callback,
+        // including the ones a re-entrant `shutdown()` would fire), `ssl` is
+        // still a valid pointer, and the `DuplexUpgradeContext` already
+        // nulled its `tls`.
     }
 
     fn call_write_or_end(&mut self, data: Option<&[u8]>, msg_more: bool) {

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -136,14 +136,28 @@ impl UpgradedDuplex {
         bun_output::scoped_log!(UpgradedDuplex, "onClose");
         // SAFETY: SSLWrapper handlers ctx is `self as *mut Self`; live for the wrapper's lifetime.
         let this = unsafe { &mut *this };
-        // Zig: `defer this.deinit();` — runs after the two calls below.
 
         (this.handlers.on_close)(this.handlers.ctx);
         // closes the underlying duplex
         this.call_write_or_end(None, false);
 
-        // Early teardown (Zig calls deinit explicitly here; struct itself is dropped later by parent).
-        this.teardown();
+        // PORT NOTE: Zig ran `defer this.deinit()` here, destroying the
+        // SSLWrapper in place. We are reached from
+        // `SSLWrapper::trigger_close_callback`, i.e. there are still
+        // `&mut SSLWrapper` frames (`flush` / `handle_traffic` /
+        // `handle_reading` / `shutdown`) on the stack below us that read
+        // `self.ssl` after we return. Writing `self.wrapper = None` here makes
+        // the niche-optimized `Option<SSLWrapper>` payload uninitialized, so
+        // those re-reads observe garbage instead of `None` and pass a wild
+        // `SSL*` to BoringSSL. Teardown is deferred to the owner: `on_close`
+        // above ran `DuplexUpgradeContext::on_close`, which always enqueues
+        // `deinit_in_next_tick()`; the next-tick Close task drops the
+        // `DuplexUpgradeContext`, whose `Drop for UpgradedDuplex` runs
+        // `teardown()` once no SSLWrapper frame is live. Until then every
+        // re-entry is inert: `closed_notified` is already set (gates
+        // `handle_traffic` / the data, write and close callbacks),
+        // `sent_ssl_shutdown` short-circuits `shutdown()`, and the
+        // `DuplexUpgradeContext` already nulled its `tls`.
     }
 
     fn call_write_or_end(&mut self, data: Option<&[u8]>, msg_more: bool) {
@@ -479,7 +493,11 @@ impl UpgradedDuplex {
         self.set_timeout_in_milliseconds(seconds * 1000);
     }
 
-    /// Side-effecting teardown shared by `on_close` (early) and `Drop` (final).
+    /// Side-effecting teardown, run from `Drop` when the owning
+    /// `DuplexUpgradeContext` is freed by its next-tick Close task. Must NOT
+    /// run while any `&mut SSLWrapper` frame is on the stack (see `on_close`):
+    /// `self.wrapper = None` drops the wrapper in place and leaves the
+    /// niche-optimized `Option` payload uninitialized.
     /// Idempotent — resets to empty state. Not the public API; callers drop the struct.
     fn teardown(&mut self) {
         bun_output::scoped_log!(UpgradedDuplex, "deinit");

--- a/test/js/node/http2/node-http2-upgrade.test.mts
+++ b/test/js/node/http2/node-http2-upgrade.test.mts
@@ -241,6 +241,95 @@ describe("HTTP/2 upgrade — socket close ordering", () => {
     netServer.close();
   });
 
+  test("many sequential connections close cleanly", async () => {
+    // Each iteration drives the full server-side teardown chain:
+    // client.close() sends GOAWAY + close_notify, the server dispatches the
+    // GOAWAY to JS from inside the TLS read callback, JS ends the socket
+    // re-entrantly, and the connection's native state is freed on the next
+    // tick while the next iteration allocates a fresh one.
+    const h2Server = http2.createSecureServer(TLS, (_req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    });
+    h2Server.on("error", () => {});
+
+    const rawSockets: net.Socket[] = [];
+    const netServer = net.createServer(socket => {
+      rawSockets.push(socket);
+      h2Server.emit("connection", socket);
+    });
+
+    const port = await new Promise<number>(resolve => {
+      netServer.listen(0, "127.0.0.1", () => resolve((netServer.address() as net.AddressInfo).port));
+    });
+
+    for (let i = 0; i < 20; i++) {
+      const client = connectClient(port);
+      const result = await request(client, "GET", "/");
+      assert.strictEqual(result.status, 200);
+      assert.strictEqual(result.body, "ok");
+
+      const rawSocket = rawSockets[i];
+      assert.ok(rawSocket, `raw socket ${i} captured`);
+      const socketClosed = Promise.withResolvers<void>();
+      rawSocket.once("close", () => socketClosed.resolve());
+      client.close();
+      await socketClosed.promise;
+    }
+
+    netServer.close();
+  });
+
+  test("rawSocket keeps emitting after session destroy", async () => {
+    let rawSocket: net.Socket | undefined;
+    let h2Session: http2.Http2Session | undefined;
+
+    const h2Server = http2.createSecureServer(TLS, (_req, res) => {
+      res.writeHead(200);
+      res.end("done");
+    });
+    h2Server.on("error", () => {});
+    h2Server.on("session", s => {
+      s.on("error", () => {});
+      h2Session = s;
+    });
+
+    const netServer = net.createServer(socket => {
+      rawSocket = socket;
+      socket.on("error", () => {});
+      h2Server.emit("connection", socket);
+    });
+
+    const port = await new Promise<number>(resolve => {
+      netServer.listen(0, "127.0.0.1", () => resolve((netServer.address() as net.AddressInfo).port));
+    });
+
+    const client = connectClient(port);
+    const clientClosed = Promise.withResolvers<void>();
+    client.on("close", () => clientClosed.resolve());
+
+    await request(client, "GET", "/");
+
+    // Destroy the server-side session, then keep poking the raw socket. The
+    // upgraded TLS connection has already fired its close callback but its
+    // native state is only freed on the next tick; these events must hit the
+    // already-closed gates instead of a freed connection.
+    h2Session!.destroy();
+    rawSocket!.write(Buffer.alloc(64));
+    rawSocket!.destroy();
+
+    const socketClosed = Promise.withResolvers<void>();
+    if (rawSocket!.closed) {
+      socketClosed.resolve();
+    } else {
+      rawSocket!.once("close", () => socketClosed.resolve());
+    }
+    await socketClosed.promise;
+    await clientClosed.promise;
+
+    netServer.close();
+  });
+
   test("no crash when session.close() precedes rawSocket.destroy()", async () => {
     let rawSocket: net.Socket | undefined;
     let h2Session: http2.Http2Session | undefined;


### PR DESCRIPTION
`UpgradedDuplex::on_close` tore the `SSLWrapper` down in place even though it is invoked from the wrapper's own close callback, with wrapper frames still on the stack below it that re-read the wrapper's fields after it returns. Teardown is now deferred to the owner's next-tick Close task, which already frees the containing `DuplexUpgradeContext` and runs the same teardown via `Drop`.

Adds two cases to `node-http2-upgrade.test.mts`: 20 sequential connect/request/close cycles against an upgraded `net.Server` -> `Http2SecureServer`, and raw-socket writes after the server-side session is destroyed. Existing cases in that file and `node-tls-connect.test.ts` still pass.