### PR TITLE
fix(bun:test): constructing a mock function must return an object

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -86,6 +86,7 @@ inline To tryJSDynamicCast(JSC::WriteBarrier<WriteBarrierT>& from)
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionCall);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionConstruct);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetter_mockGetLastCall);
@@ -462,7 +463,7 @@ public:
     }
 
     JSMockFunction(JSC::VM& vm, JSC::Structure* structure, CallbackKind wrapKind)
-        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
+        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionConstruct)
     {
         initMock();
     }
@@ -826,7 +827,7 @@ static JSValue createMockResult(JSC::VM& vm, Zig::GlobalObject* globalObject, co
     return result;
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+static JSC::EncodedJSValue jsMockFunctionCallImpl(JSGlobalObject* lexicalGlobalObject, CallFrame* callframe, JSValue thisValue)
 {
     Zig::GlobalObject* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
@@ -838,7 +839,6 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     }
 
     JSC::ArgList args = JSC::ArgList(callframe);
-    JSValue thisValue = callframe->thisValue();
     JSC::JSArray* argumentsArray = nullptr;
     {
         JSC::ObjectInitializationScope object(vm);
@@ -979,6 +979,40 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
 
     setReturnValue(createMockResult(vm, globalObject, "return"_s, jsUndefined()));
     return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    return jsMockFunctionCallImpl(lexicalGlobalObject, callframe, callframe->thisValue());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue newTarget = callframe->newTarget();
+    JSObject* prototype = nullptr;
+    if (newTarget.isObject()) {
+        JSValue prototypeValue = asObject(newTarget)->get(lexicalGlobalObject, vm.propertyNames->prototype);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (prototypeValue.isObject())
+            prototype = asObject(prototypeValue);
+    }
+
+    JSObject* thisObject = prototype
+        ? JSC::constructEmptyObject(lexicalGlobalObject, prototype)
+        : JSC::constructEmptyObject(lexicalGlobalObject);
+
+    JSValue result = JSValue::decode(jsMockFunctionCallImpl(lexicalGlobalObject, callframe, thisObject));
+    RETURN_IF_EXCEPTION(scope, {});
+
+    // A [[Construct]] call must always produce an object. If the mock implementation returned a
+    // primitive, return the newly created instance instead, matching ordinary constructor semantics.
+    if (result && result.isObject())
+        return JSValue::encode(result);
+
+    return JSValue::encode(thisObject);
 }
 
 void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -117,6 +117,33 @@ describe("mock()", () => {
     expect(fn).toHaveBeenCalledWith();
   });
 
+  test("are constructable", () => {
+    // Constructing a mock must always produce an object, even when the
+    // implementation returns a primitive or there is no implementation at all.
+    const fn = jest.fn();
+    expect(new fn()).toBeInstanceOf(Object);
+    expect(Reflect.construct(fn, [])).toBeInstanceOf(Object);
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    const withPrimitive = jest.fn(() => 42);
+    expect(new withPrimitive()).toBeInstanceOf(Object);
+
+    const withReturnValue = jest.fn();
+    withReturnValue.mockReturnValue(5);
+    expect(new withReturnValue()).toBeInstanceOf(Object);
+    expect(Reflect.construct(withReturnValue, [])).toBeInstanceOf(Object);
+
+    const result = { a: 1 };
+    const withObject = jest.fn(() => result);
+    expect(new withObject()).toBe(result);
+    expect(Reflect.construct(withObject, [])).toBe(result);
+
+    const thrower = jest.fn(() => {
+      throw new Error("boom");
+    });
+    expect(() => new thrower()).toThrow("boom");
+  });
+
   test("mockName returns this", () => {
     const fn = jest.fn();
     expect(fn.mockName()).toBe(fn);


### PR DESCRIPTION
### What does this PR do?

Fixes a crash found by fuzzing (fingerprint `JSCJSValue.h(1043)`, `ASSERTION FAILED: isCell()`).

`JSMockFunction` (the object behind `jest.fn()` / `mock()` / `spyOn()` in `bun:test`) registered its **call** callback as its **construct** callback too. When a mock was constructed and its implementation produced a non-object (e.g. no implementation at all, or `mockReturnValue(5)`), the construct callback returned that primitive. A `[[Construct]]` call must always produce an object, so paths that go through `JSC::construct()` — `Reflect.construct(mockFn, [])`, `super()` on a mocked class, proxies, etc. — ended up calling `asObject()` on a non-cell value. That trips the `isCell()` assertion in debug builds and produces a bogus "object" pointer in release builds. Plain `new mockFn()` was also wrong: it evaluated to `undefined`.

```js
const { jest } = Bun.jest("/tmp/fake.test.js");
const fn = jest.fn();
new fn();                  // previously: undefined (spec violation)
Reflect.construct(fn, []); // previously: ASSERTION FAILED: isCell()
```

This PR gives `JSMockFunction` a dedicated construct callback that:

- creates a new instance using `newTarget.prototype` (falling back to `Object.prototype`),
- runs the existing mock call logic with that instance as `this` (so calls/contexts/results are still recorded and `mockReturnThis()` returns the instance),
- returns the implementation's result when it is an object, otherwise returns the newly created instance — matching ordinary JS constructor semantics and Jest's behavior.

### How did you verify your code works?

- The fuzzer repro no longer crashes; it now runs to completion.
- Added a `mock() > are constructable` test to `test/js/bun/test/mock-fn.test.js` covering `new mockFn()` / `Reflect.construct` with no implementation, primitive return values, object return values, and throwing implementations. The file keeps its Jest/Vitest interop, and these assertions match Jest's behavior.
- `bun bd test test/js/bun/test/mock-fn.test.js`, `mock-disposable.test.ts`, `spyMatchers.test.ts`, `expect-toHaveReturnedWith.test.js`, `expect/toHaveReturnedWith.test.ts`, and `test/regression/issue/issue-1825-jest-mock-functions.test.ts` all pass.
