### PR TITLE
sys: delete unused CopyFileRangeError, copy_file_error_convert, SCS_*_BINARY/GetBinaryTypeW

### DIFF
--- a/src/sys/copy_file.rs
+++ b/src/sys/copy_file.rs
@@ -20,33 +20,6 @@ use crate::Tag;
 static debug: bun_core::output::ScopedLogger =
     bun_core::output::ScopedLogger::new("copy_file", bun_core::output::Visibility::Hidden);
 
-#[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
-pub enum CopyFileRangeError {
-    #[error("FileTooBig")]
-    FileTooBig,
-    #[error("InputOutput")]
-    InputOutput,
-    /// `in` is not open for reading; or `out` is not open  for  writing;
-    /// or the  `O.APPEND`  flag  is  set  for `out`.
-    #[error("FilesOpenedWithWrongFlags")]
-    FilesOpenedWithWrongFlags,
-    #[error("IsDir")]
-    IsDir,
-    #[error("OutOfMemory")]
-    OutOfMemory,
-    #[error("NoSpaceLeft")]
-    NoSpaceLeft,
-    #[error("Unseekable")]
-    Unseekable,
-    #[error("PermissionDenied")]
-    PermissionDenied,
-    #[error("FileBusy")]
-    FileBusy,
-    // TODO(port): Zig unioned `posix.PReadError || posix.PWriteError || posix.UnexpectedError`
-    // here; in Rust those collapse into `bun_core::Error` via `From`.
-}
-bun_core::named_error_set!(CopyFileRangeError);
-
 #[cfg(windows)]
 pub type InputType<'a> = &'a bun_core::WStr; // bun.OSPathSliceZ == [:0]const u16
 #[cfg(not(windows))]
@@ -485,12 +458,6 @@ pub fn copy_file_read_write_loop(in_: fd_t, out: fd_t, len: usize) -> crate::Res
 fn kernel_at_least(major: u32, minor: u32) -> bool {
     let v = bun_core::linux_kernel_version();
     (v.major, v.minor, v.patch) >= (major, minor, 0)
-}
-
-/// Map a raw `copy_file`-path errno to `bun_core::Error`.
-#[inline]
-pub fn copy_file_error_convert(e: crate::Error) -> bun_core::Error {
-    e.into()
 }
 
 // ported from: src/sys/copy_file.zig

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -424,8 +424,6 @@ pub const FILE_TYPE_CHAR: DWORD = 0x0002;
 pub const FILE_TYPE_PIPE: DWORD = 0x0003;
 pub const FILE_TYPE_REMOTE: DWORD = 0x8000;
 
-pub use bun_windows_sys::externs::LPDWORD;
-
 pub use SetCurrentDirectoryW as SetCurrentDirectory;
 /// Each process has a single current directory made up of two parts:
 ///

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -426,27 +426,6 @@ pub const FILE_TYPE_REMOTE: DWORD = 0x8000;
 
 pub use bun_windows_sys::externs::LPDWORD;
 
-pub use bun_windows_sys::externs::GetBinaryTypeW;
-
-/// A 32-bit Windows-based application
-#[allow(dead_code)]
-pub const SCS_32BIT_BINARY: DWORD = 0;
-/// A 64-bit Windows-based application.
-#[allow(dead_code)]
-pub const SCS_64BIT_BINARY: DWORD = 6;
-/// An MS-DOS – based application
-#[allow(dead_code)]
-pub const SCS_DOS_BINARY: DWORD = 1;
-/// A 16-bit OS/2-based application
-#[allow(dead_code)]
-pub const SCS_OS216_BINARY: DWORD = 5;
-/// A PIF file that executes an MS-DOS – based application
-#[allow(dead_code)]
-pub const SCS_PIF_BINARY: DWORD = 3;
-/// A POSIX – based application
-#[allow(dead_code)]
-pub const SCS_POSIX_BINARY: DWORD = 4;
-
 pub use SetCurrentDirectoryW as SetCurrentDirectory;
 /// Each process has a single current directory made up of two parts:
 ///


### PR DESCRIPTION
Dead-code sweep of `bun_sys`.

`cargo check --workspace` passes.

## Why this code exists

| Item | Zig original | Zig callers | Status |
|---|---|---|---|
| `CopyFileRangeError` | `src/sys/copy_file.zig:5` | 0 — defined-only; the fns return `Maybe(usize)` / `CopyFileReturnType` instead | **dead in Zig too** |
| `copy_file_error_convert` | none — `src/bun.zig:1140` has a *dangling* `pub const copyFileErrnoConvert = CopyFile.copyFileErrorConvert;` re-export pointing at a fn that does not exist in `copy_file.zig` (Zig lazy-eval hides this; 0 callers of the re-export) | n/a | **Rust-port artifact** — created to satisfy the dangling Zig re-export; body is identity `e.into()` |
| `SCS_*_BINARY` ×6 + `GetBinaryTypeW` re-export | `src/sys/windows/windows.zig:116-128` | 0 — `GetBinaryTypeW` is re-exported but never invoked (`sys.zig:3812` only mentions it in a comment) | **dead in Zig too** — WinAPI result codes copied from headers; the `#[allow(dead_code)]` attrs were suppressing a real signal |
