### PR TITLE
yaml: §6 reject newline between FLOW-KEY property and content

### DIFF
--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -3839,6 +3839,16 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     self.token.indent.is_less_than_or_equal(n)
                 };
                 if belongs_to_parent {
+                    // [63]/[78] e-node here means the indicator's value is
+                    // empty and what follows is s-l-comments. A tab-only final
+                    // line satisfies l-comment only with a trailing b-comment;
+                    // at EOF the tab is stranded as neither s-indent nor
+                    // separation-before-content. (Tab-only *blank* lines —
+                    // tab then newline — reset tab_after_indent in newline()
+                    // and are accepted as l-comment.)
+                    if self.tab_after_indent && matches!(self.token.data, TokenData::Eof) {
+                        return Err(ParseError::TabIndentation);
+                    }
                     // The post-property re-scan baked `value_tag` into a plain
                     // scalar's resolution (`ScanOptions.tag`); if that scalar
                     // is now abandoned to the parent, rewind to its start and
@@ -4013,21 +4023,34 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 }
 
                 TokenData::Anchor(_anchor) => {
+                    let prop_line = self.token.line;
                     node_props.set_anchor(self.token.clone())?;
                     self.scan(ScanOptions {
                         tag: node_props.tag(),
                         ..Default::default()
                     })?;
+                    // [80] s-separate(n,FLOW-KEY) = s-separate-in-line — an
+                    // implicit flow-map key's c-ns-properties must stay on the
+                    // key's line. parse_flow_explicit_key pre-scans properties
+                    // before pushing FlowKey, so explicit `?` keys never reach
+                    // this arm with FlowKey set.
+                    if self.context.get() == Context::FlowKey && self.token.line != prop_line {
+                        return Err(ParseError::MultilineImplicitKey);
+                    }
                     continue;
                 }
 
                 TokenData::Tag(tag) => {
                     let tag = *tag;
+                    let prop_line = self.token.line;
                     node_props.set_tag(self.token.clone())?;
                     self.scan(ScanOptions {
                         tag,
                         ..Default::default()
                     })?;
+                    if self.context.get() == Context::FlowKey && self.token.line != prop_line {
+                        return Err(ParseError::MultilineImplicitKey);
+                    }
                     continue;
                 }
 

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1997,12 +1997,24 @@ folded: >
             expect(YAML.parse(`'a'#c`)).toEqual("a");
           });
 
-          test.todo("[80] FLOW-KEY: newline between tag and key (s-separate-in-line only)", () => {
+          test("[80] FLOW-KEY: newline between tag and key (s-separate-in-line only)", () => {
             expect(() => YAML.parse(`{!!str\na: 1}`)).toThrow();
+            expect(() => YAML.parse(`{&a\nx: 1}`)).toThrow();
+            expect(() => YAML.parse(`{!!str &x\na: 1}`)).toThrow();
+            expect(() => YAML.parse(`{!!str\n&x a: 1}`)).toThrow();
+            // explicit `?` key uses s-separate(n,c) — newline allowed
+            expect(YAML.parse(`{? !!str\na: 1}`)).toEqual({ a: 1 });
+            // FLOW-IN value position uses s-separate-lines — newline allowed
+            expect(YAML.parse(`[!!str\na]`)).toEqual(["a"]);
+            expect(YAML.parse(`{a: !!str\nb}`)).toEqual({ a: "b" });
           });
 
-          test.todo("[63]/[78] value is tab-only line then EOF", () => {
+          test("[63]/[78] value is tab-only line then EOF", () => {
             expect(() => YAML.parse(`a:\n\t`)).toThrow();
+            expect(() => YAML.parse(`-\n\t`)).toThrow();
+            // tab then newline is l-comment (b-comment present) — accepted,
+            // see "tab-only blank line in block context" describe below.
+            expect(YAML.parse(`a:\n\t\n`)).toEqual({ a: null });
           });
         });
 


### PR DESCRIPTION
Stacked on #31591. Fixes the **`structure-misc`** cluster from the spec-gap catalog.



> Part of the per-spec-chapter cluster sweep. `bun bd test test/js/bun/yaml/` → all pass; `tmp/compare.ts` → bun_differs=0; `tmp/verify-suite.ts` → mismatch=0.