### PR TITLE
bun: avoid stale sync compression input after option getters

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2398,8 +2398,8 @@ pub mod JSZlib {
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        let (buffer, options_val) = parse_compress_buffer_and_options(global_this, callframe)?;
-        gzip_or_deflate_sync(global_this, &buffer, options_val, true)
+        let (buffer_value, options_val) = parse_compress_args(global_this, callframe)?;
+        gzip_or_deflate_sync(global_this, buffer_value, options_val, true)
     }
 
     #[bun_jsc::host_fn]
@@ -2407,8 +2407,8 @@ pub mod JSZlib {
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        let (buffer, options_val) = parse_compress_buffer_and_options(global_this, callframe)?;
-        gunzip_or_inflate_sync(global_this, &buffer, options_val, false)
+        let (buffer_value, options_val) = parse_compress_args(global_this, callframe)?;
+        gunzip_or_inflate_sync(global_this, buffer_value, options_val, false)
     }
 
     #[bun_jsc::host_fn]
@@ -2416,8 +2416,8 @@ pub mod JSZlib {
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        let (buffer, options_val) = parse_compress_buffer_and_options(global_this, callframe)?;
-        gzip_or_deflate_sync(global_this, &buffer, options_val, false)
+        let (buffer_value, options_val) = parse_compress_args(global_this, callframe)?;
+        gzip_or_deflate_sync(global_this, buffer_value, options_val, false)
     }
 
     #[bun_jsc::host_fn]
@@ -2425,13 +2425,13 @@ pub mod JSZlib {
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        let (buffer, options_val) = parse_compress_buffer_and_options(global_this, callframe)?;
-        gunzip_or_inflate_sync(global_this, &buffer, options_val, true)
+        let (buffer_value, options_val) = parse_compress_args(global_this, callframe)?;
+        gunzip_or_inflate_sync(global_this, buffer_value, options_val, true)
     }
 
     pub(crate) fn gunzip_or_inflate_sync(
         global_this: &JSGlobalObject,
-        buffer: &node::StringOrBuffer,
+        buffer_value: JSValue,
         options_val_: Option<JSValue>,
         is_gzip: bool,
     ) -> JsResult<JSValue> {
@@ -2483,6 +2483,14 @@ pub mod JSZlib {
             return Ok(JSValue::ZERO);
         }
 
+        // Capture the input descriptor only after option getters have run: a
+        // getter can resize the input's resizable ArrayBuffer, which would leave
+        // a descriptor captured earlier slicing freed memory.
+        let Some(buffer) = node::StringOrBuffer::from_js(global_this, buffer_value)? else {
+            return Err(global_this.throw_invalid_arguments(format_args!(
+                "Expected buffer to be a string or buffer"
+            )));
+        };
         let compressed = buffer.slice();
 
         let mut list: Vec<u8> = 'brk: {
@@ -2611,7 +2619,7 @@ pub mod JSZlib {
 
     pub(crate) fn gzip_or_deflate_sync(
         global_this: &JSGlobalObject,
-        buffer: &node::StringOrBuffer,
+        buffer_value: JSValue,
         options_val_: Option<JSValue>,
         is_gzip: bool,
     ) -> JsResult<JSValue> {
@@ -2653,6 +2661,14 @@ pub mod JSZlib {
             return Ok(JSValue::ZERO);
         }
 
+        // Capture the input descriptor only after option getters have run: a
+        // getter can resize the input's resizable ArrayBuffer, which would leave
+        // a descriptor captured earlier slicing freed memory.
+        let Some(buffer) = node::StringOrBuffer::from_js(global_this, buffer_value)? else {
+            return Err(global_this.throw_invalid_arguments(format_args!(
+                "Expected buffer to be a string or buffer"
+            )));
+        };
         let compressed = buffer.slice();
         let _ = window_bits; // unused in Zig too
 
@@ -2810,10 +2826,18 @@ pub mod JSZstd {
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        let (buffer, options_val) = parse_compress_buffer_and_options(global_this, callframe)?;
+        // Read options (which may run JS getters that resize a resizable
+        // ArrayBuffer input) before capturing the input descriptor, so the bytes
+        // handed to native zstd are never a stale view of freed memory.
+        let (buffer_value, options_val) = parse_compress_args(global_this, callframe)?;
 
         let level = get_level(global_this, options_val)?;
 
+        let Some(buffer) = node::StringOrBuffer::from_js(global_this, buffer_value)? else {
+            return Err(global_this.throw_invalid_arguments(format_args!(
+                "Expected buffer to be a string or buffer"
+            )));
+        };
         let input = buffer.slice();
 
         // Calculate max compressed size

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -736,3 +736,40 @@ describe("dictionary buffer lifetime", () => {
     expect(Buffer.concat(chunks).toString()).toBe(input.toString());
   });
 });
+
+describe("sync compression with an options getter that resizes the input", () => {
+  // A `level` getter that resizes the input's resizable ArrayBuffer to zero runs
+  // while options are read. The input descriptor is captured only after the
+  // getter, so compression sees the post-getter (empty) input rather than a
+  // freed view of the original bytes.
+  function resizingInput(level) {
+    const input = Buffer.alloc(4 * 1024 * 1024, 0x41);
+    const rab = new ArrayBuffer(input.length, { maxByteLength: input.length });
+    const view = new Uint8Array(rab);
+    view.set(input);
+    return {
+      view,
+      rab,
+      options: {
+        get level() {
+          rab.resize(0);
+          return level;
+        },
+      },
+    };
+  }
+
+  it("Bun.gzipSync compresses the post-getter empty input", () => {
+    const { view, rab, options } = resizingInput(6);
+    const out = Bun.gzipSync(view, options);
+    expect(rab.byteLength).toBe(0);
+    expect(out).toEqual(Bun.gzipSync(new Uint8Array(0), { level: 6 }));
+  });
+
+  it("Bun.zstdCompressSync compresses the post-getter empty input", () => {
+    const { view, rab, options } = resizingInput(3);
+    const out = Bun.zstdCompressSync(view, options);
+    expect(rab.byteLength).toBe(0);
+    expect(out).toEqual(Bun.zstdCompressSync(new Uint8Array(0), { level: 3 }));
+  });
+});


### PR DESCRIPTION
## Summary

Safe JS can pass `Bun.gzipSync` / `Bun.zstdCompressSync` a `Uint8Array` backed by a resizable `ArrayBuffer` plus an `options` object whose getter resizes that backing store. The sync paths captured the input descriptor before reading options, so the getter ran between capture and use, leaving native zlib/zstd with a stale pointer/length. Reading that descriptor is undefined behavior.

This reads the options before capturing the input, matching the async paths. When a getter resizes the input to zero, compression runs on the post-getter empty input.

Changes:
- `gzip`/`deflate`/`gunzip`/`inflate` sync paths capture the input after option getters run
- `zstdCompressSync` reads its `level` option before coercing the input
- regression coverage for an options getter that resizes a resizable ArrayBuffer input

## Test approach

The regression resizes the input to zero from a `level` getter and asserts the output equals compressing an empty input. The unpatched build crashes under ASAN inside native zstd/zlib; the patched build returns the empty-input bytes.

## Verification

- [x] cargo fmt --all --check
- [x] git diff --check -- src/runtime/api/BunObject.rs test/js/node/zlib/zlib.test.js
- [x] cargo clippy -p bun_runtime
- [x] bun bd -e "console.log('ok')"
- [x] bun bd test test/js/node/zlib/zlib.test.js -t "options getter that resizes"
- [x] Regression confirmed: unpatched crashes under ASAN (zstd `MEM_read64`, zlib `fold_16_vpclmulqdq_copy`); patched compresses the post-getter empty input

## Coverage note

A full zlib.test.js debug run has two pre-existing async streaming-timeout failures (brotli/zstd "streaming encode doesn't wait for entire input"). They reproduce on the unpatched binary at the same base and are unrelated to this change.

## Review map

- `src/runtime/api/BunObject.rs`: sync zlib/zstd compression reads options before capturing JS-backed input bytes
- `test/js/node/zlib/zlib.test.js`: covers gzip/zstd option getters resizing a resizable ArrayBuffer input
