### PR TITLE
crypto: X509Certificate#checkIssued() should return a boolean

### DIFF
--- a/src/jsc/bindings/JSX509CertificatePrototype.cpp
+++ b/src/jsc/bindings/JSX509CertificatePrototype.cpp
@@ -364,8 +364,7 @@ JSC_DEFINE_HOST_FUNCTION(jsX509CertificateProtoFuncCheckIssued, (JSGlobalObject 
 
     auto check = thisObject->checkIssued(globalObject, issuer);
     RETURN_IF_EXCEPTION(scope, {});
-    if (!check) return JSValue::encode(jsUndefined());
-    return JSValue::encode(issuer);
+    return JSValue::encode(jsBoolean(check));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsX509CertificateProtoFuncCheckPrivateKey, (JSGlobalObject * globalObject, CallFrame* callFrame))

--- a/test/js/node/crypto/x509-subclass.test.ts
+++ b/test/js/node/crypto/x509-subclass.test.ts
@@ -10,8 +10,13 @@ import path from "node:path";
 // Also, X509Certificate.prototype was undefined because finishCreation()
 // did not call putDirectWithoutTransition for the prototype property.
 
-const certPath = path.join(import.meta.dir, "..", "test", "fixtures", "keys", "agent1-cert.pem");
+const keysDir = path.join(import.meta.dir, "..", "test", "fixtures", "keys");
+const certPath = path.join(keysDir, "agent1-cert.pem");
 const certPem = readFileSync(certPath);
+// ca1 issued agent1-cert and is itself self-signed.
+const ca1Pem = readFileSync(path.join(keysDir, "ca1-cert.pem"));
+// ca2 is an unrelated self-signed CA.
+const ca2Pem = readFileSync(path.join(keysDir, "ca2-cert.pem"));
 
 describe("X509Certificate", () => {
   test("constructor has .prototype property", () => {
@@ -69,5 +74,43 @@ describe("X509Certificate", () => {
     expect(cert.issuer).toBeDefined();
     expect(cert.serialNumber).toBeDefined();
     expect(typeof cert.fingerprint).toBe("string");
+  });
+});
+
+// checkIssued() must return a boolean to match Node.js. Previously Bun
+// returned the issuer certificate object on success and undefined on failure.
+// https://github.com/oven-sh/bun/issues/31570
+describe("X509Certificate#checkIssued", () => {
+  const agent1 = new X509Certificate(certPem);
+  const ca1 = new X509Certificate(ca1Pem);
+  const ca2 = new X509Certificate(ca2Pem);
+
+  test("returns true when the certificate was issued by the other certificate", () => {
+    const result = agent1.checkIssued(ca1);
+    expect(typeof result).toBe("boolean");
+    expect(result).toBe(true);
+  });
+
+  test("returns true for a self-signed certificate checked against itself", () => {
+    const result = ca1.checkIssued(ca1);
+    expect(typeof result).toBe("boolean");
+    expect(result).toBe(true);
+  });
+
+  test("returns false for an unrelated issuer", () => {
+    const result = agent1.checkIssued(ca2);
+    expect(typeof result).toBe("boolean");
+    expect(result).toBe(false);
+  });
+
+  test("returns false for a non-self-signed certificate checked against itself", () => {
+    const result = agent1.checkIssued(agent1);
+    expect(typeof result).toBe("boolean");
+    expect(result).toBe(false);
+  });
+
+  test("throws ERR_INVALID_ARG_TYPE when the argument is not an X509Certificate", () => {
+    expect(() => agent1.checkIssued({} as any)).toThrow();
+    expect(() => agent1.checkIssued("" as any)).toThrow();
   });
 });


### PR DESCRIPTION
Fixes #31570

## Problem

`X509Certificate.prototype.checkIssued(otherCert)` must return a **boolean** in Node.js. Bun returned the issuer certificate object on success and `undefined` on failure.

```js
import { X509Certificate } from "node:crypto";
import { readFileSync } from "node:fs";

const cert = new X509Certificate(readFileSync("ca1-cert.pem")); // self-signed
cert.checkIssued(cert);        // Node: true      | Bun (before): <the certificate>
typeof cert.checkIssued(cert); // Node: "boolean" | Bun (before): "object"
```

## Cause

`jsX509CertificateProtoFuncCheckIssued` in `src/jsc/bindings/JSX509CertificatePrototype.cpp` copied the return pattern from `checkHost`/`checkEmail`/`checkIP`, where returning the validated value (or `undefined`) is the correct Node contract:

```cpp
if (!check) return JSValue::encode(jsUndefined());
return JSValue::encode(issuer);
```

But `checkIssued` returns a boolean in Node. The underlying `JSX509Certificate::checkIssued` already returns a C++ `bool` correctly — only the JS wrapper's return value was wrong. This has been the case since the method was first implemented (#16173); it is not a regression.

## Fix

Return the boolean directly:

```cpp
auto check = thisObject->checkIssued(globalObject, issuer);
RETURN_IF_EXCEPTION(scope, {});
return JSValue::encode(jsBoolean(check));
```

## Verification

Added coverage in `test/js/node/crypto/x509-subclass.test.ts` (the existing `node:crypto` X509Certificate test file) asserting `typeof === "boolean"` for:

- `agent1.checkIssued(ca1)` → `true` (issued by)
- `ca1.checkIssued(ca1)` → `true` (self-signed — the reported case)
- `agent1.checkIssued(ca2)` → `false` (unrelated issuer)
- `agent1.checkIssued(agent1)` → `false` (not self-signed)
- invalid argument throws `ERR_INVALID_ARG_TYPE`

The tests fail against the current release (returning `"object"`/`"undefined"`) and pass with this change. The official Node.js compat test `test/js/node/test/parallel/test-crypto-x509.js` still passes.