### PR TITLE
fix(node:module): don't register native helpers as their own constructors

### DIFF
--- a/src/jsc/bindings/webcore/JSPerformance.cpp
+++ b/src/jsc/bindings/webcore/JSPerformance.cpp
@@ -278,7 +278,7 @@ void JSPerformance::finishCreation(VM& vm)
         globalObject(),
         0,
         String("now"_s),
-        functionPerformanceNow, ImplementationVisibility::Public, NoIntrinsic, functionPerformanceNow,
+        functionPerformanceNow, ImplementationVisibility::Public, NoIntrinsic, callHostFunctionAsConstructor,
         &DOMJITSignatureForPerformanceNow);
     this->putDirect(vm, JSC::Identifier::fromString(vm, "now"_s), now, 0);
 

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -1073,7 +1073,7 @@ void addNodeModuleConstructorProperties(JSC::VM& vm,
             JSFunction* runMainFunction = JSFunction::create(
                 init.vm, init.owner, 2, "runMain"_s,
                 jsFunctionRunMain, JSC::ImplementationVisibility::Public,
-                JSC::NoIntrinsic, jsFunctionRunMain);
+                JSC::NoIntrinsic);
             init.set(runMainFunction);
         });
 
@@ -1082,7 +1082,7 @@ void addNodeModuleConstructorProperties(JSC::VM& vm,
             JSFunction* resolveFilenameFunction = JSFunction::create(
                 init.vm, init.owner, 2, "_resolveFilename"_s,
                 jsFunctionResolveFileName, JSC::ImplementationVisibility::Public,
-                JSC::NoIntrinsic, jsFunctionResolveFileName);
+                JSC::NoIntrinsic);
             init.set(resolveFilenameFunction);
         });
 
@@ -1091,7 +1091,7 @@ void addNodeModuleConstructorProperties(JSC::VM& vm,
             JSFunction* resolveFilenameFunction = JSFunction::create(
                 init.vm, init.owner, 2, "_compile"_s,
                 functionJSCommonJSModule_compile, JSC::ImplementationVisibility::Public,
-                JSC::NoIntrinsic, functionJSCommonJSModule_compile);
+                JSC::NoIntrinsic);
             init.set(resolveFilenameFunction);
         });
 

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -26,6 +26,20 @@ describe.concurrent("node-module-module", () => {
     expect(Array.isArray(require("module").globalPaths)).toBe(true);
   });
 
+  test("native module functions are not constructors", () => {
+    // Constructing these used to crash instead of throwing.
+    const compile = new Module("not-a-constructor-test")._compile;
+    expect(typeof compile).toBe("function");
+    expect(() => new compile()).toThrow(TypeError);
+    expect(() => Reflect.construct(compile, [])).toThrow(TypeError);
+    expect(() => new Module.runMain()).toThrow(TypeError);
+    expect(() => Reflect.construct(Module.runMain, [])).toThrow(TypeError);
+    expect(() => new Module._resolveFilename("fs")).toThrow(TypeError);
+    expect(() => Reflect.construct(Module._resolveFilename, ["fs"])).toThrow(TypeError);
+    // Calling still works.
+    expect(Module._resolveFilename("fs")).toBe("fs");
+  });
+
   test("createRequire trailing slash", () => {
     const req = createRequire(import.meta.dir + "/");
     expect(req.resolve("./node-module-module.test.js")).toBe(

--- a/test/js/web/timers/performance.test.js
+++ b/test/js/web/timers/performance.test.js
@@ -40,6 +40,13 @@ it("performance.timeOrigin + performance.now() should be similar to Date.now()",
   expect(Math.abs(performance.timeOrigin + performance.now() - Date.now()) < 1000).toBe(true);
 });
 
+it("performance.now is not a constructor", () => {
+  // Constructing performance.now used to crash instead of throwing.
+  expect(() => new performance.now()).toThrow(TypeError);
+  expect(() => Reflect.construct(performance.now, [])).toThrow(TypeError);
+  expect(typeof performance.now()).toBe("number");
+});
+
 // https://github.com/oven-sh/bun/issues/5604
 it("performance.now() DOMJIT", () => {
   // This test is very finnicky.


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-found crash (`ASSERTION FAILED: isCell()` in `JSCJSValue.h`, `asCell()`) triggered by constructing `process.mainModule._compile`:

```js
Reflect.construct(process.mainModule._compile, []); // ASSERTION FAILED: isCell()
```

`Module.runMain`, `Module._resolveFilename`, `module._compile` (in `src/jsc/modules/NodeModuleModule.cpp`) and `performance.now` (in `src/jsc/bindings/webcore/JSPerformance.cpp`) were created with their call function also registered as the **native construct callback**. JSC requires a native construct callback to return an object, but these functions return `undefined`, a string, or a number — so `new fn()` / `Reflect.construct(fn, …)` hit `asObject()` → `ASSERT(isCell())` in debug builds and produce an invalid `JSObject*` in release builds.

### Fix

Create these functions without a native constructor (the `JSFunction::create` default, `callHostFunctionAsConstructor`), so constructing them throws a `TypeError` like other native helper functions — matching `performance.now` behavior in browsers/Node, while calling them is unchanged.

Related: #31386 fixes the same assertion fingerprint for `bun:test` mock functions; this PR covers the remaining non-mock instances the fuzzer reached.

### How did you verify your code works?

- The minimized repros (`Reflect.construct(module._compile, [])`, `new process.mainModule._compile()`, `Reflect.construct(Module._resolveFilename, ["fs"])`, `new Module.runMain()`, `Reflect.construct(performance.now, [])`) assert on current main (debug build) and now throw `TypeError` with this change.
- Added regression tests:
  - `node-module-module > native module functions are not constructors` (`test/js/node/module/node-module-module.test.js`)
  - `performance.now is not a constructor` (`test/js/web/timers/performance.test.js`)

  Both fail on an unfixed build and pass with this change; the full files (29 and 7 tests) pass with the debug build, including the existing tests that call `module._compile` / `Module._resolveFilename`.
