### PR TITLE
ws: forward top-level TLS options (rejectUnauthorized, ca, ...) to the connection

### DIFF
--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -30,6 +30,94 @@ function sendAfterClose(state, cb) {
   }
 }
 
+// Module-load captures; user code cannot reassign these later.
+const ObjectPrototypeHasOwnProperty = Object.prototype.hasOwnProperty;
+const ArrayBufferIsView = ArrayBuffer.isView;
+const NativeArrayBuffer = ArrayBuffer;
+const NativeBlob = Blob;
+
+// Top-level TLS keys SSLConfig.fromJS parses, by how each is copied.
+const TLS_BOOL = 0; // copied unless undefined (keeps an explicit false)
+const TLS_SCALAR = 1; // copied unless null or undefined (keeps an explicit 0 or "")
+const TLS_FILE = 2; // copied only when truthy (SSLConfig reads `ca: ""` as an empty CA set)
+const tlsKeyKinds = {
+  __proto__: null,
+  rejectUnauthorized: TLS_BOOL,
+  requestCert: TLS_BOOL,
+  lowMemoryMode: TLS_BOOL,
+  allowPartialTrustChain: TLS_BOOL,
+  passphrase: TLS_SCALAR,
+  secureOptions: TLS_SCALAR,
+  clientRenegotiationLimit: TLS_SCALAR,
+  clientRenegotiationWindow: TLS_SCALAR,
+  ca: TLS_FILE,
+  cert: TLS_FILE,
+  key: TLS_FILE,
+  crl: TLS_FILE,
+  dhParamsFile: TLS_FILE,
+  keyFile: TLS_FILE,
+  certFile: TLS_FILE,
+  caFile: TLS_FILE,
+  servername: TLS_FILE,
+  serverName: TLS_FILE,
+  ciphers: TLS_FILE,
+  sigalgs: TLS_FILE,
+  ecdhCurve: TLS_FILE,
+};
+const tlsKeys = Object.keys(tlsKeyKinds);
+
+// The only connectOpts keys HttpsProxyAgent sets that SSLConfig.fromJS accepts.
+const agentTlsKeys = ["rejectUnauthorized", "ca", "cert", "key", "passphrase"];
+
+// ws accepts `{ pem, passphrase }` for key/cert; SSLConfig.fromJS throws on it.
+function isForwardableFileValue(value) {
+  if (!value) return false;
+  if ($isJSArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      if (!isRepresentableFileElement(value[i])) return false;
+    }
+    return true;
+  }
+  return isRepresentableFileElement(value);
+}
+
+function isRepresentableFileElement(value) {
+  return (
+    !$isObject(value) ||
+    ArrayBufferIsView(value) ||
+    $isTypedArrayView(value) ||
+    value instanceof NativeBlob ||
+    value instanceof NativeArrayBuffer
+  );
+}
+
+// Reads own properties only; Object.prototype is never consulted.
+function extractTlsOptions(source, keys = tlsKeys) {
+  if (!$isObject(source)) return null;
+
+  let tls = null;
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    if (!ObjectPrototypeHasOwnProperty.$call(source, key)) continue;
+    const value = source[key];
+    let keep;
+    switch (tlsKeyKinds[key]) {
+      case TLS_BOOL:
+        keep = value !== undefined;
+        break;
+      case TLS_SCALAR:
+        keep = value != null;
+        break;
+      default:
+        keep = isForwardableFileValue(value);
+    }
+    if (keep) {
+      (tls ??= { __proto__: null })[key] = value;
+    }
+  }
+  return tls;
+}
+
 /**
  * Extracts TLS and proxy options from an agent object.
  * @param {Object} agent The agent object to extract options from
@@ -37,40 +125,9 @@ function sendAfterClose(state, cb) {
  */
 function extractAgentOptions(agent) {
   const connectOpts = agent?.connectOpts || agent?.options;
-  let tls = null;
   let proxy = null;
 
-  if ($isObject(connectOpts)) {
-    // Build TLS options
-    const newTlsOptions = {};
-    let hasTlsOptions = false;
-
-    const { rejectUnauthorized, ca, cert, key, passphrase } = connectOpts;
-    if (rejectUnauthorized !== undefined) {
-      newTlsOptions.rejectUnauthorized = rejectUnauthorized;
-      hasTlsOptions = true;
-    }
-    if (ca) {
-      newTlsOptions.ca = ca;
-      hasTlsOptions = true;
-    }
-    if (cert) {
-      newTlsOptions.cert = cert;
-      hasTlsOptions = true;
-    }
-    if (key) {
-      newTlsOptions.key = key;
-      hasTlsOptions = true;
-    }
-    if (passphrase) {
-      newTlsOptions.passphrase = passphrase;
-      hasTlsOptions = true;
-    }
-
-    if (hasTlsOptions) {
-      tls = newTlsOptions;
-    }
-  }
+  const tls = extractTlsOptions(connectOpts, agentTlsKeys);
 
   // Build proxy - check connectOpts.proxy first, then agent.proxy
   const agentProxy = connectOpts?.proxy || agent?.proxy;
@@ -202,7 +259,9 @@ class BunWebSocket extends EventEmitter {
     if ($isObject(options)) {
       headers = options?.headers;
       proxy = options?.proxy;
-      tlsOptions = options?.tls;
+      // Bun's own `tls` object wins over ws-style top-level TLS options.
+      const explicitTls = $isObject(options.tls);
+      tlsOptions = explicitTls ? options.tls : extractTlsOptions(options);
       if ("perMessageDeflate" in options && !options.perMessageDeflate) {
         disableDeflate = true;
       }
@@ -215,8 +274,9 @@ class BunWebSocket extends EventEmitter {
         if (!proxy && agentProxy) {
           proxy = agentProxy;
         }
-        if (!tlsOptions && agentTls) {
-          tlsOptions = agentTls;
+        // Agent TLS is for the proxy hop; an explicit `tls` object takes precedence.
+        if (!explicitTls && agentTls) {
+          tlsOptions = tlsOptions ? { __proto__: null, ...agentTls, ...tlsOptions } : agentTls;
         }
       }
     }

--- a/test/js/first_party/ws/ws-tls-options.test.ts
+++ b/test/js/first_party/ws/ws-tls-options.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe, tls as tlsCert } from "harness";
+import WebSocket from "ws";
+
+// https://github.com/oven-sh/bun/issues/31396
+//
+// The npm `ws` package accepts TLS options as top-level options on the
+// WebSocket constructor and forwards them to https.request/tls.connect:
+//
+//   new WebSocket("wss://host", { rejectUnauthorized: false });
+//
+// Bun's `ws` shim only read TLS options from `options.tls`, so top-level keys
+// like `rejectUnauthorized: false` were dropped and connecting to a self-signed
+// `wss://` server failed with "TLS handshake failed".
+describe("ws top-level TLS options", () => {
+  function serveTls() {
+    return Bun.serve({
+      port: 0,
+      tls: { key: tlsCert.key, cert: tlsCert.cert },
+      fetch(req, server) {
+        if (server.upgrade(req)) return;
+        return new Response("expected websocket", { status: 400 });
+      },
+      websocket: {
+        open(ws) {
+          ws.close();
+        },
+        message() {},
+      },
+    });
+  }
+
+  it("rejectUnauthorized: false connects to a self-signed server", async () => {
+    await using server = serveTls();
+    const { resolve, reject, promise } = Promise.withResolvers<void>();
+
+    const ws = new WebSocket(`wss://localhost:${server.port}`, { rejectUnauthorized: false });
+    ws.on("open", () => {
+      ws.close();
+      resolve();
+    });
+    ws.on("error", reject);
+
+    await promise;
+  });
+
+  it("a self-signed server is still rejected without rejectUnauthorized: false", async () => {
+    await using server = serveTls();
+    const { resolve, reject, promise } = Promise.withResolvers<{ message: string }>();
+
+    const ws = new WebSocket(`wss://localhost:${server.port}`);
+    ws.on("open", () => reject(new Error("unexpectedly connected to a self-signed server")));
+    ws.on("error", resolve);
+
+    const err = await promise;
+    expect(err.message).toContain("TLS handshake failed");
+  });
+
+  // The agent's `ca` must still reach the handshake when a top-level TLS key
+  // is present: the self-signed cert is its own CA, so with the default
+  // `rejectUnauthorized: true` the connection only opens if `ca` was kept.
+  it("keeps agent TLS options alongside top-level TLS options", async () => {
+    await using server = serveTls();
+    const { resolve, reject, promise } = Promise.withResolvers<void>();
+
+    const agent = { connectOpts: { ca: tlsCert.cert } };
+    const ws = new WebSocket(`wss://localhost:${server.port}`, { agent, servername: "localhost" });
+    ws.on("open", () => {
+      ws.close();
+      resolve();
+    });
+    ws.on("error", reject);
+
+    await promise;
+  });
+
+  // On a conflict the top-level key wins: the agent says `rejectUnauthorized:
+  // false` but the top level says `true`, so the self-signed server is rejected.
+  // Reversing the merge order would let the agent's `false` win and connect.
+  it("top-level TLS options win over the agent on conflict", async () => {
+    await using server = serveTls();
+    const { resolve, reject, promise } = Promise.withResolvers<{ message: string }>();
+
+    const agent = { connectOpts: { rejectUnauthorized: false } };
+    const ws = new WebSocket(`wss://localhost:${server.port}`, { agent, rejectUnauthorized: true });
+    ws.on("open", () => reject(new Error("agent rejectUnauthorized:false won over the top-level true")));
+    ws.on("error", resolve);
+
+    const err = await promise;
+    expect(err.message).toContain("TLS handshake failed");
+  });
+
+  // Node/`ws` accept `ALPNProtocols` as a string[], but Bun's native TLS parser
+  // only takes string/ArrayBuffer/null. Forwarding the array form used to throw
+  // a TypeError from the constructor; it must stay a no-op (WebSocket negotiates
+  // subprotocols over Sec-WebSocket-Protocol, not TLS ALPN) so the rest of the
+  // options still apply and the connection proceeds.
+  it("ignores a string[] ALPNProtocols instead of throwing", async () => {
+    await using server = serveTls();
+    const { resolve, reject, promise } = Promise.withResolvers<void>();
+
+    const ws = new WebSocket(`wss://localhost:${server.port}`, {
+      rejectUnauthorized: false,
+      ALPNProtocols: ["http/1.1"],
+    });
+    ws.on("open", () => {
+      ws.close();
+      resolve();
+    });
+    ws.on("error", reject);
+
+    await promise;
+  });
+
+  // Node/`ws` accept `key`/`cert` as an array of `{ pem, passphrase }` objects
+  // (per-key passphrases), but Bun's native parser only understands
+  // string/ArrayBuffer/Blob (or arrays of those). Forwarding the object-array
+  // form used to throw a TypeError from the constructor; it must stay a no-op
+  // (as it was before top-level TLS forwarding) so construction doesn't throw.
+  it("ignores an object-array key instead of throwing", async () => {
+    await using server = serveTls();
+    const { resolve, reject, promise } = Promise.withResolvers<void>();
+
+    // The server doesn't request a client cert, so dropping the unparseable key
+    // is harmless and the connection still opens with rejectUnauthorized: false.
+    const ws = new WebSocket(`wss://localhost:${server.port}`, {
+      rejectUnauthorized: false,
+      key: [{ pem: tlsCert.key, passphrase: "" }],
+      cert: tlsCert.cert,
+    });
+    ws.on("open", () => {
+      ws.close();
+      resolve();
+    });
+    ws.on("error", reject);
+
+    await promise;
+  });
+
+  // The bare (non-array) `{ pem, passphrase }` object form must behave the same
+  // as the array-wrapped form above: the native parser has no arm for a plain
+  // object, so it's skipped rather than forwarded into a constructor throw.
+  it("ignores a bare object key instead of throwing", async () => {
+    await using server = serveTls();
+    const { resolve, reject, promise } = Promise.withResolvers<void>();
+
+    const ws = new WebSocket(`wss://localhost:${server.port}`, {
+      rejectUnauthorized: false,
+      key: { pem: tlsCert.key, passphrase: "" },
+      cert: tlsCert.cert,
+    });
+    ws.on("open", () => {
+      ws.close();
+      resolve();
+    });
+    ws.on("error", reject);
+
+    await promise;
+  });
+
+  // An explicit Bun `tls` object is a hard override: an agent's connect options
+  // (which target the proxy hop) must not leak into it. Here the explicit `tls`
+  // leaves `rejectUnauthorized` at its default (true) while the agent carries
+  // `rejectUnauthorized: false`. The agent's value must not disable target
+  // verification, so the self-signed server is still rejected.
+  it("keeps an explicit tls object authoritative over agent options", async () => {
+    await using server = serveTls();
+    const { resolve, reject, promise } = Promise.withResolvers<{ message: string }>();
+
+    const agent = { connectOpts: { rejectUnauthorized: false } };
+    const ws = new WebSocket(`wss://localhost:${server.port}`, { tls: {}, agent });
+    ws.on("open", () => reject(new Error("agent rejectUnauthorized:false leaked into explicit tls")));
+    ws.on("error", resolve);
+
+    const err = await promise;
+    expect(err.message).toContain("TLS handshake failed");
+  });
+
+  // These mutate globals, so each runs in its own process. The script prints
+  // "open" or "error:<message>" and the parent asserts on that.
+  async function runInChild(script: string): Promise<string> {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return stdout.trim();
+  }
+
+  const childPreamble = `
+    import WebSocket from "ws";
+    const tls = ${JSON.stringify({ key: tlsCert.key, cert: tlsCert.cert })};
+    const server = Bun.serve({
+      port: 0,
+      tls,
+      fetch(req, s) { if (s.upgrade(req)) return; return new Response("", { status: 400 }); },
+      websocket: { open(ws) { ws.close(); }, message() {} },
+    });
+    function connect(options) {
+      return new Promise(resolve => {
+        const ws = new WebSocket("wss://localhost:" + server.port, options);
+        ws.on("open", () => { ws.close(); resolve("open"); });
+        ws.on("error", e => resolve("error:" + e.message));
+      });
+    }
+  `;
+
+  // A polluted Object.prototype.rejectUnauthorized must not disable
+  // verification: only own properties of the options object are read.
+  it("ignores a polluted Object.prototype.rejectUnauthorized", async () => {
+    const out = await runInChild(`${childPreamble}
+      Object.prototype.rejectUnauthorized = false;
+      Object.prototype.allowPartialTrustChain = true;
+      console.log(await connect({}));
+      server.stop(true);
+    `);
+    expect(out).toContain("error:");
+    expect(out).toContain("TLS handshake failed");
+  });
+
+  // The file-shape check must use the ArrayBuffer.isView captured at module
+  // load. A Buffer key reaches that check (a string short-circuits before it),
+  // so a live ArrayBuffer.isView lookup would throw here and fail the test.
+  it("still forwards a Buffer key after ArrayBuffer.isView is clobbered", async () => {
+    const out = await runInChild(`${childPreamble}
+      ArrayBuffer.isView = () => { throw new Error("clobbered"); };
+      console.log(await connect({
+        rejectUnauthorized: false,
+        key: [Buffer.from(tls.key)],
+        cert: Buffer.from(tls.cert),
+      }));
+      server.stop(true);
+    `);
+    expect(out).toBe("open");
+  });
+});


### PR DESCRIPTION
### What

The npm `ws` package accepts TLS options as **top-level** options on the `WebSocket` client constructor and forwards them to the underlying `https.request`/`tls.connect`:

```js
new WebSocket("wss://localhost:8443", { rejectUnauthorized: false });
```

Bun's `ws` shim (`src/js/thirdparty/ws.js`) only read TLS options from `options.tls` (Bun's internal shape) or from an `agent`. It never read the top-level keys, so `rejectUnauthorized: false` was silently dropped and connecting to a self-signed `wss://` server failed with `TLS handshake failed`.

Fixes #31396.

### Reproduction

```js
import WebSocket from "ws";
// wss:// server with a self-signed cert
const ws = new WebSocket(`wss://localhost:${port}`, { rejectUnauthorized: false });
ws.on("open", () => console.log("open"));   // never fired
ws.on("error", err => console.error(err.message)); // "TLS handshake failed"
```

Node connects; Bun failed. Passing the same option via Bun's `tls: { rejectUnauthorized: false }` shape already worked — proving the native TLS layer was fine and the bug was purely option plumbing in the shim.

### Cause

In the constructor, TLS was read only from `options.tls`:

```js
tlsOptions = options?.tls;
```

Top-level `rejectUnauthorized`/`ca`/`cert`/`key`/… were never consulted.

### Fix

When no explicit `options.tls` object is given, collect the TLS keys the native WebSocket understands (the set `SSLConfig.fromJS` parses) off the top-level `options`:

```js
tlsOptions = $isObject(options.tls) ? options.tls : extractTlsOptions(options);
```

- An explicit `options.tls` stays authoritative, preserving Bun's existing shape.
- Booleans (`rejectUnauthorized`, …) are forwarded with a `!== undefined` check so an explicit `false` is honored.
- The agent path (`HttpsProxyAgent`, …) keeps its conservative key subset — agents put connection options in `connectOpts` that aren't all valid Bun TLS options (e.g. an array-form `ALPNProtocols`, which `SSLConfig.fromJS` rejects).

### Verification

New tests in `test/js/first_party/ws/ws-tls-options.test.ts` (alongside the existing `ws-proxy.test.ts`) stand up a self-signed `wss://` server via `Bun.serve({ tls })` and connect through the `ws` shim:

- `rejectUnauthorized: false` connects (fails before this change, passes after).
- Without the option, the self-signed server is still rejected (the option is actually doing something).
- An agent carrying `ca` plus a top-level `servername` connects — both TLS sources reach the handshake, covering the merge path.

The `ws` and `ws-proxy` suites are otherwise unchanged from their baseline.

