### PR TITLE
Bun.plugin: check for exception when coercing 'target' to a string

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -306,8 +306,11 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
     auto targetValue = obj->getIfPropertyExists(globalObject, Identifier::fromString(vm, "target"_s));
     RETURN_IF_EXCEPTION(throwScope, {});
     if (targetValue) {
-        if (auto* targetJSString = targetValue.toStringOrNull(globalObject)) {
+        auto* targetJSString = targetValue.toStringOrNull(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (targetJSString) {
             String targetString = targetJSString->value(globalObject);
+            RETURN_IF_EXCEPTION(throwScope, {});
             if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
                 JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
                 return {};

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -366,6 +366,16 @@ describe("errors", () => {
     }).toThrow("plugin target must be one of 'node', 'bun' or 'browser'");
   });
 
+  it("propagates exception when converting 'target' to a string throws", () => {
+    const opts: any = { setup: () => {} };
+    opts[Symbol.toPrimitive] = () => ({});
+    opts.target = opts;
+
+    expect(() => {
+      plugin(opts);
+    }).toThrow("Symbol.toPrimitive returned an object");
+  });
+
   it("invalid loaders throw", () => {
     const invalidLoaders = ["blah", "blah2", "blah3", "blah4"];
     const inputs = ["body { background: red; }", "<h1>hi</h1>", '{"hi": "there"}', "hi"];


### PR DESCRIPTION
## What

`Bun.plugin({ target, setup })` coerced the `target` option to a string with `toStringOrNull()` but never checked the throw scope afterwards.

`toStringOrNull()` returns `nullptr` **and leaves a pending exception** when the coercion fails — for example when the value's `Symbol.toPrimitive` returns an object (which throws a `TypeError`). Because the pending exception was never checked, `setupBunPlugin` fell through, built the builder object, and called the user's `setup()` function with an exception already live. That tripped `ExceptionScope::assertNoException()`:

```
ASSERTION FAILED: Unexpected exception observed on thread ... at:
Error Exception: Symbol.toPrimitive returned an object
!exception()
.../JavaScriptCore/ExceptionScope.h(61) : void JSC::ExceptionScope::assertNoException()
```

`JSString::value()` can also throw (OOM while resolving a rope), so that is checked too.

## Repro

```js
const v = { setup() {} };
v[Symbol.toPrimitive] = () => ({});
v.target = v;
Bun.plugin(v); // previously crashed the process
```

## After

The exception propagates to JS as expected instead of crashing:

```
TypeError: Symbol.toPrimitive returned an object
```

Valid targets (`"node"`/`"bun"`/`"browser"`), an absent target, and the existing invalid-target error path are unaffected.

## Test

Added a regression test in `test/js/bun/plugin/plugins.test.ts` next to the existing invalid-target test.

Found by Fuzzilli.