### PR TITLE
ci: fix root cert update workflow

### DIFF
--- a/.github/workflows/update-root-certs.yml
+++ b/.github/workflows/update-root-certs.yml
@@ -25,7 +25,6 @@ jobs:
       - name: Generate root certs and metadata
         id: generate-certs
         run: |
-          set -o pipefail
           cd packages/bun-usockets/
           CERT_METADATA=$(mktemp)
           bun generate-root-certs.mjs -v -f "$CERT_METADATA"
@@ -42,10 +41,11 @@ jobs:
             
             # Store the list of changed files
             CHANGED_FILES=$(git status --porcelain)
+            CHANGED_FILES_DELIMITER=$(uuidgen)
             {
-              echo "changed_files<<EOF"
+              echo "changed_files<<$CHANGED_FILES_DELIMITER"
               echo "$CHANGED_FILES"
-              echo "EOF"
+              echo "$CHANGED_FILES_DELIMITER"
             } >> "$GITHUB_ENV"
           else
             echo "No changes detected"

--- a/.github/workflows/update-root-certs.yml
+++ b/.github/workflows/update-root-certs.yml
@@ -22,41 +22,34 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Generate root certs and capture output
+      - name: Generate root certs and metadata
         id: generate-certs
         run: |
+          set -o pipefail
           cd packages/bun-usockets/
-          OUTPUT=$(bun generate-root-certs.mjs -v)
-          echo "cert_output<<EOF" >> $GITHUB_ENV
-          echo "$OUTPUT" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          CERT_METADATA=$(mktemp)
+          bun generate-root-certs.mjs -v -f "$CERT_METADATA"
+          cat "$CERT_METADATA" >> "$GITHUB_ENV"
 
       - name: Check for changes and stage files
         id: check-changes
         run: |
           if [[ -n "$(git status --porcelain)" ]]; then
             echo "Found changes, staging modified files..."
-            git config --global user.name "github-actions[bot]"
-            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A
             
-            # Get list of modified files and add them
-            git status --porcelain | while read -r status file; do
-              # Remove leading status and whitespace
-              file=$(echo "$file" | sed 's/^.* //')
-              echo "Adding changed file: $file"
-              git add "$file"
-            done
-            
-            echo "changes=true" >> $GITHUB_OUTPUT
+            echo "changes=true" >> "$GITHUB_OUTPUT"
             
             # Store the list of changed files
             CHANGED_FILES=$(git status --porcelain)
-            echo "changed_files<<EOF" >> $GITHUB_ENV
-            echo "$CHANGED_FILES" >> $GITHUB_ENV
-            echo "EOF" >> $GITHUB_ENV
+            {
+              echo "changed_files<<EOF"
+              echo "$CHANGED_FILES"
+              echo "EOF"
+            } >> "$GITHUB_ENV"
           else
             echo "No changes detected"
-            echo "changes=false" >> $GITHUB_OUTPUT
+            echo "changes=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create Pull Request
@@ -64,20 +57,21 @@ jobs:
         uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "update(root_certs): Update root certificates $(date +'%Y-%m-%d')"
-          title: "update(root_certs) $(date +'%Y-%m-%d')"
+          commit-message: ${{ env.COMMIT_MSG }}
+          committer: GitHub <noreply@github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          title: "crypto: update root certificates to NSS ${{ env.NEW_VERSION }}"
           body: |
-            Automated root certificates update
+            ${{ env.COMMIT_MSG }}
 
-            ${{ env.cert_output }}
+            ## Changed files
 
-            ## Changed Files:
-            ```
+            ```text
             ${{ env.changed_files }}
             ```
           branch: certs/update-root-certs
           base: main
           delete-branch: true
-          labels:
-            - "automation"
-            - "root-certs"
+          labels: |
+            automation
+            root-certs


### PR DESCRIPTION
### What does this PR do?

Fixes the disabled root certificate update workflow so it can generate automated root certificate update PRs again.

The workflow is currently disabled manually. The checked-in workflow also has a hard validation error in the `labels` input, so it is not runnable successfully as written. I suspect this is why the workflow was disabled, but I did not find a maintainer note confirming the reason.

With the workflow disabled, automated root certificate update PRs are not being produced. The checked-in bundle is currently NSS 3.121 from 2026-03-24, while a fresh generator run resolves NSS 3.123.1 from 2026-05-26.

The hard workflow fix is changing `labels` from a YAML sequence to the scalar string input expected by `peter-evans/create-pull-request`.

Before:

```yaml
labels:
  - "automation"
  - "root-certs"
```

After:

```yaml
labels: |
  automation
  root-certs
```

This also wires the generator's existing `-f` metadata output into the workflow so generated cert update PRs get useful titles, commit messages, and bodies based on the actual NSS release.

Extra cleanup included:

- replace literal `$(date +'%Y-%m-%d')` action inputs with generated NSS metadata
- stage generated changes with `git add -A`
- record changed files with a unique `$GITHUB_ENV` heredoc delimiter
- quote `$GITHUB_ENV` / `$GITHUB_OUTPUT` writes
- remove redundant global git user config from the staging step
- set generated PR author/committer explicitly
- keep verbose generator output in the Actions log instead of embedding it in the generated PR body

### How did you verify your code works?

Ran:

```text
actionlint .github/workflows/update-root-certs.yml
git diff --check HEAD~1..HEAD
```

The upstream workflow fails `actionlint` on the invalid `labels` input; this branch passes.

I also validated the workflow end-to-end on my fork by temporarily changing the repo guard to allow `shaanmajid/bun`:

- Workflow run: https://github.com/shaanmajid/bun/actions/runs/26681021130
- Generated PR: https://github.com/shaanmajid/bun/pull/5

That run successfully fetched NSS 3.123.1, updated `certdata.txt`, regenerated `root_certs.h`, created/updated the `certs/update-root-certs` branch, populated the generated PR title/body/commit message, and applied labels.

Note: the generated cert diff in the fork smoke test still reflects a separate root certificate parser issue (#31609). This PR only fixes the workflow plumbing.
