### PR TITLE
bundler: drop unreachable_unchecked in parse_data_loader

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1959,8 +1959,10 @@ fn parse_data_loader<'a>(
                 Err(_) => return None,
             }
         }
-        // SAFETY: outer match arm guarantees one of the five.
-        _ => unsafe { core::hint::unreachable_unchecked() },
+        // The outer match in the caller narrows `loader` to one of the five
+        // arms above; the path is cold either way (`#[cold]` on this fn), so
+        // panic on the impossible arm instead of UB.
+        _ => unreachable!("parse_data_loader called with non-data loader: {loader:?}"),
     };
     let mut expr = value_expr;
 


### PR DESCRIPTION
## What does this PR do?

  `parse_data_loader` in `src/bundler/transpiler.rs` had a wildcard arm
  `_ => unsafe { core::hint::unreachable_unchecked() }` after matching the
  five data-format loaders (Jsonc, Json, Toml, Yaml, Json5).

  restricts entry to those exact five via its own outer match, and the
  function is marked `#[cold]` + `#[inline(never)]` — so the unsafe variant
  wasn't gaining anything observable.

# Why ?

The caller already narrows `loader` to the five data-format arms above, and this function is #[cold] anyway, so the unsafe variant was buying nothing. unreachable!() panics with the loader value instead of UB if the contract ever breaks.


  ## How
  
  Replaced with `unreachable!("parse_data_loader called with non-data loader: {loader:?}")`.
  
  If the outer match contract is ever quietly broken (someone adds a new
  data loader and forgets to wire it here), this turns into a clear panic
  instead of UB. No call-path change when the contract holds; the cold
  attribute keeps the branch out of the hot icache.
  
### How did you verify your code works?

  
  - [x] `cargo check -p bun_bundler`
  - [x] `cargo clippy -p bun_bundler -- -D warnings`
  - [x] `bun bd --asan=off`
  - [x] Smoke: `bun -e 'JSON.parse(...)'` works (exercises Json loader)



