### PR TITLE
spyOn: wrap indexed-property spy value in a GetterSetter

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1553,8 +1553,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
                 moduleNamespaceObject->overrideExportValue(globalObject, propertyKey, mock);
                 mock->spyAttributes |= JSMockFunction::SpyAttributeESModuleNamespace;
             } else if (auto index = parseIndex(propertyKey)) {
-                // For indexed properties, set the mock directly instead of wrapping in GetterSetter
-                object->putDirectIndex(globalObject, *index, mock, attributes, PutDirectIndexLikePutDirect);
+                object->putDirectIndex(globalObject, *index, JSC::GetterSetter::create(vm, globalObject, mock, mock), attributes, PutDirectIndexLikePutDirect);
             } else {
                 object->putDirectAccessor(globalObject, propertyKey, JSC::GetterSetter::create(vm, globalObject, mock, mock), attributes);
             }

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1135,6 +1135,20 @@ describe("spyOn", () => {
       expect(Bar.prototype()).toBe(7);
       expect(fn).not.toHaveBeenCalled();
     });
+
+    test("spyOn works with an indexed non-callable data property", () => {
+      const obj = { 5: 123 };
+
+      const fn = spyOn(obj, 5);
+      expect(obj[5]).toBe(123);
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(Object.getOwnPropertyDescriptor(obj, "5").get).toBeInstanceOf(Function);
+      expect(Object.keys(obj)).toEqual(["5"]);
+
+      fn.mockRestore();
+      expect(obj[5]).toBe(123);
+      expect(fn).not.toHaveBeenCalled();
+    });
   }
 
   // spyOn does not work with getters/setters yet.


### PR DESCRIPTION
## What

`spyOn(obj, key)` where `key` is a numeric/indexed property and the original value is **not callable** crashed with a JavaScriptCore assertion (`PropertySlot.h:219`):

```
ASSERTION FAILED: attributes == attributesForStructure(attributes) && !(attributes & PropertyAttribute::Accessor)
.../JavaScriptCore/PropertySlot.h(219) : void JSC::PropertySlot::setValue(JSObject *, unsigned int, JSValue)
```

## Root cause

In `JSMock__jsSpyOn`, the non-callable branch ORs in `PropertyAttribute::Accessor` and then, for an indexed key, stored the mock cell directly:

```cpp
attributes |= PropertyAttribute::Accessor;
...
} else if (auto index = parseIndex(propertyKey)) {
    object->putDirectIndex(globalObject, *index, mock, attributes, PutDirectIndexLikePutDirect); // plain cell under an Accessor-flagged slot
} else {
    object->putDirectAccessor(globalObject, propertyKey, JSC::GetterSetter::create(vm, globalObject, mock, mock), attributes);
}
```

Indexed properties with non-default attributes live in a `SparseArrayValueMap`. When the slot is read, `SparseArrayEntry::get` requires an Accessor-flagged entry to hold a `GetterSetter`; otherwise it falls through to `PropertySlot::setValue`, which forbids the `Accessor` bit — hence the assertion under debug/ASAN builds. In release (no assertion) the read returned the mock cell itself instead of invoking it, so `obj[index]` gave the wrong value.

The non-indexed path already does the right thing by wrapping the mock in a `GetterSetter`.

## Fix

Wrap the mock in a `GetterSetter` for the indexed path too, so the stored value matches the `Accessor` attribute.

## Test

Added a regression test in `test/js/bun/test/mock-fn.test.js` covering `spyOn` on an indexed non-callable data property: reading the index returns the original value, the spy records the call, the property becomes an accessor descriptor, and `mockRestore` restores the original. The existing indexed tests only covered callable values (a different code path).

Fingerprint: `PropertySlot.h(219)`