### PR TITLE
escapeHTML: collapse per-length scalar_push monomorphizations into a runtime loop

### DIFF
--- a/src/bun_core/string/immutable/escapeHTML.rs
+++ b/src/bun_core/string/immutable/escapeHTML.rs
@@ -87,28 +87,22 @@ fn scalar_append(buf: *mut u8, ch: u8) -> usize {
     scalar_append_string(buf, html_escape_entity(ch).unwrap())
 }
 
-#[inline(always)]
-fn scalar_push<const LEN: usize>(chars: &[u8; LEN]) -> Escaped<u8> {
-    // PERF(port): Zig used `inline while` to fully unroll this sum at comptime
-    // for each LEN in 3..=32 — profile if it shows up on a hot path.
+fn scalar_push(chars: &[u8]) -> Escaped<u8> {
     let mut total: usize = 0;
-    let mut i = 0;
-    while i < LEN {
-        total += SCALAR_LENGTHS[chars[i] as usize] as usize;
-        i += 1;
+    for &c in chars {
+        total += SCALAR_LENGTHS[c as usize] as usize;
     }
 
-    if total == LEN {
+    if total == chars.len() {
         return Escaped::Original;
     }
 
     let mut output = vec![0u8; total].into_boxed_slice();
     let mut head = output.as_mut_ptr();
-    // PERF(port): Zig used `inline for (comptime bun.range(0, len))` — profile if hot.
-    for i in 0..LEN {
+    for &c in chars {
         // SAFETY: `total` was computed from SCALAR_LENGTHS so `head` never
         // overruns `output`.
-        head = unsafe { head.add(scalar_append(head, chars[i])) };
+        head = unsafe { head.add(scalar_append(head, c)) };
     }
 
     Escaped::Allocated(output)
@@ -156,155 +150,8 @@ pub fn escape_html_for_latin1_input(latin1: &[u8]) -> Result<Escaped<u8>, AllocE
         }
 
         // The simd implementation is slower for inputs less than 32 bytes.
-        3 => {
-            return Ok(scalar_push::<3>(
-                latin1[0..3].try_into().expect("infallible: size matches"),
-            ));
-        }
-        4 => {
-            return Ok(scalar_push::<4>(
-                latin1[0..4].try_into().expect("infallible: size matches"),
-            ));
-        }
-        5 => {
-            return Ok(scalar_push::<5>(
-                latin1[0..5].try_into().expect("infallible: size matches"),
-            ));
-        }
-        6 => {
-            return Ok(scalar_push::<6>(
-                latin1[0..6].try_into().expect("infallible: size matches"),
-            ));
-        }
-        7 => {
-            return Ok(scalar_push::<7>(
-                latin1[0..7].try_into().expect("infallible: size matches"),
-            ));
-        }
-        8 => {
-            return Ok(scalar_push::<8>(
-                latin1[0..8].try_into().expect("infallible: size matches"),
-            ));
-        }
-        9 => {
-            return Ok(scalar_push::<9>(
-                latin1[0..9].try_into().expect("infallible: size matches"),
-            ));
-        }
-        10 => {
-            return Ok(scalar_push::<10>(
-                latin1[0..10].try_into().expect("infallible: size matches"),
-            ));
-        }
-        11 => {
-            return Ok(scalar_push::<11>(
-                latin1[0..11].try_into().expect("infallible: size matches"),
-            ));
-        }
-        12 => {
-            return Ok(scalar_push::<12>(
-                latin1[0..12].try_into().expect("infallible: size matches"),
-            ));
-        }
-        13 => {
-            return Ok(scalar_push::<13>(
-                latin1[0..13].try_into().expect("infallible: size matches"),
-            ));
-        }
-        14 => {
-            return Ok(scalar_push::<14>(
-                latin1[0..14].try_into().expect("infallible: size matches"),
-            ));
-        }
-        15 => {
-            return Ok(scalar_push::<15>(
-                latin1[0..15].try_into().expect("infallible: size matches"),
-            ));
-        }
-        16 => {
-            return Ok(scalar_push::<16>(
-                latin1[0..16].try_into().expect("infallible: size matches"),
-            ));
-        }
-        17 => {
-            return Ok(scalar_push::<17>(
-                latin1[0..17].try_into().expect("infallible: size matches"),
-            ));
-        }
-        18 => {
-            return Ok(scalar_push::<18>(
-                latin1[0..18].try_into().expect("infallible: size matches"),
-            ));
-        }
-        19 => {
-            return Ok(scalar_push::<19>(
-                latin1[0..19].try_into().expect("infallible: size matches"),
-            ));
-        }
-        20 => {
-            return Ok(scalar_push::<20>(
-                latin1[0..20].try_into().expect("infallible: size matches"),
-            ));
-        }
-        21 => {
-            return Ok(scalar_push::<21>(
-                latin1[0..21].try_into().expect("infallible: size matches"),
-            ));
-        }
-        22 => {
-            return Ok(scalar_push::<22>(
-                latin1[0..22].try_into().expect("infallible: size matches"),
-            ));
-        }
-        23 => {
-            return Ok(scalar_push::<23>(
-                latin1[0..23].try_into().expect("infallible: size matches"),
-            ));
-        }
-        24 => {
-            return Ok(scalar_push::<24>(
-                latin1[0..24].try_into().expect("infallible: size matches"),
-            ));
-        }
-        25 => {
-            return Ok(scalar_push::<25>(
-                latin1[0..25].try_into().expect("infallible: size matches"),
-            ));
-        }
-        26 => {
-            return Ok(scalar_push::<26>(
-                latin1[0..26].try_into().expect("infallible: size matches"),
-            ));
-        }
-        27 => {
-            return Ok(scalar_push::<27>(
-                latin1[0..27].try_into().expect("infallible: size matches"),
-            ));
-        }
-        28 => {
-            return Ok(scalar_push::<28>(
-                latin1[0..28].try_into().expect("infallible: size matches"),
-            ));
-        }
-        29 => {
-            return Ok(scalar_push::<29>(
-                latin1[0..29].try_into().expect("infallible: size matches"),
-            ));
-        }
-        30 => {
-            return Ok(scalar_push::<30>(
-                latin1[0..30].try_into().expect("infallible: size matches"),
-            ));
-        }
-        31 => {
-            return Ok(scalar_push::<31>(
-                latin1[0..31].try_into().expect("infallible: size matches"),
-            ));
-        }
-        32 => {
-            return Ok(scalar_push::<32>(
-                latin1[0..32].try_into().expect("infallible: size matches"),
-            ));
+        3..=32 => {
+            return Ok(scalar_push(latin1));
         }
 
         _ => {


### PR DESCRIPTION
## Summary

Rust counterpart of #30346.

`escape_html_for_latin1_input` had a const-generic `scalar_push::<LEN>` instantiated once per input length 3..=32, dispatched by a 30-arm `match`. Under LTO all 30 monomorphizations get inlined into the function, producing a ~36 KB function in release builds. This PR replaces them with a single runtime loop over `&[u8]` and a `3..=32` match arm, the same shape as the >2-char dispatch the Zig source ended up with in #30346.

8 insertions, 161 deletions; output bytes are unchanged.

## Binary size

Measured on linux x64 with the `btg` profile (Release + LTO, mirrors the CI release codegen), both builds at the same base commit, same build directory:

| | before | after | Δ |
|---|---|---|---|
| `escape_html_for_latin1_input` + `Bun__escapeHTML8` (`.text` symbols) | 36,017 + 862 B | 2,592 B (single function, fully inlined into `Bun__escapeHTML8`) | −34,287 B |
| `.text` | 52,332,682 B | 52,298,282 B | −34,400 B |
| `.rodata` | 22,036,416 B | 21,995,456 B | −40,960 B |
| stripped binary | 74,713,200 B | 74,631,280 B | −81,920 B |

## Performance

Benchmarked `Bun.escapeHTML` on the affected scalar path (3–32 bytes) and the unchanged >32-byte path. 9 runs per binary in alternating A/B/B/A order, median of 15 samples × 200k iterations per run. Linux x64 (Xeon Platinum 8488C), `btg` (Release + LTO) builds.

| input | before (ns) | after (ns) | Δ |
|---|---|---|---|
| len=3 clean | 9.90 | 10.19 | +2.9% (within run-to-run noise) |
| len=3 dirty | 10.82 | 10.55 | −2.5% |
| len=8 clean | 11.06 | 9.50 | −14% |
| len=8 dirty | 55.94 | 53.63 | −4% |
| len=16 clean | 14.42 | 11.31 | −22% |
| len=16 dirty | 78.98 | 75.22 | −5% |
| len=24 clean | 15.99 | 13.56 | −15% |
| len=24 dirty | 82.83 | 82.06 | −1% |
| len=32 clean | 17.60 | 16.35 | −7% |
| len=32 dirty | 103.17 | 98.73 | −4% |
| len=64 clean (>32 path) | 60.15 | 33.52 | −44% |
| len=64 dirty (>32 path) | 224.71 | 203.72 | −9% |
| len=512 clean (>32 path) | 466.02 | 227.09 | −51% |
| len=512 dirty (>32 path) | 891.88 | 761.76 | −15% |

No regression on the scalar path — the per-length unrolled bodies were not buying anything over a simple loop.

A note on the >32-byte rows: that path's code is untouched and its instruction sequence is identical before/after (checked by disassembling both binaries — same scalar scan loop, same `bt`-mask test). The large deltas there come from the enclosing function shrinking from ~36 KB to ~2.5 KB (code layout / front-end effects), so treat them as machine-specific rather than something this PR promises everywhere.

## Correctness

- Differential check against the baseline LTO build over ~25k inputs (all lengths 0–70 with each escapable char at every position, all-escape strings, Latin-1 high bytes, UTF-16 with surrogate pairs, every single-char code point 0–255, long strings that trigger the lazy-allocation path): byte-identical outputs.

## Test plan

- [x] `bun bd test test/js/bun/util/escapeHTML.test.js` — 4 pass / 0 fail
- [ ] CI
