### PR TITLE
ast: delete unused Boundering, RefDump, Names, and dead Loader/allocator helpers

### DIFF
--- a/src/ast/ast_memory_allocator.rs
+++ b/src/ast/ast_memory_allocator.rs
@@ -151,12 +151,6 @@ impl ASTMemoryAllocator {
         }
     }
 
-    /// Zig: `var a: ASTMemoryAllocator = undefined; a.initWithoutStack(arena);`
-    /// — collapsed to a constructor that returns a ready instance.
-    pub fn new_without_stack(_fallback: &Arena) -> Self {
-        Self::default()
-    }
-
     /// The arena every allocation routes to: the caller-owned one for
     /// [`Self::borrowing`] instances, else the owned pooled one.
     #[inline]
@@ -370,22 +364,6 @@ impl ASTMemoryAllocator {
     #[inline]
     pub fn stack_allocator(&self) -> &Arena {
         self.arena()
-    }
-
-    /// Alias for callers that addressed the Zig `bump_allocator` field.
-    #[inline]
-    pub fn bump_allocator(&self) -> &Arena {
-        self.arena()
-    }
-
-    /// Initialize ASTMemoryAllocator as `undefined`, and call this.
-    pub fn init_without_stack(&mut self) {
-        // Zig set up the SFA with an empty fixed buffer so every alloc goes to the fallback
-        // `arena`. With bumpalo there is no stack buffer either way; just (re)initialize.
-        // PERF(port): was stack-fallback — profile
-        self.arena = Arena::new();
-        self.external_arena = ptr::null();
-        self.arena_dirty = false;
     }
 }
 

--- a/src/ast/base.rs
+++ b/src/ast/base.rs
@@ -1,5 +1,3 @@
-use core::fmt;
-
 use crate::symbol;
 
 // ───────────────────────────────── Index ─────────────────────────────────
@@ -174,34 +172,6 @@ impl Ref {
     #[inline]
     pub fn get_symbol<T: SymbolTable + ?Sized>(self, symbol_table: &mut T) -> &mut symbol::Symbol {
         symbol_table.get_symbol(self)
-    }
-    pub fn dump<T: SymbolTable + ?Sized>(self, symbol_table: &mut T) -> RefDump<'_> {
-        RefDump {
-            ref_: self,
-            symbol: symbol_table.get_symbol(self),
-        }
-    }
-}
-
-// Zig: `DumpImplData` + `dumpImpl` — formatter wrapper returned by `Ref.dump`.
-pub struct RefDump<'a> {
-    ref_: Ref,
-    symbol: &'a symbol::Symbol,
-}
-impl fmt::Display for RefDump<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // SAFETY: original_name is an arena-owned slice valid for the lifetime of
-        // the symbol table this RefDump was borrowed from (parser/AST arena outlives it).
-        let name = self.symbol.original_name.slice();
-        write!(
-            f,
-            "Ref[inner={}, src={}, .{}; original_name={}, uses={}]",
-            self.ref_.inner_index(),
-            self.ref_.source_index(),
-            <&'static str>::from(self.ref_.tag()),
-            bstr::BStr::new(name),
-            self.symbol.use_count_estimate,
-        )
     }
 }
 

--- a/src/ast/loader.rs
+++ b/src/ast/loader.rs
@@ -129,18 +129,6 @@ impl Loader {
         matches!(self, Loader::Jsx | Loader::Js | Loader::Ts | Loader::Tsx)
     }
 
-    pub fn disable_html(self) -> Loader {
-        match self {
-            Loader::Html => Loader::File,
-            other => other,
-        }
-    }
-
-    #[inline]
-    pub fn is_sqlite(self) -> bool {
-        matches!(self, Loader::Sqlite | Loader::SqliteEmbedded)
-    }
-
     pub fn should_copy_for_bundling(self) -> bool {
         matches!(
             self,
@@ -243,10 +231,6 @@ impl Loader {
         })
     }
 
-    pub fn supports_client_entry_point(self) -> bool {
-        matches!(self, Loader::Jsx | Loader::Js | Loader::Ts | Loader::Tsx)
-    }
-
     #[inline]
     pub fn is_jsx(self) -> bool {
         self == Loader::Jsx || self == Loader::Tsx
@@ -273,10 +257,6 @@ impl Loader {
     #[inline]
     pub fn is_java_script_like(self) -> bool {
         self.is_javascript_like()
-    }
-    #[inline]
-    pub fn is_java_script_like_or_json(self) -> bool {
-        self.is_javascript_like_or_json()
     }
 
     pub fn is_javascript_like_or_json(self) -> bool {

--- a/src/ast/runtime.rs
+++ b/src/ast/runtime.rs
@@ -141,12 +141,6 @@ impl ServerComponentsMode {
 
 // ─────────────────────────── Runtime.Names ───────────────────────────
 
-#[derive(Default, Clone, Copy)]
-pub struct Names;
-impl Names {
-    pub const ACTIVATE_FUNCTION: &'static [u8] = b"activate";
-}
-
 // ─────────────────────────── Runtime.Imports ───────────────────────────
 
 // If you change this, remember to update "runtime.js"
@@ -274,7 +268,6 @@ impl Imports {
     ];
 
     pub const NAME: &'static [u8] = b"bun:wrap";
-    pub const ALT_NAME: &'static [u8] = b"bun:wrap";
 
     /// Index → field. Expansion of Zig `@field(this, all[i])`.
     #[inline]

--- a/src/ast/runtime.rs
+++ b/src/ast/runtime.rs
@@ -2,8 +2,8 @@
 
 // REFACTOR_BUN_AST: this module holds only the data-shaped pieces of
 // `runtime.zig` that the AST crate (and `bun_js_printer::Options`) need:
-// `Runtime::source_code`, `Imports`, `ReplaceableExport*`, `ServerComponentsMode`,
-// `Names`. The `Features` struct (carries `&mut RuntimeTranspilerCache`) and
+// `Runtime::source_code`, `Imports`, `ReplaceableExport*`, `ServerComponentsMode`.
+// The `Features` struct (carries `&mut RuntimeTranspilerCache`) and
 // `Fallback` HTML rendering (needs `bun_options_types::schema`, `bun_io`,
 // `bun_base64`) live in `bun_js_parser::parser::Runtime` to avoid the
 // `bun_options_types → bun_ast → bun_options_types` cycle.
@@ -138,8 +138,6 @@ impl ServerComponentsMode {
         !matches!(self, Self::None)
     }
 }
-
-// ─────────────────────────── Runtime.Names ───────────────────────────
 
 // ─────────────────────────── Runtime.Imports ───────────────────────────
 

--- a/src/ast/use_directive.rs
+++ b/src/ast/use_directive.rs
@@ -11,38 +11,12 @@ pub enum UseDirective {
     Server = 2,
 }
 
-#[repr(u8)] // Zig: enum(u2)
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub enum Boundering {
-    Client = UseDirective::Client as u8,
-    Server = UseDirective::Server as u8,
-}
-
 #[derive(Copy, Clone, Default, Debug)]
 pub struct Flags {
     pub has_any_client: bool,
 }
 
 impl UseDirective {
-    pub fn is_boundary(self, other: UseDirective) -> bool {
-        if self == other || other == UseDirective::None {
-            return false;
-        }
-
-        true
-    }
-
-    pub fn boundering(self, other: UseDirective) -> Option<Boundering> {
-        if self == other {
-            return None;
-        }
-        match other {
-            UseDirective::None => None,
-            UseDirective::Client => Some(Boundering::Client),
-            UseDirective::Server => Some(Boundering::Server),
-        }
-    }
-
     pub fn parse(contents: &[u8]) -> Option<UseDirective> {
         let truncated = strings::trim_left(contents, b" \t\n\r;");
 


### PR DESCRIPTION
Dead-code sweep of `bun_ast`. None referenced outside their own definitions in the Rust tree.

`cargo check --workspace` and `bun bd` pass.

## Why this code exists

| Item | Zig original | Zig callers | Status |
|---|---|---|---|
| `Boundering` enum | `src/ast/use_directive.zig:9-12` | 0 external (only `boundering()`'s return type) | **dead in Zig too** |
| `UseDirective::boundering` | `use_directive.zig:25` | 0 | **dead in Zig too** — server-components boundary detection that was never hooked up |
| `UseDirective::is_boundary` | `use_directive.zig:18` (`isBoundary`) | 0 | **dead in Zig too** |
| `Ref::dump` + `RefDump` | `src/ast/base.zig:144,151,152` (`dump`/`DumpImplData`/`dumpImpl`) | 0 — the `.dump()` calls at `renamer.zig:537` and `ptr/ref_count.zig` are unrelated `symbols.dump()`/`count.debug.dump()` | **dead in Zig too** — debug-only `std.fmt.Alt` formatter for ad-hoc printing |
| `Names` + `ACTIVATE_FUNCTION` | `src/js_parser/runtime.zig:345-347` | 0 real — `parser.zig:1224` re-exports as `RuntimeNames` but `RuntimeNames` itself has 0 callers | **dead in Zig too** — vestige of an HMR/react-refresh `"activate"` lookup |
| `Imports::ALT_NAME` | `src/js_parser/runtime.zig:436` (`alt_name`) | 1 — `src/jsc/VirtualMachine.zig:1732` | The Rust port (`src/jsc/VirtualMachine.rs:4083-4086`) inlines the literal `b"bun:wrap"` with a note that `Name`/`alt_name` are identical |
| `Loader::disable_html` | `src/bundler/options.zig:618` (`disableHTML`) | 0 | **dead in Zig too** |
| `Loader::is_sqlite` | `src/bundler/options.zig:625` (`isSQLite`) | 0 | **dead in Zig too** — callers inline-match instead |
| `Loader::supports_client_entry_point` | `src/bundler/options.zig:792` | 0 — only reference (`transpiler.zig:1359`) is inside `if (comptime wrap_entry_point)`; all 8 callers pass `false` (`transpiler.zig:1307-1324`) | **dead in Zig too** (comptime branch never instantiated) |
| `Loader::is_java_script_like_or_json` | none — Zig has only one spelling (`isJavaScriptLikeOrJSON` at `options.zig:866`) | n/a | **Rust-port artifact** — Rust emitted two snake_case spellings of the same Zig name; the kept `is_javascript_like_or_json` is the one with callers |
| `new_without_stack` / `init_without_stack` | `src/ast/ast_memory_allocator.zig:79` (`initWithoutStack`) | 1 — `src/runtime/bake/bake.zig:712` | Rust port uses `ASTMemoryAllocator::borrowing(arena)` instead (`src/runtime/bake/mod.rs:230`, `bake_body.rs:1202`, `DevServer.rs:3283`) |
| `bump_allocator` | `ast_memory_allocator.zig:4` (a *field*, not a method) | 0 external — only read/written inside `ast_memory_allocator.zig` (`:15,56,73,85`) | **Rust-port artifact** — Rust-only alias method for callers that addressed the Zig field by name; never adopted |


