### PR TITLE
install: use safe from_utf8 for base64 hash in Integrity display

### DIFF
--- a/src/install/integrity.rs
+++ b/src/install/integrity.rs
@@ -242,10 +242,9 @@ impl fmt::Display for Integrity {
         let mut base64_buf = [0u8; 512];
         let bytes = self.slice();
 
-        // SAFETY: base64 alphabet is pure ASCII.
-        f.write_str(unsafe {
-            core::str::from_utf8_unchecked(base64.encoder.encode(&mut base64_buf, bytes))
-        })?;
+        let encoded = base64.encoder.encode(&mut base64_buf, bytes);
+        let encoded = core::str::from_utf8(encoded).expect("base64 encoder emits ASCII");
+        f.write_str(encoded)?;
 
         // consistentcy with yarn.lock
         match self.tag {


### PR DESCRIPTION
 ## What

  `Integrity::fmt` (the `Display` impl that prints `sha256-<base64>=` style
  hashes for the lockfile) wrapped the base64 output in
  
  The standard base64 encoder (`STANDARD_NO_PAD`) only ever emits bytes from
  the `A-Za-z0-9+/` alphabet, so the unchecked variant was not buying us
  anything — same observable output, just `unsafe` for no reason.

  ## How
  
  Replaced with `from_utf8(...).expect("base64 encoder emits ASCII")`. The
  encoder invariant is now an explicit panic instead of UB if it is ever
  broken (eg. a future encoder swap that emits something exotic). Display
  is a cold path — once per lockfile entry serialization — so the runtime
  check is free in practice.
  
  ## Test plan
  
  - [x] `cargo check -p bun_install`
  - [x] `cargo clippy -p bun_install -- -D warnings`
  - [x] `bun bd --asan=off`
  - [x] no `unsafe` block remains in `Integrity::fmt`