### PR TITLE
Fixed CSS module definitions in React templates throwing TypeScript errors

### DIFF
--- a/src/runtime/cli/init/react-app/bun-env.d.ts
+++ b/src/runtime/cli/init/react-app/bun-env.d.ts
@@ -8,8 +8,6 @@ declare module "*.svg" {
   export = path;
 }
 
-declare module "*.css" {}
-
 declare module "*.module.css" {
   /**
    * A record of class names to their corresponding CSS module classes
@@ -17,3 +15,5 @@ declare module "*.module.css" {
   const classes: { readonly [key: string]: string };
   export = classes;
 }
+
+declare module "*.css" {}

--- a/src/runtime/cli/init/react-shadcn/bun-env.d.ts
+++ b/src/runtime/cli/init/react-shadcn/bun-env.d.ts
@@ -8,8 +8,6 @@ declare module "*.svg" {
   export = path;
 }
 
-declare module "*.css" {}
-
 declare module "*.module.css" {
   /**
    * A record of class names to their corresponding CSS module classes
@@ -17,3 +15,5 @@ declare module "*.module.css" {
   const classes: { readonly [key: string]: string };
   export = classes;
 }
+
+declare module "*.css" {}

--- a/src/runtime/cli/init/react-tailwind/bun-env.d.ts
+++ b/src/runtime/cli/init/react-tailwind/bun-env.d.ts
@@ -8,8 +8,6 @@ declare module "*.svg" {
   export = path;
 }
 
-declare module "*.css" {}
-
 declare module "*.module.css" {
   /**
    * A record of class names to their corresponding CSS module classes
@@ -17,3 +15,5 @@ declare module "*.module.css" {
   const classes: { readonly [key: string]: string };
   export = classes;
 }
+
+declare module "*.css" {}


### PR DESCRIPTION
Previously, a new project created using `bun init` with React gave you a TypeScript error (`Property 'cssClassName' does not exist on type 'typeof import("*.css")'.`), at least in VSCode (tested with native preview `typescriptteam.native-preview-0.20260527.1-linux-x64`), although this seems to work fine when actually building/serving the project. Simply putting the more specific `*.module.css` module definition before the `*.css` definition both yields no errors & works when building/serving the project.

### What does this PR do?
Moved `declare module "*.module.css"` to before `declare module "*.css"` in the relevant `bun-env.d.ts` files to stop it from being superseded in the template projects.

### How did you verify your code works?
Checked that the error was resolved & the files were served correctly in the template's output projects.