### PR TITLE
bun:test: support optional trailing tuple elements in test.each

### DIFF
--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -199,6 +199,24 @@ pub(crate) fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> Js
             let mut formatter = bun_jsc::ConsoleObject::Formatter::new(global);
             return Err(global.throw(format_args!("Expected array, got {}", this.each.to_fmt(&mut formatter))));
         }
+        // Compute the table's widest row. Short array rows are padded to this
+        // width (below) so an omitted optional trailing tuple element binds as
+        // `undefined` rather than being mistaken for the callback's `done`
+        // parameter (oven-sh/bun#24347). describe.each never appends `done`.
+        let max_row_width: usize = {
+            let mut width: usize = 0;
+            let mut width_iter = this.each.array_iterator(global)?;
+            while let Some(item) = width_iter.next()? {
+                if item.is_empty() {
+                    break;
+                }
+                let row_width = if item.is_array() { item.get_length(global)? as usize } else { 1 };
+                if row_width > width {
+                    width = row_width;
+                }
+            }
+            width
+        };
         let mut iter = this.each.array_iterator(global)?;
         let mut test_idx: usize = 0;
         while let Some(item) = iter.next()? {
@@ -221,6 +239,12 @@ pub(crate) fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> Js
                     while let Some(array_item) = item_iter.next()? {
                         rooted.append(array_item);
                         args_list.push(array_item);
+                    }
+                    // Pad omitted trailing tuple elements to the table's width so a
+                    // short row binds later callback params (including `done`) to the
+                    // right slots — `done` must not land in an omitted slot (#24347).
+                    while args_list.len() < max_row_width {
+                        args_list.push(JSValue::UNDEFINED);
                     }
                 } else {
                     args_list.push(item);

--- a/test/js/bun/test/jest-each.test.ts
+++ b/test/js/bun/test/jest-each.test.ts
@@ -57,3 +57,46 @@ describe.each(["some", "cool", "strings"])("works with describe: %s", s => {
 describe("does not return zero", () => {
   expect(it.each([1, 2])("wat", () => {})).toBeUndefined();
 });
+
+// Regression for oven-sh/bun#24347: a row that omits an optional trailing tuple
+// element was treated as wanting `done`, so the callback received the `done`
+// function in that slot (and the test then timed out). Short array rows are now
+// padded to the table's widest row before `done` is appended, matching
+// describe.each.
+describe("optional trailing tuple elements (#24347)", () => {
+  it.each([
+    [1, 2],
+    [1, 2, undefined],
+    [10, 0, 10],
+  ])("omitted optional element is undefined, not the done callback [row %#]", (a, b, c) => {
+    expect(typeof c).not.toBe("function");
+  });
+
+  it.each([
+    [1, 2],
+    [1, 2, undefined],
+    [10, 0, 10],
+  ])("done still fires after an omitted optional element [row %#]", (_a, _b, c, done) => {
+    expect(typeof c).not.toBe("function");
+    expect(["number", "undefined"]).toContain(typeof c);
+    expect(typeof done).toBe("function");
+    done();
+  });
+
+  it.each([[1], [2]])("a real done callback still fires for a uniformly short table", (n, done) => {
+    expect(typeof done).toBe("function");
+    done();
+  });
+
+  // `done` accounting is per row: a padded array row uses its (normalized) width,
+  // a scalar row stays a single argument.
+  it.each([[1, 2, 3], 5])("mixed scalar and array rows keep per-row done accounting [row %#]", (value, maybeDone) => {
+    if (typeof maybeDone === "function") {
+      expect(value).toBe(5); // scalar row: second param is the done callback
+      maybeDone();
+    } else {
+      expect(value).toBe(1); // array row: second param is the array's value, not done
+      expect(maybeDone).toBe(2);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Addresses #24347.

`test.each` decided whether to append the `done` callback from each row's own length, so a row that omitted an optional trailing tuple element could receive `done` in that slot. Short array rows are now padded to the table's widest row with `undefined` before binding, then `done` detection is computed from the normalized argument list — so omitted optional elements land as `undefined`, a real `done` still binds after them, and scalar rows keep per-row accounting.

Changes:
- compute the table's max row width once
- pad omitted trailing tuple elements with `undefined` before binding
- compute `done` detection from the normalized argument list
- add `test.each` regressions for an optional slot, an optional slot followed by `done`, mixed scalar/array rows, and a real `done`

## Credits

Thanks to @ctison for the reproduction.

## Verification

- [x] cargo fmt --all --check
- [x] git diff --check -- src/runtime/test_runner/ScopeFunctions.rs test/js/bun/test/jest-each.test.ts
- [x] bun bd -e "console.log('ok')"
- [x] bun bd test test/js/bun/test/jest-each.test.ts (35 pass)
- [x] Regression confirmed: unpatched binds `done` into the omitted slot (optional tests fail); patched binds `undefined` and `done` still fires after it

## Review map

- `ScopeFunctions.rs`: one-time pre-pass for the table's widest row; short array rows padded to that width with `undefined`, then `done` arity computed from the (normalized) bound-arg length
- `jest-each.test.ts`: regressions for an omitted optional element, the same with a trailing `done`, mixed scalar/array rows, and a real-`done` guard
