### PR TITLE
http: support CONNECT method in node:http client

### DIFF
--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -75,6 +75,29 @@ const INVALID_PATH_REGEX = /[^\u0021-\u00ff]/;
 const INVALID_HOST_CHAR_REGEX = /[/\\?#@\t\n\r]/;
 const CONNECT_STATUS_LINE_REGEX = /^HTTP\/(\d)\.(\d) (\d{3})(?: (.*))?$/;
 const kEmptyBuffer = Buffer.alloc(0);
+// Headers Node's IncomingMessage._addHeaderLine treats as singletons: the first
+// occurrence wins and later duplicates are discarded (set-cookie is handled
+// separately as an array). Used when folding parsed CONNECT response headers.
+const kConnectSingletonHeaders = new Set([
+  "age",
+  "authorization",
+  "content-length",
+  "content-type",
+  "etag",
+  "expires",
+  "from",
+  "host",
+  "if-modified-since",
+  "if-unmodified-since",
+  "last-modified",
+  "location",
+  "max-forwards",
+  "proxy-authorization",
+  "referer",
+  "retry-after",
+  "server",
+  "user-agent",
+]);
 
 const { URL } = globalThis;
 
@@ -729,10 +752,8 @@ function ClientRequest(input, options, cb) {
       this[kClearTimeout]?.();
       // Abort is handled by onAbort → socketCloseListener, which emits 'close'.
       if (isAbortError(err)) return;
-      if (err?.code === "ECONNREFUSED" || err?.code === "ConnectionRefused") {
-        err = new Error("ECONNREFUSED");
-        err.code = "ECONNREFUSED";
-      }
+      // net/tls already produce a Node-shaped error (code/syscall/address/port),
+      // so propagate it verbatim like Node rather than flattening it.
       fetching = false;
       try {
         this.emit("error", err);
@@ -789,7 +810,7 @@ function ClientRequest(input, options, cb) {
       res[statusMessageSymbol] = statusMatch[4] || STATUS_CODES[statusMatch[3]] || "";
 
       const rawHeaders: string[] = [];
-      const parsedHeaders: Record<string, string> = {};
+      const parsedHeaders: Record<string, string | string[]> = {};
       for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
         const colon = line.indexOf(":");
@@ -804,9 +825,19 @@ function ClientRequest(input, options, cb) {
         const val = line.slice(start, end);
         $putByValDirect(rawHeaders, rawHeaders.length, key);
         $putByValDirect(rawHeaders, rawHeaders.length, val);
+        // Fold into headers with Node's _addHeaderLine rules: set-cookie is
+        // always an array, singleton headers keep the first value, everything
+        // else is comma-joined.
         const lowerKey = key.toLowerCase();
         const existing = parsedHeaders[lowerKey];
-        parsedHeaders[lowerKey] = existing === undefined ? val : `${existing}, ${val}`;
+        if (lowerKey === "set-cookie") {
+          if (existing === undefined) parsedHeaders[lowerKey] = [val];
+          else (existing as string[]).push(val);
+        } else if (existing === undefined) {
+          parsedHeaders[lowerKey] = val;
+        } else if (!kConnectSingletonHeaders.has(lowerKey)) {
+          parsedHeaders[lowerKey] = `${existing}, ${val}`;
+        }
       }
       res.headers = parsedHeaders;
       res.rawHeaders = rawHeaders;
@@ -818,8 +849,9 @@ function ClientRequest(input, options, cb) {
 
       // Point res.socket at the real tunnel socket and back-reference the
       // response from the request, matching Node (res.socket === socket,
-      // req.res === res). Node leaves res.req undefined for CONNECT, so we do
-      // too.
+      // req.res === res, res.upgrade === true). Node leaves res.req undefined
+      // for CONNECT, so we do too.
+      res.upgrade = true;
       res.socket = socket;
       this.res = res;
 

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -697,7 +697,11 @@ function ClientRequest(input, options, cb) {
     try {
       socket = isTLS ? tls().connect(connectOptions) : net().connect(connectOptions);
     } catch (err) {
+      fetching = false;
       process.nextTick((self, err) => self.emit("error", err), this, err);
+      // Keep this terminal path consistent with onError below: emit 'close'
+      // after 'error' so a req.on('close') cleanup listener still runs.
+      maybeEmitClose();
       return;
     }
 

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -653,6 +653,15 @@ function ClientRequest(input, options, cb) {
     } else {
       connectOptions.host = this[kHost];
       connectOptions.port = this[kPort];
+      // Forward the socket-level options Node honors when connecting to the
+      // proxy authority, so a custom DNS resolver (split-horizon DNS, service
+      // discovery) and address selection work the same as the normal path.
+      // net.connect() implements the resolution itself, so no manual loop.
+      if (options.lookup !== undefined) connectOptions.lookup = options.lookup;
+      if (options.family !== undefined) connectOptions.family = options.family;
+      if (options.hints !== undefined) connectOptions.hints = options.hints;
+      if (options.localAddress !== undefined) connectOptions.localAddress = options.localAddress;
+      if (options.localPort !== undefined) connectOptions.localPort = options.localPort;
     }
 
     const isTLS = this[kProtocol] === "https:";
@@ -715,6 +724,7 @@ function ClientRequest(input, options, cb) {
       socket.removeListener("error", onError);
       socket.removeListener("close", onClose);
       this[kClearTimeout]?.();
+      // Abort is handled by onAbort → socketCloseListener, which emits 'close'.
       if (isAbortError(err)) return;
       if (err?.code === "ECONNREFUSED" || err?.code === "ConnectionRefused") {
         err = new Error("ECONNREFUSED");
@@ -724,6 +734,8 @@ function ClientRequest(input, options, cb) {
       try {
         this.emit("error", err);
       } catch {}
+      // The request is done: emit 'close' like Node does after a failed request.
+      maybeEmitClose();
     };
 
     const onClose = () => {
@@ -743,6 +755,21 @@ function ClientRequest(input, options, cb) {
         return;
       }
 
+      const headerText = buffer.toString("latin1", 0, headerEnd);
+
+      const lines = headerText.split("\r\n");
+      const statusLine = lines.shift() || "";
+      // "HTTP/1.1 200 Connection established"
+      const statusMatch = RegExpPrototypeExec.$call(CONNECT_STATUS_LINE_REGEX, statusLine);
+      if (!statusMatch) {
+        // A proxy that answers with an unparseable status line isn't a tunnel;
+        // fail the request instead of emitting 'connect' with no statusCode.
+        // onError runs before `connected` flips, so it still fires.
+        socket.destroy();
+        onError($HPE_INVALID_HEADER_TOKEN("Parse Error: Invalid header token encountered"));
+        return;
+      }
+
       connected = true;
       socket.removeListener("data", onData);
       socket.removeListener("error", onError);
@@ -750,21 +777,13 @@ function ClientRequest(input, options, cb) {
       this[kClearTimeout]?.();
       fetching = false;
 
-      const headerText = buffer.toString("latin1", 0, headerEnd);
       const head = headerEnd + 4 < buffer.length ? buffer.subarray(headerEnd + 4) : kEmptyBuffer;
       buffer = null;
 
-      const lines = headerText.split("\r\n");
-      const statusLine = lines.shift() || "";
-      // "HTTP/1.1 200 Connection established"
-      const statusMatch = RegExpPrototypeExec.$call(CONNECT_STATUS_LINE_REGEX, statusLine);
-
       const res = new IncomingMessage(null, kEmptyObject);
-      if (statusMatch) {
-        res.httpVersion = `${statusMatch[1]}.${statusMatch[2]}`;
-        res[statusCodeSymbol] = Number(statusMatch[3]);
-        res[statusMessageSymbol] = statusMatch[4] || STATUS_CODES[statusMatch[3]] || "";
-      }
+      res.httpVersion = `${statusMatch[1]}.${statusMatch[2]}`;
+      res[statusCodeSymbol] = Number(statusMatch[3]);
+      res[statusMessageSymbol] = statusMatch[4] || STATUS_CODES[statusMatch[3]] || "";
 
       const rawHeaders: string[] = [];
       const parsedHeaders: Record<string, string> = {};

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -699,14 +699,17 @@ function ClientRequest(input, options, cb) {
 
     // Write the CONNECT request line + headers. The request target is the
     // `host:port` authority from options.path, not a URL path, so it must be
-    // written verbatim (no leading slash).
+    // written verbatim (no leading slash). Use the raw (original-case) header
+    // names so the wire bytes match what the caller set, like Node.
     const headerLines = [`CONNECT ${this[kPath]} HTTP/1.1`];
-    const headers = this.getHeaders();
-    for (const name in headers) {
-      const value = headers[name];
+    const rawNames = this.getRawHeaderNames();
+    for (let i = 0; i < rawNames.length; i++) {
+      const name = rawNames[i];
+      const value = this.getHeader(name);
+      if (value === undefined) continue;
       if ($isJSArray(value)) {
-        for (let i = 0; i < value.length; i++) {
-          headerLines.push(`${name}: ${value[i]}`);
+        for (let j = 0; j < value.length; j++) {
+          headerLines.push(`${name}: ${value[j]}`);
         }
       } else {
         headerLines.push(`${name}: ${value}`);
@@ -812,6 +815,13 @@ function ClientRequest(input, options, cb) {
       res[noBodySymbol] = true;
       res.complete = true;
       res.push(null);
+
+      // Point res.socket at the real tunnel socket and back-reference the
+      // response from the request, matching Node (res.socket === socket,
+      // req.res === res). Node leaves res.req undefined for CONNECT, so we do
+      // too.
+      res.socket = socket;
+      this.res = res;
 
       // The request is finished from the writable side's perspective.
       if (!this.finished) {

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -814,7 +814,9 @@ function ClientRequest(input, options, cb) {
       res[statusMessageSymbol] = statusMatch[4] || STATUS_CODES[statusMatch[3]] || "";
 
       const rawHeaders: string[] = [];
-      const parsedHeaders: Record<string, string | string[]> = {};
+      // Null prototype so a proxy header literally named "constructor"/"__proto__"
+      // folds against an absent own property instead of an inherited one.
+      const parsedHeaders: Record<string, string | string[]> = { __proto__: null } as any;
       for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
         const colon = line.indexOf(":");

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -813,6 +813,11 @@ function ClientRequest(input, options, cb) {
       socket.removeListener("close", onClose);
       // Hand the tunnel socket to the user with no internal listeners, like Node.
       socket.removeListener("error", swallowTeardownError);
+      // Our internal 'data' listener put the socket into flowing mode; reset it
+      // to the neutral (neither flowing nor paused) state like Node does before
+      // emitting 'connect', so bytes after the headers stay buffered until the
+      // user attaches a 'data' listener / pipes / resumes (no data loss).
+      socket.readableFlowing = null;
       this[kClearTimeout]?.();
       fetching = false;
 

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -58,10 +58,23 @@ const { globalAgent } = require("node:_http_agent");
 const { IncomingMessage } = require("node:_http_incoming");
 const { OutgoingMessage } = require("node:_http_outgoing");
 
+const { getLazy } = require("internal/shared");
+const net = getLazy(() => require("node:net"));
+const tls = getLazy(() => require("node:tls"));
+const {
+  getMaxHTTPHeaderSize,
+  STATUS_CODES,
+  statusCodeSymbol,
+  statusMessageSymbol,
+  noBodySymbol,
+} = require("internal/http");
+
 const globalReportError = globalThis.reportError;
 const setTimeout = globalThis.setTimeout;
 const INVALID_PATH_REGEX = /[^\u0021-\u00ff]/;
 const INVALID_HOST_CHAR_REGEX = /[/\\?#@\t\n\r]/;
+const CONNECT_STATUS_LINE_REGEX = /^HTTP\/(\d)\.(\d) (\d{3})(?: (.*))?$/;
+const kEmptyBuffer = Buffer.alloc(0);
 
 const { URL } = globalThis;
 
@@ -281,6 +294,16 @@ function ClientRequest(input, options, cb) {
   const startFetch = (customBody?) => {
     if (fetching) {
       return false;
+    }
+
+    // CONNECT tunnels (HTTP proxies) have no representation in fetch(): the
+    // request target is a `host:port` authority, not a URL, and the response
+    // is a raw socket rather than a message body. Dispatch it over a raw TCP
+    // socket instead and emit the 'connect' event, matching Node.
+    if (this[kMethod] === "CONNECT") {
+      fetching = true;
+      startConnect();
+      return true;
     }
 
     fetching = true;
@@ -601,6 +624,205 @@ function ClientRequest(input, options, cb) {
       process.nextTick((self, err) => self.emit("error", err), this, err);
       return false;
     }
+  };
+
+  // Dispatch a CONNECT request over a raw TCP (or TLS) socket and emit the
+  // 'connect' event once the proxy's response status line + headers arrive.
+  // This mirrors Node's http.ClientRequest CONNECT handling so HTTP proxy
+  // clients (e.g. @grpc/grpc-js proxy support) work.
+  const startConnect = () => {
+    if (!this[kAbortController]) {
+      this[kAbortController] = new AbortController();
+      this[kAbortController].signal.addEventListener("abort", onAbort, { once: true });
+    }
+
+    this[kUpgradeOrConnect] = true;
+
+    let keepalive = true;
+    const agentKeepalive = this[kAgent]?.keepAlive;
+    if (agentKeepalive !== undefined) {
+      keepalive = agentKeepalive;
+    }
+
+    const connectOptions: any = {
+      signal: this[kAbortController].signal,
+    };
+    const socketPath = this[kSocketPath];
+    if (socketPath) {
+      connectOptions.path = socketPath;
+    } else {
+      connectOptions.host = this[kHost];
+      connectOptions.port = this[kPort];
+    }
+
+    const isTLS = this[kProtocol] === "https:";
+    if (isTLS && this[kTls]) {
+      ObjectAssign(connectOptions, this[kTls]);
+      connectOptions.servername = this[kTls].servername;
+    }
+
+    let socket;
+    try {
+      socket = isTLS ? tls().connect(connectOptions) : net().connect(connectOptions);
+    } catch (err) {
+      process.nextTick((self, err) => self.emit("error", err), this, err);
+      return;
+    }
+
+    this.socket = socket;
+
+    // Default Host/Connection headers, matching Node. A CONNECT request with no
+    // Host header is rejected by many proxies (and by Bun's own server parser),
+    // so add one pointing at the proxy authority unless the caller set it.
+    if (!this.hasHeader("host") && !socketPath) {
+      let hostHeader = this[kHost];
+      if (isIPv6(hostHeader)) {
+        hostHeader = `[${hostHeader}]`;
+      }
+      if (!this[kUseDefaultPort]) {
+        hostHeader += ":" + this[kPort];
+      }
+      this.setHeader("Host", hostHeader);
+    }
+    if (!this.hasHeader("connection")) {
+      this.setHeader("Connection", keepalive ? "keep-alive" : "close");
+    }
+
+    // Write the CONNECT request line + headers. The request target is the
+    // `host:port` authority from options.path, not a URL path, so it must be
+    // written verbatim (no leading slash).
+    const headerLines = [`CONNECT ${this[kPath]} HTTP/1.1`];
+    const headers = this.getHeaders();
+    for (const name in headers) {
+      const value = headers[name];
+      if ($isJSArray(value)) {
+        for (let i = 0; i < value.length; i++) {
+          headerLines.push(`${name}: ${value[i]}`);
+        }
+      } else {
+        headerLines.push(`${name}: ${value}`);
+      }
+    }
+    const requestHead = headerLines.join("\r\n") + "\r\n\r\n";
+
+    let connected = false;
+    let buffer: Buffer | null = null;
+    const maxHeaderSize = this[kMaxHeaderSize] || getMaxHTTPHeaderSize();
+
+    const onError = err => {
+      if (connected) return;
+      socket.removeListener("data", onData);
+      socket.removeListener("error", onError);
+      socket.removeListener("close", onClose);
+      this[kClearTimeout]?.();
+      if (isAbortError(err)) return;
+      if (err?.code === "ECONNREFUSED" || err?.code === "ConnectionRefused") {
+        err = new Error("ECONNREFUSED");
+        err.code = "ECONNREFUSED";
+      }
+      fetching = false;
+      try {
+        this.emit("error", err);
+      } catch {}
+    };
+
+    const onClose = () => {
+      if (connected) return;
+      onError(new ConnResetException("socket hang up"));
+    };
+
+    const onData = chunk => {
+      buffer = buffer ? Buffer.concat([buffer, chunk]) : chunk;
+
+      const headerEnd = buffer.indexOf("\r\n\r\n");
+      if (headerEnd === -1) {
+        if (buffer.length > maxHeaderSize) {
+          socket.destroy();
+          onError($HPE_HEADER_OVERFLOW("Header overflow"));
+        }
+        return;
+      }
+
+      connected = true;
+      socket.removeListener("data", onData);
+      socket.removeListener("error", onError);
+      socket.removeListener("close", onClose);
+      this[kClearTimeout]?.();
+      fetching = false;
+
+      const headerText = buffer.toString("latin1", 0, headerEnd);
+      const head = headerEnd + 4 < buffer.length ? buffer.subarray(headerEnd + 4) : kEmptyBuffer;
+      buffer = null;
+
+      const lines = headerText.split("\r\n");
+      const statusLine = lines.shift() || "";
+      // "HTTP/1.1 200 Connection established"
+      const statusMatch = RegExpPrototypeExec.$call(CONNECT_STATUS_LINE_REGEX, statusLine);
+
+      const res = new IncomingMessage(null, kEmptyObject);
+      if (statusMatch) {
+        res.httpVersion = `${statusMatch[1]}.${statusMatch[2]}`;
+        res[statusCodeSymbol] = Number(statusMatch[3]);
+        res[statusMessageSymbol] = statusMatch[4] || STATUS_CODES[statusMatch[3]] || "";
+      }
+
+      const rawHeaders: string[] = [];
+      const parsedHeaders: Record<string, string> = {};
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        const colon = line.indexOf(":");
+        if (colon === -1) continue;
+        const key = line.slice(0, colon);
+        let val = line.slice(colon + 1);
+        if (val.charCodeAt(0) === 32 /* " " */) val = val.slice(1);
+        $putByValDirect(rawHeaders, rawHeaders.length, key);
+        $putByValDirect(rawHeaders, rawHeaders.length, val);
+        const lowerKey = key.toLowerCase();
+        const existing = parsedHeaders[lowerKey];
+        parsedHeaders[lowerKey] = existing === undefined ? val : `${existing}, ${val}`;
+      }
+      res.headers = parsedHeaders;
+      res.rawHeaders = rawHeaders;
+      // The CONNECT response has no body; mark it complete so reads emit EOF
+      // instead of touching the (absent) fetch Response backing store.
+      res[noBodySymbol] = true;
+      res.complete = true;
+      res.push(null);
+
+      // The request is finished from the writable side's perspective.
+      if (!this.finished) {
+        this.finished = true;
+      }
+      process.nextTick(emitFinishAndDeferredCloseNT);
+
+      // Once the tunnel socket goes away, the request is done too: emit 'close'
+      // on the ClientRequest the way Node does when the CONNECT socket closes.
+      socket.once("close", () => {
+        maybeEmitClose();
+      });
+
+      if (this.listenerCount("connect") > 0) {
+        this.emit("connect", res, socket, head);
+      } else {
+        // Node destroys the socket when nobody is listening for 'connect'.
+        socket.destroy();
+      }
+    };
+
+    socket.on("data", onData);
+    socket.on("error", onError);
+    socket.on("close", onClose);
+
+    const writeHead = () => {
+      socket.write(requestHead);
+    };
+    if (socket.connecting) {
+      socket.once(isTLS ? "secureConnect" : "connect", writeHead);
+    } else {
+      writeHead();
+    }
+
+    return true;
   };
 
   let onEnd = () => {};

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -61,13 +61,7 @@ const { OutgoingMessage } = require("node:_http_outgoing");
 const { getLazy } = require("internal/shared");
 const net = getLazy(() => require("node:net"));
 const tls = getLazy(() => require("node:tls"));
-const {
-  getMaxHTTPHeaderSize,
-  STATUS_CODES,
-  statusCodeSymbol,
-  statusMessageSymbol,
-  noBodySymbol,
-} = require("internal/http");
+const { getMaxHTTPHeaderSize, statusCodeSymbol, statusMessageSymbol, noBodySymbol } = require("internal/http");
 
 const globalReportError = globalThis.reportError;
 const setTimeout = globalThis.setTimeout;
@@ -754,8 +748,10 @@ function ClientRequest(input, options, cb) {
       socket.removeListener("error", onError);
       socket.removeListener("close", onClose);
       this[kClearTimeout]?.();
-      // Abort is handled by onAbort → socketCloseListener, which emits 'close'.
-      if (isAbortError(err)) return;
+      // Abort/destroy is handled by onAbort → socketCloseListener, which emits
+      // 'close' and also synthesizes a socket 'close' that lands here; don't
+      // surface a spurious 'error' for a user-initiated teardown (Node doesn't).
+      if (isAbortError(err) || this.destroyed || this[abortedSymbol]) return;
       // net/tls already produce a Node-shaped error (code/syscall/address/port),
       // so propagate it verbatim like Node rather than flattening it.
       fetching = false;
@@ -819,7 +815,8 @@ function ClientRequest(input, options, cb) {
       const res = new IncomingMessage(null, kEmptyObject);
       res.httpVersion = `${statusMatch[1]}.${statusMatch[2]}`;
       res[statusCodeSymbol] = Number(statusMatch[3]);
-      res[statusMessageSymbol] = statusMatch[4] || STATUS_CODES[statusMatch[3]] || "";
+      // Deliver the reason phrase verbatim, "" when omitted, matching llhttp/Node.
+      res[statusMessageSymbol] = statusMatch[4] ?? "";
 
       const rawHeaders: string[] = [];
       // Null prototype so a proxy header literally named "constructor"/"__proto__"
@@ -889,6 +886,12 @@ function ClientRequest(input, options, cb) {
       }
     };
 
+    // Always keep an error listener on the raw socket so a late error during
+    // teardown (e.g. the AbortController's AbortError when the request is
+    // aborted/destroyed before the tunnel is established) is swallowed instead
+    // of surfacing as an unhandled 'error'. onError/onClose below handle the
+    // pre-tunnel connection errors we care about; this is the backstop.
+    socket.on("error", () => {});
     socket.on("data", onData);
     socket.on("error", onError);
     socket.on("close", onClose);

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -792,8 +792,13 @@ function ClientRequest(input, options, cb) {
         const colon = line.indexOf(":");
         if (colon === -1) continue;
         const key = line.slice(0, colon);
-        let val = line.slice(colon + 1);
-        if (val.charCodeAt(0) === 32 /* " " */) val = val.slice(1);
+        // Strip OWS = *(SP / HTAB) on both sides of the value, matching llhttp
+        // (RFC 7230 §3.2.4), so padded proxy headers parse like they do in Node.
+        let start = colon + 1;
+        let end = line.length;
+        while (start < end && (line.charCodeAt(start) === 32 || line.charCodeAt(start) === 9)) start++;
+        while (end > start && (line.charCodeAt(end - 1) === 32 || line.charCodeAt(end - 1) === 9)) end--;
+        const val = line.slice(start, end);
         $putByValDirect(rawHeaders, rawHeaders.length, key);
         $putByValDirect(rawHeaders, rawHeaders.length, val);
         const lowerKey = key.toLowerCase();

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -884,18 +884,21 @@ function ClientRequest(input, options, cb) {
       }
       process.nextTick(emitFinishAndDeferredCloseNT);
 
-      // Once the tunnel socket goes away, the request is done too: emit 'close'
-      // on the ClientRequest the way Node does when the CONNECT socket closes.
-      socket.once("close", () => {
-        maybeEmitClose();
-      });
-
       if (this.listenerCount("connect") > 0) {
         this.emit("connect", res, socket, head);
       } else {
         // Node destroys the socket when nobody is listening for 'connect'.
         socket.destroy();
       }
+
+      // Attach this after the emit so the user's 'connect' handler sees the
+      // tunnel socket with no internal listeners, like Node. Socket 'close' is
+      // async, so a listener added here still fires even if the handler called
+      // socket.destroy() synchronously. Once the tunnel socket goes away, the
+      // request is done too: emit 'close' the way Node does on CONNECT close.
+      socket.once("close", () => {
+        maybeEmitClose();
+      });
     };
 
     // Swallow a late error that fires during pre-tunnel teardown (e.g. the

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -742,11 +742,16 @@ function ClientRequest(input, options, cb) {
     let buffer: Buffer | null = null;
     const maxHeaderSize = this[kMaxHeaderSize] || getMaxHTTPHeaderSize();
 
+    const swallowTeardownError = () => {};
+
     const onError = err => {
       if (connected) return;
       socket.removeListener("data", onData);
       socket.removeListener("error", onError);
       socket.removeListener("close", onClose);
+      // Keep swallowTeardownError attached here: on a pre-tunnel failure/abort
+      // the AbortController can still emit an AbortError on the socket after
+      // this runs, and it must not surface as an unhandled 'error'.
       this[kClearTimeout]?.();
       // Abort/destroy is handled by onAbort → socketCloseListener, which emits
       // 'close' and also synthesizes a socket 'close' that lands here; don't
@@ -806,6 +811,8 @@ function ClientRequest(input, options, cb) {
       socket.removeListener("data", onData);
       socket.removeListener("error", onError);
       socket.removeListener("close", onClose);
+      // Hand the tunnel socket to the user with no internal listeners, like Node.
+      socket.removeListener("error", swallowTeardownError);
       this[kClearTimeout]?.();
       fetching = false;
 
@@ -886,12 +893,12 @@ function ClientRequest(input, options, cb) {
       }
     };
 
-    // Always keep an error listener on the raw socket so a late error during
-    // teardown (e.g. the AbortController's AbortError when the request is
-    // aborted/destroyed before the tunnel is established) is swallowed instead
-    // of surfacing as an unhandled 'error'. onError/onClose below handle the
-    // pre-tunnel connection errors we care about; this is the backstop.
-    socket.on("error", () => {});
+    // Swallow a late error that fires during pre-tunnel teardown (e.g. the
+    // AbortController's AbortError when the request is aborted/destroyed before
+    // the tunnel is established) so it doesn't surface as an unhandled 'error'.
+    // Removed once the tunnel is handed to the user so the socket is delivered
+    // with no internal listeners, like Node.
+    socket.on("error", swallowTeardownError);
     socket.on("data", onData);
     socket.on("error", onError);
     socket.on("close", onClose);

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -782,6 +782,14 @@ function ClientRequest(input, options, cb) {
         }
         return;
       }
+      // Reject an oversized header block even when it arrives complete (with its
+      // terminator) in a single read, so maxHeaderSize is honored the way Node's
+      // llhttp counts header bytes regardless of where \r\n\r\n lands.
+      if (headerEnd > maxHeaderSize) {
+        socket.destroy();
+        onError($HPE_HEADER_OVERFLOW("Header overflow"));
+        return;
+      }
 
       const headerText = buffer.toString("latin1", 0, headerEnd);
 

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -715,6 +715,42 @@ describe("HTTP client CONNECT", () => {
     }
   });
 
+  test("http.request CONNECT destroyed before the proxy responds emits 'close' without crashing", async () => {
+    // A proxy that accepts the TCP connection but never sends a response.
+    const proxySockets: net.Socket[] = [];
+    const proxyServer = net.createServer(socket => {
+      socket.on("error", () => {});
+      proxySockets.push(socket);
+    });
+    await once(proxyServer.listen(0, "127.0.0.1"), "listening");
+    const { port } = proxyServer.address() as AddressInfo;
+
+    try {
+      const { promise, resolve } = Promise.withResolvers<string[]>();
+      const events: string[] = [];
+      const req = http.request({ method: "CONNECT", host: "127.0.0.1", port, path: "h:1" });
+      req.on("connect", () => events.push("connect"));
+      // A spurious 'error' after 'close' (or an unhandled AbortError) would be a bug.
+      req.on("error", e => events.push("error:" + ((e as NodeJS.ErrnoException).code ?? e.message)));
+      req.on("close", () => {
+        events.push("close");
+        resolve(events);
+      });
+      req.end();
+      // Destroy before the proxy has written anything.
+      await once(req, "socket");
+      req.destroy();
+
+      const result = await promise;
+      // The request must close; it must not emit a spurious post-close error.
+      expect(result).toContain("close");
+      expect(result[result.length - 1]).toBe("close");
+    } finally {
+      for (const s of proxySockets) s.destroy();
+      await new Promise<void>(r => proxyServer.close(() => r()));
+    }
+  });
+
   test("http.request CONNECT resolves the proxy host with a custom lookup", async () => {
     const proxyServer = http.createServer();
     let proxySocket: net.Socket | undefined;

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -472,7 +472,13 @@ describe("HTTP client CONNECT", () => {
         const reqResIsRes = req.res === res;
         socket.on("error", () => {});
         socket.on("data", d => {
-          resolve({ statusCode: res.statusCode, headers: res.headers, echoed: d.toString(), socketIsTunnel, reqResIsRes });
+          resolve({
+            statusCode: res.statusCode,
+            headers: res.headers,
+            echoed: d.toString(),
+            socketIsTunnel,
+            reqResIsRes,
+          });
           socket.destroy();
         });
         socket.write("ping");

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -565,32 +565,24 @@ describe("Should be compatible with node.js", () => {
   // These spawn a full `node --test` / `bun test` run of the sibling file, which
   // can take several seconds. Give them a generous timeout so they don't race the
   // default 5s deadline on a loaded CI machine.
-  test(
-    "tests should run on node.js",
-    async () => {
-      const process = Bun.spawn({
-        cmd: [nodeExe(), "--test", join(import.meta.dir, "node-http-connect.node.mts")],
-        stdout: "inherit",
-        stderr: "inherit",
-        stdin: "ignore",
-        env: bunEnv,
-      });
-      expect(await process.exited).toBe(0);
-    },
-    30_000,
-  );
-  test(
-    "tests should run on bun",
-    async () => {
-      const process = Bun.spawn({
-        cmd: [bunExe(), "test", join(import.meta.dir, "node-http-connect.node.mts")],
-        stdout: "inherit",
-        stderr: "inherit",
-        stdin: "ignore",
-        env: bunEnv,
-      });
-      expect(await process.exited).toBe(0);
-    },
-    30_000,
-  );
+  test("tests should run on node.js", async () => {
+    const process = Bun.spawn({
+      cmd: [nodeExe(), "--test", join(import.meta.dir, "node-http-connect.node.mts")],
+      stdout: "inherit",
+      stderr: "inherit",
+      stdin: "ignore",
+      env: bunEnv,
+    });
+    expect(await process.exited).toBe(0);
+  }, 30_000);
+  test("tests should run on bun", async () => {
+    const process = Bun.spawn({
+      cmd: [bunExe(), "test", join(import.meta.dir, "node-http-connect.node.mts")],
+      stdout: "inherit",
+      stderr: "inherit",
+      stdin: "ignore",
+      env: bunEnv,
+    });
+    expect(await process.exited).toBe(0);
+  }, 30_000);
 });

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -697,7 +697,7 @@ describe("HTTP client CONNECT", () => {
     // must still be rejected, matching Node's llhttp byte counting.
     const proxyServer = net.createServer(socket => {
       socket.on("error", () => {});
-      socket.on("data", () => socket.write("HTTP/1.1 200 OK\r\nX: " + "a".repeat(20000) + "\r\n\r\n"));
+      socket.on("data", () => socket.write("HTTP/1.1 200 OK\r\nX: " + Buffer.alloc(20000, "a").toString() + "\r\n\r\n"));
     });
     await once(proxyServer.listen(0, "127.0.0.1"), "listening");
     const { port } = proxyServer.address() as AddressInfo;

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -572,7 +572,7 @@ describe("HTTP client CONNECT", () => {
       socket.on("error", () => {});
       socket.on("data", () =>
         socket.write(
-          "HTTP/1.1 200 OK\r\nSet-Cookie: a=1\r\nSet-Cookie: b=2\r\nContent-Length: 10\r\nContent-Length: 20\r\nX-Multi: p\r\nX-Multi: q\r\n\r\n",
+          "HTTP/1.1 200 OK\r\nSet-Cookie: a=1\r\nSet-Cookie: b=2\r\nContent-Length: 10\r\nContent-Length: 20\r\nX-Multi: p\r\nX-Multi: q\r\nConstructor: own\r\n\r\n",
         ),
       );
     });
@@ -595,6 +595,9 @@ describe("HTTP client CONNECT", () => {
       expect(headers["set-cookie"]).toEqual(["a=1", "b=2"]);
       expect(headers["content-length"]).toBe("10");
       expect(headers["x-multi"]).toBe("p, q");
+      // A header whose name collides with Object.prototype must fold against an
+      // absent own property, not the inherited one.
+      expect(headers["constructor"]).toBe("own");
     } finally {
       await new Promise<void>(r => proxyServer.close(() => r()));
     }

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -544,20 +544,100 @@ describe("HTTP client CONNECT", () => {
     }
   });
 
-  test("http.request CONNECT emits 'error' when the proxy is unreachable", async () => {
+  test("http.request CONNECT emits 'error' then 'close' when the proxy is unreachable", async () => {
     // Bind then immediately close to obtain a port nothing listens on.
     const tmp = net.createServer();
     await once(tmp.listen(0, "127.0.0.1"), "listening");
     const { port } = tmp.address() as AddressInfo;
     await new Promise<void>(r => tmp.close(() => r()));
 
-    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    const { promise, resolve, reject } = Promise.withResolvers<{ code: string; events: string[] }>();
+    const events: string[] = [];
     const req = http.request({ method: "CONNECT", host: "127.0.0.1", port, path: "example.com:443" });
     req.on("connect", () => reject(new Error("unexpected connect")));
-    req.on("error", err => resolve((err as NodeJS.ErrnoException).code ?? err.message));
+    let code = "";
+    req.on("error", err => {
+      events.push("error");
+      code = (err as NodeJS.ErrnoException).code ?? err.message;
+    });
+    // Node emits 'close' on the request after a failed connection.
+    req.on("close", () => {
+      events.push("close");
+      resolve({ code, events });
+    });
     req.end();
 
-    expect(await promise).toBe("ECONNREFUSED");
+    const result = await promise;
+    expect(result.code).toBe("ECONNREFUSED");
+    expect(result.events).toEqual(["error", "close"]);
+  });
+
+  test("http.request CONNECT rejects a malformed proxy status line with 'error'", async () => {
+    const proxyServer = net.createServer(socket => {
+      socket.on("error", () => {});
+      // Not a valid HTTP status line, but terminated like a header block.
+      socket.on("data", () => socket.write("garbage not http\r\nX: y\r\n\r\n"));
+    });
+    await once(proxyServer.listen(0, "127.0.0.1"), "listening");
+    const { port } = proxyServer.address() as AddressInfo;
+
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<string>();
+      const req = http.request({ method: "CONNECT", host: "127.0.0.1", port, path: "example.com:443" });
+      req.on("connect", () => reject(new Error("unexpected connect on malformed response")));
+      req.on("error", err => resolve((err as NodeJS.ErrnoException).code ?? err.message));
+      req.end();
+
+      // Node surfaces an llhttp parse error (HPE_*). We only require that it's an
+      // error rather than a bogus tunnel, so assert the code class loosely.
+      const code = await promise;
+      expect(code).toContain("HPE_");
+    } finally {
+      await new Promise<void>(r => proxyServer.close(() => r()));
+    }
+  });
+
+  test("http.request CONNECT resolves the proxy host with a custom lookup", async () => {
+    const proxyServer = http.createServer();
+    let proxySocket: net.Socket | undefined;
+    proxyServer.on("connect", (req, clientSocket) => {
+      proxySocket = clientSocket;
+      clientSocket.on("error", () => {});
+      clientSocket.write("HTTP/1.1 200 Connection established\r\n\r\n");
+    });
+    await once(proxyServer.listen(0, "127.0.0.1"), "listening");
+    const { port } = proxyServer.address() as AddressInfo;
+
+    try {
+      let lookupCalledWith = "";
+      const { promise, resolve, reject } = Promise.withResolvers<number>();
+      const req = http.request({
+        method: "CONNECT",
+        // A name that only the custom lookup can resolve.
+        host: "proxy.invalid.test",
+        port,
+        path: "example.com:443",
+        lookup: (hostname: string, _opts: any, cb: any) => {
+          lookupCalledWith = hostname;
+          // net.connect() defaults autoSelectFamily on, so the all-addresses
+          // array form is what both Node and Bun expect here.
+          cb(null, [{ address: "127.0.0.1", family: 4 }]);
+        },
+      });
+      req.on("connect", (res, socket) => {
+        socket.destroy();
+        resolve(res.statusCode);
+      });
+      req.on("error", reject);
+      req.end();
+
+      const statusCode = await promise;
+      expect(lookupCalledWith).toBe("proxy.invalid.test");
+      expect(statusCode).toBe(200);
+    } finally {
+      proxySocket?.destroy();
+      await new Promise<void>(r => proxyServer.close(() => r()));
+    }
   });
 });
 

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -628,6 +628,54 @@ describe("HTTP client CONNECT", () => {
     }
   });
 
+  test("http.request CONNECT buffers post-tunnel data until a listener is attached", async () => {
+    // Node resets the tunnel socket to the neutral (non-flowing) state before
+    // emitting 'connect', so bytes arriving after the headers are buffered and a
+    // 'data' listener attached later (e.g. after an await) still receives them.
+    const proxySockets: net.Socket[] = [];
+    const proxyServer = net.createServer(socket => {
+      proxySockets.push(socket);
+      socket.on("error", () => {});
+      socket.on("data", () => {
+        socket.write("HTTP/1.1 200 Connection established\r\n\r\n");
+        // Send the tunneled bytes in a separate write after the headers.
+        setTimeout(() => socket.write("LATE-DATA"), 20);
+      });
+    });
+    await once(proxyServer.listen(0, "127.0.0.1"), "listening");
+    const { port } = proxyServer.address() as AddressInfo;
+
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<{ flowing: unknown; data: string }>();
+      const req = http.request({ method: "CONNECT", host: "127.0.0.1", port, path: "h:1" });
+      req.on("connect", async (res, socket) => {
+        const flowing = (socket as any).readableFlowing;
+        socket.on("error", () => {});
+        // Yield to the event loop before attaching the data listener; the bytes
+        // must be buffered (not dropped) until now.
+        await new Promise<void>(r => setTimeout(r, 60));
+        let data = "";
+        socket.on("data", d => {
+          data += d.toString();
+          if (data.includes("LATE-DATA")) {
+            resolve({ flowing, data });
+            socket.destroy();
+          }
+        });
+      });
+      req.on("error", reject);
+      req.end();
+
+      const result = await promise;
+      // Matches Node: socket handed over in the neutral state, data buffered.
+      expect(result.flowing).toBe(null);
+      expect(result.data).toBe("LATE-DATA");
+    } finally {
+      for (const s of proxySockets) s.destroy();
+      await new Promise<void>(r => proxyServer.close(() => r()));
+    }
+  });
+
   test("http.request CONNECT emits 'error' then 'close' when the proxy is unreachable", async () => {
     // Bind then immediately close to obtain a port nothing listens on.
     const tmp = net.createServer();

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -701,7 +701,13 @@ describe("HTTP client CONNECT", () => {
     // Node emits 'close' on the request after a failed connection.
     req.on("close", () => {
       events.push("close");
-      resolve({ code: err?.code ?? "", syscall: err?.syscall ?? "", address: err?.address ?? "", port: err?.port ?? 0, events });
+      resolve({
+        code: err?.code ?? "",
+        syscall: err?.syscall ?? "",
+        address: err?.address ?? "",
+        port: err?.port ?? 0,
+        events,
+      });
     });
     req.end();
 
@@ -745,7 +751,9 @@ describe("HTTP client CONNECT", () => {
     // must still be rejected, matching Node's llhttp byte counting.
     const proxyServer = net.createServer(socket => {
       socket.on("error", () => {});
-      socket.on("data", () => socket.write("HTTP/1.1 200 OK\r\nX: " + Buffer.alloc(20000, "a").toString() + "\r\n\r\n"));
+      socket.on("data", () =>
+        socket.write("HTTP/1.1 200 OK\r\nX: " + Buffer.alloc(20000, "a").toString() + "\r\n\r\n"),
+      );
     });
     await once(proxyServer.listen(0, "127.0.0.1"), "listening");
     const { port } = proxyServer.address() as AddressInfo;

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -463,13 +463,16 @@ describe("HTTP client CONNECT", () => {
         echoed: string;
         socketIsTunnel: boolean;
         reqResIsRes: boolean;
+        upgrade: unknown;
       }>();
 
       const req = http.request({ method: "CONNECT", host: "127.0.0.1", port, path: "example.com:443" });
       req.on("connect", (res, socket, head) => {
-        // Node wires res.socket to the tunnel socket and req.res to the response.
+        // Node wires res.socket to the tunnel socket, req.res to the response,
+        // and marks res.upgrade === true.
         const socketIsTunnel = res.socket === socket;
         const reqResIsRes = req.res === res;
+        const upgrade = (res as any).upgrade;
         socket.on("error", () => {});
         socket.on("data", d => {
           resolve({
@@ -478,6 +481,7 @@ describe("HTTP client CONNECT", () => {
             echoed: d.toString(),
             socketIsTunnel,
             reqResIsRes,
+            upgrade,
           });
           socket.destroy();
         });
@@ -494,6 +498,7 @@ describe("HTTP client CONNECT", () => {
       expect(result.echoed).toBe("ping");
       expect(result.socketIsTunnel).toBe(true);
       expect(result.reqResIsRes).toBe(true);
+      expect(result.upgrade).toBe(true);
     } finally {
       proxySocket?.destroy();
       await new Promise<void>(r => proxyServer.close(() => r()));
@@ -562,6 +567,39 @@ describe("HTTP client CONNECT", () => {
     }
   });
 
+  test("http.request CONNECT folds duplicate proxy response headers like Node", async () => {
+    const proxyServer = net.createServer(socket => {
+      socket.on("error", () => {});
+      socket.on("data", () =>
+        socket.write(
+          "HTTP/1.1 200 OK\r\nSet-Cookie: a=1\r\nSet-Cookie: b=2\r\nContent-Length: 10\r\nContent-Length: 20\r\nX-Multi: p\r\nX-Multi: q\r\n\r\n",
+        ),
+      );
+    });
+    await once(proxyServer.listen(0, "127.0.0.1"), "listening");
+    const { port } = proxyServer.address() as AddressInfo;
+
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<Record<string, string | string[]>>();
+      const req = http.request({ method: "CONNECT", host: "127.0.0.1", port, path: "h:1" });
+      req.on("connect", (res, socket) => {
+        resolve(res.headers);
+        socket.destroy();
+      });
+      req.on("error", reject);
+      req.end();
+
+      const headers = await promise;
+      // set-cookie is always an array; singleton headers keep the first value;
+      // other duplicates are comma-joined.
+      expect(headers["set-cookie"]).toEqual(["a=1", "b=2"]);
+      expect(headers["content-length"]).toBe("10");
+      expect(headers["x-multi"]).toBe("p, q");
+    } finally {
+      await new Promise<void>(r => proxyServer.close(() => r()));
+    }
+  });
+
   test("http.request CONNECT delivers bytes received after the headers as 'head'", async () => {
     const proxyServer = net.createServer(socket => {
       socket.on("error", () => {});
@@ -594,25 +632,36 @@ describe("HTTP client CONNECT", () => {
     const { port } = tmp.address() as AddressInfo;
     await new Promise<void>(r => tmp.close(() => r()));
 
-    const { promise, resolve, reject } = Promise.withResolvers<{ code: string; events: string[] }>();
+    const { promise, resolve, reject } = Promise.withResolvers<{
+      code: string;
+      syscall: string;
+      address: string;
+      port: number;
+      events: string[];
+    }>();
     const events: string[] = [];
     const req = http.request({ method: "CONNECT", host: "127.0.0.1", port, path: "example.com:443" });
     req.on("connect", () => reject(new Error("unexpected connect")));
-    let code = "";
-    req.on("error", err => {
+    let err: NodeJS.ErrnoException | undefined;
+    req.on("error", e => {
       events.push("error");
-      code = (err as NodeJS.ErrnoException).code ?? err.message;
+      err = e as NodeJS.ErrnoException;
     });
     // Node emits 'close' on the request after a failed connection.
     req.on("close", () => {
       events.push("close");
-      resolve({ code, events });
+      resolve({ code: err?.code ?? "", syscall: err?.syscall ?? "", address: err?.address ?? "", port: err?.port ?? 0, events });
     });
     req.end();
 
     const result = await promise;
     expect(result.code).toBe("ECONNREFUSED");
     expect(result.events).toEqual(["error", "close"]);
+    // The net error is propagated verbatim (Node-shaped), so the diagnostic
+    // fields survive rather than being flattened to a bare Error.
+    expect(result.syscall).toBe("connect");
+    expect(result.address).toBe("127.0.0.1");
+    expect(result.port).toBe(port);
   });
 
   test("http.request CONNECT rejects a malformed proxy status line with 'error'", async () => {

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -692,6 +692,29 @@ describe("HTTP client CONNECT", () => {
     }
   });
 
+  test("http.request CONNECT rejects a header block larger than maxHeaderSize", async () => {
+    // Oversized headers delivered complete (with the terminator) in one write
+    // must still be rejected, matching Node's llhttp byte counting.
+    const proxyServer = net.createServer(socket => {
+      socket.on("error", () => {});
+      socket.on("data", () => socket.write("HTTP/1.1 200 OK\r\nX: " + "a".repeat(20000) + "\r\n\r\n"));
+    });
+    await once(proxyServer.listen(0, "127.0.0.1"), "listening");
+    const { port } = proxyServer.address() as AddressInfo;
+
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<string>();
+      const req = http.request({ method: "CONNECT", host: "127.0.0.1", port, path: "h:1", maxHeaderSize: 16384 });
+      req.on("connect", () => reject(new Error("unexpected connect on oversized headers")));
+      req.on("error", err => resolve((err as NodeJS.ErrnoException).code ?? err.message));
+      req.end();
+
+      expect(await promise).toBe("HPE_HEADER_OVERFLOW");
+    } finally {
+      await new Promise<void>(r => proxyServer.close(() => r()));
+    }
+  });
+
   test("http.request CONNECT resolves the proxy host with a custom lookup", async () => {
     const proxyServer = http.createServer();
     let proxySocket: net.Socket | undefined;

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -440,6 +440,127 @@ describe("HTTP server socket access via normal requests", () => {
   });
 });
 
+describe("HTTP client CONNECT", () => {
+  test("http.request CONNECT tunnels through a proxy and emits 'connect'", async () => {
+    // A minimal CONNECT proxy that echoes tunneled bytes back.
+    const proxyServer = http.createServer();
+    let target = "";
+    let proxySocket: net.Socket | undefined;
+    proxyServer.on("connect", (req, clientSocket) => {
+      proxySocket = clientSocket;
+      target = req.url ?? "";
+      clientSocket.on("error", () => {});
+      clientSocket.write("HTTP/1.1 200 Connection established\r\nProxy-Agent: bun-test\r\n\r\n");
+      clientSocket.on("data", d => clientSocket.write(d));
+    });
+    await once(proxyServer.listen(0, "127.0.0.1"), "listening");
+    const { port } = proxyServer.address() as AddressInfo;
+
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<{
+        statusCode: number;
+        headers: Record<string, string>;
+        echoed: string;
+      }>();
+
+      const req = http.request({ method: "CONNECT", host: "127.0.0.1", port, path: "example.com:443" });
+      req.on("connect", (res, socket, head) => {
+        socket.on("error", () => {});
+        socket.on("data", d => {
+          resolve({ statusCode: res.statusCode, headers: res.headers, echoed: d.toString() });
+          socket.destroy();
+        });
+        socket.write("ping");
+      });
+      req.on("error", reject);
+      req.end();
+
+      const result = await promise;
+      // The tunnel target must be sent verbatim (no leading slash).
+      expect(target).toBe("example.com:443");
+      expect(result.statusCode).toBe(200);
+      expect(result.headers["proxy-agent"]).toBe("bun-test");
+      expect(result.echoed).toBe("ping");
+    } finally {
+      proxySocket?.destroy();
+      await new Promise<void>(r => proxyServer.close(() => r()));
+    }
+  });
+
+  test("http.request CONNECT emits 'connect' even on a non-200 status", async () => {
+    const proxyServer = net.createServer(socket => {
+      socket.on("error", () => {});
+      socket.on("data", () => socket.write("HTTP/1.1 403 Forbidden\r\nX-Reason: denied\r\n\r\n"));
+    });
+    await once(proxyServer.listen(0, "127.0.0.1"), "listening");
+    const { port } = proxyServer.address() as AddressInfo;
+
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<{
+        statusCode: number;
+        statusMessage: string;
+        headers: Record<string, string>;
+      }>();
+
+      const req = http.request({ method: "CONNECT", host: "127.0.0.1", port, path: "example.com:443" });
+      req.on("connect", (res, socket) => {
+        resolve({ statusCode: res.statusCode, statusMessage: res.statusMessage, headers: res.headers });
+        socket.destroy();
+      });
+      req.on("error", reject);
+      req.end();
+
+      const result = await promise;
+      expect(result.statusCode).toBe(403);
+      expect(result.statusMessage).toBe("Forbidden");
+      expect(result.headers["x-reason"]).toBe("denied");
+    } finally {
+      await new Promise<void>(r => proxyServer.close(() => r()));
+    }
+  });
+
+  test("http.request CONNECT delivers bytes received after the headers as 'head'", async () => {
+    const proxyServer = net.createServer(socket => {
+      socket.on("error", () => {});
+      socket.on("data", () => socket.write("HTTP/1.1 200 OK\r\n\r\nEARLY-DATA"));
+    });
+    await once(proxyServer.listen(0, "127.0.0.1"), "listening");
+    const { port } = proxyServer.address() as AddressInfo;
+
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<string>();
+      const req = http.request({ method: "CONNECT", host: "127.0.0.1", port, path: "h:1" });
+      req.on("connect", (res, socket, head) => {
+        expect(head).toBeInstanceOf(Buffer);
+        resolve(head.toString());
+        socket.destroy();
+      });
+      req.on("error", reject);
+      req.end();
+
+      expect(await promise).toBe("EARLY-DATA");
+    } finally {
+      await new Promise<void>(r => proxyServer.close(() => r()));
+    }
+  });
+
+  test("http.request CONNECT emits 'error' when the proxy is unreachable", async () => {
+    // Bind then immediately close to obtain a port nothing listens on.
+    const tmp = net.createServer();
+    await once(tmp.listen(0, "127.0.0.1"), "listening");
+    const { port } = tmp.address() as AddressInfo;
+    await new Promise<void>(r => tmp.close(() => r()));
+
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    const req = http.request({ method: "CONNECT", host: "127.0.0.1", port, path: "example.com:443" });
+    req.on("connect", () => reject(new Error("unexpected connect")));
+    req.on("error", err => resolve((err as NodeJS.ErrnoException).code ?? err.message));
+    req.end();
+
+    expect(await promise).toBe("ECONNREFUSED");
+  });
+});
+
 describe("Should be compatible with node.js", () => {
   test("tests should run on node.js", async () => {
     const process = Bun.spawn({

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -562,24 +562,35 @@ describe("HTTP client CONNECT", () => {
 });
 
 describe("Should be compatible with node.js", () => {
-  test("tests should run on node.js", async () => {
-    const process = Bun.spawn({
-      cmd: [nodeExe(), "--test", join(import.meta.dir, "node-http-connect.node.mts")],
-      stdout: "inherit",
-      stderr: "inherit",
-      stdin: "ignore",
-      env: bunEnv,
-    });
-    expect(await process.exited).toBe(0);
-  });
-  test("tests should run on bun", async () => {
-    const process = Bun.spawn({
-      cmd: [bunExe(), "test", join(import.meta.dir, "node-http-connect.node.mts")],
-      stdout: "inherit",
-      stderr: "inherit",
-      stdin: "ignore",
-      env: bunEnv,
-    });
-    expect(await process.exited).toBe(0);
-  });
+  // These spawn a full `node --test` / `bun test` run of the sibling file, which
+  // can take several seconds. Give them a generous timeout so they don't race the
+  // default 5s deadline on a loaded CI machine.
+  test(
+    "tests should run on node.js",
+    async () => {
+      const process = Bun.spawn({
+        cmd: [nodeExe(), "--test", join(import.meta.dir, "node-http-connect.node.mts")],
+        stdout: "inherit",
+        stderr: "inherit",
+        stdin: "ignore",
+        env: bunEnv,
+      });
+      expect(await process.exited).toBe(0);
+    },
+    30_000,
+  );
+  test(
+    "tests should run on bun",
+    async () => {
+      const process = Bun.spawn({
+        cmd: [bunExe(), "test", join(import.meta.dir, "node-http-connect.node.mts")],
+        stdout: "inherit",
+        stderr: "inherit",
+        stdin: "ignore",
+        env: bunEnv,
+      });
+      expect(await process.exited).toBe(0);
+    },
+    30_000,
+  );
 });

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -461,13 +461,18 @@ describe("HTTP client CONNECT", () => {
         statusCode: number;
         headers: Record<string, string>;
         echoed: string;
+        socketIsTunnel: boolean;
+        reqResIsRes: boolean;
       }>();
 
       const req = http.request({ method: "CONNECT", host: "127.0.0.1", port, path: "example.com:443" });
       req.on("connect", (res, socket, head) => {
+        // Node wires res.socket to the tunnel socket and req.res to the response.
+        const socketIsTunnel = res.socket === socket;
+        const reqResIsRes = req.res === res;
         socket.on("error", () => {});
         socket.on("data", d => {
-          resolve({ statusCode: res.statusCode, headers: res.headers, echoed: d.toString() });
+          resolve({ statusCode: res.statusCode, headers: res.headers, echoed: d.toString(), socketIsTunnel, reqResIsRes });
           socket.destroy();
         });
         socket.write("ping");
@@ -481,6 +486,8 @@ describe("HTTP client CONNECT", () => {
       expect(result.statusCode).toBe(200);
       expect(result.headers["proxy-agent"]).toBe("bun-test");
       expect(result.echoed).toBe("ping");
+      expect(result.socketIsTunnel).toBe(true);
+      expect(result.reqResIsRes).toBe(true);
     } finally {
       proxySocket?.destroy();
       await new Promise<void>(r => proxyServer.close(() => r()));

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -464,6 +464,7 @@ describe("HTTP client CONNECT", () => {
         socketIsTunnel: boolean;
         reqResIsRes: boolean;
         upgrade: unknown;
+        closeListeners: number;
       }>();
 
       const req = http.request({ method: "CONNECT", host: "127.0.0.1", port, path: "example.com:443" });
@@ -473,6 +474,9 @@ describe("HTTP client CONNECT", () => {
         const socketIsTunnel = res.socket === socket;
         const reqResIsRes = req.res === res;
         const upgrade = (res as any).upgrade;
+        // Node hands the tunnel socket to 'connect' with no internal listeners;
+        // capture the 'close' listener count before we attach our own.
+        const closeListeners = socket.listenerCount("close");
         socket.on("error", () => {});
         socket.on("data", d => {
           resolve({
@@ -482,6 +486,7 @@ describe("HTTP client CONNECT", () => {
             socketIsTunnel,
             reqResIsRes,
             upgrade,
+            closeListeners,
           });
           socket.destroy();
         });
@@ -499,6 +504,8 @@ describe("HTTP client CONNECT", () => {
       expect(result.socketIsTunnel).toBe(true);
       expect(result.reqResIsRes).toBe(true);
       expect(result.upgrade).toBe(true);
+      // The socket is handed over with no internal listeners, like Node.
+      expect(result.closeListeners).toBe(0);
     } finally {
       proxySocket?.destroy();
       await new Promise<void>(r => proxyServer.close(() => r()));
@@ -638,7 +645,9 @@ describe("HTTP client CONNECT", () => {
       socket.on("error", () => {});
       socket.on("data", () => {
         socket.write("HTTP/1.1 200 Connection established\r\n\r\n");
-        // Send the tunneled bytes in a separate write after the headers.
+        // Send the tunneled bytes in a separate write, a short moment after the
+        // headers, so they land in a TCP read distinct from the header block
+        // (not coalesced into it, which would deliver them as 'head' instead).
         setTimeout(() => socket.write("LATE-DATA"), 20);
       });
     });
@@ -651,9 +660,13 @@ describe("HTTP client CONNECT", () => {
       req.on("connect", async (res, socket) => {
         const flowing = (socket as any).readableFlowing;
         socket.on("error", () => {});
-        // Yield to the event loop before attaching the data listener; the bytes
-        // must be buffered (not dropped) until now.
-        await new Promise<void>(r => setTimeout(r, 60));
+        // Let the event loop turn so the post-header bytes physically arrive at
+        // the socket before the listener is attached; they must be buffered (not
+        // dropped) until now. There is no passive "data buffered" signal to wait
+        // on here — while flowing === null the bytes sit at the socket handle
+        // (readableLength stays 0) on both Node and Bun until a consumer resumes
+        // the stream, so a short yield is the condition that exercises this.
+        await Bun.sleep(50);
         let data = "";
         socket.on("data", d => {
           data += d.toString();

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -519,6 +519,36 @@ describe("HTTP client CONNECT", () => {
     }
   });
 
+  test("http.request CONNECT trims optional whitespace around proxy header values", async () => {
+    const proxyServer = net.createServer(socket => {
+      socket.on("error", () => {});
+      // Leading tab, two leading spaces, and a trailing space — llhttp trims all.
+      socket.on("data", () =>
+        socket.write("HTTP/1.1 200 OK\r\nX-Tab:\tt-val\r\nX-Two:  two-val\r\nX-Trail: trail-val \r\n\r\n"),
+      );
+    });
+    await once(proxyServer.listen(0, "127.0.0.1"), "listening");
+    const { port } = proxyServer.address() as AddressInfo;
+
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<Record<string, string>>();
+      const req = http.request({ method: "CONNECT", host: "127.0.0.1", port, path: "h:1" });
+      req.on("connect", (res, socket) => {
+        resolve(res.headers);
+        socket.destroy();
+      });
+      req.on("error", reject);
+      req.end();
+
+      const headers = await promise;
+      expect(headers["x-tab"]).toBe("t-val");
+      expect(headers["x-two"]).toBe("two-val");
+      expect(headers["x-trail"]).toBe("trail-val");
+    } finally {
+      await new Promise<void>(r => proxyServer.close(() => r()));
+    }
+  });
+
   test("http.request CONNECT delivers bytes received after the headers as 'head'", async () => {
     const proxyServer = net.createServer(socket => {
       socket.on("error", () => {});


### PR DESCRIPTION
## What

Implements the HTTP `CONNECT` method for the `node:http` client so that `http.request({ method: "CONNECT", ... })` works for proxy tunneling.

Fixes #31573.

## Repro

```js
const http = require("node:http");

const proxy = http.createServer();
proxy.on("connect", (req, clientSocket) => {
  clientSocket.write("HTTP/1.1 200 Connection established\r\n\r\n");
  clientSocket.on("data", d => clientSocket.write(d)); // echo
});

proxy.listen(0, "127.0.0.1", () => {
  const req = http.request({
    method: "CONNECT",
    host: "127.0.0.1",
    port: proxy.address().port,
    path: "example.com:443",
  });
  req.on("connect", (res, socket) => console.log("ok", res.statusCode));
  req.on("error", e => console.error("err", e.code));
  req.end();
});
```

Before: the proxy received a bogus `/example.com:443` target and the `connect` event never fired — the request hung forever. (On 1.3.11 it threw `TypeError: fetch() URL is invalid` synchronously.)

After: matches Node — the proxy sees `example.com:443`, `connect` fires with `statusCode === 200`, and bytes tunnel through the returned socket.

## Cause

`ClientRequest` dispatched **every** method through `fetch()` (`nodeHttpClient`). `fetch()` has no representation for a CONNECT tunnel:

- the request target is a `host:port` authority, not a URL path — `getURL()` prepended a leading `/`, so proxies saw `/example.com:443`;
- the result of CONNECT is a raw socket, not a message body — there was no code path that emits the `connect` event, so the request just hung.

## Fix

In `src/js/node/_http_client.ts`, detect `method === "CONNECT"` and bypass the fetch path entirely:

- open a raw TCP socket (or TLS, for an `https:` proxy) to the proxy authority via `node:net` / `node:tls`;
- write the `CONNECT <host:port> HTTP/1.1` request line verbatim (no slash) plus the request headers, adding default `Host`/`Connection` headers the way Node does (a CONNECT with no `Host` is rejected by many proxies, including Bun's own server parser);
- parse the proxy's status line and headers, then emit `connect` with `(res, socket, head)` — `res` is a minimal `IncomingMessage` carrying `statusCode`/`statusMessage`/`headers`/`rawHeaders`, `socket` is the raw tunneled socket, and `head` is any bytes received after the response headers;
- emit `error` (e.g. `ECONNREFUSED`) when the proxy is unreachable, and emit `close` on the request once the tunnel socket closes.

Event order on the request now matches Node: `socket`, `finish`, `connect`, `close`.

This unblocks HTTP CONNECT proxy clients, notably `@grpc/grpc-js` proxy support (`grpc_proxy` / `http_proxy`).

## Tests

`test/js/node/http/node-http-connect.test.ts` — new `HTTP client CONNECT` block:

- tunnels through a proxy, asserts the target is sent verbatim, `connect` fires with `statusCode` 200 + headers, and data echoes through the tunnel;
- `connect` fires even on a non-200 status (403) with the correct `statusMessage`/headers;
- bytes received after the headers are delivered as `head`;
- `error` with `ECONNREFUSED` when the proxy is unreachable.

Verified the tunnel/status/head tests fail on the released binary (they time out — `connect` never fires) and pass with this change. Behavior was compared directly against Node v24 (wire bytes, status/headers, `head`, and request event order all match).


## Related issues

Fixes #22311 (the exact-same bug — verified end-to-end with the reporter's repro).

This PR also makes `https-proxy-agent` work through a CONNECT tunnel (verified end-to-end: an HTTPS request tunneled through a proxy returns `200`), which is the core of #15499 and #31474. I've left those open rather than auto-closing them because each has a part this PR does not cover: #15499 also tracks `socks-proxy-agent` (SOCKS, unrelated to HTTP CONNECT), and #31474 is about the exact error code on an unreachable proxy, which still differs from Node at the `node:net` DNS layer (`ESERVFAIL` vs `EAI_AGAIN`), not in this CONNECT path. #4474 (`undici.ProxyAgent`) is a separate undici TLS code path that is still broken independently of this change.