### PR TITLE
cli: add `--json` / `--yaml` to eval and print result in that format

### DIFF
--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -533,6 +533,10 @@ _bun_repl_completion() {
         '(-p --print)-e[Evaluate argument as a script, then exit]:script' \
         '(-e --eval)--print[Evaluate argument as a script, print the result, then exit]:script' \
         '(-e --eval)-p[Evaluate argument as a script, print the result, then exit]:script' \
+        '--json[Evaluate argument as a script, print the result as JSON, then exit]:script' \
+        '--yaml[Evaluate argument as a script, print the result as YAML, then exit]:script' \
+        '--json-indent[Number of spaces for --json indentation. Default 2]:indent' \
+        '--yaml-indent[Number of spaces for --yaml indentation. Default 2]:indent' \
         '--preload[Import a module before other modules are loaded]:preload' \
         '-r[Import a module before other modules are loaded]:preload' \
         '--smol[Use less memory, but run garbage collection more often]' \

--- a/docs/snippets/cli/run.mdx
+++ b/docs/snippets/cli/run.mdx
@@ -22,6 +22,22 @@ bun run <file or script>
   Evaluate argument as a script and print the result. Alias: <code>-p</code>
 </ParamField>
 
+<ParamField path="--json" type="string">
+  Evaluate argument as a script and print the result as JSON.
+</ParamField>
+
+<ParamField path="--yaml" type="string">
+  Evaluate argument as a script and print the result as YAML.
+</ParamField>
+
+<ParamField path="--json-indent" type="number">
+  Number of spaces for <code>--json</code> indentation. Default <code>2</code>.
+</ParamField>
+
+<ParamField path="--yaml-indent" type="number">
+  Number of spaces for <code>--yaml</code> indentation. Default <code>2</code>.
+</ParamField>
+
 <ParamField path="--help" type="boolean">
   Display this menu and exit. Alias: <code>-h</code>
 </ParamField>

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -567,6 +567,16 @@ pub struct RuntimeOptions {
 pub struct Eval {
     pub script: Box<[u8]>,
     pub eval_and_print: bool,
+    pub print_format: EvalPrintFormat,
+    pub print_indent: u32,
+}
+
+#[derive(Default, Clone, Copy, PartialEq, Eq)]
+pub enum EvalPrintFormat {
+    #[default]
+    Inspect,
+    Json,
+    Yaml,
 }
 
 pub struct CpuProf {

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -37,7 +37,28 @@ pub(crate) fn stringify(global: &JSGlobalObject, call_frame: &CallFrame) -> JsRe
         )));
     }
 
-    let mut stringifier = Stringifier::init(global, space_value)?;
+    let space = Space::init(global, space_value)?;
+    stringify_with_space(global, value, space)
+}
+
+pub(crate) fn stringify_with_indent(
+    global: &JSGlobalObject,
+    value: JSValue,
+    indent: u32,
+) -> JsResult<JSValue> {
+    if value.is_undefined() || value.is_symbol() || value.is_function() {
+        return Ok(JSValue::UNDEFINED);
+    }
+    let space = if indent == 0 {
+        Space::Minified
+    } else {
+        Space::Number(indent.min(10))
+    };
+    stringify_with_space(global, value, space)
+}
+
+fn stringify_with_space(global: &JSGlobalObject, value: JSValue, space: Space) -> JsResult<JSValue> {
+    let mut stringifier = Stringifier::init(space)?;
 
     if let Err(err) = stringifier.find_anchors_and_aliases(global, value, ValueOrigin::Root) {
         return match err {
@@ -186,7 +207,7 @@ impl From<JsError> for StringifyError {
 bun_core::oom_from_alloc!(StringifyError);
 
 impl Stringifier {
-    pub(crate) fn init(global: &JSGlobalObject, space_value: JSValue) -> JsResult<Stringifier> {
+    pub(crate) fn init(space: Space) -> JsResult<Stringifier> {
         let mut prop_names: StringHashMap<usize> = StringHashMap::default();
         // always rename anchors named "root" to avoid collision with
         // root anchor/alias
@@ -199,7 +220,7 @@ impl Stringifier {
             known_collections: HashMap::default(),
             array_item_counter: 0,
             prop_names,
-            space: Space::init(global, space_value)?,
+            space,
         })
     }
 

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -57,7 +57,11 @@ pub(crate) fn stringify_with_indent(
     stringify_with_space(global, value, space)
 }
 
-fn stringify_with_space(global: &JSGlobalObject, value: JSValue, space: Space) -> JsResult<JSValue> {
+fn stringify_with_space(
+    global: &JSGlobalObject,
+    value: JSValue,
+    space: Space,
+) -> JsResult<JSValue> {
     let mut stringifier = Stringifier::init(space)?;
 
     if let Err(err) = stringifier.find_anchors_and_aliases(global, value, ValueOrigin::Root) {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -21,7 +21,9 @@ use bun_core::{self, FeatureFlags, Global, Output, env_var};
 use bun_jsc::RegularExpression;
 use bun_jsc::regular_expression::Flags as RegexFlags;
 use bun_options_types::code_coverage_options::Reporters as CoverageReporters;
-use bun_options_types::context::{Debugger, DebuggerEnable, HotReload, MacroOptions, Shard};
+use bun_options_types::context::{
+    Debugger, DebuggerEnable, EvalPrintFormat, HotReload, MacroOptions, Shard,
+};
 use bun_options_types::schema::api;
 use bun_paths::resolve_path;
 use bun_paths::{PathBuffer, platform};
@@ -37,6 +39,20 @@ use crate::cli::{DefineColonList, LoaderColonList};
 #[inline]
 fn slice_to_owned(input: &[&[u8]]) -> Vec<Box<[u8]>> {
     input.iter().map(|s| Box::<[u8]>::from(*s)).collect()
+}
+
+fn parse_indent_flag(value: Option<&[u8]>, flag_name: &[u8]) -> u32 {
+    let Some(value) = value else { return 2 };
+    match strings::parse_int::<u32>(value, 10) {
+        Ok(v) => v.min(10),
+        Err(_) => {
+            Output::err_generic(
+                "Invalid value for {}: \"{}\". Must be an integer between 0 and 10\n",
+                (BStr::new(flag_name), BStr::new(value)),
+            );
+            Global::exit(1);
+        }
+    }
 }
 
 pub(crate) fn loader_resolver(input: &[u8]) -> Result<api::Loader, bun_core::Error> {
@@ -253,6 +269,18 @@ pub(crate) const RUNTIME_PARAMS_: &[ParamType] = &[
     parse_param!("-e, --eval <STR>                  Evaluate argument as a script"),
     parse_param!(
         "-p, --print <STR>                 Evaluate argument as a script and print the result"
+    ),
+    parse_param!(
+        "--json <STR>                      Evaluate argument as a script and print the result as JSON"
+    ),
+    parse_param!(
+        "--yaml <STR>                      Evaluate argument as a script and print the result as YAML"
+    ),
+    parse_param!(
+        "--json-indent <NUM>               Number of spaces for --json indentation. Default 2"
+    ),
+    parse_param!(
+        "--yaml-indent <NUM>               Number of spaces for --yaml indentation. Default 2"
     ),
     parse_param!(
         "--prefer-offline                  Skip staleness checks for packages in the Bun runtime and resolve from disk"
@@ -1096,6 +1124,18 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> Result<api::TransformOptions,
         if let Some(script) = args.option(b"--print") {
             ctx.runtime_options.eval.script = script.into();
             ctx.runtime_options.eval.eval_and_print = true;
+        } else if let Some(script) = args.option(b"--json") {
+            ctx.runtime_options.eval.script = script.into();
+            ctx.runtime_options.eval.eval_and_print = true;
+            ctx.runtime_options.eval.print_format = EvalPrintFormat::Json;
+            ctx.runtime_options.eval.print_indent =
+                parse_indent_flag(args.option(b"--json-indent"), b"--json-indent");
+        } else if let Some(script) = args.option(b"--yaml") {
+            ctx.runtime_options.eval.script = script.into();
+            ctx.runtime_options.eval.eval_and_print = true;
+            ctx.runtime_options.eval.print_format = EvalPrintFormat::Yaml;
+            ctx.runtime_options.eval.print_indent =
+                parse_indent_flag(args.option(b"--yaml-indent"), b"--yaml-indent");
         } else if let Some(script) = args.option(b"--eval") {
             ctx.runtime_options.eval.script = script.into();
         }

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1291,12 +1291,7 @@ pub mod command {
                             && matches!(
                                 argv.get(1).map(bun_core::ZStr::as_bytes),
                                 Some(
-                                    b"-e"
-                                        | b"-p"
-                                        | b"--eval"
-                                        | b"--print"
-                                        | b"--json"
-                                        | b"--yaml"
+                                    b"-e" | b"-p" | b"--eval" | b"--print" | b"--json" | b"--yaml"
                                 )
                             )
                     }

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1284,13 +1284,20 @@ pub mod command {
                 let empty_eval = match argv.len() {
                     2 => matches!(
                         argv.get(1).map(bun_core::ZStr::as_bytes),
-                        Some(b"-e=" | b"-p=" | b"--eval=" | b"--print=")
+                        Some(b"-e=" | b"-p=" | b"--eval=" | b"--print=" | b"--json=" | b"--yaml=")
                     ),
                     3 => {
                         argv.get(2).is_some_and(|a| a.as_bytes().is_empty())
                             && matches!(
                                 argv.get(1).map(bun_core::ZStr::as_bytes),
-                                Some(b"-e" | b"-p" | b"--eval" | b"--print")
+                                Some(
+                                    b"-e"
+                                        | b"-p"
+                                        | b"--eval"
+                                        | b"--print"
+                                        | b"--json"
+                                        | b"--yaml"
+                                )
                             )
                     }
                     _ => false,

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1645,19 +1645,12 @@ impl Run {
                     }
                     result
                 };
-                // Zig: `to_print.print(vm.global, .Log, .Log)`.
-                // SAFETY: `vals[..1]` is the single stack `to_print`; null
-                // `ctype` routes to the VM's stdout/stderr default.
-                unsafe {
-                    bun_jsc::ConsoleObject::message_with_type_and_level(
-                        ::core::ptr::null_mut(),
-                        bun_jsc::ConsoleObject::MessageType::Log,
-                        bun_jsc::ConsoleObject::MessageLevel::Log,
-                        vm.global(),
-                        &raw const to_print,
-                        1,
-                    );
-                }
+                Self::dump_eval_result(
+                    vm,
+                    to_print,
+                    ctx.runtime_options.eval.print_format,
+                    ctx.runtime_options.eval.print_indent,
+                );
             }
 
             vm.on_before_exit();
@@ -1687,6 +1680,60 @@ impl Run {
         crate::webcore::bake_response::fix_dead_code_elimination();
         bun_crash_handler::fix_dead_code_elimination();
         vm.global_exit();
+    }
+
+    fn dump_eval_result(
+        vm: &mut VirtualMachine,
+        to_print: JSValue,
+        format: bun_options_types::context::EvalPrintFormat,
+        indent: u32,
+    ) {
+        use bun_options_types::context::EvalPrintFormat;
+
+        let global = vm.global();
+        let serialized: bun_jsc::JsResult<bun_core::String> = match format {
+            EvalPrintFormat::Inspect => {
+                // SAFETY: `vals[..1]` is the single stack `to_print`; null
+                // `ctype` routes to the VM's stdout/stderr default.
+                unsafe {
+                    bun_jsc::ConsoleObject::message_with_type_and_level(
+                        ::core::ptr::null_mut(),
+                        bun_jsc::ConsoleObject::MessageType::Log,
+                        bun_jsc::ConsoleObject::MessageLevel::Log,
+                        global,
+                        &raw const to_print,
+                        1,
+                    );
+                }
+                return;
+            }
+            EvalPrintFormat::Json => {
+                let mut out = bun_core::String::EMPTY;
+                to_print
+                    .json_stringify(global, indent, &mut out)
+                    .map(|_| out)
+            }
+            EvalPrintFormat::Yaml => {
+                crate::api::YAMLObject::stringify_with_indent(global, to_print, indent)
+                    .and_then(|v| v.to_bun_string(global))
+            }
+        };
+
+        match serialized {
+            Ok(s) => {
+                let owned = bun_core::OwnedString::new(s);
+                let utf8 = owned.to_utf8();
+                let _ = Output::writer().write_all(utf8.slice());
+                if !utf8.slice().ends_with(b"\n") {
+                    let _ = Output::writer().write_all(b"\n");
+                }
+                Output::flush();
+            }
+            Err(err) => {
+                global.report_uncaught_exception_from_error(err);
+                vm.exit_handler.exit_code = 1;
+            }
+        }
     }
 }
 

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -94,6 +94,86 @@ for (const flag of ["-e", "--print"]) {
   });
 }
 
+describe.each([
+  {
+    flag: "--json",
+    indentFlag: "--json-indent",
+    pretty: '{\n  "a": 1,\n  "b": [\n    2,\n    3\n  ]\n}\n',
+    compact: '{"a":1,"b":[2,3]}\n',
+    indent4: '{\n    "a": 1,\n    "b": [\n        2,\n        3\n    ]\n}\n',
+  },
+  {
+    flag: "--yaml",
+    indentFlag: "--yaml-indent",
+    pretty: "a: 1\nb: \n  - 2\n  - 3\n",
+    compact: "{a: 1,b: [2,3]}\n",
+    indent4: "a: 1\nb: \n    - 2\n    - 3\n",
+  },
+])("bun $flag", ({ flag, indentFlag, pretty, compact, indent4 }) => {
+  const expr = "({a: 1, b: [2, 3]})";
+
+  test("default indent is 2", () => {
+    const { stdout, stderr, exitCode } = Bun.spawnSync({
+      cmd: [bunExe(), flag, expr],
+      env: bunEnv,
+    });
+    expect(stderr.toString("utf8")).toBe("");
+    expect(stdout.toString("utf8")).toBe(pretty);
+    expect(exitCode).toBe(0);
+  });
+
+  test(`${indentFlag} 0`, () => {
+    const { stdout, stderr, exitCode } = Bun.spawnSync({
+      cmd: [bunExe(), indentFlag, "0", flag, expr],
+      env: bunEnv,
+    });
+    expect(stderr.toString("utf8")).toBe("");
+    expect(stdout.toString("utf8")).toBe(compact);
+    expect(exitCode).toBe(0);
+  });
+
+  test(`${indentFlag} 4`, () => {
+    const { stdout, stderr, exitCode } = Bun.spawnSync({
+      cmd: [bunExe(), indentFlag, "4", flag, expr],
+      env: bunEnv,
+    });
+    expect(stderr.toString("utf8")).toBe("");
+    expect(stdout.toString("utf8")).toBe(indent4);
+    expect(exitCode).toBe(0);
+  });
+
+  test("awaits promises", () => {
+    const { stdout, stderr, exitCode } = Bun.spawnSync({
+      cmd: [bunExe(), flag, "Promise.resolve({a: 1, b: [2, 3]})"],
+      env: bunEnv,
+    });
+    expect(stderr.toString("utf8")).toBe("");
+    expect(stdout.toString("utf8")).toBe(pretty);
+    expect(exitCode).toBe(0);
+  });
+
+  test(`${indentFlag} rejects non-integers`, () => {
+    const { stderr, exitCode } = Bun.spawnSync({
+      cmd: [bunExe(), indentFlag, "foo", flag, "1"],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    expect(stderr.toString("utf8")).toContain("Must be an integer between 0 and 10");
+    expect(exitCode).toBe(1);
+  });
+});
+
+test("bun --json reports stringify errors and exits non-zero", () => {
+  const { stdout, stderr, exitCode } = Bun.spawnSync({
+    cmd: [bunExe(), "--json", "const a = {}; a.self = a; a"],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  expect(stdout.toString("utf8")).toBe("");
+  expect(stderr.toString("utf8")).toContain("cyclic");
+  expect(exitCode).toBe(1);
+});
+
 describe("--print for cjs/esm", () => {
   test("eval result between esm imports", async () => {
     let cwd = tmpdirSync();


### PR DESCRIPTION
Adds `--json <expr>` and `--yaml <expr>` as siblings of `-p` / `--print`: evaluate the expression (awaiting promises, same as `--print`) and write the result through `JSON.stringify` / `Bun.YAML.stringify` instead of `util.inspect`.

```sh
$ bun --json 'process.versions' | jq .node
"24.3.0"

$ bun --yaml 'await Bun.file("package.json").json()'
name: bun
version: 1.4.0
...
```

Output is pretty by default (2-space indent). `--json-indent <N>` / `--yaml-indent <N>` set the `space` argument; `0` gives compact single-line output.

Serialization errors (e.g. cyclic structure for JSON) are reported as uncaught exceptions and exit non-zero.

`--json5` / `--toml` deferred — `Bun.TOML.stringify` doesn't exist yet, and JSON5 can follow the same pattern once wanted.