### PR TITLE
yaml: fix 5 flow-context over-accepts/under-accepts

### DIFF
--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -2683,9 +2683,46 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             return Err(Self::unexpected_token());
         }
 
+        // Consume c-ns-properties here (still in flow-in) so the post-property
+        // re-scan tokenizes `:b` as ns-plain-first per [126], same as the
+        // first scan above. The FlowKey wrap is only for the content parse so
+        // a JSON-style key early-returns at the trailing `:`.
+        let mut scanned_tag: Option<Token<Enc>> = None;
+        let mut scanned_anchor: Option<Token<Enc>> = None;
+        loop {
+            match self.token.data {
+                TokenData::Anchor(_) if scanned_anchor.is_none() => {
+                    scanned_anchor = Some(self.token.clone());
+                }
+                TokenData::Tag(_) if scanned_tag.is_none() => {
+                    scanned_tag = Some(self.token.clone());
+                }
+                _ => break,
+            }
+            let tag = match &scanned_tag {
+                Some(Token {
+                    data: TokenData::Tag(t),
+                    ..
+                }) => *t,
+                _ => NodeTag::None,
+            };
+            self.scan(ScanOptions { tag, ..Default::default() })?;
+            if matches!(
+                self.token.data,
+                TokenData::MappingValue
+                    | TokenData::CollectEntry
+                    | TokenData::MappingEnd
+                    | TokenData::SequenceEnd
+            ) {
+                return self.props_to_e_node(&scanned_tag, &scanned_anchor, start.loc());
+            }
+        }
+
         self.context.set(Context::FlowKey)?;
         let k = self.parse_node(ParseNodeOptions {
             explicit_mapping_key: true,
+            scanned_tag,
+            scanned_anchor,
             ..Default::default()
         });
         self.context.unset(Context::FlowKey);

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -2859,15 +2859,28 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         ..Default::default()
                     })?;
                 } else {
-                    let value = self.parse_node(ParseNodeOptions::default())?;
+                    // [147] the value is ns-flow-node; threading the value's
+                    // own indent as current_mapping_indent makes the Scalar
+                    // arm's cmi==scalar_indent check return the bare scalar
+                    // instead of consuming a trailing `: …` as a nested
+                    // mapping (`{a: b: c}`).
+                    let value = self.parse_node(ParseNodeOptions {
+                        current_mapping_indent: Some(self.token.indent),
+                        ..Default::default()
+                    })?;
                     props.append_maybe_merge(key, value, &mut self.merge_props_budget)?;
                 }
 
-                if matches!(self.token.data, TokenData::CollectEntry) {
-                    self.context.set(Context::FlowKey)?;
-                    let r = self.scan(ScanOptions::default());
-                    self.context.unset(Context::FlowKey);
-                    r?;
+                // [140] ns-s-flow-map-entries: after an entry, only `,` or `}`.
+                match self.token.data {
+                    TokenData::CollectEntry => {
+                        self.context.set(Context::FlowKey)?;
+                        let r = self.scan(ScanOptions::default());
+                        self.context.unset(Context::FlowKey);
+                        r?;
+                    }
+                    TokenData::MappingEnd => {}
+                    _ => return Err(Self::unexpected_token()),
                 }
             }
 

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -2706,7 +2706,10 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 }) => *t,
                 _ => NodeTag::None,
             };
-            self.scan(ScanOptions { tag, ..Default::default() })?;
+            self.scan(ScanOptions {
+                tag,
+                ..Default::default()
+            })?;
             if matches!(
                 self.token.data,
                 TokenData::MappingValue
@@ -3073,8 +3076,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         // enclosing block's). When reached via the implicit-pair path from a
         // flow collection (`["a": b]`), the key's column is not a block
         // boundary — pushing it would reject `["a":\nb]` per [149]/[80].
-        let pushed_block_indent =
-            !matches!(self.context.get(), Context::FlowIn | Context::FlowKey);
+        let pushed_block_indent = !matches!(self.context.get(), Context::FlowIn | Context::FlowKey);
         if pushed_block_indent {
             self.block_indents.push(mapping_indent)?;
         }

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -3956,10 +3956,10 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         if self.context.get() == Context::FlowKey {
                             return Ok(copy);
                         }
-                        // [150] c-s-implicit-json-key uses s-separate-in-line
-                        // (same line only); [148] in flow context uses
-                        // s-separate (spans lines), handled by the FlowKey
-                        // return above.
+                        // [154] ns-s-implicit-yaml-key uses s-separate-in-line
+                        // (same line only); [145] in flow-map uses s-separate
+                        // (spans lines, per yaml-test-suite 4MUZ etc.),
+                        // handled by the FlowKey return above.
                         if alias_line != self.token.line && !opts.explicit_mapping_key {
                             return Err(ParseError::MultilineImplicitKey);
                         }

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -3914,12 +3914,15 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         {
                             break 'node copy;
                         }
-                        if alias_line != self.token.line && !opts.explicit_mapping_key {
-                            return Err(ParseError::MultilineImplicitKey);
-                        }
-
                         if self.context.get() == Context::FlowKey {
                             return Ok(copy);
+                        }
+                        // [150] c-s-implicit-json-key uses s-separate-in-line
+                        // (same line only); [148] in flow context uses
+                        // s-separate (spans lines), handled by the FlowKey
+                        // return above.
+                        if alias_line != self.token.line && !opts.explicit_mapping_key {
+                            return Err(ParseError::MultilineImplicitKey);
                         }
 
                         // [192] implicit key sits at s-indent(n) (spaces only).
@@ -3966,12 +3969,11 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         {
                             break 'node seq;
                         }
-                        if sequence_line != self.token.line && !opts.explicit_mapping_key {
-                            return Err(ParseError::MultilineImplicitKey);
-                        }
-
                         if self.context.get() == Context::FlowKey {
                             break 'node seq;
+                        }
+                        if sequence_line != self.token.line && !opts.explicit_mapping_key {
+                            return Err(ParseError::MultilineImplicitKey);
                         }
 
                         // [192] implicit key sits at s-indent(n) (spaces only).
@@ -4054,12 +4056,11 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         {
                             break 'node map;
                         }
-                        if mapping_line != self.token.line && !opts.explicit_mapping_key {
-                            return Err(ParseError::MultilineImplicitKey);
-                        }
-
                         if self.context.get() == Context::FlowKey {
                             break 'node map;
+                        }
+                        if mapping_line != self.token.line && !opts.explicit_mapping_key {
+                            return Err(ParseError::MultilineImplicitKey);
                         }
 
                         // [192] implicit key sits at s-indent(n) (spaces only).

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -3031,7 +3031,16 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             }
         }
 
-        self.block_indents.push(mapping_indent)?;
+        // The block_indents stack drives scan()'s flow-context indent guard
+        // (continuation lines in a flow collection must be at indent > the
+        // enclosing block's). When reached via the implicit-pair path from a
+        // flow collection (`["a": b]`), the key's column is not a block
+        // boundary — pushing it would reject `["a":\nb]` per [149]/[80].
+        let pushed_block_indent =
+            !matches!(self.context.get(), Context::FlowIn | Context::FlowKey);
+        if pushed_block_indent {
+            self.block_indents.push(mapping_indent)?;
+        }
 
         // PORT NOTE: Zig `defer self.block_indents.pop()` — capture the fallible
         // body's result and pop on EVERY exit (including `?` paths).
@@ -3246,7 +3255,9 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             inner
         })();
 
-        self.block_indents.pop();
+        if pushed_block_indent {
+            self.block_indents.pop();
+        }
         result
     }
 }
@@ -3646,6 +3657,13 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         let mut value_tag: Option<Token<Enc>> = None;
         let mut value_anchor: Option<Token<Enc>> = None;
 
+        // The [196] indent dispatch below is block-semantics; in flow context
+        // ([149]/[80] s-separate(n,FLOW-IN) = s-separate-lines, any indent on
+        // a continuation line) it does not apply. Reached via the
+        // implicit-pair fallthrough when `parse_block_mapping` is entered
+        // from a flow-seq item (`["a":\nb]`).
+        let in_flow = matches!(self.context.get(), Context::FlowIn | Context::FlowKey);
+
         loop {
             // [196] s-l+block-node(n) reaches content via [197] flow-in-block
             // (s-separate-lines(n+1)) or [200] block-collection. Either way a
@@ -3653,7 +3671,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             // properties collected so far attach to e-scalar per [161].
             // [201] seq-space: a nested block sequence may sit at indent n in
             // BLOCK-OUT, but needs n+1 in BLOCK-IN.
-            if self.token.line != indicator_line {
+            if !in_flow && self.token.line != indicator_line {
                 let belongs_to_parent = if matches!(self.token.data, TokenData::SequenceEntry)
                     && kind != BlockIndentedKind::SeqEntry
                 {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1483,15 +1483,13 @@ folded: >
       // Each `test.todo` asserts the spec result (per ≥3/4 reference parsers);
       // the comment documents what Bun currently produces.
       describe("known flow over-accepts (pre-existing)", () => {
-        test.todo("flow-map requires `,` between entries", () => {
+        test("flow-map requires `,` between entries", () => {
           // [140] ns-s-flow-map-entries — entry must be followed by `,` or `}`.
-          // Currently: {"a":"b",":1":null}
-          expect(() => YAML.parse('{a: "b":1}\n')).toThrow();
-          // Currently: {"a":{"1 b":2}}
-          expect(() => YAML.parse("{a: 1 b: 2}\n")).toThrow();
+          expect(() => YAML.parse('{a: "b":1}\n')).toThrow("Unexpected token");
+          expect(() => YAML.parse("{a: 1 b: 2}\n")).toThrow("Unexpected token");
         });
 
-        test.todo(":-prefixed plain scalar after `? &x` / `? !!str` (anchor/tag re-scan in FlowKey)", () => {
+        test(":-prefixed plain scalar after `? &x` / `? !!str` (anchor/tag re-scan in FlowKey)", () => {
           // The first scan after `?` is in flow-in (so `:b` is ns-plain-first),
           // but when an anchor/tag intervenes the property arm re-scans inside
           // the key parse_node's FlowKey wrap, mis-tokenizing `:b` as a
@@ -1500,29 +1498,26 @@ folded: >
           expect(YAML.parse("{? !!str :b}\n")).toEqual({ ":b": null });
         });
 
-        test.todo("flow-map value is ns-flow-node, not a pair", () => {
+        test("flow-map value is ns-flow-node, not a pair", () => {
           // [147] c-ns-flow-map-separate-value — value is ns-flow-node only.
-          // Currently: {"a":{"b":"c"}}
-          expect(() => YAML.parse("{a: b: c}\n")).toThrow();
-          expect(() => YAML.parse("{? a: b: c}\n")).toThrow();
+          expect(() => YAML.parse("{a: b: c}\n")).toThrow("Unexpected token");
+          expect(() => YAML.parse("{? a: b: c}\n")).toThrow("Unexpected token");
         });
 
-        test.todo("flow-seq pair value on next line at column ≤ key indent", () => {
+        test("flow-seq pair value on next line at column ≤ key indent", () => {
           // [149]/[80] s-separate(n,FLOW-IN) = s-separate-lines, so a newline
-          // before the value at any indentation is valid. Currently rejects:
-          // parse_block_mapping's block-semantics e-node check (line!=, indent<=)
-          // fires when reached via the implicit-pair path in flow context.
+          // before the value at any indentation is valid.
           expect(YAML.parse('["a":\nb]\n')).toEqual([{ a: "b" }]);
           expect(YAML.parse("[a: \nb]\n")).toEqual([{ a: "b" }]);
         });
 
-        test.todo("multiline JSON-style key check ordering", () => {
+        test("multiline JSON-style key check ordering", () => {
           // [148] c-ns-flow-map-json-key-entry uses s-separate which spans
-          // lines; either accept all JSON-style multiline keys (eemeli) or
-          // reject all (js-yaml/PyYAML/ruamel). Currently inconsistent: quoted
-          // accepts ({"a":1}), flow-seq/map rejects.
+          // lines; the FlowKey early-return now precedes the multiline check
+          // in all JSON-node arms (was only the Scalar arm).
           expect(YAML.parse("{[1]\n:2}\n")).toEqual({ 1: 2 });
           expect(YAML.parse("{{k:1}\n:2}\n")).toEqual({ "[object Object]": 2 });
+          expect(YAML.parse('{"a"\n:1}\n')).toEqual({ a: 1 });
         });
 
         test("tab before block construct after `?`/`:` (Y79Y/008 family)", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1501,6 +1501,14 @@ folded: >
           expect(() => YAML.parse("{? a: b: c}\n")).toThrow("Unexpected token");
         });
 
+        test.todo("flow-map value with multiline c-ns-properties before nested pair", () => {
+          // The cmi mechanism for [147] uses the first token's indent; when an
+          // anchor/tag is on a different line than the scalar, indents diverge
+          // and the cmi check is bypassed. Pre-existing.
+          expect(() => YAML.parse("{a: &x\n b: c}\n")).toThrow();
+          expect(() => YAML.parse("{a: !!str\n b: c}\n")).toThrow();
+        });
+
         test("flow-seq pair value on next line at column ≤ key indent", () => {
           // [149]/[80] s-separate(n,FLOW-IN) = s-separate-lines, so a newline
           // before the value at any indentation is valid.

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1512,12 +1512,18 @@ folded: >
         });
 
         test("multiline JSON-style key check ordering", () => {
-          // [148] c-ns-flow-map-json-key-entry uses s-separate which spans
-          // lines; the FlowKey early-return now precedes the multiline check
-          // in all JSON-node arms (was only the Scalar arm).
+          // §7.4.2 prose says implicit keys are "restricted to a single
+          // line", but the official yaml-test-suite (4MUZ/*, 5MUD, 9SA2,
+          // K3WX, NJ66, UT92, VJP3/01) expects these to PARSE — the grammar
+          // ([148] s-separate spans lines) wins. js-yaml/PyYAML/ruamel reject
+          // (libyaml lookahead limit, not spec); eemeli/yaml accepts.
           expect(YAML.parse("{[1]\n:2}\n")).toEqual({ 1: 2 });
           expect(YAML.parse("{{k:1}\n:2}\n")).toEqual({ "[object Object]": 2 });
           expect(YAML.parse('{"a"\n:1}\n')).toEqual({ a: 1 });
+          // Block context ([150] s-separate-in-line) and flow-seq pairs
+          // ([151]/[150]) are still single-line.
+          expect(() => YAML.parse("[1]\n:2\n")).toThrow();
+          expect(() => YAML.parse("[[1]\n:2]\n")).toThrow("Multiline implicit key");
         });
 
         test("tab before block construct after `?`/`:` (Y79Y/008 family)", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1479,21 +1479,18 @@ folded: >
         });
       });
 
-      // Pre-existing flow-context over-accepts surfaced by adversarial review.
-      // Each `test.todo` asserts the spec result (per ≥3/4 reference parsers);
-      // the comment documents what Bun currently produces.
-      describe("known flow over-accepts (pre-existing)", () => {
+      describe("flow-context spec conformance", () => {
         test("flow-map requires `,` between entries", () => {
           // [140] ns-s-flow-map-entries — entry must be followed by `,` or `}`.
           expect(() => YAML.parse('{a: "b":1}\n')).toThrow("Unexpected token");
           expect(() => YAML.parse("{a: 1 b: 2}\n")).toThrow("Unexpected token");
         });
 
-        test(":-prefixed plain scalar after `? &x` / `? !!str` (anchor/tag re-scan in FlowKey)", () => {
-          // The first scan after `?` is in flow-in (so `:b` is ns-plain-first),
-          // but when an anchor/tag intervenes the property arm re-scans inside
-          // the key parse_node's FlowKey wrap, mis-tokenizing `:b` as a
-          // separator. Anchor/tag-on-empty cluster.
+        test(":-prefixed plain scalar after `? &x` / `? !!str`", () => {
+          // The first scan after `?` is in flow-in so `:b` tokenizes as
+          // ns-plain-first per [126]; parse_flow_explicit_key consumes
+          // c-ns-properties in flow-in too, so the post-property re-scan does
+          // the same.
           expect(YAML.parse("[? &x :b]\n")).toEqual([{ ":b": null }]);
           expect(YAML.parse("{? !!str :b}\n")).toEqual({ ":b": null });
         });
@@ -1732,7 +1729,7 @@ folded: >
         });
       });
 
-      describe("flow over-accepts (locked-in behavior)", () => {
+      describe("flow comma/separator placement", () => {
         test("JSON-adjacent does not apply in flow-map value position", () => {
           // [147] flow-map value is ns-flow-node, not ns-flow-pair; [140]
           // requires `,`/`}` after the entry.

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1733,10 +1733,10 @@ folded: >
 
       describe("flow over-accepts (locked-in behavior)", () => {
         test("JSON-adjacent does not apply in flow-map value position", () => {
-          // [147] flow-map value is ns-flow-node, not ns-flow-pair. These are
-          // pre-existing over-accepts on main (refs error); preserved as-is.
-          expect(YAML.parse('{a: "b":c}\n')).toEqual({ a: "b", ":c": null });
-          expect(YAML.parse("{x: [a]:b}\n")).toEqual({ x: ["a"], ":b": null });
+          // [147] flow-map value is ns-flow-node, not ns-flow-pair; [140]
+          // requires `,`/`}` after the entry.
+          expect(() => YAML.parse('{a: "b":c}\n')).toThrow("Unexpected token");
+          expect(() => YAML.parse("{x: [a]:b}\n")).toThrow("Unexpected token");
         });
 
         test("leading/double comma in flow sequence still errors", () => {


### PR DESCRIPTION
## What

Five spec-conformance fixes in flow context (`{…}` / `[…]`), each previously a `test.todo` from the #31203 review catalog:

| Input | Before | After | Spec |
|---|---|---|---|
| `{a: "b":1}`, `{a: 1 b: 2}` | accepted as garbage | error | [140] entry must be followed by `,` or `}` |
| `{a: b: c}`, `{? a: b: c}` | nested `{a:{b:c}}` | error | [147] value is `ns-flow-node`, not a pair |
| `["a":\nb]`, `[a: \nb]` | error | `[{a:"b"}]` | [149]/[80] `s-separate(n,FLOW-IN)` spans lines |
| `{[1]\n:2}`, `{{k:1}\n:2}` | error (but `{"a"\n:1}` accepted) | accept | [148] JSON-key + `:` separation spans lines in flow |
| `[? &x :b]`, `{? !!str :b}` | `[{null:"b"}]` | `[{":b":null}]` | [126] `:b` after `?`+property is `ns-plain-first` |

## How

- `parse_flow_mapping`: after the value parse, only `,`/`}` is valid (was unconditional `continue`). Value parse threads `current_mapping_indent` so the cmi check returns the bare scalar instead of consuming `: …`.
- `parse_block_mapping` reached from flow: skip the `block_indents.push` (the key's column is not a block boundary). `parse_block_indented` skips its [196] `belongs_to_parent` indent dispatch in flow context.
- `parse_node` Alias/SequenceStart/MappingStart arms: order the `FlowKey` early-return *before* the `MultilineImplicitKey` check, matching the Scalar arm.
- `parse_flow_explicit_key`: own the property loop in flow-in (so the post-property re-scan tokenizes `:b` as plain), then wrap only the content parse in `FlowKey`.

## Tests

5 todos flipped to passing tests; 2029 pass / 0 fail / 402/402 yaml-test-suite / 1015/1015 4-parser consensus.