### PR TITLE
semver: delete unused Sorter/SortDirection and any_range_satisfies

### DIFF
--- a/src/semver/SemverRange.rs
+++ b/src/semver/SemverRange.rs
@@ -50,15 +50,6 @@ impl fmt::Display for ComparatorDisplay {
 
 impl Range {
     /// *
-    /// >= 0.0.0
-    /// >= 0
-    /// >= 0.0
-    /// >= x
-    /// >= 0
-    pub fn any_range_satisfies(&self) -> bool {
-        self.left.op == Op::Gte && self.left.version.eql(Version::default())
-    }
-
     pub fn init_wildcard(version: Version, wildcard: Wildcard) -> Range {
         match wildcard {
             Wildcard::None => Range {

--- a/src/semver/SemverRange.rs
+++ b/src/semver/SemverRange.rs
@@ -49,7 +49,6 @@ impl fmt::Display for ComparatorDisplay {
 }
 
 impl Range {
-    /// *
     pub fn init_wildcard(version: Version, wildcard: Wildcard) -> Range {
         match wildcard {
             Wildcard::None => Range {

--- a/src/semver/lib.rs
+++ b/src/semver/lib.rs
@@ -760,33 +760,6 @@ pub mod semver_string {
         }
     }
 
-    // ── Sorter(comptime direction) ────────────────────────────────────────
-    // PORT NOTE: was `const DIRECTION: SortDirection` const-generic param; requires nightly
-    // `adt_const_params`. Rewritten as a runtime field for stable — branch is trivially
-    // predictable, monomorphization not load-bearing.
-    #[derive(PartialEq, Eq, Clone, Copy)]
-    pub enum SortDirection {
-        Asc,
-        Desc,
-    }
-
-    pub struct Sorter<'a> {
-        pub direction: SortDirection,
-        pub lhs_buf: &'a [u8],
-        pub rhs_buf: &'a [u8],
-    }
-
-    impl<'a> Sorter<'a> {
-        pub fn less_than(&self, lhs: String, rhs: String) -> bool {
-            lhs.order(rhs, self.lhs_buf, self.rhs_buf)
-                == if self.direction == SortDirection::Asc {
-                    Ordering::Less
-                } else {
-                    Ordering::Greater
-                }
-        }
-    }
-
     // ── HashContext / ArrayHashContext ────────────────────────────────────
     pub struct HashContext<'a> {
         pub arg_buf: &'a [u8],


### PR DESCRIPTION
Dead-code sweep of `bun_semver`.

`cargo check --workspace` passes.

## Why this code exists

| Item | Zig original | Zig callers | Status |
|---|---|---|---|
| `String::Sorter` + `SortDirection` | `src/install_types/SemverString.zig:192` — `pub fn Sorter(comptime direction: enum { asc, desc }) type` (direction is an anonymous inline enum, not a named type) | 0 — none of the `Sorter` references in `lockfile.zig`/`npm.zig`/`bun.lock.zig` use this one; they all define their own local `Sorter` structs | **dead in Zig too** |
| `Range::any_range_satisfies` | `src/semver/SemverRange.zig:33` (`anyRangeSatisfies`) | 0 | **dead in Zig too** |
