### PR TITLE
Fix use-after-free in AggregateError creation for multi-error module loads

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2558,14 +2558,18 @@ pub fn process_fetch_log(
         }
 
         _ => {
-            // Spec caps at 256 (`var errors_stack: [256]JSValue`). PERF(port):
-            // was inline switch — Zig stack-allocated; we heap-allocate the
-            // exact `len` since `JSValue` is a thin u64 and 256 * 8 B = 2 KiB
-            // is fine either way, but `Vec` avoids the uninit-array dance.
-            let len = log.msgs.len().min(256);
-            let mut errors: alloc::vec::Vec<JSValue> = alloc::vec::Vec::with_capacity(len);
-            for msg in log.msgs.drain(..len) {
-                let v = match msg.metadata {
+            // Spec caps at 256 (`var errors_stack: [256]JSValue`). The array
+            // must stay on the stack like the Zig spec: until
+            // `create_aggregate_error` runs, these freshly created
+            // BuildMessage/ResolveMessage wrappers have no other GC-visible
+            // reference, and `create()` can trigger a collection mid-loop.
+            // JSC's conservative scan only covers the stack/registers, so a
+            // heap `Vec<JSValue>` would let earlier wrappers be swept (and
+            // their native payloads freed) before the AggregateError exists.
+            let mut errors_stack = [JSValue::ZERO; 256];
+            let len = log.msgs.len().min(errors_stack.len());
+            for (i, msg) in log.msgs.drain(..len).enumerate() {
+                errors_stack[i] = match msg.metadata {
                     bun_ast::Metadata::Build => take(BuildMessage::create(global_this, msg)),
                     bun_ast::Metadata::Resolve(_) => take(ResolveMessage::create(
                         global_this,
@@ -2573,8 +2577,8 @@ pub fn process_fetch_log(
                         referrer_utf8.slice(),
                     )),
                 };
-                errors.push(v);
             }
+            let errors = &errors_stack[..len];
 
             // C++ `Zig::toString` does `createWithoutCopying`, so the buffer
             // must outlive the AggregateError. Mark it global so JSC adopts it
@@ -2588,7 +2592,7 @@ pub fn process_fetch_log(
             message.mark_global();
             *ret = ErrorableResolvedSource::err(
                 err,
-                take(global_this.create_aggregate_error(&errors, &message)),
+                take(global_this.create_aggregate_error(errors, &message)),
             );
         }
     }

--- a/test/js/bun/resolve/build-error.test.ts
+++ b/test/js/bun/resolve/build-error.test.ts
@@ -1,4 +1,4 @@
-import { tempDir } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
 
 test("BuildError is modifiable", async () => {
@@ -17,6 +17,58 @@ test("BuildError is modifiable", async () => {
   expect(() => (error!.message = "new message")).not.toThrow();
   expect(error!.message).toBe("new message");
   expect(error!.message).not.toBe(message);
+});
+
+test("AggregateError from a module with many build errors survives GC during its creation", async () => {
+  // A module that fails to load with multiple errors produces an
+  // AggregateError of BuildMessage objects. The wrappers used to be collected
+  // in a heap Vec the conservative GC scan cannot see, so a collection in the
+  // middle of creating them freed the native payloads and printing or
+  // inspecting the AggregateError afterwards was a use-after-free.
+  using dir = tempDir("aggregate-build-errors", {
+    "bad.js": Array.from({ length: 250 }, (_, i) => `let dup${i} = 1; let dup${i} = 2;`).join("\n"),
+    "index.js": `
+      let aggregate;
+      try {
+        await import("./bad.js");
+        throw new Error("expected import to fail");
+      } catch (e) {
+        aggregate = e;
+      }
+      Bun.gc(true);
+      if (aggregate.constructor.name !== "AggregateError") {
+        throw new Error("expected AggregateError, got " + aggregate.constructor.name);
+      }
+      if (aggregate.errors.length < 2) {
+        throw new Error("expected multiple build errors, got " + aggregate.errors.length);
+      }
+      for (const sub of aggregate.errors) {
+        if (typeof sub.message !== "string") throw new Error("bad message");
+        void sub.position;
+      }
+      console.error(aggregate);
+      console.log("OK", aggregate.errors.length);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.js"],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      // Make a collection land while the per-message error wrappers are being created.
+      BUN_JSC_collectContinuously: "true",
+      BUN_JSC_forceRAMSize: "1000000",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("AddressSanitizer");
+  expect(stdout).toContain("OK 250");
+  expect(exitCode).toBe(0);
 });
 
 test("BuildMessage finalize frees with the same allocator it was created with", async () => {


### PR DESCRIPTION
### What does this PR do?

Fixes a heap-use-after-free found by fuzzing (fingerprint `Address:heap-use-after-free:bun-debug+0x11afa5ac`, READ of size 1 at offset 144 of a 152-byte region — `BuildMessage.logged` read through `VirtualMachine::print_error_from_maybe_private_data` while iterating an `AggregateError`).

When a module fails to load with **multiple** transpiler/resolver errors, `process_fetch_log` creates one `BuildMessage`/`ResolveMessage` wrapper per log message and then wraps them in an `AggregateError`. The Rust port staged those freshly created `JSValue`s in a heap `Vec<JSValue>`:

- JSC's conservative scan only covers the native stack and registers, so values sitting in a heap `Vec` are invisible to the GC.
- Each `BuildMessage::create`/`ResolveMessage::create` allocates JS cells and can trigger a collection, so a GC landing in the middle of the loop could sweep wrappers created in earlier iterations.
- Their finalizers free the 152-byte `Box<BuildMessage>` payloads, and the `AggregateError` ends up holding stale values. Printing it (uncaught exception / unhandled rejection / `console.error`) or touching `error.errors[i]` afterwards reads the freed payload.

The Zig implementation (`VirtualMachine.zig` `var errors_stack: [256]JSValue`) deliberately kept this staging buffer on the stack so the conservative scan roots the wrappers until `createAggregateError` runs. This PR restores that behavior in the Rust port by using a stack array instead of a heap `Vec`.

Reproduced with `BUN_JSC_collectContinuously=true BUN_JSC_forceRAMSize=1000000` and a dynamic import of a module with ~250 parse errors: ASAN reports the UAF on the unfixed build (read in `print_error_from_maybe_private_data` → `Cell<bool>::get`, freed by `BuildMessageClass__finalize`, allocated by `process_fetch_log` → `BuildMessage::create`); the fixed build is clean.

### How did you verify your code works?

- New regression test `AggregateError from a module with many build errors survives GC during its creation` in `test/js/bun/resolve/build-error.test.ts`. It imports a module with 250 build errors under `BUN_JSC_collectContinuously=true`, then inspects and prints the resulting `AggregateError`. It fails on the unfixed ASAN debug build (AddressSanitizer abort in the subprocess) and passes with this fix.
- `bun bd test test/js/bun/resolve/build-error.test.ts` — 3 pass.
- Manually re-ran the standalone reproduction 6× on the fixed ASAN debug build with no reports; the unfixed build reports the use-after-free on most runs.
