### PR TITLE
Add microbenchmarks for latest JSC changes

### DIFF
--- a/bench/module-loader/create-tla-graph.js
+++ b/bench/module-loader/create-tla-graph.js
@@ -1,0 +1,133 @@
+// Generates ES module graphs that stress async-module linking/evaluation and
+// star re-exports in the JS engine's module machinery.
+//
+//   bun create-tla-graph.js
+//   CASCADE_COUNT=20000 TLA_COUNT=3000 STAR_COUNT=3000 bun create-tla-graph.js
+//
+// Generated entrypoints (run with the runtime you want to measure):
+//   bun ./tla-cascade-entry.mjs   # long sync-parent chain over one async leaf
+//   bun ./tla-chain-entry.mjs     # chain where every module has a top-level await
+//   bun ./star-entry.mjs          # chain of `export * from` re-exports
+const fs = require("fs");
+const path = require("path");
+
+const cascadeChains = parseInt(process.env.CASCADE_CHAINS || "100", 10);
+const cascadeDepth = parseInt(process.env.CASCADE_DEPTH || "100", 10);
+const tlaCount = parseInt(process.env.TLA_COUNT || "2000", 10);
+const starCount = parseInt(process.env.STAR_COUNT || "2000", 10);
+
+const reportMemory = `
+async function reportMemory() {
+  if (typeof Bun !== "undefined") Bun.gc(true);
+  else if (typeof globalThis.gc === "function") globalThis.gc();
+  const rss = process.memoryUsage().rss;
+  console.log("rss", (rss / 1024 / 1024).toFixed(2), "MB");
+  try {
+    const { heapStats } = await import("bun:jsc");
+    console.log("heapSize", (heapStats().heapSize / 1024 / 1024).toFixed(2), "MB");
+  } catch {}
+}
+`;
+
+function resetDir(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+// 1. Sync-parent cascade: many synchronous module chains (kept shallow to stay
+//    within stack limits) all bottom out at a single module with a top-level
+//    await. When that async leaf settles, the engine gathers every synchronous
+//    ancestor (chains x depth modules) in one pass.
+{
+  const dir = resetDir(path.join(__dirname, "output-tla-cascade"));
+  const total = cascadeChains * cascadeDepth;
+  fs.writeFileSync(
+    path.join(dir, "async-leaf.mjs"),
+    `await 0;
+export const value = 1;
+`,
+  );
+  for (let chain = 0; chain < cascadeChains; chain++) {
+    for (let i = 0; i < cascadeDepth; i++) {
+      const next = i + 1 < cascadeDepth ? `./chain${chain}-mod${i + 1}.mjs` : "./async-leaf.mjs";
+      fs.writeFileSync(
+        path.join(dir, `chain${chain}-mod${i}.mjs`),
+        `import { value as nextValue } from "${next}";
+export const value = nextValue + 1;
+`,
+      );
+    }
+  }
+  fs.writeFileSync(
+    path.join(dir, "root.mjs"),
+    Array.from({ length: cascadeChains }, (_, j) => `import { value as v${j} } from "./chain${j}-mod0.mjs";`).join(
+      "\n",
+    ) + `\nexport const value = ${Array.from({ length: cascadeChains }, (_, j) => `v${j}`).join(" + ")};\n`,
+  );
+  fs.writeFileSync(
+    path.join(__dirname, "tla-cascade-entry.mjs"),
+    `console.time("import (${total} sync parents over 1 async leaf)");
+const ns = await import("./output-tla-cascade/root.mjs");
+console.timeEnd("import (${total} sync parents over 1 async leaf)");
+console.log("value:", ns.value);
+${reportMemory}
+await reportMemory();
+`,
+  );
+}
+
+// 2. Chain where every module has its own top-level await.
+{
+  const dir = resetDir(path.join(__dirname, "output-tla-chain"));
+  for (let i = 0; i < tlaCount; i++) {
+    const next = i + 1 < tlaCount ? `import { value as nextValue } from "./mod${i + 1}.mjs";` : `const nextValue = 0;`;
+    fs.writeFileSync(
+      path.join(dir, `mod${i}.mjs`),
+      `${next}
+await 0;
+export const value = nextValue + 1;
+`,
+    );
+  }
+  fs.writeFileSync(
+    path.join(__dirname, "tla-chain-entry.mjs"),
+    `console.time("import (${tlaCount} modules, all top-level await)");
+const ns = await import("./output-tla-chain/mod0.mjs");
+console.timeEnd("import (${tlaCount} modules, all top-level await)");
+console.log("value:", ns.value);
+${reportMemory}
+await reportMemory();
+`,
+  );
+}
+
+// 3. Star re-export chain: every module re-exports everything below it.
+{
+  const dir = resetDir(path.join(__dirname, "output-star"));
+  for (let i = 0; i < starCount; i++) {
+    const next = i + 1 < starCount ? `export * from "./mod${i + 1}.mjs";` : "";
+    fs.writeFileSync(
+      path.join(dir, `mod${i}.mjs`),
+      `${next}
+export const value${i} = ${i};
+`,
+    );
+  }
+  fs.writeFileSync(
+    path.join(__dirname, "star-entry.mjs"),
+    `console.time("import (${starCount} chained star re-exports)");
+const ns = await import("./output-star/mod0.mjs");
+console.timeEnd("import (${starCount} chained star re-exports)");
+console.log("exports:", Object.keys(ns).length);
+${reportMemory}
+await reportMemory();
+`,
+  );
+}
+
+console.log(`Generated:
+  output-tla-cascade/ (${cascadeChains * cascadeDepth} modules) -> bun ./tla-cascade-entry.mjs
+  output-tla-chain/   (${tlaCount} modules) -> bun ./tla-chain-entry.mjs
+  output-star/        (${starCount} modules) -> bun ./star-entry.mjs
+`);

--- a/bench/snippets/array-concat.mjs
+++ b/bench/snippets/array-concat.mjs
@@ -1,0 +1,31 @@
+import { bench, run } from "../runner.mjs";
+
+const small1 = [1, 2, 3, 4];
+const small2 = [5, 6, 7, 8];
+const medium1 = Array.from({ length: 128 }, (_, i) => i);
+const medium2 = Array.from({ length: 128 }, (_, i) => i + 128);
+const doubles1 = Array.from({ length: 128 }, (_, i) => i + 0.5);
+const strings1 = Array.from({ length: 128 }, (_, i) => `item-${i}`);
+const strings2 = Array.from({ length: 128 }, (_, i) => `item-${i + 128}`);
+
+bench("concat: [4 ints].concat([4 ints])", () => {
+  return small1.concat(small2);
+});
+
+bench("concat: [128 ints].concat([128 ints])", () => {
+  return medium1.concat(medium2);
+});
+
+bench("concat: [128 ints].concat([128 doubles])", () => {
+  return medium1.concat(doubles1);
+});
+
+bench("concat: [128 strings].concat([128 strings])", () => {
+  return strings1.concat(strings2);
+});
+
+bench("concat: [128 ints].concat(1, 2, 3)", () => {
+  return medium1.concat(1, 2, 3);
+});
+
+await run();

--- a/bench/snippets/array-indexof.mjs
+++ b/bench/snippets/array-indexof.mjs
@@ -1,0 +1,63 @@
+import { bench, run } from "../runner.mjs";
+
+const ints = Array.from({ length: 1024 }, (_, i) => i);
+const strings = Array.from({ length: 1024 }, (_, i) => `string-value-${i}`);
+const int32 = new Int32Array(1024).map((_, i) => i);
+const float64 = new Float64Array(1024).map((_, i) => i);
+
+// rotate needles so the engine cannot hoist the search out of the benchmark loop
+const intNeedles = [1000, 512, 1023, 2048]; // 3 hits at varying depth + 1 miss
+const stringNeedles = ["string-value-1000", "string-value-512", "string-value-1023", "string-value-not-found"];
+let cursor = 0;
+
+bench("Array#indexOf (1024 ints)", () => {
+  return ints.indexOf(intNeedles[cursor++ & 3]);
+});
+
+bench("Array#includes (1024 ints)", () => {
+  return ints.includes(intNeedles[cursor++ & 3]);
+});
+
+bench("Array#lastIndexOf (1024 ints)", () => {
+  return ints.lastIndexOf(intNeedles[cursor++ & 3]);
+});
+
+bench("Array#indexOf (1024 strings)", () => {
+  return strings.indexOf(stringNeedles[cursor++ & 3]);
+});
+
+bench("Array#includes (1024 strings)", () => {
+  return strings.includes(stringNeedles[cursor++ & 3]);
+});
+
+bench("Array#lastIndexOf (1024 strings)", () => {
+  return strings.lastIndexOf(stringNeedles[cursor++ & 3]);
+});
+
+bench("Int32Array#lastIndexOf (1024)", () => {
+  return int32.lastIndexOf(intNeedles[cursor++ & 3]);
+});
+
+bench("Float64Array#lastIndexOf (1024)", () => {
+  return float64.lastIndexOf(intNeedles[cursor++ & 3]);
+});
+
+// upstream-style hot loop: one call site, stable receiver and needle, enough
+// inner iterations that the site is compiled by the optimizing JIT tiers
+// (mirrors JSTests/microbenchmarks/array-indexof-string-8bit-long.js)
+const hotArr = Array.from({ length: 64 }, (_, i) => String.fromCharCode(65 + (i % 26)) + "x".repeat(63));
+const hotKey = "@" + "x".repeat(63);
+
+bench("indexOf hot loop x 1e4 (64 x 64-char strings, miss)", () => {
+  let result = 0;
+  for (let i = 0; i < 1e4; i++) result += hotArr.indexOf(hotKey);
+  return result;
+});
+
+bench("includes hot loop x 1e4 (64 x 64-char strings, miss)", () => {
+  let result = 0;
+  for (let i = 0; i < 1e4; i++) result += hotArr.includes(hotKey);
+  return result;
+});
+
+await run();

--- a/bench/snippets/array-unshift.mjs
+++ b/bench/snippets/array-unshift.mjs
@@ -1,0 +1,31 @@
+import { bench, run } from "../runner.mjs";
+
+bench("unshift x 16 into empty array", () => {
+  const arr = [];
+  for (let i = 0; i < 16; i++) {
+    arr.unshift(i);
+  }
+  return arr;
+});
+
+bench("unshift 1 element into 128-element array", () => {
+  const arr = new Array(128).fill(1);
+  arr.unshift(0);
+  return arr;
+});
+
+bench("shift all from 128-element array", () => {
+  const arr = new Array(128).fill(1);
+  while (arr.length > 0) arr.shift();
+  return arr;
+});
+
+bench("queue: push + shift x 128", () => {
+  const arr = [];
+  for (let i = 0; i < 128; i++) arr.push(i);
+  let sum = 0;
+  while (arr.length > 0) sum += arr.shift();
+  return sum;
+});
+
+await run();

--- a/bench/snippets/date-now.mjs
+++ b/bench/snippets/date-now.mjs
@@ -1,0 +1,23 @@
+// Copied from WebKit JSTests/microbenchmarks/date-now.js and date-now-elapsed.js.
+// Not a mitata benchmark: run directly with `bun date-now.mjs`.
+{
+  let sum = 0;
+  const t0 = performance.now();
+  for (let i = 0; i < 1e6; ++i) sum += Date.now();
+  const t1 = performance.now();
+  if (sum < 0) throw new Error("bad result");
+  console.log("Date.now() x 1e6:".padEnd(28), (t1 - t0).toFixed(2), "ms");
+}
+
+{
+  let sum = 0;
+  const start = Date.now();
+  const t0 = performance.now();
+  for (let i = 0; i < 1e6; ++i) {
+    const diff = Date.now() - start;
+    if (diff >= 0 && diff < 1e9) sum += diff;
+  }
+  const t1 = performance.now();
+  if (sum < 0) throw new Error("bad result");
+  console.log("Date.now() elapsed x 1e6:".padEnd(28), (t1 - t0).toFixed(2), "ms");
+}

--- a/bench/snippets/object-define-property.mjs
+++ b/bench/snippets/object-define-property.mjs
@@ -1,0 +1,43 @@
+import { bench, run } from "../runner.mjs";
+
+bench("defineProperty data descriptor {value, writable}", () => {
+  const o = {};
+  Object.defineProperty(o, "hey", { value: 42, writable: true });
+  return o;
+});
+
+bench("defineProperty data descriptor (fully populated)", () => {
+  const o = {};
+  Object.defineProperty(o, "hey", { value: 42, writable: true, enumerable: true, configurable: true });
+  return o;
+});
+
+const getter = function () {
+  return 42;
+};
+const setter = function (value) {
+  this._value = value;
+};
+
+bench("defineProperty accessor {get, set}", () => {
+  const o = {};
+  Object.defineProperty(o, "hey", { get: getter, set: setter });
+  return o;
+});
+
+bench("defineProperty getter only", () => {
+  const o = {};
+  Object.defineProperty(o, "hey", { get: getter });
+  return o;
+});
+
+bench("defineProperty 4 data properties", () => {
+  const o = {};
+  Object.defineProperty(o, "a", { value: 1, writable: true, enumerable: true, configurable: true });
+  Object.defineProperty(o, "b", { value: 2, writable: true, enumerable: true, configurable: true });
+  Object.defineProperty(o, "c", { value: 3, writable: true, enumerable: true, configurable: true });
+  Object.defineProperty(o, "d", { value: 4, writable: true, enumerable: true, configurable: true });
+  return o;
+});
+
+await run();

--- a/bench/snippets/promise-combinators.mjs
+++ b/bench/snippets/promise-combinators.mjs
@@ -1,0 +1,46 @@
+import { bench, run } from "../runner.mjs";
+
+function plainValues(n) {
+  const arr = new Array(n);
+  for (let i = 0; i < n; i++) arr[i] = i;
+  return arr;
+}
+
+function resolvedPromises(n) {
+  const arr = new Array(n);
+  for (let i = 0; i < n; i++) arr[i] = Promise.resolve(i);
+  return arr;
+}
+
+const plain10 = plainValues(10);
+const plain1000 = plainValues(1000);
+
+bench("Promise.all(10 plain values)", async () => {
+  await Promise.all(plain10);
+});
+
+bench("Promise.all(1000 plain values)", async () => {
+  await Promise.all(plain1000);
+});
+
+bench("Promise.all(10 resolved promises)", async () => {
+  await Promise.all(resolvedPromises(10));
+});
+
+bench("Promise.all(1000 resolved promises)", async () => {
+  await Promise.all(resolvedPromises(1000));
+});
+
+bench("Promise.allSettled(1000 plain values)", async () => {
+  await Promise.allSettled(plain1000);
+});
+
+bench("Promise.any(1000 plain values)", async () => {
+  await Promise.any(plain1000);
+});
+
+bench("Promise.race(1000 plain values)", async () => {
+  await Promise.race(plain1000);
+});
+
+await run();

--- a/bench/snippets/promise-memory.mjs
+++ b/bench/snippets/promise-memory.mjs
@@ -1,0 +1,98 @@
+// Measures retained memory of Promise-heavy workloads (not a mitata benchmark).
+// Run directly: `bun bench/snippets/promise-memory.mjs`
+import { heapStats } from "bun:jsc";
+
+function gc() {
+  Bun.gc(true);
+}
+
+function snapshot() {
+  gc();
+  return {
+    rss: process.memoryUsage().rss,
+    heapSize: heapStats().heapSize,
+    objectCount: heapStats().objectCount,
+  };
+}
+
+function fmtMB(bytes) {
+  return (bytes / 1024 / 1024).toFixed(2) + " MB";
+}
+
+function measure(label, count, fn) {
+  const before = snapshot();
+  const retained = fn(count);
+  const after = snapshot();
+  const heapDelta = after.heapSize - before.heapSize;
+  const rssDelta = after.rss - before.rss;
+  console.log(
+    `${label.padEnd(48)} heap +${fmtMB(heapDelta)} (${(heapDelta / count).toFixed(1)} bytes/item)  rss +${fmtMB(rssDelta)}`,
+  );
+  return retained;
+}
+
+const COUNT = parseInt(process.env.PROMISE_MEMORY_COUNT || "1000000", 10);
+console.log(`Bun ${Bun.version} — ${COUNT.toLocaleString()} items per workload\n`);
+
+const keep = [];
+
+keep.push(
+  measure("pending Promise (no handler)", COUNT, n => {
+    const arr = new Array(n);
+    for (let i = 0; i < n; i++) arr[i] = new Promise(() => {});
+    return arr;
+  }),
+);
+
+keep.push(
+  measure("pending Promise + one .then(handler)", COUNT, n => {
+    const arr = new Array(n);
+    const handler = v => v;
+    for (let i = 0; i < n; i++) {
+      const p = new Promise(() => {});
+      p.then(handler);
+      // retaining the base promise keeps its reaction + derived promise alive
+      arr[i] = p;
+    }
+    return arr;
+  }),
+);
+
+keep.push(
+  measure("pending Promise + .then(onFulfilled, onRejected)", COUNT, n => {
+    const arr = new Array(n);
+    const onFulfilled = v => v;
+    const onRejected = e => e;
+    for (let i = 0; i < n; i++) {
+      const p = new Promise(() => {});
+      p.then(onFulfilled, onRejected);
+      arr[i] = p;
+    }
+    return arr;
+  }),
+);
+
+// kept alive at module scope so every suspended async function frame stays reachable
+const neverSettled = new Promise(() => {});
+
+keep.push(
+  measure("async function suspended at single await", Math.floor(COUNT / 2), n => {
+    async function suspend() {
+      await neverSettled;
+    }
+    const arr = new Array(n);
+    for (let i = 0; i < n; i++) arr[i] = suspend();
+    return arr;
+  }),
+);
+
+keep.push(
+  measure("resolved Promise retained", COUNT, n => {
+    const arr = new Array(n);
+    for (let i = 0; i < n; i++) arr[i] = Promise.resolve(i);
+    return arr;
+  }),
+);
+
+// keep references alive so the GC cannot reclaim the workloads early
+if (keep.length === 0) console.log("unreachable");

--- a/bench/snippets/promise-then.mjs
+++ b/bench/snippets/promise-then.mjs
@@ -1,0 +1,59 @@
+import { bench, run } from "../runner.mjs";
+
+const nonThenable = { value: 42 };
+
+bench("Promise.resolve(object).then(fn)", async () => {
+  await Promise.resolve(nonThenable).then(v => v);
+});
+
+bench("Promise.resolve({object literal})", () => {
+  return Promise.resolve({ a: 1, b: 2, c: 3 });
+});
+
+bench("await {object literal}", async () => {
+  const o = await { a: 1, b: 2, c: 3 };
+  return o.a;
+});
+
+bench("new Promise(r => r(1)).then(fn)", async () => {
+  await new Promise(r => r(1)).then(v => v);
+});
+
+bench(".then() chain x 10", async () => {
+  let p = Promise.resolve(0);
+  for (let i = 0; i < 10; i++) {
+    p = p.then(v => v + 1);
+  }
+  await p;
+});
+
+async function inner() {
+  return 1;
+}
+
+async function middle() {
+  return (await inner()) + 1;
+}
+
+bench("await async fn (depth 2)", async () => {
+  return await middle();
+});
+
+bench("await chain x 20 (single-await async fns)", async () => {
+  let v = 0;
+  for (let i = 0; i < 20; i++) {
+    v += await inner();
+  }
+  return v;
+});
+
+bench("async generator: 10 yields", async () => {
+  async function* gen() {
+    for (let i = 0; i < 10; i++) yield i;
+  }
+  let sum = 0;
+  for await (const v of gen()) sum += v;
+  return sum;
+});
+
+await run();

--- a/bench/snippets/string-equality-16bit.mjs
+++ b/bench/snippets/string-equality-16bit.mjs
@@ -1,0 +1,53 @@
+// Copied from WebKit JSTests/microbenchmarks/string-equality-long-16bit.js and
+// string-equality-256-16bit.js.
+// Not a mitata benchmark: run directly with `bun string-equality-16bit.mjs`.
+const noInline = globalThis.noInline ?? (() => {});
+
+function makeString(len, ch) {
+  let s = "";
+  for (let i = 0; i < len; ++i) s += ch;
+  return s;
+}
+
+function eqLong(x, y) {
+  return x === y;
+}
+noInline(eqLong);
+
+function eq256(x, y) {
+  return x === y;
+}
+noInline(eq256);
+
+{
+  // Two distinct JSString cells with identical 16-bit content (avoid pointer-equal fast path).
+  const a = makeString(64, "α") + "β";
+  const b = makeString(64, "α") + "β";
+  const c = makeString(64, "α") + "γ";
+
+  let n = 0;
+  const t0 = performance.now();
+  for (let i = 0; i < 1e6; ++i) {
+    if (eqLong(a, b)) n++;
+    if (eqLong(a, c)) n++;
+  }
+  const t1 = performance.now();
+  if (n !== 1e6) throw new Error("bad result: " + n);
+  console.log("=== 65-char 16-bit strings x 1e6: ".padEnd(36), (t1 - t0).toFixed(2), "ms");
+}
+
+{
+  const a = makeString(255, "α") + "β";
+  const b = makeString(255, "α") + "β";
+  const c = makeString(255, "α") + "γ";
+
+  let n = 0;
+  const t0 = performance.now();
+  for (let i = 0; i < 1e6; ++i) {
+    if (eq256(a, b)) n++;
+    if (eq256(a, c)) n++;
+  }
+  const t1 = performance.now();
+  if (n !== 1e6) throw new Error("bad result: " + n);
+  console.log("=== 256-char 16-bit strings x 1e6:".padEnd(36), (t1 - t0).toFixed(2), "ms");
+}

--- a/bench/snippets/string-search.mjs
+++ b/bench/snippets/string-search.mjs
@@ -1,0 +1,73 @@
+import { bench, run } from "../runner.mjs";
+
+const N = 64;
+const urls = [];
+const filePaths = [];
+const csvLines = [];
+const sentences = [];
+for (let i = 0; i < N; i++) {
+  const scheme = i % 4 === 0 ? "http" : "https";
+  urls.push(`${scheme}://example${i}.com/some/longer/path/to/a/resource${i}?query=string&value=${i}`);
+  const ext = i % 3 === 0 ? ".test.tsx" : i % 3 === 1 ? ".tsx" : ".css";
+  filePaths.push(`/Users/someone/projects/my-app-${i}/src/components/Button${i}/index${ext}`);
+  csvLines.push(`alpha${i},bravo,charlie,delta,echo,foxtrot,golf,hotel,india,juliett,kilo,lima${i}`);
+  sentences.push(`The quick brown fox ${i} jumps over the lazy dog and then runs away into the quick forest ${i}`);
+}
+
+bench(`startsWith("https://") x ${N} urls`, () => {
+  let count = 0;
+  for (let i = 0; i < N; i++) count += urls[i].startsWith("https://");
+  return count;
+});
+
+bench(`endsWith(".test.tsx") x ${N} paths`, () => {
+  let count = 0;
+  for (let i = 0; i < N; i++) count += filePaths[i].endsWith(".test.tsx");
+  return count;
+});
+
+bench(`lastIndexOf("/") x ${N} paths`, () => {
+  let total = 0;
+  for (let i = 0; i < N; i++) total += filePaths[i].lastIndexOf("/");
+  return total;
+});
+
+bench(`lastIndexOf("quick") x ${N} sentences`, () => {
+  let total = 0;
+  for (let i = 0; i < N; i++) total += sentences[i].lastIndexOf("quick");
+  return total;
+});
+
+bench(`split(",") x ${N} csv lines`, () => {
+  let total = 0;
+  for (let i = 0; i < N; i++) total += csvLines[i].split(",").length;
+  return total;
+});
+
+bench(`split(" ") x ${N} sentences`, () => {
+  let total = 0;
+  for (let i = 0; i < N; i++) total += sentences[i].split(" ").length;
+  return total;
+});
+
+const wordRegExp = /[a-z]+/g;
+bench(`match(global regexp) x ${N} sentences`, () => {
+  let total = 0;
+  for (let i = 0; i < N; i++) total += sentences[i].match(wordRegExp).length;
+  return total;
+});
+
+const singleRegExp = /quick ([a-z]+)/;
+bench(`match(non-global regexp) x ${N} sentences`, () => {
+  let total = 0;
+  for (let i = 0; i < N; i++) total += sentences[i].match(singleRegExp).length;
+  return total;
+});
+
+bench(`substring(8, 24) x ${N} urls`, () => {
+  let total = 0;
+  for (let i = 0; i < N; i++) total += urls[i].substring(8, 24).length;
+  return total;
+});
+
+await run();

--- a/bench/snippets/typed-array-sort.mjs
+++ b/bench/snippets/typed-array-sort.mjs
@@ -1,0 +1,23 @@
+import { bench, run } from "../runner.mjs";
+
+const randomFloats = Float64Array.from({ length: 1024 }, () => Math.random() * 1000);
+const randomInts = Int32Array.from({ length: 1024 }, () => (Math.random() * 1000) | 0);
+const small = Float64Array.from({ length: 16 }, () => Math.random() * 1000);
+
+bench("Float64Array#sort (1024 random)", () => {
+  return randomFloats.slice().sort();
+});
+
+bench("Int32Array#sort (1024 random)", () => {
+  return randomInts.slice().sort();
+});
+
+bench("Float64Array#sort (16 random)", () => {
+  return small.slice().sort();
+});
+
+bench("Float64Array#sort with comparator (1024 random)", () => {
+  return randomFloats.slice().sort((a, b) => a - b);
+});
+
+await run();


### PR DESCRIPTION
This PR adds microbenchmarks for latest JSC changes

---


Comparison of Bun 1.3.14 (WebKit `5488984d`) and Bun main (WebKit `0d85951a`), on Apple Silicon macOS.
Numbers are mitata average time per iteration of the snippet, using the benchmarks in `bench/snippets/` (`BENCHMARK_RUNNER=1 <bun> bench/snippets/<file>.mjs`).

> [!NOTE]
> The code snippets shown in each section are simplified excerpts for illustration only. The actual measurements were taken with the benchmark files added in this PR.

## `Array#indexOf` / `Array#includes` (string arrays)

```js
const arr = Array.from({ length: 64 }, (_, i) => String.fromCharCode(65 + (i % 26)) + "x".repeat(63));
const key = "@" + "x".repeat(63);

let result = 0;
for (let i = 0; i < 1e4; i++) result += arr.indexOf(key);
```

| version | time |
| ------- | -------- |
| 1.3.14  | 13.12 ms |
| main    | 2.00 ms  |

6.6 times faster (`includes`: 11.96 ms → 2.03 ms, 5.9 times faster)

upstream commits: https://commits.webkit.org/313389@main, https://commits.webkit.org/312963@main by sosukesuzuki

## `Object.defineProperty`

```js
const o = {};
Object.defineProperty(o, "hey", { value: 42, writable: true, enumerable: true, configurable: true });
```

| version | time    |
| ------- | ------- |
| 1.3.14  | 38.9 ns |
| main    | 4.5 ns  |

8.6 times faster (accessor descriptor: 1.6x, getter only: 1.4x, 4 properties in a row: 3.1x)

upstream commit: https://commits.webkit.org/313124@main by Constellation

## `Promise.all` with non-thenable values

```js
const values = Array.from({ length: 1000 }, (_, i) => i);
await Promise.all(values);
```

| version | time     |
| ------- | -------- |
| 1.3.14  | 24.46 µs |
| main    | 15.29 µs |

1.6 times faster (`Promise.race([p1, p2])`: 1.35x)

upstream commits: https://commits.webkit.org/313576@main, https://commits.webkit.org/313361@main by sosukesuzuki

## `Promise#then` chain

```js
let p = Promise.resolve(0);
for (let i = 0; i < 10; i++) p = p.then(v => v + 1);
await p;
```

| version | time     |
| ------- | -------- |
| 1.3.14  | 296.1 ns |
| main    | 228.1 ns |

1.3 times faster

upstream commits: https://commits.webkit.org/313220@main, https://commits.webkit.org/313277@main by Constellation, https://commits.webkit.org/313294@main by sosukesuzuki

## Memory per pending `Promise` with one `.then` handler

```js
const p = new Promise(() => {});
p.then(v => v);
// keep p alive, measure heap size after GC
```

| version | heap per promise |
| ------- | ---------------- |
| 1.3.14  | 104 bytes        |
| main    | 72 bytes         |

31% less memory (the promise reaction cell is no longer allocated for the first `.then`)

upstream commit: https://commits.webkit.org/313220@main by Constellation

## `String#startsWith` / `String#endsWith` with a constant search string

```js
// urls: 64 different strings
let count = 0;
for (let i = 0; i < urls.length; i++) count += urls[i].startsWith("https://");
```

| version | time     |
| ------- | -------- |
| 1.3.14  | 314.5 ns |
| main    | 68.4 ns  |

4.6 times faster (`endsWith`: 316.4 ns → 70.2 ns, 4.5 times faster)

upstream commit: https://commits.webkit.org/313394@main by sosukesuzuki

## `String#split`

```js
// sentences: 64 different ~90-char strings
sentences[i].split(" ");
```

| version | time     |
| ------- | -------- |
| 1.3.14  | 63.98 µs |
| main    | 20.85 µs |

3.1 times faster (`split(",")` on short CSV lines: 1.9 times faster)

upstream commit: https://commits.webkit.org/312843@main by sosukesuzuki

## `String#match`

```js
// sentences: 64 different ~90-char strings
sentences[i].match(/[a-z]+/g);
```

| version | time     |
| ------- | -------- |
| 1.3.14  | 50.54 µs |
| main    | 15.84 µs |

3.2 times faster (non-global regexp with a capture group: 2.7 times faster)

upstream commit: https://commits.webkit.org/313363@main by sosukesuzuki

## `String#substring`

```js
// urls: 64 different strings
urls[i].substring(8, 24);
```

| version | time     |
| ------- | -------- |
| 1.3.14  | 789.1 ns |
| main    | 354.2 ns |

2.2 times faster

upstream commit: https://commits.webkit.org/313402@main by Constellation

## `TypedArray#sort`

```js
const floats = Float64Array.from({ length: 1024 }, () => Math.random() * 1000);
floats.slice().sort();
```

| version | time     |
| ------- | -------- |
| 1.3.14  | 16.84 µs |
| main    | 7.25 µs  |

2.3 times faster (Int32Array: 1.9x, with a comparator: 2.0x)

upstream commit: https://commits.webkit.org/312803@main by syg

## `Array#sort` (small arrays)

```js
// 64 unsorted numbers
numbers.sort((a, b) => a - b);
```

| version | time     |
| ------- | -------- |
| 1.3.14  | 1.02 µs  |
| main    | 774.4 ns |

1.3 times faster

upstream commit: https://commits.webkit.org/312983@main by Constellation

## `Array#concat`

```js
const a = Array.from({ length: 128 }, (_, i) => i);
const b = Array.from({ length: 128 }, (_, i) => i + 128);
a.concat(b);
```

| version | time    |
| ------- | ------- |
| 1.3.14  | 67.6 ns |
| main    | 55.5 ns |

1.2 times faster (small int arrays: 1.3x, string arrays: 1.2x)

upstream commit: https://commits.webkit.org/312543@main by Constellation

## String equality (16-bit / non-Latin1 strings)

```js
// two distinct 256-char strings with identical 16-bit content
function eq(x, y) {
  return x === y;
}
let n = 0;
for (let i = 0; i < 1e6; ++i) {
  if (eq(a, b)) n++;
  if (eq(a, c)) n++;
}
```

| version | time     |
| ------- | -------- |
| 1.3.14  | 11.46 ms |
| main    | 8.78 ms  |

1.3 times faster (65-char strings: 5.62 ms → 4.20 ms, 1.3 times faster)

upstream commit: https://commits.webkit.org/312931@main by sosukesuzuki

## `Date.now()`

```js
let sum = 0;
for (let i = 0; i < 1e6; ++i) sum += Date.now();
```

| version | time     |
| ------- | -------- |
| 1.3.14  | 22.27 ms |
| main    | 19.18 ms |

1.2 times faster (elapsed-time pattern `Date.now() - start`: 25.02 ms → 19.80 ms, 1.3 times faster)

upstream commit: https://commits.webkit.org/313578@main by sosukesuzuki

## `Array#unshift`

```js
const arr = [];
for (let i = 0; i < 16; i++) arr.unshift(i);
```

| version | time     |
| ------- | -------- |
| 1.3.14  | 268.4 ns |
| main    | 215.2 ns |

1.2 times faster

upstream commits: https://commits.webkit.org/313475@main, https://commits.webkit.org/312915@main by Constellation

## Async module graphs (top-level await)

```sh
# 50,000 synchronous ES modules importing one module with top-level await
cd bench/module-loader
CASCADE_CHAINS=500 CASCADE_DEPTH=100 bun create-tla-graph.js
bun ./tla-cascade-entry.mjs
```

| version | time    |
| ------- | ------- |
| 1.3.14  | ~1.9 s  |
| main    | ~1.25 s |

~1.5 times faster (GatherAvailableAncestors is now O(N) instead of O(N²))

upstream commit: https://commits.webkit.org/312498@main by sosukesuzuki
