### PR TITLE
threading: delete unused init_with_mutex/into_unprotected/wait_and_deinit

### DIFF
--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -1029,9 +1029,8 @@ impl ThreadPool {
 
         // If there are threads, start off the chain sending it the shutdown signal.
         // The thread receives the shutdown signal and sends it to the next thread, and the next..
-        // Use swap (not load) so join() is idempotent: a second call (e.g., from
-        // wait_and_deinit() followed by Drop) sees null and returns instead of
-        // touching freed worker stack memory.
+        // Use swap (not load) so join() is idempotent: a second call sees null and
+        // returns instead of touching freed worker stack memory.
         let Some(thread) = NonNull::new(self.threads.swap(ptr::null_mut(), Ordering::Acquire))
         else {
             return;

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -662,18 +662,6 @@ impl ThreadPool {
         self.wait_group.wait();
     }
 
-    /// Wait for all tasks to complete, then shut down and deinit the thread pool.
-    ///
-    /// Takes `&mut self` (NOT by-value): worker threads hold `*const ThreadPool`
-    /// pointing at this struct's address; consuming `self` would move it to a new
-    /// stack slot and leave workers with dangling pointers (UAF + deadlock).
-    /// Zig `waitAndDeinit(self: *ThreadPool)` operates in place — match that.
-    pub fn wait_and_deinit(&mut self) {
-        self.wait_for_all();
-        self.shutdown();
-        self.join();
-    }
-
     fn force_spawn(&self) {
         // Try to notify a thread
         let is_waking = false;

--- a/src/threading/guarded.rs
+++ b/src/threading/guarded.rs
@@ -39,7 +39,10 @@ unsafe impl<Value: Send, M: RawMutex + Sync> Sync for GuardedBy<Value, M> {}
 impl<Value, M: RawMutex + Default> GuardedBy<Value, M> {
     /// Creates a guarded value with a default-initialized mutex.
     pub fn init(value: Value) -> Self {
-        Self::init_with_mutex(value, M::default())
+        Self {
+            unsynchronized_value: UnsafeCell::new(value),
+            mutex: M::default(),
+        }
     }
 }
 
@@ -87,14 +90,6 @@ impl<Value> GuardedBy<Value, Mutex> {
 }
 
 impl<Value, M: RawMutex> GuardedBy<Value, M> {
-    /// Creates a guarded value with the given mutex.
-    pub fn init_with_mutex(value: Value, mutex: M) -> Self {
-        Self {
-            unsynchronized_value: UnsafeCell::new(value),
-            mutex,
-        }
-    }
-
     /// Locks the mutex and returns an RAII guard that dereferences to the protected value and
     /// releases the lock on drop.
     pub fn lock(&self) -> GuardedLock<'_, Value, M> {
@@ -108,17 +103,6 @@ impl<Value, M: RawMutex> GuardedBy<Value, M> {
     #[inline]
     pub fn get_mut(&mut self) -> &mut Value {
         self.unsynchronized_value.get_mut()
-    }
-
-    /// Returns the inner unprotected value.
-    ///
-    /// You must ensure that no other threads could be concurrently using `self`. This method
-    /// invalidates `self`, so you must ensure `self` is not used on any thread after calling
-    /// this method.
-    pub fn into_unprotected(self) -> Value {
-        // Zig: `bun.memory.deinit(&self.#mutex)` then return value, then `self.* = undefined`.
-        // In Rust, moving out of `self` drops `self.mutex` automatically.
-        self.unsynchronized_value.into_inner()
     }
 }
 

--- a/src/threading/unbounded_queue.rs
+++ b/src/threading/unbounded_queue.rs
@@ -2,33 +2,6 @@ use core::hint;
 use core::ptr::{self, NonNull};
 use core::sync::atomic::{AtomicPtr, Ordering};
 
-#[cfg(any(
-    target_arch = "x86_64",
-    target_arch = "aarch64",
-    target_arch = "powerpc64",
-))]
-pub(crate) const CACHE_LINE_LENGTH: usize = 128;
-#[cfg(any(
-    target_arch = "arm",
-    target_arch = "mips",
-    target_arch = "mips64",
-    target_arch = "riscv64",
-))]
-pub(crate) const CACHE_LINE_LENGTH: usize = 32;
-#[cfg(target_arch = "s390x")]
-pub(crate) const CACHE_LINE_LENGTH: usize = 256;
-#[cfg(not(any(
-    target_arch = "x86_64",
-    target_arch = "aarch64",
-    target_arch = "powerpc64",
-    target_arch = "arm",
-    target_arch = "mips",
-    target_arch = "mips64",
-    target_arch = "riscv64",
-    target_arch = "s390x",
-)))]
-pub(crate) const CACHE_LINE_LENGTH: usize = 64;
-
 /// Intrusive next-pointer accessors for `UnboundedQueue<T>` nodes.
 ///
 /// Zig's `UnboundedQueue(T, next_field)` is parametric on the *field name* and
@@ -185,7 +158,7 @@ impl<T: Node> Batch<T> {
 /// Per-arch cache-half-line aligned wrapper — Zig's `align(queue_padding_length)`
 /// on `UnboundedQueue.back`/`.front`. Rust cannot express per-field alignment
 /// with a non-literal const, so this newtype is `#[repr(align(N))]`-cfg'd to
-/// `CACHE_LINE_LENGTH / 2` per target arch, keeping producer (CAS on `back`)
+/// half the target's cache-line size, keeping producer (CAS on `back`)
 /// and consumer (swap on `front`) on separate cache halves.
 #[cfg_attr(
     any(
@@ -232,8 +205,6 @@ impl<T: Node> Default for UnboundedQueue<T> {
 }
 
 impl<T: Node> UnboundedQueue<T> {
-    pub const QUEUE_PADDING_LENGTH: usize = CACHE_LINE_LENGTH / 2;
-
     /// Const constructor — `Default` is not usable in `static` initializers.
     #[inline]
     pub const fn new() -> Self {


### PR DESCRIPTION
Dead-code sweep of `bun_threading`.

`cargo check --workspace` passes.

## Why this code exists

| Item | Zig original | Zig callers | Status |
|---|---|---|---|
| `GuardedBy::init_with_mutex` | `src/threading/guarded.zig:23` (`initWithMutex`) | 0 external — only called internally by `init()` at `:19` | **dead in Zig too** as a public API; inlined into the Rust `init()` |
| `GuardedBy::into_unprotected` | `guarded.zig:46` (`intoUnprotected`) | 1 — `src/bun_alloc/allocation_scope.zig:191` | The Rust `AllocationScope` was deleted (98ba4b19e6); no Rust equivalent of that caller exists |
| `ThreadPool::wait_and_deinit` | `src/threading/ThreadPool.zig:288` (`waitAndDeinit`) | 0 | **dead in Zig too** — callers invoke `waitForAll`/`deinit` directly |
| `QUEUE_PADDING_LENGTH` | `src/threading/unbounded_queue.zig:81` (`queue_padding_length`) | 0 external — used only as the `align()` attribute on the struct's `back`/`front` fields (`:83,84`) | Zig consumes the const in `align(queue_padding_length)`; Rust's `#[repr(align(N))]` requires a literal, so the values are hardcoded on `QueuePadded` and the const is unread |
| `CACHE_LINE_LENGTH` | `unbounded_queue.zig:1-6` (`cache_line_length`, per-arch `switch`) | 0 external — only feeds `queue_padding_length` at `:81` | Direct port of the Zig per-arch switch; cascaded dead once `QUEUE_PADDING_LENGTH` was removed |
