### PR TITLE
upload-release: publish android and freebsd artifacts

### DIFF
--- a/.buildkite/scripts/upload-release.sh
+++ b/.buildkite/scripts/upload-release.sh
@@ -222,6 +222,14 @@ function create_release() {
     bun-linux-x64-musl-profile.zip
     bun-linux-x64-musl-baseline.zip
     bun-linux-x64-musl-baseline-profile.zip
+    bun-linux-aarch64-android.zip
+    bun-linux-aarch64-android-profile.zip
+    bun-linux-x64-android.zip
+    bun-linux-x64-android-profile.zip
+    bun-freebsd-aarch64.zip
+    bun-freebsd-aarch64-profile.zip
+    bun-freebsd-x64.zip
+    bun-freebsd-x64-profile.zip
     bun-windows-x64.zip
     bun-windows-x64-profile.zip
     bun-windows-x64-baseline.zip


### PR DESCRIPTION
Android and FreeBSD build green on every `main` commit (`linux-{aarch64,x64}-android-build-bun`, `freebsd-{x64,aarch64}-build-bun`) but their zips are absent from the `create_release` allowlist, so they never reach the canary/tagged GitHub release or S3. This adds the 8 missing entries.

Verified against build #58833: every artifact name in the array (including the 8 new ones) exists as a Buildkite artifact, so `download_buildkite_artifact` won't fail.

Not added: `bun-linux-x64-android-baseline*.zip` — `ci.mjs` has no android baseline lane, so listing it would `exit 1` the release.

Consider landing after #30769 so the first published Rust-era Android binary survives startup under seccomp.