### PR TITLE
resolver: delete unused ModKeyError, FileSystemError, ReverseResolution, and dead helper fns

### DIFF
--- a/src/resolver/dir_info.rs
+++ b/src/resolver/dir_info.rs
@@ -228,13 +228,6 @@ impl DirInfo {
         self.tsconfig_json.map(arena_ref)
     }
 
-    pub fn has_parent_package(&self) -> bool {
-        let Some(parent) = self.get_parent() else {
-            return false;
-        };
-        !parent.is_node_modules()
-    }
-
     pub fn get_file_descriptor(&self) -> Fd {
         if FeatureFlags::STORE_FILE_DESCRIPTORS {
             // Route through `entries_at` directly (returns `Option<&mut EntriesOption>`)

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -299,15 +299,6 @@ impl strings::Appender for FilenameStoreAppender {
     }
 }
 
-#[derive(strum::IntoStaticStr, Debug)]
-pub enum FileSystemError {
-    ENOENT,
-    EACCESS,
-    INVALID_NAME,
-    ENOTDIR,
-}
-// TODO(port): impl From<FileSystemError> for bun_core::Error
-
 // PORTING.md §Global mutable state: highest-fd watermark, written from
 // resolver pool / bundler / router and read from the file-limit check below.
 // `AtomicCell` (not `RacyCell`) because those callers run on different
@@ -1449,11 +1440,6 @@ impl RealFS {
     }
 }
 
-#[derive(strum::IntoStaticStr, Debug)]
-pub enum ModKeyError {
-    Unusable,
-}
-
 #[derive(Default, Clone, Copy)]
 pub struct ModKey {
     pub inode: u64, // TODO(port): std.fs.File.INode equivalent
@@ -1467,8 +1453,6 @@ thread_local! {
 }
 
 impl ModKey {
-    pub const SAFETY_GAP: i32 = 3;
-
     pub fn hash_name(&self, basename: &[u8]) -> Result<&'static [u8], bun_core::Error> {
         // TODO(port): returns slice into threadlocal buffer; lifetime is unsound — should take a caller-supplied buffer
         let hex_int = self.hash();
@@ -2316,77 +2300,6 @@ pub fn read_file_with_handle_impl<'p, 'buf, const USE_SHARED_BUFFER: bool, const
 }
 
 impl RealFS {
-    pub fn kind_from_absolute(
-        &mut self,
-        absolute_path: &ZStr,
-        existing_fd: Fd,
-        store_fd: bool,
-    ) -> Result<EntryCache, bun_core::Error> {
-        let mut outpath = PathBuffer::uninit();
-
-        let stat = bun_sys::lstat(absolute_path)?;
-        let mut kind_ = bun_sys::kind_from_mode(stat.st_mode as bun_sys::Mode);
-        let is_symlink = kind_ == bun_sys::FileKind::SymLink;
-        let mut cache = EntryCache {
-            kind: EntryKind::File,
-            symlink: PathString::EMPTY,
-            fd: Fd::INVALID,
-        };
-        let mut symlink: &[u8] = b"";
-
-        if is_symlink {
-            // TODO(port): existing_fd != 0 — Zig compared FD to integer 0; using is_valid()
-            let file: Fd = if existing_fd.is_valid() {
-                existing_fd
-            } else if store_fd {
-                bun_sys::open_file_absolute_z(absolute_path, bun_sys::OpenFlags::READ_ONLY)?
-                    .into_raw()
-            } else {
-                // PORT NOTE: Zig `bun.openFileForPath` (bun.zig:1900-1910) — O_PATH is
-                // Linux-only; macOS/BSD use O_RDONLY. Both add O_NOCTTY|O_CLOEXEC.
-                #[cfg(any(target_os = "linux", target_os = "android"))]
-                let flags = bun_sys::O::PATH | bun_sys::O::CLOEXEC | bun_sys::O::NOCTTY;
-                #[cfg(not(any(target_os = "linux", target_os = "android")))]
-                let flags = bun_sys::O::RDONLY | bun_sys::O::CLOEXEC | bun_sys::O::NOCTTY;
-                bun_sys::open(absolute_path, flags, 0)?
-            };
-            FileSystem::set_max_fd(file.native());
-
-            // PORT NOTE: Zig `defer { if (...) file.close() else cache.fd = file }` runs on
-            // BOTH success and error paths — use scopeguard so close-or-store happens even if
-            // stat()/get_fd_path() return early with `?`.
-            let need_to_close_files = self.need_to_close_files();
-            let cache_ptr: *mut EntryCache = &raw mut cache;
-            let _guard = scopeguard::guard(file, move |file| {
-                if (!store_fd || need_to_close_files) && !existing_fd.is_valid() {
-                    let _ = bun_sys::close(file);
-                } else if FeatureFlags::STORE_FILE_DESCRIPTORS {
-                    // SAFETY: `cache_ptr` points into a stack local that outlives this guard.
-                    unsafe { (*cache_ptr).fd = file };
-                }
-            });
-
-            let stat_ = bun_sys::fstat(*_guard)?;
-
-            symlink = bun_sys::get_fd_path(*_guard, &mut outpath)?;
-
-            kind_ = bun_sys::kind_from_mode(stat_.st_mode as bun_sys::Mode);
-        }
-
-        debug_assert!(kind_ != bun_sys::FileKind::SymLink);
-
-        if kind_ == bun_sys::FileKind::Directory {
-            cache.kind = EntryKind::Dir;
-        } else {
-            cache.kind = EntryKind::File;
-        }
-        if !symlink.is_empty() {
-            cache.symlink = PathString::init(FilenameStore::instance().append(symlink)?);
-        }
-
-        Ok(cache)
-    }
-
     pub fn kind(
         &mut self,
         dir_: &[u8],

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -15,7 +15,6 @@ use bun_sys::Fd;
 use crate as resolver;
 use crate::fs;
 use bun_alloc::Arena as Bump;
-use bun_wyhash::Wyhash;
 
 // ── bun_install types (MOVE_DOWN: bun_install_types) ──────────────────────
 // Note: bun_resolver cannot depend on bun_install (would loop). The
@@ -1727,21 +1726,6 @@ impl PackageJSON {
     }
 }
 
-// TODO(port): `self.hash` field referenced in Zig but not declared on
-// PackageJSON; gate until the field lands.
-
-impl PackageJSON {
-    pub fn hash_module(&self, module: &[u8]) -> u32 {
-        let mut hasher = Wyhash::init(0);
-        // PORT NOTE: Zig referenced `this.hash`, which is not a declared field on
-        // `PackageJSON` in either tree (dead body). Hash the package name as the
-        // stable per-package seed instead so `hash_module` is deterministic.
-        hasher.update(&self.name);
-        hasher.update(module);
-
-        hasher.final_() as u32
-    }
-} // end  impl PackageJSON
 
 pub struct ExportsMap {
     pub root: Entry,
@@ -2315,15 +2299,6 @@ fn replace(input: &[u8], needle: &[u8], replacement: &[u8], output: &mut [u8]) -
         }
     }
     count
-}
-
-#[derive(Clone, Default)]
-pub struct ReverseResolution {
-    // PORT NOTE: Zig returned slices into threadlocal PathBuffers / the package.json source
-    // buffer. Copy out into an owned buffer (see `Resolution.path` note above).
-    // TODO(perf): thread a real `'a` lifetime once `EntryData::String` is `&'a [u8]`.
-    pub subpath: Box<[u8]>,
-    pub token: bun_ast::Range,
 }
 
 const INVALID_PERCENT_CHARS: [&[u8]; 4] = [b"%2f", b"%2F", b"%5c", b"%5C"];

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1726,7 +1726,6 @@ impl PackageJSON {
     }
 }
 
-
 pub struct ExportsMap {
     pub root: Entry,
     pub exports_range: bun_ast::Range,


### PR DESCRIPTION
Dead-code sweep of `bun_resolver`. None referenced outside their own definitions in the Rust tree.

`cargo check --workspace` passes.

## Why this code exists

| Item | Zig original | Zig callers | Status |
|---|---|---|---|
| `ModKeyError` | `src/resolver/fs.zig:841` | 0 — `ModKey.generate` (`:887`) returns `anyerror!`, not `ModKeyError!` | **dead in Zig too** |
| `ModKey::SAFETY_GAP` | `fs.zig:912` (`SafetyGap`) | 0 — defined but never read, even inside `ModKey.generate` | **dead in Zig too** |
| `FileSystemError` | none (0 hits in `*.zig`) | n/a | **Rust-port artifact** — defined only at `fs.rs` with a `TODO(port): impl From<...>` note |
| `kind_from_absolute` | `fs.zig:1308` (`kindFromAbsolute`) | 0 | **dead in Zig too** |
| `ReverseResolution` | `src/resolver/package_json.zig:1496` | 0 — return type of `resolveExportsReverse`/`resolveImportsExportsReverse`/`resolveTargetReverse` (`:1993,2007,2041`), all of which have 0 external callers | **dead in Zig too** |
| `hash_module` | `package_json.zig:1081` (`hashModule`) | 0 | **dead in Zig too** |
| `has_parent_package` | `src/resolver/dir_info.zig:56` (`hasParentPackage`) | 0 | **dead in Zig too** |
