### PR TITLE
sourcemap: fail on a truncated base64 VLQ instead of decoding it as 0

### DIFF
--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -406,10 +406,12 @@ pub mod vlq {
             }
         }
 
-        VLQResult {
-            start: start + encoded_.len(),
-            value: 0,
-        }
+        // Reached when the input is empty or ends mid-VLQ (the last byte's
+        // continuation bit is set with no following byte, or all 8 bytes have
+        // it set — both malformed). No value was decoded; return `start`
+        // unchanged so callers' no-progress checks treat the truncated
+        // mapping as a parse failure instead of silently accepting `value: 0`.
+        VLQResult { start, value: 0 }
     }
 
     #[inline]

--- a/test/js/node/module/sourcemap.test.js
+++ b/test/js/node/module/sourcemap.test.js
@@ -1,6 +1,6 @@
 const { test, expect } = require("bun:test");
 const { SourceMap } = require("node:module");
-const { bunEnv, bunExe } = require("harness");
+const { bunEnv, bunExe, tempDir } = require("harness");
 
 test("SourceMap class exists", () => {
   expect(SourceMap).toBeDefined();
@@ -213,4 +213,30 @@ console.log("done");`,
   expect(stderr).toBe("");
   expect(stdout).toBe("test.js\ndone\n");
   expect(exitCode).toBe(0);
+});
+
+test("error.stack of // @bun code with a truncated VLQ in sourceMappingURL degrades gracefully", async () => {
+  // 'g' is a single base64 byte with the VLQ continuation bit set, so the
+  // mappings string ends mid-value. The sourcemap is unusable, but reading
+  // error.stack must still print the unmapped location instead of aborting.
+  const map = Buffer.from(
+    JSON.stringify({ version: 3, sources: ["a.ts"], sourcesContent: ["x"], names: [], mappings: "g" }),
+  ).toString("base64");
+  using dir = tempDir("sourcemap-truncated-vlq", {
+    "entry.js": `// @bun\nthrow new Error("boom");\n//# sourceMappingURL=data:application/json;base64,${map}\n`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("error: boom");
+  expect(stderr).toContain("entry.js:2:");
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(1);
 });

--- a/test/js/node/module/sourcemap.test.js
+++ b/test/js/node/module/sourcemap.test.js
@@ -215,10 +215,13 @@ console.log("done");`,
   expect(exitCode).toBe(0);
 });
 
-test("error.stack of // @bun code with a truncated VLQ in sourceMappingURL degrades gracefully", async () => {
+test("error.stack of // @bun code with a truncated VLQ in sourceMappingURL warns and degrades gracefully", async () => {
   // 'g' is a single base64 byte with the VLQ continuation bit set, so the
-  // mappings string ends mid-value. The sourcemap is unusable, but reading
-  // error.stack must still print the unmapped location instead of aborting.
+  // mappings string ends mid-value. The generated-column field is truncated,
+  // so the decoder makes no progress and parsing fails. Bun must reject the
+  // map with a "Could not decode sourcemap" warning instead of silently
+  // accepting a bogus `value: 0` mapping, and reading error.stack must still
+  // print the unmapped location instead of aborting.
   const map = Buffer.from(
     JSON.stringify({ version: 3, sources: ["a.ts"], sourcesContent: ["x"], names: [], mappings: "g" }),
   ).toString("base64");
@@ -235,6 +238,9 @@ test("error.stack of // @bun code with a truncated VLQ in sourceMappingURL degra
   });
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // The truncated mapping is rejected with a warning rather than silently
+  // decoded as 0 (which left no trace that the map was corrupt).
+  expect(stderr).toContain("Could not decode sourcemap");
   expect(stderr).toContain("error: boom");
   expect(stderr).toContain("entry.js:2:");
   expect(stdout).toBe("");


### PR DESCRIPTION
The base64 VLQ decoder's loop fallthrough — reached when a sourcemap `mappings` segment ends mid-VLQ (a continuation bit set with no following byte) — returned `start + len`, i.e. it reported *progress* while decoding the truncated value as `0`. So callers' `start == 0` no-progress check never fired, and `Mapping::parse` returned success with a wrong/empty mapping and **no warning**.

(The earlier out-of-bounds *read* on this same path was already fixed by the recent hardening round, `a8aec3067d`, which bounded the loop to the slice length. This addresses the leftover behavior that hardening left behind.)

Return `start` unchanged on the fallthrough so a truncated VLQ is treated as a parse failure. The caller then takes the existing graceful path — `warn: Could not decode sourcemap…`, falling back to the unmapped location — matching Bun 1.3.14. `node:module`'s `SourceMap` (same decoder) now throws a catchable `SyntaxError` for a truncated mapping instead of returning garbage.

Valid sourcemaps and normal end-of-buffer are unaffected: the fallthrough is only reached for empty or mid-VLQ-truncated input, and for empty input `start + 0 == start`.
