### PR TITLE
crypto: avoid aliasing one-shot hash buffers

### DIFF
--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -377,7 +377,6 @@ impl CryptoHasher {
         output: Option<ArrayBuffer>,
     ) -> JsResult<JSValue> {
         let mut output_digest_buf: Digest = [0u8; EVP_MAX_MD_SIZE_USIZE];
-        let mut output_digest_slice: &mut [u8] = &mut output_digest_buf;
         // `defer input.deinit()` — handled by Drop on `input`.
 
         if is_bun_file_blob(input) {
@@ -386,6 +385,11 @@ impl CryptoHasher {
             )));
         }
 
+        // Validate the caller buffer length, but do not build a mutable reference
+        // into it yet: `input` and `output` may be views over the same backing
+        // store, and holding `&[u8]` input alongside `&mut [u8]` output over
+        // overlapping bytes violates Rust's aliasing rules. Hash into local
+        // storage, then copy into the caller buffer once the input borrow ends.
         if let Some(output_buf) = &output {
             let size = evp.size() as usize;
             let bytes_len = output_buf.byte_slice().len();
@@ -395,25 +399,29 @@ impl CryptoHasher {
                     size
                 )));
             }
-            // SAFETY: `output_buf.ptr` is the JSC-owned writable backing store
-            // (`bytes_len >= size` checked above; not detached since len > 0);
-            // borrowed for this frame only. Build the `&mut` directly from the
-            // raw `*mut u8` field — never via `&[u8].as_ptr()` (Stacked-Borrows UB).
-            output_digest_slice = unsafe { core::slice::from_raw_parts_mut(output_buf.ptr, size) };
         }
 
-        let Some(len) = evp.hash(boring_engine(global), input.slice(), output_digest_slice) else {
+        let Some(len) = evp.hash(boring_engine(global), input.slice(), &mut output_digest_buf)
+        else {
             let err = boring_ssl::ERR_get_error();
             let instance = create_crypto_error(global, err);
             boring_ssl::ERR_clear_error();
             return Err(global.throw_value(instance));
         };
+        let len = len as usize;
 
         if let Some(output_buf) = output {
+            // SAFETY: `output_buf.ptr` is the JSC-owned writable backing store
+            // (length validated `>= len` above; not detached since len > 0). The
+            // input borrow has ended, so this write cannot alias a live shared
+            // reference even when the buffers overlap. Build the `&mut` directly
+            // from the raw `*mut u8` field — never via `&[u8].as_ptr()`.
+            let output = unsafe { core::slice::from_raw_parts_mut(output_buf.ptr, len) };
+            output.copy_from_slice(&output_digest_buf[0..len]);
             Ok(output_buf.value)
         } else {
             // Clone to GC-managed memory
-            ArrayBuffer::create_buffer(global, &output_digest_slice[0..len as usize])
+            ArrayBuffer::create_buffer(global, &output_digest_buf[0..len])
         }
     }
 
@@ -1320,7 +1328,12 @@ impl<H: StaticHasher> StaticCryptoHasher<H> {
         output: Option<ArrayBuffer>,
     ) -> JsResult<JSValue> {
         let mut output_digest_buf: H::Digest = H::new_digest();
-        let output_digest_slice: &mut H::Digest;
+
+        // Validate the caller buffer length, but do not build a mutable reference
+        // into it yet: `input` and `output` may be views over the same backing
+        // store, and holding `&[u8]` input alongside the `&mut` output over
+        // overlapping bytes violates Rust's aliasing rules. Hash into local
+        // storage, then copy into the caller buffer once the input borrow ends.
         if let Some(output_buf) = &output {
             let bytes_len = output_buf.byte_slice().len();
             if bytes_len < H::DIGEST {
@@ -1329,29 +1342,29 @@ impl<H: StaticHasher> StaticCryptoHasher<H> {
                     H::DIGEST
                 )));
             }
-            // SAFETY: `bytes_len >= H::DIGEST` checked above; `H::Digest = [u8; H::DIGEST]`;
-            // `output_buf.ptr` is the JSC-owned writable backing store. Build the
-            // `&mut` directly from the raw `*mut u8` field — never via
-            // `&[u8].as_ptr()` (Stacked-Borrows UB).
-            output_digest_slice = unsafe { &mut *output_buf.ptr.cast::<H::Digest>() };
-        } else {
-            output_digest_slice = &mut output_digest_buf;
         }
 
         // SAFETY: `boring_engine` returns the VM-owned engine (live for the
         // process) or null; the else arm passes null.
         unsafe {
             if H::HAS_ENGINE {
-                H::hash(input.slice(), output_digest_slice, boring_engine(global));
+                H::hash(input.slice(), &mut output_digest_buf, boring_engine(global));
             } else {
-                H::hash(input.slice(), output_digest_slice, core::ptr::null_mut());
+                H::hash(input.slice(), &mut output_digest_buf, core::ptr::null_mut());
             }
         }
 
         if let Some(output_buf) = output {
+            // SAFETY: `bytes_len >= H::DIGEST` checked above; `output_buf.ptr` is
+            // the JSC-owned writable backing store. The input borrow has ended,
+            // so this write cannot alias a live shared reference even when the
+            // buffers overlap. Build the `&mut` directly from the raw `*mut u8`
+            // field — never via `&[u8].as_ptr()`.
+            let output = unsafe { core::slice::from_raw_parts_mut(output_buf.ptr, H::DIGEST) };
+            output.copy_from_slice(output_digest_buf.as_ref());
             Ok(output_buf.value)
         } else {
-            ArrayBuffer::create_uint8_array(global, output_digest_slice.as_ref())
+            ArrayBuffer::create_uint8_array(global, output_digest_buf.as_ref())
         }
     }
 

--- a/test/js/bun/util/bun-cryptohasher.test.ts
+++ b/test/js/bun/util/bun-cryptohasher.test.ts
@@ -249,3 +249,55 @@ describe("CryptoHasher", () => {
     });
   }
 });
+
+describe("one-shot hash with overlapping input/output buffers", () => {
+  // Safe JS can pass views over the same backing store as both the hash input
+  // and the output buffer. The digest written into the output must match a run
+  // over a non-overlapping copy of the input. `expected` is computed from a
+  // copy taken before the overlapping call, since that call mutates the store.
+  test("Bun.SHA256.hash supports exact input/output overlap", () => {
+    const buf = new Uint8Array(64).fill(0x61);
+    const expected = Bun.SHA256.hash(new Uint8Array(buf), "hex");
+
+    const result = Bun.SHA256.hash(buf, buf);
+
+    expect(result).toBe(buf);
+    expect(Buffer.from(buf.subarray(0, 32)).toString("hex")).toBe(expected);
+  });
+
+  test("Bun.SHA256.hash supports shifted input/output overlap", () => {
+    const backing = new ArrayBuffer(96);
+    const input = new Uint8Array(backing, 16, 64);
+    input.fill(0x61);
+    const expected = Bun.SHA256.hash(new Uint8Array(input), "hex");
+    const output = new Uint8Array(backing, 17, 32);
+
+    const result = Bun.SHA256.hash(input, output);
+
+    expect(result).toBe(output);
+    expect(Buffer.from(output).toString("hex")).toBe(expected);
+  });
+
+  test("Bun.CryptoHasher.hash supports exact input/output overlap", () => {
+    const buf = new Uint8Array(64).fill(0x61);
+    const expected = Bun.CryptoHasher.hash("sha256", new Uint8Array(buf), "hex");
+
+    const result = Bun.CryptoHasher.hash("sha256", buf, buf);
+
+    expect(result).toBe(buf);
+    expect(Buffer.from(buf.subarray(0, 32)).toString("hex")).toBe(expected);
+  });
+
+  test("Bun.CryptoHasher.hash supports shifted input/output overlap", () => {
+    const backing = new ArrayBuffer(96);
+    const input = new Uint8Array(backing, 16, 64);
+    input.fill(0x61);
+    const expected = Bun.CryptoHasher.hash("sha256", new Uint8Array(input), "hex");
+    const output = new Uint8Array(backing, 17, 32);
+
+    const result = Bun.CryptoHasher.hash("sha256", input, output);
+
+    expect(result).toBe(output);
+    expect(Buffer.from(output).toString("hex")).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

The one-shot crypto hash APIs accept a caller-provided output buffer. Safe JS can pass views over the same `ArrayBuffer` as both the hash input and the output.

The Rust implementation built a `&mut [u8]` into the caller's output buffer and passed it alongside the `&[u8]` input slice to the hash function. When those buffers overlap, a shared and a mutable reference are live over the same bytes. The `&mut` carries `noalias`, making this undefined behavior under Rust's aliasing rules.

This hashes into a local digest buffer first, then copies into the caller's output buffer after the input borrow has ended. No JS-visible behavior change: overlapping input and output is still accepted and returns the correct digest.

Changes:
- EVP path (`CryptoHasher::hash_to_bytes`): hash into local storage, copy into caller output after input borrow ends
- Static path (`StaticCryptoHasher::<H>::hash_to_bytes`): same
- Validate output buffer length up front instead of via a long-lived mutable reference
- Regression coverage for exact and shifted input/output overlap

## Test approach

The regression keeps overlap supported. Expected digest is computed from a copy taken before the overlapping call, then checked against the result.

## Verification

- [x] cargo fmt --all --check
- [x] git diff --check
- [x] bun bd -e "console.log('ok')"
- [x] bun bd test test/js/bun/util/bun-cryptohasher.test.ts (401 pass, 0 fail)
- [x] bun bd test test/js/node/crypto/crypto-oneshot.test.ts (34 pass, 0 fail)
- [x] bun bd test test/js/node/crypto/crypto.test.ts (369 pass, 0 fail)

## Review map

- `CryptoHasher.rs`: both one-shot hash paths hash into a local digest and copy into the caller output after the input borrow ends
- `bun-cryptohasher.test.ts`: exact and shifted input/output overlap for static (`Bun.SHA256.hash`) and dynamic (`Bun.CryptoHasher.hash`) paths
