### PR TITLE
usockets: don't dispatch a closed socket; preserve ready_polls across nested event-loop ticks

### DIFF
--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -346,12 +346,7 @@ void us_loop_run(struct us_loop_t *loop) {
 
 extern void Bun__JSC_onBeforeWait(void * _Nonnull jsc_vm);
 
-void us_loop_run_bun_tick(struct us_loop_t *loop, const struct timespec* timeout) {
-    if (loop->num_polls == 0)
-        return;
-
-    loop->data.tick_depth++;
-
+static void us_loop_run_bun_tick_inner(struct us_loop_t *loop, const struct timespec* timeout) {
     struct us_internal_callback_t *timer_callback = (struct us_internal_callback_t*)loop->data.sweep_timer;
 
     // Only integrate the loop if we haven't already.
@@ -408,6 +403,57 @@ void us_loop_run_bun_tick(struct us_loop_t *loop, const struct timespec* timeout
 
     /* Emit post callback */
     us_internal_loop_post(loop);
+}
+
+/* ready_polls/num_ready_polls/current_ready_poll are a single buffer shared by
+ * every dispatch pass on this loop. A poll callback can re-enter
+ * us_loop_run_bun_tick (a JS handler that synchronously waits on a promise the
+ * event loop itself must drive re-enters via autoTick), and the
+ * epoll_pwait2/kevent64 in the inner body overwrites that buffer while the outer
+ * us_internal_dispatch_ready_polls is still mid-iteration over it. Without a
+ * snapshot the outer loop resumes against the nested tick's poll array and
+ * index, silently dropping its remaining events. Snapshot the outer iteration
+ * state onto the stack and restore it after the nested tick so each tick
+ * dispatches its own poll set. Kept out of the common (non-nested) path so the
+ * hot event-loop frame doesn't carry the buffer; __attribute__((noinline)) keeps
+ * it off the caller's frame. Only the live [0..num_ready_polls) slice is copied
+ * (num_ready_polls is the kernel fill count, <= LIBUS_MAX_READY_POLLS); the
+ * element type differs per backend (epoll_event vs kevent64_s), so mirror
+ * loop->ready_polls exactly. A socket the nested tick closed stays on
+ * closed_head until the outermost loop_post, so its restored entry is still
+ * valid memory — us_internal_dispatch_ready_poll skips it via us_socket_is_closed. */
+static __attribute__((noinline)) void us_loop_run_bun_tick_nested(struct us_loop_t *loop, const struct timespec* timeout) {
+    const int saved_num_ready_polls = loop->num_ready_polls;
+    const int saved_current_ready_poll = loop->current_ready_poll;
+    __typeof__(loop->ready_polls[0]) saved_ready_polls[LIBUS_MAX_READY_POLLS];
+    if (saved_num_ready_polls > 0) {
+        memcpy(saved_ready_polls, loop->ready_polls, (size_t)saved_num_ready_polls * sizeof(loop->ready_polls[0]));
+    }
+
+    us_loop_run_bun_tick_inner(loop, timeout);
+
+    if (saved_num_ready_polls > 0) {
+        memcpy(loop->ready_polls, saved_ready_polls, (size_t)saved_num_ready_polls * sizeof(loop->ready_polls[0]));
+    }
+    loop->num_ready_polls = saved_num_ready_polls;
+    loop->current_ready_poll = saved_current_ready_poll;
+}
+
+void us_loop_run_bun_tick(struct us_loop_t *loop, const struct timespec* timeout) {
+    if (loop->num_polls == 0)
+        return;
+
+    loop->data.tick_depth++;
+
+    /* tick_depth > 1 means an outer dispatch frame is live and its shared
+     * ready_polls iteration state must survive this nested tick; the outermost
+     * tick has nothing to save, so it runs the body directly. */
+    if (loop->data.tick_depth > 1) {
+        us_loop_run_bun_tick_nested(loop, timeout);
+    } else {
+        us_loop_run_bun_tick_inner(loop, timeout);
+    }
+
     loop->data.tick_depth--;
 }
 

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -462,6 +462,19 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
             if(s && s->flags.adopted && s->prev) {
                 s = s->prev;
             }
+            /* A socket closed earlier in this same tick (its fd shut, ext
+             * destructed, now sitting on loop->data.closed_head awaiting free at
+             * loop_post) can still be referenced by a stale ready_polls entry:
+             * us_internal_loop_update_pending_ready_polls only scrubs entries at
+             * indices >= current_ready_poll, and a nested us_loop_run_bun_tick
+             * restores the outer tick's ready_polls snapshot — so an entry for a
+             * socket the nested tick closed survives into the outer dispatch.
+             * Dispatching it would read the destructed ext (e.g. a dangling
+             * onAborted in uWS HttpContext::onClose) and crash. The socket is
+             * unlinked and pending free, so there is nothing to do for it. */
+            if (us_socket_is_closed(s)) {
+                return;
+            }
             /* The group can change after calling a callback but the loop is always the same */
             struct us_loop_t* loop = s->group->loop;
             if (events & LIBUS_SOCKET_WRITABLE && !error) {

--- a/test/regression/issue/31467.test.ts
+++ b/test/regression/issue/31467.test.ts
@@ -1,0 +1,77 @@
+import { connect } from "node:net";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/31467
+//
+// Segfault in `uWS::HttpContext<false>::onClose` during socket teardown. A
+// socket closed while the event loop was mid-dispatch could still be referenced
+// by a stale `ready_polls` entry and be dispatched again, reading its
+// destructed `HttpResponseData` ext (a dangling `onAborted`) and crashing with
+// no application JS frames on the stack.
+//
+// Reproduction: an HTTP server (async handler on Bun.serve) serving back-to-back
+// POSTs over keep-alive with connections resetting mid-flight, which drives the
+// socket close/teardown path (`us_internal_socket_close_raw` -> `onClose`)
+// concurrently with active dispatch of other sockets. Under the ASAN debug build
+// a use-after-free there aborts the process; the server must stay up and answer.
+test("Bun.serve keep-alive back-to-back POSTs with mid-flight resets don't crash onClose", async () => {
+  const body = Buffer.alloc(256, "x").toString();
+  const keepAliveReq =
+    `POST / HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n` +
+    `Content-Length: ${body.length}\r\n\r\n${body}`;
+
+  await using server = Bun.serve({
+    port: 0,
+    idleTimeout: 1,
+    async fetch(req) {
+      await req.text();
+      await Promise.resolve();
+      return new Response("ok");
+    },
+  });
+
+  const { promise: finished, resolve: finish } = Promise.withResolvers<void>();
+  const deadline = Date.now() + 1500;
+  let open = 0;
+  let responses = 0;
+
+  const spawnConn = () => {
+    if (Date.now() > deadline) {
+      if (open === 0) finish();
+      return;
+    }
+    open++;
+    const sock = connect(server.port, "127.0.0.1");
+    sock.setNoDelay(true);
+    let reqs = 0;
+    const respawn = () => {
+      open--;
+      if (Date.now() <= deadline) queueMicrotask(spawnConn);
+      else if (open === 0) finish();
+    };
+    sock.on("connect", () => {
+      // Pipeline two POSTs back-to-back over keep-alive.
+      sock.write(keepAliveReq + keepAliveReq);
+    });
+    sock.on("data", chunk => {
+      responses += (String(chunk).match(/HTTP\/1\.1 200/g) ?? []).length;
+      if (Date.now() > deadline) return sock.destroy();
+      // Abruptly reset a fraction of connections mid-conversation.
+      if (Math.random() < 0.25) return sock.destroy();
+      if (++reqs > 8) return sock.end();
+      sock.write(keepAliveReq);
+    });
+    sock.on("close", respawn);
+    sock.on("error", () => {});
+  };
+
+  for (let i = 0; i < 64; i++) spawnConn();
+  await finished;
+
+  // Server must still be alive and answering after all that teardown churn.
+  const res = await fetch(server.url, { method: "POST", body: "ping" });
+  expect(res.status).toBe(200);
+  expect(await res.text()).toBe("ok");
+  expect(responses).toBeGreaterThan(0);
+});

--- a/test/regression/issue/31467.test.ts
+++ b/test/regression/issue/31467.test.ts
@@ -1,6 +1,5 @@
-import { connect } from "node:net";
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { connect } from "node:net";
 
 // https://github.com/oven-sh/bun/issues/31467
 //
@@ -18,8 +17,7 @@ import { bunEnv, bunExe } from "harness";
 test("Bun.serve keep-alive back-to-back POSTs with mid-flight resets don't crash onClose", async () => {
   const body = Buffer.alloc(256, "x").toString();
   const keepAliveReq =
-    `POST / HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n` +
-    `Content-Length: ${body.length}\r\n\r\n${body}`;
+    `POST / HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n` + `Content-Length: ${body.length}\r\n\r\n${body}`;
 
   await using server = Bun.serve({
     port: 0,


### PR DESCRIPTION
## What

Fixes the intermittent segfault in `uWS::HttpContext<false>::onClose` during socket teardown reported in #31467.

The decoded crash is entirely inside Bun's socket dispatch path — no application JS frames:

```
onClose (HttpContext.h:232)          reads a dangling httpResponseData->onAborted
us_dispatch_close
us_internal_socket_close_raw         (socket.c)
us_internal_dispatch_ready_poll      (loop.c)
us_internal_dispatch_ready_polls     (epoll_kqueue.c)
us_loop_run_bun_tick → autoTickActive
```

The fault address is heap-range garbage (not near zero), consistent with reading a destructed/stale socket ext rather than a null deref.

## Cause

The event loop's `ready_polls` array, `num_ready_polls` and `current_ready_poll` are a single per-loop scratch area shared by every dispatch pass. Two interacting issues let the dispatch loop act on a socket that was already closed during the same tick:

1. **Nested ticks clobber the shared buffer.** A socket callback can synchronously re-enter `us_loop_run_bun_tick` (a handler that waits on a promise the loop itself must drive ends up in `autoTick`). The nested tick's `epoll_pwait2`/`kevent64` overwrites `ready_polls` and resets the indices while the outer `us_internal_dispatch_ready_polls` is still mid-iteration over it. This is the same shared-state hazard already documented for the pidfd poll in `src/spawn/process.rs`.

2. **The close scrub has a lower bound.** `us_internal_loop_update_pending_ready_polls` only clears a closing socket's entry for indices `>= current_ready_poll`.

When an outer tick resumes over a restored/older buffer, an entry for a socket that was closed earlier this tick (fd shut, ext destructed in `onClose`, still pending free on `closed_head`) can be dispatched. `onClose` then reads a freed `HttpResponseData` (`onAborted`/`userData`) and crashes.

## Fix

- **`us_internal_dispatch_ready_poll` (loop.c):** skip a poll whose socket is already closed (`us_socket_is_closed`). A closed socket is unlinked and pending free — there is nothing to dispatch for it. This mirrors the `us_socket_is_closed` guards the same function already applies after each callback, and is the direct fix for the faulting read.

- **`us_loop_run_bun_tick` (epoll_kqueue.c):** when re-entered (`tick_depth > 1`), snapshot the outer tick's `ready_polls`/`num_ready_polls`/`current_ready_poll` on the stack and restore them after the nested tick, so each tick dispatches its own poll set instead of resuming over the nested tick's buffer and index (which otherwise silently drops the outer tick's remaining events). The snapshot is kept off the common, non-nested path.

## Verification

- A server whose handler re-enters the event loop while keep-alive connections reset mid-flight dispatches an already-closed socket and aborts on a debug build without these changes; with them it runs cleanly.
- Added `test/regression/issue/31467.test.ts`, which drives keep-alive back-to-back POSTs with mid-flight resets and asserts the server survives and keeps answering.
- The full `test/js/bun/http/serve.test.ts` suite shows no new failures (pre-existing failures are environmental: IPv6 loopback, privileged-port binding, unrelated).

## Note

The production crash is an intermittent race (surfaced once after ~6h of traffic), so it is not reproducible on demand in a short CI test. The `us_socket_is_closed` guard is the targeted fix for the exact faulting path and follows the established guard pattern already used in this dispatcher for "a socket was closed during dispatch; don't touch it again."

## Related crashes

This is a dispatch-time use-after-free: `us_internal_dispatch_ready_poll` / `us_loop_run_bun_tick` / `autoTickActive` acting on a socket whose backing memory was already closed/freed (via a stale `ready_polls` entry, including after a nested-tick clobber). Several open segfault reports share that exact signature — same dispatch path, freed socket/ext, heap-range or null+offset fault addresses. #31004 in particular decodes to the **same `bun.report` stack hash** (`10d9b296`) as #31467.

Closes #31467
Fixes #15281
Fixes #20104
Fixes #21862
Fixes #22240
Fixes #22742
Fixes #31004

#22809 (crash through `HttpRouter::executeHandlers` on the same `us_loop_run_bun_tick`/`autoTickActive` dispatch path) is likely the same root cause; leaving it open to confirm separately since its fault is in the routing path rather than a close.