### PR TITLE
Normalize scope-object `this` in mock function calls to prevent leak/crash

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -838,7 +838,11 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     }
 
     JSC::ArgList args = JSC::ArgList(callframe);
-    JSValue thisValue = callframe->thisValue();
+    // For `f()` calls where `f` resolves through a scope, JSC passes the resolved
+    // JSScope as the unconverted `this` argument and relies on the callee's ToThis to
+    // normalize it. Host functions never run ToThis, so normalize here to avoid leaking
+    // an engine-internal scope object through mockReturnThis / the contexts array.
+    JSValue thisValue = callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict());
     JSC::JSArray* argumentsArray = nullptr;
     {
         JSC::ObjectInitializationScope object(vm);

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -238,6 +238,18 @@ describe("mock()", () => {
     const obj = { fn };
     expect(obj.fn()).toBe(obj);
   });
+  test("mockReturnThis on a closure-captured mock does not leak a scope object", () => {
+    // When a mock is called as a bare identifier captured by a closure, JSC passes the
+    // enclosing environment record as the unconverted `this`. mockReturnThis must not hand
+    // that engine-internal scope object back to JavaScript (reading a TDZ binding from it
+    // surfaces the empty JSValue and crashes the interpreter on a later `typeof`).
+    const fn = jest.fn().mockReturnThis();
+    const capture = () => fn;
+    expect(capture()).toBe(fn);
+    const result = fn();
+    expect(result).toBeUndefined();
+    expect(typeof result === "function").toBe(false);
+  });
   if (isBun) {
     test("jest.fn(10) return value shorthand", () => {
       expect(jest.fn(10)()).toBe(10);


### PR DESCRIPTION
### What

Fixes a fuzzer-found deterministic crash (fingerprint `signal:SIGNED_RIGHT_SHIFT`, SIGSEGV in `llint_op_typeof_is_function`) caused by a JSC-internal scope object escaping to JavaScript through a mock function.

### Repro

```js
const fn = Bun.jest().mock().mockReturnThis();
const capture = () => fn;   // closure-capture → the call below resolves `fn` through a scope
const leaked = fn();        // returns the enclosing JSLexicalEnvironment
typeof leaked === "function"; // dereferences a null cell in the LLInt → SIGSEGV
```

On a release build the same script returns `[native code: JSLexicalEnvironment]` from `fn()` instead of `undefined` — the engine-internal environment record is observable from JS.

### Root cause

For a call like `f()` where `f` resolves through a scope (a closure-captured variable, a module binding, or a global), JSC's bytecode passes the resolved `JSScope` — a `JSLexicalEnvironment`, module environment, `with` scope, or the raw global object — as the unconverted `this` argument and relies on the callee's `ToThis` to normalize it (`FunctionCallResolveNode::emitBytecode`). JS callees run `op_to_this`; host functions read the raw slot.

`jsMockFunctionCall` reads `callframe->thisValue()` and, for a `mockReturnThis()`-configured mock, returns it directly (and also pushes it into `mock.contexts`). When the mock is scope-resolved, that raw value is a scope object. Once it's in JS, reading a binding still in its temporal dead zone yields the empty `JSValue` (the TDZ marker), and a later `typeof x === "function"` dereferences a null cell in the LLInt.

### Fix

Normalize the `this` value with `toThis(globalObject, ECMAMode::strict())` right after reading it in `jsMockFunctionCall`, mirroring the existing pattern in `CallSite.cpp` and `JSBuffer.cpp`. Strict mode is the correct choice here:

- a normal object `this` (e.g. `obj.fn()`) passes through unchanged — `mock.contexts` and `mockReturnThis` still observe it;
- `undefined`/`null` stay as-is — bare `fn()` already returned `undefined`, and that's preserved;
- a `JSScope` becomes `undefined` — exactly what a strict JS callee would see, and what closes the leak.

### Tests

Added a regression test in `mock-fn.test.js` covering the closure-captured `mockReturnThis` case. Verified it fails without the fix (returns the leaked `JSLexicalEnvironment`) and passes with it. All 72 existing `mock-fn` tests still pass.