### PR TITLE
bun:test: return an object when constructing a mock function

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -86,6 +86,7 @@ inline To tryJSDynamicCast(JSC::WriteBarrier<WriteBarrierT>& from)
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionCall);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionConstruct);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetter_mockGetLastCall);
@@ -462,7 +463,7 @@ public:
     }
 
     JSMockFunction(JSC::VM& vm, JSC::Structure* structure, CallbackKind wrapKind)
-        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
+        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionConstruct)
     {
         initMock();
     }
@@ -826,7 +827,7 @@ static JSValue createMockResult(JSC::VM& vm, Zig::GlobalObject* globalObject, co
     return result;
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+static JSC::EncodedJSValue jsMockFunctionCallImpl(JSGlobalObject* lexicalGlobalObject, CallFrame* callframe, JSValue thisValue)
 {
     Zig::GlobalObject* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
@@ -838,7 +839,6 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     }
 
     JSC::ArgList args = JSC::ArgList(callframe);
-    JSValue thisValue = callframe->thisValue();
     JSC::JSArray* argumentsArray = nullptr;
     {
         JSC::ObjectInitializationScope object(vm);
@@ -979,6 +979,34 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
 
     setReturnValue(createMockResult(vm, globalObject, "return"_s, jsUndefined()));
     return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    return jsMockFunctionCallImpl(lexicalGlobalObject, callframe, callframe->thisValue());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // [[Construct]] must return an object: create `this` from new.target's prototype,
+    // run the mock, and return the mock's result only if it is an object.
+    JSObject* newTarget = asObject(callframe->newTarget());
+    JSGlobalObject* functionGlobalObject = getFunctionRealm(lexicalGlobalObject, newTarget);
+    RETURN_IF_EXCEPTION(scope, {});
+    Structure* structure = InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, functionGlobalObject->objectStructureForObjectConstructor());
+    RETURN_IF_EXCEPTION(scope, {});
+    JSObject* thisObject = JSC::constructEmptyObject(vm, structure);
+
+    JSValue returnValue = JSValue::decode(jsMockFunctionCallImpl(lexicalGlobalObject, callframe, thisObject));
+    RETURN_IF_EXCEPTION(scope, {});
+    if (returnValue && returnValue.isObject()) {
+        return JSValue::encode(returnValue);
+    }
+
+    return JSValue::encode(thisObject);
 }
 
 void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -238,6 +238,39 @@ describe("mock()", () => {
     const obj = { fn };
     expect(obj.fn()).toBe(obj);
   });
+  test("can be constructed with new", () => {
+    const fn = jest.fn();
+    const instance = new fn();
+    expect(typeof instance).toBe("object");
+    expect(instance).not.toBe(null);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn.mock.results[0]).toEqual({
+      type: "return",
+      value: undefined,
+    });
+
+    // the implementation is called with `this` set to the newly created object
+    const fn2 = jest.fn(function () {
+      this.x = 42;
+    });
+    const instance2 = new fn2();
+    expect(instance2.x).toBe(42);
+    expect(fn2.mock.contexts[0]).toBe(instance2);
+
+    // a primitive return value from the implementation is ignored, like a plain constructor
+    const fn3 = jest.fn(() => 123);
+    expect(typeof new fn3()).toBe("object");
+
+    // an object return value becomes the result of `new`
+    const result = { a: 1 };
+    const fn4 = jest.fn(() => result);
+    expect(new fn4()).toBe(result);
+
+    // Reflect.construct with a different new.target respects its prototype
+    class Base {}
+    const fn5 = jest.fn();
+    expect(Reflect.construct(fn5, [], Base)).toBeInstanceOf(Base);
+  });
   if (isBun) {
     test("jest.fn(10) return value shorthand", () => {
       expect(jest.fn(10)()).toBe(10);


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-found assertion failure (`ASSERTION FAILED: isCell()` in `JSCJSValue.h:1043`) triggered by constructing a `bun:test` mock function:

```js
import { mock } from "bun:test";
const fn = mock();
Reflect.construct(fn, []); // ASSERTION FAILED: isCell() in debug builds
```

`JSMockFunction` registered the same host callback (`jsMockFunctionCall`) for both call and construct, so constructing a mock returned whatever the call path produced — `undefined` when there is no implementation, or any primitive the implementation returns. JSC requires native construct callbacks to return an object; `Interpreter::executeConstruct` (the path used by `Reflect.construct`, proxies, and `JSC::construct` from C++) does `asObject(result)` on the returned value, which asserts in debug builds. In release builds `new mockFn()` silently evaluated to `undefined`/a primitive, which also breaks Jest's class-mocking pattern (`const instance = new MockedClass()`).

This PR gives `JSMockFunction` a dedicated construct callback that follows ordinary `[[Construct]]` semantics:

- create `this` from `new.target`'s `prototype` (falling back to `Object.prototype`, like `OrdinaryCreateFromConstructor`)
- run the existing mock call logic with that `this` (so `mock.calls`/`mock.contexts`/`mock.results` are recorded as before, and the implementation sees the new instance as `this`)
- return the implementation's result if it is an object, otherwise return the newly created `this`

This matches how Jest mocks behave when constructed, since Jest's `mockConstructor` is a plain JS function.

### How did you verify your code works?

- The fuzzer repro and a minimized `Reflect.construct(Bun.jest(...).mock(), [])` script no longer hit the assertion with a debug (ASAN) build.
- Added a test to `test/js/bun/test/mock-fn.test.js` covering `new fn()`, implementations that return primitives/objects, `this` handling, and `Reflect.construct` with a custom `new.target`. The test fails on current `bun` (returns `undefined` from `new fn()`) and passes with this change; assertions are written to also hold under Jest/Vitest, which this file supports.
- `bun bd test test/js/bun/test/mock-fn.test.js`, `mock-disposable.test.ts`, `mock/mock-module.test.ts`, `spyMatchers.test.ts`, and `expect-toHaveReturnedWith.test.js` all pass, including with `BUN_JSC_validateExceptionChecks=1`.