### PR TITLE
fix(bun:test): return an object when a mock function is constructed

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -879,6 +879,20 @@ static JSC::EncodedJSValue jsMockFunctionCallImpl(JSGlobalObject* lexicalGlobalO
         fn->contexts.set(vm, fn, contexts);
     }
 
+    JSC::JSArray* instances = fn->instances.get();
+    if (instances) {
+        instances->push(globalObject, thisValue);
+        RETURN_IF_EXCEPTION(scope, {});
+    } else {
+        JSC::ObjectInitializationScope object(vm);
+        instances = JSC::JSArray::tryCreateUninitializedRestricted(
+            object,
+            globalObject->arrayStructureForIndexingTypeDuringAllocation(JSC::ArrayWithContiguous),
+            1);
+        instances->initializeIndex(object, 0, thisValue);
+        fn->instances.set(vm, fn, instances);
+    }
+
     auto invocationId = JSMockModule::nextInvocationId();
     JSC::JSArray* invocationCallOrder = fn->invocationCallOrder.get();
     if (invocationCallOrder) {

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -86,6 +86,7 @@ inline To tryJSDynamicCast(JSC::WriteBarrier<WriteBarrierT>& from)
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionCall);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionConstruct);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetter_mockGetLastCall);
@@ -462,7 +463,7 @@ public:
     }
 
     JSMockFunction(JSC::VM& vm, JSC::Structure* structure, CallbackKind wrapKind)
-        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
+        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionConstruct)
     {
         initMock();
     }
@@ -826,7 +827,7 @@ static JSValue createMockResult(JSC::VM& vm, Zig::GlobalObject* globalObject, co
     return result;
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+static JSC::EncodedJSValue jsMockFunctionCallImpl(JSGlobalObject* lexicalGlobalObject, CallFrame* callframe, JSValue thisValue)
 {
     Zig::GlobalObject* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
@@ -838,7 +839,6 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     }
 
     JSC::ArgList args = JSC::ArgList(callframe);
-    JSValue thisValue = callframe->thisValue();
     JSC::JSArray* argumentsArray = nullptr;
     {
         JSC::ObjectInitializationScope object(vm);
@@ -979,6 +979,36 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
 
     setReturnValue(createMockResult(vm, globalObject, "return"_s, jsUndefined()));
     return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    return jsMockFunctionCallImpl(lexicalGlobalObject, callframe, callframe->thisValue());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // A native construct callback must return an object, so build `this` from
+    // newTarget's prototype and fall back to it when the mock returns a non-object.
+    JSObject* newTarget = asObject(callframe->newTarget());
+    JSValue prototype = newTarget->get(lexicalGlobalObject, vm.propertyNames->prototype);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    JSObject* thisObject = prototype.isObject()
+        ? JSC::constructEmptyObject(lexicalGlobalObject, asObject(prototype))
+        : JSC::constructEmptyObject(lexicalGlobalObject);
+
+    JSValue returnValue = JSValue::decode(jsMockFunctionCallImpl(lexicalGlobalObject, callframe, thisObject));
+    RETURN_IF_EXCEPTION(scope, {});
+
+    if (returnValue && returnValue.isObject()) {
+        return JSValue::encode(returnValue);
+    }
+
+    return JSValue::encode(thisObject);
 }
 
 void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -117,6 +117,56 @@ describe("mock()", () => {
     expect(fn).toHaveBeenCalledWith();
   });
 
+  test("are constructable with new", () => {
+    // no implementation: `new` should produce a fresh object, like `new` on an ordinary function
+    const fn = jest.fn();
+    const instance = new fn(1, 2);
+    expect(typeof instance).toBe("object");
+    expect(instance).not.toBe(null);
+    expect(fn.mock.calls).toEqual([[1, 2]]);
+    expect(fn.mock.contexts[0]).toBe(instance);
+
+    // Reflect.construct used to crash when the mock returned a non-object
+    const reflected = Reflect.construct(fn, []);
+    expect(typeof reflected).toBe("object");
+
+    // implementation operating on `this`
+    const withImpl = jest.fn(function (value) {
+      this.value = value;
+    });
+    const constructed = new withImpl(42);
+    expect(constructed.value).toBe(42);
+    expect(withImpl.mock.contexts[0]).toBe(constructed);
+
+    // implementation returning an object wins over the created `this`
+    const returnsObject = jest.fn(() => ({ a: 1 }));
+    expect(new returnsObject()).toEqual({ a: 1 });
+
+    // primitive return values are ignored by `new`, like ordinary functions
+    const returnsPrimitive = jest.fn().mockReturnValue(42);
+    expect(typeof new returnsPrimitive()).toBe("object");
+
+    // newTarget.prototype is respected
+    const classLike = jest.fn();
+    classLike.prototype = {
+      greet() {
+        return "hello";
+      },
+    };
+    const classInstance = new classLike();
+    expect(classInstance.greet()).toBe("hello");
+    expect(classInstance instanceof classLike).toBe(true);
+
+    // Reflect.construct with an explicit newTarget honors its prototype
+    class Base {}
+    expect(Reflect.construct(jest.fn(), [], Base)).toBeInstanceOf(Base);
+
+    // a normal call with a non-undefined `this` must still return the mock's value
+    const method = jest.fn().mockReturnValue(42);
+    const host = { method };
+    expect(host.method()).toBe(42);
+  });
+
   test("mockName returns this", () => {
     const fn = jest.fn();
     expect(fn.mockName()).toBe(fn);

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -125,10 +125,13 @@ describe("mock()", () => {
     expect(instance).not.toBe(null);
     expect(fn.mock.calls).toEqual([[1, 2]]);
     expect(fn.mock.contexts[0]).toBe(instance);
+    // `new` calls are recorded in mock.instances
+    expect(fn.mock.instances[0]).toBe(instance);
 
     // Reflect.construct used to crash when the mock returned a non-object
     const reflected = Reflect.construct(fn, []);
     expect(typeof reflected).toBe("object");
+    expect(fn.mock.instances[1]).toBe(reflected);
 
     // implementation operating on `this`
     const withImpl = jest.fn(function (value) {
@@ -137,6 +140,7 @@ describe("mock()", () => {
     const constructed = new withImpl(42);
     expect(constructed.value).toBe(42);
     expect(withImpl.mock.contexts[0]).toBe(constructed);
+    expect(withImpl.mock.instances[0]).toBe(constructed);
 
     // implementation returning an object wins over the created `this`
     const returnsObject = jest.fn(() => ({ a: 1 }));


### PR DESCRIPTION
## What

Constructing a Bun mock function (`jest.fn()` / `Bun.mock()`) with a non-object return value crashed the process with a `SIGSEGV` (an `ASSERTION FAILED: isCell()` in debug builds).

```js
const fn = Bun.jest(import.meta.path).fn();
Reflect.construct(fn, []); // TERMSIG 11 / isCell() assertion
```

`JSMockFunction` registered the same host function (`jsMockFunctionCall`) for both `[[Call]]` and `[[Construct]]`:

```cpp
: Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
```

Since it isn't `callHostFunctionAsConstructor`, `InternalFunction::getConstructData` exposes it as a native constructor. A native construct callback must return an object — `Interpreter::executeConstruct` feeds the result straight through `asObject()` — but `jsMockFunctionCall` can return `undefined`, a number, or any other primitive (no implementation → `jsUndefined()`, `mockReturnValue(42)` → `42`, `mockReturnThis()` → the receiver). Feeding a primitive to `asObject()` dereferences a non-object cell → flaky crash.

(`new fn()` from JS bytecode happened to survive because `op_construct` applies the "non-object return → use `this`" rule itself; `Reflect.construct` and other native-construct paths do not.)

## Fix

Split the call body into `jsMockFunctionCallImpl`, parameterized on the `this` value, and add a dedicated `jsMockFunctionConstruct` handler. It creates `this` from `newTarget`'s prototype, runs the mock against it, and returns the mock's result only when that result is an object — otherwise the freshly created instance, matching `new` on an ordinary JS function. This also makes `mock.contexts` / `mock.calls` observe the constructed instance and honors `newTarget.prototype` (so `Reflect.construct(fn, [], Base)` yields a `Base` instance).

A construct-specific handler is used rather than checking `callframe->newTarget()` inside the shared handler: `CallFrame::newTarget()` aliases `thisValue()` in JSC, so that check would misfire on ordinary calls with a non-undefined receiver (e.g. `obj.method()` where `method` is a `mockReturnValue(42)` mock would wrongly return `obj`).

## Test

Added `mock() > are constructable with new` to `test/js/bun/test/mock-fn.test.js`, covering: no-implementation `new`, `Reflect.construct`, `this`-mutating implementations, object-returning implementations, ignored primitive returns, `newTarget.prototype`, `Reflect.construct` with an explicit subclass target, and a guard that a normal call with a non-undefined `this` still returns the mock's value.

Found by Fuzzilli.