### PR TITLE
install: gate a 2-day default minimumReleaseAge for new projects behind configVersion 2

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -255,7 +255,9 @@ The default is controlled by a `configVersion` field in your lockfile. For a det
 
 ## Minimum release age
 
-To protect against supply chain attacks where malicious packages are quickly published, you can configure a minimum age requirement for npm packages. Package versions published more recently than the specified threshold will be filtered out during installation. The filter is disabled by default; pass `0` to disable it explicitly.
+To protect against supply chain attacks where malicious packages are quickly published, you can configure a minimum age requirement for npm packages. Package versions published more recently than the specified threshold will be filtered out during installation.
+
+Starting in Bun 1.4, new projects (lockfile `configVersion` ≥ 2) default to a **two-day** minimum release age. Projects with existing lockfiles keep the current disabled default. Pass `0` to disable the filter.
 
 The value accepts either an [`ms`](https://npmjs.com/package/ms)-style duration string (`3d`, `1 week`, `48h`) or a bare number of seconds:
 
@@ -333,16 +335,18 @@ concurrentScripts = 16 # (cpu count or GOMAXPROCS) x2
 
 # installation strategy: "hoisted" or "isolated"
 # default depends on lockfile configVersion and workspaces:
-# - configVersion = 1: "isolated" if using workspaces, otherwise "hoisted"
+# - configVersion >= 1: "isolated" if using workspaces, otherwise "hoisted"
 # - configVersion = 0: "hoisted"
 linker = "hoisted"
 
 
 # skip package versions published within this period (security feature)
 # accepts ms-style duration strings ("2d", "48h", "1 week") or a number of seconds
-# (disabled by default; 0 also disables)
-minimumReleaseAge = 259200 # or "3d"
-minimumReleaseAgeExcludes = ["@types/node", "typescript"]
+# default depends on lockfile configVersion:
+# - configVersion >= 2: "2d" (Bun 1.4+)
+# - configVersion <= 1: disabled
+minimumReleaseAge = 0 # 0 disables
+minimumReleaseAgeExcludes = []
 ```
 
 ### Configuring with environment variables

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -735,7 +735,9 @@ Learn more about [using and writing security scanners](/pm/security-scanner-api)
 
 ### `install.minimumReleaseAge`
 
-Configure a minimum age for npm package versions. Package versions published more recently than this threshold will be filtered out during installation. Accepts either a number of seconds or an [`ms`](https://npmjs.com/package/ms)-style duration string like `"2d"`, `"1 week"`, or `"48h"`. Set to `0` to disable. Disabled by default.
+Configure a minimum age for npm package versions. Package versions published more recently than this threshold will be filtered out during installation. Accepts either a number of seconds or an [`ms`](https://npmjs.com/package/ms)-style duration string like `"2d"`, `"1 week"`, or `"48h"`. Set to `0` to disable.
+
+Default is disabled. Starting in Bun 1.4, new projects (lockfile `configVersion` ≥ 2) will default to `"2d"` (two days); projects with existing lockfiles keep the disabled default.
 
 ```toml title="bunfig.toml" icon="settings"
 [install]

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -201,6 +201,10 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_DNS_CACHE, "BUN_FEATURE_FLAG_DISABLE_DNS_CACHE", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_DNS_CACHE_LIBINFO, "BUN_FEATURE_FLAG_DISABLE_DNS_CACHE_LIBINFO", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_INSTALL_INDEX, "BUN_FEATURE_FLAG_DISABLE_INSTALL_INDEX", {});
+    // Opt in to the `bun install` configVersion 2 defaults (currently: a
+    // 2-day default `minimumReleaseAge` for new projects) before they ship
+    // in Bun 1.4. Becomes a no-op once `BREAKING_CHANGES_1_4` is flipped.
+    new_feature_flag!(pub BUN_FEATURE_FLAG_INSTALL_CONFIG_V2, "BUN_FEATURE_FLAG_INSTALL_CONFIG_V2", {});
     // Disable streaming tarball extraction in `bun install`. When disabled,
     // the whole .tgz is buffered in memory before being decompressed and
     // extracted. Useful for bisecting streaming-specific bugs.

--- a/src/bun_core/feature_flags.rs
+++ b/src/bun_core/feature_flags.rs
@@ -4,6 +4,11 @@
 use crate::env;
 use crate::feature_flag;
 
+/// Enable breaking changes slated for the next major release of Bun (1.4).
+/// Flip to `true` when cutting the 1.4 branch to activate the gated install
+/// defaults (e.g. the 2-day `minimumReleaseAge`).
+pub const BREAKING_CHANGES_1_4: bool = false;
+
 /// Store and reuse file descriptors during module resolution
 /// This was a ~5% performance improvement
 pub const STORE_FILE_DESCRIPTORS: bool = !env::IS_BROWSER;

--- a/src/install/ConfigVersion.rs
+++ b/src/install/ConfigVersion.rs
@@ -8,10 +8,28 @@ use bun_ast::{Expr, ExprData};
 pub enum ConfigVersion {
     V0 = 0,
     V1 = 1,
+    V2 = 2,
 }
 
 impl ConfigVersion {
-    pub const CURRENT: ConfigVersion = ConfigVersion::V1;
+    /// The configVersion written to lockfiles that don't already have one
+    /// (fresh projects, `bun pm migrate`).
+    ///
+    /// Bumping this is how breaking changes to install defaults are rolled
+    /// out: `V2` enables a 2-day default `minimumReleaseAge` for new
+    /// projects. It ships in Bun 1.4; until then `BREAKING_CHANGES_1_4`
+    /// keeps it at `V1` and the `BUN_FEATURE_FLAG_INSTALL_CONFIG_V2`
+    /// environment variable can be used to opt in at runtime for testing.
+    pub const CURRENT: ConfigVersion = if bun_core::feature_flags::BREAKING_CHANGES_1_4 {
+        ConfigVersion::V2
+    } else {
+        ConfigVersion::V1
+    };
+
+    /// Highest configVersion this build understands. Lockfiles from a newer
+    /// Bun are clamped to this. May be ahead of `CURRENT` while a new version
+    /// is gated behind `BREAKING_CHANGES_1_4`.
+    pub const MAX_KNOWN: ConfigVersion = ConfigVersion::V2;
 
     pub fn from_expr(expr: &Expr) -> Option<ConfigVersion> {
         let ExprData::ENumber(e_number) = &expr.data else {
@@ -23,14 +41,16 @@ impl ConfigVersion {
             return Some(ConfigVersion::V0);
         } else if version == 1.0 {
             return Some(ConfigVersion::V1);
+        } else if version == 2.0 {
+            return Some(ConfigVersion::V2);
         }
 
         if version.trunc() != version {
             return None;
         }
 
-        if version > (Self::CURRENT as u8) as f64 {
-            return Some(Self::CURRENT);
+        if version > (Self::MAX_KNOWN as u8) as f64 {
+            return Some(Self::MAX_KNOWN);
         }
 
         None
@@ -40,9 +60,10 @@ impl ConfigVersion {
         match int {
             0 => Some(ConfigVersion::V0),
             1 => Some(ConfigVersion::V1),
+            2 => Some(ConfigVersion::V2),
             _ => {
-                if int > Self::CURRENT as u64 {
-                    return Some(Self::CURRENT);
+                if int > Self::MAX_KNOWN as u64 {
+                    return Some(Self::MAX_KNOWN);
                 }
 
                 None

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -865,6 +865,71 @@ impl PackageManager {
         self.update_requests = Box::default();
     }
 
+    /// Derive `options.config_version` from a lockfile load result and apply
+    /// any defaults that are gated on that version. Returns whether the
+    /// configVersion changed from what was saved in the lockfile (and
+    /// therefore the lockfile should be re-saved).
+    ///
+    /// Must be called after `Options::load()` and after the lockfile has
+    /// been loaded, but before any package resolution. Safe to call more
+    /// than once on the same manager (e.g. `bun update --interactive`
+    /// followed by `install_with_manager`): the second call re-derives the
+    /// version but does not re-apply defaults.
+    ///
+    /// NOTE: runtime auto-install (`init_with_runtime_once`) does not call this
+    /// — it doesn't load `bun.lock` or derive a configVersion — so the
+    /// configVersion-gated `minimumReleaseAge` default does NOT apply to
+    /// packages resolved by auto-install. Only `bun install` / `bun add` /
+    /// `bun update` / `bun outdated` / `bun pm trust` apply it. (Pre-existing
+    /// limitation: before this, configVersion only gated the linker, which
+    /// auto-install doesn't use.)
+    pub fn apply_config_version_defaults(
+        &mut self,
+        load_result: &lockfile::LoadResult<'_>,
+    ) -> bool {
+        use crate::config_version::ConfigVersion;
+
+        let (mut config_version, changed_config_version) = load_result.choose_config_version();
+
+        // Until `BREAKING_CHANGES_1_4` flips `ConfigVersion::CURRENT` to `V2`,
+        // the `BUN_FEATURE_FLAG_INSTALL_CONFIG_V2` environment variable opts
+        // fresh projects into the new defaults for testing. This mirrors what
+        // 1.4 will do: only the `NotFound` / `Err` cases (which currently
+        // pick `CURRENT`) are affected; existing and migrated lockfiles keep
+        // their chosen version.
+        if !bun_core::feature_flags::BREAKING_CHANGES_1_4
+            && !matches!(load_result, lockfile::LoadResult::Ok(_))
+            && bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_INSTALL_CONFIG_V2
+                .get()
+                .unwrap_or(false)
+        {
+            config_version = ConfigVersion::V2;
+        }
+
+        let already_applied = self.options.config_version.is_some();
+        self.options.config_version = Some(config_version);
+
+        if !already_applied {
+            match config_version {
+                ConfigVersion::V0 | ConfigVersion::V1 => {}
+                ConfigVersion::V2 => {
+                    // Only default when the user configured nothing. An
+                    // explicit `minimumReleaseAge = 0` is stored as
+                    // `Some(0.0)` (not `None`), so it correctly suppresses
+                    // the default and keeps the filter disabled — the
+                    // manifest-fetch gates and version filter already treat
+                    // `Some(0.0)` like "unset" for fetching/filtering.
+                    if self.options.minimum_release_age_ms.is_none() {
+                        self.options.minimum_release_age_ms =
+                            Some(package_manager_options::DEFAULT_MINIMUM_RELEASE_AGE_MS);
+                    }
+                }
+            }
+        }
+
+        changed_config_version
+    }
+
     /// Zig: `pm.lockfile.loadFromCwd(pm, allocator, log, attempt_loading_from_other_lockfile)`.
     ///
     /// PORT NOTE: reshaped for borrowck — the Zig call passes `pm` as a separate

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -277,6 +277,10 @@ impl LogLevel {
 pub use crate::config_version::ConfigVersion;
 pub use bun_install_types::NodeLinker::NodeLinker;
 
+/// Default minimum release age applied to projects with configVersion >= 2
+/// when the user has not explicitly configured `minimumReleaseAge`.
+pub const DEFAULT_MINIMUM_RELEASE_AGE_MS: f64 = 2.0 * bun_core::time::MS_PER_DAY as f64;
+
 #[derive(Default, Copy, Clone)]
 pub struct Update {
     pub development: bool,
@@ -905,6 +909,13 @@ impl Options {
             self.do_.set(Do::SAVE_LOCKFILE, false);
             self.enable.set(Enable::FORCE_SAVE_LOCKFILE, false);
         }
+
+        // NOTE: an explicit `minimumReleaseAge = 0` is kept as `Some(0.0)`
+        // (not collapsed to `None`) so `apply_config_version_defaults` can
+        // tell "user disabled it" from "unset" and not apply the configVersion
+        // 2 default. The manifest-fetch gates and version filter already treat
+        // `Some(0.0)` like "unset" for fetching/filtering, so nothing extra is
+        // needed here.
 
         // PORT NOTE: moved from `defer { ... }` after scope assignment (see note above).
         self.did_override_default_scope = self.scope.url_hash != *Npm::registry::DEFAULT_URL_HASH;

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -94,8 +94,8 @@ pub fn install_with_manager(
     // appended by manifest fetches in this resolve session.
     manager.lockfile.mark_loaded_packages();
 
-    let (config_version, changed_config_version) = load_result.choose_config_version();
-    manager.options.config_version = Some(config_version);
+    let changed_config_version = manager.apply_config_version_defaults(&load_result);
+    let config_version = manager.options.config_version.unwrap();
 
     let mut root = lockfile::Package::default();
     let mut needs_new_lockfile = !matches!(load_result, lockfile::LoadResult::Ok { .. })
@@ -793,7 +793,7 @@ pub fn install_with_manager(
                         linker = NodeLinker::Hoisted;
                         continue;
                     }
-                    ConfigVersion::V1 => {
+                    ConfigVersion::V1 | ConfigVersion::V2 => {
                         if !load_result.migrated_from_npm()
                             && manager.lockfile.workspace_paths.len() > 0
                         {

--- a/src/runtime/cli/outdated_command.rs
+++ b/src/runtime/cli/outdated_command.rs
@@ -105,12 +105,13 @@ impl OutdatedCommand {
         let lockfile: &mut bun_install::lockfile::Lockfile = unsafe { &mut *(*pm_ptr).lockfile };
         // SAFETY: `manager.log` is set non-null by `PackageManager::init`.
         let log = unsafe { &mut *log_ptr };
-        match lockfile.load_from_cwd::<true>(
+        let load_result = lockfile.load_from_cwd::<true>(
             // SAFETY: see PORT NOTE above — `load_from_cwd` accesses `manager`
             // fields disjoint from `lockfile` (Zig invariant).
             Some(unsafe { &mut *pm_ptr }),
             log,
-        ) {
+        );
+        match &load_result {
             LoadResult::NotFound => {
                 if not_silent {
                     Output::err_generic("missing lockfile, nothing outdated", ());
@@ -154,6 +155,12 @@ impl OutdatedCommand {
                 // is the same storage and no reassignment is needed.
             }
         }
+
+        // SAFETY: `load_result` borrows the lockfile, which is disjoint from
+        // `manager.options` that `apply_config_version_defaults` mutates.
+        _ = unsafe { &mut *pm_ptr }.apply_config_version_defaults(&load_result);
+        // `load_result`'s borrow of the lockfile ends at its last use above, so
+        // the `manager` reborrow below is free.
 
         if Output::enable_ansi_colors_stdout() {
             Self::outdated_dispatch::<true>(original_cwd, manager)
@@ -462,7 +469,9 @@ impl OutdatedCommand {
         // `&manager.options`).
         let cache_ctx = manager.manifest_disk_cache_ctx();
         let min_age_ms = manager.options.minimum_release_age_ms;
-        let needs_extended = min_age_ms.is_some();
+        // `Some(0.0)` means the filter is explicitly disabled — it behaves like
+        // unset, so only a positive age needs the extended manifest.
+        let needs_extended = min_age_ms.is_some_and(|ms| ms > 0.0);
         let excludes = manager.options.minimum_release_age_excludes;
 
         let mut version_buf: String = String::new();

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -661,6 +661,16 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
             // boxed lockfile. Project that field to a raw pointer (no second
             // Box-deref) so both arguments share one Stacked-Borrows lineage.
             let lf: *mut Lockfile = &raw mut *load_lockfile.ok_mut().lockfile;
+            // CONFIG VERSION: `bun pm migrate` intentionally does NOT call
+            // `apply_config_version_defaults` / `choose_config_version` here.
+            // `save_to_disk` writes `ConfigVersion::CURRENT`, so an explicit
+            // migrate is treated like a fresh project — it opts into the
+            // current install defaults (e.g. the 2-day `minimumReleaseAge`
+            // once `BREAKING_CHANGES_1_4` ships). This deliberately differs
+            // from `bun install`'s implicit auto-migrate, which preserves the
+            // conservative per-source mapping (npm/yarn → V0, pnpm → V1) so it
+            // never silently changes an existing project's behavior. See the
+            // doc comment on `ConfigVersion::CURRENT`.
             // SAFETY: `load_lockfile` is `Ok` (errors exited above). `lf` is a
             // reborrow of `ok.lockfile`; `save_to_disk` reads `load_result` only
             // for `save_format()` / `loaded_from_binary_lockfile()` (scalar

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -263,6 +263,14 @@ impl TrustCommand {
         let log_level = pm.options.log_level;
         let load_lockfile = pm.load_lockfile_from_cwd::<true>();
         PackageManagerCommand::handle_load_lockfile_errors(&load_lockfile, log_level);
+        // Derive `options.config_version` from the loaded lockfile so
+        // `save_to_disk` below preserves it instead of falling back to
+        // `ConfigVersion::CURRENT` (which would silently bump existing
+        // projects once `BREAKING_CHANGES_1_4` flips).
+        // SAFETY: `load_lockfile` borrows `pm.lockfile` (separate `Box`
+        // allocation); `apply_config_version_defaults` only touches
+        // `pm.options`, which is disjoint.
+        _ = unsafe { &mut *pm_raw }.apply_config_version_defaults(&load_lockfile);
         // PORT NOTE: `update_lockfile_if_needed` consumes `LoadResult` but we
         // need it again for `save_to_disk`; inline the body (it only flips
         // `meta.has_install_script` when `packages_need_update`).

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -483,8 +483,10 @@ impl UpdateInteractiveCommand {
         // before borrowing `&mut manager.lockfile`.
         let not_silent = manager.options.log_level != LogLevel::Silent;
         let ctx_log_ptr: *mut bun_ast::Log = ctx.log;
+        let pm_ptr: *mut PackageManager = manager;
 
-        match manager.load_lockfile_from_cwd::<true>() {
+        let load_result = manager.load_lockfile_from_cwd::<true>();
+        match &load_result {
             LoadResult::NotFound => {
                 if not_silent {
                     Output::err_generic("missing lockfile, nothing outdated", ());
@@ -515,7 +517,10 @@ impl UpdateInteractiveCommand {
                     // for every subcommand and is non-null for the command's
                     // lifetime.
                     if unsafe { (*ctx_log_ptr).has_errors() } {
-                        manager
+                        // SAFETY: `load_result` borrows `manager.lockfile`;
+                        // `log_mut()` dereferences the disjoint `manager.log`
+                        // raw pointer.
+                        unsafe { &*pm_ptr }
                             .log_mut()
                             .print(std::ptr::from_mut(Output::error_writer()))?;
                     }
@@ -528,6 +533,13 @@ impl UpdateInteractiveCommand {
                 // `manager.lockfile` (Box) in place, so no reassignment.
             }
         }
+
+        // SAFETY: `load_result` borrows `manager.lockfile` (separate `Box`
+        // allocation); `apply_config_version_defaults` only touches
+        // `manager.options`, which is disjoint.
+        _ = unsafe { &mut *pm_ptr }.apply_config_version_defaults(&load_result);
+        // `load_result`'s borrow ends at its last use above, so the `manager`
+        // reborrow below is free.
 
         let workspace_pkg_ids: Vec<PackageID> = if !manager.options.filter_patterns.is_empty() {
             let filters = manager.options.filter_patterns;
@@ -910,7 +922,9 @@ impl UpdateInteractiveCommand {
         // borrow from `manager`, so the caller may keep using it afterwards.
         let cache_ctx = manager.manifest_disk_cache_ctx();
         let min_age_ms = manager.options.minimum_release_age_ms;
-        let needs_extended = min_age_ms.is_some();
+        // `Some(0.0)` means the filter is explicitly disabled — it behaves like
+        // unset, so only a positive age needs the extended manifest.
+        let needs_extended = min_age_ms.is_some_and(|ms| ms > 0.0);
         let excludes = manager.options.minimum_release_age_excludes;
         let update_to_latest = manager.options.do_.update_to_latest();
         let default_url_hash = *bun_install::npm::Registry::DEFAULT_URL_HASH;

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -1549,6 +1549,168 @@ registry = "${mockRegistryUrl}"`,
       expect(exitCode).not.toBe(0);
     });
 
+    describe("configVersion 2 default (gated behind BUN_FEATURE_FLAG_INSTALL_CONFIG_V2 until 1.4)", () => {
+      const v2Env = { ...bunEnv, BUN_FEATURE_FLAG_INSTALL_CONFIG_V2: "1" };
+
+      test("new projects default to 2-day minimum release age", async () => {
+        using dir = tempDir("default-age-new", {
+          "package.json": JSON.stringify({
+            dependencies: { "regular-package": "*" },
+          }),
+          ".npmrc": `registry=${mockRegistryUrl}`,
+        });
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "install", "--no-verify"],
+          cwd: String(dir),
+          env: v2Env,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+
+        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+        expect(stderr).not.toContain("error:");
+        expect(exitCode).toBe(0);
+
+        const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+        // Default 2 days -> 3.0.0 (1 day old) blocked, 2.1.0 (6 days) selected
+        expect(lockfile).toContain("regular-package@2.1.0");
+        expect(lockfile).not.toContain("regular-package@3.0.0");
+        expect(lockfile).toContain('"configVersion": 2');
+      });
+
+      test("existing configVersion 1 projects have no default minimum release age", async () => {
+        using dir = tempDir("default-age-v1", {
+          "package.json": JSON.stringify({
+            name: "foo",
+            dependencies: { "regular-package": "*" },
+          }),
+          // Existing lockfile at configVersion 1 without the new dependency;
+          // bun install will detect the diff and resolve it.
+          "bun.lock": JSON.stringify({
+            lockfileVersion: 1,
+            configVersion: 1,
+            workspaces: {
+              "": {
+                name: "foo",
+              },
+            },
+            packages: {},
+          }),
+          ".npmrc": `registry=${mockRegistryUrl}`,
+        });
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "install", "--no-verify"],
+          cwd: String(dir),
+          env: v2Env,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+
+        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+        expect(stderr).not.toContain("error:");
+        expect(exitCode).toBe(0);
+
+        const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+        // No default filter on v1 -> latest (3.0.0)
+        expect(lockfile).toContain("regular-package@3.0.0");
+        expect(lockfile).toContain('"configVersion": 1');
+      });
+
+      test("bunfig minimumReleaseAge = 0 disables the default", async () => {
+        using dir = tempDir("default-age-bunfig-zero", {
+          "package.json": JSON.stringify({
+            dependencies: { "regular-package": "*" },
+          }),
+          "bunfig.toml": `[install]
+minimumReleaseAge = 0
+registry = "${mockRegistryUrl}"`,
+        });
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "install", "--no-verify"],
+          cwd: String(dir),
+          env: v2Env,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+
+        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+        expect(stderr).not.toContain("error:");
+        expect(exitCode).toBe(0);
+
+        const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+        // New project would default to 2 days, but bunfig 0 disables it -> latest
+        expect(lockfile).toContain("regular-package@3.0.0");
+      });
+
+      test("existing configVersion 2 lockfile gets the default even without the feature flag", async () => {
+        using dir = tempDir("default-age-v2-saved", {
+          "package.json": JSON.stringify({
+            name: "foo",
+            dependencies: { "regular-package": "*" },
+          }),
+          "bun.lock": JSON.stringify({
+            lockfileVersion: 1,
+            configVersion: 2,
+            workspaces: {
+              "": {
+                name: "foo",
+              },
+            },
+            packages: {},
+          }),
+          ".npmrc": `registry=${mockRegistryUrl}`,
+        });
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "install", "--no-verify"],
+          cwd: String(dir),
+          // intentionally NOT setting BUN_FEATURE_FLAG_INSTALL_CONFIG_V2
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+
+        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+        expect(stderr).not.toContain("error:");
+        expect(exitCode).toBe(0);
+
+        const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+        // Saved configVersion 2 -> default 2-day filter applies
+        expect(lockfile).toContain("regular-package@2.1.0");
+        expect(lockfile).not.toContain("regular-package@3.0.0");
+        expect(lockfile).toContain('"configVersion": 2');
+      });
+    });
+
+    test("new projects do NOT default to a minimum release age without the feature flag", async () => {
+      using dir = tempDir("default-age-flag-off", {
+        "package.json": JSON.stringify({
+          dependencies: { "regular-package": "*" },
+        }),
+        ".npmrc": `registry=${mockRegistryUrl}`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--no-verify"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+
+      const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+      // Feature flag off -> configVersion 1, no default filter, latest wins
+      expect(lockfile).toContain("regular-package@3.0.0");
+      expect(lockfile).toContain('"configVersion": 1');
+    });
+
     test("global bunfig.toml configuration works", async () => {
       // Create a fake home directory with global bunfig
       using globalConfigDir = tempDir("global-config", {

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -62,6 +62,9 @@ export const bunEnv: NodeJS.Dict<string> = {
   BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1",
   BUN_GARBAGE_COLLECTOR_LEVEL: process.env.BUN_GARBAGE_COLLECTOR_LEVEL || "0",
   BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE: "1",
+  // Strip so an ambient export (used to preview the 1.4 install defaults)
+  // doesn't leak into fresh-project install tests that assert configVersion 1.
+  BUN_FEATURE_FLAG_INSTALL_CONFIG_V2: undefined,
   BUN_DEBUG_linkerctx: "0",
   WANTS_LOUD: "0",
   AGENT: "false",


### PR DESCRIPTION
Stacked on #30529 (ms-style duration strings). **Review/merge that one first** — this PR's diff is shown against its branch.

## What

Adds a gated **2-day default `minimumReleaseAge`** for new projects, rolled out via a new lockfile `configVersion`:

- `ConfigVersion::V2` carries a 2-day default `minimumReleaseAge` for projects whose lockfile is at `configVersion >= 2` and that haven't set the option explicitly.
- `bun pm migrate` and fresh installs write `ConfigVersion::CURRENT`; existing lockfiles keep their saved version; `0` always disables.

## Gating — does not ship until 1.4

- `BREAKING_CHANGES_1_4` (compile-time, currently `false`) flips `ConfigVersion::CURRENT` from `V1` to `V2`.
- Until then, the `BUN_FEATURE_FLAG_INSTALL_CONFIG_V2` env var opts fresh projects into `V2` at runtime (for testing).
- `ConfigVersion::MAX_KNOWN` (`= V2`) lets this build read `V2` lockfiles even while `CURRENT` is still `V1`, so a lockfile written under the flag is honored without it.

So the code ships now and is testable, but no user sees a behavior change until 1.4 flips the flag.

## How

`PackageManager::apply_config_version_defaults()` centralizes deriving `config_version` from the lockfile load result and applying the gated default. It's idempotent and is called from `install`, `bun outdated`, `bun update --interactive`, and `bun pm trust` so none of them clobber a saved `configVersion`.

## Verification

`test/cli/install/minimum-release-age.test.ts` — 59 pass / 0 fail on debug+ASAN (54 base/ms + 5 configVersion-2 gated tests). Covers: new projects default to 2 days (flag on), existing `configVersion 1` unaffected, `minimumReleaseAge = 0` disables it, existing `configVersion 2` lockfile applies the default without the flag, and flag-off preserves legacy behavior.