### PR TITLE
sql: keep all-digit column names with '_' separators as named keys

### DIFF
--- a/src/jsc/bindings/SQLClient.cpp
+++ b/src/jsc/bindings/SQLClient.cpp
@@ -350,7 +350,10 @@ static JSC::JSValue toJS(JSC::Structure* structure, DataCell* cells, uint32_t co
                 if (cell.isIndexedColumn()) {
                     JSValue value = toJS(vm, globalObject, cell);
                     RETURN_IF_EXCEPTION(scope, {});
-                    ASSERT(cell.index < count);
+                    // cell.index is the column name parsed as an integer, not a
+                    // positional ordinal, so it can be >= count (e.g.
+                    // `select 1 as "8"` -> index 8). putDirectIndex handles
+                    // sparse indices, same as the indexed-only fast path above.
                     ASSERT(!cell.isNamedColumn());
                     ASSERT(!cell.isDuplicateColumn());
                     object->putDirectIndex(globalObject, cell.index, value);

--- a/src/sql/shared/ColumnIdentifier.rs
+++ b/src/sql/shared/ColumnIdentifier.rs
@@ -16,11 +16,23 @@ impl ColumnIdentifier {
             _ => false,
         };
         if might_be_int {
-            if let Ok(int) = bun_core::parse_unsigned::<u64>(name.slice(), 10) {
-                // keep `<` (not ≤): JSC indexed-property bound
-                if int < u32::MAX as u64 {
-                    return Ok(Self::Index(int as u32));
+            // Only `'0'..='9'` — not `parse_unsigned`, which skips embedded `_`
+            // separators and would turn a column named `2024_01` into `202401`.
+            // `U32_MAX_DIGITS` caps the length, so `u64` cannot overflow here.
+            let mut int: u64 = 0;
+            let mut all_digits = true;
+            for &byte in name.slice() {
+                match byte {
+                    b'0'..=b'9' => int = int * 10 + (byte - b'0') as u64,
+                    _ => {
+                        all_digits = false;
+                        break;
+                    }
                 }
+            }
+            // keep `<` (not ≤): JSC indexed-property bound
+            if all_digits && int < u32::MAX as u64 {
+                return Ok(Self::Index(int as u32));
             }
         }
 

--- a/test/js/sql/sql-mysql-column-name-digits.fixture.ts
+++ b/test/js/sql/sql-mysql-column-name-digits.fixture.ts
@@ -1,0 +1,38 @@
+// Reproducer: a result column whose name is all digits with an interior
+// underscore (e.g. `2024_01`) must stay a NAMED key. The shared
+// ColumnIdentifier classifier used to route the name through an integer parse
+// that skips `_` digit separators, so `2024_01` parsed to 202401 and was
+// misclassified as a positional array index. That corrupted the result object
+// (the `2024_01` key vanished, its value landing at index 202401) and, when
+// mixed with a normal named column, tripped a debug-build assertion
+// (`cell.index < count`) in the object-building slow path.
+//
+// Runs against a real MySQL/MariaDB server (the classifier is shared with
+// Postgres, so this also covers that decoder). Prints "CONNECTED" after the
+// first successful round-trip so the harness can tell "no DB here" apart from
+// "connected then produced the wrong shape".
+
+import { SQL, randomUUIDv7 } from "bun";
+
+const url = process.env.MYSQL_URL;
+if (!url) throw new Error("MYSQL_URL is required");
+
+const tls = process.env.CA_PATH ? { ca: Bun.file(process.env.CA_PATH) } : undefined;
+await using sql = new SQL({ url, tls, max: 1 });
+
+// Priming query doubles as a connectivity check.
+await sql`SELECT 1 AS x`;
+console.log("CONNECTED");
+
+const t = "col_digits_" + randomUUIDv7("hex").replaceAll("-", "");
+
+// `2024_01`/`2024_02` are digits+underscore; `8` is a pure digit whose value
+// (8) exceeds the column count — the combination that used to trip the
+// `cell.index < count` assertion in the mixed named+indexed slow path. A
+// leading `product` keeps the result on that slow path.
+await sql`CREATE TEMPORARY TABLE ${sql(t)} (product VARCHAR(64), \`2024_01\` INT, \`2024_02\` INT, \`8\` INT)`;
+await sql`INSERT INTO ${sql(t)} ${sql({ product: "widget", "2024_01": 10, "2024_02": 20, "8": 42 })}`;
+
+const [row] = await sql`SELECT product, \`2024_01\`, \`2024_02\`, \`8\` FROM ${sql(t)}`;
+
+console.log(JSON.stringify({ row, keys: Object.keys(row).sort() }));

--- a/test/js/sql/sql-mysql-column-name-digits.test.ts
+++ b/test/js/sql/sql-mysql-column-name-digits.test.ts
@@ -16,8 +16,8 @@
 
 import { SQL } from "bun";
 import { beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, describeWithContainer, isDockerEnabled, isLinux } from "harness";
 import { existsSync } from "fs";
+import { bunEnv, bunExe, describeWithContainer, isDockerEnabled, isLinux } from "harness";
 import path from "path";
 
 const fixture = path.join(import.meta.dir, "sql-mysql-column-name-digits.fixture.ts");

--- a/test/js/sql/sql-mysql-column-name-digits.test.ts
+++ b/test/js/sql/sql-mysql-column-name-digits.test.ts
@@ -1,0 +1,237 @@
+// A result column whose name is all digits with an interior underscore (e.g.
+// `2024_01`) must stay a NAMED key. The shared ColumnIdentifier classifier was
+// rewritten from Zig to Rust; the Zig version hand-parsed only `'0'..'9'` (any
+// other byte meant "this is a name"), but the Rust port routed the name through
+// `parse_unsigned`, which — mirroring `std.fmt.parseInt` — skips embedded `_`
+// digit separators. So `2024_01` parsed to the integer 202401 and was
+// misclassified as a positional array index.
+//
+// On release 1.3.14 the row decodes as `{ product, "2024_01", "2024_02" }`; on
+// the Rust build (before this fix) `2024_01`/`2024_02` collapse to indices
+// 202401/202402, so those keys vanish and a debug build aborts on the
+// `cell.index < count` assertion in the object-building slow path.
+//
+// Uses a minimal mock MySQL server so the test runs without Docker. The
+// classifier is shared with Postgres, so this covers that decoder too.
+
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import { once } from "events";
+import net from "net";
+
+// --- MySQL wire format helpers ---------------------------------------------
+
+function u16le(n: number): Buffer {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff]);
+}
+function u24le(n: number): Buffer {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff]);
+}
+function u32le(n: number): Buffer {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >>> 24) & 0xff]);
+}
+function packet(seq: number, payload: Buffer): Buffer {
+  return Buffer.concat([u24le(payload.length), Buffer.from([seq]), payload]);
+}
+function lenenc(n: number): Buffer {
+  if (n < 0xfb) return Buffer.from([n]);
+  if (n < 0xffff) return Buffer.concat([Buffer.from([0xfc]), u16le(n)]);
+  throw new Error("lenenc: not needed for this test");
+}
+function lenencStr(s: string): Buffer {
+  const buf = Buffer.from(s, "utf-8");
+  return Buffer.concat([lenenc(buf.length), buf]);
+}
+
+// --- Capability flags ------------------------------------------------------
+
+const CLIENT_PROTOCOL_41 = 1 << 9;
+const CLIENT_SECURE_CONNECTION = 1 << 15;
+const CLIENT_PLUGIN_AUTH = 1 << 19;
+const CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA = 1 << 21;
+const CLIENT_DEPRECATE_EOF = 1 << 24;
+const SERVER_CAPS =
+  CLIENT_PROTOCOL_41 |
+  CLIENT_SECURE_CONNECTION |
+  CLIENT_PLUGIN_AUTH |
+  CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA |
+  CLIENT_DEPRECATE_EOF;
+
+// MYSQL_TYPE_* values. From src/sql/mysql/mysql_types.rs.
+const MYSQL_TYPE_LONG = 0x03;
+const MYSQL_TYPE_VAR_STRING = 0xfd;
+
+// --- Packet builders -------------------------------------------------------
+
+function handshakeV10(): Buffer {
+  const authData1 = Buffer.alloc(8, 0x61);
+  const authData2 = Buffer.alloc(13, 0x62);
+  authData2[12] = 0;
+  return packet(
+    0,
+    Buffer.concat([
+      Buffer.from([10]),
+      Buffer.from("mock-5.7.0\0"),
+      u32le(1),
+      authData1,
+      Buffer.from([0]),
+      u16le(SERVER_CAPS & 0xffff),
+      Buffer.from([0x2d]),
+      u16le(0x0002),
+      u16le((SERVER_CAPS >>> 16) & 0xffff),
+      Buffer.from([21]),
+      Buffer.alloc(10, 0),
+      authData2,
+      Buffer.from("mysql_native_password\0"),
+    ]),
+  );
+}
+
+function okPacket(seq: number, header = 0x00): Buffer {
+  return packet(seq, Buffer.from([header, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
+}
+
+function columnDef(name: string, type: number, flags = 0): Buffer {
+  return Buffer.concat([
+    lenencStr("def"),
+    lenencStr(""),
+    lenencStr("t"),
+    lenencStr("t"),
+    lenencStr(name),
+    lenencStr(name),
+    Buffer.from([0x0c]),
+    u16le(33),
+    u32le(1024),
+    Buffer.from([type]),
+    u16le(flags),
+    Buffer.from([0]),
+    Buffer.from([0, 0]),
+  ]);
+}
+
+function stmtPrepareOK(startSeq: number, stmtId: number, columns: Buffer[]): Buffer {
+  const packets: Buffer[] = [];
+  let seq = startSeq;
+  packets.push(
+    packet(
+      seq++,
+      Buffer.concat([
+        Buffer.from([0x00]),
+        u32le(stmtId),
+        u16le(columns.length),
+        u16le(0), // num_params
+        Buffer.from([0x00]),
+        u16le(0),
+      ]),
+    ),
+  );
+  for (const c of columns) packets.push(packet(seq++, c));
+  return Buffer.concat(packets);
+}
+
+// Binary row: 0x00 header, NULL bitmap (ceil((n + 2) / 8) bytes, all zero),
+// then one `values` buffer per column, in order.
+function binaryResultSet(startSeq: number, columns: Buffer[], values: Buffer): Buffer {
+  const packets: Buffer[] = [];
+  let seq = startSeq;
+  packets.push(packet(seq++, Buffer.from([columns.length])));
+  for (const c of columns) packets.push(packet(seq++, c));
+  const nullBitmapLen = Math.ceil((columns.length + 2) / 8);
+  packets.push(
+    packet(
+      seq++,
+      Buffer.concat([Buffer.from([0x00]), Buffer.alloc(nullBitmapLen, 0), values]),
+    ),
+  );
+  packets.push(packet(seq++, Buffer.from([0xfe, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00])));
+  return Buffer.concat(packets);
+}
+
+function startMockServer(columns: Buffer[], values: Buffer) {
+  const server = net.createServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let authed = false;
+    let stmtId = 0;
+    socket.write(handshakeV10());
+    socket.on("data", chunk => {
+      buffered = Buffer.concat([buffered, chunk]);
+      while (buffered.length >= 4) {
+        const len = buffered[0] | (buffered[1] << 8) | (buffered[2] << 16);
+        if (buffered.length < 4 + len) break;
+        const seq = buffered[3];
+        const payload = buffered.subarray(4, 4 + len);
+        buffered = buffered.subarray(4 + len);
+        if (!authed) {
+          authed = true;
+          socket.write(okPacket(seq + 1));
+          continue;
+        }
+        const cmd = payload[0];
+        if (cmd === 0x16 /* COM_STMT_PREPARE */) {
+          socket.write(stmtPrepareOK(seq + 1, ++stmtId, columns));
+        } else if (cmd === 0x17 /* COM_STMT_EXECUTE */) {
+          socket.write(binaryResultSet(seq + 1, columns, values));
+        } else if (cmd === 0x03 /* COM_QUERY */) {
+          socket.write(okPacket(seq + 1));
+        } else if (cmd === 0x19 /* COM_STMT_CLOSE */) {
+          // no response expected
+        } else {
+          socket.end();
+        }
+      }
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  return server;
+}
+
+// Runs `run(sql)` against a mock server that always replies with the given
+// columns/values (via the binary prepared-statement path that a tagged-template
+// query uses). The actual SQL text is ignored by the mock — what matters is the
+// column metadata it returns, which is how the classifier is exercised.
+async function withMockedResult<T>(
+  columns: Buffer[],
+  values: Buffer,
+  run: (sql: InstanceType<typeof SQL>) => Promise<T>,
+): Promise<T> {
+  const server = startMockServer(columns, values);
+  await once(server, "listening");
+  const { port } = server.address() as net.AddressInfo;
+  try {
+    await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
+    return await run(sql);
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+}
+
+test("a digits-with-interior-underscore column stays a named key", async () => {
+  // `2024_01`/`2024_02` must NOT be treated as the indices 202401/202402.
+  // Mixing them with a normal named column exercises the object-building slow
+  // path (named + "indexed" columns), which asserts `index < count` in debug.
+  const columns = [
+    columnDef("product", MYSQL_TYPE_VAR_STRING),
+    columnDef("2024_01", MYSQL_TYPE_LONG),
+    columnDef("2024_02", MYSQL_TYPE_LONG),
+  ];
+  const values = Buffer.concat([lenencStr("widget"), u32le(10), u32le(20)]);
+
+  const [row] = await withMockedResult(
+    columns,
+    values,
+    sql => sql`SELECT product, \`2024_01\`, \`2024_02\` FROM t`,
+  );
+  expect(row).toEqual({ product: "widget", "2024_01": 10, "2024_02": 20 });
+});
+
+test("a pure-digit column name is still treated as a positional index", async () => {
+  // Guard against over-correcting: an all-digit name like `5` has always mapped
+  // to the array index 5 (JSC indexed property), and must keep doing so.
+  const columns = [columnDef("5", MYSQL_TYPE_LONG)];
+  const values = u32le(42);
+
+  const [row] = await withMockedResult(columns, values, sql => sql`SELECT 42 AS \`5\` FROM t`);
+  // Index 5 → an object with the numeric key "5" and nothing at 0..4.
+  expect(row[5]).toBe(42);
+  expect(row["5"]).toBe(42);
+});

--- a/test/js/sql/sql-mysql-column-name-digits.test.ts
+++ b/test/js/sql/sql-mysql-column-name-digits.test.ts
@@ -215,14 +215,27 @@ test("a digits-with-interior-underscore column stays a named key", async () => {
   expect(row).toEqual({ product: "widget", "2024_01": 10, "2024_02": 20 });
 });
 
-test("a pure-digit column name is still treated as a positional index", async () => {
-  // Guard against over-correcting: an all-digit name like `5` has always mapped
-  // to the array index 5 (JSC indexed property), and must keep doing so.
+test("a pure-digit column name still round-trips", async () => {
+  // Smoke test that the fix doesn't break the common all-digit case: a column
+  // named `5` still decodes to a `5` key holding its value. (Index vs Name is
+  // not observable from JS here — both land on the same property key — so this
+  // only asserts the round-trip, not the internal classification.)
   const columns = [columnDef("5", MYSQL_TYPE_LONG)];
   const values = u32le(42);
 
   const [row] = await withMockedResult(columns, values, sql => sql`SELECT 42 AS \`5\` FROM t`);
-  // Index 5 → an object with the numeric key "5" and nothing at 0..4.
   expect(row[5]).toBe(42);
-  expect(row["5"]).toBe(42);
+});
+
+test("a named column mixed with an indexed column whose value exceeds the column count", async () => {
+  // `8` is correctly an index, but its value (8) is larger than the column
+  // count (2). Mixing it with a named column takes the object-building slow
+  // path, which used to assert `cell.index < count` (→ `8 < 2`) and abort in
+  // debug builds — even though `putDirectIndex` handles sparse indices fine
+  // (the indexed-only fast path documents and relies on exactly that).
+  const columns = [columnDef("product", MYSQL_TYPE_VAR_STRING), columnDef("8", MYSQL_TYPE_LONG)];
+  const values = Buffer.concat([lenencStr("widget"), u32le(42)]);
+
+  const [row] = await withMockedResult(columns, values, sql => sql`SELECT product, 42 AS \`8\` FROM t`);
+  expect(row).toEqual({ product: "widget", "8": 42 });
 });

--- a/test/js/sql/sql-mysql-column-name-digits.test.ts
+++ b/test/js/sql/sql-mysql-column-name-digits.test.ts
@@ -57,7 +57,7 @@ const SERVER_CAPS =
   CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA |
   CLIENT_DEPRECATE_EOF;
 
-// MYSQL_TYPE_* values. From src/sql/mysql/mysql_types.rs.
+// MYSQL_TYPE_* values. From src/sql/mysql/MySQLTypes.rs.
 const MYSQL_TYPE_LONG = 0x03;
 const MYSQL_TYPE_VAR_STRING = 0xfd;
 

--- a/test/js/sql/sql-mysql-column-name-digits.test.ts
+++ b/test/js/sql/sql-mysql-column-name-digits.test.ts
@@ -6,236 +6,82 @@
 // digit separators. So `2024_01` parsed to the integer 202401 and was
 // misclassified as a positional array index.
 //
-// On release 1.3.14 the row decodes as `{ product, "2024_01", "2024_02" }`; on
-// the Rust build (before this fix) `2024_01`/`2024_02` collapse to indices
-// 202401/202402, so those keys vanish and a debug build aborts on the
+// On release 1.3.14 the row decodes as `{ product, "2024_01", "2024_02", "8" }`;
+// on the Rust build (before this fix) `2024_01`/`2024_02` collapse to indices
+// 202401/202402, so those keys vanish — and a debug build aborts on the
 // `cell.index < count` assertion in the object-building slow path.
 //
-// Uses a minimal mock MySQL server so the test runs without Docker. The
-// classifier is shared with Postgres, so this covers that decoder too.
+// Runs against a real MySQL/MariaDB server. The classifier is shared with
+// Postgres, so this also covers that decoder.
 
-import { SQL } from "bun";
-import { expect, test } from "bun:test";
-import { once } from "events";
-import net from "net";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, describeWithContainer, isDockerEnabled } from "harness";
+import path from "path";
 
-// --- MySQL wire format helpers ---------------------------------------------
+const fixture = path.join(import.meta.dir, "sql-mysql-column-name-digits.fixture.ts");
 
-function u16le(n: number): Buffer {
-  return Buffer.from([n & 0xff, (n >> 8) & 0xff]);
-}
-function u24le(n: number): Buffer {
-  return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff]);
-}
-function u32le(n: number): Buffer {
-  return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >>> 24) & 0xff]);
-}
-function packet(seq: number, payload: Buffer): Buffer {
-  return Buffer.concat([u24le(payload.length), Buffer.from([seq]), payload]);
-}
-function lenenc(n: number): Buffer {
-  if (n < 0xfb) return Buffer.from([n]);
-  if (n < 0xffff) return Buffer.concat([Buffer.from([0xfc]), u16le(n)]);
-  throw new Error("lenenc: not needed for this test");
-}
-function lenencStr(s: string): Buffer {
-  const buf = Buffer.from(s, "utf-8");
-  return Buffer.concat([lenenc(buf.length), buf]);
+async function runFixture(url: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), fixture],
+    env: { ...bunEnv, MYSQL_URL: url },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
 }
 
-// --- Capability flags ------------------------------------------------------
-
-const CLIENT_PROTOCOL_41 = 1 << 9;
-const CLIENT_SECURE_CONNECTION = 1 << 15;
-const CLIENT_PLUGIN_AUTH = 1 << 19;
-const CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA = 1 << 21;
-const CLIENT_DEPRECATE_EOF = 1 << 24;
-const SERVER_CAPS =
-  CLIENT_PROTOCOL_41 |
-  CLIENT_SECURE_CONNECTION |
-  CLIENT_PLUGIN_AUTH |
-  CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA |
-  CLIENT_DEPRECATE_EOF;
-
-// MYSQL_TYPE_* values. From src/sql/mysql/MySQLTypes.rs.
-const MYSQL_TYPE_LONG = 0x03;
-const MYSQL_TYPE_VAR_STRING = 0xfd;
-
-// --- Packet builders -------------------------------------------------------
-
-function handshakeV10(): Buffer {
-  const authData1 = Buffer.alloc(8, 0x61);
-  const authData2 = Buffer.alloc(13, 0x62);
-  authData2[12] = 0;
-  return packet(
-    0,
-    Buffer.concat([
-      Buffer.from([10]),
-      Buffer.from("mock-5.7.0\0"),
-      u32le(1),
-      authData1,
-      Buffer.from([0]),
-      u16le(SERVER_CAPS & 0xffff),
-      Buffer.from([0x2d]),
-      u16le(0x0002),
-      u16le((SERVER_CAPS >>> 16) & 0xffff),
-      Buffer.from([21]),
-      Buffer.alloc(10, 0),
-      authData2,
-      Buffer.from("mysql_native_password\0"),
-    ]),
-  );
+function assertFixtureOutput(stdout: string, stderr: string, exitCode: number) {
+  const filteredStderr = stderr
+    .split(/\r?\n/)
+    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+  expect(filteredStderr).toBe("");
+  const lines = stdout.trim().split(/\r?\n/);
+  expect(lines[0]).toBe("CONNECTED");
+  // `2024_01`/`2024_02` must be NAMED keys (not indices 202401/202402), `8`
+  // round-trips, and nothing is dropped.
+  expect(JSON.parse(lines[1] ?? "null")).toEqual({
+    row: { product: "widget", "2024_01": 10, "2024_02": 20, "8": 42 },
+    keys: ["2024_01", "2024_02", "8", "product"],
+  });
+  expect(exitCode).toBe(0);
 }
 
-function okPacket(seq: number, header = 0x00): Buffer {
-  return packet(seq, Buffer.from([header, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
-}
-
-function columnDef(name: string, type: number, flags = 0): Buffer {
-  return Buffer.concat([
-    lenencStr("def"),
-    lenencStr(""),
-    lenencStr("t"),
-    lenencStr("t"),
-    lenencStr(name),
-    lenencStr(name),
-    Buffer.from([0x0c]),
-    u16le(33),
-    u32le(1024),
-    Buffer.from([type]),
-    u16le(flags),
-    Buffer.from([0]),
-    Buffer.from([0, 0]),
-  ]);
-}
-
-function stmtPrepareOK(startSeq: number, stmtId: number, columns: Buffer[]): Buffer {
-  const packets: Buffer[] = [];
-  let seq = startSeq;
-  packets.push(
-    packet(
-      seq++,
-      Buffer.concat([
-        Buffer.from([0x00]),
-        u32le(stmtId),
-        u16le(columns.length),
-        u16le(0), // num_params
-        Buffer.from([0x00]),
-        u16le(0),
-      ]),
-    ),
-  );
-  for (const c of columns) packets.push(packet(seq++, c));
-  return Buffer.concat(packets);
-}
-
-// Binary row: 0x00 header, NULL bitmap (ceil((n + 2) / 8) bytes, all zero),
-// then one `values` buffer per column, in order.
-function binaryResultSet(startSeq: number, columns: Buffer[], values: Buffer): Buffer {
-  const packets: Buffer[] = [];
-  let seq = startSeq;
-  packets.push(packet(seq++, Buffer.from([columns.length])));
-  for (const c of columns) packets.push(packet(seq++, c));
-  const nullBitmapLen = Math.ceil((columns.length + 2) / 8);
-  packets.push(packet(seq++, Buffer.concat([Buffer.from([0x00]), Buffer.alloc(nullBitmapLen, 0), values])));
-  packets.push(packet(seq++, Buffer.from([0xfe, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00])));
-  return Buffer.concat(packets);
-}
-
-function startMockServer(columns: Buffer[], values: Buffer) {
-  const server = net.createServer(socket => {
-    let buffered = Buffer.alloc(0);
-    let authed = false;
-    let stmtId = 0;
-    socket.write(handshakeV10());
-    socket.on("data", chunk => {
-      buffered = Buffer.concat([buffered, chunk]);
-      while (buffered.length >= 4) {
-        const len = buffered[0] | (buffered[1] << 8) | (buffered[2] << 16);
-        if (buffered.length < 4 + len) break;
-        const seq = buffered[3];
-        const payload = buffered.subarray(4, 4 + len);
-        buffered = buffered.subarray(4 + len);
-        if (!authed) {
-          authed = true;
-          socket.write(okPacket(seq + 1));
-          continue;
-        }
-        const cmd = payload[0];
-        if (cmd === 0x16 /* COM_STMT_PREPARE */) {
-          socket.write(stmtPrepareOK(seq + 1, ++stmtId, columns));
-        } else if (cmd === 0x17 /* COM_STMT_EXECUTE */) {
-          socket.write(binaryResultSet(seq + 1, columns, values));
-        } else if (cmd === 0x03 /* COM_QUERY */) {
-          socket.write(okPacket(seq + 1));
-        } else if (cmd === 0x19 /* COM_STMT_CLOSE */) {
-          // no response expected
-        } else {
-          socket.end();
-        }
-      }
+if (isDockerEnabled()) {
+  // CI: run against the docker-compose MySQL service.
+  describeWithContainer("mysql", { image: "mysql_plain" }, container => {
+    test("a digits-with-interior-underscore column stays a named key", async () => {
+      await container.ready;
+      const url = `mysql://root@${container.host}:${container.port}/bun_sql_test`;
+      const { stdout, stderr, exitCode } = await runFixture(url);
+      assertFixtureOutput(stdout, stderr, exitCode);
     });
   });
-  server.listen(0, "127.0.0.1");
-  return server;
+} else {
+  // No docker daemon (e.g. local/sandboxed environments). If a MySQL server is
+  // reachable at MYSQL_URL or the conventional local address, exercise the
+  // fixture there so the regression is still covered.
+  const url = process.env.MYSQL_URL || "mysql://root@127.0.0.1:3306/bun_sql_test";
+
+  describe("mysql (local)", () => {
+    test("a digits-with-interior-underscore column stays a named key", async () => {
+      const { stdout, stderr, exitCode } = await runFixture(url);
+      // The fixture prints "CONNECTED" after the priming query succeeds. If it
+      // never got that far, there's no MySQL to talk to in this environment;
+      // the docker-gated branch above provides the CI coverage.
+      if (!stdout.startsWith("CONNECTED")) {
+        if (process.env.MYSQL_URL) {
+          // MYSQL_URL was explicitly provided; failing to connect is a real
+          // error, not an environment without MySQL.
+          throw new Error(
+            `sql-mysql-column-name-digits: MYSQL_URL was provided but fixture never reached CONNECTED\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+          );
+        }
+        console.warn("sql-mysql-column-name-digits: no MySQL reachable at " + url + "; skipping assertions");
+        return;
+      }
+      assertFixtureOutput(stdout, stderr, exitCode);
+    });
+  });
 }
-
-// Runs `run(sql)` against a mock server that always replies with the given
-// columns/values (via the binary prepared-statement path that a tagged-template
-// query uses). The actual SQL text is ignored by the mock — what matters is the
-// column metadata it returns, which is how the classifier is exercised.
-async function withMockedResult<T>(
-  columns: Buffer[],
-  values: Buffer,
-  run: (sql: InstanceType<typeof SQL>) => Promise<T>,
-): Promise<T> {
-  const server = startMockServer(columns, values);
-  await once(server, "listening");
-  const { port } = server.address() as net.AddressInfo;
-  try {
-    await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
-    return await run(sql);
-  } finally {
-    await new Promise<void>(r => server.close(() => r()));
-  }
-}
-
-test("a digits-with-interior-underscore column stays a named key", async () => {
-  // `2024_01`/`2024_02` must NOT be treated as the indices 202401/202402.
-  // Mixing them with a normal named column exercises the object-building slow
-  // path (named + "indexed" columns), which asserts `index < count` in debug.
-  const columns = [
-    columnDef("product", MYSQL_TYPE_VAR_STRING),
-    columnDef("2024_01", MYSQL_TYPE_LONG),
-    columnDef("2024_02", MYSQL_TYPE_LONG),
-  ];
-  const values = Buffer.concat([lenencStr("widget"), u32le(10), u32le(20)]);
-
-  const [row] = await withMockedResult(columns, values, sql => sql`SELECT product, \`2024_01\`, \`2024_02\` FROM t`);
-  expect(row).toEqual({ product: "widget", "2024_01": 10, "2024_02": 20 });
-});
-
-test("a pure-digit column name still round-trips", async () => {
-  // Smoke test that the fix doesn't break the common all-digit case: a column
-  // named `5` still decodes to a `5` key holding its value. (Index vs Name is
-  // not observable from JS here — both land on the same property key — so this
-  // only asserts the round-trip, not the internal classification.)
-  const columns = [columnDef("5", MYSQL_TYPE_LONG)];
-  const values = u32le(42);
-
-  const [row] = await withMockedResult(columns, values, sql => sql`SELECT 42 AS \`5\` FROM t`);
-  expect(row[5]).toBe(42);
-});
-
-test("a named column mixed with an indexed column whose value exceeds the column count", async () => {
-  // `8` is correctly an index, but its value (8) is larger than the column
-  // count (2). Mixing it with a named column takes the object-building slow
-  // path, which used to assert `cell.index < count` (→ `8 < 2`) and abort in
-  // debug builds — even though `putDirectIndex` handles sparse indices fine
-  // (the indexed-only fast path documents and relies on exactly that).
-  const columns = [columnDef("product", MYSQL_TYPE_VAR_STRING), columnDef("8", MYSQL_TYPE_LONG)];
-  const values = Buffer.concat([lenencStr("widget"), u32le(42)]);
-
-  const [row] = await withMockedResult(columns, values, sql => sql`SELECT product, 42 AS \`8\` FROM t`);
-  expect(row).toEqual({ product: "widget", "8": 42 });
-});

--- a/test/js/sql/sql-mysql-column-name-digits.test.ts
+++ b/test/js/sql/sql-mysql-column-name-digits.test.ts
@@ -14,8 +14,10 @@
 // Runs against a real MySQL/MariaDB server. The classifier is shared with
 // Postgres, so this also covers that decoder.
 
-import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, describeWithContainer, isDockerEnabled } from "harness";
+import { SQL } from "bun";
+import { beforeAll, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, describeWithContainer, isDockerEnabled, isLinux } from "harness";
+import { existsSync } from "fs";
 import path from "path";
 
 const fixture = path.join(import.meta.dir, "sql-mysql-column-name-digits.fixture.ts");
@@ -59,27 +61,76 @@ if (isDockerEnabled()) {
     });
   });
 } else {
-  // No docker daemon (e.g. local/sandboxed environments). If a MySQL server is
-  // reachable at MYSQL_URL or the conventional local address, exercise the
-  // fixture there so the regression is still covered.
-  const url = process.env.MYSQL_URL || "mysql://root@127.0.0.1:3306/bun_sql_test";
+  // No docker daemon (e.g. the sandboxed dev/CI-gate container, which ships a
+  // native MariaDB). Connect to that real server: start it if needed, provision
+  // a passwordless TCP user over the root unix socket, and run the fixture
+  // against it. `MYSQL_URL` short-circuits all of this when set.
+  const MYSQL_SOCKET = "/run/mysqld/mysqld.sock";
+
+  async function waitForSocket(timeoutMs: number): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (existsSync(MYSQL_SOCKET)) return true;
+      await Bun.sleep(250);
+    }
+    return existsSync(MYSQL_SOCKET);
+  }
+
+  // Start the native MariaDB if its socket isn't already there. Best-effort:
+  // on environments without the binaries / permissions this just fails and the
+  // test skips.
+  async function ensureServerStarted(): Promise<boolean> {
+    if (existsSync(MYSQL_SOCKET)) return true;
+    if (Bun.which("mysqld_safe") == null) return false;
+    Bun.spawn({
+      cmd: ["mysqld_safe", "--user=mysql", "--datadir=/var/lib/mysql"],
+      stdout: "ignore",
+      stderr: "ignore",
+      stdin: "ignore",
+    }).unref();
+    return waitForSocket(30_000);
+  }
+
+  // Create a passwordless `bun_sql_test` user reachable over TCP. root uses
+  // unix_socket auth (no TCP), so provision through the socket first.
+  async function provisionTcpUser(): Promise<void> {
+    await using root = new SQL({ adapter: "mysql", username: "root", database: "mysql", path: MYSQL_SOCKET, max: 1 });
+    await root`CREATE DATABASE IF NOT EXISTS bun_sql_test`;
+    await root.unsafe("CREATE USER IF NOT EXISTS 'bun_sql_test'@'%' IDENTIFIED BY ''");
+    await root.unsafe("CREATE USER IF NOT EXISTS 'bun_sql_test'@'localhost' IDENTIFIED BY ''");
+    await root.unsafe("GRANT ALL PRIVILEGES ON *.* TO 'bun_sql_test'@'%'");
+    await root.unsafe("GRANT ALL PRIVILEGES ON *.* TO 'bun_sql_test'@'localhost'");
+    await root.unsafe("FLUSH PRIVILEGES");
+  }
+
+  let url: string | null = process.env.MYSQL_URL ?? null;
+
+  beforeAll(async () => {
+    if (url) return;
+    if (!isLinux) return;
+    try {
+      if (!(await ensureServerStarted())) return;
+      await provisionTcpUser();
+      url = "mysql://bun_sql_test@127.0.0.1:3306/bun_sql_test";
+    } catch {
+      // Leave url null → the test skips; the docker branch covers CI.
+      url = null;
+    }
+  });
 
   describe("mysql (local)", () => {
     test("a digits-with-interior-underscore column stays a named key", async () => {
-      const { stdout, stderr, exitCode } = await runFixture(url);
-      // The fixture prints "CONNECTED" after the priming query succeeds. If it
-      // never got that far, there's no MySQL to talk to in this environment;
-      // the docker-gated branch above provides the CI coverage.
-      if (!stdout.startsWith("CONNECTED")) {
-        if (process.env.MYSQL_URL) {
-          // MYSQL_URL was explicitly provided; failing to connect is a real
-          // error, not an environment without MySQL.
-          throw new Error(
-            `sql-mysql-column-name-digits: MYSQL_URL was provided but fixture never reached CONNECTED\nstdout:\n${stdout}\nstderr:\n${stderr}`,
-          );
-        }
-        console.warn("sql-mysql-column-name-digits: no MySQL reachable at " + url + "; skipping assertions");
+      if (!url) {
+        console.warn("sql-mysql-column-name-digits: no MySQL reachable in this environment; skipping assertions");
         return;
+      }
+      const { stdout, stderr, exitCode } = await runFixture(url);
+      // The fixture prints "CONNECTED" after the priming query succeeds. If a
+      // URL was resolved but the fixture never connected, that's a real error.
+      if (!stdout.startsWith("CONNECTED")) {
+        throw new Error(
+          `sql-mysql-column-name-digits: could not connect to ${url}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+        );
       }
       assertFixtureOutput(stdout, stderr, exitCode);
     });

--- a/test/js/sql/sql-mysql-column-name-digits.test.ts
+++ b/test/js/sql/sql-mysql-column-name-digits.test.ts
@@ -137,12 +137,7 @@ function binaryResultSet(startSeq: number, columns: Buffer[], values: Buffer): B
   packets.push(packet(seq++, Buffer.from([columns.length])));
   for (const c of columns) packets.push(packet(seq++, c));
   const nullBitmapLen = Math.ceil((columns.length + 2) / 8);
-  packets.push(
-    packet(
-      seq++,
-      Buffer.concat([Buffer.from([0x00]), Buffer.alloc(nullBitmapLen, 0), values]),
-    ),
-  );
+  packets.push(packet(seq++, Buffer.concat([Buffer.from([0x00]), Buffer.alloc(nullBitmapLen, 0), values])));
   packets.push(packet(seq++, Buffer.from([0xfe, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00])));
   return Buffer.concat(packets);
 }
@@ -216,11 +211,7 @@ test("a digits-with-interior-underscore column stays a named key", async () => {
   ];
   const values = Buffer.concat([lenencStr("widget"), u32le(10), u32le(20)]);
 
-  const [row] = await withMockedResult(
-    columns,
-    values,
-    sql => sql`SELECT product, \`2024_01\`, \`2024_02\` FROM t`,
-  );
+  const [row] = await withMockedResult(columns, values, sql => sql`SELECT product, \`2024_01\`, \`2024_02\` FROM t`);
   expect(row).toEqual({ product: "widget", "2024_01": 10, "2024_02": 20 });
 });
 


### PR DESCRIPTION
## What does this PR do?

Fixes two related issues in the SQL object-building path, both surfacing as a debug abort on `ASSERT(cell.index < count)` at `src/jsc/bindings/SQLClient.cpp:353`.

**1. Regression: digit-with-underscore column names misclassified as indices.** A result column whose name is all digits with an interior underscore (e.g. `2024_01`) was treated as a positional array index instead of a named key.

Reproduced against a real MySQL/MariaDB:

| Binary | `SELECT product, \`2024_01\`, \`2024_02\`` → row |
| --- | --- |
| **1.3.14** (release, Zig) | `{ product: "widget", "2024_01": 10, "2024_02": 20 }` ✅ |
| **canary** (Rust) | `{ "202401": 10, "202402": 20, product: "widget" }` ❌ |

So `2024_01`/`2024_02` collapse to `202401`/`202402`, and the named keys disappear. This is a regression: at `bun-v1.3.14` the code was Zig and classified `2024_01` as a name; the `.rs` port landed after 1.3.14 (in the Rust rewrite) and changed the behavior.

**2. Latent bug: the assertion itself is wrong.** `cell.index` for an indexed column holds the column name parsed as an integer, not a positional ordinal, so it can legitimately be `>= count`. The indexed-only fast path 16 lines above documents exactly this (`// cell.index can be > count`, e.g. `select 1 as "8"`), but the mixed named+indexed slow path asserted `cell.index < count` and aborted in debug builds — reachable with **correctly**-classified input, e.g. `SELECT product, 42 AS \`8\`` (`Name` + `Index(8)`, count=2 → `8 < 2`).

### Cause

**(1)** `ColumnIdentifier::init` decided Name-vs-Index by parsing the name with `bun_core::parse_unsigned`, which ports `std.fmt.parseInt` and **skips embedded `_` separators** (`parse_with_sign` in `src/bun_core/fmt.rs` does `if c == b'_' { continue; }`). So `"2024_01"` parsed to `202401`. The original Zig `ColumnIdentifier.init` never used `std.fmt.parseInt` — it hand-parsed a byte loop accepting only `'0'..'9'` and broke to the "name" branch on any other byte. The Rust port lost that.

**(2)** Pre-existing since #16512 (Jan 2025), untouched by the rewrite.

### Fix

**(1)** Replace the `parse_unsigned` call with the exact Zig hand-loop: accept only `'0'..'9'`, treat any other byte as a name. `parse_unsigned` itself is untouched (its `_` handling is correct for other callers — semver, content-length). The `< u32::MAX` JSC bound is preserved. `2024_01` stays a name (matches 1.3.14); pure-digit names like `5`/`123` still index.

**(2)** Remove the `ASSERT(cell.index < count)` from the indexed branch of the slow path so it matches the fast path's documented `putDirectIndex` sparse-index handling. The named-branch assertion at :363 is left intact (named cells set `index` to the positional ordinal, always `< count`).

The classifier is shared by the Postgres and MySQL decoders, so (1) covers both.

## How did you verify your code works?

`test/js/sql/sql-mysql-column-name-digits.test.ts` runs against a **real** MySQL/MariaDB (not a mock): the docker-compose `mysql_plain` service in CI (`describeWithContainer`), and the native server otherwise. The fixture does a real `CREATE TEMPORARY TABLE` with backtick-quoted `` `2024_01` ``/`` `2024_02` `` (digits+underscore) and `` `8` `` (pure digit, value > column count) columns, inserts a row, selects it back, and asserts the decoded row keeps the named keys and round-trips everything.

- **Canary vs this patch**, same test file, same real MariaDB, only the binary differing:
  - published canary → **fails** (`2024_01`/`2024_02` decode as `202401`/`202402`).
  - this patch → **passes** (`{ product, "2024_01", "2024_02", "8" }`).
- **ASAN (debug) fail/pass:** without the `src/` changes the fixture aborts on `ASSERT(cell.index < count)`; with them it passes.
- 1.3.14-vs-canary behavior confirmed against the official release binaries (table above). Leading-zero names (`"01"` → index `1`) are invariant across 1.3.14 / pre-PR / this branch, so they're intentionally left as-is to preserve parity (tracked separately).

Supersedes #31516.
