### PR TITLE
fix(transpiler): preserve non-ASCII in String.raw and RegExp.source

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -3218,53 +3218,9 @@ pub mod __gated_printer {
         }
 
         fn print_raw_template_literal(&mut self, bytes: &[u8]) {
-            if IS_JSON || !ASCII_ONLY {
-                self.print(bytes);
-                return;
-            }
-
-            // Translate any non-ASCII to unicode escape sequences
-            // Note that this does not correctly handle malformed template literal strings
-            // template literal strings can contain invalid unicode code points
-            // and pretty much anything else
-            //
-            // we use WTF-8 here, but that's still not good enough.
-            //
-            let mut ascii_start: usize = 0;
-            let mut is_ascii = false;
-            let iter = CodepointIterator::init(bytes);
-            let mut cursor = strings::Cursor::default();
-
-            while iter.next(&mut cursor) {
-                match cursor.c as u32 {
-                    // unlike other versions, we only want to mutate > 0x7F
-                    0..=LAST_ASCII => {
-                        if !is_ascii {
-                            ascii_start = cursor.i as usize;
-                            is_ascii = true;
-                        }
-                    }
-                    _ => {
-                        if is_ascii {
-                            self.print(&bytes[ascii_start..(cursor.i as usize)]);
-                            is_ascii = false;
-                        }
-
-                        match cursor.c as u32 {
-                            c @ 0..=0xFFFF => self.print(&bmp_escape(c)[..]),
-                            _ => {
-                                self.print(b"\\u{");
-                                let _ = self.fmt(format_args!("{:x}", cursor.c));
-                                self.print(b"}");
-                            }
-                        }
-                    }
-                }
-            }
-
-            if is_ascii {
-                self.print(&bytes[ascii_start..]);
-            }
+            // Emit source bytes verbatim — `\uXXXX` escaping would alter
+            // `String.raw` output at runtime (#18115).
+            self.print(bytes);
         }
 
         pub fn check_stack_overflow(&self) -> Result<(), bun_core::Error> {
@@ -4636,41 +4592,9 @@ pub mod __gated_printer {
                 self.print(b" ");
             }
 
-            if IS_BUN_PLATFORM {
-                // Translate any non-ASCII to unicode escape sequences
-                let mut ascii_start: usize = 0;
-                let mut is_ascii = false;
-                let iter = CodepointIterator::init(&e.value);
-                let mut cursor = strings::Cursor::default();
-                while iter.next(&mut cursor) {
-                    match cursor.c as u32 {
-                        FIRST_ASCII..=LAST_ASCII => {
-                            if !is_ascii {
-                                ascii_start = cursor.i as usize;
-                                is_ascii = true;
-                            }
-                        }
-                        _ => {
-                            if is_ascii {
-                                self.print(&e.value[ascii_start..(cursor.i as usize)]);
-                                is_ascii = false;
-                            }
-
-                            match cursor.c as u32 {
-                                c @ 0..=0xFFFF => self.print(&bmp_escape(c)[..]),
-                                c => self.print(&surrogate_pair_escape(c)[..]),
-                            }
-                        }
-                    }
-                }
-
-                if is_ascii {
-                    self.print(&e.value[ascii_start..]);
-                }
-            } else {
-                // UTF8 sequence is fine
-                self.print(&e.value[..]);
-            }
+            // Emit source bytes verbatim — `\uXXXX` escaping would alter
+            // `RegExp.prototype.source` at runtime (#18115).
+            self.print(&e.value[..]);
 
             // Need a space before the next identifier to avoid it turning into flags
             self.prev_reg_exp_end = self.writer.written();

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -1421,7 +1421,7 @@ impl AsyncModule {
         }
 
         Ok(ResolvedSource {
-            source_code: BunString::clone_latin1(printer.ctx.get_written()),
+            source_code: BunString::clone_utf8(printer.ctx.get_written()),
             specifier: BunString::init(specifier),
             source_url: BunString::init(path.text),
             is_commonjs_module,

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -41,7 +41,9 @@ bun_core::declare_scope!(cache, visible);
 /// Version 22: Serialize `has_tla` in the cached ESM record flags byte. Entries
 /// written before #30888 carried `has_tla=false` for every module; the cache-HIT
 /// path reinstates the bug for any previously-cached TLA module (#30887).
-const EXPECTED_VERSION: u32 = 22;
+/// Version 23: `put()` picks the encoding from the bytes; pre-#18115 entries
+/// mis-tagged UTF-8 output as Latin-1.
+const EXPECTED_VERSION: u32 = 23;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a
@@ -1034,7 +1036,7 @@ impl RuntimeTranspilerCache {
             return;
         }
         debug_assert!(self.entry.is_none());
-        let output_code = BunString::clone_latin1(output_code_bytes);
+        let output_code = BunString::clone_utf8(output_code_bytes);
         // Zig: `this.output_code = output_code;` — refcount stays at 1, sole owner.
         // BunString is Copy with no Drop, so an extra dupe_ref here would leak.
         self.output_code = Some(output_code);
@@ -1053,7 +1055,7 @@ impl RuntimeTranspilerCache {
         }
         #[cfg(debug_assertions)]
         {
-            bun_core::scoped_log!(cache, "put() = {} bytes", output_code.latin1().len());
+            bun_core::scoped_log!(cache, "put() = {} chars", output_code.length());
         }
     }
 }

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -1105,10 +1105,12 @@ bun_ast::link_impl_TranspilerCacheImpl! {
             }
             debug_assert!(this.entry.is_none());
 
-            // Borrowed Latin-1 view: `to_file` only reads `byte_slice()` + the encoding
-            // tag (unmarked 8-bit ZigString -> Encoding::LATIN1, same as clone_latin1),
-            // and `output_code_bytes` outlives the synchronous `to_file` call.
-            let output_code = BunString::ascii(output_code_bytes);
+            // `clone_utf8` (not `ascii`) so `Entry::save` tags the on-disk
+            // encoding from the actual contents — Latin-1 for ASCII, UTF-16
+            // for non-ASCII (#18115). Guard the +1 refcount: unlike the
+            // non-vtable `put()`, nothing here takes ownership of `output_code`.
+            let output_code = BunString::clone_utf8(output_code_bytes);
+            let _output_code_guard = scopeguard::guard(output_code, |s| s.deref());
             let result = RuntimeTranspilerCache::to_file(
                 this.input_byte_length.unwrap(),
                 this.input_hash.unwrap(),

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -1034,7 +1034,7 @@ impl TranspilerJob {
         if !matches!(parse_result.already_bundled, AlreadyBundled::None) {
             let bytecode_slice = parse_result.already_bundled.bytecode_slice();
             self.resolved_source = OwnedResolvedSource::from(ResolvedSource {
-                source_code: String::clone_latin1(&parse_result.source.contents),
+                source_code: String::clone_utf8(&parse_result.source.contents),
                 already_bundled: true,
                 bytecode_cache: if !bytecode_slice.is_empty() {
                     bytecode_slice.as_ptr().cast_mut()
@@ -1186,7 +1186,9 @@ impl TranspilerJob {
             // `cache.output_code` (only the `r#impl == None` fallback does,
             // and `r#impl` is `Some(Jsc)` here), so it is always `None`.
             debug_assert!(cache.output_code.is_none());
-            let result = String::clone_latin1(written);
+            // UTF-8 decode is required — the printer emits raw non-ASCII
+            // bytes for `String.raw` / `RegExp.source` (#18115).
+            let result = String::clone_utf8(written);
 
             // SAFETY: leaf scalar field read on `*vm`; see `vm` PORT NOTE above.
             if written.len() > 1024 * 1024 * 2 || unsafe { (*vm).smol } {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2717,7 +2717,7 @@ fn transpile_source_code_inner(
                         _ => (core::ptr::null_mut(), 0),
                     };
                     return Ok(OwnedResolvedSource::from(ResolvedSource {
-                        source_code: bun_core::String::clone_latin1(&source.contents),
+                        source_code: bun_core::String::clone_utf8(&source.contents),
                         specifier: input_specifier.dupe_ref(),
                         source_url: create_if_different(input_specifier, path.text),
                         already_bundled: true,
@@ -3085,7 +3085,9 @@ fn transpile_source_code_inner(
                 // does, and `r#impl` is `Some(Jsc)` here), so it is always
                 // `None`.
                 debug_assert!(cache.output_code.is_none());
-                let source_code = bun_core::String::clone_latin1(written);
+                // UTF-8 decode is required — the printer emits raw non-ASCII
+                // bytes for `String.raw` / `RegExp.source` (#18115).
+                let source_code = bun_core::String::clone_utf8(written);
                 // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
                 if written.len() > 1024 * 1024 * 2 || unsafe { &*jsc_vm }.smol {
                     // PERF(port): spec deinits the printer buffer; Rust drops on

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3642,6 +3642,7 @@ console.log(foo, array);
     expectPrinted("String.raw`🐰`", "String.raw`🐰`");
     expectPrinted("/╭─╮/.source", "/╭─╮/.source");
     expectPrinted("/Redémarrage/.source", "/Redémarrage/.source");
+    expectPrinted("/🐰/.source", "/🐰/.source");
   });
 
   describe("scan", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3635,6 +3635,15 @@ console.log(foo, array);
     expectPrinted(code, result);
   });
 
+  it("raw template literal contents preserve non-ASCII (#18115)", () => {
+    expectPrinted("String.raw`Redémarrage`", "String.raw`Redémarrage`");
+    expectPrinted("String.raw`a中`", "String.raw`a中`");
+    expectPrinted("String.raw`╭─╮`", "String.raw`╭─╮`");
+    expectPrinted("String.raw`🐰`", "String.raw`🐰`");
+    expectPrinted("/╭─╮/.source", "/╭─╮/.source");
+    expectPrinted("/Redémarrage/.source", "/Redémarrage/.source");
+  });
+
   describe("scan", () => {
     it("reports all export names", () => {
       const { imports, exports } = transpiler.scan(code);

--- a/test/regression/issue/18115.test.ts
+++ b/test/regression/issue/18115.test.ts
@@ -14,9 +14,15 @@ test("String.raw preserves non-ASCII characters", async () => {
       "process.stdout.write(JSON.stringify([String.raw`Redémarrage`, String.raw`a中`, String.raw`╭─╮`, String.raw`🐰`]))",
     ],
     env: bunEnv,
+    stderr: "pipe",
   });
 
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  expect(stderr).toBe("");
   expect(stdout).toBe(JSON.stringify(["Redémarrage", "a中", "╭─╮", "🐰"]));
   expect(exitCode).toBe(0);
 });
@@ -29,9 +35,15 @@ test("RegExp.source preserves non-ASCII characters", async () => {
       "process.stdout.write(JSON.stringify([/Redémarrage/.source, /╭─╮/.source, /a中/.source]))",
     ],
     env: bunEnv,
+    stderr: "pipe",
   });
 
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  expect(stderr).toBe("");
   expect(stdout).toBe(JSON.stringify(["Redémarrage", "╭─╮", "a中"]));
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/18115.test.ts
+++ b/test/regression/issue/18115.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/18115
+// `String.raw` and `RegExp.prototype.source` must preserve non-ASCII bytes
+// verbatim — the printer previously escaped them to `\uXXXX`, changing
+// runtime values (e.g. `String.raw\`é\``.length was 6 instead of 1).
+
+test("String.raw preserves non-ASCII characters", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      "process.stdout.write(JSON.stringify([String.raw`Redémarrage`, String.raw`a中`, String.raw`╭─╮`, String.raw`🐰`]))",
+    ],
+    env: bunEnv,
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toBe(JSON.stringify(["Redémarrage", "a中", "╭─╮", "🐰"]));
+  expect(exitCode).toBe(0);
+});
+
+test("RegExp.source preserves non-ASCII characters", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      "process.stdout.write(JSON.stringify([/Redémarrage/.source, /╭─╮/.source, /a中/.source]))",
+    ],
+    env: bunEnv,
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toBe(JSON.stringify(["Redémarrage", "╭─╮", "a中"]));
+  expect(exitCode).toBe(0);
+});
+

--- a/test/regression/issue/18115.test.ts
+++ b/test/regression/issue/18115.test.ts
@@ -1,50 +1,85 @@
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { describe, expect, test } from "bun:test";
+import { existsSync, readdirSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
 
 // https://github.com/oven-sh/bun/issues/18115
 // `String.raw` and `RegExp.prototype.source` must preserve non-ASCII bytes
 // verbatim — the printer previously escaped them to `\uXXXX`, changing
 // runtime values (e.g. `String.raw\`é\``.length was 6 instead of 1).
 
-test("String.raw preserves non-ASCII characters", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      "process.stdout.write(JSON.stringify([String.raw`Redémarrage`, String.raw`a中`, String.raw`╭─╮`, String.raw`🐰`]))",
-    ],
-    env: bunEnv,
-    stderr: "pipe",
+describe.concurrent("issue/18115", () => {
+  test("String.raw preserves non-ASCII characters", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        "process.stdout.write(JSON.stringify([String.raw`Redémarrage`, String.raw`a中`, String.raw`╭─╮`, String.raw`🐰`]))",
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(JSON.stringify(["Redémarrage", "a中", "╭─╮", "🐰"]));
+    expect(exitCode).toBe(0);
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
-  expect(stderr).toBe("");
-  expect(stdout).toBe(JSON.stringify(["Redémarrage", "a中", "╭─╮", "🐰"]));
-  expect(exitCode).toBe(0);
-});
+  test("RegExp.source preserves non-ASCII characters", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "process.stdout.write(JSON.stringify([/Redémarrage/.source, /╭─╮/.source, /a中/.source]))"],
+      env: bunEnv,
+      stderr: "pipe",
+    });
 
-test("RegExp.source preserves non-ASCII characters", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      "process.stdout.write(JSON.stringify([/Redémarrage/.source, /╭─╮/.source, /a中/.source]))",
-    ],
-    env: bunEnv,
-    stderr: "pipe",
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(JSON.stringify(["Redémarrage", "╭─╮", "a中"]));
+    expect(exitCode).toBe(0);
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
-  expect(stderr).toBe("");
-  expect(stdout).toBe(JSON.stringify(["Redémarrage", "╭─╮", "a中"]));
-  expect(exitCode).toBe(0);
-});
+  // Exercises the disk-backed transpiler cache (≥ 4 KiB threshold) via the
+  // JSC vtable `put()` path, where pre-fix `BunString::ascii` mis-tagged
+  // UTF-8 output as Latin-1 and corrupted non-ASCII on the next read.
+  test("runtime transpiler cache preserves non-ASCII (write + read)", async () => {
+    // > 4 KiB padding to clear `MINIMUM_CACHE_SIZE` and force the cache path.
+    // `Buffer.alloc(...).toString()` rather than `"x".repeat(...)` — the
+    // latter is slow on debug JSC builds.
+    const padding = "// " + Buffer.alloc(5000, "x").toString();
+    using dir = tempDir("issue-18115-cache", {
+      "fixture.js": `${padding}\nprocess.stdout.write(JSON.stringify([String.raw\`Redémarrage\`, String.raw\`╭─╮\`, String.raw\`🐰\`]))`,
+    });
+    const dirPath = String(dir);
+    const scriptPath = join(dirPath, "fixture.js");
+    const cacheDir = join(dirPath, ".cache");
 
+    const env = {
+      ...bunEnv,
+      BUN_RUNTIME_TRANSPILER_CACHE_PATH: cacheDir,
+      // Required in debug builds for the cache to be read back, not just written.
+      BUN_DEBUG_ENABLE_RESTORE_FROM_TRANSPILER_CACHE: "1",
+    };
+    const expected = JSON.stringify(["Redémarrage", "╭─╮", "🐰"]);
+
+    async function runFixture() {
+      await using proc = Bun.spawn({ cmd: [bunExe(), scriptPath], env, stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(expected);
+      expect(exitCode).toBe(0);
+    }
+
+    // First run: writes the entry via the JSC vtable `put()`.
+    await runFixture();
+
+    // Sanity: the cache must actually have been written; otherwise the
+    // second run would re-transpile and the test would pass for the wrong
+    // reason (i.e. without exercising the vtable read-back path at all).
+    expect(existsSync(cacheDir)).toBeTrue();
+    expect(readdirSync(cacheDir).length).toBeGreaterThan(0);
+
+    // Second run: serves from cache — must produce identical output.
+    await runFixture();
+  });
+});


### PR DESCRIPTION
Fixes #18115.

## Repro

<pre><code>$ bun -e 'console.log(String.raw&#96;╭─╮&#96;.length, /╭─╮/.source.length)'
# before: 18 18
# after:   3  3
</code></pre>

<pre><code>$ bun -e 'const html = String.raw; console.log(html&#96;Redémarrage&#96;)'
# before: Red\u00E9marrage   (length 16)
# after:  Redémarrage         (length 11)
</code></pre>

## Cause

Two layers cooperated to mangle the bytes:

1. **Printer.** `print_raw_template_literal` and `print_reg_exp_literal` in `src/js_printer/lib.rs` re-escaped codepoints > 0x7F to `\uXXXX`. Both `TemplateStringsArray.raw` (surfaced via `String.raw`) and `RegExp.prototype.source` are spec-required to expose source bytes verbatim, so escaping silently changed the runtime string values.

2. **JSC handoff.** Five sites cloned the printer output (or raw `source.contents`) as Latin-1 unconditionally. Once the printer emits UTF-8 bytes verbatim, `clone_latin1` mis-tags them (`Redémarrage` becomes `RedÃ©marrage`).

## Fix

- `print_raw_template_literal` / `print_reg_exp_literal` now write source bytes verbatim.

- All five `clone_latin1` sites that ingest printer output or pre-bundled source contents switch to `clone_utf8`, which auto-detects all-ASCII → Latin-1 (identical to the old fast path, zero cost) and non-ASCII → UTF-16:
  - `RuntimeTranspilerStore::transpile` (printer output)
  - `RuntimeTranspilerStore` already-bundled path
  - `AsyncModule::fulfill` (async printer output)
  - `transpile_source_code_inner` (sync printer output, `jsc_hooks`)
  - `transpile_source_code_inner` already-bundled path (`jsc_hooks`)

- `RuntimeTranspilerCache::put()` also stored printer output via `clone_latin1`, so cached entries written before this fix mis-tag UTF-8 as Latin-1. Switched to `clone_utf8` and bumped `EXPECTED_VERSION` 22 → 23 to invalidate stale entries on read.

## Test plan

- `bun bd test test/regression/issue/18115.test.ts` — 2/2 pass (`String.raw` and `RegExp.source` across Latin-1, BMP CJK, box-drawing, astral planes).
- `bun bd test test/bundler/transpiler/transpiler.test.js` — 157/157 including the new printer-level assertions covering `é`, `中`, `╭─╮`, `🐰`.
- `bun bd test test/cli/run/transpiler-cache.test.ts` — 9/9.
- Same tests **fail** under `USE_SYSTEM_BUN=1` — gate confirmed.

## Performance

Apples-to-apples, same commit, vanilla vs patched, M-series ARM64, release build:

| Workload | Δ |
|---|---|
| 2.3 MB realistic French file (no `String.raw`, lots of accents in strings/comments) | +0.2% (noise, σ ≈ 0.2 ms) |
| 450 KB pure-ASCII transpile | −0.3% (noise) |
| 510 KB adversarial heavy-`String.raw` file | +3.9% |

The +4% on `String.raw`-heavy files comes from the unavoidable UTF-8 → UTF-16 transcode (correct output cannot be served as Latin-1 when a codepoint > 0xFF appears). Tried a Latin-1-first fast path in `BunString__fromUTF8` — measured worse, reverted (`simdutf` `convert_utf8_to_latin1` validates every byte, exceeding the alloc saving).
