### PR TITLE
Wrap mock in GetterSetter for indexed-accessor spyOn

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1561,8 +1561,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
                 moduleNamespaceObject->overrideExportValue(globalObject, propertyKey, mock);
                 mock->spyAttributes |= JSMockFunction::SpyAttributeESModuleNamespace;
             } else if (auto index = parseIndex(propertyKey)) {
-                // For indexed properties, set the mock directly instead of wrapping in GetterSetter
-                object->putDirectIndex(globalObject, *index, mock, attributes, PutDirectIndexLikePutDirect);
+                object->putDirectIndex(globalObject, *index, JSC::GetterSetter::create(vm, globalObject, mock, mock), attributes, PutDirectIndexLikePutDirect);
             } else {
                 object->putDirectAccessor(globalObject, propertyKey, JSC::GetterSetter::create(vm, globalObject, mock, mock), attributes);
             }

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1011,6 +1011,21 @@ describe("spyOn", () => {
       expect(arr[14]()).toBe(456);
       expect(fn).not.toHaveBeenCalled();
     });
+
+    test("spyOn on a missing indexed property does not crash on read/write", () => {
+      const obj = {};
+      const fn = spyOn(obj, 1002);
+
+      // Reading the spied index must not crash (it is installed as an accessor).
+      expect(obj[1002]).toBeUndefined();
+      expect(fn).toHaveBeenCalledTimes(1);
+
+      // Writing the spied index must not crash either.
+      obj[1002] = 42;
+      Reflect.set(obj, 1002, 43);
+
+      fn.mockRestore();
+    });
   }
 
   // spyOn does not work with getters/setters yet.


### PR DESCRIPTION
## What

`spyOn(target, index)` where the target has no callable value at that numeric
index (e.g. `spyOn(obj, 1002)` on a plain object, or a missing array index)
stored the mock **directly** via `putDirectIndex` with the
`PropertyAttribute::Accessor` bit set, instead of wrapping it in a
`JSC::GetterSetter`:

```cpp
} else if (auto index = parseIndex(propertyKey)) {
    // For indexed properties, set the mock directly instead of wrapping in GetterSetter
    object->putDirectIndex(globalObject, *index, mock, attributes, PutDirectIndexLikePutDirect);
}
```

This violates a JSC invariant: an indexed property entry carrying the
`Accessor` attribute must hold a `GetterSetter` cell. `SparseArrayEntry::get`
and `SparseArrayEntry::put` `uncheckedDowncast<GetterSetter>` the stored value
whenever the `Accessor` bit is set. So any later read or write of the spied
index downcasts the non-`GetterSetter` mock, tripping the `asObject()`
`cell->isObjectSlow()` assertion (`JSObject.h:1346`) — or, on the read path,
the `PropertySlot::setValue` assertion.

The non-indexed branch immediately below already does the right thing:
`putDirectAccessor(..., GetterSetter::create(vm, globalObject, mock, mock), attributes)`.

## Fix

Wrap the mock in a `GetterSetter` on the indexed-accessor path too, so the
stored value matches the `Accessor` attribute. The value/function indexed
branch (non-accessor, plain data property) is unchanged.

## Repro (before fix, debug build)

```js
const obj = {};
Bun.jest().spyOn(obj, 1002);
obj[1002];            // ASSERTION FAILED: PropertySlot::setValue
Reflect.set(obj, 1002, 1); // ASSERTION FAILED: asObject / isObjectSlow
```

Found by the fuzzer.

## Test

Added a regression test in `test/js/bun/test/mock-fn.test.js` covering read,
write (sloppy + `Reflect.set`), and `mockRestore` of a spied missing indexed
property. Verified it SIGABRTs on the pre-fix debug build and passes after.
Full `mock-fn.test.js` suite (73 tests) passes.