### PR TITLE
yaml: reject tab in s-indent position before structural tokens (DK95/06, Y79Y/005, Y79Y/008 — 402/402)

### DIFF
--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -4039,15 +4039,13 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         }
                     }
 
-                    let r = self.parse_block_mapping(
+                    break 'node self.parse_block_mapping(
                         key,
                         mapping_start,
                         mapping_indent,
                         mapping_line,
                         opts.flow_pair_allowed,
-                    );
-
-                    break 'node r?;
+                    )?;
                 }
 
                 TokenData::MappingValue => {
@@ -5015,11 +5013,17 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                                 self.line_indent = indent;
                                 let nc = Enc::wide(self.next());
                                 ctx.cur_more_indented = matches!(nc, 0x20 | 0x09);
+                                if nc == 0x09 {
+                                    self.tab_after_indent = true;
+                                }
                                 __c = nc;
                                 break;
                             }
                             other => {
                                 ctx.cur_more_indented = other == 0x09;
+                                if other == 0x09 {
+                                    self.tab_after_indent = true;
+                                }
                                 __c = other;
                                 break;
                             }

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -4097,11 +4097,13 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         self.anchors
                             .put(Enc::key_bytes(mapping_anchor.slice(self.input)), mapping)?;
                     }
-                    // Only clear what was consumed: has_anchor (the inner,
-                    // registered as key_anchor or as the sole mapping_anchor
-                    // by implicit_key_anchors). has_mapping_anchor and tag
-                    // fields stay so the post-loop guards still catch
-                    // overflow (`!!a\n!!b\n: x`, `&a\n&b\n&c : x`).
+                    // Clear has_anchor so the post-loop fallback doesn't
+                    // re-register the inner anchor on the mapping. The
+                    // remaining fields reach the post-loop guards: this
+                    // matches main's behavior (rejects `!!a\n!!b\n: x` and
+                    // `&a\n&b\n&c : x`), but also over-rejects the valid
+                    // `&outer\n&inner : x` — pre-existing; the Scalar arm
+                    // avoids it via `return Ok`.
                     node_props.has_anchor = None;
                     break 'node mapping;
                 }

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -4097,7 +4097,12 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         self.anchors
                             .put(Enc::key_bytes(mapping_anchor.slice(self.input)), mapping)?;
                     }
-                    node_props = NodeProperties::default();
+                    // Only clear what was consumed: has_anchor (the inner,
+                    // registered as key_anchor or as the sole mapping_anchor
+                    // by implicit_key_anchors). has_mapping_anchor and tag
+                    // fields stay so the post-loop guards still catch
+                    // overflow (`!!a\n!!b\n: x`, `&a\n&b\n&c : x`).
+                    node_props.has_anchor = None;
                     break 'node mapping;
                 }
 

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -4037,8 +4037,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     }
                     // The properties recorded in node_props apply to the
                     // e-node key (`!!str : x` → key ""), not to the mapping.
-                    let first_key =
-                        node_props.tag().resolve_null(self.token.start.loc());
+                    let first_key = node_props.tag().resolve_null(self.token.start.loc());
                     if let Some(anchor) = node_props.anchor() {
                         self.anchors
                             .put(Enc::key_bytes(anchor.slice(self.input)), first_key)?;

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -4747,7 +4747,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     self.inc(1);
                     if Enc::wide(self.next()) == 0x09 {
                         // tab for indentation
-                        return Err(ParseError::UnexpectedCharacter);
+                        return Err(ParseError::TabIndentation);
                     }
                     return Ok((
                         indent_indicator.unwrap_or(IndentIndicator::DEFAULT),
@@ -4924,7 +4924,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     self.newline();
                     self.inc(1);
                     if Enc::wide(self.next()) == 0x09 {
-                        return Err(ParseError::UnexpectedCharacter);
+                        return Err(ParseError::TabIndentation);
                     }
                     ctx.leading_newlines += 1;
                     consumed_indent_this_line = false;
@@ -4934,7 +4934,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     self.newline();
                     self.inc(1);
                     if Enc::wide(self.next()) == 0x09 {
-                        return Err(ParseError::UnexpectedCharacter);
+                        return Err(ParseError::TabIndentation);
                     }
                     ctx.leading_newlines += 1;
                     consumed_indent_this_line = false;
@@ -5020,7 +5020,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                                 self.newline();
                                 self.inc(1);
                                 if Enc::wide(self.next()) == 0x09 {
-                                    return Err(ParseError::UnexpectedCharacter);
+                                    return Err(ParseError::TabIndentation);
                                 }
                                 continue;
                             }
@@ -5029,7 +5029,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                                 self.newline();
                                 self.inc(1);
                                 if Enc::wide(self.next()) == 0x09 {
-                                    return Err(ParseError::UnexpectedCharacter);
+                                    return Err(ParseError::TabIndentation);
                                 }
                                 continue;
                             }

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -3474,6 +3474,12 @@ impl<Enc: Encoding> NodeProperties<Enc> {
         self.has_tag.as_ref().map(|t| t.line)
     }
 
+    pub fn take_tag(&mut self) -> NodeTag {
+        let t = self.tag();
+        self.has_tag = None;
+        t
+    }
+
     pub fn tag_indent(&self) -> Option<Indent> {
         self.has_tag.as_ref().map(|t| t.indent)
     }
@@ -4061,21 +4067,39 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                             break 'node Expr::init(E::Null {}, self.token.start.loc());
                         }
                     }
-                    // The properties recorded in node_props apply to the
-                    // e-node key (`!!str : x` → key ""), not to the mapping.
-                    let first_key = node_props.tag().resolve_null(self.token.start.loc());
-                    if let Some(anchor) = node_props.anchor() {
+                    // [200]/[193] split: a property on the `:` line is the
+                    // e-node key's (`!!str : x` → key ""); on a prior line
+                    // it is the [200] block-collection's. Only the key's tag
+                    // affects resolution.
+                    let colon_line = self.token.line;
+                    let key_tag = if node_props.tag_line() == Some(colon_line) {
+                        node_props.take_tag()
+                    } else {
+                        NodeTag::None
+                    };
+                    let first_key = key_tag.resolve_null(self.token.start.loc());
+
+                    let implicit_key_anchors =
+                        node_props.implicit_key_anchors(colon_line)?;
+                    if let Some(key_anchor) = implicit_key_anchors.key_anchor {
                         self.anchors
-                            .put(Enc::key_bytes(anchor.slice(self.input)), first_key)?;
+                            .put(Enc::key_bytes(key_anchor.slice(self.input)), first_key)?;
                     }
-                    node_props = NodeProperties::default();
-                    break 'node self.parse_block_mapping(
+
+                    let mapping = self.parse_block_mapping(
                         first_key,
                         self.token.start,
                         self.token.indent,
-                        self.token.line,
+                        colon_line,
                         opts.flow_pair_allowed,
                     )?;
+
+                    if let Some(mapping_anchor) = implicit_key_anchors.mapping_anchor {
+                        self.anchors
+                            .put(Enc::key_bytes(mapping_anchor.slice(self.input)), mapping)?;
+                    }
+                    node_props = NodeProperties::default();
+                    break 'node mapping;
                 }
 
                 TokenData::Scalar(_) => {

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -4035,7 +4035,15 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                             break 'node Expr::init(E::Null {}, self.token.start.loc());
                         }
                     }
-                    let first_key = Expr::init(E::Null {}, self.token.start.loc());
+                    // The properties recorded in node_props apply to the
+                    // e-node key (`!!str : x` → key ""), not to the mapping.
+                    let first_key =
+                        node_props.tag().resolve_null(self.token.start.loc());
+                    if let Some(anchor) = node_props.anchor() {
+                        self.anchors
+                            .put(Enc::key_bytes(anchor.slice(self.input)), first_key)?;
+                    }
+                    node_props = NodeProperties::default();
                     break 'node self.parse_block_mapping(
                         first_key,
                         self.token.start,

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -4079,8 +4079,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     };
                     let first_key = key_tag.resolve_null(self.token.start.loc());
 
-                    let implicit_key_anchors =
-                        node_props.implicit_key_anchors(colon_line)?;
+                    let implicit_key_anchors = node_props.implicit_key_anchors(colon_line)?;
                     if let Some(key_anchor) = implicit_key_anchors.key_anchor {
                         self.anchors
                             .put(Enc::key_bytes(key_anchor.slice(self.input)), first_key)?;

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -3608,7 +3608,10 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         self.pos = self.token.start;
                         self.line = self.token.line;
                         self.line_indent = self.token.indent;
-                        self.tab_after_indent = false;
+                        // tab_after_indent is preserved: the original scan
+                        // recorded it for this token's leading whitespace,
+                        // and the re-scan (in_indent_position=false) won't
+                        // re-detect it since pos is already past the tab.
                         self.scan(ScanOptions::default())?;
                     }
                     return self.props_to_e_node(&value_tag, &value_anchor, indicator_start.loc());

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -773,6 +773,8 @@ pub enum ParseError {
     InvalidDirective,
     #[error("UnexpectedCharacter")]
     UnexpectedCharacter,
+    #[error("TabIndentation")]
+    TabIndentation,
     #[error("UnresolvedTagHandle")]
     UnresolvedTagHandle,
     #[error("UnresolvedAlias")]
@@ -2151,6 +2153,7 @@ pub enum ParseResultError {
     UnexpectedEof { pos: Pos },
     UnexpectedToken { pos: Pos },
     UnexpectedCharacter { pos: Pos },
+    TabIndentation { pos: Pos },
     InvalidDirective { pos: Pos },
     UnresolvedTagHandle { pos: Pos },
     UnresolvedAlias { pos: Pos },
@@ -2180,6 +2183,13 @@ impl ParseResultError {
             }
             ParseResultError::UnexpectedCharacter { pos } => {
                 log.add_error(Some(source), pos.loc(), b"Unexpected character");
+            }
+            ParseResultError::TabIndentation { pos } => {
+                log.add_error(
+                    Some(source),
+                    pos.loc(),
+                    b"Tab characters cannot be used as indentation",
+                );
             }
             ParseResultError::InvalidDirective { pos } => {
                 log.add_error(Some(source), pos.loc(), b"Invalid directive");
@@ -2229,6 +2239,9 @@ impl<Enc: Encoding> ParseResult<Enc> {
                 pos: parser.token.start,
             },
             ParseError::UnexpectedEof => ParseResultError::UnexpectedEof {
+                pos: parser.token.start,
+            },
+            ParseError::TabIndentation => ParseResultError::TabIndentation {
                 pos: parser.token.start,
             },
             ParseError::InvalidDirective => ParseResultError::InvalidDirective {
@@ -2865,7 +2878,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             {
                 // [184] each `-` sits at s-indent(n) (spaces only).
                 if self.tab_after_indent {
-                    return Err(Self::unexpected_token());
+                    return Err(ParseError::TabIndentation);
                 }
                 let entry_line = self.token.line;
                 let entry_start = self.token.start;
@@ -3002,7 +3015,11 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                                 // construct; this entry has no value.
                                 break 'value Expr::init(E::Null {}, mapping_value_start.loc());
                             }
-                            return Err(Self::unexpected_token());
+                            return Err(if self.tab_after_indent {
+                                ParseError::TabIndentation
+                            } else {
+                                Self::unexpected_token()
+                            });
                         }
                         // [191] explicit `:` is on a new line at mapping_indent;
                         // a same-line `- ` after it is a compact sequence whose
@@ -3058,7 +3075,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 {
                     // [192]/[195] each entry sits at s-indent(n) (spaces only).
                     if self.tab_after_indent {
-                        return Err(Self::unexpected_token());
+                        return Err(ParseError::TabIndentation);
                     }
                     let key_line = self.token.line;
                     previous_line = key_line;
@@ -3096,7 +3113,11 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                                     })?;
                                     continue;
                                 }
-                                return Err(Self::unexpected_token());
+                                return Err(if self.tab_after_indent {
+                                    ParseError::TabIndentation
+                                } else {
+                                    Self::unexpected_token()
+                                });
                             }
                         }
                         TokenData::MappingValue => {
@@ -3634,7 +3655,11 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         && (self.token.indent.is_less_than_or_equal(n)
                             || self.tab_after_indent) =>
                 {
-                    return Err(Self::unexpected_token());
+                    return Err(if self.tab_after_indent {
+                        ParseError::TabIndentation
+                    } else {
+                        Self::unexpected_token()
+                    });
                 }
                 // [149] e-node pair value in flow (`"a":,` / `"a":]`). Gated
                 // on flow_pair_allowed so this only fires for [139]
@@ -3798,7 +3823,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         if alias_tab_after_indent
                             && matches!(self.context.get(), Context::BlockOut | Context::BlockIn)
                         {
-                            return Err(Self::unexpected_token());
+                            return Err(ParseError::TabIndentation);
                         }
 
                         if let Some(current_mapping_indent) = opts.current_mapping_indent {
@@ -3850,7 +3875,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         if sequence_tab_after_indent
                             && matches!(self.context.get(), Context::BlockOut | Context::BlockIn)
                         {
-                            return Err(Self::unexpected_token());
+                            return Err(ParseError::TabIndentation);
                         }
 
                         if let Some(current_mapping_indent) = opts.current_mapping_indent {
@@ -3938,7 +3963,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         if mapping_tab_after_indent
                             && matches!(self.context.get(), Context::BlockOut | Context::BlockIn)
                         {
-                            return Err(Self::unexpected_token());
+                            return Err(ParseError::TabIndentation);
                         }
 
                         if let Some(current_mapping_indent) = opts.current_mapping_indent {
@@ -3985,7 +4010,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     }
                     // [195] each `?` sits at s-indent(n) (spaces only).
                     if self.tab_after_indent {
-                        return Err(Self::unexpected_token());
+                        return Err(ParseError::TabIndentation);
                     }
 
                     let mapping_start = self.token.start;
@@ -4031,7 +4056,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     }
                     // [195] block `:` (e-node key) sits at s-indent(n) only.
                     if self.tab_after_indent && !matches!(self.context.get(), Context::FlowIn) {
-                        return Err(Self::unexpected_token());
+                        return Err(ParseError::TabIndentation);
                     }
                     if let Some(current_mapping_indent) = opts.current_mapping_indent {
                         if current_mapping_indent == self.token.indent {
@@ -4106,7 +4131,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         if scalar_tab_after_indent
                             && matches!(self.context.get(), Context::BlockOut | Context::BlockIn)
                         {
-                            return Err(Self::unexpected_token());
+                            return Err(ParseError::TabIndentation);
                         }
                         if let Some(current_mapping_indent) = opts.current_mapping_indent {
                             if current_mapping_indent == scalar_indent {
@@ -5816,7 +5841,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         && additional_parent_indent.is_none()
                         && self.context.get() == Context::BlockIn
                     {
-                        return Err(ParseError::UnexpectedCharacter);
+                        return Err(ParseError::TabIndentation);
                     }
                     if in_indent_position {
                         // [63] s-indent is spaces only. A tab here is

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -4950,6 +4950,9 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         };
         ctx.content_indent = content_indent;
         ctx.cur_more_indented = matches!(first, 0x20 | 0x09);
+        if first == 0x09 {
+            self.tab_after_indent = true;
+        }
 
         // A line is part of the body iff its indentation is >= content_indent
         // and strictly > the parent block's indent. Collapse both into one

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -2565,7 +2565,6 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
         let root = self.parse_node(ParseNodeOptions::default())?;
 
-
         // If document_start it needs to create a new document.
         // If document_end, consume as many as possible. They should
         // not create new documents.
@@ -2996,8 +2995,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         // The `:` must be at exactly the `?` indent (block ctx).
                         if mapping_value_line != mapping_line
                             && !matches!(self.context.get(), Context::FlowIn | Context::FlowKey)
-                            && (self.token.indent != mapping_indent
-                                || self.tab_after_indent)
+                            && (self.token.indent != mapping_indent || self.tab_after_indent)
                         {
                             if self.token.indent.is_less_than(mapping_indent) {
                                 // [189] e-node — `:` belongs to an outer
@@ -3086,9 +3084,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         }
                         TokenData::MappingValue if explicit_key => {
                             // [191] l-block-map-explicit-value ::= s-indent(n) ':' …
-                            if self.token.indent != mapping_indent
-                                || self.tab_after_indent
-                            {
+                            if self.token.indent != mapping_indent || self.tab_after_indent {
                                 if self.token.indent.is_less_than(mapping_indent) {
                                     // [189] e-node — `:` belongs to an outer
                                     // construct; this entry has no value.
@@ -3651,7 +3647,6 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     return self.props_to_e_node(&value_tag, &value_anchor, indicator_start.loc());
                 }
                 _ => {
-
                     return self.parse_node(ParseNodeOptions {
                         current_mapping_indent: Some(n),
                         explicit_mapping_key: kind == BlockIndentedKind::MapExplicitKey,
@@ -3798,10 +3793,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
                         // [192] implicit key sits at s-indent(n) (spaces only).
                         if alias_tab_after_indent
-                            && matches!(
-                                self.context.get(),
-                                Context::BlockOut | Context::BlockIn
-                            )
+                            && matches!(self.context.get(), Context::BlockOut | Context::BlockIn)
                         {
                             return Err(Self::unexpected_token());
                         }
@@ -3853,10 +3845,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
                         // [192] implicit key sits at s-indent(n) (spaces only).
                         if sequence_tab_after_indent
-                            && matches!(
-                                self.context.get(),
-                                Context::BlockOut | Context::BlockIn
-                            )
+                            && matches!(self.context.get(), Context::BlockOut | Context::BlockIn)
                         {
                             return Err(Self::unexpected_token());
                         }
@@ -3944,10 +3933,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
                         // [192] implicit key sits at s-indent(n) (spaces only).
                         if mapping_tab_after_indent
-                            && matches!(
-                                self.context.get(),
-                                Context::BlockOut | Context::BlockIn
-                            )
+                            && matches!(self.context.get(), Context::BlockOut | Context::BlockIn)
                         {
                             return Err(Self::unexpected_token());
                         }
@@ -4010,14 +3996,12 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         ..Default::default()
                     })?;
 
-
                     let key = self.parse_block_indented(
                         mapping_indent,
                         mapping_line,
                         mapping_start,
                         BlockIndentedKind::MapExplicitKey,
                     )?;
-
 
                     self.block_indents.pop();
 
@@ -4026,7 +4010,6 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                             return Ok(key);
                         }
                     }
-
 
                     let r = self.parse_block_mapping(
                         key,
@@ -4044,9 +4027,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         break 'node Expr::init(E::Null {}, self.token.start.loc());
                     }
                     // [195] block `:` (e-node key) sits at s-indent(n) only.
-                    if self.tab_after_indent
-                        && !matches!(self.context.get(), Context::FlowIn)
-                    {
+                    if self.tab_after_indent && !matches!(self.context.get(), Context::FlowIn) {
                         return Err(Self::unexpected_token());
                     }
                     if let Some(current_mapping_indent) = opts.current_mapping_indent {
@@ -4113,10 +4094,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         // entry; in compact position ([185]) it cannot be the
                         // compact mapping's first key either.
                         if scalar_tab_after_indent
-                            && matches!(
-                                self.context.get(),
-                                Context::BlockOut | Context::BlockIn
-                            )
+                            && matches!(self.context.get(), Context::BlockOut | Context::BlockIn)
                         {
                             return Err(Self::unexpected_token());
                         }

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -2291,6 +2291,12 @@ pub struct Parser<'i, Enc: Encoding> {
 
     pub pos: Pos,
     pub line_indent: Indent,
+    /// A tab was seen between the line's s-indent (or post-indicator
+    /// additional_parent_indent position) and the current token's content.
+    /// [62]/[63] s-indent is spaces only; tab here is s-separate-in-line, valid
+    /// before [197] flow-in-block content but not before a [185] compact
+    /// construct or a sibling block entry. Reset on newline().
+    pub tab_after_indent: bool,
     pub line: Line,
     pub token: Token<Enc>,
 
@@ -2324,6 +2330,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             bump,
             pos: Pos::from(0),
             line_indent: Indent::NONE,
+            tab_after_indent: false,
             line: Line::from(1),
             token: Token::eof(TokenInit {
                 start: Pos::from(0),
@@ -2387,7 +2394,17 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
     fn newline(&mut self) {
         self.line_indent = Indent::NONE;
+        self.tab_after_indent = false;
         self.line.inc(1);
+    }
+
+    #[inline]
+    fn token_init(&self, start: Pos) -> TokenInit {
+        TokenInit {
+            start,
+            indent: self.line_indent,
+            line: self.line,
+        }
     }
 
     fn slice(&self, off: Pos, end: Pos) -> &[Enc::Unit] {
@@ -2547,6 +2564,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         }
 
         let root = self.parse_node(ParseNodeOptions::default())?;
+
 
         // If document_start it needs to create a new document.
         // If document_end, consume as many as possible. They should
@@ -2846,6 +2864,10 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             while matches!(self.token.data, TokenData::SequenceEntry)
                 && self.token.indent == sequence_indent
             {
+                // [184] each `-` sits at s-indent(n) (spaces only).
+                if self.tab_after_indent {
+                    return Err(Self::unexpected_token());
+                }
                 let entry_line = self.token.line;
                 let entry_start = self.token.start;
 
@@ -2974,7 +2996,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         // The `:` must be at exactly the `?` indent (block ctx).
                         if mapping_value_line != mapping_line
                             && !matches!(self.context.get(), Context::FlowIn | Context::FlowKey)
-                            && self.token.indent != mapping_indent
+                            && (self.token.indent != mapping_indent
+                                || self.tab_after_indent)
                         {
                             if self.token.indent.is_less_than(mapping_indent) {
                                 // [189] e-node — `:` belongs to an outer
@@ -3035,6 +3058,10 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 ) && self.token.indent == mapping_indent
                     && self.token.line != previous_line
                 {
+                    // [192]/[195] each entry sits at s-indent(n) (spaces only).
+                    if self.tab_after_indent {
+                        return Err(Self::unexpected_token());
+                    }
                     let key_line = self.token.line;
                     previous_line = key_line;
                     let explicit_key = matches!(self.token.data, TokenData::MappingKey);
@@ -3059,7 +3086,9 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         }
                         TokenData::MappingValue if explicit_key => {
                             // [191] l-block-map-explicit-value ::= s-indent(n) ':' …
-                            if self.token.indent != mapping_indent {
+                            if self.token.indent != mapping_indent
+                                || self.tab_after_indent
+                            {
                                 if self.token.indent.is_less_than(mapping_indent) {
                                     // [189] e-node — `:` belongs to an outer
                                     // construct; this entry has no value.
@@ -3583,6 +3612,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         self.pos = self.token.start;
                         self.line = self.token.line;
                         self.line_indent = self.token.indent;
+                        self.tab_after_indent = false;
                         self.scan(ScanOptions::default())?;
                     }
                     return self.props_to_e_node(&value_tag, &value_anchor, indicator_start.loc());
@@ -3598,10 +3628,12 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 }
                 // [185] a compact construct on the indicator's line must be at
                 // indent ≥ n+1 via s-indent (spaces only); tab separation
-                // leaves the token at the line's natural indent.
+                // either leaves the token at the line's natural indent (≤ n)
+                // or, when spaces preceded the tab, taints tab_after_indent.
                 TokenData::SequenceEntry | TokenData::MappingKey
                     if self.token.line == indicator_line
-                        && self.token.indent.is_less_than_or_equal(n) =>
+                        && (self.token.indent.is_less_than_or_equal(n)
+                            || self.tab_after_indent) =>
                 {
                     return Err(Self::unexpected_token());
                 }
@@ -3619,6 +3651,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     return self.props_to_e_node(&value_tag, &value_anchor, indicator_start.loc());
                 }
                 _ => {
+
                     return self.parse_node(ParseNodeOptions {
                         current_mapping_indent: Some(n),
                         explicit_mapping_key: kind == BlockIndentedKind::MapExplicitKey,
@@ -3720,6 +3753,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     let alias_start = self.token.start;
                     let alias_indent = self.token.indent;
                     let alias_line = self.token.line;
+                    let alias_tab_after_indent = self.tab_after_indent;
 
                     if let Some(anchor) = &node_props.has_anchor {
                         if anchor.line == alias_line {
@@ -3762,6 +3796,16 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                             return Ok(copy);
                         }
 
+                        // [192] implicit key sits at s-indent(n) (spaces only).
+                        if alias_tab_after_indent
+                            && matches!(
+                                self.context.get(),
+                                Context::BlockOut | Context::BlockIn
+                            )
+                        {
+                            return Err(Self::unexpected_token());
+                        }
+
                         if let Some(current_mapping_indent) = opts.current_mapping_indent {
                             if current_mapping_indent == alias_indent {
                                 return Ok(copy);
@@ -3785,6 +3829,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     let sequence_start = self.token.start;
                     let sequence_indent = self.token.indent;
                     let sequence_line = self.token.line;
+                    let sequence_tab_after_indent = self.tab_after_indent;
                     let json_key = self.maybe_set_json_key(opts.flow_pair_allowed)?;
                     let seq = self.parse_flow_sequence();
                     self.unset_json_key(json_key);
@@ -3804,6 +3849,16 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
                         if self.context.get() == Context::FlowKey {
                             break 'node seq;
+                        }
+
+                        // [192] implicit key sits at s-indent(n) (spaces only).
+                        if sequence_tab_after_indent
+                            && matches!(
+                                self.context.get(),
+                                Context::BlockOut | Context::BlockIn
+                            )
+                        {
+                            return Err(Self::unexpected_token());
                         }
 
                         if let Some(current_mapping_indent) = opts.current_mapping_indent {
@@ -3864,6 +3919,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     let mapping_start = self.token.start;
                     let mapping_indent = self.token.indent;
                     let mapping_line = self.token.line;
+                    let mapping_tab_after_indent = self.tab_after_indent;
 
                     let json_key = self.maybe_set_json_key(opts.flow_pair_allowed)?;
                     let map = self.parse_flow_mapping();
@@ -3884,6 +3940,16 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
                         if self.context.get() == Context::FlowKey {
                             break 'node map;
+                        }
+
+                        // [192] implicit key sits at s-indent(n) (spaces only).
+                        if mapping_tab_after_indent
+                            && matches!(
+                                self.context.get(),
+                                Context::BlockOut | Context::BlockIn
+                            )
+                        {
+                            return Err(Self::unexpected_token());
                         }
 
                         if let Some(current_mapping_indent) = opts.current_mapping_indent {
@@ -3928,6 +3994,10 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         // the legitimate paths.
                         return Err(Self::unexpected_token());
                     }
+                    // [195] each `?` sits at s-indent(n) (spaces only).
+                    if self.tab_after_indent {
+                        return Err(Self::unexpected_token());
+                    }
 
                     let mapping_start = self.token.start;
                     let mapping_indent = self.token.indent;
@@ -3940,12 +4010,14 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         ..Default::default()
                     })?;
 
+
                     let key = self.parse_block_indented(
                         mapping_indent,
                         mapping_line,
                         mapping_start,
                         BlockIndentedKind::MapExplicitKey,
                     )?;
+
 
                     self.block_indents.pop();
 
@@ -3955,18 +4027,27 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         }
                     }
 
-                    break 'node self.parse_block_mapping(
+
+                    let r = self.parse_block_mapping(
                         key,
                         mapping_start,
                         mapping_indent,
                         mapping_line,
                         opts.flow_pair_allowed,
-                    )?;
+                    );
+
+                    break 'node r?;
                 }
 
                 TokenData::MappingValue => {
                     if self.context.get() == Context::FlowKey {
                         break 'node Expr::init(E::Null {}, self.token.start.loc());
+                    }
+                    // [195] block `:` (e-node key) sits at s-indent(n) only.
+                    if self.tab_after_indent
+                        && !matches!(self.context.get(), Context::FlowIn)
+                    {
+                        return Err(Self::unexpected_token());
                     }
                     if let Some(current_mapping_indent) = opts.current_mapping_indent {
                         if current_mapping_indent == self.token.indent {
@@ -3987,6 +4068,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     let scalar_start = self.token.start;
                     let scalar_indent = self.token.indent;
                     let scalar_line = self.token.line;
+                    let scalar_tab_after_indent = self.tab_after_indent;
 
                     // PORT NOTE: reshaped for borrowck — we must hold the scalar
                     // payload across `self.scan()` which replaces self.token.
@@ -4024,6 +4106,19 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                             // explicit-value indicator after `? - a` or
                             // `? sky\n: blue`). This scalar is not a key.
                             break 'node scalar.data.to_expr(scalar_start, self.input, self.bump);
+                        }
+                        // [192] ns-l-block-map-implicit-entry: the key is at
+                        // s-indent(n) (spaces only). A tab between s-indent
+                        // and the key means it cannot be a sibling block-map
+                        // entry; in compact position ([185]) it cannot be the
+                        // compact mapping's first key either.
+                        if scalar_tab_after_indent
+                            && matches!(
+                                self.context.get(),
+                                Context::BlockOut | Context::BlockIn
+                            )
+                        {
+                            return Err(Self::unexpected_token());
                         }
                         if let Some(current_mapping_indent) = opts.current_mapping_indent {
                             if current_mapping_indent == scalar_indent {
@@ -4144,12 +4239,16 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         indent.inc(1);
                     }
                     self.line_indent = indent;
+                    if Enc::wide(self.next()) == 0x09 {
+                        self.tab_after_indent = true;
+                    }
                     self.skip_s_white();
                     __c = Enc::wide(self.next());
                     continue;
                 }
                 0x09 /* '\t' */ => {
                     // there's no indentation, but we still skip the whitespace
+                    self.tab_after_indent = true;
                     self.inc(1);
                     self.skip_s_white();
                     __c = Enc::wide(self.next());
@@ -5430,6 +5529,14 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
     fn scan(&mut self, opts: ScanOptions) -> Result<(), ParseError> {
         // ScanCtx state inlined
         let mut count_indentation = opts.first_scan || opts.additional_parent_indent.is_some();
+        // Tracks whether we are still in leading whitespace (after a newline
+        // or after an indicator with additional_parent_indent), so a tab at
+        // this position can taint `tab_after_indent`. Unlike count_indentation
+        // it stays true through the space arm.
+        let mut in_indent_position = count_indentation;
+        if in_indent_position {
+            self.tab_after_indent = false;
+        }
         let mut additional_parent_indent = opts.additional_parent_indent;
 
         let previous_token_line = self.token.line;
@@ -5441,7 +5548,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             match c {
                 0 => {
                     let start = self.pos;
-                    break 'next Token::eof(TokenInit { start, indent: self.line_indent, line: self.line });
+                    break 'next Token::eof(self.token_init(start));
                 }
                 0x2D /* '-' */ => {
                     let start = self.pos;
@@ -5450,7 +5557,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         && self.is_s_white_or_b_char_or_eof_at(3)
                     {
                         self.inc(3);
-                        break 'next Token::document_start(TokenInit { start, indent: self.line_indent, line: self.line });
+                        break 'next Token::document_start(self.token_init(start));
                     }
 
                     match Enc::wide(self.peek(1)) {
@@ -5463,12 +5570,12 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                                     return Err(Self::unexpected_token());
                                 }
                             }
-                            break 'next Token::sequence_entry(TokenInit { start, indent: self.line_indent, line: self.line });
+                            break 'next Token::sequence_entry(self.token_init(start));
                         }
                         0x2C | 0x5D | 0x5B | 0x7D | 0x7B => match self.context.get() {
                             Context::FlowIn | Context::FlowKey => {
                                 self.inc(1);
-                                self.token = Token::sequence_entry(TokenInit { start, indent: self.line_indent, line: self.line });
+                                self.token = Token::sequence_entry(self.token_init(start));
                                 return Err(Self::unexpected_token());
                             }
                             Context::BlockIn | Context::BlockOut => {
@@ -5488,7 +5595,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         && self.is_s_white_or_b_char_or_eof_at(3)
                     {
                         self.inc(3);
-                        break 'next Token::document_end(TokenInit { start, indent: self.line_indent, line: self.line });
+                        break 'next Token::document_end(self.token_init(start));
                     }
                     break 'next self.scan_plain_scalar(opts)?;
                 }
@@ -5497,13 +5604,13 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     match Enc::wide(self.peek(1)) {
                         0 | 0x20 | 0x09 | 0x0A | 0x0D => {
                             self.inc(1);
-                            break 'next Token::mapping_key(TokenInit { start, indent: self.line_indent, line: self.line });
+                            break 'next Token::mapping_key(self.token_init(start));
                         }
                         0x2C | 0x5D | 0x5B | 0x7D | 0x7B => match self.context.get() {
                             Context::BlockIn | Context::BlockOut => {}
                             Context::FlowIn | Context::FlowKey => {
                                 self.inc(1);
-                                break 'next Token::mapping_key(TokenInit { start, indent: self.line_indent, line: self.line });
+                                break 'next Token::mapping_key(self.token_init(start));
                             }
                         },
                         _ => {}
@@ -5515,20 +5622,20 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     match Enc::wide(self.peek(1)) {
                         0 | 0x20 | 0x09 | 0x0A | 0x0D => {
                             self.inc(1);
-                            break 'next Token::mapping_value(TokenInit { start, indent: self.line_indent, line: self.line });
+                            break 'next Token::mapping_value(self.token_init(start));
                         }
                         0x2C | 0x5D | 0x5B | 0x7D | 0x7B => match self.context.get() {
                             Context::BlockIn | Context::BlockOut => {}
                             Context::FlowIn | Context::FlowKey => {
                                 self.inc(1);
-                                break 'next Token::mapping_value(TokenInit { start, indent: self.line_indent, line: self.line });
+                                break 'next Token::mapping_value(self.token_init(start));
                             }
                         },
                         _ => match self.context.get() {
                             Context::BlockIn | Context::BlockOut | Context::FlowIn => {}
                             Context::FlowKey => {
                                 self.inc(1);
-                                break 'next Token::mapping_value(TokenInit { start, indent: self.line_indent, line: self.line });
+                                break 'next Token::mapping_value(self.token_init(start));
                             }
                         },
                     }
@@ -5539,7 +5646,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     match self.context.get() {
                         Context::FlowIn | Context::FlowKey => {
                             self.inc(1);
-                            break 'next Token::collect_entry(TokenInit { start, indent: self.line_indent, line: self.line });
+                            break 'next Token::collect_entry(self.token_init(start));
                         }
                         Context::BlockIn | Context::BlockOut => {}
                     }
@@ -5548,22 +5655,22 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 0x5B /* '[' */ => {
                     let start = self.pos;
                     self.inc(1);
-                    break 'next Token::sequence_start(TokenInit { start, indent: self.line_indent, line: self.line });
+                    break 'next Token::sequence_start(self.token_init(start));
                 }
                 0x5D /* ']' */ => {
                     let start = self.pos;
                     self.inc(1);
-                    break 'next Token::sequence_end(TokenInit { start, indent: self.line_indent, line: self.line });
+                    break 'next Token::sequence_end(self.token_init(start));
                 }
                 0x7B /* '{' */ => {
                     let start = self.pos;
                     self.inc(1);
-                    break 'next Token::mapping_start(TokenInit { start, indent: self.line_indent, line: self.line });
+                    break 'next Token::mapping_start(self.token_init(start));
                 }
                 0x7D /* '}' */ => {
                     let start = self.pos;
                     self.inc(1);
-                    break 'next Token::mapping_end(TokenInit { start, indent: self.line_indent, line: self.line });
+                    break 'next Token::mapping_end(self.token_init(start));
                 }
                 0x23 /* '#' */ => {
                     let start = self.pos;
@@ -5672,12 +5779,12 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 0x25 /* '%' */ => {
                     let start = self.pos;
                     self.inc(1);
-                    break 'next Token::directive(TokenInit { start, indent: self.line_indent, line: self.line });
+                    break 'next Token::directive(self.token_init(start));
                 }
                 0x40 /* '@' */ | 0x60 /* '`' */ => {
                     let start = self.pos;
                     self.inc(1);
-                    self.token = Token::reserved(TokenInit { start, indent: self.line_indent, line: self.line });
+                    self.token = Token::reserved(self.token_init(start));
                     return Err(Self::unexpected_token());
                 }
                 // PORT NOTE: ScanCtx.scanWhitespace inlined.
@@ -5688,6 +5795,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     }
                     // fallthrough to '\n'
                     count_indentation = true;
+                    in_indent_position = true;
                     additional_parent_indent = None;
                     self.newline();
                     self.inc(1);
@@ -5695,6 +5803,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 }
                 0x0A /* '\n' */ => {
                     count_indentation = true;
+                    in_indent_position = true;
                     additional_parent_indent = None;
                     self.newline();
                     self.inc(1);
@@ -5715,16 +5824,23 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     continue;
                 }
                 0x09 /* '\t' */ => {
-                    if additional_parent_indent.is_some() {
-                        // The same-line tab after `?`/`:`/`-` is s-separate-in-
-                        // line, not s-indent. [185] compact constructs require
-                        // s-indent (spaces), so the additional-parent-indent
-                        // treatment does not apply — the resulting token gets
-                        // the line's natural indent and the caller's compact-
-                        // indent check catches it.
-                        additional_parent_indent = None;
-                    } else if count_indentation && self.context.get() == Context::BlockIn {
+                    if count_indentation
+                        && additional_parent_indent.is_none()
+                        && self.context.get() == Context::BlockIn
+                    {
                         return Err(ParseError::UnexpectedCharacter);
+                    }
+                    if in_indent_position {
+                        // [63] s-indent is spaces only. A tab here is
+                        // s-separate-in-line — valid before [197]
+                        // flow-in-block content, but not before a [185]
+                        // compact construct or a sibling block entry. The
+                        // parser-side checks distinguish; here we record the
+                        // taint and drop additional_parent_indent (so the
+                        // resulting token's indent is what the *spaces*
+                        // reached, not column-based).
+                        self.tab_after_indent = true;
+                        additional_parent_indent = None;
                     }
                     count_indentation = false;
                     self.inc(1);

--- a/test/js/bun/yaml/yaml-test-suite.test.ts
+++ b/test/js/bun/yaml/yaml-test-suite.test.ts
@@ -2989,7 +2989,7 @@ bar: 2
   expect(parsed).toEqual(expected);
 });
 
-test.todo("yaml-test-suite/DK95/06", () => {
+test("yaml-test-suite/DK95/06", () => {
   // Tabs that look like indentation
   // Error test - expecting parse to fail
   const input: string = `foo:
@@ -6185,7 +6185,7 @@ test("yaml-test-suite/Y79Y/004", () => {
   }).toThrow();
 });
 
-test.todo("yaml-test-suite/Y79Y/005", () => {
+test("yaml-test-suite/Y79Y/005", () => {
   // Tabs in various contexts
   // Error test - expecting parse to fail
   const input: string = `- 	-
@@ -6219,7 +6219,7 @@ test("yaml-test-suite/Y79Y/007", () => {
   }).toThrow();
 });
 
-test.todo("yaml-test-suite/Y79Y/008", () => {
+test("yaml-test-suite/Y79Y/008", () => {
   // Tabs in various contexts
   // Error test - expecting parse to fail
   const input: string = `?	key:

--- a/test/js/bun/yaml/yaml-test-suite.test.ts
+++ b/test/js/bun/yaml/yaml-test-suite.test.ts
@@ -329,7 +329,8 @@ Reuse anchor: *anchor
   expect(parsed).toEqual(expected);
 
   // Verify shared references
-  expect((parsed as any)["occurrence"]).toBe((parsed as any)["anchor"]);
+  expect((parsed as any)["First occurrence"]).toBe((parsed as any)["Second occurrence"]);
+  expect((parsed as any)["Override anchor"]).toBe((parsed as any)["Reuse anchor"]);
 });
 
 test("yaml-test-suite/3HFZ", () => {
@@ -2519,8 +2520,8 @@ test("yaml-test-suite/C4HZ", () => {
   expect(parsed).toEqual(expected);
 
   // Verify shared references
-  expect((parsed as any)["center"]).toBe((parsed as any)["start"]);
-  expect((parsed as any)["center"]).toBe((parsed as any)["start"]);
+  expect((parsed as any)[1].start).toBe((parsed as any)[0].center);
+  expect((parsed as any)[2].start).toBe((parsed as any)[0].center);
 });
 
 test("yaml-test-suite/CC74", () => {
@@ -3271,7 +3272,7 @@ test("yaml-test-suite/FH7J", () => {
 
   const parsed = YAML.parse(input);
 
-  const expected: any = ["", { null: "a", b: "" }, { null: null }];
+  const expected: any = ["", { null: "a", b: "" }, { "": null }];
 
   expect(parsed).toEqual(expected);
 });

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1533,11 +1533,17 @@ folded: >
           expect(YAML.parse("|\nx\n  z...\n")).toEqual("x\n  z...\n");
         });
 
-        test.todo("tab between `---` and same-line content", () => {
-          // [203] c-directives-end is followed by s-l-comments or content via
-          // s-separate-in-line; a `- ` after tab would be a [185] compact at
-          // unknown indent. ee/js both error. Pre-existing.
+        test.todo("block collection on the `---` line", () => {
+          // [200] s-l+block-collection requires s-l-comments (a line break)
+          // before l+block-sequence/mapping; same-line content after `---` is
+          // s-separate-in-line + ns-flow-node only. Not tab-specific (`--- - x`
+          // is equally invalid). ee rejects both; js-yaml only rejects the
+          // tab variant. Pre-existing.
           expect(() => YAML.parse("---\t- x\n")).toThrow();
+          expect(() => YAML.parse("--- - x\n")).toThrow();
+          // Same-line flow node IS valid.
+          expect(YAML.parse("--- foo\n")).toEqual("foo");
+          expect(YAML.parse("---\tfoo\n")).toEqual("foo");
         });
 
         test.todo("`---` inside a plain scalar (issue #25660)", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1422,7 +1422,10 @@ folded: >
             ["explicit-key", (n: string, p: string, t: string) => `${n}? a\n${n}? ${p}\n${t}? b\n`],
           ] as const;
           const props = ["!!str", "&x", "!!str &x", "&x !!str"] as const;
-          const tabs = [["col0", "\t", ""], ["after-spaces", "  \t", "  "]] as const;
+          const tabs = [
+            ["col0", "\t", ""],
+            ["after-spaces", "  \t", "  "],
+          ] as const;
           for (const [iname, build] of indicators) {
             for (const prop of props) {
               for (const [tname, tab, indent] of tabs) {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1214,6 +1214,15 @@ folded: >
           expect(() => YAML.parse("!!str\n!!map\n: x\n")).toThrow("Multiple tags");
         });
 
+        test.todo("two anchors before e-node `:` (outer=mapping, inner=key) — pre-existing over-reject", () => {
+          // Valid per [200]/[193]: outer anchors the collection, inner the
+          // e-node key. The Scalar-key analogue (`&outer\n&inner b: x`) is
+          // accepted because that arm `return Ok(mapping)`, bypassing the
+          // post-loop has_mapping_anchor guard; the e-node arm reaches it.
+          // Pre-existing on main.
+          expect(YAML.parse("&outer\n&inner : x\n")).toEqual({ null: "x" });
+        });
+
         test("tag on e-node implicit key — [200]/[193] line split", () => {
           // Same line → key's tag (`!!str` e-node = "").
           expect(YAML.parse("!!str : x\n")).toEqual({ "": "x" });

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1524,6 +1524,22 @@ folded: >
           expect(() => YAML.parse("?\t: x\n")).toThrow("Tab characters cannot be used as indentation");
         });
 
+        test.todo("block-scalar phase-2 mid-line `---`/`...` is content, not a doc marker", () => {
+          // The phase-2 body loop's `0x2D`/`0x2E` arms check for `---`/`...`
+          // and `line_indent == NONE`, but at content_indent==0 a more-indented
+          // `  z---` line still has line_indent set to 0 by the nested loop.
+          // ee/js both treat it as content. Pre-existing.
+          expect(YAML.parse("|\nx\n  z---\n")).toEqual("x\n  z---\n");
+          expect(YAML.parse("|\nx\n  z...\n")).toEqual("x\n  z...\n");
+        });
+
+        test.todo("tab between `---` and same-line content", () => {
+          // [203] c-directives-end is followed by s-l-comments or content via
+          // s-separate-in-line; a `- ` after tab would be a [185] compact at
+          // unknown indent. ee/js both error. Pre-existing.
+          expect(() => YAML.parse("---\t- x\n")).toThrow();
+        });
+
         test.todo("`---` inside a plain scalar (issue #25660)", () => {
           // [128] ns-plain-char admits `-`; a `---` not at column 0 (or not
           // followed by /[ \t\r\n]|$/) is content, not c-directives-end.

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1385,8 +1385,13 @@ folded: >
           expect(() => YAML.parse("a: |\n  x\n\tb: y\n")).toThrow(TAB_ERR);
           expect(() => YAML.parse("? |\n  x\n\t: y\n")).toThrow(TAB_ERR);
           expect(() => YAML.parse("a: >\n  x\n\tb: y\n")).toThrow(TAB_ERR);
+          // Same when the FIRST line after the header terminates (phase-1).
+          expect(() => YAML.parse("a:\n  - |\n  \t- x\n")).toThrow(TAB_ERR);
+          expect(() => YAML.parse("a:\n  key: |\n  \tsibling: x\n")).toThrow(TAB_ERR);
+          expect(() => YAML.parse("a:\n  key: >\n  \tsibling: x\n")).toThrow(TAB_ERR);
           // Tab in more-indented body content is valid (part of the scalar).
           expect(YAML.parse("- |\n  x\n  \ty\n")).toEqual(["x\n\ty\n"]);
+          expect(YAML.parse("- |\n  \t- x\n")).toEqual(["\t- x\n"]);
         });
 
         test("rejects tab before alias/flow as implicit-key sibling", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1209,6 +1209,9 @@ folded: >
           // Two anchors on separate lines before `:` — the inner can't be the
           // key's (different line), and [161] disallows two collection-props.
           expect(() => YAML.parse("&outer\n&inner\n: x\n")).toThrow("Multiple anchors");
+          // Overflow (3 anchors / 2 tags) reaches the post-loop guards.
+          expect(() => YAML.parse("&a\n&b\n&c : x\n")).toThrow("Multiple anchors");
+          expect(() => YAML.parse("!!str\n!!map\n: x\n")).toThrow("Multiple tags");
         });
 
         test("tag on e-node implicit key — [200]/[193] line split", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1025,17 +1025,17 @@ folded: >
           // [185] same-line compact constructs after `?`/`:` need s-indent
           // (spaces only); a tab is plain s-separate and does not qualify.
           // All four reference parsers reject these (eemeli/js-yaml/PyYAML/ruamel).
-          expect(() => YAML.parse("?\t- a\n: v\n")).toThrow("Unexpected token");
-          expect(() => YAML.parse("? key\n:\t- x\n")).toThrow("Unexpected token");
-          expect(() => YAML.parse("? a\n: 1\n? b\n:\t- x\n")).toThrow("Unexpected token");
-          expect(() => YAML.parse("?\t-\n")).toThrow("Unexpected token");
-          expect(() => YAML.parse("?\t? a\n: v\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("?\t- a\n: v\n")).toThrow("Tab characters cannot be used as indentation");
+          expect(() => YAML.parse("? key\n:\t- x\n")).toThrow("Tab characters cannot be used as indentation");
+          expect(() => YAML.parse("? a\n: 1\n? b\n:\t- x\n")).toThrow("Tab characters cannot be used as indentation");
+          expect(() => YAML.parse("?\t-\n")).toThrow("Tab characters cannot be used as indentation");
+          expect(() => YAML.parse("?\t? a\n: v\n")).toThrow("Tab characters cannot be used as indentation");
         });
       });
 
       describe("explicit value on same line", () => {
         test("Y79Y/009 pattern (tab + trailing :) errors", () => {
-          expect(() => YAML.parse("? key:\n:\tkey:\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("? key:\n:\tkey:\n")).toThrow("Tab characters cannot be used as indentation");
         });
 
         test("compact-mapping value via space is valid", () => {
@@ -1227,16 +1227,16 @@ folded: >
           expect(() => YAML.parse("- &a\nk: v\n")).toThrow("Unexpected token");
           expect(() => YAML.parse("- &a\nb\n")).toThrow("Unexpected token");
           expect(() => YAML.parse("-\na\n")).toThrow("Unexpected token");
-          expect(() => YAML.parse("-\ta: b\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("-\ta: b\n")).toThrow("Tab characters cannot be used as indentation");
         });
 
         test("rejects same-line `?` at indent ≤ n after indicator", () => {
           // [185] compact construct on the indicator line needs s-indent
           // (spaces, indent ≥ n+1). Tab leaves indent at the line's natural
           // value; implicit-`:` scan has no additional_parent_indent.
-          expect(() => YAML.parse("?\t? x\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("?\t? x\n")).toThrow("Tab characters cannot be used as indentation");
           expect(() => YAML.parse("a:\t? x\n")).toThrow("Unexpected token");
-          expect(() => YAML.parse("-\t? x\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("-\t? x\n")).toThrow("Tab characters cannot be used as indentation");
           // [194] implicit value reaches s-l+block-node, not block-indented;
           // no same-line compact `?` allowed.
           expect(() => YAML.parse("a: ? x\n")).toThrow("Unexpected token");
@@ -1340,45 +1340,47 @@ folded: >
       // s-separate-in-line — valid before [197] flow-in-block content, never
       // before a [184]/[192]/[195] structural sibling (`-`/`?`/`:`/key).
       describe("tab in s-indent position", () => {
+        const TAB_ERR = "Tab characters cannot be used as indentation";
+
         test("rejects tab before sibling block-seq `-` ([184])", () => {
-          expect(() => YAML.parse("- a\n\t- b\n")).toThrow("Unexpected token");
-          expect(() => YAML.parse("k:\n  - a\n  \t- b\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("- a\n\t- b\n")).toThrow(TAB_ERR);
+          expect(() => YAML.parse("k:\n  - a\n  \t- b\n")).toThrow(TAB_ERR);
         });
 
         test("rejects tab before sibling block-map entry ([192]/[195])", () => {
-          expect(() => YAML.parse("a: 1\n\tb: 2\n")).toThrow("Unexpected token");
-          expect(() => YAML.parse("foo:\n  a: 1\n  \tb: 2\n")).toThrow("Unexpected token");
-          expect(() => YAML.parse("? a\n\t? b\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("a: 1\n\tb: 2\n")).toThrow(TAB_ERR);
+          expect(() => YAML.parse("foo:\n  a: 1\n  \tb: 2\n")).toThrow(TAB_ERR);
+          expect(() => YAML.parse("? a\n\t? b\n")).toThrow(TAB_ERR);
           // Tag-neutral rewind in the helper preserves the taint.
-          expect(() => YAML.parse("a: !!str\n\tb: 2\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("a: !!str\n\tb: 2\n")).toThrow(TAB_ERR);
         });
 
         test("rejects tab before explicit `:` continuation ([191])", () => {
-          expect(() => YAML.parse("? a\n\t: b\n")).toThrow("Unexpected token");
-          expect(() => YAML.parse("k:\n  ? a\n  \t: b\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("? a\n\t: b\n")).toThrow(TAB_ERR);
+          expect(() => YAML.parse("k:\n  ? a\n  \t: b\n")).toThrow(TAB_ERR);
         });
 
         test("rejects tab before first `?`/`:` of a new mapping", () => {
-          expect(() => YAML.parse("a:\n  \t? x\n")).toThrow("Unexpected token");
-          expect(() => YAML.parse("a:\n  \t: x\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("a:\n  \t? x\n")).toThrow(TAB_ERR);
+          expect(() => YAML.parse("a:\n  \t: x\n")).toThrow(TAB_ERR);
         });
 
         test("rejects tab before first `-` of a new sequence", () => {
-          expect(() => YAML.parse("a:\n  \t- x\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("a:\n  \t- x\n")).toThrow(TAB_ERR);
         });
 
         test("rejects tab in compact-construct position ([185] same line)", () => {
           // Y79Y/005, /006, /007, /008 family.
-          expect(() => YAML.parse("- \t-\n")).toThrow("Unexpected token");
-          expect(() => YAML.parse("?\t-\n")).toThrow("Unexpected token");
-          expect(() => YAML.parse("? -\n:\t-\n")).toThrow("Unexpected token");
-          expect(() => YAML.parse("?\tkey:\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("- \t-\n")).toThrow(TAB_ERR);
+          expect(() => YAML.parse("?\t-\n")).toThrow(TAB_ERR);
+          expect(() => YAML.parse("? -\n:\t-\n")).toThrow(TAB_ERR);
+          expect(() => YAML.parse("?\tkey:\n")).toThrow(TAB_ERR);
         });
 
         test("rejects tab before alias/flow as implicit-key sibling", () => {
-          expect(() => YAML.parse("&x a: 1\n\t*x : 2\n")).toThrow("Unexpected token");
-          expect(() => YAML.parse("a: 1\n\t[b]: 2\n")).toThrow("Unexpected token");
-          expect(() => YAML.parse("a: 1\n\t{b}: 2\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("&x a: 1\n\t*x : 2\n")).toThrow(TAB_ERR);
+          expect(() => YAML.parse("a: 1\n\t[b]: 2\n")).toThrow(TAB_ERR);
+          expect(() => YAML.parse("a: 1\n\t{b}: 2\n")).toThrow(TAB_ERR);
         });
 
         test("accepts tab before [197] flow-in-block content", () => {
@@ -1415,27 +1417,17 @@ folded: >
         // indicator × each property prefix × each tab position.
         describe("property prefix does not lose tab taint on abandoned sibling", () => {
           const indicators = [
-            ["map-value", "a: ", "  ", "b: 2"],
-            ["seq-entry", "- a\n- ", "  ", "b: 2"],
-            ["explicit-key", "? a\n? ", "  ", "b"],
+            ["map-value", (n: string, p: string, t: string) => `${n}a: ${p}\n${t}b: 2\n`],
+            ["seq-entry", (n: string, p: string, t: string) => `${n}- a\n${n}- ${p}\n${t}- b\n`],
+            ["explicit-key", (n: string, p: string, t: string) => `${n}? a\n${n}? ${p}\n${t}? b\n`],
           ] as const;
           const props = ["!!str", "&x", "!!str &x", "&x !!str"] as const;
-          const tabs = [["col0", "\t"], ["after-spaces", "  \t"]] as const;
-          for (const [iname, head, indent, sibling] of indicators) {
+          const tabs = [["col0", "\t", ""], ["after-spaces", "  \t", "  "]] as const;
+          for (const [iname, build] of indicators) {
             for (const prop of props) {
-              for (const [tname, tab] of tabs) {
+              for (const [tname, tab, indent] of tabs) {
                 test(`${iname} × ${prop} × ${tname}`, () => {
-                  // For col0 the sibling is at indent 0; for after-spaces, at
-                  // indent 2 — adjust the head's indent to match so the
-                  // sibling lands at the structural indent.
-                  const n = tname === "col0" ? "" : indent;
-                  const yaml =
-                    iname === "explicit-key"
-                      ? `${n}? a\n${n}? ${prop}\n${tab}${sibling}\n`
-                      : iname === "seq-entry"
-                        ? `${n}- a\n${n}- ${prop}\n${tab}${sibling}\n`
-                        : `${n}a: ${prop}\n${tab}${sibling}\n`;
-                  expect(() => YAML.parse(yaml)).toThrow(/Unexpected (token|character)/);
+                  expect(() => YAML.parse(build(indent, prop, tab))).toThrow(TAB_ERR);
                 });
               }
             }
@@ -1492,9 +1484,9 @@ folded: >
         test("tab before block construct after `?`/`:` (Y79Y/008 family)", () => {
           // [185] s-l+block-indented requires s-indent (spaces only) before a
           // same-line compact construct.
-          expect(() => YAML.parse("?\ta: b\n")).toThrow("Unexpected token");
-          expect(() => YAML.parse("? a\n:\t? b\n")).toThrow("Unexpected token");
-          expect(() => YAML.parse("?\t: x\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("?\ta: b\n")).toThrow("Tab characters cannot be used as indentation");
+          expect(() => YAML.parse("? a\n:\t? b\n")).toThrow("Tab characters cannot be used as indentation");
+          expect(() => YAML.parse("?\t: x\n")).toThrow("Tab characters cannot be used as indentation");
         });
 
         test.todo("`---` inside a plain scalar (issue #25660)", () => {
@@ -1646,8 +1638,8 @@ folded: >
       test("Y79Y/009 pattern in loop entries", () => {
         // The first-entry guard must also apply in the loop: a second entry
         // on the same line as the explicit `:` is rejected in all positions.
-        expect(() => YAML.parse("? key:\n:\tkey:\n")).toThrow("Unexpected token");
-        expect(() => YAML.parse("x: 1\n? key:\n:\tkey:\n")).toThrow("Unexpected token");
+        expect(() => YAML.parse("? key:\n:\tkey:\n")).toThrow("Tab characters cannot be used as indentation");
+        expect(() => YAML.parse("x: 1\n? key:\n:\tkey:\n")).toThrow("Tab characters cannot be used as indentation");
       });
 
       test("flow collection inside ? - …", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1201,9 +1201,21 @@ folded: >
           expect(YAML.parse("- ? &d\n- ? &e\n  : &a\n")).toEqual([{ null: null }, { null: null }]);
         });
 
-        test("anchor as implicit-key e-node, alias in later entry", () => {
-          // [154]/[159] `&a` is the key's ns-flow-yaml-node = props + e-scalar.
+        test("anchor on e-node implicit key — [200]/[193] line split", () => {
+          // Same line as `:` → key's anchor.
           expect(YAML.parse("&a : x\nb: *a\n")).toEqual({ null: "x", b: null });
+          // Prior line → [200] collection's anchor.
+          expect(YAML.parse("- &a\n  : x\n- *a\n")).toEqual([{ null: "x" }, { null: "x" }]);
+          // Two anchors on separate lines before `:` — the inner can't be the
+          // key's (different line), and [161] disallows two collection-props.
+          expect(() => YAML.parse("&outer\n&inner\n: x\n")).toThrow("Multiple anchors");
+        });
+
+        test("tag on e-node implicit key — [200]/[193] line split", () => {
+          // Same line → key's tag (`!!str` e-node = "").
+          expect(YAML.parse("!!str : x\n")).toEqual({ "": "x" });
+          // Prior line → collection's tag; key stays null.
+          expect(YAML.parse("!!str\n: x\n")).toEqual({ null: "x" });
         });
 
         test("at top level, content at indent 0 is still content (n = -1)", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1201,11 +1201,8 @@ folded: >
           expect(YAML.parse("- ? &d\n- ? &e\n  : &a\n")).toEqual([{ null: null }, { null: null }]);
         });
 
-        test.todo("anchor as implicit-key e-node, alias in later entry", () => {
+        test("anchor as implicit-key e-node, alias in later entry", () => {
           // [154]/[159] `&a` is the key's ns-flow-yaml-node = props + e-scalar.
-          // Currently the anchor is applied to the mapping (not the key) at
-          // parse_node's exit, AFTER subsequent entries are parsed, so `*a`
-          // is unresolved at parse time. Pre-existing.
           expect(YAML.parse("&a : x\nb: *a\n")).toEqual({ null: "x", b: null });
         });
 

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1339,6 +1339,78 @@ folded: >
         });
       });
 
+      // [62]/[63] s-indent(n) is spaces only. A tab in indent position is
+      // s-separate-in-line — valid before [197] flow-in-block content, never
+      // before a [184]/[192]/[195] structural sibling (`-`/`?`/`:`/key).
+      describe("tab in s-indent position", () => {
+        test("rejects tab before sibling block-seq `-` ([184])", () => {
+          expect(() => YAML.parse("- a\n\t- b\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("k:\n  - a\n  \t- b\n")).toThrow("Unexpected token");
+        });
+
+        test("rejects tab before sibling block-map entry ([192]/[195])", () => {
+          expect(() => YAML.parse("a: 1\n\tb: 2\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("foo:\n  a: 1\n  \tb: 2\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("? a\n\t? b\n")).toThrow("Unexpected token");
+        });
+
+        test("rejects tab before explicit `:` continuation ([191])", () => {
+          expect(() => YAML.parse("? a\n\t: b\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("k:\n  ? a\n  \t: b\n")).toThrow("Unexpected token");
+        });
+
+        test("rejects tab before first `?`/`:` of a new mapping", () => {
+          expect(() => YAML.parse("a:\n  \t? x\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("a:\n  \t: x\n")).toThrow("Unexpected token");
+        });
+
+        test("rejects tab before first `-` of a new sequence", () => {
+          expect(() => YAML.parse("a:\n  \t- x\n")).toThrow("Unexpected token");
+        });
+
+        test("rejects tab in compact-construct position ([185] same line)", () => {
+          // Y79Y/005, /006, /007, /008 family.
+          expect(() => YAML.parse("- \t-\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("?\t-\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("? -\n:\t-\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("?\tkey:\n")).toThrow("Unexpected token");
+        });
+
+        test("rejects tab before alias/flow as implicit-key sibling", () => {
+          expect(() => YAML.parse("&x a: 1\n\t*x : 2\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("a: 1\n\t[b]: 2\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("a: 1\n\t{b}: 2\n")).toThrow("Unexpected token");
+        });
+
+        test("accepts tab before [197] flow-in-block content", () => {
+          // s-separate(n+1,c) admits s-separate-in-line (which permits tab)
+          // after s-indent(n+1).
+          expect(YAML.parse("a:\n  \tb\n")).toEqual({ a: "b" });
+          expect(YAML.parse("a:\n  \t[1]\n")).toEqual({ a: [1] });
+          expect(YAML.parse("a:\n  \t&x b\n")).toEqual({ a: "b" });
+          expect(YAML.parse('a:\n  \t"b"\n')).toEqual({ a: "b" });
+        });
+
+        test("accepts tab as same-line s-separate after indicator", () => {
+          // [80] s-separate-in-line between indicator and content.
+          expect(YAML.parse("-\tx\n")).toEqual(["x"]);
+          expect(YAML.parse("?\tx\n")).toEqual({ x: null });
+          expect(YAML.parse(":\tx\n")).toEqual({ null: "x" });
+          expect(YAML.parse("a:\tx\n")).toEqual({ a: "x" });
+        });
+
+        test("accepts tab in flow context (not s-indent)", () => {
+          expect(YAML.parse("[\n\ta\n]\n")).toEqual(["a"]);
+          expect(YAML.parse("{\n\ta: 1\n}\n")).toEqual({ a: 1 });
+        });
+
+        test("accepts tab in plain-scalar fold (continuation, not key)", () => {
+          // The tab is consumed by fold_lines lookahead; the next line is
+          // content of the same plain scalar, not a sibling.
+          expect(YAML.parse("a: 1\n  \tb\n")).toEqual({ a: "1 b" });
+        });
+      });
+
       // Pre-existing flow-context over-accepts surfaced by adversarial review.
       // Each `test.todo` asserts the spec result (per ≥3/4 reference parsers);
       // the comment documents what Bun currently produces.
@@ -1385,13 +1457,12 @@ folded: >
           expect(YAML.parse("{{k:1}\n:2}\n")).toEqual({ "[object Object]": 2 });
         });
 
-        test.todo("tab before block construct after `?`/`:` (Y79Y/008 family)", () => {
+        test("tab before block construct after `?`/`:` (Y79Y/008 family)", () => {
           // [185] s-l+block-indented requires s-indent (spaces only) before a
-          // same-line compact construct. Currently `?\ta: b` accepts as
-          // {"a":"b"} (compact mapping reached via tab); refs error.
-          expect(() => YAML.parse("?\ta: b\n")).toThrow();
-          expect(() => YAML.parse("? a\n:\t? b\n")).toThrow();
-          expect(() => YAML.parse("?\t: x\n")).toThrow();
+          // same-line compact construct.
+          expect(() => YAML.parse("?\ta: b\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("? a\n:\t? b\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("?\t: x\n")).toThrow("Unexpected token");
         });
 
         test.todo("`---` inside a plain scalar (issue #25660)", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1377,6 +1377,18 @@ folded: >
           expect(() => YAML.parse("?\tkey:\n")).toThrow(TAB_ERR);
         });
 
+        test("rejects tab before sibling that immediately follows block-scalar body", () => {
+          // The block-scalar body scanner is the third leading-whitespace
+          // consumer (after scan() and fold_lines()) and must taint
+          // tab_after_indent on the line that terminates the body.
+          expect(() => YAML.parse("- |\n  x\n\t- y\n")).toThrow(TAB_ERR);
+          expect(() => YAML.parse("a: |\n  x\n\tb: y\n")).toThrow(TAB_ERR);
+          expect(() => YAML.parse("? |\n  x\n\t: y\n")).toThrow(TAB_ERR);
+          expect(() => YAML.parse("a: >\n  x\n\tb: y\n")).toThrow(TAB_ERR);
+          // Tab in more-indented body content is valid (part of the scalar).
+          expect(YAML.parse("- |\n  x\n  \ty\n")).toEqual(["x\n\ty\n"]);
+        });
+
         test("rejects tab before alias/flow as implicit-key sibling", () => {
           expect(() => YAML.parse("&x a: 1\n\t*x : 2\n")).toThrow(TAB_ERR);
           expect(() => YAML.parse("a: 1\n\t[b]: 2\n")).toThrow(TAB_ERR);

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1349,6 +1349,8 @@ folded: >
           expect(() => YAML.parse("a: 1\n\tb: 2\n")).toThrow("Unexpected token");
           expect(() => YAML.parse("foo:\n  a: 1\n  \tb: 2\n")).toThrow("Unexpected token");
           expect(() => YAML.parse("? a\n\t? b\n")).toThrow("Unexpected token");
+          // Tag-neutral rewind in the helper preserves the taint.
+          expect(() => YAML.parse("a: !!str\n\tb: 2\n")).toThrow("Unexpected token");
         });
 
         test("rejects tab before explicit `:` continuation ([191])", () => {
@@ -1405,6 +1407,39 @@ folded: >
           // The tab is consumed by fold_lines lookahead; the next line is
           // content of the same plain scalar, not a sibling.
           expect(YAML.parse("a: 1\n  \tb\n")).toEqual({ a: "1 b" });
+        });
+
+        // The tag-neutral rewind in parse_block_indented re-scans an
+        // abandoned scalar from token.start (past the tab), so the original
+        // taint must be preserved across the rewind. Exhaustive over each
+        // indicator × each property prefix × each tab position.
+        describe("property prefix does not lose tab taint on abandoned sibling", () => {
+          const indicators = [
+            ["map-value", "a: ", "  ", "b: 2"],
+            ["seq-entry", "- a\n- ", "  ", "b: 2"],
+            ["explicit-key", "? a\n? ", "  ", "b"],
+          ] as const;
+          const props = ["!!str", "&x", "!!str &x", "&x !!str"] as const;
+          const tabs = [["col0", "\t"], ["after-spaces", "  \t"]] as const;
+          for (const [iname, head, indent, sibling] of indicators) {
+            for (const prop of props) {
+              for (const [tname, tab] of tabs) {
+                test(`${iname} × ${prop} × ${tname}`, () => {
+                  // For col0 the sibling is at indent 0; for after-spaces, at
+                  // indent 2 — adjust the head's indent to match so the
+                  // sibling lands at the structural indent.
+                  const n = tname === "col0" ? "" : indent;
+                  const yaml =
+                    iname === "explicit-key"
+                      ? `${n}? a\n${n}? ${prop}\n${tab}${sibling}\n`
+                      : iname === "seq-entry"
+                        ? `${n}- a\n${n}- ${prop}\n${tab}${sibling}\n`
+                        : `${n}a: ${prop}\n${tab}${sibling}\n`;
+                  expect(() => YAML.parse(yaml)).toThrow(/Unexpected (token|character)/);
+                });
+              }
+            }
+          }
         });
       });
 

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1420,7 +1420,10 @@ folded: >
             ["explicit-key", "? a\n? ", "  ", "b"],
           ] as const;
           const props = ["!!str", "&x", "!!str &x", "&x !!str"] as const;
-          const tabs = [["col0", "\t"], ["after-spaces", "  \t"]] as const;
+          const tabs = [
+            ["col0", "\t"],
+            ["after-spaces", "  \t"],
+          ] as const;
           for (const [iname, head, indent, sibling] of indicators) {
             for (const prop of props) {
               for (const [tname, tab] of tabs) {


### PR DESCRIPTION
## What

Per [62]/[63] `s-indent(n)` is **spaces only**. A tab in indent position is `s-separate-in-line` — valid before [197] flow-in-block content ([69] `s-flow-line-prefix(n) ::= s-indent(n) s-separate-in-line?`), but **never** before a [184]/[192]/[195] structural sibling (`-`/`?`/`:`/implicit-key), which the grammar places *immediately* at `s-indent(n)` with no separation production in between.

Bun was accepting tab-tainted structural tokens because `Token.indent` records the count of leading spaces (correctly), but the parser had no way to ask "was there *additional* whitespace between those spaces and the token?"

## How

**Scanner:** `Parser.tab_after_indent: bool` records "a tab was seen between this line's `s-indent` (or post-indicator `additional_parent_indent` column) and the current token." Set in `scan()`'s tab arm (and `fold_lines()`' tab arm, which is what consumes whitespace for the `DK95/06` shape). Reset on `newline()` and at `scan()` entry when re-entering indent position.

**Parser:** checked at every structural-sibling recognition site (the complete set per [184]/[192]/[195]):

| Site | Production |
|---|---|
| `parse_block_sequence` loop | [184] each `-` at `s-indent(n)` |
| `parse_block_mapping` loop | [195] each entry at `s-indent(n)` |
| explicit `:` indent check (first + subsequent) | [191] `s-indent(n) ":"` |
| `parse_node` MappingKey / MappingValue arms | first entry of new block mapping |
| `parse_node` Scalar arm | [192] implicit key |
| `parse_block_indented` same-line compact | [185] |

Content paths (flow context, `s-separate` after indicator, plain-scalar fold continuation) correctly do not check it — tab is valid there.

This is the general spec rule, not three test cases: it covers every grammar position where `s-indent(n)` precedes a structural token, not just the three official-suite inputs.

## yaml-test-suite

`DK95/06`, `Y79Y/005`, `Y79Y/008` activated. **402/402, 0 todos.**

| PR | Suite todos |
|---|---|
| #31112 | 27 → 10 |
| #31203 | 10 → 7 |
| #31308 | 7 → 3 |
| this | 3 → **0** |

## Validation

- 1887 pass / 0 fail / 11 todo
- 1015/1015 4-parser consensus harness
- 11 new unit tests (7 fail on system Bun, 4 lock in valid-tab content cases)
- Also flips the `#31203` `test.todo("tab before block construct")` (3/3 asserts)