### PR TITLE
http: detect the zlib header for deflate responses instead of testing one byte

### DIFF
--- a/src/http/Decompressor.rs
+++ b/src/http/Decompressor.rs
@@ -59,6 +59,17 @@ unsafe fn seat<'a>(input: &'a [u8], out: &'a mut Vec<u8>) -> (&'static [u8], &'s
 /// an unbounded allocation.
 const MAX_DECOMPRESSED_BODY_SIZE: usize = 1024 * 1024 * 1024;
 
+/// Whether `buffer` starts with an RFC1950 zlib header (zlib-wrapped deflate),
+/// as opposed to raw deflate. A valid header is CMF/FLG where CMF has CM=8 in
+/// the low nibble and CINFO 0..=7 in the high nibble, and `(CMF << 8 | FLG)` is
+/// a multiple of 31 — covering every window from 256 B to 32 KiB.
+fn has_zlib_header(buffer: &[u8]) -> bool {
+    buffer.len() >= 2
+        && (buffer[0] & 0x0f) == 8
+        && (buffer[0] >> 4) <= 7
+        && (((buffer[0] as u16) << 8) | buffer[1] as u16).is_multiple_of(31)
+}
+
 impl Decompressor {
     // PORT NOTE: Zig `deinit` called `that.deinit()` on the active reader and
     // reset to `.none`. The boxed readers' `Drop` impls call `end()`, so an
@@ -88,24 +99,11 @@ impl Decompressor {
                         // PORT NOTE: Zig passed `body_out_str.allocator` and
                         // `bun.http.default_allocator`; dropped per §Allocators.
                         bun_zlib::Options {
-                            // zlib.MAX_WBITS = 15
-                            // to (de-)compress raw deflate, use wbits = -zlib.MAX_WBITS
-                            // to (de-)compress zlib-wrapped deflate (RFC1950), use wbits = 0 (inflate reads CINFO from the header)
-                            // to (de-)compress gzip format, use wbits = zlib.MAX_WBITS | 16
+                            // gzip: MAX_WBITS | 16. zlib-wrapped deflate: 0 (inflate
+                            // reads the window from the header). Raw deflate: -MAX_WBITS.
                             window_bits: if encoding == Encoding::Gzip {
                                 bun_zlib::MAX_WBITS | 16
-                            } else if buffer.len() >= 2
-                                && (buffer[0] & 0x0f) == 8
-                                && (buffer[0] >> 4) <= 7
-                                && (((buffer[0] as u16) << 8) | buffer[1] as u16) % 31 == 0
-                            {
-                                // RFC1950 §2.2: CMF byte has CM=8 (deflate) in the low nibble and
-                                // CINFO (log₂ window size - 8) in the high nibble; CINFO 0..=7
-                                // covers all valid windows (256 B .. 32 KiB), and (CMF<<8 | FLG)
-                                // is a multiple of 31. Testing only `buffer[0] == 0x78` (the old
-                                // check) misses CINFO 0..6 — servers that compress with a window
-                                // smaller than 32 KiB — so those bodies were sent through raw
-                                // inflate and rejected as Z_DATA_ERROR.
+                            } else if has_zlib_header(buffer) {
                                 0
                             } else {
                                 -bun_zlib::MAX_WBITS

--- a/src/http/Decompressor.rs
+++ b/src/http/Decompressor.rs
@@ -89,12 +89,23 @@ impl Decompressor {
                         // `bun.http.default_allocator`; dropped per §Allocators.
                         bun_zlib::Options {
                             // zlib.MAX_WBITS = 15
-                            // to (de-)compress deflate format, use wbits = -zlib.MAX_WBITS
-                            // to (de-)compress deflate format with headers we use wbits = 0 (we can detect the first byte using 120)
+                            // to (de-)compress raw deflate, use wbits = -zlib.MAX_WBITS
+                            // to (de-)compress zlib-wrapped deflate (RFC1950), use wbits = 0 (inflate reads CINFO from the header)
                             // to (de-)compress gzip format, use wbits = zlib.MAX_WBITS | 16
                             window_bits: if encoding == Encoding::Gzip {
                                 bun_zlib::MAX_WBITS | 16
-                            } else if buffer.len() > 1 && buffer[0] == 120 {
+                            } else if buffer.len() >= 2
+                                && (buffer[0] & 0x0f) == 8
+                                && (buffer[0] >> 4) <= 7
+                                && (((buffer[0] as u16) << 8) | buffer[1] as u16) % 31 == 0
+                            {
+                                // RFC1950 §2.2: CMF byte has CM=8 (deflate) in the low nibble and
+                                // CINFO (log₂ window size - 8) in the high nibble; CINFO 0..=7
+                                // covers all valid windows (256 B .. 32 KiB), and (CMF<<8 | FLG)
+                                // is a multiple of 31. Testing only `buffer[0] == 0x78` (the old
+                                // check) misses CINFO 0..6 — servers that compress with a window
+                                // smaller than 32 KiB — so those bodies were sent through raw
+                                // inflate and rejected as Z_DATA_ERROR.
                                 0
                             } else {
                                 -bun_zlib::MAX_WBITS

--- a/src/http/Decompressor.rs
+++ b/src/http/Decompressor.rs
@@ -60,7 +60,9 @@ unsafe fn seat<'a>(input: &'a [u8], out: &'a mut Vec<u8>) -> (&'static [u8], &'s
 const MAX_DECOMPRESSED_BODY_SIZE: usize = 1024 * 1024 * 1024;
 
 fn has_zlib_header(buffer: &[u8]) -> bool {
-    let &[cmf, flg, ..] = buffer else { return false };
+    let &[cmf, flg, ..] = buffer else {
+        return false;
+    };
     (cmf & 0x0f) == 8 && (cmf >> 4) <= 7 && u16::from_be_bytes([cmf, flg]).is_multiple_of(31)
 }
 

--- a/src/http/Decompressor.rs
+++ b/src/http/Decompressor.rs
@@ -59,15 +59,9 @@ unsafe fn seat<'a>(input: &'a [u8], out: &'a mut Vec<u8>) -> (&'static [u8], &'s
 /// an unbounded allocation.
 const MAX_DECOMPRESSED_BODY_SIZE: usize = 1024 * 1024 * 1024;
 
-/// Whether `buffer` starts with an RFC1950 zlib header (zlib-wrapped deflate),
-/// as opposed to raw deflate. A valid header is CMF/FLG where CMF has CM=8 in
-/// the low nibble and CINFO 0..=7 in the high nibble, and `(CMF << 8 | FLG)` is
-/// a multiple of 31 — covering every window from 256 B to 32 KiB.
 fn has_zlib_header(buffer: &[u8]) -> bool {
-    buffer.len() >= 2
-        && (buffer[0] & 0x0f) == 8
-        && (buffer[0] >> 4) <= 7
-        && (((buffer[0] as u16) << 8) | buffer[1] as u16).is_multiple_of(31)
+    let &[cmf, flg, ..] = buffer else { return false };
+    (cmf & 0x0f) == 8 && (cmf >> 4) <= 7 && u16::from_be_bytes([cmf, flg]).is_multiple_of(31)
 }
 
 impl Decompressor {
@@ -99,8 +93,6 @@ impl Decompressor {
                         // PORT NOTE: Zig passed `body_out_str.allocator` and
                         // `bun.http.default_allocator`; dropped per §Allocators.
                         bun_zlib::Options {
-                            // gzip: MAX_WBITS | 16. zlib-wrapped deflate: 0 (inflate
-                            // reads the window from the header). Raw deflate: -MAX_WBITS.
                             window_bits: if encoding == Encoding::Gzip {
                                 bun_zlib::MAX_WBITS | 16
                             } else if has_zlib_header(buffer) {

--- a/src/http/Decompressor.zig
+++ b/src/http/Decompressor.zig
@@ -28,18 +28,11 @@ pub const Decompressor = union(enum) {
                         body_out_str.allocator,
                         bun.http.default_allocator,
                         .{
-                            // zlib.MAX_WBITS = 15
-                            // to (de-)compress raw deflate, use wbits = -zlib.MAX_WBITS
-                            // to (de-)compress zlib-wrapped deflate (RFC1950), use wbits = 0 (inflate reads CINFO from the header)
-                            // to (de-)compress gzip format, use wbits = zlib.MAX_WBITS | 16
+                            // gzip: MAX_WBITS | 16. zlib-wrapped deflate: 0 (inflate
+                            // reads the window from the header). Raw deflate: -MAX_WBITS.
                             .windowBits = if (encoding == Encoding.gzip)
                                 Zlib.MAX_WBITS | 16
-                            else if (buffer.len >= 2 and
-                                (buffer[0] & 0x0f) == 8 and
-                                (buffer[0] >> 4) <= 7 and
-                                ((@as(u16, buffer[0]) << 8) | @as(u16, buffer[1])) % 31 == 0)
-                                // RFC1950 §2.2: CM=8, CINFO 0..=7, (CMF<<8 | FLG) % 31 == 0.
-                                // Testing only buffer[0] == 0x78 missed CINFO 0..6 (windows < 32 KiB).
+                            else if (hasZlibHeader(buffer))
                                 0
                             else
                                 -Zlib.MAX_WBITS,
@@ -119,6 +112,17 @@ pub const Decompressor = union(enum) {
         }
     }
 };
+
+/// Whether `buffer` starts with an RFC1950 zlib header (zlib-wrapped deflate),
+/// as opposed to raw deflate. A valid header is CMF/FLG where CMF has CM=8 in
+/// the low nibble and CINFO 0..=7 in the high nibble, and (CMF << 8 | FLG) is a
+/// multiple of 31 — covering every window from 256 B to 32 KiB.
+fn hasZlibHeader(buffer: []const u8) bool {
+    return buffer.len >= 2 and
+        (buffer[0] & 0x0f) == 8 and
+        (buffer[0] >> 4) <= 7 and
+        ((@as(u16, buffer[0]) << 8) | @as(u16, buffer[1])) % 31 == 0;
+}
 
 const Zlib = @import("../zlib/zlib.zig");
 const Encoding = @import("../http_types/Encoding.zig").Encoding;

--- a/src/http/Decompressor.zig
+++ b/src/http/Decompressor.zig
@@ -29,10 +29,20 @@ pub const Decompressor = union(enum) {
                         bun.http.default_allocator,
                         .{
                             // zlib.MAX_WBITS = 15
-                            // to (de-)compress deflate format, use wbits = -zlib.MAX_WBITS
-                            // to (de-)compress deflate format with headers we use wbits = 0 (we can detect the first byte using 120)
+                            // to (de-)compress raw deflate, use wbits = -zlib.MAX_WBITS
+                            // to (de-)compress zlib-wrapped deflate (RFC1950), use wbits = 0 (inflate reads CINFO from the header)
                             // to (de-)compress gzip format, use wbits = zlib.MAX_WBITS | 16
-                            .windowBits = if (encoding == Encoding.gzip) Zlib.MAX_WBITS | 16 else (if (buffer.len > 1 and buffer[0] == 120) 0 else -Zlib.MAX_WBITS),
+                            .windowBits = if (encoding == Encoding.gzip)
+                                Zlib.MAX_WBITS | 16
+                            else if (buffer.len >= 2 and
+                                (buffer[0] & 0x0f) == 8 and
+                                (buffer[0] >> 4) <= 7 and
+                                ((@as(u16, buffer[0]) << 8) | @as(u16, buffer[1])) % 31 == 0)
+                                // RFC1950 §2.2: CM=8, CINFO 0..=7, (CMF<<8 | FLG) % 31 == 0.
+                                // Testing only buffer[0] == 0x78 missed CINFO 0..6 (windows < 32 KiB).
+                                0
+                            else
+                                -Zlib.MAX_WBITS,
                         },
                     );
                     this.* = .{ .zlib = reader };

--- a/src/http/Decompressor.zig
+++ b/src/http/Decompressor.zig
@@ -28,8 +28,6 @@ pub const Decompressor = union(enum) {
                         body_out_str.allocator,
                         bun.http.default_allocator,
                         .{
-                            // gzip: MAX_WBITS | 16. zlib-wrapped deflate: 0 (inflate
-                            // reads the window from the header). Raw deflate: -MAX_WBITS.
                             .windowBits = if (encoding == Encoding.gzip)
                                 Zlib.MAX_WBITS | 16
                             else if (hasZlibHeader(buffer))
@@ -113,10 +111,6 @@ pub const Decompressor = union(enum) {
     }
 };
 
-/// Whether `buffer` starts with an RFC1950 zlib header (zlib-wrapped deflate),
-/// as opposed to raw deflate. A valid header is CMF/FLG where CMF has CM=8 in
-/// the low nibble and CINFO 0..=7 in the high nibble, and (CMF << 8 | FLG) is a
-/// multiple of 31 — covering every window from 256 B to 32 KiB.
 fn hasZlibHeader(buffer: []const u8) bool {
     return buffer.len >= 2 and
         (buffer[0] & 0x0f) == 8 and

--- a/test/js/web/fetch/fetch.stream.test.ts
+++ b/test/js/web/fetch/fetch.stream.test.ts
@@ -180,6 +180,33 @@ describe.concurrent("fetch() with streaming", () => {
     }
   });
 
+  it.each([9, 10, 11, 12, 13, 14, 15])(
+    "decodes a Content-Encoding: deflate body compressed with a %i-bit window",
+    async windowBits => {
+      // RFC1950: the zlib CMF byte is CM=8 | CINFO<<4, so a window smaller than
+      // 32 KiB has CMF != 0x78 (e.g. 0x18 for windowBits=9). Bun used to detect
+      // a zlib header by testing buffer[0] == 0x78 only, so these bodies were
+      // sent through raw inflate and rejected as ZlibError.
+      const original = Buffer.alloc(17 * 1024, "abcdefghijklmnop");
+      const compressed = zlib.deflateSync(original, { windowBits });
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response(compressed, {
+            headers: {
+              "Content-Type": "application/octet-stream",
+              "Content-Encoding": "deflate",
+              "Content-Length": String(compressed.length),
+            },
+          });
+        },
+      });
+      const res = await fetch(server.url);
+      const got = Buffer.from(await res.arrayBuffer());
+      expect(got.equals(original)).toBe(true);
+    },
+  );
+
   for (let file of files) {
     it("stream can handle response.body + await response.something() #4500", async () => {
       let server: ReturnType<typeof http.createServer> | null = null;

--- a/test/js/web/fetch/fetch.stream.test.ts
+++ b/test/js/web/fetch/fetch.stream.test.ts
@@ -183,10 +183,7 @@ describe.concurrent("fetch() with streaming", () => {
   it.each([9, 10, 11, 12, 13, 14, 15])(
     "decodes a Content-Encoding: deflate body compressed with a %i-bit window",
     async windowBits => {
-      // RFC1950: the zlib CMF byte is CM=8 | CINFO<<4, so a window smaller than
-      // 32 KiB has CMF != 0x78 (e.g. 0x18 for windowBits=9). Bun used to detect
-      // a zlib header by testing buffer[0] == 0x78 only, so these bodies were
-      // sent through raw inflate and rejected as ZlibError.
+      // A <32 KiB window makes CMF != 0x78, which Bun used to misread as raw deflate and reject.
       const original = Buffer.alloc(17 * 1024, "abcdefghijklmnop");
       const compressed = zlib.deflateSync(original, { windowBits });
       using server = Bun.serve({


### PR DESCRIPTION
`fetch()` rejected a valid `Content-Encoding: deflate` response with `ZlibError` whenever the server compressed with a window smaller than 32 KiB (`deflateSync(body, { windowBits: 9..14 })`). Node decodes these fine.

The deflate path chose zlib-vs-raw framing by testing `buffer[0] == 0x78` — but `0x78` is the zlib CMF byte only for a 32 KiB window (CINFO=7). A valid RFC1950 stream with a smaller window has CMF `0x08`..`0x68`, so it was misread as raw deflate, `inflate` hit the 2-byte zlib header as data, and returned `Z_DATA_ERROR`.

Detect a real zlib header instead: `CM=8` (deflate) in the low nibble, `CINFO 0..=7` in the high nibble, and `(CMF<<8 | FLG) % 31 == 0` (the RFC1950 check bits). This accepts every valid window and still falls back to raw deflate — and the `% 31` check also fixes the mirror case where a raw stream that happens to start with `0x78` was mis-detected as zlib.

Verified across windowBits 9–15 (matching Node), with raw deflate / gzip / br / zstd unaffected. Not a port regression — 1.3.14 has the same single-byte check; Node is the reference.
