### PR TITLE
install: fallback to git cli if github tarball fetch fails

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -656,6 +656,64 @@ pub unsafe fn enqueue_patch_task_pre(this: &mut PackageManager, task: *mut Patch
     let _ = this.pending_pre_calc_hashes.fetch_add(1, Ordering::Relaxed);
 }
 
+fn checkout_from_git_clone(
+    this: &mut PackageManager,
+    repo_fd: Fd,
+    clone_id: Task::Id,
+    git_url: &[u8],
+    dep: &Repository,
+    res: Resolution,
+    dependency: &Dependency,
+    id: u32,
+    is_root: bool,
+    install_peer: bool,
+) -> Result<(), bun_core::Error> {
+    let alias = this.lockfile.str_detached(&dependency.name);
+    let resolved = Repository::find_commit(
+        this.env_mut(),
+        this.log_mut(),
+        repo_fd,
+        alias,
+        this.lockfile.str(&dep.committish),
+        clone_id,
+    )?;
+    let checkout_id = Task::Id::for_git_checkout(&git_url, &resolved);
+    let needs_ctx = this.lockfile.buffers.resolutions[id as usize] == invalid_package_id;
+    let entry = this
+        .task_queue
+        .get_or_put_context(checkout_id, ())
+        .expect("unreachable");
+
+    if !entry.found_existing {
+        *entry.value_ptr = TaskCallbackList::default();
+    }
+
+    if needs_ctx {
+        let ctx = if is_root {
+            TaskCallbackContext::RootDependency(id)
+        } else {
+            TaskCallbackContext::Dependency(id)
+        };
+
+        entry.value_ptr.push(ctx);
+    }
+
+    if dependency.behavior.is_peer() && !install_peer {
+        this.peer_dependencies.write_item(id)?;
+        return Ok(());
+    }
+
+    if this.has_created_network_task(checkout_id, dependency.behavior.is_required()) {
+        return Ok(());
+    }
+
+    let task = enqueue_git_checkout(this, checkout_id, repo_fd, id, alias, &res, &resolved, None);
+
+    this.task_batch.push(ThreadPool::Batch::from(task));
+
+    Ok(())
+}
+
 /// Q: "What do we do with a dependency in a package.json?"
 /// A: "We enqueue it!"
 pub fn enqueue_dependency_with_main_and_success_fn(
@@ -1212,7 +1270,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
             }
         }
         dependency::version::Tag::Git => {
-            let dep: Repository = *version.git();
+            let dep = *version.git();
             let res = Resolution::init(ResolutionTagged::Git(dep));
 
             // First: see if we already loaded the git package in-memory
@@ -1249,66 +1307,32 @@ pub fn enqueue_dependency_with_main_and_success_fn(
             }
 
             if let Some(repo_fd) = this.git_repositories.get(&clone_id).copied() {
-                let resolved = Repository::find_commit(
-                    this.env_mut(),
-                    this.log_mut(),
-                    repo_fd,
-                    alias,
-                    this.lockfile.str(&dep.committish),
-                    clone_id,
-                )?;
-                let checkout_id = Task::Id::for_git_checkout(url, &resolved);
-
-                let needs_ctx =
-                    this.lockfile.buffers.resolutions[id as usize] == invalid_package_id;
-                let entry = this
-                    .task_queue
-                    .get_or_put_context(checkout_id, ())
-                    .expect("unreachable");
-                if !entry.found_existing {
-                    *entry.value_ptr = TaskCallbackList::default();
-                }
-                if needs_ctx {
-                    entry.value_ptr.push(ctx);
-                }
-
-                if dependency.behavior.is_peer() {
-                    if !install_peer {
-                        this.peer_dependencies.write_item(id)?;
-                        return Ok(());
-                    }
-                }
-
-                if this.has_created_network_task(checkout_id, dependency.behavior.is_required()) {
-                    return Ok(());
-                }
-
-                let task = enqueue_git_checkout(
+                return checkout_from_git_clone(
                     this,
-                    checkout_id,
                     repo_fd,
+                    clone_id,
+                    url,
+                    &dep,
+                    res,
+                    dependency,
                     id,
-                    alias,
-                    &res,
-                    &resolved,
-                    None,
+                    is_root,
+                    install_peer,
                 );
-                this.task_batch.push(ThreadPool::Batch::from(task));
             } else {
                 let entry = this
                     .task_queue
                     .get_or_put_context(clone_id, ())
                     .expect("unreachable");
+
                 if !entry.found_existing {
                     *entry.value_ptr = TaskCallbackList::default();
                 }
                 entry.value_ptr.push(ctx);
 
-                if dependency.behavior.is_peer() {
-                    if !install_peer {
-                        this.peer_dependencies.write_item(id)?;
-                        return Ok(());
-                    }
+                if dependency.behavior.is_peer() && !install_peer {
+                    this.peer_dependencies.write_item(id)?;
+                    return Ok(());
                 }
 
                 if this.has_created_network_task(clone_id, dependency.behavior.is_required()) {
@@ -1317,18 +1341,41 @@ pub fn enqueue_dependency_with_main_and_success_fn(
 
                 let task =
                     enqueue_git_clone(this, clone_id, alias, &dep, id, dependency, &res, None);
+
                 this.task_batch.push(ThreadPool::Batch::from(task));
             }
+
             Ok(())
         }
         dependency::version::Tag::Github => {
-            let dep: &Repository = version.github();
+            let dep = version.github();
             let res = Resolution::init(ResolutionTagged::Github(*dep));
 
             // First: see if we already loaded the github package in-memory
             if let Some(pkg_id) = this.lockfile.get_package_id(name_hash, None, &res) {
                 success_fn(this, id, pkg_id);
                 return Ok(());
+            }
+
+            // For private repositories, the tarball may fail and fallback to a git clone.
+            // If there is a clone, resolve it via checkout but keeping the Github resolution.
+            {
+                let git_url = run_tasks::alloc_github_git_clone_url(this, dep);
+                let clone_id = Task::Id::for_git_clone(&git_url);
+                if let Some(repo_fd) = this.git_repositories.get(&clone_id).copied() {
+                    return checkout_from_git_clone(
+                        this,
+                        repo_fd,
+                        clone_id,
+                        &git_url,
+                        dep,
+                        res,
+                        dependency,
+                        id,
+                        is_root,
+                        install_peer,
+                    );
+                }
             }
 
             let url = this.alloc_github_url(dep);
@@ -1366,11 +1413,9 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 entry.value_ptr.push(ctx);
             }
 
-            if dependency.behavior.is_peer() {
-                if !install_peer {
-                    this.peer_dependencies.write_item(id)?;
-                    return Ok(());
-                }
+            if dependency.behavior.is_peer() && !install_peer {
+                this.peer_dependencies.write_item(id)?;
+                return Ok(());
             }
 
             if let Some(network_task) = run_tasks::generate_network_task_for_tarball(
@@ -1392,6 +1437,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 let nt: *mut NetworkTask = network_task;
                 enqueue_network_task(this, nt);
             }
+
             Ok(())
         }
         dependency::version::Tag::Symlink | dependency::version::Tag::Workspace => {
@@ -1717,7 +1763,7 @@ pub fn create_extract_task_for_streaming(
     init_extract_task(this, tarball, network_task)
 }
 
-fn enqueue_git_clone(
+pub fn enqueue_git_clone(
     this: &mut PackageManager,
     task_id: Task::Id,
     name: &[u8],
@@ -1825,8 +1871,10 @@ pub fn enqueue_git_checkout(
                     )
                     .expect("unreachable"),
                     url: StringOrTinyString::init_append_if_needed(
-                        // `resolution.tag == Git` for the git-checkout path.
-                        this.lockfile.str(&resolution.git().repo),
+                        // `.repository()` handles both Git and Github resolutions —
+                        // a github dep that fell back to clone (#19618) keeps its
+                        // Github resolution but checks out via this path.
+                        this.lockfile.str(&resolution.repository().repo),
                         &mut crate::network_task::filename_store_appender(),
                     )
                     .expect("unreachable"),

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1830,6 +1830,9 @@ pub fn alloc_github_git_clone_url(this: &PackageManager, repository: &Repository
     }
 
     let owner = this.lockfile.str(&repository.owner);
+    // Unlike `alloc_github_url`, we don't need to guard against an empty repo, since we validate
+    // against that upstream in `hosted_git_info`. Honestly unclear if  `alloc_github_url` needs it
+    // either. The change history that introduced the guard is about the trailing slash issue.
     let repo = this.lockfile.str(&repository.repo);
 
     let mut out = Vec::new();

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -14,8 +14,8 @@ use crate::npm;
 use crate::patch_install::{Callback as PatchTaskCallback, PatchTask};
 use crate::tarball_stream::TarballStream;
 use bun_install::{
-    DependencyID, ExtractTarball, INVALID_PACKAGE_ID, NetworkTask, PackageID, PackageManifestError,
-    Repository,
+    Dependency, DependencyID, ExtractTarball, INVALID_PACKAGE_ID, NetworkTask, PackageID,
+    PackageManifestError, Repository, Resolution,
 };
 // `Task::Id` etc. are namespaced types in Zig (`PackageManagerTask.Id`); import
 // the *module* under the `Task` name so `Task::Id` resolves as a path.
@@ -815,6 +815,73 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     let is_required = manager.is_network_task_required(task.task_id);
                     let _ = manager.network_dedupe_map.remove(&task.task_id);
 
+                    // Private repositories will 404 on the tarball fetch. Match npm
+                    // and fallback to invoke a git clone which uses the user's stored
+                    // credentials.
+                    // We keep the Github resolution (rather than swap to Git) and just
+                    // swap the task for a clone task. PackageManager's Github resolution
+                    // path has a corresponding branch for handling clones.
+                    if extract.resolution.tag == bun_install::ResolutionTag::Github {
+                        let github_res: Resolution = extract.resolution;
+                        let github_repo: Repository = *github_res.github();
+                        let url = alloc_github_git_clone_url(manager, &github_repo);
+
+                        // `enqueue_git_clone` reads the clone URL from
+                        // `Repository.repo`; append the github git URL to the
+                        // lockfile string buffer so the handle is valid. This repo
+                        // is only used for the clone URL — the stored resolution
+                        // stays `github_res`.
+                        let url_repo = {
+                            let mut builder = manager.lockfile.string_builder();
+                            builder.count(&url);
+                            builder.allocate()?;
+                            Repository {
+                                repo: builder.append::<bun_semver::String>(&url),
+                                ..Default::default()
+                            }
+                        };
+
+                        let clone_id = Task::Id::for_git_clone(&url);
+
+                        // Move the failed tarball task's waiters onto the clone
+                        // task so they resolve when the clone→checkout completes.
+                        {
+                            let waiters =
+                                manager.task_queue.remove(&task.task_id).unwrap_or_default();
+                            let entry = manager
+                                .task_queue
+                                .get_or_put_context(clone_id, ())
+                                .expect("unreachable");
+                            if entry.found_existing {
+                                entry.value_ptr.extend(waiters);
+                            } else {
+                                *entry.value_ptr = waiters;
+                            }
+                        }
+
+                        if !manager.has_created_network_task(clone_id, is_required) {
+                            // Clone the dependency (and copy the name) out before
+                            // the `&mut manager` enqueue borrow — `Dependency` is
+                            // `Clone` (its `Version` holds a union, so not `Copy`).
+                            let dependency: Dependency = manager.lockfile.buffers.dependencies
+                                [extract.dependency_id as usize]
+                                .clone();
+                            let name = extract.name.slice().to_vec();
+                            let task_ptr = enqueue::enqueue_git_clone(
+                                manager,
+                                clone_id,
+                                &name,
+                                &url_repo,
+                                extract.dependency_id,
+                                &dependency,
+                                &github_res,
+                                None,
+                            );
+                            manager.task_batch.push(ThreadPoolBatch::from(task_ptr));
+                        }
+                        continue;
+                    }
+
                     if C::HAS_ON_PACKAGE_DOWNLOAD_ERROR {
                         let err = match response.status_code {
                             400 => bun_core::err!("TarballHTTP400"),
@@ -1341,7 +1408,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             // SAFETY: `clone.res.tag == Git` — git-clone tasks are
                             // only enqueued for git resolutions; `value.git` is
                             // the active union arm.
-                            let resolved = &clone.res.git().resolved;
+                            let resolved = &clone.res.repository().resolved;
                             let checkout_id =
                                 Task::Id::for_git_checkout(url, manager.lockfile.str(resolved));
                             C::on_package_download_error_store(
@@ -1384,7 +1451,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     };
                     // SAFETY: `clone.res.tag == Git` — git-clone tasks are only
                     // enqueued for git resolutions; `value.git` is the active arm.
-                    let git = *clone.res.git();
+                    let git = *clone.res.repository();
                     // SAFETY: `string_bytes` lives as long as `manager.lockfile`
                     // and is not reallocated while resolve tasks are draining
                     // (Zig: same buffer is read after `enqueueGitCheckout`).
@@ -1464,7 +1531,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         // SAFETY: `resolution.tag == Git` — git-checkout tasks are
                         // only enqueued for git resolutions; `value.git` is the
                         // active union arm.
-                        let repo = &resolution.git().repo;
+                        let repo = &resolution.repository().repo;
                         C::on_package_download_error_store(
                             extract_ctx,
                             task.id,
@@ -1552,7 +1619,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                                     };
                                     // SAFETY: `pkg.resolution.value` is a Zig `extern union`;
                                     // `Tag::Git` was checked when the resolution was set.
-                                    repo.resolved = pkg.resolution.git().resolved;
+                                    repo.resolved = pkg.resolution.repository().resolved;
                                     repo.package_name = pkg.name;
                                     manager.process_dependency_list_item(
                                         &dep,
@@ -1749,6 +1816,25 @@ pub fn alloc_github_url(this: &PackageManager, repository: &Repository) -> Vec<u
         // repo might be empty if dep is https://github.com/... style
         if !repo.is_empty() { "/" } else { "" },
         bstr::BStr::new(committish),
+    )
+    .expect("unreachable");
+    out
+}
+
+/// The github **git** clone URL (`https://github.com/<owner>/<repo>.git`), as
+/// opposed to [`alloc_github_url`] which builds the api.github.com *tarball*
+/// URL. Used by the tarball→clone fallback (#19618): cloning goes to github.com
+/// proper so `git`'s credential handling applies (matching npm's GitFetcher),
+/// which is why `GITHUB_API_URL` is intentionally not consulted here.
+pub fn alloc_github_git_clone_url(this: &PackageManager, repository: &Repository) -> Vec<u8> {
+    let owner = this.lockfile.str(&repository.owner);
+    let repo = this.lockfile.str(&repository.repo);
+    let mut out = Vec::new();
+    write!(
+        &mut out,
+        "https://github.com/{}/{}.git",
+        bstr::BStr::new(owner),
+        bstr::BStr::new(repo),
     )
     .expect("unreachable");
     out

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1821,18 +1821,22 @@ pub fn alloc_github_url(this: &PackageManager, repository: &Repository) -> Vec<u
     out
 }
 
-/// The github **git** clone URL (`https://github.com/<owner>/<repo>.git`), as
-/// opposed to [`alloc_github_url`] which builds the api.github.com *tarball*
-/// URL. Used by the tarball→clone fallback (#19618): cloning goes to github.com
-/// proper so `git`'s credential handling applies (matching npm's GitFetcher),
-/// which is why `GITHUB_API_URL` is intentionally not consulted here.
 pub fn alloc_github_git_clone_url(this: &PackageManager, repository: &Repository) -> Vec<u8> {
+    let mut github_server_url: &[u8] = b"https://github.com";
+    if let Some(url) = this.env().get(b"GITHUB_SERVER_URL") {
+        if !url.is_empty() {
+            github_server_url = url;
+        }
+    }
+
     let owner = this.lockfile.str(&repository.owner);
     let repo = this.lockfile.str(&repository.repo);
+
     let mut out = Vec::new();
     write!(
         &mut out,
-        "https://github.com/{}/{}.git",
+        "{}/{}/{}.git",
+        bstr::BStr::new(strings::without_trailing_slash(github_server_url)),
         bstr::BStr::new(owner),
         bstr::BStr::new(repo),
     )

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -508,6 +508,7 @@ impl<'a> Task<'a> {
                         git_checkout.name.slice(),
                         git_checkout.url.slice(),
                         git_checkout.resolved.slice(),
+                        git_checkout.resolution.tag == bun_install::ResolutionTag::Github,
                     ) {
                         Ok(v) => v,
                         Err(err) => {

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -362,6 +362,10 @@ pub trait RepositoryExt: Sized {
         name: &[u8],
         url: &[u8],
         resolved: &[u8],
+        // When the resolution is `Github` (e.g. a github dep that fell back to
+        // `git clone` after its tarball errored, #19618), check out into the
+        // `@GH@` cache folder so it matches how a github resolution installs.
+        is_github: bool,
     ) -> Result<ExtractData, Error>;
 }
 
@@ -838,6 +842,7 @@ impl RepositoryExt for Repository {
         name: &[u8],
         url: &[u8],
         resolved: &[u8],
+        is_github: bool,
     ) -> Result<ExtractData, Error> {
         // `cache_dir`/`repo_dir` are borrowed views; only `package_dir` is owned.
         bun_analytics::features::git_dependencies
@@ -857,11 +862,19 @@ impl RepositoryExt for Repository {
         }
 
         let folder_name_buf = TlBufs::folder_name_buf();
-        let folder_name = crate::package_manager_real::cached_git_folder_name_print(
-            &mut folder_name_buf[..],
-            resolved,
-            None,
-        )
+        let folder_name = if is_github {
+            crate::package_manager_real::cached_github_folder_name_print(
+                &mut folder_name_buf[..],
+                resolved,
+                None,
+            )
+        } else {
+            crate::package_manager_real::cached_git_folder_name_print(
+                &mut folder_name_buf[..],
+                resolved,
+                None,
+            )
+        }
         .as_bytes();
 
         let package_dir = match bun_sys::Dir::borrow(&cache_dir)

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -63,6 +63,76 @@ async function withContext(
   }
 }
 
+// Helper function to mock a private repository. Works by creating the repo locally and
+// using a binstub to rewrite arguments to git. Requires passing the returned env to bun.
+const mockGitClone = async (ctx, { privateRepository, repositoryUrl }) => {
+  const gitPath = Bun.which("git") ?? "usr/bin/git";
+
+  // create a mock private repository fixture
+
+  const packageVersion = "9.9.9";
+
+  const privateRepositorityFixturePath = join(ctx.package_dir, privateRepository);
+  mkdir(privateRepositorityFixturePath);
+
+  await writeFile(
+    join(privateRepositorityFixturePath, "package.json"),
+    JSON.stringify({ name: privateRepository, version: packageVersion }),
+  );
+  await writeFile(join(privateRepositorityFixturePath, "index.js"), `module.exports = "privateGitPackage";`);
+
+  const gitFix = async (...args: string[]) => {
+    await using p = Bun.spawn({
+      cmd: [gitPath, "-c", "user.email=t@bun.sh", "-c", "user.name=bun-test", ...args],
+      cwd: privateRepositorityFixturePath,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    if ((await p.exited) !== 0) throw new Error(await p.stderr.text());
+  };
+  await gitFix("init", "-b", "main");
+  await gitFix("add", "-A");
+  await gitFix("commit", "-m", "init");
+
+  // create a git binstub to rewrite our private repo git string
+  // before passing to actual git
+
+  const binariesPath = join(ctx.package_dir, "bin");
+  mkdir(binariesPath);
+
+  const gitBinstubPath = join(binariesPath, "git");
+
+  await writeFile(
+    gitBinstubPath,
+    `#!/bin/sh
+
+      args=
+
+      # capture any github strings and replace with our mocked repository.
+      for a in "$@"; do
+        if [ "$a" = ${repositoryUrl} ]; then
+          a="${privateRepositorityFixturePath}"
+        fi;
+
+        args="$args $a";
+      done
+
+      # call actual git
+      exec "${gitPath}" $args
+    `,
+  );
+
+  Bun.spawnSync({ cmd: ["chmod", "755", gitBinstubPath], env: bunEnv });
+
+  const env = {
+    ...bunEnv,
+    PATH: `${binariesPath}:${bunEnv.PATH ?? process.env.PATH}`,
+  };
+
+  return { env, packageVersion };
+};
+
 // Default context options for most tests
 const defaultOpts = { linker: "hoisted" as const };
 
@@ -8847,6 +8917,87 @@ describe.concurrent("bun-install", () => {
       expect(err).toContain("warn: InvalidURL");
 
       expect(await exited).toBe(0);
+    });
+  });
+
+  describe("private git repositories", () => {
+    it("falls back to git clone when the tarball 4xxs", async () => {
+      const privateRepository = `private-${Math.random().toString(36).slice(2)}`;
+      const repositoryUrl = `https://github.com/${privateRepository}/repo.git`;
+
+      await withContext(defaultOpts, async ctx => {
+        let urls: string[] = [];
+
+        setContextHandler(ctx, dummyRegistryForContext(ctx, urls));
+
+        const { env, packageVersion } = await mockGitClone(ctx, { privateRepository, repositoryUrl });
+
+        await writeFile(
+          join(ctx.package_dir, "package.json"),
+          JSON.stringify({
+            name: "app",
+            version: "1.0.0",
+            dependencies: {
+              privateGitPackage: `git+${repositoryUrl}`,
+            },
+          }),
+        );
+
+        const { stdout, stderr, exited } = spawn({
+          cmd: [bunExe(), "install"],
+          cwd: ctx.package_dir,
+          stdout: "pipe",
+          stdin: "pipe",
+          stderr: "pipe",
+          env,
+        });
+
+        expect(await exited).toBe(0);
+
+        // Resolving dependencies
+        // Resolved, downloaded and extracted [3]
+        // Saved lockfile
+        let err = await stderr.text();
+        expect(err).toContain("Saved lockfile");
+
+        // bun install v1.4.0 (9278a1d35)
+        //
+        // + privateGitPackage@github:private-fpnib1pvev/repo#0f2edc4e2f080edea1ad3997477f3c6fa7612fa0
+        //
+        // 1 package installed [507.00ms]
+        let out = await stdout.text();
+        out = out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "");
+        out = out.replace(/(github:[^#]+)#[a-f0-9]+/, "$1");
+        expect(out.split(/\r?\n/)).toEqual([
+          expect.stringContaining("bun install v1."),
+          "",
+          `+ privateGitPackage@github:${privateRepository}/repo`,
+          "",
+          "1 package installed",
+        ]);
+
+        expect(await readdirSorted(join(ctx.package_dir, "node_modules", "privateGitPackage"))).toContain(
+          "package.json",
+        );
+        const package_json = await file(
+          join(ctx.package_dir, "node_modules", "privateGitPackage", "package.json"),
+        ).json();
+        expect(package_json.name).toBe(privateRepository);
+        expect(package_json.version).toBe(packageVersion);
+
+        // ensure resolution matches despite using the fallback clone method
+        const { stderr: frozenErr } = spawn({
+          cmd: [bunExe(), "install", "--frozen-lockfile"],
+          cwd: ctx.package_dir,
+          stdout: "pipe",
+          stdin: "pipe",
+          stderr: "pipe",
+          env,
+        });
+
+        err = await frozenErr.text();
+        expect(err).not.toContain("lockfile had changes, but lockfile is frozen");
+      });
     });
   });
 

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -66,14 +66,14 @@ async function withContext(
 // Helper function to mock a private repository. Works by creating the repo locally and
 // using a binstub to rewrite arguments to git. Requires passing the returned env to bun.
 const mockGitClone = async (ctx, { privateRepository, repositoryUrl }) => {
-  const gitPath = Bun.which("git") ?? "usr/bin/git";
+  const gitPath = Bun.which("git") ?? "/usr/bin/git";
 
   // create a mock private repository fixture
 
   const packageVersion = "9.9.9";
 
   const privateRepositorityFixturePath = join(ctx.package_dir, privateRepository);
-  mkdir(privateRepositorityFixturePath);
+  await mkdir(privateRepositorityFixturePath);
 
   await writeFile(
     join(privateRepositorityFixturePath, "package.json"),
@@ -99,7 +99,7 @@ const mockGitClone = async (ctx, { privateRepository, repositoryUrl }) => {
   // before passing to actual git
 
   const binariesPath = join(ctx.package_dir, "bin");
-  mkdir(binariesPath);
+  await mkdir(binariesPath);
 
   const gitBinstubPath = join(binariesPath, "git");
 
@@ -8952,8 +8952,6 @@ describe.concurrent("bun-install", () => {
           env,
         });
 
-        expect(await exited).toBe(0);
-
         // Resolving dependencies
         // Resolved, downloaded and extracted [3]
         // Saved lockfile
@@ -8975,6 +8973,8 @@ describe.concurrent("bun-install", () => {
           "",
           "1 package installed",
         ]);
+
+        expect(await exited).toBe(0);
 
         expect(await readdirSorted(join(ctx.package_dir, "node_modules", "privateGitPackage"))).toContain(
           "package.json",

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -8920,7 +8920,9 @@ describe.concurrent("bun-install", () => {
     });
   });
 
-  describe("private git repositories", () => {
+  // skip test on windows to avoid writing separate windows-specific shim for `mockGitClone`.
+  // behavior is OS-agnostic so doesn't need platform-specific testing.
+  describe.skipIf(isWindows)("private git repositories", () => {
     it("falls back to git clone when the tarball 4xxs", async () => {
       const privateRepository = `private-${Math.random().toString(36).slice(2)}`;
       const repositoryUrl = `https://github.com/${privateRepository}/repo.git`;


### PR DESCRIPTION
### What does this PR do?

This PR adds a `git clone` fallback to Github package resolutions during `bun install`, [mirroring NPM's handling](https://github.com/npm/pacote/blob/e0af7f6a49880895817aa863f99747b102495f93/lib/git.js#L261-L268) to allow installing packages from private repositories. NPM's handling feels slightly more DRY since it does not differentiate between Github and general Git resolutions, [instead inlining the Github tarball fetch optimization as part of the Git resolution path](https://github.com/npm/pacote/blob/e0af7f6a49880895817aa863f99747b102495f93/lib/git.js#L248-L249). I'm not familiar enough with the nuances to know if this is a reasonable refactor to suggest for Bun.  

This PR closes https://github.com/oven-sh/bun/issues/19618. 

### How did you verify your code works?

I have added a test:
* It mocks `git clone` using a binstub injected into the path to rewrite the github url to a local fixture repository. 
* It verifies that the git clone fallback branch is hit. 
* It verifies that the Github resolution re-resolves to the git clone on subsequent install via `--frozen-lockfile`. 

### Note

I am using this as a means of learning Rust and am not familiar with either Bun or Rust idioms, so I look forward to any feedback. I had Claude help me get started and understand the code paths required. 
