### PR TITLE
worker_threads: surface resourceLimits through worker.resourceLimits and the in-worker export

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -81,6 +81,7 @@ const {
   8: _markAsUncloneable,
   9: _setEntryEvaluatedHook,
   10: _isNodeWorker,
+  11: _resourceLimits,
 } = $cpp("Worker.cpp", "createNodeWorkerThreadsBinding") as [
   unknown,
   number,
@@ -93,9 +94,26 @@ const {
   (value: unknown) => void,
   (hook: () => void) => void,
   boolean,
+  NodeResourceLimits | null,
 ];
 
 type NodeWorkerOptions = import("node:worker_threads").WorkerOptions;
+type NodeResourceLimits = import("node:worker_threads").ResourceLimits;
+
+// Bun does not enforce worker resource limits (JSC has no V8-style per-context
+// heap cap), but `worker.resourceLimits` and the module-level `resourceLimits`
+// export inside a worker echo the limits passed to the constructor, filling in
+// the same defaults Node does, so the documented API shape matches.
+// `stackSizeMb` defaults to 4; the rest default to -1 when not a number.
+function applyResourceLimits(raw: NodeResourceLimits | null | undefined): Required<NodeResourceLimits> {
+  const read = (value: unknown, fallback: number): number => (typeof value === "number" ? value : fallback);
+  return {
+    maxYoungGenerationSizeMb: read(raw?.maxYoungGenerationSizeMb, -1),
+    maxOldGenerationSizeMb: read(raw?.maxOldGenerationSizeMb, -1),
+    codeRangeSizeMb: read(raw?.codeRangeSizeMb, -1),
+    stackSizeMb: read(raw?.stackSizeMb, 4),
+  };
+}
 
 // Used to ensure that Blobs created to hold the source code for `eval: true` Workers get cleaned up
 // after their Worker exits
@@ -317,7 +335,9 @@ Object.defineProperty(MessagePort.prototype, kInspectCustom, {
   configurable: true,
 });
 
-let resourceLimits = {};
+// On the main thread this is `{}` (matching Node). Inside a worker it reflects
+// the limits the parent passed to the constructor, with Node's defaults filled.
+let resourceLimits = isMainThread ? {} : applyResourceLimits(_resourceLimits);
 
 const BUN_WORKER_STDIO_KEY = "@@bunWorkerThreadsStdio";
 const BUN_WORKER_MESSAGING_KEY = "@@bunWorkerThreadsMessaging";
@@ -928,6 +948,7 @@ class Worker extends EventEmitter {
   #stderr;
   #stdoutAutoPipe = false;
   #stderrAutoPipe = false;
+  #resourceLimits: Required<NodeResourceLimits>;
 
   // this is used by terminate();
   // either is the exit code if exited, a promise resolving to the exit code, or undefined if we haven't sent .terminate() yet
@@ -944,6 +965,7 @@ class Worker extends EventEmitter {
     options ??= {};
 
     this.#name = normalizeWorkerName(options.name);
+    this.#resourceLimits = applyResourceLimits(options.resourceLimits);
 
     const builtinsGeneratorHatesEval = "ev" + "a" + "l"[0];
     if (options[builtinsGeneratorHatesEval]) {
@@ -1096,6 +1118,10 @@ class Worker extends EventEmitter {
 
   get threadName() {
     return this.#exited ? null : this.#name;
+  }
+
+  get resourceLimits() {
+    return this.#resourceLimits;
   }
 
   ref() {

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -1131,7 +1131,10 @@ class Worker extends EventEmitter {
     // the native handle is null). #onExitPromise is set to the numeric exit
     // code in #onClose, so a number here means the worker has exited.
     if (typeof this.#onExitPromise === "number") return {};
-    return this.#resourceLimits;
+    // Return a fresh copy each access, like Node (its getter builds a new
+    // object from the native handle), so identity differs between reads and
+    // mutations to the returned object don't leak back into the worker.
+    return { ...this.#resourceLimits };
   }
 
   ref() {

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -1121,6 +1121,10 @@ class Worker extends EventEmitter {
   }
 
   get resourceLimits() {
+    // Node returns {} once the worker has stopped (its getter returns {} when
+    // the native handle is null). #onExitPromise is set to the numeric exit
+    // code in #onClose, so a number here means the worker has exited.
+    if (typeof this.#onExitPromise === "number") return {};
     return this.#resourceLimits;
   }
 

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -102,16 +102,22 @@ type NodeResourceLimits = import("node:worker_threads").ResourceLimits;
 
 // Bun does not enforce worker resource limits (JSC has no V8-style per-context
 // heap cap), but `worker.resourceLimits` and the module-level `resourceLimits`
-// export inside a worker echo the limits passed to the constructor, filling in
-// the same defaults Node does, so the documented API shape matches.
-// `stackSizeMb` defaults to 4; the rest default to -1 when not a number.
+// export inside a worker reflect the limits passed to the constructor, applying
+// the same normalizations and defaults Node does so the documented API shape
+// matches. Node (lib/internal/worker.js + node_worker.cc):
+//   - maxYoungGenerationSizeMb / codeRangeSizeMb: echoed verbatim, else -1
+//   - maxOldGenerationSizeMb: clamped to Math.max(value, 2), else -1
+//   - stackSizeMb: echoed when positive, otherwise the 4 MB default
 function applyResourceLimits(raw: NodeResourceLimits | null | undefined): Required<NodeResourceLimits> {
   const read = (value: unknown, fallback: number): number => (typeof value === "number" ? value : fallback);
+  const maxOldValue = raw?.maxOldGenerationSizeMb;
+  const stack = read(raw?.stackSizeMb, 4);
   return {
     maxYoungGenerationSizeMb: read(raw?.maxYoungGenerationSizeMb, -1),
-    maxOldGenerationSizeMb: read(raw?.maxOldGenerationSizeMb, -1),
+    // A numeric maxOldGenerationSizeMb is clamped to >= 2; absent stays -1.
+    maxOldGenerationSizeMb: typeof maxOldValue === "number" ? Math.max(maxOldValue, 2) : -1,
     codeRangeSizeMb: read(raw?.codeRangeSizeMb, -1),
-    stackSizeMb: read(raw?.stackSizeMb, 4),
+    stackSizeMb: stack > 0 ? stack : 4,
   };
 }
 

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -335,6 +335,31 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSWorkerDOMConstructor::
             RETURN_IF_EXCEPTION(throwScope, {});
             options.execArgv.emplace(WTF::move(execArgv));
         }
+
+        JSValue resourceLimitsValue = optionsObject->getIfPropertyExists(lexicalGlobalObject, Identifier::fromString(vm, "resourceLimits"_s));
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (resourceLimitsValue) {
+            if (JSObject* resourceLimitsObject = resourceLimitsValue.getObject()) {
+                // Match Node: a field is applied only if it is a number; anything
+                // else (string, null, missing) falls back to the default that
+                // worker_threads.ts fills in.
+                auto readLimit = [&](ASCIILiteral name, std::optional<double>& out) -> void {
+                    JSValue fieldValue = resourceLimitsObject->getIfPropertyExists(lexicalGlobalObject, Identifier::fromString(vm, name));
+                    RETURN_IF_EXCEPTION(throwScope, void());
+                    if (fieldValue && fieldValue.isNumber()) {
+                        out = fieldValue.asNumber();
+                    }
+                };
+                readLimit("maxYoungGenerationSizeMb"_s, options.resourceLimits.maxYoungGenerationSizeMb);
+                RETURN_IF_EXCEPTION(throwScope, {});
+                readLimit("maxOldGenerationSizeMb"_s, options.resourceLimits.maxOldGenerationSizeMb);
+                RETURN_IF_EXCEPTION(throwScope, {});
+                readLimit("codeRangeSizeMb"_s, options.resourceLimits.codeRangeSizeMb);
+                RETURN_IF_EXCEPTION(throwScope, {});
+                readLimit("stackSizeMb"_s, options.resourceLimits.stackSizeMb);
+                RETURN_IF_EXCEPTION(throwScope, {});
+            }
+        }
     }
 
     // Resolve the spawning thread's env tree (founding one if needed) so disjoint

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -829,6 +829,10 @@ JSValue createNodeWorkerThreadsBinding(Zig::GlobalObject* globalObject)
     JSValue threadId = jsNumber(0);
     JSValue threadName = jsEmptyString(vm);
     JSMap* environmentData = nullptr;
+    // On the main thread this stays null, so the module-level `resourceLimits`
+    // export is `{}` (matching Node). Inside a worker it carries the limits the
+    // parent passed to the constructor; worker_threads.ts fills Node's defaults.
+    JSValue resourceLimits = jsNull();
 
     if (auto* worker = WebWorker__getParentWorker(globalObject->bunVM())) {
         auto& options = worker->options();
@@ -865,6 +869,19 @@ JSValue createNodeWorkerThreadsBinding(Zig::GlobalObject* globalObject)
         // worker-local impl so its GC deref never races m_options.name's
         // (non-atomic) refcount on the parent thread.
         threadName = jsString(vm, options.name.isolatedCopy());
+
+        const auto& limits = options.resourceLimits;
+        JSObject* limitsObject = constructEmptyObject(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (limits.maxYoungGenerationSizeMb)
+            limitsObject->putDirect(vm, Identifier::fromString(vm, "maxYoungGenerationSizeMb"_s), jsNumber(*limits.maxYoungGenerationSizeMb));
+        if (limits.maxOldGenerationSizeMb)
+            limitsObject->putDirect(vm, Identifier::fromString(vm, "maxOldGenerationSizeMb"_s), jsNumber(*limits.maxOldGenerationSizeMb));
+        if (limits.codeRangeSizeMb)
+            limitsObject->putDirect(vm, Identifier::fromString(vm, "codeRangeSizeMb"_s), jsNumber(*limits.codeRangeSizeMb));
+        if (limits.stackSizeMb)
+            limitsObject->putDirect(vm, Identifier::fromString(vm, "stackSizeMb"_s), jsNumber(*limits.stackSizeMb));
+        resourceLimits = limitsObject;
     }
     if (!environmentData) {
         environmentData = JSMap::create(vm, globalObject->mapStructure());
@@ -877,7 +894,7 @@ JSValue createNodeWorkerThreadsBinding(Zig::GlobalObject* globalObject)
     if (auto* worker = WebWorker__getParentWorker(globalObject->bunVM()))
         isNodeWorker = worker->options().kind == WorkerOptions::Kind::Node;
 
-    JSObject* array = constructEmptyArray(globalObject, nullptr, 11);
+    JSObject* array = constructEmptyArray(globalObject, nullptr, 12);
     RETURN_IF_EXCEPTION(scope, {});
     array->putDirectIndex(globalObject, 0, workerData);
     array->putDirectIndex(globalObject, 1, threadId);
@@ -890,6 +907,7 @@ JSValue createNodeWorkerThreadsBinding(Zig::GlobalObject* globalObject)
     array->putDirectIndex(globalObject, 8, JSFunction::create(vm, globalObject, 1, "markAsUncloneable"_s, jsFunctionMarkAsUncloneable, ImplementationVisibility::Public, NoIntrinsic));
     array->putDirectIndex(globalObject, 9, JSFunction::create(vm, globalObject, 1, "setEntryEvaluatedHook"_s, jsFunctionSetEntryEvaluatedHook, ImplementationVisibility::Public, NoIntrinsic));
     array->putDirectIndex(globalObject, 10, jsBoolean(isNodeWorker));
+    array->putDirectIndex(globalObject, 11, resourceLimits);
     return array;
 }
 

--- a/src/jsc/bindings/webcore/WorkerOptions.h
+++ b/src/jsc/bindings/webcore/WorkerOptions.h
@@ -8,6 +8,18 @@
 
 namespace WebCore {
 
+// Node's `resourceLimits` worker option. Bun does not enforce these limits
+// (JSC has no V8-style per-context heap cap), but they are surfaced through
+// `worker.resourceLimits` and the module-level `resourceLimits` export inside
+// the worker so the documented API shape matches Node. Each field is nullopt
+// when the user did not pass it; worker_threads.ts fills in Node's defaults.
+struct WorkerResourceLimits {
+    std::optional<double> maxYoungGenerationSizeMb;
+    std::optional<double> maxOldGenerationSizeMb;
+    std::optional<double> codeRangeSizeMb;
+    std::optional<double> stackSizeMb;
+};
+
 struct WorkerOptions {
     enum class Kind : uint8_t {
         // Created by the global Worker constructor
@@ -38,6 +50,7 @@ struct WorkerOptions {
     Vector<String> argv;
     // If nullopt, inherit execArgv from the parent thread
     std::optional<Vector<String>> execArgv;
+    WorkerResourceLimits resourceLimits;
 };
 
 } // namespace WebCore

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -191,6 +191,109 @@ test("all worker_threads worker instance properties are present", async () => {
   await worker.terminate();
 });
 
+// Bun does not enforce worker resource limits, but the `resourceLimits` passed
+// to `new Worker(...)` must be reflected back through `worker.resourceLimits`
+// and the module-level `resourceLimits` export inside the worker, matching
+// Node's shape (unset numeric fields default to -1, `stackSizeMb` to 4).
+describe("resourceLimits", () => {
+  test("worker.resourceLimits echoes the limits passed to the constructor", async () => {
+    const worker = new Worker(`setInterval(() => {}, 1000);`, {
+      eval: true,
+      resourceLimits: { maxOldGenerationSizeMb: 32, maxYoungGenerationSizeMb: 8, codeRangeSizeMb: 4, stackSizeMb: 2 },
+    });
+    expect(worker.resourceLimits).toEqual({
+      maxYoungGenerationSizeMb: 8,
+      maxOldGenerationSizeMb: 32,
+      codeRangeSizeMb: 4,
+      stackSizeMb: 2,
+    });
+    await worker.terminate();
+  });
+
+  test("worker.resourceLimits fills defaults for fields not passed", async () => {
+    const worker = new Worker(`setInterval(() => {}, 1000);`, {
+      eval: true,
+      resourceLimits: { maxOldGenerationSizeMb: 16 },
+    });
+    expect(worker.resourceLimits).toEqual({
+      maxYoungGenerationSizeMb: -1,
+      maxOldGenerationSizeMb: 16,
+      codeRangeSizeMb: -1,
+      stackSizeMb: 4,
+    });
+    await worker.terminate();
+  });
+
+  test("worker.resourceLimits is a defaulted object when no resourceLimits is passed", async () => {
+    const worker = new Worker(`setInterval(() => {}, 1000);`, { eval: true });
+    expect(worker.resourceLimits).toEqual({
+      maxYoungGenerationSizeMb: -1,
+      maxOldGenerationSizeMb: -1,
+      codeRangeSizeMb: -1,
+      stackSizeMb: 4,
+    });
+    await worker.terminate();
+  });
+
+  test("module-level resourceLimits inside a worker reflects the applied limits", async () => {
+    const worker = new Worker(
+      `
+        const { parentPort, resourceLimits } = require("node:worker_threads");
+        parentPort.postMessage(resourceLimits);
+      `,
+      {
+        eval: true,
+        resourceLimits: { maxOldGenerationSizeMb: 32, maxYoungGenerationSizeMb: 8, codeRangeSizeMb: 4, stackSizeMb: 2 },
+      },
+    );
+    const [message] = await once(worker, "message");
+    expect(message).toEqual({
+      maxYoungGenerationSizeMb: 8,
+      maxOldGenerationSizeMb: 32,
+      codeRangeSizeMb: 4,
+      stackSizeMb: 2,
+    });
+    await worker.terminate();
+  });
+
+  test("module-level resourceLimits inside a worker fills defaults for fields not passed", async () => {
+    const worker = new Worker(
+      `
+        const { parentPort, resourceLimits } = require("node:worker_threads");
+        parentPort.postMessage(resourceLimits);
+      `,
+      { eval: true, resourceLimits: { maxOldGenerationSizeMb: 16 } },
+    );
+    const [message] = await once(worker, "message");
+    expect(message).toEqual({
+      maxYoungGenerationSizeMb: -1,
+      maxOldGenerationSizeMb: 16,
+      codeRangeSizeMb: -1,
+      stackSizeMb: 4,
+    });
+    await worker.terminate();
+  });
+
+  test("module-level resourceLimits on the main thread is an empty object", () => {
+    expect(resourceLimits).toEqual({});
+  });
+
+  test("non-number resourceLimits fields fall back to defaults", async () => {
+    const worker = new Worker(`setInterval(() => {}, 1000);`, {
+      eval: true,
+      // @ts-expect-error intentionally passing wrong types
+      resourceLimits: { maxOldGenerationSizeMb: "16", codeRangeSizeMb: null },
+    });
+    expect(worker.resourceLimits).toEqual({
+      maxYoungGenerationSizeMb: -1,
+      maxOldGenerationSizeMb: -1,
+      codeRangeSizeMb: -1,
+      stackSizeMb: 4,
+    });
+    await worker.terminate();
+  });
+});
+
 test("threadId module and worker property is consistent", async () => {
   const worker1 = new Worker(new URL("./worker-thread-id.ts", import.meta.url));
   expect(threadId).toBe(0);

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -224,6 +224,18 @@ describe("resourceLimits", () => {
     await worker.terminate();
   });
 
+  test("worker.resourceLimits is an empty object once the worker has stopped", async () => {
+    const worker = new Worker(`setInterval(() => {}, 1000);`, {
+      eval: true,
+      resourceLimits: { maxOldGenerationSizeMb: 16 },
+    });
+    const exited = once(worker, "exit");
+    expect(worker.resourceLimits).toMatchObject({ maxOldGenerationSizeMb: 16 });
+    await worker.terminate();
+    await exited;
+    expect(worker.resourceLimits).toEqual({});
+  });
+
   test("worker.resourceLimits is a defaulted object when no resourceLimits is passed", async () => {
     const worker = new Worker(`setInterval(() => {}, 1000);`, { eval: true });
     expect(worker.resourceLimits).toEqual({

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -311,6 +311,22 @@ describe("resourceLimits", () => {
     });
     await worker.terminate();
   });
+
+  test("worker.resourceLimits normalizes values like Node", async () => {
+    // Node clamps maxOldGenerationSizeMb to >= 2 and treats a non-positive
+    // stackSizeMb as the 4 MB default; maxYoung/codeRange are echoed verbatim.
+    const worker = new Worker(`setInterval(() => {}, 1000);`, {
+      eval: true,
+      resourceLimits: { maxOldGenerationSizeMb: 1, stackSizeMb: 0, maxYoungGenerationSizeMb: 0, codeRangeSizeMb: -2 },
+    });
+    expect(worker.resourceLimits).toEqual({
+      maxYoungGenerationSizeMb: 0,
+      maxOldGenerationSizeMb: 2,
+      codeRangeSizeMb: -2,
+      stackSizeMb: 4,
+    });
+    await worker.terminate();
+  });
 });
 
 test("threadId module and worker property is consistent", async () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,4 +1,5 @@
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { describe, expect, it, setDefaultTimeout, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isDebug, tmpdirSync } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
@@ -21,6 +22,12 @@ import wt, {
   Worker,
   workerData,
 } from "worker_threads";
+
+// Several tests spawn a fresh bun subprocess (sometimes one that itself spawns
+// nested workers), which is much slower to start up under the debug/ASAN build
+// and can exceed the 5s default timeout. Give the whole file more headroom
+// there; it doesn't affect the fast in-process tests.
+if (isDebug || isASAN) setDefaultTimeout(60_000);
 
 test("support eval in worker", async () => {
   const worker = new Worker(`postMessage(1 + 1)`, {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -328,6 +328,20 @@ describe("resourceLimits", () => {
     await worker.terminate();
   });
 
+  test("worker.resourceLimits returns a fresh object each access (like Node)", async () => {
+    const worker = new Worker(`setInterval(() => {}, 1000);`, {
+      eval: true,
+      resourceLimits: { maxOldGenerationSizeMb: 16 },
+    });
+    const first = worker.resourceLimits;
+    // Node builds a fresh object from the native handle on every access, so the
+    // identity differs and mutating one read does not affect later reads.
+    expect(worker.resourceLimits).not.toBe(first);
+    first.maxOldGenerationSizeMb = 999;
+    expect(worker.resourceLimits.maxOldGenerationSizeMb).toBe(16);
+    await worker.terminate();
+  });
+
   test("worker.resourceLimits stays {} after a clean exit then terminate()", async () => {
     // A worker that exits cleanly gets exit code 0. terminate() must not treat
     // that falsy code as "not yet exited" — doing so would hang the returned

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -327,6 +327,23 @@ describe("resourceLimits", () => {
     });
     await worker.terminate();
   });
+
+  test("worker.resourceLimits stays {} after a clean exit then terminate()", async () => {
+    // A worker that exits cleanly gets exit code 0. terminate() must not treat
+    // that falsy code as "not yet exited" — doing so would hang the returned
+    // promise and revert resourceLimits from {} to the populated object.
+    const worker = new Worker(`1 + 1;`, {
+      eval: true,
+      resourceLimits: { maxOldGenerationSizeMb: 16 },
+    });
+    const [code] = await once(worker, "exit");
+    expect(code).toBe(0);
+    expect(worker.resourceLimits).toEqual({});
+    // terminate() after a clean exit must resolve (not hang). If it hangs, the
+    // test times out and fails, which is the assertion we want here.
+    await worker.terminate();
+    expect(worker.resourceLimits).toEqual({});
+  });
 });
 
 test("threadId module and worker property is consistent", async () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -339,9 +339,9 @@ describe("resourceLimits", () => {
     const [code] = await once(worker, "exit");
     expect(code).toBe(0);
     expect(worker.resourceLimits).toEqual({});
-    // terminate() after a clean exit must resolve (not hang). If it hangs, the
-    // test times out and fails, which is the assertion we want here.
-    await worker.terminate();
+    // terminate() after the worker has already exited resolves to undefined
+    // (matching Node), and must not hang — if it hangs, the test times out.
+    expect(await worker.terminate()).toBeUndefined();
     expect(worker.resourceLimits).toEqual({});
   });
 });

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -1,8 +1,18 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { once } from "events";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
 import path from "path";
 import wt from "worker_threads";
+
+// Several tests spawn a bun subprocess (one relays many worker messages) which
+// is much slower to start under the debug/ASAN build and can exceed the 5s
+// default test timeout. Give the whole file more headroom there.
+if (isDebug || isASAN) setDefaultTimeout(60_000);
+
+// The in-test watchdog that kills the subprocess on hang needs more headroom
+// than 1s under debug/ASAN, where subprocess startup alone can exceed that. It
+// stays below the per-test timeout so a real hang fails with a clear message.
+const subprocessWatchdogMs = isDebug || isASAN ? 30_000 : 1_000;
 
 describe("web worker", () => {
   async function waitForWorkerResult(worker: Worker, message: any): Promise<any> {
@@ -250,7 +260,7 @@ describe("web worker", () => {
     const timer = setTimeout(() => {
       x.kill();
       done(new Error("timeout"));
-    }, 1000);
+    }, subprocessWatchdogMs);
 
     x.exited.then(async code => {
       clearTimeout(timer);
@@ -278,7 +288,7 @@ describe("web worker", () => {
     const timer = setTimeout(() => {
       x.kill();
       done(new Error("timeout"));
-    }, 1000);
+    }, subprocessWatchdogMs);
 
     x.exited.then(async code => {
       clearTimeout(timer);

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -384,9 +384,11 @@ describe("worker_threads", () => {
     // Wait for the worker to self-exit (its setTimeout fires process.exit(2)
     // after 10 ms) — a fixed sleep races with worker startup, which under
     // debug/ASAN can exceed 200 ms.
-    const [code] = await once(worker, "exit");
-    await worker.terminate();
-    expect(code).toBe(2);
+    const [exitCode] = await once(worker, "exit");
+    expect(exitCode).toBe(2);
+    // terminate() after the worker has already exited resolves to undefined,
+    // matching Node (it only yields a code when it stops a running worker).
+    expect(await worker.terminate()).toBeUndefined();
   });
 
   test.todo("worker terminating forcefully properly interrupts", async () => {


### PR DESCRIPTION
Fixes #31411

## Problem

`node:worker_threads` documents `worker.resourceLimits` and a module-level `resourceLimits` export, but in Bun both were placeholders:

- `worker.resourceLimits` → `undefined`
- module-level `resourceLimits` inside a worker → always `{}`

So passing `resourceLimits` to `new Worker(...)` had no observable effect, which is confusing given the dedicated API reference pages.

### Repro (from the issue)

```js
const { Worker } = require("node:worker_threads");
const worker = new Worker(`setInterval(() => {}, 1000);`, {
  eval: true,
  resourceLimits: { maxOldGenerationSizeMb: 1 },
});
worker.on("online", () => {
  console.log("worker resourceLimits", worker.resourceLimits);
  worker.terminate();
});
```

**Before:** `worker resourceLimits undefined`
**After:** `worker resourceLimits { maxYoungGenerationSizeMb: -1, maxOldGenerationSizeMb: 2, codeRangeSizeMb: -1, stackSizeMb: 4 }` (Node clamps `maxOldGenerationSizeMb` to `>= 2`)

## Cause

- `src/js/node/worker_threads.ts` hardcoded `let resourceLimits = {}` and the `Worker` class had no `resourceLimits` getter.
- The native `WebCore::WorkerOptions` had no fields for Node's worker resource limits, and `JSWorkerDOMConstructor::construct` never parsed the `resourceLimits` option.

## Fix

- **`WorkerOptions.h`** — add a `WorkerResourceLimits` struct (`maxYoungGenerationSizeMb`, `maxOldGenerationSizeMb`, `codeRangeSizeMb`, `stackSizeMb`, each `std::optional<double>`).
- **`JSWorker.cpp`** — parse `options.resourceLimits`; a field is stored only if it is a number (matching Node, which ignores strings/null/etc.).
- **`Worker.cpp`** (`createNodeWorkerThreadsBinding`) — pass the applied limits into the worker as a new element of the binding array (index 4). On the main thread this is `null`, so the module-level export stays `{}` (matching Node).
- **`worker_threads.ts`** — add a shared `applyResourceLimits()` that fills Node's defaults (unset numeric fields → `-1`, `stackSizeMb` → `4`), used by both the new `worker.resourceLimits` getter and the in-worker module-level export.

This makes the documented API surface correct. It does **not** add enforcement: JSC has no V8-style per-context heap cap, so the values reflect what the caller requested rather than an enforced limit. The getter matches Node's synchronous shape exactly; the in-worker export echoes the applied limits (Node fills V8-computed numbers there, which have no JSC equivalent — echoing the requested values is the honest, consistent choice and is far more useful than the previous `{}`).

## Verification

New tests in `test/js/node/worker_threads/worker_threads.test.ts` (the module's existing file) cover the getter (echo + defaults + no-options + non-number fields), the in-worker module export (echo + defaults), and the main-thread `{}` export. All values were cross-checked against Node v24.

```
# without the fix (baked bun)
USE_SYSTEM_BUN=1 bun test test/js/node/worker_threads/worker_threads.test.ts -t resourceLimits
 -> 6 fail, 1 pass

# with the fix
bun bd test test/js/node/worker_threads/worker_threads.test.ts -t resourceLimits
 -> 7 pass
```

Note: a few pre-existing subprocess-spawning tests in this file (`eval does not leak source code`, `environmentData > is deeply inherited`, `execArgv option > inherits…`) intermittently hit the 5s default timeout under the debug+ASAN build and are unrelated to this change — they also time out on clean `main` and pass on release.



## Rebase notes

Rebased onto current main twice as it advanced. The second rebase had non-trivial resolutions:

- `createNodeWorkerThreadsBinding`'s array grew on main (threadName, markAsUntransferable, isNodeWorker, etc. now occupy indices 4-10), so the `resourceLimits` element moved from index 4 to index 11 (array size 12), with the JS destructure updated to match.
- Main independently landed the `terminate()` exit-code-0 fix (explicit `!== undefined` check and resolving to `undefined` after exit), so this PR's equivalent src changes collapsed into main's version; the regression tests from this PR are kept (including the stronger `toBeUndefined()` assertion in `worker.test.ts`).
- `worker.resourceLimits` getter: kept the `#onExitPromise` numeric check for the post-exit `{}` branch; it is set in `#onClose` alongside main's new `#exited` flag, so both signal the same state.

Verified after rebase: both worker test files pass (124 pass / 0 fail), including all 11 resourceLimits tests, and `test-worker-terminate-null-handler.js` passes.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 7 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts test/js/web/workers/worker.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (c28774772)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [19.49ms]
(pass) web worker > preload > string [150.32ms]
(pass) web worker > preload > array of 2 strings [149.01ms]
(pass) web worker > preload > array of string [148.90ms]
(pass) web worker > preload > error in preload doesn't crash parent [141.79ms]
(pass) web worker > worker [137.45ms]
(pass) web worker > worker-env [144.69ms]
(pass) web worker > worker-env: SHARE_ENV via the global Worker constructor [1110.44ms]
(pass) web worker > worker-env with a lot of properties [322.75ms]
(pass) web worker > argv / execArgv defaults [148.77ms]
(pass) web worker > argv / execArgv options [143.5
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (c28774772)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [0.17ms]
(pass) web worker > preload > string [3.60ms]
(pass) web worker > preload > array of 2 strings [4.03ms]
(pass) web worker > preload > array of string [2.93ms]
(pass) web worker > preload > error in preload doesn't crash parent [2.99ms]
(pass) web worker > worker [2.64ms]
(pass) web worker > worker-env [3.41ms]
(pass) web worker > worker-env: SHARE_ENV via the global Worker constructor [31.85ms]
(pass) web worker > worker-env with a lot of properties [6.30ms]
(pass) web worker > argv / execArgv defaults [2.20ms]
(pass) web worker > argv / execArgv options [3.04ms]
(pass) web worker > sending 50 messages should just work [3.87ms]
(pass) web worker > worker with event listeners doesn't close event loop [15.97ms]
(pass) web worker > worker with event listeners doesn't close event loop 2 [15.68ms]
(pass) web worker > worker with process.exit [14.25ms]
(pass) web worker > worker event > is fired with the right object [0.17ms]
(pass) web worker > error event > is fired with a string of the error [2.21ms]
(pass) worker_threads > worker with proce
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts test/js/web/workers/worker.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (c28774772)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [11.58ms]
(pass) web worker > preload > string [135.80ms]
(pass) web worker > preload > array of 2 strings [136.62ms]
(pass) web worker > preload > array of string [174.61ms]
(pass) web worker > preload > error in preload doesn't crash parent [123.45ms]
(pass) web worker > worker [125.32ms]
(pass) web worker > worker-env [131.76ms]
(pass) web worker > worker-env: SHARE_ENV via the global Worker constructor [1065.71ms]
(pass) web worker > worker-env with a lot of properties [324.44ms]
(pass) web worker > argv / execArgv defaults [137.23ms]
(pass) web worker > argv / execArgv options [144.3
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 766ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/24] gen cpp.rs (cppbind)
[2/24] gen JS modules (bundle-modules)
Preprocess modules (6610ms)
Bundle modules (36ms)
Postprocesss modules (19ms)
Bundle Functions (658ms)
Generate Code (71ms)

[7.41s] Bundled "src/js" for production
  1912 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[3/11] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[4/11] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-4.cpp.o
[5/11] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[6/11] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[7/11] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[8/11] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-0.cpp.o
[8/11] link bun-profile
[9/11] bun-profile --revis
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/worker_threads.ts                      |  41 ++++-
 src/jsc/bindings/webcore/JSWorker.cpp              |  25 +++
 src/jsc/bindings/webcore/Worker.cpp                |  20 ++-
 src/jsc/bindings/webcore/WorkerOptions.h           |  13 ++
 test/js/node/worker_threads/worker_threads.test.ts | 171 ++++++++++++++++++++-
 test/js/web/workers/worker.test.ts                 |  26 +++-
 6 files changed, 286 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 7

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js/node/worker_threads.ts                          26     22     74
src/jsc/bindings/webcore/JSWorker.cpp                   2      1     74
src/jsc/bindings/webcore/Worker.cpp                     4      7     74
src/jsc/bindings/webcore/WorkerOptions.h                1      2     74
test/js/node/worker_threads/worker_threads.test.ts     13     19     62
test/js/web/workers/worker.test.ts                      5      6     16
```

</details>

**root cause** · written by the author bot

Node's `resourceLimits` worker option was silently dropped because the JS worker_threads shim exported it only as an empty placeholder and the native worker options had no fields to carry the values, so nothing was parsed, propagated, or reflected back. The fix adds a resource limits struct to the native worker options, parses and validates the option values at worker construction, passes them through the node worker threads binding into the worker thread, and exposes normalized values via `worker.resourceLimits` on the parent side and the module-level `resourceLimits` export inside the wor…

<!-- robobun:evidence:end -->