### PR TITLE
test(coverage): report the last line of uncalled functions in lcov

### DIFF
--- a/src/sourcemap_jsc/CodeCoverage.rs
+++ b/src/sourcemap_jsc/CodeCoverage.rs
@@ -612,10 +612,9 @@ impl ByteRangeMapping {
 
                 // only mark the lines as executable if the function has not executed
                 // functions that have executed have non-executable lines in them and thats fine.
-                if !did_fn_execute {
-                    let end = max_line.min(line_count);
-                    line_hits_slice[min_line as usize..end as usize].fill(0);
-                    for line in min_line..end {
+                if !did_fn_execute && min_line <= max_line && max_line < line_count {
+                    line_hits_slice[min_line as usize..=max_line as usize].fill(0);
+                    for line in min_line..=max_line {
                         executable_lines.set(line as usize);
                         lines_which_have_executed.unset(line as usize);
                     }
@@ -793,9 +792,8 @@ impl ByteRangeMapping {
 
                 // only mark the lines as executable if the function has not executed
                 // functions that have executed have non-executable lines in them and thats fine.
-                if !did_fn_execute {
-                    let end = max_line.min(line_count);
-                    for line in min_line..end {
+                if !did_fn_execute && min_line <= max_line && max_line < line_count {
+                    for line in min_line..=max_line {
                         executable_lines.set(line as usize);
                         lines_which_have_executed.unset(line as usize);
                         line_hits_slice[line as usize] = 0;

--- a/src/sourcemap_jsc/CodeCoverage.rs
+++ b/src/sourcemap_jsc/CodeCoverage.rs
@@ -231,9 +231,6 @@ pub mod text {
         executable_lines_that_havent_been_executed.set_intersection(&report.executable_lines);
 
         let mut iter = executable_lines_that_havent_been_executed.iterator::<true, true>();
-        let mut start_of_line_range: usize = 0;
-        let mut prev_line: usize = 0;
-        let mut is_first = true;
 
         // PORT NOTE: `concat!(pretty_fmt!(..), "{}")` requires a literal; split into a
         // prefix `write_all` + plain `write!` so the const-generic `ENABLE_COLORS` can
@@ -241,47 +238,45 @@ pub mod text {
         let red = pretty_fmt::<ENABLE_COLORS>("<red>");
         let comma = pretty_fmt::<ENABLE_COLORS>("<r><d>,<r>");
 
-        while let Some(next_line) = iter.next() {
-            if next_line == (prev_line + 1) {
-                prev_line = next_line;
-                continue;
-            } else if is_first && start_of_line_range == 0 && prev_line == 0 {
-                start_of_line_range = next_line;
-                prev_line = next_line;
-                continue;
-            }
-
+        // Collapse the ascending uncovered line indices into runs and print each as
+        // `start` or `start-end` (1-based), comma-separated. A pending run is tracked
+        // with an explicit `Option` rather than sentinel zeros, because line index 0 is
+        // itself a valid value — the old `start == 0 && prev == 0` guard mistook the
+        // sentinel for line 0, printing a bogus `1-2` for a lone uncovered line 1 and
+        // dropping a trailing single-line run entirely.
+        let mut pending: Option<(usize, usize)> = None;
+        let mut is_first = true;
+        let mut flush = |writer: &mut dyn bun_io::Write, start: usize, end: usize| -> bun_io::Result<()> {
             if is_first {
                 is_first = false;
             } else {
                 writer.write_all(&comma)?;
             }
-
-            if start_of_line_range == prev_line {
-                writer.write_all(&red)?;
-                write!(writer, "{}", start_of_line_range + 1)?;
+            writer.write_all(&red)?;
+            if start == end {
+                write!(writer, "{}", start + 1)
             } else {
-                writer.write_all(&red)?;
-                write!(writer, "{}-{}", start_of_line_range + 1, prev_line + 1)?;
+                write!(writer, "{}-{}", start + 1, end + 1)
             }
+        };
 
-            prev_line = next_line;
-            start_of_line_range = next_line;
+        while let Some(next_line) = iter.next() {
+            match pending {
+                Some((_, prev)) if next_line == prev + 1 => {
+                    pending = pending.map(|(start, _)| (start, next_line));
+                }
+                Some((start, prev)) => {
+                    flush(writer, start, prev)?;
+                    pending = Some((next_line, next_line));
+                }
+                None => {
+                    pending = Some((next_line, next_line));
+                }
+            }
         }
 
-        if prev_line != start_of_line_range {
-            if is_first {
-            } else {
-                writer.write_all(&comma)?;
-            }
-
-            if start_of_line_range == prev_line {
-                writer.write_all(&red)?;
-                write!(writer, "{}", start_of_line_range + 1)?;
-            } else {
-                writer.write_all(&red)?;
-                write!(writer, "{}-{}", start_of_line_range + 1, prev_line + 1)?;
-            }
+        if let Some((start, prev)) = pending {
+            flush(writer, start, prev)?;
         }
         Ok(())
     }

--- a/src/sourcemap_jsc/CodeCoverage.rs
+++ b/src/sourcemap_jsc/CodeCoverage.rs
@@ -246,19 +246,20 @@ pub mod text {
         // dropping a trailing single-line run entirely.
         let mut pending: Option<(usize, usize)> = None;
         let mut is_first = true;
-        let mut flush = |writer: &mut dyn bun_io::Write, start: usize, end: usize| -> bun_io::Result<()> {
-            if is_first {
-                is_first = false;
-            } else {
-                writer.write_all(&comma)?;
-            }
-            writer.write_all(&red)?;
-            if start == end {
-                write!(writer, "{}", start + 1)
-            } else {
-                write!(writer, "{}-{}", start + 1, end + 1)
-            }
-        };
+        let mut flush =
+            |writer: &mut dyn bun_io::Write, start: usize, end: usize| -> bun_io::Result<()> {
+                if is_first {
+                    is_first = false;
+                } else {
+                    writer.write_all(&comma)?;
+                }
+                writer.write_all(&red)?;
+                if start == end {
+                    write!(writer, "{}", start + 1)
+                } else {
+                    write!(writer, "{}-{}", start + 1, end + 1)
+                }
+            };
 
         while let Some(next_line) = iter.next() {
             match pending {

--- a/test/cli/test/__snapshots__/coverage.test.ts.snap
+++ b/test/cli/test/__snapshots__/coverage.test.ts.snap
@@ -5,11 +5,11 @@ exports[`lcov coverage reporter: lcov-coverage-reporter-output 1`] = `
 SF:demo1.ts
 FNF:1
 FNH:0
-DA:2,19
+DA:2,0
 DA:3,16
 DA:4,1
 LF:3
-LH:3
+LH:2
 end_of_record
 TN:
 SF:demo2.ts
@@ -20,9 +20,9 @@ DA:4,11
 DA:6,9
 DA:9,0
 DA:10,0
-DA:11,1
+DA:11,0
 DA:14,9
 LF:7
-LH:5
+LH:4
 end_of_record"
 `;

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -670,3 +670,65 @@ end_of_record"
 `);
   expect(result.exitCode).toBe(0);
 });
+
+// https://github.com/oven-sh/bun/issues/31484
+// The text reporter's "Uncovered Line #s" column collapses contiguous
+// uncovered lines into `start-end` runs. It tracked the pending run with
+// sentinel zeros, which mistook the sentinel for a real line 0 (printing a
+// bogus `1-2` for a lone uncovered line 1) and dropped a trailing single-line
+// run entirely. Both are fixed by tracking the pending run explicitly.
+test("text reporter groups uncovered lines and keeps a trailing single line", () => {
+  const dir = tempDirWithFiles("cov", {
+    "bunfig.toml": `
+[test]
+coverageSkipTestFiles = true
+`,
+    "lib.ts": `export function called() {
+  return 1;
+}
+export function uncalledRun(x) {
+  const y = x + 1;
+  return y;
+}
+export class Uncalled {
+#field;
+}
+`,
+    "lib.test.ts": `import { test, expect } from "bun:test";
+import { called, uncalledRun, Uncalled } from "./lib";
+void uncalledRun;
+void Uncalled;
+test("only called runs", () => {
+  expect(called()).toBe(1);
+});
+`,
+  });
+
+  const result = Bun.spawnSync([bunExe(), "test", "--coverage", "./lib.test.ts"], {
+    cwd: dir,
+    env: { ...bunEnv },
+    stdio: [null, null, "pipe"],
+  });
+
+  const stderr = normalizeBunSnapshot(result.stderr.toString("utf-8"), dir);
+
+  // uncalledRun spans lines 4-6 (a run) and the Uncalled class constructor is a
+  // single uncovered line 8 at the end of the file, so the column must read
+  // "4-6,8" — the trailing single line used to be dropped.
+  expect(stderr).toMatchInlineSnapshot(`
+"lib.test.ts:
+(pass) only called runs
+-----------|---------|---------|-------------------
+File       | % Funcs | % Lines | Uncovered Line #s
+-----------|---------|---------|-------------------
+All files  |   33.33 |   50.00 |
+ lib.ts    |   33.33 |   50.00 | 4-6,8
+-----------|---------|---------|-------------------
+
+ 1 pass
+ 0 fail
+ 1 expect() calls
+Ran 1 test across 1 file."
+`);
+  expect(result.exitCode).toBe(0);
+});

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -192,8 +192,8 @@ test("should call only some functions", () => {
 ---------------|---------|---------|-------------------
 File           | % Funcs | % Lines | Uncovered Line #s
 ---------------|---------|---------|-------------------
-All files      |   75.00 |   83.33 |
- include-me.ts |   50.00 |   66.67 | 
+All files      |   75.00 |   75.00 |
+ include-me.ts |   50.00 |   50.00 | 6-7
  test.test.ts  |  100.00 |  100.00 | 
 ---------------|---------|---------|-------------------
 
@@ -586,6 +586,87 @@ All files  |    0.00 |    0.00 |
  0 fail
  1 expect() calls
 Ran 1 test across 1 file."
+`);
+  expect(result.exitCode).toBe(0);
+});
+
+// https://github.com/oven-sh/bun/issues/31484
+// The lines of an uncalled function must all be reported as `DA:<line>,0`.
+// A reset loop used an exclusive range that skipped the function's last line,
+// which either left a phantom `hits=1` on it or dropped it from the DA: set
+// entirely (depending on statement shape).
+test("lcov reports every line of an uncalled function as uncovered", () => {
+  const dir = tempDirWithFiles("cov", {
+    "bunfig.toml": `
+[test]
+coverageSkipTestFiles = true
+`,
+    "lib.ts": `export function greet(name) {
+  if (!name) return "Hello, friend!";
+  return \`Hello, \${name}!\`;
+}
+
+export function farewellSingle(name, formal) {
+  return name ? (formal ? "Goodbye, " : "Bye, ") + name : "Bye!";
+}
+
+export function farewellTwo(name, formal) {
+  const prefix = formal ? "Goodbye" : "Bye";
+  return name ? \`\${prefix}, \${name}\` : \`\${prefix}!\`;
+}
+
+export function farewellThree(name, formal) {
+  const prefix = formal ? "Goodbye" : "Bye";
+  const sep = name ? ", " : "!";
+  return name ? \`\${prefix}\${sep}\${name}\` : \`\${prefix}\${sep}\`;
+}
+`,
+    "lib.test.ts": `import { test, expect } from "bun:test";
+import { greet, farewellSingle, farewellTwo, farewellThree } from "./lib";
+
+void farewellSingle;
+void farewellTwo;
+void farewellThree;
+
+test("only greet runs", () => {
+  expect(greet("Gabe")).toBe("Hello, Gabe!");
+});
+`,
+  });
+
+  const result = Bun.spawnSync([bunExe(), "test", "--coverage", "--coverage-reporter", "lcov", "./lib.test.ts"], {
+    cwd: dir,
+    env: { ...bunEnv },
+    stdio: [null, null, "pipe"],
+  });
+
+  let lcovContent = readFileSync(path.join(dir, "coverage", "lcov.info"), "utf-8");
+  lcovContent = normalizeBunSnapshot(lcovContent, dir);
+
+  // greet (lines 1-3) is called; the three farewell* functions are never
+  // invoked, so every one of their body lines must be present with a hit
+  // count of 0 — including the final line of each function body, which the
+  // off-by-one used to drop or mark with a phantom hit.
+  expect(lcovContent).toMatchInlineSnapshot(`
+"TN:
+SF:lib.ts
+FNF:4
+FNH:1
+DA:1,15
+DA:2,15
+DA:3,25
+DA:6,0
+DA:7,0
+DA:10,0
+DA:11,0
+DA:12,0
+DA:15,0
+DA:16,0
+DA:17,0
+DA:18,0
+LF:12
+LH:3
+end_of_record"
 `);
   expect(result.exitCode).toBe(0);
 });


### PR DESCRIPTION
Fixes #31484.

## Repro

`lib.ts` — `greet` is called; the three `farewell*` functions are imported but never invoked:

```js
export function greet(name) {                                 // line 1 (called)
  if (!name) return "Hello, friend!";
  return `Hello, ${name}!`;
}
export function farewellSingle(name, formal) {                // line 6 (uncalled, 1-stmt body)
  return name ? (formal ? "Goodbye, " : "Bye, ") + name : "Bye!";
}
export function farewellTwo(name, formal) {                   // line 10 (uncalled, 2-stmt body)
  const prefix = formal ? "Goodbye" : "Bye";
  return name ? `${prefix}, ${name}` : `${prefix}!`;
}
export function farewellThree(name, formal) {                 // line 15 (uncalled, 3-stmt body)
  const prefix = formal ? "Goodbye" : "Bye";
  const sep = name ? ", " : "!";
  return name ? `${prefix}${sep}${name}` : `${prefix}${sep}`;
}
```

```console
$ bun test ./lib.test.js --coverage --coverage-reporter=lcov
```

The last line of each uncalled function is mishandled: kept with a phantom `hits=1` (single- and two-statement bodies) or dropped from the `DA:` set entirely (three-statement body whose final statement is a multi-line return). This inflates `LH`, shrinks `LF`, and misleads genhtml / Coverage Gutters / aggregate percentages.

## Cause & fix — two bugs in `src/sourcemap_jsc/CodeCoverage.rs`

### 1. Reset loop skips an uncalled function's last line (the reported bug)

After the per-statement pass populates `executable_lines` / `lines_which_have_executed` / `line_hits` from JSC basic-block ranges, a second pass resets the lines of any function that did **not** execute. That loop used an **exclusive** range:

```rust
let end = max_line.min(line_count);
for line in min_line..end {          // exclusive — max_line is never touched
    executable_lines.set(line as usize);
    lines_which_have_executed.unset(line as usize);
    line_hits_slice[line as usize] = 0;
}
```

Because `max_line` is skipped:
- **Phantom hit** — if the statement pass set a hit on the last line, the reset never clears it, so it stays counted in `LH`.
- **Missing line** — if `max_line` was only discovered during the function-block pass, the loop never `set`s it as executable, so it's dropped from the `DA:` iterator.
- **Single-line bodies** — when `min_line == max_line` (e.g. a class with an uncalled default constructor), the range is empty and the line is never reset at all.

Both code paths (sourcemap and no-sourcemap) had the same off-by-one. Fixed by making the range inclusive, guarded so indexing stays in bounds and the degenerate no-lines case is skipped:

```rust
if !did_fn_execute && min_line <= max_line && max_line < line_count {
    for line in min_line..=max_line {
        executable_lines.set(line as usize);
        lines_which_have_executed.unset(line as usize);
        line_hits_slice[line as usize] = 0;
    }
}
```

### 2. Text reporter mis-formats uncovered-line runs

Making single-line uncalled bodies report as uncovered surfaced a second, pre-existing bug in the text reporter's "Uncovered Line #s" column (`text::write_format`). It collapses contiguous uncovered line indices into `start-end` runs but tracked the pending run with sentinel zeros (`start_of_line_range == 0 && prev_line == 0`). Since line index 0 is a valid value, the sentinel was mistaken for line 0:
- a lone uncovered line 1 printed as a bogus `1-2`;
- the post-loop flush (gated on `prev_line != start_of_line_range`) dropped a **trailing single-line run** entirely.

Fixed by tracking the pending run with an explicit `Option<(start, end)>` so the no-run state is distinct from line 0.

## Verification

lcov output for the repro, before vs. after:

| | before | after |
|---|---|---|
| `farewellSingle` return | `DA:7,1` (phantom) | `DA:7,0` |
| `farewellTwo` return | `DA:12,1` (phantom) | `DA:12,0` |
| `farewellThree` return | *missing* | `DA:18,0` |
| `LF` / `LH` | `11` / `5` | `12` / `3` |

Text reporter, for a file with an uncalled multi-line function (lines 4-6) followed by an uncalled single-line class constructor (line 8):

| | before | after |
|---|---|---|
| Uncovered Line #s | `4-5` | `4-6,8` |

Two new tests in `test/cli/test/coverage.test.ts` assert the corrected lcov and text output; both fail on `main` and pass with this change. Two pre-existing snapshots in the same file were updated because they had captured the old buggy output (a phantom `hits=1` on the final line of uncalled single-line bodies).