### PR TITLE
Optimize markdown parser and HTML renderer

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2218,8 +2218,8 @@ fn parse_md_loader<'a>(
     let html: &'static [u8] = match bun_md::root::render_to_html(&source.contents) {
         // Spec transpiler.zig:1162 allocates the rendered HTML via
         // `arena` (the per-parse arena), so it is freed with the
-        // arena. Arena-copy the heap `Box<[u8]>` and let it drop;
-        // PORTING.md §Forbidden patterns bars `Box::leak` here.
+        // arena. Arena-copy the heap `Vec<u8>` and let it drop;
+        // PORTING.md §Forbidden patterns bars leaking it here.
         // SAFETY: ARENA — `arena` outlives the returned
         // `ParseResult.ast` (the AST crate's `Str` convention erases
         // `'bump` to `'static` for `E::String.data`).

--- a/src/md/blocks.rs
+++ b/src/md/blocks.rs
@@ -597,9 +597,7 @@ impl Parser<'_> {
         }
 
         // Scan for end of line
-        while off < self.size && !helpers::is_newline(self.text[off as usize]) {
-            off += 1;
-        }
+        off = OFF::try_from(helpers::find_line_end(self.text, off as usize)).expect("int cast");
 
         line.end = off;
 

--- a/src/md/helpers.rs
+++ b/src/md/helpers.rs
@@ -19,6 +19,150 @@ pub(crate) fn is_newline(c: u8) -> bool {
     c == b'\n' || c == b'\r'
 }
 
+const SWAR_LO: u64 = 0x0101_0101_0101_0101;
+const SWAR_HI: u64 = 0x8080_8080_8080_8080;
+
+/// High bit set in every byte of `w` equal to `b`. May also set high bits in
+/// bytes above the first match, so callers must take the lowest set bit.
+#[inline(always)]
+fn swar_matches_byte(w: u64, b: u8) -> u64 {
+    let x = w ^ (SWAR_LO * b as u64);
+    x.wrapping_sub(SWAR_LO) & !x & SWAR_HI
+}
+
+/// Find the offset of the first `\n` or `\r` at or after `start`, or `text.len()`
+/// if the rest of the text has no newline. Word-at-a-time (SWAR) scan: this runs
+/// for every byte of every line, so the per-byte loop it replaces shows up hot.
+#[inline]
+pub(crate) fn find_line_end(text: &[u8], start: usize) -> usize {
+    let len = text.len();
+    let mut i = start;
+    while i + 8 <= len {
+        let w = u64::from_le_bytes(text[i..i + 8].try_into().expect("8-byte chunk"));
+        let hits = swar_matches_byte(w, b'\n') | swar_matches_byte(w, b'\r');
+        if hits != 0 {
+            return i + (hits.trailing_zeros() as usize) / 8;
+        }
+        i += 8;
+    }
+    while i < len {
+        if is_newline(text[i]) {
+            return i;
+        }
+        i += 1;
+    }
+    len
+}
+
+/// Index of the first byte at or after `start` that needs HTML escaping
+/// (`&`, `<`, `>`, `"`), or `text.len()` if none. The renderer escapes every
+/// piece of normal text through this, so the bulk scan is NEON on aarch64 with
+/// a SWAR fallback elsewhere.
+#[inline]
+pub(crate) fn find_html_escape_byte(text: &[u8], start: usize) -> usize {
+    let len = text.len();
+    let mut i = start;
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        // SAFETY: NEON is baseline on aarch64; loads stay within `text[i..i+16]`.
+        unsafe {
+            use core::arch::aarch64::*;
+            while i + 16 <= len {
+                let v = vld1q_u8(text.as_ptr().add(i));
+                let m = vorrq_u8(
+                    vorrq_u8(vceqq_u8(v, vdupq_n_u8(b'&')), vceqq_u8(v, vdupq_n_u8(b'<'))),
+                    vorrq_u8(vceqq_u8(v, vdupq_n_u8(b'>')), vceqq_u8(v, vdupq_n_u8(b'"'))),
+                );
+                // 4 bits per lane; lowest set nibble = first matching byte.
+                let mask = vget_lane_u64::<0>(vreinterpret_u64_u8(vshrn_n_u16::<4>(
+                    vreinterpretq_u16_u8(m),
+                )));
+                if mask != 0 {
+                    return i + (mask.trailing_zeros() as usize) / 4;
+                }
+                i += 16;
+            }
+        }
+    }
+
+    while i + 8 <= len {
+        let w = u64::from_le_bytes(text[i..i + 8].try_into().expect("8-byte chunk"));
+        let hits = swar_matches_byte(w, b'&')
+            | swar_matches_byte(w, b'<')
+            | swar_matches_byte(w, b'>')
+            | swar_matches_byte(w, b'"');
+        if hits != 0 {
+            return i + (hits.trailing_zeros() as usize) / 8;
+        }
+        i += 8;
+    }
+    while i < len {
+        if matches!(text[i], b'&' | b'<' | b'>' | b'"') {
+            return i;
+        }
+        i += 1;
+    }
+    len
+}
+
+/// Find the index of the first occurrence of `needle` at or after `start`.
+/// Same SWAR scheme as `find_line_end`; used instead of the FFI SIMD search for
+/// the short slices the inline parser scans, where call overhead dominates.
+#[inline]
+pub(crate) fn find_byte(text: &[u8], start: usize, needle: u8) -> Option<usize> {
+    let len = text.len();
+    let mut i = start;
+    while i + 8 <= len {
+        let w = u64::from_le_bytes(text[i..i + 8].try_into().expect("8-byte chunk"));
+        let hits = swar_matches_byte(w, needle);
+        if hits != 0 {
+            return Some(i + (hits.trailing_zeros() as usize) / 8);
+        }
+        i += 8;
+    }
+    while i < len {
+        if text[i] == needle {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Find the index of the first byte at or after `start` whose entry in `table`
+/// is non-zero, or `content.len()` if there is none. Reads eight table entries
+/// per iteration so plain-text runs between special characters are skipped in
+/// bulk instead of one byte at a time.
+#[inline]
+pub(crate) fn next_marked_byte(table: &[u8; 256], content: &[u8], start: usize) -> usize {
+    let len = content.len();
+    // Mark-dense input (e.g. runs of emphasis characters) hits this immediately;
+    // skip the eight-entry probe in that case.
+    if start < len && table[content[start] as usize] != 0 {
+        return start;
+    }
+    let mut i = start;
+    while i + 8 <= len {
+        let f = table[content[i] as usize]
+            | table[content[i + 1] as usize]
+            | table[content[i + 2] as usize]
+            | table[content[i + 3] as usize]
+            | table[content[i + 4] as usize]
+            | table[content[i + 5] as usize]
+            | table[content[i + 6] as usize]
+            | table[content[i + 7] as usize];
+        if f != 0 {
+            break;
+        }
+        i += 8;
+    }
+    while i < len && table[content[i] as usize] == 0 {
+        i += 1;
+    }
+    i
+}
+
 /// Check if byte is ASCII alphanumeric.
 #[inline]
 pub(crate) fn is_alpha_num(c: u8) -> bool {

--- a/src/md/html_renderer.rs
+++ b/src/md/html_renderer.rs
@@ -33,7 +33,22 @@ pub struct OutputBuffer {
 }
 
 impl OutputBuffer {
+    #[inline]
     fn write(&mut self, data: &[u8]) {
+        let len = self.list.len();
+        if self.list.capacity() - len >= data.len() {
+            // Common case: capacity was reserved up front, append without the
+            // grow/oom bookkeeping so callers can inline this into plain stores.
+            // (Writes after an OOM may still land here, but `take_output` discards
+            // the buffer once `oom` is set, so they are never observed.)
+            self.list.extend_from_slice(data);
+            return;
+        }
+        self.write_grow(data);
+    }
+
+    #[cold]
+    fn write_grow(&mut self, data: &[u8]) {
         if self.oom {
             return;
         }
@@ -44,25 +59,26 @@ impl OutputBuffer {
         self.list.extend_from_slice(data);
     }
 
+    #[inline]
     fn write_byte(&mut self, b: u8) {
-        if self.oom {
+        if self.list.capacity() - self.list.len() >= 1 {
+            self.list.push(b);
             return;
         }
-        if self.list.try_reserve(1).is_err() {
-            self.oom = true;
-            return;
-        }
-        self.list.push(b);
+        self.write_grow(&[b]);
     }
 }
 
 impl<'src> HtmlRenderer<'src> {
     pub(crate) fn init(src_text: &'src [u8], render_opts: RenderOptions) -> HtmlRenderer<'src> {
+        // HTML output is typically 1.2x-1.7x the source size; reserving up front
+        // avoids repeated growth-reallocations of the output buffer. Capped so a
+        // pathological input can't trigger an enormous speculative allocation.
+        let mut list = Vec::new();
+        let reserve = (src_text.len() * 2 + 64).min(16 * 1024 * 1024);
+        let _ = list.try_reserve(reserve);
         HtmlRenderer {
-            out: OutputBuffer {
-                list: Vec::new(),
-                oom: false,
-            },
+            out: OutputBuffer { list, oom: false },
             src_text,
             image_nesting_level: 0,
             saved_img_title: Box::default(),
@@ -77,11 +93,11 @@ impl<'src> HtmlRenderer<'src> {
     // deinit → Drop: body only freed Vec/tracker fields, which Rust drops
     // automatically. No explicit Drop impl needed.
 
-    pub(crate) fn to_owned_slice(&mut self) -> Result<Box<[u8]>, AllocError> {
+    pub(crate) fn take_output(&mut self) -> Result<Vec<u8>, AllocError> {
         if self.out.oom {
             return Err(AllocError);
         }
-        Ok(core::mem::take(&mut self.out.list).into_boxed_slice())
+        Ok(core::mem::take(&mut self.out.list))
     }
 
     pub(crate) fn renderer(&mut self) -> Renderer<'_> {
@@ -440,25 +456,27 @@ impl<'src> HtmlRenderer<'src> {
     // HTML writing utilities
     // ========================================
 
+    #[inline]
     pub(crate) fn write(&mut self, data: &[u8]) {
         if self.heading_tracker.in_heading {
-            if self.heading_buf.try_reserve(data.len()).is_err() {
-                self.out.oom = true;
-                return;
-            }
-            self.heading_buf.extend_from_slice(data);
+            self.write_to_heading_buf(data);
         } else {
             self.out.write(data);
         }
     }
 
+    fn write_to_heading_buf(&mut self, data: &[u8]) {
+        if self.heading_buf.try_reserve(data.len()).is_err() {
+            self.out.oom = true;
+            return;
+        }
+        self.heading_buf.extend_from_slice(data);
+    }
+
+    #[inline]
     fn write_byte(&mut self, b: u8) {
         if self.heading_tracker.in_heading {
-            if self.heading_buf.try_reserve(1).is_err() {
-                self.out.oom = true;
-                return;
-            }
-            self.heading_buf.push(b);
+            self.write_to_heading_buf(&[b]);
         } else {
             self.out.write_byte(b);
         }
@@ -528,58 +546,45 @@ impl<'src> HtmlRenderer<'src> {
 
     pub(crate) fn write_html_escaped(&mut self, txt: &[u8]) {
         let mut i: usize = 0;
-        let needle: &[u8] = b"&<>\"";
-
         loop {
-            let Some(next) = strings::index_of_any(&txt[i..], needle) else {
+            let pos = helpers::find_html_escape_byte(txt, i);
+            if pos >= txt.len() {
                 self.write(&txt[i..]);
                 return;
-            };
-            let pos = i + next;
+            }
             if pos > i {
                 self.write(&txt[i..pos]);
             }
-            // needle b"&<>\"" guarantees Some
+            // find_html_escape_byte only stops on bytes html_escape_entity knows
             self.write(strings::html_escape_entity(txt[pos]).unwrap());
             i = pos + 1;
         }
     }
 
     fn write_url_escaped(&mut self, txt: &[u8]) {
-        for &byte in txt {
-            self.write_url_byte(byte);
+        let mut i: usize = 0;
+        while i < txt.len() {
+            // Bulk-copy runs of bytes write_url_byte would pass through verbatim.
+            let pos = helpers::next_marked_byte(&URL_ESCAPE_STOP, txt, i);
+            if pos > i {
+                self.write(&txt[i..pos]);
+            }
+            if pos >= txt.len() {
+                return;
+            }
+            self.write_url_byte(txt[pos]);
+            i = pos + 1;
         }
     }
 
     fn write_url_byte(&mut self, byte: u8) {
-        match byte {
-            b'&' | b'\'' => self.write(strings::html_escape_entity(byte).unwrap()),
-            b'A'..=b'Z'
-            | b'a'..=b'z'
-            | b'0'..=b'9'
-            | b'-'
-            | b'.'
-            | b'_'
-            | b'~'
-            | b':'
-            | b'/'
-            | b'?'
-            | b'#'
-            | b'@'
-            | b'!'
-            | b'$'
-            | b'('
-            | b')'
-            | b'*'
-            | b'+'
-            | b','
-            | b';'
-            | b'='
-            | b'%' => self.write_byte(byte),
-            _ => {
-                let [hi, lo] = bun_core::fmt::hex_byte_upper(byte);
-                self.write(&[b'%', hi, lo]);
-            }
+        if URL_ESCAPE_STOP[byte as usize] == 0 {
+            self.write_byte(byte);
+        } else if byte == b'&' || byte == b'\'' {
+            self.write(strings::html_escape_entity(byte).unwrap());
+        } else {
+            let [hi, lo] = bun_core::fmt::hex_byte_upper(byte);
+            self.write(&[b'%', hi, lo]);
         }
     }
 
@@ -587,6 +592,16 @@ impl<'src> HtmlRenderer<'src> {
     fn write_url_with_escapes(&mut self, txt: &[u8]) {
         let mut i: usize = 0;
         while i < txt.len() {
+            // Bulk-copy runs of bytes that need no escaping ('\\' and '&' are
+            // stop bytes, so the branches below still see them).
+            let run_end = helpers::next_marked_byte(&URL_ESCAPE_STOP, txt, i);
+            if run_end > i {
+                self.write(&txt[i..run_end]);
+                i = run_end;
+                if i >= txt.len() {
+                    break;
+                }
+            }
             if txt[i] == b'\\' && i + 1 < txt.len() && helpers::is_ascii_punctuation(txt[i + 1]) {
                 self.write_url_byte(txt[i + 1]);
                 i += 2;
@@ -681,6 +696,27 @@ impl<'src> HtmlRenderer<'src> {
 // ========================================
 // Static helpers
 // ========================================
+
+/// Single source of truth for URL escaping: zero entries are written verbatim
+/// by `write_url_byte`, non-zero entries get percent-encoded or entity-escaped,
+/// and the URL writers use the same table to bulk-copy safe runs.
+static URL_ESCAPE_STOP: [u8; 256] = {
+    let mut t = [1u8; 256];
+    let mut b: usize = 0;
+    while b < 256 {
+        if (b as u8).is_ascii_alphanumeric() {
+            t[b] = 0;
+        }
+        b += 1;
+    }
+    let safe: &[u8] = b"-._~:/?#@!$()*+,;=%";
+    let mut k: usize = 0;
+    while k < safe.len() {
+        t[safe[k] as usize] = 0;
+        k += 1;
+    }
+    t
+};
 
 // PORT NOTE: Zig's manual `*anyopaque + VTable` is collapsed into the
 // `RendererImpl` trait (see types.rs); the static VTABLE is no longer needed.

--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -123,6 +123,27 @@ impl Parser<'_> {
             return Ok(());
         }
 
+        // Single-line blocks (the common case) need no line merging: process the
+        // source slice directly instead of copying it into the scratch buffer.
+        if block_lines.len() == 1 {
+            let vline = block_lines[0];
+            if vline.beg <= vline.end && vline.end <= self.size {
+                let text = self.text;
+                let mut slice = &text[vline.beg as usize..vline.end as usize];
+                if trim_trailing {
+                    while let Some((&last, rest)) = slice.split_last() {
+                        if last == b' ' || last == b'\t' {
+                            slice = rest;
+                        } else {
+                            break;
+                        }
+                    }
+                }
+                return self.process_inline_content(slice, vline.beg);
+            }
+            return Ok(());
+        }
+
         self.buffer.clear();
 
         for vline in block_lines {
@@ -165,6 +186,16 @@ impl Parser<'_> {
             return Err(parser::Error::StackOverflow);
         }
 
+        // Fast path: no special characters at all (every construct this function
+        // recognizes starts with a byte in the mark map), so the whole slice is a
+        // single plain-text run. Common for table cells, list items and headings.
+        if helpers::next_marked_byte(self.mark_char_map.table(), content, 0) >= content.len() {
+            if !content.is_empty() {
+                self.emit_text(TextType::Normal, content)?;
+            }
+            return Ok(());
+        }
+
         // Failed HTML terminator searches recorded for another slice must not
         // leak into this one (the merged-line buffer is recycled across blocks,
         // so a stale entry could alias a new slice of the same length). The
@@ -183,9 +214,10 @@ impl Parser<'_> {
         self.collect_emphasis_delimiters(content, &brackets);
         self.resolve_emphasis_delimiters();
 
-        // Copy resolved delimiters locally (recursive calls may modify emph_delims)
-        // PORT NOTE: Zig dupe() catch OOM → emit plain text fallback; Rust Vec::clone aborts on OOM.
-        let resolved: Vec<EmphDelim> = self.emph_delims.clone();
+        // Recursive calls (link labels) rebuild self.emph_delims for their own
+        // slice, so the parent keeps its resolved delimiters locally and hands the
+        // storage back at the end for reuse.
+        let resolved: Vec<EmphDelim> = core::mem::take(&mut self.emph_delims);
 
         // Phase 2: Emit content using resolved emphasis info
         let mut i: usize = 0;
@@ -193,13 +225,12 @@ impl Parser<'_> {
         let mut delim_cursor: usize = 0;
 
         while i < content.len() {
-            let c = content[i];
-
-            // Fast path: character has no special meaning, skip it
-            if !self.mark_char_map.is_set(c as usize) {
-                i += 1;
-                continue;
+            // Fast path: bulk-skip runs of characters with no special meaning.
+            i = helpers::next_marked_byte(self.mark_char_map.table(), content, i);
+            if i >= content.len() {
+                break;
             }
+            let c = content[i];
 
             // Newline from merged lines — check for hard break
             if c == b'\n' {
@@ -489,7 +520,8 @@ impl Parser<'_> {
         if text_start < content.len() {
             self.emit_text(TextType::Normal, &content[text_start..])?;
         }
-        // Hand the bracket-map storage back for reuse by the next block.
+        // Hand the delimiter and bracket-map storage back for reuse by the next block.
+        self.emph_delims = resolved;
         self.bracket_pairs = brackets.into_storage();
         // Restore the enclosing slice's memo (the entries built for this slice
         // are meaningless to the caller).
@@ -546,7 +578,7 @@ impl Parser<'_> {
     /// or null if no matching closer found.
     pub fn find_code_span_end(&self, content: &[u8], start: usize, count: usize) -> Option<usize> {
         let mut pos = start;
-        while let Some(backtick_pos) = bun_core::strings::index_of_char_pos(content, b'`', pos) {
+        while let Some(backtick_pos) = helpers::find_byte(content, pos, b'`') {
             pos = backtick_pos + 1;
             while pos < content.len() && content[pos] == b'`' {
                 pos += 1;
@@ -579,6 +611,13 @@ impl Parser<'_> {
         self.emph_delims.clear();
         let mut i: usize = 0;
         while i < content.len() {
+            // Every character this pass cares about is in the mark map, so runs of
+            // unmarked bytes can be skipped in bulk; marked-but-irrelevant bytes
+            // (e.g. '&', ']') still fall through to the `i += 1` at the bottom.
+            i = helpers::next_marked_byte(self.mark_char_map.table(), content, i);
+            if i >= content.len() {
+                break;
+            }
             let c = content[i];
             // Skip backslash escapes
             if c == b'\\' && i + 1 < content.len() && helpers::is_ascii_punctuation(content[i + 1])

--- a/src/md/links.rs
+++ b/src/md/links.rs
@@ -37,10 +37,19 @@ pub struct Autolink {
 
 /// Characters that can affect bracket matching: the brackets themselves,
 /// backslash escapes, code spans, and (unless HTML spans are disabled) HTML
-/// tags/autolinks. Used to SIMD-skip runs of ordinary text while building the
-/// bracket-pair map.
-const BRACKET_SCAN_CHARS: &[u8] = b"[]\\`<";
-const BRACKET_SCAN_CHARS_NO_HTML: &[u8] = b"[]\\`";
+/// tags/autolinks. Stop tables for `helpers::next_marked_byte`, used to skip
+/// runs of ordinary text while building the bracket-pair map.
+const fn bracket_scan_table(chars: &[u8]) -> [u8; 256] {
+    let mut t = [0u8; 256];
+    let mut i = 0;
+    while i < chars.len() {
+        t[chars[i] as usize] = 1;
+        i += 1;
+    }
+    t
+}
+static BRACKET_SCAN_STOP: [u8; 256] = bracket_scan_table(b"[]\\`<");
+static BRACKET_SCAN_STOP_NO_HTML: [u8; 256] = bracket_scan_table(b"[]\\`");
 
 /// Result of matching a `[` against its closing `]`.
 struct BracketScan {
@@ -122,23 +131,23 @@ impl Parser<'_> {
 
         // No '[' means nothing will ever be looked up; no ']' means every
         // opener is trivially unmatched (e.g. "[".repeat(n)) — skip the walk.
-        if bun_core::immutable::index_of_char(content, b'[').is_none() {
+        if helpers::find_byte(content, 0, b'[').is_none() {
             return BracketMatches {
                 pairs: storage,
                 no_closers: false,
             };
         }
-        if bun_core::immutable::index_of_char(content, b']').is_none() {
+        if helpers::find_byte(content, 0, b']').is_none() {
             return BracketMatches {
                 pairs: storage,
                 no_closers: true,
             };
         }
 
-        let scan_chars: &'static [u8] = if self.flags.no_html_spans {
-            BRACKET_SCAN_CHARS_NO_HTML
+        let scan_stop: &'static [u8; 256] = if self.flags.no_html_spans {
+            &BRACKET_SCAN_STOP_NO_HTML
         } else {
-            BRACKET_SCAN_CHARS
+            &BRACKET_SCAN_STOP
         };
 
         // While an opener is still unmatched, its `close` slot holds the index
@@ -183,12 +192,15 @@ impl Parser<'_> {
                     }
                     pos += 1;
                 }
-                // Ordinary text: SIMD-jump to the next character that can
-                // affect bracket matching.
-                _ => match bun_core::immutable::index_of_any(&content[pos..], scan_chars) {
-                    Some(rel) => pos += rel as usize,
-                    None => break,
-                },
+                // Ordinary text: jump to the next character that can affect
+                // bracket matching.
+                _ => {
+                    let next = helpers::next_marked_byte(scan_stop, content, pos);
+                    if next >= content.len() {
+                        break;
+                    }
+                    pos = next;
+                }
             }
         }
 

--- a/src/md/parser.rs
+++ b/src/md/parser.rs
@@ -3,15 +3,6 @@
 use core::cell::Cell;
 use core::ffi::c_void;
 
-use bun_collections::bit_set::{ArrayBitSet, num_masks_for};
-
-// Zig `bun.bit_set.StaticBitSet(256)` resolves to `ArrayBitSet(usize, 256)`
-// (size > @bitSizeOf(usize)). Stable Rust cannot branch a type on a const
-// generic, so per bit_set.rs guidance we pick `ArrayBitSet` directly. The
-// inline scanner in inlines.rs depends on `is_set()` being real — a no-op
-// stub here makes every byte fall through the fast path and disables all
-// inline-span recognition (emphasis, links, code, entities, breaks).
-pub type MarkCharMap = ArrayBitSet<256, { num_masks_for(256) }>;
 use bun_core::StackCheck;
 
 use super::helpers;
@@ -26,6 +17,38 @@ use crate::RenderOptions; // Zig: `root.RenderOptions` (root.zig → crate lib.r
 // aliases, so they live at module scope as `parser::EmphDelim` etc.
 pub use super::inlines::{EmphDelim, HtmlScanMemo, MAX_EMPH_MATCHES};
 pub use super::ref_defs::RefDef;
+
+// Zig used `bun.bit_set.StaticBitSet(256)`. The Rust port keeps a byte-per-char
+// table instead of a bitset: the inline scanner skips runs of non-mark bytes
+// eight at a time by OR-ing table entries (helpers::next_marked_byte), which a
+// bitset cannot do without per-byte shift/mask work. The inline scanner in
+// inlines.rs depends on `is_set()` being real — a no-op stub here makes every
+// byte fall through the fast path and disables all inline-span recognition
+// (emphasis, links, code, entities, breaks).
+pub struct MarkCharMap {
+    table: [u8; 256],
+}
+
+impl MarkCharMap {
+    pub fn init_empty() -> MarkCharMap {
+        MarkCharMap { table: [0; 256] }
+    }
+
+    #[inline]
+    pub fn set(&mut self, idx: usize) {
+        self.table[idx] = 1;
+    }
+
+    #[inline]
+    pub fn is_set(&self, idx: usize) -> bool {
+        self.table[idx] != 0
+    }
+
+    #[inline]
+    pub fn table(&self) -> &[u8; 256] {
+        &self.table
+    }
+}
 
 /// Parser context holding all state during parsing.
 // PORT NOTE: `text` is a caller-owned borrow for the parser's lifetime.
@@ -177,6 +200,14 @@ impl<'a> Parser<'a> {
 
     fn init(text: &'a [u8], flags: Flags, rend: Renderer<'a>) -> Parser<'a> {
         let size: OFF = OFF::try_from(text.len()).expect("int cast");
+        // block_bytes holds one BlockHeader per block plus one VerbatimLine per
+        // line, which works out to a fraction of the source size for typical
+        // documents. Reserving up front avoids growth-reallocations on the hot
+        // path; the cap keeps the speculative allocation bounded.
+        let mut block_bytes = Vec::new();
+        let _ = block_bytes.try_reserve((text.len() / 2 + 128).min(4 * 1024 * 1024));
+        let mut current_block_lines = Vec::new();
+        let _ = current_block_lines.try_reserve(16);
         let mut p = Parser {
             text,
             size,
@@ -193,14 +224,14 @@ impl<'a> Parser<'a> {
             mark_char_map: MarkCharMap::init_empty(),
             marks: Vec::new(),
             containers: Vec::new(),
-            block_bytes: Vec::new(),
+            block_bytes,
             buffer: Vec::new(),
             emph_delims: Vec::new(),
             bracket_pairs: Vec::new(),
             html_scan_memo: Cell::new(HtmlScanMemo::EMPTY),
             n_containers: 0,
             current_block: None,
-            current_block_lines: Vec::new(),
+            current_block_lines,
             opener_stacks: [(); NUM_OPENER_STACKS].map(|_| OpenerStack::default()),
             unresolved_link_head: -1,
             unresolved_link_tail: -1,
@@ -330,7 +361,7 @@ pub fn render_to_html(
     text: &[u8],
     flags: Flags,
     render_opts: RenderOptions,
-) -> Result<Box<[u8]>, ParserError> {
+) -> Result<Vec<u8>, ParserError> {
     // Skip UTF-8 BOM
     let input = helpers::skip_utf8_bom(text);
 
@@ -349,7 +380,7 @@ pub fn render_to_html(
     }
     drop(parser);
 
-    Ok(html_renderer.to_owned_slice()?)
+    Ok(html_renderer.take_output()?)
 }
 
 /// Parse and render using a custom renderer. The caller provides its own

--- a/src/md/ref_defs.rs
+++ b/src/md/ref_defs.rs
@@ -386,6 +386,26 @@ impl Parser<'_> {
                 continue;
             }
 
+            // A ref def can only start at the very beginning of the paragraph, so
+            // when the first character already rules that out, skip the block
+            // without merging its lines (the common case for ordinary text).
+            {
+                // SAFETY: n_lines >= 1 and lines_off + size_of::<VerbatimLine>() <= bytes_len
+                // per the lines_size bounds check above.
+                let first: VerbatimLine = unsafe {
+                    bytes_ptr
+                        .add(lines_off)
+                        .cast::<VerbatimLine>()
+                        .read_unaligned()
+                };
+                if first.beg < first.end
+                    && first.end <= self.size
+                    && self.text[first.beg as usize] != b'['
+                {
+                    continue;
+                }
+            }
+
             // Merge lines into buffer to parse ref defs
             self.buffer.clear();
             for li in 0..n_lines {

--- a/src/md/render_blocks.rs
+++ b/src/md/render_blocks.rs
@@ -148,7 +148,19 @@ impl Parser<'_> {
                 // GFM: \| in table cells should be consumed at the table level,
                 // replacing \| with | before inline processing. This matters for
                 // code spans where backslash escapes don't apply.
-                if bun_core::strings::index_of(cell_content, b"\\|").is_some() {
+                let has_escaped_pipe = {
+                    let mut search = 0usize;
+                    let mut found = false;
+                    while let Some(bs) = helpers::find_byte(cell_content, search, b'\\') {
+                        if bs + 1 < cell_content.len() && cell_content[bs + 1] == b'|' {
+                            found = true;
+                            break;
+                        }
+                        search = bs + 1;
+                    }
+                    found
+                };
+                if has_escaped_pipe {
                     let mut buf: Vec<u8> = Vec::new();
                     let unescaped: &[u8] = if buf.try_reserve(cell_content.len()).is_ok() {
                         let mut ci: usize = 0;

--- a/src/md/root.rs
+++ b/src/md/root.rs
@@ -210,7 +210,7 @@ impl Options {
 }
 
 // TODO(port): narrow error set — Zig: `parser.Parser.Error`
-pub fn render_to_html(text: &[u8]) -> Result<Box<[u8]>, parser::ParserError> {
+pub fn render_to_html(text: &[u8]) -> Result<Vec<u8>, parser::ParserError> {
     render_to_html_with_options(text, Options::default())
 }
 
@@ -218,7 +218,7 @@ pub fn render_to_html(text: &[u8]) -> Result<Box<[u8]>, parser::ParserError> {
 pub fn render_to_html_with_options(
     text: &[u8],
     options: Options,
-) -> Result<Box<[u8]>, parser::ParserError> {
+) -> Result<Vec<u8>, parser::ParserError> {
     parser::render_to_html(text, options.to_flags(), options.to_render_options())
 }
 


### PR DESCRIPTION
## Summary
- Replace per-byte scanning with word-at-a-time (SWAR) and NEON scans for line endings, inline mark lookup, and HTML escaping
- Add fast paths: inline content with no special characters, single-line blocks processed without copying into the scratch buffer, and reference-definition parsing skipped for paragraphs that cannot contain one
- Batch HTML/URL escape output into runs, preallocate the output buffer and block storage, and make the output write path inlinable
- Replace FFI SIMD searches on short slices with local SWAR helpers, return `Vec<u8>` from `render_to_html` to drop the final shrink copy, and reuse emphasis delimiter storage instead of cloning it per block

## Benchmarks

`Bun.markdown.html` (parse + render to HTML) on a typical Markdown document containing headings, lists, fenced code, a blockquote, a table, links, and emphasis. Apple Silicon (M-series), release build, warm process, default options.

| Input size | Bun 1.3.11 | main (before) | this PR | vs main |
|---|---|---|---|---|
| 0.5 KB | 337,259 ops/s (160 MB/s) | 265,722 ops/s (126 MB/s) | 501,452 ops/s (238 MB/s) | 1.89x |
| 4.9 KB | 36,769 ops/s (175 MB/s) | 36,567 ops/s (174 MB/s) | 54,067 ops/s (257 MB/s) | 1.48x |
| 48.7 KB | 3,765 ops/s (179 MB/s) | 3,726 ops/s (177 MB/s) | 5,464 ops/s (260 MB/s) | 1.47x |

Parser-level throughput (excluding JS string conversion) on the 48.7 KB input goes from ~184 MB/s to ~274 MB/s.

## Test plan
- [x] `bun bd test test/js/bun/md/` — 1040 tests pass (CommonMark spec, GFM compatibility, edge cases, heading IDs, React renderer, render callback)
- [x] Output of the benchmark inputs is byte-identical before and after
- [ ] CI