### PR TITLE
yaml: §8 [162] reject header indicators after s-separate; [185] property before compact ?/-

### DIFF
--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -3883,10 +3883,15 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 // indent ≥ n+1 via s-indent (spaces only); tab separation
                 // either leaves the token at the line's natural indent (≤ n)
                 // or, when spaces preceded the tab, taints tab_after_indent.
+                // The compact branch has no properties production — an
+                // anchor/tag forces the [200] block-collection path, which
+                // requires s-l-comments (a line break) before the collection.
                 TokenData::SequenceEntry | TokenData::MappingKey
                     if self.token.line == indicator_line
                         && (self.token.indent.is_less_than_or_equal(n)
-                            || self.tab_after_indent) =>
+                            || self.tab_after_indent
+                            || value_anchor.is_some()
+                            || value_tag.is_some()) =>
                 {
                     return Err(if self.tab_after_indent {
                         ParseError::TabIndentation
@@ -5012,6 +5017,9 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     continue;
                 }
                 0x20 | 0x09 /* ' ' | '\t' */ => {
+                    // [162] header indicators are adjacent to `|`/`>`; once
+                    // s-separate-in-line is seen we are in [77] s-b-comment —
+                    // only an optional `#…` then b-break/EOF may follow.
                     self.inc(1);
                     self.skip_s_white();
                     if Enc::wide(self.next()) == 0x23 /* '#' */ {
@@ -5019,6 +5027,9 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         while !self.is_b_char_or_eof() {
                             self.inc(1);
                         }
+                    }
+                    if !self.is_b_char_or_eof() {
+                        return Err(ParseError::UnexpectedCharacter);
                     }
                     __c = Enc::wide(self.next());
                     continue;

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1921,7 +1921,7 @@ folded: >
           expect(() => YAML.parse("- &a 1\n- !!str\n  *a")).toThrow();
         });
 
-        test.todo("block-scalar header rejects whitespace before chomp/indent indicator", () => {
+        test("block-scalar header rejects whitespace before chomp/indent indicator", () => {
           // [162] c-b-block-header: no s-separate between `|`/`>` and indicators.
           expect(() => YAML.parse("| 1\n  text")).toThrow();
         });
@@ -2155,7 +2155,7 @@ folded: >
         });
 
         describe("§8.1 Block scalar styles (ch8-block-scalars)", () => {
-          test.todo("[162] chomp after s-separate is not part of header (should error)", () => {
+          test("[162] chomp after s-separate is not part of header (should error)", () => {
             expect(() => YAML.parse(`|1 +\n text\n`)).toThrow();
           });
 
@@ -2169,7 +2169,7 @@ folded: >
         });
 
         describe("§8.2 Block collection styles (ch8-block-collections)", () => {
-          test.todo("[185] anchor between `-` and compact `?` — property blocks compact-map", () => {
+          test("[185] anchor between `-` and compact `?` — property blocks compact-map", () => {
             expect(() => YAML.parse(`- &a ? b\n`)).toThrow();
           });
 


### PR DESCRIPTION
Stacked on #31591. Fixes the **`block-misc`** cluster from the spec-gap catalog.



> Part of the per-spec-chapter cluster sweep. `bun bd test test/js/bun/yaml/` → all pass; `tmp/compare.ts` → bun_differs=0; `tmp/verify-suite.ts` → mismatch=0.