### PR TITLE
install: make lockfileVersion 2 stamp independent of the writer's registry config

### DIFF
--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -190,20 +190,22 @@ impl Stringifier {
     /// backfill), so stamping v2 on a lockfile that still carries such an entry
     /// would make the *next* parse reject it. Only stamp v2 when every package
     /// already satisfies the v2 invariants; otherwise stay at v1 so the file
-    /// round-trips (load → save → load) cleanly.
+    /// round-trips (load → save → load) cleanly — across machines too, since a
+    /// lockfile is committed and shared. The decision is therefore made without
+    /// consulting the writer's registry config: whether the *reader* will accept
+    /// the file must not depend on the writer's `~/.npmrc` / scoped registries.
     ///
     /// Walks the package tree the same way the writer does — only packages that
     /// are actually serialized are considered, not every entry in the in-memory
     /// `pkg_resolutions` buffer (migration can leave pruned/unreferenced entries
     /// there that never reach the written `packages` object).
-    fn version_to_write(lockfile: &BinaryLockfile, options: &PackageManagerOptions) -> Version {
+    fn version_to_write(lockfile: &BinaryLockfile) -> Version {
         let buf = lockfile.buffers.string_bytes.as_slice();
         let deps_buf = lockfile.buffers.dependencies.as_slice();
         let resolution_buf = lockfile.buffers.resolutions.as_slice();
         let pkgs = lockfile.packages.slice();
         let pkg_resolutions: &[Resolution] = pkgs.items_resolution();
         let pkg_metas: &[Meta] = pkgs.items_meta();
-        let pkg_names: &[String] = pkgs.items_name();
 
         let mut iter = tree::Iterator::<'_, { tree::IteratorPathStyle::PkgPath }>::from_slices(
             lockfile.buffers.trees.as_slice(),
@@ -226,16 +228,19 @@ impl Stringifier {
                             continue;
                         }
                         // No supported integrity: only v2-clean if the tarball
-                        // URL is under the configured/default registry (mirrors
-                        // the parser's `npm_url_needs_integrity` computation).
+                        // URL is under the *default* registry, the one case the
+                        // writer normalizes to `""` (see the URL serialization
+                        // above). An empty URL never sets the parser's
+                        // `npm_url_needs_integrity`, so that round-trips for any
+                        // reader. A URL under a configured-but-not-default scope
+                        // is written verbatim and the parser's integrity check
+                        // is evaluated against the *reader's* scope config, so
+                        // it is not config-independent: a writer with a private
+                        // `@scope` registry could stamp v2 on a lockfile a
+                        // teammate without that scope then fails to parse. Stay
+                        // at v1 for those so the file keeps loading everywhere.
                         let url = res.npm().url.slice(buf);
-                        let configured_registry = options
-                            .scope_for_package_name(pkg_names[i].slice(buf))
-                            .url
-                            .href();
-                        let under_registry = url_is_under_registry(url, configured_registry)
-                            || url_is_under_registry(url, Npm::Registry::DEFAULT_URL.as_bytes());
-                        if !under_registry {
+                        if !url_is_under_registry(url, Npm::Registry::DEFAULT_URL.as_bytes()) {
                             return Version::V1;
                         }
                     }
@@ -336,7 +341,7 @@ impl Stringifier {
         writer.write_all(b"{\n")?;
         Self::inc_indent(writer, indent)?;
         {
-            let lockfile_version = Self::version_to_write(lockfile, options);
+            let lockfile_version = Self::version_to_write(lockfile);
             writeln!(writer, "\"lockfileVersion\": {},", lockfile_version as u32)?;
             Self::write_indent(writer, *indent)?;
 

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -229,16 +229,17 @@ impl Stringifier {
                         }
                         // No supported integrity: only v2-clean if the tarball
                         // URL is under the *default* registry, the one case the
-                        // writer normalizes to `""` (see the URL serialization
-                        // above). An empty URL never sets the parser's
-                        // `npm_url_needs_integrity`, so that round-trips for any
-                        // reader. A URL under a configured-but-not-default scope
-                        // is written verbatim and the parser's integrity check
-                        // is evaluated against the *reader's* scope config, so
-                        // it is not config-independent: a writer with a private
-                        // `@scope` registry could stamp v2 on a lockfile a
-                        // teammate without that scope then fails to parse. Stay
-                        // at v1 for those so the file keeps loading everywhere.
+                        // writer normalizes to `""` (see the npm URL
+                        // serialization in `save_from_binary_inner`). An empty
+                        // URL never sets the parser's `npm_url_needs_integrity`,
+                        // so that round-trips for any reader. A URL under a
+                        // configured-but-not-default scope is written verbatim,
+                        // and the parser's integrity check is evaluated against
+                        // the *reader's* scope config, so it is not
+                        // config-independent: a writer with a private `@scope`
+                        // registry could stamp v2 on a lockfile a teammate
+                        // without that scope then fails to parse. Stay at v1 for
+                        // those so the file keeps loading everywhere.
                         let url = res.npm().url.slice(buf);
                         if !url_is_under_registry(url, Npm::Registry::DEFAULT_URL.as_bytes()) {
                             return Version::V1;

--- a/test/cli/install/lockfile-version-2.test.ts
+++ b/test/cli/install/lockfile-version-2.test.ts
@@ -268,3 +268,85 @@ it("re-saving a v1 off-registry lockfile keeps it at version 1", async () => {
   expect(after).toContain(`"lockfileVersion": 1,`);
   expect(exitCode).toBe(0);
 });
+
+// The version stamp must not depend on the writer's registry config. A lockfile
+// is committed and shared, so whether the *reader* accepts it cannot hinge on
+// the *writer*'s `~/.npmrc` / scoped registries. A v1 lockfile with a tarball
+// under a writer-only scoped registry (and no integrity hash) used to be stamped
+// v2 — matching the writer's own scope — which then failed to parse for a
+// teammate or CI that lacks that scope. It must round-trip as v1 so it keeps
+// loading regardless of the reader's config.
+it("re-saving keeps v1 for a tarball under a writer-only scoped registry", async () => {
+  // A scoped registry the writer knows about but a reader won't. `--lockfile-only`
+  // never fetches the tarball, so the host need not be reachable.
+  await using scopedRegistry = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch() {
+      return new Response("not found", { status: 404 });
+    },
+  });
+  const scopedRegistryUrl = `http://127.0.0.1:${scopedRegistry.port}/`;
+  const scopedTarball = `${scopedRegistryUrl}@myorg/foo/-/foo-1.0.0.tgz`;
+
+  const v1Lockfile = JSON.stringify({
+    lockfileVersion: 1,
+    configVersion: 1,
+    workspaces: { "": { name: "root", dependencies: { "@myorg/foo": "1.0.0" } } },
+    packages: {
+      // Off-registry tarball (under the scoped registry, not the default) with
+      // an empty integrity hash.
+      "@myorg/foo": ["@myorg/foo@1.0.0", scopedTarball, {}, ""],
+    },
+  });
+
+  // Writer: has the `@myorg` scope configured, so `scope_for_package_name`
+  // resolves the tarball URL to its registry. This is the config that used to
+  // make the writer consider the entry "v2-clean" and stamp v2.
+  using writerDir = tempDir("lockfile-scoped-writer", {
+    "package.json": JSON.stringify({ name: "root", dependencies: { "@myorg/foo": "1.0.0" } }),
+    "bunfig.toml": `[install.scopes]\nmyorg = { url = "${scopedRegistryUrl}" }\n`,
+    "bun.lock": v1Lockfile,
+  });
+
+  await using writerProc = spawn({
+    cmd: [bunExe(), "install", "--lockfile-only"],
+    cwd: String(writerDir),
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, writerErr, writerExit] = await Promise.all([
+    writerProc.stdout.text(),
+    writerProc.stderr.text(),
+    writerProc.exited,
+  ]);
+
+  const rewritten = await file(join(String(writerDir), "bun.lock")).text();
+  expect(writerErr).toContain("Saved lockfile");
+  // Must stay v1: the tarball is not under the *default* registry, which is the
+  // only normalization the writer applies, so v2 can't be guaranteed to parse
+  // for a reader without the `@myorg` scope.
+  expect(rewritten).toContain(`"lockfileVersion": 1,`);
+  expect(writerExit).toBe(0);
+
+  // Reader: no `@myorg` scope. The re-saved lockfile must still load — if the
+  // writer had stamped v2, this would fail with the integrity error.
+  using readerDir = tempDir("lockfile-scoped-reader", {
+    "package.json": JSON.stringify({ name: "root", dependencies: { "@myorg/foo": "1.0.0" } }),
+    "bun.lock": rewritten,
+  });
+
+  await using readerProc = spawn({
+    cmd: [bunExe(), "install", "--frozen-lockfile", "--lockfile-only"],
+    cwd: String(readerDir),
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, readerErr] = await Promise.all([readerProc.stdout.text(), readerProc.stderr.text(), readerProc.exited]);
+
+  expect(readerErr).not.toContain(
+    "Missing integrity hash for npm package resolved to a tarball URL outside the configured registry",
+  );
+});

--- a/test/cli/install/lockfile-version-2.test.ts
+++ b/test/cli/install/lockfile-version-2.test.ts
@@ -167,15 +167,18 @@ it("unsafe git .bun-tag is rejected only at version 2", async () => {
     expect(exitCode).not.toBe(0);
   }
 
-  // version 1 predates the check, so parsing no longer rejects it (the install
-  // then fails cloning the unreachable repo, but not with the parse-time error).
+  // version 1 predates the check, so parsing no longer rejects it. Use
+  // `--lockfile-only`: the lockfile is still parsed (so the v1 git-tag check is
+  // exercised and correctly does not fire), but the command returns before the
+  // install phase, so it never reaches the `git clone` of the unreachable repo
+  // — which can hang instead of failing fast (notably on macOS).
   {
     using dir = tempDir("lockfile-v1-gittag", {
       "package.json": JSON.stringify({ name: "root", dependencies: { dep: gitUrl } }),
       "bun.lock": lockfile(1),
     });
     await using proc = spawn({
-      cmd: [bunExe(), "install", "--frozen-lockfile"],
+      cmd: [bunExe(), "install", "--frozen-lockfile", "--lockfile-only"],
       cwd: String(dir),
       env,
       stdout: "pipe",

--- a/test/cli/install/lockfile-version-2.test.ts
+++ b/test/cli/install/lockfile-version-2.test.ts
@@ -344,9 +344,15 @@ it("re-saving keeps v1 for a tarball under a writer-only scoped registry", async
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [, readerErr] = await Promise.all([readerProc.stdout.text(), readerProc.stderr.text(), readerProc.exited]);
+  const [, readerErr, readerExit] = await Promise.all([
+    readerProc.stdout.text(),
+    readerProc.stderr.text(),
+    readerProc.exited,
+  ]);
 
   expect(readerErr).not.toContain(
     "Missing integrity hash for npm package resolved to a tarball URL outside the configured registry",
   );
+  // v1 round-trips with no fetch, so the reader exits cleanly.
+  expect(readerExit).toBe(0);
 });

--- a/test/cli/install/lockfile-version-2.test.ts
+++ b/test/cli/install/lockfile-version-2.test.ts
@@ -132,9 +132,10 @@ it("off-registry npm tarball integrity is enforced only at version 2", async () 
 // lockfile carrying an unsafe git tag still never executes anything unsafe.
 // (The `github` tarball path has no such re-validation — see the next test.)
 it("unsafe git .bun-tag is rejected only at version 2", async () => {
-  // Point at an unreachable local endpoint (port 1) so that when v1 parsing
-  // succeeds and install proceeds to `git clone`, the clone fails fast instead
-  // of reaching out to a real host — keeping this test offline.
+  // Point at an unreachable local endpoint (port 1) so the URL never reaches a
+  // real host — keeping this test offline. Neither block actually clones it: v2
+  // fails at parse time, and the v1 block uses `--lockfile-only` to return before
+  // the install phase (the clone can hang on macOS rather than fail fast).
   const gitUrl = "git+ssh://git@127.0.0.1:1/example/repo.git#main";
   const lockfile = (lockfileVersion: number) =>
     JSON.stringify({

--- a/test/cli/install/lockfile-version-2.test.ts
+++ b/test/cli/install/lockfile-version-2.test.ts
@@ -186,6 +186,8 @@ it("unsafe git .bun-tag is rejected only at version 2", async () => {
     });
     const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(err).not.toContain("Invalid git dependency tag");
+    // v1 parses cleanly and `--lockfile-only` skips the install, so it exits 0.
+    expect(exitCode).toBe(0);
   }
 });
 

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -1,6 +1,11 @@
 import type { Server } from "bun";
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+
+// These tests drive real `bun install` runs against a mock registry, which is
+// slow under the debug/ASAN build — give them the same generous timeout the
+// other install test files use so they don't flake on the 5s default.
+setDefaultTimeout(1000 * 60 * 5);
 
 /**
  * Comprehensive test suite for the minimum-release-age security feature.

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -1978,7 +1978,7 @@ linker = "${linker}"
       const normalizedLockfile = lockfile.replace(/http:\/\/localhost:\d+/g, "http://localhost:<port>");
       expect(normalizeBunSnapshot(normalizedLockfile, dir)).toMatchInlineSnapshot(`
           "{
-            "lockfileVersion": 2,
+            "lockfileVersion": 1,
             "configVersion": 1,
             "workspaces": {
               "": {


### PR DESCRIPTION
Follow-up to #31539 (review [thread](https://github.com/oven-sh/bun/pull/31539#discussion_r2213321779)). Jarred asked for this as a separate PR.

## What

`version_to_write` picks whether a re-saved text lockfile can be stamped `lockfileVersion: 2`. For an npm package without a supported integrity hash, it treated the entry as "v2-clean" if the tarball URL was under **either** the writer's scope-configured registry (`scope_for_package_name(...)`) **or** the default registry. The `scope_for_package_name` half is config-dependent and undermines the cross-machine round-trip guarantee the function exists for. This PR drops it, keeping only the config-independent default-registry check.

## The problem

A lockfile is committed and shared, so whether the **reader** accepts it must not depend on the **writer's** registry config. But:

1. A dev has `@myorg → http://internal.example.com` configured locally (`~/.npmrc` / `bunfig.toml`, not committed).
2. The repo has a v1 `bun.lock` with `"@myorg/foo": ["@myorg/foo@1.0.0", "http://internal.example.com/@myorg/foo/-/foo-1.0.0.tgz", {}, ""]` — off-default-registry, empty integrity (e.g. from a migration or older Bun).
3. The dev re-saves (`bun add …`, `--lockfile-only`, …). `version_to_write` sees the entry: integrity unsupported, but the URL **is** under `scope_for_package_name("@myorg/foo")` (their `@myorg` scope) → treated as v2-clean → whole file stamped **v2**.
4. The writer only blanks a URL to `""` when it's under the **default** registry, so this URL is written verbatim and integrity stays `""`.
5. A teammate / CI with **no** `@myorg` scope runs `bun install`. The parser's `npm_url_needs_integrity` is evaluated against the *reader's* config → the URL is under neither the reader's scope nor the default → at v2, parse **fails** with *"Missing integrity hash for npm package resolved to a tarball URL outside the configured registry"*.

So a v1 lockfile that (post-#31539) loads fine becomes unloadable for a teammate after the first dev re-saves it — the exact load→save→load failure `version_to_write` was added to prevent, just split across two machines' configs.

## The fix

In `version_to_write`'s `Npm` arm, drop the `scope_for_package_name` check and only treat an integrity-less entry as v2-clean when the URL is under `Npm::Registry::DEFAULT_URL`:

```rust
let url = res.npm().url.slice(buf);
if !url_is_under_registry(url, Npm::Registry::DEFAULT_URL.as_bytes()) {
    return Version::V1;
}
```

The default-registry case is the only normalization the writer actually performs (it blanks those URLs to `""`, and an empty URL never sets `npm_url_needs_integrity`), so it round-trips for any reader regardless of config. Packages freshly resolved from a configured registry carry integrity and pass the `is_supported()` early-continue before this branch, so the only cost is keeping legacy private-registry-without-integrity lockfiles at v1 a little longer for single-config teams. `options` is no longer needed, so it's dropped from the signature.

## Verification

New test in `test/cli/install/lockfile-version-2.test.ts` — *"re-saving keeps v1 for a tarball under a writer-only scoped registry"* — runs fully offline:

- **Writer** has `@myorg` scoped to a loopback registry and re-saves (`--lockfile-only`) a v1 lockfile with an `@myorg/foo` tarball under that registry and empty integrity. The re-saved lockfile must stay `"lockfileVersion": 1`.
- **Reader** (fresh dir, no `@myorg` scope) loads the re-saved lockfile and must **not** hit the integrity error — proving the round-trip holds across config boundaries.

Fail-before/pass-after confirmed by building with the `src/` change stashed: the writer stamps `"lockfileVersion": 2` and the assertion fails; with the change applied it stays v1 and the reader loads it.
