### PR TITLE
css: gate atan2() re-parses on the failure counter to fix exponential backtracking

### DIFF
--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -851,14 +851,46 @@ impl<V: CalcValue> Calc<V> {
             }
         }
 
-        if let Ok(v) = try_parse_atan2_args::<C, Length>(input, ctx) {
-            return Ok(v);
+        // The length/percentage/time parses below re-descend the entire
+        // argument subtree, which — because `atan2()` arguments may contain
+        // nested `atan2()`/`min()`/… — is exponential in the nesting depth if
+        // left unchecked. The `hit_unrecoverable` arms above cut the re-parses
+        // off when the `<angle>`/`<number>` attempt itself descended into a
+        // nested `<angle>`/`<number>`-only function that failed, but a
+        // reduction failure (e.g. a `min()` of unitless numbers that can't
+        // fold to an angle) fails *before* ever reaching a nested function, so
+        // the re-parses still run.
+        //
+        // Re-check the failure counter after each one. A nested
+        // `<angle>`/`<number>`-only function parses identically under every
+        // value type — its only type-dependence is `V::try_from_angle` on the
+        // result, which is `None` for all of Length/Percentage/Time/CSSNumber
+        // — so once one has failed during an attempt, every remaining attempt
+        // must fail at that same function. Skipping them bounds the work to
+        // one descent of the argument subtree per nesting level.
+        match try_parse_atan2_args::<C, Length>(input, ctx) {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                if hit_unrecoverable(input) {
+                    return Err(e);
+                }
+            }
         }
-        if let Ok(v) = try_parse_atan2_args::<C, Percentage>(input, ctx) {
-            return Ok(v);
+        match try_parse_atan2_args::<C, Percentage>(input, ctx) {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                if hit_unrecoverable(input) {
+                    return Err(e);
+                }
+            }
         }
-        if let Ok(v) = try_parse_atan2_args::<C, Time>(input, ctx) {
-            return Ok(v);
+        match try_parse_atan2_args::<C, Time>(input, ctx) {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                if hit_unrecoverable(input) {
+                    return Err(e);
+                }
+            }
         }
 
         let parse_ident_fn = move |c: C, ident: &[u8]| -> Option<Calc<CSSNumber>> {

--- a/test/js/bun/css/atan2-min-backtracking-hang.test.ts
+++ b/test/js/bun/css/atan2-min-backtracking-hang.test.ts
@@ -1,0 +1,148 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// A nesting shape that slipped past the `math_fn_parse_failures` tripwire from
+// the earlier atan2() backtracking fix (atan2-backtracking-hang.test.ts): each
+// atan2() argument is a *sum* whose leading term is a `min()`/product of
+// unitless numbers (which can't fold to an <angle>), so the <angle> parse
+// fails at that reduction — before it ever reaches the nested atan2() that
+// would bump the tripwire. The length/percentage/time re-parses then
+// re-descended the whole subtree, 4-5x per level. The fix re-checks the
+// tripwire counter between those re-parses, so the first one to descend into
+// the failing nested atan2() is also the last. (bun-fuzz)
+//
+// `leaf` is the innermost argument. A dimension leaf (e.g. `atan2(1px)`) must
+// stay linear too: it makes the innermost atan2() fail without any folding
+// shortcut, exercising the same one-descent-per-level bound.
+function minAtan2Chain(depth: number, leaf: string = "atan2(73709551615)"): string {
+  let inner = leaf;
+  for (let i = 0; i < depth; i++) {
+    inner = `atan2(73709551615 *min(9 *09,75 *09,75) + -18446744073709551615 + ${inner})`;
+  }
+  return `hsl(sin(sin(sin(${inner}))))`;
+}
+
+const cases: [css: string, expected: string | null][] = [
+  // min()/product-led argument sums nested through atan2() (bun-fuzz repro).
+  [minAtan2Chain(40), null],
+  [minAtan2Chain(80), null],
+  ["hsl(atan2(7 *min(9,75) + 1 + atan2(atan2(9))) 50% 50%)", null],
+  ["hsl(atan2(max(1,2,3), min(4,5,6)) 50% 50%)", null],
+  // Same chain with a dimension at the innermost leaf: a single `1px`/`1%`/`1s`
+  // buried inside the nested atan2() must not re-open the dimension re-parses
+  // at every enclosing level.
+  [minAtan2Chain(40, "atan2(1px)"), null],
+  [minAtan2Chain(80, "atan2(1px)"), null],
+  [minAtan2Chain(40, "atan2(1%)"), null],
+  [minAtan2Chain(40, "atan2(1s)"), null],
+  // behavior preservation for the min()/max() argument shapes: a dimension
+  // leaf is still reachable via the length re-parse.
+  ["hsl(atan2(min(1px,2px), 3px) 50% 50%)", "#bf6740"],
+  ["hsl(atan2(min(1,2), max(3,4)) 50% 50%)", null],
+  ["hsl(atan2(min(1deg,2deg), 3deg) 50% 50%)", "#bf6740"],
+  // dimensions buried inside nested type-dependent functions (calc/hypot)
+  // keep folding via the length re-parse.
+  ["hsl(atan2(calc(1px + 1px), calc(2px)) 50% 50%)", "#bf9f40"],
+  ["hsl(atan2(2px, calc(1px + 1px)) 50% 50%)", "#bf9f40"],
+  ["hsl(atan2(hypot(3px,4px), 5px) 50% 50%)", "#bf9f40"],
+  // clamp() reduces to a Calc::Function (a Min of the max/center args), not a
+  // Calc::Value, so atan2 can't reconcile it — pinned for behavior preservation.
+  ["hsl(atan2(clamp(1px, 2px, 3px), 4px) 50% 50%)", null],
+  // Unitless sums that can't fold to an <angle> still reach the Percentage
+  // retry (no nested angle/number-only function fails, so the counter never
+  // bumps), whose NaN fallback (`Percentage::from_calc` → NaN) resolves to an
+  // `Angle::Rad(NaN)` color — unchanged from before the fix.
+  ["hsl(atan2(min(1,2) + 3 + 4, min(5,6) + 7 + 8) 50% 50%)", "#bf4040"],
+];
+
+test.concurrent(
+  "min()-led nested atan2() color values parse in linear time instead of hanging",
+  async () => {
+    const script = `
+    const inputs = ${JSON.stringify(cases.map(([css]) => css))};
+    console.log(JSON.stringify(inputs.map(css => Bun.color(css, "css"))));
+  `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 20_000,
+      killSignal: "SIGKILL",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual(cases.map(([, expected]) => expected));
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);
+
+const fuzzerInputs: [name: string, blob: string][] = [
+  [
+    // 2,016 bytes of `hsl(sin(sin(sin(-Infinity + … atan2(… *min(9 *09,75 …`
+    // with int-boundary numbers; hung Tokenizer::next_impl for 25s+ before the fix.
+    "min()-led atan2 chain",
+    "H4sIAAAAAAACA8soztEozsyDY13PvLTMvMySSi5tLl1DCxMTM3MTEwNzY3MDS1NTQzND0wEUTyxJzDPSAIrRVjlcDAy0coGhYsmlZWCpY24KozTpYE5BfrnGYHPTqDkDac6oMaPGDH1jSDfHKi2zqLhENz9Nt6SyIBWHqYMvv0pRwxxNZKiEyiUGAgDmlnNY4AcAAA==",
+  ],
+  [
+    // 1,840-byte variant of the same class: the chain bottoms out in a
+    // `color(from atan2(…))` token (fails with no tripwire bump at the leaf)
+    // and several `min()`s are left unclosed so their last argument swallows
+    // the next nested atan2(). Exponential before the fix (~2x per level).
+    "min()-led atan2 chain ending in color(from …)",
+    "H4sIAAAAAAAAA8soztEozsyDY10jQxNzEwtjMxNLLm0uXUMLExMzcxMTA3NjcwNLU1NDM0PTARRPLEnMM9IwNzanrXK4GBho5WbmaVhyaRlY6pibwijNYWnOqEFEhdGQCb1Rq0fT/UAmSq2BKvKS83PyizTSivJzFSAmcHFhMVuTdAgAPqXrnDAHAAA=",
+  ],
+  [
+    // 2,273-byte variant: the chain bottoms out in `atan2(73709551615` with
+    // no comma before its closing paren, and the last `min()`'s final
+    // argument ends in a dangling `+`. Hung in Calc<Percentage>::parse_product
+    // before the fix (~7x per nesting level).
+    "min()-led atan2 chain ending in a dangling +",
+    "H4sIAAAAAAACA8soztEozsyDY13LUUAG4NLm0jW0MDExMzcxMTA3NjewNDU1NDM0HUDxxJLEPCMNoBhtlcPFwEArF5iGLLm0DCx1zE1hlOYgNWdEGUeZOfQyiBgLqOHIUTNGzSDXDFrkm8FlDMJbg6g81yQPAgAgY/8x4QgAAA==",
+  ],
+  [
+    // 2,150-byte variant: same chain shape as above at 24 nesting levels,
+    // with one extra leading `+ -18446744073709551615` sum term. Hung in
+    // Parser::next_including_whitespace_and_comments before the fix.
+    "min()-led atan2 chain with extra leading sum term",
+    "H4sIAAAAAAACA8soztEozsyDY13LUUAG4NLm0jW0MDExMzcxMTA3NjewNDU1NDM0paU4KZoTSxLzjDSAYrRVDhcDA61cYIKy5NIysNQxN4VRmkD1w9E4AoZSy3GDxxx6GUSMBdRw5KgZo2aQawZt880gKgw0yYMAuYa6bWYIAAA=",
+  ],
+  [
+    // 1,668-byte variant: 21-level chain with one doubly-nested `min()` (a
+    // `775 * min(...)` product as the last argument of an enclosing `min()`)
+    // and two surplus closing parentheses. Hung in Calc<Length>::parse_product
+    // before the fix.
+    "min()-led atan2 chain with a nested min() product",
+    "H4sIAAAAAAAAA8soztEozsyDY10jQxNzEwtjMxNLLm0uXUMLExMzcxMTA3NjcwNLU1NDM0PTARRPLEnMM9IAitFWOVwMDLRygeFiyaVlYKljbgqjNIelOaMG0degoeTWwW7QYHILPQ0aRMWKJnkQAD8DPxaEBgAA",
+  ],
+];
+
+test.concurrent.each(fuzzerInputs)(
+  "the exact fuzzer-minimized nested-math input parses instead of hanging: %s",
+  async (_name, blob) => {
+    const script = `
+    const input = Buffer.from(Bun.gunzipSync(Buffer.from(${JSON.stringify(blob)}, "base64"))).toString("latin1");
+    console.log(JSON.stringify(Bun.color(input, "rgba")));
+  `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 20_000,
+      killSignal: "SIGKILL",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toBeNull();
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);


### PR DESCRIPTION
## What

Fixes an exponential-time hang in `Bun.color()` (and any CSS `calc()` path) on deeply nested `atan2()` math functions whose arguments are sums led by a `min()`/product of unitless numbers. Found by fuzzing.

## Repro

```js
// 2,016 bytes of hsl(sin(sin(sin(-Infinity + … atan2(… *min(9 *09,75 … ; hangs 25s+
Bun.color(<deeply nested atan2/min CSS>, "rgba"); // → null, but after ~15s
```

Reduced, the pathology is a chain of `atan2()` nested through a sum whose leading term is a `min()` of unitless numbers:

```js
function chain(depth) {
  let inner = "atan2(73709551615)";
  for (let i = 0; i < depth; i++)
    inner = `atan2(73709551615 *min(9 *09,75 *09,75) + -18446744073709551615 + ${inner})`;
  return `hsl(sin(sin(sin(${inner}))))`;
}
Bun.color(chain(20), "rgba"); // ~13s; each +2 nesting ≈ 4× time
```

## Cause

`Calc::parse_atan2` (`src/css/values/calc.rs`) parses its arguments once as an `<angle>`/`<number>` expression, then retries under the `Length`, `Percentage`, and `Time` value types. Each retry re-descends the **entire** argument subtree, and because `atan2()` arguments can nest further `atan2()`/`min()` calls, this is exponential in the nesting depth.

This is the same class of bug as #31558, which added a `math_fn_parse_failures` counter: when a nested `<angle>`/`<number>`-only function (`sin`/`atan2`/`pow`/…) fails to parse, the dimension retries are skipped because they can't rescue it. But that check only runs after the **`<angle>` attempt**. When an argument is `N *min(9,75) + N + atan2(…)`, the `<angle>` parse fails at the `min()`-of-unitless-numbers **reduction** — *before* it ever reaches the nested `atan2()` that would bump the counter — so the retries all run, each re-descending the subtree, 4–5× per level.

## Fix — re-check the failure counter between the re-parses

Re-check `math_fn_parse_failures` after each of the Length/Percentage/Time attempts and stop on the first bump. No extra passes over the input, no new state — just counter comparisons at the existing decision points.

Why stopping is always correct: a nested `<angle>`/`<number>`-only function parses identically under every value type — its only type-dependence is `V::try_from_angle` on its *result*, which is `None` for all of `Length`/`Percentage`/`Time`/`CSSNumber` (only `Angle` converts). So once such a function has failed during one attempt, every remaining attempt must fail at that same function; skipping them changes nothing. This bounds the work to **one descent of the argument subtree per nesting level**: either the `<angle>` attempt descends into the failing nested function (counter bumps → existing #31558 arms return), or it fails early at a reduction and the `Length` attempt is the single descent (counter bumps → the new checks return).

## Verification

- Regression cases in `test/js/bun/css/atan2-min-backtracking-hang.test.ts` (its own file, alongside the sibling per-hang-shape files; `atan2-backtracking-hang.test.ts` is no longer touched): the `min()`-led nested chains (depth 40/80), the same chains with `1px`/`1%`/`1s` innermost leaves, `atan2(max(1,2,3), min(4,5,6))`, and every fuzzer-minimized report of this class found so far (five at the time of writing, each commented inline in the `fuzzerInputs` table — the original 2 KB chain plus variants bottoming out in `color(from atan2(…))`, a dangling `+`, an extra leading sum term, and a nested `min()` product), all in subprocesses with a 20s SIGKILL. They pass in <1s with the fix; with `src/css/values/calc.rs` reverted to `main` the subprocesses hang and the tests fail at the 20s kill (re-verified by swapping in main's calc.rs, rebuilding, re-running).
- The real fuzzer inputs: the 2 KB repro **>15s → ~10ms**; the second report's variant **hangs 20s+ on an unfixed debug build → ~7ms**. Depth-300 chains (20 KB) stay polynomial (~0.6s debug+ASAN, parser error-recovery unwind) instead of exponential; the bare nested chain from #31558 is unchanged (4ms at depth 64).
- Behavior: output is **identical to a rebuilt `main` across 105 probed `atan2()` cases** (every argument type; `calc()`/`min()`/`max()`/`abs()`/`sign()`/`sin()`/`pow()`/`hypot()`/`clamp()` args; mismatched-type rejections; relative-color channel args; unitless sums that resolve through the Percentage NaN fallback).
- `test/js/bun/css/css.test.ts` (1087 pass), `nested-function-backtracking.test.ts`, `angle-serialization-hang.test.ts`, `color.test.ts` (916 pass; the pre-existing `fuzz ansi256` debug-build timeout reproduces identically on `main`).

