### PR TITLE
install: bail out of npm-lock migration on resolved:null + non-default registry

### DIFF
--- a/src/install/migration.rs
+++ b/src/install/migration.rs
@@ -353,6 +353,7 @@ pub(crate) fn migrate_npm_lockfile<'a>(
     id_map.reserve(packages_properties.len());
     let mut num_extern_strings: u32 = 0;
     let mut package_idx: u32 = 0;
+    let mut has_unsynthesised_npm_entry = false;
     for (i, entry) in packages_properties.iter().enumerate() {
         let pkg_path = entry
             .key
@@ -435,8 +436,35 @@ pub(crate) fn migrate_npm_lockfile<'a>(
             if let Some(version_prop) = version_prop
                 && !pkg_name.is_empty()
             {
-                // construct registry url
-                let href: &[u8] = manager.scope_for_package_name(pkg_name).url.href();
+                // The `<registry>/<name>/-/<unscoped>-<ver>.tgz` URL we
+                // synthesise here is npm's own convention — it matches
+                // real tarball paths on registry.npmjs.org/.com but not
+                // on alternative registries. GitHub Packages, for
+                // example, publishes at `/download/<scope>/<pkg>/<ver>/
+                // <sha>` and 302-redirects the npm-style path to upstream
+                // npmjs (with the scope dropped), where the private
+                // package doesn't exist → 404 → install fails.
+                //
+                // The synthesised URL was only ever a guess. For
+                // non-default registries we can't reconstruct the path
+                // without the package's metadata, so set a flag that
+                // makes the migration return `NotAllPackagesGotResolved`
+                // before phase 2 runs — bun's caller then falls back to
+                // a fresh resolve, which queries the registry's package
+                // metadata for the correct tarball URL.
+                //
+                // (We can't just `continue` here: the entry already has
+                // an id_map slot, and phase 3's dep-walk would fall
+                // through to a `.folder` resolution pointing at the
+                // package path, which makes bun treat the dep as a
+                // local file that doesn't exist on disk and silently
+                // skip it — the original symptom the customer hit.)
+                let scope = manager.scope_for_package_name(pkg_name);
+                if scope.url_hash != *Npm::registry::DEFAULT_URL_HASH {
+                    has_unsynthesised_npm_entry = true;
+                    continue;
+                }
+                let href: &[u8] = scope.url.href();
                 let mut count: usize = 0;
                 count += href.len() + pkg_name.len() + b"/-/".len();
                 if pkg_name[0] == b'@' {
@@ -486,6 +514,15 @@ pub(crate) fn migrate_npm_lockfile<'a>(
     }
     if num_deps == u32::MAX {
         return Err(err!("InvalidNPMLockfile")); // lol
+    }
+
+    if has_unsynthesised_npm_entry {
+        // At least one `resolved: null` entry resolved to a non-default
+        // registry where the npmjs `/-/<name>-<ver>.tgz` URL pattern
+        // doesn't match — see the comment in the counting loop. Bail
+        // out before phase 2/3 to let bun's caller fall back to a fresh
+        // resolve.
+        return Err(err!("NotAllPackagesGotResolved"));
     }
 
     debug!("counted {} dependencies", num_deps);

--- a/test/cli/install/migration/migrate.test.ts
+++ b/test/cli/install/migration/migrate.test.ts
@@ -217,3 +217,49 @@ test("npm lockfile migration skips extraneous packages that also declare inBundl
   expect(await Bun.file(join(testDir, "node_modules", "pkg0", "package.json")).json()).toEqual({ name: "pkg0" });
   expect(fs.existsSync(join(testDir, "bun.lock"))).toBeTrue();
 });
+
+test("npm lockfile migration bails when resolved:null entry is on a non-default registry", async () => {
+  // For `resolved: null` entries the migration synthesises a tarball URL from
+  // `<registry>/<name>/-/<unscoped>-<ver>.tgz`. That path is npm's own and
+  // doesn't match registries with a different tarball layout (GitHub Packages
+  // serves at `/download/<scope>/<pkg>/<ver>/<sha>`, for example). If we
+  // synthesised regardless, the install would either 404 (best case) or
+  // silently drop the affected entries when the dep-walk falls through to a
+  // local-folder resolution. The migration must instead refuse and let the
+  // outer install fall back to a fresh resolve, which queries the registry's
+  // package metadata for the correct URL.
+  const testDir = tempDirWithFiles("npm-resolved-null-altreg", {
+    "package.json": JSON.stringify({
+      name: "pkg",
+      dependencies: { "@altreg/dep": "1.0.0" },
+    }),
+    "bunfig.toml": `[install.scopes]\n"@altreg" = { url = "https://npm.pkg.github.com/" }\n`,
+    "package-lock.json": JSON.stringify({
+      name: "pkg",
+      version: "0.0.0",
+      lockfileVersion: 3,
+      requires: true,
+      packages: {
+        "": {
+          name: "pkg",
+          version: "0.0.0",
+          dependencies: { "@altreg/dep": "1.0.0" },
+        },
+        "node_modules/@altreg/dep": {
+          version: "1.0.0",
+        },
+      },
+    }),
+  });
+
+  const { stderr } = Bun.spawnSync({
+    cmd: [bunExe(), "install"],
+    env: bunEnv,
+    cwd: testDir,
+    stdout: "ignore",
+  });
+
+  const err = stderr.toString();
+  expect(err).toContain("failed to migrate lockfile");
+  expect(err).toContain("Ignoring lockfile");
+});


### PR DESCRIPTION
### What does this PR do?

When a \`package-lock.json\` entry has \`resolved: null\` and isn't bundled, the counting phase of \`migrateNPMLockfile\` synthesises a tarball URL of the form \`<registry>/<name>/-/<unscoped>-<ver>.tgz\`. That path is npm's own and only matches a real tarball on \`registry.npmjs.{org,com}\`. Alternative registries use different paths — GitHub Packages publishes at \`/download/<scope>/<pkg>/<ver>/<sha>\` and 302-redirects the npm-style path back to upstream npmjs with the scope dropped, so private packages 404 and the install fails.

For \`resolved: null\` entries whose scope resolves to a non-default registry, skip synthesis and record that the migration is incomplete. After the counting loop, return \`NotAllPackagesGotResolved\` before phase 2 runs so the install falls back to a fresh resolve, which queries the registry's package metadata for the correct tarball URL.

The bail-out has to happen *before* phase 2. An earlier draft only skipped synthesis but kept the entry's \`id_map\` slot, and phase 3's dep-walk fell through to a \`.folder\` resolution pointing at a \`node_modules\` path that didn't exist on disk — bun then treated the dep as a missing local file and silently dropped it.

For lockfiles whose scopes all map to the default npmjs registry the synthesised URL still matches a real path, so this is a no-op there.

This is the npm-lock analogue of #28959; #28961 took the same approach on the pnpm-lock side (preserve what the lockfile records, fail-back rather than synthesise around it).

### How did you verify your code works?

Added \`test/cli/install/migration/migrate.test.ts: "npm lockfile migration bails when resolved:null entry is on a non-default registry"\`. The test writes a synthetic \`package-lock.json\` with a \`@altreg/dep\` entry that has no \`resolved\`, points \`@altreg\` at \`https://npm.pkg.github.com/\` via \`bunfig.toml\`, runs \`bun install\`, and asserts the stderr contains both \`failed to migrate lockfile\` and \`Ignoring lockfile\` — i.e. the bail-out fired and the install fell back as intended.

- Before this change: migration silently succeeds with a synthesised URL → install hits \`error: GET https://registry.npmjs.com/<unscoped>/-/...tgz - 404\`.
- After: migration bails, install falls back to a fresh resolve.

The existing migration test suite (\`migrate.test.ts\`, including \`missing-resolved-properties\` and the relative-workspaces lockfile that uses npmjs-scoped \`resolved: null\` entries) still passes — those scopes resolve to the default registry, so the synthesis path is unchanged.