### PR TITLE
mysql: decode computed DECIMAL columns as strings, not raw buffers

### DIFF
--- a/src/sql_jsc/mysql/protocol/DecodeBinaryValue.rs
+++ b/src/sql_jsc/mysql/protocol/DecodeBinaryValue.rs
@@ -322,11 +322,35 @@ pub fn decode_binary_value<Context: ReaderContext>(
             _ => Err(bun_core::err!("InvalidBinaryValue")),
         },
 
+        // NEWDECIMAL is always sent as an ASCII decimal string regardless of the
+        // column's BINARY flag / charset. Computed decimals (SUM/AVG/arithmetic/CAST)
+        // carry the BINARY flag and charset 63, so the binary-charset heuristic in the
+        // string/blob arm below would wrongly return them as a Buffer.
+        FieldType::MYSQL_TYPE_NEWDECIMAL => {
+            if raw {
+                let data = reader.encode_len_string()?;
+                return Ok(SQLDataCell::raw(Some(&data)));
+            }
+            let string_data = reader.encode_len_string()?;
+            let slice = string_data.slice();
+            Ok(SQLDataCell {
+                tag: CellTag::String,
+                value: CellValue {
+                    string: if !slice.is_empty() {
+                        clone_utf8_wtf_impl(slice)
+                    } else {
+                        core::ptr::null_mut()
+                    },
+                },
+                free_value: 1,
+                ..Default::default()
+            })
+        }
+
         // When the column contains a binary string we return a Buffer otherwise a string
         FieldType::MYSQL_TYPE_ENUM
         | FieldType::MYSQL_TYPE_SET
         | FieldType::MYSQL_TYPE_GEOMETRY
-        | FieldType::MYSQL_TYPE_NEWDECIMAL
         | FieldType::MYSQL_TYPE_STRING
         | FieldType::MYSQL_TYPE_VARCHAR
         | FieldType::MYSQL_TYPE_VAR_STRING

--- a/src/sql_jsc/mysql/protocol/DecodeBinaryValue.zig
+++ b/src/sql_jsc/mysql/protocol/DecodeBinaryValue.zig
@@ -146,11 +146,26 @@ pub fn decodeBinaryValue(globalObject: *jsc.JSGlobalObject, field_type: types.Fi
             else => error.InvalidBinaryValue,
         },
 
+        // NEWDECIMAL is always sent as an ASCII decimal string regardless of the
+        // column's BINARY flag / charset. Computed decimals (SUM/AVG/arithmetic/CAST)
+        // carry the BINARY flag and charset 63, so the binary-charset heuristic in the
+        // string/blob arm below would wrongly return them as a Buffer.
+        .MYSQL_TYPE_NEWDECIMAL => {
+            if (raw) {
+                var data = try reader.encodeLenString();
+                defer data.deinit();
+                return SQLDataCell.raw(&data);
+            }
+            var string_data = try reader.encodeLenString();
+            defer string_data.deinit();
+            const slice = string_data.slice();
+            return SQLDataCell{ .tag = .string, .value = .{ .string = if (slice.len > 0) bun.String.cloneUTF8(slice).value.WTFStringImpl else null }, .free_value = 1 };
+        },
+
         // When the column contains a binary string we return a Buffer otherwise a string
         .MYSQL_TYPE_ENUM,
         .MYSQL_TYPE_SET,
         .MYSQL_TYPE_GEOMETRY,
-        .MYSQL_TYPE_NEWDECIMAL,
         .MYSQL_TYPE_STRING,
         .MYSQL_TYPE_VARCHAR,
         .MYSQL_TYPE_VAR_STRING,

--- a/src/sql_jsc/mysql/protocol/ResultSet.rs
+++ b/src/sql_jsc/mysql/protocol/ResultSet.rs
@@ -249,6 +249,21 @@ impl<'a> Row<'a> {
                     ..SQLDataCell::default()
                 };
             }
+            // NEWDECIMAL is always sent as an ASCII decimal string regardless of the
+            // column's BINARY flag / charset. Computed decimals (SUM/AVG/arithmetic/CAST)
+            // carry the BINARY flag and charset 63, so the catch-all arm's binary-charset
+            // heuristic would wrongly return them as a Buffer.
+            MYSQL_TYPE_NEWDECIMAL => {
+                let slice = value.slice();
+                *cell = SQLDataCell {
+                    tag: Tag::String,
+                    value: Value {
+                        string: clone_wtf_string_or_null(slice),
+                    },
+                    free_value: 1,
+                    ..SQLDataCell::default()
+                };
+            }
             MYSQL_TYPE_BIT => {
                 // BIT(1) is a special case, it's a boolean
                 if column.column_length == 1 {

--- a/src/sql_jsc/mysql/protocol/ResultSet.zig
+++ b/src/sql_jsc/mysql/protocol/ResultSet.zig
@@ -132,6 +132,14 @@ pub const Row = struct {
                 };
                 cell.* = SQLDataCell{ .tag = .date, .value = .{ .date = date } };
             },
+            // NEWDECIMAL is always sent as an ASCII decimal string regardless of the
+            // column's BINARY flag / charset. Computed decimals (SUM/AVG/arithmetic/CAST)
+            // carry the BINARY flag and charset 63, so the catch-all arm's binary-charset
+            // heuristic would wrongly return them as a Buffer.
+            .MYSQL_TYPE_NEWDECIMAL => {
+                const slice = value.slice();
+                cell.* = SQLDataCell{ .tag = .string, .value = .{ .string = if (slice.len > 0) bun.String.cloneUTF8(slice).value.WTFStringImpl else null }, .free_value = 1 };
+            },
             .MYSQL_TYPE_BIT => {
                 // BIT(1) is a special case, it's a boolean
                 if (column.column_length == 1) {

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -138,6 +138,54 @@ if (isDockerEnabled()) {
           const [simpleRow] = await sql`SELECT id, yr, followup, control, yr_last FROM ${sql(t)} WHERE id = 1`.simple();
           expect(simpleRow).toEqual({ id: 1, yr: 2024, followup: 12345, control: 42, yr_last: 2001 });
         });
+        test("computed DECIMAL columns return strings, not Buffers", async () => {
+          // MySQL reports computed/aggregate NEWDECIMAL columns (SUM/AVG/CAST/
+          // arithmetic/ROUND/literals, and SUM of INT) with the BINARY flag and
+          // charset 63. The binary-charset heuristic used for STRING/BLOB types
+          // wrongly returned these as Buffers; NEWDECIMAL is always ASCII text.
+          await using db = new SQL({ ...getOptions(), max: 1, idleTimeout: 5 });
+          using sql = await db.reserve();
+          const t = "dec_" + randomUUIDv7("hex").replaceAll("-", "");
+          await sql`CREATE TEMPORARY TABLE ${sql(t)} (id INT, balance DECIMAL(12,2), qty INT)`;
+          await sql`INSERT INTO ${sql(t)} VALUES (1, 100.50, 3), (2, 250.25, 4)`;
+          const expected = {
+            total: "350.75",
+            avg_bal: "175.375000",
+            casted: "100.5000",
+            mul2: "201.00",
+            rounded: "100.5",
+            sum_int: "7",
+            lit: "1.23",
+            plain: "100.50",
+          };
+          // Binary protocol (prepared statement).
+          const [row] = await sql`SELECT
+              SUM(balance) AS total,
+              AVG(balance) AS avg_bal,
+              CAST(balance AS DECIMAL(20,4)) AS casted,
+              balance*2 AS mul2,
+              ROUND(balance,1) AS rounded,
+              SUM(qty) AS sum_int,
+              1.23 AS lit,
+              balance AS plain
+            FROM ${sql(t)} WHERE id <= ${2}`;
+          expect(row).toEqual(expected);
+          // Text protocol must decode the same way.
+          const [simpleRow] = await sql`SELECT
+              SUM(balance) AS total,
+              AVG(balance) AS avg_bal,
+              CAST(balance AS DECIMAL(20,4)) AS casted,
+              balance*2 AS mul2,
+              ROUND(balance,1) AS rounded,
+              SUM(qty) AS sum_int,
+              1.23 AS lit,
+              balance AS plain
+            FROM ${sql(t)}`.simple();
+          expect(simpleRow).toEqual(expected);
+          // `.raw()` must still return raw bytes.
+          const [rawRow] = await sql`SELECT SUM(balance) AS total FROM ${sql(t)} WHERE id <= ${2}`.raw();
+          expect(rawRow[0]).toEqual(new Uint8Array(Buffer.from("350.75")));
+        });
         describe("should work with more than the max inline capacity", () => {
           for (let size of [50, 60, 62, 64, 70, 100]) {
             for (let duplicated of [true, false]) {

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -1,7 +1,7 @@
 import { SQL, randomUUIDv7 } from "bun";
 import { beforeAll, describe, expect, mock, test } from "bun:test";
-import { bunEnv, bunRun, describeWithContainer, isDockerEnabled, tempDirWithFiles } from "harness";
 import { once } from "events";
+import { bunEnv, bunRun, describeWithContainer, isDockerEnabled, tempDirWithFiles } from "harness";
 import net from "net";
 import path from "path";
 const dir = tempDirWithFiles("sql-test", {

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -12,8 +12,9 @@ function rel(filename: string) {
   return path.join(dir, filename);
 }
 
-// Shared assertions for the NEWDECIMAL decoder, used by both the docker-backed
-// suite below and the non-docker fallback at the end of this file.
+// Assertions for the NEWDECIMAL decoder against a real server, used by the
+// docker-backed suite below. (The non-docker mock-server suite at the end of
+// this file drives a single canned column, so it asserts inline instead.)
 //
 // MySQL reports computed/aggregate NEWDECIMAL columns (SUM/AVG/CAST/arithmetic/
 // ROUND/literals, and SUM of an INT column) with the BINARY flag and charset

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -1,6 +1,7 @@
 import { SQL, randomUUIDv7 } from "bun";
 import { beforeAll, describe, expect, mock, test } from "bun:test";
 import { bunEnv, bunRun, describeWithContainer, isDockerEnabled, tempDirWithFiles } from "harness";
+import { once } from "events";
 import net from "net";
 import path from "path";
 const dir = tempDirWithFiles("sql-test", {
@@ -1153,46 +1154,192 @@ if (isDockerEnabled()) {
       },
     );
   }
-} else {
-  // No docker daemon (e.g. local/sandboxed environments). If a MySQL server is
-  // reachable — via MYSQL_URL, or as root over a conventional unix socket — run
-  // the NEWDECIMAL regression there so it is still covered off-CI. When nothing
-  // is reachable and MYSQL_URL was not set, soft-skip: the docker-backed suite
-  // above provides the CI coverage.
-  describe("mysql (local)", () => {
-    // Connection candidates, most-specific first. A plain `root` over the unix
-    // socket needs no TCP auth and works against the stock server images used
-    // outside CI.
-    const candidates: Bun.SQL.Options[] = [];
-    if (process.env.MYSQL_URL) candidates.push({ url: process.env.MYSQL_URL });
-    for (const socketPath of ["/run/mysqld/mysqld.sock", "/var/run/mysqld/mysqld.sock", "/tmp/mysql.sock"]) {
-      candidates.push({ adapter: "mysql", username: "root", database: "mysql", path: socketPath });
-    }
-
-    async function connect(): Promise<SQL | undefined> {
-      for (const options of candidates) {
-        const db = new SQL({ ...options, max: 1, idleTimeout: 5 });
-        try {
-          await db`SELECT 1`;
-          return db;
-        } catch {
-          await db.close().catch(() => {});
-        }
-      }
-      return undefined;
-    }
-
-    test("computed DECIMAL columns return strings, not Buffers", async () => {
-      const db = await connect();
-      if (!db) {
-        if (process.env.MYSQL_URL) {
-          throw new Error(`MYSQL_URL was provided but no MySQL server was reachable at ${process.env.MYSQL_URL}`);
-        }
-        console.warn("sql-mysql: no MySQL reachable locally; skipping NEWDECIMAL assertions");
-        return;
-      }
-      await using sql = db;
-      await assertComputedDecimalsAreStrings(sql);
-    });
-  });
 }
+
+// The docker-backed suite above only runs where a docker daemon is available.
+// The NEWDECIMAL decode path does not need a real server to exercise, though:
+// the bug is a misclassification driven entirely by the column's wire metadata
+// (NEWDECIMAL + BINARY flag + charset 63). A minimal mock MySQL server can reply
+// with exactly that column so the decoder is exercised offline, with no docker
+// and no external database. This runs everywhere.
+describe("NEWDECIMAL decodes as a string (mock server, no docker)", () => {
+  const MYSQL_TYPE_NEWDECIMAL = 0xf6;
+  const BINARY_FLAG = 1 << 7; // ColumnFlags::BINARY
+  const BINARY_CHARSET = 63; // the "binary" pseudo-charset
+  // The exact wire metadata MySQL attaches to a computed/aggregate DECIMAL
+  // (SUM/AVG/CAST/arithmetic/ROUND/literal). Without the NEWDECIMAL special-case
+  // in the decoder, `BINARY_FLAG && charset == 63` routes this to a Buffer.
+  const DECIMAL_VALUE = "350.75";
+
+  function u16le(n: number): Buffer {
+    return Buffer.from([n & 0xff, (n >> 8) & 0xff]);
+  }
+  function u24le(n: number): Buffer {
+    return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff]);
+  }
+  function u32le(n: number): Buffer {
+    return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >>> 24) & 0xff]);
+  }
+  function packet(seq: number, payload: Buffer): Buffer {
+    return Buffer.concat([u24le(payload.length), Buffer.from([seq]), payload]);
+  }
+  function lenenc(n: number): Buffer {
+    if (n < 0xfb) return Buffer.from([n]);
+    if (n < 0xffff) return Buffer.concat([Buffer.from([0xfc]), u16le(n)]);
+    throw new Error("lenenc: not needed for this test");
+  }
+  function lenencStr(s: string): Buffer {
+    const buf = Buffer.from(s, "utf-8");
+    return Buffer.concat([lenenc(buf.length), buf]);
+  }
+
+  const CLIENT_PROTOCOL_41 = 1 << 9;
+  const CLIENT_SECURE_CONNECTION = 1 << 15;
+  const CLIENT_PLUGIN_AUTH = 1 << 19;
+  const CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA = 1 << 21;
+  const CLIENT_DEPRECATE_EOF = 1 << 24;
+  const SERVER_CAPS =
+    CLIENT_PROTOCOL_41 |
+    CLIENT_SECURE_CONNECTION |
+    CLIENT_PLUGIN_AUTH |
+    CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA |
+    CLIENT_DEPRECATE_EOF;
+
+  function handshakeV10(): Buffer {
+    const authData1 = Buffer.alloc(8, 0x61);
+    const authData2 = Buffer.alloc(13, 0x62);
+    authData2[12] = 0;
+    return packet(
+      0,
+      Buffer.concat([
+        Buffer.from([10]),
+        Buffer.from("mock-5.7.0\0"),
+        u32le(1),
+        authData1,
+        Buffer.from([0]),
+        u16le(SERVER_CAPS & 0xffff),
+        Buffer.from([0x2d]),
+        u16le(0x0002),
+        u16le((SERVER_CAPS >>> 16) & 0xffff),
+        Buffer.from([21]),
+        Buffer.alloc(10, 0),
+        authData2,
+        Buffer.from("mysql_native_password\0"),
+      ]),
+    );
+  }
+  function okPacket(seq: number, header = 0x00): Buffer {
+    return packet(seq, Buffer.from([header, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
+  }
+  // NEWDECIMAL column carrying the BINARY flag and the binary charset — the
+  // metadata computed decimals arrive with.
+  function decimalColumn(): Buffer {
+    return Buffer.concat([
+      lenencStr("def"),
+      lenencStr(""),
+      lenencStr("t"),
+      lenencStr("t"),
+      lenencStr("total"),
+      lenencStr("total"),
+      Buffer.from([0x0c]),
+      u16le(BINARY_CHARSET),
+      u32le(1024),
+      Buffer.from([MYSQL_TYPE_NEWDECIMAL]),
+      u16le(BINARY_FLAG),
+      Buffer.from([2]), // decimals
+      Buffer.from([0, 0]),
+    ]);
+  }
+  function stmtPrepareOK(startSeq: number, stmtId: number): Buffer {
+    let seq = startSeq;
+    return Buffer.concat([
+      packet(
+        seq++,
+        Buffer.concat([Buffer.from([0x00]), u32le(stmtId), u16le(1), u16le(0), Buffer.from([0x00]), u16le(0)]),
+      ),
+      packet(seq++, decimalColumn()),
+    ]);
+  }
+  // Binary result row: 0x00 header, 1-byte NULL bitmap (nothing null), then the
+  // value as a length-encoded string (how NEWDECIMAL is framed on the wire).
+  function binaryResultSet(startSeq: number): Buffer {
+    let seq = startSeq;
+    return Buffer.concat([
+      packet(seq++, Buffer.from([1])),
+      packet(seq++, decimalColumn()),
+      packet(seq++, Buffer.concat([Buffer.from([0x00]), Buffer.from([0x00]), lenencStr(DECIMAL_VALUE)])),
+      okPacket(seq++, 0xfe),
+    ]);
+  }
+  // Text result row: the value is a single length-encoded string.
+  function textResultSet(startSeq: number): Buffer {
+    let seq = startSeq;
+    return Buffer.concat([
+      packet(seq++, Buffer.from([1])),
+      packet(seq++, decimalColumn()),
+      packet(seq++, lenencStr(DECIMAL_VALUE)),
+      okPacket(seq++, 0xfe),
+    ]);
+  }
+
+  function startMockServer(): net.Server {
+    const server = net.createServer(socket => {
+      let buffered = Buffer.alloc(0);
+      let authed = false;
+      let stmtId = 0;
+      socket.write(handshakeV10());
+      socket.on("data", chunk => {
+        buffered = Buffer.concat([buffered, chunk]);
+        while (buffered.length >= 4) {
+          const len = buffered[0] | (buffered[1] << 8) | (buffered[2] << 16);
+          if (buffered.length < 4 + len) break;
+          const seq = buffered[3];
+          const payload = buffered.subarray(4, 4 + len);
+          buffered = buffered.subarray(4 + len);
+          if (!authed) {
+            authed = true;
+            socket.write(okPacket(seq + 1));
+            continue;
+          }
+          const cmd = payload[0];
+          if (cmd === 0x16 /* COM_STMT_PREPARE */) {
+            socket.write(stmtPrepareOK(seq + 1, ++stmtId));
+          } else if (cmd === 0x17 /* COM_STMT_EXECUTE */) {
+            socket.write(binaryResultSet(seq + 1));
+          } else if (cmd === 0x03 /* COM_QUERY */) {
+            socket.write(textResultSet(seq + 1));
+          } else if (cmd === 0x19 /* COM_STMT_CLOSE */) {
+            // no response expected
+          } else {
+            socket.end();
+          }
+        }
+      });
+    });
+    server.listen(0, "127.0.0.1");
+    return server;
+  }
+
+  test("computed DECIMAL columns return strings, not Buffers", async () => {
+    const server = startMockServer();
+    await once(server, "listening");
+    const { port } = server.address() as net.AddressInfo;
+    try {
+      await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
+
+      // Binary protocol (prepared statement).
+      const [row] = await sql`SELECT SUM(balance) AS total FROM t`;
+      expect(row).toEqual({ total: DECIMAL_VALUE });
+
+      // Text protocol (`.simple()`) must decode the same way.
+      const [simpleRow] = await sql`SELECT SUM(balance) AS total FROM t`.simple();
+      expect(simpleRow).toEqual({ total: DECIMAL_VALUE });
+
+      // `.raw()` must still return the raw bytes.
+      const [rawRow] = await sql`SELECT SUM(balance) AS total FROM t`.raw();
+      expect(rawRow[0]).toEqual(new Uint8Array(Buffer.from(DECIMAL_VALUE)));
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+});

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -148,42 +148,37 @@ if (isDockerEnabled()) {
           const t = "dec_" + randomUUIDv7("hex").replaceAll("-", "");
           await sql`CREATE TEMPORARY TABLE ${sql(t)} (id INT, balance DECIMAL(12,2), qty INT)`;
           await sql`INSERT INTO ${sql(t)} VALUES (1, 100.50, 3), (2, 250.25, 4)`;
-          const expected = {
-            total: "350.75",
-            avg_bal: "175.375000",
-            casted: "100.5000",
-            mul2: "201.00",
-            rounded: "100.5",
-            sum_int: "7",
-            lit: "1.23",
-            plain: "100.50",
-          };
+
+          // Aggregate decimals, plus a decimal literal and SUM of an INT column
+          // (which MySQL also returns as NEWDECIMAL). Kept separate from the
+          // per-row expressions below so the query has no non-aggregated columns
+          // and stays valid under ONLY_FULL_GROUP_BY (the MySQL 8+ default).
+          const aggExpected = { total: "350.75", avg_bal: "175.375000", sum_int: "7", lit: "1.23" };
           // Binary protocol (prepared statement).
-          const [row] = await sql`SELECT
-              SUM(balance) AS total,
-              AVG(balance) AS avg_bal,
-              CAST(balance AS DECIMAL(20,4)) AS casted,
-              balance*2 AS mul2,
-              ROUND(balance,1) AS rounded,
-              SUM(qty) AS sum_int,
-              1.23 AS lit,
-              balance AS plain
-            FROM ${sql(t)} WHERE id <= ${2}`;
-          expect(row).toEqual(expected);
-          // Text protocol must decode the same way.
-          const [simpleRow] = await sql`SELECT
-              SUM(balance) AS total,
-              AVG(balance) AS avg_bal,
-              CAST(balance AS DECIMAL(20,4)) AS casted,
-              balance*2 AS mul2,
-              ROUND(balance,1) AS rounded,
-              SUM(qty) AS sum_int,
-              1.23 AS lit,
-              balance AS plain
+          const [aggRow] = await sql`
+            SELECT SUM(balance) AS total, AVG(balance) AS avg_bal, SUM(qty) AS sum_int, 1.23 AS lit
+            FROM ${sql(t)}`;
+          expect(aggRow).toEqual(aggExpected);
+          // Text protocol (`.simple()`) must decode the same way.
+          const [aggSimple] = await sql`
+            SELECT SUM(balance) AS total, AVG(balance) AS avg_bal, SUM(qty) AS sum_int, 1.23 AS lit
             FROM ${sql(t)}`.simple();
-          expect(simpleRow).toEqual(expected);
+          expect(aggSimple).toEqual(aggExpected);
+
+          // Per-row computed decimals: CAST, arithmetic, ROUND, and a plain stored
+          // column. A single row is selected so the result is deterministic.
+          const rowExpected = { casted: "100.5000", mul2: "201.00", rounded: "100.5", plain: "100.50" };
+          const [row] = await sql`
+            SELECT CAST(balance AS DECIMAL(20,4)) AS casted, balance*2 AS mul2, ROUND(balance,1) AS rounded, balance AS plain
+            FROM ${sql(t)} WHERE id = ${1}`;
+          expect(row).toEqual(rowExpected);
+          const [simpleRow] = await sql`
+            SELECT CAST(balance AS DECIMAL(20,4)) AS casted, balance*2 AS mul2, ROUND(balance,1) AS rounded, balance AS plain
+            FROM ${sql(t)} WHERE id = 1`.simple();
+          expect(simpleRow).toEqual(rowExpected);
+
           // `.raw()` must still return raw bytes.
-          const [rawRow] = await sql`SELECT SUM(balance) AS total FROM ${sql(t)} WHERE id <= ${2}`.raw();
+          const [rawRow] = await sql`SELECT SUM(balance) AS total FROM ${sql(t)}`.raw();
           expect(rawRow[0]).toEqual(new Uint8Array(Buffer.from("350.75")));
         });
         describe("should work with more than the max inline capacity", () => {

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -10,6 +10,51 @@ const dir = tempDirWithFiles("sql-test", {
 function rel(filename: string) {
   return path.join(dir, filename);
 }
+
+// Shared assertions for the NEWDECIMAL decoder, used by both the docker-backed
+// suite below and the non-docker fallback at the end of this file.
+//
+// MySQL reports computed/aggregate NEWDECIMAL columns (SUM/AVG/CAST/arithmetic/
+// ROUND/literals, and SUM of an INT column) with the BINARY flag and charset
+// 63. The binary-charset heuristic used for STRING/BLOB types wrongly returned
+// these as Buffers; NEWDECIMAL is always ASCII decimal text.
+async function assertComputedDecimalsAreStrings(sql: SQL) {
+  const t = "dec_" + randomUUIDv7("hex").replaceAll("-", "");
+  await sql`CREATE TEMPORARY TABLE ${sql(t)} (id INT, balance DECIMAL(12,2), qty INT)`;
+  await sql`INSERT INTO ${sql(t)} VALUES (1, 100.50, 3), (2, 250.25, 4)`;
+
+  // Aggregate decimals, plus a decimal literal and SUM of an INT column (which
+  // MySQL also returns as NEWDECIMAL). Kept separate from the per-row
+  // expressions below so the query has no non-aggregated columns and stays
+  // valid under ONLY_FULL_GROUP_BY (the MySQL 8+ default).
+  const aggExpected = { total: "350.75", avg_bal: "175.375000", sum_int: "7", lit: "1.23" };
+  // Binary protocol (prepared statement).
+  const [aggRow] = await sql`
+    SELECT SUM(balance) AS total, AVG(balance) AS avg_bal, SUM(qty) AS sum_int, 1.23 AS lit
+    FROM ${sql(t)}`;
+  expect(aggRow).toEqual(aggExpected);
+  // Text protocol (`.simple()`) must decode the same way.
+  const [aggSimple] = await sql`
+    SELECT SUM(balance) AS total, AVG(balance) AS avg_bal, SUM(qty) AS sum_int, 1.23 AS lit
+    FROM ${sql(t)}`.simple();
+  expect(aggSimple).toEqual(aggExpected);
+
+  // Per-row computed decimals: CAST, arithmetic, ROUND, and a plain stored
+  // column. A single row is selected so the result is deterministic.
+  const rowExpected = { casted: "100.5000", mul2: "201.00", rounded: "100.5", plain: "100.50" };
+  const [row] = await sql`
+    SELECT CAST(balance AS DECIMAL(20,4)) AS casted, balance*2 AS mul2, ROUND(balance,1) AS rounded, balance AS plain
+    FROM ${sql(t)} WHERE id = ${1}`;
+  expect(row).toEqual(rowExpected);
+  const [simpleRow] = await sql`
+    SELECT CAST(balance AS DECIMAL(20,4)) AS casted, balance*2 AS mul2, ROUND(balance,1) AS rounded, balance AS plain
+    FROM ${sql(t)} WHERE id = 1`.simple();
+  expect(simpleRow).toEqual(rowExpected);
+
+  // `.raw()` must still return raw bytes.
+  const [rawRow] = await sql`SELECT SUM(balance) AS total FROM ${sql(t)}`.raw();
+  expect(rawRow[0]).toEqual(new Uint8Array(Buffer.from("350.75")));
+}
 if (isDockerEnabled()) {
   const images = [
     {
@@ -139,47 +184,9 @@ if (isDockerEnabled()) {
           expect(simpleRow).toEqual({ id: 1, yr: 2024, followup: 12345, control: 42, yr_last: 2001 });
         });
         test("computed DECIMAL columns return strings, not Buffers", async () => {
-          // MySQL reports computed/aggregate NEWDECIMAL columns (SUM/AVG/CAST/
-          // arithmetic/ROUND/literals, and SUM of INT) with the BINARY flag and
-          // charset 63. The binary-charset heuristic used for STRING/BLOB types
-          // wrongly returned these as Buffers; NEWDECIMAL is always ASCII text.
           await using db = new SQL({ ...getOptions(), max: 1, idleTimeout: 5 });
           using sql = await db.reserve();
-          const t = "dec_" + randomUUIDv7("hex").replaceAll("-", "");
-          await sql`CREATE TEMPORARY TABLE ${sql(t)} (id INT, balance DECIMAL(12,2), qty INT)`;
-          await sql`INSERT INTO ${sql(t)} VALUES (1, 100.50, 3), (2, 250.25, 4)`;
-
-          // Aggregate decimals, plus a decimal literal and SUM of an INT column
-          // (which MySQL also returns as NEWDECIMAL). Kept separate from the
-          // per-row expressions below so the query has no non-aggregated columns
-          // and stays valid under ONLY_FULL_GROUP_BY (the MySQL 8+ default).
-          const aggExpected = { total: "350.75", avg_bal: "175.375000", sum_int: "7", lit: "1.23" };
-          // Binary protocol (prepared statement).
-          const [aggRow] = await sql`
-            SELECT SUM(balance) AS total, AVG(balance) AS avg_bal, SUM(qty) AS sum_int, 1.23 AS lit
-            FROM ${sql(t)}`;
-          expect(aggRow).toEqual(aggExpected);
-          // Text protocol (`.simple()`) must decode the same way.
-          const [aggSimple] = await sql`
-            SELECT SUM(balance) AS total, AVG(balance) AS avg_bal, SUM(qty) AS sum_int, 1.23 AS lit
-            FROM ${sql(t)}`.simple();
-          expect(aggSimple).toEqual(aggExpected);
-
-          // Per-row computed decimals: CAST, arithmetic, ROUND, and a plain stored
-          // column. A single row is selected so the result is deterministic.
-          const rowExpected = { casted: "100.5000", mul2: "201.00", rounded: "100.5", plain: "100.50" };
-          const [row] = await sql`
-            SELECT CAST(balance AS DECIMAL(20,4)) AS casted, balance*2 AS mul2, ROUND(balance,1) AS rounded, balance AS plain
-            FROM ${sql(t)} WHERE id = ${1}`;
-          expect(row).toEqual(rowExpected);
-          const [simpleRow] = await sql`
-            SELECT CAST(balance AS DECIMAL(20,4)) AS casted, balance*2 AS mul2, ROUND(balance,1) AS rounded, balance AS plain
-            FROM ${sql(t)} WHERE id = 1`.simple();
-          expect(simpleRow).toEqual(rowExpected);
-
-          // `.raw()` must still return raw bytes.
-          const [rawRow] = await sql`SELECT SUM(balance) AS total FROM ${sql(t)}`.raw();
-          expect(rawRow[0]).toEqual(new Uint8Array(Buffer.from("350.75")));
+          await assertComputedDecimalsAreStrings(sql);
         });
         describe("should work with more than the max inline capacity", () => {
           for (let size of [50, 60, 62, 64, 70, 100]) {
@@ -1146,4 +1153,46 @@ if (isDockerEnabled()) {
       },
     );
   }
+} else {
+  // No docker daemon (e.g. local/sandboxed environments). If a MySQL server is
+  // reachable — via MYSQL_URL, or as root over a conventional unix socket — run
+  // the NEWDECIMAL regression there so it is still covered off-CI. When nothing
+  // is reachable and MYSQL_URL was not set, soft-skip: the docker-backed suite
+  // above provides the CI coverage.
+  describe("mysql (local)", () => {
+    // Connection candidates, most-specific first. A plain `root` over the unix
+    // socket needs no TCP auth and works against the stock server images used
+    // outside CI.
+    const candidates: Bun.SQL.Options[] = [];
+    if (process.env.MYSQL_URL) candidates.push({ url: process.env.MYSQL_URL });
+    for (const socketPath of ["/run/mysqld/mysqld.sock", "/var/run/mysqld/mysqld.sock", "/tmp/mysql.sock"]) {
+      candidates.push({ adapter: "mysql", username: "root", database: "mysql", path: socketPath });
+    }
+
+    async function connect(): Promise<SQL | undefined> {
+      for (const options of candidates) {
+        const db = new SQL({ ...options, max: 1, idleTimeout: 5 });
+        try {
+          await db`SELECT 1`;
+          return db;
+        } catch {
+          await db.close().catch(() => {});
+        }
+      }
+      return undefined;
+    }
+
+    test("computed DECIMAL columns return strings, not Buffers", async () => {
+      const db = await connect();
+      if (!db) {
+        if (process.env.MYSQL_URL) {
+          throw new Error(`MYSQL_URL was provided but no MySQL server was reachable at ${process.env.MYSQL_URL}`);
+        }
+        console.warn("sql-mysql: no MySQL reachable locally; skipping NEWDECIMAL assertions");
+        return;
+      }
+      await using sql = db;
+      await assertComputedDecimalsAreStrings(sql);
+    });
+  });
 }


### PR DESCRIPTION
Any computed/aggregate MySQL `DECIMAL` — `SUM`/`AVG`/`MIN`/`MAX`, arithmetic, `CAST(x AS DECIMAL)`, `ROUND(...)`, a decimal literal, and `SUM`/`AVG` of INT columns (which MySQL returns as DECIMAL) — was returned by `Bun.sql` as a `Buffer`/`Uint8Array` instead of a decimal string (so `value.toFixed()` throws and `JSON.stringify` shows `{"type":"Buffer",…}`). A plain stored DECIMAL column returns a string correctly.

`MYSQL_TYPE_NEWDECIMAL` was grouped with the STRING/BLOB types, which apply a `binary && charset == 63 → return a Buffer` heuristic. DECIMAL values are always ASCII decimal text, always have charset 63, and MySQL sets the BINARY column flag on every *computed* decimal — so the heuristic misfired for all of them.

Give `NEWDECIMAL` an explicit arm in both the binary (`DecodeBinaryValue.rs`) and text (`ResultSet.rs`) decoders that always decodes to a string. A `.raw()` query still gets raw bytes. ENUM/SET were checked against a real server and are unaffected — they carry the connection's real charset, so the heuristic never fires for them. Matches node `mysql2`.

Adds a real-MySQL test covering `SUM`/`AVG`/`CAST`/arithmetic/`ROUND`/literal/`SUM`-of-INT on both the binary and text protocols (plus `.raw()` still returning bytes).
