### PR TITLE
node:fs: move fs.watch's FSWatcher into a lazily loaded internal module

### DIFF
--- a/src/js/internal/fs/watch.ts
+++ b/src/js/internal/fs/watch.ts
@@ -1,0 +1,82 @@
+// fs.watch is lazily loaded so the FSWatcher class is only set up when it is used.
+const EventEmitter = require("node:events");
+
+// The native `node:fs` binding, shared via `internal/fs/binding`.
+const fs = require("internal/fs/binding");
+
+class FSWatcher extends EventEmitter {
+  #watcher;
+  #listener;
+  constructor(path, options, listener) {
+    super();
+
+    if (path instanceof URL) {
+      path = Bun.fileURLToPath(path);
+    } else if (typeof path === "string" && path.startsWith("file:")) {
+      path = Bun.fileURLToPath(path);
+    }
+
+    if (typeof options === "function") {
+      listener = options;
+      options = {};
+    } else if (typeof options === "string") {
+      options = { encoding: options };
+    }
+
+    if (typeof listener !== "function") {
+      listener = () => {};
+    }
+
+    this.#listener = listener;
+    try {
+      this.#watcher = fs.watch(path, options || {}, this.#onEvent.bind(this));
+    } catch (e: any) {
+      e.path = path;
+      e.filename = path;
+      throw e;
+    }
+  }
+
+  #onEvent(eventType, filenameOrError) {
+    if (eventType === "close") {
+      // close on next microtask tick to avoid long-running function calls when
+      // we're trying to detach the watcher
+      queueMicrotask(() => {
+        this.emit("close", filenameOrError);
+      });
+      return;
+    } else if (eventType === "error") {
+      // Next.js/watchpack ends up watching paths it does not have access to,
+      // which surfaces here as EACCES errors. Rewriting the code to EPERM
+      // makes watchpack's error handling ignore the error instead of failing.
+      if (filenameOrError.code === "EACCES") filenameOrError.code = "EPERM";
+
+      this.emit(eventType, filenameOrError);
+    } else {
+      this.emit("change", eventType, filenameOrError);
+      this.#listener(eventType, filenameOrError);
+    }
+  }
+
+  close() {
+    this.#watcher?.close();
+    this.#watcher = null;
+  }
+
+  ref() {
+    this.#watcher?.ref();
+  }
+
+  unref() {
+    this.#watcher?.unref();
+  }
+
+  // https://github.com/nodejs/node/blob/9f51c55a47702dc6a0ca3569853dd7ba022bf7bb/lib/internal/fs/watchers.js#L259-L263
+  start() {}
+}
+
+function watch(path, options, listener) {
+  return new FSWatcher(path, options, listener);
+}
+
+export default { watch, FSWatcher };

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -1,6 +1,5 @@
 // Hardcoded module "node:fs"
 import type { Dirent as DirentType, PathLike, Stats as StatsType } from "fs";
-const EventEmitter = require("node:events");
 const promises = require("node:fs/promises");
 const types = require("node:util/types");
 const {
@@ -41,78 +40,6 @@ function nullcallback(callback) {
   return FunctionPrototypeBind.$call(callback, undefined, null);
 }
 const FunctionPrototypeBind = nullcallback.bind;
-
-class FSWatcher extends EventEmitter {
-  #watcher;
-  #listener;
-  constructor(path, options, listener) {
-    super();
-
-    if (path instanceof URL) {
-      path = Bun.fileURLToPath(path);
-    } else if (typeof path === "string" && path.startsWith("file:")) {
-      path = Bun.fileURLToPath(path);
-    }
-
-    if (typeof options === "function") {
-      listener = options;
-      options = {};
-    } else if (typeof options === "string") {
-      options = { encoding: options };
-    }
-
-    if (typeof listener !== "function") {
-      listener = () => {};
-    }
-
-    this.#listener = listener;
-    try {
-      this.#watcher = fs.watch(path, options || {}, this.#onEvent.bind(this));
-    } catch (e: any) {
-      e.path = path;
-      e.filename = path;
-      throw e;
-    }
-  }
-
-  #onEvent(eventType, filenameOrError) {
-    if (eventType === "close") {
-      // close on next microtask tick to avoid long-running function calls when
-      // we're trying to detach the watcher
-      queueMicrotask(() => {
-        this.emit("close", filenameOrError);
-      });
-      return;
-    } else if (eventType === "error") {
-      // TODO: Next.js/watchpack causes this to emits weird EACCES errors on
-      // paths that shouldn't be watched. A better solution is to figure out why
-      // these paths get watched in the first place. For now we will rewrite the
-      // .code, which will cause their code path to ignore the error.
-      if (filenameOrError.code === "EACCES") filenameOrError.code = "EPERM";
-
-      this.emit(eventType, filenameOrError);
-    } else {
-      this.emit("change", eventType, filenameOrError);
-      this.#listener(eventType, filenameOrError);
-    }
-  }
-
-  close() {
-    this.#watcher?.close();
-    this.#watcher = null;
-  }
-
-  ref() {
-    this.#watcher?.ref();
-  }
-
-  unref() {
-    this.#watcher?.unref();
-  }
-
-  // https://github.com/nodejs/node/blob/9f51c55a47702dc6a0ca3569853dd7ba022bf7bb/lib/internal/fs/watchers.js#L259-L263
-  start() {}
-}
 
 function openAsBlob(path, options) {
   return Promise.$resolve(Bun.file(path, options));
@@ -577,7 +504,7 @@ var access = function access(path, mode, callback) {
   Dirent = fs.Dirent,
   Stats = fs.Stats,
   watch = function watch(path, options, listener) {
-    return new FSWatcher(path, options, listener);
+    return require("internal/fs/watch").watch(path, options, listener);
   },
   opendir = function opendir(path, options, callback) {
     // TODO: validatePath
@@ -1218,7 +1145,6 @@ function setName(fn, value) {
   Object.$defineProperty(fn, "name", { value, enumerable: false, configurable: true });
 }
 setName(Dirent, "Dirent");
-setName(FSWatcher, "FSWatcher");
 setName(Stats, "Stats");
 setName(_toUnixTimestamp, "_toUnixTimestamp");
 setName(access, "access");

--- a/src/jsc/bindings/ProcessBindingNatives.cpp
+++ b/src/jsc/bindings/ProcessBindingNatives.cpp
@@ -117,6 +117,7 @@ static JSValue processBindingNativesReturnUndefined(VM& vm, JSObject* bindingObj
     internal/fs/cp                              processBindingNativesGetter     PropertyCallback
     internal/fs/glob                            processBindingNativesGetter     PropertyCallback
     internal/fs/streams                         processBindingNativesGetter     PropertyCallback
+    internal/fs/watch                           processBindingNativesGetter     PropertyCallback
     internal/fs/watchfile                       processBindingNativesGetter     PropertyCallback
     internal/html                               processBindingNativesGetter     PropertyCallback
     internal/http                               processBindingNativesGetter     PropertyCallback

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -1,5 +1,6 @@
 import { pathToFileURL } from "bun";
 import { bunEnv, bunExe, bunRun, bunRunAsScript, isMacOS, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { EventEmitter } from "node:events";
 import fs, { FSWatcher } from "node:fs";
 import path from "path";
 
@@ -264,6 +265,31 @@ describe("fs.watch", () => {
       expect(err.code).toBe("ENOENT");
       expect(err.syscall).toBe("watch");
       done();
+    }
+  });
+
+  test("returns an FSWatcher that inherits from EventEmitter", () => {
+    const watcher = fs.watch(path.join(testDir, "watch.txt"));
+    try {
+      expect(watcher).toBeInstanceOf(EventEmitter);
+      expect(watcher.constructor.name).toBe("FSWatcher");
+      expect(typeof watcher.ref).toBe("function");
+      expect(typeof watcher.unref).toBe("function");
+      expect(typeof watcher.start).toBe("function");
+    } finally {
+      watcher.close();
+    }
+  });
+
+  test("errors from watching a missing path keep path and filename properties", () => {
+    const missing = path.join(testDir, "missing-subdir", "404.txt");
+    try {
+      fs.watch(missing);
+      expect.unreachable();
+    } catch (err: any) {
+      expect(err.code).toBe("ENOENT");
+      expect(err.path).toBe(missing);
+      expect(err.filename).toBe(missing);
     }
   });
 


### PR DESCRIPTION
### What

Moves the `fs.watch` implementation (the `FSWatcher` class) out of `node:fs` into a new lazily loaded internal module, as requested. `fs.watch` in `fs.ts` is now just a thin wrapper that `require`s the internal module and calls its `watch()`.

- **`src/js/internal/fs/watch.ts` (new):** `FSWatcher` plus a `watch()` wrapper, moved from `fs.ts`. Gets the native binding from `internal/fs/binding`, the same way the other lazily loaded `internal/fs/*` modules do. Only evaluated on the first `fs.watch` call.
- **`src/js/node/fs.ts`:** `watch` delegates to `require("internal/fs/watch").watch(...)`; the `FSWatcher` class, its `setName` call, and the now-unused `node:events` import are gone (−75 lines). `watchFile`/`unwatchFile` (`StatWatcher`) are untouched — that was the counterpart refactor #31424.
- **`src/jsc/bindings/ProcessBindingNatives.cpp`:** list `internal/fs/watch` in `process.binding('natives')`, like the other internal fs modules.

No `src/jsc/lib.rs` change: since #31424 the specifier → `ResolvedSourceTag` table is code-generated (`generated_resolved_source_tag.rs`, emitted by `bundle-modules.ts` and `include!`'d by `lib.rs`), so adding the module and rebuilding regenerates it — `internal:fs/watch` lands at tag 537 and later ids shift automatically.

### Verification

- Rebuilt with the debug build; `build/debug/codegen/generated_resolved_source_tag.rs` now contains `b"internal:fs/watch" => ResolvedSourceTag(537)` with all later entries shifted.
- All-builtins sanity check on the debug build: every `require("node:module").builtinModules` entry (76) loads, and identity checks (`fs.promises === require("node:fs/promises")`, `stream.Readable === require("node:_stream_readable")`, `path.posix === require("node:path/posix")`, `util.types === require("node:util/types")`, `dns.promises === require("node:dns/promises")`, …) pass — confirms the id shift didn't misalign any builtin.
- `process.binding('natives')` includes `internal/fs/watch`.
- `test/js/node/watch/fs.watch.test.ts` on the debug build: 34 pass / 3 platform-skips. The only 2 failures are the "no permission to watch" tests, which fail identically on the stock release build in this environment because the container runs as root (chmod can't block root) — unrelated to this change.
- New tests pin the behaviors that live in the moved code: the watcher is an `EventEmitter` named `FSWatcher` with `ref`/`unref`/`start`, and watch errors keep the `path`/`filename` properties. Behavior is unchanged, so they pass both before and after.

### Notes

- Rebased onto main after #31424 merged; adopts its `internal/fs/binding` native-binding module and its code-generated tag table, so this diff no longer touches `lib.rs`.
- `internal/fs/watch.ts` is a verbatim move, apart from rewording the comment that documents the watchpack `EACCES` → `EPERM` workaround.
