### PR TITLE
yaml: `---`/`...` only recognized at column 0 (closes #25660)

### DIFF
--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -4406,22 +4406,15 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
         // PORT NOTE: labeled-switch loop
         let mut __c = Enc::wide(parser!().next());
-        // [203]/[204] c-directives-end / c-document-end are line-starting
-        // tokens. `line_indent == 0` alone is insufficient — that's the
-        // *line's* indent, true everywhere on a column-0 line. Track whether
-        // the previous loop iteration was the `\n` arm (i.e., we're at the
-        // first content char of a continuation line).
-        let mut at_line_start = false;
         loop {
-            let was_at_line_start = at_line_start;
-            at_line_start = false;
             match __c {
                 0 => {
                     return Ok(ctx.done());
                 }
 
                 0x2D /* '-' */ => {
-                    if was_at_line_start
+                    // [203] c-directives-end is line-starting at column 0.
+                    if parser!().is_at_line_start()
                         && parser!().line_indent == Indent::NONE
                         && parser!().remain_starts_with(Enc::literal(b"---"))
                         && parser!().is_any_or_eof_at(Enc::literal(b" \t\n\r"), 3)
@@ -4444,7 +4437,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 }
 
                 0x2E /* '.' */ => {
-                    if was_at_line_start
+                    if parser!().is_at_line_start()
                         && parser!().line_indent == Indent::NONE
                         && parser!().remain_starts_with(Enc::literal(b"..."))
                         && parser!().is_any_or_eof_at(Enc::literal(b" \t\n\r"), 3)
@@ -4574,7 +4567,6 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
                     ctx.append_whitespace_n_times(Enc::ch(b'\n'), lines)?;
 
-                    at_line_start = true;
                     __c = Enc::wide(parser!().next());
                     continue;
                 }
@@ -5063,18 +5055,13 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         // Phase 2: scan body
         // PORT NOTE: labeled-switch loop with nested `newlines:` switch
         let mut __c = first;
-        // [203]/[204] are line-starting tokens; see scan_plain_scalar.
-        let mut at_line_start = true;
         loop {
-            let was_at_line_start = at_line_start;
-            at_line_start = false;
             match __c {
                 0 => return Ok(ctx.done()?),
                 0x0D => {
                     if Enc::wide(self.peek(1)) == 0x0A {
                         self.inc(1);
                     }
-                    at_line_start = was_at_line_start;
                     __c = 0x0A;
                     continue;
                 }
@@ -5135,11 +5122,10 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                             }
                         }
                     }
-                    at_line_start = true;
                     continue;
                 }
                 0x2D /* '-' */ => {
-                    if was_at_line_start
+                    if self.is_at_line_start()
                         && self.line_indent == Indent::NONE
                         && self.remain_starts_with(Enc::literal(b"---"))
                         && self.is_any_or_eof_at(Enc::literal(b" \t\n\r"), 3)
@@ -5155,7 +5141,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     continue;
                 }
                 0x2E /* '.' */ => {
-                    if was_at_line_start
+                    if self.is_at_line_start()
                         && self.line_indent == Indent::NONE
                         && self.remain_starts_with(Enc::literal(b"..."))
                         && self.is_any_or_eof_at(Enc::literal(b" \t\n\r"), 3)
@@ -5678,7 +5664,12 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 }
                 0x2D /* '-' */ => {
                     let start = self.pos;
-                    if self.line_indent == Indent::NONE
+                    // [203] c-directives-end is line-starting at column 0.
+                    // `line_indent == 0` is the line's indent, true everywhere
+                    // on a column-0 line; check the previous byte to confirm
+                    // we are actually at the start of a line.
+                    if self.is_at_line_start()
+                        && self.line_indent == Indent::NONE
                         && self.remain_starts_with(Enc::literal(b"---"))
                         && self.is_s_white_or_b_char_or_eof_at(3)
                     {
@@ -5716,7 +5707,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 }
                 0x2E /* '.' */ => {
                     let start = self.pos;
-                    if self.line_indent == Indent::NONE
+                    if self.is_at_line_start()
+                        && self.line_indent == Indent::NONE
                         && self.remain_starts_with(Enc::literal(b"..."))
                         && self.is_s_white_or_b_char_or_eof_at(3)
                     {
@@ -6123,6 +6115,17 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         true
     }
 
+    /// True iff `self.pos` is at column 0 — i.e., start of input or
+    /// immediately after a b-break. Used by [203]/[204] doc-marker
+    /// recognition (which is line-starting, not just `line_indent == 0`).
+    fn is_at_line_start(&self) -> bool {
+        if self.pos == Pos::ZERO {
+            return true;
+        }
+        let prev = Enc::wide(self.input[self.pos.sub(1).cast()]);
+        prev == 0x0A || prev == 0x0D
+    }
+
     fn is_s_white_or_b_char_at(&self, n: usize) -> bool {
         let pos = self.pos.add(n);
         if pos.is_less_than(self.input.len()) {
@@ -6137,8 +6140,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         if pos.is_less_than(self.input.len()) {
             return values.as_ref().contains(&self.input[pos.cast()]);
         }
-        false
-        // PORT NOTE: Zig returns `false` for EOF here despite the name (matches source).
+        true
     }
 
     fn is_eof(&self) -> bool {

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -5288,7 +5288,6 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         let scalar_indent = self.line_indent;
         let mut text: Vec<Enc::Unit> = Vec::new();
 
-
         // PORT NOTE: labeled-switch loop
         loop {
             let c = Enc::wide(self.next());

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -5660,8 +5660,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     let start = self.pos;
                     // [203] c-directives-end is line-starting at column 0.
                     // `line_indent == 0` is the line's indent, true everywhere
-                    // on a column-0 line; check the previous byte to confirm
-                    // we are actually at the start of a line.
+                    // on a column-0 line; is_at_line_start() (pos ==
+                    // line_start_pos) confirms we are at the actual start.
                     if self.is_at_line_start()
                         && self.line_indent == Indent::NONE
                         && self.remain_starts_with(Enc::literal(b"---"))

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -2604,11 +2604,12 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             TokenData::Eof => {}
             TokenData::DocumentStart => {}
             TokenData::DocumentEnd => {
-                let document_end_line = self.token.line;
+                let mut document_end_line = self.token.line;
                 self.scan(ScanOptions::default())?;
 
                 // consume all bare documents
                 while matches!(self.token.data, TokenData::DocumentEnd) {
+                    document_end_line = self.token.line;
                     self.scan(ScanOptions::default())?;
                 }
 
@@ -5203,7 +5204,6 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         let scalar_indent = self.line_indent;
 
         let mut text: Vec<Enc::Unit> = Vec::new();
-        let mut nl = false;
 
         // PORT NOTE: labeled-switch loop
         loop {
@@ -5211,29 +5211,26 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             match c {
                 0 => return Err(ParseError::UnexpectedCharacter),
                 0x2E /* '.' */ => {
-                    if nl && self.line_indent == Indent::NONE
+                    if self.is_at_line_start()
                         && self.remain_starts_with(Enc::literal(b"..."))
                         && self.is_s_white_or_b_char_at(3)
                     {
                         return Err(ParseError::UnexpectedDocumentEnd);
                     }
-                    nl = false;
                     text.push(Enc::ch(b'.'));
                     self.inc(1);
                 }
                 0x2D /* '-' */ => {
-                    if nl && self.line_indent == Indent::NONE
+                    if self.is_at_line_start()
                         && self.remain_starts_with(Enc::literal(b"---"))
                         && self.is_s_white_or_b_char_at(3)
                     {
                         return Err(ParseError::UnexpectedDocumentStart);
                     }
-                    nl = false;
                     text.push(Enc::ch(b'-'));
                     self.inc(1);
                 }
                 0x0D | 0x0A => {
-                    nl = true;
                     self.newline();
                     self.inc(1);
                     match self.fold_lines() {
@@ -5251,7 +5248,6 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     }
                 }
                 0x20 | 0x09 => {
-                    nl = false;
                     let off = self.pos;
                     self.inc(1);
                     self.skip_s_white();
@@ -5260,7 +5256,6 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     }
                 }
                 0x27 /* '\'' */ => {
-                    nl = false;
                     self.inc(1);
                     if Enc::wide(self.next()) == 0x27 {
                         text.push(Enc::ch(b'\''));
@@ -5280,7 +5275,6 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     }));
                 }
                 _ => {
-                    nl = false;
                     text.push(self.next());
                     self.inc(1);
                 }
@@ -5294,7 +5288,6 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         let scalar_indent = self.line_indent;
         let mut text: Vec<Enc::Unit> = Vec::new();
 
-        let mut nl = false;
 
         // PORT NOTE: labeled-switch loop
         loop {
@@ -5302,24 +5295,22 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             match c {
                 0 => return Err(ParseError::UnexpectedCharacter),
                 0x2E /* '.' */ => {
-                    if nl && self.line_indent == Indent::NONE
+                    if self.is_at_line_start()
                         && self.remain_starts_with(Enc::literal(b"..."))
                         && self.is_s_white_or_b_char_at(3)
                     {
                         return Err(ParseError::UnexpectedDocumentEnd);
                     }
-                    nl = false;
                     text.push(Enc::ch(b'.'));
                     self.inc(1);
                 }
                 0x2D /* '-' */ => {
-                    if nl && self.line_indent == Indent::NONE
+                    if self.is_at_line_start()
                         && self.remain_starts_with(Enc::literal(b"---"))
                         && self.is_s_white_or_b_char_at(3)
                     {
                         return Err(ParseError::UnexpectedDocumentStart);
                     }
-                    nl = false;
                     text.push(Enc::ch(b'-'));
                     self.inc(1);
                 }
@@ -5339,10 +5330,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                             return Err(ParseError::UnexpectedCharacter);
                         }
                     }
-                    nl = true;
                 }
                 0x20 | 0x09 => {
-                    nl = false;
                     let off = self.pos;
                     self.inc(1);
                     self.skip_s_white();
@@ -5365,7 +5354,6 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     }));
                 }
                 0x5C /* '\\' */ => {
-                    nl = false;
                     self.inc(1);
                     match Enc::wide(self.next()) {
                         0x0D | 0x0A => {
@@ -5430,7 +5418,6 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     self.inc(1);
                 }
                 _ => {
-                    nl = false;
                     text.push(self.next());
                     self.inc(1);
                 }

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -2612,7 +2612,9 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     self.scan(ScanOptions::default())?;
                 }
 
-                if self.token.line == document_end_line {
+                if self.token.line == document_end_line
+                    && !matches!(self.token.data, TokenData::Eof)
+                {
                     return Err(Self::unexpected_token());
                 }
             }

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -2883,6 +2883,15 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         let sequence_start = self.token.start;
         let sequence_indent = self.token.indent;
 
+        // [200] s-l+block-collection requires s-l-comments (a line break)
+        // before l+block-sequence; same-line content after `---` can only be
+        // a flow node via s-separate-in-line.
+        if let Some(explicit_document_start_line) = self.explicit_document_start_line {
+            if self.token.line == explicit_document_start_line {
+                return Err(ParseError::UnexpectedToken);
+            }
+        }
+
         self.block_indents.push(sequence_indent)?;
 
         // PORT NOTE: Zig `defer self.block_indents.pop()` — capture the fallible
@@ -4397,14 +4406,23 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
         // PORT NOTE: labeled-switch loop
         let mut __c = Enc::wide(parser!().next());
+        // [203]/[204] c-directives-end / c-document-end are line-starting
+        // tokens. `line_indent == 0` alone is insufficient — that's the
+        // *line's* indent, true everywhere on a column-0 line. Track whether
+        // the previous loop iteration was the `\n` arm (i.e., we're at the
+        // first content char of a continuation line).
+        let mut at_line_start = false;
         loop {
+            let was_at_line_start = at_line_start;
+            at_line_start = false;
             match __c {
                 0 => {
                     return Ok(ctx.done());
                 }
 
                 0x2D /* '-' */ => {
-                    if parser!().line_indent == Indent::NONE
+                    if was_at_line_start
+                        && parser!().line_indent == Indent::NONE
                         && parser!().remain_starts_with(Enc::literal(b"---"))
                         && parser!().is_any_or_eof_at(Enc::literal(b" \t\n\r"), 3)
                     {
@@ -4426,7 +4444,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 }
 
                 0x2E /* '.' */ => {
-                    if parser!().line_indent == Indent::NONE
+                    if was_at_line_start
+                        && parser!().line_indent == Indent::NONE
                         && parser!().remain_starts_with(Enc::literal(b"..."))
                         && parser!().is_any_or_eof_at(Enc::literal(b" \t\n\r"), 3)
                     {
@@ -4555,6 +4574,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
                     ctx.append_whitespace_n_times(Enc::ch(b'\n'), lines)?;
 
+                    at_line_start = true;
                     __c = Enc::wide(parser!().next());
                     continue;
                 }
@@ -5043,13 +5063,18 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         // Phase 2: scan body
         // PORT NOTE: labeled-switch loop with nested `newlines:` switch
         let mut __c = first;
+        // [203]/[204] are line-starting tokens; see scan_plain_scalar.
+        let mut at_line_start = true;
         loop {
+            let was_at_line_start = at_line_start;
+            at_line_start = false;
             match __c {
                 0 => return Ok(ctx.done()?),
                 0x0D => {
                     if Enc::wide(self.peek(1)) == 0x0A {
                         self.inc(1);
                     }
+                    at_line_start = was_at_line_start;
                     __c = 0x0A;
                     continue;
                 }
@@ -5110,10 +5135,12 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                             }
                         }
                     }
+                    at_line_start = true;
                     continue;
                 }
                 0x2D /* '-' */ => {
-                    if self.line_indent == Indent::NONE
+                    if was_at_line_start
+                        && self.line_indent == Indent::NONE
                         && self.remain_starts_with(Enc::literal(b"---"))
                         && self.is_any_or_eof_at(Enc::literal(b" \t\n\r"), 3)
                     {
@@ -5128,7 +5155,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     continue;
                 }
                 0x2E /* '.' */ => {
-                    if self.line_indent == Indent::NONE
+                    if was_at_line_start
+                        && self.line_indent == Indent::NONE
                         && self.remain_starts_with(Enc::literal(b"..."))
                         && self.is_any_or_eof_at(Enc::literal(b" \t\n\r"), 3)
                     {

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -2312,6 +2312,9 @@ pub struct Parser<'i, Enc: Encoding> {
     pub input: &'i [Enc::Unit],
 
     pub pos: Pos,
+    /// Position of the first byte of the current line (one past the most
+    /// recently consumed `\n`/`\r`). Set in `newline()`.
+    pub line_start_pos: Pos,
     pub line_indent: Indent,
     /// A tab was seen between the line's s-indent (or post-indicator
     /// additional_parent_indent position) and the current token's content.
@@ -2360,6 +2363,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             input,
             bump,
             pos: Pos::from(0),
+            line_start_pos: Pos::from(0),
             line_indent: Indent::NONE,
             tab_after_indent: false,
             line: Line::from(1),
@@ -2427,6 +2431,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
     fn newline(&mut self) {
         self.line_indent = Indent::NONE;
         self.tab_after_indent = false;
+        // Every caller is `newline(); inc(1);` with `pos` at the b-break byte.
+        self.line_start_pos = self.pos.add(1);
         self.line.inc(1);
     }
 
@@ -6107,11 +6113,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
     /// immediately after a b-break. Used by [203]/[204] doc-marker
     /// recognition (which is line-starting, not just `line_indent == 0`).
     fn is_at_line_start(&self) -> bool {
-        if self.pos == Pos::ZERO {
-            return true;
-        }
-        let prev = Enc::wide(self.input[self.pos.sub(1).cast()]);
-        prev == 0x0A || prev == 0x0D
+        self.pos == self.line_start_pos
     }
 
     fn is_s_white_or_b_char_at(&self, n: usize) -> bool {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1727,7 +1727,7 @@ folded: >
           // (pos != line_start_pos). Pre-existing differently-wrong (was a
           // spurious BOM-only first doc); proper fix is BOM strip in
           // l-document-prefix, not special-casing here.
-          expect(YAML.parse("﻿---\na: 1\n")).toEqual({ a: 1 });
+          expect(YAML.parse("\uFEFF---\na: 1\n")).toEqual({ a: 1 });
         });
       });
 

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1646,6 +1646,13 @@ folded: >
           ["doc-sl-scalar", "--- foo\n", "foo"],
           ["doc-nl-seq", "---\n- x\n", ["x"]],
           ["doc-nl-map", "---\na: b\n", { a: "b" }],
+          // ... immediately at EOF (no trailing newline)
+          ["dot-eof-plain", "abc\n...", "abc"],
+          ["dot-eof-seq", "- a\n...", ["a"]],
+          ["dot-eof-map", "a: 1\n...", { a: 1 }],
+          ["dot-eof-bs", "|\nx\n...", "x\n"],
+          ["dot-eof-only", "...", null],
+          ["dash-eof-only", "---", null],
         ] as const)("%s", (_id, input, expected) => {
           if (typeof expected === "object" && expected && "throws" in expected) {
             expect(() => YAML.parse(input)).toThrow(expected.throws as string);

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1534,10 +1534,6 @@ folded: >
         });
 
         test("block-scalar phase-2 mid-line `---`/`...` is content, not a doc marker", () => {
-          // The phase-2 body loop's `0x2D`/`0x2E` arms check for `---`/`...`
-          // and `line_indent == NONE`, but at content_indent==0 a more-indented
-          // `  z---` line still has line_indent set to 0 by the nested loop.
-          // ee/js both treat it as content. Pre-existing.
           expect(YAML.parse("|\nx\n  z---\n")).toEqual("x\n  z---\n");
           expect(YAML.parse("|\nx\n  z...\n")).toEqual("x\n  z...\n");
         });
@@ -1545,9 +1541,7 @@ folded: >
         test("block collection on the `---` line", () => {
           // [200] s-l+block-collection requires s-l-comments (a line break)
           // before l+block-sequence/mapping; same-line content after `---` is
-          // s-separate-in-line + ns-flow-node only. Not tab-specific (`--- - x`
-          // is equally invalid). ee rejects both; js-yaml only rejects the
-          // tab variant. Pre-existing.
+          // s-separate-in-line + ns-flow-node only.
           expect(() => YAML.parse("---\t- x\n")).toThrow();
           expect(() => YAML.parse("--- - x\n")).toThrow();
           // Same-line flow node IS valid.
@@ -1661,6 +1655,30 @@ folded: >
           }
         });
 
+        test("multi-line quoted scalar: tab-prefixed `---`/`...` is content", () => {
+          // is_at_line_start() (prev byte == LF/CR) replaces the `nl &&
+          // line_indent==0` gate; after fold_lines() consumed `\n\t`, prev is
+          // tab, not at line start.
+          expect(YAML.parse("'foo\n\t--- x'\n")).toEqual("foo --- x");
+          expect(YAML.parse('"foo\n\t--- x"\n')).toEqual("foo --- x");
+          expect(() => YAML.parse("'foo\n--- x'\n")).toThrow("document start");
+        });
+
+        test("rejects content on the last `...` line of a multi-suffix run", () => {
+          expect(() => YAML.parse("a\n...\n... b\n")).toThrow("Unexpected token");
+        });
+
+        test.todo("BOM-prefixed `---` recognized as doc marker", () => {
+          // [202] l-document-prefix admits c-byte-order-mark before
+          // c-directives-end. is_at_line_start() returns false after BOM
+          // (prev byte is BOM, not LF/CR). Pre-existing differently-wrong
+          // (was a spurious BOM-only first doc); proper fix is BOM strip in
+          // l-document-prefix, not special-casing here.
+          expect(YAML.parse("﻿---\na: 1\n")).toEqual({ a: 1 });
+        });
+      });
+
+      describe("? in flow context (continued)", () => {
         test("JSON-adjacent does not apply in flow-map value position", () => {
           // [147] flow-map value is ns-flow-node, not ns-flow-pair. These are
           // pre-existing over-accepts on main (refs error); preserved as-is.

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1558,11 +1558,100 @@ folded: >
         test("`---` inside a plain scalar (issue #25660)", () => {
           // [128] ns-plain-char admits `-`; a `---` not at column 0 (or not
           // followed by /[ \t\r\n]|$/) is content, not c-directives-end.
-          // Currently splits into [{"name":"some-text"},{"description":"x"}].
           expect(YAML.parse("name: some-text---\ndescription: x\n")).toEqual({
             name: "some-text---",
             description: "x",
           });
+        });
+      });
+
+      // [203]/[204] c-directives-end / c-document-end are line-starting
+      // tokens at column 0, followed by s-white/b-break/eof. Everywhere else
+      // `-` and `.` are ns-plain-char per [126]/[130]. Exhaustive over
+      // position × column × follower × count × scanner context. Each row
+      // verified against ≥2/3 of eemeli/yaml, js-yaml, PyYAML.
+      describe("`---`/`...` doc-marker recognition", () => {
+        const E = (msg = "Unexpected token") => ({ throws: msg });
+        test.each([
+          // Mid-line / end-of-line in a plain-scalar value (not at column 0)
+          ["trail-dash", "a: text---\n", { a: "text---" }],
+          ["trail-dot", "a: text...\n", { a: "text..." }],
+          ["mid-dash", "a: te---xt\n", { a: "te---xt" }],
+          ["mid-dot", "a: te...xt\n", { a: "te...xt" }],
+          ["lead-dash", "a: ---text\n", { a: "---text" }],
+          ["lead-dot", "a: ...text\n", { a: "...text" }],
+          ["only-dash-val", "a: ---\n", { a: "---" }],
+          ["only-dot-val", "a: ...\n", { a: "..." }],
+          ["git-diff-line", "line: --- a/file\n", { line: "--- a/file" }],
+          // Count: only exactly 3 with ws/eol after is a marker
+          ["2dash", "a: b--\n", { a: "b--" }],
+          ["4dash", "a: b----\n", { a: "b----" }],
+          ["5dash", "a: b-----\n", { a: "b-----" }],
+          ["2dot", "a: b..\n", { a: "b.." }],
+          ["4dot", "a: b....\n", { a: "b...." }],
+          // Follower: must be s-white/b-break/eof
+          ["col0-4dash", "a\n----\n", "a ----"],
+          ["col0-dash-noeol", "a\n---b\n", "a ---b"],
+          ["col0-dot-noeol", "a\n...b\n", "a ...b"],
+          // Top-level plain scalar (no key prefix)
+          ["top-trail", "text---\n", "text---"],
+          ["top-trail-dot", "text...\n", "text..."],
+          ["top-followed-eof", "text---", "text---"],
+          ["top-followed-sp", "text--- more\n", "text--- more"],
+          // Column 0 — IS a marker
+          ["col0-dash", "a\n---\nb\n", ["a", "b"]],
+          ["col0-dot", "a\n...\n", "a"],
+          ["col0-dash-sp", "a\n--- b\n", ["a", "b"]],
+          ["col0-dash-tab", "a\n---\tb\n", ["a", "b"]],
+          ["col0-dash-eof", "a\n---", ["a", null]],
+          ["col0-dash-crlf", "a\r\n---\r\nb\r\n", ["a", "b"]],
+          // Indented — NOT a marker
+          ["indent1-dash", "a\n ---\n", "a ---"],
+          ["indent1-dot", "a\n ...\n", "a ..."],
+          // Block scalar body
+          ["bs-mid", "|\nx\n  z---\n", "x\n  z---\n"],
+          ["bs-mid-dot", "|\nx\n  z...\n", "x\n  z...\n"],
+          ["bsf-mid", ">\nx\n  z---\n", "x\n  z---\n"],
+          ["bs-col0", "|\nx\n---\ny\n", ["x\n", "y"]],
+          ["bs-col0-dot", "|\nx\n...\n", "x\n"],
+          ["bs-first-mid", "|\n  z---\n", "z---\n"],
+          // Quoted scalars — always content
+          ["sq", "a: 'x---'\n", { a: "x---" }],
+          ["dq", 'a: "x---"\n', { a: "x---" }],
+          ["sq-dot", "a: 'x...'\n", { a: "x..." }],
+          // Flow context — always content
+          ["flow-seq", "[a---, b...]\n", ["a---", "b..."]],
+          ["flow-map", "{a: b---}\n", { a: "b---" }],
+          ["flow-only", "[---, ...]\n", ["---", "..."]],
+          // Nested
+          ["nested-trail", "k:\n  a: text---\n  b: y\n", { k: { a: "text---", b: "y" } }],
+          ["nested-col0", "k:\n  a: text\n---\nb\n", [{ k: { a: "text" } }, "b"]],
+          // Real-world text patterns
+          ["ellipsis", "msg: wait...\n", { msg: "wait..." }],
+          ["ellipsis-mid", "msg: wait... done\n", { msg: "wait... done" }],
+          ["range", "span: 2023--2025\n", { span: "2023--2025" }],
+          ["arrow", "dir: <--->\n", { dir: "<--->" }],
+          ["em-dash-ish", "a: foo --- bar\n", { a: "foo --- bar" }],
+          ["frontmatter", "---\ntitle: x\n---\n", [{ title: "x" }, null]],
+          // Mixed
+          ["dash-dot", "a: ---...\n", { a: "---..." }],
+          ["dot-dash", "a: ...---\n", { a: "...---" }],
+          // After --- on the same line: only flow node allowed
+          ["doc-sl-seq", "--- - x\n", E()],
+          ["doc-sl-seq-tab", "---\t- x\n", E()],
+          ["doc-sl-map", "--- a: b\n", E()],
+          ["doc-sl-qmark", "--- ? a\n", E()],
+          ["doc-sl-flow", "--- [a]\n", ["a"]],
+          ["doc-sl-flowmap", "--- {a: 1}\n", { a: 1 }],
+          ["doc-sl-scalar", "--- foo\n", "foo"],
+          ["doc-nl-seq", "---\n- x\n", ["x"]],
+          ["doc-nl-map", "---\na: b\n", { a: "b" }],
+        ] as const)("%s", (_id, input, expected) => {
+          if (typeof expected === "object" && expected && "throws" in expected) {
+            expect(() => YAML.parse(input)).toThrow(expected.throws as string);
+          } else {
+            expect(YAML.parse(input)).toEqual(expected);
+          }
         });
 
         test("JSON-adjacent does not apply in flow-map value position", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1694,6 +1694,12 @@ folded: >
           ["seq-only-dot", "- ...\n- x\n", ["...", "x"]],
           // Compact `- -` prefix collision
           ["compact-dash-val", "- - ---\n", [["---"]]],
+          // #23489: ellipsis inside quoted strings (the original case `nl` was added for)
+          ["i23489", `balance: "👛 لا تمتلك محفظة... !"\n`, { balance: "👛 لا تمتلك محفظة... !" }],
+          ["dq-dot-mid", 'a: "x ... y"\n', { a: "x ... y" }],
+          ["dq-dot-start", 'a: "... rest"\n', { a: "... rest" }],
+          ["dq-dot-end", 'a: "rest ..."\n', { a: "rest ..." }],
+          ["dq-dash-mid", 'a: "x --- y"\n', { a: "x --- y" }],
         ] as const)("%s", (_id, input, expected) => {
           if (typeof expected === "object" && expected && "throws" in expected) {
             expect(() => YAML.parse(input)).toThrow(expected.throws as string);

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1723,9 +1723,9 @@ folded: >
 
         test.todo("BOM-prefixed `---` recognized as doc marker", () => {
           // [202] l-document-prefix admits c-byte-order-mark before
-          // c-directives-end. is_at_line_start() returns false after BOM
-          // (prev byte is BOM, not LF/CR). Pre-existing differently-wrong
-          // (was a spurious BOM-only first doc); proper fix is BOM strip in
+          // c-directives-end. is_at_line_start() is false after the BOM
+          // (pos != line_start_pos). Pre-existing differently-wrong (was a
+          // spurious BOM-only first doc); proper fix is BOM strip in
           // l-document-prefix, not special-casing here.
           expect(YAML.parse("﻿---\na: 1\n")).toEqual({ a: 1 });
         });

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1725,7 +1725,7 @@ folded: >
         });
       });
 
-      describe("? in flow context (continued)", () => {
+      describe("flow over-accepts (locked-in behavior)", () => {
         test("JSON-adjacent does not apply in flow-map value position", () => {
           // [147] flow-map value is ns-flow-node, not ns-flow-pair. These are
           // pre-existing over-accepts on main (refs error); preserved as-is.

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1533,7 +1533,7 @@ folded: >
           expect(() => YAML.parse("?\t: x\n")).toThrow("Tab characters cannot be used as indentation");
         });
 
-        test.todo("block-scalar phase-2 mid-line `---`/`...` is content, not a doc marker", () => {
+        test("block-scalar phase-2 mid-line `---`/`...` is content, not a doc marker", () => {
           // The phase-2 body loop's `0x2D`/`0x2E` arms check for `---`/`...`
           // and `line_indent == NONE`, but at content_indent==0 a more-indented
           // `  z---` line still has line_indent set to 0 by the nested loop.
@@ -1542,7 +1542,7 @@ folded: >
           expect(YAML.parse("|\nx\n  z...\n")).toEqual("x\n  z...\n");
         });
 
-        test.todo("block collection on the `---` line", () => {
+        test("block collection on the `---` line", () => {
           // [200] s-l+block-collection requires s-l-comments (a line break)
           // before l+block-sequence/mapping; same-line content after `---` is
           // s-separate-in-line + ns-flow-node only. Not tab-specific (`--- - x`
@@ -1555,7 +1555,7 @@ folded: >
           expect(YAML.parse("---\tfoo\n")).toEqual("foo");
         });
 
-        test.todo("`---` inside a plain scalar (issue #25660)", () => {
+        test("`---` inside a plain scalar (issue #25660)", () => {
           // [128] ns-plain-char admits `-`; a `---` not at column 0 (or not
           // followed by /[ \t\r\n]|$/) is content, not c-directives-end.
           // Currently splits into [{"name":"some-text"},{"description":"x"}].

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1647,6 +1647,53 @@ folded: >
           ["dot-eof-bs", "|\nx\n...", "x\n"],
           ["dot-eof-only", "...", null],
           ["dash-eof-only", "---", null],
+          // ── Nesting depth / structural variation ──────────────────────────
+          // Deep block-map nesting (--- at columns 8, 12)
+          ["deep-3-dash", "a:\n  b:\n    c: text---\n    d: y\n", { a: { b: { c: "text---", d: "y" } } }],
+          ["deep-3-dot", "a:\n  b:\n    c: text...\n    d: y\n", { a: { b: { c: "text...", d: "y" } } }],
+          ["deep-4", "a:\n  b:\n    c:\n      d: t---\n", { a: { b: { c: { d: "t---" } } } }],
+          // Block-seq nesting
+          ["seq-2", "- - text---\n", [["text---"]]],
+          ["seq-3", "- - - text...\n", [[["text..."]]]],
+          ["seq-map-seq", "- a:\n    - b---\n    - c\n", [{ a: ["b---", "c"] }]],
+          // Mixed block↔flow
+          ["block-flow-seq", "a:\n  - [text---, x]\n", { a: [["text---", "x"]] }],
+          ["block-flow-map", "a:\n  - {k: text...}\n", { a: [{ k: "text..." }] }],
+          ["flow-in-flow", "[[text---], {k: text...}]\n", [["text---"], { k: "text..." }]],
+          ["flow-nested-3", "[[[a---]]]\n", [[["a---"]]]],
+          // Block scalar inside nesting
+          ["nested-bs", "a:\n  b: |\n    text---\n  c: x\n", { a: { b: "text---\n", c: "x" } }],
+          ["nested-bs-fold", "a:\n  b: >\n    text...\n  c: x\n", { a: { b: "text...\n", c: "x" } }],
+          ["seq-bs", "- |\n  text---\n- y\n", ["text---\n", "y"]],
+          // Quoted inside nesting
+          ["nested-sq", "a:\n  b: 'text---'\n  c: x\n", { a: { b: "text---", c: "x" } }],
+          ["nested-dq", 'a:\n  b: "text..."\n  c: x\n', { a: { b: "text...", c: "x" } }],
+          // Key position (--- as part of a key)
+          ["key-dash", "text---: v\n", { "text---": "v" }],
+          ["key-dot", "text...: v\n", { "text...": "v" }],
+          ["nested-key", "a:\n  text---: v\n", { a: { "text---": "v" } }],
+          ["explicit-key", "? text---\n: v\n", { "text---": "v" }],
+          // After anchor/tag
+          ["anchor-val", "a: &x text---\nb: *x\n", { a: "text---", b: "text---" }],
+          ["tag-val", "a: !!str text---\n", { a: "text---" }],
+          ["anchor-tag-val", "a: &x !!str text...\n", { a: "text..." }],
+          // After flow indicator (, [ {)
+          ["flow-after-comma", "[a, text---, b]\n", ["a", "text---", "b"]],
+          ["flow-after-colon", "{a: text---, b: text...}\n", { a: "text---", b: "text..." }],
+          ["flow-map-key", "{text---: v}\n", { "text---": "v" }],
+          // Multi-doc with --- as content in a doc
+          ["multidoc-content", "---\na: text---\n---\nb: text...\n", [{ a: "text---" }, { b: "text..." }]],
+          // Multi-line plain with --- on continuation (column > 0)
+          ["fold-dash", "a: text\n  ---more\n", { a: "text ---more" }],
+          ["fold-dot", "a: text\n  ...more\n", { a: "text ...more" }],
+          ["fold-dash-end", "a: text\n  more---\n", { a: "text more---" }],
+          // Multi-line plain with --- on continuation at column 0 (IS marker)
+          ["fold-col0", "a: text\n---\nb\n", [{ a: "text" }, "b"]],
+          // Seq item that's just --- (column > 0)
+          ["seq-only-dash", "- ---\n- x\n", ["---", "x"]],
+          ["seq-only-dot", "- ...\n- x\n", ["...", "x"]],
+          // Compact `- -` prefix collision
+          ["compact-dash-val", "- - ---\n", [["---"]]],
         ] as const)("%s", (_id, input, expected) => {
           if (typeof expected === "object" && expected && "throws" in expected) {
             expect(() => YAML.parse(input)).toThrow(expected.throws as string);


### PR DESCRIPTION
## What

Per [203]/[204], `c-directives-end` (`---`) and `c-document-end` (`...`) are line-starting tokens at column 0 followed by `s-white`/`b-break`/EOF. Everywhere else `-` and `.` are `ns-plain-char` per [126]/[130].

Bun was checking `line_indent == 0` — which is the *line's* indent, true everywhere on a line that starts at column 0, not just at its start. So:

```yaml
name: some-text---
description: x
```

…was splitting into two documents (`---` at column 16 on a column-0 line matched). Same for `a: ...`, `line: --- a/file`, `msg: wait...`, etc.

## How

New `Parser::is_at_line_start()` helper: prev byte is `\n`/`\r` or `pos == 0`. Added to all 6 doc-marker checks (`scan()`, `scan_plain_scalar`, block-scalar phase-2 — `0x2D` and `0x2E` arms each).

Also:
- `is_any_or_eof_at` returned `false` at EOF despite its name (Zig port artifact). Only the 4 doc-marker checks call it; fixed to match its name so `a\n---<EOF>` is a marker.
- `parse_block_sequence` now mirrors `parse_block_mapping`'s `explicit_document_start_line` check, so `--- - x` is rejected (per [200], a block collection after `---` requires `s-l-comments` first; same-line content can only be a flow node).

## Tests

60-case `test.each` matrix covering position × column × follower × count × scanner context (plain, `|`, `>`, quoted, flow) × real-world text patterns (ellipsis, ranges, git-diff lines, frontmatter). Each row verified against ≥2/3 of eemeli/yaml, js-yaml, PyYAML. 20/62 fail on system Bun.

- 1978 pass / 0 fail / 10 todo
- 402/402 yaml-test-suite
- 1015/1015 4-parser consensus

Closes #25660.