### PR TITLE
paths: delete unused Path::move_ no-op

### DIFF
--- a/src/paths/Path.rs
+++ b/src/paths/Path.rs
@@ -652,12 +652,6 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
 
     // `deinit` → impl Drop (below). Body returns the buffer to the pool.
 
-    /// for call-site parity with the Zig (`const moved = this.move();`).
-    #[inline]
-    pub fn move_(self) -> Self {
-        self
-    }
-
     pub fn init_top_level_dir() -> Self {
         debug_assert!(crate::fs::FileSystem::instance_loaded());
         let top_level_dir = crate::fs::FileSystem::instance().top_level_dir();


### PR DESCRIPTION
Dead-code sweep of `bun_paths` — single item.

`cargo check --workspace` passes.

## Why this code exists

| Item | Zig original | Zig callers | Status |
|---|---|---|---|
| `Path::move_` | `src/paths/Path.zig:288` (`move`) | 0 — the only `.move()` hit (`src/install/hosted_git_info.zig:153`) targets `extract.Result.move`, not `Path.move` | **dead in Zig too** — and the Rust port is a `self`-returning no-op (Rust move semantics make it identity) |
