### PR TITLE
fix(bun:test): return an object when constructing a mock function

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -86,6 +86,7 @@ inline To tryJSDynamicCast(JSC::WriteBarrier<WriteBarrierT>& from)
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionCall);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionConstruct);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetter_mockGetLastCall);
@@ -462,7 +463,7 @@ public:
     }
 
     JSMockFunction(JSC::VM& vm, JSC::Structure* structure, CallbackKind wrapKind)
-        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
+        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionConstruct)
     {
         initMock();
     }
@@ -826,7 +827,7 @@ static JSValue createMockResult(JSC::VM& vm, Zig::GlobalObject* globalObject, co
     return result;
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+static JSC::EncodedJSValue jsMockFunctionCallImpl(JSGlobalObject* lexicalGlobalObject, CallFrame* callframe, JSValue thisValue)
 {
     Zig::GlobalObject* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
@@ -838,7 +839,6 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     }
 
     JSC::ArgList args = JSC::ArgList(callframe);
-    JSValue thisValue = callframe->thisValue();
     JSC::JSArray* argumentsArray = nullptr;
     {
         JSC::ObjectInitializationScope object(vm);
@@ -979,6 +979,36 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
 
     setReturnValue(createMockResult(vm, globalObject, "return"_s, jsUndefined()));
     return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    return jsMockFunctionCallImpl(lexicalGlobalObject, callframe, callframe->thisValue());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // [[Construct]] must return an object. Mimic ordinary constructor semantics:
+    // create `this` from newTarget.prototype, run the mock body with it, and
+    // return the body's result only if it is an object.
+    JSObject* newTarget = asObject(callframe->newTarget());
+    JSValue prototype = newTarget->get(lexicalGlobalObject, vm.propertyNames->prototype);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    JSObject* thisObject = prototype.isObject()
+        ? JSC::constructEmptyObject(lexicalGlobalObject, asObject(prototype))
+        : JSC::constructEmptyObject(lexicalGlobalObject);
+
+    JSValue result = JSValue::decode(jsMockFunctionCallImpl(lexicalGlobalObject, callframe, thisObject));
+    RETURN_IF_EXCEPTION(scope, {});
+
+    if (result && result.isObject())
+        return JSValue::encode(result);
+
+    return JSValue::encode(thisObject);
 }
 
 void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -117,6 +117,34 @@ describe("mock()", () => {
     expect(fn).toHaveBeenCalledWith();
   });
 
+  test("can be constructed with new", () => {
+    // with no implementation, `new` returns a newly created object
+    const fn = jest.fn();
+    const instance = new fn();
+    expect(typeof instance).toBe("object");
+    expect(instance).not.toBeNull();
+    const reflected = Reflect.construct(fn, []);
+    expect(typeof reflected).toBe("object");
+    expect(reflected).not.toBeNull();
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    // a primitive return value is ignored, like ordinary constructors
+    const returnsPrimitive = jest.fn(() => 42);
+    expect(typeof new returnsPrimitive()).toBe("object");
+    expect(typeof Reflect.construct(returnsPrimitive, [])).toBe("object");
+
+    // an object return value is passed through, like ordinary constructors
+    const result = { value: 42 };
+    const returnsObject = jest.fn(() => result);
+    expect(new returnsObject()).toBe(result);
+    expect(Reflect.construct(returnsObject, [])).toBe(result);
+
+    // mockReturnValue with a primitive still constructs an object
+    const mockedReturnValue = jest.fn().mockReturnValue(123);
+    expect(typeof new mockedReturnValue()).toBe("object");
+    expect(typeof Reflect.construct(mockedReturnValue, [])).toBe("object");
+  });
+
   test("mockName returns this", () => {
     const fn = jest.fn();
     expect(fn.mockName()).toBe(fn);
@@ -827,6 +855,22 @@ describe("spyOn", () => {
     expect(obj.original()).toBe(42);
     expect(fn).not.toHaveBeenCalled();
   });
+
+  if (isBun) {
+    test("spy on a missing property can be constructed with new", () => {
+      // the spy's implementation returns the original value (undefined), which
+      // must not escape as the result of a [[Construct]]
+      const target = {};
+      const fn = spyOn(target, "doesNotExist");
+      const instance = new fn();
+      expect(typeof instance).toBe("object");
+      expect(instance).not.toBeNull();
+      const reflected = Reflect.construct(fn, []);
+      expect(typeof reflected).toBe("object");
+      expect(reflected).not.toBeNull();
+      fn.mockRestore();
+    });
+  }
 
   test("override impl after doesnt break restore", () => {
     var obj = {


### PR DESCRIPTION
### What does this PR do?

Fixes a Fuzzilli-found crash (assertion `isCell()` in `JSCJSValue.h:1043`, reached from `JSC::Interpreter::executeConstruct` → `asObject`).

`JSMockFunction` (the object behind `jest.fn()` / `mock()` / `spyOn()`) registered `jsMockFunctionCall` as **both** its call and construct callbacks. That callback returns whatever the mock's implementation produces — `undefined` when there is no implementation, or any primitive from `mockReturnValue`/a primitive-returning implementation. A native `[[Construct]]` callback must return an object, so:

- `Reflect.construct(mockFn, [])` hit the `isCell()` assertion in debug builds (and in release builds `asObject()` fabricates a bogus `JSObject*` from a primitive encoding — type confusion).
- `new mockFn()` silently evaluated to `undefined`, which ordinary JS constructor semantics never allow.

Minimal repro (crashes a debug build before this change):

```js
import { mock } from "bun:test";
Reflect.construct(mock(), []); // ASSERTION FAILED: isCell()
```

#### Fix

Give `JSMockFunction` a dedicated construct callback that follows ordinary constructor semantics:

1. Create `this` from `newTarget.prototype` (falling back to a plain object).
2. Run the existing mock body (call recording, implementations, etc.) with that `this`.
3. Return the body's result if it is an object, otherwise return the created `this`.

This matches how Jest mock functions behave, since they are ordinary JS functions there (`new jest.fn()()` yields the new instance, and an object-returning implementation passes through).

### How did you verify your code works?

- The original Fuzzilli crash script and the minimized repro no longer crash a debug build (clean exit).
- Added tests in `test/js/bun/test/mock-fn.test.js` covering `new`/`Reflect.construct` on `jest.fn()` (no implementation, primitive-returning, object-returning, `mockReturnValue`) and on a spy over a missing property (the fuzzer's exact path). They fail on the previous build and pass with this change.
- `bun bd test test/js/bun/test/mock-fn.test.js` (74 pass), plus `mock-disposable`, `mock-module*`, `spyMatchers`, `expect-toHaveReturnedWith`, and `describe` suites all pass.
