### PR TITLE
encoding: don't corrupt encodeInto output when a valid astral char doesn't fit

### DIFF
--- a/src/runtime/webcore/TextEncoder.rs
+++ b/src/runtime/webcore/TextEncoder.rs
@@ -280,13 +280,7 @@ pub(crate) unsafe extern "C" fn TextEncoder__encodeInto16(
     let output = unsafe { core::slice::from_raw_parts_mut(buf_ptr, buf_len) };
     // SAFETY: caller guarantees input_ptr[0..input_len] is valid UTF-16 data
     let input = unsafe { core::slice::from_raw_parts(input_ptr, input_len) };
-    let mut result: strings::EncodeIntoResult = strings::copy_utf16_into_utf8(output, input);
-    if output.len() >= 3 && (result.read == 0 || result.written == 0) {
-        const REPLACEMENT_CHAR: [u8; 3] = [239, 191, 189];
-        output[..REPLACEMENT_CHAR.len()].copy_from_slice(&REPLACEMENT_CHAR);
-        result.read = 1;
-        result.written = 3;
-    }
+    let result: strings::EncodeIntoResult = strings::copy_utf16_into_utf8(output, input);
     // Zig `@bitCast([2]u32 → u64)`: field 0 (`read`) at byte offset 0, field 1 (`written`)
     // at offset 4. Compose via native-endian bytes — identical bit pattern, no `unsafe`.
     let mut b = [0u8; 8];

--- a/src/runtime/webcore/TextEncoder.zig
+++ b/src/runtime/webcore/TextEncoder.zig
@@ -220,13 +220,7 @@ pub export fn TextEncoder__encodeInto16(
 ) u64 {
     const output = buf_ptr[0..buf_len];
     const input = input_ptr[0..input_len];
-    var result: strings.EncodeIntoResult = strings.copyUTF16IntoUTF8(output, input);
-    if (output.len >= 3 and (result.read == 0 or result.written == 0)) {
-        const replacement_char = [_]u8{ 239, 191, 189 };
-        @memcpy(buf_ptr[0..replacement_char.len], &replacement_char);
-        result.read = 1;
-        result.written = 3;
-    }
+    const result: strings.EncodeIntoResult = strings.copyUTF16IntoUTF8(output, input);
     const sized: [2]u32 = .{ result.read, result.written };
     return @bitCast(sized);
 }

--- a/src/runtime/webcore/TextEncoder.zig
+++ b/src/runtime/webcore/TextEncoder.zig
@@ -220,7 +220,13 @@ pub export fn TextEncoder__encodeInto16(
 ) u64 {
     const output = buf_ptr[0..buf_len];
     const input = input_ptr[0..input_len];
-    const result: strings.EncodeIntoResult = strings.copyUTF16IntoUTF8(output, input);
+    var result: strings.EncodeIntoResult = strings.copyUTF16IntoUTF8(output, input);
+    if (output.len >= 3 and (result.read == 0 or result.written == 0)) {
+        const replacement_char = [_]u8{ 239, 191, 189 };
+        @memcpy(buf_ptr[0..replacement_char.len], &replacement_char);
+        result.read = 1;
+        result.written = 3;
+    }
     const sized: [2]u32 = .{ result.read, result.written };
     return @bitCast(sized);
 }

--- a/test/js/web/encoding/text-encoder.test.js
+++ b/test/js/web/encoding/text-encoder.test.js
@@ -22,6 +22,29 @@ it("not enough space for replacement character", () => {
   expect(Array.from(bytes)).toEqual([0x00, 0x00]);
 });
 
+describe("encodeInto astral characters and buffer sizing", () => {
+  // WHATWG Encoding spec: a code point that doesn't fit in the remaining
+  // destination space is left unwritten, and that destination space is left
+  // untouched. A previous implementation incorrectly wrote U+FFFD when a
+  // valid 4-byte astral character met an exactly-3-byte buffer.
+  it.each([
+    ["\u{1F600}", 3, { read: 0, written: 0 }, [0xaa, 0xaa, 0xaa]],
+    ["\u{1F600}", 4, { read: 2, written: 4 }, [0xf0, 0x9f, 0x98, 0x80]],
+    ["\u{1F600}", 2, { read: 0, written: 0 }, [0xaa, 0xaa]],
+    ["\uD800", 3, { read: 1, written: 3 }, [0xef, 0xbf, 0xbd]],
+    ["\uDC00", 3, { read: 1, written: 3 }, [0xef, 0xbf, 0xbd]],
+    ["\uD800", 2, { read: 0, written: 0 }, [0xaa, 0xaa]],
+    ["a\u{1F600}", 3, { read: 1, written: 1 }, [0x61, 0xaa, 0xaa]],
+    ["a\u{1F600}", 4, { read: 1, written: 1 }, [0x61, 0xaa, 0xaa, 0xaa]],
+    ["a\u{1F600}", 5, { read: 3, written: 5 }, [0x61, 0xf0, 0x9f, 0x98, 0x80]],
+  ])("%j into %i-byte buffer", (input, size, expectedResult, expectedBytes) => {
+    const bytes = new Uint8Array(size).fill(0xaa);
+    const result = new TextEncoder().encodeInto(input, bytes);
+    expect(Array.from(bytes)).toEqual(expectedBytes);
+    expect(result).toEqual(expectedResult);
+  });
+});
+
 describe("TextEncoder", () => {
   it("should handle undefined", () => {
     const encoder = new TextEncoder();
@@ -442,11 +465,12 @@ describe("TextEncoder", () => {
       expect(Array.from(buffer2)).toEqual([0xef, 0xbf, 0xbd]); // U+FFFD in UTF-8
 
       // Multiple unpaired surrogates with limited buffer
-      const str2 = String.fromCharCode(0xd800, 0xdc00);
+      const str2 = String.fromCharCode(0xd800, 0xd801);
       const buffer3 = new Uint8Array(3); // Only room for one replacement
       const result3 = encoder.encodeInto(str2, buffer3);
       expect(result3.read).toBe(1); // Should only read first surrogate
       expect(result3.written).toBe(3); // Should write one U+FFFD
+      expect(Array.from(buffer3)).toEqual([0xef, 0xbf, 0xbd]);
     });
 
     it("should handle boundary surrogates correctly", () => {

--- a/test/v8/v8-module/main.cpp
+++ b/test/v8/v8-module/main.cpp
@@ -245,6 +245,44 @@ void test_v8_string_write_utf8(const FunctionCallbackInfo<Value> &info) {
   return ok(info);
 }
 
+// Regression test for WriteUtf8 when a valid surrogate pair (astral character)
+// does not fit in the remaining buffer. V8's legacy WriteUtf8 encodes the
+// unpaired lead surrogate as WTF-8 (3 bytes, 0xED 0xA0-0xAF ...) in that case
+// rather than leaving the buffer untouched. The encoder that backs this on Bun
+// previously wrote U+FFFD (0xEF 0xBF 0xBD) here, diverging from V8.
+void test_v8_string_write_utf8_surrogate(const FunctionCallbackInfo<Value> &info) {
+  Isolate *isolate = info.GetIsolate();
+
+  struct {
+    const char *label;
+    const char *utf8;
+  } inputs[] = {
+      // "😀" = U+1F600 (surrogate pair D83D DE00), leading astral character
+      {"emoji", "\xF0\x9F\x98\x80"},
+      // "a😀" — one ASCII byte then the astral character
+      {"a+emoji", "a\xF0\x9F\x98\x80"},
+  };
+
+  constexpr int total = 8;
+  char buf[total];
+  for (auto &in : inputs) {
+    Local<String> s = String::NewFromUtf8(isolate, in.utf8).ToLocalChecked();
+    for (int i = total; i >= 0; i--) {
+      memset(buf, 0xaa, total);
+      int nchars;
+      int retval = s->WriteUtf8(isolate, buf, i, &nchars);
+      printf("%-7s size = %d, nchars = %d, returned = %d, data =", in.label, i,
+             nchars, retval);
+      for (int j = 0; j < total; j++) {
+        printf("%c%02x", j == i ? '|' : ' ',
+               reinterpret_cast<unsigned char *>(buf)[j]);
+      }
+      printf("\n");
+    }
+  }
+  return ok(info);
+}
+
 void test_v8_external(const FunctionCallbackInfo<Value> &info) {
   Isolate *isolate = info.GetIsolate();
   int x = 5;
@@ -1153,6 +1191,8 @@ void initialize(Local<Object> exports, Local<Value> module,
   NODE_SET_METHOD(exports, "test_v8_string_latin1", test_v8_string_latin1);
   NODE_SET_METHOD(exports, "test_v8_string_write_utf8",
                   test_v8_string_write_utf8);
+  NODE_SET_METHOD(exports, "test_v8_string_write_utf8_surrogate",
+                  test_v8_string_write_utf8_surrogate);
   NODE_SET_METHOD(exports, "test_v8_external", test_v8_external);
   NODE_SET_METHOD(exports, "test_v8_object", test_v8_object);
   NODE_SET_METHOD(exports, "test_v8_array_new", test_v8_array_new);

--- a/test/v8/v8.test.ts
+++ b/test/v8/v8.test.ts
@@ -193,6 +193,9 @@ describe.todoIf(isBroken && isMusl)("node:v8", () => {
       it("truncates the string correctly", async () => {
         await checkSameOutput("test_v8_string_write_utf8");
       });
+      it("encodes an astral character that doesn't fit the same way V8 does", async () => {
+        await checkSameOutput("test_v8_string_write_utf8_surrogate");
+      });
     });
   });
 


### PR DESCRIPTION
`new TextEncoder().encodeInto("😀", new Uint8Array(3))` — a valid 4-byte astral character into a 3-byte buffer — should leave the buffer untouched and return `{read:0, written:0}` per the WHATWG Encoding spec (it doesn't fit). Bun instead wrote `EF BF BD` (U+FFFD) and returned `{read:1, written:3}`, corrupting the output and orphaning the surrogate pair's low half so a resume loop re-replaced it.

`encodeInto16` had a fallback that wrote U+FFFD and reported `{1,3}` whenever `copy_utf16_into_utf8` returned `{0,0}` for a ≥3-byte buffer — intended for unpaired surrogates. But `copy_utf16_into_utf8` already emits U+FFFD for a lone surrogate when it fits (≥3 bytes → `{1,3}`), so the fallback only ever fired for valid input whose leading 4-byte char doesn't fit — exactly the case it corrupted. Remove it.

Matches Node across the matrix: astral-no-fit → `{0,0}` untouched, astral-fits → `{2,4}`, lone surrogate → `{1,3}` U+FFFD, `"a😀"` partial → `{1,1}`. Also fixes a pre-existing test that mislabeled a *valid* surrogate pair (`0xD800,0xDC00` = U+10000) as "unpaired" and asserted the old buggy output. Not a port regression — 1.3.14 has the same fallback.
