### PR TITLE
use Imports::NAME instead of hardcoded b"bun:wrap"

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3219,7 +3219,7 @@ pub mod bv2_impl {
             // try this.graph.entry_points.append(arena, Index.runtime);
             let _ = self.graph.ast.append(JSAst::empty_in(self.graph.heap)); // OOM/capacity: Zig aborts; port keeps fire-and-forget
             self.path_to_source_index_map(self.transpiler.options.target)
-                .put(&b"bun:wrap"[..], Index::RUNTIME.get())
+                .put(bun_ast::runtime::Imports::NAME, Index::RUNTIME.get())
                 .expect("oom");
             // SAFETY: arena (`self.graph.heap`) outlives the bundle pass; coerce the
             // `&mut ParseTask` to `*mut` immediately so the `&self` borrow from
@@ -5943,7 +5943,7 @@ pub mod bv2_impl {
                     }
                 }
 
-                if import_record.path.text == b"bun:wrap" {
+                if import_record.path.text == bun_ast::runtime::Imports::NAME {
                     import_record.path.namespace = b"bun";
                     import_record.tag = bun_ast::ImportRecordTag::Runtime;
                     import_record.path.text = b"wrap";

--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -450,7 +450,13 @@ impl Linker {
                         if import_record.path.namespace == b"runtime" {
                             if import_path_format == ImportPathFormat::AbsoluteUrl {
                                 import_record.path = PFs::Path::init_with_namespace(
-                                    dupe(&origin.join_alloc(b"", b"", RUNTIME_SOURCE_PATH, b"", b"")?),
+                                    dupe(&origin.join_alloc(
+                                        b"",
+                                        b"",
+                                        RUNTIME_SOURCE_PATH,
+                                        b"",
+                                        b"",
+                                    )?),
                                     b"bun",
                                 );
                             } else {

--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -65,7 +65,7 @@ pub struct Linker {
     pub plugin_runner: Option<*mut dyn PluginResolver>,
 }
 
-pub(crate) const RUNTIME_SOURCE_PATH: &[u8] = b"bun:wrap";
+pub(crate) const RUNTIME_SOURCE_PATH: &[u8] = bun_ast::runtime::Imports::NAME;
 
 #[derive(Default)]
 pub struct TaggedResolution {
@@ -450,7 +450,7 @@ impl Linker {
                         if import_record.path.namespace == b"runtime" {
                             if import_path_format == ImportPathFormat::AbsoluteUrl {
                                 import_record.path = PFs::Path::init_with_namespace(
-                                    dupe(&origin.join_alloc(b"", b"", b"bun:wrap", b"", b"")?),
+                                    dupe(&origin.join_alloc(b"", b"", RUNTIME_SOURCE_PATH, b"", b"")?),
                                     b"bun",
                                 );
                             } else {

--- a/src/bundler/linker_context/convertStmtsForChunkForDevServer.rs
+++ b/src/bundler/linker_context/convertStmtsForChunkForDevServer.rs
@@ -140,7 +140,7 @@ pub fn convert_stmts_for_chunk_for_dev_server<'bump>(
                                 args: ExprNodeList::from_slice(&[Expr::init(
                                     E::String {
                                         data: if record.tag == ImportRecordTag::Runtime {
-                                            b"bun:wrap".into()
+                                            bun_ast::runtime::Imports::NAME.into()
                                         } else {
                                             record.path.pretty.into()
                                         },

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4080,10 +4080,8 @@ impl VirtualMachine {
         // result paths without threading a lifetime parameter through the VM.
         let specifier: &'static [u8] = unsafe { bun_ptr::detach_lifetime(specifier) };
 
-        // `Runtime.Runtime.Imports.{alt_name, Name}` are both `"bun:wrap"`
-        // (see js_parser/runtime.rs).
-        if bun_paths::basename(specifier) == b"bun:wrap" {
-            ret.path = b"bun:wrap";
+        if bun_paths::basename(specifier) == bun_ast::runtime::Imports::NAME {
+            ret.path = bun_ast::runtime::Imports::NAME;
             return Ok(());
         }
         if specifier == MAIN_FILE_NAME && self.entry_point.generated {
@@ -5273,7 +5271,8 @@ impl VirtualMachine {
                 || name.eql_comptime("processTicksAndRejections")
         }
         fn is_hidden_frame(f: &crate::ZigStackFrame) -> bool {
-            f.source_url.eql_comptime("bun:wrap") || f.function_name.eql_comptime("::bunternal::")
+            f.source_url.eql_comptime(bun_ast::runtime::Imports::NAME)
+                || f.function_name.eql_comptime("::bunternal::")
         }
         fn is_unknown_source(url: &bun_core::String) -> bool {
             url.is_empty() || url.eql_comptime("[unknown]") || url.has_prefix_comptime(b"[source:")

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4738,12 +4738,8 @@ unsafe fn _resolve<'a>(
     use bun_jsc::virtual_machine::MAIN_FILE_NAME;
     use bun_resolve_builtins::{Alias, Cfg as AliasCfg};
 
-    // Spec :1732 — `Runtime.Runtime.Imports.alt_name` == `Runtime.Runtime.Imports.Name`
-    // == `"bun:wrap"` (see js_parser/runtime.rs:644-645). Zig compared the
-    // *basename* against `alt_name`; both consts are the bare specifier so a
-    // direct equality on `basename(specifier)` is correct.
-    if bun_paths::basename(specifier) == b"bun:wrap" {
-        *ret_path = b"bun:wrap";
+    if bun_paths::basename(specifier) == bun_ast::runtime::Imports::NAME {
+        *ret_path = bun_ast::runtime::Imports::NAME;
         return Ok(());
     }
 


### PR DESCRIPTION
Replaces 9 hardcoded `b"bun:wrap"` literals with `bun_ast::runtime::Imports::NAME` so the runtime-module identifier has a single source of truth.

Touched call sites:
- `bundler/linker.rs` (×2) — `RUNTIME_SOURCE_PATH` const + `join_alloc` arg
- `bundler/bundle_v2.rs` (×2) — path-to-source-index map key + import-record path comparison
- `bundler/linker_context/convertStmtsForChunkForDevServer.rs` — runtime import string literal
- `jsc/VirtualMachine.rs` (×3) — specifier basename check + `is_hidden_frame`
- `runtime/jsc_hooks.rs` (×2) — specifier basename check

**Left as literals** (intentionally — these are entries in a canonical name table alongside ~80 other module identifiers, not "inlined copies"):
- `resolve_builtins/HardcodedModule.rs:24` — `#[strum(serialize = "bun:wrap")]` (attribute, must be a literal)
- `resolve_builtins/HardcodedModule.rs:194` — match arm in the builtin-module dispatch table
- `resolve_builtins/HardcodedModule.rs:687` — `entry!("bun:wrap")` in the alias table

`cargo check --workspace` passes; `bun bd -e` and `bun bd build` smoke-tested.