### PR TITLE
js_parser: guard stack depth when parsing nested JSX elements

### DIFF
--- a/src/js_parser/parse/parse_jsx.rs
+++ b/src/js_parser/parse/parse_jsx.rs
@@ -16,6 +16,11 @@ use bun_core::err;
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
     pub fn parse_jsx_element(&mut self, loc: bun_ast::Loc) -> Result<Expr, bun_core::Error> {
         let p = self;
+        // Nested child elements (`<a><b><c>...`) recurse back into this function,
+        // so guard the stack the same way the other recursive parse entry points do.
+        if !p.stack_check.is_safe_to_recurse() {
+            return Err(err!("StackOverflow"));
+        }
         if SCAN_ONLY {
             p.needs_jsx_import = true;
         }

--- a/test/bundler/transpiler/jsx-deep-nesting-stack-overflow.test.ts
+++ b/test/bundler/transpiler/jsx-deep-nesting-stack-overflow.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import path from "node:path";
+
+// Regression test for a stack overflow in the TSX parser, found by fuzzing.
+//
+// `parse_jsx_element` recurses directly for every nested child element
+// (`<a><b><c>...`), but unlike the other recursive parse entry points it never
+// consulted the parser's stack guard. A source like `() => <div>` repeated
+// thousands of times nests that many `<div>` children (the `() =>` between each
+// pair is parsed as JSX text), so the unbounded recursion ran off the end of
+// the stack and the process died on the guard page with a bare SIGSEGV — no
+// crash handler, no error message.
+//
+// With the guard in place the parser stops and reports "Maximum call stack size
+// exceeded" instead of crashing. The transpile runs in a child process so a
+// regression fails these assertions rather than taking down the test runner.
+test("deeply nested arrow/JSX does not overflow the stack", async () => {
+  // Each `() => <div>` adds one arrow frame and one JSX-element frame. This is
+  // far deeper than the fuzzer's ~23k repetitions so the guard fires well
+  // before the real stack end on both release and the larger debug frames.
+  const source = "() => <div>".repeat(50_000);
+
+  using dir = tempDir("jsx-deep-nesting-stack-overflow", {
+    "input.tsx": source,
+    "run.ts": `
+      const src = require("node:fs").readFileSync(${JSON.stringify(path.join("input.tsx"))}, "latin1");
+      try {
+        new Bun.Transpiler({
+          loader: "tsx",
+          target: "bun",
+          minifyWhitespace: true,
+          deadCodeElimination: true,
+        }).transformSync(src);
+        console.log("NO ERROR");
+      } catch (e) {
+        console.error(String((e as Error).message));
+      }
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Must terminate on its own, not be killed by the stack-guard-page SIGSEGV.
+  expect(proc.signalCode).toBeNull();
+  // The parser bounds the recursion and throws a catchable SyntaxError.
+  expect(stderr).toContain("Maximum call stack size exceeded");
+  expect(stdout).not.toContain("NO ERROR");
+  expect(exitCode).toBe(0);
+});

--- a/test/bundler/transpiler/jsx-deep-nesting-stack-overflow.test.ts
+++ b/test/bundler/transpiler/jsx-deep-nesting-stack-overflow.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
-import path from "node:path";
 
 // Regression test for a stack overflow in the TSX parser, found by fuzzing.
 //
@@ -19,12 +18,14 @@ test("deeply nested arrow/JSX does not overflow the stack", async () => {
   // Each `() => <div>` adds one arrow frame and one JSX-element frame. This is
   // far deeper than the fuzzer's ~23k repetitions so the guard fires well
   // before the real stack end on both release and the larger debug frames.
-  const source = "() => <div>".repeat(50_000);
+  // (`Buffer.alloc` fill over `.repeat` — the latter is very slow in debug JSC.)
+  const unit = "() => <div>";
+  const source = Buffer.alloc(unit.length * 50_000, unit).toString();
 
   using dir = tempDir("jsx-deep-nesting-stack-overflow", {
     "input.tsx": source,
     "run.ts": `
-      const src = require("node:fs").readFileSync(${JSON.stringify(path.join("input.tsx"))}, "latin1");
+      const src = require("node:fs").readFileSync("input.tsx", "latin1");
       try {
         new Bun.Transpiler({
           loader: "tsx",


### PR DESCRIPTION
## Summary

The TSX parser SIGSEGVs on deeply-nested JSX. Found by fuzzing: a source like `() => <div>` repeated thousands of times crashes with a bare `SIGSEGV` (exit 139) and no crash-handler output — it dies on the stack guard page.

## Repro

```js
// ~50k repetitions of "() => <div>"
const src = "() => <div>".repeat(50_000);
new Bun.Transpiler({ loader: "tsx", target: "bun", minifyWhitespace: true, deadCodeElimination: true }).transformSync(src);
// -> SIGSEGV (exit 139)
```

## Cause

`parse_jsx_element` (`src/js_parser/parse/parse_jsx.rs`) recurses **directly** for every nested child element (`<a><b><c>...`) at the `T::TLessThan` child branch. Every other recursive parse entry point (`parse_expr_common`, `parse_stmt`, `parse_property`, `parse_binding`, the TypeScript skippers) consults the parser's `stack_check`, but this JSX child-recursion path never did.

The fuzzer input `() => <div>() => <div>...` nests that many `<div>` children — the `() =>` between each pair is lexed as JSX text (`TStringLiteral`) — so the recursion depth grows unbounded and runs off the end of the stack.

## Fix

Add the standard guard at the top of `parse_jsx_element`:

```rust
if !p.stack_check.is_safe_to_recurse() {
    return Err(err!("StackOverflow"));
}
```

The parse entry points (`parse_entry.rs`) already catch `err!("StackOverflow")` and turn it into a graceful `Maximum call stack size exceeded` diagnostic, so the transpiler now reports a catchable `SyntaxError` instead of crashing. Valid nested JSX is unaffected — the guard only fires near stack exhaustion, well past any realistic nesting depth.

## Verification

- `test/bundler/transpiler/jsx-deep-nesting-stack-overflow.test.ts`: spawns a child that transpiles 50k-deep `() => <div>` and asserts it is **not** killed by a signal and reports the call-stack error.
  - **Without the fix**: child exits with `SIGSEGV` → test fails.
  - **With the fix**: graceful `Maximum call stack size exceeded` → test passes.
- Existing JSX/transpiler suites still pass (`transpiler.test.js`: 166 pass / 0 fail; `scope-mismatch-panic.test.ts`: all pass).
- Spot-checked that valid nested JSX (`<a><b><c>hi</c></b></a>`) still transpiles correctly.