### PR TITLE
Deepen the lots-of-for-loop fixture so the transpiler stack-overflow tests throw on Windows

### DIFF
--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4049,13 +4049,13 @@ it("Bun.Transpiler.transformSync stack overflows", async () => {
   const code = await Bun.file(join(import.meta.dir, "fixtures", "lots-of-for-loop.js")).text();
   const transpiler = new Bun.Transpiler();
   expect(() => transpiler.transformSync(code)).toThrow(`Maximum call stack size exceeded`);
-});
+}, 60_000);
 
 it("Bun.Transpiler.transform stack overflows", async () => {
   const code = await Bun.file(join(import.meta.dir, "fixtures", "lots-of-for-loop.js")).text();
   const transpiler = new Bun.Transpiler();
   expect(async () => await transpiler.transform(code)).toThrow(`Maximum call stack size exceeded`);
-});
+}, 60_000);
 
 it("deeply nested expressions error instead of crashing the process", () => {
   const script = `


### PR DESCRIPTION
### Problem

Every PR build since #31333 merged fails the Windows test lanes (2019 x64, 2019 x64-baseline, 11 aarch64) on the same two tests in `test/bundler/transpiler/transpiler.test.js`:

```
✗ Bun.Transpiler.transformSync stack overflows
✗ Bun.Transpiler.transform stack overflows

error: expect(received).toThrow(expected)
Expected substring: "Maximum call stack size exceeded"
Received function did not throw
Received value: "let counter = 0;\nfor (let i = 0;i ..."
```

It reproduces on unrelated PRs (checked ~10 recent PR builds — all carry the identical annotation on a Windows lane) and doesn't show on `main`'s own CI because main builds don't run the Windows test lanes.

#31333 removed the parser's fixed `MAX_STMT_DEPTH` cap; recursion is now bounded only by `StackCheck`. The old `lots-of-for-loop.js` fixture is ~15k levels deep, which still exhausts the ~8 MB main stacks on the Linux/macOS lanes but fits comfortably inside the 18 MiB stack reserve bun links with on Windows (`/STACK:0x1200000`), so the transpile now succeeds there and `toThrow` fails.

### Fix

Per review: keep the assertions exactly as they are and make the fixture big enough that it overflows everywhere.

- `fixtures/lots-of-for-loop.js` is regenerated from 15,112 to **320,000 nested `for` loops** (~9 MB, same shape: `let counter = 0;` → nested fors → `counter++;` → `console.log(counter);`). Against Windows' 18 MiB reserve minus the 256 KiB `StackCheck` headroom, 320k levels need only ~58 bytes of stack per recursion level to trip the guard — far below any realistic parse/visit/print frame, and leaves the same margin against future codegen getting leaner. The smaller Linux/macOS stacks keep throwing exactly as before.
- The two `Bun.Transpiler.*` tests get a `60_000` ms timeout (the value the neighboring deeply-nested subprocess tests already use): on Windows the parser now recurses through ~18 MiB of stack before the guard trips, which costs a few seconds of wall time; the default 5 s would be tight.

No other changes; no comments added.

### Verification

- `bun bd test test/bundler/transpiler/transpiler.test.js` on current `main` + this change: 157 pass / 0 fail; the three stack-overflow tests throw in 57–360 ms on Linux (debug build).
- Same three tests pass against a release build as well.
- The Windows lanes on this PR are the proof that 320k levels overflow the 18 MiB reserve; if they somehow still don't throw there, the fixture gets another bump.
