### PR TITLE
fix(bun:test): return an object when constructing a mock function

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -86,6 +86,7 @@ inline To tryJSDynamicCast(JSC::WriteBarrier<WriteBarrierT>& from)
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionCall);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionConstruct);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetter_mockGetLastCall);
@@ -462,7 +463,7 @@ public:
     }
 
     JSMockFunction(JSC::VM& vm, JSC::Structure* structure, CallbackKind wrapKind)
-        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
+        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionConstruct)
     {
         initMock();
     }
@@ -979,6 +980,42 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
 
     setReturnValue(createMockResult(vm, globalObject, "return"_s, jsUndefined()));
     return JSValue::encode(jsUndefined());
+}
+
+// Native constructors must always return an object, so this mirrors the behavior of
+// constructing a plain JavaScript function: create `this` from newTarget.prototype,
+// invoke the mock with it, and return the result if it is an object, otherwise `this`.
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * globalObject, CallFrame* callframe))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSMockFunction* fn = dynamicDowncast<JSMockFunction>(callframe->jsCallee());
+    if (!fn) [[unlikely]] {
+        throwTypeError(globalObject, scope, "Expected callee to be mock function"_s);
+        return {};
+    }
+
+    JSObject* newTarget = callframe->newTarget().getObject();
+    if (!newTarget) [[unlikely]] {
+        newTarget = fn;
+    }
+    JSValue prototype = newTarget->get(globalObject, vm.propertyNames->prototype);
+    RETURN_IF_EXCEPTION(scope, {});
+    JSObject* thisObject = prototype.isObject()
+        ? JSC::constructEmptyObject(globalObject, asObject(prototype))
+        : JSC::constructEmptyObject(globalObject);
+
+    JSC::CallData callData = JSC::getCallData(fn);
+    ASSERT(callData.type != JSC::CallData::Type::None);
+    JSC::ArgList args = JSC::ArgList(callframe);
+    JSValue returnValue = JSC::call(globalObject, fn, callData, thisObject, args);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    if (returnValue.isObject()) {
+        return JSValue::encode(returnValue);
+    }
+
+    return JSValue::encode(thisObject);
 }
 
 void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -794,6 +794,46 @@ describe("mock()", () => {
 
     expect(bar()()).toBe(true);
   });
+
+  describe("constructing a mock", () => {
+    test("new on a mock with no implementation returns an object and records the call", () => {
+      const fn = jest.fn();
+      const instance = new fn(1, 2);
+      expect(typeof instance).toBe("object");
+      expect(instance).not.toBeNull();
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(fn.mock.calls[0]).toEqual([1, 2]);
+      expect(fn.mock.contexts[0]).toBe(instance);
+    });
+
+    test("Reflect.construct on a mock returns an object", () => {
+      const fn = jest.fn();
+      const instance = Reflect.construct(fn, []);
+      expect(typeof instance).toBe("object");
+      expect(instance).not.toBeNull();
+    });
+
+    test("new calls the implementation with the newly created `this`", () => {
+      const fn = jest.fn(function () {
+        this.x = 42;
+      });
+      const instance = new fn();
+      expect(instance.x).toBe(42);
+    });
+
+    test("new returns the implementation's return value when it is an object", () => {
+      const result = { a: 1 };
+      const fn = jest.fn(() => result);
+      expect(new fn()).toBe(result);
+    });
+
+    test("new ignores non-object return values", () => {
+      const fn = jest.fn().mockReturnValue(42);
+      const instance = new fn();
+      expect(typeof instance).toBe("object");
+      expect(instance).not.toBeNull();
+    });
+  });
 });
 
 describe("spyOn", () => {


### PR DESCRIPTION
### What does this PR do?

Fixes a crash (debug assertion `ASSERTION FAILED: isCell()` in `JSC::JSValue::asCell`, `JSCJSValue.h:1043`) found by fuzzing, triggered by constructing a `bun:test` mock function when its invocation result is not an object:

```js
import { mock } from "bun:test";
Reflect.construct(mock(), []); // assertion failure in debug builds
new (mock())();                // evaluates to `undefined` instead of an object
```

`JSMockFunction` passed `jsMockFunctionCall` as both its `[[Call]]` and `[[Construct]]` handler. JSC requires a native constructor to return an object (`Interpreter::executeConstruct` does `asObject(result)` on the return value), but the mock call handler can return any value — `undefined` when there is no implementation, whatever `mockReturnValue()` was given, etc. Constructing such a mock through `Reflect.construct` (or any C++ caller of `JSC::construct`) hit the assertion, and plain `new` on a mock returned a non-object, which violates constructor semantics.

This PR gives `JSMockFunction` a dedicated construct handler that mirrors how constructing an ordinary JavaScript function behaves (and matches Jest):

- create `this` from `newTarget.prototype` (falling back to a plain object)
- invoke the mock with that `this`, so calls/contexts are recorded and `function () { this.x = 1 }` implementations work
- return the invocation result if it is an object, otherwise the newly created `this`

Behavior before/after:

| expression | before | after |
|---|---|---|
| `Reflect.construct(mock(), [])` | assertion failure (debug) | returns an object |
| `new (mock())()` | `undefined` | returns an object, call recorded |
| `new (mock(function () { this.x = 1 }))().x` | assertion failure (debug) | `1` |
| `new (mock(() => someObject))()` | `someObject` | `someObject` (unchanged) |
| `new (mock().mockReturnValue(42))()` | assertion failure (debug) | returns an object |

### How did you verify your code works?

- The fuzzer reproduction and minimized variants no longer crash on a debug (ASAN + assertions) build.
- Added tests in `test/js/bun/test/mock-fn.test.js` covering `new` and `Reflect.construct` on mocks with no implementation, with an implementation that assigns to `this`, with an object-returning implementation, and with a non-object `mockReturnValue`. 4 of the 5 new tests fail on the current release build and all pass with this change.
- Existing mock/spy test suites (`mock-fn`, `mock-disposable`, `mock-module*`, `spyMatchers`, `expect-toHaveReturnedWith`) pass, including with `BUN_JSC_validateExceptionChecks=1`.
