### PR TITLE
Fix use-after-free in `bun run --parallel` workspace script spawning

### DIFF
--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use bun_collections::{StringArrayHashMap, VecExt};
 use bun_core::strings;
-use bun_core::{self as bun, Error, Global, Output, err};
+use bun_core::{self as bun, Error, Global, Output, UnwrapOrOom, err};
 use bun_event_loop::EventLoopHandle;
 use bun_event_loop::MiniEventLoop::MiniEventLoop;
 use bun_io::BufferedReader;
@@ -32,7 +32,12 @@ type OutputWriter = bun_core::io::Writer;
 
 /// Value type for package.json `scripts` map. Mirrors
 /// `bun_resolver::package_json::ScriptsMap` (`StringArrayHashMap<&'static [u8]>`).
+/// Its `&'static [u8]` values borrow the owning `PackageJSON.source_contents`.
 type ScriptsMap = StringArrayHashMap<&'static [u8]>;
+
+/// Owned variant of `ScriptsMap`: both keys and values are owned `Box<[u8]>`, so
+/// it can outlive the `PackageJSON` the bytes were parsed from (see `MatchedPackage`).
+type OwnedScriptsMap = StringArrayHashMap<Box<[u8]>>;
 
 struct ScriptConfig {
     label: Box<[u8]>,
@@ -638,11 +643,16 @@ struct GroupInfo {
 
 /// Add configs for a single script name (with pre/post handling).
 /// When `label_prefix` is non-null, labels become "{prefix}:{name}" (for workspace runs).
-fn add_script_configs(
+///
+/// Generic over the scripts map value type so both the single-package path
+/// (values borrow the process-lifetime DirInfo-cached package.json) and the
+/// workspace path (values are owned `Box<[u8]>` copies, see `MatchedPackage`)
+/// can share this code. The script bytes are only ever read here, never stored.
+fn add_script_configs<V: core::ops::Deref<Target = [u8]>>(
     configs: &mut Vec<ScriptConfig>,
     group_infos: &mut Vec<GroupInfo>,
     raw_name: &[u8],
-    scripts_map: Option<&ScriptsMap>,
+    scripts_map: Option<&StringArrayHashMap<V>>,
     cwd: &[u8],
     path: &[u8],
     label_prefix: Option<&[u8]>,
@@ -865,10 +875,18 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
         // Drop handles deinit
 
         // Phase 1: Collect matching packages (filesystem order is nondeterministic)
+        //
+        // `scripts` owns its bytes (`OwnedScriptsMap`): the `ScriptsMap` values
+        // parsed from each package.json borrow that package's `source_contents`,
+        // which is freed when the standalone `PackageJSON` drops at the end of
+        // each loop iteration below. Storing the borrowed map here would dangle
+        // (heap-use-after-free, #31636) — unlike the single-package path, whose
+        // package.json is kept alive by the process-lifetime DirInfo cache — so
+        // we deep-copy keys and values into owned storage before `pkgjson` drops.
         struct MatchedPackage {
             name: Box<[u8]>,
             dirpath: Box<[u8]>,
-            scripts: Box<ScriptsMap>,
+            scripts: OwnedScriptsMap,
             path: Box<[u8]>,
         }
         let mut matched_packages: Vec<MatchedPackage> = Vec::new();
@@ -897,9 +915,18 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
                 continue;
             }
 
-            let Some(pkg_scripts) = pkgjson.scripts else {
+            let Some(pkg_scripts) = &pkgjson.scripts else {
                 continue;
             };
+            // Deep-copy the scripts map while `pkgjson` (and the `source_contents`
+            // the borrowed `&'static [u8]` values point into) is still alive.
+            let mut owned_scripts = OwnedScriptsMap::with_capacity(pkg_scripts.count());
+            for (key, value) in pkg_scripts.iter() {
+                owned_scripts
+                    .put(&key[..], Box::<[u8]>::from(&value[..]))
+                    .unwrap_or_oom();
+            }
+
             let run_in_bun = ctx.debug.run_in_bun;
             let pkg_path_env = RunCommand::configure_path_for_run_with_package_json_dir(
                 ctx,
@@ -910,7 +937,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
                 run_in_bun,
             )?;
             let pkg_name: Box<[u8]> = if !pkgjson.name.is_empty() {
-                pkgjson.name
+                Box::<[u8]>::from(&pkgjson.name[..])
             } else {
                 // Fallback: use relative path from workspace root
                 Box::from(bun_paths::resolve_path::relative_platform::<
@@ -922,7 +949,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
             matched_packages.push(MatchedPackage {
                 name: pkg_name,
                 dirpath,
-                scripts: pkg_scripts,
+                scripts: owned_scripts,
                 path: pkg_path_env.into(),
             });
         }

--- a/test/regression/issue/31636.test.ts
+++ b/test/regression/issue/31636.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+
+// Regression test for https://github.com/oven-sh/bun/issues/31636
+//
+// `bun run --parallel` (with `--filter` or `--workspaces`) parsed a standalone
+// PackageJSON per workspace package and moved its `scripts` map into a
+// collected struct. The map's values borrow the package.json source bytes the
+// PackageJSON owns, so when that PackageJSON dropped at the end of each
+// collection-loop iteration, the bytes were freed while the scripts map still
+// pointed into them (heap-use-after-free). The freed bytes were later scanned
+// while building the shell command, producing a corrupted command: the reporter
+// saw `bash: line 1: $'\375\001': command not found` and exit 127, with the
+// garbage varying between runs.
+//
+// Under ASAN the use-after-free is deterministic; on release builds the freed
+// region is only sometimes reused before the read, which is why a tiny repro
+// "may succeed" while heavier monorepos fail consistently. Release CI lanes
+// skip this; the gate runs under `bun bd` which is debug+ASAN, so it's covered.
+
+// The workspace scripts run `bun <file>` — `bun` goes through
+// `replacePackageManagerRun` (which scans the freed script bytes) and the file
+// is a real entrypoint that prints a marker and exits, so we can assert the
+// children actually started with an uncorrupted command.
+function workspace() {
+  const dev = (marker: string) => ({
+    [`packages/${marker}/package.json`]: JSON.stringify({
+      name: marker,
+      scripts: { dev: "bun index.ts" },
+    }),
+    [`packages/${marker}/index.ts`]: `console.log(${JSON.stringify(marker + "-started")});`,
+  });
+  return tempDir("issue-31636", {
+    "package.json": JSON.stringify({
+      name: "monorepo-root",
+      private: true,
+      workspaces: ["packages/*"],
+    }),
+    ...dev("pdf-service"),
+    ...dev("app-website"),
+    ...dev("api"),
+  });
+}
+
+describe.skipIf(!isDebug)("issue 31636", () => {
+  test("bun run --parallel --filter spawns an uncorrupted workspace script", async () => {
+    using dir = workspace();
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--parallel", "--filter=pdf-service", "dev"],
+      env: { ...bunEnv, NO_COLOR: "1" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stderr).not.toContain("command not found");
+    expect(stderr).not.toContain("No such file or directory");
+    expect(stdout).toContain("pdf-service-started");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun run --parallel --workspaces spawns uncorrupted workspace scripts", async () => {
+    using dir = workspace();
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--parallel", "--workspaces", "--if-present", "dev"],
+      env: { ...bunEnv, NO_COLOR: "1" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stderr).not.toContain("command not found");
+    expect(stderr).not.toContain("No such file or directory");
+    expect(stdout).toContain("pdf-service-started");
+    expect(stdout).toContain("app-website-started");
+    expect(stdout).toContain("api-started");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/regression/issue/31636.test.ts
+++ b/test/regression/issue/31636.test.ts
@@ -53,11 +53,7 @@ describe.skipIf(!isDebug)("issue 31636", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).not.toContain("command not found");
     expect(stderr).not.toContain("No such file or directory");
@@ -75,11 +71,7 @@ describe.skipIf(!isDebug)("issue 31636", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).not.toContain("command not found");
     expect(stderr).not.toContain("No such file or directory");

--- a/test/regression/issue/31636.test.ts
+++ b/test/regression/issue/31636.test.ts
@@ -42,7 +42,7 @@ function workspace() {
   });
 }
 
-describe.skipIf(!isDebug)("issue 31636", () => {
+describe.concurrent.skipIf(!isDebug)("issue 31636", () => {
   test("bun run --parallel --filter spawns an uncorrupted workspace script", async () => {
     using dir = workspace();
 


### PR DESCRIPTION
Fixes #31636

### Repro

```sh
mkdir -p repro/packages/pdf-service && cd repro
echo '{ "name": "monorepo-root", "private": true, "workspaces": ["packages/*"] }' > package.json
echo '{ "name": "pdf-service", "scripts": { "dev": "bun --watch index.ts" } }' > packages/pdf-service/package.json
echo 'console.log("started"); setInterval(() => {}, 1000);' > packages/pdf-service/index.ts
bun install
bun run --parallel --filter=pdf-service dev
```

On `1.4.0-canary` this exits 127 with a corrupted shell command — the bytes
vary between runs (`bash: line 1: $'\375\001': command not found`, or
truncated `node_modules/.bin` PATH segments). Works on 1.3.14; non-parallel
`bun run dev` is unaffected.

### Cause

The garbage command is a **heap-use-after-free** (deterministic under ASAN,
intermittent garbage on release — hence the varying bytes and why a tiny repro
"may succeed").

`multi_run::run` (the `--parallel`/`--filter`/`--workspaces` path) collects
each matching workspace package's `scripts` map into a `MatchedPackage`. The
map is `StringArrayHashMap<&'static [u8]>`, and those `&'static [u8]` values
borrow the `PackageJSON.source_contents` the map was parsed from. The
standalone `PackageJSON` is a local that drops at the end of each
collection-loop iteration, freeing `source_contents` while the stored map
still points into it. A later phase reads those dangling bytes while building
the shell command via `replacePackageManagerRun`:

```
heap-use-after-free
  READ   src/install/lifecycle_script_runner.rs:153  (replace_package_manager_run)
  FREED  src/runtime/cli/multi_run.rs (PackageJSON drops at end of loop iteration)
  ALLOC  src/resolver/package_json.rs:1103            (source_contents)
```

In the original Zig, `PackageJSON` was kept alive for the process lifetime by
the DirInfo cache, so these borrows stayed valid; the Rust port made
`PackageJSON` a standalone owner, so the borrows dangle once it drops. The
single-package path is unaffected — its package.json comes from the (still
process-lifetime) DirInfo cache.

### Fix

Deep-copy the scripts map into an owned `StringArrayHashMap<Box<[u8]>>` while
the `PackageJSON` is still alive, so `MatchedPackage` no longer borrows freed
memory. `add_script_configs` is made generic over the map value type so the
single-package path keeps borrowing its process-lifetime map unchanged (same
codegen as before).

### Verification

- New regression test `test/regression/issue/31636.test.ts`: a workspace whose
  package scripts run `bun <file>` (so the `bun` rewrite scans the script bytes
  and the child actually starts), run via `--parallel --filter` and
  `--parallel --workspaces`, asserting the children print their marker and exit
  0 with no corrupted-command errors in stderr.
- Fails under `bun bd` (debug + ASAN) without the fix (UAF → child never
  starts), passes with it. Gated on debug builds; release CI lanes skip it, the
  ASAN gate lane catches it.
- `test/cli/run/multi-run.test.ts` workspace integration suite passes.