### PR TITLE
Honor auto-discovered bunfig [run] elide-lines for bun run --filter

### DIFF
--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -685,6 +685,19 @@ pub(crate) fn run_scripts_with_filter(
     ctx: Command::Context,
 ) -> Result<core::convert::Infallible, bun_core::Error> {
     // Never returns normally; Result<Infallible, _> keeps `?` support.
+    // `bun run` dispatches to the filter runner before `RunCommand::exec_with_cfg`,
+    // so the auto-discovery fallback there never runs for `--filter`. Mirror it here
+    // so `[run]` settings (e.g. `elide-lines`) from a bunfig found by auto-discovery
+    // are honored, matching plain `bun run` and `--config=`.
+    if !ctx.debug.loaded_bunfig {
+        let _ = crate::cli::arguments::load_config_path(
+            crate::cli::command::Tag::RunCommand,
+            true,
+            bun_core::zstr!("bunfig.toml"),
+            &mut *ctx,
+        );
+    }
+
     // Own the slice — `ctx` is reborrowed `&mut` for
     // `configure_env_for_run` below while `script_name` is still live.
     let script_name_owned: Box<[u8]> = if ctx.positionals.len() > 1 {

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -690,11 +690,18 @@ pub(crate) fn run_scripts_with_filter(
     // so `[run]` settings (e.g. `elide-lines`) from a bunfig found by auto-discovery
     // are honored, matching plain `bun run` and `--config=`.
     if !ctx.debug.loaded_bunfig {
-        // A CLI `--elide-lines=N` must win over `[run] elide-lines`. For `--config=`,
-        // `Arguments::parse` re-applies the CLI flag after the config load
-        // (Arguments.rs:1380); this fallback runs after `parse` returns, so snapshot
-        // the CLI value and restore it if it was set, preserving that precedence.
+        // CLI flags must win over the matching `[run]` settings. For `--config=`,
+        // `Arguments::parse` re-applies the flags after the config load (the
+        // `"run.silent" in bunfig.toml` block in Arguments.rs); this fallback runs
+        // after `parse` returns, so snapshot the CLI-applied values and restore
+        // them afterward, preserving that precedence.
+        // Only the fields this path actually consumes need it:
+        // `--elide-lines` (read below) and `--bun` (read at the PATH-shim call).
+        // A CLI flag can only raise these from their defaults — `--elide-lines`
+        // sets `Some`, `--bun` sets `true` — so "restore when the snapshot differs
+        // from the unset default" keeps `[run]` winning when no flag was passed.
         let cli_elide_lines = ctx.bundler_options.elide_lines;
+        let cli_run_in_bun = ctx.debug.run_in_bun;
         let _ = crate::cli::arguments::load_config_path(
             crate::cli::command::Tag::RunCommand,
             true,
@@ -703,6 +710,9 @@ pub(crate) fn run_scripts_with_filter(
         );
         if cli_elide_lines.is_some() {
             ctx.bundler_options.elide_lines = cli_elide_lines;
+        }
+        if cli_run_in_bun {
+            ctx.debug.run_in_bun = true;
         }
     }
 

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -690,12 +690,20 @@ pub(crate) fn run_scripts_with_filter(
     // so `[run]` settings (e.g. `elide-lines`) from a bunfig found by auto-discovery
     // are honored, matching plain `bun run` and `--config=`.
     if !ctx.debug.loaded_bunfig {
+        // A CLI `--elide-lines=N` must win over `[run] elide-lines`. For `--config=`,
+        // `Arguments::parse` re-applies the CLI flag after the config load
+        // (Arguments.rs:1380); this fallback runs after `parse` returns, so snapshot
+        // the CLI value and restore it if it was set, preserving that precedence.
+        let cli_elide_lines = ctx.bundler_options.elide_lines;
         let _ = crate::cli::arguments::load_config_path(
             crate::cli::command::Tag::RunCommand,
             true,
             bun_core::zstr!("bunfig.toml"),
             &mut *ctx,
         );
+        if cli_elide_lines.is_some() {
+            ctx.bundler_options.elide_lines = cli_elide_lines;
+        }
     }
 
     // Own the slice — `ctx` is reborrowed `&mut` for

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -630,6 +630,40 @@ describe("bun", () => {
     expect(exitCode).toBe(0);
   });
 
+  // The auto-discovered bunfig also sets `ctx.debug.run_in_bun` from `[run] bun`,
+  // which the --filter path reads to install the node->bun PATH shim. A CLI `--bun`
+  // must still win over `[run] bun = false` (same precedence as --elide-lines above).
+  // When the shim is active, a script's `node` resolves to bun, so
+  // `process.versions.bun` is set.
+  test("--bun flag overrides auto-discovered bunfig [run] bun = false", () => {
+    const dir = tempDirWithFiles("testworkspace", {
+      packages: {
+        dep0: {
+          "package.json": JSON.stringify({
+            name: "dep0",
+            scripts: { whichnode: `node -e "console.log('bunver=' + (process.versions.bun || 'none'))"` },
+          }),
+        },
+      },
+      "package.json": JSON.stringify({ name: "ws", workspaces: ["packages/*"] }),
+      "bunfig.toml": "[run]\nbun = false\n",
+    });
+
+    const { exitCode, stderr, stdout } = spawnSync({
+      cwd: dir,
+      cmd: [bunExe(), "--bun", "run", "--filter", "./packages/dep0", "whichnode"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const stdoutval = stdout.toString();
+    // `--bun` won over `[run] bun = false`: the node shim ran bun.
+    expect(stdoutval).toContain(`bunver=${Bun.version}`);
+    expect(stdoutval).not.toContain("bunver=none");
+    expect(exitCode).toBe(0);
+  });
+
   test("--elide-lines is a no-op (not an error) when stdout is not a terminal", () => {
     const dir = tempDirWithFiles("testworkspace", {
       packages: {

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -560,6 +560,43 @@ describe("bun", () => {
     });
   });
 
+  // Regression test for https://github.com/oven-sh/bun/issues/31479
+  // `bun run --filter` must honor `[run] elide-lines` from an auto-discovered
+  // `bunfig.toml` (no `--config`, no `--elide-lines` flag), the same way plain
+  // `bun run` and `--config=` already do. Before the fix, the filter runner was
+  // dispatched before the bunfig auto-discovery fallback and ignored the config.
+  test("honors auto-discovered bunfig [run] elide-lines with --filter", () => {
+    const dir = tempDirWithFiles("testworkspace", {
+      packages: {
+        dep0: {
+          "index.js": Array(20).fill("console.log('log_line');").join("\n"),
+          "package.json": JSON.stringify({ name: "dep0", scripts: { script: `${bunExe()} run index.js` } }),
+        },
+      },
+      "package.json": JSON.stringify({ name: "ws", workspaces: ["packages/*"] }),
+      // elide-lines = 0 disables elision; only auto-discovered (no --config).
+      "bunfig.toml": "[run]\nelide-lines = 0\n",
+    });
+
+    // No --elide-lines on the CLI: the value must come from bunfig alone.
+    const { exitCode, stderr, stdout } = spawnSync({
+      cwd: dir,
+      cmd: [bunExe(), "run", "--filter", "./packages/dep0", "script"],
+      env: { ...bunEnv, FORCE_COLOR: "1", NO_COLOR: "0" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const stdoutval = stdout.toString();
+    // On Windows piped stdout is not a terminal, so elision never runs; the
+    // 20-line match still validates the script output was produced.
+    if (process.platform !== "win32") {
+      expect(stdoutval).not.toMatch(/lines elided/);
+    }
+    expect(stdoutval).toMatch(/(?:log_line[\s\S]*?){20}/);
+    expect(exitCode).toBe(0);
+  });
+
   test("--elide-lines is a no-op (not an error) when stdout is not a terminal", () => {
     const dir = tempDirWithFiles("testworkspace", {
       packages: {

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -597,6 +597,39 @@ describe("bun", () => {
     expect(exitCode).toBe(0);
   });
 
+  // A CLI `--elide-lines` must still win over `[run] elide-lines` in bunfig,
+  // matching the `--config=` precedence. Here bunfig says 0 (no elision) but the
+  // flag says 10, so elision must still happen.
+  test("--elide-lines flag overrides auto-discovered bunfig [run] elide-lines", () => {
+    const dir = tempDirWithFiles("testworkspace", {
+      packages: {
+        dep0: {
+          "index.js": Array(20).fill("console.log('log_line');").join("\n"),
+          "package.json": JSON.stringify({ name: "dep0", scripts: { script: `${bunExe()} run index.js` } }),
+        },
+      },
+      "package.json": JSON.stringify({ name: "ws", workspaces: ["packages/*"] }),
+      "bunfig.toml": "[run]\nelide-lines = 0\n",
+    });
+
+    const { exitCode, stderr, stdout } = spawnSync({
+      cwd: dir,
+      cmd: [bunExe(), "run", "--filter", "./packages/dep0", "--elide-lines", "10", "script"],
+      env: { ...bunEnv, FORCE_COLOR: "1", NO_COLOR: "0" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const stdoutval = stdout.toString();
+    // On Windows piped stdout is not a terminal so elision never runs; skip the
+    // TTY-only assertion there (see the sibling tests above).
+    if (process.platform !== "win32") {
+      expect(stdoutval).toMatch(/\[10 lines elided\]/);
+    }
+    expect(stdoutval).toMatch(/(?:log_line[\s\S]*?){10}/);
+    expect(exitCode).toBe(0);
+  });
+
   test("--elide-lines is a no-op (not an error) when stdout is not a terminal", () => {
     const dir = tempDirWithFiles("testworkspace", {
       packages: {


### PR DESCRIPTION
Fixes #31479
Fixes #17918

### Repro

Workspace with a root `bunfig.toml`:

```toml
[run]
elide-lines = 0
```

and `packages/app` whose script prints many lines. Running from the workspace root:

```bash
bun run --filter app print-many   # elided in 10-line chunks — bunfig ignored (bug)
```

`cd packages/app && bun run print-many`, `bun run --config=./bunfig.toml --filter app print-many`, and `bun run --elide-lines=0 --filter app print-many` all honor the config/flag. Only the auto-discovered-bunfig + `--filter` combination ignored it.

### Cause

`bun run` dispatches to the `--filter` runner (`run_scripts_with_filter` in `src/runtime/cli/filter_run.rs`) in `exec_auto_or_run` **before** `RunCommand::exec_with_cfg` is ever reached. The plain-run path auto-loads `bunfig.toml` via a `!ctx.debug.loaded_bunfig` fallback at the top of `exec_with_cfg` (`run_command.rs`), but the filter path has no such fallback, so it read `ctx.bundler_options.elide_lines` while it was still `None` and fell back to the hardcoded default of `10`.

`--config=` works because it loads the bunfig during `Arguments::parse` (setting `loaded_bunfig`); `--elide-lines=` works because it sets `elide_lines` directly during parse.

### Fix

Add the same `!loaded_bunfig` auto-discovery fallback at the top of `run_scripts_with_filter`, mirroring `run_command.rs` and the Zig reference (`run_command.zig:1706`). The `!loaded_bunfig` guard means an explicit `--config=` is not re-loaded, and the relative `"bunfig.toml"` resolves against the process cwd exactly like the plain-run fallback.

### Verification

New regression test in `test/cli/run/filter-workspace.test.ts` ("honors auto-discovered bunfig [run] elide-lines with --filter") puts `elide-lines = 0` in an auto-discovered root `bunfig.toml` (no `--config`, no `--elide-lines` flag) and asserts `bun run --filter` emits no `[N lines elided]`.

- Fails on current release (`[10 lines elided]` present despite `elide-lines = 0`).
- Passes with this change.
- Full `filter-workspace.test.ts` suite (55 tests) green.
