### PR TITLE
collections: fix LinearFifo::ordered_remove_item wrapped-buffer bounds

### DIFF
--- a/src/collections/linear_fifo.rs
+++ b/src/collections/linear_fifo.rs
@@ -710,10 +710,15 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
             } else {
                 index %= buf_len;
             }
+            // Length of the wrapped prefix `buf[0..wrap_len)`. The readable
+            // region is split into the tail `buf[head..buf_len)` and this
+            // prefix; `wrap_len <= head` (since `count <= buf_len`) so the
+            // prefix never overlaps the tail.
+            let wrap_len = head + count - buf_len;
             let buf = self.buf.as_mut_slice();
             if index < head {
                 // If the item to remove is before the head, one slice is moved.
-                shift_down_one(&mut buf[index..count - head]);
+                shift_down_one(&mut buf[index..wrap_len]);
             } else {
                 // The items before and after the head have to be shifted
                 // SAFETY: buf[0] is initialized (it's in the wrapped readable
@@ -723,7 +728,7 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
                 // SAFETY: writing into the last slot; previous occupant already
                 // shifted down.
                 unsafe { ptr::write(buf.as_mut_ptr().add(buf_len - 1), wrap) };
-                shift_down_one(&mut buf[..head - count]);
+                shift_down_one(&mut buf[..wrap_len]);
             }
         }
         self.count -= 1;
@@ -885,6 +890,141 @@ mod tests {
             let mut read_buf = [0u8; 3];
             let n = fifo.read(&mut read_buf);
             assert_eq!(3usize, n); // NOTE: It should be the number of items.
+        }
+    }
+
+    // 16-slot static buffer: `POWERS_OF_TWO` is true, matching the in-tree
+    // `weak_refs` FIFO in the dev server's source-map store (cap 16), the one
+    // real caller of `ordered_remove_item`. `i32` elements make every shift
+    // observable (distinct values), unlike a buffer of repeated bytes.
+    type WrapFifo = LinearFifo<i32, StaticBuffer<i32, 16>>;
+
+    /// Drains the FIFO into a `Vec` without mutating it, preserving FIFO order.
+    fn fifo_to_vec(fifo: &WrapFifo) -> Vec<i32> {
+        (0..fifo.readable_length())
+            .map(|i| fifo.peek_item(i))
+            .collect()
+    }
+
+    // Regression for the wrapped-branch bounds bug: `ordered_remove_item` used
+    // `count - head` / `head - count` for the wrapped-prefix length instead of
+    // the correct `head + count - buf_len`. In wrapped layouts that panics with
+    // an out-of-range slice index (and in narrow cases silently corrupts
+    // contents). The two sub-branches are `index < head` (item in the wrapped
+    // prefix) and `index >= head` (item in the tail segment).
+    #[test]
+    fn ordered_remove_item_wrapped_tail_branch_head_lt_count() {
+        // write 12, read 8, write 10 -> head=8, count=14, buf_len=16.
+        let mut fifo = WrapFifo::init();
+        for v in 0..12 {
+            fifo.write_item(v).unwrap();
+        }
+        for _ in 0..8 {
+            fifo.read_item().unwrap();
+        }
+        for v in 100..110 {
+            fifo.write_item(v).unwrap();
+        }
+
+        // Precondition: readable region wraps, and head < count.
+        assert_eq!(fifo.head, 8);
+        assert_eq!(fifo.count, 14);
+        assert_eq!(fifo.buf_len(), 16);
+        assert!(fifo.buf_len() - fifo.head < fifo.count);
+        assert!(fifo.head < fifo.count);
+
+        let mut expected = fifo_to_vec(&fifo);
+        assert_eq!(
+            expected,
+            vec![
+                8, 9, 10, 11, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109
+            ]
+        );
+
+        // offset 6 -> index = (8 + 6) & 15 = 14 >= head -> tail sub-branch.
+        fifo.ordered_remove_item(6);
+        expected.remove(6);
+
+        assert_eq!(fifo.readable_length(), 13);
+        assert_eq!(fifo_to_vec(&fifo), expected);
+        assert_eq!(
+            expected,
+            vec![8, 9, 10, 11, 100, 101, 103, 104, 105, 106, 107, 108, 109]
+        );
+    }
+
+    #[test]
+    fn ordered_remove_item_wrapped_prefix_branch_head_gt_count() {
+        // write 12, read 12, write 8 -> head=12, count=8, buf_len=16.
+        let mut fifo = WrapFifo::init();
+        for v in 0..12 {
+            fifo.write_item(v).unwrap();
+        }
+        for _ in 0..12 {
+            fifo.read_item().unwrap();
+        }
+        for v in 200..208 {
+            fifo.write_item(v).unwrap();
+        }
+
+        // Precondition: readable region wraps, and head > count.
+        assert_eq!(fifo.head, 12);
+        assert_eq!(fifo.count, 8);
+        assert_eq!(fifo.buf_len(), 16);
+        assert!(fifo.buf_len() - fifo.head < fifo.count);
+        assert!(fifo.head > fifo.count);
+
+        let mut expected = fifo_to_vec(&fifo);
+        assert_eq!(expected, vec![200, 201, 202, 203, 204, 205, 206, 207]);
+
+        // offset 5 -> index = (12 + 5) & 15 = 1 < head -> wrapped-prefix sub-branch.
+        fifo.ordered_remove_item(5);
+        expected.remove(5);
+
+        assert_eq!(fifo.readable_length(), 7);
+        assert_eq!(fifo_to_vec(&fifo), expected);
+        assert_eq!(expected, vec![200, 201, 202, 203, 204, 206, 207]);
+    }
+
+    // Exhaustively remove every valid offset from a wrapped layout and compare
+    // against a reference `Vec`. Uses a fresh FIFO per offset (remove mutates).
+    #[test]
+    fn ordered_remove_item_wrapped_all_offsets_match_reference() {
+        // Build the same wrapped layout as the tail-branch test: head=8, count=14.
+        let build = || {
+            let mut fifo = WrapFifo::init();
+            for v in 0..12 {
+                fifo.write_item(v).unwrap();
+            }
+            for _ in 0..8 {
+                fifo.read_item().unwrap();
+            }
+            for v in 100..110 {
+                fifo.write_item(v).unwrap();
+            }
+            fifo
+        };
+
+        let reference = fifo_to_vec(&build());
+        assert!(build().buf_len() - build().head < build().count);
+
+        for offset in 0..reference.len() {
+            let mut fifo = build();
+            fifo.ordered_remove_item(offset);
+
+            let mut expected = reference.clone();
+            expected.remove(offset);
+
+            assert_eq!(
+                fifo.readable_length(),
+                expected.len(),
+                "count must drop by one for offset {offset}"
+            );
+            assert_eq!(
+                fifo_to_vec(&fifo),
+                expected,
+                "contents mismatch for offset {offset}"
+            );
         }
     }
 }

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -235,6 +235,11 @@ export const decodeURIComponentSIMD = $newCppFunction(
 
 export const getDevServerDeinitCount = $bindgenFn("DevServer.bind.ts", "getDeinitCountForTesting");
 export const getCounters = $newZigFunction("Counters.zig", "createCountersObject", 0);
+export const linearFifoOrderedRemoveProbe = $newZigFunction(
+  "collections/linear_fifo.zig",
+  "TestingAPIs.orderedRemoveProbe",
+  1,
+) as (scenario: number) => number[];
 export const hasNonReifiedStatic = $newCppFunction("InternalForTesting.cpp", "jsFunction_hasReifiedStatic", 1);
 
 interface setSocketOptionsFn {

--- a/src/runtime/dispatch_js2native.rs
+++ b/src/runtime/dispatch_js2native.rs
@@ -104,4 +104,10 @@ pub use css::prefix_test as css_jsc_css_internals_prefix_test;
 pub use css::prefix_test_with_options as css_jsc_css_internals_prefix_test_with_options;
 pub use css::test_with_options as css_jsc_css_internals_test_with_options;
 
+// ── src/collections/linear_fifo.zig TestingAPIs (test-only) ─────────────────
+// `LinearFifo` has no JSC consumer of its own; this `bun:internal-for-testing`
+// probe lives in `bun_runtime` (which depends on both `bun_collections` and
+// `bun_jsc`) rather than inventing a JSC edge into the collections crate.
+pub use crate::linear_fifo_testing::ordered_remove_probe as collections_linear_fifo_testing_ap_is_ordered_remove_probe;
+
 // ported from: generated_js2native.rs

--- a/src/runtime/lib.rs
+++ b/src/runtime/lib.rs
@@ -37,6 +37,7 @@ pub mod dispatch;
 pub mod hw_exports;
 pub mod ipc_host;
 pub mod jsc_hooks;
+pub mod linear_fifo_testing;
 pub mod napi;
 #[path = "../bun.js.rs"]
 pub mod run_main;

--- a/src/runtime/linear_fifo_testing.rs
+++ b/src/runtime/linear_fifo_testing.rs
@@ -1,0 +1,77 @@
+//! Test-only bridge exposing `bun_collections::LinearFifo::ordered_remove_item`
+//! to `bun:internal-for-testing` (see `src/js/internal-for-testing.ts`).
+//!
+//! `LinearFifo` is an internal Rust ring buffer with no JS-visible surface of
+//! its own; its only in-tree caller (the bake dev server's source-map weak-ref
+//! store) drives it with CSPRNG keys and an async expiry timer, so the
+//! wrapped-buffer branch of `ordered_remove_item` can't be reached
+//! deterministically from a normal test. This bridge reconstructs the exact
+//! wrapped states from issue #31563 and returns the resulting FIFO contents so
+//! a JS test can assert FIFO order is preserved across a wrapped removal.
+//!
+//! Lives in `bun_runtime` (not `bun_collections`) because it needs the JSC
+//! types; `bun_runtime` already depends on both `bun_collections` and
+//! `bun_jsc`. Registered via `$newZigFunction("collections/linear_fifo.zig",
+//! "TestingAPIs.orderedRemoveProbe", 1)` — the `.zig` path is only the codegen
+//! key; the implementation is this Rust function (see `dispatch_js2native.rs`).
+
+use bun_collections::linear_fifo::{LinearFifo, StaticBuffer};
+use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
+
+/// A 16-slot static buffer matches the real `weak_refs` FIFO in the dev
+/// server's source-map store and makes `POWERS_OF_TWO` true.
+type ProbeFifo = LinearFifo<i32, StaticBuffer<i32, 16>>;
+
+/// Builds a wrapped `LinearFifo` for the requested scenario, removes one item,
+/// and returns the live items (FIFO order) as a JS `number[]`.
+///
+/// Scenarios mirror issue #31563:
+///   0 — tail sub-branch (`index >= head`), `head < count`:
+///       write 12, read 8, write 10 → head=8 count=14, remove offset 6.
+///   1 — wrapped-prefix sub-branch (`index < head`), `head > count`:
+///       write 12, read 12, write 8 → head=12 count=8, remove offset 5.
+///
+/// Any other scenario value returns an empty array.
+pub fn ordered_remove_probe(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    let scenario = frame.argument(0).to_int32();
+
+    let mut fifo = ProbeFifo::init();
+    match scenario {
+        0 => {
+            for v in 0..12 {
+                fifo.write_item(v).unwrap();
+            }
+            for _ in 0..8 {
+                fifo.read_item().unwrap();
+            }
+            for v in 100..110 {
+                fifo.write_item(v).unwrap();
+            }
+            fifo.ordered_remove_item(6);
+        }
+        1 => {
+            for v in 0..12 {
+                fifo.write_item(v).unwrap();
+            }
+            for _ in 0..12 {
+                fifo.read_item().unwrap();
+            }
+            for v in 200..208 {
+                fifo.write_item(v).unwrap();
+            }
+            fifo.ordered_remove_item(5);
+        }
+        _ => {}
+    }
+
+    let len = fifo.readable_length();
+    let array = JSValue::create_empty_array(global, len)?;
+    for i in 0..len {
+        array.put_index(
+            global,
+            i as u32,
+            JSValue::js_number_from_int32(fifo.peek_item(i)),
+        )?;
+    }
+    Ok(array)
+}

--- a/test/internal/linear-fifo.test.ts
+++ b/test/internal/linear-fifo.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Regression coverage for the `LinearFifo::ordered_remove_item` wrapped-buffer
+ * bounds bug (issue #31563).
+ *
+ * `LinearFifo` (src/collections/linear_fifo.rs) is an internal Rust collection
+ * in the `bun_collections` crate. Its only in-tree caller is the bake dev
+ * server's source-map weak-ref store, which drives it with CSPRNG keys and an
+ * asynchronous expiry timer — there is no JS-visible, deterministic way to
+ * force its `ordered_remove_item` onto a *wrapped* buffer layout from here, and
+ * the type is not exposed through `bun:internal-for-testing`. The authoritative
+ * coverage therefore lives in the crate's own `#[cfg(test)] mod tests`
+ * (src/collections/linear_fifo.rs), which builds the exact wrapped states from
+ * the issue deterministically via `write_item`/`read_item`.
+ *
+ * This test is the discoverable `test/` entry point for that fix: it runs those
+ * Rust unit tests with the workspace `cargo` and asserts they pass. With the
+ * buggy bounds (`count - head` / `head - count`) the wrapped-branch tests panic
+ * with a `usize` subtraction overflow / out-of-range slice index; with the fix
+ * (`head + count - buf_len`) they pass.
+ */
+import { describe, expect, test } from "bun:test";
+import { isWindows } from "harness";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "..", "..");
+
+// The wrapped-branch regression tests added alongside the fix. Each must be
+// reported by `cargo test` as `<name> ... ok`.
+const REQUIRED_TESTS = [
+  "ordered_remove_item_wrapped_tail_branch_head_lt_count",
+  "ordered_remove_item_wrapped_prefix_branch_head_gt_count",
+  "ordered_remove_item_wrapped_all_offsets_match_reference",
+] as const;
+
+// Cargo is on PATH on the Linux/macOS CI test lanes (same baked image as the
+// build lanes). Windows test agents don't reliably expose it, so skip there —
+// the Miri CI lane already runs these same tests on `src/collections/**`.
+describe.skipIf(isWindows)("LinearFifo::ordered_remove_item (Rust crate tests)", () => {
+  test("wrapped-buffer removal regression tests pass", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        "cargo",
+        "test",
+        "-p",
+        "bun_collections",
+        "--",
+        // Run exactly the three wrapped-branch regression tests by prefix.
+        "linear_fifo::tests::ordered_remove_item_wrapped",
+      ],
+      cwd: repoRoot,
+      env: process.env as Record<string, string>,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const output = stdout + stderr;
+
+    // `cargo` missing (e.g. a stripped local env): don't fail the suite, the
+    // Miri CI lane covers it. This never triggers on the real CI test lanes.
+    if (exitCode === null || (exitCode !== 0 && /No such file or directory|program not found|ENOENT/i.test(output))) {
+      return;
+    }
+
+    // Every wrapped-branch regression test must have run AND passed. If the fix
+    // (and its co-located tests) are absent, cargo runs 0 matching tests and
+    // these assertions fail — which is the intended fail-before behavior.
+    for (const name of REQUIRED_TESTS) {
+      expect(output).toContain(`test linear_fifo::tests::${name} ... ok`);
+    }
+
+    // The summary must report success with at least the three required tests.
+    const summary = output.match(/test result: ok\. (\d+) passed; (\d+) failed/);
+    expect(summary, `cargo did not report a passing summary:\n${output}`).not.toBeNull();
+    expect(Number(summary![1])).toBeGreaterThanOrEqual(REQUIRED_TESTS.length);
+    expect(Number(summary![2])).toBe(0);
+
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/internal/linear-fifo.test.ts
+++ b/test/internal/linear-fifo.test.ts
@@ -2,77 +2,33 @@
  * Regression coverage for the `LinearFifo::ordered_remove_item` wrapped-buffer
  * bounds bug (issue #31563).
  *
- * `LinearFifo` (src/collections/linear_fifo.rs) is an internal Rust collection
- * in the `bun_collections` crate. Its only in-tree caller is the bake dev
- * server's source-map weak-ref store, which drives it with CSPRNG keys and an
- * asynchronous expiry timer — there is no JS-visible, deterministic way to
- * force its `ordered_remove_item` onto a *wrapped* buffer layout from here, and
- * the type is not exposed through `bun:internal-for-testing`. The authoritative
- * coverage therefore lives in the crate's own `#[cfg(test)] mod tests`
- * (src/collections/linear_fifo.rs), which builds the exact wrapped states from
- * the issue deterministically via `write_item`/`read_item`.
+ * `LinearFifo` (src/collections/linear_fifo.rs) is an internal Rust ring buffer
+ * with no JS-visible surface of its own. Its only in-tree caller (the bake dev
+ * server's source-map weak-ref store) drives it with CSPRNG keys and an async
+ * expiry timer, so the *wrapped* branch of `ordered_remove_item` can't be
+ * reached deterministically from a normal test. The `linearFifoOrderedRemoveProbe`
+ * helper (src/runtime/linear_fifo_testing.rs, exposed via
+ * `bun:internal-for-testing`) reconstructs the exact wrapped states from the
+ * issue and returns the resulting FIFO contents.
  *
- * This test is the discoverable `test/` entry point for that fix: it runs those
- * Rust unit tests with the workspace `cargo` and asserts they pass. With the
- * buggy bounds (`count - head` / `head - count`) the wrapped-branch tests panic
- * with a `usize` subtraction overflow / out-of-range slice index; with the fix
- * (`head + count - buf_len`) they pass.
+ * With the buggy bounds (`count - head` / `head - count`) the wrapped branch
+ * panics with a `usize` subtraction overflow / out-of-range slice index; with
+ * the fix (`head + count - buf_len`) these assertions hold. The crate's own
+ * `#[cfg(test)] mod tests` exercise the same states under Miri as well.
  */
-import { describe, expect, test } from "bun:test";
-import { isWindows } from "harness";
-import { join } from "node:path";
+import { linearFifoOrderedRemoveProbe } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
 
-const repoRoot = join(import.meta.dir, "..", "..");
+test("ordered_remove_item preserves FIFO order in the wrapped tail sub-branch (head < count)", () => {
+  // write 12, read 8, write 10 -> head=8, count=14, buf_len=16 (wraps).
+  // readable = [8,9,10,11, 100,101,102,103, 104,105,106,107,108,109]
+  // remove offset 6 -> index=(8+6)&15=14 >= head -> tail sub-branch, drops 102.
+  expect(linearFifoOrderedRemoveProbe(0)).toEqual([8, 9, 10, 11, 100, 101, 103, 104, 105, 106, 107, 108, 109]);
+});
 
-// The wrapped-branch regression tests added alongside the fix. Each must be
-// reported by `cargo test` as `<name> ... ok`.
-const REQUIRED_TESTS = [
-  "ordered_remove_item_wrapped_tail_branch_head_lt_count",
-  "ordered_remove_item_wrapped_prefix_branch_head_gt_count",
-  "ordered_remove_item_wrapped_all_offsets_match_reference",
-] as const;
-
-// Cargo is on PATH on the Linux/macOS CI test lanes (same baked image as the
-// build lanes). Skip when it isn't: Windows test agents don't reliably expose
-// it, and a stripped local env may lack it — the Miri CI lane already runs
-// these same tests on `src/collections/**`. `Bun.spawn` resolves `argv[0]`
-// synchronously and throws if it's missing, so this must be gated up front
-// (matches test/js/third_party/grpc-js/test-tonic.test.ts).
-describe.skipIf(isWindows || !Bun.which("cargo"))("LinearFifo::ordered_remove_item (Rust crate tests)", () => {
-  // A cold test lane may have to compile the crate's test binary first, so give
-  // cargo generous headroom rather than the 5s default.
-  test("wrapped-buffer removal regression tests pass", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        "cargo",
-        "test",
-        "-p",
-        "bun_collections",
-        // Run exactly the three wrapped-branch regression tests by prefix.
-        "linear_fifo::tests::ordered_remove_item_wrapped",
-      ],
-      cwd: repoRoot,
-      env: process.env as Record<string, string>,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const output = stdout + stderr;
-
-    // Every wrapped-branch regression test must have run AND passed. If the
-    // fix (and its co-located tests) are absent, cargo runs 0 matching tests
-    // and these assertions fail — which is the intended fail-before behavior.
-    for (const name of REQUIRED_TESTS) {
-      expect(output).toContain(`test linear_fifo::tests::${name} ... ok`);
-    }
-
-    // The summary must report success with at least the three required tests.
-    const summary = output.match(/test result: ok\. (\d+) passed; (\d+) failed/);
-    expect(summary, `cargo did not report a passing summary:\n${output}`).not.toBeNull();
-    expect(Number(summary![1])).toBeGreaterThanOrEqual(REQUIRED_TESTS.length);
-    expect(Number(summary![2])).toBe(0);
-
-    expect(exitCode).toBe(0);
-  }, 120_000);
+test("ordered_remove_item preserves FIFO order in the wrapped prefix sub-branch (head > count)", () => {
+  // write 12, read 12, write 8 -> head=12, count=8, buf_len=16 (wraps).
+  // readable = [200,201,202,203, 204,205,206,207]
+  // remove offset 5 -> index=(12+5)&15=1 < head -> wrapped-prefix sub-branch, drops 205.
+  expect(linearFifoOrderedRemoveProbe(1)).toEqual([200, 201, 202, 203, 204, 206, 207]);
 });

--- a/test/internal/linear-fifo.test.ts
+++ b/test/internal/linear-fifo.test.ts
@@ -33,9 +33,14 @@ const REQUIRED_TESTS = [
 ] as const;
 
 // Cargo is on PATH on the Linux/macOS CI test lanes (same baked image as the
-// build lanes). Windows test agents don't reliably expose it, so skip there —
-// the Miri CI lane already runs these same tests on `src/collections/**`.
-describe.skipIf(isWindows)("LinearFifo::ordered_remove_item (Rust crate tests)", () => {
+// build lanes). Skip when it isn't: Windows test agents don't reliably expose
+// it, and a stripped local env may lack it — the Miri CI lane already runs
+// these same tests on `src/collections/**`. `Bun.spawn` resolves `argv[0]`
+// synchronously and throws if it's missing, so this must be gated up front
+// (matches test/js/third_party/grpc-js/test-tonic.test.ts).
+describe.skipIf(isWindows || !Bun.which("cargo"))("LinearFifo::ordered_remove_item (Rust crate tests)", () => {
+  // A cold test lane may have to compile the crate's test binary first, so give
+  // cargo generous headroom rather than the 5s default.
   test("wrapped-buffer removal regression tests pass", async () => {
     await using proc = Bun.spawn({
       cmd: [
@@ -43,7 +48,6 @@ describe.skipIf(isWindows)("LinearFifo::ordered_remove_item (Rust crate tests)",
         "test",
         "-p",
         "bun_collections",
-        "--",
         // Run exactly the three wrapped-branch regression tests by prefix.
         "linear_fifo::tests::ordered_remove_item_wrapped",
       ],
@@ -56,15 +60,9 @@ describe.skipIf(isWindows)("LinearFifo::ordered_remove_item (Rust crate tests)",
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     const output = stdout + stderr;
 
-    // `cargo` missing (e.g. a stripped local env): don't fail the suite, the
-    // Miri CI lane covers it. This never triggers on the real CI test lanes.
-    if (exitCode === null || (exitCode !== 0 && /No such file or directory|program not found|ENOENT/i.test(output))) {
-      return;
-    }
-
-    // Every wrapped-branch regression test must have run AND passed. If the fix
-    // (and its co-located tests) are absent, cargo runs 0 matching tests and
-    // these assertions fail — which is the intended fail-before behavior.
+    // Every wrapped-branch regression test must have run AND passed. If the
+    // fix (and its co-located tests) are absent, cargo runs 0 matching tests
+    // and these assertions fail — which is the intended fail-before behavior.
     for (const name of REQUIRED_TESTS) {
       expect(output).toContain(`test linear_fifo::tests::${name} ... ok`);
     }
@@ -76,5 +74,5 @@ describe.skipIf(isWindows)("LinearFifo::ordered_remove_item (Rust crate tests)",
     expect(Number(summary![2])).toBe(0);
 
     expect(exitCode).toBe(0);
-  });
+  }, 120_000);
 });


### PR DESCRIPTION
Fixes #31563.

## Problem

`LinearFifo::ordered_remove_item` (`src/collections/linear_fifo.rs`) uses the
wrong slice bounds when the readable region wraps around the end of the backing
buffer. When the data wraps, the readable region splits into two segments:

- tail:           `buf[head..buf_len)`
- wrapped prefix: `buf[0..wrap_len)`

where the correct prefix length is `wrap_len = head + count - buf_len`.

The wrapped branch instead used:

- `count - head`  for the `index < head` sub-branch (remove from wrapped prefix)
- `head - count`  for the `index >= head` sub-branch (remove from tail)

Neither equals `wrap_len`. In wrapped layouts these underflow `usize` and panic
with an out-of-range slice index; in the narrow cases where the wrong bound
happens to stay in range, the shift moves the wrong number of elements and
silently corrupts FIFO contents.

This is a faithful port of a latent bug in the Zig reference
(`orderedRemoveItem`), which uses the same `self.count - self.head` /
`self.head - self.count` bounds. It was never correct, so it is not a
regression from a prior Bun release.

### Reachability

The one in-tree caller is `weak_refs.ordered_remove_item(i)` in
`src/runtime/bake/dev_server/source_map_store.rs` (`weak_refs` is a
`LinearFifo<_, StaticBuffer<_, 16>>`). The `read_item`/`write_item` churn in
`add_weak_ref` advances `head` and wraps the tail, so a wrapped layout with
`head != 0` is reachable during normal dev-server operation. (github-actions
linked #23617 — a crash in `SourceMapStore.removeOrUpgradeWeakRef`, the only
caller of this method.)

## Fix

Compute `wrap_len = head + count - buf_len` once and use it in both wrapped
sub-branches:

```rust
let wrap_len = head + count - buf_len;
if index < head {
    shift_down_one(&mut buf[index..wrap_len]);
} else {
    let wrap = unsafe { ptr::read(buf.as_ptr()) };
    shift_down_one(&mut buf[index..]);
    unsafe { ptr::write(buf.as_mut_ptr().add(buf_len - 1), wrap) };
    shift_down_one(&mut buf[..wrap_len]);
}
```

Since `count <= buf_len` always holds, `wrap_len <= head`, so the prefix
`buf[..wrap_len]` stays entirely inside the wrapped prefix and never overlaps
the tail `buf[head..]`. The wrapped branch is only entered when
`buf_len - head < count`, i.e. `head + count > buf_len`, so `wrap_len >= 1` and
the subtraction cannot underflow.

## Tests

Two layers:

1. **Rust unit tests** in the crate's inline `#[cfg(test)] mod tests`
   (`src/collections/linear_fifo.rs`) reconstruct the exact wrapped states from
   the issue via the public API on a `LinearFifo<i32, StaticBuffer<i32, 16>>`
   (cap 16 matches the real dev-server `weak_refs` FIFO):
   - tail sub-branch (`index >= head`, `head < count`),
   - wrapped-prefix sub-branch (`index < head`, `head > count`),
   - an exhaustive per-offset comparison against a reference `Vec`.

   These run in CI on the Miri lane (`.github/workflows/miri.yml` → `cargo miri
   test -p bun_collections`, triggered on `src/collections/**`), which also
   verifies the `unsafe` `ptr::read`/`ptr::write`/memmove path is UB-free.

2. **`test/internal/linear-fifo.test.ts`** — a deterministic JS regression test.
   `LinearFifo` has no JS-visible surface and its only caller uses CSPRNG keys +
   an async timer, so the wrapped branch can't be reached deterministically from
   a normal test. A small pure-Rust probe (`linearFifoOrderedRemoveProbe`,
   `src/runtime/linear_fifo_testing.rs`) is exposed through
   `bun:internal-for-testing`; it rebuilds the two wrapped states, calls
   `ordered_remove_item`, and returns the resulting FIFO contents for the test
   to assert FIFO order is preserved. The probe lives in `bun_runtime` (which
   depends on both `bun_collections` and `bun_jsc`) and is wired via the
   existing `$newZigFunction` js2native path — the `.zig` filename is only the
   codegen key; the body is Rust.

### Verification

```console
# Rust unit tests — fail without the fix (matches the issue), pass with it:
$ cargo test -p bun_collections linear_fifo
  ...attempt to subtract with overflow   # count-head / head-count
  test result: FAILED. 3 passed; 3 failed   # (buggy bounds)
  test result: ok. 6 passed; 0 failed       # (fixed)

# full crate under Miri (Tree Borrows) — no UB:
$ MIRIFLAGS=-Zmiri-tree-borrows cargo miri test -p bun_collections
  test result: ok. 36 passed; 0 failed

# JS test, debug build — passes with the fix; with the buggy bounds the
# probe's ordered_remove_item call panics (usize underflow):
$ bun bd test test/internal/linear-fifo.test.ts
  (pass) ...wrapped tail sub-branch (head < count)
  (pass) ...wrapped prefix sub-branch (head > count)
```