### PR TITLE
runtime: error on missing explicit env file

### DIFF
--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -923,15 +923,24 @@ impl<'a> Loader<'a> {
 
         let file = match bun_sys::open_file(file_path, bun_sys::OpenFlags::READ_ONLY) {
             Ok(f) => f,
-            Err(_) => {
-                // prevent retrying
-                // `Source::init_path_string` requires a `'static` path; the
-                // map key already carries `file_path` (boxed), and the value is never
-                // read for its path/contents — only `.contains()` and key iteration —
-                // so an empty placeholder is observationally identical.
-                self.custom_files_loaded
-                    .put(file_path, bun_ast::Source::default())?;
-                return Ok(());
+            Err(err) => {
+                // An explicitly requested `--env-file` that won't open is a user
+                // error: report it and fail instead of silently running without
+                // the variables. Only explicit files reach here — default `.env`
+                // discovery uses `load_default_files`, which stays silent. The
+                // loader reports and returns the error; the CLI caller decides to
+                // exit (it propagates to a non-zero exit). The loader must not
+                // exit the process itself.
+                bun_core::err_generic!(
+                    "failed to load env file \"{}\": {}",
+                    bstr::BStr::new(file_path),
+                    bstr::BStr::new(err.name()),
+                );
+                // `InvalidArgument` is the "already reported, exit quietly" code:
+                // callers propagate it to a non-zero exit and the top-level
+                // handler emits no extra message (the detailed line above is the
+                // only output). The bad `--env-file` path is an invalid argument.
+                return Err(bun_core::err!("InvalidArgument"));
             }
         };
 

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -670,7 +670,10 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
 
             // Always skip default .env files for package.json script runner
             // (the script's own bun instance loads .env)
-            let _ = this_transpiler.run_env_loader(true);
+            //
+            // Propagate: the loader reports a missing explicit `--env-file` and
+            // returns an error, which must surface as a non-zero exit.
+            this_transpiler.run_env_loader(true)?;
         }
 
         // Re-derive after `run_env_loader` — that call creates its own
@@ -1799,6 +1802,15 @@ impl RunCommand {
         let _ = unsafe { ctx.log() }.print(std::ptr::from_mut::<bun_core::io::Writer>(
             Output::error_writer(),
         ));
+
+        // Already-reported errors (e.g. a missing explicit `--env-file`, which the
+        // env loader prints in detail before returning this sentinel) must not get
+        // a second generic line — which would also leak the internal code name.
+        // Mirror the crash handler's `InvalidArgument` handling: exit non-zero
+        // without printing more.
+        if *err == bun_core::err!("InvalidArgument") {
+            Global::exit(1);
+        }
 
         pretty_errorln!(
             "<r><red>error<r>: Failed to run <b>{}<r> due to error <b>{}<r>",

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -564,7 +564,7 @@ describe("--env-file", () => {
   });
 
   test("empty string disables default dotenv behavior", () => {
-    expect(bunRun(["--env-file=''"]).stdout).toBe("");
+    expect(bunRun(["--env-file="]).stdout).toBe("");
   });
 
   test("should correctly ignore invalid values and parse the rest", () => {
@@ -572,9 +572,48 @@ describe("--env-file", () => {
     expect(res.stdout).toBe("BUNTEST_A=1,BUNTEST_B=1,BUNTEST_C=1,BUNTEST_D=,BUNTEST_E=1");
   });
 
-  test("should ignore a file that doesn't exist", () => {
-    const res = bunRun(["--env-file=.env.nonexisting"]);
-    expect(res.stdout).toBe("");
+  test("errors when an explicit env file does not exist", () => {
+    // Regression for #21105: an explicitly requested --env-file that can't be
+    // opened must fail (like Node), not silently run without the vars. Use a
+    // non-empty script — `-e ""` is treated as "no script" and prints help.
+    const result = Bun.spawnSync([bunExe(), "--env-file=.env.nonexisting", "-e", "0"], {
+      cwd: dir,
+      env: { ...bunEnv, NODE_ENV: undefined },
+    });
+    expect(result.stdout.toString("utf8")).toBe("");
+    expect(result.stderr.toString("utf8")).toContain(".env.nonexisting");
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  test("errors when an explicit env file does not exist (run path)", () => {
+    // The run-file / package.json-script path loads --env-file through a
+    // different caller than -e; make sure it fails there too.
+    const file = `${dir}/index.ts`;
+    const result = Bun.spawnSync([bunExe(), "--env-file=.env.nonexisting", file], {
+      cwd: path.dirname(file),
+      env: { ...bunEnv, NODE_ENV: undefined },
+    });
+    expect(result.stdout.toString("utf8")).toBe("");
+    expect(result.stderr.toString("utf8")).toContain(".env.nonexisting");
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  test("errors when an explicit env file does not exist (.sh entry path)", () => {
+    // A `.sh` entry boots through bun-shell and surfaces failures via a
+    // different handler than the JS paths; make sure it also fails with one
+    // message and doesn't leak the internal already-reported error code.
+    const shDir = tempDirWithFiles("dotenv-sh", { "script.sh": "echo hi\n" });
+    const file = `${shDir}/script.sh`;
+    const result = Bun.spawnSync([bunExe(), "--env-file=.env.nonexisting", file], {
+      cwd: path.dirname(file),
+      env: { ...bunEnv, NODE_ENV: undefined },
+    });
+    expect(result.stdout.toString("utf8")).toBe("");
+    const stderr = result.stderr.toString("utf8");
+    expect(stderr).toContain(".env.nonexisting");
+    expect(stderr).not.toContain("InvalidArgument");
+    expect(stderr).not.toContain("Failed to run");
+    expect(result.exitCode).not.toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

Addresses #21105.

Explicit `--env-file` paths were ignored when the file could not be opened. This now errors instead of continuing with missing environment variables.

Changes:
- error on missing explicit env files
- propagate env-loader errors through the run path
- update `--env-file` regression coverage

## Credits

Thanks to @zeon256 for the issue report and reproduction, and @allandiegoasilva for confirming the bug.

## Verification

- [x] cargo fmt --all --check
- [x] git diff --check -- src/dotenv/env_loader.rs src/runtime/cli/run_command.rs test/cli/run/env.test.ts
- [x] bun bd -e "console.log('ok')"
- [x] bun bd test test/cli/run/env.test.ts -t "env-file"

## Review map

- `src/dotenv/env_loader.rs`: report missing explicit `--env-file` and return the already-reported `InvalidArgument` sentinel
- `src/runtime/cli/run_command.rs`: propagate env-loader errors through run/script paths and suppress duplicate already-reported errors in `.sh` boot failure handling
- `test/cli/run/env.test.ts`: cover missing env-file errors for eval, run, and `.sh` entry paths
- `test/cli/run/env.test.ts`: preserve `--env-file=` behavior that disables default dotenv loading
