### PR TITLE
Hold cellLock() when removing or clearing JSC module registry entries

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -160,7 +160,11 @@ static EncodedJSValue jsFunctionAppendVirtualModulePluginBody(JSC::JSGlobalObjec
     if (moduleIdValue.isString()) {
         auto idIdent = JSC::Identifier::fromString(vm, asString(moduleIdValue)->value(globalObject));
         RETURN_IF_EXCEPTION(scope, {});
-        global->moduleLoader()->removeEntry(idIdent);
+        auto* moduleLoader = global->moduleLoader();
+        // JSModuleLoader::visitChildrenImpl iterates these maps on the GC thread
+        // under cellLock(); take the same lock so the removal can't race it.
+        WTF::Locker locker { moduleLoader->cellLock() };
+        moduleLoader->removeEntry(idIdent);
     }
 
     return JSValue::encode(callframe->thisValue());
@@ -696,7 +700,9 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
     }
 
     if (removeFromESM) {
-        globalObject->moduleLoader()->removeEntry(specifierIdent);
+        auto* moduleLoader = globalObject->moduleLoader();
+        WTF::Locker locker { moduleLoader->cellLock() };
+        moduleLoader->removeEntry(specifierIdent);
     }
 
     if (removeFromCJS) {

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -721,7 +721,11 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmRegistryDelete, (JSC::JSGlobalObject * globa
         return JSValue::encode(jsBoolean(false));
     auto key = JSC::Identifier::fromString(vm, asString(keyValue)->value(globalObject));
     RETURN_IF_EXCEPTION(scope, {});
-    return JSValue::encode(jsBoolean(globalObject->moduleLoader()->removeEntry(key)));
+    auto* moduleLoader = globalObject->moduleLoader();
+    // JSModuleLoader::visitChildrenImpl iterates these maps on the GC thread
+    // under cellLock(); take the same lock so the removal can't race it.
+    WTF::Locker locker { moduleLoader->cellLock() };
+    return JSValue::encode(jsBoolean(moduleLoader->removeEntry(key)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionEsmRegistryEvaluatedKeys, (JSC::JSGlobalObject * globalObject, JSC::CallFrame*))
@@ -800,8 +804,10 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
         // outer import() is mid-load, or the module is EvaluatingAsync from a
         // prior import), removing it would force a second evaluation and a
         // second namespace object once that outer load completes.
-        if (!entryExistedBefore)
+        if (!entryExistedBefore) {
+            WTF::Locker locker { loader->cellLock() };
             loader->removeEntry(key);
+        }
         return throwVMTypeError(globalObject, scope, makeString("require() async module \""_s, keyString, "\" is unsupported. use \"await import()\" instead."_s));
     }
     }
@@ -3324,7 +3330,11 @@ void GlobalObject::reload()
 {
     auto& vm = this->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    this->moduleLoader()->clearAll();
+    {
+        auto* moduleLoader = this->moduleLoader();
+        WTF::Locker locker { moduleLoader->cellLock() };
+        moduleLoader->clearAll();
+    }
     this->requireMap()->clear(this);
     RETURN_IF_EXCEPTION(scope, );
 
@@ -3947,7 +3957,11 @@ extern "C" void Zig__GlobalObject__destructOnExit(Zig::GlobalObject* globalObjec
         // ExternalStringImpl deallocators never run and LSan reports the
         // backing buffers as leaked. Mirrors WebWorker__teardownJSCVM.
         auto scope = DECLARE_THROW_SCOPE(vm);
-        globalObject->moduleLoader()->clearAll();
+        {
+            auto* moduleLoader = globalObject->moduleLoader();
+            WTF::Locker locker { moduleLoader->cellLock() };
+            moduleLoader->clearAll();
+        }
         globalObject->requireMap()->clear(globalObject);
         scope.exception(); // mirror WebWorker__teardownJSCVM — leave any pending exception in place
     }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2854,7 +2854,11 @@ JSC::EncodedJSValue JSC__JSGlobalObject__putCachedObject(JSC::JSGlobalObject* gl
 void JSC__JSGlobalObject__deleteModuleRegistryEntry(JSC::JSGlobalObject* global, ZigString* arg1)
 {
     const JSC::Identifier identifier = Zig::toIdentifier(*arg1, global);
-    global->moduleLoader()->removeEntry(identifier);
+    auto* moduleLoader = global->moduleLoader();
+    // JSModuleLoader::visitChildrenImpl iterates these maps on the GC thread
+    // under cellLock(); take the same lock so the removal can't race it.
+    WTF::Locker locker { moduleLoader->cellLock() };
+    moduleLoader->removeEntry(identifier);
 }
 
 void JSC__VM__collectAsync(JSC::VM* vm)
@@ -4969,7 +4973,11 @@ void JSC__VM__deleteAllCode(JSC::VM* arg1, JSC::JSGlobalObject* globalObject)
     JSC::JSLockHolder locker(globalObject->vm());
 
     arg1->drainMicrotasks();
-    globalObject->moduleLoader()->clearAll();
+    {
+        auto* moduleLoader = globalObject->moduleLoader();
+        WTF::Locker cellLocker { moduleLoader->cellLock() };
+        moduleLoader->clearAll();
+    }
     arg1->deleteAllCode(JSC::DeleteAllCodeEffort::PreventCollectionAndDeleteAllCode);
     arg1->heap.reportAbandonedObjectGraph();
 }

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -572,7 +572,14 @@ extern "C" void WebWorker__teardownJSCVM(Zig::GlobalObject* globalObject)
 
     {
         auto scope = DECLARE_THROW_SCOPE(vm);
-        globalObject->moduleLoader()->clearAll();
+        {
+            auto* moduleLoader = globalObject->moduleLoader();
+            // JSModuleLoader::visitChildrenImpl iterates these maps on the GC
+            // thread under cellLock(); take the same lock so clearing them
+            // can't race a concurrent marker.
+            WTF::Locker locker { moduleLoader->cellLock() };
+            moduleLoader->clearAll();
+        }
         globalObject->requireMap()->clear(globalObject);
         scope.exception(); // TODO: handle or assert none?
         vm.deleteAllCode(JSC::DeleteAllCodeEffort::PreventCollectionAndDeleteAllCode);

--- a/test/js/node/module/esm-registry-concurrent-gc.test.ts
+++ b/test/js/node/module/esm-registry-concurrent-gc.test.ts
@@ -1,0 +1,73 @@
+// JSModuleLoader's module registry (m_moduleMap / m_loadedModules /
+// m_resolutionFailures) is iterated by JSModuleLoader::visitChildrenImpl on
+// the concurrent GC marker thread under cellLock(). Bun mutates those maps on
+// the mutator thread via removeEntry() (require.cache deletes, mock.module,
+// plugin virtual modules) and clearAll() (hot reload, VM teardown, process
+// exit), so those mutation sites must hold the same cellLock() or a removal
+// can invalidate/ free the table the marker is still walking. Fuzzing caught
+// this as a UBSAN null deref in WTF::HashTable's iterator bookkeeping
+// (removeIterator racing invalidateIterators).
+//
+// The race is timing dependent and not reliably observable as a crash, so
+// this test is a regression guard for the locking: it drives the ESM registry
+// add/remove paths in a tight loop (require(esm) + delete require.cache) and
+// exits while collectContinuously keeps the concurrent marker visiting the
+// module loader, then asserts the program ran to completion.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+// collectContinuously is very slow on Windows in CI and the code path is
+// identical across platforms; skip there (same rationale as
+// module-children-concurrent-gc.test.ts).
+test.skipIf(isWindows)(
+  "ESM registry removeEntry/clearAll under concurrent GC",
+  async () => {
+    const files: Record<string, string> = {
+      "dep.mjs": `export const value = 1;\n`,
+      "entry.cjs": `
+        // Pad the registry so the marker spends longer iterating it.
+        const pads = [];
+        for (let i = 0; i < 8; i++) pads.push(import("data:text/javascript,export default " + i));
+        Promise.all(pads).then(() => {
+          const depPath = require.resolve("./dep.mjs");
+          let v = 0;
+          for (let i = 0; i < 300; i++) {
+            // require(esm): loadModuleSync re-adds the registry entry and
+            // write-barriers the module loader so the marker re-visits it.
+            v = require("./dep.mjs").value;
+            // require.cache delete: JSModuleLoader::removeEntry on the mutator.
+            delete require.cache[depPath];
+          }
+          console.log("ok " + v);
+          // Process exit then runs the clearAll() teardown path while the
+          // continuous collector is still marking.
+        });
+      `,
+    };
+
+    using dir = tempDir("esm-registry-concurrent-gc", files);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.cjs"],
+      env: {
+        ...bunEnv,
+        BUN_JSC_collectContinuously: "1",
+      },
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Assert output before exit code so a failure shows the actual crash
+    // text. Debug/ASAN builds print a harmless "WARNING: ASAN interferes
+    // with JSC signal handlers" banner on stderr, so only surface stderr
+    // when the process failed.
+    expect(stdout.trim()).toBe("ok 1");
+    if (exitCode !== 0) expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  },
+  90_000,
+);


### PR DESCRIPTION
### What does this PR do?

Fixes a data race between the concurrent GC marker and Bun's mutations of the JSC module registry, found by fuzzing (flaky UBSAN crash):

```
HashTable.h:1574:17: runtime error: member access within null pointer of type 'const HashTableType'
(... HashMap<pair<UniquedStringImpl*, ScriptFetchParameters::Type>, WriteBarrier<ModuleRegistryEntry>, ModuleMapHash, ...>)
```

That map is `JSModuleLoader::m_moduleMap`. `JSModuleLoader::visitChildrenImpl` iterates `m_moduleMap` / `m_loadedModules` / `m_resolutionFailures` on the concurrent GC marker thread while holding the loader's `cellLock()`, and JSC's own registry insertions (`ensureRegistered`, `provideFetch`, `addResolutionFailure`) take that same lock before mutating. Bun's `removeEntry()` / `clearAll()` call sites did not:

- `$esmRegistryDelete` (`require.cache` deletes) and `$esmLoadSync`'s error path (ZigGlobalObject.cpp)
- `mock.module()` and `Bun.plugin` virtual modules (BunPlugin.cpp)
- `deleteModuleRegistryEntry` / `JSC__VM__deleteAllCode` (bindings.cpp)
- hot reload (`GlobalObject::reload`), process-exit teardown (`Zig__GlobalObject__destructOnExit`), and worker VM teardown (Worker.cpp)

An unlocked removal can run while the marker is still walking the table: the removal's `invalidateIterators()` nulls the marker's registered iterator mid-`removeIterator()`, which is the null deref UBSAN reports in debug builds; in release builds the same race can free/rehash the bucket array out from under the marker. This is the same bug class previously fixed for `NodeVMModule::m_resolveCache` and `JSCommonJSModule::m_children` — both sides must hold `cellLock()`.

The fix takes `cellLock()` at each Bun call site that removes or clears registry entries, mirroring what JSC's own mutation paths already do. Read-only lookups don't need the lock (the GC never mutates these maps).

### How did you verify your code works?

- The race is timing-dependent (the fuzzer crash was flaky and did not reproduce deterministically), so the regression test `test/js/node/module/esm-registry-concurrent-gc.test.ts` follows the pattern of `module-children-concurrent-gc.test.ts`: it drives the registry add/remove paths in a tight loop under `BUN_JSC_collectContinuously=1`, exits while the collector is still marking, and asserts clean completion. It exercises every newly locked path reachable from JS plus the exit-time `clearAll()`.
- Ran stress loops (require(esm) + `delete require.cache` under `collectContinuously`, and the original fuzzer sample) against the debug+ASAN build with this change: no crashes, no deadlocks, throughput unchanged.
- Existing coverage for the touched call sites passes with a debug build: `mock-module.test.ts`, `plugins.test.ts`, `bun-jsc.test.ts`, `node-module-module.test.js`, `require-esm-gc-roots.test.ts`, `module-children-concurrent-gc.test.ts`, `worker-terminate-lifetime.test.ts`, and the hot-reload test for file overwrite.
