### PR TITLE
install: refuse npm-lock migration when scoped GHP pkg lacks resolved URL

### DIFF
--- a/src/install/migration.rs
+++ b/src/install/migration.rs
@@ -437,6 +437,29 @@ pub(crate) fn migrate_npm_lockfile<'a>(
             {
                 // construct registry url
                 let href: &[u8] = manager.scope_for_package_name(pkg_name).url.href();
+                // GitHub Packages doesn't recognise the npm-compat
+                // `<registry>/<scope>/<pkg>/-/<unscoped>-<ver>.tgz` URL
+                // synthesised below — GHP serves tarballs at
+                // `/download/<scope>/<pkg>/<ver>/<sha>` (per each
+                // package's own `dist.tarball` metadata), so the
+                // npm-compat request 302-redirects to upstream npmjs
+                // with the scope dropped from the path. The private
+                // package doesn't exist on npmjs, so the install
+                // fails with 404.
+                //
+                // This is the npm-lock analogue of #28959 (pnpm-lock);
+                // npm-lock has no `tarball` field separate from
+                // `resolved`, so we can't mirror #28961's fix. Instead
+                // refuse migration when the case is hit and let bun's
+                // outer flow fall back to a fresh metadata-driven
+                // resolve, which uses GHP's correct dist.tarball URL.
+                if pkg_name[0] == b'@'
+                    && href
+                        .windows(b"npm.pkg.github.com".len())
+                        .any(|w| w == b"npm.pkg.github.com")
+                {
+                    return Err(err!("InvalidNPMLockfile"));
+                }
                 let mut count: usize = 0;
                 count += href.len() + pkg_name.len() + b"/-/".len();
                 if pkg_name[0] == b'@' {


### PR DESCRIPTION
### What's the problem this PR addresses?

The npm-lockfile analogue of #28959 (pnpm-lock).

When bun migrates a `package-lock.json` (npm v3) entry with a missing `resolved` field, it synthesises the URL `<registry>/<scope>/<pkg>/-/<unscoped>-<ver>.tgz` in `src/install/migration.rs` (the `if pkg.get(b"resolved").is_none()` block) and uses that as the tarball URL.

For scoped packages whose registry is GitHub Packages, that URL is wrong: GHP's npm-compat `/-/<name>-<ver>.tgz` endpoint isn't where it serves tarballs (those live at `/download/<scope>/<pkg>/<ver>/<sha>`, per each package's own `dist.tarball` metadata). The request 302-redirects to upstream npmjs with the scope dropped from the path, where the private package doesn't exist → 404 → install fails.

### How did you solve the problem?

#28961 fixed the pnpm case by preserving `resolution.tarball` from the lockfile. That approach doesn't translate to npm-lock because the npm-lockfile entry has no `tarball` field separate from `resolved` — when `resolved` is null, there's nothing to preserve.

So instead, refuse to migrate when this specific case is hit (scoped package + null `resolved` + registry on `npm.pkg.github.com`). Bun's outer flow already catches `InvalidNPMLockfile` and falls back to a fresh metadata-driven resolve, which fetches the registry manifest and uses the correct `dist.tarball` URL.

The check is narrow: customers whose scopes resolve to npmjs (most `@types/*` deps, etc.) still hit the existing synthesis path, which works for npmjs's `/-/` tarball layout.

### How did you verify your code works?

Built a debug binary from this branch on a CI runner (ubuntu-22.04, glibc 2.35) and ran it against a real customer's repo on Debian 12:

**Stock bun** (current main):
```
[migrated lockfile from package-lock.json]
error: GET https://registry.npmjs.com/<unscoped>/-/<unscoped>-<ver>.tgz - 404
```

**This patch:**
```
InvalidNPMLockfile: failed to migrate lockfile: 'package-lock.json'
warn: Ignoring lockfile
Resolving dependencies
Resolved, downloaded and extracted [3174]
Saved lockfile
```

All 3174 packages install successfully — including the scoped @\<org\>/* packages from GHP that fail on stock bun.

I'll add a regression test in a follow-up commit once the approach is acceptable. Happy to refine into a per-entry skip instead of a whole-migration bail if maintainers prefer.

Related: #28959, #28961