### PR TITLE
strings: bind StringJoiner borrowed segments to a lifetime

### DIFF
--- a/src/bun_core/string/StringJoiner.rs
+++ b/src/bun_core/string/StringJoiner.rs
@@ -288,6 +288,28 @@ mod tests {
         j.push_cloned(b"another KEY");
         assert_eq!(j.watcher.estimated_count, 2);
     }
+
+    #[test]
+    fn detach_lifetime_round_trips_borrowed_data() {
+        let borrowed = b"KEY borrowed ".to_vec();
+        let input = b"KEY".to_vec();
+        let mut j = StringJoiner {
+            watcher: Watcher {
+                input: &input,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        j.push(&borrowed);
+        j.push_cloned(b"cloned KEY");
+        // SAFETY: `borrowed` and `input` are declared before `detached`, so they outlive it.
+        let mut detached = unsafe { j.detach_lifetime() };
+        assert_eq!(detached.len, "KEY borrowed cloned KEY".len());
+        assert_eq!(detached.watcher.input, b"KEY");
+        assert_eq!(detached.watcher.estimated_count, 2);
+        assert!(detached.watcher.needs_newline);
+        assert_eq!(&*detached.done().unwrap(), b"KEY borrowed cloned KEY");
+    }
 }
 
 // ported from: src/string/StringJoiner.zig

--- a/src/bun_core/string/StringJoiner.rs
+++ b/src/bun_core/string/StringJoiner.rs
@@ -1,87 +1,53 @@
 //! Rope-like data structure for joining many small strings into one big string.
-//! Implemented as a flat `Vec` of potentially-owned slices plus a running
+//! Implemented as a flat `Vec` of borrowed-or-owned slices plus a running
 //! length, so the join-time output buffer can be sized exactly once.
 
-use crate::RawSlice;
 use crate::string::strings;
 use bun_alloc::AllocError;
 
 // PORT NOTE: Zig's `std.mem.Allocator` param field dropped — global mimalloc is used for
 // node and duplicated-string allocations.
 #[derive(Default)]
-pub struct StringJoiner {
+pub struct StringJoiner<'a> {
     /// Total length of all nodes
     pub len: usize,
 
     /// Slices in insertion order. Stored flat instead of as a singly-linked
     /// list so a join with N pieces does ~log₂N Vec reallocs instead of N
     /// `Box<Node>` allocations and N pointer-chasing dereferences on drain.
-    nodes: Vec<Node>,
+    nodes: Vec<Node<'a>>,
 
     /// Avoid an extra pass over the list when joining
-    pub watcher: Watcher,
+    pub watcher: Watcher<'a>,
 }
 
-// SAFETY: `nodes` holds `RawSlice<u8>` raw fat pointers which alias
-// caller-owned (`owns_slice = false`) or joiner-owned (`owns_slice = true`)
-// storage; no aliasing escapes `&mut self` methods. The Zig original is
-// passed across bundler worker threads (see Chunk.IntermediateOutput).
-unsafe impl Send for StringJoiner {}
-// SAFETY: `&StringJoiner` only exposes read-only views (`last_byte`,
-// `node_slices`, `contains`) over `RawSlice<u8>` storage with no interior
-// mutability; concurrent shared reads of the owned/borrowed-until-`done()`
-// byte buffers are data-race-free.
-unsafe impl Sync for StringJoiner {}
-
-struct Node {
-    /// Replaces Zig's `NullableAllocator`: when `true`, `slice` was heap-allocated by
-    /// this joiner (via `push_owned`/`push_cloned`) and is freed on node drop;
-    /// when `false`, `slice` is borrowed and the caller guarantees it outlives `done()`.
-    owns_slice: bool,
-    // TODO(port): lifetime — borrowed slices must outlive `done()`; the port avoids
-    // struct lifetime params, so this is stored as a typed raw fat pointer.
-    // `RawSlice` (one encapsulated unsafe in `.slice()`) replaces the open-coded
-    // raw deref at every read site; the backing storage outlives the node by
-    // either ownership (`owns_slice`) or caller contract.
-    slice: RawSlice<u8>,
+enum Node<'a> {
+    /// Borrowed for `'a`; the caller's data must stay valid until the joiner's
+    /// last read (`done`/`done_with_end`/`node_slices`/`contains`/`last_byte`).
+    Borrowed(&'a [u8]),
+    /// Heap-allocated by this joiner (via `push_owned`/`push_cloned`); freed
+    /// when the node drops.
+    Owned(Box<[u8]>),
 }
 
-impl Node {
+impl Node<'_> {
     #[inline]
     fn slice(&self) -> &[u8] {
-        self.slice.slice()
-    }
-}
-
-// SAFETY: `Node` is a plain (slice, ownership-bit) record; the `RawSlice` raw
-// pointer is uniquely owned (or borrowed under caller contract) through the
-// `Vec` rooted at `StringJoiner.nodes` and never shared aliased across threads
-// concurrently. The Zig original moves these between bundler worker threads.
-unsafe impl Send for Node {}
-// SAFETY: `&Node` only reads the immutable `RawSlice<u8>` backing bytes via
-// `slice()`; there is no interior mutability, so concurrent shared access from
-// multiple threads cannot race.
-unsafe impl Sync for Node {}
-
-impl Drop for Node {
-    fn drop(&mut self) {
-        if self.owns_slice {
-            // SAFETY: when owns_slice is true, slice was produced by Box::<[u8]>::into_raw
-            // in `push_cloned`/`push_owned` and has not been freed.
-            drop(unsafe { crate::heap::take(self.slice.as_ptr().cast_mut()) });
+        match self {
+            Node::Borrowed(slice) => slice,
+            Node::Owned(boxed) => boxed,
         }
     }
 }
 
 #[derive(Default)]
-pub struct Watcher {
-    // TODO(port): lifetime — callers may assign non-'static data; never freed in Zig.
-    pub input: &'static [u8],
+pub struct Watcher<'a> {
+    pub input: &'a [u8],
     pub estimated_count: u32,
     pub needs_newline: bool,
 }
 
-impl StringJoiner {
+impl<'a> StringJoiner<'a> {
     /// Pre-allocate room for `additional` more pushed slices, so a join with a
     /// known piece count does a single nodes allocation instead of log₂N grows.
     pub fn reserve(&mut self, additional: usize) {
@@ -89,7 +55,7 @@ impl StringJoiner {
     }
 
     /// `data` is expected to live until `.done` is called
-    pub fn push_static(&mut self, data: &[u8]) {
+    pub fn push_static(&mut self, data: &'a [u8]) {
         self.push(data);
     }
 
@@ -98,10 +64,7 @@ impl StringJoiner {
         if data.is_empty() {
             return;
         }
-        let raw: *const [u8] = crate::heap::into_raw(data);
-        // SAFETY: `raw` is a fresh `Box::into_raw` allocation owned by the node
-        // until `Node::drop` reclaims it (`owns_slice = true`).
-        self.push_raw(unsafe { RawSlice::from_raw(raw) }, true);
+        self.push_node(Node::Owned(data));
     }
 
     /// `data` is cloned
@@ -117,18 +80,16 @@ impl StringJoiner {
     // The optional allocator only encoded ownership of `data`, which has no Rust
     // analogue for a borrowed `&[u8]`; callers wanting owned semantics use
     // `push_owned`/`push_cloned` instead.
-    pub fn push(&mut self, data: &[u8]) {
+    pub fn push(&mut self, data: &'a [u8]) {
         if data.is_empty() {
             return;
         }
-        self.push_raw(RawSlice::new(data), false);
+        self.push_node(Node::Borrowed(data));
     }
 
-    fn push_raw(&mut self, data: RawSlice<u8>, owned: bool) {
-        let data_slice = data.slice();
-        if data_slice.is_empty() {
-            return;
-        }
+    fn push_node(&mut self, node: Node<'a>) {
+        let data_slice = node.slice();
+        debug_assert!(!data_slice.is_empty());
         self.len += data_slice.len();
 
         self.watcher.estimated_count += (self.watcher.input.len() > 0
@@ -136,10 +97,41 @@ impl StringJoiner {
             as u32;
         self.watcher.needs_newline = data_slice[data_slice.len() - 1] != b'\n';
 
-        self.nodes.push(Node {
-            owns_slice: owned,
-            slice: data,
-        });
+        self.nodes.push(node);
+    }
+
+    /// Re-tag every borrowed segment (and `watcher.input`) as `'static` so the
+    /// joiner can be stored in lifetime-free storage and read later (e.g. the
+    /// bundler's deferred `Chunk.intermediate_output`).
+    ///
+    /// # Safety
+    /// Every borrowed segment previously pushed (`push`/`push_static`) and
+    /// `watcher.input` must remain valid — not freed, moved, or reallocated —
+    /// for as long as the returned joiner (or anything it is moved into) is
+    /// alive.
+    pub unsafe fn detach_lifetime(self) -> StringJoiner<'static> {
+        StringJoiner {
+            len: self.len,
+            nodes: self
+                .nodes
+                .into_iter()
+                .map(|node| match node {
+                    Node::Borrowed(slice) => {
+                        // SAFETY: caller contract — the backing storage outlives
+                        // the returned joiner.
+                        Node::Borrowed(unsafe { &*core::ptr::from_ref::<[u8]>(slice) })
+                    }
+                    Node::Owned(boxed) => Node::Owned(boxed),
+                })
+                .collect(),
+            watcher: Watcher {
+                // SAFETY: caller contract — `watcher.input` outlives the
+                // returned joiner.
+                input: unsafe { &*core::ptr::from_ref::<[u8]>(self.watcher.input) },
+                estimated_count: self.watcher.estimated_count,
+                needs_newline: self.watcher.needs_newline,
+            },
+        }
     }
 
     /// This deinits the string joiner on success, the new string is owned by the caller.
@@ -158,7 +150,7 @@ impl StringJoiner {
         let mut out = Vec::<u8>::with_capacity(len);
         for node in self.nodes.drain(..) {
             out.extend_from_slice(node.slice());
-            // `drop(node)` runs `Node::drop`, freeing `slice` when owned.
+            // `drop(node)` frees the buffer when owned.
         }
         debug_assert_eq!(out.len(), len);
         Ok(out.into_boxed_slice())
@@ -212,7 +204,90 @@ impl StringJoiner {
     }
 }
 
-// `Drop` for `StringJoiner` is implicit: `Vec<Node>::drop` runs `Node::drop`
-// for each element, which frees joiner-owned slices.
+// `Drop` for `StringJoiner` is implicit: `Vec<Node>::drop` frees joiner-owned
+// slices (`Node::Owned`); borrowed nodes are not freed.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_kinds_concatenate_in_insertion_order() {
+        let owned: Box<[u8]> = Box::from(b"owned".as_slice());
+        let cloned_src = b"cloned".to_vec();
+        let mut j = StringJoiner::default();
+        j.push(b"borrowed ");
+        j.push_static(b"static ");
+        j.push_owned(owned);
+        j.push_cloned(&cloned_src);
+        drop(cloned_src);
+        assert_eq!(j.len, "borrowed static ownedcloned".len());
+        assert_eq!(&*j.done().unwrap(), b"borrowed static ownedcloned");
+        assert_eq!(j.len, 0);
+    }
+
+    #[test]
+    fn empty_pushes_are_skipped() {
+        let mut j = StringJoiner::default();
+        j.push(b"");
+        j.push_static(b"");
+        j.push_owned(Box::default());
+        j.push_cloned(b"");
+        assert_eq!(j.len, 0);
+        assert_eq!(j.node_slices().count(), 0);
+        assert_eq!(&*j.done().unwrap(), b"");
+    }
+
+    #[test]
+    fn done_with_end_appends_suffix() {
+        let mut j = StringJoiner::default();
+        assert_eq!(&*j.done_with_end(b"").unwrap(), b"");
+        assert_eq!(&*j.done_with_end(b"suffix").unwrap(), b"suffix");
+        j.push(b"body");
+        assert_eq!(&*j.done_with_end(b"!\n").unwrap(), b"body!\n");
+    }
+
+    #[test]
+    fn last_byte_contains_and_node_slices() {
+        let mut j = StringJoiner::default();
+        assert_eq!(j.last_byte(), 0);
+        j.push(b"abc");
+        j.push_cloned(b"def");
+        assert_eq!(j.last_byte(), b'f');
+        assert!(!j.contains(b"cd"));
+        assert!(j.contains(b"de"));
+        let slices: Vec<&[u8]> = j.node_slices().collect();
+        assert_eq!(slices, vec![b"abc".as_slice(), b"def".as_slice()]);
+    }
+
+    #[test]
+    fn ensure_newline_at_end_tracks_watcher() {
+        let mut j = StringJoiner::default();
+        j.push(b"no newline");
+        j.ensure_newline_at_end();
+        j.ensure_newline_at_end();
+        assert_eq!(&*j.done().unwrap(), b"no newline\n");
+
+        let mut j = StringJoiner::default();
+        j.push(b"has newline\n");
+        j.ensure_newline_at_end();
+        assert_eq!(&*j.done().unwrap(), b"has newline\n");
+    }
+
+    #[test]
+    fn watcher_estimates_unique_key_occurrences() {
+        let mut j = StringJoiner {
+            watcher: Watcher {
+                input: b"KEY",
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        j.push(b"prefix KEY suffix");
+        j.push(b"no match");
+        j.push_cloned(b"another KEY");
+        assert_eq!(j.watcher.estimated_count, 2);
+    }
+}
 
 // ported from: src/string/StringJoiner.zig

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -378,7 +378,7 @@ pub enum IntermediateOutput {
     /// If the chunk doesn't have any references to other chunks, then
     /// `joiner` contains the contents of the chunk. This is more efficient
     /// because it avoids doing a join operation twice.
-    Joiner(StringJoiner),
+    Joiner(StringJoiner<'static>),
 
     #[default]
     Empty,

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -113,7 +113,7 @@ impl Default for Content {
 
 // SAFETY: `Chunk` is processed across the bundler thread pool (see
 // `computeCrossChunkDependencies`, `generateChunksInParallel`). Raw-pointer
-// fields (`Layers::Borrowed`, `StringJoiner` nodes, `ChunkRenamer` arena)
+// fields (`Layers::Borrowed`, `ChunkRenamer` arena)
 // point into bundler-arena storage that outlives the
 // pool join and is only mutated by the owning task. Zig has no Send/Sync
 // distinction; mirror `InputFile`'s blanket impls (bundle_v2.rs).

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -4149,7 +4149,7 @@ impl<'a> LinkerContext<'a> {
     pub fn break_output_into_pieces(
         &self,
         _alloc: *const Bump,
-        j: &mut StringJoiner,
+        j: &mut StringJoiner<'static>,
         count: u32,
     ) -> Result<crate::chunk::IntermediateOutput, BunError> {
         let _trace = bun::perf::trace("Bundler.breakOutputIntoPieces");

--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -410,6 +410,11 @@ pub fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> Result<Box<[u8]>
 
     // Break output into pieces and resolve chunk references to final paths
     let alloc = c.arena();
+    // SAFETY: every borrowed node in `j` points into `chunk.metafile_chunk_json`,
+    // parse-graph data (import-record kind labels), or `'static` literals, all of
+    // which outlive `intermediate` — it is consumed by `code()` below while `chunks`
+    // and `c` are still alive.
+    let mut j = unsafe { j.detach_lifetime() };
     let mut intermediate = c.break_output_into_pieces(
         alloc,
         &mut j,

--- a/src/bundler/linker_context/postProcessCSSChunk.rs
+++ b/src/bundler/linker_context/postProcessCSSChunk.rs
@@ -142,6 +142,13 @@ pub fn post_process_css_chunk(
 
     // SAFETY: `worker.arena` set by `Worker::create`, outlives the worker step.
     let alloc = worker.arena();
+    // SAFETY: every borrowed node in `j` points into `chunk.compile_results_for_chunk`
+    // (filled in place before post-processing, never reassigned afterwards), graph
+    // source paths (`Path<'static>`), or `'static` literals; `watcher.input` is
+    // `chunk.unique_key` (`&'static`). All of these outlive the joiner stored in
+    // `chunk.intermediate_output`, which is only read while the chunk and the linker
+    // graph are alive.
+    let mut j = unsafe { j.detach_lifetime() };
     chunk.intermediate_output =
         bun_core::handle_oom(c.break_output_into_pieces(alloc, &mut j, ctx.chunks.len() as u32));
     // TODO: meta contents

--- a/src/bundler/linker_context/postProcessHTMLChunk.rs
+++ b/src/bundler/linker_context/postProcessHTMLChunk.rs
@@ -31,6 +31,12 @@ pub fn post_process_html_chunk(
 
     // SAFETY: `worker.arena` is set by `Worker::create` and outlives the worker step.
     let alloc = worker.arena();
+    // SAFETY: every borrowed node in `j` points into `chunk.compile_results_for_chunk`
+    // (filled in place before post-processing, never reassigned afterwards);
+    // `watcher.input` is `chunk.unique_key` (`&'static`). Both outlive the joiner
+    // stored in `chunk.intermediate_output`, which is only read while the chunk and
+    // the linker graph are alive.
+    let mut j = unsafe { j.detach_lifetime() };
     chunk.intermediate_output = bun_core::handle_oom(c.break_output_into_pieces(
         alloc,
         &mut j,

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -804,9 +804,9 @@ pub fn post_process_js_chunk(
                 // PERF(port): worker.arena is an arena in Zig
                 let _ = js_printer::quote_for_json(input.pretty, &mut buf, true); // fmt::Result into Vec<u8> is infallible
                 // bun.handleOom dropped — Rust aborts on OOM
-                let str = buf.slice(); // worker.arena is an arena
-                j.push_static(str);
-                line_offset.advance(str);
+                let quoted = buf.take_slice();
+                line_offset.advance(&quoted);
+                j.push_owned(quoted.into_boxed_slice());
             }
             // {
             //     let str = b"\n  react_refresh: ";
@@ -842,6 +842,15 @@ pub fn post_process_js_chunk(
         line_offset.advance(b"\n");
     }
 
+    // SAFETY: every borrowed node in `j` points into `chunk.compile_results_for_chunk`
+    // (slots pre-sized in generateChunksInParallel, filled in place by the print
+    // workers before post-processing, never reassigned afterwards), `c.options`
+    // banner/footer (`&'static`), graph/parse-graph data (hashbangs, source paths,
+    // HMR runtime), or `'static` literals; `watcher.input` is `chunk.unique_key`
+    // (`&'static`). All of these outlive the joiner stored in
+    // `chunk.intermediate_output`, which is only read while the chunk and the
+    // linker graph are alive.
+    let mut j = unsafe { j.detach_lifetime() };
     chunk.intermediate_output = c
         .break_output_into_pieces(worker_arena, &mut j, ctx.chunks.len() as u32)
         .unwrap_or_else(|_| panic!("Unhandled out of memory error in breakOutputIntoPieces()"));

--- a/src/runtime/bake/dev_server/source_map_store.rs
+++ b/src/runtime/bake/dev_server/source_map_store.rs
@@ -280,10 +280,10 @@ impl Entry {
         .map_err(|_| EncodeSourceMapPathError::OutOfMemory)
     }
 
-    fn join_vlq(
-        &self,
+    fn join_vlq<'a>(
+        &'a self,
         kind: ChunkKind,
-        j: &mut StringJoiner,
+        j: &mut StringJoiner<'a>,
         side: Side,
     ) -> Result<(), bun_core::Error> {
         let _ = side;

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3629,10 +3629,11 @@ impl BlobExt for Blob {
                                         }
                                         continue;
                                     } else {
-                                        let sliced = current.to_slice_clone(global)?;
+                                        let sliced = item.to_slice_clone(global)?;
                                         could_have_non_ascii =
                                             could_have_non_ascii || sliced.is_allocated();
                                         joiner.push_cloned(sliced.slice());
+                                        continue;
                                     }
                                 }
                                 _ => {}

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3607,8 +3607,11 @@ impl BlobExt for Blob {
                                     continue;
                                 }
                                 jsc::JSType::Array | jsc::JSType::DerivedArray => {
-                                    could_have_non_ascii = true;
-                                    break;
+                                    let sliced = item.to_slice_clone(global)?;
+                                    could_have_non_ascii =
+                                        could_have_non_ascii || sliced.is_allocated();
+                                    joiner.push_cloned(sliced.slice());
+                                    continue;
                                 }
                                 jsc::JSType::DOMWrapper => {
                                     if let Some(blob) = item.as_class_ref::<Blob>() {
@@ -3636,12 +3639,14 @@ impl BlobExt for Blob {
                                         continue;
                                     }
                                 }
-                                _ => {}
+                                _ => {
+                                    let sliced = item.to_slice_clone(global)?;
+                                    could_have_non_ascii =
+                                        could_have_non_ascii || sliced.is_allocated();
+                                    joiner.push_cloned(sliced.slice());
+                                }
                             }
                         }
-
-                        // `reserve(iter.len)` above guarantees no realloc here.
-                        stack.push(item);
                     }
                 }
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3596,7 +3596,13 @@ impl BlobExt for Blob {
                                         // or resizes this buffer before `done()`.
                                         joiner.push_cloned(buf.byte_slice());
                                     } else {
-                                        joiner.push_static(buf.byte_slice());
+                                        // SAFETY: the prescan above proved no remaining
+                                        // part can run user JS, so this buffer (rooted
+                                        // via `_keep`/`arg`) stays attached and valid
+                                        // until `joiner.done()` below.
+                                        joiner.push(unsafe {
+                                            bun_ptr::detach_lifetime(buf.byte_slice())
+                                        });
                                     }
                                     continue;
                                 }
@@ -3613,7 +3619,13 @@ impl BlobExt for Blob {
                                         if parts_can_run_js {
                                             joiner.push_cloned(blob.shared_view());
                                         } else {
-                                            joiner.push_static(blob.shared_view());
+                                            // SAFETY: the prescan above proved no
+                                            // remaining part can run user JS, so this
+                                            // Blob (rooted via `_keep`/`arg`) keeps its
+                                            // Store alive until `joiner.done()` below.
+                                            joiner.push(unsafe {
+                                                bun_ptr::detach_lifetime(blob.shared_view())
+                                            });
                                         }
                                         continue;
                                     } else {
@@ -3662,7 +3674,11 @@ impl BlobExt for Blob {
                 | jsc::JSType::BigUint64Array
                 | jsc::JSType::DataView => {
                     let buf = current.as_array_buffer(global).unwrap();
-                    joiner.push_static(buf.slice());
+                    // SAFETY: this arm is only reached when the typed array is the
+                    // top-level value (the walk stack is empty), so no user JS runs
+                    // between this push and `joiner.done()` below; `_keep`/`arg` keeps
+                    // the buffer alive for that span.
+                    joiner.push(unsafe { bun_ptr::detach_lifetime(buf.slice()) });
                     could_have_non_ascii = true;
                 }
 
@@ -3953,7 +3969,7 @@ where
 /// `*jsc.JSGlobalObject`), so they are stored as plain references rather than
 /// raw pointers.
 struct FormDataContext<'a> {
-    joiner: StringJoiner,
+    joiner: StringJoiner<'a>,
     boundary: &'a [u8], // borrowed; outlives the joiner
     failed: bool,
     global_this: &'a JSGlobalObject,
@@ -3986,7 +4002,7 @@ impl FormDataContext<'_> {
     /// (Zig: `joiner.push(slice, slice.allocator.get())`); an owned slice
     /// (UTF-16 / non-ASCII Latin-1 conversion) transfers its allocation to the
     /// joiner. When `escape` is set, `"`/CR/LF are percent-encoded into a copy.
-    fn push_string_slice(joiner: &mut StringJoiner, slice: ZigStringSlice, escape: bool) {
+    fn push_string_slice(joiner: &mut StringJoiner<'_>, slice: ZigStringSlice, escape: bool) {
         if escape {
             if let Some(escaped) = escape_form_data_name(slice.slice()) {
                 joiner.push_owned(escaped);
@@ -3997,7 +4013,9 @@ impl FormDataContext<'_> {
             // `into_vec` moves the buffer out of an `Owned` slice without copying.
             joiner.push_owned(slice.into_vec().into_boxed_slice());
         } else if matches!(slice, ZigStringSlice::Static(..)) {
-            joiner.push_static(slice.slice());
+            // SAFETY: `Static` bytes are owned by the `DOMFormData` being serialized
+            // (never freed), which outlives `joiner.done()` in `from_dom_form_data`.
+            joiner.push(unsafe { bun_ptr::detach_lifetime(slice.slice()) });
         } else {
             // WTF-backed slices release their pin on drop — copy rather than
             // borrow past it. (`ZigString::to_slice` never produces these.)
@@ -4043,7 +4061,10 @@ impl FormDataContext<'_> {
                     b"application/octet-stream"
                 };
                 joiner.push_static(b"Content-Type: ");
-                joiner.push_static(content_type);
+                // SAFETY: either a `'static` literal or borrowed from the entry's Blob,
+                // which the `DOMFormData` keeps alive past `joiner.done()` in
+                // `from_dom_form_data`.
+                joiner.push(unsafe { bun_ptr::detach_lifetime(content_type) });
                 joiner.push_static(b"\r\n\r\n");
 
                 if blob.store.get().is_some() {
@@ -4095,10 +4116,10 @@ impl FormDataContext<'_> {
                             }
                         }
                         store::Data::Bytes(_) => {
-                            // Borrowed: the blob's store is kept alive by the
-                            // `DOMFormData` entry until after `joiner.done()`
-                            // (Zig used `pushStatic` here too).
-                            joiner.push_static(blob.shared_view());
+                            // SAFETY: borrowed from the blob's store, which the
+                            // `DOMFormData` entry keeps alive until after
+                            // `joiner.done()` (Zig used `pushStatic` here too).
+                            joiner.push(unsafe { bun_ptr::detach_lifetime(blob.shared_view()) });
                         }
                     }
                 }

--- a/src/sourcemap/lib.rs
+++ b/src/sourcemap/lib.rs
@@ -1278,11 +1278,11 @@ pub fn parse_json(
 // After all chunks are computed, they are joined together in a second pass.
 // This rewrites the first mapping in each chunk to be relative to the end
 // state of the previous chunk.
-pub fn append_source_map_chunk(
-    j: &mut bun_core::string_joiner::StringJoiner,
+pub fn append_source_map_chunk<'a>(
+    j: &mut bun_core::string_joiner::StringJoiner<'a>,
     prev_end_state_: SourceMapState,
     start_state_: SourceMapState,
-    source_map_: &[u8],
+    source_map_: &'a [u8],
 ) -> Result<(), bun_core::Error> {
     // TODO(port): narrow error set
     let mut prev_end_state = prev_end_state_;

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -103,10 +103,13 @@ test("new Blob", () => {
   expect(blob.type).toBe("");
 });
 
-test("new Blob stringifies non-Blob object wrapper parts in order", async () => {
+test("new Blob stringifies non-Blob object parts in order", async () => {
   const url = new URL("https://example.com/path");
   expect(await new Blob([url]).text()).toBe("https://example.com/path");
   expect(await new Blob(["a", url, "b"]).text()).toBe("ahttps://example.com/pathb");
+  expect(await new Blob(["a", {}, "b"]).text()).toBe("a[object Object]b");
+  expect(await new Blob(["a", {}, "b", { toString: () => "X" }]).text()).toBe("a[object Object]bX");
+  expect(await new Blob(["a", ["x", "y"], "b"]).text()).toBe("ax,yb");
 });
 
 test("blob: can be fetched", async () => {

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -103,6 +103,12 @@ test("new Blob", () => {
   expect(blob.type).toBe("");
 });
 
+test("new Blob stringifies non-Blob object wrapper parts in order", async () => {
+  const url = new URL("https://example.com/path");
+  expect(await new Blob([url]).text()).toBe("https://example.com/path");
+  expect(await new Blob(["a", url, "b"]).text()).toBe("ahttps://example.com/pathb");
+});
+
 test("blob: can be fetched", async () => {
   const blob = new Blob(["Bun", "Foo"]);
   const url = URL.createObjectURL(blob);


### PR DESCRIPTION
`StringJoiner` stored every borrowed segment as a lifetime-erased raw fat pointer (`RawSlice<u8>` plus an `owns_slice` flag), with blanket `unsafe impl Send/Sync` on both the joiner and its nodes and a manual `Drop` to free owned slices. Nothing tied a pushed segment to the data it pointed at, so every `push()` call site relied on an undocumented "must outlive `done()`" convention.

### What changed

- `StringJoiner` and `Node` take a lifetime parameter; `Node` is now `enum { Borrowed(&'a [u8]), Owned(Box<[u8]>) }`. This deletes the manual `Drop`, the four `unsafe impl Send/Sync`, the `RawSlice` round-trips, and `Watcher.input`'s `&'static` workaround.
- `push()` / `push_static()` borrow segments for the joiner's lifetime, so the sourcemap join (`append_source_map_chunk`), the dev-server sourcemap store, and most bundler/Blob/FormData call sites are now plain borrow-checked code.
- The bundler's deferred path stores the joiner in `Chunk.intermediate_output` (no lifetime parameter), so each of the four `break_output_into_pieces` callers (`postProcessJSChunk`, `postProcessCSSChunk`, `postProcessHTMLChunk`, `MetafileBuilder::generate`) re-tags the joiner with a new documented `unsafe StringJoiner::detach_lifetime()` immediately before the call, with a SAFETY comment naming exactly which storage the borrowed nodes point into and why it outlives the stored joiner.
- Blob constructor / FormData serialization keep borrowing (not copying) buffers whose liveness comes from GC rooting, via `bun_ptr::detach_lifetime` with per-site SAFETY comments — including the FormData file-entry `Data::Bytes` site and the top-level typed-array arm, each with its own justification.
- Fixes a latent use-after-free in `postProcessJSChunk`'s `InternalBakeDev` arm: it pushed the bytes of a block-local `MutableString` by reference into a joiner that is stored in `chunk.intermediate_output` and read later. The bytes are now moved into the joiner (`take_slice()` + `push_owned`).
- Adds unit tests for the node-storage rewrite.

### Net unsafe accounting

Removed: 4 blanket `unsafe impl Send/Sync` (which made every push call site unauditable), the `unsafe` free in `Node::drop`, the `unsafe` `RawSlice::from_raw` in `push_owned`, and the lifetime-erased `RawSlice` storage itself.

Added: one `unsafe fn detach_lifetime()` on `StringJoiner`, 4 `detach_lifetime()` call sites in the bundler, and 6 `bun_ptr::detach_lifetime` slice re-tags in Blob/FormData — 10 narrowly-scoped expressions, each with a SAFETY comment naming the owner of the bytes and why it outlives the joiner's last read.

The trade is deliberate: instead of two type-level `unsafe impl`s that silence the compiler for every present and future call site, the remaining unsafety is at the specific points where the borrow genuinely cannot be expressed.

### Why lifetimes alone can't cover the remaining sites

- **Chunk self-reference:** the joiner stored in `Chunk.intermediate_output` borrows from the same chunk's `compile_results_for_chunk` (and from linker-graph data). A struct field cannot name a lifetime that refers to a sibling field of the same struct, so expressing this with pure lifetimes would mean copying every compiled segment at join time or restructuring chunk storage.
- **GC-kept-alive Blob/FormData buffers:** the pushed bytes are owned by JS-heap objects (ArrayBuffers, Blob stores, `DOMFormData` entries) whose liveness over the push→`done()` span is guaranteed by GC rooting, not by any Rust owner with a nameable lifetime. Borrow-checking those would require cloning each buffer; the prior code already borrowed them, so this keeps the no-copy behavior with the justification written down.

### Testing

- `cargo check -p bun_bin`, `bun run rust:check-all` (10/10 targets), debug build smoke test.
- Bundler: `bundler_edgecase`, `bundler_npm`, `bundler_minify`, `bundler_splitting` — all pass.
- Bake dev server: `test/bake/dev/esm.test.ts`, `test/bake/dev/html.test.ts` — pass.
- FormData/Blob: `FormData.test.ts`, `FormData-multipart-serialization.test.ts`, `blob.test.ts` — pass except two pre-existing debug-build failures (a 5s-timeout GC test and an RSS-threshold test) that fail identically on a main debug build.
- Sourcemaps: `test/js/bun/sourcemap/`, `compile-sourcemap-internal.test.ts` — pass. The `bun-build-compile*.test.ts` standalone-executable tests time out at 5s when spawning debug-build binaries on this machine; the same tests fail identically on a main debug build (0 new failures).
- New `StringJoiner` unit tests compile under `cargo check`; `cargo test -p bun_core` does not link standalone on main either (pre-existing).
