### PR TITLE
fix: console.trace() should output to stderr instead of stdout

### DIFF
--- a/src/jsc/ConsoleObject.zig
+++ b/src/jsc/ConsoleObject.zig
@@ -111,7 +111,7 @@ fn messageWithTypeAndLevel_(
 
     // Lock/unlock a mutex incase two JS threads are console.log'ing at the same time
     // We do this the slightly annoying way to avoid assigning a pointer
-    if (level == .Warning or level == .Error or message_type == .Assert) {
+    if (level == .Warning or level == .Error or message_type == .Assert or message_type == .Trace) {
         if (stderr_lock_count == 0) {
             stderr_mutex.lock();
         }
@@ -126,7 +126,7 @@ fn messageWithTypeAndLevel_(
     }
 
     defer {
-        if (level == .Warning or level == .Error or message_type == .Assert) {
+        if (level == .Warning or level == .Error or message_type == .Assert or message_type == .Trace) {
             stderr_lock_count -= 1;
 
             if (stderr_lock_count == 0) {
@@ -156,12 +156,12 @@ fn messageWithTypeAndLevel_(
         return;
     }
 
-    const enable_colors = if (level == .Warning or level == .Error)
+    const enable_colors = if (level == .Warning or level == .Error or message_type == .Trace)
         Output.enable_ansi_colors_stderr
     else
         Output.enable_ansi_colors_stdout;
 
-    const writer = if (level == .Warning or level == .Error)
+    const writer = if (level == .Warning or level == .Error or message_type == .Trace)
         console.error_writer
     else
         console.writer;


### PR DESCRIPTION
Fixes #19952

When calling [console.trace()](cci:1://file:///d:/Documents/Kernel%20Contribution/bun/src/js/builtins/ConsoleObject.ts:575:4-582:5), the output should go to stderr like Node.js does, but it was going to stdout instead.

Root Cause
In [ConsoleObject.zig](cci:7://file:///d:/Documents/Kernel%20Contribution/bun/src/jsc/ConsoleObject.zig:0:0-0:0), the writer selection and mutex locking were based only on the `level` parameter (Warning/Error use stderr, everything else uses stdout). Since [console.trace()](cci:1://file:///d:/Documents/Kernel%20Contribution/bun/src/js/builtins/ConsoleObject.ts:575:4-582:5) uses `MessageType.Trace` without a specific level, it defaulted to stdout.

Fix
Added `message_type == .Trace` to the conditions that determine whether to use stderr:
- Mutex locking (lines 114, 129)
- Writer selection (lines 164, 159)
- Color enable selection (line 159)

This ensures [console.trace()](cci:1://file:///d:/Documents/Kernel%20Contribution/bun/src/js/builtins/ConsoleObject.ts:575:4-582:5) outputs to stderr, matching Node.js behavior.

Testing
- Verified the fix addresses the root cause by examining the code flow
- The change is minimal and follows existing patterns in the codebase
- Existing tests should pass as this only adds a new condition to existing checks