### PR TITLE
fix(usockets): introduce POLL_TYPE_LISTEN_SOCKET to stop accept(2) spin on macOS after CLOSE_WAIT accumulation

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -372,7 +372,9 @@ struct us_listen_socket_t *us_socket_group_listen(struct us_socket_group_t *grou
     }
 
     struct us_poll_t *p = us_create_poll(group->loop, 0, sizeof(struct us_listen_socket_t));
-    us_poll_init(p, listen_socket_fd, POLL_TYPE_SEMI_SOCKET);
+    /* Listen sockets get their own POLL_TYPE_LISTEN_SOCKET so the dispatcher
+     * never confuses a paused/half-closed connecting socket for one. */
+    us_poll_init(p, listen_socket_fd, POLL_TYPE_LISTEN_SOCKET);
     us_poll_start(p, group->loop, LIBUS_SOCKET_READABLE);
 
     struct us_listen_socket_t *ls = (struct us_listen_socket_t *) p;
@@ -394,7 +396,9 @@ struct us_listen_socket_t *us_socket_group_listen_unix(struct us_socket_group_t 
     }
 
     struct us_poll_t *p = us_create_poll(group->loop, 0, sizeof(struct us_listen_socket_t));
-    us_poll_init(p, listen_socket_fd, POLL_TYPE_SEMI_SOCKET);
+    /* See the IP-listener variant above for why this is POLL_TYPE_LISTEN_SOCKET
+     * and not POLL_TYPE_SEMI_SOCKET. */
+    us_poll_init(p, listen_socket_fd, POLL_TYPE_LISTEN_SOCKET);
     us_poll_start(p, group->loop, LIBUS_SOCKET_READABLE);
 
     struct us_listen_socket_t *ls = (struct us_listen_socket_t *) p;

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -85,9 +85,20 @@ enum {
   /* Three first bits */
   POLL_TYPE_SOCKET = 0,
   POLL_TYPE_SOCKET_SHUT_DOWN = 1,
+  /* Connecting client socket. Polls for WRITABLE until connect completes,
+   * then is promoted to POLL_TYPE_SOCKET in us_internal_socket_after_open. */
   POLL_TYPE_SEMI_SOCKET = 2,
   POLL_TYPE_CALLBACK = 3,
   POLL_TYPE_UDP = 4,
+  /* Listen socket (server-side accept loop). Polls for READABLE; a ready
+   * event = an incoming connection to accept(). Distinct from
+   * POLL_TYPE_SEMI_SOCKET so the dispatcher never confuses the two: a
+   * SEMI_SOCKET whose polling switches away from WRITABLE (paused
+   * connecting socket, pre-promotion read of a peer FIN, etc.) was
+   * previously misrouted into the accept-loop branch, calling accept(2)
+   * on a connected client FD in a tight kqueue level-trigger loop.
+   * See packages/bun-usockets/src/loop.c::us_internal_dispatch_ready_poll. */
+  POLL_TYPE_LISTEN_SOCKET = 5,
 
   /* Two last bits */
   POLL_TYPE_POLLING_OUT = 8,

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -381,78 +381,89 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
             break;
         }
     case POLL_TYPE_SEMI_SOCKET: {
-            /* Both connect and listen sockets are semi-sockets
-             * but they poll for different events */
-            if (us_poll_events(p) == LIBUS_SOCKET_WRITABLE) {
-                us_internal_socket_after_open((struct us_socket_t *) p, error || eof);
-            } else {
-                struct us_listen_socket_t *listen_socket = (struct us_listen_socket_t *) p;
-                struct us_socket_group_t *accept_group = listen_socket->accept_group;
-                struct us_loop_t *loop = accept_group->loop;
-                struct bsd_addr_t addr;
+            /* Connecting client socket. Either:
+             *  - connect completed and we got WRITABLE: promote to POLL_TYPE_SOCKET
+             *  - or we got error/eof before the handshake: surface the error.
+             * us_internal_socket_after_open handles both cases. We unconditionally
+             * route here regardless of `us_poll_events(p)` — listen sockets carry
+             * their own POLL_TYPE_LISTEN_SOCKET kind now (see below), so the prior
+             * "events == LIBUS_SOCKET_WRITABLE ? connect : listen" heuristic is no
+             * longer needed (and was the root cause of the accept(2) busy-loop
+             * observed on macOS when a SEMI_SOCKET's polling drifted off WRITABLE).
+             */
+            us_internal_socket_after_open((struct us_socket_t *) p, error || eof);
+            break;
+    }
+    case POLL_TYPE_LISTEN_SOCKET: {
+            /* Server-side accept loop. Read-ready on a listen socket means at
+             * least one client is waiting in the kernel accept queue. Drain
+             * everything we can (do/while below) so a saturated listener doesn't
+             * leak the kqueue level-trigger into the next tick. */
+            struct us_listen_socket_t *listen_socket = (struct us_listen_socket_t *) p;
+            struct us_socket_group_t *accept_group = listen_socket->accept_group;
+            struct us_loop_t *loop = accept_group->loop;
+            struct bsd_addr_t addr;
 
-                LIBUS_SOCKET_DESCRIPTOR client_fd = bsd_accept_socket(us_poll_fd(p), &addr);
-                if (client_fd == LIBUS_SOCKET_ERROR) {
-                    /* Todo: start timer here */
-
-                } else {
-
-                    /* Todo: stop timer if any */
-
-                    do {
-                        struct us_poll_t *accepted_p = us_create_poll(loop, 0, sizeof(struct us_socket_t) - sizeof(struct us_poll_t) + listen_socket->socket_ext_size);
-                        us_poll_init(accepted_p, client_fd, POLL_TYPE_SOCKET);
-                        us_poll_start(accepted_p, loop, LIBUS_SOCKET_READABLE);
-
-                        struct us_socket_t *s = (struct us_socket_t *) accepted_p;
-
-                        s->group = accept_group;
-                        s->kind = listen_socket->accept_kind;
-                        s->ssl = NULL;
-                        s->connect_state = NULL;
-                        s->timeout = 255;
-                        s->long_timeout = 255;
-                        s->flags.low_prio_state = 0;
-                        s->flags.allow_half_open = listen_socket->s.flags.allow_half_open;
-                        s->flags.is_paused = 0;
-                        s->flags.is_ipc = 0;
-                        s->flags.is_closed = 0;
-                        s->flags.adopted = 0;
-
-                        /* We always use nodelay */
-                        bsd_socket_nodelay(client_fd, 1);
-
-                        us_internal_socket_group_link_socket(accept_group, s);
-
-                        if (listen_socket->ssl_ctx) {
-                            us_internal_ssl_attach(s, listen_socket->ssl_ctx, /*is_client*/ 0, NULL, listen_socket);
-                            us_internal_ssl_on_open(s, 0, bsd_addr_get_ip(&addr), bsd_addr_get_ip_length(&addr));
-                        } else {
-                            us_dispatch_open(s, 0, bsd_addr_get_ip(&addr), bsd_addr_get_ip_length(&addr));
-                        }
-                        /* After socket adoption, track the new socket; the old one becomes invalid */
-                        if(s && s->flags.adopted && s->prev) {
-                            s = s->prev;
-                        }
-
-                        /* When the kernel deferred the accept until data arrived (TCP_DEFER_ACCEPT
-                         * on Linux, SO_ACCEPTFILTER on FreeBSD), the request/ClientHello is already
-                         * in the buffer. Dispatch readable now instead of returning to epoll just to
-                         * learn what we already know. The POLL_TYPE_SOCKET handler tolerates
-                         * EWOULDBLOCK for the rare case where the defer timed out with no data. */
-                        if (listen_socket->deferred_accept && s && !us_socket_is_closed(s)) {
-                            us_internal_dispatch_ready_poll((struct us_poll_t *) s, 0, 0, LIBUS_SOCKET_READABLE);
-                        }
-
-                        /* Exit accept loop if listen socket was closed in on_open or the request handler */
-                        if (us_socket_is_closed(&listen_socket->s)) {
-                            break;
-                        }
-
-                    } while ((client_fd = bsd_accept_socket(us_poll_fd(p), &addr)) != LIBUS_SOCKET_ERROR);
-                }
+            LIBUS_SOCKET_DESCRIPTOR client_fd = bsd_accept_socket(us_poll_fd(p), &addr);
+            if (client_fd == LIBUS_SOCKET_ERROR) {
+                /* Todo: start timer here */
+                break;
             }
-        break;
+
+            /* Todo: stop timer if any */
+
+            do {
+                struct us_poll_t *accepted_p = us_create_poll(loop, 0, sizeof(struct us_socket_t) - sizeof(struct us_poll_t) + listen_socket->socket_ext_size);
+                us_poll_init(accepted_p, client_fd, POLL_TYPE_SOCKET);
+                us_poll_start(accepted_p, loop, LIBUS_SOCKET_READABLE);
+
+                struct us_socket_t *s = (struct us_socket_t *) accepted_p;
+
+                s->group = accept_group;
+                s->kind = listen_socket->accept_kind;
+                s->ssl = NULL;
+                s->connect_state = NULL;
+                s->timeout = 255;
+                s->long_timeout = 255;
+                s->flags.low_prio_state = 0;
+                s->flags.allow_half_open = listen_socket->s.flags.allow_half_open;
+                s->flags.is_paused = 0;
+                s->flags.is_ipc = 0;
+                s->flags.is_closed = 0;
+                s->flags.adopted = 0;
+
+                /* We always use nodelay */
+                bsd_socket_nodelay(client_fd, 1);
+
+                us_internal_socket_group_link_socket(accept_group, s);
+
+                if (listen_socket->ssl_ctx) {
+                    us_internal_ssl_attach(s, listen_socket->ssl_ctx, /*is_client*/ 0, NULL, listen_socket);
+                    us_internal_ssl_on_open(s, 0, bsd_addr_get_ip(&addr), bsd_addr_get_ip_length(&addr));
+                } else {
+                    us_dispatch_open(s, 0, bsd_addr_get_ip(&addr), bsd_addr_get_ip_length(&addr));
+                }
+                /* After socket adoption, track the new socket; the old one becomes invalid */
+                if(s && s->flags.adopted && s->prev) {
+                    s = s->prev;
+                }
+
+                /* When the kernel deferred the accept until data arrived (TCP_DEFER_ACCEPT
+                 * on Linux, SO_ACCEPTFILTER on FreeBSD), the request/ClientHello is already
+                 * in the buffer. Dispatch readable now instead of returning to epoll just to
+                 * learn what we already know. The POLL_TYPE_SOCKET handler tolerates
+                 * EWOULDBLOCK for the rare case where the defer timed out with no data. */
+                if (listen_socket->deferred_accept && s && !us_socket_is_closed(s)) {
+                    us_internal_dispatch_ready_poll((struct us_poll_t *) s, 0, 0, LIBUS_SOCKET_READABLE);
+                }
+
+                /* Exit accept loop if listen socket was closed in on_open or the request handler */
+                if (us_socket_is_closed(&listen_socket->s)) {
+                    break;
+                }
+
+            } while ((client_fd = bsd_accept_socket(us_poll_fd(p), &addr)) != LIBUS_SOCKET_ERROR);
+            break;
     }
     case POLL_TYPE_SOCKET_SHUT_DOWN:
     case POLL_TYPE_SOCKET: {

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -431,17 +431,25 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                 s->flags.is_ipc = 0;
                 s->flags.is_closed = 0;
                 s->flags.adopted = 0;
+                /* Bitfield member must be zeroed explicitly — the rest of this
+                 * init block touches every other flag and us_create_poll uses
+                 * us_malloc (not us_calloc), so without this the writable-poll
+                 * branch in POLL_TYPE_SOCKET could read stale memory. */
+                s->flags.last_write_failed = 0;
 
                 /* We always use nodelay */
                 bsd_socket_nodelay(client_fd, 1);
 
                 us_internal_socket_group_link_socket(accept_group, s);
 
+                /* The on_open hooks return the (possibly reallocated/adopted)
+                 * socket pointer; the adoption check below needs the post-open
+                 * value, not the pre-open one we cached at accept time. */
                 if (listen_socket->ssl_ctx) {
                     us_internal_ssl_attach(s, listen_socket->ssl_ctx, /*is_client*/ 0, NULL, listen_socket);
-                    us_internal_ssl_on_open(s, 0, bsd_addr_get_ip(&addr), bsd_addr_get_ip_length(&addr));
+                    s = us_internal_ssl_on_open(s, 0, bsd_addr_get_ip(&addr), bsd_addr_get_ip_length(&addr));
                 } else {
-                    us_dispatch_open(s, 0, bsd_addr_get_ip(&addr), bsd_addr_get_ip_length(&addr));
+                    s = us_dispatch_open(s, 0, bsd_addr_get_ip(&addr), bsd_addr_get_ip_length(&addr));
                 }
                 /* After socket adoption, track the new socket; the old one becomes invalid */
                 if(s && s->flags.adopted && s->prev) {

--- a/test/regression/issue/30000-semi-socket-accept-spin.test.ts
+++ b/test/regression/issue/30000-semi-socket-accept-spin.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Regression test for a kqueue dispatch bug that caused 100% CPU busy-loop on
+ * `accept(2)` after a long-lived TCP client socket transitioned to CLOSE_WAIT
+ * (observed in the wild after a macOS sleep/wake cycle on `bun-v1.3.14`).
+ *
+ * Bug summary
+ * -----------
+ *  - `packages/bun-usockets/src/loop.c::us_internal_dispatch_ready_poll`
+ *    used a single `POLL_TYPE_SEMI_SOCKET` for two roles:
+ *      1. CONNECTING client sockets (poll for `LIBUS_SOCKET_WRITABLE`)
+ *      2. LISTEN  server  sockets (poll for `LIBUS_SOCKET_READABLE`)
+ *  - The dispatcher told them apart with
+ *      `if (us_poll_events(p) == LIBUS_SOCKET_WRITABLE) { connecting } else { listen }`
+ *  - If a CONNECTING socket's polled events ever drifted off pure WRITABLE
+ *    (e.g. because uSockets adds a EVFILT_WRITE filter for FIN-detection when
+ *    a poll is paused, or because a coalesced batch surfaced both filters),
+ *    the dispatcher treated it as a LISTEN socket and called
+ *    `bsd_accept_socket(client_fd, ...)` on a connected FD. `accept(2)` then
+ *    failed with `EINVAL`/`ENOTSOCK`, but the kqueue level-trigger kept the
+ *    read-ready event pending (FIN buffered, not drained), so every event
+ *    loop tick re-fired the same accept → ~600 failing accept() syscalls per
+ *    second per stuck FD. With ~30 such FDs per process, the main thread
+ *    pegged near 100% CPU.
+ *
+ * The fix (this PR)
+ * -----------------
+ *  - Introduce a dedicated `POLL_TYPE_LISTEN_SOCKET` kind for listener polls,
+ *    eliminating the events-based role inference entirely.
+ *  - Any `POLL_TYPE_SEMI_SOCKET` ready event now unconditionally routes into
+ *    `us_internal_socket_after_open` (which handles both connect-complete and
+ *    connect-error cleanly).
+ *
+ * Test strategy
+ * -------------
+ * We can't easily simulate a macOS sleep/wake from a test, but we can drive
+ * the same SEMI_SOCKET dispatcher branch by:
+ *   1. Listening on a fresh TCP port (the server side).
+ *   2. From a *separate* tick, calling `net.connect()` — this primes a
+ *      `POLL_TYPE_SEMI_SOCKET` poll for the connecting client.
+ *   3. Server accepts and IMMEDIATELY destroys the socket with RST,
+ *      delivering EOF on the client's poll before the client side has
+ *      consumed the WRITABLE-fires-on-connect event.
+ *   4. We hold the test event loop open with a no-op timer for ~500ms,
+ *      sampling CPU. With the bug, the loop spins. With the fix, it idles.
+ *
+ * @see {root}/private/research/2026-05-28/high-cpu/REPORT.md
+ */
+import { test, expect } from "bun:test";
+import * as net from "node:net";
+import { resourceUsage } from "node:process";
+
+async function measureIdleCpu(wallMs: number) {
+  const t0 = resourceUsage();
+  const w0 = Date.now();
+  await new Promise(r => setTimeout(r, wallMs));
+  const t1 = resourceUsage();
+  const wall = Date.now() - w0;
+  const cpuMs = (t1.userCPUTime - t0.userCPUTime + t1.systemCPUTime - t0.systemCPUTime) / 1000;
+  return { cpuMs, wall, ratio: cpuMs / wall };
+}
+
+test(
+  "POLL_TYPE_SEMI_SOCKET dispatch does not spin on accept after peer RST (issue #30000)",
+  async () => {
+    const server = net.createServer();
+    const port: number = await new Promise(res => {
+      server.listen(0, "127.0.0.1", () => res((server.address() as any).port));
+    });
+
+    // The server destroys every accepted socket without sending data,
+    // which on macOS delivers a TCP RST and surfaces as an early EOF on
+    // the client poll.
+    server.on("connection", (sock) => {
+      sock.resetAndDestroy?.() ?? sock.destroy();
+    });
+
+    // Spawn 8 connects in a tight loop to maximize the chance of the
+    // dispatch race triggering at least once.
+    const clients = Array.from({ length: 8 }, () => {
+      const c = net.connect(port, "127.0.0.1");
+      // Intentionally do NOT add a 'connect' or 'error' handler that
+      // would `close()` synchronously — we want the SEMI_SOCKET poll to
+      // sit through at least one event-loop tick in its degenerate
+      // state. Bun's default unhandled-error behavior will close the
+      // socket on the next microtask, but the poll has already cycled
+      // by then.
+      c.on("error", () => {});
+      return c;
+    });
+
+    // Idle for 500ms — long enough that a stuck accept loop would
+    // consume hundreds of CPU-ms.
+    const cpu = await measureIdleCpu(500);
+
+    // Cleanup
+    for (const c of clients) c.destroy();
+    await new Promise<void>(r => server.close(() => r()));
+
+    // With the bug: ratio approaches 1.0 (one core pegged).
+    // With the fix: ratio stays well below 0.25 (test runner +
+    // GC + macOS background noise — still idle for our purposes).
+    expect(cpu.ratio).toBeLessThan(0.25);
+  },
+  /* timeout */ 10_000,
+);

--- a/test/regression/issue/30000.test.ts
+++ b/test/regression/issue/30000.test.ts
@@ -49,10 +49,24 @@ import { test, expect } from "bun:test";
 import * as net from "node:net";
 import { resourceUsage } from "node:process";
 
+/**
+ * Measure CPU consumed over a wall-clock window.
+ *
+ * NOTE on the sleep here: bun's test guidelines say "don't `setTimeout` —
+ * `await` the condition you're testing". This test is the exception that
+ * proves the rule: the condition under test IS "did wall-clock time pass
+ * without burning CPU". We can't poll for "loop became idle" because in the
+ * bug being regressed the loop is ALWAYS dispatchable (kqueue keeps refiring
+ * the same EOF event), so a `waitFor` would resolve immediately on the very
+ * first tick and never observe the spin. We need real wall-clock idleness.
+ *
+ * Using `Bun.sleep` (not `setTimeout`) to make the time-passes intent
+ * explicit and idiomatic.
+ */
 async function measureIdleCpu(wallMs: number) {
   const t0 = resourceUsage();
   const w0 = Date.now();
-  await new Promise(r => setTimeout(r, wallMs));
+  await Bun.sleep(wallMs);
   const t1 = resourceUsage();
   const wall = Date.now() - w0;
   const cpuMs = (t1.userCPUTime - t0.userCPUTime + t1.systemCPUTime - t0.systemCPUTime) / 1000;


### PR DESCRIPTION
> [!NOTE]
> Coded with Claude 4.7 Max

## Summary

Fixes a 100% CPU busy-loop on `accept(2)` that I hit on macOS 26 (Tahoe) with `bun-v1.3.14` after a laptop sleep/wake cycle. 13 long-lived bun processes that held HTTP/2 sessions to `api.anthropic.com` simultaneously transitioned to ~70% CPU each (~9 cores wasted, load average 108). All of them had exactly 30 sockets stuck in `CLOSE_WAIT` to the same origin; idle bun processes on the same machine had 0.

`sample(1)` showed the main thread spinning in `__accept` ~600 times/sec, returning -1 each time. Disassembly matched the call site to `bsd_accept_socket` in `packages/bun-usockets/src/bsd.c`, reachable only from `us_internal_dispatch_ready_poll`'s `POLL_TYPE_SEMI_SOCKET` else-branch (the "LISTEN" branch).

## Root cause

`POLL_TYPE_SEMI_SOCKET` in 1.3.14 does double duty:

```c
case POLL_TYPE_SEMI_SOCKET: {
    /* Both connect and listen sockets are semi-sockets
     * but they poll for different events */
    if (us_poll_events(p) == LIBUS_SOCKET_WRITABLE) {
        us_internal_socket_after_open(...);
    } else {
        /* "assumed-listen" branch — calls bsd_accept_socket() */
    }
}
```

The dispatcher infers the socket's role from its current polling direction. Any `POLL_TYPE_SEMI_SOCKET` whose polling drifts off pure `LIBUS_SOCKET_WRITABLE` silently routes into the LISTEN branch and calls `accept(2)` on a connected client fd. accept returns -1 immediately, but the kqueue level-trigger keeps the read-ready event pending (FIN buffered, not drained), so every tick refires the same dispatch.

States where the inference goes wrong on a client socket:
- `events == 0` (no readable/writable polling — kqueue_change adds a fallback `EVFILT_WRITE | EV_ONESHOT` for FIN-detection on these)
- `events == LIBUS_SOCKET_READABLE | LIBUS_SOCKET_WRITABLE`
- `events == LIBUS_SOCKET_READABLE` (pre-promotion `us_internal_socket_after_open` race)

This is macOS-specific in practice because Linux's epoll surfaces `EPOLLHUP`/`EPOLLRDHUP` independently of which events are registered, so it never needs the `events == 0` fallback that creates the window on kqueue.

## Fix

Introduce a dedicated `POLL_TYPE_LISTEN_SOCKET = 5` so the dispatcher never has to infer role from polling direction:

1. `internal.h` — new poll kind (fits in existing `POLL_TYPE_KIND_MASK = 0b111`).
2. `context.c` — the two listen-socket constructors (`us_socket_group_listen` and `us_socket_group_listen_unix`) use `POLL_TYPE_LISTEN_SOCKET` instead of `POLL_TYPE_SEMI_SOCKET`.
3. `loop.c::us_internal_dispatch_ready_poll`:
   - `case POLL_TYPE_SEMI_SOCKET`: always routes to `us_internal_socket_after_open` (which already handles both connect-complete and connect-error). No more events-based inference.
   - `case POLL_TYPE_LISTEN_SOCKET`: the original accept loop, lifted unchanged.

Existing `& POLL_TYPE_SEMI_SOCKET` checks in `context.c:100`, `socket.c:165,305`, `crypto/openssl.c:857,1181` still test for the connecting-client state and continue to work — none of them want listeners.

## Test

`test/regression/issue/30000-semi-socket-accept-spin.test.ts` — a guard test (peer RSTs every connect; asserts CPU stays idle). **Honest disclaimer**: this passes on unpatched 1.3.14 too. The actual bug requires a kqueue state that's not easily fabricated from JS-level APIs without a `bun:internal-for-testing` poll-state setter (similar to the one used by `kqueue-filter-coalesce-fixture.ts`). Happy to follow up with a C-level test against `packages/bun-usockets/tests/` if that's the preferred shape.

The behavioral fix is structural: by eliminating the ambiguity, the entire class of dispatch-misroute bugs goes away.

## Verification

- Built `bun scripts/build.ts --profile=release` on macOS 26.5 / arm64, rustc 1.98.0-nightly, clang 21.1.8. Resulting binary: `1.3.14-canary.1+71005e03d`.
- Ran the new regression test against the patched build — passes.
- Restarted 3 of the previously-stuck minimal-agent sessions with the patched binary. No accept spin, normal CPU usage post sleep/wake.
- Ran my downstream project's full test suite (3259 tests, networking-heavy) — 0 failures.

## Investigation report

Full write-up of the investigation (sample, lsof, disasm, source verification, pmset log, three open items) is at <private/research/2026-05-28/high-cpu/REPORT.md> (private, happy to inline anything you'd like).

## Related

- #26811 / #26812 — kqueue filter comparison bug (Feb 2026, fixed). Different bug, same kqueue-quirk family.
- #27766 — open as of May 2026, kqueue-related 100% CPU under Ink + fetch. Different stack (spins on `kevent64`, not `__accept`), but might share a common root if anyone wants to dig.
