### PR TITLE
css: bound selector expansion through nesting-holding at-rules

### DIFF
--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -607,8 +607,14 @@ impl<R> CssRuleList<R> {
                             break 'arm;
                         }
                     }
-                    CssRule::Container(_cont) => {
-                        // TODO(port): ContainerRule minify — Zig fallthrough.
+                    CssRule::Container(cont) => {
+                        // The condition-merge/dedup port is still pending, but the
+                        // nested rules must be minified so the nesting-away
+                        // selector expansion stays bounded by
+                        // `MAX_SELECTOR_EXPANSION` — otherwise an at-rule between
+                        // two nesting levels hides the inner levels from the cap
+                        // and the printer expands them exponentially.
+                        cont.rules.minify(context, parent_is_unused)?;
                     }
                     CssRule::LayerBlock(lay) => {
                         lay.rules.minify(context, parent_is_unused)?;
@@ -619,8 +625,10 @@ impl<R> CssRuleList<R> {
                     CssRule::LayerStatement(_lay) => {
                         // TODO(port): LayerStatementRule minify — Zig fallthrough.
                     }
-                    CssRule::MozDocument(_doc) => {
-                        // TODO(port): MozDocumentRule minify — Zig fallthrough.
+                    CssRule::MozDocument(doc) => {
+                        // See `Container` above: recurse so nested style rules
+                        // count against the selector-expansion cap.
+                        doc.rules.minify(context, parent_is_unused)?;
                     }
                     CssRule::Style(_sty) => {
                         // The full `.style` arm (selector compat partitioning,
@@ -641,9 +649,33 @@ impl<R> CssRuleList<R> {
                         }
                     }
                     CssRule::CounterStyle(_) => { /* TODO(port): Zig fallthrough */ }
-                    CssRule::Scope(_) => { /* TODO(port): Zig fallthrough */ }
-                    CssRule::Nesting(_) => { /* TODO(port): Zig fallthrough */ }
-                    CssRule::StartingStyle(_) => { /* TODO(port): Zig fallthrough */ }
+                    CssRule::Scope(scpe) => {
+                        // See `Container` above: recurse so nested style rules
+                        // count against the selector-expansion cap.
+                        scpe.rules.minify(context, parent_is_unused)?;
+                    }
+                    CssRule::Nesting(nst) => {
+                        // See `Container` above. `@nest` wraps a single style
+                        // rule whose own selectors also form a nesting level, so
+                        // charge them against the cap and recurse into its nested
+                        // rules with the multiplier bumped accordingly.
+                        //
+                        // Deliberately does NOT run `StyleRule::minify` on the
+                        // wrapped rule: that would feed its declarations through
+                        // the property handlers, which consume logical properties
+                        // (staging LTR/RTL fallbacks in the handler context) that
+                        // the `@nest` minify port does not yet drain — silently
+                        // dropping the declaration. Leaving the declarations
+                        // untouched preserves them verbatim, matching the
+                        // pre-port behavior.
+                        nst.style.charge_selector_expansion(context)?;
+                        nst.style.minify_nested_rules(context, parent_is_unused)?;
+                    }
+                    CssRule::StartingStyle(rl) => {
+                        // See `Container` above: recurse so nested style rules
+                        // count against the selector-expansion cap.
+                        rl.rules.minify(context, parent_is_unused)?;
+                    }
                     CssRule::FontPaletteValues(_) => { /* TODO(port): Zig fallthrough */ }
                     CssRule::Property(_) => { /* TODO(port): Zig fallthrough */ }
                     _ => {}

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -276,7 +276,7 @@ impl<R> StyleRule<R> {
     where
         R: for<'b> css::generics::DeepClone<'b>,
     {
-        use css::context::{DeclarationContext, PropertyHandlerContext};
+        use css::context::DeclarationContext;
 
         let mut unused = false;
         // TODO(port): blocked_on key-type mismatch — `selector::is_unused` takes
@@ -303,26 +303,7 @@ impl<R> StyleRule<R> {
             }
         }
 
-        // Compiling the enclosing nesting away for the targets repeats this
-        // rule's selectors once per combination of the enclosing style rules'
-        // selectors. That expansion is multiplicative across nesting levels,
-        // so bound it — otherwise a few hundred bytes of deeply nested
-        // multi-selector rules expand into gigabytes of cloned rules and
-        // output. See `css_rules::MAX_SELECTOR_EXPANSION`.
-        if context.selector_expansion_multiplier > 1 {
-            context.selector_expansion_total = context.selector_expansion_total.saturating_add(
-                context
-                    .selector_expansion_multiplier
-                    .saturating_mul(self.selectors.v.len().max(1)),
-            );
-            if context.selector_expansion_total > super::MAX_SELECTOR_EXPANSION {
-                context.err = Some(crate::error::MinifyError {
-                    kind: crate::error::MinifyErrorKind::selector_expansion_limit_exceeded,
-                    loc: self.loc,
-                });
-                return Err(MinifyErr::minify_err);
-            }
-        }
+        self.charge_selector_expansion(context)?;
 
         // TODO: this
         // let pure_css_modules = context.pure_css_modules;
@@ -352,49 +333,95 @@ impl<R> StyleRule<R> {
         context.handler_context.context = DeclarationContext::None;
 
         if self.rules.v.len() > 0 {
-            // When the targets require compiling nesting away (or splitting
-            // this rule's selectors for compatibility), each of this rule's
-            // selectors multiplies the expansion of every nested rule.
-            //
-            // Mirrors the selector-compatibility branch in `minify_style_arm`
-            // (rules/mod.rs): an incompatible selector list is either collapsed
-            // into a single `:is()` selector (nothing cloned) or partitioned
-            // into one cloned rule per selector (fan-out = selector count).
-            // Only the partition case multiplies on its own — but the `:is()`
-            // wrap keeps one `&` reference per original selector, so when
-            // nesting is compiled away the printed output still fans out per
-            // selector, which is why the nesting branch bumps unconditionally.
-            let saved_expansion_multiplier = context.selector_expansion_multiplier;
-            let selectors_incompatible = self.selectors.v.len() > 1
-                && context.targets.should_compile_selectors()
-                && !self.is_compatible(context.targets);
-            let splits_selectors = selectors_incompatible
-                && !(context.targets.is_compatible(css::Feature::IsSelector)
-                    && !self.selectors.any_has_pseudo_element()
-                    && self.selectors.specifities_all_equal());
-            if context.targets.should_compile_same(css::Feature::Nesting) || splits_selectors {
-                context.selector_expansion_multiplier = context
-                    .selector_expansion_multiplier
-                    .saturating_mul(self.selectors.v.len().max(1));
-            }
-
-            let mut handler_context = context.handler_context.child(DeclarationContext::StyleRule);
-            core::mem::swap::<PropertyHandlerContext<'_>>(
-                &mut context.handler_context,
-                &mut handler_context,
-            );
-            self.rules.minify(context, unused)?;
-            core::mem::swap::<PropertyHandlerContext<'_>>(
-                &mut context.handler_context,
-                &mut handler_context,
-            );
-            context.selector_expansion_multiplier = saved_expansion_multiplier;
+            self.minify_nested_rules(context, unused)?;
             if unused && self.rules.v.len() == 0 {
                 return Ok(true);
             }
         }
 
         Ok(false)
+    }
+
+    /// Charge this rule's selectors against the selector-expansion budget.
+    ///
+    /// Compiling the enclosing nesting away for the targets repeats this rule's
+    /// selectors once per combination of the enclosing style rules' selectors.
+    /// That expansion is multiplicative across nesting levels, so bound it —
+    /// otherwise a few hundred bytes of deeply nested multi-selector rules
+    /// expand into gigabytes of cloned rules and output. See
+    /// [`css_rules::MAX_SELECTOR_EXPANSION`](super::MAX_SELECTOR_EXPANSION).
+    pub(crate) fn charge_selector_expansion(
+        &self,
+        context: &mut MinifyContext<'_, '_>,
+    ) -> Result<(), MinifyErr> {
+        if context.selector_expansion_multiplier > 1 {
+            context.selector_expansion_total = context.selector_expansion_total.saturating_add(
+                context
+                    .selector_expansion_multiplier
+                    .saturating_mul(self.selectors.v.len().max(1)),
+            );
+            if context.selector_expansion_total > super::MAX_SELECTOR_EXPANSION {
+                context.err = Some(crate::error::MinifyError {
+                    kind: crate::error::MinifyErrorKind::selector_expansion_limit_exceeded,
+                    loc: self.loc,
+                });
+                return Err(MinifyErr::minify_err);
+            }
+        }
+        Ok(())
+    }
+
+    /// Minify this rule's nested rules, bumping the selector-expansion
+    /// multiplier by this rule's selector count first (and restoring it after)
+    /// so the nested rules are charged for the combinations they expand into.
+    pub(crate) fn minify_nested_rules(
+        &mut self,
+        context: &mut MinifyContext<'_, '_>,
+        parent_is_unused: bool,
+    ) -> Result<(), MinifyErr>
+    where
+        R: for<'b> css::generics::DeepClone<'b>,
+    {
+        use css::context::{DeclarationContext, PropertyHandlerContext};
+
+        // When the targets require compiling nesting away (or splitting this
+        // rule's selectors for compatibility), each of this rule's selectors
+        // multiplies the expansion of every nested rule.
+        //
+        // Mirrors the selector-compatibility branch in `minify_style_arm`
+        // (rules/mod.rs): an incompatible selector list is either collapsed
+        // into a single `:is()` selector (nothing cloned) or partitioned
+        // into one cloned rule per selector (fan-out = selector count).
+        // Only the partition case multiplies on its own — but the `:is()`
+        // wrap keeps one `&` reference per original selector, so when
+        // nesting is compiled away the printed output still fans out per
+        // selector, which is why the nesting branch bumps unconditionally.
+        let saved_expansion_multiplier = context.selector_expansion_multiplier;
+        let selectors_incompatible = self.selectors.v.len() > 1
+            && context.targets.should_compile_selectors()
+            && !self.is_compatible(context.targets);
+        let splits_selectors = selectors_incompatible
+            && !(context.targets.is_compatible(css::Feature::IsSelector)
+                && !self.selectors.any_has_pseudo_element()
+                && self.selectors.specifities_all_equal());
+        if context.targets.should_compile_same(css::Feature::Nesting) || splits_selectors {
+            context.selector_expansion_multiplier = context
+                .selector_expansion_multiplier
+                .saturating_mul(self.selectors.v.len().max(1));
+        }
+
+        let mut handler_context = context.handler_context.child(DeclarationContext::StyleRule);
+        core::mem::swap::<PropertyHandlerContext<'_>>(
+            &mut context.handler_context,
+            &mut handler_context,
+        );
+        let result = self.rules.minify(context, parent_is_unused);
+        core::mem::swap::<PropertyHandlerContext<'_>>(
+            &mut context.handler_context,
+            &mut handler_context,
+        );
+        context.selector_expansion_multiplier = saved_expansion_multiplier;
+        result
     }
 
     /// Returns whether this rule is a duplicate of another rule.

--- a/src/css/rules/supports.rs
+++ b/src/css/rules/supports.rs
@@ -459,12 +459,19 @@ impl<R> SupportsRule<R> {
         &mut self,
         context: &mut MinifyContext,
         parent_is_unused: bool,
-    ) -> core::result::Result<(), MinifyErr> {
-        let _ = self;
-        let _ = context;
-        let _ = parent_is_unused;
-        // TODO: Implement this
-        Ok(())
+    ) -> core::result::Result<(), MinifyErr>
+    where
+        R: for<'b> crate::generics::DeepClone<'b>,
+    {
+        // The condition-merge/dedup port is still pending, but the nested rules
+        // must be minified so compiling nesting away for the targets stays
+        // bounded by `MAX_SELECTOR_EXPANSION`. `@supports` preserves the `&`
+        // resolution context at print time (`to_css` below recurses into
+        // `self.rules` without clearing `dest.ctx`), so style rules nested
+        // behind it multiply against the enclosing nesting levels exactly like
+        // plain nested rules — leaving them unvisited here lets the printer
+        // expand them exponentially.
+        self.rules.minify(context, parent_is_unused)
     }
 }
 

--- a/test/js/bun/css/nested-selector-list-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-list-expansion.test.ts
@@ -14,9 +14,39 @@ import { bunEnv, bunExe, tempDir } from "harness";
 // plain `bun build` since the default bundler targets predate `:is()` and
 // native nesting. The minifier now bounds the expansion and reports an error.
 
-const { minifyTest } = cssInternals;
+const { minifyTest, prefixTest } = cssInternals;
 
 const LIMIT_ERROR = "Nested CSS rules expand to more than";
+
+// `outer` plain-nested two-selector rules, then `atRule`'s block, then `inner`
+// more nested two-selector rules. The blocks are left unclosed (the CSS parser
+// closes them at EOF), matching the fuzzer's shape.
+//
+// The at-rule sits between two nesting levels: the minifier used to descend
+// into plain nested style rules but skip the rules nested inside nesting-holding
+// at-rules like `@starting-style`, so the selector-expansion cap only counted
+// the `outer` levels and never saw the `inner` ones. These at-rules preserve the
+// `&`-resolution context at print time, so when compiling nesting away for old
+// targets the printer expanded the full `outer + inner` depth — an exponential
+// number of selector preludes — without bound.
+function nestedAcrossAtRule(atRule: string, selectors: string, outer: number, inner: number): string {
+  return `${selectors} {\n`.repeat(outer) + `${atRule} {\n` + `${selectors} {\n`.repeat(inner) + "color: red";
+}
+
+function nestedAcrossStartingStyle(selectors: string, outer: number, inner: number): string {
+  return nestedAcrossAtRule("@starting-style", selectors, outer, inner);
+}
+
+// Every nesting-holding at-rule that preserves the parent-selector context at
+// print time (so inner rules multiply against the outer nesting levels) must
+// count those inner rules against the cap. `@supports` in particular calls into
+// a `minify` that looks active but used to be a no-op that never recursed.
+const CONTEXT_PRESERVING_AT_RULES = [
+  "@starting-style",
+  "@supports (color: red)",
+  "@container (width > 1px)",
+  "@-moz-document url-prefix()",
+];
 
 /** `depth` nested copies of a two-selector rule, innermost holding `color: red`. */
 function nestedRules(selectors: string, depth: number): string {
@@ -106,5 +136,130 @@ test("bun build reports an error instead of exploding on deeply nested multi-sel
   expect(stderr).toContain(LIMIT_ERROR);
   expect(exitCode).toBe(1);
   // The build must fail before emitting the (multi-megabyte) expanded output.
+  expect(await Bun.file(`${dir}/out/input.css`).exists()).toBe(false);
+});
+
+// An at-rule such as `@starting-style` sitting between two nesting levels used
+// to hide the inner levels from the selector-expansion cap: the minifier
+// descended into plain nested style rules but not into the rules nested inside
+// `@starting-style`, so the cap never counted them and the printer expanded the
+// full depth exponentially. The minifier now recurses through these at-rules.
+
+test("nested multi-selector rules spanning @starting-style error instead of exploding (minify)", () => {
+  // 8 outer + 8 inner = 16 levels: enough that the full depth blows the cap,
+  // but only if the minifier counts the inner levels hidden behind the at-rule.
+  const src = nestedAcrossStartingStyle('[foo="bar"], .bar', 8, 8);
+  expect(() => minifyTest(src, "", OLD_TARGETS)).toThrow(LIMIT_ERROR);
+});
+
+test("nested multi-selector rules spanning @starting-style error instead of exploding (prefix)", () => {
+  // The exact entrypoint from the fuzzer report: vendor-prefix lowering for old
+  // targets over selector lists nested across `@starting-style`.
+  const src = nestedAcrossStartingStyle('[foo="bar"], .bar', 8, 8);
+  expect(() => prefixTest(src, "", { safari: 11 << 16, firefox: 60 << 16, chrome: 50 << 16 })).toThrow(LIMIT_ERROR);
+});
+
+test.each(CONTEXT_PRESERVING_AT_RULES)("nested multi-selector rules spanning %s error instead of exploding", atRule => {
+  const src = nestedAcrossAtRule(atRule, '[foo="bar"], .bar', 8, 8);
+  expect(() => minifyTest(src, "", OLD_TARGETS)).toThrow(LIMIT_ERROR);
+});
+
+test.each(CONTEXT_PRESERVING_AT_RULES)("shallow nesting spanning %s still compiles for old targets", atRule => {
+  const src = nestedAcrossAtRule(atRule, ".a, .b", 1, 2);
+  const out = minifyTest(src, "", OLD_TARGETS);
+  expect(out.length).toBeLessThan(10_000);
+  // The inner rules resolve against the outer `.a, .b` chain (cartesian product).
+  expect(out).toContain(":is(.a,.b) .b .b");
+});
+
+test("shallow nesting spanning @starting-style still compiles for old targets", () => {
+  const src = nestedAcrossStartingStyle('[foo="bar"], .bar', 1, 2);
+  const out = prefixTest(src, "", { safari: 11 << 16, firefox: 60 << 16, chrome: 50 << 16 });
+  // The `&` chain flows through `@starting-style`, so the inner rules expand to
+  // the cartesian product of the two-selector lists.
+  expect(out).toContain("@starting-style");
+  expect(out).toContain(':is([foo="bar"], .bar) .bar .bar');
+  expect(out.length).toBeLessThan(10_000);
+});
+
+test("declarations nested inside @starting-style are minified", () => {
+  // Previously the `@starting-style` minify arm was a no-op, so nested
+  // declarations were never minified. Duplicate declarations should collapse.
+  const out = minifyTest("@starting-style { .a { color: red; color: red } }", "");
+  expect(out).toBe("@starting-style{.a{color:red}}");
+});
+
+test("@nest declarations are preserved and do not leak onto the following sibling rule", () => {
+  // The `@nest` arm charges the wrapped rule's selectors against the cap and
+  // recurses into its nested rules, but deliberately does not run the wrapped
+  // rule's declarations through the property handlers: those consume logical
+  // properties and only stage physical fallbacks in the shared handler context
+  // (which the `@nest` minify port does not yet drain). Running them would both
+  // drop the declaration from `&.x` and leak the staged fallback onto the next
+  // sibling's selector. The declaration must therefore survive verbatim on
+  // `&.x`, and the sibling must be untouched.
+  const out = minifyTest(".p { @nest &.x { padding-inline-start: 7px } .sibling { color: #abc } }", "", {
+    ie: 11 << 16,
+  });
+  // The `@nest` rule keeps its own declaration verbatim (not dropped, not lowered).
+  expect(out).toContain("padding-inline-start:7px");
+  // The sibling keeps only its own declaration — no leaked padding.
+  expect(out).toContain(".sibling{color:#abc}");
+  expect(out).not.toContain("padding-left");
+  expect(out).not.toContain("padding-right");
+});
+
+test("deeply nested multi-selector rules spanning @scope error instead of exploding", () => {
+  // `@scope` clears the `&`-resolution context at print time, but compiling
+  // nesting away still duplicates the whole `@scope` block once per enclosing
+  // selector combination — so the output is exponential in the outer depth and
+  // the multiplier must be carried through the `@scope` boundary.
+  //
+  // 10 outer + 10 inner levels, chosen so the outer levels alone stay under the
+  // cap (they compile fine on their own, asserted below): the limit can only
+  // fire if the multiplier is carried into the rules nested inside `@scope`.
+  // Resetting it to 1 across the boundary would instead emit 2^outer copies of
+  // the block without ever hitting the cap.
+  const outer = 10;
+  const inner = 10;
+  expect(() => minifyTest(nestedAcrossAtRule("@scope", ".a, .b", outer, inner), "", OLD_TARGETS)).toThrow(LIMIT_ERROR);
+  // The outer levels on their own are well under the cap, so the error above is
+  // attributable to the inner levels counted through `@scope`, not the outer
+  // nesting alone.
+  expect(minifyTest(".a, .b {\n".repeat(outer) + "color: red", "", OLD_TARGETS).length).toBeGreaterThan(0);
+});
+
+test("shallow nesting spanning @scope still compiles for old targets", () => {
+  const src = nestedAcrossAtRule("@scope", ".a, .b", 2, 2);
+  const out = minifyTest(src, "", OLD_TARGETS);
+  expect(out.length).toBeLessThan(10_000);
+  // Inside @scope the inner rules resolve against `:scope`, not the outer chain.
+  expect(out).toContain(":scope");
+  expect(out).toContain("@scope");
+});
+
+test("bun build does not hang on deeply nested multi-selector css spanning @starting-style", async () => {
+  using dir = tempDir("css-starting-style-expansion", {
+    // The fuzzer's depth (14 outer + 11 inner): without the fix this hangs for
+    // 20+ seconds while expanding the inner levels hidden behind the at-rule.
+    "input.css": nestedAcrossStartingStyle('[foo="bar"], .bar', 14, 11),
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "input.css", "--outdir", "out", "--minify"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    // Kill switch: before the fix this hung while expanding the hidden inner
+    // nesting levels. Let the child terminate itself so a regression fails the
+    // assertions below instead of hanging the runner.
+    timeout: 20_000,
+    killSignal: "SIGKILL",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  // Must terminate on its own (reporting the limit error), not be SIGKILLed.
+  expect(proc.signalCode).toBeNull();
+  expect(stderr).toContain(LIMIT_ERROR);
+  expect(exitCode).toBe(1);
   expect(await Bun.file(`${dir}/out/input.css`).exists()).toBe(false);
 });


### PR DESCRIPTION
## What

A deeply-nested CSS stylesheet that interleaves multi-selector rules with a nesting-holding at-rule (e.g. `@starting-style`) hangs for 20+ seconds and produces gigabytes of output when compiled for browser targets that lack CSS nesting. A 599-byte, fully-printable input reproduces it.

## Repro

```
BUN_GARBAGE_COLLECTOR_LEVEL=0 BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1 bun -e 'const I = Buffer.from(Bun.gunzipSync(Buffer.from("H4sIAAAAAAACA4tOy8+3VUpKLFKK1VHQA9IK1VzRo2JcDsUliUUlmXnpusUllTmpZIsM5zBSgILk/Jz8IiuFopzUtBKISC0AoEiSPlcCAAA=", "base64"))).toString("latin1"); require("bun:internal-for-testing").cssInternals.prefixTest(I, "", { safari: 11 << 16, firefox: 60 << 16, chrome: 50 << 16 })'
```

The input decodes to 14 nested `[foo="bar"], .bar` rules, then 4 `@starting-style` blocks, then 11 more nested `[foo="bar"], .bar` rules.

## Cause

The minifier already bounds this class of blowup: `MAX_SELECTOR_EXPANSION` (`src/css/rules/mod.rs`) caps how many selector copies compiling nesting away for the targets will produce, reporting `selector_expansion_limit_exceeded` instead of expanding without bound. The cap's running multiplier is threaded down through `StyleRule::minify` → `CssRuleList::minify` as it recurses into nested rules.

But the minify arms for `@starting-style`, `@container`, `@scope`, `@-moz-document`, `@nest` and `@supports` never recursed into their nested rules (the first five were no-op stubs; `@supports` called a `SupportsRule::minify` that was itself a no-op). So any style rules nested *behind* one of these at-rules were never visited by the minifier and never counted against the cap.

At print time, the serializer still resolves the full parent-selector chain through the at-rule, so the cartesian `&`-expansion runs across the full depth unbounded. The printer's own per-prelude `MAX_NESTING_EXPANSIONS` budget resets per prelude, so it bounds a single prelude's `&` count but not the exponential *number* of preludes.

## Fix

Recurse into the nested rules of these at-rules during minify, mirroring the existing `@layer-block` / `@media` arms, so the existing cap sees the full nesting depth regardless of which at-rules are interleaved. The runaway input now errors in milliseconds.

- **`@nest`** wraps a single style rule whose own selectors form a nesting level. Its selectors are charged against the cap and its nested rules recursed into — but its *own declarations are left verbatim*. The selector-expansion charge/bump was factored out of `StyleRule::minify` into `StyleRule::{charge_selector_expansion, minify_nested_rules}` and reused, so `@nest` can account for its selectors without running `StyleRule::minify` (which would feed the declarations through the property handlers, consume logical properties into the handler context the `@nest` port doesn't yet drain, and silently drop them).
- **`@scope`** clears the nesting context at print time, but compiling nesting away still duplicates the whole `@scope` block once per enclosing selector combination, so its output is exponential in the outer depth and the cap must still count the outer levels.

This does not port the at-rule-specific minify logic (condition merging/dedup) that remains a separate TODO — only the nested-rule recursion that is the root cause of the unbounded expansion.

## ⚠️ Output-behavior change worth a look

Beyond the hang fix, recursing into these arms means declarations nested inside `@starting-style`, `@container`, `@scope`, `@-moz-document` and `@supports` now flow through the normal minification path (property handlers, vendor-prefix lowering, adjacent-rule merging, dedup) where the no-op stubs previously left them verbatim. This is a real change to minifier *output* for valid stylesheets (e.g. duplicate declarations inside `@starting-style` now collapse). The existing CSS suite (1087) and bundler CSS tests (166) all pass, so no regression surfaced, but flagging it for a maintainer's awareness. `@nest` is the exception — its declarations stay verbatim (see above).

## Verification

- The repro now fails fast with `Nested CSS rules expand to more than 65536 selectors ...` (was: 20s+ timeout, CPU pegged).
- `css.test.ts`: 1087 pass, 0 fail. `test/bundler/css/`: 166 pass, 0 fail.
- `test/js/bun/css/nested-selector-list-expansion.test.ts` gains parameterized coverage for all four context-preserving at-rules (`@starting-style`/`@supports`/`@container`/`@-moz-document`), a `@nest` test asserting its declaration survives verbatim with no sibling leak, and `@scope` carry-through bounding. Confirmed the file **fails on the unfixed build** (in-process minify/prefix produce MB of output without erroring; `bun build` is SIGKILLed after hanging) and **passes with the fix**.