### PR TITLE
yaml: §7.3 DQ escaped-CRLF joins as nothing; combine \\u surrogate pairs

### DIFF
--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -5679,7 +5679,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         if matches!(escape, Escape::LowerU)
             && (0xD800..=0xDBFF).contains(&value)
             && Enc::wide(self.peek(1)) == 0x5C /* '\\' */
-            && Enc::wide(self.peek(2)) == 0x75 /* 'u' */
+            && Enc::wide(self.peek(2)) == 0x75
+        /* 'u' */
         {
             let mut lo: u32 = 0;
             let mut have_lo = true;
@@ -5693,8 +5694,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 }
             }
             if have_lo {
-                if let Some(cp) =
-                    bun_core::strings::decode_surrogate_pair(value as u16, lo as u16)
+                if let Some(cp) = bun_core::strings::decode_surrogate_pair(value as u16, lo as u16)
                 {
                     // Skip `\uXXXX`; the caller's trailing inc(1) lands past it.
                     self.inc(6);

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -5581,7 +5581,14 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 0x5C /* '\\' */ => {
                     self.inc(1);
                     match Enc::wide(self.next()) {
-                        0x0D | 0x0A => {
+                        b @ (0x0D | 0x0A) => {
+                            // [112] s-double-escaped: `\` + b-non-content joins
+                            // as nothing. CRLF is a single b-break — step past
+                            // the CR so fold_lines doesn't count the trailing
+                            // LF as an extra empty line.
+                            if b == 0x0D && Enc::wide(self.peek(1)) == 0x0A {
+                                self.inc(1);
+                            }
                             self.newline();
                             self.inc(1);
                             let lines = self.fold_lines();
@@ -5664,6 +5671,36 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             let num =
                 bun_core::fmt::hex_digit_value_u32(digit).ok_or(ParseError::UnexpectedCharacter)?;
             value = value * 16 + num as u32;
+        }
+
+        // [57] ns-esc-16-bit: a `\u` high surrogate immediately followed by a
+        // `\u` low surrogate combines to one supplementary code point. Peek
+        // non-destructively; only commit when the pair is well-formed.
+        if matches!(escape, Escape::LowerU)
+            && (0xD800..=0xDBFF).contains(&value)
+            && Enc::wide(self.peek(1)) == 0x5C /* '\\' */
+            && Enc::wide(self.peek(2)) == 0x75 /* 'u' */
+        {
+            let mut lo: u32 = 0;
+            let mut have_lo = true;
+            for i in 0..4 {
+                match bun_core::fmt::hex_digit_value_u32(Enc::wide(self.peek(3 + i))) {
+                    Some(d) => lo = lo * 16 + d as u32,
+                    None => {
+                        have_lo = false;
+                        break;
+                    }
+                }
+            }
+            if have_lo {
+                if let Some(cp) =
+                    bun_core::strings::decode_surrogate_pair(value as u16, lo as u16)
+                {
+                    // Skip `\uXXXX`; the caller's trailing inc(1) lands past it.
+                    self.inc(6);
+                    value = cp;
+                }
+            }
         }
 
         if value > 0x10_FFFF {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1879,10 +1879,13 @@ folded: >
           expect(() => YAML.parse("!!float 0x1f")).toThrow();
         });
 
-        test.todo("`\\uXXXX` surrogate pairs combine ([57] ns-esc-16-bit)", () => {
+        test("`\\uXXXX` surrogate pairs combine ([57] ns-esc-16-bit)", () => {
           // js-yaml/eemeli combine surrogate halves to the supplementary code
-          // point. Currently rejected.
-          expect(YAML.parse('"\\uD834\\uDD1E"')).toBe("�\u0084�");
+          // point.
+          expect(YAML.parse('"\\uD834\\uDD1E"')).toBe("\u{1D11E}");
+          // a high surrogate not followed by a `\u` low half still errors.
+          expect(() => YAML.parse('"\\uD834x"')).toThrow();
+          expect(() => YAML.parse('"\\uD834\\n"')).toThrow();
         });
 
         test.todo("s-separate required after tag ([97] c-ns-tag-property)", () => {
@@ -2123,7 +2126,7 @@ folded: >
             expect(YAML.parse(`"\\U0000D800"`)).toEqual("\uD800");
           });
 
-          test.todo("[112] escaped CRLF as b-non-content �\u0086� 'ab' (REAL BUG: bun gives 'a\\nb')", () => {
+          test("[112] escaped CRLF as b-non-content �\u0086� 'ab' (REAL BUG: bun gives 'a\\nb')", () => {
             expect(YAML.parse(`"a\\\r\nb"`)).toEqual("ab");
           });
 


### PR DESCRIPTION
Stacked on #31591. Fixes the **`crlf-escape`** cluster from the spec-gap catalog.



> Part of the per-spec-chapter cluster sweep. `bun bd test test/js/bun/yaml/` → all pass; `tmp/compare.ts` → bun_differs=0; `tmp/verify-suite.ts` → mismatch=0.