### PR TITLE
Decode Buffer base64/base64url with simdutf's lenient accept-garbage mode

### DIFF
--- a/bench/snippets/buffer-base64-decode.mjs
+++ b/bench/snippets/buffer-base64-decode.mjs
@@ -47,7 +47,7 @@ bench("Buffer.from 64 KiB base64 with 1% garbage bytes", () => {
   Buffer.from(b64_64K_garbage, "base64");
 });
 
-bench("Buffer.from 684-char base64url (512 bytes)", () => {
+bench(`Buffer.from ${b64url_512.length}-char base64url (512 bytes)`, () => {
   Buffer.from(b64url_512, "base64url");
 });
 

--- a/bench/snippets/buffer-base64-decode.mjs
+++ b/bench/snippets/buffer-base64-decode.mjs
@@ -1,0 +1,58 @@
+// Buffer base64/base64url decoding across the input shapes that take
+// different paths through the decoder: clean input for each alphabet,
+// whitespace-wrapped input, input with non-alphabet bytes, and writes into an
+// existing Buffer.
+import { bench, run } from "../runner.mjs";
+
+function deterministicBytes(n) {
+  const b = Buffer.allocUnsafe(n);
+  let state = 0x12345678;
+  for (let i = 0; i < n; i++) {
+    state = (Math.imul(state, 1103515245) + 12345) | 0;
+    b[i] = state & 0xff;
+  }
+  return b;
+}
+
+const MiB = 1 << 20;
+const bytes1M = deterministicBytes(MiB);
+const bytes64K = deterministicBytes(64 * 1024);
+const bytes512 = deterministicBytes(512);
+
+const b64_1M = bytes1M.toString("base64");
+const b64url_1M = bytes1M.toString("base64url");
+const b64_1M_wrapped = b64_1M.replace(/(.{76})/g, "$1\r\n");
+const b64_64K_garbage = bytes64K.toString("base64").replace(/(.{100})/g, "$1\x01");
+const b64url_512 = bytes512.toString("base64url");
+
+const writeDst = Buffer.allocUnsafe(MiB + 16);
+
+bench("Buffer.from 1 MiB base64", () => {
+  Buffer.from(b64_1M, "base64");
+});
+
+bench("Buffer.from 1 MiB base64url", () => {
+  Buffer.from(b64url_1M, "base64url");
+});
+
+bench("Buffer.from 1 MiB base64, CRLF every 76 chars", () => {
+  Buffer.from(b64_1M_wrapped, "base64");
+});
+
+bench('Buffer.from 1 MiB URL alphabet as "base64"', () => {
+  Buffer.from(b64url_1M, "base64");
+});
+
+bench("Buffer.from 64 KiB base64 with 1% garbage bytes", () => {
+  Buffer.from(b64_64K_garbage, "base64");
+});
+
+bench("Buffer.from 684-char base64url (512 bytes)", () => {
+  Buffer.from(b64url_512, "base64url");
+});
+
+bench("buf.write 1 MiB base64 into existing Buffer", () => {
+  writeDst.write(b64_1M, 0, "base64");
+});
+
+await run();

--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -61,11 +61,20 @@ pub const fn decode_lenient_len(source_len: usize) -> usize {
 /// bytes are skipped, and decoding stops at the first `'='`. Invalid input
 /// never fails — as much data as possible is decoded.
 ///
-/// This is simdutf's `base64_default_or_url_accept_garbage` mode, the same
-/// family of options Node.js uses for its lenient Buffer base64 decoding.
+/// Like Node.js, strictly valid input for the requested alphabet
+/// (`is_urlsafe`) is decoded with simdutf's fastest kernel; everything else is
+/// decoded with simdutf's `base64_default_or_url_accept_garbage` mode.
 ///
 /// Returns the number of bytes written to `destination`.
-pub fn decode_lenient(destination: &mut [u8], source: &[u8]) -> usize {
+pub fn decode_lenient(destination: &mut [u8], source: &[u8], is_urlsafe: bool) -> usize {
+    // Fast path: the common case is strictly valid base64 for the requested
+    // alphabet (possibly with whitespace and padding), which simdutf decodes
+    // with its fastest kernel. This is the same first attempt Node.js makes.
+    let strict = simdutf::base64::decode(source, destination, is_urlsafe);
+    if strict.is_successful() {
+        return strict.count;
+    }
+
     // simdutf only honors the accept-garbage stop-at-'=' rule when the
     // destination can hold the worst-case decode; with a smaller destination
     // (e.g. `buf.write` into a short buffer) it switches to a chunked strategy

--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -48,6 +48,50 @@ pub fn decode(destination: &mut [u8], source: &[u8]) -> SIMDUTFResult {
     result
 }
 
+/// Destination size that lets [`decode_lenient`] decode an input of
+/// `source_len` base64 characters in a single simdutf pass (the worst-case
+/// decoded length).
+pub const fn decode_lenient_len(source_len: usize) -> usize {
+    source_len.div_ceil(4) * 3
+}
+
+/// Decode base64 the way Node.js `Buffer.from(str, "base64" | "base64url")`
+/// and `buf.write(str, "base64" | "base64url")` do: both the standard and the
+/// URL-safe alphabets are accepted, whitespace and any other non-alphabet
+/// bytes are skipped, and decoding stops at the first `'='`. Invalid input
+/// never fails — as much data as possible is decoded.
+///
+/// This is simdutf's `base64_default_or_url_accept_garbage` mode, the same
+/// family of options Node.js uses for its lenient Buffer base64 decoding.
+///
+/// Returns the number of bytes written to `destination`.
+pub fn decode_lenient(destination: &mut [u8], source: &[u8]) -> usize {
+    // simdutf only honors the accept-garbage stop-at-'=' rule when the
+    // destination can hold the worst-case decode; with a smaller destination
+    // (e.g. `buf.write` into a short buffer) it switches to a chunked strategy
+    // that keeps decoding past the '='. Apply the rule up front in that case
+    // so both strategies agree.
+    let source = if destination.len() < decode_lenient_len(source.len()) {
+        match source.iter().position(|&c| c == b'=') {
+            Some(index) => &source[..index],
+            None => source,
+        }
+    } else {
+        source
+    };
+
+    let result = simdutf::base64::decode_lenient(source, destination);
+    if result.is_successful() {
+        return result.count;
+    }
+
+    // The decoded data does not fit in `destination`: fall back to the scalar
+    // decoder, which fills `destination` and stops.
+    let mut wrote: usize = 0;
+    let _ = MIXED_DECODER.decode(destination, source, &mut wrote);
+    wrote
+}
+
 #[derive(thiserror::Error, strum::IntoStaticStr, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DecodeAllocError {
     #[error("DecodingFailed")]

--- a/src/runtime/webcore/encoding.rs
+++ b/src/runtime/webcore/encoding.rs
@@ -572,7 +572,7 @@ pub(crate) unsafe fn write_u8<const ENCODING: u8>(
         Encoding::Hex => Ok(strings::decode_hex_to_bytes_truncate(to_slice, input_slice)),
 
         Encoding::Base64 | Encoding::Base64url => {
-            Ok(bun_base64::decode(to_slice, input_slice).count)
+            Ok(bun_base64::decode_lenient(to_slice, input_slice))
         }
     }
 }
@@ -811,10 +811,10 @@ pub(crate) unsafe fn construct_from_u8<const ENCODING: u8>(
                 return Vec::new();
             }
 
-            let outlen = bun_base64::decode_len(slice);
+            let outlen = bun_base64::decode_lenient_len(slice.len());
             let mut to = vec![0u8; outlen];
 
-            let wrote = bun_base64::decode(&mut to[..outlen], slice).count;
+            let wrote = bun_base64::decode_lenient(&mut to[..outlen], slice);
             if wrote == 0 {
                 return Vec::new();
             }

--- a/src/runtime/webcore/encoding.rs
+++ b/src/runtime/webcore/encoding.rs
@@ -572,7 +572,12 @@ pub(crate) unsafe fn write_u8<const ENCODING: u8>(
         Encoding::Hex => Ok(strings::decode_hex_to_bytes_truncate(to_slice, input_slice)),
 
         Encoding::Base64 | Encoding::Base64url => {
-            Ok(bun_base64::decode_lenient(to_slice, input_slice))
+            let is_urlsafe = matches!(encoding_from_u8(ENCODING), Encoding::Base64url);
+            Ok(bun_base64::decode_lenient(
+                to_slice,
+                input_slice,
+                is_urlsafe,
+            ))
         }
     }
 }
@@ -809,14 +814,23 @@ pub(crate) unsafe fn construct_from_u8<const ENCODING: u8>(
                 return Vec::new();
             }
 
+            let is_urlsafe = matches!(encoding_from_u8(ENCODING), Encoding::Base64url);
             let outlen = bun_base64::decode_lenient_len(slice.len());
-            let mut to = vec![0u8; outlen];
-
-            let wrote = bun_base64::decode_lenient(&mut to[..outlen], slice);
+            // Decode into uninitialized spare capacity: the decoder only ever
+            // writes to the destination, and only the `wrote` bytes it
+            // initialized are committed below. This buffer becomes the
+            // Buffer's storage, so a zero-fill would be pure overhead for
+            // large inputs.
+            let mut to: Vec<u8> = Vec::new();
+            // SAFETY: the returned spare bytes are write-only until committed.
+            let dest = unsafe { bun_core::vec::reserve_spare_bytes(&mut to, outlen) };
+            let wrote = bun_base64::decode_lenient(&mut dest[..outlen], slice, is_urlsafe);
             if wrote == 0 {
                 return Vec::new();
             }
-            to.truncate(wrote);
+            // SAFETY: the decoder initialized the first `wrote` bytes
+            // (`wrote <= outlen <= capacity`).
+            unsafe { bun_core::vec::commit_spare(&mut to, wrote) };
             to
         }
     }

--- a/src/runtime/webcore/encoding.rs
+++ b/src/runtime/webcore/encoding.rs
@@ -716,20 +716,18 @@ pub(crate) unsafe fn write_u16<const ENCODING: u8, const ALLOW_PARTIAL_WRITE: bo
         }
 
         Encoding::Base64 | Encoding::Base64url => {
-            if to_len < 2 || len == 0 {
-                return Ok(0);
-            }
-
-            // very very slow case!
-            // shouldn't really happen though
+            // Match Node.js: two-byte strings are decoded from the low byte of
+            // each UTF-16 code unit (so e.g. U+013D behaves like '=' and
+            // U+1234 like '4'), the same narrowing Node's lenient fallback
+            // decoder applies.
             // SAFETY: caller guarantees `input[..len]` is valid; only an immutable view is
             // needed here since the output goes through `write_u8` with raw `to`.
             let input_slice = unsafe { bun_core::ffi::slice(input, len) };
-            let transcoded = strings::to_utf8_alloc(input_slice);
-            // transcoded dropped at end of scope
-            // SAFETY: `transcoded` is a valid local Vec; `to[..to_len]` validity is
-            // forwarded from this fn's contract and is disjoint from `transcoded`.
-            unsafe { write_u8::<ENCODING>(transcoded.as_ptr(), transcoded.len(), to, to_len) }
+            let mut narrowed = vec![0u8; len];
+            strings::copy_u16_into_u8(&mut narrowed, input_slice);
+            // SAFETY: `narrowed` is a valid local Vec; `to[..to_len]` validity is
+            // forwarded from this fn's contract and is disjoint from `narrowed`.
+            unsafe { write_u8::<ENCODING>(narrowed.as_ptr(), narrowed.len(), to, to_len) }
         } // else => return &[_]u8{};
     }
 }
@@ -868,12 +866,14 @@ pub(crate) unsafe fn construct_from_u16<const ENCODING: u8>(
         }
 
         Encoding::Base64 | Encoding::Base64url => {
-            // very very slow case!
-            // shouldn't really happen though
-            let transcoded = strings::to_utf8_alloc(input_slice);
-            // transcoded dropped at end of scope
-            // SAFETY: `transcoded` is a valid local Vec.
-            unsafe { construct_from_u8::<ENCODING>(transcoded.as_ptr(), transcoded.len()) }
+            // Match Node.js: two-byte strings are decoded from the low byte of
+            // each UTF-16 code unit (so e.g. U+013D behaves like '=' and
+            // U+1234 like '4'), the same narrowing Node's lenient fallback
+            // decoder applies.
+            let mut narrowed = vec![0u8; len];
+            strings::copy_u16_into_u8(&mut narrowed, input_slice);
+            // SAFETY: `narrowed` is a valid local Vec.
+            unsafe { construct_from_u8::<ENCODING>(narrowed.as_ptr(), narrowed.len()) }
         }
     }
 }

--- a/src/simdutf_sys/bun-simdutf.cpp
+++ b/src/simdutf_sys/bun-simdutf.cpp
@@ -368,6 +368,25 @@ SIMDUTFResult simdutf__base64_decode_from_binary16(const char16_t* input, size_t
     return { .error = res.error, .count = res.count };
 }
 
+// Lenient base64 decoding for Node.js Buffer semantics ("base64" and
+// "base64url"): both the standard and URL-safe alphabets are accepted,
+// whitespace and any other non-alphabet characters are skipped, and decoding
+// stops at the first '='. This is simdutf's base64_default_or_url_accept_garbage
+// mode combined with loose handling of the final chunk.
+SIMDUTFResult simdutf__base64_decode_from_binary_lenient(const char* input, size_t length, char* output, size_t outlen_)
+{
+    size_t outlen = outlen_;
+    auto res = simdutf::base64_to_binary_safe(input, length, output, outlen,
+        simdutf::base64_default_or_url_accept_garbage,
+        simdutf::last_chunk_handling_options::loose);
+
+    if (res.error == simdutf::error_code::SUCCESS) {
+        return { .error = 0, .count = outlen };
+    }
+
+    return { .error = res.error, .count = res.count };
+}
+
 size_t simdutf__utf16_length_from_latin1(const char* input, size_t length)
 {
     UNUSED_PARAM(input);

--- a/src/simdutf_sys/simdutf.rs
+++ b/src/simdutf_sys/simdutf.rs
@@ -761,6 +761,12 @@ pub mod base64 {
             outlen: usize,
             is_urlsafe: c_int,
         ) -> SIMDUTFResult;
+        fn simdutf__base64_decode_from_binary_lenient(
+            input: *const u8,
+            length: usize,
+            output: *mut u8,
+            outlen: usize,
+        ) -> SIMDUTFResult;
         fn simdutf__base64_length_from_binary(length: usize, options: c_int) -> usize;
     }
 
@@ -818,6 +824,23 @@ pub mod base64 {
                 output.as_mut_ptr(),
                 output.len(),
                 is_urlsafe as c_int,
+            )
+        }
+    }
+
+    /// Lenient decode matching Node.js `Buffer` semantics
+    /// (`simdutf::base64_default_or_url_accept_garbage` + loose last chunk):
+    /// accepts both the standard and URL-safe alphabets, skips whitespace and
+    /// any other non-alphabet characters, and stops at the first `'='`.
+    /// On success, `count` is the number of bytes written to `output`.
+    pub fn decode_lenient(input: &[u8], output: &mut [u8]) -> SIMDUTFResult {
+        // SAFETY: input/output are valid slices; FFI honors outlen bound.
+        unsafe {
+            simdutf__base64_decode_from_binary_lenient(
+                input.as_ptr(),
+                input.len(),
+                output.as_mut_ptr(),
+                output.len(),
             )
         }
     }

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -788,6 +788,69 @@ for (let withOverridenBufferWrite of [false, true]) {
         expect(() => Buffer.from("", "buffer")).toThrow(/encoding/);
       });
 
+      // Like Node.js, the base64 and base64url decoders are lenient: both
+      // alphabets are accepted, whitespace and any other non-alphabet
+      // characters are ignored, and decoding stops at the first '='.
+      forEachBase64("lenient decoding skips non-alphabet characters", encoding => {
+        expect(Buffer.from("Zm9v\x80YmFy", encoding).toString("latin1")).toBe("foobar");
+        expect(Buffer.from("Zm9v*YmFy", encoding).toString("latin1")).toBe("foobar");
+        expect(Buffer.from("Zm9v\x00YmFy", encoding).toString("latin1")).toBe("foobar");
+        expect(Buffer.from("\xffZm9vYmFy\x03", encoding).toString("latin1")).toBe("foobar");
+        expect(Buffer.from(" Z m 9\tv\nY\rm F y ", encoding).toString("latin1")).toBe("foobar");
+        expect(Buffer.from(" \n\t ", encoding).length).toBe(0);
+        // UTF-16 (two-byte) strings behave the same way
+        expect(Buffer.from("Zm9v\u0100YmFy", encoding).toString("latin1")).toBe("foobar");
+        expect(Buffer.from("Zm9vYmFy\u3000", encoding).toString("latin1")).toBe("foobar");
+      });
+
+      forEachBase64("lenient decoding accepts both alphabets in the same input", encoding => {
+        expect(Array.from(Buffer.from("-_+/", encoding))).toStrictEqual([0xfb, 0xff, 0xbf]);
+        expect(Buffer.from("PDw/Pz8+Pg==", encoding).toString("latin1")).toBe("<<???>>");
+        expect(Buffer.from("PDw_Pz8-Pg", encoding).toString("latin1")).toBe("<<???>>");
+      });
+
+      forEachBase64("lenient decoding stops at the first '='", encoding => {
+        expect(Buffer.from("Zm9v=YmFy", encoding).toString("latin1")).toBe("foo");
+        expect(Buffer.from("=Zm9vYmFy", encoding).length).toBe(0);
+        expect(Buffer.from("YW55=======", encoding).toString("latin1")).toBe("any");
+        expect(Buffer.from("Zm9vYmFy=", encoding).toString("latin1")).toBe("foobar");
+        expect(Buffer.from("Zg=", encoding).toString("latin1")).toBe("f");
+        // a single leftover character contributes nothing
+        expect(Buffer.from("Zm9vYmFyA", encoding).toString("latin1")).toBe("foobar");
+      });
+
+      forEachBase64("lenient decoding of long inputs", encoding => {
+        const expected = Buffer.alloc(6 * 1024, "foobar").toString("latin1");
+        const b64 = Buffer.alloc(8 * 1024, "Zm9vYmFy").toString("latin1");
+        expect(Buffer.from(b64, encoding).toString("latin1")).toBe(expected);
+        expect(Buffer.from(b64.replace(/(.{64})/g, "$1\n"), encoding).toString("latin1")).toBe(expected);
+        expect(Buffer.from(b64.replace(/(.{64})/g, "$1\x85"), encoding).toString("latin1")).toBe(expected);
+      });
+
+      forEachBase64("write() only reports bytes actually written", encoding => {
+        {
+          const b = Buffer.alloc(3, 0xaa);
+          expect(b.write("Zm9vYmFy", 0, encoding)).toBe(3);
+          expect(b.toString("latin1")).toBe("foo");
+        }
+        {
+          const b = Buffer.alloc(8, 0xaa);
+          expect(b.write("Zm9vYmFy", 2, 3, encoding)).toBe(3);
+          expect(Array.from(b)).toStrictEqual([0xaa, 0xaa, 0x66, 0x6f, 0x6f, 0xaa, 0xaa, 0xaa]);
+        }
+        {
+          // '=' early in the string: nothing is decoded and nothing is written
+          const b = Buffer.alloc(8, 0xaa);
+          expect(b.write("Z=m9vYmFy", 0, 3, encoding)).toBe(0);
+          expect(Array.from(b)).toStrictEqual(Array(8).fill(0xaa));
+        }
+        {
+          const b = Buffer.alloc(4, 0xaa);
+          expect(b.write("QQ==QUJD", 0, encoding)).toBe(1);
+          expect(Array.from(b)).toStrictEqual([0x41, 0xaa, 0xaa, 0xaa]);
+        }
+      });
+
       it("creating buffers larger than pool size", () => {
         const l = Buffer.poolSize + 5;
         const s = "h".repeat(l);

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -798,9 +798,38 @@ for (let withOverridenBufferWrite of [false, true]) {
         expect(Buffer.from("\xffZm9vYmFy\x03", encoding).toString("latin1")).toBe("foobar");
         expect(Buffer.from(" Z m 9\tv\nY\rm F y ", encoding).toString("latin1")).toBe("foobar");
         expect(Buffer.from(" \n\t ", encoding).length).toBe(0);
-        // UTF-16 (two-byte) strings behave the same way
+        // two-byte strings: code units whose low byte is not in the alphabet are skipped too
         expect(Buffer.from("Zm9v\u0100YmFy", encoding).toString("latin1")).toBe("foobar");
         expect(Buffer.from("Zm9vYmFy\u3000", encoding).toString("latin1")).toBe("foobar");
+      });
+
+      // Like Node.js, two-byte (UTF-16) strings are decoded from the low byte
+      // of each code unit: a unit like U+013D acts like '=', U+1234 acts like
+      // '4', and units whose low byte is not in the alphabet are skipped.
+      forEachBase64("two-byte strings decode from the low byte of each code unit", encoding => {
+        // \uD83D (first unit of 😀) narrows to 0x3D ('='), which stops decoding
+        expect(Buffer.from("QUJD\u{1F600}REVG", encoding).toString("latin1")).toBe("ABC");
+        expect(Buffer.from("\u{1F600}QUJDREVG", encoding).length).toBe(0);
+        expect(Buffer.from("QUJD\uD83D", encoding).toString("latin1")).toBe("ABC");
+        expect(Buffer.from("\u013DZm9v", encoding).length).toBe(0);
+        expect(Buffer.from("Zm9vYmFy\u013D", encoding).toString("latin1")).toBe("foobar");
+
+        // U+1234 narrows to 0x34 ('4'), U+0441 narrows to 0x41 ('A'): they contribute data
+        expect(Array.from(Buffer.from("\u1234QUJDREVG", encoding))).toStrictEqual([0xe1, 0x05, 0x09, 0x0d, 0x11, 0x15]);
+        expect(Buffer.from("Zm9v\u0441YmFy", encoding)).toStrictEqual(Buffer.from("Zm9vAYmFy", encoding));
+
+        // write() and fill() narrow the same way
+        {
+          const b = Buffer.alloc(8, 0xaa);
+          expect(b.write("QUJD\u{1F600}REVG", 0, encoding)).toBe(3);
+          expect(b.toString("hex")).toBe("414243aaaaaaaaaa");
+        }
+        {
+          const b = Buffer.alloc(1, 0xaa);
+          expect(b.write("YWJj\u3000", 0, encoding)).toBe(1);
+          expect(b.toString("hex")).toBe("61");
+        }
+        expect(Buffer.alloc(6, "QUJD\u{1F600}REVG", encoding).toString("latin1")).toBe("ABCABC");
       });
 
       forEachBase64("lenient decoding accepts both alphabets in the same input", encoding => {


### PR DESCRIPTION
### Motivation

`Buffer.from(str, "base64" | "base64url")` and `buf.write(str, "base64" | "base64url")` decoded through `bun_base64::decode`, which calls simdutf with the strict **standard** alphabet only (`base64_default`). Any URL-safe character (`-`/`_`), non-alphabet byte, interior `=`, or unusual padding made that call fail and the whole input was re-decoded by a scalar fallback decoder — so `base64url` input containing its own alphabet never got the SIMD path at all. Two-byte (UTF-16) strings also decoded differently from Node.

simdutf (8.x, vendored via the WebKit headers) ships the lenient decode modes that Node.js Buffer semantics map onto: `base64_default_or_url_accept_garbage` — accept both alphabets in the same input, skip whitespace and any other non-alphabet characters, stop at the first `=`.

### What changed

- `src/simdutf_sys/bun-simdutf.cpp` / `simdutf.rs`: new `simdutf__base64_decode_from_binary_lenient` wrapper around `simdutf::base64_to_binary_safe(..., base64_default_or_url_accept_garbage, loose)`.
- `src/base64/lib.rs`: new `bun_base64::decode_lenient()` (plus `decode_lenient_len()`), implementing the Node Buffer semantics in one simdutf call. The scalar fallback only remains for destinations smaller than the worst-case decode (e.g. `buf.write` into a short buffer), where simdutf's chunked strategy doesn't honor the stop-at-`=` rule on its own — the input is cut at the first `=` up front so both strategies agree.
- `src/runtime/webcore/encoding.rs`:
  - the Buffer `base64`/`base64url` arms of `construct_from_u8` and `write_u8` use the lenient decode, and the scratch buffer is sized with the worst-case bound (like Node) so the whole decode happens in a single simdutf pass;
  - two-byte (UTF-16) strings are now decoded from the **low byte of each code unit** (the same narrowing the `latin1` encoding uses), matching Node's lenient fallback decoder, instead of transcoding to UTF-8 and skipping non-Latin-1 characters.
- Other `bun_base64::decode` callers (data URLs, ini, csrf, sourcemaps, postgres, images) are unchanged.

### Behavior

For one-byte (Latin-1) strings there is no behavior change — the lenient mode matches what the previous simdutf-then-scalar-fallback combination produced.

For two-byte (UTF-16) strings, decoding now matches Node.js exactly: each code unit is narrowed to its low byte before the lenient decode, so e.g. `U+D83D` (the first unit of 😀) behaves like `=` and stops decoding, and `U+1234` behaves like `4` and contributes data. Previously Bun skipped such characters, producing different output than Node:

```js
Buffer.from("QUJD\u{1F600}REVG", "base64").toString("latin1")
// Node and Bun with this PR: "ABC"     Bun before: "ABCDEF"

Buffer.from("\u1234QUJDREVG", "base64")
// Node and Bun with this PR: <e1 05 09 0d 11 15>     Bun before: "ABCDEF"
```

Verification:

- A 244,000-line randomized differential corpus (garbage/padding/alphabet/whitespace/non-Latin-1 permutations through `Buffer.from` and `buf.write` with random destination sizes, both encodings) now produces **byte-for-byte identical output to Node v24**; before this PR the same corpus had ~34,000 differing lines (all two-byte-string cases).
- A 1,236-input structured corpus (Node's buffer test edge cases plus padding/garbage/alphabet permutations, every ASCII byte, long inputs) is byte-for-byte identical to Bun 1.4.0 for one-byte strings.
- `test/js/node/buffer.test.js` (488 tests) and the vendored Node suites `test-buffer-alloc.js`, `test-buffer-write.js`, `test-buffer-bytelength.js`, `test-buffer-from.js`, `test-buffer-tostring.js`, `test-buffer-fill.js` pass with the debug build.
- New tests pin the lenient semantics (garbage skipping, mixed alphabets, stop-at-`=`, whitespace, undersized `write()`), and the new two-byte tests fail on Bun without this change and pass with it (and pass on Node).

### Performance

Same machine, sequential runs, identical inputs (benchmark added as `bench/snippets/buffer-base64-decode.mjs`); details in the benchmark comment below.

| benchmark | this PR | main | Bun 1.3.14 | Node 24.3 |
|---|---|---|---|---|
| `Buffer.from` 1 MiB base64 (clean) | **141 µs** | 176 µs | 166 µs | 208 µs |
| `Buffer.from` 1 MiB base64url (clean) | **138 µs** | 2.30 ms | 3.88 ms | 207 µs |
| `Buffer.from` 1 MiB base64 + CRLF wrapping | **161 µs** | 205 µs | 179 µs | 250 µs |
| `Buffer.from` 1 MiB URL alphabet as `"base64"` | **169 µs** | 2.30 ms | 3.83 ms | 1.06 ms |
| `Buffer.from` 64 KiB base64, 1% garbage | **10.2 µs** | 160 µs | 248 µs | 71.8 µs |
| `Buffer.from` 512-byte base64url | **~375 ns** | 1.52 µs | 2.28 µs | ~350–385 ns |
| `buf.write` 1 MiB base64 | ~74 µs | ~73 µs | ~72 µs | ~72 µs |

Clean input decodes with simdutf's strict per-alphabet kernel (same first attempt Node makes); the lenient accept-garbage kernel only runs when the input needs it; `Buffer.from` no longer zero-fills the output buffer before decoding.

### Notes

- `base64url` input and inputs containing whitespace/garbage now decode through simdutf's SIMD kernels instead of the scalar fallback.
- The two-byte narrowing applies to `Buffer.from`, `buf.write`, and `buf.fill` with `base64`/`base64url` encodings.

