### PR TITLE
Optimize TextEncoder.encode: restore SIMD ASCII fast paths lost in the Rust port

### DIFF
--- a/scripts/verify-baseline-static/allowlist-aarch64.txt
+++ b/scripts/verify-baseline-static/allowlist-aarch64.txt
@@ -5,13 +5,14 @@
 
 # ----------------------------------------------------------------------------
 # Bun's Highway SVE/SVE2 targets. Gate: hwy::SupportedTargets via getauxval(AT_HWCAP).
-# (72 symbols)
+# (76 symbols)
 # ----------------------------------------------------------------------------
 _ZN3bun10N_SVE2_12810MemMemImplEPKhmS2_m                                      [SVE]
 _ZN3bun10N_SVE2_12815CopyU16ToU8ImplEPKtmPh                                   [SVE]
 _ZN3bun10N_SVE2_12815IndexOfCharImplEPKhmh                                    [SVE]
 _ZN3bun10N_SVE2_12818FirstNonAscii8ImplEPKhm                                  [SVE]
 _ZN3bun10N_SVE2_12818IndexOfAnyCharImplEPKhmS2_m                              [SVE]
+_ZN3bun10N_SVE2_12819CopyAsciiPrefixImplEPKhmPh                               [SVE]
 _ZN3bun10N_SVE2_12819FirstNonAscii16ImplEPKtm                                 [SVE]
 _ZN3bun10N_SVE2_12820FillWithSkipMaskImplEPKhmPhS2_mb                         [SVE]
 _ZN3bun10N_SVE2_12821VisibleUTF16WidthImplEPKtmPm                             [SVE]
@@ -30,6 +31,7 @@ _ZN3bun5N_SVE15CopyU16ToU8ImplEPKtmPh                                         [S
 _ZN3bun5N_SVE15IndexOfCharImplEPKhmh                                          [SVE]
 _ZN3bun5N_SVE18FirstNonAscii8ImplEPKhm                                        [SVE]
 _ZN3bun5N_SVE18IndexOfAnyCharImplEPKhmS2_m                                    [SVE]
+_ZN3bun5N_SVE19CopyAsciiPrefixImplEPKhmPh                                     [SVE]
 _ZN3bun5N_SVE19FirstNonAscii16ImplEPKtm                                       [SVE]
 _ZN3bun5N_SVE20FillWithSkipMaskImplEPKhmPhS2_mb                               [SVE]
 _ZN3bun5N_SVE21VisibleUTF16WidthImplEPKtmPm                                   [SVE]
@@ -48,6 +50,7 @@ _ZN3bun6N_SVE215CopyU16ToU8ImplEPKtmPh                                        [S
 _ZN3bun6N_SVE215IndexOfCharImplEPKhmh                                         [SVE]
 _ZN3bun6N_SVE218FirstNonAscii8ImplEPKhm                                       [SVE]
 _ZN3bun6N_SVE218IndexOfAnyCharImplEPKhmS2_m                                   [SVE]
+_ZN3bun6N_SVE219CopyAsciiPrefixImplEPKhmPh                                    [SVE]
 _ZN3bun6N_SVE219FirstNonAscii16ImplEPKtm                                      [SVE]
 _ZN3bun6N_SVE220FillWithSkipMaskImplEPKhmPhS2_mb                              [SVE]
 _ZN3bun6N_SVE221VisibleUTF16WidthImplEPKtmPm                                  [SVE]
@@ -66,6 +69,7 @@ _ZN3bun9N_SVE_25615CopyU16ToU8ImplEPKtmPh                                     [S
 _ZN3bun9N_SVE_25615IndexOfCharImplEPKhmh                                      [SVE]
 _ZN3bun9N_SVE_25618FirstNonAscii8ImplEPKhm                                    [SVE]
 _ZN3bun9N_SVE_25618IndexOfAnyCharImplEPKhmS2_m                                [SVE]
+_ZN3bun9N_SVE_25619CopyAsciiPrefixImplEPKhmPh                                 [SVE]
 _ZN3bun9N_SVE_25619FirstNonAscii16ImplEPKtm                                   [SVE]
 _ZN3bun9N_SVE_25620FillWithSkipMaskImplEPKhmPhS2_mb                           [SVE]
 _ZN3bun9N_SVE_25621VisibleUTF16WidthImplEPKtmPm                               [SVE]

--- a/scripts/verify-baseline-static/allowlist-x64-windows.txt
+++ b/scripts/verify-baseline-static/allowlist-x64-windows.txt
@@ -437,9 +437,10 @@ ctiMasmProbeTrampolineAVX  [AVX]
 
 # ----------------------------------------------------------------------------
 # Highway. MSVC-mangled bun::N_AVX* names.
-# (108 symbols)
+# (114 symbols)
 # ----------------------------------------------------------------------------
 bun::N_AVX10_2::ContainsNewlineOrNonASCIIOrQuoteImpl                 [AVX, AVX512BW, AVX512F]
+bun::N_AVX10_2::CopyAsciiPrefixImpl                                  [AVX, AVX512BW, AVX512F, AVX512VL]
 bun::N_AVX10_2::CopyU16ToU8Impl                                      [AVX, AVX512BW, AVX512F, AVX512VL, AVX512_VBMI]
 bun::N_AVX10_2::CountPrintableAscii16Impl                            [AVX, AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL]
 bun::N_AVX10_2::FillWithSkipMaskImpl                                 [AVX, AVX512DQ, AVX512F]
@@ -458,6 +459,7 @@ bun::N_AVX10_2::VisibleLatin1WidthExcludeANSIImpl                    [AVX, AVX2,
 bun::N_AVX10_2::VisibleLatin1WidthImpl                               [AVX, AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL]
 bun::N_AVX10_2::VisibleUTF16WidthImpl                                [AVX, AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL, BMI1, BMI2]
 bun::N_AVX2::ContainsNewlineOrNonASCIIOrQuoteImpl                    [AVX, AVX2]
+bun::N_AVX2::CopyAsciiPrefixImpl                                     [AVX, AVX2]
 bun::N_AVX2::CopyU16ToU8Impl                                         [AVX, AVX2]
 bun::N_AVX2::CountPrintableAscii16Impl                               [AVX, AVX2]
 bun::N_AVX2::FillWithSkipMaskImpl                                    [AVX]
@@ -476,6 +478,7 @@ bun::N_AVX2::VisibleLatin1WidthExcludeANSIImpl                       [AVX, AVX2,
 bun::N_AVX2::VisibleLatin1WidthImpl                                  [AVX, AVX2]
 bun::N_AVX2::VisibleUTF16WidthImpl                                   [AVX, AVX2, BMI1, BMI2]
 bun::N_AVX3::ContainsNewlineOrNonASCIIOrQuoteImpl                    [AVX, AVX512BW, AVX512F]
+bun::N_AVX3::CopyAsciiPrefixImpl                                     [AVX, AVX512BW, AVX512F]
 bun::N_AVX3::CopyU16ToU8Impl                                         [AVX, AVX512BW, AVX512F, AVX512VL]
 bun::N_AVX3::CountPrintableAscii16Impl                               [AVX, AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL]
 bun::N_AVX3::FillWithSkipMaskImpl                                    [AVX, AVX512DQ, AVX512F]
@@ -494,6 +497,7 @@ bun::N_AVX3::VisibleLatin1WidthExcludeANSIImpl                       [AVX, AVX2,
 bun::N_AVX3::VisibleLatin1WidthImpl                                  [AVX, AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL]
 bun::N_AVX3::VisibleUTF16WidthImpl                                   [AVX, AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL, BMI1, BMI2]
 bun::N_AVX3_DL::ContainsNewlineOrNonASCIIOrQuoteImpl                 [AVX, AVX512BW, AVX512F]
+bun::N_AVX3_DL::CopyAsciiPrefixImpl                                  [AVX, AVX512BW, AVX512F]
 bun::N_AVX3_DL::CopyU16ToU8Impl                                      [AVX, AVX512BW, AVX512F, AVX512VL, AVX512_VBMI]
 bun::N_AVX3_DL::CountPrintableAscii16Impl                            [AVX, AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL]
 bun::N_AVX3_DL::FillWithSkipMaskImpl                                 [AVX, AVX512DQ, AVX512F]
@@ -512,6 +516,7 @@ bun::N_AVX3_DL::VisibleLatin1WidthExcludeANSIImpl                    [AVX, AVX2,
 bun::N_AVX3_DL::VisibleLatin1WidthImpl                               [AVX, AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL]
 bun::N_AVX3_DL::VisibleUTF16WidthImpl                                [AVX, AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL, BMI1, BMI2]
 bun::N_AVX3_SPR::ContainsNewlineOrNonASCIIOrQuoteImpl                [AVX, AVX512BW, AVX512F]
+bun::N_AVX3_SPR::CopyAsciiPrefixImpl                                 [AVX, AVX512BW, AVX512F]
 bun::N_AVX3_SPR::CopyU16ToU8Impl                                     [AVX, AVX512BW, AVX512F, AVX512VL, AVX512_VBMI]
 bun::N_AVX3_SPR::CountPrintableAscii16Impl                           [AVX, AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL]
 bun::N_AVX3_SPR::FillWithSkipMaskImpl                                [AVX, AVX512DQ, AVX512F]
@@ -530,6 +535,7 @@ bun::N_AVX3_SPR::VisibleLatin1WidthExcludeANSIImpl                   [AVX, AVX2,
 bun::N_AVX3_SPR::VisibleLatin1WidthImpl                              [AVX, AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL]
 bun::N_AVX3_SPR::VisibleUTF16WidthImpl                               [AVX, AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL, BMI1, BMI2]
 bun::N_AVX3_ZEN4::ContainsNewlineOrNonASCIIOrQuoteImpl               [AVX, AVX512BW, AVX512F]
+bun::N_AVX3_ZEN4::CopyAsciiPrefixImpl                                [AVX, AVX512BW, AVX512F]
 bun::N_AVX3_ZEN4::CopyU16ToU8Impl                                    [AVX, AVX512BW, AVX512F, AVX512VL, AVX512_VBMI]
 bun::N_AVX3_ZEN4::CountPrintableAscii16Impl                          [AVX, AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL]
 bun::N_AVX3_ZEN4::FillWithSkipMaskImpl                               [AVX, AVX512DQ, AVX512F]

--- a/scripts/verify-baseline-static/allowlist-x64.txt
+++ b/scripts/verify-baseline-static/allowlist-x64.txt
@@ -459,13 +459,14 @@ ctiMasmProbeTrampolineAVX  [AVX]
 
 # ----------------------------------------------------------------------------
 # Bun's Highway SIMD. Gate: HWY_DYNAMIC_DISPATCH via hwy::SupportedTargets.
-# (108 symbols)
+# (114 symbols)
 # ----------------------------------------------------------------------------
 _ZN3bun10N_AVX3_SPR10MemMemImplEPKhmS2_m                                       [AVX, AVX512BW, AVX512F, BMI1]
 _ZN3bun10N_AVX3_SPR15CopyU16ToU8ImplEPKtmPh                                    [AVX, AVX512BW, AVX512F, AVX512VL, AVX512_VBMI]
 _ZN3bun10N_AVX3_SPR15IndexOfCharImplEPKhmh                                     [AVX, AVX512BW, BMI2]
 _ZN3bun10N_AVX3_SPR18FirstNonAscii8ImplEPKhm                                   [AVX, AVX512BW]
 _ZN3bun10N_AVX3_SPR18IndexOfAnyCharImplEPKhmS2_m                               [AVX, AVX512BW, AVX512F, AVX512VL, AVX512_FP16]
+_ZN3bun10N_AVX3_SPR19CopyAsciiPrefixImplEPKhmPh                                [AVX, AVX512BW, AVX512F]
 _ZN3bun10N_AVX3_SPR19FirstNonAscii16ImplEPKtm                                  [AVX, AVX512BW, AVX512F]
 _ZN3bun10N_AVX3_SPR20FillWithSkipMaskImplEPKhmPhS2_mb                          [AVX, AVX512DQ, AVX512F]
 _ZN3bun10N_AVX3_SPR21VisibleUTF16WidthImplEPKtmPm                              [AVX, AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL, BMI1, BMI2]
@@ -484,6 +485,7 @@ _ZN3bun11N_AVX3_ZEN415CopyU16ToU8ImplEPKtmPh                                   [
 _ZN3bun11N_AVX3_ZEN415IndexOfCharImplEPKhmh                                    [AVX, AVX512BW, BMI2]
 _ZN3bun11N_AVX3_ZEN418FirstNonAscii8ImplEPKhm                                  [AVX, AVX512BW]
 _ZN3bun11N_AVX3_ZEN418IndexOfAnyCharImplEPKhmS2_m                              [AVX, AVX512BW, AVX512F, AVX512VL]
+_ZN3bun11N_AVX3_ZEN419CopyAsciiPrefixImplEPKhmPh                               [AVX, AVX512BW, AVX512F]
 _ZN3bun11N_AVX3_ZEN419FirstNonAscii16ImplEPKtm                                 [AVX, AVX512BW, AVX512F]
 _ZN3bun11N_AVX3_ZEN420FillWithSkipMaskImplEPKhmPhS2_mb                         [AVX, AVX512DQ, AVX512F]
 _ZN3bun11N_AVX3_ZEN421VisibleUTF16WidthImplEPKtmPm                             [AVX, AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL, BMI1, BMI2]
@@ -502,6 +504,7 @@ _ZN3bun6N_AVX215CopyU16ToU8ImplEPKtmPh                                         [
 _ZN3bun6N_AVX215IndexOfCharImplEPKhmh                                          [AVX, AVX2]
 _ZN3bun6N_AVX218FirstNonAscii8ImplEPKhm                                        [AVX, AVX2]
 _ZN3bun6N_AVX218IndexOfAnyCharImplEPKhmS2_m                                    [AVX, AVX2]
+_ZN3bun6N_AVX219CopyAsciiPrefixImplEPKhmPh                                     [AVX, AVX2]
 _ZN3bun6N_AVX219FirstNonAscii16ImplEPKtm                                       [AVX, AVX2, BMI2]
 _ZN3bun6N_AVX220FillWithSkipMaskImplEPKhmPhS2_mb                               [AVX]
 _ZN3bun6N_AVX221VisibleUTF16WidthImplEPKtmPm                                   [AVX, AVX2, BMI1, BMI2]
@@ -520,6 +523,7 @@ _ZN3bun6N_AVX315CopyU16ToU8ImplEPKtmPh                                         [
 _ZN3bun6N_AVX315IndexOfCharImplEPKhmh                                          [AVX, AVX512BW, BMI2]
 _ZN3bun6N_AVX318FirstNonAscii8ImplEPKhm                                        [AVX, AVX512BW]
 _ZN3bun6N_AVX318IndexOfAnyCharImplEPKhmS2_m                                    [AVX, AVX512BW, AVX512F, AVX512VL]
+_ZN3bun6N_AVX319CopyAsciiPrefixImplEPKhmPh                                     [AVX, AVX512BW, AVX512F]
 _ZN3bun6N_AVX319FirstNonAscii16ImplEPKtm                                       [AVX, AVX512BW, AVX512F]
 _ZN3bun6N_AVX320FillWithSkipMaskImplEPKhmPhS2_mb                               [AVX, AVX512DQ, AVX512F]
 _ZN3bun6N_AVX321VisibleUTF16WidthImplEPKtmPm                                   [AVX, AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL, BMI1, BMI2]
@@ -538,6 +542,7 @@ _ZN3bun9N_AVX10_215CopyU16ToU8ImplEPKtmPh                                      [
 _ZN3bun9N_AVX10_215IndexOfCharImplEPKhmh                                       [AVX, AVX512BW, BMI2]
 _ZN3bun9N_AVX10_218FirstNonAscii8ImplEPKhm                                     [AVX, AVX512BW]
 _ZN3bun9N_AVX10_218IndexOfAnyCharImplEPKhmS2_m                                 [AVX, AVX512BW, AVX512F, AVX512VL, AVX512_FP16]
+_ZN3bun9N_AVX10_219CopyAsciiPrefixImplEPKhmPh                                  [AVX, AVX512BW, AVX512F, AVX512VL]
 _ZN3bun9N_AVX10_219FirstNonAscii16ImplEPKtm                                    [AVX, AVX512BW, AVX512F]
 _ZN3bun9N_AVX10_220FillWithSkipMaskImplEPKhmPhS2_mb                            [AVX, AVX512DQ, AVX512F]
 _ZN3bun9N_AVX10_221VisibleUTF16WidthImplEPKtmPm                                [AVX, AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL, BMI1, BMI2]
@@ -556,6 +561,7 @@ _ZN3bun9N_AVX3_DL15CopyU16ToU8ImplEPKtmPh                                      [
 _ZN3bun9N_AVX3_DL15IndexOfCharImplEPKhmh                                       [AVX, AVX512BW, BMI2]
 _ZN3bun9N_AVX3_DL18FirstNonAscii8ImplEPKhm                                     [AVX, AVX512BW]
 _ZN3bun9N_AVX3_DL18IndexOfAnyCharImplEPKhmS2_m                                 [AVX, AVX512BW, AVX512F, AVX512VL]
+_ZN3bun9N_AVX3_DL19CopyAsciiPrefixImplEPKhmPh                                  [AVX, AVX512BW, AVX512F]
 _ZN3bun9N_AVX3_DL19FirstNonAscii16ImplEPKtm                                    [AVX, AVX512BW, AVX512F]
 _ZN3bun9N_AVX3_DL20FillWithSkipMaskImplEPKhmPhS2_mb                            [AVX, AVX512DQ, AVX512F]
 _ZN3bun9N_AVX3_DL21VisibleUTF16WidthImplEPKtmPm                                [AVX, AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL, BMI1, BMI2]

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1892,21 +1892,15 @@ pub(crate) mod strings_impl {
         simdutf::length::utf8::from::utf16::le(utf16)
     }
 
-    /// Port of `elementLengthLatin1IntoUTF8`.
+    /// Port of `elementLengthLatin1IntoUTF8` — exact UTF-8 byte length of a
+    /// Latin-1 input (every byte ≥ 0x80 encodes as 2 bytes). simdutf-backed
+    /// like the Zig original; short inputs use a scalar count to skip the FFI
+    /// dispatch (same rationale as `is_all_ascii`).
     pub fn element_length_latin1_into_utf8(latin1: &[u8]) -> usize {
-        let mut len = latin1.len();
-        let mut rest = latin1;
-        while let Some(i) = first_non_ascii(rest) {
-            rest = &rest[i..];
-            while let Some(&c) = rest.first() {
-                if c < 0x80 {
-                    break;
-                }
-                len += 1; // each high-latin1 byte → 2 utf8 bytes
-                rest = &rest[1..];
-            }
+        if latin1.len() <= 32 {
+            return latin1.len() + latin1.iter().filter(|&&c| c >= 0x80).count();
         }
-        len
+        simdutf::length::utf8::from::latin1(latin1)
     }
 
     /// Port of `copyUTF16IntoUTF8` — encode UTF-16 into a fixed-size UTF-8 buffer.
@@ -1916,10 +1910,37 @@ pub(crate) mod strings_impl {
         if utf16.is_empty() || buf.is_empty() {
             return EncodeIntoResult::default();
         }
+        // A UTF-16 code unit expands to at most 3 UTF-8 bytes (a surrogate pair
+        // — two units — becomes four), so a buffer that can hold the worst case
+        // proves the simdutf fast path fits without paying for an exact length
+        // pass first (mirrors the Zig `out_len` selection).
+        let worst_case = utf16.len().saturating_mul(3);
+        let utf8_len = if worst_case <= buf.len() {
+            worst_case
+        } else {
+            simdutf::length::utf8::from::utf16::le(utf16)
+        };
+        copy_utf16_into_utf8_with_utf8_len(buf, utf16, utf8_len)
+    }
+
+    /// [`copy_utf16_into_utf8`] for callers that already know the UTF-8 output
+    /// length — or an upper bound on it — e.g. the exact size from
+    /// [`element_length_utf16_into_utf8`] used to allocate `buf`, so it is not
+    /// recomputed here. `utf8_len` must not understate the real output length:
+    /// the simdutf fast path uses `utf8_len <= buf.len()` as proof that the
+    /// whole conversion fits in `buf` before writing.
+    pub fn copy_utf16_into_utf8_with_utf8_len(
+        buf: &mut [u8],
+        utf16: &[u16],
+        utf8_len: usize,
+    ) -> EncodeIntoResult {
+        debug_assert!(utf8_len >= element_length_utf16_into_utf8(utf16));
+        if utf16.is_empty() || buf.is_empty() {
+            return EncodeIntoResult::default();
+        }
         // Fast path: if buf can definitely hold the whole conversion, try simdutf.
-        let need = simdutf::length::utf8::from::utf16::le(utf16);
-        if need > 0 && need <= buf.len() {
-            // SAFETY: buf has `need` writable bytes; simdutf reads exactly utf16.len() u16.
+        if utf8_len > 0 && utf8_len <= buf.len() {
+            // SAFETY: buf has `utf8_len` writable bytes; simdutf reads exactly utf16.len() u16.
             let r = unsafe {
                 simdutf::simdutf__convert_utf16le_to_utf8_with_errors(
                     utf16.as_ptr(),
@@ -1960,53 +1981,94 @@ pub(crate) mod strings_impl {
         copy_latin1_into_utf8_stop_on_non_ascii::<false>(buf, latin1)
     }
 
-    /// Port of `copyLatin1IntoUTF8StopOnNonASCII`. The Zig original hand-rolled a
-    /// `@Vector(16,u8)` max-reduce + two SWAR `u64` mask/ctz ladders to find each
-    /// non-ASCII byte; in Rust that work is exactly [`first_non_ascii`] (simdutf
-    /// `validate_ascii_with_errors`, with a ≤32B scalar fast path), so the body
-    /// reduces to "scan the next ASCII span, memcpy it, encode one high byte,
-    /// repeat". Speculative 8-byte over-write is dropped (callers only read
-    /// `buf[..written]`).
+    /// Copy the longest all-ASCII prefix of `src` into `dst` (equal lengths) in
+    /// a single fused scan+copy pass. Returns the number of bytes copied — the
+    /// index of the first non-ASCII byte, or the full length when the run is
+    /// pure ASCII. Exactly that many bytes of `dst` are written.
+    ///
+    /// Short runs (rope leaves are often a dozen bytes) use a SWAR `u64` loop
+    /// so they skip the FFI/dynamic-dispatch overhead of the highway kernel;
+    /// longer runs go through `bun_highway::copy_ascii_prefix` (full-width
+    /// vectors, runtime CPU dispatch).
+    #[inline]
+    fn copy_ascii_prefix(dst: &mut [u8], src: &[u8]) -> usize {
+        debug_assert_eq!(dst.len(), src.len());
+
+        // Below ~2 vectors the dispatch shim costs more than it saves.
+        const HIGHWAY_MIN_LEN: usize = 64;
+        if src.len() >= HIGHWAY_MIN_LEN {
+            return bun_highway::copy_ascii_prefix(src, dst);
+        }
+
+        const HIGH_BITS: u64 = 0x8080_8080_8080_8080;
+        let mut copied = 0usize;
+        for (d, s) in dst.chunks_exact_mut(8).zip(src.chunks_exact(8)) {
+            let word = u64::from_ne_bytes(s.try_into().expect("infallible: size matches"));
+            let mask = word & HIGH_BITS;
+            if mask != 0 {
+                // Bun targets little-endian hosts only, so byte `k` occupies
+                // bits `k*8..k*8+8` and `trailing_zeros / 8` is its index.
+                let ascii = (mask.trailing_zeros() / 8) as usize;
+                d[..ascii].copy_from_slice(&s[..ascii]);
+                return copied + ascii;
+            }
+            d.copy_from_slice(&word.to_ne_bytes());
+            copied += 8;
+        }
+        for (d, &s) in dst[copied..].iter_mut().zip(&src[copied..]) {
+            if s >= 0x80 {
+                return copied;
+            }
+            *d = s;
+            copied += 1;
+        }
+        copied
+    }
+
+    /// Port of `copyLatin1IntoUTF8StopOnNonASCII`. Streams Latin-1 into `buf_`
+    /// as UTF-8: ASCII runs are copied with a fused SIMD/SWAR scan+copy
+    /// ([`copy_ascii_prefix`], mirroring the Zig `@Vector(16,u8)` + SWAR
+    /// ladders), and each non-ASCII byte is expanded to its 2-byte UTF-8
+    /// sequence — or, when `STOP` is set, aborts with the `u32::MAX` sentinels
+    /// like the Zig original. Only `buf_[..written]` is written.
     pub fn copy_latin1_into_utf8_stop_on_non_ascii<const STOP: bool>(
         buf_: &mut [u8],
         latin1_: &[u8],
     ) -> EncodeIntoResult {
-        let buf_total = buf_.len();
-        let latin1_total = latin1_.len();
-        let mut buf: &mut [u8] = buf_;
-        let mut latin1: &[u8] = latin1_;
+        let mut written = 0usize;
+        let mut read = 0usize;
 
-        while !buf.is_empty() && !latin1.is_empty() {
-            // Find the longest pure-ASCII prefix that fits in `buf` and copy it
-            // in one shot. simdutf provides the index; the subsequent
-            // `copy_from_slice` is a single memcpy.
-            let limit = buf.len().min(latin1.len());
-            let span = first_non_ascii(&latin1[..limit]).unwrap_or(limit);
-            buf[..span].copy_from_slice(&latin1[..span]);
-            buf = &mut buf[span..];
-            latin1 = &latin1[span..];
-
-            // Either we filled `buf`, drained `latin1`, or hit a non-ASCII byte.
-            if latin1.is_empty() || latin1[0] < 0x80 {
+        while written < buf_.len() && read < latin1_.len() {
+            let n = (buf_.len() - written).min(latin1_.len() - read);
+            let copied =
+                copy_ascii_prefix(&mut buf_[written..written + n], &latin1_[read..read + n]);
+            written += copied;
+            read += copied;
+            if copied == n {
+                // Filled `buf_` or drained `latin1_`.
                 break;
             }
+
+            // `latin1_[read]` is non-ASCII.
+            debug_assert!(latin1_[read] >= 0x80);
             if STOP {
                 return EncodeIntoResult {
                     written: u32::MAX,
                     read: u32::MAX,
                 };
             }
-            if buf.len() < 2 {
+            if buf_.len() - written < 2 {
                 break;
             }
-            buf[..2].copy_from_slice(&latin1_to_codepoint_bytes_assume_not_ascii(latin1[0]));
-            latin1 = &latin1[1..];
-            buf = &mut buf[2..];
+            buf_[written..written + 2]
+                .copy_from_slice(&latin1_to_codepoint_bytes_assume_not_ascii(latin1_[read]));
+            written += 2;
+            read += 1;
         }
 
         EncodeIntoResult {
-            written: (buf_total - buf.len()) as u32,
-            read: (latin1_total - latin1.len()) as u32,
+            written: written as u32,
+            read: read as u32,
         }
     }
 

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1892,10 +1892,7 @@ pub(crate) mod strings_impl {
         simdutf::length::utf8::from::utf16::le(utf16)
     }
 
-    /// Port of `elementLengthLatin1IntoUTF8` — exact UTF-8 byte length of a
-    /// Latin-1 input (every byte ≥ 0x80 encodes as 2 bytes). simdutf-backed
-    /// like the Zig original; short inputs use a scalar count to skip the FFI
-    /// dispatch (same rationale as `is_all_ascii`).
+    /// Port of `elementLengthLatin1IntoUTF8`.
     pub fn element_length_latin1_into_utf8(latin1: &[u8]) -> usize {
         if latin1.len() <= 32 {
             return latin1.len() + latin1.iter().filter(|&&c| c >= 0x80).count();
@@ -1910,10 +1907,6 @@ pub(crate) mod strings_impl {
         if utf16.is_empty() || buf.is_empty() {
             return EncodeIntoResult::default();
         }
-        // A UTF-16 code unit expands to at most 3 UTF-8 bytes (a surrogate pair
-        // — two units — becomes four), so a buffer that can hold the worst case
-        // proves the simdutf fast path fits without paying for an exact length
-        // pass first (mirrors the Zig `out_len` selection).
         let worst_case = utf16.len().saturating_mul(3);
         let utf8_len = if worst_case <= buf.len() {
             worst_case
@@ -1923,12 +1916,6 @@ pub(crate) mod strings_impl {
         copy_utf16_into_utf8_with_utf8_len(buf, utf16, utf8_len)
     }
 
-    /// [`copy_utf16_into_utf8`] for callers that already know the UTF-8 output
-    /// length — or an upper bound on it — e.g. the exact size from
-    /// [`element_length_utf16_into_utf8`] used to allocate `buf`, so it is not
-    /// recomputed here. `utf8_len` must not understate the real output length:
-    /// the simdutf fast path uses `utf8_len <= buf.len()` as proof that the
-    /// whole conversion fits in `buf` before writing.
     pub fn copy_utf16_into_utf8_with_utf8_len(
         buf: &mut [u8],
         utf16: &[u16],
@@ -1981,20 +1968,10 @@ pub(crate) mod strings_impl {
         copy_latin1_into_utf8_stop_on_non_ascii::<false>(buf, latin1)
     }
 
-    /// Copy the longest all-ASCII prefix of `src` into `dst` (equal lengths) in
-    /// a single fused scan+copy pass. Returns the number of bytes copied — the
-    /// index of the first non-ASCII byte, or the full length when the run is
-    /// pure ASCII. Exactly that many bytes of `dst` are written.
-    ///
-    /// Short runs (rope leaves are often a dozen bytes) use a SWAR `u64` loop
-    /// so they skip the FFI/dynamic-dispatch overhead of the highway kernel;
-    /// longer runs go through `bun_highway::copy_ascii_prefix` (full-width
-    /// vectors, runtime CPU dispatch).
     #[inline]
     fn copy_ascii_prefix(dst: &mut [u8], src: &[u8]) -> usize {
         debug_assert_eq!(dst.len(), src.len());
 
-        // Below ~2 vectors the dispatch shim costs more than it saves.
         const HIGHWAY_MIN_LEN: usize = 64;
         if src.len() >= HIGHWAY_MIN_LEN {
             return bun_highway::copy_ascii_prefix(src, dst);
@@ -2006,8 +1983,6 @@ pub(crate) mod strings_impl {
             let word = u64::from_ne_bytes(s.try_into().expect("infallible: size matches"));
             let mask = word & HIGH_BITS;
             if mask != 0 {
-                // Bun targets little-endian hosts only, so byte `k` occupies
-                // bits `k*8..k*8+8` and `trailing_zeros / 8` is its index.
                 let ascii = (mask.trailing_zeros() / 8) as usize;
                 d[..ascii].copy_from_slice(&s[..ascii]);
                 return copied + ascii;
@@ -2025,12 +2000,7 @@ pub(crate) mod strings_impl {
         copied
     }
 
-    /// Port of `copyLatin1IntoUTF8StopOnNonASCII`. Streams Latin-1 into `buf_`
-    /// as UTF-8: ASCII runs are copied with a fused SIMD/SWAR scan+copy
-    /// ([`copy_ascii_prefix`], mirroring the Zig `@Vector(16,u8)` + SWAR
-    /// ladders), and each non-ASCII byte is expanded to its 2-byte UTF-8
-    /// sequence — or, when `STOP` is set, aborts with the `u32::MAX` sentinels
-    /// like the Zig original. Only `buf_[..written]` is written.
+    /// Port of `copyLatin1IntoUTF8StopOnNonASCII`.
     pub fn copy_latin1_into_utf8_stop_on_non_ascii<const STOP: bool>(
         buf_: &mut [u8],
         latin1_: &[u8],
@@ -2045,11 +2015,9 @@ pub(crate) mod strings_impl {
             written += copied;
             read += copied;
             if copied == n {
-                // Filled `buf_` or drained `latin1_`.
                 break;
             }
 
-            // `latin1_[read]` is non-ASCII.
             debug_assert!(latin1_[read] >= 0x80);
             if STOP {
                 return EncodeIntoResult {

--- a/src/highway/lib.rs
+++ b/src/highway/lib.rs
@@ -49,6 +49,8 @@ unsafe extern "C" {
     );
 
     fn highway_copy_u16_to_u8(input: *const u16, count: usize, output: *mut u8);
+
+    fn highway_copy_ascii_prefix(src: *const u8, len: usize, dst: *mut u8) -> usize;
 }
 
 // NOTE: every public wrapper below is `#[inline(always)]`. They are thin
@@ -237,6 +239,27 @@ pub fn copy_u16_to_u8(input: &[u16], output: &mut [u8]) {
     // SAFETY: input.ptr/len readable, output.ptr writable for at least input.len() bytes
     // (caller contract matches Zig: output.len >= input.len()).
     unsafe { highway_copy_u16_to_u8(input.as_ptr(), input.len(), output.as_mut_ptr()) }
+}
+
+/// Copy the leading all-ASCII run of `src` into `dst` in a single fused
+/// scan+copy pass, stopping at the first byte `>= 0x80`. Only the common
+/// prefix `min(src.len(), dst.len())` is considered. Returns the number of
+/// bytes copied — exactly that many bytes of `dst` are written.
+#[inline(always)]
+pub fn copy_ascii_prefix(src: &[u8], dst: &mut [u8]) -> usize {
+    let len = src.len().min(dst.len());
+    if len == 0 {
+        return 0;
+    }
+
+    // SAFETY: `src` is readable and `dst` writable for at least `len` bytes;
+    // the kernel reads and writes at most `len` bytes of each.
+    let copied = unsafe { highway_copy_ascii_prefix(src.as_ptr(), len, dst.as_mut_ptr()) };
+
+    debug_assert!(copied <= len);
+    debug_assert!(copied == len || src[copied] >= 0x80);
+
+    copied
 }
 
 /// Apply a WebSocket mask to data using SIMD acceleration

--- a/src/highway/lib.rs
+++ b/src/highway/lib.rs
@@ -241,10 +241,6 @@ pub fn copy_u16_to_u8(input: &[u16], output: &mut [u8]) {
     unsafe { highway_copy_u16_to_u8(input.as_ptr(), input.len(), output.as_mut_ptr()) }
 }
 
-/// Copy the leading all-ASCII run of `src` into `dst` in a single fused
-/// scan+copy pass, stopping at the first byte `>= 0x80`. Only the common
-/// prefix `min(src.len(), dst.len())` is considered. Returns the number of
-/// bytes copied — exactly that many bytes of `dst` are written.
 #[inline(always)]
 pub fn copy_ascii_prefix(src: &[u8], dst: &mut [u8]) -> usize {
     let len = src.len().min(dst.len());

--- a/src/jsc/bindings/highway_strings.cpp
+++ b/src/jsc/bindings/highway_strings.cpp
@@ -1140,12 +1140,6 @@ size_t FirstNonAscii8Impl(const uint8_t* HWY_RESTRICT input, size_t len)
     return len;
 }
 
-// Copy the leading all-ASCII run of `src` into `dst`, stopping at the first
-// byte greater than 0x7F. Returns the number of bytes copied (== the index of
-// the first non-ASCII byte, or `len` when the whole input is ASCII). Exactly
-// that many bytes of `dst` are written. This fuses the "find first non-ASCII"
-// scan with the copy so the Latin-1 → UTF-8 ASCII fast path (TextEncoder,
-// copyLatin1IntoUTF8) reads the input once instead of scan-then-memcpy.
 size_t CopyAsciiPrefixImpl(const uint8_t* HWY_RESTRICT src, size_t len, uint8_t* HWY_RESTRICT dst)
 {
     D8 d;
@@ -1161,7 +1155,6 @@ size_t CopyAsciiPrefixImpl(const uint8_t* HWY_RESTRICT src, size_t len, uint8_t*
             const auto non_ascii = hn::Gt(chunk, vec_0x7F);
             const intptr_t pos = hn::FindFirstTrue(d, non_ascii);
             if (pos >= 0) {
-                // Copy only the ASCII prefix of this vector.
                 if (pos > 0) {
                     std::memcpy(dst + i, src + i, static_cast<size_t>(pos));
                 }
@@ -1170,9 +1163,6 @@ size_t CopyAsciiPrefixImpl(const uint8_t* HWY_RESTRICT src, size_t len, uint8_t*
             hn::StoreU(chunk, d, dst + i);
         }
 
-        // Tail: one overlapping vector covering the last N bytes. The overlap
-        // [len - N, i) was already copied and verified ASCII, so re-storing it
-        // is harmless and nothing is written past `dst + len`.
         if (i < len) {
             const size_t start = len - N;
             const auto chunk = hn::LoadU(d, src + start);
@@ -1182,8 +1172,6 @@ size_t CopyAsciiPrefixImpl(const uint8_t* HWY_RESTRICT src, size_t len, uint8_t*
                 hn::StoreU(chunk, d, dst + start);
                 return len;
             }
-            // The first non-ASCII byte is at or after `i` (everything before
-            // `i` was verified ASCII above).
             const size_t stop = start + static_cast<size_t>(pos);
             if (stop > i) {
                 std::memcpy(dst + i, src + i, stop - i);

--- a/src/jsc/bindings/highway_strings.cpp
+++ b/src/jsc/bindings/highway_strings.cpp
@@ -1140,6 +1140,69 @@ size_t FirstNonAscii8Impl(const uint8_t* HWY_RESTRICT input, size_t len)
     return len;
 }
 
+// Copy the leading all-ASCII run of `src` into `dst`, stopping at the first
+// byte greater than 0x7F. Returns the number of bytes copied (== the index of
+// the first non-ASCII byte, or `len` when the whole input is ASCII). Exactly
+// that many bytes of `dst` are written. This fuses the "find first non-ASCII"
+// scan with the copy so the Latin-1 → UTF-8 ASCII fast path (TextEncoder,
+// copyLatin1IntoUTF8) reads the input once instead of scan-then-memcpy.
+size_t CopyAsciiPrefixImpl(const uint8_t* HWY_RESTRICT src, size_t len, uint8_t* HWY_RESTRICT dst)
+{
+    D8 d;
+    const size_t N = hn::Lanes(d);
+
+    const auto vec_0x7F = hn::Set(d, uint8_t { 0x7F });
+
+    size_t i = 0;
+    if (len >= N) {
+        const size_t simd_len = len - (len % N);
+        for (; i < simd_len; i += N) {
+            const auto chunk = hn::LoadU(d, src + i);
+            const auto non_ascii = hn::Gt(chunk, vec_0x7F);
+            const intptr_t pos = hn::FindFirstTrue(d, non_ascii);
+            if (pos >= 0) {
+                // Copy only the ASCII prefix of this vector.
+                if (pos > 0) {
+                    std::memcpy(dst + i, src + i, static_cast<size_t>(pos));
+                }
+                return i + static_cast<size_t>(pos);
+            }
+            hn::StoreU(chunk, d, dst + i);
+        }
+
+        // Tail: one overlapping vector covering the last N bytes. The overlap
+        // [len - N, i) was already copied and verified ASCII, so re-storing it
+        // is harmless and nothing is written past `dst + len`.
+        if (i < len) {
+            const size_t start = len - N;
+            const auto chunk = hn::LoadU(d, src + start);
+            const auto non_ascii = hn::Gt(chunk, vec_0x7F);
+            const intptr_t pos = hn::FindFirstTrue(d, non_ascii);
+            if (pos < 0) {
+                hn::StoreU(chunk, d, dst + start);
+                return len;
+            }
+            // The first non-ASCII byte is at or after `i` (everything before
+            // `i` was verified ASCII above).
+            const size_t stop = start + static_cast<size_t>(pos);
+            if (stop > i) {
+                std::memcpy(dst + i, src + i, stop - i);
+            }
+            return stop;
+        }
+        return len;
+    }
+
+    for (; i < len; ++i) {
+        const uint8_t c = src[i];
+        if (c > 0x7F) {
+            return i;
+        }
+        dst[i] = c;
+    }
+    return len;
+}
+
 // Implementation for WebSocket mask application
 void FillWithSkipMaskImpl(const uint8_t* HWY_RESTRICT mask, size_t mask_len, uint8_t* HWY_RESTRICT output, const uint8_t* HWY_RESTRICT input, size_t length, bool skip_mask)
 {
@@ -1197,6 +1260,7 @@ namespace bun {
 // Define the dispatch tables. The names here must exactly match
 // the *Impl function names defined within the HWY_NAMESPACE block above.
 HWY_EXPORT(ContainsNewlineOrNonASCIIOrQuoteImpl);
+HWY_EXPORT(CopyAsciiPrefixImpl);
 HWY_EXPORT(CopyU16ToU8Impl);
 HWY_EXPORT(CountPrintableAscii16Impl);
 HWY_EXPORT(FillWithSkipMaskImpl);
@@ -1353,6 +1417,11 @@ size_t highway_first_non_ascii16(const uint16_t* HWY_RESTRICT input, size_t len)
 size_t highway_first_non_ascii8(const uint8_t* HWY_RESTRICT input, size_t len)
 {
     return HWY_DYNAMIC_DISPATCH(FirstNonAscii8Impl)(input, len);
+}
+
+size_t highway_copy_ascii_prefix(const uint8_t* HWY_RESTRICT src, size_t len, uint8_t* HWY_RESTRICT dst)
+{
+    return HWY_DYNAMIC_DISPATCH(CopyAsciiPrefixImpl)(src, len, dst);
 }
 
 } // extern "C"

--- a/src/runtime/webcore/TextEncoder.rs
+++ b/src/runtime/webcore/TextEncoder.rs
@@ -19,43 +19,113 @@ pub(crate) unsafe extern "C" fn TextEncoder__encode8(
     ptr: *const u8,
     len: usize,
 ) -> JSValue {
-    // as much as possible, rely on jsc to own the memory
-    // their code is more battle-tested than bun's code
-    // so we do a stack allocation here
-    // and then copy into jsc memory
-    // unless it's huge
-    // JSC will GC Uint8Array that occupy less than 512 bytes
-    // so it's extra good for that case
-    // this also means there won't be reallocations for small strings
-    let mut buf = [0u8; 2048];
     // SAFETY: caller guarantees ptr[0..len] is valid Latin-1 data
     let slice = unsafe { core::slice::from_raw_parts(ptr, len) };
 
-    if slice.len() <= buf.len() / 2 {
-        let result = strings::copy_latin1_into_utf8(&mut buf, slice);
-        let Ok(uint8array) = create_uninitialized_uint8_array(global_this, result.written as usize)
-        else {
+    // Encode straight into a JSC-owned Uint8Array sized exactly for the input:
+    // no intermediate stack/heap buffer and no second copy. JSC owning the
+    // memory keeps small arrays cheap for the GC and avoids external-buffer
+    // bookkeeping for large ones.
+    if strings::first_non_ascii(slice).is_none() {
+        // ASCII fast path: the UTF-8 output is byte-for-byte the input.
+        let Ok(uint8array) = create_uninitialized_uint8_array(global_this, slice.len()) else {
             return JSValue::ZERO;
         };
-        debug_assert!(result.written as usize <= buf.len());
-        debug_assert!(result.read as usize == slice.len());
         let Some(mut array_buffer) = uint8array.as_array_buffer(global_this) else {
             return JSValue::ZERO;
         };
-        debug_assert!(result.written as usize == array_buffer.len);
-        array_buffer.byte_slice_mut()[..result.written as usize]
-            .copy_from_slice(&buf[..result.written as usize]);
-        uint8array
-    } else {
-        let Ok(bytes) = strings::allocate_latin1_into_utf8(slice) else {
-            return global_this.throw_out_of_memory_value();
-        };
-        debug_assert!(bytes.len() >= slice.len());
-        // PORT NOTE: ownership transfers to JSC via to_js_unchecked; leak the Vec.
-        ArrayBuffer::from_bytes(bytes.leak(), JSType::Uint8Array)
-            .to_js_unchecked(global_this)
-            .unwrap_or(JSValue::ZERO)
+        debug_assert!(array_buffer.len == slice.len());
+        array_buffer.byte_slice_mut().copy_from_slice(slice);
+        return uint8array;
     }
+
+    // Latin-1 bytes ≥ 0x80 expand to two UTF-8 bytes: size the array exactly
+    // and convert directly into it.
+    let utf8_len = strings::element_length_latin1_into_utf8(slice);
+    let Ok(uint8array) = create_uninitialized_uint8_array(global_this, utf8_len) else {
+        return JSValue::ZERO;
+    };
+    let Some(mut array_buffer) = uint8array.as_array_buffer(global_this) else {
+        return JSValue::ZERO;
+    };
+    debug_assert!(array_buffer.len == utf8_len);
+    let result = strings::copy_latin1_into_utf8(array_buffer.byte_slice_mut(), slice);
+    debug_assert!(result.written as usize == utf8_len);
+    debug_assert!(result.read as usize == slice.len());
+    uint8array
+}
+
+fn replacement_char_uint8_array(global_this: &JSGlobalObject) -> JSValue {
+    let Ok(uint8array) = create_uninitialized_uint8_array(global_this, 3) else {
+        return JSValue::ZERO;
+    };
+    let Some(mut array_buffer) = uint8array.as_array_buffer(global_this) else {
+        return JSValue::ZERO;
+    };
+    const REPLACEMENT_CHAR: [u8; 3] = [239, 191, 189];
+    array_buffer.byte_slice_mut()[..REPLACEMENT_CHAR.len()].copy_from_slice(&REPLACEMENT_CHAR);
+    uint8array
+}
+
+fn encode16_impl(global_this: &JSGlobalObject, slice: &[u16]) -> JSValue {
+    // Small strings: convert into a stack buffer sized for the worst case
+    // (3 bytes per code unit), which lets copy_utf16_into_utf8 go straight to
+    // the simdutf conversion without an exact length pass, then copy the
+    // written bytes into a JSC-owned Uint8Array.
+    const SMALL_BUF_LEN: usize = 192;
+    if slice.len() <= SMALL_BUF_LEN / 3 {
+        let mut buf = [0u8; SMALL_BUF_LEN];
+        let result = strings::copy_utf16_into_utf8(&mut buf, slice);
+        if result.read == 0 || result.written == 0 {
+            return replacement_char_uint8_array(global_this);
+        }
+        let written = result.written as usize;
+        debug_assert!(result.read as usize == slice.len());
+        let Ok(uint8array) = create_uninitialized_uint8_array(global_this, written) else {
+            return JSValue::ZERO;
+        };
+        let Some(mut array_buffer) = uint8array.as_array_buffer(global_this) else {
+            return JSValue::ZERO;
+        };
+        debug_assert!(array_buffer.len == written);
+        array_buffer.byte_slice_mut().copy_from_slice(&buf[..written]);
+        return uint8array;
+    }
+
+    // Exact UTF-8 size of the input (valid surrogate pairs count as 4 bytes,
+    // everything else 1–3 bytes per code unit).
+    let need = strings::element_length_utf16_into_utf8(slice);
+
+    if need == 0 {
+        // Nothing to encode: preserve the historical behavior of returning a
+        // single U+FFFD replacement character.
+        return replacement_char_uint8_array(global_this);
+    }
+
+    // Encode straight into a JSC-owned Uint8Array of exactly `need` bytes —
+    // no intermediate heap buffer and no second copy.
+    let Ok(uint8array) = create_uninitialized_uint8_array(global_this, need) else {
+        return JSValue::ZERO;
+    };
+    let Some(mut array_buffer) = uint8array.as_array_buffer(global_this) else {
+        return JSValue::ZERO;
+    };
+    debug_assert!(array_buffer.len == need);
+    let result =
+        strings::copy_utf16_into_utf8_with_utf8_len(array_buffer.byte_slice_mut(), slice, need);
+    if result.written as usize == need && result.read as usize == slice.len() {
+        return uint8array;
+    }
+
+    // Unpaired surrogates: the U+FFFD-replaced output does not necessarily fit
+    // the exact-size buffer above, so redo the conversion through the
+    // allocating path (which replaces each unpaired surrogate with U+FFFD) and
+    // hand those bytes to JSC. The array allocated above is discarded.
+    let bytes = strings::to_utf8_alloc_with_type(slice);
+    // PORT NOTE: ownership transfers to JSC via to_js_unchecked; leak the Vec.
+    ArrayBuffer::from_bytes(bytes.leak(), JSType::Uint8Array)
+        .to_js_unchecked(global_this)
+        .unwrap_or(JSValue::ZERO)
 }
 
 /// # Safety
@@ -66,49 +136,9 @@ pub(crate) unsafe extern "C" fn TextEncoder__encode16(
     ptr: *const u16,
     len: usize,
 ) -> JSValue {
-    // as much as possible, rely on jsc to own the memory
-    // their code is more battle-tested than bun's code
-    // so we do a stack allocation here
-    // and then copy into jsc memory
-    // unless it's huge
-    // JSC will GC Uint8Array that occupy less than 512 bytes
-    // so it's extra good for that case
-    // this also means there won't be reallocations for small strings
-    let mut buf = [0u8; 2048];
-
     // SAFETY: caller guarantees ptr[0..len] is valid UTF-16 data
     let slice = unsafe { core::slice::from_raw_parts(ptr, len) };
-
-    // max utf16 -> utf8 length
-    if slice.len() <= buf.len() / 4 {
-        let result = strings::copy_utf16_into_utf8(&mut buf, slice);
-        if result.read == 0 || result.written == 0 {
-            let Ok(uint8array) = create_uninitialized_uint8_array(global_this, 3) else {
-                return JSValue::ZERO;
-            };
-            let mut array_buffer = uint8array.as_array_buffer(global_this).unwrap();
-            const REPLACEMENT_CHAR: [u8; 3] = [239, 191, 189];
-            array_buffer.slice_mut()[..REPLACEMENT_CHAR.len()].copy_from_slice(&REPLACEMENT_CHAR);
-            return uint8array;
-        }
-        let Ok(uint8array) = create_uninitialized_uint8_array(global_this, result.written as usize)
-        else {
-            return JSValue::ZERO;
-        };
-        debug_assert!(result.written as usize <= buf.len());
-        debug_assert!(result.read as usize == slice.len());
-        let mut array_buffer = uint8array.as_array_buffer(global_this).unwrap();
-        debug_assert!(result.written as usize == array_buffer.len);
-        array_buffer.slice_mut()[..result.written as usize]
-            .copy_from_slice(&buf[..result.written as usize]);
-        uint8array
-    } else {
-        let bytes = strings::to_utf8_alloc_with_type(slice);
-        // PORT NOTE: ownership transfers to JSC via to_js_unchecked; leak the Vec.
-        ArrayBuffer::from_bytes(bytes.leak(), JSType::Uint8Array)
-            .to_js_unchecked(global_this)
-            .unwrap_or(JSValue::ZERO)
-    }
+    encode16_impl(global_this, slice)
 }
 
 /// # Safety
@@ -119,49 +149,9 @@ pub(crate) unsafe extern "C" fn c(
     ptr: *const u16,
     len: usize,
 ) -> JSValue {
-    // as much as possible, rely on jsc to own the memory
-    // their code is more battle-tested than bun's code
-    // so we do a stack allocation here
-    // and then copy into jsc memory
-    // unless it's huge
-    // JSC will GC Uint8Array that occupy less than 512 bytes
-    // so it's extra good for that case
-    // this also means there won't be reallocations for small strings
-    let mut buf = [0u8; 2048];
-
     // SAFETY: caller guarantees ptr[0..len] is valid UTF-16 data
     let slice = unsafe { core::slice::from_raw_parts(ptr, len) };
-
-    // max utf16 -> utf8 length
-    if slice.len() <= buf.len() / 4 {
-        let result = strings::copy_utf16_into_utf8(&mut buf, slice);
-        if result.read == 0 || result.written == 0 {
-            let Ok(uint8array) = create_uninitialized_uint8_array(global_this, 3) else {
-                return JSValue::ZERO;
-            };
-            let mut array_buffer = uint8array.as_array_buffer(global_this).unwrap();
-            const REPLACEMENT_CHAR: [u8; 3] = [239, 191, 189];
-            array_buffer.slice_mut()[..REPLACEMENT_CHAR.len()].copy_from_slice(&REPLACEMENT_CHAR);
-            return uint8array;
-        }
-        let Ok(uint8array) = create_uninitialized_uint8_array(global_this, result.written as usize)
-        else {
-            return JSValue::ZERO;
-        };
-        debug_assert!(result.written as usize <= buf.len());
-        debug_assert!(result.read as usize == slice.len());
-        let mut array_buffer = uint8array.as_array_buffer(global_this).unwrap();
-        debug_assert!(result.written as usize == array_buffer.len);
-        array_buffer.slice_mut()[..result.written as usize]
-            .copy_from_slice(&buf[..result.written as usize]);
-        uint8array
-    } else {
-        let bytes = strings::to_utf8_alloc_with_type(slice);
-        // PORT NOTE: ownership transfers to JSC via to_js_unchecked; leak the Vec.
-        ArrayBuffer::from_bytes(bytes.leak(), JSType::Uint8Array)
-            .to_js_unchecked(global_this)
-            .unwrap_or(JSValue::ZERO)
-    }
+    encode16_impl(global_this, slice)
 }
 
 // This is a fast path for copying a Rope string into a Uint8Array.
@@ -270,24 +260,22 @@ pub(crate) extern "C" fn TextEncoder__encodeRopeString(
     rope_str: &JSString,
 ) -> JSValue {
     debug_assert!(rope_str.is_8bit());
-    let mut stack_buf = [0u8; 2048];
-    let stack_buf_len = stack_buf.len();
-    let mut buf_to_use: &mut [u8] = &mut stack_buf;
+    // The rope is ASCII-only on this fast path, so the UTF-8 byte length equals
+    // the string length: allocate the JSC-owned Uint8Array up front and let the
+    // rope iterator write each segment directly into it (no stack buffer, no
+    // second copy). If a non-ASCII byte shows up we bail with `undefined` and
+    // the caller re-encodes through the resolved-string path.
     let length = rope_str.length();
-    let mut array: JSValue = JSValue::ZERO;
-    // PORT NOTE: store the ArrayBuffer view so the borrowed slice outlives the if-branch.
-    let mut heap_ab: ArrayBuffer;
-    if length > stack_buf_len / 2 {
-        array = match create_uninitialized_uint8_array(global_this, length) {
-            Ok(v) => v,
-            Err(_) => return JSValue::ZERO,
-        };
-        array.ensure_still_alive();
-        heap_ab = array.as_array_buffer(global_this).unwrap();
-        buf_to_use = heap_ab.slice_mut();
-    }
+    let array = match create_uninitialized_uint8_array(global_this, length) {
+        Ok(v) => v,
+        Err(_) => return JSValue::ZERO,
+    };
+    array.ensure_still_alive();
+    let Some(mut array_buffer) = array.as_array_buffer(global_this) else {
+        return JSValue::ZERO;
+    };
     let mut encoder = RopeStringEncoder {
-        buf: buf_to_use,
+        buf: array_buffer.byte_slice_mut(),
         tail: 0,
         any_non_ascii: false,
     };
@@ -298,20 +286,6 @@ pub(crate) extern "C" fn TextEncoder__encodeRopeString(
 
     if encoder.any_non_ascii {
         return JSValue::UNDEFINED;
-    }
-
-    if array.is_empty() {
-        array = match create_uninitialized_uint8_array(global_this, length) {
-            Ok(v) => v,
-            Err(_) => return JSValue::ZERO,
-        };
-        array.ensure_still_alive();
-        // PORT NOTE: reshaped for borrowck — encoder.buf aliases stack_buf here
-        array
-            .as_array_buffer(global_this)
-            .unwrap()
-            .byte_slice_mut()
-            .copy_from_slice(&encoder.buf[..length]);
     }
 
     array

--- a/src/runtime/webcore/TextEncoder.rs
+++ b/src/runtime/webcore/TextEncoder.rs
@@ -88,7 +88,9 @@ fn encode16_impl(global_this: &JSGlobalObject, slice: &[u16]) -> JSValue {
             return JSValue::ZERO;
         };
         debug_assert!(array_buffer.len == written);
-        array_buffer.byte_slice_mut().copy_from_slice(&buf[..written]);
+        array_buffer
+            .byte_slice_mut()
+            .copy_from_slice(&buf[..written]);
         return uint8array;
     }
 

--- a/src/runtime/webcore/TextEncoder.rs
+++ b/src/runtime/webcore/TextEncoder.rs
@@ -22,12 +22,7 @@ pub(crate) unsafe extern "C" fn TextEncoder__encode8(
     // SAFETY: caller guarantees ptr[0..len] is valid Latin-1 data
     let slice = unsafe { core::slice::from_raw_parts(ptr, len) };
 
-    // Encode straight into a JSC-owned Uint8Array sized exactly for the input:
-    // no intermediate stack/heap buffer and no second copy. JSC owning the
-    // memory keeps small arrays cheap for the GC and avoids external-buffer
-    // bookkeeping for large ones.
     if strings::first_non_ascii(slice).is_none() {
-        // ASCII fast path: the UTF-8 output is byte-for-byte the input.
         let Ok(uint8array) = create_uninitialized_uint8_array(global_this, slice.len()) else {
             return JSValue::ZERO;
         };
@@ -39,8 +34,6 @@ pub(crate) unsafe extern "C" fn TextEncoder__encode8(
         return uint8array;
     }
 
-    // Latin-1 bytes ≥ 0x80 expand to two UTF-8 bytes: size the array exactly
-    // and convert directly into it.
     let utf8_len = strings::element_length_latin1_into_utf8(slice);
     let Ok(uint8array) = create_uninitialized_uint8_array(global_this, utf8_len) else {
         return JSValue::ZERO;
@@ -68,10 +61,6 @@ fn replacement_char_uint8_array(global_this: &JSGlobalObject) -> JSValue {
 }
 
 fn encode16_impl(global_this: &JSGlobalObject, slice: &[u16]) -> JSValue {
-    // Small strings: convert into a stack buffer sized for the worst case
-    // (3 bytes per code unit), which lets copy_utf16_into_utf8 go straight to
-    // the simdutf conversion without an exact length pass, then copy the
-    // written bytes into a JSC-owned Uint8Array.
     const SMALL_BUF_LEN: usize = 192;
     if slice.len() <= SMALL_BUF_LEN / 3 {
         let mut buf = [0u8; SMALL_BUF_LEN];
@@ -94,18 +83,12 @@ fn encode16_impl(global_this: &JSGlobalObject, slice: &[u16]) -> JSValue {
         return uint8array;
     }
 
-    // Exact UTF-8 size of the input (valid surrogate pairs count as 4 bytes,
-    // everything else 1–3 bytes per code unit).
     let need = strings::element_length_utf16_into_utf8(slice);
 
     if need == 0 {
-        // Nothing to encode: preserve the historical behavior of returning a
-        // single U+FFFD replacement character.
         return replacement_char_uint8_array(global_this);
     }
 
-    // Encode straight into a JSC-owned Uint8Array of exactly `need` bytes —
-    // no intermediate heap buffer and no second copy.
     let Ok(uint8array) = create_uninitialized_uint8_array(global_this, need) else {
         return JSValue::ZERO;
     };
@@ -119,12 +102,7 @@ fn encode16_impl(global_this: &JSGlobalObject, slice: &[u16]) -> JSValue {
         return uint8array;
     }
 
-    // Unpaired surrogates: the U+FFFD-replaced output does not necessarily fit
-    // the exact-size buffer above, so redo the conversion through the
-    // allocating path (which replaces each unpaired surrogate with U+FFFD) and
-    // hand those bytes to JSC. The array allocated above is discarded.
     let bytes = strings::to_utf8_alloc_with_type(slice);
-    // PORT NOTE: ownership transfers to JSC via to_js_unchecked; leak the Vec.
     ArrayBuffer::from_bytes(bytes.leak(), JSType::Uint8Array)
         .to_js_unchecked(global_this)
         .unwrap_or(JSValue::ZERO)
@@ -262,11 +240,6 @@ pub(crate) extern "C" fn TextEncoder__encodeRopeString(
     rope_str: &JSString,
 ) -> JSValue {
     debug_assert!(rope_str.is_8bit());
-    // The rope is ASCII-only on this fast path, so the UTF-8 byte length equals
-    // the string length: allocate the JSC-owned Uint8Array up front and let the
-    // rope iterator write each segment directly into it (no stack buffer, no
-    // second copy). If a non-ASCII byte shows up we bail with `undefined` and
-    // the caller re-encodes through the resolved-string path.
     let length = rope_str.length();
     let array = match create_uninitialized_uint8_array(global_this, length) {
         Ok(v) => v,

--- a/test/js/web/encoding/text-encoder.test.js
+++ b/test/js/web/encoding/text-encoder.test.js
@@ -493,3 +493,180 @@ describe("TextEncoder", () => {
     expect(new TextDecoder().decode(encoder.encode(text))).toBe(textReal);
   });
 });
+
+// Pure-JS reference implementation of TextEncoder.encode (UTF-8 with lone
+// surrogates replaced by U+FFFD), used to cross-check the native SIMD/SWAR
+// fast paths without relying on any other native conversion routine.
+function utf8Reference(str) {
+  const out = [];
+  for (let i = 0; i < str.length; i++) {
+    let cp = str.charCodeAt(i);
+    if (cp >= 0xd800 && cp <= 0xdbff) {
+      const next = i + 1 < str.length ? str.charCodeAt(i + 1) : 0;
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        cp = (cp - 0xd800) * 0x400 + (next - 0xdc00) + 0x10000;
+        i++;
+      } else {
+        cp = 0xfffd;
+      }
+    } else if (cp >= 0xdc00 && cp <= 0xdfff) {
+      cp = 0xfffd;
+    }
+
+    if (cp < 0x80) {
+      out.push(cp);
+    } else if (cp < 0x800) {
+      out.push(0xc0 | (cp >> 6), 0x80 | (cp & 0x3f));
+    } else if (cp < 0x10000) {
+      out.push(0xe0 | (cp >> 12), 0x80 | ((cp >> 6) & 0x3f), 0x80 | (cp & 0x3f));
+    } else {
+      out.push(0xf0 | (cp >> 18), 0x80 | ((cp >> 12) & 0x3f), 0x80 | ((cp >> 6) & 0x3f), 0x80 | (cp & 0x3f));
+    }
+  }
+  return Uint8Array.from(out);
+}
+
+describe("TextEncoder latin1 ASCII fast path boundaries", () => {
+  const encoder = new TextEncoder();
+
+  // Force the string out of JSC's rope representation so encode() takes the
+  // resolved-string path (TextEncoder__encode8).
+  const flatten = s => {
+    s.charCodeAt(0);
+    return s;
+  };
+
+  it("should encode all-ASCII strings of every length around the SIMD/SWAR thresholds", () => {
+    for (const len of [0, 1, 2, 3, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127, 128, 129, 255, 256, 1024, 4096]) {
+      const text = flatten("abcdefgh".repeat(Math.ceil(len / 8) + 1).slice(0, len));
+      const encoded = encoder.encode(text);
+      expect({ len, bytes: Array.from(encoded) }).toEqual({ len, bytes: Array.from(utf8Reference(text)) });
+    }
+  });
+
+  it("should encode latin1 strings with a non-ASCII byte at every boundary position", () => {
+    for (const len of [1, 7, 8, 9, 16, 31, 32, 63, 64, 65, 100, 128, 200]) {
+      for (const pos of new Set([0, 1, 6, 7, 8, 9, 15, 16, 31, 32, 62, 63, 64, 65, len - 2, len - 1])) {
+        if (pos < 0 || pos >= len) continue;
+        const text = flatten("a".repeat(pos) + "©" + "b".repeat(len - pos - 1));
+        const encoded = encoder.encode(text);
+        const expected = utf8Reference(text);
+        expect({ len, pos, bytes: Array.from(encoded) }).toEqual({ len, pos, bytes: Array.from(expected) });
+
+        // encodeInto() into an exactly-sized destination must produce the same
+        // bytes and report full consumption.
+        const dest = new Uint8Array(expected.length);
+        const result = encoder.encodeInto(text, dest);
+        expect({ len, pos, read: result.read, written: result.written, bytes: Array.from(dest) }).toEqual({
+          len,
+          pos,
+          read: text.length,
+          written: expected.length,
+          bytes: Array.from(expected),
+        });
+      }
+    }
+  });
+
+  it("should encode latin1 strings made entirely of non-ASCII characters", () => {
+    for (const len of [1, 8, 16, 64, 100, 1025]) {
+      const text = flatten("©ÿé".repeat(Math.ceil(len / 3)).slice(0, len));
+      const encoded = encoder.encode(text);
+      expect(Array.from(encoded)).toEqual(Array.from(utf8Reference(text)));
+      expect(encoded.length).toBe(2 * len);
+    }
+  });
+
+  it("encodeInto should not write past `written` when the destination is too small", () => {
+    // 8 ASCII bytes, then a 2-byte character that no longer fits.
+    const text = flatten("abcdefgh©xyz");
+    const dest = new Uint8Array(16).fill(0xaa);
+    const result = encoder.encodeInto(text, dest.subarray(0, 9));
+    expect(result.read).toBe(8);
+    expect(result.written).toBe(8);
+    expect(Array.from(dest.subarray(0, 8))).toEqual(Array.from(utf8Reference("abcdefgh")));
+    // Everything past `written` is untouched.
+    expect(Array.from(dest.subarray(8))).toEqual(new Array(8).fill(0xaa));
+  });
+
+  it("encodeInto should stop cleanly mid-ASCII-run when the destination is smaller than the input", () => {
+    const text = flatten("a".repeat(150));
+    const dest = new Uint8Array(200).fill(0xaa);
+    const result = encoder.encodeInto(text, dest.subarray(0, 70));
+    expect(result.read).toBe(70);
+    expect(result.written).toBe(70);
+    expect(Array.from(dest.subarray(0, 70))).toEqual(new Array(70).fill(0x61));
+    expect(Array.from(dest.subarray(70))).toEqual(new Array(130).fill(0xaa));
+  });
+});
+
+describe("TextEncoder rope fast path", () => {
+  const encoder = new TextEncoder();
+
+  it("should encode ropes built from large ASCII segments", () => {
+    // Segments larger than one SIMD register so the rope iterator feeds long
+    // runs through the vectorized copy.
+    let text = "";
+    let expected = "";
+    for (let i = 0; i < 16; i++) {
+      const segment = String.fromCharCode(0x41 + i).repeat(100 + i);
+      text += segment;
+      expected += segment;
+    }
+    const encoded = encoder.encode(text);
+    expect(encoded.length).toBe(expected.length);
+    expect(new TextDecoder().decode(encoded)).toBe(expected);
+  });
+
+  it("should encode ropes whose segments contain non-ASCII latin1 characters", () => {
+    for (const where of ["start", "middle", "end"]) {
+      let text = "";
+      const segments = ["x".repeat(80), "y".repeat(13), "z".repeat(200)];
+      if (where === "start") segments[0] = "©" + segments[0];
+      if (where === "middle") segments[1] = segments[1] + "é" + segments[1];
+      if (where === "end") segments[2] = segments[2] + "ÿ";
+      for (const segment of segments) {
+        text += segment;
+      }
+      const encoded = encoder.encode(text);
+      const expected = utf8Reference(segments.join(""));
+      expect({ where, bytes: Array.from(encoded) }).toEqual({ where, bytes: Array.from(expected) });
+    }
+  });
+
+  it("should encode a large repeated rope identically to its resolved copy", () => {
+    const rope = "Hello World!".repeat(1024);
+    const resolved = "Hello World!".repeat(1024);
+    resolved.charCodeAt(0); // resolve the rope
+    const fromRope = encoder.encode(rope);
+    const fromResolved = encoder.encode(resolved);
+    expect(fromRope.length).toBe(12 * 1024);
+    expect(fromRope).toEqual(fromResolved);
+    expect(new TextDecoder().decode(fromRope)).toBe(resolved);
+  });
+});
+
+describe("TextEncoder UTF-16 exact-size path", () => {
+  const encoder = new TextEncoder();
+
+  it("should encode long valid UTF-16 strings of varying lengths", () => {
+    for (const repeat of [1, 32, 170, 171, 512, 600, 5000]) {
+      const text = "n💕ó".repeat(repeat);
+      const encoded = encoder.encode(text);
+      expect({ repeat, bytes: encoded.length }).toEqual({ repeat, bytes: 7 * repeat });
+      expect(new TextDecoder().decode(encoded)).toBe(text);
+    }
+  });
+
+  it("should encode long UTF-16 strings containing unpaired surrogates", () => {
+    for (const repeat of [1, 100, 1000]) {
+      for (const lone of ["\ud800", "\udc00"]) {
+        const text = ("ab💕" + lone + "cd").repeat(repeat);
+        const encoded = encoder.encode(text);
+        const expected = utf8Reference(text);
+        expect(encoded.length).toBe(expected.length);
+        expect(encoded).toEqual(expected);
+      }
+    }
+  });
+});

--- a/test/js/web/encoding/text-encoder.test.js
+++ b/test/js/web/encoding/text-encoder.test.js
@@ -494,9 +494,6 @@ describe("TextEncoder", () => {
   });
 });
 
-// Pure-JS reference implementation of TextEncoder.encode (UTF-8 with lone
-// surrogates replaced by U+FFFD), used to cross-check the native SIMD/SWAR
-// fast paths without relying on any other native conversion routine.
 function utf8Reference(str) {
   const out = [];
   for (let i = 0; i < str.length; i++) {
@@ -529,8 +526,6 @@ function utf8Reference(str) {
 describe("TextEncoder latin1 ASCII fast path boundaries", () => {
   const encoder = new TextEncoder();
 
-  // Force the string out of JSC's rope representation so encode() takes the
-  // resolved-string path (TextEncoder__encode8).
   const flatten = s => {
     s.charCodeAt(0);
     return s;
@@ -553,8 +548,6 @@ describe("TextEncoder latin1 ASCII fast path boundaries", () => {
         const expected = utf8Reference(text);
         expect({ len, pos, bytes: Array.from(encoded) }).toEqual({ len, pos, bytes: Array.from(expected) });
 
-        // encodeInto() into an exactly-sized destination must produce the same
-        // bytes and report full consumption.
         const dest = new Uint8Array(expected.length);
         const result = encoder.encodeInto(text, dest);
         expect({ len, pos, read: result.read, written: result.written, bytes: Array.from(dest) }).toEqual({
@@ -578,14 +571,12 @@ describe("TextEncoder latin1 ASCII fast path boundaries", () => {
   });
 
   it("encodeInto should not write past `written` when the destination is too small", () => {
-    // 8 ASCII bytes, then a 2-byte character that no longer fits.
     const text = flatten("abcdefgh©xyz");
     const dest = new Uint8Array(16).fill(0xaa);
     const result = encoder.encodeInto(text, dest.subarray(0, 9));
     expect(result.read).toBe(8);
     expect(result.written).toBe(8);
     expect(Array.from(dest.subarray(0, 8))).toEqual(Array.from(utf8Reference("abcdefgh")));
-    // Everything past `written` is untouched.
     expect(Array.from(dest.subarray(8))).toEqual(new Array(8).fill(0xaa));
   });
 
@@ -604,8 +595,6 @@ describe("TextEncoder rope fast path", () => {
   const encoder = new TextEncoder();
 
   it("should encode ropes built from large ASCII segments", () => {
-    // Segments larger than one SIMD register so the rope iterator feeds long
-    // runs through the vectorized copy.
     let text = "";
     let expected = "";
     for (let i = 0; i < 16; i++) {
@@ -637,7 +626,7 @@ describe("TextEncoder rope fast path", () => {
   it("should encode a large repeated rope identically to its resolved copy", () => {
     const rope = "Hello World!".repeat(1024);
     const resolved = "Hello World!".repeat(1024);
-    resolved.charCodeAt(0); // resolve the rope
+    resolved.charCodeAt(0);
     const fromRope = encoder.encode(rope);
     const fromResolved = encoder.encode(resolved);
     expect(fromRope.length).toBe(12 * 1024);


### PR DESCRIPTION
### What does this PR do?

`TextEncoder.encode`'s Rust port was measurably slower than the Zig implementation it replaced (4-char ASCII ~2× slower, 12 KB ASCII ~40% slower; only the large UTF-8 case was a tie). This PR restores the lost fast paths and vectorization:

**Cause**

- `TextEncoder__encode8/16/encodeRopeString` zero-filled a 2 KB stack buffer on every call (`[0u8; 2048]`) where the Zig code used `undefined`, then copied the output a second time from that buffer into JSC memory. For a 4-byte input the memset alone is most of the regression.
- The 12 KB ASCII benchmark case is actually JSC **rope** iteration (`"Hello World!".repeat(1024)` stays a rope): ~1024 12-byte leaves hit `copy_latin1_into_utf8_stop_on_non_ascii`, whose port replaced the Zig fused `@Vector(16,u8)`/SWAR copy with a scan (`first_non_ascii`) followed by a `memcpy` per span — two passes plus per-leaf call overhead.
- `element_length_latin1_into_utf8` was ported as a scalar span loop instead of `simdutf.length.utf8.from.latin1`.
- The small UTF-16 path paid an exact `utf8_length_from_utf16le` pass even when the destination buffer already provably fit the worst case (the Zig `out_len` shortcut was dropped).

**Fix**

- New `CopyAsciiPrefix` highway kernel in `highway_strings.cpp` (same `HWY_EXPORT` + `HWY_DYNAMIC_DISPATCH` pattern as the existing kernels): fused scan+copy of the leading ASCII run that stops at the first byte ≥ 0x80 and writes only the bytes it reports. Exposed as `bun_highway::copy_ascii_prefix`, with per-target symbols added to the `verify-baseline-static` allowlists.
- `copy_latin1_into_utf8_stop_on_non_ascii` now streams through a fused `copy_ascii_prefix` helper: SWAR `u64` for short runs (rope leaves are usually a dozen bytes, so FFI dispatch isn't worth it), the highway kernel for runs ≥ 64 bytes. Only `buf[..written]` is ever written, same as before.
- `element_length_latin1_into_utf8` uses simdutf (scalar count for ≤ 32 bytes), matching the Zig original.
- `copy_utf16_into_utf8` skips the exact-length pass when `buf.len() >= 3 * utf16.len()` (worst case), mirroring the Zig `out_len` selection; a `copy_utf16_into_utf8_with_utf8_len` variant lets callers that already computed the length (to size the destination) avoid recomputing it.
- `TextEncoder__encode8` / `__encode16` now encode straight into an exactly-sized, JSC-owned `Uint8Array` — no stack buffer, no second copy, and the former large-string path no longer hands JSC an external `Vec`. `encode16` keeps a small 192-byte stack path for tiny strings and falls back to the allocating U+FFFD path when unpaired surrogates make the exact-size buffer insufficient. `TextEncoder__encodeRopeString` allocates the array up front and lets the rope iterator write each segment directly into it.

Output bytes, `encodeInto` read/written semantics, and the "never write past `written`" guarantee are unchanged.

### Benchmarks

`bench/snippets/text-encoder.mjs`, median of 3 interleaved rounds on linux x64 (AVX2/AVX-512), comparing the last Zig-based release (1.3.9), the current Rust implementation, and this PR (both built with the `release` profile from this tree):

| case | Zig 1.3.9 | Rust before | Rust after |
|---|---|---|---|
| 4 ascii | 40.6 ns | 61.8 ns | **40.9 ns** |
| 4 utf8 | 59.4 ns | 80.2 ns | **59.6 ns** |
| 12 ascii | 45.2 ns | 66.0 ns | **47.3 ns** |
| 12 utf8 | 71.0 ns | 114.1 ns | **71.2 ns** |
| 12288 ascii (rope) | 16.95 µs | 21.5 µs | **16.58 µs** |
| 18432 utf8 | 10.54 µs | 8.60 µs | **8.37 µs** |

The tiny-string cases are now bounded by shared machinery (call dispatch, `Uint8Array` allocation), so they land at parity with Zig instead of 1.5–2× behind; the large cases win outright. Additional paths not in the stock benchmark, same methodology:

| case | Zig 1.3.9 | Rust before | Rust after |
|---|---|---|---|
| encode 12288 ascii, resolved (non-rope) string | 1.98 µs | 1.86 µs | **1.51 µs** |
| encode 12289 latin1 (1 non-ASCII byte) | 2.69 µs | 2.44 µs | **2.04 µs** |
| encodeInto 12288 ascii | 838 ns | 330 ns | **201 ns** |
| encode 1 MB ascii | 165 µs | 166 µs | **161 µs** |

(The benchmark host is a shared/noisy container; medians of interleaved runs are reported. Ratios, not absolute numbers, are the signal.)

### How did you verify your code works?

- `bun bd test test/js/web/encoding/` — all TextEncoder/TextEncoderStream/TextDecoder tests pass with the debug (ASAN) build. The only failures in that directory are the two pre-existing `TextDecoder ... should not leak the output buffer` RSS tests, which fail on any local ASAN debug build because the binary isn't named `bun-asan` (the measured delta is within the test's own ASAN allowance).
- Added boundary coverage to `test/js/web/encoding/text-encoder.test.js` (10 new tests, ~10k assertions): every length around the SWAR/SIMD thresholds, a non-ASCII byte at every word/vector boundary position, `encodeInto` exact-fit and partial-fit behavior including "bytes past `written` are untouched", rope strings with >64-byte segments and with non-ASCII segments (bail path), and long UTF-16 strings with and without unpaired surrogates, all cross-checked against a pure-JS reference encoder.
- `cargo clippy -p bun_core -p bun_highway` clean; websocket/inspect suites (which share the rewritten Latin-1 kernels) pass apart from tests that dial external network endpoints unavailable in the sandbox.
- The baseline-ISA allowlist entries for the new kernel follow the existing `FirstNonAscii8Impl`/`FillWithSkipMaskImpl` ceilings; if `verify-baseline-static` reports different feature sets on the baseline/aarch64 CI builds I'll update the entries to match its report.
- Note on test coverage: this is a deliberately behavior-preserving optimization, so the new tests are regression coverage for the rewritten paths (they pass before and after this change by design — there is no functional delta to assert). The before/after evidence for the optimization itself is the benchmark tables above, reproducible via `bench/snippets/text-encoder.mjs`.
