### PR TITLE
TextDecoder: keep the codec alive across streaming chunks for legacy multi-byte encodings

### DIFF
--- a/src/runtime/webcore/TextDecoder.rs
+++ b/src/runtime/webcore/TextDecoder.rs
@@ -252,12 +252,15 @@ impl TextDecoder {
         }
     }
 
+    /// DOMJIT fast path for `decode(typedArray)` called with no options object.
+    /// A no-options decode is flushing per WHATWG Encoding, matching the slow
+    /// path in `decode()` when `stream` is absent.
     pub fn decode_without_type_checks(
         &self,
         global_this: &JSGlobalObject,
         uint8array: &mut JSUint8Array,
     ) -> JsResult<JSValue> {
-        self.decode_slice::<false>(global_this, uint8array.slice())
+        self.decode_slice::<true>(global_this, uint8array.slice())
     }
 
     fn decode_slice<const FLUSH: bool>(

--- a/src/runtime/webcore/TextDecoder.rs
+++ b/src/runtime/webcore/TextDecoder.rs
@@ -5,6 +5,7 @@ use crate::webcore::jsc::{
 use bun_core::AllocError;
 use bun_core::{OwnedString, strings};
 use core::cell::Cell;
+use core::ptr::NonNull;
 
 use jsc::StringJsc as _;
 use jsc::ZigStringJsc as _;
@@ -37,6 +38,12 @@ pub struct TextDecoder {
     pub lead_byte: Cell<Option<u8>>,
     pub lead_surrogate: Cell<Option<u16>>,
 
+    // WebKit `PAL::TextCodec` for every other encoding. The codec owns the
+    // streaming state (lead byte, ISO-2022-JP mode, GB18030 first/second/third),
+    // so it must live across `{stream: true}` chunks. Created lazily on first
+    // decode, dropped when a flushing decode ends the stream and in `Drop`.
+    codec: Cell<Option<NonNull<TextCodec>>>,
+
     // Read-only after construction (set in `constructor` before the JS wrapper
     // exists) — left bare.
     pub ignore_bom: bool,
@@ -50,6 +57,7 @@ impl Default for TextDecoder {
             buffered: Cell::new(Buffered::default()),
             lead_byte: Cell::new(None),
             lead_surrogate: Cell::new(None),
+            codec: Cell::new(None),
             ignore_bom: false,
             fatal: false,
             encoding: EncodingLabel::Utf8,
@@ -57,32 +65,18 @@ impl Default for TextDecoder {
     }
 }
 
+impl Drop for TextDecoder {
+    fn drop(&mut self) {
+        if let Some(codec) = self.codec.get_mut().take() {
+            // SAFETY: `codec` was returned by `TextCodec::create` and has not
+            // been freed (the field is cleared whenever we destroy it).
+            unsafe { TextCodec::destroy(codec.as_ptr()) }
+        }
+    }
+}
+
 // pub const js = jsc.Codegen.JSTextDecoder;
 // pub const toJS / fromJS / fromJSDirect — provided by #[bun_jsc::JsClass] codegen.
-
-/// RAII guard for an FFI-owned `TextCodec` (matches Zig `defer codec.deinit()`).
-struct CodecGuard(core::ptr::NonNull<TextCodec>);
-impl Drop for CodecGuard {
-    fn drop(&mut self) {
-        // SAFETY: `self.0` came from `TextCodec::create` and has not been freed.
-        unsafe { TextCodec::destroy(self.0.as_ptr()) }
-    }
-}
-impl core::ops::Deref for CodecGuard {
-    type Target = TextCodec;
-    fn deref(&self) -> &TextCodec {
-        // `TextCodec` is an opaque ZST FFI handle (S008); pointer is live for
-        // the guard's lifetime — safe `*const → &` via `opaque_deref`.
-        bun_opaque::opaque_deref(self.0.as_ptr())
-    }
-}
-impl core::ops::DerefMut for CodecGuard {
-    fn deref_mut(&mut self) -> &mut TextCodec {
-        // `TextCodec` is an opaque ZST FFI handle (S008); pointer is live for
-        // the guard's lifetime, `&mut self` is exclusive — safe via `opaque_deref_mut`.
-        bun_opaque::opaque_deref_mut(self.0.as_ptr())
-    }
-}
 
 impl TextDecoder {
     pub fn new(init: TextDecoder) -> Box<TextDecoder> {
@@ -443,19 +437,30 @@ impl TextDecoder {
             _ => {
                 let encoding_name = EncodingLabel::get_label(self.encoding);
 
-                // Create codec if we don't have one cached
-                // Note: In production, we might want to cache these per-encoding
-                let Some(codec) = TextCodec::create(encoding_name) else {
-                    // Fallback to empty string if codec creation fails
-                    return Ok(ZigString::init(b"").to_js(global_this));
+                // The codec carries streaming state (lead bytes, escape mode),
+                // so reuse the one from the previous `{stream: true}` chunk.
+                // Create it lazily on first use — matches WebKit's
+                // `if (!m_codec) m_codec = newTextCodec(...)`.
+                let codec_ptr = match self.codec.get() {
+                    Some(ptr) => ptr,
+                    None => {
+                        let Some(ptr) = TextCodec::create(encoding_name) else {
+                            // Fallback to empty string if codec creation fails
+                            return Ok(ZigString::init(b"").to_js(global_this));
+                        };
+                        if !self.ignore_bom {
+                            // `TextCodec` is an opaque ZST FFI handle (S008);
+                            // `ptr` is live — safe via `opaque_deref_mut`.
+                            bun_opaque::opaque_deref_mut(ptr.as_ptr()).strip_bom();
+                        }
+                        self.codec.set(Some(ptr));
+                        ptr
+                    }
                 };
-                let mut codec = CodecGuard(codec);
-                // `codec` drops at scope exit (matches `defer codec.deinit()`).
-
-                // Handle BOM stripping if needed
-                if !self.ignore_bom {
-                    codec.strip_bom();
-                }
+                // `TextCodec` is an opaque ZST FFI handle (S008); `codec_ptr`
+                // is live for this call — safe via `opaque_deref_mut`. The
+                // C++ `decode()` does not call back into JS, so no re-entrancy.
+                let codec = bun_opaque::opaque_deref_mut(codec_ptr.as_ptr());
 
                 // Decode the data
                 let result = codec.decode(buffer_slice, FLUSH, self.fatal);
@@ -463,6 +468,18 @@ impl TextDecoder {
                 // `DecodeResult` has none either — wrap the +1 ref in `OwnedString`
                 // so it derefs on scope exit (matches Zig `defer result.result.deref()`).
                 let result_str = OwnedString::new(result.result);
+
+                // A flushing decode ends the stream. Per WHATWG Encoding the
+                // next `decode()` starts with a fresh decoder, so drop this
+                // codec now — otherwise mode state that the C++ codec does not
+                // reset on flush (e.g. `m_iso2022JPDecoderState`) would leak
+                // into the next stream.
+                if FLUSH {
+                    self.codec.set(None);
+                    // SAFETY: `codec_ptr` came from `TextCodec::create` above
+                    // (or on an earlier chunk) and is freed exactly once here.
+                    unsafe { TextCodec::destroy(codec_ptr.as_ptr()) };
+                }
 
                 // Check for errors if fatal mode is enabled
                 if result.saw_error && self.fatal {

--- a/test/js/web/encoding/text-decoder-cjk.test.ts
+++ b/test/js/web/encoding/text-decoder-cjk.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 test("TextDecoder - Shift_JIS encoding", () => {
   const decoder = new TextDecoder("shift_jis");
@@ -79,4 +79,90 @@ test("TextDecoder - ISO-2022-JP encoding", () => {
   ]);
   const result = decoder.decode(bytes);
   expect(result).toBe("日本");
+});
+
+// A `{stream: true}` decode must carry the codec's partial state (lead byte,
+// escape mode, GB18030 first/second/third) across chunk boundaries so that
+// concatenating the streamed results equals a single whole decode.
+describe("TextDecoder - streaming across chunk boundaries", () => {
+  function streamingDecode(encoding: string, bytes: readonly number[], split: readonly number[]): string {
+    const d = new TextDecoder(encoding);
+    let out = "";
+    let off = 0;
+    for (let i = 0; i < split.length; i++) {
+      const chunk = new Uint8Array(bytes.slice(off, off + split[i]));
+      off += split[i];
+      out += d.decode(chunk, i < split.length - 1 ? { stream: true } : {});
+    }
+    return out;
+  }
+
+  const cases: Array<[encoding: string, bytes: number[], expected: string, splits: number[][]]> = [
+    ["big5", [0xa4, 0x40], "一", [[1, 1]]],
+    ["shift_jis", [0x88, 0xea], "一", [[1, 1]]],
+    ["gbk", [0xd2, 0xbb], "一", [[1, 1]]],
+    ["euc-kr", [0xec, 0xe9], "一", [[1, 1]]],
+    // JIS X 0212 plane: 0x8F lead + two trail bytes
+    [
+      "euc-jp",
+      [0x8f, 0xb0, 0xa1],
+      "丂",
+      [
+        [1, 2],
+        [2, 1],
+        [1, 1, 1],
+      ],
+    ],
+    // 4-byte GB18030 sequence for U+1F4A9
+    [
+      "gb18030",
+      [0x94, 0x39, 0xda, 0x33],
+      "💩",
+      [
+        [2, 2],
+        [1, 3],
+        [3, 1],
+        [1, 1, 1, 1],
+      ],
+    ],
+    // ESC $ B (switch to JIS X 0208) split mid-escape, then "一", then ESC ( B
+    [
+      "iso-2022-jp",
+      [0x1b, 0x24, 0x42, 0x30, 0x6c, 0x1b, 0x28, 0x42],
+      "一",
+      [
+        [1, 7],
+        [2, 6],
+        [4, 4],
+        [3, 2, 3],
+      ],
+    ],
+  ];
+
+  describe.each(cases)("%s", (encoding, bytes, expected, splits) => {
+    test("whole decode", () => {
+      expect(new TextDecoder(encoding).decode(new Uint8Array(bytes))).toBe(expected);
+    });
+    for (const split of splits) {
+      test(`split ${JSON.stringify(split)}`, () => {
+        expect(streamingDecode(encoding, bytes, split)).toBe(expected);
+      });
+    }
+  });
+
+  test("reusing a decoder after a flushing decode starts a fresh stream", () => {
+    // End the first stream in JIS X 0208 mode; a fresh stream must start in
+    // ASCII so plain ASCII bytes decode as themselves.
+    const d = new TextDecoder("iso-2022-jp");
+    let first = d.decode(new Uint8Array([0x1b, 0x24, 0x42, 0x30, 0x6c]), { stream: true });
+    first += d.decode(new Uint8Array([0x1b, 0x28, 0x42]));
+    expect(first).toBe("一");
+    expect(d.decode(new Uint8Array([0x41, 0x42, 0x43]))).toBe("ABC");
+
+    // Same for a lead-byte encoding: a buffered lead must not survive a flush.
+    const d2 = new TextDecoder("big5");
+    expect(d2.decode(new Uint8Array([0xa4]), { stream: true })).toBe("");
+    expect(d2.decode(new Uint8Array([0x40]))).toBe("一");
+    expect(d2.decode(new Uint8Array([0x40]))).toBe("@");
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Streaming `TextDecoder` (`{stream: true}`) of every multi-byte legacy/CJK encoding — shift_jis, euc-jp, iso-2022-jp, gbk, gb18030, big5, euc-kr — silently corrupted any character or escape state split across a chunk boundary (e.g. big5 `[A4][40]` → `"@"` instead of `"一"`). Whole (non-streaming) decode was correct; utf-8/utf-16/latin1 were unaffected.

The catch-all decode arm created a fresh WebKit `TextCodec` on every `decode()` call and destroyed it at scope exit. The codec is where the streaming state lives (lead byte, ISO-2022-JP mode, GB18030 first/second/third), so that state was thrown away between chunks and the next chunk's trail bytes decoded standalone.

Persist the codec on the `TextDecoder` across `{stream: true}` chunks (lazy create, reuse, drop+recreate after a flushing decode per the WHATWG spec, free in `Drop`). This mirrors WebKit's own `TextDecoder`, which keeps a single `m_codec` and calls `decode(..., flush)` repeatedly.

Also makes the (currently ungenerated) DOMJIT fast path `decode_without_type_checks` flush like the slow path does for a no-options `decode(buf)`, so it cannot carry persisted codec state across independent decodes if DOMJIT signatures are re-enabled.

Not a port regression — the Zig path has the same shape — but Node and the spec are correct.

### How did you verify your code works?

- New matrix of encoding × split-offset streaming tests plus a reuse-after-flush test in `test/js/web/encoding/text-decoder-cjk.test.ts`; every expected value cross-checked against Node.js. They fail on current bun (16 failures) and pass with this branch (30/30).
- The rest of `test/js/web/encoding/` passes with the branch.
