### PR TITLE
fix(process): handle exceptions during lazy process.nextTick initialization

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3824,8 +3824,13 @@ void Process::queueNextTick(JSC::JSGlobalObject* globalObject, const ArgList& ar
         if (nextTick && nextTick.isObject())
             nextTickFn = asObject(nextTick);
         else {
-            throwVMError(globalObject, scope, "Failed to call nextTick"_s);
-            return;
+            constructNextTickFn(vm, defaultGlobalObject(this->globalObject()));
+            RETURN_IF_EXCEPTION(scope, void());
+            nextTickFn = this->m_nextTickFunction.get();
+            if (!nextTickFn) {
+                throwVMError(globalObject, scope, "Failed to call nextTick"_s);
+                return;
+            }
         }
     }
     ASSERT_WITH_MESSAGE(!args.at(0).inherits<AsyncContextFrame>(), "queueNextTick must not pass an AsyncContextFrame. This will cause a crash.");
@@ -3913,6 +3918,7 @@ static JSValue constructMainModuleProperty(VM& vm, JSObject* processObject)
 
 JSValue Process::constructNextTickFn(JSC::VM& vm, Zig::GlobalObject* globalObject)
 {
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSNextTickQueue* nextTickQueueObject;
     if (!globalObject->m_nextTickQueue) {
         nextTickQueueObject = JSNextTickQueue::create(globalObject);
@@ -3930,6 +3936,10 @@ JSValue Process::constructNextTickFn(JSC::VM& vm, Zig::GlobalObject* globalObjec
     args.append(JSC::JSFunction::create(vm, globalObject, 1, String(), jsFunctionReportUncaughtException, ImplementationVisibility::Private));
 
     JSValue nextTickFunction = JSC::profiledCall(globalObject, ProfilingReason::API, initializer, JSC::getCallData(initializer), globalObject->globalThis(), args);
+    if (scope.exception()) [[unlikely]] {
+        (void)scope.tryClearException();
+        return jsUndefined();
+    }
     if (nextTickFunction && nextTickFunction.isObject()) {
         this->m_nextTickFunction.set(vm, this, nextTickFunction.getObject());
     }

--- a/test/js/node/process/process-nexttick.test.js
+++ b/test/js/node/process/process-nexttick.test.js
@@ -2,6 +2,7 @@
 // mess with timers, producing unreliable results. You must manually test this
 // in Node.
 import { expect, it } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 const isBun = !!process.versions.bun;
 
 it("process.nextTick", async () => {
@@ -1035,4 +1036,64 @@ it("process.nextTick and AsyncLocalStorage.enterWith don't conflict", async () =
 
   expect(call1).toBe(true);
   expect(call2).toBe(true);
+});
+
+// The first use of process.nextTick lazily initializes it by calling a JS builtin. If that first
+// use happens while the stack is nearly exhausted (here via the Worker constructor, which queues a
+// process 'worker' event on nextTick), the initialization used to leave a pending stack overflow
+// exception behind and cache a bogus nextTick function, crashing debug builds and permanently
+// breaking Worker construction afterwards.
+it("first use of process.nextTick during stack exhaustion does not break nextTick", async () => {
+  using dir = tempDir("nexttick-stack-exhaustion", {
+    "worker.js": `postMessage("ready");`,
+    "main.js": `
+      const workerPath = new URL("./worker.js", import.meta.url).href;
+
+      let done = false;
+      function attemptWorker() {
+        try {
+          const w = new Worker(workerPath);
+          w.terminate();
+          return true;
+        } catch (e) {
+          // Out of stack; retry in a shallower frame.
+          if (e instanceof RangeError) return false;
+          return true;
+        }
+      }
+
+      function dive() {
+        try {
+          dive();
+        } catch {}
+        if (!done) done = attemptWorker();
+      }
+      dive();
+
+      // With a healthy stack, constructing a Worker must succeed again.
+      const w = new Worker(workerPath);
+      w.onmessage = () => {
+        console.log("WORKER_OK");
+        w.terminate();
+        process.exit(0);
+      };
+      w.onerror = e => {
+        console.error("WORKER_ERROR", e.message);
+        process.exit(1);
+      };
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout).toContain("WORKER_OK");
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-found assertion crash (deterministic, fingerprint `JSObjectInlines.h(102)`):

```
ASSERTION FAILED: !scope.exception() || vm.hasPendingTerminationException() || !hasProperty
JavaScriptCore/JSObjectInlines.h(102) : JSValue JSC::JSObject::get(JSGlobalObject *, PropertyName) const
```

`process.nextTick` is a lazy static property on the process object: the first access reifies it via `constructProcessNextTickFn`, which calls the `initializeNextTickQueue` JS builtin. JSC's static-property reification cannot tolerate a throwing property callback, but that builtin call can throw — e.g. a stack overflow when the first-ever use of `process.nextTick` happens while the stack is nearly exhausted.

The fuzzer hit this through the Worker constructor: deep recursion catches `Maximum call stack size exceeded`, then constructs a `Worker`. The constructor emits the process `'worker'` event via `Process::queueNextTick`, whose `get("nextTick")` triggers the reification. The builtin call overflowed the stack, and:

* the pending exception escaped the property callback, so `JSObject::get` returned a found property with an exception pending → assertion failure (SIGABRT) in debug builds;
* in release builds the thrown error object was cached as `m_nextTickFunction` and reified as `process.nextTick`, so every later internal `nextTick` user — including every subsequent `new Worker()`, even with a healthy stack — failed forever with `Failed to call nextTick`.

Changes in `BunProcess.cpp`:

* `Process::constructNextTickFn` now clears any exception from the builtin call (same pattern as `constructStdioWriteStream`/`constructStdin`, which are also property callbacks that call JS) and returns `jsUndefined()` instead of caching/reifying a bogus value. The exception is not re-reported: when initialization cannot run, callers already surface an error, and when it is retried successfully there is nothing to report.
* `Process::queueNextTick` retries `constructNextTickFn` when no usable `nextTick` function is available, so internal users (Worker construction, `process.emitWarning`, …) recover once the stack is healthy instead of being permanently broken by one failed lazy initialization.

Minimized reproduction (previously aborted a debug build at the first `new Worker` attempt):

```js
function dive() {
  try { dive(); } catch {}
  try { new Worker("./worker.js"); } catch {}
}
dive();
```

Note: the original fuzz input constructs a Worker at every unwind level, so with the crash fixed it now runs into thread-creation exhaustion from spawning thousands of workers; that is a separate pre-existing condition reachable with a plain loop of `new Worker()` calls and is not addressed here.

### How did you verify your code works?

* The minimized fuzz reproduction aborts a debug build before this change (`JSObjectInlines.h(102)` assertion) and exits cleanly after it.
* Added a regression test in `test/js/node/process/process-nexttick.test.js` that reproduces the scenario in a child process and verifies Worker construction still works afterwards:
  * fails on the current release build (`Failed to call nextTick`, no `WORKER_OK`) and crashes the current debug build;
  * passes with this change (`bun bd test test/js/node/process/process-nexttick.test.js`).
* `test/js/web/workers/worker.test.ts` and `test/js/node/worker_threads/worker_threads.test.ts` pass with the debug build, except two pre-existing timing/resource flakes that also fail on the unmodified binary.
