### PR TITLE
build: enable cross-language LTO on linux aarch64-musl

### DIFF
--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -766,21 +766,24 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
     lto = false;
   }
 
-  // Cross-language LTO normally tracks `lto`. Gated off for aarch64-musl
-  // where LLVM's `globalopt` pass segfaults on the `bun_runtime` bitcode
-  // module during the merged link (CI build #53109), and for native Windows
-  // hosts — there `ld` is the host LLVM's lld-link and no rust-lld swap is
-  // wired up, so rustc's newer-LLVM bitcode would be unreadable at link
-  // time. Both halves still LTO independently when this is false — only the
-  // Rust↔C++ inlining is lost.
-  // Tracked in workarounds.ts ("globalopt-crash-aarch64-musl").
+  // Cross-language LTO normally tracks `lto`. Gated off only for native
+  // Windows hosts — there `ld` is the host LLVM's lld-link and no rust-lld
+  // swap is wired up, so rustc's newer-LLVM bitcode would be unreadable at
+  // link time. Both halves still LTO independently when this is false — only
+  // the Rust↔C++ inlining is lost.
+  // (aarch64-musl used to be gated too: LLVM's `globalopt` segfaulted on the
+  // per-crate `bun_runtime` bitcode module during the merged link, CI build
+  // #53109. That bitcode shape no longer exists — the Rust side is one fat,
+  // pre-merged module since the CARGO_PROFILE_RELEASE_LTO=fat switch — so
+  // the gate was lifted; see the deleted "globalopt-crash-aarch64-musl"
+  // workarounds.ts entry if it ever needs to come back.)
   // Darwin cross uses the same rust-lld swap as ELF: rustc's sysroot ships
   // `gcc-ld/ld64.lld` (rust-lld in the Mach-O flavor, built against rustc's
   // LLVM), which findRustLld() already resolves for darwin targets, so the
   // newer-LLVM bitcode rustc emits under -Clinker-plugin-lto is readable at
   // link time. Windows cross does the same with the `gcc-ld/lld-link`
   // sibling (COFF flavor) — see the wantRustLld swap below.
-  const crossLangLto = lto && !(windows && host.os === "windows") && !(arm64 && abi === "musl");
+  const crossLangLto = lto && !(windows && host.os === "windows");
 
   // Cross-language LTO bitcode-version skew: `-Clinker-plugin-lto` makes
   // rustc emit raw LLVM bitcode into libbun_rust.a. LLVM bitcode is

--- a/scripts/build/workarounds.ts
+++ b/scripts/build/workarounds.ts
@@ -85,29 +85,6 @@ export const workarounds: Workaround[] = [
     cleanup: `Delete scripts/build/shims/asan-dyld-shim.c, scripts/build/shims.ts, the emitShims() calls in bun.ts, registerShimRules in rules.ts, and this entry.`,
   },
   {
-    id: "globalopt-crash-aarch64-musl",
-    issue: "https://github.com/llvm/llvm-project/issues/ (file once reduced; see CI #53109)",
-    description:
-      "rust-lld's link-stage LTO segfaults in the `globalopt` pass on the bun_runtime " +
-      "bitcode module on aarch64-unknown-linux-musl. Disable cross-language LTO for " +
-      "that target only — both halves still LTO independently (C++ via -flto=thin, " +
-      'Rust via [profile.release] lto = "fat"); only Rust↔C++ inlining is lost.',
-    // Only exercised on the lane the crash hits.
-    applies: cfg => cfg.lto && cfg.arm64 && cfg.abi === "musl",
-    expectedToBeFixed: cfg => {
-      // The crash is inside rust-lld's LLVM (rustc nightly-2026-05-06 ⇒ LLVM 22).
-      // Re-test once the pinned rustc moves to LLVM 23. If it still crashes,
-      // bump this and file the upstream LLVM issue with a reduced repro
-      // (`llvm-reduce` over the bun_runtime cgu bitcode).
-      const FIXED_IN_RUST_LLVM = "23.0.0";
-      return cfg.rustLlvmVersion !== undefined && satisfiesRange(cfg.rustLlvmVersion, `>=${FIXED_IN_RUST_LLVM}`);
-    },
-    cleanup:
-      `Delete the \`!(aarch64 && abi === "musl")\` clause from the \`crossLangLto\` ` +
-      `derivation in resolveConfig() (config.ts), and this entry. The \`crossLangLto\` ` +
-      `field itself can stay (collapses to \`= lto\` when no per-target gates remain).`,
-  },
-  {
     id: "rustc-no-regular-lto-summary",
     issue:
       "https://github.com/rust-lang/rust/issues/ (none filed yet — rustc has no equivalent of clang's shouldEmitRegularLTOSummary())",


### PR DESCRIPTION
The `crossLangLto` gate for aarch64-musl dates from CI build #53109: LLVM's `globalopt` pass segfaulted on the per-crate `bun_runtime` bitcode module during the merged link. That bitcode shape no longer exists — since #31412 the Rust side reaches the link as **one fat, pre-merged module** (`CARGO_PROFILE_RELEASE_LTO=fat` + the regular-LTO summary fix-up), and #31412 explicitly flagged lifting this gate as the follow-up.

This removes the gate and the `globalopt-crash-aarch64-musl` workarounds.ts entry, so `bun-linux-aarch64-musl` gets the same Rust↔C++ cross-language inlining as the other ELF release targets (it also picks up `-Cforce-unwind-tables=no`, which matters most on musl since that binary keeps `.eh_frame`).

**The `linux-aarch64-musl` build + test lanes on this PR are the actual test.** If the link still segfaults in `globalopt` (or the binary misbehaves), close this PR — the workaround stays and the entry should get the reduced repro filed upstream instead.