### PR TITLE
Fix unchecked exception when Bun.plugin 'target' fails string conversion

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -302,12 +302,11 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
     auto targetValue = obj->getIfPropertyExists(globalObject, Identifier::fromString(vm, "target"_s));
     RETURN_IF_EXCEPTION(throwScope, {});
     if (targetValue) {
-        if (auto* targetJSString = targetValue.toStringOrNull(globalObject)) {
-            String targetString = targetJSString->value(globalObject);
-            if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
-                JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
-                return {};
-            }
+        String targetString = targetValue.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
+            JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
+            return {};
         }
     }
 

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -366,6 +366,40 @@ describe("errors", () => {
     }).toThrow("plugin target must be one of 'node', 'bun' or 'browser'");
   });
 
+  it("handles 'target' that cannot be converted to a string", () => {
+    const opts = {
+      setup: () => {},
+      target: {
+        toString() {
+          return {};
+        },
+        valueOf() {
+          return {};
+        },
+      },
+    };
+
+    expect(() => {
+      plugin(opts as any);
+    }).toThrow(TypeError);
+  });
+
+  it("propagates exceptions thrown while converting 'target' to a string", () => {
+    const error = new Error("target toString failed");
+    const opts = {
+      setup: () => {},
+      target: {
+        toString() {
+          throw error;
+        },
+      },
+    };
+
+    expect(() => {
+      plugin(opts as any);
+    }).toThrow(error);
+  });
+
   it("invalid loaders throw", () => {
     const invalidLoaders = ["blah", "blah2", "blah3", "blah4"];
     const inputs = ["body { background: red; }", "<h1>hi</h1>", '{"hi": "there"}', "hi"];


### PR DESCRIPTION
### What does this PR do?

Fixes a crash (debug assertion `ExceptionScope::assertNoException`, fuzzer fingerprint `54cc4233a9cdc31c`) in `Bun.plugin()` when the `target` option is a value whose string conversion throws, e.g. an object whose `toString()` returns a non-primitive:

```js
Bun.plugin({
  setup: () => {},
  target: { toString() { return {}; }, valueOf() { return {}; } },
});
```

In `setupBunPlugin`, the `target` value was converted with `toStringOrNull()` and the null (exception) case was silently ignored, leaving a pending exception on the VM. The later call into the plugin's `setup()` function then observed the stale exception and aborted with:

```
ASSERTION FAILED: Unexpected exception observed on thread ...
Error Exception: No default value
!exception()
JavaScriptCore/ExceptionScope.h(61) : void JSC::ExceptionScope::assertNoException()
```

The fix converts `target` with `toWTFString()` and checks the throw scope, matching the rest of the file, so the conversion error (e.g. `TypeError: No default value` or a user-thrown error from `toString()`) propagates to the caller as a normal JS exception instead of crashing.

### How did you verify your code works?

- Before the fix, the repro above aborts a debug build with the `assertNoException` assertion; after the fix it throws a catchable `TypeError`.
- Added regression tests in `test/js/bun/plugin/plugins.test.ts` covering both a non-convertible `target` and a `target` whose `toString()` throws; `bun bd test test/js/bun/plugin/plugins.test.ts` passes.