### PR TITLE
Fix crash constructing a Worker with a nearly-exhausted stack

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3814,7 +3814,7 @@ void Process::queueNextTick(JSC::JSGlobalObject* globalObject, const ArgList& ar
 
     JSValue nextTick;
     if (!this->m_nextTickFunction) {
-        nextTick = this->get(globalObject, Identifier::fromString(vm, "nextTick"_s));
+        nextTick = this->constructNextTickFn(vm, defaultGlobalObject(globalObject));
         RETURN_IF_EXCEPTION(scope, void());
     }
 

--- a/test/js/web/workers/worker-construct-stack-overflow-fixture.js
+++ b/test/js/web/workers/worker-construct-stack-overflow-fixture.js
@@ -1,0 +1,19 @@
+// Construct a Worker while the JS stack is nearly exhausted. The Worker
+// constructor emits the "worker" event on the next tick, which lazily
+// initializes process.nextTick by calling a JS function. With no stack budget
+// left that inner call throws a stack-overflow RangeError, which used to crash
+// the process instead of surfacing cleanly.
+let spawned = false;
+function recurse() {
+  try {
+    recurse();
+  } catch (e) {
+    if (!spawned) {
+      spawned = true;
+      const w = new Worker("data:text/javascript,", { type: "module" });
+      w.terminate();
+    }
+  }
+}
+recurse();
+console.log("ok");

--- a/test/js/web/workers/worker-construct-stack-overflow.test.ts
+++ b/test/js/web/workers/worker-construct-stack-overflow.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
+
+// Constructing a Worker emits the "worker" event on the next tick, which
+// lazily initializes process.nextTick by calling a JS function. When the
+// constructor is reached with a nearly-exhausted stack, that inner call
+// throws a stack-overflow RangeError. This used to abort the process with an
+// EXCEPTION_ASSERT in JSObject::get instead of surfacing the error cleanly.
+test("constructing a Worker with a nearly-exhausted stack does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "worker-construct-stack-overflow-fixture.js")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: "ok\n",
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
+});

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -413,4 +413,20 @@ describe("worker_threads", () => {
     await p;
     expect(message).toEqual("hello");
   });
+
+  test("constructing a Worker with a nearly-exhausted stack does not crash", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "worker-construct-stack-overflow-fixture.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "ok\n",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
 });

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -413,20 +413,4 @@ describe("worker_threads", () => {
     await p;
     expect(message).toEqual("hello");
   });
-
-  test("constructing a Worker with a nearly-exhausted stack does not crash", async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "worker-construct-stack-overflow-fixture.js")],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
-      stdout: "ok\n",
-      stderr: "",
-      exitCode: 0,
-      signalCode: null,
-    });
-  });
 });


### PR DESCRIPTION
### What

Constructing a `Worker` while the JS stack is nearly exhausted crashed the process with a JSC assertion:

```
ASSERTION FAILED: !scope.exception() || vm.hasPendingTerminationException() || !hasProperty
JavaScriptCore/JSObjectInlines.h(102) : JSValue JSC::JSObject::get(JSGlobalObject *, PropertyName) const
```

### Why

The `Worker` constructor emits the `"worker"` event on the next tick via `Process::emitOnNextTick()` → `Process::queueNextTick()`. On the first call, `queueNextTick` resolved `process.nextTick` with:

```cpp
nextTick = this->get(globalObject, Identifier::fromString(vm, "nextTick"_s));
```

`nextTick` is a `PropertyCallback` static-table property whose initializer (`constructNextTickFn`) runs a JS function. When the stack is already nearly exhausted (e.g. the constructor is reached while unwinding a deep recursion that just overflowed and was caught), that initializer throws a stack-overflow `RangeError`.

WebKit's `PropertyCallback` reification (`setUpStaticFunctionSlot` / `reifyStaticProperty` in `Lookup.cpp`/`Lookup.h`) has no throw scope and does not propagate exceptions — it stores the (empty) result and reports the property as found. `JSObject::get` then returns with `hasProperty == true` while a non-termination exception is pending, which trips the `EXCEPTION_ASSERT`.

### Fix

Call `Process::constructNextTickFn()` directly instead of going through `JSObject::get()`. The lazy initializer does exactly the same work and caches `m_nextTickFunction`, but now any exception it throws (including the stack overflow) propagates through the normal throw scope and is handled by the existing `RETURN_IF_EXCEPTION`, surfacing as a clean `RangeError` rather than an engine assertion.

### Test

Added a regression test in `test/js/web/workers/worker.test.ts` that spawns a subprocess which overflows the stack, catches it, and constructs a `Worker` at the deepest catch point. Before the fix this aborts with the assertion above; after the fix the process exits cleanly.

Found by Fuzzilli.