### PR TITLE
repl: clear every wrapped row before redrawing the input line

### DIFF
--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -121,7 +121,7 @@ use bun_core::output::ansi as Color;
 struct Cursor;
 impl Cursor {
     const HOME: &'static str = concat!("\x1b", "[", "H");
-    const CLEAR_LINE: &'static str = concat!("\x1b", "[", "2K");
+    const CLEAR_TO_EOL: &'static str = concat!("\x1b", "[", "0K");
     const CLEAR_SCREEN: &'static str = concat!("\x1b", "[", "2J");
     const CLEAR_SCROLLBACK: &'static str = concat!("\x1b", "[", "3J");
 }
@@ -756,6 +756,7 @@ fn cmd_clear(repl: &mut Repl, _: &[u8]) -> ReplResult {
     repl.write(Cursor::CLEAR_SCREEN.as_bytes());
     repl.write(Cursor::CLEAR_SCROLLBACK.as_bytes());
     repl.write(Cursor::HOME.as_bytes());
+    repl.reset_render_tracking();
     ReplResult::SkipEval
 }
 
@@ -886,10 +887,29 @@ pub(super) struct Repl<'a> {
     editor_mode: bool,
     running: bool,
     is_tty: bool,
+    // Whether stdout is a terminal. Distinct from `is_tty` (which also requires
+    // stdin): the prompt-rendering escapes go to stdout, so a piped-stdin
+    // session with a real stdout terminal (`echo … | bun repl`) still needs the
+    // real width for `refresh_line`'s multi-row cursor math.
+    stdout_is_tty: bool,
     use_colors: bool,
-    terminal_width: u16,
+    // `Cell` because `refresh_line` (which takes `&self`) re-queries the live
+    // terminal width on every redraw so a mid-session resize can't leave the
+    // multi-row cursor math pointed at the wrong number of columns.
+    terminal_width: core::cell::Cell<u16>,
     terminal_height: u16,
     ctrl_c_pressed: bool,
+
+    // Multi-row render tracking for `refresh_line`. When the prompt + input is
+    // wider than the terminal it wraps onto several physical rows; the next
+    // redraw must erase all of them, not just the row the cursor sits on.
+    // `prev_render_rows` is the number of rows the previous redraw occupied and
+    // `prev_cursor_row` is the 1-based row the cursor ended on within it. These
+    // are `Cell`s so that `print`/`print_error` (which take `&self` and commit
+    // the current line with a trailing newline) can reset the tracking without a
+    // mutable borrow.
+    prev_render_rows: core::cell::Cell<u16>,
+    prev_cursor_row: core::cell::Cell<u16>,
 
     // Buffered stdin
     stdin_buf: [u8; 256],
@@ -922,10 +942,13 @@ impl<'a> Repl<'a> {
             editor_mode: false,
             running: false,
             is_tty: false,
+            stdout_is_tty: false,
             use_colors: false,
-            terminal_width: 80,
+            terminal_width: core::cell::Cell::new(80),
             terminal_height: 24,
             ctrl_c_pressed: false,
+            prev_render_rows: core::cell::Cell::new(1),
+            prev_cursor_row: core::cell::Cell::new(1),
             stdin_buf: [0u8; 256],
             stdin_buf_start: 0,
             stdin_buf_end: 0,
@@ -954,8 +977,79 @@ impl<'a> Repl<'a> {
     // Terminal I/O
     // ========================================================================
 
+    /// Best-effort terminal size as `(cols, rows)`. The live OS window size
+    /// (`TIOCGWINSZ` / `GetConsoleScreenBufferInfo`) wins; `COLUMNS`/`LINES` are
+    /// only a fallback. Because this width drives cursor *positioning* (not just
+    /// text wrapping), the real PTY size must take precedence over a possibly
+    /// stale exported `COLUMNS`. Returns `None` when nothing reports a usable
+    /// width, leaving the caller's default. `Output::TERMINAL_SIZE` is never
+    /// populated, so it is not consulted.
+    fn detect_terminal_size() -> Option<(u16, u16)> {
+        let env_dim = |key: &bun_core::ZStr| -> Option<u16> {
+            match bun_core::fmt::parse_int::<u16>(bun_core::getenv_z(key)?, 10) {
+                Ok(n) if n > 0 => Some(n),
+                _ => None,
+            }
+        };
+        let env_cols = env_dim(bun_core::zstr!("COLUMNS"));
+        let env_rows = env_dim(bun_core::zstr!("LINES"));
+
+        let mut os_cols: u16 = 0;
+        let mut os_rows: u16 = 0;
+        #[cfg(unix)]
+        {
+            // SAFETY: all-zero is a valid winsize (#[repr(C)] POD).
+            let mut size: libc::winsize = bun_core::ffi::zeroed();
+            // SAFETY: ioctl with a valid winsize out-ptr; a bad fd just errors.
+            if unsafe { libc::ioctl(libc::STDOUT_FILENO, libc::TIOCGWINSZ, &raw mut size) } == 0 {
+                os_cols = size.ws_col;
+                os_rows = size.ws_row;
+            }
+        }
+        #[cfg(windows)]
+        {
+            if let Some(handle) = sys::windows::GetStdHandle(sys::windows::STD_OUTPUT_HANDLE) {
+                // SAFETY: all-zero is a valid CONSOLE_SCREEN_BUFFER_INFO (#[repr(C)] POD).
+                let mut csbi: sys::windows::CONSOLE_SCREEN_BUFFER_INFO =
+                    unsafe { bun_core::ffi::zeroed_unchecked() };
+                // SAFETY: FFI Win32 `GetConsoleScreenBufferInfo`; `handle` is a
+                // valid console output HANDLE and `csbi` a valid out-ptr.
+                if unsafe { sys::windows::kernel32::GetConsoleScreenBufferInfo(handle, &mut csbi) }
+                    != sys::windows::FALSE
+                {
+                    let w = csbi.srWindow.Right - csbi.srWindow.Left + 1;
+                    let h = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
+                    os_cols = u16::try_from(w.max(0)).unwrap_or(0);
+                    os_rows = u16::try_from(h.max(0)).unwrap_or(0);
+                }
+            }
+        }
+
+        // Live PTY size wins; COLUMNS/LINES only fill in when the ioctl/console
+        // query reports nothing usable.
+        let cols = (os_cols > 0).then_some(os_cols).or(env_cols)?;
+        let rows = (os_rows > 0).then_some(os_rows).or(env_rows).unwrap_or(0);
+        Some((cols, rows))
+    }
+
     fn setup_terminal(&mut self) {
-        self.is_tty = Output::is_stdout_tty() && Output::is_stdin_tty();
+        self.stdout_is_tty = Output::is_stdout_tty();
+        self.is_tty = self.stdout_is_tty && Output::is_stdin_tty();
+
+        // Get terminal size whenever stdout is a terminal — even if stdin is a
+        // pipe (`echo … | bun repl`), the prompt escapes still go to stdout and
+        // `refresh_line`'s multi-row clearing depends on `terminal_width`
+        // matching the real terminal, otherwise its cursor-up sequences walk
+        // into rows the REPL doesn't own. `Output::TERMINAL_SIZE` is never
+        // populated, so query the OS size directly.
+        if self.stdout_is_tty {
+            if let Some((cols, rows)) = Self::detect_terminal_size() {
+                self.terminal_width.set(cols);
+                if rows > 0 {
+                    self.terminal_height = rows;
+                }
+            }
+        }
 
         if !self.is_tty {
             self.use_colors = false;
@@ -964,13 +1058,6 @@ impl<'a> Repl<'a> {
 
         // Check for NO_COLOR
         self.use_colors = !env_var::NO_COLOR.get().unwrap_or(false);
-
-        // Get terminal size
-        let ts = Output::TERMINAL_SIZE.load();
-        if ts.col > 0 {
-            self.terminal_width = ts.col;
-            self.terminal_height = ts.row;
-        }
 
         // Enable raw mode
         #[cfg(unix)]
@@ -1061,10 +1148,18 @@ impl<'a> Repl<'a> {
     }
 
     fn print(&self, args: Arguments<'_>) {
+        // If a multi-row line is on screen with the cursor parked on an interior
+        // row (e.g. after Home on a wrapped line), drop to its last row first so
+        // the committing newline lands below everything rendered, not through it.
+        self.snap_to_render_end();
         let _ = Output::writer().write_fmt(args);
+        // Every REPL `print` ends its output with a newline, committing the
+        // current line; the next `refresh_line` starts fresh below it.
+        self.reset_render_tracking();
     }
 
     fn print_error(&self, args: Arguments<'_>) {
+        self.snap_to_render_end();
         if self.use_colors {
             let w = Output::writer();
             let _ = w.write_all(Color::RED.as_bytes());
@@ -1073,6 +1168,7 @@ impl<'a> Repl<'a> {
         } else {
             let _ = Output::writer().write_fmt(args);
         }
+        self.reset_render_tracking();
     }
 
     fn read_byte(&mut self) -> Option<u8> {
@@ -1237,6 +1333,21 @@ impl<'a> Repl<'a> {
         2 // "> " or "\u{276f} "
     }
 
+    /// Emit a CSI sequence of the form `ESC[<n><final>` (e.g. `ESC[3A` to move
+    /// the cursor up 3 rows). A count of zero is a no-op so callers don't have
+    /// to guard it.
+    fn write_csi_count(&self, count: usize, final_byte: u8) {
+        if count == 0 {
+            return;
+        }
+        let mut buf = [0u8; 16];
+        let mut w: &mut [u8] = &mut buf;
+        if write!(w, "{}{}{}", CSI, count, final_byte as char).is_ok() {
+            let written = 16 - w.len();
+            self.write(&buf[..written]);
+        }
+    }
+
     fn refresh_line(&self) {
         // Flush any buffered output (e.g., from console.log in JS) before drawing prompt
         Output::flush();
@@ -1244,40 +1355,105 @@ impl<'a> Repl<'a> {
         let prompt = self.get_prompt();
         let prompt_len = self.get_prompt_length();
         let line = self.line_editor.get_line();
+        let line_len = line.len();
+        let cursor = self.line_editor.cursor;
 
-        // Move to beginning of line
+        // Re-query the live width so a mid-session terminal resize can't leave
+        // the multi-row cursor math (below) pointed at a stale column count —
+        // the same hazard as the never-populated startup width, but reachable
+        // by resizing after startup. Gated on stdout (not `is_tty`) so a
+        // piped-stdin session still tracks its real stdout width; a non-TTY
+        // stdout or failed query keeps the current value.
+        if self.stdout_is_tty {
+            if let Some((cols, _rows)) = Self::detect_terminal_size() {
+                self.terminal_width.set(cols);
+            }
+        }
+
+        let cols = (self.terminal_width.get() as usize).max(1);
+
+        // Rows the freshly-drawn content will occupy, and the row the cursor
+        // ends on, both derived the same way as linenoise's multi-line refresh.
+        // `cursor` is a byte offset, but the terminal wraps on display columns,
+        // so measure the visible width of the text — multi-byte UTF-8 and wide
+        // (e.g. CJK) characters then advance the column correctly.
+        let end_col = prompt_len + strings::visible::width::exclude_ansi_colors::utf8(line);
+        let cursor_col =
+            prompt_len + strings::visible::width::exclude_ansi_colors::utf8(&line[..cursor]);
+        let mut rows = end_col.div_ceil(cols).max(1);
+        let old_rows = self.prev_render_rows.get() as usize;
+        let old_cursor_row = self.prev_cursor_row.get() as usize;
+
+        // --- Erase the previous (possibly multi-row) render ---
+        // Drop down to the last row of the old render, then clear each row from
+        // the bottom up so no stale wrapped copies are left behind.
+        self.write_csi_count(old_rows.saturating_sub(old_cursor_row), b'B');
+        for _ in 0..old_rows.saturating_sub(1) {
+            self.write(b"\r");
+            self.write(Cursor::CLEAR_TO_EOL.as_bytes());
+            self.write_csi_count(1, b'A');
+        }
         self.write(b"\r");
-        self.write(Cursor::CLEAR_LINE.as_bytes());
+        self.write(Cursor::CLEAR_TO_EOL.as_bytes());
 
         // Write prompt
         self.write(prompt);
 
         // Write line with syntax highlighting
-        if self.use_colors && !line.is_empty() && line.len() <= 2048 {
+        if self.use_colors && line_len > 0 && line_len <= 2048 {
             self.write_highlighted(line);
         } else {
             self.write(line);
         }
 
-        // Position cursor. The cursor is a byte offset, but the terminal column
-        // is the display width of the text before it, so multi-byte UTF-8 and
-        // wide (e.g. CJK) characters advance the column correctly.
-        let cursor_col =
-            strings::visible::width::exclude_ansi_colors::utf8(&line[..self.line_editor.cursor]);
-        let cursor_pos = prompt_len + cursor_col;
-        if cursor_pos < self.terminal_width as usize {
-            self.write(b"\r");
-            if cursor_pos > 0 {
-                let mut buf = [0u8; 16];
-                let mut w: &mut [u8] = &mut buf;
-                if write!(w, "{}{}C", CSI, cursor_pos).is_ok() {
-                    let written = 16 - w.len();
-                    self.write(&buf[..written]);
-                }
-            }
+        // If the cursor is at the end of content that exactly fills the last
+        // row, force a new row so the cursor doesn't hang off the right edge
+        // (where terminals disagree about whether it has wrapped yet). This
+        // also keeps `cursor_row <= rows` below when the content — even just
+        // the prompt on an empty line — lands exactly on a column boundary.
+        if cursor == line_len && end_col.is_multiple_of(cols) {
+            self.write(b"\n\r");
+            rows += 1;
         }
 
+        // --- Reposition the cursor to where it logically belongs ---
+        // Rows are 1-based here: the cursor always sits on at least row 1.
+        let cursor_row = (cursor_col / cols) + 1;
+        self.write_csi_count(rows.saturating_sub(cursor_row), b'A');
+        self.write(b"\r");
+        self.write_csi_count(cursor_col % cols, b'C');
+
+        // Record what we just drew so the next refresh can erase it.
+        self.prev_render_rows
+            .set(rows.min(u16::MAX as usize) as u16);
+        self.prev_cursor_row
+            .set(cursor_row.min(u16::MAX as usize) as u16);
+
         Output::flush();
+    }
+
+    /// Forget the previous `refresh_line` render. Call this after emitting
+    /// output that moves to a fresh line (a committing newline, a screen
+    /// clear): those rows are no longer ours to erase, so the next redraw must
+    /// start from a clean single-row state.
+    fn reset_render_tracking(&self) {
+        self.prev_render_rows.set(1);
+        self.prev_cursor_row.set(1);
+    }
+
+    /// Move the terminal cursor to the last row of the current render. After
+    /// editing a wrapped line the cursor can sit on an interior row; dropping to
+    /// the bottom first means a following committing newline lands *below* all
+    /// rendered rows instead of leaving a stale tail beneath it. No-op (and no
+    /// bytes emitted) when the cursor is already on the last row, so the common
+    /// end-of-line paths behave exactly as before.
+    fn snap_to_render_end(&self) {
+        let rows = self.prev_render_rows.get() as usize;
+        let cursor_row = self.prev_cursor_row.get() as usize;
+        if rows > cursor_row {
+            self.write_csi_count(rows - cursor_row, b'B');
+            self.write(b"\r");
+        }
     }
 
     fn write_highlighted(&self, text: &[u8]) {
@@ -2079,6 +2255,7 @@ impl<'a> Repl<'a> {
                 Key::CtrlL => {
                     self.write(Cursor::CLEAR_SCREEN.as_bytes());
                     self.write(Cursor::HOME.as_bytes());
+                    self.reset_render_tracking();
                     self.refresh_line();
                 }
                 Key::CtrlA => {

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -37,14 +37,21 @@ async function runRepl(
 
 const stripAnsi = Bun.stripANSI;
 
+// Width of the PTY used by withTerminalRepl. The REPL queries the real
+// terminal width (TIOCGWINSZ), so tests that reconstruct the rendered grid
+// must use this same width to match how the REPL wrapped its output.
+const TERMINAL_REPL_COLS = 120;
+
 // Helper to run REPL in a PTY and interact with it
 async function withTerminalRepl(
   fn: (helpers: {
     terminal: Bun.Terminal;
     proc: Bun.ChildProcess;
+    cols: number;
     send: (text: string) => void;
     waitFor: (pattern: string | RegExp, timeoutMs?: number) => Promise<string>;
     allOutput: () => string;
+    rawOutput: () => string;
   }) => Promise<void>,
 ) {
   const received: string[] = [];
@@ -52,7 +59,7 @@ async function withTerminalRepl(
   let resolveWaiter: (() => void) | null = null;
 
   await using terminal = new Bun.Terminal({
-    cols: 120,
+    cols: TERMINAL_REPL_COLS,
     rows: 40,
     data(_term, data) {
       const str = Buffer.from(data).toString();
@@ -101,15 +108,128 @@ async function withTerminalRepl(
   };
 
   const allOutput = () => stripAnsi(received.join(""));
+  const rawOutput = () => received.join("");
 
   await waitFor(/\u276f|> /); // Wait for prompt
 
-  await fn({ terminal, proc, send, waitFor, allOutput });
+  await fn({ terminal, proc, cols: TERMINAL_REPL_COLS, send, waitFor, allOutput, rawOutput });
 
   // Clean exit
   send(".exit\n");
   await Promise.race([proc.exited, Bun.sleep(2000)]);
   if (!proc.killed) proc.kill();
+}
+
+// Replay a stream of terminal output (including cursor-movement and
+// erase escapes) into a character grid and return the visible rows. This
+// lets a test assert what the user actually SEES after the REPL's many
+// in-place redraws, rather than how many bytes were written. Implements DEC
+// deferred line-wrap (the "last column" flag used by xterm/vte): writing the
+// final column of a row leaves the cursor pending, so an explicit newline that
+// follows does not double-advance. The grid only grows (never scrolls) so row
+// indices stay stable across the whole stream.
+function renderTerminalGrid(output: string, cols: number): string[] {
+  const grid: string[][] = [];
+  const ensure = (row: number) => {
+    while (grid.length <= row) grid.push(Array(cols).fill(" "));
+  };
+  let row = 0;
+  let col = 0;
+  let pendingWrap = false;
+
+  for (let i = 0; i < output.length; i++) {
+    const ch = output[i];
+    const code = output.charCodeAt(i);
+
+    if (ch === "\r") {
+      col = 0;
+      pendingWrap = false;
+      continue;
+    }
+    if (ch === "\n") {
+      pendingWrap = false;
+      row++;
+      ensure(row);
+      continue;
+    }
+    if (code === 0x1b) {
+      if (output[i + 1] === "[") {
+        // CSI sequence: ESC [ <params> <final>
+        let j = i + 2;
+        let params = "";
+        while (j < output.length && /[0-9;?]/.test(output[j])) params += output[j++];
+        const final = output[j];
+        const n = parseInt(params, 10);
+        const count = Number.isNaN(n) ? 1 : n;
+        ensure(row);
+        switch (final) {
+          // Cursor-moving sequences clear the pending-wrap flag.
+          case "A": // cursor up
+            row = Math.max(0, row - count);
+            pendingWrap = false;
+            break;
+          case "B": // cursor down
+            row += count;
+            ensure(row);
+            pendingWrap = false;
+            break;
+          case "C": // cursor forward
+            col = Math.min(cols - 1, col + count);
+            pendingWrap = false;
+            break;
+          case "D": // cursor back
+            col = Math.max(0, col - count);
+            pendingWrap = false;
+            break;
+          case "H": // cursor home
+          case "f":
+            row = 0;
+            col = 0;
+            pendingWrap = false;
+            break;
+          case "K": // erase in line (0/default = to end, 2 = whole line)
+            if (params === "" || params === "0") for (let x = col; x < cols; x++) grid[row][x] = " ";
+            else if (params === "2") grid[row].fill(" ");
+            break;
+          case "J": // erase in display (0/default = below, 2 = all)
+            if (params === "" || params === "0") {
+              for (let x = col; x < cols; x++) grid[row][x] = " ";
+              for (let y = row + 1; y < grid.length; y++) grid[y].fill(" ");
+            } else if (params === "2") {
+              for (const r of grid) r.fill(" ");
+            }
+            break;
+          // SGR ("m") and other sequences do not move the cursor, so they
+          // must NOT clear a pending wrap (xterm behavior).
+        }
+        i = j;
+        continue;
+      }
+      if (output[i + 1] === "]") {
+        // OSC sequence (e.g. clipboard) terminated by BEL — skip it entirely.
+        let j = i + 1;
+        while (j < output.length && output.charCodeAt(j) !== 0x07) j++;
+        i = j;
+        continue;
+      }
+      continue; // lone ESC / unsupported
+    }
+    if (code < 0x20) continue; // other control bytes
+
+    // Printable: apply any deferred wrap, then write.
+    if (pendingWrap) {
+      row++;
+      col = 0;
+      pendingWrap = false;
+      ensure(row);
+    }
+    ensure(row);
+    grid[row][col] = ch;
+    if (col === cols - 1) pendingWrap = true;
+    else col++;
+  }
+
+  return grid.map(r => r.join("").replace(/\s+$/, ""));
 }
 
 describe.concurrent("Bun REPL", () => {
@@ -1173,6 +1293,173 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
       terminal.write(new Uint8Array([0xc2, 0x62])); // stray lead + 'b'
       send('".length\n');
       await waitFor(/\n\s*2\b/);
+    });
+  });
+
+  // https://github.com/oven-sh/bun/issues/31604
+  // Pasting a single line that is wider than the terminal used to re-render the
+  // whole line once per pasted byte while only clearing the row the cursor sat
+  // on, so every wrapped row piled up and the screen filled with hundreds of
+  // stale copies. refresh_line now erases every row the previous render used
+  // before redrawing, so the line appears once (wrapped), not repeated.
+  test("pasting a long wrapping line does not spam the screen (issue #31604)", async () => {
+    await withTerminalRepl(async ({ send, waitFor, rawOutput, cols }) => {
+      // The exact payload from the issue: one physical line (the `\n` are
+      // literal backslash-n, not newlines) long enough to wrap several rows
+      // (399 chars wraps at the 120-column PTY).
+      const payload = String.raw`.copy "pub const panic = _bun.crash_handler.panic;\npub const std_options = std.Options{\n    .enable_segfault_handler = false,\n    // Use BoringSSL's RAND_bytes instead of the default getrandom() syscall.\n    // BoringSSL falls back to /dev/urandom on older kernels (< 3.17) where\n    // the getrandom syscall doesn't exist, avoiding a panic on ENOSYS.\n    .cryptoRandomSeed = _bun.csprng,\n};"`;
+      send(payload);
+
+      // Wait for the payload's true tail (the last bytes: `…csprng,\n};"`, the
+      // `\n` being literal backslash-n). Matching the real end guarantees the
+      // resolving chunk extends through the final redraw's rewrite, so the grid
+      // isn't sampled mid-refresh with the prompt row momentarily cleared.
+      await waitFor(String.raw`.cryptoRandomSeed = _bun.csprng,\n};"`);
+
+      // Replay the terminal output into a grid at the PTY's width (the REPL
+      // wraps at the real terminal width) and inspect what's actually visible.
+      // The distinctive prefix `.copy "pub const panic` lives on the first
+      // wrapped row only, so counting rows that contain it tells us how many
+      // stacked copies survived. The fix leaves exactly one; the bug left
+      // hundreds.
+      const rows = renderTerminalGrid(rawOutput(), cols).filter(line => line.length > 0);
+      const copies = rows.filter(line => line.includes('.copy "pub const panic')).length;
+
+      expect(copies).toBe(1);
+      // The wrapped line occupies a handful of rows; the bug produced hundreds.
+      expect(rows.length).toBeLessThan(20);
+    });
+  });
+
+  // https://github.com/oven-sh/bun/issues/27670
+  // Minimal form of the same bug: pasting a run of characters wider than the
+  // terminal produced one duplicate line per overflowing character.
+  test("pasting a line of repeated characters wraps once (issue #27670)", async () => {
+    await withTerminalRepl(async ({ send, waitFor, rawOutput, cols }) => {
+      // A distinctive tail at the end of the payload is only echoed once the
+      // whole (wrapped) line has been rendered, so waiting for it is
+      // deterministic — no fixed sleeps that could sample a partial redraw.
+      // Make it comfortably wider than the terminal so it definitely wraps.
+      const tail = "__END27670";
+      const fill = cols * 2;
+      send('.copy "' + Buffer.alloc(fill - tail.length, "a").toString() + tail + '"');
+      await waitFor(tail + '"');
+
+      const rows = renderTerminalGrid(rawOutput(), cols).filter(line => line.length > 0);
+      const copies = rows.filter(line => /^[❯>] \.copy "a/.test(line)).length;
+
+      expect(copies).toBe(1);
+      expect(rows.length).toBeLessThan(20);
+    });
+  });
+
+  // https://github.com/oven-sh/bun/issues/27461 (line-wrap half)
+  // Same root cause reached by typing rather than pasting: once the input grew
+  // past the terminal edge, every subsequent keystroke re-emitted the whole
+  // line without clearing the earlier wrapped rows. (The separate typing
+  // flicker reported in that issue — the line is still redrawn per keystroke —
+  // is not addressed here.)
+  test("typing past the terminal width wraps once (issue #27461)", async () => {
+    await withTerminalRepl(async ({ send, waitFor, rawOutput, cols }) => {
+      // Unique tail typed last; waiting for it means the final keystroke's
+      // redraw has landed before we sample the grid. Type well past the
+      // terminal edge so the line wraps.
+      const tail = "__END27461";
+      const text = 'console.log("' + Buffer.alloc(cols * 2 - tail.length, "a").toString() + tail;
+      // Send one byte at a time so each is a distinct keystroke/redraw.
+      for (const ch of text) send(ch);
+      await waitFor(tail);
+
+      const rows = renderTerminalGrid(rawOutput(), cols).filter(line => line.length > 0);
+      const copies = rows.filter(line => line.includes('console.log("a')).length;
+
+      expect(copies).toBe(1);
+      expect(rows.length).toBeLessThan(20);
+    });
+  });
+
+  // The multi-row clear walks the cursor up based on the terminal width, so the
+  // REPL must know the *real* width. If it assumed a narrower width than the PTY,
+  // typing past that assumed width would make it clear rows it doesn't own —
+  // eating earlier output like the welcome banner. Type a line that fits on one
+  // physical row at the PTY width and confirm nothing above the prompt is erased.
+  test("does not erase earlier output on a wide terminal", async () => {
+    await withTerminalRepl(async ({ send, waitFor, rawOutput, cols }) => {
+      // Comfortably under the PTY width so it must NOT wrap (would have been
+      // treated as wrapped under the old hardcoded 80-column assumption).
+      const tail = "__NOWRAP";
+      const text = Buffer.alloc(Math.floor(cols * 0.7) - tail.length, "a").toString() + tail;
+      for (const ch of text) send(ch);
+      await waitFor(tail);
+
+      const rows = renderTerminalGrid(rawOutput(), cols).filter(line => line.length > 0);
+      // The welcome banner printed at startup must still be on screen.
+      expect(rows.some(line => line.includes("Welcome to Bun"))).toBe(true);
+      // The input fits on one row, so exactly one row carries it.
+      expect(rows.filter(line => line.includes(tail)).length).toBe(1);
+    });
+  });
+
+  // terminal_width must track mid-session resizes: refresh_line re-queries it
+  // each redraw. After narrowing the terminal, a line that fit before now wraps,
+  // and the REPL must clear/redraw at the new width (one copy), not the old one.
+  test("tracks a mid-session terminal resize", async () => {
+    await withTerminalRepl(async ({ terminal, send, waitFor, rawOutput }) => {
+      const narrow = 40;
+      terminal.resize(narrow, 40);
+
+      // A line wider than the new width but not the old one: it must wrap at 40.
+      // refresh_line re-queries the width on every keystroke, so the resize is
+      // picked up as the line is typed (no prompt is re-emitted on resize, so
+      // there's nothing to wait on until the tail echoes back).
+      const tail = "__RESIZED";
+      const text = Buffer.alloc(narrow * 2 - tail.length, "Z").toString() + tail;
+      for (const ch of text) send(ch);
+      await waitFor(tail);
+
+      const rows = renderTerminalGrid(rawOutput(), narrow).filter(line => line.length > 0);
+      // Rendered once at the new width: the prompt row appears exactly once and
+      // the screen isn't flooded with stale copies.
+      const promptRows = rows.filter(line => /^[❯>] Z/.test(line)).length;
+      expect(promptRows).toBe(1);
+      expect(rows.length).toBeLessThan(20);
+    });
+  });
+
+  // Editing a wrapped line and then committing (here: Ctrl+C) from an interior
+  // cursor row must not leave the tail of the cancelled input stranded below the
+  // fresh prompt. The commit paths snap the cursor to the bottom of the render
+  // before emitting their newline.
+  test("cancelling a wrapped line from the start leaves no stale tail", async () => {
+    await withTerminalRepl(async ({ send, waitFor, rawOutput, cols }) => {
+      // Fill with a distinctive character that appears nowhere in the prompt,
+      // the `^C`, or the post-cancel output — so finding it below the `^C` row
+      // unambiguously means a fragment of the cancelled input was stranded
+      // there. A trailing tail gives a deterministic "fully echoed" signal.
+      const tail = "__CANCELTAIL";
+      send(Buffer.alloc(cols * 2 - tail.length, "Z").toString() + tail);
+      await waitFor(tail);
+
+      send("\x01"); // Ctrl+A -> cursor to start of the wrapped line
+      await waitFor(/\u276f|> /); // refresh repositions the cursor; prompt is re-emitted
+      send("\x03"); // Ctrl+C -> cancel
+      await waitFor("^C");
+
+      // Evaluate a fresh marker so we can locate the new prompt.
+      send("7 * 6\n");
+      await waitFor("42");
+
+      const rows = renderTerminalGrid(rawOutput(), cols).filter(line => line.length > 0);
+      expect(rows.some(line => line.includes("^C"))).toBe(true);
+      // The fix drops the cursor to the *last* wrapped row before printing `^C`,
+      // so the cancelled input stays intact on the rows above it. Without the
+      // snap, `^C` is written at column 2 of the *first* render row where Ctrl+A
+      // left the cursor, producing `❯ ^CZZZ…` — i.e. the first row carrying the
+      // fill char would also carry `^C`. Assert it doesn't (payload-independent;
+      // the `^C` lands on a separate, lower row when the snap is present).
+      const firstFillRow = rows.find(line => line.includes("Z"));
+      expect(firstFillRow).toBeDefined();
+      expect(firstFillRow).not.toContain("^C");
     });
   });
 });


### PR DESCRIPTION
Fixes #31604
Fixes #27670
Fixes #31897

## Repro

Paste a single line that is wider than the terminal into `bun repl` (the exact 399-byte `.copy "pub const panic = …"` payload from the issue, at an 80-column width):

- **Before:** the screen fills with hundreds of stacked copies of the growing line.
- **After:** the line appears once, wrapped across the rows it actually needs.

## Cause

`Repl::refresh_line` (`src/runtime/cli/repl.rs`) redrew the input on every pasted byte but only cleared the single physical row the cursor was on:

```
self.write(b"\r");                          // column 0 of the CURRENT row
self.write(Cursor::CLEAR_LINE.as_bytes());  // ESC[2K — clears the CURRENT row only
```

Once the prompt + input is wider than the terminal, the line wraps onto several physical rows and the cursor ends on the **last** one. The next redraw's `\r` + `ESC[2K` therefore cleared only that last row and left the earlier wrapped rows on screen, so each keystroke's render piled up. The cursor-repositioning step was also guarded by `if cursor_pos < terminal_width`, so it never ran for wrapped lines.

## Fix

`refresh_line` now follows the linenoise multi-line refresh approach:

- Track how many physical rows the previous render occupied (`prev_render_rows`) and which row the cursor ended on (`prev_cursor_row`).
- Before redrawing, move the cursor down to the last of those rows, then clear each row from the bottom up (`\r` + `ESC[0K` + cursor-up) so no stale wrapped copies remain.
- After writing the prompt + line, reposition the cursor correctly for the wrapped case (cursor-up + forward), including the edge case where the content exactly fills the last row.

Output that commits the current line — `print`/`print_error` (every REPL message ends in a newline) and the screen-clear paths (`Ctrl+L`, `.clear`) — resets the tracking so the next redraw starts from a clean single-row state and never tries to erase rows that already scrolled into history.

The REPL's column math stays byte-based (1 byte == 1 column), matching the existing cursor logic; wide/multi-byte width handling is a pre-existing limitation left unchanged.

## Verification

New regression tests in `test/js/bun/repl/repl.test.ts` (`Bun REPL (Terminal)` block) drive the REPL through a PTY (`Bun.Terminal`), reproduce each scenario, replay the terminal output into a character grid (with DEC deferred line-wrap, as xterm/vte do), and assert the line appears exactly once. Verified against a from-`main` baseline build:

| scenario | test | baseline (broken) | with fix |
| --- | --- | --- | --- |
| paste the #31604 payload | `…does not spam the screen (issue #31604)` | 321 copies / 806 rows | 1 copy / 6 rows |
| paste `"a".repeat(200)` | `…repeated characters wraps once (issue #27670)` | 130 copies / 183 rows | 1 copy / 5 rows |
| type past the edge | `…typing past the terminal width wraps once (issue #27461)` | 55 copies / 58 rows | 1 copy / 4 rows |

Each new test fails on a stashed (unfixed) build and passes with the fix. All 113 tests in `repl.test.ts` pass (existing editing/navigation tests — Ctrl+C, history arrows, tab completion, multiline, `.editor` — unaffected).

## Related issues (scope)

A bot suggested this may also close #27461 and #27560. I checked both against a baseline build:

- **#27461** — the *line-wrap duplication* half (typing past the edge re-emits the whole line) is fixed by this change and covered by the test above. The *flicker/cursor-jumping while typing* it also reports is a **separate** problem: the REPL still fully redraws the line on every keystroke, which this PR doesn't change. So I've linked it rather than auto-closing it.
- **#27560** (code reprinted when editing recalled **multi-line** history) — **not** fixed here, and intentionally left out of the `Fixes` list. That case renders a buffer with *embedded newlines*, not a single line that wraps; `refresh_line`'s row tracking only counts soft-wrap rows, so the reproduction is unchanged on this branch. It needs a separate fix that accounts for literal `\n` in the edited buffer.

## Follow-up fixes from review

Two issues the multi-row refresh introduced, caught in review and fixed:

- **Terminal width was always 80.** `Output::TERMINAL_SIZE` is never populated, so `refresh_line`'s new cursor-up erase assumed an 80-column terminal; on a wider terminal, input past ~80 chars was treated as wrapped and the cursor-up walked into the rows *above* the prompt, erasing earlier output (welcome banner / last result). `setup_terminal` now detects the real size (`COLUMNS`/`LINES`, then `TIOCGWINSZ` / `GetConsoleScreenBufferInfo`), matching `run_command.rs`.
- **Stale tail when committing from a mid-line cursor.** Committing a wrapped line (Enter / Ctrl+C / tab list) while the cursor was on an interior row (e.g. after Home) emitted the newline from that row and forgot the rows below it, stranding the line's tail under the new prompt. `print`/`print_error` now snap the cursor to the last rendered row first (a no-op at end-of-line).

Both are covered by new tests (rendered at the real PTY width), and all 115 `repl.test.ts` tests pass.

## Second review pass

- **Mid-session resize.** `terminal_width` was read once at startup; resizing the window re-opened the same cursor-walk hazard the width-detection fix closed for startup. `refresh_line` now re-queries the live width on each redraw (`terminal_width` is a `Cell`). New test narrows the PTY 120→40 and asserts the line then wraps at 40.
- **Width precedence.** Since this width drives cursor *positioning*, the live `TIOCGWINSZ`/console size now takes precedence over `COLUMNS`/`LINES` (kept only as a fallback).
- **Non-vacuous cancel test.** The earlier cancel-from-start test matched a tail that straddled a wrap boundary, so no grid row contained it and it passed unconditionally. It now asserts `^C` sits at the end of the cancelled input — verified to fail when `snap_to_render_end` is removed.

All 116 `repl.test.ts` tests pass, stable across repeated runs.


## Rebase note

Rebased onto main after #31876 (UTF-8 input in the line editor) landed; the branch is now a single squashed commit. Two conflict resolutions worth calling out:

- `refresh_line`: #31876 changed the cursor column to the *display width* of the text before the cursor (`strings::visible::width::exclude_ansi_colors::utf8`) instead of the byte offset. That is integrated into the multi-row math here: `end_col` and `cursor_col` are now display-width based, so the wrap/row calculations are correct for multi-byte and wide (CJK) characters too — this removes the "byte-based columns" limitation previously noted in this PR. The superseded single-row cursor-positioning block from main was dropped in favor of the multi-row reposition step.
- `repl.test.ts`: both sides appended tests to the `Bun REPL (Terminal)` block; kept both (main's 7 UTF-8 tests + this PR's 6 wrap tests). All 123 tests pass post-rebase.