### PR TITLE
mock: return an object when a mock function is constructed

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -86,6 +86,7 @@ inline To tryJSDynamicCast(JSC::WriteBarrier<WriteBarrierT>& from)
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionCall);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionConstruct);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetter_mockGetLastCall);
@@ -462,7 +463,7 @@ public:
     }
 
     JSMockFunction(JSC::VM& vm, JSC::Structure* structure, CallbackKind wrapKind)
-        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
+        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionConstruct)
     {
         initMock();
     }
@@ -979,6 +980,29 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
 
     setReturnValue(createMockResult(vm, globalObject, "return"_s, jsUndefined()));
     return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * globalObject, CallFrame* callframe))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    EncodedJSValue encodedResult = jsMockFunctionCall(globalObject, callframe);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    // A native [[Construct]] implementation must return an object. The mock's
+    // implementation may return a primitive (or undefined), so fall back to a
+    // freshly constructed instance in that case, matching ordinary
+    // `new aFunctionReturningAPrimitive()` semantics and avoiding a crash when
+    // invoked via Reflect.construct / the C++ construct path.
+    JSValue result = JSValue::decode(encodedResult);
+    if (result.isObject())
+        return encodedResult;
+
+    JSObject* newTarget = asObject(callframe->newTarget());
+    Structure* structure = JSC::InternalFunction::createSubclassStructure(globalObject, newTarget, globalObject->objectStructureForObjectConstructor());
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(JSC::constructEmptyObject(vm, structure));
 }
 
 void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -794,6 +794,25 @@ describe("mock()", () => {
 
     expect(bar()()).toBe(true);
   });
+
+  it("constructing a mock returns an object and does not crash", () => {
+    // A native [[Construct]] must return an object. Previously, constructing a
+    // mock via Reflect.construct / the C++ construct path crashed because the
+    // mock returned the implementation's (possibly primitive) result.
+    const noImpl = jest.fn();
+    expect(typeof new noImpl()).toBe("object");
+    expect(typeof Reflect.construct(noImpl, [])).toBe("object");
+    expect(typeof Reflect.construct(noImpl, [], Object)).toBe("object");
+
+    const returnsPrimitive = jest.fn(() => 5);
+    expect(typeof new returnsPrimitive()).toBe("object");
+    expect(typeof Reflect.construct(returnsPrimitive, [])).toBe("object");
+
+    const instance = { tag: "instance" };
+    const returnsObject = jest.fn(() => instance);
+    expect(new returnsObject()).toBe(instance);
+    expect(Reflect.construct(returnsObject, [])).toBe(instance);
+  });
 });
 
 describe("spyOn", () => {


### PR DESCRIPTION
## What

Constructing a `jest.fn()` / `Bun.jest().mock()` mock function via `Reflect.construct` (or any code path that goes through the C++ `JSC::construct` helper) could crash the process.

Minimal repro:

```js
const m = Bun.jest().mock();
Reflect.construct(m, []);
```

In a debug/ASAN build this trips `ASSERTION FAILED: cell->isObjectSlow()` in `JSC::asObject`. It was originally surfaced by a fuzzer as a flaky `SIGSEGV`.

## Why

A native `[[Construct]]` implementation in JavaScriptCore must return a `JSObject`. The mock reused its *call* handler (`jsMockFunctionCall`) for *construct*, so constructing a mock returned the implementation's result — which is frequently a primitive or `undefined` (e.g. `jest.fn()` with no implementation returns `undefined`; `jest.fn(() => 5)` returns `5`).

- The `op_construct` bytecode path (`new m()`) tolerated a non-object return, so `new m()` merely returned the raw (often primitive) value — already not spec-correct.
- `Reflect.construct` / `JSC::construct` go through `Interpreter::executeConstruct`, which ends in `return asObject(JSValue::decode(result))`. With a non-object result this dereferences a non-cell value and crashes.

## Fix

Give the mock a dedicated construct handler. It runs the same recording + implementation logic, then enforces the native `[[Construct]]` contract: if the implementation's result is not an object, it returns a freshly constructed instance derived from the `new.target`'s prototype — matching ordinary `new aFunctionReturningAPrimitive()` semantics. When the implementation returns an object, that object is passed through unchanged.

This also makes `new mockFn()` spec-correct (it now returns an object instance instead of a primitive).

## Test

Added a portable (Jest/Vitest/Bun) regression test in `test/js/bun/test/mock-fn.test.js` covering `new`, `Reflect.construct(m, [])`, an explicit `newTarget`, and the primitive-vs-object implementation-return cases. It fails on the released build (`typeof new jest.fn()` was `"undefined"`) and passes with this change. The existing mock/spyOn suite (73 tests) still passes.