### PR TITLE
Fix crash in require.resolve when options.paths contains invalid entries

### DIFF
--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -4,6 +4,7 @@
 
 #include "ImportMetaObject.h"
 #include "ZigGlobalObject.h"
+#include "Bindgen/IDLConvert.h"
 #include "ExtendedDOMClientIsoSubspaces.h"
 #include "ExtendedDOMIsoSubspaces.h"
 #include "IDLTypes.h"
@@ -13,6 +14,7 @@
 #include "JSDOMConstructor.h"
 #include "JSDOMConvertBase.h"
 #include "JSDOMConvertInterface.h"
+#include "JSDOMConvertSequences.h"
 #include "JSDOMConvertStrings.h"
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMGlobalObject.h"
@@ -275,36 +277,27 @@ extern "C" JSC::EncodedJSValue functionImportMeta__resolveSyncPrivate(JSC::JSGlo
                     return {};
                 }
 
-                JSC::EncodedJSValue result = {};
-                WTF::Vector<BunString> paths;
-                for (size_t i = 0; i < userPathListArray->length(); ++i) {
-                    JSValue path = userPathListArray->getIndex(globalObject, i);
-                    if (scope.exception()) [[unlikely]]
-                        goto cleanup;
-                    if (!path.isString()) {
-                        Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, makeString("paths["_s, i, "]"_s), "string"_s, path);
-                        goto cleanup;
-                    }
-                    WTF::String pathStr = path.toWTFString(globalObject);
-                    if (scope.exception()) [[unlikely]]
-                        goto cleanup;
-                    paths.append(Bun::toStringRef(pathStr));
-                }
+                auto pathsCtx = Bun::Bindgen::LiteralConversionContext { "options.paths"_s };
+                Vector<WTF::String> paths = Bun::convertIDL<IDLSequence<Bun::IDLStrictString>>(*globalObject, userPathListArray, pathsCtx);
+                RETURN_IF_EXCEPTION(scope, {});
 
-                result = Bun__resolveSyncWithPaths(lexicalGlobalObject, JSC::JSValue::encode(moduleName), JSValue::encode(from), isESM, isRequireDotResolve, paths.begin(), paths.size());
-                if (scope.exception()) [[unlikely]]
-                    goto cleanup;
+                WTF::Vector<BunString> bunPaths;
+                bunPaths.reserveInitialCapacity(paths.size());
+                for (auto& path : paths)
+                    bunPaths.append(Bun::toStringRef(path));
+
+                JSC::EncodedJSValue result = Bun__resolveSyncWithPaths(lexicalGlobalObject, JSC::JSValue::encode(moduleName), JSValue::encode(from), isESM, isRequireDotResolve, bunPaths.begin(), bunPaths.size());
+
+                for (auto& path : bunPaths) {
+                    path.deref();
+                }
+                RETURN_IF_EXCEPTION(scope, {});
 
                 if (!JSC::JSValue::decode(result).isString()) {
                     JSC::throwException(lexicalGlobalObject, scope, JSC::JSValue::decode(result));
-                    result = {};
-                    goto cleanup;
+                    return {};
                 }
 
-            cleanup:
-                for (auto& path : paths) {
-                    path.deref();
-                }
                 RELEASE_AND_RETURN(scope, result);
             } else {
                 Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, "options.paths"_s, userPathList);

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -20,6 +20,8 @@
 #include "ZigGlobalObject.h"
 #include "headers.h"
 #include "ErrorCode.h"
+#include "Bindgen/IDLConvert.h"
+#include "JSDOMConvertSequences.h"
 
 #include "GeneratedNodeModuleModule.h"
 #include "ZigGeneratedClasses.h"
@@ -349,32 +351,19 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionResolveFileName,
                 return {};
             }
 
-            WTF::Vector<BunString> paths;
+            auto pathsCtx = Bun::Bindgen::LiteralConversionContext { "options.paths"_s };
+            Vector<WTF::String> paths = Bun::convertIDL<WebCore::IDLSequence<Bun::IDLStrictString>>(*globalObject, pathsValue, pathsCtx);
+            RETURN_IF_EXCEPTION(scope, {});
 
-            // Iterate through the array using forEachInIterable
-            forEachInIterable(globalObject, pathsValue, [&](JSC::VM&, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue item) {
-                if (scope.exception())
-                    return;
+            WTF::Vector<BunString> bunPaths;
+            bunPaths.reserveInitialCapacity(paths.size());
+            for (auto& path : paths)
+                bunPaths.append(Bun::toStringRef(path));
 
-                WTF::String pathStr = item.toWTFString(lexicalGlobalObject);
-                if (scope.exception())
-                    return;
-
-                paths.append(Bun::toStringRef(pathStr));
-            });
-
-            if (scope.exception()) {
-                // Clean up on exception
-                for (auto& path : paths) {
-                    path.deref();
-                }
-                return {};
-            }
-
-            result = Bun__resolveSyncWithPaths(globalObject, JSC::JSValue::encode(moduleName), JSValue::encode(fromValue), false, true, paths.begin(), paths.size());
+            result = Bun__resolveSyncWithPaths(globalObject, JSC::JSValue::encode(moduleName), JSValue::encode(fromValue), false, true, bunPaths.begin(), bunPaths.size());
 
             // Clean up BunStrings to avoid leaking
-            for (auto& path : paths) {
+            for (auto& path : bunPaths) {
                 path.deref();
             }
 

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -339,6 +339,14 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionResolveFileName,
 
         JSC::EncodedJSValue result;
 
+        // Node resolves builtin ids before it validates `options.paths`.
+        if (!pathsValue.isUndefinedOrNull() && moduleName.isString()) {
+            auto builtinCheckStr = moduleName.toWTFString(globalObject);
+            RETURN_IF_EXCEPTION(scope, {});
+            if (Bun::isBuiltinModule(builtinCheckStr))
+                pathsValue = JSC::jsUndefined();
+        }
+
         // If paths are provided, use Bun__resolveSyncWithPaths
         if (!pathsValue.isUndefinedOrNull()) {
             // Node.js requires options.paths to be an array

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -361,6 +361,21 @@ pub mod fs {
             join_abs_string_buf_checked::<platform::Loose>(self.top_level_dir, buf, parts)
         }
 
+        /// Like `abs_buf_checked`, but uses host-native absolute semantics
+        /// (`platform::Auto`) rather than `Loose`. `Loose` treats a Windows
+        /// drive prefix (`C:/…`) as absolute on every host, which would leave a
+        /// non-native-absolute path unchanged on POSIX; `Auto` matches
+        /// `bun_paths::is_absolute`, so a native-relative part is always
+        /// anchored at `top_level_dir`.
+        pub fn abs_buf_checked_native<'b>(
+            &self,
+            parts: &[&[u8]],
+            buf: &'b mut [u8],
+        ) -> Option<&'b [u8]> {
+            use bun_paths::resolve_path::{join_abs_string_buf_checked, platform};
+            join_abs_string_buf_checked::<platform::Auto>(self.top_level_dir, buf, parts)
+        }
+
         /// Normalizes `str` (separators, `.`/`..` segments) into `buf`.
         pub fn normalize_buf<'b>(&self, buf: &'b mut [u8], str: &[u8]) -> &'b [u8] {
             use bun_paths::resolve_path::{normalize_string_buf, platform};

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -361,8 +361,7 @@ pub mod fs {
             join_abs_string_buf_checked::<platform::Loose>(self.top_level_dir, buf, parts)
         }
 
-        /// `abs_buf_checked` with host-native (`platform::Auto`) absolute-path
-        /// semantics, matching `bun_paths::is_absolute`.
+        /// `abs_buf_checked` with host-native (`platform::Auto`) absolute-path semantics.
         pub fn abs_buf_checked_native<'b>(
             &self,
             parts: &[&[u8]],

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -361,12 +361,8 @@ pub mod fs {
             join_abs_string_buf_checked::<platform::Loose>(self.top_level_dir, buf, parts)
         }
 
-        /// Like `abs_buf_checked`, but uses host-native absolute semantics
-        /// (`platform::Auto`) rather than `Loose`. `Loose` treats a Windows
-        /// drive prefix (`C:/…`) as absolute on every host, which would leave a
-        /// non-native-absolute path unchanged on POSIX; `Auto` matches
-        /// `bun_paths::is_absolute`, so a native-relative part is always
-        /// anchored at `top_level_dir`.
+        /// `abs_buf_checked` with host-native (`platform::Auto`) absolute-path
+        /// semantics, matching `bun_paths::is_absolute`.
         pub fn abs_buf_checked_native<'b>(
             &self,
             parts: &[&[u8]],

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1831,9 +1831,7 @@ impl<'a> Resolver<'a> {
                 let mut custom_abs_buf = bun_paths::path_buffer_pool::get();
                 for custom_path in custom_paths {
                     let custom_utf8 = custom_path.to_utf8();
-                    // As in the package-path loop below, anchor a relative entry
-                    // at cwd so `check_relative_path` joins against an absolute
-                    // source dir (matching Node's `path.resolve`).
+                    // Relative entries are anchored at cwd, like Node's `path.resolve`.
                     let source_dir: &[u8] = if bun_paths::is_absolute(custom_utf8.slice()) {
                         custom_utf8.slice()
                     } else {
@@ -1982,8 +1980,7 @@ impl<'a> Resolver<'a> {
                 let mut custom_abs_buf = bun_paths::path_buffer_pool::get();
                 for custom_path in custom_paths {
                     let custom_utf8 = custom_path.to_utf8();
-                    // Node resolves relative `paths` entries against the cwd; do
-                    // the same so `check_package_path` gets an absolute source dir.
+                    // Relative entries are anchored at cwd, like Node's `path.resolve`.
                     let source_dir: &[u8] = if bun_paths::is_absolute(custom_utf8.slice()) {
                         custom_utf8.slice()
                     } else {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1828,14 +1828,24 @@ impl<'a> Resolver<'a> {
             if let Some(custom_paths) = self.custom_dir_paths {
                 // @branchHint(.unlikely)
                 bun_core::hint::cold();
+                let mut custom_abs_buf = bun_paths::path_buffer_pool::get();
                 for custom_path in custom_paths {
                     let custom_utf8 = custom_path.to_utf8();
-                    match self.check_relative_path(
-                        custom_utf8.slice(),
-                        import_path,
-                        kind,
-                        global_cache,
-                    ) {
+                    // As in the package-path loop below, anchor a relative entry
+                    // at cwd so `check_relative_path` joins against an absolute
+                    // source dir (matching Node's `path.resolve`).
+                    let source_dir: &[u8] = if bun_paths::is_absolute(custom_utf8.slice()) {
+                        custom_utf8.slice()
+                    } else {
+                        match self
+                            .fs_ref()
+                            .abs_buf_checked_native(&[custom_utf8.slice()], &mut custom_abs_buf[..])
+                        {
+                            Some(abs) => abs,
+                            None => continue,
+                        }
+                    };
+                    match self.check_relative_path(source_dir, import_path, kind, global_cache) {
                         ResultUnion::Success(res) => return ResultUnion::Success(res),
                         ResultUnion::Pending(p) => return ResultUnion::Pending(p),
                         ResultUnion::Failure(p) => return ResultUnion::Failure(p),
@@ -1969,14 +1979,23 @@ impl<'a> Resolver<'a> {
 
             if let Some(custom_paths) = self.custom_dir_paths {
                 bun_core::hint::cold();
+                let mut custom_abs_buf = bun_paths::path_buffer_pool::get();
                 for custom_path in custom_paths {
                     let custom_utf8 = custom_path.to_utf8();
-                    match self.check_package_path(
-                        custom_utf8.slice(),
-                        import_path,
-                        kind,
-                        global_cache,
-                    ) {
+                    // Node resolves relative `paths` entries against the cwd; do
+                    // the same so `check_package_path` gets an absolute source dir.
+                    let source_dir: &[u8] = if bun_paths::is_absolute(custom_utf8.slice()) {
+                        custom_utf8.slice()
+                    } else {
+                        match self
+                            .fs_ref()
+                            .abs_buf_checked_native(&[custom_utf8.slice()], &mut custom_abs_buf[..])
+                        {
+                            Some(abs) => abs,
+                            None => continue,
+                        }
+                    };
+                    match self.check_package_path(source_dir, import_path, kind, global_cache) {
                         ResultUnion::Success(res) => return ResultUnion::Success(res),
                         ResultUnion::Pending(p) => return ResultUnion::Pending(p),
                         ResultUnion::Failure(p) => return ResultUnion::Failure(p),

--- a/test/js/node/module/module-resolve-filename-paths.test.js
+++ b/test/js/node/module/module-resolve-filename-paths.test.js
@@ -199,3 +199,73 @@ test("Module._resolveFilename throws ERR_INVALID_ARG_TYPE if options.paths is no
     Module._resolveFilename("path", __filename, false, { paths: { 0: "/some/path" } });
   }).toThrow();
 });
+
+test("require.resolve throws ERR_INVALID_ARG_TYPE when options.paths contains a non-string", () => {
+  const codeOf = fn => {
+    let err;
+    try {
+      fn();
+    } catch (e) {
+      err = e;
+    }
+    return err && err.code;
+  };
+
+  // A non-string entry is rejected at the boundary rather than coerced into a
+  // directory name. The original Fuzzilli input (a number) hit this path.
+  expect(codeOf(() => require.resolve("this-pkg-does-not-exist-zzz", { paths: [512] }))).toBe("ERR_INVALID_ARG_TYPE");
+  expect(codeOf(() => require.resolve("this-pkg-does-not-exist-zzz", { paths: ["/abs", 512] }))).toBe(
+    "ERR_INVALID_ARG_TYPE",
+  );
+});
+
+test("require.resolve does not crash when options.paths contains a non-absolute path", () => {
+  // A non-absolute entry that does not exist relative to cwd simply cannot be
+  // found. Previously this crashed the process.
+  expect(() => {
+    require.resolve("this-pkg-does-not-exist-zzz", { paths: ["this_dir_does_not_exist", "./nope"] });
+  }).toThrow();
+
+  // createRequire().resolve goes through the same resolver path.
+  let caught;
+  try {
+    Module.createRequire(join(realpathSync(tmpdir()), "x.js")).resolve("this-pkg-does-not-exist-zzz", {
+      paths: ["./rel"],
+    });
+  } catch (e) {
+    caught = e.code;
+  }
+  expect(caught).toBe("MODULE_NOT_FOUND");
+
+  // A Windows-style drive path is not absolute on POSIX (it is a relative
+  // segment there), so it must be anchored at cwd rather than tripping the
+  // resolver's absolute-path assertion.
+  expect(() => {
+    require.resolve("this-pkg-does-not-exist-zzz", { paths: ["C:/Users/nope", "C:\\Users\\nope"] });
+  }).toThrow();
+
+  // Relative specifiers take the relative-resolution path, which is a separate
+  // consumer of options.paths; the same non-absolute entries must not crash it.
+  expect(() => {
+    require.resolve("./does-not-exist", { paths: ["this_dir_does_not_exist", "C:/Users/nope", "C:\\Users\\nope"] });
+  }).toThrow();
+});
+
+test("require.resolve resolves relative options.paths entries against cwd (Node compat)", () => {
+  const { path: dir, cleanup } = createTempDir("require-resolve-relative-paths", {
+    "rel_dir/node_modules/rel-pkg/package.json": JSON.stringify({ name: "rel-pkg", main: "index.js" }),
+    "rel_dir/node_modules/rel-pkg/index.js": "module.exports = 'rel-pkg';",
+  });
+
+  const prevCwd = process.cwd();
+  try {
+    // Node's Module._nodeModulePaths does path.resolve(from), so a relative
+    // paths entry is anchored at process.cwd().
+    process.chdir(dir);
+    const resolved = require.resolve("rel-pkg", { paths: ["rel_dir"] });
+    expect(resolved).toBe(resolve(dir, "rel_dir/node_modules/rel-pkg/index.js"));
+  } finally {
+    process.chdir(prevCwd);
+    cleanup();
+  }
+});

--- a/test/js/node/module/module-resolve-filename-paths.test.js
+++ b/test/js/node/module/module-resolve-filename-paths.test.js
@@ -184,19 +184,22 @@ test("require.resolve with relative path and options.paths (Next.js use case)", 
 });
 
 test("Module._resolveFilename throws ERR_INVALID_ARG_TYPE if options.paths is not an array", () => {
+  // Use a non-builtin id: builtin ids resolve before `options.paths` is looked at.
+  const fakeParent = new Module("/some/dir/file.js");
+
   // Test with string (which is iterable but not an array)
   expect(() => {
-    Module._resolveFilename("path", __filename, false, { paths: "/some/path" });
+    Module._resolveFilename("this-pkg-does-not-exist-zzz", fakeParent, false, { paths: "/some/path" });
   }).toThrow();
 
   // Test with Set (which is iterable but not an array)
   expect(() => {
-    Module._resolveFilename("path", __filename, false, { paths: new Set(["/some/path"]) });
+    Module._resolveFilename("this-pkg-does-not-exist-zzz", fakeParent, false, { paths: new Set(["/some/path"]) });
   }).toThrow();
 
   // Test with object (not iterable)
   expect(() => {
-    Module._resolveFilename("path", __filename, false, { paths: { 0: "/some/path" } });
+    Module._resolveFilename("this-pkg-does-not-exist-zzz", fakeParent, false, { paths: { 0: "/some/path" } });
   }).toThrow();
 });
 
@@ -217,6 +220,12 @@ test("require.resolve throws ERR_INVALID_ARG_TYPE when options.paths contains a 
   expect(codeOf(() => require.resolve("this-pkg-does-not-exist-zzz", { paths: ["/abs", 512] }))).toBe(
     "ERR_INVALID_ARG_TYPE",
   );
+
+  // Builtin ids resolve before `options.paths` is validated, as in Node.
+  const fakeParent = new Module("/some/dir/file.js");
+  expect(require.resolve("node:fs", { paths: [0] })).toBe("node:fs");
+  expect(Module._resolveFilename("node:fs", fakeParent, false, { paths: [0] })).toBe("node:fs");
+  expect(Module._resolveFilename("node:fs", fakeParent, false, { paths: "notanarray" })).toBe("node:fs");
 });
 
 test("require.resolve does not crash when options.paths contains a non-absolute path", () => {


### PR DESCRIPTION
## What

`require.resolve(id, { paths })`, `Module._resolveFilename(..., { paths })` and `import.meta.resolve` pass each `options.paths` entry to the resolver as a module search directory (`custom_dir_paths`). Fuzzilli found that an entry that is not an absolute path reached `dir_info_cached`, which asserted and aborted the process:

```js
require.resolve("total", { paths: [512] });          // panic: cannot resolve DirInfo for non-absolute path: 512
require.resolve("total", { paths: ["relative_dir"] }); // panic: cannot resolve DirInfo for non-absolute path: relative_dir
```

## Status relative to main

#35349 has since replaced that assert with `return Ok(None)`, so the panic itself no longer reproduces on main. What this PR still changes:

1. Node compat for relative entries. Node anchors a relative `paths` entry at the cwd (`Module._nodeModulePaths` starts with `path.resolve(from)`). On main a relative entry silently misses. Here both `custom_dir_paths` consumers (the package-path loop and the relative-specifier loop in `resolver.rs`) absolutize a non-absolute entry against `top_level_dir` before use, with a pooled `PathBuffer` and a host-native join (`abs_buf_checked_native`, `platform::Auto`). The host-native join matters on POSIX, where `platform::Loose` treats `C:/foo` as absolute and would leave it unchanged.
2. `options.paths` conversion at the JS boundary goes through the IDL machinery, as requested in review: `Bun::convertIDL<IDLSequence<Bun::IDLStrictString>>` with a `Bindgen::LiteralConversionContext`, in both `ImportMetaObject.cpp` (`require.resolve`) and `NodeModuleModule.cpp` (`Module._resolveFilename`). A non-string entry throws `TypeError` with code `ERR_INVALID_ARG_TYPE` in both. On main, `Module._resolveFilename` coerced it with `toString`.
3. Regression tests.

Behavior after this PR (`options.paths` must still be an array):
- `require.resolve("pkg", { paths: ["rel_dir"] })` searches `<cwd>/rel_dir/node_modules` (matches Node and `test-require-resolve-opts-paths-relative.js`)
- `require.resolve("pkg", { paths: ["C:/Users/foo"] })` on POSIX is anchored at `<cwd>/C:/Users/foo`, like Node's `path.resolve`
- `require.resolve("pkg", { paths: [512] })` and `Module._resolveFilename("pkg", m, false, { paths: [512] })` throw `ERR_INVALID_ARG_TYPE` (matches Node and `test-require-resolve-invalid-paths.js`)

## Rebase notes

The rebase onto main had non-trivial conflicts. Resolution:
- `resolver.rs`, `dir_info_cached`: took main's `return Ok(None)` from #35349. An earlier revision of this PR downgraded the assert to `debug_assert!`; that is dropped.
- `ImportMetaObject.cpp`: #34660 added a hand-rolled per-element `isString()` loop on main. It is replaced by the IDL conversion above. The error name and code are unchanged (`TypeError`, `ERR_INVALID_ARG_TYPE`). The message text now comes from the IDL context (`element of options.paths must be a string`) instead of Node's exact phrasing. The vendored Node test asserts name and code only and passes.
- `NodeModuleModule.cpp`: same conversion, which makes `Module._resolveFilename` strict as well.
- `resolver/lib.rs`: kept `abs_buf_checked_native`; did not resurrect `abs_buf_z`, which main removed.
- An intermediate revision of this PR coerced non-string entries via WebIDL `DOMString`. That is gone: strict rejection matches Node, main's direction in #34660, and the vendored test, so the earlier coercion-vs-strict question is resolved toward strict.
- History is squashed to one commit on top of main.

## Test

`test/js/node/module/module-resolve-filename-paths.test.js` gains tests for non-string entries (`ERR_INVALID_ARG_TYPE`), relative and Windows-drive entries with bare and relative specifiers (no crash, `MODULE_NOT_FOUND`), `createRequire().resolve` with a relative entry, and a positive cwd-relative resolution. The file passes under both `bun test` and `node --test`. `test-require-resolve.js`, `test-require-resolve-invalid-paths.js` and `test-require-resolve-opts-paths-relative.js` from the vendored Node suite pass.

Found by Fuzzilli.

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 15 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/module/module-resolve-filename-paths.test.js
bun test v1.4.3 (f42e98025)

test/js/node/module/module-resolve-filename-paths.test.js:
(pass) Module._resolveFilename respects options.paths for package resolution [49.99ms]
(pass) Module._resolveFilename respects options.paths for relative paths [5.68ms]
(pass) Module._resolveFilename with overridden function receives options.paths [11.89ms]
(pass) require.resolve respects options.paths for package resolution [11.75ms]
(pass) require.resolve with relative path and options.paths (Next.js use case) [8.31ms]
(pass) Module._resolveFilename throws ERR_INVALID_ARG_TYPE if options.paths is not an array [8.90ms]
223 | 
224 |   // Builtin ids resolve before `options.paths` is validated, as in Node.
225 |   const fakeParent = new Module("/some/dir/file.js");
226 |   expect(require.resolve("node:fs", { paths: [0] })).toBe("node:fs");
227 |   expect(Module._resolveFilename("node:fs", fakeParent, false, { paths: [0] })).toBe("node:fs");
228 |   expect(Module._resolveFilename("node:fs", fake
... (truncated)

release without fix: 2 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/node/module/module-resolve-filename-paths.test.js:
(pass) Module._resolveFilename respects options.paths for package resolution [1.02ms]
(pass) Module._resolveFilename respects options.paths for relative paths [0.24ms]
(pass) Module._resolveFilename with overridden function receives options.paths [0.49ms]
(pass) require.resolve respects options.paths for package resolution [0.40ms]
(pass) require.resolve with relative path and options.paths (Next.js use case) [0.42ms]
(pass) Module._resolveFilename throws ERR_INVALID_ARG_TYPE if options.paths is not an array [0.12ms]
223 | 
224 |   // Builtin ids resolve before `options.paths` is validated, as in Node.
225 |   const fakeParent = new Module("/some/dir/file.js");
226 |   expect(require.resolve("node:fs", { paths: [0] })).toBe("node:fs");
227 |   expect(Module._resolveFilename("node:fs", fakeParent, false, { paths: [0] })).toBe("node:fs");
228 |   expect(Module._resolveFilename("node:fs", fakeParent, false, { paths: "notanarray" })).toBe("node:fs");
                      ^
TypeError: options.paths must be an array
      at <anonymous> (/workspace/bun/test/js/node/module/mod
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/module/module-resolve-filename-paths.test.js
bun test v1.4.3 (f42e98025)

test/js/node/module/module-resolve-filename-paths.test.js:
(pass) Module._resolveFilename respects options.paths for package resolution [51.81ms]
(pass) Module._resolveFilename respects options.paths for relative paths [8.12ms]
(pass) Module._resolveFilename with overridden function receives options.paths [11.87ms]
(pass) require.resolve respects options.paths for package resolution [9.23ms]
(pass) require.resolve with relative path and options.paths (Next.js use case) [10.33ms]
(pass) Module._resolveFilename throws ERR_INVALID_ARG_TYPE if options.paths is not an array [9.83ms]
(pass) require.resolve throws ERR_INVALID_ARG_TYPE when options.paths contains a non-string [9.79ms]
(pass) require.resolve does not crash when options.paths contains a non-absolute path [13.26ms]
(pass) require.resolve resolves relative options.paths entries against cwd (Node compat) [11.59ms]

 9 pass
 0 fail
 20 expect() calls
Ran 9 tests across 1 file. [2.46s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     625143d9c1
  features     lto, baseline

24 deps, 131 codegen, 2175 objects in 1115ms

ninja: Entering directory `/workspace/bun/build/release'
[1/2863] mkdir obj
[2/2863] mkdir pch
[3/2863] mkdir stamps
[4/2863] mkdir codegen
[5/2863] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [9.00ms]
[6/2863] gen ErrorCode+*.h
[7/2863] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [4.00ms]
[8/2863] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [8.00ms]
[9/2863] fetch WebKit
[WebKit] up to date
[10/2863] fetch mimalloc
[mimalloc] up to date
[11/2863] fetch icu
[icu] up to date
[12/2863] fetch tinycc
[tinycc] up to date
[13/2863] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[14/2863] gen .bind.ts → GeneratedBindings.c
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ImportMetaObject.cpp              | 41 +++++------
 src/jsc/modules/NodeModuleModule.cpp               | 41 +++++------
 src/resolver/lib.rs                                | 10 +++
 src/resolver/resolver.rs                           | 40 +++++++---
 .../module/module-resolve-filename-paths.test.js   | 85 +++++++++++++++++++++-
 5 files changed, 156 insertions(+), 61 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 15

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/bindings/ImportMetaObject.cpp                         7     10     60
src/jsc/modules/NodeModuleModule.cpp                          7     11     61
src/resolver/lib.rs                                           8      5     60
src/resolver/resolver.rs                                     22     13     61
…st/js/node/module/module-resolve-filename-paths.test.js     12     14     60
```

</details>

<!-- robobun:evidence:end -->