### PR TITLE
Fix node:http2 and worker_threads crashes found by extended Node test suite runs

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1163,6 +1163,40 @@ impl JSValue {
             .get(global, property)?
             .filter(|v| !v.is_empty_or_undefined_or_null() && !(v.is_string() && !v.to_boolean())))
     }
+    /// `JSValue.getPropertyValue` (JSValue.zig:1565) — like `get`, but safe for
+    /// property names that parse as array indices.
+    pub fn get_property_value(
+        self,
+        global: &JSGlobalObject,
+        property: impl AsRef<[u8]>,
+    ) -> JsResult<Option<JSValue>> {
+        let property = property.as_ref();
+        // SAFETY: bytes valid for the call.
+        let v = unsafe {
+            crate::cpp::JSC__JSValue__getPropertyValue(
+                self,
+                global,
+                property.as_ptr(),
+                property.len(),
+            )
+        }?;
+        if v.0 == JSValue::PROPERTY_DOES_NOT_EXIST.0 || v.is_undefined() {
+            Ok(None)
+        } else {
+            Ok(Some(v))
+        }
+    }
+    /// `JSValue.getTruthyPropertyValue` (JSValue.zig:1668) — `get_truthy` for
+    /// property names that may parse as array indices.
+    pub fn get_truthy_property_value(
+        self,
+        global: &JSGlobalObject,
+        property: impl AsRef<[u8]>,
+    ) -> JsResult<Option<JSValue>> {
+        Ok(self
+            .get_property_value(global, property)?
+            .filter(|v| !v.is_empty_or_undefined_or_null() && !(v.is_string() && !v.to_boolean())))
+    }
     /// JSValue.zig:1649 `getTruthyComptime` — `fast_get` (precached `JSC::Identifier`,
     /// no StringImpl alloc / atom-table probe) followed by the same `truthyPropertyValue`
     /// filter as `get_truthy`. Use this when the property name is a `BuiltinName`.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1419,6 +1419,12 @@ impl VirtualMachine {
 
         let hooks = runtime_hooks().expect("RuntimeHooks not installed");
         if self.is_handling_uncaught_exception {
+            if !self.is_main_thread() {
+                self.unhandled_error_counter += 1;
+                self.exit_handler.exit_code = 1;
+                (self.on_unhandled_rejection)(self, global_object, err);
+                return true;
+            }
             self.run_error_handler(err, None);
             // SAFETY: `global_object` is the live VM global; `process_exit` is
             // `bun_runtime::node::process::exit` (main-thread `noreturn`).
@@ -1447,10 +1453,10 @@ impl VirtualMachine {
         // (VirtualMachine.zig:707) covers BOTH the FFI call and the
         // `onUnhandledRejection` callback above. The flag must stay raised
         // while that callback runs so a re-entrant `uncaught_exception` from
-        // a user handler trips the recursion guard and hard-exits with code 7
+        // a user handler trips the recursion guard (main thread: hard-exit
+        // with code 7; worker: dispatch the error and request termination)
         // instead of recursing. Neither the FFI call nor the fn-pointer
-        // callback unwind past this frame (re-entry hits `process_exit` →
-        // `panic!`, which never returns), so a linear reset here matches the
+        // callback unwind past this frame, so a linear reset here matches the
         // Zig `defer` scope.
         self.is_handling_uncaught_exception = false;
         handled

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1425,7 +1425,7 @@ impl VirtualMachine {
             unsafe { (hooks.process_exit)(global_object.as_ptr(), 7) };
             panic!("Uncaught exception while handling uncaught exception");
         }
-        if self.exit_on_uncaught_exception {
+        if self.exit_on_uncaught_exception && self.is_main_thread() {
             self.run_error_handler(err, None);
             // SAFETY: see above.
             unsafe { (hooks.process_exit)(global_object.as_ptr(), 1) };

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4401,9 +4401,9 @@ JSC::EncodedJSValue JSC__JSValue__createObject2(JSC::JSGlobalObject* globalObjec
 // Returns empty for exception, returns deleted if not found.
 // Be careful when handling the return value.
 // Can handle numeric index property names safely. If you know that the property name is not an integer index, use JSC__JSValue__getIfPropertyExistsImpl instead.
-JSC::EncodedJSValue JSC__JSValue__getPropertyValue(JSC::EncodedJSValue encodedValue,
+[[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue JSC__JSValue__getPropertyValue(JSC::EncodedJSValue encodedValue,
     JSC::JSGlobalObject* globalObject,
-    const unsigned char* propertyName, uint32_t propertyNameLength)
+    const unsigned char* propertyName, size_t propertyNameLength)
 {
 
     ASSERT_NO_PENDING_EXCEPTION(globalObject);

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -1686,6 +1686,12 @@ private:
             }
             if (auto* errorInstance = dynamicDowncast<ErrorInstance>(obj)) {
                 auto& vm = m_lexicalGlobalObject->vm();
+                // The descriptor reads below lazily materialize the error's stack info,
+                // which can run user JS (Error.prepareStackTrace) that may throw.
+                // Materialize once up front under exception control so a pending
+                // exception cannot leak into getOwnPropertyDescriptor().
+                errorInstance->materializeErrorInfoIfNeeded(vm);
+                RETURN_IF_EXCEPTION(scope, false);
                 auto errorTypeValue = errorInstance->get(m_lexicalGlobalObject, vm.propertyNames->name);
                 RETURN_IF_EXCEPTION(scope, false);
                 auto errorTypeString = errorTypeValue.toWTFString(m_lexicalGlobalObject);

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -1690,8 +1690,10 @@ private:
                 // which can run user JS (Error.prepareStackTrace) that may throw.
                 // Materialize once up front under exception control so a pending
                 // exception cannot leak into getOwnPropertyDescriptor().
-                errorInstance->materializeErrorInfoIfNeeded(vm);
-                RETURN_IF_EXCEPTION(scope, false);
+                if (!errorInstance->hasMaterializedErrorInfo()) {
+                    errorInstance->materializeErrorInfoIfNeeded(vm);
+                    RETURN_IF_EXCEPTION(scope, false);
+                }
                 auto errorTypeValue = errorInstance->get(m_lexicalGlobalObject, vm.propertyNames->name);
                 RETURN_IF_EXCEPTION(scope, false);
                 auto errorTypeString = errorTypeValue.toWTFString(m_lexicalGlobalObject);

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -45,6 +45,8 @@
 #include "CloseEvent.h"
 #include "JSMessagePort.h"
 #include "JSBroadcastChannel.h"
+#include <JavaScriptCore/ErrorInstance.h>
+#include <JavaScriptCore/TopExceptionScope.h>
 
 namespace WebCore {
 
@@ -496,6 +498,30 @@ void Worker::dispatchErrorWithMessage(WTF::String message)
 
 bool Worker::dispatchErrorWithValue(Zig::GlobalObject* workerGlobalObject, JSValue value)
 {
+    // Serializing an Error materializes its stack info, which can run user JS
+    // (Error.prepareStackTrace) that may throw. Materialize it up front under
+    // exception control: if it throws, clear the exception and drop the
+    // partially-materialized stack property so the error is still delivered to
+    // the parent's 'error' event (without a stack), matching Node. This is a
+    // native entry point that never propagates exceptions, hence the
+    // TopExceptionScope.
+    if (auto* errorInstance = dynamicDowncast<JSC::ErrorInstance>(value)) {
+        auto& vm = JSC::getVM(workerGlobalObject);
+        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+        errorInstance->materializeErrorInfoIfNeeded(vm);
+        if (scope.exception()) [[unlikely]] {
+            if (!scope.clearExceptionExceptTermination())
+                return false;
+            JSC::VM::DeletePropertyModeScope deleteScope(vm, JSC::VM::DeletePropertyMode::IgnoreConfigurable);
+            JSC::DeletePropertySlot slot;
+            JSC::JSObject::deleteProperty(errorInstance, workerGlobalObject, vm.propertyNames->stack, slot);
+            if (scope.exception()) [[unlikely]] {
+                if (!scope.clearExceptionExceptTermination())
+                    return false;
+            }
+        }
+    }
+
     auto serialized = SerializedScriptValue::create(*workerGlobalObject, value, SerializationForStorage::No, SerializationErrorMode::NonThrowing);
     if (!serialized)
         return false;

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -6211,11 +6211,14 @@ impl H2FrameParser {
                         }
                     };
 
-                    let never_index =
-                        match sensitive_arg.get_truthy(global_object, validated_name)? {
-                            Some(_) => true,
-                            None => sensitive_arg.get_truthy(global_object, name)?.is_some(),
-                        };
+                    let never_index = match sensitive_arg
+                        .get_truthy_property_value(global_object, validated_name)?
+                    {
+                        Some(_) => true,
+                        None => sensitive_arg
+                            .get_truthy_property_value(global_object, name)?
+                            .is_some(),
+                    };
 
                     let value_slice = value_str.to_slice(global_object);
                     let value = value_slice.slice();
@@ -6253,10 +6256,13 @@ impl H2FrameParser {
                     }
                 };
 
-                let never_index = match sensitive_arg.get_truthy(global_object, validated_name)? {
-                    Some(_) => true,
-                    None => sensitive_arg.get_truthy(global_object, name)?.is_some(),
-                };
+                let never_index =
+                    match sensitive_arg.get_truthy_property_value(global_object, validated_name)? {
+                        Some(_) => true,
+                        None => sensitive_arg
+                            .get_truthy_property_value(global_object, name)?
+                            .is_some(),
+                    };
 
                 let value_slice = value_str.to_slice(global_object);
                 let value = value_slice.slice();
@@ -6842,11 +6848,14 @@ impl H2FrameParser {
                             }
                         };
 
-                        let never_index =
-                            match sensitive_arg.get_truthy(global_object, validated_name)? {
-                                Some(_) => true,
-                                None => sensitive_arg.get_truthy(global_object, name)?.is_some(),
-                            };
+                        let never_index = match sensitive_arg
+                            .get_truthy_property_value(global_object, validated_name)?
+                        {
+                            Some(_) => true,
+                            None => sensitive_arg
+                                .get_truthy_property_value(global_object, name)?
+                                .is_some(),
+                        };
 
                         let value_slice = value_str.to_slice(global_object);
                         let value = value_slice.slice();
@@ -6929,11 +6938,14 @@ impl H2FrameParser {
                         }
                     };
 
-                    let never_index =
-                        match sensitive_arg.get_truthy(global_object, validated_name)? {
-                            Some(_) => true,
-                            None => sensitive_arg.get_truthy(global_object, name)?.is_some(),
-                        };
+                    let never_index = match sensitive_arg
+                        .get_truthy_property_value(global_object, validated_name)?
+                    {
+                        Some(_) => true,
+                        None => sensitive_arg
+                            .get_truthy_property_value(global_object, name)?
+                            .is_some(),
+                    };
 
                     let value_slice = value_str.to_slice(global_object);
                     let value = value_slice.slice();

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1569,6 +1569,43 @@ it("sensitive headers should work", async () => {
   }
 });
 
+it("sensitive headers work with numeric header names", async () => {
+  const server = http2.createServer();
+  let client;
+  try {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    server.on("stream", stream => {
+      stream.respond({
+        ":status": 200,
+        "0": "some-value",
+
+        [http2.sensitiveHeaders]: ["0"],
+      });
+
+      stream.end();
+    });
+
+    server.listen(0, () => {
+      const port = server.address().port;
+      client = http2.connect(`http://localhost:${port}`);
+
+      client.on("error", reject);
+
+      const req = client.request({ ":path": "/", "1": "x" });
+      req.on("response", resolve);
+      req.on("error", reject);
+      req.end();
+    });
+    const res = await promise;
+
+    expect(res["0"]).toBe("some-value");
+    expect(res[http2.sensitiveHeaders]).toEqual(["0"]);
+  } finally {
+    server.close();
+    client?.close?.();
+  }
+});
+
 it("http2 session.goaway() validates input types", async done => {
   const { mustCall } = createCallCheckCtx(done);
   const server = http2.createServer((req, res) => {

--- a/test/js/node/test/parallel/test-worker-error-stack-getter-throws.js
+++ b/test/js/node/test/parallel/test-worker-error-stack-getter-throws.js
@@ -1,0 +1,22 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+const w = new Worker(
+  `const fn = (err) => {
+    if (err.message === 'fhqwhgads')
+      throw new Error('come on');
+    return 'This is my custom stack trace!';
+  };
+  Error.prepareStackTrace = fn;
+  throw new Error('fhqwhgads');
+  `,
+  { eval: true }
+);
+w.on('message', common.mustNotCall());
+w.on('error', common.mustCall((err) => {
+  assert.strictEqual(err.stack, undefined);
+  assert.strictEqual(err.message, 'fhqwhgads');
+  assert.strictEqual(err.name, 'Error');
+}));

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -278,6 +278,33 @@ w.on("exit", code => console.log("exit:", code, workerData[1]));`,
   });
 });
 
+test("throwing in a Worker's uncaughtException handler terminates only the worker", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const { Worker } = require("worker_threads");
+const w = new Worker(
+  "process.on('uncaughtException', () => { throw new Error('boom2'); }); throw new Error('boom1');",
+  { eval: true },
+);
+w.on("error", err => console.log("error:", err.message));
+w.on("exit", code => console.log("exit:", code));`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, signalCode: proc.signalCode, exitCode }).toEqual({
+    stdout: "error: boom2\nexit: 1\n",
+    stderr: "",
+    signalCode: null,
+    exitCode: 0,
+  });
+});
+
 describe("execArgv option", async () => {
   // this needs to be a subprocess to ensure that the parent's execArgv is not empty
   // otherwise we could not distinguish between the worker inheriting the parent's execArgv

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -269,9 +269,13 @@ w.on("exit", code => console.log("exit:", code, workerData[1]));`,
     stderr: "pipe",
   });
 
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-  expect(stdout).toBe("error: banana\nexit: 1 200\n");
-  expect(exitCode).toBe(0);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, signalCode: proc.signalCode, exitCode }).toEqual({
+    stdout: "error: banana\nexit: 1 200\n",
+    stderr: "",
+    signalCode: null,
+    exitCode: 0,
+  });
 });
 
 describe("execArgv option", async () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -250,6 +250,30 @@ test("support worker eval that throws", async () => {
   await worker.terminate();
 });
 
+test("throwing in a Worker's beforeExit handler does not crash the process", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const { Worker } = require("worker_threads");
+const workerData = new Uint8Array(new SharedArrayBuffer(2));
+const w = new Worker(
+  "const { workerData } = require('worker_threads'); process.on('beforeExit', () => { workerData[1] = 200; throw new Error('banana'); });",
+  { eval: true, workerData },
+);
+w.on("error", err => console.log("error:", err.message));
+w.on("exit", code => console.log("exit:", code, workerData[1]));`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toBe("error: banana\nexit: 1 200\n");
+  expect(exitCode).toBe(0);
+});
+
 describe("execArgv option", async () => {
   // this needs to be a subprocess to ensure that the parent's execArgv is not empty
   // otherwise we could not distinguish between the worker inheriting the parent's execArgv


### PR DESCRIPTION
Fixes three crashes found by running the full Node.js v24.3.0 `test/parallel` suite (3,723 files; Bun's suite imports 2,189 of them) against an assertion-enabled build. All three are in code paths Bun's existing test suite never exercises; each fix includes a regression test that fails on the released build.

### node:http2 — numeric header names in `sensitiveHeaders`
`h2_frame_parser.rs` looked up header names from the `[http2.sensitiveHeaders]` object through a property-lookup helper whose contract excludes array-index names, so a header name like `"0"` hit an assertion (and in release builds took an incorrect lookup path). The lookup now routes index-shaped names through the indexed-property path.
*Found by:* `test-http2-raw-headers.js`, `test-http2-sensitive-headers.js`.
*Note:* names like `toString`/`constructor` in the sensitiveHeaders object resolve via the prototype chain (same as 1.3.x); using `{ __proto__: null }` for that object in http2.ts is a possible follow-up.

### worker_threads — `process.exit()` after a throwing `beforeExit` handler
`Process__dispatchOnBeforeExit` marked the VM as exiting-during-uncaught-exception before emitting `beforeExit`. Inside a Worker, the subsequent `process.exit()` then fell through the worker exit path and hit the "made it past process.exit()" trap. Worker uncaught exceptions now route through worker error handling, and `process.exit()` in a worker terminates that worker with the given code (Node semantics).
*Found by:* `test-worker-beforeexit-throw-exit.js` (also covers the main-thread twin `test-process-beforeexit-throw-exit.js`).

### worker_threads — error with a throwing stack getter crossing the thread boundary
Posting an Error whose stack materialization throws (e.g. a throwing `Error.prepareStackTrace`) from a worker to its parent left a pending exception inside the structured-clone serializer, tripping JSC's exception-check discipline. The serializer now pre-materializes stack info and propagates the exception; `Worker::dispatchErrorWithValue` clears it and drops the unreadable property, so the parent still receives the error event.
*Found by:* `test-worker-error-stack-getter-throws.js` (imported as a regression test).
*Known remaining:* the pure-JS `Object.getOwnPropertyDescriptor(err, "stack")` variant of this hits an invariant inside vendored WebKit's ErrorInstance and needs an oven-sh/WebKit change — tracked separately.

A fourth crash found by the same sweep (`test-worker-http2-stream-terminate.js`) is already fixed by #31216 and is not addressed here.

### Tests
- `node-http2.test.js`: new "sensitive headers work with numeric header names" test — fails on the released build, passes here; full file 275 pass with no new failures.
- `worker_threads.test.ts`: new beforeExit/process.exit test — fails on the released build (panic), passes here.
- `test/js/node/test/parallel/test-worker-error-stack-getter-throws.js`: imported from Node, exits 0 here, crashes the released build.
- All three pass under `BUN_JSC_validateExceptionChecks=1`; `rust:check-all` 10/10; formatters clean.
