### PR TITLE
crypto: fix root cert trust comment parsing

### DIFF
--- a/packages/bun-usockets/generate-root-certs.pl
+++ b/packages/bun-usockets/generate-root-certs.pl
@@ -273,7 +273,8 @@ while (<TXT>) {
     }
     # now scan the trust part to determine how we should trust this cert
     while (<TXT>) {
-      last if (/^#/);
+      last if (/^\s*$/);
+      next if (/^#/);
       if (/^CKA_TRUST_([A-Z_]+)\s+CK_TRUST\s+CKT_NSS_([A-Z_]+)\s*$/) {
         if ( !is_in_list($1,@valid_mozilla_trust_purposes) ) {
           report "Warning: Unrecognized trust purpose for cert: $caname. Trust purpose: $1. Trust Level: $2";


### PR DESCRIPTION
## What does this PR do?

Fixes #31611 

Fixes the root certificate generator's NSS trust-object parsing when a trust object contains inline comments.

### Root cause

`generate-root-certs.pl` currently stops reading a trust object on the first line starting with `#`.

NSS 3.123.1 places this inside Izenpe.com's trust object before the server-auth trust bit:

```text
END
# For Server Distrust After: Wed Apr 15 23:59:59 2026
CKA_NSS_SERVER_DISTRUST_AFTER MULTILINE_OCTAL
...
CKA_TRUST_SERVER_AUTH CK_TRUST CKT_NSS_TRUSTED_DELEGATOR
```

The old parser exits at the comment and silently drops the root. Trust objects are delimited by a blank line, so comments inside the object should be skipped instead.

### Why this matters

Updating the current checked-in bundle to NSS 3.123.1 should produce 121 roots. With the current parser, it produces 120 roots because `Izenpe.com` is incorrectly dropped.

This PR only fixes parser correctness. It does not change the checked-in root bundle.

## How did you verify your code works?

- Unpatched parser against NSS 3.123.1: 120 roots, no `Izenpe.com`
- Patched parser against NSS 3.123.1: 121 roots, includes `Izenpe.com`
- Patched parser against checked-in `certdata.txt`: 145 roots
- Regenerating from checked-in `certdata.txt` is byte-identical to current `root_certs.h`
- `git diff --check`