### PR TITLE
shell: don't abort when a glob's directory prefix doesn't exist

### DIFF
--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -649,22 +649,39 @@ impl Expansion {
     ) {
         use crate::shell::dispatch_tasks::ShellGlobErr;
         log!("Expansion {} onGlobWalkDone", this);
-        // A failed walk (e.g. ENOENT because the pattern's literal directory
-        // prefix does not exist, as in `echo /nonexistent/*`) is not fatal to
-        // the script: fall through so the empty (or partial) result set goes
-        // through the no-match handling below — "no matches found" in command
-        // position, the literal pattern in assignment position — the same
-        // outcome as a relative pattern whose directory is missing. Raising a
-        // JS exception here would leave it pending on the VM with no JS frame
-        // above this task callback to observe it, aborting the process on the
-        // next exception check; `.nothrow()`/`try` could never intercept it.
+        // A failed walk must not raise a JS exception here: that would leave
+        // it pending on the VM with no JS frame above this task callback to
+        // observe it, aborting the process on the next exception check —
+        // `.nothrow()`/`try` could never intercept it.
         if let Some(err) = err {
             match err {
-                ShellGlobErr::Syscall(e) => {
+                // ENOENT/ENOTDIR mean the pattern's literal directory prefix
+                // doesn't exist (`echo /nonexistent/*`): fall through so the
+                // empty result set goes through the no-match handling below —
+                // "no matches found" in command position, the literal pattern
+                // in assignment position — the same outcome as a relative
+                // pattern whose directory is missing.
+                ShellGlobErr::Syscall(e)
+                    if matches!(e.get_errno(), bun_sys::E::ENOENT | bun_sys::E::ENOTDIR) =>
+                {
                     log!("Expansion {} glob walk failed: {}", this, e);
                 }
+                // Any other failure (EACCES, EMFILE, …) aborts the command
+                // through the same error path as a walker-init failure in
+                // `transition_to_glob_state`, so the real error reaches stderr
+                // with exit code 1 instead of masquerading as "no matches".
+                ShellGlobErr::Syscall(e) => {
+                    interp.as_expansion_mut(this).state =
+                        ExpansionState::Err(Box::new(ShellErr::new_sys(&e)));
+                    Yield::Next(this).run(interp);
+                    return;
+                }
                 ShellGlobErr::Unknown(e) => {
-                    log!("Expansion {} glob walk failed: {}", this, e);
+                    interp.as_expansion_mut(this).state = ExpansionState::Err(Box::new(
+                        ShellErr::Custom(e.to_string().into_bytes().into()),
+                    ));
+                    Yield::Next(this).run(interp);
+                    return;
                 }
             }
         }

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -649,15 +649,24 @@ impl Expansion {
     ) {
         use crate::shell::dispatch_tasks::ShellGlobErr;
         log!("Expansion {} onGlobWalkDone", this);
+        // A failed walk (e.g. ENOENT because the pattern's literal directory
+        // prefix does not exist, as in `echo /nonexistent/*`) is not fatal to
+        // the script: fall through so the empty (or partial) result set goes
+        // through the no-match handling below — "no matches found" in command
+        // position, the literal pattern in assignment position — the same
+        // outcome as a relative pattern whose directory is missing. Raising a
+        // JS exception here would leave it pending on the VM with no JS frame
+        // above this task callback to observe it, aborting the process on the
+        // next exception check; `.nothrow()`/`try` could never intercept it.
         if let Some(err) = err {
-            let shell_err = match err {
-                ShellGlobErr::Syscall(e) => ShellErr::new_sys(&e),
-                ShellGlobErr::Unknown(e) => ShellErr::Custom(e.to_string().into_bytes().into()),
-            };
-            interp.throw(shell_err);
-            interp.as_expansion_mut(this).state = ExpansionState::Done;
-            Yield::Next(this).run(interp);
-            return;
+            match err {
+                ShellGlobErr::Syscall(e) => {
+                    log!("Expansion {} glob walk failed: {}", this, e);
+                }
+                ShellGlobErr::Unknown(e) => {
+                    log!("Expansion {} glob walk failed: {}", this, e);
+                }
+            }
         }
 
         if result.is_empty() {

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -653,42 +653,27 @@ impl Expansion {
         // it pending on the VM with no JS frame above this task callback to
         // observe it, aborting the process on the next exception check —
         // `.nothrow()`/`try` could never intercept it.
-        if let Some(err) = err {
-            match err {
-                // ENOENT/ENOTDIR mean the pattern's literal directory prefix
-                // doesn't exist (`echo /nonexistent/*`): fall through so the
-                // empty result set goes through the no-match handling below —
-                // "no matches found" in command position, the literal pattern
-                // in assignment position — the same outcome as a relative
-                // pattern whose directory is missing.
-                ShellGlobErr::Syscall(e)
-                    if matches!(e.get_errno(), bun_sys::E::ENOENT | bun_sys::E::ENOTDIR) =>
-                {
-                    log!("Expansion {} glob walk failed: {}", this, e);
-                }
-                // Any other failure (EACCES, EMFILE, …) aborts the command
-                // through the same error path as a walker-init failure in
-                // `transition_to_glob_state`, so the real error reaches stderr
-                // with exit code 1 instead of masquerading as "no matches".
-                ShellGlobErr::Syscall(e) => {
-                    interp.as_expansion_mut(this).state =
-                        ExpansionState::Err(Box::new(ShellErr::new_sys(&e)));
-                    Yield::Next(this).run(interp);
-                    return;
-                }
-                ShellGlobErr::Unknown(e) => {
-                    interp.as_expansion_mut(this).state = ExpansionState::Err(Box::new(
-                        ShellErr::Custom(e.to_string().into_bytes().into()),
-                    ));
-                    Yield::Next(this).run(interp);
-                    return;
-                }
+        //
+        // ENOENT/ENOTDIR mean the pattern's literal directory prefix doesn't
+        // exist (`echo /nonexistent/*`): treat that exactly like a glob that
+        // matched nothing — the same outcome as a relative pattern whose
+        // directory is missing. Any other failure is kept and surfaced below.
+        let walk_err = match err {
+            Some(ShellGlobErr::Syscall(e))
+                if matches!(e.get_errno(), bun_sys::E::ENOENT | bun_sys::E::ENOTDIR) =>
+            {
+                log!("Expansion {} glob walk failed: {}", this, e);
+                None
             }
-        }
+            other => other,
+        };
 
-        if result.is_empty() {
-            // Spec lines 559-578: in variable assignments a no-match glob
-            // expands to the literal pattern; otherwise it's an error.
+        if result.is_empty() || walk_err.is_some() {
+            // Spec lines 559-578: in variable assignments a no-match (or
+            // failed) glob expands to the literal pattern; otherwise it's an
+            // error. The parent of an assignment never prints expansion
+            // errors, so the literal-pattern fallback applies to every kind
+            // of walk failure there.
             let parent = interp.as_expansion(this).base.parent;
             let in_assign = matches!(interp.node(parent).kind(), StateKind::Assign)
                 || matches!(
@@ -702,6 +687,17 @@ impl Expansion {
             if in_assign {
                 Self::push_current_out(me);
                 me.state = ExpansionState::Done;
+            } else if let Some(err) = walk_err {
+                // A real walk failure (EACCES, EMFILE, …) aborts the command
+                // through the same error path as a walker-init failure in
+                // `transition_to_glob_state`, so the actual error reaches
+                // stderr with exit code 1 instead of masquerading as
+                // "no matches found".
+                let shell_err = match err {
+                    ShellGlobErr::Syscall(e) => ShellErr::new_sys(&e),
+                    ShellGlobErr::Unknown(e) => ShellErr::Custom(e.to_string().into_bytes().into()),
+                };
+                me.state = ExpansionState::Err(Box::new(shell_err));
             } else {
                 let msg = format!("no matches found: {}", bstr::BStr::new(&me.current_out));
                 me.state = ExpansionState::Err(Box::new(ShellErr::Custom(msg.into_bytes().into())));

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -649,15 +649,6 @@ impl Expansion {
     ) {
         use crate::shell::dispatch_tasks::ShellGlobErr;
         log!("Expansion {} onGlobWalkDone", this);
-        // A failed walk must not raise a JS exception here: that would leave
-        // it pending on the VM with no JS frame above this task callback to
-        // observe it, aborting the process on the next exception check —
-        // `.nothrow()`/`try` could never intercept it.
-        //
-        // ENOENT/ENOTDIR mean the pattern's literal directory prefix doesn't
-        // exist (`echo /nonexistent/*`): treat that exactly like a glob that
-        // matched nothing — the same outcome as a relative pattern whose
-        // directory is missing. Any other failure is kept and surfaced below.
         let walk_err = match err {
             Some(ShellGlobErr::Syscall(e))
                 if matches!(e.get_errno(), bun_sys::E::ENOENT | bun_sys::E::ENOTDIR) =>
@@ -669,11 +660,8 @@ impl Expansion {
         };
 
         if result.is_empty() || walk_err.is_some() {
-            // Spec lines 559-578: in variable assignments a no-match (or
-            // failed) glob expands to the literal pattern; otherwise it's an
-            // error. The parent of an assignment never prints expansion
-            // errors, so the literal-pattern fallback applies to every kind
-            // of walk failure there.
+            // Spec lines 559-578: in variable assignments a no-match glob
+            // expands to the literal pattern; otherwise it's an error.
             let parent = interp.as_expansion(this).base.parent;
             let in_assign = matches!(interp.node(parent).kind(), StateKind::Assign)
                 || matches!(
@@ -688,11 +676,6 @@ impl Expansion {
                 Self::push_current_out(me);
                 me.state = ExpansionState::Done;
             } else if let Some(err) = walk_err {
-                // A real walk failure (EACCES, EMFILE, …) aborts the command
-                // through the same error path as a walker-init failure in
-                // `transition_to_glob_state`, so the actual error reaches
-                // stderr with exit code 1 instead of masquerading as
-                // "no matches found".
                 let shell_err = match err {
                     ShellGlobErr::Syscall(e) => ShellErr::new_sys(&e),
                     ShellGlobErr::Unknown(e) => ShellErr::Custom(e.to_string().into_bytes().into()),

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -54,6 +54,8 @@ afterAll(async () => {
 });
 
 const BUN = bunExe();
+// Some tests rely on permission checks (EACCES), which root bypasses.
+const isRoot = process.getuid?.() === 0;
 
 describe("bunshell", () => {
   describe("exit codes", async () => {
@@ -844,6 +846,26 @@ booga"
       ]);
       expect(exitCode).toBe(0);
     });
+
+    // Unlike a missing directory (treated as "no matches found" above), a glob
+    // walk that fails for another reason — here EACCES on an unreadable
+    // directory — must surface the real error on stderr with exit code 1, not
+    // pretend the pattern matched nothing. Skipped as root, which bypasses
+    // permission checks.
+    test.if(isPosix && !isRoot)("glob over an unreadable directory reports the real error", async () => {
+      const dir = tempDirWithFiles("glob-eacces", { "placeholder.txt": "" });
+      const noaccess = join(dir, "noaccess").replaceAll("\\", "/");
+      mkdirSync(noaccess);
+      chmodSync(noaccess, 0o000);
+      try {
+        const { stderr, exitCode } = await $`echo ${noaccess}/*`.quiet().nothrow();
+        expect(stderr.toString()).toContain(`bun: Permission denied: ${noaccess}`);
+        expect(stderr.toString()).not.toContain("no matches found");
+        expect(exitCode).toBe(1);
+      } finally {
+        chmodSync(noaccess, 0o755);
+      }
+    });
   });
 
   describe("brace expansion", () => {
@@ -1034,7 +1056,6 @@ booga"
     // to stderr or calling done(), so any errno other than NOTDIR/NOENT/NAMETOOLONG
     // (e.g. EACCES, ELOOP) left the shell promise unresolved forever.
     // Skipped as root: permission checks don't apply, so EACCES never happens.
-    const isRoot = process.getuid?.() === 0;
     test.if(isPosix && !isRoot)("cd with EACCES fails with exit code 1 instead of hanging", async () => {
       const dir = tempDirWithFiles("cd-eacces", { "placeholder.txt": "" });
       const noaccess = join(dir, "noaccess");

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -862,6 +862,13 @@ booga"
         expect(stderr.toString()).toContain(`bun: Permission denied: ${noaccess}`);
         expect(stderr.toString()).not.toContain("no matches found");
         expect(exitCode).toBe(1);
+
+        // In assignment position the same failure falls back to the literal
+        // pattern instead of erroring (scalar assignments don't glob).
+        const assign = await $`FOO=${noaccess}/*; echo $FOO`.quiet().nothrow();
+        expect(assign.stderr.toString()).toBe("");
+        expect(assign.stdout.toString()).toBe(`${noaccess}/*\n`);
+        expect(assign.exitCode).toBe(0);
       } finally {
         chmodSync(noaccess, 0o755);
       }

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -54,7 +54,6 @@ afterAll(async () => {
 });
 
 const BUN = bunExe();
-// Some tests rely on permission checks (EACCES), which root bypasses.
 const isRoot = process.getuid?.() === 0;
 
 describe("bunshell", () => {
@@ -794,14 +793,6 @@ booga"
         .runAsTest("long leading run of injected ! stays literal");
     });
 
-    // A glob whose literal directory prefix does not exist (e.g.
-    // `echo /nonexistent/*`) makes the walker fail with ENOENT before matching
-    // anything. That failure must flow through the normal no-match handling
-    // ("no matches found" / literal pattern in assignments) instead of raising
-    // a JS exception from the glob task callback, which left the exception
-    // pending on the VM and aborted the whole process — not even `.nothrow()`
-    // or try/catch could intercept it. Spawned in a subprocess so a regression
-    // crashes the child, not the test runner.
     test("glob on a nonexistent absolute directory does not crash the process", async () => {
       const missing = join(tmpdirSync(), "does-not-exist").replaceAll("\\", "/");
       const script = `
@@ -809,13 +800,11 @@ booga"
         const missing = ${JSON.stringify(missing)};
         const results = [];
 
-        // command position, .nothrow(): shell error, script keeps running
         {
           const r = await $\`echo \${missing}/*\`.nothrow().quiet();
           results.push({ exitCode: r.exitCode, stderr: r.stderr.toString() });
         }
 
-        // command position, default throws: catchable ShellError
         try {
           await $\`echo \${missing}/*\`.quiet();
           results.push({ threw: false });
@@ -823,7 +812,6 @@ booga"
           results.push({ threw: true, exitCode: e.exitCode, stderr: e.stderr.toString() });
         }
 
-        // assignment position: expands to the literal pattern
         {
           const r = await $\`FOO=\${missing}/*; echo $FOO\`.nothrow().quiet();
           results.push({ exitCode: r.exitCode, stdout: r.stdout.toString() });
@@ -847,11 +835,6 @@ booga"
       expect(exitCode).toBe(0);
     });
 
-    // Unlike a missing directory (treated as "no matches found" above), a glob
-    // walk that fails for another reason — here EACCES on an unreadable
-    // directory — must surface the real error on stderr with exit code 1, not
-    // pretend the pattern matched nothing. Skipped as root, which bypasses
-    // permission checks.
     test.if(isPosix && !isRoot)("glob over an unreadable directory reports the real error", async () => {
       const dir = tempDirWithFiles("glob-eacces", { "placeholder.txt": "" });
       const noaccess = join(dir, "noaccess").replaceAll("\\", "/");
@@ -863,8 +846,6 @@ booga"
         expect(stderr.toString()).not.toContain("no matches found");
         expect(exitCode).toBe(1);
 
-        // In assignment position the same failure falls back to the literal
-        // pattern instead of erroring (scalar assignments don't glob).
         const assign = await $`FOO=${noaccess}/*; echo $FOO`.quiet().nothrow();
         expect(assign.stderr.toString()).toBe("");
         expect(assign.stdout.toString()).toBe(`${noaccess}/*\n`);
@@ -1062,7 +1043,6 @@ booga"
     // handleChangeCwdErr's `else` arm previously returned `.failed` without writing
     // to stderr or calling done(), so any errno other than NOTDIR/NOENT/NAMETOOLONG
     // (e.g. EACCES, ELOOP) left the shell promise unresolved forever.
-    // Skipped as root: permission checks don't apply, so EACCES never happens.
     test.if(isPosix && !isRoot)("cd with EACCES fails with exit code 1 instead of hanging", async () => {
       const dir = tempDirWithFiles("cd-eacces", { "placeholder.txt": "" });
       const noaccess = join(dir, "noaccess");

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -791,6 +791,59 @@ booga"
         })
         .runAsTest("long leading run of injected ! stays literal");
     });
+
+    // A glob whose literal directory prefix does not exist (e.g.
+    // `echo /nonexistent/*`) makes the walker fail with ENOENT before matching
+    // anything. That failure must flow through the normal no-match handling
+    // ("no matches found" / literal pattern in assignments) instead of raising
+    // a JS exception from the glob task callback, which left the exception
+    // pending on the VM and aborted the whole process — not even `.nothrow()`
+    // or try/catch could intercept it. Spawned in a subprocess so a regression
+    // crashes the child, not the test runner.
+    test("glob on a nonexistent absolute directory does not crash the process", async () => {
+      const missing = join(tmpdirSync(), "does-not-exist").replaceAll("\\", "/");
+      const script = `
+        import { $ } from "bun";
+        const missing = ${JSON.stringify(missing)};
+        const results = [];
+
+        // command position, .nothrow(): shell error, script keeps running
+        {
+          const r = await $\`echo \${missing}/*\`.nothrow().quiet();
+          results.push({ exitCode: r.exitCode, stderr: r.stderr.toString() });
+        }
+
+        // command position, default throws: catchable ShellError
+        try {
+          await $\`echo \${missing}/*\`.quiet();
+          results.push({ threw: false });
+        } catch (e) {
+          results.push({ threw: true, exitCode: e.exitCode, stderr: e.stderr.toString() });
+        }
+
+        // assignment position: expands to the literal pattern
+        {
+          const r = await $\`FOO=\${missing}/*; echo $FOO\`.nothrow().quiet();
+          results.push({ exitCode: r.exitCode, stdout: r.stdout.toString() });
+        }
+
+        console.log(JSON.stringify(results));
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual([
+        { exitCode: 1, stderr: `bun: no matches found: ${missing}/*\n` },
+        { threw: true, exitCode: 1, stderr: `bun: no matches found: ${missing}/*\n` },
+        { exitCode: 0, stdout: `${missing}/*\n` },
+      ]);
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("brace expansion", () => {
@@ -980,7 +1033,9 @@ booga"
     // handleChangeCwdErr's `else` arm previously returned `.failed` without writing
     // to stderr or calling done(), so any errno other than NOTDIR/NOENT/NAMETOOLONG
     // (e.g. EACCES, ELOOP) left the shell promise unresolved forever.
-    test.if(isPosix)("cd with EACCES fails with exit code 1 instead of hanging", async () => {
+    // Skipped as root: permission checks don't apply, so EACCES never happens.
+    const isRoot = process.getuid?.() === 0;
+    test.if(isPosix && !isRoot)("cd with EACCES fails with exit code 1 instead of hanging", async () => {
       const dir = tempDirWithFiles("cd-eacces", { "placeholder.txt": "" });
       const noaccess = join(dir, "noaccess");
       mkdirSync(noaccess);


### PR DESCRIPTION
### What does this PR do?

Fixes a process abort (SIGTRAP / exit 133 in release, `assertNoException` assertion in debug) when a `Bun.$` glob pattern points into a directory that doesn't exist:

```js
await Bun.$`echo /nonexistent-path-xyz/*`.nothrow().text();
console.log("survived"); // never reached — the process aborts
```

`.nothrow()` / `try`-`catch` cannot prevent it.

### Cause

For `echo /nonexistent/*` the pattern's literal prefix (`/nonexistent`) becomes the glob walk root, and opening it fails with ENOENT. `Expansion::on_glob_walk_done` handled any walk error by calling `interp.throw(...)` — raising a JS exception from the glob task callback — and then kept running the interpreter with the expansion marked `Done`. The exception stayed pending on the VM with no JS frame above the task to observe it, so the next exception check aborted the process. (It also silently dropped the argument and let the command "succeed" with exit 0.)

Relative patterns never hit this path: `echo ./nonexistent/*` already reports `bun: no matches found: ./nonexistent/*` with exit code 1.

### Fix

Stop throwing from the task callback, and handle walk errors through the shell's normal expansion-error machinery:

- **ENOENT / ENOTDIR** (the pattern's literal directory prefix doesn't exist): treated exactly like a glob that matched nothing — `bun: no matches found: <pattern>` on stderr, exit code 1, catchable `ShellError`, `.nothrow()` respected. Matches what relative patterns already do and zsh.
- **Any other failure in command position** (EACCES, EMFILE, internal errors): routed through `ExpansionState::Err`, the same path walker-init failures use, so the real error reaches stderr with exit code 1 (e.g. `bun: Permission denied: /root/`) instead of masquerading as "no matches found".
- **Assignment position** (`FOO=/nonexistent/*`, `FOO=/unreadable/*`): every kind of walk failure falls back to the literal pattern, matching the existing no-match behavior and bash/zsh (scalar assignments don't glob). Assigns never prints expansion errors, so erroring there would mean exit 1 with empty stderr.

(The last two refinements came out of review on earlier revisions of this PR.)

### How did you verify your code works?

- Before: `bun -e 'await Bun.$`echo /nonexistent-path-xyz/*`.nothrow().text(); console.log("survived")'` aborts (exit 133/134). After: prints `survived`, the command fails with exit 1 and `bun: no matches found: /nonexistent-path-xyz/*`.
- New test in `test/js/bun/shell/bunshell.test.ts` (`glob on a nonexistent absolute directory does not crash the process`) runs the repro in a subprocess and covers `.nothrow()`, the default-throws ShellError path, and assignment position. It fails (the child aborts) without the fix and passes with it.
- New test `glob over an unreadable directory reports the real error` covers the EACCES path in command and assignment position (skipped when running as root); the behavior was also verified manually by running the debug build as an unprivileged user against a mode-000 directory.
- Full `test/js/bun/shell/bunshell.test.ts` passes with a debug (ASAN) build.
