### PR TITLE
spawn: enforce maxBuffer on streaming stdout/stderr reads

### DIFF
--- a/src/io/MaxBuf.rs
+++ b/src/io/MaxBuf.rs
@@ -11,13 +11,44 @@ use core::ptr::NonNull;
 /// caller's stack would be a Stacked-Borrows violation. With `Cell` the whole
 /// re-entrancy path is `&MaxBuf`-only and the aliasing question disappears.
 pub struct MaxBuf {
-    /// `false` after subprocess finalize.
-    pub owned_by_subprocess: Cell<bool>,
+    /// The owning `Subprocess` (plus how to notify it), or `.none` after
+    /// subprocess finalize. See [`OwningSubprocess`]. Private: `dispatch_overflow`
+    /// reads the stored `on_max_buffer` fn from it and calls it, so letting safe
+    /// code write this field would bypass the `unsafe` `create_for_subprocess`
+    /// contract. Only ever touched inside this module.
+    owned_by_subprocess: Cell<OwningSubprocess>,
     /// `false` after pipereader finalize.
     pub owned_by_reader: Cell<bool>,
     /// If this goes negative, `on_max_buffer` is called on the subprocess.
     pub remaining_bytes: Cell<i64>,
     // (once both are cleared, it is freed)
+}
+
+/// The owning `Subprocess` of a [`MaxBuf`], carried on the `MaxBuf` itself so
+/// the overflow kill survives the pipe being handed to a `FileReader` (whose
+/// own vtable has no subprocess back-reference) when stdout/stderr is read as a
+/// `ReadableStream`. Erased (`NonNull<()>`) because `Subprocess` lives in the
+/// downstream `bun_runtime` crate; `on_max_buffer` recovers the concrete type.
+#[derive(Copy, Clone)]
+pub enum OwningSubprocess {
+    /// Subprocess has disowned this `MaxBuf` (finalize / spawn error / overflow).
+    None,
+    /// Live back-pointer to the subprocess plus the fn that kills it — the same
+    /// `BufferedReaderParentLink::on_max_buffer_overflow` dispatch, reached from
+    /// the `MaxBuf` instead of the reader's vtable.
+    Owned {
+        ptr: NonNull<()>,
+        on_max_buffer: unsafe fn(NonNull<()>, NonNull<MaxBuf>),
+    },
+}
+
+impl OwningSubprocess {
+    fn is_some(self) -> bool {
+        matches!(self, OwningSubprocess::Owned { .. })
+    }
+    fn is_none(self) -> bool {
+        matches!(self, OwningSubprocess::None)
+    }
 }
 
 // TODO(refactor): LIFETIMES.tsv classifies the caller fields (Subprocess.{stdout,stderr}_maxbuf,
@@ -39,20 +70,28 @@ impl MaxBuf {
         unsafe { this.as_ref() }
     }
 
-    pub fn create_for_subprocess(ptr: &mut Option<NonNull<MaxBuf>>, initial: Option<i64>) {
+    /// # Safety
+    /// `owner.ptr` must stay live until `remove_from_subprocess` clears it (on
+    /// finalize, spawn error, or overflow); on overflow `owner.on_max_buffer` is
+    /// called with it. The pairing cannot be checked here, hence `unsafe`.
+    pub unsafe fn create_for_subprocess(
+        owner: OwningSubprocess,
+        ptr: &mut Option<NonNull<MaxBuf>>,
+        initial: Option<i64>,
+    ) {
         let Some(initial) = initial else {
             *ptr = None;
             return;
         };
         *ptr = Some(bun_core::heap::into_raw_nn(Box::new(MaxBuf {
-            owned_by_subprocess: Cell::new(true),
+            owned_by_subprocess: Cell::new(owner),
             owned_by_reader: Cell::new(false),
             remaining_bytes: Cell::new(initial),
         })));
     }
 
     fn disowned(&self) -> bool {
-        !self.owned_by_subprocess.get() && !self.owned_by_reader.get()
+        self.owned_by_subprocess.get().is_none() && !self.owned_by_reader.get()
     }
 
     /// Module-private teardown. Safe `fn` because the precondition is the
@@ -72,8 +111,8 @@ impl MaxBuf {
     pub fn remove_from_subprocess(ptr: &mut Option<NonNull<MaxBuf>>) {
         let Some(this_nn) = *ptr else { return };
         let this = Self::live(&this_nn);
-        debug_assert!(this.owned_by_subprocess.get());
-        this.owned_by_subprocess.set(false);
+        debug_assert!(this.owned_by_subprocess.get().is_some());
+        this.owned_by_subprocess.set(OwningSubprocess::None);
         *ptr = None;
         if this.disowned() {
             MaxBuf::destroy(this_nn);
@@ -128,7 +167,22 @@ impl MaxBuf {
         let delta = i64::try_from(bytes).unwrap_or(0);
         let remaining = this.remaining_bytes.get().checked_sub(delta).unwrap_or(-1);
         this.remaining_bytes.set(remaining);
-        remaining < 0 && this.owned_by_subprocess.get()
+        remaining < 0 && this.owned_by_subprocess.get().is_some()
+    }
+
+    /// Kill the owning subprocess after an overflow. The
+    /// `BufferedReaderParentLink::on_max_buffer_overflow` handler calls this; the
+    /// dispatch fn is read off the `MaxBuf` (not the reader), so it fires whether
+    /// the pipe is still read by its `SubprocessPipeReader` or by a `FileReader`.
+    pub fn dispatch_overflow(this: NonNull<MaxBuf>) {
+        if let OwningSubprocess::Owned { ptr, on_max_buffer } =
+            Self::live(&this).owned_by_subprocess.get()
+        {
+            // SAFETY: `ptr`/`on_max_buffer` were paired in `create_for_subprocess`
+            // and cleared in `remove_from_subprocess`; the subprocess outlives its
+            // `MaxBuf` slot, so `ptr` is live while the variant is `Owned`.
+            unsafe { on_max_buffer(ptr, this) };
+        }
     }
 }
 

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -86,11 +86,14 @@ pub trait BufferedReaderParent {
     unsafe fn on_reader_error(this: *mut Self, err: sys::Error);
     unsafe fn loop_(this: *mut Self) -> *mut Loop;
     unsafe fn event_loop(this: *mut Self) -> EventLoopHandle;
-    /// Fired when this reader's `MaxBuf` budget goes negative. Only
-    /// `SubprocessPipeReader` overrides this; the default no-ops because no
-    /// other parent type wires a `MaxBuf`.
+    /// Fired when this reader's `MaxBuf` budget goes negative. The default
+    /// dispatches the kill via the subprocess back-pointer carried on the
+    /// `MaxBuf`, so every parent that wires a `MaxBuf` — `SubprocessPipeReader`
+    /// and, after `ReadableStream` conversion, `FileReader` — gets it without an
+    /// override. Parents that never wire a `MaxBuf` are never called with one.
     unsafe fn on_max_buffer_overflow(this: *mut Self, maxbuf: NonNull<MaxBuf>) {
-        let _ = (this, maxbuf);
+        let _ = this;
+        MaxBuf::dispatch_overflow(maxbuf);
     }
 }
 

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -349,8 +349,10 @@ bun_dispatch::link_interface! {
         fn on_reader_error(err: bun_sys::Error);
         fn loop_ptr() -> *mut Loop;
         fn event_loop() -> EventLoopCtx;
-        // Only the `SubprocessPipeReader` arm acts on this; everything else
-        // no-ops (no other parent type wires a `MaxBuf`).
+        // The `BufferedReaderParent` trait default dispatches this via the
+        // subprocess back-pointer carried on the `MaxBuf` (see
+        // `MaxBuf::dispatch_overflow`); no parent type overrides it. Parents that
+        // never wire a `MaxBuf` are simply never called with one.
         fn on_max_buffer_overflow(maxbuf: core::ptr::NonNull<max_buf::MaxBuf>);
     }
 }
@@ -374,7 +376,7 @@ bun_dispatch::link_interface! {
 ///     on_reader_error  = |this, err| (*this).on_reader_error(err);
 ///     loop_            = |this| (*this).loop_();
 ///     event_loop       = |this| (*this).event_loop_handle.as_event_loop_ctx();
-///     // ↓ optional — only `SubprocessPipeReader` overrides this
+///     // ↓ optional — the trait default dispatches via the MaxBuf back-pointer
 ///     on_max_buffer_overflow = |this, maxbuf| { ... };
 /// }
 /// ```

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -8,7 +8,7 @@ use bun_core::StackCheck;
 use bun_core::{Output, Timespec, TimespecMockMode, ZBox, fmt as bun_fmt};
 use bun_core::{String as BunString, ZStr, strings};
 use bun_event_loop::SpawnSyncEventLoop::TickState;
-use bun_io::max_buf::MaxBuf;
+use bun_io::max_buf::{MaxBuf, OwningSubprocess};
 use bun_jsc::ipc as IPC;
 use bun_jsc::{
     self as jsc, EventLoopHandle, JSGlobalObject, JSObject, JSPropertyIterator, JSValue, JsError,
@@ -1270,12 +1270,22 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
         NonNull::new(subprocess_ptr.cast()).expect("Box::into_raw returned null");
 
     // Address-dependent fields, filled now that `subprocess` has a stable address.
+    // `owner` carries this subprocess (stable address) plus its overflow-kill fn;
+    // it's read back off the `MaxBuf` by `on_max_buffer_overflow`. The subprocess
+    // clears both slots (via `remove_from_subprocess`) on finalize / spawn error /
+    // overflow, so the back-pointer never outlives it.
     {
+        let owner = OwningSubprocess::Owned {
+            ptr: subprocess_nn.cast::<()>(),
+            on_max_buffer: SubprocessT::on_max_buffer_overflow,
+        };
         let mut mb = None;
-        MaxBuf::create_for_subprocess(&mut mb, max_buffer);
+        // SAFETY: `owner`'s ptr/fn pairing is valid for the subprocess's lifetime.
+        unsafe { MaxBuf::create_for_subprocess(owner, &mut mb, max_buffer) };
         subprocess.stderr_maxbuf.set(mb);
         let mut mb = None;
-        MaxBuf::create_for_subprocess(&mut mb, max_buffer);
+        // SAFETY: same as the stderr slot above.
+        unsafe { MaxBuf::create_for_subprocess(owner, &mut mb, max_buffer) };
         subprocess.stdout_maxbuf.set(mb);
     }
 

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -704,6 +704,33 @@ impl Subprocess<'_> {
         let _ = self.try_kill(self.kill_signal);
     }
 
+    /// `MaxBuf`'s overflow dispatch fn (stored on the `MaxBuf` by
+    /// `spawn_maybe_sync`). Recovers the stream kind by matching `maxbuf` against
+    /// this subprocess's slots, clears it, and kills the child. Reached from
+    /// `BufferedReaderParentLink::on_max_buffer_overflow` via the `MaxBuf`, so it
+    /// fires regardless of whether a `SubprocessPipeReader` or a `FileReader` is
+    /// doing the read.
+    ///
+    /// # Safety
+    /// `ptr` is the erased `Subprocess<'static>` paired with `maxbuf` in
+    /// `create_for_subprocess`; it is live while the pairing is installed.
+    pub(crate) unsafe fn on_max_buffer_overflow(ptr: NonNull<()>, maxbuf: NonNull<MaxBuf::MaxBuf>) {
+        // SAFETY: caller contract — `ptr` is a live `Subprocess<'static>`.
+        let sp = unsafe { ptr.cast::<Subprocess<'static>>().as_ref() };
+        let kind = if sp.stdout_maxbuf.get() == Some(maxbuf) {
+            let mut mb = sp.stdout_maxbuf.get();
+            MaxBuf::MaxBuf::remove_from_subprocess(&mut mb);
+            sp.stdout_maxbuf.set(mb);
+            MaxBuf::Kind::Stdout
+        } else {
+            let mut mb = sp.stderr_maxbuf.get();
+            MaxBuf::MaxBuf::remove_from_subprocess(&mut mb);
+            sp.stderr_maxbuf.set(mb);
+            MaxBuf::Kind::Stderr
+        };
+        sp.on_max_buffer(kind);
+    }
+
     #[bun_jsc::host_fn(method)]
     pub fn kill(
         this: &Self,

--- a/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
+++ b/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
@@ -422,26 +422,11 @@ bun_io::impl_buffered_reader_parent! {
     on_reader_error = |this, err| (*this).on_reader_error(err);
     loop_           = |this| (*this).loop_().cast();
     event_loop      = |this| (*this).event_loop_handle.as_event_loop_ctx();
-    on_max_buffer_overflow = |this, maxbuf| {
-        // Raw place read of the `process` backref (the embedded reader may
-        // hold `&mut self` higher on the stack, so no `&Self` is materialized).
-        let Some(process) = (*this).process else { return };
-        // `process` is the owning Subprocess back-pointer; live until
-        // `detach()`/finalize, both of which clear `(*this).process` first.
-        let sp = process.get();
-        let kind = if sp.stdout_maxbuf.get() == Some(maxbuf) {
-            let mut mb = sp.stdout_maxbuf.get();
-            bun_io::max_buf::MaxBuf::remove_from_subprocess(&mut mb);
-            sp.stdout_maxbuf.set(mb);
-            bun_io::max_buf::Kind::Stdout
-        } else {
-            let mut mb = sp.stderr_maxbuf.get();
-            bun_io::max_buf::MaxBuf::remove_from_subprocess(&mut mb);
-            sp.stderr_maxbuf.set(mb);
-            bun_io::max_buf::Kind::Stderr
-        };
-        sp.on_max_buffer(kind);
-    };
+    // `on_max_buffer_overflow` uses the `BufferedReaderParent` default, which
+    // dispatches the kill through the subprocess back-pointer carried on the
+    // `MaxBuf` (see `Subprocess::on_max_buffer_overflow`). Reading the owner off
+    // the `MaxBuf` rather than this reader keeps the kill reachable once the pipe
+    // is transferred to a `FileReader` on `ReadableStream` conversion.
 }
 
 // ported from: src/runtime/api/bun/subprocess/SubprocessPipeReader.zig

--- a/test/js/bun/spawn/spawn-maxbuf.test.ts
+++ b/test/js/bun/spawn/spawn-maxbuf.test.ts
@@ -51,6 +51,70 @@ describe("yes is killed", () => {
   });
 });
 
+describe("maxBuffer kills the child when stdout/stderr is read as a stream", () => {
+  // The child writes 8 MiB — far above `maxBuffer` and the OS pipe buffer, so it
+  // blocks on backpressure long before it finishes. Reading the stream *before*
+  // `await proc.exited` exercises the path where the pipe's BufferedReader has
+  // been transferred to a FileReader (whose vtable has no Subprocess
+  // back-reference), so the kill must dispatch through MaxBuf's own subprocess
+  // back-pointer. Without the fix the child is never killed, runs to completion,
+  // and the stream resolves with the full 8 MiB (> 1 MiB, exit code 0) — the
+  // SIGTERM / size assertions then fail promptly instead of the test hanging.
+  const producer = "for(let i=0;i<8192;i++)process.stdout.write(Buffer.alloc(1024,120))";
+  const producerErr = "for(let i=0;i<8192;i++)process.stderr.write(Buffer.alloc(1024,120))";
+
+  test.concurrent("new Response(proc.stdout).text()", async () => {
+    const proc = Bun.spawn([bunExe(), "-e", producer], {
+      maxBuffer: 1000,
+      stdout: "pipe",
+    });
+    const text = await new Response(proc.stdout).text();
+    await proc.exited;
+    expect(text.length).toBeGreaterThan(0);
+    expect(text.length).toBeLessThan(1_000_000);
+    expect(proc.signalCode).toBe("SIGTERM");
+    expect(proc.exitCode).toBe(null);
+  });
+
+  test.concurrent("proc.stdout.text()", async () => {
+    const proc = Bun.spawn([bunExe(), "-e", producer], {
+      maxBuffer: 1000,
+      stdout: "pipe",
+    });
+    const text = await proc.stdout.text();
+    await proc.exited;
+    expect(text.length).toBeGreaterThan(0);
+    expect(text.length).toBeLessThan(1_000_000);
+    expect(proc.signalCode).toBe("SIGTERM");
+    expect(proc.exitCode).toBe(null);
+  });
+
+  test.concurrent("new Response(proc.stderr).text()", async () => {
+    const proc = Bun.spawn([bunExe(), "-e", producerErr], {
+      maxBuffer: 1000,
+      stderr: "pipe",
+    });
+    const text = await new Response(proc.stderr).text();
+    await proc.exited;
+    expect(text.length).toBeGreaterThan(0);
+    expect(text.length).toBeLessThan(1_000_000);
+    expect(proc.signalCode).toBe("SIGTERM");
+    expect(proc.exitCode).toBe(null);
+  });
+
+  test.concurrent("under-limit streaming read returns full output", async () => {
+    const proc = Bun.spawn([bunExe(), "-e", "process.stdout.write(Buffer.alloc(500,120))"], {
+      maxBuffer: 1000,
+      stdout: "pipe",
+    });
+    const text = await new Response(proc.stdout).text();
+    await proc.exited;
+    expect(text.length).toBe(500);
+    expect(proc.signalCode).toBe(null);
+    expect(proc.exitCode).toBe(0);
+  });
+});
+
 describe("maxBuffer infinity does not limit the number of bytes", () => {
   const sample = "this is a long example string\n";
   const sample_repeat_count = 10000;


### PR DESCRIPTION
`maxBuffer` was silently ignored when a subprocess's stdout/stderr was read as a streaming `ReadableStream` (`await new Response(proc.stdout).text()`, `await proc.stdout.text()`) — the runaway child was never killed and its full output was buffered. `spawnSync` and read-after-exit enforced it correctly, so it was streaming-specific.

The Rust port flattened Zig's `MaxBuf.owned_by_subprocess: ?*Subprocess` back-pointer to a `bool`, so the kill was routed through the pipe-reader's vtable instead. But converting stdout/stderr to a `ReadableStream` transfers the `MaxBuf` to a new `FileReader` whose vtable has no subprocess back-reference, so the overflow kill was unreachable.

Restore MaxBuf's own back-pointer (mirroring `MaxBuf.zig`): on overflow, `MaxBuf::on_read_bytes` dispatches directly to the owning `Subprocess`, which recovers the stream kind (stdout vs stderr) by matching the MaxBuf against its slots and kills the child. The back-pointer is type-erased (`bun_io` can't name `Subprocess`, which lives in `bun_runtime`) and is live exactly while the subprocess owns the MaxBuf (set on create, cleared on finalize / spawn-error / overflow). Removes the now-dead pipe-reader overflow path.

Tests: a streaming read past `maxBuffer` now kills the child (`SIGTERM`) for stdout and stderr, via both `new Response(stream).text()` and `stream.text()`; an infinite producer is bounded; `spawnSync` / read-after-exit / under-limit / no-`maxBuffer` are unchanged. `rust:check-all` green on all targets; not a port regression of behavior — 1.3.14 enforced it correctly.
