### PR TITLE
bun:sqlite: decode short non-UTF-8 TEXT leniently instead of dropping the field

### DIFF
--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -574,7 +574,7 @@ static JSValue toJS(JSC::VM& vm, JSC::JSGlobalObject* globalObject, sqlite3_stmt
         }
 
         if (len < 64) {
-            return jsString(vm, WTF::String::fromUTF8({ text, len }));
+            return jsString(vm, WTF::String::fromUTF8ReplacingInvalidSequences({ text, len }));
         }
 
         auto encoded = Bun__encoding__toStringUTF8(text, len, globalObject);

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -308,7 +308,9 @@ static JSValue createSQLiteError(JSC::JSGlobalObject* globalObject, sqlite3* db)
     int byteOffset = sqlite3_error_offset(db);
 
     const char* msg = sqlite3_errmsg(db);
-    WTF::String str = WTF::String::fromUTF8(msg);
+    // Error messages can echo identifiers/values from the query, which SQLite does
+    // not validate as UTF-8, so decode leniently to avoid dropping the message.
+    WTF::String str = WTF::String::fromUTF8ReplacingInvalidSequences({ reinterpret_cast<const unsigned char*>(msg), strlen(msg) });
     JSC::JSObject* object = JSC::createError(globalObject, str);
     auto& builtinNames = WebCore::builtinNames(vm);
     object->putDirect(vm, vm.propertyNames->name, jsString(vm, String("SQLiteError"_s)), JSC::PropertyAttribute::DontEnum | 0);
@@ -2729,8 +2731,12 @@ JSC_DEFINE_CUSTOM_GETTER(jsSqlStatementGetColumnDeclaredTypes, (JSGlobalObject *
         JSC::JSValue typeValue;
 
         if (declType != nullptr) {
-            String typeStr = String::fromUTF8(declType);
-            typeValue = JSC::jsNontrivialString(vm, typeStr);
+            // Declared types come from the schema, which SQLite does not validate as
+            // UTF-8, so decode leniently (invalid -> U+FFFD) like column names. Use
+            // jsString rather than jsNontrivialString because a single-character
+            // declared type (e.g. CREATE TABLE t (a "X")) is valid.
+            String typeStr = WTF::String::fromUTF8ReplacingInvalidSequences({ reinterpret_cast<const unsigned char*>(declType), strlen(declType) });
+            typeValue = JSC::jsString(vm, typeStr);
             RETURN_IF_EXCEPTION(scope, {});
         } else {
             // If no declared type (e.g., for expressions or results of functions)

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -721,7 +721,7 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
             // We can't have two properties with the same name, so we use validColumns to track this.
             auto preCount = columnNames->size();
             columnNames->add(
-                Identifier::fromString(vm, WTF::String::fromUTF8({ name, len })));
+                Identifier::fromString(vm, WTF::String::fromUTF8ReplacingInvalidSequences({ reinterpret_cast<const unsigned char*>(name), len })));
             auto curCount = columnNames->size();
 
             if (preCount != curCount) {
@@ -774,7 +774,7 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
         if (len == 0)
             break;
 
-        const auto key = Identifier::fromString(vm, WTF::String::fromUTF8({ name, len }));
+        const auto key = Identifier::fromString(vm, WTF::String::fromUTF8ReplacingInvalidSequences({ reinterpret_cast<const unsigned char*>(name), len }));
 
         JSC::JSValue primitive = JSC::jsUndefined();
         auto decl = sqlite3_column_decltype(stmt, i);
@@ -2559,7 +2559,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementToStringFunction, (JSC::JSGlobalObject * 
         RELEASE_AND_RETURN(scope, JSValue::encode(jsEmptyString(vm)));
     }
     size_t length = strlen(string);
-    auto* jsString = JSC::jsString(vm, WTF::String::fromUTF8({ string, length }));
+    auto* jsString = JSC::jsString(vm, WTF::String::fromUTF8ReplacingInvalidSequences({ reinterpret_cast<const unsigned char*>(string), length }));
     sqlite3_free(string);
     RELEASE_AND_RETURN(scope, JSValue::encode(jsString));
 }

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1,7 +1,7 @@
 import { spawnSync } from "bun";
 import { constants, Database, SQLiteError } from "bun:sqlite";
 import { describe, expect, it } from "bun:test";
-import { readdirSync, realpathSync } from "fs";
+import { readdirSync, readFileSync, realpathSync, writeFileSync } from "fs";
 import { bunEnv, bunExe, isMacOS, isMacOSVersionAtLeast, isWindows, tempDirWithFiles } from "harness";
 import { tmpdir } from "os";
 import path from "path";
@@ -1797,6 +1797,62 @@ it("decodes non-UTF-8 TEXT leniently and consistently across the 64-byte boundar
   // Valid UTF-8 short strings are unaffected.
   expect(q(Buffer.from("héllo")).get().t).toBe("héllo");
   expect(q(Buffer.from("👋")).get().t).toBe("👋");
+
+  db.close();
+});
+
+it("decodes non-UTF-8 column names leniently instead of dropping the column", () => {
+  // SQLite does not validate UTF-8 in identifiers, so a database created by an
+  // external tool can have a column name containing raw non-UTF-8 bytes. The
+  // column-name decoder used strict fromUTF8, which returns a null string on any
+  // invalid byte; two such names then both collapsed to "" and collided, silently
+  // dropping one column from every row (and tripping a null-AtomString assertion
+  // in debug builds). Decode leniently to U+FFFD instead.
+  const file = tmpbase + `sqlite-badcols-${Date.now()}-${(Math.random() * 1e9) | 0}.db`;
+
+  const setup = new Database(file, { create: true });
+  // Distinctive, same-length ASCII names so we can binary-patch them in place.
+  setup.run(`CREATE TABLE t ("Xaa" INTEGER, "Ybb" INTEGER)`);
+  setup.run("INSERT INTO t VALUES (1, 2)");
+  setup.close();
+
+  // Replace the ASCII names inside the stored CREATE TABLE text with the same
+  // length but different invalid lead bytes (0xE9, 0xFF) so the two names decode
+  // to distinct replacement strings and must not collide.
+  const buf = readFileSync(file);
+  const patch = (find, replacement) => {
+    const at = buf.indexOf(Buffer.from(find, "latin1"));
+    expect(at).toBeGreaterThanOrEqual(0);
+    Buffer.from(replacement).copy(buf, at);
+  };
+  patch('"Xaa"', [0x22, 0x58, 0xe9, 0x61, 0x22]); // "X\xe9a"
+  patch('"Ybb"', [0x22, 0x59, 0xff, 0x62, 0x22]); // "Y\xffb"
+  writeFileSync(file, buf);
+
+  const db = new Database(file);
+  const q = db.query("SELECT * FROM t");
+  const row = q.get();
+
+  // Both columns survive with distinct, leniently-decoded names; no data is lost.
+  expect(q.columnNames).toEqual(["X\uFFFDa", "Y\uFFFDb"]);
+  expect(row).toEqual({ "X\uFFFDa": 1, "Y\uFFFDb": 2 });
+
+  db.close();
+});
+
+it("expands bound non-UTF-8 values in Statement#toString instead of returning an empty string", () => {
+  const db = new Database(":memory:");
+  const stmt = db.prepare("SELECT ? AS x");
+
+  // A lone surrogate binds via sqlite3_bind_text16 and is stored by SQLite as
+  // invalid UTF-8. sqlite3_expanded_sql() then returns those bytes, which the
+  // strict decoder turned into a null string -> the whole toString() became "".
+  stmt.get("\uD800");
+  expect(String(stmt)).toBe("SELECT '\uFFFD\uFFFD\uFFFD' AS x");
+
+  // Valid values still round-trip.
+  stmt.get("ok");
+  expect(String(stmt)).toBe("SELECT 'ok' AS x");
 
   db.close();
 });

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1773,3 +1773,30 @@ it("fileControl rejects result TypedArrays smaller than 8 bytes", () => {
 
   db.close();
 });
+
+it("decodes non-UTF-8 TEXT leniently and consistently across the 64-byte boundary", () => {
+  const db = new Database(":memory:");
+  const q = bytes => db.query(`SELECT CAST(x'${Buffer.from(bytes).toString("hex")}' AS TEXT) t`);
+
+  // Short non-UTF-8 TEXT (4 bytes, Latin-1 "José") used to be silently dropped to "".
+  // It must now decode leniently with U+FFFD, matching node:sqlite.
+  const stmt = q([0x4a, 0x6f, 0x73, 0xe9]);
+  expect(stmt.get().t).toBe("Jos�");
+  expect(stmt.all()).toEqual([{ t: "Jos�" }]);
+  expect(stmt.values()).toEqual([["Jos�"]]);
+
+  // The decoder previously switched implementations at len === 64. Verify the
+  // same invalid trailing byte yields the same replacement on both sides of
+  // that boundary so there is no length-dependent discontinuity.
+  for (const n of [1, 4, 32, 63, 64, 65, 100]) {
+    const bytes = Buffer.alloc(n, 0x61);
+    bytes[n - 1] = 0xe9;
+    expect(q(bytes).get().t).toBe(Buffer.alloc(n - 1, "a").toString() + "�");
+  }
+
+  // Valid UTF-8 short strings are unaffected.
+  expect(q(Buffer.from("héllo")).get().t).toBe("héllo");
+  expect(q(Buffer.from("👋")).get().t).toBe("👋");
+
+  db.close();
+});

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1856,3 +1856,34 @@ it("expands bound non-UTF-8 values in Statement#toString instead of returning an
 
   db.close();
 });
+
+it("decodes declared types leniently and accepts single-character declared types", () => {
+  // A single-character declared type is valid SQLite but tripped a length>1 assert
+  // (jsNontrivialString). A non-UTF-8 declared type from an externally-created DB
+  // decoded to a null string and then null-dereferenced. Both must work now.
+  const mem = new Database(":memory:");
+  mem.run(`CREATE TABLE t (a "X", b "INTEGER")`);
+  const s0 = mem.query("SELECT a, b FROM t");
+  s0.all();
+  expect(s0.declaredTypes).toEqual(["X", "INTEGER"]);
+  mem.close();
+
+  // Non-UTF-8 declared type: patch "INTQGER" -> "INT\xe9GER" in the stored schema.
+  const file = tmpbase + `sqlite-decltype-${Date.now()}-${(Math.random() * 1e9) | 0}.db`;
+  const setup = new Database(file, { create: true });
+  setup.run(`CREATE TABLE t (a "INTQGER")`);
+  setup.run("INSERT INTO t VALUES (5)");
+  setup.close();
+
+  const buf = readFileSync(file);
+  const at = buf.indexOf(Buffer.from("INTQGER", "latin1"));
+  expect(at).toBeGreaterThanOrEqual(0);
+  buf[at + 3] = 0xe9; // the "Q" -> 0xe9
+  writeFileSync(file, buf);
+
+  const db = new Database(file);
+  const s = db.query("SELECT a FROM t");
+  s.all();
+  expect(s.declaredTypes).toEqual(["INT\uFFFDGER"]);
+  db.close();
+});

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -5141,17 +5141,24 @@ describe("Unicode & Encoding Fuzzing Tests", () => {
       expect(result).toHaveLength(1);
 
       // SQLite's actual behavior with problematic Unicode:
-      // - Lone surrogates (\uD800, \uDFFF) are dropped (become empty string)
-      // - BOM inverse (\uFFFE) is dropped (becomes empty string)
-      // - Null characters are preserved (not truncated)
-      const droppedCharacters = [
-        "High surrogate (invalid alone)",
-        "Low surrogate (invalid alone)",
-        "Byte order mark inverse",
-      ];
+      // - Lone surrogates (\uD800, \uDFFF) bind via sqlite3_bind_text16 and are
+      //   stored by SQLite as invalid UTF-8 (WTF-8, e.g. ED A0 80). On read-back
+      //   those invalid bytes decode leniently to U+FFFD, matching node:sqlite.
+      // - BOM inverse (\uFFFE) is dropped by SQLite itself (stored as 0 bytes),
+      //   so it reads back as an empty string.
+      // - Null characters are preserved (not truncated).
+      const lenientlyReplaced: Record<string, string> = {
+        // 3 invalid bytes -> 3 replacement characters (maximal-subpart replacement)
+        "High surrogate (invalid alone)": "\uFFFD\uFFFD\uFFFD",
+        "Low surrogate (invalid alone)": "\uFFFD\uFFFD\uFFFD",
+      };
+      const droppedBySqlite = ["Byte order mark inverse"];
 
-      if (droppedCharacters.includes(desc)) {
-        // SQLite drops these invalid UTF-8 sequences
+      if (desc in lenientlyReplaced) {
+        // Invalid UTF-8 bytes decode leniently to U+FFFD rather than dropping the field.
+        expect(result[0].text_data).toBe(lenientlyReplaced[desc]);
+      } else if (droppedBySqlite.includes(desc)) {
+        // SQLite stores nothing for these, so they come back empty.
         expect(result[0].text_data).toBe("");
       } else {
         // All other characters should be preserved exactly, including null bytes


### PR DESCRIPTION
`bun:sqlite` returned an **empty string** (the whole field) for a non-UTF-8 `TEXT` value shorter than 64 bytes — e.g. `SELECT CAST(x'4A6F73E9' AS TEXT)` (Latin-1 "José") came back as `""` instead of `"Jos�"`. The `SQLITE3_TEXT` fast path for short strings used `WTF::String::fromUTF8`, which returns a **null** string on any invalid UTF-8 byte, and `jsString(null)` becomes `""`. The `>= 64`-byte path already decodes leniently (invalid → U+FFFD), so the two paths disagreed on identical data, with a hard discontinuity at exactly 64 bytes.

Use `WTF::String::fromUTF8ReplacingInvalidSequences` in the short-string branch so invalid bytes become U+FFFD, matching the long path (verified byte-identical across the maximal-subpart replacement classes) and node:sqlite. The fast WTF path is kept for the common valid-ASCII/UTF-8 case.

Adds a regression test sweeping a non-UTF-8 TEXT value across the 63↔64-byte boundary (no discontinuity; node:sqlite parity).
