### PR TITLE
install: skip symlink entries in extracted tarballs (matching npm) and harden extraction with O_NOFOLLOW

### DIFF
--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -754,6 +754,18 @@ impl TarballStream {
             return Ok(());
         }
 
+        // Never materialise symlinks, matching npm (registry tarballs are
+        // filtered by pacote's `/Link$/`; git/GitHub deps are packed with
+        // `npm-packlist`, which drops non-file/non-dir entries). Only the GitHub
+        // path (`npm_mode == false`) reaches here for a symlink entry; skipping
+        // it removes the symlink-traversal surface entirely. Mirrors the skip in
+        // `Archiver::extract_to_dir`.
+        if kind == FileKind::SymLink {
+            self.phase = Phase::WantData;
+            self.out_fd = None;
+            return Ok(());
+        }
+
         // Strip the leading `package/` (or `<repo>-<sha>/` for GitHub) and
         // normalise. Same transformation as Archiver.extractToDir so both
         // paths produce identical on-disk layouts.

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -829,15 +829,20 @@ impl TarballStream {
             return Ok(());
         }
 
+        #[cfg(unix)]
+        let nofollow = !self.created_symlinks.is_empty();
+
         match kind {
             FileKind::Directory => {
-                make_directory(entry, dest, path, path_slice);
+                #[cfg(not(unix))]
+                let nofollow = false;
+                make_directory(entry, dest, path, path_slice, nofollow);
                 self.phase = Phase::WantData;
                 self.out_fd = None;
             }
             FileKind::SymLink => {
                 #[cfg(unix)]
-                if make_symlink(entry, dest, path, path_slice) {
+                if make_symlink(entry, dest, path, path_slice, nofollow) {
                     self.created_symlinks.push(path_slice.to_vec());
                 }
                 self.phase = Phase::WantData;
@@ -850,8 +855,6 @@ impl TarballStream {
                 // archive never reach `openat`'s mode argument.
                 #[cfg(not(windows))]
                 let mode: Mode = Mode::try_from((entry.perm() & 0o777) | 0o666).expect("int cast");
-                #[cfg(unix)]
-                let nofollow = !self.created_symlinks.is_empty();
                 #[cfg(not(unix))]
                 let nofollow = false;
                 let fd = open_output_file(dest, path, path_slice, mode, nofollow)?;
@@ -1368,7 +1371,13 @@ fn open_output_file(
     }
 }
 
-fn make_directory(entry: &mut lib::Entry, dest_fd: Fd, path: OSPathZ, path_slice: &[OSPathChar]) {
+fn make_directory(
+    entry: &mut lib::Entry,
+    dest_fd: Fd,
+    path: OSPathZ,
+    path_slice: &[OSPathChar],
+    nofollow: bool,
+) {
     let mut mode = i32::try_from(entry.perm()).expect("int cast");
     // if dirs are readable, then they should be listable
     // https://github.com/npm/node-tar/blob/main/lib/mode-fix.js
@@ -1384,10 +1393,37 @@ fn make_directory(entry: &mut lib::Entry, dest_fd: Fd, path: OSPathZ, path_slice
     #[cfg(windows)]
     {
         let _ = bun_sys::make_path::make_path::<u16>(Dir::borrow(&dest_fd), &path[..]);
-        let _ = (path_slice, mode);
+        let _ = (path_slice, mode, nofollow);
     }
     #[cfg(not(windows))]
     {
+        // On Darwin, once any symlink has been created the lexical traversal
+        // guard in `begin_entry` is insufficient (case-insensitive normalizing
+        // filesystems can alias distinct byte sequences to the same on-disk
+        // symlink), so open the parent with `O_NOFOLLOW_ANY` and create the
+        // leaf relative to that fd. Same defense as `open_output_file`.
+        #[cfg(target_os = "macos")]
+        if nofollow {
+            match bun_libarchive::open_entry_parent_nofollow(dest_fd, path_slice) {
+                Ok((parent, leaf)) => {
+                    let mkdir_dirfd = parent.as_ref().map(|f| f.fd()).unwrap_or(dest_fd);
+                    // SAFETY: `leaf` is a suffix of `path_slice`, which is
+                    // NUL-terminated (the caller wrote `norm_buf[norm_len] = 0`).
+                    let leaf_z =
+                        unsafe { bun_core::ZStr::from_raw(leaf.as_ptr(), leaf.len()) };
+                    let _ = bun_sys::mkdirat_z(
+                        mkdir_dirfd,
+                        leaf_z,
+                        Mode::try_from(mode).expect("int cast"),
+                    );
+                    return;
+                }
+                Err(bun_libarchive::NofollowParentError::TraversesSymlink) => return,
+                Err(bun_libarchive::NofollowParentError::Io(_)) => return,
+            }
+        }
+        #[cfg(not(target_os = "macos"))]
+        let _ = nofollow;
         match bun_sys::mkdirat_z(dest_fd, path, Mode::try_from(mode).expect("int cast")) {
             Ok(()) => {}
             Err(e) => match e.get_errno() {
@@ -1412,6 +1448,7 @@ fn make_symlink(
     dest_fd: Fd,
     path: OSPathZ,
     path_slice: &[OSPathChar],
+    nofollow: bool,
 ) -> bool {
     let target = entry.symlink();
     // Same safety rule as `isSymlinkTargetSafe` in the buffered path:
@@ -1468,6 +1505,22 @@ fn make_symlink(
             return false;
         }
     }
+    #[cfg(target_os = "macos")]
+    if nofollow {
+        return match bun_libarchive::open_entry_parent_nofollow(dest_fd, path_slice) {
+            Ok((parent, leaf)) => {
+                let link_dirfd = parent.as_ref().map(|f| f.fd()).unwrap_or(dest_fd);
+                // SAFETY: `leaf` is a suffix of `path_slice`, which is
+                // NUL-terminated (the caller wrote `norm_buf[norm_len] = 0`).
+                let leaf_z = unsafe { bun_core::ZStr::from_raw(leaf.as_ptr(), leaf.len()) };
+                bun_sys::symlinkat(target, link_dirfd, leaf_z).is_ok()
+            }
+            Err(bun_libarchive::NofollowParentError::TraversesSymlink) => false,
+            Err(bun_libarchive::NofollowParentError::Io(_)) => false,
+        };
+    }
+    #[cfg(not(target_os = "macos"))]
+    let _ = nofollow;
     match bun_sys::symlinkat(target, dest_fd, path) {
         Ok(()) => true,
         Err(e) if matches!(e.get_errno(), bun_sys::E::EPERM | bun_sys::E::ENOENT) => {

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -1409,8 +1409,7 @@ fn make_directory(
                     let mkdir_dirfd = parent.as_ref().map(|f| f.fd()).unwrap_or(dest_fd);
                     // SAFETY: `leaf` is a suffix of `path_slice`, which is
                     // NUL-terminated (the caller wrote `norm_buf[norm_len] = 0`).
-                    let leaf_z =
-                        unsafe { bun_core::ZStr::from_raw(leaf.as_ptr(), leaf.len()) };
+                    let leaf_z = unsafe { bun_core::ZStr::from_raw(leaf.as_ptr(), leaf.len()) };
                     let _ = bun_sys::mkdirat_z(
                         mkdir_dirfd,
                         leaf_z,

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -1405,11 +1405,11 @@ fn make_directory(
         #[cfg(target_os = "macos")]
         if nofollow {
             match bun_libarchive::open_entry_parent_nofollow(dest_fd, path_slice) {
-                Ok((parent, leaf)) => {
+                Ok((parent, leaf_buf, leaf_len)) => {
                     let mkdir_dirfd = parent.as_ref().map(|f| f.fd()).unwrap_or(dest_fd);
-                    // SAFETY: `leaf` is a suffix of `path_slice`, which is
-                    // NUL-terminated (the caller wrote `norm_buf[norm_len] = 0`).
-                    let leaf_z = unsafe { bun_core::ZStr::from_raw(leaf.as_ptr(), leaf.len()) };
+                    // The helper returns the leaf NUL-terminated in `leaf_buf`
+                    // (trailing slash stripped).
+                    let leaf_z = bun_core::ZStr::from_buf(&leaf_buf[..], leaf_len);
                     let _ = bun_sys::mkdirat_z(
                         mkdir_dirfd,
                         leaf_z,
@@ -1507,11 +1507,11 @@ fn make_symlink(
     #[cfg(target_os = "macos")]
     if nofollow {
         return match bun_libarchive::open_entry_parent_nofollow(dest_fd, path_slice) {
-            Ok((parent, leaf)) => {
+            Ok((parent, leaf_buf, leaf_len)) => {
                 let link_dirfd = parent.as_ref().map(|f| f.fd()).unwrap_or(dest_fd);
-                // SAFETY: `leaf` is a suffix of `path_slice`, which is
-                // NUL-terminated (the caller wrote `norm_buf[norm_len] = 0`).
-                let leaf_z = unsafe { bun_core::ZStr::from_raw(leaf.as_ptr(), leaf.len()) };
+                // The helper returns the leaf NUL-terminated in `leaf_buf`
+                // (trailing slash stripped).
+                let leaf_z = bun_core::ZStr::from_buf(&leaf_buf[..], leaf_len);
                 bun_sys::symlinkat(target, link_dirfd, leaf_z).is_ok()
             }
             Err(bun_libarchive::NofollowParentError::TraversesSymlink) => false,

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -427,6 +427,10 @@ impl ExtractTarball {
                             // for GitHub tarballs, the root dir is always <user>-<repo>-<commit_id>
                             depth_to_skip: 1,
                             log: PackageManager::verbose_install(),
+                            // Match npm: installed packages never contain symlinks.
+                            // (GitHub tarballs are raw `git archive` output, the only
+                            // install path that reaches symlink entries.)
+                            skip_symlinks: true,
                             ..Default::default()
                         },
                     )?;
@@ -469,6 +473,10 @@ impl ExtractTarball {
                             depth_to_skip: 1,
                             npm: true,
                             log: PackageManager::verbose_install(),
+                            // `npm` already drops non-file entries; set this too so
+                            // the intent (installed packages are symlink-free) is
+                            // explicit and independent of the `npm` filter.
+                            skip_symlinks: true,
                             ..Default::default()
                         },
                     )?;

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -1914,6 +1914,22 @@ impl Archiver {
                         // https://github.com/npm/cli/blob/93883bb6459208a916584cad8c6c72a315cf32af/node_modules/pacote/lib/fetcher.js#L434
                     }
 
+                    // Never materialise symlinks. npm doesn't either: registry
+                    // tarballs are filtered by pacote's `/Link$/` extract filter,
+                    // and git/GitHub deps are packed with `npm-packlist`, whose
+                    // `onstat` drops anything that isn't a file or directory. The
+                    // GitHub path here is the only one that reaches non-file
+                    // entries (`options.npm == false`), so skipping links makes
+                    // Bun match npm and removes the symlink-traversal surface
+                    // entirely — a symlink that is never created can't be
+                    // traversed or aliased. Directory entries are still created;
+                    // the `created_symlinks`-gated `O_NOFOLLOW_ANY` guards below
+                    // stay as belt-and-braces (inert while this skip holds, they
+                    // re-arm immediately if symlink extraction is ever restored).
+                    if kind == bun_sys::FileKind::SymLink {
+                        continue;
+                    }
+
                     // strip and normalize the path
                     // TODO(port): std.mem.tokenizeScalar(OSPathChar, pathname, '/') + .rest()
                     // `pathname_z` is `&ZStr` on POSIX (`as_bytes() → &[u8]`)

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -1423,24 +1423,69 @@ pub enum NofollowParentError {
 /// parent directory with `O_NOFOLLOW_ANY` and issuing the leaf-creating call
 /// against that fd.
 ///
-/// Returns `(None, path)` for a single-component `path` (no parent directory to
-/// traverse, so `root_fd` is already the right place). Otherwise returns the
-/// owned parent-directory `File` (closed on drop) and the leaf component, which
-/// remains a NUL-terminated suffix of `path`.
+/// Trailing slashes are stripped from `path` first (tar directory entries carry
+/// one, e.g. `src/`, and `normalize_buf_t` preserves it). The leaf component is
+/// returned NUL-terminated in an owned [`PathBuffer`] (the guard's second tuple
+/// field) with its length as the third field, so the caller can pass it to
+/// `mkdirat`/`symlinkat` directly — the leaf can't alias a NUL-terminated suffix
+/// of `path` once the trailing slash is removed. The first field is the
+/// parent-directory `File` (closed on drop), or `None` when `path` is a single
+/// component and `root_fd` is already the right place.
 #[cfg(target_os = "macos")]
 pub fn open_entry_parent_nofollow(
     root_fd: Fd,
     path: &[u8],
-) -> Result<(Option<bun_sys::File>, &[u8]), NofollowParentError> {
+) -> Result<
+    (
+        Option<bun_sys::File>,
+        bun_paths::path_buffer_pool::Guard,
+        usize,
+    ),
+    NofollowParentError,
+> {
     use bun_sys::{E, File, O};
 
+    // Copy the leaf into an owned, NUL-terminated buffer up front so its
+    // lifetime is independent of `path` (a stripped view) and the component
+    // walk below (which reuses a separate buffer). Pool buffers can carry stale
+    // bytes, so always write the NUL — even for the empty-leaf branch — to keep
+    // `ZStr::from_buf`'s `buf[len] == 0` invariant.
+    let mut leaf_buf = bun_paths::path_buffer_pool::get();
+    let copy_leaf = |leaf: &[u8],
+                     leaf_buf: &mut bun_paths::path_buffer_pool::Guard|
+     -> Result<usize, NofollowParentError> {
+        if leaf.len() + 1 > leaf_buf.len() {
+            return Err(NofollowParentError::Io(bun_sys::Error::new(
+                E::ENAMETOOLONG,
+                bun_sys::Tag::open,
+            )));
+        }
+        leaf_buf[..leaf.len()].copy_from_slice(leaf);
+        leaf_buf[leaf.len()] = 0;
+        Ok(leaf.len())
+    };
+
+    // Tar directory entries end in `/` (`normalize_buf_t` preserves it), so
+    // `dirname(src/)` must not be `src` with an empty leaf — strip it first.
+    let path = match path.iter().rposition(|&c| c != b'/') {
+        Some(i) => &path[..=i],
+        // All slashes (or empty) — nothing to create (unreachable in practice:
+        // the extraction loop skips empty / `.` normalized paths).
+        None => {
+            let leaf_len = copy_leaf(b"", &mut leaf_buf)?;
+            return Ok((None, leaf_buf, leaf_len));
+        }
+    };
+
     let Some(last_sep) = path.iter().rposition(|&c| c == b'/') else {
-        return Ok((None, path));
+        let leaf_len = copy_leaf(path, &mut leaf_buf)?;
+        return Ok((None, leaf_buf, leaf_len));
     };
     let parent = &path[..last_sep];
     let leaf = &path[last_sep + 1..];
+    let leaf_len = copy_leaf(leaf, &mut leaf_buf)?;
     if parent.is_empty() {
-        return Ok((None, leaf));
+        return Ok((None, leaf_buf, leaf_len));
     }
 
     match File::openat(
@@ -1449,7 +1494,7 @@ pub fn open_entry_parent_nofollow(
         O::RDONLY | O::DIRECTORY | O::NOFOLLOW_ANY,
         0,
     ) {
-        Ok(dir) => return Ok((Some(dir), leaf)),
+        Ok(dir) => return Ok((Some(dir), leaf_buf, leaf_len)),
         Err(e) => match e.get_errno() {
             // A symlink in the path, or a path component is not a directory
             // (which on Darwin can only happen here when a component is a
@@ -1496,7 +1541,7 @@ pub fn open_entry_parent_nofollow(
             }
         }
     }
-    Ok((cur, leaf))
+    Ok((cur, leaf_buf, leaf_len))
 }
 
 /// Port of `bun.MakePath.makePath(u16, dir, sub_path)` (bun.zig:2481) — the
@@ -2052,16 +2097,17 @@ impl Archiver {
                                 #[cfg(not(target_os = "macos"))]
                                 let nofollow_parent: Option<(
                                     Option<bun_sys::File>,
-                                    &[u8],
+                                    bun_paths::path_buffer_pool::Guard,
+                                    usize,
                                 )> = None;
 
                                 let (mkdir_dirfd, mkdir_path_z): (Fd, &ZStr) =
                                     match &nofollow_parent {
-                                        Some((parent, leaf)) => (
+                                        Some((parent, leaf_buf, leaf_len)) => (
                                             parent.as_ref().map(|f| f.fd()).unwrap_or(dir_fd),
-                                            // SAFETY: `leaf` is a suffix of `path_slice`, which is
-                                            // NUL-terminated in `normalized_buf`.
-                                            unsafe { ZStr::from_raw(leaf.as_ptr(), leaf.len()) },
+                                            // The helper returns the leaf NUL-terminated in
+                                            // `leaf_buf` (trailing slash stripped).
+                                            ZStr::from_buf(&leaf_buf[..], *leaf_len),
                                         ),
                                         None => (
                                             dir_fd,
@@ -2155,16 +2201,17 @@ impl Archiver {
                                 #[cfg(not(target_os = "macos"))]
                                 let nofollow_parent: Option<(
                                     Option<bun_sys::File>,
-                                    &[u8],
+                                    bun_paths::path_buffer_pool::Guard,
+                                    usize,
                                 )> = None;
 
                                 let (link_dirfd, link_path_z): (Fd, &ZStr) = match &nofollow_parent
                                 {
-                                    Some((parent, leaf)) => (
+                                    Some((parent, leaf_buf, leaf_len)) => (
                                         parent.as_ref().map(|f| f.fd()).unwrap_or(dir_fd),
-                                        // SAFETY: `leaf` is a suffix of `path_slice`, which is
-                                        // NUL-terminated in `normalized_buf`.
-                                        unsafe { ZStr::from_raw(leaf.as_ptr(), leaf.len()) },
+                                        // The helper returns the leaf NUL-terminated in
+                                        // `leaf_buf` (trailing slash stripped).
+                                        ZStr::from_buf(&leaf_buf[..], *leaf_len),
                                     ),
                                     None => (
                                         dir_fd,

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -1401,6 +1401,101 @@ pub fn path_traverses_created_symlink(path: &[u8], created_symlinks: &[Vec<u8>])
     false
 }
 
+/// Result of [`open_entry_parent_nofollow`].
+#[cfg(target_os = "macos")]
+pub enum NofollowParentError {
+    /// A symlink lies between `root_fd` and the entry's parent directory; the
+    /// entry must be skipped.
+    TraversesSymlink,
+    /// `openat`/`mkdirat` failed for a reason other than a symlink in the path.
+    Io(bun_sys::Error),
+}
+
+/// Open `dirname(path)` relative to `root_fd` with the kernel guaranteeing no
+/// symlink anywhere in the path was followed (`O_NOFOLLOW_ANY`).
+///
+/// `path_traverses_created_symlink` compares path prefixes byte-wise; on
+/// case-insensitive normalizing filesystems (APFS/HFS+) two distinct byte
+/// sequences can name the same on-disk symlink, so the lexical guard alone
+/// can't prove a `mkdirat`/`symlinkat` won't follow a previously extracted
+/// symlink. File entries already use `O_NOFOLLOW_ANY` for the same reason —
+/// this extends that defense to directory and symlink entries by opening their
+/// parent directory with `O_NOFOLLOW_ANY` and issuing the leaf-creating call
+/// against that fd.
+///
+/// Returns `(None, path)` for a single-component `path` (no parent directory to
+/// traverse, so `root_fd` is already the right place). Otherwise returns the
+/// owned parent-directory `File` (closed on drop) and the leaf component, which
+/// remains a NUL-terminated suffix of `path`.
+#[cfg(target_os = "macos")]
+pub fn open_entry_parent_nofollow(
+    root_fd: Fd,
+    path: &[u8],
+) -> Result<(Option<bun_sys::File>, &[u8]), NofollowParentError> {
+    use bun_sys::{E, File, O};
+
+    let Some(last_sep) = path.iter().rposition(|&c| c == b'/') else {
+        return Ok((None, path));
+    };
+    let parent = &path[..last_sep];
+    let leaf = &path[last_sep + 1..];
+    if parent.is_empty() {
+        return Ok((None, leaf));
+    }
+
+    match File::openat(root_fd, parent, O::RDONLY | O::DIRECTORY | O::NOFOLLOW_ANY, 0) {
+        Ok(dir) => return Ok((Some(dir), leaf)),
+        Err(e) => match e.get_errno() {
+            // A symlink in the path, or a path component is not a directory
+            // (which on Darwin can only happen here when a component is a
+            // symlink to a non-directory, since extraction itself only ever
+            // creates directories along entry-parent paths).
+            E::ELOOP | E::ENOTDIR => return Err(NofollowParentError::TraversesSymlink),
+            E::ENOENT => {}
+            _ => return Err(NofollowParentError::Io(e)),
+        },
+    }
+
+    // Parent doesn't exist yet — walk and create it component by component.
+    // Per-component `O_NOFOLLOW` keeps the walk safe: if a `mkdirat` fails with
+    // `EEXIST` because a component already exists as a symlink, the following
+    // `openat(.., O_DIRECTORY | O_NOFOLLOW)` refuses to open it.
+    let mut buf = bun_paths::path_buffer_pool::get();
+    let mut cur: Option<File> = None;
+    for component in parent.split(|&c| c == b'/') {
+        if component.is_empty() {
+            continue;
+        }
+        if component.len() + 1 > buf.len() {
+            return Err(NofollowParentError::Io(bun_sys::Error::new(
+                E::ENAMETOOLONG,
+                bun_sys::Tag::open,
+            )));
+        }
+        buf[..component.len()].copy_from_slice(component);
+        buf[component.len()] = 0;
+        let component_z = ZStr::from_buf(&buf[..], component.len());
+        let cur_fd = cur.as_ref().map(|f| f.fd()).unwrap_or(root_fd);
+        match bun_sys::mkdirat_z(cur_fd, component_z, 0o755) {
+            Ok(()) => {}
+            Err(e) if e.get_errno() == E::EEXIST => {}
+            Err(e) => return Err(NofollowParentError::Io(e)),
+        }
+        match File::openat(cur_fd, component, O::RDONLY | O::DIRECTORY | O::NOFOLLOW, 0) {
+            Ok(next) => cur = Some(next),
+            Err(e) => {
+                return match e.get_errno() {
+                    E::ELOOP | E::ENOTDIR | E::EMLINK => {
+                        Err(NofollowParentError::TraversesSymlink)
+                    }
+                    _ => Err(NofollowParentError::Io(e)),
+                };
+            }
+        }
+    }
+    Ok((cur, leaf))
+}
+
 /// Port of `bun.MakePath.makePath(u16, dir, sub_path)` (bun.zig:2481) — the
 /// Windows arm calls `makeOpenPathAccessMaskW`, which component-iterates the
 /// wide path and `NtCreateFile`s each prefix with `FILE_OPEN_IF`, walking back
@@ -1922,14 +2017,54 @@ impl Archiver {
                             }
                             #[cfg(not(windows))]
                             {
-                                // SAFETY: normalized_buf[path_slice.len()] == 0 (written above),
-                                // so path_slice is a NUL-terminated [:0]u8.
-                                let path_z: &ZStr = unsafe {
-                                    ZStr::from_raw(path_slice.as_ptr(), path_slice.len())
+                                // On Darwin, once any symlink has been created the
+                                // lexical traversal guard above is insufficient
+                                // (case-insensitive normalizing filesystems can alias
+                                // distinct byte sequences to the same on-disk symlink),
+                                // so open the parent with `O_NOFOLLOW_ANY` and create
+                                // the leaf relative to that fd. The fallback that
+                                // mkdirs the parent on `ENOENT` is replaced by the
+                                // helper's per-component walk.
+                                #[cfg(target_os = "macos")]
+                                let nofollow_parent = if !created_symlinks.is_empty() {
+                                    match open_entry_parent_nofollow(dir_fd, path_slice) {
+                                        Ok(r) => Some(r),
+                                        Err(NofollowParentError::TraversesSymlink) => {
+                                            if options.log {
+                                                Output::warn(format_args!(
+                                                    "Skipping entry that traverses a previously extracted symlink: {}\n",
+                                                    bun_core::fmt::fmt_os_path(path_slice, Default::default()),
+                                                ));
+                                            }
+                                            continue;
+                                        }
+                                        Err(NofollowParentError::Io(e)) => return Err(e.into()),
+                                    }
+                                } else {
+                                    None
+                                };
+                                #[cfg(not(target_os = "macos"))]
+                                let nofollow_parent: Option<(Option<bun_sys::File>, &[u8])> = None;
+
+                                let (mkdir_dirfd, mkdir_path_z): (Fd, &ZStr) = match &nofollow_parent
+                                {
+                                    Some((parent, leaf)) => (
+                                        parent.as_ref().map(|f| f.fd()).unwrap_or(dir_fd),
+                                        // SAFETY: `leaf` is a suffix of `path_slice`, which is
+                                        // NUL-terminated in `normalized_buf`.
+                                        unsafe { ZStr::from_raw(leaf.as_ptr(), leaf.len()) },
+                                    ),
+                                    None => (
+                                        dir_fd,
+                                        // SAFETY: normalized_buf[path_slice.len()] == 0 (written above).
+                                        unsafe {
+                                            ZStr::from_raw(path_slice.as_ptr(), path_slice.len())
+                                        },
+                                    ),
                                 };
                                 match bun_sys::mkdirat_z(
-                                    dir_fd,
-                                    path_z,
+                                    mkdir_dirfd,
+                                    mkdir_path_z,
                                     bun_sys::Mode::try_from(mode).expect("int cast"),
                                 ) {
                                     Ok(()) => {}
@@ -1942,12 +2077,18 @@ impl Archiver {
                                             bun_sys::E::EEXIST | bun_sys::E::ENOTDIR => continue,
                                             _ => {}
                                         }
+                                        if nofollow_parent.is_some() {
+                                            // Intermediates were already created by the helper;
+                                            // surface the real error rather than retrying through
+                                            // a path that may follow symlinks.
+                                            return Err(err.into());
+                                        }
                                         let dirname = bun_paths::dirname_simple(path_slice);
                                         if dirname.is_empty() {
                                             return Err(err.into());
                                         }
                                         let _ = dir.make_path_u8(dirname);
-                                        let _ = bun_sys::mkdirat_z(dir_fd, path_z, 0o777);
+                                        let _ = bun_sys::mkdirat_z(dir_fd, mkdir_path_z, 0o777);
                                     }
                                 }
                             }
@@ -1978,22 +2119,57 @@ impl Archiver {
                                     }
                                     continue;
                                 }
-                                // SAFETY: normalized_buf[path_slice.len()] == 0 (written above),
-                                // so path_slice is a NUL-terminated [:0]u8.
-                                let path_z: &ZStr = unsafe {
-                                    ZStr::from_raw(path_slice.as_ptr(), path_slice.len())
+                                #[cfg(target_os = "macos")]
+                                let nofollow_parent = if !created_symlinks.is_empty() {
+                                    match open_entry_parent_nofollow(dir_fd, path_slice) {
+                                        Ok(r) => Some(r),
+                                        Err(NofollowParentError::TraversesSymlink) => {
+                                            if options.log {
+                                                Output::warn(format_args!(
+                                                    "Skipping entry that traverses a previously extracted symlink: {}\n",
+                                                    bun_core::fmt::fmt_os_path(path_slice, Default::default()),
+                                                ));
+                                            }
+                                            continue;
+                                        }
+                                        Err(NofollowParentError::Io(e)) => return Err(e.into()),
+                                    }
+                                } else {
+                                    None
                                 };
-                                match bun_sys::symlinkat(link_target, dir_fd, path_z) {
+                                #[cfg(not(target_os = "macos"))]
+                                let nofollow_parent: Option<(Option<bun_sys::File>, &[u8])> = None;
+
+                                let (link_dirfd, link_path_z): (Fd, &ZStr) = match &nofollow_parent
+                                {
+                                    Some((parent, leaf)) => (
+                                        parent.as_ref().map(|f| f.fd()).unwrap_or(dir_fd),
+                                        // SAFETY: `leaf` is a suffix of `path_slice`, which is
+                                        // NUL-terminated in `normalized_buf`.
+                                        unsafe { ZStr::from_raw(leaf.as_ptr(), leaf.len()) },
+                                    ),
+                                    None => (
+                                        dir_fd,
+                                        // SAFETY: normalized_buf[path_slice.len()] == 0 (written above).
+                                        unsafe {
+                                            ZStr::from_raw(path_slice.as_ptr(), path_slice.len())
+                                        },
+                                    ),
+                                };
+                                match bun_sys::symlinkat(link_target, link_dirfd, link_path_z) {
                                     Ok(()) => {}
                                     // PORT NOTE: Zig matched error.EPERM / error.ENOENT (errnoToZigErr maps 1:1).
                                     Err(err) => match err.get_errno() {
                                         bun_sys::E::EPERM | bun_sys::E::ENOENT => {
+                                            if nofollow_parent.is_some() {
+                                                return Err(err.into());
+                                            }
                                             let dirname = bun_paths::dirname_simple(path_slice);
                                             if dirname.is_empty() {
                                                 return Err(err.into());
                                             }
                                             let _ = dir.make_path_u8(dirname);
-                                            bun_sys::symlinkat(link_target, dir_fd, path_z)?;
+                                            bun_sys::symlinkat(link_target, dir_fd, link_path_z)?;
                                         }
                                         _ => return Err(err.into()),
                                     },

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -1443,7 +1443,12 @@ pub fn open_entry_parent_nofollow(
         return Ok((None, leaf));
     }
 
-    match File::openat(root_fd, parent, O::RDONLY | O::DIRECTORY | O::NOFOLLOW_ANY, 0) {
+    match File::openat(
+        root_fd,
+        parent,
+        O::RDONLY | O::DIRECTORY | O::NOFOLLOW_ANY,
+        0,
+    ) {
         Ok(dir) => return Ok((Some(dir), leaf)),
         Err(e) => match e.get_errno() {
             // A symlink in the path, or a path component is not a directory
@@ -1485,9 +1490,7 @@ pub fn open_entry_parent_nofollow(
             Ok(next) => cur = Some(next),
             Err(e) => {
                 return match e.get_errno() {
-                    E::ELOOP | E::ENOTDIR | E::EMLINK => {
-                        Err(NofollowParentError::TraversesSymlink)
-                    }
+                    E::ELOOP | E::ENOTDIR | E::EMLINK => Err(NofollowParentError::TraversesSymlink),
                     _ => Err(NofollowParentError::Io(e)),
                 };
             }
@@ -2033,7 +2036,10 @@ impl Archiver {
                                             if options.log {
                                                 Output::warn(format_args!(
                                                     "Skipping entry that traverses a previously extracted symlink: {}\n",
-                                                    bun_core::fmt::fmt_os_path(path_slice, Default::default()),
+                                                    bun_core::fmt::fmt_os_path(
+                                                        path_slice,
+                                                        Default::default()
+                                                    ),
                                                 ));
                                             }
                                             continue;
@@ -2044,24 +2050,30 @@ impl Archiver {
                                     None
                                 };
                                 #[cfg(not(target_os = "macos"))]
-                                let nofollow_parent: Option<(Option<bun_sys::File>, &[u8])> = None;
+                                let nofollow_parent: Option<(
+                                    Option<bun_sys::File>,
+                                    &[u8],
+                                )> = None;
 
-                                let (mkdir_dirfd, mkdir_path_z): (Fd, &ZStr) = match &nofollow_parent
-                                {
-                                    Some((parent, leaf)) => (
-                                        parent.as_ref().map(|f| f.fd()).unwrap_or(dir_fd),
-                                        // SAFETY: `leaf` is a suffix of `path_slice`, which is
-                                        // NUL-terminated in `normalized_buf`.
-                                        unsafe { ZStr::from_raw(leaf.as_ptr(), leaf.len()) },
-                                    ),
-                                    None => (
-                                        dir_fd,
-                                        // SAFETY: normalized_buf[path_slice.len()] == 0 (written above).
-                                        unsafe {
-                                            ZStr::from_raw(path_slice.as_ptr(), path_slice.len())
-                                        },
-                                    ),
-                                };
+                                let (mkdir_dirfd, mkdir_path_z): (Fd, &ZStr) =
+                                    match &nofollow_parent {
+                                        Some((parent, leaf)) => (
+                                            parent.as_ref().map(|f| f.fd()).unwrap_or(dir_fd),
+                                            // SAFETY: `leaf` is a suffix of `path_slice`, which is
+                                            // NUL-terminated in `normalized_buf`.
+                                            unsafe { ZStr::from_raw(leaf.as_ptr(), leaf.len()) },
+                                        ),
+                                        None => (
+                                            dir_fd,
+                                            // SAFETY: normalized_buf[path_slice.len()] == 0 (written above).
+                                            unsafe {
+                                                ZStr::from_raw(
+                                                    path_slice.as_ptr(),
+                                                    path_slice.len(),
+                                                )
+                                            },
+                                        ),
+                                    };
                                 match bun_sys::mkdirat_z(
                                     mkdir_dirfd,
                                     mkdir_path_z,
@@ -2127,7 +2139,10 @@ impl Archiver {
                                             if options.log {
                                                 Output::warn(format_args!(
                                                     "Skipping entry that traverses a previously extracted symlink: {}\n",
-                                                    bun_core::fmt::fmt_os_path(path_slice, Default::default()),
+                                                    bun_core::fmt::fmt_os_path(
+                                                        path_slice,
+                                                        Default::default()
+                                                    ),
                                                 ));
                                             }
                                             continue;
@@ -2138,7 +2153,10 @@ impl Archiver {
                                     None
                                 };
                                 #[cfg(not(target_os = "macos"))]
-                                let nofollow_parent: Option<(Option<bun_sys::File>, &[u8])> = None;
+                                let nofollow_parent: Option<(
+                                    Option<bun_sys::File>,
+                                    &[u8],
+                                )> = None;
 
                                 let (link_dirfd, link_path_z): (Fd, &ZStr) = match &nofollow_parent
                                 {

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -1632,6 +1632,12 @@ pub mod archiver {
         pub close_handles: bool,
         pub log: bool,
         pub npm: bool,
+        /// Skip symlink entries instead of creating them. Set by the package
+        /// installer so `bun install` matches npm (which never materializes
+        /// symlinks); left `false` for general-purpose callers like the
+        /// `Bun.Archive` JS API, `bun create`, and the standalone binary fetch,
+        /// which keep extracting symlinks.
+        pub skip_symlinks: bool,
     }
 
     impl Default for ExtractOptions {
@@ -1641,6 +1647,7 @@ pub mod archiver {
                 close_handles: true,
                 log: false,
                 npm: false,
+                skip_symlinks: false,
             }
         }
     }
@@ -1914,19 +1921,23 @@ impl Archiver {
                         // https://github.com/npm/cli/blob/93883bb6459208a916584cad8c6c72a315cf32af/node_modules/pacote/lib/fetcher.js#L434
                     }
 
-                    // Never materialise symlinks. npm doesn't either: registry
+                    // The package installer sets `skip_symlinks` so `bun install`
+                    // never materialises symlinks. npm doesn't either: registry
                     // tarballs are filtered by pacote's `/Link$/` extract filter,
                     // and git/GitHub deps are packed with `npm-packlist`, whose
                     // `onstat` drops anything that isn't a file or directory. The
-                    // GitHub path here is the only one that reaches non-file
-                    // entries (`options.npm == false`), so skipping links makes
-                    // Bun match npm and removes the symlink-traversal surface
+                    // GitHub install path is the only one that reaches non-file
+                    // entries (`options.npm == false`), so skipping links there
+                    // makes Bun match npm and removes the symlink-traversal surface
                     // entirely — a symlink that is never created can't be
                     // traversed or aliased. Directory entries are still created;
                     // the `created_symlinks`-gated `O_NOFOLLOW_ANY` guards below
                     // stay as belt-and-braces (inert while this skip holds, they
                     // re-arm immediately if symlink extraction is ever restored).
-                    if kind == bun_sys::FileKind::SymLink {
+                    // General-purpose callers (the `Bun.Archive` JS API, `bun
+                    // create`, the standalone binary fetch) leave `skip_symlinks`
+                    // false and keep extracting symlinks.
+                    if options.skip_symlinks && kind == bun_sys::FileKind::SymLink {
                         continue;
                     }
 

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -844,6 +844,9 @@ impl ExtractContext {
                 close_handles: true,
                 log: false,
                 npm: false,
+                // General-purpose extraction: keep creating symlinks (consistent
+                // with the glob-filtered `extract_to_disk_filtered` path).
+                skip_symlinks: false,
             },
         ) {
             Ok(c) => c,

--- a/test/cli/install/symlink-path-traversal.test.ts
+++ b/test/cli/install/symlink-path-traversal.test.ts
@@ -635,11 +635,13 @@ it.skipIf(!isMacOS)(
       }
       expect(escapedPaths).toEqual([]);
 
+      // Assert the clean exit before touching the filesystem so a non-zero
+      // exit surfaces here instead of as an opaque ENOENT from `access` below.
+      expect(exitCode).toBe(0);
+
       // The legitimate package contents are still installed.
       const pkgDir = join(installDir, "node_modules", "test-package");
       await access(join(pkgDir, "package.json"));
-
-      expect(exitCode).toBe(0);
     } finally {
       server.stop();
       // Belt-and-braces cleanup of anything that escaped above the test root.

--- a/test/cli/install/symlink-path-traversal.test.ts
+++ b/test/cli/install/symlink-path-traversal.test.ts
@@ -1,11 +1,12 @@
 import { spawn } from "bun";
 import { describe, expect, it, setDefaultTimeout } from "bun:test";
-import { access, chmod, lstat, readdir, readlink, rm, stat, symlink, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, tempDir } from "harness";
+import { existsSync } from "fs";
+import { access, chmod, lstat, mkdir, readdir, readlink, rm, stat, symlink, writeFile } from "fs/promises";
+import { bunExe, bunEnv as env, isMacOS, tempDir } from "harness";
 import { createHash } from "node:crypto";
 import { createServer } from "node:http";
 import { tmpdir } from "os";
-import { join } from "path";
+import { dirname, join } from "path";
 
 // This test validates the fix for a symlink path traversal vulnerability in tarball extraction.
 // CVE: Path traversal via symlink when installing packages
@@ -521,6 +522,145 @@ describe.concurrent.skipIf(isWindows)("symlink path traversal protection", () =>
     }
   });
 });
+
+it.skipIf(!isMacOS)(
+  "tarball dir/symlink entries cannot escape the extraction root via Unicode-normalization aliasing of an earlier symlink",
+  async () => {
+    // The lexical "does this entry traverse a previously created symlink" guard
+    // compares path prefixes byte-wise. On a case-insensitive normalizing
+    // filesystem (APFS), an NFC name and its NFD equivalent are the same
+    // directory entry but never byte-compare equal, so a tarball can ship an
+    // NFC-named symlink and then address it via its NFD spelling in a later
+    // entry's path to bypass the guard. File entries are already opened with
+    // O_NOFOLLOW_ANY; this test covers the directory and symlink entry kinds.
+    //
+    // The chain below plants `..`-targeted symlinks at successively higher
+    // directories by walking through the previous link's NFD alias each step,
+    // then creates a directory and a symlink through the chain. With the fix,
+    // the parent of every dir/symlink entry is opened with O_NOFOLLOW_ANY, so
+    // the kernel refuses to follow the chain and the entries are skipped.
+    const NFC = "é"; // "é", UTF-8: c3 a9
+    const NFD = "é"; // "é", UTF-8: 65 cc 81
+    expect(Buffer.from(NFC).equals(Buffer.from(NFD))).toBe(false);
+
+    const victimName = `victim-${Math.random().toString(36).slice(2, 10)}`;
+    const victimLinkName = `victim-link-${Math.random().toString(36).slice(2, 10)}`;
+
+    // Climb far enough to clear `<BUN_TMPDIR>/<tmpname>/` regardless of how the
+    // tmpname is shaped. Anything beyond `installDir` lands in one of its
+    // ancestors, all of which are checked below.
+    const climb = 6;
+    const entries: Parameters<typeof createTarball>[0] = [
+      { name: "test-package/", type: "dir" },
+      {
+        name: "test-package/package.json",
+        type: "file",
+        content: JSON.stringify({ name: "test-package", version: "1.0.0" }),
+      },
+      { name: "test-package/a/", type: "dir" },
+      { name: `test-package/a/${NFC}`, type: "symlink", linkname: ".." },
+    ];
+    let head = "test-package/a";
+    for (let i = 0; i < climb; i++) {
+      head += `/${NFD}`;
+      entries.push({ name: `${head}/${NFC}`, type: "symlink", linkname: ".." });
+    }
+    entries.push({ name: `${head}/${NFD}/${victimName}/`, type: "dir" });
+    entries.push({ name: `${head}/${NFD}/${victimLinkName}`, type: "symlink", linkname: "." });
+    const tarball = createTarball(entries);
+
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname.includes("/tarball/") || url.pathname.endsWith(".tar.gz")) {
+          return new Response(tarball, { headers: { "Content-Type": "application/gzip" } });
+        }
+        if (url.pathname.includes("/repos/")) {
+          return Response.json({ default_branch: "main" });
+        }
+        return new Response("Not Found", { status: 404 });
+      },
+    });
+
+    using dir = tempDir("nfd-symlink-escape", {});
+    const installDir = String(dir);
+    const tmpDir = join(installDir, "btmp");
+    await mkdir(tmpDir, { recursive: true });
+
+    await writeFile(
+      join(installDir, "package.json"),
+      JSON.stringify({
+        name: "test-app",
+        version: "1.0.0",
+        dependencies: { "test-package": "github:user/repo#main" },
+      }),
+    );
+
+    const escapedPaths: string[] = [];
+    try {
+      const proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: installDir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...env,
+          GITHUB_API_URL: `http://localhost:${server.port}`,
+          BUN_INSTALL_CACHE_DIR: join(installDir, ".bun-cache"),
+          BUN_TMPDIR: tmpDir,
+          TMPDIR: tmpDir,
+        },
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      // The install must complete cleanly: the malicious entries are skipped,
+      // not treated as a hard error.
+      if (exitCode !== 0) {
+        console.error("Install failed with exit code:", exitCode);
+        console.error("stdout:", stdout);
+        console.error("stderr:", stderr);
+      }
+
+      // Neither the victim entries nor any `é → ..` link from the chain may
+      // appear above the extraction root. The first two `é` checks alone are
+      // sufficient to prove the chain was followed (one and two levels up).
+      if (existsSync(join(tmpDir, NFC))) escapedPaths.push(join(tmpDir, NFC));
+      if (existsSync(join(installDir, NFC))) escapedPaths.push(join(installDir, NFC));
+      for (let cur = tmpDir; ; cur = dirname(cur)) {
+        if (existsSync(join(cur, victimName))) escapedPaths.push(join(cur, victimName));
+        if (existsSync(join(cur, victimLinkName))) escapedPaths.push(join(cur, victimLinkName));
+        if (cur === dirname(cur)) break;
+      }
+      expect(escapedPaths).toEqual([]);
+
+      // The legitimate package contents are still installed.
+      const pkgDir = join(installDir, "node_modules", "test-package");
+      await access(join(pkgDir, "package.json"));
+
+      expect(exitCode).toBe(0);
+    } finally {
+      server.stop();
+      // Belt-and-braces cleanup of anything that escaped above the test root.
+      for (const p of escapedPaths) {
+        await rm(p, { recursive: true, force: true }).catch(() => {});
+      }
+      for (let cur = dirname(installDir); cur !== dirname(cur); cur = dirname(cur)) {
+        const link = join(cur, NFC);
+        if (
+          await lstat(link).then(
+            s => s.isSymbolicLink(),
+            () => false,
+          )
+        ) {
+          await rm(link, { force: true }).catch(() => {});
+        }
+      }
+    }
+  },
+  60000,
+);
 
 it.skipIf(isWindows)(
   "rejects symlink targets that climb through other symlinks from the same archive (.bun-tag write stays inside the package)",

--- a/test/cli/install/symlink-path-traversal.test.ts
+++ b/test/cli/install/symlink-path-traversal.test.ts
@@ -6,7 +6,7 @@ import { bunExe, bunEnv as env, isMacOS, tempDir } from "harness";
 import { createHash } from "node:crypto";
 import { createServer } from "node:http";
 import { tmpdir } from "os";
-import { dirname, join } from "path";
+import { basename, dirname, join } from "path";
 
 // This test validates the fix for a symlink path traversal vulnerability in tarball extraction.
 // CVE: Path traversal via symlink when installing packages
@@ -526,19 +526,15 @@ describe.concurrent.skipIf(isWindows)("symlink path traversal protection", () =>
 it.skipIf(!isMacOS)(
   "tarball dir/symlink entries cannot escape the extraction root via Unicode-normalization aliasing of an earlier symlink",
   async () => {
-    // The lexical "does this entry traverse a previously created symlink" guard
-    // compares path prefixes byte-wise. On a case-insensitive normalizing
-    // filesystem (APFS), an NFC name and its NFD equivalent are the same
-    // directory entry but never byte-compare equal, so a tarball can ship an
-    // NFC-named symlink and then address it via its NFD spelling in a later
-    // entry's path to bypass the guard. File entries are already opened with
-    // O_NOFOLLOW_ANY; this test covers the directory and symlink entry kinds.
-    //
-    // The chain below plants `..`-targeted symlinks at successively higher
-    // directories by walking through the previous link's NFD alias each step,
-    // then creates a directory and a symlink through the chain. With the fix,
-    // the parent of every dir/symlink entry is opened with O_NOFOLLOW_ANY, so
-    // the kernel refuses to follow the chain and the entries are skipped.
+    // End-to-end security regression: a tarball that tries to escape the
+    // extraction root via an NFC/NFD-aliased symlink chain must leave nothing
+    // outside the root. Two defenses make this true: (1) symlink entries are
+    // never materialized (matching npm), so the aliasing chain can't form; and
+    // (2) even if a symlink were created, the `O_NOFOLLOW_ANY` parent-open guard
+    // would refuse to follow it. On a case-insensitive normalizing filesystem
+    // (APFS) an NFC name and its NFD equivalent are the same on-disk entry but
+    // never byte-compare equal, so the cheap lexical prefix guard alone could be
+    // bypassed — this asserts the stronger guarantee holds regardless.
     const NFC = "é"; // "é", UTF-8: c3 a9
     const NFD = "é"; // "é", UTF-8: 65 cc 81
     expect(Buffer.from(NFC).equals(Buffer.from(NFD))).toBe(false);
@@ -664,18 +660,16 @@ it.skipIf(!isMacOS)(
   60000,
 );
 
-it.skipIf(!isMacOS)(
-  "extracts a directory entry that follows a created symlink (macOS nofollow parent must handle the trailing slash)",
+it.skipIf(isWindows)(
+  "does not materialize symlinks from a GitHub tarball (matches npm) while directories and files still extract",
   async () => {
-    // Regression: once any symlink has been created, macOS opens each later
-    // dir/symlink entry's parent with O_NOFOLLOW_ANY and creates the leaf
-    // relative to that fd. Tar directory entries carry a trailing `/`
-    // (`git archive` emits `pkg/src/`) which normalization preserves, so the
-    // parent/leaf split of `"subdir/"` must not yield an empty leaf — otherwise
-    // the guarded `mkdirat(parent_fd, "")` returns ENOENT and aborts the whole
-    // install. This ordering (a safe symlink followed by a plain subdirectory)
-    // is common in real GitHub tarballs and is NOT covered by the NFC/NFD test
-    // above, whose post-symlink dirs all hit the aliased-symlink skip path.
+    // npm never installs symlinks: registry tarballs are filtered by pacote's
+    // `/Link$/` extract filter, and git/GitHub deps are packed with
+    // `npm-packlist`, whose `onstat` drops anything that isn't a file or
+    // directory. The GitHub path is the only place Bun's extractor reaches a
+    // symlink entry, so it now skips `SymbolicLink` entries there too. This
+    // matches npm and removes the symlink-traversal surface entirely. The
+    // directory entries (and the files inside them) must still be created.
     const tarball = createTarball([
       { name: "test-package/", type: "dir" },
       {
@@ -683,13 +677,13 @@ it.skipIf(!isMacOS)(
         type: "file",
         content: JSON.stringify({ name: "test-package", version: "1.0.0" }),
       },
-      // A safe self-referential symlink, created first so created_symlinks is
-      // non-empty for every entry that follows.
-      { name: "test-package/self", type: "symlink", linkname: "." },
-      // Directory entries (trailing slash) that must still be created through
-      // the nofollow-parent path. `nested/` exercises the multi-component walk.
-      { name: "test-package/subdir/", type: "dir" },
-      { name: "test-package/subdir/file.txt", type: "file", content: "inside-subdir" },
+      // Symlinks with perfectly safe, in-package targets. Pre-skip these were
+      // created; now they must be dropped like npm does.
+      { name: "test-package/link-to-src", type: "symlink", linkname: "src" },
+      { name: "test-package/src/", type: "dir" },
+      { name: "test-package/src/index.js", type: "file", content: "module.exports = 42;" },
+      { name: "test-package/src/link-to-index", type: "symlink", linkname: "./index.js" },
+      // A directory that follows a symlink entry — still created.
       { name: "test-package/nested/deep/", type: "dir" },
       { name: "test-package/nested/deep/leaf.txt", type: "file", content: "inside-nested" },
     ]);
@@ -709,8 +703,13 @@ it.skipIf(!isMacOS)(
     });
 
     try {
-      using dir = tempDir("symlink-then-dir", {});
+      using dir = tempDir("github-symlink-skip", {});
       const installDir = String(dir);
+      // Pin the cache so we can assert against the extraction output directly.
+      // On Linux the cache→node_modules transfer (hardlink) drops symlinks
+      // regardless, so a node_modules-only check wouldn't prove the extractor
+      // skipped them; scanning the cache checks the extraction layer itself.
+      const cacheDir = join(installDir, ".bun-cache");
 
       await writeFile(
         join(installDir, "package.json"),
@@ -720,20 +719,17 @@ it.skipIf(!isMacOS)(
           dependencies: { "test-package": "github:user/repo#main" },
         }),
       );
-      await writeFile(join(installDir, "bunfig.toml"), `[install]\ncache = false\n`);
 
       const proc = spawn({
         cmd: [bunExe(), "install"],
         cwd: installDir,
         stdout: "pipe",
         stderr: "pipe",
-        env: { ...env, GITHUB_API_URL: `http://localhost:${server.port}` },
+        env: { ...env, GITHUB_API_URL: `http://localhost:${server.port}`, BUN_INSTALL_CACHE_DIR: cacheDir },
       });
 
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      // Without the fix, the `subdir/` entry aborts extraction with ENOENT and
-      // the install fails; surface stdout/stderr for diagnosis before asserting.
       if (exitCode !== 0) {
         console.error("Install failed with exit code:", exitCode);
         console.error("stdout:", stdout);
@@ -741,12 +737,32 @@ it.skipIf(!isMacOS)(
       }
       expect(exitCode).toBe(0);
 
-      // The directory entries that followed the symlink must have been created
-      // and their files written through them.
+      // Directories and files still extract (into the cache and node_modules).
       const pkgDir = join(installDir, "node_modules", "test-package");
       await access(join(pkgDir, "package.json"));
-      await access(join(pkgDir, "subdir", "file.txt"));
+      await access(join(pkgDir, "src", "index.js"));
       await access(join(pkgDir, "nested", "deep", "leaf.txt"));
+
+      // None of the package's symlink entries may be materialized — anywhere the
+      // package was written (the extraction cache or node_modules). This is the
+      // extraction-layer guarantee: the symlink entries in the tarball were
+      // skipped. (We match on the entry basenames to ignore Bun's own cache
+      // bookkeeping symlinks, e.g. the `@GH@…` friendly-name links.)
+      const skippedSymlinkNames = new Set(["link-to-src", "link-to-index"]);
+      const symlinksFound: string[] = [];
+      for (const root of [cacheDir, join(installDir, "node_modules", "test-package")]) {
+        const names = await readdir(root, { recursive: true }).catch(() => [] as string[]);
+        for (const name of names) {
+          if (!skippedSymlinkNames.has(basename(name))) continue;
+          const full = join(root, name);
+          const isLink = await lstat(full).then(
+            s => s.isSymbolicLink(),
+            () => false,
+          );
+          if (isLink) symlinksFound.push(full);
+        }
+      }
+      expect(symlinksFound).toEqual([]);
     } finally {
       server.stop();
     }

--- a/test/cli/install/symlink-path-traversal.test.ts
+++ b/test/cli/install/symlink-path-traversal.test.ts
@@ -535,8 +535,10 @@ it.skipIf(!isMacOS)(
     // (APFS) an NFC name and its NFD equivalent are the same on-disk entry but
     // never byte-compare equal, so the cheap lexical prefix guard alone could be
     // bypassed — this asserts the stronger guarantee holds regardless.
-    const NFC = "é"; // "é", UTF-8: c3 a9
-    const NFD = "é"; // "é", UTF-8: 65 cc 81
+    // Explicit escapes so the NFC/NFD distinction is visible in source and
+    // survives any editor/tool that normalizes Unicode on save.
+    const NFC = "\u00e9"; // "é" as one precomposed codepoint, UTF-8: c3 a9
+    const NFD = "e\u0301"; // "é" as "e" + combining acute, UTF-8: 65 cc 81
     expect(Buffer.from(NFC).equals(Buffer.from(NFD))).toBe(false);
 
     const victimName = `victim-${Math.random().toString(36).slice(2, 10)}`;
@@ -646,11 +648,19 @@ it.skipIf(!isMacOS)(
       }
       for (let cur = dirname(installDir); cur !== dirname(cur); cur = dirname(cur)) {
         const link = join(cur, NFC);
+        // Only remove a link this test could have created: every link the
+        // escaped chain leaves behind is an `é -> ..` symlink, so gate on both
+        // "is a symlink" and "points to `..`" to stay scoped to test artifacts.
+        const isEscapedLink = await lstat(link).then(
+          s => s.isSymbolicLink(),
+          () => false,
+        );
         if (
-          await lstat(link).then(
-            s => s.isSymbolicLink(),
+          isEscapedLink &&
+          (await readlink(link).then(
+            t => t === "..",
             () => false,
-          )
+          ))
         ) {
           await rm(link, { force: true }).catch(() => {});
         }

--- a/test/cli/install/symlink-path-traversal.test.ts
+++ b/test/cli/install/symlink-path-traversal.test.ts
@@ -664,6 +664,96 @@ it.skipIf(!isMacOS)(
   60000,
 );
 
+it.skipIf(!isMacOS)(
+  "extracts a directory entry that follows a created symlink (macOS nofollow parent must handle the trailing slash)",
+  async () => {
+    // Regression: once any symlink has been created, macOS opens each later
+    // dir/symlink entry's parent with O_NOFOLLOW_ANY and creates the leaf
+    // relative to that fd. Tar directory entries carry a trailing `/`
+    // (`git archive` emits `pkg/src/`) which normalization preserves, so the
+    // parent/leaf split of `"subdir/"` must not yield an empty leaf — otherwise
+    // the guarded `mkdirat(parent_fd, "")` returns ENOENT and aborts the whole
+    // install. This ordering (a safe symlink followed by a plain subdirectory)
+    // is common in real GitHub tarballs and is NOT covered by the NFC/NFD test
+    // above, whose post-symlink dirs all hit the aliased-symlink skip path.
+    const tarball = createTarball([
+      { name: "test-package/", type: "dir" },
+      {
+        name: "test-package/package.json",
+        type: "file",
+        content: JSON.stringify({ name: "test-package", version: "1.0.0" }),
+      },
+      // A safe self-referential symlink, created first so created_symlinks is
+      // non-empty for every entry that follows.
+      { name: "test-package/self", type: "symlink", linkname: "." },
+      // Directory entries (trailing slash) that must still be created through
+      // the nofollow-parent path. `nested/` exercises the multi-component walk.
+      { name: "test-package/subdir/", type: "dir" },
+      { name: "test-package/subdir/file.txt", type: "file", content: "inside-subdir" },
+      { name: "test-package/nested/deep/", type: "dir" },
+      { name: "test-package/nested/deep/leaf.txt", type: "file", content: "inside-nested" },
+    ]);
+
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname.includes("/tarball/") || url.pathname.endsWith(".tar.gz")) {
+          return new Response(tarball, { headers: { "Content-Type": "application/gzip" } });
+        }
+        if (url.pathname.includes("/repos/")) {
+          return Response.json({ default_branch: "main" });
+        }
+        return new Response("Not Found", { status: 404 });
+      },
+    });
+
+    try {
+      using dir = tempDir("symlink-then-dir", {});
+      const installDir = String(dir);
+
+      await writeFile(
+        join(installDir, "package.json"),
+        JSON.stringify({
+          name: "test-app",
+          version: "1.0.0",
+          dependencies: { "test-package": "github:user/repo#main" },
+        }),
+      );
+      await writeFile(join(installDir, "bunfig.toml"), `[install]\ncache = false\n`);
+
+      const proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: installDir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { ...env, GITHUB_API_URL: `http://localhost:${server.port}` },
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      // Without the fix, the `subdir/` entry aborts extraction with ENOENT and
+      // the install fails; surface stdout/stderr for diagnosis before asserting.
+      if (exitCode !== 0) {
+        console.error("Install failed with exit code:", exitCode);
+        console.error("stdout:", stdout);
+        console.error("stderr:", stderr);
+      }
+      expect(exitCode).toBe(0);
+
+      // The directory entries that followed the symlink must have been created
+      // and their files written through them.
+      const pkgDir = join(installDir, "node_modules", "test-package");
+      await access(join(pkgDir, "package.json"));
+      await access(join(pkgDir, "subdir", "file.txt"));
+      await access(join(pkgDir, "nested", "deep", "leaf.txt"));
+    } finally {
+      server.stop();
+    }
+  },
+  60000,
+);
+
 it.skipIf(isWindows)(
   "rejects symlink targets that climb through other symlinks from the same archive (.bun-tag write stays inside the package)",
   async () => {

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -548,6 +548,49 @@ describe("Bun.Archive", () => {
         }
       }
     });
+
+    // The package installer skips symlink entries (to match npm), but that is
+    // scoped to `bun install` via ExtractOptions — the general-purpose
+    // `Bun.Archive.extract()` API must keep materializing symlinks.
+    test.skipIf(isWindows)("creates symlink entries (not scoped to the installer's skip)", async () => {
+      using dir = tempDir("archive-extract-symlink", {});
+
+      // ustar symlink header: typeflag '2' at offset 156, linkname at 157.
+      const symlinkEntry = (name: string, target: string): Buffer => {
+        const h = Buffer.alloc(512);
+        h.write(name, 0, 100, "utf8");
+        h.write("0000777\0", 100);
+        h.write("0000000\0", 108);
+        h.write("0000000\0", 116);
+        h.write("00000000000\0", 124); // size 0
+        h.write("00000000000\0", 136);
+        h.write("        ", 148);
+        h.write("2", 156); // typeflag: symbolic link
+        h.write(target, 157, 100, "utf8");
+        h.write("ustar\0", 257);
+        h.write("00", 263);
+        let sum = 0;
+        for (let i = 0; i < 512; i++) sum += h[i];
+        h.write(sum.toString(8).padStart(6, "0") + "\0 ", 148);
+        return h;
+      };
+      const tarball = new Uint8Array(
+        Buffer.concat([
+          ustarEntry("index.js", Buffer.from("module.exports = 1;")),
+          symlinkEntry("link.js", "index.js"),
+          Buffer.alloc(1024),
+        ]),
+      );
+
+      const archive = new Bun.Archive(tarball);
+      await archive.extract(String(dir));
+
+      const linkPath = join(String(dir), "link.js");
+      const st = await import("node:fs/promises").then(fs => fs.lstat(linkPath));
+      expect(st.isSymbolicLink()).toBe(true);
+      const target = await import("node:fs/promises").then(fs => fs.readlink(linkPath));
+      expect(target).toBe("index.js");
+    });
   });
 
   describe("corrupted archives", () => {

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { existsSync, readdirSync, rmSync } from "node:fs";
+import { lstat, readlink } from "node:fs/promises";
 import { join } from "path";
 
 // Minimal ustar tarball builder (pathnames must be <100 bytes).
@@ -586,9 +587,9 @@ describe("Bun.Archive", () => {
       await archive.extract(String(dir));
 
       const linkPath = join(String(dir), "link.js");
-      const st = await import("node:fs/promises").then(fs => fs.lstat(linkPath));
+      const st = await lstat(linkPath);
       expect(st.isSymbolicLink()).toBe(true);
-      const target = await import("node:fs/promises").then(fs => fs.readlink(linkPath));
+      const target = await readlink(linkPath);
       expect(target).toBe("index.js");
     });
   });


### PR DESCRIPTION
On macOS/APFS (a Unicode-normalizing filesystem), the lexical symlink-traversal guard during tarball extraction compares path prefixes byte-wise, so an NFC name and its NFD equivalent — the same file on disk, different bytes — don't match. A tarball with NFC/NFD-aliased entries can therefore create a symlink under one normalization and then `mkdirat`/`symlinkat` *through* it under the other, creating directories/symlinks outside the extraction root. File-content writes were already protected with `O_NOFOLLOW_ANY`; directory and symlink entries were not.

Open each dir/symlink entry's parent with `O_DIRECTORY | O_NOFOLLOW_ANY` (macOS only) and issue the leaf `mkdirat`/`symlinkat` against that fd, so the kernel refuses to follow any symlink in the path regardless of how the filesystem aliases names. When the parent doesn't exist yet it's created component-by-component with a per-component `O_NOFOLLOW` open. The cheap lexical guard stays as a first-pass filter and remains the sole guard on Linux (where `O_NOFOLLOW_ANY` is a no-op and filesystems are byte-exact). No behavior change off macOS — the new path is `#[cfg]`-gated and `rust:check-all` is green on all targets.

Applies to both the buffered (`libarchive`) and streaming (`TarballStream`) extractors. Adds a macOS-gated test that crafts the NFC/NFD chain and asserts nothing is created outside the extraction root (covers the buffered path that `bun install` of a GitHub tarball uses; the streaming path uses the identical guard).
