### PR TITLE
install: bail on npm-lock migration when scoped pkg lacks resolved URL

### DIFF
--- a/src/install/migration.zig
+++ b/src/install/migration.zig
@@ -333,6 +333,14 @@ pub fn migrateNPMLockfile(
         if (pkg.get("resolved") == null) {
             const version_prop = pkg.get("version");
             const pkg_name = packageNameFromPath(pkg_path);
+            // Scoped packages without a `resolved` URL can't be migrated reliably:
+            // bun would synthesize an npm-compat /-/ tarball URL, but GitHub
+            // Packages 302-redirects that URL to npmjs.com with the scope
+            // stripped, leading to 404s. Bail out of migration so bun does a
+            // fresh metadata-driven resolve where dist.tarball is honoured.
+            if (version_prop != null and pkg_name.len > 0 and pkg_name[0] == '@') {
+                return error.InvalidNPMLockfile;
+            }
             if (version_prop != null and pkg_name.len > 0) {
                 // construct registry url
                 const registry = manager.scopeForPackageName(pkg_name);


### PR DESCRIPTION
**Draft for CI build only — not asking for review yet.** Will close after pulling artifacts.

## What

When migrating `package-lock.json` (npm v3) entries without a `resolved` field, bun synthesizes an npm-compat tarball URL of the form `<registry>/<scope>/<pkg>/-/<unscoped>-<ver>.tgz`. GitHub Packages 302-redirects that URL to `registry.npmjs.com` with the scope stripped from the path. The redirect target doesn't exist on npmjs (the package is private), so the install fails with 404.

This is the npm-lockfile analogue of #28959 (which #28961 fixes for pnpm-lock by preserving `resolution.tarball`). For npm package-lock.json there's no tarball field to fall back to — `resolved` IS the URL, and we're in the branch where it's null — so I can't mirror that approach.

This minimal change bails out of the whole migration when the case is hit. bun's outer flow already catches `InvalidNPMLockfile` and falls back to "Ignoring lockfile" + fresh metadata-driven resolve, which uses `dist.tarball` correctly and succeeds.

Long-term, a less aggressive fix would skip just the affected entries and trigger per-package metadata resolution; happy to iterate if the bail-out approach lands.

## Repro

`package-lock.json` with a scoped `@<org>/<pkg>` dep that lacks `resolved`, where `@<org>:registry` points at `npm.pkg.github.com` (via `.npmrc` or `[install.scopes]`). Currently → 404 from `registry.npmjs.com/<unscoped>`. With this patch → fresh resolve from GH Packages metadata, install succeeds.