### PR TITLE
Cap ANSI markdown indentation so deeply nested lists render in linear time

### DIFF
--- a/src/md/ansi_renderer.rs
+++ b/src/md/ansi_renderer.rs
@@ -116,6 +116,11 @@ pub struct AnsiRenderer<'a> {
     theme: Theme<'a>,
     /// Stack of active block contexts (li/quote) for indentation.
     block_stack: Vec<BlockContext>,
+    /// Number of Quote entries currently in block_stack. Kept in sync with
+    /// push/pop so per-line indentation doesn't rescan the whole stack.
+    quote_depth: u32,
+    /// Sum of `indent` over the non-Quote entries currently in block_stack.
+    list_indent_cols: u32,
     /// Currently open span styles (bit flags).
     span_flags: u32,
     /// Non-null when we're inside a link span; the href to emit in OSC 8.
@@ -213,6 +218,14 @@ const SPAN_DEL: u32 = 1 << 2;
 const SPAN_U: u32 = 1 << 3;
 const SPAN_CODE: u32 = 1 << 4;
 
+/// Upper bound on the visible indentation (blockquote bars + list indent)
+/// emitted at the start of each rendered line. Nesting deeper than this is
+/// unreadable on any terminal, and without a cap every line's prefix grows
+/// with the nesting depth — a document of pathologically nested lists or
+/// quotes (e.g. `- - - - …` repeated thousands of times) would otherwise
+/// produce output quadratic in the input size.
+const MAX_INDENT_COLS: u32 = 128;
+
 struct InlineStyle {
     flag: u32,
     on: &'static [u8],
@@ -280,6 +293,8 @@ impl<'a> AnsiRenderer<'a> {
             src_text,
             theme,
             block_stack: Vec::new(),
+            quote_depth: 0,
+            list_indent_cols: 0,
             span_flags: 0,
             link_href: None,
             link_depth: 0,
@@ -327,7 +342,7 @@ impl<'a> AnsiRenderer<'a> {
             BlockType::Doc => {}
             BlockType::Quote => {
                 self.ensure_blank_line();
-                self.block_stack.push(BlockContext {
+                self.push_block(BlockContext {
                     kind: BlockKind::Quote,
                     indent: 2,
                     ..Default::default()
@@ -335,7 +350,7 @@ impl<'a> AnsiRenderer<'a> {
             }
             BlockType::Ul => {
                 self.ensure_newline();
-                self.block_stack.push(BlockContext {
+                self.push_block(BlockContext {
                     kind: BlockKind::Ul,
                     data,
                     indent: 2,
@@ -344,7 +359,7 @@ impl<'a> AnsiRenderer<'a> {
             }
             BlockType::Ol => {
                 self.ensure_newline();
-                self.block_stack.push(BlockContext {
+                self.push_block(BlockContext {
                     kind: BlockKind::Ol,
                     data,
                     indent: 3,
@@ -405,7 +420,7 @@ impl<'a> AnsiRenderer<'a> {
                 // Wrapped continuation lines need to land under the item's
                 // content (past the marker), so record the marker width.
                 entry.indent = u32::try_from(visible_width(glyph)).expect("int cast");
-                self.block_stack.push(entry);
+                self.push_block(entry);
             }
             BlockType::Hr => {
                 self.ensure_blank_line();
@@ -503,7 +518,7 @@ impl<'a> AnsiRenderer<'a> {
         match block_type {
             BlockType::Doc => {}
             BlockType::Quote | BlockType::Ul | BlockType::Ol | BlockType::Li => {
-                let _ = self.block_stack.pop();
+                self.pop_block();
                 self.ensure_newline();
             }
             BlockType::Hr => {}
@@ -1137,19 +1152,46 @@ impl<'a> AnsiRenderer<'a> {
         }
     }
 
+    /// Track a block push so indentation stays O(1) per line instead of
+    /// rescanning the whole block_stack.
+    fn push_block(&mut self, entry: BlockContext) {
+        match entry.kind {
+            BlockKind::Quote => self.quote_depth = self.quote_depth.saturating_add(1),
+            _ => {
+                self.list_indent_cols = self.list_indent_cols.saturating_add(entry.indent);
+            }
+        }
+        self.block_stack.push(entry);
+    }
+
+    fn pop_block(&mut self) {
+        let Some(entry) = self.block_stack.pop() else {
+            return;
+        };
+        match entry.kind {
+            BlockKind::Quote => self.quote_depth = self.quote_depth.saturating_sub(1),
+            _ => {
+                self.list_indent_cols = self.list_indent_cols.saturating_sub(entry.indent);
+            }
+        }
+    }
+
+    /// Quote bars and indent spaces to draw for the current block stack,
+    /// capped at MAX_INDENT_COLS visible columns total. writeIndent and
+    /// currentIndent must agree on these numbers so the wrap math matches
+    /// what was actually emitted.
+    fn indent_counts(&self) -> (u32, u32) {
+        let quote_bars = self.quote_depth.min(MAX_INDENT_COLS / 2);
+        let other_indent = self.list_indent_cols.min(MAX_INDENT_COLS - quote_bars * 2);
+        (quote_bars, other_indent)
+    }
+
     fn write_indent(&mut self) {
         // writeIndent is called at the start of every content line, so
         // this is the right place to clear the "blank line just emitted"
         // flag ensureBlankLine uses for dedup.
         self.blank_emitted = false;
-        let mut quote_bars: u32 = 0;
-        let mut other_indent: u32 = 0;
-        for entry in &self.block_stack {
-            match entry.kind {
-                BlockKind::Quote => quote_bars += 1,
-                _ => other_indent += entry.indent,
-            }
-        }
+        let (quote_bars, other_indent) = self.indent_counts();
         let bar: &[u8] = if self.theme.colors {
             "│ ".as_bytes()
         } else {
@@ -1179,15 +1221,8 @@ impl<'a> AnsiRenderer<'a> {
     }
 
     fn current_indent(&self) -> u32 {
-        let mut total: u32 = 0;
-        for entry in &self.block_stack {
-            total += if entry.kind == BlockKind::Quote {
-                2
-            } else {
-                entry.indent
-            };
-        }
-        total
+        let (quote_bars, other_indent) = self.indent_counts();
+        quote_bars * 2 + other_indent
     }
 
     fn update_col_from_text(&mut self, data: &[u8]) {
@@ -1214,12 +1249,7 @@ impl<'a> AnsiRenderer<'a> {
     /// current block_stack. Used by ensureBlankLine so the inter-block
     /// gap inside a blockquote keeps its visual border.
     fn write_quote_bars(&mut self) {
-        let mut quote_bars: u32 = 0;
-        for entry in &self.block_stack {
-            if entry.kind == BlockKind::Quote {
-                quote_bars += 1;
-            }
-        }
+        let (quote_bars, _) = self.indent_counts();
         if quote_bars == 0 {
             return;
         }

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -87,6 +87,33 @@ describe("fuzzer-like edge cases", () => {
     expect(typeof Markdown.html(input)).toBe("string");
   });
 
+  test("ansi: pathologically nested lists produce linear output", () => {
+    // Every rendered list-item line starts with its indentation, so if the
+    // per-line indent grows without bound the output becomes quadratic in
+    // the nesting depth (a ~240 KB fuzzer document of `- - - …` lines
+    // produced gigabytes of ANSI output). The renderer caps the emitted
+    // indent, keeping the output proportional to the number of items.
+    const depth = 2000;
+    const input = Buffer.alloc(depth * 2, "- ").toString() + "hi";
+    const out = Markdown.ansi(input);
+    expect(out).toContain("hi");
+    expect(out).toContain("•");
+    // ~8 MB without the indent cap, ~300 KB with it.
+    expect(out.length).toBeLessThan(2_000_000);
+  });
+
+  test("ansi: pathologically nested blockquotes + lists produce linear output", () => {
+    // Same idea as above, but the per-line prefix is dominated by the
+    // blockquote `│ ` bars instead of list indent spaces.
+    const depth = 1500;
+    const input = Buffer.alloc(depth * 2, "> ").toString() + Buffer.alloc(depth * 2, "- ").toString() + "hi";
+    const out = Markdown.ansi(input);
+    expect(out).toContain("hi");
+    expect(out).toContain("│");
+    // ~9 MB without the indent cap, ~450 KB with it.
+    expect(out.length).toBeLessThan(2_000_000);
+  });
+
   test("deeply nested emphasis", () => {
     const depth = 50;
     const open = Buffer.alloc(depth, "*").toString();


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-discovered hang in `Bun.markdown.ansi()` (`hang:markdown:…ansi_renderer::render_to_ansi…`, plus the sibling fingerprints in `AnsiRenderer::write_styled`, `AnsiRenderer::write_indent`, and `RawVec` growth).

**Repro / cause.** The fuzzer input is ~240 KB: 8 lines of `- - - - …` with ~15,000 dashes each. Each line parses as a ~15,000-deep nested list. The ANSI renderer starts every rendered line by re-emitting the full indentation (2 spaces per ancestor list level, `│ ` per blockquote level), so the per-line prefix grows with the nesting depth and the total output grows quadratically with the input size:

| input | `Bun.markdown.ansi` (release, before) | output |
|---|---|---|
| 1 line, depth ~7,500 | 0.8 s | 111 MB |
| 1 line, depth ~15,000 | 3.4 s | 444 MB |
| full fuzzer doc (8 lines) | 25+ s, then OOM abort | ~3.5 GB |

`Bun.markdown.html()` on the same document is linear (~1.3 s, 2.1 MB), so the parser is not at fault — it's purely the ANSI renderer's per-line indent emission. The renderer also rescanned the whole block stack (`O(depth)`) for every line to compute that indent.

**Fix** (`src/md/ansi_renderer.rs`):
- Keep running counters (`quote_depth`, `list_indent_cols`) updated when blocks are pushed/popped, instead of walking `block_stack` in `write_indent` / `current_indent` / `write_quote_bars` for every line.
- Cap the emitted per-line indentation at 128 visible columns (`MAX_INDENT_COLS`). Nesting deeper than ~64 levels is unreadable on any terminal — content at that indent already exceeds the wrap width and was treated as pathological — so rendering is unchanged for any realistic document, while the output size stays proportional to the number of rendered items.

After the fix the full fuzzer document renders to 16.5 MB, and the ANSI render costs only ~20% more than the (linear) parse + HTML render of the same document.

### How did you verify your code works?

- New tests in `test/js/bun/md/md-edge-cases.test.ts` (`ansi: pathologically nested lists produce linear output`, `… nested blockquotes + lists …`) assert the output size stays linear. They fail on the previous build (8–9 MB output vs the 2 MB bound) and pass with this change (~300–450 KB, each under 150 ms in a debug build).
- Full `test/js/bun/md/` suite (1040 tests) and `test/cli/run/markdown-entrypoint.test.ts` ANSI snapshots (29 tests) pass, confirming normal-depth rendering is unchanged.
- The original fuzzer document now renders successfully instead of hanging/aborting.
