### PR TITLE
Fix out-of-bounds read in JS highlighter on trailing backslash in `${}`

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -1949,7 +1949,7 @@ impl Display for QuickAndDirtyJavaScriptSyntaxHighlighter<'_> {
                                     i += 2;
 
                                     while i < text.len() && text[i] != b'}' {
-                                        if text[i] == b'\\' {
+                                        if i + 1 < text.len() && text[i] == b'\\' {
                                             i += 1;
                                         }
                                         i += 1;

--- a/src/bun_core/fmt.zig
+++ b/src/bun_core/fmt.zig
@@ -1008,7 +1008,7 @@ pub const QuickAndDirtyJavaScriptSyntaxHighlighter = struct {
                                     i += 2;
 
                                     while (i < text.len and text[i] != '}') {
-                                        if (text[i] == '\\') {
+                                        if (i + 1 < text.len and text[i] == '\\') {
                                             i += 1;
                                         }
                                         i += 1;

--- a/test/js/bun/util/highlighter.test.ts
+++ b/test/js/bun/util/highlighter.test.ts
@@ -5,3 +5,15 @@ test("highlighter", () => {
   expect(highlighter("`can do ${123} ${'123'} ${`123`}`").length).toBeLessThan(150);
   expect(highlighter("`can do ${123} ${'123'} ${`123`}`123").length).toBeLessThan(150);
 });
+
+// https://github.com/oven-sh/bun/issues/31434
+// A trailing backslash inside an unterminated `${` interpolation used to run
+// the scanner past the end of the input (OOB read / crash).
+test.each([
+  "`${\\", // backtick, $, {, backslash
+  "`${\\\\", // backtick, $, {, backslash, backslash
+  "`a${b\\", // some content before the trailing backslash
+  "`${\\}", // backslash escaping the closing brace, nothing after
+])("highlighter does not read past end of input for %p", input => {
+  expect(typeof highlighter(input)).toBe("string");
+});


### PR DESCRIPTION
Fixes #31434

## Repro

Launching the REPL and typing `` `${\ `` verbatim (backtick, `$`, `{`, trailing backslash) dumps garbage from adjacent memory and segfaults on 1.3.14, and panics on 1.4.0-canary:

```
panic: range end index 5 out of range for slice of length 4
```

Node and Deno handle the same input without crashing.

## Cause

The `QuickAndDirtyJavaScriptSyntaxHighlighter` (`src/bun_core/fmt.rs`) — used by the REPL to highlight the current line — scans the contents of a `${...}` interpolation with this loop:

```rust
while i < text.len() && text[i] != b'}' {
    if text[i] == b'\\' {
        i += 1;   // when '\' is the LAST byte, i becomes text.len()
    }
    i += 1;       // ...then this bumps i to text.len() + 1
}
```

When the backslash is the final byte, the skip runs the cursor past the end, and the subsequent slice `&text[curly_start + 2..i]` (fmt.rs:1970) is out of range. For `` `${\ `` the bytes are `['`', '$', '{', '\\']` (len 4) and `i` ends at 5.

The old Zig build had no bounds check and read adjacent memory (the "garbage text" in the report) before segfaulting; the Rust port turns the over-read into a panic. Same root cause, both behaviors.

The sibling string-scan loop a few lines below already guards its backslash skip with `i + 1 < text.len()` — the `${...}` loop was missing that guard.

## Fix

Add the same `i + 1 < text.len()` guard to the `${...}` inner loop so the backslash skip can't push the cursor past the end. When the backslash is the last byte it's no longer skipped, the loop exits with `i == text.len()`, and the slice stays in range. All other inputs (backslash followed by more content, `\}`, `\\`) are unchanged. Mirrored into the `.zig` porting reference.

## Verification

Regression cases added to `test/js/bun/util/highlighter.test.ts`, exercising the highlighter via `highlightJavaScript` from `bun:internal-for-testing` (same options the REPL uses).

- `USE_SYSTEM_BUN=1 bun test test/js/bun/util/highlighter.test.ts` → crashes (exit 132, `range end index 5 out of range for slice of length 4` — matches the issue's crash report).
- `bun bd test test/js/bun/util/highlighter.test.ts` → 5 pass, 0 fail.