### PR TITLE
node:zlib: avoid aliasing compression input/output buffers

### DIFF
--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -199,10 +199,58 @@ pub(crate) fn crc32(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsRe
 // Each `Native{Zlib,Brotli,Zstd}` implements this
 // trait to expose its fields + per-class codegen accessors.
 
+/// Raw input/output spans handed to the native compressors. Built from a JS
+/// `ArrayBuffer`'s `ptr + offset` after bounds checks, deliberately *not* as
+/// `&[u8]` / `&mut [u8]`: safe JS (via `_processChunk` + `_outBuffer`) can pass
+/// views over the same backing store as both input and output, and a live
+/// shared + mutable reference pair over overlapping bytes is undefined behavior.
+///
+/// These are short-lived handoff values, consumed immediately by `set_buffers`,
+/// which copies the pointer/length into the native compressor's own buffer
+/// struct. They carry no borrow and intentionally stay `!Send` / `!Sync`: buffer
+/// lifetime is provided by the existing model — pinning for async, call-stack
+/// rooting for sync — so the spans must not be stored or treated as transferable
+/// ownership handles.
+#[derive(Clone, Copy)]
+pub(crate) struct InputSpan {
+    ptr: *const u8,
+    len: usize,
+}
+
+impl InputSpan {
+    #[inline]
+    pub(crate) fn ptr(self) -> *const u8 {
+        self.ptr
+    }
+
+    #[inline]
+    pub(crate) fn len(self) -> usize {
+        self.len
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct OutputSpan {
+    ptr: *mut u8,
+    len: usize,
+}
+
+impl OutputSpan {
+    #[inline]
+    pub(crate) fn ptr(self) -> *mut u8 {
+        self.ptr
+    }
+
+    #[inline]
+    pub(crate) fn len(self) -> usize {
+        self.len
+    }
+}
+
 /// Backing-stream surface used by [`CompressionStream`] (zlib / brotli / zstd
 /// `Context` types).
 pub(crate) trait CompressionContext {
-    fn set_buffers(&mut self, in_: Option<&[u8]>, out: Option<&mut [u8]>);
+    fn set_buffers(&mut self, in_: Option<InputSpan>, out: Option<OutputSpan>);
     fn set_flush(&mut self, flush: i32);
     fn do_work(&mut self);
     fn reset(&mut self) -> Error;
@@ -404,24 +452,34 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         // FastTypedArray's backing store can fail on OOM, and failing here
         // leaves nothing to unwind.
         let in_buf: jsc::ArrayBuffer;
-        let in_: Option<&[u8]> = if arguments[1].is_null() {
+        let in_: Option<InputSpan> = if arguments[1].is_null() {
             None
         } else {
             let Some(buf) = arguments[1].as_pinned_arraybuffer(global_this) else {
                 return Err(global_this.throw_out_of_memory());
             };
             in_buf = buf;
-            Some(&in_buf.byte_slice()[in_off as usize..in_off as usize + in_len as usize])
+            // Bounds checked above. Build a raw span from `ptr + offset` rather
+            // than a `&[u8]`: input and output may alias the same backing store,
+            // and a live `&[u8]`/`&mut [u8]` pair over overlapping bytes is UB.
+            // The buffer stays alive via the pin + pending-input cache below.
+            Some(InputSpan {
+                ptr: in_buf.ptr.wrapping_add(in_off as usize).cast_const(),
+                len: in_len as usize,
+            })
         };
-        let Some(mut out_buf) = arguments[4].as_pinned_arraybuffer(global_this) else {
+        let Some(out_buf) = arguments[4].as_pinned_arraybuffer(global_this) else {
             if !arguments[1].is_null() {
                 arguments[1].unpin_array_buffer();
             }
             return Err(global_this.throw_out_of_memory());
         };
-        let out: Option<&mut [u8]> = Some(
-            &mut out_buf.byte_slice_mut()[out_off as usize..out_off as usize + out_len as usize],
-        );
+        // Bounds checked above; raw span (not `&mut [u8]`) for the same overlap
+        // reason. Kept alive via the pin + pending-output cache below.
+        let out: Option<OutputSpan> = Some(OutputSpan {
+            ptr: out_buf.ptr.wrapping_add(out_off as usize),
+            len: out_len as usize,
+        });
 
         this.write_in_progress().set(true);
         this.ref_();
@@ -589,7 +647,7 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
 
         let in_off: u32;
         let in_len: u32;
-        let in_: Option<&[u8]>;
+        let in_: Option<InputSpan>;
 
         if arguments[0].is_undefined() {
             return Err(global_this
@@ -642,12 +700,17 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
                     )
                     .throw());
             }
-            // Bounds checked above; `byte_slice` is the safe accessor for the JS
-            // ArrayBuffer's backing store (rooted via `arguments[1]` on the call stack).
-            in_ = Some(&in_buf.byte_slice()[in_off as usize..in_off as usize + in_len as usize]);
+            // Bounds checked above. Build a raw span from `ptr + offset` rather
+            // than a `&[u8]`: input and output may alias the same backing store,
+            // and a live `&[u8]`/`&mut [u8]` pair over overlapping bytes is UB.
+            // The buffer is rooted via `arguments[1]` on the call stack.
+            in_ = Some(InputSpan {
+                ptr: in_buf.ptr.wrapping_add(in_off as usize).cast_const(),
+                len: in_len as usize,
+            });
         }
 
-        let Some(mut out_buf) = arguments[4].as_array_buffer(global_this) else {
+        let Some(out_buf) = arguments[4].as_array_buffer(global_this) else {
             return Err(global_this
                 .err(
                     ErrorCode::INVALID_ARG_TYPE,
@@ -669,11 +732,12 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
                 )
                 .throw());
         }
-        // Bounds checked above; `byte_slice_mut` is the safe accessor for the JS
-        // ArrayBuffer's backing store (rooted via `arguments[4]` on the call stack).
-        let out: Option<&mut [u8]> = Some(
-            &mut out_buf.byte_slice_mut()[out_off as usize..out_off as usize + out_len as usize],
-        );
+        // Bounds checked above; raw span (not `&mut [u8]`) for the same overlap
+        // reason. The buffer is rooted via `arguments[4]` on the call stack.
+        let out: Option<OutputSpan> = Some(OutputSpan {
+            ptr: out_buf.ptr.wrapping_add(out_off as usize),
+            len: out_len as usize,
+        });
         let _ = (in_off, in_len, out_off, out_len);
 
         if this.write_in_progress().get() {
@@ -993,7 +1057,7 @@ macro_rules! __impl_compression_stream {
         }
 
         impl $crate::node::node_zlib_binding::CompressionContext for $ctx {
-            #[inline] fn set_buffers(&mut self, in_: Option<&[u8]>, out: Option<&mut [u8]>) { Self::set_buffers(self, in_, out) }
+            #[inline] fn set_buffers(&mut self, in_: Option<$crate::node::node_zlib_binding::InputSpan>, out: Option<$crate::node::node_zlib_binding::OutputSpan>) { Self::set_buffers(self, in_, out) }
             #[inline] fn set_flush(&mut self, flush: i32) { Self::set_flush(self, flush) }
             #[inline] fn do_work(&mut self) { Self::do_work(self) }
             #[inline] fn reset(&mut self) -> $crate::node::node_zlib_binding::Error { Self::reset(self) }

--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -57,7 +57,9 @@ mod _impl {
         StrongOptional, WorkPoolTask,
     };
 
-    use crate::node::node_zlib_binding::{CompressionStream, CountedKeepAlive, Error};
+    use crate::node::node_zlib_binding::{
+        CompressionStream, CountedKeepAlive, Error, InputSpan, OutputSpan,
+    };
     use crate::node::util::validators;
 
     // Intrusive refcount: the handle type is `bun_ptr::IntrusiveRc<NativeBrotli>`; the
@@ -398,14 +400,13 @@ mod _impl {
             self.state = None;
         }
 
-        pub fn set_buffers(&mut self, in_: Option<&[u8]>, out: Option<&mut [u8]>) {
-            self.next_in = in_.map_or(ptr::null(), |p| p.as_ptr());
-            self.avail_in = in_.map_or(0, |p| p.len());
-            // Reshaped for borrowck — compute ptr/len before consuming `out`.
+        pub(crate) fn set_buffers(&mut self, in_: Option<InputSpan>, out: Option<OutputSpan>) {
+            self.next_in = in_.map_or(ptr::null(), |s| s.ptr());
+            self.avail_in = in_.map_or(0, |s| s.len());
             match out {
-                Some(p) => {
-                    self.avail_out = p.len();
-                    self.next_out = p.as_mut_ptr();
+                Some(s) => {
+                    self.avail_out = s.len();
+                    self.next_out = s.ptr();
                 }
                 None => {
                     self.avail_out = 0;

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -3,7 +3,7 @@ use core::mem;
 
 use bun_zlib as c; // bun.zlib — C zlib FFI (NodeMode, z_stream, ReturnCode, FlushValue, deflate*, inflate*)
 
-use crate::node::node_zlib_binding::Error;
+use crate::node::node_zlib_binding::{Error, InputSpan, OutputSpan};
 
 // ─── gated: JsClass payload + host fns ────────────────────────────────────
 // `NativeZlib` carries `#[bun_jsc::JsClass]` and its methods are
@@ -430,21 +430,21 @@ impl Context {
         self.set_dictionary()
     }
 
-    pub fn set_buffers(&mut self, in_: Option<&[u8]>, out: Option<&mut [u8]>) {
+    pub(crate) fn set_buffers(&mut self, in_: Option<InputSpan>, out: Option<OutputSpan>) {
         self.state.avail_in = match &in_ {
-            Some(p) => u32::try_from(p.len()).expect("int cast"),
+            Some(s) => u32::try_from(s.len()).expect("int cast"),
             None => 0,
         };
         self.state.next_in = match in_ {
-            Some(p) => p.as_ptr(),
+            Some(s) => s.ptr(),
             None => core::ptr::null(),
         };
         self.state.avail_out = match &out {
-            Some(p) => u32::try_from(p.len()).expect("int cast"),
+            Some(s) => u32::try_from(s.len()).expect("int cast"),
             None => 0,
         };
         self.state.next_out = match out {
-            Some(p) => p.as_mut_ptr(),
+            Some(s) => s.ptr(),
             None => core::ptr::null_mut(),
         };
     }

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -11,7 +11,9 @@ mod _impl {
     };
     use bun_zstd::c; // `bun.c` translated-c-headers (ZSTD_* fns/consts live here)
 
-    use crate::node::node_zlib_binding::{CompressionStream, CountedKeepAlive, Error};
+    use crate::node::node_zlib_binding::{
+        CompressionStream, CountedKeepAlive, Error, InputSpan, OutputSpan,
+    };
     use crate::node::util::validators;
     // #[repr(u8)] enum shared by all native-zlib stream types.
     use bun_zlib::NodeMode;
@@ -398,14 +400,14 @@ mod _impl {
             self.state = None;
         }
 
-        pub fn set_buffers(&mut self, in_: Option<&[u8]>, out: Option<&mut [u8]>) {
-            self.input.src = in_.map_or(ptr::null(), |p| p.as_ptr().cast());
-            self.input.size = in_.map_or(0, |p| p.len());
+        pub(crate) fn set_buffers(&mut self, in_: Option<InputSpan>, out: Option<OutputSpan>) {
+            self.input.src = in_.map_or(ptr::null(), |s| s.ptr().cast());
+            self.input.size = in_.map_or(0, |s| s.len());
             self.input.pos = 0;
             match out {
-                Some(p) => {
-                    self.output.size = p.len();
-                    self.output.dst = p.as_mut_ptr().cast();
+                Some(s) => {
+                    self.output.size = s.len();
+                    self.output.dst = s.ptr().cast();
                 }
                 None => {
                     self.output.size = 0;

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -736,3 +736,79 @@ describe("dictionary buffer lifetime", () => {
     expect(Buffer.concat(chunks).toString()).toBe(input.toString());
   });
 });
+
+describe("one-shot _processChunk with overlapping input/output", () => {
+  // Safe JS can point `_processChunk`'s input at the same backing store as the
+  // handle's `_outBuffer` (both are ordinary Buffers). Bun, like Node, accepts
+  // this and must keep accepting it. The native binding hands the compressor
+  // raw pointer/length spans rather than forming overlapping `&[u8]`/`&mut [u8]`
+  // references, so observable behavior is unchanged. These lock that the normal
+  // separate-buffer path stays correct and the overlap path is still accepted,
+  // across all three native compressors (zlib, Brotli, Zstd).
+  function makeSeed() {
+    const seed = Buffer.alloc(1024);
+    for (let i = 0; i < seed.length; i++) seed[i] = (i * 31 + 7) & 255;
+    return seed;
+  }
+
+  const codecs = [
+    ["zstd", () => zlib.createZstdCompress({ chunkSize: 8192 }), zlib.constants.ZSTD_e_end, zlib.zstdDecompressSync],
+    [
+      "brotli",
+      () => zlib.createBrotliCompress({ chunkSize: 8192 }),
+      zlib.constants.BROTLI_OPERATION_FINISH,
+      zlib.brotliDecompressSync,
+    ],
+    ["deflate", () => zlib.createDeflate({ chunkSize: 8192 }), zlib.constants.Z_FINISH, zlib.inflateSync],
+  ];
+
+  describe.each(codecs)("%s", (_name, create, endFlush, decompress) => {
+    it("separate input/output round-trips", () => {
+      const seed = makeSeed();
+      const s = create();
+      const out = Buffer.alloc(8192);
+      s._outBuffer = out;
+      s._outOffset = 0;
+      s._chunkSize = out.length;
+      const compressed = s._processChunk(Buffer.from(seed), endFlush);
+      expect(decompress(compressed)).toEqual(seed);
+    });
+
+    it.each([0, 1])("accepts input and output aliasing the same backing store at offset %d", offset => {
+      const seed = makeSeed();
+      const backing = Buffer.alloc(8192);
+      seed.copy(backing, offset);
+      const s = create();
+      s._outBuffer = backing;
+      s._outOffset = 0;
+      s._chunkSize = backing.length;
+      const out = s._processChunk(backing.subarray(offset, offset + seed.length), endFlush);
+      expect(Buffer.isBuffer(out)).toBe(true);
+      expect(out.length).toBeGreaterThan(0);
+    });
+  });
+
+  // The async worker path (`handle.write` → `CompressionStream::write`) builds
+  // its span the same way as the sync path; passing a callback to `_processChunk`
+  // routes through it. Exercise it once with overlapping input/output.
+  it("accepts input and output aliasing through the async write path", async () => {
+    const seed = makeSeed();
+    const backing = Buffer.alloc(8192);
+    seed.copy(backing, 0);
+    const s = zlib.createDeflate({ chunkSize: 8192 });
+    s._outBuffer = backing;
+    s._outOffset = 0;
+    s._chunkSize = backing.length;
+
+    const chunks = [];
+    s.on("data", chunk => chunks.push(chunk));
+    const { promise, resolve, reject } = Promise.withResolvers();
+    s.on("error", reject);
+    s._processChunk(backing.subarray(0, seed.length), zlib.constants.Z_FINISH, resolve);
+    await promise;
+
+    const out = Buffer.concat(chunks);
+    expect(Buffer.isBuffer(out)).toBe(true);
+    expect(out.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

The native `node:zlib` write paths build a `&[u8]` over the input buffer and a `&mut [u8]` over the output buffer before passing both to the compression context. Safe JS can make those views overlap the same backing store through the `_processChunk` + `_outBuffer` path. A shared and a mutable reference live over the same bytes is undefined behavior under Rust's aliasing rules.

This changes `CompressionContext::set_buffers` to take raw pointer/length spans instead of Rust references. The native compressors receive the same pointer and length values as before. No observable behavior change: overlapping input/output remains accepted, byte-for-byte identical before and after.

Changes:
- `set_buffers` takes `Option<InputSpan>` / `Option<OutputSpan>` (raw `ptr` + `len`) instead of `Option<&[u8]>` / `Option<&mut [u8]>`
- sync and async write paths build spans from `ptr + offset` after bounds validation, without forming references for the IO pair
- the three native contexts (zlib, Brotli, Zstd) consume the spans
- regression coverage for overlapping and separate-buffer paths across all three

## Test approach

For each of zlib, Brotli, and Zstd: the separate-buffer path round-trips, and exact and shifted input/output overlap is accepted without throwing.

## Verification

- [x] cargo fmt --all --check
- [x] git diff --check
- [x] bun bd -e "console.log('ok')"
- [x] bun bd test test/js/node/zlib/zlib.test.js -t "overlapping input/output"
- [x] Behavior preserved: overlap output byte-identical before and after across zlib/Brotli/Zstd

## Coverage note

A full `zlib.test.js` debug run has two pre-existing async streaming-timeout failures (Brotli/Zstd "streaming encode doesn't wait for entire input"). They reproduce on the unpatched binary and are unrelated to this change.

## Review map

- `node_zlib_binding.rs`: `InputSpan` / `OutputSpan`; `set_buffers` contract; sync + async sites build spans from `ptr + offset` after bounds checks
- `NativeZlib.rs`, `NativeBrotli.rs`, `NativeZstd.rs`: consume raw spans
- `zlib.test.js`: overlap acceptance + separate-buffer round-trip for all three engines
