### PR TITLE
install: skip npm-lock entries for scoped GHP pkgs missing `resolved`

### DIFF
--- a/.github/workflows/build-patched.yml
+++ b/.github/workflows/build-patched.yml
@@ -1,0 +1,77 @@
+name: Build patched bun (linux-x64)
+
+on:
+  push:
+    branches:
+      - claude/npm-lock-ghp-skip
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install gcc-13 + libstdc++-13-dev (bun CI parity)
+        run: |
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt-get update -qq
+          sudo apt-get install -y gcc-13 g++-13 libstdc++-13-dev
+
+      - name: Install cmake 3.30.5
+        run: |
+          wget -q -O /tmp/cmake.sh https://github.com/Kitware/CMake/releases/download/v3.30.5/cmake-3.30.5-linux-x86_64.sh
+          sudo sh /tmp/cmake.sh --skip-license --prefix=/usr/local
+
+      - name: Install LLVM 21
+        run: |
+          wget -q https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 21 all
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: bun install
+        run: bun install --frozen-lockfile
+
+      - name: Build debug
+        run: bun ./scripts/build.ts --profile=debug
+
+      - name: Build release
+        run: bun ./scripts/build.ts --profile=release
+
+      - name: Stage outputs
+        id: stage
+        run: |
+          mkdir -p out
+          BUN_DEBUG=$(find build -name bun-debug -type f -executable | head -1)
+          BUN_REL=$(find build/release -maxdepth 2 -name bun -type f -executable -not -path '*/CMakeFiles/*' | head -1)
+          [ -n "$BUN_DEBUG" ] && cp "$BUN_DEBUG" out/bun-debug
+          [ -n "$BUN_REL" ] && cp "$BUN_REL" out/bun
+          ls -lh out/
+          [ -f out/bun ] && sha256sum out/bun | tee out/bun.sha256
+
+      - name: Upload bun-debug
+        if: hashFiles('out/bun-debug') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: bun-debug-linux-x64
+          path: out/bun-debug
+          retention-days: 14
+
+      - name: Upload bun release
+        if: hashFiles('out/bun') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: bun-linux-x64
+          path: |
+            out/bun
+            out/bun.sha256
+          retention-days: 30

--- a/src/install/migration.rs
+++ b/src/install/migration.rs
@@ -398,6 +398,40 @@ pub(crate) fn migrate_npm_lockfile<'a>(
             continue;
         }
 
+        // Scoped packages without a `resolved` URL whose scope resolves to
+        // GitHub Packages: skip the lockfile entry entirely so the dep walk
+        // at the bottom of this function falls through to its existing
+        // "could not find package, treat like it doesn't exist" branch.
+        //
+        // Background: the synthesis path below builds the npm-compat URL
+        // `<registry>/<scope>/<pkg>/-/<unscoped>-<ver>.tgz`. GHP doesn't
+        // serve tarballs at that URL — it 302-redirects to upstream npmjs
+        // with the scope dropped from the path, where the private package
+        // doesn't exist (404). Without the package's SHA we can't synthesize
+        // a working GHP URL (`/download/<scope>/<pkg>/<ver>/<sha>`) here, so
+        // we drop the entry and let bun's runtime metadata-driven resolve
+        // (the same path a fresh `bun install` uses) populate it correctly.
+        //
+        // This is the npm-lock analogue of #28959 (pnpm-lock); #28961's
+        // approach of preserving `resolution.tarball` doesn't translate
+        // because npm-lock has no tarball field separate from `resolved`.
+        // Only the affected entries are dropped — the rest of the lockfile
+        // remains pinned exactly as before.
+        if pkg.get(b"resolved").is_none() {
+            let pkg_name = package_name_from_path(pkg_path);
+            if !pkg_name.is_empty()
+                && pkg_name[0] == b'@'
+                && manager
+                    .scope_for_package_name(pkg_name)
+                    .url
+                    .href()
+                    .windows(b"npm.pkg.github.com".len())
+                    .any(|w| w == b"npm.pkg.github.com")
+            {
+                continue;
+            }
+        }
+
         id_map.put_assume_capacity(
             pkg_path,
             IdMapValue {


### PR DESCRIPTION
### What's the problem this PR addresses?

The npm-lockfile analogue of #28959 (pnpm-lock).

When bun migrates a `package-lock.json` (npm v3) entry without a `resolved` field, it synthesises the URL `<registry>/<scope>/<pkg>/-/<unscoped>-<ver>.tgz` (in `src/install/migration.rs` around the `if pkg.get(b"resolved").is_none()` synthesis block) and uses that as the tarball URL.

For scoped packages whose registry is GitHub Packages this is the wrong endpoint: GHP serves tarballs at `/download/<scope>/<pkg>/<ver>/<sha>` (per each package's own `dist.tarball` metadata). The npm-compat request 302-redirects to upstream npmjs with the scope dropped from the path, where the private package doesn't exist → 404 → install fails.

#28961 fixed the pnpm case by preserving `resolution.tarball` from the lockfile. That doesn't translate to npm-lock because the npm-lockfile entry has no tarball field separate from `resolved` — when `resolved` is null, there's nothing to preserve. The package's SHA isn't available at migration time either, so we can't locally synthesise a working GHP URL.

### How did you solve the problem?

Detect the case before adding to `id_map` and skip the entry. The dep-walk later in the same function already has graceful "could not find package, treat like it doesn't exist" handling (the trailing `continue 'dep_loop` branch), so bun's runtime resolver fetches the registry manifest for the missing dep and uses the correct `dist.tarball` URL — exactly what it already does on a fresh `bun install` for that dep.

The check is narrow: only scoped + null `resolved` + scope resolves to `npm.pkg.github.com`. Every other lockfile entry stays pinned, so users only pay the manifest-fetch cost for the affected packages.

### How did you verify your code works?

Built debug + release on a CI runner (ubuntu-22.04, glibc 2.35) and ran against a real customer's lockfile on Debian 12.

**Stock bun** (current main):
```
[migrated lockfile from package-lock.json]
error: GET https://registry.npmjs.com/<unscoped>/-/<unscoped>-<ver>.tgz - 404
```

**With this patch**: migration completes normally, the affected scoped packages get resolved against GHP's manifest at install time, all 3000+ packages download correctly (the unaffected ones from cached resolutions in the lockfile, the dropped ones from fresh manifest fetch).

Tested previously with a coarser "bail-out the whole migration" variant — same end result for the failing install but at the cost of `Ignoring lockfile` for every other dep. This PR is the per-entry refinement.

### Open question for maintainers

Substring check `href.windows(18).any(|w| w == b"npm.pkg.github.com")` is a host-detection heuristic rather than a host check (would also match a URL whose path happens to contain `npm.pkg.github.com`). I'd be happy to refactor `Npm::Scope` to compute `is_github_packages: bool` once at scope-load time in `fromAPI` — that turns the per-entry check into a byte compare and avoids the fragility. Holding off until there's signal that the overall approach is acceptable.

Related: #28959, #28961