### PR TITLE
node:vm: throw instead of crashing on a cyclic SourceTextModule linked inside the linker

### DIFF
--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -5,6 +5,7 @@
 #include "ErrorCode.h"
 #include "JSDOMExceptionHandling.h"
 
+#include "wtf/HashSet.h"
 #include "wtf/Scope.h"
 
 #include "JavaScriptCore/BuiltinNames.h"
@@ -393,6 +394,35 @@ JSValue NodeVMSourceTextModule::link(JSGlobalObject* globalObject, JSArray* spec
     return jsUndefined();
 }
 
+// JSC's record->link() walks the whole dependency graph via innerModuleLinking,
+// which calls JSModuleLoader::getImportedModule() for every request of every
+// reachable record and asserts the request is present in that record's
+// loadedModules() (populated by setImportedModule() during link()). When a
+// module is linked *and evaluated* from inside the linker callback of a cyclic
+// graph, instantiate() can run while a dependency is still mid-link(): its
+// loadedModules() is empty, so getImportedModule() would dereference end() —
+// an assert in debug, a segfault in release. Pre-walk the graph the same way
+// and throw a catchable ERR_VM_MODULE_LINK_FAILURE (matching Node) instead.
+static bool isModuleGraphLinked(AbstractModuleRecord* record, WTF::HashSet<AbstractModuleRecord*>& visited, String& missingSpecifier)
+{
+    if (!visited.add(record).isNewEntry)
+        return true;
+
+    for (const auto& request : record->requestedModules()) {
+        const auto& loaded = record->loadedModules();
+        auto iter = loaded.find(JSC::ModuleMapKey { request.m_specifier.impl(), request.type() });
+        if (iter == loaded.end()) {
+            missingSpecifier = request.m_specifier.string();
+            return false;
+        }
+        AbstractModuleRecord* dependency = iter->value.m_module.get();
+        if (dependency && !isModuleGraphLinked(dependency, visited, missingSpecifier))
+            return false;
+    }
+
+    return true;
+}
+
 JSValue NodeVMSourceTextModule::instantiate(JSGlobalObject* globalObject)
 {
     VM& vm = globalObject->vm();
@@ -406,6 +436,13 @@ JSValue NodeVMSourceTextModule::instantiate(JSGlobalObject* globalObject)
     RETURN_IF_EXCEPTION(scope, {});
     if (nodeVmGlobalObject)
         globalObject = nodeVmGlobalObject;
+
+    WTF::HashSet<AbstractModuleRecord*> visited;
+    String missingSpecifier;
+    if (!isModuleGraphLinked(record, visited, missingSpecifier)) {
+        throwError(globalObject, scope, ErrorCode::ERR_VM_MODULE_LINK_FAILURE, makeString("request for '"_s, missingSpecifier, "' is not in cache"_s));
+        return {};
+    }
 
     record->link(globalObject, nullptr);
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -403,21 +403,32 @@ JSValue NodeVMSourceTextModule::link(JSGlobalObject* globalObject, JSArray* spec
 // loadedModules() is empty, so getImportedModule() would dereference end() —
 // an assert in debug, a segfault in release. Pre-walk the graph the same way
 // and throw a catchable ERR_VM_MODULE_LINK_FAILURE (matching Node) instead.
-static bool isModuleGraphLinked(AbstractModuleRecord* record, WTF::HashSet<AbstractModuleRecord*>& visited, String& missingSpecifier)
+//
+// The walk is iterative (an explicit worklist) rather than recursive: a deep
+// linear import chain has graph depth proportional to its length, and we must
+// not add an unguarded native recursion that would overflow the stack before
+// record->link()'s own isSafeToRecurse() guard throws a catchable RangeError.
+static bool isModuleGraphLinked(AbstractModuleRecord* root, String& missingSpecifier)
 {
-    if (!visited.add(record).isNewEntry)
-        return true;
+    WTF::HashSet<AbstractModuleRecord*> visited;
+    WTF::Vector<AbstractModuleRecord*, 16> worklist;
+    worklist.append(root);
 
-    for (const auto& request : record->requestedModules()) {
+    while (!worklist.isEmpty()) {
+        AbstractModuleRecord* record = worklist.takeLast();
+        if (!visited.add(record).isNewEntry)
+            continue;
+
         const auto& loaded = record->loadedModules();
-        auto iter = loaded.find(JSC::ModuleMapKey { request.m_specifier.impl(), request.type() });
-        if (iter == loaded.end()) {
-            missingSpecifier = request.m_specifier.string();
-            return false;
+        for (const auto& request : record->requestedModules()) {
+            auto iter = loaded.find(JSC::ModuleMapKey { request.m_specifier.impl(), request.type() });
+            if (iter == loaded.end()) {
+                missingSpecifier = request.m_specifier.string();
+                return false;
+            }
+            if (AbstractModuleRecord* dependency = iter->value.m_module.get())
+                worklist.append(dependency);
         }
-        AbstractModuleRecord* dependency = iter->value.m_module.get();
-        if (dependency && !isModuleGraphLinked(dependency, visited, missingSpecifier))
-            return false;
     }
 
     return true;
@@ -437,9 +448,8 @@ JSValue NodeVMSourceTextModule::instantiate(JSGlobalObject* globalObject)
     if (nodeVmGlobalObject)
         globalObject = nodeVmGlobalObject;
 
-    WTF::HashSet<AbstractModuleRecord*> visited;
     String missingSpecifier;
-    if (!isModuleGraphLinked(record, visited, missingSpecifier)) {
+    if (!isModuleGraphLinked(record, missingSpecifier)) {
         throwError(globalObject, scope, ErrorCode::ERR_VM_MODULE_LINK_FAILURE, makeString("request for '"_s, missingSpecifier, "' is not in cache"_s));
         return {};
     }

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1057,3 +1057,123 @@ test("node:vm SourceTextModule.link() rejects non-module entries in the moduleNa
   `);
   expect(exitCode).toBe(0);
 });
+
+describe("node:vm SourceTextModule cyclic graph linking", () => {
+  // Building a cyclic SourceTextModule graph and linking + evaluating each
+  // module from inside the linker callback (instead of linking the whole graph
+  // first and evaluating once) used to segfault: instantiate() runs JSC's
+  // whole-graph record->link(), which walks into a dependency whose own link()
+  // has not run yet (its loadedModules() is empty), dereferencing an end()
+  // iterator. Bun must instead throw a catchable ERR_VM_MODULE_LINK_FAILURE,
+  // matching Node. See https://github.com/oven-sh/bun/issues/31623.
+  test("link + evaluate inside the linker throws instead of crashing", async () => {
+    const fixture = `
+      const vm = require("node:vm");
+      const ctx = vm.createContext({ globalThis });
+      const sources = {
+        a: 'import { b } from "b"; export const a = "A"; export const ab = () => b;',
+        b: 'import { a } from "a"; export const b = "B"; export const ba = () => a;',
+      };
+      const built = new Map();
+      async function ensure(id) {
+        const existing = built.get(id);
+        if (existing) return existing;
+        const m = new vm.SourceTextModule(sources[id], { context: ctx, identifier: id });
+        built.set(id, m);
+        await m.link(async spec => await ensure(spec));
+        await m.evaluate();
+        return m;
+      }
+      try {
+        const root = await ensure("a");
+        console.log("UNEXPECTED_OK " + Object.keys(root.namespace).join(","));
+      } catch (e) {
+        console.log("CAUGHT " + e.code + " " + e.message);
+      }
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("CAUGHT ERR_VM_MODULE_LINK_FAILURE request for 'b' is not in cache");
+    expect(exitCode).toBe(0);
+  });
+
+  test("a self-importing module links + evaluates without crashing", async () => {
+    const fixture = `
+      const vm = require("node:vm");
+      const ctx = vm.createContext({ globalThis });
+      const sources = { self: 'import {} from "self"; export const x = 1;' };
+      const built = new Map();
+      async function ensure(id) {
+        const existing = built.get(id);
+        if (existing) return existing;
+        const m = new vm.SourceTextModule(sources[id], { context: ctx, identifier: id });
+        built.set(id, m);
+        await m.link(async spec => await ensure(spec));
+        await m.evaluate();
+        return m;
+      }
+      const root = await ensure("self");
+      console.log("OK " + Object.keys(root.namespace).join(","));
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("OK x");
+    expect(exitCode).toBe(0);
+  });
+
+  test("the canonical link-whole-graph-then-evaluate pattern still works", async () => {
+    const fixture = `
+      const vm = require("node:vm");
+      const ctx = vm.createContext({ globalThis });
+      const sources = {
+        a: 'import { b } from "b"; export const a = "A"; export const ab = () => b;',
+        b: 'import { a } from "a"; export const b = "B"; export const ba = () => a;',
+      };
+      const built = new Map();
+      function get(id) {
+        let m = built.get(id);
+        if (m) return m;
+        m = new vm.SourceTextModule(sources[id], { context: ctx, identifier: id });
+        built.set(id, m);
+        return m;
+      }
+      const root = get("a");
+      await root.link(spec => get(spec));
+      await root.evaluate();
+      const nsA = root.namespace;
+      const nsB = built.get("b").namespace;
+      console.log("ab=" + nsA.ab() + " ba=" + nsB.ba());
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("ab=B ba=A");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #31623

## Repro

Build a two-module `node:vm` `SourceTextModule` import cycle (A imports B, B imports A) and link + evaluate each module *inside* the linker callback as it's first encountered:

```ts
import * as vm from "node:vm";

const ctx = vm.createContext({ globalThis });
const sources = {
  a: `import { b } from "b"; export const a = "A"; export const ab = () => b;`,
  b: `import { a } from "a"; export const b = "B"; export const ba = () => a;`,
};
const built = new Map();

async function ensure(id) {
  const existing = built.get(id);
  if (existing) return existing;
  const m = new vm.SourceTextModule(sources[id], { context: ctx, identifier: id });
  built.set(id, m);
  await m.link(async spec => await ensure(spec));
  await m.evaluate();
  return m;
}

await ensure("a");
```

```
$ bun repro.ts
panic(main thread): Segmentation fault at address 0xFFFFFFFFFFFFFFF8
```

Under a debug/ASAN build it surfaces as the underlying JSC assert:

```
ASSERTION FAILED: iter != referrer->loadedModules().end()
vendor/WebKit/Source/JavaScriptCore/runtime/JSModuleLoader.cpp(591)
```

## Cause

`SourceTextModule` `instantiate()` runs JSC's whole-graph `record->link()`, which walks every reachable record via `innerModuleLinking` and calls `JSModuleLoader::getImportedModule()` for each requested module. `getImportedModule()` looks the request up in the referrer's `loadedModules()`, which is only populated by `setImportedModule()` during that module's own native `link()`.

In the link+evaluate-inside-the-linker pattern, module B finishes its `[kLink]` and calls `instantiate()` while module A is still suspended mid-`link()` (awaiting its own linker promise for B). A's `setImportedModule()` calls haven't run yet, so A's `loadedModules()` is empty. When B's `record->link()` descends into A and iterates A's requested modules, `getImportedModule(A, "b")` finds nothing → dereferences the `end()` iterator: an assert in debug, a read of `0xFFFFFFFFFFFFFFF8` (offset 8 past `end()`) in release.

## Fix

Before `instantiate()` calls the whole-graph `record->link()`, pre-walk the dependency graph exactly the way `innerModuleLinking` does. If any request is missing from a record's `loadedModules()`, the graph isn't fully linked, so throw a catchable `ERR_VM_MODULE_LINK_FAILURE` with Node's message (`request for '<specifier>' is not in cache`) instead of letting JSC crash. A `visited` set keeps the walk finite on cycles.

The canonical cyclic pattern — link the whole graph first (linker just returns the module), then evaluate the root once — already populates every record's `loadedModules()` before any `instantiate()`, so it is unaffected. Same for acyclic incremental linking.

## Verification

- `bun repro.ts` now throws `ERR_VM_MODULE_LINK_FAILURE: request for 'b' is not in cache` and exits 1 instead of segfaulting — matching Node.
- Canonical link-whole-graph-then-evaluate still resolves cyclic bindings (`a.ab() === "B"`, `b.ba() === "A"`).
- New tests in `test/js/node/vm/vm.test.ts` (`node:vm SourceTextModule cyclic graph linking`): the cyclic case fails (crashes) without the fix under both `bun bd` (the JSC assert) and the release build (SIGSEGV), and passes with it; self-import and canonical cases guard the working paths.
- Full `test/js/node/vm/vm.test.ts`, the SourceTextModule leak/GC suites, and the node-parallel `test-vm-module-{link,errors,reevaluate,synthetic}` tests all pass.