### PR TITLE
css: fix exponential backtracking in atan2() color parsing

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -3745,6 +3745,20 @@ impl<'a> Parser<'a> {
         parse_nested_block(self, parsefn)
     }
 
+    /// Monotonic count of failed math-function parses. See
+    /// `ParserInput::math_fn_parse_failures`.
+    #[inline]
+    pub fn math_fn_parse_failures(&self) -> u64 {
+        self.input.math_fn_parse_failures
+    }
+
+    /// Record that a math function failed to parse. See
+    /// `ParserInput::math_fn_parse_failures`.
+    #[inline]
+    pub fn note_math_fn_parse_failure(&mut self) {
+        self.input.math_fn_parse_failures += 1;
+    }
+
     pub fn is_exhausted(&mut self) -> bool {
         self.expect_exhausted().is_ok()
     }
@@ -4288,6 +4302,15 @@ pub struct ParserInput<'a> {
     /// instead of re-scanning (and re-recursing through) the truncated
     /// suffix once per backtracking alternative per nesting level.
     unclosed_block_at_eof: Option<UnclosedBlockAtEof>,
+    /// Monotonic count of math functions (`calc()`, `atan2()`, `sin()`, …) that
+    /// failed to parse, bumped at the `parse_value` math-function guard. It
+    /// lets `Calc::parse_atan2` tell *why* parsing an argument failed: comparing
+    /// the count before and after reveals whether a nested math function failed
+    /// (no length/time/percentage re-parse can rescue that) versus a plain
+    /// dimension leaf (which the dimension-typed parses can). Skipping the
+    /// re-parse in the former case keeps nested `atan2()` from being
+    /// re-descended once per candidate type — exponential in the nesting depth.
+    math_fn_parse_failures: u64,
 }
 
 /// See `ParserInput::unclosed_block_at_eof`.
@@ -4315,6 +4338,7 @@ impl<'a> ParserInput<'a> {
             cached_token: None,
             nesting_depth: 0,
             unclosed_block_at_eof: None,
+            math_fn_parse_failures: 0,
         }
     }
 }

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -3745,15 +3745,11 @@ impl<'a> Parser<'a> {
         parse_nested_block(self, parsefn)
     }
 
-    /// Monotonic count of failed math-function parses. See
-    /// `ParserInput::math_fn_parse_failures`.
     #[inline]
     pub fn math_fn_parse_failures(&self) -> u64 {
         self.input.math_fn_parse_failures
     }
 
-    /// Record that a math function failed to parse. See
-    /// `ParserInput::math_fn_parse_failures`.
     #[inline]
     pub fn note_math_fn_parse_failure(&mut self) {
         self.input.math_fn_parse_failures += 1;
@@ -4302,16 +4298,6 @@ pub struct ParserInput<'a> {
     /// instead of re-scanning (and re-recursing through) the truncated
     /// suffix once per backtracking alternative per nesting level.
     unclosed_block_at_eof: Option<UnclosedBlockAtEof>,
-    /// Monotonic count of *type-independently parsed* math functions
-    /// (`atan2()`, the trig functions, `pow()`/`log()`/`sqrt()`/`exp()` — see
-    /// `CalcUnit::arg_parse_is_type_independent`) that failed to parse, bumped at
-    /// the `parse_value` math-function guard. It lets `Calc::parse_atan2` tell
-    /// *why* parsing an argument failed: comparing the count before and after
-    /// reveals whether one of those functions failed (no length/time/percentage
-    /// re-parse can rescue that) versus a plain dimension leaf or a type-passing
-    /// function like `calc()` (which the dimension-typed parses can). Skipping
-    /// the re-parse in the former case keeps nested `atan2()` from being
-    /// re-descended once per candidate type — exponential in the nesting depth.
     math_fn_parse_failures: u64,
 }
 

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -4302,13 +4302,15 @@ pub struct ParserInput<'a> {
     /// instead of re-scanning (and re-recursing through) the truncated
     /// suffix once per backtracking alternative per nesting level.
     unclosed_block_at_eof: Option<UnclosedBlockAtEof>,
-    /// Monotonic count of math functions (`calc()`, `atan2()`, `sin()`, …) that
-    /// failed to parse, bumped at the `parse_value` math-function guard. It
-    /// lets `Calc::parse_atan2` tell *why* parsing an argument failed: comparing
-    /// the count before and after reveals whether a nested math function failed
-    /// (no length/time/percentage re-parse can rescue that) versus a plain
-    /// dimension leaf (which the dimension-typed parses can). Skipping the
-    /// re-parse in the former case keeps nested `atan2()` from being
+    /// Monotonic count of *type-independently parsed* math functions
+    /// (`atan2()`, the trig functions, `pow()`/`log()`/`sqrt()`/`exp()` — see
+    /// `CalcUnit::arg_parse_is_type_independent`) that failed to parse, bumped at
+    /// the `parse_value` math-function guard. It lets `Calc::parse_atan2` tell
+    /// *why* parsing an argument failed: comparing the count before and after
+    /// reveals whether one of those functions failed (no length/time/percentage
+    /// re-parse can rescue that) versus a plain dimension leaf or a type-passing
+    /// function like `calc()` (which the dimension-typed parses can). Skipping
+    /// the re-parse in the former case keeps nested `atan2()` from being
     /// re-descended once per candidate type — exponential in the nesting depth.
     math_fn_parse_failures: u64,
 }

--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -7,8 +7,7 @@ use crate::values::percentage::{DimensionPercentage, Percentage};
 use crate::values::protocol;
 use crate::values::time::Time;
 // Bring the numeric-protocol traits into scope so their methods resolve via the
-// `CalcValue` supertrait bounds inside `impl<V: CalcValue> Calc<V>`. `TryOpTo`
-// is also needed for the concrete `Angle` reconciliation in `parse_atan2`.
+// `CalcValue` supertrait bounds inside `impl<V: CalcValue> Calc<V>`.
 use crate::values::protocol::{IsCompatible, ToCss, TryOpTo};
 
 use core::cmp::Ordering;
@@ -73,24 +72,6 @@ impl CalcUnit {
         }
     }
 
-    /// Whether a failure to parse this function under an `<angle>`/`<number>`
-    /// type can never be rescued by re-parsing under a length/time/percentage
-    /// type — i.e. the function parses its arguments *independently of the
-    /// surrounding value type `V`*, so the failure is the same under every type.
-    ///
-    /// The trigonometric functions parse their argument as an `<angle>`
-    /// (`parse_trig`), and `pow()`/`log()`/`sqrt()`/`exp()` parse theirs as a
-    /// `<number>` (`parse_numeric`); `atan2()` probes fixed concrete types. None
-    /// of these depend on `V`, so a failure is terminal. The remaining functions
-    /// — `calc()`/`min()`/`max()`/`clamp()`/`round()`/`mod()`/`rem()`/`hypot()`
-    /// and, notably, `abs()`/`sign()` — parse their argument via `parse_sum`,
-    /// which *is* `V`-dependent (e.g. `sign(1px)` fails under `Calc<Angle>` but
-    /// succeeds under `Calc<Length>`), so they are excluded.
-    ///
-    /// Used by the `parse_value` math-function guard: recording a failure of one
-    /// of these functions is what lets `parse_atan2` skip the dimension parses
-    /// (and thereby the otherwise-exponential re-descent of nested `atan2()`)
-    /// without wrongly rejecting a dimension argument.
     pub fn arg_parse_is_type_independent(self) -> bool {
         matches!(
             self,
@@ -722,14 +703,6 @@ impl<V: CalcValue> Calc<V> {
                 };
                 input.reset(&start);
                 if let Some(unit) = failed_unit {
-                    // A function that parses its argument independently of the
-                    // value type (trig, `atan2()`, `pow()`, …) failed here, so no
-                    // length/time/percentage re-parse can succeed either: record
-                    // the failure so `parse_atan2` can skip re-descending such an
-                    // argument (nested `atan2()` is otherwise exponential).
-                    // Functions whose argument parse is type-dependent — `calc()`,
-                    // `abs()`, `sign()`, … — are not recorded, because the
-                    // dimension parses can still succeed on them.
                     if unit.arg_parse_is_type_independent() {
                         input.note_math_fn_parse_failure();
                     }
@@ -838,28 +811,6 @@ impl<V: CalcValue> Calc<V> {
         ctx: C,
         parse_ident: impl Fn(C, &[u8]) -> Option<Self> + Copy,
     ) -> CssResult<Angle> {
-        // atan2 supports arguments of any <number>, <dimension>, or
-        // <percentage>, even ones that wouldn't normally be supported by V. The
-        // only requirement is that the arguments be of the same type.
-        //
-        // The arguments — and any math functions nested in them — are parsed
-        // exactly once. The naive approach of re-parsing the whole argument
-        // subtree once per candidate value type is exponential as soon as
-        // `atan2()` nests inside its own arguments, because every ancestor
-        // re-parses each descendant once per type it probes.
-        //
-        // A math function always resolves to an <angle> or a <number>, never to
-        // a length/time/percentage. So parse the first argument as an <angle>/
-        // <number> expression first:
-        //
-        //   * On success it contains no length/time/percentage leaf, so parse
-        //     the second argument the same way and reconcile. A type mismatch is
-        //     a genuine error; the dimension parses below cannot rescue it.
-        //   * On failure, fall back to the dimension-typed parses only if the
-        //     failure was at a real dimension leaf. If instead a *nested math
-        //     function* failed (tracked by `math_fn_parse_failures`), no
-        //     dimension type can parse it either, so re-descending it — which is
-        //     what makes nested `atan2()` exponential — is skipped.
         let angle_ident = move |c: C, ident: &[u8]| -> Option<Calc<Angle>> {
             match parse_ident(c, ident)? {
                 Calc::Number(n) => Some(Calc::Number(n)),
@@ -869,10 +820,6 @@ impl<V: CalcValue> Calc<V> {
 
         let before_args = input.state();
         let failures_before = input.math_fn_parse_failures();
-        // Returns true when a failed <angle>/<number> parse is unrecoverable —
-        // a nested type-independent function failed (no dimension re-parse can
-        // help) — versus failing at a plain dimension leaf (which the dimension
-        // parses below can handle). Compared against the count captured above.
         let hit_unrecoverable =
             |input: &css::Parser| input.math_fn_parse_failures() != failures_before;
 
@@ -890,24 +837,15 @@ impl<V: CalcValue> Calc<V> {
 
         match Calc::<Angle>::parse_sum(input, ctx, angle_ident) {
             Ok(a) => {
-                // A missing comma is a structural error the dimension parses
-                // cannot fix, so it stays terminal.
                 input.expect_comma()?;
                 match Calc::<Angle>::parse_sum(input, ctx, angle_ident) {
                     Ok(b) => {
                         if let Ok(v) = reconcile(input, &a, &b) {
                             return Ok(v);
                         }
-                        // Both arguments parsed as <angle>/<number> but are of
-                        // incompatible kinds — re-parsing under a dimension type
-                        // cannot help (neither has a dimension leaf).
                         return Err(input.new_custom_error(css::ParserError::invalid_value));
                     }
                     Err(e) => {
-                        // The second argument failed. If it failed on a nested
-                        // type-independent function, the dimension parses can't
-                        // help either; otherwise it has a dimension leaf (e.g.
-                        // `sign(1px)`), so fall through to them.
                         if hit_unrecoverable(input) {
                             return Err(e);
                         }
@@ -917,9 +855,6 @@ impl<V: CalcValue> Calc<V> {
             }
             Err(e) => {
                 if hit_unrecoverable(input) {
-                    // The first argument failed on a nested type-independent
-                    // function, so the dimension parses below cannot succeed
-                    // either. Don't re-descend it.
                     return Err(e);
                 }
                 input.reset(&before_args);

--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -873,18 +873,20 @@ impl<V: CalcValue> Calc<V> {
         // a nested type-independent function failed (no dimension re-parse can
         // help) — versus failing at a plain dimension leaf (which the dimension
         // parses below can handle). Compared against the count captured above.
-        let hit_unrecoverable = |input: &css::Parser| input.math_fn_parse_failures() != failures_before;
+        let hit_unrecoverable =
+            |input: &css::Parser| input.math_fn_parse_failures() != failures_before;
 
-        let reconcile = |input: &mut css::Parser, a: &Calc<Angle>, b: &Calc<Angle>| -> CssResult<Angle> {
-            if let (Calc::Value(av), Calc::Value(bv)) = (a, b) {
-                if let Some(v) = av.try_op_to(&**bv, (), |_, x, y| Angle::Rad(x.atan2(y))) {
-                    return Ok(v);
+        let reconcile =
+            |input: &mut css::Parser, a: &Calc<Angle>, b: &Calc<Angle>| -> CssResult<Angle> {
+                if let (Calc::Value(av), Calc::Value(bv)) = (a, b) {
+                    if let Some(v) = av.try_op_to(&**bv, (), |_, x, y| Angle::Rad(x.atan2(y))) {
+                        return Ok(v);
+                    }
+                } else if let (Calc::Number(an), Calc::Number(bn)) = (a, b) {
+                    return Ok(Angle::Rad(an.atan2(*bn)));
                 }
-            } else if let (Calc::Number(an), Calc::Number(bn)) = (a, b) {
-                return Ok(Angle::Rad(an.atan2(*bn)));
-            }
-            Err(input.new_custom_error(css::ParserError::invalid_value))
-        };
+                Err(input.new_custom_error(css::ParserError::invalid_value))
+            };
 
         match Calc::<Angle>::parse_sum(input, ctx, angle_ident) {
             Ok(a) => {

--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -7,8 +7,9 @@ use crate::values::percentage::{DimensionPercentage, Percentage};
 use crate::values::protocol;
 use crate::values::time::Time;
 // Bring the numeric-protocol traits into scope so their methods resolve via the
-// `CalcValue` supertrait bounds inside `impl<V: CalcValue> Calc<V>`.
-use crate::values::protocol::{IsCompatible, ToCss};
+// `CalcValue` supertrait bounds inside `impl<V: CalcValue> Calc<V>`. `TryOpTo`
+// is also needed for the concrete `Angle` reconciliation in `parse_atan2`.
+use crate::values::protocol::{IsCompatible, ToCss, TryOpTo};
 
 use core::cmp::Ordering;
 
@@ -70,6 +71,41 @@ impl CalcUnit {
             b"tan" => Some(Self::Tan),
             _ => None,
         }
+    }
+
+    /// Whether a failure to parse this function under an `<angle>`/`<number>`
+    /// type can never be rescued by re-parsing under a length/time/percentage
+    /// type — i.e. the function parses its arguments *independently of the
+    /// surrounding value type `V`*, so the failure is the same under every type.
+    ///
+    /// The trigonometric functions parse their argument as an `<angle>`
+    /// (`parse_trig`), and `pow()`/`log()`/`sqrt()`/`exp()` parse theirs as a
+    /// `<number>` (`parse_numeric`); `atan2()` probes fixed concrete types. None
+    /// of these depend on `V`, so a failure is terminal. The remaining functions
+    /// — `calc()`/`min()`/`max()`/`clamp()`/`round()`/`mod()`/`rem()`/`hypot()`
+    /// and, notably, `abs()`/`sign()` — parse their argument via `parse_sum`,
+    /// which *is* `V`-dependent (e.g. `sign(1px)` fails under `Calc<Angle>` but
+    /// succeeds under `Calc<Length>`), so they are excluded.
+    ///
+    /// Used by the `parse_value` math-function guard: recording a failure of one
+    /// of these functions is what lets `parse_atan2` skip the dimension parses
+    /// (and thereby the otherwise-exponential re-descent of nested `atan2()`)
+    /// without wrongly rejecting a dimension argument.
+    pub fn arg_parse_is_type_independent(self) -> bool {
+        matches!(
+            self,
+            Self::Sin
+                | Self::Cos
+                | Self::Tan
+                | Self::Asin
+                | Self::Acos
+                | Self::Atan
+                | Self::Atan2
+                | Self::Pow
+                | Self::Log
+                | Self::Sqrt
+                | Self::Exp
+        )
     }
 }
 
@@ -680,12 +716,23 @@ impl<V: CalcValue> Calc<V> {
                 // `Calc::parse` again, which makes deeply nested invalid
                 // arguments exponentially slow to reject.
                 let start = input.state();
-                let is_math_function = matches!(
-                    input.next(),
-                    Ok(css::Token::Function(name)) if CalcUnit::get_any_case(name).is_some()
-                );
+                let failed_unit = match input.next() {
+                    Ok(css::Token::Function(name)) => CalcUnit::get_any_case(name),
+                    _ => None,
+                };
                 input.reset(&start);
-                if is_math_function {
+                if let Some(unit) = failed_unit {
+                    // A function that parses its argument independently of the
+                    // value type (trig, `atan2()`, `pow()`, …) failed here, so no
+                    // length/time/percentage re-parse can succeed either: record
+                    // the failure so `parse_atan2` can skip re-descending such an
+                    // argument (nested `atan2()` is otherwise exponential).
+                    // Functions whose argument parse is type-dependent — `calc()`,
+                    // `abs()`, `sign()`, … — are not recorded, because the
+                    // dimension parses can still succeed on them.
+                    if unit.arg_parse_is_type_independent() {
+                        input.note_math_fn_parse_failure();
+                    }
                     return Err(e);
                 }
             }
@@ -791,10 +838,92 @@ impl<V: CalcValue> Calc<V> {
         ctx: C,
         parse_ident: impl Fn(C, &[u8]) -> Option<Self> + Copy,
     ) -> CssResult<Angle> {
-        // atan2 supports arguments of any <number>, <dimension>, or <percentage>, even ones that wouldn't
-        // normally be supported by V. The only requirement is that the arguments be of the same type.
-        // Try parsing with each type, and return the first one that parses successfully.
+        // atan2 supports arguments of any <number>, <dimension>, or
+        // <percentage>, even ones that wouldn't normally be supported by V. The
+        // only requirement is that the arguments be of the same type.
         //
+        // The arguments — and any math functions nested in them — are parsed
+        // exactly once. The naive approach of re-parsing the whole argument
+        // subtree once per candidate value type is exponential as soon as
+        // `atan2()` nests inside its own arguments, because every ancestor
+        // re-parses each descendant once per type it probes.
+        //
+        // A math function always resolves to an <angle> or a <number>, never to
+        // a length/time/percentage. So parse the first argument as an <angle>/
+        // <number> expression first:
+        //
+        //   * On success it contains no length/time/percentage leaf, so parse
+        //     the second argument the same way and reconcile. A type mismatch is
+        //     a genuine error; the dimension parses below cannot rescue it.
+        //   * On failure, fall back to the dimension-typed parses only if the
+        //     failure was at a real dimension leaf. If instead a *nested math
+        //     function* failed (tracked by `math_fn_parse_failures`), no
+        //     dimension type can parse it either, so re-descending it — which is
+        //     what makes nested `atan2()` exponential — is skipped.
+        let angle_ident = move |c: C, ident: &[u8]| -> Option<Calc<Angle>> {
+            match parse_ident(c, ident)? {
+                Calc::Number(n) => Some(Calc::Number(n)),
+                _ => None,
+            }
+        };
+
+        let before_args = input.state();
+        let failures_before = input.math_fn_parse_failures();
+        // Returns true when a failed <angle>/<number> parse is unrecoverable —
+        // a nested type-independent function failed (no dimension re-parse can
+        // help) — versus failing at a plain dimension leaf (which the dimension
+        // parses below can handle). Compared against the count captured above.
+        let hit_unrecoverable = |input: &css::Parser| input.math_fn_parse_failures() != failures_before;
+
+        let reconcile = |input: &mut css::Parser, a: &Calc<Angle>, b: &Calc<Angle>| -> CssResult<Angle> {
+            if let (Calc::Value(av), Calc::Value(bv)) = (a, b) {
+                if let Some(v) = av.try_op_to(&**bv, (), |_, x, y| Angle::Rad(x.atan2(y))) {
+                    return Ok(v);
+                }
+            } else if let (Calc::Number(an), Calc::Number(bn)) = (a, b) {
+                return Ok(Angle::Rad(an.atan2(*bn)));
+            }
+            Err(input.new_custom_error(css::ParserError::invalid_value))
+        };
+
+        match Calc::<Angle>::parse_sum(input, ctx, angle_ident) {
+            Ok(a) => {
+                // A missing comma is a structural error the dimension parses
+                // cannot fix, so it stays terminal.
+                input.expect_comma()?;
+                match Calc::<Angle>::parse_sum(input, ctx, angle_ident) {
+                    Ok(b) => {
+                        if let Ok(v) = reconcile(input, &a, &b) {
+                            return Ok(v);
+                        }
+                        // Both arguments parsed as <angle>/<number> but are of
+                        // incompatible kinds — re-parsing under a dimension type
+                        // cannot help (neither has a dimension leaf).
+                        return Err(input.new_custom_error(css::ParserError::invalid_value));
+                    }
+                    Err(e) => {
+                        // The second argument failed. If it failed on a nested
+                        // type-independent function, the dimension parses can't
+                        // help either; otherwise it has a dimension leaf (e.g.
+                        // `sign(1px)`), so fall through to them.
+                        if hit_unrecoverable(input) {
+                            return Err(e);
+                        }
+                        input.reset(&before_args);
+                    }
+                }
+            }
+            Err(e) => {
+                if hit_unrecoverable(input) {
+                    // The first argument failed on a nested type-independent
+                    // function, so the dimension parses below cannot succeed
+                    // either. Don't re-descend it.
+                    return Err(e);
+                }
+                input.reset(&before_args);
+            }
+        }
+
         // blocked_on: values/length.rs un-gate — until Length is real,
         // `atan2(10px, 5px)` (and any other length-dimension pair) falls
         // through to the CSSNumber path below and errors with `invalid_value`,
@@ -805,9 +934,6 @@ impl<V: CalcValue> Calc<V> {
             return Ok(v);
         }
         if let Ok(v) = try_parse_atan2_args::<C, Percentage>(input, ctx) {
-            return Ok(v);
-        }
-        if let Ok(v) = try_parse_atan2_args::<C, Angle>(input, ctx) {
             return Ok(v);
         }
         if let Ok(v) = try_parse_atan2_args::<C, Time>(input, ctx) {

--- a/test/js/bun/css/atan2-backtracking-hang.test.ts
+++ b/test/js/bun/css/atan2-backtracking-hang.test.ts
@@ -28,7 +28,7 @@ function nestedAtan2Chain(depth: number): string {
   let body = "";
   for (let i = 0; i < depth; i++) body += "-(atan2(9\n";
   body += "-(atan2(";
-  return `hsl(sin(2\n${body}` + ")".repeat(depth + 3);
+  return `hsl(sin(2\n${body}` + Buffer.alloc(depth + 3, ")").toString();
 }
 
 // [input, expected Bun.color(input, "css") result].
@@ -41,7 +41,7 @@ const cases: [css: string, expected: string | null][] = [
   [nestedAtan2Chain(64), null],
   // Deeply nested `atan2()` in the hue position — both the valid (each level
   // resolves to an angle) and invalid (type mismatch) shapes were exponential.
-  ["hsl(" + "atan2(".repeat(64) + "9, 1" + ")".repeat(64) + " 50% 50%)", null],
+  ["hsl(" + Buffer.alloc(6 * 64, "atan2(").toString() + "9, 1" + Buffer.alloc(64, ")").toString() + " 50% 50%)", null],
   // Behavior preservation: valid `atan2()` with each supported argument type.
   ["hsl(atan2(9, 1) 50% 50%)", "#8dbf40"],
   ["hsl(atan2(atan2(9,1), atan2(2,3)) 50% 50%)", "#aebf40"],
@@ -91,4 +91,7 @@ test("deeply nested atan2() color values parse in linear time instead of hanging
   expect(stderr).toBe("");
   expect(JSON.parse(stdout)).toEqual(cases.map(([, expected]) => expected));
   expect(exitCode).toBe(0);
-});
+  // Outer timeout larger than the subprocess kill switch above, so a regression
+  // trips the kill switch (and the assertions) rather than the test runner's
+  // default timeout firing first.
+}, 30_000);

--- a/test/js/bun/css/atan2-backtracking-hang.test.ts
+++ b/test/js/bun/css/atan2-backtracking-hang.test.ts
@@ -1,29 +1,6 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-// Regression test for exponential backtracking in the CSS calc parser's
-// `atan2()` math function, found by fuzzing `Bun.color()`.
-//
-// `Calc::parse_atan2` probes its arguments under several value types
-// (length/percentage/angle/time/number), each re-descending the same argument
-// subtree via `try_parse`. Because `atan2()` calls can nest inside one
-// another's arguments, a nested `atan2()` was re-parsed once per ancestor
-// type-probe, making parse time grow ~5x per nesting level: a 110-byte color
-// value was already multiple seconds, and the 4 KB fuzzer input hung.
-//
-// A math function always resolves to an <angle> or a <number>, never to a
-// length/time/percentage, so `parse_atan2` now parses each argument once as an
-// <angle>/<number> expression and only re-parses it under a dimension type when
-// the failure was a real dimension leaf (not a failed nested math function).
-// That makes parsing linear in the nesting depth.
-//
-// The child process is given a kill switch so a regression fails the
-// assertions below instead of hanging the test runner forever.
-
-// A chain of `-(atan2(9 -(atan2(9 -(...` nested via subtraction. Each inner
-// `atan2()` is missing its comma and fails to parse, so before the fix every
-// ancestor type-probe re-descended the whole chain. This is a reduced form of
-// the original fuzzer input.
 function nestedAtan2Chain(depth: number): string {
   let body = "";
   for (let i = 0; i < depth; i++) body += "-(atan2(9\n";
@@ -31,42 +8,25 @@ function nestedAtan2Chain(depth: number): string {
   return `hsl(sin(2\n${body}` + Buffer.alloc(depth + 3, ")").toString();
 }
 
-// [input, expected Bun.color(input, "css") result].
-// The hang inputs are invalid color values, so they resolve to `null`. The
-// remaining cases pin down that valid `atan2()` usage is unchanged by the fix.
 const cases: [css: string, expected: string | null][] = [
-  // Reduced fuzzer repros: nested `atan2()` deep enough that the pre-fix
-  // exponential blows up well past the kill switch.
   [nestedAtan2Chain(40), null],
   [nestedAtan2Chain(64), null],
-  // Deeply nested `atan2()` in the hue position — both the valid (each level
-  // resolves to an angle) and invalid (type mismatch) shapes were exponential.
   ["hsl(" + Buffer.alloc(6 * 64, "atan2(").toString() + "9, 1" + Buffer.alloc(64, ")").toString() + " 50% 50%)", null],
-  // Behavior preservation: valid `atan2()` with each supported argument type.
   ["hsl(atan2(9, 1) 50% 50%)", "#8dbf40"],
   ["hsl(atan2(atan2(9,1), atan2(2,3)) 50% 50%)", "#aebf40"],
   ["hsl(atan2(1deg, 2deg) 50% 50%)", "#bf7840"],
   ["hsl(atan2(1px, 2px) 50% 50%)", "#bf7840"],
   ["hsl(atan2(1s, 2s) 50% 50%)", "#bf7840"],
   ["hsl(atan2(50%, 25%) 50% 50%)", "#b8bf40"],
-  // Type-passing functions parse their argument via the value type, so a
-  // dimension inside them must still reach the dimension parse (they are not
-  // <angle>/<number>-only functions). `calc()` holding a dimension, and the
-  // type-passing `abs()`/`sign()` over a dimension, must all keep working — and
-  // a (valid) `atan2()` nested inside `calc()` must still resolve to an angle.
   ["hsl(atan2(calc(1px + 1px), 2px) 50% 50%)", "#bf9f40"],
   ["hsl(atan2(calc(atan2(1px,2px)), 3deg) 50% 50%)", "#8dbf40"],
   ["hsl(atan2(abs(1px), abs(2px)) 50% 50%)", "#bf7840"],
   ["hsl(atan2(sign(1px), sign(2px)) 50% 50%)", "#bf9f40"],
   ["hsl(atan2(sign(1s), sign(2s)) 50% 50%)", "#bf9f40"],
-  // A type-dependent function in the *second* argument (after the first parses
-  // as a number/angle) must still reach the dimension parse too, not just the
-  // first — the fall-back applies symmetrically to both arguments.
   ["hsl(atan2(1, sign(1px)) 50% 50%)", "#bf9f40"],
   ["hsl(atan2(sin(1), sign(1px)) 50% 50%)", "#bf9540"],
   ["hsl(atan2(1, sign(1s)) 50% 50%)", "#bf9f40"],
   ["hsl(atan2(1, calc(sign(1px))) 50% 50%)", "#bf9f40"],
-  // Mismatched argument types are invalid and must still be rejected.
   ["hsl(atan2(atan2(9,1), 1) 50% 50%)", null],
 ];
 
@@ -81,7 +41,6 @@ test("deeply nested atan2() color values parse in linear time instead of hanging
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
-    // Kill switch: before the fix, the first input spun for many seconds.
     timeout: 20_000,
     killSignal: "SIGKILL",
   });
@@ -91,7 +50,4 @@ test("deeply nested atan2() color values parse in linear time instead of hanging
   expect(stderr).toBe("");
   expect(JSON.parse(stdout)).toEqual(cases.map(([, expected]) => expected));
   expect(exitCode).toBe(0);
-  // Outer timeout larger than the subprocess kill switch above, so a regression
-  // trips the kill switch (and the assertions) rather than the test runner's
-  // default timeout firing first.
 }, 30_000);

--- a/test/js/bun/css/atan2-backtracking-hang.test.ts
+++ b/test/js/bun/css/atan2-backtracking-hang.test.ts
@@ -1,0 +1,94 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test for exponential backtracking in the CSS calc parser's
+// `atan2()` math function, found by fuzzing `Bun.color()`.
+//
+// `Calc::parse_atan2` probes its arguments under several value types
+// (length/percentage/angle/time/number), each re-descending the same argument
+// subtree via `try_parse`. Because `atan2()` calls can nest inside one
+// another's arguments, a nested `atan2()` was re-parsed once per ancestor
+// type-probe, making parse time grow ~5x per nesting level: a 110-byte color
+// value was already multiple seconds, and the 4 KB fuzzer input hung.
+//
+// A math function always resolves to an <angle> or a <number>, never to a
+// length/time/percentage, so `parse_atan2` now parses each argument once as an
+// <angle>/<number> expression and only re-parses it under a dimension type when
+// the failure was a real dimension leaf (not a failed nested math function).
+// That makes parsing linear in the nesting depth.
+//
+// The child process is given a kill switch so a regression fails the
+// assertions below instead of hanging the test runner forever.
+
+// A chain of `-(atan2(9 -(atan2(9 -(...` nested via subtraction. Each inner
+// `atan2()` is missing its comma and fails to parse, so before the fix every
+// ancestor type-probe re-descended the whole chain. This is a reduced form of
+// the original fuzzer input.
+function nestedAtan2Chain(depth: number): string {
+  let body = "";
+  for (let i = 0; i < depth; i++) body += "-(atan2(9\n";
+  body += "-(atan2(";
+  return `hsl(sin(2\n${body}` + ")".repeat(depth + 3);
+}
+
+// [input, expected Bun.color(input, "css") result].
+// The hang inputs are invalid color values, so they resolve to `null`. The
+// remaining cases pin down that valid `atan2()` usage is unchanged by the fix.
+const cases: [css: string, expected: string | null][] = [
+  // Reduced fuzzer repros: nested `atan2()` deep enough that the pre-fix
+  // exponential blows up well past the kill switch.
+  [nestedAtan2Chain(40), null],
+  [nestedAtan2Chain(64), null],
+  // Deeply nested `atan2()` in the hue position — both the valid (each level
+  // resolves to an angle) and invalid (type mismatch) shapes were exponential.
+  ["hsl(" + "atan2(".repeat(64) + "9, 1" + ")".repeat(64) + " 50% 50%)", null],
+  // Behavior preservation: valid `atan2()` with each supported argument type.
+  ["hsl(atan2(9, 1) 50% 50%)", "#8dbf40"],
+  ["hsl(atan2(atan2(9,1), atan2(2,3)) 50% 50%)", "#aebf40"],
+  ["hsl(atan2(1deg, 2deg) 50% 50%)", "#bf7840"],
+  ["hsl(atan2(1px, 2px) 50% 50%)", "#bf7840"],
+  ["hsl(atan2(1s, 2s) 50% 50%)", "#bf7840"],
+  ["hsl(atan2(50%, 25%) 50% 50%)", "#b8bf40"],
+  // Type-passing functions parse their argument via the value type, so a
+  // dimension inside them must still reach the dimension parse (they are not
+  // <angle>/<number>-only functions). `calc()` holding a dimension, and the
+  // type-passing `abs()`/`sign()` over a dimension, must all keep working — and
+  // a (valid) `atan2()` nested inside `calc()` must still resolve to an angle.
+  ["hsl(atan2(calc(1px + 1px), 2px) 50% 50%)", "#bf9f40"],
+  ["hsl(atan2(calc(atan2(1px,2px)), 3deg) 50% 50%)", "#8dbf40"],
+  ["hsl(atan2(abs(1px), abs(2px)) 50% 50%)", "#bf7840"],
+  ["hsl(atan2(sign(1px), sign(2px)) 50% 50%)", "#bf9f40"],
+  ["hsl(atan2(sign(1s), sign(2s)) 50% 50%)", "#bf9f40"],
+  // A type-dependent function in the *second* argument (after the first parses
+  // as a number/angle) must still reach the dimension parse too, not just the
+  // first — the fall-back applies symmetrically to both arguments.
+  ["hsl(atan2(1, sign(1px)) 50% 50%)", "#bf9f40"],
+  ["hsl(atan2(sin(1), sign(1px)) 50% 50%)", "#bf9540"],
+  ["hsl(atan2(1, sign(1s)) 50% 50%)", "#bf9f40"],
+  ["hsl(atan2(1, calc(sign(1px))) 50% 50%)", "#bf9f40"],
+  // Mismatched argument types are invalid and must still be rejected.
+  ["hsl(atan2(atan2(9,1), 1) 50% 50%)", null],
+];
+
+test("deeply nested atan2() color values parse in linear time instead of hanging", async () => {
+  const script = `
+    const inputs = ${JSON.stringify(cases.map(([css]) => css))};
+    console.log(JSON.stringify(inputs.map(css => Bun.color(css, "css"))));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    // Kill switch: before the fix, the first input spun for many seconds.
+    timeout: 20_000,
+    killSignal: "SIGKILL",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual(cases.map(([, expected]) => expected));
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

Fixes an exponential-time hang in `Bun.color()` (and any CSS `calc()` path) on deeply nested `atan2()` math functions, found by fuzzing.

## Repro

```js
// 4 KB of nested -(atan2(9 -(atan2(...))) inside hsl(); hangs well past 25s
Bun.color(<deeply nested atan2 CSS>, "css");
```

Reduced (via delta-debugging) to 110 bytes, the pathology is a chain of `atan2()` nested through subtraction:

```js
Bun.color("hsl(sin(2\n-(atan2(9\n-(atan2(9\n-(atan2(atan2(9\n...", "css"); // seconds → minutes
```

Parse time grows ~5× per nesting level: depth 10 ≈ 0.6s, depth 11 ≈ 3s, depth 13 ≈ 15s.

## Cause

`Calc::parse_atan2` (`src/css/values/calc.rs`) parses its arguments by trying each supported value type in turn — `Length`, `Percentage`, `Angle`, `Time`, then a `<number>` fallback — via `try_parse`, which re-descends the **entire** argument subtree on each attempt. Because `atan2()` calls can nest inside one another's arguments, a nested `atan2()` is re-parsed once per ancestor type-probe, which is exponential in the nesting depth (≈5^depth).

This is the same class of exponential backtracking fixed for unclosed/invalid nested function values in #31243; that fix's `unclosed_block_at_eof` guard only covers blocks left unclosed at EOF, so it does not catch these balanced-but-nested `atan2()` chains. `atan2()` is the only calc function that re-descends its arguments under multiple value types.

## Fix — parse each argument once

A math function (`atan2()`, `sin()`, `pow()`, …) always resolves to an `<angle>` or a `<number>`, never to a length/time/percentage. So `parse_atan2` now parses each argument **once** as an `<angle>`/`<number>` expression:

- On success, the argument contains no length/time/percentage leaf, so the second argument is parsed the same way and reconciled. A type mismatch is a genuine error that the dimension parses can't rescue.
- On failure, the dimension-typed parses are tried **only** if the failure was at a real dimension leaf (e.g. `1px`). If instead a nested `<angle>`/`<number>`-only function failed, no dimension parse can succeed either, so re-descending it — the exponential step — is skipped.

"A nested `<angle>`/`<number>`-only function failed" is detected with a small monotonic counter bumped at the existing `parse_value` math-function guard, compared before/after the argument parse. It is **not** a per-position failure cache — just an event count. Type-passing functions (`calc()`, `min()`, `abs()`, …) are left to the dimension parses exactly as before, so `atan2(calc(1px + 1px), 2px)` still folds.

## Verification

- New test `test/js/bun/css/atan2-backtracking-hang.test.ts` runs the nested-`atan2()` repros plus behavior-preservation cases (each argument type, `calc()` args, `atan2()` nested in `calc()`, invalid type mismatches) in a subprocess with a 20s kill switch. Passes on this build in well under a second; on an unfixed build the subprocess hangs and the test times out (confirmed by reverting `src/` to `main` and rebuilding).
- The original 4 KB repro: **>12s → ~8ms**. A 300-deep nested chain stays flat (linear).
- Behavior preserved: output is **identical to `main`** across all valid/invalid `atan2()` cases (`atan2(9, 1)`, `atan2(1deg, 2deg)`, `atan2(1px, 2px)`, `atan2(1s, 2s)`, `atan2(50%, 25%)`, `atan2(atan2(…), atan2(…))`, `atan2(calc(1px + 1px), 2px)` → `45deg`, relative-color channel args, and the mismatched-type rejections).
- `test/js/bun/css/color.test.ts` (915), `css.test.ts` (1087), `nested-function-backtracking.test.ts` (5), `angle-serialization-hang.test.ts` + `doesnt_crash.test.ts` (62) pass. The pre-existing `fuzz ansi256` timeout (a 16.7M-iteration integer-path loop unrelated to the CSS parser) and the pre-existing `css-fuzz.test.ts` debug-build timeouts reproduce identically on `main`.