### PR TITLE
Copy the message string when constructing Error/AggregateError from a ZigString

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3459,10 +3459,12 @@ JSC::EncodedJSValue JSC__JSGlobalObject__createAggregateError(JSC::JSGlobalObjec
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // toStringCopy, not toString: the AggregateError (and its message string)
-    // outlives this call, while an untagged ZigString message would alias the
-    // caller's buffer without owning it. See Zig::getErrorInstance.
-    WTF::String message = Zig::toStringCopy(*arg3);
+    // External-tagged messages transfer ownership of their heap buffer to the
+    // JS string (VirtualMachine.rs marks the joined build-failure message
+    // global and relies on C++ freeing it); everything else is copied so an
+    // untagged ZigString can't leave the AggregateError aliasing the caller's
+    // buffer. See Zig::getErrorInstance.
+    WTF::String message = Zig::isTaggedExternalPtr(arg3->ptr) ? Zig::toString(*arg3) : Zig::toStringCopy(*arg3);
     JSC::JSValue cause = JSC::jsUndefined();
     JSC::JSArray* array = nullptr;
     {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3459,7 +3459,10 @@ JSC::EncodedJSValue JSC__JSGlobalObject__createAggregateError(JSC::JSGlobalObjec
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    WTF::String message = Zig::toString(*arg3);
+    // toStringCopy, not toString: the AggregateError (and its message string)
+    // outlives this call, while an untagged ZigString message would alias the
+    // caller's buffer without owning it. See Zig::getErrorInstance.
+    WTF::String message = Zig::toStringCopy(*arg3);
     JSC::JSValue cause = JSC::jsUndefined();
     JSC::JSArray* array = nullptr;
     {

--- a/src/jsc/bindings/helpers.h
+++ b/src/jsc/bindings/helpers.h
@@ -393,7 +393,12 @@ static const WTF::String toStringStatic(ZigString str)
 
 static JSC::JSValue getErrorInstance(const ZigString* str, JSC::JSGlobalObject* globalObject)
 {
-    WTF::String message = toString(*str);
+    // toStringCopy, not toString: an untagged ZigString would otherwise become
+    // a JSString that aliases the caller's bytes with no ownership, and several
+    // callers (AsyncModule's resolve/download error paths) pass stack-local
+    // buffers that are freed before JS can ever read error.message. The
+    // TypeError/SyntaxError/RangeError siblings below already copy.
+    WTF::String message = toStringCopy(*str);
     if (message.isNull() && str->len > 0) [[unlikely]] {
         // pending exception while creating an error.
         return {};

--- a/src/jsc/bindings/helpers.h
+++ b/src/jsc/bindings/helpers.h
@@ -393,12 +393,16 @@ static const WTF::String toStringStatic(ZigString str)
 
 static JSC::JSValue getErrorInstance(const ZigString* str, JSC::JSGlobalObject* globalObject)
 {
-    // toStringCopy, not toString: an untagged ZigString would otherwise become
-    // a JSString that aliases the caller's bytes with no ownership, and several
-    // callers (AsyncModule's resolve/download error paths) pass stack-local
-    // buffers that are freed before JS can ever read error.message. The
-    // TypeError/SyntaxError/RangeError siblings below already copy.
-    WTF::String message = toStringCopy(*str);
+    // External-tagged strings transfer ownership: the caller heap-allocated
+    // the bytes and marked them global so the JS string adopts them (and
+    // frees them via free_global_string) — keep that path, like toIdentifier
+    // does. Everything else is copied: an untagged ZigString would otherwise
+    // become a JSString that aliases the caller's bytes with no ownership,
+    // and several callers (AsyncModule's resolve/download error paths) pass
+    // stack-local buffers that are freed before JS can ever read
+    // error.message. The TypeError/SyntaxError/RangeError siblings below
+    // already copy.
+    WTF::String message = isTaggedExternalPtr(str->ptr) ? toString(*str) : toStringCopy(*str);
     if (message.isNull() && str->len > 0) [[unlikely]] {
         // pending exception while creating an error.
         return {};


### PR DESCRIPTION
`Zig::getErrorInstance` builds the Error message with `Zig::toString`, which for an untagged `ZigString` wraps the caller's bytes via `StringImpl::createWithoutCopying` — no copy, no ownership, no liveness link. Several callers pass stack-local buffers (AsyncModule's `resolve_error`/`download_error` format the message into a local `Vec<u8>` that drops at function return), so the JSString backing `error.message` aliases freed memory by the time user code reads it — a long-standing latent use-after-free read on those error paths (it predates the Rust port; the Zig code freed the buffer with a `defer` the same way).

The `TypeError`/`SyntaxError`/`RangeError` helpers right next to it already use `toStringCopy`. This switches `getErrorInstance` and `JSC__JSGlobalObject__createAggregateError` (same lifetime requirement for the AggregateError message) to copy as well. Error paths only, so the extra copy is free in practice.

Found while auditing string ownership at the FFI boundary for the Windows cross-compile work; verified the module-resolution error path still produces intact messages with a debug build.