### PR TITLE
standalone_graph: zero-copy source string for compiled JS modules when contents are ASCII

### DIFF
--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -928,8 +928,17 @@ pub(crate) fn to_bytes(
             )),
             loader: output_file.loader,
             contents: string_builder.append_count_z(buf_bytes),
+            // Latin1 lets the runtime wrap the mmapped section bytes in a
+            // zero-copy ExternalStringImpl. The printer escapes non-ASCII for
+            // server-side JS, but `--banner`/`--footer`/hashbang and
+            // client-side (target=browser) chunks are concatenated verbatim
+            // as UTF-8, so verify the final bytes before committing to Latin1.
             encoding: match output_file.loader {
-                Loader::Js | Loader::Jsx | Loader::Ts | Loader::Tsx => Encoding::Latin1,
+                Loader::Js | Loader::Jsx | Loader::Ts | Loader::Tsx
+                    if strings::first_non_ascii(buf_bytes).is_none() =>
+                {
+                    Encoding::Latin1
+                }
                 _ => Encoding::Binary,
             },
             module_format: if output_file.loader.is_javascript_like() {

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -639,7 +639,7 @@ impl StandaloneModuleGraph {
                     module_format: module.module_format,
                     side: module.side,
                     cached_blob: None,
-                    encoding: Encoding::Binary,
+                    encoding: module.encoding,
                     wtf_string: BunString::empty(),
                 },
             );

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -26,7 +26,10 @@ describe("bundler", () => {
   // standalone module graph treating those bytes as Latin-1, which would
   // print "rÃ©sumÃ©" / "ã\x81\x93ã\x82\x93..." (one Latin-1 char per UTF-8
   // byte) instead of the original codepoints.
-  for (const [where, flag] of [["Footer", "--footer"], ["Banner", "--banner"]] as const) {
+  for (const [where, flag] of [
+    ["Footer", "--footer"],
+    ["Banner", "--banner"],
+  ] as const) {
     test(`compile/${where}NonAsciiUTF8`, async () => {
       using dir = tempDir(`compile-${where.toLowerCase()}-nonascii`, {
         "entry.ts": `export const x = 1;`,
@@ -34,7 +37,16 @@ describe("bundler", () => {
       const outfile = join(String(dir), isWindows ? "out.exe" : "out");
       {
         await using proc = Bun.spawn({
-          cmd: [bunExe(), "build", "--compile", flag, `console.log("résumé", "こんにちは");`, "./entry.ts", "--outfile", outfile],
+          cmd: [
+            bunExe(),
+            "build",
+            "--compile",
+            flag,
+            `console.log("résumé", "こんにちは");`,
+            "./entry.ts",
+            "--outfile",
+            outfile,
+          ],
           env: bunEnv,
           cwd: String(dir),
           stdout: "pipe",

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -22,6 +22,34 @@ describe("bundler", () => {
     },
     run: { stdout: "Hello, world!" },
   });
+  // --footer/--banner are concatenated verbatim (UTF-8). Guard against the
+  // standalone module graph treating those bytes as Latin-1, which would
+  // print "rÃ©sumÃ©" / "ã\x81\x93ã\x82\x93..." (one Latin-1 char per UTF-8
+  // byte) instead of the original codepoints.
+  for (const [where, flag] of [["Footer", "--footer"], ["Banner", "--banner"]] as const) {
+    test(`compile/${where}NonAsciiUTF8`, async () => {
+      using dir = tempDir(`compile-${where.toLowerCase()}-nonascii`, {
+        "entry.ts": `export const x = 1;`,
+      });
+      const outfile = join(String(dir), isWindows ? "out.exe" : "out");
+      {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "build", "--compile", flag, `console.log("résumé", "こんにちは");`, "./entry.ts", "--outfile", outfile],
+          env: bunEnv,
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).not.toContain("error:");
+        expect(exitCode).toBe(0);
+      }
+      await using proc = Bun.spawn({ cmd: [outfile], env: bunEnv, cwd: String(dir), stdout: "pipe", stderr: "pipe" });
+      const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toBe("résumé こんにちは\n");
+      expect(exitCode).toBe(0);
+    });
+  }
   itBundled("compile/HelloWorldWithProcessVersionsBun", {
     compile: true,
     files: {


### PR DESCRIPTION
`from_bytes()` was hardcoding `encoding: Encoding::Binary` for every embedded file instead of reading the per-module value serialized by `to_bytes()`, so `File::to_wtf_string()` always took the `clone_utf8` path — a fresh heap copy of the entire bundled source at module load — instead of the zero-copy `create_static_external` path that wraps the kernel-mmapped `.bun` section directly.

Honoring the serialized encoding alone is unsafe: `to_bytes()` previously tagged JS as `Latin1` purely by loader type, but `--banner` / `--footer` / hashbang and client-side (`target=browser`) chunks are concatenated verbatim as UTF-8 by `postProcessJSChunk`, so non-ASCII bytes there would mojibake under a Latin-1 `ExternalStringImpl` (e.g. `--footer 'console.log("résumé")'` → `rÃ©sumÃ©`). This PR gates the `Latin1` tag in `to_bytes()` on `strings::first_non_ascii(buf_bytes).is_none()` — a build-time SIMD scan — so the runtime only takes the zero-copy path when it's actually safe, and falls back to `clone_utf8` (today's behaviour) otherwise.

The printer escapes non-ASCII for server-side JS by default, so the common case (no banner/footer, no client chunks imported on the server) gets the zero-copy path. On a `bun build --compile --bytecode` binary with a 40 MB bundle, that avoids one 40 MB allocation + walk at startup and 40 MB of pinned heap that should have stayed evictable file-backed pages.

Adds `compile/FooterNonAsciiUTF8` and `compile/BannerNonAsciiUTF8` tests that fail (mojibake) without the ASCII guard.

(Supersedes the `.zig`-only #29319, which targets the no-longer-compiled reference implementation and gates on `side == .server` rather than verifying the bytes — that still mojibakes a non-ASCII `--footer` on a server chunk.)