### PR TITLE
Fix crash when constructing a mock function whose implementation returns a primitive

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -86,6 +86,7 @@ inline To tryJSDynamicCast(JSC::WriteBarrier<WriteBarrierT>& from)
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionCall);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionConstruct);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetter_mockGetLastCall);
@@ -462,7 +463,7 @@ public:
     }
 
     JSMockFunction(JSC::VM& vm, JSC::Structure* structure, CallbackKind wrapKind)
-        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
+        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionConstruct)
     {
         initMock();
     }
@@ -979,6 +980,39 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
 
     setReturnValue(createMockResult(vm, globalObject, "return"_s, jsUndefined()));
     return JSValue::encode(jsUndefined());
+}
+
+// Native constructors must return an object, so behave like `new` on an ordinary JS function:
+// run the mock with a freshly created `this` and return its result only when it is an object.
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (!dynamicDowncast<JSMockFunction>(callframe->jsCallee())) [[unlikely]] {
+        throwTypeError(lexicalGlobalObject, scope, "Expected callee to be mock function"_s);
+        return {};
+    }
+
+    JSValue newTarget = callframe->newTarget();
+    JSObject* thisObject = nullptr;
+    if (newTarget && newTarget.isObject()) {
+        JSValue prototype = asObject(newTarget)->get(lexicalGlobalObject, vm.propertyNames->prototype);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (prototype.isObject())
+            thisObject = JSC::constructEmptyObject(lexicalGlobalObject, asObject(prototype));
+    }
+    if (!thisObject)
+        thisObject = JSC::constructEmptyObject(lexicalGlobalObject);
+
+    callframe->setThisValue(thisObject);
+    JSValue returnValue = JSValue::decode(jsMockFunctionCall(lexicalGlobalObject, callframe));
+    RETURN_IF_EXCEPTION(scope, {});
+
+    if (returnValue && returnValue.isObject())
+        return JSValue::encode(returnValue);
+
+    return JSValue::encode(thisObject);
 }
 
 void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -796,31 +796,31 @@ describe("mock()", () => {
   });
 
   test("can be invoked with new", () => {
-    const noImpl = mock();
+    const noImpl = jest.fn();
     const instance = new noImpl();
     expect(instance).toBeInstanceOf(Object);
     expect(noImpl.mock.contexts[0]).toBe(instance);
     expect(Reflect.construct(noImpl, [])).toBeInstanceOf(Object);
 
-    const primitiveImpl = mock(() => 42);
+    const primitiveImpl = jest.fn(() => 42);
     expect(new primitiveImpl()).toBeInstanceOf(Object);
     expect(primitiveImpl.mock.results[0]).toEqual({ type: "return", value: 42 });
 
-    const usesThis = mock(function () {
+    const usesThis = jest.fn(function () {
       this.x = 1;
     });
     expect(new usesThis()).toEqual({ x: 1 });
 
-    const returnsObject = mock(() => ({ y: 2 }));
+    const returnsObject = jest.fn(() => ({ y: 2 }));
     expect(new returnsObject()).toEqual({ y: 2 });
 
-    const throws = mock(() => {
+    const throws = jest.fn(() => {
       throw new Error("boom");
     });
     expect(() => new throws()).toThrow("boom");
 
     class Target {}
-    const withNewTarget = mock();
+    const withNewTarget = jest.fn();
     expect(Object.getPrototypeOf(Reflect.construct(withNewTarget, [], Target))).toBe(Target.prototype);
   });
 });

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -794,6 +794,35 @@ describe("mock()", () => {
 
     expect(bar()()).toBe(true);
   });
+
+  test("can be invoked with new", () => {
+    const noImpl = mock();
+    const instance = new noImpl();
+    expect(instance).toBeInstanceOf(Object);
+    expect(noImpl.mock.contexts[0]).toBe(instance);
+    expect(Reflect.construct(noImpl, [])).toBeInstanceOf(Object);
+
+    const primitiveImpl = mock(() => 42);
+    expect(new primitiveImpl()).toBeInstanceOf(Object);
+    expect(primitiveImpl.mock.results[0]).toEqual({ type: "return", value: 42 });
+
+    const usesThis = mock(function () {
+      this.x = 1;
+    });
+    expect(new usesThis()).toEqual({ x: 1 });
+
+    const returnsObject = mock(() => ({ y: 2 }));
+    expect(new returnsObject()).toEqual({ y: 2 });
+
+    const throws = mock(() => {
+      throw new Error("boom");
+    });
+    expect(() => new throws()).toThrow("boom");
+
+    class Target {}
+    const withNewTarget = mock();
+    expect(Object.getPrototypeOf(Reflect.construct(withNewTarget, [], Target))).toBe(Target.prototype);
+  });
 });
 
 describe("spyOn", () => {
@@ -1010,6 +1039,13 @@ describe("spyOn", () => {
       expect(arr[14]).toBe(original);
       expect(arr[14]()).toBe(456);
       expect(fn).not.toHaveBeenCalled();
+    });
+
+    test("constructing a spy on a missing property returns an object", () => {
+      const target = {};
+      const fn = spyOn(target, "missing");
+      expect(Reflect.construct(fn, [])).toBeInstanceOf(Object);
+      expect(new fn()).toBeInstanceOf(Object);
     });
   }
 


### PR DESCRIPTION
### What does this PR do?

Fixes a crash found by fuzzing (assertion `isCell()` in `JSC::JSValue::asCell`, `JSCJSValue.h:1043`).

`JSMockFunction` registered `jsMockFunctionCall` as both its call **and** construct callback, so constructing a mock returned whatever the mock implementation produced. Native constructors must always return an object: `Interpreter::executeConstruct` does `asObject(result)` on the returned value, so a primitive result asserts in debug builds and is a type confusion in release builds. It was also observable from JS — `new (mock())()` evaluated to `undefined`, which should be impossible for a `new` expression.

Repro before this change (crashes debug builds, `Reflect.construct` path):

```js
import { mock } from "bun:test";
const fn = mock(); // or spyOn(obj, "someNonFunctionProperty")
Reflect.construct(fn, []);
```

This PR gives `JSMockFunction` a dedicated construct callback that follows ordinary JS constructor semantics (and matches Jest, where mocks are plain JS functions):

- creates the `this` object from `newTarget.prototype` (falling back to `Object.prototype`)
- runs the existing mock call logic with that `this`, so `mock.contexts`/`mock.results` keep recording as before and implementations that assign to `this` work
- returns the implementation's result when it is an object, otherwise the newly created `this`

### How did you verify your code works?

- Added tests in `test/js/bun/test/mock-fn.test.js` covering `new mock()` with no implementation, primitive-returning, object-returning, `this`-mutating and throwing implementations, `Reflect.construct` with a custom `newTarget`, and constructing a spy on a missing property (the fuzzer scenario). The new tests fail with the `isCell()` assertion on a build without the fix and pass with it.
- `bun bd test test/js/bun/test/mock-fn.test.js` (also with `BUN_JSC_validateExceptionChecks=1`), plus `mock-disposable.test.ts`, `spyMatchers.test.ts`, and `mock/mock-module-non-string.test.ts` — all pass.
- The original fuzzer reproducer no longer crashes.
