### PR TITLE
bun: snapshot shared buffers before scanning and hashing

### DIFF
--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -44,6 +44,31 @@ impl Default for ArrayBuffer {
     }
 }
 
+/// A scan/hash-stable view of an [`ArrayBuffer`]'s bytes, produced by
+/// [`ArrayBuffer::stable_bytes`].
+///
+/// Ordinary fixed, unshared buffers are borrowed zero-copy. Shared (or growable
+/// shared) and resizable buffers are snapshotted into a fresh non-shared buffer,
+/// because another JS agent can mutate (or the owner can resize) the backing
+/// store while Rust holds a `&[u8]` — a data race / aliasing violation that
+/// corrupts SIMD scanners and hashers. The snapshot variant keeps the copy's JS
+/// value alive for the duration of the borrow.
+pub enum StableBytes {
+    /// Direct borrow of the original buffer's backing store (safe to scan).
+    Borrowed(ArrayBuffer),
+    /// A fresh non-shared copy of a shared/resizable buffer.
+    Snapshot(ArrayBuffer),
+}
+
+impl StableBytes {
+    #[inline]
+    pub fn as_slice(&self) -> &[u8] {
+        match self {
+            StableBytes::Borrowed(ab) | StableBytes::Snapshot(ab) => ab.byte_slice(),
+        }
+    }
+}
+
 // Aliasing: `JSGlobalObject` is an opaque ZST handle on the Rust side — the
 // `&JSGlobalObject` reference covers zero bytes, and all mutation happens inside
 // C++ on memory Rust never observes. Declaring the FFI parameter as
@@ -586,6 +611,35 @@ impl ArrayBuffer {
         // SAFETY: ptr is non-null (checked above) and backed by JSC ArrayBuffer of byte_len bytes.
         // `&mut self` enforces exclusive access to this view.
         unsafe { core::slice::from_raw_parts_mut(self.ptr, self.byte_len) }
+    }
+
+    /// Returns a scan/hash-stable view of the bytes (see [`StableBytes`]).
+    ///
+    /// Fixed, unshared buffers are borrowed zero-copy. `SharedArrayBuffer`,
+    /// growable `SharedArrayBuffer`, and resizable `ArrayBuffer` inputs are
+    /// snapshotted into a fresh non-shared buffer first: another agent can write
+    /// the bytes (or the owner can resize) while Rust holds the `&[u8]`, which is
+    /// undefined behavior. The snapshot's copy runs inside C++
+    /// (`Bun__createArrayBufferForCopy`), so Rust never reads concurrently-mutable
+    /// JS memory through an ordinary slice. The backing store cannot move or be
+    /// freed during this synchronous call (shared buffers reserve their max and
+    /// grow in place; non-shared resizable buffers can only be resized by the same
+    /// agent), so the captured `byte_len` copy cannot over-read.
+    pub fn stable_bytes(&self, global: &JSGlobalObject) -> JsResult<StableBytes> {
+        if !self.is_detached() && (self.shared || self.resizable) {
+            let copy = crate::host_fn::from_js_host_call(global, || unsafe {
+                Bun__createArrayBufferForCopy(global, self.ptr.cast(), self.byte_len)
+            })?;
+            if let Some(copy_ab) = copy.as_array_buffer(global) {
+                return Ok(StableBytes::Snapshot(copy_ab));
+            }
+            // A snapshot was required but none was produced — never fall back to
+            // borrowing the original shared/resizable backing store.
+            return Err(global.throw(format_args!(
+                "Failed to snapshot shared/resizable ArrayBuffer"
+            )));
+        }
+        Ok(StableBytes::Borrowed(*self))
     }
 
     /// The equivalent of

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1510,9 +1510,11 @@ pub(crate) fn index_of_line(
         return Ok(JSValue::js_number_from_int32(-1));
     }
 
-    let Some(buffer) = arguments[0].as_array_buffer(global_this) else {
+    // Preserve the existing ordering: a non-buffer first argument returns -1
+    // before the offset is coerced.
+    if arguments[0].as_array_buffer(global_this).is_none() {
         return Ok(JSValue::js_number_from_int32(-1));
-    };
+    }
 
     let mut offset: usize = 0;
     if arguments.len() > 1 {
@@ -1520,7 +1522,16 @@ pub(crate) fn index_of_line(
         offset = offset_value.max(0) as usize;
     }
 
-    let bytes = buffer.byte_slice();
+    // Re-read after offset coercion: coercion can run JS and detach/resize arg0,
+    // leaving a buffer descriptor captured before coercion stale.
+    let Some(buffer) = arguments[0].as_array_buffer(global_this) else {
+        return Ok(JSValue::js_number_from_int32(-1));
+    };
+
+    // Snapshot SharedArrayBuffer / resizable inputs before scanning — a worker
+    // can mutate shared bytes underneath the SIMD newline scanner otherwise.
+    let stable = buffer.stable_bytes(global_this)?;
+    let bytes = stable.as_slice();
     let mut current_offset = offset;
     let end = bytes.len() as u32;
 

--- a/src/runtime/api/HashObject.rs
+++ b/src/runtime/api/HashObject.rs
@@ -268,8 +268,9 @@ fn hash_wrap<H: HashAlgorithm>(global: &JSGlobalObject, frame: &CallFrame) -> Js
 
     let mut input: &[u8] = b"";
     let input_slice: ZigStringSlice;
-    // Hoisted so `array_buffer` outlives the borrow stored in `input`.
-    let array_buffer;
+    // Hoisted to outlive the borrow stored in `input`: snapshots a shared /
+    // resizable buffer, or borrows an ordinary one (see `ArrayBuffer::stable_bytes`).
+    let stable_bytes;
     if let Some(arg) = args.next_eat() {
         if let Some(blob) = arg.as_class_ref::<Blob>() {
             // TODO: files
@@ -290,7 +291,7 @@ fn hash_wrap<H: HashAlgorithm>(global: &JSGlobalObject, frame: &CallFrame) -> Js
                 | jsc::JSType::BigInt64Array
                 | jsc::JSType::BigUint64Array
                 | jsc::JSType::DataView => {
-                    array_buffer = match arg.as_array_buffer(global) {
+                    let array_buffer = match arg.as_array_buffer(global) {
                         Some(ab) => ab,
                         None => {
                             return Err(global.throw_invalid_arguments(format_args!(
@@ -298,7 +299,8 @@ fn hash_wrap<H: HashAlgorithm>(global: &JSGlobalObject, frame: &CallFrame) -> Js
                             )));
                         }
                     };
-                    input = array_buffer.byte_slice();
+                    stable_bytes = array_buffer.stable_bytes(global)?;
+                    input = stable_bytes.as_slice();
                 }
                 _ => {
                     input_slice = arg.to_slice(global)?;

--- a/test/js/bun/util/hash.test.js
+++ b/test/js/bun/util/hash.test.js
@@ -7,6 +7,16 @@ it(`Bun.hash()`, () => {
   expect(Bun.hash("hello world")).toBe(0x668d5e431c3b2573n);
   expect(Bun.hash(new TextEncoder().encode("hello world"))).toBe(0x668d5e431c3b2573n);
 });
+it("Bun.hash accepts SharedArrayBuffer input", () => {
+  // SharedArrayBuffer (and views over it) are snapshotted, not borrowed, before
+  // hashing. Stable shared input must hash identically to the owned-bytes vector.
+  const sab = new SharedArrayBuffer(11);
+  new Uint8Array(sab).set(new TextEncoder().encode("hello world"));
+  expect(Bun.hash(sab)).toBe(0x668d5e431c3b2573n);
+  expect(Bun.hash(new Uint8Array(sab))).toBe(0x668d5e431c3b2573n);
+  expect(Bun.hash.wyhash(new Uint8Array(sab))).toBe(0x668d5e431c3b2573n);
+  expect(Bun.hash.crc32(new Uint8Array(sab))).toBe(0x0d4a1185);
+});
 it(`Bun.hash.wyhash()`, () => {
   expect(Bun.hash.wyhash("hello world")).toBe(0x668d5e431c3b2573n);
   gcTick();

--- a/test/js/bun/util/index-of-line.test.ts
+++ b/test/js/bun/util/index-of-line.test.ts
@@ -1,5 +1,6 @@
 import { indexOfLine } from "bun";
 import { expect, test } from "bun:test";
+import { Worker } from "node:worker_threads";
 
 test("indexOfLine handles non-number offset", () => {
   // Regression test: passing a non-number offset should not crash
@@ -50,4 +51,93 @@ test("indexOfLine", () => {
     expect(i++ - delta).toBe(j++);
     nonEmptyLineCount++;
   }
+});
+
+test("indexOfLine returns the newline index for a SharedArrayBuffer view", () => {
+  const bytes = new Uint8Array(new SharedArrayBuffer(32));
+  bytes.fill(0x41);
+  bytes[10] = 0x0a;
+  expect(indexOfLine(bytes, 0)).toBe(10);
+});
+
+test("indexOfLine re-reads the buffer after offset coercion detaches it", () => {
+  const ab = new ArrayBuffer(32);
+  const bytes = new Uint8Array(ab);
+  bytes[0] = 0x0a;
+
+  // Coercing the offset runs JS that detaches the first argument. indexOfLine
+  // must re-read the buffer after coercion instead of scanning the freed store.
+  const offset = {
+    valueOf() {
+      structuredClone(ab, { transfer: [ab] });
+      return 0;
+    },
+  };
+
+  expect(indexOfLine(bytes, offset as any)).toBe(-1);
+});
+
+const supportsGrowableSharedArrayBuffer = (() => {
+  try {
+    return new SharedArrayBuffer(32, { maxByteLength: 64 }).growable === true;
+  } catch {
+    return false;
+  }
+})();
+
+test.skipIf(!supportsGrowableSharedArrayBuffer)("indexOfLine accepts a growable SharedArrayBuffer", () => {
+  const gsab = new SharedArrayBuffer(32, { maxByteLength: 64 });
+  const bytes = new Uint8Array(gsab);
+  bytes[7] = 0x0a;
+  expect(indexOfLine(bytes, 0)).toBe(7);
+});
+
+// indexOfLine must snapshot a SharedArrayBuffer before scanning, so a worker
+// mutating the same bytes can't race the SIMD newline scanner into a debug
+// crash. Before the fix this reliably SIGILLs.
+test("indexOfLine is safe while a worker concurrently mutates a SharedArrayBuffer", async () => {
+  const sab = new SharedArrayBuffer(64 * 1024);
+  const bytes = new Uint8Array(sab);
+  bytes.fill(0x41);
+  bytes[bytes.length - 1] = 0x0a;
+  // state[0]: 0 = wait, 1 = run, 2 = stop; state[1]: worker write counter
+  const state = new Int32Array(new SharedArrayBuffer(8));
+
+  const worker = new Worker(
+    `
+      const { workerData } = require("node:worker_threads");
+      const bytes = new Uint8Array(workerData.sab);
+      const state = new Int32Array(workerData.state);
+      while (Atomics.load(state, 0) === 0) Atomics.wait(state, 0, 0);
+      let prev = bytes.length - 1;
+      let i = 0;
+      while (Atomics.load(state, 0) === 1) {
+        bytes[prev] = 0x41;
+        prev = (i++ * 131) % bytes.length;
+        bytes[prev] = 0x0a;
+        Atomics.add(state, 1, 1);
+      }
+    `,
+    { eval: true, workerData: { sab, state: state.buffer } },
+  );
+
+  Atomics.store(state, 0, 1);
+  Atomics.notify(state, 0);
+  // Wait until the worker is actively mutating before scanning. Poll without
+  // blocking the test runner's main thread (the worker side still uses
+  // Atomics.wait to park until signalled).
+  while (Atomics.load(state, 1) < 50) {
+    await Bun.sleep(0);
+  }
+
+  const results: number[] = [];
+  for (let i = 0; i < 4000; i++) results.push(indexOfLine(bytes, 0));
+
+  Atomics.store(state, 0, 2);
+  await worker.terminate();
+
+  // Reaching here means the snapshot prevented the data-race crash; every
+  // result is a valid index, and the worker really did mutate concurrently.
+  expect(results.every(r => r >= -1 && r < bytes.length)).toBe(true);
+  expect(Atomics.load(state, 1)).toBeGreaterThan(50);
 });


### PR DESCRIPTION
## Summary

`Bun.indexOfLine` and `Bun.hash` accepted SharedArrayBuffer-backed inputs and read them through a `&[u8]` built with `slice::from_raw_parts`. Another JS agent can mutate that shared memory while Rust holds the slice — `from_raw_parts` requires the referenced bytes not be mutated for the slice's lifetime, so this is undefined behavior under Rust's aliasing rules.

This adds a stable byte boundary for scan/hash consumers: fixed unshared buffers stay zero-copy, while shared or resizable buffers are snapshotted into a fresh non-shared buffer before Rust scans or hashes them.

Changes:
- add `ArrayBuffer::stable_bytes` / `StableBytes` for JSC ArrayBuffer inputs
- route `Bun.indexOfLine` through stable bytes before SIMD scanning
- route `Bun.hash` through stable bytes before hashing
- add SharedArrayBuffer and worker-mutation regressions

## Test approach

The `indexOfLine` regression uses a worker that moves a newline through a SharedArrayBuffer while the main thread scans repeatedly. The unpatched debug build crashes in the scanner (SIGILL); the patched build exits cleanly.

## Verification

- [x] cargo fmt --all -- --check
- [x] git diff --check -- src/jsc/array_buffer.rs src/runtime/api/BunObject.rs src/runtime/api/HashObject.rs test/js/bun/util/index-of-line.test.ts test/js/bun/util/hash.test.js
- [x] bun bd test test/js/bun/util/index-of-line.test.ts test/js/bun/util/hash.test.js (27 pass, 0 fail)
- [x] Regression confirmed: unpatched debug build crashes (SIGILL) on the SharedArrayBuffer worker-mutation witness; patched build exits cleanly after 16M+ concurrent worker writes

## Review map

- `src/jsc/array_buffer.rs`: add `stable_bytes` — keep fixed unshared buffers zero-copy, snapshot shared/resizable buffers before Rust borrowing
- `src/runtime/api/BunObject.rs`: use stable bytes before `indexOfLine` scans
- `src/runtime/api/HashObject.rs`: use stable bytes before hashing ArrayBuffer-backed inputs
- `test/js/bun/util/index-of-line.test.ts`: cover SharedArrayBuffer, growable SharedArrayBuffer, and concurrent worker mutation
- `test/js/bun/util/hash.test.js`: cover SharedArrayBuffer-backed hash inputs
