### PR TITLE
css: escape custom pseudo-class/element names when printing

### DIFF
--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -1183,8 +1183,6 @@ pub mod serialize {
             PseudoClass::Dir { .. } => unreachable!(),
             PseudoClass::Custom { name } => {
                 dest.write_char(b':')?;
-                // The name was unescaped while parsing, so re-escape it to keep
-                // the output parseable (e.g. a name containing a space).
                 return dest.serialize_identifier(name);
             }
             PseudoClass::CustomFunction { name, arguments } => {
@@ -1325,8 +1323,6 @@ pub mod serialize {
             }
             PseudoElement::Custom { name } => {
                 dest.write_str(b"::")?;
-                // The name was unescaped while parsing, so re-escape it to keep
-                // the output parseable (e.g. a name containing a space).
                 return dest.serialize_identifier(name);
             }
             PseudoElement::CustomFunction { name, arguments } => {

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -1183,11 +1183,13 @@ pub mod serialize {
             PseudoClass::Dir { .. } => unreachable!(),
             PseudoClass::Custom { name } => {
                 dest.write_char(b':')?;
-                return dest.write_str(name);
+                // The name was unescaped while parsing, so re-escape it to keep
+                // the output parseable (e.g. a name containing a space).
+                return dest.serialize_identifier(name);
             }
             PseudoClass::CustomFunction { name, arguments } => {
                 dest.write_char(b':')?;
-                dest.write_str(name)?;
+                dest.serialize_identifier(name)?;
                 dest.write_char(b'(')?;
                 // blocked_on: properties::custom (TokenList::to_css_raw) un-gate.
 
@@ -1323,11 +1325,13 @@ pub mod serialize {
             }
             PseudoElement::Custom { name } => {
                 dest.write_str(b"::")?;
-                return dest.write_str(name);
+                // The name was unescaped while parsing, so re-escape it to keep
+                // the output parseable (e.g. a name containing a space).
+                return dest.serialize_identifier(name);
             }
             PseudoElement::CustomFunction { name, arguments } => {
                 dest.write_str(b"::")?;
-                dest.write_str(name)?;
+                dest.serialize_identifier(name)?;
                 dest.write_char(b'(')?;
                 // blocked_on: properties::custom (TokenList::to_css_raw) un-gate.
 

--- a/test/js/bun/css/custom-pseudo-ident-escape.test.ts
+++ b/test/js/bun/css/custom-pseudo-ident-escape.test.ts
@@ -1,0 +1,39 @@
+import { cssInternals } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
+
+const { minifyTest } = cssInternals;
+
+// Unknown (custom) pseudo-class/pseudo-element names are unescaped while parsing, but used to be
+// printed raw. A name that needs escaping (e.g. an escaped space, `:\ `) was emitted as a bare `: `,
+// so the minified output no longer parsed (found by fuzzing `:\ {w:`).
+
+test("custom pseudo-class names are re-escaped when printed", () => {
+  // fuzzer-minimized input: escaped space as the entire pseudo-class name
+  expect(minifyTest(":\\ {w:", "")).toBe(":\\ {w:}");
+  expect(minifyTest(":\\ {color: red}", "")).toBe(":\\ {color:red}");
+
+  // escapes in the middle of the name
+  expect(minifyTest(":hover\\:focus {color: red}", "")).toBe(":hover\\:focus{color:red}");
+
+  // unknown functional pseudo-class
+  expect(minifyTest(":\\ (x) {color: red}", "")).toBe(":\\ (x){color:red}");
+});
+
+test("custom pseudo-element names are re-escaped when printed", () => {
+  expect(minifyTest("::\\ {color: red}", "")).toBe("::\\ {color:red}");
+  expect(minifyTest("::\\ (x) {color: red}", "")).toBe("::\\ (x){color:red}");
+});
+
+test("minified output with escaped pseudo names round-trips", () => {
+  for (const source of [":\\ {w:", ":\\ {color: red}", "::\\ {color: red}", ":hover\\:focus {color: red}"]) {
+    const minified = minifyTest(source, "");
+    // Re-parsing and re-minifying the output must not throw and must be stable.
+    expect(minifyTest(minified, "")).toBe(minified);
+  }
+});
+
+test("ordinary unknown pseudo names are unchanged", () => {
+  expect(minifyTest(":unknown-pseudo {color: red}", "")).toBe(":unknown-pseudo{color:red}");
+  expect(minifyTest("::-webkit-unknown {color: red}", "")).toBe("::-webkit-unknown{color:red}");
+  expect(minifyTest(":-custom-fn(x) {color: red}", "")).toBe(":-custom-fn(x){color:red}");
+});

--- a/test/js/bun/css/custom-pseudo-ident-escape.test.ts
+++ b/test/js/bun/css/custom-pseudo-ident-escape.test.ts
@@ -3,19 +3,10 @@ import { expect, test } from "bun:test";
 
 const { minifyTest } = cssInternals;
 
-// Unknown (custom) pseudo-class/pseudo-element names are unescaped while parsing, but used to be
-// printed raw. A name that needs escaping (e.g. an escaped space, `:\ `) was emitted as a bare `: `,
-// so the minified output no longer parsed (found by fuzzing `:\ {w:`).
-
 test("custom pseudo-class names are re-escaped when printed", () => {
-  // fuzzer-minimized input: escaped space as the entire pseudo-class name
   expect(minifyTest(":\\ {w:", "")).toBe(":\\ {w:}");
   expect(minifyTest(":\\ {color: red}", "")).toBe(":\\ {color:red}");
-
-  // escapes in the middle of the name
   expect(minifyTest(":hover\\:focus {color: red}", "")).toBe(":hover\\:focus{color:red}");
-
-  // unknown functional pseudo-class
   expect(minifyTest(":\\ (x) {color: red}", "")).toBe(":\\ (x){color:red}");
 });
 
@@ -27,7 +18,6 @@ test("custom pseudo-element names are re-escaped when printed", () => {
 test("minified output with escaped pseudo names round-trips", () => {
   for (const source of [":\\ {w:", ":\\ {color: red}", "::\\ {color: red}", ":hover\\:focus {color: red}"]) {
     const minified = minifyTest(source, "");
-    // Re-parsing and re-minifying the output must not throw and must be stable.
     expect(minifyTest(minified, "")).toBe(minified);
   }
 });


### PR DESCRIPTION
### What

Fuzzer-found round-trip violation (`invariant:css:minified CSS does not reparse`): a 6-byte CSS input whose selector is a pseudo-class named with an escaped space (`:\ `) minifies to a bare `: `, and the minifier's own output no longer parses.

```sh
BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1 bun -e 'require("bun:internal-for-testing").cssInternals.minifyTest(":\\ {w:", "")'
```

Before: the input `:\ {w:` prints as `: {w:}`, and re-parsing that output fails with `Invalid selector. Expected identifier in pseudo-element, found:  `.

### Cause

Unknown (custom) pseudo-class and pseudo-element names are stored unescaped by the tokenizer, but `serialize_pseudo_class` / `serialize_pseudo_element` in `src/css/selectors/selector.rs` wrote them back raw:

```rust
PseudoClass::Custom { name } => {
    dest.write_char(b':')?;
    return dest.write_str(name);
}
```

So any name containing characters that require escaping (a space, a colon, etc.) loses its escapes on output, producing CSS that no longer parses. Other identifier-bearing selector parts (classes, ids, `:lang()` arguments) already re-escape via `serialize_identifier`; the four custom pseudo arms (`Custom` / `CustomFunction` for both pseudo-classes and pseudo-elements) did not.

### Fix

Serialize custom pseudo-class/element names with `Printer::serialize_identifier` instead of `write_str`, so escapes are regenerated on output. Ordinary names (letters, digits, hyphens, vendor prefixes) are unaffected — `serialize_identifier` only escapes when needed.

Now `:\ {w:` prints as `:\ {w:}`, which reparses to the same stylesheet.

### Verification

- New test `test/js/bun/css/custom-pseudo-ident-escape.test.ts` covers the fuzzer-minimized input, escaped names in custom pseudo-classes/elements/functions, round-trip stability of the minified output, and that ordinary unknown pseudo names are unchanged. 3 of 4 tests fail without the fix.
- `test/js/bun/css/css.test.ts` (1087 pass), the other CSS test files, and `test/bundler/css/` all pass with the change.
