### PR TITLE
node:fs: avoid int32 truncation in statfs

### DIFF
--- a/src/runtime/node/StatFS.rs
+++ b/src/runtime/node/StatFS.rs
@@ -10,10 +10,13 @@ pub(crate) type RawStatFS = libc::statfs;
 #[cfg(not(unix))]
 pub(crate) type RawStatFS = bun_sys::StatFS;
 
-// The field integer type is i64 ("big") or i32 ("small"). Stable Rust const
-// generics cannot select a field type from a `const BIG: bool`, so we generate
-// the two concrete instantiations with a small macro. The two exported aliases
-// (`StatFSSmall`, `StatFSBig`) are the only call sites.
+// Earlier the non-bigint fields were stored as `i32`, truncating block counts
+// above `i32::MAX` (oven-sh/bun#31510). The default JS API returns Number, not
+// `i32`, so both variants keep `i64` fields here and the macro varies only the
+// JS conversion (Number vs BigInt). Stable Rust const generics cannot select a
+// field type from a `const BIG: bool`, so we generate the two concrete
+// instantiations with a small macro. The exported aliases (`StatFSSmall`,
+// `StatFSBig`) are the only call sites.
 macro_rules! define_statfs_type {
     ($name:ident, $Int:ty, big = $big:expr) => {
         #[allow(non_snake_case)]
@@ -81,9 +84,9 @@ macro_rules! define_statfs_type {
                 #[cfg(target_arch = "wasm32")]
                 compile_error!("Unsupported OS");
 
-                // Platform field types vary (u32/i64/u64); widen with `as i64`
-                // (lossless for the in-range values statfs reports), then `as $Int`
-                // truncates (intentional wrap).
+                // Platform field types vary (u32/i64/u64); `as i64` is lossless
+                // for the in-range values statfs reports. `as $Int` is `i64` for
+                // both variants, so this no longer narrows.
                 Self {
                     _fstype: (fstype_ as i64) as $Int,
                     _bsize: (bsize_ as i64) as $Int,
@@ -125,7 +128,7 @@ unsafe extern "C" {
     ) -> JSValue;
 }
 
-define_statfs_type!(StatFSSmall, i32, big = false);
+define_statfs_type!(StatFSSmall, i64, big = false);
 define_statfs_type!(StatFSBig, i64, big = true);
 
 /// Union between `Stats` and `BigIntStats` where the type can be decided at runtime

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5,6 +5,7 @@ import {
   gc,
   getMaxFD,
   isBroken,
+  isGlibc,
   isIntelMacOS,
   isPosix,
   isWindows,
@@ -3799,6 +3800,79 @@ it("fs.statfs (callback) should work with bigint", async () => {
     expect(stats.bsize > 0n).toBe(true);
     expect(stats.blocks > 0n).toBe(true);
   }
+});
+
+// Regression for oven-sh/bun#31510: the non-bigint statfs path stored block
+// counts as i32, so values above i32::MAX (e.g. `bavail` on a filesystem past
+// ~8 TiB) wrapped negative. We can't mount a multi-TiB filesystem in CI, so we
+// LD_PRELOAD a shim that makes `statfs(2)` report large block counts and a
+// sentinel `bsize` (proving the shim actually interposed). glibc-only: the
+// shim relies on ELF symbol interposition and a libc `struct statfs` layout.
+it.skipIf(!isGlibc)("fs.statfsSync preserves block counts above i32::MAX (#31510)", () => {
+  const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+  if (!cc) {
+    throw new Error("No C compiler found for statfs LD_PRELOAD regression");
+  }
+
+  const BSIZE = 12288; // sentinel (3 * 4096) — proves the shim ran
+  const BLOCKS = 3747442852; // > i32::MAX
+  const BFREE = 3248532185; // > i32::MAX
+  const BAVAIL = 3248532185; // > i32::MAX
+
+  using dir = tempDir("statfs-i32", {
+    "shim.c": `
+#define _GNU_SOURCE
+#include <sys/statfs.h>
+#include <string.h>
+
+// glibc declares statfs() with \`struct statfs *\` and statfs64() with
+// \`struct statfs64 *\`; both share these field names, so fill via a macro to
+// keep each prototype type-correct.
+#define FILL(buf) do { \\
+  memset((buf), 0, sizeof(*(buf))); \\
+  (buf)->f_bsize = ${BSIZE}ULL; \\
+  (buf)->f_blocks = ${BLOCKS}ULL; \\
+  (buf)->f_bfree = ${BFREE}ULL; \\
+  (buf)->f_bavail = ${BAVAIL}ULL; \\
+} while (0)
+
+int statfs(const char *path, struct statfs *buf) { (void)path; FILL(buf); return 0; }
+int statfs64(const char *path, struct statfs64 *buf) { (void)path; FILL(buf); return 0; }
+`,
+  });
+
+  const soPath = path.join(String(dir), "shim.so");
+  const compile = Bun.spawnSync({
+    cmd: [cc, "-shared", "-fPIC", "-o", soPath, path.join(String(dir), "shim.c")],
+    env: bunEnv,
+  });
+  // Surface the compiler's stderr only on failure; a successful build may still
+  // warn, so don't assert stderr is empty.
+  if (compile.exitCode !== 0) {
+    throw new Error(`Failed to build statfs shim:\n${compile.stderr.toString()}`);
+  }
+
+  const script = `console.log(JSON.stringify((() => {
+    const s = require("fs").statfsSync(process.cwd());
+    return { bsize: s.bsize, blocks: s.blocks, bfree: s.bfree, bavail: s.bavail };
+  })()));`;
+
+  const proc = Bun.spawnSync({
+    cmd: [bunExe(), "-e", script],
+    env: { ...bunEnv, LD_PRELOAD: soPath },
+    cwd: String(dir),
+  });
+
+  const stdout = proc.stdout.toString().trim();
+  expect(proc.stderr.toString()).toBe("");
+  expect(proc.exitCode).toBe(0);
+
+  const result = JSON.parse(stdout);
+  // If bsize isn't the sentinel, the shim didn't interpose — fail, don't skip.
+  expect(result.bsize).toBe(BSIZE);
+  expect(result.blocks).toBe(BLOCKS);
+  expect(result.bfree).toBe(BFREE);
+  expect(result.bavail).toBe(BAVAIL);
 });
 
 it("fs.Stat constructor", () => {


### PR DESCRIPTION
## Summary

Addresses #31510.

The non-bigint `fs.statfs` path stored fields as `i32`, truncating block counts above `i32::MAX`. This widens to `i64`, matching the existing BigInt path's storage.

Changes:
- `i64` storage for default StatFS fields
- Linux/glibc regression test with LD_PRELOAD injected large block counts

## Test approach

Can't mount an 8TB filesystem in CI, so the test LD_PRELOADs a shim that injects large block counts and a sentinel `bsize` to prove interposition.

## Credits

Thanks to @tri-woods for the detailed issue analysis and reproduction values.

## Verification

- [x] cargo fmt --all --check
- [x] git diff --check -- src/runtime/node/StatFS.rs test/js/node/fs/fs.test.ts
- [x] bun bd -e "console.log('ok')"
- [x] bun bd test test/js/node/fs/fs.test.ts -t "statfs"
- [x] Regression confirmed: unpatched returns bavail: -1046435111 (i32 wrap of 3248532185); patched returns 3248532185

## Review map

- `StatFS.rs:133`: `i32` → `i64` in the macro instantiation, plus updated PORT NOTE comments
- `fs.test.ts:3805-3876`: LD_PRELOAD regression — C shim compiled at test time, subprocess validates block counts survive the binding layer
