### PR TITLE
install: gate the exit-callback cache teardown to the main thread

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1415,15 +1415,12 @@ pub(crate) fn allocate_package_manager() {
         bun_core::heap::into_raw(Box::<PackageManager>::new_uninit()).cast::<PackageManager>();
     holder::RAW_PTR.store(ptr, core::sync::atomic::Ordering::Release);
     // The exit callback exists only so LeakSanitizer does not report the
-    // caches as still reachable at exit. In non-ASAN builds it is wasted work
-    // at process exit, so don't register it. (`ENABLE_ASAN` is a compile-time
-    // const, so this branch folds away while keeping `deinit_caches_at_exit`
-    // referenced.)
-    if bun_core::Environment::ENABLE_ASAN {
-        bun_core::add_exit_callback(deinit_caches_at_exit);
-    }
+    // caches as still reachable at exit; non-ASAN builds don't compile it in.
+    #[cfg(bun_asan)]
+    bun_core::add_exit_callback(deinit_caches_at_exit);
 }
 
+#[cfg(bun_asan)]
 extern "C" fn deinit_caches_at_exit() {
     // Exit callbacks run on whichever thread called `Global::exit()` — e.g.
     // the HTTP client thread when CA-file validation fails in

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1414,21 +1414,12 @@ pub(crate) fn allocate_package_manager() {
     let ptr =
         bun_core::heap::into_raw(Box::<PackageManager>::new_uninit()).cast::<PackageManager>();
     holder::RAW_PTR.store(ptr, core::sync::atomic::Ordering::Release);
-    // The exit callback exists only so LeakSanitizer does not report the
-    // caches as still reachable at exit; non-ASAN builds don't compile it in.
     #[cfg(bun_asan)]
     bun_core::add_exit_callback(deinit_caches_at_exit);
 }
 
 #[cfg(bun_asan)]
 extern "C" fn deinit_caches_at_exit() {
-    // Exit callbacks run on whichever thread called `Global::exit()` — e.g.
-    // the HTTP client thread when CA-file validation fails in
-    // `http_thread_on_init_error`. The cache's `MimallocArena` heaps are
-    // created by and belong to the main thread, and the main thread may still
-    // be mutating the cache concurrently, so off-main this would be both a
-    // wrong-thread `mi_heap_destroy` and a data race. Skip it and let the OS
-    // reclaim the memory.
     if !bun_crash_handler::cli_state::is_main_thread() {
         return;
     }
@@ -1439,8 +1430,7 @@ extern "C" fn deinit_caches_at_exit() {
     if ptr.is_null() {
         return;
     }
-    // SAFETY: `deinit_caches()` only touches main-thread-owned fields, and the
-    // main-thread precondition is checked above (not assumed).
+    // SAFETY: `deinit_caches()` only touches main-thread-owned fields.
     unsafe { (*ptr).deinit_caches() };
 }
 

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1414,10 +1414,27 @@ pub(crate) fn allocate_package_manager() {
     let ptr =
         bun_core::heap::into_raw(Box::<PackageManager>::new_uninit()).cast::<PackageManager>();
     holder::RAW_PTR.store(ptr, core::sync::atomic::Ordering::Release);
-    bun_core::add_exit_callback(deinit_caches_at_exit);
+    // The exit callback exists only so LeakSanitizer does not report the
+    // caches as still reachable at exit. In non-ASAN builds it is wasted work
+    // at process exit, so don't register it. (`ENABLE_ASAN` is a compile-time
+    // const, so this branch folds away while keeping `deinit_caches_at_exit`
+    // referenced.)
+    if bun_core::Environment::ENABLE_ASAN {
+        bun_core::add_exit_callback(deinit_caches_at_exit);
+    }
 }
 
 extern "C" fn deinit_caches_at_exit() {
+    // Exit callbacks run on whichever thread called `Global::exit()` — e.g.
+    // the HTTP client thread when CA-file validation fails in
+    // `http_thread_on_init_error`. The cache's `MimallocArena` heaps are
+    // created by and belong to the main thread, and the main thread may still
+    // be mutating the cache concurrently, so off-main this would be both a
+    // wrong-thread `mi_heap_destroy` and a data race. Skip it and let the OS
+    // reclaim the memory.
+    if !bun_crash_handler::cli_state::is_main_thread() {
+        return;
+    }
     if !holder::INITIALIZED.load(core::sync::atomic::Ordering::Acquire) {
         return;
     }
@@ -1425,7 +1442,8 @@ extern "C" fn deinit_caches_at_exit() {
     if ptr.is_null() {
         return;
     }
-    // SAFETY: `deinit_caches()` only touches main-thread-owned fields.
+    // SAFETY: `deinit_caches()` only touches main-thread-owned fields, and the
+    // main-thread precondition is checked above (not assumed).
     unsafe { (*ptr).deinit_caches() };
 }
 

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -260,6 +260,42 @@ describe("certificate authority", () => {
     expect(await exited).toBe(1);
   });
 
+  test("non-existent --cafile with workspaces exits 1 without crashing", async () => {
+    // The workspace walk in `PackageManager::init()` populates the workspace
+    // package.json cache before the HTTP thread starts. When the HTTP thread
+    // then fails CA validation and drives process exit, the exit path must not
+    // tear down that main-thread-owned cache from the HTTP thread.
+    await Promise.all([
+      write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+          dependencies: { "no-deps": "1.1.1" },
+        }),
+      ),
+      ...["a", "b", "c"].map(name =>
+        write(
+          join(packageDir, "packages", name, "package.json"),
+          JSON.stringify({ name: `pkg-${name}`, version: "1.0.0" }),
+        ),
+      ),
+    ]);
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--cafile", "/does/not/exist"],
+      cwd: packageDir,
+      stderr: "pipe",
+      stdout: "pipe",
+      env,
+    });
+    const out = await stdout.text();
+    expect(out).not.toContain("no-deps");
+    const err = await stderr.text();
+    expect(err).toContain(`HTTPThread: could not find CA file: '/does/not/exist'`);
+    expect(await exited).toBe(1);
+  });
+
   test("cafile from bunfig does not exist", async () => {
     await Promise.all([
       write(


### PR DESCRIPTION
The package manager registers an exit callback that tears down its workspace package.json cache so LeakSanitizer does not report it as still reachable at exit. Exit callbacks run on whichever thread drives process exit, but the cache's per-entry arenas are created by and owned by the main thread, so running that teardown from another thread (e.g. the HTTP client thread when CA-file validation fails) is unsound and can abort the process instead of exiting with code 1.

This change registers the callback only in ASAN builds (it is wasted work otherwise) and makes the callback a no-op when invoked off the main thread, letting the OS reclaim the memory on that path.

Adds a test that runs `bun install --cafile /does/not/exist` in a workspace project, which populates the cache on the main thread before the HTTP thread fails initialization and drives exit; it asserts the error message and exit code 1. Because the underlying failure is timing-dependent, the unfixed binary does not fail this test on every run, but the test pins the exact configuration that was intermittently dumping core in CI ("certificate authority > non-existent --cafile" on the alpine x64 lane). The existing cafile tests continue to pass.