### PR TITLE
jsc: require `T: Send`/`T: Sync` for `JsCell<T>`'s `Send`/`Sync` impls

### DIFF
--- a/src/jsc/ConcurrentPromiseTask.rs
+++ b/src/jsc/ConcurrentPromiseTask.rs
@@ -48,10 +48,22 @@ pub struct ConcurrentPromiseTask<'a, Context: ConcurrentPromiseTaskContext> {
 
 bun_threading::intrusive_work_task!(['a, Context: ConcurrentPromiseTaskContext] ConcurrentPromiseTask<'a, Context>, task);
 
-// SAFETY: `ConcurrentPromiseTask` is heap-allocated and only its address crosses
-// threads via the intrusive `task` node and the concurrent queue. All access to
-// `ctx` / `promise` / `global_this` is sequenced by the work-pool → on_finish →
-// run_from_js hand-off; raw pointers are inert.
+// SAFETY: `ConcurrentPromiseTask` is heap-allocated and only its *address* crosses
+// threads, via the intrusive `task` node and the concurrent queue; it is never
+// aliased on two threads at once. The hand-off is strictly sequenced:
+// `schedule` (JS thread) → `run_from_thread_pool` (one worker, exclusive) →
+// `on_finish` re-enqueues onto the JS event loop → `run_from_js` (JS thread).
+//
+// `Context` is deliberately NOT required to be `Send`: its implementors hold
+// JS-thread-bound state — a `&JSGlobalObject` (opaque `!Sync` FFI handle) and
+// raw pointers into the JS heap — that `then()` touches back on the JS thread.
+// The only method the worker runs is `ctx.run()`, which operates on the
+// thread-safe subset; any value that genuinely needs to cross to the worker is
+// wrapped at the field level in `bun_jsc::ThreadSafe` (e.g. `TransformTask::input_code`),
+// which protects the JS value and unprotects on drop. Requiring `C: Send` would
+// reject this correct-by-construction design, so the invariant is discharged here
+// rather than by an auto-trait bound — the same single-JS-thread contract that
+// backs `JsCell` and `VirtualMachine`'s hand-written `unsafe impl`s.
 unsafe impl<C: ConcurrentPromiseTaskContext> Send for ConcurrentPromiseTask<'_, C> {}
 
 impl<Context: ConcurrentPromiseTaskContext> Taskable for ConcurrentPromiseTask<'_, Context> {

--- a/src/jsc/JSCell.rs
+++ b/src/jsc/JSCell.rs
@@ -119,11 +119,21 @@ pub struct JsCell<T>(core::cell::UnsafeCell<T>);
 // SAFETY: see type-level docs — `JsCell` is only dereferenced on the owning
 // JS thread; the `Sync` impl exists so `&'static VirtualMachine` (which
 // contains `JsCell` fields) satisfies `'static`-bound trait objects and
-// `thread_local!` accessors without `T: Sync` cascading everywhere. It is NOT
-// a license for cross-thread `get_mut()`.
-unsafe impl<T> Sync for JsCell<T> {}
-// SAFETY: same single-thread-owner invariant as `Sync` above.
-unsafe impl<T> Send for JsCell<T> {}
+// `thread_local!` accessors without hand-written `unsafe impl`s cascading
+// everywhere. It is NOT a license for cross-thread `get_mut()`.
+//
+// The `T: Sync` / `T: Send` bounds are load-bearing: `get()` is a *safe* fn
+// that hands out `&T`, so an unconditional `Sync` would let a `&JsCell<T>`
+// cross threads (via any `Sync` container) and surface a `&T` to a `!Sync`
+// `T` (`Rc`, `Cell`, `RefCell`) on another thread — UB with zero `unsafe` at
+// the call site. Gating on the inner bound keeps the thread-affinity escape
+// hatch while making `JsCell<!Sync>`/`JsCell<!Send>` correctly `!Sync`/`!Send`,
+// so such a field can never silently make its container cross-thread-shareable.
+unsafe impl<T: Sync> Sync for JsCell<T> {}
+// SAFETY: same single-thread-owner invariant as `Sync` above; `T: Send`
+// because `into_inner()` moves the owned `T` out across whatever thread holds
+// the cell.
+unsafe impl<T: Send> Send for JsCell<T> {}
 
 impl<T> JsCell<T> {
     #[inline(always)]
@@ -224,4 +234,41 @@ impl<T: core::fmt::Debug> core::fmt::Debug for JsCell<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.get().fmt(f)
     }
+}
+
+// Compile-time proof that the `Send`/`Sync` bounds on `JsCell<T>` are honored.
+//
+// The safe `get()` makes unconditional `Send`/`Sync` unsound (see the SAFETY
+// note on the impls): a `&JsCell<!Sync>` must not be shareable across threads.
+// Stable Rust has no negative bounds, so the `!Send`/`!Sync` direction uses the
+// auto-trait-ambiguity trick — if `JsCell<Rc<u32>>` ever regains `Send`/`Sync`,
+// both blanket impls below apply and the anonymous `const` fails to compile
+// with "conflicting implementations" (same shape as `subproc.rs`'s
+// `__pipe_reader_thread_confined`).
+mod jscell_send_sync_proof {
+    use super::JsCell;
+
+    // `JsCell<T>` stays `Send`/`Sync` when `T` is — the escape hatch still works.
+    const _: fn() = || {
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+        assert_send::<JsCell<u32>>();
+        assert_sync::<JsCell<u32>>();
+    };
+
+    // `JsCell<T>` is NOT `Send`/`Sync` when `T` is not (`Rc` is `!Send + !Sync`).
+    trait NotSend<A> {
+        const OK: () = ();
+    }
+    impl<T: ?Sized> NotSend<()> for T {}
+    impl<T: ?Sized + Send> NotSend<u8> for T {}
+
+    trait NotSync<A> {
+        const OK: () = ();
+    }
+    impl<T: ?Sized> NotSync<()> for T {}
+    impl<T: ?Sized + Sync> NotSync<u8> for T {}
+
+    const _: () = <JsCell<std::rc::Rc<u32>> as NotSend<_>>::OK;
+    const _: () = <JsCell<std::rc::Rc<u32>> as NotSync<_>>::OK;
 }

--- a/src/jsc/WorkTask.rs
+++ b/src/jsc/WorkTask.rs
@@ -51,10 +51,20 @@ pub struct WorkTask<Context: WorkTaskContext> {
 
 bun_threading::intrusive_work_task!([Context: WorkTaskContext] WorkTask<Context>, task);
 
-// SAFETY: `WorkTask` is moved into the thread pool's queue (intrusive `task`
-// node) and back via the concurrent task queue. All access to `ctx` /
-// `global_this` is sequenced by the work-pool → on_finish → run_from_js
-// hand-off; raw pointers are inert.
+// SAFETY: `WorkTask` is heap-allocated; only its *address* crosses threads, via
+// the intrusive `task` node and the concurrent queue, and it is never aliased on
+// two threads at once. The hand-off is strictly sequenced: `schedule` (JS thread)
+// → `run_from_thread_pool` (one worker, exclusive) → `on_finish` re-enqueues onto
+// the JS event loop → `run_from_js` (JS thread).
+//
+// `Context` is deliberately NOT required to be `Send`: `ctx` is a raw
+// `*mut Context` and its implementors (e.g. `GetAddrInfoRequest`) hold
+// JS-thread-bound raw pointers (`*mut DNSLookup`, `*mut Resolver`) that `then()`
+// uses back on the JS thread. The worker only runs `Context::run`, which touches
+// the thread-safe subset; the raw pointer is inert while the address is in flight.
+// Requiring `C: Send` would reject this correct-by-construction design — the same
+// single-JS-thread contract that backs `JsCell` and `VirtualMachine`'s
+// hand-written `unsafe impl`s.
 unsafe impl<C: WorkTaskContext> Send for WorkTask<C> {}
 
 impl<Context: WorkTaskContext> Taskable for WorkTask<Context> {

--- a/test/internal/jscell-send-sync-bounds.test.ts
+++ b/test/internal/jscell-send-sync-bounds.test.ts
@@ -1,0 +1,132 @@
+// `JsCell<T>` (src/jsc/JSCell.rs) is a `#[repr(transparent)]` wrapper over
+// `UnsafeCell<T>` whose `get(&self) -> &T` is a SAFE function. Its `Send`/`Sync`
+// impls must be gated on the inner type:
+//
+//   unsafe impl<T: Sync> Sync for JsCell<T> {}
+//   unsafe impl<T: Send> Send for JsCell<T> {}
+//
+// If they were unconditional (`unsafe impl<T> ...`), a `&JsCell<T>` would be
+// shareable across threads via any `Sync` container, and the safe `get()` would
+// then hand out a `&T` to a `!Sync` `T` (`Rc`, `Cell`, `RefCell`) on another
+// thread — UB with zero `unsafe` at the call site (oven-sh/bun#31498).
+//
+// This is a type-level invariant with no runtime surface, so the compiler checks
+// it: a throwaway crate depends on the real `bun_jsc` and asserts `JsCell<Rc<u32>>`
+// is `!Send + !Sync` via the auto-trait-ambiguity trick (stable Rust has no
+// negative bounds). `cargo check` succeeds iff the bounds are present — with the
+// unconditional impls `JsCell<Rc<u32>>` is `Send + Sync`, both blanket impls apply,
+// and the build fails with E0283. `cargo check` does not link, so no C++/JSC objects
+// are needed; it only needs the codegen the debug build already emitted.
+import { expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const cargo = Bun.which("cargo");
+const repoRoot = path.resolve(import.meta.dir, "..", "..");
+const jscCrate = path.join(repoRoot, "src", "jsc");
+
+// `bun_jsc`'s build.rs pulls generated Rust from here; emitted by `bun bd`.
+const codegenReady =
+  existsSync(path.join(repoRoot, "build", "debug", "codegen", "cpp.rs")) &&
+  existsSync(path.join(repoRoot, "build", "debug", "codegen", "generated_resolved_source_tag.rs"));
+
+// Pin the same toolchain `bun bd` uses (the temp crate lives outside the repo, so
+// it wouldn't otherwise pick up rust-toolchain.toml).
+function pinnedToolchain(): string | undefined {
+  try {
+    const toml = readFileSync(path.join(repoRoot, "rust-toolchain.toml"), "utf8");
+    return toml.match(/channel\s*=\s*"([^"]+)"/)?.[1];
+  } catch {
+    return undefined;
+  }
+}
+const toolchain = pinnedToolchain();
+
+// Host triple, for `--target` so the build.rs codegen path lines up.
+function hostTriple(): string | undefined {
+  if (!cargo) return undefined;
+  const out = Bun.spawnSync({ cmd: [cargo, "-vV"], env: process.env }).stdout.toString();
+  return out.match(/host:\s*(\S+)/)?.[1];
+}
+const triple = hostTriple();
+
+const proof = `
+use bun_jsc::JsCell;
+use std::rc::Rc;
+
+trait NotSend<A> { const OK: () = (); }
+impl<T: ?Sized> NotSend<()> for T {}
+impl<T: ?Sized + Send> NotSend<u8> for T {}
+
+trait NotSync<A> { const OK: () = (); }
+impl<T: ?Sized> NotSync<()> for T {}
+impl<T: ?Sized + Sync> NotSync<u8> for T {}
+
+// JsCell<Rc<u32>> must be !Send and !Sync. If either impl is unconditional the
+// type gains the trait, both blanket impls apply, and this fails to compile (E0283).
+const _: () = <JsCell<Rc<u32>> as NotSend<_>>::OK;
+const _: () = <JsCell<Rc<u32>> as NotSync<_>>::OK;
+
+// Positive direction: a Send/Sync inner type keeps the thread-affinity escape hatch.
+const _: fn() = || {
+    fn assert_send<T: Send>() {}
+    fn assert_sync<T: Sync>() {}
+    assert_send::<JsCell<u32>>();
+    assert_sync::<JsCell<u32>>();
+};
+
+fn main() {}
+`;
+
+test.skipIf(!cargo || !codegenReady || !toolchain || !triple)(
+  "JsCell<T>'s Send/Sync impls require T: Send/Sync (issue #31498)",
+  async () => {
+    // `[workspace]` detaches this crate from the repo's workspace; the absolute
+    // path dep resolves `bun_jsc` regardless of cwd. The target dir lives inside
+    // the temp dir so the run is self-contained and leaves the build untouched.
+    using dir = tempDir("jscell-send-sync", {
+      "Cargo.toml": `[package]
+name = "jscell_send_sync_proof"
+version = "0.0.0"
+edition = "2021"
+
+[[bin]]
+name = "jscell_send_sync_proof"
+path = "main.rs"
+
+[dependencies]
+bun_jsc = { path = ${JSON.stringify(jscCrate)} }
+
+[workspace]
+`,
+      "main.rs": proof,
+    });
+
+    await using proc = Bun.spawn({
+      // --offline: every dep is already in the cargo cache from `bun bd`; never
+      // touch the network in CI.
+      cmd: [cargo!, "check", "--quiet", "--offline", "--target", triple!],
+      cwd: String(dir),
+      env: {
+        ...process.env,
+        RUSTUP_TOOLCHAIN: toolchain!,
+        CARGO_TARGET_DIR: path.join(String(dir), "target"),
+        CARGO_TERM_COLOR: "never",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // `cargo check` must succeed — the negative assertions compile only when
+    // `JsCell<Rc<u32>>` is correctly `!Send + !Sync`. E0283 is the signature of
+    // the unconditional impls (both ambiguity blankets apply).
+    const output = stdout + stderr;
+    expect(output).not.toContain("E0283");
+    expect(output).not.toMatch(/^error/m);
+    expect(exitCode).toBe(0);
+  },
+  300_000,
+);


### PR DESCRIPTION
Closes #31498.

## What

`JsCell<T>` (`src/jsc/JSCell.rs`) is a `#[repr(transparent)]` wrapper over `UnsafeCell<T>` whose `get(&self) -> &T` is a **safe** function. Its `Send`/`Sync` impls were unconditional:

```rust
unsafe impl<T> Sync for JsCell<T> {}   // no T: Sync
unsafe impl<T> Send for JsCell<T> {}   // no T: Send
```

Because `get()` is safe and hands out `&T`, an unconditional `Sync` lets a `&JsCell<T>` cross threads (via any `Sync` container) and surface a `&T` to a `!Sync` `T` (`Rc`, `Cell`, `RefCell`) on another thread — UB with **zero `unsafe` at the call site**. Anyone writing `JsCell<Rc<…>>` directly, or through a struct field, would break the single-JS-thread model with no `unsafe` marker. This is location #1 from the issue, and the one the reporter flagged as the real leak (its dangerous surface is a *public, safe* fn).

## Cause

The single-JS-thread invariant is a runtime contract, not something the unconditional impls enforce. The `Sync` impl is a deliberate, documented escape hatch so `&'static VirtualMachine` (which embeds `JsCell` fields) satisfies `'static` trait objects without hand-written impls cascading everywhere — but it was stated as `<T>` rather than `<T: Sync>`, so it covered `!Sync` inner types it never should have.

## Fix

Gate each impl on the corresponding inner bound:

```rust
unsafe impl<T: Sync> Sync for JsCell<T> {}
unsafe impl<T: Send> Send for JsCell<T> {}
```

This keeps the escape hatch intact — `VirtualMachine` carries its own `unsafe impl Sync`/`Send` and is unaffected, and every other `JsCell<!Sync>` field in the tree (`JsCell<Strong>`, `JsCell<KeepAlive>`, `JsCell<EventLoopTimer>`, `JsCell<Vec<u8>>`, …) lives in a struct that is already `!Sync` via a `Cell`/`RefCount` field and is never required to be `Send`. A `JsCell<!Sync>`/`JsCell<!Send>` is now correctly `!Sync`/`!Send`, so such a field can no longer silently make its container cross-thread-shareable. **The full `bun bd` build stays green** (this was the open question — it compiles workspace-wide).

### `ConcurrentPromiseTask` / `WorkTask` (issue locations #2 and #3)

The issue proposed adding a `Send` bound (on the trait or the `unsafe impl`) for these, on the premise that "every implementor is already `Send`." **That premise does not hold** — I tried it and the build fails. All four/three implementors are genuinely `!Send`:

- `TransformTask`, `WalkTask`, `PipelineTask` hold a `&JSGlobalObject` (an opaque `!Sync` FFI handle) plus JS-heap raw pointers.
- `GetAddrInfoRequest` holds `*mut DNSLookup` / `*mut Resolver`.

These fields are JS-thread-bound and are touched by `then()` back **on the JS thread**; the worker only runs `run()`, which operates on the thread-safe subset. Fields that genuinely cross to the worker are already wrapped at the field level in `bun_jsc::ThreadSafe` (e.g. `TransformTask::input_code`). A `C: Send` bound would reject this correct-by-construction design. These `unsafe impl Send`s are the same class of audited escape hatch as `JsCell` / `VirtualMachine`, so they keep the hand-written impl and I expanded their SAFETY docs to name the single-JS-thread contract and the strict `schedule → run_from_thread_pool → on_finish → run_from_js` sequencing, rather than adding a bound that breaks compilation.

## Verification

- **Full `bun bd` debug build is green** with the tightened `JsCell` bounds — the `JsCell<!Send/!Sync>`-heavy modules (Response, Request, FileSink/FileReader, sockets, valkey, dns) all compile.
- Smoke-tested the two task-wrapper paths the changed SAFETY comments cover: async `Bun.Transpiler().transform()` (`ConcurrentPromiseTask<TransformTask>`) and `dns.lookup` (`WorkTask<GetAddrInfoRequest>`) — both work.
- **Regression guard:** a co-located compile-time proof module (`jscell_send_sync_proof`) asserts both directions — `JsCell<u32>` stays `Send + Sync`, and `JsCell<Rc<u32>>` is `!Send + !Sync` via the auto-trait-ambiguity trick (same shape as `src/runtime/shell/subproc.rs`'s `__pipe_reader_thread_confined`). I confirmed with a standalone `rustc` that this negative assertion **fails to compile under the old unconditional impls** (E0283, "multiple impls satisfying `JsCell<Rc<u32>>: …`") and passes under the tightened bounds. It is not behind `#[cfg(test)]`, so it compiles on every build and `rust:check`/`rust:clippy` run — reverting the bound turns CI red.

## Tests

`test/internal/jscell-send-sync-bounds.test.ts` checks the invariant with the compiler, since it has no runtime surface: it `cargo check`s a throwaway crate that depends on the real `bun_jsc` and asserts `JsCell<Rc<u32>>` is `!Send + !Sync` via the auto-trait-ambiguity trick. `cargo check` does not link (no C++/JSC objects needed — only the codegen the debug build already emitted), so it's cheap and self-contained. **Verified fail-before/pass-after**: with the old unconditional impls `JsCell<Rc<u32>>` is `Send + Sync`, both ambiguity blankets apply, and the check fails with `E0283`; with the tightened bounds it passes. The test skips on lanes without the debug codegen / cargo / pinned toolchain (e.g. release-only), and runs fully offline.

A co-located compile-time proof (`jscell_send_sync_proof` in `JSCell.rs`, same shape as `src/runtime/shell/subproc.rs`'s `__pipe_reader_thread_confined`) additionally guards both directions on every build, so reverting the bound also turns the `rust:check`/`rust:clippy` CI lanes red.