### PR TITLE
install: bump default lockfileVersion to 2, gate stricter parse checks behind it

### DIFF
--- a/docs/pm/catalogs.mdx
+++ b/docs/pm/catalogs.mdx
@@ -242,7 +242,7 @@ Bun's lockfile tracks catalog versions, ensuring consistent installations across
 
 ```json bun.lock(excerpt) icon="file-json"
 {
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "workspaces": {
     "": {
       "name": "react-monorepo",

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9420,7 +9420,7 @@ declare module "bun" {
    * Types for `bun.lock`
    */
   type BunLockFile = {
-    lockfileVersion: 0 | 1;
+    lockfileVersion: 0 | 1 | 2;
     workspaces: {
       [workspace: string]: BunLockFileWorkspacePackage;
     };

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -114,7 +114,9 @@ pub enum Version {
     /// lockfile keeps loading:
     /// - an npm package resolved to a tarball URL outside the configured
     ///   registry must carry a supported integrity hash
-    /// - a git/github `.bun-tag` must be a safe path/checkout component
+    /// - a git `.bun-tag` must be a safe path/checkout component (the same
+    ///   check on a `github` tag is enforced at every version, since its
+    ///   download path has no checkout-time re-validation)
     V2 = 2,
 }
 
@@ -216,7 +218,11 @@ impl Stringifier {
                         return Version::V1;
                     }
                 }
-                ResolutionTag::Git | ResolutionTag::Github => {
+                ResolutionTag::Git => {
+                    // An unsafe git `.bun-tag` is only rejected at v2, so staying
+                    // at v1 keeps it loading. (A `github` tag is rejected at every
+                    // version, so no lockfile version can round-trip an unsafe one
+                    // — nothing to gate here.)
                     if !crate::repository::is_safe_resolved_tag(
                         res.repository().resolved.slice(buf),
                     ) {

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -108,10 +108,18 @@ pub enum Version {
 
     /// fixed unnecessary listing of workspace dependencies
     V1 = 1,
+
+    /// Stricter parsing that rejects, rather than accepts, lockfiles the
+    /// earlier versions tolerated. Gated here so an already-written v0/v1
+    /// lockfile keeps loading:
+    /// - an npm package resolved to a tarball URL outside the configured
+    ///   registry must carry a supported integrity hash
+    /// - a git/github `.bun-tag` must be a safe path/checkout component
+    V2 = 2,
 }
 
 impl Version {
-    pub const CURRENT: Version = Version::V1;
+    pub const CURRENT: Version = Version::V2;
 
     #[inline]
     pub const fn current() -> Version {
@@ -122,8 +130,16 @@ impl Version {
         match n {
             0 => Some(Version::V0),
             1 => Some(Version::V1),
+            2 => Some(Version::V2),
             _ => None,
         }
+    }
+
+    /// `true` when this lockfile version is at least `other`. Used to gate
+    /// strict parse-time checks introduced in a later version.
+    #[inline]
+    pub const fn at_least(self, other: Version) -> bool {
+        (self as u32) >= (other as u32)
     }
 }
 
@@ -2546,7 +2562,14 @@ pub fn parse_into_binary_lockfile(
                     // Fail closed: otherwise a tampered lockfile could redirect
                     // the tarball URL off-registry and install arbitrary content
                     // under a trusted package name with verification disabled.
-                    if npm_url_needs_integrity && !pkg.meta.integrity.tag.is_supported() {
+                    //
+                    // Only enforced for v2+. Older lockfiles predate this check
+                    // and may legitimately omit integrity for an off-registry
+                    // tarball; rejecting them would break existing installs.
+                    if lockfile_version.at_least(Version::V2)
+                        && npm_url_needs_integrity
+                        && !pkg.meta.integrity.tag.is_supported()
+                    {
                         log.add_error(
                             Some(source),
                             integrity_expr.loc,
@@ -2587,7 +2610,14 @@ pub fn parse_into_binary_lockfile(
                         return Err(ParseError::InvalidPackageInfo);
                     };
 
-                    if !crate::repository::is_safe_resolved_tag(bun_tag_str) {
+                    // Only reject an unsafe `.bun-tag` at parse time for v2+.
+                    // Older lockfiles predate this check; `Repository::checkout`
+                    // re-validates with the same guard before building any cache
+                    // path or invoking `git`, so skipping it here keeps older
+                    // lockfiles loading without reopening the checkout hole.
+                    if lockfile_version.at_least(Version::V2)
+                        && !crate::repository::is_safe_resolved_tag(bun_tag_str)
+                    {
                         log.add_error(Some(source), bun_tag.loc, b"Invalid git dependency tag");
                         return Err(ParseError::InvalidPackageInfo);
                     }

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -191,45 +191,67 @@ impl Stringifier {
     /// would make the *next* parse reject it. Only stamp v2 when every package
     /// already satisfies the v2 invariants; otherwise stay at v1 so the file
     /// round-trips (load → save → load) cleanly.
-    fn version_to_write(
-        pkg_resolutions: &[Resolution],
-        pkg_metas: &[Meta],
-        pkg_names: &[String],
-        buf: &[u8],
-        options: &PackageManagerOptions,
-    ) -> Version {
-        for (i, res) in pkg_resolutions.iter().enumerate() {
-            match res.tag {
-                ResolutionTag::Npm => {
-                    if pkg_metas[i].integrity.tag.is_supported() {
-                        continue;
-                    }
-                    // No supported integrity: only v2-clean if the tarball URL
-                    // is under the configured/default registry (mirrors the
-                    // parser's `npm_url_needs_integrity` computation).
-                    let url = res.npm().url.slice(buf);
-                    let configured_registry = options
-                        .scope_for_package_name(pkg_names[i].slice(buf))
-                        .url
-                        .href();
-                    let under_registry = url_is_under_registry(url, configured_registry)
-                        || url_is_under_registry(url, Npm::Registry::DEFAULT_URL.as_bytes());
-                    if !under_registry {
-                        return Version::V1;
-                    }
+    ///
+    /// Walks the package tree the same way the writer does — only packages that
+    /// are actually serialized are considered, not every entry in the in-memory
+    /// `pkg_resolutions` buffer (migration can leave pruned/unreferenced entries
+    /// there that never reach the written `packages` object).
+    fn version_to_write(lockfile: &BinaryLockfile, options: &PackageManagerOptions) -> Version {
+        let buf = lockfile.buffers.string_bytes.as_slice();
+        let deps_buf = lockfile.buffers.dependencies.as_slice();
+        let resolution_buf = lockfile.buffers.resolutions.as_slice();
+        let pkgs = lockfile.packages.slice();
+        let pkg_resolutions: &[Resolution] = pkgs.items_resolution();
+        let pkg_metas: &[Meta] = pkgs.items_meta();
+        let pkg_names: &[String] = pkgs.items_name();
+
+        let mut iter = tree::Iterator::<'_, { tree::IteratorPathStyle::PkgPath }>::from_slices(
+            lockfile.buffers.trees.as_slice(),
+            lockfile.buffers.hoisted_dependencies.as_slice(),
+            deps_buf,
+            buf,
+        );
+
+        while let Some(node) = iter.next(None) {
+            for &dep_id in node.dependencies {
+                let pkg_id = resolution_buf[dep_id as usize];
+                if pkg_id == invalid_package_id {
+                    continue;
                 }
-                ResolutionTag::Git => {
-                    // An unsafe git `.bun-tag` is only rejected at v2, so staying
-                    // at v1 keeps it loading. (A `github` tag is rejected at every
-                    // version, so no lockfile version can round-trip an unsafe one
-                    // — nothing to gate here.)
-                    if !crate::repository::is_safe_resolved_tag(
-                        res.repository().resolved.slice(buf),
-                    ) {
-                        return Version::V1;
+                let i = pkg_id as usize;
+                let res = &pkg_resolutions[i];
+                match res.tag {
+                    ResolutionTag::Npm => {
+                        if pkg_metas[i].integrity.tag.is_supported() {
+                            continue;
+                        }
+                        // No supported integrity: only v2-clean if the tarball
+                        // URL is under the configured/default registry (mirrors
+                        // the parser's `npm_url_needs_integrity` computation).
+                        let url = res.npm().url.slice(buf);
+                        let configured_registry = options
+                            .scope_for_package_name(pkg_names[i].slice(buf))
+                            .url
+                            .href();
+                        let under_registry = url_is_under_registry(url, configured_registry)
+                            || url_is_under_registry(url, Npm::Registry::DEFAULT_URL.as_bytes());
+                        if !under_registry {
+                            return Version::V1;
+                        }
                     }
+                    ResolutionTag::Git => {
+                        // An unsafe git `.bun-tag` is only rejected at v2, so
+                        // staying at v1 keeps it loading. (A `github` tag is
+                        // rejected at every version, so no lockfile version can
+                        // round-trip an unsafe one — nothing to gate here.)
+                        if !crate::repository::is_safe_resolved_tag(
+                            res.repository().resolved.slice(buf),
+                        ) {
+                            return Version::V1;
+                        }
+                    }
+                    _ => {}
                 }
-                _ => {}
             }
         }
         Version::CURRENT
@@ -314,8 +336,7 @@ impl Stringifier {
         writer.write_all(b"{\n")?;
         Self::inc_indent(writer, indent)?;
         {
-            let lockfile_version =
-                Self::version_to_write(pkg_resolutions, pkg_metas, pkg_names, buf, options);
+            let lockfile_version = Self::version_to_write(lockfile, options);
             writeln!(writer, "\"lockfileVersion\": {},", lockfile_version as u32)?;
             Self::write_indent(writer, *indent)?;
 

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -217,8 +217,9 @@ impl Stringifier {
                     }
                 }
                 ResolutionTag::Git | ResolutionTag::Github => {
-                    if !crate::repository::is_safe_resolved_tag(res.repository().resolved.slice(buf))
-                    {
+                    if !crate::repository::is_safe_resolved_tag(
+                        res.repository().resolved.slice(buf),
+                    ) {
                         return Version::V1;
                     }
                 }

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -181,6 +181,53 @@ impl Stringifier {
         Self::save_from_binary_inner(lockfile, load_result, options, writer)
     }
 
+    /// Pick the `lockfileVersion` to stamp. `Version::CURRENT` (v2) adds
+    /// parse-time checks that reject entries older versions tolerated: an
+    /// off-registry npm tarball without a supported integrity hash, and an
+    /// unsafe git `.bun-tag`. The writer emits those fields verbatim (no
+    /// backfill), so stamping v2 on a lockfile that still carries such an entry
+    /// would make the *next* parse reject it. Only stamp v2 when every package
+    /// already satisfies the v2 invariants; otherwise stay at v1 so the file
+    /// round-trips (load → save → load) cleanly.
+    fn version_to_write(
+        pkg_resolutions: &[Resolution],
+        pkg_metas: &[Meta],
+        pkg_names: &[String],
+        buf: &[u8],
+        options: &PackageManagerOptions,
+    ) -> Version {
+        for (i, res) in pkg_resolutions.iter().enumerate() {
+            match res.tag {
+                ResolutionTag::Npm => {
+                    if pkg_metas[i].integrity.tag.is_supported() {
+                        continue;
+                    }
+                    // No supported integrity: only v2-clean if the tarball URL
+                    // is under the configured/default registry (mirrors the
+                    // parser's `npm_url_needs_integrity` computation).
+                    let url = res.npm().url.slice(buf);
+                    let configured_registry = options
+                        .scope_for_package_name(pkg_names[i].slice(buf))
+                        .url
+                        .href();
+                    let under_registry = url_is_under_registry(url, configured_registry)
+                        || url_is_under_registry(url, Npm::Registry::DEFAULT_URL.as_bytes());
+                    if !under_registry {
+                        return Version::V1;
+                    }
+                }
+                ResolutionTag::Git | ResolutionTag::Github => {
+                    if !crate::repository::is_safe_resolved_tag(res.repository().resolved.slice(buf))
+                    {
+                        return Version::V1;
+                    }
+                }
+                _ => {}
+            }
+        }
+        Version::CURRENT
+    }
+
     pub(crate) fn save_from_binary_inner(
         lockfile: &mut BinaryLockfile,
         load_result: &LoadResult,
@@ -260,7 +307,9 @@ impl Stringifier {
         writer.write_all(b"{\n")?;
         Self::inc_indent(writer, indent)?;
         {
-            writeln!(writer, "\"lockfileVersion\": {},", Version::CURRENT as u32)?;
+            let lockfile_version =
+                Self::version_to_write(pkg_resolutions, pkg_metas, pkg_names, buf, options);
+            writeln!(writer, "\"lockfileVersion\": {},", lockfile_version as u32)?;
             Self::write_indent(writer, *indent)?;
 
             let config_version: ConfigVersion =
@@ -2610,14 +2659,17 @@ pub fn parse_into_binary_lockfile(
                         return Err(ParseError::InvalidPackageInfo);
                     };
 
-                    // Only reject an unsafe `.bun-tag` at parse time for v2+.
-                    // Older lockfiles predate this check; `Repository::checkout`
+                    // Reject an unsafe `.bun-tag`. For `git`, `Repository::checkout`
                     // re-validates with the same guard before building any cache
-                    // path or invoking `git`, so skipping it here keeps older
-                    // lockfiles loading without reopening the checkout hole.
-                    if lockfile_version.at_least(Version::V2)
-                        && !crate::repository::is_safe_resolved_tag(bun_tag_str)
-                    {
+                    // path or invoking `git`, so this parse-time check is gated to
+                    // v2+ — older git lockfiles keep loading without reopening the
+                    // checkout hole. For `github` there is no such re-validation
+                    // (the tarball-download path feeds the tag straight into the
+                    // cache folder name), so the check must stay unconditional to
+                    // keep the path-traversal guard intact at every version.
+                    let enforce_safe_tag =
+                        tag == ResolutionTag::Github || lockfile_version.at_least(Version::V2);
+                    if enforce_safe_tag && !crate::repository::is_safe_resolved_tag(bun_tag_str) {
                         log.add_error(Some(source), bun_tag.loc, b"Invalid git dependency tag");
                         return Err(ParseError::InvalidPackageInfo);
                     }

--- a/test/cli/install/__snapshots__/bun-install-registry.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-install-registry.test.ts.snap
@@ -10,7 +10,7 @@ exports[`auto-install symlinks (and junctions) are created correctly in the inst
 
 exports[`text lockfile workspace sorting 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -45,7 +45,7 @@ exports[`text lockfile workspace sorting 1`] = `
 
 exports[`text lockfile workspace sorting 2`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -88,7 +88,7 @@ exports[`text lockfile workspace sorting 2`] = `
 
 exports[`text lockfile --frozen-lockfile 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -120,7 +120,7 @@ exports[`text lockfile --frozen-lockfile 1`] = `
 
 exports[`binaries each type of binary serializes correctly to text lockfile 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -148,7 +148,7 @@ exports[`binaries each type of binary serializes correctly to text lockfile 1`] 
 
 exports[`binaries root resolution bins 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 0,
   "workspaces": {
     "": {
@@ -170,7 +170,7 @@ exports[`binaries root resolution bins 1`] = `
 
 exports[`hoisting text lockfile is hoisted 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -280,7 +280,7 @@ exports[`outdated NO_COLOR works 1`] = `
 
 exports[`it should ignore peerDependencies within workspaces 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {

--- a/test/cli/install/__snapshots__/bun-lock.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-lock.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`should write plaintext lockfiles 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -21,7 +21,7 @@ exports[`should write plaintext lockfiles 1`] = `
 
 exports[`should escape names 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -48,7 +48,7 @@ exports[`should escape names 1`] = `
 
 exports[`should be the default save format 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -67,7 +67,7 @@ exports[`should be the default save format 1`] = `
 
 exports[`should be the default save format 2`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -89,7 +89,7 @@ exports[`should be the default save format 2`] = `
 
 exports[`should save the lockfile if --save-text-lockfile and --frozen-lockfile are used 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -108,7 +108,7 @@ exports[`should save the lockfile if --save-text-lockfile and --frozen-lockfile 
 
 exports[`should save the lockfile if --save-text-lockfile and --frozen-lockfile are used 2`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -130,7 +130,7 @@ exports[`should save the lockfile if --save-text-lockfile and --frozen-lockfile 
 
 exports[`should convert a binary lockfile with invalid optional peers 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 0,
   "workspaces": {
     "": {
@@ -300,7 +300,7 @@ exports[`should not deduplicate bundled packages with un-bundled packages 2`] = 
 
 exports[`should not change formatting unexpectedly 2`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -400,7 +400,7 @@ exports[`should not change formatting unexpectedly 2`] = `
 
 exports[`should sort overrides before comparing 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -438,7 +438,7 @@ exports[`should sort overrides before comparing 1`] = `
 
 exports[`should include unused resolutions in the lockfile 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {

--- a/test/cli/install/__snapshots__/catalogs.test.ts.snap
+++ b/test/cli/install/__snapshots__/catalogs.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`basic detect changes (bun.lock) 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -37,7 +37,7 @@ exports[`basic detect changes (bun.lock) 1`] = `
 
 exports[`basic detect changes (bun.lock) 2`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -72,7 +72,7 @@ exports[`basic detect changes (bun.lock) 2`] = `
 
 exports[`basic detect changes (bun.lock) 3`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -9013,7 +9013,7 @@ describe.concurrent("bun-install", () => {
       expect(await exists(join(ctx.package_dir, "bun.lockb"))).toBeFalse();
       expect(await file(join(ctx.package_dir, "bun.lock")).text()).toMatchInlineSnapshot(`
       "{
-        "lockfileVersion": 1,
+        "lockfileVersion": 2,
         "configVersion": 1,
         "workspaces": {
           "": {

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -616,12 +616,11 @@ it("should include unused resolutions in the lockfile", async () => {
   await runBunInstall(env, packageDir, { frozenLockfile: true });
 });
 
-it("requires an integrity hash when an npm package entry points at a tarball URL outside the configured registry", async () => {
+it("requires an integrity hash for an off-registry npm tarball URL at lockfileVersion 2", async () => {
   const { packageDir, packageJson } = await registry.createTestDir();
 
-  // Stand-in for a host that is not the configured registry. A correct install
-  // must never contact it for this lockfile, because the entry carries no
-  // integrity hash that would pin the tarball contents.
+  // Stand-in for a host that is not the configured registry. Parsing fails
+  // before any fetch, so this is never actually contacted.
   let offRegistryRequests = 0;
   await using offRegistry = Bun.serve({
     port: 0,
@@ -642,9 +641,14 @@ it("requires an integrity hash when an npm package entry points at a tarball URL
     }),
   );
 
-  const lockfileWithUrl = (tarballUrl: string) =>
+  // The entry keeps the well-known name and version but points the tarball at a
+  // different host and provides no integrity hash. At lockfileVersion 2 this
+  // fails closed: parsing rejects it before any fetch. (The v1 backward-compat
+  // case — parsing accepts such an entry — is covered in lockfile-version-2.test.ts.)
+  await write(
+    join(packageDir, "bun.lock"),
     JSON.stringify({
-      lockfileVersion: 1,
+      lockfileVersion: 2,
       configVersion: 1,
       workspaces: {
         "": {
@@ -655,15 +659,14 @@ it("requires an integrity hash when an npm package entry points at a tarball URL
         },
       },
       packages: {
-        "no-deps": ["no-deps@1.0.0", tarballUrl, {}, ""],
+        "no-deps": [
+          "no-deps@1.0.0",
+          `http://127.0.0.1:${offRegistry.port}/no-deps/-/no-deps-1.0.0.tgz`,
+          {},
+          "",
+        ],
       },
-    });
-
-  // The entry keeps the well-known name and version but points the tarball at
-  // a different host and provides no integrity hash.
-  await write(
-    join(packageDir, "bun.lock"),
-    lockfileWithUrl(`http://127.0.0.1:${offRegistry.port}/no-deps/-/no-deps-1.0.0.tgz`),
+    }),
   );
 
   let { exited, stdout, stderr } = spawn({
@@ -681,28 +684,6 @@ it("requires an integrity hash when an npm package entry points at a tarball URL
   expect(offRegistryRequests).toBe(0);
   expect(await exists(join(packageDir, "node_modules", "no-deps"))).toBe(false);
   expect(await exited).not.toBe(0);
-
-  // The same entry with the tarball URL under the configured registry and no
-  // integrity hash is still accepted (backward compat for lockfiles that omit
-  // the hash for registry-hosted tarballs).
-  await write(join(packageDir, "bun.lock"), lockfileWithUrl(`${registry.registryUrl()}no-deps/-/no-deps-1.0.0.tgz`));
-
-  ({ exited, stdout, stderr } = spawn({
-    cmd: [bunExe(), "install"],
-    cwd: packageDir,
-    env,
-    stdout: "pipe",
-    stderr: "pipe",
-  }));
-
-  [out, err] = await Promise.all([stdout.text(), stderr.text()]);
-  expect(err).not.toContain("Missing integrity hash");
-  expect(offRegistryRequests).toBe(0);
-  expect(await exited).toBe(0);
-  expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
-    name: "no-deps",
-    version: "1.0.0",
-  });
 });
 
 it("escapes double quotes in npm registry tarball URLs when saving bun.lock", async () => {

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -641,12 +641,7 @@ it("requires an integrity hash for an off-registry npm tarball URL at lockfileVe
     }),
   );
 
-  // The entry keeps the well-known name and version but points the tarball at a
-  // different host and provides no integrity hash. At lockfileVersion 2 this
-  // fails closed: parsing rejects it before any fetch. (The v1 backward-compat
-  // case — parsing accepts such an entry — is covered in lockfile-version-2.test.ts.)
-  await write(
-    join(packageDir, "bun.lock"),
+  const lockfileWithUrl = (tarballUrl: string) =>
     JSON.stringify({
       lockfileVersion: 2,
       configVersion: 1,
@@ -659,9 +654,17 @@ it("requires an integrity hash for an off-registry npm tarball URL at lockfileVe
         },
       },
       packages: {
-        "no-deps": ["no-deps@1.0.0", `http://127.0.0.1:${offRegistry.port}/no-deps/-/no-deps-1.0.0.tgz`, {}, ""],
+        "no-deps": ["no-deps@1.0.0", tarballUrl, {}, ""],
       },
-    }),
+    });
+
+  // The entry keeps the well-known name and version but points the tarball at a
+  // different host and provides no integrity hash. At lockfileVersion 2 this
+  // fails closed: parsing rejects it before any fetch. (The v1 backward-compat
+  // case — parsing accepts such an entry — is covered in lockfile-version-2.test.ts.)
+  await write(
+    join(packageDir, "bun.lock"),
+    lockfileWithUrl(`http://127.0.0.1:${offRegistry.port}/no-deps/-/no-deps-1.0.0.tgz`),
   );
 
   let { exited, stdout, stderr } = spawn({
@@ -679,6 +682,29 @@ it("requires an integrity hash for an off-registry npm tarball URL at lockfileVe
   expect(offRegistryRequests).toBe(0);
   expect(await exists(join(packageDir, "node_modules", "no-deps"))).toBe(false);
   expect(await exited).not.toBe(0);
+
+  // The same entry with the tarball URL *under* the configured registry and no
+  // integrity hash is accepted even at v2 (the off-registry gate does not apply,
+  // so `npm_url_needs_integrity` is false — registry-hosted tarballs may still
+  // omit the hash).
+  await write(join(packageDir, "bun.lock"), lockfileWithUrl(`${registry.registryUrl()}no-deps/-/no-deps-1.0.0.tgz`));
+
+  ({ exited, stdout, stderr } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  }));
+
+  [out, err] = await Promise.all([stdout.text(), stderr.text()]);
+  expect(err).not.toContain("Missing integrity hash");
+  expect(offRegistryRequests).toBe(0);
+  expect(await exited).toBe(0);
+  expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+    name: "no-deps",
+    version: "1.0.0",
+  });
 });
 
 it("escapes double quotes in npm registry tarball URLs when saving bun.lock", async () => {

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -659,12 +659,7 @@ it("requires an integrity hash for an off-registry npm tarball URL at lockfileVe
         },
       },
       packages: {
-        "no-deps": [
-          "no-deps@1.0.0",
-          `http://127.0.0.1:${offRegistry.port}/no-deps/-/no-deps-1.0.0.tgz`,
-          {},
-          "",
-        ],
+        "no-deps": ["no-deps@1.0.0", `http://127.0.0.1:${offRegistry.port}/no-deps/-/no-deps-1.0.0.tgz`, {}, ""],
       },
     }),
   );

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -1981,7 +1981,7 @@ test("matching workspace devDependency and npm peerDependency", async () => {
   expect((await file(join(packageDir, "bun.lock")).text()).replaceAll(/localhost:\d+/g, "localhost:1234"))
     .toMatchInlineSnapshot(`
     "{
-      "lockfileVersion": 1,
+      "lockfileVersion": 2,
       "configVersion": 1,
       "workspaces": {
         "": {

--- a/test/cli/install/config-version.test.ts
+++ b/test/cli/install/config-version.test.ts
@@ -41,7 +41,7 @@ describe("configVersion", () => {
     ).replaceAll(/localhost:\d+/g, "localhost:1234");
     expect(lockfile).toMatchInlineSnapshot(`
       "{
-        "lockfileVersion": 1,
+        "lockfileVersion": 2,
         "configVersion": 1,
         "workspaces": {
           "": {
@@ -89,7 +89,7 @@ describe("configVersion", () => {
     ).replaceAll(/localhost:\d+/g, "localhost:1234");
     expect(lockfile).toMatchInlineSnapshot(`
       "{
-        "lockfileVersion": 1,
+        "lockfileVersion": 2,
         "configVersion": 1,
         "workspaces": {
           "": {
@@ -160,7 +160,7 @@ describe("configVersion", () => {
     ).replaceAll(/localhost:\d+/g, "localhost:1234");
     expect(lockfile).toMatchInlineSnapshot(`
       "{
-        "lockfileVersion": 1,
+        "lockfileVersion": 2,
         "configVersion": 0,
         "workspaces": {
           "": {

--- a/test/cli/install/lockfile-version-2.test.ts
+++ b/test/cli/install/lockfile-version-2.test.ts
@@ -234,11 +234,9 @@ it("re-saving a v1 off-registry lockfile keeps it at version 1", async () => {
     },
   });
 
-  // No `configVersion` key → the install triggers a lockfile re-save (the
-  // configVersion auto-upgrade), which is exactly the save path that would
-  // wrongly stamp v2 without the version-selection guard.
   const v1Lockfile = JSON.stringify({
     lockfileVersion: 1,
+    configVersion: 1,
     workspaces: { "": { name: "root", dependencies: { "no-deps": "1.0.0" } } },
     packages: {
       "no-deps": ["no-deps@1.0.0", `http://127.0.0.1:${offRegistry.port}/no-deps/-/no-deps-1.0.0.tgz`, {}, ""],
@@ -250,7 +248,9 @@ it("re-saving a v1 off-registry lockfile keeps it at version 1", async () => {
     "bun.lock": v1Lockfile,
   });
 
-  // `--lockfile-only` re-serializes the lockfile without performing the install.
+  // `--lockfile-only` re-serializes the lockfile without performing the install
+  // (so the unreachable off-registry tarball is never fetched). This is the
+  // write path that would wrongly stamp v2 without the version-selection guard.
   await using proc = spawn({
     cmd: [bunExe(), "install", "--lockfile-only"],
     cwd: String(dir),

--- a/test/cli/install/lockfile-version-2.test.ts
+++ b/test/cli/install/lockfile-version-2.test.ts
@@ -130,26 +130,27 @@ it("off-registry npm tarball integrity is enforced only at version 2", async () 
 // re-validates the tag before running git, so a v1 lockfile carrying an unsafe
 // tag still never executes anything unsafe.
 it("unsafe git .bun-tag is rejected only at version 2", async () => {
+  // Point at an unreachable local endpoint (port 1) so that when v1 parsing
+  // succeeds and install proceeds to `git clone`, the clone fails fast instead
+  // of reaching out to a real host — keeping this test offline.
+  const gitUrl = "git+ssh://git@127.0.0.1:1/example/repo.git#main";
   const lockfile = (lockfileVersion: number) =>
     JSON.stringify({
       lockfileVersion,
       configVersion: 1,
       workspaces: {
-        "": { name: "root", dependencies: { dep: "git+ssh://git@github.com/example/repo.git#main" } },
+        "": { name: "root", dependencies: { dep: gitUrl } },
       },
       packages: {
         // `.bun-tag` (last element) contains a path separator.
-        dep: ["dep@git+ssh://git@github.com/example/repo.git#main", {}, "../escape"],
+        dep: [`dep@${gitUrl}`, {}, "../escape"],
       },
     });
 
-  // version 2 rejects the unsafe tag while parsing.
+  // version 2 rejects the unsafe tag while parsing, before any git work.
   {
     using dir = tempDir("lockfile-v2-gittag", {
-      "package.json": JSON.stringify({
-        name: "root",
-        dependencies: { dep: "git+ssh://git@github.com/example/repo.git#main" },
-      }),
+      "package.json": JSON.stringify({ name: "root", dependencies: { dep: gitUrl } }),
       "bun.lock": lockfile(2),
     });
     await using proc = spawn({
@@ -164,13 +165,11 @@ it("unsafe git .bun-tag is rejected only at version 2", async () => {
     expect(exitCode).not.toBe(0);
   }
 
-  // version 1 predates the check, so parsing no longer rejects it.
+  // version 1 predates the check, so parsing no longer rejects it (the install
+  // then fails cloning the unreachable repo, but not with the parse-time error).
   {
     using dir = tempDir("lockfile-v1-gittag", {
-      "package.json": JSON.stringify({
-        name: "root",
-        dependencies: { dep: "git+ssh://git@github.com/example/repo.git#main" },
-      }),
+      "package.json": JSON.stringify({ name: "root", dependencies: { dep: gitUrl } }),
       "bun.lock": lockfile(1),
     });
     await using proc = spawn({

--- a/test/cli/install/lockfile-version-2.test.ts
+++ b/test/cli/install/lockfile-version-2.test.ts
@@ -66,8 +66,9 @@ it("an existing v1 lockfile still loads (backward compatible)", async () => {
 // introduced after the Rust rewrite: rejecting it breaks lockfiles written
 // before the check existed, so it is only enforced at version 2.
 it("off-registry npm tarball integrity is enforced only at version 2", async () => {
-  // A host that is never the configured registry. Parsing happens before any
-  // fetch, so this is not actually contacted by the assertions below.
+  // A loopback host that is never the configured registry. For v2 parsing fails
+  // before any fetch, so it is not contacted; for v1 parsing succeeds and the
+  // install proceeds to request the tarball, hitting this 404 handler.
   await using offRegistry = Bun.serve({
     port: 0,
     hostname: "127.0.0.1",
@@ -107,7 +108,7 @@ it("off-registry npm tarball integrity is enforced only at version 2", async () 
   }
 
   // version 1 predates the check, so parsing accepts it (the install then fails
-  // to download the unreachable tarball, but not with the integrity error).
+  // to download the tarball from the 404 handler, but not with the integrity error).
   {
     using dir = tempDir("lockfile-v1-integrity", {
       "package.json": JSON.stringify({ name: "root", dependencies: { "no-deps": "1.0.0" } }),
@@ -125,10 +126,10 @@ it("off-registry npm tarball integrity is enforced only at version 2", async () 
   }
 });
 
-// A git/github `.bun-tag` that is not a safe path/checkout component is also a
-// post-rewrite breaking change, gated the same way. `Repository::checkout`
-// re-validates the tag before running git, so a v1 lockfile carrying an unsafe
-// tag still never executes anything unsafe.
+// An unsafe `git` `.bun-tag` is a post-rewrite breaking change that is gated to
+// v2. `Repository::checkout` re-validates the tag before running git, so a v1
+// lockfile carrying an unsafe git tag still never executes anything unsafe.
+// (The `github` tarball path has no such re-validation — see the next test.)
 it("unsafe git .bun-tag is rejected only at version 2", async () => {
   // Point at an unreachable local endpoint (port 1) so that when v1 parsing
   // succeeds and install proceeds to `git clone`, the clone fails fast instead
@@ -182,4 +183,87 @@ it("unsafe git .bun-tag is rejected only at version 2", async () => {
     const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(err).not.toContain("Invalid git dependency tag");
   }
+});
+
+// A `github` dependency resolves via the tarball-download path, not
+// `Repository::checkout`, so its `.bun-tag` is fed into the cache folder name
+// with no use-site re-validation. The parse-time safety check therefore stays
+// unconditional for github — an unsafe tag is rejected at every version.
+it("unsafe github .bun-tag is rejected at every version", async () => {
+  const ghUrl = "github:example/repo#main";
+  const lockfile = (lockfileVersion: number) =>
+    JSON.stringify({
+      lockfileVersion,
+      configVersion: 1,
+      workspaces: {
+        "": { name: "root", dependencies: { dep: ghUrl } },
+      },
+      packages: {
+        // `.bun-tag` (last element) contains a path separator.
+        dep: [`dep@${ghUrl}`, {}, "../escape"],
+      },
+    });
+
+  for (const version of [1, 2]) {
+    using dir = tempDir(`lockfile-v${version}-githubtag`, {
+      "package.json": JSON.stringify({ name: "root", dependencies: { dep: ghUrl } }),
+      "bun.lock": lockfile(version),
+    });
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--frozen-lockfile"],
+      cwd: String(dir),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).toContain("Invalid git dependency tag");
+    expect(exitCode).not.toBe(0);
+  }
+});
+
+// The writer must not silently upgrade a lockfile to v2 if doing so would make
+// it fail the v2 parse checks on the next install. A v1 lockfile with an
+// off-registry tarball and no integrity hash must round-trip as v1.
+it("re-saving a v1 off-registry lockfile keeps it at version 1", async () => {
+  await using offRegistry = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch() {
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  // No `configVersion` key → the install triggers a lockfile re-save (the
+  // configVersion auto-upgrade), which is exactly the save path that would
+  // wrongly stamp v2 without the version-selection guard.
+  const v1Lockfile = JSON.stringify({
+    lockfileVersion: 1,
+    workspaces: { "": { name: "root", dependencies: { "no-deps": "1.0.0" } } },
+    packages: {
+      "no-deps": ["no-deps@1.0.0", `http://127.0.0.1:${offRegistry.port}/no-deps/-/no-deps-1.0.0.tgz`, {}, ""],
+    },
+  });
+
+  using dir = tempDir("lockfile-v1-roundtrip", {
+    "package.json": JSON.stringify({ name: "root", dependencies: { "no-deps": "1.0.0" } }),
+    "bun.lock": v1Lockfile,
+  });
+
+  // `--lockfile-only` re-serializes the lockfile without performing the install.
+  await using proc = spawn({
+    cmd: [bunExe(), "install", "--lockfile-only"],
+    cwd: String(dir),
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const after = await file(join(String(dir), "bun.lock")).text();
+  expect(err).toContain("Saved lockfile");
+  // Still v1 — the off-registry no-integrity entry can't be made v2-valid, so
+  // stamping v2 would make the next parse reject it.
+  expect(after).toContain(`"lockfileVersion": 1,`);
+  expect(exitCode).toBe(0);
 });

--- a/test/cli/install/lockfile-version-2.test.ts
+++ b/test/cli/install/lockfile-version-2.test.ts
@@ -1,7 +1,7 @@
 import { file, spawn } from "bun";
 import { expect, it } from "bun:test";
 import { exists } from "fs/promises";
-import { bunEnv as env, bunExe, tempDir } from "harness";
+import { bunExe, bunEnv as env, tempDir } from "harness";
 import { join } from "path";
 
 // These tests cover the text lockfile bump to version 2 and the parse-time

--- a/test/cli/install/lockfile-version-2.test.ts
+++ b/test/cli/install/lockfile-version-2.test.ts
@@ -1,0 +1,186 @@
+import { file, spawn } from "bun";
+import { expect, it } from "bun:test";
+import { exists } from "fs/promises";
+import { bunEnv as env, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// These tests cover the text lockfile bump to version 2 and the parse-time
+// checks gated behind it. They use `file:` dependencies so they run fully
+// offline (no registry required).
+
+it("a freshly written text lockfile defaults to version 2", async () => {
+  using dir = tempDir("lockfile-v2-default", {
+    "package.json": JSON.stringify({ name: "root", dependencies: { dep: "file:./dep" } }),
+    "dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
+  });
+
+  await using proc = spawn({
+    cmd: [bunExe(), "install", "--save-text-lockfile"],
+    cwd: String(dir),
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const lockfile = await file(join(String(dir), "bun.lock")).text();
+  expect(err).not.toContain("error:");
+  expect(lockfile).toContain(`"lockfileVersion": 2,`);
+  expect(exitCode).toBe(0);
+});
+
+it("an existing v1 lockfile still loads (backward compatible)", async () => {
+  const v1Lockfile =
+    JSON.stringify(
+      {
+        lockfileVersion: 1,
+        configVersion: 1,
+        workspaces: { "": { name: "root", dependencies: { dep: "file:./dep" } } },
+        packages: { dep: ["dep@file:dep", {}] },
+      },
+      null,
+      2,
+    ) + "\n";
+
+  using dir = tempDir("lockfile-v1-load", {
+    "package.json": JSON.stringify({ name: "root", dependencies: { dep: "file:./dep" } }),
+    "dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
+    "bun.lock": v1Lockfile,
+  });
+
+  await using proc = spawn({
+    cmd: [bunExe(), "install", "--frozen-lockfile"],
+    cwd: String(dir),
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(err).not.toContain("error:");
+  expect(await exists(join(String(dir), "node_modules", "dep", "package.json"))).toBe(true);
+  expect(exitCode).toBe(0);
+});
+
+// An off-registry npm tarball URL with no integrity hash is a breaking change
+// introduced after the Rust rewrite: rejecting it breaks lockfiles written
+// before the check existed, so it is only enforced at version 2.
+it("off-registry npm tarball integrity is enforced only at version 2", async () => {
+  // A host that is never the configured registry. Parsing happens before any
+  // fetch, so this is not actually contacted by the assertions below.
+  await using offRegistry = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch() {
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  const offRegistryTarball = `http://127.0.0.1:${offRegistry.port}/no-deps/-/no-deps-1.0.0.tgz`;
+  const lockfile = (lockfileVersion: number) =>
+    JSON.stringify({
+      lockfileVersion,
+      configVersion: 1,
+      workspaces: { "": { name: "root", dependencies: { "no-deps": "1.0.0" } } },
+      packages: { "no-deps": ["no-deps@1.0.0", offRegistryTarball, {}, ""] },
+    });
+
+  // version 2 fails closed while parsing.
+  {
+    using dir = tempDir("lockfile-v2-integrity", {
+      "package.json": JSON.stringify({ name: "root", dependencies: { "no-deps": "1.0.0" } }),
+      "bun.lock": lockfile(2),
+    });
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--frozen-lockfile"],
+      cwd: String(dir),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).toContain(
+      "Missing integrity hash for npm package resolved to a tarball URL outside the configured registry",
+    );
+    expect(await exists(join(String(dir), "node_modules", "no-deps"))).toBe(false);
+    expect(exitCode).not.toBe(0);
+  }
+
+  // version 1 predates the check, so parsing accepts it (the install then fails
+  // to download the unreachable tarball, but not with the integrity error).
+  {
+    using dir = tempDir("lockfile-v1-integrity", {
+      "package.json": JSON.stringify({ name: "root", dependencies: { "no-deps": "1.0.0" } }),
+      "bun.lock": lockfile(1),
+    });
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--frozen-lockfile"],
+      cwd: String(dir),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("Missing integrity hash");
+  }
+});
+
+// A git/github `.bun-tag` that is not a safe path/checkout component is also a
+// post-rewrite breaking change, gated the same way. `Repository::checkout`
+// re-validates the tag before running git, so a v1 lockfile carrying an unsafe
+// tag still never executes anything unsafe.
+it("unsafe git .bun-tag is rejected only at version 2", async () => {
+  const lockfile = (lockfileVersion: number) =>
+    JSON.stringify({
+      lockfileVersion,
+      configVersion: 1,
+      workspaces: {
+        "": { name: "root", dependencies: { dep: "git+ssh://git@github.com/example/repo.git#main" } },
+      },
+      packages: {
+        // `.bun-tag` (last element) contains a path separator.
+        dep: ["dep@git+ssh://git@github.com/example/repo.git#main", {}, "../escape"],
+      },
+    });
+
+  // version 2 rejects the unsafe tag while parsing.
+  {
+    using dir = tempDir("lockfile-v2-gittag", {
+      "package.json": JSON.stringify({
+        name: "root",
+        dependencies: { dep: "git+ssh://git@github.com/example/repo.git#main" },
+      }),
+      "bun.lock": lockfile(2),
+    });
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--frozen-lockfile"],
+      cwd: String(dir),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).toContain("Invalid git dependency tag");
+    expect(exitCode).not.toBe(0);
+  }
+
+  // version 1 predates the check, so parsing no longer rejects it.
+  {
+    using dir = tempDir("lockfile-v1-gittag", {
+      "package.json": JSON.stringify({
+        name: "root",
+        dependencies: { dep: "git+ssh://git@github.com/example/repo.git#main" },
+      }),
+      "bun.lock": lockfile(1),
+    });
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--frozen-lockfile"],
+      cwd: String(dir),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("Invalid git dependency tag");
+  }
+});

--- a/test/cli/install/lockfile-version-2.test.ts
+++ b/test/cli/install/lockfile-version-2.test.ts
@@ -5,8 +5,9 @@ import { bunExe, bunEnv as env, tempDir } from "harness";
 import { join } from "path";
 
 // These tests cover the text lockfile bump to version 2 and the parse-time
-// checks gated behind it. They use `file:` dependencies so they run fully
-// offline (no registry required).
+// checks gated behind it. They run fully offline — using `file:` deps or
+// loopback/unreachable endpoints — so no external network or registry is
+// required.
 
 it("a freshly written text lockfile defaults to version 2", async () => {
   using dir = tempDir("lockfile-v2-default", {

--- a/test/cli/install/migration/__snapshots__/pnpm-comprehensive.test.ts.snap
+++ b/test/cli/install/migration/__snapshots__/pnpm-comprehensive.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`pnpm comprehensive migration tests large single package with many dependencies: large-single-package 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -94,7 +94,7 @@ exports[`pnpm comprehensive migration tests large single package with many depen
 
 exports[`pnpm comprehensive migration tests complex monorepo with cross-dependencies: complex-monorepo 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -248,7 +248,7 @@ exports[`pnpm comprehensive migration tests complex monorepo with cross-dependen
 
 exports[`pnpm comprehensive migration tests pnpm with patches and overrides: patches-overrides 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -287,7 +287,7 @@ exports[`pnpm comprehensive migration tests pnpm with patches and overrides: pat
 
 exports[`pnpm comprehensive migration tests pnpm with peer dependencies and auto-install-peers: peer-deps-auto-install 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {

--- a/test/cli/install/migration/__snapshots__/pnpm-lock-migration.test.ts.snap
+++ b/test/cli/install/migration/__snapshots__/pnpm-lock-migration.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`pnpm-lock.yaml migration simple pnpm lockfile migration produces correct bun.lock: simple-pnpm-migration 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -24,7 +24,7 @@ exports[`pnpm-lock.yaml migration simple pnpm lockfile migration produces correc
 
 exports[`pnpm-lock.yaml migration pnpm workspace lockfile migration: workspace-pnpm-migration 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -86,7 +86,7 @@ exports[`pnpm-lock.yaml migration pnpm workspace lockfile migration: workspace-p
 
 exports[`pnpm-lock.yaml migration pnpm with npm protocol aliases: npm-aliases-pnpm-migration 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {

--- a/test/cli/install/migration/__snapshots__/pnpm-migration-complete.test.ts.snap
+++ b/test/cli/install/migration/__snapshots__/pnpm-migration-complete.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: basic-dependencies 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -33,7 +33,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: canary-versions 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -58,7 +58,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: monorepo-workspaces 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -112,7 +112,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: patches-overrides 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -137,7 +137,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: file-link-deps 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -159,7 +159,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: custom-registries 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -181,7 +181,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: peer-dependencies 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -210,7 +210,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: duplicate-packages 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -242,7 +242,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: catalogs 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -276,7 +276,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: integrity-hashes 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -298,7 +298,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: version-zero 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -317,7 +317,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: mixed-dependency-types 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -349,7 +349,7 @@ exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with al
 
 exports[`PNPM Migration Complete Test Suite comprehensive PNPM migration with all edge cases: circular-workspaces 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {

--- a/test/cli/install/migration/__snapshots__/pnpm-migration.test.ts.snap
+++ b/test/cli/install/migration/__snapshots__/pnpm-migration.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`basic: bun.lock 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {

--- a/test/cli/install/migration/__snapshots__/yarn-lock-migration.test.ts.snap
+++ b/test/cli/install/migration/__snapshots__/yarn-lock-migration.test.ts.snap
@@ -3120,7 +3120,7 @@ exports[`bun pm migrate for existing yarn.lock yarn-lock-mkdirp-no-resolved: yar
 
 exports[`bun pm migrate for existing yarn.lock yarn-stuff: yarn-stuff 1`] = `
 "{
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {

--- a/test/cli/install/migration/__snapshots__/yarn-lock-migration.test.ts.snap
+++ b/test/cli/install/migration/__snapshots__/yarn-lock-migration.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`yarn.lock migration basic simple yarn.lock migration produces correct bun.lock: simple-yarn-migration 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -21,7 +21,7 @@ exports[`yarn.lock migration basic simple yarn.lock migration produces correct b
 
 exports[`yarn.lock migration basic complex yarn.lock with multiple dependencies and versions: complex-yarn-migration 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -169,7 +169,7 @@ exports[`yarn.lock migration basic complex yarn.lock with multiple dependencies 
 
 exports[`yarn.lock migration basic yarn.lock with npm aliases: aliases-yarn-migration 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -195,7 +195,7 @@ exports[`yarn.lock migration basic yarn.lock with npm aliases: aliases-yarn-migr
 
 exports[`yarn.lock migration basic yarn.lock with resolutions: resolutions-yarn-migration 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -219,7 +219,7 @@ exports[`yarn.lock migration basic yarn.lock with resolutions: resolutions-yarn-
 
 exports[`yarn.lock migration basic yarn.lock with workspace dependencies: workspace-yarn-migration 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -238,7 +238,7 @@ exports[`yarn.lock migration basic yarn.lock with workspace dependencies: worksp
 
 exports[`yarn.lock migration basic yarn.lock with scoped packages and parent/child relationships: scoped-yarn-migration 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -266,7 +266,7 @@ exports[`yarn.lock migration basic yarn.lock with scoped packages and parent/chi
 
 exports[`yarn.lock migration basic migration with realistic complex yarn.lock: complex-realistic-yarn-migration 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -321,7 +321,7 @@ exports[`yarn.lock migration basic migration with realistic complex yarn.lock: c
 
 exports[`bun pm migrate for existing yarn.lock yarn-cli-repo: yarn-cli-repo 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3066,7 +3066,7 @@ exports[`bun pm migrate for existing yarn.lock yarn-cli-repo: yarn-cli-repo 1`] 
 
 exports[`bun pm migrate for existing yarn.lock yarn-lock-mkdirp: yarn-lock-mkdirp 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3084,7 +3084,7 @@ exports[`bun pm migrate for existing yarn.lock yarn-lock-mkdirp: yarn-lock-mkdir
 
 exports[`bun pm migrate for existing yarn.lock yarn-lock-mkdirp-file-dep: yarn-lock-mkdirp-file-dep 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3102,7 +3102,7 @@ exports[`bun pm migrate for existing yarn.lock yarn-lock-mkdirp-file-dep: yarn-l
 
 exports[`bun pm migrate for existing yarn.lock yarn-lock-mkdirp-no-resolved: yarn-lock-mkdirp-no-resolved 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3120,7 +3120,7 @@ exports[`bun pm migrate for existing yarn.lock yarn-lock-mkdirp-no-resolved: yar
 
 exports[`bun pm migrate for existing yarn.lock yarn-stuff: yarn-stuff 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3163,7 +3163,7 @@ exports[`bun pm migrate for existing yarn.lock yarn-stuff: yarn-stuff 1`] = `
 
 exports[`bun pm migrate for existing yarn.lock yarn-stuff/abbrev-link-target: yarn-stuff/abbrev-link-target 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -3177,7 +3177,7 @@ exports[`bun pm migrate for existing yarn.lock yarn-stuff/abbrev-link-target: ya
 
 exports[`bun pm migrate for existing yarn.lock yarn.lock with packages that have os/cpu requirements: os-cpu-yarn-migration 1`] = `
 "{
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -1978,7 +1978,7 @@ linker = "${linker}"
       const normalizedLockfile = lockfile.replace(/http:\/\/localhost:\d+/g, "http://localhost:<port>");
       expect(normalizeBunSnapshot(normalizedLockfile, dir)).toMatchInlineSnapshot(`
           "{
-            "lockfileVersion": 1,
+            "lockfileVersion": 2,
             "configVersion": 1,
             "workspaces": {
               "": {


### PR DESCRIPTION
## What

Introduces text `lockfileVersion` 2, makes it the default, and gates two parse-time checks — added after the Rust rewrite — behind it so that older lockfiles keep loading.

## Background

Two checks landed in `src/install/lockfile/bun.lock.rs` that *reject* a text lockfile the earlier versions accepted:

1. **Off-registry npm tarball integrity** — an npm package resolved to a tarball URL that is not under the configured/default registry must carry a supported integrity hash, otherwise parsing fails with `Missing integrity hash for npm package resolved to a tarball URL outside the configured registry`.
2. **Unsafe git `.bun-tag`** — a git/github `.bun-tag` that is not a safe single path component (`is_safe_resolved_tag`) is rejected at parse with `Invalid git dependency tag`.

Both are breaking: a `bun.lock` written before these checks existed (e.g. an npm entry with an off-registry tarball and no integrity hash) now fails to parse.

## Change

- Add `Version::V2` and an `at_least()` helper; bump `Version::CURRENT` from V1 to V2. The writer always emits the current version, so fresh lockfiles are now `"lockfileVersion": 2`.
- Gate both parse-time rejections behind `lockfile_version.at_least(Version::V2)`. For v0/v1 lockfiles the checks are skipped (the pre-check behavior), so existing lockfiles keep loading.

### Security note

The git `.bun-tag` check is a path-traversal / checkout-arg guard. It is **re-validated at the point of use** in `Repository::checkout` (`src/install/repository.rs`) with the same `is_safe_resolved_tag`, before any cache directory path is built or `git` is invoked — and a git dependency can only reach the cache through `checkout`. Skipping the *parse-time* rejection for older lockfile versions therefore does not reopen the vulnerability; an unsafe tag still cannot be checked out or turned into a traversal path.

The off-registry integrity gate restores, for v0/v1 only, the behavior Bun shipped before the check was added. Lockfiles written at v2 always carry integrity for off-registry tarballs, so enforcement there is unaffected.

## Verification

New offline test `test/cli/install/lockfile-version-2.test.ts` (uses `file:` deps, no registry):

- a freshly written text lockfile defaults to version 2
- an existing v1 lockfile still loads
- off-registry npm tarball integrity is enforced only at version 2 (v2 rejects at parse; v1 does not)
- unsafe git `.bun-tag` is rejected only at version 2

Fail-before/pass-after confirmed by building with the `src/` change stashed: the three version-gated tests fail (v2 is an unknown version / v1 still rejects), and pass with the change applied.

Also updated the existing off-registry-integrity test in `test/cli/install/bun-lock.test.ts` to assert the v2 behavior, and regenerated the written-lockfile snapshots (`lockfileVersion` 1 → 2). Input-fixture lockfiles in tests are deliberately left at version 1 to keep exercising backward-compatible loading.
