### PR TITLE
Bun.serve: restore per-request GC memory accounting to fix elevated RSS under HTTP load

### DIFF
--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -729,10 +729,6 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // SAFETY: fully initialized by `create()`.
         let ctx_mut = unsafe { &mut *ctx };
 
-        // Zig parity (server.zig:2490): report the claimed context's size as
-        // extra memory so the GC keeps reclaiming per-request garbage (the JS
-        // `Request`/`Response` wrappers and the native allocations their
-        // finalizers release) under sustained load.
         server
             .vm()
             .jsc_vm()

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -729,9 +729,16 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // SAFETY: fully initialized by `create()`.
         let ctx_mut = unsafe { &mut *ctx };
 
-        // Don't report extra GC memory here: ctx lives in a recycled pool
-        // slot, not a fresh heap allocation, and reporting it per request
-        // hits the slow GC heuristic path on every request.
+        // Zig parity (server.zig:2490): report the claimed context's size as
+        // extra memory so the GC keeps reclaiming per-request garbage (the JS
+        // `Request`/`Response` wrappers and the native allocations their
+        // finalizers release) under sustained load.
+        server
+            .vm()
+            .jsc_vm()
+            .deprecated_report_extra_memory(core::mem::size_of::<
+                ServerRequestContext<SSL, DEBUG>,
+            >());
 
         // Allocate the pooled body slot (ref_count = 1).
         let body_hive = crate::webcore::body::hive_alloc(crate::webcore::body::Value::Null);

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -736,9 +736,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         server
             .vm()
             .jsc_vm()
-            .deprecated_report_extra_memory(core::mem::size_of::<
-                ServerRequestContext<SSL, DEBUG>,
-            >());
+            .deprecated_report_extra_memory(
+                core::mem::size_of::<ServerRequestContext<SSL, DEBUG>>(),
+            );
 
         // Allocate the pooled body slot (ref_count = 1).
         let body_hive = crate::webcore::body::hive_alloc(crate::webcore::body::Value::Null);

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3068,8 +3068,12 @@ where
         // SAFETY: ctx_slot was just initialized by create_in.
         let ctx = unsafe { &mut *ctx_slot };
 
-        // Don't report extra GC memory here: ctx is a recycled pool slot,
-        // not a fresh heap allocation (see NewServer::on_request).
+        // Zig parity (server.zig:2490): report the claimed context's size as
+        // extra memory so the GC keeps reclaiming per-request garbage under
+        // sustained load.
+        self.vm()
+            .jsc_vm()
+            .deprecated_report_extra_memory(core::mem::size_of::<Ctx>());
 
         // `vm.initRequestBodyValue(.{ .Null = {} })` — pooled body slot,
         // ref_count = 1.

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3068,9 +3068,6 @@ where
         // SAFETY: ctx_slot was just initialized by create_in.
         let ctx = unsafe { &mut *ctx_slot };
 
-        // Zig parity (server.zig:2490): report the claimed context's size as
-        // extra memory so the GC keeps reclaiming per-request garbage under
-        // sustained load.
         self.vm()
             .jsc_vm()
             .deprecated_report_extra_memory(core::mem::size_of::<Ctx>());

--- a/test/js/bun/http/serve-request-extra-memory-fixture.ts
+++ b/test/js/bun/http/serve-request-extra-memory-fixture.ts
@@ -1,7 +1,3 @@
-// Fixture for serve-request-extra-memory.test.ts: a hello-world Bun.serve
-// whose /report endpoint returns this process's GC extra-memory accounting
-// (process.memoryUsage().external) so the parent test can verify that serving
-// requests reports the per-request native context memory to the GC.
 const server = Bun.serve({
   port: 0,
   fetch(req) {

--- a/test/js/bun/http/serve-request-extra-memory-fixture.ts
+++ b/test/js/bun/http/serve-request-extra-memory-fixture.ts
@@ -1,0 +1,18 @@
+// Fixture for serve-request-extra-memory.test.ts: a hello-world Bun.serve
+// whose /report endpoint returns this process's GC extra-memory accounting
+// (process.memoryUsage().external) so the parent test can verify that serving
+// requests reports the per-request native context memory to the GC.
+const server = Bun.serve({
+  port: 0,
+  fetch(req) {
+    if (req.url.endsWith("/report")) {
+      return Response.json({
+        external: process.memoryUsage().external,
+        rss: process.memoryUsage.rss(),
+      });
+    }
+    return new Response("Hello, World!");
+  },
+});
+
+process.send!({ url: server.url.href });

--- a/test/js/bun/http/serve-request-extra-memory.test.ts
+++ b/test/js/bun/http/serve-request-extra-memory.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import path from "path";
+
+// Serving a request creates native per-request state (the pooled request
+// context, the Request/Response boxes, the AbortSignal) that is only released
+// once the GC collects the JS wrappers. The server reports that memory to the
+// GC per request (server.zig reportExtraMemory(@sizeOf(Ctx))) — without the
+// report, sustained HTTP load lets the garbage pile up between collections
+// and steady-state RSS balloons.
+//
+// The accounting is observable as process.memoryUsage().external (JSC's
+// extraMemorySize): it must grow by roughly sizeof(RequestContext) per request
+// served since the last full GC.
+test("Bun.serve reports per-request context memory to the GC", async () => {
+  const { promise, resolve } = Promise.withResolvers<string>();
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, "serve-request-extra-memory-fixture.ts")],
+    env: bunEnv,
+    stdout: "inherit",
+    stderr: "inherit",
+    stdin: "ignore",
+    ipc(message) {
+      if (message?.url) resolve(message.url);
+    },
+  });
+
+  const origin = new URL(await promise).origin;
+  const report = async (): Promise<{ external: number; rss: number }> =>
+    await fetch(`${origin}/report`).then(r => r.json());
+
+  const baseline = (await report()).external;
+
+  // Fire keep-alive requests at the hello-world route in concurrent batches,
+  // sampling the server's extra-memory accounting as we go. A full GC in the
+  // server resets the counter, so track the maximum delta seen rather than
+  // only the final value.
+  let maxDelta = 0;
+  const batchSize = 50;
+  const batches = 40; // 2000 requests total
+  for (let i = 0; i < batches; i++) {
+    const batch: Promise<unknown>[] = [];
+    for (let j = 0; j < batchSize; j++) {
+      batch.push(fetch(`${origin}/`).then(r => r.text()));
+    }
+    await Promise.all(batch);
+    if (i % 5 === 4) {
+      const { external } = await report();
+      maxDelta = Math.max(maxDelta, external - baseline);
+    }
+  }
+
+  // 2000 requests × sizeof(RequestContext) (hundreds of bytes each) is well
+  // over 512 KiB of reported extra memory. Without the per-request
+  // accounting, the counter stays within allocator noise (a few KiB).
+  expect(maxDelta).toBeGreaterThan(256 * 1024);
+});

--- a/test/js/bun/http/serve-request-extra-memory.test.ts
+++ b/test/js/bun/http/serve-request-extra-memory.test.ts
@@ -2,16 +2,6 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import path from "path";
 
-// Serving a request creates native per-request state (the pooled request
-// context, the Request/Response boxes, the AbortSignal) that is only released
-// once the GC collects the JS wrappers. The server reports that memory to the
-// GC per request (server.zig reportExtraMemory(@sizeOf(Ctx))) — without the
-// report, sustained HTTP load lets the garbage pile up between collections
-// and steady-state RSS balloons.
-//
-// The accounting is observable as process.memoryUsage().external (JSC's
-// extraMemorySize): it must grow by roughly sizeof(RequestContext) per request
-// served since the last full GC.
 test("Bun.serve reports per-request context memory to the GC", async () => {
   const { promise, resolve } = Promise.withResolvers<string>();
   await using proc = Bun.spawn({
@@ -31,13 +21,9 @@ test("Bun.serve reports per-request context memory to the GC", async () => {
 
   const baseline = (await report()).external;
 
-  // Fire keep-alive requests at the hello-world route in concurrent batches,
-  // sampling the server's extra-memory accounting as we go. A full GC in the
-  // server resets the counter, so track the maximum delta seen rather than
-  // only the final value.
   let maxDelta = 0;
   const batchSize = 50;
-  const batches = 40; // 2000 requests total
+  const batches = 40;
   for (let i = 0; i < batches; i++) {
     const batch: Promise<unknown>[] = [];
     for (let j = 0; j < batchSize; j++) {
@@ -50,8 +36,5 @@ test("Bun.serve reports per-request context memory to the GC", async () => {
     }
   }
 
-  // 2000 requests × sizeof(RequestContext) (hundreds of bytes each) is well
-  // over 512 KiB of reported extra memory. Without the per-request
-  // accounting, the counter stays within allocator noise (a few KiB).
   expect(maxDelta).toBeGreaterThan(256 * 1024);
 });


### PR DESCRIPTION
### What

Peak RSS of `Bun.serve` hello-world servers under HTTP load regressed vs v1.3.14 (last Zig-based release). Measured with `oha -c 125 -z 10s` against `Bun.serve({ fetch: () => new Response("Hello, World!") })` and an Elysia hello-world, reading `VmHWM` from `/proc/<pid>/status` (Linux x64, 16 cores), across official and locally-built release binaries:

| server | v1.3.14 | main (unfixed) | main + this PR |
|---|---|---|---|
| `Bun.serve` | 46 MB | 53–61 MB | **42–43 MB** |
| Elysia | 70 MB | 78–83 MB | **65–67 MB** |

(The same regression shows up as 45→58 MB / 77→123 MB on a faster benchmark machine.) It reproduces on plain canary builds, so it is unrelated to the fat-LTO work, and it is already present before the recent Blob content-type changes.

It is **not a leak**: RSS is flat over 5 minutes / 45M requests and returns to baseline when the load stops. It is a higher steady-state plateau.

### Cause

Every request creates native state that is only reclaimed when the GC collects its JS wrappers: the `Request`/`Response` boxes, the `AbortSignal`, the body string. The Zig server accounts for this by reporting `@sizeOf(Ctx)` of extra memory to the GC for every claimed request context (`server.zig:2490`), which keeps eden collections frequent under sustained load so per-request garbage is reclaimed promptly.

The Rust port originally preserved that call, but #30909 removed it. With no allocation pressure reported, JSC collects far less often under load — the JS heap itself stays tiny, but a rolling backlog of dead-but-uncollected request garbage sits in the native allocators and raises the plateau by ~15–20 MB.

Evidence: under load, `process.memoryUsage().external` (JSC's extra-memory accounting) sits at ~15.7 MB on v1.3.14 vs ~55 KB on main; forcing more frequent collections on an **unmodified** canary (`Bun.gc(false)` every 4096 requests) brings the plateau right back to v1.3.14 levels (65 MB → 49 MB), confirming the mechanism.

### Fix

Bring the per-request report back, exactly as the Zig server does it: report `size_of::<Ctx>()` to the GC for every claimed request context, in both `prepare_js_request_context` (HTTP/1) and the generic `prepare_js_request_context_for` (H3) path.

### Verification

- Release benchmark above: peak RSS back below the v1.3.14 baseline with this patch applied.
- Throughput: unchanged within run-to-run noise (±3%) on config-matched local release builds (unfixed ~165k req/s vs fixed 160–168k req/s across sessions on the same box); v1.3.14 performs this exact per-request report and sustains the same throughput. (Official canary binaries aren't directly comparable to local builds on req/s because the release build configuration just changed.)
- Debug-build A/B driving 16,384 requests at the debug server from a release-build client: 127 req/s both with and without the change — no added cost in debug/ASAN lanes.
- New test `test/js/bun/http/serve-request-extra-memory.test.ts`: spawns a hello-world server, drives 2,000 keep-alive requests, and asserts the server's `process.memoryUsage().external` grows by more than 256 KiB (it grows by ~sizeof(RequestContext) per request with the fix, and stays within ~9 KB of noise without it). Fails on an unfixed build, passes with this PR.
