### PR TITLE
http: match Content-Encoding/Transfer-Encoding case-insensitively and accept x-gzip

### DIFF
--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -2861,41 +2861,44 @@ pub fn handleResponseMetadata(
             },
             hashHeaderConst("Content-Encoding") => {
                 if (!this.flags.disable_decompression) {
-                    if (strings.eqlComptime(header.value, "gzip")) {
+                    // RFC 9110 §8.4.1: content codings are case-insensitive.
+                    // `x-gzip` is a registered deprecated alias of `gzip`.
+                    if (std.ascii.eqlIgnoreCase(header.value, "gzip") or std.ascii.eqlIgnoreCase(header.value, "x-gzip")) {
                         this.state.encoding = Encoding.gzip;
                         this.state.content_encoding_i = @as(u8, @truncate(header_i));
-                    } else if (strings.eqlComptime(header.value, "deflate")) {
+                    } else if (std.ascii.eqlIgnoreCase(header.value, "deflate")) {
                         this.state.encoding = Encoding.deflate;
                         this.state.content_encoding_i = @as(u8, @truncate(header_i));
-                    } else if (strings.eqlComptime(header.value, "br")) {
+                    } else if (std.ascii.eqlIgnoreCase(header.value, "br")) {
                         this.state.encoding = Encoding.brotli;
                         this.state.content_encoding_i = @as(u8, @truncate(header_i));
-                    } else if (strings.eqlComptime(header.value, "zstd")) {
+                    } else if (std.ascii.eqlIgnoreCase(header.value, "zstd")) {
                         this.state.encoding = Encoding.zstd;
                         this.state.content_encoding_i = @as(u8, @truncate(header_i));
                     }
                 }
             },
             hashHeaderConst("Transfer-Encoding") => {
-                if (strings.eqlComptime(header.value, "gzip")) {
+                // RFC 9112 §7: transfer-coding names are case-insensitive.
+                if (std.ascii.eqlIgnoreCase(header.value, "gzip") or std.ascii.eqlIgnoreCase(header.value, "x-gzip")) {
                     if (!this.flags.disable_decompression) {
                         this.state.transfer_encoding = Encoding.gzip;
                     }
-                } else if (strings.eqlComptime(header.value, "deflate")) {
+                } else if (std.ascii.eqlIgnoreCase(header.value, "deflate")) {
                     if (!this.flags.disable_decompression) {
                         this.state.transfer_encoding = Encoding.deflate;
                     }
-                } else if (strings.eqlComptime(header.value, "br")) {
+                } else if (std.ascii.eqlIgnoreCase(header.value, "br")) {
                     if (!this.flags.disable_decompression) {
                         this.state.transfer_encoding = .brotli;
                     }
-                } else if (strings.eqlComptime(header.value, "zstd")) {
+                } else if (std.ascii.eqlIgnoreCase(header.value, "zstd")) {
                     if (!this.flags.disable_decompression) {
                         this.state.transfer_encoding = .zstd;
                     }
-                } else if (strings.eqlComptime(header.value, "identity")) {
+                } else if (std.ascii.eqlIgnoreCase(header.value, "identity")) {
                     this.state.transfer_encoding = Encoding.identity;
-                } else if (strings.eqlComptime(header.value, "chunked")) {
+                } else if (std.ascii.eqlIgnoreCase(header.value, "chunked")) {
                     this.state.transfer_encoding = Encoding.chunked;
                 } else {
                     return error.UnsupportedTransferEncoding;

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4396,16 +4396,23 @@ impl<'a> HTTPClient<'a> {
                 }
                 h if h == hash_header_const(b"Content-Encoding") => {
                     if !self.flags.disable_decompression {
-                        if header.value() == b"gzip" {
+                        // RFC 9110 §8.4.1: content codings are case-insensitive.
+                        // `x-gzip` is a registered deprecated alias of `gzip`.
+                        let value = header.value();
+                        if strings::eql_case_insensitive_ascii_check_length(value, b"gzip")
+                            || strings::eql_case_insensitive_ascii_check_length(value, b"x-gzip")
+                        {
                             self.state.encoding = Encoding::Gzip;
                             self.state.content_encoding_i = header_i as u8;
-                        } else if header.value() == b"deflate" {
+                        } else if strings::eql_case_insensitive_ascii_check_length(
+                            value, b"deflate",
+                        ) {
                             self.state.encoding = Encoding::Deflate;
                             self.state.content_encoding_i = header_i as u8;
-                        } else if header.value() == b"br" {
+                        } else if strings::eql_case_insensitive_ascii_check_length(value, b"br") {
                             self.state.encoding = Encoding::Brotli;
                             self.state.content_encoding_i = header_i as u8;
-                        } else if header.value() == b"zstd" {
+                        } else if strings::eql_case_insensitive_ascii_check_length(value, b"zstd") {
                             self.state.encoding = Encoding::Zstd;
                             self.state.content_encoding_i = header_i as u8;
                         }
@@ -4421,25 +4428,29 @@ impl<'a> HTTPClient<'a> {
                     {
                         continue;
                     }
-                    if header.value() == b"gzip" {
+                    // RFC 9112 §7: transfer-coding names are case-insensitive.
+                    let value = header.value();
+                    if strings::eql_case_insensitive_ascii_check_length(value, b"gzip")
+                        || strings::eql_case_insensitive_ascii_check_length(value, b"x-gzip")
+                    {
                         if !self.flags.disable_decompression {
                             self.state.transfer_encoding = Encoding::Gzip;
                         }
-                    } else if header.value() == b"deflate" {
+                    } else if strings::eql_case_insensitive_ascii_check_length(value, b"deflate") {
                         if !self.flags.disable_decompression {
                             self.state.transfer_encoding = Encoding::Deflate;
                         }
-                    } else if header.value() == b"br" {
+                    } else if strings::eql_case_insensitive_ascii_check_length(value, b"br") {
                         if !self.flags.disable_decompression {
                             self.state.transfer_encoding = Encoding::Brotli;
                         }
-                    } else if header.value() == b"zstd" {
+                    } else if strings::eql_case_insensitive_ascii_check_length(value, b"zstd") {
                         if !self.flags.disable_decompression {
                             self.state.transfer_encoding = Encoding::Zstd;
                         }
-                    } else if header.value() == b"identity" {
+                    } else if strings::eql_case_insensitive_ascii_check_length(value, b"identity") {
                         self.state.transfer_encoding = Encoding::Identity;
-                    } else if header.value() == b"chunked" {
+                    } else if strings::eql_case_insensitive_ascii_check_length(value, b"chunked") {
                         self.state.transfer_encoding = Encoding::Chunked;
                     } else {
                         return Err(err!(UnsupportedTransferEncoding));

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -1,6 +1,9 @@
 import { Socket } from "bun";
-import { beforeAll, expect, it } from "bun:test";
+import { beforeAll, describe, expect, it } from "bun:test";
 import { gcTick } from "harness";
+import { once } from "node:events";
+import { createServer } from "node:http";
+import { brotliCompressSync, deflateSync, gzipSync, zstdCompressSync } from "node:zlib";
 import path from "path";
 
 const gzipped = path.join(import.meta.dir, "fixture.html.gz");
@@ -118,6 +121,74 @@ it("fetch() with a gzip response works (one chunk, streamed, with a delay)", asy
   const res = await fetch(server.url);
   const text = (await res.text()).replace(/\r\n/g, "\n");
   expect(text).toEqual(htmlText);
+});
+
+// RFC 9110 §8.4.1: content codings are case-insensitive. `x-gzip` is a
+// registered deprecated alias of `gzip`. Node/undici lowercase the
+// Content-Encoding value before matching and accept `x-gzip`; we must too,
+// otherwise res.text()/res.json() silently return raw compressed bytes.
+describe("fetch() decodes Content-Encoding case-insensitively", () => {
+  const payload = JSON.stringify({ hello: "world", n: 42 });
+  const bodies = {
+    gzip: gzipSync(payload),
+    deflate: deflateSync(payload),
+    br: brotliCompressSync(payload),
+    zstd: zstdCompressSync(payload),
+  };
+  // [Content-Encoding header value as sent on the wire, compressor]
+  const cases: Array<[string, keyof typeof bodies]> = [
+    ["gzip", "gzip"],
+    ["GZIP", "gzip"],
+    ["Gzip", "gzip"],
+    ["x-gzip", "gzip"],
+    ["X-Gzip", "gzip"],
+    ["X-GZIP", "gzip"],
+    ["deflate", "deflate"],
+    ["Deflate", "deflate"],
+    ["DEFLATE", "deflate"],
+    ["br", "br"],
+    ["BR", "br"],
+    ["Br", "br"],
+    ["zstd", "zstd"],
+    ["ZSTD", "zstd"],
+    ["Zstd", "zstd"],
+  ];
+
+  it.each(cases)("Content-Encoding: %s", async (enc, kind) => {
+    // Use node:http so the header value reaches the wire exactly as written.
+    const server = createServer((req, res) => {
+      res.setHeader("Content-Encoding", enc);
+      res.setHeader("Content-Type", "application/json");
+      res.end(bodies[kind]);
+    });
+    await once(server.listen(0), "listening");
+    try {
+      const { port } = server.address() as import("node:net").AddressInfo;
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      expect(res.status).toBe(200);
+      // Must be the decoded JSON, not the raw compressed bytes.
+      expect(await res.json()).toEqual({ hello: "world", n: 42 });
+    } finally {
+      server.close();
+    }
+  });
+
+  it("unknown Content-Encoding still passes through untouched", async () => {
+    const server = createServer((req, res) => {
+      res.setHeader("Content-Encoding", "foobar");
+      res.setHeader("Content-Type", "text/plain");
+      res.end("plain-text-body");
+    });
+    await once(server.listen(0), "listening");
+    try {
+      const { port } = server.address() as import("node:net").AddressInfo;
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("plain-text-body");
+    } finally {
+      server.close();
+    }
+  });
 });
 
 it("fetch() with a gzip response works (multiple chunks, TCP server)", async done => {


### PR DESCRIPTION
A response whose `Content-Encoding` wasn't exactly lowercase — `GZIP`, `Gzip`, `X-Gzip`, the legacy `x-gzip` alias — was handed to JS **still compressed**: the four codings were matched with case-sensitive byte equality, so any other casing fell through, the encoding was never set, and `res.text()`/`res.json()` saw the raw gzip bytes (`status: 200`, no error). RFC 9110 §8.4.1 requires content codings be compared case-insensitively, and `x-gzip` is a registered alias of `gzip`.

Compare the `Content-Encoding` (and `Transfer-Encoding`) values case-insensitively — using the same `eql_case_insensitive_ascii_check_length` helper this function already uses for the `Connection` header — and accept `x-gzip`. Verified against undici that only `x-gzip` is an alias Node honors (not `x-deflate`/`x-compress`), so those are deliberately left out. Unknown encodings still pass through untouched.

Now decodes all casings of gzip/deflate/br/zstd + `x-gzip` (matching Node), covered by 21 fetch-gzip tests. Not a port regression — 1.3.14 has the same case-sensitive match; Node is the reference.
