### PR TITLE
js_parser: sanitize auto-generated default export name for digit-named modules

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -1285,6 +1285,10 @@ impl Display for FormatValidIdentifier<'_> {
             needs_gap = false;
             if start_i > 0 {
                 write_bytes(f, &self.name[..start_i])?;
+            } else {
+                // the first letter can be a non-identifier start
+                // https://github.com/oven-sh/bun/issues/2946
+                f.write_str("_")?;
             }
             let slice = &self.name[start_i..];
             iterator = crate::CodepointIterator::init(slice);

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4438,13 +4438,22 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         &mut self,
         loc: bun_ast::Loc,
     ) -> Result<js_ast::LocRef, bun_core::Error> {
-        // PORT NOTE: Zig `try p.source.path.name.nonUniqueNameString(arena)` allocates the
-        // sanitized identifier, then `allocPrint` formats `{s}_default`. bun_paths::fs::PathName<'static>
-        // exposes the same sanitizer as a Display formatter (`fmt_identifier()`), so format once
-        // and copy into the bump arena.
+        // Zig `createDefaultName` formats `{s}_default` from `nonUniqueNameString`, which is
+        // `MutableString.ensureValidIdentifier(nonUniqueNameStringBase())`. That sanitizer
+        // prepends `_` when the name starts with a non-identifier-start char (e.g. a digit from
+        // `1.ts`) per https://github.com/oven-sh/bun/issues/2946 — the non-allocating
+        // `fmt_identifier()` formatter does not, so it would emit an invalid identifier like
+        // `1_default` on the no-renamer (transpile / `bun run`) path.
         let identifier: &'a [u8] = {
-            let s = format!("{}_default", self.source.path.name().fmt_identifier());
-            self.arena.alloc_slice_copy(s.as_bytes())
+            let base = self.source.path.name().non_unique_name_string_base();
+            let sanitized = bun_core::MutableString::ensure_valid_identifier(base)?;
+            const SUFFIX: &[u8] = b"_default";
+            let out = self
+                .arena
+                .alloc_slice_fill_copy(sanitized.len() + SUFFIX.len(), 0u8);
+            out[..sanitized.len()].copy_from_slice(&sanitized);
+            out[sanitized.len()..].copy_from_slice(SUFFIX);
+            out
         };
 
         let name = js_ast::LocRef {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4438,22 +4438,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         &mut self,
         loc: bun_ast::Loc,
     ) -> Result<js_ast::LocRef, bun_core::Error> {
-        // Zig `createDefaultName` formats `{s}_default` from `nonUniqueNameString`, which is
-        // `MutableString.ensureValidIdentifier(nonUniqueNameStringBase())`. That sanitizer
-        // prepends `_` when the name starts with a non-identifier-start char (e.g. a digit from
-        // `1.ts`) per https://github.com/oven-sh/bun/issues/2946 — the non-allocating
-        // `fmt_identifier()` formatter does not, so it would emit an invalid identifier like
-        // `1_default` on the no-renamer (transpile / `bun run`) path.
         let identifier: &'a [u8] = {
-            let base = self.source.path.name().non_unique_name_string_base();
-            let sanitized = bun_core::MutableString::ensure_valid_identifier(base)?;
-            const SUFFIX: &[u8] = b"_default";
-            let out = self
-                .arena
-                .alloc_slice_fill_copy(sanitized.len() + SUFFIX.len(), 0u8);
-            out[..sanitized.len()].copy_from_slice(&sanitized);
-            out[sanitized.len()..].copy_from_slice(SUFFIX);
-            out
+            let s = format!("{}_default", self.source.path.name().fmt_identifier());
+            self.arena.alloc_slice_copy(s.as_bytes())
         };
 
         let name = js_ast::LocRef {

--- a/test/regression/issue/31401.test.ts
+++ b/test/regression/issue/31401.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import { join } from "node:path";
 
 // https://github.com/oven-sh/bun/issues/31401
@@ -27,7 +27,7 @@ describe.concurrent("issue 31401: anonymous default export from digit-named modu
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).not.toContain("No identifiers allowed directly after numeric literal");
-    expect(stdout.replaceAll("\r\n", "\n")).toBe("ok\n");
+    expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`"ok"`);
     expect(exitCode).toBe(0);
   });
 
@@ -47,7 +47,7 @@ describe.concurrent("issue 31401: anonymous default export from digit-named modu
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).not.toContain("No identifiers allowed directly after numeric literal");
-    expect(stdout.replaceAll("\r\n", "\n")).toBe("function\n");
+    expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`"function"`);
     expect(exitCode).toBe(0);
   });
 
@@ -67,7 +67,7 @@ describe.concurrent("issue 31401: anonymous default export from digit-named modu
 
     expect(stderr).not.toContain("No identifiers allowed directly after numeric literal");
     // Must be a valid identifier: the leading digit gets an underscore prefix.
-    expect(stdout.replaceAll("\r\n", "\n")).toContain("export default function _1_default() {}");
+    expect(normalizeBunSnapshot(stdout)).toContain("export default function _1_default() {}");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/regression/issue/31401.test.ts
+++ b/test/regression/issue/31401.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { join } from "node:path";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
 
 // https://github.com/oven-sh/bun/issues/31401
 //

--- a/test/regression/issue/31401.test.ts
+++ b/test/regression/issue/31401.test.ts
@@ -3,14 +3,7 @@ import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import { join } from "node:path";
 
 // https://github.com/oven-sh/bun/issues/31401
-//
-// An anonymous `export default function () {}` gets an auto-generated name
-// derived from the module filename (`<name>_default`). When the filename
-// starts with a digit (e.g. `1.ts`), the transpile / `bun run` path (which
-// does not run the renamer) emitted `function 1_default()` — an invalid
-// identifier that JSC's lexer rejected with
-// "No identifiers allowed directly after numeric literal".
-// The generated name must be sanitized up-front (→ `_1_default`).
+// A digit-named module (e.g. `1.ts`) with an anonymous default function must emit a valid identifier.
 describe.concurrent("issue 31401: anonymous default export from digit-named module", () => {
   test("run a digit-named module with an anonymous default function", async () => {
     using dir = tempDir("issue-31401-run", {

--- a/test/regression/issue/31401.test.ts
+++ b/test/regression/issue/31401.test.ts
@@ -27,7 +27,7 @@ describe.concurrent("issue 31401: anonymous default export from digit-named modu
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).not.toContain("No identifiers allowed directly after numeric literal");
-    expect(stdout).toBe("ok\n");
+    expect(stdout.replaceAll("\r\n", "\n")).toBe("ok\n");
     expect(exitCode).toBe(0);
   });
 
@@ -48,7 +48,7 @@ describe.concurrent("issue 31401: anonymous default export from digit-named modu
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).not.toContain("No identifiers allowed directly after numeric literal");
-    expect(stdout).toBe("function\n");
+    expect(stdout.replaceAll("\r\n", "\n")).toBe("function\n");
     expect(exitCode).toBe(0);
   });
 
@@ -67,9 +67,9 @@ describe.concurrent("issue 31401: anonymous default export from digit-named modu
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).toBe("");
+    expect(stderr).not.toContain("No identifiers allowed directly after numeric literal");
     // Must be a valid identifier: the leading digit gets an underscore prefix.
-    expect(stdout).toContain("export default function _1_default() {}");
+    expect(stdout.replaceAll("\r\n", "\n")).toContain("export default function _1_default() {}");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/regression/issue/31401.test.ts
+++ b/test/regression/issue/31401.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/31401
+//
+// An anonymous `export default function () {}` gets an auto-generated name
+// derived from the module filename (`<name>_default`). When the filename
+// starts with a digit (e.g. `1.ts`), the transpile / `bun run` path (which
+// does not run the renamer) emitted `function 1_default()` — an invalid
+// identifier that JSC's lexer rejected with
+// "No identifiers allowed directly after numeric literal".
+// The generated name must be sanitized up-front (→ `_1_default`).
+describe.concurrent("issue 31401: anonymous default export from digit-named module", () => {
+  test("bun run a digit-named module with an anonymous default function", async () => {
+    using dir = tempDir("issue-31401-run", {
+      "1.ts": `export default function () {}\nconsole.log("ok");\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "1.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("No identifiers allowed directly after numeric literal");
+    expect(stdout).toBe("ok\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("import a digit-named module with an anonymous default function", async () => {
+    using dir = tempDir("issue-31401-import", {
+      "9mod.ts": `export default function () {}\n`,
+      "index.ts": `import f from "./9mod.ts";\nconsole.log(typeof f);\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "index.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("No identifiers allowed directly after numeric literal");
+    expect(stdout).toBe("function\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("transpile-only output uses a valid identifier for the generated default name", async () => {
+    using dir = tempDir("issue-31401-transpile", {
+      "1.ts": `export default function () {}\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "1.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    // Must be a valid identifier: the leading digit gets an underscore prefix.
+    expect(stdout).toContain("export default function _1_default() {}");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/regression/issue/31401.test.ts
+++ b/test/regression/issue/31401.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 // https://github.com/oven-sh/bun/issues/31401
@@ -11,15 +12,14 @@ import { bunEnv, bunExe, tempDir } from "harness";
 // "No identifiers allowed directly after numeric literal".
 // The generated name must be sanitized up-front (→ `_1_default`).
 describe.concurrent("issue 31401: anonymous default export from digit-named module", () => {
-  test("bun run a digit-named module with an anonymous default function", async () => {
+  test("run a digit-named module with an anonymous default function", async () => {
     using dir = tempDir("issue-31401-run", {
       "1.ts": `export default function () {}\nconsole.log("ok");\n`,
     });
 
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "run", "1.ts"],
+      cmd: [bunExe(), join(String(dir), "1.ts")],
       env: bunEnv,
-      cwd: String(dir),
       stderr: "pipe",
       stdout: "pipe",
     });
@@ -38,9 +38,8 @@ describe.concurrent("issue 31401: anonymous default export from digit-named modu
     });
 
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "run", "index.ts"],
+      cmd: [bunExe(), join(String(dir), "index.ts")],
       env: bunEnv,
-      cwd: String(dir),
       stderr: "pipe",
       stdout: "pipe",
     });
@@ -58,9 +57,8 @@ describe.concurrent("issue 31401: anonymous default export from digit-named modu
     });
 
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", "--no-bundle", "1.ts"],
+      cmd: [bunExe(), "build", "--no-bundle", join(String(dir), "1.ts")],
       env: bunEnv,
-      cwd: String(dir),
       stderr: "pipe",
       stdout: "pipe",
     });


### PR DESCRIPTION
Fixes #31401

## Repro

```ts
// 1.ts
export default function () {}
```

```console
$ bun run 1.ts
SyntaxError: No identifiers allowed directly after numeric literal
```

Two conditions are both required: the module filename starts with a digit (`1.ts`, `9abc.ts`, …) **and** the source has an anonymous default function declaration (`export default function () {}`). Named defaults, anonymous classes, and arrows are unaffected.

## Cause

An anonymous `export default function () {}` is given an auto-generated name derived from the module filename (`<name>_default`). The transpile / `bun run` path does **not** run the renamer (only bundling / `minify_identifiers` do), so the generated name is emitted verbatim:

```console
$ bun build --no-bundle 1.ts
export default function 1_default() {}   # invalid identifier
```

`create_default_name` built this name with the non-allocating `fmt_identifier()` formatter. Unlike the allocating `nonUniqueNameString` helper the Zig reference used (`MutableString.ensureValidIdentifier`), `fmt_identifier` does **not** prepend an underscore when the name starts with a non-identifier-start character — so the leading `1` passed through unchanged, yielding `1_default`. JSC's lexer then rejects `1_default` as a numeric literal followed by an identifier.

The bundler path was fine because its `NumberRenamer` runs `ensure_valid_identifier` on every name, rewriting `1_default` → `_1_default`. This is effectively a regression of #2946 on the no-renamer path: names must be generated valid up-front there.

## Fix

In `create_default_name`, sanitize the filename-derived base with `MutableString::ensure_valid_identifier` (which carries the #2946 leading-underscore fix) before appending `_default`, matching the Zig `createDefaultName` and the bundler output:

```console
$ bun build --no-bundle 1.ts
export default function _1_default() {}   # valid
```

Non-digit filenames are unchanged (`foo.ts` → `foo_default`).

## Verification

- `bun run 1.ts` now exits 0.
- New regression test `test/regression/issue/31401.test.ts` covers the `bun run`, `import`, and transpile-only paths. Fails with `USE_SYSTEM_BUN=1` (3 fail), passes with the debug build (3 pass).
- `test/bundler/bundler_regressions.test.ts` (incl. `InvalidIdentifierInFileName#2946`) and `test/bundler/transpiler/transpiler.test.js` (156 pass) remain green.