### PR TITLE
http_types: delete unused can_open_in_editor and URLPath::is_root/path_without_asset_prefix

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -185,7 +185,7 @@ let mime = mime_type::by_extension(b"html");            // MimeType
 let mime = mime_type::by_extension_no_default(b"xyz");  // Option<MimeType>
 
 mime.category   // Category::Javascript | Css | Html | Json | Image | Text | Wasm | ...
-mime.category.is_code()
+mime.category.is_text_like()
 ```
 
 Common constants: `JAVASCRIPT`, `JSON`, `HTML`, `CSS`, `TEXT`, `WASM`, `ICO`, `OTHER`.

--- a/src/http_types/MimeType.rs
+++ b/src/http_types/MimeType.rs
@@ -130,7 +130,6 @@ pub fn create_hash_table() -> Result<Map, bun_alloc::AllocError> {
     Ok(map)
 }
 
-
 #[derive(Clone, Copy, PartialEq, Eq, Debug, strum::IntoStaticStr)]
 #[strum(serialize_all = "lowercase")]
 pub enum Category {

--- a/src/http_types/MimeType.rs
+++ b/src/http_types/MimeType.rs
@@ -291,13 +291,6 @@ impl Category {
         Category::Other
     }
 
-    pub fn is_code(self) -> bool {
-        matches!(
-            self,
-            Category::Wasm | Category::Json | Category::Css | Category::Html | Category::Javascript
-        )
-    }
-
     pub fn is_text_like(self) -> bool {
         matches!(
             self,

--- a/src/http_types/MimeType.rs
+++ b/src/http_types/MimeType.rs
@@ -130,19 +130,6 @@ pub fn create_hash_table() -> Result<Map, bun_alloc::AllocError> {
     Ok(map)
 }
 
-impl MimeType {
-    pub fn can_open_in_editor(&self) -> bool {
-        if self.category == Category::Text || self.category.is_code() {
-            return true;
-        }
-
-        if self.category == Category::Image {
-            return self.value.as_ref() == b"image/svg+xml";
-        }
-
-        false
-    }
-}
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, strum::IntoStaticStr)]
 #[strum(serialize_all = "lowercase")]

--- a/src/http_types/URLPath.rs
+++ b/src/http_types/URLPath.rs
@@ -29,36 +29,6 @@ pub struct URLPath {
 }
 
 impl URLPath {
-    pub fn is_root(&self, asset_prefix: &[u8]) -> bool {
-        let without = self.path_without_asset_prefix(asset_prefix);
-        if without.len() == 1 && without[0] == b'.' {
-            return true;
-        }
-        without == b"index"
-    }
-
-    // TODO: use a real URL parser
-    // this treats a URL like /_next/ identically to /
-    pub fn path_without_asset_prefix(&self, asset_prefix: &[u8]) -> &[u8] {
-        if asset_prefix.is_empty() {
-            return self.path;
-        }
-        let leading_slash_offset: usize = if asset_prefix[0] == b'/' { 1 } else { 0 };
-        let base = self.path;
-        let origin = &asset_prefix[leading_slash_offset..];
-
-        let out = if base.len() >= origin.len() && &base[0..origin.len()] == origin {
-            &base[origin.len()..]
-        } else {
-            base
-        };
-        if self.is_source_map && out.ends_with(b".map") {
-            return &out[0..out.len() - 4];
-        }
-
-        out
-    }
-
     /// Take ownership of the percent-decode buffer, if `parse()` had to
     /// allocate one. The slice fields of `self` keep pointing into the
     /// returned allocation — the caller must keep it alive for as long as any


### PR DESCRIPTION
Dead-code sweep of `bun_http_types`.

`cargo check --workspace` passes.

## Why this code exists

| Item | Zig original | Zig callers | Status |
|---|---|---|---|
| `MimeType::can_open_in_editor` | `src/http_types/MimeType.zig:64` (`canOpenInEditor`) | 0 | **dead in Zig too** |
| `URLPath::is_root` | `src/http_types/URLPath.zig:13` (`isRoot`) | 0 | **dead in Zig too** |
| `URLPath::path_without_asset_prefix` | `URLPath.zig:21` (`pathWithoutAssetPrefix`) | 0 — only caller is `isRoot` at `:14` (same file), itself dead | **dead in Zig too** |
