### PR TITLE
fix(net): preserve connecting=false set synchronously by connect({fd})

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -887,6 +887,14 @@ Socket.prototype.connect = function connect(...args) {
       connection = socket;
     }
     if (fd) {
+      // Establish initial state BEFORE doConnect so the synchronous SocketHandlers.open
+      // callback (fired inline by Listener.connectInner on Windows for an existing pipe
+      // HANDLE) can flip connecting → false and set _handle. Setting connecting = true
+      // afterwards would clobber that, leaving the Socket stuck in the connecting state
+      // forever — _write then buffers writes into _pendingData and registers a
+      // "connect" listener for an event that has already fired, dropping subsequent
+      // writes silently. See child.stdio[3] regression in child_process.test.ts.
+      this.connecting = true;
       doConnect(this._handle, {
         data: this,
         fd: fd,
@@ -906,7 +914,9 @@ Socket.prototype.connect = function connect(...args) {
       process.nextTick(() => {
         this.resume();
       });
-      this.connecting = true;
+      if (!fd) {
+        this.connecting = true;
+      }
     }
     if (fd) {
       return this;

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -307,6 +307,86 @@ describe("spawn()", () => {
       expect(child.stdout).not.toBeNull();
       expect(child.stderr).not.toBeNull();
     });
+
+    // Regression: parent->child writes on the extra stdio[3] pipe were
+    // silently dropped on Windows. The Duplex returned `true` from write(),
+    // never invoked the write callback, and the bytes never reached the
+    // child. Reads (child->parent) worked.
+    it("stdio[3] is duplex: parent<->child round trips work", async () => {
+      const childScript = `
+        const fs = require("node:fs");
+        const writer = fs.createWriteStream("", { fd: 3 });
+        const reader = fs.createReadStream("", { fd: 3 });
+        let buffer = "";
+        reader.setEncoding("utf-8");
+        reader.on("data", chunk => {
+          buffer += chunk;
+          let idx;
+          while ((idx = buffer.indexOf("\\n")) !== -1) {
+            const line = buffer.slice(0, idx);
+            buffer = buffer.slice(idx + 1);
+            if (!line) continue;
+            if (line === "parent:hello") writer.write("child:hello-ack\\n");
+            else if (line === "parent:ping") writer.write("child:pong\\n");
+            else if (line === "parent:bye") process.exit(0);
+          }
+        });
+        writer.write("child:ready\\n");
+      `;
+
+      await using child = spawn(bunExe(), ["-e", childScript], {
+        stdio: ["ignore", "ignore", "ignore", "pipe"],
+        env: bunEnv,
+      });
+
+      const fd3 = child.stdio[3]!;
+      expect(fd3).not.toBeNull();
+
+      const writeCallbacksFired: string[] = [];
+      const linesReceived: string[] = [];
+      const { promise: done, resolve, reject } = Promise.withResolvers<void>();
+
+      let buffer = "";
+      fd3.on("data", (chunk: Buffer) => {
+        buffer += chunk.toString();
+        let idx: number;
+        while ((idx = buffer.indexOf("\n")) !== -1) {
+          const line = buffer.slice(0, idx);
+          buffer = buffer.slice(idx + 1);
+          if (!line) continue;
+          linesReceived.push(line);
+
+          const reply =
+            line === "child:ready"
+              ? "parent:hello"
+              : line === "child:hello-ack"
+                ? "parent:ping"
+                : line === "child:pong"
+                  ? "parent:bye"
+                  : null;
+
+          if (reply) {
+            (fd3 as NodeJS.WritableStream).write(reply + "\n", err => {
+              if (err) reject(err);
+              else writeCallbacksFired.push(reply);
+            });
+          }
+        }
+      });
+      fd3.on("error", reject);
+      child.on("error", reject);
+      let exitCode: number | null = null;
+      child.on("exit", code => {
+        exitCode = code;
+        resolve();
+      });
+
+      await done;
+
+      expect(linesReceived).toEqual(["child:ready", "child:hello-ack", "child:pong"]);
+      expect(writeCallbacksFired).toEqual(["parent:hello", "parent:ping", "parent:bye"]);
+      expect(exitCode).toBe(0);
+    }, 10_000);
   });
 });
 


### PR DESCRIPTION
On Windows, net.connect({ fd }) for an existing pipe HANDLE (as returned by child.stdio[i] for spawned children with stdio[i] = "pipe") runs the bun socket open handshake synchronously inside doConnect. SocketHandlers.open fires inline and sets _handle, flips connecting=false, and emits "connect" before control returns to JS.

Socket.prototype.connect then unconditionally re-ran `this.connecting = true` after doConnect, clobbering the false written by the open callback. From then on _write saw connecting === true, stashed each chunk into _pendingData, and registered `this.once("connect", ...)` to flush later — but the "connect" event had already fired in the same tick, so the listener never triggered. Writes returned true with no error and no callback; bytes never reached the child.

Reads worked because they don't depend on the connecting flag, which is why child.stdio[3] looked half-functional: child->parent fine, parent->child silently dropped.

Fix: set connecting=true *before* doConnect (so the synchronous open callback still observes the connecting→connected transition), and skip the post-call assignment on the fd path so the false survives.

The non-fd path is unchanged (lookupAndConnect's connect is genuinely async, and the redundant connecting=true at line 1078 still runs).

### What does this PR do?

Fixes a Windows-only silent data drop on `net.connect({ fd })` when the fd is an existing pipe HANDLE — most visibly, parent → child writes on `child.stdio[3]` from `spawn(..., { stdio: ["inherit","inherit","inherit","pipe"] })`. `fd3.write(data, cb)` returns `true`, no `error` event fires, the callback is never invoked, and the bytes never reach the child. Reads (child → parent) on the same fd work, which makes this look like a half-broken pipe rather than a `connect` failure. Node 24 works in both directions on the same code; Bun 1.3.x through current main does not.

**Root cause.** `child.stdio[i]` (for `i ≥ 3`) ends up at `net.connect({ fd })` (see `getBunSpawnIo` in `src/js/node/child_process.ts`). On Windows for an existing pipe HANDLE, `doConnect → Listener::connect_inner → WindowsNamedPipeContext::open → WindowsNamedPipe::open` runs the open handshake **synchronously** — `Self::on_connect(self, ZERO)` is called inline ([`src/runtime/socket/WindowsNamedPipe.rs:843`](https://github.com/oven-sh/bun/blob/main/src/runtime/socket/WindowsNamedPipe.rs#L843)). That fires `SocketHandlers.open` from `net.ts`, which sets `_handle`, flips `connecting = false`, and emits `"connect"` — all before control returns to JS.

`Socket.prototype.connect` then unconditionally ran `this.connecting = true` after the `doConnect` call, clobbering the `false` written by the open callback. From then on `_write` saw `connecting === true`, stashed each chunk into `_pendingData`, and registered `this.once("connect", ...)` to flush later — but the `"connect"` event had already fired in the same tick, so the listener never triggered. The data sits in `_pendingData` forever; the write callback is never called. Reads work because the read path doesn't depend on the `connecting` flag.

**Fix.** `src/js/node/net.ts`, two adjustments inside the `if (fd) {}` branch of `Socket.prototype.connect`:

1. Set `this.connecting = true` **before** `doConnect`, so the synchronous open callback still observes the legitimate `connecting → connected` transition (and matches the conceptually-correct state during the call).
2. Guard the post-call `this.connecting = true` on `!fd`, so when `doConnect` already flipped it to `false` synchronously, that survives.

The non-fd path is unchanged — `lookupAndConnect`'s connect is genuinely async, and the redundant `this.connecting = true` at line ~1078 still runs.

**Not addressed here.** The original report also notes that the Node-style object form `{ type: 'pipe', readable: true, writable: true }` throws `Invalid stdio option`. That's a separate gap in `nodeToBun` (`src/js/node/child_process.ts`) — strings/numbers/streams are handled, the object form isn't. Out of scope for the silent-write-drop fix; happy to follow up if useful.

### How did you verify your code works?

Added a regression test at `test/js/node/child_process/child_process.test.ts` — `it("stdio[3] is duplex: parent<->child round trips work")` under `describe("stdio")`:

- Spawns a bun child with `stdio: ["ignore","ignore","ignore","pipe"]`.
- Child opens `fs.createReadStream("",{fd:3})` + `fs.createWriteStream("",{fd:3})`, says `child:ready`, then echoes a 3-step handshake.
- Parent reads on `child.stdio[3]`, replies on each line, and asserts both the lines received in order *and* the write callbacks fired in order.

Verification matrix (Windows 11, x64):

- [x] `USE_SYSTEM_BUN=1 bun test test/js/node/child_process/child_process.test.ts -t "stdio\[3\] is duplex"` → **fails (10s timeout)** on stock bun (tested both 1.3.8 and current main 1.3.14) — confirms the test catches the bug.
- [x] `bun bd test ... -t "stdio\[3\] is duplex"` → **1 pass, 0 fail** with the patch (~1.2s).
- [x] `bun bd test test/js/node/child_process/child_process.test.ts` full file → **30 pass, 1 skip, 1 todo, 0 fail**.
- [x] `bun bd test test/js/node/net/node-net.test.ts` regression check → **35 pass, 1 skip, 0 fail**.
- [x] Built a full release binary on the Rust-backed runtime (`bun_rust.lib` produced via cargo, `bun.exe` v1.4.0-canary.1 — *not* a Zig-backed link) and re-ran the same suites against it: **62 pass, 5 skip, 1 todo, 0 fail** across `child_process.test.ts` + `node-net.test.ts`.
- [x] Manual repro of the original bug report (separate `parent.ts` + `child.ts` files, exact stdio config from the report, `spawn("bun", ...)`): three round trips complete, child exits 0, all three write callbacks fire.
