### PR TITLE
htmlrewriter: release end-tag handler resources after each rewrite

### DIFF
--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -218,7 +218,9 @@ pub struct LOLHTMLContext {
 impl LOLHTMLContext {
     fn drain_end_tag_handlers(&self) {
         for handler in &self.element_handlers {
-            handler.end_tag_handlers.with_mut(|handlers| handlers.clear());
+            handler
+                .end_tag_handlers
+                .with_mut(|handlers| handlers.clear());
         }
     }
 }

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -212,6 +212,15 @@ pub struct LOLHTMLContext {
     pub element_handlers: Vec<Box<ElementHandler>>,
     #[expect(clippy::vec_box)]
     pub document_handlers: Vec<Box<DocumentHandler>>,
+    pub active_rewriters: usize,
+}
+
+impl LOLHTMLContext {
+    fn drain_end_tag_handlers(&self) {
+        for handler in &self.element_handlers {
+            handler.end_tag_handlers.with_mut(|handlers| handlers.clear());
+        }
+    }
 }
 
 impl Drop for LOLHTMLContext {
@@ -528,6 +537,13 @@ impl HTMLRewriterLoader {
         }
         // SAFETY: rewriter created via builder.build(); not yet freed.
         unsafe { lolhtml::HTMLRewriter::destroy(self.rewriter) };
+        {
+            let mut ctx = self.context.borrow_mut();
+            ctx.active_rewriters -= 1;
+            if ctx.active_rewriters == 0 {
+                ctx.drain_end_tag_handlers();
+            }
+        }
         self.backpressure = LinearFifo::<u8, DynamicBuffer<u8>>::init();
         self.finalized = true;
     }
@@ -643,6 +659,7 @@ impl HTMLRewriterLoader {
         // POD struct copy of an `ArrayListUnmanaged`, which in Rust would
         // double-own `Vec`/`Box` heap buffers. Clone the Rc instead.
         self.context = context;
+        self.context.borrow_mut().active_rewriters += 1;
         self.output = output;
 
         None
@@ -868,6 +885,7 @@ impl BufferOutputSink {
                     return Ok(create_lolhtml_error(global));
                 }
             };
+            (*sink).context.borrow_mut().active_rewriters += 1;
         }
 
         // SAFETY: result and original are both live *Response (result allocated
@@ -1140,6 +1158,11 @@ impl Drop for BufferOutputSink {
         if !self.rewriter.is_null() {
             // SAFETY: rewriter created via builder.build() and not yet freed.
             unsafe { lolhtml::HTMLRewriter::destroy(self.rewriter) };
+            let mut ctx = self.context.borrow_mut();
+            ctx.active_rewriters -= 1;
+            if ctx.active_rewriters == 0 {
+                ctx.drain_end_tag_handlers();
+            }
         }
     }
 }
@@ -1495,6 +1518,8 @@ pub struct ElementHandler {
     pub on_text_callback: Option<ProtectedJSValue>,
     pub this_object: ProtectedJSValue,
     pub global: GlobalRef, // JSC_BORROW
+    #[expect(clippy::vec_box)]
+    pub end_tag_handlers: JsCell<Vec<Box<EndTagHandler>>>,
 }
 
 impl ElementHandler {
@@ -1505,6 +1530,7 @@ impl ElementHandler {
             on_text_callback: None,
             this_object: ProtectedJSValue::adopt(JSValue::ZERO),
             global: GlobalRef::from(global),
+            end_tag_handlers: JsCell::new(Vec::new()),
         };
 
         if !this_object.is_object() {
@@ -1541,6 +1567,9 @@ impl ElementHandler {
     }
 
     pub fn on_element(this: *mut Self, value: *mut lolhtml::Element) -> bool {
+        if let Some(el) = lolhtml::Element::from_ptr(value) {
+            el.set_user_data(this.cast::<core::ffi::c_void>());
+        }
         handler_callback::<Self, Element, lolhtml::Element>(
             this,
             value,
@@ -1907,9 +1936,7 @@ pub struct EndTag {
 }
 
 pub struct EndTagHandler {
-    // TODO(port): bare JSValue heap field kept alive via JSC gcProtect —
-    // evaluate bun_jsc::Strong (see DocumentHandler note).
-    pub callback: Option<JSValue>,
+    pub callback: Option<ProtectedJSValue>,
     pub global: GlobalRef, // JSC_BORROW
 }
 
@@ -1919,7 +1946,7 @@ impl EndTagHandler {
             this,
             value,
             |w| w.end_tag.set(core::ptr::null_mut()),
-            |h| h.callback,
+            |h| h.callback.as_ref().map(ProtectedJSValue::value),
         )
     }
 
@@ -1932,7 +1959,9 @@ impl EndTagHandler {
 
 impl lolhtml::DirectiveCallback<lolhtml::EndTag> for EndTagHandler {
     fn call(&mut self, container: &mut lolhtml::EndTag) -> bool {
-        EndTagHandler::on_end_tag(self, container)
+        let result = EndTagHandler::on_end_tag(self, container);
+        self.callback = None;
+        result
     }
 }
 
@@ -2184,25 +2213,37 @@ impl Element {
             return Ok(ZigString::init_utf8(b"Expected a function").to_js(global_object));
         }
 
-        let end_tag_handler = bun_core::heap::into_raw(Box::new(EndTagHandler {
+        let Some(element_handler) = el.get_user_data::<ElementHandler>() else {
+            let err = create_lolhtml_error(global_object);
+            return Err(global_object.throw_value(err));
+        };
+
+        let mut end_tag_handler = Box::new(EndTagHandler {
             global: GlobalRef::from(global_object),
-            callback: Some(function),
-        }));
+            callback: Some(function.protected()),
+        });
+        let end_tag_handler_ptr: NonNull<EndTagHandler> = NonNull::from(&mut *end_tag_handler);
 
         if el
             .on_end_tag(
                 EndTagHandler::ON_END_TAG_HANDLER,
-                end_tag_handler.cast::<core::ffi::c_void>(),
+                end_tag_handler_ptr.as_ptr().cast::<core::ffi::c_void>(),
             )
             .is_err()
         {
-            // SAFETY: end_tag_handler allocated above and not yet handed to lol-html.
-            unsafe { drop(bun_core::heap::take(end_tag_handler)) };
             let err = create_lolhtml_error(global_object);
             return Err(global_object.throw_value(err));
         }
 
-        function.protect();
+        // SAFETY: `element_handler` is the element user_data set in
+        // `ElementHandler::on_element`: the live `Box<ElementHandler>` owned by
+        // `LOLHTMLContext::element_handlers`, which outlives this call. Aliased
+        // `&ElementHandler` is sound (see `handler_callback`); the only
+        // mutation goes through the `JsCell` field.
+        let element_handler = unsafe { &*element_handler };
+        element_handler
+            .end_tag_handlers
+            .with_mut(|handlers| handlers.push(end_tag_handler));
         Ok(call_frame.this())
     }
 

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -537,9 +537,9 @@ impl HTMLRewriterLoader {
         if self.finalized {
             return;
         }
-        // SAFETY: rewriter created via builder.build(); not yet freed.
-        unsafe { lolhtml::HTMLRewriter::destroy(self.rewriter) };
-        {
+        if !self.rewriter.is_null() {
+            // SAFETY: rewriter created via builder.build(); not yet freed.
+            unsafe { lolhtml::HTMLRewriter::destroy(self.rewriter) };
             let mut ctx = self.context.borrow_mut();
             ctx.active_rewriters -= 1;
             if ctx.active_rewriters == 0 {

--- a/test/js/workerd/html-rewriter-leak.test.ts
+++ b/test/js/workerd/html-rewriter-leak.test.ts
@@ -79,3 +79,82 @@ test.skipIf(isDebug)(
   },
   15_000,
 );
+
+// Each Element.onEndTag(fn) call heap-allocates an EndTagHandler and gcProtects
+// the JS callback. Those registrations must be released once the rewrite that
+// created them finishes — both for elements whose end tag is reached (handler
+// invoked) and for elements whose end tag never appears (handler never invoked).
+// Previously neither was ever freed, so memory grew per matching element.
+//
+// Skipped in debug for the same reason as the test above: the workload is sized
+// for release allocator behavior and debug allocation tracking drowns the signal.
+test.skipIf(isDebug)(
+  "HTMLRewriter does not leak onEndTag handler registrations",
+  async () => {
+    const code = /* js */ `
+      const closed = "<div></div>".repeat(1000);
+      const unclosed = "<div>".repeat(1000);
+
+      async function once(html) {
+        await new HTMLRewriter()
+          .on("div", {
+            element(el) {
+              el.onEndTag(() => {});
+            },
+          })
+          .transform(new Response(html))
+          .text();
+      }
+
+      async function pass() {
+        for (let i = 0; i < 25; i++) await once(closed);
+        for (let i = 0; i < 25; i++) await once(unclosed);
+        Bun.gc(true);
+        return process.memoryUsage.rss();
+      }
+
+      await pass(); await pass();
+      const before = await pass();
+      await pass(); await pass();
+      const after = await pass();
+
+      process.stdout.write(
+        JSON.stringify({ before, after, deltaMB: (after - before) / 1024 / 1024 }) + "\\n",
+      );
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--smol", "-e", code],
+      env: {
+        ...bunEnv,
+        // Don't inherit the runner's GC_LEVEL=1 — it changes the per-pass live set.
+        BUN_GARBAGE_COLLECTOR_LEVEL: "0",
+        // ASAN's freed-block quarantine is exactly the thing that pins RSS at
+        // peak; disable it so freed handler allocations get reused across passes.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0", "thread_local_quarantine_size_kb=0"]
+          .filter(Boolean)
+          .join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const filteredStderr = stderr
+      .split("\n")
+      .filter(line => !line.startsWith("WARNING: ASAN interferes"))
+      .join("\n")
+      .trim();
+    expect(filteredStderr).toBe("");
+
+    const { deltaMB } = JSON.parse(stdout.trim());
+
+    // Unfixed: ~26 MB over 3 measured passes (~150k registrations at ~180 bytes
+    // each). Fixed: low single-digit MB plateau. Threshold sits at ~half the
+    // unfixed signal.
+    expect(deltaMB).toBeLessThan(13);
+    expect(exitCode).toBe(0);
+  },
+  15_000,
+);

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -531,6 +531,78 @@ describe("HTMLRewriter", () => {
       circle: false,
     });
   });
+
+  it("onEndTag: before/after/remove operate on the end tag", async () => {
+    const before = await new HTMLRewriter()
+      .on("div", {
+        element(el) {
+          el.onEndTag(end => {
+            end.before("X");
+          });
+        },
+      })
+      .transform(new Response("<div>a</div><div>b"))
+      .text();
+    expect(before).toBe("<div>aX</div><div>b");
+
+    const after = await new HTMLRewriter()
+      .on("div", {
+        element(el) {
+          el.onEndTag(end => {
+            end.after("Y", { html: true });
+          });
+        },
+      })
+      .transform(new Response("<div>a</div>z"))
+      .text();
+    expect(after).toBe("<div>a</div>Yz");
+
+    const removed = await new HTMLRewriter()
+      .on("div", {
+        element(el) {
+          el.onEndTag(end => {
+            end.remove();
+          });
+        },
+      })
+      .transform(new Response("<div>a</div>"))
+      .text();
+    expect(removed).toBe("<div>a");
+  });
+
+  it("onEndTag: callback fires only for elements whose end tag appears", async () => {
+    let calls = 0;
+    const output = await new HTMLRewriter()
+      .on("div", {
+        element(el) {
+          el.onEndTag(() => {
+            calls++;
+          });
+        },
+      })
+      .transform(new Response("<div>a</div><div>b<span>c</span>"))
+      .text();
+    expect(output).toBe("<div>a</div><div>b<span>c</span>");
+    expect(calls).toBe(1);
+  });
+
+  it("onEndTag: throws on void elements", async () => {
+    let error;
+    const output = await new HTMLRewriter()
+      .on("br", {
+        element(el) {
+          try {
+            el.onEndTag(() => {});
+          } catch (e) {
+            error = e;
+          }
+        },
+      })
+      .transform(new Response("<br>"))
+      .text();
+    expect(output).toBe("<br>");
+    expect(error?.message).toBe("No end tag.");
+  });
 });
 
 // By not segfaulting, this test passes


### PR DESCRIPTION
## What

When an `HTMLRewriter` element handler calls `element.onEndTag(fn)`, the binding allocated an `EndTagHandler` and gc-protected the callback, but never released either of them. Memory therefore grew with every matching element, across every rewrite, for as long as the process lived — both when the end tag was reached (handler invoked) and when it never appeared (handler never invoked, e.g. unclosed elements).

This change gives those registrations an owner:

- `EndTagHandler.callback` is now a `ProtectedJSValue` (RAII protect/unprotect, same as the other handler types) and is released as soon as the end-tag callback has run (lol-html end-tag handlers are one-shot).
- Each registration's `Box<EndTagHandler>` is owned by the `ElementHandler` that produced the element (reached via the lol-html element user-data slot, which was previously unused).
- `LOLHTMLContext` tracks in-flight rewrites; when the last one for a rewriter finishes (the lol-html rewriter is destroyed first), all end-tag registrations are dropped, covering handlers whose end tag never appeared. Anything still held is released when the rewriter itself is collected.

No JS-observable behavior change: `end.before/after/remove` output, the single invocation per explicitly closed element, the "Expected a function" return for non-callables, and the "No end tag." throw for void elements are unchanged (covered by new tests).

## Verification

- New test in `test/js/workerd/html-rewriter-leak.test.ts`: RSS across repeated transforms with `onEndTag` (both `<div></div>` and unclosed `<div>` inputs) must stay bounded. On bun 1.4.0 it fails (~27 MB growth over the measured window, ~180 bytes per registration); with this change a release build stays flat (0 MB delta, RSS plateau across 12 passes). Like the existing test in that file it skips on debug builds, where allocator tracking drowns the signal.
- New behavior tests in `test/js/workerd/html-rewriter.test.js` (first `onEndTag` coverage in the repo): `end.before/after/remove` output, callback fires only for elements whose end tag appears, and void elements throw "No end tag.". These pass on released bun as well — they pin existing behavior.
- `bun bd test` on `html-rewriter.test.js`, `html-rewriter-leak.test.ts`, `html-rewriter-end-error.test.ts`, `html-rewriter-doctype.test.ts`, and `htmlrewriter-additional-bugs.test.ts`: all pass; same suite also run against a local release build (58 pass / 0 fail).
- `bun run rust:check-all`: 10 ok, 0 failed.

Note: while a rewriter still has another transform in flight, registrations from a finished transform are retained until the rewriter is idle (or collected) — bounded and reclaimable, no longer permanent.