### PR TITLE
fix(Bun.plugin): propagate exception thrown while converting 'target' to a string

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -302,12 +302,11 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
     auto targetValue = obj->getIfPropertyExists(globalObject, Identifier::fromString(vm, "target"_s));
     RETURN_IF_EXCEPTION(throwScope, {});
     if (targetValue) {
-        if (auto* targetJSString = targetValue.toStringOrNull(globalObject)) {
-            String targetString = targetJSString->value(globalObject);
-            if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
-                JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
-                return {};
-            }
+        String targetString = targetValue.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
+            JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
+            return {};
         }
     }
 

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -366,6 +366,21 @@ describe("errors", () => {
     }).toThrow("plugin target must be one of 'node', 'bun' or 'browser'");
   });
 
+  it("handles a 'target' that throws while being converted to a string", () => {
+    const opts = {
+      setup: () => {},
+      target: {
+        [Symbol.toPrimitive]() {
+          return [];
+        },
+      },
+    };
+
+    expect(() => {
+      plugin(opts as any);
+    }).toThrow("Symbol.toPrimitive returned an object");
+  });
+
   it("invalid loaders throw", () => {
     const invalidLoaders = ["blah", "blah2", "blah3", "blah4"];
     const inputs = ["body { background: red; }", "<h1>hi</h1>", '{"hi": "there"}', "hi"];


### PR DESCRIPTION
### What does this PR do?

Fixes a debug assertion failure (`ASSERTION FAILED: Unexpected exception observed ... !exception()` in `ExceptionScope::assertNoException`) found by fuzzing, fingerprint `34a19a3501a83cae`.

`Bun.plugin()` converted the `target` option to a string with `toStringOrNull()` and silently ignored the case where the conversion throws — for example when `target` is an object whose `Symbol.toPrimitive` returns an object. The pending `TypeError: Symbol.toPrimitive returned an object` was then carried into the subsequent object construction and the `setup()` call, tripping `assertNoException` in debug builds (and invoking `setup()` with a pending exception in release builds).

The fix converts `target` with `toWTFString()` and returns early if the conversion throws, matching how the rest of `BunPlugin.cpp` handles string conversions.

Repro that crashed before:

```js
const v = {};
v[Symbol.toPrimitive] = () => [1, 2, 3];
v.target = v;
Object.defineProperty(v, "setup", { value: ArrayBuffer });
Bun.plugin(v);
```

Now it throws `TypeError: Symbol.toPrimitive returned an object` instead.

### How did you verify your code works?

- Reproduced the assertion failure with the fuzzilli debug build before the change; after the change the script exits with a proper `TypeError`.
- Added a regression test in `test/js/bun/plugin/plugins.test.ts` (`errors > handles a 'target' that throws while being converted to a string`); ran the full file with `bun bd test test/js/bun/plugin/plugins.test.ts` — 30 pass, 0 fail.
- Verified with `BUN_JSC_validateExceptionChecks=1` that no unchecked-exception warnings are reported on this path.
