### PR TITLE
node:process: track bytesWritten for stdio streams

### DIFF
--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -587,6 +587,13 @@ function _write(data, encoding, cb) {
 }
 writeStreamPrototype._write = _write;
 
+// `bytesWritten` must reflect encoded bytes, not UTF-16 code units: `writeFast`
+// is the public `.write`, so a string reaches the fast path undecoded and must
+// be measured with `Buffer.byteLength` (oven-sh/bun#23061).
+function bytesForWrite(data: any, encoding?: BufferEncoding): number {
+  return typeof data === "string" ? Buffer.byteLength(data, encoding) : (data?.byteLength ?? data?.length ?? 0);
+}
+
 function underscoreWriteFast(this: FSStream, data: any, encoding: any, cb: any) {
   let fileSink = this[kWriteStreamFastPath];
   if (!fileSink) {
@@ -602,7 +609,9 @@ function underscoreWriteFast(this: FSStream, data: any, encoding: any, cb: any) 
       this.fd = fileSink._getFd();
     }
 
+    const bytes = bytesForWrite(data, encoding);
     const maybePromise = fileSink.write(data);
+    this.bytesWritten += bytes; // see writeFast (oven-sh/bun#23061)
     if ($isPromise(maybePromise)) {
       maybePromise.then(
         () => {
@@ -651,7 +660,12 @@ function writeFast(this: FSStream, data: any, encoding: any, cb: any) {
 
   const fileSink = this[kWriteStreamFastPath];
   if (fileSink && fileSink !== true) {
+    // Track bytes handed to the sink so process.stdout/stderr.bytesWritten
+    // reflects writes (oven-sh/bun#23061). Count encoded bytes, not UTF-16 code
+    // units, since a string write reaches the fast path undecoded.
+    const bytes = bytesForWrite(data, encoding);
     const maybePromise = fileSink.write(data);
+    this.bytesWritten += bytes;
     if ($isPromise(maybePromise)) {
       maybePromise
         .then(() => {
@@ -697,7 +711,9 @@ writeStreamPrototype._writev = function (data, cb) {
 
   const fileSink = this[kWriteStreamFastPath];
   if (fileSink && fileSink !== true) {
-    const maybePromise = fileSink.write(Buffer.concat(chunks));
+    const buffer = Buffer.concat(chunks);
+    const maybePromise = fileSink.write(buffer);
+    this.bytesWritten += buffer.length; // see writeFast (oven-sh/bun#23061)
     if ($isPromise(maybePromise)) {
       maybePromise
         .then(() => {

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { WriteStream } from "node:tty";
 
 describe("ReadStream.prototype.setRawMode", () => {
@@ -103,5 +105,51 @@ describe("WriteStream.prototype.getColorDepth", () => {
 
   it("empty", () => {
     expect(WriteStream.prototype.getColorDepth.call(undefined, {})).toBe(isWindows ? 24 : 1);
+  });
+});
+
+// Regression for oven-sh/bun#23061: in TTY mode Node increments
+// process.stdout/stderr.bytesWritten on write, but Bun left it at 0. Uses
+// Bun.spawn({ terminal }) for a real pty and a side-channel report file so the
+// stdout/stderr writes don't corrupt the assertion channel.
+describe("process.stdout/stderr.bytesWritten (#23061)", () => {
+  it("increments after writes in TTY mode", async () => {
+    using dir = tempDir("stdio-bytes-written", {});
+    const reportPath = join(dir, "bytes-written.json");
+    const script = `
+      const fs = require("node:fs");
+      process.stdout.write("out-🚀"); // 4 + 4 = 8 UTF-8 bytes (not 6 UTF-16 units)
+      process.stderr.write("err-⚡"); // 4 + 3 = 7 UTF-8 bytes
+      fs.writeFileSync(${JSON.stringify(reportPath)}, JSON.stringify({
+        stdoutIsTTY: process.stdout.isTTY,
+        stderrIsTTY: process.stderr.isTTY,
+        stdoutBytesWritten: process.stdout.bytesWritten,
+        stderrBytesWritten: process.stderr.bytesWritten,
+      }));
+      process.exit(0);
+    `;
+    const done = Promise.withResolvers<void>();
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      terminal: {
+        cols: 200,
+        rows: 24,
+        data() {},
+        exit() {
+          done.resolve();
+        },
+      },
+    });
+    await Promise.race([done.promise, proc.exited]);
+    const exitCode = await proc.exited;
+    proc.terminal?.close();
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    expect(report.stdoutIsTTY).toBe(true);
+    expect(report.stderrIsTTY).toBe(true);
+    expect(report.stdoutBytesWritten).toBe(8); // "out-🚀"
+    expect(report.stderrBytesWritten).toBe(7); // "err-⚡"
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Addresses #23061.

TTY-backed `process.stdout` and `process.stderr` used fast-path stdio writes without updating `bytesWritten`. This tracks the byte count handed to the sink after successful fast-path writes.

Changes:
- track `bytesWritten` in stdio fast-path write paths
- count string writes by encoded byte length
- add a TTY regression for stdout/stderr byte counters

## Credits

Thanks to @erictheswift for the reproduction.

## Verification

- [x] cargo fmt --all --check
- [x] git diff --check -- src/js/internal/fs/streams.ts test/js/node/tty.test.ts
- [x] bun bd -e "console.log('ok')"
- [x] bun bd test test/js/node/tty.test.ts -t "bytesWritten"
- [x] bun bd test test/js/node/tty.test.ts
- [x] bun bd test test/js/node/fs/fs.test.ts -t "WriteStream"
- [x] Regression confirmed: unpatched TTY stdio stays at `0`; patched increments to `8` / `7` for multibyte writes

## Review map

- `streams.ts`: `bytesForWrite()` helper counts encoded bytes for fast-path writes in `writeFast`, `underscoreWriteFast`, and `_writev`
- `tty.test.ts`: pty-backed regression writes multibyte strings and checks stdout/stderr `bytesWritten`
