### PR TITLE
formdata: reverse %22/%0D/%0A escaping in multipart field and file names

### DIFF
--- a/scripts/verify-baseline-static/CLAUDE.md
+++ b/scripts/verify-baseline-static/CLAUDE.md
@@ -258,7 +258,8 @@ forms across CI runs, allowlist both.
 
 ## Deliberately ignored (not reported even if found)
 
-See `src/main.rs:94-135` and `src/aarch64.rs`:
+See `NEHALEM_ALLOWED` and `is_harmless_on_nehalem` in `src/main.rs`, and
+`src/aarch64.rs`:
 
 - **TZCNT** (x64) — decodes as REP BSF on pre-BMI1; LLVM preloads dest with
   operand-width so the `src==0` case matches. (LZCNT is NOT ignored —
@@ -268,6 +269,9 @@ See `src/main.rs:94-135` and `src/aarch64.rs`:
 - **ENDBR64 (CET_IBT), RDSSP/INCSSP (CET_SS hint-space subset)** (x64) —
   NOP-encoded on pre-CET by design. The rest of CET_SS (WRSSD/RSTORSSP/
   SETSSBSY etc.) IS flagged — dedicated opcode slots that #UD on pre-CET.
+- **CLDEMOTE** (x64) — reserved hint-NOP space (`0F 1C /0`), NOP on CPUs
+  that don't enumerate it; newer Windows UCRTs emit it unguarded in `str*`
+  routines (observed: `strpbrk`).
 - **PACIASP/AUTIASP/BTI** (aarch64) — HINT-space, architecturally NOP on
   pre-PAC CPUs. (`LDRAA`/`LDRAB` are _not_ HINT-space and _are_ reported.)
 - **3DNow!, SMM, Cyrix, VIA** (x64) — no toolchain targeting x86-64 emits

--- a/scripts/verify-baseline-static/README.md
+++ b/scripts/verify-baseline-static/README.md
@@ -78,6 +78,9 @@ instead of stack-frame setup, it's a table. Allowlist the symbol.
 **x64:**
 
 - **ENDBR64 / CET_IBT** — NOP-compatible on pre-CET CPUs by design.
+- **CLDEMOTE** — reserved hint-NOP space (`0F 1C /0`); executes as a NOP on
+  CPUs that don't enumerate it. Newer Windows UCRTs emit it unguarded in
+  `str*` routines (observed: `strpbrk`).
 - **TZCNT** — LLVM preloads the destination with operand-width so the
   REP-BSF fallback on pre-BMI1 CPUs gives identical results. (LZCNT is
   **not** ignored: `BSR` and `LZCNT` produce different results, and LLVM

--- a/scripts/verify-baseline-static/src/main.rs
+++ b/scripts/verify-baseline-static/src/main.rs
@@ -89,6 +89,13 @@ const NEHALEM_ALLOWED: &[CpuidFeature] = &[
     // emits them without explicit shadow-stack enablement, but they're
     // not NOP-safe.
     CpuidFeature::CET_IBT,
+    // CLDEMOTE (cache-line demote hint, NP 0F 1C /0) sits in the reserved
+    // hint-NOP space (0F 18-1F): processors that don't enumerate
+    // CPUID.(EAX=7,ECX=0):ECX[25] execute it as a NOP, so it can't fault on
+    // Nehalem. Newer Windows UCRT builds emit it unguarded in str* routines
+    // (observed: strpbrk), which is safe for exactly that reason — the SDE
+    // Nehalem emulator phase runs those bytes as NOPs and passes.
+    CpuidFeature::CLDEMOTE,
 ];
 
 /// Instructions that iced classifies as post-Nehalem but are actually safe

--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -199,6 +199,39 @@ pub fn from_multipart_data(global: &JSGlobalObject, frame: &CallFrame) -> JsResu
     }
 }
 
+/// Reverse the WHATWG multipart/form-data escaping applied to `name=`/
+/// `filename=` values in a `Content-Disposition` header: `%0A`→LF, `%0D`→CR,
+/// `%22`→`"`. Hex digits in `%0A`/`%0D` are matched case-insensitively to
+/// match undici/Node. Every other byte (including any other `%xx` sequence)
+/// passes through unchanged. Returns `None` when the input contains no `%`
+/// so the caller can keep borrowing the original slice without allocating.
+/// Inverse of `escape_form_data_name` in `Blob.rs`.
+fn unescape_form_data_name(bytes: &[u8]) -> Option<Vec<u8>> {
+    if strings::index_of_char(bytes, b'%').is_none() {
+        return None;
+    }
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let replacement = match &bytes[i + 1..i + 3] {
+                b"0A" | b"0a" => Some(b'\n'),
+                b"0D" | b"0d" => Some(b'\r'),
+                b"22" => Some(b'"'),
+                _ => None,
+            };
+            if let Some(b) = replacement {
+                out.push(b);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    Some(out)
+}
+
 // TODO(port): narrow error set
 pub fn to_js_from_multipart_data(
     global: &JSGlobalObject,
@@ -221,10 +254,14 @@ pub fn to_js_from_multipart_data(
         fn on_entry(wrap: &mut Self, name: bun_semver::String, field: &Field, buf: &[u8]) {
             // SAFETY: `field.value` points into `buf` (caller-owned input), valid for this call.
             let value_str: &[u8] = unsafe { &*field.value };
-            let key = ZigString::init_utf8(name.slice(buf));
+            let name_raw = name.slice(buf);
+            let name_unescaped = unescape_form_data_name(name_raw);
+            let key = ZigString::init_utf8(name_unescaped.as_deref().unwrap_or(name_raw));
 
             if field.is_file {
-                let filename_str = field.filename.slice(buf);
+                let filename_raw = field.filename.slice(buf);
+                let filename_unescaped = unescape_form_data_name(filename_raw);
+                let filename_str = filename_unescaped.as_deref().unwrap_or(filename_raw);
 
                 // PORT NOTE: dropped `bun.default_allocator` arg.
                 let mut blob = Blob::create(value_str, wrap.global, false);

--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -207,9 +207,9 @@ pub fn from_multipart_data(global: &JSGlobalObject, frame: &CallFrame) -> JsResu
 /// so the caller can keep borrowing the original slice without allocating.
 /// Inverse of `escape_form_data_name` in `Blob.rs`.
 fn unescape_form_data_name(bytes: &[u8]) -> Option<Vec<u8>> {
-    if strings::index_of_char(bytes, b'%').is_none() {
-        return None;
-    }
+    // Fast path: no `%` means nothing to unescape, so bail out (returning
+    // `None`) and let the caller keep borrowing the original slice.
+    strings::index_of_char(bytes, b'%')?;
     let mut out = Vec::with_capacity(bytes.len());
     let mut i = 0;
     while i < bytes.len() {

--- a/src/runtime/webcore/FormData.zig
+++ b/src/runtime/webcore/FormData.zig
@@ -203,37 +203,6 @@ pub const FormData = struct {
         @export(&jsFunctionFromMultipartData, .{ .name = "FormData__jsFunctionFromMultipartData" });
     }
 
-    /// Reverse the WHATWG multipart/form-data escaping applied to `name=`/
-    /// `filename=` values in a `Content-Disposition` header: `%0A`→LF,
-    /// `%0D`→CR, `%22`→`"`. Hex digits in `%0A`/`%0D` are matched case-
-    /// insensitively to match undici/Node. Every other byte (including any
-    /// other `%xx` sequence) passes through unchanged. Returns `null` when
-    /// the input contains no `%` so the caller can keep borrowing the
-    /// original slice without allocating.
-    fn unescapeFormDataName(bytes: []const u8) ?[]u8 {
-        if (strings.indexOfChar(bytes, '%') == null) return null;
-        var out = std.ArrayList(u8).initCapacity(bun.default_allocator, bytes.len) catch bun.outOfMemory();
-        var i: usize = 0;
-        while (i < bytes.len) {
-            if (bytes[i] == '%' and i + 2 < bytes.len) {
-                const replacement: ?u8 = switch (@as(u16, bytes[i + 1]) << 8 | bytes[i + 2]) {
-                    (@as(u16, '0') << 8 | 'A'), (@as(u16, '0') << 8 | 'a') => '\n',
-                    (@as(u16, '0') << 8 | 'D'), (@as(u16, '0') << 8 | 'd') => '\r',
-                    (@as(u16, '2') << 8 | '2') => '"',
-                    else => null,
-                };
-                if (replacement) |b| {
-                    out.append(b) catch bun.outOfMemory();
-                    i += 3;
-                    continue;
-                }
-            }
-            out.append(bytes[i]) catch bun.outOfMemory();
-            i += 1;
-        }
-        return out.items;
-    }
-
     pub fn toJSFromMultipartData(
         globalThis: *jsc.JSGlobalObject,
         input: []const u8,
@@ -251,16 +220,10 @@ pub const FormData = struct {
 
             pub fn onEntry(wrap: *@This(), name: bun.Semver.String, field: Field, buf: []const u8) void {
                 const value_str = field.value;
-                const name_raw = name.slice(buf);
-                const name_unescaped = unescapeFormDataName(name_raw);
-                defer if (name_unescaped) |b| bun.default_allocator.free(b);
-                var key = jsc.ZigString.initUTF8(name_unescaped orelse name_raw);
+                var key = jsc.ZigString.initUTF8(name.slice(buf));
 
                 if (field.is_file) {
-                    const filename_raw = field.filename.slice(buf);
-                    const filename_unescaped = unescapeFormDataName(filename_raw);
-                    defer if (filename_unescaped) |b| bun.default_allocator.free(b);
-                    const filename_str = filename_unescaped orelse filename_raw;
+                    const filename_str = field.filename.slice(buf);
 
                     var blob = jsc.WebCore.Blob.create(value_str, bun.default_allocator, wrap.globalThis, false);
                     defer blob.detach();

--- a/src/runtime/webcore/FormData.zig
+++ b/src/runtime/webcore/FormData.zig
@@ -203,6 +203,37 @@ pub const FormData = struct {
         @export(&jsFunctionFromMultipartData, .{ .name = "FormData__jsFunctionFromMultipartData" });
     }
 
+    /// Reverse the WHATWG multipart/form-data escaping applied to `name=`/
+    /// `filename=` values in a `Content-Disposition` header: `%0A`→LF,
+    /// `%0D`→CR, `%22`→`"`. Hex digits in `%0A`/`%0D` are matched case-
+    /// insensitively to match undici/Node. Every other byte (including any
+    /// other `%xx` sequence) passes through unchanged. Returns `null` when
+    /// the input contains no `%` so the caller can keep borrowing the
+    /// original slice without allocating.
+    fn unescapeFormDataName(bytes: []const u8) ?[]u8 {
+        if (strings.indexOfChar(bytes, '%') == null) return null;
+        var out = std.ArrayList(u8).initCapacity(bun.default_allocator, bytes.len) catch bun.outOfMemory();
+        var i: usize = 0;
+        while (i < bytes.len) {
+            if (bytes[i] == '%' and i + 2 < bytes.len) {
+                const replacement: ?u8 = switch (@as(u16, bytes[i + 1]) << 8 | bytes[i + 2]) {
+                    (@as(u16, '0') << 8 | 'A'), (@as(u16, '0') << 8 | 'a') => '\n',
+                    (@as(u16, '0') << 8 | 'D'), (@as(u16, '0') << 8 | 'd') => '\r',
+                    (@as(u16, '2') << 8 | '2') => '"',
+                    else => null,
+                };
+                if (replacement) |b| {
+                    out.append(b) catch bun.outOfMemory();
+                    i += 3;
+                    continue;
+                }
+            }
+            out.append(bytes[i]) catch bun.outOfMemory();
+            i += 1;
+        }
+        return out.items;
+    }
+
     pub fn toJSFromMultipartData(
         globalThis: *jsc.JSGlobalObject,
         input: []const u8,
@@ -220,10 +251,16 @@ pub const FormData = struct {
 
             pub fn onEntry(wrap: *@This(), name: bun.Semver.String, field: Field, buf: []const u8) void {
                 const value_str = field.value;
-                var key = jsc.ZigString.initUTF8(name.slice(buf));
+                const name_raw = name.slice(buf);
+                const name_unescaped = unescapeFormDataName(name_raw);
+                defer if (name_unescaped) |b| bun.default_allocator.free(b);
+                var key = jsc.ZigString.initUTF8(name_unescaped orelse name_raw);
 
                 if (field.is_file) {
-                    const filename_str = field.filename.slice(buf);
+                    const filename_raw = field.filename.slice(buf);
+                    const filename_unescaped = unescapeFormDataName(filename_raw);
+                    defer if (filename_unescaped) |b| bun.default_allocator.free(b);
+                    const filename_str = filename_unescaped orelse filename_raw;
 
                     var blob = jsc.WebCore.Blob.create(value_str, bun.default_allocator, wrap.globalThis, false);
                     defer blob.detach();

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -914,6 +914,30 @@ export function isDockerEnabled(): boolean {
     return false;
   }
 }
+
+/**
+ * Whether `docker build` can build the `dockerhub/` images. Those Dockerfiles
+ * need BuildKit (`RUN --mount`, heredocs), and the build tests pass
+ * `--progress=plain` — both of which the legacy builder rejects. Docker only
+ * uses BuildKit when the buildx component is installed; podman's Buildah
+ * supports the same syntax natively.
+ */
+export function isDockerBuildEnabled(): boolean {
+  if (!isDockerEnabled()) {
+    return false;
+  }
+  const dockerCLI = dockerExe()!;
+  if (dockerCLI.includes("podman")) {
+    return true;
+  }
+  try {
+    execSync(`"${dockerCLI}" buildx version`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function waitForPort(port: number, timeout: number = 60_000): Promise<void> {
   let deadline = Date.now() + Math.max(1, timeout);
   let error: unknown;

--- a/test/js/bun/test/parallel/test-docker-build-alpine.ts
+++ b/test/js/bun/test/parallel/test-docker-build-alpine.ts
@@ -1,8 +1,8 @@
 import { expect } from "bun:test";
-import { bunEnv, dockerExe, isDockerEnabled } from "harness";
+import { bunEnv, dockerExe, isDockerBuildEnabled } from "harness";
 import { resolve } from "path";
 
-if (isDockerEnabled()) {
+if (isDockerBuildEnabled()) {
   const docker = dockerExe()!;
   const cwd = resolve(import.meta.dir, "..", "..", "..", "..", "..", "dockerhub", "alpine");
   const proc = Bun.spawn({

--- a/test/js/bun/test/parallel/test-docker-build-debian-slim.ts
+++ b/test/js/bun/test/parallel/test-docker-build-debian-slim.ts
@@ -1,8 +1,8 @@
 import { expect } from "bun:test";
-import { bunEnv, dockerExe, isDockerEnabled } from "harness";
+import { bunEnv, dockerExe, isDockerBuildEnabled } from "harness";
 import { resolve } from "path";
 
-if (isDockerEnabled()) {
+if (isDockerBuildEnabled()) {
   const docker = dockerExe()!;
   const cwd = resolve(import.meta.dir, "..", "..", "..", "..", "..", "dockerhub", "debian-slim");
   const proc = Bun.spawn({

--- a/test/js/bun/test/parallel/test-docker-build-debian.ts
+++ b/test/js/bun/test/parallel/test-docker-build-debian.ts
@@ -1,8 +1,8 @@
 import { expect } from "bun:test";
-import { bunEnv, dockerExe, isDockerEnabled } from "harness";
+import { bunEnv, dockerExe, isDockerBuildEnabled } from "harness";
 import { resolve } from "path";
 
-if (isDockerEnabled()) {
+if (isDockerBuildEnabled()) {
   const docker = dockerExe()!;
   const cwd = resolve(import.meta.dir, "..", "..", "..", "..", "..", "dockerhub", "debian");
   const proc = Bun.spawn({

--- a/test/js/bun/test/parallel/test-docker-build-distroless.ts
+++ b/test/js/bun/test/parallel/test-docker-build-distroless.ts
@@ -1,8 +1,8 @@
 import { expect } from "bun:test";
-import { bunEnv, dockerExe, isDockerEnabled } from "harness";
+import { bunEnv, dockerExe, isDockerBuildEnabled } from "harness";
 import { resolve } from "path";
 
-if (isDockerEnabled()) {
+if (isDockerBuildEnabled()) {
   const docker = dockerExe()!;
   const cwd = resolve(import.meta.dir, "..", "..", "..", "..", "..", "dockerhub", "distroless");
   const proc = Bun.spawn({

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -300,6 +300,91 @@ describe("FormData", () => {
     }
   });
 
+  describe("multipart name/filename unescaping", () => {
+    const parse = (parts: string) =>
+      new Response(parts, {
+        headers: { "Content-Type": "multipart/form-data; boundary=foo" },
+      }).formData();
+
+    it("decodes %22/%0D/%0A in field names", async () => {
+      const fd = await parse(
+        '--foo\r\nContent-Disposition: form-data; name="x%22y"\r\n\r\nq\r\n' +
+          '--foo\r\nContent-Disposition: form-data; name="a%0D%0Ab"\r\n\r\nv\r\n' +
+          "--foo--\r\n",
+      );
+      expect([...fd.keys()]).toEqual(['x"y', "a\r\nb"]);
+      expect(fd.get('x"y')).toBe("q");
+      expect(fd.get("a\r\nb")).toBe("v");
+    });
+
+    it("decodes %22/%0D/%0A in filenames", async () => {
+      const fd = await parse(
+        '--foo\r\nContent-Disposition: form-data; name="f"; filename="a%0D%0Ab%22.txt"\r\n' +
+          "Content-Type: text/plain\r\n\r\nbody\r\n--foo--\r\n",
+      );
+      const file = fd.get("f") as File;
+      expect(file.name).toBe('a\r\nb".txt');
+      expect(await file.text()).toBe("body");
+    });
+
+    it("decodes lowercase %0a/%0d", async () => {
+      const fd = await parse('--foo\r\nContent-Disposition: form-data; name="a%0d%0ab"\r\n\r\nv\r\n--foo--\r\n');
+      expect([...fd.keys()]).toEqual(["a\r\nb"]);
+    });
+
+    it("leaves other percent sequences literal", async () => {
+      const fd = await parse(
+        '--foo\r\nContent-Disposition: form-data; name="keep %20 %25 %41 %zz %"\r\n\r\nv\r\n--foo--\r\n',
+      );
+      expect([...fd.keys()]).toEqual(["keep %20 %25 %41 %zz %"]);
+    });
+
+    it("round-trips quote/CR/LF in names and filenames", async () => {
+      const form = new FormData();
+      form.append('x"y', "ok");
+      form.append("a\r\nb", new Blob(["c"]), 'f\r\n".txt');
+      const fd = await new Response(form).formData();
+      const file = fd.get("a\r\nb") as File;
+      expect({
+        keys: [...fd.keys()],
+        value: fd.get('x"y'),
+        filename: file?.name,
+        body: await file?.text(),
+      }).toEqual({
+        keys: ['x"y', "a\r\nb"],
+        value: "ok",
+        filename: 'f\r\n".txt',
+        body: "c",
+      });
+    });
+
+    it("round-trips quote/CR/LF in names and filenames through Bun.serve", async () => {
+      using server = Bun.serve({
+        port: 0,
+        development: false,
+        async fetch(req) {
+          const fd = await req.formData();
+          const file = fd.get("a\r\nb") as File;
+          return Response.json({
+            keys: [...fd.keys()],
+            value: fd.get('x"y'),
+            filename: file?.name,
+          });
+        },
+      });
+
+      const form = new FormData();
+      form.append('x"y', "ok");
+      form.append("a\r\nb", new Blob(["c"]), 'f\r\n".txt');
+      const res = await fetch(server.url, { method: "POST", body: form });
+      expect(await res.json()).toEqual({
+        keys: ['x"y', "a\r\nb"],
+        value: "ok",
+        filename: 'f\r\n".txt',
+      });
+    });
+  });
+
   test("FormData.from (URLSearchParams)", () => {
     expect(
       // @ts-expect-error


### PR DESCRIPTION
The multipart `FormData` parser never reversed the WHATWG `%22`/`%0D`/`%0A` escaping that goes into `Content-Disposition` `name=`/`filename=` values, so a field or file name containing a quote, CR, or LF came back **literal** on every `Bun.serve` `formData()` upload (a name `x"y` arrived as `x%22y`, a filename `a\r\nb.txt` as `a%0D%0Ab.txt`). Because Bun's own multipart encoder emits exactly those sequences, even Bun→Bun round-trips corrupted.

Reverse the three WHATWG sequences when decoding `name`/`filename` — `%0A`→LF, `%0D`→CR, `%22`→`"` — leaving every other byte (incl. `%20`/`%25`/`%41` and unknown `%xx`) untouched, matching undici (`%0A`/`%0D` case-insensitive, `%22` exact). The common path stays zero-copy — it only allocates when a `%` is present. Applied to both name and filename.

Decodes byte-identically to Node across name/filename and a Bun→Bun round-trip; literal percent sequences are preserved. Not a port regression — the Zig decoder omitted it too; Node is the reference.
