### PR TITLE
yaml: §9 strip BOM in l-document-prefix; no spurious null doc for leading ...

### DIFF
--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -2521,6 +2521,20 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
     pub fn parse_stream(&mut self) -> Result<Stream<Enc>, ParseError> {
         let mut docs: Vec<Document> = Vec::new();
 
+        // [211] l-yaml-stream ::= l-document-prefix* l-any-document?
+        //   ( l-document-suffix+ l-document-prefix* l-any-document? | … )*
+        // The first `l-any-document?` is optional, so a leading `...`
+        // (l-document-suffix) does not imply a preceding null document.
+        // Consume any leading suffixes here so `parse_document` doesn't emit
+        // a spurious null root for them.
+        while matches!(self.token.data, TokenData::DocumentEnd) {
+            let document_end_line = self.token.line;
+            self.scan(ScanOptions::default())?;
+            if self.token.line == document_end_line && !matches!(self.token.data, TokenData::Eof) {
+                return Err(Self::unexpected_token());
+            }
+        }
+
         // we want one null document if eof, not zero documents.
         let mut first = true;
         while first || !matches!(self.token.data, TokenData::Eof) {
@@ -6178,6 +6192,20 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     }
                     count_indentation = false;
                     self.inc(1);
+                    continue;
+                }
+                // [3] c-byte-order-mark — [202]/[211] admit BOM in
+                // l-document-prefix before each document, not just at
+                // stream-start (which `init()` handles). At line start, skip
+                // it like whitespace and advance `line_start_pos` so a
+                // following `---`/`...` is still recognized at column 0. A
+                // BOM not at line-start (or a non-BOM 0xEF lead byte) falls
+                // through to scan_plain_scalar via the `_` arm.
+                0xEF | 0xFEFF
+                    if self.is_at_line_start() && Enc::bom_len(self.remain()) > 0 =>
+                {
+                    self.inc(Enc::bom_len(self.remain()));
+                    self.line_start_pos = self.pos;
                     continue;
                 }
                 _ => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -2237,20 +2237,25 @@ folded: >
             expect(() => YAML.parse(`a\n%YAML 1.2\n---\nb`)).toThrow();
           });
 
-          // bun emits a spurious leading null doc for these
-          test.todo.each([`...\nfoo`, `...\n---\nfoo`, `﻿...\nfoo`, `# c\n...\n# c\nfoo`])(
-            "[211] leading `...` before any doc — bun emits spurious null doc: %j",
+          // [211] the first `l-any-document?` is optional, so a stream that
+          // opens with `...` (l-document-suffix) has no preceding null doc.
+          test.each([`...\nfoo`, `...\n---\nfoo`, `﻿...\nfoo`, `# c\n...\n# c\nfoo`])(
+            "[211] leading `...` before any doc — no spurious null doc: %j",
             input => {
-              expect(() => YAML.parse(input)).toThrow();
+              expect(YAML.parse(input)).toBe("foo");
             },
           );
 
-          test.todo("[211]/[202] BOM as inter-doc prefix — bun keeps BOM in content", () => {
-            expect(() => YAML.parse(`a\n...\n﻿b`)).toThrow();
+          test("[211]/[202] BOM as inter-doc prefix — stripped from content", () => {
+            expect(YAML.parse(`a\n...\n﻿b`)).toEqual(["a", "b"]);
           });
 
-          test.todo("[211]/[202] BOM + newline as inter-doc prefix — bun emits BOM as a doc", () => {
-            expect(() => YAML.parse(`a\n...\n﻿\n---\nb`)).toThrow();
+          test("[211]/[202] BOM + newline as inter-doc prefix — not a doc", () => {
+            expect(YAML.parse(`a\n...\n﻿\n---\nb`)).toEqual(["a", "b"]);
+          });
+
+          test("[211]/[202] BOM directly before `---` between docs", () => {
+            expect(YAML.parse(`a\n...\n﻿---\nb`)).toEqual(["a", "b"]);
           });
         });
 


### PR DESCRIPTION
Stacked on #31591. Fixes the **`doc-stream`** cluster from the spec-gap catalog.



> Part of the per-spec-chapter cluster sweep. `bun bd test test/js/bun/yaml/` → all pass; `tmp/compare.ts` → bun_differs=0; `tmp/verify-suite.ts` → mismatch=0.