### PR TITLE
build: fat Rust bitcode for cross-language LTO on Linux

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -17,7 +17,11 @@ channel = "nightly-2026-05-06"
 # comes with the toolchain install regardless; they're listed here so a dev
 # running `bun run rust:check-all` or `cargo check --target` from any host
 # still gets prebuilt std for every Tier 1/2 triple.
-components = ["rust-src", "rustfmt", "clippy", "miri"]
+# llvm-tools provides llvm-link/opt for the ELF cross-language LTO
+# regular-LTO-summary fix-up (scripts/build/rust-lto-fix-cli.ts). CI agents
+# that pin via RUSTUP_TOOLCHAIN bypass this list; that script self-heals by
+# running `rustup component add llvm-tools` when the tools are missing.
+components = ["rust-src", "rustfmt", "clippy", "miri", "llvm-tools"]
 targets = [
   "aarch64-unknown-linux-gnu",
   "x86_64-unknown-linux-gnu",

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -35,7 +35,7 @@ import { assert } from "./error.ts";
 import { bunIncludes, computeFlags, extraFlagsFor, linkDepends } from "./flags.ts";
 import { writeIfChanged } from "./fs.ts";
 import type { BuildNode, Ninja } from "./ninja.ts";
-import { emitRust, linkerMapPath, rustLibPath } from "./rust.ts";
+import { emitRust, linkerMapPath, rustLibPath, rustLtoLinkInputs } from "./rust.ts";
 import { quote, slash } from "./shell.ts";
 import { emitShims, machoPostlinkCommand, machoPostlinkImplicitInputs } from "./shims.ts";
 import { computeDepLibs, resolveDep, type ResolvedDep } from "./source.ts";
@@ -467,7 +467,9 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
   // is needed; if a member ever isn't, `rustLinkFlags()` in rust.ts is the
   // wrapping helper.
   const shims = emitShims(n, cfg);
-  const linkObjects = [...allObjects, ...rustObjects, ...windowsRes];
+  // rustLtoLinkInputs(): on ELF cross-language LTO targets the Rust bitcode
+  // is rewritten with a regular-LTO summary first (identity elsewhere).
+  const linkObjects = [...allObjects, ...rustLtoLinkInputs(n, cfg, rustObjects), ...windowsRes];
   const ldflags = [...flags.ldflags, ...systemLibs(cfg), ...manifestLinkFlags(cfg), ...shims.ldflags];
   const exe = link(n, cfg, exeName, linkObjects, {
     libs: depLibs,
@@ -598,8 +600,10 @@ function emitLinkOnly(n: Ninja, cfg: Config): BunOutput {
 
   // libbun_rust.a from rust-only: same path emitRust writes to. Shared
   // helper so both sides of the CI split agree (cargo's
-  // `<target-dir>/<triple>/<profile>/` layout).
-  const rustObjects = [rustLibPath(cfg)];
+  // `<target-dir>/<triple>/<profile>/` layout). rustLtoLinkInputs(): on ELF
+  // cross-language LTO targets the downloaded archive's bitcode is rewritten
+  // with a regular-LTO summary on this (link) agent before the link.
+  const rustObjects = rustLtoLinkInputs(n, cfg, [rustLibPath(cfg)]);
 
   // Only need ldflags + stripflags (no cflags/cxxflags — no compile).
   const flags = computeFlags(cfg);

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -474,11 +474,14 @@ export const globalFlags: Flag[] = [
     // importing disabled, ICF ruled out, and WPD ruled out. The same
     // bitcode through ld64.lld on darwin is fine. Full LTO uses a different
     // (regular-LTO) pass pipeline over one merged module and has shipped
-    // green for months. Costs: the link is serial (~14 min vs ~1.5 min) and
-    // there is no Rust<->C++ cross-language inlining (the Rust thin
-    // partition cannot import from the C++ regular partition). Revisit once
-    // the miscompiling pass is isolated — the repro is
-    // `bun -e 'require("axobject-query")'` failing in the DFG tier.
+    // green for months. Cost: the link is serial (~14 min vs ~1.5 min).
+    // Rust<->C++ cross-language inlining still happens: the Rust side emits
+    // one fat, summary-less bitcode module (CARGO_PROFILE_RELEASE_LTO=fat
+    // under -Clinker-plugin-lto — see rust.ts) that joins the same
+    // regular-LTO partition as the C++, so nothing goes through the
+    // miscompiling ThinLTO backends. Revisit ThinLTO once the bad pass is
+    // isolated — the repro is `bun -e 'require("axobject-query")'` failing
+    // in the DFG tier.
     flag: "-flto=full",
     when: c => c.unix && !c.darwin && c.lto,
     desc: "Full link-time optimization (linux: ThinLTO miscompiles JSC, see comment)",

--- a/scripts/build/rust-lto-fix-cli.ts
+++ b/scripts/build/rust-lto-fix-cli.ts
@@ -43,7 +43,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, openSync, readSync, closeSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, readSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { BuildError, assert } from "./error.ts";
 

--- a/scripts/build/rust-lto-fix-cli.ts
+++ b/scripts/build/rust-lto-fix-cli.ts
@@ -1,0 +1,154 @@
+/**
+ * Rust regular-LTO summary fix-up — the ninja build-time CLI for the
+ * `rust_lto_fix` rule (see `rustLtoLinkInputs()` in rust.ts and the
+ * `rustc-no-regular-lto-summary` entry in workarounds.ts).
+ *
+ * ## Why this exists
+ *
+ * The ELF release link is full (regular) LTO: every C/C++ object — ours,
+ * the direct deps', the WebKit `-lto` prebuilts' — is clang full-LTO
+ * bitcode, and clang unconditionally writes a per-module *regular-LTO
+ * summary* with `EnableSplitLTOUnit=1` into such objects on ELF
+ * (`shouldEmitRegularLTOSummary()` in clang's BackendUtil; neither
+ * `-fno-split-lto-unit` nor any other driver flag turns that off).
+ *
+ * The Rust side reaches the link as `-Clinker-plugin-lto` + `lto = "fat"`
+ * bitcode: one merged module with *no* summary at all. lld's
+ * `getLTOInfo()` reports a summary-less module as `EnableSplitLTOUnit=0`,
+ * the link becomes "partially split", and because `-fwhole-program-vtables`
+ * puts `llvm.type.test` calls in the merged C++ module,
+ * `LTO::checkPartiallySplit()` aborts the link with
+ * "inconsistent LTO Unit splitting (recompile with -fsplit-lto-unit)".
+ * rustc has no option to emit a regular-LTO summary, so this step bolts
+ * one on:
+ *
+ *   1. extract the bitcode member(s) from `libbun_rust.a`,
+ *   2. `llvm-link` in a stub that adds the `ThinLTO=0` module flag — that
+ *      flag is what makes the bitcode writer emit a FULL_LTO summary block
+ *      instead of a ThinLTO one,
+ *   3. re-emit with `opt --module-summary`, which builds the per-module
+ *      summary from the IR. Its `EnableSplitLTOUnit` bit is copied from the
+ *      module flag that `-Zsplit-lto-unit` stamped on every CGU (rust.ts
+ *      passes it on ELF for exactly this reason), so the result matches the
+ *      clang objects and the consistency check passes.
+ *
+ * The tools must come from rustc's own LLVM (the rustup `llvm-tools`
+ * component, installed next to rust-lld) — clang's older LLVM cannot read
+ * rustc's newer bitcode. If the component is missing, this script installs
+ * it (`rustup component add llvm-tools`), mirroring how the
+ * `rust_build_cross` rule self-heals missing `rust-std` targets on CI
+ * agents that pin the toolchain via `RUSTUP_TOOLCHAIN`.
+ *
+ * argv: [node, rust-lto-fix-cli.ts, <libbun_rust.a>, <out.o>, <llvm-bin-dir>, <ar>]
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, openSync, readSync, closeSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { BuildError, assert } from "./error.ts";
+
+/** Absolute path to this file — referenced by the `rust_lto_fix` ninja rule. */
+export const rustLtoFixCliPath: string = import.meta.filename;
+
+/** Run a tool, streaming its output; throw a BuildError on failure. */
+function run(cmd: string, args: string[], cwd?: string): void {
+  const res = spawnSync(cmd, args, { stdio: "inherit", cwd });
+  if (res.error !== undefined || res.status !== 0) {
+    throw new BuildError(`${cmd} ${args.join(" ")} failed${res.status !== null ? ` (exit ${res.status})` : ""}`, {
+      cause: res.error,
+    });
+  }
+}
+
+/** First bytes of an LLVM bitcode file: 'BC\xC0\xDE', or the wrapper magic 0x0B17C0DE (LE). */
+function isBitcode(path: string): boolean {
+  const buf = Buffer.alloc(4);
+  const fd = openSync(path, "r");
+  try {
+    if (readSync(fd, buf, 0, 4, 0) < 4) return false;
+  } finally {
+    closeSync(fd);
+  }
+  if (buf[0] === 0x42 && buf[1] === 0x43 && buf[2] === 0xc0 && buf[3] === 0xde) return true;
+  return buf[0] === 0xde && buf[1] === 0xc0 && buf[2] === 0x17 && buf[3] === 0x0b;
+}
+
+/**
+ * Make sure llvm-link/opt/llvm-as exist in rustc's host tool dir. They ship
+ * with the rustup `llvm-tools` component (rust-toolchain.toml lists it, but
+ * CI agents pin via `RUSTUP_TOOLCHAIN` which bypasses that file's component
+ * list), so install it on demand.
+ */
+function ensureLlvmTools(llvmBin: string): void {
+  const needed = ["llvm-link", "opt", "llvm-as"];
+  const missing = () => needed.filter(t => !existsSync(join(llvmBin, t)));
+  if (missing().length === 0) return;
+
+  // `<...>/toolchains/<name>/lib/rustlib/<triple>/bin` → `<name>`.
+  const toolchain = /[\\/]toolchains[\\/]([^\\/]+)[\\/]/.exec(llvmBin)?.[1];
+  const args = ["component", "add", "llvm-tools"];
+  if (toolchain !== undefined) args.push("--toolchain", toolchain);
+  console.log(`rust-lto-fix: ${missing().join(", ")} not found in ${llvmBin}, running rustup ${args.join(" ")}`);
+  const res = spawnSync("rustup", args, { stdio: "inherit" });
+  assert(
+    res.error === undefined && res.status === 0 && missing().length === 0,
+    `missing ${missing().join(", ")} in ${llvmBin}`,
+    {
+      hint: `Install rustc's LLVM tools: rustup component add llvm-tools${toolchain !== undefined ? ` --toolchain ${toolchain}` : ""}`,
+    },
+  );
+}
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  assert(
+    argv[0] !== undefined && argv[1] !== undefined && argv[2] !== undefined && argv[3] !== undefined,
+    "usage: rust-lto-fix-cli.ts <libbun_rust.a> <out.o> <llvm-bin-dir> <ar>",
+  );
+  // Ninja passes buildDir-relative $in/$out and runs us with cwd=buildDir,
+  // but the archive is extracted with cwd set to the scratch dir below —
+  // make them absolute first. The tool paths are already absolute.
+  const [rustLib, outObj, llvmBin, ar] = [resolve(argv[0]), resolve(argv[1]), argv[2], argv[3]];
+  assert(existsSync(rustLib), `${rustLib} does not exist`);
+  ensureLlvmTools(llvmBin);
+
+  // Scratch space next to the output; recreated from scratch every run.
+  const tmp = `${outObj}.tmp`;
+  rmSync(tmp, { recursive: true, force: true });
+  mkdirSync(tmp, { recursive: true });
+
+  try {
+    // Extract the archive and pick out the bitcode member(s). With
+    // `lto = "fat"` there is exactly one (the merged module); the rest are
+    // native objects (compiler_builtins) that stay in the archive.
+    run(ar, ["x", rustLib], tmp);
+    const bitcode = readdirSync(tmp)
+      .filter(f => isBitcode(join(tmp, f)))
+      .map(f => join(tmp, f));
+    assert(bitcode.length > 0, `no LLVM bitcode members found in ${rustLib}`, {
+      hint:
+        "The ELF cross-language LTO build expects cargo to emit fat bitcode " +
+        "(-Clinker-plugin-lto with CARGO_PROFILE_RELEASE_LTO=fat — see emitRust() in rust.ts).",
+    });
+
+    // The `ThinLTO=0` module flag is the bitcode writer's "this is a regular
+    // LTO module" marker — without it `--module-summary` writes a ThinLTO
+    // summary block and lld would send the module to a ThinLTO backend.
+    const stubLl = join(tmp, "regular-lto-flag-stub.ll");
+    const stubBc = join(tmp, "regular-lto-flag-stub.bc");
+    writeFileSync(stubLl, '!llvm.module.flags = !{!0}\n!0 = !{i32 1, !"ThinLTO", i32 0}\n');
+    run(join(llvmBin, "llvm-as"), [stubLl, "-o", stubBc]);
+
+    const merged = join(tmp, "merged.bc");
+    run(join(llvmBin, "llvm-link"), [...bitcode, stubBc, "-o", merged]);
+    run(join(llvmBin, "opt"), ["--module-summary", merged, "-o", outObj]);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+// Imported by rust.ts for `rustLtoFixCliPath`; only act as a CLI when ninja
+// invokes this file directly.
+if (process.argv[1] === import.meta.filename) {
+  main();
+}

--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -29,6 +29,7 @@ import { dirname, join, resolve } from "node:path";
 import { bunExeName, type Config } from "./config.ts";
 import { assert } from "./error.ts";
 import type { Ninja } from "./ninja.ts";
+import { rustLtoFixCliPath } from "./rust-lto-fix-cli.ts";
 import { quote, quoteArgs } from "./shell.ts";
 import { streamPath } from "./stream.ts";
 
@@ -178,9 +179,21 @@ export function rustLibPath(cfg: Config): string {
 // ───────────────────────────────────────────────────────────────────────────
 
 export function registerRustRules(n: Ninja, cfg: Config): void {
-  if (cfg.cargo === undefined) return; // emitRust() asserts with a hint
   const hostWin = cfg.host.os === "windows";
   const q = (p: string) => quote(p, hostWin);
+
+  // Regular-LTO summary fix-up for the ELF cross-language LTO link (see
+  // rustLtoLinkInputs() below). Registered before the cargo gate: the
+  // link-only CI agents emit this edge too, and it needs rustc's
+  // llvm-tools, not cargo.
+  if (cfg.crossLangLto && !cfg.darwin) {
+    n.rule("rust_lto_fix", {
+      command: `${cfg.jsRuntime} ${q(rustLtoFixCliPath)} $in $out $llvm_bin $ar`,
+      description: "regular-LTO summary → $out",
+    });
+  }
+
+  if (cfg.cargo === undefined) return; // emitRust() asserts with a hint
   const stream = `${cfg.jsRuntime} ${q(streamPath)} rust`;
 
   // Cargo build for `bun_bin`. Runs from repo root (workspace `Cargo.toml`
@@ -536,13 +549,15 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
     //     default is also 0 — pass nothing. Adding -Zsplit-lto-unit here
     //     would make the Rust modules the inconsistent ones and abort the
     //     link.
-    //   - linux (full LTO): -fwhole-program-vtables on ELF defaults the
-    //     split ON for C++, so every C++ module (ours and the WebKit -lto
-    //     prebuilts) carries EnableSplitLTOUnit=1. The Rust modules'
+    //   - linux (full LTO): the regular-LTO summary clang writes on ELF
+    //     always says EnableSplitLTOUnit=1, so every C++ module (ours and
+    //     the WebKit -lto prebuilts) carries 1. The Rust modules'
     //     EnableSplitLTOUnit module flag must say 1 to match →
-    //     -Zsplit-lto-unit. (The flag is stamped per-CGU at module creation,
-    //     so it survives rustc's fat-LTO pre-merge — see the
-    //     CARGO_PROFILE_RELEASE_LTO note in the env block below.)
+    //     -Zsplit-lto-unit. (The flag is stamped per-CGU at module
+    //     creation, survives rustc's fat-LTO pre-merge, and is what the
+    //     rust_lto_fix step's `opt --module-summary` copies into the
+    //     regular-LTO summary it bolts onto the merged module — see
+    //     rust-lto-fix-cli.ts.)
     //
     // (`-Clink-arg=-fuse-ld=lld` is pushed unconditionally above — under LTO
     // it doubles as making rustc's bitcode link go through the LTO-aware
@@ -633,7 +648,10 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
     //     embedded bitcode) into ONE summary-less regular-LTO module, which
     //     lld then merges into the same regular-LTO partition as the C++
     //     `-flto=full` objects — that merge is what gives Rust↔C++
-    //     cross-language inlining under full LTO. With `off`, the per-CGU
+    //     cross-language inlining under full LTO. (The merged module first
+    //     gets a regular-LTO summary bolted on by the rust_lto_fix edge —
+    //     rustLtoLinkInputs() below — because lld's EnableSplitLTOUnit
+    //     consistency check requires one.) With `off`, the per-CGU
     //     ThinLTO-summaried modules are processed as ThinLTO partitions
     //     instead, which (a) never exchange function bodies with the C++
     //     regular partition (no cross-language inlining at all), and
@@ -787,6 +805,44 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
   n.blank();
 
   return [lib];
+}
+
+/**
+ * Link inputs for the Rust side of the binary.
+ *
+ * On ELF cross-language LTO targets the fat Rust bitcode member can't go
+ * into the link as-is: it has no per-module summary, so lld reads it as
+ * EnableSplitLTOUnit=0 while every clang-produced full-LTO object (ours,
+ * the deps', the WebKit -lto prebuilts') says 1, and the link aborts with
+ * "inconsistent LTO Unit splitting". rustc has no way to emit a regular-LTO
+ * summary (clang hardcodes one in shouldEmitRegularLTOSummary()), so a
+ * build step rewrites the bitcode with rustc's own LLVM tools — see
+ * rust-lto-fix-cli.ts and the `rustc-no-regular-lto-summary` workaround
+ * entry.
+ *
+ * Returns [fixed bitcode .o, original .a]: the .o defines every Rust symbol
+ * (so the archive's bitcode member is never pulled), and the archive still
+ * supplies its native members (compiler_builtins). On every other config
+ * this is the identity function.
+ */
+export function rustLtoLinkInputs(n: Ninja, cfg: Config, rustObjects: string[]): string[] {
+  const rustLib = rustObjects[0];
+  if (!cfg.crossLangLto || cfg.darwin || rustLib === undefined) return rustObjects;
+  assert(
+    cfg.rustSysroot !== undefined && cfg.host.rustTriple !== undefined,
+    "ELF cross-language LTO needs rustc's sysroot to locate its LLVM tools (llvm-link/opt) for the regular-LTO summary fix-up, but rustc wasn't found",
+    { hint: "Install the pinned rust toolchain (rustup show active-toolchain), or build with --lto=off" },
+  );
+  const llvmBin = join(cfg.rustSysroot, "lib", "rustlib", cfg.host.rustTriple, "bin");
+  const out = resolve(cfg.buildDir, "bun_rust.lto.o");
+  n.build({
+    outputs: [out],
+    rule: "rust_lto_fix",
+    inputs: [rustLib],
+    implicitInputs: [rustLtoFixCliPath],
+    vars: { llvm_bin: llvmBin, ar: cfg.ar },
+  });
+  return [out, ...rustObjects];
 }
 
 /** `${buildDir}/${exe}.linker-map` — lld's `-Wl,-Map=` output (see flags.ts). */

--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -512,10 +512,11 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
   if (!cfg.windows) rustflags.push(`-Clink-arg=-fuse-ld=lld`);
   if (cfg.crossLangLto) {
     // Cross-language LTO: emit LLVM bitcode (not machine code) into the .a
-    // so the final lld `-flto=thin` link sees through Rust↔C++ call edges.
-    // `linker-plugin-lto` supersedes Cargo's `[profile.release] lto="fat"`
-    // (cargo skips its own LTO pass and defers to the linker), so there's no
-    // double-LTO cost.
+    // so the final lld LTO link sees through Rust↔C++ call edges. The shape
+    // of that bitcode must match the platform's C++ LTO mode — thin
+    // (per-CGU, ThinLTO-summaried) on darwin, fat (pre-merged by rustc,
+    // summary-less) on ELF — selected via the CARGO_PROFILE_RELEASE_LTO
+    // override in the env block below.
     //
     // Bitcode-format compatibility: lld must be able to read rustc's bitcode.
     // LLVM bitcode is forward-compatible (newer reads older), so this works
@@ -537,13 +538,11 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
     //     link.
     //   - linux (full LTO): -fwhole-program-vtables on ELF defaults the
     //     split ON for C++, so every C++ module (ours and the WebKit -lto
-    //     prebuilts) carries EnableSplitLTOUnit=1. The Rust ThinLTO
-    //     summaries must say 1 to match → -Zsplit-lto-unit.
-    //
-    // The CARGO_PROFILE_RELEASE_LTO override below keeps the per-CGU
-    // ThinLTO summaries that the consistency check (and cross-language
-    // importing) reads — `lto = "fat"` would pre-merge all crates into one
-    // summary-less blob.
+    //     prebuilts) carries EnableSplitLTOUnit=1. The Rust modules'
+    //     EnableSplitLTOUnit module flag must say 1 to match →
+    //     -Zsplit-lto-unit. (The flag is stamped per-CGU at module creation,
+    //     so it survives rustc's fat-LTO pre-merge — see the
+    //     CARGO_PROFILE_RELEASE_LTO note in the env block below.)
     //
     // (`-Clink-arg=-fuse-ld=lld` is pushed unconditionally above — under LTO
     // it doubles as making rustc's bitcode link go through the LTO-aware
@@ -617,14 +616,30 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
     }
   }
   if (cfg.crossLangLto) {
-    // The workspace `[profile.release]` sets `lto = "fat"` so non-LTO release
-    // builds (where the rust .a is linked as native code) still get
-    // intra-Rust inlining. With `-Clinker-plugin-lto` that pre-merge is
-    // wasted work — the linker re-merges everything anyway — and it strips
-    // the per-module summary index lld needs for the EnableSplitLTOUnit
-    // consistency check (see the EnableSplitLTOUnit note above). Override to
-    // `off` so each crate's bitcode reaches lld with its summary intact.
-    env.CARGO_PROFILE_RELEASE_LTO = "off";
+    // The Rust bitcode's shape must match the platform's C++ LTO mode so both
+    // sides land in the same LTO partition at link time and can exchange
+    // function bodies. (The workspace `[profile.release] lto = "fat"` exists
+    // for non-LTO release builds, where the rust .a is linked as
+    // already-codegen'd machine code and still wants intra-Rust inlining.)
+    //
+    //   - darwin (ThinLTO link): `off`. Each crate's per-CGU bitcode keeps
+    //     its ThinLTO summary, so the whole link is one uniform ThinLTO
+    //     graph and cross-module importing works across Rust↔C++/JSC.
+    //     `fat` would pre-merge the crates into one summary-less blob the
+    //     thin link can't import from (and rustc's serial pre-merge is
+    //     wasted work — the linker schedules the backends itself).
+    //   - ELF (full-LTO link — see the -flto=full entry in flags.ts): `fat`.
+    //     rustc pre-merges every crate (including the prebuilt std's
+    //     embedded bitcode) into ONE summary-less regular-LTO module, which
+    //     lld then merges into the same regular-LTO partition as the C++
+    //     `-flto=full` objects — that merge is what gives Rust↔C++
+    //     cross-language inlining under full LTO. With `off`, the per-CGU
+    //     ThinLTO-summaried modules are processed as ThinLTO partitions
+    //     instead, which (a) never exchange function bodies with the C++
+    //     regular partition (no cross-language inlining at all), and
+    //     (b) go through the LLVM 22 ThinLTO backend pipeline that
+    //     miscompiles JSC on linux.
+    env.CARGO_PROFILE_RELEASE_LTO = cfg.darwin ? "off" : "fat";
   } else if (cfg.asan) {
     // release-asan has `cfg.lto` forced off (config.ts), but without this
     // override Cargo.toml's `[profile.release] lto = "fat"` still applies —

--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -564,6 +564,19 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
     // linker our final link uses, not BFD `/usr/bin/ld`.)
     if (!cfg.darwin) {
       rustflags.push("-Zsplit-lto-unit");
+
+      // Rust functions default to carrying the `uwtable(async)` attribute.
+      // When the LTO inliner inlines such a callee into one of our C++
+      // callers (compiled without unwind tables), the caller inherits the
+      // attribute — so cross-language inlining sprays full .eh_frame FDEs
+      // across thousands of C++ functions (~+1.8 MB on the linux links;
+      // the musl release binary keeps .eh_frame so it pays it in full).
+      // We build with panic=abort and always keep frame pointers, and the
+      // glibc release binary already ships without .eh_frame entirely, so
+      // the tables are pure dead weight here — turn them off for the Rust
+      // side of the merged module. (The prebuilt std bitcode keeps its own
+      // uwtable attrs; this only stops our crates from spreading them.)
+      rustflags.push("-Cforce-unwind-tables=no");
     }
   }
 

--- a/scripts/build/workarounds.ts
+++ b/scripts/build/workarounds.ts
@@ -108,6 +108,30 @@ export const workarounds: Workaround[] = [
       `field itself can stay (collapses to \`= lto\` when no per-target gates remain).`,
   },
   {
+    id: "rustc-no-regular-lto-summary",
+    issue:
+      "https://github.com/rust-lang/rust/issues/ (none filed yet — rustc has no equivalent of clang's shouldEmitRegularLTOSummary())",
+    description:
+      'Under -Clinker-plugin-lto + lto = "fat", rustc emits the merged bitcode module without a ' +
+      "per-module summary, so lld reads it as EnableSplitLTOUnit=0 while every clang full-LTO " +
+      "object (ours and the WebKit -lto prebuilts) hardcodes 1 — the ELF release link aborts " +
+      'with "inconsistent LTO Unit splitting". rust-lto-fix-cli.ts re-emits the Rust bitcode ' +
+      "with a regular-LTO summary using rustc's own llvm-tools (rustLtoLinkInputs() in rust.ts).",
+    applies: cfg => cfg.crossLangLto && !cfg.darwin,
+    expectedToBeFixed: cfg => {
+      // Re-evaluate when the pinned rustc moves to its next LLVM major:
+      // either rustc grew a way to emit regular-LTO summaries (delete the
+      // fix-up), or linux moved to ThinLTO (it's moot), or neither — bump
+      // the threshold and keep it.
+      const RECHECK_AT_RUST_LLVM = "23.0.0";
+      return cfg.rustLlvmVersion !== undefined && satisfiesRange(cfg.rustLlvmVersion, `>=${RECHECK_AT_RUST_LLVM}`);
+    },
+    cleanup:
+      `Delete scripts/build/rust-lto-fix-cli.ts, the rust_lto_fix rule and rustLtoLinkInputs() in ` +
+      `rust.ts, unwrap its two call sites in bun.ts, drop "llvm-tools" from rust-toolchain.toml's ` +
+      `components, and delete this entry.`,
+  },
+  {
     id: "rust-lld-for-crosslang-lto",
     issue: "https://rustc-dev-guide.rust-lang.org/backend/updating-llvm.html",
     description:

--- a/scripts/verify-baseline-static/src/main.rs
+++ b/scripts/verify-baseline-static/src/main.rs
@@ -222,6 +222,13 @@ fn is_impossible_feature(feat: CpuidFeature) -> bool {
 ///   LLVM's per-build internalisation ID (e.g. `__xgetbv.llvm.21110093...`).
 ///   Pure noise.
 ///
+/// - trailing `.[0-9]+` suffix → stripped
+///   LLVM's collision-avoidance rename when (regular-)LTO internalisation
+///   pulls two same-named locals into one module (e.g.
+///   `...Finder14with_pair_impl.1859`). The number is per-build noise, just
+///   like `.llvm.NNNN`. Mangled C/C++/Rust names never contain `.`, so this
+///   only ever touches compiler-generated suffixes.
+///
 /// Non-Rust symbols pass through unchanged: the `Cs[alnum]+_` pattern is
 /// specific enough not to collide with C/C++/asm names in practice (it
 /// requires an uppercase C immediately followed by lowercase s and a
@@ -233,6 +240,18 @@ fn canonicalize_symbol(name: &str) -> String {
         Some(i) if name[i + 6..].bytes().all(|b| b.is_ascii_digit()) => &name[..i],
         _ => name,
     };
+
+    // Then strip plain trailing `.NNNN` LTO-rename suffixes (possibly
+    // stacked, e.g. `foo.12.34`).
+    let mut base = base;
+    while let Some(i) = base.rfind('.') {
+        let digits = &base[i + 1..];
+        if !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit()) {
+            base = &base[..i];
+        } else {
+            break;
+        }
+    }
 
     // Scan for Cs<base62>_ and replace. Hand-rolled rather than pulling in
     // the regex crate for one pattern. The disambiguator is base-62


### PR DESCRIPTION
### What

Rust↔C++ cross-language LTO on the Linux release links, without touching the ThinLTO-miscompile situation: the Rust side now emits **fat** (pre-merged) bitcode that joins the same regular-LTO partition as the `-flto=full` C++ objects.

Two commits:

1. **`CARGO_PROFILE_RELEASE_LTO = fat` on ELF cross-language-LTO builds** (darwin keeps `off` — its ThinLTO link needs the per-CGU summaries from #31303). rustc pre-merges every crate (incl. prebuilt std bitcode) into one regular-LTO module, so lld folds it into the C++ partition: cross-language inlining happens through the regular-LTO merge, and **no ThinLTO backend runs anywhere in the link**.
2. **A regular-LTO-summary fix-up step** (`rust-lto-fix-cli.ts` + the `rust_lto_fix` ninja edge). lld checks split-LTO-unit consistency via each module's *summary*: clang full-LTO objects on ELF always carry `EnableSplitLTOUnit=1` (hardcoded in `shouldEmitRegularLTOSummary()`), while rustc's fat output has no summary at all → reads as 0 → `LTO::checkPartiallySplit()` aborts with "inconsistent LTO Unit splitting" (this is what the first CI round's 4 Linux link jobs hit). rustc can't emit such a summary, so the step extracts the fat bitcode member, adds the `ThinLTO=0` module flag, and re-emits it with `opt --module-summary` from rustc's own llvm-tools. Metadata-only; no optimization passes run. Registered in `workarounds.ts` (`rustc-no-regular-lto-summary`, re-checked at the LLVM-23 rustc bump).

### Local validation (release+LTO build on Linux x64)

- Link succeeds; smoke test + eval/fs/`Bun.serve`+fetch + a real test file (75/75) pass with the built binary.
- **Link: 763s** (vs ~14 min for the previous C++-only full-LTO link — roughly unchanged). Fix-up step: **32s**. Stripped binary: **74.7MB** (+0.9% vs the current release binary).
- **Cross-language inlining is real**: of the 2,508 extern "C" symbols defined by the Rust side, **1,937 are fully inlined and eliminated**, and only **607 out-of-line calls** (to 201 symbols) remain in the entire binary — the survivors are large/cold targets (`Bun__panic`, finalizers, init paths). Before this, every C++→Rust boundary call stayed out-of-line (~15.7k calls total across the boundary, per the #31303 analysis).

### What to watch in CI

- Link-step wall time / memory on the Linux link boxes (locally it's on par with the old link, but those boxes have 64 GB).
- The thin-LTO miscompile symptoms (`require("axobject-query")` DFG repro, bundler-test hangs) must **not** appear — nothing thin runs in this configuration.
- The `rust_lto_fix` step self-installs the `llvm-tools` rustup component on agents that don't have it; first run on each link agent does one `rustup component add`.

### Not changed

- macOS/darwin-cross links: exactly as #31303 shipped.
- aarch64-musl keeps its `crossLangLto` gate (globalopt segfault workaround); lifting it is a candidate follow-up since the bitcode shape that crashed no longer exists.
- Non-LTO and ASAN builds untouched; debug build graph identical.

### Known wart

The fix-up step exists because rustc has no equivalent of clang's regular-LTO summary emission. The durable alternatives are upstreaming that into rustc, or moving Linux to ThinLTO once the LLVM 22 thin-backend miscompile of JSC is isolated — either one deletes the workaround (the `workarounds.ts` entry will nag at the LLVM-23 bump).