### PR TITLE
node:http: do not throw on empty pfx option

### DIFF
--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -782,7 +782,12 @@ function ClientRequest(input, options, cb) {
   }
   this.joinDuplicateHeaders = joinDuplicateHeaders;
 
-  if (options.pfx) {
+  // An empty `pfx` (e.g. `pfx: []`) carries no certificate data and is a no-op
+  // in Node, so it must not throw. Playwright always sets `pfx: []` on the
+  // request options when `clientCertificates` are configured, even when only
+  // `cert`/`key` are provided. Only reject a `pfx` that actually holds data,
+  // since PKCS#12 is not yet supported by Bun's TLS pipeline.
+  if (options.pfx && (!$isArray(options.pfx) || options.pfx.length > 0)) {
     throw new Error("pfx is not supported");
   }
 

--- a/test/js/node/http/node-http-client-pfx.test.ts
+++ b/test/js/node/http/node-http-client-pfx.test.ts
@@ -80,7 +80,9 @@ describe.concurrent("https.request pfx option", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
+    // The regression surfaced as a thrown "pfx is not supported" before the
+    // request started; assert it is gone and the request completed.
+    expect(stderr).not.toContain("pfx is not supported");
     expect(stdout).toContain("STATUS=200");
     expect(stdout).toContain("BODY=hello");
     expect(exitCode).toBe(0);

--- a/test/js/node/http/node-http-client-pfx.test.ts
+++ b/test/js/node/http/node-http-client-pfx.test.ts
@@ -45,10 +45,12 @@ describe.concurrent("https.request pfx option", () => {
             res.writeHead(200);
             res.end("hello");
           });
-          server.listen(0, () => {
+          // Bind and connect over 127.0.0.1 (not "localhost") so the client
+          // never races ::1 vs 127.0.0.1, which can stall on Windows CI.
+          server.listen(0, "127.0.0.1", () => {
             const req = https.request({
               port: server.address().port,
-              host: "localhost",
+              host: "127.0.0.1",
               method: "GET",
               rejectUnauthorized: false,
               servername: "agent1",
@@ -85,6 +87,7 @@ describe.concurrent("https.request pfx option", () => {
     expect(stderr).not.toContain("pfx is not supported");
     expect(stdout).toContain("STATUS=200");
     expect(stdout).toContain("BODY=hello");
+    if (exitCode !== 0) expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });
 
@@ -98,7 +101,7 @@ describe.concurrent("https.request pfx option", () => {
         `
           const https = require("https");
           try {
-            https.request({ host: "localhost", port: 443, pfx: Buffer.from("x") });
+            https.request({ host: "127.0.0.1", port: 443, pfx: Buffer.from("x") });
             console.log("NO_THROW");
           } catch (err) {
             console.log("THREW=" + err.message);

--- a/test/js/node/http/node-http-client-pfx.test.ts
+++ b/test/js/node/http/node-http-client-pfx.test.ts
@@ -1,0 +1,115 @@
+// Regression test for https://github.com/oven-sh/bun/issues/31471
+//
+// `https.request` / `http.request` threw `Error: pfx is not supported`
+// whenever the request options contained a truthy `pfx` value — including an
+// empty array `pfx: []`. An empty array carries no certificate data and is a
+// no-op in Node, so it must not throw.
+//
+// Playwright's `APIRequestContext` (request.newContext({ clientCertificates }))
+// unconditionally adds `pfx: []` to the request options whenever client
+// certificates are configured, even when the user only supplies `cert`/`key`.
+// Bun's truthy guard then rejected the request with `pfx is not supported`,
+// breaking mutual-TLS requests through Playwright.
+//
+// PKCS#12 is not yet supported by Bun's TLS pipeline, so a `pfx` that actually
+// carries data should still be rejected — only the empty case must pass.
+
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const keys = join(import.meta.dir, "..", "test", "fixtures", "keys");
+const agent1 = {
+  key: readFileSync(join(keys, "agent1-key.pem"), "utf8"),
+  cert: readFileSync(join(keys, "agent1-cert.pem"), "utf8"),
+  ca: readFileSync(join(keys, "ca1-cert.pem"), "utf8"),
+};
+
+describe.concurrent("https.request pfx option", () => {
+  // Mirrors what Playwright sends: an empty `pfx: []` alongside `cert`/`key`.
+  // Before the fix the empty array tripped the `pfx is not supported` guard and
+  // the request never started; after, the request proceeds to completion.
+  test("empty pfx array does not throw and completes the request", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const https = require("https");
+          const server = https.createServer({
+            key: ${JSON.stringify(agent1.key)},
+            cert: ${JSON.stringify(agent1.cert)},
+            ca: ${JSON.stringify(agent1.ca)},
+          }, (req, res) => {
+            res.writeHead(200);
+            res.end("hello");
+          });
+          server.listen(0, () => {
+            const req = https.request({
+              port: server.address().port,
+              host: "localhost",
+              method: "GET",
+              rejectUnauthorized: false,
+              servername: "agent1",
+              ca: ${JSON.stringify(agent1.ca)},
+              // What Playwright always sets when clientCertificates are present:
+              pfx: [],
+              key: ${JSON.stringify(agent1.key)},
+              cert: ${JSON.stringify(agent1.cert)},
+            }, res => {
+              let body = "";
+              res.setEncoding("utf8");
+              res.on("data", d => (body += d));
+              res.on("end", () => {
+                console.log("STATUS=" + res.statusCode);
+                console.log("BODY=" + body);
+                server.close();
+              });
+            });
+            req.on("error", err => {
+              console.log("ERROR=" + err.message);
+              server.close();
+            });
+            req.end();
+          });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("STATUS=200");
+    expect(stdout).toContain("BODY=hello");
+    expect(exitCode).toBe(0);
+  });
+
+  // A `pfx` that actually carries data is still unsupported — it must throw
+  // rather than silently dropping the credentials.
+  test("non-empty pfx still throws pfx is not supported", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const https = require("https");
+          try {
+            https.request({ host: "localhost", port: 443, pfx: Buffer.from("x") });
+            console.log("NO_THROW");
+          } catch (err) {
+            console.log("THREW=" + err.message);
+          }
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("THREW=pfx is not supported");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #31471

## Problem

`https.request` / `http.request` threw `Error: pfx is not supported` whenever the request options contained a **truthy** `pfx` value — including an **empty array** `pfx: []`. In Node an empty `pfx` carries no certificate data and is a harmless no-op, so it does not throw.

Playwright's `APIRequestContext` (`request.newContext({ clientCertificates })`) **unconditionally** injects `pfx: []` into the request options whenever `clientCertificates` are configured — even when the user only supplies `cert`/`key` and no PFX. Bun's truthy guard then rejected every such request, which is why the reporter (correctly) noted "No pfx is used in the example":

```
Request failed: get: pfx is not supported
```

## Reproduction

```js
const https = require("https");

// What Playwright sets when clientCertificates are configured:
https.request({ hostname: "localhost", port: 9443, method: "GET", pfx: [], key: [], cert: [] });
```

- **Node** constructs the request fine (and it completes).
- **Bun (before fix)** throws `pfx is not supported` from the `ClientRequest` constructor.

## Root cause

`src/js/node/_http_client.ts`:

```ts
if (options.pfx) {
  throw new Error("pfx is not supported");
}
```

`[]` is truthy in JS, so Playwright's `pfx: []` trips the guard.

## Fix

Narrow the guard so it only throws when `pfx` actually holds data. An empty array (or any falsy value) is treated as "no pfx" and the request proceeds, matching Node:

```ts
if (options.pfx && (!$isArray(options.pfx) || options.pfx.length > 0)) {
  throw new Error("pfx is not supported");
}
```

PKCS#12 is still not supported by Bun's TLS pipeline (there is no `PKCS12_parse` path in `SSLConfig`), so a **non-empty** `pfx` continues to throw rather than silently dropping credentials.

## Verification

New test `test/js/node/http/node-http-client-pfx.test.ts`:
- `pfx: []` alongside `cert`/`key` no longer throws and the request completes (`STATUS=200`).
- a non-empty `pfx` still throws `pfx is not supported`.

```
git stash push -- src/ && bun bd test test/js/node/http/node-http-client-pfx.test.ts
  -> (fail) empty pfx array ... : error: pfx is not supported

git stash pop && bun bd test test/js/node/http/node-http-client-pfx.test.ts
  -> 2 pass, 0 fail
```