### PR TITLE
text-encoder: handle detached encodeInto destinations

### DIFF
--- a/src/runtime/webcore/TextEncoder.rs
+++ b/src/runtime/webcore/TextEncoder.rs
@@ -276,6 +276,14 @@ pub(crate) unsafe extern "C" fn TextEncoder__encodeInto16(
     buf_ptr: *mut u8,
     buf_len: usize,
 ) -> u64 {
+    // A detached destination view reports a zero byte length and a null
+    // `buf_ptr`. `from_raw_parts_mut` requires a non-null pointer even for a
+    // zero-length slice, so bail out before constructing it. Nothing can be
+    // written into an empty buffer; `0` packs to `{ read: 0, written: 0 }`,
+    // matching Node.
+    if buf_len == 0 {
+        return 0;
+    }
     // SAFETY: caller guarantees buf_ptr[0..buf_len] is a valid mutable buffer
     let output = unsafe { core::slice::from_raw_parts_mut(buf_ptr, buf_len) };
     // SAFETY: caller guarantees input_ptr[0..input_len] is valid UTF-16 data
@@ -298,6 +306,14 @@ pub(crate) unsafe extern "C" fn TextEncoder__encodeInto8(
     buf_ptr: *mut u8,
     buf_len: usize,
 ) -> u64 {
+    // A detached destination view reports a zero byte length and a null
+    // `buf_ptr`. `from_raw_parts_mut` requires a non-null pointer even for a
+    // zero-length slice, so bail out before constructing it. Nothing can be
+    // written into an empty buffer; `0` packs to `{ read: 0, written: 0 }`,
+    // matching Node.
+    if buf_len == 0 {
+        return 0;
+    }
     // SAFETY: caller guarantees buf_ptr[0..buf_len] is a valid mutable buffer
     let output = unsafe { core::slice::from_raw_parts_mut(buf_ptr, buf_len) };
     // SAFETY: caller guarantees input_ptr[0..input_len] is valid Latin-1 data

--- a/test/js/web/encoding/text-encoder.test.js
+++ b/test/js/web/encoding/text-encoder.test.js
@@ -683,3 +683,28 @@ describe("TextEncoder UTF-16 exact-size path", () => {
     }
   });
 });
+
+describe("TextEncoder encodeInto detached destination", () => {
+  const encoder = new TextEncoder();
+
+  // `structuredClone(ab, { transfer: [ab] })` detaches the ArrayBuffer, so the
+  // view reports byteLength 0 and a null backing pointer. Both encodeInto arms
+  // (Latin-1 for "x", UTF-16 for the others) must report { read: 0, written: 0 }
+  // like Node instead of constructing a slice from a null pointer.
+  it.each([
+    ["x"], // Latin-1
+    ["Ā"], // UTF-16
+    ["💕"], // astral
+  ])("returns { read: 0, written: 0 } for a detached Uint8Array with input %j", input => {
+    const ab = new ArrayBuffer(1);
+    const dest = new Uint8Array(ab);
+    structuredClone(ab, { transfer: [ab] });
+
+    expect(dest.byteLength).toBe(0);
+    expect(encoder.encodeInto(input, dest)).toEqual({ read: 0, written: 0 });
+  });
+
+  it("returns { read: 0, written: 0 } for a non-detached zero-length destination", () => {
+    expect(encoder.encodeInto("x", new Uint8Array(0))).toEqual({ read: 0, written: 0 });
+  });
+});

--- a/test/js/web/encoding/text-encoder.test.js
+++ b/test/js/web/encoding/text-encoder.test.js
@@ -707,4 +707,17 @@ describe("TextEncoder encodeInto detached destination", () => {
   it("returns { read: 0, written: 0 } for a non-detached zero-length destination", () => {
     expect(encoder.encodeInto("x", new Uint8Array(0))).toEqual({ read: 0, written: 0 });
   });
+
+  it("returns { read: 0, written: 0 } when source toString() detaches the destination", () => {
+    const ab = new ArrayBuffer(16);
+    const dest = new Uint8Array(ab);
+    const src = {
+      toString() {
+        structuredClone(ab, { transfer: [ab] });
+        return "hello";
+      },
+    };
+    expect(encoder.encodeInto(src, dest)).toEqual({ read: 0, written: 0 });
+    expect(dest.byteLength).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

`TextEncoder.prototype.encodeInto()` accepted a detached `Uint8Array` destination. A detached view reports `byteLength` 0 and a null backing pointer, but that pointer and length were still passed into the Rust encoder, which built its output slice with `core::slice::from_raw_parts_mut(null, 0)`. `from_raw_parts_mut` requires a non-null pointer even for a zero-length slice. Violating this is undefined behavior in all Rust builds; debug builds catch it with a precondition trap.

This returns `{ read: 0, written: 0 }` for an empty output buffer before constructing the slice, in both the Latin-1 and UTF-16 encode paths. It matches Node, which returns `{ read: 0, written: 0 }` for the same input. A non-detached zero-length destination (`new Uint8Array(0)`) was already handled correctly because its backing pointer is non-null; that behavior is unchanged.

Changes:
- guard `buf_len == 0` in `TextEncoder__encodeInto8` / `TextEncoder__encodeInto16` before `from_raw_parts_mut`
- add regression coverage for detached destinations through the 8-bit and UTF-16 source paths, plus the non-detached zero-length control

## Test approach

The destination is detached with `structuredClone(ab, { transfer: [ab] })`, which drives the view's `byteLength` to 0 and its backing pointer to null.

## Verification

- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [x] `bun bd -e "console.log('ok')"`
- [x] `bun bd test test/js/web/encoding/text-encoder.test.js` (44 pass, 0 fail)
- [x] Regression confirmed: a detached destination traps in `from_raw_parts_mut` on the unpatched debug build and returns `{ read: 0, written: 0 }` after the fix

## Review map

- `src/runtime/webcore/TextEncoder.rs`: early-return the packed zero result for a zero-length output buffer in both encodeInto FFI entrypoints, before the slice is constructed
- `test/js/web/encoding/text-encoder.test.js`: cover detached `Uint8Array` destinations for Latin-1 (`"x"`), UTF-16 (`"Ā"`), and astral (`"💕"`) sources, and keep the non-detached zero-length case
