### PR TITLE
node-fallbacks: embed browser polyfills zstd-compressed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,6 +1631,7 @@ dependencies = [
  "bun_url",
  "bun_watcher",
  "bun_wyhash",
+ "bun_zstd",
  "const_format",
  "enum-map",
  "enumset",

--- a/scripts/build/codegen.ts
+++ b/scripts/build/codegen.ts
@@ -485,8 +485,11 @@ function emitNodeFallbacks({ n, cfg, sources, o, dirStamp }: Ctx): void {
   const installStamp = emitBunInstall(n, cfg, sourceDir);
 
   const outDir = resolve(cfg.codegenDir, "node-fallbacks");
-  // One output per source, same basename.
-  const outputs = sources.nodeFallbacks.map(s => resolve(outDir, basename(s)));
+  // Two outputs per source: the bundled `.js` (read at runtime by debug
+  // builds) and its zstd-compressed `.js.zst` twin (embedded by release
+  // builds — see src/resolver/node_fallbacks.rs).
+  const jsOutputs = sources.nodeFallbacks.map(s => resolve(outDir, basename(s)));
+  const outputs = [...jsOutputs, ...jsOutputs.map(o => `${o}.zst`)];
 
   // The script (build-fallbacks.ts) reads its args as [outdir, ...sources]
   // but actually ignores the sources — it does readdirSync(".") to discover

--- a/src/node-fallbacks/build-fallbacks.ts
+++ b/src/node-fallbacks/build-fallbacks.ts
@@ -74,6 +74,11 @@ for (let fileIndex = 0; fileIndex < allFiles.length; fileIndex++) {
       }
 
       await Bun.write(`${outdir}/${name}`, outfile);
+      // Release builds embed the zstd-compressed copy (see
+      // src/resolver/node_fallbacks.rs) so the ~1 MB of polyfill text doesn't
+      // sit uncompressed in the binary; debug builds keep reading the plain
+      // `.js` at runtime.
+      await Bun.write(`${outdir}/${name}.zst`, Bun.zstdCompressSync(Buffer.from(outfile), { level: 19 }));
     }),
   );
 }

--- a/src/resolver/Cargo.toml
+++ b/src/resolver/Cargo.toml
@@ -48,4 +48,5 @@ bun_watcher.workspace = true
 bun_url.workspace = true
 bun_wyhash.workspace = true
 bun_hash.workspace = true
+bun_zstd.workspace = true
 bumpalo.workspace = true

--- a/src/resolver/node_fallbacks.rs
+++ b/src/resolver/node_fallbacks.rs
@@ -26,13 +26,47 @@ pub(crate) struct FallbackModule {
 // `*const fn () string` by defining a nested struct with a `get` fn closing over the
 // comptime path. Rust fn pointers cannot close over const-generic `&str` on stable, so
 // this is expressed as a macro that expands to a local `fn get()` and yields its pointer.
+//
+// Release builds (`bun_codegen_embed`) embed the zstd-compressed `<name>.js.zst`
+// written by the codegen step (src/node-fallbacks/build-fallbacks.ts) and
+// decompress it lazily on first access; these polyfills are only ever read when
+// bundling with `--target=browser`, so everything else stops paying ~1 MB of
+// .rodata for the plain text. Debug builds keep loading the uncompressed `.js`
+// from `BUN_CODEGEN_DIR` at runtime so JS-only edits don't need a native rebuild.
 macro_rules! create_source_code_getter {
     ($code_path:literal) => {{
         // `$code_path` is relative to `BUN_CODEGEN_DIR` (codegen output, not
-        // the source tree). The `cfg(bun_codegen_embed)` split lives inside
-        // `runtime_embed_file!` itself.
+        // the source tree).
         fn get() -> &'static str {
-            ::bun_core::runtime_embed_file!(Codegen, $code_path)
+            // `bun_codegen_embed` is set via RUSTFLAGS by scripts/build/rust.ts;
+            // plain `cargo check` doesn't pass `--check-cfg` for it.
+            #[allow(unexpected_cfgs)]
+            let source: &'static str = {
+                #[cfg(bun_codegen_embed)]
+                {
+                    static SOURCE: ::bun_core::Once<String> = ::bun_core::Once::new();
+                    SOURCE
+                        .get_or_init(|| {
+                            let compressed: &'static [u8] =
+                                ::core::include_bytes!(::core::concat!(
+                                    ::core::env!("BUN_CODEGEN_DIR"),
+                                    "/",
+                                    $code_path,
+                                    ".zst"
+                                ));
+                            let bytes = ::bun_zstd::decompress_alloc(compressed)
+                                .expect("embedded node-fallback polyfill: invalid zstd frame");
+                            String::from_utf8(bytes)
+                                .expect("embedded node-fallback polyfill: invalid UTF-8")
+                        })
+                        .as_str()
+                }
+                #[cfg(not(bun_codegen_embed))]
+                {
+                    ::bun_core::runtime_embed_file!(Codegen, $code_path)
+                }
+            };
+            source
         }
         get as fn() -> &'static str
     }};


### PR DESCRIPTION
## Summary

Rust counterpart of #30347 (which targeted the old Zig implementation and is now stale).

The bundled `node-fallbacks/*.js` browser polyfills are embedded as plain-text strings in `.rodata` (~1 MB, 477 KB of which is `crypto.js` alone). They are only ever read when bundling with `--target=browser`, so everyone who never bundles for the browser pays the ~1 MB on disk for nothing.

This PR compresses each polyfill with zstd-19 at codegen time (~85% ratio) and embeds the `.js.zst` in release builds (`bun_codegen_embed`). The first access to a given module decompresses it into the heap and caches it for the process lifetime. Debug builds keep reading the uncompressed `.js` from `BUN_CODEGEN_DIR` at runtime, so JS-only edits still don't trigger a native rebuild.

## Size

Measured with the `btg` profile (Release + LTO, linux x64), both builds at the same base commit, same build directory:

| | before | after | Δ |
|---|---|---|---|
| stripped binary | 74,713,200 B | 73,910,384 B | **−802,816 B (−1.07%)** |
| `.rodata` | 22,036,416 B | 21,232,448 B | −803,968 B |
| `.text` | 52,332,682 B | 52,338,218 B | +5,536 B (lazy-decompress getters) |
| `crypto.js` polyfill in binary | 477,051 B | 71,164 B | |

## Performance

`bun build --target=browser`, hyperfine, warmup=3, runs=30, linux x64 (Xeon Platinum 8488C), Release+LTO builds:

**worst case** — entry imports the 5 largest polyfills (crypto, stream, assert, zlib, http; all decompressed on the path):

| | mean ± σ |
|---|---|
| before | 33.9 ms ± 0.6 ms |
| after | 34.5 ms ± 0.5 ms |
| ratio | 1.02 ± 0.02 (≈ +0.6 ms once per build for ~700 KB of one-time zstd decompression) |

**no polyfills** — `console.log("hello")` entry: 5.1 ms vs 5.2 ms (1.01 ± 0.05, within noise).

**runtime startup** — `bun -e 'console.log(1)'`: 10.1 ms vs 10.1 ms (1.00 ± 0.04). Decompression is lazy; it never runs unless a polyfill is actually requested.

Bundler output is byte-identical before and after (verified for an entry importing all 23 polyfills and for the worst-case entry above).

## Implementation

- `src/node-fallbacks/build-fallbacks.ts` — write a `.js.zst` next to each bundled `.js` (`Bun.zstdCompressSync(..., { level: 19 })`).
- `scripts/build/codegen.ts` — declare both `.js` and `.js.zst` as ninja outputs of the codegen step (both feed the cargo edge's implicit inputs).
- `src/resolver/node_fallbacks.rs` — `create_source_code_getter!` embeds the `.zst` via `include_bytes!` under `cfg(bun_codegen_embed)` and lazily decompresses into a per-module `bun_core::Once<String>` on first call; the `cfg(not(bun_codegen_embed))` (debug) path is unchanged.
- `src/resolver/Cargo.toml` — add `bun_zstd` dependency.

`react-refresh.js` is unchanged since it's referenced from the bake dev server, not the fallback resolver.

## Test plan

- [x] `bun bd test test/bundler/bundler_browser.test.ts` — 12 pass / 0 fail (debug build, runtime-load path)
- [x] same test file run with the Release+LTO binary (exercises the embed + decompress path) — 12 pass / 0 fail
- [x] `bun build --target=browser` output diff'd byte-identical against a pre-change build (all 23 polyfills)
- [ ] CI
