### PR TITLE
js_parser: discard the fake if-block scope for a forward-declared function

### DIFF
--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -81,7 +81,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if has_if_scope {
             if_stmt_scope_index = p.push_scope_for_parse_pass(js_ast::scope::Kind::Block, loc)?;
         }
-        let _ = if_stmt_scope_index;
 
         let scope_index: usize =
             p.push_scope_for_parse_pass(js_ast::scope::Kind::FunctionArgs, p.lexer.loc())?;
@@ -118,9 +117,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             {
                 p.pop_and_discard_scope(scope_index);
 
-                // Balance the fake block scope introduced above
+                // Discard the fake block scope introduced above. A forward declaration
+                // emits nothing (`S::TypeScript`), so the block must be removed from
+                // `scopes_in_order` too — a plain `pop_scope()` only updates
+                // `current_scope` and would leave the block orphaned in the scope order,
+                // desyncing the visit pass (scope mismatch / pop past the topmost scope).
                 if has_if_scope {
-                    p.pop_scope();
+                    p.pop_and_discard_scope(if_stmt_scope_index);
                 }
 
                 if opts.is_typescript_declare && opts.is_namespace_scope && opts.is_export {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -226,7 +226,9 @@ describe("Bun.Transpiler", () => {
 
       // The exact fuzz repro: ts loader, dead-code elimination, trailing \r.
       const dce = new Bun.Transpiler({ loader: "ts", target: "browser", deadCodeElimination: true });
-      expect(dce.transformSync("if(l)function f(ag): g;\r\nfor (g in {}) {}\r")).toBe("if (l)\n  ;\nfor (g in {}) {}\n");
+      expect(dce.transformSync("if(l)function f(ag): g;\r\nfor (g in {}) {}\r")).toBe(
+        "if (l)\n  ;\nfor (g in {}) {}\n",
+      );
     });
 
     it("export default interface that is not an interface declaration does not crash", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -209,6 +209,26 @@ describe("Bun.Transpiler", () => {
       err("module = (t) => 0 Foo { () => () => 0 }", 'Expected ";" but found "Foo"');
     });
 
+    it("scope tracking stays balanced for a forward-declared function inside an if", () => {
+      const exp = ts.expectPrinted_;
+
+      // A function declaration in a single-statement `if`/`else` body gets a fake
+      // block scope so it can be wrapped when it has a body. A TypeScript forward
+      // declaration (no body) emits nothing, so that fake block scope must be
+      // discarded from the scope order; otherwise the next statement's scope is
+      // read out of sync and the parser pops past the topmost scope.
+      exp("if(l)function f(ag): g;\nfor (g in {}) {}", "if (l)\n  ;\nfor (g in {}) {}");
+      exp("if (x) function f(): void;\nfor (y in {}) {}", "if (x)\n  ;\nfor (y in {}) {}");
+      exp("if (x) {} else function g(): void;\nfor (z in {}) {}", "if (x) {}\nfor (z in {}) {}");
+
+      // A function declaration with a body in the same position is still wrapped.
+      exp("if(l)function f(ag): g {}\nfor (g in {}) {}", "if (l) {\n  let f = function(ag) {};\n}\nfor (g in {}) {}");
+
+      // The exact fuzz repro: ts loader, dead-code elimination, trailing \r.
+      const dce = new Bun.Transpiler({ loader: "ts", target: "browser", deadCodeElimination: true });
+      expect(dce.transformSync("if(l)function f(ag): g;\r\nfor (g in {}) {}\r")).toBe("if (l)\n  ;\nfor (g in {}) {}\n");
+    });
+
     it("export default interface that is not an interface declaration does not crash", () => {
       const exp = ts.expectPrinted_;
       const err = ts.expectParseError;


### PR DESCRIPTION
## Summary

A TypeScript forward-declared function used as the single-statement body of an `if` (or `else`), followed by another statement that opens a block scope, crashes the transpiler:

```
panic: Internal error: attempted to call popScope() on the topmost scope
```

### Repro

```js
new Bun.Transpiler({ loader: "ts", target: "browser", deadCodeElimination: true })
  .transformSync("if(l)function f(ag): g;\nfor (g in {}) {}");
```

```ts
if (l) function f(ag): g;   // forward declaration (no body) — emits nothing
for (g in {}) {}
```

## Cause

A function declaration in a single-statement `if`/`else` body is given a **fake block scope** during parsing so it can be wrapped in a block if it turns out to have a body (`if (l) { let f = function () {} }`).

When the declaration is a TypeScript **forward declaration** (no body), `parse_fn_stmt` emits nothing (`S::TypeScript`) and takes an early return. On that path it:

1. pops the function-args scope with `pop_and_discard_scope` — which also removes it from `scopes_in_order`, and
2. "balances" the fake block scope with a plain `pop_scope()`.

But `pop_scope()` only walks `current_scope` up to its parent — it does **not** remove the block's entry from `scopes_in_order`. That leaves an orphaned block scope in the scope order.

The visit pass replays the scope-order list. The orphan gets handed to the next statement that opens a block (here the `for (g in {})`), so every subsequent scope is read one step out of sync. In debug builds this trips the scope-location sanity check (`Scope mismatch while visiting`); in release builds that check is compiled out, so the desync propagates until the parser pops past the topmost scope and panics.

A function declaration *with* a body in the same position was already fine, because it is emitted as a real `S::Function` that the visit pass re-pushes the block scope for — only the no-op forward-declaration path was unbalanced.

## Fix

On the forward-declaration path, discard the fake block scope with `pop_and_discard_scope(if_stmt_scope_index)` instead of a plain `pop_scope()`. This removes the block from `scopes_in_order` as well as walking `current_scope` up, mirroring the existing "dropped TypeScript construct → discard the scopes it recorded" handling used elsewhere in the parser (e.g. `declare global { ... }`).

## Verification

- New test in `test/bundler/transpiler/transpiler.test.js` ("scope tracking stays balanced for a forward-declared function inside an if"). It panics (exit 132) on the current canary and passes with this change.
- Covers the exact fuzz repro plus `if`/`else` variants and confirms the with-body form is still wrapped in a block.
- Full `test/bundler/transpiler/transpiler.test.js` (166 pass) and `test/bundler/esbuild/ts.test.ts` (57 pass) green with the fix.