### PR TITLE
bun_alloc: delete unused MimallocHeapRef, TypedArena, BumpWithFallback

### DIFF
--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -326,8 +326,6 @@ macro_rules! arena_format {
         __s
     }};
 }
-/// `typed_arena::Arena<T>` — typed slab with stable addresses (AST node Store).
-pub type TypedArena<T> = typed_arena::Arena<T>;
 
 /// `bun.use_mimalloc` — false under ASAN, where the global allocator is `std::alloc::System`.
 pub const USE_MIMALLOC: bool = cfg!(not(bun_asan));
@@ -526,7 +524,7 @@ pub use buffer_fallback_allocator::BufferFallbackAllocator;
 pub use max_heap_allocator::MaxHeapAllocator;
 pub use maybe_owned::MaybeOwned;
 pub use nullable_allocator::NullableAllocator;
-pub use stack_fallback::{ArenaPtr, BumpWithFallback, MimallocHeapRef, StackFallback};
+pub use stack_fallback::{ArenaPtr, StackFallback};
 
 #[path = "MimallocArena.rs"]
 pub mod mimalloc_arena;

--- a/src/bun_alloc/maybe_owned.rs
+++ b/src/bun_alloc/maybe_owned.rs
@@ -69,12 +69,6 @@ impl<A> MaybeOwned<A> {
         self._parent.as_ref()
     }
 
-    pub fn into_parent(self) -> Option<A> {
-        // Zig: `defer self.* = undefined; return self.rawParent();`
-        // Taking `self` by value consumes it; no explicit invalidation needed.
-        self._parent
-    }
-
     /// Used by smart pointer types and allocator wrappers. See `crate::borrow`.
     pub fn borrow(&self) -> MaybeOwnedBorrowed {
         // Borrowed view carries no allocator state — just the owned/borrowed bit.

--- a/src/bun_alloc/memory.rs
+++ b/src/bun_alloc/memory.rs
@@ -2,16 +2,6 @@
 
 /// Default-initializes a value of type `T`.
 ///
-/// Zig tried, in order: `T.initDefault()`, then `T.init()`, then `.{}`. All three
-/// collapse into Rust's `Default` trait — types that had `initDefault`/`init` in Zig
-/// should `impl Default` in their Rust port.
-// PORT NOTE: `std.meta.hasFn` (≈ `@hasDecl`) fallback chain → single `Default` bound
-// per §Comptime reflection ("optional behavior → trait with default method").
-#[inline]
-pub fn init_default<T: Default>() -> T {
-    T::default()
-}
-
 // ──────────────────────────────────────────────────────────────────────────────
 // PORT NOTE: `exemptedFromDeinit`, `deinitIsVoid`, and `deinit` are intentionally
 // NOT ported as functions.

--- a/src/bun_alloc/memory.rs
+++ b/src/bun_alloc/memory.rs
@@ -1,7 +1,5 @@
 //! Basic utilities for working with memory and objects.
 
-/// Default-initializes a value of type `T`.
-///
 // ──────────────────────────────────────────────────────────────────────────────
 // PORT NOTE: `exemptedFromDeinit`, `deinitIsVoid`, and `deinit` are intentionally
 // NOT ported as functions.

--- a/src/bun_alloc/stack_fallback.rs
+++ b/src/bun_alloc/stack_fallback.rs
@@ -59,9 +59,6 @@ pub struct StackFallback<const N: usize, A: Allocator = std::alloc::Global> {
     buf: UnsafeCell<[MaybeUninit<u8>; N]>,
 }
 
-/// Back-compat alias for the previous name; prefer [`StackFallback`].
-pub type BumpWithFallback<const N: usize, A> = StackFallback<N, A>;
-
 impl<const N: usize, A: Allocator> StackFallback<N, A> {
     /// Zig: `std.heap.stackFallback(N, fallback)`. `const` — `MaybeUninit<u8>:
     /// Copy`, so `[MaybeUninit::uninit(); N]` needs no inline-const;
@@ -105,13 +102,6 @@ impl<const N: usize, A: Allocator> StackFallback<N, A> {
     #[inline]
     pub fn fallback(&self) -> &A {
         &self.fallback
-    }
-
-    /// Mutably borrow the fallback allocator (e.g. to rebind a heap pointer
-    /// after the backing `MimallocArena::reset` swapped it).
-    #[inline]
-    pub fn fallback_mut(&mut self) -> &mut A {
-        &mut self.fallback
     }
 
     #[inline(always)]
@@ -401,106 +391,6 @@ unsafe impl Allocator for ArenaPtr {
         new: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
         // SAFETY: same paths as `grow`.
-        unsafe { self.grow(ptr, old, new) }
-    }
-}
-
-// ── MimallocHeapRef ──────────────────────────────────────────────────────────
-//
-// Thin `Allocator` over a raw `*mut mi_heap_t`. Unlike [`ArenaPtr`] this
-// addresses the C-heap-resident `mi_heap_t` directly (stable across moves of
-// the `MimallocArena` wrapper struct), at the cost of bypassing
-// `MimallocArena::track_alloc`. Kept for callers that only have a heap handle.
-//
-// `heap == null` routes to global `mi_malloc`/`mi_free`, matching
-// [`crate::ast_alloc::AstAlloc`] when no AST scope is active.
-
-/// Borrowed `mi_heap_t*` as an [`Allocator`]. See section doc above.
-#[derive(Clone, Copy)]
-pub struct MimallocHeapRef {
-    heap: *mut mimalloc::Heap,
-}
-
-impl MimallocHeapRef {
-    /// Wrap a live `mi_heap_t*`. The caller guarantees `heap` outlives every
-    /// allocation made through this ref (i.e. the owning `MimallocArena` is not
-    /// `reset()`/dropped while this ref is in use).
-    #[inline]
-    pub const fn new(heap: *mut mimalloc::Heap) -> Self {
-        Self { heap }
-    }
-    /// Null heap → process-global `mi_malloc`/`mi_free`.
-    #[inline]
-    pub const fn global() -> Self {
-        Self {
-            heap: ptr::null_mut(),
-        }
-    }
-    /// The wrapped heap pointer (null when global).
-    #[inline]
-    pub fn heap(&self) -> *mut mimalloc::Heap {
-        self.heap
-    }
-    /// Rebind to a new heap (e.g. after `MimallocArena::reset` rebuilt it).
-    #[inline]
-    pub fn set_heap(&mut self, heap: *mut mimalloc::Heap) {
-        self.heap = heap;
-    }
-}
-
-// SAFETY: identical contract to `&MimallocArena` / `AstAlloc` —
-// `mi_[heap_]malloc[_aligned]` yields ≥`size` bytes aligned to `align`;
-// `mi_free` accepts any mimalloc-owned pointer regardless of origin heap;
-// `mi_[heap_]realloc_aligned` preserves the `min(old,new)` prefix and frees
-// the old block. `heap` must be null or a live `mi_heap_t*` for this ref's
-// lifetime (caller contract — see [`MimallocHeapRef::new`]).
-unsafe impl Allocator for MimallocHeapRef {
-    #[inline]
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        let h = self.heap;
-        let p = if h.is_null() {
-            mimalloc::mi_malloc_auto_align(layout.size(), layout.align())
-        } else {
-            // SAFETY: `h` is live per the caller contract on `new`.
-            unsafe { mimalloc::mi_heap_malloc_auto_align(h, layout.size(), layout.align()) }
-        };
-        alloc_result(p, layout.size())
-    }
-
-    #[inline]
-    unsafe fn deallocate(&self, ptr: NonNull<u8>, _layout: Layout) {
-        // SAFETY: `ptr` came from `mi_[heap_]malloc*` per `allocate`/`grow`;
-        // `mi_free` is heap-agnostic and thread-safe.
-        unsafe { mimalloc::mi_free(ptr.as_ptr().cast()) }
-    }
-
-    #[inline]
-    unsafe fn grow(
-        &self,
-        ptr: NonNull<u8>,
-        _old: Layout,
-        new: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
-        let h = self.heap;
-        // SAFETY: see `allocate`; realloc accepts cross-heap pointers.
-        let p = unsafe {
-            if h.is_null() {
-                mimalloc::mi_realloc_aligned(ptr.as_ptr().cast(), new.size(), new.align())
-            } else {
-                mimalloc::mi_heap_realloc_aligned(h, ptr.as_ptr().cast(), new.size(), new.align())
-            }
-        };
-        alloc_result(p, new.size())
-    }
-
-    #[inline]
-    unsafe fn shrink(
-        &self,
-        ptr: NonNull<u8>,
-        old: Layout,
-        new: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
-        // SAFETY: same realloc path as `grow`.
         unsafe { self.grow(ptr, old, new) }
     }
 }


### PR DESCRIPTION
Dead-code sweep of `bun_alloc`. None referenced outside their own definitions.

`cargo check --workspace` passes.

## Why this code exists

| Item | Zig original | Zig callers | Status |
|---|---|---|---|
| `MimallocHeapRef` | none (0 hits in `*.zig`) | n/a | **Rust-port artifact** — speculative `Allocator` impl over raw `*mut mi_heap_t`, added in 9532c8403b; superseded by `ArenaPtr`, never referenced outside `src/bun_alloc/` |
| `TypedArena<T>` | none (0 hits for `typed_arena`/`TypedArena` in `*.zig`) | n/a | **Rust-port artifact** — re-export of `typed_arena::Arena` added in 76a508931e, never referenced |
| `BumpWithFallback` | none | n/a | **Rust-port artifact** — was the original struct name in 9532c8403b, renamed to `StackFallback` in 4075846085 leaving this "back-compat alias"; no external caller ever existed |
| `StackFallback::fallback_mut` | none — Zig `std.heap.StackFallbackAllocator` exposes `fallback_allocator` as a public *field* (e.g. `src/js_printer/renamer.zig:496,532`), no method accessor | n/a | **Rust-port artifact** — Rust-idiom getter (fields are private in the Rust port); the immutable `fallback()` is used, this `&mut` variant never was |
| `init_default<T>` | `src/bun_alloc/memory.zig:36` (`initDefault`) | 15 — e.g. `src/ptr/owned.zig:58,64,111,147`, `src/ptr/shared.zig:100`, `src/collections/array_list.zig:70,81,165`, `src/threading/guarded.zig:19` | Rust callers were rewritten to plain `T::default()` over 1f86fa622b / 87d8efd791 / 98ba4b19e6 / 21daace12c; the wrapper is now identity |
| `MaybeOwned::into_parent` | `src/bun_alloc/maybe_owned.zig:76` (`intoParent`) | 0 external — only called internally by `deinit` at `:48` | **dead in Zig too** (public but only self-consumed) |
