### PR TITLE
bun_core: delete unused MapLike trait, FieldType marker, EmbedDir

### DIFF
--- a/src/bun_core/deprecated.rs
+++ b/src/bun_core/deprecated.rs
@@ -74,18 +74,6 @@ pub fn buffered_reader<R: DeprecatedRead>(reader: R) -> BufferedReader<4096, R> 
     }
 }
 
-pub fn buffered_reader_size<const SIZE: usize, R: DeprecatedRead>(
-    reader: R,
-) -> BufferedReader<SIZE, R> {
-    BufferedReader {
-        unbuffered_reader: reader,
-        // PERF(port): Zig left `buf` undefined; zero-init here is an extra memset.
-        buf: [0u8; SIZE],
-        start: 0,
-        end: 0,
-    }
-}
-
 // ──────────────────────────────────────────────────────────────────────────
 // SinglyLinkedList
 // ──────────────────────────────────────────────────────────────────────────
@@ -330,24 +318,6 @@ impl<T> DoublyLinkedList<T> {
 // Canonical impl lives in the leaf `bun_hash` crate; re-export so the
 // historical `crate::deprecated::RapidHash` path keeps resolving.
 pub use bun_hash::RapidHash;
-
-// ──────────────────────────────────────────────────────────────────────────
-// misc
-// ──────────────────────────────────────────────────────────────────────────
-
-// TODO(port): comptime reflection — Zig picks "{f}" if `ty` has a `format` method,
-// otherwise `fallback`. Rust has no `@hasDecl`; the equivalent is "does `T: Display`?".
-// Format specifiers also differ (Rust uses "{}" for both). Callers should be migrated
-// to use `Display` directly; until then this returns the fallback unconditionally.
-pub const fn auto_format_label_fallback<T>(fallback: &'static str) -> &'static str {
-    // TODO(port): `std.meta.hasFn(ty, "format")` reflection — see note above.
-    let _ = core::marker::PhantomData::<T>;
-    fallback
-}
-
-pub const fn auto_format_label<T>() -> &'static str {
-    auto_format_label_fallback::<T>("{s}")
-}
 
 // ──────────────────────────────────────────────────────────────────────────
 // tests

--- a/src/bun_core/string/PathString.rs
+++ b/src/bun_core/string/PathString.rs
@@ -54,10 +54,6 @@ const POINTER_BITS: u32 = if USE_SMALL_PATH_STRING_ {
 pub struct PathString(PathStringBackingInt);
 
 impl PathString {
-    // pub const PathInt / PointerIntType — Zig exposed these as type aliases; in
-    // Rust the packed accessors below replace them.
-    pub const USE_SMALL_PATH_STRING: bool = USE_SMALL_PATH_STRING_;
-
     const PTR_MASK: PathStringBackingInt = (1 as PathStringBackingInt)
         .wrapping_shl(POINTER_BITS)
         .wrapping_sub(1);

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -1,108 +1,3 @@
-// Things that maybe should go in Zig standard library at some point
-//
-// PORT NOTE: This file is almost entirely comptime type reflection (`@typeInfo`,
-// `@hasField`, `@hasDecl`, `std.meta.fields`, `bun.trait.*`) used to generically
-// construct maps/arrays from heterogeneous inputs. Rust has no runtime/comptime
-// type reflection; the idiomatic equivalents are the `From` / `FromIterator` /
-// `Extend` traits, plus associated types for `Key`/`Value`. The functions
-// below preserve the Zig names and intent but delegate to traits that the
-// concrete collection types (HashMap, Vec, MultiArrayList, Vec) must impl.
-// TODO(refactor): audit call sites of `bun.from(...)` / `bun.fromEntries(...)` and
-// likely replace them with direct `.collect()` / `Vec::from` at the caller.
-
-use core::hash::Hash;
-
-// TODO(port): impls for bun_collections::{VecExt, HashMap, MultiArrayList} move to
-// bun_collections (move-in pass) — orphan rule lets the higher-tier crate impl
-// MapLike for its own types.
-
-// ─── Key / Value ──────────────────────────────────────────────────────────────
-// Zig: `pub fn Key(comptime Map: type) type { return FieldType(Map.KV, "key").?; }`
-// Zig: `pub fn Value(comptime Map: type) type { return FieldType(Map.KV, "value").?; }`
-//
-// Rust has no `fn -> type`; these become associated types on a trait that all
-// map-like collections implement.
-pub trait MapLike {
-    type Key;
-    type Value;
-
-    fn ensure_unused_capacity(&mut self, additional: usize);
-    fn put_assume_capacity(&mut self, key: Self::Key, value: Self::Value);
-    fn put_assume_capacity_no_clobber(&mut self, key: Self::Key, value: Self::Value);
-}
-
-// Convenience aliases mirroring the Zig `Key(Map)` / `Value(Map)` call sites.
-pub type Key<M> = <M as MapLike>::Key;
-pub type Value<M> = <M as MapLike>::Value;
-
-// ─── fromEntries ──────────────────────────────────────────────────────────────
-// Zig dispatches on `@typeInfo(EntryType)`:
-//   - indexable tuple/array of `[k, v]` pairs  → reserve + putAssumeCapacity
-//   - container with `.count()` + `.iterator()` → reserve + iterate
-//   - struct with fields                        → reserve(fields.len) + inline for
-//   - *const struct with fields                 → same, deref'd
-//   - else: @compileError
-//
-// In Rust the first two arms collapse to `IntoIterator<Item = (K, V)>` with an
-// `ExactSizeIterator` bound for the reserve; the "struct fields as entries"
-// arms have no equivalent (would need a derive) and are TODO'd.
-pub fn from_entries<M, I>(entries: I) -> M
-where
-    M: MapLike + Default,
-    I: IntoIterator<Item = (M::Key, M::Value)>,
-    I::IntoIter: ExactSizeIterator,
-{
-    // Zig: `if (@hasField(Map, "allocator")) Map.init(allocator) else Map{}`
-    // Allocator param dropped (non-AST crate); both arms become `Default`.
-    let mut map = M::default();
-
-    let iter = entries.into_iter();
-
-    // Zig: `try map.ensureUnusedCapacity([allocator,] entries.len)` — the
-    // `needsAllocator` check vanishes because the allocator param is gone.
-    map.ensure_unused_capacity(iter.len());
-
-    for (k, v) in iter {
-        // PERF(port): was putAssumeCapacity — profile if hot.
-        map.put_assume_capacity(k, v);
-    }
-
-    // TODO(port): the Zig `bun.trait.isContainer(EntryType) && fields.len > 0`
-    // and `isConstPtr(EntryType) && fields(Child).len > 0` arms iterated *struct
-    // fields* as entries (anonymous-struct-literal init). No Rust equivalent
-    // without a proc-macro; callers should pass an array/iterator of tuples.
-
-    map
-}
-
-// ─── fromMapLike ──────────────────────────────────────────────────────────────
-// Zig: takes `[]const struct { K, V }` and `putAssumeCapacityNoClobber`s each.
-pub fn from_map_like<M>(entries: &[(M::Key, M::Value)]) -> M
-where
-    M: MapLike + Default,
-    M::Key: Clone,
-    M::Value: Clone,
-{
-    // Zig: `if (@hasField(Map, "allocator")) Map.init(allocator) else Map{}`
-    let mut map = M::default();
-
-    map.ensure_unused_capacity(entries.len());
-
-    for entry in entries {
-        map.put_assume_capacity_no_clobber(entry.0.clone(), entry.1.clone());
-    }
-
-    map
-}
-
-// ─── FieldType ────────────────────────────────────────────────────────────────
-// Zig: `pub fn FieldType(comptime Map: type, comptime name: []const u8) ?type`
-// TODO(port): no Rust equivalent for `std.meta.fieldIndex` / `.field_type`.
-// Callers should use associated types (`MapLike::Key`) directly. Left as a
-// doc-only marker so cross-file grep finds it.
-#[doc(hidden)]
-pub enum FieldType {} // unconstructible; reflection placeholder
-
 // ─── std.mem.bytesAsSlice / sliceAsBytes ─────────────────────────────────────
 /// Zig `std.mem.bytesAsSlice(T, bytes)` for `&mut [u8]` → `&mut [T]`.
 ///
@@ -189,9 +84,6 @@ impl<T: Copy> Unaligned<T> {
         unsafe { core::slice::from_raw_parts_mut(slice.as_mut_ptr().cast::<T>(), slice.len()) }
     }
 }
-
-// ─── needsAllocator ───────────────────────────────────────────────────────────
-// Zig: `fn needsAllocator(comptime Fn: anytype) bool { ArgsTuple(Fn).len > 2 }`
 
 // ════════════════════════════════════════════════════════════════════════════
 // Low-tier primitives hoisted into bun_core.
@@ -3227,8 +3119,6 @@ pub enum EmbedKind {
     Src,
     SrcEager,
 }
-/// The original drafts spelled this both ways; alias keeps both compiling.
-pub type EmbedDir = EmbedKind;
 
 pub fn runtime_embed_file(_root: EmbedKind, sub_path: &'static str) -> &'static str {
     panic!(

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -110,10 +110,8 @@ pub fn validate_path(
     Box::from(out)
 }
 
-// PORT NOTE: options.zig `stringHashMapFromArrays` — use `bun_core::util::{MapLike, from_entries}`
-// or inline the construction (see definesFromTransformOptions / loadersFromTransformOptions below).
-// Note `from_entries` reserves `iter.len()`; if you need the Zig over-reserve (`keys.len + N`),
-// call `MapLike::ensure_unused_capacity(total_cap)` yourself before zipping keys/values.
+// PORT NOTE: options.zig `stringHashMapFromArrays` — inline the construction
+// (see definesFromTransformOptions / loadersFromTransformOptions below).
 
 // `AllowUnresolved` is defined canonically in
 // `bun_js_parser::options` (lower tier) because the parser is the consumer
@@ -434,8 +432,7 @@ pub trait LoaderExt: Copy {
     // import.
 
     // TODO(port): `obj: anytype` — Zig duck-typed `.get(ext) -> Option<Loader>`.
-    // Monomorphized to the only concrete map type callers pass (`LoaderHashTable`);
-    // a `MapLike` trait is overkill for one call site.
+    // Monomorphized to the only concrete map type callers pass (`LoaderHashTable`).
     fn for_file_name(filename: &[u8], obj: &LoaderHashTable) -> Option<Loader> {
         let ext = bun_paths::extension(filename);
         if ext.is_empty() || (ext.len() == 1 && ext[0] == b'.') {


### PR DESCRIPTION
Follow-up to #31536 — removes the remaining unused comptime-reflection placeholders from `util.rs` plus a few `bun_core` strays.

`cargo check --workspace` passes.

## Why this code exists

`src/bun_core/util.zig` is **not `@import`ed anywhere** in `src/**/*.zig` (every `util` import points at `runtime/shell/util.zig`, `node/util/validators.zig`, etc.; `bun.zig` does not re-export it). So everything ported from that file was dead from day one.

| Item | Zig original | Zig callers | Status |
|---|---|---|---|
| `MapLike` trait | none — Zig used comptime duck-typing (`Map.KV`, `@hasField`, `@FieldType` builtin) | n/a | **Rust-port artifact** (translation of the comptime probes) |
| `Key<M>` / `Value<M>` | `src/bun_core/util.zig:3,7` | 0 — not even used inside `util.zig` (`fromMapLike` calls the `@FieldType` builtin directly) | **dead in Zig too** |
| `from_entries` | `util.zig:11` (`fromEntries`) | 0 external — only called by `from()` at `:151,153`, which has 0 callers | **dead in Zig too** |
| `from_map_like` | `util.zig:80` (`fromMapLike`) | 0 external — only called by `from()` at `:139` | **dead in Zig too** |
| `FieldType` enum | `util.zig:101` (a `fn → ?type`) | 0 external — all grep hits are the Zig builtin `@FieldType` or unrelated SQL enums | **dead in Zig too** (and obsoleted by Zig's builtin `@FieldType`) |
| `EmbedDir` | none — neither `EmbedDir` nor `EmbedKind` exist in `*.zig` | n/a | **Rust-port artifact** (alias for an alternate Rust-side spelling) |
| `buffered_reader_size` | `src/bun_core/deprecated.zig:47` (`bufferedReaderSize`) | 0 | **dead in Zig too** |
| `auto_format_label` / `_fallback` | `deprecated.zig:639,631` | 2 — `src/runtime/node.zig:342`, `src/runtime/test_runner/expect.zig:122` | Zig callers' Rust ports use native `Display`/`Debug` instead of comptime format-label dispatch |
| `PathString::USE_SMALL_PATH_STRING` | `src/string/PathString.zig:12` (`pub const use_small_path_string`) | 0 — `PathString.zig` only reads the file-private `use_small_path_string_` (`:2`); the `pub` re-export has no consumers | **dead in Zig too** (the public const; the private backing value is still load-bearing) |

Also updates the stale port-note comment in `bundler/options.rs` that pointed at the deleted `MapLike`.
